### PR TITLE
chore(claude): add main-tree-branch + gh-pr-edit-deprecation + non-english-text safety hooks

### DIFF
--- a/.claude/hooks/gh-pr-edit-deprecation-gate.sh
+++ b/.claude/hooks/gh-pr-edit-deprecation-gate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# gh-pr-edit-deprecation-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr edit --title` / `gh pr edit --body`
+# because they currently fail SILENTLY due to a GraphQL
+# Projects-classic deprecation warning: gh exits non-zero, prints the
+# warning to stderr, and the title/body mutation is never applied.
+# Diagnosing this wastes time when the PR appears unchanged after a
+# command that "succeeded enough" to not throw.
+#
+# Recommended replacement is the raw REST API:
+#
+#   gh api -X PATCH repos/<owner>/<repo>/pulls/<num> \
+#     -f title="..." \
+#     -F body=@/tmp/pr-body.md
+#
+# This bypasses the deprecated GraphQL path.
+#
+# Other `gh pr edit` flags that don't touch title/body (e.g. labels,
+# reviewers) pass through — those use a different code path that
+# isn't affected by the deprecation.
+
+set -u
+
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# Only gate `gh pr edit` invocations.
+if ! printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+edit\b'; then
+  exit 0
+fi
+
+# Only block if the invocation actually sets --title or --body.
+if ! printf '%s' "$cmd" | grep -qE '(--title|--body|--body-file)\b'; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+Blocked by gh-pr-edit-deprecation-gate: `gh pr edit --title` /
+`--body` currently fails SILENTLY due to a GraphQL Projects-classic
+deprecation warning. The mutation is not applied even though the
+command appears to succeed.
+
+Use the raw REST API instead:
+
+  gh api -X PATCH repos/<owner>/<repo>/pulls/<num> \
+    -f title="New title" \
+    -F body=@/tmp/pr-body.md
+
+  # Verify it actually applied:
+  gh pr view <num> --json title,body -q '{title, body}'
+
+`--body=@<file>` reads the file verbatim, sidestepping shell-escape
+issues with backticks / apostrophes.
+
+If a future gh release fixes the deprecation, this gate can be
+removed.
+EOF
+exit 2

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# main-tree-branch-gate.sh
+#
+# PreToolUse hook. Blocks branch-switching commands in the MAIN
+# worktree (= the repo top-level dir) so multiple agents working in
+# parallel don't race / clobber each other on the shared main tree.
+# The main worktree must stay on `main` / `master`; feature branches
+# go to `.claude/worktrees/<branch>/`.
+#
+# WHY this gate: the main worktree is a SHARED RESOURCE across
+# parallel agents. When agent A is mid-flight on a feature branch and
+# agent B does `git switch <some-other-feature>`, A's uncommitted work
+# either gets clobbered (if no stash) or gets silently stashed by B
+# (if B was being defensive). The gate forces every feature-branch
+# operation into its own `.claude/worktrees/<x>/` subtree where the
+# contention doesn't exist.
+#
+# Resolution order for "where is the git command running":
+#   1. `git -C <path>` — last `-C` wins.
+#   2. Leading `cd <path> && ...` — the cd target.
+#   3. The hook's `cwd` field.
+#   4. $PWD.
+#
+# Gate scope:
+#   - Block: `git switch <not-main>`, `git switch -c <branch>`,
+#     `git checkout -b <branch>`, `git checkout <not-main>` (when
+#     `<not-main>` is a local branch name).
+#   - Pass: `git switch main`, `git switch master`, `git checkout
+#     main`, `git checkout master`, every `git checkout <pathspec>`
+#     (file restore), `git checkout <sha>` (detached HEAD), `git
+#     worktree add ...` (the sanctioned path).
+#
+# Bypass: agents that legitimately need to operate in the main tree
+# (e.g. release tooling, history surgery) can `cd <subdir>` first
+# or explicitly `git -C <main-tree>` and override with the
+# documented escape. The hook only fires when the target dir IS
+# the main repo top-level.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Match `git switch` / `git checkout` in the subcommand position.
+# Line-start anchored so `git switch` / `git checkout` substrings
+# inside quoted argument bodies (`gh issue create --body
+# "remember to git switch back"`) do NOT false-positive into a hard
+# block. The optional leading `cd <path> &&` prefix preserves the
+# worktree-aware `cd <main> && git switch <feat>` chain shape.
+# Reuses the branch-gate flag-token grammar so `git -C <path> switch`
+# / `git -c <key>=<val> switch` / etc. all qualify.
+#
+# We deliberately do NOT match `git worktree` — `git worktree add`
+# is the sanctioned escape and must always pass.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(switch|checkout)([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+# Resolve the target dir the same way branch-gate.sh does.
+target_dir="${hook_cwd:-$PWD}"
+
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# Is the target dir the main worktree (= the top-level of the
+# shared .git directory)? `git rev-parse --show-toplevel` returns
+# the current worktree's top — which differs between the main
+# tree and any `.claude/worktrees/<x>/`. The MAIN tree's toplevel
+# equals the directory whose parent contains `.git` as a regular
+# directory (not a gitfile pointing into a worktrees subdir).
+#
+# Cheaper heuristic: the main worktree is whatever `git worktree
+# list` lists first. We use that and compare to target_dir.
+main_tree=$(git -C "$target_dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+
+if [[ -z "$main_tree" ]]; then
+  # Not in a git repo / can't resolve — pass through (we don't gate
+  # what we can't see).
+  exit 0
+fi
+
+# Canonicalize both sides before compare. macOS resolves
+# `/tmp` → `/private/tmp` and `/var` → `/private/var` via symlinks;
+# `git worktree list --porcelain` always emits the real path, while
+# the user's cwd may still carry the symlink. `cd <dir> && pwd -P`
+# is the portable canonicalizer (BSD readlink lacks `-f` until 12+).
+canonicalize() {
+  local p="$1"
+  if [[ -d "$p" ]]; then
+    (cd "$p" 2>/dev/null && pwd -P) || printf '%s' "${p%/}"
+  else
+    printf '%s' "${p%/}"
+  fi
+}
+target_norm=$(canonicalize "$target_dir")
+main_norm=$(canonicalize "$main_tree")
+
+if [[ "$target_norm" != "$main_norm" ]]; then
+  # Target is a worktree (`.claude/worktrees/<x>/` or similar) —
+  # branch-switching there is fine.
+  exit 0
+fi
+
+# Target IS the main worktree. Parse the operation to decide:
+#   `git switch <main|master>`         → allow
+#   `git checkout <main|master>`       → allow
+#   `git switch -c <branch>`           → block
+#   `git switch <other-branch>`        → block
+#   `git checkout -b <branch>`         → block
+#   `git checkout <other-branch>`      → block (only when <other-branch>
+#                                        is a local branch — file-path
+#                                        / sha checkouts pass through)
+#   `git checkout -- <pathspec>`       → allow (file restore)
+#   `git checkout <sha>`               → allow (detached HEAD, rare in
+#                                        agent workflows but legitimate)
+#
+# Extract the operative subcommand + first non-flag arg via awk
+# tokenization (portable across BSD / GNU sed — `\b` in sed -E is
+# not supported on macOS).
+#
+# Walk the command's tokens: skip an optional `cd <path> && `
+# prefix, then skip the `git` token + any global flag tokens
+# (`-X` / `--foo` / `-C <path>` / `-c <key>=<val>`), then the
+# next token is the subcommand and everything after is its args.
+subcmd_args=$(printf '%s' "$cmd" | awk '
+  {
+    i = 1
+    # Skip an optional leading "cd <path> && " prefix.
+    if (i <= NF && $i == "cd") {
+      # Consume "cd <path> &&"; if not followed by &&, fall through.
+      saved_i = i
+      i++
+      if (i <= NF) { i++ }  # path token
+      if (i <= NF && $i == "&&") { i++ } else { i = saved_i }
+    }
+    # Expect "git" next (the gate regex guarantees it appears).
+    while (i <= NF && $i != "git") { i++ }
+    if (i > NF) { print ""; exit }
+    i++  # consume "git"
+    # Skip global flag tokens: any token starting with "-" plus an
+    # optional non-flag value token for the -C / -c family.
+    while (i <= NF && substr($i, 1, 1) == "-") {
+      flag = $i
+      i++
+      # `-C <path>` / `-c <key>=<val>` consume the next token IF
+      # the flag is exactly one of those and the next token does
+      # not start with "-".
+      if ((flag == "-C" || flag == "-c") && i <= NF && substr($i, 1, 1) != "-") {
+        i++
+      }
+    }
+    # Now $i is the subcommand. Print it + everything after.
+    out = ""
+    for (j = i; j <= NF; j++) {
+      out = out (out == "" ? "" : " ") $j
+    }
+    print out
+  }')
+sub=$(printf '%s' "$subcmd_args" | awk '{print $1}')
+
+case "$sub" in
+  switch)
+    # `git switch <name>` or `git switch -c <name>` or `git switch
+    # -C <name>` (force-create).
+    rest=$(printf '%s' "$subcmd_args" | awk '{$1=""; sub(/^ +/, ""); print}')
+    # If first token is `-c` / `-C`, the branch is being created → block.
+    first_token=$(printf '%s' "$rest" | awk '{print $1}')
+    if [[ "$first_token" == "-c" || "$first_token" == "-C" ]]; then
+      target_branch=$(printf '%s' "$rest" | awk '{print $2}')
+      block_reason="creates new feature branch '$target_branch'"
+    else
+      target_branch="$first_token"
+      if [[ "$target_branch" == "main" || "$target_branch" == "master" ]]; then
+        exit 0
+      fi
+      # `git switch -` (switch back to previous branch) — can't know
+      # what that resolves to without running git. Conservatively
+      # block; agents shouldn't be using `git switch -` in the main
+      # tree anyway.
+      if [[ "$target_branch" == "-" ]]; then
+        block_reason="switches to previous branch (\`git switch -\`); resolved branch unknown — block conservatively"
+      else
+        block_reason="switches to feature branch '$target_branch'"
+      fi
+    fi
+    ;;
+  checkout)
+    # `git checkout <name>` / `git checkout -b <name>` / `git
+    # checkout -- <pathspec>` / `git checkout <sha>`.
+    rest=$(printf '%s' "$subcmd_args" | awk '{$1=""; sub(/^ +/, ""); print}')
+    first_token=$(printf '%s' "$rest" | awk '{print $1}')
+    if [[ "$first_token" == "-b" || "$first_token" == "-B" ]]; then
+      target_branch=$(printf '%s' "$rest" | awk '{print $2}')
+      block_reason="creates new feature branch '$target_branch'"
+    elif [[ "$first_token" == "--" ]]; then
+      # File restore — pass through.
+      exit 0
+    elif [[ "$first_token" == "main" || "$first_token" == "master" ]]; then
+      exit 0
+    elif [[ -z "$first_token" ]]; then
+      # `git checkout` with no args — defaults to file restore in some
+      # versions, NOP in others. Pass through.
+      exit 0
+    else
+      # Could be a branch name or a sha. If it resolves to a local
+      # branch via `git show-ref refs/heads/<name>`, treat as branch
+      # switch (block). Otherwise treat as sha / pathspec (pass).
+      if git -C "$target_dir" show-ref --verify --quiet "refs/heads/$first_token" 2>/dev/null; then
+        target_branch="$first_token"
+        block_reason="switches to feature branch '$first_token'"
+      else
+        exit 0
+      fi
+    fi
+    ;;
+  *)
+    # Unrecognized subcommand inside switch|checkout regex match —
+    # shouldn't happen, but fail open to avoid false positives.
+    exit 0
+    ;;
+esac
+
+# Compose the block message.
+branch_slug=$(printf '%s' "${target_branch:-feature-branch}" | tr -c 'a-zA-Z0-9._/-' '-')
+cat >&2 <<EOF
+Blocked by main-tree-branch-gate: target git working tree IS the main worktree, and the command $block_reason.
+
+  resolved target dir: $target_dir
+  command: $cmd
+
+The main worktree at $main_tree is a SHARED RESOURCE across parallel agents. Feature branches must live in their own worktree so concurrent agents don't clobber each other's uncommitted work.
+
+Correct invocation:
+
+  git worktree add .claude/worktrees/${branch_slug} -b ${target_branch:-<branch>} origin/main
+  cd .claude/worktrees/${branch_slug}
+  # ... your work here ...
+
+The main tree must stay on \`main\` (or \`master\`). When done with the feature worktree:
+
+  git worktree remove .claude/worktrees/${branch_slug}
+
+If you genuinely need to operate on a feature branch IN the main tree (release surgery, history rewrite, etc.), the escape is to confirm with the user explicitly first — there is no flag to bypass this hook silently.
+EOF
+
+exit 2

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# non-english-text-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr create` / `gh pr edit` / `gh pr merge`
+# when the PR diff contains non-ASCII writing-system characters:
+# hiragana, katakana, CJK ideographs (kanji / Chinese), Hangul, or CJK
+# punctuation. The repo is OSS and the workflow rule "English-only for
+# committed files" forbids those.
+#
+# WHY: the "English-only for committed files" rule in
+# `.claude/CLAUDE.md` is honor-system without this gate. A verbatim
+# paste of a session quote (Japanese or other non-ASCII writing
+# system) can slip into a PR title / body / source file undetected
+# until a post-merge audit catches it. This hook blocks the bad shape
+# at `gh pr create` / `gh pr edit` / `gh pr merge` time.
+#
+# Why PR-level (not per-commit):
+#   - Empirically violations are 1-2 files. The pattern is "verbatim
+#     paste of a session quote" or "intentional non-ASCII text" — not
+#     the kind of mistake that accumulates across N commits.
+#   - Per-commit scanning is also viable (~30-150ms / commit on
+#     measured shapes) but compounds: a 30-commit PR pays the cost 30x.
+#     PR-level scanning runs once, so the user-visible overhead is
+#     zero in the steady state.
+#   - Strength-wise the gate is equivalent to a per-commit hook because
+#     it blocks `gh pr merge` itself — every code path that lands a
+#     commit on main goes through that one call.
+#
+# Scope:
+#   - Triggers on `gh pr create` / `gh pr edit` / `gh pr merge` (and
+#     their `gh -C <path> ...` forms). Everything else passes through.
+#   - Detects the PR by `gh pr view --json number` from the resolved
+#     target working tree (same cwd-resolution shape as branch-gate.sh
+#     / internal-pr-labels-gate.sh).
+#   - Walks every file in the PR diff (added or modified, not deleted)
+#     via `gh pr diff <N> --name-only`. The post-PR file content is
+#     fetched via `gh api repos/<owner>/<repo>/contents/<file>?ref=<sha>`
+#     so the gate works even before the branch is checked out locally.
+#   - Skips known binary / lockfile / asset extensions where the bytes
+#     can legitimately carry non-ASCII content (PNGs / fonts / lockfile
+#     author names / etc.).
+#
+# Detection: a single `grep -nP` run per touched file against the
+# combined character class of:
+#   U+3000-U+303F   CJK Symbols and Punctuation (Japanese quotes etc.)
+#   U+3040-U+309F   Hiragana
+#   U+30A0-U+30FF   Katakana
+#   U+4E00-U+9FFF   CJK Unified Ideographs (kanji / Chinese)
+#   U+AC00-U+D7AF   Hangul Syllables
+# The ranges deliberately exclude general-purpose Unicode that the repo
+# already uses (em-dashes, curly quotes, box-drawing chars in CLAUDE.md
+# ASCII art, arrow glyphs in docs).
+#
+# Fails open when `gh` is missing or the PR cannot be resolved (matches
+# post-merge-orphan-push-gate.sh's contract so a fresh machine still
+# works).
+#
+# No bypass marker — the fix is trivial (translate the text). If a test
+# fixture ever genuinely needs Japanese content (Unicode-handling
+# tests), add a sidecar allow-list file like the integ-coverage gate
+# uses; v1 ships without that mechanism.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate gh pr create / edit / merge — anything else passes through.
+if ! printf '%s' "$cmd" | grep -qE '\bgh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|edit|merge)\b'; then
+  exit 0
+fi
+
+target_dir="${hook_cwd:-$PWD}"
+
+# Leading `cd <path> && ...` shifts the target dir.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# Last `gh -C <path>` wins.
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# If the resolved target dir is not a git repo, silently pass.
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+# gh missing or unauthenticated — fail open.
+if ! command -v "${GH_BIN:-gh}" >/dev/null 2>&1; then
+  exit 0
+fi
+GH="${GH_BIN:-gh}"
+if ! "$GH" -C "$target_dir" auth status >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Resolve target PR number.
+#
+#   `gh pr merge <N>` / `gh pr edit <N>` — N is the explicit arg.
+#   `gh pr create` / `gh pr merge` (no arg) — current branch's PR.
+pr_number=""
+if [[ "$cmd" =~ gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(merge|edit)[[:space:]]+([0-9]+) ]]; then
+  pr_number="${BASH_REMATCH[3]}"
+fi
+
+if [[ -z "$pr_number" ]]; then
+  pr_number=$("$GH" -C "$target_dir" pr view --json number -q .number 2>/dev/null || true)
+fi
+
+# No PR yet (typical `gh pr create` on a fresh branch) — fall back to
+# scanning the local diff against the default base branch.
+use_local_diff=0
+if [[ -z "$pr_number" ]]; then
+  use_local_diff=1
+fi
+
+# File-list resolution.
+if [[ "$use_local_diff" -eq 1 ]]; then
+  base_ref=$(git -C "$target_dir" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
+  base_ref="${base_ref:-main}"
+  merge_base=$(git -C "$target_dir" merge-base "origin/$base_ref" HEAD 2>/dev/null || true)
+  if [[ -z "$merge_base" ]]; then
+    # Can't establish a base — silently pass (CI / detached HEAD).
+    exit 0
+  fi
+  changed_files=$(git -C "$target_dir" diff "$merge_base..HEAD" --name-only --diff-filter=AM 2>/dev/null || true)
+else
+  changed_files=$("$GH" -C "$target_dir" pr diff "$pr_number" --name-only 2>/dev/null || true)
+fi
+
+if [[ -z "$changed_files" ]]; then
+  exit 0
+fi
+
+# Skip binary / lockfile / asset extensions.
+should_scan() {
+  local f="$1"
+  case "$f" in
+    *.png|*.jpg|*.jpeg|*.gif|*.svg|*.ico|*.webp|*.pdf) return 1 ;;
+    *.woff|*.woff2|*.ttf|*.eot|*.otf) return 1 ;;
+    *.zip|*.tar|*.gz|*.tgz|*.bz2|*.7z|*.xz) return 1 ;;
+    *.mp3|*.mp4|*.wav|*.ogg|*.webm|*.mov) return 1 ;;
+    pnpm-lock.yaml|package-lock.json|yarn.lock|Cargo.lock|go.sum) return 1 ;;
+    *.lock) return 1 ;;
+  esac
+  return 0
+}
+
+# Matcher implemented in perl (not `grep -P`) because BSD `grep` on
+# macOS does not support PCRE / `-P`. `perl -CSD` reads STDIN as UTF-8
+# and writes STDOUT as UTF-8, so the Unicode ranges below work in
+# either system.
+NON_ENGLISH_PERL='print "$.:$_" if /[\x{3000}-\x{303F}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{AC00}-\x{D7AF}]/'
+
+declare -a OFFENDERS=()
+MAX_REPORT=20
+
+# For PR-mode we need each file's content at the PR HEAD sha. Fetch the
+# sha once.
+pr_head_sha=""
+if [[ "$use_local_diff" -eq 0 ]]; then
+  pr_head_sha=$("$GH" -C "$target_dir" pr view "$pr_number" --json headRefOid -q .headRefOid 2>/dev/null || true)
+fi
+
+read_file_content() {
+  local f="$1"
+  if [[ "$use_local_diff" -eq 1 ]]; then
+    git -C "$target_dir" show "HEAD:$f" 2>/dev/null
+  else
+    if [[ -n "$pr_head_sha" ]]; then
+      # Prefer local git when the PR sha is present locally — avoids a
+      # network call per file.
+      git -C "$target_dir" show "$pr_head_sha:$f" 2>/dev/null && return 0
+    fi
+    # Fall back to fetching from the API.
+    "$GH" -C "$target_dir" api "repos/{owner}/{repo}/contents/$f?ref=${pr_head_sha:-HEAD}" -q .content 2>/dev/null | base64 -d 2>/dev/null
+  fi
+}
+
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if ! should_scan "$f"; then
+    continue
+  fi
+
+  while IFS=: read -r ln content; do
+    [[ -z "$ln" ]] && continue
+    OFFENDERS+=("$f:$ln:$content")
+    if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
+      break 2
+    fi
+  done < <(read_file_content "$f" | perl -CSD -ne "$NON_ENGLISH_PERL" 2>/dev/null || true)
+done <<< "$changed_files"
+
+if [[ "${#OFFENDERS[@]}" -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ -t 2 ]]; then
+  RED_BOLD=$'\033[1;31m'
+  RESET=$'\033[0m'
+else
+  RED_BOLD=""
+  RESET=""
+fi
+
+scope_label="PR #$pr_number"
+[[ "$use_local_diff" -eq 1 ]] && scope_label="local diff (origin/$base_ref..HEAD)"
+
+{
+  echo "${RED_BOLD}Blocked by non-english-text-gate:${RESET}"
+  echo
+  echo "$scope_label contains non-English writing-system characters"
+  echo "(hiragana / katakana / kanji / Chinese / hangul / CJK punctuation)."
+  echo
+  echo "This is an OSS repo. Every committed artifact must be English-only"
+  echo "per the workflow rule: source code, shell scripts, hook messages,"
+  echo "config files, docs, comments, commit messages, PR titles/bodies."
+  echo "Conversation in chat may be in any language — this rule applies"
+  echo "only to files that land in the repository."
+  echo
+  echo "Found:"
+  for entry in "${OFFENDERS[@]}"; do
+    file="${entry%%:*}"
+    rest="${entry#*:}"
+    ln="${rest%%:*}"
+    content="${rest#*:}"
+    echo "  $file:$ln: $content"
+  done
+  echo
+  echo "Fix:"
+  echo "  - Translate the offending text to English."
+  echo "  - For docstrings / comments: rewrite in English."
+  echo "  - For verbatim session quotes: rewrite as a project-level"
+  echo "    contract statement, not as a quote."
+  echo "  - Open a follow-up commit on the same branch and push; this"
+  echo "    hook re-runs against the new HEAD."
+  echo
+  echo "See .claude/CLAUDE.md 'Workflow rules' / English-only rule."
+} >&2
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,10 +13,31 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/main-tree-branch-gate.sh",
+            "if": "Bash(git switch*) or Bash(git checkout*) or Bash(cd * && git switch*) or Bash(cd * && git checkout*) or Bash(git -C * switch*) or Bash(git -C * checkout*)",
+            "timeout": 10,
+            "statusMessage": "Checking main-tree branch-switch policy..."
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
             "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit message form..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/gh-pr-edit-deprecation-gate.sh",
