### PR TITLE
feat(exports): expose setEmbedConfig / getEmbedConfig / resetEmbedConfig

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -72,6 +72,34 @@ default, so omitting `embedConfig` (or any single field) leaves native
 `cdkl` behavior unchanged. Pass the same `embedConfig` to each factory
 the host mounts so the branding is consistent across commands.
 
+### Shim hosts that don't use the factories
+
+A host that re-exports cdk-local's leaf modules as shims
+(`export { resolveRuntimeImage } from 'cdk-local'` etc.) but keeps its
+OWN command implementations does not go through the factories, so the
+factory-internal `setEmbedConfig` never fires — those bundled modules
+would render cdk-local's `cdkl` defaults. Such a host calls
+`setEmbedConfig` directly, once, at startup (before any shimmed module
+runs — e.g. when building its local command tree):
+
+```typescript
+import { setEmbedConfig } from 'cdk-local';
+
+setEmbedConfig({
+  cliName: 'mytool local',
+  binaryName: 'mytool',
+  productName: 'mytool',
+  resourceNamePrefix: 'mytool-local',
+  awsBindMountPath: '/mytool-aws',
+  envPrefix: 'MYTOOL',
+});
+```
+
+`setEmbedConfig` is idempotent and installs process-wide state read by
+every `getEmbedConfig()` call in cdk-local's bundle, so a single call
+covers all re-exported shims. `getEmbedConfig()` reads the resolved
+config and `resetEmbedConfig()` restores the defaults (test isolation).
+
 ## Low-level building blocks (shim hosts)
 
 Most hosts only need the command factories above. A host that instead

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,16 @@ export {
 } from './cli/commands/local-state-source.js';
 
 export type { CdkLocalEmbedConfig } from './local/embed-config.js';
+/**
+ * Embed-config setter / getter / reset. A host that does NOT use cdk-local's
+ * Commander factories (which install the config themselves) but DOES re-export
+ * cdk-local's leaf modules as shims must call `setEmbedConfig(...)` once at
+ * startup so those bundled modules render the host's branding (`cliName` /
+ * `resourceNamePrefix` / etc.) instead of cdk-local's `cdkl` defaults.
+ * `getEmbedConfig` reads the resolved config; `resetEmbedConfig` restores the
+ * defaults (test isolation).
+ */
+export { getEmbedConfig, resetEmbedConfig, setEmbedConfig } from './local/embed-config.js';
 
 export type { LocalStateProvider, LocalStateRecord } from './local/local-state-provider.js';
 export type { CrossStackResolver, SubstitutionContext } from './local/state-resolver.js';


### PR DESCRIPTION
## Summary

Expose the embed-config **setter** from the package entry, alongside the already-exported `CdkLocalEmbedConfig` type:

```ts
export { getEmbedConfig, resetEmbedConfig, setEmbedConfig } from './local/embed-config.js';
```

### Why

cdk-local's Commander factories (`createLocalInvokeCommand` etc.) call `setEmbedConfig` internally with the host's `embedConfig`, so a host that **uses the factories** never needs the setter directly. But a host that re-exports cdk-local's leaf modules as **shims** while keeping its **own** command implementations does not go through the factories — so those bundled modules read `getEmbedConfig()` and render cdk-local's `cdkl` defaults in user-facing error strings and generated resource names.

This is exactly cdkd's situation: cdkd shims `runtime-image` / `route-discovery` / `websocket-*` / `layer-arn-materializer` etc. from cdk-local but keeps its own `cdkd local` command tree. Without a directly-callable `setEmbedConfig`, cdkd's shimmed modules emit `cdkl invoke` / `cdkl-*` resource names instead of `cdkd local invoke` / `cdkd-local-*`. cdkd will call `setEmbedConfig` once at startup to fix this.

`getEmbedConfig` (read-back) and `resetEmbedConfig` (test isolation) round out the public surface. Pure export-surface addition — the functions and their behavior are unchanged and already covered by the existing factory-path tests.

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) green
- [x] `vp run build` green; `dist/index.d.ts` exposes `setEmbedConfig` / `getEmbedConfig` / `resetEmbedConfig`
- [x] `vp run test` — 719 tests pass
- [x] docs updated: `docs/library-mode.md` gains a "Shim hosts that don't use the factories" subsection
