### PR TITLE
fix(integ): add missing lambda-non-proxy handler for local-start-api-rest-v1-non-proxy

### DIFF
--- a/tests/integration/local-start-api-rest-v1-non-proxy/.gitignore
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/.gitignore
@@ -1,0 +1,3 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is tracked.
+!lambda-non-proxy/*.js

--- a/tests/integration/local-start-api-rest-v1-non-proxy/lambda-non-proxy/index.js
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/lambda-non-proxy/index.js
@@ -1,0 +1,4 @@
+exports.handler = async (event) => {
+  const name = event && typeof event.name === 'string' && event.name.length > 0 ? event.name : 'world';
+  return { greeting: `Hello, ${name}` };
+};


### PR DESCRIPTION
## Summary

- Add `tests/integration/local-start-api-rest-v1-non-proxy/lambda-non-proxy/index.js` (a minimal CommonJS handler returning `{ greeting: "Hello, <name>" }`).
- Add a per-fixture `.gitignore` with `!lambda-non-proxy/*.js` so the handler is tracked, matching the convention used by every other Node-handler fixture in this repo (`local-invoke/.gitignore`, `local-start-api/.gitignore`, etc.).

## Why

The fixture stack at `tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts:47` references `lambda.Code.fromAsset(path.join(__dirname, '../lambda-non-proxy'))`, but the `lambda-non-proxy/` directory was never tracked in git. As a result, `cdkl synth` errored with `CannotFindAsset: Cannot find asset at .../lambda-non-proxy` and the integ test has been broken since the fixture was first imported from cdkd into cdk-local in PR #1.

The root cause is the parent `tests/integration/.gitignore` ignoring all `*.js` files (treating them as build artifacts), with each Node-handler fixture overriding via its own `.gitignore`. This fixture was missing its override file AND its `index.js` source.

The handler contract is fixed by the REST v1 non-AWS_PROXY integration shape in the stack: the request template synthesizes `{action, name}`, and the response template wraps `$input.json("$.greeting")` into `{"data": <value>}`. The minimal handler returns `{ greeting: "Hello, <name>" }`, which the response template shapes into `{"data": "Hello, Alice"}` — exactly what `verify.sh` asserts.

## Test plan

- [x] `bash tests/integration/local-start-api-rest-v1-non-proxy/verify.sh` passes locally — all 4 routes (MOCK 200 / MOCK 404 / HTTP_PROXY tolerant / POST /aws-lambda) return the expected status and body.
- [x] No other fixture is affected (the change is scoped to the broken fixture's directory).
- [ ] CI green.

## Notes

The same fixture exists in cdkd with the same missing handler — a parallel fix in cdkd is appropriate as a follow-up (cdkd PR #505 originally introduced the fixture without the handler).
