### PR TITLE
feat(exports): expose runtime-image + websocket-event/mgmt-api primitives

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -131,6 +131,16 @@ The `invoke` / `start-api` env-var and stage layers, plus the
   service registry so peers reach each other by IP / network alias on the
   shared service network; `RegistrationHandle` is the handle returned by
   `register()` for symmetric unregister.
+- `resolveRuntimeImage` / `resolveRuntimeFileExtension` /
+  `resolveRuntimeCodeMountPath` — Lambda `Runtime` → ECR base-image,
+  source-file extension, and in-container code-mount path.
+- `buildConnectEvent` / `buildDisconnectEvent` / `buildMessageEvent`
+  (+ `WebSocketHandshakeSnapshot` / `WebSocketLambdaEvent`) — WebSocket API
+  `$connect` / `$disconnect` / message Lambda event-shape builders.
+- `ConnectionRegistry` / `handleConnectionsRequest` / `parseConnectionsPath` /
+  `buildMgmtEndpointEnvUrl` (+ `ConnectionRegistryEntry`) — WebSocket
+  `@connections` management API: in-process connection registry + the local
+  management-endpoint HTTP handler.
 
 These are stable, side-effect-free utilities; they are exposed for
 1:1 re-export and are not a recommended way to build a custom CLI (use

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,3 +151,41 @@ export { attachStageContext, buildStageMap, type ResolvedStage } from './local/s
  * the service runner) imports it as a type alongside the class.
  */
 export { CloudMapRegistry, type RegistrationHandle } from './local/cloud-map-registry.js';
+
+/**
+ * `invoke` / `start-api` Lambda runtime → ECR base-image + source-file
+ * extension + in-container code-mount-path resolution. Exposed only as the
+ * consuming host's `import` statements require them (the host's runtime-image
+ * shim re-exports exactly these three).
+ */
+export {
+  resolveRuntimeCodeMountPath,
+  resolveRuntimeFileExtension,
+  resolveRuntimeImage,
+} from './local/runtime-image.js';
+
+/**
+ * `start-api` WebSocket API event-shape builders — synthesize the
+ * `$connect` / `$disconnect` / message Lambda event payloads for a local
+ * WebSocket handshake.
+ */
+export {
+  buildConnectEvent,
+  buildDisconnectEvent,
+  buildMessageEvent,
+  type WebSocketHandshakeSnapshot,
+  type WebSocketLambdaEvent,
+} from './local/websocket-event.js';
+
+/**
+ * `start-api` WebSocket `@connections` management API — in-process
+ * connection registry + the local management-endpoint HTTP handler
+ * (POST / GET / DELETE `/@connections/{connectionId}`).
+ */
+export {
+  ConnectionRegistry,
+  type ConnectionRegistryEntry,
+  buildMgmtEndpointEnvUrl,
+  handleConnectionsRequest,
+  parseConnectionsPath,
+} from './local/websocket-mgmt-api.js';

