### PR TITLE
docs: clarify start-api covers Function URLs + multi-stack selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cdk-local deliberately does NOT emulate AWS managed services. The bet is: keep d
 It also picks up where `sam local` leaves off:
 
 - **CDK-native** — point it at your CDK app's `cdk.json`. No SAM templates, no extra config files.
-- **Wider coverage** — Lambda (ZIP + container image), API Gateway REST v1 / HTTP v2 / Function URL / WebSocket API, ECS run-task, ECS service with Service Connect + Cloud Map.
+- **Wider coverage** — Lambda (ZIP + container image, plus Function URL), API Gateway REST v1 / HTTP v2 / WebSocket API, ECS run-task, ECS service with Service Connect + Cloud Map.
 - **Real container images** — Lambda code runs in the real `public.ecr.aws/lambda/*` base image via Lambda Runtime Interface Emulator (RIE). ECS tasks run as real Docker containers. The only dependency is Docker.
 
 ## What runs locally, what doesn't
@@ -32,7 +32,7 @@ cdk-local runs your **application compute** locally in Docker, using your CDK ap
 **Runs locally (application compute):**
 
 - **Lambda functions** — your code in a real `public.ecr.aws/lambda/*` container via the Lambda Runtime Interface Emulator
-- **API Gateway** — REST v1 / HTTP v2 / Function URL / WebSocket served by a local HTTP server
+- **HTTP APIs & Function URLs** — API Gateway REST v1 / HTTP v2 / WebSocket and Lambda Function URLs served by a local HTTP server
 - **ECS** — tasks and services as real Docker containers (awsvpc / Service Connect / Cloud Map registry)
 - **Authorizers** — Lambda authorizers, Cognito User Pool JWT verification, IAM SigV4 verification
 
@@ -66,13 +66,25 @@ cdkl invoke MyStack/MyFunction --event ./event.json
 
 ![cdkl invoke against a local sample CDK app — no AWS account, no deploy](assets/cdkl-invoke.gif)
 
-#### API Gateway — `start-api`
+#### HTTP APIs & Function URLs — `start-api`
 
-Serve your API Gateway routes (REST v1 / HTTP v2 / Function URL / WebSocket) on a local HTTP server.
+Serve your app's HTTP surface locally — API Gateway routes (REST v1 / HTTP v2 / WebSocket) and Lambda Function URLs — on a local HTTP server.
 
 ```bash
+# Single-stack app: serve every API in the stack (each on its own port)
+cdkl start-api
+
+# Or target one API
 cdkl start-api MyStack/MyApi
 ```
