### PR TITLE
feat(run-task,start-service): remap privileged container ports on macOS

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -650,6 +650,13 @@ each other via a `docker --add-host` DNS overlay.
 > container IP / network alias on the shared docker network; to hit a
 > specific replica from the host, `docker exec` into it or read its IP
 > from `docker inspect`.
+>
+> **macOS privileged ports.** On macOS, a container port below 1024 is
+> published on a non-privileged host port (`hostPort + 8000`, e.g.
+> `80 → 8080`, `443 → 8443`) so the run never triggers Docker Desktop's
+> privileged-port admin-password prompt (`com.docker.vmnetd`). The
+> container port is unchanged; a log line names the actual host port to
+> `curl`. On Linux the host port is left as-is.
 
 ### Target resolution
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1344,6 +1344,13 @@ replica's sidecar.
 > multi-replica service by container IP / network alias on the shared
 > docker network; to hit a specific replica from the host, `docker exec`
 > into it or read its IP from `docker inspect`.
+>
+> **macOS privileged ports.** On macOS, a container port below 1024 is
+> published on a non-privileged host port (`hostPort + 8000`, e.g.
+> `80 → 8080`, `443 → 8443`) so the run never triggers Docker Desktop's
+> privileged-port admin-password prompt (`com.docker.vmnetd`). The
+> container port is unchanged; a log line names the actual host port to
+> `curl`. On Linux the host port is left as-is.
 
 ### `start-service` target resolution
 

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -896,6 +896,29 @@ interface BuildDockerRunArgs {
 }
 
 /**
+ * Resolve the HOST port to publish a container port on.
+ *
+ * On macOS, Docker Desktop binds host ports below 1024 through a
+ * privileged helper (`com.docker.vmnetd`) that prompts for an admin
+ * password — and fails outright when that helper isn't running. A
+ * container that declares e.g. port 80 would otherwise force that prompt
+ * on every `run-task` / `start-service`. To keep the local run
+ * password-free, remap a privileged host port to a non-privileged one by
+ * adding 8000 (80 -> 8080, 443 -> 8443). The container port is unchanged
+ * — only the host side moves — and the caller logs where to reach it.
+ *
+ * Only macOS is affected: on Linux the Docker daemon runs as root and
+ * binds privileged ports directly, so the host port is left as-is to
+ * preserve the `host == container` mapping users expect.
+ *
+ * Exported for unit testing with an explicit `platform`.
+ */
+export function resolvePublishHostPort(hostPort: number, platform: NodeJS.Platform): number {
+  if (platform === 'darwin' && hostPort < 1024) return hostPort + 8000;
+  return hostPort;
+}
+
+/**
  * Build the full `docker run -d` argument list for one container.
  * Exported (no-leading-underscore) so the unit tests can assert against
  * the shape directly without spawning a process.
@@ -959,7 +982,18 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
   if (!opts.skipHostPortPublish) {
     for (const pm of container.portMappings) {
       const hostPort = pm.hostPort ?? pm.containerPort;
-      args.push('-p', `${containerHost}:${hostPort}:${pm.containerPort}/${pm.protocol}`);
+      const publishHostPort = resolvePublishHostPort(hostPort, process.platform);
+      if (publishHostPort !== hostPort) {
+        getLogger()
+          .child('ecs')
+          .info(
+            `Container '${container.name}' container port ${pm.containerPort} published on ` +
+              `${containerHost}:${publishHostPort} (remapped from privileged host port ${hostPort}; ` +
+              'macOS Docker Desktop needs an admin helper to bind ports < 1024). ' +
+              `Reach it at ${containerHost}:${publishHostPort}.`
+          );
+      }
+      args.push('-p', `${containerHost}:${publishHostPort}:${pm.containerPort}/${pm.protocol}`);
     }
   }
 

--- a/tests/unit/local/ecs-publish-host-port.test.ts
+++ b/tests/unit/local/ecs-publish-host-port.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { resolvePublishHostPort } from '../../../src/local/ecs-task-runner.js';
+
+describe('resolvePublishHostPort', () => {
+  it('remaps privileged host ports (<1024) by +8000 on macOS', () => {
+    expect(resolvePublishHostPort(80, 'darwin')).toBe(8080);
+    expect(resolvePublishHostPort(443, 'darwin')).toBe(8443);
+    expect(resolvePublishHostPort(22, 'darwin')).toBe(8022);
+    expect(resolvePublishHostPort(1023, 'darwin')).toBe(9023);
+  });
+
+  it('leaves non-privileged host ports unchanged on macOS', () => {
+    expect(resolvePublishHostPort(1024, 'darwin')).toBe(1024);
+    expect(resolvePublishHostPort(3000, 'darwin')).toBe(3000);
+    expect(resolvePublishHostPort(8080, 'darwin')).toBe(8080);
+  });
+
+  it('never remaps on Linux (daemon runs as root, binds <1024 directly)', () => {
+    expect(resolvePublishHostPort(80, 'linux')).toBe(80);
+    expect(resolvePublishHostPort(443, 'linux')).toBe(443);
+    expect(resolvePublishHostPort(3000, 'linux')).toBe(3000);
+  });
+
+  it('does not remap on win32 (scoped to the confirmed macOS vmnetd case)', () => {
+    expect(resolvePublishHostPort(80, 'win32')).toBe(80);
+  });
+});


### PR DESCRIPTION
## Summary

On macOS, Docker Desktop binds host ports below 1024 through a privileged
helper (`com.docker.vmnetd`) that prompts for an admin password — and
fails outright when the helper isn't running. An ECS container declaring
e.g. port 80 forced that prompt on every `run-task` / `start-service`,
and cancelling it aborted the boot:

```
docker: Error response from daemon: Ports are not available: exposing
port TCP 127.0.0.1:80 ...: failed to connect to
/var/run/com.docker.vmnetd.sock: is vmnetd running?
```

## Fix

Publish a privileged container port on a non-privileged **host** port
instead — `hostPort + 8000` (80 → 8080, 443 → 8443) — when running on
macOS, with a log line naming the actual host port. The container port is
unchanged; only the host side moves. Linux is untouched (the Docker
daemon runs as root and binds privileged ports directly), preserving the
`host == container` mapping users expect there.

- `resolvePublishHostPort(hostPort, platform)` — pure, exported.
- `buildDockerRunArgs` calls it with `process.platform` and logs each
  remap (`container port 80 published on 127.0.0.1:8080 ...`).

## Test plan

- [x] `vp run check` / `vp run build`
- [x] `vp run test` — 48 files, 614 tests
- [x] New `tests/unit/local/ecs-publish-host-port.test.ts`: +8000 remap
      for `<1024` on darwin; unchanged for `>=1024`; never remapped on
      linux / win32; 1024 boundary.
- [x] Live-tested on macOS: a service container declaring port 80 now
      logs "published on 127.0.0.1:8080 (remapped from privileged host
      port 80 ...)" and the container starts with **no admin-password
      prompt** and no `vmnetd` error (previously it required the prompt /
      failed when cancelled).
- [x] Docs note added to the host-port-publishing sections of
      `cli-reference.md` / `local-emulation.md`.
