### PR TITLE
chore(claude): fix docs gate scope + document gate workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -166,6 +166,94 @@ vp run runtime:smoke
   This is what CI runs; failing locally is faster feedback than failing
   in GitHub Actions.
 
+- **Before every commit**: two markgate gates guard `git commit` via
+  `.claude/hooks/check-gate.sh`. Both must be fresh:
+  - `check` — recorded by `/check` (typecheck + lint + format + build +
+    tests). Scope: `src/**`, `tests/**`, lockfiles, build/test configs
+    (see `.markgate.yml`). Only invalidated by changes in that scope.
+  - `docs` — recorded by `/check-docs` (README.md / `.claude/CLAUDE.md`
+    / `docs/` / `.claude/rules/` consistency with src). Scope: `src/**`,
+    `docs/**`, `README.md`, `.claude/CLAUDE.md`, `.claude/rules/**`.
+    Only invalidated by changes in that scope.
+
+  Run the required skills proactively before attempting the commit —
+  look at `git status` / `git diff --cached --name-only` and match it
+  against each gate's scope: a tests-only commit only needs `/check`;
+  a docs-only commit only needs `/check-docs`; a src edit needs both;
+  changes that fall outside both scopes (e.g. `.claude/hooks/**`,
+  `.claude/skills/**`, `.markgate.yml`) need neither. The hook is a
+  safety net, not the primary trigger — if you see "Blocked by
+  check-gate", the message names exactly which skill to re-run, but
+  getting there means you skipped the proactive step. `/verify-pr`
+  refreshes both markers in one shot. Install `vp` and `markgate` via
+  `mise install` at the repo root.
+
+- **Before opening or merging any PR**: a third markgate gate,
+  `verify-pr`, guards `gh pr create` and `gh pr merge` via
+  `.claude/hooks/verify-pr-gate.sh`. Declared as
+  `requires: [check, docs]` in `.markgate.yml`, so the gate is fresh
+  ONLY when both children are fresh AND `/verify-pr` itself has set
+  the parent marker. The skill walks the full checklist — typecheck /
+  lint / build / tests, CI status, working tree, docs consistency,
+  Docker + integ marker check, code review (incl. shared-utility
+  caller verification), live-test of the changed behavior against
+  real or fixture input, session retrospective + proposals for new
+  rules / hooks / skills, residual review-nit sweep + auto-close
+  audit, and PR title + body freshness vs the diff. So opening or
+  merging a PR whose live behavior was never exercised, or whose
+  retrospective produced no rule proposals for surprises in the
+  session, is physically blocked — the hook refuses `gh pr create` /
+  `gh pr merge` until `/verify-pr` is re-run end-to-end.
+
+- **Before merging large / security-sensitive PRs**: a fourth markgate
+  gate, `pr-review`, guards `gh pr merge` via
+  `.claude/hooks/pr-review-gate.sh`. The hook re-applies the
+  `/review-pr` skill's size + bias heuristic to the target PR:
+  `loc < 300 OR fc < 5` → `inline` (pass-through);
+  `300 <= loc < 1000 AND 5 <= fc < 10` → `1-reviewer`;
+  `loc >= 1000 OR fc >= 10` → `3-axis`. Up-bias triggers (security /
+  process-launch surface paths, > 1 fix-back commit) bump the tier UP
+  one step; down-bias triggers (every path under docs/infra, or every
+  path under `tests/`) bump it DOWN one step; when both fire, up wins.
+  For PRs whose final tier is `1-reviewer` or `3-axis`, the marker
+  must be fresh AND bound to the PR's current HEAD sha via the
+  `.markgate-pr-review-sha` sentinel — set ONLY by `/review-pr` after
+  the recommended reviewers complete and every blocker is addressed.
+  A new push to the PR invalidates the marker naturally. `inline`-tier
+  PRs always pass through. Only `gh pr merge` is gated; `gh pr create`
+  is NOT gated (small PRs should be openable freely).
+
+- **PR review pattern**: 3 read-only review sub-agents are codified at
+  `.claude/agents/pr-{spec,code,test}-reviewer.md`. The orchestrator
+  dispatches the recommended count (0 / 1 / 3) in parallel against
+  a PR's diff and synthesizes the findings before merge. The 3 axes
+  (spec compliance / code quality / test adequacy) catch different
+  classes of issues. Each agent has read-only tools (Read / Glob /
+  Grep / Bash) so they can never accidentally edit; their output is a
+  structured report that the orchestrator uses to decide whether to
+  merge or send fixes back to the implementing agent.
+
+- **When running integration tests**: use `/run-integ <test-name>`
+  with the appropriate test name (e.g., `/run-integ local-invoke`).
+  Never bypass the skill by manually invoking the fixture's
+  `verify.sh` from a shell — the skill encodes Docker pre-flight +
+  the verify.sh run + post-run Docker orphan sweep + (for
+  `*-from-cfn-stack` tests) AWS stack orphan check in a single block,
+  and skipping any step risks setting the `integ` marker on
+  incomplete verification. The marker is consulted by the future
+  `integ-gate.sh` hook (TODO — separate follow-up PR) to block
+  `gh pr merge` when `src/**` or `tests/integration/**` is touched.
+
+- **After running integration tests**: verify no leftover Docker
+  containers / networks remain (`docker ps --filter name=cdkl-`,
+  `docker network ls --filter name=cdkl-task-` /
+  `cdkl-svc-`). For `*-from-cfn-stack` tests, also verify no orphan
+  CloudFormation stacks remain. If the run failed or left orphans,
+  clean them up immediately via direct Docker / `cdk destroy` /
+  `aws cloudformation` calls — leaving orphan resources after an
+  integ run is never acceptable, regardless of whether the test
+  passed.
+
 ## Positioning when communicating
 
 - `cdkl` is the **binary** name (the command users type).

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -47,7 +47,7 @@ gates:
       - "src/**"
       - "docs/**"
       - "README.md"
