### PR TITLE
docs: add --env-vars usage and move library mode to docs/

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -274,6 +274,9 @@ vp run runtime:smoke
 ## Reference
 
 - `README.md` — user-facing intro + install + usage.
+- `docs/library-mode.md` — programmatic / library-mode integration
+  surface (factory exports, `LocalStateProvider` API) — linked from
+  README's "Programmatic use" pointer.
 - `vite.config.ts` — vp tasks, lint / fmt / pack / test config.
 - `.github/workflows/ci.yml` — CI (typecheck + lint + test + build +
   Node 20/22/24 matrix smoke).

--- a/README.md
+++ b/README.md
@@ -112,6 +112,29 @@ cdkl start-service MyStack/MyService --from-cfn-stack MyStack
 
 Use this for production debugging, integration verification with real AWS resources, and validating real IAM permissions before deploy.
 
+## Override env vars without a state source
+
+When env-var values in your CDK template are CloudFormation intrinsics (`Ref`, `Fn::GetAtt`, `Fn::ImportValue`), cdk-local cannot resolve them without a state source — it drops them with a warning that names the affected key. To inject literal values instead, use `--env-vars <file>` (SAM-compatible JSON shape):
+
+```json
+{
+  "Parameters": { "LOG_LEVEL": "debug" },
+  "MyFunctionLogicalId": {
+    "SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:MySecret-abc123",
+    "TABLE_NAME": "my-table"
+  }
+}
+```
+
+```bash
+cdkl invoke MyStack/MyFunction --event ./event.json --env-vars ./env.json
+```
+
+- `Parameters` applies to every function; function-specific blocks override it.
+- Function-specific keys are CloudFormation logical IDs (named in `cdk.out/<Stack>.template.json` or in the drop-warning message).
+- Available on `invoke`, `start-api`, `run-task`, and `start-service`.
+- The file format matches `sam local invoke --env-vars`, so an existing SAM env-vars file works unchanged.
+
 ## Supported resources
 
 | Resource | Local execution support |
@@ -125,39 +148,9 @@ Use this for production debugging, integration verification with real AWS resour
 | `AWS::ECS::Service` (start-service) | ✓ |
 | `AWS::ServiceDiscovery::*` (Cloud Map / Service Connect) | ✓ |
 
-## Use as a library
+## Programmatic use
 
