### PR TITLE
fix(invoke,start-api): authenticate container-Lambda ECR pull with --profile

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -705,6 +705,7 @@ export async function resolveContainerImagePlan(
       skipPull: options.pull === false,
       ...(options.region !== undefined && { region: options.region }),
       ...(options.ecrRoleArn !== undefined && { ecrRoleArn: options.ecrRoleArn }),
+      ...(options.profile !== undefined && { profile: options.profile }),
     });
   }
 

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -622,6 +622,7 @@ async function localStartApiCommand(
         layerTmpDirs,
         stateByStack,
         skipPull: options.pull === false,
+        ...(options.profile !== undefined && { profile: options.profile }),
         ...(options.layerRoleArn !== undefined && { layerRoleArn: options.layerRoleArn }),
         ...(profileCredentials && { profileCredentials }),
         ...(profileCredsFile && { profileCredsFile }),
@@ -1639,6 +1640,13 @@ async function buildContainerSpec(args: {
    */
   skipPull: boolean;
   /**
+   * The CLI's `--profile`, forwarded to the IMAGE branch's ECR-pull
+   * fallback so `ecr:GetAuthorizationToken` authenticates as the
+   * profile's account (matching the ECS path). Undefined when
+   * `--profile` is unset.
+   */
+  profile?: string;
+  /**
    * Issue #448: optional `--layer-role-arn` value. Forwarded into
    * {@link materializeLambdaLayers}, which `sts:AssumeRole`s into this
    * role before calling `lambda:GetLayerVersion` for every literal-ARN
@@ -1744,7 +1752,7 @@ async function buildContainerSpec(args: {
     // manifest, OR pull from ECR when no matching asset is found.
     // Same-account/region only on the ECR-pull path — cross-account /
     // cross-region is deferred to a sibling PR (W2-1).
-    const built = await resolveContainerImageForStartApi(lambda, skipPull);
+    const built = await resolveContainerImageForStartApi(lambda, skipPull, args.profile);
     imageRef = built.imageRef;
     platform = architectureToPlatform(lambda.architecture);
   }
@@ -1980,7 +1988,8 @@ async function buildContainerSpec(args: {
  */
 export async function resolveContainerImageForStartApi(
   lambda: ResolvedStartApiImageLambda,
-  skipPull: boolean
+  skipPull: boolean,
+  profile?: string
 ): Promise<{ imageRef: string }> {
   const logger = getLogger();
   const localBuild = await resolveLocalBuildPlan(lambda);
@@ -2000,7 +2009,10 @@ export async function resolveContainerImageForStartApi(
   logger.info(
     `No matching cdk.out asset for ${lambda.imageUri}; falling back to ECR pull (same-acct/region only)...`
   );
-  const imageRef = await pullEcrImage(lambda.imageUri, { skipPull });
+  const imageRef = await pullEcrImage(lambda.imageUri, {
+    skipPull,
+    ...(profile !== undefined && { profile }),
+  });
   return { imageRef };
 }
 

--- a/tests/unit/cli/local-invoke-image-profile.test.ts
+++ b/tests/unit/cli/local-invoke-image-profile.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { pullMock, parseMock } = vi.hoisted(() => ({
+  pullMock: vi.fn(),
+  parseMock: vi.fn(),
+}));
+
+vi.mock('../../../src/local/ecr-puller.js', () => ({
+  pullEcrImage: pullMock,
+  parseEcrUri: parseMock,
+}));
+
+const { resolveContainerImagePlan } = await import('../../../src/cli/commands/local-invoke.js');
+
+// Container Lambda with no local asset (assetManifestPath undefined) so
+// resolution falls through to the ECR-pull path (the branch forwarding
+// `--profile`). `imageConfig: {}` + no `ephemeralStorageMb` keep the
+// post-pull plan construction clean.
+function ecrLambda() {
+  return {
+    logicalId: 'ImgFn',
+    kind: 'image',
+    architecture: 'x86_64',
+    imageUri: '111122223333.dkr.ecr.ap-northeast-1.amazonaws.com/repo:latest',
+    imageConfig: {},
+    stack: { stackName: 'S', assetManifestPath: undefined },
+  } as unknown as Parameters<typeof resolveContainerImagePlan>[0];
+}
+
+describe('resolveContainerImagePlan — ECR-pull --profile forwarding', () => {
+  beforeEach(() => {
+    pullMock.mockReset();
+    parseMock.mockReset();
+    parseMock.mockReturnValue({
+      registry: '111122223333.dkr.ecr.ap-northeast-1.amazonaws.com',
+      accountId: '111122223333',
+      region: 'ap-northeast-1',
+      repository: 'repo',
+      tag: 'latest',
+    });
+    pullMock.mockImplementation((uri: string) => Promise.resolve(uri));
+  });
+
+  it('forwards --profile to pullEcrImage on the ECR-pull fallback', async () => {
+    const lambda = ecrLambda();
+    await resolveContainerImagePlan(lambda, {
+      profile: 'mates_dev',
+      pull: true,
+    } as unknown as Parameters<typeof resolveContainerImagePlan>[1]);
+
+    expect(pullMock).toHaveBeenCalledWith(lambda.imageUri, {
+      skipPull: false,
+      profile: 'mates_dev',
+    });
+  });
+
+  it('omits the profile key when --profile is unset', async () => {
+    const lambda = ecrLambda();
+    await resolveContainerImagePlan(lambda, {
+      pull: true,
+    } as unknown as Parameters<typeof resolveContainerImagePlan>[1]);
+
+    expect(pullMock).toHaveBeenCalledWith(lambda.imageUri, { skipPull: false });
+  });
+});

--- a/tests/unit/cli/local-start-api-image-profile.test.ts
+++ b/tests/unit/cli/local-start-api-image-profile.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { pullMock, parseMock } = vi.hoisted(() => ({
+  pullMock: vi.fn(),
+  parseMock: vi.fn(),
+}));
+
+vi.mock('../../../src/local/ecr-puller.js', () => ({
+  pullEcrImage: pullMock,
+  parseEcrUri: parseMock,
+}));
+
+const { resolveContainerImageForStartApi } = await import(
+  '../../../src/cli/commands/local-start-api.js'
+);
+
+// A container Lambda with no local asset (assetManifestPath undefined) so
+// `resolveLocalBuildPlan` returns undefined and resolution falls through to
+// the ECR-pull path — the branch that must forward `--profile`.
+function ecrLambda() {
+  return {
+    logicalId: 'ImgFn',
+    imageUri: '111122223333.dkr.ecr.ap-northeast-1.amazonaws.com/repo:latest',
+    architecture: 'x86_64',
+    stack: { stackName: 'S', assetManifestPath: undefined },
+  } as unknown as Parameters<typeof resolveContainerImageForStartApi>[0];
+}
+
+describe('resolveContainerImageForStartApi — ECR-pull --profile forwarding', () => {
+  beforeEach(() => {
+    pullMock.mockReset();
+    parseMock.mockReset();
+    parseMock.mockReturnValue({
+      registry: '111122223333.dkr.ecr.ap-northeast-1.amazonaws.com',
+      accountId: '111122223333',
+      region: 'ap-northeast-1',
+      repository: 'repo',
+      tag: 'latest',
+    });
+    pullMock.mockImplementation((uri: string) => Promise.resolve(uri));
+  });
+
+  it('forwards --profile to pullEcrImage on the ECR-pull fallback', async () => {
+    const lambda = ecrLambda();
+    await resolveContainerImageForStartApi(lambda, false, 'mates_dev');
+    expect(pullMock).toHaveBeenCalledWith(lambda.imageUri, {
+      skipPull: false,
+      profile: 'mates_dev',
+    });
+  });
+
+  it('omits the profile key when --profile is unset', async () => {
+    const lambda = ecrLambda();
+    await resolveContainerImageForStartApi(lambda, true);
+    expect(pullMock).toHaveBeenCalledWith(lambda.imageUri, { skipPull: true });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the ECS `--from-cfn-stack` `--profile` work. The
container-Lambda ECR-pull fallback (`Code.ImageUri` with no matching
cdk.out asset) called `pullEcrImage` without threading `--profile`, so it
authenticated `ecr:GetAuthorizationToken` with the default credential
chain — the same wrong-account / cross-account denial just fixed for
`run-task` / `start-service`. This closes that gap for `invoke` and
`start-api`, making the `--profile` contract consistent across all four
commands.

## Changes

- `local-invoke.ts` — `resolveContainerImagePlan` adds `profile` to the
  `pullEcrImage` options (`options.profile` was already in scope).
- `local-start-api.ts` —
  `resolveContainerImageForStartApi(lambda, skipPull, profile?)` threads
  `profile` into `pullEcrImage`; `buildContainerSpec` gains a `profile`
  arg fed from `options.profile` at the call site.

`pullEcrImage` already honors `EcrPullOptions.profile` (unit-tested).

## Test plan

- [x] `vp run check` / `vp run build`
- [x] `vp run test` — 44 files, 572 tests
- [x] New site-level forwarding tests for both exported entry points
      (`tests/unit/cli/local-invoke-image-profile.test.ts`,
      `local-start-api-image-profile.test.ts`): `--profile` forwarded to
      `pullEcrImage` when set, omitted when unset.

## Live-test note

The container-Lambda ECR-pull *runtime* path was not separately live-run
this session (no fixture exercises it — `local-invoke-container` builds
the image locally rather than pulling from ECR). Coverage is the unit
forwarding tests above plus `pullEcrImage`'s own profile unit tests; the
underlying `pullEcrImage` profile behavior was live-verified end-to-end
on the ECS path in the preceding PR.
