### PR TITLE
refactor(error-handler): self-contained error-handler (rename base class, drop dead subclasses, scrub cdkd strings)

### DIFF
--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -5,7 +5,7 @@
  * Two implementations:
  *
  *   - {@link S3LocalStateProvider} (default for `--from-state`) — reads
- *     the host's S3 state for stacks deployed via `cdkd deploy`. Same
+ *     the host's S3 state for stacks deployed via `cdkl deploy`. Same
  *     behavior as the pre-issue-#606 code path; the S3 implementation is
  *     a thin wrapper around the existing `loadStateForStack` +
  *     `buildCrossStackResolver` helpers in
@@ -18,7 +18,7 @@
  *     via the upstream CDK CLI (`cdk deploy` → CloudFormation), so users
  *     migrating between cdk-local and CFn (or running cdk-local against an
  *     existing CFn-managed CDK app) get the same UX they get with
- *     `--from-state` against cdkd-deployed stacks.
+ *     `--from-state` against cdk-local-deployed stacks.
  *
  * The interface intentionally mirrors what `state-resolver.ts` consumes:
  * a `Record<string, ResourceState>` (covers `Ref`), an outputs map
@@ -108,7 +108,7 @@ export interface LocalStateProvider {
    * Build a cross-stack resolver for `Fn::ImportValue` /
    * `Fn::GetStackOutput`. The S3 provider reads the host's exports index +
    * per-stack state; the CFn provider uses `ListExports` (paginated)
-   * for `Fn::ImportValue` and rejects `Fn::GetStackOutput` (cdkd-specific
+   * for `Fn::ImportValue` and rejects `Fn::GetStackOutput` (cdk-local-specific
    * intrinsic — CFn has no equivalent). `consumerRegion` is the
    * region the consumer Lambda / ECS task lives in.
    *

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -6,7 +6,7 @@
  * drops it. That's correct when there's no source of truth for the
  * deployed value — which is also the SAM behavior — but it's wrong when
  * cdk-local has already deployed the stack and the AWS-current physical IDs
- * sit in the cdkd state file.
+ * sit in the cdk-local state file.
  *
  * `--from-state` closes that gap: it loads the host's S3 state for the target
  * stack and substitutes `Ref` / `Fn::GetAtt` / `Fn::Sub` placeholders in
@@ -66,7 +66,7 @@
  *     looked up via `crossStackResolver.resolveImport(exportName)`. The
  *     resolver typically reads the persistent exports index at
  *     `s3://{bucket}/cdkd/_index/{region}/exports.json` populated by
- *     `cdkd deploy`, falling back to a per-stack state.json scan on
+ *     `cdkl deploy`, falling back to a per-stack state.json scan on
  *     index miss (closes issue #454).
  *   - `Fn::GetStackOutput: { StackName, OutputName, Region? }` — looked
  *     up via `crossStackResolver.resolveGetStackOutput(stackName, region,

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -9,12 +9,12 @@
  *       grew. v2 readers see v3 as `version: 3` and fail clearly.
  * - 4 — adds `StackState.imports` (the set of `Fn::ImportValue` references
  *       this stack resolved during its last deploy). Consumed by
- *       `cdkd destroy` to refuse deleting a producer while a consumer still
+ *       `cdkl destroy` to refuse deleting a producer while a consumer still
  *       references its outputs (strong reference, matches CloudFormation).
  *       Layout is the same as v3; only the stack-level shape grew. v3
  *       readers see v4 as `version: 4` and fail clearly.
  * - 5 — adds `ResourceState.deletionPolicy` and `updateReplacePolicy`, the
- *       CloudFormation template attributes recorded at deploy time. cdkd
+ *       CloudFormation template attributes recorded at deploy time. cdk-local
  *       compares these against the next deploy's template to detect
  *       attribute-only changes (e.g. `RemovalPolicy.DESTROY` removed →
  *       `DeletionPolicy: Retain` now in template), which previously fell
@@ -25,8 +25,8 @@
  *       to support `AWS::CloudFormation::Stack` nested-stack adoption (issue
  *       [#459](https://github.com/go-to-k/cdkd/issues/459)). Child stacks
  *       record their parent's name + the child's logical id in the parent's
- *       template, so `cdkd state list` / `state show` can surface the
- *       parent → child tree and `cdkd destroy <child-only>` can reject
+ *       template, so `cdkl state list` / `state show` can surface the
+ *       parent → child tree and `cdkl destroy <child-only>` can reject
  *       with a clear pointer at the parent. The child's S3 key uses
  *       `cdkd/<parent>~<NestedStackLogicalId>/<region>/state.json` (the `~`
  *       separator avoids ambiguity with CDK Stage's `/`). Layout
@@ -76,12 +76,12 @@ export const STATE_SCHEMA_VERSIONS_READABLE: readonly StateSchemaVersion[] = [1,
 
 /**
  * One `Fn::ImportValue` reference recorded during a consumer stack's
- * deploy. Persisted in `StackState.imports` so `cdkd destroy` can refuse
+ * deploy. Persisted in `StackState.imports` so `cdkl destroy` can refuse
  * to delete the producer while the consumer still references its outputs
  * (strong reference, matches CloudFormation behavior).
  *
  * Only `Fn::ImportValue` populates this — `Fn::GetStackOutput` is a weak
- * reference by design (cdkd-specific) and intentionally does NOT record
+ * reference by design (cdk-local-specific) and intentionally does NOT record
  * an entry here so the producer stays deletable independently of consumers.
  */
 export interface StateImportEntry {
@@ -125,7 +125,7 @@ export interface StackState {
   /**
    * `Fn::ImportValue` references this stack resolved during its last
    * successful deploy. Populated on schema v4+; absent (or undefined)
-   * on state written by an older cdkd binary, in which case the
+   * on state written by an older cdk-local binary, in which case the
    * destroy-time strong-reference check degrades gracefully (no
    * recorded imports = no consumers known = destroy proceeds). The
    * next deploy of an upgraded stack repopulates the field.
@@ -138,8 +138,8 @@ export interface StackState {
    * Undefined on top-level stacks. The pre-v6 reader sees the field as
    * undefined and degrades to "I am a top-level stack" — which is correct
    * for every state file written before nested-stack support shipped.
-   * v6+ writers populate this on child state records so `cdkd state list`
-   * can surface the parent → child tree and `cdkd destroy <child-only>`
+   * v6+ writers populate this on child state records so `cdkl state list`
+   * can surface the parent → child tree and `cdkl destroy <child-only>`
    * can reject with a pointer at the parent (matches CFn's "cannot
    * directly destroy a nested stack" semantic).
    *
@@ -152,7 +152,7 @@ export interface StackState {
    * The `AWS::CloudFormation::Stack` logical ID inside the parent's
    * template that produced this child. Combined with `parentStack`, the
    * pair uniquely identifies the child's position in the parent's DAG.
-   * Used by `cdkd destroy` to reject `destroy <child-only>` with a
+   * Used by `cdkl destroy` to reject `destroy <child-only>` with a
    * clear "destroy the parent instead" error message that names the
    * specific parent + child-logical-id pair, mirroring CFn's behavior.
    *
@@ -199,7 +199,7 @@ export interface ResourceState {
    * template still surface as drift.
    *
    * Optional for backwards compatibility — resources written by an older
-   * cdkd binary (v2 state, or v3 state on a provider that does not
+   * cdk-local binary (v2 state, or v3 state on a provider that does not
    * implement `readCurrentState`) keep this field undefined; the drift
    * command falls back to comparing against `properties` in that case.
    */
@@ -312,8 +312,8 @@ export interface ResourceChange {
   /**
    * `DeletionPolicy` / `UpdateReplacePolicy` attribute changes (schema v5+).
    * Populated when the template attribute differs from the value recorded in
-   * cdkd state. AWS has no API to mutate these attributes per-resource, so
-   * the deploy engine handles the change by updating cdkd state only — no
+   * cdk-local state. AWS has no API to mutate these attributes per-resource, so
+   * the deploy engine handles the change by updating cdk-local state only — no
    * provider call. UPDATE classification still fires when only these change
    * (DiffCalculator does not stay at `NO_CHANGE`), so users see the diff
    * instead of `No changes detected`.
@@ -326,7 +326,7 @@ export interface ResourceChange {
  *
  * `DeletionPolicy` / `UpdateReplacePolicy` are CloudFormation template
  * metadata — they have no AWS API per-resource and are mutated through the
- * cdkd state record alone.
+ * cdk-local state record alone.
  */
 export interface AttributeChange {
   /** Attribute name: `DeletionPolicy` or `UpdateReplacePolicy`. */
@@ -336,7 +336,7 @@ export interface AttributeChange {
 }
 
 /**
- * Returns true when a recorded `DeletionPolicy` should prevent cdkd from
+ * Returns true when a recorded `DeletionPolicy` should prevent cdk-local from
  * deleting the underlying AWS resource. `Retain` and `RetainExceptOnCreate`
  * both keep the resource around; `Delete` / `Snapshot` / undefined all
  * fall through to the normal delete path. Shared between

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -3,7 +3,7 @@ import { getLogger } from './logger.js';
 /**
  * Base error class for cdk-local
  */
-export class CdkdError extends Error {
+export class CdkLocalError extends Error {
   public readonly code: string;
   public readonly cause: Error | undefined;
 
@@ -11,52 +11,8 @@ export class CdkdError extends Error {
     super(message);
     this.code = code;
     this.cause = cause;
-    this.name = 'CdkdError';
-    Object.setPrototypeOf(this, CdkdError.prototype);
-  }
-}
-
-/**
- * State management errors
- */
-export class StateError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'STATE_ERROR', cause);
-    this.name = 'StateError';
-    Object.setPrototypeOf(this, StateError.prototype);
-  }
-}
-
-/**
- * Lock acquisition errors
- */
-export class LockError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'LOCK_ERROR', cause);
-    this.name = 'LockError';
-    Object.setPrototypeOf(this, LockError.prototype);
-  }
-}
-
-/**
- * Synthesis errors
- */
-export class SynthesisError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'SYNTHESIS_ERROR', cause);
-    this.name = 'SynthesisError';
-    Object.setPrototypeOf(this, SynthesisError.prototype);
-  }
-}
-
-/**
- * Asset errors
- */
-export class AssetError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'ASSET_ERROR', cause);
-    this.name = 'AssetError';
-    Object.setPrototypeOf(this, AssetError.prototype);
+    this.name = 'CdkLocalError';
+    Object.setPrototypeOf(this, CdkLocalError.prototype);
   }
 }
 
@@ -66,375 +22,14 @@ export class AssetError extends CdkdError {
  * Surfaces the stderr captured from `docker build` so the user can
  * re-run the same command directly to debug Dockerfile syntax errors
  * or missing build context. Used by `src/local/docker-image-builder.ts`
- * (PR 5) for container Lambdas; the parallel `AssetError` covers the
- * `cdkd publish-assets` / `cdkd deploy` build path. Kept distinct from
- * `AssetError` so `cdkl invoke` failures don't show up under the
- * "asset" error class.
+ * for container Lambdas. Kept distinct from a generic asset/build error
+ * so `cdkl invoke` failures don't show up under an unrelated error class.
  */
-export class LocalInvokeBuildError extends CdkdError {
+export class LocalInvokeBuildError extends CdkLocalError {
   constructor(message: string, cause?: Error) {
     super(message, 'LOCAL_INVOKE_BUILD_ERROR', cause);
     this.name = 'LocalInvokeBuildError';
     Object.setPrototypeOf(this, LocalInvokeBuildError.prototype);
-  }
-}
-
-/**
- * Resource provisioning errors
- */
-export class ProvisioningError extends CdkdError {
-  public readonly resourceType: string;
-  public readonly logicalId: string;
-  public readonly physicalId: string | undefined;
-
-  constructor(
-    message: string,
-    resourceType: string,
-    logicalId: string,
-    physicalId?: string,
-    cause?: Error
-  ) {
-    super(message, 'PROVISIONING_ERROR', cause);
-    this.resourceType = resourceType;
-    this.logicalId = logicalId;
-    this.physicalId = physicalId;
-    this.name = 'ProvisioningError';
-    Object.setPrototypeOf(this, ProvisioningError.prototype);
-  }
-}
-
-/**
- * Resource provisioning timeout errors (per-resource wall-clock deadline).
- *
- * Thrown by `withResourceDeadline` when a single CREATE / UPDATE / DELETE
- * operation exceeds the user-configured `--resource-timeout`. The deploy
- * engine catches this, wraps it in {@link ProvisioningError}, and lets the
- * existing failure path (interrupt siblings → pre-rollback save → rollback
- * unless `--no-rollback`) take over.
- *
- * The message intentionally names the resource, type, region, elapsed time
- * and operation, plus how to override the default. Long-running providers
- * (e.g. Custom Resource: 1h polling cap) self-report their needed budget
- * via `getMinResourceTimeoutMs()`, so the user only needs a per-type
- * override (`--resource-timeout TYPE=DURATION`) when they want to bump a
- * specific non-self-reporting type or shorten a self-reported one.
- */
-export class ResourceTimeoutError extends CdkdError {
-  public readonly logicalId: string;
-  public readonly resourceType: string;
-  public readonly region: string;
-  public readonly elapsedMs: number;
-  public readonly operation: 'CREATE' | 'UPDATE' | 'DELETE';
-  public readonly timeoutMs: number;
-
-  constructor(
-    logicalId: string,
-    resourceType: string,
-    region: string,
-    elapsedMs: number,
-    operation: 'CREATE' | 'UPDATE' | 'DELETE',
-    timeoutMs: number
-  ) {
-    const elapsedLabel = formatDuration(elapsedMs);
-    const timeoutLabel = formatDuration(timeoutMs);
-    super(
-      `Resource ${logicalId} (${resourceType}) in ${region} timed out after ${timeoutLabel} during ${operation} (elapsed ${elapsedLabel}).\n` +
-        'This may indicate a stuck Cloud Control polling loop, hung Custom Resource, or\n' +
-        `slow ENI provisioning. Re-run with --resource-timeout ${resourceType}=<DURATION>\n` +
-        'to bump the budget for this resource type only, or --verbose to see the\n' +
-        'underlying provider activity.',
-      'RESOURCE_TIMEOUT'
-    );
-    this.logicalId = logicalId;
-    this.resourceType = resourceType;
-    this.region = region;
-    this.elapsedMs = elapsedMs;
-    this.operation = operation;
-    this.timeoutMs = timeoutMs;
-    this.name = 'ResourceTimeoutError';
-    Object.setPrototypeOf(this, ResourceTimeoutError.prototype);
-  }
-}
-
-/**
- * Format a duration in milliseconds as a short human-readable label
- * (`30m`, `1h30m`, `45s`). Used by {@link ResourceTimeoutError} so the
- * error message stays compact.
- */
-function formatDuration(ms: number): string {
-  if (ms < 60_000) {
-    return `${Math.round(ms / 1000)}s`;
-  }
-  const totalMinutes = Math.round(ms / 60_000);
-  if (totalMinutes < 60) return `${totalMinutes}m`;
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return minutes === 0 ? `${hours}h` : `${hours}h${minutes}m`;
-}
-
-/**
- * Dependency resolution errors
- */
-export class DependencyError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'DEPENDENCY_ERROR', cause);
-    this.name = 'DependencyError';
-    Object.setPrototypeOf(this, DependencyError.prototype);
-  }
-}
-
-/**
- * Configuration errors
- */
-export class ConfigError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'CONFIG_ERROR', cause);
-    this.name = 'ConfigError';
-    Object.setPrototypeOf(this, ConfigError.prototype);
-  }
-}
-
-/**
- * Signals a partial-failure outcome that should map to exit code 2 (not 1).
- *
- * Used by `cdkd destroy` and `cdkd state destroy` when one or more
- * per-resource deletes failed but the overall command finished its work
- * (state.json is preserved, the rest of the stack was deleted, and the
- * user can re-run to clean up the remaining resources).
- *
- * Exit code conventions:
- *   - 0: command completed successfully, no resources left in error state.
- *   - 1: command-level failure (auth error, bad arguments, synth crash,
- *        unhandled exception). Default for any thrown error.
- *   - 2: partial failure — work completed but some resources are still in
- *        an error state. Re-running typically resolves it. Documented in
- *        README's "Exit codes" section.
- *
- * `handleError` recognizes this class via `instanceof` and uses its
- * `exitCode` instead of the default 1.
- */
-export class PartialFailureError extends CdkdError {
-  readonly exitCode: number = 2;
-
-  constructor(message: string, cause?: Error) {
-    super(message, 'PARTIAL_FAILURE', cause);
-    this.name = 'PartialFailureError';
-    Object.setPrototypeOf(this, PartialFailureError.prototype);
-  }
-}
-
-/**
- * Signals that a provider cannot perform an in-place `update` for a
- * resource type — most commonly because the AWS resource is structurally
- * immutable (`AWS::Lambda::LayerVersion`, `AWS::S3Tables::TableBucket` once
- * created, certain `AWS::EC2::*` sub-resources) or because the provider
- * surfaces a sub-resource attachment whose only mutation pattern is
- * delete + add (Lambda permission statements, IAM policy attachments).
- *
- * Surfaced through `cdkd drift --revert`, which calls
- * `provider.update(logicalId, physicalId, type, stateProps, awsProps)` to
- * push cdkd state values back into AWS for every drifted resource. When a
- * provider throws this error, the drift command collects it as a
- * per-resource outcome distinct from a generic AWS update failure: the
- * fix is to re-deploy with `--replace` (or recreate the resource), not to
- * retry the update.
- *
- * Carries the same `exitCode = 2` as {@link PartialFailureError} so a
- * drift run that hits one immutable resource is reported as partial-
- * success rather than fatal — the rest of the drifted resources still
- * had their `update` invoked, and the user has a clear next step printed
- * for the unsupported one.
- */
-export class ResourceUpdateNotSupportedError extends CdkdError {
-  readonly exitCode: number = 2;
-  public readonly resourceType: string;
-  public readonly logicalId: string;
-  /**
-   * Human-readable hint printed alongside the error. The default is
-   * "use cdkd deploy with --replace, or change the resource definition
-   * to create a new version" — providers are encouraged to override
-   * with a more specific suggestion when one is available (e.g.
-   * Lambda::Permission's "delete + add a new statement").
-   */
-  public readonly suggestion: string | undefined;
-
-  constructor(resourceType: string, logicalId: string, suggestion?: string, cause?: Error) {
-    const tail = suggestion
-      ? suggestion
-      : 'use cdkd deploy with --replace, or change the resource definition to create a new version';
-    super(
-      `${resourceType} (${logicalId}) cannot be updated in place: ${tail}.`,
-      'RESOURCE_UPDATE_NOT_SUPPORTED',
-      cause
-    );
-    this.resourceType = resourceType;
-    this.logicalId = logicalId;
-    this.suggestion = suggestion;
-    this.name = 'ResourceUpdateNotSupportedError';
-    Object.setPrototypeOf(this, ResourceUpdateNotSupportedError.prototype);
-  }
-}
-
-/**
- * Signals a refusal to destroy a stack whose CDK manifest has
- * `terminationProtection: true`.
- *
- * Surfaced from `cdkd destroy <stack>` / `cdkd destroy --all` BEFORE
- * any lock acquisition or per-resource delete. In multi-stack runs
- * (e.g. `--all`) this counts as a per-stack failure and the rest of
- * the targets continue — the aggregated count is wrapped in
- * {@link PartialFailureError} so the command exits with code 2.
- *
- * The bypass workflow is documented in the message: edit the CDK code
- * (`new Stack(app, '...', { terminationProtection: false })`),
- * redeploy, then retry the destroy. A future `--remove-protection`
- * flag (separate scope) will provide an explicit one-shot bypass.
- *
- * Note: `cdkd state destroy` (state-only, no synth) does NOT honor
- * `terminationProtection` — the flag is a CDK property not persisted
- * in cdkd's state.json. Use `cdkd destroy` when synth is available.
- */
-export class StackTerminationProtectionError extends CdkdError {
-  public readonly stackName: string;
-
-  constructor(stackName: string, cause?: Error) {
-    super(
-      `Stack '${stackName}' has terminationProtection: true and cannot be destroyed. ` +
-        `Set terminationProtection: false in the CDK code, redeploy, then retry 'cdkd destroy ${stackName}'.`,
-      'STACK_TERMINATION_PROTECTION',
-      cause
-    );
-    this.stackName = stackName;
-    this.name = 'StackTerminationProtectionError';
-    Object.setPrototypeOf(this, StackTerminationProtectionError.prototype);
-  }
-}
-
-/**
- * `cdkd destroy <child>` refused because the named stack is a nested
- * child of another stack. Mirrors CloudFormation's `you can't directly
- * destroy a nested stack` semantic — destroying the child without
- * touching the parent would leave the parent's `AWS::CloudFormation::Stack`
- * record pointing at non-existent resources, and the parent's next
- * deploy would silently try to re-create them.
- *
- * Detected by reading the loaded state's v6 `parentStack` field — only
- * state files written by `NestedStackProvider.create` (or by the
- * recursive `cdkd import --migrate-from-cloudformation` walk) carry
- * this field; top-level stacks have `parentStack: undefined` and pass
- * the guard unchanged.
- *
- * Fires from `cdkd destroy` AFTER state load but BEFORE lock
- * acquisition or any per-resource delete, so the refusal is cheap.
- * Surfaced as a per-stack failure (wrapped in {@link PartialFailureError},
- * exit code 2) in multi-stack runs — siblings continue.
- *
- * Bypass paths (both intentional escape hatches):
- *
- *  1. `cdkd destroy <parent>` — the normal cascading-destroy path; the
- *     parent's reverse-DAG walks into the child via
- *     `NestedStackProvider.delete` and removes both layers atomically.
- *  2. `cdkd state destroy <child>` — state-only destroy with no parent
- *     coupling check. The state-driven entry point intentionally
- *     bypasses this guard for the same reason `cdkd state destroy`
- *     bypasses `terminationProtection`: it's the "I know what I'm
- *     doing" path for cleaning up state when synth is unavailable or
- *     the user accepts leaving the parent's reference dangling.
- */
-export class NestedStackChildDirectDestroyError extends CdkdError {
-  public readonly stackName: string;
-  public readonly parentStack: string;
-  public readonly parentLogicalId?: string;
-
-  constructor(stackName: string, parentStack: string, parentLogicalId?: string, cause?: Error) {
-    const logicalIdSuffix = parentLogicalId ? ` (parent's logical id: ${parentLogicalId})` : '';
-    super(
-      `Stack '${stackName}' is a nested child of '${parentStack}'${logicalIdSuffix}; ` +
-        `directly destroying a nested stack is not supported. ` +
-        `Either run 'cdkd destroy ${parentStack}' to cascade-delete this child along with its parent, ` +
-        `or run 'cdkd state destroy ${stackName}' if you intentionally want to leave the parent's ` +
-        `reference dangling (the state-only escape hatch).`,
-      'NESTED_STACK_CHILD_DIRECT_DESTROY',
-      cause
-    );
-    this.stackName = stackName;
-    this.parentStack = parentStack;
-    if (parentLogicalId !== undefined) this.parentLogicalId = parentLogicalId;
-    this.name = 'NestedStackChildDirectDestroyError';
-    Object.setPrototypeOf(this, NestedStackChildDirectDestroyError.prototype);
-  }
-}
-
-/**
- * One consumer that still references the producer being destroyed via
- * `Fn::ImportValue`. Surfaced inside {@link StackHasActiveImportsError}.
- */
-export interface ActiveImportConsumer {
-  consumerStack: string;
-  consumerRegion: string;
-  exportName: string;
-}
-
-/**
- * `cdkd destroy <producer>` refused because at least one consumer stack
- * still records an `Fn::ImportValue` reference to one of the producer's
- * outputs. This matches CloudFormation's strong-reference semantics —
- * CFn rejects `DeleteStack` for an exporter while an importer exists.
- *
- * cdkd has no `--force` escape hatch for this (intentionally, mirroring
- * CFn). The error message lists every offending consumer and points the
- * user at the two valid resolution paths:
- *
- *  1. Destroy the consumer first: `cdkd destroy <consumer>`
- *  2. Remove the `Fn::ImportValue` from the consumer's template and
- *     redeploy, then retry the producer destroy.
- *
- * Weak-reference consumers (`Fn::GetStackOutput`, cdkd-specific) never
- * trigger this error by design — the producer stays deletable
- * independently of consumers when the user intentionally chose a weak
- * reference at template-authoring time.
- *
- * Exit code 2 (same as `PartialFailureError`) so multi-stack `cdkd
- * destroy --all` runs that partially succeed still surface as
- * non-zero without being indistinguishable from a fatal cdkd error.
- */
-export class StackHasActiveImportsError extends CdkdError {
-  readonly exitCode: number = 2;
-  public readonly producerStack: string;
-  public readonly producerRegion: string;
-  public readonly consumers: ActiveImportConsumer[];
-
-  constructor(
-    producerStack: string,
-    producerRegion: string,
-    consumers: ActiveImportConsumer[],
-    cause?: Error
-  ) {
-    const lines = consumers.map(
-      (c) => `  - ${c.consumerStack} (${c.consumerRegion}): imports export '${c.exportName}'`
-    );
-    super(
-      `Cannot destroy stack '${producerStack}' (${producerRegion}): ` +
-        `the following stacks still import its outputs via Fn::ImportValue:\n` +
-        `${lines.join('\n')}\n\n` +
-        `This matches CloudFormation's strong-reference semantics — exports are\n` +
-        `protected as long as a consumer references them.\n\n` +
-        `To proceed:\n` +
-        `  1. Destroy the consumer first: cdkd destroy <consumer-stack>\n` +
-        `  2. Or remove the Fn::ImportValue from the consumer's template\n` +
-        `     (e.g. inline the value, or refactor) and re-deploy the consumer,\n` +
-        `     then retry this destroy.\n\n` +
-        `Note: cdkd's Fn::GetStackOutput intrinsic is a weak alternative that\n` +
-        `does NOT protect the producer — use it when you intentionally want\n` +
-        `the producer to be deletable independently of consumers.`,
-      'STACK_HAS_ACTIVE_IMPORTS',
-      cause
-    );
-    this.producerStack = producerStack;
-    this.producerRegion = producerRegion;
-    this.consumers = consumers;
-    this.name = 'StackHasActiveImportsError';
-    Object.setPrototypeOf(this, StackHasActiveImportsError.prototype);
   }
 }
 
@@ -445,14 +40,13 @@ export class StackHasActiveImportsError extends CdkdError {
  * unrecognized `AuthType` (anything other than `'NONE'` / `'AWS_IAM'`),
  * or an unsupported intrinsic function in `IntegrationUri`. (Lambda::Url
  * with `InvokeMode: RESPONSE_STREAM` is a normal route dispatched via
- * the streaming protocol — #467. Lambda::Url with `AuthType: 'AWS_IAM'`
- * is a normal route verified through the SigV4 pipeline — #621.)
+ * the streaming protocol. Lambda::Url with `AuthType: 'AWS_IAM'`
+ * is a normal route verified through the SigV4 pipeline.)
  *
- * The message names every offending route and points the user at the
- * deferred follow-up PR (8b for authorizers, etc.). Hard-error at
- * discovery so the server never starts in a half-working state.
+ * The message names every offending route. Hard-error at discovery so
+ * the server never starts in a half-working state.
  */
-export class RouteDiscoveryError extends CdkdError {
+export class RouteDiscoveryError extends CdkLocalError {
   constructor(message: string, cause?: Error) {
     super(message, 'ROUTE_DISCOVERY_ERROR', cause);
     this.name = 'RouteDiscoveryError';
@@ -461,43 +55,13 @@ export class RouteDiscoveryError extends CdkdError {
 }
 
 /**
- * Signals an unrecoverable failure inside `cdkl start-api`'s HTTP
- * server — port-binding failure, RIE returned malformed JSON, container
- * pool acquire timed out, etc. Distinct from {@link RouteDiscoveryError}
- * which fires before the server starts.
+ * Signals a `cdkl start-service` orchestration failure
+ * (`AWS::ECS::Service` emulator). The service runner has its own
+ * lifecycle (long-running replica pool, restart-on-exit), so a failure
+ * inside it carries different operator semantics than a one-shot task
+ * failure.
  */
-export class StartApiServerError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'START_API_SERVER_ERROR', cause);
-    this.name = 'StartApiServerError';
-    Object.setPrototypeOf(this, StartApiServerError.prototype);
-  }
-}
-
-/**
- * Signals a `cdkl run-task` orchestration failure that did not
- * originate from a lower-level module (those throw their own narrower
- * errors — `EcsTaskResolutionError`, `EcsSecretsResolutionError`,
- * `DockerRunnerError`, `LocalInvokeBuildError`). Used by the runner /
- * CLI when the failure is meaningful only at the task-orchestrator
- * layer (e.g. cyclic dependsOn, essential container did not start).
- */
-export class LocalRunTaskError extends CdkdError {
-  constructor(message: string, cause?: Error) {
-    super(message, 'LOCAL_RUN_TASK_ERROR', cause);
-    this.name = 'LocalRunTaskError';
-    Object.setPrototypeOf(this, LocalRunTaskError.prototype);
-  }
-}
-
-/**
- * Signals a `cdkl start-service` orchestration failure (Phase 2
- * of #262 — `AWS::ECS::Service` emulator). Distinct from
- * `LocalRunTaskError` because the service runner has its own lifecycle
- * (long-running replica pool, restart-on-exit), so a failure inside it
- * carries different operator semantics than a one-shot task failure.
- */
-export class LocalStartServiceError extends CdkdError {
+export class LocalStartServiceError extends CdkLocalError {
   constructor(message: string, cause?: Error) {
     super(message, 'LOCAL_START_SERVICE_ERROR', cause);
     this.name = 'LocalStartServiceError';
@@ -506,97 +70,17 @@ export class LocalStartServiceError extends CdkdError {
 }
 
 /**
- * Signals that the upstream `cdk` CLI is not available on PATH (or at
- * the override path passed via `--cdk-bin`). Surfaced from `cdkd migrate`
- * (#465 PR A) before any other work runs.
- *
- * The message includes the install hint `npm install -g aws-cdk@latest`
- * so users on a fresh machine see exactly how to recover.
- */
-export class MissingCdkCliError extends CdkdError {
-  constructor(detail?: string, cause?: Error) {
-    const head = detail ?? "upstream 'cdk' CLI not found on PATH";
-    super(
-      `${head}. ` +
-        `'cdkd migrate' shells out to the upstream aws-cdk CLI for L1 codegen — ` +
-        `install it with 'npm install -g aws-cdk@latest' (or pass --cdk-bin <path>).`,
-      'MISSING_CDK_CLI',
-      cause
-    );
-    this.name = 'MissingCdkCliError';
-    Object.setPrototypeOf(this, MissingCdkCliError.prototype);
-  }
-}
-
-/**
- * Generic local-migrate orchestration failure (#465 PR A). Used by
- * `cdkd migrate` for pre-flight rejections (Custom Resource / nested
- * stack / non-terminal CFn stack state), output-dir collisions, and
- * `cdk migrate` subprocess failures whose underlying stderr is folded
- * into the error message. Exit code 2 (partial-failure family) because
- * some pre-flight failures leave the user with a partially-populated
- * output directory that's still useful for debugging.
- */
-export class LocalMigrateError extends CdkdError {
-  readonly exitCode: number = 2;
-
-  constructor(message: string, cause?: Error) {
-    super(message, 'LOCAL_MIGRATE_ERROR', cause);
-    this.name = 'LocalMigrateError';
-    Object.setPrototypeOf(this, LocalMigrateError.prototype);
-  }
-}
-
-/**
- * CloudFormation macro / `Fn::Transform` expansion failure (#463).
- *
- * cdkd hands templates that declare `Transform: [...]` (or carry
- * `Fn::Transform: {...}` snippets) to CloudFormation server-side via a
- * transient `CreateChangeSet --change-set-type CREATE` against a
- * `cdkd-macro-expand-<id>` stack name. This error wraps every failure
- * mode of that round-trip:
- *
- *   - `CreateChangeSet` rejection (bad template, missing macro IAM
- *     permission, custom macro not found in the account).
- *   - Changeset settles in `FAILED` (`StatusReason` from CFn is
- *     surfaced verbatim — typically a custom macro Lambda error).
- *   - Waiter timeout (the macro Lambda is stuck or oversized).
- *   - `GetTemplate --template-stage Processed` returns no body (would
- *     indicate a CFn-side regression — fail loud rather than silently
- *     proceed with the un-expanded template).
- *   - Multi-stage detection: the expanded template still contains
- *     macros, which cdkl v1 does not support (the design intentionally
- *     rejects this so a second round-trip is not silently triggered).
- *
- * The error surfaces at exit code 2 (partial-failure family) — the
- * cleanup `finally` in the expander always runs `DeleteChangeSet` +
- * `DeleteStack` regardless of this error firing, so a failed
- * expansion never leaves a transient CFn stack behind in a routine
- * case. The user can re-run `cdkd deploy` once the upstream cause is
- * fixed.
- */
-export class MacroExpansionError extends CdkdError {
-  readonly exitCode: number = 2;
-
-  constructor(message: string, cause?: Error) {
-    super(message, 'MACRO_EXPANSION_ERROR', cause);
-    this.name = 'MacroExpansionError';
-    Object.setPrototypeOf(this, MacroExpansionError.prototype);
-  }
-}
-
-/**
  * Check if error is a cdk-local error
  */
-export function isCdkdError(error: unknown): error is CdkdError {
-  return error instanceof CdkdError;
+export function isCdkLocalError(error: unknown): error is CdkLocalError {
+  return error instanceof CdkLocalError;
 }
 
 /**
  * Format error for display
  */
 export function formatError(error: unknown): string {
-  if (isCdkdError(error)) {
+  if (isCdkLocalError(error)) {
     let message = `${error.name}: ${error.message}`;
     if (error.cause) {
       message += `\nCaused by: ${error.cause.message}`;
@@ -614,18 +98,20 @@ export function formatError(error: unknown): string {
 /**
  * Global error handler
  *
- * Default exit code is 1 (general error). `PartialFailureError`
- * overrides it to 2 so callers can distinguish "command crashed /
- * unauthorized / bad arguments" from "command completed but some
- * resources are still in an error state, re-run to clean up".
+ * Default exit code is 1 (general error). A {@link CdkLocalError}
+ * subclass may override it by declaring a custom `exitCode` field so
+ * callers can distinguish "command crashed / unauthorized / bad
+ * arguments" from "command completed but some resources are still in an
+ * error state, re-run to clean up".
  *
- * A {@link CdkdError} subclass may set `silent = true` to suppress the
- * default `logger.error` line — used by `cdkd drift` where the command
- * has already printed a richer report and only needs the exit code.
+ * A {@link CdkLocalError} subclass may set `silent = true` to suppress
+ * the default `logger.error` line — used when the command has already
+ * printed a richer report and only needs the exit code.
  */
 export function handleError(error: unknown): never {
   const logger = getLogger();
-  const silent = error instanceof CdkdError && (error as CdkdError & { silent?: boolean }).silent;
+  const silent =
+    error instanceof CdkLocalError && (error as CdkLocalError & { silent?: boolean }).silent;
   if (!silent) {
     logger.error(formatError(error));
   }
@@ -634,13 +120,13 @@ export function handleError(error: unknown): never {
     logger.debug('Stack trace:', error.stack);
   }
 
-  // Honor any CdkdError subclass that declares a custom `exitCode`
-  // field (PartialFailureError + ResourceUpdateNotSupportedError +
-  // StackHasActiveImportsError + LocalMigrateError + MacroExpansionError
-  // etc.). Falling back to 1 covers `CdkdError` subclasses with no
+  // Honor any CdkLocalError subclass that declares a custom `exitCode`
+  // field. Falling back to 1 covers `CdkLocalError` subclasses with no
   // override and every non-cdk-local error.
   const customExitCode =
-    error instanceof CdkdError ? (error as CdkdError & { exitCode?: number }).exitCode : undefined;
+    error instanceof CdkLocalError
+      ? (error as CdkLocalError & { exitCode?: number }).exitCode
+      : undefined;
   const exitCode = typeof customExitCode === 'number' ? customExitCode : 1;
   process.exit(exitCode);
 }
@@ -723,7 +209,7 @@ export function normalizeAwsError(err: unknown, context: NormalizeAwsErrorContex
       const where = region ? ` (in ${region})` : '';
       return new Error(
         `Bucket '${bucket}'${where} is in a different region than the client. ` +
-          `cdkd resolves this automatically; if you see this message, please report it.`
+          `cdk-local resolves this automatically; if you see this message, please report it.`
       );
     }
     case 403:


### PR DESCRIPTION
## Summary

Make `src/utils/error-handler.ts` self-contained — remove the dead code and `cdkd`-branded strings inherited from the cdkd fork (issue #54):

- **Rename the base class** `CdkdError` → `CdkLocalError` (and `isCdkdError` → `isCdkLocalError`). `error-handler.ts` is NOT re-exported from `src/index.ts`, so the rename is not a public-API break; every reference lived inside `error-handler.ts` itself.
- **Delete 18 dead error subclasses** — zero `new X` throw sites in `src/`, zero references outside `error-handler.ts`. Also removed the now-orphaned `formatDuration` helper and `ActiveImportConsumer` interface. The 3 live subclasses are kept (with throw sites): `LocalInvokeBuildError`, `RouteDiscoveryError`, `LocalStartServiceError`.
- **Scrub `cdkd` → `cdk-local` branding** in the kept classes' JSDoc/messages, plus a JSDoc-only sweep in `local-state-provider.ts` / `state-resolver.ts` / `types/state.ts`.

Intentionally left for the separate runtime-string scrub (#52): the `s3://{bucket}/cdkd/...` state key-path literals and the `github.com/go-to-k/cdkd/issues/N` links (rewriting those now would desync the doc from the still-`cdkd`-prefixed runtime path / break real upstream links).

Pure refactor + content rewrite, no behavior change. Disjoint from `0.11.2` (no file overlap).

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) green
- [x] `vp run build` green
- [x] `vp run test` — all unit tests pass
- [x] No public API change (`error-handler.ts` not in `src/index.ts`); confirmed 0 `new <deleted-class>` and 0 external references to deleted classes on current `main`
