### PR TITLE
feat(index): re-export start-api authorizer primitives for host shims

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -107,6 +107,17 @@ server runs on:
   `parseSelectionExpressionPath` (+ `DiscoveredWebSocketApi` /
   `WebSocketRouteEntry`) — WebSocket API discovery.
 
+The `start-api` authorizer primitives are exposed on the same basis:
+
+- `createAuthorizerCache` (+ `AuthorizerCache` / `CachedAuthorizerResult`)
+  — TTL-aware cache mirroring API Gateway's authorizer-result caching.
+- `createJwksCache` / `buildCognitoJwksUrl` / `buildJwksUrlFromIssuer` /
+  `verifyCognitoJwt` / `verifyJwtAuthorizer` (+ `JwksCache`) — Cognito
+  User Pool / JWT authorizer verification against published JWKS.
+- `buildMethodArn` / `invokeTokenAuthorizer` / `invokeRequestAuthorizer` /
+  `computeRequestIdentityHash` / `evaluateCachedLambdaPolicy` — Lambda
+  (TOKEN / REQUEST) authorizer invocation and IAM-policy evaluation.
+
 These are stable, side-effect-free utilities; they are exposed for
 1:1 re-export and are not a recommended way to build a custom CLI (use
 the factories for that).

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,3 +101,30 @@ export {
   type DiscoveredWebSocketApi,
   type WebSocketRouteEntry,
 } from './local/websocket-route-discovery.js';
+
+/**
+ * `start-api` authorizer primitives — the TTL-aware authorizer-result
+ * cache, Cognito User Pool / JWT verification, and Lambda (TOKEN / REQUEST)
+ * authorizer invocation. Exposed only as the consuming host's `import`
+ * statements require them.
+ */
+export {
+  createAuthorizerCache,
+  type AuthorizerCache,
+  type CachedAuthorizerResult,
+} from './local/authorizer-cache.js';
+export {
+  createJwksCache,
+  buildCognitoJwksUrl,
+  buildJwksUrlFromIssuer,
+  verifyCognitoJwt,
+  verifyJwtAuthorizer,
+  type JwksCache,
+} from './local/cognito-jwt.js';
+export {
+  buildMethodArn,
+  computeRequestIdentityHash,
+  evaluateCachedLambdaPolicy,
+  invokeRequestAuthorizer,
+  invokeTokenAuthorizer,
+} from './local/lambda-authorizer.js';

--- a/tests/unit/local/authorizer-cache.test.ts
+++ b/tests/unit/local/authorizer-cache.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { createAuthorizerCache } from '../../../src/local/authorizer-cache.js';
+
+describe('authorizer-cache', () => {
+  it('returns undefined on miss', () => {
+    const cache = createAuthorizerCache();
+    expect(cache.get('A1', 'tok')).toBeUndefined();
+  });
+
+  it('roundtrips a cached entry within its TTL', () => {
+    let now = 1_000_000;
+    const cache = createAuthorizerCache({ now: () => now });
+    cache.set('A1', 'tok', 60, { allow: true, principalId: 'u1', context: { foo: 'bar' } });
+    expect(cache.get('A1', 'tok')).toEqual({
+      allow: true,
+      principalId: 'u1',
+      context: { foo: 'bar' },
+    });
+    now += 30_000; // 30 seconds in
+    expect(cache.get('A1', 'tok')).toEqual({
+      allow: true,
+      principalId: 'u1',
+      context: { foo: 'bar' },
+    });
+  });
+
+  it('evicts past-expiry entries on get', () => {
+    let now = 1_000_000;
+    const cache = createAuthorizerCache({ now: () => now });
+    cache.set('A1', 'tok', 5, { allow: true });
+    expect(cache.get('A1', 'tok')).toEqual({ allow: true });
+    now += 6_000; // 1 second past TTL
+    expect(cache.get('A1', 'tok')).toBeUndefined();
+    expect(cache.size()).toBe(0);
+  });
+
+  it('treats ttl=0 as no-op (HTTP v2 JWT default)', () => {
+    const cache = createAuthorizerCache();
+    cache.set('A1', 'tok', 0, { allow: true });
+    expect(cache.get('A1', 'tok')).toBeUndefined();
+  });
+
+  it('isolates entries by authorizer id and identity hash', () => {
+    const cache = createAuthorizerCache();
+    cache.set('A1', 'a', 60, { allow: true, principalId: 'u1' });
+    cache.set('A2', 'a', 60, { allow: false });
+    cache.set('A1', 'b', 60, { allow: false });
+    expect(cache.get('A1', 'a')).toEqual({ allow: true, principalId: 'u1' });
+    expect(cache.get('A2', 'a')).toEqual({ allow: false });
+    expect(cache.get('A1', 'b')).toEqual({ allow: false });
+  });
+
+  it('clear() drops every entry', () => {
+    const cache = createAuthorizerCache();
+    cache.set('A1', 'a', 60, { allow: true });
+    cache.set('A1', 'b', 60, { allow: false });
+    expect(cache.size()).toBe(2);
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(cache.get('A1', 'a')).toBeUndefined();
+  });
+});

