### PR TITLE
feat(start-api): add --all-stacks for multi-stack union serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,18 @@ cdkl start-api
 cdkl start-api MyStack/MyApi
 ```
 
-In a multi-stack app, a bare `cdkl start-api` errors out rather than serving every stack's API at once (so a side-stack's API is never booted by accident). Pick the synth stack with the first of these you supply:
+In a multi-stack app, a bare `cdkl start-api` errors out rather than serving every stack's API at once (so a side-stack's API is never booted by accident). Either serve them all explicitly, or pick one stack with the first selector you supply:
+
+```bash
+# Serve every stack's API (each on its own port)
+cdkl start-api --all-stacks
+```
 
 - `--stack <name>` — the synth stack name, matched against your CDK app.
 - `--from-cfn-stack <name>` — the deployed CloudFormation stack name; doubles as the stack selector (see [section 2](#2-bound-to-a-deployed-stack)).
 - a stack-qualified target like `MyStack/MyApi` — the `MyStack` prefix selects the stack.
 
-See [docs/cli-reference.md](docs/cli-reference.md) for the full precedence rules.
+`--all-stacks` is mutually exclusive with those single-target selectors (the bare `--from-cfn-stack` flag stays compatible). See [docs/cli-reference.md](docs/cli-reference.md) for the full precedence rules.
 
 #### ECS — `run-task` / `start-service`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -301,6 +301,7 @@ cdkl start-api                              # auto-allocate one port PER discove
 cdkl start-api --port 3000                  # first API → 3000, second API → 3001, ...
 cdkl start-api MyAdminApi                   # logical id (single-stack apps)
 cdkl start-api MyStack/MyAdminApi           # OR: CDK Construct path (prefix-matched)
+cdkl start-api --all-stacks                 # multi-stack: serve EVERY stack's API
 cdkl start-api --warm                       # pre-start one container per Lambda
 ```
 
@@ -351,7 +352,8 @@ an error — they're mutually exclusive.
 | --- | --- | --- |
 | `--port <port>` | `0` (auto-allocate) | First API server's port (subsequent APIs get `port+1`, `port+2`, ...). Pass `0` (default) to auto-allocate each. The actual port assignment is printed at startup. |
 | `--host <host>` | `127.0.0.1` | Bind address. |
-| `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks AND no other selector identifies the target. In multi-stack apps the synth stack is picked from the first match of: (1) `--stack <name>`, (2) `--from-cfn-stack <explicit-name>`, (3) the positional target's stack-name prefix (e.g. `MyStack/MyApi` → `MyStack`). |
+| `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks AND no other selector identifies the target. In multi-stack apps the synth stack is picked from the first match of: (1) `--stack <name>`, (2) `--from-cfn-stack <explicit-name>`, (3) the positional target's stack-name prefix (e.g. `MyStack/MyApi` → `MyStack`), (4) `--all-stacks` (serve every stack). |
+| `--all-stacks` | off | Serve every stack's API in a multi-stack app (each API on its own port) instead of erroring out for an ambiguous selection. Mutually exclusive with a positional target, `--stack`, and an explicit `--from-cfn-stack <name>` (those name a single stack); the bare `--from-cfn-stack` flag stays compatible — it binds each routed stack to its own CFn stack. No-op in a single-stack app (that one stack is already served). |
 | `--warm` | off | Pre-start one container per discovered Lambda at server boot. Trades RAM for first-request latency. |
 | `--per-lambda-concurrency <n>` | `2` | Pool size cap per Lambda. Max 4 in v1; above-cap values are clamped with a warn. |
 | `--no-pull` | off | Skip `docker pull` (use cached image). |

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -242,13 +242,16 @@ region and silently picking `us-east-1` would query the wrong stack
 environment.
 
 **Multi-stack guard**: `start-api` / `start-service` route multiple
-stacks in one invocation. Bare `--from-cfn-stack` works there because
-each routed stack uses its own CDK stack name as the CFn stack name.
-**Explicit `--from-cfn-stack <name>` is rejected** when more than one
-stack is routed (the explicit name would apply to every routed stack
-and silently mismap `Ref` lookups whose logical IDs happen to collide
-between siblings). Use bare `--from-cfn-stack` for multi-stack apps, or
-run one cdk-local invocation per stack.
+stacks in one invocation (for `start-api`, multi-stack routing is opt-in
+via `--all-stacks`). Bare `--from-cfn-stack` works there because each
+routed stack uses its own CDK stack name as the CFn stack name — so
+`--all-stacks --from-cfn-stack` (bare) binds every routed stack to its
+own deployed stack. **Explicit `--from-cfn-stack <name>` is rejected**
+when more than one stack is routed (the explicit name would apply to
+every routed stack and silently mismap `Ref` lookups whose logical IDs
+happen to collide between siblings) — and `--all-stacks` rejects it
+upfront for the same reason. Use bare `--from-cfn-stack` for multi-stack
+apps, or run one cdk-local invocation per stack.
 
 **Failure modes**: `ListStackResources` failures (stack not found,
 access denied, throttling) degrade to a per-key warn + drop — the
