### PR TITLE
fix(from-cfn-stack): resolve ECR image Fn::Join via synthesized repo Arn

### DIFF
--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -346,6 +346,26 @@ function resolveImageIntrinsicAny(
     if (resources[logicalId]?.Type !== 'AWS::ECR::Repository') return undefined;
     const cached = context?.stateResources?.[logicalId]?.attributes?.[attr];
     if (typeof cached === 'string' && cached.length > 0) return cached;
+    // No recorded attribute. `--from-cfn-stack` resolves state from
+    // `ListStackResources`, which returns physical IDs only (never the
+    // `Arn` / `RepositoryUri` attributes), so the canonical
+    // `ContainerImage.fromEcrRepository` join — which extracts the
+    // account + region by `Fn::Select`-ing over `Fn::Split(":", <Arn>)` —
+    // would otherwise fail here. A same-stack ECR repository's Arn /
+    // RepositoryUri are deterministic, so synthesize them from the repo's
+    // physical name (the `ListStackResources` physical ID) plus the
+    // already-resolved account / region / partition / URL suffix (the
+    // stack's own, which is where a same-stack repo lives).
+    const physicalId = context?.stateResources?.[logicalId]?.physicalId;
+    const p = context?.pseudoParameters;
+    if (physicalId && p?.region && p.accountId) {
+      if (attr === 'Arn' && p.partition) {
+        return `arn:${p.partition}:ecr:${p.region}:${p.accountId}:repository/${physicalId}`;
+      }
+      if (attr === 'RepositoryUri' && p.urlSuffix) {
+        return `${p.accountId}.dkr.ecr.${p.region}.${p.urlSuffix}/${physicalId}`;
+      }
+    }
     return undefined;
   }
 

