### PR TITLE
feat: add embedConfig for host-CLI rebranding

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,7 +63,8 @@ Gateway).
   websocket-server, ecs-task-runner, ecs-service-runner, ecs-network,
   cloud-map-registry, lambda-resolver, ecs-task-resolver,
   route-discovery, authorizer-resolver, lambda-authorizer, cognito-jwt,
-  sigv4-verify, rie-client, intrinsic-image, runtime-image, etc.
+  sigv4-verify, rie-client, intrinsic-image, runtime-image, embed-config
+  (embed-time branding overrides for host CLIs), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cdkl invoke MyStack/MyFunction --event ./event.json --env-vars ./env.json
 
 ## Programmatic use
 
-cdk-local also exports its commands as Commander factories so a host project can embed it into its own CLI and register custom state sources alongside the built-in `--from-cfn-stack`. See [docs/library-mode.md](docs/library-mode.md) for the API and an example.
+cdk-local also exports its commands as Commander factories so a host project can embed it into its own CLI, register custom state sources alongside the built-in `--from-cfn-stack`, and rebrand the embedded commands under its own name. See [docs/library-mode.md](docs/library-mode.md) for the API and an example.
 
 ## License
 

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -61,6 +61,7 @@ const embedConfig: CdkLocalEmbedConfig = {
   productName: 'mytool',        // prose refs: `mytool supports ...`
   resourceNamePrefix: 'mytool-local', // docker/AWS names: `mytool-local-<id>`
   awsBindMountPath: '/mytool-aws',    // container creds bind-mount target
+  envPrefix: 'MYTOOL',          // env fallbacks: MYTOOL_APP / MYTOOL_ROLE_ARN
 };
 
 program.addCommand(createLocalInvokeCommand({ extraStateProviders, embedConfig }));

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -41,3 +41,32 @@ class MyStoreStateProvider implements LocalStateProvider {
 The dispatcher enforces mutual exclusion across `--from-cfn-stack` and
 every registered extra flag, so users get one consistent error message
 when they pass conflicting flags.
+
+## Rebranding the embedded commands
+
+By default the factories render cdk-local's own branding into
+user-visible strings and generated resource names — the `cdkl` binary
+name, the `cdk-local` product name, `cdkl-*` Docker / AWS resource
+identifiers, and the `/cdk-local-aws` credentials bind-mount. A host
+that surfaces these commands under its own name passes an `embedConfig`
+so error messages and resource names read in the host's branding
+instead:
+
+```typescript
+import { createLocalInvokeCommand, type CdkLocalEmbedConfig } from 'cdk-local';
+
+const embedConfig: CdkLocalEmbedConfig = {
+  cliName: 'mytool local',      // subcommand refs: `mytool local invoke` ...
+  binaryName: 'mytool',         // bare process refs: `mytool is exiting` ...
+  productName: 'mytool',        // prose refs: `mytool supports ...`
+  resourceNamePrefix: 'mytool-local', // docker/AWS names: `mytool-local-<id>`
+  awsBindMountPath: '/mytool-aws',    // container creds bind-mount target
+};
+
+program.addCommand(createLocalInvokeCommand({ extraStateProviders, embedConfig }));
+```
+
+Every field is optional and independently falls back to the cdk-local
+default, so omitting `embedConfig` (or any single field) leaves native
+`cdkl` behavior unchanged. Pass the same `embedConfig` to each factory
+the host mounts so the branding is consistent across commands.

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -270,7 +270,9 @@ async function localInvokeCommand(
 
     const appCmd = resolveApp(options.app);
     if (!appCmd) {
-      throw new Error('No CDK app specified. Pass --app, set CDKL_APP, or add "app" to cdk.json.');
+      throw new Error(
+        `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+      );
     }
 
     logger.info('Synthesizing CDK app...');
@@ -1099,7 +1101,7 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
       })
     );
 
-  [...commonOptions, ...appOptions, ...contextOptions].forEach((option) =>
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((option) =>
     invoke.addOption(option)
   );
   invoke.addOption(deprecatedRegionOption);

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -19,6 +19,11 @@ import { resolveApp } from '../config-loader.js';
 import { readCdkPathOrUndefined } from '../cdk-path.js';
 import { createLocalStateProvider, type ExtraStateProviders } from './local-state-source.js';
 import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
+import {
   resolveLambdaTarget,
   type ResolvedImageLambda,
   type ResolvedLambda,
@@ -129,6 +134,8 @@ interface LocalInvokeOptions {
  */
 export interface CreateLocalInvokeCommandOptions {
   extraStateProviders?: ExtraStateProviders;
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
 }
 
 /**
@@ -629,7 +636,9 @@ export function materializeLambdaLayers(layers: { logicalId: string; assetPath: 
       mount: { hostPath: layers[0]!.assetPath, containerPath: '/opt', readOnly: true },
     };
   }
-  const tmpDir = mkdtempSync(path.join(tmpdir(), 'cdkl-invoke-layers-'));
+  const tmpDir = mkdtempSync(
+    path.join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-invoke-layers-`)
+  );
   for (const layer of layers) {
     cpSync(layer.assetPath, tmpDir, { recursive: true, force: true });
   }
@@ -657,7 +666,7 @@ export async function resolveContainerImagePlan(
     if (!parseEcrUri(lambda.imageUri)) {
       throw new Error(
         `Container Lambda '${lambda.logicalId}' has no matching asset in cdk.out, and Code.ImageUri ` +
-          `'${lambda.imageUri}' is not an ECR URI cdkl can authenticate against. ` +
+          `'${lambda.imageUri}' is not an ECR URI ${getEmbedConfig().binaryName} can authenticate against. ` +
           'Re-synthesize the CDK app (so cdk.out includes the build context) or deploy the image to ECR first.'
       );
     }
@@ -742,7 +751,7 @@ async function resolvePseudoParametersForInvoke(
     options.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'] ?? stackRegion;
   if (!region) {
     logger.warn(
-      'Resolver references ${AWS::Region} but cdkl could not determine the target region. ' +
+      `Resolver references \${AWS::Region} but ${getEmbedConfig().binaryName} could not determine the target region. ` +
         'Pass --region, set AWS_REGION, or declare env.region on the CDK stack.'
     );
   }
@@ -863,7 +872,7 @@ async function assumeLambdaExecutionRole(
     const response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
-        RoleSessionName: `cdkl-invoke-${Date.now()}`,
+        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-invoke-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );
@@ -947,7 +956,7 @@ function materializeInlineCode(handler: string, source: string, fileExtension: s
     throw new Error(`Handler '${handler}' is malformed: expected '<modulePath>.<exportName>'.`);
   }
   const modulePath = handler.substring(0, lastDot);
-  const dir = mkdtempSync(path.join(tmpdir(), 'cdkl-invoke-'));
+  const dir = mkdtempSync(path.join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-invoke-`));
   const filePath = path.join(dir, `${modulePath}${fileExtension}`);
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, source, 'utf-8');
@@ -1000,6 +1009,7 @@ function pickReferencedLogicalId(intrinsic: Record<string, unknown>): string | u
 }
 
 export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions = {}): Command {
+  setEmbedConfig(opts.embedConfig);
   const invoke = new Command('invoke')
     .description(
       'Run a Lambda function locally in a Docker container (RIE-backed). ' +

--- a/src/cli/commands/local-profile-credentials-file.ts
+++ b/src/cli/commands/local-profile-credentials-file.ts
@@ -30,15 +30,19 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
+import { getEmbedConfig } from '../../local/embed-config.js';
 
 /**
  * Path inside the container where the credentials file is mounted. Fixed
- * (not user-configurable) so the env-var injection is stable.
- * `/cdk-local-aws/` is outside `/var/task` (the Lambda code mount) and
- * outside `/root/` (which the user's handler may bind-mount or modify),
- * so there is no collision risk with the user's payload.
+ * per run (not user-configurable) so the env-var injection is stable. The
+ * default `/cdk-local-aws/` is outside `/var/task` (the Lambda code mount)
+ * and outside `/root/` (which the user's handler may bind-mount or
+ * modify), so there is no collision risk with the user's payload. The
+ * `${awsBindMountPath}` segment honors the active embed config.
  */
-export const CONTAINER_AWS_CREDENTIALS_PATH = '/cdk-local-aws/credentials';
+export function getContainerAwsCredentialsPath(): string {
+  return `${getEmbedConfig().awsBindMountPath}/credentials`;
+}
 
 /**
  * Resolved profile credentials file ready to mount into a Lambda container.
@@ -58,7 +62,7 @@ export interface ProfileCredentialsFile {
 /**
  * Write a temporary AWS shared-credentials file containing the resolved
  * `--profile <name>` credentials, ready to bind-mount into a Lambda
- * container at {@link CONTAINER_AWS_CREDENTIALS_PATH}.
+ * container at {@link getContainerAwsCredentialsPath}.
  *
  * The file content is the standard `[profile-name]` INI shape:
  *
@@ -97,7 +101,7 @@ export async function writeProfileCredentialsFile(
         `(any of CR, LF, '[', ']' would corrupt the INI file or the docker -e env var).`
     );
   }
-  const dir = await mkdtemp(path.join(tmpdir(), 'cdk-local-profile-creds-'));
+  const dir = await mkdtemp(path.join(tmpdir(), `${getEmbedConfig().productName}-profile-creds-`));
   const hostPath = path.join(dir, 'credentials');
   const lines: string[] = [
     `[${profileName}]`,
@@ -113,7 +117,7 @@ export async function writeProfileCredentialsFile(
   await writeFile(hostPath, lines.join('\n') + '\n', { mode: 0o600 });
   return {
     hostPath,
-    containerPath: CONTAINER_AWS_CREDENTIALS_PATH,
+    containerPath: getContainerAwsCredentialsPath(),
     profileName,
     dispose: async () => {
       // `recursive: true` removes the credentials file + its parent

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -38,6 +38,11 @@ import {
 } from '../../local/ecs-task-runner.js';
 import { matchStacks } from '../stack-matcher.js';
 import { createLocalStateProvider, type ExtraStateProviders } from './local-state-source.js';
+import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
 import type { LocalStateProvider } from '../../local/local-state-provider.js';
 import type { SubstitutionContext } from '../../local/state-resolver.js';
 
@@ -93,6 +98,8 @@ interface LocalRunTaskOptions {
  */
 export interface CreateLocalRunTaskCommandOptions {
   extraStateProviders?: ExtraStateProviders;
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
 }
 
 /**
@@ -261,7 +268,7 @@ async function localRunTaskCommand(
       if (!task.taskRoleArn) {
         throw new Error(
           `--assume-task-role passed without an ARN but the task definition has no resolvable TaskRoleArn. ` +
-            `Either the task definition does not set TaskRoleArn, or it points at a resource cdkl cannot resolve to an IAM Role at synth time. ` +
+            `Either the task definition does not set TaskRoleArn, or it points at a resource ${getEmbedConfig().binaryName} cannot resolve to an IAM Role at synth time. ` +
             `Pass the ARN explicitly: --assume-task-role <arn>`
         );
       }
@@ -329,7 +336,9 @@ async function localRunTaskCommand(
     const result = await runEcsTask(task, runOpts, state);
 
     if (options.detach) {
-      logger.info('Task containers started in detached mode; cdkl is exiting.');
+      logger.info(
+        `Task containers started in detached mode; ${getEmbedConfig().binaryName} is exiting.`
+      );
       logger.info(
         `Use 'docker ps --filter network=${result.state.network?.networkName ?? '<network>'}' to inspect; ` +
           `tear down with 'docker rm -f' and 'docker network rm'.`
@@ -391,7 +400,7 @@ async function assumeTaskRole(
     const response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
-        RoleSessionName: `cdkl-run-task-${Date.now()}`,
+        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-run-task-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );
@@ -442,7 +451,7 @@ async function buildEcsImageResolutionContext(
       candidate.region;
     if (!region) {
       logger.warn(
-        'Resolver references ${AWS::Region} but cdkl could not determine the target region. ' +
+        `Resolver references \${AWS::Region} but ${getEmbedConfig().binaryName} could not determine the target region. ` +
           'Pass --region, set AWS_REGION, or declare env.region on the CDK stack.'
       );
     }
@@ -575,6 +584,7 @@ export async function resolveSidecarCredentials(
 }
 
 export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions = {}): Command {
+  setEmbedConfig(opts.embedConfig);
   const cmd = new Command('run-task')
     .description(
       'Run an AWS::ECS::TaskDefinition locally — pulls/builds images, sets up a per-task docker network ' +
@@ -590,7 +600,7 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
       new Option(
         '--cluster <name>',
         'Cluster name surfaced to ECS_CONTAINER_METADATA_URI_V4 and used as the docker network prefix'
-      ).default('cdkl')
+      ).default(getEmbedConfig().resourceNamePrefix)
     )
     .addOption(
       new Option(
@@ -651,7 +661,7 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
         'Read a deployed CloudFormation stack via DescribeStackResources and substitute Ref / Fn::ImportValue ' +
           'in container env vars / secrets / image URIs with the deployed physical IDs / exports. ' +
           'Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). ' +
-          'Bare form uses the cdkl stack name; pass an explicit value when the CFn stack name differs. ' +
+          `Bare form uses the ${getEmbedConfig().binaryName} stack name; pass an explicit value when the CFn stack name differs. ` +
           'Fn::GetAtt is warn-and-dropped in v1 (CFn DescribeStackResources does not return per-attribute values).'
       )
     )

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -169,7 +169,9 @@ async function localRunTaskCommand(
 
     const appCmd = resolveApp(options.app);
     if (!appCmd) {
-      throw new Error('No CDK app specified. Pass --app, set CDKL_APP, or add "app" to cdk.json.');
+      throw new Error(
+        `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+      );
     }
 
     logger.info('Synthesizing CDK app...');
@@ -677,7 +679,7 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
       })
     );
 
