### PR TITLE
chore(claude): add verify-pr-gate markgate-backed PR-readiness hook

### DIFF
--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# verify-pr-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr create` and `gh pr merge` (including
+# --auto) unless the `verify-pr` markgate marker is fresh for the
+# current content state. The gate's scope (see .markgate.yml) is the
+# AND of the `check` and `docs` child gates plus the /verify-pr
+# skill's own work — so editing any code/test/doc path invalidates
+# the marker and forces a successful /verify-pr run before the PR
+# can be opened or merged.
+#
+# This is the structural enforcement of the "PR readiness checklist"
+# rule: live-test the changed behavior, walk all shared-utility
+# callers, refresh PR title + body, and run the session retrospective
+# (proposing new rules/hooks/skills for recurring patterns) BEFORE
+# `gh pr create` / `gh pr merge`. The skill said it; the hook
+# enforces it.
+#
+# WHY cwd-aware resolution: this repo is regularly worked in via
+# `git worktree`, and markgate stores marker state per-worktree at
+# `<git rev-parse --absolute-git-dir>/markgate/`. We resolve the
+# target working tree from the PreToolUse payload's `cwd` field +
+# leading `cd <path>` + last `gh -C <path>` flag, so the markgate
+# verify runs against the worktree the PR will actually open / merge
+# from. Convention: set markers from the worktree you intend to open
+# the PR (and merge it) from.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate `gh pr create` and `gh pr merge`. Match both `gh pr merge`
+# and `gh pr merge --auto`. Tolerate an optional `gh -C <path>` between
+# `gh` and `pr`. Line-start anchored so `gh pr create` / `gh pr merge`
+# substrings inside quoted argument bodies
+# (`echo "next step: gh pr create"`) do NOT false-positive into a hard
+# block. The optional leading `cd <path> &&` prefix preserves the
+# worktree-aware `cd <side> && gh pr create` chain shape.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+# Resolve where the gh command will actually run (cwd-aware; mirrors
+# non-english-text-gate.sh / pr-review-gate.sh).
+target_dir="${hook_cwd:-$PWD}"
+
+# `cd <path>` at the start of the command shifts the target dir.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# Last `gh -C <path>` wins.
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# If the resolved target dir is not a git repo, silently pass — we
+# can't audit what we can't see.
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+cd "$target_dir" 2>/dev/null || exit 0
+
+# Prefer the mise-managed version via `mise exec --` so the repo's
+# canonical markgate wins over an older PATH binary.
+if command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+elif command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+else
+  echo "Blocked by verify-pr-gate: markgate is not installed. Run 'mise install' at the repo root." >&2
+  exit 2
+fi
+
+"${markgate[@]}" verify verify-pr >/dev/null 2>&1
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+fi
+
+# Extract the parenthesized reason from `markgate status verify-pr` so
+# the error message tells the user *why* the gate is stale. With
+# `requires: [check, docs]` the reason often names the failing child
+# (e.g. "(child docs is stale)"), pointing the user straight at /check
+# or /check-docs without forcing them to re-run /verify-pr blindly.
+# Fails open to the static heredoc body when extraction fails.
+reason=$("${markgate[@]}" status verify-pr 2>/dev/null \
+  | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
+
+if [ -n "$reason" ]; then
+  printf "Blocked by verify-pr-gate: the \`verify-pr\` marker is stale %s.\n\n" "$reason" >&2
+else
+  echo "Blocked by verify-pr-gate: the \`verify-pr\` marker is stale (or missing)." >&2
+  echo >&2
+fi
+
+cat >&2 <<'EOF'
+Required action — no exceptions:
+  /verify-pr [PR-number]
+
+The skill walks the full PR-readiness checklist:
+  - typecheck / lint / build / unit tests
+  - test coverage for the diff
+  - CI status / working tree / docs consistency
+  - Docker + integ marker verification (for src/** or tests/integration/** touches)
+  - code review (incl. shared-utility caller verification)
+  - live-test the changed behavior against real or fixture input
+  - retrospective + proposals for new rules / hooks / skills
+  - residual review-nit sweep + auto-close audit
+  - PR title + body freshness vs the actual diff
+
+It is the ONLY legitimate setter of this marker. Do NOT call
+`markgate set verify-pr` directly from a shell to bypass this hook —
+the whole point of the gate is that an unverified PR cannot be opened
+or merged. If a check legitimately cannot pass right now (e.g. no
+Docker daemon for live-test), say so explicitly in the report; the
+gate stays red so a human can decide whether to override.
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,6 +73,13 @@
             "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*)",
             "timeout": 30,
             "statusMessage": "Verifying pr-review marker (sha-bound)..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/verify-pr-gate.sh",
+            "if": "Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr merge*)",
+            "timeout": 15,
+            "statusMessage": "Verifying verify-pr markgate marker..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

Adds the `verify-pr-gate.sh` markgate-backed PreToolUse hook. Pairs with the `/verify-pr` skill that PR #23 just landed.

### What it does

Blocks `gh pr create` and `gh pr merge` (incl. `--auto`) unless the `verify-pr` markgate marker is fresh for the current content state. The marker is declared as `requires: [check, docs]` in `.markgate.yml`, so freshness is the AND of those children plus the `/verify-pr` skill's own work — editing any code/test/doc path invalidates the marker and forces a successful `/verify-pr` run before the PR can be opened or merged.

This is the structural enforcement of the "PR readiness checklist" rule: live-test the changed behavior, walk all shared-utility callers, refresh PR title + body, and run the session retrospective (proposing new rules/hooks/skills for recurring patterns) BEFORE `gh pr create` / `gh pr merge`. The skill said it; the hook enforces it.

### Error message

When stale, the hook extracts the parenthetical state reason from `markgate status verify-pr` (e.g. `(child docs is stale)`) so the user knows whether to re-run `/check` / `/check-docs` / `/verify-pr`.

### Cwd-aware

Parses `tool_input.cwd` + leading `cd <path>` + last `gh -C <path>` flag so each worktree's markgate state is consulted. Concurrent agents in different worktrees don't collide on the marker.

### Bootstrap note

The `verify-pr` marker has never been set in any worktree before this PR, so the install commit's `gh pr create` and `gh pr merge` would normally be blocked by the new gate. This worktree bootstrapped `check` + `docs` + `verify-pr` via the same `vp run check / build / test + mise exec -- markgate set` pattern PR #20 used for `check-gate`. After this PR merges, the legitimate `/verify-pr` skill flow is the only path to refresh the marker on real-code PRs.

## Test plan

- [x] Local check / build / test pass before commit (gated by check-gate).
- [x] Smoke-tested: non-PR command pass-through; `gh pr create` blocks when marker stale; quoted-body false-positive avoidance.
- [x] CI green.
- [ ] Live-tested on the next non-trivial PR — verify the gate blocks `gh pr create` until `/verify-pr` runs end-to-end.
