### PR TITLE
chore(infra): add .mise.toml pinning markgate 0.3.3 + vp 0.1.20

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,14 @@
+[tools]
+"ubi:go-to-k/markgate" = "0.3.3"
+
+[tools."http:vp"]
+version = "0.1.20"
+strip_components = 1
+
+[tools."http:vp".platforms]
+macos-arm64 = { url = "https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-darwin-arm64/-/vite-plus-cli-darwin-arm64-{{version}}.tgz" }
+macos-x64 = { url = "https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-darwin-x64/-/vite-plus-cli-darwin-x64-{{version}}.tgz" }
+linux-arm64 = { url = "https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-linux-arm64-gnu/-/vite-plus-cli-linux-arm64-gnu-{{version}}.tgz" }
+linux-x64 = { url = "https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-linux-x64-gnu/-/vite-plus-cli-linux-x64-gnu-{{version}}.tgz" }
+windows-arm64 = { url = "https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-win32-arm64-msvc/-/vite-plus-cli-win32-arm64-msvc-{{version}}.tgz" }
+windows-x64 = { url = "https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-win32-x64-msvc/-/vite-plus-cli-win32-x64-msvc-{{version}}.tgz" }


### PR DESCRIPTION
## Summary

cdkd has a `.mise.toml` that pins the two CLI dependencies all the markgate gate hooks and the build / test skills depend on. cdk-local was missing this file — closing the gap.

```toml
[tools]
"ubi:go-to-k/markgate" = "0.3.3"

[tools."http:vp"]
version = "0.1.20"
strip_components = 1

[tools."http:vp".platforms]
# (6 platform URL templates: macos-arm64 / macos-x64 / linux-arm64 / linux-x64 / windows-arm64 / windows-x64)
```

## Why it matters

Without `.mise.toml`:

- The 4 markgate gate hooks (`check-gate.sh` / `verify-pr-gate.sh` / `pr-review-gate.sh` / `integ-gate.sh`) all run `mise exec -- markgate verify <gate>`. They fall back to PATH `markgate` when `mise exec` finds nothing — and on a fresh contributor's machine, that's nothing, so every gate prints `Blocked by <gate>: markgate is not installed. Run 'mise install' at the repo root.`
- Even with `markgate` on PATH via homebrew or similar, version drift across contributors risks marker-schema mismatches (markgate 0.3.0 markers are silently invisible to 0.3.1+ — schema-bump rationale documented inside `check-gate.sh`).
- The `/check` / `/check-docs` / `/run-integ` skills all instruct "Install `vp` and `markgate` via `mise install` at the repo root" — but without `.mise.toml`, `mise install` is a no-op.

Copied verbatim from cdkd's `.mise.toml`. Smoke-tested locally:

```
$ mise trust && mise install
$ mise exec -- markgate --version
0.3.3
$ mise exec -- vp --version
vp v0.1.20
```

## Post-merge note for contributors

`.mise.toml` requires per-worktree trust (mise's default refuse-to-load-untrusted-config security feature). After `git worktree add` or fresh clone, run `mise trust` once in the repo root before `mise install`. Maybe worth adding to a future `CONTRIBUTING.md` (cdk-local doesn't have one yet).

## Test plan

- [x] `mise install` resolves both pinned versions cleanly on macos-arm64.
- [x] `mise exec -- markgate --version` returns `0.3.3` (matches cdkd).
- [x] `mise exec -- vp --version` returns `vp v0.1.20` (matches cdkd).
- [x] All 4 markgate markers refreshed in the worktree before commit (bootstrap pattern PRs #20 / #24 / #25 / #29 / #30 / #31 / #32 / #34 also used).
- [x] CI green.
