### PR TITLE
feat(start-service): surface container log tail when a replica exits

### DIFF
--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -797,7 +797,16 @@ async function watchReplica(
       `Replica ${instance.index} essential container exited with code ${exitCode} ` +
         `(restartCount=${instance.restartCount}).`
     );
-    if (!shouldRestart(exitCode, options.restartPolicy)) {
+    // Surface the container's log tail so the user sees WHY it exited
+    // (run-task streams logs in the foreground, but detached service
+    // replicas otherwise leave the exit unexplained). Dump on the first
+    // failure and on the terminal degraded exit, but NOT on every
+    // restart cycle of a crash loop.
+    const willRestart = shouldRestart(exitCode, options.restartPolicy);
+    if (!willRestart || instance.restartCount === 0) {
+      await printExitedContainerLogs(instance.index, essentialId, logger);
+    }
+    if (!willRestart) {
       logger.warn(
         `Replica ${instance.index} not restarting (policy=${options.restartPolicy}, ` +
           `exit=${exitCode}). Service running in degraded mode.`
@@ -932,6 +941,60 @@ export function __setWaitForExitImpl(
     return;
   }
   waitForExitImpl = impl;
+}
+
+/** How many trailing lines of a crashed container's logs to surface. */
+const EXIT_LOG_TAIL_LINES = 50;
+
+/**
+ * Production `docker logs --tail <N> <id>` reader. Captures BOTH streams
+ * (apps log to stdout and stderr) so the surfaced tail shows whatever the
+ * container printed before exiting.
+ */
+const defaultReadContainerLogsImpl = async (containerId: string): Promise<string> => {
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const { getDockerCmd } = await import('../utils/docker-cmd.js');
+  const execFileAsync = promisify(execFile);
+  const { stdout, stderr } = await execFileAsync(
+    getDockerCmd(),
+    ['logs', '--tail', String(EXIT_LOG_TAIL_LINES), containerId],
+    { maxBuffer: 4 * 1024 * 1024 }
+  );
+  return [stdout, stderr].filter((s) => s.length > 0).join('\n');
+};
+
+/**
+ * Surface the tail of a just-exited essential container's logs so the
+ * user sees WHY it stopped (e.g. an app's startup DB-connection error)
+ * without manually running `docker logs`. Best-effort: a read failure or
+ * empty output is swallowed (debug-logged) rather than masking the
+ * primary exit message.
+ *
+ * `read` is injectable so the unit test can assert the formatting without
+ * a real container; production callers use the default `docker logs`
+ * reader.
+ */
+export async function printExitedContainerLogs(
+  replicaIndex: number,
+  containerId: string,
+  logger: { warn: (m: string) => void; debug: (m: string) => void },
+  read: (id: string) => Promise<string> = defaultReadContainerLogsImpl
+): Promise<void> {
+  let raw: string;
+  try {
+    raw = await read(containerId);
+  } catch (err) {
+    logger.debug(
+      `Replica ${replicaIndex}: could not read container logs: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return;
+  }
+  const tail = raw.trimEnd();
+  if (tail.length === 0) return;
+  logger.warn(
+    `Replica ${replicaIndex} essential container logs (last ${EXIT_LOG_TAIL_LINES} lines):\n${tail}`
+  );
 }
 
 const defaultSleepImpl = (ms: number): Promise<void> =>

--- a/tests/unit/local/ecs-service-runner-exit-logs.test.ts
+++ b/tests/unit/local/ecs-service-runner-exit-logs.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { printExitedContainerLogs } from '../../../src/local/ecs-service-runner.js';
+
+describe('printExitedContainerLogs', () => {
+  const logger = { warn: vi.fn(), debug: vi.fn() };
+  beforeEach(() => {
+    logger.warn.mockReset();
+    logger.debug.mockReset();
+  });
+
+  it('warns with the container log tail so the exit reason is visible', async () => {
+    await printExitedContainerLogs(
+      0,
+      'container-id',
+      logger,
+      async () => 'Nest started\nPrismaClientInitializationError: Timed out\n'
+    );
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const msg = logger.warn.mock.calls[0]![0] as string;
+    expect(msg).toContain('Replica 0 essential container logs');
+    expect(msg).toContain('PrismaClientInitializationError: Timed out');
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the container printed nothing', async () => {
+    await printExitedContainerLogs(0, 'container-id', logger, async () => '   \n  ');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('swallows a read failure as a debug line (never masks the exit message)', async () => {
+    await printExitedContainerLogs(2, 'container-id', logger, async () => {
+      throw new Error('No such container');
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug.mock.calls[0]![0] as string).toContain('could not read container logs');
+  });
+});


### PR DESCRIPTION
## Summary

`run-task` streams container logs in the foreground, but `start-service`
runs replicas detached — so when an essential container exits the user
saw only `Replica N essential container exited with code X` with no clue
why (e.g. an app failing to reach its database at startup). Debugging
required manually `docker logs`-ing the dead container.

The watcher now surfaces the essential container's `docker logs --tail
50` (stdout + stderr) right after reporting the exit, so the failure
reason is inline.

## Behavior

- Dumps the log tail on the **first** failure (`restartCount === 0`) and
  on the **terminal degraded** exit (no restart) — NOT on every restart
  cycle of a crash loop.
- Best-effort: a `docker logs` failure or empty output is swallowed
  (debug-logged) and never masks the primary exit message.

## Changes

- Add `printExitedContainerLogs` (exported; injectable `read` for tests)
  + `defaultReadContainerLogsImpl` (`docker logs --tail 50`).
- Call it from `watchReplica` after the exit warning, gated as above.

## Test plan

- [x] `vp run check` / `vp run build`
- [x] `vp run test` — 52 files, 719 tests
- [x] New `tests/unit/local/ecs-service-runner-exit-logs.test.ts`: warns
      with the tail on output, stays silent on empty, swallows a read
      failure as a debug line.
- [x] Live-verified on macOS: `start-service` against a real app whose
      container exits at startup now prints the Nest bootstrap logs +
      `PrismaClientInitializationError: Can't reach database server ...`
      inline — no manual `docker logs` needed.
