### PR TITLE
feat(start-api): --watch watches the CDK app source tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,18 +144,19 @@ Use this for production debugging, integration verification with real AWS resour
 
 ## `--watch` (hot reload)
 
-Pass `--watch` to `cdkl start-api` and the server hot-reloads when your CDK app's synth output (or any routed Lambda's asset directory) changes:
+Pass `--watch` to `cdkl start-api` and the server re-synths and hot-reloads when your CDK app's **source** changes — edit a handler or construct, save, and the change is live:
 
 ```bash
 cdkl start-api MyStack/MyApi --watch
 ```
 
-- 500 ms debounced [chokidar](https://github.com/paulmillr/chokidar) file watcher on `cdk.out/` + every routed Lambda's asset dir.
-- Re-synths and re-discovers routes on each firing — adding a new route to your CDK app shows up locally on save.
+- 500 ms debounced [chokidar](https://github.com/paulmillr/chokidar) file watcher on your CDK app's source tree (the directory holding `cdk.json`). Honors `cdk.json`'s `watch.include` / `watch.exclude` globs, exactly like `cdk watch`.
+- `cdk.out/`, `node_modules`, and `.git` are always excluded — the reload's own re-synth writes to `cdk.out/` never re-trigger the watcher, so there is no reload loop.
+- Re-synths and re-discovers routes on each firing — adding a new route to your CDK app shows up locally on save. No separate `cdk watch` / `cdk synth` process is needed.
 - Synth failures keep the previous version serving (warn-and-continue, never crashes the server).
-- Compatible with `--from-cfn-stack`: each reload re-reads the deployed CloudFormation stack so a deploy event picks up new ARNs without restarting the server.
+- Compatible with `--from-cfn-stack`: each reload re-reads the deployed CloudFormation stack so newly-deployed ARNs are picked up on your next source save without restarting the server.
 
-See [docs/local-emulation.md](docs/local-emulation.md#hot-reload---watch) for the full lifecycle, file-list update semantics, and known limitations.
+See [docs/local-emulation.md](docs/local-emulation.md#hot-reload---watch) for the full lifecycle, `watch.include` / `watch.exclude` semantics, and known limitations.
 
 ## Override env vars without a state source
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -575,7 +575,7 @@ the same tier; cdk-local uses literal-segment count as a heuristic).
 | `--debug-port-base <port>` | unset | Allocate a contiguous `--inspect-brk` port range across Lambdas (one per Lambda). |
 | `--env-vars <file>` | unset | SAM-shape JSON: `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. Same format as `cdkl invoke`. |
 | `--assume-role <arn-or-pair>` | unset | Repeatable. Bare `<arn>` = global default; `<LogicalId>=<arn>` = per-Lambda override. Per-Lambda > global > unset (developer creds passed through). |
-| `--watch` | off | Hot reload: re-synth + re-discover routes when `cdk.out/` or any routed Lambda's asset directory changes. 500ms debounce. Synth failures keep the previous version serving (warn-and-continue, never crashes the server). |
+| `--watch` | off | Hot reload: re-synth + re-discover routes when the CDK app's source tree (the directory holding `cdk.json`) changes. Honors `cdk.json` `watch.include` / `watch.exclude`; `cdk.out/`, `node_modules`, and `.git` are always excluded so the reload's own re-synth writes never re-trigger it. 500ms debounce. Synth failures keep the previous version serving (warn-and-continue, never crashes the server). |
 | `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). When the override doesn't match any Stage on a given API, that API's routes get `stageVariables: null` and the CLI emits a warn line up front. |
 | `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters in Lambda env vars with the deployed physical IDs / exports. **The bare form is the typical shape** — `cdkl start-api MyStack/MyApi --from-cfn-stack` resolves to the CDK stack name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden). The explicit form is rejected when more than one stack is routed in one invocation; the bare form is fine for multi-stack. `Fn::GetAtt` (and other intrinsics `ListStackResources` can't resolve) in a routed Lambda's OWN env is recovered from the deployed function's resolved `Environment.Variables` via `lambda:GetFunctionConfiguration`. Re-runs against fresh CFn data on every hot-reload firing (`--watch`). ListStackResources failures degrade per-stack to warn-and-fall-back so an unreadable stack never aborts the server. |
 | `--stack-region <region>` | auto | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
@@ -602,11 +602,28 @@ region and no `AWS_REGION` env still surfaces that SDK error — set
 
 When `--watch` is set, cdk-local installs a
 [chokidar](https://github.com/paulmillr/chokidar)-backed file watcher
-over `cdk.out/` plus every routed Lambda's asset directory. A change
-in any watched path triggers a debounced (500ms window) reload:
+over the CDK app's **source tree** — the synth working directory, which
+is where `cdk.json` lives. Editing handler or construct source and
+saving triggers a debounced (500ms window) reload, so no separate
+`cdk watch` / `cdk synth` process is needed.
 
-1. Re-run `cdk synth` (skipped when `-a <dir>` was passed at server
-   boot — the directory is treated as already-synthesized).
+The watch set honors `cdk.json`'s `watch.include` / `watch.exclude`
+globs (mirroring `cdk watch`); `watch.include` defaults to `**` and a
+missing `watch` block is not an error. Three paths are ALWAYS excluded:
+
+- the synth **output directory** (`cdk.out/`, or the `--output` value),
+- `node_modules`,
+- `.git`.
+
+Excluding the output directory is load-bearing for correctness: each
+reload re-synths INTO `cdk.out/`, so watching it would make the reload's
+own writes re-trigger the watcher forever. Because the output directory
+is pruned, those re-synth writes are invisible to the watcher and there
+is no reload loop.
+
+A qualifying change triggers the reload sequence:
+
+1. Re-run `cdk synth`.
 2. Re-run route discovery, stage resolution, and CORS-config
    extraction.
 3. Build per-Lambda specs + a fresh container pool.

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -17,7 +17,8 @@ import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
-import { resolveApp } from '../config-loader.js';
+import { resolveApp, resolveWatchConfig } from '../config-loader.js';
+import { createGlobMatcher } from '../../utils/glob-match.js';
 import { readCdkPathOrUndefined } from '../cdk-path.js';
 import {
   createLocalStateProvider,
@@ -336,17 +337,6 @@ async function localStartApiCommand(
   // file mid-flight would race with running containers' SDK reads).
   // Disposed in the cleanup chain. Undefined when `--profile` is unset.
   let profileCredsFile: ProfileCredentialsFile | undefined;
-  // Track every Lambda asset directory the server is currently
-  // referencing; the file watcher uses this list to know what to
-  // watch beyond `cdk.out/`. The value is updated AFTER the reload
-  // orchestrator's atomic state swap completes (see the `.then(...)`
-  // block on `orchestrator.reload()` below) — pre-fix, the assignment
-  // happened mid-`synthesizeAndBuild`, so a concurrent file event
-  // during a reload would call `watcher.update([...new asset dirs])`
-  // while the server still serves the old state. Now the file
-  // watcher's view of "what asset dirs to watch" stays in lockstep
-  // with the server's state.
-  const lastAssetPaths: { value: string[] } = { value: [] };
 
   // PR 8b: per-server-lifecycle caches. Constructed once at server
   // startup; persisted across hot reloads (PR 8c) so authorizer
@@ -647,10 +637,7 @@ async function localStartApiCommand(
     // resolved by `buildContainerSpec` (`resolveContainerImageForStartApi`
     // ran the local build or ECR pull before this point), so the
     // ContainerPool can `docker run` against it without any further
-    // pull step. NOTE: the watched-asset list (`lastAssetPaths.value`)
-    // is NOT mutated here — the assignment happens AFTER the reload
-    // orchestrator's atomic state swap completes. See the `.then(...)`
-    // block on `orchestrator.reload()` below.
+    // pull step.
     const distinctImages = new Set<string>();
     for (const spec of specs.values()) {
       if (spec.kind === 'zip') {
@@ -688,38 +675,8 @@ async function localStartApiCommand(
     return pool;
   };
 
-  /**
-   * Compute the watched-asset list from a spec map. Pure helper —
-   * keeps the side-effect (`lastAssetPaths.value = ...`) confined to
-   * the post-swap call sites (initial boot + post-reload). For ZIP
-   * Lambdas `codeDir` is either the unzipped asset directory or the
-   * inline-code tmpdir; both are watch-worthy. IMAGE Lambdas
-   * (`kind: 'image'`) don't have a host-side bind-mount source — the
-   * code is baked into the docker image at build time. Their build
-   * context (Dockerfile + source directory) is rebuilt on every
-   * reload via `synthesizeAndBuild` → `buildContainerSpec` →
-   * `resolveContainerImageForStartApi`, so a source edit DOES trigger
-   * rebuild AND the deterministic `image` tag changes — but watching
-   * the build-context dir explicitly here is deferred to a follow-up
-   * (the watched-asset list is currently sourced from `cdk.out/`
-   * which transitively covers most container-Lambda asset dirs since
-   * `cdk synth` re-stages them on every synth call).
-   */
-  const computeAssetPaths = (specs: Map<string, ContainerSpec>): string[] => {
-    const assetPaths = new Set<string>();
-    for (const spec of specs.values()) {
-      if (spec.kind === 'zip') {
-        assetPaths.add(spec.codeDir);
-      }
-    }
-    return [...assetPaths];
-  };
-
   // Initial boot.
   const initialMaterial = await synthesizeAndBuild();
-  // Initial assignment is safe (no reload race possible before any
-  // server is even listening).
-  lastAssetPaths.value = computeAssetPaths(initialMaterial.specs);
 
   // PR 8b: pre-warm JWKS for Cognito / JWT authorizers so the first
   // request doesn't pay the fetch latency. Failures fall through to
@@ -1052,27 +1009,57 @@ async function localStartApiCommand(
   let watcher: FileWatcher | undefined;
   let reloadChain: Promise<unknown> = Promise.resolve();
   if (options.watch) {
-    const initialWatchPaths = [options.output, ...lastAssetPaths.value];
+    // Watch the CDK app's source tree (the synth working directory, where
+    // `cdk.json` lives) so editing handler / construct source re-synths
+    // and hot-reloads. We honor `cdk.json`'s `watch.include` /
+    // `watch.exclude` (mirroring `cdk watch`).
+    const watchRoot = process.cwd();
+    const watchConfig = resolveWatchConfig();
+    const toRel = (abs: string): string => path.relative(watchRoot, abs).split(path.sep).join('/');
+    // The synth output directory MUST be excluded: each reload re-synths
+    // INTO it, so watching it would make our own writes re-trigger the
+    // reload forever. `node_modules` / `.git` are pruned for the same
+    // loop-safety reasons plus traversal cost.
+    const outputRel = toRel(path.resolve(watchRoot, options.output));
+    const mandatoryExcludes =
+      outputRel && outputRel !== '.' && !outputRel.startsWith('..') ? [outputRel] : [];
+    const excludeMatcher = createGlobMatcher([
+      ...mandatoryExcludes,
+      'node_modules',
+      '.git',
+      ...watchConfig.exclude,
+    ]);
+    const includeMatcher = createGlobMatcher(watchConfig.include);
     watcher = createFileWatcher({
-      paths: initialWatchPaths,
+      paths: [watchRoot],
+      ignored: (p: string): boolean => {
+        const rel = toRel(p);
+        if (rel === '') return false; // the watch root itself
+        if (rel.startsWith('..')) return true; // outside the root
+        return excludeMatcher(rel);
+      },
+      shouldTrigger: (p: string): boolean => {
+        const rel = toRel(p);
+        if (rel === '' || rel.startsWith('..')) return false;
+        if (excludeMatcher(rel)) return false;
+        return includeMatcher(rel);
+      },
       onChange: () => {
-        logger.info('Detected file change; reloading...');
+        logger.info('Detected source change; reloading...');
         const next = reloadChain.then(() =>
           reloadAllServers({
             synthesizeAndBuild,
             servers,
             buildPool,
-            computeAssetPaths,
-            lastAssetPaths,
-            watcher,
-            output: options.output,
             logger,
           })
         );
         reloadChain = next.catch(() => undefined);
       },
     });
-    logger.info(`Watching ${options.output} (and ${lastAssetPaths.value.length} asset dir(s))`);
+    logger.info(
+      `Watching ${watchRoot} for source changes (excluding ${options.output}, node_modules, .git).`
+    );
   }
 
   // Graceful shutdown: SIGINT / SIGTERM / uncaughtException /
@@ -2915,22 +2902,9 @@ async function reloadAllServers(args: {
   synthesizeAndBuild: () => Promise<NextStateMaterial>;
   servers: readonly BootedApiServer[];
   buildPool: (specs: Map<string, ContainerSpec>) => ContainerPool;
-  computeAssetPaths: (specs: Map<string, ContainerSpec>) => string[];
-  lastAssetPaths: { value: string[] };
-  watcher: FileWatcher | undefined;
-  output: string;
   logger: ReturnType<typeof getLogger>;
 }): Promise<void> {
-  const {
-    synthesizeAndBuild,
-    servers,
-    buildPool,
-    computeAssetPaths,
-    lastAssetPaths,
-    watcher,
-    output,
-    logger,
-  } = args;
+  const { synthesizeAndBuild, servers, buildPool, logger } = args;
   let material: NextStateMaterial;
   try {
     material = await synthesizeAndBuild();
@@ -2985,11 +2959,6 @@ async function reloadAllServers(args: {
     });
   }
 
-  // Update the watcher's asset-path list AFTER all swaps complete.
-  lastAssetPaths.value = computeAssetPaths(material.specs);
-  if (watcher) {
-    watcher.update([output, ...lastAssetPaths.value]);
-  }
   // Re-print the per-server route table when any routes changed.
   // Cheap heuristic: always re-print after a successful reload — the
   // user is watching for the diff and a stable table reassures them
@@ -3363,7 +3332,7 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
     .addOption(
       new Option(
         '--watch',
-        'Hot-reload: re-synth + re-discover routes when cdk.out/ or asset directories change. Off by default; the server keeps the previous version serving when synth fails mid-reload.'
+        "Hot-reload: re-synth + re-discover routes when the CDK app's source changes (honors cdk.json watch.include/exclude; cdk.out, node_modules, .git are always excluded). Off by default; the server keeps the previous version serving when synth fails mid-reload."
       ).default(false)
     )
     .addOption(

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -17,7 +17,7 @@ import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
-import { resolveApp, resolveWatchConfig } from '../config-loader.js';
+import { resolveApp, resolveWatchConfig, type CdkWatchConfig } from '../config-loader.js';
 import { createGlobMatcher } from '../../utils/glob-match.js';
 import { readCdkPathOrUndefined } from '../cdk-path.js';
 import {
@@ -1014,36 +1014,15 @@ async function localStartApiCommand(
     // and hot-reloads. We honor `cdk.json`'s `watch.include` /
     // `watch.exclude` (mirroring `cdk watch`).
     const watchRoot = process.cwd();
-    const watchConfig = resolveWatchConfig();
-    const toRel = (abs: string): string => path.relative(watchRoot, abs).split(path.sep).join('/');
-    // The synth output directory MUST be excluded: each reload re-synths
-    // INTO it, so watching it would make our own writes re-trigger the
-    // reload forever. `node_modules` / `.git` are pruned for the same
-    // loop-safety reasons plus traversal cost.
-    const outputRel = toRel(path.resolve(watchRoot, options.output));
-    const mandatoryExcludes =
-      outputRel && outputRel !== '.' && !outputRel.startsWith('..') ? [outputRel] : [];
-    const excludeMatcher = createGlobMatcher([
-      ...mandatoryExcludes,
-      'node_modules',
-      '.git',
-      ...watchConfig.exclude,
-    ]);
-    const includeMatcher = createGlobMatcher(watchConfig.include);
+    const { ignored, shouldTrigger, excludePatterns } = createWatchPredicates({
+      watchRoot,
+      output: options.output,
+      watchConfig: resolveWatchConfig(),
+    });
     watcher = createFileWatcher({
       paths: [watchRoot],
-      ignored: (p: string): boolean => {
-        const rel = toRel(p);
-        if (rel === '') return false; // the watch root itself
-        if (rel.startsWith('..')) return true; // outside the root
-        return excludeMatcher(rel);
-      },
-      shouldTrigger: (p: string): boolean => {
-        const rel = toRel(p);
-        if (rel === '' || rel.startsWith('..')) return false;
-        if (excludeMatcher(rel)) return false;
-        return includeMatcher(rel);
-      },
+      ignored,
+      shouldTrigger,
       onChange: () => {
         logger.info('Detected source change; reloading...');
         const next = reloadChain.then(() =>
@@ -1058,7 +1037,7 @@ async function localStartApiCommand(
       },
     });
     logger.info(
-      `Watching ${watchRoot} for source changes (excluding ${options.output}, node_modules, .git).`
+      `Watching ${watchRoot} for source changes (excluding ${excludePatterns.join(', ')}).`
     );
   }
 
@@ -1233,6 +1212,62 @@ async function localStartApiCommand(
 
   // Block forever — the signal handlers exit the process.
   await new Promise<never>(() => undefined);
+}
+
+/** The `--watch` file-watcher predicates + the resolved exclude list. */
+export interface WatchPredicates {
+  /** chokidar `ignored` predicate (exclude-only; prunes dirs + files). */
+  ignored: (absPath: string) => boolean;
+  /** Per-event include gate — exclude wins, then include. */
+  shouldTrigger: (absPath: string) => boolean;
+  /** Resolved exclude glob list (mandatory + cdk.json), for logging. */
+  excludePatterns: string[];
+}
+
+/**
+ * Build the `--watch` file-watcher predicates for a source tree rooted
+ * at `watchRoot` (the synth working directory).
+ *
+ * The synth output directory is always excluded so the reload's own
+ * re-synth writes never re-trigger the watcher (no loop); `node_modules`
+ * / `.git` are excluded for traversal cost. `cdk.json` `watch.exclude`
+ * globs layer on top, and `watch.include` gates which changes fire a
+ * reload. The output dir is only added as a glob when it lives UNDER the
+ * watch root — when it equals the root (`''`) or sits outside it
+ * (`..`-prefixed), a watcher rooted at `watchRoot` never traverses it,
+ * so no exclude entry is needed (and a `''` / `..` glob is meaningless).
+ *
+ * `@internal` exported for unit tests (the exclude/include composition +
+ * the output-dir relativization edge cases).
+ */
+export function createWatchPredicates(args: {
+  watchRoot: string;
+  output: string;
+  watchConfig: CdkWatchConfig;
+}): WatchPredicates {
+  const { watchRoot, output, watchConfig } = args;
+  const toRel = (abs: string): string => path.relative(watchRoot, abs).split(path.sep).join('/');
+  // `path.relative` yields `''` when the output dir IS the watch root and a
+  // `..`-prefixed path when it is outside — in both cases a watcher rooted
+  // at `watchRoot` never traverses it, so it needs no exclude glob.
+  const outputRel = toRel(path.resolve(watchRoot, output));
+  const mandatoryExcludes = outputRel !== '' && !outputRel.startsWith('..') ? [outputRel] : [];
+  const excludePatterns = [...mandatoryExcludes, 'node_modules', '.git', ...watchConfig.exclude];
+  const excludeMatcher = createGlobMatcher(excludePatterns);
+  const includeMatcher = createGlobMatcher(watchConfig.include);
+  const ignored = (absPath: string): boolean => {
+    const rel = toRel(absPath);
+    if (rel === '') return false; // the watch root itself
+    if (rel.startsWith('..')) return true; // outside the root
+    return excludeMatcher(rel);
+  };
+  const shouldTrigger = (absPath: string): boolean => {
+    const rel = toRel(absPath);
+    if (rel === '' || rel.startsWith('..')) return false;
+    if (excludeMatcher(rel)) return false;
+    return includeMatcher(rel);
+  };
+  return { ignored, shouldTrigger, excludePatterns };
 }
 
 /**

--- a/src/cli/config-loader.ts
+++ b/src/cli/config-loader.ts
@@ -3,7 +3,12 @@ import { resolve } from 'node:path';
 import { getLogger } from '../utils/logger.js';
 import { getEmbedConfig } from '../local/embed-config.js';
 
-function loadCdkJson(): { app?: string } | null {
+interface CdkJson {
+  app?: string;
+  watch?: { include?: string | string[]; exclude?: string | string[] };
+}
+
+function loadCdkJson(): CdkJson | null {
   const filePath = resolve(process.cwd(), 'cdk.json');
   if (!existsSync(filePath)) {
     return null;
@@ -11,13 +16,20 @@ function loadCdkJson(): { app?: string } | null {
 
   try {
     const content = readFileSync(filePath, 'utf-8');
-    return JSON.parse(content) as { app?: string };
+    return JSON.parse(content) as CdkJson;
   } catch (error) {
     getLogger().warn(
       `Failed to parse ${filePath}: ${error instanceof Error ? error.message : String(error)}`
     );
     return null;
   }
+}
+
+function normalizeGlobList(value: string | string[] | undefined): string[] | undefined {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value))
+    return value.filter((entry): entry is string => typeof entry === 'string');
+  return undefined;
 }
 
 /**
@@ -38,4 +50,32 @@ export function resolveApp(cliApp?: string): string | undefined {
   if (envApp) return envApp;
 
   return loadCdkJson()?.app ?? undefined;
+}
+
+/** Resolved `cdk.json` `watch` block (include / exclude glob lists). */
+export interface CdkWatchConfig {
+  /** Globs of source paths whose changes trigger a `--watch` reload. */
+  include: string[];
+  /** Globs of source paths that never trigger a reload. */
+  exclude: string[];
+}
+
+/**
+ * Resolve the `cdk.json` `watch` block, mirroring `cdk watch`'s
+ * include / exclude semantics for `cdkl start-api --watch` source-tree
+ * watching.
+ *
+ * Defaults when the keys are absent: `include` -> `['**']` (watch the
+ * whole app directory), `exclude` -> `[]`. Unlike `cdk watch`, a missing
+ * `watch` block is NOT an error — `--watch` still works against the
+ * defaults. The caller layers in mandatory excludes (the synth output
+ * directory, `node_modules`, `.git`) so re-synth writes never re-trigger
+ * a reload and large noise directories are pruned.
+ */
+export function resolveWatchConfig(): CdkWatchConfig {
+  const watch = loadCdkJson()?.watch;
+  return {
+    include: normalizeGlobList(watch?.include) ?? ['**'],
+    exclude: normalizeGlobList(watch?.exclude) ?? [],
+  };
 }

--- a/src/cli/config-loader.ts
+++ b/src/cli/config-loader.ts
@@ -25,11 +25,9 @@ function loadCdkJson(): CdkJson | null {
   }
 }
 
-function normalizeGlobList(value: string | string[] | undefined): string[] | undefined {
-  if (typeof value === 'string') return [value];
-  if (Array.isArray(value))
-    return value.filter((entry): entry is string => typeof entry === 'string');
-  return undefined;
+function normalizeGlobList(value: string | string[] | undefined): string[] {
+  const arr = typeof value === 'string' ? [value] : Array.isArray(value) ? value : [];
+  return arr.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
 }
 
 /**
@@ -74,8 +72,11 @@ export interface CdkWatchConfig {
  */
 export function resolveWatchConfig(): CdkWatchConfig {
   const watch = loadCdkJson()?.watch;
+  const include = normalizeGlobList(watch?.include);
   return {
-    include: normalizeGlobList(watch?.include) ?? ['**'],
-    exclude: normalizeGlobList(watch?.exclude) ?? [],
+    // An empty / all-invalid `include` (e.g. `[]` or `""`) would make the
+    // watcher match nothing and silently never reload — fall back to `**`.
+    include: include.length > 0 ? include : ['**'],
+    exclude: normalizeGlobList(watch?.exclude),
   };
 }

--- a/src/local/file-watcher.ts
+++ b/src/local/file-watcher.ts
@@ -5,27 +5,24 @@ import { getLogger } from '../utils/logger.js';
  * Debounced file watcher used by `cdkl start-api --watch`
  * (PR 8c, issue #235).
  *
- * Wraps {@link chokidar.watch} with a 500ms debounce window so a single
- * `cdk synth` (which rewrites every file under `cdk.out/` over the
- * course of a few hundred ms) collapses to one `'reload'` event.
+ * Wraps {@link chokidar.watch} with a 500ms debounce window so a burst
+ * of file writes (e.g. an editor save plus its sidecar files, or a
+ * `tsc` emit) collapses to one `'reload'` event.
  *
- * The watch list is dynamic — at server boot we pass in `cdk.out/`
- * plus every routed Lambda's asset directory; on hot reload we
- * `update(...)` to add/remove paths in place rather than tearing the
- * watcher down + rebuilding (which would lose chokidar's internal
- * inode-stat cache and re-fire `'add'` events for every existing
- * file).
+ * `--watch` watches the CDK app's source tree (the directory holding
+ * `cdk.json`), so editing handler / construct source re-synths and
+ * hot-reloads. The synth output directory (`cdk.out/`) is excluded via
+ * {@link FileWatcherOptions.ignored} so the reload's own re-synth writes
+ * never re-trigger the watcher (no self-fire loop).
  *
  * Emits a single `'reload'` callback per debounce window. Does NOT
  * pass the changed file path — the orchestrator re-runs the full
- * synth → discover → diff sequence regardless of which file changed,
+ * synth -> discover -> diff sequence regardless of which file changed,
  * because `cdk synth` rewrites template + asset paths atomically and
  * the orchestrator can't reason about partial updates.
  */
 
 export interface FileWatcher {
-  /** Replace the watched-paths list. Accepts both add + remove. */
-  update(paths: readonly string[]): void;
   /** Stop watching everything. */
   close(): Promise<void>;
 }
@@ -40,10 +37,30 @@ export interface FileWatcherOptions {
   /**
    * Pass `true` to suppress the initial `'add'` event chokidar
    * normally fires for every existing file when the watcher starts up
-   * — without this, the first `cdk synth` watcher boot would fire
-   * `'reload'` immediately. Default `true`.
+   * — without this, watching the app source tree would fire `'reload'`
+   * immediately for every existing source file. Default `true`.
    */
   ignoreInitial?: boolean;
+  /**
+   * Predicate forwarded to chokidar's `ignored` option. Returning
+   * `true` prunes the path (and, for a directory, its whole subtree)
+   * from the watch. Used to exclude the synth output directory,
+   * `node_modules`, `.git`, and `cdk.json` `watch.exclude` globs when
+   * watching the app source tree. Decides on the path alone so it is
+   * safe on chokidar's pre-stat probe call (which omits `stats`).
+   */
+  ignored?: (path: string) => boolean;
+  /**
+   * Per-path gate checked on each raw chokidar event BEFORE the
+   * debounce timer is (re)armed. Returning `false` drops the event so
+   * it does not trigger a reload — used to honor `cdk.json`
+   * `watch.include` (only matching source files trigger a reload).
+   * Unlike {@link FileWatcherOptions.ignored} this never affects
+   * chokidar's directory traversal, so include filtering can't prune a
+   * directory the watcher must descend into. Default: every event
+   * fires.
+   */
+  shouldTrigger?: (path: string) => boolean;
 }
 
 const DEFAULT_DEBOUNCE_MS = 500;
@@ -71,6 +88,7 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcher {
     followSymlinks: false,
     // Don't crash on permission errors.
     ignorePermissionErrors: true,
+    ...(options.ignored && { ignored: options.ignored }),
   });
 
   let timer: NodeJS.Timeout | null = null;
@@ -98,15 +116,23 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcher {
     timer.unref?.();
   };
 
+  // Apply the optional include gate before arming the debounce. A
+  // dropped event leaves any already-armed timer in place — a prior
+  // qualifying event still reloads.
+  const onEvent = (path: string): void => {
+    if (options.shouldTrigger && !options.shouldTrigger(path)) return;
+    fire();
+  };
+
   // Subscribe to every file-changing event chokidar emits. We
   // intentionally don't subscribe to `'addDir'` / `'unlinkDir'` because
   // those fire for every nested directory chokidar discovers at
   // start-up; the surrounding `'add'` / `'unlink'` events are enough
   // for our purposes (a directory rename that doesn't change any file
   // contents shouldn't trigger a hot reload).
-  watcher.on('add', fire);
-  watcher.on('change', fire);
-  watcher.on('unlink', fire);
+  watcher.on('add', onEvent);
+  watcher.on('change', onEvent);
+  watcher.on('unlink', onEvent);
 
   watcher.on('error', (err) => {
     logger.debug(
@@ -114,20 +140,7 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcher {
     );
   });
 
-  let currentPaths = new Set(options.paths);
-
   return {
-    update: (paths: readonly string[]): void => {
-      if (closed) return;
-      const next = new Set(paths);
-      const toAdd: string[] = [];
-      const toRemove: string[] = [];
-      for (const p of next) if (!currentPaths.has(p)) toAdd.push(p);
-      for (const p of currentPaths) if (!next.has(p)) toRemove.push(p);
-      if (toAdd.length > 0) watcher.add(toAdd);
-      if (toRemove.length > 0) watcher.unwatch(toRemove);
-      currentPaths = next;
-    },
     close: async (): Promise<void> => {
       closed = true;
       if (timer) {

--- a/src/utils/glob-match.ts
+++ b/src/utils/glob-match.ts
@@ -1,0 +1,83 @@
+/**
+ * Minimal glob -> RegExp matcher for `cdk.json` `watch.include` /
+ * `watch.exclude` patterns (used by `cdkl start-api --watch` source-tree
+ * watching).
+ *
+ * chokidar v4 dropped built-in glob support, so the watcher translates
+ * the cdk.json watch globs into matcher predicates here. Supported
+ * syntax (the subset CDK's own `cdk watch` config uses):
+ *
+ *   - `**` — any number of path segments (incl. zero), crosses `/`.
+ *   - `*`  — any run of characters except `/`.
+ *   - `?`  — a single character except `/`.
+ *   - a pattern with no `/` matches its basename at any depth
+ *     (`node_modules` is treated as `** / node_modules`), mirroring
+ *     gitignore / cdk-watch behavior.
+ *
+ * Every pattern also matches the contents of a directory it names
+ * (`node_modules` matches `node_modules/x/y`) so a directory exclude
+ * prunes the whole subtree. Brace / extglob / character-class syntax is
+ * NOT supported — cdk.json watch configs don't use it.
+ *
+ * Paths are matched in POSIX form (forward slashes); the matcher
+ * normalizes Windows separators before testing.
+ */
+
+export type GlobMatcher = (relPath: string) => boolean;
+
+const REGEX_SPECIALS = '.+^${}()|[]\\';
+
+function globToRegExp(glob: string): RegExp | null {
+  let g = glob.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  if (g === '') return null;
+  // A pattern with no slash matches its basename at any depth.
+  if (!g.includes('/')) g = `**/${g}`;
+
+  let re = '';
+  for (let i = 0; i < g.length; i++) {
+    const c = g[i];
+    if (c === undefined) break;
+    if (c === '*') {
+      if (g[i + 1] === '*') {
+        i++;
+        if (g[i + 1] === '/') {
+          // `**/` — zero or more leading path segments.
+          i++;
+          re += '(?:.*/)?';
+        } else {
+          // `**` — anything, including `/`.
+          re += '.*';
+        }
+      } else {
+        // `*` — anything except `/`.
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else if (REGEX_SPECIALS.includes(c)) {
+      re += `\\${c}`;
+    } else {
+      re += c;
+    }
+  }
+  // Trailing `(?:/.*)?` lets a directory pattern also match its contents.
+  return new RegExp(`^${re}(?:/.*)?$`);
+}
+
+/**
+ * Compile a list of globs into a single matcher. The returned predicate
+ * is `true` when the (relative, POSIX-normalized) path matches ANY
+ * pattern. An empty or all-invalid pattern list yields a matcher that
+ * never matches.
+ */
+export function createGlobMatcher(patterns: readonly string[]): GlobMatcher {
+  const regexps: RegExp[] = [];
+  for (const p of patterns) {
+    const re = globToRegExp(p);
+    if (re) regexps.push(re);
+  }
+  return (relPath: string): boolean => {
+    const norm = relPath.replace(/\\/g, '/');
+    return regexps.some((re) => re.test(norm));
+  };
+}

--- a/src/utils/glob-match.ts
+++ b/src/utils/glob-match.ts
@@ -1,23 +1,32 @@
 /**
- * Minimal glob -> RegExp matcher for `cdk.json` `watch.include` /
+ * Minimal, linear-time glob matcher for `cdk.json` `watch.include` /
  * `watch.exclude` patterns (used by `cdkl start-api --watch` source-tree
  * watching).
  *
- * chokidar v4 dropped built-in glob support, so the watcher translates
- * the cdk.json watch globs into matcher predicates here. Supported
- * syntax (the subset CDK's own `cdk watch` config uses):
+ * chokidar v4 dropped built-in glob support, so the watcher matches the
+ * cdk.json watch globs here. Supported syntax (the subset CDK's own
+ * `cdk watch` config uses):
  *
- *   - `**` — any number of path segments (incl. zero), crosses `/`.
- *   - `*`  — any run of characters except `/`.
+ *   - `**` (a whole path segment) — matches zero or more path segments,
+ *     i.e. crosses `/`.
+ *   - `*`  — any run of characters except `/` (within one segment).
  *   - `?`  — a single character except `/`.
  *   - a pattern with no `/` matches its basename at any depth
- *     (`node_modules` is treated as `** / node_modules`), mirroring
+ *     (`node_modules` is treated as `**` + `/node_modules`), mirroring
  *     gitignore / cdk-watch behavior.
  *
- * Every pattern also matches the contents of a directory it names
+ * A pattern also matches the CONTENTS of a directory it names
  * (`node_modules` matches `node_modules/x/y`) so a directory exclude
  * prunes the whole subtree. Brace / extglob / character-class syntax is
  * NOT supported — cdk.json watch configs don't use it.
+ *
+ * Matching is implemented with two classic two-pointer wildcard passes
+ * (one over path segments for `**`, one within a segment for `*` / `?`)
+ * rather than a translated `RegExp`. This is deliberate: a `RegExp`
+ * built from many `*` (each `[^/]*`) backtracks catastrophically on a
+ * non-matching input, and these matchers run on EVERY watched file
+ * event with user-supplied patterns. The two-pointer form is O(n*m) and
+ * cannot blow up.
  *
  * Paths are matched in POSIX form (forward slashes); the matcher
  * normalizes Windows separators before testing.
@@ -25,43 +34,84 @@
 
 export type GlobMatcher = (relPath: string) => boolean;
 
-const REGEX_SPECIALS = '.+^${}()|[]\\';
-
-function globToRegExp(glob: string): RegExp | null {
-  let g = glob.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+/**
+ * Normalize a glob and split it into path-segment tokens. Returns
+ * `null` for an empty pattern (callers skip it). A slash-free pattern is
+ * prefixed with a `**` token so it matches its basename at any depth.
+ */
+function compilePattern(glob: string): string[] | null {
+  const g = glob.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
   if (g === '') return null;
-  // A pattern with no slash matches its basename at any depth.
-  if (!g.includes('/')) g = `**/${g}`;
+  if (!g.includes('/')) return ['**', g];
+  return g.split('/');
+}
 
-  let re = '';
-  for (let i = 0; i < g.length; i++) {
-    const c = g[i];
-    if (c === undefined) break;
-    if (c === '*') {
-      if (g[i + 1] === '*') {
-        i++;
-        if (g[i + 1] === '/') {
-          // `**/` — zero or more leading path segments.
-          i++;
-          re += '(?:.*/)?';
-        } else {
-          // `**` — anything, including `/`.
-          re += '.*';
-        }
-      } else {
-        // `*` — anything except `/`.
-        re += '[^/]*';
-      }
-    } else if (c === '?') {
-      re += '[^/]';
-    } else if (REGEX_SPECIALS.includes(c)) {
-      re += `\\${c}`;
+/**
+ * Linear wildcard match for ONE path segment (no `/`). `*` matches any
+ * run of characters, `?` matches exactly one. Classic two-pointer
+ * algorithm with single backtrack pointer — O(len(pat) * len(str)),
+ * never exponential.
+ */
+function matchSegment(pat: string, str: string): boolean {
+  let s = 0;
+  let p = 0;
+  let starP = -1;
+  let starS = 0;
+  while (s < str.length) {
+    const pc = pat[p];
+    if (p < pat.length && (pc === str[s] || pc === '?')) {
+      s++;
+      p++;
+    } else if (pc === '*') {
+      starP = p;
+      starS = s;
+      p++;
+    } else if (starP !== -1) {
+      p = starP + 1;
+      starS++;
+      s = starS;
     } else {
-      re += c;
+      return false;
     }
   }
-  // Trailing `(?:/.*)?` lets a directory pattern also match its contents.
-  return new RegExp(`^${re}(?:/.*)?$`);
+  while (pat[p] === '*') p++;
+  return p === pat.length;
+}
+
+/**
+ * Match a compiled pattern's segment tokens against a path's segments. A
+ * `**` token matches zero or more path segments; every other token
+ * matches exactly one segment via {@link matchSegment}. The pattern
+ * matches when it consumes a PREFIX of the path (the contents rule), so
+ * a directory pattern also matches everything beneath it. Single
+ * backtrack pointer over `**` — O(patSegs * pathSegs), never
+ * exponential.
+ */
+function matchSegments(pat: readonly string[], path: readonly string[]): boolean {
+  let pi = 0;
+  let si = 0;
+  let starPi = -1;
+  let starSi = 0;
+  while (si < path.length) {
+    if (pi === pat.length) return true; // pattern consumed -> contents match
+    if (pat[pi] === '**') {
+      starPi = pi;
+      starSi = si;
+      pi++;
+    } else if (matchSegment(pat[pi] as string, path[si] as string)) {
+      pi++;
+      si++;
+    } else if (starPi !== -1) {
+      pi = starPi + 1;
+      starSi++;
+      si = starSi;
+    } else {
+      return false;
+    }
+  }
+  if (pi === pat.length) return true;
+  while (pi < pat.length && pat[pi] === '**') pi++;
+  return pi === pat.length;
 }
 
 /**
@@ -71,13 +121,13 @@ function globToRegExp(glob: string): RegExp | null {
  * never matches.
  */
 export function createGlobMatcher(patterns: readonly string[]): GlobMatcher {
-  const regexps: RegExp[] = [];
+  const compiled: string[][] = [];
   for (const p of patterns) {
-    const re = globToRegExp(p);
-    if (re) regexps.push(re);
+    const segs = compilePattern(p);
+    if (segs) compiled.push(segs);
   }
   return (relPath: string): boolean => {
-    const norm = relPath.replace(/\\/g, '/');
-    return regexps.some((re) => re.test(norm));
+    const pathSegs = relPath.replace(/\\/g, '/').split('/');
+    return compiled.some((pat) => matchSegments(pat, pathSegs));
   };
 }

--- a/tests/integration/local-start-api-watch/.gitignore
+++ b/tests/integration/local-start-api-watch/.gitignore
@@ -1,0 +1,3 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is tracked.
+!lambda-ping/*.js

--- a/tests/integration/local-start-api-watch/.scenarios.json
+++ b/tests/integration/local-start-api-watch/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-start-api-watch"
+  ]
+}

--- a/tests/integration/local-start-api-watch/bin/app.ts
+++ b/tests/integration/local-start-api-watch/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartApiWatchStack } from '../lib/watch-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartApiWatchStack(app, 'CdkLocalStartApiWatchFixture', {
+  description: 'Fixture stack for cdkl start-api --watch integ test',
+});

--- a/tests/integration/local-start-api-watch/cdk.json
+++ b/tests/integration/local-start-api-watch/cdk.json
@@ -1,0 +1,16 @@
+{
+  "app": "node bin/app.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "**/*.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "node_modules",
+      "dist"
+    ]
+  }
+}

--- a/tests/integration/local-start-api-watch/lambda-ping/index.js
+++ b/tests/integration/local-start-api-watch/lambda-ping/index.js
@@ -1,0 +1,13 @@
+// Ping handler for the local-start-api-watch integ fixture.
+//
+// verify.sh rewrites this whole file mid-run to bump the `version`
+// marker (v1 -> v2) and asserts the served response changes after a
+// single hot reload. Keep the handler trivial so the asset re-stages
+// quickly on re-synth.
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ functionUrl: true, version: 'v1' }),
+  };
+};

--- a/tests/integration/local-start-api-watch/lib/watch-stack.ts
+++ b/tests/integration/local-start-api-watch/lib/watch-stack.ts
@@ -1,0 +1,35 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture stack for `cdkl start-api --watch` integ test.
+ *
+ * No AWS deploy required — the integ exercises the synthesized cdk.out
+ * locally against Docker + RIE.
+ *
+ * One Lambda (`PingHandler`) behind a NONE-auth Function URL. verify.sh
+ * boots `cdkl start-api --watch`, asserts the handler's `version`
+ * marker, edits `lambda-ping/index.js` to bump the marker, and asserts
+ * the served response changes after a single hot reload — proving the
+ * watcher re-synths the CDK app source and swaps the container without a
+ * restart, and that the reload's own `cdk.out/` re-synth writes do NOT
+ * re-trigger the watcher (no loop).
+ */
+export class LocalStartApiWatchStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const pingHandler = new lambda.Function(this, 'PingHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-ping')),
+      timeout: cdk.Duration.seconds(10),
+    });
+    pingHandler.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE });
+  }
+}

--- a/tests/integration/local-start-api-watch/package.json
+++ b/tests/integration/local-start-api-watch/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-start-api-watch",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-api --watch",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.4.0"
+}

--- a/tests/integration/local-start-api-watch/pnpm-lock.yaml
+++ b/tests/integration/local-start-api-watch/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.169.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+
+  '@aws-cdk/cloud-assembly-schema@53.27.0':
+    resolution: {integrity: sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.27.0': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.27.0
+      constructs: 10.6.0
+
+  constructs@10.6.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/tests/integration/local-start-api-watch/tsconfig.json
+++ b/tests/integration/local-start-api-watch/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-api-watch/verify.sh
+++ b/tests/integration/local-start-api-watch/verify.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-api-watch integ test
+#
+# Exercises `cdkl start-api --watch` end-to-end against Docker + the AWS
+# Lambda Node.js base image (which bundles RIE). Deploys nothing.
+#
+# What it proves:
+#   1. Editing the CDK app's Lambda SOURCE (not cdk.out) re-synths and
+#      hot-reloads — the served response changes from v1 to v2 without a
+#      server restart.
+#   2. Loop-safety: the reload's own re-synth writes into cdk.out/ do NOT
+#      re-trigger the watcher. Exactly ONE reload fires per source edit.
+#   3. cdk.json `watch.exclude` is honored: touching an excluded path
+#      (a *.md file) triggers no reload.
+#
+# Run via `/run-integ local-start-api-watch` (recommended) or directly:
+#
+#     bash tests/integration/local-start-api-watch/verify.sh
+#
+# Requires Docker.
+#
+# Robust cleanup: SIGTERM -> 120s grace -> SIGKILL on the server, plus a
+# defense-in-depth `docker ps --filter name=cdkl-` sweep, plus restoring
+# the Lambda handler source the test mutates so the git tree stays clean.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+PORT=3939
+
+HANDLER="lambda-ping/index.js"
+HANDLER_BACKUP="$(mktemp)"
+cp "${HANDLER}" "${HANDLER_BACKUP}"
+PROBE_EXCLUDED="probe-excluded.md"
+
+LOG_FILE="$(mktemp)"
+SERVER_PID=""
+
+term_server() {
+  local pid="$1" label="$2"
+  if [[ -n "${pid:-}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    echo "==> Sending SIGTERM to ${label} (pid ${pid})"
+    kill -TERM "${pid}" 2>/dev/null || true
+    for _ in $(seq 1 120); do
+      kill -0 "${pid}" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "${pid}" 2>/dev/null; then
+      echo "==> ${label} did not exit within 120s; SIGKILL"
+      kill -KILL "${pid}" 2>/dev/null || true
+    fi
+  fi
+}
+
+restore_handler() {
+  # Put the committed v1 source back so the working tree is unchanged
+  # whether the test passed, failed, or was interrupted mid-edit.
+  if [[ -f "${HANDLER_BACKUP}" ]]; then
+    cp "${HANDLER_BACKUP}" "${HANDLER}"
+    rm -f "${HANDLER_BACKUP}"
+  fi
+  rm -f "${PROBE_EXCLUDED}"
+}
+
+cleanup() {
+  term_server "${SERVER_PID:-}" "server"
+  restore_handler
+  ORPHANS=$(docker ps --filter "name=cdkl-" --format "{{.ID}}" 2>/dev/null || true)
+  if [[ -n "${ORPHANS}" ]]; then
+    echo "==> Cleaning up orphan containers"
+    echo "${ORPHANS}" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  fi
+  rm -f "${LOG_FILE}"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling ${IMAGE} (one-time, ~600MB)"
+docker pull "${IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+# 127.0.0.1 (not host.docker.internal) — matches the other start-api
+# integs so the test works on any docker daemon, not just Docker Desktop.
+CONTAINER_HOST="127.0.0.1"
+
+reload_count() {
+  local n
+  n=$(grep -c "Detected source change" "${LOG_FILE}" 2>/dev/null) || n=0
+  echo "${n}"
+}
+
+echo "==> Starting cdkl start-api --watch on port ${PORT}"
+${CDKL} start-api \
+  --watch \
+  --port "${PORT}" \
+  --container-host "${CONTAINER_HOST}" \
+  --no-pull \
+  >"${LOG_FILE}" 2>&1 &
+SERVER_PID=$!
+
+echo "==> Waiting for the server to come up"
+READY=0
+for _ in $(seq 1 60); do
+  count=$(grep -c "Server listening" "${LOG_FILE}" 2>/dev/null) || count=0
+  if [[ "${count}" -ge 1 ]]; then
+    READY=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ "${READY}" -eq 0 ]]; then
+  echo "FAIL: server did not come up within 30s. Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+echo "==> Server log preview:"
+head -30 "${LOG_FILE}" | sed 's/^/    /'
+
+# The boot line must name source-tree watching (not cdk.out watching).
+if ! grep -q "for source changes" "${LOG_FILE}"; then
+  echo "FAIL: startup did not announce source-tree watching. Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+URL="http://127.0.0.1:${PORT}/"
+
+# Poll a URL until the response body contains a needle, or fail. Cold
+# RIE container boot is slow (~3-5s) on the first request, and after a
+# reload the swapped-in container is cold again.
+curl_until() {
+  local label="$1" url="$2" needle="$3" tries="$4"
+  local response=""
+  for _ in $(seq 1 "${tries}"); do
+    if response=$(curl -sf "${url}" 2>&1); then
+      if echo "${response}" | grep -q "${needle}"; then
+        echo "    [${label}] OK"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  echo "FAIL: ${label} never matched '${needle}'. Last response: ${response}"
+  cat "${LOG_FILE}"
+  return 1
+}
+
+echo "==> Asserting the handler serves v1 before any edit"
+curl_until "GET / (v1)" "${URL}" '"version":"v1"' 15
+
+RELOADS_BEFORE_EDIT="$(reload_count)"
+echo "==> Reload count before edit: ${RELOADS_BEFORE_EDIT} (expect 0)"
+if [[ "${RELOADS_BEFORE_EDIT}" != "0" ]]; then
+  echo "FAIL: a reload fired before any source edit. Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+echo "==> Editing Lambda source (v1 -> v2) to trigger a hot reload"
+cat >"${HANDLER}" <<'EOF'
+// Ping handler for the local-start-api-watch integ fixture (mutated to v2).
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ functionUrl: true, version: 'v2' }),
+  };
+};
+EOF
+
+echo "==> Asserting the watcher detected the source change"
+DETECTED=0
+for _ in $(seq 1 60); do
+  if [[ "$(reload_count)" -ge 1 ]]; then
+    DETECTED=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ "${DETECTED}" -eq 0 ]]; then
+  echo "FAIL: source edit did not trigger a reload within 30s. Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    [source change detected] OK"
+
+echo "==> Asserting the handler now serves v2 (re-synth + container swap)"
+curl_until "GET / (v2)" "${URL}" '"version":"v2"' 40
+
+# Loop-safety: the reload re-synths INTO cdk.out/, which is excluded from
+# the watch. Those writes must NOT re-trigger the watcher. Give any
+# runaway loop a few seconds to manifest, then assert exactly one reload.
+echo "==> Asserting loop-safety (re-synth writes do not re-trigger the watcher)"
+sleep 4
+RELOADS_AFTER_EDIT="$(reload_count)"
+echo "    reload count after one edit: ${RELOADS_AFTER_EDIT} (expect 1)"
+if [[ "${RELOADS_AFTER_EDIT}" != "1" ]]; then
+  echo "FAIL: expected exactly 1 reload, got ${RELOADS_AFTER_EDIT} (cdk.out writes likely re-triggered the watcher). Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    [loop-safe: exactly 1 reload] OK"
+
+# Excluded path: cdk.json watch.exclude lists *.md. Writing one must NOT
+# trigger a reload.
+echo "==> Asserting watch.exclude is honored (*.md write triggers no reload)"
+echo "excluded change at $(date)" >"${PROBE_EXCLUDED}"
+sleep 3
+RELOADS_AFTER_EXCLUDED="$(reload_count)"
+echo "    reload count after excluded write: ${RELOADS_AFTER_EXCLUDED} (expect 1)"
+if [[ "${RELOADS_AFTER_EXCLUDED}" != "1" ]]; then
+  echo "FAIL: an excluded (*.md) write triggered a reload. Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+rm -f "${PROBE_EXCLUDED}"
+echo "    [watch.exclude honored] OK"
+
+echo ""
+echo "==> All local-start-api-watch smoke tests passed"

--- a/tests/unit/cli/config-loader.test.ts
+++ b/tests/unit/cli/config-loader.test.ts
@@ -107,6 +107,16 @@ describe('resolveWatchConfig', () => {
     expect(resolveWatchConfig()).toEqual({ include: ['a', 'b'], exclude: ['x'] });
   });
 
+  it('falls back to include `**` when include is empty or all-invalid', () => {
+    writeFileSync('cdk.json', JSON.stringify({ watch: { include: [], exclude: ['x'] } }));
+    expect(resolveWatchConfig()).toEqual({ include: ['**'], exclude: ['x'] });
+  });
+
+  it('falls back to include `**` when include is an empty string', () => {
+    writeFileSync('cdk.json', JSON.stringify({ watch: { include: '' } }));
+    expect(resolveWatchConfig()).toEqual({ include: ['**'], exclude: [] });
+  });
+
   it('falls back to defaults on invalid JSON (does not throw)', () => {
     writeFileSync('cdk.json', '{invalid');
     expect(resolveWatchConfig()).toEqual({ include: ['**'], exclude: [] });

--- a/tests/unit/cli/config-loader.test.ts
+++ b/tests/unit/cli/config-loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { resolveApp } from '../../../src/cli/config-loader.js';
+import { resolveApp, resolveWatchConfig } from '../../../src/cli/config-loader.js';
 
 describe('resolveApp', () => {
   let tmpDir: string;
@@ -56,5 +56,59 @@ describe('resolveApp', () => {
   it('returns undefined when cdk.json contains invalid JSON (logs a warning, does not throw)', () => {
     writeFileSync('cdk.json', '{invalid');
     expect(resolveApp(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveWatchConfig', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cdk-local-watch-config-'));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('defaults to include `**` and empty exclude when no cdk.json', () => {
+    expect(resolveWatchConfig()).toEqual({ include: ['**'], exclude: [] });
+  });
+
+  it('defaults when cdk.json has no watch block', () => {
+    writeFileSync('cdk.json', JSON.stringify({ app: 'node bin/app.js' }));
+    expect(resolveWatchConfig()).toEqual({ include: ['**'], exclude: [] });
+  });
+
+  it('reads include / exclude arrays from the watch block', () => {
+    writeFileSync(
+      'cdk.json',
+      JSON.stringify({ watch: { include: ['src/**'], exclude: ['**/*.d.ts', 'node_modules'] } })
+    );
+    expect(resolveWatchConfig()).toEqual({
+      include: ['src/**'],
+      exclude: ['**/*.d.ts', 'node_modules'],
+    });
+  });
+
+  it('normalizes a string include / exclude to a single-element array', () => {
+    writeFileSync('cdk.json', JSON.stringify({ watch: { include: 'lib/**', exclude: '*.md' } }));
+    expect(resolveWatchConfig()).toEqual({ include: ['lib/**'], exclude: ['*.md'] });
+  });
+
+  it('drops non-string entries from include / exclude', () => {
+    writeFileSync(
+      'cdk.json',
+      JSON.stringify({ watch: { include: ['a', 1, null, 'b'], exclude: [true, 'x'] } })
+    );
+    expect(resolveWatchConfig()).toEqual({ include: ['a', 'b'], exclude: ['x'] });
+  });
+
+  it('falls back to defaults on invalid JSON (does not throw)', () => {
+    writeFileSync('cdk.json', '{invalid');
+    expect(resolveWatchConfig()).toEqual({ include: ['**'], exclude: [] });
   });
 });

--- a/tests/unit/cli/local-start-api-watch-predicates.test.ts
+++ b/tests/unit/cli/local-start-api-watch-predicates.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vite-plus/test';
+import * as path from 'node:path';
+import { createWatchPredicates } from '../../../src/cli/commands/local-start-api.js';
+import type { CdkWatchConfig } from '../../../src/cli/config-loader.js';
+
+const ROOT = path.resolve('/proj');
+const abs = (...parts: string[]): string => path.join(ROOT, ...parts);
+const cfg = (over: Partial<CdkWatchConfig> = {}): CdkWatchConfig => ({
+  include: ['**'],
+  exclude: [],
+  ...over,
+});
+
+describe('createWatchPredicates', () => {
+  it('always excludes the output dir, node_modules, and .git', () => {
+    const { ignored, excludePatterns } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: 'cdk.out',
+      watchConfig: cfg(),
+    });
+    expect(excludePatterns).toEqual(['cdk.out', 'node_modules', '.git']);
+    expect(ignored(abs('cdk.out', 'asset.123', 'index.js'))).toBe(true);
+    expect(ignored(abs('node_modules', 'foo', 'index.js'))).toBe(true);
+    expect(ignored(abs('.git', 'HEAD'))).toBe(true);
+    expect(ignored(abs('src', 'handler.ts'))).toBe(false);
+  });
+
+  it('never ignores the watch root itself, and ignores paths outside it', () => {
+    const { ignored, shouldTrigger } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: 'cdk.out',
+      watchConfig: cfg(),
+    });
+    expect(ignored(ROOT)).toBe(false);
+    expect(ignored(path.resolve('/elsewhere', 'x.ts'))).toBe(true);
+    expect(shouldTrigger(ROOT)).toBe(false);
+    expect(shouldTrigger(path.resolve('/elsewhere', 'x.ts'))).toBe(false);
+  });
+
+  it('shouldTrigger fires for an included source file and not for an excluded one', () => {
+    const { shouldTrigger } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: 'cdk.out',
+      watchConfig: cfg({ exclude: ['*.md'] }),
+    });
+    expect(shouldTrigger(abs('src', 'handler.ts'))).toBe(true);
+    expect(shouldTrigger(abs('README.md'))).toBe(false);
+    expect(shouldTrigger(abs('cdk.out', 'tree.json'))).toBe(false);
+  });
+
+  it('honors a narrowed watch.include (non-included files do not trigger but are not pruned)', () => {
+    const { ignored, shouldTrigger } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: 'cdk.out',
+      watchConfig: cfg({ include: ['src/**'] }),
+    });
+    expect(shouldTrigger(abs('src', 'a.ts'))).toBe(true);
+    expect(shouldTrigger(abs('lib', 'a.ts'))).toBe(false);
+    // include only gates the reload, never chokidar traversal — `lib/`
+    // must still be descended (it is not excluded).
+    expect(ignored(abs('lib', 'a.ts'))).toBe(false);
+  });
+
+  it('exclude wins over include (exclude checked first in shouldTrigger)', () => {
+    const { shouldTrigger } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: 'cdk.out',
+      watchConfig: cfg({ include: ['**'], exclude: ['secrets/**'] }),
+    });
+    expect(shouldTrigger(abs('secrets', 'key.ts'))).toBe(false);
+    expect(shouldTrigger(abs('app', 'key.ts'))).toBe(true);
+  });
+
+  it('handles an absolute --output that lives under the watch root', () => {
+    const { ignored, excludePatterns } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: abs('cdk.out'),
+      watchConfig: cfg(),
+    });
+    expect(excludePatterns).toEqual(['cdk.out', 'node_modules', '.git']);
+    expect(ignored(abs('cdk.out', 'x'))).toBe(true);
+  });
+
+  it('drops the output exclude when --output equals the watch root', () => {
+    const { excludePatterns } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: '.',
+      watchConfig: cfg(),
+    });
+    expect(excludePatterns).toEqual(['node_modules', '.git']);
+  });
+
+  it('drops the output exclude when --output is outside the watch root (still loop-safe)', () => {
+    const { ignored, excludePatterns } = createWatchPredicates({
+      watchRoot: ROOT,
+      output: path.join('..', 'shared-out'),
+      watchConfig: cfg(),
+    });
+    // Not added as a glob (it is not under the root)...
+    expect(excludePatterns).toEqual(['node_modules', '.git']);
+    // ...but a watcher rooted at ROOT never reaches it, and the `..`
+    // guard ignores it anyway, so re-synth writes there can't loop.
+    expect(ignored(path.resolve('/shared-out', 'tree.json'))).toBe(true);
+  });
+});

--- a/tests/unit/local/file-watcher.test.ts
+++ b/tests/unit/local/file-watcher.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+
+const { watchMock } = vi.hoisted(() => ({ watchMock: vi.fn() }));
+
+vi.mock('chokidar', () => ({ watch: watchMock }));
+
+import { createFileWatcher } from '../../../src/local/file-watcher.js';
+
+interface FakeWatcher {
+  capturedPaths: unknown;
+  capturedOptions: Record<string, unknown>;
+  on(event: string, cb: (p: string) => void): FakeWatcher;
+  add: ReturnType<typeof vi.fn>;
+  unwatch: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  emit(event: string, p: string): void;
+}
+
+function makeFakeWatcher(): FakeWatcher {
+  const handlers: Record<string, (p: string) => void> = {};
+  const fake: FakeWatcher = {
+    capturedPaths: undefined,
+    capturedOptions: {},
+    on(event, cb) {
+      handlers[event] = cb;
+      return fake;
+    },
+    add: vi.fn(),
+    unwatch: vi.fn(),
+    close: vi.fn(async () => undefined),
+    emit(event, p) {
+      handlers[event]?.(p);
+    },
+  };
+  return fake;
+}
+
+describe('createFileWatcher', () => {
+  let fake: FakeWatcher;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fake = makeFakeWatcher();
+    watchMock.mockReset();
+    watchMock.mockImplementation((paths: unknown, options: Record<string, unknown>) => {
+      fake.capturedPaths = paths;
+      fake.capturedOptions = options;
+      return fake;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('forwards the watched paths and the ignored predicate to chokidar', () => {
+    const ignored = (p: string): boolean => p.endsWith('/cdk.out');
+    createFileWatcher({ paths: ['/root'], onChange: () => {}, ignored });
+    expect(fake.capturedPaths).toEqual(['/root']);
+    expect(fake.capturedOptions['ignored']).toBe(ignored);
+    expect(fake.capturedOptions['ignoreInitial']).toBe(true);
+  });
+
+  it('omits the ignored option when not provided', () => {
+    createFileWatcher({ paths: ['/root'], onChange: () => {} });
+    expect('ignored' in fake.capturedOptions).toBe(false);
+  });
+
+  it('fires onChange (debounced) on a change event', () => {
+    const onChange = vi.fn();
+    createFileWatcher({ paths: ['/root'], onChange, debounceMs: 10 });
+    fake.emit('change', '/root/src/handler.ts');
+    expect(onChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(10);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses a burst of events into a single onChange', () => {
+    const onChange = vi.fn();
+    createFileWatcher({ paths: ['/root'], onChange, debounceMs: 10 });
+    fake.emit('add', '/root/a.ts');
+    fake.emit('change', '/root/b.ts');
+    fake.emit('unlink', '/root/c.ts');
+    vi.advanceTimersByTime(10);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops events rejected by shouldTrigger', () => {
+    const onChange = vi.fn();
+    createFileWatcher({
+      paths: ['/root'],
+      onChange,
+      debounceMs: 10,
+      shouldTrigger: (p) => p.endsWith('.ts'),
+    });
+    fake.emit('change', '/root/README.md');
+    vi.advanceTimersByTime(10);
+    expect(onChange).not.toHaveBeenCalled();
+
+    fake.emit('change', '/root/src/handler.ts');
+    vi.advanceTimersByTime(10);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onChange after close(), even with a timer armed', async () => {
+    const onChange = vi.fn();
+    const watcher = createFileWatcher({ paths: ['/root'], onChange, debounceMs: 10 });
+    fake.emit('change', '/root/a.ts');
+    await watcher.close();
+    vi.advanceTimersByTime(10);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(fake.close).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/glob-match.test.ts
+++ b/tests/unit/utils/glob-match.test.ts
@@ -52,8 +52,9 @@ describe('createGlobMatcher', () => {
     expect(m('a.ts')).toBe(false);
   });
 
-  it('honors `/**` (everything under a directory)', () => {
+  it('honors `/**` (everything under a directory, including the dir itself)', () => {
     const m = createGlobMatcher(['src/**']);
+    expect(m('src')).toBe(true);
     expect(m('src/a')).toBe(true);
     expect(m('src/a/b/c')).toBe(true);
     expect(m('srcfoo/a')).toBe(false);
@@ -78,5 +79,23 @@ describe('createGlobMatcher', () => {
     expect(m('cdk.json')).toBe(true);
     expect(m('cdk.context.json')).toBe(true);
     expect(m('index.ts')).toBe(false);
+  });
+
+  it('handles multiple `**` tokens', () => {
+    const m = createGlobMatcher(['a/**/b/**/c.ts']);
+    expect(m('a/b/c.ts')).toBe(true);
+    expect(m('a/x/y/b/z/c.ts')).toBe(true);
+    expect(m('a/b/c.js')).toBe(false);
+  });
+
+  it('does not catastrophically backtrack on a star-heavy pattern (ReDoS guard)', () => {
+    // Many single `*` separated by literals is the textbook
+    // catastrophic-backtracking shape for a naive RegExp translation
+    // (each `*` -> `[^/]*`). The two-pointer matcher must stay linear.
+    const m = createGlobMatcher(['*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*.bak']);
+    const evil = `${'-'.repeat(80)}.txt`; // never matches (no .bak)
+    const start = Date.now();
+    expect(m(evil)).toBe(false);
+    expect(Date.now() - start).toBeLessThan(1000);
   });
 });

