### PR TITLE
test(phase-2e): add unit tests for cli/options.ts + synthesis/synthesizer.ts

### DIFF
--- a/tests/unit/cli/options.test.ts
+++ b/tests/unit/cli/options.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+
+import {
+  parseContextOptions,
+  parseAssumeRoleToken,
+  effectiveAssumeRoleArn,
+  warnIfDeprecatedRegion,
+  type AssumeRoleOption,
+} from '../../../src/cli/options.js';
+
+const VALID_ARN = 'arn:aws:iam::123456789012:role/MyRole';
+const VALID_ARN_2 = 'arn:aws:iam::123456789012:role/OtherRole';
+
+describe('parseContextOptions', () => {
+  it('returns an empty record when input is undefined', () => {
+    expect(parseContextOptions()).toEqual({});
+  });
+
+  it('returns an empty record when input is empty', () => {
+    expect(parseContextOptions([])).toEqual({});
+  });
+
+  it('parses a single key=value pair', () => {
+    expect(parseContextOptions(['env=prod'])).toEqual({ env: 'prod' });
+  });
+
+  it('parses multiple key=value pairs', () => {
+    expect(parseContextOptions(['k1=v1', 'k2=v2'])).toEqual({ k1: 'v1', k2: 'v2' });
+  });
+
+  it('treats only the first = as the delimiter (preserves further = in value)', () => {
+    expect(parseContextOptions(['key=a=b=c'])).toEqual({ key: 'a=b=c' });
+  });
+
+  it('skips entries with no =', () => {
+    expect(parseContextOptions(['key=val', 'noequals'])).toEqual({ key: 'val' });
+  });
+
+  it('skips entries where = is at index 0 (empty key, eqIndex > 0 guard)', () => {
+    expect(parseContextOptions(['=value', 'k=v'])).toEqual({ k: 'v' });
+  });
+
+  it('preserves an empty value (trailing =)', () => {
+    expect(parseContextOptions(['k='])).toEqual({ k: '' });
+  });
+
+  it('last duplicate key wins', () => {
+    expect(parseContextOptions(['k=v1', 'k=v2'])).toEqual({ k: 'v2' });
+  });
+});
+
+describe('parseAssumeRoleToken', () => {
+  describe('bare ARN', () => {
+    it('sets globalArn when previous is undefined', () => {
+      const result = parseAssumeRoleToken(VALID_ARN, undefined);
+      expect(result).toEqual({ globalArn: VALID_ARN, perLambda: {} });
+    });
+
+    it('overwrites previous globalArn (last bare token wins)', () => {
+      const acc = parseAssumeRoleToken(VALID_ARN, undefined);
+      const next = parseAssumeRoleToken(VALID_ARN_2, acc);
+      expect(next.globalArn).toBe(VALID_ARN_2);
+    });
+
+    it('throws on non-ARN string', () => {
+      expect(() => parseAssumeRoleToken('not-an-arn', undefined)).toThrow(
+        /Invalid --assume-role/
+      );
+    });
+
+    it('throws on ARN whose resource type is not role/', () => {
+      expect(() =>
+        parseAssumeRoleToken('arn:aws:iam::123456789012:user/foo', undefined)
+      ).toThrow(/Invalid --assume-role/);
+    });
+
+    it('accepts gov-cloud / china partition (regex matches arn:<partition>)', () => {
+      const arn = 'arn:aws-cn:iam::123456789012:role/CnRole';
+      const result = parseAssumeRoleToken(arn, undefined);
+      expect(result.globalArn).toBe(arn);
+    });
+  });
+
+  describe('LogicalId=arn form', () => {
+    it('sets perLambda[id] = arn', () => {
+      const result = parseAssumeRoleToken(`MyFn=${VALID_ARN}`, undefined);
+      expect(result).toEqual({ perLambda: { MyFn: VALID_ARN } });
+    });
+
+    it('accumulates per-Lambda entries across calls', () => {
+      const acc = parseAssumeRoleToken(`MyFn=${VALID_ARN}`, undefined);
+      const next = parseAssumeRoleToken(`OtherFn=${VALID_ARN_2}`, acc);
+      expect(next.perLambda).toEqual({ MyFn: VALID_ARN, OtherFn: VALID_ARN_2 });
+    });
+
+    it('trims whitespace around logicalId and arn', () => {
+      const result = parseAssumeRoleToken(`  MyFn  =  ${VALID_ARN}  `, undefined);
+      expect(result.perLambda.MyFn).toBe(VALID_ARN);
+    });
+
+    it('throws when logicalId contains a non-alphanumeric character', () => {
+      expect(() => parseAssumeRoleToken(`my-fn=${VALID_ARN}`, undefined)).toThrow(
+        /left-hand side/
+      );
+    });
+
+    it('throws when logicalId starts with a digit', () => {
+      expect(() => parseAssumeRoleToken(`1Fn=${VALID_ARN}`, undefined)).toThrow(
+        /left-hand side/
+      );
+    });
+
+    it('throws when arn portion is invalid', () => {
+      expect(() => parseAssumeRoleToken('MyFn=not-an-arn', undefined)).toThrow(
+        /right-hand side/
+      );
+    });
+
+    it('overwrites a prior perLambda entry for the same logicalId', () => {
+      const acc = parseAssumeRoleToken(`MyFn=${VALID_ARN}`, undefined);
+      const next = parseAssumeRoleToken(`MyFn=${VALID_ARN_2}`, acc);
+      expect(next.perLambda.MyFn).toBe(VALID_ARN_2);
+    });
+  });
+
+  describe('mixed bare + per-Lambda accumulation', () => {
+    it('keeps perLambda entries when a later bare arn updates global', () => {
+      const acc = parseAssumeRoleToken(`MyFn=${VALID_ARN}`, undefined);
+      const next = parseAssumeRoleToken(VALID_ARN_2, acc);
+      expect(next).toEqual({
+        globalArn: VALID_ARN_2,
+        perLambda: { MyFn: VALID_ARN },
+      });
+    });
+
+    it('initializes perLambda when previous.perLambda is missing (defensive)', () => {
+      const accWithoutPerLambda = { globalArn: VALID_ARN } as AssumeRoleOption;
+      const next = parseAssumeRoleToken(`MyFn=${VALID_ARN_2}`, accWithoutPerLambda);
+      expect(next.perLambda).toEqual({ MyFn: VALID_ARN_2 });
+    });
+  });
+});
+
+describe('effectiveAssumeRoleArn', () => {
+  it('returns undefined when opt is undefined', () => {
+    expect(effectiveAssumeRoleArn('MyFn', undefined)).toBeUndefined();
+  });
+
+  it('returns perLambda value when logicalId hits', () => {
+    const opt: AssumeRoleOption = {
+      globalArn: VALID_ARN_2,
+      perLambda: { MyFn: VALID_ARN },
+    };
+    expect(effectiveAssumeRoleArn('MyFn', opt)).toBe(VALID_ARN);
+  });
+
+  it('falls back to globalArn when perLambda misses', () => {
+    const opt: AssumeRoleOption = {
+      globalArn: VALID_ARN_2,
+      perLambda: { MyFn: VALID_ARN },
+    };
+    expect(effectiveAssumeRoleArn('Other', opt)).toBe(VALID_ARN_2);
+  });
+
+  it('returns undefined when perLambda misses and no globalArn', () => {
+    const opt: AssumeRoleOption = { perLambda: {} };
+    expect(effectiveAssumeRoleArn('MyFn', opt)).toBeUndefined();
+  });
+
+  it('returns undefined when both perLambda and globalArn are absent', () => {
+    const opt = {} as AssumeRoleOption;
+    expect(effectiveAssumeRoleArn('MyFn', opt)).toBeUndefined();
+  });
+});
+
+describe('warnIfDeprecatedRegion', () => {
+  it('does not write to stderr when region is undefined', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    warnIfDeprecatedRegion({});
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('writes a deprecation warning to stderr when region is provided', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    warnIfDeprecatedRegion({ region: 'us-east-1' });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatch(/deprecated/);
+    spy.mockRestore();
+  });
+
+  it('warns even when region is empty string (strict !== undefined check)', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    warnIfDeprecatedRegion({ region: '' });
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/tests/unit/synthesis/synthesizer.test.ts
+++ b/tests/unit/synthesis/synthesizer.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { mockRead, MockAssemblyReader } = vi.hoisted(() => {
+  const mockRead = vi.fn();
+  const MockAssemblyReader = vi.fn().mockImplementation(() => ({ read: mockRead }));
+  return { mockRead, MockAssemblyReader };
+});
+
+vi.mock('../../../src/synthesis/assembly-reader.js', () => ({
+  AssemblyReader: MockAssemblyReader,
+}));
+
+import { Synthesizer } from '../../../src/synthesis/synthesizer.js';
+
+describe('Synthesizer.synthesize', () => {
+  beforeEach(() => {
+    mockRead.mockReset();
+    MockAssemblyReader.mockClear();
+  });
+
+  it('returns { stacks } pulled from AssemblyReader.read', async () => {
+    const fakeStacks = [
+      { stackName: 'A' },
+      { stackName: 'B' },
+    ];
+    mockRead.mockResolvedValue(fakeStacks);
+
+    const s = new Synthesizer();
+    const result = await s.synthesize({ app: 'node app.ts' });
+
+    expect(result).toEqual({ stacks: fakeStacks });
+  });
+
+  it('passes app as the first arg to AssemblyReader.read', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'node my-app.ts' });
+
+    expect(mockRead).toHaveBeenCalledTimes(1);
+    expect(mockRead.mock.calls[0][0]).toBe('node my-app.ts');
+  });
+
+  it('forwards output to readOpts.outdir', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x', output: 'custom-out' });
+
+    expect(mockRead).toHaveBeenCalledWith('x', { outdir: 'custom-out' });
+  });
+
+  it('omits readOpts.outdir when output is undefined', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x' });
+
+    const opts = mockRead.mock.calls[0][1];
+    expect(opts).not.toHaveProperty('outdir');
+  });
+
+  it('threads profile into readOpts.env.AWS_PROFILE', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x', profile: 'dev' });
+
+    expect(mockRead).toHaveBeenCalledWith('x', {
+      env: { AWS_PROFILE: 'dev' },
+    });
+  });
+
+  it('threads region into readOpts.env.AWS_REGION AND CDK_DEFAULT_REGION', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x', region: 'us-east-1' });
+
+    expect(mockRead).toHaveBeenCalledWith('x', {
+      env: {
+        AWS_REGION: 'us-east-1',
+        CDK_DEFAULT_REGION: 'us-east-1',
+      },
+    });
+  });
+
+  it('threads profile + region together into a single env object', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x', profile: 'p', region: 'eu-west-1' });
+
+    expect(mockRead).toHaveBeenCalledWith('x', {
+      env: {
+        AWS_PROFILE: 'p',
+        AWS_REGION: 'eu-west-1',
+        CDK_DEFAULT_REGION: 'eu-west-1',
+      },
+    });
+  });
+
+  it('omits readOpts.env when neither profile nor region is set', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x' });
+
+    const opts = mockRead.mock.calls[0][1];
+    expect(opts).not.toHaveProperty('env');
+  });
+
+  it('drops context (Phase 2d-2 follow-up: not currently threaded)', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x', context: { k: 'v', k2: 'v2' } });
+
+    const opts = mockRead.mock.calls[0][1];
+    expect(opts).not.toHaveProperty('env');
+    expect(opts).not.toHaveProperty('context');
+  });
+
+  it('combines output + profile + region into a single readOpts object', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({
+      app: 'x',
+      output: 'dist-cdk',
+      profile: 'p',
+      region: 'ap-northeast-1',
+    });
+
+    expect(mockRead).toHaveBeenCalledWith('x', {
+      outdir: 'dist-cdk',
+      env: {
+        AWS_PROFILE: 'p',
+        AWS_REGION: 'ap-northeast-1',
+        CDK_DEFAULT_REGION: 'ap-northeast-1',
+      },
+    });
+  });
+
+  it('instantiates a fresh AssemblyReader per call', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x' });
+    await s.synthesize({ app: 'y' });
+
+    expect(MockAssemblyReader).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates the AssemblyReader.read rejection', async () => {
+    const err = new Error('boom');
+    mockRead.mockRejectedValue(err);
+
+    const s = new Synthesizer();
+    await expect(s.synthesize({ app: 'x' })).rejects.toThrow('boom');
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage for `src/cli/options.ts` and `src/synthesis/synthesizer.ts` — the two source files the original handover (`/tmp/handover-cdk-local-phase-2e-followup2.md`) flagged as having no tests yet.

Total test count: **78** (was 35 — +43 new).

## tests/unit/cli/options.test.ts (31 tests)

- **`parseContextOptions`** (9): empty / single / multi / first-`=`-only / no-`=` skip / index-0-`=` skip / trailing-`=` empty value / duplicate-key last-wins
- **`parseAssumeRoleToken`** (15):
  - bare-arn: set + overwrite, invalid-arn throw, non-`role/` throw, gov/cn partition accept
  - LogicalId=arn: set + accumulate, whitespace trim, invalid-id throw (kebab + leading-digit), invalid-arn throw, same-id overwrite
  - bare+per-Lambda mixed accumulation
  - defensive `perLambda` init when previous lacks it
- **`effectiveAssumeRoleArn`** (5): undefined opt, perLambda hit, fallback to global, miss + no global, empty opt
- **`warnIfDeprecatedRegion`** (3): no-write on undefined, write on string, defensive write on empty string

## tests/unit/synthesis/synthesizer.test.ts (12 tests)

- Returns `{ stacks }` from `AssemblyReader.read`
- Forwards `app` to `read()` first arg
- `output` -> `readOpts.outdir`; omitted when undefined
- `profile` -> `AWS_PROFILE`
- `region` -> `AWS_REGION` AND `CDK_DEFAULT_REGION` (both)
- Combines `profile + region` in a single env object
- Omits `readOpts.env` when neither profile nor region is set
- Drops `context` (Phase 2d-2 follow-up: not currently threaded — this is the bug PR-C will close)
- Combines `output + profile + region` into a single readOpts
- Instantiates a fresh AssemblyReader per call
- Propagates the AssemblyReader.read rejection

`AssemblyReader` is mocked via `vi.hoisted` + `vi.mock` to keep the test environment hermetic (no subprocess execution, no real cdk.out). The hoisted pattern avoids the top-level class declaration hoisting trap (memory rule `feedback_vi_mock_hoisting`).

## Test plan

- [x] `vp run typecheck` clean
- [x] `vp run build` clean
- [x] `vp run test` — 78/78 pass

## Follow-up

- PR-C will close the `context` drop tested above by threading `opts.context` to the assembly reader (currently a documented Phase 2d-2 gap).
- PR-B' will sweep the remaining standalone `cdkd` JSDoc refs (~300 in src/) — context-dependent rewrite.
