### PR TITLE
chore(claude): seed .claude/hooks with branch-gate + commit-msg-heredoc-gate + settings.json

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# branch-gate.sh
+#
+# PreToolUse hook. Blocks `git commit` and `git push` when the working
+# tree the command will actually act on is on `main` / `master`. All
+# changes to this repo must land via PR from a feature branch — direct
+# commits/pushes to main are not allowed.
+#
+# WHY the cwd-aware resolution matters: this repo is regularly worked
+# in via `git worktree`. A naive implementation that derived the repo
+# root from `BASH_SOURCE` (the hook script's location) would check the
+# worktree's branch (a feature branch) and allow the commit, even when
+# the user's actual command did `cd /path/to/parent && git commit` and
+# the commit landed on the parent worktree's `main`.
+#
+# Resolution order for "where will the git command actually run":
+#   1. Explicit `git -C <path> commit/push` — last `-C` wins.
+#   2. Leading `cd <path> && ...` — the cd target.
+#   3. The hook input's `cwd` field (the Bash tool's persisted cwd).
+#   4. The hook process's own $PWD (fallback, almost never reached).
+
+set -u
+
+# Read the entire stdin payload once; we need both .tool_input.command
+# and .cwd from it. Reading via two separate jq invocations would
+# consume stdin twice and the second read would see nothing.
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate git commit / git push — any other command passes through.
+# The regex matches `git` + optional global flags (e.g. `-C <path>`,
+# `-c <key>=<value>`, `--no-pager`, `--git-dir=<path>`) + the literal
+# subcommand `commit` or `push`, anchored so that `commit` / `push`
+# must appear in the GIT SUBCOMMAND POSITION — not as a substring of
+# a refspec (`<sha>^{commit}`), a pathspec (`-- '*push*.md'`), or a
+# `--grep=push` query.
+#
+# Line-start anchored so `git commit` / `git push` substrings inside
+# quoted argument bodies (`gh issue create --body "git commit later"`)
+# do NOT false-positive into a hard block. The optional leading
+# `cd <path> &&` prefix preserves the worktree-aware
+# `cd <side> && git commit` chain shape.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(commit|push)([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+# Start from the Bash session's persisted cwd; fall back to the hook
+# process's own cwd if the payload did not include a `cwd` field.
+target_dir="${hook_cwd:-$PWD}"
+
+# `cd <path>` at the start of the command shifts the target dir. We
+# look at the FIRST `cd` and stop — chained `cd` patterns are rare
+# enough that handling only the leading one covers the realistic
+# foot-gun (the "cd into parent for tooling" case) without parsing
+# arbitrary shell.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  # Strip surrounding single or double quotes if present.
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  # Resolve relative paths against the inherited cwd.
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# `git -C <path>` is git's own "run as if from <path>" flag and beats
+# any earlier cd. Find the LAST occurrence so a chained
+# `git -C /a foo && git -C /b commit` resolves to /b.
+if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# Read the branch from the resolved target dir. `-C` lets git operate
+# on a directory that isn't our cwd; if the dir doesn't exist or isn't
+# inside a git repo, symbolic-ref returns empty and we fall through to
+# the safe `exit 0` below (we can't gate what we can't see).
+branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+case "$branch" in
+  main|master)
+    echo "Blocked by branch-gate: target git working tree is on branch '$branch'." >&2
+    echo "  resolved target dir: $target_dir" >&2
+    echo "  command: $cmd" >&2
+    echo "Create a feature branch and open a PR instead (e.g. 'git -C \"$target_dir\" switch -c fix/xxx')." >&2
+    echo "Direct commits/pushes to main are not allowed in this repo." >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/commit-msg-heredoc-gate.sh
+++ b/.claude/hooks/commit-msg-heredoc-gate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# commit-msg-heredoc-gate.sh
+#
+# PreToolUse hook. Blocks `git commit -m "$(cat <<'EOF' ... EOF)"`-
+# style invocations because the outer-shell parser miscounts quotes
+# when the heredoc body contains apostrophes / backticks, producing
+# cryptic "unexpected EOF while looking for matching '" errors that
+# burn time to diagnose.
+#
+# The unsafe shape is specifically `git commit -m "$(cat <<EOF...)"`
+# (or `--message`) — a heredoc body being interpolated into the -m
+# argument of the same git commit invocation. The hook detects this
+# shape by looking for `<<` AFTER `-m` / `--message` within the same
+# pipeline segment (no `;` / `&&` / `||` / `|` between them).
+#
+# Recommended replacement: `git commit -F <file>` — write the message
+# to a file (which is read verbatim by git, no shell parsing) and
+# pass the path. The `cat > /tmp/file <<EOF...EOF && git commit -F
+# /tmp/file` pattern is SAFE and explicitly allowed even though
+# `<<` appears in the same Bash call: the heredoc writes the file,
+# the `-F` reads it back, and there is no shell parsing of the body
+# in between.
+
+set -u
+
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# Only gate git commit invocations.
+if ! printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+commit\b'; then
+  exit 0
+fi
+
+# Block only when `git commit ... (-m|--message) ... <<` appears in
+# the same pipeline segment (no `;` / `&&` / `||` / `|` between them).
+# The character class `[^|;&]` constrains the match to a single
+# segment, so `cat > file <<EOF; git commit -F file` (heredoc and
+# commit in different segments, file-based commit) is allowed, but
+# `git commit -m "$(cat <<EOF)"` (heredoc inside -m on one segment)
+# is caught.
+if ! printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+commit\b[^|;&]*(-m|--message)[^|;&]*<<'; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+Blocked by commit-msg-heredoc-gate: `git commit -m "$(cat <<'EOF' ... EOF)"`
+is fragile — apostrophes / backticks in the body confuse the outer
+shell's quote tracking and produce cryptic
+"unexpected EOF while looking for matching `'" errors.
+
+Use a message file instead:
+
+  cat > /tmp/commit-msg.txt <<'MSG'
+  feat(scope): subject line
+
+  Body paragraphs that may contain stack's apostrophes, `code`
+  fences, or any other shell-confusing characters.
+  MSG
+  git commit -F /tmp/commit-msg.txt
+
+`-F <file>` reads the file verbatim — no shell parsing of the body.
+Same pattern works for PR bodies via `gh pr create --body-file <file>`
+or `gh api PATCH --field body=@<file>`.
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/branch-gate.sh",
+            "if": "Bash(git commit*) or Bash(git push*) or Bash(git -C * commit*) or Bash(git -C * push*) or Bash(cd * && git commit*) or Bash(cd * && git push*)",
+            "timeout": 10,
+            "statusMessage": "Checking current branch..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
+            "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)",
+            "timeout": 10,
+            "statusMessage": "Checking commit message form..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Seed `.claude/hooks/` + `.claude/settings.json` with the minimum-useful subset of PreToolUse safety hooks. cdk-local's `.claude/CLAUDE.md` (PR #7) declares the workflow rules ("Never commit / push directly to main", "Use `--body-file` for PR bodies") but nothing physically enforces them. This PR fixes that for two highest-cost foot-guns:

