### PR TITLE
fix(start-service): stop logging service warnings twice

### DIFF
--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -420,7 +420,6 @@ async function runOneTarget(
       `(service=${service.serviceName}, desiredCount=${service.desiredCount}, ` +
       `task=${service.task.taskDefinitionLogicalId})`
   );
-  for (const w of service.warnings) logger.warn(w);
   if (service.serviceConnect) {
     logger.info(
       `Service Connect: namespace='${service.serviceConnect.namespaceName}', ` +


### PR DESCRIPTION
## Summary

`start-service` printed each resolved-service warning twice. The
warnings produced by `resolveEcsServiceTarget` (for example the
"LoadBalancers are not emulated locally" notice) were logged once by
the `start-service` command and then again by `startEcsService` in the
runner.

## Fix

Drop the command-layer `for (const w of service.warnings) logger.warn(w)`
loop and let `startEcsService` (`src/local/ecs-service-runner.ts`) be the
single owner of warning output, so each warning surfaces exactly once.

## Test plan

- [x] `vp check --fix` / `vp run build`
- [x] `vp test run` — 52 files, 719 tests
- [x] Confirmed `startEcsService` is always reached after resolution (no
      early return between resolve and runner start), so no warning is
      lost by removing the command-layer loop.
