### PR TITLE
fix(start-service): clearer not-found error for logical-ID-in-path

### DIFF
--- a/src/local/ecs-service-resolver.ts
+++ b/src/local/ecs-service-resolver.ts
@@ -7,6 +7,7 @@ import {
   parseEcsTarget,
   resolveEcsTaskTarget,
   type EcsImageResolutionContext,
+  type ParsedEcsTarget,
   type ResolvedEcsTask,
 } from './ecs-task-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
@@ -188,7 +189,7 @@ export function resolveEcsServiceTarget(
       ({ logicalId: l }) => resources[l]?.Type === 'AWS::ECS::Service'
     );
     if (services.length === 0) {
-      throw notFoundError(target, stack, resources);
+      throw notFoundError(target, stack, resources, parsed);
     }
     if (services.length > 1) {
       throw new EcsTaskResolutionError(
@@ -201,11 +202,11 @@ export function resolveEcsServiceTarget(
     serviceResource = resources[serviceLogicalId];
   } else {
     serviceResource = resources[parsed.pathOrId];
-    if (!serviceResource) throw notFoundError(target, stack, resources);
+    if (!serviceResource) throw notFoundError(target, stack, resources, parsed);
     serviceLogicalId = parsed.pathOrId;
   }
 
-  if (!serviceLogicalId || !serviceResource) throw notFoundError(target, stack, resources);
+  if (!serviceLogicalId || !serviceResource) throw notFoundError(target, stack, resources, parsed);
 
   if (serviceResource.Type === 'AWS::ECS::TaskDefinition') {
     throw new EcsTaskResolutionError(
@@ -579,19 +580,46 @@ function pickStack(
 function notFoundError(
   target: string,
   stack: StackInfo,
-  resources: Record<string, TemplateResource>
+  resources: Record<string, TemplateResource>,
+  parsed: ParsedEcsTarget
 ): EcsTaskResolutionError {
-  const services = Object.entries(resources)
-    .filter(([, r]) => r.Type === 'AWS::ECS::Service')
-    .map(([id]) => id);
+  const services: { displayPath: string; logicalId: string }[] = [];
+  for (const [logicalId, r] of Object.entries(resources)) {
+    if (r.Type !== 'AWS::ECS::Service') continue;
+    const meta = r.Metadata;
+    const cdkPath = typeof meta?.['aws:cdk:path'] === 'string' ? meta['aws:cdk:path'] : '';
+    services.push({ displayPath: cdkPath || logicalId, logicalId });
+  }
   if (services.length === 0) {
     return new EcsTaskResolutionError(
       `Target '${target}' did not match any resource in ${stack.stackName}, and the stack ` +
         'declares no AWS::ECS::Service resources at all.'
     );
   }
-  return new EcsTaskResolutionError(
-    `Target '${target}' did not match any ECS Service in ${stack.stackName}. ` +
-      `Available services: ${services.join(', ')}.`
-  );
+  // Show BOTH forms per service so the message itself documents how to
+  // address each: the 'Stack/Path' form matches the CDK construct path
+  // (left column), the 'Stack:LogicalId' form matches the logical ID
+  // (right column).
+  const width = Math.max(...services.map((s) => s.displayPath.length));
+  let msg = `Target '${target}' did not match any ECS Service in ${stack.stackName}.\n\n`;
+  msg += `Available services in ${stack.stackName} (CDK path and logical ID):\n`;
+  for (const s of services) {
+    msg += `  ${s.displayPath.padEnd(width)}  (${s.logicalId})\n`;
+  }
+  // When a 'Stack/Path'-form target's trailing segment is exactly a
+  // service logical ID, the user almost certainly meant the colon form —
+  // the slash form resolves CDK construct paths, not logical IDs, so it
+  // dead-ends with an "Available services" list that appears to contain
+  // the very name they typed. Call out the fix explicitly.
+  if (parsed.isPath) {
+    const tail = parsed.pathOrId.includes('/')
+      ? parsed.pathOrId.slice(parsed.pathOrId.lastIndexOf('/') + 1)
+      : parsed.pathOrId;
+    if (services.some((s) => s.logicalId === tail)) {
+      msg +=
+        `\n'${tail}' is a logical ID, but the 'Stack/Path' form matches CDK construct paths. ` +
+        `To target it by logical ID, use the colon form: '${stack.stackName}:${tail}'.`;
+    }
+  }
+  return new EcsTaskResolutionError(msg.trimEnd());
 }

--- a/tests/unit/local/ecs-service-resolver-not-found.test.ts
+++ b/tests/unit/local/ecs-service-resolver-not-found.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { resolveEcsServiceTarget } from '../../../src/local/ecs-service-resolver.js';
+import { EcsTaskResolutionError } from '../../../src/local/ecs-task-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+function stackWithService(): StackInfo {
+  return {
+    stackName: 'MyStack',
+    template: {
+      Resources: {
+        BackendServiceABC123: {
+          Type: 'AWS::ECS::Service',
+          Properties: {},
+          Metadata: { 'aws:cdk:path': 'MyStack/Backend/Service/Service/Service' },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
+function call(target: string): EcsTaskResolutionError {
+  try {
+    resolveEcsServiceTarget(target, [stackWithService()]);
+  } catch (e) {
+    return e as EcsTaskResolutionError;
+  }
+  throw new Error('expected resolveEcsServiceTarget to throw');
+}
+
+describe('resolveEcsServiceTarget not-found message', () => {
+  it('lists each service by CDK display path AND logical ID', () => {
+    const err = call('MyStack/does/not/exist');
+    expect(err).toBeInstanceOf(EcsTaskResolutionError);
+    expect(err.message).toContain('Available services in MyStack');
+    expect(err.message).toContain('MyStack/Backend/Service/Service/Service');
+    expect(err.message).toContain('(BackendServiceABC123)');
+  });
+
+  it('hints the colon form when a Stack/Path target is actually a logical ID', () => {
+    const err = call('MyStack/BackendServiceABC123');
+    expect(err.message).toContain("'BackendServiceABC123' is a logical ID");
+    expect(err.message).toContain("use the colon form: 'MyStack:BackendServiceABC123'");
+  });
+
+  it('does NOT add the colon hint for a genuine path miss (tail is not a logical ID)', () => {
+    const err = call('MyStack/Backend/Nope');
+    expect(err.message).toContain('Available services in MyStack');
+    expect(err.message).not.toContain('is a logical ID');
+  });
+
+  it('does NOT add the colon hint for the colon form (logical ID typo)', () => {
+    const err = call('MyStack:BackendServiceXYZ');
+    expect(err.message).toContain('Available services in MyStack');
+    expect(err.message).not.toContain('is a logical ID');
+  });
+
+  it('reports the no-services-at-all case distinctly', () => {
+    const empty = {
+      stackName: 'MyStack',
+      template: { Resources: { SomeBucket: { Type: 'AWS::S3::Bucket', Properties: {} } } },
+    } as unknown as StackInfo;
+    let err: EcsTaskResolutionError | undefined;
+    try {
+      resolveEcsServiceTarget('MyStack:Whatever', [empty]);
+    } catch (e) {
+      err = e as EcsTaskResolutionError;
+    }
+    expect(err?.message).toContain('declares no AWS::ECS::Service resources at all');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl start-service` accepts a target as either `Stack/Path` (resolves a
CDK construct path) or `Stack:LogicalId` (resolves a logical ID
directly). When a user passed a **logical ID** in the **slash** form
(e.g. `MyStack/MyServiceLogicalIdABC123`), the resolver searched
construct paths, found nothing, and printed:

```
Target '...' did not match any ECS Service in MyStack. Available services: MyServiceLogicalIdABC123.
```

Because the "Available services" list showed logical IDs — including the
exact name just typed — the error looked self-contradictory and offered
no path forward.

## Fix

Enrich the service resolver's not-found message:

1. List each service by **both** its CDK construct path and its logical
   ID (matching the task resolver's existing format), so the message
   itself documents what each target form expects:

   ```
   Available services in MyStack (CDK path and logical ID):
     MyStack/Backend/Service/Service  (MyServiceLogicalIdABC123)
   ```

2. When a `Stack/Path` target's trailing segment is exactly a service
   logical ID, append a hint pointing at the colon form:

   ```
   'MyServiceLogicalIdABC123' is a logical ID, but the 'Stack/Path' form
   matches CDK construct paths. To target it by logical ID, use the colon
   form: 'MyStack:MyServiceLogicalIdABC123'.
   ```

The success path and target grammar are unchanged; only the not-found
error message is improved.

## Test plan

- [x] `vp run check` / `vp run build`
- [x] `vp run test` — 34 files, 453 tests
- [x] New `tests/unit/local/ecs-service-resolver-not-found.test.ts`:
      enriched listing, colon-form hint, genuine-path-miss (no hint),
      colon-form typo (no hint), and the no-services-at-all branch.
- [x] Live-tested against a real multi-stack app: a `Stack/<logicalId>`
      target now prints the CDK path + logical ID list and the colon-form
      hint instead of the old self-contradictory message.

## Notes

No Docker integ was run: this changes only the not-found error path
(exercised by the unit tests + the live run above); the start-service
Docker fixtures cover the success path, not this message.
