### PR TITLE
feat(index): re-export start-api route-resolution layer for host shims

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -92,6 +92,21 @@ pure, dependency-free helpers those modules expose:
 - `getContainerNetworkIp` — read a container's per-network IP via
   `docker inspect`.
 
+The `start-api` route-resolution layer is exposed on the same basis —
+pure functions over a synthesized Cloud Assembly that the local HTTP
+server runs on:
+
+- `discoverRoutes` (+ `DiscoveredRoute` / `RestV1IntegrationConfig`) —
+  synth template → discovered REST v1 / HTTP API / Function URL routes.
+- `matchRoute` (+ `RouteMatchResult`) — match an incoming request path
+  to a discovered route (full → greedy → `$default` precedence).
+- `buildHttpApiV2Event` / `buildRestV1Event` / `applyAuthorizerOverlay`
+  (+ `HttpRequestSnapshot` / `MatchedRouteContext` /
+  `AuthorizerEventOverlay`) — build the API Gateway v1 / v2 event shapes.
+- `discoverWebSocketApis` / `discoverWebSocketApisOrThrow` /
+  `parseSelectionExpressionPath` (+ `DiscoveredWebSocketApi` /
+  `WebSocketRouteEntry`) — WebSocket API discovery.
+
 These are stable, side-effect-free utilities; they are exposed for
 1:1 re-export and are not a recommended way to build a custom CLI (use
 the factories for that).

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,3 +70,33 @@ export {
   type TranslatedHttpResponse,
 } from './local/api-gateway-response.js';
 export { getContainerNetworkIp } from './local/docker-inspect.js';
+
+/**
+ * `start-api` route-resolution layer, re-exported for hosts that shim
+ * cdk-local's `src/local/**` modules verbatim (e.g. cdkd). These turn a
+ * synthesized Cloud Assembly into discovered API routes, match an
+ * incoming request to a route, and build the API Gateway event shapes —
+ * the building blocks the local HTTP server runs on. Exposed only as the
+ * consuming host's `import` statements require them.
+ */
+export {
+  discoverRoutes,
+  type DiscoveredRoute,
+  type RestV1IntegrationConfig,
+} from './local/route-discovery.js';
+export { matchRoute, type RouteMatchResult } from './local/route-matcher.js';
+export {
+  buildHttpApiV2Event,
+  buildRestV1Event,
+  applyAuthorizerOverlay,
+  type HttpRequestSnapshot,
+  type MatchedRouteContext,
+  type AuthorizerEventOverlay,
+} from './local/api-gateway-event.js';
+export {
+  discoverWebSocketApis,
+  discoverWebSocketApisOrThrow,
+  parseSelectionExpressionPath,
+  type DiscoveredWebSocketApi,
+  type WebSocketRouteEntry,
+} from './local/websocket-route-discovery.js';