-`cdk-local` also exports its Commander commands as factories, so you can build a custom CLI that adds your own state-source flags on top of the built-in `--from-cfn-stack`.
-
-```typescript
-import { Command } from 'commander';
-import {
-  createLocalInvokeCommand,
-  createLocalStartApiCommand,
-  type LocalStateProvider,
-  type LocalStateProviderFactory,
-} from 'cdk-local';
-
-// Register a custom state source. The key (e.g. `fromMyStore`) is the
-// camel-case Commander option name your factory keys off.
-const extraStateProviders: Record<string, LocalStateProviderFactory> = {
-  fromMyStore: (opts) => new MyStoreStateProvider(opts),
-};
-
-const program = new Command();
-program.addCommand(createLocalInvokeCommand({ extraStateProviders }));
-program.addCommand(createLocalStartApiCommand({ extraStateProviders }));
-program.parseAsync(process.argv);
-
-class MyStoreStateProvider implements LocalStateProvider {
-  readonly label = '--from-my-store';
-  async load(stackName: string, synthRegion: string | undefined) { /* ... */ return undefined; }
-  async buildCrossStackResolver(consumerRegion: string) { /* ... */ return undefined; }
-  dispose() { /* close clients */ }
-}
-```
-
-The dispatcher enforces mutual exclusion across `--from-cfn-stack` and every registered extra flag, so users get one consistent error message when they pass conflicting flags.
+cdk-local also exports its commands as Commander factories so a host project can embed it into its own CLI and register custom state sources alongside the built-in `--from-cfn-stack`. See [docs/library-mode.md](docs/library-mode.md) for the API and an example.
 
 ## License
 

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -1,0 +1,43 @@
+# Programmatic use
+
+cdk-local exports its Commander commands as factories, so you can build
+a custom CLI that adds your own state-source flags on top of the
+built-in `--from-cfn-stack`.
+
+This is the integration surface that lets a host project reuse
+cdk-local's local-execution engine while plugging in its own way of
+locating deployed ARNs / Secret values / IAM credentials (for example,
+a CLI that reads from a custom deployment registry rather than from
+CloudFormation).
+
+```typescript
+import { Command } from 'commander';
+import {
+  createLocalInvokeCommand,
+  createLocalStartApiCommand,
+  type LocalStateProvider,
+  type LocalStateProviderFactory,
+} from 'cdk-local';
+
+// Register a custom state source. The key (e.g. `fromMyStore`) is the
+// camel-case Commander option name your factory keys off.
+const extraStateProviders: Record<string, LocalStateProviderFactory> = {
+  fromMyStore: (opts) => new MyStoreStateProvider(opts),
+};
+
+const program = new Command();
+program.addCommand(createLocalInvokeCommand({ extraStateProviders }));
+program.addCommand(createLocalStartApiCommand({ extraStateProviders }));
+program.parseAsync(process.argv);
+
+class MyStoreStateProvider implements LocalStateProvider {
+  readonly label = '--from-my-store';
+  async load(stackName: string, synthRegion: string | undefined) { /* ... */ return undefined; }
+  async buildCrossStackResolver(consumerRegion: string) { /* ... */ return undefined; }
+  dispose() { /* close clients */ }
+}
+```
+
+The dispatcher enforces mutual exclusion across `--from-cfn-stack` and
+every registered extra flag, so users get one consistent error message
+when they pass conflicting flags.


### PR DESCRIPTION
## Summary

Two README hygiene improvements:

- **Add `--env-vars` to the README.** The flag was implemented (and surfaced via `--help`) but never appeared in the user-facing README, so users hitting "intrinsic env var was dropped" warnings had no on-page path to recovery. A new section "Override env vars without a state source" documents the SAM-compatible JSON shape (`Parameters` block + per-function logical-ID blocks), shows the file + command pair, and lists which subcommands accept it. Calls out the `sam local invoke --env-vars` compatibility so anyone migrating their existing env-vars file knows it works unchanged.

- **Move the library-mode example out of the README.** The "Use as a library" section targeted host integrators (custom CLIs that register their own state-source flags), not the general CDK user reading the README to learn how to run their Lambda locally. The full example now lives at `docs/library-mode.md`; the README keeps a one-paragraph "Programmatic use" pointer.

`.claude/CLAUDE.md` Reference section gets a one-line entry pointing at the new `docs/library-mode.md` so the new doc location is discoverable from the project guidance.

## Test plan

- [x] `vp run check` — pass (typecheck + lint + format)
- [x] `vp run test` — pass (6 files, 101 tests)
- [x] `vp run build` — pass (dist/cli.js + dist/index.js)
- [x] Manual docs consistency review against [src/local/env-resolver.ts](src/local/env-resolver.ts) and [src/cli/commands/local-invoke.ts](src/cli/commands/local-invoke.ts)
- [x] Verified `--env-vars` is wired on all four subcommands (`invoke`, `start-api`, `run-task`, `start-service`)
- [ ] Visual review of rendered README sections on the PR page

## Out of scope

A separate issue will track whether `--env-vars` should also accept CDK construct path keys (e.g. `MyStack/MyFn`) alongside the current logical-ID keys. Keeping that out of this PR because (a) cdkd currently has its own duplicate copy of `resolveEnvVars` while a detachment effort is in flight, so a feature change to the resolver would force a parallel-mirror change in cdkd, and (b) waiting until detachment completes lets the feature land in one place and propagate via dependency upgrade.
