### PR TITLE
feat(start-api): seed container AWS_REGION from profile / synth / --stack-region

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -375,6 +375,21 @@ an error — they're mutually exclusive.
 Plus the [common flags](#common-flags): `-a/--app`, `--output`,
 `-c/--context`, `--profile`, `--role-arn`, `--verbose`, `-y/--yes`.
 
+**Container `AWS_REGION` fallback**: when neither `--assume-role`'s STS
+region nor an `AWS_REGION` / `AWS_DEFAULT_REGION` env var already set a
+region for a Lambda container, cdk-local seeds `AWS_REGION` from the first
+available of `--stack-region` > the synth-derived stack region
+(`env.region` on the CDK stack, read from the cloud assembly manifest) >
+the `--profile`'s configured region (`~/.aws/config`'s `region =`).
+`--profile` injects the credential triple but the synthesized credentials
+file carries no `region =`, and the synth-derived stack region was
+previously used only host-side for the `--from-cfn-stack` CFn client — so
+without this a handler's ambient-region SDK call (`new XxxClient({})`)
+booted with credentials but failed locally with "Region is missing" while
+succeeding when deployed. A region-agnostic stack run with no profile
+region and no `AWS_REGION` env still surfaces that SDK error — set
+`AWS_REGION` or `--stack-region`.
+
 ### `cdkl start-api` exit codes
 
 - `0` — server started cleanly and shut down on SIGTERM.

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -570,6 +570,21 @@ the same tier; cdk-local uses literal-segment count as a heuristic).
 | `--mtls-cert <path>` | unset | PEM-encoded server certificate for mutual TLS. Self-signed is fine for local dev. Must be set together with `--mtls-truststore` + `--mtls-key`. |
 | `--mtls-key <path>` | unset | PEM-encoded server private key matching `--mtls-cert`. Must be set together with `--mtls-truststore` + `--mtls-cert`. |
 
+**Container `AWS_REGION` fallback**: when neither `--assume-role`'s STS
+region nor an `AWS_REGION` / `AWS_DEFAULT_REGION` env var already set a
+region for a Lambda container, cdk-local seeds `AWS_REGION` from the first
+available of `--stack-region` > the synth-derived stack region
+(`env.region` on the CDK stack, read from the cloud assembly manifest) >
+the `--profile`'s configured region (`~/.aws/config`'s `region =`).
+`--profile` injects the credential triple but the synthesized credentials
+file carries no `region =`, and the synth-derived stack region was
+previously used only host-side for the `--from-cfn-stack` CFn client — so
+without this a handler's ambient-region SDK call (`new XxxClient({})`)
+booted with credentials but failed locally with "Region is missing" while
+succeeding when deployed. A region-agnostic stack run with no profile
+region and no `AWS_REGION` env still surfaces that SDK error — set
+`AWS_REGION` or `--stack-region`.
+
 ### Hot reload (`--watch`)
 
 When `--watch` is set, cdk-local installs a

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -633,6 +633,8 @@ async function localStartApiCommand(
         ...(options.layerRoleArn !== undefined && { layerRoleArn: options.layerRoleArn }),
         ...(profileCredentials && { profileCredentials }),
         ...(profileCredsFile && { profileCredsFile }),
+        ...(profileCredentials?.region && { profileRegion: profileCredentials.region }),
+        ...(options.stackRegion && { stackRegionOverride: options.stackRegion }),
       });
       specs.set(logicalId, spec);
     }
