### PR TITLE
docs(readme): note logical-ID target forms in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ cdkl invoke MyStack/MyFunction --event ./event.json
 
 ![cdkl invoke against a local sample CDK app — no AWS account, no deploy](assets/cdkl-invoke.gif)
 
+Every target argument (across `invoke`, `run-task`, `start-service`) accepts
+either form — the CDK display path is the recommended default, but a
+CloudFormation logical ID works too, which is handy when copying it straight
+out of `cdk.out/<Stack>.template.json` beats tracing the construct path (and
+matches what a SAM background expects):
+
+```bash
+# CDK display path (recommended)
+cdkl invoke MyStack/MyFunction --event ./event.json
+
+# Stack-qualified logical ID (works in any app)
+cdkl invoke MyStack:MyFunction1234ABCD --event ./event.json
+
+# Bare logical ID (single-stack apps — the stack is auto-detected)
+cdkl invoke MyFunction1234ABCD --event ./event.json
+```
+
 #### HTTP APIs & Function URLs — `start-api`
 
 Serve your app's HTTP surface locally — API Gateway routes (REST v1 / HTTP v2 / WebSocket) and Lambda Function URLs — on a local HTTP server.


### PR DESCRIPTION
## Summary

- Documents that `invoke` / `run-task` / `start-service` target arguments accept a CloudFormation logical ID in addition to the CDK display path. The resolvers already supported this (`lambda-resolver.parseTarget` and the mirrored `ecs-task-resolver` accept `Stack:LogicalId` and a bare logical ID in single-stack apps); only the README was missing it.
- Adds a single note next to the first `invoke` example with three concrete commands: CDK display path (recommended), stack-qualified logical ID, and bare logical ID. The note is placed once rather than repeated under every subcommand.
- Motivation: copying a logical ID out of `cdk.out/<Stack>.template.json` is sometimes easier than tracing the construct path, and it matches what a SAM background expects. The display path remains the recommended default.

## Test plan

- [x] `vp run check` (typecheck + lint + format)
- [x] `vp run build`
- [x] `vp test run` — 32 files, 438 tests pass
- [x] Live-test against the `local-invoke` fixture through Docker: both `cdkl invoke CdkLocalInvokeFixture:EchoHandlerB75BC5D4` and bare `cdkl invoke EchoHandlerB75BC5D4` return `{"echoed":{},"greeting":"hello"}`
- [x] No Docker container/network orphans after the run
