### PR TITLE
feat(run-task,start-service): explicit --host-port override; drop macOS auto-remap

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -450,6 +450,7 @@ Path matching is prefix-based: an L2 path like
 | `--cluster <name>` | `cdkl` | Surfaced as `ECS_CONTAINER_METADATA_URI_V4`'s `Cluster` field and used as the docker network prefix (`<name>-task-<rand>`). |
 | `--env-vars <file>` | unset | SAM-shape JSON overlay. Top-level keys are container names; `Parameters` is a global overlay. Same shape as `cdkl invoke --env-vars`. |
 | `--container-host <ip>` | `127.0.0.1` | Bind IP for `PortMappings` published ports. Must be a numeric IP — Docker rejects hostnames in `-p <ip>:<port>:<port>`. |
+| `--host-port <containerPort=hostPort>` | — | Publish a container port on a specific host port (e.g. `80=8080`); repeatable. Default: host port == container port. Map a privileged container port (< 1024) to a non-privileged host port to avoid macOS Docker Desktop's admin-password prompt. |
 | `--assume-task-role [<arn>]` | unset | Bare flag uses the task definition's `TaskRoleArn`. Resolves a flat-string ARN directly; for `{Ref: <Role>}` / `{Fn::GetAtt: [<Role>, 'Arn']}` against a same-stack `AWS::IAM::Role`, cdk-local substitutes the caller's account id (via STS `GetCallerIdentity`) into `arn:aws:iam::<account>:role/<RoleLogicalId>`. Pass an explicit ARN to override. Either way, `sts:AssumeRole` runs once at startup; the resulting creds are exposed via the local metadata sidecar at `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. |
 | `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1. See [Env / Secrets substitution](#env--secrets-substitution---from-cfn-stack) below. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region for `--from-cfn-stack`. |
@@ -651,12 +652,13 @@ each other via a `docker --add-host` DNS overlay.
 > specific replica from the host, `docker exec` into it or read its IP
 > from `docker inspect`.
 >
-> **macOS privileged ports.** On macOS, a container port below 1024 is
-> published on a non-privileged host port (`hostPort + 8000`, e.g.
-> `80 → 8080`, `443 → 8443`) so the run never triggers Docker Desktop's
-> privileged-port admin-password prompt (`com.docker.vmnetd`). The
-> container port is unchanged; a log line names the actual host port to
-> `curl`. On Linux the host port is left as-is.
+> **macOS privileged ports.** The host port equals the container port by
+> default. On macOS, Docker Desktop binds host ports below 1024 through a
+> privileged helper (`com.docker.vmnetd`) that prompts for an admin
+> password. To avoid the prompt, map the privileged container port to a
+> non-privileged host port explicitly with `--host-port` (repeatable),
+> e.g. `--host-port 80=8080` — then reach the container at
+> `127.0.0.1:8080`. cdk-local never changes the host port silently.
 
 ### Target resolution
 
@@ -683,6 +685,7 @@ error.
 | `--restart-policy <policy>` | `on-failure` | Restart-on-exit behavior. `on-failure` restarts only on non-zero exit; `always` restarts on every exit; `none` shuts the affected replica down and runs the service degraded. |
 | `--env-vars <file>` | — | SAM-shape JSON env-var overrides; same format as `cdkl run-task`. |
 | `--container-host <ip>` | `127.0.0.1` | Host IP to bind published container ports to. Must be a numeric IP. |
+| `--host-port <containerPort=hostPort>` | — | Publish a container port on a specific host port (e.g. `80=8080`); repeatable. Default: host port == container port. Map a privileged container port (< 1024) to a non-privileged host port to avoid macOS Docker Desktop's admin-password prompt. Single-replica services only. |
 | `--assume-task-role [arn]` | unset | Assume the task definition's `TaskRoleArn` (or the supplied ARN) and forward STS-issued temp credentials via the metadata sidecar so every replica's containers run with the deployed task role. Same three-form grammar as `cdkl run-task`. |
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before ECR `docker pull` for cross-account / centralized registries. Same shape as `cdkl run-task`. |
 | `--platform <platform>` | inferred | Force `--platform linux/amd64` or `linux/arm64`. |

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1130,6 +1130,7 @@ resolves to the synthesized L1 child (`MyStack/MyService/TaskDef/Resource`).
 | `--cluster <name>` | `cdkl` | Surfaced as `ECS_CONTAINER_METADATA_URI_V4`'s `Cluster` field and used as the docker network prefix (`<name>-task-<rand>`). |
 | `--env-vars <file>` | unset | SAM-shape JSON overlay. Top-level keys are container names; `Parameters` is a global overlay. Same shape as `cdkl invoke --env-vars`. |
 | `--container-host <ip>` | `127.0.0.1` | Bind IP for `PortMappings` published ports. Must be a numeric IP — Docker rejects hostnames in `-p <ip>:<port>:<port>`. |
+| `--host-port <containerPort=hostPort>` | — | Publish a container port on a specific host port (e.g. `80=8080`); repeatable. Default: host port == container port. Map a privileged container port (< 1024) to a non-privileged host port to avoid macOS Docker Desktop's admin-password prompt. |
 | `--assume-task-role [<arn>]` | unset (host creds pass through) | Bare flag uses the task definition's `TaskRoleArn`. Resolves a flat-string ARN directly; for `{Ref: <Role>}` / `{Fn::GetAtt: [<Role>, 'Arn']}` against a same-stack `AWS::IAM::Role`, cdk-local substitutes the caller's account id (via STS `GetCallerIdentity`) into `arn:aws:iam::<account>:role/<RoleLogicalId>`. Pass an explicit ARN to override. Either way, `sts:AssumeRole` runs once at startup; the resulting creds are exposed via the local metadata sidecar at `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. |
 | `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `ListStackResources` does not return per-attribute values). See "Env / Secrets substitution" below. |
 | `--stack-region <region>` | unset | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
