### PR TITLE
refactor(local): scrub residual cdkd references from runtime strings

### DIFF
--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -10,7 +10,7 @@
  * This lets `cdkl *` substitute env vars / secrets / images that
  * reference deployed resources in a CDK app deployed via the upstream
  * CDK CLI (`cdk deploy` → CloudFormation) WITHOUT first migrating the
- * stack to cdkd.
+ * stack into a separate state store.
  *
  * Wire-format mapping:
  *
@@ -33,8 +33,8 @@
  *   - `Fn::ImportValue: <exportName>` → resolved via `ListExports`
  *     (paginated). Same-region only — CFn exports are region-scoped.
  *   - `Fn::GetStackOutput` → rejected with a clear pointer that the
- *     intrinsic is cdkd-specific (CFn has no equivalent — exports +
- *     outputs are the only cross-stack vocabulary CFn understands).
+ *     intrinsic has no CFn equivalent (exports + outputs are the only
+ *     cross-stack vocabulary CFn understands).
  *   - Stack outputs (consumed by both `Fn::GetStackOutput` and the
  *     cross-stack-resolver's index-miss fallback) → sourced from
  *     `DescribeStacks.Outputs[]`.
@@ -272,9 +272,8 @@ export class CfnLocalStateProvider implements LocalStateProvider {
   /**
    * Build a `CrossStackResolver` that resolves `Fn::ImportValue` via
    * `cloudformation:ListExports`. `Fn::GetStackOutput` is rejected here
-   * — it's a cdkd-specific intrinsic with no CFn-side equivalent, and
-   * the user-visible error message names the right intrinsic
-   * (`Fn::ImportValue`) for that use case.
+   * — it has no CFn-side equivalent, and the user-visible error message
+   * names the right intrinsic (`Fn::ImportValue`) for that use case.
    *
    * `consumerRegion` is accepted for interface parity with the S3
    * provider but the `CfnLocalStateProvider` only resolves exports in
@@ -330,20 +329,17 @@ export class CfnLocalStateProvider implements LocalStateProvider {
         producerRegion: string,
         outputName: string
       ): Promise<string | undefined> {
-        // `Fn::GetStackOutput` is a cdkd-specific intrinsic that reads
-        // the producer stack's state.json directly from S3. There is
-        // no CFn-side equivalent (CFn templates use `Fn::ImportValue`
-        // + an explicit `Outputs.<name>.Export`); rather than silently
-        // returning undefined we surface a logger.warn naming the
-        // intrinsic and the producer so the user sees why the env var
-        // dropped. The `state-resolver.ts` async path turns the
-        // `undefined` into its own per-key warn with the standard
-        // "output not found in producer stack state" message, so
-        // skipping the warn here would mask the cdkd-vs-CFn nature
-        // of the gap.
+        // `Fn::GetStackOutput` has no CFn-side equivalent (CFn templates
+        // use `Fn::ImportValue` + an explicit `Outputs.<name>.Export`);
+        // rather than silently returning undefined we surface a
+        // logger.warn naming the intrinsic and the producer so the user
+        // sees why the env var dropped. The `state-resolver.ts` async
+        // path turns the `undefined` into its own per-key warn with the
+        // standard "output not found in producer stack state" message,
+        // so skipping the warn here would mask the nature of the gap.
         logger.warn(
-          `${label}: Fn::GetStackOutput '${producerStack}.${outputName}' (${producerRegion}) is a cdkd-specific intrinsic with no CloudFormation equivalent. ` +
-            `Use Fn::ImportValue against an exported output instead, or deploy the producer stack via cdkd deploy and use --from-state.`
+          `${label}: Fn::GetStackOutput '${producerStack}.${outputName}' (${producerRegion}) has no CloudFormation equivalent and cannot be resolved when reading state from a CloudFormation stack. ` +
+            `Use Fn::ImportValue against an exported output instead.`
         );
         return undefined;
       },

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -1022,8 +1022,9 @@ function parseContainerImage(
   // as a `Fn::Join` that builds the ECR URI from nested `Fn::Select` /
   // `Fn::Split` over the repository's `Arn` GetAtt plus a `Ref` to the
   // repo and `Ref: AWS::URLSuffix`. The repository's account-id and
-  // region only exist in cdkd's S3 state (set at deploy time), so this
-  // shape inherently requires `--from-state` (Tier 2).
+  // region are only available from deployed-stack state (recorded at
+  // deploy time), so this shape inherently requires loading state via
+  // `--from-cfn-stack` (Tier 2).
   const joinResolved = tryResolveImageFnJoin(raw, resources, context);
   if (joinResolved.kind === 'resolved') {
     return classifyResolvedImage(joinResolved.uri);
@@ -1032,7 +1033,7 @@ function parseContainerImage(
     throw new EcsTaskResolutionError(
       `Container '${containerName}' in task '${taskLogicalId}' references same-stack ECR repository '${joinResolved.repoLogicalId}' via Fn::Join. ` +
         `${getEmbedConfig().cliName} run-task cannot resolve the repository URI without state — ` +
-        'pass --from-state (the stack must have been deployed via cdkd deploy), ' +
+        'pass --from-cfn-stack to load the deployed stack state, ' +
         'build via ContainerImage.fromAsset, or pin a public image.'
     );
   }
@@ -1078,7 +1079,7 @@ function parseContainerImage(
       throw new EcsTaskResolutionError(
         `Container '${containerName}' in task '${taskLogicalId}' references same-stack ECR repository '${unresolvedRepoRef}'. ` +
           `${getEmbedConfig().cliName} run-task v1 cannot resolve the repository URI without state — ` +
-          'pass --from-state (the stack must have been deployed via cdkd deploy), ' +
+          'pass --from-cfn-stack to load the deployed stack state, ' +
           'build via ContainerImage.fromAsset, or pin a public image.'
       );
     }

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -684,7 +684,7 @@ function buildAwsIntegrationConfig(
   if (!isLambda) {
     return {
       kind: 'unsupported',
-      reason: `${stackName}/${logicalId}: REST v1 AWS integration targeting a non-Lambda service (Uri ${shortJson(uri)}) is not emulated locally in ${getEmbedConfig().binaryName} v1. Lambda non-proxy AWS integrations are supported; direct AWS service integrations (S3 / SQS / SNS / DynamoDB) require deploying to AWS. See https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md.`,
+      reason: `${stackName}/${logicalId}: REST v1 AWS integration targeting a non-Lambda service (Uri ${shortJson(uri)}) is not emulated locally in ${getEmbedConfig().binaryName} v1. Lambda non-proxy AWS integrations are supported; direct AWS service integrations (S3 / SQS / SNS / DynamoDB) require deploying to AWS. See https://github.com/go-to-k/cdk-local/blob/main/docs/local-emulation.md.`,
     };
   }
   const arnOutcome = resolveLambdaArnOutcome(uri);


### PR DESCRIPTION
## Summary

Issue #52 (category 1 — runtime user-visible strings): cdk-local source still branded user-facing error messages with cdkd's deploy / state / intrinsic vocabulary, which cdk-local (a local-execution-only CLI: `invoke` / `start-api` / `run-task` / `start-service`) does not own. This rewrites the three remaining runtime sites to self-contained, CLI-accurate wording:

- **`route-discovery.ts`** — the REST-v1 non-Lambda AWS-integration "unsupported" reason pointed users at cdkd's docs (`github.com/go-to-k/cdkd/.../docs/local-emulation.md`). cdk-local has its own `docs/local-emulation.md`; point there instead.
- **`cfn-local-state-provider.ts`** — the `Fn::GetStackOutput` rejection warning called the intrinsic "cdkd-specific" and advised "deploy the producer stack via cdkd deploy and use `--from-state`". `--from-state` is a host-injected flag, not the native `--from-cfn-stack` path this provider serves, so the advice was both branded and inapplicable. Reworded to "has no CloudFormation equivalent … use `Fn::ImportValue`".
- **`ecs-task-resolver.ts`** (x2) — the `run-task` ECR-needs-state errors advised "pass `--from-state` (the stack must have been deployed via cdkd deploy)". `--from-cfn-stack` is cdk-local's native state-source flag; reworded to "pass `--from-cfn-stack` to load the deployed stack state".

Also genericized the comments/docstrings that directly explain those three rewritten messages.

### Why a content rewrite, not embedConfig

Per #52: `cdkd deploy` / `cdkd state` / `Fn::GetStackOutput` are concepts cdk-local does not own, so the `embedConfig` branding mechanism (which parameterizes cdk-local's *own* `cdkl` / `cdk-local` branding for host CLIs) does not apply. These strings are rewritten to wording that is accurate for cdk-local's own CLI.

### Scope / deliberately deferred

- The ~140 history comments citing cdkd PR numbers, the `cdkd/` S3 key-path literals, and the `go-to-k/cdkd/issues/N` links are **category 2** in #52 ("lower priority — not user-visible … follow-up sweep") and are left for a separate PR. #52 stays open to track that.
- `error-handler.ts` and `state-resolver.ts` runtime strings listed in #52 were **already scrubbed by #54** (error-handler self-containment refactor).

Pure content rewrite — no behavior change. `Refs #52`.

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) green — 80 files
- [x] `vp run build` green — 10 files
- [x] `vp run test` — 42 files / 568 tests pass
- [x] No unit test asserts any changed string (`route-discovery.test.ts` asserts only `/non-Lambda service/`, unchanged), so the wording changes don't break the suite
- [ ] `integ` gate (Docker local-execution) — required for merge; this is a no-behavior string change but the gate fires mechanically on any `src/**` edit
