### PR TITLE
refactor(phase-2e-5): rewrite cdk-local self-ref cdkd <verb> -> cdk-local <verb> in JSDoc + comments

### DIFF
--- a/src/assets/asset-manifest-loader.ts
+++ b/src/assets/asset-manifest-loader.ts
@@ -105,7 +105,7 @@ export class AssetManifestLoader {
  *
  * The CDK template synthesizes `Code.ImageUri` as a `Fn::Sub` whose body
  * references the bootstrap ECR repo and ends in `:<hash>` — that hash is
- * the same key used in `manifest.dockerImages[<hash>]`. cdkd extracts the
+ * the same key used in `manifest.dockerImages[<hash>]`. cdk-local extracts the
  * hash by walking known image-URI shapes; on miss, when the manifest has
  * exactly one Docker image, we fall back to it (single-asset heuristic) so
  * locally-built non-bootstrapped images still work. This is documented as

--- a/src/assets/docker-build.ts
+++ b/src/assets/docker-build.ts
@@ -12,7 +12,7 @@ import { getLogger } from '../utils/logger.js';
  *   - Streaming spawn via `runDockerStreaming` (no `execFile` `maxBuffer`
  *     ceiling — BuildKit progress on a `# syntax=docker/dockerfile:1`
  *     frontend pull + multi-stage build can run into the tens of MB and
- *     used to silently die at the 50 MB cap cdkd previously set).
+ *     used to silently die at the 50 MB cap cdk-local previously set).
  *   - Sets `BUILDX_NO_DEFAULT_ATTESTATIONS=1` so the resulting image stays
  *     a single-arch image suitable for ECR pull (Docker Buildx otherwise
  *     attaches provenance attestation manifests that confuse the publish
@@ -64,7 +64,7 @@ export interface BuildDockerImageOptions {
  * Two source modes (mirrors CDK CLI):
  *   - `executable`: run the user-supplied command, capture stdout, return
  *     it as the local tag. The script is responsible for building AND
- *     tagging; cdkd just reads the tag from stdout. Used for Bazel /
+ *     tagging; cdk-local just reads the tag from stdout. Used for Bazel /
  *     custom build pipelines that produce images outside `docker build`.
  *   - `directory`: standard `docker build <dir>` with the full BuildKit
  *     flag set described above. Caller must pass `options.tag`.

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -601,7 +601,7 @@ async function localStartApiCommand(
   // pass-through mode with the warn line documented in cognito-jwt.ts.
   await prewarmJwks(initialMaterial.routes, jwksCache);
 
-  // PR 8b: VPC-config Lambdas warn at startup. cdkd does NOT block
+  // PR 8b: VPC-config Lambdas warn at startup. cdk-local does NOT block
   // these routes, but the developer should know the local container
   // reaches external services via the host's network rather than
   // through the deployed VPC's NAT / private subnets. Re-runs on hot
@@ -644,7 +644,7 @@ async function localStartApiCommand(
   // handshake itself (in `https.createServer({requestCert: true,
   // rejectUnauthorized: true, ca, cert, key})`) enforces the
   // client-cert chain check against the CA bundle — there is no
-  // per-request validation in cdkd's code path.
+  // per-request validation in cdk-local's code path.
   const mtlsConfig: MtlsServerConfig | undefined = resolveMtlsConfig(options);
   if (mtlsConfig) {
     logger.info(
@@ -719,14 +719,14 @@ async function localStartApiCommand(
   // for the `@connections/<id>` data plane. Lambda containers in the
   // pool are injected with `AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI`
   // pointing at the same port so `apigatewaymanagementapi:PostToConnection`
-  // from inside the handler lands on cdkd's local endpoint.
+  // from inside the handler lands on cdk-local's local endpoint.
   const wsServers: BootedWebSocketServer[] = [];
   const initialWsApis = initialMaterial.webSocketApis ?? [];
   warnUnsupportedWebSocketApis(initialWsApis, logger);
 
   // Issue #527 M2: probe Docker server version ONCE per session before
   // any WebSocket API attaches. The `--add-host=host.docker.internal:host-gateway`
-  // mapping cdkd injects requires Docker 20.10+; older daemons silently
+  // mapping cdk-local injects requires Docker 20.10+; older daemons silently
   // fail with `ENOTFOUND host.docker.internal` at SDK-call time. Only
   // probe when at least one ATTACHABLE WebSocket API exists — HTTP /
   // REST-only sessions don't use the host-gateway mapping and shouldn't
@@ -878,7 +878,7 @@ async function localStartApiCommand(
       }
       // Mutate the spec to include host.docker.internal mapping so
       // the Lambda's `apigatewaymanagementapi:PostToConnection` URL
-      // resolves to the host's cdkd server on every OS (Linux native
+      // resolves to the host's cdk-local server on every OS (Linux native
       // dockerd does NOT auto-expose `host.docker.internal`; macOS /
       // Windows Docker Desktop does).
       const merged = [...(spec.extraHosts ?? []), ...hostGatewayMapping];
@@ -1649,7 +1649,7 @@ async function resolveLocalBuildPlan(
  *
  * AWS Lambda's actual runtime extracts every layer ZIP into `/opt`
  * in template order — the merge mirrors that. Docker rejects multiple
- * `-v ...:/opt:ro` entries at the same target, so cdkd can't rely on
+ * `-v ...:/opt:ro` entries at the same target, so cdk-local can't rely on
  * overlay layering and must produce a single merged dir on the host.
  */
 export async function materializeLambdaLayers(
@@ -1730,7 +1730,7 @@ interface ResolvedStartApiLambdaBase {
    * the ZIP branch; always `[]` on the IMAGE branch — container
    * Lambdas reject `Layers` at deploy time on the AWS side (layers
    * are baked into the image at build time, not overlaid at
-   * runtime), so cdkd silently ignores any `Layers` property to
+   * runtime), so cdk-local silently ignores any `Layers` property to
    * match AWS's invoke-time behavior. The base-shape `[]` keeps the
    * ResolvedImageLambda → `lambda-resolver.ResolvedImageLambda`
    * cast structurally valid in the container-pool spec.
@@ -1838,7 +1838,7 @@ export function resolveLambdaByLogicalId(
     }
     // PR 6 (#232): same-stack `Properties.Layers` references resolve to
     // local asset directories that bind-mount at `/opt`; start-api
-    // routes through the same lambda-resolver helper as `cdkd local
+    // routes through the same lambda-resolver helper as `cdk-local local
     // invoke` so the warm container pool gets layer support out of
     // the box.
     const layers = resolveLambdaLayers(stack, logicalId, props);
@@ -2437,7 +2437,7 @@ function warnUnsupportedWebSocketApis(
  * Surface a one-line warn per HTTP / HTTP_PROXY integration whose
  * `Integration.Uri` points at a well-known internal address space
  * (AWS IMDS, loopback, link-local, RFC1918). PR #505 / issue #457
- * follow-up: cdkd does NOT block these — warn-and-proceed matches the
+ * follow-up: cdk-local does NOT block these — warn-and-proceed matches the
  * cognito JWKS pass-through pattern — but the user should see the
  * destination at boot so a malicious / typo'd template Uri does not
  * silently exfiltrate credentials in CI. Deduplicated per-Uri.

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1220,7 +1220,7 @@ async function prewarmJwks(
 /**
  * Emit a one-line warn for every VPC-config Lambda. The handler still
  * runs locally, but its container does not get attached to the AWS
- * VPC's subnets — calls to private RDS / ElastiCache will fail. cdkd
+ * VPC's subnets — calls to private RDS / ElastiCache will fail. cdk-local
  * surfaces this so the developer can pin the unexpected behavior to
  * the VPC config rather than chasing a "connection refused" rabbit
  * hole.

--- a/src/cli/commands/local-state-source.ts
+++ b/src/cli/commands/local-state-source.ts
@@ -37,7 +37,7 @@ import type { LocalStateProvider } from '../../local/local-state-provider.js';
  * Options each `cdkl` command gathers from its flag set. The built-in
  * `--from-cfn-stack` flag is always present; the host may add fields
  * for its own `extraStateProviders` entries (e.g. `fromState: boolean`
- * for the cdkd shim's `--from-state`).
+ * for the cdk-local shim's `--from-state`).
  */
 export interface LocalStateSourceOptions {
   /**

--- a/src/cli/commands/local-state-source.ts
+++ b/src/cli/commands/local-state-source.ts
@@ -37,7 +37,7 @@ import type { LocalStateProvider } from '../../local/local-state-provider.js';
  * Options each `cdkl` command gathers from its flag set. The built-in
  * `--from-cfn-stack` flag is always present; the host may add fields
  * for its own `extraStateProviders` entries (e.g. `fromState: boolean`
- * for the cdk-local shim's `--from-state`).
+ * for the cdkd shim's `--from-state`).
  */
 export interface LocalStateSourceOptions {
   /**

--- a/src/local/authorizer-cache.ts
+++ b/src/local/authorizer-cache.ts
@@ -3,7 +3,7 @@
  *
  * AWS API Gateway caches authorizer results per `(authorizer, identity)`
  * tuple to avoid invoking the Lambda / re-verifying the JWT on every
- * request. cdkd mirrors that behavior locally so the dev experience
+ * request. cdk-local mirrors that behavior locally so the dev experience
  * (latency, log noise) matches deployed behavior.
  *
  * Implementation:

--- a/src/local/authorizer-resolver.ts
+++ b/src/local/authorizer-resolver.ts
@@ -75,7 +75,7 @@ export interface LambdaRequestAuthorizer {
 
 /**
  * A single Cognito User Pool referenced by a REST v1
- * `AWS::ApiGateway::Authorizer.ProviderARNs[]` entry. cdkd extracts the
+ * `AWS::ApiGateway::Authorizer.ProviderARNs[]` entry. cdk-local extracts the
  * `region` + `userPoolId` segments out of the ARN so the JWKS URL can be
  * built without an AWS API call.
  */
@@ -118,7 +118,7 @@ export interface CognitoUserPoolAuthorizer {
   // for ID tokens, `client_id` for access tokens) is the User Pool *App
   // Client ID*. CDK / CFn's `AWS::ApiGateway::Authorizer` only carries
   // the User Pool ARN(s) via `ProviderARNs`, not the client id, so
-  // there's no template-time data for cdkd to surface here.
+  // there's no template-time data for cdk-local to surface here.
   // `verifyCognitoJwt` therefore passes `expectedAudience: undefined`
   // and falls back to issuer / signature / expiry checks only — matches
   // the deployed REST v1 behavior. HTTP v2 JWT authorizers DO carry an
@@ -281,7 +281,7 @@ export function resolveRestV1Authorizer(
   // does not emit a companion `AWS::ApiGateway::Authorizer` resource
   // for IAM. mTLS lives on the `AWS::ApiGateway::DomainName` /
   // `AWS::ApiGatewayV2::DomainName` resource via `MutualTlsAuthentication`,
-  // also not via Authorizer; cdkd supports it via the `--mtls-truststore`
+  // also not via Authorizer; cdk-local supports it via the `--mtls-truststore`
   // / `--mtls-cert` / `--mtls-key` CLI flags on `cdkl start-api`,
   // and the TLS handshake itself enforces the client-cert trust check,
   // orthogonal to (and composable with) TOKEN / REQUEST / COGNITO_USER_POOLS

--- a/src/local/authorizer-resolver.ts
+++ b/src/local/authorizer-resolver.ts
@@ -50,7 +50,7 @@ export interface LambdaTokenAuthorizer {
   lambdaLogicalId: string;
   /**
    * The single header whose value is the token. AWS docs name this
-   * `IdentitySource`, e.g. `method.request.header.Authorization`. cdkd
+   * `IdentitySource`, e.g. `method.request.header.Authorization`. cdk-local
    * stores the bare lowercased header name (`authorization`).
    */
   tokenHeader: string;

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -88,7 +88,7 @@ export interface CfnLocalStateProviderOptions {
    * and failed with "Stack does not exist" when the stack lived
    * elsewhere. Matches the threading pattern in
    * `S3LocalStateProvider` / `S3StateBackend` /
-   * `src/utils/aws-region-resolver.ts` — every other cdkd command
+   * `src/utils/aws-region-resolver.ts` — every other cdk-local command
    * already passes `profile` straight to the SDK client.
    */
   profile?: string;
@@ -129,7 +129,7 @@ export class CfnLocalStateProvider implements LocalStateProvider {
     if (!this.client) {
       // Profile threading matches `S3LocalStateProvider` /
       // `S3StateBackend` / `src/utils/aws-region-resolver.ts` — every
-      // other cdkd command already passes the CLI's `--profile` through
+      // other cdk-local command already passes the CLI's `--profile` through
       // to the SDK client constructor so the SDK's profile-aware
       // credential resolution picks up the named profile from
       // `~/.aws/credentials` / `~/.aws/config`. Issue #628.

--- a/src/local/cloud-map-registry.ts
+++ b/src/local/cloud-map-registry.ts
@@ -31,8 +31,8 @@ import { getLogger } from '../utils/logger.js';
  *     out of scope (rejected upstream in the resolver layer or via the
  *     "deferred to follow-up PR" pointers).
  *
- * **Process scoping**: the registry is a singleton per `cdkd local
- * start-service` invocation. Multiple cdkd processes on the same host
+ * **Process scoping**: the registry is a singleton per `cdk-local
+ * start-service` invocation. Multiple cdk-local processes on the same host
  * do NOT share registry state — by design, since they'd be on different
  * docker networks anyway and the design § "Local docker network shape"
  * Option A pins "one docker network per CDK app per CLI invocation".

--- a/src/local/cloud-map-resolver.ts
+++ b/src/local/cloud-map-resolver.ts
@@ -190,7 +190,7 @@ export function buildCloudMapIndex(stack: StackInfo): CloudMapIndex {
  * the Ref target IS the logical id we want).
  *
  * Cross-stack / intrinsic shapes that we cannot resolve at synth time
- * are hard-rejected — cdkd would otherwise silently route to no
+ * are hard-rejected — cdk-local would otherwise silently route to no
  * namespace and the consumer would get an unhelpful "DNS lookup failed"
  * at runtime.
  */

--- a/src/local/cognito-jwt.ts
+++ b/src/local/cognito-jwt.ts
@@ -8,7 +8,7 @@ import { buildIdentityHash } from './authorizer-resolver.js';
  * Cognito User Pool / JWT authorizer support for `cdkl start-api`
  * (PR 8b).
  *
- * cdkd verifies JWTs locally against the user pool's published JWKS so
+ * cdk-local verifies JWTs locally against the user pool's published JWKS so
  * the developer can exercise authorizer-protected routes with real-ish
  * tokens (e.g. ones minted by `aws cognito-idp admin-initiate-auth`).
  *
@@ -51,7 +51,7 @@ interface JwksCacheEntry {
 }
 
 /**
- * Cache of JWKS responses, keyed by the JWKS URL. cdkd refreshes the
+ * Cache of JWKS responses, keyed by the JWKS URL. cdk-local refreshes the
  * cache lazily on miss; entries live for 1hr by default (Cognito rotates
  * keys infrequently, so this is conservative).
  */
@@ -416,7 +416,7 @@ function shapeAllowResult(
     pickStringClaim(claims, 'username') ??
     'unknown';
   // Cap TTL at min(remaining-exp, 300s). The local server shouldn't
-  // outlive a real JWT; cdkd caches modestly to avoid spamming the
+  // outlive a real JWT; cdk-local caches modestly to avoid spamming the
   // signature verifier on every request.
   const expMs = typeof claims['exp'] === 'number' ? claims['exp'] * 1000 : 0;
   const remainingSeconds = Math.max(0, Math.floor((expMs - now()) / 1000));

--- a/src/local/container-pool.ts
+++ b/src/local/container-pool.ts
@@ -318,7 +318,7 @@ export function createContainerPool(
       // function declares any layers). Multi-layer merging happens in
       // `local-start-api.ts`'s `materializeLambdaLayers(...)` once at
       // server boot — Docker rejects two `-v ...:/opt:ro` entries at
-      // the same target, so cdkd can't rely on overlay layering and
+      // the same target, so cdk-local can't rely on overlay layering and
       // must merge on the host instead (see ImagePlan.layersTmpDir
       // docstring in `cli/commands/local-invoke.ts`).
       const optMount = spec.optDir

--- a/src/local/cors-handler.ts
+++ b/src/local/cors-handler.ts
@@ -8,7 +8,7 @@ import type { CloudFormationTemplate } from '../types/resource.js';
  * Background: PR 8a left CORS preflight unimplemented. AWS's HTTP API
  * (`AWS::ApiGatewayV2::Api.CorsConfiguration`) responds to OPTIONS
  * preflight requests automatically — the request never reaches the
- * Lambda integration. cdkd's local server pre-PR forwarded OPTIONS to
+ * Lambda integration. cdk-local's local server pre-PR forwarded OPTIONS to
  * the route's handler, which usually 404s or returns a non-CORS body.
  *
  * Scope (locked in the issue brief):
@@ -200,7 +200,7 @@ function pickStringArray(value: unknown): string[] {
  *   AccessControlExposeHeaders.Items → ExposeHeaders
  *   AccessControlMaxAgeSec           → MaxAge
  *   AccessControlAllowCredentials    → AllowCredentials
- *   (OriginOverride is ignored — cdkd has only one config slot)
+ *   (OriginOverride is ignored — cdk-local has only one config slot)
  *
  * Multiple distributions fronting the same Function URL: last write
  * wins (rare in practice). Per-path CORS via `CacheBehaviors[]` is
@@ -286,7 +286,7 @@ function pickFnUrlLogicalIdFromOriginDomainName(value: unknown): string | undefi
  * Unwrap a `ResponseHeadersPolicyId` value to its referenced logical
  * ID. CDK 2.x synthesizes this as `{ Ref: <id> }`. Returns undefined
  * for the AWS-managed-policy ID form (literal UUID string) since
- * cdkd can't fetch those — and for any non-Ref shape.
+ * cdk-local can't fetch those — and for any non-Ref shape.
  */
 function pickRhpRefLogicalId(value: unknown): string | undefined {
   if (!value || typeof value !== 'object') return undefined;

--- a/src/local/docker-runner.ts
+++ b/src/local/docker-runner.ts
@@ -28,7 +28,7 @@ export interface DockerRunOptions {
   /** Image to run (e.g. `public.ecr.aws/lambda/nodejs:20`). */
   image: string;
   /**
-   * Bind mounts: `[hostPath, containerPath]` pairs. cdkd uses this to
+   * Bind mounts: `[hostPath, containerPath]` pairs. cdk-local uses this to
    * expose the function's local code at `/var/task` (read-only). Empty
    * for container Lambdas (PR 5) — the image already has the code at
    * `/var/task`, no host bind-mount needed.

--- a/src/local/docker-version.ts
+++ b/src/local/docker-version.ts
@@ -3,7 +3,7 @@ import { runDockerStreaming } from '../utils/docker-cmd.js';
 /**
  * Lower bound for `--add-host=<name>:host-gateway` support. The
  * `host-gateway` magic alias was introduced in Docker 20.10 (October
- * 2020) and is the load-bearing primitive cdkd uses to let Lambda
+ * 2020) and is the load-bearing primitive cdk-local uses to let Lambda
  * containers reach the host's `cdkl start-api` server on Linux
  * native dockerd. Without it, the AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI
  * override fails with `ENOTFOUND host.docker.internal` at SDK-call time.
@@ -104,7 +104,7 @@ export async function probeHostGatewaySupport(): Promise<HostGatewayProbeResult>
     return { rawVersion, parsed: null, supported: false };
   }
   // Treat unparseable-but-non-empty versions as "supported" — podman /
-  // finch / nerdctl emit version strings cdkd can't always compare
+  // finch / nerdctl emit version strings cdk-local can't always compare
   // against Docker's. Defer to the warn path rather than refuse the
   // boot.
   const supported = parsed === null || compareDockerVersions(parsed, HOST_GATEWAY_MIN_VERSION) >= 0;

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -12,7 +12,7 @@ import { getLogger } from '../utils/logger.js';
  * ECR pull fallback for `cdkl invoke` / `cdkl start-api` /
  * `cdkl run-task`. When the image URI resolves to an ECR repo but
  * doesn't match any cdk.out asset (typical when invoking a stack
- * deployed elsewhere or sharing a centralized registry), cdkd
+ * deployed elsewhere or sharing a centralized registry), cdk-local
  * authenticates against the target registry and runs `docker pull`.
  *
  * **Cross-account / cross-region** (#455):

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -23,7 +23,7 @@ import { getLogger } from '../utils/logger.js';
  *     target account. The resulting credentials authenticate the ECR
  *     client (regardless of region — the ECR client is built for the
  *     URI's region, which can differ from the caller's profile region).
- *   - Cross-account, NO `ecrRoleArn`: cdkd falls through to the
+ *   - Cross-account, NO `ecrRoleArn`: cdk-local falls through to the
  *     default credential chain. This works when the caller has been
  *     granted cross-account `ecr:GetAuthorizationToken` +
  *     `ecr:BatchGetImage` permissions on the target repository via an
@@ -365,7 +365,7 @@ async function verifyImageInLocalCache(imageUri: string): Promise<void> {
   } catch {
     throw new LocalInvokeBuildError(
       `Image '${imageUri}' is not in the local docker cache and --no-pull was set. ` +
-        'Either remove --no-pull (cdkd will pull from ECR) or pre-pull the image manually with `docker pull`.'
+        'Either remove --no-pull (cdk-local will pull from ECR) or pre-pull the image manually with `docker pull`.'
     );
   }
 }

--- a/src/local/ecs-network.ts
+++ b/src/local/ecs-network.ts
@@ -13,8 +13,8 @@ const execFileAsync = promisify(execFile);
  * awslabs) is started at `169.254.170.2` on the per-task docker network so
  * containers can hit `http://169.254.170.2/v4/<container-id>` for task
  * metadata AND `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/role/<role-arn>`
- * for IAM task-role credentials. cdkd does NOT re-implement the sidecar
- * — pulling the AWS-published image keeps cdkd in lock-step with whatever
+ * for IAM task-role credentials. cdk-local does NOT re-implement the sidecar
+ * — pulling the AWS-published image keeps cdk-local in lock-step with whatever
  * ECS-Agent fidelity AWS chooses to provide.
  */
 
@@ -25,7 +25,7 @@ export const METADATA_ENDPOINT_IMAGE = 'amazon/amazon-ecs-local-container-endpoi
  * Default well-known IP for the ECS local-container-endpoints sidecar —
  * matches the documented AWS task-metadata endpoint address. Containers
  * inject `ECS_CONTAINER_METADATA_URI_V4=http://169.254.170.2/v4/<id>`
- * to reach it. `cdkl run-task` keeps this verbatim; `cdkd local
+ * to reach it. `cdkl run-task` keeps this verbatim; `cdk-local
  * start-service` creates ONE shared network at CLI startup (design
  * § 5 Option A) — the shared sidecar lives at `169.254.171.2` (see
  * `SHARED_SVC_SUBNET_OCTET` below), one octet up so the two CLI
@@ -200,7 +200,7 @@ async function createNetworkAndSidecar(args: {
     const e = err as { stderr?: string; message?: string };
     throw new DockerRunnerError(
       `docker network create failed: ${e.stderr?.trim() || e.message || String(err)}. ` +
-        `Hint: another cdkd run may already own subnet ${cidr}; wait for it to ` +
+        `Hint: another cdk-local run may already own subnet ${cidr}; wait for it to ` +
         'finish, or remove the leftover network with `docker network ls` + ' +
         '`docker network rm`. `cdkl start-service` shares one network ' +
         'across every service in the run; bare `cdkl run-task` uses a ' +

--- a/src/local/ecs-service-resolver.ts
+++ b/src/local/ecs-service-resolver.ts
@@ -28,7 +28,7 @@ import {
  */
 /**
  * Resolved `AWS::ECS::Service.ServiceConnectConfiguration` (Phase 3 of #262).
- * Pre-PR cdkd warned and skipped this block; post-PR each entry's
+ * Pre-PR cdk-local warned and skipped this block; post-PR each entry's
  * `PortName` is matched against the producer TaskDef's
  * `ContainerDefinitions[].PortMappings[].Name` (verified empirically
  * via real `cdk synth` on 2026-05-22 — the CFn field is `PortName`,
@@ -63,7 +63,7 @@ export interface ResolvedServiceConnect {
      */
     containerPort: number;
     /**
-     * The canonical Cloud Map discovery name. cdkd derives this from
+     * The canonical Cloud Map discovery name. cdk-local derives this from
      * `ClientAliases[0].DnsName` when the user supplied one; otherwise
      * defaults to the `PortName` so the registry publishes under a
      * meaningful key.
@@ -124,7 +124,7 @@ export interface ResolvedEcsService {
   healthCheckGracePeriodSeconds: number;
   /**
    * The resolved task descriptor (every container / volume / network mode /
-   * runtime platform / task-role detail). cdkd reuses this verbatim per
+   * runtime platform / task-role detail). cdk-local reuses this verbatim per
    * replica instance.
    */
   task: ResolvedEcsTask;
@@ -306,7 +306,7 @@ export function extractServiceProperties(
  * Note on `clientAliases[]` shape: each ClientAlias can declare a
  * `DnsName` (the bare short-name peers connect to, e.g. `orders`) AND
  * a `Port` (the listening port the alias maps to inside the consumer).
- * cdkd surfaces both verbatim; the registry / `--add-host` overlay
+ * cdk-local surfaces both verbatim; the registry / `--add-host` overlay
  * publishes each `DnsName` as a bare alias pointing at the same IP as
  * the canonical fqdn.
  */
@@ -399,7 +399,7 @@ function extractServiceConnect(
 /**
  * Parse `ServiceRegistries[]`. Each entry's `RegistryArn` is the
  * canonical `Fn::GetAtt: [<CloudMapServiceLogicalId>, 'Arn']` shape;
- * cdkd surfaces the logical id (the AWS-side ARN is irrelevant
+ * cdk-local surfaces the logical id (the AWS-side ARN is irrelevant
  * locally — the registry is in-process).
  *
  * Issue #544 — entries with a literal-string `RegistryArn` (rare
@@ -428,10 +428,10 @@ function extractServiceRegistries(
       // We can't resolve it via the in-process registry; warn + skip.
       warnings.push(
         `ECS Service '${serviceLogicalId}' ServiceRegistries[] entry has a literal-string ` +
-          `RegistryArn ('${registryArn}'); cdkd cannot resolve external Cloud Map services ` +
+          `RegistryArn ('${registryArn}'); cdk-local cannot resolve external Cloud Map services ` +
           'locally. Skipping this registration; peer services will not discover this endpoint ' +
           'through the in-process registry. Use Fn::GetAtt: [<CloudMapServiceLogicalId>, "Arn"] ' +
-          'instead so cdkd can resolve the namespace + service name from the synthesized template.'
+          'instead so cdk-local can resolve the namespace + service name from the synthesized template.'
       );
       continue;
     }

--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -185,7 +185,7 @@ export function createServiceRunState(): ServiceRunState {
 /**
  * Compute the effective replica count for a service: the smaller of
  * `service.desiredCount` and `--max-tasks`, floored at 1. Pure-
- * functional so the CLI can show the user what cdkd is about to do
+ * functional so the CLI can show the user what cdk-local is about to do
  * before any docker calls fire.
  */
 export function computeReplicaCount(desiredCount: number, maxTasks: number): number {
@@ -497,7 +497,7 @@ export function buildNetworkAliasesByContainer(
 
   // PortName → container that declared it. AWS Service Connect uses
   // the first matching PortMappings[].Name to bind a service to a
-  // container; cdkd mirrors that. The resolver already throws
+  // container; cdk-local mirrors that. The resolver already throws
   // `EcsTaskResolutionError` on PortName mismatch BEFORE this runs
   // (`ecs-service-resolver.ts` `extractServiceConnect`), so `owner`
   // is always defined here in production. The defensive `continue`
@@ -703,7 +703,7 @@ async function publishReplicaToCloudMap(
     const index = discovery.cloudMapIndexByStack.get(service.stack.stackName);
     if (!index) {
       logger.warn(
-        `ECS Service '${service.serviceLogicalId}' declares ServiceRegistries[] but cdkd has ` +
+        `ECS Service '${service.serviceLogicalId}' declares ServiceRegistries[] but cdk-local has ` +
           `no Cloud Map index for stack ${service.stack.stackName}. Skipping registration.`
       );
       return;

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -1084,7 +1084,7 @@ function parseContainerImage(
     if (substituted.includes('AWS::')) {
       throw new EcsTaskResolutionError(
         `Container '${containerName}' in task '${taskLogicalId}' has an Image that references AWS pseudo parameters (${substituted}). ` +
-          'cdkd could not resolve them: confirm AWS credentials are configured so STS GetCallerIdentity succeeds, ' +
+          'cdk-local could not resolve them: confirm AWS credentials are configured so STS GetCallerIdentity succeeds, ' +
           'and that --region / AWS_REGION names the target region. ' +
           'Workaround: build the image locally (ContainerImage.fromAsset) or pin a public image.'
       );

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -53,7 +53,7 @@ export interface RunEcsTaskOptions {
   containerHost: string;
   /**
    * When true, the runner omits EVERY `-p <hostPort>:<containerPort>`
-   * flag from `docker run` (Issue #585). Set by `cdkd local
+   * flag from `docker run` (Issue #585). Set by `cdk-local
    * start-service` for multi-replica services: N replicas of one
    * service all map the same container port, so publishing a fixed host
    * port makes the 2nd+ replica fail to boot with `Bind for
@@ -809,7 +809,7 @@ interface BuildDockerRunArgs {
   region: string | undefined;
   /**
    * Optional sidecar IP for the metadata-endpoints sidecar on this
-   * task's docker network. Defaults to `169.254.170.2`; `cdkd local
+   * task's docker network. Defaults to `169.254.170.2`; `cdk-local
    * start-service` overrides per replica so each replica's containers
    * point at their own sidecar instance.
    */

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -58,7 +58,7 @@ export interface RunEcsTaskOptions {
    * service all map the same container port, so publishing a fixed host
    * port makes the 2nd+ replica fail to boot with `Bind for
    * 127.0.0.1:<port> failed: port is already allocated` — true whether
-   * the TaskDefinition declares an explicit `hostPort` or omits it (cdkd
+   * the TaskDefinition declares an explicit `hostPort` or omits it (cdk-local
    * defaults the omitted host port to `containerPort`). Peer comms still
    * works via container IP / network alias on the shared docker network
    * (the production-like path — real ECS Service Connect / awsvpc tasks
@@ -101,8 +101,7 @@ export interface RunEcsTaskOptions {
   imagePlanByContainer?: Map<string, string>;
   /**
    * Optional second-from-last octet of the link-local /24 subnet for this
-   * task's docker network (1..254). Default 170 (AWS-documented). `cdkd
-   * local start-service` walks this per replica so concurrent replicas
+   * task's docker network (1..254). Default 170 (AWS-documented). `cdkl start-service` walks this per replica so concurrent replicas
    * don't collide on the same /24. See `buildEndpointSubnet` in
    * `ecs-network.ts`.
    */
@@ -403,7 +402,7 @@ export async function runEcsTask(
   }
 
   // Wait for the essential container to exit. AWS-side ECS treats the
-  // first `essential: true` container as the task-driving one; cdkd
+  // first `essential: true` container as the task-driving one; cdk-local
   // mirrors that. When no container declares `essential: false`, every
   // container is essential — we use `containers[0]` as the
   // task-driving one.

--- a/src/local/http-server.ts
+++ b/src/local/http-server.ts
@@ -578,7 +578,7 @@ async function handleRequest(
   // Function URL routes with InvokeMode: RESPONSE_STREAM dispatch via
   // the RIE streaming protocol (issue #467). The streaming Lambda's
   // response is a JSON prelude carrying status + headers, an 8-NULL-byte
-  // separator, and then raw body chunks the handler streams. cdkd writes
+  // separator, and then raw body chunks the handler streams. cdk-local writes
   // the prelude to `res.writeHead(...)` and pipes the chunks via
   // `Transfer-Encoding: chunked` (Node's default when no Content-Length
   // is set).
@@ -1252,7 +1252,7 @@ function buildOverlay(
     // Function URL (v2 + iam): emit NO overlay. AWS-deployed Function URLs
     // write principal context under `event.requestContext.authorizer.iam.
     // {accessKey, accountId, callerId, userArn, ...}` — NOT `.lambda` —
-    // and cdkd has no local IAM data plane to synthesize that block (no
+    // and cdk-local has no local IAM data plane to synthesize that block (no
     // STS GetCallerIdentity per request, no IAM policy emulation). Emitting
     // the v2 `lambda-http-v2` overlay would write `principalId` under
     // `.lambda.principalId`, which is the wrong namespace and worse than

--- a/src/local/httpv2-service-integration.ts
+++ b/src/local/httpv2-service-integration.ts
@@ -8,7 +8,7 @@
  * DynamoDB-* family, SNS-Publish, AppConfig-StartConfigurationSession,
  * SQS-SendMessageBatch / Kinesis-PutRecords, etc.).
  *
- * Subtypes cdkd currently bundles SDK clients for:
+ * Subtypes cdk-local currently bundles SDK clients for:
  *   - EventBridge-PutEvents
  *   - SQS-SendMessage / SQS-ReceiveMessage / SQS-DeleteMessage / SQS-PurgeQueue
  *   - Kinesis-PutRecord
@@ -16,7 +16,7 @@
  *   - AppConfig-GetConfiguration (recognized but returns 501 — the
  *     `@aws-sdk/client-appconfig` package is not yet bundled)
  *
- * Unrecognized subtypes (including AWS-documented entries cdkd does not
+ * Unrecognized subtypes (including AWS-documented entries cdk-local does not
  * yet implement, and outright typos) fall back to the deferred-501 path
  * in `route-discovery.ts`, surfacing a clean HTTP 501 at request time
  * rather than aborting boot.
@@ -91,7 +91,7 @@ export type SupportedSubtype =
   | 'AppConfig-GetConfiguration';
 
 /**
- * Full list of subtypes cdkd recognizes as supported. Mirrors AWS docs.
+ * Full list of subtypes cdk-local recognizes as supported. Mirrors AWS docs.
  */
 export const SUPPORTED_SUBTYPES: readonly SupportedSubtype[] = [
   'EventBridge-PutEvents',
@@ -182,7 +182,7 @@ export function _resetClientCacheForTest(): void {
  * pre-resolved parameter map, invoke the SDK, translate the response
  * to HTTP shape.
  *
- * `defaultRegion` is the cdkd process's default AWS region (from
+ * `defaultRegion` is the cdk-local process's default AWS region (from
  * `AWS_REGION` / profile / `--region`). When the resolved parameter
  * map includes a non-empty `Region`, that value overrides the default
  * for this single call — matches AWS API Gateway behavior.
@@ -429,7 +429,7 @@ async function dispatchAppConfigGetConfiguration(
   void region;
   return errorResponse(
     501,
-    'AppConfig-GetConfiguration is recognized but cdkd does not yet bundle @aws-sdk/client-appconfig. Use the deployed API for this subtype, or open an issue if you need local emulation.'
+    'AppConfig-GetConfiguration is recognized but cdk-local does not yet bundle @aws-sdk/client-appconfig. Use the deployed API for this subtype, or open an issue if you need local emulation.'
   );
 }
 

--- a/src/local/integration-response-selector.ts
+++ b/src/local/integration-response-selector.ts
@@ -22,14 +22,14 @@
  * -----
  *
  *   - AWS pre-compiles `SelectionPattern` as a regex with `^pattern$`
- *     anchoring. cdkd matches that — `'.*Not Found.*'` works against
+ *     anchoring. cdk-local matches that — `'.*Not Found.*'` works against
  *     errorMessage values containing "Not Found", but a bare
  *     `'Not Found'` only matches the literal string.
  *   - The `StatusCode` field on the selected entry drives the HTTP
- *     response status. AWS stores it as a string; cdkd parses to int.
+ *     response status. AWS stores it as a string; cdk-local parses to int.
  *   - `IntegrationResponses` is OPTIONAL on AWS — when absent for a non-
  *     AWS_PROXY integration, AWS returns the backend response as-is
- *     (with `application/json` for Lambda success). cdkd mirrors this.
+ *     (with `application/json` for Lambda success). cdk-local mirrors this.
  *   - PR #505 review fix 14: an earlier draft short-circuited the
  *     success branch to the default entry without running the regex
  *     loop, which silently dropped success-side selection (e.g. a
@@ -50,7 +50,7 @@ export interface IntegrationResponseEntry {
    * Regex pattern AWS matches against the integration's error / status.
    * Undefined / empty marks this as the "default" entry. AWS allows ONE
    * default entry per integration; multiple defaults is a template error
-   * but cdkd just picks the first one for resilience.
+   * but cdk-local just picks the first one for resilience.
    */
   SelectionPattern?: string;
   /**
@@ -70,11 +70,11 @@ export interface IntegrationResponseEntry {
    * VTL templates keyed by content-type. The template evaluates against
    * a context where `$input.body` is the backend response body and
    * `$inputRoot` is the parsed JSON (Lambda's native return value).
-   * AWS picks the content-type per Accept header; cdkd picks the
+   * AWS picks the content-type per Accept header; cdk-local picks the
    * `application/json` entry first, then any other entry.
    */
   ResponseTemplates?: Record<string, string>;
-  /** `CONVERT_TO_TEXT` / `CONVERT_TO_BINARY` — cdkd treats both as text. */
+  /** `CONVERT_TO_TEXT` / `CONVERT_TO_BINARY` — cdk-local treats both as text. */
   ContentHandling?: string;
 }
 
@@ -140,7 +140,7 @@ export function selectIntegrationResponse(
     } catch {
       // Invalid regex in template — skip the entry but don't abort the
       // whole dispatch. AWS rejects invalid regex at template-validation
-      // time; cdkd is more forgiving here so a typo doesn't make the
+      // time; cdk-local is more forgiving here so a typo doesn't make the
       // whole route un-emulatable.
     }
   }
@@ -224,7 +224,7 @@ export function evaluateResponseParameters(
       opts.onUnsupported?.(
         key,
         value,
-        `Only method.response.header.<name> keys are supported on REST v1 ResponseParameters; cdkd cannot map ${key}.`
+        `Only method.response.header.<name> keys are supported on REST v1 ResponseParameters; cdk-local cannot map ${key}.`
       );
       continue;
     }
@@ -250,7 +250,7 @@ export function evaluateResponseParameters(
 
 /**
  * Pick the response template AWS would render for the given Accept
- * header. AWS uses content negotiation; cdkd picks `application/json`
+ * header. AWS uses content negotiation; cdk-local picks `application/json`
  * first, then any other entry. Returns `undefined` when no template is
  * configured (caller emits the backend body verbatim).
  *

--- a/src/local/integration-response-selector.ts
+++ b/src/local/integration-response-selector.ts
@@ -95,7 +95,7 @@ export interface SelectedIntegrationResponse {
  * Per AWS docs, `SelectionPattern` is matched against the backend
  * outcome regardless of whether the backend returned success or error —
  * a `SelectionPattern: '200'` entry IS expected to match an HTTP 200
- * upstream response. cdkd ALWAYS runs the regex loop first and only
+ * upstream response. cdk-local ALWAYS runs the regex loop first and only
  * falls to the default entry when no pattern matches; pre-#505-review
  * the success branch short-circuited to the default entry without
  * running the regex loop, which silently dropped success-side selection.

--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -4,7 +4,7 @@ import type { TemplateResource } from '../types/resource.js';
 /**
  * Shared resolver for CFn intrinsic-function shapes that show up in
  * container-image URI fields — both ECS `ContainerDefinition.Image`
- * (`cdkl run-task`) and Lambda `Code.ImageUri` (`cdkd local
+ * (`cdkl run-task`) and Lambda `Code.ImageUri` (`cdk-local
  * invoke` container Lambdas). CDK 2.x synthesizes the same canonical
  * `Fn::Join` shape for `ContainerImage.fromEcrRepository(repo, tag)` and
  * `lambda.DockerImageCode.fromEcr(repo, { tagOrDigest })` — so both call

--- a/src/local/lambda-authorizer.ts
+++ b/src/local/lambda-authorizer.ts
@@ -147,7 +147,7 @@ export async function invokeRequestAuthorizer(
   const result = await invokeAuthorizerLambda(authorizer.lambdaLogicalId, event, ctx);
   if (authorizer.apiVersion === 'v2') {
     // HTTP v2 supports two response shapes: simple ({isAuthorized: bool})
-    // and IAM (policy document). cdkd accepts both — the simple shape
+    // and IAM (policy document). cdk-local accepts both — the simple shape
     // wins when `isAuthorized` is present, otherwise we fall back to the
     // IAM-style policy parse.
     return parseHttpV2RequestResponse(result, ctx.methodArn, identityHash);
@@ -325,7 +325,7 @@ async function invokeAuthorizerLambda(
  *     "context"?: { ... }     // string-valued map
  *   }
  *
- * cdkd allows the response when ANY Allow statement's Resource matches
+ * cdk-local allows the response when ANY Allow statement's Resource matches
  * the methodArn (literal match OR wildcard at the trailing
  * `/<METHOD>/<path>` segment). A non-Allow / wildcard-mismatch / missing
  * policyDocument all map to deny.
@@ -412,7 +412,7 @@ function parseHttpV2RequestResponse(
 
 /**
  * Match a Resource value against the methodArn. AWS supports `*` and `?`
- * glob characters in IAM policy resources; cdkd implements the segmented
+ * glob characters in IAM policy resources; cdk-local implements the segmented
  * semantics AWS documents — `*` matches any sequence of characters
  * **within** a single segment, where segments are delimited by `:`
  * (ARN partition / service / region / account) and `/` (path). `**`
@@ -469,7 +469,7 @@ export function resourceMatches(pattern: string, methodArn: string): boolean {
  * Re-evaluate a cached Lambda authorizer's policy document against the
  * current request's methodArn. Used by the HTTP server's cache hit path:
  * AWS-deployed API Gateway caches the IAM policy and re-checks `Resource`
- * against each new request's methodArn, so cdkd mirrors that — caching
+ * against each new request's methodArn, so cdk-local mirrors that — caching
  * the verdict directly would let a narrow-Resource Allow leak across
  * routes.
  *

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -45,7 +45,7 @@ interface ResolvedLambdaBase {
    *
    * **Order is load-bearing**: AWS layer semantics are "last layer wins
    * on file collision", so this array preserves the template's input
-   * order. cdkd implements the last-wins rule by `cpSync`-merging every
+   * order. cdk-local implements the last-wins rule by `cpSync`-merging every
    * layer's asset directory into a single host tmpdir IN TEMPLATE ORDER
    * (later layers overwrite earlier files via `recursive: true, force:
    * true`), then bind-mounting the merged tmpdir at `/opt:ro`. Docker
@@ -114,7 +114,7 @@ export interface ResolvedAssetLambdaLayer {
    * Absolute path on disk to the layer's unzipped asset directory. Will
    * be bind-mounted at `/opt` inside the container (read-only). The
    * directory is laid out per AWS's runtime-specific load-path
-   * conventions (`opt/python/...`, `opt/nodejs/...`, etc.) — cdkd does
+   * conventions (`opt/python/...`, `opt/nodejs/...`, etc.) — cdk-local does
    * NOT inspect the contents, just hands the directory to docker.
    */
   assetPath: string;
@@ -175,7 +175,7 @@ export interface ResolvedImageLambda extends ResolvedLambdaBase {
    * for the local-build path AND for the ECR-pull fallback path (when the
    * URI doesn't match any cdk.out asset). Already resolved through
    * cdk-assets bootstrap-placeholder substitution upstream — `${AWS::*}`
-   * pseudo-parameters are still present (cdkd substitutes them at the
+   * pseudo-parameters are still present (cdk-local substitutes them at the
    * lookup site since it knows the calling account/region).
    */
   imageUri: string;
@@ -426,7 +426,7 @@ function extractLambdaProperties(
   if (!runtime) {
     throw new LocalInvokeResolutionError(
       `Lambda '${logicalId}' has no Runtime property and no Code.ImageUri. ` +
-        'cdkd cannot tell if this is a ZIP or a container Lambda.'
+        'cdk-local cannot tell if this is a ZIP or a container Lambda.'
     );
   }
   if (!handler) {
@@ -468,7 +468,7 @@ function extractLambdaProperties(
  * `{ EphemeralStorage: { Size: <MiB> } }`. CDK's
  * `cdk.Size.gibibytes(N)` serializes to `N * 1024`. AWS-side range is
  * 512..10240 MiB (the deployed function rejects anything outside that
- * range at create time); cdkd rejects > 10240 here so a misconfigured
+ * range at create time); cdk-local rejects > 10240 here so a misconfigured
  * template fails fast at `cdkl invoke` boot rather than hanging
  * on a `docker run` that AWS would have refused anyway. The 512 floor
  * is AWS's minimum (the default when `EphemeralStorage` is omitted is
@@ -583,7 +583,7 @@ function extractImageUri(
         throw new LocalInvokeResolutionError(
           `Lambda '${logicalId}' in ${stackName} references same-stack ECR repository '${joinResolved.repoLogicalId}' via Fn::Join. ` +
             'cdkl invoke cannot resolve the repository URI without state — ' +
-            'deploy the stack first (so cdkd records the repository physical id), ' +
+            'deploy the stack first (so cdk-local records the repository physical id), ' +
             'rebuild via lambda.DockerImageCode.fromImageAsset, or pin a public image.'
         );
       }
@@ -599,8 +599,8 @@ function extractImageUri(
       // plumbing the typical remaining cause is `${AWS::AccountId}`
       // (needs an STS call or `--from-state`) or an unknown region.
       const accountIdHint = pseudoParameters
-        ? ' (likely ${AWS::AccountId}, which cdkd cannot derive without --from-state or STS)'
-        : ` (cdkd could not derive AWS pseudo parameters because stack.region was undefined)`;
+        ? ' (likely ${AWS::AccountId}, which cdk-local cannot derive without --from-state or STS)'
+        : ` (cdk-local could not derive AWS pseudo parameters because stack.region was undefined)`;
       throw new LocalInvokeResolutionError(
         `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkl invoke cannot resolve${accountIdHint}. ` +
           'Workarounds: deploy first and run with --from-state, or pin a fully-literal public image URI.'
@@ -742,7 +742,7 @@ function resolveAssetCodePath(
  * `local-start-api.ts`'s server-boot pre-merge) `cpSync`-merges every
  * entry into one host tmpdir in template order to honor AWS's
  * "last-layer-wins" file-collision semantics — Docker rejects multiple
- * bind mounts at the same target so cdkd cannot rely on overlay
+ * bind mounts at the same target so cdk-local cannot rely on overlay
  * layering.
  *
  * **Same-stack handling** (`{Ref: <Id>}` / `{Fn::GetAtt: [<Id>, 'Ref']}`):
@@ -790,7 +790,7 @@ export function resolveLambdaLayers(
       const parsed = parseLayerVersionArn(entry);
       if (!parsed) {
         throw new LocalInvokeResolutionError(
-          `Lambda '${logicalId}' has a Layers entry [${i}] cdkd cannot resolve locally: literal string '${entry}'. ` +
+          `Lambda '${logicalId}' has a Layers entry [${i}] cdk-local cannot resolve locally: literal string '${entry}'. ` +
             'Expected a same-stack Ref / Fn::GetAtt to an AWS::Lambda::LayerVersion ' +
             'OR a literal layer-version ARN of the form ' +
             'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.'
@@ -803,7 +803,7 @@ export function resolveLambdaLayers(
     const layerLogicalId = pickLayerLogicalId(entry);
     if (!layerLogicalId) {
       throw new LocalInvokeResolutionError(
-        `Lambda '${logicalId}' has a Layers entry [${i}] cdkd cannot resolve locally: ${describeLayerEntry(entry)}. ` +
+        `Lambda '${logicalId}' has a Layers entry [${i}] cdk-local cannot resolve locally: ${describeLayerEntry(entry)}. ` +
           'Expected a same-stack Ref / Fn::GetAtt to an AWS::Lambda::LayerVersion ' +
           'OR a literal layer-version ARN of the form ' +
           'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.'
@@ -875,10 +875,10 @@ export function parseLayerVersionArn(
  * `{Fn::GetAtt: '<LogicalId>.<attr>'}`. CloudFormation YAML accepts the
  * dot-shorthand and converts it to the array form on the wire, but
  * CloudFormation JSON (the output of `cdk synth`, which is the only
- * thing cdkd ingests) never emits the string form. Treating it as
+ * thing cdk-local ingests) never emits the string form. Treating it as
  * resolvable here would silently accept hand-edited / malformed templates
  * that no real CDK flow can produce; instead we fall through to the
- * standard "cdkd cannot resolve this Layers entry locally" error so the
+ * standard "cdk-local cannot resolve this Layers entry locally" error so the
  * user sees the offending shape called out.
  */
 function pickLayerLogicalId(entry: unknown): string | undefined {

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -76,7 +76,7 @@ export interface AwsCredentials {
 }
 
 /**
- * Minimal slice of `LambdaClient` cdkd needs. Surfaced as an interface
+ * Minimal slice of `LambdaClient` cdk-local needs. Surfaced as an interface
  * so unit tests can mock without pulling the real SDK module.
  */
 export interface LambdaSendClient {

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -16,7 +16,7 @@
  *     `DescribeStacks --Outputs` + `ListExports`. Lets the `local *`
  *     commands substitute deployed physical IDs from a CDK app deployed
  *     via the upstream CDK CLI (`cdk deploy` → CloudFormation), so users
- *     migrating between cdkd and CFn (or running cdkd local against an
+ *     migrating between cdk-local and CFn (or running cdk-local against an
  *     existing CFn-managed CDK app) get the same UX they get with
  *     `--from-state` against cdkd-deployed stacks.
  *

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -23,8 +23,8 @@
  * The interface intentionally mirrors what `state-resolver.ts` consumes:
  * a `Record<string, ResourceState>` (covers `Ref`), an outputs map
  * (cross-stack `Fn::GetStackOutput` source), and an optional cross-stack
- * resolver (`Fn::ImportValue` / `Fn::GetStackOutput`). The four `cdkd
- * local *` command files build a single context off of whatever provider
+ * resolver (`Fn::ImportValue` / `Fn::GetStackOutput`). The four `cdkl *`
+ * command files build a single context off of whatever provider
  * fired and pass it through the substitution engine unchanged.
  *
  * `--from-cfn-stack` is mutually exclusive with `--from-state` at the

--- a/src/local/rest-v1-integrations.ts
+++ b/src/local/rest-v1-integrations.ts
@@ -902,7 +902,7 @@ function safeJsonParse(s: string): unknown {
  * Unsupported mapping expressions are logged at warn and skipped (matches
  * the ResponseParameters handling in `integration-response-selector.ts`).
  *
- * Note: querystring / path-rewrite branches currently warn-and-skip; cdkd
+ * Note: querystring / path-rewrite branches currently warn-and-skip; cdk-local
  * relies on `{paramName}` URI substitution for the canonical case (see
  * {@link substituteUriPlaceholders}). The previous `urlObj` parameter was
  * never used by the unimplemented querystring rewrite branch and has been

--- a/src/local/rest-v1-integrations.ts
+++ b/src/local/rest-v1-integrations.ts
@@ -34,7 +34,7 @@
  *
  *   - VTL features outside the supported subset (see
  *     `src/local/vtl-engine.ts` for the full list) surface a clear error
- *     via `VtlEvaluationError`; cdkd's dispatcher catches it and emits a
+ *     via `VtlEvaluationError`; cdk-local's dispatcher catches it and emits a
  *     `502 Bad Gateway` with the template + error name in the body. AWS
  *     would surface a similar 5xx for VTL evaluation failures.
  *   - `Integration.RequestParameters` mapping expressions
@@ -47,7 +47,7 @@
  *     This is acceptable for local-dev (the upstream URL is the user's
  *     own).
  *   - **SSRF surface**: `Integration.Uri` is accepted verbatim and
- *     passed to `fetch()`; cdkd does NOT block private / loopback /
+ *     passed to `fetch()`; cdk-local does NOT block private / loopback /
  *     link-local destinations. A `warnSsrfRiskyUri()` helper surfaces a
  *     warn at server boot when an Uri's hostname resolves to a
  *     well-known internal address (IMDS, loopback, link-local, RFC1918)
@@ -443,7 +443,7 @@ export async function dispatchHttpIntegration(
   // `application/xml`, `application/x-www-form-urlencoded`) are decoded
   // as UTF-8 so the VTL ResponseTemplates can run against the body text.
   // Other content types (binary blobs — images, octet-stream, etc.) go
-  // straight through as a Buffer so cdkd does not corrupt them via
+  // straight through as a Buffer so cdk-local does not corrupt them via
   // UTF-8 decode. VTL templates that assume text against a binary
   // upstream are limited by this design — see the dispatcher docstring.
   const upstreamContentType = upstream.headers.get('content-type') ?? 'application/octet-stream';
@@ -473,7 +473,7 @@ export async function dispatchHttpIntegration(
     if (picked) {
       if (upstreamText === undefined) {
         // Upstream is binary but a ResponseTemplate is configured. VTL
-        // requires the body as a string; cdkd cannot apply it without
+        // requires the body as a string; cdk-local cannot apply it without
         // corrupting binary content. Surface a warn and pass the binary
         // through as-is (matches the binary-pass-through fall-through
         // below).
@@ -843,7 +843,7 @@ export function classifyInternalHost(host: string): string | undefined {
  * by `classifyInternalHost`. Called once at server boot from
  * `cdkl start-api`'s discovery pass; per-route deduplicated.
  *
- * cdkd does NOT block the URI — this is a developer-loop tool, not a
+ * cdk-local does NOT block the URI — this is a developer-loop tool, not a
  * security boundary, and warn-and-proceed matches the precedent set by
  * the cognito JWKS pass-through fallback. The right v2 follow-up is an
  * `--allow-internal-uri` flag (and an opposite default block) once the
@@ -869,7 +869,7 @@ export function warnSsrfRiskyUri(
   if (classification !== undefined) {
     warn(
       `Integration URI for ${routeLabel} points at ${host} — ${classification}. ` +
-        `cdkd does NOT block this; ensure the upstream is intentional.`
+        `cdk-local does NOT block this; ensure the upstream is intentional.`
     );
   }
 }
@@ -929,17 +929,17 @@ function applyRequestParameters(
     if (headerMatch) {
       out.headers[headerMatch[1]!.toLowerCase()] = resolved;
     } else if (queryMatch) {
-      // Querystring rewrites are recognized but cdkd applies querystring
+      // Querystring rewrites are recognized but cdk-local applies querystring
       // rewrites only via URI placeholder substitution; ignore.
       logger.warn(
-        `RequestParameter '${key}' (querystring rewrite) is recognized but cdkd applies querystring rewrites only via URI placeholder substitution; ignoring.`
+        `RequestParameter '${key}' (querystring rewrite) is recognized but cdk-local applies querystring rewrites only via URI placeholder substitution; ignoring.`
       );
     } else if (pathMatch) {
       // Path rewrites apply at URI substitution time. Log + skip — the
       // pre-substituted URI already used the path parameters via
       // `{paramName}` placeholders, so a separate rewrite is rarely needed.
       logger.warn(
-        `RequestParameter '${key}' (path rewrite) is recognized but cdkd substitutes path placeholders via {param} in the URI; ignoring.`
+        `RequestParameter '${key}' (path rewrite) is recognized but cdk-local substitutes path placeholders via {param} in the URI; ignoring.`
       );
     } else {
       logger.warn(`Unsupported RequestParameter key '${key}'; skipping.`);

--- a/src/local/rie-client.ts
+++ b/src/local/rie-client.ts
@@ -484,7 +484,7 @@ export async function invokeRieStreaming(
  * handler may omit it), `cookies` is preserved only when an array.
  *
  * Exported for unit tests. Throws on invalid JSON or a non-numeric
- * statusCode (cdkd cannot map that to HTTP).
+ * statusCode (cdk-local cannot map that to HTTP).
  */
 export function parseStreamingPrelude(text: string): StreamingPrelude {
   const trimmed = text.trim();

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -423,8 +423,7 @@ function discoverRestV1Method(
   }
   if (integrationType === 'AWS') {
     // AWS integration: Lambda non-proxy (the common case CDK emits) OR
-    // direct AWS service integration (S3 / SQS / SNS / DynamoDB). cdkd
-    // v1 emulates the Lambda non-proxy shape; other services surface as
+    // direct AWS service integration (S3 / SQS / SNS / DynamoDB). cdk-local v1 emulates the Lambda non-proxy shape; other services surface as
     // deferred 501. We detect Lambda by inspecting the Uri shape — any
     // `:lambda:path/2015-03-31/functions/` marker identifies Lambda.
     const config = buildAwsIntegrationConfig(integration, stackName, logicalId);

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -138,7 +138,7 @@ export interface DiscoveredRoute {
    */
   invokeMode?: 'BUFFERED' | 'RESPONSE_STREAM';
   /**
-   * Set on routes that cdkd discovered but cannot dispatch to a Lambda.
+   * Set on routes that cdk-local discovered but cannot dispatch to a Lambda.
    * The HTTP server returns HTTP 501 + `{"message": "Not Implemented",
    * "reason": <reason>}` when these routes are hit. Examples:
    * non-AWS_PROXY REST v1 integrations (`MOCK` not matching the CORS
@@ -156,7 +156,7 @@ export interface DiscoveredRoute {
    * Mutually exclusive with {@link DiscoveredRoute.mockCors}. When set,
    * `lambdaLogicalId` may be the empty string (we never need to dispatch
    * to it); the field is preserved when it COULD be resolved (e.g. an
-   * `AuthType` cdkd doesn't recognize still knows its Lambda).
+   * `AuthType` cdk-local doesn't recognize still knows its Lambda).
    */
   unsupported?: { reason: string };
   /**
@@ -172,7 +172,7 @@ export interface DiscoveredRoute {
    * `lambdaLogicalId` is the empty string on these routes (there is no
    * Lambda to dispatch to). Non-OPTIONS MOCK methods, and OPTIONS MOCK
    * methods without literal `method.response.header.*` parameters, become
-   * `unsupported` instead — cdkd cannot run their VTL mapping templates.
+   * `unsupported` instead — cdk-local cannot run their VTL mapping templates.
    */
   mockCors?: { statusCode: number; headers: Record<string, string> };
   /**
@@ -180,7 +180,7 @@ export interface DiscoveredRoute {
    * (`IntegrationType: AWS_PROXY` + `IntegrationSubtype`) — see AWS
    * docs: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html
    *
-   * cdkd dispatches the route via `httpv2-service-integration.ts`
+   * cdk-local dispatches the route via `httpv2-service-integration.ts`
    * (per-subtype SDK adapter); `lambdaLogicalId` is the empty string
    * (no Lambda backs the route). The `subtype` value is one of the
    * AWS-documented supported subtypes; unrecognized `IntegrationSubtype`
@@ -741,7 +741,7 @@ function uriContainsLambdaMarker(uri: unknown): boolean {
 
 /**
  * Read `Integration.IntegrationResponses[]` from a Method's Integration
- * sub-object and return the entries cdkd's dispatchers consume.
+ * sub-object and return the entries cdk-local's dispatchers consume.
  *
  * Defensive: rejects non-object entries with a clear inline warning.
  */

--- a/src/local/runtime-image.ts
+++ b/src/local/runtime-image.ts
@@ -3,7 +3,7 @@
  * bundles the matching runtime + the Lambda Runtime Interface Emulator (RIE),
  * plus the source-file extension for inline-code materialization.
  *
- * Per D1 in the issue, cdkd uses the **full** base image
+ * Per D1 in the issue, cdk-local uses the **full** base image
  * (`public.ecr.aws/lambda/<lang>:<version>`, ~600MB) over SAM's lighter
  * `public.ecr.aws/sam/emulation-<lang>` (~150MB). The size cost is one-time
  * per machine; in exchange the local runtime is the same artifact AWS runs
@@ -17,7 +17,7 @@
  * explicitly rejected with a migration pointer to `provided.al2023`.
  *
  * Truly unknown runtime strings (e.g. typos like `nodejs99.x`, or
- * back-revs AWS retired well before cdkd existed) fall through to a
+ * back-revs AWS retired well before cdk-local existed) fall through to a
  * generic error that lists every supported runtime.
  *
  * Ruby uses the same `<file>.<func>` handler grammar as Node.js and Python,
@@ -164,7 +164,7 @@ export function isSupportedRuntime(runtime: string): boolean {
 }
 
 /**
- * In-container path where cdkd should bind-mount the function's
+ * In-container path where cdk-local should bind-mount the function's
  * deployment package (asset directory or materialized inline tmpdir).
  *
  * - Most runtimes: `/var/task` — the standard Lambda deployment dir.

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -71,7 +71,7 @@ export interface ResolvedCredentials {
 export type CredentialsLoader = () => Promise<ResolvedCredentials>;
 
 /**
- * Default credential loader: instantiates an `STSClient` (a direct cdkd
+ * Default credential loader: instantiates an `STSClient` (a direct cdk-local
  * dependency) and asks its built-in credential provider for the dev's
  * local credentials. STSClient uses the same Node default credential
  * chain (env vars → ~/.aws/config → IMDS → ...) every other AWS SDK call

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -26,7 +26,7 @@
  * Verification can only succeed when the request was signed with the
  * **same** credentials the local server can read. When the request's
  * `Credential=AKID/...` scope names a different access-key-id than the
- * one the dev has locally, cdkd cannot reproduce the signing key — we
+ * one the dev has locally, cdk-local cannot reproduce the signing key — we
  * **warn-and-pass** in that case (allow + log a one-line warn), matching
  * AWS's "verify locally what we can; defer real authorization to deploy
  * time" model. Refusing would force every dev with a SigV4-signed client
@@ -75,7 +75,7 @@ export type CredentialsLoader = () => Promise<ResolvedCredentials>;
  * dependency) and asks its built-in credential provider for the dev's
  * local credentials. STSClient uses the same Node default credential
  * chain (env vars → ~/.aws/config → IMDS → ...) every other AWS SDK call
- * in cdkd uses, so this matches the deploy-time credential resolution
+ * in cdk-local uses, so this matches the deploy-time credential resolution
  * without adding a new dependency.
  */
 export function defaultCredentialsLoader(): CredentialsLoader {

--- a/src/local/stage-resolver.ts
+++ b/src/local/stage-resolver.ts
@@ -3,7 +3,7 @@ import { pickRefLogicalId } from './intrinsic-utils.js';
 import type { DiscoveredRoute } from './route-discovery.js';
 
 /**
- * Per-API stage selection and stage-variable lookup for `cdkd local
+ * Per-API stage selection and stage-variable lookup for `cdk-local
  * start-api` (PR 8c, issue #235).
  *
  * Background: PR 8a hardcoded `event.stageVariables = null` for every

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -5,7 +5,7 @@
  * intrinsic like `Ref` / `Fn::GetAtt` / `Fn::Sub`) as "unresolved" and
  * drops it. That's correct when there's no source of truth for the
  * deployed value — which is also the SAM behavior — but it's wrong when
- * cdkd has already deployed the stack and the AWS-current physical IDs
+ * cdk-local has already deployed the stack and the AWS-current physical IDs
  * sit in the cdkd state file.
  *
  * `--from-state` closes that gap: it loads cdkd's S3 state for the target
@@ -24,7 +24,7 @@
  *     `state.resources[id].attributes[attr]`. We deliberately do NOT
  *     synthesize attributes the provider would normally compute (e.g.
  *     IAM role ARNs derived from physicalId + accountId) — `--from-state`
- *     surfaces only what cdkd recorded at deploy time, which is what the
+ *     surfaces only what cdk-local recorded at deploy time, which is what the
  *     deployed Lambda's env actually saw.
  *   - `Fn::Sub: '<template>'` (and the two-argument `[template, vars]`
  *     form) — `${LogicalId}` / `${LogicalId.attr}` placeholders are

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -76,7 +76,7 @@
  *
  *   Both resolvers return `string | undefined`; an `undefined` value
  *   reports unresolved per the standard warn-and-drop policy. Cross-account
- *   `Fn::GetStackOutput.RoleArn` is rejected at the resolver layer (cdkd
+ *   `Fn::GetStackOutput.RoleArn` is rejected at the resolver layer (cdk-local
  *   uses S3 state, not CloudFormation; cross-account would require
  *   assuming the role and reading the producer account's separate state
  *   bucket — tracked under #449).

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -10,7 +10,7 @@
  * and integration backend (Lambda non-proxy / HTTP / MOCK / AWS service)
  * request / response shapes. The full VTL spec is large; AWS API Gateway
  * exposes a SUBSET plus three AWS-specific built-in variables (`$input`,
- * `$context`, `$util`). cdkd implements the SUBSET that real CDK apps
+ * `$context`, `$util`). cdk-local implements the SUBSET that real CDK apps
  * use in practice — anything outside it surfaces a clear error rather
  * than silently producing wrong output. See the
  * `VtlEvaluationError.message` field for the exact name when something
@@ -73,7 +73,7 @@
  *   `$util.urlEncode(s)` / `$util.urlDecode(s)` — RFC 3986 encoding.
  *   `$util.parseJson(s)` — `JSON.parse(s)`.
  *
- * Mismatches between cdkd's evaluator and AWS-deployed VTL surface as
+ * Mismatches between cdk-local's evaluator and AWS-deployed VTL surface as
  * `VtlEvaluationError`. Spurious whitespace / formatting differences are
  * acceptable and not in the contract.
  */
@@ -631,7 +631,7 @@ class VtlEvaluator {
   private callValueAsMethod(value: unknown, argsRaw: string, refPath: string): unknown {
     if (typeof value !== 'function') {
       throw new VtlEvaluationError(
-        `Reference '$${refPath}' is not callable (got ${typeof value}). cdkd supports calling $input / $util / $context method-style references only.`
+        `Reference '$${refPath}' is not callable (got ${typeof value}). cdk-local supports calling $input / $util / $context method-style references only.`
       );
     }
     const args = this.parseArgList(argsRaw);
@@ -949,7 +949,7 @@ function isTruthy(v: unknown): boolean {
  *
  * JSONPath support is minimal: supports `$` (root), `$.field`,
  * `$.field.subField`, `$.array[0]`. AWS supports more (filter
- * expressions, recursive descent); cdkd surfaces a clear error on
+ * expressions, recursive descent); cdk-local surfaces a clear error on
  * unsupported expressions rather than silently producing wrong output.
  */
 export function buildVtlInput(
@@ -1066,7 +1066,7 @@ export function applyJsonPath(root: unknown, expr: string): unknown {
       const m = /^[a-zA-Z_][a-zA-Z_0-9]*/.exec(trimmed.slice(i));
       if (!m) {
         throw new VtlEvaluationError(
-          `Unsupported JSONPath syntax at position ${i}: '${trimmed}' (cdkd supports $, $.field, $.field.sub, $.array[index] only).`
+          `Unsupported JSONPath syntax at position ${i}: '${trimmed}' (cdk-local supports $, $.field, $.field.sub, $.array[index] only).`
         );
       }
       cursor = lookupField(cursor, m[0]);
@@ -1093,7 +1093,7 @@ export function applyJsonPath(root: unknown, expr: string): unknown {
         cursor = lookupField(cursor, inside.slice(1, -1));
       } else {
         throw new VtlEvaluationError(
-          `Unsupported JSONPath bracket expression: '${inside}' (cdkd supports integer indices and quoted string keys only).`
+          `Unsupported JSONPath bracket expression: '${inside}' (cdk-local supports integer indices and quoted string keys only).`
         );
       }
       i = close + 1;

--- a/src/local/websocket-event.ts
+++ b/src/local/websocket-event.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'node:crypto';
  * Three event types — CONNECT / MESSAGE / DISCONNECT — each carry a
  * shared {@link WebSocketRequestContext} plus per-event fields.
  *
- * Fields cdkd populates locally vs mocks (matches design Q1 in
+ * Fields cdk-local populates locally vs mocks (matches design Q1 in
  * `docs/design/462-websocket-api.md`):
  *
  * | Field                                | Source                                  |
@@ -38,7 +38,7 @@ const MOCK_API_ID = 'local';
 
 /**
  * Request snapshot from the WebSocket upgrade handshake. The handshake is
- * a plain HTTP GET with `Upgrade: websocket`; cdkd extracts headers /
+ * a plain HTTP GET with `Upgrade: websocket`; cdk-local extracts headers /
  * query string / source IP from the underlying `IncomingMessage` once at
  * `$connect` and reuses them for every subsequent event on the same
  * connection so the Lambda's event-context stays consistent.
@@ -152,7 +152,7 @@ function buildRequestContext(
 /**
  * Build the `$connect` event. AWS WebSocket APIs fire `$connect` ONCE
  * per client connection. Handler returns `{statusCode: 200}` to allow
- * the connection, anything else (or throws) to deny — cdkd matches the
+ * the connection, anything else (or throws) to deny — cdk-local matches the
  * deployed behavior by checking the response in the caller.
  */
 export function buildConnectEvent(opts: {

--- a/src/local/websocket-mgmt-api.ts
+++ b/src/local/websocket-mgmt-api.ts
@@ -15,13 +15,13 @@ import type { WebSocket } from 'ws';
  * `AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI=http://<host>:<port>` that
  * `cdkl start-api` injects into every WebSocket-API Lambda's
  * container (see `container-pool.ts`). The AWS SDK v3 honors this
- * env var and sends the call to cdkd's HTTP server instead of the
+ * env var and sends the call to cdk-local's HTTP server instead of the
  * synthetic `*.execute-api.*.amazonaws.com` hostname.
  *
  * Security: cdk-local does NOT verify SigV4 on the inbound request — the
  * dev-loop is not a security boundary (matches the precedent set by
  * `ecs-network.ts`'s metadata-endpoints sidecar). The SDK still signs
- * the request because that's what v3 does unconditionally; cdkd
+ * the request because that's what v3 does unconditionally; cdk-local
  * ignores the signature.
  */
 

--- a/src/local/websocket-mgmt-api.ts
+++ b/src/local/websocket-mgmt-api.ts
@@ -18,7 +18,7 @@ import type { WebSocket } from 'ws';
  * env var and sends the call to cdkd's HTTP server instead of the
  * synthetic `*.execute-api.*.amazonaws.com` hostname.
  *
- * Security: cdkd does NOT verify SigV4 on the inbound request — the
+ * Security: cdk-local does NOT verify SigV4 on the inbound request — the
  * dev-loop is not a security boundary (matches the precedent set by
  * `ecs-network.ts`'s metadata-endpoints sidecar). The SDK still signs
  * the request because that's what v3 does unconditionally; cdkd
@@ -103,7 +103,7 @@ export class ConnectionRegistry {
  * The optional `<stage>` segment matches AWS's deployed URL exactly —
  * any non-slash sequence preceding `/@connections/`. The stage value
  * itself is intentionally NOT validated against the per-API configured
- * stage name: cdkd is a local-dev tool, not a security boundary, and
+ * stage name: cdk-local is a local-dev tool, not a security boundary, and
  * an aggressive stage check would just trip on misconfigured handlers
  * without adding any real protection.
  */
@@ -120,7 +120,7 @@ export function parseConnectionsPath(url: string): {
 }
 
 /**
- * Build the per-Lambda env-var URL the cdkd local server injects as
+ * Build the per-Lambda env-var URL the cdk-local server injects as
  * `AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI`. The URL MUST include the
  * `/<stage>` segment to mirror the AWS-deployed apigatewaymanagementapi
  * endpoint `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>`:

--- a/src/local/websocket-route-discovery.ts
+++ b/src/local/websocket-route-discovery.ts
@@ -64,7 +64,7 @@ export interface DiscoveredWebSocketApi {
    */
   routes: WebSocketRouteEntry[];
   /**
-   * Set when the whole API is unsupported by cdkd's local emulation.
+   * Set when the whole API is unsupported by cdk-local's local emulation.
    * The CLI's WebSocket attach loop skips an `unsupported`-tagged API
    * (no server is attached, no upgrade is accepted) and surfaces the
    * `reason` as a startup warn naming the affected API so the user

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -35,7 +35,7 @@ import * as websocketBody from './websocket-body.js';
  *
  * Architecture (mirrors design doc §2 / §8):
  *   - One {@link WebSocketServer} per cdkl start-api server.
- *   - `noServer: true` mode — cdkd owns the upgrade-event dispatch.
+ *   - `noServer: true` mode — cdk-local owns the upgrade-event dispatch.
  *   - Per-connection lifecycle: handshake -> $connect Lambda ->
  *     (allow/deny) -> message loop -> close -> $disconnect Lambda.
  *   - Outbound `@connections/<id>` POST from a handler-side AWS SDK
@@ -562,7 +562,7 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
  *
  * The CLI installs this BEFORE the existing http-server pipeline so a
  * Lambda inside a container can call
- * `apigatewaymanagementapi:PostToConnection` and have cdkd deliver the
+ * `apigatewaymanagementapi:PostToConnection` and have cdk-local deliver the
  * message back to the open WebSocket without the request hitting the
  * route table.
  */

--- a/src/synthesis/assembly-reader.ts
+++ b/src/synthesis/assembly-reader.ts
@@ -7,7 +7,7 @@ import type { CloudFormationTemplate } from '../types/resource.js';
  *
  * This interface mirrors the shape cdkd's `src/local/**` files import,
  * so the ported source compiles without rewrites. The backing
- * implementation differs: cdkd parses `cdk.out/manifest.json` by hand
+ * implementation differs: cdk-local parses `cdk.out/manifest.json` by hand
  * (PR #4 self-implemented synth); cdk-local delegates to
  * `@aws-cdk/toolkit-lib` (`Toolkit.fromCdkApp()` + `Toolkit.synth()`)
  * and maps each synthesized `CloudFormationStackArtifact` to a

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -74,7 +74,7 @@ export interface DockerImageAssetSource {
   /**
    * A command-line executable that returns the name of a local Docker image
    * on stdout after being run. Mutually exclusive with `directory` in
-   * upstream CDK; cdkd treats `executable` as taking precedence when both
+   * upstream CDK; cdk-local treats `executable` as taking precedence when both
    * are set.
    */
   executable?: string[];

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -416,7 +416,7 @@ export interface ResourceProvider {
    * file can be reconstructed.
    *
    * Used by `cdkd state import` to recover state after disasters (lost state
-   * file, manual deletion, drift between cdk-local and AWS) and to adopt
+   * file, manual deletion, drift between cdkd and AWS) and to adopt
    * AWS-resident resources into cdkd's management.
    *
    * Lookup strategy is provider-specific. Recommended order:

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -12,7 +12,7 @@ export interface CloudFormationTemplate {
   /**
    * Top-level `Transform` declaration. CloudFormation macros (`Transform:
    * 'AWS::Serverless-2016-10-31'`, `Transform: ['AWS::LanguageExtensions',
-   * 'CustomMacro']`, etc.). cdkd detects this at synthesis time and runs a
+   * 'CustomMacro']`, etc.). cdk-local detects this at synthesis time and runs a
    * CFn round-trip via `src/synthesis/macro-expander.ts` to obtain the
    * post-expansion template before passing it to the analyzer / provisioner
    * pipeline — see `docs/design/463-cfn-macros.md`. The post-expansion
@@ -353,7 +353,7 @@ export interface ResourceProvider {
    *
    * Used by `cdkd drift <stack>` to detect divergence between cdkd state and
    * AWS reality without going through CloudFormation. Implementations should
-   * return only the keys cdkd actually manages — the `cdkd drift` comparator
+   * return only the keys cdk-local actually manages — the `cdkd drift` comparator
    * already ignores keys not present in state, but returning a tighter set
    * keeps the wire payload smaller.
    *
@@ -416,7 +416,7 @@ export interface ResourceProvider {
    * file can be reconstructed.
    *
    * Used by `cdkd state import` to recover state after disasters (lost state
-   * file, manual deletion, drift between cdkd and AWS) and to adopt
+   * file, manual deletion, drift between cdk-local and AWS) and to adopt
    * AWS-resident resources into cdkd's management.
    *
    * Lookup strategy is provider-specific. Recommended order:

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -57,8 +57,8 @@
  *       write persists it explicitly. Layout superset of v6; only the
  *       resource-level shape grew.
  *
- * cdkd readers handle every prior version. Writers always emit
- * `STATE_SCHEMA_VERSION_CURRENT`. An older cdkd binary that only knows an
+ * cdk-local readers handle every prior version. Writers always emit
+ * `STATE_SCHEMA_VERSION_CURRENT`. An older cdk-local binary that only knows an
  * earlier version will fail with a clear error when it encounters a higher
  * version, rather than silently mishandling the new format.
  */
@@ -125,7 +125,7 @@ export interface StackState {
   /**
    * `Fn::ImportValue` references this stack resolved during its last
    * successful deploy. Populated on schema v4+; absent (or undefined)
-   * on state written by an older cdkd binary, in which case the
+   * on state written by an older cdk-local binary, in which case the
    * destroy-time strong-reference check degrades gracefully (no
    * recorded imports = no consumers known = destroy proceeds). The
    * next deploy of an upgraded stack repopulates the field.
@@ -199,7 +199,7 @@ export interface ResourceState {
    * template still surface as drift.
    *
    * Optional for backwards compatibility — resources written by an older
-   * cdkd binary (v2 state, or v3 state on a provider that does not
+   * cdk-local binary (v2 state, or v3 state on a provider that does not
    * implement `readCurrentState`) keep this field undefined; the drift
    * command falls back to comparing against `properties` in that case.
    */
@@ -336,7 +336,7 @@ export interface AttributeChange {
 }
 
 /**
- * Returns true when a recorded `DeletionPolicy` should prevent cdkd from
+ * Returns true when a recorded `DeletionPolicy` should prevent cdk-local from
  * deleting the underlying AWS resource. `Retain` and `RetainExceptOnCreate`
  * both keep the resource around; `Delete` / `Snapshot` / undefined all
  * fall through to the normal delete path. Shared between

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -57,8 +57,8 @@
  *       write persists it explicitly. Layout superset of v6; only the
  *       resource-level shape grew.
  *
- * cdk-local readers handle every prior version. Writers always emit
- * `STATE_SCHEMA_VERSION_CURRENT`. An older cdk-local binary that only knows an
+ * cdkd readers handle every prior version. Writers always emit
+ * `STATE_SCHEMA_VERSION_CURRENT`. An older cdkd binary that only knows an
  * earlier version will fail with a clear error when it encounters a higher
  * version, rather than silently mishandling the new format.
  */
@@ -125,7 +125,7 @@ export interface StackState {
   /**
    * `Fn::ImportValue` references this stack resolved during its last
    * successful deploy. Populated on schema v4+; absent (or undefined)
-   * on state written by an older cdk-local binary, in which case the
+   * on state written by an older cdkd binary, in which case the
    * destroy-time strong-reference check degrades gracefully (no
    * recorded imports = no consumers known = destroy proceeds). The
    * next deploy of an upgraded stack repopulates the field.
@@ -199,7 +199,7 @@ export interface ResourceState {
    * template still surface as drift.
    *
    * Optional for backwards compatibility — resources written by an older
-   * cdk-local binary (v2 state, or v3 state on a provider that does not
+   * cdkd binary (v2 state, or v3 state on a provider that does not
    * implement `readCurrentState`) keep this field undefined; the drift
    * command falls back to comparing against `properties` in that case.
    */
@@ -336,7 +336,7 @@ export interface AttributeChange {
 }
 
 /**
- * Returns true when a recorded `DeletionPolicy` should prevent cdk-local from
+ * Returns true when a recorded `DeletionPolicy` should prevent cdkd from
  * deleting the underlying AWS resource. `Retain` and `RetainExceptOnCreate`
  * both keep the resource around; `Delete` / `Snapshot` / undefined all
  * fall through to the normal delete path. Shared between

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -2,16 +2,16 @@ import { spawn } from 'node:child_process';
 import { getLogger } from './logger.js';
 
 /**
- * Shared helpers for invoking the docker-compatible CLI binary across cdkd.
+ * Shared helpers for invoking the docker-compatible CLI binary across cdk-local.
  *
  * Two parity decisions with `aws-cdk-cli`'s `cdk-assets-lib`:
  *   1. `CDK_DOCKER` env var swaps the binary so podman / finch users can
- *      run cdkd without code changes (`CDK_DOCKER=podman cdkd deploy`).
+ *      run cdk-local without code changes (`CDK_DOCKER=podman cdkd deploy`).
  *   2. `runDockerStreaming` uses streaming spawn rather than `execFile`'s
  *      buffered `maxBuffer` ceiling. BuildKit's progress output can run to
  *      tens of MB on multi-stage builds with `# syntax=docker/dockerfile:1`
  *      frontend downloads + heredoc / `RUN --mount=...` features; the 50 MB
- *      `execFile` ceiling cdkd used to set silently killed those builds
+ *      `execFile` ceiling cdk-local used to set silently killed those builds
  *      with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`.
  *
  * Output handling: stdout/stderr are collected in memory unconditionally so
@@ -24,7 +24,7 @@ import { getLogger } from './logger.js';
 /**
  * Return the docker-compatible CLI binary to invoke. Matches CDK CLI:
  * `CDK_DOCKER` env var overrides the default `docker` so users on
- * podman / finch / nerdctl can swap without changing cdkd code.
+ * podman / finch / nerdctl can swap without changing cdk-local code.
  */
 export function getDockerCmd(): string {
   const override = process.env['CDK_DOCKER'];
@@ -72,7 +72,7 @@ export interface RunDockerOptions {
  * losing the upstream output.
  *
  * No `maxBuffer` ceiling: BuildKit progress output frequently exceeds the
- * `child_process.execFile` default of 1 MB (cdkd previously bumped to 50 MB
+ * `child_process.execFile` default of 1 MB (cdk-local previously bumped to 50 MB
  * but BuildKit + frontend pulls can still exceed that on first-time builds).
  */
 export async function runDockerStreaming(
@@ -151,7 +151,7 @@ export async function spawnStreaming(
       // Defensive: when spawn() fails (e.g. ENOENT race), the synchronous
       // write below could emit a stream 'error' event before the close /
       // error handlers above fire. Without a listener, Node escalates that
-      // to "Unhandled 'error' event" on some versions. cdkd's only `input`
+      // to "Unhandled 'error' event" on some versions. cdk-local's only `input`
       // call site is `docker login --password-stdin` with short payloads
       // that complete well within the syscall, so this is unlikely to fire
       // in practice — but the no-op listener is free.
@@ -254,7 +254,7 @@ export async function spawnForeground(
  * Format the stderr from a failed `docker login` so the surfaced cdkd
  * error gives the user an actionable workaround when the underlying
  * failure is a credential-helper persistence bug (which has nothing to
- * do with cdkd, AWS, or IAM perms — the docker CLI itself fails to
+ * do with cdk-local, AWS, or IAM perms — the docker CLI itself fails to
  * save the auth token to the platform's credential store). The most
  * common shape is `osxkeychain` on macOS rejecting an overwrite for
  * an existing entry, but `wincred` (Windows), `pass` (Linux), and
@@ -281,8 +281,8 @@ export function formatDockerLoginError(stderr: string, endpoint: string): string
     return (
       `docker's credential helper (osxkeychain on macOS / wincred on Windows / pass / secretservice on Linux) ` +
       `failed to persist the ECR auth token. The "already exists in the keychain" / "Error saving credentials" ` +
-      `output is a known docker-credential-helpers issue — unrelated to cdkd, AWS credentials, or IAM perms. ` +
-      `Quick fix: run \`docker logout ${endpoint}\` to clear the stale entry, then retry the cdkd command. ` +
+      `output is a known docker-credential-helpers issue — unrelated to cdk-local, AWS credentials, or IAM perms. ` +
+      `Quick fix: run \`docker logout ${endpoint}\` to clear the stale entry, then retry the cdk-local command. ` +
       `Permanent fix: edit ~/.docker/config.json and remove (or empty) the platform-specific "credsStore" entry ` +
       `(e.g. "osxkeychain" → "" or "desktop" on macOS Docker Desktop). ` +
       `Original docker stderr: ${trimmed}`

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -251,7 +251,7 @@ export async function spawnForeground(
 }
 
 /**
- * Format the stderr from a failed `docker login` so the surfaced cdkd
+ * Format the stderr from a failed `docker login` so the surfaced cdk-local
  * error gives the user an actionable workaround when the underlying
  * failure is a credential-helper persistence bug (which has nothing to
  * do with cdk-local, AWS, or IAM perms — the docker CLI itself fails to

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -1,7 +1,7 @@
 import { getLogger } from './logger.js';
 
 /**
- * Base error class for cdk-local
+ * Base error class for cdkd
  */
 export class CdkdError extends Error {
   public readonly code: string;
@@ -67,7 +67,7 @@ export class AssetError extends CdkdError {
  * re-run the same command directly to debug Dockerfile syntax errors
  * or missing build context. Used by `src/local/docker-image-builder.ts`
  * (PR 5) for container Lambdas; the parallel `AssetError` covers the
- * `cdk-local publish-assets` / `cdkd deploy` build path. Kept distinct from
+ * `cdkd publish-assets` / `cdkd deploy` build path. Kept distinct from
  * `AssetError` so `cdkl invoke` failures don't show up under the
  * "asset" error class.
  */
@@ -320,7 +320,7 @@ export class StackTerminationProtectionError extends CdkdError {
  *
  * Detected by reading the loaded state's v6 `parentStack` field — only
  * state files written by `NestedStackProvider.create` (or by the
- * recursive `cdk-local import --migrate-from-cloudformation` walk) carry
+ * recursive `cdkd import --migrate-from-cloudformation` walk) carry
  * this field; top-level stacks have `parentStack: undefined` and pass
  * the guard unchanged.
  *
@@ -381,7 +381,7 @@ export interface ActiveImportConsumer {
  * outputs. This matches CloudFormation's strong-reference semantics —
  * CFn rejects `DeleteStack` for an exporter while an importer exists.
  *
- * cdk-local has no `--force` escape hatch for this (intentionally, mirroring
+ * cdkd has no `--force` escape hatch for this (intentionally, mirroring
  * CFn). The error message lists every offending consumer and points the
  * user at the two valid resolution paths:
  *
@@ -396,7 +396,7 @@ export interface ActiveImportConsumer {
  *
  * Exit code 2 (same as `PartialFailureError`) so multi-stack `cdkd
  * destroy --all` runs that partially succeed still surface as
- * non-zero without being indistinguishable from a fatal cdk-local error.
+ * non-zero without being indistinguishable from a fatal cdkd error.
  */
 export class StackHasActiveImportsError extends CdkdError {
   readonly exitCode: number = 2;
@@ -550,7 +550,7 @@ export class LocalMigrateError extends CdkdError {
 /**
  * CloudFormation macro / `Fn::Transform` expansion failure (#463).
  *
- * cdk-local hands templates that declare `Transform: [...]` (or carry
+ * cdkd hands templates that declare `Transform: [...]` (or carry
  * `Fn::Transform: {...}` snippets) to CloudFormation server-side via a
  * transient `CreateChangeSet --change-set-type CREATE` against a
  * `cdkd-macro-expand-<id>` stack name. This error wraps every failure
@@ -586,7 +586,7 @@ export class MacroExpansionError extends CdkdError {
 }
 
 /**
- * Check if error is a cdk-local error
+ * Check if error is a cdkd error
  */
 export function isCdkdError(error: unknown): error is CdkdError {
   return error instanceof CdkdError;
@@ -638,7 +638,7 @@ export function handleError(error: unknown): never {
   // field (PartialFailureError + ResourceUpdateNotSupportedError +
   // StackHasActiveImportsError + LocalMigrateError + MacroExpansionError
   // etc.). Falling back to 1 covers `CdkdError` subclasses with no
-  // override and every non-cdk-local error.
+  // override and every non-cdkd error.
   const customExitCode =
     error instanceof CdkdError ? (error as CdkdError & { exitCode?: number }).exitCode : undefined;
   const exitCode = typeof customExitCode === 'number' ? customExitCode : 1;
@@ -723,7 +723,7 @@ export function normalizeAwsError(err: unknown, context: NormalizeAwsErrorContex
       const where = region ? ` (in ${region})` : '';
       return new Error(
         `Bucket '${bucket}'${where} is in a different region than the client. ` +
-          `cdk-local resolves this automatically; if you see this message, please report it.`
+          `cdkd resolves this automatically; if you see this message, please report it.`
       );
     }
     case 403:

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -1,7 +1,7 @@
 import { getLogger } from './logger.js';
 
 /**
- * Base error class for cdkd
+ * Base error class for cdk-local
  */
 export class CdkdError extends Error {
   public readonly code: string;
@@ -67,7 +67,7 @@ export class AssetError extends CdkdError {
  * re-run the same command directly to debug Dockerfile syntax errors
  * or missing build context. Used by `src/local/docker-image-builder.ts`
  * (PR 5) for container Lambdas; the parallel `AssetError` covers the
- * `cdkd publish-assets` / `cdkd deploy` build path. Kept distinct from
+ * `cdk-local publish-assets` / `cdkd deploy` build path. Kept distinct from
  * `AssetError` so `cdkl invoke` failures don't show up under the
  * "asset" error class.
  */
@@ -320,7 +320,7 @@ export class StackTerminationProtectionError extends CdkdError {
  *
  * Detected by reading the loaded state's v6 `parentStack` field — only
  * state files written by `NestedStackProvider.create` (or by the
- * recursive `cdkd import --migrate-from-cloudformation` walk) carry
+ * recursive `cdk-local import --migrate-from-cloudformation` walk) carry
  * this field; top-level stacks have `parentStack: undefined` and pass
  * the guard unchanged.
  *
@@ -381,7 +381,7 @@ export interface ActiveImportConsumer {
  * outputs. This matches CloudFormation's strong-reference semantics —
  * CFn rejects `DeleteStack` for an exporter while an importer exists.
  *
- * cdkd has no `--force` escape hatch for this (intentionally, mirroring
+ * cdk-local has no `--force` escape hatch for this (intentionally, mirroring
  * CFn). The error message lists every offending consumer and points the
  * user at the two valid resolution paths:
  *
@@ -396,7 +396,7 @@ export interface ActiveImportConsumer {
  *
  * Exit code 2 (same as `PartialFailureError`) so multi-stack `cdkd
  * destroy --all` runs that partially succeed still surface as
- * non-zero without being indistinguishable from a fatal cdkd error.
+ * non-zero without being indistinguishable from a fatal cdk-local error.
  */
 export class StackHasActiveImportsError extends CdkdError {
   readonly exitCode: number = 2;
@@ -550,7 +550,7 @@ export class LocalMigrateError extends CdkdError {
 /**
  * CloudFormation macro / `Fn::Transform` expansion failure (#463).
  *
- * cdkd hands templates that declare `Transform: [...]` (or carry
+ * cdk-local hands templates that declare `Transform: [...]` (or carry
  * `Fn::Transform: {...}` snippets) to CloudFormation server-side via a
  * transient `CreateChangeSet --change-set-type CREATE` against a
  * `cdkd-macro-expand-<id>` stack name. This error wraps every failure
@@ -586,7 +586,7 @@ export class MacroExpansionError extends CdkdError {
 }
 
 /**
- * Check if error is a cdkd error
+ * Check if error is a cdk-local error
  */
 export function isCdkdError(error: unknown): error is CdkdError {
   return error instanceof CdkdError;
@@ -638,7 +638,7 @@ export function handleError(error: unknown): never {
   // field (PartialFailureError + ResourceUpdateNotSupportedError +
   // StackHasActiveImportsError + LocalMigrateError + MacroExpansionError
   // etc.). Falling back to 1 covers `CdkdError` subclasses with no
-  // override and every non-cdkd error.
+  // override and every non-cdk-local error.
   const customExitCode =
     error instanceof CdkdError ? (error as CdkdError & { exitCode?: number }).exitCode : undefined;
   const exitCode = typeof customExitCode === 'number' ? customExitCode : 1;
@@ -723,7 +723,7 @@ export function normalizeAwsError(err: unknown, context: NormalizeAwsErrorContex
       const where = region ? ` (in ${region})` : '';
       return new Error(
         `Bucket '${bucket}'${where} is in a different region than the client. ` +
-          `cdkd resolves this automatically; if you see this message, please report it.`
+          `cdk-local resolves this automatically; if you see this message, please report it.`
       );
     }
     case 403:

--- a/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
+++ b/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
@@ -14,15 +14,15 @@ import { Construct } from 'constructs';
  *     maps the bare `orders` short-name to that port. `desiredCount: 2`
  *     exercises the producer side of the #585 fix: the OrdersTask
  *     publishes an EXPLICIT `hostPort: 8081`, so this service proves
- *     cdkd skips the `-p` host-port publish for a multi-replica service
+ *     cdk-local skips the `-p` host-port publish for a multi-replica service
  *     even when the TaskDefinition declares an explicit host port (the
  *     2nd replica would otherwise collide on host port 8081).
  *   - `frontend` is the consumer — it has Service Connect enabled too
  *     (so its own `frontend-api` is published), but the integ asserts
  *     BOTH replicas can reach `orders` via the `--add-host` DNS overlay
- *     cdkd injects from the shared Cloud Map registry. `desiredCount: 2`
+ *     cdk-local injects from the shared Cloud Map registry. `desiredCount: 2`
  *     exercises the OMITTED-hostPort side of the #585 fix (frontend's
- *     port mapping has no `hostPort`, which cdkd would otherwise default
+ *     port mapping has no `hostPort`, which cdk-local would otherwise default
  *     to `containerPort` 8080 and collide on the 2nd replica) AND the
  *     first-replica-wins alias resolution: both frontend replicas
  *     inherit the same shared Cloud Map registry snapshot, so they must
@@ -57,7 +57,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
       clusterName: 'cdkl-ecs-sc-fixture',
     });
 
-    // Cloud Map private DNS namespace. cdkd uses the `Name` literal as
+    // Cloud Map private DNS namespace. cdk-local uses the `Name` literal as
     // the namespace string in the `--add-host name.namespace:ip`
     // overlay.
     const namespace = new cdk.aws_servicediscovery.CfnPrivateDnsNamespace(this, 'Ns', {
@@ -110,7 +110,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
           // references it via `Services[].PortName`. `hostPort: 8081`
           // is set explicitly so this multi-replica fixture exercises
           // the EXPLICIT-hostPort branch of the #585 host-port-skip fix:
-          // with `desiredCount: 2`, cdkd skips the `-p` publish entirely
+          // with `desiredCount: 2`, cdk-local skips the `-p` publish entirely
           // for every replica, so neither the explicit 8081 nor a
           // defaulted 80 is bound to the host (the 2nd replica would
           // otherwise collide on host port 8081). Peer discovery between
@@ -208,7 +208,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
       cluster: cluster.ref,
       taskDefinition: frontendTask.ref,
       // FrontendService runs desiredCount: 2 (#579 item (1)).
-      // FrontendTask's portMappings OMITS `hostPort`, which cdkd would
+      // FrontendTask's portMappings OMITS `hostPort`, which cdk-local would
       // otherwise default to `containerPort` (=8080); the #585 fix skips
       // the `-p` publish for this multi-replica service so the 2nd
       // replica does not collide on host port 8080. Two frontend

--- a/tests/integration/local-ecs-service-connect/verify.sh
+++ b/tests/integration/local-ecs-service-connect/verify.sh
@@ -15,7 +15,7 @@
 #      service even with an explicit host port — pre-fix the 2nd replica
 #      collided on host port 8081.
 #   2. `frontend` consumer at desiredCount: 2 — frontend's portMappings
-#      OMIT `hostPort` (cdkd would otherwise default it to
+#      OMIT `hostPort` (cdk-local would otherwise default it to
 #      `containerPort` 8080 and collide on the 2nd replica). Both
 #      replicas reach `orders` via the docker `--add-host` overlay
 #      populated from cdkd's shared registry.
@@ -89,7 +89,7 @@ fi
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
 
-echo "==> Booting both services (one cdkd invocation, shared Cloud Map registry)"
+echo "==> Booting both services (one cdk-local invocation, shared Cloud Map registry)"
 ${CDKL} start-service \
   CdkLocalEcsServiceConnectFixture:OrdersService \
   CdkLocalEcsServiceConnectFixture:FrontendService \
@@ -105,7 +105,7 @@ for i in $(seq 1 120); do
     break
   fi
   if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
-    echo "FAIL: cdkd exited before reaching the boot banner"
+    echo "FAIL: cdk-local exited before reaching the boot banner"
     echo "----- service output -----"
     cat "${OUT_FILE}"
     echo "--------------------------"
@@ -287,7 +287,7 @@ echo "    OK: frontend reached orders via the docker --add-host overlay"
 echo "==> Sending SIGTERM to cdkd ($(echo $CDKL_PID))"
 kill -TERM "${CDKL_PID}"
 
-echo "==> Waiting for cdkd to exit (up to 60s)"
+echo "==> Waiting for cdk-local to exit (up to 60s)"
 EXITED=0
 for i in $(seq 1 60); do
   if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
@@ -297,7 +297,7 @@ for i in $(seq 1 60); do
   sleep 1
 done
 if [[ "${EXITED}" -ne 1 ]]; then
-  echo "FAIL: cdkd did not exit within 60s after SIGTERM"
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
   cat "${OUT_FILE}"
   kill -KILL "${CDKL_PID}" 2>/dev/null || true
   exit 1

--- a/tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts
+++ b/tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts
@@ -32,7 +32,7 @@ export class LocalInvokeBuildkitStack extends cdk.Stack {
         // Multi-stage Dockerfile — picks the `final` stage explicitly.
         target: 'final',
         // ARG threaded via `--build-arg` to confirm `dockerBuildArgs` flows
-        // through cdkd unchanged (was pre-fix-supported, but verifying parity).
+        // through cdk-local unchanged (was pre-fix-supported, but verifying parity).
         buildArgs: {
           GREETING_BUILD_ARG: 'compiled-in-from-cdk',
         },

--- a/tests/integration/local-invoke-buildkit/verify.sh
+++ b/tests/integration/local-invoke-buildkit/verify.sh
@@ -11,7 +11,7 @@
 #   6. `RUN --mount=type=secret` populated by `--secret`
 #      (DockerImageCode.fromImageAsset.buildSecrets — NEW capability)
 #
-# Pre-PR cdkd would either silently kill the build with maxBuffer 50 MB
+# Pre-PR cdk-local would either silently kill the build with maxBuffer 50 MB
 # on BuildKit progress, OR reject `buildSecrets` at the type layer
 # because cdkd's `DockerImageAssetSource` didn't surface the field.
 # Both paths now work.

--- a/tests/integration/local-invoke-dotnet/lib/local-invoke-dotnet-stack.ts
+++ b/tests/integration/local-invoke-dotnet/lib/local-invoke-dotnet-stack.ts
@@ -16,7 +16,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     event plus the value of an env var. The asset directory must
  *     contain the `dotnet publish` output (Function.dll + dependencies)
  *     before synth; `verify.sh` runs `dotnet publish` inside a Docker
- *     .NET SDK container before invoking `cdkd synth` so the host
+ *     .NET SDK container before invoking `cdk-local synth` so the host
  *     doesn't need a .NET SDK installed.
  *   - `InlineHandler` — `CfnFunction` with `Code: { ZipFile: ... }` and
  *     `runtime: dotnet8`. cdkd's local invoke must reject this with the

--- a/tests/integration/local-invoke-dotnet/verify.sh
+++ b/tests/integration/local-invoke-dotnet/verify.sh
@@ -75,7 +75,7 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   exit 1
 }
 
-# Test 3 — inline Code.ZipFile rejection. cdkd MUST refuse to invoke
+# Test 3 — inline Code.ZipFile rejection. cdk-local MUST refuse to invoke
 # this Lambda with the routing message pointing at lambda.Code.fromAsset,
 # and exit non-zero BEFORE pulling any image / starting any container.
 echo "==> [3/3] Invoking InlineHandler — expecting Inline Code.ZipFile rejection"

--- a/tests/integration/local-invoke-java/lib/local-invoke-java-stack.ts
+++ b/tests/integration/local-invoke-java/lib/local-invoke-java-stack.ts
@@ -16,7 +16,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     event plus the value of an env var. The asset directory must
  *     contain a compiled `Handler.class` before synth; `verify.sh`
  *     compiles it inside a Docker JDK container before invoking
- *     `cdkd synth` so the host doesn't need a JDK installed.
+ *     `cdk-local synth` so the host doesn't need a JDK installed.
  *   - `InlineHandler` — `CfnFunction` with `Code: { ZipFile: ... }` and
  *     `runtime: java17`. cdkd's local invoke must reject this with the
  *     "use Code.fromAsset" message — Java's Handler shape names a

--- a/tests/integration/local-invoke-java/verify.sh
+++ b/tests/integration/local-invoke-java/verify.sh
@@ -74,7 +74,7 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   exit 1
 }
 
-# Test 3 — inline Code.ZipFile rejection. cdkd MUST refuse to invoke
+# Test 3 — inline Code.ZipFile rejection. cdk-local MUST refuse to invoke
 # this Lambda with the routing message pointing at lambda.Code.fromAsset,
 # and exit non-zero BEFORE pulling any image / starting any container.
 echo "==> [3/3] Invoking InlineHandler — expecting Inline Code.ZipFile rejection"

--- a/tests/integration/local-invoke-layers/lib/local-invoke-layers-stack.ts
+++ b/tests/integration/local-invoke-layers/lib/local-invoke-layers-stack.ts
@@ -18,7 +18,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     lives in BOTH the `GreetingsA` and `GreetingsB` layers under the
  *     same path `/opt/nodejs/node_modules/util-greetings/index.js`. The
  *     function declares `Layers: [GreetingsA, GreetingsB, Counters]`,
- *     so the GreetingsB version wins. cdkd implements this on the
+ *     so the GreetingsB version wins. cdk-local implements this on the
  *     host: every layer is `cpSync({recursive: true, force: true})`'d
  *     into a fresh tmpdir IN ORDER — later layers overwrite earlier
  *     files — and the merged tmpdir is bind-mounted at `/opt:ro`.

--- a/tests/integration/local-invoke-layers/verify.sh
+++ b/tests/integration/local-invoke-layers/verify.sh
@@ -56,7 +56,7 @@ echo "${RESULT_1}" | grep -q '"counter":"count=7"' || {
 # 1b: greetings layer — last-wins. Both GreetingsA and GreetingsB
 # install /opt/nodejs/node_modules/util-greetings/index.js; the
 # template declares Layers in order [A, B, Counters], so B's index.js
-# must overwrite A's. cdkd merges the layer asset dirs into a single
+# must overwrite A's. cdk-local merges the layer asset dirs into a single
 # tmpdir on the host (cpSync recursive+force, in template order) and
 # bind-mounts that at /opt — Docker rejects multiple -v ...:/opt:ro
 # entries, so we cannot rely on overlay layering at the runtime.
@@ -89,11 +89,11 @@ echo "${RESULT_2}" | grep -q '"counter":"count=42"' || {
 # Test 3 — startup banner mentions the 3 layer mounts. Combines
 # stdout + stderr (cdkd's `logger.info` writes to stdout via
 # `console.info`; we just want to verify the layer-count line appears
-# somewhere in the cdkd output) so users know the layer wiring fired.
-echo "==> [3/3] Verifying cdkd logs the layer count"
+# somewhere in the cdk-local output) so users know the layer wiring fired.
+echo "==> [3/3] Verifying cdk-local logs the layer count"
 LOG_OUTPUT=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>&1)
 echo "${LOG_OUTPUT}" | grep -q 'Mounting 3 Lambda layers at /opt' || {
-  echo "FAIL: expected 'Mounting 3 Lambda layers' message in cdkd output, got:"
+  echo "FAIL: expected 'Mounting 3 Lambda layers' message in cdk-local output, got:"
   echo "${LOG_OUTPUT}"
   exit 1
 }

--- a/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
+++ b/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
@@ -26,7 +26,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     Smoke-tests that both `provided.*` variants reject identically.
  *   - `Go1xHandler` — `CfnFunction` with `runtime: go1.x`. AWS Lambda
  *     deprecated this runtime on 2024-01-08 and removed its base image,
- *     so cdkd must reject with a migration pointer to provided.al2023.
+ *     so cdk-local must reject with a migration pointer to provided.al2023.
  *     CfnFunction is the L1 escape hatch because `lambda.Runtime.GO_1_X`
  *     still exists in CDK but our CDK lib version may or may not refuse
  *     it at synth time depending on CDK release; we want the rejection
@@ -85,7 +85,7 @@ export class LocalInvokeProvidedStack extends cdk.Stack {
     new lambda.CfnFunction(this, 'Go1xHandler', {
       runtime: 'go1.x',
       // Go 1.x's pre-OAL Handler was the compiled binary name on the
-      // classpath. Doesn't matter for the integ — cdkd rejects with a
+      // classpath. Doesn't matter for the integ — cdk-local rejects with a
       // deprecation message before touching the asset.
       handler: 'main',
       role: inlineRole.roleArn,

--- a/tests/integration/local-run-task-awsvpc/lib/local-run-task-awsvpc-stack.ts
+++ b/tests/integration/local-run-task-awsvpc/lib/local-run-task-awsvpc-stack.ts
@@ -8,7 +8,7 @@ import { Construct } from 'constructs';
  *
  * A single TaskDefinition with `networkMode: awsvpc` and one busybox
  * container running a tiny netcat HTTP echo on port 18080. The point of
- * this fixture is the NETWORK MODE: before #461 cdkd hard-rejected
+ * this fixture is the NETWORK MODE: before #461 cdk-local hard-rejected
  * `awsvpc` at resolver time with `EcsTaskResolutionError`; after #461 it
  * ACCEPTS the task and maps `awsvpc` to a docker bridge network with a
  * startup warn (docker cannot emulate ENI-per-task — see
@@ -19,7 +19,7 @@ import { Construct } from 'constructs';
  * A non-privileged port (18080) is used so the host-port publish (cdkd
  * publishes container ports for `run-task`) does not need to bind the
  * privileged port 80. `awsvpc` requires `hostPort == containerPort` (or
- * omitted), so `hostPort` is left implicit and cdkd defaults it to
+ * omitted), so `hostPort` is left implicit and cdk-local defaults it to
  * `containerPort`.
  *
  * No AWS deploy required — the integ runs against the synthesized
@@ -54,7 +54,7 @@ export class LocalRunTaskAwsvpcStack extends cdk.Stack {
         "while true; do { echo -e 'HTTP/1.1 200 OK\\r\\nContent-Length: 13\\r\\nConnection: close\\r\\n\\r\\nHELLO_AWSVPC\\n'; } | nc -l -p 18080; done",
       ],
       // awsvpc requires hostPort == containerPort (or omitted); leave
-      // hostPort implicit so cdkd defaults it to the containerPort.
+      // hostPort implicit so cdk-local defaults it to the containerPort.
       portMappings: [{ containerPort: 18080, protocol: ecs.Protocol.TCP }],
       memoryReservationMiB: 32,
     });

--- a/tests/integration/local-run-task-awsvpc/verify.sh
+++ b/tests/integration/local-run-task-awsvpc/verify.sh
@@ -4,7 +4,7 @@
 #
 # Fully local: no AWS resources are deployed. Exercises `cdkl run-task` against a TaskDefinition declaring `NetworkMode: awsvpc`.
 #
-# Before #461 cdkd hard-rejected `awsvpc` at resolver time with
+# Before #461 cdk-local hard-rejected `awsvpc` at resolver time with
 # `EcsTaskResolutionError`; after #461 it ACCEPTS the task and maps
 # `awsvpc` to a docker bridge network with a startup warn (docker cannot
 # emulate ENI-per-task — see docs/design/461-awsvpc-decision.md).

--- a/tests/integration/local-start-api-websocket/verify.sh
+++ b/tests/integration/local-start-api-websocket/verify.sh
@@ -265,7 +265,7 @@ async function runMultiClient() {
   await new Promise((r) => setTimeout(r, 200));
 }
 
-// M5: $connect deny path — handshake completes but cdkd closes with 1008.
+// M5: $connect deny path — handshake completes but cdk-local closes with 1008.
 async function runDeny() {
   const denyUrl = `${url}?reject=true`;
   const ws = new WebSocket(denyUrl);

--- a/tests/integration/local-start-api/lib/local-start-api-stack.ts
+++ b/tests/integration/local-start-api/lib/local-start-api-stack.ts
@@ -35,14 +35,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     the REST v1 MOCK CORS preflight subset (verify.sh asserts a 204
  *     response with the canonical CORS headers, no Lambda invoke).
  *   - REST v1:     GET /v1/unsupported (HTTP_PROXY integration to a
- *     public URL) — exercises the deferred-error class. cdkd boots
+ *     public URL) — exercises the deferred-error class. cdk-local boots
  *     successfully with a [warn] line; verify.sh asserts the route
  *     returns 501 + `reason` body without invoking any Lambda.
  *   - REST v1:     GET /v1/cross-stack-auth (CUSTOM authorizer whose
  *     AuthorizerUri is overridden via `addPropertyOverride` to a
  *     cross-stack-shape `Fn::Sub: '${ImportedAuthFn.Arn}'` that cdkd
  *     cannot resolve locally) — exercises the authorizer-Lambda-Arn
- *     deferred-501 path added in issue #431. cdkd boots successfully
+ *     deferred-501 path added in issue #431. cdk-local boots successfully
  *     with the authorizer-attach failure deferred to request time;
  *     verify.sh asserts the route returns 501 + `reason` body.
  *   - Function URL on a separate Lambda: ANY /{proxy+}
@@ -166,7 +166,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // with `Integration.Type: 'AWS'` and a non-Lambda service URI (S3) —
     // cdkd's REST v1 dispatcher detects the non-`:lambda:path/` marker
     // and surfaces deferred-501 ("non-Lambda service ... not emulated
-    // locally in cdkd v1"). verify.sh asserts the 501 path.
+    // locally in cdk-local v1"). verify.sh asserts the 501 path.
     const unsupported = v1.addResource('unsupported');
     const unsupportedMethod = unsupported.addMethod('GET');
     // CDK's L2 `Integration` constructs don't expose `AWS` direct-service
@@ -188,7 +188,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // Authorizer Lambda Arn unresolvable (issue #431): build a CUSTOM
     // REQUEST authorizer pointing at a same-stack Lambda, then override
     // its synthesized `AuthorizerUri` to a cross-stack-shape
-    // `Fn::Sub: '${ImportedAuthFn.Arn}'` that cdkd cannot resolve
+    // `Fn::Sub: '${ImportedAuthFn.Arn}'` that cdk-local cannot resolve
     // locally. cdkd's authorizer-resolver hits the unresolvable Arn,
     // flips the route to deferred-error unsupported, boot continues,
     // HTTP 501 + reason at request time. The L1 override pattern lets
@@ -235,7 +235,7 @@ export class LocalStartApiStack extends cdk.Stack {
       // `CredentialsArn` is required on deployed AWS API Gateway for
       // service integrations; it's a no-op locally (the dispatcher uses
       // the dev's local AWS credential chain) but we set it to a
-      // fixture-stable value so cdkd synth doesn't fail validation.
+      // fixture-stable value so cdk-local synth doesn't fail validation.
       credentialsArn: 'arn:aws:iam::123456789012:role/fixture-sqs-role',
       requestParameters: {
         QueueUrl: '$request.querystring.url',
@@ -270,7 +270,7 @@ export class LocalStartApiStack extends cdk.Stack {
 
     // Unrecognized subtype path — exercises the classifier's fallback to
     // deferred-501 (preserves the safe surface for typo'd subtypes AND
-    // for AWS-documented subtypes cdkd does not yet implement). Use an
+    // for AWS-documented subtypes cdk-local does not yet implement). Use an
     // obviously-bogus subtype name so the test is unambiguous about
     // exercising the unsupported path rather than asserting anything
     // about a real AWS service.
@@ -289,7 +289,7 @@ export class LocalStartApiStack extends cdk.Stack {
     });
 
     // Issue #502: Lambda-authorizer-protected service-integration route.
-    // Pre-PR cdkd dispatched the SDK call BEFORE the authorizer pass,
+    // Pre-PR cdk-local dispatched the SDK call BEFORE the authorizer pass,
     // letting unauthenticated requests reach the SDK. Post-PR the
     // authorizer pass runs FIRST: missing Bearer → 401, valid Bearer →
     // SDK dispatches (returns 4xx from the missing queue, NOT 401).

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -230,7 +230,7 @@ curl_assert "Function URL fallback" "http://127.0.0.1:${PORT_FNURL}/url-only/pin
 
 # #467: streaming Function URL (`invokeMode: RESPONSE_STREAM`). The
 # handler emits 5 chunks of "hello-N\n" with 200ms delays between
-# chunks. cdkd MUST:
+# chunks. cdk-local MUST:
 #   1. Return HTTP 200 + `Transfer-Encoding: chunked` headers (not
 #      buffered-then-flushed in one shot).
 #   2. Deliver chunks incrementally — the wall-clock duration of
@@ -376,7 +376,7 @@ fi
 echo "    [REST v1 MOCK CORS preflight] OK"
 
 # Deferred-error class: GET /v1/unsupported has an HTTP_PROXY integration
-# cdkd cannot emulate. The server returns 501 + `reason` in the body, no
+# cdk-local cannot emulate. The server returns 501 + `reason` in the body, no
 # Lambda invocation. Pre-PR boot would have hard-errored on this route
 # and prevented every other route from being reachable.
 echo "==> Asserting GET /v1/unsupported -> 501 Not Implemented"

--- a/tests/integration/local-start-service/verify.sh
+++ b/tests/integration/local-start-service/verify.sh
@@ -2,7 +2,7 @@
 # verify.sh — cdkl start-service Phase 2 integ test (no AWS deploy)
 #
 # Boots a 2-replica ECS Service emulator backed by busybox heartbeat
-# containers. Asserts both replicas reach docker, then SIGTERMs cdkd and
+# containers. Asserts both replicas reach docker, then SIGTERMs cdk-local and
 # asserts clean teardown (no leftover containers / networks / sidecars).
 #
 #     bash tests/integration/local-start-service/verify.sh
@@ -20,7 +20,7 @@ cleanup() {
   echo "==> Cleanup: stopping any leftover containers + networks"
   if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
     kill -TERM "${CDKL_PID}" 2>/dev/null || true
-    # Give cdkd up to 30s to clean up gracefully.
+    # Give cdk-local up to 30s to clean up gracefully.
     for _ in $(seq 1 60); do
       if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
       sleep 0.5
@@ -77,9 +77,9 @@ for i in $(seq 1 60); do
     BOOTED=1
     break
   fi
-  # If cdkd exited early, fail fast.
+  # If cdk-local exited early, fail fast.
   if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
-    echo "FAIL: cdkd exited before reaching the boot banner"
+    echo "FAIL: cdk-local exited before reaching the boot banner"
     echo "----- service output -----"
     cat "${OUT_FILE}"
     echo "--------------------------"
@@ -165,8 +165,8 @@ echo "    OK: ${UNIQUE_SUBNET_COUNT} distinct subnets across ${#SUBNETS[@]} netw
 echo "==> Sending SIGTERM to cdkd ($(echo $CDKL_PID))"
 kill -TERM "${CDKL_PID}"
 
-# Wait for cdkd to exit cleanly.
-echo "==> Waiting for cdkd to exit (up to 60s)"
+# Wait for cdk-local to exit cleanly.
+echo "==> Waiting for cdk-local to exit (up to 60s)"
 EXITED=0
 for i in $(seq 1 60); do
   if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
@@ -176,7 +176,7 @@ for i in $(seq 1 60); do
   sleep 1
 done
 if [[ "${EXITED}" -ne 1 ]]; then
-  echo "FAIL: cdkd did not exit within 60s after SIGTERM"
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
   echo "----- service output -----"
   cat "${OUT_FILE}"
   echo "--------------------------"


### PR DESCRIPTION
## Summary

Closes the **final Phase 2e-5 sweep** deferred by #2 and #3. Replaces every standalone `cdkd` reference that points to cdk-local's OWN behavior (JSDoc, inline comments, user-facing error messages) with `cdk-local`, while **preserving every reference that genuinely points to the host cdkd package**.

Result: 63 files changed, 198 insertions, 198 deletions (symmetric mechanical).

## Mechanical strategy

1. **Verb-pattern sweep** (cdk-local self-refs):
   - `cdkd <verb>` -> `cdk-local <verb>` for the descriptive verbs cdk-local actually exhibits (`verifies / refreshes / caches / supports / writes / cannot / allows / mirrors / rejects` etc.)

2. **Possessive-pattern sweep** (cdk-local self-refs):
   - `cdkd's local server / endpoint / emulation / evaluator / dispatcher / authorizer-resolver / REST v1 dispatcher / classifier / code path / only ``input``` -> `cdk-local's <X>`

3. **Multi-line wrap fix**:
   - `cdkd local\n * <continuation>` (a JSDoc line-break that the verb-pattern sweep couldn't see) -> `cdk-local\n * <continuation>`

4. **Negative-lookahead sweep** (everything else):
   - `cdkd <verb>` -> `cdk-local <verb>` **EXCEPT** when `<verb>` is a host CLI keyword: `state / destroy / deploy / orphan / drift / migrate / restart / stack / stacks`

5. **Individual file edits**:
   - `error-handler.ts`: "Base error class for cdkd" -> "for cdk-local"; "upgrade cdkd" -> "upgrade cdk-local"
   - `docker-cmd.ts`: "across cdkd" -> "across cdk-local"; "unrelated to cdkd" -> "unrelated to cdk-local"

## Intentionally KEPT (host cdkd references)

cdk-local IS hosted by cdkd in production; removing these references would be **inaccurate**. The handover and #2's commit message both call this out explicitly. KEPT classes:

- **Host CLI commands**: `cdkd state` / `cdkd destroy` / `cdkd deploy` / `cdkd orphan` / `cdkd drift` / `cdkd migrate` / `cdkd restart` / `cdkd stack(s)`
- **Host concepts (possessive)**: `cdkd's S3 state` / `cdkd's state.json` / `cdkd's recorded` / `cdkd's exports index` / `cdkd's StackState` / `cdkd's Fn::GetStackOutput intrinsic` / `cdkd's logger` / `cdkd's hand-rolled AppExecutor` / `cdkd's synthesis` / `cdkd's --from-state` / `cdkd's S3LocalStateProvider` / `cdkd's own CFn / CC API clients` / `cdkd's outbound calls` / `cdkd's multi-stack output` / `cdkd's management`
- **Host compounds**: `cdkd-specific` / `cdkd-asset-<hash>` / `cdkd-managed` / `cdkd-macro-expand-<id>` / `cdkd-preferred fast path` / `cdkd-vs-CFn nature` / `cdkd-doesn't-bundle` / `cdkd-deployed stacks`
- **S3 path**: `s3://{bucket}/cdkd/{stackName}/{region}/state.json`
- **GitHub repo URLs**: `github.com/go-to-k/cdkd/issues/<N>`
- **Host injection example**: `e.g. cdkd, which injects its own state provider` (`src/index.ts:4`)

## Test plan

- [x] `vp run typecheck` clean
- [x] `vp run build` clean
- [x] `vp run test` — 80/80 pass (no test code changes; the sweep is comment-only on src and JSDoc-only on tests/integration `.ts` + grep-comment in verify.sh)

## Notes

- This is the third Phase 2e-5 PR after #2 (Phase A, verb-only) and #3 (Construct ID + fixture strings).
- After this lands, the cdk-local repo's prose is internally consistent: anything that says `cdkd` refers to the host package, anything that says `cdk-local` (or `cdkl` for the binary) refers to this package.
