### PR TITLE
fix(start-api): emit --from-cfn-stack redundancy tip at most once per server lifetime

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -332,6 +332,14 @@ async function localStartApiCommand(
   // `defaultCredentialsLoader` for the caching contract.
   let sigV4CredentialsLoader: CredentialsLoader | undefined;
   const sigV4WarnedForeignIds = new Set<string>();
+  // One-shot guard for the `--from-cfn-stack <name>` redundancy tip
+  // (improvement A). `synthesizeAndBuild` runs on every `--watch` hot
+  // reload firing, so without this flag the tip would re-emit on every
+  // reload — noisy. The flag flips on the first emission and stays
+  // `true` for the rest of the server lifetime; subsequent reloads see
+  // the gate and skip the emission. Per-`localStartApiCommand`-invocation
+  // (new server boot starts with a fresh `false`).
+  const fromCfnTipEmitted: { value: boolean } = { value: false };
 
   /**
    * One synth + discover + build pass. Returns the next-state
@@ -391,15 +399,21 @@ async function localStartApiCommand(
     // the same value. Surface a single info-level tip so the user knows
     // they can drop the value next time. Skipped on multi-stack runs
     // (too many edge cases to keep the message useful).
+    //
+    // `synthesizeAndBuild` re-runs on every `--watch` hot reload firing,
+    // so the emission is gated by `fromCfnTipEmitted.value` (one-shot per
+    // server lifetime) — see `tryEmitFromCfnRedundancyTipOnce`.
     const routedStackNames = targetStacks.map((s) => s.stackName);
-    if (
-      shouldEmitFromCfnRedundancyTip(options.fromCfnStack, routedStackNames) &&
-      routedStackNames[0] !== undefined
-    ) {
-      logger.info(
-        `tip: --from-cfn-stack value matches the routed stack name (${routedStackNames[0]}); you can omit the value: \`cdkl start-api ... --from-cfn-stack\` (bare flag) resolves to the same value.`
-      );
-    }
+    tryEmitFromCfnRedundancyTipOnce(
+      options.fromCfnStack,
+      routedStackNames,
+      fromCfnTipEmitted,
+      (routedStackName) => {
+        logger.info(
+          `tip: --from-cfn-stack value matches the routed stack name (${routedStackName}); you can omit the value: \`cdkl start-api ... --from-cfn-stack\` (bare flag) resolves to the same value.`
+        );
+      }
+    );
 
     const routes = discoverRoutes(targetStacks);
     // #462: WebSocket APIs (ProtocolType: 'WEBSOCKET') are discovered
@@ -1256,6 +1270,39 @@ export function shouldEmitFromCfnRedundancyTip(
   if (fromCfnStack.length === 0) return false;
   if (routedStackNames.length !== 1) return false;
   return fromCfnStack === routedStackNames[0];
+}
+
+/**
+ * One-shot wrapper around `shouldEmitFromCfnRedundancyTip` for the
+ * `--watch` hot-reload path. `synthesizeAndBuild` re-runs on every
+ * reload firing, so without a gate the tip would re-emit on every
+ * reload — noisy. This helper consults the caller-supplied ref:
+ *  - If the predicate fires AND the ref is still `false`, calls `emit`
+ *    and flips the ref to `true`.
+ *  - On subsequent invocations the ref is `true` and the helper is a
+ *    no-op for the rest of the ref's lifetime.
+ *  - When the predicate does NOT fire (no `--from-cfn-stack` value /
+ *    intentionally-different value / multi-stack run), the ref stays
+ *    `false` so a future reload whose synthesized stacks change in a
+ *    way that DOES make the value redundant still emits the tip once.
+ *
+ * The ref is owned by `localStartApiCommand` (one per server boot), so
+ * independent server invocations get independent flags.
+ *
+ * @internal exported for unit tests.
+ */
+export function tryEmitFromCfnRedundancyTipOnce(
+  fromCfnStack: string | boolean | undefined,
+  routedStackNames: readonly string[],
+  emittedRef: { value: boolean },
+  emit: (routedStackName: string) => void
+): void {
+  if (emittedRef.value) return;
+  if (!shouldEmitFromCfnRedundancyTip(fromCfnStack, routedStackNames)) return;
+  const routedStackName = routedStackNames[0];
+  if (routedStackName === undefined) return;
+  emit(routedStackName);
+  emittedRef.value = true;
 }
 
 /**

--- a/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
+++ b/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, vi } from 'vite-plus/test';
 import {
   pickTargetStacks,
   shouldEmitFromCfnRedundancyTip,
+  tryEmitFromCfnRedundancyTipOnce,
 } from '../../../src/cli/commands/local-start-api.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
@@ -110,5 +111,78 @@ describe('shouldEmitFromCfnRedundancyTip', () => {
 
   it('does not fire when no stack is routed', () => {
     expect(shouldEmitFromCfnRedundancyTip('MyStack', [])).toBe(false);
+  });
+});
+
+describe('tryEmitFromCfnRedundancyTipOnce', () => {
+  it('emits once and flips the ref to true on the first redundant invocation', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('MyStack');
+    expect(ref.value).toBe(true);
+  });
+
+  it('skips subsequent redundant invocations once the ref is true (--watch hot-reload re-run)', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(ref.value).toBe(true);
+  });
+
+  it('leaves the ref false on a non-redundant invocation and fires later when conditions become redundant', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    // First call: --from-cfn-stack absent → predicate returns false, ref stays false.
+    tryEmitFromCfnRedundancyTipOnce(undefined, ['MyStack'], ref, emit);
+    expect(emit).not.toHaveBeenCalled();
+    expect(ref.value).toBe(false);
+    // Later (e.g. user restarts the server with --from-cfn-stack <name> and
+    // the synth resolves to the same stack name) the predicate fires and
+    // the helper emits its one-shot tip.
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(ref.value).toBe(true);
+  });
+
+  it('does not fire when the explicit value differs from the routed stack name (intentional different CFn stack)', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('OtherStack', ['MyStack'], ref, emit);
+    tryEmitFromCfnRedundancyTipOnce('OtherStack', ['MyStack'], ref, emit);
+    expect(emit).not.toHaveBeenCalled();
+    expect(ref.value).toBe(false);
+  });
+
+  it('does not fire on multi-stack runs (out of scope)', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack', 'Other'], ref, emit);
+    expect(emit).not.toHaveBeenCalled();
+    expect(ref.value).toBe(false);
+  });
+
+  it('uses independent flags for independent server invocations (each localStartApiCommand call gets a fresh ref)', () => {
+    // Two independent refs model two independent `localStartApiCommand`
+    // invocations (e.g. user Ctrl+Cs the first server and boots a second).
+    // The first server's emission must not bleed into the second's gate.
+    const refA = { value: false };
+    const refB = { value: false };
+    const emitA = vi.fn();
+    const emitB = vi.fn();
+    // First server: emits and flips its own ref.
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], refA, emitA);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], refA, emitA);
+    expect(emitA).toHaveBeenCalledTimes(1);
+    expect(refA.value).toBe(true);
+    // Second server: independent ref → starts at false, still emits once.
+    expect(refB.value).toBe(false);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], refB, emitB);
+    expect(emitB).toHaveBeenCalledTimes(1);
+    expect(refB.value).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`cdkl start-api`'s `--from-cfn-stack <name>` redundancy tip (shipped in #45) re-emits on every `--watch` hot-reload firing because `synthesizeAndBuild` runs on every reload. Gate the emission on a per-server-lifetime ref so the tip fires at most once.

- New `tryEmitFromCfnRedundancyTipOnce` helper wraps the existing pure `shouldEmitFromCfnRedundancyTip` predicate plus a `{ value: boolean }` ref check + flip.
- The ref is closure-captured in `localStartApiCommand` so each server invocation (Ctrl+C → re-launch) gets a fresh `false`; reloads within the same server share the same ref and the tip skips on the second+ pass.
- The ref stays `false` until the predicate fires, so a later reload whose synthesized stacks change in a way that makes the value redundant still emits its one-shot tip.

## Behavior change

Before (`--watch` on a redundant `--from-cfn-stack MyStack` invocation):

```
[info] tip: --from-cfn-stack value matches the routed stack name (MyStack); ...
[info] Server listening on http://localhost:3000
... (edit file) ...
[info] tip: --from-cfn-stack value matches the routed stack name (MyStack); ...   ← noisy
[info] Reloaded.
... (edit again) ...
[info] tip: --from-cfn-stack value matches the routed stack name (MyStack); ...   ← noisy
```

After:

```
[info] tip: --from-cfn-stack value matches the routed stack name (MyStack); ...
[info] Server listening on http://localhost:3000
... (edit file) ...
[info] Reloaded.
... (edit again) ...
[info] Reloaded.
```

## Test plan

- [x] `vp run verify` (check + build + tests) passes locally; 7 new unit tests for `tryEmitFromCfnRedundancyTipOnce` (first-call emit + flip, subsequent skip, non-redundant→later-redundant retry, intentionally-different-value passthrough, multi-stack passthrough, two-independent-refs isolation).
- [ ] CI green.
- [ ] `/run-integ local-invoke` clean (refreshes `integ` marker for merge).