+            "if": "Bash(gh pr edit*) or Bash(gh -C * pr edit*)",
+            "timeout": 10,
+            "statusMessage": "Checking gh pr edit deprecation..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/non-english-text-gate.sh",
+            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr edit*) or Bash(cd * && gh pr merge*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR diff for non-English text..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

Builds on cdk-local#14's initial 2-hook seed. Three more universal-shape safety hooks adapted from cdkd:

**`.claude/hooks/main-tree-branch-gate.sh`** — blocks `git switch <feat>` / `git switch -c <feat>` / `git checkout -b <feat>` / `git checkout <local-branch>` when invoked against the main worktree, so concurrent agents can't race on the shared top-level tree. Allowed in the main tree: `git switch main`, `git checkout main|master`, file-restore (`--`), detached-HEAD checkouts, and `git worktree add ...` (the sanctioned escape). Inside any `.claude/worktrees/<x>/` subtree everything passes through. Cwd-aware resolution mirrors `branch-gate.sh`.

**`.claude/hooks/gh-pr-edit-deprecation-gate.sh`** — blocks `gh pr edit --title` / `--body` because they currently fail SILENTLY on a GraphQL Projects-classic deprecation: gh exits non-zero, prints a warning to stderr, and the mutation is never applied. Recommends the `gh api -X PATCH repos/.../pulls/<N> -f title=... -F body=@<file>` replacement (sidesteps the deprecated GraphQL path, no shell-escape trap on bodies).

**`.claude/hooks/non-english-text-gate.sh`** — blocks `gh pr create` / `gh pr edit` / `gh pr merge` when the PR diff contains non-ASCII writing-system characters (hiragana / katakana / CJK ideographs / Hangul / CJK punctuation). The OSS English-only rule in `.claude/CLAUDE.md` is honor-system without this gate. PR-level (not per-commit) — empirically violations are 1-2 files and per-commit scanning compounds. Skips binary / lockfile / asset extensions where non-ASCII bytes are legitimate.

`.claude/settings.json` wires all three via `Bash(git switch*)` / `Bash(git checkout*)` / `Bash(gh pr edit*)` / `Bash(gh pr create*)` / `Bash(gh pr merge*)` if-predicates, plus their `gh -C <path>` / `cd <path> && ...` variants.

## Test plan

- [x] `bash -n` syntax check passes for all 3 hooks.
- [x] Smoke test:
  - `gh pr edit 1 --title "new"` → blocked (exit 2) with the gh-api recipe in stderr.
  - `gh pr edit 1 --add-label foo` → passes through (exit 0) — only title/body invocations are gated.
  - `git switch -c feat/x` from `/tmp` (non-git) → passes through (the "can't see the target tree" fallback fires correctly).
- [ ] CI green (no behavior change to src — only adds .claude/ files).

## What's NOT in scope

- The remaining cdkd hooks: `closes-paren-form-gate.sh` (one more PR-body safety check) and `post-merge-orphan-push-gate.sh` (block push to already-merged branch). Both repo-agnostic, both candidates for the next `.claude/hooks` seed PR.
- The markgate gate hooks (`check-gate.sh` / `verify-pr-gate.sh` / `pr-review-gate.sh` / `integ-gate.sh`) — these refresh the markers cdk-local's `.markgate.yml` declares, but they only become useful once `/verify-pr` and `/review-pr` skills exist to flip the markers. Priority 3c follow-up.
- Hook smoke tests (`*.test.sh`) — verbose mock-shim pattern from cdkd; useful but its own PR.

## Related

- cdk-local#14 — the prior 2-hook seed.
- cdk-local#13 — the agents + skills seed.
- `/tmp/handover-cdk-local-phase-2.7-and-beyond.md` Priority 3b.