--- a/tests/unit/local/intrinsic-image-ecr-getatt.test.ts
+++ b/tests/unit/local/intrinsic-image-ecr-getatt.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  tryResolveImageFnJoin,
+  type ImageResolutionContext,
+} from '../../../src/local/intrinsic-image.js';
+import type { TemplateResource } from '../../../src/types/resource.js';
+import type { ResourceState } from '../../../src/types/state.js';
+
+const REPO = 'BackendRepoABC123';
+
+// The canonical CDK 2.x `ContainerImage.fromEcrRepository(repo, 'latest')`
+// Image shape: the account + region are extracted by Fn::Select over
+// Fn::Split(":", <repo Arn GetAtt>); the repo name is a Ref; the tag is a
+// literal.
+function canonicalImage(): unknown {
+  const arnSplit = {
+    'Fn::Split': [':', { 'Fn::GetAtt': [REPO, 'Arn'] }],
+  };
+  return {
+    'Fn::Join': [
+      '',
+      [
+        { 'Fn::Select': [4, arnSplit] }, // account
+        '.dkr.ecr.',
+        { 'Fn::Select': [3, arnSplit] }, // region
+        '.',
+        { Ref: 'AWS::URLSuffix' },
+        '/',
+        { Ref: REPO },
+        ':latest',
+      ],
+    ],
+  };
+}
+
+const resources: Record<string, TemplateResource> = {
+  [REPO]: { Type: 'AWS::ECR::Repository', Properties: {} } as unknown as TemplateResource,
+};
+
+function repoState(attributes?: Record<string, unknown>): Record<string, ResourceState> {
+  return {
+    [REPO]: {
+      physicalId: 'my-backend-repo',
+      resourceType: 'AWS::ECR::Repository',
+      properties: {},
+      ...(attributes && { attributes }),
+    },
+  };
+}
+
+const pseudo = {
+  accountId: '123456789012',
+  region: 'ap-northeast-1',
+  partition: 'aws',
+  urlSuffix: 'amazonaws.com',
+};
+
+describe('tryResolveImageFnJoin — ECR GetAtt Arn under --from-cfn-stack', () => {
+  it('synthesizes the repo Arn (no recorded attributes) so the canonical join resolves', () => {
+    const ctx: ImageResolutionContext = { pseudoParameters: pseudo, stateResources: repoState() };
+    const out = tryResolveImageFnJoin(canonicalImage(), resources, ctx);
+    expect(out).toEqual({
+      kind: 'resolved',
+      uri: '123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/my-backend-repo:latest',
+    });
+  });
+
+  it('prefers a recorded Arn attribute over the synthesized one', () => {
+    const ctx: ImageResolutionContext = {
+      pseudoParameters: pseudo,
+      stateResources: repoState({ Arn: 'arn:aws:ecr:us-west-2:999988887777:repository/other' }),
+    };
+    const out = tryResolveImageFnJoin(canonicalImage(), resources, ctx);
+    // account/region come from the recorded Arn; the repo name still comes
+    // from the Ref (physicalId).
+    expect(out).toEqual({
+      kind: 'resolved',
+      uri: '999988887777.dkr.ecr.us-west-2.amazonaws.com/my-backend-repo:latest',
+    });
+  });
+
+  it('returns needs-state when the repo is referenced but no state was supplied', () => {
+    const out = tryResolveImageFnJoin(canonicalImage(), resources, { pseudoParameters: pseudo });
+    expect(out).toEqual({ kind: 'needs-state', repoLogicalId: REPO });
+  });
+
+  it('cannot synthesize the Arn without an accountId, so the join is unsupported', () => {
+    const ctx: ImageResolutionContext = {
+      pseudoParameters: { region: 'ap-northeast-1', partition: 'aws', urlSuffix: 'amazonaws.com' },
+      stateResources: repoState(),
+    };
+    const out = tryResolveImageFnJoin(canonicalImage(), resources, ctx);
+    expect(out).toEqual({
+      kind: 'unsupported-join',
+      reason: 'one or more Fn::Join elements could not be resolved',
+    });
+  });
+
+  it('synthesizes RepositoryUri for the GetAtt RepositoryUri shape', () => {
+    const image = {
+      'Fn::Join': ['', [{ 'Fn::GetAtt': [REPO, 'RepositoryUri'] }, ':latest']],
+    };
+    const ctx: ImageResolutionContext = { pseudoParameters: pseudo, stateResources: repoState() };
+    const out = tryResolveImageFnJoin(image, resources, ctx);
+    expect(out).toEqual({
+      kind: 'resolved',
+      uri: '123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/my-backend-repo:latest',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`ContainerImage.fromEcrRepository(repo, tag)` (ECS) and
`lambda.DockerImageCode.fromEcr(repo, ...)` (container Lambda) synthesize
the image URI as an `Fn::Join` that derives the account + region by
`Fn::Select`-ing over `Fn::Split(":", Fn::GetAtt[<Repo>, "Arn"])`, with
the repo name as a `Ref` and `Ref: AWS::URLSuffix`.

Under `--from-cfn-stack`, state comes from `ListStackResources`, which
returns physical IDs only and never records the `Arn` attribute. The
image resolver therefore could not resolve the `Fn::GetAtt[<Repo>,"Arn"]`
element, and the whole join failed:

```
unsupported Fn::Join Image shape: one or more Fn::Join elements could not be resolved
```

This blocked `cdkl run-task` / `start-service` against a deployed stack.

## Fix

A same-stack ECR repository's `Arn` / `RepositoryUri` are deterministic,
so synthesize them in the image-intrinsic resolver when no attribute was
recorded, from:

- the repo's physical name (the `ListStackResources` physical ID), and
- the already-resolved account / region / partition / URL suffix.

```
Arn           = arn:<partition>:ecr:<region>:<account>:repository/<name>
RepositoryUri = <account>.dkr.ecr.<region>.<urlSuffix>/<name>
```

The cached-attribute path (e.g. `--from-state`, which records `Arn`)
still takes precedence; synthesis is a fallback for the physical-ID-only
case. The resolver is shared, so container-Lambda image URIs benefit
identically.

## Test plan

- [x] `vp run check` / `vp run build`
- [x] `vp run test` — 35 files, 458 tests
- [x] New `tests/unit/local/intrinsic-image-ecr-getatt.test.ts`:
      synthesized-Arn join, recorded-attribute precedence, the
      `RepositoryUri` shape, the needs-state case, and the no-account
      (cannot synthesize) fallback.
- [x] Live-tested against a real deployed stack: the canonical
      `fromEcrRepository` image that previously failed with
      "unsupported Fn::Join ... could not be resolved" now resolves to a
      concrete ECR URI and `start-service` advances to `docker pull`.

## Follow-up (separate PR)

Live-testing surfaced two downstream `--profile` threading gaps that this
PR intentionally does NOT cover (they belong with the ECR-pull
credential layer, which is reviewed separately):

- the `${AWS::AccountId}` pseudo-parameter (`resolveCallerAccountId`) is
  resolved without `--profile`, so the synthesized URI can carry the
  default-chain account instead of the profile's account; and
- the ECR puller authenticates `ecr:GetAuthorizationToken` with the
  default chain rather than `--profile`.

Both will be addressed together in a follow-up.