@@ -1345,12 +1346,13 @@ replica's sidecar.
 > docker network; to hit a specific replica from the host, `docker exec`
 > into it or read its IP from `docker inspect`.
 >
-> **macOS privileged ports.** On macOS, a container port below 1024 is
-> published on a non-privileged host port (`hostPort + 8000`, e.g.
-> `80 → 8080`, `443 → 8443`) so the run never triggers Docker Desktop's
-> privileged-port admin-password prompt (`com.docker.vmnetd`). The
-> container port is unchanged; a log line names the actual host port to
-> `curl`. On Linux the host port is left as-is.
+> **macOS privileged ports.** The host port equals the container port by
+> default. On macOS, Docker Desktop binds host ports below 1024 through a
+> privileged helper (`com.docker.vmnetd`) that prompts for an admin
+> password. To avoid the prompt, map the privileged container port to a
+> non-privileged host port explicitly with `--host-port` (repeatable),
+> e.g. `--host-port 80=8080` — then reach the container at
+> `127.0.0.1:8080`. cdk-local never changes the host port silently.
 
 ### `start-service` target resolution
 
@@ -1376,6 +1378,7 @@ error.
 | `--restart-policy <p>` | `on-failure` | Restart-on-exit behavior. `on-failure` restarts only on non-zero exit; `always` restarts on every exit (mirrors ECS Service deployment semantics more closely); `none` shuts the affected replica down and runs the service degraded. |
 | `--env-vars <file>` | — | SAM-shape JSON env-var overrides; same format as `run-task`. |
 | `--container-host <ip>` | `127.0.0.1` | Host IP to bind published container ports to. Must be a numeric IP. |
