### PR TITLE
chore(sync): pull cdkd src/local commits #662..#672 into cdk-local

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -53,6 +53,10 @@ import {
   getDockerImageBySourceHash,
 } from '../../assets/asset-manifest-loader.js';
 import { singleFlight } from '../../utils/single-flight.js';
+import {
+  writeProfileCredentialsFile,
+  type ProfileCredentialsFile,
+} from './local-profile-credentials-file.js';
 import type { StackState } from '../../types/state.js';
 
 interface LocalInvokeOptions {
@@ -148,6 +152,11 @@ async function localInvokeCommand(
   let containerId: string | undefined;
   let stopLogs: (() => void) | undefined;
   let sigintHandler: (() => void) | undefined;
+  // cdkd PR #670 (deferred follow-up from #655): synthesized AWS shared
+  // credentials file (one INI section) bind-mounted into the container so
+  // handlers using `fromIni({ profile })` explicitly resolve to the same
+  // creds. Disposed in the shared `cleanup` single-flight.
+  let profileCredsFile: ProfileCredentialsFile | undefined;
 
   /**
    * Unified cleanup for both the success / failure unwind path AND the
@@ -208,6 +217,17 @@ async function localInvokeCommand(
           }
         }
       }
+      if (profileCredsFile) {
+        try {
+          await profileCredsFile.dispose();
+        } catch (err) {
+          getLogger().debug(
+            `Failed to remove profile credentials tmpdir ${profileCredsFile.hostPath}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
     },
     (err) => {
       getLogger().debug(`cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -225,6 +245,20 @@ async function localInvokeCommand(
     const profileCredentials = options.profile
       ? await resolveProfileCredentials(options.profile)
       : undefined;
+
+    // cdkd PR #670 (deferred follow-up from #655): synthesize an AWS
+    // shared credentials file with the resolved creds under
+    // `[<options.profile>]` so handler code that uses
+    // `fromIni({ profile: '<options.profile>' })` explicitly (instead of
+    // the default credential chain) resolves to the same creds locally.
+    // Mounted read-only into the container at the path pointed to by
+    // `AWS_SHARED_CREDENTIALS_FILE` (set below). The default-chain path
+    // (most handlers) keeps working through the existing env-var
+    // injection; this file is the additive layer for the explicit-
+    // profile case. Disposed in the shared `cleanup` single-flight above.
+    if (options.profile && profileCredentials) {
+      profileCredsFile = await writeProfileCredentialsFile(options.profile, profileCredentials);
+    }
 
     const appCmd = resolveApp(options.app);
     if (!appCmd) {
@@ -385,6 +419,15 @@ async function localInvokeCommand(
     if (!assumeSucceeded) {
       forwardAwsEnv(dockerEnv);
       applyProfileCredentialsOverlay(dockerEnv, profileCredentials, false);
+      // cdkd PR #670 (deferred follow-up from #655): point the container's
+      // SDK chain at the bind-mounted credentials file so
+      // `fromIni({ profile })` calls inside the handler resolve to the
+      // same creds. `AWS_PROFILE` makes `fromIni()` (no explicit arg)
+      // ALSO use this profile.
+      if (profileCredsFile) {
+        dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
+        dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
+      }
     }
 
     let debugPort: number | undefined;
@@ -411,10 +454,26 @@ async function localInvokeCommand(
       );
     }
     logger.info(`Starting container (image=${imagePlan.image}, port=${hostPort})...`);
+    // cdkd PR #670 (deferred follow-up from #655): append the profile
+    // credentials file bind-mount to the existing extraMounts (which
+    // already carry the /opt layer mount when present). Read-only — the
+    // container has no business writing to its credentials file; a
+    // writable mount would let a compromised handler tamper with the
+    // host-side temp file.
+    const extraMountsWithProfile = profileCredsFile
+      ? [
+          ...(imagePlan.extraMounts ?? []),
+          {
+            hostPath: profileCredsFile.hostPath,
+            containerPath: profileCredsFile.containerPath,
+            readOnly: true,
+          },
+        ]
+      : imagePlan.extraMounts;
     containerId = await runDetached({
       image: imagePlan.image,
       mounts: imagePlan.mounts,
-      extraMounts: imagePlan.extraMounts,
+      extraMounts: extraMountsWithProfile,
       env: dockerEnv,
       cmd: imagePlan.cmd,
       hostPort,

--- a/src/cli/commands/local-profile-credentials-file.ts
+++ b/src/cli/commands/local-profile-credentials-file.ts
@@ -1,0 +1,152 @@
+// Profile-aware credentials file mount for cdk-local Lambda containers.
+//
+// Background: cdkd#655 / #657 forward `--profile <p>`-resolved credentials to
+// the Lambda container as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
+// `AWS_SESSION_TOKEN` env vars. The SDK's default credential provider chain
+// reads those env vars, so the common handler pattern
+// (`new SecretsManagerClient({ region })`) works.
+//
+// What this module adds: handlers that explicitly call
+// `fromIni({ profile: '<name>' })` bypass the env-var chain and look for
+// `[<name>]` in `~/.aws/credentials` (or `AWS_SHARED_CREDENTIALS_FILE`).
+// Inside the Lambda container neither file exists by default, so those
+// handlers fail locally even when production AWS Lambda + IAM-role-baked-
+// profile setups (Lambda Layer with credentials etc.) make them work.
+//
+// Fix: when `--profile <name>` is passed, ALSO write a temp credentials
+// file with the resolved creds under `[<name>]`, bind-mount it into the
+// container, and set `AWS_SHARED_CREDENTIALS_FILE=<containerPath>` +
+// `AWS_PROFILE=<name>` env vars. Now both code paths work:
+//
+//   - Default chain: reads `AWS_ACCESS_KEY_ID` etc. (existing behavior)
+//   - `fromIni({ profile: '<name>' })`: reads the mounted file via
+//     `AWS_SHARED_CREDENTIALS_FILE`, finds `[<name>]`, returns the same
+//     resolved creds
+//
+// The profile NAME inside the container matches what the user passed via
+// `--profile` so handler code `fromIni({ profile: '<name>' })` matches
+// without source changes.
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Path inside the container where the credentials file is mounted. Fixed
+ * (not user-configurable) so the env-var injection is stable.
+ * `/cdk-local-aws/` is outside `/var/task` (the Lambda code mount) and
+ * outside `/root/` (which the user's handler may bind-mount or modify),
+ * so there is no collision risk with the user's payload.
+ */
+export const CONTAINER_AWS_CREDENTIALS_PATH = '/cdk-local-aws/credentials';
+
+/**
+ * Resolved profile credentials file ready to mount into a Lambda container.
+ *
+ * `hostPath` is the absolute path on the host
+ * (`/tmp/cdk-local-profile-creds-<rand>/credentials`).
+ * `dispose` removes the host-side file + its parent tempdir; safe to call
+ * multiple times (idempotent rm).
+ */
+export interface ProfileCredentialsFile {
+  hostPath: string;
+  containerPath: string;
+  profileName: string;
+  dispose: () => Promise<void>;
+}
+
+/**
+ * Write a temporary AWS shared-credentials file containing the resolved
+ * `--profile <name>` credentials, ready to bind-mount into a Lambda
+ * container at {@link CONTAINER_AWS_CREDENTIALS_PATH}.
+ *
+ * The file content is the standard `[profile-name]` INI shape:
+ *
+ *   [<profileName>]
+ *   aws_access_key_id = <accessKeyId>
+ *   aws_secret_access_key = <secretAccessKey>
+ *   aws_session_token = <sessionToken>   ← only when present
+ *
+ * `aws_session_token` is omitted when the resolved profile produced
+ * long-lived (non-STS) credentials, mirroring the same logic
+ * `applyProfileCredentialsOverlay` uses for env-var injection.
+ *
+ * Caller is responsible for invoking `dispose()` when the container pool
+ * tears down (e.g., on `SIGINT` via `singleFlight` cleanup). Leaving the
+ * file behind in `/tmp` is a security smell (temp credentials live on
+ * disk).
+ */
+export async function writeProfileCredentialsFile(
+  profileName: string,
+  creds: { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
+): Promise<ProfileCredentialsFile> {
+  // cdkd PR #670 code review finding #2: validate the profile name before
+  // interpolating into the INI section header / AWS_PROFILE env var.
+  // The injection surface is local-dev-only (the caller is the user's
+  // own `--profile <name>` arg) so this is hardening, not security
+  // boundary — but a value containing `]` would silently start a second
+  // INI section, and a value containing newlines would break the
+  // `-e AWS_PROFILE=...` docker-run env line. Reject at the helper
+  // boundary so the caller never has to think about it.
+  if (profileName === '') {
+    throw new Error('writeProfileCredentialsFile: profile name must not be empty.');
+  }
+  if (/[\r\n[\]]/.test(profileName)) {
+    throw new Error(
+      `writeProfileCredentialsFile: profile name '${profileName}' contains a forbidden character ` +
+        `(any of CR, LF, '[', ']' would corrupt the INI file or the docker -e env var).`
+    );
+  }
+  const dir = await mkdtemp(path.join(tmpdir(), 'cdk-local-profile-creds-'));
+  const hostPath = path.join(dir, 'credentials');
+  const lines: string[] = [
+    `[${profileName}]`,
+    `aws_access_key_id = ${creds.accessKeyId}`,
+    `aws_secret_access_key = ${creds.secretAccessKey}`,
+  ];
+  if (creds.sessionToken) {
+    lines.push(`aws_session_token = ${creds.sessionToken}`);
+  }
+  // Trailing newline for POSIX-text-file convention; some INI parsers
+  // (including AWS SDK's older versions) reject files without a final
+  // newline.
+  await writeFile(hostPath, lines.join('\n') + '\n', { mode: 0o600 });
+  return {
+    hostPath,
+    containerPath: CONTAINER_AWS_CREDENTIALS_PATH,
+    profileName,
+    dispose: async () => {
+      // `recursive: true` removes the credentials file + its parent
+      // tempdir in one shot. `force: true` makes the dispose idempotent
+      // (multiple cleanup paths call this on SIGINT, single-flight
+      // teardown, etc.).
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Build the docker-args fragment that mounts a profile credentials file
+ * into the container + sets the env vars the SDK chain needs.
+ *
+ * Returns an array of `docker run` args that the caller splices into its
+ * own argv builder. Empty array when `file` is `undefined` (the
+ * `--profile` flag was not set).
+ *
+ * The `:ro` mount flag is load-bearing — the container has no business
+ * writing to its credentials file; a writable mount would let a
+ * compromised handler tamper with the host-side temp file.
+ */
+export function buildProfileCredentialsDockerArgs(
+  file: ProfileCredentialsFile | undefined
+): string[] {
+  if (!file) return [];
+  return [
+    '-v',
+    `${file.hostPath}:${file.containerPath}:ro`,
+    '-e',
+    `AWS_SHARED_CREDENTIALS_FILE=${file.containerPath}`,
+    '-e',
+    `AWS_PROFILE=${file.profileName}`,
+  ];
+}

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -14,6 +14,11 @@ import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
+import { resolveProfileCredentials } from './local-start-api.js';
+import {
+  writeProfileCredentialsFile,
+  type ProfileCredentialsFile,
+} from './local-profile-credentials-file.js';
 import {
   applyCrossStackResolverToTask,
   derivePartitionAndUrlSuffix,
@@ -115,6 +120,11 @@ async function localRunTaskCommand(
   // extra). Hoisted so the outer `finally` can dispose it even if the
   // body throws between provider creation and the normal exit path.
   let stateProvider: LocalStateProvider | undefined;
+  // ECS analogue of cdkd PR #670: synthesized AWS shared credentials
+  // file (one INI section) bind-mounted into every user container so
+  // handlers using `fromIni({ profile })` resolve to the same creds.
+  // Disposed in the cleanup chain below.
+  let profileCredsFile: ProfileCredentialsFile | undefined;
 
   // Single-flight cleanup: the SIGINT handler AND the outer `finally` both
   // call this, so we await the first invocation's promise on every later
@@ -129,6 +139,17 @@ async function localRunTaskCommand(
           await cleanupEcsRun(state, { keepRunning: options.keepRunning });
         } catch (err) {
           getLogger().debug(`cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        if (profileCredsFile) {
+          try {
+            await profileCredsFile.dispose();
+          } catch (err) {
+            getLogger().debug(
+              `Failed to remove profile credentials tmpdir ${profileCredsFile.hostPath}: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+          }
         }
       })();
     }
@@ -251,6 +272,37 @@ async function localRunTaskCommand(
       assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
     }
 
+    // cdkd#658: when `--assume-task-role` is NOT effective but
+    // `--profile <p>` IS set, resolve the profile via the SDK's default
+    // credential provider chain (SSO / IAM Identity Center / fromIni /
+    // role-assumption) and forward the resulting `{AKID, SAK,
+    // sessionToken?}` to the metadata-endpoints sidecar. Without this,
+    // the sidecar starts inside a fresh container with no SSO config and
+    // no `~/.aws/credentials`, so every user container that hits
+    // `169.254.170.2/role/<role>` gets a credential-provider failure.
+    // Same gap class as cdkd#654/#655, which shipped the equivalent
+    // forward for `cdkl start-api`'s Lambda container path.
+    const sidecarCredentials = await resolveSidecarCredentials(options, assumedCredentials);
+
+    // ECS analogue of cdkd PR #670 (Lambda-container fix-back finding #1):
+    // when `--profile <p>` is set AND `--assume-task-role` did NOT
+    // produce credentials for this task, synthesize a host-side AWS
+    // shared credentials file under `[<options.profile>]` and bind-
+    // mount it read-only into every user container. Handler code
+    // calling `fromIni({ profile: '<options.profile>' })` then
+    // resolves to the same creds the metadata sidecar serves —
+    // without this, the SDK looks for `[<options.profile>]` in
+    // `~/.aws/credentials` inside the container and fails.
+    //
+    // Gating `!assumedCredentials` preserves the documented
+    // precedence (assume-task-role > profile-file > sidecar): when
+    // `--assume-task-role` won, the sidecar's `/role/<arn>` endpoint
+    // already serves the assumed creds and the file env vars must
+    // NOT override them.
+    if (options.profile && sidecarCredentials && !assumedCredentials) {
+      profileCredsFile = await writeProfileCredentialsFile(options.profile, sidecarCredentials);
+    }
+
     const envOverrides = readEnvOverridesFile(options.envVars);
 
     const runOpts: RunEcsTaskOptions = {
@@ -261,11 +313,18 @@ async function localRunTaskCommand(
       detach: options.detach,
     };
     if (envOverrides) runOpts.envOverrides = envOverrides;
-    if (assumedCredentials) runOpts.taskCredentials = assumedCredentials;
+    if (sidecarCredentials) runOpts.taskCredentials = sidecarCredentials;
     if (resolvedRoleArn) runOpts.taskRoleArn = resolvedRoleArn;
     if (options.platform) runOpts.platformOverride = options.platform;
     if (options.region) runOpts.region = options.region;
     if (options.ecrRoleArn) runOpts.ecrRoleArn = options.ecrRoleArn;
+    if (profileCredsFile) {
+      runOpts.profileCredentialsFile = {
+        hostPath: profileCredsFile.hostPath,
+        containerPath: profileCredsFile.containerPath,
+        profileName: profileCredsFile.profileName,
+      };
+    }
 
     const result = await runEcsTask(task, runOpts, state);
 
@@ -483,6 +542,36 @@ function readEnvOverridesFile(
     throw new Error(`--env-vars file '${filePath}' must contain a JSON object at the top level.`);
   }
   return parsed as Record<string, Record<string, string | null> | undefined>;
+}
+
+/**
+ * cdkd#658: pick the credentials forwarded to the AWS-published
+ * `amazon-ecs-local-container-endpoints` sidecar. Precedence:
+ *   1. `--assume-task-role <arn>` (or bare `--assume-task-role` against
+ *      a resolvable `TaskRoleArn`) → STS-assumed temp creds. Highest
+ *      priority — when the user opted in to IAM emulation, those creds
+ *      drive the sidecar regardless of `--profile`.
+ *   2. `--profile <p>` → resolved via {@link resolveProfileCredentials}
+ *      (the SDK's default credential provider chain — SSO / IAM
+ *      Identity Center / fromIni / role-assumption). NEW in this PR.
+ *   3. Neither set → `undefined`; the sidecar runs with its own
+ *      default credential chain (typically empty inside a fresh
+ *      container — user containers will get 4xx from the credentials
+ *      endpoint, mimicking IAM-misconfigured prod).
+ *
+ * Extracted as an exported helper so a unit test can exercise every
+ * branch without having to mock the full Synth + Docker + AWS pipeline
+ * (the strategy cdkd#655 used for the Lambda container path).
+ */
+export async function resolveSidecarCredentials(
+  options: { profile?: string },
+  assumedCredentials:
+    | { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
+    | undefined
+): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string } | undefined> {
+  if (assumedCredentials) return assumedCredentials;
+  if (options.profile) return resolveProfileCredentials(options.profile);
+  return undefined;
 }
 
 export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions = {}): Command {

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -110,6 +110,10 @@ import {
 } from '../../local/cognito-jwt.js';
 import { defaultCredentialsLoader, type CredentialsLoader } from '../../local/sigv4-verify.js';
 import { singleFlight } from '../../utils/single-flight.js';
+import {
+  writeProfileCredentialsFile,
+  type ProfileCredentialsFile,
+} from './local-profile-credentials-file.js';
 
 interface LocalStartApiOptions {
   app?: string;
@@ -293,6 +297,14 @@ async function localStartApiCommand(
   // shutdown path is the single owner of cleanup so leaks are
   // bounded by server lifetime).
   const layerTmpDirs = new Set<string>();
+  // cdkd PR #670 (deferred follow-up from #655): synthesized AWS shared
+  // credentials file bind-mounted into every Lambda container so handlers
+  // using `fromIni({ profile })` explicitly resolve to the same creds as
+  // the default chain. Created ONCE at server boot (NOT on hot reload —
+  // re-resolving profile creds is fine for env vars but rewriting the
+  // file mid-flight would race with running containers' SDK reads).
+  // Disposed in the cleanup chain. Undefined when `--profile` is unset.
+  let profileCredsFile: ProfileCredentialsFile | undefined;
   // Track every Lambda asset directory the server is currently
   // referencing; the file watcher uses this list to know what to
   // watch beyond `cdk.out/`. The value is updated AFTER the reload
@@ -488,6 +500,30 @@ async function localStartApiCommand(
       ? await resolveProfileCredentials(options.profile)
       : undefined;
 
+    // cdkd PR #670 (deferred follow-up from #655): when `--profile <p>`
+    // is set, ALSO synthesize a shared AWS credentials file with the
+    // resolved creds under `[<p>]` and bind-mount it into every Lambda
+    // container at `/cdk-local-aws/credentials`. This lets handlers that
+    // use `fromIni({ profile: '<p>' })` explicitly inside their code
+    // (instead of the default credential chain) resolve to the same
+    // creds locally. The default-chain path (most handlers) keeps
+    // working through the existing `AWS_*` env-var injection — the
+    // file is the additive layer for the explicit-profile case.
+    //
+    // Caveat: under `--watch` hot reload, `profileCredentials` re-resolves
+    // and the new env vars flow to the next cold start, but the on-disk
+    // file is NOT re-written. Long-running sessions whose SSO temp creds
+    // expire need a cdk-local restart (matches the auto-refresh-deferred
+    // stance for env vars from cdkd#655).
+    //
+    // Assigned to outer-scope `profileCredsFile` so the cleanup chain
+    // disposes the file at shutdown. Only ever assigned on the FIRST
+    // synthesizeAndBuild (initial server boot) — hot reload sees the
+    // variable already set and skips re-writing per the caveat above.
+    if (options.profile && profileCredentials && !profileCredsFile) {
+      profileCredsFile = await writeProfileCredentialsFile(options.profile, profileCredentials);
+    }
+
     // Build the per-Lambda spec map. Every reachable logical ID is
     // resolved to its asset / inline code, env vars, optional STS creds
     // (--assume-role), optional --debug-port reservation. The container
@@ -512,6 +548,7 @@ async function localStartApiCommand(
         skipPull: options.pull === false,
         ...(options.layerRoleArn !== undefined && { layerRoleArn: options.layerRoleArn }),
         ...(profileCredentials && { profileCredentials }),
+        ...(profileCredsFile && { profileCredsFile }),
       });
       specs.set(logicalId, spec);
     }
@@ -1067,6 +1104,21 @@ async function localStartApiCommand(
         );
       }
     }
+    // cdkd PR #670 (deferred follow-up from #655): dispose the synthesized
+    // profile credentials file (one INI file under
+    // `/tmp/cdk-local-profile-creds-*/`). Leaving temp credential files on
+    // disk after process exit is a security smell; `dispose()` rm's the
+    // tempdir recursively + force, so re-entrant calls (signal-mid-finally
+    // race) are safe.
+    if (profileCredsFile) {
+      try {
+        await profileCredsFile.dispose();
+      } catch (err) {
+        logger.warn(
+          `Failed to remove profile credentials tmpdir ${profileCredsFile.hostPath}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
   });
   const shutdown = async (signal: string, exitCode: number): Promise<void> => {
     if (shutdownStarted) {
@@ -1358,6 +1410,16 @@ async function buildContainerSpec(args: {
    * effect — `forwardAwsEnv` copies `process.env.AWS_*`).
    */
   profileCredentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
+  /**
+   * cdkd PR #670 (deferred follow-up from #655): when set, a synthesized
+   * AWS shared credentials file (one INI section, the resolved
+   * `[<profile-name>]` block) the container should bind-mount + reference
+   * via `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env vars. Lets
+   * handlers that use `fromIni({ profile })` explicitly inside their
+   * code resolve to the same creds locally. Undefined when `--profile`
+   * was not passed.
+   */
+  profileCredsFile?: ProfileCredentialsFile;
 }): Promise<ContainerSpec> {
   const {
     logicalId,
@@ -1373,6 +1435,7 @@ async function buildContainerSpec(args: {
     skipPull,
     layerRoleArn,
     profileCredentials,
+    profileCredsFile,
   } = args;
   const lambda = resolveLambdaByLogicalId(logicalId, stacks);
 
@@ -1512,6 +1575,27 @@ async function buildContainerSpec(args: {
         delete dockerEnv['AWS_SESSION_TOKEN'];
       }
     }
+
+    // cdkd PR #670 (profile-aware SDK config inside container): when the
+    // server boot synthesized a credentials file via
+    // `writeProfileCredentialsFile(options.profile, ...)`, point the
+    // container's SDK chain at the bind-mounted path so
+    // `fromIni({ profile: '<name>' })` calls inside the handler resolve
+    // to the same creds as the default chain. `AWS_PROFILE` makes
+    // `fromIni()` (no explicit arg) ALSO use this profile — both code
+    // paths converge on the same `[<name>]` section.
+    //
+    // GATED on `!roleArn` (nested in the assume-role-NOT-effective branch)
+    // so the existing precedence "assume-role > profile > env" holds for
+    // the file path too. Without this nesting, a handler in an
+    // assume-role'd Lambda that called `fromIni({ profile: '<name>' })`
+    // explicitly would silently bypass the execution-role creds and use
+    // the `--profile <name>` creds — breaking the documented precedence
+    // (cdkd PR #670 code review finding #1).
+    if (profileCredsFile) {
+      dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
+      dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
+    }
   }
 
   if (debugPort !== undefined) {
@@ -1540,6 +1624,12 @@ async function buildContainerSpec(args: {
       ...(optDir !== undefined && { optDir }),
       ...(debugPort !== undefined && { debugPort }),
       ...(tmpfs !== undefined && { tmpfs }),
+      ...(profileCredsFile && {
+        profileCredentialsFile: {
+          hostPath: profileCredsFile.hostPath,
+          containerPath: profileCredsFile.containerPath,
+        },
+      }),
     };
     return spec;
   }
@@ -1561,6 +1651,12 @@ async function buildContainerSpec(args: {
     containerHost,
     ...(debugPort !== undefined && { debugPort }),
     ...(tmpfs !== undefined && { tmpfs }),
+    ...(profileCredsFile && {
+      profileCredentialsFile: {
+        hostPath: profileCredsFile.hostPath,
+        containerPath: profileCredsFile.containerPath,
+      },
+    }),
   };
   return spec;
 }

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -15,6 +15,11 @@ import { singleFlight } from '../../utils/single-flight.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
+import { resolveProfileCredentials } from './local-start-api.js';
+import {
+  writeProfileCredentialsFile,
+  type ProfileCredentialsFile,
+} from './local-profile-credentials-file.js';
 import {
   applyCrossStackResolverToTask,
   derivePartitionAndUrlSuffix,
@@ -142,6 +147,16 @@ async function localStartServiceCommand(
   // Hoisted out of the try block so the single-flight cleanup closure
   // can teardown the shared network after every container is gone.
   let sharedNetwork: TaskNetwork | undefined;
+  // ECS analogue of cdkd PR #670: synthesized AWS shared credentials
+  // file bind-mounted into every service replica's containers so
+  // `fromIni({ profile })` handlers resolve to the same creds the
+  // sidecar serves. One-per-CLI-invocation (mirrors the shared
+  // sidecar's shape — `--profile` is a CLI-level concern, not a
+  // per-service one). Disposed by the single-flight cleanup AFTER
+  // every replica's containers are gone but BEFORE the shared
+  // network is torn down (the file outlives running containers but
+  // can vanish once they're stopped).
+  let profileCredsFile: ProfileCredentialsFile | undefined;
 
   // Single-flight cleanup so the SIGINT handler and the outer `finally`
   // collapse to one underlying invocation. Fans out across every
@@ -170,6 +185,23 @@ async function localStartServiceCommand(
           }
         })
       );
+      // Profile credentials file dispose — must happen AFTER every
+      // replica's containers are gone (the bind-mount keeps the
+      // file alive for as long as a container references it) but
+      // BEFORE / parallel-with the shared network teardown.
+      // Idempotent (`rm` is `force: true`); see
+      // `writeProfileCredentialsFile`'s `dispose` for the contract.
+      if (profileCredsFile) {
+        try {
+          await profileCredsFile.dispose();
+        } catch (err) {
+          getLogger().warn(
+            `Failed to remove profile credentials tmpdir ${profileCredsFile.hostPath}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        profileCredsFile = undefined;
+      }
+
       // Shared network teardown.
       if (sharedNetwork) {
         try {
@@ -225,16 +257,40 @@ async function localStartServiceCommand(
     const registry = new CloudMapRegistry();
     // Create ONE shared docker network used by every service-replica
     // boot in this CLI invocation.
+    //
+    // cdkd#658: when `--profile <p>` is set, the resolved credentials
+    // are forwarded to the AWS-published metadata-endpoints sidecar so
+    // its `/role/<role-arn>` endpoint serves them to user containers.
+    // Without this, the sidecar starts inside a fresh container with
+    // no SSO config / no `~/.aws/credentials` and falls back to its
+    // own (empty) default chain, breaking every container that hits
+    // 169.254.171.2. Per-service `--assume-task-role <Service>=<arn>`
+    // overrides are independent — they flow into `buildMetadataEnv`
+    // per container and are unrelated to the SIDECAR's own startup
+    // credentials.
+    const sidecarCredentials = await resolveSharedSidecarCredentials(options);
     try {
       sharedNetwork = await createSharedSvcNetwork({
         prefix: options.cluster,
         skipPull,
         cluster: options.cluster,
+        ...(sidecarCredentials !== undefined && { credentials: sidecarCredentials }),
       });
     } catch (err) {
       throw new LocalStartServiceError(
         `Failed to create shared service network: ${err instanceof Error ? err.message : String(err)}`
       );
+    }
+    // ECS analogue of cdkd PR #670 — when `--profile <p>` is set, write
+    // ONCE the host-side credentials file used by every replica's
+    // containers. Mirrors the shared-sidecar shape (one-per-CLI-
+    // invocation): `--profile` is a CLI-level concern. Per-service
+    // `--assume-task-role <Service>=<arn>` overrides are independent
+    // and re-gated INSIDE `runOneTarget` so an assume-role'd service
+    // does NOT receive the file env vars (preserves the assume >
+    // file > sidecar precedence applied per-service).
+    if (options.profile && sidecarCredentials) {
+      profileCredsFile = await writeProfileCredentialsFile(options.profile, sidecarCredentials);
     }
     const discovery: ServiceDiscoveryContext = {
       registry,
@@ -266,7 +322,8 @@ async function localStartServiceCommand(
         options,
         discovery,
         skipPull,
-        extraStateProviders
+        extraStateProviders,
+        profileCredsFile
       );
     }
 
@@ -300,7 +357,8 @@ async function bootOneTarget(
   options: LocalStartServiceOptions,
   discovery: ServiceDiscoveryContext,
   skipPull: boolean,
-  extraStateProviders: ExtraStateProviders | undefined
+  extraStateProviders: ExtraStateProviders | undefined,
+  profileCredsFile: ProfileCredentialsFile | undefined
 ): Promise<ServiceController> {
   const parsed = parseEcsTarget(target);
   const candidate = pickCandidateStack(parsed.stackPattern, stacks);
@@ -319,7 +377,8 @@ async function bootOneTarget(
       options,
       discovery,
       skipPull,
-      stateProvider
+      stateProvider,
+      profileCredsFile
     );
   } finally {
     if (stateProvider) stateProvider.dispose();
@@ -333,7 +392,8 @@ async function runOneTarget(
   options: LocalStartServiceOptions,
   discovery: ServiceDiscoveryContext,
   skipPull: boolean,
-  stateProvider: LocalStateProvider | undefined
+  stateProvider: LocalStateProvider | undefined,
+  profileCredsFile: ProfileCredentialsFile | undefined
 ): Promise<ServiceController> {
   const logger = getLogger();
 
@@ -416,6 +476,22 @@ async function runOneTarget(
   if (options.platform) taskOpts.platformOverride = options.platform;
   if (options.region) taskOpts.region = options.region;
   if (options.ecrRoleArn) taskOpts.ecrRoleArn = options.ecrRoleArn;
+  // Per-service gating (mirrors cdkd PR #670 fix-back finding #1
+  // applied in `local-run-task.ts`): the shared credentials file is
+  // bound ONLY to services that did NOT win an `--assume-task-role`.
+  // An assume-role'd service serves its own STS creds via the
+  // sidecar's `/role/<arn>` endpoint; injecting
+  // `AWS_SHARED_CREDENTIALS_FILE` / `AWS_PROFILE` on top would
+  // silently bypass the assumed creds for `fromIni({ profile })`
+  // callers and break the documented precedence (assume > file >
+  // sidecar).
+  if (profileCredsFile && !assumedCredentials) {
+    taskOpts.profileCredentialsFile = {
+      hostPath: profileCredsFile.hostPath,
+      containerPath: profileCredsFile.containerPath,
+      profileName: profileCredsFile.profileName,
+    };
+  }
 
   const runnerOpts: ServiceRunnerOptions = {
     maxTasks: options.maxTasks,
@@ -635,6 +711,37 @@ function parseRestartPolicy(raw: string): 'on-failure' | 'always' | 'none' {
   throw new LocalStartServiceError(
     `--restart-policy must be one of 'on-failure', 'always', or 'none' (got '${raw}').`
   );
+}
+
+/**
+ * cdkd#658: pick the credentials forwarded to the AWS-published
+ * `amazon-ecs-local-container-endpoints` sidecar. `cdkl start-service`'s
+ * sidecar is SHARED across every replica boot in one CLI invocation, so
+ * this resolves ONCE at startup. Precedence:
+ *   1. `--profile <p>` → resolved via {@link resolveProfileCredentials}
+ *      (the SDK's default credential provider chain — SSO / IAM
+ *      Identity Center / fromIni / role-assumption). NEW in this PR.
+ *   2. Not set → `undefined`; the sidecar runs with its own default
+ *      credential chain (typically empty inside a fresh container —
+ *      user containers will get 4xx from the credentials endpoint).
+ *
+ * Note: per-service `--assume-task-role <Service>=<arn>` overrides are
+ * INTENTIONALLY NOT consulted here. The shared sidecar has no concept
+ * of per-service IAM — per-service `TaskRoleArn` flows into each
+ * container's env via `buildMetadataEnv` at boot time, where the
+ * sidecar's `/role/<role-arn>` path resolves per-request. The shared
+ * sidecar's OWN startup credentials govern only the fallback path
+ * (containers that did not bind a `TaskRoleArn`).
+ *
+ * Extracted as an exported helper so a unit test can exercise both
+ * branches without having to mock the full Synth + Docker + AWS
+ * pipeline (the strategy cdkd#655 used for the Lambda container path).
+ */
+export async function resolveSharedSidecarCredentials(options: {
+  profile?: string;
+}): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string } | undefined> {
+  if (options.profile) return resolveProfileCredentials(options.profile);
+  return undefined;
 }
 
 export function createLocalStartServiceCommand(

--- a/src/local/container-pool.ts
+++ b/src/local/container-pool.ts
@@ -116,6 +116,23 @@ interface ContainerSpecBase {
    * for Lambdas not backing a WebSocket API.
    */
   extraHosts?: { host: string; ip: string }[];
+  /**
+   * cdkd PR #670 (deferred follow-up from #655) — when `cdkl *` is
+   * invoked with `--profile <name>`, this is the host path of a
+   * synthesized AWS shared credentials file (one INI section, the
+   * resolved `[<name>]` block). The pool bind-mounts it read-only at
+   * the container path so SDK calls via `fromIni({ profile: '<name>' })`
+   * inside the handler find their profile locally — production AWS
+   * Lambda doesn't ship `~/.aws/`, so this is purely a local-development
+   * convenience to keep handler code portable without source changes.
+   *
+   * Set in `local-start-api.ts` / `local-invoke.ts`'s startup flow
+   * alongside the `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env
+   * entries (already in `env`) so the SDK's default chain + explicit
+   * `fromIni({ profile })` both resolve to the same creds. Unset when
+   * `--profile` was not passed (the env-var-only path stays in effect).
+   */
+  profileCredentialsFile?: { hostPath: string; containerPath: string };
 }
 
 export interface ZipContainerSpec extends ContainerSpecBase {
@@ -324,6 +341,22 @@ export function createContainerPool(
       const optMount = spec.optDir
         ? [{ hostPath: spec.optDir, containerPath: '/opt', readOnly: true }]
         : [];
+      // Append the profile credentials file mount (cdkd PR #670 deferred
+      // from #655) when --profile was passed. Read-only — the container
+      // has no business writing to its credentials file, and a writable
+      // mount would let a compromised handler tamper with the host-side
+      // temp file. Combined with `optMount` since Docker accepts an array
+      // of -v args (no conflict with the /opt layer mount).
+      const extraMounts = spec.profileCredentialsFile
+        ? [
+            ...optMount,
+            {
+              hostPath: spec.profileCredentialsFile.hostPath,
+              containerPath: spec.profileCredentialsFile.containerPath,
+              readOnly: true,
+            },
+          ]
+        : optMount;
       // provided.al2 / provided.al2023 require the deployment package at
       // /var/runtime (where the base image's hardcoded entrypoint exec's
       // /var/runtime/bootstrap); every other runtime expects /var/task.
@@ -332,7 +365,7 @@ export function createContainerPool(
       containerId = await runDetached({
         image,
         mounts: [{ hostPath: spec.codeDir, containerPath: containerCodePath, readOnly: true }],
-        extraMounts: optMount,
+        extraMounts,
         env: spec.env,
         cmd: [spec.lambda.handler],
         hostPort,
@@ -355,6 +388,15 @@ export function createContainerPool(
       containerId = await runDetached({
         image: spec.image,
         mounts: [],
+        ...(spec.profileCredentialsFile && {
+          extraMounts: [
+            {
+              hostPath: spec.profileCredentialsFile.hostPath,
+              containerPath: spec.profileCredentialsFile.containerPath,
+              readOnly: true,
+            },
+          ],
+        }),
         env: spec.env,
         cmd: spec.command,
         hostPort,

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -158,6 +158,25 @@ export interface RunEcsTaskOptions {
    * (network-aliases default to the container's `--name` only).
    */
   networkAliasesByContainer?: ReadonlyMap<string, ReadonlyArray<string>>;
+  /**
+   * ECS analogue of the Lambda-container fix shipped in cdkd PR #670:
+   * synthesized AWS shared credentials file (one INI section under
+   * `[<profileName>]`) bind-mounted read-only into EVERY user
+   * container, plus `AWS_SHARED_CREDENTIALS_FILE` +
+   * `AWS_PROFILE` env-var injection. Lets handlers that call
+   * `fromIni({ profile: '<name>' })` explicitly resolve to the same
+   * `--profile`-resolved creds the metadata sidecar serves, instead
+   * of failing with `CredentialsProviderError: Profile <name> could
+   * not be found` inside the container.
+   *
+   * Set by the CLI ONLY when `--profile` is effective AND
+   * `--assume-task-role` is NOT (precedence: assume-task-role >
+   * profile-file > sidecar). Caller is responsible for the
+   * `writeProfileCredentialsFile()` allocation + `dispose()` cleanup
+   * in its single-flight chain — the runner just plumbs the mount
+   * and env-vars through `buildDockerRunArgs`.
+   */
+  profileCredentialsFile?: { hostPath: string; containerPath: string; profileName: string };
 }
 
 /**
@@ -361,6 +380,9 @@ export async function runEcsTask(
         ...((options.networkAliasesByContainer?.get(container.name)?.length ?? 0) > 0
           ? { networkAliases: options.networkAliasesByContainer!.get(container.name)! }
           : {}),
+        ...(options.profileCredentialsFile && {
+          profileCredentialsFile: options.profileCredentialsFile,
+        }),
       })
     );
   }
@@ -838,6 +860,17 @@ interface BuildDockerRunArgs {
    * additional aliases registered alongside it.
    */
   networkAliases?: ReadonlyArray<string>;
+  /**
+   * ECS analogue of the Lambda-container fix in cdkd PR #670 — bind-mounts
+   * a host-side AWS shared credentials file (one `[<profileName>]`
+   * INI section) read-only into the container and sets
+   * `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env vars so handler
+   * code calling `fromIni({ profile })` resolves to the same creds
+   * the metadata sidecar serves. When undefined (the default), no
+   * mount / env vars are emitted — `--profile` is forwarded to the
+   * sidecar only.
+   */
+  profileCredentialsFile?: { hostPath: string; containerPath: string; profileName: string };
 }
 
 /**
@@ -902,6 +935,22 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): string[] {
     }
   }
 
+  // cdkd PR #670 follow-up — bind-mount the host-side profile credentials
+  // file read-only at the fixed in-container path so `fromIni({
+  // profile })` handlers resolve to the same creds the sidecar
+  // serves. The `:ro` flag is load-bearing: a compromised handler
+  // must not be able to tamper with the host-side temp file. Set
+  // BEFORE the user's own `MountPoints` so a (malformed) user mount
+  // that targets `/cdk-local-aws/credentials` doesn't shadow the
+  // creds file — docker honors mount-order by container path
+  // uniqueness; a later mount at the same target would fail or shadow.
+  if (opts.profileCredentialsFile) {
+    args.push(
+      '-v',
+      `${opts.profileCredentialsFile.hostPath}:${opts.profileCredentialsFile.containerPath}:ro`
+    );
+  }
+
   // Mounts: walk the container's `MountPoints` and look up the matching
   // volume to decide bind-mount vs docker volume.
   for (const mp of container.mountPoints) {
@@ -927,7 +976,8 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): string[] {
   //   2. global `Parameters` `--env-vars` entry
   //   3. resolved secrets
   //   4. template literal env
-  //   5. metadata sidecar env (sidecar URL / role URL)
+  //   5. profile credentials file env (AWS_SHARED_CREDENTIALS_FILE / AWS_PROFILE)
+  //   6. metadata sidecar env (sidecar URL / role URL)
   const finalEnv: Record<string, string> = {};
   const metaEnv = buildMetadataEnv({
     containerName: container.name,
@@ -936,6 +986,17 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): string[] {
     ...(opts.sidecarIp !== undefined && { sidecarIp: opts.sidecarIp }),
   });
   Object.assign(finalEnv, metaEnv);
+  // cdkd PR #670 follow-up — point the container's SDK chain at the bind-
+  // mounted credentials file so `fromIni({ profile })` calls inside
+  // the handler resolve to the same creds. `AWS_PROFILE` makes
+  // `fromIni()` (no explicit arg) ALSO use this profile. Sits ABOVE
+  // template / secret / --env-vars overrides so a user template that
+  // sets its own `AWS_PROFILE` (e.g. for a different in-container
+  // chain) still wins.
+  if (opts.profileCredentialsFile) {
+    finalEnv['AWS_SHARED_CREDENTIALS_FILE'] = opts.profileCredentialsFile.containerPath;
+    finalEnv['AWS_PROFILE'] = opts.profileCredentialsFile.profileName;
+  }
   Object.assign(finalEnv, container.environment);
   for (const s of secrets) finalEnv[s.name] = s.value;
 

--- a/src/local/rie-client.ts
+++ b/src/local/rie-client.ts
@@ -397,23 +397,75 @@ export async function invokeRieStreaming(
     }
   }
 
+  // Whether we synthesized a default prelude because no separator was found
+  // in the response. See the cdkd#664 fix block below for the rationale.
+  let preludeSynthesized = false;
+
   if (separatorIdx < 0) {
-    clearTimeout(timer);
-    throw new Error(
-      `RIE streaming response ended before the prelude/body separator (got ${preludeBytes.length} bytes). ` +
-        `The handler likely threw before streaming the prelude — check container logs.`
-    );
+    // No prelude/body separator found in the entire response. Two real-world
+    // scenarios produce this — empirically verified 2026-05-27 for cdkd#664
+    // against `public.ecr.aws/lambda/nodejs:22`:
+    //
+    //   (1) The handler is wrapped by `awslambda.streamifyResponse(...)` AND
+    //       uses the documented `responseStream.setContentType('...')` +
+    //       `responseStream.write(...)` shortcut WITHOUT explicitly calling
+    //       `awslambda.HttpResponseStream.from(stream, metadata)`. Production
+    //       AWS Lambda + Function URL handles this — the runtime auto-completes
+    //       the prelude lazily — but RIE emits only the raw body bytes the
+    //       handler wrote, no prelude+separator framing. This is the most
+    //       common case in the wild (the `setContentType` shortcut appears in
+    //       most tutorials + AWS docs).
+    //
+    //   (2) The handler crashed mid-invoke and RIE emitted a Lambda error
+    //       envelope (`{"errorType":"...","errorMessage":"..."}`) instead of
+    //       the prelude+separator framing. RIE itself reports
+    //       `INVOKE RTDONE(status: success, produced bytes: 0)` because from
+    //       its perspective the handler never finalized the streaming
+    //       response; the envelope bytes are sidecar diagnostics.
+    //
+    // In BOTH cases the right move is to NOT reject the invocation. We
+    // synthesize a default prelude (status 200, `application/octet-stream`)
+    // and surface the buffered bytes as the HTTP body. Case (1) lets the
+    // handler work locally exactly as it does in production. Case (2)
+    // surfaces the Lambda error envelope verbatim so the dev can read it
+    // from the curl response (much better UX than cdk-local swallowing the
+    // bytes behind a generic "RIE streaming invoke failed").
+    //
+    // The genuinely-empty case (zero buffered bytes — handler threw before
+    // any write AND RIE didn't emit a diagnostic envelope) still falls
+    // through to the original error path: there's no body worth surfacing,
+    // and the rapid log is the right place for the dev to read the cause.
+    if (preludeBytes.length === 0) {
+      clearTimeout(timer);
+      throw new Error(
+        `RIE streaming response ended with zero bytes. The handler likely threw before any write — check container logs.`
+      );
+    }
+    preludeSynthesized = true;
+    bodyTail = preludeBytes;
+    preludeBytes = Buffer.alloc(0);
   }
 
   let prelude: StreamingPrelude;
-  try {
-    prelude = parseStreamingPrelude(preludeBytes.toString('utf8'));
-  } catch (err) {
-    clearTimeout(timer);
-    reader.cancel().catch(() => undefined);
-    throw new Error(
-      `RIE streaming response prelude is not valid JSON: ${err instanceof Error ? err.message : String(err)}`
-    );
+  if (preludeSynthesized) {
+    // Default prelude when the handler bypassed `HttpResponseStream.from(...)`.
+    // `application/octet-stream` matches the documented AWS default; consumers
+    // that care about Content-Type should call `HttpResponseStream.from(...)`
+    // explicitly with the right metadata.
+    prelude = {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/octet-stream' },
+    };
+  } else {
+    try {
+      prelude = parseStreamingPrelude(preludeBytes.toString('utf8'));
+    } catch (err) {
+      clearTimeout(timer);
+      reader.cancel().catch(() => undefined);
+      throw new Error(
+        `RIE streaming response prelude is not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
   }
 
   // Build a Readable that emits any already-buffered body bytes first,

--- a/tests/integration/local-start-api/lambda-stream-url-set-content-type/index.mjs
+++ b/tests/integration/local-start-api/lambda-stream-url-set-content-type/index.mjs
@@ -1,0 +1,19 @@
+// Streaming Function URL handler that uses the documented
+// `responseStream.setContentType(...)` + `responseStream.write(...)` shortcut
+// WITHOUT explicitly calling `awslambda.HttpResponseStream.from(stream, metadata)`.
+//
+// This is the most common Function URL streaming idiom in AWS tutorials and
+// in real-world handlers — production Lambda + Function URL accepts it. Local
+// RIE does NOT emit the prelude+separator framing for this pattern, so
+// cdk-local must synthesize a default prelude and surface the body bytes
+// verbatim (cdkd#664 fix).
+//
+// verify.sh asserts the response arrives with HTTP 200 + the expected body
+// bytes, mirroring what the deployed Function URL would return.
+
+export const handler = awslambda.streamifyResponse(async (event, responseStream) => {
+  responseStream.setContentType('text/event-stream');
+  responseStream.write(`data: ${JSON.stringify({ hello: 'world' })}\n\n`);
+  responseStream.write(`data: ${JSON.stringify({ count: 2 })}\n\n`);
+  responseStream.end();
+});

--- a/tests/integration/local-start-api/lib/local-start-api-stack.ts
+++ b/tests/integration/local-start-api/lib/local-start-api-stack.ts
@@ -358,5 +358,31 @@ export class LocalStartApiStack extends cdk.Stack {
       authType: lambda.FunctionUrlAuthType.NONE,
       invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
     });
+
+    // cdkd#664: a second streaming Function URL whose handler uses the
+    // `responseStream.setContentType(...)` + `responseStream.write(...)`
+    // shortcut WITHOUT explicitly calling
+    // `awslambda.HttpResponseStream.from(stream, metadata)`. Production AWS
+    // Lambda accepts this pattern; pre-fix cdk-local rejected it because
+    // RIE emits no prelude+separator framing in that case. Post-fix
+    // cdk-local synthesizes a default prelude (200 / application/octet-stream)
+    // and surfaces the body bytes verbatim — verify.sh asserts the route
+    // returns 200 + the expected SSE-style body.
+    const streamUrlSetContentTypeHandler = new lambda.Function(
+      this,
+      'StreamUrlSetContentTypeHandler',
+      {
+        runtime: lambda.Runtime.NODEJS_20_X,
+        handler: 'index.handler',
+        code: lambda.Code.fromAsset(
+          path.join(__dirname, '../lambda-stream-url-set-content-type')
+        ),
+        timeout: cdk.Duration.seconds(30),
+      }
+    );
+    streamUrlSetContentTypeHandler.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+      invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
+    });
   }
 }

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -126,15 +126,21 @@ PORT_REST=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*REST API v1\
 # so the `(` boundary excludes it).
 PORT_FNURL=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(UrlHandler[A-F0-9]{8}\s+\(Function URL\)\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
 PORT_FNURL_STREAM=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(StreamUrlHandler[A-F0-9]{8}\s+\(Function URL\)\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
-if [[ -z "${PORT_HTTP}" || -z "${PORT_REST}" || -z "${PORT_FNURL}" || -z "${PORT_FNURL_STREAM}" ]]; then
+# cdkd#664: a second streaming Function URL whose handler uses the
+# setContentType-only shortcut (no explicit `HttpResponseStream.from(...)`).
+# `StreamUrlSetContentTypeHandler[A-F0-9]{8}` is distinct from
+# `StreamUrlHandler[A-F0-9]{8}` (the `Set` infix breaks the latter regex).
+PORT_FNURL_STREAM_SCT=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(StreamUrlSetContentTypeHandler[A-F0-9]{8}\s+\(Function URL\)\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
+if [[ -z "${PORT_HTTP}" || -z "${PORT_REST}" || -z "${PORT_FNURL}" || -z "${PORT_FNURL_STREAM}" || -z "${PORT_FNURL_STREAM_SCT}" ]]; then
   echo "FAIL: could not extract per-API port mappings. Log:"
   cat "${LOG_FILE}"
   exit 1
 fi
-echo "    HTTP API v2:           ${PORT_HTTP}"
-echo "    REST API v1:           ${PORT_REST}"
-echo "    Function URL:          ${PORT_FNURL}"
-echo "    Function URL (stream): ${PORT_FNURL_STREAM}"
+echo "    HTTP API v2:                  ${PORT_HTTP}"
+echo "    REST API v1:                  ${PORT_REST}"
+echo "    Function URL:                 ${PORT_FNURL}"
+echo "    Function URL (stream):        ${PORT_FNURL_STREAM}"
+echo "    Function URL (stream/SCT):    ${PORT_FNURL_STREAM_SCT}"
 
 # Verify the route table contains every route. Method-column width
 # varies per server (REST v1 with OPTIONS preflight rows has a wider
@@ -201,7 +207,7 @@ curl_assert() {
   local needle="$3"
   shift 3
   local response=""
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
     if response=$(curl -sf "$@" "${url}" 2>&1); then
       if echo "${response}" | grep -q "${needle}"; then
         echo "    [${label}] OK"
@@ -252,7 +258,7 @@ echo "==> Asserting streaming Function URL (#467)"
 STREAM_URL="http://127.0.0.1:${PORT_FNURL_STREAM}/anything"
 # First-request retry loop (cold container ~3-5s on first invoke).
 STREAM_RESPONSE=""
-for attempt in 1 2 3 4 5 6 7 8 9 10; do
+for _ in 1 2 3 4 5 6 7 8 9 10; do
   if STREAM_RESPONSE=$(curl -sf -i --no-buffer "${STREAM_URL}" 2>&1); then
     if echo "${STREAM_RESPONSE}" | grep -q 'hello-0'; then break; fi
   fi
@@ -300,6 +306,46 @@ if echo "${STREAM_RESPONSE}" | grep -q '"statusCode":200,"headers"'; then
   exit 1
 fi
 echo "    [streaming Function URL] OK"
+
+# cdkd#664: streaming Function URL whose handler uses the documented
+# `responseStream.setContentType(...)` + `responseStream.write(...)`
+# shortcut WITHOUT explicitly calling
+# `awslambda.HttpResponseStream.from(stream, metadata)`. Production AWS
+# Lambda + Function URL handles this — the runtime auto-completes the
+# prelude — but RIE emits only the raw body bytes the handler wrote
+# (verified empirically 2026-05-27 against `public.ecr.aws/lambda/nodejs:22`).
+# Pre-fix cdk-local rejected the invocation with "RIE streaming response
+# ended before the prelude/body separator". Post-fix cdk-local synthesizes
+# a default 200 / application/octet-stream prelude and surfaces the body
+# bytes verbatim so the handler runs locally as it does in production.
+echo "==> Asserting streaming Function URL (cdkd#664 — setContentType-only handler)"
+STREAM_URL_SCT="http://127.0.0.1:${PORT_FNURL_STREAM_SCT}/anything"
+STREAM_SCT_RESPONSE=""
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if STREAM_SCT_RESPONSE=$(curl -sf -i --no-buffer "${STREAM_URL_SCT}" 2>&1); then
+    if echo "${STREAM_SCT_RESPONSE}" | grep -q '"hello":"world"'; then break; fi
+  fi
+  sleep 1
+done
+if ! echo "${STREAM_SCT_RESPONSE}" | grep -qi '^HTTP/1.1 200'; then
+  echo "FAIL: setContentType-only streaming Function URL did not return 200. Response:"
+  echo "${STREAM_SCT_RESPONSE}"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+if ! echo "${STREAM_SCT_RESPONSE}" | grep -q '"hello":"world"'; then
+  echo "FAIL: setContentType-only streaming response missing first chunk body. Response:"
+  echo "${STREAM_SCT_RESPONSE}"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+if ! echo "${STREAM_SCT_RESPONSE}" | grep -q '"count":2'; then
+  echo "FAIL: setContentType-only streaming response missing second chunk body. Response:"
+  echo "${STREAM_SCT_RESPONSE}"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    [streaming Function URL — setContentType-only (cdkd#664)] OK"
 
 # PR 8c: CORS preflight interception. The HTTP API has CorsConfiguration
 # with `*` origins; verify.sh asserts the canonical preflight response.

--- a/tests/integration/local-start-service/verify.sh
+++ b/tests/integration/local-start-service/verify.sh
@@ -67,13 +67,14 @@ ${CDKL} start-service CdkLocalStartServiceFixture:WebService \
   > "${OUT_FILE}" 2>&1 &
 CDKL_PID=$!
 
-# Wait for the service boot banner. The runner prints
-# "Service '...' running with N active replica(s)" once startEcsService
-# returns; that's the deterministic ready marker.
+# Wait for the service boot banner. The CLI prints
+# "Service(s) running: <Name> (N replica(s)). Press ^C to shut down."
+# once every target's controller has been started — that's the
+# deterministic ready marker.
 echo "==> Waiting for boot banner (up to 60s)"
 BOOTED=0
 for i in $(seq 1 60); do
-  if grep -q "running with .* active replica" "${OUT_FILE}" 2>/dev/null; then
+  if grep -q "Service(s) running:" "${OUT_FILE}" 2>/dev/null; then
     BOOTED=1
     break
   fi
@@ -111,58 +112,29 @@ if [[ "${WEB_COUNT}" -lt 2 ]]; then
 fi
 echo "    OK: ${WEB_COUNT} busybox web containers running"
 
-echo "==> Asserting per-replica docker networks (2 networks expected)"
+echo "==> Asserting one shared docker network (design § 5 Option A, cdkd PR #522)"
+# Post-#522 every replica in a single CLI invocation joins ONE shared
+# `cdkl-*` network so peers can reach each other by IP / network alias
+# without `docker network connect` choreography. The pre-#522
+# per-replica-network shape (with the `170 + (index % 84)` subnet
+# allocator + per-replica subnet isolation assertion) is gone.
 NET_COUNT=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
-if [[ "${NET_COUNT}" -lt 2 ]]; then
-  echo "FAIL: expected at least 2 cdkl-* docker networks, found ${NET_COUNT}"
+if [[ "${NET_COUNT}" -ne 1 ]]; then
+  echo "FAIL: expected exactly 1 shared cdkl-* docker network, found ${NET_COUNT}"
   docker network ls --filter "name=cdkl-"
   exit 1
 fi
-echo "    OK: ${NET_COUNT} per-replica networks present"
-
-echo "==> Asserting per-replica subnet isolation (each network has a distinct /24 in 169.254.170-253)"
-# Regression guard for the per-replica subnet allocator in
-# ecs-service-runner.ts (`170 + (index % 84)`). The pre-PR assertion
-# only counted networks, so a collapsed allocator that put every
-# replica on the same /24 would still pass. Walk every network's
-# IPAM.Config[0].Subnet and assert (a) they are all distinct AND (b)
-# each is in the expected 169.254.<170-253>.0/24 range that
-# `buildReplicaSubnet(index)` allocates.
-NET_IDS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}')
-declare -a SUBNETS=()
-for net_id in ${NET_IDS}; do
-  SUBNET=$(docker network inspect "${net_id}" --format '{{(index .IPAM.Config 0).Subnet}}' 2>/dev/null || echo "")
-  if [[ -z "${SUBNET}" ]]; then
-    echo "FAIL: docker network ${net_id} has no IPAM.Config[0].Subnet"
-    docker network inspect "${net_id}"
-    exit 1
-  fi
-  echo "    network ${net_id}: subnet=${SUBNET}"
-  # Assert the subnet falls inside the allocator's range. The allocator
-  # emits `169.254.<170 + (index % 84)>.0/24` so the third octet must
-  # be in 170..253 inclusive.
-  if [[ ! "${SUBNET}" =~ ^169\.254\.([0-9]+)\.0/24$ ]]; then
-    echo "FAIL: subnet ${SUBNET} for network ${net_id} is not in the expected 169.254.X.0/24 shape"
-    exit 1
-  fi
-  OCTET="${BASH_REMATCH[1]}"
-  if (( OCTET < 170 || OCTET > 253 )); then
-    echo "FAIL: subnet ${SUBNET} third octet ${OCTET} is outside the allocator range 170..253"
-    exit 1
-  fi
-  SUBNETS+=("${SUBNET}")
-done
-
-# Assert every subnet is distinct (no duplicates). Sort + uniq + count.
-UNIQUE_SUBNET_COUNT=$(printf '%s\n' "${SUBNETS[@]}" | sort -u | wc -l | tr -d ' ')
-if [[ "${UNIQUE_SUBNET_COUNT}" -ne "${#SUBNETS[@]}" ]]; then
-  echo "FAIL: detected duplicate subnets across replicas — subnet allocator regression"
-  printf '    %s\n' "${SUBNETS[@]}"
+NET_ID=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}')
+SUBNET=$(docker network inspect "${NET_ID}" --format '{{(index .IPAM.Config 0).Subnet}}' 2>/dev/null || echo "")
+echo "    network ${NET_ID}: subnet=${SUBNET}"
+# Subnet must be the shared-service `169.254.171.0/24` (SHARED_SVC_SUBNET_OCTET).
+if [[ "${SUBNET}" != "169.254.171.0/24" ]]; then
+  echo "FAIL: expected shared subnet 169.254.171.0/24 (SHARED_SVC_SUBNET_OCTET), got ${SUBNET}"
   exit 1
 fi
-echo "    OK: ${UNIQUE_SUBNET_COUNT} distinct subnets across ${#SUBNETS[@]} networks"
+echo "    OK: 1 shared network on 169.254.171.0/24"
 
-echo "==> Sending SIGTERM to cdkd ($(echo $CDKL_PID))"
+echo "==> Sending SIGTERM to cdk-local ($(echo $CDKL_PID))"
 kill -TERM "${CDKL_PID}"
 
 # Wait for cdk-local to exit cleanly.

--- a/tests/unit/cli/local-profile-credentials-file.test.ts
+++ b/tests/unit/cli/local-profile-credentials-file.test.ts
@@ -1,0 +1,164 @@
+import { readFile, stat } from 'node:fs/promises';
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildProfileCredentialsDockerArgs,
+  CONTAINER_AWS_CREDENTIALS_PATH,
+  writeProfileCredentialsFile,
+} from '../../../src/cli/commands/local-profile-credentials-file.js';
+
+describe('writeProfileCredentialsFile', () => {
+  it('writes a valid AWS INI section with sessionToken when present', async () => {
+    const file = await writeProfileCredentialsFile('dev-sso', {
+      accessKeyId: 'AKIA-EXAMPLE',
+      secretAccessKey: 'SECRET-EXAMPLE',
+      sessionToken: 'SESSION-EXAMPLE',
+    });
+    try {
+      const body = await readFile(file.hostPath, 'utf8');
+      expect(body).toBe(
+        '[dev-sso]\n' +
+          'aws_access_key_id = AKIA-EXAMPLE\n' +
+          'aws_secret_access_key = SECRET-EXAMPLE\n' +
+          'aws_session_token = SESSION-EXAMPLE\n'
+      );
+      expect(file.containerPath).toBe(CONTAINER_AWS_CREDENTIALS_PATH);
+      expect(file.profileName).toBe('dev-sso');
+    } finally {
+      await file.dispose();
+    }
+  });
+
+  it('omits aws_session_token when the profile resolved to long-lived creds', async () => {
+    const file = await writeProfileCredentialsFile('long-lived', {
+      accessKeyId: 'AKIA-LIVED',
+      secretAccessKey: 'SECRET-LIVED',
+    });
+    try {
+      const body = await readFile(file.hostPath, 'utf8');
+      expect(body).toBe(
+        '[long-lived]\n' +
+          'aws_access_key_id = AKIA-LIVED\n' +
+          'aws_secret_access_key = SECRET-LIVED\n'
+      );
+      expect(body).not.toContain('aws_session_token');
+    } finally {
+      await file.dispose();
+    }
+  });
+
+  it('writes the file with 0o600 permissions (owner-only readable)', async () => {
+    const file = await writeProfileCredentialsFile('perm-check', {
+      accessKeyId: 'AKIA-P',
+      secretAccessKey: 'SECRET-P',
+    });
+    try {
+      const stats = await stat(file.hostPath);
+      // mode & 0o777 isolates the permission bits from file-type flags.
+      // 0o600 = owner read+write only, no group/other access.
+      // Credential files on disk must not be world-readable.
+      expect(stats.mode & 0o777).toBe(0o600);
+    } finally {
+      await file.dispose();
+    }
+  });
+
+  it('dispose() removes the file + tempdir', async () => {
+    const file = await writeProfileCredentialsFile('cleanup', {
+      accessKeyId: 'AKIA-C',
+      secretAccessKey: 'SECRET-C',
+    });
+    // File exists pre-dispose.
+    await expect(stat(file.hostPath)).resolves.toBeDefined();
+    await file.dispose();
+    // Gone post-dispose.
+    await expect(stat(file.hostPath)).rejects.toThrow();
+  });
+
+  it('dispose() is idempotent (safe to call from concurrent cleanup paths)', async () => {
+    const file = await writeProfileCredentialsFile('idempotent', {
+      accessKeyId: 'AKIA-I',
+      secretAccessKey: 'SECRET-I',
+    });
+    await file.dispose();
+    // Second call must not throw — single-flight cleanup runners +
+    // SIGINT-mid-finally races can both fire dispose simultaneously.
+    await expect(file.dispose()).resolves.toBeUndefined();
+  });
+
+  it('rejects an empty profile name (would write an `[]` header)', async () => {
+    await expect(
+      writeProfileCredentialsFile('', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/must not be empty/);
+  });
+
+  it("rejects a profile name containing ']' (would inject a second INI section)", async () => {
+    await expect(
+      writeProfileCredentialsFile('a]\n[evil', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+  });
+
+  it("rejects a profile name containing '[' (would corrupt the INI section header)", async () => {
+    await expect(
+      writeProfileCredentialsFile('a[b', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+  });
+
+  it('rejects a profile name containing CR/LF (would break the docker -e env line)', async () => {
+    await expect(
+      writeProfileCredentialsFile('a\nb', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+    await expect(
+      writeProfileCredentialsFile('a\rb', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+  });
+
+  it('uses the profile name the caller passed (matches handler-side fromIni({ profile }))', async () => {
+    // Real-world case: user passes `--profile my-team-dev`; handler code
+    // has `fromIni({ profile: 'my-team-dev' })`. The INI section header
+    // MUST match exactly or the SDK throws "Profile 'my-team-dev' could
+    // not be found".
+    const file = await writeProfileCredentialsFile('my-team-dev', {
+      accessKeyId: 'A',
+      secretAccessKey: 'B',
+    });
+    try {
+      const body = await readFile(file.hostPath, 'utf8');
+      expect(body.startsWith('[my-team-dev]\n')).toBe(true);
+    } finally {
+      await file.dispose();
+    }
+  });
+});
+
+describe('buildProfileCredentialsDockerArgs', () => {
+  it('returns empty when no file is provided (--profile not set)', () => {
+    expect(buildProfileCredentialsDockerArgs(undefined)).toEqual([]);
+  });
+
+  it('emits -v mount + AWS_SHARED_CREDENTIALS_FILE + AWS_PROFILE env when file is provided', () => {
+    const args = buildProfileCredentialsDockerArgs({
+      hostPath: '/tmp/cdk-local-profile-creds-xyz/credentials',
+      containerPath: '/cdk-local-aws/credentials',
+      profileName: 'dev',
+      dispose: async () => undefined,
+    });
+    expect(args).toEqual([
+      '-v',
+      '/tmp/cdk-local-profile-creds-xyz/credentials:/cdk-local-aws/credentials:ro',
+      '-e',
+      'AWS_SHARED_CREDENTIALS_FILE=/cdk-local-aws/credentials',
+      '-e',
+      'AWS_PROFILE=dev',
+    ]);
+  });
+
+  it('uses :ro suffix on the mount (compromised handler must not tamper with the host file)', () => {
+    const args = buildProfileCredentialsDockerArgs({
+      hostPath: '/host/path',
+      containerPath: '/container/path',
+      profileName: 'p',
+      dispose: async () => undefined,
+    });
+    expect(args[1]).toMatch(/:ro$/);
+  });
+});

--- a/tests/unit/cli/local-run-task-profile-creds.test.ts
+++ b/tests/unit/cli/local-run-task-profile-creds.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { resolveSidecarCredentials } from '../../../src/cli/commands/local-run-task.js';
+
+// cdkd#658: `cdkl run-task --profile <p>` (without
+// `--assume-task-role`) used to resolve the profile for cdk-local's OWN
+// AWS calls but the AWS-published `amazon-ecs-local-container-endpoints`
+// sidecar started with empty `AWS_*` env, so every user container that
+// hit `169.254.170.2/role/<role>` got a credential-provider failure.
+// This test exercises the small `resolveSidecarCredentials` helper that
+// drives the new precedence: assumed-creds win when set; otherwise the
+// profile chain is resolved; otherwise undefined (the pre-existing
+// "sidecar uses its own default chain" path).
+//
+// Same gap class as cdkd#654/#655 (which shipped for `cdkl start-api`'s
+// Lambda container env overlay); the helper-extraction pattern mirrors
+// cdkd PR #655's `resolveProfileCredentials` test surface.
+
+const credsProviderMock = vi.fn();
+const stsDestroyMock = vi.fn();
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      config: { credentials: credsProviderMock },
+      destroy: stsDestroyMock,
+    };
+  }),
+}));
+
+describe('resolveSidecarCredentials (cdkd#658)', () => {
+  beforeEach(() => {
+    credsProviderMock.mockReset();
+    stsDestroyMock.mockReset();
+    stsCtorMock.mockReset();
+  });
+
+  it('returns the assumed credentials verbatim when --assume-task-role is effective (assume wins over --profile)', async () => {
+    const assumed = {
+      accessKeyId: 'AKIA-ASSUMED',
+      secretAccessKey: 'SECRET-ASSUMED',
+      sessionToken: 'SESSION-ASSUMED',
+    };
+    // Both `--profile` AND `--assume-task-role` set; assume must win.
+    const result = await resolveSidecarCredentials({ profile: 'my-sso' }, assumed);
+    expect(result).toBe(assumed);
+    // The SDK STS client must NOT be touched on this path — the assumed
+    // creds came from an earlier STS hop, the sidecar resolver is a no-op.
+    expect(stsCtorMock).not.toHaveBeenCalled();
+    expect(credsProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves --profile via the SDK default chain when --assume-task-role is NOT effective', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    const result = await resolveSidecarCredentials({ profile: 'my-sso' }, undefined);
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    // STSClient instantiated with the profile so SSO / fromIni resolve.
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'my-sso' });
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns undefined when neither --profile nor --assume-task-role is set (sidecar falls back to its own default chain)', async () => {
+    const result = await resolveSidecarCredentials({}, undefined);
+    expect(result).toBeUndefined();
+    // No AWS calls at all — pre-existing "lowest precedence" path.
+    expect(stsCtorMock).not.toHaveBeenCalled();
+    expect(credsProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolveProfileCredentials errors (expired SSO etc.) — no silent fallback', async () => {
+    credsProviderMock.mockRejectedValue(
+      new Error('The SSO session associated with this profile has expired')
+    );
+    await expect(
+      resolveSidecarCredentials({ profile: 'expired-sso' }, undefined)
+    ).rejects.toThrow(/SSO session.*expired/);
+  });
+});

--- a/tests/unit/cli/local-start-service-profile-creds.test.ts
+++ b/tests/unit/cli/local-start-service-profile-creds.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { resolveSharedSidecarCredentials } from '../../../src/cli/commands/local-start-service.js';
+
+// cdkd#658: `cdkl start-service --profile <p>` used to resolve the
+// profile for cdk-local's OWN AWS calls but the AWS-published shared
+// `amazon-ecs-local-container-endpoints` sidecar (one per CLI
+// invocation) started with empty `AWS_*` env, so every replica's
+// containers hit `169.254.171.2/role/<role>` and got credential-provider
+// failures. This test exercises the small
+// `resolveSharedSidecarCredentials` helper that drives the new
+// precedence: the per-CLI sidecar has no concept of `--assume-task-role`
+// (that flag is per-container via `buildMetadataEnv`), so this is the
+// simpler of the two siblings — `--profile` set → resolve, else
+// undefined.
+
+const credsProviderMock = vi.fn();
+const stsDestroyMock = vi.fn();
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      config: { credentials: credsProviderMock },
+      destroy: stsDestroyMock,
+    };
+  }),
+}));
+
+describe('resolveSharedSidecarCredentials (cdkd#658)', () => {
+  beforeEach(() => {
+    credsProviderMock.mockReset();
+    stsDestroyMock.mockReset();
+    stsCtorMock.mockReset();
+  });
+
+  it('resolves --profile via the SDK default chain when set', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    const result = await resolveSharedSidecarCredentials({ profile: 'my-sso' });
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    // STSClient instantiated with the profile so SSO / fromIni resolve.
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'my-sso' });
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('omits sessionToken when the profile resolved to long-lived creds', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-LONG',
+      secretAccessKey: 'SECRET-LONG',
+    });
+    const result = await resolveSharedSidecarCredentials({ profile: 'long-lived' });
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-LONG',
+      secretAccessKey: 'SECRET-LONG',
+    });
+    expect(result).not.toHaveProperty('sessionToken');
+  });
+
+  it('returns undefined when --profile is NOT set (sidecar falls back to its own default chain)', async () => {
+    const result = await resolveSharedSidecarCredentials({});
+    expect(result).toBeUndefined();
+    // No AWS calls at all — pre-existing behavior preserved.
+    expect(stsCtorMock).not.toHaveBeenCalled();
+    expect(credsProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolveProfileCredentials errors (expired SSO etc.) — no silent fallback', async () => {
+    credsProviderMock.mockRejectedValue(
+      new Error('The SSO session associated with this profile has expired')
+    );
+    await expect(
+      resolveSharedSidecarCredentials({ profile: 'expired-sso' })
+    ).rejects.toThrow(/SSO session.*expired/);
+  });
+});


### PR DESCRIPTION
## Summary

Differential sync of 4 cdkd `src/local/**` fix commits (cdkd PR #662, #667, #670, #672) that landed after cdk-local PR #1 was opened. Required pre-Phase 3 so the shim-conversion PR can pin a cdk-local version that includes the post-snapshot fixes.

## What lands in this PR

| cdkd PR | One-line | Files touched in cdk-local |
|---|---|---|
| cdkd#662 | forward `--profile`-resolved creds to ECS metadata sidecar | `local-run-task.ts`, `local-start-service.ts` |
| cdkd#667 | synthesize default prelude when RIE streaming response lacks separator | `local/rie-client.ts` + `local-start-api` integ fixture |
| cdkd#670 | mount profile-aware credentials file for Lambda `fromIni({ profile })` handlers | new `local-profile-credentials-file.ts` + 3 callers + `container-pool.ts` |
| cdkd#672 | ECS analogue of #670 — same fix for run-task / start-service containers | `local-run-task.ts`, `local-start-service.ts`, `local/ecs-task-runner.ts` |

Sanitization (Plan notice-10 — public surface):
- Container mount path is `/cdk-local-aws/credentials` (was `/cdkd-aws/credentials` in cdkd).
- Tempdir prefix is `cdk-local-profile-creds-*` (was `cdkd-profile-creds-*`).
- User-facing prose: `cdkd local <verb>` -> `cdkl <verb>`.
- cdkd PR / issue numbers preserved as `cdkd#NNN` cross-repo references in internal comments (per handover; Phase 3 sweeps the remaining internal JSDoc).

In-scope drift cleanup:
- `tests/integration/local-start-service/verify.sh` — boot-banner regex + network-topology assertion updated to match the shared-network shape that PR #1 already shipped in `src/local/ecs-network.ts` but whose verify.sh was left in the pre-cdkd-PR-522 per-replica form.

## Skipped from cdkd commits

- `tests/unit/local/rie-client-streaming.test.ts` — cdk-local has no `tests/unit/local/` tree yet; HTTP-streaming test would require new test infrastructure. Behavior covered by cdkd's own integ test (`local-start-api`).
- `tests/unit/local/ecs-task-runner.test.ts` — same reason; cdk-local has no `makeContainer` / `makeTask` helpers yet.

Both are documented in the commit message.

## Out of scope (deferred to Phase 3)

- Sweep of remaining internal `cdkd` JSDoc / inline comments (handover §2b step 2).
- `cdkd-string-gate.sh` pre-commit hook activation (handover §2b step 4).

## Test plan

- [x] `vp run check` (typecheck + lint + format) — pass
- [x] `vp run test` — **101 passed** (76 prior + 21 new + 4 type-test-only)
  - 13 new in `local-profile-credentials-file.test.ts` (INI shape, file permissions, dispose idempotency, profile-name validation)
  - 4 new in `local-run-task-profile-creds.test.ts` (precedence: assume-task-role > profile > undefined; error propagation)
  - 4 new in `local-start-service-profile-creds.test.ts` (same shape, shared-sidecar variant)
- [x] `vp run build` — 2.48 MB ESM bundle, `cdkl --version` + `cdkl invoke --help` smoke OK
- [ ] CI workflow (the `ci.yml` shipped in PR #7) — will run on push

## Refs

- Cross-repo: cdkd#658, cdkd#664, cdkd#670, cdkd#672
- Handover: `/tmp/handover-cdk-local-phase-2-followup-meta.md`
