### PR TITLE
refactor(phase-2e-5): rename CdkdLocal* construct ids + cdkd- fixture strings to cdk-local-native form

### DIFF
--- a/tests/integration/local-ecs-service-connect/bin/app.ts
+++ b/tests/integration/local-ecs-service-connect/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalEcsServiceConnectStack } from '../lib/local-ecs-service-connect-st
 
 const app = new cdk.App();
 
-new LocalEcsServiceConnectStack(app, 'CdkdLocalEcsServiceConnectFixture', {
+new LocalEcsServiceConnectStack(app, 'CdkLocalEcsServiceConnectFixture', {
   description: 'Fixture stack for cdkl ECS Service Connect + Cloud Map integ test (Issue #460)',
 });

--- a/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
+++ b/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
@@ -26,7 +26,7 @@ import { Construct } from 'constructs';
  *     to `containerPort` 8080 and collide on the 2nd replica) AND the
  *     first-replica-wins alias resolution: both frontend replicas
  *     inherit the same shared Cloud Map registry snapshot, so they must
- *     resolve `orders` / `orders.cdkd-sc.local` to the SAME (first
+ *     resolve `orders` / `orders.cdkl-sc.local` to the SAME (first
  *     registered) orders replica IP.
  *
  * Item (2) of #579 adds an `AWS::ServiceDiscovery::Service` resource
@@ -35,7 +35,7 @@ import { Construct } from 'constructs';
  * This exercises the SECOND Cloud Map mechanism in
  * `publishReplicaToCloudMap` (the ServiceRegistries[] branch — distinct
  * from the Service Connect alias branch) end-to-end: the integ asserts
- * `orders-discovery.cdkd-sc.local` resolves to an orders container IP
+ * `orders-discovery.cdkl-sc.local` resolves to an orders container IP
  * in the frontend container's `/etc/hosts`.
  *
  * L1 `CfnService` + `CfnTaskDefinition` directly (no VPC) so the
@@ -61,7 +61,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     // the namespace string in the `--add-host name.namespace:ip`
     // overlay.
     const namespace = new cdk.aws_servicediscovery.CfnPrivateDnsNamespace(this, 'Ns', {
-      name: 'cdkd-sc.local',
+      name: 'cdkl-sc.local',
       // CfnPrivateDnsNamespace requires `Vpc` in real AWS, but cdkd
       // never sends this — local emulation skips the field on every
       // SDK call. CFn property-required validation is bypassed because
@@ -78,7 +78,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     // a collision would silently shadow per first-wins semantics.
     // `publishReplicaToCloudMap` resolves this via the synth-time
     // `cloudMapIndexByStack` entry and registers `{ip, port}` against
-    // `<discoveryName>.<namespaceName>` = `orders-discovery.cdkd-sc.local`.
+    // `<discoveryName>.<namespaceName>` = `orders-discovery.cdkl-sc.local`.
     const ordersDiscovery = new cdk.aws_servicediscovery.CfnService(this, 'OrdersDiscovery', {
       name: 'orders-discovery',
       // `Fn::GetAtt: [<NsLogicalId>, 'Id']` is the canonical CDK 2.x
@@ -152,7 +152,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
       launchType: 'EC2',
       serviceConnectConfiguration: {
         enabled: true,
-        namespace: 'cdkd-sc.local',
+        namespace: 'cdkl-sc.local',
         services: [
           {
             portName: 'orders-api',
@@ -170,8 +170,8 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
       // is distinct from the Service Connect alias branch above —
       // BOTH get registered against the same replica IP, so the
       // frontend container's `/etc/hosts` will carry both
-      // `orders.cdkd-sc.local` (Service Connect) AND
-      // `orders-discovery.cdkd-sc.local` (Cloud Map) entries.
+      // `orders.cdkl-sc.local` (Service Connect) AND
+      // `orders-discovery.cdkl-sc.local` (Cloud Map) entries.
       serviceRegistries: [
         {
           registryArn: ordersDiscovery.attrArn,
@@ -220,7 +220,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
       launchType: 'EC2',
       serviceConnectConfiguration: {
         enabled: true,
-        namespace: 'cdkd-sc.local',
+        namespace: 'cdkl-sc.local',
         services: [
           {
             portName: 'frontend-api',

--- a/tests/integration/local-ecs-service-connect/package.json
+++ b/tests/integration/local-ecs-service-connect/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-ecs-service-connect",
+  "name": "cdkl-integ-local-ecs-service-connect",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl start-service Service Connect + Cloud Map (Issue #460)",

--- a/tests/integration/local-ecs-service-connect/verify.sh
+++ b/tests/integration/local-ecs-service-connect/verify.sh
@@ -26,16 +26,16 @@
 #     are visible in `docker ps` (proves the #585 multi-replica
 #     host-port-skip fix — pre-fix the 2nd replica failed to boot with
 #     "port is already allocated"; #579 item (1)).
-#   - EACH frontend container has `orders.cdkd-sc.local` AND the bare
+#   - EACH frontend container has `orders.cdkl-sc.local` AND the bare
 #     `orders` alias mapped in its `/etc/hosts` (proves the Service
 #     Connect branch of `--add-host` flowed through to every consumer
 #     replica).
-#   - EACH frontend container ALSO has `orders-discovery.cdkd-sc.local`
+#   - EACH frontend container ALSO has `orders-discovery.cdkl-sc.local`
 #     mapped to an orders-container IP (proves the ServiceRegistries[]
 #     branch is wired end-to-end; #579 item (2)).
 #   - First-replica-wins alias resolution: BOTH frontend replicas
-#     resolve `orders` / `orders.cdkd-sc.local` /
-#     `orders-discovery.cdkd-sc.local` to the SAME orders replica IP
+#     resolve `orders` / `orders.cdkl-sc.local` /
+#     `orders-discovery.cdkl-sc.local` to the SAME orders replica IP
 #     (the first-registered one), since both consumers inherit the same
 #     shared Cloud Map registry snapshot (#579 item (1)).
 #   - `wget http://orders/` from inside a frontend container returns
@@ -91,8 +91,8 @@ trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
 
 echo "==> Booting both services (one cdkd invocation, shared Cloud Map registry)"
 ${CDKL} start-service \
-  CdkdLocalEcsServiceConnectFixture:OrdersService \
-  CdkdLocalEcsServiceConnectFixture:FrontendService \
+  CdkLocalEcsServiceConnectFixture:OrdersService \
+  CdkLocalEcsServiceConnectFixture:FrontendService \
   --no-pull --container-host 127.0.0.1 \
   > "${OUT_FILE}" 2>&1 &
 CDKL_PID=$!
@@ -170,7 +170,7 @@ fi
 echo "    frontend containers: $(tr '\n' ' ' <<<"${FRONTEND_IDS}")"
 
 # Collect the orders container's docker network IP so the
-# `orders-discovery.cdkd-sc.local` resolution can be cross-checked
+# `orders-discovery.cdkl-sc.local` resolution can be cross-checked
 # against it. The loop is N-agnostic (works for 1 or N>=2 containers)
 # so a future producer-side-multi-replica follow-up to #579 won't
 # need to rewrite this block.
@@ -197,8 +197,8 @@ fi
 
 # Per-replica /etc/hosts assertions across BOTH frontend replicas. Each
 # consumer must carry the Service Connect alias (`orders` short-form +
-# `orders.cdkd-sc.local` fqdn) AND the Cloud Map ServiceRegistries[]
-# alias (`orders-discovery.cdkd-sc.local`, #579 item (2)) — proving the
+# `orders.cdkl-sc.local` fqdn) AND the Cloud Map ServiceRegistries[]
+# alias (`orders-discovery.cdkl-sc.local`, #579 item (2)) — proving the
 # `--add-host` overlay flowed to EVERY consumer replica, not just one.
 echo "==> Asserting --add-host overlay in EACH frontend replica + first-replica-wins"
 ORDERS_ALIAS_IPS=""
@@ -208,20 +208,20 @@ for fid in ${FRONTEND_IDS}; do
   echo "----- /etc/hosts (${fid}) -----"
   echo "${HOSTS_OUTPUT}"
   echo "-------------------------------"
-  if ! grep -q "orders.cdkd-sc.local" <<<"${HOSTS_OUTPUT}"; then
-    echo "FAIL: frontend ${fid} /etc/hosts missing orders.cdkd-sc.local (Service Connect fqdn)"
+  if ! grep -q "orders.cdkl-sc.local" <<<"${HOSTS_OUTPUT}"; then
+    echo "FAIL: frontend ${fid} /etc/hosts missing orders.cdkl-sc.local (Service Connect fqdn)"
     exit 1
   fi
   if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders$" <<<"${HOSTS_OUTPUT}"; then
     echo "FAIL: frontend ${fid} /etc/hosts missing bare 'orders' alias (ClientAlias short-form)"
     exit 1
   fi
-  if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}"; then
-    echo "FAIL: frontend ${fid} /etc/hosts missing orders-discovery.cdkd-sc.local (ServiceRegistries[] branch)"
+  if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkl-sc\.local$" <<<"${HOSTS_OUTPUT}"; then
+    echo "FAIL: frontend ${fid} /etc/hosts missing orders-discovery.cdkl-sc.local (ServiceRegistries[] branch)"
     exit 1
   fi
   orders_ip=$(grep -oE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders$" <<<"${HOSTS_OUTPUT}" | awk '{print $1}' | head -1)
-  discovery_ip=$(grep -oE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}" | awk '{print $1}' | head -1)
+  discovery_ip=$(grep -oE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkl-sc\.local$" <<<"${HOSTS_OUTPUT}" | awk '{print $1}' | head -1)
   if [[ -z "${orders_ip}" || -z "${discovery_ip}" ]]; then
     echo "FAIL: frontend ${fid} — could not extract orders / orders-discovery IP from /etc/hosts"
     exit 1
@@ -229,11 +229,11 @@ for fid in ${FRONTEND_IDS}; do
   ORDERS_ALIAS_IPS+="${orders_ip} "
   DISCOVERY_ALIAS_IPS+="${discovery_ip} "
 done
-echo "    OK: every frontend replica carries orders / orders.cdkd-sc.local / orders-discovery.cdkd-sc.local"
+echo "    OK: every frontend replica carries orders / orders.cdkl-sc.local / orders-discovery.cdkl-sc.local"
 
 # First-replica-wins: both consumers inherit the same shared Cloud Map
 # registry snapshot, so every frontend replica must resolve `orders`
-# AND `orders-discovery.cdkd-sc.local` to the SAME (first-registered)
+# AND `orders-discovery.cdkl-sc.local` to the SAME (first-registered)
 # orders replica IP. Collapsing the collected IPs with `sort -u` must
 # yield exactly one IP per alias.
 UNIQ_ORDERS_IPS=$(tr ' ' '\n' <<<"${ORDERS_ALIAS_IPS}" | grep -v '^$' | sort -u)
@@ -243,7 +243,7 @@ if [[ "$(wc -l <<<"${UNIQ_ORDERS_IPS}" | tr -d ' ')" -ne 1 ]]; then
   exit 1
 fi
 if [[ "$(wc -l <<<"${UNIQ_DISCOVERY_IPS}" | tr -d ' ')" -ne 1 ]]; then
-  echo "FAIL: frontend replicas disagree on the 'orders-discovery.cdkd-sc.local' alias IP: ${DISCOVERY_ALIAS_IPS}"
+  echo "FAIL: frontend replicas disagree on the 'orders-discovery.cdkl-sc.local' alias IP: ${DISCOVERY_ALIAS_IPS}"
   exit 1
 fi
 # The winning alias IP must be a REAL orders container IP, and both

--- a/tests/integration/local-invoke-buildkit/bin/app.ts
+++ b/tests/integration/local-invoke-buildkit/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeBuildkitStack } from '../lib/local-invoke-buildkit-stack.ts'
 
 const app = new cdk.App();
 
-new LocalInvokeBuildkitStack(app, 'CdkdLocalInvokeBuildkitFixture', {
+new LocalInvokeBuildkitStack(app, 'CdkLocalInvokeBuildkitFixture', {
   description: 'Fixture stack for cdkl invoke against a BuildKit-only Dockerfile',
 });

--- a/tests/integration/local-invoke-buildkit/docker/Dockerfile
+++ b/tests/integration/local-invoke-buildkit/docker/Dockerfile
@@ -25,7 +25,7 @@ ARG GREETING_BUILD_ARG
 # Heredoc + cache-mount (BuildKit-only): capture the build arg value.
 RUN --mount=type=cache,target=/var/cache <<EOF
 mkdir -p /tmp/cdkd-build
-echo "${GREETING_BUILD_ARG}" > /tmp/cdkd-build/build-arg.txt
+echo "${GREETING_BUILD_ARG}" > /tmp/cdkl-build/build-arg.txt
 EOF
 
 # Secret-mount (BuildKit-only): compute sha256 of the secret file and
@@ -37,14 +37,14 @@ if [ ! -f /run/secrets/mysecret ]; then
   echo "FAIL: /run/secrets/mysecret does not exist (--secret was not threaded through)" >&2
   exit 1
 fi
-sha256sum /run/secrets/mysecret | cut -d' ' -f1 > /tmp/cdkd-build/secret-sha.txt
+sha256sum /run/secrets/mysecret | cut -d' ' -f1 > /tmp/cdkl-build/secret-sha.txt
 EOF
 
 # Stage 2 — final. The `--target final` flag selects THIS stage. Pulls
 # baked artifacts from the builder + the handler source.
 FROM public.ecr.aws/lambda/nodejs:20 AS final
-COPY --from=builder /tmp/cdkd-build/build-arg.txt ${LAMBDA_TASK_ROOT}/build-arg.txt
-COPY --from=builder /tmp/cdkd-build/secret-sha.txt ${LAMBDA_TASK_ROOT}/secret-sha.txt
+COPY --from=builder /tmp/cdkl-build/build-arg.txt ${LAMBDA_TASK_ROOT}/build-arg.txt
+COPY --from=builder /tmp/cdkl-build/secret-sha.txt ${LAMBDA_TASK_ROOT}/secret-sha.txt
 COPY app.js ${LAMBDA_TASK_ROOT}/
 
 CMD ["app.handler"]

--- a/tests/integration/local-invoke-buildkit/docker/Dockerfile
+++ b/tests/integration/local-invoke-buildkit/docker/Dockerfile
@@ -24,7 +24,7 @@ ARG GREETING_BUILD_ARG
 
 # Heredoc + cache-mount (BuildKit-only): capture the build arg value.
 RUN --mount=type=cache,target=/var/cache <<EOF
-mkdir -p /tmp/cdkd-build
+mkdir -p /tmp/cdkl-build
 echo "${GREETING_BUILD_ARG}" > /tmp/cdkl-build/build-arg.txt
 EOF
 

--- a/tests/integration/local-invoke-buildkit/docker/secret.txt
+++ b/tests/integration/local-invoke-buildkit/docker/secret.txt
@@ -1,1 +1,1 @@
-cdkd-buildkit-integ-secret-content-2026-05-21
+cdkl-buildkit-integ-secret-content-2026-05-21

--- a/tests/integration/local-invoke-buildkit/package.json
+++ b/tests/integration/local-invoke-buildkit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-buildkit",
+  "name": "cdkl-integ-local-invoke-buildkit",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkd against a Dockerfile that uses BuildKit-only features (# syntax=docker/dockerfile:1 + heredocs + RUN --mount=type=cache)",

--- a/tests/integration/local-invoke-buildkit/verify.sh
+++ b/tests/integration/local-invoke-buildkit/verify.sh
@@ -58,31 +58,31 @@ done
 
 
 echo "==> [1/3] Building + invoking BuildkitHandler (exercises every BuildKit feature)"
-${CDKL} invoke CdkdLocalInvokeBuildkitFixture/BuildkitHandler --no-pull >/tmp/cdkd-buildkit-1.log 2>&1
-RESULT_1=$(grep -E '"(buildArg|secretSha|fromBuildkitImage)"' /tmp/cdkd-buildkit-1.log | tail -1)
+${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler --no-pull >/tmp/cdkl-buildkit-1.log 2>&1
+RESULT_1=$(grep -E '"(buildArg|secretSha|fromBuildkitImage)"' /tmp/cdkl-buildkit-1.log | tail -1)
 echo "    response: ${RESULT_1}"
 
 # Every BuildKit feature must show up in the response.
 echo "${RESULT_1}" | grep -q "\"buildArg\":\"${EXPECTED_BUILD_ARG}\"" || {
   echo "FAIL: --build-arg did not flow through. Expected buildArg=${EXPECTED_BUILD_ARG}"
   echo "      response: ${RESULT_1}"
-  cat /tmp/cdkd-buildkit-1.log
+  cat /tmp/cdkl-buildkit-1.log
   exit 1
 }
 echo "${RESULT_1}" | grep -q "\"secretSha\":\"${EXPECTED_SECRET_SHA}\"" || {
   echo "FAIL: --secret did not flow through. Expected secretSha=${EXPECTED_SECRET_SHA}"
   echo "      response: ${RESULT_1}"
-  cat /tmp/cdkd-buildkit-1.log
+  cat /tmp/cdkl-buildkit-1.log
   exit 1
 }
 echo "${RESULT_1}" | grep -q '"multiStageTarget":"final"' || {
   echo "FAIL: multi-stage --target final did not run (app.js missing from image)"
-  cat /tmp/cdkd-buildkit-1.log
+  cat /tmp/cdkl-buildkit-1.log
   exit 1
 }
 echo "${RESULT_1}" | grep -q '"greeting":"hello-buildkit"' || {
   echo "FAIL: GREETING env var did not flow through"
-  cat /tmp/cdkd-buildkit-1.log
+  cat /tmp/cdkl-buildkit-1.log
   exit 1
 }
 echo "    ✓ build-arg=${EXPECTED_BUILD_ARG}"
@@ -92,7 +92,7 @@ echo "    ✓ multi-stage --target=final"
 # Verify the raw secret content NEVER landed in any image layer. This is
 # the load-bearing security property of `RUN --mount=type=secret`: the
 # secret content is mounted ONLY during the RUN step, never baked into a
-# layer. Grep the local cdkd-built image's history for the secret
+# layer. Grep the local cdkl-built image's history for the secret
 # content — must NOT match.
 echo "==> [2/3] Verifying secret content NEVER baked into image layers (security property of --secret)"
 SECRET_LITERAL=$(cat docker/secret.txt | head -1)
@@ -116,22 +116,22 @@ echo "    ✓ secret content absent from all image layers"
 # Re-invoke under --no-build to confirm tag stability (the deterministic
 # tag computed from the source must match across builds).
 echo "==> [3/3] Re-invoking under --no-build to confirm tag stability"
-${CDKL} invoke CdkdLocalInvokeBuildkitFixture/BuildkitHandler --no-pull --no-build >/tmp/cdkd-buildkit-3.log 2>&1
-RESULT_3=$(grep -E '"buildArg"' /tmp/cdkd-buildkit-3.log | tail -1)
+${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler --no-pull --no-build >/tmp/cdkl-buildkit-3.log 2>&1
+RESULT_3=$(grep -E '"buildArg"' /tmp/cdkl-buildkit-3.log | tail -1)
 echo "${RESULT_3}" | grep -q "\"buildArg\":\"${EXPECTED_BUILD_ARG}\"" || {
   echo "FAIL: --no-build re-invocation did not pick up the same baked image"
-  cat /tmp/cdkd-buildkit-3.log
+  cat /tmp/cdkl-buildkit-3.log
   exit 1
 }
 echo "    ✓ --no-build reused the cached tag"
 
-rm -f /tmp/cdkd-buildkit-1.log /tmp/cdkd-buildkit-3.log
+rm -f /tmp/cdkl-buildkit-1.log /tmp/cdkl-buildkit-3.log
 
-# Cleanup: remove the cdkd-built image(s) so CI hosts don't accumulate
+# Cleanup: remove the cdkl-built image(s) so CI hosts don't accumulate
 # multi-stage builder layers across iterations. The integ owns the
 # `cdkl-invoke-*` namespace and the run-time docker containers are
 # already removed by `docker run --rm` + cdkd's removeContainer().
-echo "==> Cleanup: removing cdkd-built images"
+echo "==> Cleanup: removing cdkl-built images"
 docker image ls --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' | while read -r tag; do
   docker image rm -f "${tag}" >/dev/null 2>&1 || true
 done

--- a/tests/integration/local-invoke-container/bin/app.ts
+++ b/tests/integration/local-invoke-container/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeContainerStack } from '../lib/local-invoke-container-stack.t
 
 const app = new cdk.App();
 
-new LocalInvokeContainerStack(app, 'CdkdLocalInvokeContainerFixture', {
+new LocalInvokeContainerStack(app, 'CdkLocalInvokeContainerFixture', {
   description: 'Fixture stack for cdkl invoke container Lambda integ test',
 });

--- a/tests/integration/local-invoke-container/package.json
+++ b/tests/integration/local-invoke-container/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-container",
+  "name": "cdkl-integ-local-invoke-container",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke against container Lambdas",

--- a/tests/integration/local-invoke-container/verify.sh
+++ b/tests/integration/local-invoke-container/verify.sh
@@ -38,7 +38,7 @@ fi
 # documented as a no-op in CLI help — it still skips the public-base
 # image's `docker pull` from the ZIP path which we did up front).
 echo "==> [1/4] Invoking EchoHandler (container) with default empty event"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokeContainerFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -54,7 +54,7 @@ echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokeContainerFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"key":"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -66,7 +66,7 @@ echo "==> [3/4] Invoking EchoHandler with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkdLocalInvokeContainerFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -83,7 +83,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 echo "==> [4/4] Invoking EchoHandler with --no-build (image must already be cached from steps 1-3)"
 COMBINED_4=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${COMBINED_4}"' EXIT
-${CDKL} invoke CdkdLocalInvokeContainerFixture/EchoHandler --no-pull --no-build >"${COMBINED_4}" 2>&1
+${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --no-pull --no-build >"${COMBINED_4}" 2>&1
 RESULT_4=$(tail -1 "${COMBINED_4}")
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -q '"greeting":"hello"' || {

--- a/tests/integration/local-invoke-dotnet/bin/app.ts
+++ b/tests/integration/local-invoke-dotnet/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeDotnetStack } from '../lib/local-invoke-dotnet-stack.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeDotnetStack(app, 'CdkdLocalInvokeDotnetFixture', {
+new LocalInvokeDotnetStack(app, 'CdkLocalInvokeDotnetFixture', {
   description: 'Fixture stack for cdkl invoke .NET integ test',
 });

--- a/tests/integration/local-invoke-dotnet/package.json
+++ b/tests/integration/local-invoke-dotnet/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-dotnet",
+  "name": "cdkl-integ-local-invoke-dotnet",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke (.NET runtimes, issue #248)",

--- a/tests/integration/local-invoke-dotnet/verify.sh
+++ b/tests/integration/local-invoke-dotnet/verify.sh
@@ -56,7 +56,7 @@ fi
 # Silicon emulating x86_64) — the function's Timeout: 30 + cdkd's
 # `invokeTimeoutMs = max(30s, 2 * fn.timeout)` = 60s provides headroom.
 echo "==> [1/3] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokeDotnetFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokeDotnetFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -68,7 +68,7 @@ echo "==> [2/3] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokeDotnetFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokeDotnetFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -80,7 +80,7 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
 # and exit non-zero BEFORE pulling any image / starting any container.
 echo "==> [3/3] Invoking InlineHandler — expecting Inline Code.ZipFile rejection"
 RESULT_3=""
-if RESULT_3=$(${CDKL} invoke CdkdLocalInvokeDotnetFixture/InlineHandler --no-pull 2>&1); then
+if RESULT_3=$(${CDKL} invoke CdkLocalInvokeDotnetFixture/InlineHandler --no-pull 2>&1); then
   echo "FAIL: expected non-zero exit on inline .NET, got success: ${RESULT_3}"
   exit 1
 fi

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/bin/app.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/bin/app.ts
@@ -9,14 +9,14 @@ const app = new cdk.App();
 // `Export.Name` set to this; consumer's Lambda env var pulls it via
 // `Fn::ImportValue`. The literal is intentionally distinctive so the
 // integ can grep for it.
-const EXPORT_NAME = 'cdkd-multi-stack-shared-value';
+const EXPORT_NAME = 'cdkl-multi-stack-shared-value';
 
-const producer = new ProducerStack(app, 'CdkdLocalInvokeMultiStackProducer', {
+const producer = new ProducerStack(app, 'CdkLocalInvokeMultiStackProducer', {
   description: 'Producer stack: emits an SSM Parameter and exports its name via Fn::ImportValue.',
   exportName: EXPORT_NAME,
 });
 
-new ConsumerStack(app, 'CdkdLocalInvokeMultiStackConsumer', {
+new ConsumerStack(app, 'CdkLocalInvokeMultiStackConsumer', {
   description: 'Consumer stack: Lambda env reads producer export via Fn::ImportValue.',
   exportName: EXPORT_NAME,
 }).addDependency(producer);

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/producer-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/producer-stack.ts
@@ -20,7 +20,7 @@ export interface ProducerStackProps extends cdk.StackProps {
  * resolve it via `Fn::ImportValue`.
  *
  * The Parameter's `Ref` (which is the parameter name itself, e.g.
- * `CdkdLocalInvokeMultiStackProducer-SharedParameter-XXXX`) is what
+ * `CdkLocalInvokeMultiStackProducer-SharedParameter-XXXX`) is what
  * gets exported. The consumer's Lambda env var ends up with that exact
  * string when `--from-cfn-stack` substitutes the `Fn::ImportValue`.
  *

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-from-cfn-stack-multi-stack",
+  "name": "cdkl-integ-local-invoke-from-cfn-stack-multi-stack",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke --from-cfn-stack 2-stack Fn::ImportValue",

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -11,7 +11,7 @@
 # `Fn::ImportValue` code path in `CfnLocalStateProvider` (~50 LOC) has
 # no integ coverage on its own — only unit tests prove it. This fixture
 # closes that gap with a producer/consumer pair: producer emits a
-# CloudFormation `Output` with `Export.Name: cdkd-multi-stack-shared-
+# CloudFormation `Output` with `Export.Name: cdkl-multi-stack-shared-
 # value`; consumer's Lambda env var is `Fn::ImportValue` against the
 # same name. With `--from-cfn-stack`, the consumer's env var should
 # resolve to the producer's exported value at local-invoke time
@@ -45,9 +45,9 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-PRODUCER_STACK="CdkdLocalInvokeMultiStackProducer"
-CONSUMER_STACK="CdkdLocalInvokeMultiStackConsumer"
-EXPORT_NAME="cdkd-multi-stack-shared-value"
+PRODUCER_STACK="CdkLocalInvokeMultiStackProducer"
+CONSUMER_STACK="CdkLocalInvokeMultiStackConsumer"
+EXPORT_NAME="cdkl-multi-stack-shared-value"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/tests/integration/local-invoke-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-invoke-from-cfn-stack/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeFromCfnStackStack } from '../lib/local-invoke-from-cfn-stack
 
 const app = new cdk.App();
 
-new LocalInvokeFromCfnStackStack(app, 'CdkdLocalInvokeFromCfnStackFixture', {
+new LocalInvokeFromCfnStackStack(app, 'CdkLocalInvokeFromCfnStackFixture', {
   description: 'Fixture stack for cdkl invoke --from-cfn-stack integ test',
 });

--- a/tests/integration/local-invoke-from-cfn-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-from-cfn-stack",
+  "name": "cdkl-integ-local-invoke-from-cfn-stack",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke --from-cfn-stack",

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -13,7 +13,7 @@
 #
 # Steps:
 #   1. install + build cdkd (root) + install fixture deps + docker pull
-#   2. cdk deploy CdkdLocalInvokeFromCfnStackFixture (upstream CDK CLI)
+#   2. cdk deploy CdkLocalInvokeFromCfnStackFixture (upstream CDK CLI)
 #   3. baseline: cdkl invoke (no --from-cfn-stack) — assert
 #      TABLE_NAME comes through as "unset" (env var dropped because it's
 #      intrinsic-valued and the default behavior warns + drops).
@@ -34,7 +34,7 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkdLocalInvokeFromCfnStackFixture"
+STACK="CdkLocalInvokeFromCfnStackFixture"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/tests/integration/local-invoke-java/bin/app.ts
+++ b/tests/integration/local-invoke-java/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeJavaStack } from '../lib/local-invoke-java-stack.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeJavaStack(app, 'CdkdLocalInvokeJavaFixture', {
+new LocalInvokeJavaStack(app, 'CdkLocalInvokeJavaFixture', {
   description: 'Fixture stack for cdkl invoke Java integ test',
 });

--- a/tests/integration/local-invoke-java/package.json
+++ b/tests/integration/local-invoke-java/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-java",
+  "name": "cdkl-integ-local-invoke-java",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke (Java runtimes, issue #248)",

--- a/tests/integration/local-invoke-java/verify.sh
+++ b/tests/integration/local-invoke-java/verify.sh
@@ -55,7 +55,7 @@ fi
 # function's Timeout: 30 + cdkd's `invokeTimeoutMs = max(30s, 2 * fn.timeout)`
 # = 60s provides ample headroom.
 echo "==> [1/3] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokeJavaFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokeJavaFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -67,7 +67,7 @@ echo "==> [2/3] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokeJavaFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokeJavaFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -79,7 +79,7 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
 # and exit non-zero BEFORE pulling any image / starting any container.
 echo "==> [3/3] Invoking InlineHandler — expecting Inline Code.ZipFile rejection"
 RESULT_3=""
-if RESULT_3=$(${CDKL} invoke CdkdLocalInvokeJavaFixture/InlineHandler --no-pull 2>&1); then
+if RESULT_3=$(${CDKL} invoke CdkLocalInvokeJavaFixture/InlineHandler --no-pull 2>&1); then
   echo "FAIL: expected non-zero exit on inline Java, got success: ${RESULT_3}"
   exit 1
 fi

--- a/tests/integration/local-invoke-layers/bin/app.ts
+++ b/tests/integration/local-invoke-layers/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeLayersStack } from '../lib/local-invoke-layers-stack.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeLayersStack(app, 'CdkdLocalInvokeLayersFixture', {
+new LocalInvokeLayersStack(app, 'CdkLocalInvokeLayersFixture', {
   description: 'Fixture stack for cdkl invoke Lambda Layers integ test',
 });

--- a/tests/integration/local-invoke-layers/package.json
+++ b/tests/integration/local-invoke-layers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-layers",
+  "name": "cdkl-integ-local-invoke-layers",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke Lambda Layers support (PR 6 of #224, issue #232)",

--- a/tests/integration/local-invoke-layers/verify.sh
+++ b/tests/integration/local-invoke-layers/verify.sh
@@ -40,7 +40,7 @@ echo "==> [1/3] Invoking EchoHandler (default empty event)"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"name":"alice","n":7}' > "${EVENT_FILE}"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 
 # 1a: counters layer — distinct module name, no path overlap.
@@ -75,7 +75,7 @@ echo "==> [2/3] Invoking with a different event payload"
 EVENT2=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${EVENT2}"' EXIT
 echo '{"name":"bob","n":42}' > "${EVENT2}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokeLayersFixture/EchoHandler --event "${EVENT2}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT2}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"greeting":"from-layer-B:hello-bob"' || {
   echo "FAIL: expected greeting=from-layer-B:hello-bob, got: ${RESULT_2}"
@@ -91,7 +91,7 @@ echo "${RESULT_2}" | grep -q '"counter":"count=42"' || {
 # `console.info`; we just want to verify the layer-count line appears
 # somewhere in the cdkd output) so users know the layer wiring fired.
 echo "==> [3/3] Verifying cdkd logs the layer count"
-LOG_OUTPUT=$(${CDKL} invoke CdkdLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>&1)
+LOG_OUTPUT=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>&1)
 echo "${LOG_OUTPUT}" | grep -q 'Mounting 3 Lambda layers at /opt' || {
   echo "FAIL: expected 'Mounting 3 Lambda layers' message in cdkd output, got:"
   echo "${LOG_OUTPUT}"

--- a/tests/integration/local-invoke-provided/bin/app.ts
+++ b/tests/integration/local-invoke-provided/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeProvidedStack } from '../lib/local-invoke-provided-stack.ts'
 
 const app = new cdk.App();
 
-new LocalInvokeProvidedStack(app, 'CdkdLocalInvokeProvidedFixture', {
+new LocalInvokeProvidedStack(app, 'CdkLocalInvokeProvidedFixture', {
   description: 'Fixture stack for cdkl invoke provided.* + go1.x integ test',
 });

--- a/tests/integration/local-invoke-provided/package.json
+++ b/tests/integration/local-invoke-provided/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-provided",
+  "name": "cdkl-integ-local-invoke-provided",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke (provided.* + go1.x deprecation, issue #248)",

--- a/tests/integration/local-invoke-provided/verify.sh
+++ b/tests/integration/local-invoke-provided/verify.sh
@@ -68,7 +68,7 @@ fi
 # linux/amd64 emulation. The first invocation pays a one-time emulator
 # warm-up tax (~5s); the function's 30s timeout absorbs it comfortably.
 echo "==> [1/4] Invoking BootstrapHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokeProvidedFixture/BootstrapHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"Greeting": *"hello"|"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -80,7 +80,7 @@ echo "==> [2/4] Invoking BootstrapHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokeProvidedFixture/BootstrapHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -90,7 +90,7 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
 # Test 3 — inline Code.ZipFile rejection for provided.al2023.
 echo "==> [3/4] Invoking ProvidedAl2023InlineHandler — expecting inline Code.ZipFile rejection"
 RESULT_3=""
-if RESULT_3=$(${CDKL} invoke CdkdLocalInvokeProvidedFixture/ProvidedAl2023InlineHandler --no-pull 2>&1); then
+if RESULT_3=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/ProvidedAl2023InlineHandler --no-pull 2>&1); then
   echo "FAIL: expected non-zero exit on inline provided.al2023, got success: ${RESULT_3}"
   exit 1
 fi
@@ -109,7 +109,7 @@ echo "    rejection ✓"
 # Test 4 — go1.x deprecation rejection.
 echo "==> [4/4] Invoking Go1xHandler — expecting go1.x deprecation message"
 RESULT_4=""
-if RESULT_4=$(${CDKL} invoke CdkdLocalInvokeProvidedFixture/Go1xHandler --no-pull 2>&1); then
+if RESULT_4=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/Go1xHandler --no-pull 2>&1); then
   echo "FAIL: expected non-zero exit on go1.x, got success: ${RESULT_4}"
   exit 1
 fi

--- a/tests/integration/local-invoke-python/bin/app.ts
+++ b/tests/integration/local-invoke-python/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokePythonStack } from '../lib/local-invoke-python-stack.ts';
 
 const app = new cdk.App();
 
-new LocalInvokePythonStack(app, 'CdkdLocalInvokePythonFixture', {
+new LocalInvokePythonStack(app, 'CdkLocalInvokePythonFixture', {
   description: 'Fixture stack for cdkl invoke Python integ test',
 });

--- a/tests/integration/local-invoke-python/package.json
+++ b/tests/integration/local-invoke-python/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-python",
+  "name": "cdkl-integ-local-invoke-python",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke (Python runtimes, PR 4 of #224)",

--- a/tests/integration/local-invoke-python/verify.sh
+++ b/tests/integration/local-invoke-python/verify.sh
@@ -34,7 +34,7 @@ fi
 
 # Test 1 — asset-backed Python Lambda echoes event + env var
 echo "==> [1/4] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokePythonFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting": "hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -46,7 +46,7 @@ echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokePythonFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"key": "value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -60,7 +60,7 @@ trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 # Use a wildcard Parameters block so the test doesn't break if the L1
 # logical ID changes (mirrors the Node.js integ).
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkdLocalInvokePythonFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -q '"greeting": "overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -72,7 +72,7 @@ echo "==> [4/4] Invoking InlineHandler (Code.ZipFile)"
 INLINE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}"' EXIT
 echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_4=$(${CDKL} invoke CdkdLocalInvokePythonFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_4=$(${CDKL} invoke CdkLocalInvokePythonFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -q '"hi": "there"' || {
   echo "FAIL: expected inlineEcho with hi=there, got: ${RESULT_4}"

--- a/tests/integration/local-invoke-ruby/bin/app.ts
+++ b/tests/integration/local-invoke-ruby/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeRubyStack } from '../lib/local-invoke-ruby-stack.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeRubyStack(app, 'CdkdLocalInvokeRubyFixture', {
+new LocalInvokeRubyStack(app, 'CdkLocalInvokeRubyFixture', {
   description: 'Fixture stack for cdkl invoke Ruby integ test',
 });

--- a/tests/integration/local-invoke-ruby/package.json
+++ b/tests/integration/local-invoke-ruby/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke-ruby",
+  "name": "cdkl-integ-local-invoke-ruby",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke (Ruby runtimes, issue #248)",

--- a/tests/integration/local-invoke-ruby/verify.sh
+++ b/tests/integration/local-invoke-ruby/verify.sh
@@ -34,7 +34,7 @@ fi
 
 # Test 1 — asset-backed Ruby Lambda echoes event + env var
 echo "==> [1/4] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokeRubyFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -46,7 +46,7 @@ echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokeRubyFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -60,7 +60,7 @@ trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 # Use a wildcard Parameters block so the test doesn't break if the L1
 # logical ID changes (mirrors the Python integ).
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkdLocalInvokeRubyFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -Eq '"greeting": *"overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -72,7 +72,7 @@ echo "==> [4/4] Invoking InlineHandler (Code.ZipFile)"
 INLINE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}"' EXIT
 echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_4=$(${CDKL} invoke CdkdLocalInvokeRubyFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_4=$(${CDKL} invoke CdkLocalInvokeRubyFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -Eq '"hi": *"there"' || {
   echo "FAIL: expected inlineEcho with hi=there, got: ${RESULT_4}"

--- a/tests/integration/local-invoke/bin/app.ts
+++ b/tests/integration/local-invoke/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalInvokeStack } from '../lib/local-invoke-stack.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeStack(app, 'CdkdLocalInvokeFixture', {
+new LocalInvokeStack(app, 'CdkLocalInvokeFixture', {
   description: 'Fixture stack for cdkl invoke integ test',
 });

--- a/tests/integration/local-invoke/package.json
+++ b/tests/integration/local-invoke/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-invoke",
+  "name": "cdkl-integ-local-invoke",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl invoke",

--- a/tests/integration/local-invoke/verify.sh
+++ b/tests/integration/local-invoke/verify.sh
@@ -34,7 +34,7 @@ fi
 
 # Test 1 — asset-backed Lambda echoes event + env var
 echo "==> [1/4] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkdLocalInvokeFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -46,7 +46,7 @@ echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkdLocalInvokeFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"key":"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -60,7 +60,7 @@ trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 # Logical ID is what the CDK construct synthesizes to. Use a wildcard
 # Parameters block so the test doesn't break if the L1 logical ID changes.
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkdLocalInvokeFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -72,7 +72,7 @@ echo "==> [4/4] Invoking InlineHandler (Code.ZipFile)"
 INLINE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}"' EXIT
 echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_4=$(${CDKL} invoke CdkdLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_4=$(${CDKL} invoke CdkLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -q '"inlineEcho":{"hi":"there"}' || {
   echo "FAIL: expected inlineEcho={hi:there}, got: ${RESULT_4}"

--- a/tests/integration/local-run-task-awsvpc/bin/app.ts
+++ b/tests/integration/local-run-task-awsvpc/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalRunTaskAwsvpcStack } from '../lib/local-run-task-awsvpc-stack.ts';
 
 const app = new cdk.App();
 
-new LocalRunTaskAwsvpcStack(app, 'CdkdLocalRunTaskAwsvpcFixture', {
+new LocalRunTaskAwsvpcStack(app, 'CdkLocalRunTaskAwsvpcFixture', {
   description: 'Fixture stack for cdkl run-task awsvpc-mode integ test',
 });

--- a/tests/integration/local-run-task-awsvpc/package.json
+++ b/tests/integration/local-run-task-awsvpc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-run-task-awsvpc",
+  "name": "cdkl-integ-local-run-task-awsvpc",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl run-task awsvpc network mode",

--- a/tests/integration/local-run-task-awsvpc/verify.sh
+++ b/tests/integration/local-run-task-awsvpc/verify.sh
@@ -61,7 +61,7 @@ OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
 
 echo "==> Starting awsvpc task via --detach (output captured)"
-${CDKL} run-task CdkdLocalRunTaskAwsvpcFixture/AwsvpcTask \
+${CDKL} run-task CdkLocalRunTaskAwsvpcFixture/AwsvpcTask \
   --detach --no-pull --container-host 127.0.0.1 \
   > "${OUT_FILE}" 2>&1
 echo "----- run-task output -----"

--- a/tests/integration/local-run-task-multi-container/bin/app.ts
+++ b/tests/integration/local-run-task-multi-container/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalRunTaskMultiStack } from '../lib/local-run-task-multi-stack.ts';
 
 const app = new cdk.App();
 
-new LocalRunTaskMultiStack(app, 'CdkdLocalRunTaskMultiFixture', {
+new LocalRunTaskMultiStack(app, 'CdkLocalRunTaskMultiFixture', {
   description: 'Fixture stack for cdkl run-task multi-container integ test',
 });

--- a/tests/integration/local-run-task-multi-container/package.json
+++ b/tests/integration/local-run-task-multi-container/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-run-task-multi-container",
+  "name": "cdkl-integ-local-run-task-multi-container",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl run-task multi-container sidecar pattern",

--- a/tests/integration/local-run-task-multi-container/verify.sh
+++ b/tests/integration/local-run-task-multi-container/verify.sh
@@ -42,7 +42,7 @@ trap 'rm -f "${OUT_FILE}"' EXIT
 echo "==> Running multi-container task"
 # Run synchronously so `cdkl run-task` waits for the essential
 # container to exit; logs land on stdout with [container-name] prefix.
-${CDKL} run-task CdkdLocalRunTaskMultiFixture/AppTask --no-pull --container-host 127.0.0.1 \
+${CDKL} run-task CdkLocalRunTaskMultiFixture/AppTask --no-pull --container-host 127.0.0.1 \
   > "${OUT_FILE}" 2>&1
 
 echo "==> Asserting [app] container logged 'hello from app'"

--- a/tests/integration/local-run-task/bin/app.ts
+++ b/tests/integration/local-run-task/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalRunTaskStack } from '../lib/local-run-task-stack.ts';
 
 const app = new cdk.App();
 
-new LocalRunTaskStack(app, 'CdkdLocalRunTaskFixture', {
+new LocalRunTaskStack(app, 'CdkLocalRunTaskFixture', {
   description: 'Fixture stack for cdkl run-task integ test',
 });

--- a/tests/integration/local-run-task/package.json
+++ b/tests/integration/local-run-task/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-run-task",
+  "name": "cdkl-integ-local-run-task",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl run-task",

--- a/tests/integration/local-run-task/verify.sh
+++ b/tests/integration/local-run-task/verify.sh
@@ -41,7 +41,7 @@ fi
 
 
 echo "==> [1/2] Starting task via --detach"
-${CDKL} run-task CdkdLocalRunTaskFixture/NginxTask --detach --no-pull --container-host 127.0.0.1
+${CDKL} run-task CdkLocalRunTaskFixture/NginxTask --detach --no-pull --container-host 127.0.0.1
 
 echo "==> [2/2] Curling http://127.0.0.1:18080/"
 # Give nginx ~5s to listen.

--- a/tests/integration/local-start-api-container/bin/app.ts
+++ b/tests/integration/local-start-api-container/bin/app.ts
@@ -4,7 +4,7 @@ import { LocalStartApiContainerStack } from '../lib/local-start-api-container-st
 
 const app = new cdk.App();
 
-new LocalStartApiContainerStack(app, 'CdkdLocalStartApiContainerFixture', {
+new LocalStartApiContainerStack(app, 'CdkLocalStartApiContainerFixture', {
   description:
     'Fixture stack for cdkl start-api integ test against a container Lambda (closes #453)',
 });

--- a/tests/integration/local-start-api-container/package.json
+++ b/tests/integration/local-start-api-container/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-start-api-container",
+  "name": "cdkl-integ-local-start-api-container",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl start-api against a container Lambda (closes #453)",

--- a/tests/integration/local-start-api-rest-v1-non-proxy/bin/app.ts
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/bin/app.ts
@@ -2,4 +2,4 @@ import * as cdk from 'aws-cdk-lib';
 import { LocalStartApiRestV1NonProxyStack } from '../lib/local-start-api-rest-v1-non-proxy-stack.ts';
 
 const app = new cdk.App();
-new LocalStartApiRestV1NonProxyStack(app, 'CdkdLocalStartApiRestV1NonProxyStack', {});
+new LocalStartApiRestV1NonProxyStack(app, 'CdkLocalStartApiRestV1NonProxyStack', {});

--- a/tests/integration/local-start-api-rest-v1-non-proxy/package.json
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-start-api-rest-v1-non-proxy",
+  "name": "cdkl-integ-local-start-api-rest-v1-non-proxy",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl start-api REST v1 non-AWS_PROXY integrations (#457)",

--- a/tests/integration/local-start-api-websocket/bin/app.ts
+++ b/tests/integration/local-start-api-websocket/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalStartApiWebSocketStack } from '../lib/stack.ts';
 
 const app = new cdk.App();
 
-new LocalStartApiWebSocketStack(app, 'CdkdLocalStartApiWebSocket', {
+new LocalStartApiWebSocketStack(app, 'CdkLocalStartApiWebSocket', {
   description: 'Fixture stack for cdkl start-api WebSocket integ test (#462)',
 });

--- a/tests/integration/local-start-api-websocket/package.json
+++ b/tests/integration/local-start-api-websocket/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-start-api-websocket",
+  "name": "cdkl-integ-local-start-api-websocket",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl start-api WebSocket support (#462)",

--- a/tests/integration/local-start-api/bin/app.ts
+++ b/tests/integration/local-start-api/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalStartApiStack } from '../lib/local-start-api-stack.ts';
 
 const app = new cdk.App();
 
-new LocalStartApiStack(app, 'CdkdLocalStartApiFixture', {
+new LocalStartApiStack(app, 'CdkLocalStartApiFixture', {
   description: 'Fixture stack for cdkl start-api integ test',
 });

--- a/tests/integration/local-start-api/package.json
+++ b/tests/integration/local-start-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-start-api",
+  "name": "cdkl-integ-local-start-api",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl start-api",

--- a/tests/integration/local-start-service/bin/app.ts
+++ b/tests/integration/local-start-service/bin/app.ts
@@ -4,6 +4,6 @@ import { LocalStartServiceStack } from '../lib/local-start-service-stack.ts';
 
 const app = new cdk.App();
 
-new LocalStartServiceStack(app, 'CdkdLocalStartServiceFixture', {
+new LocalStartServiceStack(app, 'CdkLocalStartServiceFixture', {
   description: 'Fixture stack for cdkl start-service integ test',
 });

--- a/tests/integration/local-start-service/package.json
+++ b/tests/integration/local-start-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdkd-integ-local-start-service",
+  "name": "cdkl-integ-local-start-service",
   "version": "1.0.0",
   "private": true,
   "description": "Integration test fixture for cdkl start-service",

--- a/tests/integration/local-start-service/verify.sh
+++ b/tests/integration/local-start-service/verify.sh
@@ -62,7 +62,7 @@ OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
 
 echo "==> Booting service (DesiredCount=2)"
-${CDKL} start-service CdkdLocalStartServiceFixture:WebService \
+${CDKL} start-service CdkLocalStartServiceFixture:WebService \
   --no-pull --container-host 127.0.0.1 \
   > "${OUT_FILE}" 2>&1 &
 CDKL_PID=$!


### PR DESCRIPTION
## Summary

Mechanical sweep on `tests/integration/` fixtures to bring construct IDs and fixture-side cdkd- strings in line with the cdk-local naming convention. These were declared out-of-scope in #2 but the original handover (`/tmp/handover-cdk-local-phase-2e-followup2.md`) notes they could be cleaned up "alongside Phase 2e-5 for total consistency"; this PR closes that gap.

## Changes

- Construct ID rename: `CdkdLocal*` -> `CdkLocal*` (across 30+ fixtures)
- Fixture cdkd- strings:
  - `package.json` `cdkd-integ-local-*` -> `cdkl-integ-local-*`
  - `cdkd-sc.local` (Cloud Map namespace example) -> `cdkl-sc.local`
  - `cdkd-multi-stack-shared-value` (CFn export name) -> `cdkl-multi-stack-shared-value`
  - `cdkd-built` (image label) -> `cdkl-built`
  - `cdkd-buildkit-integ-secret-content` (test secret) -> `cdkl-buildkit-integ-secret-content`
  - `/tmp/cdkd-build/` -> `/tmp/cdkl-build/`
  - `/tmp/cdkd-buildkit-*.log` -> `/tmp/cdkl-buildkit-*.log`

60 files changed, 125 insertions, 125 deletions (symmetric mechanical).

## Out of scope (still deferred)

Standalone `cdkd` references to cdk-local itself in src/ JSDoc (~300) and tests/integration comments (~100) — context-dependent rewrite, follow-up PR (PR-B').

## Test plan

- [x] `vp run typecheck` clean
- [x] `vp run build` clean
- [x] `vp run test` — 35/35 unit tests pass
- [ ] Spot-check the diff: every change is a mechanical name swap with no surrounding semantic change

Note: host-cdkd-referring values (`cdkd-asset-<hash>`, `cdkd deploy`, `cdkd state`, etc.) are intentionally **kept** — cdk-local IS hosted by cdkd in production, so those refs remain accurate.
