### PR TITLE
fix(from-cfn-stack): authenticate ECS container secrets with --profile

### DIFF
--- a/src/local/ecs-secrets-resolver.ts
+++ b/src/local/ecs-secrets-resolver.ts
@@ -49,6 +49,15 @@ export interface ResolveEcsSecretsOptions {
   /** Region for the AWS SDK clients. Falls back to env defaults when unset. */
   region?: string;
   /**
+   * The CLI's `--profile`. Threaded into the Secrets Manager / SSM
+   * clients so `secretsmanager:GetSecretValue` / `ssm:GetParameter`
+   * authenticate as the profile's account — for `--from-cfn-stack` the
+   * secret lives in the deployed (profile) account, and without this the
+   * default credential chain authenticates as the wrong account and AWS
+   * rejects with AccessDenied. Undefined when `--profile` is unset.
+   */
+  profile?: string;
+  /**
    * Hook for tests: supply pre-built SDK clients. Production callers
    * leave both unset and let the resolver construct + destroy its own
    * clients.
@@ -71,9 +80,16 @@ export async function resolveEcsSecrets(
 
   const secretsClient =
     options.secretsManagerClient ??
-    new SecretsManagerClient({ ...(options.region && { region: options.region }) });
+    new SecretsManagerClient({
+      ...(options.region && { region: options.region }),
+      ...(options.profile && { profile: options.profile }),
+    });
   const ssmClient =
-    options.ssmClient ?? new SSMClient({ ...(options.region && { region: options.region }) });
+    options.ssmClient ??
+    new SSMClient({
+      ...(options.region && { region: options.region }),
+      ...(options.profile && { profile: options.profile }),
+    });
   const ownsSecretsClient = options.secretsManagerClient === undefined;
   const ownsSsmClient = options.ssmClient === undefined;
 

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -336,6 +336,7 @@ export async function runEcsTask(
   }
   const resolvedSecrets = await resolveEcsSecrets(allSecrets, {
     ...(options.region !== undefined && { region: options.region }),
+    ...(options.profile !== undefined && { profile: options.profile }),
   });
   const secretsByContainer = groupSecretsByContainer(resolvedSecrets);
 

--- a/tests/unit/local/ecs-secrets-resolver-profile.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-profile.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { smCtorArgs, ssmCtorArgs, smSend, ssmSend } = vi.hoisted(() => ({
+  smCtorArgs: [] as Array<Record<string, unknown>>,
+  ssmCtorArgs: [] as Array<Record<string, unknown>>,
+  smSend: vi.fn(),
+  ssmSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: class {
+    constructor(cfg: Record<string, unknown>) {
+      smCtorArgs.push(cfg);
+    }
+    send = smSend;
+    destroy(): void {}
+  },
+  GetSecretValueCommand: class {},
+}));
+
+vi.mock('@aws-sdk/client-ssm', () => ({
+  SSMClient: class {
+    constructor(cfg: Record<string, unknown>) {
+      ssmCtorArgs.push(cfg);
+    }
+    send = ssmSend;
+    destroy(): void {}
+  },
+  GetParameterCommand: class {},
+}));
+
+const { resolveEcsSecrets } = await import('../../../src/local/ecs-secrets-resolver.js');
+
+const SM_ARN = 'arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:my-secret';
+
+describe('resolveEcsSecrets — --profile threading', () => {
+  beforeEach(() => {
+    smCtorArgs.length = 0;
+    ssmCtorArgs.length = 0;
+    smSend.mockReset();
+    ssmSend.mockReset();
+    smSend.mockResolvedValue({ SecretString: 'resolved-value' });
+  });
+
+  it('threads --profile into both the Secrets Manager and SSM clients', async () => {
+    const out = await resolveEcsSecrets(
+      [{ containerName: 'App', name: 'HASH_SALT', valueFrom: SM_ARN }],
+      { region: 'ap-northeast-1', profile: 'mates_dev' }
+    );
+
+    expect(out).toEqual([
+      { containerName: 'App', name: 'HASH_SALT', valueFrom: SM_ARN, value: 'resolved-value' },
+    ]);
+    expect(smCtorArgs).toEqual([{ region: 'ap-northeast-1', profile: 'mates_dev' }]);
+    expect(ssmCtorArgs).toEqual([{ region: 'ap-northeast-1', profile: 'mates_dev' }]);
+  });
+
+  it('omits the profile key when --profile is unset', async () => {
+    await resolveEcsSecrets([{ containerName: 'App', name: 'HASH_SALT', valueFrom: SM_ARN }], {
+      region: 'ap-northeast-1',
+    });
+
+    expect(smCtorArgs[0]!).not.toHaveProperty('profile');
+    expect(ssmCtorArgs[0]!).not.toHaveProperty('profile');
+  });
+});


### PR DESCRIPTION
## Summary

ECS container `secrets` / `valueFrom` resolution built its Secrets
Manager and SSM clients with no profile, so `secretsmanager:GetSecretValue`
/ `ssm:GetParameter` authenticated via the default credential chain. Under
`--from-cfn-stack` the secret lives in the deployed (profile) account, so
the wrong-account caller was rejected:

```
Failed to resolve Secrets Manager secret for container 'AppContainer' /
env 'HASH_SALT' (...): User: arn:aws:iam::<default-acct>:user/... is not
authorized to perform: secretsmanager:GetSecretValue ...
```

This is the same `--profile` threading gap previously fixed for the
synth lookups, CFn region, image account, and ECR pull — now closed for
container secret resolution too.

## Fix

- Add `profile` to `ResolveEcsSecretsOptions`; thread it into both the
  `SecretsManagerClient` and `SSMClient` constructors.
- `ecs-task-runner` forwards `options.profile` (already on
  `RunEcsTaskOptions`) to `resolveEcsSecrets`.

## Test plan

- [x] `vp run check` / `vp run build`
- [x] `vp run test` — 45 files, 574 tests
- [x] New `tests/unit/local/ecs-secrets-resolver-profile.test.ts`:
      `--profile` reaches both the Secrets Manager and SSM client
      constructors; omitted when unset.
- [x] Live-tested `start-service ... --from-cfn-stack --profile` against a
      real deployed stack with the real image tag: the prior
      `GetSecretValue` AccessDenied is gone — the secret resolves under
      the profile's account and the replica proceeds to start its
      container.
