### PR TITLE
chore(meta): add CLAUDE.md + ci workflow + README repositioning

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,191 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Project overview
+
+**cdk-local** is a CDK-native local execution CLI. Bin name: `cdkl`, npm
+package: `cdk-local`. Read your CDK app's `cdk.json`, synth it, and run the
+synthesized Lambda functions / API Gateway routes / ECS tasks locally in
+Docker — using real `public.ecr.aws/lambda/*` base images via the Lambda
+Runtime Interface Emulator (RIE).
+
+cdk-local is a **library + CLI** consumed by cdkd (and any other host that
+wants CDK-app-aware local execution). The dependency direction is
+**cdkd -> cdk-local** — cdk-local does NOT depend on cdkd.
+
+## Scope: what runs locally, what doesn't
+
+cdk-local runs your **application compute** locally; it does NOT emulate
+AWS managed services.
+
+### Runs locally (application compute)
+
+- Lambda functions — your code in a real `public.ecr.aws/lambda/*`
+  container via the Lambda Runtime Interface Emulator
+- API Gateway routing — REST v1 / HTTP v2 / Function URL / WebSocket
+  served by a local HTTP server
+- ECS tasks and services — real Docker containers with awsvpc /
+  Service Connect / Cloud Map registry
+- API Gateway authorizers — Lambda authorizers, Cognito User Pool JWT
+  verification, IAM SigV4 verification
+
+### Calls real AWS (managed services)
+
+- DynamoDB / S3 / Secrets Manager / SSM Parameter Store / Cognito user
+  pool / SNS / SQS / Kinesis / EventBridge / Step Functions / etc.
+- Your Lambda code talks to real AWS via:
+  - `--assume-role <arn>` to inject IAM role credentials into the
+    container
+  - `--from-cfn-stack <stack>` to bind to a deployed CloudFormation
+    stack and inject its real ARNs / Secret values into Lambda env
+- cdk-local does NOT bundle a managed-service emulator. If you need
+  offline emulation, pair cdk-local with a service emulator like
+  LocalStack — they are complementary, not competing.
+
+When writing committed artifacts (README, docs, commit messages, PR
+bodies, JSDoc), keep to this scope. Do NOT add comparison tables vs
+`aws-cdk-local` or LocalStack. The only public comparison the docs may
+make is to `sam local` (same compute-locally category for Lambda + API
+Gateway).
+
+## Architecture
+
+`src/` layout:
+
+- `src/cli/` — Commander command factories (`createLocalInvokeCommand`,
+  `createLocalStartApiCommand`, `createLocalRunTaskCommand`,
+  `createLocalStartServiceCommand`) + shared option helpers.
+- `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
+  (`Toolkit.fromCdkApp()` + context store threading) that returns
+  `StackInfo[]` for downstream consumers.
+- `src/local/` — runtime layer: docker-runner, container-pool, http-server,
+  websocket-server, ecs-task-runner, ecs-service-runner, ecs-network,
+  cloud-map-registry, lambda-resolver, ecs-task-resolver,
+  route-discovery, authorizer-resolver, lambda-authorizer, cognito-jwt,
+  sigv4-verify, rie-client, intrinsic-image, runtime-image, etc.
+- `src/assets/` — asset manifest loader + docker-build for container Lambdas.
+- `src/types/` — shared interfaces (`StackState`, `ResourceState`,
+  `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state
+  schema so host-side state can flow into cdk-local unchanged.
+
+`tests/integration/local-*` — per-fixture real-Docker E2E tests
+(`verify.sh` runs the CLI against a deployed-style fixture). cdk-local
+itself does not invoke AWS; integration tests that need `--from-cfn-stack`
+deploy via the upstream `cdk` CLI.
+
+## Build and test commands
+
+```bash
+# Install (pnpm + vite-plus)
+pnpm install
+
+# Build (tsdown via vp pack)
+vp run build
+
+# Watch
+vp run dev
+
+# Typecheck
+vp run typecheck
+
+# Lint / format
+vp run lint
+vp run lint:fix
+vp run format
+vp run format:check
+
+# Unified check (typecheck + lint + format-check)
+vp run check
+
+# Unit tests (vitest)
+vp run test
+vp run test:watch
+vp run test:coverage
+
+# verify = check + test + build
+vp run verify
+
+# Build artifact smoke test
+vp run runtime:smoke
+```
+
+## Important implementation details
+
+- **ESM Modules**: `package.json` declares `"type": "module"`. All imports
+  must carry the `.js` extension even in TypeScript source:
+
+  ```typescript
+  import { foo } from './bar.js';  // OK
+  import { foo } from './bar';     // wrong
+  ```
+
+- **Library + CLI dual entry**: `src/index.ts` (library exports) and
+  `src/cli/index.ts` (binary entrypoint). `vp pack` produces both
+  `dist/index.js` (library) and `dist/cli.js` (CLI).
+
+- **Toolkit-lib integration**: `src/synthesis/assembly-reader.ts`
+  delegates synthesis to `@aws-cdk/toolkit-lib`'s `Toolkit.fromCdkApp()`.
+  CLI `-c key=value` overrides land in a `CdkAppMultiContext(workingDir,
+  context)` so `cdk.json` / `cdk.context.json` / `~/.cdk.json` remain
+  the base layer and overrides only win for keys they touch.
+
+- **Node version**: `.node-version` pins to 24.x for dev / CI. `vp pack`
+  targets `node20` for the shipped runtime — `package.json` engines
+  declares `>=20`.
+
+## Workflow rules
+
+- **English only for committed files**: source, scripts, hook messages,
+  configs (`.claude/settings.json`, `vite.config.ts`), docs, comments,
+  commit messages, PR titles/bodies/comments, GitHub issue text. No
+  Japanese characters (hiragana / katakana / kanji) in any committed
+  artifact. Chat in the orchestrating session may be Japanese — this rule
+  applies only to files / GitHub artifacts that land in the repo.
+
+- **Never commit / push directly to `main`**: all changes via a feature
+  branch + PR. Feature branches live under
+  `.claude/worktrees/<branch>/`; use
+  `git worktree add .claude/worktrees/<branch> -b <branch> origin/main`
+  rather than branching in the main worktree (shared state across
+  parallel agents).
+
+- **Squash merge only**: prefer `gh pr merge <N> --squash --delete-branch`.
+  PR #1 was squash-merged; keep the history flat.
+
+- **Always add unit tests for new functionality**: don't wait to be
+  asked. `tests/unit/**` mirrors `src/**`. Mock external boundaries
+  (toolkit-lib, docker CLI, AWS SDK) with `vi.mock` / `vi.hoisted`.
+
+- **After source changes**: run `vp run build` before reporting "ready
+  to test" — users invoke cdk-local via `node dist/cli.js` (or the
+  `cdkl` bin), so source changes without a build have no runtime
+  effect.
+
+- **Before opening a PR**: run `vp run verify` (= check + test + build).
+  This is what CI runs; failing locally is faster feedback than failing
+  in GitHub Actions.
+
+## Positioning when communicating
+
+- `cdkl` is the **binary** name (the command users type).
+- `cdk-local` is the **npm package** name (what users import / install).
+- When referring to the project in prose, use "cdk-local".
+- When referring to the CLI command in code blocks / examples, use
+  `cdkl invoke / start-api / run-task / start-service`.
+- Do NOT write comparison tables against `aws-cdk-local` / `cdklocal` /
+  LocalStack in committed artifacts (README, docs, JSDoc). The
+  cdk-local vs LocalStack distinction is the
+  "compute vs managed services" one above; lead with that, not with
+  side-by-side tables.
+- Do NOT reference cdkd internal implementation (deploy / destroy /
+  state schema details / provider system) in cdk-local artifacts — the
+  dependency direction is cdkd -> cdk-local, and cdk-local should read
+  as self-contained.
+
+## Reference
+
+- `README.md` — user-facing intro + install + usage.
+- `vite.config.ts` — vp tasks, lint / fmt / pack / test config.
+- `.github/workflows/ci.yml` — CI (typecheck + lint + test + build +
+  Node 20/22/24 matrix smoke).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version: "24"
+          cache: true
+          run-install: false
+
+      - run: vp install --frozen-lockfile
+      - run: vp run check
+      - run: vp run test
+      - run: vp run build
+
+  runtime-compat:
+    runs-on: ubuntu-latest
+    needs: check-build-test
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version: "24"
+          cache: true
+          run-install: false
+
+      - run: vp install --frozen-lockfile
+      - run: vp run build
+      - run: vp env exec --node ${{ matrix.node-version }} node dist/cli.js --version

