### PR TITLE
chore(claude): add integ-gate markgate-backed merge hook

### DIFF
--- a/.claude/hooks/integ-gate.sh
+++ b/.claude/hooks/integ-gate.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# integ-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr merge` (including --auto) and
+# `git merge` unless the `integ` markgate marker is fresh for
+# the current content state. The gate's scope (see .markgate.yml)
+# covers `src/**` and `tests/integration/**`; editing any of them
+# invalidates the marker and forces a successful Docker-based
+# `/run-integ <test-name>` run before the PR can be merged.
+#
+# The `.markgate.yml` integ gate also carries a 14-day TTL on top
+# of the file-scope check, so the marker decays even when nothing
+# changed in the repo — Docker base-image behavior, RIE binary, and
+# host network plumbing drift over time, so a marker more than two
+# weeks old no longer proves today's local code path works.
+#
+# WHY cwd-aware resolution: this repo is regularly worked in via
+# `git worktree`. We read the actual git working tree the command
+# will run against (via `git -C` or leading `cd <path>`) before
+# consulting markgate. Convention: set markers from the worktree you
+# intend to merge from.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate `gh pr merge` and `git merge`. `gh pr create` is
+# intentionally NOT gated — opening a PR for review should be allowed
+# even when the integ marker is stale; the gate only fires at merge
+# time. Line-start anchored so `gh pr merge` / `git merge` substrings
+# inside quoted argument bodies do NOT false-positive.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$|[|;&`)])|^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git[^|;&]*[[:space:]]merge([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+target_dir="${hook_cwd:-$PWD}"
+
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+cd "$target_dir" 2>/dev/null || exit 0
+
+if command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+elif command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+else
+  echo "Blocked by integ-gate: markgate is not installed. Run 'mise install' at the repo root." >&2
+  exit 2
+fi
+
+"${markgate[@]}" verify integ >/dev/null 2>&1
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+fi
+
+# Extract the parenthesized reason from `markgate status integ` so
+# the error message tells the user *why* the gate is stale. With the
+# 14d TTL configured in .markgate.yml, the stale reason is either
+# "(digest differs)" (a src/** or tests/integration/** file changed)
+# or "(expired by ttl: 14d, marker is Nd old)" (the marker aged out).
+reason=$("${markgate[@]}" status integ 2>/dev/null \
+  | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
+
+if [ -n "$reason" ]; then
+  printf "Blocked by integ-gate: this PR touches src/** or tests/integration/** and the \`integ\` marker is stale %s.\n\n" "$reason" >&2
+else
+  cat >&2 <<'EOF_HEAD'
+Blocked by integ-gate: this PR touches src/** or tests/integration/**
+and the `integ` marker is stale.
+
+EOF_HEAD
+fi
+
+cat >&2 <<'EOF'
+Required action — no exceptions:
+  /run-integ <test-name>            # e.g. local-invoke / local-start-api /
+                                    # local-run-task / local-invoke-container /
+                                    # local-invoke-from-cfn-stack /
+                                    # local-invoke-layers / local-invoke-python /
+                                    # local-invoke-ruby / local-invoke-java /
+                                    # local-invoke-dotnet / local-invoke-provided
+
+The /run-integ skill is the ONLY legitimate setter of this marker. It
+runs the Docker-based fixture (no AWS deploy needed except for
+`*-from-cfn-stack` tests) and only calls `markgate set integ` if ALL
+of the following hold:
+  - the verify.sh run exited cleanly,
+  - 0 orphan containers / networks after the post-run docker sweep,
+  - for *-from-cfn-stack tests: 0 orphan CloudFormation stacks.
+
+Do NOT call `markgate set integ` directly from a shell to bypass this
+hook. The whole point of the gate is that an unverified local code
+path cannot reach main. If you believe the file in scope is genuinely
+unrelated to local execution, narrow `.markgate.yml`'s integ scope —
+do not bypass the marker.
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,6 +80,13 @@
             "if": "Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr merge*)",
             "timeout": 15,
             "statusMessage": "Verifying verify-pr markgate marker..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/integ-gate.sh",
+            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*) or Bash(git merge*) or Bash(git -C * merge*) or Bash(cd * && git merge*)",
+            "timeout": 15,
+            "statusMessage": "Verifying integ markgate marker..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

Adds the `integ-gate.sh` markgate-backed PreToolUse hook adapted from cdkd's `integ-local-gate.sh`. This completes the markgate-gate enforcement story for cdk-local: check / docs (PR #20), pr-review (PR #22), verify-pr (PR #24), and now `integ`.

### What it does

Blocks `gh pr merge` (incl. `--auto`) and `git merge` unless the `integ` markgate marker is fresh. `.markgate.yml`'s `integ` gate scope covers `src/**` and `tests/integration/**` with a 14-day TTL on top of the file-scope check — Docker base-image behavior (`public.ecr.aws/lambda/*`, RIE binary), `dockerd` semantics, and chokidar / network plumbing drift even when the repo doesn't, so a marker more than two weeks old no longer proves today's local code path works.

`gh pr create` is intentionally NOT gated — opening a PR for review should be allowed even when the marker is stale.

### Cwd-aware

Parses `tool_input.cwd` + leading `cd <path>` + last `git -C <path>` / `gh -C <path>` flag so each worktree has its own markgate state and parallel agents in different worktrees don't collide.

### Bootstrap

This worktree's `integ` marker was set via a legitimate `/run-integ` flow — `vp run build` + the `local-invoke` fixture's `verify.sh` (4/4 tests passed) + 0-orphan post-run Docker sweep:

```
docker ps --filter name=cdkl-      → 0
docker network ls --filter name=cdkl-task-   → 0
docker network ls --filter name=cdkl-svc-    → 0
```

The check / docs / verify-pr markers were also refreshed in this worktree per the install-commit precedent set by PRs #20 / #24 / #25. After this PR merges, the only legitimate way for any other worktree to refresh `integ` is to run `/run-integ <test-name>` against a Docker-clean state.

### Steady-state implications

Every future PR whose diff touches `src/**` or `tests/integration/**` must have a fresh `integ` marker in its merging worktree before `gh pr merge` succeeds. The marker is per-worktree (cwd-aware), so each agent merging from a different worktree must run `/run-integ` themselves. The 14-day TTL also forces a re-run on PRs that sit open longer than two weeks.

## Test plan

- [x] Local `vp run check` / `build` / `test` pass before commit (gated by check-gate).
- [x] Smoke-tested: non-merge pass-through; gh pr merge with fresh marker passes; gh pr create not gated; quoted-body false-positive avoidance.
- [x] Real integ run (`local-invoke`) + 0-orphan sweep verified the marker-set path.
- [x] CI green.