--- a/tests/unit/local/runtime-image.test.ts
+++ b/tests/unit/local/runtime-image.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  isSupportedRuntime,
+  resolveRuntimeCodeMountPath,
+  resolveRuntimeFileExtension,
+  resolveRuntimeImage,
+  resolveRuntimeSpec,
+  UnsupportedRuntimeError,
+} from '../../../src/local/runtime-image.js';
+
+describe('resolveRuntimeImage', () => {
+  it.each([
+    ['nodejs18.x', 'public.ecr.aws/lambda/nodejs:18'],
+    ['nodejs20.x', 'public.ecr.aws/lambda/nodejs:20'],
+    ['nodejs22.x', 'public.ecr.aws/lambda/nodejs:22'],
+    ['nodejs24.x', 'public.ecr.aws/lambda/nodejs:24'],
+    ['python3.11', 'public.ecr.aws/lambda/python:3.11'],
+    ['python3.12', 'public.ecr.aws/lambda/python:3.12'],
+    ['python3.13', 'public.ecr.aws/lambda/python:3.13'],
+    ['python3.14', 'public.ecr.aws/lambda/python:3.14'],
+    ['ruby3.2', 'public.ecr.aws/lambda/ruby:3.2'],
+    ['ruby3.3', 'public.ecr.aws/lambda/ruby:3.3'],
+    ['java8.al2', 'public.ecr.aws/lambda/java:8.al2'],
+    ['java11', 'public.ecr.aws/lambda/java:11'],
+    ['java17', 'public.ecr.aws/lambda/java:17'],
+    ['java21', 'public.ecr.aws/lambda/java:21'],
+    ['dotnet6', 'public.ecr.aws/lambda/dotnet:6'],
+    ['dotnet8', 'public.ecr.aws/lambda/dotnet:8'],
+    ['provided.al2', 'public.ecr.aws/lambda/provided:al2'],
+    ['provided.al2023', 'public.ecr.aws/lambda/provided:al2023'],
+  ])('maps %s to %s', (runtime, expected) => {
+    expect(resolveRuntimeImage(runtime)).toBe(expected);
+  });
+
+  it('rejects empty runtime (this branch is only reached for ZIP Lambdas)', () => {
+    expect(() => resolveRuntimeImage('')).toThrow(UnsupportedRuntimeError);
+    try {
+      resolveRuntimeImage('');
+    } catch (err) {
+      // Container Lambdas now take a different code path (PR 5); this
+      // branch is only reached when a ZIP Lambda has no Runtime
+      // property — which is itself a malformed template.
+      expect((err as Error).message).toMatch(/no Runtime property/);
+    }
+  });
+
+  it('rejects deprecated go1.x with a migration pointer to provided.al2023', () => {
+    expect(() => resolveRuntimeImage('go1.x')).toThrow(UnsupportedRuntimeError);
+    try {
+      resolveRuntimeImage('go1.x');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/deprecated/);
+      expect(msg).toMatch(/2024-01-08/);
+      expect(msg).toMatch(/PROVIDED_AL2023/);
+      expect(msg).toMatch(/bootstrap/);
+    }
+  });
+
+  it('no longer has a "follow in subsequent PRs" deferred branch (every AWS runtime is now either supported or deprecated)', () => {
+    // Pre-#248 the unsupported-runtime path printed "Other runtimes
+    // follow in subsequent PRs". With every Lambda runtime now either
+    // resolved by SUPPORTED_RUNTIMES, special-cased as deprecated
+    // (go1.x), or rejected as unknown, that wording is gone.
+    for (const r of ['nodejs10.x', 'python2.7', 'dotnetcore3.1', 'lolcat1.0']) {
+      try {
+        resolveRuntimeImage(r);
+      } catch (err) {
+        const msg = (err as Error).message;
+        expect(msg).not.toMatch(/follow in subsequent PRs/);
+      }
+    }
+  });
+
+  it('rejects unrecognized java versions through the unknown-runtime branch (java is no longer in the prefix-deferred list)', () => {
+    // java19 has no AWS Lambda base image. With Java now supported, this
+    // should land in the unknown-runtime branch (not the deferred-prefix
+    // branch), so the message lists all supported runtimes — including
+    // the supported Java versions — to route the user to a real version.
+    expect(() => resolveRuntimeImage('java19')).toThrow(/Unknown runtime/);
+    try {
+      resolveRuntimeImage('java19');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/java17/);
+      expect(msg).toMatch(/java21/);
+    }
+  });
+
+  it('rejects unrecognized dotnet versions through the unknown-runtime branch (dotnet is no longer in the prefix-deferred list)', () => {
+    // dotnet9 was added in CDK lib but not yet in cdk-local's supported set.
+    // Now that some dotnet versions are supported, this should land in
+    // the unknown-runtime branch (not the prefix-deferred branch).
+    expect(() => resolveRuntimeImage('dotnet9')).toThrow(/Unknown runtime/);
+    try {
+      resolveRuntimeImage('dotnet9');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/dotnet6/);
+      expect(msg).toMatch(/dotnet8/);
+    }
+  });
+
+  it('rejects unknown runtime strings with a clear message that lists every supported runtime', () => {
+    expect(() => resolveRuntimeImage('lolcat1.0')).toThrow(/Unknown runtime/);
+    try {
+      resolveRuntimeImage('lolcat1.0');
+    } catch (err) {
+      const msg = (err as Error).message;
+      // The "supported runtimes" line should mention Node, Python, Ruby, and Java.
+      expect(msg).toMatch(/nodejs20\.x/);
+      expect(msg).toMatch(/nodejs24\.x/);
+      expect(msg).toMatch(/python3\.12/);
+      expect(msg).toMatch(/python3\.14/);
+      expect(msg).toMatch(/ruby3\.2/);
+      expect(msg).toMatch(/ruby3\.3/);
+      expect(msg).toMatch(/java11/);
+      expect(msg).toMatch(/java8\.al2/);
+      expect(msg).toMatch(/java17/);
+      expect(msg).toMatch(/java21/);
+      expect(msg).toMatch(/dotnet6/);
+      expect(msg).toMatch(/dotnet8/);
+      expect(msg).toMatch(/provided\.al2/);
+      expect(msg).toMatch(/provided\.al2023/);
+    }
+  });
+});
+
+describe('resolveRuntimeFileExtension', () => {
+  it.each([
+    ['nodejs18.x', '.js'],
+    ['nodejs20.x', '.js'],
+    ['nodejs22.x', '.js'],
+    ['nodejs24.x', '.js'],
+    ['python3.11', '.py'],
+    ['python3.12', '.py'],
+    ['python3.13', '.py'],
+    ['python3.14', '.py'],
+    ['ruby3.2', '.rb'],
+    ['ruby3.3', '.rb'],
+  ])('maps %s to %s', (runtime, expected) => {
+    expect(resolveRuntimeFileExtension(runtime)).toBe(expected);
+  });
+
+  it('rejects unsupported runtimes the same way resolveRuntimeImage does', () => {
+    expect(() => resolveRuntimeFileExtension('go1.x')).toThrow(UnsupportedRuntimeError);
+    expect(() => resolveRuntimeFileExtension('')).toThrow(UnsupportedRuntimeError);
+  });
+
+  it.each([
+    'java8.al2',
+    'java11',
+    'java17',
+    'java21',
+    'dotnet6',
+    'dotnet8',
+    'provided.al2',
+    'provided.al2023',
+  ])(
+    'rejects inline Code.ZipFile for compiled-artifact runtime %s with a message routing to Code.fromAsset',
+    (runtime) => {
+      expect(() => resolveRuntimeFileExtension(runtime)).toThrow(UnsupportedRuntimeError);
+      try {
+        resolveRuntimeFileExtension(runtime);
+      } catch (err) {
+        const msg = (err as Error).message;
+        expect(msg).toMatch(/Inline 'Code\.ZipFile' is not supported/);
+        expect(msg).toMatch(/lambda\.Code\.fromAsset/);
+        expect(msg).toContain(runtime);
+      }
+    }
+  );
+});
+
+describe('resolveRuntimeSpec', () => {
+  it('returns both image and fileExtension in one shot', () => {
+    expect(resolveRuntimeSpec('python3.12')).toEqual({
+      image: 'public.ecr.aws/lambda/python:3.12',
+      fileExtension: '.py',
+    });
+    expect(resolveRuntimeSpec('nodejs22.x')).toEqual({
+      image: 'public.ecr.aws/lambda/nodejs:22',
+      fileExtension: '.js',
+    });
+    expect(resolveRuntimeSpec('ruby3.3')).toEqual({
+      image: 'public.ecr.aws/lambda/ruby:3.3',
+      fileExtension: '.rb',
+    });
+  });
+
+  it('returns fileExtension: null for Java entries — inline materialization is unsupported (use Code.fromAsset)', () => {
+    expect(resolveRuntimeSpec('java17')).toEqual({
+      image: 'public.ecr.aws/lambda/java:17',
+      fileExtension: null,
+    });
+    expect(resolveRuntimeSpec('java8.al2')).toEqual({
+      image: 'public.ecr.aws/lambda/java:8.al2',
+      fileExtension: null,
+    });
+  });
+
+  it('returns fileExtension: null for .NET entries — inline materialization is unsupported (use Code.fromAsset)', () => {
+    expect(resolveRuntimeSpec('dotnet8')).toEqual({
+      image: 'public.ecr.aws/lambda/dotnet:8',
+      fileExtension: null,
+    });
+    expect(resolveRuntimeSpec('dotnet6')).toEqual({
+      image: 'public.ecr.aws/lambda/dotnet:6',
+      fileExtension: null,
+    });
+  });
+
+  it('returns fileExtension: null for OS-only provided.* entries — host an arbitrary bootstrap binary via Code.fromAsset', () => {
+    expect(resolveRuntimeSpec('provided.al2023')).toEqual({
+      image: 'public.ecr.aws/lambda/provided:al2023',
+      fileExtension: null,
+    });
+    expect(resolveRuntimeSpec('provided.al2')).toEqual({
+      image: 'public.ecr.aws/lambda/provided:al2',
+      fileExtension: null,
+    });
+  });
+});
+
+describe('resolveRuntimeCodeMountPath', () => {
+  it.each([
+    'nodejs20.x',
+    'nodejs24.x',
+    'python3.12',
+    'python3.14',
+    'ruby3.3',
+    'java17',
+    'java8.al2',
+    'dotnet8',
+    'dotnet6',
+  ])('returns /var/task for non-provided runtime %s', (runtime) => {
+    expect(resolveRuntimeCodeMountPath(runtime)).toBe('/var/task');
+  });
+
+  it.each(['provided.al2', 'provided.al2023'])(
+    'returns /var/runtime for provided.* runtime %s (Lambda base image hardcodes the bootstrap path)',
+    (runtime) => {
+      expect(resolveRuntimeCodeMountPath(runtime)).toBe('/var/runtime');
+    }
+  );
+
+  it('throws for unsupported runtimes — validation matches resolveRuntimeImage', () => {
+    expect(() => resolveRuntimeCodeMountPath('go1.x')).toThrow(UnsupportedRuntimeError);
+    expect(() => resolveRuntimeCodeMountPath('lolcat1.0')).toThrow(UnsupportedRuntimeError);
+    expect(() => resolveRuntimeCodeMountPath('')).toThrow(UnsupportedRuntimeError);
+  });
+});
+
+describe('isSupportedRuntime', () => {
+  it('returns true for every current AWS Lambda runtime, false otherwise', () => {
+    expect(isSupportedRuntime('nodejs20.x')).toBe(true);
+    expect(isSupportedRuntime('nodejs24.x')).toBe(true);
+    expect(isSupportedRuntime('python3.12')).toBe(true);
+    expect(isSupportedRuntime('python3.11')).toBe(true);
+    expect(isSupportedRuntime('python3.13')).toBe(true);
+    expect(isSupportedRuntime('python3.14')).toBe(true);
+    expect(isSupportedRuntime('ruby3.2')).toBe(true);
+    expect(isSupportedRuntime('ruby3.3')).toBe(true);
+    expect(isSupportedRuntime('java8.al2')).toBe(true);
+    expect(isSupportedRuntime('java11')).toBe(true);
+    expect(isSupportedRuntime('java17')).toBe(true);
+    expect(isSupportedRuntime('java21')).toBe(true);
+    expect(isSupportedRuntime('dotnet6')).toBe(true);
+    expect(isSupportedRuntime('dotnet8')).toBe(true);
+    expect(isSupportedRuntime('provided.al2')).toBe(true);
+    expect(isSupportedRuntime('provided.al2023')).toBe(true);
+    // Deprecated / unknown runtimes don't count as supported (they go
+    // through the rejection / unknown-runtime branches in resolveRuntimeSpec).
+    expect(isSupportedRuntime('go1.x')).toBe(false);
+    expect(isSupportedRuntime('ruby3.1')).toBe(false);
+    expect(isSupportedRuntime('python3.10')).toBe(false);
+    expect(isSupportedRuntime('java19')).toBe(false);
+    expect(isSupportedRuntime('java8')).toBe(false);
+    expect(isSupportedRuntime('dotnet9')).toBe(false);
+    expect(isSupportedRuntime('dotnetcore3.1')).toBe(false);
+    expect(isSupportedRuntime('provided')).toBe(false);
+    expect(isSupportedRuntime('')).toBe(false);
+  });
+});

