### PR TITLE
feat(exports): expose cors-handler + intrinsic-image primitives

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,3 +229,31 @@ export {
  * layers. Exposed only as the consuming host's `import` statement requires it.
  */
 export { materializeLayerFromArn } from './local/layer-arn-materializer.js';
+
+/**
+ * `start-api` CORS handling — parses CFn `CorsConfiguration` (and the CloudFront
+ * distribution chain) into a per-API CORS config and answers OPTIONS preflight
+ * for HTTP API v2. Exposed only as the consuming host's `import` statements
+ * require them.
+ */
+export {
+  applyCorsResponseHeaders,
+  buildCorsConfigByApiId,
+  buildCorsConfigFromCloudFrontChain,
+  matchPreflight,
+  type CorsConfig,
+} from './local/cors-handler.js';
+
+/**
+ * `invoke` / `start-api` / `run-task` container-image intrinsic resolver —
+ * resolves the canonical CDK 2.x `Fn::Join` shape for ECR image URIs
+ * (`lambda.DockerImageCode.fromEcr` / ECS `ContainerImage.fromEcrRepository`)
+ * and the same-stack ECR `Fn::GetAtt` Arn / RepositoryUri synthesis. Exposed
+ * only as the consuming host's `import` statements require them.
+ */
+export {
+  derivePseudoParametersFromRegion,
+  substituteImagePlaceholders,
+  tryResolveImageFnJoin,
+  type ImageResolutionContext,
+} from './local/intrinsic-image.js';

--- a/tests/unit/local/cors-handler.test.ts
+++ b/tests/unit/local/cors-handler.test.ts
@@ -1,6 +1,884 @@
-import { describe, it, expect } from 'vite-plus/test';
-import { isFunctionUrlOacFronted } from '../../../src/local/cors-handler.js';
-import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyCorsResponseHeaders,
+  buildCorsConfigByApiId,
+  buildCorsConfigFromCloudFrontChain,
+  isFunctionUrlOacFronted,
+  matchPreflight,
+  type CorsConfig,
+} from '../../../src/local/cors-handler.js';
+import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+/**
+ * Minimal stub for `ServerResponse`'s set/get/header interface used by
+ * `applyCorsResponseHeaders`. Captures `setHeader` calls into a map for
+ * assertion-friendly inspection. Only the surface
+ * `applyCorsResponseHeaders` touches is implemented.
+ */
+function mockRes(): {
+  setHeader: (name: string, value: string | string[]) => void;
+  getHeader: (name: string) => string | string[] | undefined;
+  headers: Map<string, string | string[]>;
+} {
+  const headers = new Map<string, string | string[]>();
+  return {
+    headers,
+    setHeader(name: string, value: string | string[]) {
+      headers.set(name, value);
+    },
+    getHeader(name: string) {
+      return headers.get(name);
+    },
+  };
+}
+
+function tpl(resources: Record<string, TemplateResource>): CloudFormationTemplate {
+  return { Resources: resources };
+}
+
+describe('buildCorsConfigByApiId', () => {
+  it('extracts CorsConfiguration from AWS::ApiGatewayV2::Api', () => {
+    const m = buildCorsConfigByApiId(
+      tpl({
+        Api: {
+          Type: 'AWS::ApiGatewayV2::Api',
+          Properties: {
+            ProtocolType: 'HTTP',
+            CorsConfiguration: {
+              AllowOrigins: ['https://example.com'],
+              AllowMethods: ['GET', 'POST'],
+              AllowHeaders: ['Content-Type'],
+              ExposeHeaders: ['X-Trace-Id'],
+              MaxAge: 600,
+              AllowCredentials: true,
+            },
+          },
+        },
+      })
+    );
+    const cors = m.get('Api');
+    expect(cors).toBeDefined();
+    expect(cors!.AllowOrigins).toEqual(['https://example.com']);
+    expect(cors!.AllowMethods).toEqual(['GET', 'POST']);
+    expect(cors!.MaxAge).toBe(600);
+    expect(cors!.AllowCredentials).toBe(true);
+  });
+
+  it('skips APIs without CorsConfiguration', () => {
+    const m = buildCorsConfigByApiId(
+      tpl({
+        Api: {
+          Type: 'AWS::ApiGatewayV2::Api',
+          Properties: { ProtocolType: 'HTTP' },
+        },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('skips REST v1 RestApi resources (not in scope)', () => {
+    const m = buildCorsConfigByApiId(
+      tpl({
+        RestApi: {
+          Type: 'AWS::ApiGateway::RestApi',
+          Properties: { Name: 'A' },
+        },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('returns empty when CorsConfiguration is fully blank', () => {
+    const m = buildCorsConfigByApiId(
+      tpl({
+        Api: {
+          Type: 'AWS::ApiGatewayV2::Api',
+          Properties: { ProtocolType: 'HTTP', CorsConfiguration: {} },
+        },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  // Issue #644: Function URL Cors block extraction. The CFn schema for
+  // AWS::Lambda::Url.Cors is field-for-field identical to HTTP API v2's
+  // CorsConfiguration, so the same parser handles both.
+  describe('AWS::Lambda::Url.Cors (issue #644)', () => {
+    it('extracts Cors from AWS::Lambda::Url', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'AWS_IAM',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: {
+                AllowOrigins: ['http://127.0.0.1:5050'],
+                AllowMethods: ['POST'],
+                AllowHeaders: ['Authorization', 'Content-Type'],
+                AllowCredentials: true,
+                MaxAge: 600,
+              },
+            },
+          },
+        })
+      );
+      const cors = m.get('Url');
+      expect(cors).toBeDefined();
+      expect(cors?.AllowOrigins).toEqual(['http://127.0.0.1:5050']);
+      expect(cors?.AllowMethods).toEqual(['POST']);
+      expect(cors?.AllowHeaders).toEqual(['Authorization', 'Content-Type']);
+      expect(cors?.AllowCredentials).toBe(true);
+      expect(cors?.MaxAge).toBe(600);
+    });
+
+    it('skips Function URLs without a Cors block', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: { AuthType: 'NONE', TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+          },
+        })
+      );
+      expect(m.size).toBe(0);
+    });
+
+    it('returns empty for a Function URL with a fully blank Cors block', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'NONE',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: {},
+            },
+          },
+        })
+      );
+      expect(m.size).toBe(0);
+    });
+
+    it('merges Function URL entries with HTTP API v2 entries (different logical IDs)', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          HttpApi: {
+            Type: 'AWS::ApiGatewayV2::Api',
+            Properties: {
+              ProtocolType: 'HTTP',
+              CorsConfiguration: { AllowOrigins: ['*'] },
+            },
+          },
+          FnUrl: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'NONE',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: { AllowOrigins: ['http://localhost:3000'] },
+            },
+          },
+        })
+      );
+      expect(m.size).toBe(2);
+      expect(m.get('HttpApi')?.AllowOrigins).toEqual(['*']);
+      expect(m.get('FnUrl')?.AllowOrigins).toEqual(['http://localhost:3000']);
+    });
+
+    it('tolerates a malformed Cors block (non-object) without throwing', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'NONE',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: 'not-an-object',
+            },
+          },
+        })
+      );
+      expect(m.size).toBe(0);
+    });
+  });
+});
+
+// Issue #646: CloudFront ResponseHeadersPolicy CORS borrowed for the
+// fronted Function URL. The canonical production-correct CDK pattern
+// puts CORS on the edge (CloudFront), not on the origin (Function URL).
+describe('buildCorsConfigFromCloudFrontChain (issue #646)', () => {
+  function fnUrlOriginDomainName(fnUrlLogicalId: string): unknown {
+    return {
+      'Fn::Select': [
+        2,
+        {
+          'Fn::Split': ['/', { 'Fn::GetAtt': [fnUrlLogicalId, 'FunctionUrl'] }],
+        },
+      ],
+    };
+  }
+
+  function rhpResource(corsConfig: unknown): TemplateResource {
+    return {
+      Type: 'AWS::CloudFront::ResponseHeadersPolicy',
+      Properties: {
+        ResponseHeadersPolicyConfig: { CorsConfig: corsConfig, Name: 'rhp' },
+      },
+    };
+  }
+
+  function distributionResource(args: {
+    fnUrlLogicalId: string;
+    rhpLogicalId?: string;
+  }): TemplateResource {
+    return {
+      Type: 'AWS::CloudFront::Distribution',
+      Properties: {
+        DistributionConfig: {
+          Origins: [
+            {
+              DomainName: fnUrlOriginDomainName(args.fnUrlLogicalId),
+              Id: 'origin-1',
+            },
+          ],
+          DefaultCacheBehavior: {
+            TargetOriginId: 'origin-1',
+            ...(args.rhpLogicalId !== undefined && {
+              ResponseHeadersPolicyId: { Ref: args.rhpLogicalId },
+            }),
+          },
+        },
+      },
+    };
+  }
+
+  it('extracts CORS from a CloudFront → Function URL chain', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'AWS_IAM', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl', rhpLogicalId: 'Rhp' }),
+        Rhp: rhpResource({
+          AccessControlAllowOrigins: { Items: ['http://127.0.0.1:5050', 'https://dev.example.com'] },
+          AccessControlAllowMethods: { Items: ['POST'] },
+          AccessControlAllowHeaders: { Items: ['authorization', 'content-type'] },
+          AccessControlAllowCredentials: false,
+          AccessControlMaxAgeSec: 600,
+          OriginOverride: true,
+        }),
+      })
+    );
+    const cors = m.get('FnUrl');
+    expect(cors).toBeDefined();
+    expect(cors?.AllowOrigins).toEqual(['http://127.0.0.1:5050', 'https://dev.example.com']);
+    expect(cors?.AllowMethods).toEqual(['POST']);
+    expect(cors?.AllowHeaders).toEqual(['authorization', 'content-type']);
+    expect(cors?.AllowCredentials).toBe(false);
+    expect(cors?.MaxAge).toBe(600);
+  });
+
+  it('returns empty when the CloudFront distribution has no ResponseHeadersPolicy', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl' }),
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('returns empty when the ResponseHeadersPolicy has no CorsConfig', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl', rhpLogicalId: 'Rhp' }),
+        Rhp: {
+          Type: 'AWS::CloudFront::ResponseHeadersPolicy',
+          Properties: { ResponseHeadersPolicyConfig: { Name: 'rhp' } },
+        },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('ignores CloudFront distributions whose origin is not a Function URL', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        Bucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [{ DomainName: 'static.example.com.s3.amazonaws.com', Id: 'origin-1' }],
+              DefaultCacheBehavior: {
+                TargetOriginId: 'origin-1',
+                ResponseHeadersPolicyId: { Ref: 'Rhp' },
+              },
+            },
+          },
+        },
+        Rhp: rhpResource({ AccessControlAllowOrigins: { Items: ['*'] } }),
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('ignores AWS-managed RHP IDs (literal UUID, not Ref)', () => {
+    // CDK can set ResponseHeadersPolicyId to a literal AWS-managed-policy
+    // UUID. cdkd can't fetch those (they live in AWS), so we skip.
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [{ DomainName: fnUrlOriginDomainName('FnUrl'), Id: 'origin-1' }],
+              DefaultCacheBehavior: {
+                TargetOriginId: 'origin-1',
+                ResponseHeadersPolicyId: '67f7b8e0-7e4f-4e4c-a4f6-aws-managed',
+              },
+            },
+          },
+        },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('maps multiple distributions / Function URLs independently', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl1: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn1' } },
+        },
+        FnUrl2: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn2' } },
+        },
+        Dist1: distributionResource({ fnUrlLogicalId: 'FnUrl1', rhpLogicalId: 'Rhp1' }),
+        Dist2: distributionResource({ fnUrlLogicalId: 'FnUrl2', rhpLogicalId: 'Rhp2' }),
+        Rhp1: rhpResource({ AccessControlAllowOrigins: { Items: ['https://a.example.com'] } }),
+        Rhp2: rhpResource({ AccessControlAllowOrigins: { Items: ['https://b.example.com'] } }),
+      })
+    );
+    expect(m.size).toBe(2);
+    expect(m.get('FnUrl1')?.AllowOrigins).toEqual(['https://a.example.com']);
+    expect(m.get('FnUrl2')?.AllowOrigins).toEqual(['https://b.example.com']);
+  });
+
+  it('walks both DefaultCacheBehavior and CacheBehaviors[]', () => {
+    // Per-path CORS: v1 applies last-write-wins across cache behaviors
+    // (no per-path routing). Confirms we DO walk CacheBehaviors[].
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [{ DomainName: fnUrlOriginDomainName('FnUrl'), Id: 'origin-1' }],
+              DefaultCacheBehavior: {
+                TargetOriginId: 'origin-1',
+                ResponseHeadersPolicyId: { Ref: 'RhpDefault' },
+              },
+              CacheBehaviors: [
+                {
+                  PathPattern: '/api/*',
+                  TargetOriginId: 'origin-1',
+                  ResponseHeadersPolicyId: { Ref: 'RhpApi' },
+                },
+              ],
+            },
+          },
+        },
+        RhpDefault: rhpResource({
+          AccessControlAllowOrigins: { Items: ['https://default.example.com'] },
+        }),
+        RhpApi: rhpResource({
+          AccessControlAllowOrigins: { Items: ['https://api.example.com'] },
+        }),
+      })
+    );
+    // Last-write-wins: CacheBehaviors[] iterated after DefaultCacheBehavior.
+    expect(m.get('FnUrl')?.AllowOrigins).toEqual(['https://api.example.com']);
+  });
+
+  it('tolerates a malformed CorsConfig (non-object) without throwing', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl', rhpLogicalId: 'Rhp' }),
+        Rhp: rhpResource('not-an-object'),
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+});
+
+describe('matchPreflight', () => {
+  const config: CorsConfig = {
+    AllowOrigins: ['https://example.com'],
+    AllowMethods: ['GET', 'POST'],
+    AllowHeaders: ['Content-Type', 'Authorization'],
+    ExposeHeaders: [],
+  };
+
+  it('returns null on non-OPTIONS requests', () => {
+    expect(
+      matchPreflight(
+        {
+          method: 'GET',
+          headers: { origin: ['https://example.com'] },
+        },
+        config
+      )
+    ).toBeNull();
+  });
+
+  it('returns null when Origin header is absent', () => {
+    expect(
+      matchPreflight(
+        {
+          method: 'OPTIONS',
+          headers: { 'access-control-request-method': ['GET'] },
+        },
+        config
+      )
+    ).toBeNull();
+  });
+
+  it('emits canonical preflight response on full match', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['POST'],
+          'access-control-request-headers': ['Content-Type'],
+        },
+      },
+      config
+    );
+    expect(r).not.toBeNull();
+    expect(r!.statusCode).toBe(204);
+    expect(r!.headers['access-control-allow-origin']).toBe('https://example.com');
+    expect(r!.headers['access-control-allow-methods']).toBe('POST');
+    expect(r!.headers['access-control-allow-headers']).toBe('Content-Type');
+  });
+
+  it('returns null when Origin is not allowed', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://other.example'],
+          'access-control-request-method': ['GET'],
+        },
+      },
+      config
+    );
+    expect(r).toBeNull();
+  });
+
+  it('returns null when method is not allowed', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['DELETE'],
+        },
+      },
+      config
+    );
+    expect(r).toBeNull();
+  });
+
+  it('returns null when a requested header is not allowed', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['POST'],
+          'access-control-request-headers': ['X-Forbidden-Header'],
+        },
+      },
+      config
+    );
+    expect(r).toBeNull();
+  });
+
+  it("`*` wildcard matches any Origin", () => {
+    const wildcardConfig: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['*'],
+      AllowHeaders: ['*'],
+      ExposeHeaders: [],
+    };
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://anywhere.example'],
+          'access-control-request-method': ['DELETE'],
+          'access-control-request-headers': ['X-Custom-Header'],
+        },
+      },
+      wildcardConfig
+    );
+    expect(r).not.toBeNull();
+    expect(r!.headers['access-control-allow-origin']).toBe('*');
+    expect(r!.headers['access-control-allow-methods']).toBe('DELETE');
+    expect(r!.headers['access-control-allow-headers']).toBe('X-Custom-Header');
+  });
+
+  it('echoes request Origin (not `*`) when AllowCredentials is true', () => {
+    const wildcardCreds: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['*'],
+      AllowHeaders: ['*'],
+      ExposeHeaders: [],
+      AllowCredentials: true,
+    };
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://anywhere.example'],
+          'access-control-request-method': ['POST'],
+        },
+      },
+      wildcardCreds
+    );
+    expect(r).not.toBeNull();
+    expect(r!.headers['access-control-allow-origin']).toBe('https://anywhere.example');
+    expect(r!.headers['access-control-allow-credentials']).toBe('true');
+  });
+
+  it('emits MaxAge + ExposeHeaders when configured', () => {
+    const c: CorsConfig = {
+      AllowOrigins: ['https://example.com'],
+      AllowMethods: ['GET'],
+      AllowHeaders: ['*'],
+      ExposeHeaders: ['X-A', 'X-B'],
+      MaxAge: 1800,
+    };
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['GET'],
+        },
+      },
+      c
+    );
+    expect(r!.headers['access-control-expose-headers']).toBe('X-A,X-B');
+    expect(r!.headers['access-control-max-age']).toBe('1800');
+  });
+
+  it('treats requested-headers absence as a clean match', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['GET'],
+        },
+      },
+      config
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it('case-insensitively matches Methods + Headers', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['get'],
+          'access-control-request-headers': ['content-type, authorization'],
+        },
+      },
+      config
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it('emits Vary: Origin on every successful preflight (literal Origin path)', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['POST'],
+        },
+      },
+      config
+    );
+    expect(r).not.toBeNull();
+    expect(r!.headers['vary']).toBe('Origin');
+  });
+
+  it('emits Vary: Origin on the wildcard / no-credentials path', () => {
+    const wildcardConfig: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['*'],
+      AllowHeaders: ['*'],
+      ExposeHeaders: [],
+    };
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://anywhere.example'],
+          'access-control-request-method': ['GET'],
+        },
+      },
+      wildcardConfig
+    );
+    expect(r).not.toBeNull();
+    expect(r!.headers['access-control-allow-origin']).toBe('*');
+    expect(r!.headers['vary']).toBe('Origin');
+  });
+
+  it('emits Vary: Origin on the AllowCredentials echo path', () => {
+    const credsConfig: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['*'],
+      AllowHeaders: ['*'],
+      ExposeHeaders: [],
+      AllowCredentials: true,
+    };
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://anywhere.example'],
+          'access-control-request-method': ['POST'],
+        },
+      },
+      credsConfig
+    );
+    expect(r).not.toBeNull();
+    expect(r!.headers['access-control-allow-origin']).toBe('https://anywhere.example');
+    expect(r!.headers['vary']).toBe('Origin');
+  });
+
+  it('rejects access-control-request-headers with an empty entry (e.g. "Content-Type,,Authorization")', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://example.com'],
+          'access-control-request-method': ['POST'],
+          'access-control-request-headers': ['Content-Type,,Authorization'],
+        },
+      },
+      config
+    );
+    // Pre-fix the empty entry was silently skipped and the request
+    // matched. Post-fix the malformed list rejects.
+    expect(r).toBeNull();
+  });
+
+  it('does NOT include access-control-allow-origin header when origin is rejected (negative-header pin)', () => {
+    const r = matchPreflight(
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: ['https://other.example'],
+          'access-control-request-method': ['GET'],
+        },
+      },
+      config
+    );
+    // Returning null means the server falls through to route dispatch
+    // (404 / user OPTIONS handler). Pinning the null contract here
+    // because callers depend on "no preflight headers in null result".
+    expect(r).toBeNull();
+  });
+});
+
+// Issue #652: actual responses (2xx / 4xx / 5xx) need Allow-Origin too,
+// not just preflight. Without it the browser blocks the body from JS
+// even when the request itself succeeded server-side.
+describe('applyCorsResponseHeaders (issue #652)', () => {
+  const config: CorsConfig = {
+    AllowOrigins: ['http://127.0.0.1:5050', 'https://dev.example.com'],
+    AllowMethods: ['GET', 'POST'],
+    AllowHeaders: ['content-type', 'authorization'],
+    ExposeHeaders: [],
+  };
+  const map = new Map<string, CorsConfig>([['Url', config]]);
+
+  it('sets Allow-Origin echoing the request Origin on a matched API + matched Origin', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://127.0.0.1:5050');
+    expect(res.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('no-op when route has no apiLogicalId', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(res as never, undefined, map, 'http://127.0.0.1:5050');
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('no-op when API has no CORS config (route is not in the map)', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(res as never, 'OtherApi', map, 'http://127.0.0.1:5050');
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('no-op when request has no Origin header (non-CORS request)', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(res as never, 'Url', map, undefined);
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('no-op when Origin is not in AllowOrigins (do not smuggle through)', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'https://evil.example.com'
+    );
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('uses literal `*` when AllowOrigins has `*` AND AllowCredentials is not true', () => {
+    const wildcardConfig: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['GET'],
+      AllowHeaders: [],
+      ExposeHeaders: [],
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', wildcardConfig]]),
+      'https://anyone.example.com'
+    );
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    // Vary: Origin NOT set when serving `*` (response is identical
+    // across origins).
+    expect(res.headers.has('Vary')).toBe(false);
+  });
+
+  it('echoes Origin (not `*`) + sets Allow-Credentials when AllowCredentials is true', () => {
+    const credsConfig: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['GET'],
+      AllowHeaders: [],
+      ExposeHeaders: [],
+      AllowCredentials: true,
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', credsConfig]]),
+      'https://app.example.com'
+    );
+    // Per fetch spec: `*` is invalid alongside Allow-Credentials, so
+    // echo the request Origin instead.
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example.com');
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(res.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('sets Expose-Headers when configured', () => {
+    const exposeConfig: CorsConfig = {
+      AllowOrigins: ['http://127.0.0.1:5050'],
+      AllowMethods: ['GET'],
+      AllowHeaders: [],
+      ExposeHeaders: ['X-Request-Id', 'X-Trace-Id'],
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', exposeConfig]]),
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Access-Control-Expose-Headers')).toBe('X-Request-Id,X-Trace-Id');
+  });
+
+  it('does NOT set preflight-only headers (Allow-Methods / Allow-Headers / Max-Age)', () => {
+    const fullConfig: CorsConfig = {
+      AllowOrigins: ['http://127.0.0.1:5050'],
+      AllowMethods: ['GET', 'POST'],
+      AllowHeaders: ['Authorization'],
+      ExposeHeaders: [],
+      MaxAge: 600,
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', fullConfig]]),
+      'http://127.0.0.1:5050'
+    );
+    // Allow-Origin yes; preflight-only headers no.
+    expect(res.headers.has('Access-Control-Allow-Origin')).toBe(true);
+    expect(res.headers.has('Access-Control-Allow-Methods')).toBe(false);
+    expect(res.headers.has('Access-Control-Allow-Headers')).toBe(false);
+    expect(res.headers.has('Access-Control-Max-Age')).toBe(false);
+  });
+
+  it('appends to existing Vary header instead of overwriting', () => {
+    const res = mockRes();
+    res.setHeader('Vary', 'Accept-Encoding');
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Vary')).toBe('Accept-Encoding, Origin');
+  });
+
+  it('does NOT duplicate Origin in Vary when already present', () => {
+    const res = mockRes();
+    res.setHeader('Vary', 'Origin, Accept-Encoding');
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Vary')).toBe('Origin, Accept-Encoding');
+  });
+});
 
 /** The canonical CDK 2.x origin DomainName chain pointing at a Function URL. */
 function fnUrlDomainName(fnUrlLogicalId: string): unknown {

--- a/tests/unit/local/intrinsic-image.test.ts
+++ b/tests/unit/local/intrinsic-image.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  derivePseudoParametersFromRegion,
+  substituteImagePlaceholders,
+  tryResolveImageFnJoin,
+  type ImageResolutionContext,
+} from '../../../src/local/intrinsic-image.js';
+import type { TemplateResource } from '../../../src/types/resource.js';
+import type { ResourceState } from '../../../src/types/state.js';
+
+/**
+ * Unit tests for the shared image-URI intrinsic resolver extracted in
+ * issue #286 Gap 2. The helper is consumed by both ECS
+ * (`ecs-task-resolver.ts`) and Lambda container (`lambda-resolver.ts`)
+ * resolvers — the test surface covers the canonical CDK 2.x shapes both
+ * call sites care about.
+ */
+
+const repoResources: Record<string, TemplateResource> = {
+  Repo1: { Type: 'AWS::ECR::Repository', Properties: {} },
+};
+
+/**
+ * The canonical `Fn::Join` shape CDK 2.x emits for
+ * `lambda.DockerImageCode.fromEcr(repo, { tagOrDigest })` and
+ * `ContainerImage.fromEcrRepository(repo, tag)`. Captured by `cdk synth`
+ * + `jq` from a real CDK app (see issue #286 Gap 2 verification step).
+ */
+function canonicalFromEcrJoin(repoLogicalId: string, tagOrDigest: string): unknown {
+  return {
+    'Fn::Join': [
+      '',
+      [
+        {
+          'Fn::Select': [
+            4,
+            { 'Fn::Split': [':', { 'Fn::GetAtt': [repoLogicalId, 'Arn'] }] },
+          ],
+        },
+        '.dkr.ecr.',
+        {
+          'Fn::Select': [
+            3,
+            { 'Fn::Split': [':', { 'Fn::GetAtt': [repoLogicalId, 'Arn'] }] },
+          ],
+        },
+        '.',
+        { Ref: 'AWS::URLSuffix' },
+        '/',
+        { Ref: repoLogicalId },
+        tagOrDigest.startsWith('sha256:') ? `@${tagOrDigest}` : `:${tagOrDigest}`,
+      ],
+    ],
+  };
+}
+
+describe('tryResolveImageFnJoin', () => {
+  it('returns not-applicable for a non-Fn::Join value', () => {
+    expect(tryResolveImageFnJoin('public.ecr.aws/nginx:1', repoResources, undefined)).toEqual({
+      kind: 'not-applicable',
+    });
+    expect(tryResolveImageFnJoin({ 'Fn::Sub': 'foo:bar' }, repoResources, undefined)).toEqual({
+      kind: 'not-applicable',
+    });
+    expect(tryResolveImageFnJoin(null, repoResources, undefined)).toEqual({
+      kind: 'not-applicable',
+    });
+    expect(tryResolveImageFnJoin(undefined, repoResources, undefined)).toEqual({
+      kind: 'not-applicable',
+    });
+  });
+
+  it('returns needs-state when the canonical from-ECR shape has no state context', () => {
+    const result = tryResolveImageFnJoin(
+      canonicalFromEcrJoin('Repo1', 'latest'),
+      repoResources,
+      undefined
+    );
+    expect(result).toEqual({ kind: 'needs-state', repoLogicalId: 'Repo1' });
+  });
+
+  it('returns needs-state when state-resources is missing the matching entry', () => {
+    const ctx: ImageResolutionContext = {
+      pseudoParameters: { urlSuffix: 'amazonaws.com' },
+      // stateResources omitted entirely → needs-state
+    };
+    const result = tryResolveImageFnJoin(
+      canonicalFromEcrJoin('Repo1', 'latest'),
+      repoResources,
+      ctx
+    );
+    expect(result).toEqual({ kind: 'needs-state', repoLogicalId: 'Repo1' });
+  });
+
+  it('resolves canonical from-ECR Fn::Join when full state + pseudo-parameters are supplied', () => {
+    const stateResources: Record<string, ResourceState> = {
+      Repo1: {
+        physicalId: 'my-repo-name',
+        resourceType: 'AWS::ECR::Repository',
+        properties: {},
+        attributes: {
+          Arn: 'arn:aws:ecr:us-east-1:111111111111:repository/my-repo-name',
+        },
+        dependencies: [],
+      },
+    };
+    const ctx: ImageResolutionContext = {
+      pseudoParameters: { urlSuffix: 'amazonaws.com' },
+      stateResources,
+    };
+    const result = tryResolveImageFnJoin(
+      canonicalFromEcrJoin('Repo1', 'latest'),
+      repoResources,
+      ctx
+    );
+    expect(result).toEqual({
+      kind: 'resolved',
+      uri: '111111111111.dkr.ecr.us-east-1.amazonaws.com/my-repo-name:latest',
+    });
+  });
+
+  it('resolves a digest-form from-ECR Fn::Join (with @sha256: tail)', () => {
+    const stateResources: Record<string, ResourceState> = {
+      Repo1: {
+        physicalId: 'r',
+        resourceType: 'AWS::ECR::Repository',
+        properties: {},
+        attributes: { Arn: 'arn:aws:ecr:us-west-2:222222222222:repository/r' },
+        dependencies: [],
+      },
+    };
+    const result = tryResolveImageFnJoin(
+      canonicalFromEcrJoin('Repo1', 'sha256:abc123'),
+      repoResources,
+      { pseudoParameters: { urlSuffix: 'amazonaws.com' }, stateResources }
+    );
+    expect(result).toEqual({
+      kind: 'resolved',
+      uri: '222222222222.dkr.ecr.us-west-2.amazonaws.com/r@sha256:abc123',
+    });
+  });
+
+  it('returns not-applicable for an unrelated Fn::Join with no ECR refs and unresolvable parts', () => {
+    // Imported-repo style — literal acct + region, `Ref: AWS::URLSuffix`,
+    // literal path. No same-stack ECR Repository ref. Without pseudo-
+    // parameter context the URLSuffix Ref returns undefined, so we fall
+    // through to not-applicable (the caller surfaces its own error).
+    const importedShape = {
+      'Fn::Join': [
+        '',
+        ['123456789012.dkr.ecr.us-east-1.', { Ref: 'AWS::URLSuffix' }, '/external:v1'],
+      ],
+    };
+    expect(tryResolveImageFnJoin(importedShape, {}, undefined)).toEqual({
+      kind: 'not-applicable',
+    });
+  });
+
+  it('resolves a public-URI Fn::Join with no intrinsic refs (literal concat only)', () => {
+    const literalShape = {
+      'Fn::Join': ['', ['public.ecr.aws/', 'nginx/nginx', ':alpine']],
+    };
+    expect(tryResolveImageFnJoin(literalShape, {}, undefined)).toEqual({
+      kind: 'resolved',
+      uri: 'public.ecr.aws/nginx/nginx:alpine',
+    });
+  });
+
+  it('rejects a malformed Fn::Join (wrong shape)', () => {
+    const bad = { 'Fn::Join': 'not-an-array' };
+    expect(tryResolveImageFnJoin(bad, {}, undefined)).toEqual({
+      kind: 'unsupported-join',
+      reason: expect.stringContaining('Fn::Join must be'),
+    });
+  });
+
+  it('rejects an Fn::Join with a non-string delimiter', () => {
+    const bad = { 'Fn::Join': [42, ['a', 'b']] };
+    expect(tryResolveImageFnJoin(bad, {}, undefined)).toEqual({
+      kind: 'unsupported-join',
+      reason: expect.stringContaining('delimiter must be a string'),
+    });
+  });
+
+  it('returns unsupported-join for an ECR-tree shape with an unresolvable element', () => {
+    // The Repo1 ref is present (so repoLogicalId is set), and stateResources
+    // is also present (so the needs-state path is skipped). But one of the
+    // inner elements is an unsupported intrinsic that the resolver does
+    // not handle, so it cannot be reduced to a string.
+    const stateResources: Record<string, ResourceState> = {
+      Repo1: {
+        physicalId: 'r',
+        resourceType: 'AWS::ECR::Repository',
+        properties: {},
+        attributes: { Arn: 'arn:aws:ecr:us-east-1:111111111111:repository/r' },
+        dependencies: [],
+      },
+    };
+    const ctx: ImageResolutionContext = {
+      pseudoParameters: { urlSuffix: 'amazonaws.com' },
+      stateResources,
+    };
+    const bad = {
+      'Fn::Join': [
+        '',
+        [
+          { Ref: 'Repo1' },
+          ':',
+          // Fn::If is intentionally out of scope for this resolver.
+          { 'Fn::If': ['SomeCondition', 'a', 'b'] },
+        ],
+      ],
+    };
+    const result = tryResolveImageFnJoin(bad, repoResources, ctx);
+    expect(result.kind).toBe('unsupported-join');
+  });
+});
+
+describe('substituteImagePlaceholders', () => {
+  it('passes through strings with no placeholders unchanged', () => {
+    expect(substituteImagePlaceholders('public.ecr.aws/x:1', {}, undefined)).toBe(
+      'public.ecr.aws/x:1'
+    );
+  });
+
+  it('substitutes AWS pseudo parameters', () => {
+    const ctx: ImageResolutionContext = {
+      pseudoParameters: {
+        accountId: '111111111111',
+        region: 'us-east-1',
+        partition: 'aws',
+        urlSuffix: 'amazonaws.com',
+      },
+    };
+    expect(
+      substituteImagePlaceholders(
+        '${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/repo:tag',
+        {},
+        ctx
+      )
+    ).toBe('111111111111.dkr.ecr.us-east-1.amazonaws.com/repo:tag');
+  });
+
+  it('substitutes same-stack ECR Repository Ref and GetAtt placeholders', () => {
+    const resources: Record<string, TemplateResource> = {
+      Repo1: { Type: 'AWS::ECR::Repository', Properties: {} },
+    };
+    const stateResources: Record<string, ResourceState> = {
+      Repo1: {
+        physicalId: 'my-repo-name',
+        resourceType: 'AWS::ECR::Repository',
+        properties: {},
+        attributes: { Arn: 'arn:aws:ecr:us-east-1:111111111111:repository/my-repo-name' },
+        dependencies: [],
+      },
+    };
+    expect(
+      substituteImagePlaceholders('prefix-${Repo1}-${Repo1.Arn}', resources, {
+        stateResources,
+      })
+    ).toBe(
+      'prefix-my-repo-name-arn:aws:ecr:us-east-1:111111111111:repository/my-repo-name'
+    );
+  });
+
+  it('leaves unrecognized placeholders untouched', () => {
+    expect(substituteImagePlaceholders('${Unknown}/x', {}, undefined)).toBe('${Unknown}/x');
+  });
+});
+
+describe('derivePseudoParametersFromRegion (issue #637)', () => {
+  it('returns aws partition for standard commercial regions', () => {
+    expect(derivePseudoParametersFromRegion('us-east-1')).toEqual({
+      region: 'us-east-1',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePseudoParametersFromRegion('eu-west-2')).toEqual({
+      region: 'eu-west-2',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePseudoParametersFromRegion('ap-northeast-1')).toEqual({
+      region: 'ap-northeast-1',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('returns aws-cn partition + .com.cn urlSuffix for China regions', () => {
+    expect(derivePseudoParametersFromRegion('cn-north-1')).toEqual({
+      region: 'cn-north-1',
+      partition: 'aws-cn',
+      urlSuffix: 'amazonaws.com.cn',
+    });
+    expect(derivePseudoParametersFromRegion('cn-northwest-1')).toEqual({
+      region: 'cn-northwest-1',
+      partition: 'aws-cn',
+      urlSuffix: 'amazonaws.com.cn',
+    });
+  });
+
+  it('returns aws-us-gov partition for GovCloud regions (urlSuffix stays .com)', () => {
+    expect(derivePseudoParametersFromRegion('us-gov-west-1')).toEqual({
+      region: 'us-gov-west-1',
+      partition: 'aws-us-gov',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePseudoParametersFromRegion('us-gov-east-1')).toEqual({
+      region: 'us-gov-east-1',
+      partition: 'aws-us-gov',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('returns aws-iso / aws-iso-b partitions for ISO regions', () => {
+    // us-isob-* must be checked BEFORE us-iso-* (prefix overlap).
+    expect(derivePseudoParametersFromRegion('us-iso-east-1')).toEqual({
+      region: 'us-iso-east-1',
+      partition: 'aws-iso',
+      urlSuffix: 'c2s.ic.gov',
+    });
+    expect(derivePseudoParametersFromRegion('us-isob-east-1')).toEqual({
+      region: 'us-isob-east-1',
+      partition: 'aws-iso-b',
+      urlSuffix: 'sc2s.sgov.gov',
+    });
+  });
+
+  it('passes accountId through when supplied', () => {
+    expect(derivePseudoParametersFromRegion('us-east-1', '123456789012')).toEqual({
+      accountId: '123456789012',
+      region: 'us-east-1',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('omits accountId field when not supplied', () => {
+    const result = derivePseudoParametersFromRegion('us-east-1');
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('accountId');
+  });
+
+  it('returns undefined for empty / falsy region', () => {
+    expect(derivePseudoParametersFromRegion(undefined)).toBeUndefined();
+    expect(derivePseudoParametersFromRegion('')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Exposes two more `src/local/**` modules from the package entry so a host (cdkd) can shim them as `export { ... } from 'cdk-local'`. This is the cdk-local half of cdkd shim slice 8 (the cdkd shim PR follows once this releases).

New exports in `src/index.ts`:

- **cors-handler**: `buildCorsConfigByApiId`, `buildCorsConfigFromCloudFrontChain`, `applyCorsResponseHeaders`, `matchPreflight`, `type CorsConfig` (CFn `CorsConfiguration` / CloudFront-chain parsing + HTTP API v2 OPTIONS preflight). `isFunctionUrlOacFronted` and `PreflightResponse` are NOT exported — the host's `src/` does not consume them; they stay reachable via the source for the ported test.
- **intrinsic-image**: `derivePseudoParametersFromRegion`, `tryResolveImageFnJoin`, `substituteImagePlaceholders`, `type ImageResolutionContext` (canonical CDK 2.x `Fn::Join` ECR image-URI resolver + same-stack ECR `Fn::GetAtt` synthesis). `FnJoinResolveOutcome` is NOT exported (no host consumer).

## Tests

- **cors-handler.test.ts**: merged the host's comprehensive 4-export coverage (`buildCorsConfigByApiId` / `buildCorsConfigFromCloudFrontChain` / `matchPreflight` / `applyCorsResponseHeaders`, 44 cases) into this repo's pre-existing `isFunctionUrlOacFronted` test (9 cases) → 53 cases total. No helper-name collisions (the two test files used disjoint helper names). No branding flips needed.
- **intrinsic-image.test.ts**: ported verbatim from the host (21 cases). Distinct filename from this repo's pre-existing `intrinsic-image-ecr-getatt.test.ts` (5 cases), so both coexist. No branding flips needed.

## Test plan

- [x] `vp run check` (format + lint + typecheck) clean
- [x] `vp run test` — 827 tests pass (56 files); cors-handler 53, intrinsic-image 21, intrinsic-image-ecr-getatt 5
- [x] `vp run build` — dist builds; all 7 value symbols present in `dist/index.js`, `CorsConfig` + `ImageResolutionContext` in `dist/index.d.ts`
