### PR TITLE
feat(exports): expose env-resolver / stage-resolver / cloud-map-registry primitives

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -118,6 +118,18 @@ The `start-api` authorizer primitives are exposed on the same basis:
   `computeRequestIdentityHash` / `evaluateCachedLambdaPolicy` — Lambda
   (TOKEN / REQUEST) authorizer invocation and IAM-policy evaluation.
 
+The `invoke` / `start-api` env-var and stage layers, plus the
+`start-service` Cloud Map registry, are exposed on the same basis:
+
+- `resolveEnvVars` (+ `EnvOverrideFile`) — merge template-literal env
+  vars with SAM-shape `--env-vars` overrides (intrinsic-valued entries
+  warn-and-drop unless substituted upstream).
+- `buildStageMap` / `attachStageContext` (+ `ResolvedStage`) — per-API
+  Stage selection; attaches stage context (`event.stageVariables`) to
+  discovered routes.
+- `CloudMapRegistry` — in-process Cloud Map service registry so peers
+  reach each other by IP / network alias on the shared service network.
+
 These are stable, side-effect-free utilities; they are exposed for
 1:1 re-export and are not a recommended way to build a custom CLI (use
 the factories for that).

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,3 +128,24 @@ export {
   invokeRequestAuthorizer,
   invokeTokenAuthorizer,
 } from './local/lambda-authorizer.js';
+
+/**
+ * `invoke` / `start-api` Lambda env-var resolution — merges template-literal
+ * env vars with SAM-shape `--env-vars` overrides (intrinsic-valued entries
+ * warn-and-drop unless `--from-*` substituted them upstream). Exposed only as
+ * the consuming host's `import` statements require them.
+ */
+export { resolveEnvVars, type EnvOverrideFile } from './local/env-resolver.js';
+
+/**
+ * `start-api` per-API Stage selection — builds the stage map and attaches
+ * stage context (populating `event.stageVariables`) to discovered routes.
+ */
+export { attachStageContext, buildStageMap, type ResolvedStage } from './local/stage-resolver.js';
+
+/**
+ * `start-service` in-process Cloud Map service registry — peers reach each
+ * other by IP / network alias on the shared service network without docker
+ * `network connect` choreography.
+ */
+export { CloudMapRegistry } from './local/cloud-map-registry.js';

