### PR TITLE
chore(infra): add .vite-hooks/pre-commit + .vscode/{extensions,settings}.json

### DIFF
--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,0 +1,1 @@
+vp staged

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "VoidZero.vite-plus-extension-pack",
+    "TypeScriptTeam.native-preview",
+    "DavidAnson.vscode-markdownlint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.oxc": "explicit"
+  },
+
+  // Vite+ / Oxc
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+  },
+  "oxc.fmt.configPath": "./vite.config.ts",
+  "npm.scriptRunner": "vp",
+
+  // TypeScript
+  "typescript.experimental.useTsgo": true,
+
+  // cSpell
+  "cSpell.words": ["cdkl", "cdk-local"]
+}


### PR DESCRIPTION
## Summary

Closes the remaining cdk-local vs cdkd top-level dotfile gap (after PR #36 landed `.mise.toml`).

### Files

| File | Purpose |
|---|---|
| `.vite-hooks/pre-commit` (`+x`) | One-line `vp staged` — auto-format / lint staged files on every `git commit`. Universal for vp-based projects. |
| `.vscode/extensions.json` | Recommends 3 extensions: `VoidZero.vite-plus-extension-pack`, `TypeScriptTeam.native-preview`, `DavidAnson.vscode-markdownlint`. |
| `.vscode/settings.json` | Editor defaults: format-on-save via oxc, `npm.scriptRunner = vp`, TS native preview, markdown formatter = markdownlint. |

### Adaptation from cdkd

cdkd's `.vscode/settings.json` ends with `"cSpell.words": ["cdkd"]`. Rewritten for cdk-local as `["cdkl", "cdk-local"]` so cSpell stops flagging cdk-local's brand strings as misspellings.

The other files copied verbatim from cdkd.

## Test plan

- [x] `.vite-hooks/pre-commit` mode is `0o755` (executable) — matches cdkd.
- [x] `.vscode/settings.json` parses as valid JSONC (VS Code accepts comments).
- [x] All 4 markgate markers refreshed in the worktree.
- [x] CI green.
