### PR TITLE
chore(claude): seed .claude/agents + key skills (check / check-docs / cleanup / run-integ)

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -1,0 +1,39 @@
+---
+name: pr-code-reviewer
+description: Review a PR for bugs, edge cases, security issues, dead code, and resource leaks. Read-only — never writes or edits. Reports issues with file:line citations and severity.
+tools: Read, Glob, Grep, Bash
+---
+
+# PR Code Quality Reviewer
+
+You find bugs the implementing agent might have missed. The caller provides a PR number.
+
+## Inputs you read
+
+1. **PR diff** — `gh pr diff <N>` (full diff).
+2. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
+3. **Project conventions** — `.claude/CLAUDE.md` at the repo root for ESM `.js` imports, library + CLI dual entry, English-only committed artifacts, etc.
+
+## Review focus
+
+Read every changed file end-to-end. For each, ask:
+
+1. **Bugs**: logic error, off-by-one, race, resource leak (unclosed handle, unawaited child process, dangling timer, leftover docker container/network), unhandled promise rejection, type-cast hiding a real mismatch.
+2. **Edge cases not handled**: input is `undefined` / `''` / `[]` / very long / contains weird chars; failure path of every external call (`execFile`, `fetch`, `fs`, AWS SDK, docker CLI).
+3. **Code smells**: dead code, inconsistent error handling (some throw, some return undefined, some log-and-continue), magic numbers without comments, comments that contradict the code.
+4. **Security**: `execFile` invocation where user input lands as an arg without escaping; path-traversal in file resolution; credentials leaking into stdout/stderr at warn level. Pay extra attention to anything under `src/local/docker-runner.ts`, `src/local/docker-image-builder.ts`, `src/local/ecr-puller.ts`, `src/local/cognito-jwt.ts`, `src/local/lambda-authorizer.ts`, `src/local/sigv4-verify.ts`.
+5. **Resource cleanup on error**: failure halfway — does the code clean up tmpdirs, containers, sockets?
+
+## What NOT to check
+
+- Whether tests pass (CI handles that).
+- Whether decisions match the design doc (separate spec-compliance reviewer).
+- Documentation prose.
+
+## Report format
+
+Return ONE of:
+- **Clean**: no issues worth flagging.
+- **Issues**: list each issue with file:line, what's wrong, suggested fix, severity (blocker = ships a bug / minor = should fix in same PR / nit = could fix later).
+
+Keep the report under 500 words. Be direct — no "consider" / "might want to" hedging.

--- a/.claude/agents/pr-spec-reviewer.md
+++ b/.claude/agents/pr-spec-reviewer.md
@@ -1,0 +1,34 @@
+---
+name: pr-spec-reviewer
+description: Review a PR's implementation against a design doc the caller provides. Returns file:line citations for each decision verified, or a list of spec drifts with severity. Read-only — never writes or edits.
+tools: Read, Glob, Grep, Bash
+---
+
+# PR Spec Compliance Reviewer
+
+You verify whether a PR's implementation matches a design doc. The caller provides:
+- A path to the design doc (e.g. `/tmp/.../design-X.md`)
+- A PR number (e.g. `12`)
+
+## Inputs you read
+
+1. **Design doc** — the source of truth for what the impl should look like. Find the locked decisions table (typically D-prefixed: D5.1, D5.2, ...) and the critical-bug section (typically C-prefixed). Both are mandatory matches.
+2. **PR diff** — `gh pr diff <N>` for the full diff, `gh pr view <N> --json files -q '.files[].path'` for the file list.
+3. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch — leave the parent worktree on main. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
+
+## Review focus (the ENTIRE scope)
+
+For each D-decision and C-fix in the design doc, verify the implementation matches with a file:line citation. Nothing else. Do NOT comment on:
+
+- Code quality / style / lint (separate reviewer)
+- Test passing / coverage (separate reviewer)
+- Documentation prose
+- Type correctness
+
+## Report format
+
+Return ONE of:
+- **Clean**: every decision and critical fix verified; cite file:line for each in a table.
+- **Issues**: list each spec drift with file:line, expected behavior per design doc, actual behavior, severity (blocker / minor / nit).
+
+Keep the report under 400 words. Be specific.