--- a/tests/unit/local/cloud-map-registry.test.ts
+++ b/tests/unit/local/cloud-map-registry.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { CloudMapRegistry } from '../../../src/local/cloud-map-registry.js';
+
+describe('CloudMapRegistry', () => {
+  describe('register / lookup', () => {
+    it('publishes a single endpoint and looks it up by fqdn', () => {
+      const r = new CloudMapRegistry();
+      const handle = r.register('cdkl.local', 'orders', {
+        ip: '172.20.0.5',
+        port: 80,
+        ownerKey: 'Orders:r0:sc:0',
+      });
+      expect(handle.fqdn).toBe('orders.cdkl.local');
+      expect(handle.ownerKey).toBe('Orders:r0:sc:0');
+      const endpoints = r.lookup('cdkl.local', 'orders');
+      expect(endpoints?.length).toBe(1);
+      expect(endpoints?.[0]).toEqual({
+        ip: '172.20.0.5',
+        port: 80,
+        ownerKey: 'Orders:r0:sc:0',
+      });
+    });
+
+    it('returns undefined when fqdn was never registered', () => {
+      const r = new CloudMapRegistry();
+      expect(r.lookup('cdkl.local', 'missing')).toBeUndefined();
+    });
+
+    it('supports multiple replicas under the same fqdn', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'svc', { ip: '1.2.3.4', port: 80, ownerKey: 'Svc:r0' });
+      r.register('ns.local', 'svc', { ip: '1.2.3.5', port: 80, ownerKey: 'Svc:r1' });
+      const endpoints = r.lookup('ns.local', 'svc');
+      expect(endpoints?.length).toBe(2);
+      expect(endpoints?.map((e) => e.ip)).toEqual(['1.2.3.4', '1.2.3.5']);
+    });
+
+    it('re-register by same ownerKey replaces the prior entry', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'svc', { ip: '1.2.3.4', port: 80, ownerKey: 'Svc:r0' });
+      r.register('ns.local', 'svc', { ip: '5.6.7.8', port: 81, ownerKey: 'Svc:r0' });
+      const endpoints = r.lookup('ns.local', 'svc');
+      expect(endpoints?.length).toBe(1);
+      expect(endpoints?.[0]?.ip).toBe('5.6.7.8');
+      expect(endpoints?.[0]?.port).toBe(81);
+    });
+
+    it('rejects empty namespace and empty discoveryName', () => {
+      const r = new CloudMapRegistry();
+      expect(() => r.register('', 'svc', { ip: '1.1.1.1', port: 1, ownerKey: 'k' })).toThrow(
+        /namespace must be a non-empty string/
+      );
+      expect(() => r.register('ns.local', '', { ip: '1.1.1.1', port: 1, ownerKey: 'k' })).toThrow(
+        /discoveryName must be a non-empty string/
+      );
+    });
+  });
+
+  describe('unregister', () => {
+    it('removes one endpoint by handle', () => {
+      const r = new CloudMapRegistry();
+      const handleA = r.register('ns.local', 'svc', {
+        ip: '1.1.1.1',
+        port: 80,
+        ownerKey: 'Svc:r0',
+      });
+      r.register('ns.local', 'svc', { ip: '2.2.2.2', port: 80, ownerKey: 'Svc:r1' });
+      expect(r.unregister(handleA)).toBe(true);
+      const left = r.lookup('ns.local', 'svc');
+      expect(left?.length).toBe(1);
+      expect(left?.[0]?.ip).toBe('2.2.2.2');
+    });
+
+    it('returns false on unknown handle (idempotent)', () => {
+      const r = new CloudMapRegistry();
+      expect(r.unregister({ fqdn: 'x.y.z', ownerKey: 'gone' })).toBe(false);
+    });
+
+    it('deletes the fqdn entry when the last endpoint is removed', () => {
+      const r = new CloudMapRegistry();
+      const h = r.register('ns.local', 'svc', { ip: '1.1.1.1', port: 1, ownerKey: 'k' });
+      r.unregister(h);
+      expect(r.lookup('ns.local', 'svc')).toBeUndefined();
+      expect(r.isEmpty()).toBe(true);
+    });
+
+    it('unregisterByOwner drops every entry with the matching prefix', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'svc', { ip: '1.1.1.1', port: 80, ownerKey: 'Svc:r0:sc:0' });
+      r.register('ns.local', 'svc', { ip: '2.2.2.2', port: 80, ownerKey: 'Svc:r1:sc:0' });
+      r.register('ns.local', 'other', { ip: '3.3.3.3', port: 80, ownerKey: 'Other:r0:sc:0' });
+      const removed = r.unregisterByOwner('Svc:');
+      expect(removed).toBe(2);
+      expect(r.lookup('ns.local', 'svc')).toBeUndefined();
+      expect(r.lookup('ns.local', 'other')?.length).toBe(1);
+    });
+  });
+
+  describe('registerAlias / lookupAlias', () => {
+    it('maps a bare alias to the target fqdn', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'orders', { ip: '1.1.1.1', port: 80, ownerKey: 'O:r0' });
+      r.registerAlias('orders', 'orders.ns.local');
+      const endpoints = r.lookupAlias('orders');
+      expect(endpoints?.length).toBe(1);
+      expect(endpoints?.[0]?.ip).toBe('1.1.1.1');
+    });
+
+    it('returns undefined when alias has no registered target', () => {
+      const r = new CloudMapRegistry();
+      r.registerAlias('orders', 'orders.ns.local');
+      expect(r.lookupAlias('orders')).toBeUndefined();
+    });
+
+    it('rejects empty alias and empty targetFqdn', () => {
+      const r = new CloudMapRegistry();
+      expect(() => r.registerAlias('', 'a.b')).toThrow(/alias must be a non-empty string/);
+      expect(() => r.registerAlias('a', '')).toThrow(/targetFqdn must be a non-empty string/);
+    });
+  });
+
+  describe('registerAlias collision (Issue #544 — first-wins, design § O6)', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // The logger routes warn lines through console.warn. Capture them
+      // so we can assert the collision message fires (and does not fire
+      // for idempotent same-source re-register).
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('first-wins on alias DnsName collision (later mapping ignored + warn fires)', () => {
+      const r = new CloudMapRegistry();
+      r.register('namespace.local', 'svcA', { ip: '1.1.1.1', port: 80, ownerKey: 'A:r0' });
+      r.register('namespace.local', 'svcB', { ip: '2.2.2.2', port: 80, ownerKey: 'B:r0' });
+      r.registerAlias('api', 'svcA.namespace.local');
+      // Second registration of the SAME alias to a DIFFERENT target —
+      // first-wins per design § O6, the new mapping is dropped + warn.
+      r.registerAlias('api', 'svcB.namespace.local');
+
+      const endpoints = r.lookupAlias('api');
+      expect(endpoints?.length).toBe(1);
+      expect(endpoints?.[0]?.ip).toBe('1.1.1.1');
+
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(
+        warnMessages.some(
+          (m) => /ClientAlias DnsName collision/.test(m) && /'api'/.test(m) && /first-wins/.test(m)
+        )
+      ).toBe(true);
+    });
+
+    it('idempotent re-register of same-source mapping does not warn', () => {
+      const r = new CloudMapRegistry();
+      r.register('namespace.local', 'svcA', { ip: '1.1.1.1', port: 80, ownerKey: 'A:r0' });
+      r.registerAlias('api', 'svcA.namespace.local');
+      // Same alias → same target re-registered (e.g. a service was
+      // re-resolved after a restart) — no-op, no warn.
+      r.registerAlias('api', 'svcA.namespace.local');
+
+      const endpoints = r.lookupAlias('api');
+      expect(endpoints?.length).toBe(1);
+      expect(endpoints?.[0]?.ip).toBe('1.1.1.1');
+
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(warnMessages.some((m) => /ClientAlias DnsName collision/.test(m))).toBe(false);
+    });
+  });
+
+  describe('buildAddHostFlags', () => {
+    it('emits one --add-host pair per fqdn', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'svc', { ip: '1.1.1.1', port: 80, ownerKey: 'Svc:r0' });
+      r.register('ns.local', 'other', { ip: '2.2.2.2', port: 80, ownerKey: 'Other:r0' });
+      const flags = r.buildAddHostFlags();
+      // Each entry produces two argv tokens (--add-host + name:ip).
+      expect(flags.length).toBe(4);
+      expect(flags).toEqual(
+        expect.arrayContaining([
+          '--add-host',
+          'svc.ns.local:1.1.1.1',
+          '--add-host',
+          'other.ns.local:2.2.2.2',
+        ])
+      );
+    });
+
+    it('emits both the fqdn and every alias mapped to it', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'orders', { ip: '1.1.1.1', port: 80, ownerKey: 'O:r0' });
+      r.registerAlias('orders', 'orders.ns.local');
+      r.registerAlias('orders-svc', 'orders.ns.local');
+      const flags = r.buildAddHostFlags();
+      const map = parseAddHostFlags(flags);
+      expect(map['orders.ns.local']).toBe('1.1.1.1');
+      expect(map['orders']).toBe('1.1.1.1');
+      expect(map['orders-svc']).toBe('1.1.1.1');
+    });
+
+    it('skips aliases pointing at fqdns with no live endpoint', () => {
+      const r = new CloudMapRegistry();
+      r.registerAlias('orders', 'orders.ns.local');
+      const flags = r.buildAddHostFlags();
+      expect(flags).toEqual([]);
+    });
+
+    it('excludeOwnerKeyPrefix drops every endpoint owned by that prefix', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'a', { ip: '1.1.1.1', port: 80, ownerKey: 'A:r0' });
+      r.register('ns.local', 'b', { ip: '2.2.2.2', port: 80, ownerKey: 'B:r0' });
+      const flags = r.buildAddHostFlags('A:');
+      const map = parseAddHostFlags(flags);
+      expect(map['a.ns.local']).toBeUndefined();
+      expect(map['b.ns.local']).toBe('2.2.2.2');
+    });
+
+    it('first endpoint wins when multiple replicas registered under the same fqdn', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'svc', { ip: '1.1.1.1', port: 80, ownerKey: 'S:r0' });
+      r.register('ns.local', 'svc', { ip: '2.2.2.2', port: 80, ownerKey: 'S:r1' });
+      const flags = r.buildAddHostFlags();
+      const map = parseAddHostFlags(flags);
+      expect(map['svc.ns.local']).toBe('1.1.1.1');
+    });
+  });
+
+  describe('list / isEmpty', () => {
+    it('isEmpty reports the registry state', () => {
+      const r = new CloudMapRegistry();
+      expect(r.isEmpty()).toBe(true);
+      r.register('ns.local', 'svc', { ip: '1.1.1.1', port: 1, ownerKey: 'k' });
+      expect(r.isEmpty()).toBe(false);
+    });
+
+    it('list surfaces fqdn rows and alias rows', () => {
+      const r = new CloudMapRegistry();
+      r.register('ns.local', 'orders', { ip: '1.1.1.1', port: 80, ownerKey: 'O:r0' });
+      r.registerAlias('orders', 'orders.ns.local');
+      const rows = r.list();
+      expect(rows.length).toBe(2);
+      const fqdnRow = rows.find((r) => !r.isAlias);
+      const aliasRow = rows.find((r) => r.isAlias);
+      expect(fqdnRow?.discoveryName).toBe('orders');
+      expect(fqdnRow?.namespace).toBe('ns.local');
+      expect(aliasRow?.discoveryName).toBe('orders');
+      expect(aliasRow?.namespace).toBe('');
+      expect(aliasRow?.endpoints[0]?.ip).toBe('1.1.1.1');
+    });
+  });
+});
+
+function parseAddHostFlags(flags: ReadonlyArray<string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < flags.length; i += 2) {
+    if (flags[i] !== '--add-host') continue;
+    const [name, ip] = (flags[i + 1] ?? '').split(':');
+    if (name && ip) out[name] = ip;
+  }
+  return out;
+}

