### PR TITLE
feat(exports): expose docker-version / api-server-grouping / layer-arn-materializer primitives

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,3 +199,33 @@ export {
   handleConnectionsRequest,
   parseConnectionsPath,
 } from './local/websocket-mgmt-api.js';
+
+/**
+ * `start-api` Docker host-gateway version probe — gates the
+ * `--add-host=...:host-gateway` mapping WebSocket Lambda containers need to
+ * reach the host server on Linux native dockerd. Exposed only as the
+ * consuming host's `import` statements require them.
+ */
+export { HOST_GATEWAY_MIN_VERSION, probeHostGatewaySupport } from './local/docker-version.js';
+
+/**
+ * `start-api` API-server grouping — splits a flat discovered-route list into
+ * one group per local HTTP server (one per RestApi / HTTP API / Function URL)
+ * and filters the route list to a single API by a user-supplied `--api`
+ * identifier. Exposed only as the consuming host's `import` statements
+ * require them.
+ */
+export {
+  availableApiIdentifiers,
+  filterRoutesByApiIdentifier,
+  groupRoutesByServer,
+  type ApiServerGroup,
+} from './local/api-server-grouping.js';
+
+/**
+ * `invoke` / `start-api` literal-ARN Lambda Layer materializer — downloads a
+ * layer version's ZIP (optionally via an assumed role), unzips it to a host
+ * tmpdir, and returns the path for `/opt` bind-mounting alongside same-stack
+ * layers. Exposed only as the consuming host's `import` statement requires it.
+ */
+export { materializeLayerFromArn } from './local/layer-arn-materializer.js';