--- a/tests/unit/local/api-gateway-event.test.ts
+++ b/tests/unit/local/api-gateway-event.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyAuthorizerOverlay,
+  buildHttpApiV2Event,
+  buildRestV1Event,
+  type HttpRequestSnapshot,
+  type MatchedRouteContext,
+} from '../../../src/local/api-gateway-event.js';
+import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+
+function makeRoute(
+  apiVersion: 'v1' | 'v2',
+  pathPattern: string,
+  method = 'GET'
+): DiscoveredRoute {
+  return {
+    method,
+    pathPattern,
+    lambdaLogicalId: 'Fn',
+    source: apiVersion === 'v1' ? 'rest-v1' : 'http-api',
+    apiVersion,
+    stage: apiVersion === 'v1' ? 'prod' : '$default',
+    declaredAt: 'Test',
+  };
+}
+
+const FIXED_NOW = new Date('2026-05-10T12:00:00.000Z');
+const fixedNow = (): Date => FIXED_NOW;
+
+describe('buildHttpApiV2Event — shape', () => {
+  it('produces the canonical v2 shape with all required fields', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/items/123?foo=bar',
+      headers: {
+        'Content-Type': ['application/json'],
+        'User-Agent': ['curl/8.0.0'],
+      },
+      body: Buffer.from('{"x":1}', 'utf-8'),
+      sourceIp: '10.0.0.1',
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v2', '/items/{id}'),
+      pathParameters: { id: '123' },
+      matchedPath: '/items/123',
+    };
+    const event = buildHttpApiV2Event(req, ctx, { now: fixedNow });
+    expect(event['version']).toBe('2.0');
+    expect(event['routeKey']).toBe('GET /items/{id}');
+    expect(event['rawPath']).toBe('/items/123');
+    expect(event['rawQueryString']).toBe('foo=bar');
+    expect(event['cookies']).toEqual([]);
+    expect(event['stageVariables']).toBeNull();
+    expect(event['isBase64Encoded']).toBe(false);
+    expect(event['body']).toBe('{"x":1}');
+    const rc = event['requestContext'] as Record<string, unknown>;
+    expect(rc['accountId']).toBe('123456789012');
+    expect(rc['apiId']).toBe('local');
+    expect(rc['domainPrefix']).toBe('local');
+    expect(rc['authentication']).toBeNull();
+    expect(rc['authorizer']).toBeNull();
+    expect((rc['http'] as Record<string, unknown>)['protocol']).toBe('HTTP/1.1');
+    expect((rc['http'] as Record<string, unknown>)['userAgent']).toBe('curl/8.0.0');
+    expect((rc['http'] as Record<string, unknown>)['sourceIp']).toBe('10.0.0.1');
+    expect(rc['stage']).toBe('$default');
+  });
+
+  it('lowercases header names and joins duplicates with commas (C14)', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/x',
+      headers: { 'X-Foo': ['a', 'b', 'c'] },
+      body: Buffer.alloc(0),
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v2', '/x'),
+      pathParameters: {},
+      matchedPath: '/x',
+    };
+    const event = buildHttpApiV2Event(req, ctx);
+    expect((event['headers'] as Record<string, string>)['x-foo']).toBe('a,b,c');
+  });
+
+  it('splits the cookie header into the cookies array (C5)', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/x',
+      headers: { Cookie: ['session=abc; theme=dark'] },
+      body: Buffer.alloc(0),
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v2', '/x'),
+      pathParameters: {},
+      matchedPath: '/x',
+    };
+    const event = buildHttpApiV2Event(req, ctx);
+    expect(event['cookies']).toEqual(['session=abc', 'theme=dark']);
+    expect((event['headers'] as Record<string, string>)['cookie']).toBeUndefined();
+  });
+
+  it('decodes pathParameters values (C11)', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/items/hello%20world',
+      headers: {},
+      body: Buffer.alloc(0),
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v2', '/items/{id}'),
+      pathParameters: { id: 'hello%20world' },
+      matchedPath: '/items/hello%20world',
+    };
+    const event = buildHttpApiV2Event(req, ctx);
+    expect((event['pathParameters'] as Record<string, string>)['id']).toBe('hello world');
+    // rawPath stays NOT decoded:
+    expect(event['rawPath']).toBe('/items/hello%20world');
+  });
+
+  it('leaves rawQueryString undecoded but decodes queryStringParameters values', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/?key=hello%20world&key=baz',
+      headers: {},
+      body: Buffer.alloc(0),
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v2', '/'),
+      pathParameters: {},
+      matchedPath: '/',
+    };
+    const event = buildHttpApiV2Event(req, ctx);
+    expect(event['rawQueryString']).toBe('key=hello%20world&key=baz');
+    expect((event['queryStringParameters'] as Record<string, string>)['key']).toBe(
+      'hello world,baz'
+    );
+  });
+
+  it('base64-encodes a binary body when content-type is binary', () => {
+    const body = Buffer.from([0xff, 0xd8, 0xff]); // jpeg magic
+    const req: HttpRequestSnapshot = {
+      method: 'POST',
+      rawUrl: '/upload',
+      headers: { 'Content-Type': ['image/jpeg'] },
+      body,
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v2', '/upload', 'POST'),
+      pathParameters: {},
+      matchedPath: '/upload',
+    };
+    const event = buildHttpApiV2Event(req, ctx);
+    expect(event['isBase64Encoded']).toBe(true);
+    expect(event['body']).toBe(body.toString('base64'));
+  });
+
+  it("requestContext.routeKey is '$default' when the matched route is $default", () => {
+    const route: DiscoveredRoute = makeRoute('v2', '$default', 'ANY');
+    const req: HttpRequestSnapshot = { method: 'GET', rawUrl: '/x', headers: {}, body: Buffer.alloc(0) };
+    const ctx: MatchedRouteContext = { route, pathParameters: {}, matchedPath: '/x' };
+    const event = buildHttpApiV2Event(req, ctx);
+    expect(event['routeKey']).toBe('$default');
+    expect((event['requestContext'] as Record<string, unknown>)['routeKey']).toBe('$default');
+  });
+});
+
+describe('buildRestV1Event — shape', () => {
+  it('produces the v1 shape with multiValueHeaders + identity', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'POST',
+      rawUrl: '/items?key=a&key=b',
+      headers: {
+        'Content-Type': ['application/json'],
+        'X-Custom': ['v1', 'v2'],
+      },
+      body: Buffer.from('{"y":2}'),
+      sourceIp: '127.0.0.1',
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v1', '/items', 'POST'),
+      pathParameters: {},
+      matchedPath: '/items',
+    };
+    const event = buildRestV1Event(req, ctx, { now: fixedNow });
+    expect(event['httpMethod']).toBe('POST');
+    expect(event['resource']).toBe('/items');
+    expect(event['path']).toBe('/items');
+    const headers = event['headers'] as Record<string, string>;
+    const mvh = event['multiValueHeaders'] as Record<string, string[]>;
+    expect(headers['x-custom']).toBe('v2');
+    expect(mvh['x-custom']).toEqual(['v1', 'v2']);
+    const rc = event['requestContext'] as Record<string, unknown>;
+    expect((rc['identity'] as Record<string, unknown>)['sourceIp']).toBe('127.0.0.1');
+    expect(rc['stage']).toBe('prod');
+    expect(rc['path']).toBe('/prod/items');
+    expect(rc['authorizer']).toBeNull();
+  });
+
+  it('queryStringParameters: null when none, multiValueQueryStringParameters: null when none', () => {
+    const req: HttpRequestSnapshot = { method: 'GET', rawUrl: '/x', headers: {}, body: Buffer.alloc(0) };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v1', '/x'),
+      pathParameters: {},
+      matchedPath: '/x',
+    };
+    const event = buildRestV1Event(req, ctx);
+    expect(event['queryStringParameters']).toBeNull();
+    expect(event['multiValueQueryStringParameters']).toBeNull();
+    expect(event['pathParameters']).toBeNull();
+    expect(event['body']).toBeNull();
+  });
+});
+
+describe('buildHttpApiV2Event / buildRestV1Event — stage variables (PR 8c)', () => {
+  it('surfaces stageVariables on v2 events when route carries them', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/x',
+      headers: {},
+      body: Buffer.alloc(0),
+    };
+    const route = makeRoute('v2', '/x');
+    route.stageVariables = { theme: 'dark' };
+    const ctx: MatchedRouteContext = {
+      route,
+      pathParameters: {},
+      matchedPath: '/x',
+    };
+    const event = buildHttpApiV2Event(req, ctx);
+    expect(event['stageVariables']).toEqual({ theme: 'dark' });
+  });
+
+  it('surfaces stageVariables on v1 events when route carries them', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/x',
+      headers: {},
+      body: Buffer.alloc(0),
+    };
+    const route = makeRoute('v1', '/x');
+    route.stageVariables = { region: 'us-east-1' };
+    const ctx: MatchedRouteContext = {
+      route,
+      pathParameters: {},
+      matchedPath: '/x',
+    };
+    const event = buildRestV1Event(req, ctx);
+    expect(event['stageVariables']).toEqual({ region: 'us-east-1' });
+  });
+
+  it('falls back to null when route has no stageVariables', () => {
+    const req: HttpRequestSnapshot = {
+      method: 'GET',
+      rawUrl: '/x',
+      headers: {},
+      body: Buffer.alloc(0),
+    };
+    const ctx: MatchedRouteContext = {
+      route: makeRoute('v2', '/x'),
+      pathParameters: {},
+      matchedPath: '/x',
+    };
+    expect(buildHttpApiV2Event(req, ctx)['stageVariables']).toBeNull();
+  });
+});
+
+describe('applyAuthorizerOverlay', () => {
+  it('lambda-rest-v1: principalId + context flat under requestContext.authorizer', () => {
+    const event = { foo: 1, requestContext: { authorizer: null, stage: 'prod' } };
+    const out = applyAuthorizerOverlay(event, {
+      kind: 'lambda-rest-v1',
+      principalId: 'u',
+      context: { tier: 'pro' },
+    });
+    expect((out['requestContext'] as Record<string, unknown>)['authorizer']).toEqual({
+      principalId: 'u',
+      tier: 'pro',
+    });
+    // does not mutate the input
+    expect((event['requestContext'] as Record<string, unknown>)['authorizer']).toBeNull();
+  });
+
+  it('lambda-http-v2: nests under .authorizer.lambda', () => {
+    const event = { requestContext: { authorizer: null } };
+    const out = applyAuthorizerOverlay(event, {
+      kind: 'lambda-http-v2',
+      principalId: 'u',
+      context: { tier: 'pro' },
+    });
+    const auth = (out['requestContext'] as Record<string, unknown>)['authorizer'] as Record<string, unknown>;
+    expect(auth['lambda']).toEqual({ principalId: 'u', tier: 'pro' });
+  });
+
+  it('cognito-rest-v1: claims under .authorizer.claims', () => {
+    const event = { requestContext: { authorizer: null } };
+    const out = applyAuthorizerOverlay(event, {
+      kind: 'cognito-rest-v1',
+      claims: { sub: 'user-1', 'cognito:username': 'alice' },
+    });
+    const auth = (out['requestContext'] as Record<string, unknown>)['authorizer'] as Record<string, unknown>;
+    expect(auth['claims']).toEqual({ sub: 'user-1', 'cognito:username': 'alice' });
+  });
+
+  it('jwt-http-v2: claims + scopes under .authorizer.jwt', () => {
+    const event = { requestContext: { authorizer: null } };
+    const out = applyAuthorizerOverlay(event, {
+      kind: 'jwt-http-v2',
+      claims: { sub: 'user-1' },
+      scopes: ['read:items'],
+    });
+    const auth = (out['requestContext'] as Record<string, unknown>)['authorizer'] as Record<string, unknown>;
+    expect(auth['jwt']).toEqual({ claims: { sub: 'user-1' }, scopes: ['read:items'] });
+  });
+
+  it('jwt-http-v2: scopes default to []', () => {
+    const event = { requestContext: { authorizer: null } };
+    const out = applyAuthorizerOverlay(event, {
+      kind: 'jwt-http-v2',
+      claims: {},
+    });
+    const auth = (out['requestContext'] as Record<string, unknown>)['authorizer'] as Record<string, unknown>;
+    expect((auth['jwt'] as Record<string, unknown>)['scopes']).toEqual([]);
+  });
+});
+
+describe('mTLS clientCert surfacing', () => {
+  function makeSnapshot(extra: Partial<HttpRequestSnapshot> = {}): HttpRequestSnapshot {
+    return {
+      method: 'GET',
+      rawUrl: '/items',
+      headers: {},
+      body: Buffer.alloc(0),
+      ...extra,
+    };
+  }
+
+  const sampleClientCert = {
+    clientCertPem: '-----BEGIN CERTIFICATE-----\nMIIBkTCB+w...\n-----END CERTIFICATE-----\n',
+    subjectDN: 'CN=client,O=example,C=US',
+    issuerDN: 'CN=My CA,O=example,C=US',
+    serialNumber: '01:23:45:67:89:AB:CD:EF',
+    validity: {
+      notBefore: 'May 22 03:30:00 2026 GMT',
+      notAfter: 'May 22 03:30:00 2027 GMT',
+    },
+  };
+
+  function makeCtx(apiVersion: 'v1' | 'v2'): MatchedRouteContext {
+    return {
+      route: {
+        method: 'GET',
+        pathPattern: '/items',
+        lambdaLogicalId: 'Fn',
+        source: apiVersion === 'v1' ? 'rest-v1' : 'http-api',
+        apiVersion,
+        stage: apiVersion === 'v1' ? 'prod' : '$default',
+        declaredAt: 'S/X',
+      } as DiscoveredRoute,
+      pathParameters: {},
+      matchedPath: '/items',
+    };
+  }
+
+  it('REST v1: clientCert lands under requestContext.identity.clientCert when set', () => {
+    const event = buildRestV1Event(makeSnapshot({ clientCert: sampleClientCert }), makeCtx('v1'));
+    const rc = event['requestContext'] as Record<string, unknown>;
+    const identity = rc['identity'] as Record<string, unknown>;
+    expect(identity['clientCert']).toEqual(sampleClientCert);
+  });
+
+  it('REST v1: identity.clientCert is omitted when clientCert is not set (plain HTTP)', () => {
+    const event = buildRestV1Event(makeSnapshot(), makeCtx('v1'));
+    const rc = event['requestContext'] as Record<string, unknown>;
+    const identity = rc['identity'] as Record<string, unknown>;
+    expect('clientCert' in identity).toBe(false);
+  });
+
+  it('HTTP API v2: clientCert lands under requestContext.authentication.clientCert when set', () => {
+    const event = buildHttpApiV2Event(makeSnapshot({ clientCert: sampleClientCert }), makeCtx('v2'));
+    const rc = event['requestContext'] as Record<string, unknown>;
+    const auth = rc['authentication'] as Record<string, unknown>;
+    expect(auth).toEqual({ clientCert: sampleClientCert });
+  });
+
+  it('HTTP API v2: authentication stays explicit-null when clientCert is not set (plain HTTP)', () => {
+    const event = buildHttpApiV2Event(makeSnapshot(), makeCtx('v2'));
+    const rc = event['requestContext'] as Record<string, unknown>;
+    expect(rc['authentication']).toBeNull();
+  });
+});

