### PR TITLE
feat(exports): expose RegistrationHandle type from cloud-map-registry

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -127,8 +127,10 @@ The `invoke` / `start-api` env-var and stage layers, plus the
 - `buildStageMap` / `attachStageContext` (+ `ResolvedStage`) — per-API
   Stage selection; attaches stage context (`event.stageVariables`) to
   discovered routes.
-- `CloudMapRegistry` — in-process Cloud Map service registry so peers
-  reach each other by IP / network alias on the shared service network.
+- `CloudMapRegistry` (+ `RegistrationHandle`) — in-process Cloud Map
+  service registry so peers reach each other by IP / network alias on the
+  shared service network; `RegistrationHandle` is the handle returned by
+  `register()` for symmetric unregister.
 
 These are stable, side-effect-free utilities; they are exposed for
 1:1 re-export and are not a recommended way to build a custom CLI (use

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,8 @@ export { attachStageContext, buildStageMap, type ResolvedStage } from './local/s
 /**
  * `start-service` in-process Cloud Map service registry — peers reach each
  * other by IP / network alias on the shared service network without docker
- * `network connect` choreography.
+ * `network connect` choreography. `RegistrationHandle` is the handle returned
+ * by `register()` for symmetric unregister; a still-local host sibling (e.g.
+ * the service runner) imports it as a type alongside the class.
  */
-export { CloudMapRegistry } from './local/cloud-map-registry.js';
+export { CloudMapRegistry, type RegistrationHandle } from './local/cloud-map-registry.js';


### PR DESCRIPTION
## Summary

Expose `type RegistrationHandle` from the package entry, alongside the
already-exported `CloudMapRegistry` class:

```ts
export { CloudMapRegistry, type RegistrationHandle } from './local/cloud-map-registry.js';
```

### Why

cdk-local@0.14.0 ([#78](https://github.com/go-to-k/cdk-local/pull/78)) exposed only the `CloudMapRegistry` class — sufficient for the CLI-command importer (`local-start-service`). But a **still-local cdkd host sibling**, `src/local/ecs-service-runner.ts`, imports `RegistrationHandle` as a type alongside the class:

```ts
import type { CloudMapRegistry, RegistrationHandle } from './cloud-map-registry.js';
```

Because `ecs-service-runner.ts` stays local in cdkd (not shimmed yet), once cdkd's `cloud-map-registry.ts` becomes a bare re-export shim, the type `RegistrationHandle` must also be re-exportable from `cdk-local`. With 0.14.0 it was not on the package entry, so the shim would fail typecheck (`no exported member 'RegistrationHandle'`) — which is exactly why cdkd's Phase 3 Batch B slice 4 **deferred** `cloud-map-registry`. This PR unblocks that shim.

`RegistrationHandle` is a self-contained interface (`fqdn` / `ownerKey` strings only — no nested type dependency on `RegisteredEndpoint` / `RegistryListing`, which stay internal since no host consumer imports them). The cloud-map-registry unit test is already ported in #78, so no test change is needed.

Pure export-surface addition — no runtime behavior change.

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) green
- [x] `vp run build` green; `dist/index.d.ts` exposes `type RegistrationHandle`
- [x] `vp run test` — 610 tests pass (47 files)
- [x] docs updated: `docs/library-mode.md` building-blocks list notes `RegistrationHandle` alongside `CloudMapRegistry`