@@ -550,7 +553,8 @@ the same tier; cdk-local uses literal-segment count as a heuristic).
 | --- | --- | --- |
 | `--port <port>` | auto-allocate | First API server's port (subsequent APIs get `port+1`, `port+2`, ...). Pass `0` (default) to auto-allocate each. The actual port assignment is printed at startup. |
 | `--host <host>` | `127.0.0.1` | Bind address. |
-| `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks AND no other selector identifies the target. In multi-stack apps the synth stack is picked from the first match of: (1) `--stack <name>`, (2) `--from-cfn-stack <explicit-name>`, (3) the positional target's stack-name prefix (e.g. `MyStack/MyApi` → `MyStack`). |
+| `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks AND no other selector identifies the target. In multi-stack apps the synth stack is picked from the first match of: (1) `--stack <name>`, (2) `--from-cfn-stack <explicit-name>`, (3) the positional target's stack-name prefix (e.g. `MyStack/MyApi` → `MyStack`), (4) `--all-stacks` (serve every stack). |
+| `--all-stacks` | off | Serve every stack's API in a multi-stack app (each API on its own port) instead of erroring out for an ambiguous selection. Mutually exclusive with a positional target, `--stack`, and an explicit `--from-cfn-stack <name>`; the bare `--from-cfn-stack` flag stays compatible (binds each routed stack to its own CFn stack). No-op in a single-stack app. |
 | `--warm` | off | Pre-start one container per discovered Lambda at server boot. Trades RAM for first-request latency. |
 | `--per-lambda-concurrency <n>` | `2` | Pool size cap per Lambda. Max 4 in v1; above-cap values are clamped with a warn. |
 | `--no-pull` | off | Skip `docker pull`. |

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -135,6 +135,15 @@ interface LocalStartApiOptions {
   host: string;
   /** Stack pattern (single-stack apps auto-detect). */
   stack?: string;
+  /**
+   * Issue #55: serve the union of every stack's APIs (each on its own
+   * port) instead of erroring out in a multi-stack app. Mutually
+   * exclusive with a single-target selector (positional target /
+   * `--stack` / explicit `--from-cfn-stack <name>`); the bare
+   * `--from-cfn-stack` flag stays compatible (binds each routed stack
+   * to its own CFn stack).
+   */
+  allStacks?: boolean;
   /** Pre-warm one container per Lambda at server boot. */
   warm: boolean;
   /** Pool size cap per Lambda (default 2, max 4). */
@@ -274,6 +283,17 @@ async function localStartApiCommand(
     apiFilter = options.api;
   }
 
+  // Issue #55: `--all-stacks` serves every stack's API as a union, so it
+  // cannot be combined with a selector that names ONE target.
+  const allStacksConflictList = allStacksConflicts(options, target, apiFilter);
+  if (allStacksConflictList.length > 0) {
+    throw new Error(
+      `--all-stacks serves every stack's API and cannot be combined with a single-target selector (${allStacksConflictList.join(', ')}). ` +
+        `Drop --all-stacks to target one stack, or drop the selector to serve them all. ` +
+        `The bare --from-cfn-stack flag (no value) IS compatible with --all-stacks.`
+    );
+  }
+
   warnIfDeprecatedRegion(options);
   await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
 
@@ -394,7 +414,8 @@ async function localStartApiCommand(
       stacks,
       options.stack,
       cfnStackFallback,
-      targetStackPrefix
+      targetStackPrefix,
+      options.allStacks
     );
     if (targetStacks.length === 0) {
       throw new Error(
@@ -1234,8 +1255,16 @@ export function pickTargetStacks(
   stacks: StackInfo[],
   pattern: string | undefined,
   cfnStackFallback?: string,
-  targetFallback?: string
+  targetFallback?: string,
+  allStacks?: boolean
 ): StackInfo[] {
+  // Issue #55: `--all-stacks` serves the union of every stack's APIs.
+  // It is mutually exclusive with the selectors below (validated by the
+  // caller), so when set we skip the resolution chain entirely and
+  // return every stack. The downstream server grouping disambiguates
+  // same-logical-id collisions across stacks, so a union boots fine.
+  if (allStacks) return stacks;
+
   // Resolution chain (first non-empty wins):
   //   1. `--stack <pattern>`                            (explicit)
   //   2. `--from-cfn-stack <explicit-name>`             (PR #44)
@@ -1251,12 +1280,46 @@ export function pickTargetStacks(
   }
   if (stacks.length === 1) return stacks;
   if (stacks.length === 0) return [];
-  // Multi-stack apps can be served as a union — every stack contributes
-  // its routes — but for v1 we require an explicit selection so users
-  // don't accidentally serve a side-stack's API.
+  // Multi-stack apps are served as a union only on explicit opt-in
+  // (`--all-stacks`); otherwise we require an explicit single-target
+  // selection so users don't accidentally serve (and boot Docker
+  // containers for) a side-stack's API.
   throw new Error(
-    `Multi-stack app: pass --stack <name>, --from-cfn-stack <name>, or a stack-qualified target like "<StackName>/<construct>" to pick a target. Available stacks: ${stacks.map((s) => s.stackName).join(', ')}.`
+    `Multi-stack app: pass --stack <name>, --from-cfn-stack <name>, a stack-qualified target like "<StackName>/<construct>", or --all-stacks to serve every stack. Available stacks: ${stacks.map((s) => s.stackName).join(', ')}.`
   );
+}
+
+/**
+ * Issue #55: `--all-stacks` serves every stack's API as a union, so it
+ * cannot be combined with a selector that names exactly ONE target.
+ * Returns the human-readable list of conflicting selectors (empty when
+ * `--all-stacks` is off or there is no conflict).
+ *
+ * The bare `--from-cfn-stack` flag (Commander maps it to boolean `true`)
+ * is NOT a conflict — it binds each routed stack to its own CFn stack,
+ * which is exactly the multi-stack union case. Only an explicit
+ * `--from-cfn-stack <name>` (a string) names a single stack and conflicts.
+ *
+ * Extracted as a pure function so it can be unit-tested without booting
+ * the full server.
+ *
+ * @internal exported for unit tests.
+ */
+export function allStacksConflicts(
+  options: Pick<LocalStartApiOptions, 'allStacks' | 'stack' | 'api' | 'fromCfnStack'>,
+  target: string | undefined,
+  apiFilter: string | undefined
+): string[] {
+  if (!options.allStacks) return [];
+  const conflicts: string[] = [];
+  if (apiFilter !== undefined) {
+    conflicts.push(target !== undefined ? `target '${target}'` : `--api '${options.api}'`);
+  }
+  if (options.stack !== undefined) conflicts.push(`--stack '${options.stack}'`);
+  if (typeof options.fromCfnStack === 'string') {
+    conflicts.push(`--from-cfn-stack '${options.fromCfnStack}'`);
+  }
+  return conflicts;
 }
 
 /**
@@ -3109,6 +3172,12 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
     )
     .addOption(new Option('--host <host>', 'Bind address').default('127.0.0.1'))
     .addOption(new Option('--stack <name>', 'Stack to start (single-stack apps auto-detect)'))
+    .addOption(
+      new Option(
+        '--all-stacks',
+        "Serve every stack's API in a multi-stack app (each API on its own port) instead of erroring out. Mutually exclusive with a positional target, --stack, and an explicit --from-cfn-stack <name>; the bare --from-cfn-stack flag stays compatible (binds each routed stack to its own CFn stack)."
+      ).default(false)
+    )
     .addOption(
       new Option('--warm', 'Pre-start one container per Lambda at server boot').default(false)
     )

--- a/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
+++ b/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vite-plus/test';
 import {
   pickTargetStacks,
+  allStacksConflicts,
   shouldEmitFromCfnRedundancyTip,
   tryEmitFromCfnRedundancyTipOnce,
 } from '../../../src/cli/commands/local-start-api.js';
@@ -75,12 +76,85 @@ describe('pickTargetStacks', () => {
     });
   });
 
+  describe('--all-stacks (issue #55)', () => {
+    it('returns every stack in a multi-stack app (union serve)', () => {
+      expect(pickTargetStacks([A, B], undefined, undefined, undefined, true)).toEqual([A, B]);
+    });
+
+    it('returns the only stack in a single-stack app (no-op)', () => {
+      expect(pickTargetStacks([A], undefined, undefined, undefined, true)).toEqual([A]);
+    });
+
+    it('returns empty for an empty app without throwing', () => {
+      expect(pickTargetStacks([], undefined, undefined, undefined, true)).toEqual([]);
+    });
+
+    it('wins over the selector chain (no throw even though selectors are unset)', () => {
+      // allStacks short-circuits before the multi-stack rejection.
+      expect(() => pickTargetStacks([A, B], undefined, undefined, undefined, true)).not.toThrow();
+    });
+  });
+
   describe('error message', () => {
-    it('lists every available stack name and mentions all three selection routes', () => {
+    it('lists every available stack name and mentions all selection routes incl. --all-stacks', () => {
       expect(() => pickTargetStacks([A, B], undefined)).toThrowError(
-        /Multi-stack app: pass --stack <name>, --from-cfn-stack <name>, or a stack-qualified target like "<StackName>\/<construct>" to pick a target\. Available stacks: A, B\./
+        /Multi-stack app: pass --stack <name>, --from-cfn-stack <name>, a stack-qualified target like "<StackName>\/<construct>", or --all-stacks to serve every stack\. Available stacks: A, B\./
       );
     });
+  });
+});
+
+describe('allStacksConflicts', () => {
+  it('returns no conflicts when --all-stacks is off', () => {
+    expect(allStacksConflicts({ allStacks: false, stack: 'A' }, 'A/Api', 'A/Api')).toEqual([]);
+  });
+
+  it('returns no conflicts when --all-stacks is undefined', () => {
+    expect(allStacksConflicts({}, undefined, undefined)).toEqual([]);
+  });
+
+  it('returns no conflicts when --all-stacks is the only selector', () => {
+    expect(allStacksConflicts({ allStacks: true }, undefined, undefined)).toEqual([]);
+  });
+
+  it('flags a positional target conflict', () => {
+    expect(allStacksConflicts({ allStacks: true }, 'MyStack/MyApi', 'MyStack/MyApi')).toEqual([
+      "target 'MyStack/MyApi'",
+    ]);
+  });
+
+  it('flags the deprecated --api alias conflict (no positional target)', () => {
+    expect(allStacksConflicts({ allStacks: true, api: 'MyApi' }, undefined, 'MyApi')).toEqual([
+      "--api 'MyApi'",
+    ]);
+  });
+
+  it('flags a --stack conflict', () => {
+    expect(allStacksConflicts({ allStacks: true, stack: 'MyStack' }, undefined, undefined)).toEqual(
+      ["--stack 'MyStack'"]
+    );
+  });
+
+  it('flags an explicit --from-cfn-stack <name> conflict', () => {
+    expect(
+      allStacksConflicts({ allStacks: true, fromCfnStack: 'MyStack' }, undefined, undefined)
+    ).toEqual(["--from-cfn-stack 'MyStack'"]);
+  });
+
+  it('does NOT flag the bare --from-cfn-stack flag (boolean true) — it is union-compatible', () => {
+    expect(
+      allStacksConflicts({ allStacks: true, fromCfnStack: true }, undefined, undefined)
+    ).toEqual([]);
+  });
+
+  it('aggregates multiple conflicting selectors in one message', () => {
+    expect(
+      allStacksConflicts(
+        { allStacks: true, stack: 'S', fromCfnStack: 'C' },
+        'S/Api',
+        'S/Api'
+      )
+    ).toEqual(["target 'S/Api'", "--stack 'S'", "--from-cfn-stack 'C'"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `--all-stacks` to `cdkl start-api`: the explicit opt-in to serve the union of every stack's APIs (each on its own port) in a multi-stack app, instead of erroring out for an ambiguous selection. A bare `cdkl start-api` still errors in a multi-stack app so a side-stack's API is never booted by accident.
- The downstream server grouping already disambiguates same-logical-id collisions across stacks, so `pickTargetStacks` was the only gate — `--all-stacks` short-circuits its selector chain and returns every stack.

## Behavior

- `--all-stacks` is mutually exclusive with a single-target selector (positional target / `--stack` / explicit `--from-cfn-stack <name>`); combining them is a fast CLI error (before Docker / synth).
- The bare `--from-cfn-stack` flag (no value) stays compatible — it binds each routed stack to its own CFn stack, which is exactly the union case.
- No-op in a single-stack app (that one stack is already served).
- The multi-stack rejection message now lists `--all-stacks` as a fourth selection route.

## Implementation

- `src/cli/commands/local-start-api.ts` — new `--all-stacks` option + `allStacks?` on the options type; `pickTargetStacks` gains an `allStacks` param (early-returns the union); the conflict check is extracted into the pure, exported `allStacksConflicts` helper.
- Docs: `README.md`, `docs/cli-reference.md`, `docs/local-emulation.md`.

## Verification

- `vp run check` + `vp run build` + `vp run test` (16 files, 211 tests) pass. `pickTargetStacks` gains 13 tests (union / single-stack no-op / empty); `allStacksConflicts` gains 9 (every conflict + the bare-`--from-cfn-stack` non-conflict).
- Integ: `/run-integ local-start-api` passed fully with 0 Docker orphans; additionally booted the fixture with `--all-stacks` (6 servers up, `GET /items` -> HTTP 200).
- Live-tested via the built CLI: all three conflict errors fire, and `--all-stacks --from-cfn-stack` (bare) passes validation.

## Note

The call-site binding for `allStacksConflicts` / `pickTargetStacks(allStacks)` is verified via the live-test rather than a unit test, because `localStartApiCommand` boots a server and is not unit-testable.

Closes #55