@@ -1638,6 +1640,22 @@ async function buildContainerSpec(args: {
    * was not passed.
    */
   profileCredsFile?: ProfileCredentialsFile;
+  /**
+   * `--profile`'s configured region (`~/.aws/config`'s `region =` for the
+   * profile), resolved once at server boot via
+   * {@link resolveProfileCredentials}. Lowest-precedence fallback for the
+   * container's `AWS_REGION` — used only when no explicit region was
+   * injected. Undefined when `--profile` is unset or the profile has no
+   * region.
+   */
+  profileRegion?: string | undefined;
+  /**
+   * `--stack-region` flag value. Highest-precedence fallback for the
+   * container's `AWS_REGION` (it also drives the `--from-cfn-stack` CFn
+   * client, so the container reaches the same region as the resources it
+   * is bound to). Undefined when the flag is unset.
+   */
+  stackRegionOverride?: string | undefined;
 }): Promise<ContainerSpec> {
   const {
     logicalId,
@@ -1654,6 +1672,8 @@ async function buildContainerSpec(args: {
     layerRoleArn,
     profileCredentials,
     profileCredsFile,
+    profileRegion,
+    stackRegionOverride,
   } = args;
   const lambda = resolveLambdaByLogicalId(logicalId, stacks);
 
@@ -1819,6 +1839,24 @@ async function buildContainerSpec(args: {
       dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
       dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
     }
+  }
+
+  // Fallback AWS_REGION for the container's AWS SDK. The branches above
+  // only set AWS_REGION from the assume-role STS region or a forwarded
+  // AWS_REGION / AWS_DEFAULT_REGION env var. `--profile` injects the
+  // credential triple but NOT the profile's region (the synthesized
+  // credentials file carries no `region =`), and the synth-derived stack
+  // region was previously used only host-side for the --from-cfn-stack CFn
+  // client. Seed both here (precedence in resolveContainerFallbackRegion)
+  // so a handler's ambient-region SDK call resolves to the same region the
+  // deployed function runs in instead of failing with "Region is missing".
+  if (!dockerEnv['AWS_REGION']) {
+    const fallbackRegion = resolveContainerFallbackRegion({
+      stackRegionOverride,
+      synthRegion: lambda.stack.region,
+      profileRegion,
+    });
+    if (fallbackRegion) dockerEnv['AWS_REGION'] = fallbackRegion;
   }
 
   if (debugPort !== undefined) {
@@ -2541,10 +2579,25 @@ function forwardAwsEnv(env: Record<string, string>): void {
  * common dev session; long-running `--watch` sessions that outlive
  * the creds need a cdk-local restart (deferred refresh out of scope for
  * v1, see issue #654).
+ *
+ * Also resolves the profile's configured `region` (from `~/.aws/config`'s
+ * `region = ...` for this profile) off the same client config. The
+ * synthesized credentials file we mount into the container carries only
+ * the credential triple — no `region =` — so without this the container
+ * boots with creds but no region, and a handler's ambient-region SDK call
+ * (`new XxxClient({})`) fails with "Region is missing". The caller seeds
+ * the container's `AWS_REGION` fallback with it (see
+ * {@link resolveContainerFallbackRegion}). Region resolution is
+ * best-effort: a profile with no region (or any resolution failure)
+ * yields `region: undefined` rather than throwing — a missing region is
+ * not a missing-credentials error.
  */
-export async function resolveProfileCredentials(
-  profile: string
-): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }> {
+export async function resolveProfileCredentials(profile: string): Promise<{
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  region?: string;
+}> {
   const { STSClient } = await import('@aws-sdk/client-sts');
   const sts = new STSClient({ profile });
   try {
@@ -2558,14 +2611,58 @@ export async function resolveProfileCredentials(
           '` for SSO profiles, or `~/.aws/credentials` / `~/.aws/config` for regular profiles.'
       );
     }
+    let region: string | undefined;
+    try {
+      const regionProvider = sts.config.region;
+      const resolved =
+        typeof regionProvider === 'function' ? await regionProvider() : regionProvider;
+      if (typeof resolved === 'string' && resolved.length > 0) region = resolved;
+    } catch {
+      // Profile has no region configured (and no AWS_REGION env) — leave
+      // undefined; the container falls through to the next region source.
+      region = undefined;
+    }
     return {
       accessKeyId: creds.accessKeyId,
       secretAccessKey: creds.secretAccessKey,
       ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
+      ...(region && { region }),
     };
   } finally {
     sts.destroy();
   }
+}
+
+/**
+ * Resolve the fallback `AWS_REGION` for a Lambda container when neither
+ * the assume-role STS region nor a forwarded `AWS_REGION` /
+ * `AWS_DEFAULT_REGION` env var already set one.
+ *
+ * Precedence mirrors where the deployed function would actually run, so a
+ * handler's ambient-region SDK call (`new XxxClient({})`) reaches the same
+ * region locally as the resources it is bound to:
+ *
+ *   1. `--stack-region` — explicit; also drives the `--from-cfn-stack` CFn
+ *      client, so the container matches the region the bound stack was read
+ *      from.
+ *   2. the synth-derived stack region — `env.region` on the CDK stack, read
+ *      from the cloud assembly manifest (`StackInfo.region`). Previously
+ *      used only host-side for the `--from-cfn-stack` CFn client; never
+ *      injected into the container.
+ *   3. the `--profile`'s configured region — `~/.aws/config`'s `region =`
+ *      for the profile. `--profile` injected credentials but not this.
+ *
+ * Returns `undefined` when none is known; the caller leaves `AWS_REGION`
+ * unset so the SDK's own "Region is missing" surfaces (the correct signal
+ * for a region-agnostic stack with no profile region and no `AWS_REGION`
+ * env).
+ */
+export function resolveContainerFallbackRegion(args: {
+  stackRegionOverride?: string | undefined;
+  synthRegion?: string | undefined;
+  profileRegion?: string | undefined;
+}): string | undefined {
+  return args.stackRegionOverride ?? args.synthRegion ?? args.profileRegion;
 }
 
 /**

--- a/tests/unit/cli/local-start-api-container-region.test.ts
+++ b/tests/unit/cli/local-start-api-container-region.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import {
+  resolveContainerFallbackRegion,
+  resolveProfileCredentials,
+} from '../../../src/cli/commands/local-start-api.js';
+
+// A `--profile`-fronted Lambda container used to boot with the profile's
+// credentials but NO region: the synthesized credentials file we mount
+// carries only the credential triple (no `region =`), and the
+// synth-derived stack region was only ever used host-side for the
+// --from-cfn-stack CFn client. The result was a handler's ambient-region
+// SDK call (`new XxxClient({})`) failing with "Region is missing" locally
+// while succeeding when deployed. These tests pin the two pieces that
+// close that gap: the region precedence helper and the profile-region
+// resolution added to `resolveProfileCredentials`.
+
+const credsProviderMock = vi.fn();
+const regionProviderMock = vi.fn();
+const stsDestroyMock = vi.fn();
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      config: { credentials: credsProviderMock, region: regionProviderMock },
+      destroy: stsDestroyMock,
+    };
+  }),
+}));
+
+describe('resolveContainerFallbackRegion', () => {
+  it('prefers --stack-region over the synth and profile regions', () => {
+    expect(
+      resolveContainerFallbackRegion({
+        stackRegionOverride: 'eu-west-1',
+        synthRegion: 'us-east-1',
+        profileRegion: 'ap-northeast-1',
+      })
+    ).toBe('eu-west-1');
+  });
+
+  it('falls back to the synth-derived stack region when --stack-region is unset', () => {
+    expect(
+      resolveContainerFallbackRegion({
+        synthRegion: 'us-east-1',
+        profileRegion: 'ap-northeast-1',
+      })
+    ).toBe('us-east-1');
+  });
+
+  it('falls back to the profile region for a region-agnostic stack with no --stack-region', () => {
+    expect(resolveContainerFallbackRegion({ profileRegion: 'ap-northeast-1' })).toBe(
+      'ap-northeast-1'
+    );
+  });
+
+  it('returns undefined when no region source is known', () => {
+    expect(resolveContainerFallbackRegion({})).toBeUndefined();
+  });
+});
+
+describe('resolveProfileCredentials region resolution', () => {
+  beforeEach(() => {
+    credsProviderMock.mockReset();
+    regionProviderMock.mockReset();
+    stsDestroyMock.mockReset();
+    stsCtorMock.mockReset();
+  });
+
+  it('returns the profile-configured region alongside the credentials', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+    });
+    regionProviderMock.mockResolvedValue('ap-northeast-1');
+    const result = await resolveProfileCredentials('dev');
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      region: 'ap-northeast-1',
+    });
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'dev' });
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('omits region when the profile has none (region provider throws "Region is missing")', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    regionProviderMock.mockRejectedValue(new Error('Region is missing'));
+    const result = await resolveProfileCredentials('dev');
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    expect(result).not.toHaveProperty('region');
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('omits region when the region provider resolves an empty string', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+    });
+    regionProviderMock.mockResolvedValue('');
+    const result = await resolveProfileCredentials('dev');
+    expect(result).not.toHaveProperty('region');
+  });
+
+  it('still throws when credentials cannot be resolved (the region path does not mask it)', async () => {
+    credsProviderMock.mockResolvedValue({});
+    await expect(resolveProfileCredentials('dev')).rejects.toThrow(
+      /resolved without usable credentials/
+    );
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- When neither `--assume-role`'s STS region nor an `AWS_REGION` / `AWS_DEFAULT_REGION` env var set a region, `start-api` Lambda containers booted **without one**. `--profile` injects only the credential triple (the synthesized credentials file carries no `region =`), and the synth-derived stack region was used only host-side for the `--from-cfn-stack` CFn client.
- A handler's ambient-region SDK call (`new XxxClient({})`) then failed locally with `Region is missing` while succeeding against the deployed function.
- Seed the container's `AWS_REGION` from the first available of `--stack-region` > synth-derived stack region (`env.region` on the CDK stack) > the `--profile`'s configured region — only when no explicit region was already injected.
- `resolveProfileCredentials` now also resolves the profile's region; a new `resolveContainerFallbackRegion` helper encodes the precedence.

## Test plan

- [x] `vp run verify` — typecheck + lint + format + build + 230 unit tests pass
- [x] New unit tests (8): `resolveContainerFallbackRegion` precedence + `resolveProfileCredentials` region resolution / omission paths
- [x] `/run-integ local-start-api` clean (0 docker orphans)
- [x] Live-test: region-agnostic fixture + `--stack-region eu-north-1`, with `AWS_REGION` / `AWS_DEFAULT_REGION` unset, injected `AWS_REGION=eu-north-1` into the running container (verified via `docker inspect`); route returned HTTP 200
- [x] Docs updated: `docs/cli-reference.md`, `docs/local-emulation.md`

## Notes

- Scope is `start-api` only. `invoke` / `run-task` / `start-service` build their container env through separate code paths and still drop the profile region; extending the same fallback there is a sensible follow-up. `resolveProfileCredentials` gained an optional `region` field those callers currently ignore (additive, no behavior change for them).
