### PR TITLE
fix(from-cfn-stack): paginate ListStackResources past the 100 cap

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -111,7 +111,7 @@ in the resolved stack so the user can copy/paste a valid one.
 | `--container-host <host>` | `127.0.0.1` | Host to bind the RIE port to. |
 | `--assume-role [arn]` | off | STS-assume the deployed function's execution role and forward the resulting temp credentials to the container, so the handler runs under the deployed role's narrow permissions instead of the developer's typically-admin shell credentials. Three forms: (1) `--assume-role <arn>` assumes the explicit ARN (precedence wins); (2) `--assume-role` (bare) auto-resolves the function's `Properties.Role` from the active state source (requires `--from-cfn-stack` or a host-provided extension); (3) `--no-assume-role` explicitly opts out. Off by default — when omitted, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` are passed through unchanged (SAM-compatible default). STS failures degrade to a warn + dev-creds fallback. |
 | `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers`. Use only when the dev credentials cannot read the layer — typically cross-account layers. AWS-published public layers (e.g. Lambda Powertools) are readable from every account and need no role. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` placeholders in env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the resolved stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `DescribeStackResources` does not return per-attribute values). See [CloudFormation-driven env recovery](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` placeholders in env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the resolved stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `ListStackResources` does not return per-attribute values). See [CloudFormation-driven env recovery](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region when `--from-cfn-stack` is set. |
 
 Plus the [common flags](#common-flags): `-a/--app`, `--output`,
@@ -142,7 +142,7 @@ handler's `context.*` fields look real.
 For CDK apps deployed via the upstream CDK CLI (`cdk deploy` →
 CloudFormation), use `--from-cfn-stack` to pull deployed physical IDs
 and exports into the Lambda's env block: cdk-local calls
-`cloudformation:DescribeStackResources` against the named CFn stack to
+`cloudformation:ListStackResources` against the named CFn stack to
 populate the per-logical-id physical-id map, then runs the substitution
 engine against it.
 
@@ -166,7 +166,8 @@ cdkl invoke MyStack/MyApi/Handler --from-cfn-stack \
 ```
 
 **What's resolved**: `Ref: <LogicalId>` against
-`DescribeStackResources` (one CFn API call per stack) and
+`ListStackResources` (paginated — every page is walked so stacks with
+more than 100 resources are fully mapped) and
 `Fn::ImportValue: <ExportName>` against
 `cloudformation:ListExports` (paginated, memoized for one substitution
 pass).
@@ -181,7 +182,7 @@ pass).
 4. Template literal value.
 
 **`Fn::GetAtt` is warn-and-dropped** in v1. CFn's
