### PR TITLE
fix(synthesis): populate StackInfo.assetManifestPath from the cloud assembly

### DIFF
--- a/src/synthesis/assembly-reader.ts
+++ b/src/synthesis/assembly-reader.ts
@@ -1,4 +1,7 @@
-import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
+import {
+  AssetManifestArtifact,
+  type CloudFormationStackArtifact,
+} from '@aws-cdk/cloud-assembly-api';
 import { Toolkit, CdkAppMultiContext } from '@aws-cdk/toolkit-lib';
 import type { CloudFormationTemplate } from '../types/resource.js';
 
@@ -172,6 +175,20 @@ function mapStackArtifact(stack: CloudFormationStackArtifact): StackInfo {
   }
   if (stack.terminationProtection !== undefined) {
     info.terminationProtection = stack.terminationProtection;
+  }
+  // Locate the AssetManifestArtifact among the stack's dependencies and
+  // surface its absolute path. Downstream resolvers (`lambda-resolver.ts`,
+  // `ecs-task-resolver.ts`, etc.) read `dirname(assetManifestPath)` to find
+  // the cdk.out directory where every `asset.<hash>` subdirectory lives —
+  // without this, the fallback `process.cwd()` resolves asset directories
+  // against the user's CWD instead of cdk.out, so `cdkl invoke`'s
+  // asset-directory existence check fires a `LocalInvokeResolutionError`
+  // for every Lambda whose code was synthesized as a separate asset.
+  const assetManifest = stack.dependencies.find(
+    (d): d is AssetManifestArtifact => d instanceof AssetManifestArtifact
+  );
+  if (assetManifest) {
+    info.assetManifestPath = assetManifest.file;
   }
   return info;
 }


### PR DESCRIPTION
## Summary

Discovered while running `tests/integration/local-invoke/verify.sh` for the first time end-to-end on cdk-local. Every `cdkl invoke` against an asset-backed Lambda (i.e. anything not using `Code.ZipFile` inline) failed with:

```
LocalInvokeResolutionError: Lambda 'EchoHandlerB75BC5D4' asset directory
'/Users/goto/pc/github/cdk-local/tests/integration/local-invoke/asset.<hash>'
does not exist or is not a directory. Re-synthesize the app and retry.
```

The error path lives in `src/local/lambda-resolver.ts:715` — `stack.assetManifestPath` was `undefined`, the fallback used `process.cwd()`, and `<cwd>/asset.<hash>` did not exist (the real path is `<cwd>/cdk.out/asset.<hash>`).

## Root cause

Phase 2d-1 ("assembly-reader real impl, toolkit-lib + cloud-assembly-api backed") declared `assetManifestPath?` on the `StackInfo` interface but `mapStackArtifact` in `src/synthesis/assembly-reader.ts` never populated it. The equivalent population logic from cdkd's self-implemented synthesizer (`src/synthesis/assembly-reader.ts:237-246` walking artifact dependencies for the assets manifest) was not ported to the toolkit-lib-backed reader.

## Fix

Walk `stack.dependencies` looking for the `AssetManifestArtifact` instance and read its `.file` field (absolute path to the `<stack>.assets.json` produced alongside the stack template). One additional import + one `find` + one assignment.

## Test plan

- [x] `vp run check`, `vp run test` (101 passing), `vp run build` — all pass
- [x] `tests/integration/local-invoke/verify.sh` — **4/4 passing** end-to-end:
  - EchoHandler with default empty event
  - EchoHandler with --event payload
  - EchoHandler with --env-vars override
  - InlineHandler (Code.ZipFile inline — pre-fix path that worked all along)
- [ ] CI workflow on push

This is the **first real end-to-end run** of `cdkl invoke` against Docker + RIE on cdk-local. Pre-fix every asset-backed Lambda failed; post-fix the docker container boots, the RIE-served event reaches the handler, and the handler's response surfaces correctly.

## No unit test

`cdk.out` is gitignored so a unit fixture would either:
- ship a checked-in `cdk.out` that drifts as the test app's CDK code evolves, or
- duplicate the toolkit-lib synth pipeline inside the unit test.

The integration test IS the regression check, and the fix is one `instanceof` check — pre/post integ run is the canonical proof.

## Refs

Discovered during the post-PR-8 audit ("does the built `cdkl` actually work end-to-end") triggered by handover `/tmp/handover-cdk-local-phase-2-followup-meta.md`. This bug was latent through every prior cdk-local PR because no one had run an integ end-to-end yet.