--- a/tests/unit/utils/glob-match.test.ts
+++ b/tests/unit/utils/glob-match.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createGlobMatcher } from '../../../src/utils/glob-match.js';
+
+describe('createGlobMatcher', () => {
+  it('matches everything for `**`', () => {
+    const m = createGlobMatcher(['**']);
+    expect(m('a')).toBe(true);
+    expect(m('a/b/c')).toBe(true);
+    expect(m('')).toBe(true);
+  });
+
+  it('never matches for an empty pattern list', () => {
+    const m = createGlobMatcher([]);
+    expect(m('a')).toBe(false);
+    expect(m('a/b')).toBe(false);
+  });
+
+  it('treats a slash-free pattern as a basename match at any depth', () => {
+    const m = createGlobMatcher(['node_modules']);
+    expect(m('node_modules')).toBe(true);
+    expect(m('node_modules/x/y')).toBe(true);
+    expect(m('a/node_modules')).toBe(true);
+    expect(m('a/b/node_modules/c')).toBe(true);
+  });
+
+  it('does not match a partial segment (loop-safety for prefixed names)', () => {
+    const m = createGlobMatcher(['node_modules']);
+    expect(m('node_modules_foo')).toBe(false);
+    expect(m('a/node_modules_foo/b')).toBe(false);
+  });
+
+  it('matches a directory pattern AND its contents', () => {
+    const m = createGlobMatcher(['cdk.out']);
+    expect(m('cdk.out')).toBe(true);
+    expect(m('cdk.out/asset.123/index.js')).toBe(true);
+    // The dot is a literal, not a regex wildcard.
+    expect(m('cdkXout')).toBe(false);
+  });
+
+  it('honors `*` (single segment) without crossing slashes', () => {
+    const m = createGlobMatcher(['*.test.ts']);
+    expect(m('foo.test.ts')).toBe(true);
+    expect(m('a/b/foo.test.ts')).toBe(true);
+    expect(m('foo.ts')).toBe(false);
+    expect(m('footest.ts')).toBe(false);
+  });
+
+  it('honors `**/` (zero or more leading segments)', () => {
+    const m = createGlobMatcher(['**/*.d.ts']);
+    expect(m('a.d.ts')).toBe(true);
+    expect(m('src/types/a.d.ts')).toBe(true);
+    expect(m('a.ts')).toBe(false);
+  });
+
+  it('honors `/**` (everything under a directory)', () => {
+    const m = createGlobMatcher(['src/**']);
+    expect(m('src/a')).toBe(true);
+    expect(m('src/a/b/c')).toBe(true);
+    expect(m('srcfoo/a')).toBe(false);
+  });
+
+  it('honors `?` (single character, not a slash)', () => {
+    const m = createGlobMatcher(['a?c']);
+    expect(m('abc')).toBe(true);
+    expect(m('ac')).toBe(false);
+    expect(m('a/c')).toBe(false);
+  });
+
+  it('normalizes Windows separators in both pattern and path', () => {
+    const m = createGlobMatcher(['src\\lambda']);
+    expect(m('src/lambda')).toBe(true);
+    expect(m('src\\lambda')).toBe(true);
+  });
+
+  it('matches if ANY pattern in the list matches', () => {
+    const m = createGlobMatcher(['*.md', 'cdk*.json']);
+    expect(m('README.md')).toBe(true);
+    expect(m('cdk.json')).toBe(true);
+    expect(m('cdk.context.json')).toBe(true);
+    expect(m('index.ts')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl start-api --watch` previously watched `cdk.out/` and the staged Lambda asset directories, so editing your CDK app's source never triggered a reload until something else re-synthed. It now watches the app's **source tree** (the directory holding `cdk.json`) and re-synths + hot-reloads on a source change — no separate `cdk watch` / `cdk synth` process needed.

- Honors `cdk.json` `watch.include` / `watch.exclude` globs (mirrors `cdk watch`). Default include `**`; a missing `watch` block is not an error; an empty / invalid `include` falls back to `**`.
- Always excludes the synth output dir (`cdk.out`), `node_modules`, and `.git`. Excluding the output dir is load-bearing for loop-safety: each reload re-synths into it, so watching it would re-trigger the watcher forever.
- Glob matching uses a linear two-pointer matcher. chokidar v4 dropped glob support, and a naive glob to `RegExp` translation backtracks catastrophically on user-supplied globs (runs on every file event).
- New `createGlobMatcher`, `resolveWatchConfig`, `createWatchPredicates`; `FileWatcher` gains `ignored` / `shouldTrigger`. Removed the now-dead asset-path tracking and `FileWatcher.update`.

## Test plan

- [x] `vp run verify` — typecheck + lint + format + 473 unit tests + build
- [x] Unit: `glob-match` (incl. a ReDoS guard), `resolveWatchConfig`, `file-watcher` (chokidar mocked), `createWatchPredicates` (output-dir absolute / equal-to-root / outside-root edge cases)
- [x] Integration (Docker): `tests/integration/local-start-api-watch` — source edit drives a v1 to v2 reload, exactly-one-reload loop-safety, and `watch.exclude` honored. Run via `/run-integ local-start-api-watch`; 0 orphan containers / networks.
- [x] 3-axis review (spec / code / test). A BLOCKER (glob ReDoS), a test-coverage gap, and minor findings were fixed in the second commit; a follow-up re-review confirmed them resolved.

## Notes

No new hooks / skills warranted by the retrospective. All reviewer-flagged nits were addressed in this PR (0 unhandled).