`.claude/hooks/branch-gate.sh` — blocks `git commit` / `git push` when the resolved target git working tree is on `main` / `master`. Cwd-aware: reads `tool_input.cwd` from the hook payload + parses leading `cd <path>` and the last `git -C <path>` from the command, so `cd /path/to/main-tree && git commit` is caught even when invoked from a worktree-side bash session. Adapted from cdkd's `branch-gate.sh`; same line-start matcher anchoring (`gh issue create --body "git commit later"` does NOT false-positive).

`.claude/hooks/commit-msg-heredoc-gate.sh` — blocks `git commit -m "$(cat <<'EOF' ... EOF)"` because the outer-shell parser miscounts quotes when the body contains apostrophes / backticks, producing cryptic `"unexpected EOF while looking for matching '"` errors. Suggests `git commit -F <file>` as the safe replacement.

`.claude/settings.json` wires both hooks via `Bash(git commit*)` / `Bash(git push*)` / `Bash(git -C * commit*)` / `Bash(cd * && git commit*)` `if:` predicates.

## Why

Honor-system rules in `.claude/CLAUDE.md` rely on whoever is at the keyboard remembering them. Hooks make compliance mechanical: the bad shape physically cannot reach the next step in the pipeline.

## Test plan

- [x] `bash -n` syntax check passes for both hooks.
- [x] Smoke test:
  - Feeding `git commit -m "$(cat <<EOF\nfoo\nEOF\n)"` to commit-msg-heredoc-gate via stdin → blocked with exit code 2 and the recipe in stderr.
  - Feeding `git commit -F /tmp/x` from cwd `/tmp` (non-git) to branch-gate via stdin → passes through (exit 0) — correctly handles the "can't see the target tree" fallback.
- [ ] CI green (no behavior change to src — only adds .claude/ files).

## What's NOT in scope

- The other ~10 universal-ish hooks from cdkd (main-tree-branch-gate, post-merge-orphan-push-gate, non-english-text-gate, closes-paren-form-gate, gh-pr-edit-deprecation-gate, …) — each is high-value but adapting them takes a focused pass. Follow-up PR.
- The markgate-backed gate hooks (check-gate, integ-gate, verify-pr-gate, pr-review-gate) — these refresh the markers that cdk-local's `.markgate.yml` declares. Without the matching `/verify-pr` / `/review-pr` skills (also follow-up), the gates would be decorative anyway.
- Hook smoke tests (`.claude/hooks/*.test.sh`) — cdkd's tests use a `$GH_BIN` / `$MARKGATE_BIN` PATH-shim pattern to assert the resolution logic. Useful but a separate PR.

## Related

- cdk-local#13 — the prior PR that seeded `.claude/agents/` + `.claude/skills/`. This is the natural next step in the Priority 3b cut from `/tmp/handover-cdk-local-phase-2.6-and-beyond.md`.
- cdkd `feedback_git_use_C_in_worktree.md` (in `~/.claude/.../memory/`) — describes the worktree foot-gun that the cwd-aware branch-gate closes.