-  [...commonOptions, ...appOptions, ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
   cmd.addOption(deprecatedRegionOption);
   return cmd;
 }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -25,6 +25,11 @@ import {
   rejectExplicitCfnStackWithMultipleStacks,
   type ExtraStateProviders,
 } from './local-state-source.js';
+import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
 import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../../types/resource.js';
 import type { StackState } from '../../types/state.js';
@@ -237,6 +242,8 @@ interface LocalStartApiOptions {
  */
 export interface CreateLocalStartApiCommandOptions {
   extraStateProviders?: ExtraStateProviders;
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
 }
 
 async function localStartApiCommand(
@@ -262,7 +269,7 @@ async function localStartApiCommand(
       );
     }
     logger.warn(
-      "[deprecated] --api <id> will be removed in a future major release. Use the positional argument instead: 'cdkl start-api <id>'."
+      `[deprecated] --api <id> will be removed in a future major release. Use the positional argument instead: '${getEmbedConfig().cliName} start-api <id>'.`
     );
     apiFilter = options.api;
   }
@@ -410,7 +417,7 @@ async function localStartApiCommand(
       fromCfnTipEmitted,
       (routedStackName) => {
         logger.info(
-          `tip: --from-cfn-stack value matches the routed stack name (${routedStackName}); you can omit the value: \`cdkl start-api ... --from-cfn-stack\` (bare flag) resolves to the same value.`
+          `tip: --from-cfn-stack value matches the routed stack name (${routedStackName}); you can omit the value: \`${getEmbedConfig().cliName} start-api ... --from-cfn-stack\` (bare flag) resolves to the same value.`
         );
       }
     );
