### PR TITLE
feat(index): re-export local leaf helpers for host shims

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -89,7 +89,6 @@ pure, dependency-free helpers those modules expose:
   Gateway request-parameter mapping.
 - `translateLambdaResponse` (+ `TranslatedHttpResponse`) — Lambda
   proxy response → HTTP response translation.
-- `bufferToBody` — websocket frame buffer → string/base64 body coercion.
 - `getContainerNetworkIp` — read a container's per-network IP via
   `docker inspect`.
 

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -71,3 +71,28 @@ Every field is optional and independently falls back to the cdk-local
 default, so omitting `embedConfig` (or any single field) leaves native
 `cdkl` behavior unchanged. Pass the same `embedConfig` to each factory
 the host mounts so the branding is consistent across commands.
+
+## Low-level building blocks (shim hosts)
+
+Most hosts only need the command factories above. A host that instead
+re-exports cdk-local's individual `src/local/**` modules verbatim
+(rather than carrying its own byte-identical copy) can also import the
+pure, dependency-free helpers those modules expose:
+
+- `pickRefLogicalId` — extract the logical id from a `{ Ref: ... }`
+  intrinsic.
+- `resolveLambdaArnIntrinsic` (+ `LambdaArnResolveOutcome`) — resolve a
+  Lambda ARN expressed as `Ref` / `Fn::GetAtt` / the REST-v1 invoke-ARN
+  `Fn::Join` / `Fn::Sub` wrappers.
+- `resolveServiceIntegrationParameters` / `resolveSelectionExpression`
+  (+ `RequestParameterContext` / `ResolveParametersOutcome`) — API
+  Gateway request-parameter mapping.
+- `translateLambdaResponse` (+ `TranslatedHttpResponse`) — Lambda
+  proxy response → HTTP response translation.
+- `bufferToBody` — websocket frame buffer → string/base64 body coercion.
+- `getContainerNetworkIp` — read a container's per-network IP via
+  `docker inspect`.
+
+These are stable, side-effect-free utilities; they are exposed for
+1:1 re-export and are not a recommended way to build a custom CLI (use
+the factories for that).

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,30 @@ export {
   CfnLocalStateProvider,
   type CfnLocalStateProviderOptions,
 } from './local/cfn-local-state-provider.js';
+
+/**
+ * Low-level local-execution building blocks re-exported for hosts that
+ * shim cdk-local's `src/local/**` modules verbatim (e.g. cdkd). These
+ * are pure, dependency-free helpers — intrinsic resolution, parameter
+ * mapping, response translation, websocket body coercion, and container
+ * network inspection — that a host re-exports 1:1 instead of carrying
+ * its own byte-identical copy. Exposed only as the consuming host's
+ * `import` statements require them.
+ */
+export { pickRefLogicalId } from './local/intrinsic-utils.js';
+export {
+  resolveLambdaArnIntrinsic,
+  type LambdaArnResolveOutcome,
+} from './local/intrinsic-lambda-arn.js';
+export {
+  resolveServiceIntegrationParameters,
+  resolveSelectionExpression,
+  type RequestParameterContext,
+  type ResolveParametersOutcome,
+} from './local/parameter-mapping.js';
+export {
+  translateLambdaResponse,
+  type TranslatedHttpResponse,
+} from './local/api-gateway-response.js';
+export { bufferToBody } from './local/websocket-body.js';
+export { getContainerNetworkIp } from './local/docker-inspect.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,10 @@ export {
  * Low-level local-execution building blocks re-exported for hosts that
  * shim cdk-local's `src/local/**` modules verbatim (e.g. cdkd). These
  * are pure, dependency-free helpers — intrinsic resolution, parameter