+| `--host-port <containerPort=hostPort>` | — | Publish a container port on a specific host port (e.g. `80=8080`); repeatable. Default: host port == container port. Map a privileged container port (< 1024) to a non-privileged host port to avoid macOS Docker Desktop's admin-password prompt. Single-replica services only. |
 | `--assume-task-role [arn]` | unset | Assume the task definition's TaskRoleArn (or the supplied ARN) and forward STS-issued temp credentials via the metadata sidecar so every replica's containers run with the deployed task role. Same three-form grammar as `run-task`. |
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before ECR `docker pull` for cross-account / centralized registries. Same shape as `run-task`. |
 | `--platform <p>` | inferred | Force `--platform linux/amd64` or `linux/arm64`. |

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -32,6 +32,7 @@ import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import {
   cleanupEcsRun,
   createEcsRunState,
+  parseHostPortOverrides,
   runEcsTask,
   type EcsRunState,
   type RunEcsTaskOptions,
@@ -77,6 +78,8 @@ interface LocalRunTaskOptions {
    * authenticate against the target ECR repository.
    */
   ecrRoleArn?: string;
+  /** `--host-port <containerPort=hostPort>` overrides (repeatable; variadic array). */
+  hostPort?: string[];
   platform?: string;
   keepRunning: boolean;
   detach: boolean;
@@ -332,6 +335,8 @@ async function localRunTaskCommand(
     if (options.region) runOpts.region = options.region;
     if (options.ecrRoleArn) runOpts.ecrRoleArn = options.ecrRoleArn;
     if (options.profile) runOpts.profile = options.profile;
+    const hostPortOverrides = parseHostPortOverrides(options.hostPort);
+    if (Object.keys(hostPortOverrides).length > 0) runOpts.hostPortOverrides = hostPortOverrides;
     if (profileCredsFile) {
       runOpts.profileCredentialsFile = {
         hostPath: profileCredsFile.hostPath,
@@ -628,6 +633,15 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
         '--container-host <ip>',
         'Host IP to bind published container ports to. Must be a numeric IP (Docker rejects hostnames here)'
       ).default('127.0.0.1')
+    )
+    .addOption(
+      new Option(
+        '--host-port <containerPort=hostPort...>',
+        'Publish a container port on a specific host port (e.g. 80=8080); repeatable. ' +
+          'Default: host port == container port. Use this on macOS to map a privileged ' +
+          'container port (< 1024) to a non-privileged host port and avoid the Docker ' +
+          'Desktop admin-password prompt.'
+      )
     )
     .addOption(
       new Option(

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -38,7 +38,11 @@ import {
   type ServiceRunState,
 } from '../../local/ecs-service-runner.js';
 import type { StackInfo } from '../../synthesis/assembly-reader.js';
-import { cleanupEcsRun, type RunEcsTaskOptions } from '../../local/ecs-task-runner.js';
+import {
+  cleanupEcsRun,
+  parseHostPortOverrides,
+  type RunEcsTaskOptions,
+} from '../../local/ecs-task-runner.js';
 import { matchStacks } from '../stack-matcher.js';
 import {
   createLocalStateProvider,
@@ -76,6 +80,8 @@ interface LocalStartServiceOptions {
   assumeTaskRole?: string | boolean;
   pull: boolean;
   ecrRoleArn?: string;
+  /** `--host-port <containerPort=hostPort>` overrides (repeatable; variadic array). */
+  hostPort?: string[];
   platform?: string;
   /** Cap on local replica count regardless of template `DesiredCount`. */
   maxTasks: number;
@@ -487,6 +493,8 @@ async function runOneTarget(
   if (options.region) taskOpts.region = options.region;
   if (options.ecrRoleArn) taskOpts.ecrRoleArn = options.ecrRoleArn;
   if (options.profile) taskOpts.profile = options.profile;
+  const hostPortOverrides = parseHostPortOverrides(options.hostPort);
+  if (Object.keys(hostPortOverrides).length > 0) taskOpts.hostPortOverrides = hostPortOverrides;
   // Per-service gating (mirrors cdkd PR #670 fix-back finding #1
   // applied in `local-run-task.ts`): the shared credentials file is
   // bound ONLY to services that did NOT win an `--assume-task-role`.
@@ -800,6 +808,16 @@ export function createLocalStartServiceCommand(
         '--container-host <ip>',
         'Host IP to bind published container ports to. Must be a numeric IP (Docker rejects hostnames here)'
       ).default('127.0.0.1')
+    )
+    .addOption(
+      new Option(
+        '--host-port <containerPort=hostPort...>',
+        'Publish a container port on a specific host port (e.g. 80=8080); repeatable. ' +
+          'Default: host port == container port. Use this on macOS to map a privileged ' +
+          'container port (< 1024) to a non-privileged host port and avoid the Docker ' +
+          'Desktop admin-password prompt. (Single-replica services only — multi-replica ' +
+          'services do not publish host ports.)'
+      )
     )
     .addOption(
       new Option(

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -76,6 +76,16 @@ export interface RunEcsTaskOptions {
    * still works.
    */
   skipHostPortPublish?: boolean;
+  /**
+   * `--host-port <containerPort>=<hostPort>` overrides (`containerPort ->
+   * hostPort`). When a published container port has an entry here, it is
+   * bound on that host port instead of the declared one. Lets the user
+   * map a privileged container port (e.g. 80) to a non-privileged host
+   * port (e.g. 8080) so the run avoids macOS Docker Desktop's privileged
+   * helper. Empty / unset = bind the declared host port (`host ==
+   * container`).
+   */
+  hostPortOverrides?: Record<number, number>;
   /** Optional STS-issued temp credentials to expose via the metadata sidecar (`--assume-task-role`). */
   taskCredentials?: {
     accessKeyId: string;
@@ -392,6 +402,7 @@ export async function runEcsTask(
         region: options.region,
         sidecarIp: state.network.sidecarIp,
         ...(options.skipHostPortPublish ? { skipHostPortPublish: true } : {}),
+        ...(options.hostPortOverrides ? { hostPortOverrides: options.hostPortOverrides } : {}),
         ...(options.addHostFlags && options.addHostFlags.length > 0
           ? { addHostFlags: options.addHostFlags }
           : {}),
@@ -865,6 +876,11 @@ interface BuildDockerRunArgs {
    */
   skipHostPortPublish?: boolean;
   /**
+   * `--host-port` overrides (`containerPort -> hostPort`); see the
+   * matching field on {@link RunEcsTaskOptions}.
+   */
+  hostPortOverrides?: Record<number, number>;
+  /**
    * Issue #460 — extra `--add-host name:ip` flag pairs forwarded
    * verbatim to `docker run`. Used by the Cloud Map overlay so
    * `<discoveryName>.<namespace>` (and bare ClientAlias short forms)
@@ -896,26 +912,42 @@ interface BuildDockerRunArgs {
 }
 
 /**
- * Resolve the HOST port to publish a container port on.
+ * Parse `--host-port <containerPort>=<hostPort>` overrides into a
+ * `containerPort -> hostPort` map.
  *
- * On macOS, Docker Desktop binds host ports below 1024 through a
- * privileged helper (`com.docker.vmnetd`) that prompts for an admin
- * password — and fails outright when that helper isn't running. A
- * container that declares e.g. port 80 would otherwise force that prompt
- * on every `run-task` / `start-service`. To keep the local run
- * password-free, remap a privileged host port to a non-privileged one by
- * adding 8000 (80 -> 8080, 443 -> 8443). The container port is unchanged
- * — only the host side moves — and the caller logs where to reach it.
+ * By default cdk-local publishes a container port on the SAME host port
+ * (`host == container`), which is predictable but fails on macOS for
+ * privileged ports (< 1024): Docker Desktop binds those through the
+ * `com.docker.vmnetd` privileged helper, which prompts for an admin
+ * password and fails when cancelled. Rather than silently changing the
+ * host port, the user opts in explicitly — e.g. `--host-port 80=8080`
+ * publishes the container's port 80 on host port 8080.
  *
- * Only macOS is affected: on Linux the Docker daemon runs as root and
- * binds privileged ports directly, so the host port is left as-is to
- * preserve the `host == container` mapping users expect.
- *
- * Exported for unit testing with an explicit `platform`.
+ * Repeatable; each value is `<containerPort>=<hostPort>` with both in
+ * 1-65535. Throws on a malformed value so the CLI surfaces a clear error.
  */
-export function resolvePublishHostPort(hostPort: number, platform: NodeJS.Platform): number {
-  if (platform === 'darwin' && hostPort < 1024) return hostPort + 8000;
-  return hostPort;
+export function parseHostPortOverrides(values: string[] | undefined): Record<number, number> {
+  const out: Record<number, number> = {};
+  for (const raw of values ?? []) {
+    const m = /^(\d+)=(\d+)$/.exec(raw.trim());
+    if (!m) {
+      throw new Error(
+        `Invalid --host-port '${raw}'. Expected <containerPort>=<hostPort> (e.g. 80=8080).`
+      );
+    }
+    const containerPort = Number(m[1]);
+    const hostPort = Number(m[2]);
+    for (const [label, p] of [
+      ['container', containerPort],
+      ['host', hostPort],
+    ] as const) {
+      if (p < 1 || p > 65535) {
+        throw new Error(`Invalid --host-port '${raw}': ${label} port must be 1-65535.`);
+      }
+    }
+    out[containerPort] = hostPort;
+  }
+  return out;
 }
 
 /**
@@ -981,19 +1013,17 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
   // Connect tasks have per-task ENIs and never share a host port).
   if (!opts.skipHostPortPublish) {
     for (const pm of container.portMappings) {
-      const hostPort = pm.hostPort ?? pm.containerPort;
-      const publishHostPort = resolvePublishHostPort(hostPort, process.platform);
-      if (publishHostPort !== hostPort) {
+      const declaredHostPort = pm.hostPort ?? pm.containerPort;
+      const hostPort = opts.hostPortOverrides?.[pm.containerPort] ?? declaredHostPort;
+      if (hostPort !== declaredHostPort) {
         getLogger()
           .child('ecs')
           .info(
             `Container '${container.name}' container port ${pm.containerPort} published on ` +
-              `${containerHost}:${publishHostPort} (remapped from privileged host port ${hostPort}; ` +
-              'macOS Docker Desktop needs an admin helper to bind ports < 1024). ' +
-              `Reach it at ${containerHost}:${publishHostPort}.`
+              `${containerHost}:${hostPort} (--host-port override). Reach it at ${containerHost}:${hostPort}.`
           );
       }
-      args.push('-p', `${containerHost}:${publishHostPort}:${pm.containerPort}/${pm.protocol}`);
+      args.push('-p', `${containerHost}:${hostPort}:${pm.containerPort}/${pm.protocol}`);
     }
   }
 

--- a/tests/unit/local/ecs-publish-host-port.test.ts
+++ b/tests/unit/local/ecs-publish-host-port.test.ts
@@ -1,27 +1,77 @@
 import { describe, it, expect } from 'vite-plus/test';
-import { resolvePublishHostPort } from '../../../src/local/ecs-task-runner.js';
+import { buildDockerRunArgs, parseHostPortOverrides } from '../../../src/local/ecs-task-runner.js';
+import type { ResolvedEcsContainer, ResolvedEcsTask } from '../../../src/local/ecs-task-resolver.js';
 
-describe('resolvePublishHostPort', () => {
-  it('remaps privileged host ports (<1024) by +8000 on macOS', () => {
-    expect(resolvePublishHostPort(80, 'darwin')).toBe(8080);
-    expect(resolvePublishHostPort(443, 'darwin')).toBe(8443);
-    expect(resolvePublishHostPort(22, 'darwin')).toBe(8022);
-    expect(resolvePublishHostPort(1023, 'darwin')).toBe(9023);
+describe('parseHostPortOverrides', () => {
+  it('parses <containerPort>=<hostPort> pairs into a map', () => {
+    expect(parseHostPortOverrides(['80=8080'])).toEqual({ 80: 8080 });
+    expect(parseHostPortOverrides(['80=8080', '443=8443'])).toEqual({ 80: 8080, 443: 8443 });
   });
 
-  it('leaves non-privileged host ports unchanged on macOS', () => {
-    expect(resolvePublishHostPort(1024, 'darwin')).toBe(1024);
-    expect(resolvePublishHostPort(3000, 'darwin')).toBe(3000);
-    expect(resolvePublishHostPort(8080, 'darwin')).toBe(8080);
+  it('returns an empty map for undefined / empty input', () => {
+    expect(parseHostPortOverrides(undefined)).toEqual({});
+    expect(parseHostPortOverrides([])).toEqual({});
   });
 
-  it('never remaps on Linux (daemon runs as root, binds <1024 directly)', () => {
-    expect(resolvePublishHostPort(80, 'linux')).toBe(80);
-    expect(resolvePublishHostPort(443, 'linux')).toBe(443);
-    expect(resolvePublishHostPort(3000, 'linux')).toBe(3000);
+  it('throws on a malformed value', () => {
+    expect(() => parseHostPortOverrides(['8080'])).toThrow(/Expected <containerPort>=<hostPort>/);
+    expect(() => parseHostPortOverrides(['80:8080'])).toThrow(/Expected <containerPort>=<hostPort>/);
+    expect(() => parseHostPortOverrides(['abc=8080'])).toThrow(/Expected <containerPort>=<hostPort>/);
   });
 
-  it('does not remap on win32 (scoped to the confirmed macOS vmnetd case)', () => {
-    expect(resolvePublishHostPort(80, 'win32')).toBe(80);
+  it('throws on an out-of-range port', () => {
+    expect(() => parseHostPortOverrides(['80=0'])).toThrow(/host port must be 1-65535/);
+    expect(() => parseHostPortOverrides(['70000=8080'])).toThrow(/container port must be 1-65535/);
+  });
+});
+
+function containerWithPort(): ResolvedEcsContainer {
+  return {
+    name: 'app',
+    image: { kind: 'public', uri: 'public.ecr.aws/docker/library/busybox:latest' },
+    environment: {},
+    secrets: [],
+    portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+    mountPoints: [],
+    dependsOn: [],
+    links: [],
+    essential: true,
+    ulimits: [],
+    warnings: [],
+  } as unknown as ResolvedEcsContainer;
+}
+
+const task = { family: 'fam' } as unknown as ResolvedEcsTask;
+
+function publishArg(hostPortOverrides?: Record<number, number>): string | undefined {
+  const { args } = buildDockerRunArgs({
+    task,
+    container: containerWithPort(),
+    image: 'public.ecr.aws/docker/library/busybox:latest',
+    network: 'net',
+    volumeByName: new Map(),
+    secrets: [],
+    envOverrides: undefined,
+    containerHost: '127.0.0.1',
+    roleArn: undefined,
+    platformOverride: undefined,
+    region: undefined,
+    ...(hostPortOverrides && { hostPortOverrides }),
+  });
+  const i = args.indexOf('-p');
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+describe('buildDockerRunArgs host-port publishing', () => {
+  it('publishes container port on the SAME host port by default (no silent remap)', () => {
+    expect(publishArg()).toBe('127.0.0.1:80:80/tcp');
+  });
+
+  it('honors a --host-port override for the matching container port', () => {
+    expect(publishArg({ 80: 8080 })).toBe('127.0.0.1:8080:80/tcp');
+  });
+
+  it('ignores an override for a different container port', () => {
+    expect(publishArg({ 443: 8443 })).toBe('127.0.0.1:80:80/tcp');
   });
 });


### PR DESCRIPTION
## Summary

Replaces the macOS privileged-port **auto-remap** (shipped in the prior
PR) with an **explicit** `--host-port` override. Silently publishing a
container's port 80 on host 8080 means the user must know the changed
port to reach the service — so changing it automatically is the wrong
default. Now the host port equals the container port unless the user
maps it.

## Behavior

- **Default (all platforms):** publish the container port on the SAME
  host port (`host == container`). Predictable; never changed silently.
  On macOS a privileged port (< 1024) still triggers Docker Desktop's
  `com.docker.vmnetd` admin-password prompt — the user opts out by
  mapping it.
- **`--host-port <containerPort>=<hostPort>`** (repeatable): publish a
  container port on a specific host port, e.g. `--host-port 80=8080`
  → reach the container at `127.0.0.1:8080`. A log line names the
  override.

## Changes

- Drop `resolvePublishHostPort` (auto-remap); add
  `parseHostPortOverrides`.
- Thread `hostPortOverrides` from the CLI through `RunEcsTaskOptions`
  into `buildDockerRunArgs`; the publish loop uses the override or falls
  back to the declared host port.
- `--host-port` option added to `run-task` and `start-service`.
- Docs updated (host-port-publishing notes + flag tables).

## Test plan

- [x] `vp run check` / `vp run build`
- [x] `vp run test` — 48 files, 617 tests
- [x] `parseHostPortOverrides` (valid / multiple / malformed /
      out-of-range / empty) + `buildDockerRunArgs` publishing (default
      `host==container`, override applied, non-matching override ignored).
- [x] Live-verified on macOS: `start-service ... --host-port 80=8080`
      publishes `127.0.0.1:8080->80/tcp` with no admin-password prompt;
      without the flag the host port equals the container port.

## Note

This supersedes the auto-remap from the immediately preceding PR (same
session). Net user-facing change is the explicit flag; the silent remap
is removed.
