### PR TITLE
refactor(cli): trim unused surface in config-loader.ts

### DIFF
--- a/src/cli/config-loader.ts
+++ b/src/cli/config-loader.ts
@@ -1,31 +1,18 @@
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, join } from 'node:path';
-import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import { getLogger } from '../utils/logger.js';
 
-/**
- * CDK configuration loaded from cdk.json and environment variables.
- */
-export interface CdkConfig {
-  app?: string;
-  output?: string;
-  context?: Record<string, unknown>;
-}
-
-function loadJsonConfig(filePath: string): CdkConfig | null {
-  const logger = getLogger();
-
+function loadCdkJson(): { app?: string } | null {
+  const filePath = resolve(process.cwd(), 'cdk.json');
   if (!existsSync(filePath)) {
     return null;
   }
 
   try {
     const content = readFileSync(filePath, 'utf-8');
-    const config = JSON.parse(content) as CdkConfig;
-    logger.debug(`Loaded config from ${filePath}`);
-    return config;
+    return JSON.parse(content) as { app?: string };
   } catch (error) {
-    logger.warn(
+    getLogger().warn(
       `Failed to parse ${filePath}: ${error instanceof Error ? error.message : String(error)}`
     );
     return null;
@@ -33,28 +20,15 @@ function loadJsonConfig(filePath: string): CdkConfig | null {
 }
 
 /**
- * Load `cdk.json` from the current working directory.
- */
-export function loadCdkJson(cwd?: string): CdkConfig | null {
-  const dir = cwd || process.cwd();
-  return loadJsonConfig(resolve(dir, 'cdk.json'));
-}
-
-/**
- * Load user-level defaults from `~/.cdk.json`.
- *
- * CDK CLI reads this as user-level defaults (lowest priority).
- * Context values from `~/.cdk.json` are merged below project `cdk.json`
- * context.
- */
-export function loadUserCdkJson(): CdkConfig | null {
-  return loadJsonConfig(join(homedir(), '.cdk.json'));
-}
-
-/**
  * Resolve the `--app` option from CLI, `CDKL_APP` env var, or `cdk.json`.
  *
- * Priority: CLI option > `CDKL_APP` env > `cdk.json` `app` field.
+ * Priority: CLI option > `CDKL_APP` env > `cdk.json` `app` field > undefined.
+ *
+ * `@aws-cdk/toolkit-lib`'s `Toolkit.fromCdkApp(...)` requires the CDK app
+ * command as a positional argument and does NOT auto-resolve `cdk.json`'s
+ * `app` field, so cdk-local resolves it here before handing the command to
+ * the toolkit. `~/.cdk.json` context is intentionally NOT read here —
+ * `CdkAppMultiContext` inside `assembly-reader.ts` already merges it.
  */
 export function resolveApp(cliApp?: string): string | undefined {
   if (cliApp) return cliApp;
@@ -62,6 +36,5 @@ export function resolveApp(cliApp?: string): string | undefined {
   const envApp = process.env['CDKL_APP'];
   if (envApp) return envApp;
 
-  const cdkJson = loadCdkJson();
-  return cdkJson?.app ?? undefined;
+  return loadCdkJson()?.app ?? undefined;
 }

--- a/tests/integration/local-invoke/package.json
+++ b/tests/integration/local-invoke/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.4.0"
 }

--- a/tests/integration/local-invoke/pnpm-lock.yaml
+++ b/tests/integration/local-invoke/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.169.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+
+  '@aws-cdk/cloud-assembly-schema@53.27.0':
+    resolution: {integrity: sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==, tarball: https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==, tarball: https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.27.0': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.27.0
+      constructs: 10.6.0
+
+  constructs@10.6.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/tests/unit/cli/config-loader.test.ts
+++ b/tests/unit/cli/config-loader.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveApp } from '../../../src/cli/config-loader.js';
+
+describe('resolveApp', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cdk-local-config-loader-'));
+    originalCwd = process.cwd();
+    originalEnv = process.env['CDKL_APP'];
+    delete process.env['CDKL_APP'];
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (originalEnv === undefined) {
+      delete process.env['CDKL_APP'];
+    } else {
+      process.env['CDKL_APP'] = originalEnv;
+    }
+  });
+
+  it('returns the --app CLI option when provided (wins over env + cdk.json)', () => {
+    process.env['CDKL_APP'] = 'env-app';
+    writeFileSync('cdk.json', JSON.stringify({ app: 'cdk-json-app' }));
+    expect(resolveApp('cli-app')).toBe('cli-app');
+  });
+
+  it('falls back to CDKL_APP env var when --app is not provided (wins over cdk.json)', () => {
+    process.env['CDKL_APP'] = 'env-app';
+    writeFileSync('cdk.json', JSON.stringify({ app: 'cdk-json-app' }));
+    expect(resolveApp(undefined)).toBe('env-app');
+  });
+
+  it('falls back to cdk.json app field when --app and CDKL_APP are not set', () => {
+    writeFileSync('cdk.json', JSON.stringify({ app: 'cdk-json-app' }));
+    expect(resolveApp(undefined)).toBe('cdk-json-app');
+  });
+
+  it('returns undefined when no cdk.json, no env, and no --app are present', () => {
+    expect(resolveApp(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when cdk.json exists but has no app field', () => {
+    writeFileSync('cdk.json', JSON.stringify({ output: 'cdk.out' }));
+    expect(resolveApp(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when cdk.json contains invalid JSON (logs a warning, does not throw)', () => {
+    writeFileSync('cdk.json', '{invalid');
+    expect(resolveApp(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #38

Shrink `src/cli/config-loader.ts` to a single internal helper that does just what `resolveApp` needs. The four `local-*` command callers (`local-invoke.ts`, `local-start-api.ts`, `local-run-task.ts`, `local-start-service.ts`) only use `resolveApp`; the rest of the file was dead surface.

### Dead surface dropped

| Item | Why it was safe |
|---|---|
| `loadUserCdkJson()` | zero callers; `~/.cdk.json` context is already merged by `CdkAppMultiContext` inside `assembly-reader.ts:132-137` |
| `loadCdkJson(cwd?)` `export` | only used internally by `resolveApp`, with the `cwd?` parameter never passed. Demoted to internal `function`, param removed |
| `CdkConfig.output` / `CdkConfig.context` fields | never read by callers. `output` comes from CLI `--output` and `context` is fully delegated to toolkit-lib |
| `CdkConfig` type | only used inside `config-loader.ts` after the trim; replaced with an inline `{ app?: string }` return type |
| Now-unused imports: `join`, `homedir`, the `loadJsonConfig` wrapper | inlined / dropped after the above changes |

Net `config-loader.ts`: -40 / +13 LOC.

### Scope guard

`resolveApp` precedence is unchanged: **CLI `--app` > `CDKL_APP` env > `cdk.json` `app` field > `undefined`**. The export name is unchanged. The four caller sites are not modified.

### Tests

New file `tests/unit/cli/config-loader.test.ts` (6 tests) covers the precedence chain end-to-end via a temp-dir fixture + `process.chdir` (no `vi.mock` complexity needed):

- `--app` CLI option wins over env + `cdk.json`
- `CDKL_APP` env wins over `cdk.json`
- `cdk.json` `app` field is read when neither CLI nor env is set
- `undefined` when no source provides an app
- `undefined` when `cdk.json` exists but has no `app` field
- `undefined` when `cdk.json` contains invalid JSON (warn logged, no throw)

## Verification

- [x] `vp run check` (typecheck + lint + format) — pass
- [x] `vp run test` — 107 passing (101 pre-existing + 6 new)
- [x] `vp run build` — clean

## Out of scope

The four `resolveApp` callers in `src/cli/commands/local-*.ts` are untouched — adjusting precedence semantics or moving the helper belongs in a separate change.

## Refs

- Closes #38