--- a/tests/unit/local/websocket-event.test.ts
+++ b/tests/unit/local/websocket-event.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildConnectEvent,
+  buildDisconnectEvent,
+  buildMessageEvent,
+  type WebSocketHandshakeSnapshot,
+} from '../../../src/local/websocket-event.js';
+
+const baseSnapshot: WebSocketHandshakeSnapshot = {
+  headers: {
+    'Sec-WebSocket-Protocol': ['chat.v1'],
+    'X-Forwarded-For': ['10.0.0.1', '10.0.0.2'],
+  },
+  rawQueryString: 'auth=token&id=42',
+  queryStringParameters: { auth: 'token', id: '42' },
+  multiValueQueryStringParameters: { auth: ['token'], id: ['42'] },
+  sourceIp: '127.0.0.1',
+  userAgent: 'wscat/1.0',
+};
+
+describe('buildConnectEvent', () => {
+  it('produces a CONNECT event with lowercased headers and stable request context', () => {
+    const event = buildConnectEvent({
+      connectionId: 'conn-1',
+      connectedAt: 1_700_000_000_000,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+    });
+
+    expect(event.body).toBe('');
+    expect(event.isBase64Encoded).toBe(false);
+    expect(event.headers?.['sec-websocket-protocol']).toBe('chat.v1');
+    expect(event.headers?.['x-forwarded-for']).toBe('10.0.0.1,10.0.0.2');
+    expect(event.multiValueHeaders?.['x-forwarded-for']).toEqual(['10.0.0.1', '10.0.0.2']);
+    expect(event.queryStringParameters).toEqual({ auth: 'token', id: '42' });
+
+    expect(event.requestContext.eventType).toBe('CONNECT');
+    expect(event.requestContext.routeKey).toBe('$connect');
+    expect(event.requestContext.connectionId).toBe('conn-1');
+    expect(event.requestContext.connectedAt).toBe(1_700_000_000_000);
+    expect(event.requestContext.stage).toBe('prod');
+    expect(event.requestContext.apiId).toBe('local');
+    expect(event.requestContext.domainName).toBe('localhost');
+    expect(event.requestContext.authorizer).toBeNull();
+    expect(event.requestContext.identity.sourceIp).toBe('127.0.0.1');
+    expect(event.requestContext.identity.userAgent).toBe('wscat/1.0');
+    // #531 N1 + m3-code: AWS-deployed WebSocket events carry
+    // `requestContext.identity.accountId`; local emulation populates it
+    // from the shared mock account so handler code reading the field is
+    // non-undefined.
+    expect(event.requestContext.identity.accountId).toBe('123456789012');
+    expect(event.requestContext.messageDirection).toBe('IN');
+    expect(typeof event.requestContext.requestId).toBe('string');
+    expect(event.requestContext.requestId.length).toBeGreaterThan(0);
+    expect(event.requestContext.requestId).not.toBe(event.requestContext.extendedRequestId);
+  });
+
+  it('falls back to 127.0.0.1 + empty UA when snapshot omits them', () => {
+    const event = buildConnectEvent({
+      connectionId: 'conn-2',
+      connectedAt: 0,
+      stage: 'local',
+      snapshot: { headers: {}, rawQueryString: '' },
+    });
+    expect(event.headers).toBeUndefined();
+    expect(event.multiValueHeaders).toBeUndefined();
+    expect(event.queryStringParameters).toBeNull();
+    expect(event.multiValueQueryStringParameters).toBeNull();
+    expect(event.requestContext.identity.sourceIp).toBe('127.0.0.1');
+    expect(event.requestContext.identity.userAgent).toBe('');
+  });
+
+  it('formats requestTime in AWS dd/MMM/yyyy:HH:mm:ss +0000 shape', () => {
+    const event = buildConnectEvent({
+      connectionId: 'c',
+      connectedAt: 0,
+      stage: 'local',
+      snapshot: baseSnapshot,
+    });
+    expect(event.requestContext.requestTime).toMatch(
+      /^\d{2}\/[A-Z][a-z]{2}\/\d{4}:\d{2}:\d{2}:\d{2} \+0000$/
+    );
+  });
+});
+
+describe('buildMessageEvent', () => {
+  it('produces a MESSAGE event with the resolved routeKey and messageId', () => {
+    const event = buildMessageEvent({
+      connectionId: 'c',
+      connectedAt: 1,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+      routeKey: 'sendMessage',
+      body: '{"hello":"world"}',
+      isBase64Encoded: false,
+    });
+    expect(event.requestContext.eventType).toBe('MESSAGE');
+    expect(event.requestContext.routeKey).toBe('sendMessage');
+    expect(event.body).toBe('{"hello":"world"}');
+    expect(event.isBase64Encoded).toBe(false);
+    expect(typeof event.requestContext['messageId']).toBe('string');
+  });
+
+  it('passes through binary body strings (caller already encoded)', () => {
+    const event = buildMessageEvent({
+      connectionId: 'c',
+      connectedAt: 1,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+      routeKey: '$default',
+      body: 'aGVsbG8=',
+      isBase64Encoded: false,
+    });
+    expect(event.body).toBe('aGVsbG8=');
+    expect(event.requestContext.routeKey).toBe('$default');
+  });
+
+  // B3 (#526): isBase64Encoded MUST round-trip from the caller — pre-fix
+  // it was hardcoded `false`, silently corrupting every binary frame
+  // because the AWS-canonical handler decoded the base64-encoded body as
+  // UTF-8: `Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')`.
+  it('surfaces isBase64Encoded=true for binary frames (B3 regression guard)', () => {
+    const event = buildMessageEvent({
+      connectionId: 'c',
+      connectedAt: 1,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+      routeKey: '$default',
+      body: 'aGVsbG8gd29ybGQ=', // base64 of "hello world"
+      isBase64Encoded: true,
+    });
+    expect(event.isBase64Encoded).toBe(true);
+    expect(event.body).toBe('aGVsbG8gd29ybGQ=');
+  });
+
+  it('round-trips both isBase64Encoded values via the same field shape', () => {
+    const textEvent = buildMessageEvent({
+      connectionId: 'c',
+      connectedAt: 1,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+      routeKey: 'r',
+      body: 'plaintext',
+      isBase64Encoded: false,
+    });
+    const binaryEvent = buildMessageEvent({
+      connectionId: 'c',
+      connectedAt: 1,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+      routeKey: 'r',
+      body: 'AQID', // base64 bytes
+      isBase64Encoded: true,
+    });
+    // Same shape, only isBase64Encoded + body differ.
+    expect(Object.keys(textEvent).sort()).toEqual(Object.keys(binaryEvent).sort());
+    expect(textEvent.isBase64Encoded).toBe(false);
+    expect(binaryEvent.isBase64Encoded).toBe(true);
+  });
+});
+
+describe('buildDisconnectEvent', () => {
+  it('produces a DISCONNECT event with status code + reason from close frame', () => {
+    const event = buildDisconnectEvent({
+      connectionId: 'c',
+      connectedAt: 100,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+      disconnectStatusCode: 1001,
+      disconnectReason: 'going-away',
+    });
+    expect(event.requestContext.eventType).toBe('DISCONNECT');
+    expect(event.requestContext.routeKey).toBe('$disconnect');
+    expect(event.requestContext['disconnectStatusCode']).toBe(1001);
+    expect(event.requestContext['disconnectReason']).toBe('going-away');
+    expect(event.body).toBe('');
+  });
+
+  it('omits status code / reason when not provided', () => {
+    const event = buildDisconnectEvent({
+      connectionId: 'c',
+      connectedAt: 100,
+      stage: 'prod',
+      snapshot: baseSnapshot,
+    });
+    expect(event.requestContext['disconnectStatusCode']).toBeUndefined();
+    expect(event.requestContext['disconnectReason']).toBeUndefined();
+  });
+});

