### PR TITLE
feat(from-cfn-stack): recover Lambda env GetAtt values from deployed function config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Use this for fast iteration on Lambda code, API routing checks, and container ta
 
 Once your stack is deployed to AWS (via the AWS CDK CLI or any other tool), pass `--from-cfn-stack <StackName>` and cdk-local reads the deployed CloudFormation stack to inject real ARNs, Secrets values, and IAM credentials (resolved from your current AWS profile) into the local execution.
 
+For Lambda (`invoke`, `start-api`), this also recovers env-var values that CloudFormation resolved at deploy time but `ListStackResources` does not expose — e.g. `SIBLING_ARN: Fn::GetAtt <OtherFunction>.Arn`. cdk-local reads the deployed function's own resolved `Environment.Variables` (via `lambda:GetFunctionConfiguration`) and fills those keys, so a Lambda that calls a sibling Lambda by ARN runs locally without a manual `--env-vars` entry. (These values enter the local container env in plaintext; Lambda env vars are a non-secret property, so this exposes nothing the deployed function doesn't already surface to any caller with `lambda:GetFunctionConfiguration`.)
+
 #### HTTP APIs & Function URLs — `start-api` (the headline use case)
 
 A local API talking to real AWS — point a frontend at it for end-to-end debugging, including real Cognito JWT verification.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -111,7 +111,7 @@ in the resolved stack so the user can copy/paste a valid one.
 | `--container-host <host>` | `127.0.0.1` | Host to bind the RIE port to. |
 | `--assume-role [arn]` | off | STS-assume the deployed function's execution role and forward the resulting temp credentials to the container, so the handler runs under the deployed role's narrow permissions instead of the developer's typically-admin shell credentials. Three forms: (1) `--assume-role <arn>` assumes the explicit ARN (precedence wins); (2) `--assume-role` (bare) auto-resolves the function's `Properties.Role` from the active state source (requires `--from-cfn-stack` or a host-provided extension); (3) `--no-assume-role` explicitly opts out. Off by default — when omitted, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` are passed through unchanged (SAM-compatible default). STS failures degrade to a warn + dev-creds fallback. |
 | `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers`. Use only when the dev credentials cannot read the layer — typically cross-account layers. AWS-published public layers (e.g. Lambda Powertools) are readable from every account and need no role. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` placeholders in env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the resolved stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `ListStackResources` does not return per-attribute values). See [CloudFormation-driven env recovery](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` placeholders in env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the resolved stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` (and other intrinsics `ListStackResources` can't resolve) in the Lambda's OWN env is recovered from the deployed function's resolved `Environment.Variables` via `lambda:GetFunctionConfiguration`. See [CloudFormation-driven env recovery](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region when `--from-cfn-stack` is set. |
 
 Plus the [common flags](#common-flags): `-a/--app`, `--output`,
@@ -179,15 +179,26 @@ pass).
 3. `--from-cfn-stack` substituted intrinsic (when the flag is set AND
    the template entry was a supported intrinsic AND substitution
    succeeded).
-4. Template literal value.
+4. `--from-cfn-stack` deployed-env fallback (the consumer function's own
+   deploy-time-resolved value, for intrinsic keys step 3 could not
+   resolve — see below).
+5. Template literal value.
 
-**`Fn::GetAtt` is warn-and-dropped** in v1. CFn's
-`ListStackResources` does NOT return per-attribute values — it only
-exposes `(LogicalResourceId, PhysicalResourceId, ResourceType)`
-triplets. Recovering per-attribute values would require per-service
-describe calls (e.g. `GetQueueAttributes` for SQS, `GetFunction` for
-Lambda), which is out of scope for v1. Override the affected env var
-via `--env-vars` if the value is critical.
+**`Fn::GetAtt` recovery**: CFn's `ListStackResources` does NOT return
+per-attribute values — it only exposes `(LogicalResourceId,
+PhysicalResourceId, ResourceType)` triplets — so `Fn::GetAtt` does not
+resolve against the resource map. cdk-local closes this for a Lambda's
+OWN env vars by reading the deployed function's already-resolved
+`Environment.Variables` via `lambda:GetFunctionConfiguration`
+(CloudFormation resolved every intrinsic at deploy time), so e.g.
+`SIBLING_ARN: Fn::GetAtt <OtherFunction>.Arn` is recovered without a
+manual override. The same fallback also covers `Fn::Sub` /
+`Fn::ImportValue` / cross-stack `Ref` in the env block. Keys not present
+in the deployed function's env (e.g. a var you added locally since the
+last deploy) still warn-and-drop — override via `--env-vars`. Recovered
+values enter the local container env in plaintext; Lambda env vars are a
+non-secret property, so this exposes nothing the deployed function
+doesn't already surface to a caller with `lambda:GetFunctionConfiguration`.
 
 **Region handling**: the CFn client is region-bound at construction
 time using the precedence `--stack-region` > `AWS_REGION` >
@@ -365,7 +376,7 @@ an error — they're mutually exclusive.
 | `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). For HTTP API v2 routes, `requestContext.stage` is always `$default` regardless of this flag (AWS-side limitation); only `event.stageVariables` is affected. For REST v1 the selected StageName is also threaded into `requestContext.stage`. |
 | `--api <id>` | unset | **Deprecated** — use the positional `<target>` argument instead. Same accepted forms. Emits a deprecation warn on use. |
 | `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers`. Same semantics as `cdkl invoke --layer-role-arn`. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in Lambda env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the routed stack's CDK name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` is warn-and-dropped in v1. Same warn-and-drop semantics as `cdkl invoke --from-cfn-stack`. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in Lambda env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the routed stack's CDK name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` (and other intrinsics `ListStackResources` can't resolve) in a routed Lambda's OWN env is recovered from the deployed function's resolved `Environment.Variables` via `lambda:GetFunctionConfiguration`. Same semantics as `cdkl invoke --from-cfn-stack`. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region for `--from-cfn-stack`. |
 | `--mtls-truststore <path>` | unset | PEM-encoded CA bundle for client-certificate verification. When set, the server switches from HTTP to HTTPS and the TLS handshake rejects clients whose certificate doesn't chain to one of these CAs. Must be set together with `--mtls-cert` + `--mtls-key`; partial flag sets are rejected. See [local-emulation.md](./local-emulation.md) for the openssl recipe + event-shape details. |
 | `--mtls-cert <path>` | unset | PEM-encoded server certificate for mutual TLS. Self-signed is fine for local dev. Must be set together with `--mtls-truststore` + `--mtls-key`. |

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -136,7 +136,7 @@ in the resolved stack so the user can copy/paste a valid one.
 | `--assume-role [arn]` | off | STS-assume the deployed function's execution role and forward the resulting temp credentials to the container, so the handler runs under the deployed role's narrow permissions instead of the developer's typically-admin shell credentials. Three forms: (1) `--assume-role <arn>` assumes the explicit ARN (precedence wins); (2) `--assume-role` (bare) auto-resolves the function's `Properties.Role` from the bound CloudFormation stack (requires `--from-cfn-stack`); (3) `--no-assume-role` explicitly opts out (forces dev creds even with `--from-cfn-stack`). Off by default — when omitted, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` are passed through unchanged (SAM-compatible default). STS failures degrade to a warn + dev-creds fallback. |
 | `-a, --app <cmd-or-dir>` | — | CDK app command or pre-synthesized `cdk.out` directory. Default: synth every time. Pass `-a cdk.out` to skip synthesis when iterating. |
 | `--output <dir>` | `cdk.out` | Output directory for synthesis. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in env vars with the deployed physical IDs / exports. Bare form uses the CDK stack name (typical case); pass an explicit value when the deployed CFn stack name differs (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` is warn-and-dropped in v1 (CFn `ListStackResources` does not return per-attribute values). See [CloudFormation-driven env recovery (`--from-cfn-stack`)](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in env vars with the deployed physical IDs / exports. Bare form uses the CDK stack name (typical case); pass an explicit value when the deployed CFn stack name differs (e.g. CDK's `stackName` prop was overridden). `Fn::GetAtt` (and other intrinsics `ListStackResources` can't resolve) in the Lambda's OWN env is recovered from the deployed function's resolved `Environment.Variables` via `lambda:GetFunctionConfiguration`. See [CloudFormation-driven env recovery (`--from-cfn-stack`)](#cloudformation-driven-env-recovery---from-cfn-stack) below. |
 | `--stack-region <region>` | auto | Region used to construct the CloudFormation client for `--from-cfn-stack`. Defaults to `--region` > `AWS_REGION` > `AWS_DEFAULT_REGION` > the synth-derived stack region. |
 | `--layer-role-arn <arn>` | — | Role ARN to assume before calling `lambda:GetLayerVersion` on literal-ARN layer entries. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for the GetLayerVersion call only — the assumed role is NOT propagated into the Lambda container at runtime (that's what `--assume-role` is for). Use this when the layer lives in a different account than the calling identity and direct cross-account access is not granted via the layer's resource policy. |
 
@@ -198,7 +198,10 @@ cdkl invoke MyStack/MyApi/Handler --from-cfn-stack \
 3. `--from-cfn-stack` substituted intrinsic (when the flag is set AND
    the template entry was a supported intrinsic AND substitution
    succeeded).
-4. Template literal value.
+4. `--from-cfn-stack` deployed-env fallback (the consumer function's own
+   deploy-time-resolved value, for intrinsic keys step 3 could not
+   resolve — see `Fn::GetAtt` recovery below).
+5. Template literal value.
 
 **What's resolved**: `Ref: <LogicalId>` against
 `ListStackResources` (paginated — every page is walked so stacks with
@@ -207,14 +210,21 @@ more than 100 resources are fully mapped), `Fn::ImportValue:
 for one substitution pass), and supported `Fn::Sub` / `Fn::Join` /
 `${AWS::*}` shapes via the same substitution engine.
 
-**`Fn::GetAtt` is warn-and-dropped** in v1. CFn's
-`ListStackResources` does NOT return per-attribute values — it only
-exposes `(LogicalResourceId, PhysicalResourceId, ResourceType)`
-triplets. Recovering per-attribute values would require provider-
-specific describe calls (e.g. `GetQueueAttributes` for SQS,
-`GetFunction` for Lambda), which is out of scope for the v1 cut.
-Override the affected env var via `--env-vars` if the value is
-critical.
+**`Fn::GetAtt` recovery**: CFn's `ListStackResources` does NOT return
+per-attribute values — it only exposes `(LogicalResourceId,
+PhysicalResourceId, ResourceType)` triplets — so `Fn::GetAtt` does not
+resolve against the resource map. For a Lambda's OWN env vars cdk-local
+closes this by reading the deployed function's already-resolved
+`Environment.Variables` via `lambda:GetFunctionConfiguration`
+(CloudFormation resolved every intrinsic at deploy time), so e.g.
+`SIBLING_ARN: Fn::GetAtt <OtherFunction>.Arn` is recovered without a
+manual override. The same fallback covers `Fn::Sub` / `Fn::ImportValue`
+/ cross-stack `Ref` in the env block. Keys absent from the deployed
+function's env (e.g. a var added locally since the last deploy) still
+warn-and-drop — override via `--env-vars`. Recovered values enter the
+local container env in plaintext; Lambda env vars are a non-secret
+property, so this exposes nothing the deployed function doesn't already
+surface to a caller with `lambda:GetFunctionConfiguration`.
 
 **Auto-assume execution role**: when `--from-cfn-stack` is paired with
 bare `--assume-role` (no ARN argument), cdk-local reads the function's
@@ -260,10 +270,13 @@ only affect `Fn::ImportValue` resolution; same-stack `Ref`
 substitutions still succeed because they only need the
 `ListStackResources` result.
 
-**Out of scope** (deferred): `Fn::GetAtt` (warn + drop today), other
-intrinsics (`Fn::Select`, `Fn::Split`, `Fn::If`, etc.). Anything beyond
-the listed supported intrinsics is treated as unresolved (warn +
-drop).
+**Out of scope** (deferred): the substitution engine itself still does
+not resolve `Fn::GetAtt` or other intrinsics (`Fn::Select`, `Fn::Split`,
+`Fn::If`, etc.) against the resource map — but for a Lambda's own env the
+deployed-env fallback above recovers `Fn::GetAtt` (and `Fn::Sub` /
+`Fn::ImportValue` / cross-stack `Ref`) from the deployed function config.
+Intrinsics with no deployed-env counterpart are treated as unresolved
+(warn + drop).
 
 ### Asset resolution
 
@@ -394,8 +407,8 @@ same sized `/tmp`.
 | Out of scope | Deferred to |
 | --- | --- |
 | Cross-account / cross-region / pre-existing-ARN Lambda Layers | Future PR (same-stack `AWS::Lambda::LayerVersion` refs are supported in v1; literal ARNs hard-error — see "Lambda Layers" section above) |
-| `Fn::GetAtt` in `--from-cfn-stack` (CFn API limitation) | Future PR (warn + drop today) |
-| `Fn::Select` / `Fn::Split` / `Fn::If` etc. in `--from-cfn-stack` | Future PR (warn + drop today) |
+| `Fn::GetAtt` in `--from-cfn-stack` Lambda env | Recovered from the deployed function's `Environment.Variables` (`lambda:GetFunctionConfiguration`) |
+| `Fn::Select` / `Fn::Split` / `Fn::If` etc. in `--from-cfn-stack` (substitution engine) | Future PR (warn + drop today, unless present in the deployed function's env) |
 | SQS / S3 event source emulation | Future PR |
 | VPC simulation | Never (local can't replicate VPC) |
 | Custom Resources (`Custom::*`) | Never — these are invoked by the deploy framework, not by users. cdk-local surfaces a clear error pointing at the underlying ServiceToken Lambda. |
@@ -564,7 +577,7 @@ the same tier; cdk-local uses literal-segment count as a heuristic).
 | `--assume-role <arn-or-pair>` | unset | Repeatable. Bare `<arn>` = global default; `<LogicalId>=<arn>` = per-Lambda override. Per-Lambda > global > unset (developer creds passed through). |
 | `--watch` | off | Hot reload: re-synth + re-discover routes when `cdk.out/` or any routed Lambda's asset directory changes. 500ms debounce. Synth failures keep the previous version serving (warn-and-continue, never crashes the server). |
 | `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). When the override doesn't match any Stage on a given API, that API's routes get `stageVariables: null` and the CLI emits a warn line up front. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters in Lambda env vars with the deployed physical IDs / exports. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the CDK stack name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). The explicit form is rejected when more than one stack is routed in one invocation; the bare form is fine for multi-stack. `Fn::GetAtt` is warn-and-dropped in v1. Re-runs against fresh CFn data on every hot-reload firing (`--watch`). ListStackResources failures degrade per-stack to warn-and-fall-back so an unreadable stack never aborts the server. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters in Lambda env vars with the deployed physical IDs / exports. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the CDK stack name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). The explicit form is rejected when more than one stack is routed in one invocation; the bare form is fine for multi-stack. `Fn::GetAtt` (and other intrinsics `ListStackResources` can't resolve) in a routed Lambda's OWN env is recovered from the deployed function's resolved `Environment.Variables` via `lambda:GetFunctionConfiguration`. Re-runs against fresh CFn data on every hot-reload firing (`--watch`). ListStackResources failures degrade per-stack to warn-and-fall-back so an unreadable stack never aborts the server. |
 | `--stack-region <region>` | auto | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
 | `--mtls-truststore <path>` | unset | PEM-encoded CA bundle for client-certificate verification. When set, the server switches from HTTP to HTTPS and the TLS handshake rejects clients whose certificate doesn't chain to one of these CAs. Must be set together with `--mtls-cert` + `--mtls-key`; partial flag sets are rejected. See the "mTLS (mutual TLS)" section below for the openssl recipe + event-shape details. |
 | `--mtls-cert <path>` | unset | PEM-encoded server certificate for mutual TLS. Self-signed is fine for local dev. Must be set together with `--mtls-truststore` + `--mtls-key`. |

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -33,6 +33,7 @@ import {
 import { materializeLayerFromArn } from '../../local/layer-arn-materializer.js';
 import { resolveEnvVars, type EnvOverrideFile } from '../../local/env-resolver.js';
 import {
+  applyDeployedEnvFallback,
   substituteEnvVarsFromStateAsync,
   type StateEnvSubstitutionAudit,
   type SubstitutionContext,
@@ -336,12 +337,33 @@ async function localInvokeCommand(
           }
           const { env, audit } = await substituteEnvVarsFromStateAsync(templateEnv, subContext);
           templateEnv = env;
-          stateAudit = audit;
           const label = stateProvider.label;
           for (const key of audit.resolvedKeys) {
             logger.debug(`${label}: substituted env var ${key}`);
           }
-          for (const { key, reason } of audit.unresolved) {
+          // Deployed-env fallback: keys whose intrinsic value the static
+          // substituter could not resolve (e.g. `Fn::GetAtt <Sibling>.Arn`)
+          // are filled from the consumer function's deploy-time-resolved
+          // `Environment.Variables`. Only the CFn provider implements
+          // `resolveDeployedFunctionEnv`; the S3 provider's state already
+          // carries deploy-time attributes so its GetAtt resolves above.
+          let unresolved = audit.unresolved;
+          const resolvedKeys = [...audit.resolvedKeys];
+          if (unresolved.length > 0 && stateProvider.resolveDeployedFunctionEnv) {
+            const physicalId = loaded.resources[lambda.logicalId]?.physicalId;
+            if (physicalId) {
+              const deployedEnv = await stateProvider.resolveDeployedFunctionEnv(physicalId);
+              const fb = applyDeployedEnvFallback(templateEnv, unresolved, deployedEnv);
+              templateEnv = fb.env;
+              unresolved = fb.stillUnresolved;
+              for (const key of fb.filled) {
+                resolvedKeys.push(key);
+                logger.debug(`${label}: filled env var ${key} from deployed function config`);
+              }
+            }
+          }
+          stateAudit = { resolvedKeys, unresolved };
+          for (const { key, reason } of unresolved) {
             logger.warn(
               `${label}: could not substitute env var ${key} (${reason}). ` +
                 `Override it via --env-vars or it will be dropped.`

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -3078,7 +3078,7 @@ function hasExtraStateProviderActive(
   return false;
 }
 
-async function loadStateForRoutedStacks(
+export async function loadStateForRoutedStacks(
   stacks: readonly StackInfo[],
   routes: readonly DiscoveredRoute[],
   routesWithAuth: readonly RouteWithAuth[],

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -34,6 +34,7 @@ import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../../types/resource.js';
 import type { StackState } from '../../types/state.js';
 import {
+  applyDeployedEnvFallback,
   substituteEnvVarsFromState,
   type PseudoParameters,
   type SubstitutionContext,
@@ -1742,11 +1743,29 @@ async function buildContainerSpec(args: {
     }
     const { env, audit } = substituteEnvVarsFromState(templateEnv, context);
     templateEnv = env;
-    stateAudit = audit;
     for (const key of audit.resolvedKeys) {
       getLogger().debug(`Lambda ${logicalId}: state source substituted env var ${key}`);
     }
-    for (const { key, reason } of audit.unresolved) {
+    // Deployed-env fallback: fill keys static substitution dropped (e.g.
+    // `Fn::GetAtt <Sibling>.Arn`) from the consumer function's
+    // deploy-time-resolved env, fetched during the state-load pass (see
+    // `loadStateForRoutedStacks`). Only populated under `--from-cfn-stack`.
+    let unresolved = audit.unresolved;
+    const resolvedKeys = [...audit.resolvedKeys];
+    const deployedEnv = stateBundle.deployedEnvByLambda?.get(logicalId);
+    if (unresolved.length > 0 && deployedEnv) {
+      const fb = applyDeployedEnvFallback(templateEnv, unresolved, deployedEnv);
+      templateEnv = fb.env;
+      unresolved = fb.stillUnresolved;
+      for (const key of fb.filled) {
+        resolvedKeys.push(key);
+        getLogger().debug(
+          `Lambda ${logicalId}: filled env var ${key} from deployed function config`
+        );
+      }
+    }
+    stateAudit = { resolvedKeys, unresolved };
+    for (const { key, reason } of unresolved) {
       getLogger().warn(
         `Lambda ${logicalId}: state source could not substitute env var ${key} (${reason}). ` +
           `Override it via --env-vars or it will be dropped.`
@@ -2999,6 +3018,15 @@ interface StackStateBundle {
    * refs).
    */
   pseudoParameters?: PseudoParameters;
+  /**
+   * Deploy-time-resolved `Environment.Variables` per reachable Lambda
+   * logical ID, fetched while the `--from-cfn-stack` provider was alive.
+   * Consumed by `buildContainerSpec` to fill env keys whose intrinsic
+   * value the static substituter could not resolve (e.g.
+   * `Fn::GetAtt <Sibling>.Arn`). `undefined`/absent for stacks where no
+   * provider implements the deployed-env fallback (e.g. `--from-state`).
+   */
+  deployedEnvByLambda?: Map<string, Record<string, string>>;
 }
 
 /**
@@ -3139,6 +3167,27 @@ async function loadStateForRoutedStacks(
       if (stackHasIntrinsicEnv(stackName)) {
         const pseudo = await resolvePseudoParametersForStartApi(loaded.region, options);
         if (pseudo) bundle.pseudoParameters = pseudo;
+      }
+      // Deployed-env fallback source: for each reachable Lambda in this
+      // stack whose template env carries an intrinsic, fetch the deployed
+      // function's already-resolved `Environment.Variables` while the
+      // provider (and its AWS client) is still alive. `buildContainerSpec`
+      // later splices these in for keys static substitution dropped (e.g.
+      // `Fn::GetAtt <Sibling>.Arn`). Only the CFn provider implements
+      // `resolveDeployedFunctionEnv`; `--from-state` carries deploy-time
+      // attributes in its state so its GetAtt resolves statically.
+      if (provider.resolveDeployedFunctionEnv) {
+        const deployedEnvByLambda = new Map<string, Record<string, string>>();
+        for (const logicalId of lambdaIds) {
+          const resource = stack.template.Resources?.[logicalId];
+          if (!resource || resource.Type !== 'AWS::Lambda::Function') continue;
+          if (!envHasIntrinsicValue(getTemplateEnv(resource))) continue;
+          const physicalId = loaded.resources[logicalId]?.physicalId;
+          if (!physicalId) continue;
+          const deployedEnv = await provider.resolveDeployedFunctionEnv(physicalId);
+          if (deployedEnv) deployedEnvByLambda.set(logicalId, deployedEnv);
+        }
+        if (deployedEnvByLambda.size > 0) bundle.deployedEnvByLambda = deployedEnvByLambda;
       }
       out.set(stackName, bundle);
       logger.debug(`${provider.label}: loaded state for ${stackName} (${loaded.region})`);

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -18,13 +18,18 @@
  *     map built from `ListStackResources.StackResourceSummaries[]` (one
  *     entry per `(LogicalResourceId, PhysicalResourceId, ResourceType)`
  *     tuple).
- *   - `Fn::GetAtt: [<LogicalId>, <Attr>]` → **warn-and-drop**. CFn's
- *     `ListStackResources` does NOT return per-attribute values
- *     and the v1 policy (issue #606 recommendation (a)) is to surface
- *     a per-key warn instead of pulling in the full provisioning layer
- *     to call provider-specific describe APIs (e.g. `GetQueueAttributes`
- *     for SQS, `GetFunction` for Lambda). Users override the affected
- *     env var via `--env-vars` if the value is critical.
+ *   - `Fn::GetAtt: [<LogicalId>, <Attr>]` → not resolvable from
+ *     `ListStackResources` (which returns physical IDs only, no
+ *     per-attribute values). For a Lambda function's OWN env vars this
+ *     gap is closed by {@link CfnLocalStateProvider.resolveDeployedFunctionEnv}:
+ *     because `--from-cfn-stack` means the consumer function is itself
+ *     deployed, CloudFormation already resolved every intrinsic (incl.
+ *     `Fn::GetAtt <Sibling>.Arn`) into the function's
+ *     `Environment.Variables` at deploy time, so the env-substitution
+ *     layer reads the concrete value back via
+ *     `lambda:GetFunctionConfiguration`. Intrinsic values that are NOT a
+ *     consumer-Lambda env var (e.g. an ECS container env entry) still
+ *     warn-and-drop and can be overridden via `--env-vars`.
  *   - `Fn::ImportValue: <exportName>` → resolved via `ListExports`
  *     (paginated). Same-region only — CFn exports are region-scoped.
  *   - `Fn::GetStackOutput` → rejected with a clear pointer that the
@@ -63,6 +68,7 @@ import {
   ListExportsCommand,
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
+import { LambdaClient, GetFunctionConfigurationCommand } from '@aws-sdk/client-lambda';
 import { getLogger } from '../utils/logger.js';
 import type { ResourceState } from '../types/state.js';
 import type { CrossStackResolver } from './state-resolver.js';
@@ -111,6 +117,11 @@ export class CfnLocalStateProvider implements LocalStateProvider {
   // exercises the provider (e.g. when the synth template has no
   // intrinsic-valued env vars) doesn't open a needless client.
   private client: CloudFormationClient | undefined;
+  // The Lambda client is constructed lazily on the first
+  // `resolveDeployedFunctionEnv` call so invocations that never need the
+  // deployed-env fallback (no unresolvable intrinsic in any consumer
+  // Lambda's env) don't open a needless client.
+  private lambdaClient: LambdaClient | undefined;
   private readonly clientOptions: { region: string; profile?: string };
   // Issue #611 NIT 2: `dispose()` is terminal. The lazy `getClient()`
   // path would otherwise resurrect the client on a post-dispose
@@ -145,6 +156,56 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       });
     }
     return this.client;
+  }
+
+  private getLambdaClient(): LambdaClient {
+    if (this.disposed) {
+      throw new Error('CfnLocalStateProvider used after dispose()');
+    }
+    if (!this.lambdaClient) {
+      this.lambdaClient = new LambdaClient({
+        region: this.region,
+        ...(this.clientOptions.profile !== undefined && { profile: this.clientOptions.profile }),
+      });
+    }
+    return this.lambdaClient;
+  }
+
+  /**
+   * Read a deployed Lambda function's already-resolved
+   * `Environment.Variables` via `lambda:GetFunctionConfiguration`. See
+   * {@link LocalStateProvider.resolveDeployedFunctionEnv} for why this
+   * closes the `Fn::GetAtt`/`Fn::Sub`/cross-stack gap for a consumer
+   * function's own env vars.
+   *
+   * Best-effort: on any expected miss (function not found, access
+   * denied, throttling) logs a warn and returns `undefined` so the
+   * caller falls back to warn-and-drop on the affected keys. Never
+   * throws out of the substitution pass.
+   */
+  public async resolveDeployedFunctionEnv(
+    functionPhysicalId: string
+  ): Promise<Record<string, string> | undefined> {
+    if (this.disposed) {
+      throw new Error('CfnLocalStateProvider used after dispose()');
+    }
+    const logger = getLogger();
+    const client = this.getLambdaClient();
+    try {
+      const resp = await client.send(
+        new GetFunctionConfigurationCommand({ FunctionName: functionPhysicalId })
+      );
+      // `Environment.Variables` is the deploy-time-resolved map. Absent
+      // when the function declares no env vars — treat as empty so the
+      // caller's fallback simply fills nothing.
+      return resp.Environment?.Variables ?? {};
+    } catch (err) {
+      logger.warn(
+        `${this.label}: GetFunctionConfiguration(${functionPhysicalId}) failed: ${formatAwsErrorForWarn(err)}. ` +
+          `Intrinsic-valued env vars that need the deployed value will warn-and-drop (grant lambda:GetFunctionConfiguration or override via --env-vars).`
+      );
+      return undefined;
+    }
   }
 
   /**
@@ -294,6 +355,10 @@ export class CfnLocalStateProvider implements LocalStateProvider {
     if (this.client) {
       this.client.destroy();
       this.client = undefined;
+    }
+    if (this.lambdaClient) {
+      this.lambdaClient.destroy();
+      this.lambdaClient = undefined;
     }
   }
 }

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -45,10 +45,13 @@ import type { CrossStackResolver } from './state-resolver.js';
 export interface LocalStateRecord {
   /**
    * Per-logical-id resource records. Covers `Ref: <logicalId>` lookups
-   * via `physicalId`. The CFn provider also leaves `attributes` empty —
-   * `ListStackResources` does not return per-attribute values, and
-   * the v1 policy is warn-and-drop for unresolvable `Fn::GetAtt` (per
-   * issue #606's recommendation (a)).
+   * via `physicalId`. The CFn provider leaves `attributes` empty —
+   * `ListStackResources` does not return per-attribute values, so
+   * `Fn::GetAtt` does not resolve statically against this map. For a
+   * consumer Lambda's own env vars that gap is closed at runtime by
+   * {@link LocalStateProvider.resolveDeployedFunctionEnv} (reads the
+   * deployed function's already-resolved env); other `Fn::GetAtt` sites
+   * still warn-and-drop.
    */
   resources: Record<string, ResourceState>;
   /**
@@ -114,6 +117,36 @@ export interface LocalStateProvider {
    * case.
    */
   buildCrossStackResolver(consumerRegion: string): Promise<CrossStackResolver | undefined>;
+  /**
+   * Optional: read a deployed Lambda function's already-resolved
+   * environment variables, keyed by env-var name. Used as a last-resort
+   * fill for env keys whose template value is a CloudFormation intrinsic
+   * the static substituter could not resolve (e.g. `Fn::GetAtt
+   * <SiblingFn>.Arn`, which `ListStackResources` does not return an
+   * attribute for). CloudFormation resolved every intrinsic at deploy
+   * time, so the deployed function's `Environment.Variables` already
+   * carries the concrete value — reading it covers `Fn::GetAtt` /
+   * `Fn::Sub` / `Fn::ImportValue` / cross-stack `Ref` uniformly without
+   * per-resource-type reconstruction.
+   *
+   * `functionPhysicalId` is the deployed function name / ARN (the `Ref`
+   * value `ListStackResources` returns for `AWS::Lambda::Function`).
+   * Returns `undefined` on any expected miss (no such function, access
+   * denied, throttling) so the caller falls back to warn-and-drop.
+   *
+   * Implemented only by the CFn provider (`--from-cfn-stack`) — the S3
+   * provider's state already carries deploy-time attributes, so its
+   * `Fn::GetAtt` resolves statically and no fallback is needed. Optional
+   * so existing / host-extension providers need not implement it.
+   *
+   * Note: `Environment.Variables` is a plaintext, non-secret-intended
+   * property (AWS surfaces it to any caller with
+   * `lambda:GetFunctionConfiguration`); recovered values land in the
+   * local container env. Callers must never log the values.
+   */
+  resolveDeployedFunctionEnv?(
+    functionPhysicalId: string
+  ): Promise<Record<string, string> | undefined>;
   /**
    * Release any AWS clients the provider owns. Always called by the
    * CLI layer in the outer `finally`. Idempotent.

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -1075,3 +1075,51 @@ export async function substituteEnvVarsFromStateAsync(
 
   return { env, audit };
 }
+
+/**
+ * Last-resort fill for env keys that static substitution could not
+ * resolve, using the consumer resource's already-deployed environment.
+ *
+ * When a Lambda / container is bound to a deployed CloudFormation stack
+ * (`--from-cfn-stack`), the consumer itself is deployed, so CloudFormation
+ * already resolved every intrinsic (`Fn::GetAtt`, `Fn::Sub`,
+ * `Fn::ImportValue`, cross-stack `Ref`) into its concrete deployed env
+ * value. `ListStackResources` does not return per-attribute values, so
+ * the static substituter drops those keys — but the deployed env carries
+ * the answer. The provider fetches the deployed env (e.g.
+ * `lambda:GetFunctionConfiguration`) and this helper splices it in for
+ * the keys that remained unresolved.
+ *
+ * Precedence: only keys in `unresolved` are touched — statically resolved
+ * keys and literal keys are left exactly as the substituter produced
+ * them, and a `--env-vars` override still wins downstream. Keys absent
+ * from `deployedEnv` stay unresolved so the caller's warn-and-drop fires.
+ *
+ * Pure: returns new arrays / a new env map, never mutates the inputs.
+ */
+export function applyDeployedEnvFallback(
+  resolvedEnv: Record<string, unknown>,
+  unresolved: ReadonlyArray<{ key: string; reason: string }>,
+  deployedEnv: Record<string, string> | undefined
+): {
+  env: Record<string, unknown>;
+  filled: string[];
+  stillUnresolved: Array<{ key: string; reason: string }>;
+} {
+  if (!deployedEnv) {
+    return { env: resolvedEnv, filled: [], stillUnresolved: [...unresolved] };
+  }
+  const env = { ...resolvedEnv };
+  const filled: string[] = [];
+  const stillUnresolved: Array<{ key: string; reason: string }> = [];
+  for (const item of unresolved) {
+    const deployedValue = deployedEnv[item.key];
+    if (deployedValue !== undefined) {
+      env[item.key] = deployedValue;
+      filled.push(item.key);
+    } else {
+      stillUnresolved.push({ key: item.key, reason: item.reason });
+    }
+  }
+  return { env, filled, stillUnresolved };
+}

--- a/tests/integration/local-invoke-from-cfn-stack/lambda/index.js
+++ b/tests/integration/local-invoke-from-cfn-stack/lambda/index.js
@@ -1,9 +1,11 @@
 // Echoes back the env vars the container saw. The integ asserts that
-// TABLE_NAME is the deployed DynamoDB table's actual physical name (not
-// the literal string "${Token[...]}" or the unresolved intrinsic shape).
+// TABLE_NAME is the deployed DynamoDB table's actual physical name and
+// SIBLING_ARN is the deployed sibling function's actual ARN (not the
+// literal "${Token[...]}" or the unresolved intrinsic shape).
 exports.handler = async (event) => {
   return {
     tableName: process.env.TABLE_NAME ?? 'unset',
+    siblingArn: process.env.SIBLING_ARN ?? 'unset',
     staticValue: process.env.STATIC_VALUE ?? 'unset',
     event,
   };

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -112,6 +112,31 @@ if [ -z "${DEPLOYED_TABLE}" ] || [ "${DEPLOYED_TABLE}" = "None" ]; then
   exit 1
 fi
 
+echo "[verify] step 4b: read the deployed sibling Lambda ARN (for the GetAtt fallback assertion)"
+# SIBLING_ARN is a Fn::GetAtt .Arn env var that ListStackResources cannot
+# resolve; the deployed-env fallback recovers it from the echo function's
+# own deployed Environment.Variables. The sibling's physical id is its
+# function NAME, so resolve the full ARN via lambda:GetFunction.
+SIBLING_NAME=$(aws cloudformation describe-stack-resources \
+  --stack-name "${STACK}" \
+  --region "${REGION}" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function' && contains(LogicalResourceId, 'SiblingHandler')].PhysicalResourceId | [0]" \
+  --output text)
+if [ -z "${SIBLING_NAME}" ] || [ "${SIBLING_NAME}" = "None" ]; then
+  echo "[verify] FAIL: could not read deployed sibling function name from CloudFormation"
+  exit 1
+fi
+DEPLOYED_SIBLING_ARN=$(aws lambda get-function \
+  --function-name "${SIBLING_NAME}" \
+  --region "${REGION}" \
+  --query 'Configuration.FunctionArn' \
+  --output text)
+echo "[verify]   deployed sibling ARN: ${DEPLOYED_SIBLING_ARN}"
+if [ -z "${DEPLOYED_SIBLING_ARN}" ] || [ "${DEPLOYED_SIBLING_ARN}" = "None" ]; then
+  echo "[verify] FAIL: could not read deployed sibling ARN from Lambda"
+  exit 1
+fi
+
 # Local invoke is flaky on cold dockers: the rie-client's TCP probe can
 # succeed before RIE has fully wired up its HTTP listener, producing a
 # `TypeError: fetch failed`. Retry up to 3 times so a hot-cache run (the
@@ -144,6 +169,10 @@ echo "${RESULT_BASELINE}" | grep -q '"tableName":"unset"' || {
   echo "[verify] FAIL: expected TABLE_NAME to be dropped (default warn-and-drop), got: ${RESULT_BASELINE}"
   exit 1
 }
+echo "${RESULT_BASELINE}" | grep -q '"siblingArn":"unset"' || {
+  echo "[verify] FAIL: expected SIBLING_ARN to be dropped (GetAtt warn-and-drop), got: ${RESULT_BASELINE}"
+  exit 1
+}
 echo "${RESULT_BASELINE}" | grep -q '"staticValue":"always-the-same"' || {
   echo "[verify] FAIL: expected STATIC_VALUE=always-the-same in baseline response, got: ${RESULT_BASELINE}"
   exit 1
@@ -159,6 +188,10 @@ echo "${RESULT_FROM_CFN}" | grep -q "\"tableName\":\"${DEPLOYED_TABLE}\"" || {
   echo "[verify] FAIL: expected TABLE_NAME=${DEPLOYED_TABLE}, got: ${RESULT_FROM_CFN}"
   exit 1
 }
+echo "${RESULT_FROM_CFN}" | grep -q "\"siblingArn\":\"${DEPLOYED_SIBLING_ARN}\"" || {
+  echo "[verify] FAIL: expected SIBLING_ARN=${DEPLOYED_SIBLING_ARN} (deployed-env GetAtt fallback), got: ${RESULT_FROM_CFN}"
+  exit 1
+}
 echo "${RESULT_FROM_CFN}" | grep -q '"staticValue":"always-the-same"' || {
   echo "[verify] FAIL: STATIC_VALUE regressed under --from-cfn-stack, got: ${RESULT_FROM_CFN}"
   exit 1
@@ -169,4 +202,6 @@ cdk destroy "${STACK}" --force --region "${REGION}" \
   --no-version-reporting --no-asset-metadata --no-path-metadata
 
 echo ""
-echo "[verify] All checks passed: --from-cfn-stack substituted TABLE_NAME with the deployed table name."
+echo "[verify] All checks passed:"
+echo "[verify]   - existing behavior intact: TABLE_NAME (Ref) substituted, STATIC_VALUE (literal) passed through, baseline drops both intrinsics."
+echo "[verify]   - new behavior: SIBLING_ARN (Fn::GetAtt .Arn) recovered from the deployed function's resolved env."

--- a/tests/integration/local-start-api-from-cfn-stack/.gitignore
+++ b/tests/integration/local-start-api-from-cfn-stack/.gitignore
@@ -1,0 +1,3 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is tracked.
+!lambda/*.js

--- a/tests/integration/local-start-api-from-cfn-stack/.scenarios.json
+++ b/tests/integration/local-start-api-from-cfn-stack/.scenarios.json
@@ -1,0 +1,6 @@
+{
+  "scenarios": [
+    "local-from-cfn-stack-substitution",
+    "local-apigateway-server"
+  ]
+}

--- a/tests/integration/local-start-api-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-api-from-cfn-stack/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartApiFromCfnStackStack } from '../lib/local-start-api-from-cfn-stack-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartApiFromCfnStackStack(app, 'CdkLocalStartApiFromCfnStackFixture', {
+  description: 'Fixture stack for cdkl start-api --from-cfn-stack integ test',
+});

--- a/tests/integration/local-start-api-from-cfn-stack/cdk.json
+++ b/tests/integration/local-start-api-from-cfn-stack/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-api-from-cfn-stack/lambda/index.js
+++ b/tests/integration/local-start-api-from-cfn-stack/lambda/index.js
@@ -1,0 +1,16 @@
+// Function URL handler that echoes back (as a JSON HTTP body) the env
+// vars the container saw. The integ asserts that under --from-cfn-stack
+// TABLE_NAME is the deployed table name (Ref) and SIBLING_ARN is the
+// deployed sibling function ARN (Fn::GetAtt .Arn, recovered via the
+// deployed-env fallback), while STATIC_VALUE passes through unchanged.
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      tableName: process.env.TABLE_NAME ?? 'unset',
+      siblingArn: process.env.SIBLING_ARN ?? 'unset',
+      staticValue: process.env.STATIC_VALUE ?? 'unset',
+    }),
+  };
+};

--- a/tests/integration/local-start-api-from-cfn-stack/lib/local-start-api-from-cfn-stack-stack.ts
+++ b/tests/integration/local-start-api-from-cfn-stack/lib/local-start-api-from-cfn-stack-stack.ts
@@ -8,30 +8,26 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Fixture stack for `cdkl invoke --from-cfn-stack` (issue #606).
+ * Fixture stack for `cdkl start-api --from-cfn-stack`.
  *
- * One echo Lambda + one DynamoDB table + one sibling Lambda. The echo
- * Lambda's env exercises two distinct intrinsic shapes:
+ * The originally-reported bug was on `start-api`: an env var set to
+ * `Fn::GetAtt <SiblingFn>.Arn` warn-and-dropped under `--from-cfn-stack`
+ * because `ListStackResources` returns physical IDs only (no attributes).
+ * The deployed-env fallback closes that gap by reading the consumer
+ * function's deploy-time-resolved `Environment.Variables`.
  *
- *   - `TABLE_NAME: Ref MyTable` — resolved from `ListStackResources`
- *     physical IDs (the original #606 path).
- *   - `SIBLING_ARN: Fn::GetAtt SiblingHandler.Arn` — NOT returned by
- *     `ListStackResources` (which carries physical IDs only, no
- *     attributes). Without `--from-cfn-stack` it warns-and-drops; with
- *     `--from-cfn-stack` the deployed-env fallback reads the echo
- *     function's already-resolved `Environment.Variables` via
- *     `lambda:GetFunctionConfiguration` (CloudFormation resolved the
- *     GetAtt to the sibling's real ARN at deploy time).
+ * The echo Lambda is fronted by a Function URL so `cdkl start-api` can
+ * route to it. Its env exercises two intrinsic shapes:
  *
- * Without `--from-cfn-stack` both intrinsics drop (same warn-and-drop
- * semantics as the `local-invoke-from-state` fixture). With it, after
- * the CDK app is deployed via the upstream `cdk deploy` (the CDK CLI, not
- * a host CLI like cdkd), both flow through to the container.
+ *   - `TABLE_NAME: Ref MyTable` — resolved from ListStackResources
+ *     physical IDs (the existing #606 behavior — regression guard).
+ *   - `SIBLING_ARN: Fn::GetAtt SiblingHandler.Arn` — recovered via the
+ *     deployed-env fallback (the new behavior).
  *
- * Table carries `removalPolicy: DESTROY` so the integ teardown is
- * fully self-contained on `cdk destroy`.
+ * Table carries `removalPolicy: DESTROY` so `cdk destroy` fully tears
+ * the fixture down.
  */
-export class LocalInvokeFromCfnStackStack extends cdk.Stack {
+export class LocalStartApiFromCfnStackStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
@@ -51,7 +47,7 @@ export class LocalInvokeFromCfnStackStack extends cdk.Stack {
       timeout: cdk.Duration.seconds(10),
     });
 
-    new lambda.Function(this, 'EchoTableHandler', {
+    const echo = new lambda.Function(this, 'EchoHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
@@ -70,5 +66,7 @@ export class LocalInvokeFromCfnStackStack extends cdk.Stack {
       },
       timeout: cdk.Duration.seconds(10),
     });
+
+    echo.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE });
   }
 }

--- a/tests/integration/local-start-api-from-cfn-stack/package.json
+++ b/tests/integration/local-start-api-from-cfn-stack/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-api-from-cfn-stack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-api --from-cfn-stack",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-api-from-cfn-stack/tsconfig.json
+++ b/tests/integration/local-start-api-from-cfn-stack/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-api-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-api-from-cfn-stack/verify.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkl start-api --from-cfn-stack`.
+#
+# Why this exists: the originally-reported bug was on `start-api` — an
+# env var set to `Fn::GetAtt <SiblingFn>.Arn` warn-and-dropped under
+# `--from-cfn-stack` because `ListStackResources` returns physical IDs
+# only (no attributes). This integ deploys a fixture stack via the
+# upstream `cdk deploy` (CloudFormation, not a host CLI), starts the
+# Function-URL-fronted echo Lambda locally with `cdkl start-api`, and
+# asserts BOTH:
+#   - existing behavior: TABLE_NAME (Ref) substitutes, STATIC_VALUE
+#     (literal) passes through, and the baseline (no flag) drops both
+#     intrinsics.
+#   - new behavior: SIBLING_ARN (Fn::GetAtt .Arn) is recovered from the
+#     deployed function's already-resolved Environment.Variables.
+#
+# Steps:
+#   1. install + build cdk-local (root) + docker pull
+#   2. cdk deploy CdkLocalStartApiFromCfnStackFixture (upstream CDK CLI)
+#   3. read deployed table name + sibling ARN from AWS
+#   4. baseline: cdkl start-api (no flag) — assert TABLE_NAME / SIBLING_ARN
+#      come through as "unset" (intrinsic-valued, default warn-and-drop).
+#   5. cdkl start-api --from-cfn-stack — assert TABLE_NAME is the deployed
+#      table name and SIBLING_ARN is the deployed sibling ARN.
+#   6. cdk destroy --force
+#
+# Run via `/run-integ local-start-api-from-cfn-stack` (recommended) or:
+#
+#     bash tests/integration/local-start-api-from-cfn-stack/verify.sh
+#
+# Requires Docker AND AWS credentials with deploy permissions. Also
+# requires the global `cdk` (aws-cdk) CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalStartApiFromCfnStackFixture"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+CONTAINER_HOST="127.0.0.1"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-start-api-from-cfn-stack"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed)"
+
+echo "[verify] step 1a: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+
+echo "[verify] step 1b: verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "[verify] step 1c: pulling ${IMAGE} (one-time, ~600MB if not cached)"
+docker pull "${IMAGE}"
+
+LOG_FILE="$(mktemp)"
+SERVER_PID=""
+
+# Stop the running start-api server (if any) between the baseline and
+# --from-cfn-stack passes, and on exit. SIGTERM -> 60s grace -> SIGKILL.
+stop_server() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill -TERM "${SERVER_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      kill -0 "${SERVER_PID}" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "${SERVER_PID}" 2>/dev/null; then
+      kill -KILL "${SERVER_PID}" 2>/dev/null || true
+    fi
+  fi
+  SERVER_PID=""
+}
+
+# Gate the stack cleanup on a "we created the stack" sentinel so the EXIT
+# trap never destroys a pre-existing same-named stack found by the
+# pre-flight scan.
+WE_CREATED_STACK=0
+cleanup() {
+  rc=$?
+  stop_server
+  # Defense-in-depth: kill every cdkl-* container regardless of how the
+  # server cleaned up (catches a server that crashed before dispose()).
+  ORPHANS=$(docker ps --filter "name=cdkl-" --format "{{.ID}}" 2>/dev/null || true)
+  if [[ -n "${ORPHANS}" ]]; then
+    echo "[verify] cleaning up orphan containers"
+    echo "${ORPHANS}" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  fi
+  if [ "${rc}" -ne 0 ] && [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] FAIL (exit ${rc}) — attempting cdk destroy to clean up"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  rm -f "${LOG_FILE}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists in CloudFormation — clean up first via:"
+  echo "          aws cloudformation delete-stack --stack-name ${STACK} --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 3: cdk deploy (upstream CDK CLI)"
+# Set the sentinel BEFORE `cdk deploy`: pre-flight verified the namespace
+# is clean, so once we issue the deploy we OWN it (cdk destroy is a no-op
+# on stacks that never reached AWS).
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 3 ok: cdk deploy completed"
+
+echo "[verify] step 4: read the deployed table name + sibling ARN from AWS"
+DEPLOYED_TABLE=$(aws cloudformation describe-stack-resources \
+  --stack-name "${STACK}" \
+  --region "${REGION}" \
+  --query 'StackResources[?ResourceType==`AWS::DynamoDB::Table`].PhysicalResourceId | [0]' \
+  --output text)
+echo "[verify]   deployed table: ${DEPLOYED_TABLE}"
+if [ -z "${DEPLOYED_TABLE}" ] || [ "${DEPLOYED_TABLE}" = "None" ]; then
+  echo "[verify] FAIL: could not read deployed table name from CloudFormation"
+  exit 1
+fi
+SIBLING_NAME=$(aws cloudformation describe-stack-resources \
+  --stack-name "${STACK}" \
+  --region "${REGION}" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function' && contains(LogicalResourceId, 'SiblingHandler')].PhysicalResourceId | [0]" \
+  --output text)
+if [ -z "${SIBLING_NAME}" ] || [ "${SIBLING_NAME}" = "None" ]; then
+  echo "[verify] FAIL: could not read deployed sibling function name from CloudFormation"
+  exit 1
+fi
+DEPLOYED_SIBLING_ARN=$(aws lambda get-function \
+  --function-name "${SIBLING_NAME}" \
+  --region "${REGION}" \
+  --query 'Configuration.FunctionArn' \
+  --output text)
+echo "[verify]   deployed sibling ARN: ${DEPLOYED_SIBLING_ARN}"
+if [ -z "${DEPLOYED_SIBLING_ARN}" ] || [ "${DEPLOYED_SIBLING_ARN}" = "None" ]; then
+  echo "[verify] FAIL: could not read deployed sibling ARN from Lambda"
+  exit 1
+fi
+
+# Start `cdkl start-api` with the given extra args, wait for the Function
+# URL server to bind, and echo its port on stdout. The server PID lands
+# in the global SERVER_PID so stop_server / cleanup can reap it.
+start_server_and_get_port() {
+  : >"${LOG_FILE}"
+  # shellcheck disable=SC2086
+  ${CLI} start-api \
+    --container-host "${CONTAINER_HOST}" \
+    --no-pull \
+    "$@" \
+    >"${LOG_FILE}" 2>&1 &
+  SERVER_PID=$!
+
+  local ready=0
+  for _ in $(seq 1 60); do
+    if grep -q "Server listening" "${LOG_FILE}" 2>/dev/null; then
+      ready=1
+      break
+    fi
+    # Bail early if the server died.
+    kill -0 "${SERVER_PID}" 2>/dev/null || break
+    sleep 0.5
+  done
+  if [[ "${ready}" -eq 0 ]]; then
+    echo "[verify] FAIL: start-api server did not come up. Log:" >&2
+    cat "${LOG_FILE}" >&2
+    return 1
+  fi
+  grep -E 'Server listening on http://' "${LOG_FILE}" \
+    | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1
+}
+
+# curl the Function URL server (serves any path) with a cold-boot retry.
+curl_echo() {
+  local port="$1"
+  local response=""
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if response=$(curl -sf "http://127.0.0.1:${port}/" 2>&1); then
+      if echo "${response}" | grep -q '"tableName":'; then
+        printf '%s' "${response}"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  echo "[verify] FAIL: no JSON echo from start-api server on port ${port}. Last: ${response}" >&2
+  cat "${LOG_FILE}" >&2
+  return 1
+}
+
+echo "[verify] step 5: baseline start-api (no --from-cfn-stack) — expect both intrinsics dropped"
+PORT_BASELINE=$(start_server_and_get_port)
+echo "[verify]   server on port ${PORT_BASELINE}"
+RESULT_BASELINE=$(curl_echo "${PORT_BASELINE}")
+echo "[verify]   response: ${RESULT_BASELINE}"
+stop_server
+echo "${RESULT_BASELINE}" | grep -q '"tableName":"unset"' || {
+  echo "[verify] FAIL: expected TABLE_NAME=unset in baseline, got: ${RESULT_BASELINE}"; exit 1;
+}
+echo "${RESULT_BASELINE}" | grep -q '"siblingArn":"unset"' || {
+  echo "[verify] FAIL: expected SIBLING_ARN=unset in baseline, got: ${RESULT_BASELINE}"; exit 1;
+}
+echo "${RESULT_BASELINE}" | grep -q '"staticValue":"always-the-same"' || {
+  echo "[verify] FAIL: expected STATIC_VALUE=always-the-same in baseline, got: ${RESULT_BASELINE}"; exit 1;
+}
+
+echo "[verify] step 6: cdkl start-api --from-cfn-stack — expect deployed values"
+PORT_FROM_CFN=$(start_server_and_get_port --from-cfn-stack)
+echo "[verify]   server on port ${PORT_FROM_CFN}"
+RESULT_FROM_CFN=$(curl_echo "${PORT_FROM_CFN}")
+echo "[verify]   response: ${RESULT_FROM_CFN}"
+stop_server
+echo "${RESULT_FROM_CFN}" | grep -q "\"tableName\":\"${DEPLOYED_TABLE}\"" || {
+  echo "[verify] FAIL: expected TABLE_NAME=${DEPLOYED_TABLE}, got: ${RESULT_FROM_CFN}"; exit 1;
+}
+echo "${RESULT_FROM_CFN}" | grep -q "\"siblingArn\":\"${DEPLOYED_SIBLING_ARN}\"" || {
+  echo "[verify] FAIL: expected SIBLING_ARN=${DEPLOYED_SIBLING_ARN} (deployed-env GetAtt fallback), got: ${RESULT_FROM_CFN}"; exit 1;
+}
+echo "${RESULT_FROM_CFN}" | grep -q '"staticValue":"always-the-same"' || {
+  echo "[verify] FAIL: STATIC_VALUE regressed under --from-cfn-stack, got: ${RESULT_FROM_CFN}"; exit 1;
+}
+
+echo "[verify] step 7: cdk destroy --force"
+cdk destroy "${STACK}" --force --region "${REGION}" \
+  --no-version-reporting --no-asset-metadata --no-path-metadata
+
+echo ""
+echo "[verify] All checks passed:"
+echo "[verify]   - existing behavior intact: TABLE_NAME (Ref) substituted, STATIC_VALUE (literal) passed through, baseline drops both intrinsics."
+echo "[verify]   - new behavior: SIBLING_ARN (Fn::GetAtt .Arn) recovered from the deployed function's resolved env via start-api."

--- a/tests/unit/cli/local-start-api-deployed-env-fetch.test.ts
+++ b/tests/unit/cli/local-start-api-deployed-env-fetch.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+
+// Site-level binding test for the `--from-cfn-stack` deployed-env fetch
+// wired into `loadStateForRoutedStacks`. The pure helper
+// (applyDeployedEnvFallback) and the provider method
+// (resolveDeployedFunctionEnv) are unit-tested elsewhere; this locks the
+// CALL SITE: the deployed function's PHYSICAL id (not the logical id) is
+// passed, the fetch happens while the provider is alive (before
+// dispose()), the result is stashed per-logical-id, and a provider that
+// does NOT implement the optional method is skipped cleanly.
+
+const { createProviderMock, rejectMock, stsSendMock } = vi.hoisted(() => ({
+  createProviderMock: vi.fn(),
+  rejectMock: vi.fn(),
+  stsSendMock: vi.fn(),
+}));
+
+vi.mock('../../../src/cli/commands/local-state-source.js', () => ({
+  createLocalStateProvider: createProviderMock,
+  rejectExplicitCfnStackWithMultipleStacks: rejectMock,
+  isCfnFlagPresent: vi.fn(() => false),
+}));
+
+// `loadStateForRoutedStacks` issues one `sts:GetCallerIdentity` for the
+// pseudo-parameter bag when a reachable Lambda has an intrinsic env;
+// stub it so the test stays hermetic (no real AWS / credential chain).
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    send = stsSendMock;
+    destroy(): void {}
+  },
+  GetCallerIdentityCommand: class {},
+}));
+
+const { loadStateForRoutedStacks } = await import('../../../src/cli/commands/local-start-api.js');
+
+function lambdaStack(): StackInfo {
+  return {
+    stackName: 'MyStack',
+    region: 'us-east-1',
+    template: {
+      Resources: {
+        EchoFn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Environment: {
+              Variables: { SIBLING_ARN: { 'Fn::GetAtt': ['SiblingFn', 'Arn'] } },
+            },
+          },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
+function routeTo(logicalId: string): DiscoveredRoute {
+  return {
+    method: 'GET',
+    pathPattern: '/x',
+    lambdaLogicalId: logicalId,
+    source: 'http-api',
+    apiVersion: 'v2',
+    stage: '$default',
+    unsupported: false,
+    mockCors: false,
+    serviceIntegration: false,
+  } as unknown as DiscoveredRoute;
+}
+
+describe('loadStateForRoutedStacks deployed-env fetch (site binding)', () => {
+  beforeEach(() => {
+    createProviderMock.mockReset();
+    rejectMock.mockReset();
+    stsSendMock.mockReset();
+    stsSendMock.mockResolvedValue({ Account: '111111111111' });
+  });
+
+  it('fetches the deployed env by PHYSICAL id, before dispose(), and stashes it per logical id', async () => {
+    const provider = {
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({
+        resources: {
+          EchoFn: {
+            physicalId: 'echo-physical-name',
+            resourceType: 'AWS::Lambda::Function',
+            properties: {},
+            attributes: {},
+            dependencies: [],
+          },
+        },
+        outputs: {},
+        region: 'us-east-1',
+      }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      resolveDeployedFunctionEnv: vi
+        .fn()
+        .mockResolvedValue({ SIBLING_ARN: 'arn:aws:lambda:us-east-1:111111111111:function:Sib' }),
+      dispose: vi.fn(),
+    };
+    createProviderMock.mockReturnValue(provider);
+
+    const result = await loadStateForRoutedStacks(
+      [lambdaStack()],
+      [routeTo('EchoFn')],
+      [],
+      {} as never,
+      undefined
+    );
+
+    // Bound by PHYSICAL id (regression guard: passing the logical id would
+    // be a silent bug — GetFunctionConfiguration would 404).
+    expect(provider.resolveDeployedFunctionEnv).toHaveBeenCalledTimes(1);
+    expect(provider.resolveDeployedFunctionEnv).toHaveBeenCalledWith('echo-physical-name');
+
+    // Fetched while the provider (and its AWS client) is still alive.
+    expect(provider.resolveDeployedFunctionEnv.mock.invocationCallOrder[0]).toBeLessThan(
+      provider.dispose.mock.invocationCallOrder[0]!
+    );
+
+    // Stashed per logical id for buildContainerSpec to splice in.
+    const bundle = result.get('MyStack');
+    expect(bundle?.deployedEnvByLambda?.get('EchoFn')).toEqual({
+      SIBLING_ARN: 'arn:aws:lambda:us-east-1:111111111111:function:Sib',
+    });
+    expect(provider.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the fetch cleanly for a provider without resolveDeployedFunctionEnv (e.g. --from-state)', async () => {
+    const provider = {
+      label: '--from-state',
+      load: vi.fn().mockResolvedValue({
+        resources: {
+          EchoFn: {
+            physicalId: 'echo-physical-name',
+            resourceType: 'AWS::Lambda::Function',
+            properties: {},
+            attributes: {},
+            dependencies: [],
+          },
+        },
+        outputs: {},
+        region: 'us-east-1',
+      }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn(),
+      // no resolveDeployedFunctionEnv
+    };
+    createProviderMock.mockReturnValue(provider);
+
+    const result = await loadStateForRoutedStacks(
+      [lambdaStack()],
+      [routeTo('EchoFn')],
+      [],
+      {} as never,
+      undefined
+    );
+
+    expect(result.get('MyStack')?.deployedEnvByLambda).toBeUndefined();
+    expect(provider.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/local/cfn-local-state-provider-deployed-env.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-deployed-env.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Mock the Lambda SDK so `resolveDeployedFunctionEnv()` (which constructs
+// its own LambdaClient via the lazy getLambdaClient()) can be exercised
+// without real AWS.
+const { lambdaSendMock, lambdaDestroyMock } = vi.hoisted(() => ({
+  lambdaSendMock: vi.fn(),
+  lambdaDestroyMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: class {
+    send = lambdaSendMock;
+    destroy = lambdaDestroyMock;
+  },
+  GetFunctionConfigurationCommand: class {
+    constructor(public readonly input: unknown) {}
+  },
+}));
+
+// The CFn client is unused by these tests but the module imports it at
+// load time, so provide a no-op stub.
+vi.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: class {
+    send = vi.fn();
+    destroy(): void {}
+  },
+  ListStackResourcesCommand: class {},
+  DescribeStacksCommand: class {},
+  ListExportsCommand: class {},
+}));
+
+const { CfnLocalStateProvider } = await import('../../../src/local/cfn-local-state-provider.js');
+
+describe('CfnLocalStateProvider.resolveDeployedFunctionEnv', () => {
+  beforeEach(() => {
+    lambdaSendMock.mockReset();
+    lambdaDestroyMock.mockReset();
+  });
+
+  it("returns the deployed function's Environment.Variables", async () => {
+    lambdaSendMock.mockResolvedValueOnce({
+      Environment: { Variables: { SWIFT_LAMBDA_ARN: 'arn:aws:lambda:us-east-1:111:function:Math' } },
+    });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const env = await provider.resolveDeployedFunctionEnv('Scoring');
+
+    expect(env).toEqual({ SWIFT_LAMBDA_ARN: 'arn:aws:lambda:us-east-1:111:function:Math' });
+    expect(lambdaSendMock).toHaveBeenCalledTimes(1);
+    const cmd = lambdaSendMock.mock.calls[0]![0] as { input: { FunctionName: string } };
+    expect(cmd.input.FunctionName).toBe('Scoring');
+    provider.dispose();
+  });
+
+  it('returns {} when the function declares no env vars', async () => {
+    lambdaSendMock.mockResolvedValueOnce({});
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    expect(await provider.resolveDeployedFunctionEnv('Scoring')).toEqual({});
+    provider.dispose();
+  });
+
+  it('returns undefined (warn-and-fallback) when GetFunctionConfiguration fails', async () => {
+    lambdaSendMock.mockRejectedValueOnce(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    expect(await provider.resolveDeployedFunctionEnv('Scoring')).toBeUndefined();
+    provider.dispose();
+  });
+
+  it('passes --profile through to the LambdaClient and destroys it on dispose', async () => {
+    lambdaSendMock.mockResolvedValueOnce({ Environment: { Variables: { K: 'v' } } });
+    const provider = new CfnLocalStateProvider({
+      cfnStackName: 'S',
+      region: 'us-east-1',
+      profile: 'mates_dev',
+    });
+
+    await provider.resolveDeployedFunctionEnv('Scoring');
+    provider.dispose();
+
+    expect(lambdaDestroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on use after dispose()', async () => {
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    provider.dispose();
+    await expect(provider.resolveDeployedFunctionEnv('Scoring')).rejects.toThrow(/after dispose/);
+  });
+});

--- a/tests/unit/local/state-resolver-deployed-env-fallback.test.ts
+++ b/tests/unit/local/state-resolver-deployed-env-fallback.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vite-plus/test';
+
+import { applyDeployedEnvFallback } from '../../../src/local/state-resolver.js';
+
+describe('applyDeployedEnvFallback', () => {
+  it('fills unresolved keys from the deployed env and leaves resolved keys untouched', () => {
+    const resolvedEnv = { TABLE_NAME: 'tbl-1' };
+    const unresolved = [{ key: 'SIBLING_ARN', reason: "Fn::GetAtt 'Fn.Arn': attribute not captured" }];
+    const deployedEnv = { SIBLING_ARN: 'arn:aws:lambda:us-east-1:111:function:Fn', TABLE_NAME: 'ignored' };
+
+    const result = applyDeployedEnvFallback(resolvedEnv, unresolved, deployedEnv);
+
+    expect(result.env).toEqual({
+      TABLE_NAME: 'tbl-1',
+      SIBLING_ARN: 'arn:aws:lambda:us-east-1:111:function:Fn',
+    });
+    expect(result.filled).toEqual(['SIBLING_ARN']);
+    expect(result.stillUnresolved).toEqual([]);
+  });
+
+  it('keeps keys absent from the deployed env unresolved (warn-and-drop path)', () => {
+    const unresolved = [
+      { key: 'A', reason: 'r1' },
+      { key: 'B', reason: 'r2' },
+    ];
+    const deployedEnv = { A: 'a-value' };
+
+    const result = applyDeployedEnvFallback({}, unresolved, deployedEnv);
+
+    expect(result.env).toEqual({ A: 'a-value' });
+    expect(result.filled).toEqual(['A']);
+    expect(result.stillUnresolved).toEqual([{ key: 'B', reason: 'r2' }]);
+  });
+
+  it('returns the env unchanged and all keys unresolved when deployedEnv is undefined', () => {
+    const resolvedEnv = { X: '1' };
+    const unresolved = [{ key: 'Y', reason: 'r' }];
+
+    const result = applyDeployedEnvFallback(resolvedEnv, unresolved, undefined);
+
+    expect(result.env).toEqual({ X: '1' });
+    expect(result.filled).toEqual([]);
+    expect(result.stillUnresolved).toEqual([{ key: 'Y', reason: 'r' }]);
+  });
+
+  it('does not mutate the input env or unresolved array', () => {
+    const resolvedEnv = { X: '1' };
+    const unresolved = [{ key: 'Y', reason: 'r' }];
+
+    const result = applyDeployedEnvFallback(resolvedEnv, unresolved, { Y: 'y-value' });
+
+    expect(resolvedEnv).toEqual({ X: '1' });
+    expect(unresolved).toEqual([{ key: 'Y', reason: 'r' }]);
+    expect(result.env).not.toBe(resolvedEnv);
+  });
+
+  it('treats an empty deployed env as no fill (function declares no env vars)', () => {
+    const unresolved = [{ key: 'A', reason: 'r1' }];
+
+    const result = applyDeployedEnvFallback({}, unresolved, {});
+
+    expect(result.env).toEqual({});
+    expect(result.filled).toEqual([]);
+    expect(result.stillUnresolved).toEqual([{ key: 'A', reason: 'r1' }]);
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl invoke` / `start-api --from-cfn-stack` warn-and-dropped env vars whose template value is a CloudFormation intrinsic that `ListStackResources` cannot resolve — most commonly `Fn::GetAtt <SiblingFn>.Arn`, the Lambda-invokes-Lambda-by-ARN pattern. `ListStackResources` returns only `(LogicalResourceId, PhysicalResourceId, ResourceType)`, no per-attribute values, so the static substituter dropped those keys and the user had to hand-write `--env-vars`.

Because `--from-cfn-stack` means the consumer function is itself deployed, CloudFormation already resolved every intrinsic into that function's `Environment.Variables` at deploy time. This PR reads that back via `lambda:GetFunctionConfiguration` and fills only the env keys static substitution could not resolve — covering `Fn::GetAtt` / `Fn::Sub` / `Fn::ImportValue` / cross-stack `Ref` uniformly, with no per-resource-type reconstruction.

- `LocalStateProvider` gains an optional `resolveDeployedFunctionEnv(functionPhysicalId)`; implemented only by `CfnLocalStateProvider` (the S3 provider already carries deploy-time attributes, so its `Fn::GetAtt` resolves statically — no fallback needed).
- New pure helper `applyDeployedEnvFallback` splices deployed values in for unresolved keys only (never mutates inputs; keys absent from the deployed env stay warn-and-dropped).
- Precedence: static substitution -> deployed-env fallback -> `--env-vars` override (override always wins). Recovered values are never logged (only key names).

## Scope

Lambda only (`invoke` + `start-api`). ECS container `environment` is deploy-time-resolved the same way and can reuse this approach via `DescribeTaskDefinition` in a follow-up; it is intentionally out of scope here. ECS `secrets` (runtime `valueFrom`) are a separate concern and unaffected.

## Security note

Recovered values land in the local container env in plaintext. Lambda `Environment.Variables` is a non-secret-intended property that AWS already surfaces to any caller with `lambda:GetFunctionConfiguration`, so this exposes nothing the deployed function does not already expose; values are never logged or written to disk. Documented in README + docs.

## Known cost (accepted)

In `start-api`, the deployed-env fetch fires one `GetFunctionConfiguration` per reachable Lambda whose template env has any intrinsic — including intrinsics that resolve statically (e.g. plain `Ref`), where the fetched map goes unused. This is latency/cost only, not a correctness issue; the precise fix needs a load/build-pass restructure (the load pass does not yet know which keys static substitution will drop) and is deferred.

## Test plan

- [x] Unit: `applyDeployedEnvFallback` (fill / partial-miss / undefined / no-mutation / empty-env) and `CfnLocalStateProvider.resolveDeployedFunctionEnv` (success / empty / failure / profile threading / after-dispose).
- [x] Unit (site binding): `loadStateForRoutedStacks` fetches by physical id, before `dispose()`, stashes per logical id, and skips a provider without the optional method.
- [x] Integ (real AWS, ran live): extended `local-invoke-from-cfn-stack` asserts both `Ref` (existing) and `Fn::GetAtt` (new); new `local-start-api-from-cfn-stack` fixture covers the reported `start-api` path. Both baseline-drop and `--from-cfn-stack`-recover assertions pass; Docker + CloudFormation cleanup verified.
- [x] `vp run verify` (typecheck + lint + format + build + 300 unit tests) green.