--- a/tests/unit/local/api-server-grouping.test.ts
+++ b/tests/unit/local/api-server-grouping.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vite-plus/test';
+import type { RouteWithAuth } from '../../../src/local/authorizer-resolver.js';
+import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+import {
+  availableApiIdentifiers,
+  filterRoutesByApiIdentifier,
+  groupRoutesByServer,
+} from '../../../src/local/api-server-grouping.js';
+
+function makeRoute(partial: Partial<DiscoveredRoute>): RouteWithAuth {
+  const route: DiscoveredRoute = {
+    method: partial.method ?? 'GET',
+    pathPattern: partial.pathPattern ?? '/',
+    lambdaLogicalId: partial.lambdaLogicalId ?? 'Handler',
+    source: partial.source ?? 'http-api',
+    apiVersion: partial.apiVersion ?? 'v2',
+    stage: partial.stage ?? '$default',
+    declaredAt: partial.declaredAt ?? 'Stack/Method',
+    ...(partial.apiLogicalId !== undefined && { apiLogicalId: partial.apiLogicalId }),
+    ...(partial.apiStackName !== undefined && { apiStackName: partial.apiStackName }),
+    ...(partial.apiCdkPath !== undefined && { apiCdkPath: partial.apiCdkPath }),
+  };
+  return { route, authorizer: undefined };
+}
+
+describe('groupRoutesByServer', () => {
+  it('returns one group per HTTP API logical id, preserving first-seen order', () => {
+    const routes = [
+      makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi', pathPattern: '/public' }),
+      makeRoute({ source: 'http-api', apiLogicalId: 'AdminApi', pathPattern: '/admin' }),
+      makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi', pathPattern: '/public/v2' }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.serverKey).toBe('http-api:PublicApi');
+    expect(groups[0]!.kind).toBe('http-api');
+    expect(groups[0]!.identifier).toBe('PublicApi');
+    expect(groups[0]!.displayName).toBe('PublicApi (HTTP API v2)');
+    expect(groups[0]!.routes).toHaveLength(2);
+    expect(groups[1]!.serverKey).toBe('http-api:AdminApi');
+    expect(groups[1]!.routes).toHaveLength(1);
+  });
+
+  it('groups REST v1 separately from HTTP API even with the same logical id', () => {
+    // Defense-in-depth: a CDK app could in theory name a RestApi and an
+    // ApiGwV2 Api with the same identifier. Group by (kind, identifier),
+    // not identifier alone.
+    const routes = [
+      makeRoute({ source: 'rest-v1', apiLogicalId: 'MyApi', apiVersion: 'v1' }),
+      makeRoute({ source: 'http-api', apiLogicalId: 'MyApi', apiVersion: 'v2' }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.kind).sort()).toEqual(['http-api', 'rest-v1']);
+    expect(groups.find((g) => g.kind === 'rest-v1')!.displayName).toBe('MyApi (REST API v1)');
+    expect(groups.find((g) => g.kind === 'http-api')!.displayName).toBe('MyApi (HTTP API v2)');
+  });
+
+  it('keys Function URLs by backing Lambda logical id (no parent API)', () => {
+    const routes = [
+      makeRoute({ source: 'function-url', lambdaLogicalId: 'GoHandler', apiLogicalId: undefined }),
+      makeRoute({ source: 'function-url', lambdaLogicalId: 'NodeHandler', apiLogicalId: undefined }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.serverKey).toBe('function-url:GoHandler');
+    expect(groups[0]!.displayName).toBe('GoHandler (Function URL)');
+    expect(groups[0]!.kind).toBe('function-url');
+    expect(groups[0]!.identifier).toBe('GoHandler');
+    expect(groups[1]!.serverKey).toBe('function-url:NodeHandler');
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(groupRoutesByServer([])).toEqual([]);
+  });
+
+  it('handles a mix of HTTP API, REST v1, and Function URL in one shot', () => {
+    const routes = [
+      makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi' }),
+      makeRoute({ source: 'rest-v1', apiLogicalId: 'LegacyApi', apiVersion: 'v1' }),
+      makeRoute({ source: 'function-url', lambdaLogicalId: 'GoHandler' }),
+      makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi' }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.serverKey)).toEqual([
+      'http-api:PublicApi',
+      'rest-v1:LegacyApi',
+      'function-url:GoHandler',
+    ]);
+    const publicGroup = groups.find((g) => g.identifier === 'PublicApi')!;
+    expect(publicGroup.routes).toHaveLength(2);
+  });
+
+  it('stack-prefixes serverKey so same-logical-id APIs across stacks get separate servers', () => {
+    // Cross-stack same-logical-id case: `MyHttpApi` in both `WebStack`
+    // and `AdminStack`. Pre-fix the serverKey was `http-api:MyHttpApi`
+    // for both, silently merging routes from two different APIs into
+    // one server. Post-fix the serverKey includes `apiStackName`, so
+    // the two surfaces get two separate servers on different ports.
+    const routes = [
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'MyHttpApi',
+        apiStackName: 'WebStack',
+        pathPattern: '/web',
+      }),
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'MyHttpApi',
+        apiStackName: 'AdminStack',
+        pathPattern: '/admin',
+      }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.serverKey).toBe('http-api:WebStack:MyHttpApi');
+    expect(groups[1]!.serverKey).toBe('http-api:AdminStack:MyHttpApi');
+    // Routes must NOT cross-pollinate between the two servers.
+    expect(groups[0]!.routes).toHaveLength(1);
+    expect(groups[0]!.routes[0]!.route.pathPattern).toBe('/web');
+    expect(groups[1]!.routes).toHaveLength(1);
+    expect(groups[1]!.routes[0]!.route.pathPattern).toBe('/admin');
+  });
+
+  it('falls back to un-prefixed serverKey when apiStackName is absent (backward compat)', () => {
+    // Templates without `aws:cdk:path` Metadata (or hand-rolled
+    // `cfn.Resource` defs) produce routes with `apiStackName: undefined`.
+    // The serverKey stays in the pre-fix shape so existing fixtures /
+    // synthesized templates without the metadata still group cleanly.
+    const routes = [
+      makeRoute({ source: 'http-api', apiLogicalId: 'BareApi' }),
+      makeRoute({ source: 'rest-v1', apiLogicalId: 'BareRest', apiVersion: 'v1' }),
+      makeRoute({ source: 'function-url', lambdaLogicalId: 'BareHandler' }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups.map((g) => g.serverKey)).toEqual([
+      'http-api:BareApi',
+      'rest-v1:BareRest',
+      'function-url:BareHandler',
+    ]);
+  });
+});
+
+describe('filterRoutesByApiIdentifier', () => {
+  const routes = [
+    makeRoute({
+      source: 'http-api',
+      apiLogicalId: 'PublicApi',
+      apiStackName: 'WebStack',
+      apiCdkPath: 'WebStack/PublicApi/Resource',
+      pathPattern: '/p',
+    }),
+    makeRoute({
+      source: 'http-api',
+      apiLogicalId: 'AdminApi',
+      apiStackName: 'AdminStack',
+      apiCdkPath: 'AdminStack/AdminApi/Resource',
+      pathPattern: '/a',
+    }),
+    makeRoute({
+      source: 'function-url',
+      lambdaLogicalId: 'GoHandler',
+      apiLogicalId: undefined,
+      apiStackName: 'BackendStack',
+      apiCdkPath: 'BackendStack/GoHandler',
+    }),
+  ];
+
+  it('matches HTTP API by bare logical id (form 1)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'PublicApi');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
+  });
+
+  it('matches Function URLs by backing Lambda logical id (form 1)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'GoHandler');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.source).toBe('function-url');
+  });
+
+  it('matches HTTP API by stack-qualified logical id (form 2)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'WebStack:PublicApi');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
+  });
+
+  it('matches Function URL by stack-qualified Lambda logical id (form 2)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'BackendStack:GoHandler');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.source).toBe('function-url');
+  });
+
+  it('matches HTTP API by exact CDK Construct path (form 3)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'WebStack/PublicApi/Resource');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
+  });
+
+  it('matches Function URL by exact CDK Construct path (form 3)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'BackendStack/GoHandler');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.source).toBe('function-url');
+  });
+
+  it('matches HTTP API by L2 Construct-path prefix → synthesized L1 child (form 4)', () => {
+    // CDK's `new apigatewayv2.HttpApi(stack, 'PublicApi')` emits L1 child
+    // at `WebStack/PublicApi/Resource`; users would type the L2 path
+    // `WebStack/PublicApi` and expect prefix-rule resolution — same UX
+    // as `cdkd orphan`.
+    const result = filterRoutesByApiIdentifier(routes, 'WebStack/PublicApi');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
+  });
+
+  it('does NOT prefix-match on partial path component (boundary check)', () => {
+    // `WebStack/Public` is a partial component of `WebStack/PublicApi/...`,
+    // NOT an ancestor cdk path — must not match. The trailing-`/` rule
+    // protects against this.
+    expect(filterRoutesByApiIdentifier(routes, 'WebStack/Public')).toEqual([]);
+  });
+
+  it('returns an empty array on no match (caller surfaces error)', () => {
+    expect(filterRoutesByApiIdentifier(routes, 'Nope')).toEqual([]);
+  });
+
+  it('falls back to bare-logical-id-only when apiCdkPath/apiStackName are missing', () => {
+    // Backward compat: routes discovered from a synthesized template
+    // without `aws:cdk:path` metadata (e.g. hand-rolled `cfn.Resource`)
+    // keep the pre-PR behavior — bare logical id matches, but the new
+    // forms don't.
+    const sparse = [
+      makeRoute({ source: 'http-api', apiLogicalId: 'BareApi', pathPattern: '/b' }),
+    ];
+    expect(filterRoutesByApiIdentifier(sparse, 'BareApi')).toHaveLength(1);
+    expect(filterRoutesByApiIdentifier(sparse, 'Stack:BareApi')).toEqual([]);
+    expect(filterRoutesByApiIdentifier(sparse, 'Stack/BareApi')).toEqual([]);
+  });
+});
+
+describe('availableApiIdentifiers', () => {
+  it('returns CDK Construct path when present (preferred primary form)', () => {
+    const routes = [
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'PublicApi',
+        apiCdkPath: 'WebStack/PublicApi/Resource',
+      }),
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'PublicApi',
+        apiCdkPath: 'WebStack/PublicApi/Resource',
+      }),
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'AdminApi',
+        apiCdkPath: 'AdminStack/AdminApi/Resource',
+      }),
+      makeRoute({
+        source: 'function-url',
+        lambdaLogicalId: 'GoHandler',
+        apiCdkPath: 'BackendStack/GoHandler',
+      }),
+    ];
+    expect(availableApiIdentifiers(routes)).toEqual([
+      'WebStack/PublicApi/Resource',
+      'AdminStack/AdminApi/Resource',
+      'BackendStack/GoHandler',
+    ]);
+  });
+
+  it('falls back to bare logical id when apiCdkPath is missing', () => {
+    const routes = [
+      makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi' }),
+      makeRoute({ source: 'http-api', apiLogicalId: 'AdminApi' }),
+      makeRoute({ source: 'function-url', lambdaLogicalId: 'GoHandler' }),
+    ];
+    expect(availableApiIdentifiers(routes)).toEqual(['PublicApi', 'AdminApi', 'GoHandler']);
+  });
+});