- * mapping, response translation, websocket body coercion, and container
- * network inspection — that a host re-exports 1:1 instead of carrying
- * its own byte-identical copy. Exposed only as the consuming host's
- * `import` statements require them.
+ * mapping, response translation, and container network inspection —
+ * that a host re-exports 1:1 instead of carrying its own byte-identical
+ * copy. Exposed only as the consuming host's `import` statements require
+ * them.
  */
 export { pickRefLogicalId } from './local/intrinsic-utils.js';
 export {
@@ -69,5 +69,4 @@ export {
   translateLambdaResponse,
   type TranslatedHttpResponse,
 } from './local/api-gateway-response.js';
-export { bufferToBody } from './local/websocket-body.js';
 export { getContainerNetworkIp } from './local/docker-inspect.js';

--- a/tests/unit/local/api-gateway-response.test.ts
+++ b/tests/unit/local/api-gateway-response.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { translateLambdaResponse } from '../../../src/local/api-gateway-response.js';
+
+describe('translateLambdaResponse — shaped', () => {
+  it('passes statusCode / headers / body through', () => {
+    const result = translateLambdaResponse(
+      {
+        statusCode: 201,
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"ok":true}',
+      },
+      'v2'
+    );
+    expect(result.statusCode).toBe(201);
+    expect(result.headers['content-type']).toBe('application/json');
+    expect(result.body.toString('utf-8')).toBe('{"ok":true}');
+  });
+
+  it('decodes base64 body when isBase64Encoded is true', () => {
+    const original = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+    const result = translateLambdaResponse(
+      { statusCode: 200, body: original.toString('base64'), isBase64Encoded: true },
+      'v2'
+    );
+    expect(Array.from(result.body)).toEqual(Array.from(original));
+  });
+
+  it('emits multiple Set-Cookie headers from the v2 cookies array (C5)', () => {
+    const result = translateLambdaResponse(
+      { statusCode: 200, body: 'ok', cookies: ['a=b', 'c=d'] },
+      'v2'
+    );
+    expect(result.cookies).toEqual(['a=b', 'c=d']);
+    expect(result.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('v1 multiValueHeaders set-cookie maps to multiple Set-Cookie headers', () => {
+    const result = translateLambdaResponse(
+      {
+        statusCode: 200,
+        body: 'ok',
+        multiValueHeaders: { 'Set-Cookie': ['a=b', 'c=d'] },
+      },
+      'v1'
+    );
+    expect(result.cookies).toEqual(['a=b', 'c=d']);
+  });
+
+  it('v1 set-cookie via single headers map is also lifted into cookies', () => {
+    const result = translateLambdaResponse(
+      { statusCode: 200, body: '', headers: { 'Set-Cookie': 'a=b' } },
+      'v1'
+    );
+    expect(result.cookies).toEqual(['a=b']);
+  });
+});
+
+describe('translateLambdaResponse — error envelope (C7)', () => {
+  it('returns 502 with canonical body when payload has errorMessage and no statusCode', () => {
+    const result = translateLambdaResponse(
+      {
+        errorMessage: 'oops',
+        errorType: 'Error',
+        stackTrace: ['Error: oops at ...'],
+      },
+      'v2'
+    );
+    expect(result.statusCode).toBe(502);
+    expect(result.body.toString('utf-8')).toBe('{"message":"Internal server error"}');
+    expect(result.headers['content-type']).toBe('application/json');
+  });
+
+  it('respects user payload that legitimately includes errorMessage AND statusCode', () => {
+    const result = translateLambdaResponse(
+      { statusCode: 400, body: '{"errorMessage":"validation"}', headers: {} },
+      'v2'
+    );
+    expect(result.statusCode).toBe(400);
+  });
+});
+
+describe('translateLambdaResponse — auto-format (C6)', () => {
+  it('wraps a JSON object without statusCode as 200 + JSON body', () => {
+    const result = translateLambdaResponse({ message: 'hello' }, 'v2');
+    expect(result.statusCode).toBe(200);
+    expect(result.headers['content-type']).toBe('application/json');
+    expect(result.body.toString('utf-8')).toBe('{"message":"hello"}');
+  });
+
+  it('wraps an array without statusCode as 200 + JSON body', () => {
+    const result = translateLambdaResponse([1, 2, 3], 'v2');
+    expect(result.statusCode).toBe(200);
+    expect(result.body.toString('utf-8')).toBe('[1,2,3]');
+  });
+
+  it('wraps a primitive value (number) as 200 + JSON body', () => {
+    const result = translateLambdaResponse(42, 'v2');
+    expect(result.statusCode).toBe(200);
+    expect(result.body.toString('utf-8')).toBe('42');
+  });
+});

--- a/tests/unit/local/intrinsic-lambda-arn.test.ts
+++ b/tests/unit/local/intrinsic-lambda-arn.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { resolveLambdaArnIntrinsic } from '../../../src/local/intrinsic-lambda-arn.js';
+
+describe('resolveLambdaArnIntrinsic', () => {
+  it('resolves bare Ref', () => {
+    expect(resolveLambdaArnIntrinsic({ Ref: 'MyHandler' })).toEqual({
+      kind: 'resolved',
+      logicalId: 'MyHandler',
+    });
+  });
+
+  it("resolves Fn::GetAtt: [LogicalId, 'Arn']", () => {
+    expect(resolveLambdaArnIntrinsic({ 'Fn::GetAtt': ['MyHandler', 'Arn'] })).toEqual({
+      kind: 'resolved',
+      logicalId: 'MyHandler',
+    });
+  });
+
+  it("rejects Fn::GetAtt with non-Arn attribute", () => {
+    const r = resolveLambdaArnIntrinsic({ 'Fn::GetAtt': ['MyHandler', 'Name'] });
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it("resolves the canonical REST v1 / HTTP v2 invoke-ARN Fn::Join wrapper", () => {
+    // The exact shape `apigateway.LambdaIntegration({proxy: true})` and
+    // CDK 2.x `apigatewayv2-authorizers.HttpLambdaAuthorizer` synthesize.
+    const shape = {
+      'Fn::Join': [
+        '',
+        [
+          'arn:',
+          { Ref: 'AWS::Partition' },
+          ':apigateway:',
+          { Ref: 'AWS::Region' },
+          ':lambda:path/2015-03-31/functions/',
+          { 'Fn::GetAtt': ['MyHandler', 'Arn'] },
+          '/invocations',
+        ],
+      ],
+    };
+    expect(resolveLambdaArnIntrinsic(shape)).toEqual({
+      kind: 'resolved',
+      logicalId: 'MyHandler',
+    });
+  });
+
+  it('resolves Fn::Sub 1-arg invoke-ARN (AWS-docs canonical shape)', () => {
+    // `cdk.Fn.sub('arn:...${LogicalId.Arn}/invocations')` synthesizes this.
+    const shape = {
+      'Fn::Sub':
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyHandler.Arn}/invocations',
+    };
+    expect(resolveLambdaArnIntrinsic(shape)).toEqual({
+      kind: 'resolved',
+      logicalId: 'MyHandler',
+    });
+  });
+
+  it('resolves Fn::Sub 2-arg invoke-ARN (CDK Fn.sub(template, vars))', () => {
+    // `cdk.Fn.sub(template, { MyLambdaArn: fn.functionArn })` synthesizes
+    // this — the var map value is the Fn::GetAtt: [..., 'Arn'] shape.
+    const shape = {
+      'Fn::Sub': [
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaArn}/invocations',
+        { MyLambdaArn: { 'Fn::GetAtt': ['MyHandler', 'Arn'] } },
+      ],
+    };
+    expect(resolveLambdaArnIntrinsic(shape)).toEqual({
+      kind: 'resolved',
+      logicalId: 'MyHandler',
+    });
+  });
+
+  it('rejects Fn::Sub against an arbitrary (non-invoke-ARN) template', () => {
+    // The bare `${X.Arn}` shape — used as the negative case in the
+    // pre-PR rejection test for route-discovery. Still rejected because
+    // the template doesn't contain the invoke-ARN marker.
+    const r = resolveLambdaArnIntrinsic({ 'Fn::Sub': '${MyHandler.Arn}' });
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it("rejects Fn::Sub whose marker-bearing template has no ${X.Arn} placeholder", () => {
+    // Marker present, but the only placeholder is `${AWS::Region}` — no
+    // Lambda reference at all.
+    const r = resolveLambdaArnIntrinsic({
+      'Fn::Sub':
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/static-name/invocations',
+    });
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it('rejects Fn::Sub 2-arg whose var-map value is not Fn::GetAtt [_, "Arn"]', () => {
+    const r = resolveLambdaArnIntrinsic({
+      'Fn::Sub': [
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaArn}/invocations',
+        { MyLambdaArn: { Ref: 'NotAGetAtt' } },
+      ],
+    });
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it("rejects Fn::Join that doesn't contain the invoke-ARN marker", () => {
+    const r = resolveLambdaArnIntrinsic({
+      'Fn::Join': ['/', ['prefix', { 'Fn::GetAtt': ['Other', 'Arn'] }, 'suffix']],
+    });
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it('rejects Fn::Join with marker but no GetAtt element', () => {
+    // Pathological shape — the parts contain the marker as a literal
+    // segment but no Fn::GetAtt: [..., 'Arn'] to extract.
+    const r = resolveLambdaArnIntrinsic({
+      'Fn::Join': [
+        '',
+        [
+          'arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/',
+          { Ref: 'NotAGetAtt' },
+          '/invocations',
+        ],
+      ],
+    });
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it('rejects bare primitives / arrays / null', () => {
+    expect(resolveLambdaArnIntrinsic('string').kind).toBe('unsupported');
+    expect(resolveLambdaArnIntrinsic([1, 2]).kind).toBe('unsupported');
+    expect(resolveLambdaArnIntrinsic(null).kind).toBe('unsupported');
+    expect(resolveLambdaArnIntrinsic(undefined).kind).toBe('unsupported');
+  });
+
+  it('rejects unknown intrinsic shape', () => {
+    expect(resolveLambdaArnIntrinsic({ 'Fn::ImportValue': 'X' }).kind).toBe('unsupported');
+  });
+
+  it("Fn::Sub 1-arg ignores ${LogicalId.OtherAttr} and only resolves ${LogicalId.Arn}", () => {
+    // The template references the right Lambda but uses an unrelated
+    // attribute name — the resolver should skip and continue scanning
+    // (in this case there are no other placeholders, so it fails).
+    const r = resolveLambdaArnIntrinsic({
+      'Fn::Sub':
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyHandler.Name}/invocations',
+    });
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it("Fn::Sub 1-arg picks the FIRST resolvable ${LogicalId.Arn} placeholder", () => {
+    // Defensive: a single template containing two Lambda references is
+    // not a shape CDK actually emits, but the resolver must be
+    // deterministic. The first non-pseudo `${X.Arn}` wins.
+    const r = resolveLambdaArnIntrinsic({
+      'Fn::Sub':
+        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${First.Arn}/invocations-suffix-${Second.Arn}',
+    });
+    expect(r).toEqual({ kind: 'resolved', logicalId: 'First' });
+  });
+});

--- a/tests/unit/local/intrinsic-utils.test.ts
+++ b/tests/unit/local/intrinsic-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { pickRefLogicalId } from '../../../src/local/intrinsic-utils.js';
+
+describe('pickRefLogicalId', () => {
+  it('returns the logical id when given a {Ref: <string>} intrinsic', () => {
+    expect(pickRefLogicalId({ Ref: 'MyResource' })).toBe('MyResource');
+  });
+
+  it('returns null when Ref value is not a string', () => {
+    expect(pickRefLogicalId({ Ref: 123 })).toBeNull();
+    expect(pickRefLogicalId({ Ref: { nested: 'object' } })).toBeNull();
+    expect(pickRefLogicalId({ Ref: null })).toBeNull();
+  });
+
+  it('returns null for non-Ref intrinsics', () => {
+    expect(pickRefLogicalId({ 'Fn::GetAtt': ['Foo', 'Arn'] })).toBeNull();
+    expect(pickRefLogicalId({ 'Fn::Sub': '${MyRef}' })).toBeNull();
+  });
+
+  it('returns null for primitives, arrays, and nullish values', () => {
+    expect(pickRefLogicalId(null)).toBeNull();
+    expect(pickRefLogicalId(undefined)).toBeNull();
+    expect(pickRefLogicalId('literal-string')).toBeNull();
+    expect(pickRefLogicalId(42)).toBeNull();
+    expect(pickRefLogicalId([{ Ref: 'X' }])).toBeNull();
+  });
+});

--- a/tests/unit/local/parameter-mapping.test.ts
+++ b/tests/unit/local/parameter-mapping.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  resolveSelectionExpression,
+  resolveServiceIntegrationParameters,
+  type RequestParameterContext,
+} from '../../../src/local/parameter-mapping.js';
+
+function makeCtx(overrides: Partial<RequestParameterContext> = {}): RequestParameterContext {
+  return {
+    headers: {},
+    queryString: {},
+    pathParameters: {},
+    requestPath: '/',
+    body: '',
+    context: {},
+    stageVariables: {},
+    ...overrides,
+  };
+}
+
+describe('resolveSelectionExpression — bare references', () => {
+  it('resolves $request.header.X case-insensitively', () => {
+    const ctx = makeCtx({ headers: { authorization: 'Bearer xyz' } });
+    expect(resolveSelectionExpression('$request.header.Authorization', ctx)).toBe('Bearer xyz');
+  });
+
+  it('resolves $request.querystring.X case-sensitively', () => {
+    const ctx = makeCtx({ queryString: { url: 'https://example.com', URL: 'OTHER' } });
+    expect(resolveSelectionExpression('$request.querystring.url', ctx)).toBe('https://example.com');
+    expect(resolveSelectionExpression('$request.querystring.URL', ctx)).toBe('OTHER');
+  });
+
+  it('resolves $request.path.X from extracted path parameters', () => {
+    const ctx = makeCtx({ pathParameters: { id: '42' } });
+    expect(resolveSelectionExpression('$request.path.id', ctx)).toBe('42');
+  });
+
+  it('resolves $request.path to the full request path', () => {
+    const ctx = makeCtx({ requestPath: '/items/42' });
+    expect(resolveSelectionExpression('$request.path', ctx)).toBe('/items/42');
+  });
+
+  it('resolves $request.body to the raw body string', () => {
+    const ctx = makeCtx({ body: '{"foo":1}' });
+    expect(resolveSelectionExpression('$request.body', ctx)).toBe('{"foo":1}');
+  });
+
+  it('resolves $request.body.<jsonpath> against parsed JSON', () => {
+    const ctx = makeCtx({ body: '{"user":{"name":"Alice","age":30},"items":["a","b"]}' });
+    expect(resolveSelectionExpression('$request.body.user.name', ctx)).toBe('Alice');
+    expect(resolveSelectionExpression('$request.body.user.age', ctx)).toBe('30');
+    expect(resolveSelectionExpression('$request.body.items[0]', ctx)).toBe('a');
+    expect(resolveSelectionExpression('$request.body.items[1]', ctx)).toBe('b');
+  });
+
+  it('JSONPath: returns empty string for missing keys', () => {
+    const ctx = makeCtx({ body: '{"x":1}' });
+    expect(resolveSelectionExpression('$request.body.missing', ctx)).toBe('');
+  });
+
+  it('JSONPath: returns empty string for malformed JSON body', () => {
+    const ctx = makeCtx({ body: 'not json' });
+    expect(resolveSelectionExpression('$request.body.anything', ctx)).toBe('');
+  });
+
+  it('JSONPath: rejects recursive descent and filter expressions', () => {
+    const ctx = makeCtx({ body: '{"x":1}' });
+    expect(resolveSelectionExpression('$request.body..x', ctx)).toBe('');
+    expect(resolveSelectionExpression('$request.body.x?(@.y)', ctx)).toBe('');
+  });
+
+  it('resolves $context.<key>', () => {
+    const ctx = makeCtx({ context: { requestId: 'abc-123', 'identity.sourceIp': '1.2.3.4' } });
+    expect(resolveSelectionExpression('$context.requestId', ctx)).toBe('abc-123');
+    expect(resolveSelectionExpression('$context.identity.sourceIp', ctx)).toBe('1.2.3.4');
+  });
+
+  describe('$context.authorizer.X (closes #502)', () => {
+    it('resolves $context.authorizer.principalId for Lambda authorizers', () => {
+      const ctx = makeCtx({
+        authorizer: { principalId: 'user-42', tier: 'pro' },
+      });
+      expect(resolveSelectionExpression('$context.authorizer.principalId', ctx)).toBe('user-42');
+      expect(resolveSelectionExpression('$context.authorizer.tier', ctx)).toBe('pro');
+    });
+
+    it('resolves $context.authorizer.jwt.claims.X for JWT authorizers', () => {
+      const ctx = makeCtx({
+        authorizer: {
+          jwt: {
+            claims: { sub: 'cognito-user-id', email: 'a@example.com' },
+            scopes: ['read', 'write'],
+          },
+        },
+      });
+      expect(resolveSelectionExpression('$context.authorizer.jwt.claims.sub', ctx)).toBe(
+        'cognito-user-id'
+      );
+      expect(resolveSelectionExpression('$context.authorizer.jwt.claims.email', ctx)).toBe(
+        'a@example.com'
+      );
+    });
+
+    it('resolves $context.authorizer.claims.X for Cognito REST v1 authorizers', () => {
+      const ctx = makeCtx({
+        authorizer: {
+          claims: { sub: 'cog-user', email: 'b@example.com' },
+        },
+      });
+      expect(resolveSelectionExpression('$context.authorizer.claims.sub', ctx)).toBe('cog-user');
+    });
+
+    it('returns empty string for missing authorizer path', () => {
+      const ctx = makeCtx({ authorizer: { principalId: 'u' } });
+      expect(resolveSelectionExpression('$context.authorizer.missing', ctx)).toBe('');
+      expect(resolveSelectionExpression('$context.authorizer.jwt.claims.sub', ctx)).toBe('');
+    });
+
+    it('returns empty string when no authorizer is attached', () => {
+      const ctx = makeCtx();
+      expect(resolveSelectionExpression('$context.authorizer.principalId', ctx)).toBe('');
+      expect(resolveSelectionExpression('$context.authorizer.jwt.claims.sub', ctx)).toBe('');
+    });
+
+    it('stringifies non-string leaves (numbers, booleans, arrays, objects)', () => {
+      const ctx = makeCtx({
+        authorizer: {
+          age: 42,
+          isAdmin: true,
+          roles: ['admin', 'user'],
+          nested: { x: 1 },
+        },
+      });
+      expect(resolveSelectionExpression('$context.authorizer.age', ctx)).toBe('42');
+      expect(resolveSelectionExpression('$context.authorizer.isAdmin', ctx)).toBe('true');
+      expect(resolveSelectionExpression('$context.authorizer.roles', ctx)).toBe('["admin","user"]');
+      expect(resolveSelectionExpression('$context.authorizer.nested', ctx)).toBe('{"x":1}');
+    });
+
+    it('${...} interpolation works for $context.authorizer.X', () => {
+      const ctx = makeCtx({
+        authorizer: { jwt: { claims: { sub: 'user-42' } } },
+      });
+      expect(
+        resolveSelectionExpression('prefix-${context.authorizer.jwt.claims.sub}-suffix', ctx)
+      ).toBe('prefix-user-42-suffix');
+    });
+  });
+
+  it('resolves $stageVariables.<key>', () => {
+    const ctx = makeCtx({ stageVariables: { env: 'prod' } });
+    expect(resolveSelectionExpression('$stageVariables.env', ctx)).toBe('prod');
+  });
+
+  it('unresolved reference (recognized prefix, absent key) → empty string', () => {
+    const ctx = makeCtx();
+    expect(resolveSelectionExpression('$request.querystring.missing', ctx)).toBe('');
+    expect(resolveSelectionExpression('$request.header.missing', ctx)).toBe('');
+  });
+
+  it('unrecognized $-prefixed string → literal passthrough', () => {
+    const ctx = makeCtx();
+    expect(resolveSelectionExpression('$reqeust.X', ctx)).toBe('$reqeust.X');
+  });
+
+  it('plain literal string → returned verbatim', () => {
+    const ctx = makeCtx();
+    expect(resolveSelectionExpression('plain-literal', ctx)).toBe('plain-literal');
+    expect(resolveSelectionExpression('', ctx)).toBe('');
+  });
+});
+
+describe('resolveSelectionExpression — ${...} interpolation', () => {
+  it('substitutes a single ${...} placeholder', () => {
+    const ctx = makeCtx({ pathParameters: { id: '42' } });
+    expect(resolveSelectionExpression('item-${request.path.id}', ctx)).toBe('item-42');
+  });
+
+  it('substitutes multiple placeholders with literal interleaved text', () => {
+    const ctx = makeCtx({ pathParameters: { name: 'Alice' }, queryString: { id: '7' } });
+    expect(
+      resolveSelectionExpression('${request.path.name}: ${request.querystring.id}', ctx)
+    ).toBe('Alice: 7');
+  });
+
+  it('absent placeholder → empty string inside template', () => {
+    const ctx = makeCtx();
+    expect(resolveSelectionExpression('[${request.querystring.x}]', ctx)).toBe('[]');
+  });
+
+  it('throws on unclosed ${...} interpolation', () => {
+    const ctx = makeCtx();
+    expect(() => resolveSelectionExpression('${request.path.id', ctx)).toThrow(/unclosed/);
+  });
+});
+
+describe('resolveServiceIntegrationParameters', () => {
+  it('resolves every value while preserving keys', () => {
+    const ctx = makeCtx({
+      queryString: { url: 'https://q', body: 'hi' },
+      pathParameters: { id: '7' },
+      body: '{"msg":"hello"}',
+    });
+    const outcome = resolveServiceIntegrationParameters(
+      {
+        QueueUrl: '$request.querystring.url',
+        MessageBody: '$request.body.msg',
+        SomePath: '/foo/${request.path.id}/bar',
+        Literal: 'static',
+      },
+      ctx
+    );
+    expect(outcome.kind).toBe('ok');
+    if (outcome.kind === 'ok') {
+      expect(outcome.resolved).toEqual({
+        QueueUrl: 'https://q',
+        MessageBody: 'hello',
+        SomePath: '/foo/7/bar',
+        Literal: 'static',
+      });
+    }
+  });
+
+  it('rejects non-string parameter values', () => {
+    const outcome = resolveServiceIntegrationParameters({ X: 5 } as Record<string, unknown>, makeCtx());
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.reason).toContain('must be a string');
+    }
+  });
+
+  it('passes the inner unclosed-interpolation error up', () => {
+    const outcome = resolveServiceIntegrationParameters(
+      { Body: 'hello-${request.path.id' },
+      makeCtx()
+    );
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.reason).toContain('unclosed');
+      expect(outcome.reason).toContain('Body');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Re-export five `src/local` modules' pure, dependency-free helpers from the package entry (`src/index.ts`) plus their public types, so a host that shims cdk-local's `src/local` modules verbatim (e.g. cdkd) can re-export them 1:1 instead of carrying byte-identical copies:

- `pickRefLogicalId` (`intrinsic-utils`)
- `resolveLambdaArnIntrinsic` + `LambdaArnResolveOutcome` (`intrinsic-lambda-arn`)
- `resolveServiceIntegrationParameters` / `resolveSelectionExpression` + `RequestParameterContext` / `ResolveParametersOutcome` (`parameter-mapping`)
- `translateLambdaResponse` + `TranslatedHttpResponse` (`api-gateway-response`)
- `getContainerNetworkIp` (`docker-inspect`)

The set is driven by the consuming host's actual `import` statements, not added speculatively. (`bufferToBody` / `websocket-body` was dropped from this PR — its host shim is deferred to a later batch because the module needs spy-friendly export handling; it will be re-added with its shim + test then.)

Two supporting changes:

- **Test coverage moves to where the implementation lives.** These helpers had no unit tests in this repo; their tests lived only in the consuming host. Ported them into `tests/unit/local/` so the now-public surface is covered here.
- **Docs.** Documented the helpers in `docs/library-mode.md` under a new "Low-level building blocks (shim hosts)" section, framed as 1:1 re-export targets — not a recommended way to build a custom CLI (the factories remain the recommended path).

Purely additive to `src/index.ts`; no existing export changed. `feat` → minor version bump.

## Test plan

- [x] `vp run verify` (typecheck + lint + format-check + 288 unit tests, including the 4 ported) green
- [x] Built `dist/index.js` smoke test: all 6 functions importable from the package entry; all 4 new types present in `dist/index.d.ts`
- [x] No existing export removed/renamed (additive only)