-`DescribeStackResources` does NOT return per-attribute values — it only
+`ListStackResources` does NOT return per-attribute values — it only
 exposes `(LogicalResourceId, PhysicalResourceId, ResourceType)`
 triplets. Recovering per-attribute values would require per-service
 describe calls (e.g. `GetQueueAttributes` for SQS, `GetFunction` for
@@ -192,14 +193,14 @@ via `--env-vars` if the value is critical.
 time using the precedence `--stack-region` > `AWS_REGION` >
 `AWS_DEFAULT_REGION` > the synth-derived stack region. When NONE of
 these signals is set, the CLI throws with a remediation message — CFn
-`DescribeStackResources` queries a specific region and silently
+`ListStackResources` queries a specific region and silently
 picking `us-east-1` would query the wrong stack environment.
 
-**Failure modes**: `DescribeStackResources` failures (stack not found,
+**Failure modes**: `ListStackResources` failures (stack not found,
 access denied, throttling) degrade to a per-key warn + drop.
 `ListExports` failures only affect `Fn::ImportValue` resolution;
 same-stack `Ref` substitutions still succeed because they only need
-the `DescribeStackResources` result.
+the `ListStackResources` result.
 
 **Auto-assume execution role**: when `--from-cfn-stack` is paired with
 bare `--assume-role` (no ARN argument), cdk-local resolves the
@@ -361,7 +362,7 @@ an error — they're mutually exclusive.
 | `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). For HTTP API v2 routes, `requestContext.stage` is always `$default` regardless of this flag (AWS-side limitation); only `event.stageVariables` is affected. For REST v1 the selected StageName is also threaded into `requestContext.stage`. |
 | `--api <id>` | unset | **Deprecated** — use the positional `<target>` argument instead. Same accepted forms. Emits a deprecation warn on use. |
 | `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers`. Same semantics as `cdkl invoke --layer-role-arn`. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in Lambda env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the routed stack's CDK name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` is warn-and-dropped in v1. Same warn-and-drop semantics as `cdkl invoke --from-cfn-stack`. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in Lambda env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the routed stack's CDK name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` is warn-and-dropped in v1. Same warn-and-drop semantics as `cdkl invoke --from-cfn-stack`. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region for `--from-cfn-stack`. |
 | `--mtls-truststore <path>` | unset | PEM-encoded CA bundle for client-certificate verification. When set, the server switches from HTTP to HTTPS and the TLS handshake rejects clients whose certificate doesn't chain to one of these CAs. Must be set together with `--mtls-cert` + `--mtls-key`; partial flag sets are rejected. See [local-emulation.md](./local-emulation.md) for the openssl recipe + event-shape details. |
 | `--mtls-cert <path>` | unset | PEM-encoded server certificate for mutual TLS. Self-signed is fine for local dev. Must be set together with `--mtls-truststore` + `--mtls-key`. |
@@ -417,7 +418,7 @@ Path matching is prefix-based: an L2 path like
 | `--env-vars <file>` | unset | SAM-shape JSON overlay. Top-level keys are container names; `Parameters` is a global overlay. Same shape as `cdkl invoke --env-vars`. |
 | `--container-host <ip>` | `127.0.0.1` | Bind IP for `PortMappings` published ports. Must be a numeric IP — Docker rejects hostnames in `-p <ip>:<port>:<port>`. |
 | `--assume-task-role [<arn>]` | unset | Bare flag uses the task definition's `TaskRoleArn`. Resolves a flat-string ARN directly; for `{Ref: <Role>}` / `{Fn::GetAtt: [<Role>, 'Arn']}` against a same-stack `AWS::IAM::Role`, cdk-local substitutes the caller's account id (via STS `GetCallerIdentity`) into `arn:aws:iam::<account>:role/<RoleLogicalId>`. Pass an explicit ARN to override. Either way, `sts:AssumeRole` runs once at startup; the resulting creds are exposed via the local metadata sidecar at `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1. See [Env / Secrets substitution](#env--secrets-substitution---from-cfn-stack) below. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1. See [Env / Secrets substitution](#env--secrets-substitution---from-cfn-stack) below. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region for `--from-cfn-stack`. |
 | `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before authenticating against ECR for cross-account / centralized registry pulls. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for `ecr:GetAuthorizationToken` + `docker pull` on every container whose `Image` resolves to an `<acct>.dkr.ecr.<region>.amazonaws.com/...` URI. Required when the caller does not have direct cross-account access. Same-account / same-region pulls do not need this flag. No-op when `--no-pull` is set. |
@@ -500,12 +501,12 @@ entry against the deployed CFn stack plus AWS pseudo parameters:
 
 | Intrinsic | Source |
 | --- | --- |
-| `Ref: <LogicalId>` | `DescribeStackResources` physical resource id |
+| `Ref: <LogicalId>` | `ListStackResources` physical resource id |
 | `Fn::ImportValue: <ExportName>` | `ListExports` (paginated, memoized) |
 | `Fn::Sub: '...${X}...${AWS::Region}...'` | recursive substitution against CFn lookups + pseudo parameters |
 | `Fn::Join: [<delim>, [<elements>]]` | recursive substitution of every element, then `Array.join` |
 | `Ref: AWS::AccountId` / `AWS::Region` / `AWS::Partition` / `AWS::URLSuffix` | STS `GetCallerIdentity` (lazy, cached) + the resolved region + region-derived partition / URL suffix |
-| `Fn::GetAtt: [<LogicalId>, <Attr>]` | **warn-and-dropped** in v1 (CFn `DescribeStackResources` does not return per-attribute values) |
+| `Fn::GetAtt: [<LogicalId>, <Attr>]` | **warn-and-dropped** in v1 (CFn `ListStackResources` does not return per-attribute values) |
 
 Per-key best-effort: when a substitution can't be produced (state
 missing for a referenced logical ID, attribute not captured, unsupported
@@ -646,7 +647,7 @@ error.
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before ECR `docker pull` for cross-account / centralized registries. Same shape as `cdkl run-task`. |
 | `--platform <platform>` | inferred | Force `--platform linux/amd64` or `linux/arm64`. |
 | `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. Bare form uses the CDK stack name (per target when multiple `<targets...>` are supplied). `Fn::GetAtt` is warn-and-dropped in v1. Same shape as `cdkl run-task --from-cfn-stack`. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. Bare form uses the CDK stack name (per target when multiple `<targets...>` are supplied). `Fn::GetAtt` is warn-and-dropped in v1. Same shape as `cdkl run-task --from-cfn-stack`. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region for `--from-cfn-stack`. |
 
 Plus the [common flags](#common-flags): `-a/--app`, `--output`,

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -48,7 +48,7 @@ Shared across all subcommands:
   consult each section).
 - `--from-cfn-stack [cfn-stack-name]` — Bind the local run to a
   deployed CloudFormation stack: cdk-local calls
-  `cloudformation:DescribeStacks` / `DescribeStackResources` /
+  `cloudformation:DescribeStacks` / `ListStackResources` /
   `ListExports` and substitutes the deployed physical IDs / exports /
   outputs into the local container's env vars / secrets / image URIs.
   See the per-command sections below.
@@ -136,7 +136,7 @@ in the resolved stack so the user can copy/paste a valid one.
 | `--assume-role [arn]` | off | STS-assume the deployed function's execution role and forward the resulting temp credentials to the container, so the handler runs under the deployed role's narrow permissions instead of the developer's typically-admin shell credentials. Three forms: (1) `--assume-role <arn>` assumes the explicit ARN (precedence wins); (2) `--assume-role` (bare) auto-resolves the function's `Properties.Role` from the bound CloudFormation stack (requires `--from-cfn-stack`); (3) `--no-assume-role` explicitly opts out (forces dev creds even with `--from-cfn-stack`). Off by default — when omitted, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` are passed through unchanged (SAM-compatible default). STS failures degrade to a warn + dev-creds fallback. |
 | `-a, --app <cmd-or-dir>` | — | CDK app command or pre-synthesized `cdk.out` directory. Default: synth every time. Pass `-a cdk.out` to skip synthesis when iterating. |
 | `--output <dir>` | `cdk.out` | Output directory for synthesis. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in env vars with the deployed physical IDs / exports. Bare form uses the CDK stack name (typical case); pass an explicit value when the deployed CFn stack name differs (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` is warn-and-dropped in v1 (CFn `DescribeStackResources` does not return per-attribute values). See [CloudFormation-driven env recovery (`--from-cfn-stack`)](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in env vars with the deployed physical IDs / exports. Bare form uses the CDK stack name (typical case); pass an explicit value when the deployed CFn stack name differs (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` is warn-and-dropped in v1 (CFn `ListStackResources` does not return per-attribute values). See [CloudFormation-driven env recovery (`--from-cfn-stack`)](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
 | `--stack-region <region>` | auto | Region used to construct the CloudFormation client for `--from-cfn-stack`. Defaults to `--region` > `AWS_REGION` > `AWS_DEFAULT_REGION` > the synth-derived stack region. |
 | `--layer-role-arn <arn>` | — | Role ARN to assume before calling `lambda:GetLayerVersion` on literal-ARN layer entries. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for the GetLayerVersion call only — the assumed role is NOT propagated into the Lambda container at runtime (that's what `--assume-role` is for). Use this when the layer lives in a different account than the calling identity and direct cross-account access is not granted via the layer's resource policy. |
 
@@ -201,13 +201,14 @@ cdkl invoke MyStack/MyApi/Handler --from-cfn-stack \
 4. Template literal value.
 
 **What's resolved**: `Ref: <LogicalId>` against
-`DescribeStackResources` (one CFn API call per stack), `Fn::ImportValue:
+`ListStackResources` (paginated — every page is walked so stacks with
+more than 100 resources are fully mapped), `Fn::ImportValue:
 <ExportName>` against `cloudformation:ListExports` (paginated, memoized
 for one substitution pass), and supported `Fn::Sub` / `Fn::Join` /
 `${AWS::*}` shapes via the same substitution engine.
 
 **`Fn::GetAtt` is warn-and-dropped** in v1. CFn's
-`DescribeStackResources` does NOT return per-attribute values — it only
+`ListStackResources` does NOT return per-attribute values — it only
 exposes `(LogicalResourceId, PhysicalResourceId, ResourceType)`
 triplets. Recovering per-attribute values would require provider-
 specific describe calls (e.g. `GetQueueAttributes` for SQS,
@@ -236,7 +237,7 @@ warn + drop. Literal-only env maps skip the STS hop.
 
 **Region handling**: the CFn client is region-bound at construction
 time. When NONE of the region signals is set the CLI **throws** with a
-remediation message — CFn `DescribeStackResources` queries a specific
+remediation message — CFn `ListStackResources` queries a specific
 region and silently picking `us-east-1` would query the wrong stack
 environment.
 
@@ -249,12 +250,12 @@ and silently mismap `Ref` lookups whose logical IDs happen to collide
 between siblings). Use bare `--from-cfn-stack` for multi-stack apps, or
 run one cdk-local invocation per stack.
 
-**Failure modes**: `DescribeStackResources` failures (stack not found,
+**Failure modes**: `ListStackResources` failures (stack not found,
 access denied, throttling) degrade to a per-key warn + drop — the
 invoke continues with literal-only env vars. `ListExports` failures
 only affect `Fn::ImportValue` resolution; same-stack `Ref`
 substitutions still succeed because they only need the
-`DescribeStackResources` result.
+`ListStackResources` result.
 
 **Out of scope** (deferred): `Fn::GetAtt` (warn + drop today), other
 intrinsics (`Fn::Select`, `Fn::Split`, `Fn::If`, etc.). Anything beyond
@@ -559,7 +560,7 @@ the same tier; cdk-local uses literal-segment count as a heuristic).
 | `--assume-role <arn-or-pair>` | unset | Repeatable. Bare `<arn>` = global default; `<LogicalId>=<arn>` = per-Lambda override. Per-Lambda > global > unset (developer creds passed through). |
 | `--watch` | off | Hot reload: re-synth + re-discover routes when `cdk.out/` or any routed Lambda's asset directory changes. 500ms debounce. Synth failures keep the previous version serving (warn-and-continue, never crashes the server). |
 | `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). When the override doesn't match any Stage on a given API, that API's routes get `stageVariables: null` and the CLI emits a warn line up front. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters in Lambda env vars with the deployed physical IDs / exports. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the CDK stack name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). The explicit form is rejected when more than one stack is routed in one invocation; the bare form is fine for multi-stack. `Fn::GetAtt` is warn-and-dropped in v1. Re-runs against fresh CFn data on every hot-reload firing (`--watch`). DescribeStackResources failures degrade per-stack to warn-and-fall-back so an unreadable stack never aborts the server. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters in Lambda env vars with the deployed physical IDs / exports. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the CDK stack name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). The explicit form is rejected when more than one stack is routed in one invocation; the bare form is fine for multi-stack. `Fn::GetAtt` is warn-and-dropped in v1. Re-runs against fresh CFn data on every hot-reload firing (`--watch`). ListStackResources failures degrade per-stack to warn-and-fall-back so an unreadable stack never aborts the server. |
 | `--stack-region <region>` | auto | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
 | `--mtls-truststore <path>` | unset | PEM-encoded CA bundle for client-certificate verification. When set, the server switches from HTTP to HTTPS and the TLS handshake rejects clients whose certificate doesn't chain to one of these CAs. Must be set together with `--mtls-cert` + `--mtls-key`; partial flag sets are rejected. See the "mTLS (mutual TLS)" section below for the openssl recipe + event-shape details. |
 | `--mtls-cert <path>` | unset | PEM-encoded server certificate for mutual TLS. Self-signed is fine for local dev. Must be set together with `--mtls-truststore` + `--mtls-key`. |
@@ -1076,7 +1077,7 @@ resolves to the synthesized L1 child (`MyStack/MyService/TaskDef/Resource`).
 | `--env-vars <file>` | unset | SAM-shape JSON overlay. Top-level keys are container names; `Parameters` is a global overlay. Same shape as `cdkl invoke --env-vars`. |
 | `--container-host <ip>` | `127.0.0.1` | Bind IP for `PortMappings` published ports. Must be a numeric IP — Docker rejects hostnames in `-p <ip>:<port>:<port>`. |
 | `--assume-task-role [<arn>]` | unset (host creds pass through) | Bare flag uses the task definition's `TaskRoleArn`. Resolves a flat-string ARN directly; for `{Ref: <Role>}` / `{Fn::GetAtt: [<Role>, 'Arn']}` against a same-stack `AWS::IAM::Role`, cdk-local substitutes the caller's account id (via STS `GetCallerIdentity`) into `arn:aws:iam::<account>:role/<RoleLogicalId>`. Pass an explicit ARN to override. Either way, `sts:AssumeRole` runs once at startup; the resulting creds are exposed via the local metadata sidecar at `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `DescribeStackResources` does not return per-attribute values). See "Env / Secrets substitution" below. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `ListStackResources` does not return per-attribute values). See "Env / Secrets substitution" below. |
 | `--stack-region <region>` | unset | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
 | `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before authenticating against ECR for cross-account / centralized registry pulls. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for `ecr:GetAuthorizationToken` + `docker pull` on every container whose `Image` resolves to an `<acct>.dkr.ecr.<region>.amazonaws.com/...` URI. Required when the caller's identity does not already have cross-account access to the target repository. Same-account / same-region pulls do not need this flag. No-op when `--no-pull` is set. |
@@ -1132,7 +1133,7 @@ resolution tiers fire **before** the URI is fed to tier 2:
   `Fn::GetAtt: [<Repo>, 'RepositoryUri']`, cdk-local needs the
   deployed physical repo name. Pass `--from-cfn-stack` (the stack must
   have been deployed via `cdk deploy`); cdk-local calls
-  `DescribeStackResources`, substitutes the physical name, then routes
+  `ListStackResources`, substitutes the physical name, then routes
   through tier 2. Without `--from-cfn-stack` the error message points
   back at this flag as the resolution path.
 
@@ -1153,7 +1154,7 @@ parameters:
 
 | Intrinsic | Source |
 | --- | --- |
-| `Ref: <LogicalId>` | `DescribeStackResources` → `PhysicalResourceId` |
+| `Ref: <LogicalId>` | `ListStackResources` → `PhysicalResourceId` |
 | `Fn::ImportValue: <ExportName>` | `ListExports` (memoized for one substitution pass) |
 | `Fn::Sub: '...${X}...${AWS::Region}...'` | recursive substitution against CFn data + pseudo parameters |
 | `Fn::Join: [<delim>, [<elements>]]` | recursive substitution of every element, then `Array.join` |
@@ -1165,7 +1166,7 @@ Per-key best-effort: when a substitution can't be produced (CFn
 resource missing, attribute not exposed via CFn, unsupported
 intrinsic), the env / secret entry is dropped and a per-key warning
 surfaces on the task's warnings line — the run-task invocation never
-aborts. DescribeStackResources failures (no record, access denied,
+aborts. ListStackResources failures (no record, access denied,
 throttling) also degrade to warn-and-fall-back rather than hard-fail.
 
 Resolved `Secrets[].ValueFrom` strings then flow into the standard

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,7 +101,7 @@ The stack-qualified logical ID form (`MyStack:MyFunctionLogicalId`) is also acce
 The flag reads CloudFormation Outputs and resolves resource ARNs into env vars on the local container. If env injection seems missing:
 
 - Confirm the stack name matches a deployed stack (`aws cloudformation describe-stacks --stack-name <name>`).
-- Confirm your IAM credentials have `cloudformation:DescribeStacks`.
+- Confirm your IAM credentials have `cloudformation:ListStackResources`, `cloudformation:DescribeStacks`, and `cloudformation:ListExports`.
 - Confirm the stack has the Outputs / resources your CDK code expects (the local synth's expectations must match the deployed state).
 
 ### `--env-vars <file>` not applying overrides

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -113,7 +113,7 @@ interface LocalInvokeOptions {
   /**
    * Issue #606: alternative state source for CDK apps deployed via the
    * upstream CDK CLI (`cdk deploy` → CloudFormation). Reads the named
-   * CFn stack via `DescribeStackResources` to populate physical IDs.
+   * CFn stack via `ListStackResources` to populate physical IDs.
    * Commander maps:
    *   - flag absent → `undefined`
    *   - `--from-cfn-stack` (bare) → `true` (use the resolved stack name)
@@ -1083,10 +1083,10 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
     .addOption(
       new Option(
         '--from-cfn-stack [cfn-stack-name]',
-        'Read a deployed CloudFormation stack via DescribeStackResources and substitute Ref / Fn::ImportValue ' +
+        'Read a deployed CloudFormation stack via ListStackResources and substitute Ref / Fn::ImportValue ' +
           'in env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream ' +
           'CDK CLI (`cdk deploy`). Bare form uses the resolved stack name; pass an explicit value when CFn stack name differs. ' +
-          'Fn::GetAtt is warn-and-dropped in v1 (CFn DescribeStackResources does not return per-attribute values).'
+          'Fn::GetAtt is warn-and-dropped in v1 (CFn ListStackResources does not return per-attribute values).'
       )
     )
     .addOption(

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -78,7 +78,7 @@ interface LocalRunTaskOptions {
   detach: boolean;
   /**
    * Issue #606: alternative state source. Reads physical IDs from a
-   * deployed CloudFormation stack via `DescribeStackResources`.
+   * deployed CloudFormation stack via `ListStackResources`.
    */
   fromCfnStack?: string | boolean;
   /**
@@ -660,11 +660,11 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
     .addOption(
       new Option(
         '--from-cfn-stack [cfn-stack-name]',
-        'Read a deployed CloudFormation stack via DescribeStackResources and substitute Ref / Fn::ImportValue ' +
+        'Read a deployed CloudFormation stack via ListStackResources and substitute Ref / Fn::ImportValue ' +
           'in container env vars / secrets / image URIs with the deployed physical IDs / exports. ' +
           'Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). ' +
           `Bare form uses the ${getEmbedConfig().binaryName} stack name; pass an explicit value when the CFn stack name differs. ` +
-          'Fn::GetAtt is warn-and-dropped in v1 (CFn DescribeStackResources does not return per-attribute values).'
+          'Fn::GetAtt is warn-and-dropped in v1 (CFn ListStackResources does not return per-attribute values).'
       )
     )
     .addOption(

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -169,7 +169,7 @@ interface LocalStartApiOptions {
   api?: string;
   /**
    * Issue #606: alternative state source. Reads physical IDs from a
-   * deployed CloudFormation stack via `DescribeStackResources`.
+   * deployed CloudFormation stack via `ListStackResources`.
    * Commander maps:
    *   - flag absent → `undefined`
    *   - `--from-cfn-stack` (bare) → `true` (use the resolved stack name per routed stack)
@@ -3173,11 +3173,11 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
     .addOption(
       new Option(
         '--from-cfn-stack [cfn-stack-name]',
-        'Read a deployed CloudFormation stack via DescribeStackResources and substitute Ref / Fn::ImportValue ' +
+        'Read a deployed CloudFormation stack via ListStackResources and substitute Ref / Fn::ImportValue ' +
           'in Lambda env vars with the deployed physical IDs / exports. ' +
           'Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). ' +
           'Bare form uses the resolved stack name per routed stack; pass an explicit value when a single CFn stack should serve every routed stack. ' +
-          'Fn::GetAtt is warn-and-dropped in v1 (CFn DescribeStackResources does not return per-attribute values).'
+          'Fn::GetAtt is warn-and-dropped in v1 (CFn ListStackResources does not return per-attribute values).'
       )
     )
     .addOption(

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -82,7 +82,7 @@ interface LocalStartServiceOptions {
   restartPolicy: 'on-failure' | 'always' | 'none';
   /**
    * Issue #606: alternative state source. Reads physical IDs from a
-   * deployed CloudFormation stack via `DescribeStackResources`.
+   * deployed CloudFormation stack via `ListStackResources`.
    */
   fromCfnStack?: string | boolean;
   stackRegion?: string;
@@ -837,11 +837,11 @@ export function createLocalStartServiceCommand(
     .addOption(
       new Option(
         '--from-cfn-stack [cfn-stack-name]',
-        'Read a deployed CloudFormation stack via DescribeStackResources and substitute Ref / Fn::ImportValue ' +
+        'Read a deployed CloudFormation stack via ListStackResources and substitute Ref / Fn::ImportValue ' +
           'in container env vars / secrets / image URIs with the deployed physical IDs / exports. ' +
           'Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). ' +
           `Bare form uses the ${getEmbedConfig().binaryName} stack name; pass an explicit value when the CFn stack name differs. ` +
-          'Fn::GetAtt is warn-and-dropped in v1 (CFn DescribeStackResources does not return per-attribute values).'
+          'Fn::GetAtt is warn-and-dropped in v1 (CFn ListStackResources does not return per-attribute values).'
       )
     )
     .addOption(

--- a/src/cli/commands/local-state-source.ts
+++ b/src/cli/commands/local-state-source.ts
@@ -5,7 +5,7 @@
  * Built-in flag (always wired):
  *
  *   - `--from-cfn-stack [<cfn-stack-name>]` — CFn-backed; reads a
- *     deployed CloudFormation stack via `DescribeStackResources`.
+ *     deployed CloudFormation stack via `ListStackResources`.
  *
  * Host-extensible state sources (via the `extraStateProviders` option):
  *
@@ -228,7 +228,7 @@ export function createLocalStateProvider(
 
   // Reject empty `--from-cfn-stack ""`. Letting it through would
   // construct a `CfnLocalStateProvider` with `cfnStackName: ''` and the
-  // SDK's `DescribeStackResources({ StackName: '' })` rejects with a
+  // SDK's `ListStackResources({ StackName: '' })` rejects with a
   // generic ValidationError far from the call site. Reject at the
   // dispatcher with a clear remediation message instead.
   if (cfnStackOpt === '') {

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -4,7 +4,7 @@
  * --from-cfn-stack` (issue #606).
  *
  * The shape mirrors the SAM CLI's `sam local invoke --stack-name X`
- * behavior: reach into a deployed CFn stack via `DescribeStackResources`
+ * behavior: reach into a deployed CFn stack via `ListStackResources`
  * to look up physical IDs of every same-stack resource, then make those
  * IDs available to the existing `state-resolver.ts` substitution engine.
  * This lets `cdkl *` substitute env vars / secrets / images that
@@ -15,11 +15,11 @@
  * Wire-format mapping:
  *
  *   - `Ref: <LogicalId>` → resolved via the synthetic `ResourceState`
- *     map built from `DescribeStackResources.StackResources[]` (one
+ *     map built from `ListStackResources.StackResourceSummaries[]` (one
  *     entry per `(LogicalResourceId, PhysicalResourceId, ResourceType)`
  *     tuple).
  *   - `Fn::GetAtt: [<LogicalId>, <Attr>]` → **warn-and-drop**. CFn's
- *     `DescribeStackResources` does NOT return per-attribute values
+ *     `ListStackResources` does NOT return per-attribute values
  *     and the v1 policy (issue #606 recommendation (a)) is to surface
  *     a per-key warn instead of pulling in the full provisioning layer
  *     to call provider-specific describe APIs (e.g. `GetQueueAttributes`
@@ -44,8 +44,14 @@
  *
  * AWS API contract notes:
  *
- *   - `DescribeStackResources` is unpaginated up to 500 resources (CFn's
- *     hard stack cap). One call suffices for the entire stack.
+ *   - `ListStackResources` is paginated and returns EVERY resource in
+ *     the stack across pages. We deliberately do NOT use
+ *     `DescribeStackResources` here: that API returns only the first
+ *     100 resources (AWS-documented hard cap) with no `NextToken`, so a
+ *     stack with > 100 resources silently loses its tail — every `Ref`
+ *     to a dropped resource then warn-and-drops its env var. The
+ *     provider walks `ListStackResources`'s `NextToken` until the page
+ *     set is exhausted so all resources are mapped regardless of count.
  *   - `DescribeStacks` is unpaginated when called with `StackName`.
  *   - `ListExports` is paginated; the provider walks `NextToken` until
  *     the page set is exhausted.
@@ -53,9 +59,9 @@
 
 import {
   CloudFormationClient,
-  DescribeStackResourcesCommand,
   DescribeStacksCommand,
   ListExportsCommand,
+  ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
 import { getLogger } from '../utils/logger.js';
 import type { ResourceState } from '../types/state.js';
@@ -165,13 +171,11 @@ export class CfnLocalStateProvider implements LocalStateProvider {
 
     let resourceMap: Record<string, ResourceState>;
     try {
-      const resp = await client.send(
-        new DescribeStackResourcesCommand({ StackName: this.cfnStackName })
-      );
-      resourceMap = buildResourceStateMap(resp.StackResources ?? []);
+      const summaries = await fetchAllStackResources(client, this.cfnStackName);
+      resourceMap = buildResourceStateMap(summaries);
     } catch (err) {
       logger.warn(
-        `${this.label}: DescribeStackResources(${this.cfnStackName}) failed: ${formatAwsErrorForWarn(err)}. ` +
+        `${this.label}: ListStackResources(${this.cfnStackName}) failed: ${formatAwsErrorForWarn(err)}. ` +
           `Was the stack deployed in region '${this.region}'? Falling back.`
       );
       return undefined;
@@ -296,7 +300,7 @@ export class CfnLocalStateProvider implements LocalStateProvider {
 
 /**
  * Build the synthetic per-logical-id resource map from
- * `DescribeStackResources` output. Each `ResourceState` carries the
+ * `ListStackResources` output. Each `ResourceState` carries the
  * physical id (covers `Ref`) and the resource type; `attributes` is
  * left empty per issue #606's (a) recommendation — the warn-and-drop
  * policy on unresolvable `Fn::GetAtt` is the v1 contract. The other
@@ -347,6 +351,64 @@ export function buildOutputsMap(
     if (o.OutputKey === undefined || o.OutputValue === undefined) continue;
     out[o.OutputKey] = o.OutputValue;
   }
+  return out;
+}
+
+/**
+ * Walk `ListStackResources` until every page is consumed and return the
+ * full `StackResourceSummary[]`. `ListStackResources` is paginated and
+ * returns up to 100 resources per page; the provider must walk every
+ * page so stacks with more than 100 resources are mapped completely.
+ *
+ * This is the reason the provider does not use `DescribeStackResources`:
+ * that API caps its response at the first 100 resources with no
+ * `NextToken`, so a > 100-resource stack silently loses its tail and the
+ * dropped resources' `Ref`s become unresolvable. Exported for unit
+ * testing.
+ */
+export async function fetchAllStackResources(
+  client: CloudFormationClient,
+  stackName: string
+): Promise<
+  Array<{
+    LogicalResourceId?: string | undefined;
+    PhysicalResourceId?: string | undefined;
+    ResourceType?: string | undefined;
+  }>
+> {
+  const out: Array<{
+    LogicalResourceId?: string | undefined;
+    PhysicalResourceId?: string | undefined;
+    ResourceType?: string | undefined;
+  }> = [];
+  let nextToken: string | undefined;
+  // Safety bound — a CFn stack holds at most 500 resources by default
+  // (raisable, but far below this ceiling) and ListStackResources returns
+  // up to 100 per page, so a real stack needs only a handful of pages.
+  // 100 pages defends against a hypothetical NextToken loop without ever
+  // tripping on a legitimate stack.
+  let pages = 0;
+  do {
+    const resp = await client.send(
+      new ListStackResourcesCommand({
+        StackName: stackName,
+        ...(nextToken !== undefined && { NextToken: nextToken }),
+      })
+    );
+    for (const summary of resp.StackResourceSummaries ?? []) {
+      out.push(summary);
+    }
+    nextToken = resp.NextToken;
+    pages += 1;
+    if (pages > 100) {
+      throw new Error(
+        'ListStackResources pagination exceeded 100 pages — likely a malformed NextToken loop.'
+      );
+    }
+    // Treat an empty-string NextToken as terminal (mirrors fetchAllExports):
+    // the SDK types it as `string | undefined`; AWS should not return `''`
+    // but if it does, looping on it would waste round-trips.
+  } while (nextToken !== undefined && nextToken !== '');
   return out;
 }
 

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -12,7 +12,7 @@
  *     `src/cli/commands/local-state-loader.ts`.
  *
  *   - {@link CfnLocalStateProvider} (new for `--from-cfn-stack`) — reads
- *     a deployed CloudFormation stack via `DescribeStackResources` +
+ *     a deployed CloudFormation stack via `ListStackResources` +
  *     `DescribeStacks --Outputs` + `ListExports`. Lets the `local *`
  *     commands substitute deployed physical IDs from a CDK app deployed
  *     via the upstream CDK CLI (`cdk deploy` → CloudFormation), so users
@@ -46,7 +46,7 @@ export interface LocalStateRecord {
   /**
    * Per-logical-id resource records. Covers `Ref: <logicalId>` lookups
    * via `physicalId`. The CFn provider also leaves `attributes` empty —
-   * `DescribeStackResources` does not return per-attribute values, and
+   * `ListStackResources` does not return per-attribute values, and
    * the v1 policy is warn-and-drop for unresolvable `Fn::GetAtt` (per
    * issue #606's recommendation (a)).
    */

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -304,7 +304,7 @@ function resolveRef(arg: unknown, context: SubstitutionContext): StateSubstituti
   if (!resource) {
     return {
       kind: 'unresolved',
-      reason: `Ref '${arg}': no record in cdkd state (was the resource deployed?)`,
+      reason: `Ref '${arg}': no record in the state source (was the resource deployed?)`,
     };
   }
   return { kind: 'literal', value: resource.physicalId };
@@ -317,7 +317,7 @@ function resolvePseudoParameter(
   if (!pseudo) {
     return {
       kind: 'unresolved',
-      reason: `Ref '${name}': pseudo parameter not supplied (need --from-state context)`,
+      reason: `Ref '${name}': pseudo parameter not supplied (need an active state source, e.g. --from-cfn-stack)`,
     };
   }
   switch (name) {
@@ -377,14 +377,14 @@ function resolveGetAtt(arg: unknown, context: SubstitutionContext): StateSubstit
   if (!resource) {
     return {
       kind: 'unresolved',
-      reason: `Fn::GetAtt '${logicalId}.${attr}': no record in cdkd state`,
+      reason: `Fn::GetAtt '${logicalId}.${attr}': no record in the state source`,
     };
   }
   const cached = resource.attributes?.[attr];
   if (cached === undefined) {
     return {
       kind: 'unresolved',
-      reason: `Fn::GetAtt '${logicalId}.${attr}': attribute not captured in cdkd state at deploy time`,
+      reason: `Fn::GetAtt '${logicalId}.${attr}': attribute not captured in the state source at deploy time`,
     };
   }
   if (typeof cached === 'string' || typeof cached === 'number' || typeof cached === 'boolean') {
@@ -828,7 +828,7 @@ async function resolveImportValueAsync(
   if (!context.crossStackResolver) {
     return {
       kind: 'unresolved',
-      reason: `Fn::ImportValue '${exportName}': no cross-stack resolver supplied (pass --from-state and ensure the producer stack was deployed via cdkd deploy)`,
+      reason: `Fn::ImportValue '${exportName}': no cross-stack resolver supplied (pass a state-source flag, e.g. --from-cfn-stack, and ensure the producer stack was deployed)`,
     };
   }
 
@@ -844,7 +844,7 @@ async function resolveImportValueAsync(
   if (resolved === undefined) {
     return {
       kind: 'unresolved',
-      reason: `Fn::ImportValue '${exportName}': export not found in any cdkd-managed stack in this region`,
+      reason: `Fn::ImportValue '${exportName}': export not found in any deployed stack in this region`,
     };
   }
   return { kind: 'literal', value: resolved };
@@ -929,14 +929,14 @@ async function resolveGetStackOutputAsync(
   if (args['RoleArn'] !== undefined && args['RoleArn'] !== null) {
     return {
       kind: 'unresolved',
-      reason: `Fn::GetStackOutput '${stackName}.${outputName}': RoleArn (cross-account) is not yet supported by --from-state — tracked under issue #449`,
+      reason: `Fn::GetStackOutput '${stackName}.${outputName}': RoleArn (cross-account) is not yet supported by the state source — tracked under issue #449`,
     };
   }
 
   if (!context.crossStackResolver) {
     return {
       kind: 'unresolved',
-      reason: `Fn::GetStackOutput '${stackName}.${outputName}': no cross-stack resolver supplied (pass --from-state and ensure the producer stack was deployed via cdkd deploy)`,
+      reason: `Fn::GetStackOutput '${stackName}.${outputName}': no cross-stack resolver supplied (pass a state-source flag, e.g. --from-cfn-stack, and ensure the producer stack was deployed)`,
     };
   }
 

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/.gitignore
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/.gitignore
@@ -1,0 +1,3 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is tracked.
+!lambda/*.js

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/.scenarios.json
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/.scenarios.json
@@ -1,0 +1,6 @@
+{
+  "scenarios": [
+    "local-from-cfn-stack-substitution",
+    "local-lambda-rie-zip"
+  ]
+}

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/bin/app.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalInvokeFromCfnStackLargeStack } from '../lib/local-invoke-from-cfn-stack-large-stack-stack.ts';
+
+const app = new cdk.App();
+
+new LocalInvokeFromCfnStackLargeStack(app, 'CdkLocalInvokeFromCfnStackLargeFixture', {
+  description: 'Fixture stack (>100 resources) for cdkl invoke --from-cfn-stack pagination',
+});

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/cdk.json
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/lambda/index.js
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/lambda/index.js
@@ -1,0 +1,13 @@
+// Counts how many `P###` env vars survived state-source substitution.
+// The integ asserts that --from-cfn-stack resolves ALL of them even
+// though the stack has more than 100 resources: DescribeStackResources
+// would cap at the first 100 and silently drop the tail, whereas the
+// paginated ListStackResources provider maps every parameter.
+exports.handler = async (event) => {
+  const paramCount = Object.keys(process.env).filter((k) => /^P\d{3}$/.test(k)).length;
+  return {
+    paramCount,
+    staticValue: process.env.STATIC_VALUE ?? 'unset',
+    event,
+  };
+};

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts
@@ -1,0 +1,72 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture for `cdkl invoke --from-cfn-stack` against a stack with MORE
+ * than 100 resources.
+ *
+ * Regression guard for the CloudFormation `DescribeStackResources` cap:
+ * that API returns only the first 100 resources of a stack with no
+ * pagination token, so a stack with > 100 resources silently loses its
+ * tail and every `Ref` to a dropped resource warn-and-drops its Lambda
+ * env var. The `--from-cfn-stack` provider must walk the paginated
+ * `ListStackResources` so all resources are mapped regardless of count.
+ *
+ * Shape: PARAM_COUNT (> 100) SSM parameters + one Lambda. The Lambda's
+ * env has one intrinsic-valued var per parameter (`Ref` -> parameter
+ * name). Two details keep the fixture honest:
+ *
+ *   - Each parameter carries an explicit SHORT name so the deployed
+ *     Lambda env (CFn resolves every `Ref` to its name at deploy time)
+ *     stays under the 4 KB Lambda env limit.
+ *   - The env values are the L1 `.ref` intrinsic, not the literal
+ *     explicit name, so the substitution code path is actually
+ *     exercised (a literal would pass through without touching the
+ *     state source).
+ *
+ * Without --from-cfn-stack every intrinsic env var drops (paramCount=0).
+ * With --from-cfn-stack and the paginated provider, all PARAM_COUNT
+ * names resolve (paramCount=PARAM_COUNT). With the old 100-cap provider
+ * the count would fall short — the regression this fixture catches.
+ */
+const PARAM_COUNT = 105;
+
+export class LocalInvokeFromCfnStackLargeStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const environment: Record<string, string> = {
+      // Literal env var: confirms --from-cfn-stack does not regress
+      // normal-case pass-through on its way through the substituter.
+      STATIC_VALUE: 'always-the-same',
+    };
+
+    for (let i = 0; i < PARAM_COUNT; i++) {
+      const suffix = String(i).padStart(3, '0');
+      const param = new ssm.CfnParameter(this, `Param${suffix}`, {
+        type: 'String',
+        name: `/cdkl-ls/p${suffix}`,
+        value: `value-${suffix}`,
+      });
+      // `param.ref` synthesizes to `{ Ref: Param<suffix> }`, which CFn
+      // resolves to the parameter NAME on the deployed stack. Forcing the
+      // intrinsic (rather than using the literal explicit name) is what
+      // routes this env var through the --from-cfn-stack substituter.
+      environment[`P${suffix}`] = param.ref;
+    }
+
+    new lambda.Function(this, 'CountParamsHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
+      environment,
+      timeout: cdk.Duration.seconds(10),
+    });
+  }
+}

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-invoke-from-cfn-stack-large-stack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl invoke --from-cfn-stack against a >100-resource stack",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/tsconfig.json
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/verify.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkl invoke --from-cfn-stack`
+# against a stack with MORE than 100 resources.
+#
+# Why this exists: the `--from-cfn-stack` provider reads the deployed
+# stack's physical IDs from CloudFormation. CloudFormation's
+# `DescribeStackResources` returns only the FIRST 100 resources of a
+# stack (AWS-documented hard cap, no pagination token), so a stack with
+# more than 100 resources silently loses its tail — every `Ref` to a
+# dropped resource then warn-and-drops its Lambda env var. The provider
+# must instead walk the paginated `ListStackResources`, which returns
+# every resource across pages.
+#
+# The fixture stack has 105 SSM parameters + one Lambda (> 100 resources
+# total). The Lambda's env carries one intrinsic-valued var per parameter
+# (`Ref` -> parameter name) and returns how many survived substitution.
+#
+# Steps:
+#   1. install + build cdk-local (root) + install fixture deps + docker pull
+#   2. cdk deploy CdkLocalInvokeFromCfnStackLargeFixture (upstream CDK CLI)
+#   3. baseline: cdkl invoke (no --from-cfn-stack) — assert paramCount=0
+#      (every intrinsic-valued env var dropped via warn-and-drop).
+#   4. cdkl invoke --from-cfn-stack — assert paramCount=105, i.e. ALL
+#      parameters resolved even though the stack exceeds the 100-resource
+#      DescribeStackResources cap, and STATIC_VALUE still passes through.
+#   5. cdk destroy --force
+#
+# Run via `/run-integ local-invoke-from-cfn-stack-large-stack` (recommended)
+# or directly:
+#
+#     bash tests/integration/local-invoke-from-cfn-stack-large-stack/verify.sh
+#
+# Requires Docker AND AWS credentials with deploy permissions in the
+# target account. Also requires the global `cdk` (aws-cdk) CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalInvokeFromCfnStackLargeFixture"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+EXPECTED_COUNT=105
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-from-cfn-stack-large-stack"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed, >100 resources)"
+
+echo "[verify] step 1a: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+
+echo "[verify] step 1b: verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "[verify] step 1c: pulling ${IMAGE} (one-time, ~600MB if not cached)"
+docker pull "${IMAGE}"
+
+# Gate the cleanup trap on a "we created the stack" sentinel so the EXIT
+# trap never destroys a pre-existing same-named stack we did not create.
+WE_CREATED_STACK=0
+cleanup() {
+  rc=$?
+  if [ "${rc}" -ne 0 ] && [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] FAIL (exit ${rc}) — attempting cdk destroy to clean up"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists in CloudFormation — clean up first via:"
+  echo "          aws cloudformation delete-stack --stack-name ${STACK} --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 3: cdk deploy (upstream CDK CLI) — 105 SSM params + 1 Lambda"
+# Set the sentinel BEFORE `cdk deploy`: pre-flight has verified the
+# namespace is clean, so once we issue the deploy we OWN the namespace
+# (cdk destroy is a no-op on stacks that never reached AWS).
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 3 ok: cdk deploy completed"
+
+# Sanity-check the deployed stack really exceeds the 100-resource cap so
+# this test is exercising the pagination path and not silently passing on
+# a small stack (e.g. if PARAM_COUNT is ever lowered below the cap).
+RESOURCE_COUNT=$(aws cloudformation list-stack-resources \
+  --stack-name "${STACK}" \
+  --region "${REGION}" \
+  --query 'length(StackResourceSummaries)' \
+  --output text)
+echo "[verify] step 3b: deployed resource count = ${RESOURCE_COUNT}"
+if [ "${RESOURCE_COUNT}" -le 100 ]; then
+  echo "[verify] FAIL: stack has ${RESOURCE_COUNT} resources (<=100); this fixture must exceed the DescribeStackResources cap to be meaningful"
+  exit 1
+fi
+
+# Local invoke is flaky on cold dockers: retry up to 3 times.
+invoke_with_retry() {
+  local args=("$@")
+  local attempts=3
+  local i=1
+  while [ $i -le $attempts ]; do
+    if out=$(${CLI} invoke "${args[@]}" 2>/dev/null | tail -1) && \
+       echo "${out}" | grep -q '"paramCount":'; then
+      printf '%s' "${out}"
+      return 0
+    fi
+    if [ $i -lt $attempts ]; then
+      echo "[verify]   invoke attempt ${i} failed, retrying..." >&2
+      sleep 2
+    fi
+    i=$((i+1))
+  done
+  echo "[verify]   all ${attempts} invoke attempts failed; last stderr below:" >&2
+  ${CLI} invoke "${args[@]}" 2>&1 | tail -10 >&2
+  return 1
+}
+
+echo "[verify] step 4: cdkl invoke (no --from-cfn-stack) — expect paramCount=0"
+RESULT_BASELINE=$(invoke_with_retry "${STACK}/CountParamsHandler" --no-pull)
+echo "[verify]   response: ${RESULT_BASELINE}"
+echo "${RESULT_BASELINE}" | grep -q '"paramCount":0' || {
+  echo "[verify] FAIL: expected paramCount=0 (intrinsic env vars dropped without a state source), got: ${RESULT_BASELINE}"
+  exit 1
+}
+
+echo "[verify] step 5: cdkl invoke --from-cfn-stack — expect paramCount=${EXPECTED_COUNT}"
+# Bare --from-cfn-stack uses the host stack name verbatim as the CFn
+# stack name, which matches the deployed name here.
+RESULT_FROM_CFN=$(invoke_with_retry "${STACK}/CountParamsHandler" --from-cfn-stack --no-pull)
+echo "[verify]   response: ${RESULT_FROM_CFN}"
+echo "${RESULT_FROM_CFN}" | grep -q "\"paramCount\":${EXPECTED_COUNT}" || {
+  echo "[verify] FAIL: expected paramCount=${EXPECTED_COUNT} (all params resolved past the 100-resource cap), got: ${RESULT_FROM_CFN}"
+  exit 1
+}
+echo "${RESULT_FROM_CFN}" | grep -q '"staticValue":"always-the-same"' || {
+  echo "[verify] FAIL: STATIC_VALUE regressed under --from-cfn-stack, got: ${RESULT_FROM_CFN}"
+  exit 1
+}
+
+echo "[verify] step 6: cdk destroy --force"
+cdk destroy "${STACK}" --force --region "${REGION}" \
+  --no-version-reporting --no-asset-metadata --no-path-metadata
+
+echo ""
+echo "[verify] All checks passed: --from-cfn-stack resolved all ${EXPECTED_COUNT} parameters across the >100-resource pagination boundary."

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/verify.sh
@@ -97,11 +97,15 @@ echo "[verify] step 3 ok: cdk deploy completed"
 # Sanity-check the deployed stack really exceeds the 100-resource cap so
 # this test is exercising the pagination path and not silently passing on
 # a small stack (e.g. if PARAM_COUNT is ever lowered below the cap).
+# Count logical IDs across ALL pages. `--query 'length(...)'` is wrong here:
+# the AWS CLI auto-paginates and applies the query per page, emitting one
+# length per page (e.g. "100\n7") instead of the total. Projecting the IDs
+# to text and counting words sums correctly across pages.
 RESOURCE_COUNT=$(aws cloudformation list-stack-resources \
   --stack-name "${STACK}" \
   --region "${REGION}" \
-  --query 'length(StackResourceSummaries)' \
-  --output text)
+  --query 'StackResourceSummaries[].LogicalResourceId' \
+  --output text | wc -w | tr -d ' ')
 echo "[verify] step 3b: deployed resource count = ${RESOURCE_COUNT}"
 if [ "${RESOURCE_COUNT}" -le 100 ]; then
   echo "[verify] FAIL: stack has ${RESOURCE_COUNT} resources (<=100); this fixture must exceed the DescribeStackResources cap to be meaningful"

--- a/tests/unit/local/cfn-local-state-provider-load.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-load.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Mock the SDK so `load()` (which constructs its own CloudFormationClient
+// via the lazy getClient()) can be exercised without real AWS. `load()`
+// always calls ListStackResources first, then DescribeStacks, so the tests
+// script the shared `send` mock in that fixed order with mockResolvedValueOnce.
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+vi.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: class {
+    send = sendMock;
+    destroy(): void {}
+  },
+  ListStackResourcesCommand: class {},
+  DescribeStacksCommand: class {},
+  ListExportsCommand: class {},
+}));
+
+const { CfnLocalStateProvider, buildOutputsMap, formatAwsErrorForWarn } = await import(
+  '../../../src/local/cfn-local-state-provider.js'
+);
+
+describe('CfnLocalStateProvider.load', () => {
+  beforeEach(() => sendMock.mockReset());
+
+  it('returns resources + outputs on the happy path', async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        StackResourceSummaries: [
+          { LogicalResourceId: 'Table', PhysicalResourceId: 'tbl-1', ResourceType: 'AWS::DynamoDB::Table' },
+        ],
+      })
+      .mockResolvedValueOnce({ Stacks: [{ Outputs: [{ OutputKey: 'Url', OutputValue: 'https://x' }] }] });
+
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    const rec = await provider.load('S', undefined);
+
+    expect(rec).toBeDefined();
+    expect(rec!.resources['Table']?.physicalId).toBe('tbl-1');
+    expect(rec!.outputs['Url']).toBe('https://x');
+    expect(rec!.region).toBe('us-east-1');
+    provider.dispose();
+  });
+
+  it('returns undefined (warn-and-fallback) when ListStackResources fails', async () => {
+    sendMock.mockRejectedValueOnce(new Error('AccessDenied'));
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    expect(await provider.load('S', undefined)).toBeUndefined();
+    provider.dispose();
+  });
+
+  it('keeps resources but empties outputs when DescribeStacks returns no stack', async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        StackResourceSummaries: [
+          { LogicalResourceId: 'Q', PhysicalResourceId: 'q-url', ResourceType: 'AWS::SQS::Queue' },
+        ],
+      })
+      .mockResolvedValueOnce({ Stacks: [] });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    const rec = await provider.load('S', undefined);
+    expect(rec!.resources['Q']?.physicalId).toBe('q-url');
+    expect(rec!.outputs).toEqual({});
+    provider.dispose();
+  });
+
+  it('keeps resources but empties outputs when DescribeStacks throws', async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        StackResourceSummaries: [
+          { LogicalResourceId: 'Q', PhysicalResourceId: 'q-url', ResourceType: 'AWS::SQS::Queue' },
+        ],
+      })
+      .mockRejectedValueOnce(new Error('Throttling'));
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    const rec = await provider.load('S', undefined);
+    expect(rec!.resources['Q']?.physicalId).toBe('q-url');
+    expect(rec!.outputs).toEqual({});
+    provider.dispose();
+  });
+
+  it('throws on use after dispose()', async () => {
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    provider.dispose();
+    await expect(provider.load('S', undefined)).rejects.toThrow(/after dispose/);
+  });
+});
+
+describe('buildOutputsMap', () => {
+  it('maps OutputKey -> OutputValue and skips undefined entries', () => {
+    expect(
+      buildOutputsMap([{ OutputKey: 'A', OutputValue: '1' }, { OutputKey: 'B' }, { OutputValue: '2' }])
+    ).toEqual({ A: '1' });
+  });
+});
+
+describe('formatAwsErrorForWarn', () => {
+  it('prefixes the error name and HTTP status', () => {
+    const err = Object.assign(new Error('boom'), {
+      name: 'ThrottlingException',
+      $metadata: { httpStatusCode: 400 },
+    });
+    expect(formatAwsErrorForWarn(err)).toBe('ThrottlingException HTTP 400: boom');
+  });
+
+  it('falls back to the bare message for a generic Error', () => {
+    expect(formatAwsErrorForWarn(new Error('plain'))).toBe('plain');
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(formatAwsErrorForWarn('weird')).toBe('weird');
+  });
+});

--- a/tests/unit/local/cfn-local-state-provider.test.ts
+++ b/tests/unit/local/cfn-local-state-provider.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import type { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import {
+  fetchAllStackResources,
+  buildResourceStateMap,
+} from '../../../src/local/cfn-local-state-provider.js';
+
+/**
+ * Helper: a fake `CloudFormationClient` whose `send` returns the supplied
+ * `ListStackResources` responses in order. Only `send` is exercised by the
+ * code under test, so the cast through `unknown` is safe.
+ */
+function fakeClient(responses: unknown[]): { client: CloudFormationClient; send: ReturnType<typeof vi.fn> } {
+  const send = vi.fn();
+  for (const r of responses) send.mockResolvedValueOnce(r);
+  return { client: { send } as unknown as CloudFormationClient, send };
+}
+
+function summary(i: number) {
+  return {
+    LogicalResourceId: `Resource${i}`,
+    PhysicalResourceId: `physical-${i}`,
+    ResourceType: 'AWS::SSM::Parameter',
+  };
+}
+
+describe('fetchAllStackResources', () => {
+  it('walks every page so a >100-resource stack is mapped completely', async () => {
+    // The bug this guards: DescribeStackResources caps at the first 100
+    // resources. ListStackResources paginates — page 1 has 100, page 2 has
+    // the 5 that DescribeStackResources would have silently dropped.
+    const page1 = Array.from({ length: 100 }, (_, i) => summary(i));
+    const page2 = Array.from({ length: 5 }, (_, i) => summary(100 + i));
+    const { client, send } = fakeClient([
+      { StackResourceSummaries: page1, NextToken: 'page-2' },
+      { StackResourceSummaries: page2 },
+    ]);
+
+    const all = await fetchAllStackResources(client, 'MyStack');
+
+    expect(all).toHaveLength(105);
+    expect(send).toHaveBeenCalledTimes(2);
+    // Second call must carry the NextToken from page 1.
+    const secondInput = (send.mock.calls[1]![0] as { input: { NextToken?: string } }).input;
+    expect(secondInput.NextToken).toBe('page-2');
+
+    // The resource at index 104 — beyond the DescribeStackResources cap —
+    // must be present and resolvable via the resource map.
+    const map = buildResourceStateMap(all);
+    expect(Object.keys(map)).toHaveLength(105);
+    expect(map['Resource104']?.physicalId).toBe('physical-104');
+  });
+
+  it('single page (no NextToken) issues exactly one call', async () => {
+    const { client, send } = fakeClient([
+      { StackResourceSummaries: [summary(0), summary(1)] },
+    ]);
+    const all = await fetchAllStackResources(client, 'MyStack');
+    expect(all).toHaveLength(2);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an empty-string NextToken as terminal', async () => {
+    const { client, send } = fakeClient([
+      { StackResourceSummaries: [summary(0)], NextToken: '' },
+    ]);
+    const all = await fetchAllStackResources(client, 'MyStack');
+    expect(all).toHaveLength(1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on a runaway NextToken loop instead of paging forever', async () => {
+    const send = vi.fn().mockResolvedValue({ StackResourceSummaries: [], NextToken: 'never-ends' });
+    const client = { send } as unknown as CloudFormationClient;
+    await expect(fetchAllStackResources(client, 'MyStack')).rejects.toThrow(/exceeded 100 pages/);
+  });
+});
+
+describe('buildResourceStateMap', () => {
+  it('skips half-populated entries (mid-create resources, CDK metadata sentinels)', () => {
+    const map = buildResourceStateMap([
+      { LogicalResourceId: 'Good', PhysicalResourceId: 'p', ResourceType: 'AWS::S3::Bucket' },
+      { LogicalResourceId: 'NoPhysical', ResourceType: 'AWS::S3::Bucket' },
+      { PhysicalResourceId: 'p2', ResourceType: 'AWS::S3::Bucket' },
+      { LogicalResourceId: 'NoType', PhysicalResourceId: 'p3' },
+    ]);
+    expect(Object.keys(map)).toEqual(['Good']);
+    expect(map['Good']).toEqual({
+      physicalId: 'p',
+      resourceType: 'AWS::S3::Bucket',
+      properties: {},
+      attributes: {},
+      dependencies: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl * --from-cfn-stack` read the deployed CloudFormation stack via
`DescribeStackResources`, which AWS caps at the **first 100 resources** with
no pagination token. A stack with more than 100 resources silently lost its
tail, so every `Ref` to a dropped resource warn-and-dropped its Lambda env var
— e.g. a Secrets Manager secret name or SSM parameter name never reached the
local container, and the handler then could not fetch the value at runtime.

This was hit on a real 101-resource stack: `describe-stack-resources` returned
100 (the secret absent), `list-stack-resources` returned 101 (the secret
present).

### Changes

- `CfnLocalStateProvider` now reads resources via the paginated
  `ListStackResources` (new `fetchAllStackResources` helper walks every page),
  so all resources map regardless of count.
- Scrubbed cdkd-internal wording from the user-facing `state-resolver`
  warnings so cdk-local reads self-contained (`state source` /
  `--from-cfn-stack` instead of `cdkd state` / `--from-state` / `cdkd deploy`).
- Updated `--help` text, docs (cli-reference, local-emulation, troubleshooting),
  and the documented required IAM action to `cloudformation:ListStackResources`.

### Tests

- Unit: pagination walk (multi-page, empty-token terminal, runaway-loop guard,
  >100-resource map completeness) + `load()` coverage (warn-and-fallback,
  DescribeStacks happy/empty/error paths, dispose guard).
- Integ: `local-invoke-from-cfn-stack-large-stack` deploys 105 SSM parameters
  + a Lambda (>100 resources) and asserts all 105 resolve under
  `--from-cfn-stack` — a regression guard the old 100-cap code would fail.

## Test plan

- [x] `vp run check` (typecheck + lint + format)
- [x] `vp run test` (198 unit tests)
- [x] `vp run build`
- [x] integ `local-invoke-from-cfn-stack-large-stack` on real AWS: 107-resource
      stack, `paramCount=0` without the flag and `paramCount=105` with
      `--from-cfn-stack` (all params resolved across the cap), clean
      deploy/destroy, 0 orphan stacks/containers
- [x] verified the root cause against a real 101-resource stack
      (describe=100 / list=101, secret dropped by the cap)

## Retrospective

- Proposal: a commit-time hook grepping `src/**` user-facing runtime strings
  (`reason:` / `logger.warn` / `throw`) for `cdkd` would have caught the
  state-resolver wording leak mechanically (model: `non-english-text-gate`).
  Candidate follow-up alongside the error-handler cleanup.

## Follow-ups (not in this PR)

- https://github.com/go-to-k/cdk-local/issues/53 — harden ECS secret env
  injection (`--env-file` vs `-e KEY=VALUE`); start after this merges.
- https://github.com/go-to-k/cdk-local/issues/54 — scrub cdkd references +
  dead error classes from `src/utils/error-handler.ts`.

## Accepted review nits (shipping as-is)

- `fetchAllStackResources`' inline summary type is repeated 3x; extracting a
  named type would DRY it. Cosmetic; deferred.
- The pagination safety-bound comment is slightly over-documented (500
  resources / 100 per page = 5 pages, bound at 100). Harmless.