--- a/tests/unit/local/env-resolver.test.ts
+++ b/tests/unit/local/env-resolver.test.ts
@@ -80,6 +80,22 @@ describe('resolveEnvVars', () => {
       const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
       expect(result.resolved).toEqual({ LITERAL: 'template' });
     });
+
+    it('substitutes the template intrinsic with an override when provided', () => {
+      // Common workflow: template has an intrinsic-valued env, user supplies a
+      // literal via --env-vars to make it concrete for local invoke.
+      const result = resolveEnvVars(
+        LOGICAL,
+        L1_PATH,
+        { TABLE_NAME: { Ref: 'MyTable' } },
+        { [LOGICAL]: { TABLE_NAME: 'literal-table' } }
+      );
+      expect(result.resolved).toEqual({ TABLE_NAME: 'literal-table' });
+      // Still reported as unresolved at the template level so the caller can
+      // decide whether to warn; the override's success is observable via
+      // `resolved`.
+      expect(result.unresolved).toEqual(['TABLE_NAME']);
+    });
   });
 
   describe('--env-vars: function-specific entry — display-path key (issue #27)', () => {

--- a/tests/unit/local/stage-resolver.test.ts
+++ b/tests/unit/local/stage-resolver.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  attachStageContext,
+  buildStageMap,
+  type ResolvedStage,
+} from '../../../src/local/stage-resolver.js';
+import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+
+function tpl(resources: Record<string, TemplateResource>): CloudFormationTemplate {
+  return { Resources: resources };
+}
+
+describe('buildStageMap', () => {
+  it('returns empty map when no Stage resources are present', () => {
+    const m = buildStageMap(
+      tpl({
+        Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('picks the first REST v1 Stage attached to a RestApi by default', () => {
+    // Build the resources record explicitly via an entries array so the
+    // test does not depend on the implementation reading object-literal
+    // insertion order — though ES2015+ guarantees that string keys
+    // iterate in insertion order, the dependence used to be implicit.
+    // ProdStage appears FIRST in the entries below, so it must be
+    // selected when no `--stage` override is set.
+    const orderedEntries: Array<[string, TemplateResource]> = [
+      ['Api', { Type: 'AWS::ApiGateway::RestApi', Properties: {} }],
+      [
+        'ProdStage',
+        {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: {
+            RestApiId: { Ref: 'Api' },
+            StageName: 'prod',
+            Variables: { region: 'us-east-1', dbHost: 'rds.example' },
+          },
+        },
+      ],
+      [
+        'DevStage',
+        {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: {
+            RestApiId: { Ref: 'Api' },
+            StageName: 'dev',
+            Variables: { region: 'us-west-2' },
+          },
+        },
+      ],
+    ];
+    const m = buildStageMap(tpl(Object.fromEntries(orderedEntries)));
+    const stage = m.get('Api');
+    expect(stage).toBeDefined();
+    expect(stage!.stageName).toBe('prod');
+    expect(stage!.apiVersion).toBe('v1');
+    expect(stage!.variables).toEqual({ region: 'us-east-1', dbHost: 'rds.example' });
+  });
+
+  it('selects the matching Stage when --stage override is provided', () => {
+    const m = buildStageMap(
+      tpl({
+        Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+        ProdStage: {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: {
+            RestApiId: { Ref: 'Api' },
+            StageName: 'prod',
+            Variables: { stage: 'prod' },
+          },
+        },
+        DevStage: {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: {
+            RestApiId: { Ref: 'Api' },
+            StageName: 'dev',
+            Variables: { stage: 'dev' },
+          },
+        },
+      }),
+      'dev'
+    );
+    expect(m.get('Api')!.stageName).toBe('dev');
+    expect(m.get('Api')!.variables).toEqual({ stage: 'dev' });
+  });
+
+  it('omits the API entry when --stage override does not match any Stage', () => {
+    const m = buildStageMap(
+      tpl({
+        Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+        ProdStage: {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: { RestApiId: { Ref: 'Api' }, StageName: 'prod' },
+        },
+      }),
+      'staging'
+    );
+    expect(m.has('Api')).toBe(false);
+  });
+
+  it('reads StageVariables from HTTP API v2 Stage', () => {
+    const m = buildStageMap(
+      tpl({
+        Api: {
+          Type: 'AWS::ApiGatewayV2::Api',
+          Properties: { ProtocolType: 'HTTP' },
+        },
+        Stage: {
+          Type: 'AWS::ApiGatewayV2::Stage',
+          Properties: {
+            ApiId: { Ref: 'Api' },
+            StageName: '$default',
+            StageVariables: { theme: 'dark' },
+          },
+        },
+      })
+    );
+    expect(m.get('Api')!.apiVersion).toBe('v2');
+    expect(m.get('Api')!.variables).toEqual({ theme: 'dark' });
+  });
+
+  it('drops intrinsic-valued variables and emits null when nothing literal remains', () => {
+    const m = buildStageMap(
+      tpl({
+        Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+        Stage: {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: {
+            RestApiId: { Ref: 'Api' },
+            StageName: 'prod',
+            Variables: {
+              dynamicHost: { 'Fn::GetAtt': ['Bucket', 'WebsiteURL'] },
+            },
+          },
+        },
+      })
+    );
+    expect(m.get('Api')!.variables).toBeNull();
+  });
+
+  it('keeps literal entries when only some variables are intrinsic', () => {
+    const m = buildStageMap(
+      tpl({
+        Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+        Stage: {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: {
+            RestApiId: { Ref: 'Api' },
+            StageName: 'prod',
+            Variables: {
+              region: 'us-east-1',
+              dynamicHost: { 'Fn::GetAtt': ['Bucket', 'WebsiteURL'] },
+            },
+          },
+        },
+      })
+    );
+    expect(m.get('Api')!.variables).toEqual({ region: 'us-east-1' });
+  });
+
+  it('treats a Stage with no Variables block as null variables', () => {
+    const m = buildStageMap(
+      tpl({
+        Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+        Stage: {
+          Type: 'AWS::ApiGateway::Stage',
+          Properties: { RestApiId: { Ref: 'Api' }, StageName: 'prod' },
+        },
+      })
+    );
+    expect(m.get('Api')!.variables).toBeNull();
+  });
+});
+
+describe('attachStageContext', () => {
+  function route(over: Partial<DiscoveredRoute>): DiscoveredRoute {
+    return {
+      method: 'GET',
+      pathPattern: '/x',
+      lambdaLogicalId: 'L',
+      source: 'rest-v1',
+      apiVersion: 'v1',
+      stage: '$default',
+      declaredAt: 'S/M',
+      ...over,
+    };
+  }
+
+  it('overrides stage name + sets variables on REST v1 routes', () => {
+    const routes = [route({ apiLogicalId: 'Api', source: 'rest-v1', apiVersion: 'v1' })];
+    const stageMap = new Map<string, ResolvedStage>([
+      [
+        'Api',
+        {
+          stageLogicalId: 'Stage',
+          stageName: 'prod',
+          apiVersion: 'v1',
+          variables: { foo: 'bar' },
+        },
+      ],
+    ]);
+    attachStageContext(routes, stageMap);
+    expect(routes[0]!.stage).toBe('prod');
+    expect(routes[0]!.stageVariables).toEqual({ foo: 'bar' });
+  });
+
+  it('overrides stage name + sets variables on HTTP API v2 routes too (named v2 stages are surfaced)', () => {
+    // Pre-issue #241 item 4: v2 routes kept `stage: '$default'` even
+    // when the template carried a named v2 Stage. AWS supports named
+    // stages on HTTP API v2 (CreateStage accepts any name), so the
+    // local event should mirror what the deployed endpoint would emit.
+    const routes = [route({ apiLogicalId: 'Api', source: 'http-api', apiVersion: 'v2' })];
+    const stageMap = new Map<string, ResolvedStage>([
+      [
+        'Api',
+        {
+          stageLogicalId: 'Stage',
+          stageName: 'prod',
+          apiVersion: 'v2',
+          variables: { foo: 'bar' },
+        },
+      ],
+    ]);
+    attachStageContext(routes, stageMap);
+    expect(routes[0]!.stage).toBe('prod');
+    expect(routes[0]!.stageVariables).toEqual({ foo: 'bar' });
+  });
+
+  it('keeps stage at $default when the resolved v2 Stage is named $default', () => {
+    const routes = [route({ apiLogicalId: 'Api', source: 'http-api', apiVersion: 'v2' })];
+    const stageMap = new Map<string, ResolvedStage>([
+      [
+        'Api',
+        {
+          stageLogicalId: 'Stage',
+          stageName: '$default',
+          apiVersion: 'v2',
+          variables: { theme: 'dark' },
+        },
+      ],
+    ]);
+    attachStageContext(routes, stageMap);
+    expect(routes[0]!.stage).toBe('$default');
+    expect(routes[0]!.stageVariables).toEqual({ theme: 'dark' });
+  });
+
+  it('sets stageVariables: null on Function URL routes (no apiLogicalId)', () => {
+    const routes = [route({ source: 'function-url', apiVersion: 'v2' })];
+    attachStageContext(routes, new Map());
+    expect(routes[0]!.stageVariables).toBeNull();
+  });
+
+  it('sets stageVariables: null when apiLogicalId is absent from stageMap', () => {
+    const routes = [route({ apiLogicalId: 'Api', source: 'http-api', apiVersion: 'v2' })];
+    attachStageContext(routes, new Map());
+    expect(routes[0]!.stageVariables).toBeNull();
+    // stage stays at the discovery-time default
+    expect(routes[0]!.stage).toBe('$default');
+  });
+
+  it('handles a per-API stage override mismatch (--stage prod matches API A only)', () => {
+    // API A has a `prod` Stage; API B only has `dev`. With `--stage
+    // prod`, A enters the stage map, B is left out. attachStageContext
+    // sets variables on A's routes, leaves B's routes with
+    // stageVariables: null + stage at the default placeholder.
+    const m = buildStageMap(
+      tpl({
+        ApiA: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+        ApiAStage: {
+          Type: 'AWS::ApiGatewayV2::Stage',
+          Properties: {
+            ApiId: { Ref: 'ApiA' },
+            StageName: 'prod',
+            StageVariables: { region: 'us-east-1' },
+          },
+        },
+        ApiB: { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+        ApiBStage: {
+          Type: 'AWS::ApiGatewayV2::Stage',
+          Properties: {
+            ApiId: { Ref: 'ApiB' },
+            StageName: 'dev',
+            StageVariables: { region: 'us-west-2' },
+          },
+        },
+      }),
+      'prod'
+    );
+    expect(m.has('ApiA')).toBe(true);
+    expect(m.has('ApiB')).toBe(false);
+    const routes = [
+      route({ apiLogicalId: 'ApiA', source: 'http-api', apiVersion: 'v2' }),
+      route({
+        apiLogicalId: 'ApiB',
+        source: 'http-api',
+        apiVersion: 'v2',
+        pathPattern: '/b',
+      }),
+    ];
+    attachStageContext(routes, m);
+    expect(routes[0]!.stageVariables).toEqual({ region: 'us-east-1' });
+    expect(routes[1]!.stageVariables).toBeNull();
+    // ApiA matched the `prod` Stage, so its v2 route gets stage='prod'
+    // (issue #241 item 4 — v2 named stages are now surfaced through
+    // requestContext.stage, not silently flattened to $default). ApiB
+    // has no matching Stage in the map, so the discovery-time
+    // placeholder ($default for HTTP API v2) is preserved.
+    expect(routes[0]!.stage).toBe('prod');
+    expect(routes[1]!.stage).toBe('$default');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 Batch B slice 4 **prerequisite**: re-export three more `src/local/**` leaf modules from cdk-local's package entry (`src/index.ts`) so cdkd can convert its byte-identical copies into thin `export … from 'cdk-local'` shims. Exports are driven by cdkd's actual imports — nothing speculative:

- **env-resolver** — `resolveEnvVars`, `EnvOverrideFile` (invoke / start-api Lambda env-var resolution)
- **stage-resolver** — `buildStageMap`, `attachStageContext`, `ResolvedStage` (start-api per-API Stage selection)
- **cloud-map-registry** — `CloudMapRegistry` (start-service in-process Cloud Map service registry)

### Tests

- `stage-resolver` and `cloud-map-registry` had no unit test in cdk-local → ported cdkd's verbatim (identical relative import paths). `cloud-map-registry`'s namespace fixtures rebranded `cdkd-local.local` → `cdkl.local` for self-containment.
- `env-resolver` already had an independent suite here (20 tests). Added the one case cdkd's suite had that this lacked — *"substitutes the template intrinsic with an override when provided"* (asserts `unresolved` still reports a template-level intrinsic even when an override makes it concrete) — so coverage is preserved once cdkd deletes its copy. Now 21 tests.
- `docs/library-mode.md` building-blocks list updated.

### Deferred from this cluster

`cloud-map-resolver` was a candidate but is **deferred to the ECS cluster slice**: it `throw new EcsTaskResolutionError(...)` (imported from the still-local `ecs-task-resolver`), and its test asserts `toThrow(EcsTaskResolutionError)` against that local class. A shim would throw cdk-local's *bundled* `EcsTaskResolutionError` — a different class identity — failing the `instanceof` check. It must ship together with `ecs-task-resolver`.

## Test plan

- [x] `vp check --fix` green — 80 files
- [x] `vp run build` green — 10 files
- [x] `vp run test` — 47 files / 610 tests pass (env-resolver 21, stage-resolver 14, cloud-map-registry 21)
- [ ] `integ` gate (Docker local-execution) — required for merge (`src/**` touched); pure export-surface + test change, no runtime behavior change
