### PR TITLE
docs(readme): explain no cluster command and document --cluster flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ cdkl run-task MyStack/MyTask
 cdkl start-service MyStack/MyService
 ```
 
+There is no cluster command — locally, Docker is the placement target a cluster abstracts away, so there is nothing to run. Both commands accept an optional `--cluster <name>` to set the cluster name surfaced to `ECS_CONTAINER_METADATA_URI_V4` (also used as the local Docker network prefix). See [docs/cli-reference.md](docs/cli-reference.md) for the full ECS option list.
+
 Use this for fast iteration on Lambda code, API routing checks, and container task smoke tests.
 
 ### 2. Bound to a deployed stack


### PR DESCRIPTION
## Summary

- The README ECS section showed `run-task` / `start-service` but never explained why there is no cluster command, nor that both commands accept `--cluster`.
- Adds one paragraph to the standalone ECS section: clarifies that locally Docker is the placement target a cluster abstracts away (so there is nothing to run), documents the optional `--cluster <name>` flag, and links the full ECS option list in `docs/cli-reference.md`.

## Why

A user reading the README could not tell whether cluster-based ECS apps are supported. The flag was already documented in `docs/cli-reference.md` and `docs/local-emulation.md`, but the README — the first thing users read — was silent.

## Test plan

- [x] `vp run check` (typecheck + lint + format) passes
- [x] `vp run build` produces `dist/cli.js` + `dist/index.js`
- [x] `vp run test` — 10 files, 155 tests pass
- [x] Live-test: `node dist/cli.js --help` shows no `cluster` subcommand; `run-task --help` and `start-service --help` both expose `--cluster <name>` — README claims verified against the actual binary
- [x] Link target `docs/cli-reference.md` exists

## Notes

- Docs-only change (single file, README.md). No `src/**` or `tests/integration/**` touched, so the integ marker is n/a.
- Retrospective: the original edit was made in the main worktree before being moved to a feature worktree; reinforced the worktree-first workflow. No new mechanical rule proposed — the convention is already in `.claude/CLAUDE.md` and there is no clean PreToolUse signal that distinguishes a legitimate main-worktree file edit from one that should have started in a worktree.
