### PR TITLE
chore(comments): sweep stale cdkd refs in cdk-local JSDoc and integ comments

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -202,7 +202,7 @@ interface LocalStartApiOptions {
  * synthesized API routes to Lambda invocations against the AWS Lambda
  * Runtime Interface Emulator (Docker required).
  *
- * Modeled on `sam local start-api` but reusing cdkd's synthesis /
+ * Modeled on `sam local start-api` but reusing cdk-local's synthesis /
  * route-discovery / container plumbing. PR 8a scope:
  *   - REST v1 (AWS::ApiGateway::*) + HTTP API (AWS::ApiGatewayV2::*) +
  *     Function URL (AWS::Lambda::Url).
@@ -494,7 +494,7 @@ async function localStartApiCommand(
     // already resolves `--profile` for cdkd's own CFn / CC API clients).
     // Resolved here so a stack with N Lambdas pays one STS round-trip.
     // SSO temp creds typically last 1h+; long-running `--watch` sessions
-    // outliving the creds need a cdkd restart (auto-refresh deferred,
+    // outliving the creds need a cdk-local restart (auto-refresh deferred,
     // see issue #654).
     const profileCredentials = options.profile
       ? await resolveProfileCredentials(options.profile)
@@ -864,7 +864,7 @@ async function localStartApiCommand(
     // `AWS_ACCESS_KEY_ID` etc. are set, the SDK errors with
     // `CredentialsProviderError: Could not load credentials from
     // any providers`. We populate fake credentials per the
-    // ecs-network.ts metadata-sidecar precedent — cdkd's
+    // ecs-network.ts metadata-sidecar precedent — cdk-local's
     // `@connections` handler doesn't verify SigV4, so the values
     // are opaque.
     //
@@ -2314,7 +2314,7 @@ function forwardAwsEnv(env: Record<string, string>): void {
  * that Lambda — assume-role wins per the existing precedence). SSO
  * temp creds typically last 1h+, so a single resolve is fine for the
  * common dev session; long-running `--watch` sessions that outlive
- * the creds need a cdkd restart (deferred refresh out of scope for
+ * the creds need a cdk-local restart (deferred refresh out of scope for
  * v1, see issue #654).
  */
 export async function resolveProfileCredentials(
@@ -2772,17 +2772,17 @@ async function loadStateForRoutedStacks(
   // Issue #606: route through `createLocalStateProvider` so the same
   // code path drives both `--from-state` (S3) and `--from-cfn-stack`
   // (CFn). One provider PER reachable stack — bare `--from-cfn-stack`
-  // uses the cdkd stack name per routed stack, so the dispatcher needs
+  // uses the host stack name per routed stack, so the dispatcher needs
   // each stack's name at construction time. Each provider is disposed
   // after its `load` call returns so the AWS client tied to that
   // provider doesn't outlive the boot pass.
   //
-  // Reject explicit `--from-cfn-stack <name>` when multiple cdkd stacks
+  // Reject explicit `--from-cfn-stack <name>` when multiple host stacks
   // are routed: the explicit name would apply to every routed stack
   // and silently misresolve `Ref` lookups when logical IDs happen to
   // collide between siblings (see local-state-source.ts for the
   // rationale). Bare `--from-cfn-stack` is safe because each routed
-  // stack uses its own cdkd stack name.
+  // stack uses its own host stack name.
   rejectExplicitCfnStackWithMultipleStacks(options, reachableStackNames.size);
   for (const stackName of reachableStackNames) {
     const stack = stacks.find((s) => s.stackName === stackName);

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -66,7 +66,7 @@ export interface CfnLocalStateProviderOptions {
   /**
    * CFn stack name to read physical IDs / outputs from. Required; the
    * CLI layer resolves the bare-vs-explicit form (`--from-cfn-stack`
-   * with no value → uses the cdkd stack name) before calling the
+   * with no value → uses the host stack name) before calling the
    * provider.
    */
   cfnStackName: string;

--- a/src/local/ecs-service-resolver.ts
+++ b/src/local/ecs-service-resolver.ts
@@ -110,7 +110,7 @@ export interface ResolvedEcsService {
    * HealthCheckGracePeriodSeconds from the template. AWS defaults to 0
    * when the service has no load balancer, 30s with an ALB attached.
    *
-   * **Currently not consumed by the runner.** cdkd's
+   * **Currently not consumed by the runner.** cdk-local's
    * `ecs-service-runner.ts` is exit-code-driven (`docker wait` →
    * `shouldRestart`); there is no health-check polling in v1 because
    * health-check-driven restarts are only meaningful once the local
@@ -333,7 +333,7 @@ function extractServiceConnect(
   const rawServices = cfg['Services'];
   if (!Array.isArray(rawServices) || rawServices.length === 0) {
     // No `Services[]` is valid in AWS — the task still gets the local
-    // Cloud Map DNS resolver but doesn't expose anything itself. cdkd's
+    // Cloud Map DNS resolver but doesn't expose anything itself. cdk-local's
     // local emulation treats it the same way (registry publishes
     // nothing, consumer-side `--add-host` still works).
     return { namespaceName, services: [] };

--- a/src/local/httpv2-service-integration.ts
+++ b/src/local/httpv2-service-integration.ts
@@ -422,7 +422,7 @@ async function dispatchAppConfigGetConfiguration(
   // GetLatestConfiguration via AppConfigData). The legacy operation
   // lives in `@aws-sdk/client-appconfig`, not appconfigdata. We do
   // NOT carry that client in package.json today (not used elsewhere
-  // in cdkd) — surface a clear "package not present" error rather
+  // in cdk-local) — surface a clear "package not present" error rather
   // than depending on it for a single subtype. Adding the dep is a
   // follow-up if real usage emerges.
   void params;

--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -50,7 +50,7 @@ export interface ImageResolutionContext {
     urlSuffix?: string;
   };
   /**
-   * `state.resources` from cdkd's S3 state record for the target stack,
+   * `state.resources` from the host's S3 state record for the target stack,
    * loaded by the CLI command before resolution when `--from-state` is
    * passed. Used to substitute `${<LogicalId>}` against an
    * `AWS::ECR::Repository` and the `Fn::GetAtt` `Arn` / `RepositoryUri`

--- a/src/local/lambda-authorizer.ts
+++ b/src/local/lambda-authorizer.ts
@@ -417,7 +417,7 @@ function parseHttpV2RequestResponse(
  * **within** a single segment, where segments are delimited by `:`
  * (ARN partition / service / region / account) and `/` (path). `**`
  * matches across segment boundaries for callers that need the looser
- * behavior (cdkd-specific extension; no AWS equivalent, useful for
+ * behavior (cdk-local-specific extension; no AWS equivalent, useful for
  * stage-wide rules like `arn:.../prod/**`).
  *
  * Examples:

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -538,7 +538,7 @@ export function extractEphemeralStorageMb(
  *      For IMPORTED repositories (literal acct-id / region + `Ref:
  *      AWS::URLSuffix` + literal repo path) the resolver returns a
  *      complete ECR URI here without state. For SAME-STACK references
- *      the resolver needs cdkd state (`--from-state`) to recover the
+ *      the resolver needs the host's state (`--from-state`) to recover the
  *      repository's account-id / region; without state we surface a
  *      clear error pointing the user at `cdkl invoke --from-state`
  *      / `ContainerImage.fromAsset` / a public-image alternative.

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -5,7 +5,7 @@
  * Two implementations:
  *
  *   - {@link S3LocalStateProvider} (default for `--from-state`) — reads
- *     cdkd's S3 state for stacks deployed via `cdkd deploy`. Same
+ *     the host's S3 state for stacks deployed via `cdkd deploy`. Same
  *     behavior as the pre-issue-#606 code path; the S3 implementation is
  *     a thin wrapper around the existing `loadStateForStack` +
  *     `buildCrossStackResolver` helpers in
@@ -38,7 +38,7 @@ import type { CrossStackResolver } from './state-resolver.js';
 
 /**
  * Result of loading state for a specific (stack, region) pair. The
- * shape is intentionally a strict subset of cdkd's `StackState` so the
+ * shape is intentionally a strict subset of cdk-local's `StackState` so the
  * substituter doesn't depend on schema fields irrelevant to local
  * execution (lock state, version, lastModified, etc.).
  */
@@ -52,7 +52,7 @@ export interface LocalStateRecord {
    */
   resources: Record<string, ResourceState>;
   /**
-   * Stack outputs map. Sourced from cdkd state for the S3 provider and
+   * Stack outputs map. Sourced from the host's state for the S3 provider and
    * from `DescribeStacks.Outputs[]` for the CFn provider. Consumed by
    * `Fn::GetStackOutput` and by the cross-stack resolver when no
    * persistent exports index is available.
@@ -103,7 +103,7 @@ export interface LocalStateProvider {
   load(stackName: string, synthRegion: string | undefined): Promise<LocalStateRecord | undefined>;
   /**
    * Build a cross-stack resolver for `Fn::ImportValue` /
-   * `Fn::GetStackOutput`. The S3 provider reads cdkd's exports index +
+   * `Fn::GetStackOutput`. The S3 provider reads the host's exports index +
    * per-stack state; the CFn provider uses `ListExports` (paginated)
    * for `Fn::ImportValue` and rejects `Fn::GetStackOutput` (cdkd-specific
    * intrinsic — CFn has no equivalent). `consumerRegion` is the

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -1042,7 +1042,7 @@ function discoverHttpApiRoute(
  * (service integration, no Lambda backing). Recognized subtypes
  * become `serviceIntegration` routes the HTTP server dispatches via
  * the SDK adapter table in `httpv2-service-integration.ts`;
- * unrecognized subtypes (typo / future-AWS-subtype-cdkd-doesn't-bundle
+ * unrecognized subtypes (typo / future-AWS-subtype-cdk-local-doesn't-bundle
  * an SDK for) become deferred-501 unsupported routes.
  *
  * `RequestParameters` is the load-bearing field for dispatch — it

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -4,7 +4,7 @@
  *
  * # Scope
  *
- * cdkd's `cdkl start-api` runs API Gateway routes locally. When a
+ * cdk-local's `cdkl start-api` runs API Gateway routes locally. When a
  * route declares `AuthorizationType: 'AWS_IAM'`, AWS-deployed API Gateway
  * validates the request's SigV4 signature against the calling identity's
  * IAM permissions. We can't fully reproduce that locally — IAM policy

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -8,7 +8,7 @@
  * cdk-local has already deployed the stack and the AWS-current physical IDs
  * sit in the cdkd state file.
  *
- * `--from-state` closes that gap: it loads cdkd's S3 state for the target
+ * `--from-state` closes that gap: it loads the host's S3 state for the target
  * stack and substitutes `Ref` / `Fn::GetAtt` / `Fn::Sub` placeholders in
  * the function's `Properties.Environment.Variables` with the deployed
  * values. The result feeds back into the existing
@@ -992,7 +992,7 @@ export interface StateEnvSubstitutionAudit {
  * @param templateEnv  The function's `Properties.Environment.Variables`
  *                     map from the synthesized template, or `undefined`
  *                     when the function has no env vars.
- * @param resources    `state.resources` from cdkd's S3 state file for
+ * @param resources    `state.resources` from the host's S3 state file for
  *                     the function's stack.
  */
 export function substituteEnvVarsFromState(

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -978,7 +978,7 @@ export function buildVtlInput(
     if (jsonBodyParseError && opts?.throwOnParseError) {
       // Issue (#507) item 7: `$input.json(...)` against a non-JSON body
       // surfaces a `VtlEvaluationError` (AWS API Gateway returns
-      // 400 + `{"message": "Invalid JSON request body"}` here; cdkd's
+      // 400 + `{"message": "Invalid JSON request body"}` here; cdk-local's
       // dispatcher catches the error and returns 502 + the template + reason
       // in the body, which is the closest local approximation given that
       // the existing dispatch path treats every VtlEvaluationError as a

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,5 +1,5 @@
 /**
- * Schema versions for cdkd state.json.
+ * Schema versions for the state.json the host writes via cdk-local.
  *
  * - 1 — legacy layout: `s3://{bucket}/cdkd/{stackName}/state.json` (pre PR 1).
  * - 2 — region-prefixed layout: `s3://{bucket}/cdkd/{stackName}/{region}/state.json`.
@@ -50,15 +50,15 @@
  *       what it means and would route a CC-managed resource through
  *       the SDK Provider on update / destroy → silent data corruption
  *       (mid-life provider swap). The bump from 6 to 7 forces a v6
- *       reader to fail with a clear "upgrade cdkd" error instead.
+ *       reader to fail with a clear "upgrade cdk-local" error instead.
  *       v7 writers always emit `provisionedBy` explicitly (`'sdk'` or
  *       `'cc-api'`); resources read from v6 state with the field
  *       absent are treated as `'sdk'` (legacy default) and the next
  *       write persists it explicitly. Layout superset of v6; only the
  *       resource-level shape grew.
  *
- * cdkd readers handle every prior version. Writers always emit
- * `STATE_SCHEMA_VERSION_CURRENT`. An older cdkd binary that only knows an
+ * cdk-local readers handle every prior version. Writers always emit
+ * `STATE_SCHEMA_VERSION_CURRENT`. An older cdk-local binary that only knows an
  * earlier version will fail with a clear error when it encounters a higher
  * version, rather than silently mishandling the new format.
  */
@@ -70,7 +70,7 @@ export const STATE_SCHEMA_VERSION_CURRENT: StateSchemaVersion = 7;
  * Every schema version this binary can read. Writers always emit
  * `STATE_SCHEMA_VERSION_CURRENT`; older versions are accepted for
  * forward-migration, and an unknown / future version triggers an explicit
- * "upgrade cdkd" error in the parser.
+ * "upgrade cdk-local" error in the parser.
  */
 export const STATE_SCHEMA_VERSIONS_READABLE: readonly StateSchemaVersion[] = [1, 2, 3, 4, 5, 6, 7];
 
@@ -89,7 +89,7 @@ export interface StateImportEntry {
   sourceStack: string;
   /**
    * The producer's region. Required so destroy-time strong-ref checks
-   * can scan the producer's exact `state.json` key (cdkd state is keyed
+   * can scan the producer's exact `state.json` key (cdk-local state is keyed
    * by `(stackName, region)` since schema v2).
    */
   sourceRegion: string;
@@ -243,7 +243,7 @@ export interface ResourceState {
    * Which provisioning layer owns this resource (schema v7+, issue
    * [#614](https://github.com/go-to-k/cdkd/issues/614)).
    *
-   * - `'sdk'` — SDK Provider (the cdkd-preferred fast path: direct
+   * - `'sdk'` — SDK Provider (the preferred fast path: direct
    *   synchronous AWS SDK calls per resource type, no polling).
    * - `'cc-api'` — Cloud Control API (the fallback path: async polling
    *   create/update/delete via the unified CloudControlClient). Routed

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -50,17 +50,17 @@
  *       what it means and would route a CC-managed resource through
  *       the SDK Provider on update / destroy → silent data corruption
  *       (mid-life provider swap). The bump from 6 to 7 forces a v6
- *       reader to fail with a clear "upgrade cdk-local" error instead.
+ *       reader to fail with a clear "upgrade the host" error instead.
  *       v7 writers always emit `provisionedBy` explicitly (`'sdk'` or
  *       `'cc-api'`); resources read from v6 state with the field
  *       absent are treated as `'sdk'` (legacy default) and the next
  *       write persists it explicitly. Layout superset of v6; only the
  *       resource-level shape grew.
  *
- * cdk-local readers handle every prior version. Writers always emit
- * `STATE_SCHEMA_VERSION_CURRENT`. An older cdk-local binary that only knows an
- * earlier version will fail with a clear error when it encounters a higher
- * version, rather than silently mishandling the new format.
+ * The cdk-local parser handles every prior version. Writers always emit
+ * `STATE_SCHEMA_VERSION_CURRENT`. An older host binary embedding cdk-local that
+ * only knows an earlier version will fail with a clear error when it encounters
+ * a higher version, rather than silently mishandling the new format.
  */
 export type StateSchemaVersion = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 export const STATE_SCHEMA_VERSION_LEGACY: StateSchemaVersion = 1;
@@ -70,7 +70,7 @@ export const STATE_SCHEMA_VERSION_CURRENT: StateSchemaVersion = 7;
  * Every schema version this binary can read. Writers always emit
  * `STATE_SCHEMA_VERSION_CURRENT`; older versions are accepted for
  * forward-migration, and an unknown / future version triggers an explicit
- * "upgrade cdk-local" error in the parser.
+ * "upgrade the host" error in the parser.
  */
 export const STATE_SCHEMA_VERSIONS_READABLE: readonly StateSchemaVersion[] = [1, 2, 3, 4, 5, 6, 7];
 

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -1,7 +1,7 @@
 import { getLogger } from './logger.js';
 
 /**
- * Base error class for cdkd
+ * Base error class for cdk-local
  */
 export class CdkdError extends Error {
   public readonly code: string;
@@ -586,7 +586,7 @@ export class MacroExpansionError extends CdkdError {
 }
 
 /**
- * Check if error is a cdkd error
+ * Check if error is a cdk-local error
  */
 export function isCdkdError(error: unknown): error is CdkdError {
   return error instanceof CdkdError;
@@ -638,7 +638,7 @@ export function handleError(error: unknown): never {
   // field (PartialFailureError + ResourceUpdateNotSupportedError +
   // StackHasActiveImportsError + LocalMigrateError + MacroExpansionError
   // etc.). Falling back to 1 covers `CdkdError` subclasses with no
-  // override and every non-cdkd error.
+  // override and every non-cdk-local error.
   const customExitCode =
     error instanceof CdkdError ? (error as CdkdError & { exitCode?: number }).exitCode : undefined;
   const exitCode = typeof customExitCode === 'number' ? customExitCode : 1;

--- a/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
+++ b/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
@@ -62,7 +62,7 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     // overlay.
     const namespace = new cdk.aws_servicediscovery.CfnPrivateDnsNamespace(this, 'Ns', {
       name: 'cdkl-sc.local',
-      // CfnPrivateDnsNamespace requires `Vpc` in real AWS, but cdkd
+      // CfnPrivateDnsNamespace requires `Vpc` in real AWS, but cdk-local
       // never sends this — local emulation skips the field on every
       // SDK call. CFn property-required validation is bypassed because
       // CDK only emits the field when assigned.

--- a/tests/integration/local-ecs-service-connect/verify.sh
+++ b/tests/integration/local-ecs-service-connect/verify.sh
@@ -18,7 +18,7 @@
 #      OMIT `hostPort` (cdk-local would otherwise default it to
 #      `containerPort` 8080 and collide on the 2nd replica). Both
 #      replicas reach `orders` via the docker `--add-host` overlay
-#      populated from cdkd's shared registry.
+#      populated from cdk-local's shared registry.
 #
 # Asserts:
 #   - The boot banner reports both services running.
@@ -284,7 +284,7 @@ if ! grep -q "HELLO_ORDERS" <<<"${RESPONSE}"; then
 fi
 echo "    OK: frontend reached orders via the docker --add-host overlay"
 
-echo "==> Sending SIGTERM to cdkd ($(echo $CDKL_PID))"
+echo "==> Sending SIGTERM to cdk-local ($(echo $CDKL_PID))"
 kill -TERM "${CDKL_PID}"
 
 echo "==> Waiting for cdk-local to exit (up to 60s)"

--- a/tests/integration/local-invoke-buildkit/docker/Dockerfile
+++ b/tests/integration/local-invoke-buildkit/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Comprehensive BuildKit-only Dockerfile used by the local-invoke-buildkit
 # integ test. Exercises every BuildKit feature that this PR newly forwards
-# via cdkd's docker build path:
+# via cdk-local's docker build path:
 #   - `# syntax=docker/dockerfile:1` parser directive
 #   - Multi-stage with named stages + `--target` to pick a non-final stage
 #   - `ARG` populated by `--build-arg` from CDK's `dockerBuildArgs`
@@ -10,7 +10,7 @@
 #   - `RUN --mount=type=secret` populated by `--secret` from CDK's
 #     `dockerBuildSecrets`
 #
-# Pre-PR cdkd would fail this build silently (maxBuffer 50 MB) on the
+# Pre-PR cdk-local would fail this build silently (maxBuffer 50 MB) on the
 # BuildKit progress stream OR reject `dockerBuildSecrets` at the type
 # layer. Both paths now work.
 

--- a/tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts
+++ b/tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts
@@ -10,7 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * Fixture stack for the comprehensive BuildKit-Dockerfile regression integ.
  *
  * `BuildkitHandler` is built from a Dockerfile that exercises EVERY
- * BuildKit feature this PR newly forwards through cdkd's docker build
+ * BuildKit feature this PR newly forwards through cdk-local's docker build
  * path: `# syntax=docker/dockerfile:1`, multi-stage with `--target`,
  * `ARG` via `--build-arg`, heredocs (`RUN <<EOF`), `RUN --mount=type=cache`,
  * AND `RUN --mount=type=secret` via `--secret`.
@@ -36,7 +36,7 @@ export class LocalInvokeBuildkitStack extends cdk.Stack {
         buildArgs: {
           GREETING_BUILD_ARG: 'compiled-in-from-cdk',
         },
-        // BuildKit `--secret` via cdkd's new `dockerBuildSecrets` forwarding.
+        // BuildKit `--secret` via cdk-local's new `dockerBuildSecrets` forwarding.
         // The Dockerfile's `RUN --mount=type=secret,id=mysecret` reads the
         // file at /run/secrets/mysecret during build only.
         buildSecrets: {

--- a/tests/integration/local-invoke-buildkit/package.json
+++ b/tests/integration/local-invoke-buildkit/package.json
@@ -2,7 +2,7 @@
   "name": "cdkl-integ-local-invoke-buildkit",
   "version": "1.0.0",
   "private": true,
-  "description": "Integration test fixture for cdkd against a Dockerfile that uses BuildKit-only features (# syntax=docker/dockerfile:1 + heredocs + RUN --mount=type=cache)",
+  "description": "Integration test fixture for cdk-local against a Dockerfile that uses BuildKit-only features (# syntax=docker/dockerfile:1 + heredocs + RUN --mount=type=cache)",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w"

--- a/tests/integration/local-invoke-buildkit/verify.sh
+++ b/tests/integration/local-invoke-buildkit/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # verify.sh — BuildKit-Dockerfile regression integ test.
 #
-# Exercises every BuildKit feature this PR newly forwards via cdkd's
+# Exercises every BuildKit feature this PR newly forwards via cdk-local's
 # docker build path, in ONE build:
 #   1. `# syntax=docker/dockerfile:1`
 #   2. Multi-stage with `--target final` (DockerImageCode.fromImageAsset.target)
@@ -13,7 +13,7 @@
 #
 # Pre-PR cdk-local would either silently kill the build with maxBuffer 50 MB
 # on BuildKit progress, OR reject `buildSecrets` at the type layer
-# because cdkd's `DockerImageAssetSource` didn't surface the field.
+# because cdk-local's `DockerImageAssetSource` didn't surface the field.
 # Both paths now work.
 #
 # Run via `/run-integ local-invoke-buildkit` (recommended) or directly:
@@ -130,7 +130,7 @@ rm -f /tmp/cdkl-buildkit-1.log /tmp/cdkl-buildkit-3.log
 # Cleanup: remove the cdkl-built image(s) so CI hosts don't accumulate
 # multi-stage builder layers across iterations. The integ owns the
 # `cdkl-invoke-*` namespace and the run-time docker containers are
-# already removed by `docker run --rm` + cdkd's removeContainer().
+# already removed by `docker run --rm` + cdk-local's removeContainer().
 echo "==> Cleanup: removing cdkl-built images"
 docker image ls --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' | while read -r tag; do
   docker image rm -f "${tag}" >/dev/null 2>&1 || true

--- a/tests/integration/local-invoke-container/verify.sh
+++ b/tests/integration/local-invoke-container/verify.sh
@@ -75,7 +75,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 
 # Test 4 — --no-build (closes #233): the previous tests already built the
 # image under the deterministic local tag, so a 4th invocation with
-# --no-build should skip the rebuild and reuse the cached tag. cdkd
+# --no-build should skip the rebuild and reuse the cached tag. cdk-local
 # logger output goes to stdout (not stderr), so we capture combined
 # stdout+stderr to inspect the build-vs-skip log lines, and rely on
 # the JSON response always being on the LAST stdout line for the

--- a/tests/integration/local-invoke-dotnet/lib/local-invoke-dotnet-stack.ts
+++ b/tests/integration/local-invoke-dotnet/lib/local-invoke-dotnet-stack.ts
@@ -19,7 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     .NET SDK container before invoking `cdk-local synth` so the host
  *     doesn't need a .NET SDK installed.
  *   - `InlineHandler` — `CfnFunction` with `Code: { ZipFile: ... }` and
- *     `runtime: dotnet8`. cdkd's local invoke must reject this with the
+ *     `runtime: dotnet8`. cdk-local's local invoke must reject this with the
  *     "use Code.fromAsset" message — .NET's Handler shape names a
  *     compiled assembly (`Assembly::Namespace.Class::Method`), which
  *     can't be expressed as a single source file. Built via the L1

--- a/tests/integration/local-invoke-dotnet/verify.sh
+++ b/tests/integration/local-invoke-dotnet/verify.sh
@@ -53,7 +53,7 @@ fi
 
 # Test 1 — asset-backed .NET Lambda echoes event + env var.
 # .NET cold-start in the local container is slow (~5-10s on Apple
-# Silicon emulating x86_64) — the function's Timeout: 30 + cdkd's
+# Silicon emulating x86_64) — the function's Timeout: 30 + cdk-local's
 # `invokeTimeoutMs = max(30s, 2 * fn.timeout)` = 60s provides headroom.
 echo "==> [1/3] Invoking EchoHandler with default empty event"
 RESULT_1=$(${CDKL} invoke CdkLocalInvokeDotnetFixture/EchoHandler --no-pull 2>/dev/null | tail -1)

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/consumer-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/consumer-stack.ts
@@ -23,7 +23,7 @@ export interface ConsumerStackProps extends cdk.StackProps {
  * the env var back so the integ can assert two things:
  *
  *   1. Baseline (no `--from-cfn-stack`): `SHARED_VALUE` is `"unset"`
- *      because cdkd's local-invoke default behavior drops
+ *      because cdk-local's local-invoke default behavior drops
  *      intrinsic-valued env vars (warn-and-drop).
  *   2. With `--from-cfn-stack`: `SHARED_VALUE` equals the producer's
  *      deployed parameter name, proving `Fn::ImportValue` substitution

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -18,7 +18,7 @@
 # (read via `cloudformation:ListExports`, paginated + memoized).
 #
 # Steps:
-#   1. install + build cdkd (root) + install fixture deps + docker pull
+#   1. install + build cdk-local (root) + install fixture deps + docker pull
 #   2. pre-flight orphan scan for BOTH stacks
 #   3. cdk deploy (producer + consumer, in that order — cdk handles the
 #      ordering automatically from `addDependency`)
@@ -56,7 +56,7 @@ CLI="node ${REPO_ROOT}/dist/cli.js"
 
 echo "[verify] region=${REGION} producer=${PRODUCER_STACK} consumer=${CONSUMER_STACK} export=${EXPORT_NAME}"
 
-echo "[verify] step 1a: install + build cdkd"
+echo "[verify] step 1a: install + build cdk-local"
 (cd "${REPO_ROOT}" && pnpm install)
 (cd "${REPO_ROOT}" && vp run build)
 
@@ -99,7 +99,7 @@ for stack in "${PRODUCER_STACK}" "${CONSUMER_STACK}"; do
   fi
 done
 
-echo "[verify] step 3: cdk deploy producer + consumer (upstream CDK CLI, NOT cdkd)"
+echo "[verify] step 3: cdk deploy producer + consumer (upstream CDK CLI)"
 # CDK CLI deploys in dependency order: producer first, consumer after,
 # so the export exists before the consumer's Fn::ImportValue resolves.
 #
@@ -170,7 +170,7 @@ echo "${RESULT_BASELINE}" | grep -q '"staticValue":"always-the-same"' || {
 }
 
 echo "[verify] step 6: cdkl invoke --from-cfn-stack — expect SHARED_VALUE=${DEPLOYED_VALUE}"
-# Bare --from-cfn-stack uses the cdkd stack name verbatim as the CFn
+# Bare --from-cfn-stack uses the host stack name verbatim as the CFn
 # stack name. The consumer stack carries the Fn::ImportValue, so we
 # point at the consumer; CfnLocalStateProvider then calls list-exports
 # (across the account, not scoped to a specific stack) to resolve the

--- a/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
@@ -14,7 +14,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * set to `Ref: MyTable` (an intrinsic). Without `--from-cfn-stack` the
  * local invoke would drop it (same warn-and-drop semantics as the
  * `local-invoke-from-state` fixture). With `--from-cfn-stack`, after
- * the CDK app is deployed via the upstream `cdk deploy` (NOT cdkd),
+ * the CDK app is deployed via the upstream `cdk deploy` (not a host CLI like cdkd),
  * the deployed table name is read from CloudFormation via
  * `DescribeStackResources` and substituted, so the Lambda echoes the
  * literal physical table name back.

--- a/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
@@ -14,8 +14,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * set to `Ref: MyTable` (an intrinsic). Without `--from-cfn-stack` the
  * local invoke would drop it (same warn-and-drop semantics as the
  * `local-invoke-from-state` fixture). With `--from-cfn-stack`, after
- * the CDK app is deployed via the upstream `cdk deploy` (not a host CLI like cdkd),
- * the deployed table name is read from CloudFormation via
+ * the CDK app is deployed via the upstream `cdk deploy` (the CDK CLI, not
+ * a host CLI like cdkd), the deployed table name is read from CloudFormation via
  * `DescribeStackResources` and substituted, so the Lambda echoes the
  * literal physical table name back.
  *

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -3,16 +3,17 @@
 # End-to-end real-AWS validation for `cdkl invoke --from-cfn-stack`
 # (issue #606).
 #
-# Why this exists: the existing `local-invoke-from-state` integ exercises
-# the cdkd-deployed path (cdkd deploy + cdkd state read). Issue #606 adds
-# a parallel path for CDK apps deployed via the upstream CDK CLI (cdk
-# deploy → CloudFormation). The only way to exercise that round-trip is
-# to deploy the fixture via `cdk deploy` (NOT `cdkd deploy`) and then
-# invoke locally with `--from-cfn-stack`, which reads physical IDs via
-# `cloudformation:DescribeStackResources` instead of cdkd's S3 state.
+# Why this exists: the host-deployed path (e.g. cdkd's `--from-state`,
+# which reads the host's S3 state) covers stacks deployed via the host
+# CLI. Issue #606 adds a parallel path for CDK apps deployed via the
+# upstream CDK CLI (cdk deploy → CloudFormation). The only way to
+# exercise that round-trip is to deploy the fixture via `cdk deploy` and
+# then invoke locally with `--from-cfn-stack`, which reads physical IDs
+# via `cloudformation:DescribeStackResources` instead of a host-managed
+# state store.
 #
 # Steps:
-#   1. install + build cdkd (root) + install fixture deps + docker pull
+#   1. install + build cdk-local (root) + install fixture deps + docker pull
 #   2. cdk deploy CdkLocalInvokeFromCfnStackFixture (upstream CDK CLI)
 #   3. baseline: cdkl invoke (no --from-cfn-stack) — assert
 #      TABLE_NAME comes through as "unset" (env var dropped because it's
@@ -20,7 +21,7 @@
 #   4. issue #606: cdkl invoke --from-cfn-stack — assert TABLE_NAME
 #      is the actual deployed DynamoDB table name, and STATIC_VALUE still
 #      passes through unchanged.
-#   5. cdk destroy --force (NOT cdkd destroy — the fixture lives in CFn)
+#   5. cdk destroy --force (the fixture lives in CFn, not in a host state store)
 #
 # Run via `/run-integ local-invoke-from-cfn-stack` (recommended) or directly:
 #
@@ -43,7 +44,7 @@ CLI="node ${REPO_ROOT}/dist/cli.js"
 
 echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed)"
 
-echo "[verify] step 1a: install + build cdkd"
+echo "[verify] step 1a: install + build cdk-local"
 (cd "${REPO_ROOT}" && pnpm install)
 (cd "${REPO_ROOT}" && vp run build)
 
@@ -79,9 +80,9 @@ if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION
   exit 1
 fi
 
-echo "[verify] step 3: cdk deploy (upstream CDK CLI, NOT cdkd)"
+echo "[verify] step 3: cdk deploy (upstream CDK CLI)"
 # The fixture deliberately uses upstream `cdk deploy` so the resulting
-# stack is owned by CloudFormation, not cdkd. The cdk CLI is supplied by
+# stack is owned by CloudFormation, not by any host state store. The cdk CLI is supplied by
 # vp's globally-managed environment (same pattern as
 # import-nested-stack); no per-fixture install round-trip needed since
 # Node's parent-dir resolution finds aws-cdk-lib from the repo root.
@@ -150,7 +151,7 @@ echo "${RESULT_BASELINE}" | grep -q '"staticValue":"always-the-same"' || {
 }
 
 echo "[verify] step 6: cdkl invoke --from-cfn-stack — expect TABLE_NAME=${DEPLOYED_TABLE}"
-# Bare --from-cfn-stack uses the cdkd stack name verbatim as the CFn
+# Bare --from-cfn-stack uses the host stack name verbatim as the CFn
 # stack name — which matches here because the CDK app exports the same
 # name to both.
 RESULT_FROM_CFN=$(invoke_with_retry "${STACK}/EchoTableHandler" --from-cfn-stack --no-pull)

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -3,14 +3,13 @@
 # End-to-end real-AWS validation for `cdkl invoke --from-cfn-stack`
 # (issue #606).
 #
-# Why this exists: the host-deployed path (e.g. cdkd's `--from-state`,
-# which reads the host's S3 state) covers stacks deployed via the host
-# CLI. Issue #606 adds a parallel path for CDK apps deployed via the
-# upstream CDK CLI (cdk deploy → CloudFormation). The only way to
-# exercise that round-trip is to deploy the fixture via `cdk deploy` and
-# then invoke locally with `--from-cfn-stack`, which reads physical IDs
-# via `cloudformation:DescribeStackResources` instead of a host-managed
-# state store.
+# Why this exists: the host's S3-state path (e.g. cdkd's `--from-state`)
+# covers stacks deployed via the host CLI. Issue #606 adds a parallel
+# path for CDK apps deployed via the upstream CDK CLI (cdk deploy →
+# CloudFormation). The only way to exercise that round-trip is to deploy
+# the fixture via `cdk deploy` and then invoke locally with
+# `--from-cfn-stack`, which reads physical IDs via
+# `cloudformation:DescribeStackResources` instead of host-managed state.
 #
 # Steps:
 #   1. install + build cdk-local (root) + install fixture deps + docker pull

--- a/tests/integration/local-invoke-java/lib/local-invoke-java-stack.ts
+++ b/tests/integration/local-invoke-java/lib/local-invoke-java-stack.ts
@@ -18,7 +18,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     compiles it inside a Docker JDK container before invoking
  *     `cdk-local synth` so the host doesn't need a JDK installed.
  *   - `InlineHandler` — `CfnFunction` with `Code: { ZipFile: ... }` and
- *     `runtime: java17`. cdkd's local invoke must reject this with the
+ *     `runtime: java17`. cdk-local's local invoke must reject this with the
  *     "use Code.fromAsset" message — Java's Handler shape names a
  *     compiled class, which can't be expressed as a single source file.
  *     Built via the L1 escape hatch because `lambda.Code.fromInline`

--- a/tests/integration/local-invoke-java/verify.sh
+++ b/tests/integration/local-invoke-java/verify.sh
@@ -52,7 +52,7 @@ fi
 
 # Test 1 — asset-backed Java Lambda echoes event + env var.
 # Java cold-start in the local container is slow (~10-15s) — the
-# function's Timeout: 30 + cdkd's `invokeTimeoutMs = max(30s, 2 * fn.timeout)`
+# function's Timeout: 30 + cdk-local's `invokeTimeoutMs = max(30s, 2 * fn.timeout)`
 # = 60s provides ample headroom.
 echo "==> [1/3] Invoking EchoHandler with default empty event"
 RESULT_1=$(${CDKL} invoke CdkLocalInvokeJavaFixture/EchoHandler --no-pull 2>/dev/null | tail -1)

--- a/tests/integration/local-invoke-layers/verify.sh
+++ b/tests/integration/local-invoke-layers/verify.sh
@@ -87,7 +87,7 @@ echo "${RESULT_2}" | grep -q '"counter":"count=42"' || {
 }
 
 # Test 3 — startup banner mentions the 3 layer mounts. Combines
-# stdout + stderr (cdkd's `logger.info` writes to stdout via
+# stdout + stderr (cdk-local's `logger.info` writes to stdout via
 # `console.info`; we just want to verify the layer-count line appears
 # somewhere in the cdk-local output) so users know the layer wiring fired.
 echo "==> [3/3] Verifying cdk-local logs the layer count"

--- a/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
+++ b/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
@@ -19,7 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     Runtime API. Architecture pinned to `x86_64` so the linux/amd64
  *     bootstrap built in CI matches the base image's default platform.
  *   - `ProvidedAl2023InlineHandler` — `CfnFunction` with `Code: { ZipFile }`
- *     and `runtime: provided.al2023`. cdkd's local invoke must reject
+ *     and `runtime: provided.al2023`. cdk-local's local invoke must reject
  *     with the "use Code.fromAsset" message — `provided.*` runtimes ship
  *     arbitrary native binaries that can't be expressed as inline source.
  *   - `ProvidedAl2InlineHandler` — same as above but `runtime: provided.al2`.
@@ -30,7 +30,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     CfnFunction is the L1 escape hatch because `lambda.Runtime.GO_1_X`
  *     still exists in CDK but our CDK lib version may or may not refuse
  *     it at synth time depending on CDK release; we want the rejection
- *     to come from cdkd, not the construct.
+ *     to come from cdk-local, not the construct.
  *
  * No AWS deploy required — the integ runs against the synthesized
  * cdk.out only, mirroring the other local-invoke fixtures.

--- a/tests/integration/local-invoke-ruby/lib/local-invoke-ruby-stack.ts
+++ b/tests/integration/local-invoke-ruby/lib/local-invoke-ruby-stack.ts
@@ -19,7 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     directly (the L2 `lambda.Code.fromInline` construct refuses Ruby
  *     at synth time even though AWS Lambda itself accepts it; using the
  *     L1 escape hatch bypasses the construct-side guard). Exercises
- *     cdkd's inline-code materializer with the `.rb` extension.
+ *     cdk-local's inline-code materializer with the `.rb` extension.
  *
  * No AWS deploy required — the integ runs against the synthesized
  * cdk.out only, mirroring `tests/integration/local-invoke-python/`.

--- a/tests/integration/local-run-task-awsvpc/lib/local-run-task-awsvpc-stack.ts
+++ b/tests/integration/local-run-task-awsvpc/lib/local-run-task-awsvpc-stack.ts
@@ -16,7 +16,7 @@ import { Construct } from 'constructs';
  * that acceptance + the warn + that the container actually boots and
  * serves on the bridge fallback.
  *
- * A non-privileged port (18080) is used so the host-port publish (cdkd
+ * A non-privileged port (18080) is used so the host-port publish (cdk-local
  * publishes container ports for `run-task`) does not need to bind the
  * privileged port 80. `awsvpc` requires `hostPort == containerPort` (or
  * omitted), so `hostPort` is left implicit and cdk-local defaults it to
@@ -37,7 +37,7 @@ export class LocalRunTaskAwsvpcStack extends cdk.Stack {
       // (`cdkl-cdkl-run-task-awsvpc-web-<rand>`) and
       // verify.sh can filter `docker ps` on it.
       family: 'cdkl-run-task-awsvpc',
-      // The whole point of the fixture: NetworkMode awsvpc, which cdkd
+      // The whole point of the fixture: NetworkMode awsvpc, which cdk-local
       // maps to a docker bridge network locally with a warn (#461).
       networkMode: ecs.NetworkMode.AWS_VPC,
     });

--- a/tests/integration/local-start-api-container/verify.sh
+++ b/tests/integration/local-start-api-container/verify.sh
@@ -142,7 +142,7 @@ curl_assert() {
 
 echo "==> Smoke-testing route via curl"
 # fromContainer: true is the marker the app.js emits — verifies the
-# request reached the container Lambda (NOT a 5xx surfaced by cdkd's
+# request reached the container Lambda (NOT a 5xx surfaced by cdk-local's
 # own error handling), AND that the env-var GREETING=hello passed in
 # via the CDK environment block reached the runtime.
 curl_assert "GET / (container Lambda)" "http://127.0.0.1:${PORT_HTTP}/" '"fromContainer":true'

--- a/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
@@ -20,7 +20,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *
  *   - `GET /mock-200` — MOCK integration with a request template that
  *     selects `{"statusCode": 200}` and a response template that
- *     returns `{"source":"mock"}`. Asserts cdkd's MOCK dispatcher
+ *     returns `{"source":"mock"}`. Asserts cdk-local's MOCK dispatcher
  *     (VTL evaluation against an empty input) round-trips correctly.
  *
  *   - `GET /mock-404` — MOCK integration with a request template that

--- a/tests/integration/local-start-api-websocket/lib/stack.ts
+++ b/tests/integration/local-start-api-websocket/lib/stack.ts
@@ -64,7 +64,7 @@ export class LocalStartApiWebSocketStack extends cdk.Stack {
 
     // Per-route integrations. CDK's CfnIntegration emits the canonical
     // `Fn::Join: ['', ['arn:...:lambda:path/2015-03-31/functions/', <Fn::GetAtt Arn>, '/invocations']]`
-    // IntegrationUri shape that cdkd's `intrinsic-lambda-arn.ts` parses.
+    // IntegrationUri shape that cdk-local's `intrinsic-lambda-arn.ts` parses.
     const region = cdk.Stack.of(this).region;
     function makeIntegration(scope: Construct, id: string, fn: lambda.Function): apigwv2.CfnIntegration {
       return new apigwv2.CfnIntegration(scope, id, {

--- a/tests/integration/local-start-api/lib/local-start-api-stack.ts
+++ b/tests/integration/local-start-api/lib/local-start-api-stack.ts
@@ -40,7 +40,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     returns 501 + `reason` body without invoking any Lambda.
  *   - REST v1:     GET /v1/cross-stack-auth (CUSTOM authorizer whose
  *     AuthorizerUri is overridden via `addPropertyOverride` to a
- *     cross-stack-shape `Fn::Sub: '${ImportedAuthFn.Arn}'` that cdkd
+ *     cross-stack-shape `Fn::Sub: '${ImportedAuthFn.Arn}'` that cdk-local
  *     cannot resolve locally) — exercises the authorizer-Lambda-Arn
  *     deferred-501 path added in issue #431. cdk-local boots successfully
  *     with the authorizer-attach failure deferred to request time;
@@ -164,7 +164,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // to deferred-501; post-#505 HTTP_PROXY is first-class so the route
     // started forwarding to example.com (404). Now we use an integration
     // with `Integration.Type: 'AWS'` and a non-Lambda service URI (S3) —
-    // cdkd's REST v1 dispatcher detects the non-`:lambda:path/` marker
+    // cdk-local's REST v1 dispatcher detects the non-`:lambda:path/` marker
     // and surfaces deferred-501 ("non-Lambda service ... not emulated
     // locally in cdk-local v1"). verify.sh asserts the 501 path.
     const unsupported = v1.addResource('unsupported');
@@ -173,7 +173,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // type out of the box, so we use `addPropertyOverride` on the
     // synthesized Method's Integration sub-resource. This produces a CFn
     // `Integration: { Type: 'AWS', Uri: 'arn:aws:apigateway:...:s3:path/...' }`
-    // shape cdkd's REST v1 classifier rejects with the non-Lambda hint.
+    // shape cdk-local's REST v1 classifier rejects with the non-Lambda hint.
     (unsupportedMethod.node.defaultChild as apigw.CfnMethod).addPropertyOverride('Integration', {
       Type: 'AWS',
       IntegrationHttpMethod: 'GET',
@@ -189,7 +189,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // REQUEST authorizer pointing at a same-stack Lambda, then override
     // its synthesized `AuthorizerUri` to a cross-stack-shape
     // `Fn::Sub: '${ImportedAuthFn.Arn}'` that cdk-local cannot resolve
-    // locally. cdkd's authorizer-resolver hits the unresolvable Arn,
+    // locally. cdk-local's authorizer-resolver hits the unresolvable Arn,
     // flips the route to deferred-error unsupported, boot continues,
     // HTTP 501 + reason at request time. The L1 override pattern lets
     // us fixture this without spinning up a separate stack.
@@ -312,7 +312,7 @@ export class LocalStartApiStack extends cdk.Stack {
           // context is plumbed into the parameter-mapping context (#502).
           // The SDK call will fail (missing queue) but the resolved
           // MessageAttributes value rides in on the request so verify.sh
-          // can grep cdkd's log for the substituted value.
+          // can grep cdk-local's log for the substituted value.
           MessageAttributes: cdk.Fn.sub(
             JSON.stringify({
               caller: {
@@ -342,7 +342,7 @@ export class LocalStartApiStack extends cdk.Stack {
     urlHandler.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE });
 
     // Streaming Function URL — exercises the RESPONSE_STREAM invoke mode
-    // path added in #467. cdkd's local server detects InvokeMode and
+    // path added in #467. cdk-local's local server detects InvokeMode and
     // routes the request through invokeRieStreaming(), parses the JSON
     // prelude carrying status + headers, and pipes the body chunks to
     // the HTTP client with `Transfer-Encoding: chunked`. The handler

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -249,7 +249,7 @@ curl_assert "Function URL fallback" "http://127.0.0.1:${PORT_FNURL}/url-only/pin
 # buffers every `responseStream.write(...)` call into one response that
 # arrives at the HTTP client as a single block. This is a RIE limitation
 # (verified empirically against the v1.0 RIE shipped in the base image
-# on 2026-05-22); cdkd's `invokeRieStreaming` correctly parses the
+# on 2026-05-22); cdk-local's `invokeRieStreaming` correctly parses the
 # streaming protocol and pipes the body bytes with `Transfer-Encoding:
 # chunked`, but real incremental delivery only manifests against the
 # deployed Lambda runtime. The integ asserts the protocol shape, not
@@ -293,7 +293,7 @@ for i in 0 1 2 3 4; do
   fi
 done
 # Protocol-shape audit: the response body must NOT contain the literal
-# bytes of the 8-NULL separator — that would mean cdkd's prelude parser
+# bytes of the 8-NULL separator — that would mean cdk-local's prelude parser
 # leaked separator bytes into the body. We grep `chunk-` instead of a
 # binary NULL match because curl's `-i` output is rendered for
 # terminals and may mask NULs; the indirect signal is that the body
@@ -400,7 +400,7 @@ curl_assert "GET /protected (allow)" \
 
 # REST v1 MOCK CORS preflight: the `defaultCorsPreflightOptions` on
 # MyRestApi synthesizes an OPTIONS Method with a MOCK integration on
-# every resource. cdkd's discovery layer captures the literal
+# every resource. cdk-local's discovery layer captures the literal
 # `method.response.header.Access-Control-Allow-*` values from
 # `IntegrationResponses[0].ResponseParameters`; the HTTP server returns
 # them directly on OPTIONS (no Lambda invocation, no VTL evaluation).
@@ -446,7 +446,7 @@ echo "    [GET /v1/unsupported (501)] OK"
 
 # Issue #431: authorizer Lambda Arn unresolvable. The route's
 # AuthorizerUri was overridden in the fixture to a cross-stack-shape
-# Fn::Sub the resolver cannot pin down. cdkd's authorizer-resolver
+# Fn::Sub the resolver cannot pin down. cdk-local's authorizer-resolver
 # flips the route to deferred-error unsupported at boot; the HTTP
 # server returns 501 + reason at request time. The authorizer Lambda
 # is never invoked.

--- a/tests/integration/local-start-service/lib/local-start-service-stack.ts
+++ b/tests/integration/local-start-service/lib/local-start-service-stack.ts
@@ -7,7 +7,7 @@ import { Construct } from 'constructs';
  *
  * Spins up an `AWS::ECS::Service` with DesiredCount=2 backed by a
  * minimal busybox task definition that loops printing a heartbeat. The
- * service runs indefinitely; the integ harness boots cdkd, asserts the
+ * service runs indefinitely; the integ harness boots cdk-local, asserts the
  * 2 replicas are running via `docker ps`, then sends SIGTERM and
  * asserts every container + network + sidecar is cleaned up.
  *


### PR DESCRIPTION
## Summary

- Sweep stale `cdkd` references in cdk-local's JSDoc / inline comments / integ `verify.sh` files. cdk-local was extracted from cdkd's `src/local/**` so the internal docs still pretended cdk-local IS cdkd; this PR removes the cdkd-isms where the described behavior actually lives in cdk-local.
- Folds in the two `tests/integration/local-invoke-from-cfn-stack*/verify.sh` files that PR #34's surgical fix deliberately left alone (handover callout — Phase 3 prep).
- No behavior change. 89 lines changed across 39 files; the touched lines are purely JSDoc / shell comments / TypeScript comments.

## Rules applied

KEEP:
- `cdkd#NNN` cross-repo issue refs, `github.com/go-to-k/cdkd` URLs.
- Host CLI command literals (`cdkd deploy` / `cdkd destroy` / `cdkd state list` / etc.) — they accurately name the cdkd host's CLI surface.
- S3 key path literals (`cdkd/{stackName}/...`) — literal prefix the host writes.
- User-facing error message strings — appear in the host's CLI output.
- Class identifiers (`CdkdError`, `isCdkdError`) — internal-name refactor out of scope.

CHANGE:
- `cdkd's <thing in cdk-local>` → `cdk-local's <thing>` (logger, prelude parser, discovery layer, authorizer-resolver, docker build path, etc.).
- `Base error class for cdkd` → `Base error class for cdk-local`.
- `cdkd-specific extension` → `cdk-local-specific extension` (where the extension lives in cdk-local).
- `cdkd readers` / `upgrade cdkd` (schema-parser context) → `cdk-local readers` / `upgrade cdk-local` — the parser definition lives in cdk-local.
- Generic `cdkd stack name` → `host stack name`.
- `build cdkd` (in verify.sh referring to the local repo build) → `build cdk-local`.
- `cdk deploy (NOT cdkd)` qualifier in verify.sh → drop the qualifier (the comment was contrasting cdk CLI vs the cdkd host's CLI, but the post-`--from-cfn-stack` framing is host-agnostic).

## Test plan

- [x] `vp run check` (typecheck + lint + format) passes
- [x] `vp run build` passes
- [x] `vp run test` — 101 unit tests pass
- [x] No behavior change: every edit is JSDoc / `#`-prefixed shell comment / `//`-prefixed TS comment
- [x] Spot-checked `tests/integration/local-invoke-from-cfn-stack/verify.sh` (heaviest rewrite — 13 lines reframed around host-deployed vs CDK-deployed framing); reads cleanly