--- a/tests/unit/local/docker-version.test.ts
+++ b/tests/unit/local/docker-version.test.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi } from 'vite-plus/test';
+import {
+  compareDockerVersions,
+  HOST_GATEWAY_MIN_VERSION,
+  parseDockerVersion,
+  probeHostGatewaySupport,
+} from '../../../src/local/docker-version.js';
+
+describe('parseDockerVersion', () => {
+  it('parses canonical "<major>.<minor>.<patch>"', () => {
+    expect(parseDockerVersion('20.10.21')).toEqual({ major: 20, minor: 10, patch: 21 });
+    expect(parseDockerVersion('27.3.1')).toEqual({ major: 27, minor: 3, patch: 1 });
+  });
+  it('parses "<major>.<minor>" with implicit patch=0', () => {
+    expect(parseDockerVersion('24.0')).toEqual({ major: 24, minor: 0, patch: 0 });
+  });
+  it('strips Docker Desktop / rootless / podman suffixes', () => {
+    expect(parseDockerVersion('24.0.7-rd')).toEqual({ major: 24, minor: 0, patch: 7 });
+    expect(parseDockerVersion('27.3.1+podman')).toEqual({ major: 27, minor: 3, patch: 1 });
+    expect(parseDockerVersion('20.10.21-ce')).toEqual({ major: 20, minor: 10, patch: 21 });
+  });
+  it('tolerates leading / trailing whitespace', () => {
+    expect(parseDockerVersion('  20.10.21\n')).toEqual({ major: 20, minor: 10, patch: 21 });
+  });
+  it('returns null on unparseable input (podman / finch / nerdctl shapes)', () => {
+    expect(parseDockerVersion('')).toBeNull();
+    expect(parseDockerVersion('not-a-version')).toBeNull();
+    expect(parseDockerVersion('podman version 4.6.1')).toBeNull();
+  });
+});
+
+describe('compareDockerVersions', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareDockerVersions({ major: 20, minor: 10, patch: 0 }, { major: 19, minor: 99, patch: 99 })).toBeGreaterThan(0);
+    expect(compareDockerVersions({ major: 20, minor: 10, patch: 0 }, { major: 20, minor: 10, patch: 1 })).toBeLessThan(0);
+    expect(compareDockerVersions({ major: 20, minor: 10, patch: 0 }, { major: 20, minor: 10, patch: 0 })).toBe(0);
+  });
+  it('returns positive for newer-than-min versions', () => {
+    expect(
+      compareDockerVersions({ major: 27, minor: 3, patch: 1 }, HOST_GATEWAY_MIN_VERSION)
+    ).toBeGreaterThan(0);
+  });
+  it('returns negative for older-than-min versions', () => {
+    expect(
+      compareDockerVersions({ major: 19, minor: 3, patch: 8 }, HOST_GATEWAY_MIN_VERSION)
+    ).toBeLessThan(0);
+    expect(
+      compareDockerVersions({ major: 20, minor: 9, patch: 0 }, HOST_GATEWAY_MIN_VERSION)
+    ).toBeLessThan(0);
+  });
+});
+
+vi.mock('../../../src/utils/docker-cmd.js', () => ({
+  runDockerStreaming: vi.fn(),
+}));
+
+const dockerCmd = (await import('../../../src/utils/docker-cmd.js')) as unknown as {
+  runDockerStreaming: ReturnType<typeof vi.fn>;
+};
+
+describe('probeHostGatewaySupport', () => {
+  it('returns supported=true for Docker 20.10', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '20.10.21\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe).toEqual({
+      rawVersion: '20.10.21',
+      parsed: { major: 20, minor: 10, patch: 21 },
+      supported: true,
+    });
+  });
+  it('returns supported=true for Docker 27+', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '27.3.1\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.supported).toBe(true);
+  });
+  it('returns supported=false for Docker 19.x (pre-20.10)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '19.03.15\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.supported).toBe(false);
+    expect(probe.parsed).toEqual({ major: 19, minor: 3, patch: 15 });
+  });
+  it('returns supported=false for Docker 20.9 (just below the bar)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '20.9.0\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.supported).toBe(false);
+  });
+  it('returns supported=true with parsed=null for unparseable version strings (podman / finch fallback)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({
+      stdout: 'podman version 4.6.1\n',
+      stderr: '',
+    });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.parsed).toBeNull();
+    expect(probe.supported).toBe(true); // defer to warn path, not hard-fail
+    expect(probe.rawVersion).toBe('podman version 4.6.1');
+  });
+  it('returns supported=false for empty stdout (daemon unreachable / output stripped)', async () => {
+    // Surfaced by PR #539 review: pre-fix the empty-stdout case
+    // returned `supported=true` (warn-and-pass) because the
+    // unparseable-version branch short-circuited before checking for
+    // the empty string. Empty stdout from `docker version` is much
+    // more likely a broken probe than a real-but-unparseable engine.
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.rawVersion).toBe('');
+    expect(probe.parsed).toBeNull();
+    expect(probe.supported).toBe(false);
+  });
+  it('returns supported=false for whitespace-only stdout', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '   \n  ', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.rawVersion).toBe('');
+    expect(probe.supported).toBe(false);
+  });
+  it('lets a docker subprocess failure bubble up unchanged (binary missing / daemon down)', async () => {
+    const fakeErr = new Error('Failed to find and execute \'docker\'');
+    dockerCmd.runDockerStreaming.mockRejectedValueOnce(fakeErr);
+    await expect(probeHostGatewaySupport()).rejects.toThrow(/Failed to find and execute/);
+  });
+});

