### PR TITLE
feat(synthesis): thread CLI -c context overrides through Synthesizer to AssemblyReader

### DIFF
--- a/src/synthesis/assembly-reader.ts
+++ b/src/synthesis/assembly-reader.ts
@@ -1,5 +1,5 @@
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
-import { Toolkit } from '@aws-cdk/toolkit-lib';
+import { Toolkit, CdkAppMultiContext } from '@aws-cdk/toolkit-lib';
 import type { CloudFormationTemplate } from '../types/resource.js';
 
 /**
@@ -92,6 +92,23 @@ export interface AssemblyReadOptions {
   outdir?: string;
   /** Additional env vars passed to the CDK app subprocess (e.g. `AWS_PROFILE`, `AWS_REGION`). */
   env?: Record<string, string | undefined>;
+  /**
+   * Working directory the CDK app subprocess is executed in. Defaults
+   * to the current process cwd. When `context` is also set, this is
+   * also the directory `CdkAppMultiContext` resolves `cdk.json` /
+   * `cdk.context.json` / `~/.cdk.json` against.
+   */
+  workingDirectory?: string;
+  /**
+   * Commandline context overrides (CDK CLI `-c key=value`).
+   *
+   * Threaded through `CdkAppMultiContext(workingDirectory, context)` so
+   * cdk.json / cdk.context.json / ~/.cdk.json remain the base layer and
+   * CLI overrides win for keys they touch. Empty / undefined leaves
+   * toolkit-lib's default context store (CdkAppMultiContext with no
+   * commandline context) in place.
+   */
+  context?: Record<string, string>;
 }
 
 export class AssemblyReader {
@@ -101,9 +118,20 @@ export class AssemblyReader {
    */
   async read(cdkAppCommand: string, options: AssemblyReadOptions = {}): Promise<StackInfo[]> {
     const toolkit = new Toolkit();
+    const hasContextOverrides =
+      options.context !== undefined && Object.keys(options.context).length > 0;
     const source = await toolkit.fromCdkApp(cdkAppCommand, {
       ...(options.outdir !== undefined && { outdir: options.outdir }),
       ...(options.env !== undefined && { env: options.env }),
+      ...(options.workingDirectory !== undefined && {
+        workingDirectory: options.workingDirectory,
+      }),
+      ...(hasContextOverrides && {
+        contextStore: new CdkAppMultiContext(
+          options.workingDirectory ?? process.cwd(),
+          options.context
+        ),
+      }),
     });
     const cached = await toolkit.synth(source);
     try {

--- a/src/synthesis/synthesizer.ts
+++ b/src/synthesis/synthesizer.ts
@@ -23,10 +23,10 @@ export interface SynthesisOptions {
   /**
    * Context key-value pairs (CLI `-c`/`--context`).
    *
-   * Accepted for API parity with the cdkd shape, but currently NOT
-   * forwarded to the CDK app subprocess — cdk-local relies on
-   * `cdk.json` / `cdk.context.json` for context. CLI overrides land in
-   * a Phase 2d-2 follow-up.
+   * Threaded through `CdkAppMultiContext(workingDirectory, context)` so
+   * `cdk.json` / `cdk.context.json` / `~/.cdk.json` remain the base
+   * layer and CLI overrides win for keys they touch. Empty / undefined
+   * leaves toolkit-lib's default context store in place.
    */
   context?: Record<string, string>;
 }
@@ -58,6 +58,9 @@ export class Synthesizer {
     }
     if (Object.keys(env).length > 0) {
       readOpts.env = env;
+    }
+    if (opts.context !== undefined && Object.keys(opts.context).length > 0) {
+      readOpts.context = opts.context;
     }
     const stacks = await reader.read(opts.app, readOpts);
     return { stacks };

--- a/tests/unit/synthesis/synthesizer.test.ts
+++ b/tests/unit/synthesis/synthesizer.test.ts
@@ -103,13 +103,31 @@ describe('Synthesizer.synthesize', () => {
     expect(opts).not.toHaveProperty('env');
   });
 
-  it('drops context (Phase 2d-2 follow-up: not currently threaded)', async () => {
+  it('forwards non-empty context to readOpts.context', async () => {
     mockRead.mockResolvedValue([]);
     const s = new Synthesizer();
     await s.synthesize({ app: 'x', context: { k: 'v', k2: 'v2' } });
 
+    expect(mockRead).toHaveBeenCalledWith('x', {
+      context: { k: 'v', k2: 'v2' },
+    });
+  });
+
+  it('omits readOpts.context when context is undefined', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x' });
+
     const opts = mockRead.mock.calls[0][1];
-    expect(opts).not.toHaveProperty('env');
+    expect(opts).not.toHaveProperty('context');
+  });
+
+  it('omits readOpts.context when context is an empty object', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x', context: {} });
+
+    const opts = mockRead.mock.calls[0][1];
     expect(opts).not.toHaveProperty('context');
   });
 


### PR DESCRIPTION
## Summary

Closes the Phase 2d-2 follow-up gap (handover item 2e-4): wire CLI `-c key=value` overrides through `Synthesizer` -> `AssemblyReader` -> `Toolkit.fromCdkApp` so they actually reach the CDK app subprocess.

Before this change, `Synthesizer.synthesize({ context: { ... } })` accepted a `context` field for cdkd API parity but silently dropped it on the floor — CLI flag values existed but had no effect on synthesis.

## Implementation

- **`src/synthesis/assembly-reader.ts`**: extend `AssemblyReadOptions` with `context` + `workingDirectory` fields. When `context` is non-empty, wire `CdkAppMultiContext(workingDirectory, context)` into `FromCdkAppOptions.contextStore`. `cdk.json` / `cdk.context.json` / `~/.cdk.json` remain the base layer; CLI overrides win for keys they touch. Empty / undefined `context` leaves toolkit-lib's default context store untouched (no behavior change for callers that pass no overrides).

- **`src/synthesis/synthesizer.ts`**: forward `opts.context` to `readOpts.context`. Doc comment updated (Phase 2d-2 deferral note removed, threading mechanics documented).

## Why `CdkAppMultiContext`, not `MemoryContext`

`CdkAppMultiContext(appDirectory, commandlineContext)` is the same constructor toolkit-lib uses internally as the `fromCdkApp` default — its second arg is exactly "commandline context". So this PR slots in *on the same code path* as the default rather than replacing the entire context-resolution stack with an in-memory map. The trade-off:

- `MemoryContext` would mean cdk-local CLI users lose access to `cdk.json` / `cdk.context.json` whenever they pass even one `-c` flag.
- `CdkAppMultiContext` preserves the full CDK context-layering contract; `-c` overrides only beat lower-priority sources for keys they explicitly set.

## Test plan

- [x] `vp run typecheck` clean
- [x] `vp run build` clean
- [x] `vp run test` — 80/80 pass (14 synthesizer + 31 options + 35 existing)

Test updates:
- Replace existing `drops context (Phase 2d-2 follow-up: not currently threaded)` with three new assertions:
  - forwards non-empty context to `readOpts.context`
  - omits `readOpts.context` when context is undefined
  - omits `readOpts.context` when context is an empty object (Object.keys length === 0 guard)

## Follow-up

- This PR plumbs the option through `Synthesizer` only. The four CLI factories (`cdkl invoke` / `start-api` / `run-task` / `start-service`) need a separate pass to surface `--context` parsing — already in place via `contextOptions` in `src/cli/options.ts` (`parseContextOptions` parses `key=value...` from commander) but not yet routed into each factory's `synthesize()` call. Tracked as PR-C-followup if any current fixture trips on it; otherwise opportunistic.
- PR-B' will still sweep the remaining standalone `cdkd` JSDoc refs (~300 in src/) — context-dependent rewrite.
