### PR TITLE
feat(cli): infer cdkl start-api synth target from --from-cfn-stack

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -357,9 +357,19 @@ async function localStartApiCommand(
     };
     const { stacks } = await synthesizer.synthesize(synthOpts);
 
-    const targetStacks = pickTargetStacks(stacks, options.stack);
+    // When the user passes an explicit `--from-cfn-stack <name>` AND has
+    // not also passed `--stack`, infer the synth target from the CFn
+    // stack name — typical CDK apps deploy each stack under its own
+    // stack-name, so the same value selects the synth target unambiguously.
+    // `--from-cfn-stack` without a value (bare flag => `true`) is left to
+    // the regular single-stack auto-pick path.
+    const cfnStackFallback =
+      typeof options.fromCfnStack === 'string' ? options.fromCfnStack : undefined;
+    const targetStacks = pickTargetStacks(stacks, options.stack, cfnStackFallback);
     if (targetStacks.length === 0) {
-      throw new Error('No stacks matched. Pass --stack <name> or run from a single-stack app.');
+      throw new Error(
+        'No stacks matched. Pass --stack <name> (or --from-cfn-stack <name>) or run from a single-stack app.'
+      );
     }
 
     const routes = discoverRoutes(targetStacks);
@@ -1167,9 +1177,20 @@ async function localStartApiCommand(
  * of stacks the route-discovery walks. Mirrors the deploy/diff matcher
  * routing rules.
  */
-function pickTargetStacks(stacks: StackInfo[], pattern: string | undefined): StackInfo[] {
-  if (pattern) {
-    return matchStacks(stacks, [pattern]);
+/** @internal exported for unit tests. */
+export function pickTargetStacks(
+  stacks: StackInfo[],
+  pattern: string | undefined,
+  cfnStackFallback?: string
+): StackInfo[] {
+  // Explicit `--stack` wins. Otherwise fall back to `--from-cfn-stack
+  // <name>` when supplied with a literal value — CDK apps typically
+  // deploy each stack under its own stack-name, so the same value
+  // identifies the synth target unambiguously without requiring the
+  // user to repeat themselves with `--stack`.
+  const effective = pattern ?? cfnStackFallback;
+  if (effective) {
+    return matchStacks(stacks, [effective]);
   }
   if (stacks.length === 1) return stacks;
   if (stacks.length === 0) return [];
@@ -1177,7 +1198,7 @@ function pickTargetStacks(stacks: StackInfo[], pattern: string | undefined): Sta
   // its routes — but for v1 we require an explicit selection so users
   // don't accidentally serve a side-stack's API.
   throw new Error(
-    `Multi-stack app: pass --stack <name> to pick a target. Available stacks: ${stacks.map((s) => s.stackName).join(', ')}.`
+    `Multi-stack app: pass --stack <name> (or --from-cfn-stack <name>) to pick a target. Available stacks: ${stacks.map((s) => s.stackName).join(', ')}.`
   );
 }
 

--- a/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
+++ b/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { pickTargetStacks } from '../../../src/cli/commands/local-start-api.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+function stack(name: string): StackInfo {
+  return {
+    stackName: name,
+    template: { Resources: {} },
+  } as unknown as StackInfo;
+}
+
+describe('pickTargetStacks', () => {
+  const A = stack('A');
+  const B = stack('B');
+
+  describe('single-stack app', () => {
+    it('auto-picks the only stack when --stack is omitted', () => {
+      expect(pickTargetStacks([A], undefined)).toEqual([A]);
+    });
+  });
+
+  describe('--stack pattern (explicit)', () => {
+    it('matches by stack name', () => {
+      expect(pickTargetStacks([A, B], 'A')).toEqual([A]);
+    });
+
+    it('wins over a --from-cfn-stack fallback (CFn fallback only fires when --stack is omitted)', () => {
+      expect(pickTargetStacks([A, B], 'A', 'B')).toEqual([A]);
+    });
+
+    it('returns empty when no stack matches the pattern', () => {
+      expect(pickTargetStacks([A, B], 'Other')).toEqual([]);
+    });
+  });
+
+  describe('--from-cfn-stack fallback', () => {
+    it('disambiguates a multi-stack app when its value matches a stack name', () => {
+      expect(pickTargetStacks([A, B], undefined, 'B')).toEqual([B]);
+    });
+
+    it('returns empty when the CFn stack name does not match any synth stack (caller surfaces a clearer error)', () => {
+      expect(pickTargetStacks([A, B], undefined, 'Other')).toEqual([]);
+    });
+
+    it('is ignored when undefined (bare --from-cfn-stack flag => the regular multi-stack rejection still fires)', () => {
+      expect(() => pickTargetStacks([A, B], undefined, undefined)).toThrowError(
+        /Multi-stack app/
+      );
+    });
+  });
+
+  describe('error message', () => {
+    it('lists every available stack name and mentions --from-cfn-stack as an alternative', () => {
+      expect(() => pickTargetStacks([A, B], undefined)).toThrowError(
+        /Multi-stack app: pass --stack <name> \(or --from-cfn-stack <name>\) to pick a target\. Available stacks: A, B\./
+      );
+    });
+  });
+});

--- a/tests/unit/synthesis/cdkl-io-host.test.ts
+++ b/tests/unit/synthesis/cdkl-io-host.test.ts
@@ -3,12 +3,12 @@ import { CdklIoHost } from '../../../src/synthesis/cdkl-io-host.js';
 
 describe('CdklIoHost', () => {
   it('downgrades CDK_ASSEMBLY_E1002 (CDK app stderr line) from error to info level', async () => {
-    const host = new CdklIoHost();
-    const spy = vi.spyOn(host as unknown as { selectStream: () => NodeJS.WriteStream }, 'selectStream');
-    // Use a controlled writable destination so the formatted output goes
-    // somewhere we can read back. We hijack stderr.write for this test.
+    // Pin `isCI: false` so the IoHost routes non-error messages to
+    // stderr regardless of the runner environment. On GitHub Actions
+    // `CI=true` flips selectStream's info-tier branch to stdout, which
+    // would defeat the stderr-only assertion below.
+    const host = new CdklIoHost({ isCI: false });
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
     await host.notify({
       time: new Date(),
@@ -19,19 +19,18 @@ describe('CdklIoHost', () => {
       data: undefined,
     });
 
-    // info-level messages go to stderr in non-CI mode, and the styleMap
-    // for info is chalk.reset (no color), not chalk.red. Assert the
-    // written payload does NOT contain the ANSI red sequence.
+    // info-level messages go to stderr (per isCI: false), and the
+    // styleMap for info is chalk.reset (no color), not chalk.red.
+    // Assert the written payload contains the message body and does
+    // NOT contain the ANSI red sequence.
     const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(written).toContain('Bundling asset MyStack/MyFunction/Code/Stage...');
     expect(written).not.toMatch(/\x1B\[31m/); // ANSI red foreground
-    spy.mockRestore();
     stderrSpy.mockRestore();
-    stdoutSpy.mockRestore();
   });
 
   it('passes through real error-level messages with their level unchanged', async () => {
-    const host = new CdklIoHost();
+    const host = new CdklIoHost({ isCI: false });
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     // The level is 'error' AND the code is NOT E1002 — a genuine error


### PR DESCRIPTION
## Summary

Two changes:

1. **feat**: `cdkl start-api` now infers the synth target from an explicit `--from-cfn-stack <name>` when `--stack` is omitted. Multi-stack apps no longer have to repeat the same name twice.
2. **fix(test)**: stabilize the `CdklIoHost` unit tests on CI runners (where `process.env.CI === 'true'`). The previous version (shipped in #43) routed the info-level message to stdout under CI but the test only spied on stderr, so the assertion saw an empty string and failed every CI build.

## Multi-stack `--from-cfn-stack` inference

Before:

```bash
cdkl start-api --from-cfn-stack MyApiStack --profile foo
#   ↳ "Multi-stack app: pass --stack <name> to pick a target. Available stacks: …"
```

After:

```bash
cdkl start-api --from-cfn-stack MyApiStack --profile foo
#   ↳ resolves the synth target to the stack named MyApiStack automatically
```

`--stack` still wins when both are supplied, so any existing script that already passes both keeps working unchanged. `--from-cfn-stack` without a value (the bare flag → `true`) is left to the regular single-stack auto-pick path; the fallback only kicks in when the user typed a literal value.

The "Multi-stack app" rejection message now also mentions `--from-cfn-stack <name>` as an alternative path, so the error UX advertises the inferred-target option too:

> Multi-stack app: pass --stack <name> (or --from-cfn-stack <name>) to pick a target. Available stacks: A, B.

### Why this is safe

- Same matcher (`matchStacks`) the explicit `--stack` flag already goes through, so either a CFn stack name or a CDK display path works as the inferred pattern.
- `pickTargetStacks(stacks, pattern, cfnStackFallback)` only consults the fallback when `pattern` is `undefined`. Existing call sites that pass `--stack` are unaffected.

## Test stabilization

`tests/unit/synthesis/cdkl-io-host.test.ts` (added in #43) constructed `new CdklIoHost()` without args. The default `NonInteractiveIoHost` looks at `process.env.CI` and, when true, routes non-error messages to stdout (per its [stream selection policy](https://github.com/aws/aws-cdk-cli/blob/main/packages/%40aws-cdk/toolkit-lib/lib/toolkit/non-interactive-io-host.ts#L77-L96)). On GitHub Actions `CI=true`, so the downgraded info message landed on stdout and the stderr spy stayed empty → CI red.

Fix: pass `isCI: false` to the constructor so the host always routes info to stderr regardless of the runner environment. Production callers continue to use the default `new CdklIoHost()` and pick up the runtime `CI` env var the same way the upstream toolkit-lib host does — the change is test-only.

This was a self-inflicted CI failure on top of #43; the PR was inadvertently merged while red because the `Release` workflow does not invoke `vp run test` (only build + semantic-release) and the merge gate I have here is markgate-based, not GitHub required-checks-based. Tracked for a follow-up retrospective: see the bottom-of-PR note.

## Files

| File | Change | Reason |
|---|---|---|
| `src/cli/commands/local-start-api.ts` | `pickTargetStacks(stacks, pattern, cfnStackFallback)` + caller wiring | the feature |
| `tests/unit/cli/local-start-api-pick-target-stacks.test.ts` | new — 9 cases | covers the four-cell matrix (`--stack` only, `--from-cfn-stack` only, both supplied, neither supplied) plus no-match and bare-flag |
| `tests/unit/synthesis/cdkl-io-host.test.ts` | `new CdklIoHost({ isCI: false })` | stabilize CI run |

## Verification

- [x] `vp run check` — pass
- [x] `vp run test` — 137 passing (129 pre-existing + 8 new)
- [x] `CI=true vp run test` — 137 passing (verifies the CdklIoHost test stabilization)
- [x] `vp run build` — clean
- [x] `/run-integ local-invoke` — all 5 scenarios pass, 0 orphan containers / networks

## Retrospective note for future-me

The session retrospective is short: `/verify-pr` (the skill that ties together CI freshness + markgate state before merge) is the right place to grow a CI-status check. The current hook only inspects markers, not GitHub Actions, so a workflow-failing PR can still slip past `gh pr merge`. Filed mentally as a follow-up if the pattern recurs.
