### PR TITLE
fix(synthesis): apply --profile/--region to toolkit-lib lookups

### DIFF
--- a/src/synthesis/assembly-reader.ts
+++ b/src/synthesis/assembly-reader.ts
@@ -2,7 +2,7 @@ import {
   AssetManifestArtifact,
   type CloudFormationStackArtifact,
 } from '@aws-cdk/cloud-assembly-api';
-import { Toolkit, CdkAppMultiContext } from '@aws-cdk/toolkit-lib';
+import { Toolkit, CdkAppMultiContext, BaseCredentials } from '@aws-cdk/toolkit-lib';
 import { CdklIoHost } from './cdkl-io-host.js';
 import type { CloudFormationTemplate } from '../types/resource.js';
 
@@ -97,6 +97,20 @@ export interface AssemblyReadOptions {
   /** Additional env vars passed to the CDK app subprocess (e.g. `AWS_PROFILE`, `AWS_REGION`). */
   env?: Record<string, string | undefined>;
   /**
+   * AWS profile used for toolkit-lib's OWN AWS calls — most importantly
+   * the synth-time context lookups (assume `cdk-hnb659fds-lookup-role-*`
+   * + the SSM / VPC / etc. provider call). Without this, those lookups
+   * fall back to the parent process's default credential chain even
+   * when `--profile` was supplied, so a cross-account lookup-role
+   * assume resolves with the wrong account and synthesis aborts with
+   * `AssemblyError: Found errors`. Setting `env.AWS_PROFILE` alone is
+   * not enough: that only reaches the forked CDK app subprocess, not
+   * the lookup machinery that runs in this process.
+   */
+  profile?: string;
+  /** Default region for toolkit-lib's own AWS calls (context lookups). */
+  region?: string;
+  /**
    * Working directory the CDK app subprocess is executed in. Defaults
    * to the current process cwd. When `context` is also set, this is
    * also the directory `CdkAppMultiContext` resolves `cdk.json` /
@@ -121,7 +135,15 @@ export class AssemblyReader {
    * artifact in the resulting Cloud Assembly.
    */
   async read(cdkAppCommand: string, options: AssemblyReadOptions = {}): Promise<StackInfo[]> {
-    const toolkit = new Toolkit({ ioHost: new CdklIoHost() });
+    const toolkit = new Toolkit({
+      ioHost: new CdklIoHost(),
+      sdkConfig: {
+        baseCredentials: BaseCredentials.awsCliCompatible({
+          ...(options.profile !== undefined && { profile: options.profile }),
+          ...(options.region !== undefined && { defaultRegion: options.region }),
+        }),
+      },
+    });
     const hasContextOverrides =
       options.context !== undefined && Object.keys(options.context).length > 0;
     const source = await toolkit.fromCdkApp(cdkAppCommand, {

--- a/src/synthesis/synthesizer.ts
+++ b/src/synthesis/synthesizer.ts
@@ -51,10 +51,16 @@ export class Synthesizer {
     const env: Record<string, string | undefined> = {};
     if (opts.profile !== undefined) {
       env['AWS_PROFILE'] = opts.profile;
+      // Also threaded into the Toolkit's own SDK config (not just the
+      // subprocess env) so synth-time context lookups assume the
+      // lookup-role with this profile rather than the parent process's
+      // default credential chain.
+      readOpts.profile = opts.profile;
     }
     if (opts.region !== undefined) {
       env['AWS_REGION'] = opts.region;
       env['CDK_DEFAULT_REGION'] = opts.region;
+      readOpts.region = opts.region;
     }
     if (Object.keys(env).length > 0) {
       readOpts.env = env;

--- a/tests/unit/synthesis/assembly-reader.test.ts
+++ b/tests/unit/synthesis/assembly-reader.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const {
+  MockToolkit,
+  mockFromCdkApp,
+  mockSynth,
+  mockDispose,
+  mockAwsCliCompatible,
+  MockCdkAppMultiContext,
+  baseCredsSentinel,
+} = vi.hoisted(() => {
+  const baseCredsSentinel = { __baseCreds: true };
+  const mockAwsCliCompatible = vi.fn(() => baseCredsSentinel);
+  const mockDispose = vi.fn().mockResolvedValue(undefined);
+  const mockSynth = vi.fn().mockResolvedValue({
+    cloudAssembly: { stacks: [] },
+    dispose: mockDispose,
+  });
+  const mockFromCdkApp = vi.fn().mockResolvedValue({ __source: true });
+  const MockToolkit = vi.fn().mockImplementation(() => ({
+    fromCdkApp: mockFromCdkApp,
+    synth: mockSynth,
+  }));
+  const MockCdkAppMultiContext = vi.fn();
+  return {
+    MockToolkit,
+    mockFromCdkApp,
+    mockSynth,
+    mockDispose,
+    mockAwsCliCompatible,
+    MockCdkAppMultiContext,
+    baseCredsSentinel,
+  };
+});
+
+vi.mock('@aws-cdk/toolkit-lib', () => ({
+  Toolkit: MockToolkit,
+  CdkAppMultiContext: MockCdkAppMultiContext,
+  BaseCredentials: { awsCliCompatible: mockAwsCliCompatible },
+  // CdklIoHost extends NonInteractiveIoHost; provide a stub so the
+  // subclass `extends` clause resolves under the mocked module.
+  NonInteractiveIoHost: class {
+    async notify(): Promise<void> {}
+  },
+}));
+
+vi.mock('@aws-cdk/cloud-assembly-api', () => ({
+  AssetManifestArtifact: class {},
+}));
+
+import { AssemblyReader } from '../../../src/synthesis/assembly-reader.js';
+
+describe('AssemblyReader.read — toolkit SDK credential wiring', () => {
+  beforeEach(() => {
+    MockToolkit.mockClear();
+    mockFromCdkApp.mockClear();
+    mockSynth.mockClear();
+    mockDispose.mockClear();
+    mockAwsCliCompatible.mockClear();
+  });
+
+  it('passes profile + region into BaseCredentials.awsCliCompatible', async () => {
+    await new AssemblyReader().read('node app.ts', {
+      profile: 'myprof',
+      region: 'ap-northeast-1',
+    });
+
+    expect(mockAwsCliCompatible).toHaveBeenCalledWith({
+      profile: 'myprof',
+      defaultRegion: 'ap-northeast-1',
+    });
+  });
+
+  it('seeds the Toolkit sdkConfig.baseCredentials with the awsCliCompatible result', async () => {
+    await new AssemblyReader().read('node app.ts', { profile: 'p' });
+
+    expect(MockToolkit).toHaveBeenCalledTimes(1);
+    const toolkitArgs = MockToolkit.mock.calls[0][0];
+    expect(toolkitArgs.sdkConfig.baseCredentials).toBe(baseCredsSentinel);
+  });
+
+  it('omits defaultRegion when only profile is set', async () => {
+    await new AssemblyReader().read('x', { profile: 'p' });
+
+    expect(mockAwsCliCompatible).toHaveBeenCalledWith({ profile: 'p' });
+  });
+
+  it('omits profile when only region is set', async () => {
+    await new AssemblyReader().read('x', { region: 'us-east-1' });
+
+    expect(mockAwsCliCompatible).toHaveBeenCalledWith({ defaultRegion: 'us-east-1' });
+  });
+
+  it('calls awsCliCompatible with no profile/region keys when neither is supplied', async () => {
+    await new AssemblyReader().read('x');
+
+    expect(mockAwsCliCompatible).toHaveBeenCalledWith({});
+  });
+
+  it('still drives fromCdkApp + synth + dispose for the happy path', async () => {
+    const stacks = await new AssemblyReader().read('node app.ts');
+
+    expect(mockFromCdkApp).toHaveBeenCalledTimes(1);
+    expect(mockFromCdkApp.mock.calls[0][0]).toBe('node app.ts');
+    expect(mockSynth).toHaveBeenCalledTimes(1);
+    expect(mockDispose).toHaveBeenCalledTimes(1);
+    expect(stacks).toEqual([]);
+  });
+});

--- a/tests/unit/synthesis/synthesizer.test.ts
+++ b/tests/unit/synthesis/synthesizer.test.ts
@@ -57,17 +57,18 @@ describe('Synthesizer.synthesize', () => {
     expect(opts).not.toHaveProperty('outdir');
   });
 
-  it('threads profile into readOpts.env.AWS_PROFILE', async () => {
+  it('threads profile into readOpts.env.AWS_PROFILE AND readOpts.profile', async () => {
     mockRead.mockResolvedValue([]);
     const s = new Synthesizer();
     await s.synthesize({ app: 'x', profile: 'dev' });
 
     expect(mockRead).toHaveBeenCalledWith('x', {
       env: { AWS_PROFILE: 'dev' },
+      profile: 'dev',
     });
   });
 
-  it('threads region into readOpts.env.AWS_REGION AND CDK_DEFAULT_REGION', async () => {
+  it('threads region into env (AWS_REGION + CDK_DEFAULT_REGION) AND readOpts.region', async () => {
     mockRead.mockResolvedValue([]);
     const s = new Synthesizer();
     await s.synthesize({ app: 'x', region: 'us-east-1' });
@@ -77,10 +78,11 @@ describe('Synthesizer.synthesize', () => {
         AWS_REGION: 'us-east-1',
         CDK_DEFAULT_REGION: 'us-east-1',
       },
+      region: 'us-east-1',
     });
   });
 
-  it('threads profile + region together into a single env object', async () => {
+  it('threads profile + region into both env and the top-level readOpts fields', async () => {
     mockRead.mockResolvedValue([]);
     const s = new Synthesizer();
     await s.synthesize({ app: 'x', profile: 'p', region: 'eu-west-1' });
@@ -91,7 +93,19 @@ describe('Synthesizer.synthesize', () => {
         AWS_REGION: 'eu-west-1',
         CDK_DEFAULT_REGION: 'eu-west-1',
       },
+      profile: 'p',
+      region: 'eu-west-1',
     });
+  });
+
+  it('omits readOpts.profile / readOpts.region when neither is set', async () => {
+    mockRead.mockResolvedValue([]);
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'x' });
+
+    const opts = mockRead.mock.calls[0][1];
+    expect(opts).not.toHaveProperty('profile');
+    expect(opts).not.toHaveProperty('region');
   });
 
   it('omits readOpts.env when neither profile nor region is set', async () => {
@@ -148,6 +162,8 @@ describe('Synthesizer.synthesize', () => {
         AWS_REGION: 'ap-northeast-1',
         CDK_DEFAULT_REGION: 'ap-northeast-1',
       },
+      profile: 'p',
+      region: 'ap-northeast-1',
     });
   });
 


### PR DESCRIPTION
## Summary

`--profile` / `--region` were applied only to the forked CDK app
subprocess (via `AWS_PROFILE` in `fromCdkApp`'s `env`), but **not** to
the `Toolkit`'s own SDK config. toolkit-lib runs synth-time context
lookups (assume `cdk-hnb659fds-lookup-role-*` + the SSM / VPC / etc.
provider call) in the parent process using
`BaseCredentials.awsCliCompatible()`, which — with no profile supplied —
falls back to the parent process's default credential chain.

As a result, when a stack required an uncached cross-account context
lookup, the lookup-role assume ran with the wrong (default-chain)
account instead of the account behind `--profile`, and synthesis aborted
with `AssemblyError: Found errors`, e.g.:

```
[error at .../DockerImage] Could not assume role in target account
using current credentials (which are for account <default-chain-acct>)
... is not authorized to perform: sts:AssumeRole on resource:
arn:aws:iam::<stack-acct>:role/cdk-hnb659fds-lookup-role-...
```

## Fix

- Add `profile` / `region` to `AssemblyReadOptions`.
- In `AssemblyReader.read`, seed the `Toolkit` `sdkConfig.baseCredentials`
  with `BaseCredentials.awsCliCompatible({ profile, defaultRegion })` so
  context lookups use the same profile/region as the subprocess.
- `Synthesizer.synthesize` threads the existing `--profile` / `--region`
  into both the subprocess `env` (unchanged) and the new top-level
  `readOpts.profile` / `readOpts.region`.

The no-profile path is behavior-preserving: `awsCliCompatible({})` is
equivalent to the prior default `awsCliCompatible()`.

## Test plan

- [x] `vp run check` (typecheck + lint + format)
- [x] `vp run build`
- [x] `vp run test` — 28 files, 309 tests pass
- [x] New `tests/unit/synthesis/assembly-reader.test.ts` locks the
      credential wiring (profile/region -> `awsCliCompatible` ->
      `Toolkit.sdkConfig.baseCredentials`); updated
      `synthesizer.test.ts` for the new `readOpts` fields.
- [x] Live-tested the rebuilt CLI against a real cross-account CDK app:
      a synth-time SSM lookup that previously aborted with
      `AssemblyError` now resolves under the supplied profile and synth
      advances past the lookup.

## Notes

Integration fixtures are single-account / local and cannot reproduce a
cross-account context lookup, so this path is covered by the unit
binding test plus the live run above rather than a Docker integ.