-      - "CLAUDE.md"
+      - ".claude/CLAUDE.md"
       - ".claude/rules/**"
 
   verify-pr:


### PR DESCRIPTION
## Summary

Two related changes that complete the markgate-gate enforcement story for cdk-local.

### 1. `.markgate.yml` `docs` scope bug fix

The `docs` gate scope listed `CLAUDE.md` (top-level), but cdk-local's CLAUDE.md lives at `.claude/CLAUDE.md`. markgate's `hash:files` mode silently skips missing scope entries, so edits to the actual CLAUDE.md never invalidated the docs marker. Pre-fix, `/check-docs` was effectively a no-op against the only doc the gate cares about.

Fix: replace the bare `CLAUDE.md` with `.claude/CLAUDE.md`.

### 2. `.claude/CLAUDE.md` workflow rules expansion

Documents the gate enforcement shipped by PRs #20 / #22 / #24:

- **Before every commit**: `check-gate.sh` blocks `git commit` when `check` or `docs` markers are stale. Names which skill (`/check` / `/check-docs`) to re-run and the per-gate scope so contributors know what each marker actually tracks.
- **Before opening or merging any PR**: `verify-pr-gate.sh` blocks `gh pr create` / `gh pr merge` when the `verify-pr` marker (declared `requires: [check, docs]`) is stale. Names the full `/verify-pr` checklist so contributors know what the gate is structurally enforcing.
- **Before merging large / security-sensitive PRs**: `pr-review-gate.sh` blocks `gh pr merge` for `1-reviewer` / `3-axis` tier PRs without a sha-bound `pr-review` marker. Walks the size + bias heuristic so contributors can predict the tier before opening a PR.
- **PR review pattern**: codifies the 3 read-only sub-agents at `.claude/agents/pr-{spec,code,test}-reviewer.md` and the orchestrator's dispatch role.
- **`/run-integ` skill conventions**: never bypass via shelling into `verify.sh` directly; post-run Docker + AWS orphan cleanup is non-negotiable.

### Size note

CLAUDE.md grows from 192 to 279 lines (~87-line addition). Slightly above cdkd's "stay around 200 lines" guidance. A follow-up PR can split the verbose gate explanations into `.claude/rules/hooks.md` (cdkd's pattern) if the context cost becomes a problem; for now, having the rules co-located with the other workflow guidance helps discoverability.

## Test plan

- [x] Local `vp run check / build / test` pass before commit (gated by check-gate).
- [x] Both pre-existing markers (`check` / `docs`) re-set in the worktree after the .markgate.yml scope change to capture the new content/path mix.
- [x] `verify-pr` marker bootstrapped (one-time install cost; same pattern as PR #24).
- [x] CI green.
