### PR TITLE
fix(integ): use cdkl invoke not cdkl local invoke in cfn-stack fixtures

### DIFF
--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -141,7 +141,7 @@ invoke_with_retry() {
   local attempts=3
   local i=1
   while [ $i -le $attempts ]; do
-    if out=$(${CLI} local invoke "${args[@]}" 2>/dev/null | tail -1) && \
+    if out=$(${CLI} invoke "${args[@]}" 2>/dev/null | tail -1) && \
        echo "${out}" | grep -q '"sharedValue":'; then
       printf '%s' "${out}"
       return 0
@@ -153,7 +153,7 @@ invoke_with_retry() {
     i=$((i+1))
   done
   echo "[verify]   all ${attempts} invoke attempts failed; last stderr below:" >&2
-  ${CLI} local invoke "${args[@]}" 2>&1 | tail -10 >&2
+  ${CLI} invoke "${args[@]}" 2>&1 | tail -10 >&2
   return 1
 }
 

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -121,7 +121,7 @@ invoke_with_retry() {
   local attempts=3
   local i=1
   while [ $i -le $attempts ]; do
-    if out=$(${CLI} local invoke "${args[@]}" 2>/dev/null | tail -1) && \
+    if out=$(${CLI} invoke "${args[@]}" 2>/dev/null | tail -1) && \
        echo "${out}" | grep -q '"tableName":'; then
       printf '%s' "${out}"
       return 0
@@ -133,7 +133,7 @@ invoke_with_retry() {
     i=$((i+1))
   done
   echo "[verify]   all ${attempts} invoke attempts failed; last stderr below:" >&2
-  ${CLI} local invoke "${args[@]}" 2>&1 | tail -10 >&2
+  ${CLI} invoke "${args[@]}" 2>&1 | tail -10 >&2
   return 1
 }
 


### PR DESCRIPTION
## Summary

Two AWS-deploy integ fixtures (`local-invoke-from-cfn-stack` and `local-invoke-from-cfn-stack-multi-stack`) called the cdk-local CLI as `${CLI} local invoke ...` — the cdkd-style shape from before cdk-local stripped the `local-` prefix. Surfaced when I ran `local-invoke-from-cfn-stack` end-to-end this session: the CDK stack deployed fine, but every `cdkl invoke` retry failed with:

```
error: unknown command 'local'
```

The stack was correctly destroyed by verify.sh's fallback, so no orphan resources.

### Fix

Substitution: `${CLI} local invoke` -> `${CLI} invoke` in both verify.sh files (lines 124 + 136 in single-stack; 144 + 156 in multi-stack). Total: 4 line replacements across 2 files.

The legacy `cdkd` comment strings in the verify.sh headers ("install + build cdkd", "the cdkd-deployed path", etc.) are documentation-only and don't affect behavior. They stay untouched in this targeted fix and can be swept in a later pass.

### Why no pnpm-workspace.yaml

I considered adding a `pnpm-workspace.yaml` with `allowBuilds: esbuild: true` for parity with cdkd. After investigation: cdk-local's `vite-plus@0.1.22` resolves `vite@8.x` which no longer pulls esbuild as a transitive dep (cdkd's older `vite-plus@0.1.20` -> `vite@5.x` does). The file would have no effect today. Skipped per user direction — defensive parity isn't needed unless a future vite bump brings esbuild back.

## Test plan

- [x] `vp run check` / `build` / `test` clean post-fix.
- [x] Both verify.sh files no longer contain `local invoke`; the `${CLI} invoke` invocations are unchanged otherwise.
- [ ] Re-run `local-invoke-from-cfn-stack` integ end-to-end with AWS creds and confirm it now passes (was BLOCKED before this fix).