+
+In a multi-stack app, a bare `cdkl start-api` errors out rather than serving every stack's API at once (so a side-stack's API is never booted by accident). Pick the synth stack with the first of these you supply:
+
+- `--stack <name>` — the synth stack name, matched against your CDK app.
+- `--from-cfn-stack <name>` — the deployed CloudFormation stack name; doubles as the stack selector (see [section 2](#2-bound-to-a-deployed-stack)).
+- a stack-qualified target like `MyStack/MyApi` — the `MyStack` prefix selects the stack.
+
+See [docs/cli-reference.md](docs/cli-reference.md) for the full precedence rules.
 
 #### ECS — `run-task` / `start-service`
 
@@ -91,7 +103,7 @@ Use this for fast iteration on Lambda code, API routing checks, and container ta
 
 Once your stack is deployed to AWS (via the AWS CDK CLI or any other tool), pass `--from-cfn-stack <StackName>` and cdk-local reads the deployed CloudFormation stack to inject real ARNs, Secrets values, and IAM credentials (resolved from your current AWS profile) into the local execution.
 
-#### API Gateway — `start-api` (the headline use case)
+#### HTTP APIs & Function URLs — `start-api` (the headline use case)
 
 A local API talking to real AWS — point a frontend at it for end-to-end debugging, including real Cognito JWT verification.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -12,7 +12,7 @@ cdk-local has four subcommands, all under the `cdkl` binary:
 | Subcommand | Emulates | Backed by |
 | --- | --- | --- |
 | `cdkl invoke <target>` | One-shot Lambda invoke | AWS Lambda Runtime Interface Emulator (RIE) container |
-| `cdkl start-api` | Long-running API Gateway (REST v1 / HTTP API / Function URL) | RIE container pool + `node:http` listener (one server per discovered API) |
+| `cdkl start-api` | Long-running HTTP server — API Gateway (REST v1 / HTTP API / WebSocket) + Lambda Function URL | RIE container pool + `node:http` listener (one server per discovered API) |
 | `cdkl run-task <target>` | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
 | `cdkl start-service <targets...>` | Long-running ECS `Service` emulator | `run-task` machinery per replica + per-replica docker subnet allocator + restart-on-exit watcher |
 
@@ -289,10 +289,11 @@ same sized `/tmp`.
 ## `cdkl start-api` (long-running local API server)
 
 `cdkl start-api` stands up a long-running HTTP server that maps
-synthesized API Gateway routes (REST v1, HTTP API, Function URL) to
-local Lambda invocations against the AWS Lambda Runtime Interface
-Emulator. Modeled on `sam local start-api` but reusing cdk-local's
-synthesis, asset, and route-discovery plumbing.
+synthesized API Gateway routes (REST v1, HTTP API, WebSocket) and
+Lambda Function URLs to local Lambda invocations against the AWS
+Lambda Runtime Interface Emulator. Modeled on `sam local start-api`
+but reusing cdk-local's synthesis, asset, and route-discovery
+plumbing.
 
 ```bash
 cdkl start-api                              # auto-allocate one port PER discovered API

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,7 +90,7 @@ The event payload lands in `event` inside your handler.
 
 ## Next steps
 
-- **Serve API Gateway routes locally**: `cdkl start-api HelloCdklStack/HelloApi` — REST v1 / HTTP v2 / Function URL / WebSocket all served by a local HTTP server. See [docs/local-emulation.md](./local-emulation.md) when it ships.
+- **Serve your HTTP surface locally**: `cdkl start-api HelloCdklStack/HelloApi` — API Gateway REST v1 / HTTP v2 / WebSocket and Lambda Function URLs all served by a local HTTP server. See [docs/local-emulation.md](./local-emulation.md) when it ships.
 - **Run an ECS task or service**: `cdkl run-task <Stack>/<Task>` or `cdkl start-service <Stack>/<Service>`.
 - **Bind to a deployed CloudFormation stack**: `--from-cfn-stack <StackName>` injects real ARNs, Secret values, and IAM credentials from the live stack into the local container. This is the "iterate against your real deployed stack, including its data" flow described in the [README](../README.md).
 - **Override env vars without redeploying**: `--env-vars <file>` — supports per-function overrides keyed by CDK logical ID (display-path keys [tracked in #27](https://github.com/go-to-k/cdk-local/issues/27)).

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -20,7 +20,7 @@ cdk-local with a service emulator like LocalStack.
 | Subcommand | Emulates | Backed by |
 | --- | --- | --- |
 | `cdkl invoke <target>` | One-shot Lambda invoke | AWS Lambda Runtime Interface Emulator (RIE) container |
-| `cdkl start-api` | Long-running API Gateway (REST v1 / HTTP API / Function URL) | RIE container pool + `node:http` listener (one server per discovered API) |
+| `cdkl start-api` | Long-running HTTP server — API Gateway (REST v1 / HTTP API / WebSocket) + Lambda Function URL | RIE container pool + `node:http` listener (one server per discovered API) |
 | `cdkl run-task <target>` | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
 | `cdkl start-service <target>` | Long-running ECS `Service` emulator | `run-task` machinery per replica + per-replica docker subnet allocator + restart-on-exit watcher |
 
@@ -399,11 +399,11 @@ same sized `/tmp`.
 ## `start-api` (long-running local API server)
 
 `cdkl start-api` stands up a long-running HTTP server that maps
-synthesized API Gateway routes (REST v1, HTTP API, Function URL) to
-local Lambda invocations against the AWS Lambda Runtime Interface
-Emulator. Modeled on `sam local start-api` but reusing cdk-local's
-synthesis, asset, and route-discovery plumbing — no `template.yaml`
-round-trip.
+synthesized API Gateway routes (REST v1, HTTP API, WebSocket) and
+Lambda Function URLs to local Lambda invocations against the AWS
+Lambda Runtime Interface Emulator. Modeled on `sam local start-api`
+but reusing cdk-local's synthesis, asset, and route-discovery
+plumbing — no `template.yaml` round-trip.
 
 **Requires Docker.** As with `cdkl invoke`, the first run pulls the
 Lambda base image (~600MB once per machine). Pass `--no-pull` on


### PR DESCRIPTION
## Summary

- `cdkl start-api` serves Lambda **Function URLs** (`AWS::Lambda::Url`) in addition to API Gateway, but the docs filed Function URL under "API Gateway" in 8 places. Relabel the `start-api` sections to "HTTP APIs & Function URLs" across README + docs, and separate API Gateway (REST v1 / HTTP v2 / WebSocket) from Lambda Function URLs in the prose and the subcommand tables.
- Document the no-target behavior: a bare `cdkl start-api` serves every API in a single-stack app, but errors out in a multi-stack app (so a side-stack's API is never booted by accident). Add bare-command examples + the stack-selection precedence (`--stack` / `--from-cfn-stack` / stack-qualified target) to the README.

## Why

The README headed the `start-api` section "API Gateway — start-api" and described Function URL as an "API Gateway route" — but Function URL is a Lambda feature, and `start-api` is no longer API-Gateway-only. Separately, the multi-stack selection error points users at three selectors the README never explained (`--stack` did not appear in the README at all).

## Changes

- `README.md` — relabel both `start-api` headings + the coverage / "what runs locally" bullets; add bare-command examples and the stack-selection precedence with a pointer to `docs/cli-reference.md`.
- `docs/getting-started.md`, `docs/cli-reference.md`, `docs/local-emulation.md` — same API-Gateway / Function-URL separation in prose and the subcommand tables.

## Verification

- `vp run check` + `vp run build` + `vp run test` (14 files, 184 tests) all pass.
- Behavior claims verified against `pickTargetStacks` (`src/cli/commands/local-start-api.ts`) and the 26-test `local-start-api-pick-target-stacks` unit suite.
- Docs-only change; no runtime delta.

## Related

- Opt-in multi-stack union serving via an `--all-stacks` flag is parked as a follow-up (#55).

## Test plan

- [ ] Render README + docs and confirm the `start-api` sections read correctly.
- [ ] Confirm no remaining API-Gateway / Function-URL miscategorization.
