### PR TITLE
fix(docker): keep secret/credential env out of docker run argv

### DIFF
--- a/src/local/docker-runner.ts
+++ b/src/local/docker-runner.ts
@@ -240,9 +240,11 @@ export async function runDetached(opts: DockerRunOptions): Promise<string> {
     }
   }
 
-  for (const [k, v] of Object.entries(opts.env)) {
-    args.push('-e', `${k}=${v}`);
-  }
+  // AWS credentials route through docker's value-from-process-env form
+  // (`-e KEY`, value supplied via the spawned process's env below) so they
+  // never appear in `docker run`'s argv. Non-credential env keeps the
+  // inline `-e KEY=VALUE` form.
+  const passthroughEnv = appendEnvFlags(args, opts.env, SENSITIVE_ENV_KEYS);
 
   // Issue #440 — Lambda EphemeralStorage.Size: emit `--tmpfs
   // <target>:rw,size=<N>m` so the container's `/tmp` is capped at the
@@ -277,6 +279,7 @@ export async function runDetached(opts: DockerRunOptions): Promise<string> {
   try {
     const { stdout } = await execFileAsync(getDockerCmd(), args, {
       maxBuffer: 10 * 1024 * 1024,
+      ...execEnvForSecrets(passthroughEnv),
     });
     return stdout.trim();
   } catch (error) {
@@ -377,24 +380,76 @@ export function pickFreePort(): Promise<number> {
 }
 
 /**
- * AWS credential keys whose values must NOT be written to the debug log.
- * `forwardAwsEnv` / `assumeLambdaExecutionRole` (in `local-invoke.ts`)
- * push these via `-e <KEY>=<value>` flags into `runDetached`'s args
- * array, and `cdkl invoke --verbose` would otherwise leak them
- * into stdout / log files. Only the matching `-e <KEY>=<value>` pair is
- * redacted; non-credential `-e KEY=val` entries pass through unchanged.
+ * Env keys whose VALUES are sensitive (AWS credentials). These are
+ * routed through docker's value-from-process-env form by
+ * {@link appendEnvFlags} so the value never appears in `docker run`'s
+ * argv (`ps` / `/proc/<pid>/cmdline`), and they are also redacted by
+ * {@link redactAwsCredentialsInArgs} as a defense for any path that
+ * still emits the inline `-e <KEY>=<value>` form into the debug log.
  */
-const REDACTED_ENV_KEYS = new Set([
+export const SENSITIVE_ENV_KEYS: ReadonlySet<string> = new Set([
   'AWS_ACCESS_KEY_ID',
   'AWS_SECRET_ACCESS_KEY',
   'AWS_SESSION_TOKEN',
 ]);
 
 /**
+ * Append `-e` flags for `env` to `args`, routing keys in `sensitiveKeys`
+ * through docker's value-from-process-env form (`-e KEY`, with NO
+ * `=value`). Docker reads the value from its OWN environment at run time,
+ * so the secret never lands in `docker run`'s argv — invisible to
+ * `ps aux` / `/proc/<pid>/cmdline` (other users on a shared host) and to
+ * shell history. Non-sensitive keys keep the inline `-e KEY=VALUE` form
+ * (fine for non-secret config, and keeps `--debug` output readable).
+ *
+ * Returns the `{ KEY: value }` map of routed-through keys; the caller MUST
+ * merge it into the spawned docker process's `env` (see
+ * {@link execEnvForSecrets}) so docker can resolve each passed-through
+ * key. Values still appear in `docker inspect` Config.Env — that is
+ * inherent to container env and matches production behavior.
+ *
+ * Unlike `--env-file`, this handles multi-line values (e.g. PEM secrets)
+ * and needs no temp file on disk.
+ */
+export function appendEnvFlags(
+  args: string[],
+  env: Record<string, string>,
+  sensitiveKeys: ReadonlySet<string>
+): Record<string, string> {
+  const passthrough: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (sensitiveKeys.has(k)) {
+      args.push('-e', k);
+      passthrough[k] = v;
+    } else {
+      args.push('-e', `${k}=${v}`);
+    }
+  }
+  return passthrough;
+}
+
+/**
+ * Build the `env` option for an `execFile` / `spawn` call that runs a
+ * `docker run` whose args include passed-through sensitive keys (from
+ * {@link appendEnvFlags}). Returns `{ env: {...process.env, ...passthrough} }`
+ * so docker inherits the normal environment PLUS the sensitive values it
+ * must resolve, or `{}` when there is nothing to pass through (preserving
+ * the default inherited-environment behavior).
+ */
+export function execEnvForSecrets(passthrough: Record<string, string>): {
+  env?: NodeJS.ProcessEnv;
+} {
+  if (Object.keys(passthrough).length === 0) return {};
+  return { env: { ...process.env, ...passthrough } };
+}
+
+/**
  * Returns a copy of `args` with any `-e <KEY>=<value>` pair whose KEY is
- * in {@link REDACTED_ENV_KEYS} replaced with `-e <KEY>=***`. The actual
+ * in {@link SENSITIVE_ENV_KEYS} replaced with `-e <KEY>=***`. The actual
  * `args` passed to `spawn` are never mutated — this is for log output
- * only.
+ * only. With {@link appendEnvFlags} routing credentials through the
+ * value-less `-e KEY` form this rarely fires, but it stays as defense for
+ * any inline-form credential that slips into a logged command.
  */
 export function redactAwsCredentialsInArgs(args: readonly string[]): string[] {
   const out: string[] = [];
@@ -405,7 +460,7 @@ export function redactAwsCredentialsInArgs(args: readonly string[]): string[] {
       const eqIdx = next.indexOf('=');
       if (eqIdx > 0) {
         const key = next.substring(0, eqIdx);
-        if (REDACTED_ENV_KEYS.has(key)) {
+        if (SENSITIVE_ENV_KEYS.has(key)) {
           out.push('-e', `${key}=***`);
           i++;
           continue;

--- a/src/local/ecs-network.ts
+++ b/src/local/ecs-network.ts
@@ -3,7 +3,14 @@ import { randomBytes } from 'node:crypto';
 import { promisify } from 'node:util';
 import { getDockerCmd } from '../utils/docker-cmd.js';
 import { getLogger } from '../utils/logger.js';
-import { DockerRunnerError, pullImage, removeContainer } from './docker-runner.js';
+import {
+  DockerRunnerError,
+  pullImage,
+  removeContainer,
+  appendEnvFlags,
+  execEnvForSecrets,
+  SENSITIVE_ENV_KEYS,
+} from './docker-runner.js';
 import { getEmbedConfig } from './embed-config.js';
 
 const execFileAsync = promisify(execFile);
@@ -229,15 +236,17 @@ async function createNetworkAndSidecar(args: {
     }
   }
   if (cluster) sidecarEnv['CLUSTER'] = cluster;
-  for (const [k, v] of Object.entries(sidecarEnv)) {
-    sidecarArgs.push('-e', `${k}=${v}`);
-  }
+  // AWS credentials served by the metadata sidecar route through docker's
+  // value-from-process-env form (`-e KEY`) so they never appear in argv;
+  // CLUSTER (non-secret) keeps the inline `-e KEY=VALUE` form.
+  const sidecarPassthroughEnv = appendEnvFlags(sidecarArgs, sidecarEnv, SENSITIVE_ENV_KEYS);
   sidecarArgs.push(METADATA_ENDPOINT_IMAGE);
 
   logger.info(`Starting ECS local-container-endpoints sidecar at ${sidecarIp}...`);
   try {
     const { stdout } = await execFileAsync(getDockerCmd(), sidecarArgs, {
       maxBuffer: 10 * 1024 * 1024,
+      ...execEnvForSecrets(sidecarPassthroughEnv),
     });
     return stdout.trim();
   } catch (err) {

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -5,7 +5,14 @@ import { promisify } from 'node:util';
 import graphlib from 'graphlib';
 import { getDockerCmd, runDockerStreaming } from '../utils/docker-cmd.js';
 import { getLogger } from '../utils/logger.js';
-import { DockerRunnerError, pullImage, removeContainer } from './docker-runner.js';
+import {
+  DockerRunnerError,
+  pullImage,
+  removeContainer,
+  appendEnvFlags,
+  execEnvForSecrets,
+  SENSITIVE_ENV_KEYS,
+} from './docker-runner.js';
 import { buildDockerImage } from '../assets/docker-build.js';
 import { pullEcrImage } from './ecr-puller.js';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
@@ -351,7 +358,7 @@ export async function runEcsTask(
 
   // Pre-compute every container's CMD args so the start loop only does
   // docker calls.
-  const dockerCmds = new Map<string, string[]>();
+  const dockerCmds = new Map<string, { args: string[]; sensitiveEnv: Record<string, string> }>();
   for (const container of task.containers) {
     const image = imagePlan.get(container.name);
     if (!image) {
@@ -400,11 +407,14 @@ export async function runEcsTask(
     const container = task.containers.find((c) => c.name === containerName)!;
     await awaitDependencies(container, startedByName);
 
-    const args = dockerCmds.get(container.name)!;
+    const { args, sensitiveEnv } = dockerCmds.get(container.name)!;
     logger.info(`Starting container '${container.name}' (image=${imagePlan.get(container.name)})`);
     let id: string;
     try {
-      const { stdout } = await execFileAsync(getDockerCmd(), args, { maxBuffer: 10 * 1024 * 1024 });
+      const { stdout } = await execFileAsync(getDockerCmd(), args, {
+        maxBuffer: 10 * 1024 * 1024,
+        ...execEnvForSecrets(sensitiveEnv),
+      });
       id = stdout.trim();
     } catch (err) {
       const e = err as { stderr?: string; message?: string };
@@ -879,7 +889,10 @@ interface BuildDockerRunArgs {
  * Exported (no-leading-underscore) so the unit tests can assert against
  * the shape directly without spawning a process.
  */
-export function buildDockerRunArgs(opts: BuildDockerRunArgs): string[] {
+export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
+  args: string[];
+  sensitiveEnv: Record<string, string>;
+} {
   const { task, container, image, network, volumeByName, secrets, containerHost, roleArn } = opts;
   const args: string[] = ['run', '-d'];
 
@@ -1010,9 +1023,13 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): string[] {
     applyOverrideMap(finalEnv, overrides[container.name]);
   }
 
-  for (const [k, v] of Object.entries(finalEnv)) {
-    args.push('-e', `${k}=${v}`);
-  }
+  // Resolved secret values (and any AWS credentials that landed in the
+  // env) route through docker's value-from-process-env form (`-e KEY`,
+  // value supplied via the spawned docker process's env) so they never
+  // appear in `docker run`'s argv. Non-secret config keeps `-e KEY=VALUE`.
+  const sensitiveEnvKeys = new Set<string>(SENSITIVE_ENV_KEYS);
+  for (const s of secrets) sensitiveEnvKeys.add(s.name);
+  const sensitiveEnv = appendEnvFlags(args, finalEnv, sensitiveEnvKeys);
 
   if (container.user) args.push('--user', container.user);
   if (container.privileged) args.push('--privileged');
@@ -1048,7 +1065,7 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): string[] {
   }
 
   args.push(image, ...entryPointTail, ...(container.command ?? []));
-  return args;
+  return { args, sensitiveEnv };
 }
 
 function applyOverrideMap(

--- a/tests/unit/local/docker-env-passthrough.test.ts
+++ b/tests/unit/local/docker-env-passthrough.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  appendEnvFlags,
+  execEnvForSecrets,
+  redactAwsCredentialsInArgs,
+  SENSITIVE_ENV_KEYS,
+} from '../../../src/local/docker-runner.js';
+
+describe('appendEnvFlags', () => {
+  it('routes sensitive keys through the value-less `-e KEY` form, others inline', () => {
+    const args: string[] = [];
+    const passthrough = appendEnvFlags(
+      args,
+      { AWS_SECRET_ACCESS_KEY: 'shh', TABLE_NAME: 'tbl', AWS_SESSION_TOKEN: 'tok' },
+      SENSITIVE_ENV_KEYS
+    );
+
+    // Sensitive keys appear as `-e KEY` with NO value in argv.
+    expect(args).toContain('-e');
+    expect(args).toContain('AWS_SECRET_ACCESS_KEY');
+    expect(args).toContain('AWS_SESSION_TOKEN');
+    // No sensitive VALUE leaked into argv.
+    expect(args.join(' ')).not.toContain('shh');
+    expect(args.join(' ')).not.toContain('tok');
+    // Non-sensitive keeps the inline form.
+    expect(args).toContain('TABLE_NAME=tbl');
+    // The passthrough map carries the sensitive values for the process env.
+    expect(passthrough).toEqual({ AWS_SECRET_ACCESS_KEY: 'shh', AWS_SESSION_TOKEN: 'tok' });
+  });
+
+  it('supports an arbitrary sensitive-key set (e.g. ECS secret names)', () => {
+    const args: string[] = [];
+    const passthrough = appendEnvFlags(
+      args,
+      { DB_PASSWORD: 'p@ss', LOG_LEVEL: 'debug' },
+      new Set(['DB_PASSWORD'])
+    );
+    expect(args).toEqual(['-e', 'DB_PASSWORD', '-e', 'LOG_LEVEL=debug']);
+    expect(passthrough).toEqual({ DB_PASSWORD: 'p@ss' });
+  });
+
+  it('preserves multi-line values (e.g. PEM) — they never enter argv', () => {
+    const pem = '-----BEGIN KEY-----\nABC\nDEF\n-----END KEY-----';
+    const args: string[] = [];
+    const passthrough = appendEnvFlags(args, { PRIVATE_KEY: pem }, new Set(['PRIVATE_KEY']));
+    expect(args).toEqual(['-e', 'PRIVATE_KEY']);
+    expect(passthrough['PRIVATE_KEY']).toBe(pem);
+    expect(args.join(' ')).not.toContain('BEGIN KEY');
+  });
+
+  it('returns an empty map when no keys are sensitive', () => {
+    const args: string[] = [];
+    const passthrough = appendEnvFlags(args, { A: '1', B: '2' }, new Set());
+    expect(args).toEqual(['-e', 'A=1', '-e', 'B=2']);
+    expect(passthrough).toEqual({});
+  });
+});
+
+describe('execEnvForSecrets', () => {
+  it('returns no env option when there is nothing to pass through', () => {
+    expect(execEnvForSecrets({})).toEqual({});
+  });
+
+  it('merges passthrough values onto the inherited process env', () => {
+    const result = execEnvForSecrets({ AWS_SECRET_ACCESS_KEY: 'shh' });
+    expect(result.env).toBeDefined();
+    expect(result.env!['AWS_SECRET_ACCESS_KEY']).toBe('shh');
+    // Inherits the parent environment so docker keeps PATH/HOME/etc.
+    expect(result.env!['PATH']).toBe(process.env['PATH']);
+  });
+});
+
+describe('redactAwsCredentialsInArgs', () => {
+  it('redacts the inline `-e KEY=value` credential form (log defense)', () => {
+    expect(
+      redactAwsCredentialsInArgs(['-e', 'AWS_SECRET_ACCESS_KEY=xyz', '-e', 'FOO=bar'])
+    ).toEqual(['-e', 'AWS_SECRET_ACCESS_KEY=***', '-e', 'FOO=bar']);
+  });
+
+  it('leaves the value-less `-e KEY` pass-through form untouched (already safe)', () => {
+    expect(redactAwsCredentialsInArgs(['-e', 'AWS_SECRET_ACCESS_KEY', '-e', 'FOO=bar'])).toEqual([
+      '-e',
+      'AWS_SECRET_ACCESS_KEY',
+      '-e',
+      'FOO=bar',
+    ]);
+  });
+});

--- a/tests/unit/local/docker-runner-rundetached-env.test.ts
+++ b/tests/unit/local/docker-runner-rundetached-env.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Capture the execFile invocation so we can assert how runDetached wires
+// sensitive env: the credential VALUE must reach docker via the spawned
+// process's `options.env` (value-less `-e KEY` in argv), never argv itself.
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+
+vi.mock('node:child_process', () => ({
+  // promisify(execFile) calls execFile(cmd, args, options, callback).
+  execFile: (
+    cmd: string,
+    args: string[],
+    options: { env?: NodeJS.ProcessEnv },
+    cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
+  ) => {
+    execFileMock(cmd, args, options);
+    cb(null, { stdout: 'container-id-abc\n', stderr: '' });
+  },
+  spawn: vi.fn(),
+}));
+
+const { runDetached } = await import('../../../src/local/docker-runner.js');
+
+describe('runDetached sensitive-env wiring', () => {
+  beforeEach(() => execFileMock.mockReset());
+
+  it('passes AWS credentials via process env, not argv', async () => {
+    const id = await runDetached({
+      image: 'public.ecr.aws/lambda/nodejs:20',
+      mounts: [],
+      env: {
+        AWS_ACCESS_KEY_ID: 'AKIA-xxx',
+        AWS_SECRET_ACCESS_KEY: 'super-secret-value',
+        AWS_SESSION_TOKEN: 'sess-tok',
+        TABLE_NAME: 'my-table',
+      },
+      cmd: ['index.handler'],
+      hostPort: 9001,
+    });
+
+    expect(id).toBe('container-id-abc');
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [, args, options] = execFileMock.mock.calls[0] as [
+      string,
+      string[],
+      { env?: NodeJS.ProcessEnv },
+    ];
+
+    // Credentials appear as value-less `-e KEY`; their VALUES never in argv.
+    const joined = args.join(' ');
+    expect(joined).not.toContain('super-secret-value');
+    expect(joined).not.toContain('sess-tok');
+    expect(joined).not.toContain('AKIA-xxx');
+    expect(args).toContain('AWS_SECRET_ACCESS_KEY');
+    // Non-sensitive config keeps the inline form.
+    expect(args).toContain('TABLE_NAME=my-table');
+
+    // The values are supplied to docker through the spawned process env so
+    // docker resolves the value-less `-e KEY` flags.
+    expect(options.env).toBeDefined();
+    expect(options.env!['AWS_SECRET_ACCESS_KEY']).toBe('super-secret-value');
+    expect(options.env!['AWS_SESSION_TOKEN']).toBe('sess-tok');
+    // Inherits the parent environment (docker keeps PATH/etc.).
+    expect(options.env!['PATH']).toBe(process.env['PATH']);
+  });
+
+  it('uses no env option when the container has no sensitive env', async () => {
+    await runDetached({
+      image: 'public.ecr.aws/lambda/nodejs:20',
+      mounts: [],
+      env: { TABLE_NAME: 'my-table' },
+      cmd: ['index.handler'],
+      hostPort: 9002,
+    });
+    const [, args, options] = execFileMock.mock.calls[0] as [
+      string,
+      string[],
+      { env?: NodeJS.ProcessEnv },
+    ];
+    expect(args).toContain('TABLE_NAME=my-table');
+    // No sensitive keys → default inherited-environment behavior (no env opt).
+    expect(options.env).toBeUndefined();
+  });
+});

--- a/tests/unit/local/ecs-task-runner-secret-env.test.ts
+++ b/tests/unit/local/ecs-task-runner-secret-env.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { buildDockerRunArgs } from '../../../src/local/ecs-task-runner.js';
+import type { ResolvedEcsContainer, ResolvedEcsTask } from '../../../src/local/ecs-task-resolver.js';
+
+// buildDockerRunArgs reads only a bounded subset of the container/task
+// shapes (name/environment/image + the iterated collections), so a cast
+// partial keeps the fixture small.
+function minimalContainer(environment: Record<string, string>): ResolvedEcsContainer {
+  return {
+    name: 'app',
+    image: { kind: 'public', uri: 'public.ecr.aws/docker/library/busybox:latest' },
+    environment,
+    secrets: [],
+    portMappings: [],
+    mountPoints: [],
+    dependsOn: [],
+    links: [],
+    essential: true,
+    ulimits: [],
+    warnings: [],
+  } as unknown as ResolvedEcsContainer;
+}
+
+const task = { family: 'fam' } as unknown as ResolvedEcsTask;
+
+describe('buildDockerRunArgs secret env routing', () => {
+  it('routes resolved secret values through `-e KEY` pass-through, never argv', () => {
+    const { args, sensitiveEnv } = buildDockerRunArgs({
+      task,
+      container: minimalContainer({ LOG_LEVEL: 'info' }),
+      image: 'public.ecr.aws/docker/library/busybox:latest',
+      network: 'net',
+      volumeByName: new Map(),
+      secrets: [{ name: 'DB_PASSWORD', value: 'p@ss-w0rd' }],
+      envOverrides: undefined,
+      containerHost: '127.0.0.1',
+      roleArn: undefined,
+      platformOverride: undefined,
+      region: undefined,
+    });
+
+    // The secret is emitted as a value-less `-e DB_PASSWORD` pair...
+    const i = args.indexOf('DB_PASSWORD');
+    expect(i).toBeGreaterThan(0);
+    expect(args[i - 1]).toBe('-e');
+    // ...with NO inline `DB_PASSWORD=...` form, and the value never in argv.
+    expect(args.some((a) => a.startsWith('DB_PASSWORD='))).toBe(false);
+    expect(args.join(' ')).not.toContain('p@ss-w0rd');
+
+    // Non-secret config keeps the inline form.
+    expect(args).toContain('LOG_LEVEL=info');
+
+    // The value is carried in the passthrough map (merged into the docker
+    // process env at the run site), not in argv.
+    expect(sensitiveEnv['DB_PASSWORD']).toBe('p@ss-w0rd');
+    expect(sensitiveEnv['LOG_LEVEL']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

cdk-local passed every container env var via `docker run -e KEY=VALUE`,
putting secret/credential VALUES in the docker process's argv — readable via
`ps aux` / `/proc/<pid>/cmdline` by other users on a shared host. Exposed:

- ECS task secrets (Secrets Manager / SSM values resolved by
  `ecs-secrets-resolver` and injected as plain env)
- AWS credentials forwarded to Lambda containers and served by the ECS
  metadata sidecar

This routes SENSITIVE keys through docker's value-from-process-env form
(`-e KEY`, no `=value`): the value is supplied via the spawned docker
process's `env` (the `execFile` / `spawn` `env` option), so docker reads it
from its own environment and it never enters argv.

Shared helpers in `docker-runner.ts` — `appendEnvFlags` (routes + returns the
passthrough map) and `execEnvForSecrets` (spreads `process.env` + the
passthrough, or `{}` when empty) — wired at all three sites:

- Lambda `runDetached` (AWS credentials)
- ECS `buildDockerRunArgs` (resolved secret values; the ECS service runner
  reuses this via `runEcsTask`)
- ECS metadata sidecar `ecs-network.ts` (AWS credentials it serves)

Unlike `--env-file` this preserves multi-line values (e.g. PEM) and needs no
temp file. Values still appear in `docker inspect` Config.Env — inherent to
container env and unchanged from production behavior.

**No user-facing change**: CLI flags and the env the container receives are
identical; only the docker-process plumbing changes.

Closes #53

## Test plan

- [x] `vp run check` (typecheck + lint + format)
- [x] `vp run test` (209 unit tests, incl. new pass-through coverage)
- [x] `vp run build`
- [x] integ `local-run-task` (Docker-only): ECS task + metadata sidecar boot
      cleanly with the credential pass-through, 0 orphan containers/networks

### New tests

- `docker-env-passthrough.test.ts` — `appendEnvFlags` (sensitive→`-e KEY`,
  non-sensitive→inline, multi-line PEM preserved), `execEnvForSecrets`
  (empty→{}, non-empty merges onto `process.env`), `redactAwsCredentialsInArgs`.
- `ecs-task-runner-secret-env.test.ts` — `buildDockerRunArgs` routes a
  resolved secret value through `-e KEY`; value only in `sensitiveEnv`, not argv.
- `docker-runner-rundetached-env.test.ts` — `runDetached` binds AWS creds via
  `execFile`'s `options.env`, never argv (locks the primary Lambda leak vector).

## Reviews

Code review: clean. Test review: pass with one accepted minor below.

## Accepted review nits (shipping as-is)

- A site-level `execFile`-mock test for the ECS metadata **sidecar**
  (`ecs-network.ts`) binding was not added — it uses the identical
  `appendEnvFlags` + `execEnvForSecrets` pattern as `runDetached` (which IS
  site-tested) and was code-review-verified. Minor.
- `execEnvForSecrets` JSDoc could note that passthrough values take precedence
  over a same-named parent-env var (the intended behavior). Cosmetic.

## Retrospective

When extracting a shared helper used at multiple call sites, unit-testing the
helper alone leaves the per-site BINDING (helper output threaded into the right
call) unverified — a copy-paste/spread bug would pass. Worth a habit: add at
least one site-level test that locks the binding for the highest-risk caller.