@@ -431,7 +438,7 @@ async function localStartApiCommand(
     const webSocketApis = wsDiscovery.apis;
     if (routes.length === 0 && webSocketApis.length === 0) {
       throw new Error(
-        'No supported API routes were discovered. cdkl start-api supports AWS::ApiGateway::* (REST v1), AWS::ApiGatewayV2::* (HTTP + WebSocket), and AWS::Lambda::Url (Function URL) with AWS_PROXY integrations only.'
+        `No supported API routes were discovered. ${getEmbedConfig().cliName} start-api supports AWS::ApiGateway::* (REST v1), AWS::ApiGatewayV2::* (HTTP + WebSocket), and AWS::Lambda::Url (Function URL) with AWS_PROXY integrations only.`
       );
     }
 
@@ -829,7 +836,7 @@ async function localStartApiCommand(
     const probe = await probeHostGatewaySupport();
     if (!probe.supported) {
       throw new Error(
-        `cdkl start-api requires Docker ${HOST_GATEWAY_MIN_VERSION.major}.${HOST_GATEWAY_MIN_VERSION.minor}+ ` +
+        `${getEmbedConfig().cliName} start-api requires Docker ${HOST_GATEWAY_MIN_VERSION.major}.${HOST_GATEWAY_MIN_VERSION.minor}+ ` +
           `for WebSocket API support (--add-host=host.docker.internal:host-gateway needs the 20.10 host-gateway alias). ` +
           `Detected server version: ${probe.rawVersion || '<empty — daemon unreachable or output stripped>'}. ` +
           `Upgrade Docker, or remove the WebSocket API from this app to fall back to HTTP-only start-api.`
@@ -1179,7 +1186,7 @@ async function localStartApiCommand(
       if (!forceExitArmed) {
         forceExitArmed = true;
         logger.warn(
-          `Received second ${signal}; force-exiting. Orphan containers may remain — run 'docker ps --filter name=cdkl-' and 'docker rm -f' to clean up.`
+          `Received second ${signal}; force-exiting. Orphan containers may remain — run 'docker ps --filter name=${getEmbedConfig().resourceNamePrefix}-' and 'docker rm -f' to clean up.`
         );
         process.exit(130);
       }
@@ -1470,7 +1477,7 @@ function warnIamRoutes(routesWithAuth: readonly RouteWithAuth[]): boolean {
   if (iamRoutes.length === 0 && oacRoutes.length === 0) return false;
   if (iamRoutes.length > 0) {
     logger.warn(
-      `${iamRoutes.length} route(s) declare AuthorizationType: AWS_IAM — cdkl start-api ` +
+      `${iamRoutes.length} route(s) declare AuthorizationType: AWS_IAM — ${getEmbedConfig().cliName} start-api ` +
         `verifies SigV4 signatures against your local AWS credentials, but does NOT emulate IAM ` +
         `policy evaluation (resource / action / condition rules). Signature-verified callers reach ` +
         `the handler under their own identity; downstream authorization is the dev's responsibility.`
@@ -1483,13 +1490,12 @@ function warnIamRoutes(routesWithAuth: readonly RouteWithAuth[]): boolean {
     logger.warn(
       `${oacRoutes.length} Function URL route(s) with AuthType: AWS_IAM are fronted by a CloudFront ` +
         `Origin Access Control. In production CloudFront re-signs the origin request, so no local ` +
-        `client signature can be verified — cdkl start-api passes these through (warn-and-pass) ` +
+        `client signature can be verified — ${getEmbedConfig().cliName} start-api passes these through (warn-and-pass) ` +
         `WITHOUT requiring --allow-unverified-sigv4. Do NOT trust the request identity in handler code.`
     );
     for (const declaredAt of oacRoutes) {
       logger.warn(`  - ${declaredAt}`);
     }
-  }
   return true;
 }
 
@@ -1839,7 +1845,7 @@ export async function resolveContainerImageForStartApi(
   if (!parseEcrUri(lambda.imageUri)) {
     throw new Error(
       `Container Lambda '${lambda.logicalId}' has no matching asset in cdk.out, and Code.ImageUri ` +
-        `'${lambda.imageUri}' is not an ECR URI cdkl can authenticate against. ` +
+        `'${lambda.imageUri}' is not an ECR URI ${getEmbedConfig().binaryName} can authenticate against. ` +
         'Re-synthesize the CDK app (so cdk.out includes the build context) or deploy the image to ECR first.'
     );
   }
@@ -1925,7 +1931,9 @@ export async function materializeLambdaLayers(
   }
 
   if (flat.length === 1) return flat[0]!.assetPath;
-  const dir = mkdtempSync(path.join(tmpdir(), 'cdkl-start-api-layers-'));
+  const dir = mkdtempSync(
+    path.join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-start-api-layers-`)
+  );
   for (const layer of flat) {
     // `recursive: true` enables the directory copy. `force: true`
     // implements AWS's "last layer wins" file-collision semantic: a
@@ -2073,7 +2081,7 @@ export function resolveLambdaByLogicalId(
     if (!runtime) {
       throw new Error(
         `Lambda '${logicalId}' has no Runtime property and no Code.ImageUri. ` +
-          'cdkl start-api cannot tell if this is a ZIP or a container Lambda.'
+          `${getEmbedConfig().cliName} start-api cannot tell if this is a ZIP or a container Lambda.`
       );
     }
     if (!handler) {
@@ -2169,14 +2177,14 @@ function extractImageUri(
       if (joinResolved.kind === 'needs-state') {
         throw new Error(
           `Lambda '${logicalId}' in ${stackName} references same-stack ECR repository '${joinResolved.repoLogicalId}' via Fn::Join. ` +
-            'cdkl start-api cannot resolve the repository URI without state — ' +
+            `${getEmbedConfig().cliName} start-api cannot resolve the repository URI without state — ` +
             'deploy the stack first, rebuild via lambda.DockerImageCode.fromImageAsset, or pin a public image.'
         );
       }
       if (joinResolved.kind === 'unsupported-join') {
         throw new Error(
           `Lambda '${logicalId}' in ${stackName} has an unsupported Fn::Join Code.ImageUri shape: ${joinResolved.reason}. ` +
-            'cdkl start-api recognizes the canonical CDK 2.x lambda.DockerImageCode.fromEcr Fn::Join shape ' +
+            `${getEmbedConfig().cliName} start-api recognizes the canonical CDK 2.x lambda.DockerImageCode.fromEcr Fn::Join shape ` +
             '(delimiter "" with nested Fn::Select/Fn::Split over an ECR Repository Arn GetAtt + Ref to the repo).'
         );
       }
@@ -2188,10 +2196,10 @@ function extractImageUri(
       // couldn't derive `urlSuffix`). Either way, surface a clear
       // error instead of falling through to ZIP-branch validation.
       const accountIdHint = pseudoParameters
-        ? ' (likely ${AWS::AccountId}, which cdkl cannot derive without a state source or STS)'
-        : ` (cdkl could not derive AWS pseudo parameters because stack.region was undefined)`;
+        ? ` (likely \${AWS::AccountId}, which ${getEmbedConfig().binaryName} cannot derive without a state source or STS)`
+        : ` (${getEmbedConfig().binaryName} could not derive AWS pseudo parameters because stack.region was undefined)`;
       throw new Error(
-        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkl start-api cannot resolve${accountIdHint}. ` +
+        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that ${getEmbedConfig().cliName} start-api cannot resolve${accountIdHint}. ` +
           'Workarounds: deploy first and run with a state-source flag (e.g. --from-cfn-stack or a host-provided extension), or pin a fully-literal public image URI.'
       );
     }
@@ -2242,7 +2250,7 @@ function resolveImageLambda(args: {
     else {
       throw new Error(
         `Lambda '${logicalId}' has unsupported Architectures value '${String(first)}'. ` +
-          'cdkl start-api supports x86_64 and arm64.'
+          `${getEmbedConfig().cliName} start-api supports x86_64 and arm64.`
       );
     }
   }
@@ -2281,7 +2289,7 @@ function resolveAssetCodePath(
   const assetPath = meta?.['aws:asset:path'];
   if (typeof assetPath !== 'string' || assetPath.length === 0) {
     throw new Error(
-      `Lambda '${logicalId}' has no Metadata['aws:asset:path']. cdkl start-api needs this hint to find the local asset directory. Re-synthesize the app and retry.`
+      `Lambda '${logicalId}' has no Metadata['aws:asset:path']. ${getEmbedConfig().cliName} start-api needs this hint to find the local asset directory. Re-synthesize the app and retry.`
     );
   }
   const cdkOutDir = stack.assetManifestPath ? path.dirname(stack.assetManifestPath) : process.cwd();
@@ -2372,7 +2380,7 @@ function materializeInlineCode(
     throw new Error(`Handler '${handler}' is malformed: expected '<modulePath>.<exportName>'.`);
   }
   const modulePath = handler.substring(0, lastDot);
-  const dir = mkdtempSync(path.join(tmpdir(), 'cdkl-start-api-'));
+  const dir = mkdtempSync(path.join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-start-api-`));
   tmpDirsOut.add(dir);
   const filePath = path.join(dir, `${modulePath}${fileExtension}`);
   mkdirSync(path.dirname(filePath), { recursive: true });
@@ -2509,7 +2517,7 @@ async function assumeLambdaExecutionRole(
     const response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
-        RoleSessionName: `cdkl-start-api-${Date.now()}`,
+        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-start-api-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );
@@ -2758,7 +2766,7 @@ async function reloadAllServers(args: {
   const removed = [...oldKeys].filter((k) => !newKeys.has(k));
   if (added.length > 0) {
     logger.warn(
-      `Reload detected new API surface(s): ${added.join(', ')}. Restart 'cdkl start-api' to serve them.`
+      `Reload detected new API surface(s): ${added.join(', ')}. Restart '${getEmbedConfig().cliName} start-api' to serve them.`
     );
   }
   if (removed.length > 0) {
@@ -3084,13 +3092,14 @@ export function resolveMtlsConfig(
  * Builder for the `start-api` subcommand.
  */
 export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptions = {}): Command {
+  setEmbedConfig(opts.embedConfig);
   const startApi = new Command('start-api')
     .description(
       'Run a long-running local HTTP server that maps API Gateway routes (REST v1, HTTP API, Function URL) to Lambda invocations against the AWS Lambda Runtime Interface Emulator (Docker required). Supports Lambda TOKEN/REQUEST authorizers, Cognito User Pool / HTTP v2 JWT authorizers, and AWS_IAM auth (REST v1 `AuthorizationType: AWS_IAM` and Function URL `AuthType: AWS_IAM` — SigV4 signature verification only; IAM policy evaluation is NOT emulated). When JWKS is unreachable, JWT authorizers fall back to pass-through (every token accepted) with a warn line — local dev fallback. VPC-config Lambdas run locally and surface a warn line at startup; their containers do NOT get attached to the deployed VPC subnets, so calls to private RDS / ElastiCache will fail.'
     )
     .argument(
       '[target]',
-      "Optional API filter. Accepts the bare CDK logical id ('MyHttpApi'; single-stack apps only), stack-qualified logical id ('MyStack:MyHttpApi'), full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). When omitted, every discovered API gets its own server. Mirrors `cdkl invoke` / `cdkl run-task` target syntax."
+      `Optional API filter. Accepts the bare CDK logical id ('MyHttpApi'; single-stack apps only), stack-qualified logical id ('MyStack:MyHttpApi'), full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). When omitted, every discovered API gets its own server. Mirrors \`${getEmbedConfig().cliName} invoke\` / \`${getEmbedConfig().cliName} run-task\` target syntax.`
     )
     .addOption(
       new Option('--port <port>', 'HTTP server port (default: auto-allocate)').default('0')
@@ -3184,7 +3193,7 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
           'requestContext.authentication.clientCert (HTTP API v2). Must be set together with ' +
           '--mtls-cert + --mtls-key; partial flag sets are rejected. ' +
           'Generate a CA + server + client cert for local dev: ' +
-          'openssl req -x509 -newkey rsa:2048 -nodes -keyout ca-key.pem -out ca.pem -subj "/CN=cdkl-ca" -days 365; ' +
+          `openssl req -x509 -newkey rsa:2048 -nodes -keyout ca-key.pem -out ca.pem -subj "/CN=${getEmbedConfig().resourceNamePrefix}-ca" -days 365; ` +
           'openssl req -newkey rsa:2048 -nodes -keyout server-key.pem -out server-csr.pem -subj "/CN=localhost"; ' +
           'openssl x509 -req -in server-csr.pem -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -days 365; ' +
           'openssl req -newkey rsa:2048 -nodes -keyout client-key.pem -out client-csr.pem -subj "/CN=client"; ' +

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -281,7 +281,9 @@ async function localStartApiCommand(
 
   const appCmd = resolveApp(options.app);
   if (!appCmd) {
-    throw new Error('No CDK app specified. Pass --app, set CDKL_APP, or add "app" to cdk.json.');
+    throw new Error(
+      `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+    );
   }
 
   const overrides = readEnvOverridesFile(options.envVars);
@@ -3231,7 +3233,9 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
       })
     );
 
-  [...commonOptions, ...appOptions, ...contextOptions].forEach((opt) => startApi.addOption(opt));
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) =>
+    startApi.addOption(opt)
+  );
   startApi.addOption(deprecatedRegionOption);
 
   return startApi;

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1498,6 +1498,7 @@ function warnIamRoutes(routesWithAuth: readonly RouteWithAuth[]): boolean {
     for (const declaredAt of oacRoutes) {
       logger.warn(`  - ${declaredAt}`);
     }
+  }
   return true;
 }
 

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -233,7 +233,9 @@ async function localStartServiceCommand(
 
     const appCmd = resolveApp(options.app);
     if (!appCmd) {
-      throw new Error('No CDK app specified. Pass --app, set CDKL_APP, or add "app" to cdk.json.');
+      throw new Error(
+        `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+      );
     }
 
     logger.info('Synthesizing CDK app...');
@@ -854,7 +856,7 @@ export function createLocalStartServiceCommand(
       })
     );
 
-  [...commonOptions, ...appOptions, ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
   cmd.addOption(deprecatedRegionOption);
   return cmd;
 }

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -45,6 +45,11 @@ import {
   rejectExplicitCfnStackWithMultipleStacks,
   type ExtraStateProviders,
 } from './local-state-source.js';
+import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
 import type { LocalStateProvider } from '../../local/local-state-provider.js';
 import type { SubstitutionContext } from '../../local/state-resolver.js';
 import { CloudMapRegistry } from '../../local/cloud-map-registry.js';
@@ -90,6 +95,8 @@ interface LocalStartServiceOptions {
  */
 export interface CreateLocalStartServiceCommandOptions {
   extraStateProviders?: ExtraStateProviders;
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
 }
 
 /**
@@ -116,7 +123,7 @@ async function localStartServiceCommand(
 
   if (!targets || targets.length === 0) {
     throw new LocalStartServiceError(
-      'cdkl start-service requires at least one <target>. ' +
+      `${getEmbedConfig().cliName} start-service requires at least one <target>. ` +
         "Pass one or more service paths like 'Stack/Orders' 'Stack/Frontend'."
     );
   }
@@ -531,7 +538,7 @@ async function assumeTaskRole(
     const response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
-        RoleSessionName: `cdkl-start-service-${Date.now()}`,
+        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-start-service-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );
@@ -583,7 +590,7 @@ async function buildEcsImageResolutionContext(
       candidate.region;
     if (!region) {
       logger.warn(
-        'Resolver references ${AWS::Region} but cdkl could not determine the target region. ' +
+        `Resolver references \${AWS::Region} but ${getEmbedConfig().binaryName} could not determine the target region. ` +
           'Pass --region, set AWS_REGION, or declare env.region on the CDK stack.'
       );
     }
@@ -747,11 +754,12 @@ export async function resolveSharedSidecarCredentials(options: {
 export function createLocalStartServiceCommand(
   opts: CreateLocalStartServiceCommandOptions = {}
 ): Command {
+  setEmbedConfig(opts.embedConfig);
   const cmd = new Command('start-service')
     .description(
       'Run one or more AWS::ECS::Service resources locally as a long-running emulator. Spins up ' +
         'DesiredCount task replicas per service (clamped by --max-tasks) using the same per-task ' +
-        'docker network + metadata sidecar pattern as `cdkl run-task`, then keeps each ' +
+        `docker network + metadata sidecar pattern as \`${getEmbedConfig().cliName} run-task\`, then keeps each ` +
         'replica running and restarts it on exit per --restart-policy. ^C tears every replica + ' +
         'sidecar + network down. Each <target> accepts a CDK display path (MyStack/MyService) ' +
         'or stack-qualified logical ID (MyStack:MyServiceXYZ); single-stack apps may omit the ' +
@@ -767,7 +775,7 @@ export function createLocalStartServiceCommand(
       new Option(
         '--cluster <name>',
         'Cluster name surfaced to ECS_CONTAINER_METADATA_URI_V4 and used as the docker network prefix'
-      ).default('cdkl')
+      ).default(getEmbedConfig().resourceNamePrefix)
     )
     .addOption(
       new Option(
@@ -830,7 +838,7 @@ export function createLocalStartServiceCommand(
         'Read a deployed CloudFormation stack via DescribeStackResources and substitute Ref / Fn::ImportValue ' +
           'in container env vars / secrets / image URIs with the deployed physical IDs / exports. ' +
           'Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). ' +
-          'Bare form uses the cdkl stack name; pass an explicit value when the CFn stack name differs. ' +
+          `Bare form uses the ${getEmbedConfig().binaryName} stack name; pass an explicit value when the CFn stack name differs. ` +
           'Fn::GetAtt is warn-and-dropped in v1 (CFn DescribeStackResources does not return per-attribute values).'
       )
     )

--- a/src/cli/commands/local-state-source.ts
+++ b/src/cli/commands/local-state-source.ts
@@ -31,6 +31,7 @@
  */
 
 import { CfnLocalStateProvider } from '../../local/cfn-local-state-provider.js';
+import { getEmbedConfig } from '../../local/embed-config.js';
 import type { LocalStateProvider } from '../../local/local-state-provider.js';
 
 /**
@@ -166,7 +167,7 @@ export function rejectExplicitCfnStackWithMultipleStacks(
   throw new LocalStateSourceError(
     `--from-cfn-stack <name> cannot be used with multiple routed stacks (got ${routedStackCount}). ` +
       'An explicit CFn stack name applies to one stack only and would silently mismap logical IDs across siblings. ' +
-      'Use bare --from-cfn-stack (each stack uses its own name as the CFn stack name) or run one cdkl invocation per stack.'
+      `Use bare --from-cfn-stack (each stack uses its own name as the CFn stack name) or run one ${getEmbedConfig().binaryName} invocation per stack.`
   );
 }
 

--- a/src/cli/config-loader.ts
+++ b/src/cli/config-loader.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { getLogger } from '../utils/logger.js';
+import { getEmbedConfig } from '../local/embed-config.js';
 
 function loadCdkJson(): { app?: string } | null {
   const filePath = resolve(process.cwd(), 'cdk.json');
@@ -33,7 +34,7 @@ function loadCdkJson(): { app?: string } | null {
 export function resolveApp(cliApp?: string): string | undefined {
   if (cliApp) return cliApp;
 
-  const envApp = process.env['CDKL_APP'];
+  const envApp = process.env[`${getEmbedConfig().envPrefix}_APP`];
   if (envApp) return envApp;
 
   return loadCdkJson()?.app ?? undefined;

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,4 +1,5 @@
 import { Option } from 'commander';
+import { getEmbedConfig } from '../local/embed-config.js';
 
 /**
  * Parse context key=value pairs from CLI arguments into a Record.
@@ -17,21 +18,29 @@ export function parseContextOptions(contextArgs?: string[]): Record<string, stri
 }
 
 /**
- * Options shared across every cdk-local command.
+ * Options shared across every cdk-local command. Built per-call (not a
+ * module-level const) so the `--role-arn` env-var hint reflects the active
+ * embed config, which the command factory installs before calling this.
  *
  * `--region` is intentionally NOT in `commonOptions` — local commands
  * pick the region from `AWS_REGION` / profile / synthesized stack env.
  * The deprecated flag below remains for muscle-memory compatibility.
  */
-export const commonOptions = [
-  new Option('--verbose', 'Enable verbose logging').default(false),
-  new Option('--profile <profile>', 'AWS profile'),
-  new Option('--role-arn <arn>', 'IAM role ARN to assume for AWS API calls (env: CDKL_ROLE_ARN)'),
-  new Option(
-    '-y, --yes',
-    'Automatically answer interactive prompts with the recommended response'
-  ).default(false),
-];
+export function commonOptions(): Option[] {
+  const { envPrefix } = getEmbedConfig();
+  return [
+    new Option('--verbose', 'Enable verbose logging').default(false),
+    new Option('--profile <profile>', 'AWS profile'),
+    new Option(
+      '--role-arn <arn>',
+      `IAM role ARN to assume for AWS API calls (env: ${envPrefix}_ROLE_ARN)`
+    ),
+    new Option(
+      '-y, --yes',
+      'Automatically answer interactive prompts with the recommended response'
+    ).default(false),
+  ];
+}
 
 /**
  * Deprecated `--region` option attached to every command.
@@ -59,19 +68,24 @@ export function warnIfDeprecatedRegion(options: { region?: string }): void {
 }
 
 /**
- * App options.
+ * App options. Built per-call (not a module-level const) so the `--app`
+ * env-var hint reflects the active embed config.
  *
- * `--app` is optional: falls back to `CDKL_APP` env var, then `cdk.json`
- * `app` field. Accepts either a shell command (e.g. `"node app.ts"`) or
- * a path to a pre-synthesized cloud assembly directory (e.g. `"cdk.out"`).
+ * `--app` is optional: falls back to `${envPrefix}_APP` env var, then
+ * `cdk.json` `app` field. Accepts either a shell command (e.g.
+ * `"node app.ts"`) or a path to a pre-synthesized cloud assembly directory
+ * (e.g. `"cdk.out"`).
  */
-export const appOptions = [
-  new Option(
-    '-a, --app <command>',
-    'CDK app command (e.g., "node app.ts") or path to a pre-synthesized cloud assembly directory. Falls back to cdk.json or CDKL_APP env'
-  ),
-  new Option('--output <path>', 'Output directory for synthesis').default('cdk.out'),
-];
+export function appOptions(): Option[] {
+  const { envPrefix } = getEmbedConfig();
+  return [
+    new Option(
+      '-a, --app <command>',
+      `CDK app command (e.g., "node app.ts") or path to a pre-synthesized cloud assembly directory. Falls back to cdk.json or ${envPrefix}_APP env`
+    ),
+    new Option('--output <path>', 'Output directory for synthesis').default('cdk.out'),
+  ];
+}
 
 /**
  * Context options.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ export {
   type LocalStateSourceOptions,
 } from './cli/commands/local-state-source.js';
 
+export type { CdkLocalEmbedConfig } from './local/embed-config.js';
+
 export type { LocalStateProvider, LocalStateRecord } from './local/local-state-provider.js';
 export type { CrossStackResolver, SubstitutionContext } from './local/state-resolver.js';
 

--- a/src/local/authorizer-resolver.ts
+++ b/src/local/authorizer-resolver.ts
@@ -6,6 +6,7 @@ import { stringifyValue } from '../utils/stringify.js';
 import { isFunctionUrlOacFronted } from './cors-handler.js';
 import { resolveLambdaArnIntrinsic as resolveLambdaArnShared } from './intrinsic-lambda-arn.js';
 import { pickRefLogicalId } from './intrinsic-utils.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Authorizer detection for `cdkl start-api` (PR 8b of #224).
@@ -300,7 +301,7 @@ export function resolveRestV1Authorizer(
   // orthogonal to (and composable with) TOKEN / REQUEST / COGNITO_USER_POOLS
   // authorizers.
   throw new RouteDiscoveryError(
-    `${stackName}/${authorizerLogicalId}: AWS::ApiGateway::Authorizer.Type '${String(type)}' is not supported by cdkl start-api (only TOKEN / REQUEST / COGNITO_USER_POOLS are accepted at the Authorizer resource).`
+    `${stackName}/${authorizerLogicalId}: AWS::ApiGateway::Authorizer.Type '${String(type)}' is not supported by ${getEmbedConfig().cliName} start-api (only TOKEN / REQUEST / COGNITO_USER_POOLS are accepted at the Authorizer resource).`
   );
 }
 
@@ -378,7 +379,7 @@ export function resolveHttpApiAuthorizer(
   }
 
   throw new RouteDiscoveryError(
-    `${stackName}/${authorizerLogicalId}: AWS::ApiGatewayV2::Authorizer.AuthorizerType '${String(authType)}' is not supported by cdkl start-api (only REQUEST / JWT).`
+    `${stackName}/${authorizerLogicalId}: AWS::ApiGatewayV2::Authorizer.AuthorizerType '${String(authType)}' is not supported by ${getEmbedConfig().cliName} start-api (only REQUEST / JWT).`
   );
 }
 
@@ -594,7 +595,7 @@ function pickStringFromArn(value: unknown, location: string): string {
         const logicalId = arg[0];
         getLogger().warn(
           `${location}: uses Fn::GetAtt against logical ID '${logicalId}'. ` +
-            `cdkl start-api cannot resolve the deployed user pool ARN — synthesizing ` +
+            `${getEmbedConfig().cliName} start-api cannot resolve the deployed user pool ARN — synthesizing ` +
             `an unreachable placeholder so JWKS pass-through admits every token. ` +
             `For real signature verification, set 'providerArns: [pool.userPoolArn]' explicitly on the CDK construct.`
         );
@@ -603,7 +604,7 @@ function pickStringFromArn(value: unknown, location: string): string {
         // is supposed to 404 so the pass-through path is the only outcome.
         // The pool id is namespaced with the logical id so the warn line is
         // easy to grep back to the offending authorizer if multiple coexist.
-        return `arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_cdklplaceholder${logicalId}`;
+        return `arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_${getEmbedConfig().binaryName}placeholder${logicalId}`;
       }
     }
   }
@@ -713,7 +714,7 @@ export function attachAuthorizers(
 
   if (errors.length > 0) {
     throw new RouteDiscoveryError(
-      `cdkl start-api: ${errors.length} authorizer error(s):\n` +
+      `${getEmbedConfig().cliName} start-api: ${errors.length} authorizer error(s):\n` +
         errors.map((e) => `  - ${e}`).join('\n')
     );
   }

--- a/src/local/cloud-map-resolver.ts
+++ b/src/local/cloud-map-resolver.ts
@@ -1,5 +1,6 @@
 import type { StackInfo } from '../synthesis/assembly-reader.js';
 import { EcsTaskResolutionError } from './ecs-task-resolver.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Phase 3 of #262 (Issue #460) — `AWS::ServiceDiscovery::*` template
@@ -99,7 +100,7 @@ export function buildCloudMapIndex(stack: StackInfo): CloudMapIndex {
       throw new EcsTaskResolutionError(
         `Stack ${stack.stackName}: AWS::ServiceDiscovery::PublicDnsNamespace '${logicalId}' ` +
           'is not supported by local emulation — public DNS defeats the "local" point. ' +
-          'Use a PrivateDnsNamespace for cdkl start-service.'
+          `Use a PrivateDnsNamespace for ${getEmbedConfig().cliName} start-service.`
       );
     }
     if (resource.Type === 'AWS::ServiceDiscovery::HttpNamespace') {

--- a/src/local/container-pool.ts
+++ b/src/local/container-pool.ts
@@ -3,6 +3,7 @@ import { pickFreePort, removeContainer, runDetached, streamLogs } from './docker
 import type { ResolvedImageLambda, ResolvedZipLambda } from './lambda-resolver.js';
 import { waitForRieReady } from './rie-client.js';
 import { resolveRuntimeCodeMountPath, resolveRuntimeImage } from './runtime-image.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Per-Lambda warm container pool for `cdkl start-api` (D8.3).
@@ -322,7 +323,7 @@ export function createContainerPool(
    */
   async function startOne(spec: ContainerSpec): Promise<ContainerHandle> {
     const hostPort = await pickFreePort();
-    const name = `cdkl-${spec.lambda.logicalId}-${process.pid}-${Math.floor(
+    const name = `${getEmbedConfig().resourceNamePrefix}-${spec.lambda.logicalId}-${process.pid}-${Math.floor(
       Math.random() * 1_000_000
     )}`;
     logger.debug(
@@ -660,7 +661,7 @@ export function createContainerPool(
           if (r.timedOut) {
             anyTimedOut = true;
             logger.warn(
-              `Container pool dispose timed out waiting for ${r.entry.inUse.size} in-flight handle(s) on ${r.entry.logicalId} after ${drainTimeoutMs}ms; tearing down anyway. The verify.sh \`docker rm -f cdkl-*\` sweep is the safety net.`
+              `Container pool dispose timed out waiting for ${r.entry.inUse.size} in-flight handle(s) on ${r.entry.logicalId} after ${drainTimeoutMs}ms; tearing down anyway. The verify.sh \`docker rm -f ${getEmbedConfig().resourceNamePrefix}-*\` sweep is the safety net.`
             );
           }
         }

--- a/src/local/docker-image-builder.ts
+++ b/src/local/docker-image-builder.ts
@@ -5,6 +5,7 @@ import { runDockerStreaming } from '../utils/docker-cmd.js';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
 import { getLogger } from '../utils/logger.js';
 import { isImageInLocalCache } from './ecr-puller.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Local-build path for `cdkl invoke` against container Lambdas
@@ -137,7 +138,7 @@ function computeLocalTag(source: DockerImageAssetSource): string {
   pushField(hash, 'dockerOutputs', (source.dockerOutputs ?? []).join('\x1f'));
   pushField(hash, 'cacheFrom', (source.cacheFrom ?? []).map((o) => JSON.stringify(o)).join('\x1f'));
   pushField(hash, 'cacheTo', source.cacheTo ? JSON.stringify(source.cacheTo) : '');
-  return `cdkl-invoke-${hash.digest('hex').slice(0, 16)}`;
+  return `${getEmbedConfig().resourceNamePrefix}-invoke-${hash.digest('hex').slice(0, 16)}`;
 }
 
 function pushField(hash: ReturnType<typeof createHash>, name: string, value: string): void {

--- a/src/local/docker-image-builder.ts
+++ b/src/local/docker-image-builder.ts
@@ -120,7 +120,7 @@ export function architectureToPlatform(architecture: 'x86_64' | 'arm64'): string
  * `DockerImageSource` schema so `dockerBuildSecrets` / `dockerBuildContexts`
  * / `cacheFrom` / etc. changes also bust the local cache as expected.
  */
-function computeLocalTag(source: DockerImageAssetSource): string {
+export function computeLocalTag(source: DockerImageAssetSource): string {
   const hash = createHash('sha256');
   // Field-tagged fingerprint: prepend each field's name so adding new fields
   // later doesn't shift the digest for old shapes.

--- a/src/local/docker-runner.ts
+++ b/src/local/docker-runner.ts
@@ -3,6 +3,7 @@ import { createServer } from 'node:net';
 import { promisify } from 'node:util';
 import { getDockerCmd, runDockerForeground, runDockerStreaming } from '../utils/docker-cmd.js';
 import { getLogger } from '../utils/logger.js';
+import { getEmbedConfig } from './embed-config.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -337,7 +338,7 @@ export async function ensureDockerAvailable(): Promise<void> {
     const err = error as { code?: string; stderr?: string; message?: string };
     if (err.code === 'ENOENT') {
       throw new DockerRunnerError(
-        `${cmd} is not installed or not on PATH. cdkl invoke needs Docker (or a compatible CLI specified via CDK_DOCKER) — install it and retry.`
+        `${cmd} is not installed or not on PATH. ${getEmbedConfig().cliName} invoke needs Docker (or a compatible CLI specified via CDK_DOCKER) — install it and retry.`
       );
     }
     throw new DockerRunnerError(

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -7,6 +7,7 @@ import {
 } from '../utils/docker-cmd.js';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
 import { getLogger } from '../utils/logger.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * ECR pull fallback for `cdkl invoke` / `cdkl start-api` /
@@ -166,7 +167,7 @@ export async function pullEcrImage(imageUri: string, options: EcrPullOptions): P
   if (!parsed) {
     throw new LocalInvokeBuildError(
       `Image URI '${imageUri}' is not an ECR URI. ` +
-        'cdkl invoke v1 only authenticates against ECR for the deployed-image fallback path.'
+        `${getEmbedConfig().cliName} invoke v1 only authenticates against ECR for the deployed-image fallback path.`
     );
   }
 
@@ -290,7 +291,7 @@ async function assumeRoleForEcr(
     const response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
-        RoleSessionName: `cdkl-ecr-${Date.now()}`,
+        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-ecr-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );
@@ -365,7 +366,7 @@ async function verifyImageInLocalCache(imageUri: string): Promise<void> {
   } catch {
     throw new LocalInvokeBuildError(
       `Image '${imageUri}' is not in the local docker cache and --no-pull was set. ` +
-        'Either remove --no-pull (cdk-local will pull from ECR) or pre-pull the image manually with `docker pull`.'
+        `Either remove --no-pull (${getEmbedConfig().productName} will pull from ECR) or pre-pull the image manually with \`docker pull\`.`
     );
   }
 }

--- a/src/local/ecs-network.ts
+++ b/src/local/ecs-network.ts
@@ -4,6 +4,7 @@ import { promisify } from 'node:util';
 import { getDockerCmd } from '../utils/docker-cmd.js';
 import { getLogger } from '../utils/logger.js';
 import { DockerRunnerError, pullImage, removeContainer } from './docker-runner.js';
+import { getEmbedConfig } from './embed-config.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -150,7 +151,7 @@ export const SHARED_SVC_SUBNET_OCTET = 171;
 export async function createSharedSvcNetwork(
   options: Omit<CreateTaskNetworkOptions, 'subnetOctet'> = {}
 ): Promise<TaskNetwork> {
-  const prefix = options.prefix ?? 'cdkl';
+  const prefix = options.prefix ?? getEmbedConfig().resourceNamePrefix;
   const suffix = randomBytes(4).toString('hex');
   const networkName = `${prefix}-svc-${suffix}`;
   const { cidr, sidecarIp } = buildEndpointSubnet(SHARED_SVC_SUBNET_OCTET);
@@ -200,10 +201,10 @@ async function createNetworkAndSidecar(args: {
     const e = err as { stderr?: string; message?: string };
     throw new DockerRunnerError(
       `docker network create failed: ${e.stderr?.trim() || e.message || String(err)}. ` +
-        `Hint: another cdk-local run may already own subnet ${cidr}; wait for it to ` +
+        `Hint: another ${getEmbedConfig().productName} run may already own subnet ${cidr}; wait for it to ` +
         'finish, or remove the leftover network with `docker network ls` + ' +
-        '`docker network rm`. `cdkl start-service` shares one network ' +
-        'across every service in the run; bare `cdkl run-task` uses a ' +
+        `\`docker network rm\`. \`${getEmbedConfig().cliName} start-service\` shares one network ` +
+        `across every service in the run; bare \`${getEmbedConfig().cliName} run-task\` uses a ` +
         'per-task network so only one run can be active at a time.'
     );
   }
@@ -257,7 +258,7 @@ async function createNetworkAndSidecar(args: {
 export async function createTaskNetwork(
   options: CreateTaskNetworkOptions = {}
 ): Promise<TaskNetwork> {
-  const prefix = options.prefix ?? 'cdkl';
+  const prefix = options.prefix ?? getEmbedConfig().resourceNamePrefix;
   const suffix = randomBytes(4).toString('hex');
   const networkName = `${prefix}-task-${suffix}`;
   const { cidr, sidecarIp } =

--- a/src/local/ecs-service-resolver.ts
+++ b/src/local/ecs-service-resolver.ts
@@ -9,6 +9,7 @@ import {
   type EcsImageResolutionContext,
   type ResolvedEcsTask,
 } from './ecs-task-resolver.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Phase 2 of #262 — synthesized `AWS::ECS::Service` resolved against the
@@ -209,7 +210,7 @@ export function resolveEcsServiceTarget(
   if (serviceResource.Type === 'AWS::ECS::TaskDefinition') {
     throw new EcsTaskResolutionError(
       `Resource '${serviceLogicalId}' in ${stack.stackName} is an ECS TaskDefinition, not a Service. ` +
-        'Use `cdkl run-task` for one-shot tasks; `cdkl start-service` is Service-only.'
+        `Use \`${getEmbedConfig().cliName} run-task\` for one-shot tasks; \`${getEmbedConfig().cliName} start-service\` is Service-only.`
     );
   }
   if (serviceResource.Type !== 'AWS::ECS::Service') {
@@ -325,7 +326,7 @@ function extractServiceConnect(
   if (!namespaceName) {
     throw new EcsTaskResolutionError(
       `ServiceConnectConfiguration.Namespace must be a literal string (the Cloud Map ` +
-        `namespace name like 'cdkl.local'); got ${JSON.stringify(cfg['Namespace'])}. ` +
+        `namespace name like '${getEmbedConfig().resourceNamePrefix}.local'); got ${JSON.stringify(cfg['Namespace'])}. ` +
         'Intrinsic / cross-stack namespace references are not supported in v1.'
     );
   }
@@ -428,10 +429,10 @@ function extractServiceRegistries(
       // We can't resolve it via the in-process registry; warn + skip.
       warnings.push(
         `ECS Service '${serviceLogicalId}' ServiceRegistries[] entry has a literal-string ` +
-          `RegistryArn ('${registryArn}'); cdk-local cannot resolve external Cloud Map services ` +
+          `RegistryArn ('${registryArn}'); ${getEmbedConfig().productName} cannot resolve external Cloud Map services ` +
           'locally. Skipping this registration; peer services will not discover this endpoint ' +
           'through the in-process registry. Use Fn::GetAtt: [<CloudMapServiceLogicalId>, "Arn"] ' +
-          'instead so cdk-local can resolve the namespace + service name from the synthesized template.'
+          `instead so ${getEmbedConfig().productName} can resolve the namespace + service name from the synthesized template.`
       );
       continue;
     }
@@ -503,7 +504,7 @@ function resolveTaskDefinitionReference(
   }
   throw new EcsTaskResolutionError(
     `ECS Service '${serviceLogicalId}' has an unsupported TaskDefinition reference shape: ` +
-      `${JSON.stringify(taskDefRef)}. cdkl start-service v1 supports only Ref to a ` +
+      `${JSON.stringify(taskDefRef)}. ${getEmbedConfig().cliName} start-service v1 supports only Ref to a ` +
       'same-stack AWS::ECS::TaskDefinition; cross-stack TaskDefinitions are deferred.'
   );
 }

--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -12,6 +12,7 @@ import type { CloudMapRegistry, RegistrationHandle } from './cloud-map-registry.
 import type { CloudMapIndex } from './cloud-map-resolver.js';
 import { getContainerNetworkIp } from './docker-inspect.js';
 import { SHARED_SVC_SUBNET_OCTET, type TaskNetwork } from './ecs-network.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Phase 2 of #262 — long-running ECS Service emulator. Wraps the existing
@@ -703,7 +704,7 @@ async function publishReplicaToCloudMap(
     const index = discovery.cloudMapIndexByStack.get(service.stack.stackName);
     if (!index) {
       logger.warn(
-        `ECS Service '${service.serviceLogicalId}' declares ServiceRegistries[] but cdk-local has ` +
+        `ECS Service '${service.serviceLogicalId}' declares ServiceRegistries[] but ${getEmbedConfig().productName} has ` +
           `no Cloud Map index for stack ${service.stack.stackName}. Skipping registration.`
       );
       return;

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -14,6 +14,7 @@ import {
   substituteAgainstStateAsync,
   type SubstitutionContext,
 } from './state-resolver.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Result of resolving a `cdkl run-task <target>` argument back to a
@@ -581,7 +582,7 @@ export function resolveEcsTaskTarget(
   if (resource.Type === 'AWS::Lambda::Function') {
     throw new EcsTaskResolutionError(
       `Resource '${logicalId}' in ${stack.stackName} is a Lambda function, not an ECS task definition. ` +
-        'Use `cdkl invoke` for Lambda; `cdkl run-task` is ECS only.'
+        `Use \`${getEmbedConfig().cliName} invoke\` for Lambda; \`${getEmbedConfig().cliName} run-task\` is ECS only.`
     );
   }
   if (resource.Type !== 'AWS::ECS::TaskDefinition') {
@@ -660,7 +661,7 @@ function extractTaskDefinitionProperties(
   if (props['ProxyConfiguration']) {
     warnings.push(
       `Task definition '${logicalId}' declares 'ProxyConfiguration' (custom Envoy / App Mesh bootstrap), ` +
-        "which is NOT honored by 'cdkl start-service' / 'cdkl run-task' in v1. " +
+        `which is NOT honored by '${getEmbedConfig().cliName} start-service' / '${getEmbedConfig().cliName} run-task' in v1. ` +
         'Local execution will run without the configured proxy. See design doc § 2 for the rationale.'
     );
   }
@@ -1030,7 +1031,7 @@ function parseContainerImage(
   if (joinResolved.kind === 'needs-state') {
     throw new EcsTaskResolutionError(
       `Container '${containerName}' in task '${taskLogicalId}' references same-stack ECR repository '${joinResolved.repoLogicalId}' via Fn::Join. ` +
-        'cdkl run-task cannot resolve the repository URI without state — ' +
+        `${getEmbedConfig().cliName} run-task cannot resolve the repository URI without state — ` +
         'pass --from-state (the stack must have been deployed via cdkd deploy), ' +
         'build via ContainerImage.fromAsset, or pin a public image.'
     );
@@ -1038,7 +1039,7 @@ function parseContainerImage(
   if (joinResolved.kind === 'unsupported-join') {
     throw new EcsTaskResolutionError(
       `Container '${containerName}' in task '${taskLogicalId}' has an unsupported Fn::Join Image shape: ${joinResolved.reason}. ` +
-        'cdkl run-task recognizes the canonical CDK 2.x ContainerImage.fromEcrRepository Fn::Join shape ' +
+        `${getEmbedConfig().cliName} run-task recognizes the canonical CDK 2.x ContainerImage.fromEcrRepository Fn::Join shape ` +
         '(delimiter "" with nested Fn::Select/Fn::Split over an ECR Repository Arn GetAtt + Ref to the repo).'
     );
   }
@@ -1047,7 +1048,7 @@ function parseContainerImage(
   if (!flat) {
     throw new EcsTaskResolutionError(
       `Container '${containerName}' in task '${taskLogicalId}' has an unparseable Image property. ` +
-        'cdkl run-task v1 supports flat string images, single-key Fn::Sub bodies, and CDK-asset Image references.'
+        `${getEmbedConfig().cliName} run-task v1 supports flat string images, single-key Fn::Sub bodies, and CDK-asset Image references.`
     );
   }
 
@@ -1076,7 +1077,7 @@ function parseContainerImage(
     if (unresolvedRepoRef) {
       throw new EcsTaskResolutionError(
         `Container '${containerName}' in task '${taskLogicalId}' references same-stack ECR repository '${unresolvedRepoRef}'. ` +
-          'cdkl run-task v1 cannot resolve the repository URI without state — ' +
+          `${getEmbedConfig().cliName} run-task v1 cannot resolve the repository URI without state — ` +
           'pass --from-state (the stack must have been deployed via cdkd deploy), ' +
           'build via ContainerImage.fromAsset, or pin a public image.'
       );
@@ -1084,7 +1085,7 @@ function parseContainerImage(
     if (substituted.includes('AWS::')) {
       throw new EcsTaskResolutionError(
         `Container '${containerName}' in task '${taskLogicalId}' has an Image that references AWS pseudo parameters (${substituted}). ` +
-          'cdk-local could not resolve them: confirm AWS credentials are configured so STS GetCallerIdentity succeeds, ' +
+          `${getEmbedConfig().productName} could not resolve them: confirm AWS credentials are configured so STS GetCallerIdentity succeeds, ` +
           'and that --region / AWS_REGION names the target region. ' +
           'Workaround: build the image locally (ContainerImage.fromAsset) or pin a public image.'
       );
@@ -1094,7 +1095,7 @@ function parseContainerImage(
     // a "public" image.
     throw new EcsTaskResolutionError(
       `Container '${containerName}' in task '${taskLogicalId}' has an Image with unresolved \${...} placeholders (${substituted}). ` +
-        'cdkl run-task v1 only resolves AWS pseudo parameters and same-stack AWS::ECR::Repository refs.'
+        `${getEmbedConfig().cliName} run-task v1 only resolves AWS pseudo parameters and same-stack AWS::ECR::Repository refs.`
     );
   }
 
@@ -1237,13 +1238,13 @@ function parseVolume(
 
   if (v['EFSVolumeConfiguration']) {
     throw new EcsTaskResolutionError(
-      `Task '${taskLogicalId}' Volumes[${idx}] '${name}' uses EFSVolumeConfiguration, which cdkl run-task cannot proxy locally. ` +
+      `Task '${taskLogicalId}' Volumes[${idx}] '${name}' uses EFSVolumeConfiguration, which ${getEmbedConfig().cliName} run-task cannot proxy locally. ` +
         `Workaround: bind-mount a local directory at the same containerPath via Host: { SourcePath: '<local-path>' }, or override at runtime via --env-vars semantics for a Phase 2 follow-up.`
     );
   }
   if (v['FSxWindowsFileServerVolumeConfiguration']) {
     throw new EcsTaskResolutionError(
-      `Task '${taskLogicalId}' Volumes[${idx}] '${name}' uses FSxWindowsFileServerVolumeConfiguration, which cdkl run-task cannot proxy locally.`
+      `Task '${taskLogicalId}' Volumes[${idx}] '${name}' uses FSxWindowsFileServerVolumeConfiguration, which ${getEmbedConfig().cliName} run-task cannot proxy locally.`
     );
   }
 

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -24,6 +24,7 @@ import {
   type ResolvedEcsTask,
   type ResolvedEcsVolume,
 } from './ecs-task-resolver.js';
+import { getEmbedConfig } from './embed-config.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -723,7 +724,7 @@ async function prepareOneImage(
             'Re-synthesize the CDK app and retry.'
         );
       }
-      const tag = `cdkl-run-task-${(image.assetHash ?? 'single').slice(0, 16)}`;
+      const tag = `${getEmbedConfig().resourceNamePrefix}-run-task-${(image.assetHash ?? 'single').slice(0, 16)}`;
       const actualTag = await buildDockerImage(asset, cdkOutDir, {
         tag,
         ...(options.platformOverride !== undefined && { platform: options.platformOverride }),
@@ -783,7 +784,7 @@ async function realizeDockerVolumes(
     if (cfg?.labels) {
       for (const [k, val] of Object.entries(cfg.labels)) args.push('--label', `${k}=${val}`);
     }
-    const dockerVolumeName = `cdkl-${v.name}-${randHex(4)}`;
+    const dockerVolumeName = `${getEmbedConfig().resourceNamePrefix}-${v.name}-${randHex(4)}`;
     args.push(dockerVolumeName);
     try {
       await execFileAsync(getDockerCmd(), args);
@@ -883,7 +884,10 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): string[] {
   const args: string[] = ['run', '-d'];
 
   // Stable name so siblings can reach this container via DNS.
-  args.push('--name', `cdkl-${task.family}-${container.name}-${randHex(3)}`);
+  args.push(
+    '--name',
+    `${getEmbedConfig().resourceNamePrefix}-${task.family}-${container.name}-${randHex(3)}`
+  );
   args.push('--network', network);
   args.push('--network-alias', container.name);
 

--- a/src/local/embed-config.ts
+++ b/src/local/embed-config.ts
@@ -49,6 +49,12 @@ export interface CdkLocalEmbedConfig {
    * `'/cdkd-aws'`.
    */
   awsBindMountPath?: string;
+  /**
+   * Prefix for the environment variables this CLI reads — `${envPrefix}_APP`
+   * (the `--app` fallback) and `${envPrefix}_ROLE_ARN` (the `--role-arn`
+   * fallback). Default `'CDKL'`; cdkd passes `'CDKD'`.
+   */
+  envPrefix?: string;
 }
 
 export interface ResolvedEmbedConfig {
@@ -57,6 +63,7 @@ export interface ResolvedEmbedConfig {
   productName: string;
   resourceNamePrefix: string;
   awsBindMountPath: string;
+  envPrefix: string;
 }
 
 const DEFAULTS: ResolvedEmbedConfig = {
@@ -65,6 +72,7 @@ const DEFAULTS: ResolvedEmbedConfig = {
   productName: 'cdk-local',
   resourceNamePrefix: 'cdkl',
   awsBindMountPath: '/cdk-local-aws',
+  envPrefix: 'CDKL',
 };
 
 let current: ResolvedEmbedConfig = DEFAULTS;
@@ -82,6 +90,7 @@ export function setEmbedConfig(config?: CdkLocalEmbedConfig): void {
     productName: config?.productName ?? DEFAULTS.productName,
     resourceNamePrefix: config?.resourceNamePrefix ?? DEFAULTS.resourceNamePrefix,
     awsBindMountPath: config?.awsBindMountPath ?? DEFAULTS.awsBindMountPath,
+    envPrefix: config?.envPrefix ?? DEFAULTS.envPrefix,
   };
 }
 

--- a/src/local/embed-config.ts
+++ b/src/local/embed-config.ts
@@ -1,0 +1,96 @@
+/**
+ * Embed-time branding configuration.
+ *
+ * cdk-local hardcodes its own branding (`cdkl` binary, `cdk-local`
+ * product name, `cdkl-*` Docker / AWS resource names, `/cdk-local-aws`
+ * credential bind-mount) into user-visible error messages and resource
+ * identifiers. A host that embeds cdk-local's Commander factories (e.g.
+ * cdkd, whose binary is `cdkd` and whose subcommand group is
+ * `cdkd local`) passes a {@link CdkLocalEmbedConfig} so those strings
+ * read in the host's own branding instead.
+ *
+ * The four command factories call {@link setEmbedConfig} before building
+ * their Commander option tree, so both construction-time strings (option
+ * descriptions / defaults) and action-time strings (errors, resource
+ * names) read the resolved config via {@link getEmbedConfig}. When no
+ * config is supplied every field falls back to cdk-local's own defaults,
+ * leaving native `cdkl` behavior byte-identical.
+ */
+export interface CdkLocalEmbedConfig {
+  /**
+   * Command prefix for subcommand references in user-facing strings, e.g.
+   * `${cliName} invoke` / `${cliName} start-api`. Default `'cdkl'`; cdkd
+   * passes `'cdkd local'`.
+   */
+  cliName?: string;
+  /**
+   * Bare executable / process name for standalone references, e.g.
+   * `${binaryName} is exiting` / `${binaryName} could not determine ...`,
+   * and the hyphen-free Cognito user-pool placeholder id. Default
+   * `'cdkl'`; cdkd passes `'cdkd'`.
+   */
+  binaryName?: string;
+  /**
+   * Product name for prose references, e.g. `${productName} supports ...`.
+   * Also seeds the profile-credentials tmpdir prefix. Default
+   * `'cdk-local'`; cdkd passes `'cdkd'`.
+   */
+  productName?: string;
+  /**
+   * Prefix for generated Docker / AWS resource identifiers — container,
+   * volume, network, image-tag, tmpdir names, STS `RoleSessionName`s, the
+   * local request id, and the example Cloud Map namespace. Default
+   * `'cdkl'`; cdkd passes `'cdkd-local'`.
+   */
+  resourceNamePrefix?: string;
+  /**
+   * Container directory the host AWS shared-credentials file is
+   * bind-mounted under. Default `'/cdk-local-aws'`; cdkd passes
+   * `'/cdkd-aws'`.
+   */
+  awsBindMountPath?: string;
+}
+
+export interface ResolvedEmbedConfig {
+  cliName: string;
+  binaryName: string;
+  productName: string;
+  resourceNamePrefix: string;
+  awsBindMountPath: string;
+}
+
+const DEFAULTS: ResolvedEmbedConfig = {
+  cliName: 'cdkl',
+  binaryName: 'cdkl',
+  productName: 'cdk-local',
+  resourceNamePrefix: 'cdkl',
+  awsBindMountPath: '/cdk-local-aws',
+};
+
+let current: ResolvedEmbedConfig = DEFAULTS;
+
+/**
+ * Resolve and install the active embed config. Called once per command
+ * factory with the host's overrides (or `undefined` for native cdkl
+ * behavior). Idempotent: re-calling with the same overrides is a no-op,
+ * which is why all four factories may safely set the same config.
+ */
+export function setEmbedConfig(config?: CdkLocalEmbedConfig): void {
+  current = {
+    cliName: config?.cliName ?? DEFAULTS.cliName,
+    binaryName: config?.binaryName ?? DEFAULTS.binaryName,
+    productName: config?.productName ?? DEFAULTS.productName,
+    resourceNamePrefix: config?.resourceNamePrefix ?? DEFAULTS.resourceNamePrefix,
+    awsBindMountPath: config?.awsBindMountPath ?? DEFAULTS.awsBindMountPath,
+  };
+}
+
+/** The active resolved embed config. */
+export function getEmbedConfig(): ResolvedEmbedConfig {
+  return current;
+}
+
+/** Restore cdk-local defaults. Primarily a test-isolation helper. */
+export function resetEmbedConfig(): void {
+  current = DEFAULTS;
+}

--- a/src/local/embed-config.ts
+++ b/src/local/embed-config.ts
@@ -26,8 +26,8 @@ export interface CdkLocalEmbedConfig {
   /**
    * Bare executable / process name for standalone references, e.g.
    * `${binaryName} is exiting` / `${binaryName} could not determine ...`,
-   * and the hyphen-free Cognito user-pool placeholder id. Default
-   * `'cdkl'`; cdkd passes `'cdkd'`.
+   * the local request id, and the hyphen-free Cognito user-pool
+   * placeholder id. Default `'cdkl'`; cdkd passes `'cdkd'`.
    */
   binaryName?: string;
   /**
@@ -38,9 +38,9 @@ export interface CdkLocalEmbedConfig {
   productName?: string;
   /**
    * Prefix for generated Docker / AWS resource identifiers — container,
-   * volume, network, image-tag, tmpdir names, STS `RoleSessionName`s, the
-   * local request id, and the example Cloud Map namespace. Default
-   * `'cdkl'`; cdkd passes `'cdkd-local'`.
+   * volume, network, image-tag, tmpdir names, STS `RoleSessionName`s, and
+   * the example Cloud Map namespace. Default `'cdkl'`; cdkd passes
+   * `'cdkd-local'`.
    */
   resourceNamePrefix?: string;
   /**

--- a/src/local/http-server.ts
+++ b/src/local/http-server.ts
@@ -47,6 +47,7 @@ import {
   resolveServiceIntegrationParameters,
   type RequestParameterContext,
 } from './parameter-mapping.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * The user-facing HTTP server for `cdkl start-api`.
@@ -1577,7 +1578,7 @@ function buildServiceIntegrationContextVars(
   req: IncomingMessage,
   route: DiscoveredRoute
 ): Record<string, string> {
-  const requestId = `cdkl-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const requestId = `${getEmbedConfig().binaryName}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
   const sourceIp = req.socket.remoteAddress ?? '127.0.0.1';
   return {
     requestId,

--- a/src/local/httpv2-service-integration.ts
+++ b/src/local/httpv2-service-integration.ts
@@ -53,6 +53,7 @@ import type * as SfnNs from '@aws-sdk/client-sfn';
 import type * as SqsNs from '@aws-sdk/client-sqs';
 import { stringifyValue } from '../utils/stringify.js';
 import { getLogger } from '../utils/logger.js';
+import { getEmbedConfig } from './embed-config.js';
 
 const logger = getLogger();
 
@@ -429,7 +430,7 @@ async function dispatchAppConfigGetConfiguration(
   void region;
   return errorResponse(
     501,
-    'AppConfig-GetConfiguration is recognized but cdk-local does not yet bundle @aws-sdk/client-appconfig. Use the deployed API for this subtype, or open an issue if you need local emulation.'
+    `AppConfig-GetConfiguration is recognized but ${getEmbedConfig().productName} does not yet bundle @aws-sdk/client-appconfig. Use the deployed API for this subtype, or open an issue if you need local emulation.`
   );
 }
 

--- a/src/local/integration-response-selector.ts
+++ b/src/local/integration-response-selector.ts
@@ -38,6 +38,7 @@
  */
 
 import { VtlEvaluationError } from './vtl-engine.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Shape of one entry in `Integration.IntegrationResponses`. CFn property
@@ -224,7 +225,7 @@ export function evaluateResponseParameters(
       opts.onUnsupported?.(
         key,
         value,
-        `Only method.response.header.<name> keys are supported on REST v1 ResponseParameters; cdk-local cannot map ${key}.`
+        `Only method.response.header.<name> keys are supported on REST v1 ResponseParameters; ${getEmbedConfig().productName} cannot map ${key}.`
       );
       continue;
     }
@@ -242,7 +243,7 @@ export function evaluateResponseParameters(
     opts.onUnsupported?.(
       key,
       value,
-      `ResponseParameter value '${value}' is a mapping expression (integration.response.* / context.*) which cdkl start-api does not emulate. Only single-quoted literals are honored.`
+      `ResponseParameter value '${value}' is a mapping expression (integration.response.* / context.*) which ${getEmbedConfig().cliName} start-api does not emulate. Only single-quoted literals are honored.`
     );
   }
   return out;

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -6,6 +6,7 @@ import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cli/cdk-path.j
 import { matchStacks } from '../cli/stack-matcher.js';
 import { derivePseudoParametersFromRegion, tryResolveImageFnJoin } from './intrinsic-image.js';
 import { stringifyValue } from '../utils/stringify.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Result of resolving a `cdkl invoke <target>` argument back to a
@@ -331,7 +332,7 @@ export function resolveLambdaTarget(target: string, stacks: StackInfo[]): Resolv
     }
     throw new LocalInvokeResolutionError(
       `Resource '${logicalId}' in ${stack.stackName} is ${resource.Type}, not a Lambda function. ` +
-        `cdkl invoke only works on AWS::Lambda::Function resources in v1.`
+        `${getEmbedConfig().cliName} invoke only works on AWS::Lambda::Function resources in v1.`
     );
   }
 
@@ -426,7 +427,7 @@ function extractLambdaProperties(
   if (!runtime) {
     throw new LocalInvokeResolutionError(
       `Lambda '${logicalId}' has no Runtime property and no Code.ImageUri. ` +
-        'cdk-local cannot tell if this is a ZIP or a container Lambda.'
+        `${getEmbedConfig().productName} cannot tell if this is a ZIP or a container Lambda.`
     );
   }
   if (!handler) {
@@ -582,15 +583,15 @@ function extractImageUri(
       if (joinResolved.kind === 'needs-state') {
         throw new LocalInvokeResolutionError(
           `Lambda '${logicalId}' in ${stackName} references same-stack ECR repository '${joinResolved.repoLogicalId}' via Fn::Join. ` +
-            'cdkl invoke cannot resolve the repository URI without state — ' +
-            'deploy the stack first (so cdk-local records the repository physical id), ' +
+            `${getEmbedConfig().cliName} invoke cannot resolve the repository URI without state — ` +
+            `deploy the stack first (so ${getEmbedConfig().productName} records the repository physical id), ` +
             'rebuild via lambda.DockerImageCode.fromImageAsset, or pin a public image.'
         );
       }
       if (joinResolved.kind === 'unsupported-join') {
         throw new LocalInvokeResolutionError(
           `Lambda '${logicalId}' in ${stackName} has an unsupported Fn::Join Code.ImageUri shape: ${joinResolved.reason}. ` +
-            'cdkl invoke recognizes the canonical CDK 2.x lambda.DockerImageCode.fromEcr Fn::Join shape ' +
+            `${getEmbedConfig().cliName} invoke recognizes the canonical CDK 2.x lambda.DockerImageCode.fromEcr Fn::Join shape ` +
             '(delimiter "" with nested Fn::Select/Fn::Split over an ECR Repository Arn GetAtt + Ref to the repo).'
         );
       }
@@ -599,10 +600,10 @@ function extractImageUri(
       // plumbing the typical remaining cause is `${AWS::AccountId}`
       // (needs an STS call or `--from-state`) or an unknown region.
       const accountIdHint = pseudoParameters
-        ? ' (likely ${AWS::AccountId}, which cdk-local cannot derive without --from-state or STS)'
-        : ` (cdk-local could not derive AWS pseudo parameters because stack.region was undefined)`;
+        ? ` (likely \${AWS::AccountId}, which ${getEmbedConfig().productName} cannot derive without --from-state or STS)`
+        : ` (${getEmbedConfig().productName} could not derive AWS pseudo parameters because stack.region was undefined)`;
       throw new LocalInvokeResolutionError(
-        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkl invoke cannot resolve${accountIdHint}. ` +
+        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that ${getEmbedConfig().cliName} invoke cannot resolve${accountIdHint}. ` +
           'Workarounds: deploy first and run with --from-state, or pin a fully-literal public image URI.'
       );
     }
@@ -655,7 +656,7 @@ function extractImageLambdaProperties(args: {
     else {
       throw new LocalInvokeResolutionError(
         `Lambda '${logicalId}' has unsupported Architectures value '${String(first)}'. ` +
-          'cdkl invoke supports x86_64 and arm64.'
+          `${getEmbedConfig().cliName} invoke supports x86_64 and arm64.`
       );
     }
   }
@@ -701,7 +702,7 @@ function resolveAssetCodePath(
   if (typeof assetPath !== 'string' || assetPath.length === 0) {
     throw new LocalInvokeResolutionError(
       `Lambda '${logicalId}' has no Metadata['aws:asset:path']. ` +
-        'cdkl invoke needs this hint to find the local asset directory. ' +
+        `${getEmbedConfig().cliName} invoke needs this hint to find the local asset directory. ` +
         'Re-synthesize the app (without `--output <stale-dir>`) and retry.'
     );
   }
@@ -790,7 +791,7 @@ export function resolveLambdaLayers(
       const parsed = parseLayerVersionArn(entry);
       if (!parsed) {
         throw new LocalInvokeResolutionError(
-          `Lambda '${logicalId}' has a Layers entry [${i}] cdk-local cannot resolve locally: literal string '${entry}'. ` +
+          `Lambda '${logicalId}' has a Layers entry [${i}] ${getEmbedConfig().productName} cannot resolve locally: literal string '${entry}'. ` +
             'Expected a same-stack Ref / Fn::GetAtt to an AWS::Lambda::LayerVersion ' +
             'OR a literal layer-version ARN of the form ' +
             'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.'
@@ -803,7 +804,7 @@ export function resolveLambdaLayers(
     const layerLogicalId = pickLayerLogicalId(entry);
     if (!layerLogicalId) {
       throw new LocalInvokeResolutionError(
-        `Lambda '${logicalId}' has a Layers entry [${i}] cdk-local cannot resolve locally: ${describeLayerEntry(entry)}. ` +
+        `Lambda '${logicalId}' has a Layers entry [${i}] ${getEmbedConfig().productName} cannot resolve locally: ${describeLayerEntry(entry)}. ` +
           'Expected a same-stack Ref / Fn::GetAtt to an AWS::Lambda::LayerVersion ' +
           'OR a literal layer-version ARN of the form ' +
           'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.'

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -6,6 +6,7 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { getLogger } from '../utils/logger.js';
 import type { ResolvedArnLambdaLayer } from './lambda-resolver.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Materialize a literal-ARN Lambda Layer to a host tmpdir so it can be
@@ -147,7 +148,12 @@ export async function materializeLayerFromArn(
     );
   }
 
-  const dir = await mkdtemp(join(tmpdir(), `cdkl-arn-layer-${layer.name}-${layer.version}-`));
+  const dir = await mkdtemp(
+    join(
+      tmpdir(),
+      `${getEmbedConfig().resourceNamePrefix}-arn-layer-${layer.name}-${layer.version}-`
+    )
+  );
   try {
     await unzipBufferToDirectory(zipBytes, dir);
   } catch (err) {
@@ -255,7 +261,7 @@ async function buildAssumeRoleCommand(roleArn: string): Promise<any> {
   const { AssumeRoleCommand } = await import('@aws-sdk/client-sts');
   return new AssumeRoleCommand({
     RoleArn: roleArn,
-    RoleSessionName: `cdkl-layer-${Date.now()}`,
+    RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-layer-${Date.now()}`,
     DurationSeconds: 3600,
   });
 }

--- a/src/local/rest-v1-integrations.ts
+++ b/src/local/rest-v1-integrations.ts
@@ -77,6 +77,7 @@ import {
   type VtlContext,
 } from './vtl-engine.js';
 import { getLogger } from '../utils/logger.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Per-request snapshot the dispatchers consume. Mirrors the shape
@@ -869,7 +870,7 @@ export function warnSsrfRiskyUri(
   if (classification !== undefined) {
     warn(
       `Integration URI for ${routeLabel} points at ${host} — ${classification}. ` +
-        `cdk-local does NOT block this; ensure the upstream is intentional.`
+        `${getEmbedConfig().productName} does NOT block this; ensure the upstream is intentional.`
     );
   }
 }
@@ -932,14 +933,14 @@ function applyRequestParameters(
       // Querystring rewrites are recognized but cdk-local applies querystring
       // rewrites only via URI placeholder substitution; ignore.
       logger.warn(
-        `RequestParameter '${key}' (querystring rewrite) is recognized but cdk-local applies querystring rewrites only via URI placeholder substitution; ignoring.`
+        `RequestParameter '${key}' (querystring rewrite) is recognized but ${getEmbedConfig().productName} applies querystring rewrites only via URI placeholder substitution; ignoring.`
       );
     } else if (pathMatch) {
       // Path rewrites apply at URI substitution time. Log + skip — the
       // pre-substituted URI already used the path parameters via
       // `{paramName}` placeholders, so a separate rewrite is rarely needed.
       logger.warn(
-        `RequestParameter '${key}' (path rewrite) is recognized but cdk-local substitutes path placeholders via {param} in the URI; ignoring.`
+        `RequestParameter '${key}' (path rewrite) is recognized but ${getEmbedConfig().productName} substitutes path placeholders via {param} in the URI; ignoring.`
       );
     } else {
       logger.warn(`Unsupported RequestParameter key '${key}'; skipping.`);

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -13,6 +13,7 @@ import type {
   MockIntegrationConfig,
 } from './rest-v1-integrations.js';
 import type { IntegrationResponseEntry } from './integration-response-selector.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Union of REST v1 non-AWS_PROXY integration configurations captured at
@@ -260,7 +261,7 @@ export function discoverRoutes(stacks: readonly StackInfo[]): DiscoveredRoute[] 
 
   if (errors.length > 0) {
     throw new RouteDiscoveryError(
-      `cdkl start-api: ${errors.length} malformed route(s) in the synthesized template:\n` +
+      `${getEmbedConfig().cliName} start-api: ${errors.length} malformed route(s) in the synthesized template:\n` +
         errors.map((e) => `  - ${e}`).join('\n')
     );
   }
@@ -478,7 +479,7 @@ function discoverRestV1Method(
         unsupported: {
           reason: `${stackName}/${logicalId}.Integration.Uri: ${arnOutcome.detail} (got ${shortJson(
             integrationUri
-          )}). Lambda Arn intrinsics on cross-stack / imported references are not resolvable locally; deploy the producer stack and use \`cdkl invoke --from-state\` shapes if you need it.`,
+          )}). Lambda Arn intrinsics on cross-stack / imported references are not resolvable locally; deploy the producer stack and use \`${getEmbedConfig().cliName} invoke --from-state\` shapes if you need it.`,
         },
       },
     ];
@@ -610,7 +611,7 @@ function buildHttpProxyIntegrationConfig(
   if (typeof uri !== 'string' || uri.length === 0) {
     return {
       kind: 'unsupported',
-      reason: `${stackName}/${logicalId}: HTTP_PROXY Integration.Uri must be a literal string in v1 (cdkl start-api does not resolve Fn::Sub / Fn::Join in HTTP_PROXY Uris); got ${shortJson(uri)}.`,
+      reason: `${stackName}/${logicalId}: HTTP_PROXY Integration.Uri must be a literal string in v1 (${getEmbedConfig().cliName} start-api does not resolve Fn::Sub / Fn::Join in HTTP_PROXY Uris); got ${shortJson(uri)}.`,
     };
   }
   const integrationHttpMethod = pickStringField(integration, 'IntegrationHttpMethod');
@@ -641,7 +642,7 @@ function buildHttpIntegrationConfig(
   if (typeof uri !== 'string' || uri.length === 0) {
     return {
       kind: 'unsupported',
-      reason: `${stackName}/${logicalId}: HTTP Integration.Uri must be a literal string in v1 (cdkl start-api does not resolve Fn::Sub / Fn::Join in HTTP Uris); got ${shortJson(uri)}.`,
+      reason: `${stackName}/${logicalId}: HTTP Integration.Uri must be a literal string in v1 (${getEmbedConfig().cliName} start-api does not resolve Fn::Sub / Fn::Join in HTTP Uris); got ${shortJson(uri)}.`,
     };
   }
   const integrationHttpMethod = pickStringField(integration, 'IntegrationHttpMethod');
@@ -683,7 +684,7 @@ function buildAwsIntegrationConfig(
   if (!isLambda) {
     return {
       kind: 'unsupported',
-      reason: `${stackName}/${logicalId}: REST v1 AWS integration targeting a non-Lambda service (Uri ${shortJson(uri)}) is not emulated locally in cdkl v1. Lambda non-proxy AWS integrations are supported; direct AWS service integrations (S3 / SQS / SNS / DynamoDB) require deploying to AWS. See https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md.`,
+      reason: `${stackName}/${logicalId}: REST v1 AWS integration targeting a non-Lambda service (Uri ${shortJson(uri)}) is not emulated locally in ${getEmbedConfig().binaryName} v1. Lambda non-proxy AWS integrations are supported; direct AWS service integrations (S3 / SQS / SNS / DynamoDB) require deploying to AWS. See https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md.`,
     };
   }
   const arnOutcome = resolveLambdaArnOutcome(uri);
@@ -1067,7 +1068,7 @@ function classifyServiceIntegrationRoute(
       unsupported: {
         reason: `${declaredAt}: HTTP API v2 service integration subtype '${stringifyValue(
           subtypeRaw
-        )}' is not supported by cdkl start-api (see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html for the supported list).`,
+        )}' is not supported by ${getEmbedConfig().cliName} start-api (see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html for the supported list).`,
       },
     };
   }

--- a/src/local/runtime-image.ts
+++ b/src/local/runtime-image.ts
@@ -36,6 +36,8 @@
  * routing the user to `Code.fromAsset(...)`.
  */
 
+import { getEmbedConfig } from './embed-config.js';
+
 interface RuntimeSpec {
   /** ECR image tag the container should pull. */
   readonly image: string;
@@ -151,7 +153,7 @@ export function resolveRuntimeSpec(runtime: string): RuntimeSpec {
 
   throw new UnsupportedRuntimeError(
     runtime,
-    `Unknown runtime '${runtime}'. cdkl invoke supports nodejs18.x / nodejs20.x / nodejs22.x / nodejs24.x / python3.11 / python3.12 / python3.13 / python3.14 / ruby3.2 / ruby3.3 / java8.al2 / java11 / java17 / java21 / dotnet6 / dotnet8 / provided.al2 / provided.al2023.`
+    `Unknown runtime '${runtime}'. ${getEmbedConfig().cliName} invoke supports nodejs18.x / nodejs20.x / nodejs22.x / nodejs24.x / python3.11 / python3.12 / python3.13 / python3.14 / ruby3.2 / ruby3.3 / java8.al2 / java11 / java17 / java21 / dotnet6 / dotnet8 / provided.al2 / provided.al2023.`
   );
 }
 

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -78,6 +78,8 @@
  * acceptable and not in the contract.
  */
 
+import { getEmbedConfig } from './embed-config.js';
+
 /**
  * Bindings available to a VTL template evaluation. Built up by
  * `buildVtlContext` from an `HttpRequestSnapshot` + `MatchedRouteContext`.
@@ -320,7 +322,7 @@ class VtlEvaluator {
         throw new VtlEvaluationError(`Unexpected #${name} outside of a #if / #foreach block`);
       default:
         throw new VtlEvaluationError(
-          `Unsupported VTL directive #${name} (cdkl start-api supports #set / #if / #elseif / #else / #foreach / #end / ##)`
+          `Unsupported VTL directive #${name} (${getEmbedConfig().cliName} start-api supports #set / #if / #elseif / #else / #foreach / #end / ##)`
         );
     }
   }
@@ -631,7 +633,7 @@ class VtlEvaluator {
   private callValueAsMethod(value: unknown, argsRaw: string, refPath: string): unknown {
     if (typeof value !== 'function') {
       throw new VtlEvaluationError(
-        `Reference '$${refPath}' is not callable (got ${typeof value}). cdk-local supports calling $input / $util / $context method-style references only.`
+        `Reference '$${refPath}' is not callable (got ${typeof value}). ${getEmbedConfig().productName} supports calling $input / $util / $context method-style references only.`
       );
     }
     const args = this.parseArgList(argsRaw);
@@ -1066,7 +1068,7 @@ export function applyJsonPath(root: unknown, expr: string): unknown {
       const m = /^[a-zA-Z_][a-zA-Z_0-9]*/.exec(trimmed.slice(i));
       if (!m) {
         throw new VtlEvaluationError(
-          `Unsupported JSONPath syntax at position ${i}: '${trimmed}' (cdk-local supports $, $.field, $.field.sub, $.array[index] only).`
+          `Unsupported JSONPath syntax at position ${i}: '${trimmed}' (${getEmbedConfig().productName} supports $, $.field, $.field.sub, $.array[index] only).`
         );
       }
       cursor = lookupField(cursor, m[0]);
@@ -1093,7 +1095,7 @@ export function applyJsonPath(root: unknown, expr: string): unknown {
         cursor = lookupField(cursor, inside.slice(1, -1));
       } else {
         throw new VtlEvaluationError(
-          `Unsupported JSONPath bracket expression: '${inside}' (cdk-local supports integer indices and quoted string keys only).`
+          `Unsupported JSONPath bracket expression: '${inside}' (${getEmbedConfig().productName} supports integer indices and quoted string keys only).`
         );
       }
       i = close + 1;

--- a/src/local/websocket-route-discovery.ts
+++ b/src/local/websocket-route-discovery.ts
@@ -4,6 +4,7 @@ import type { CloudFormationTemplate, TemplateResource } from '../types/resource
 import { RouteDiscoveryError } from '../utils/error-handler.js';
 import { resolveLambdaArnIntrinsic } from './intrinsic-lambda-arn.js';
 import { pickRefLogicalId } from './intrinsic-utils.js';
+import { getEmbedConfig } from './embed-config.js';
 
 /**
  * Discovered WebSocket API for `cdkl start-api`.
@@ -152,7 +153,7 @@ export function discoverWebSocketApisOrThrow(
   const { apis, errors } = discoverWebSocketApis(stacks);
   if (errors.length > 0) {
     throw new RouteDiscoveryError(
-      `cdkl start-api: ${errors.length} malformed WebSocket API(s) in the synthesized template:\n` +
+      `${getEmbedConfig().cliName} start-api: ${errors.length} malformed WebSocket API(s) in the synthesized template:\n` +
         errors.map((e) => `  - ${e}`).join('\n')
     );
   }
@@ -202,7 +203,7 @@ function discoverOneApi(
   const unsupported =
     authRoutes.length > 0
       ? {
-          reason: `WebSocket API requires authorizer support, which cdkl v1 does not emulate. Affected route(s): ${authRoutes
+          reason: `WebSocket API requires authorizer support, which ${getEmbedConfig().binaryName} v1 does not emulate. Affected route(s): ${authRoutes
             .map((r) => `${r.routeKey} [AuthorizationType=${r.authorizationType}]`)
             .join(
               ', '
@@ -282,7 +283,7 @@ function collectAuthRoutesForApi(
 function assertSupportedSelectionExpression(expr: string, declaredAt: string): void {
   if (!/^\$request\.body(?:\.[A-Za-z_][A-Za-z0-9_]*)+$/.test(expr)) {
     throw new Error(
-      `${declaredAt}: RouteSelectionExpression '${expr}' is not supported in cdkl start-api v1 — only '$request.body.<key>' shapes (optionally nested via dots) are recognized. File a follow-up issue if you need '$request.header.X' / '$context.X' / array-index access.`
+      `${declaredAt}: RouteSelectionExpression '${expr}' is not supported in ${getEmbedConfig().cliName} start-api v1 — only '$request.body.<key>' shapes (optionally nested via dots) are recognized. File a follow-up issue if you need '$request.header.X' / '$context.X' / array-index access.`
     );
   }
 }
@@ -367,7 +368,7 @@ function collectRoutesForApi(
       throw new Error(
         `${declaredAt}: WebSocket route IntegrationType '${String(
           integrationType
-        )}' is not supported in cdkl start-api v1 — only AWS_PROXY (Lambda) integrations are emulated.`
+        )}' is not supported in ${getEmbedConfig().cliName} start-api v1 — only AWS_PROXY (Lambda) integrations are emulated.`
       );
     }
 

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { getLogger } from './logger.js';
+import { getEmbedConfig } from '../local/embed-config.js';
 
 /**
  * Shared helpers for invoking the docker-compatible CLI binary across cdk-local.
@@ -281,8 +282,8 @@ export function formatDockerLoginError(stderr: string, endpoint: string): string
     return (
       `docker's credential helper (osxkeychain on macOS / wincred on Windows / pass / secretservice on Linux) ` +
       `failed to persist the ECR auth token. The "already exists in the keychain" / "Error saving credentials" ` +
-      `output is a known docker-credential-helpers issue — unrelated to cdk-local, AWS credentials, or IAM perms. ` +
-      `Quick fix: run \`docker logout ${endpoint}\` to clear the stale entry, then retry the cdk-local command. ` +
+      `output is a known docker-credential-helpers issue — unrelated to ${getEmbedConfig().productName}, AWS credentials, or IAM perms. ` +
+      `Quick fix: run \`docker logout ${endpoint}\` to clear the stale entry, then retry the ${getEmbedConfig().productName} command. ` +
       `Permanent fix: edit ~/.docker/config.json and remove (or empty) the platform-specific "credsStore" entry ` +
       `(e.g. "osxkeychain" → "" or "desktop" on macOS Docker Desktop). ` +
       `Original docker stderr: ${trimmed}`

--- a/src/utils/role-arn.ts
+++ b/src/utils/role-arn.ts
@@ -1,5 +1,6 @@
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { getLogger } from './logger.js';
+import { getEmbedConfig } from '../local/embed-config.js';
 
 /**
  * Resolve the role-arn argument (CLI flag or `CDKL_ROLE_ARN` env var) and,
@@ -32,7 +33,7 @@ export async function applyRoleArnIfSet(opts: {
     const response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
-        RoleSessionName: `cdkl-${Date.now()}`,
+        RoleSessionName: `${getEmbedConfig().binaryName}-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );

--- a/src/utils/role-arn.ts
+++ b/src/utils/role-arn.ts
@@ -22,7 +22,7 @@ export async function applyRoleArnIfSet(opts: {
   roleArn: string | undefined;
   region: string | undefined;
 }): Promise<void> {
-  const roleArn = opts.roleArn || process.env['CDKL_ROLE_ARN'];
+  const roleArn = opts.roleArn || process.env[`${getEmbedConfig().envPrefix}_ROLE_ARN`];
   if (!roleArn) return;
 
   const logger = getLogger().child('role-arn');

--- a/tests/unit/cli/local-profile-credentials-file.test.ts
+++ b/tests/unit/cli/local-profile-credentials-file.test.ts
@@ -2,7 +2,7 @@ import { readFile, stat } from 'node:fs/promises';
 import { describe, expect, it } from 'vite-plus/test';
 import {
   buildProfileCredentialsDockerArgs,
-  CONTAINER_AWS_CREDENTIALS_PATH,
+  getContainerAwsCredentialsPath,
   writeProfileCredentialsFile,
 } from '../../../src/cli/commands/local-profile-credentials-file.js';
 
@@ -21,7 +21,7 @@ describe('writeProfileCredentialsFile', () => {
           'aws_secret_access_key = SECRET-EXAMPLE\n' +
           'aws_session_token = SESSION-EXAMPLE\n'
       );
-      expect(file.containerPath).toBe(CONTAINER_AWS_CREDENTIALS_PATH);
+      expect(file.containerPath).toBe(getContainerAwsCredentialsPath());
       expect(file.profileName).toBe('dev-sso');
     } finally {
       await file.dispose();

--- a/tests/unit/local/embed-config.test.ts
+++ b/tests/unit/local/embed-config.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import {
+  getEmbedConfig,
+  resetEmbedConfig,
+  setEmbedConfig,
+} from '../../../src/local/embed-config.js';
+import { resolveRuntimeImage } from '../../../src/local/runtime-image.js';
+import {
+  getContainerAwsCredentialsPath,
+  writeProfileCredentialsFile,
+} from '../../../src/cli/commands/local-profile-credentials-file.js';
+
+// The embed config is a module-level singleton; reset after every test so
+// one test's override never leaks into the next.
+afterEach(() => {
+  resetEmbedConfig();
+});
+
+describe('embed-config', () => {
+  it('defaults to cdk-local branding before any setEmbedConfig call', () => {
+    expect(getEmbedConfig()).toEqual({
+      cliName: 'cdkl',
+      binaryName: 'cdkl',
+      productName: 'cdk-local',
+      resourceNamePrefix: 'cdkl',
+      awsBindMountPath: '/cdk-local-aws',
+    });
+  });
+
+  it('applies a full override', () => {
+    setEmbedConfig({
+      cliName: 'cdkd local',
+      binaryName: 'cdkd',
+      productName: 'cdkd',
+      resourceNamePrefix: 'cdkd-local',
+      awsBindMountPath: '/cdkd-aws',
+    });
+    expect(getEmbedConfig()).toEqual({
+      cliName: 'cdkd local',
+      binaryName: 'cdkd',
+      productName: 'cdkd',
+      resourceNamePrefix: 'cdkd-local',
+      awsBindMountPath: '/cdkd-aws',
+    });
+  });
+
+  it('fills unspecified fields with defaults on a partial override', () => {
+    setEmbedConfig({ resourceNamePrefix: 'cdkd-local' });
+    expect(getEmbedConfig()).toEqual({
+      cliName: 'cdkl',
+      binaryName: 'cdkl',
+      productName: 'cdk-local',
+      resourceNamePrefix: 'cdkd-local',
+      awsBindMountPath: '/cdk-local-aws',
+    });
+  });
+
+  it('treats setEmbedConfig(undefined) as a reset to defaults', () => {
+    setEmbedConfig({ cliName: 'cdkd local' });
+    setEmbedConfig(undefined);
+    expect(getEmbedConfig().cliName).toBe('cdkl');
+  });
+
+  it('is idempotent — re-setting the same override is a no-op', () => {
+    const override = { binaryName: 'cdkd' };
+    setEmbedConfig(override);
+    const first = getEmbedConfig();
+    setEmbedConfig(override);
+    expect(getEmbedConfig()).toEqual(first);
+  });
+
+  it('resetEmbedConfig restores defaults', () => {
+    setEmbedConfig({ productName: 'cdkd' });
+    resetEmbedConfig();
+    expect(getEmbedConfig().productName).toBe('cdk-local');
+  });
+});
+
+describe('embed-config threading into branded sites', () => {
+  it('cliName flows into runtime-image error messages', () => {
+    expect(() => resolveRuntimeImage('bogus-runtime')).toThrow(/cdkl invoke supports/);
+    setEmbedConfig({ cliName: 'cdkd local' });
+    expect(() => resolveRuntimeImage('bogus-runtime')).toThrow(/cdkd local invoke supports/);
+  });
+
+  it('awsBindMountPath flows into the container credentials path', () => {
+    expect(getContainerAwsCredentialsPath()).toBe('/cdk-local-aws/credentials');
+    setEmbedConfig({ awsBindMountPath: '/cdkd-aws' });
+    expect(getContainerAwsCredentialsPath()).toBe('/cdkd-aws/credentials');
+  });
+
+  it('productName flows into the profile-credentials tmpdir prefix', async () => {
+    setEmbedConfig({ productName: 'cdkd' });
+    const file = await writeProfileCredentialsFile('dev', {
+      accessKeyId: 'AKIA-EXAMPLE',
+      secretAccessKey: 'SECRET-EXAMPLE',
+    });
+    try {
+      expect(file.hostPath).toContain('cdkd-profile-creds-');
+      expect(file.hostPath).not.toContain('cdk-local-profile-creds-');
+    } finally {
+      await file.dispose();
+    }
+  });
+});

--- a/tests/unit/local/embed-config.test.ts
+++ b/tests/unit/local/embed-config.test.ts
@@ -10,6 +10,9 @@ import {
   writeProfileCredentialsFile,
 } from '../../../src/cli/commands/local-profile-credentials-file.js';
 import { resolveApp } from '../../../src/cli/config-loader.js';
+import { resolveRestV1Authorizer } from '../../../src/local/authorizer-resolver.js';
+import { computeLocalTag } from '../../../src/local/docker-image-builder.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
 
 // The embed config is a module-level singleton; reset after every test so
 // one test's override never leaks into the next.
@@ -106,6 +109,42 @@ describe('embed-config threading into branded sites', () => {
     } finally {
       await file.dispose();
     }
+  });
+
+  it('resourceNamePrefix flows into generated Docker image tags', () => {
+    const source = { directory: '/some/asset/dir' };
+    const def = computeLocalTag(source);
+    expect(def).toMatch(/^cdkl-invoke-[0-9a-f]{16}$/);
+
+    setEmbedConfig({ resourceNamePrefix: 'cdkd-local' });
+    const cdkd = computeLocalTag(source);
+    expect(cdkd).toMatch(/^cdkd-local-invoke-[0-9a-f]{16}$/);
+    // Same source ⇒ same hash suffix; only the prefix changes.
+    expect(cdkd.slice('cdkd-local-invoke-'.length)).toBe(def.slice('cdkl-invoke-'.length));
+  });
+
+  it('binaryName flows into the synthesized Cognito user-pool placeholder ARN', () => {
+    const template = {
+      Resources: {
+        MyAuth: {
+          Type: 'AWS::ApiGateway::Authorizer',
+          Properties: {
+            Type: 'COGNITO_USER_POOLS',
+            // Fn::GetAtt is unresolvable at synth time, so the resolver
+            // synthesizes an unreachable placeholder user-pool ARN.
+            ProviderARNs: [{ 'Fn::GetAtt': ['MyPool', 'Arn'] }],
+          },
+        },
+      },
+    } as unknown as CloudFormationTemplate;
+
+    const def = resolveRestV1Authorizer('MyAuth', template, 'MyStack', 'MyStack/api');
+    expect(def.userPoolArn).toContain('us-east-1_cdklplaceholder');
+
+    setEmbedConfig({ binaryName: 'cdkd' });
+    const cdkd = resolveRestV1Authorizer('MyAuth', template, 'MyStack', 'MyStack/api');
+    expect(cdkd.userPoolArn).toContain('us-east-1_cdkdplaceholder');
+    expect(cdkd.userPoolArn).not.toContain('cdklplaceholder');
   });
 
   it('envPrefix flows into the --app env-var fallback that resolveApp reads', () => {

--- a/tests/unit/local/embed-config.test.ts
+++ b/tests/unit/local/embed-config.test.ts
@@ -9,6 +9,7 @@ import {
   getContainerAwsCredentialsPath,
   writeProfileCredentialsFile,
 } from '../../../src/cli/commands/local-profile-credentials-file.js';
+import { resolveApp } from '../../../src/cli/config-loader.js';
 
 // The embed config is a module-level singleton; reset after every test so
 // one test's override never leaks into the next.
@@ -24,6 +25,7 @@ describe('embed-config', () => {
       productName: 'cdk-local',
       resourceNamePrefix: 'cdkl',
       awsBindMountPath: '/cdk-local-aws',
+      envPrefix: 'CDKL',
     });
   });
 
@@ -34,6 +36,7 @@ describe('embed-config', () => {
       productName: 'cdkd',
       resourceNamePrefix: 'cdkd-local',
       awsBindMountPath: '/cdkd-aws',
+      envPrefix: 'CDKD',
     });
     expect(getEmbedConfig()).toEqual({
       cliName: 'cdkd local',
@@ -41,6 +44,7 @@ describe('embed-config', () => {
       productName: 'cdkd',
       resourceNamePrefix: 'cdkd-local',
       awsBindMountPath: '/cdkd-aws',
+      envPrefix: 'CDKD',
     });
   });
 
@@ -52,6 +56,7 @@ describe('embed-config', () => {
       productName: 'cdk-local',
       resourceNamePrefix: 'cdkd-local',
       awsBindMountPath: '/cdk-local-aws',
+      envPrefix: 'CDKL',
     });
   });
 
@@ -100,6 +105,24 @@ describe('embed-config threading into branded sites', () => {
       expect(file.hostPath).not.toContain('cdk-local-profile-creds-');
     } finally {
       await file.dispose();
+    }
+  });
+
+  it('envPrefix flows into the --app env-var fallback that resolveApp reads', () => {
+    const saved = { app: process.env['CDKL_APP'], cdkd: process.env['CDKD_APP'] };
+    try {
+      delete process.env['CDKL_APP'];
+      process.env['CDKD_APP'] = 'node cdkd-app.ts';
+      // Default prefix reads CDKL_APP (unset) — falls through to cdk.json.
+      expect(resolveApp(undefined)).not.toBe('node cdkd-app.ts');
+      // CDKD prefix reads CDKD_APP.
+      setEmbedConfig({ envPrefix: 'CDKD' });
+      expect(resolveApp(undefined)).toBe('node cdkd-app.ts');
+    } finally {
+      if (saved.app === undefined) delete process.env['CDKL_APP'];
+      else process.env['CDKL_APP'] = saved.app;
+      if (saved.cdkd === undefined) delete process.env['CDKD_APP'];
+      else process.env['CDKD_APP'] = saved.cdkd;
     }
   });
 });


### PR DESCRIPTION
## Summary

Adds an embed-time branding config (`CdkLocalEmbedConfig`) so a host CLI
that mounts cdk-local's Commander factories can rebrand every
user-visible string and generated resource name under its own name —
the prerequisite for letting another project consume cdk-local's
local-execution engine without leaking `cdkl` / `cdk-local` to its
users.

- New module `src/local/embed-config.ts` holds a module-level resolved
  config with six string fields, each defaulting to cdk-local's own
  value, so native `cdkl` output stays **byte-identical** when no
  `embedConfig` is passed:
  - `cliName` (`cdkl`) — subcommand refs: `${cliName} invoke` / `start-api` / ...
  - `binaryName` (`cdkl`) — bare process refs, the local request id, the Cognito user-pool placeholder
  - `productName` (`cdk-local`) — prose product refs + profile-creds tmpdir
  - `resourceNamePrefix` (`cdkl`) — Docker / AWS resource names (container / volume / network / image-tag / tmpdir / RoleSessionName / TLS CN / example namespace)
  - `awsBindMountPath` (`/cdk-local-aws`) — container credentials bind-mount target
  - `envPrefix` (`CDKL`) — env fallbacks `${envPrefix}_APP` / `${envPrefix}_ROLE_ARN`
- Each of the four command factories calls `setEmbedConfig(opts.embedConfig)`
  before building its option tree; ~115 leaf sites across `src/local/**`,
  `src/cli/commands/**`, and `src/utils/**` read `getEmbedConfig().<field>`.
- `CdkLocalEmbedConfig` is exported from `src/index.ts`; usage documented
  in `docs/library-mode.md`.

This is scoped to cdk-local's **own** branding (`cdkl` / `cdk-local`).
Residual `cdkd` references in error strings are a separate, pre-existing
concern tracked elsewhere — not in scope here.

## Notes for reviewers

- **Field-to-site mapping is the high-risk part**: `cliName`, `binaryName`,
  and `resourceNamePrefix` all default to `cdkl`, so default-mode tests
  cannot catch a wrong field choice. Each site was classified by meaning
  and cross-checked against the reference host as an oracle (e.g. the
  Cognito placeholder and the bare RoleSessionName map to `binaryName`,
  not `resourceNamePrefix`, because a hyphen would corrupt a user-pool id
  and the host's literal there is the bare binary name).
- `cli/options.ts`'s `commonOptions` / `appOptions` changed from
  module-level const arrays to per-call builder functions, because their
  option descriptions embed the env-var prefix and must be read **after**
  the factory installs the config — a module-level const would bake the
  default at import time. A useful gotcha for future batches that touch
  shared const modules.
- The config is a process-global singleton. The documented contract is
  "build all commands once at startup with one config," which is how both
  cdk-local's own entrypoint and any embedder use it. Interleaving
  construction across different configs in one process is out of contract;
  accepted as a deliberate tradeoff (avoids threading a config arg through
  ~115 leaf signatures).
- Rebased onto `main` after it advanced to 0.4.0; the only conflict was in
  `warnIamRoutes` (start-api), where the new AWS_IAM OAC-fronted Function
  URL handling was combined with the `cliName` branding of both warn
  strings.

## Test plan

- [x] `vp run verify` (typecheck + lint + format + full unit suite + build) green
- [x] The pre-existing unit suite passes unchanged → default-mode output byte-identical
- [x] New `embed-config.test.ts`: module mechanics + threading for all six fields (cliName / binaryName / productName / resourceNamePrefix / awsBindMountPath / envPrefix)
- [x] End-to-end: built all four factories with a non-default config and confirmed zero `cdkl` / `cdk-local` / `CDKL_` leak in their option descriptions; default config still renders `cdkl` / `CDKL_*`
- [x] `node dist/cli.js invoke` (no app) renders the `CDKL_APP` hint in default mode
- [x] `/run-integ local-invoke` passed (5/5) on the rebased tree, exercising the default `cdkl-*` Docker container path; 0 docker orphans
- [x] CI green (check / check-build-test / runtime-compat 20·22·24)