--- a/README.md
+++ b/README.md
@@ -9,17 +9,22 @@ Run AWS CDK stacks locally with Docker. A native, CDK-first alternative to `sam 
 - **Two execution modes** — standalone (no AWS deployment), or bound to a deployed stack to inject real ARNs / Secrets / IAM credentials.
 - **No AWS emulator required** — your Lambda code runs in the real `public.ecr.aws/lambda/*` base image via Lambda Runtime Interface Emulator (RIE). ECS tasks run as real Docker containers. The only dependency is Docker.
 
-## How is this different from aws-cdk-local / LocalStack?
+## What runs locally, what doesn't
 
-`cdk-local` and [`aws-cdk-local`](https://github.com/localstack/aws-cdk-local) solve **different problems** — they're complementary, not competing:
+cdk-local runs your **application compute** locally in Docker, using your CDK app as the source of truth. It does NOT emulate AWS managed services.
 
-| Tool | What it is | Lambda code runs where? | Backing AWS APIs |
-|------|------------|-------------------------|------------------|
-| `aws-cdk-local` (`cdklocal`) | CDK CLI wrapper that deploys your CDK stack to a LocalStack server | Inside LocalStack's Lambda emulator | LocalStack's emulated AWS APIs |
-| **`cdk-local` (`cdkl`)** | **CDK-native invoke / start-api / run-task — runs your actual code in Docker** | **Real `public.ecr.aws/lambda/*` container via RIE** | **Real AWS** (via `--assume-role` / `--from-cfn-stack`) or no AWS at all |
-| `sam local` | SAM CLI's local invoke for SAM-template apps | Real Lambda base image via RIE | Real AWS or none |
+**Runs locally (application compute):**
 
-If you want to deploy your CDK stack to LocalStack for end-to-end emulation, use `aws-cdk-local`. If you want to iterate on Lambda code, debug an API Gateway route, or run an ECS task locally — using **real AWS data and real IAM permissions** (or no AWS at all) — use `cdk-local`. Many projects benefit from both.
+- **Lambda functions** — your code in a real `public.ecr.aws/lambda/*` container via the Lambda Runtime Interface Emulator
+- **API Gateway** — REST v1 / HTTP v2 / Function URL / WebSocket served by a local HTTP server
+- **ECS** — tasks and services as real Docker containers (awsvpc / Service Connect / Cloud Map registry)
+- **Authorizers** — Lambda authorizers, Cognito User Pool JWT verification, IAM SigV4 verification
+
+**Calls real AWS (managed services):**
+
+- DynamoDB / S3 / Secrets Manager / SSM / SNS / SQS / Kinesis / EventBridge / Step Functions / etc.
+- Your Lambda code talks to real AWS via your IAM credentials (`--assume-role` or `--from-cfn-stack` to bind to a deployed stack)
+- If you want offline emulation of managed services, pair cdk-local with a service emulator like LocalStack — cdk-local does not bundle one.
 
 ## Install
 

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -462,7 +462,8 @@ async function localStartApiCommand(
     // differ if stacks span partitions. Per-stack failures degrade to
     // warn-and-fall-back (the PR 1 behavior is preserved) so a missing
     // or unreadable state file never aborts the server boot.
-    const stateSourceActive = isCfnFlagPresent(options) || hasExtraStateProviderActive(options, extraStateProviders);
+    const stateSourceActive =
+      isCfnFlagPresent(options) || hasExtraStateProviderActive(options, extraStateProviders);
     const stateByStack = stateSourceActive
       ? await loadStateForRoutedStacks(
           targetStacks,

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -26,10 +26,7 @@ export function parseContextOptions(contextArgs?: string[]): Record<string, stri
 export const commonOptions = [
   new Option('--verbose', 'Enable verbose logging').default(false),
   new Option('--profile <profile>', 'AWS profile'),
-  new Option(
-    '--role-arn <arn>',
-    'IAM role ARN to assume for AWS API calls (env: CDKL_ROLE_ARN)'
-  ),
+  new Option('--role-arn <arn>', 'IAM role ARN to assume for AWS API calls (env: CDKL_ROLE_ARN)'),
   new Option(
     '-y, --yes',
     'Automatically answer interactive prompts with the recommended response'


### PR DESCRIPTION
## Summary

Phase 2 follow-up **stage 1** scaffolding: project guidance file, minimal CI, and a README repositioning that brings the docs in line with Plan notice-13 (no aws-cdk-local / LocalStack comparison tables; lead with the compute-vs-managed-services boundary).

249 additions, 13 deletions, 5 files.

## Stage-1 additions

### `.claude/CLAUDE.md` (new, ~190 lines)

- Project overview + library/CLI dual entry + dependency direction (cdkd -> cdk-local, never the reverse).
- **Scope** section: compute (Lambda RIE / API Gateway local server / ECS Docker / Cloud Map registry) runs locally; managed services (DynamoDB / S3 / Secrets Manager / Cognito / SSM / SNS / SQS / Kinesis / EventBridge / Step Functions) call real AWS. LocalStack mentioned **once** as a complementary tool.
- Architecture map for `src/` layout.
- Build/test command table (`vp run build / test / check / typecheck / lint / format / verify / runtime:smoke`).
- Workflow rules: English-only committed artifacts, no-direct-push-to-main, squash-merge-only, always-add-unit-tests, `vp run build` before "ready to test", `vp run verify` before opening a PR.
- Positioning rules: `cdkl` = bin, `cdk-local` = npm package; no comparison tables in committed artifacts; no cdkd-internal references; `sam local` is the only public peer comparison.

### `.github/workflows/ci.yml` (new, ~40 lines)

- `check-build-test` job: `vp install --frozen-lockfile` -> `vp run check` -> `vp run test` -> `vp run build`. Same shape as cdkd's `check-build-test`, minus the cdkd-specific drift guards (provider-coverage / integ-coverage / scenario-coverage) that do not apply here.
- `runtime-compat` job: Node 20 / 22 / 24 matrix smoke against the built CLI. Mirrors cdkd's `runtime-compat`.
- Pinned `actions/checkout` + `voidzero-dev/setup-vp` to the same shas cdkd uses.

### README repositioning

- **Delete**: "How is this different from aws-cdk-local / LocalStack?" comparison table (added in an earlier session; Plan notice-13 explicitly forbids these tables in committed artifacts).
- **Add**: "What runs locally, what doesn't" — directly states the compute-vs-managed-services boundary, per Plan notice-13 preferred wording.
- LocalStack mentioned **once** ("pair cdk-local with a service emulator like LocalStack — cdk-local does not bundle one"), per Plan section 5 budget.

## Format pass byproduct

`vp run check` surfaced two pre-existing format issues on `main`:

- `src/cli/commands/local-start-api.ts`: one statement re-wrapped to the 100-col `printWidth` budget.
- `src/cli/options.ts`: `--role-arn` Option declaration collapsed onto a single line per the same budget.

These were left in `main` because there was no CI to catch them. Fixed here so the new `ci.yml` doesn't immediately fail on the next PR. No logic change.

## Out of scope (Plan notice-13 stage-2 deferral)

Per the Plan, these need a working `cdkl invoke` end-to-end before being copy-rewritten from cdkd. Deferred to a later PR after the next functional bump:

- `.claude/settings.json`
- `.claude/hooks/**` / `.claude/skills/**` / `.claude/agents/**` / `.claude/rules/**`
- `.github/workflows/release.yml` (semantic-release wiring)
- `.github/PULL_REQUEST_TEMPLATE.md`
- `CONTRIBUTING.md`
- `.vscode/settings.json` / `.vscode/extensions.json`

Also intentionally NOT added: `.editorconfig`. cdkd doesn't ship one (sanity-checked: `cat /Users/goto/pc/github/cdkd/.editorconfig` returns "No such file"), and cdk-local already has a `vp fmt` config in `vite.config.ts` that covers the same ground (`endOfLine: 'lf'` / `tabWidth: 2` / `useTabs: false` / `singleQuote` / `printWidth: 100`). An `.editorconfig` would be either redundant or risk drifting from `vp fmt`.

## Test plan

- [x] `vp run verify` clean (= `check` + `test` + `build`)
  - typecheck: no errors
  - lint: 0 warnings
  - format: 0 issues
  - tests: 80/80 pass
  - build: clean
- [x] CI workflow self-tests when this PR runs through GitHub Actions

## Follow-up

- **Phase 2.5** (cdkd `src/local/**` differential sync into cdk-local): handover note at `/tmp/handover-cdk-local-phase-2-followup-meta.md` for the next session.
- Stage-2 meta items (above) when the next functional PR has landed.