--- a/tests/unit/local/websocket-mgmt-api.test.ts
+++ b/tests/unit/local/websocket-mgmt-api.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Socket } from 'node:net';
+import { EventEmitter } from 'node:events';
+import {
+  buildMgmtEndpointEnvUrl,
+  ConnectionRegistry,
+  handleConnectionsRequest,
+  parseConnectionsPath,
+  readRequestBody,
+  type ConnectionRegistryEntry,
+} from '../../../src/local/websocket-mgmt-api.js';
+import type { WebSocket } from 'ws';
+
+/**
+ * Minimal in-memory WebSocket fake — the management-API code calls
+ * .send / .close / reads .readyState / .OPEN, nothing else.
+ */
+class FakeWebSocket extends EventEmitter {
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readyState = 1;
+  sent: Array<Buffer | string> = [];
+  closed: { code?: number; reason?: string } | null = null;
+  send(payload: Buffer | string): void {
+    this.sent.push(payload);
+  }
+  close(code?: number, reason?: string): void {
+    this.closed = { code, reason };
+    this.readyState = this.CLOSING;
+  }
+}
+
+function newRequest(method: string, url: string, body?: string): IncomingMessage {
+  const socket = new Socket();
+  const req = new IncomingMessage(socket);
+  req.method = method;
+  req.url = url;
+  if (body !== undefined) {
+    process.nextTick(() => {
+      req.emit('data', Buffer.from(body, 'utf-8'));
+      req.emit('end');
+    });
+  } else {
+    process.nextTick(() => req.emit('end'));
+  }
+  return req;
+}
+
+function newResponse(): {
+  res: ServerResponse;
+  status: () => number;
+  body: () => string;
+  headers: () => Record<string, string | number | string[]>;
+} {
+  const socket = new Socket();
+  const req = new IncomingMessage(socket);
+  const res = new ServerResponse(req);
+  const chunks: Buffer[] = [];
+  // Catch write/end output for inspection.
+  const origWrite = res.write.bind(res);
+  res.write = ((chunk: Buffer | string) => {
+    if (Buffer.isBuffer(chunk)) chunks.push(chunk);
+    else chunks.push(Buffer.from(chunk));
+    return origWrite(chunk);
+  }) as typeof res.write;
+  const origEnd = res.end.bind(res);
+  res.end = ((chunk?: Buffer | string) => {
+    if (chunk) {
+      if (Buffer.isBuffer(chunk)) chunks.push(chunk);
+      else chunks.push(Buffer.from(chunk));
+    }
+    return origEnd();
+  }) as typeof res.end;
+  return {
+    res,
+    status: () => res.statusCode,
+    body: () => Buffer.concat(chunks).toString('utf-8'),
+    headers: () =>
+      res.getHeaders() as unknown as Record<string, string | number | string[]>,
+  };
+}
+
+describe('parseConnectionsPath', () => {
+  it('matches /@connections/<id>', () => {
+    expect(parseConnectionsPath('/@connections/abc-123')).toEqual({ connectionId: 'abc-123' });
+  });
+  it('matches /@connections/<id>/ (trailing slash)', () => {
+    expect(parseConnectionsPath('/@connections/abc-123/')).toEqual({ connectionId: 'abc-123' });
+  });
+  it('strips ?query', () => {
+    expect(parseConnectionsPath('/@connections/abc?Action=PostToConnection')).toEqual({
+      connectionId: 'abc',
+    });
+  });
+  it('decodes URL-encoded connection ids', () => {
+    expect(parseConnectionsPath('/@connections/conn%2Bid')).toEqual({ connectionId: 'conn+id' });
+  });
+  it('returns null for non-matching URLs', () => {
+    expect(parseConnectionsPath('/users/abc')).toBeNull();
+    expect(parseConnectionsPath('/@connections')).toBeNull();
+    expect(parseConnectionsPath('/@connections/')).toBeNull();
+  });
+  it('returns null for malformed percent-escapes', () => {
+    expect(parseConnectionsPath('/@connections/abc%2x')).toBeNull();
+  });
+
+  // B1 (#526): AWS-docs-canonical handler shape calls
+  // `POST /<stage>/@connections/<id>`, where <stage> matches the
+  // deployed apigatewaymanagementapi endpoint URL. The pre-fix regex
+  // rejected this shape and SDK calls built from `domainName + stage`
+  // hit a 404 against the local mgmt API. Verify the new accepted
+  // shapes work end-to-end.
+  it('matches /<stage>/@connections/<id> (AWS-docs-canonical with stage prefix)', () => {
+    expect(parseConnectionsPath('/prod/@connections/abc-123')).toEqual({
+      connectionId: 'abc-123',
+    });
+    expect(parseConnectionsPath('/dev/@connections/abc-123')).toEqual({
+      connectionId: 'abc-123',
+    });
+    expect(parseConnectionsPath('/local/@connections/abc-123')).toEqual({
+      connectionId: 'abc-123',
+    });
+  });
+  it('matches /<stage>/@connections/<id>/ (stage prefix + trailing slash)', () => {
+    expect(parseConnectionsPath('/prod/@connections/abc-123/')).toEqual({
+      connectionId: 'abc-123',
+    });
+  });
+  it('matches /<stage>/@connections/<id>?query (stage prefix + query string)', () => {
+    expect(
+      parseConnectionsPath('/prod/@connections/abc?Action=PostToConnection')
+    ).toEqual({
+      connectionId: 'abc',
+    });
+  });
+  it('decodes URL-encoded connection ids when stage prefix is present', () => {
+    expect(parseConnectionsPath('/prod/@connections/conn%2Bid')).toEqual({
+      connectionId: 'conn+id',
+    });
+  });
+  it('still rejects two-segment paths without @connections', () => {
+    expect(parseConnectionsPath('/prod/users/abc')).toBeNull();
+    expect(parseConnectionsPath('/prod/@conn/abc')).toBeNull();
+  });
+  it('rejects multi-segment stage prefixes (only ONE segment before @connections)', () => {
+    // Two segments before @connections — would match if regex allowed
+    // greedy prefixes, but we only accept ONE optional segment.
+    expect(parseConnectionsPath('/v1/prod/@connections/abc')).toBeNull();
+  });
+
+  // Issue #537 item 9: B1 regex edge cases. These all flow through
+  // `^/(?:[^/]+/)?@connections/([^/]+)/?$` — pin the behavior so a
+  // regex rewrite in the future surfaces the change in CI.
+  it('rejects double-slash before @connections (empty stage segment)', () => {
+    // `//@connections/abc` reads as stage='' under a permissive prefix.
+    // Our regex requires `[^/]+/` (>=1 char) so this correctly fails.
+    expect(parseConnectionsPath('//@connections/abc')).toBeNull();
+  });
+  it('rejects a trailing path segment after the connection id', () => {
+    // `/@connections/abc/extra` — the trailing `/extra` is unknown to
+    // the AWS API plane and must not be silently truncated.
+    expect(parseConnectionsPath('/@connections/abc/extra')).toBeNull();
+    expect(parseConnectionsPath('/prod/@connections/abc/extra')).toBeNull();
+  });
+  it('matches a single trailing slash with no stage prefix', () => {
+    // Already covered above; pinned here as a sibling assertion to the
+    // stage-prefix + trailing-slash test for the no-stage form.
+    expect(parseConnectionsPath('/@connections/abc/')).toEqual({ connectionId: 'abc' });
+  });
+});
+
+// Issue #537 item 7: assert the Lambda-container env-var URL includes
+// `/<stage>`. The pre-fix CLI dropped the stage segment and any
+// SDK-built `POST /<stage>/@connections/<id>` hit a 404 against the
+// local parser. Producer (this helper) + consumer
+// (parseConnectionsPath) live in lockstep — a regression here would
+// re-introduce the 404.
+describe('buildMgmtEndpointEnvUrl', () => {
+  it('produces http://<host>:<port>/<stage> with the stage suffix', () => {
+    expect(buildMgmtEndpointEnvUrl('host.docker.internal', 4001, 'prod')).toBe(
+      'http://host.docker.internal:4001/prod'
+    );
+  });
+  it('does NOT drop the stage suffix (B1 #526 regression guard)', () => {
+    const url = buildMgmtEndpointEnvUrl('host.docker.internal', 4001, 'prod');
+    expect(url.endsWith('/prod')).toBe(true);
+  });
+  it('output is parseable end-to-end by parseConnectionsPath', () => {
+    // Simulate the round-trip: SDK builds the per-connection URL from
+    // the env-var endpoint + the AWS-deployed shape; the local server
+    // must accept it. Pins the producer/consumer contract on one test.
+    const env = buildMgmtEndpointEnvUrl('host.docker.internal', 4001, 'prod');
+    const stagePath = new URL(env).pathname; // '/prod'
+    const sdkPath = `${stagePath}/@connections/conn-1`; // '/prod/@connections/conn-1'
+    expect(parseConnectionsPath(sdkPath)).toEqual({ connectionId: 'conn-1' });
+  });
+});
+
+describe('ConnectionRegistry', () => {
+  it('registers + retrieves + unregisters connections', () => {
+    const reg = new ConnectionRegistry();
+    const socket = new FakeWebSocket() as unknown as WebSocket;
+    const entry: ConnectionRegistryEntry = {
+      connectionId: 'c1',
+      socket,
+      connectedAt: 100,
+      apiLogicalId: 'WsApi',
+      stage: 'prod',
+    };
+    reg.register(entry);
+    expect(reg.get('c1')).toBe(entry);
+    expect(reg.size()).toBe(1);
+    const removed = reg.unregister('c1');
+    expect(removed).toBe(entry);
+    expect(reg.size()).toBe(0);
+    expect(reg.get('c1')).toBeUndefined();
+  });
+
+  it('unregister returns undefined for an unknown id', () => {
+    const reg = new ConnectionRegistry();
+    expect(reg.unregister('nope')).toBeUndefined();
+  });
+
+  it('list returns a snapshot', () => {
+    const reg = new ConnectionRegistry();
+    const s1 = new FakeWebSocket() as unknown as WebSocket;
+    const s2 = new FakeWebSocket() as unknown as WebSocket;
+    reg.register({ connectionId: 'a', socket: s1, connectedAt: 1, apiLogicalId: 'X', stage: 's' });
+    reg.register({ connectionId: 'b', socket: s2, connectedAt: 2, apiLogicalId: 'X', stage: 's' });
+    expect(reg.list()).toHaveLength(2);
+  });
+});
+
+describe('readRequestBody', () => {
+  it('collects body chunks into a buffer', async () => {
+    const req = newRequest('POST', '/x', 'hello');
+    const buf = await readRequestBody(req);
+    expect(buf.toString('utf-8')).toBe('hello');
+  });
+  it('returns empty buffer for no body', async () => {
+    const req = newRequest('GET', '/x');
+    const buf = await readRequestBody(req);
+    expect(buf.length).toBe(0);
+  });
+});
+
+describe('handleConnectionsRequest', () => {
+  it('returns 410 GoneException for an unknown connection on POST', async () => {
+    const reg = new ConnectionRegistry();
+    const req = newRequest('POST', '/@connections/missing', 'hi');
+    const { res, status, body } = newResponse();
+    await handleConnectionsRequest({ req, res, registry: reg });
+    expect(status()).toBe(410);
+    expect(JSON.parse(body())).toEqual({ message: 'GoneException' });
+  });
+
+  it('delivers POST body to the connection socket on success', async () => {
+    const reg = new ConnectionRegistry();
+    const socket = new FakeWebSocket();
+    reg.register({
+      connectionId: 'c1',
+      socket: socket as unknown as WebSocket,
+      connectedAt: 0,
+      apiLogicalId: 'X',
+      stage: 's',
+    });
+    const req = newRequest('POST', '/@connections/c1', 'payload-bytes');
+    const { res, status } = newResponse();
+    await handleConnectionsRequest({ req, res, registry: reg });
+    expect(status()).toBe(200);
+    expect(socket.sent).toHaveLength(1);
+    expect((socket.sent[0] as Buffer).toString('utf-8')).toBe('payload-bytes');
+  });
+
+  it('returns 410 when the socket is not in OPEN state', async () => {
+    const reg = new ConnectionRegistry();
+    const socket = new FakeWebSocket();
+    socket.readyState = 2;
+    reg.register({
+      connectionId: 'c1',
+      socket: socket as unknown as WebSocket,
+      connectedAt: 0,
+      apiLogicalId: 'X',
+      stage: 's',
+    });
+    const req = newRequest('POST', '/@connections/c1', 'bytes');
+    const { res, status, body } = newResponse();
+    await handleConnectionsRequest({ req, res, registry: reg });
+    expect(status()).toBe(410);
+    expect(JSON.parse(body()).message).toBe('GoneException');
+  });
+
+  it('DELETE closes the socket with code 1000 and returns 204', async () => {
+    const reg = new ConnectionRegistry();
+    const socket = new FakeWebSocket();
+    reg.register({
+      connectionId: 'c1',
+      socket: socket as unknown as WebSocket,
+      connectedAt: 0,
+      apiLogicalId: 'X',
+      stage: 's',
+    });
+    const req = newRequest('DELETE', '/@connections/c1');
+    const { res, status } = newResponse();
+    await handleConnectionsRequest({ req, res, registry: reg });
+    expect(status()).toBe(204);
+    expect(socket.closed?.code).toBe(1000);
+  });
+
+  it('GET returns 200 + synthetic metadata for a live connection', async () => {
+    const reg = new ConnectionRegistry();
+    const socket = new FakeWebSocket();
+    reg.register({
+      connectionId: 'c1',
+      socket: socket as unknown as WebSocket,
+      connectedAt: 1_700_000_000_000,
+      apiLogicalId: 'X',
+      stage: 's',
+    });
+    const req = newRequest('GET', '/@connections/c1');
+    const { res, status, body } = newResponse();
+    await handleConnectionsRequest({ req, res, registry: reg });
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    expect(typeof parsed.ConnectedAt).toBe('string');
+    expect(parsed.Identity).toEqual({ SourceIp: '127.0.0.1' });
+    expect(typeof parsed.LastActiveAt).toBe('string');
+  });
+
+  it('returns 405 with Allow header on unsupported methods', async () => {
+    const reg = new ConnectionRegistry();
+    const socket = new FakeWebSocket();
+    reg.register({
+      connectionId: 'c1',
+      socket: socket as unknown as WebSocket,
+      connectedAt: 0,
+      apiLogicalId: 'X',
+      stage: 's',
+    });
+    const req = newRequest('PATCH', '/@connections/c1');
+    const { res, status, headers } = newResponse();
+    await handleConnectionsRequest({ req, res, registry: reg });
+    expect(status()).toBe(405);
+    expect(headers()['allow']).toBe('POST, GET, DELETE');
+  });
+
+  it('returns 404 when the URL is not under /@connections/', async () => {
+    const reg = new ConnectionRegistry();
+    const req = newRequest('POST', '/other/path');
+    const { res, status } = newResponse();
+    await handleConnectionsRequest({ req, res, registry: reg });
+    expect(status()).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Expose three more local-emulation leaf modules from the package entry (`src/index.ts`) so the `cdkd` host can convert its byte-identical copies into thin re-export shims (Phase 3 Batch B slice 6):

```ts
export { resolveRuntimeCodeMountPath, resolveRuntimeFileExtension, resolveRuntimeImage } from './local/runtime-image.js';
export { buildConnectEvent, buildDisconnectEvent, buildMessageEvent, type WebSocketHandshakeSnapshot, type WebSocketLambdaEvent } from './local/websocket-event.js';
export { ConnectionRegistry, type ConnectionRegistryEntry, buildMgmtEndpointEnvUrl, handleConnectionsRequest, parseConnectionsPath } from './local/websocket-mgmt-api.js';
```

- **runtime-image** — Lambda `Runtime` → ECR base image / source-file extension / in-container code-mount path.
- **websocket-event** — `$connect` / `$disconnect` / message WebSocket Lambda event-shape builders.
- **websocket-mgmt-api** — `@connections` management API: in-process connection registry + the local management-endpoint HTTP handler.

### Driven by the consuming host's actual imports

The exported set is exactly what the cdkd host's **src** imports (the shim's re-export surface), not a speculative bulk export. Test-only symbols (`resolveRuntimeSpec` / `isSupportedRuntime` / `UnsupportedRuntimeError` / `readRequestBody` / `WEBSOCKET_MOCK_CONSTANTS` / `WebSocketRequestContextBase`) stay reachable via the source file for the ported tests but are intentionally NOT on the package entry — keeping every public export both consumed and covered.

### Tests ported

The three modules' unit tests are ported from cdkd verbatim (the modules are byte-identical save runtime-image's one `embedConfig`-branded error string — `${getEmbedConfig().cliName} invoke supports …` — which the test does not assert on, so no assertion flip was needed; only a `cdkd` → `cdk-local` comment was genericized). cdk-local now owns the implementation AND its tests.

Pure export-surface + test addition — no runtime behavior change.

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) green
- [x] `vp run build` green; `dist/index.d.ts` exposes all 13 symbols
- [x] `vp run test` — 713 tests pass (51 files; +3 ported test files)
- [x] docs updated: `docs/library-mode.md` building-blocks list gains all three modules