--- a/tests/unit/local/cognito-jwt.test.ts
+++ b/tests/unit/local/cognito-jwt.test.ts
@@ -1,0 +1,800 @@
+import { generateKeyPairSync, createSign } from 'node:crypto';
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildCognitoJwksUrl,
+  buildJwksUrlFromIssuer,
+  createJwksCache,
+  verifyCognitoJwt,
+  verifyJwtAuthorizer,
+} from '../../../src/local/cognito-jwt.js';
+import type {
+  CognitoUserPoolAuthorizer,
+  JwtAuthorizer,
+} from '../../../src/local/authorizer-resolver.js';
+
+/**
+ * Test helper: produce an RSA keypair, an RFC 7518 JWK for the public
+ * half, and a sign() that mints an RS256-signed JWT for the given header
+ * + payload. We use this fixture for end-to-end JWT-verify tests.
+ */
+function makeJwtFixture(): {
+  jwk: { kid: string; kty: string; n: string; e: string };
+  sign: (header: Record<string, unknown>, payload: Record<string, unknown>) => string;
+} {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' }) as Record<string, string>;
+  const fullJwk = {
+    kid: 'test-kid',
+    kty: jwk['kty']!,
+    n: jwk['n']!,
+    e: jwk['e']!,
+  };
+  return {
+    jwk: fullJwk,
+    sign(header, payload) {
+      const headerB64 = base64Url(Buffer.from(JSON.stringify({ ...header, kid: 'test-kid', alg: 'RS256' })));
+      const payloadB64 = base64Url(Buffer.from(JSON.stringify(payload)));
+      const signingInput = `${headerB64}.${payloadB64}`;
+      const signer = createSign('RSA-SHA256');
+      signer.update(signingInput);
+      signer.end();
+      const sigB64 = base64Url(signer.sign(privateKey));
+      return `${signingInput}.${sigB64}`;
+    },
+  };
+}
+
+function base64Url(buf: Buffer): string {
+  return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+const COGNITO_AUTH: CognitoUserPoolAuthorizer = {
+  kind: 'cognito',
+  logicalId: 'Auth',
+  pools: [
+    {
+      userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_x',
+      region: 'us-east-1',
+      userPoolId: 'us-east-1_x',
+    },
+  ],
+  userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_x',
+  region: 'us-east-1',
+  userPoolId: 'us-east-1_x',
+  declaredAt: 'S/Method',
+};
+
+const JWT_AUTH: JwtAuthorizer = {
+  kind: 'jwt',
+  logicalId: 'Auth',
+  issuer: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+  audience: ['test-audience'],
+  region: 'us-east-1',
+  userPoolId: 'us-east-1_x',
+  declaredAt: 'S/Route',
+};
+
+describe('JWKS URL builders', () => {
+  it('buildCognitoJwksUrl', () => {
+    expect(buildCognitoJwksUrl('us-east-1', 'us-east-1_xyz')).toBe(
+      'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xyz/.well-known/jwks.json'
+    );
+  });
+  it('buildJwksUrlFromIssuer strips trailing slash', () => {
+    expect(buildJwksUrlFromIssuer('https://issuer.example.com/')).toBe(
+      'https://issuer.example.com/.well-known/jwks.json'
+    );
+    expect(buildJwksUrlFromIssuer('https://issuer.example.com')).toBe(
+      'https://issuer.example.com/.well-known/jwks.json'
+    );
+  });
+});
+
+describe('createJwksCache — JWKS fetch failure → pass-through', () => {
+  it('warns and falls back to pass-through when fetch throws', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('connect ECONNREFUSED');
+      },
+    });
+    const entry = await cache.fetchAndCache('https://no.example/jwks.json');
+    expect(entry.passThrough).toBe(true);
+    expect(entry.byKid.size).toBe(0);
+  });
+
+  it('caches successful fetches by URL', async () => {
+    const fetchImpl = async (): Promise<{
+      ok: boolean;
+      status: number;
+      text: () => Promise<string>;
+    }> => ({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          keys: [{ kid: 'k1', kty: 'RSA', n: 'n', e: 'AQAB' }],
+        }),
+    });
+    let now = 0;
+    const cache = createJwksCache({ fetchImpl, now: () => now });
+    const e1 = await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(e1.byKid.has('k1')).toBe(true);
+    expect(e1.passThrough).toBe(false);
+    // Second call within TTL returns the same entry (no new fetch).
+    const e2 = await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(e2).toBe(e1);
+  });
+});
+
+describe('verifyCognitoJwt — pass-through', () => {
+  it('allows every JWT when JWKS is unreachable', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const fixture = makeJwtFixture();
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+      }
+    );
+    const result = await verifyCognitoJwt(COGNITO_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(true);
+  });
+
+  it('rejects a missing Authorization header', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, undefined, cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('rejects a non-Bearer Authorization header', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'Basic xyz', cache);
+    expect(result.allow).toBe(false);
+  });
+});
+
+describe('verifyCognitoJwt — happy path with real JWKS', () => {
+  it('verifies an RS256-signed token against the user pool JWKS', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [fixture.jwk] }),
+      }),
+    });
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+      }
+    );
+    const result = await verifyCognitoJwt(COGNITO_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(true);
+    expect(result.principalId).toBe('user-1');
+    expect((result.context as Record<string, unknown>)['sub']).toBe('user-1');
+  });
+
+  it('rejects an expired token', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [fixture.jwk] }),
+      }),
+    });
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) - 60,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+      }
+    );
+    const result = await verifyCognitoJwt(COGNITO_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('rejects a wrong issuer', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [fixture.jwk] }),
+      }),
+    });
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://attacker.example.com/x',
+      }
+    );
+    const result = await verifyCognitoJwt(COGNITO_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(false);
+  });
+});
+
+describe('verifyJwtAuthorizer — audience check', () => {
+  it('accepts a token whose aud matches the configured audience', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [fixture.jwk] }),
+      }),
+    });
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+        aud: 'test-audience',
+      }
+    );
+    const result = await verifyJwtAuthorizer(JWT_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(true);
+  });
+
+  it('rejects a token whose aud does not match', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [fixture.jwk] }),
+      }),
+    });
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+        aud: 'wrong-audience',
+      }
+    );
+    const result = await verifyJwtAuthorizer(JWT_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('accepts client_id when aud is absent (Cognito access tokens)', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [fixture.jwk] }),
+      }),
+    });
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+        client_id: 'test-audience',
+      }
+    );
+    const result = await verifyJwtAuthorizer(JWT_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(true);
+  });
+});
+
+describe('verifyCognitoJwt — malformed token', () => {
+  it('rejects a non-3-part token', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [] }),
+      }),
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'Bearer abc.def', cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('rejects a token whose kid is not in the JWKS', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({ keys: [{ kid: 'other-kid', kty: 'RSA', n: 'n', e: 'AQAB' }] }),
+      }),
+    });
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_x',
+      }
+    );
+    const result = await verifyCognitoJwt(COGNITO_AUTH, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(false);
+  });
+});
+
+/**
+ * Should-fix #5: pass-through must accept every JWT including malformed
+ * tokens (design says "every JWT accepted as if valid" → "every Bearer
+ * token accepted"). Pre-fix the parseJwt check above the JWKS fetch
+ * denied malformed tokens even in pass-through mode.
+ */
+describe('verifyCognitoJwt — pass-through accepts malformed tokens', () => {
+  it('allows a non-JWT garbage token in pass-through mode', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'Bearer not-a-jwt', cache);
+    expect(result.allow).toBe(true);
+    expect(result.principalId).toBe('unknown');
+    expect(result.context).toEqual({});
+  });
+
+  it('allows a 2-part malformed token in pass-through mode', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'Bearer abc.def', cache);
+    expect(result.allow).toBe(true);
+  });
+});
+
+/**
+ * Security: a malformed Bearer token against a MULTI-pool authorizer
+ * must reject (401) even when pool[0] would happily pass-through, so
+ * unparseable / no-iss tokens cannot bypass the configured-issuer guard.
+ * Closes the security review blocker on PR #488 (multi-pool federation).
+ */
+describe('verifyCognitoJwt — multi-pool federation safety on malformed tokens', () => {
+  const MULTI_POOL_AUTH: CognitoUserPoolAuthorizer = {
+    kind: 'cognito',
+    logicalId: 'Auth',
+    pools: [
+      {
+        userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_x',
+        region: 'us-east-1',
+        userPoolId: 'us-east-1_x',
+      },
+      {
+        userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_y',
+        region: 'us-east-1',
+        userPoolId: 'us-east-1_y',
+      },
+    ],
+    userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_x',
+    region: 'us-east-1',
+    userPoolId: 'us-east-1_x',
+    declaredAt: 'S/Method',
+  };
+
+  it('rejects malformed (unparseable) tokens under multi-pool even if pool[0] is pass-through', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom — both pools unreachable');
+      },
+    });
+    const result = await verifyCognitoJwt(MULTI_POOL_AUTH, 'Bearer not-a-jwt', cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('rejects 2-part malformed tokens under multi-pool even if pool[0] is pass-through', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(MULTI_POOL_AUTH, 'Bearer abc.def', cache);
+    expect(result.allow).toBe(false);
+  });
+});
+
+/**
+ * Should-fix #7: a transient JWKS-fetch failure should NOT lock
+ * pass-through for a full 1hr — short failure TTL (~60s default) means
+ * the next minute's request retries the fetch.
+ */
+describe('createJwksCache — failure TTL is shorter than success TTL', () => {
+  it('failure entry expires after the failure TTL, allowing a retry', async () => {
+    let now = 0;
+    let attempts = 0;
+    const cache = createJwksCache({
+      now: () => now,
+      ttlMs: 60 * 60 * 1000, // 1hr success TTL
+      failureTtlMs: 60 * 1000, // 60s failure TTL
+      fetchImpl: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('blip');
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({ keys: [{ kid: 'k1', kty: 'RSA', n: 'n', e: 'AQAB' }] }),
+        };
+      },
+    });
+    const e1 = await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(e1.passThrough).toBe(true);
+
+    // 30s later: still in pass-through (within failure TTL).
+    now = 30 * 1000;
+    const e2 = await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(e2).toBe(e1);
+    expect(attempts).toBe(1);
+
+    // 90s later: failure TTL expired, retry succeeds.
+    now = 90 * 1000;
+    const e3 = await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(e3.passThrough).toBe(false);
+    expect(e3.byKid.has('k1')).toBe(true);
+    expect(attempts).toBe(2);
+  });
+
+  it('success TTL refreshes after the configured ttlMs (covers the existing-but-untested branch)', async () => {
+    let now = 0;
+    let fetchCalls = 0;
+    const cache = createJwksCache({
+      now: () => now,
+      ttlMs: 1000, // 1s for fast test
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              keys: [{ kid: `k${fetchCalls}`, kty: 'RSA', n: 'n', e: 'AQAB' }],
+            }),
+        };
+      },
+    });
+    await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(fetchCalls).toBe(1);
+
+    // Advance now() past TTL — next fetchAndCache must re-fetch.
+    now = 2000;
+    const e2 = await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(fetchCalls).toBe(2);
+    expect(e2.byKid.has('k2')).toBe(true);
+  });
+});
+
+/**
+ * The existing test suite covered fetch THROW (network exception). This
+ * pins the OTHER failure-mode branch: the response arrives but is HTTP
+ * non-2xx (e.g. 500 from the JWKS endpoint).
+ */
+describe('createJwksCache — JWKS HTTP-error path', () => {
+  it('falls through to pass-through when response.ok is false', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      }),
+    });
+    const entry = await cache.fetchAndCache('https://issuer/.well-known/jwks.json');
+    expect(entry.passThrough).toBe(true);
+    expect(entry.byKid.size).toBe(0);
+  });
+});
+
+/**
+ * Pin extractBearer's whitespace / case tolerance via verifyCognitoJwt:
+ * the helper itself is private but every JWT path goes through it, so
+ * verifying via the public surface is enough.
+ */
+describe('verifyCognitoJwt — extractBearer edge cases', () => {
+  it('accepts a lowercase bearer scheme (case-insensitive)', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    // Pass-through mode allows the "valid Bearer token" path; we only
+    // care that extractBearer didn't reject the lowercase scheme.
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'bearer xyz', cache);
+    expect(result.allow).toBe(true);
+  });
+
+  it('accepts a Bearer scheme with double space before the token', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'Bearer  xyz', cache);
+    expect(result.allow).toBe(true);
+  });
+
+  it('rejects a Bearer scheme with no token (just whitespace)', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'Bearer ', cache);
+    expect(result.allow).toBe(false);
+  });
+
+  /**
+   * Bearer regex tightened to `[A-Za-z0-9._\-]+` (JWT character class).
+   * Pre-fix the regex was `(.+)`, so embedded whitespace in the header
+   * (`Bearer foo bar`) captured `foo bar` as the token — the JWT parser
+   * then quietly failed on the embedded space. Reject early at the
+   * extract layer instead, which gives a cleaner 401.
+   */
+  it('rejects a Bearer header with embedded whitespace inside the token', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await verifyCognitoJwt(COGNITO_AUTH, 'Bearer foo bar', cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('accepts a real-looking JWT token (base64url + dots)', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    // JWT character class: A-Z a-z 0-9 . _ -
+    const result = await verifyCognitoJwt(
+      COGNITO_AUTH,
+      'Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImtpZC0xIn0.eyJzdWIiOiJ1Iiwib2suaWdub3JlIjp0cnVlfQ.sig-abc_def',
+      cache
+    );
+    expect(result.allow).toBe(true);
+  });
+
+  it('rejects a Bearer header containing non-JWT characters in the token', async () => {
+    const cache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('boom');
+      },
+    });
+    // Quote chars / spaces / `=` / `+` / `/` are all outside the JWT class.
+    expect((await verifyCognitoJwt(COGNITO_AUTH, 'Bearer "abc"', cache)).allow).toBe(false);
+    expect((await verifyCognitoJwt(COGNITO_AUTH, 'Bearer abc=def', cache)).allow).toBe(false);
+    expect((await verifyCognitoJwt(COGNITO_AUTH, 'Bearer a+b/c', cache)).allow).toBe(false);
+  });
+});
+
+/**
+ * Issue #456: multi-pool federation. The authorizer carries `pools: [1+]`;
+ * verifyCognitoJwt picks the matching pool by the token's `iss` claim
+ * and verifies against that pool's JWKS only. A token issued by pool A
+ * cannot be verified against pool B's keys; a token whose `iss` does not
+ * match any configured pool rejects with 401 without touching JWKS.
+ */
+describe('verifyCognitoJwt — multi-pool federation', () => {
+  /** Build a 2-pool authorizer using fresh keys per pool. */
+  function makeMultiPoolFixture(): {
+    auth: CognitoUserPoolAuthorizer;
+    poolA: ReturnType<typeof makeJwtFixture>;
+    poolB: ReturnType<typeof makeJwtFixture>;
+  } {
+    const auth: CognitoUserPoolAuthorizer = {
+      kind: 'cognito',
+      logicalId: 'MultiAuth',
+      pools: [
+        {
+          userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_tenantA',
+          region: 'us-east-1',
+          userPoolId: 'us-east-1_tenantA',
+        },
+        {
+          userPoolArn: 'arn:aws:cognito-idp:us-west-2:111:userpool/us-west-2_tenantB',
+          region: 'us-west-2',
+          userPoolId: 'us-west-2_tenantB',
+        },
+      ],
+      // Legacy single-pool aliases point at pools[0].
+      userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_tenantA',
+      region: 'us-east-1',
+      userPoolId: 'us-east-1_tenantA',
+      declaredAt: 'S/Method',
+    };
+    return { auth, poolA: makeJwtFixture(), poolB: makeJwtFixture() };
+  }
+
+  it('verifies a token issued by the SECOND configured pool against its JWKS', async () => {
+    const { auth, poolA, poolB } = makeMultiPoolFixture();
+    // Per-URL fetch: pool A's JWKS returns poolA's key only; pool B's
+    // returns poolB's key only.
+    const cache = createJwksCache({
+      fetchImpl: async (url: string) => {
+        const key = url.includes('us-east-1_tenantA') ? poolA.jwk : poolB.jwk;
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ keys: [key] }),
+        };
+      },
+    });
+    const tokenFromB = poolB.sign(
+      {},
+      {
+        sub: 'tenant-b-user',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_tenantB',
+      }
+    );
+    const result = await verifyCognitoJwt(auth, `Bearer ${tokenFromB}`, cache);
+    expect(result.allow).toBe(true);
+    expect(result.principalId).toBe('tenant-b-user');
+  });
+
+  it('rejects when issuer matches no configured pool', async () => {
+    const { auth, poolA } = makeMultiPoolFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [poolA.jwk] }),
+      }),
+    });
+    // Token signed legitimately by poolA, but `iss` claims a pool that
+    // isn't in the authorizer's `pools[]` — reject without touching JWKS.
+    const fakeToken = poolA.sign(
+      {},
+      {
+        sub: 'attacker',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_unregistered',
+      }
+    );
+    const result = await verifyCognitoJwt(auth, `Bearer ${fakeToken}`, cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('rejects a token from pool A signed with pool B keys (signature mismatch)', async () => {
+    const { auth, poolA, poolB } = makeMultiPoolFixture();
+    // poolA's JWKS contains poolA's key only.
+    const cache = createJwksCache({
+      fetchImpl: async (url: string) => {
+        const key = url.includes('us-east-1_tenantA') ? poolA.jwk : poolB.jwk;
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ keys: [key] }),
+        };
+      },
+    });
+    // Token claims pool A as issuer but is signed with pool B's private
+    // key. verifyAndShape pulls pool A's JWKS (per the `iss` match), but
+    // the kid won't be found (poolA and poolB are independent keypairs).
+    const crossSignedToken = poolB.sign(
+      {},
+      {
+        sub: 'attacker',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_tenantA',
+      }
+    );
+    const result = await verifyCognitoJwt(auth, `Bearer ${crossSignedToken}`, cache);
+    expect(result.allow).toBe(false);
+  });
+
+  it('single-element pools[] behaves identically to the legacy single-pool case (backward compat)', async () => {
+    const fixture = makeJwtFixture();
+    const cache = createJwksCache({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ keys: [fixture.jwk] }),
+      }),
+    });
+    const auth: CognitoUserPoolAuthorizer = {
+      kind: 'cognito',
+      logicalId: 'Auth',
+      pools: [
+        {
+          userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_solo',
+          region: 'us-east-1',
+          userPoolId: 'us-east-1_solo',
+        },
+      ],
+      userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_solo',
+      region: 'us-east-1',
+      userPoolId: 'us-east-1_solo',
+      declaredAt: 'S/Method',
+    };
+    const token = fixture.sign(
+      {},
+      {
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_solo',
+      }
+    );
+    const result = await verifyCognitoJwt(auth, `Bearer ${token}`, cache);
+    expect(result.allow).toBe(true);
+    expect(result.principalId).toBe('user-1');
+  });
+
+  it('JWKS pass-through is per-pool (one pool reachable, the other not)', async () => {
+    const { auth, poolA } = makeMultiPoolFixture();
+    let aFetched = 0;
+    let bFetched = 0;
+    const cache = createJwksCache({
+      fetchImpl: async (url: string) => {
+        if (url.includes('us-east-1_tenantA')) {
+          aFetched++;
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ keys: [poolA.jwk] }),
+          };
+        }
+        bFetched++;
+        // pool B's endpoint is unreachable — falls back to pass-through.
+        throw new Error('pool B network unreachable');
+      },
+      // Failure-mode TTL of 0 keeps the test deterministic; we just want
+      // to assert each pool's URL is fetched at least once.
+      failureTtlMs: 0,
+    });
+    // Token issued by pool A — verifies normally against pool A's JWKS,
+    // never triggers pool B's fetch.
+    const tokenA = poolA.sign(
+      {},
+      {
+        sub: 'user-a',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_tenantA',
+      }
+    );
+    const resultA = await verifyCognitoJwt(auth, `Bearer ${tokenA}`, cache);
+    expect(resultA.allow).toBe(true);
+    expect(aFetched).toBe(1);
+    expect(bFetched).toBe(0);
+
+    // Now a token issued by pool B — its JWKS fetch fails, so the
+    // pass-through path accepts the token (matches PR 8b's "JWKS
+    // unreachable → allow every Bearer token" design intent).
+    // Use the SAME signing key as poolA (sig won't verify but
+    // pass-through skips verification).
+    const tokenB = poolA.sign(
+      {},
+      {
+        sub: 'user-b',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iss: 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_tenantB',
+      }
+    );
+    const resultB = await verifyCognitoJwt(auth, `Bearer ${tokenB}`, cache);
+    expect(resultB.allow).toBe(true);
+    expect(bFetched).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/unit/local/lambda-authorizer.test.ts
+++ b/tests/unit/local/lambda-authorizer.test.ts
@@ -1,0 +1,530 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import {
+  buildMethodArn,
+  computeRequestIdentityHash,
+  evaluateCachedLambdaPolicy,
+  extractIdentityValue,
+  invokeRequestAuthorizer,
+  invokeTokenAuthorizer,
+  parseLambdaAuthorizerResponse,
+  resourceMatches,
+} from '../../../src/local/lambda-authorizer.js';
+import type {
+  LambdaRequestAuthorizer,
+  LambdaTokenAuthorizer,
+} from '../../../src/local/authorizer-resolver.js';
+
+vi.mock('../../../src/local/rie-client.js', () => ({
+  invokeRie: vi.fn(),
+}));
+import * as rieClient from '../../../src/local/rie-client.js';
+const invokeRieMock = rieClient.invokeRie as unknown as ReturnType<typeof vi.fn>;
+
+function makePool(): { pool: unknown; acquire: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> } {
+  const acquire = vi.fn(async () => ({ containerHost: '127.0.0.1', hostPort: 1234 }));
+  const release = vi.fn();
+  const pool = {
+    acquire,
+    release,
+    dispose: vi.fn(async () => undefined),
+  };
+  return { pool, acquire, release };
+}
+
+const baseRequest = {
+  method: 'GET',
+  headers: { authorization: 'Bearer xyz123', 'user-agent': 'test' },
+  queryStringParameters: { token: 'qtok' },
+  pathParameters: {},
+  sourceIp: '127.0.0.1',
+  matchedPath: '/items/42',
+  stage: 'prod',
+};
+
+describe('buildMethodArn', () => {
+  it('strips the leading slash from the path', () => {
+    expect(
+      buildMethodArn({
+        apiId: 'a',
+        accountId: '111',
+        stage: 'prod',
+        method: 'get',
+        path: '/items/42',
+      })
+    ).toBe('arn:aws:execute-api:local:111:a/prod/GET/items/42');
+  });
+});
+
+describe('parseLambdaAuthorizerResponse', () => {
+  const methodArn = 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42';
+
+  it("returns allow=false for missing policyDocument", () => {
+    const result = parseLambdaAuthorizerResponse({ principalId: 'u' }, methodArn, 'h');
+    expect(result.allow).toBe(false);
+    expect(result.principalId).toBe('u');
+  });
+
+  it('returns allow=true for matching Allow Resource (literal)', () => {
+    const result = parseLambdaAuthorizerResponse(
+      {
+        principalId: 'u',
+        policyDocument: {
+          Version: '2012-10-17',
+          Statement: [{ Effect: 'Allow', Action: 'execute-api:Invoke', Resource: methodArn }],
+        },
+        context: { foo: 'bar' },
+      },
+      methodArn,
+      'h'
+    );
+    expect(result.allow).toBe(true);
+    expect(result.context).toEqual({ foo: 'bar' });
+  });
+
+  it('returns allow=true for wildcard Resource (** crosses path segments)', () => {
+    const result = parseLambdaAuthorizerResponse(
+      {
+        principalId: 'u',
+        policyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              // ** crosses path segments — needed to match the full
+              // `<METHOD>/<resource>/<id>` tail of the methodArn.
+              Resource: 'arn:aws:execute-api:local:123456789012:local/prod/**',
+            },
+          ],
+        },
+      },
+      methodArn,
+      'h'
+    );
+    expect(result.allow).toBe(true);
+  });
+
+  it('returns allow=false for Deny statements', () => {
+    const result = parseLambdaAuthorizerResponse(
+      {
+        principalId: 'u',
+        policyDocument: {
+          Statement: [{ Effect: 'Deny', Resource: methodArn }],
+        },
+      },
+      methodArn,
+      'h'
+    );
+    expect(result.allow).toBe(false);
+  });
+
+  it('returns allow=false for non-matching Resource', () => {
+    const result = parseLambdaAuthorizerResponse(
+      {
+        policyDocument: {
+          Statement: [{ Effect: 'Allow', Resource: 'arn:aws:execute-api:local:111:other/x/y/z' }],
+        },
+      },
+      methodArn,
+      'h'
+    );
+    expect(result.allow).toBe(false);
+  });
+});
+
+describe('invokeTokenAuthorizer', () => {
+  const auth: LambdaTokenAuthorizer = {
+    kind: 'lambda-token',
+    logicalId: 'Auth',
+    lambdaLogicalId: 'AuthFn',
+    tokenHeader: 'authorization',
+    resultTtlSeconds: 300,
+    declaredAt: 'S/Method',
+  };
+
+  it('builds a TOKEN event and parses an Allow response', async () => {
+    const { pool, acquire, release } = makePool();
+    invokeRieMock.mockResolvedValueOnce({
+      raw: '',
+      payload: {
+        principalId: 'u1',
+        policyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Resource: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42',
+            },
+          ],
+        },
+        context: { user: 'u1' },
+      },
+    });
+    const result = await invokeTokenAuthorizer(auth, baseRequest, {
+      pool: pool as never,
+      rieTimeoutMs: 1000,
+      methodArn: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42',
+      mockAccountId: '123456789012',
+      mockApiId: 'local',
+    });
+    expect(result.allow).toBe(true);
+    expect(result.principalId).toBe('u1');
+    expect(result.context).toEqual({ user: 'u1' });
+    expect(acquire).toHaveBeenCalledWith('AuthFn');
+    expect(release).toHaveBeenCalledOnce();
+    const event = invokeRieMock.mock.calls[0]![2];
+    expect(event).toMatchObject({
+      type: 'TOKEN',
+      authorizationToken: 'Bearer xyz123',
+      methodArn: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42',
+    });
+  });
+
+  it("returns allow=false without invoking the Lambda when the token header is missing", async () => {
+    const { pool, acquire } = makePool();
+    invokeRieMock.mockClear();
+    const result = await invokeTokenAuthorizer(
+      auth,
+      { ...baseRequest, headers: { 'user-agent': 'test' } },
+      {
+        pool: pool as never,
+        rieTimeoutMs: 1000,
+        methodArn: 'm',
+        mockAccountId: '1',
+        mockApiId: 'local',
+      }
+    );
+    expect(result.allow).toBe(false);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(invokeRieMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('invokeRequestAuthorizer (HTTP v2 simple shape)', () => {
+  const auth: LambdaRequestAuthorizer = {
+    kind: 'lambda-request',
+    logicalId: 'Auth',
+    lambdaLogicalId: 'AuthFn',
+    identitySources: [{ kind: 'header', name: 'authorization' }],
+    resultTtlSeconds: 60,
+    apiVersion: 'v2',
+    declaredAt: 'S/Route',
+  };
+
+  it('parses the v2 simple {isAuthorized,context} shape', async () => {
+    const { pool } = makePool();
+    invokeRieMock.mockResolvedValueOnce({
+      raw: '',
+      payload: { isAuthorized: true, context: { tier: 'pro' } },
+    });
+    const result = await invokeRequestAuthorizer(auth, baseRequest, {
+      pool: pool as never,
+      rieTimeoutMs: 1000,
+      methodArn: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42',
+      mockAccountId: '123456789012',
+      mockApiId: 'local',
+    });
+    expect(result.allow).toBe(true);
+    expect(result.context).toEqual({ tier: 'pro' });
+  });
+
+  it('falls back to IAM-policy parse when isAuthorized is missing', async () => {
+    const { pool } = makePool();
+    invokeRieMock.mockResolvedValueOnce({
+      raw: '',
+      payload: {
+        principalId: 'u',
+        policyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Resource: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42',
+            },
+          ],
+        },
+      },
+    });
+    const result = await invokeRequestAuthorizer(auth, baseRequest, {
+      pool: pool as never,
+      rieTimeoutMs: 1000,
+      methodArn: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42',
+      mockAccountId: '123456789012',
+      mockApiId: 'local',
+    });
+    expect(result.allow).toBe(true);
+  });
+});
+
+describe('invokeRequestAuthorizer (REST v1 missing identity)', () => {
+  it('returns allow=false (401) when every identity source is empty', async () => {
+    const auth: LambdaRequestAuthorizer = {
+      kind: 'lambda-request',
+      logicalId: 'Auth',
+      lambdaLogicalId: 'AuthFn',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: 60,
+      apiVersion: 'v1',
+      declaredAt: 'S/Method',
+    };
+    const { pool, acquire } = makePool();
+    invokeRieMock.mockClear();
+    const result = await invokeRequestAuthorizer(
+      auth,
+      { ...baseRequest, headers: { 'user-agent': 'test' } },
+      {
+        pool: pool as never,
+        rieTimeoutMs: 1000,
+        methodArn: 'm',
+        mockAccountId: '1',
+        mockApiId: 'local',
+      }
+    );
+    expect(result.allow).toBe(false);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(invokeRieMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * PR #237 review must-fix #2 + missing-Effect test gap. The drift fix
+ * landed by reshaping `evaluateCachedLambdaPolicy`: every cache hit
+ * re-runs `Resource` matching against the current methodArn so a
+ * narrow-Resource Allow can't leak across routes. The missing-Effect
+ * branch maps to deny per AWS spec ("Effect is required").
+ */
+describe('evaluateCachedLambdaPolicy', () => {
+  const arnA = 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42';
+  const arnB = 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/999';
+
+  it('returns allow=true for matching narrow Resource', () => {
+    const cached = {
+      allow: true,
+      principalId: 'u',
+      policy: {
+        Version: '2012-10-17',
+        Statement: [{ Effect: 'Allow', Resource: arnA }],
+      },
+    };
+    expect(evaluateCachedLambdaPolicy(cached, arnA).allow).toBe(true);
+  });
+
+  it('returns allow=false when narrow Resource does not match the new methodArn', () => {
+    const cached = {
+      allow: true,
+      principalId: 'u',
+      policy: {
+        Version: '2012-10-17',
+        Statement: [{ Effect: 'Allow', Resource: arnA }],
+      },
+    };
+    // Pre-fix: cache hit returned allow=true even for the second route
+    // (security bypass). Post-fix: Resource is re-evaluated.
+    expect(evaluateCachedLambdaPolicy(cached, arnB).allow).toBe(false);
+  });
+
+  it('returns allow=true for wildcard Resource (** crosses path segments) regardless of methodArn', () => {
+    const cached = {
+      allow: true,
+      principalId: 'u',
+      policy: {
+        Statement: [
+          // ** crosses path segments — covers every method+path under the stage.
+          { Effect: 'Allow', Resource: 'arn:aws:execute-api:local:123456789012:local/prod/**' },
+        ],
+      },
+    };
+    expect(evaluateCachedLambdaPolicy(cached, arnA).allow).toBe(true);
+    expect(evaluateCachedLambdaPolicy(cached, arnB).allow).toBe(true);
+  });
+
+  it('preserves principalId / context across cache hits', () => {
+    const cached = {
+      allow: true,
+      principalId: 'u',
+      context: { tier: 'pro' },
+      policy: { Statement: [{ Effect: 'Allow', Resource: arnA }] },
+    };
+    const out = evaluateCachedLambdaPolicy(cached, arnA);
+    expect(out.principalId).toBe('u');
+    expect(out.context).toEqual({ tier: 'pro' });
+  });
+
+  it('returns allow=false when policy is missing', () => {
+    const cached = { allow: true };
+    expect(evaluateCachedLambdaPolicy(cached, arnA).allow).toBe(false);
+  });
+
+  it('treats a Statement without Effect field as deny (AWS spec)', () => {
+    // Test gap: the "missing Effect → deny" branch in evaluatePolicy.
+    const cached = {
+      allow: true,
+      policy: {
+        // No Effect field on the statement; AWS spec requires Effect, so
+        // a statement without one cannot grant Allow.
+        Statement: [{ Resource: arnA }],
+      },
+    };
+    expect(evaluateCachedLambdaPolicy(cached, arnA).allow).toBe(false);
+  });
+});
+
+/**
+ * `parseLambdaAuthorizerResponse` already encodes the missing-Effect →
+ * deny rule. Pin it here so a refactor can't regress the spec compliance.
+ */
+describe('parseLambdaAuthorizerResponse — missing-Effect deny', () => {
+  it('returns allow=false when a statement omits Effect (spec compliance)', () => {
+    const methodArn = 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42';
+    const result = parseLambdaAuthorizerResponse(
+      {
+        principalId: 'u',
+        policyDocument: {
+          Statement: [{ Resource: methodArn }],
+        },
+      },
+      methodArn,
+      'h'
+    );
+    expect(result.allow).toBe(false);
+  });
+});
+
+describe('computeRequestIdentityHash', () => {
+  const baseRequestNoAuth = {
+    method: 'GET',
+    headers: {},
+    queryStringParameters: {},
+    pathParameters: {},
+    sourceIp: '127.0.0.1',
+    matchedPath: '/items/42',
+    stage: 'prod',
+  };
+
+  it('REST v1 + missing every identity source → missing=true (401 path)', () => {
+    const auth: LambdaRequestAuthorizer = {
+      kind: 'lambda-request',
+      logicalId: 'A',
+      lambdaLogicalId: 'F',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: 60,
+      apiVersion: 'v1',
+      declaredAt: 'S/M',
+    };
+    const out = computeRequestIdentityHash(auth, baseRequestNoAuth);
+    expect(out.missing).toBe(true);
+  });
+
+  it('REST v1 + present identity → missing=false', () => {
+    const auth: LambdaRequestAuthorizer = {
+      kind: 'lambda-request',
+      logicalId: 'A',
+      lambdaLogicalId: 'F',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: 60,
+      apiVersion: 'v1',
+      declaredAt: 'S/M',
+    };
+    const out = computeRequestIdentityHash(auth, {
+      ...baseRequestNoAuth,
+      headers: { authorization: 'Bearer xyz' },
+    });
+    expect(out.missing).toBe(false);
+    expect(out.identityHash).toBe('Bearer xyz');
+  });
+
+  it('HTTP v2 + missing → missing=false (HTTP v2 falls through)', () => {
+    const auth: LambdaRequestAuthorizer = {
+      kind: 'lambda-request',
+      logicalId: 'A',
+      lambdaLogicalId: 'F',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: 60,
+      apiVersion: 'v2',
+      declaredAt: 'S/R',
+    };
+    const out = computeRequestIdentityHash(auth, baseRequestNoAuth);
+    expect(out.missing).toBe(false);
+  });
+});
+
+describe('extractIdentityValue', () => {
+  const req = {
+    method: 'GET',
+    headers: { authorization: 'Bearer xyz', 'x-api-key': 'k1' },
+    queryStringParameters: { token: 't1' },
+    pathParameters: {},
+    sourceIp: '1.2.3.4',
+    matchedPath: '/items/42',
+    stage: 'prod',
+  };
+
+  it('reads header values', () => {
+    expect(extractIdentityValue({ kind: 'header', name: 'authorization' }, req)).toBe('Bearer xyz');
+  });
+
+  it('reads query values', () => {
+    expect(extractIdentityValue({ kind: 'query', name: 'token' }, req)).toBe('t1');
+  });
+
+  it('returns undefined for context (v1 not yet wired)', () => {
+    expect(extractIdentityValue({ kind: 'context', name: 'foo' }, req)).toBeUndefined();
+  });
+
+  it('returns undefined for stage-variable (v1 not yet wired)', () => {
+    expect(extractIdentityValue({ kind: 'stage-variable', name: 'bar' }, req)).toBeUndefined();
+  });
+});
+
+describe('resourceMatches', () => {
+  const arn = 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42';
+
+  it('exact literal match', () => {
+    expect(resourceMatches(arn, arn)).toBe(true);
+  });
+  it('non-matching literal returns false', () => {
+    expect(resourceMatches('arn:other:not:matching', arn)).toBe(false);
+  });
+  it('* matches a single path segment (tail)', () => {
+    // `*` matches `42` (one path segment).
+    expect(
+      resourceMatches('arn:aws:execute-api:local:123456789012:local/prod/GET/items/*', arn)
+    ).toBe(true);
+  });
+  it('* does NOT cross / segment boundaries (matches AWS IAM spec)', () => {
+    // Pattern has 4 trailing path-segments after `prod/`: `*/*/*` is only
+    // three segments, would-match if `*` greedily ate `GET/items/42`,
+    // but does NOT under the segmented rule. Pre-fix this returned true.
+    expect(
+      resourceMatches('arn:aws:execute-api:local:123456789012:local/prod/*/*', arn)
+    ).toBe(false);
+    // Three single-segment wildcards line up — matches.
+    expect(
+      resourceMatches('arn:aws:execute-api:local:123456789012:local/prod/*/*/*', arn)
+    ).toBe(true);
+  });
+  it('* does NOT cross : segment boundaries (matches AWS IAM spec)', () => {
+    // `*` in the region/account slot can NOT eat through `:` into the
+    // account / api segments.
+    expect(
+      resourceMatches('arn:aws:execute-api:*:local/prod/GET/items/42', arn)
+    ).toBe(false);
+    // Single segment between the two : is fine.
+    expect(
+      resourceMatches('arn:aws:execute-api:*:123456789012:local/prod/GET/items/42', arn)
+    ).toBe(true);
+  });
+  it('** crosses / and : boundaries (cdk-local extension)', () => {
+    expect(
+      resourceMatches('arn:aws:execute-api:local:123456789012:local/prod/**', arn)
+    ).toBe(true);
+    expect(resourceMatches('arn:**', arn)).toBe(true);
+  });
+  it('? matches a single character within a segment', () => {
+    expect(resourceMatches('arn:aws:execute-api:local:123456789012:local/prod/?ET/items/42', arn)).toBe(
+      true
+    );
+  });
+  it('? does NOT cross / boundary', () => {
+    // Trying to match `T/i` with `???` — the middle char is `/`, must be rejected.
+    expect(resourceMatches('arn:aws:execute-api:local:123456789012:local/prod/GE???tems/42', arn)).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Expose the three `start-api` authorizer leaf modules from the package entry (`src/index.ts`) so a host that shims cdk-local's `src/local` modules verbatim (e.g. cdkd) can re-export them 1:1 instead of carrying byte-identical copies:

- **authorizer-cache**: `createAuthorizerCache` (+ `AuthorizerCache` / `CachedAuthorizerResult`)
- **cognito-jwt**: `createJwksCache` / `buildCognitoJwksUrl` / `buildJwksUrlFromIssuer` / `verifyCognitoJwt` / `verifyJwtAuthorizer` (+ `JwksCache`)
- **lambda-authorizer**: `buildMethodArn` / `computeRequestIdentityHash` / `evaluateCachedLambdaPolicy` / `invokeRequestAuthorizer` / `invokeTokenAuthorizer`

The set is driven by the consuming host's actual `import` statements (not a speculative bulk export). The functions' transitive signature types (`LambdaTokenAuthorizer` / `RequestSnapshotForAuthorizer` / `AuthorizerInvocationContext`) are inlined into the bundled `dist/index.d.ts` by tsdown, so they resolve for consumers without needing their own named exports.

Two supporting changes:

- **Tests ported to where the implementation lives.** These three modules had no unit tests in this repo; their tests lived only in the consuming host. Ported them into `tests/unit/local/`. The authorizer leaf modules carry no runtime branded strings, so the only adjustment from a verbatim copy is one branded test *title* in `lambda-authorizer.test.ts` (`cdkd extension` → `cdk-local extension`) — no assertion changes.
- **Docs.** Documented the layer in `docs/library-mode.md` under the existing "Low-level building blocks (shim hosts)" section.

Purely additive to `src/index.ts`. `feat` → minor version bump.

Note: `lambda-authorizer` transitively uses `invokeRie` (rie-client) + `buildIdentityHash` (authorizer-resolver), both byte-identical in code between this repo and the consuming host, and `ContainerPool` only as a type — so a 1:1 shim is behavior-preserving.

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) green, 79 files
- [x] `vp run build` green; `dist/index.d.ts` declares all 11 functions, `dist/index.js` exports all 11 at runtime
- [x] `vp run test` — 36 files / 520 tests pass (incl. the 3 ported)
- [x] No existing export removed/renamed (additive only)