--- a/tests/unit/local/layer-arn-materializer.test.ts
+++ b/tests/unit/local/layer-arn-materializer.test.ts
@@ -1,0 +1,304 @@
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { deflateRaw } from 'node:zlib';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import {
+  LayerMaterializationError,
+  materializeLayerFromArn,
+  type AwsCredentials,
+  type LambdaSendClient,
+  type StsSendClient,
+} from '../../../src/local/layer-arn-materializer.js';
+import type { ResolvedArnLambdaLayer } from '../../../src/local/lambda-resolver.js';
+
+/**
+ * Build a minimal ZIP buffer containing the listed `{name, data}`
+ * entries. The format follows the documented PKZIP central directory
+ * shape with DEFLATE-compressed payloads — exactly what AWS Lambda
+ * publishes as a layer ZIP.
+ *
+ * Hand-rolling the ZIP in test code keeps the test fully synchronous
+ * against the production `unzipBufferToDirectory` helper without
+ * pulling in a heavyweight test-only dep. The helper supports both
+ * STORE (method 0) and DEFLATE (method 8); we always emit DEFLATE
+ * here because real layer ZIPs use it.
+ */
+async function buildZip(entries: { name: string; data: Buffer | string }[]): Promise<Uint8Array> {
+  const central: Buffer[] = [];
+  const localParts: Buffer[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const dataBuf = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data, 'utf-8');
+    const compressed = await new Promise<Buffer>((resolve, reject) => {
+      deflateRaw(dataBuf, (err, out) => (err ? reject(err) : resolve(out)));
+    });
+    const nameBuf = Buffer.from(entry.name, 'utf-8');
+    // crc32 stub: we use 0 because the production decoder does not
+    // verify the CRC (we only compare uncompressed length).
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4); // version needed
+    localHeader.writeUInt16LE(0, 6); // gen flags
+    localHeader.writeUInt16LE(8, 8); // compression: DEFLATE
+    localHeader.writeUInt16LE(0, 10); // mtime
+    localHeader.writeUInt16LE(0, 12); // mdate
+    localHeader.writeUInt32LE(0, 14); // crc32 (unverified)
+    localHeader.writeUInt32LE(compressed.length, 18);
+    localHeader.writeUInt32LE(dataBuf.length, 22);
+    localHeader.writeUInt16LE(nameBuf.length, 26);
+    localHeader.writeUInt16LE(0, 28); // extra len
+    localParts.push(localHeader, nameBuf, compressed);
+
+    const cdEntry = Buffer.alloc(46);
+    cdEntry.writeUInt32LE(0x02014b50, 0);
+    cdEntry.writeUInt16LE(20, 4); // version made by
+    cdEntry.writeUInt16LE(20, 6); // version needed
+    cdEntry.writeUInt16LE(0, 8); // gen flags
+    cdEntry.writeUInt16LE(8, 10); // compression
+    cdEntry.writeUInt16LE(0, 12);
+    cdEntry.writeUInt16LE(0, 14);
+    cdEntry.writeUInt32LE(0, 16);
+    cdEntry.writeUInt32LE(compressed.length, 20);
+    cdEntry.writeUInt32LE(dataBuf.length, 24);
+    cdEntry.writeUInt16LE(nameBuf.length, 28);
+    cdEntry.writeUInt16LE(0, 30); // extra
+    cdEntry.writeUInt16LE(0, 32); // comment
+    cdEntry.writeUInt16LE(0, 34); // disk no
+    cdEntry.writeUInt16LE(0, 36); // internal
+    cdEntry.writeUInt32LE(0, 38); // external (regular file)
+    cdEntry.writeUInt32LE(offset, 42);
+    central.push(cdEntry, nameBuf);
+    offset += localHeader.length + nameBuf.length + compressed.length;
+  }
+  const cdBuf = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cdBuf.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  eocd.writeUInt16LE(0, 20);
+  return new Uint8Array(Buffer.concat([Buffer.concat(localParts), cdBuf, eocd]));
+}
+
+function makeLayer(overrides: Partial<ResolvedArnLambdaLayer> = {}): ResolvedArnLambdaLayer {
+  return {
+    kind: 'arn',
+    logicalId: 'arn:aws:lambda:us-east-1:111122223333:layer:MyLayer:3',
+    arn: 'arn:aws:lambda:us-east-1:111122223333:layer:MyLayer:3',
+    region: 'us-east-1',
+    accountId: '111122223333',
+    name: 'MyLayer',
+    version: '3',
+    ...overrides,
+  };
+}
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop()!;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup; some tests already removed the dir.
+    }
+  }
+});
+
+describe('materializeLayerFromArn', () => {
+  it('calls GetLayerVersion in the layer ARN region (not the dev profile region) and unzips Content.Location into a tmpdir', async () => {
+    const calls: { region: string; command: unknown }[] = [];
+    const zip = await buildZip([
+      { name: 'nodejs/', data: '' },
+      { name: 'nodejs/index.js', data: 'module.exports = 42;' },
+    ]);
+
+    const lambdaFactory = (region: string): LambdaSendClient => ({
+      send: async (command: { input?: unknown }) => {
+        calls.push({ region, command: command.input ?? command });
+        return { Content: { Location: 'https://presigned.example/zip' } };
+      },
+    });
+
+    const fetchedUrls: string[] = [];
+    const dir = await materializeLayerFromArn(makeLayer({ region: 'eu-west-1' }), {
+      lambdaClientFactory: lambdaFactory,
+      fetchZip: async (url) => {
+        fetchedUrls.push(url);
+        return zip;
+      },
+    });
+    cleanupDirs.push(dir);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.region).toBe('eu-west-1');
+    expect(fetchedUrls).toEqual(['https://presigned.example/zip']);
+    expect(existsSync(join(dir, 'nodejs', 'index.js'))).toBe(true);
+    expect(readFileSync(join(dir, 'nodejs', 'index.js'), 'utf-8')).toBe('module.exports = 42;');
+  });
+
+  it('routes through sts:AssumeRole when roleArn is set and forwards the temp creds to the Lambda client', async () => {
+    const stsCalls: { region: string }[] = [];
+    const lambdaCalls: { credentials?: AwsCredentials }[] = [];
+    const stsFactory = (region: string): StsSendClient => ({
+      send: async () => {
+        stsCalls.push({ region });
+        return {
+          Credentials: {
+            AccessKeyId: 'AKIAFAKE',
+            SecretAccessKey: 'secret/fake',
+            SessionToken: 'session-token-fake',
+          },
+        };
+      },
+    });
+    const lambdaFactory = (_region: string, credentials?: AwsCredentials): LambdaSendClient => ({
+      send: async () => {
+        lambdaCalls.push({ ...(credentials !== undefined && { credentials }) });
+        return { Content: { Location: 'https://presigned.example/zip' } };
+      },
+    });
+    const zip = await buildZip([{ name: 'python/handler.py', data: 'print(1)' }]);
+
+    const dir = await materializeLayerFromArn(makeLayer({ region: 'us-west-2' }), {
+      roleArn: 'arn:aws:iam::999988887777:role/CrossAccountReadLayer',
+      stsClientFactory: stsFactory,
+      lambdaClientFactory: lambdaFactory,
+      fetchZip: async () => zip,
+    });
+    cleanupDirs.push(dir);
+
+    expect(stsCalls).toEqual([{ region: 'us-west-2' }]);
+    expect(lambdaCalls).toHaveLength(1);
+    expect(lambdaCalls[0]!.credentials).toEqual({
+      accessKeyId: 'AKIAFAKE',
+      secretAccessKey: 'secret/fake',
+      sessionToken: 'session-token-fake',
+    });
+  });
+
+  it('surfaces an actionable error on GetLayerVersion AccessDenied', async () => {
+    const lambdaFactory = (): LambdaSendClient => ({
+      send: async () => {
+        const err = new Error(
+          'User: arn:aws:iam::111122223333:user/dev is not authorized to perform: lambda:GetLayerVersion'
+        );
+        (err as { name?: string }).name = 'AccessDeniedException';
+        throw err;
+      },
+    });
+    await expect(
+      materializeLayerFromArn(makeLayer(), {
+        lambdaClientFactory: lambdaFactory,
+        fetchZip: async () => new Uint8Array(),
+      })
+    ).rejects.toThrow(LayerMaterializationError);
+    await expect(
+      materializeLayerFromArn(makeLayer(), {
+        lambdaClientFactory: lambdaFactory,
+        fetchZip: async () => new Uint8Array(),
+      })
+    ).rejects.toThrow(/GetLayerVersion access denied.*--layer-role-arn/);
+  });
+
+  it('reports STS failure separately from GetLayerVersion failure (different hint)', async () => {
+    const stsFactory = (): StsSendClient => ({
+      send: async () => {
+        throw new Error('Not authorized to perform: sts:AssumeRole');
+      },
+    });
+    await expect(
+      materializeLayerFromArn(makeLayer(), {
+        roleArn: 'arn:aws:iam::999988887777:role/BadRole',
+        stsClientFactory: stsFactory,
+        fetchZip: async () => new Uint8Array(),
+      })
+    ).rejects.toThrow(/STS AssumeRole.*BadRole.*role trust policy/);
+  });
+
+  it('rejects ZIP entries that try to escape the destination directory (Zip Slip)', async () => {
+    const zip = await buildZip([{ name: '../escaped.txt', data: 'evil' }]);
+    const lambdaFactory = (): LambdaSendClient => ({
+      send: async () => ({ Content: { Location: 'https://presigned.example/zip' } }),
+    });
+    await expect(
+      materializeLayerFromArn(makeLayer(), {
+        lambdaClientFactory: lambdaFactory,
+        fetchZip: async () => zip,
+      })
+    ).rejects.toThrow(/escapes the destination directory/);
+  });
+
+  it('rmSyncs the just-created tmpdir on unzip failure (no orphan dir leak)', async () => {
+    // Review-fix M1 from PR #491: `materializeLayerFromArn` creates a
+    // fresh tmpdir via `mkdtemp(...)` BEFORE calling
+    // `unzipBufferToDirectory`. The unzip step can throw (Zip Slip /
+    // symlink / corrupt ZIP / unsupported compression) and the caller
+    // never receives the directory path on the error path — so the
+    // outer cleanup loops in `local-invoke.ts` (`ImagePlan.layerArnTmpDirs`)
+    // and `local-start-api.ts` (`layerTmpDirs: Set<string>`) never learn
+    // about it. Without the in-materializer `rmSync` the OS would keep
+    // the dir until reboot. This test pins the fix.
+    //
+    // Detection strategy: snapshot the set of `cdkl-arn-layer-*`
+    // dirs under `os.tmpdir()` before the failing call, then after the
+    // reject assert no NEW dir matching the layer's `<name>-<version>`
+    // prefix survived.
+    const layer = makeLayer({ name: 'CleanupLayer', version: '99' });
+    const prefix = `cdkl-arn-layer-${layer.name}-${layer.version}-`;
+    const snapshot = new Set(
+      readdirSync(tmpdir()).filter((entry) => entry.startsWith(prefix))
+    );
+
+    const zip = await buildZip([{ name: '../escaped.txt', data: 'evil' }]);
+    const lambdaFactory = (): LambdaSendClient => ({
+      send: async () => ({ Content: { Location: 'https://presigned.example/zip' } }),
+    });
+    await expect(
+      materializeLayerFromArn(layer, {
+        lambdaClientFactory: lambdaFactory,
+        fetchZip: async () => zip,
+      })
+    ).rejects.toThrow(LayerMaterializationError);
+
+    const after = readdirSync(tmpdir()).filter((entry) => entry.startsWith(prefix));
+    const newDirs = after.filter((entry) => !snapshot.has(entry));
+    expect(newDirs).toEqual([]);
+    // Defense-in-depth: also assert none of those potential dirs exist
+    // (covers a race where the OS hands out the same random suffix).
+    for (const entry of newDirs) {
+      expect(existsSync(join(tmpdir(), entry))).toBe(false);
+    }
+  });
+
+  it('rejects HTTP failures on the presigned URL with a clear message', async () => {
+    const lambdaFactory = (): LambdaSendClient => ({
+      send: async () => ({ Content: { Location: 'https://presigned.example/zip' } }),
+    });
+    await expect(
+      materializeLayerFromArn(makeLayer(), {
+        lambdaClientFactory: lambdaFactory,
+        fetchZip: async () => {
+          throw new Error('HTTP 403 Forbidden from layer Content.Location URL');
+        },
+      })
+    ).rejects.toThrow(/failed to download layer ZIP/);
+  });
+
+  it('rejects an empty Content.Location response (missing presigned URL)', async () => {
+    const lambdaFactory = (): LambdaSendClient => ({
+      send: async () => ({ Content: {} }),
+    });
+    await expect(
+      materializeLayerFromArn(makeLayer(), {
+        lambdaClientFactory: lambdaFactory,
+        fetchZip: async () => new Uint8Array(),
+      })
+    ).rejects.toThrow(/GetLayerVersion response did not include Content\.Location/);
+  });
+});


