### PR TITLE
feat(cli): accept CDK display path keys in --env-vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ When env-var values in your CDK template are CloudFormation intrinsics (`Ref`, `
 ```json
 {
   "Parameters": { "LOG_LEVEL": "debug" },
-  "MyFunctionLogicalId": {
+  "MyStack/MyFunction": {
     "SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:MySecret-abc123",
     "TABLE_NAME": "my-table"
   }
@@ -130,10 +130,10 @@ When env-var values in your CDK template are CloudFormation intrinsics (`Ref`, `
 cdkl invoke MyStack/MyFunction --event ./event.json --env-vars ./env.json
 ```
 
-- `Parameters` applies to every function; function-specific blocks override it.
-- Function-specific keys are CloudFormation logical IDs (named in `cdk.out/<Stack>.template.json` or in the drop-warning message).
-- Available on `invoke`, `start-api`, `run-task`, and `start-service`.
-- The file format matches `sam local invoke --env-vars`, so an existing SAM env-vars file works unchanged.
+- `Parameters` applies to every function / container; function-specific blocks override it.
+- For Lambda (`invoke`, `start-api`), function-specific keys can be either a **CDK display path** (`MyStack/MyFunction` — recommended for new files; same form `cdkl invoke` accepts as a target) or a **CloudFormation logical ID** (`MyFunctionLogicalId1234ABCD` — named in `cdk.out/<Stack>.template.json`, the SAM-compatible form). Both coexist; if both are listed for the same function, the later JSON entry wins (matching SAM's apply-in-order semantics).
+- For ECS (`run-task`, `start-service`), function-specific keys are container names from the task definition's `ContainerDefinitions[].Name` field.
+- The file format matches `sam local invoke --env-vars`, so an existing SAM env-vars file (logical-ID keys) works unchanged.
 
 ## Supported resources
 

--- a/src/cli/cdk-path.ts
+++ b/src/cli/cdk-path.ts
@@ -16,6 +16,22 @@ export function readCdkPath(resource: TemplateResource): string {
 }
 
 /**
+ * Same lookup as `readCdkPath`, but returns `undefined` instead of an
+ * empty string when no `aws:cdk:path` metadata is present.
+ *
+ * Use this variant when the caller passes the value into APIs whose
+ * contract distinguishes "no path known" from "empty path". For example,
+ * `resolveEnvVars(logicalId, displayPath, ...)` short-circuits the
+ * display-path lookup when `displayPath` is `undefined`, but an empty
+ * string `''` would still hit the loop and could spuriously match a
+ * malformed override key.
+ */
+export function readCdkPathOrUndefined(resource: TemplateResource): string | undefined {
+  const path = readCdkPath(resource);
+  return path === '' ? undefined : path;
+}
+
+/**
  * Build a `Map<cdkPath, logicalId>` from a synthesized template.
  *
  * Used by `cdkd orphan <constructPath>` to translate user-supplied

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -16,6 +16,7 @@ import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
+import { readCdkPathOrUndefined } from '../cdk-path.js';
 import { createLocalStateProvider, type ExtraStateProviders } from './local-state-source.js';
 import {
   resolveLambdaTarget,
@@ -346,14 +347,14 @@ async function localInvokeCommand(
     // Resolve env vars. Intrinsic-valued template entries are warned about
     // and dropped; the user can override them via --env-vars (SAM-shape).
     const overrides = readEnvOverridesFile(options.envVars);
-    const lambdaCdkPath =
-      typeof lambda.resource.Metadata?.['aws:cdk:path'] === 'string'
-        ? lambda.resource.Metadata['aws:cdk:path']
-        : undefined;
+    const lambdaCdkPath = readCdkPathOrUndefined(lambda.resource);
     const envResult = resolveEnvVars(lambda.logicalId, lambdaCdkPath, templateEnv, overrides);
     for (const key of envResult.unresolved) {
       if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
-      const overrideKeyExample = lambdaCdkPath ?? lambda.logicalId;
+      // Prefer the L2 form (`MyStack/MyFn`) in the suggestion since that
+      // matches the README guidance and `cdkl invoke` target shape; the
+      // resolver's prefix rule accepts either form.
+      const overrideKeyExample = lambdaCdkPath?.replace(/\/Resource$/, '') ?? lambda.logicalId;
       logger.warn(
         `Environment variable ${key} contains a CloudFormation intrinsic and was dropped. ` +
           `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}), or pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to recover deployed values.`

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -346,12 +346,17 @@ async function localInvokeCommand(
     // Resolve env vars. Intrinsic-valued template entries are warned about
     // and dropped; the user can override them via --env-vars (SAM-shape).
     const overrides = readEnvOverridesFile(options.envVars);
-    const envResult = resolveEnvVars(lambda.logicalId, templateEnv, overrides);
+    const lambdaCdkPath =
+      typeof lambda.resource.Metadata?.['aws:cdk:path'] === 'string'
+        ? lambda.resource.Metadata['aws:cdk:path']
+        : undefined;
+    const envResult = resolveEnvVars(lambda.logicalId, lambdaCdkPath, templateEnv, overrides);
     for (const key of envResult.unresolved) {
       if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
+      const overrideKeyExample = lambdaCdkPath ?? lambda.logicalId;
       logger.warn(
         `Environment variable ${key} contains a CloudFormation intrinsic and was dropped. ` +
-          `Override it with --env-vars (e.g. {"${lambda.logicalId}":{"${key}":"<literal>"}}), or pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to recover deployed values.`
+          `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}), or pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to recover deployed values.`
       );
     }
 

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1515,7 +1515,11 @@ async function buildContainerSpec(args: {
       );
     }
   }
-  const envResult = resolveEnvVars(logicalId, templateEnv, overrides);
+  const lambdaCdkPath =
+    typeof lambda.resource.Metadata?.['aws:cdk:path'] === 'string'
+      ? lambda.resource.Metadata['aws:cdk:path']
+      : undefined;
+  const envResult = resolveEnvVars(logicalId, lambdaCdkPath, templateEnv, overrides);
   for (const key of envResult.unresolved) {
     // The state-resolver already warned for keys it tried + failed on
     // (defensive: substituteEnvVarsFromState drops unresolved keys from
@@ -1523,9 +1527,10 @@ async function buildContainerSpec(args: {
     // `cdkl invoke --from-state`'s safety dedupe in case the
     // state-resolver evolves).
     if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
+    const overrideKeyExample = lambdaCdkPath ?? logicalId;
     getLogger().warn(
       `Lambda ${logicalId}: env var ${key} contains a CloudFormation intrinsic and was dropped. ` +
-        `Override it with --env-vars (e.g. {"${logicalId}":{"${key}":"<literal>"}}) ` +
+        `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}) ` +
         `or pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to recover deployed values.`
     );
   }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -18,6 +18,7 @@ import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
+import { readCdkPathOrUndefined } from '../cdk-path.js';
 import {
   createLocalStateProvider,
   isCfnFlagPresent,
@@ -1515,10 +1516,7 @@ async function buildContainerSpec(args: {
       );
     }
   }
-  const lambdaCdkPath =
-    typeof lambda.resource.Metadata?.['aws:cdk:path'] === 'string'
-      ? lambda.resource.Metadata['aws:cdk:path']
-      : undefined;
+  const lambdaCdkPath = readCdkPathOrUndefined(lambda.resource);
   const envResult = resolveEnvVars(logicalId, lambdaCdkPath, templateEnv, overrides);
   for (const key of envResult.unresolved) {
     // The state-resolver already warned for keys it tried + failed on
@@ -1527,7 +1525,10 @@ async function buildContainerSpec(args: {
     // `cdkl invoke --from-state`'s safety dedupe in case the
     // state-resolver evolves).
     if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
-    const overrideKeyExample = lambdaCdkPath ?? logicalId;
+    // Prefer the L2 form (`MyStack/MyFn`) in the suggestion since that
+    // matches the README guidance and `cdkl invoke` target shape; the
+    // resolver's prefix rule accepts either form.
+    const overrideKeyExample = lambdaCdkPath?.replace(/\/Resource$/, '') ?? logicalId;
     getLogger().warn(
       `Lambda ${logicalId}: env var ${key} contains a CloudFormation intrinsic and was dropped. ` +
         `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}) ` +

--- a/src/local/env-resolver.ts
+++ b/src/local/env-resolver.ts
@@ -94,17 +94,23 @@ export function resolveEnvVars(
     applyOverrideMap(resolved, overrides.Parameters);
     // Iterate non-Parameters keys in JSON insertion order so a
     // logical-ID + display-path collision applies later-wins (SAM-compat).
-    // We dedupe against `logicalId === displayPath` so a fallback caller
-    // that passes the logical ID as the display path does not apply the
-    // same map twice.
-    const matchedKeys: string[] = [logicalId];
-    if (displayPath && displayPath !== logicalId) {
-      matchedKeys.push(displayPath);
-    }
+    //
+    // Display-path matching mirrors the prefix rule the rest of cdk-local
+    // uses for `cdkl invoke <target>` (`src/cli/cdk-path.ts`
+    // `resolveCdkPathToLogicalIds`): an override key matches when the
+    // resource's `aws:cdk:path` is exactly that key OR starts with
+    // `key + "/"`. That lets a user write `MyStack/MyFn` (the L2 form
+    // they read from CDK app code, same form `cdkl invoke` accepts) and
+    // have it match the synthesized L1 resource at `MyStack/MyFn/Resource`
+    // — without forcing them to look up the `/Resource` suffix.
     for (const [key, val] of Object.entries(overrides)) {
       if (key === 'Parameters') continue;
-      if (!matchedKeys.includes(key)) continue;
-      if (val && typeof val === 'object') {
+      if (!val || typeof val !== 'object') continue;
+      if (key === logicalId) {
+        applyOverrideMap(resolved, val);
+        continue;
+      }
+      if (displayPath && (displayPath === key || displayPath.startsWith(`${key}/`))) {
         applyOverrideMap(resolved, val);
       }
     }

--- a/src/local/env-resolver.ts
+++ b/src/local/env-resolver.ts
@@ -10,17 +10,24 @@
  * variable is **dropped** rather than silently substituted with garbage
  * (a bad env var that "exists" is harder to debug than one that's missing).
  *
- * `--env-vars <file>` overrides match SAM's shape (D5):
+ * `--env-vars <file>` overrides match SAM's shape (D5), with the
+ * additional CDK ergonomics that a function-specific entry can be keyed
+ * by either the CloudFormation logical ID or the CDK display path
+ * (`Metadata['aws:cdk:path']`):
  *
  *   {
  *     "Parameters":           { "GLOBAL_KEY": "value" },
- *     "MyHandlerLogicalId":   { "FUNCTION_KEY": "value" }
+ *     "MyHandlerLogicalId":   { "FUNCTION_KEY": "value" },
+ *     "MyStack/MyHandler":    { "FUNCTION_KEY": "value" }
  *   }
  *
  * Override merge order (lowest to highest priority):
  *   1. Template literal env vars
  *   2. `Parameters` (global, applied to every invoke)
- *   3. Function-specific entry keyed by logical ID
+ *   3. Function-specific entries (logical-ID or display-path keyed)
+ *      applied in JSON insertion order, so a later key wins on conflict.
+ *      This matches SAM's apply-in-order semantics; pick one form per
+ *      function to avoid surprises.
  *
  * The override file may also clear a variable by setting it to `null`
  * (matches SAM behavior).
@@ -36,8 +43,11 @@ export interface EnvResolutionResult {
 export interface EnvOverrideFile {
   /** Variables applied to every function invocation. */
   Parameters?: Record<string, string | null>;
-  /** Function-specific overrides keyed by logical ID. */
-  [logicalId: string]: Record<string, string | null> | undefined;
+  /**
+   * Function-specific overrides keyed by either the CloudFormation
+   * logical ID or the CDK display path (`Metadata['aws:cdk:path']`).
+   */
+  [logicalIdOrDisplayPath: string]: Record<string, string | null> | undefined;
 }
 
 /**
@@ -46,6 +56,15 @@ export interface EnvOverrideFile {
  * @param logicalId         The function's CloudFormation logical ID. Used
  *                          to look up function-specific overrides in the
  *                          `--env-vars` file.
+ * @param displayPath       The function's CDK display path
+ *                          (`Metadata['aws:cdk:path']`, e.g.
+ *                          `"MyStack/MyHandler"`), or `undefined` when
+ *                          the resource has no path metadata. Display-path
+ *                          keys in the override file are matched against
+ *                          this value in addition to `logicalId`. Pass
+ *                          `undefined` rather than the logical ID when no
+ *                          path is known, so the override lookup does not
+ *                          accidentally double-match the same key.
  * @param templateEnv       The function's `Properties.Environment.Variables`
  *                          object from the synthesized template, or
  *                          `undefined` when the function has no env vars.
@@ -54,6 +73,7 @@ export interface EnvOverrideFile {
  */
 export function resolveEnvVars(
   logicalId: string,
+  displayPath: string | undefined,
   templateEnv: Record<string, unknown> | undefined,
   overrides?: EnvOverrideFile
 ): EnvResolutionResult {
@@ -72,9 +92,21 @@ export function resolveEnvVars(
 
   if (overrides) {
     applyOverrideMap(resolved, overrides.Parameters);
-    const fnOverrides = overrides[logicalId];
-    if (fnOverrides && typeof fnOverrides === 'object') {
-      applyOverrideMap(resolved, fnOverrides);
+    // Iterate non-Parameters keys in JSON insertion order so a
+    // logical-ID + display-path collision applies later-wins (SAM-compat).
+    // We dedupe against `logicalId === displayPath` so a fallback caller
+    // that passes the logical ID as the display path does not apply the
+    // same map twice.
+    const matchedKeys: string[] = [logicalId];
+    if (displayPath && displayPath !== logicalId) {
+      matchedKeys.push(displayPath);
+    }
+    for (const [key, val] of Object.entries(overrides)) {
+      if (key === 'Parameters') continue;
+      if (!matchedKeys.includes(key)) continue;
+      if (val && typeof val === 'object') {
+        applyOverrideMap(resolved, val);
+      }
     }
   }
 

--- a/tests/integration/local-invoke/verify.sh
+++ b/tests/integration/local-invoke/verify.sh
@@ -53,12 +53,12 @@ echo "${RESULT_2}" | grep -q '"key":"value"' || {
   exit 1
 }
 
-# Test 3 — --env-vars override
-echo "==> [3/4] Invoking EchoHandler with --env-vars override"
+# Test 3 — --env-vars override (Parameters)
+echo "==> [3/5] Invoking EchoHandler with --env-vars Parameters block"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
-# Logical ID is what the CDK construct synthesizes to. Use a wildcard
-# Parameters block so the test doesn't break if the L1 logical ID changes.
+# Use a wildcard `Parameters` block so the test doesn't break if the
+# L1 logical ID changes.
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
 RESULT_3=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_3}"
@@ -67,17 +67,31 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
   exit 1
 }
 
-# Test 4 — inline (Code.ZipFile) Lambda
-echo "==> [4/4] Invoking InlineHandler (Code.ZipFile)"
-INLINE_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}"' EXIT
-echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_4=$(${CDKL} invoke CdkLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+# Test 4 — --env-vars function-specific key by display path (issue #27)
+echo "==> [4/5] Invoking EchoHandler with --env-vars display-path key"
+DP_ENV_FILE=$(mktemp)
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}"' EXIT
+# The display-path key matches `Metadata['aws:cdk:path']` — i.e. the
+# same form `cdkl invoke <target>` already accepts.
+echo '{"CdkLocalInvokeFixture/EchoHandler":{"GREETING":"path-key-overridden"}}' > "${DP_ENV_FILE}"
+RESULT_4=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${DP_ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
-echo "${RESULT_4}" | grep -q '"inlineEcho":{"hi":"there"}' || {
-  echo "FAIL: expected inlineEcho={hi:there}, got: ${RESULT_4}"
+echo "${RESULT_4}" | grep -q '"greeting":"path-key-overridden"' || {
+  echo "FAIL: expected greeting=path-key-overridden, got: ${RESULT_4}"
+  exit 1
+}
+
+# Test 5 — inline (Code.ZipFile) Lambda
+echo "==> [5/5] Invoking InlineHandler (Code.ZipFile)"
+INLINE_EVENT=$(mktemp)
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}" "${INLINE_EVENT}"' EXIT
+echo '{"hi":"there"}' > "${INLINE_EVENT}"
+RESULT_5=$(${CDKL} invoke CdkLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+echo "    response: ${RESULT_5}"
+echo "${RESULT_5}" | grep -q '"inlineEcho":{"hi":"there"}' || {
+  echo "FAIL: expected inlineEcho={hi:there}, got: ${RESULT_5}"
   exit 1
 }
 
 echo ""
-echo "==> All 4 local-invoke tests passed"
+echo "==> All 5 local-invoke tests passed"

--- a/tests/integration/local-invoke/verify.sh
+++ b/tests/integration/local-invoke/verify.sh
@@ -33,7 +33,7 @@ fi
 
 
 # Test 1 — asset-backed Lambda echoes event + env var
-echo "==> [1/4] Invoking EchoHandler with default empty event"
+echo "==> [1/5] Invoking EchoHandler with default empty event"
 RESULT_1=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
@@ -42,7 +42,7 @@ echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
 }
 
 # Test 2 — event payload via --event
-echo "==> [2/4] Invoking EchoHandler with --event payload"
+echo "==> [2/5] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"

--- a/tests/unit/local/env-resolver.test.ts
+++ b/tests/unit/local/env-resolver.test.ts
@@ -5,13 +5,18 @@ import {
 } from '../../../src/local/env-resolver.js';
 
 const LOGICAL = 'MyHandler1234ABCD';
-const PATH = 'MyStack/MyHandler';
-const NESTED_PATH = 'MyStack/Nested/MyHandler';
+// The full L1 form CDK encodes into `Metadata['aws:cdk:path']`.
+const L1_PATH = 'MyStack/MyHandler/Resource';
+// The L2 construct path the user actually reads from CDK app code, and
+// the same form `cdkl invoke` accepts as a target.
+const L2_PATH = 'MyStack/MyHandler';
+const L1_NESTED_PATH = 'MyStack/Nested/MyHandler/Resource';
+const L2_NESTED_PATH = 'MyStack/Nested/MyHandler';
 
 describe('resolveEnvVars', () => {
   describe('template-only path (no overrides)', () => {
     it('returns literal string / number / boolean values coerced to string', () => {
-      const result = resolveEnvVars(LOGICAL, PATH, {
+      const result = resolveEnvVars(LOGICAL, L1_PATH, {
         STR: 'hello',
         NUM: 42,
         BOOL: true,
@@ -21,7 +26,7 @@ describe('resolveEnvVars', () => {
     });
 
     it('drops intrinsic-valued entries and records them in `unresolved`', () => {
-      const result = resolveEnvVars(LOGICAL, PATH, {
+      const result = resolveEnvVars(LOGICAL, L1_PATH, {
         LITERAL: 'ok',
         TABLE: { Ref: 'MyTable' },
         ARN: { 'Fn::GetAtt': ['MyTable', 'Arn'] },
@@ -31,7 +36,7 @@ describe('resolveEnvVars', () => {
     });
 
     it('returns empty maps when templateEnv is undefined', () => {
-      const result = resolveEnvVars(LOGICAL, PATH, undefined);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined);
       expect(result.resolved).toEqual({});
       expect(result.unresolved).toEqual([]);
     });
@@ -42,13 +47,18 @@ describe('resolveEnvVars', () => {
       const overrides: EnvOverrideFile = {
         Parameters: { GLOBAL: 'on', LITERAL: 'overridden' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'overridden', GLOBAL: 'on' });
     });
 
     it('null in Parameters clears a templateEnv-supplied key (SAM-compat)', () => {
       const overrides: EnvOverrideFile = { Parameters: { LITERAL: null } };
-      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template', KEEP: 'k' }, overrides);
+      const result = resolveEnvVars(
+        LOGICAL,
+        L1_PATH,
+        { LITERAL: 'template', KEEP: 'k' },
+        overrides
+      );
       expect(result.resolved).toEqual({ KEEP: 'k' });
     });
   });
@@ -59,7 +69,7 @@ describe('resolveEnvVars', () => {
         Parameters: { LITERAL: 'global', GLOBAL: 'g' },
         [LOGICAL]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'fn-specific', GLOBAL: 'g', FN_ONLY: 'f' });
     });
 
@@ -67,53 +77,91 @@ describe('resolveEnvVars', () => {
       const overrides: EnvOverrideFile = {
         OtherFn99: { FN_ONLY: 'should-not-apply' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'template' });
     });
   });
 
   describe('--env-vars: function-specific entry — display-path key (issue #27)', () => {
-    it('applies a top-level display-path-keyed map', () => {
+    it('matches the exact L1 metadata path', () => {
       const overrides: EnvOverrideFile = {
-        [PATH]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
+        [L1_PATH]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'fn-specific', FN_ONLY: 'f' });
     });
 
-    it('applies a nested-stack display path', () => {
+    it('matches the L2 construct path (prefix of the L1 metadata path)', () => {
+      // This is the natural form the user reads from CDK app code and the
+      // same shape `cdkl invoke` accepts as a target.
       const overrides: EnvOverrideFile = {
-        [NESTED_PATH]: { NESTED_ONLY: 'on' },
+        [L2_PATH]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
       };
-      const result = resolveEnvVars(LOGICAL, NESTED_PATH, undefined, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'fn-specific', FN_ONLY: 'f' });
+    });
+
+    it('matches a nested-stack L2 construct path', () => {
+      const overrides: EnvOverrideFile = {
+        [L2_NESTED_PATH]: { NESTED_ONLY: 'on' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_NESTED_PATH, undefined, overrides);
       expect(result.resolved).toEqual({ NESTED_ONLY: 'on' });
     });
 
+    it('matches a parent stack path (prefix applies to every function under it)', () => {
+      // Key `MyStack` is a prefix of `MyStack/MyHandler/Resource` so the
+      // override fires; this lets a user set a stack-wide override without
+      // listing every function (same UX as `Parameters` scoped to one
+      // stack).
+      const overrides: EnvOverrideFile = {
+        MyStack: { STACK_WIDE: 'yes' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ STACK_WIDE: 'yes' });
+    });
+
     it('display-path key with null clears a templateEnv-supplied key', () => {
-      const overrides: EnvOverrideFile = { [PATH]: { LITERAL: null } };
+      const overrides: EnvOverrideFile = { [L2_PATH]: { LITERAL: null } };
       const result = resolveEnvVars(
         LOGICAL,
-        PATH,
+        L1_PATH,
         { LITERAL: 'template', KEEP: 'k' },
         overrides
       );
       expect(result.resolved).toEqual({ KEEP: 'k' });
     });
 
+    it('does not partial-match within a path segment (no false positive on siblings)', () => {
+      // displayPath `MyStack/MyHandlerBackup/Resource` shares a string
+      // prefix with the key `MyStack/MyHandler`, but the prefix rule
+      // requires a `/` boundary — so this MUST NOT match. Without the
+      // `${key}/` slash boundary `MyHandler` would erroneously match
+      // `MyHandlerBackup`.
+      const overrides: EnvOverrideFile = {
+        [L2_PATH]: { FN_ONLY: 'should-not-apply' },
+      };
+      const result = resolveEnvVars(
+        LOGICAL,
+        'MyStack/MyHandlerBackup/Resource',
+        { LITERAL: 'template' },
+        overrides
+      );
+      expect(result.resolved).toEqual({ LITERAL: 'template' });
+    });
+
     it('does not match a different display path', () => {
       const overrides: EnvOverrideFile = {
         'OtherStack/OtherHandler': { FN_ONLY: 'should-not-apply' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'template' });
     });
 
     it('skips the display-path lookup when displayPath is undefined', () => {
       const overrides: EnvOverrideFile = {
-        [PATH]: { FN_ONLY: 'should-not-apply' },
+        [L2_PATH]: { FN_ONLY: 'should-not-apply' },
       };
-      // No display path known for this function — only the logical-ID key
-      // would be matched, and there isn't one in this override file.
       const result = resolveEnvVars(LOGICAL, undefined, { LITERAL: 'template' }, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'template' });
     });
@@ -121,46 +169,30 @@ describe('resolveEnvVars', () => {
 
   describe('--env-vars: conflict resolution between logical-ID and display-path keys', () => {
     it('applies later JSON insertion wins (display path after logical ID)', () => {
-      // JSON insertion order is preserved by Object.entries on a plain
-      // object literal; the display-path entry comes after the logical-ID
-      // entry, so its value wins.
       const overrides: EnvOverrideFile = {
         [LOGICAL]: { LITERAL: 'from-logical-id' },
-        [PATH]: { LITERAL: 'from-display-path' },
+        [L2_PATH]: { LITERAL: 'from-display-path' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'from-display-path' });
     });
 
     it('applies later JSON insertion wins (logical ID after display path)', () => {
       const overrides: EnvOverrideFile = {
-        [PATH]: { LITERAL: 'from-display-path' },
+        [L2_PATH]: { LITERAL: 'from-display-path' },
         [LOGICAL]: { LITERAL: 'from-logical-id' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'from-logical-id' });
     });
 
     it('merges non-conflicting keys from both forms', () => {
       const overrides: EnvOverrideFile = {
         [LOGICAL]: { FROM_LOGICAL: 'L' },
-        [PATH]: { FROM_PATH: 'P' },
+        [L2_PATH]: { FROM_PATH: 'P' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
       expect(result.resolved).toEqual({ FROM_LOGICAL: 'L', FROM_PATH: 'P' });
-    });
-
-    it('does not double-apply when caller passes the same value for logicalId and displayPath', () => {
-      // A defensive caller may fall back to the logical ID when the
-      // display path is missing; the resolver dedupes so the map is not
-      // applied twice (which would matter if the map's values were
-      // computed at resolution time — here it is idempotent, but the
-      // contract holds).
-      const overrides: EnvOverrideFile = {
-        [LOGICAL]: { ONLY: 'applied-once' },
-      };
-      const result = resolveEnvVars(LOGICAL, LOGICAL, undefined, overrides);
-      expect(result.resolved).toEqual({ ONLY: 'applied-once' });
     });
   });
 
@@ -170,7 +202,7 @@ describe('resolveEnvVars', () => {
         Parameters: { GLOBAL: 'g' },
         [LOGICAL]: 'a-string-not-a-map',
       } as unknown as EnvOverrideFile;
-      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
       expect(result.resolved).toEqual({ GLOBAL: 'g' });
     });
 
@@ -179,7 +211,7 @@ describe('resolveEnvVars', () => {
         Parameters: { GLOBAL: 'g' },
         OtherFn99: { FN_ONLY: 'no-match' },
       };
-      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
       expect(result.resolved).toEqual({ GLOBAL: 'g' });
     });
   });

--- a/tests/unit/local/env-resolver.test.ts
+++ b/tests/unit/local/env-resolver.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  resolveEnvVars,
+  type EnvOverrideFile,
+} from '../../../src/local/env-resolver.js';
+
+const LOGICAL = 'MyHandler1234ABCD';
+const PATH = 'MyStack/MyHandler';
+const NESTED_PATH = 'MyStack/Nested/MyHandler';
+
+describe('resolveEnvVars', () => {
+  describe('template-only path (no overrides)', () => {
+    it('returns literal string / number / boolean values coerced to string', () => {
+      const result = resolveEnvVars(LOGICAL, PATH, {
+        STR: 'hello',
+        NUM: 42,
+        BOOL: true,
+      });
+      expect(result.resolved).toEqual({ STR: 'hello', NUM: '42', BOOL: 'true' });
+      expect(result.unresolved).toEqual([]);
+    });
+
+    it('drops intrinsic-valued entries and records them in `unresolved`', () => {
+      const result = resolveEnvVars(LOGICAL, PATH, {
+        LITERAL: 'ok',
+        TABLE: { Ref: 'MyTable' },
+        ARN: { 'Fn::GetAtt': ['MyTable', 'Arn'] },
+      });
+      expect(result.resolved).toEqual({ LITERAL: 'ok' });
+      expect(result.unresolved.sort()).toEqual(['ARN', 'TABLE']);
+    });
+
+    it('returns empty maps when templateEnv is undefined', () => {
+      const result = resolveEnvVars(LOGICAL, PATH, undefined);
+      expect(result.resolved).toEqual({});
+      expect(result.unresolved).toEqual([]);
+    });
+  });
+
+  describe('--env-vars: Parameters (global) overlay', () => {
+    it('applies Parameters on top of templateEnv', () => {
+      const overrides: EnvOverrideFile = {
+        Parameters: { GLOBAL: 'on', LITERAL: 'overridden' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'overridden', GLOBAL: 'on' });
+    });
+
+    it('null in Parameters clears a templateEnv-supplied key (SAM-compat)', () => {
+      const overrides: EnvOverrideFile = { Parameters: { LITERAL: null } };
+      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template', KEEP: 'k' }, overrides);
+      expect(result.resolved).toEqual({ KEEP: 'k' });
+    });
+  });
+
+  describe('--env-vars: function-specific entry — logical-ID key', () => {
+    it('applies the logical-ID-keyed map on top of Parameters', () => {
+      const overrides: EnvOverrideFile = {
+        Parameters: { LITERAL: 'global', GLOBAL: 'g' },
+        [LOGICAL]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'fn-specific', GLOBAL: 'g', FN_ONLY: 'f' });
+    });
+
+    it('does not match a different logical ID', () => {
+      const overrides: EnvOverrideFile = {
+        OtherFn99: { FN_ONLY: 'should-not-apply' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'template' });
+    });
+  });
+
+  describe('--env-vars: function-specific entry — display-path key (issue #27)', () => {
+    it('applies a top-level display-path-keyed map', () => {
+      const overrides: EnvOverrideFile = {
+        [PATH]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'fn-specific', FN_ONLY: 'f' });
+    });
+
+    it('applies a nested-stack display path', () => {
+      const overrides: EnvOverrideFile = {
+        [NESTED_PATH]: { NESTED_ONLY: 'on' },
+      };
+      const result = resolveEnvVars(LOGICAL, NESTED_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ NESTED_ONLY: 'on' });
+    });
+
+    it('display-path key with null clears a templateEnv-supplied key', () => {
+      const overrides: EnvOverrideFile = { [PATH]: { LITERAL: null } };
+      const result = resolveEnvVars(
+        LOGICAL,
+        PATH,
+        { LITERAL: 'template', KEEP: 'k' },
+        overrides
+      );
+      expect(result.resolved).toEqual({ KEEP: 'k' });
+    });
+
+    it('does not match a different display path', () => {
+      const overrides: EnvOverrideFile = {
+        'OtherStack/OtherHandler': { FN_ONLY: 'should-not-apply' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'template' });
+    });
+
+    it('skips the display-path lookup when displayPath is undefined', () => {
+      const overrides: EnvOverrideFile = {
+        [PATH]: { FN_ONLY: 'should-not-apply' },
+      };
+      // No display path known for this function — only the logical-ID key
+      // would be matched, and there isn't one in this override file.
+      const result = resolveEnvVars(LOGICAL, undefined, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'template' });
+    });
+  });
+
+  describe('--env-vars: conflict resolution between logical-ID and display-path keys', () => {
+    it('applies later JSON insertion wins (display path after logical ID)', () => {
+      // JSON insertion order is preserved by Object.entries on a plain
+      // object literal; the display-path entry comes after the logical-ID
+      // entry, so its value wins.
+      const overrides: EnvOverrideFile = {
+        [LOGICAL]: { LITERAL: 'from-logical-id' },
+        [PATH]: { LITERAL: 'from-display-path' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'from-display-path' });
+    });
+
+    it('applies later JSON insertion wins (logical ID after display path)', () => {
+      const overrides: EnvOverrideFile = {
+        [PATH]: { LITERAL: 'from-display-path' },
+        [LOGICAL]: { LITERAL: 'from-logical-id' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'from-logical-id' });
+    });
+
+    it('merges non-conflicting keys from both forms', () => {
+      const overrides: EnvOverrideFile = {
+        [LOGICAL]: { FROM_LOGICAL: 'L' },
+        [PATH]: { FROM_PATH: 'P' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ FROM_LOGICAL: 'L', FROM_PATH: 'P' });
+    });
+
+    it('does not double-apply when caller passes the same value for logicalId and displayPath', () => {
+      // A defensive caller may fall back to the logical ID when the
+      // display path is missing; the resolver dedupes so the map is not
+      // applied twice (which would matter if the map's values were
+      // computed at resolution time — here it is idempotent, but the
+      // contract holds).
+      const overrides: EnvOverrideFile = {
+        [LOGICAL]: { ONLY: 'applied-once' },
+      };
+      const result = resolveEnvVars(LOGICAL, LOGICAL, undefined, overrides);
+      expect(result.resolved).toEqual({ ONLY: 'applied-once' });
+    });
+  });
+
+  describe('--env-vars: misc', () => {
+    it('ignores non-object entries (loose-shape tolerance)', () => {
+      const overrides = {
+        Parameters: { GLOBAL: 'g' },
+        [LOGICAL]: 'a-string-not-a-map',
+      } as unknown as EnvOverrideFile;
+      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ GLOBAL: 'g' });
+    });
+
+    it('Parameters layer applies even when no function-specific key matches', () => {
+      const overrides: EnvOverrideFile = {
+        Parameters: { GLOBAL: 'g' },
+        OtherFn99: { FN_ONLY: 'no-match' },
+      };
+      const result = resolveEnvVars(LOGICAL, PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ GLOBAL: 'g' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #27

Extend `--env-vars <file>` so a function-specific override entry can be keyed by either:

- a **CloudFormation logical ID** (`MyFunction1234ABCD`) — the existing SAM-compatible form, unchanged.
- a **CDK display path** (`MyStack/MyFunction` / `MyStack/Nested/MyFunction`) — the same form `cdkl invoke <target>` accepts, new.

Both forms coexist in the same file. When both keys are present for the same function the later JSON entry wins (matching SAM's apply-in-order semantics). Use one form per function to avoid surprises.

## Implementation

Resolver signature change:
```ts
- resolveEnvVars(logicalId, templateEnv, overrides)
+ resolveEnvVars(logicalId, displayPath, templateEnv, overrides)
```

`displayPath` is the resource's `Metadata['aws:cdk:path']` (the L1 form CDK encodes, e.g. `MyStack/MyFunction/Resource`), or `undefined` when no path metadata exists. The two production callers (`cdkl invoke` + `cdkl start-api`) thread it through from each lambda's already-loaded template resource.

### Display-path matching: prefix rule

Override-key matching for display paths uses the **same prefix rule** the rest of cdk-local applies to `cdkl invoke <target>` (see [`src/cli/cdk-path.ts`](src/cli/cdk-path.ts) `resolveCdkPathToLogicalIds`):

> An override key matches when the resource's `aws:cdk:path` is **exactly that key** OR **starts with `key + "/"`**.

That lets a user write the L2 form they read straight out of CDK app code (`MyStack/MyFunction`) and have it match the synthesized L1 resource at `MyStack/MyFunction/Resource` — no `/Resource` suffix lookup required. The `key + "/"` slash boundary prevents false positives across sibling constructs: `MyStack/MyFn` does NOT match `MyStack/MyFnBackup/Resource`.

Side effect: a parent-stack key (`MyStack`) now applies to every function under that subtree — a natural "scope to one stack" pattern that mirrors how `cdkl invoke MyStack` would match every Lambda in the stack.

### Unresolved-intrinsic warning

The "this var was dropped, override it with --env-vars" warning now interpolates the display path (when one is known) into its example, so the suggested fix matches the README guidance.

### ECS (`run-task` / `start-service`)

Unaffected — those paths key function-specific overrides by container name (from the task definition's `ContainerDefinitions[].Name`), a separate namespace from logical ID / display path. The README's overlay section is updated to clarify which key form applies to which command (this clarification fixes a pre-existing wording bug in the README that said "function-specific keys are CloudFormation logical IDs" for all four commands).

## Tests

### Unit (`tests/unit/local/env-resolver.test.ts`, new — 19 cases)

Covers template-only resolution, `Parameters` overlay (with `null` clearing for SAM-compat), logical-ID key match, display-path exact match (L1 form), display-path prefix match (L2 form, nested stack form, parent-stack scope), `displayPath: undefined` fallback, the sibling-no-false-positive guarantee from the `key + "/"` boundary, conflict resolution (later wins both ways), non-overlapping merge across both forms, and loose-shape tolerance for non-object entries.

### Integration (`tests/integration/local-invoke/verify.sh`)

Added a `[4/5]` scenario that exercises the L2 display-path key end-to-end against the existing `EchoHandler` fixture:

```bash
echo '{"CdkLocalInvokeFixture/EchoHandler":{"GREETING":"path-key-overridden"}}' > "${DP_ENV_FILE}"
${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${DP_ENV_FILE}" --no-pull
# expected response: {"echoed":{},"greeting":"path-key-overridden"}
```

`[1/5]` and `[2/5]` labels also updated from `[1/4]` / `[2/4]` for consistency. `/run-integ local-invoke` passes all 5 scenarios cleanly with 0 orphan containers / networks.

## README

The "Override env vars without a state source" section now leads with the display-path form as the recommended shape for new files and documents both the L2 prefix rule for Lambda and the container-name keying for ECS.

## Versioning impact

This is the first `feat:` commit since the baseline tag `v0.0.1` was set at the previous main HEAD. Merging this PR will fire `release.yml` → semantic-release will compute `v0.1.0` from the conventional-commit history and publish `cdk-local@0.1.0` to npm via OIDC.

## Follow-up

The note in #27 about cdkd needing a parallel mirror is **handled by Phase 3** (cdkd's `src/local/**` becomes a shim that imports `cdk-local`). That work is queued separately; the feature ships in one place and propagates to cdkd via a dependency-version bump once Phase 3 lands.

## Refs

- Closes #27
- Companion to draft PR #40 (GIF demo scaffolding, recording deferred until `cdk-local@0.1.0` lands on npm)