--- a/.claude/agents/pr-test-reviewer.md
+++ b/.claude/agents/pr-test-reviewer.md
@@ -1,0 +1,40 @@
+---
+name: pr-test-reviewer
+description: Review test adequacy for a PR — find coverage gaps, mock anti-patterns, fixture realism issues. Read-only — never writes or edits.
+tools: Read, Glob, Grep, Bash
+---
+
+# PR Test Adequacy Reviewer
+
+You verify the test suite actually covers the new behavior. The caller provides a PR number.
+
+## Inputs you read
+
+1. **PR test files** — `gh pr view <N> --json files -q '.files[].path' | grep -E "^tests/"`.
+2. **Test contents** — `git fetch origin <branch>` then `git show origin/<branch>:tests/<path>`. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
+3. **Implementation files** to identify untested branches.
+
+## Review focus
+
+For each meaningful new behavior in the implementation, find a corresponding test or flag the gap. Specifically watch for:
+
+- **Branches with no test**: every `if` / `switch` arm in new code; failure paths of external calls.
+- **Mocks that pass for the wrong reason**: e.g. `vi.mock(...)` returning `{}` so the production code returns `undefined` and "passes"; mocks that handle a single call when production code makes multiple; `expect(x).toBe(true)` against an unconditional return.
+- **Fixture data that doesn't match real-world output**: e.g. a CDK `Code.ImageUri` as a flat string when CDK actually emits `{Fn::Sub: ...}`; a docker `inspect` mock that returns the JSON shape from one docker version when the production code reads a field that only newer versions emit.
+- **Tests that call the function but never assert behavior**: `await fn()` followed by no `expect`.
+- **Mock calling-convention mismatches**: e.g. `child_process.execFile` 3-arg vs 4-arg forms; `vi.mock` factory hoisting (top-level class references must be wrapped in `vi.hoisted()`).
+
+## What NOT to check
+
+- Whether tests pass (CI does this).
+- Coverage percentages — misleading.
+- Style of the test code.
+
+## Report format
+
+Return ONE of:
+- **Clean**: each behavior has a corresponding test, fixtures look realistic.
+- **Gaps**: list each behavior that lacks a test (file:line of production code, what's untested, severity).
+- **Anti-patterns**: list each "passes for wrong reasons" test (test file:line, why it passes, what it should verify).
+
+Keep the report under 500 words.

--- a/.claude/skills/check-docs/SKILL.md
+++ b/.claude/skills/check-docs/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: check-docs
+description: Check if documentation (README.md, .claude/CLAUDE.md) is up to date with recent code changes. Use when code has been modified and docs may be stale.
+---
+
+# Documentation Consistency Check
+
+Check whether documentation is up to date with recent code changes.
+
+## Steps
+
+1. **Identify what changed**: Run `git diff main...HEAD --name-only` (or `git diff HEAD~5 --name-only` if on main) to see recently changed source files.
+
+2. **Decide whether a deep review is needed (short-circuit)**. The `docs` gate's scope includes `src/**`, so any src edit invalidates the marker — but most internal refactors and bug fixes don't affect anything the docs describe. Skip the LLM-judged review and set the marker directly when the diff **only** touches files that the docs don't describe. A deep review is required if the diff touches ANY of:
+   - `src/index.ts` — public library exports
+   - `src/cli/index.ts`, `src/cli/commands/**` — CLI surface described in README.md
+   - `src/types/**` — public type definitions
+   - **any new file added** anywhere under `src/**` — must be mentioned in `.claude/CLAUDE.md` "Architecture" section
+   - `package.json` — dependency additions/removals
+   - `README.md`, `.claude/CLAUDE.md`, `.claude/rules/**`, `docs/**` (when it exists) — the docs themselves
+   - README-visible CLI behavior changes (new flags, changed defaults, new commands)
+
+   If none of the above apply (only internal src files modified, no new files, no deps changed), write a one-line note — "no docs-visible surface touched" — set the `docs` marker (see "Commit-gate marker" below), and stop. Do NOT re-read docs for unrelated internal edits.
+
+3. **For each changed source file** (when a deep review is warranted), determine what documentation might be affected:
+   - `src/cli/` changes → check CLI options/commands in README.md, `.claude/CLAUDE.md`
+   - `src/synthesis/` changes → check `.claude/CLAUDE.md` Architecture section
+   - `src/local/` changes → check README.md usage examples + scope statement, `.claude/CLAUDE.md` "Runs locally" list
+   - `src/assets/` changes → check `.claude/CLAUDE.md` Architecture section
+   - New files added → check if they're mentioned in `.claude/CLAUDE.md` "Architecture"
+   - New exports in `src/index.ts` → check if README usage matches
+   - `package.json` dependency changes → mention in `.claude/CLAUDE.md` if user-facing
+   - New CLI options → check README.md usage section
+
+4. **Read the relevant documentation sections** and compare with the actual code to find:
+   - Missing mentions of new files, features, or options
+   - Outdated descriptions that no longer match the code
+   - Stale lists that don't match what's in the source
+   - Comparison-table additions that violate the `.claude/CLAUDE.md` "Positioning" rule (no comparisons vs `aws-cdk-local`/`cdklocal`/LocalStack beyond the "compute vs managed services" lead).
+
+5. **Report findings** as a checklist:
+   - List each discrepancy found with the specific file and section
+   - For each issue, suggest the fix
+   - If no issues found, confirm documentation is consistent
+
+6. **Fix the issues** if the user agrees, or ask for confirmation first.
+
+## Commit-gate marker (on success only)
+
+After documentation is verified consistent (either no issues were found, or all issues were fixed), record the `docs` markgate marker:
+
+```bash
+mise exec -- markgate set docs
+```
+
+Skip this step if issues remain unfixed.
+
+## Important
+
+- Do NOT add documentation that doesn't exist yet (don't create new doc files unless explicitly asked)
+- Focus on consistency between existing docs and code, not completeness
+- English-only for all committed artifacts (see `.claude/CLAUDE.md` "Workflow rules")
+- Do NOT reference cdkd internal implementation in cdk-local docs (the dependency direction is `cdkd -> cdk-local`)

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: check
+description: Run local quality checks (typecheck, lint, format, build, tests). Quick check during development.
+---
+
+# Local Quality Check
+
+Run all local quality checks. Use during development to verify the current state quickly.
+
+## Steps
+
+Run these sequentially and report results:
+
+1. `vp run check` — typecheck + lint + format check (the unified task wired in `vite.config.ts`).
+2. `vp run build` — produces `dist/cli.js` and `dist/index.js`.
+3. `vp run test` — vitest unit tests.
+
+`vp run verify` is the convenience alias that runs all three; either path is fine.
+
+## Output
+
+Report as a table:
+
+| Check | Result |
+|-------|--------|
+| typecheck + lint + format (`vp run check`) | pass/fail |
+| build | pass/fail |
+| tests (N files, M tests) | pass/fail |
+
+If all pass, confirm "All checks passed."
+If any fail, show the error output and STOP — do not write the commit-gate marker.
+
+## Commit-gate marker (on success only)
+
+After all three checks pass, record a marker so the `check` gate is fresh. The marker is managed by [markgate](https://github.com/go-to-k/markgate) and captures the current working tree state; any subsequent edits invalidate it and require re-running `/check`.
+
+Run this from the repo root (cdk-local pins markgate via mise, so use `mise exec` to avoid PATH issues when shims aren't active):
+
+```bash
+mise exec -- markgate set check
+```
+
+Skip this step if any check failed — a stale or missing marker correctly forces re-running `/check` after fixing the failure.

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: cleanup
+description: Detect and delete leftover Docker containers / networks left by interrupted cdk-local integ runs.
+argument-hint: "[--detect-only]"
+---
+
+# Leftover Docker Resource Cleanup
+
+Detect and optionally delete Docker resources left behind when a `cdkl` run is interrupted (SIGKILL, crash, etc.) before its own cleanup hook fires.
+
+## Safety
+
+- ONLY targets Docker containers / networks whose names match the cdk-local prefix conventions (`cdkl-*`, `cdk-local-*`).
+- NEVER touches non-matching containers — random unrelated containers on the host are out of scope.
+- Default mode is detect-only (no deletion).
+- Uses `AskUserQuestion` to confirm before any actual `docker rm -f` / `docker network rm`.
+
+## Arguments
+
+- `--detect-only`: Only list leftover resources, don't delete (this is the default).
+
+## Steps
+
+1. **Scan containers**:
+
+   ```bash
+   docker ps -a --filter name=cdkl- --format '{{.ID}}\t{{.Names}}\t{{.Status}}'
+   docker ps -a --filter name=cdk-local- --format '{{.ID}}\t{{.Names}}\t{{.Status}}'
+   ```
+
+2. **Scan networks**:
+
+   ```bash
+   docker network ls --filter name=cdkl-task- --format '{{.ID}}\t{{.Name}}\t{{.Driver}}'
+   docker network ls --filter name=cdkl-svc- --format '{{.ID}}\t{{.Name}}\t{{.Driver}}'
+   docker network ls --filter name=cdk-local-task- --format '{{.ID}}\t{{.Name}}\t{{.Driver}}'
+   ```
+
+3. **Scan ephemeral cdkl-built images** (optional — only if the user passed an argument hinting at image cleanup):
+
+   ```bash
+   docker images --filter reference='cdkl-built:*' --format '{{.ID}}\t{{.Repository}}:{{.Tag}}'
+   ```
+
+4. **Report findings**: Show a table of detected resources grouped by type. If everything is empty, confirm "no orphans" and stop.
+
+5. **If deletion requested** (not `--detect-only`):
+   - Use `AskUserQuestion` to show the full list and confirm deletion.
+   - Delete in this order:
+     1. Containers first (`docker rm -f <id>` — works even if running).
+     2. Networks next (`docker network rm <id>` — must come after containers that use them are gone).
+     3. Built images last (`docker rmi <id>` — only if image cleanup was requested AND the image is not referenced by any remaining container).
+   - Report each deletion result.
+
+## Important
+
+- This skill is for cleaning up LOCAL DOCKER state from cdk-local runs only.
+- cdk-local itself does NOT deploy AWS resources, so there is no AWS-side orphan scan here — use the upstream `cdk destroy` (or the host's deploy tool) for AWS resources created by a `--from-cfn-stack` deploy.
+- The `cdkl-*` / `cdk-local-*` name prefix is the contract: anything not matching that prefix is presumed external and is never touched.

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: run-integ
+description: Run an integration test (Docker-based, optionally AWS-deploy-backed for `*-from-cfn-stack` tests) and refresh the `integ` markgate marker on a clean run.
+argument-hint: "<test-name>"
+---
+
+# Integration Test Runner
+
+Run an integration test against real Docker (and, for `*-from-cfn-stack` tests, a real CloudFormation stack deployed via the upstream `cdk` CLI).
+
+cdk-local is a local-execution CLI — it does NOT deploy resources itself. The only AWS-side activity in any integ test is when a fixture's `verify.sh` invokes the upstream `cdk deploy` to create a target stack for `--from-cfn-stack` to point at. Cleanup is always done by the fixture's own `verify.sh`.
+
+## Arguments
+
+- `test-name`: Which test to run. Run `ls tests/integration/` to see all available tests. If not specified, use the `AskUserQuestion` tool to ask which test to run, showing the available options.
+
+## Steps
+
+1. **Build first**: Run `vp run build` to ensure `dist/cli.js` is up to date. The fixture's `verify.sh` resolves the binary via `node ../../../dist/cli.js`, so source changes without a build have no runtime effect.
+
+2. **Resolve the fixture path**: `tests/integration/<test-name>/`. Confirm `verify.sh` exists; if not, the test does not have a Docker-driven flow yet and this skill exits with a clear error pointing the user at the missing script.
+
+3. **Pre-flight Docker sweep**: `docker ps --filter name=cdkl- -q | wc -l` and `docker network ls --filter name=cdkl-task- -q | wc -l` should both return `0`. If either is non-zero, abort and ask the user to run `/cleanup` first — running on top of orphans causes name collisions and confusing failures.
+
+4. **For `*-from-cfn-stack` tests only — AWS pre-flight**:
+   - Verify the upstream `cdk` CLI is on `$PATH`: `which cdk`.
+   - Verify AWS credentials: `aws sts get-caller-identity`.
+   - Scan for orphan stacks from a previous interrupted run:
+     ```bash
+     aws cloudformation describe-stacks --stack-name <FixtureStackName> 2>/dev/null && echo "ORPHAN" || echo "(no orphan stack)"
+     ```
+     If an orphan stack is reported, abort with a `cdk destroy <FixtureStackName>` recipe — do NOT proceed.
+
+5. **Run the test**: `bash tests/integration/<test-name>/verify.sh`. Propagate the script's exit code — a non-zero exit must drive this skill into the failure path so step 7's cleanup verification fires. Do NOT swallow `verify.sh` failures.
+
+6. **Verify Docker cleanup** (mandatory regardless of pass/fail):
+
+   ```bash
+   docker ps --filter name=cdkl- -q | wc -l         # must be 0
+   docker network ls --filter name=cdkl-task- -q | wc -l   # must be 0
+   docker network ls --filter name=cdkl-svc- -q  | wc -l   # must be 0
+   ```
+
+   If any are non-zero, dispatch `/cleanup` (no `--detect-only`) and re-run the checks. Never end the run with orphan Docker resources still present.
+
+7. **Verify AWS cleanup** (only for `*-from-cfn-stack` tests):
+
+   ```bash
+   aws cloudformation describe-stacks --stack-name <FixtureStackName> 2>/dev/null \
+     && echo "ORPHAN STACK REMAINS" \
+     || echo "AWS clean"
+   ```
+
+   If the stack remains, run `cdk destroy <FixtureStackName> --force` until clean. Same rule: never end the run with orphan AWS resources.
+
+8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for `from-cfn-stack`: "+ AWS: 0 orphan stacks").
+
+9. **Set the `integ` markgate marker (only on full clean success)**:
+
+   When — and ONLY when — all of the following hold:
+   - the `verify.sh` step finished with exit code 0,
+   - step 6 reports 0 docker orphans,
+   - step 7 (when applicable) reports 0 AWS orphans,
+
+   record the gate so subsequent `gh pr merge` calls are unblocked:
+
+   ```bash
+   mise exec -- markgate set integ
+   ```
+
+   If any of the above failed, do NOT set the marker — that is the whole point of the gate. The `integ` gate (see `.markgate.yml`) blocks `gh pr merge` for any PR that touches `src/**` or `tests/integration/**` until this marker is fresh.
+
+## Important
+
+- **Never bypass this skill** by invoking the fixture's `verify.sh` directly from a shell — the cleanup verification + markgate set are part of the contract.
+- **Never call `markgate set integ` directly** to skip the verification. The marker only earns its place by completing the full sequence above.
+- Always confirm the test name is on the official list (`ls tests/integration/`) — typos lead to confusing "no verify.sh" errors.
+- The 14-day TTL on the marker (see `.markgate.yml`) accepts that Docker base-image behavior drifts over time even when the repo doesn't; re-running an integ after two weeks is the explicit revalidation.


### PR DESCRIPTION
## Summary

Seed cdk-local's `.claude/` infrastructure with the minimum subset needed to support the workflow that `.claude/CLAUDE.md` and `.markgate.yml` already describe:

**`.claude/agents/`** (3 files, copied + adapted from cdkd):
- `pr-code-reviewer.md` — read-only bug / edge-case / security reviewer. Security surface list reframed for cdk-local (`src/local/docker-runner.ts`, `cognito-jwt.ts`, `lambda-authorizer.ts`, `docker-image-builder.ts`, `ecr-puller.ts`, `sigv4-verify.ts`).
- `pr-spec-reviewer.md` — read-only design-doc compliance reviewer. Repo-agnostic; only PR-number example changed.
- `pr-test-reviewer.md` — read-only test adequacy / mock-anti-pattern reviewer. Reworded `child_process.execFile` 3-arg vs 4-arg + `vi.mock` hoisting notes to drop the cdkd-internal memory-rule pointers but keep the substance.

**`.claude/skills/`** (4 files):
- `check/SKILL.md` — `vp run check` + `build` + `test`, then `markgate set check`.
- `check-docs/SKILL.md` — README.md / `.claude/CLAUDE.md` consistency vs src. Short-circuit logic mirrors cdkd's but the path triggers are cdk-local's surface (`src/cli/index.ts`, `src/local/**`, etc.) and the "no comparison tables vs LocalStack" positioning rule from `.claude/CLAUDE.md` is enforced.
- `cleanup/SKILL.md` — `cdkl-*` / `cdk-local-*` docker container + network sweep. No AWS resource scan — cdk-local doesn't deploy AWS resources itself.
- `run-integ/SKILL.md` — `vp run build` + `bash tests/integration/<name>/verify.sh` + docker cleanup verification + optional AWS pre-flight for `*-from-cfn-stack` tests + `markgate set integ` on full clean success.

## Why

After PR #1's extraction, `.claude/CLAUDE.md` references skills (`/check`, `/check-docs`, `/run-integ`) and a markgate-based workflow that doesn't physically exist in this repo — every check is fully manual. This PR closes that gap with the minimum useful subset.

## What's NOT in scope

- `verify-pr` and `review-pr` skills — these have substantial cdkd-internal references (`src/utils/role-arn.ts`, provider system, deployment scope, integ-broad / integ-destroy gates) that need careful adaptation. Deferred to a follow-up.
- `.claude/hooks/**` — Priority 3b per the prior session's handover. Hooks need cwd-aware adaptation and a `.claude/settings.json` to wire them in; out of scope for this PR.
- `.claude/rules/**` — Priority 3c, follow-up.
- `verify-pr` / `pr-review` markgate gates remain in `.markgate.yml` but currently have no skill to set them — they will stay stale until the follow-up PR ships the matching skills.

## Test plan

- [x] Files render correctly in a fresh worktree (no syntax / frontmatter errors).
- [x] `git diff --stat` shows the expected 7 new files, 0 modified.
- [ ] CI green (vp run check / build / test pass — these are markdown / yaml only, no behavior change).

## Related

- cdk-local#1 — original Phase 2 extraction that seeded `.claude/CLAUDE.md` + `.markgate.yml` without the matching agents/skills.
- `/tmp/handover-cdk-local-phase-2.6-and-beyond.md` Priority 3 — outlines the full migration; this PR covers 3a.