### PR DESCRIPTION
## Summary

Exposes three more `src/local/**` leaf primitives from the package entry so a host (cdkd) can shim them as `export { ... } from 'cdk-local'` and stop carrying byte-identical copies. This is the cdk-local half of cdkd shim slice 7 (the cdkd shim PR follows once this releases).

New exports in `src/index.ts`:

- **docker-version**: `HOST_GATEWAY_MIN_VERSION`, `probeHostGatewaySupport` (Docker host-gateway version probe for `start-api`).
- **api-server-grouping**: `availableApiIdentifiers`, `filterRoutesByApiIdentifier`, `groupRoutesByServer`, `type ApiServerGroup` (splits discovered routes into one group per local HTTP server).
- **layer-arn-materializer**: `materializeLayerFromArn` (downloads + unzips a literal-ARN Lambda Layer to a host tmpdir).

Test-only symbols (`parseDockerVersion` / `compareDockerVersions` / `routeMatchesIdentifier` / `LayerMaterializationError` / the layer test-seam types) are reachable via the source for the ported tests and intentionally NOT added to the package entry — the entry surface equals exactly what the host's `src/` imports.

## Tests

Ports the three modules' unit tests (cdk-local previously had none) verbatim from cdkd into `tests/unit/local/`:

- `docker-version.test.ts` (16 tests) — mocks `src/utils/docker-cmd.js`, which resolves to cdk-local's own copy.
- `api-server-grouping.test.ts` (19 tests) — type imports (`RouteWithAuth`, `DiscoveredRoute`) resolve at identical paths.
- `layer-arn-materializer.test.ts` (8 tests) — the tmpdir-prefix detection assertion was flipped from the cdkd-branded `cdkd-local-arn-layer-` to the cdk-local default `cdkl-arn-layer-` (the source builds the prefix from `getEmbedConfig().resourceNamePrefix`, which defaults to `cdkl`); without the flip the leak-detection filter would never match and the test would pass vacuously.

## Test plan

- [x] `vp run check` (format + lint + typecheck) clean
- [x] `vp run test` — 762 tests pass (55 files; 3 new files: 16 + 19 + 8)
- [x] `vp run build` — dist builds; all six value symbols present in `dist/index.js`, `ApiServerGroup` in `dist/index.d.ts`