--- a/tests/unit/local/route-discovery.test.ts
+++ b/tests/unit/local/route-discovery.test.ts
@@ -1,0 +1,1441 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { discoverRoutes } from '../../../src/local/route-discovery.js';
+import { RouteDiscoveryError } from '../../../src/utils/error-handler.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+function buildStack(stackName: string, resources: Record<string, TemplateResource>): StackInfo {
+  const template: CloudFormationTemplate = { Resources: resources };
+  return {
+    stackName,
+    displayName: stackName,
+    artifactId: stackName,
+    template,
+    dependencyNames: [],
+  };
+}
+
+describe('discoverRoutes — REST v1', () => {
+  it('builds path by walking ParentId chain to RestApi root', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: { Name: 'A' } },
+      RootProxyResource: {
+        Type: 'AWS::ApiGateway::Resource',
+        Properties: {
+          RestApiId: { Ref: 'Api' },
+          ParentId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          PathPart: 'items',
+        },
+      },
+      ItemIdResource: {
+        Type: 'AWS::ApiGateway::Resource',
+        Properties: {
+          RestApiId: { Ref: 'Api' },
+          ParentId: { Ref: 'RootProxyResource' },
+          PathPart: '{id}',
+        },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { Ref: 'ItemIdResource' },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: { 'Fn::GetAtt': ['MyHandler', 'Arn'] },
+          },
+        },
+      },
+      Stage: {
+        Type: 'AWS::ApiGateway::Stage',
+        Properties: { RestApiId: { Ref: 'Api' }, StageName: 'prod' },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toEqual([
+      {
+        method: 'GET',
+        pathPattern: '/items/{id}',
+        lambdaLogicalId: 'MyHandler',
+        source: 'rest-v1',
+        apiVersion: 'v1',
+        stage: 'prod',
+        apiLogicalId: 'Api',
+        apiStackName: 'S',
+        declaredAt: 'S/Method',
+      },
+    ]);
+  });
+
+  it("parses CDK's REST v1 invoke-ARN Fn::Join wrapper", () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'ANY',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  { Ref: 'AWS::Partition' },
+                  ':apigateway:',
+                  { Ref: 'AWS::Region' },
+                  ':lambda:path/2015-03-31/functions/',
+                  { 'Fn::GetAtt': ['MyHandler', 'Arn'] },
+                  '/invocations',
+                ],
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.lambdaLogicalId).toBe('MyHandler');
+  });
+
+  it('treats { Ref: lambda } as the Lambda logical ID', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'AWS_PROXY', Uri: { Ref: 'MyHandler' } },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.lambdaLogicalId).toBe('MyHandler');
+  });
+
+  it("falls back to '$default' when no Stage is attached", () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'AWS_PROXY', Uri: { 'Fn::GetAtt': ['Handler', 'Arn'] } },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.stage).toBe('$default');
+  });
+
+  it('classifies non-CORS MOCK integrations as kind="mock" (#457; pre-PR they were 501 unsupported)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'MOCK' },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.method).toBe('GET');
+    expect(routes[0]?.pathPattern).toBe('/');
+    expect(routes[0]?.lambdaLogicalId).toBe('');
+    expect(routes[0]?.restV1Integration?.kind).toBe('mock');
+    expect(routes[0]?.mockCors).toBeUndefined();
+    expect(routes[0]?.unsupported).toBeUndefined();
+  });
+
+  it('classifies REST v1 HTTP_PROXY integrations with the new restV1Integration config (#457)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'HTTP_PROXY', Uri: 'http://example.com' },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported).toBeUndefined();
+    expect(routes[0]?.restV1Integration?.kind).toBe('http-proxy');
+    expect(
+      routes[0]?.restV1Integration?.kind === 'http-proxy' &&
+        routes[0]?.restV1Integration.uri
+    ).toBe('http://example.com');
+  });
+
+  it('flags Fn::Sub against an arbitrary (non-invoke-ARN) template as deferred-error unsupported', () => {
+    // Pre-issue-#286-Gap-3 this was the bare-`${Handler.Arn}` example; the
+    // resolver still cannot pin down a Lambda logical id without the
+    // `:lambda:path/2015-03-31/functions/` invoke-ARN marker, so the
+    // route lands as deferred-501 instead of throwing.
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'AWS_PROXY', Uri: { 'Fn::Sub': '${Handler.Arn}' } },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported?.reason).toMatch(/Lambda Arn intrinsics/);
+    expect(routes[0]?.lambdaLogicalId).toBe('');
+  });
+
+  // Issue #286 Gap 3: hand-written / non-canonical CDK constructs may
+  // emit `Fn::Sub` instead of the `Fn::Join` invoke-ARN wrapper. Both
+  // canonical shapes (1-arg + 2-arg) now resolve to the Lambda logical
+  // ID.
+  it("parses CDK Fn.sub(template) 1-arg invoke-ARN shape", () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: {
+              'Fn::Sub':
+                'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyHandler.Arn}/invocations',
+            },
+          },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.lambdaLogicalId).toBe('MyHandler');
+  });
+
+  it("parses CDK Fn.sub(template, vars) 2-arg invoke-ARN shape", () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: {
+              'Fn::Sub': [
+                'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaArn}/invocations',
+                { MyLambdaArn: { 'Fn::GetAtt': ['MyHandler', 'Arn'] } },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.lambdaLogicalId).toBe('MyHandler');
+  });
+});
+
+describe('discoverRoutes — REST v1 non-AWS_PROXY classification (#457)', () => {
+  // Each test asserts that the new restV1Integration field is populated
+  // with the right `kind` discriminator + per-kind config.
+
+  it('classifies MOCK non-CORS as kind="mock" with requestTemplate + responses', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'MOCK',
+            RequestTemplates: { 'application/json': '{"statusCode": 200}' },
+            IntegrationResponses: [
+              { StatusCode: '200', ResponseTemplates: { 'application/json': '{}' } },
+            ],
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0];
+    expect(route?.restV1Integration?.kind).toBe('mock');
+    if (route?.restV1Integration?.kind === 'mock') {
+      expect(route.restV1Integration.requestTemplate).toBe('{"statusCode": 200}');
+      expect(route.restV1Integration.responses).toHaveLength(1);
+    }
+  });
+
+  it('classifies HTTP_PROXY with uri + responses', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'HTTP_PROXY',
+            Uri: 'https://example.com/api',
+            IntegrationHttpMethod: 'POST',
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0];
+    expect(route?.restV1Integration?.kind).toBe('http-proxy');
+    if (route?.restV1Integration?.kind === 'http-proxy') {
+      expect(route.restV1Integration.uri).toBe('https://example.com/api');
+      expect(route.restV1Integration.integrationHttpMethod).toBe('POST');
+    }
+  });
+
+  it('classifies HTTP non-proxy with uri + requestTemplates + responses', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'HTTP',
+            Uri: 'https://upstream/api',
+            RequestTemplates: { 'application/json': '{"wrapped":$input.body}' },
+            IntegrationResponses: [
+              {
+                StatusCode: '200',
+                ResponseTemplates: { 'application/json': '{"x":1}' },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0];
+    expect(route?.restV1Integration?.kind).toBe('http');
+    if (route?.restV1Integration?.kind === 'http') {
+      expect(route.restV1Integration.uri).toBe('https://upstream/api');
+      expect(route.restV1Integration.requestTemplates).toEqual({
+        'application/json': '{"wrapped":$input.body}',
+      });
+    }
+  });
+
+  it('classifies AWS integration targeting Lambda as kind="aws-lambda"', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Handler: {
+        Type: 'AWS::Lambda::Function',
+        Properties: { Runtime: 'nodejs20.x', Handler: 'index.handler' },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS',
+            Uri: {
+              'Fn::Sub':
+                'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Handler.Arn}/invocations',
+            },
+            RequestTemplates: { 'application/json': '{"event":$input.body}' },
+            IntegrationResponses: [
+              {
+                StatusCode: '200',
+                ResponseTemplates: { 'application/json': 'value=$input.json("$")' },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0];
+    expect(route?.restV1Integration?.kind).toBe('aws-lambda');
+    expect(route?.lambdaLogicalId).toBe('Handler');
+    if (route?.restV1Integration?.kind === 'aws-lambda') {
+      expect(route.restV1Integration.lambdaLogicalId).toBe('Handler');
+      expect(route.restV1Integration.requestTemplates).toBeDefined();
+      expect(route.restV1Integration.responses).toHaveLength(1);
+    }
+  });
+
+  it('flags AWS integration targeting a non-Lambda service (e.g. S3) as deferred-error unsupported', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS',
+            Uri: 'arn:aws:apigateway:us-east-1:s3:path/my-bucket/{key}',
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0];
+    expect(route?.unsupported?.reason).toMatch(/non-Lambda service/);
+    expect(route?.restV1Integration).toBeUndefined();
+  });
+
+  it('flags HTTP_PROXY with non-literal Uri as deferred-error unsupported', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'HTTP_PROXY', Uri: { Ref: 'SomeParam' } },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0];
+    expect(route?.unsupported?.reason).toMatch(/HTTP_PROXY/);
+    expect(route?.restV1Integration).toBeUndefined();
+  });
+
+  it('flags unknown REST v1 integration type as deferred-error unsupported', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'NONSENSE' },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0];
+    expect(route?.unsupported?.reason).toMatch(/unknown REST v1 integration type/);
+  });
+});
+
+describe('discoverRoutes — REST v1 buildRestV1Path error branches', () => {
+  // Each test fixtures a malformed template stub and asserts the
+  // specific error message thrown by `buildRestV1Path` so a regression
+  // in the wording / class can't slip through unnoticed.
+
+  it('throws on cycle in ParentId chain', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      A: {
+        Type: 'AWS::ApiGateway::Resource',
+        Properties: {
+          RestApiId: { Ref: 'Api' },
+          ParentId: { Ref: 'B' },
+          PathPart: 'a',
+        },
+      },
+      B: {
+        Type: 'AWS::ApiGateway::Resource',
+        Properties: {
+          RestApiId: { Ref: 'Api' },
+          ParentId: { Ref: 'A' },
+          PathPart: 'b',
+        },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { Ref: 'A' },
+          Integration: { Type: 'AWS_PROXY', Uri: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+        },
+      },
+    });
+    expect(() => discoverRoutes([stack])).toThrow(/cycle detected in AWS::ApiGateway::Resource ParentId chain/);
+  });
+
+  it('throws on missing parent resource', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Orphan: {
+        Type: 'AWS::ApiGateway::Resource',
+        Properties: {
+          RestApiId: { Ref: 'Api' },
+          ParentId: { Ref: 'DoesNotExist' },
+          PathPart: 'orphan',
+        },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { Ref: 'Orphan' },
+          Integration: { Type: 'AWS_PROXY', Uri: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+        },
+      },
+    });
+    expect(() => discoverRoutes([stack])).toThrow(/ParentId chain references missing resource 'DoesNotExist'/);
+  });
+
+  it('throws when ParentId chain hits a non-Resource type', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Strange: {
+        // Wrong type; pretends to be a parent.
+        Type: 'AWS::S3::Bucket',
+        Properties: {},
+      },
+      Child: {
+        Type: 'AWS::ApiGateway::Resource',
+        Properties: {
+          RestApiId: { Ref: 'Api' },
+          ParentId: { Ref: 'Strange' },
+          PathPart: 'child',
+        },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { Ref: 'Child' },
+          Integration: { Type: 'AWS_PROXY', Uri: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+        },
+      },
+    });
+    expect(() => discoverRoutes([stack])).toThrow(
+      /ParentId chain hit AWS::S3::Bucket \(expected AWS::ApiGateway::Resource or RestApi root\)/
+    );
+  });
+
+  it('throws on Resource missing PathPart', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      MissingPathPart: {
+        Type: 'AWS::ApiGateway::Resource',
+        Properties: {
+          RestApiId: { Ref: 'Api' },
+          ParentId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          // PathPart missing.
+        },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { Ref: 'MissingPathPart' },
+          Integration: { Type: 'AWS_PROXY', Uri: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+        },
+      },
+    });
+    expect(() => discoverRoutes([stack])).toThrow(
+      /AWS::ApiGateway::Resource 'MissingPathPart' missing PathPart/
+    );
+  });
+});
+
+describe('discoverRoutes — HTTP API v2', () => {
+  it('parses RouteKey and resolves Target integration', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items/{id}',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]).toEqual({
+      method: 'GET',
+      pathPattern: '/items/{id}',
+      lambdaLogicalId: 'Handler',
+      source: 'http-api',
+      apiVersion: 'v2',
+      stage: '$default',
+      apiLogicalId: 'Api',
+      apiStackName: 'S',
+      declaredAt: 'S/Route',
+    });
+  });
+
+  it('omits WebSocket protocol routes from the HTTP route table (#462 — discovered by sibling pipeline)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'WEBSOCKET' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    // The HTTP-side discovery no longer emits a stub deferred-501 row;
+    // WebSocket routes are picked up by `discoverWebSocketApis` and
+    // wired through a separate upgrade-event server.
+    const routes = discoverRoutes([stack]);
+    expect(routes).toEqual([]);
+  });
+
+  it('classifies AWS-recognized IntegrationSubtype routes as serviceIntegration (issue #458)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationSubtype: 'SQS-SendMessage',
+          PayloadFormatVersion: '1.0',
+          RequestParameters: {
+            QueueUrl: '$request.querystring.url',
+            MessageBody: '$request.body',
+          },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'POST /enqueue',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported).toBeUndefined();
+    expect(routes[0]?.lambdaLogicalId).toBe('');
+    expect(routes[0]?.serviceIntegration?.subtype).toBe('SQS-SendMessage');
+    expect(routes[0]?.serviceIntegration?.requestParameters).toEqual({
+      QueueUrl: '$request.querystring.url',
+      MessageBody: '$request.body',
+    });
+  });
+
+  it('preserves ResponseParameters on serviceIntegration routes', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationSubtype: 'EventBridge-PutEvents',
+          PayloadFormatVersion: '1.0',
+          RequestParameters: { Detail: '{}', DetailType: 't', Source: 's' },
+          ResponseParameters: {
+            '200': { 'overwrite:statuscode': '202' },
+          },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'POST /events',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes[0]?.serviceIntegration?.responseParameters).toEqual({
+      '200': { 'overwrite:statuscode': '202' },
+    });
+  });
+
+  it('falls back to deferred-501 on unrecognized IntegrationSubtype (e.g. typo or future-AWS)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationSubtype: 'DynamoDB-PutItem',
+          PayloadFormatVersion: '1.0',
+          RequestParameters: {},
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'POST /ddb',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.serviceIntegration).toBeUndefined();
+    expect(routes[0]?.unsupported?.reason).toMatch(/DynamoDB-PutItem/);
+    expect(routes[0]?.unsupported?.reason).toMatch(/not supported/);
+  });
+
+  it('flags serviceIntegration with missing RequestParameters as deferred-501', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationSubtype: 'SQS-SendMessage',
+          PayloadFormatVersion: '1.0',
+          // RequestParameters omitted on purpose
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'POST /noparams',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes[0]?.serviceIntegration).toBeUndefined();
+    expect(routes[0]?.unsupported?.reason).toMatch(/RequestParameters/);
+  });
+
+  it("parses CDK's actual Target shape Fn::Join ['', ['integrations/', { Ref }]]", () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.lambdaLogicalId).toBe('Handler');
+  });
+
+  it("parses Fn::Sub 1-arg Target shape 'integrations/${Integ}' (AWS-docs canonical)", () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items',
+          Target: { 'Fn::Sub': 'integrations/${Integ}' },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.lambdaLogicalId).toBe('Handler');
+  });
+
+  it("parses Fn::Sub 2-arg Target shape ['integrations/${Var}', { Var: { Ref } }] (what cdk.Fn.sub emits)", () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'POST /items',
+          Target: {
+            'Fn::Sub': ['integrations/${IntId}', { IntId: { Ref: 'Integ' } }],
+          },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.lambdaLogicalId).toBe('Handler');
+  });
+
+  it('rejects Fn::Sub Target whose template does not start with integrations/', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items',
+          Target: { 'Fn::Sub': 'something-else/${Integ}' },
+        },
+      },
+    });
+    expect(() => discoverRoutes([stack])).toThrow(/Target must be/);
+  });
+
+  it('rejects Fn::Sub Target whose 2-arg binding is not a Ref', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items',
+          Target: {
+            'Fn::Sub': [
+              'integrations/${IntId}',
+              { IntId: { 'Fn::GetAtt': ['Integ', 'Arn'] } },
+            ],
+          },
+        },
+      },
+    });
+    expect(() => discoverRoutes([stack])).toThrow(/Target must be/);
+  });
+
+  it('parses $default RouteKey', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: '$default',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes[0]?.pathPattern).toBe('$default');
+    expect(routes[0]?.method).toBe('ANY');
+  });
+});
+
+describe('discoverRoutes — Function URL', () => {
+  it('synthesizes ANY /{proxy+} for a NONE-auth Function URL', () => {
+    const stack = buildStack('S', {
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: { AuthType: 'NONE', TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+      },
+    });
+    expect(discoverRoutes([stack])[0]).toEqual({
+      method: 'ANY',
+      pathPattern: '/{proxy+}',
+      lambdaLogicalId: 'Fn',
+      source: 'function-url',
+      apiVersion: 'v2',
+      stage: '$default',
+      apiStackName: 'S',
+      apiLogicalId: 'Url', // issue #644: Function URL's own logical ID (CORS-config-bearing)
+      declaredAt: 'S/Url',
+      invokeMode: 'BUFFERED',
+    });
+  });
+
+  it('synthesizes a normal route for AuthType: AWS_IAM (#621 — SigV4 verified at request time)', () => {
+    const stack = buildStack('S', {
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: { AuthType: 'AWS_IAM', TargetFunctionArn: { Ref: 'Fn' } },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    // Not flipped to unsupported anymore — Function URL AWS_IAM rides
+    // the same SigV4 verifier that REST v1 AWS_IAM ships (PR #447).
+    // The IamAuthorizer descriptor is attached later by
+    // `attachAuthorizers` in `authorizer-resolver.ts`.
+    expect(routes[0]?.unsupported).toBeUndefined();
+    expect(routes[0]?.lambdaLogicalId).toBe('Fn');
+    expect(routes[0]?.apiVersion).toBe('v2');
+    expect(routes[0]?.invokeMode).toBe('BUFFERED');
+  });
+
+  it('flags unknown AuthType as deferred-error unsupported with a clear message', () => {
+    const stack = buildStack('S', {
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: { AuthType: 'CUSTOM', TargetFunctionArn: { Ref: 'Fn' } },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported?.reason).toMatch(/CUSTOM/);
+    expect(routes[0]?.unsupported?.reason).toMatch(/expected 'NONE' or 'AWS_IAM'/);
+    // The Lambda IS known on Function URLs even when unsupported;
+    // unlike REST v1 MOCK / unresolvable Arn cases, Function URLs always
+    // identify their backing Lambda.
+    expect(routes[0]?.lambdaLogicalId).toBe('Fn');
+  });
+
+  it('tags InvokeMode RESPONSE_STREAM as a normal streaming route (#467)', () => {
+    const stack = buildStack('S', {
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: {
+          AuthType: 'NONE',
+          InvokeMode: 'RESPONSE_STREAM',
+          TargetFunctionArn: { Ref: 'Fn' },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported).toBeUndefined();
+    expect(routes[0]?.invokeMode).toBe('RESPONSE_STREAM');
+    expect(routes[0]?.lambdaLogicalId).toBe('Fn');
+  });
+
+  it('defaults InvokeMode to BUFFERED when the template omits the field', () => {
+    const stack = buildStack('S', {
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: {
+          AuthType: 'NONE',
+          TargetFunctionArn: { Ref: 'Fn' },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported).toBeUndefined();
+    expect(routes[0]?.invokeMode).toBe('BUFFERED');
+  });
+
+  it('preserves an explicit InvokeMode: BUFFERED value', () => {
+    const stack = buildStack('S', {
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: {
+          AuthType: 'NONE',
+          InvokeMode: 'BUFFERED',
+          TargetFunctionArn: { Ref: 'Fn' },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.invokeMode).toBe('BUFFERED');
+  });
+
+  it('flags unknown InvokeMode values as deferred-error unsupported', () => {
+    const stack = buildStack('S', {
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: {
+          AuthType: 'NONE',
+          InvokeMode: 'WEIRD_NEW_MODE',
+          TargetFunctionArn: { Ref: 'Fn' },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported?.reason).toMatch(/WEIRD_NEW_MODE/);
+    expect(routes[0]?.lambdaLogicalId).toBe('Fn');
+  });
+});
+
+describe('discoverRoutes — aws:cdk:path propagation', () => {
+  // The discovery layer surfaces the parent API's (or the backing
+  // Lambda's, for Function URLs) `aws:cdk:path` Metadata so the
+  // `--api` filter in `filterRoutesByApiIdentifier` can accept the
+  // CDK Construct path form — same UX rule the rest of `cdkd local *`
+  // family uses.
+
+  it('propagates RestApi aws:cdk:path to REST v1 routes', () => {
+    const stack = buildStack('S', {
+      Api: {
+        Type: 'AWS::ApiGateway::RestApi',
+        Properties: {},
+        Metadata: { 'aws:cdk:path': 'WebStack/MyRestApi/Resource' },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.apiCdkPath).toBe('WebStack/MyRestApi/Resource');
+    expect(route.apiStackName).toBe('S');
+  });
+
+  it('propagates HTTP API aws:cdk:path to v2 routes', () => {
+    const stack = buildStack('S', {
+      Api: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'HTTP' },
+        Metadata: { 'aws:cdk:path': 'WebStack/MyHttpApi/Resource' },
+      },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.apiCdkPath).toBe('WebStack/MyHttpApi/Resource');
+    expect(route.apiStackName).toBe('S');
+  });
+
+  it('propagates the BACKING LAMBDA aws:cdk:path to Function URLs (not the URL resource)', () => {
+    // For Function URLs, the natural CDK Construct path is the
+    // Function's path (the URL is an auto-generated child). Users
+    // expect `--api MyStack/MyHandler` to match — so surface the
+    // Lambda's cdk path, not the URL's own.
+    const stack = buildStack('S', {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {},
+        Metadata: { 'aws:cdk:path': 'BackendStack/GoHandler/Resource' },
+      },
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: { AuthType: 'NONE', TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+        Metadata: { 'aws:cdk:path': 'BackendStack/GoHandler/FunctionUrl' },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.source).toBe('function-url');
+    expect(route.apiCdkPath).toBe('BackendStack/GoHandler/Resource');
+    expect(route.apiStackName).toBe('S');
+  });
+
+  it('omits apiCdkPath when the parent resource has no aws:cdk:path metadata', () => {
+    // Backward compat path — hand-rolled CFn resources or templates
+    // without the metadata stay matchable by bare logical id (and
+    // by stack-qualified logical id, since `apiStackName` is always
+    // set from the StackInfo).
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.apiCdkPath).toBeUndefined();
+    expect(route.apiStackName).toBe('S');
+    expect(route.apiLogicalId).toBe('Api');
+  });
+});
+
+describe('discoverRoutes — multi-error aggregation (template-structural)', () => {
+  it('collects multiple template-structural failures into one message', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      // M1: missing Integration → template-structural failure.
+      M1: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+        },
+      },
+      // M2: RestApiId not a Ref → template-structural failure.
+      M2: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RestApiId: 'literal-not-a-ref',
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'AWS_PROXY', Uri: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+        },
+      },
+    });
+    try {
+      discoverRoutes([stack]);
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(RouteDiscoveryError);
+      expect((e as Error).message).toMatch(/2 malformed route/);
+    }
+  });
+});
+
+describe('discoverRoutes — deferred-error unsupported (multi-route)', () => {
+  it('collects multiple per-integration unsupportedness as separate routes, no throw', () => {
+    // Pre-refactor: this fixture would have thrown a RouteDiscoveryError
+    // listing both routes. Post-refactor: discovery succeeds with two
+    // routes carrying `unsupported`; boot proceeds; 501 fires at request
+    // time.
+    // Post-#457: MOCK is no longer unsupported (the dispatcher handles
+    // it). The fixture uses an AWS-integration-to-S3 (non-Lambda service)
+    // case, which remains unsupported in v1.
+    // Post-#621: Function URL `AuthType: 'AWS_IAM'` is no longer
+    // unsupported — it routes through the SigV4 verifier. The Function
+    // URL row in this fixture uses an unrecognized `AuthType: 'CUSTOM'`
+    // value instead so the deferred-unsupported behavior is still
+    // exercised here.
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      M1: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS',
+            Uri: 'arn:aws:apigateway:us-east-1:s3:path/my-bucket/{key}',
+          },
+        },
+      },
+      U1: {
+        Type: 'AWS::Lambda::Url',
+        Properties: { AuthType: 'CUSTOM', TargetFunctionArn: { Ref: 'Fn' } },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(2);
+    for (const r of routes) {
+      expect(r.unsupported).toBeDefined();
+    }
+  });
+});
+
+describe('discoverRoutes — REST v1 MOCK CORS preflight', () => {
+  // CDK's `defaultCorsPreflightOptions` synthesizes an OPTIONS Method
+  // backed by a MOCK integration whose IntegrationResponses[0].
+  // ResponseParameters carry literal `method.response.header.<Name>:
+  // "'<value>'"` pairs. We extract those literals and emit a synthetic
+  // preflight route the HTTP server answers directly (204) without
+  // invoking any Lambda.
+  it('detects CDK-shape OPTIONS Method MOCK preflight and extracts headers', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'OPTIONS',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          AuthorizationType: 'NONE',
+          Integration: {
+            Type: 'MOCK',
+            RequestTemplates: { 'application/json': '{ statusCode: 200 }' },
+            IntegrationResponses: [
+              {
+                StatusCode: '204',
+                ResponseParameters: {
+                  'method.response.header.Access-Control-Allow-Headers':
+                    "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+                  'method.response.header.Access-Control-Allow-Origin': "'*'",
+                  'method.response.header.Access-Control-Allow-Methods':
+                    "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                },
+              },
+            ],
+          },
+          MethodResponses: [
+            {
+              StatusCode: '204',
+              ResponseParameters: {
+                'method.response.header.Access-Control-Allow-Headers': true,
+                'method.response.header.Access-Control-Allow-Origin': true,
+                'method.response.header.Access-Control-Allow-Methods': true,
+              },
+            },
+          ],
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.method).toBe('OPTIONS');
+    expect(routes[0]?.pathPattern).toBe('/');
+    expect(routes[0]?.unsupported).toBeUndefined();
+    expect(routes[0]?.mockCors).toEqual({
+      statusCode: 204,
+      headers: {
+        'Access-Control-Allow-Headers':
+          'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD',
+      },
+    });
+    expect(routes[0]?.lambdaLogicalId).toBe('');
+  });
+
+  it('defaults to 204 when StatusCode is missing on the IntegrationResponse', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'OPTIONS',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'MOCK',
+            IntegrationResponses: [
+              {
+                ResponseParameters: {
+                  'method.response.header.Access-Control-Allow-Origin': "'*'",
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(discoverRoutes([stack])[0]?.mockCors?.statusCode).toBe(204);
+  });
+
+  it('falls through to the MOCK dispatcher (kind="mock") when MOCK OPTIONS has no IntegrationResponses (#457)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'OPTIONS',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: { Type: 'MOCK' },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes[0]?.mockCors).toBeUndefined();
+    expect(routes[0]?.restV1Integration?.kind).toBe('mock');
+  });
+
+  it('falls through to the MOCK dispatcher when MOCK is non-OPTIONS (e.g. POST) (#457)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'POST',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'MOCK',
+            IntegrationResponses: [
+              {
+                StatusCode: '200',
+                ResponseParameters: {
+                  'method.response.header.X-Custom': "'value'",
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes[0]?.mockCors).toBeUndefined();
+    expect(routes[0]?.restV1Integration?.kind).toBe('mock');
+  });
+
+  it('all-intrinsic ResponseParameters falls through to the MOCK dispatcher (no preflight shape match) (#457)', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'OPTIONS',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'MOCK',
+            IntegrationResponses: [
+              {
+                StatusCode: '204',
+                ResponseParameters: {
+                  'method.response.header.X-Sub': { 'Fn::Sub': "'${SomeRef}'" },
+                  'method.response.header.X-Unquoted': 'no-quotes-around-this',
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes[0]?.mockCors).toBeUndefined();
+    expect(routes[0]?.restV1Integration?.kind).toBe('mock');
+  });
+
+  it('mixed-shape ResponseParameters (one literal + one intrinsic) falls through to MOCK dispatcher, all-or-nothing on preflight (#457)', () => {
+    // Load-bearing: a partial preflight with some headers missing would
+    // silently break CORS in the browser. The synthetic preflight path
+    // is all-or-nothing; the MOCK dispatcher takes over and answers via
+    // its IntegrationResponses[]/ResponseTemplates contract instead.
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'OPTIONS',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'MOCK',
+            IntegrationResponses: [
+              {
+                StatusCode: '204',
+                ResponseParameters: {
+                  'method.response.header.Access-Control-Allow-Origin': "'*'",
+                  'method.response.header.Access-Control-Allow-Headers': {
+                    'Fn::Sub': "'${HeaderListVar}'",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes[0]?.mockCors).toBeUndefined();
+    expect(routes[0]?.restV1Integration?.kind).toBe('mock');
+  });
+});
+
+describe('discoverRoutes — HTTP API v2 unresolvable Lambda Arn (deferred-error symmetry)', () => {
+  // Symmetric with the REST v1 case (`flags Fn::Sub against an arbitrary
+  // (non-invoke-ARN) template as deferred-error unsupported`). HTTP API
+  // v2 routes whose IntegrationUri carries an unresolvable Lambda Arn
+  // intrinsic (cross-stack reference, imported Lambda, hand-rolled
+  // `Fn::Sub` outside the invoke-ARN wrapper) flow through the same
+  // unsupported branch.
+  it('flags HTTP API v2 IntegrationUri with non-invoke-ARN Fn::Sub as deferred-error unsupported', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          // Bare `${X.Arn}` lacks the `:lambda:path/2015-03-31/functions/`
+          // invoke-ARN marker, so the resolver cannot pin a Lambda
+          // logical id — same shape as the REST v1 unresolvable case.
+          IntegrationUri: { 'Fn::Sub': '${ImportedHandler.Arn}' },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const routes = discoverRoutes([stack]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.unsupported?.reason).toMatch(/Lambda Arn intrinsics/);
+    expect(routes[0]?.lambdaLogicalId).toBe('');
+    expect(routes[0]?.apiLogicalId).toBe('Api'); // route identity preserved for the route table
+    expect(routes[0]?.method).toBe('GET');
+    expect(routes[0]?.pathPattern).toBe('/items');
+  });
+});

--- a/tests/unit/local/route-matcher.test.ts
+++ b/tests/unit/local/route-matcher.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { matchRoute } from '../../../src/local/route-matcher.js';
+import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+
+function r(method: string, pathPattern: string, lambdaLogicalId = 'Fn'): DiscoveredRoute {
+  return {
+    method,
+    pathPattern,
+    lambdaLogicalId,
+    source: 'http-api',
+    apiVersion: 'v2',
+    stage: '$default',
+    declaredAt: `Test/${method}-${pathPattern}`,
+  };
+}
+
+describe('matchRoute — full match', () => {
+  it('matches a literal path', () => {
+    const result = matchRoute('GET', '/items', [r('GET', '/items')]);
+    expect(result?.route.pathPattern).toBe('/items');
+    expect(result?.pathParameters).toEqual({});
+  });
+
+  it('extracts {name} placeholders', () => {
+    const result = matchRoute('GET', '/items/42', [r('GET', '/items/{id}')]);
+    expect(result?.route.pathPattern).toBe('/items/{id}');
+    expect(result?.pathParameters).toEqual({ id: '42' });
+  });
+
+  it('rejects mismatched segment count', () => {
+    expect(matchRoute('GET', '/items/1/2', [r('GET', '/items/{id}')])).toBeNull();
+  });
+
+  it('rejects mismatched literal segment', () => {
+    expect(matchRoute('GET', '/widgets/1', [r('GET', '/items/{id}')])).toBeNull();
+  });
+
+  it('routes ANY-method routes to every HTTP method', () => {
+    const result = matchRoute('PATCH', '/items', [r('ANY', '/items')]);
+    expect(result?.route.pathPattern).toBe('/items');
+  });
+
+  it('case-insensitive method comparison', () => {
+    expect(matchRoute('get', '/items', [r('GET', '/items')])).not.toBeNull();
+  });
+
+  it('treats trailing slash as equivalent', () => {
+    expect(matchRoute('GET', '/items/', [r('GET', '/items')])).not.toBeNull();
+  });
+});
+
+describe('matchRoute — precedence (3-tier)', () => {
+  it('full match beats greedy proxy', () => {
+    const routes = [r('GET', '/items/{proxy+}', 'Proxy'), r('GET', '/items/42', 'Specific')];
+    const result = matchRoute('GET', '/items/42', routes);
+    expect(result?.route.lambdaLogicalId).toBe('Specific');
+  });
+
+  it('greedy proxy beats $default', () => {
+    const routes = [r('ANY', '$default', 'Default'), r('ANY', '/api/{proxy+}', 'Proxy')];
+    const result = matchRoute('GET', '/api/foo/bar', routes);
+    expect(result?.route.lambdaLogicalId).toBe('Proxy');
+    expect(result?.pathParameters).toEqual({ proxy: 'foo/bar' });
+  });
+
+  it('falls through to $default', () => {
+    const routes = [r('GET', '/items', 'A'), r('ANY', '$default', 'Default')];
+    const result = matchRoute('GET', '/anything', routes);
+    expect(result?.route.lambdaLogicalId).toBe('Default');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(matchRoute('GET', '/nothing', [r('GET', '/items')])).toBeNull();
+  });
+});
+
+describe('matchRoute — literal-segment tie-break', () => {
+  it('within tier 1, more literal segments wins', () => {
+    const routes = [
+      r('GET', '/{a}/{b}', 'AllPlaceholders'),
+      r('GET', '/items/{b}', 'OneLiteral'),
+    ];
+    const result = matchRoute('GET', '/items/42', routes);
+    expect(result?.route.lambdaLogicalId).toBe('OneLiteral');
+  });
+});
+
+describe('matchRoute — greedy proxy', () => {
+  it('captures every remaining segment as `proxy`', () => {
+    const result = matchRoute('GET', '/api/v1/foo/bar', [r('GET', '/api/{proxy+}')]);
+    expect(result?.pathParameters).toEqual({ proxy: 'v1/foo/bar' });
+  });
+
+  it('matches root /{proxy+}', () => {
+    const result = matchRoute('GET', '/anything/here', [r('ANY', '/{proxy+}')]);
+    expect(result?.pathParameters).toEqual({ proxy: 'anything/here' });
+  });
+
+  it('within tier 2, longest literal prefix wins', () => {
+    const routes = [r('ANY', '/{proxy+}', 'Root'), r('ANY', '/api/{proxy+}', 'Api')];
+    const result = matchRoute('GET', '/api/v1', routes);
+    expect(result?.route.lambdaLogicalId).toBe('Api');
+  });
+
+  it('extracts {name} placeholders in the literal prefix of a {proxy+} pattern', () => {
+    // CDK's `addProxy({path: '/items/{id}'})` synthesizes
+    // `/items/{id}/{proxy+}`. The literal prefix has a placeholder; the
+    // greedy tail captures the rest. Both `id` and `proxy` must surface
+    // in pathParameters.
+    const result = matchRoute('GET', '/items/42/sub/path', [
+      r('GET', '/items/{id}/{proxy+}'),
+    ]);
+    expect(result?.route.pathPattern).toBe('/items/{id}/{proxy+}');
+    expect(result?.pathParameters).toEqual({ id: '42', proxy: 'sub/path' });
+  });
+
+  it('method precedence still beats {proxy+} prefix-placeholder when methods differ', () => {
+    // Sibling pattern with a different method must NOT win for a GET
+    // request. The placeholder-extracting branch still has to honor
+    // the method filter applied in tier 1.
+    const routes = [
+      r('POST', '/items/{id}/{proxy+}', 'Post'),
+      r('GET', '/items/{id}/{proxy+}', 'Get'),
+    ];
+    const result = matchRoute('GET', '/items/42/sub/path', routes);
+    expect(result?.route.lambdaLogicalId).toBe('Get');
+    expect(result?.pathParameters).toEqual({ id: '42', proxy: 'sub/path' });
+  });
+});

--- a/tests/unit/local/websocket-route-discovery.test.ts
+++ b/tests/unit/local/websocket-route-discovery.test.ts
@@ -1,0 +1,627 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  discoverWebSocketApis,
+  discoverWebSocketApisOrThrow,
+  parseSelectionExpressionPath,
+} from '../../../src/local/websocket-route-discovery.js';
+import { RouteDiscoveryError } from '../../../src/utils/error-handler.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+function buildStack(stackName: string, resources: Record<string, TemplateResource>): StackInfo {
+  const template: CloudFormationTemplate = { Resources: resources };
+  return {
+    stackName,
+    displayName: stackName,
+    artifactId: stackName,
+    template,
+    dependencyNames: [],
+  };
+}
+
+function buildLambda(): TemplateResource {
+  return {
+    Type: 'AWS::Lambda::Function',
+    Properties: { Runtime: 'nodejs20.x', Handler: 'index.handler' },
+  };
+}
+
+function buildIntegration(): TemplateResource {
+  return {
+    Type: 'AWS::ApiGatewayV2::Integration',
+    Properties: {
+      ApiId: { Ref: 'WsApi' },
+      IntegrationType: 'AWS_PROXY',
+      IntegrationUri: { 'Fn::GetAtt': ['MyHandler', 'Arn'] },
+    },
+  };
+}
+
+describe('discoverWebSocketApis', () => {
+  it('returns empty + no error for a stack with no WebSocket API', () => {
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+    });
+    const { apis, errors } = discoverWebSocketApis([stack]);
+    expect(apis).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  it('discovers a WebSocket API with $connect / $disconnect / $default routes', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectInteg: buildIntegration(),
+      DisconnectInteg: buildIntegration(),
+      DefaultInteg: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'ConnectInteg' }]] },
+        },
+      },
+      DisconnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$disconnect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'DisconnectInteg' }]] },
+        },
+      },
+      DefaultRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$default',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'DefaultInteg' }]] },
+        },
+      },
+      Stage: {
+        Type: 'AWS::ApiGatewayV2::Stage',
+        Properties: { ApiId: { Ref: 'WsApi' }, StageName: 'prod' },
+      },
+    });
+    const { apis, errors } = discoverWebSocketApis([stack]);
+    expect(errors).toEqual([]);
+    expect(apis).toHaveLength(1);
+    const api = apis[0]!;
+    expect(api.apiLogicalId).toBe('WsApi');
+    expect(api.apiStackName).toBe('S');
+    expect(api.routeSelectionExpression).toBe('$request.body.action');
+    expect(api.stage).toBe('prod');
+    expect(api.routes.map((r) => r.routeKey).sort()).toEqual(
+      ['$connect', '$default', '$disconnect'].sort()
+    );
+    expect(api.routes.every((r) => r.targetLambdaLogicalId === 'MyHandler')).toBe(true);
+  });
+
+  it('defaults selection expression to $request.body.action when omitted', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET', Name: 'WsApi' },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { apis, errors } = discoverWebSocketApis([stack]);
+    expect(errors).toEqual([]);
+    expect(apis[0]!.routeSelectionExpression).toBe('$request.body.action');
+  });
+
+  it('defaults stage to "local" when no AWS::ApiGatewayV2::Stage refers to the API', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET', Name: 'WsApi' },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([stack]);
+    expect(apis[0]!.stage).toBe('local');
+  });
+
+  it('rejects an API with no routes', () => {
+    const stack = buildStack('S', {
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET', Name: 'WsApi' },
+      },
+    });
+    const { apis, errors } = discoverWebSocketApis([stack]);
+    expect(apis).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('no AWS::ApiGatewayV2::Route children');
+  });
+
+  it('rejects unsupported selection expression shapes', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          RouteSelectionExpression: '$request.header.X-Route',
+        },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { errors } = discoverWebSocketApis([stack]);
+    expect(errors[0]).toContain("RouteSelectionExpression '$request.header.X-Route'");
+  });
+
+  it('accepts nested-dot selection expressions', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          RouteSelectionExpression: '$request.body.v1.action',
+        },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { apis, errors } = discoverWebSocketApis([stack]);
+    expect(errors).toEqual([]);
+    expect(apis[0]!.routeSelectionExpression).toBe('$request.body.v1.action');
+  });
+
+  it('rejects non-AWS_PROXY integration types', () => {
+    const stack = buildStack('S', {
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET' },
+      },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          IntegrationType: 'MOCK',
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { errors } = discoverWebSocketApis([stack]);
+    expect(errors[0]).toContain("IntegrationType 'MOCK' is not supported");
+  });
+
+  it('rejects duplicate RouteKey within the same API', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET' },
+      },
+      Integ: buildIntegration(),
+      Route1: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+      Route2: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { errors } = discoverWebSocketApis([stack]);
+    expect(errors[0]).toContain("duplicate RouteKey '$connect'");
+  });
+
+  it('discovers two WebSocket APIs across two stacks', () => {
+    const a = buildStack('A', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET' },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const b = buildStack('B', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET' },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([a, b]);
+    expect(apis.map((api) => api.apiStackName).sort()).toEqual(['A', 'B']);
+  });
+
+  it('orThrow surface aggregates per-error into a RouteDiscoveryError', () => {
+    const stack = buildStack('S', {
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET' },
+      },
+    });
+    expect(() => discoverWebSocketApisOrThrow([stack])).toThrow(RouteDiscoveryError);
+  });
+
+  it('accepts Fn::Sub target shape (1-arg)', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET' },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Sub': 'integrations/${Integ}' },
+        },
+      },
+    });
+    const { apis, errors } = discoverWebSocketApis([stack]);
+    expect(errors).toEqual([]);
+    expect(apis[0]!.routes[0]!.targetLambdaLogicalId).toBe('MyHandler');
+  });
+});
+
+describe('parseSelectionExpressionPath', () => {
+  it('parses single-segment $request.body.action into [action]', () => {
+    expect(parseSelectionExpressionPath('$request.body.action')).toEqual(['action']);
+  });
+
+  it('parses nested $request.body.v1.action into [v1, action]', () => {
+    expect(parseSelectionExpressionPath('$request.body.v1.action')).toEqual(['v1', 'action']);
+  });
+
+  it('returns empty for shapes outside the supported grammar', () => {
+    expect(parseSelectionExpressionPath('$request.body')).toEqual([]);
+    expect(parseSelectionExpressionPath('$context.connectionId')).toEqual([]);
+  });
+});
+
+// #531 m2-test: `parseSelectionExpressionPath` is only ever called on
+// expressions that passed `assertSupportedSelectionExpression` at
+// discovery time, but the discovery-side validator is the actual
+// boundary that user-supplied templates hit. Pin the rejection set so a
+// future grammar relaxation can't silently leak unsupported shapes into
+// the dispatcher.
+describe('selection expression validation rejection set (#531 m2)', () => {
+  const ApiResource = {
+    Type: 'AWS::ApiGatewayV2::Api',
+    Properties: {
+      ProtocolType: 'WEBSOCKET',
+    },
+  } as const;
+  // Build a stack with a hand-picked RouteSelectionExpression and assert
+  // the discovery surface error mentions exactly that string. The lambda
+  // / integration / route boilerplate matches the other tests in this
+  // file.
+  function tryExpression(expr: string): string | undefined {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        ...ApiResource,
+        Properties: {
+          ...ApiResource.Properties,
+          RouteSelectionExpression: expr,
+        },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { errors } = discoverWebSocketApis([stack]);
+    return errors[0];
+  }
+
+  it.each([
+    // Trailing dot: regex requires at least one identifier after each
+    // dot; a bare trailing dot fails the `[A-Za-z_]` class.
+    '$request.body.',
+    // Nested trailing dot
+    '$request.body.action.',
+    // Uppercase prefix: regex is case-sensitive, matches AWS-deployed
+    // case-sensitive selection expressions.
+    '$REQUEST.body.action',
+    // Mixed-case middle: the leading `$request.body.` is literal.
+    '$Request.Body.action',
+    // Leading / trailing whitespace
+    ' $request.body.action',
+    '$request.body.action ',
+    // Identifier starting with a digit
+    '$request.body.1action',
+    // Empty key segment in the middle
+    '$request.body..action',
+    // Hyphen in identifier (regex only allows `[A-Za-z0-9_]`)
+    '$request.body.my-action',
+    // Array-index access (called out by the reviewer as a candidate for
+    // future support — must error today)
+    '$request.body[0]',
+    // Header / context shapes (already tested above; included here for
+    // grouping)
+    '$request.header.action',
+    '$context.connectionId',
+  ])('rejects %j with an actionable error', (expr) => {
+    const err = tryExpression(expr);
+    expect(err).toBeDefined();
+    expect(err).toContain(expr);
+    expect(err).toContain('not supported');
+  });
+});
+
+// B2 (#526): non-NONE `AuthorizationType` on any Route belonging to a
+// WebSocket API must tag the parent API as `unsupported`. cdkd v1 does
+// not emulate WebSocket authorizers; silently admitting unauthenticated
+// clients would be a security gap (mirrors the structural pre-empt fix
+// PR #514 shipped for HTTP API v2 service integrations). The CLI's
+// attach loop skips an `unsupported`-tagged API and surfaces the reason
+// as a startup warn.
+describe('discoverWebSocketApis B2 authorizer admission guard', () => {
+  function buildAuthApi(authorizationType: string | undefined): StackInfo {
+    return buildStack('AuthStack', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectIntegration: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: 'integrations/ConnectIntegration',
+          ...(authorizationType !== undefined && { AuthorizationType: authorizationType }),
+        },
+      },
+    });
+  }
+
+  it('tags API as unsupported when $connect Route has AuthorizationType: AWS_IAM', () => {
+    const { apis, errors } = discoverWebSocketApis([buildAuthApi('AWS_IAM')]);
+    expect(errors).toEqual([]);
+    expect(apis).toHaveLength(1);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('AWS_IAM');
+    expect(apis[0]!.unsupported!.reason).toContain('$connect');
+    expect(apis[0]!.unsupported!.reason).toContain('cdkl v1 does not emulate');
+  });
+
+  it('tags API as unsupported when $connect Route has AuthorizationType: CUSTOM', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('CUSTOM')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('CUSTOM');
+  });
+
+  it('tags API as unsupported when $connect Route has AuthorizationType: JWT', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('JWT')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('JWT');
+  });
+
+  it('does NOT tag API as unsupported when AuthorizationType is explicitly NONE', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('NONE')]);
+    expect(apis[0]!.unsupported).toBeUndefined();
+  });
+
+  it('does NOT tag API as unsupported when AuthorizationType is omitted (AWS default = NONE)', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi(undefined)]);
+    expect(apis[0]!.unsupported).toBeUndefined();
+  });
+
+  it('lists every auth-tagged route in the reason when multiple routes have auth', () => {
+    const stack = buildStack('MultiAuth', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectIntegration: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: 'integrations/ConnectIntegration',
+          AuthorizationType: 'AWS_IAM',
+        },
+      },
+      DefaultRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$default',
+          Target: 'integrations/ConnectIntegration',
+          AuthorizationType: 'CUSTOM',
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([stack]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    const reason = apis[0]!.unsupported!.reason;
+    expect(reason).toContain('$connect [AuthorizationType=AWS_IAM]');
+    expect(reason).toContain('$default [AuthorizationType=CUSTOM]');
+  });
+
+  // Issue #537 item 8: defense-in-depth for AuthorizationType shapes that
+  // are neither the literal `'NONE'` string nor `undefined`. Includes
+  // typo'd known names, hypothetical future AWS additions, and the
+  // intrinsic-valued / structurally-malformed shapes from item 1.
+  it('tags API as unsupported for typo\'d AuthorizationType (IAM, not AWS_IAM)', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('IAM')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('IAM');
+  });
+  it('tags API as unsupported for hypothetical future AuthorizationType (LAMBDA)', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('LAMBDA')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('LAMBDA');
+  });
+  it('tags API as unsupported when AuthorizationType is `null` (fail-closed)', () => {
+    const stack = buildStack('NullAuth', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectIntegration: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: 'integrations/ConnectIntegration',
+          AuthorizationType: null,
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([stack]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('<intrinsic-or-malformed>');
+  });
+  it('tags API as unsupported when AuthorizationType is an empty string (fail-closed)', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('<intrinsic-or-malformed>');
+  });
+  it('tags API as unsupported when AuthorizationType is an intrinsic ({Ref}) — defense-in-depth', () => {
+    const stack = buildStack('RefAuth', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectIntegration: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: 'integrations/ConnectIntegration',
+          AuthorizationType: { Ref: 'AuthTypeParam' },
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([stack]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('<intrinsic-or-malformed>');
+  });
+
+  it('does NOT tag the API when only $disconnect / non-$connect routes have NONE auth', () => {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectIntegration: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: 'integrations/ConnectIntegration',
+          AuthorizationType: 'NONE',
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([stack]);
+    expect(apis[0]!.unsupported).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Expose the four `start-api` route-resolution modules from the package entry (`src/index.ts`) so a host that shims cdk-local's `src/local` modules verbatim (e.g. cdkd) can re-export them 1:1 instead of carrying byte-identical copies:

- **route-discovery**: `discoverRoutes` (+ `DiscoveredRoute` / `RestV1IntegrationConfig`)
- **route-matcher**: `matchRoute` (+ `RouteMatchResult`)
- **api-gateway-event**: `buildHttpApiV2Event` / `buildRestV1Event` / `applyAuthorizerOverlay` (+ `HttpRequestSnapshot` / `MatchedRouteContext` / `AuthorizerEventOverlay`)
- **websocket-route-discovery**: `discoverWebSocketApis` / `discoverWebSocketApisOrThrow` / `parseSelectionExpressionPath` (+ `DiscoveredWebSocketApi` / `WebSocketRouteEntry`)

The set is driven by the consuming host's actual `import` statements, not a speculative bulk export.

Two supporting changes:

- **Tests ported to where the implementation lives.** These four modules had no unit tests in this repo; their tests lived only in the consuming host. Ported them into `tests/unit/local/`. The only adjustment from a verbatim copy is one branded assertion in `websocket-route-discovery.test.ts` (`cdkd v1` → `cdkl v1`) — the test runs under this repo's default `embedConfig`, and the route-discovery error strings it exercises are otherwise `embedConfig`-parameterized.
- **Docs.** Documented the layer in `docs/library-mode.md` under the existing "Low-level building blocks (shim hosts)" section.

Purely additive to `src/index.ts`. `feat` → minor version bump.

Note: `route-discovery.ts` still emits a `go-to-k/cdkd` docs URL in one error string (a residual cross-reference). That is intentionally left for the self-containment cleanup (cdk-local #52), which will parameterize it via a new `embedConfig` field — leaving it now means the consuming host's shim keeps emitting the host's own URL until then.

## Test plan

- [x] `vp run verify` (typecheck + lint + format-check + 431 unit tests incl. the 4 ported) green
- [x] Built `dist/index.js` smoke test: all 8 route-layer functions importable from the package entry; new types present in `dist/index.d.ts`
- [x] No existing export removed/renamed (additive only)
