### PR TITLE
feat(list): add `cdkl list` / `ls` to enumerate runnable targets

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,7 +55,8 @@ Gateway).
 
 - `src/cli/` — Commander command factories (`createLocalInvokeCommand`,
   `createLocalStartApiCommand`, `createLocalRunTaskCommand`,
-  `createLocalStartServiceCommand`) + shared option helpers.
+  `createLocalStartServiceCommand`, `createLocalListCommand`) + shared
+  option helpers.
 - `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
   (`Toolkit.fromCdkApp()` + context store threading) that returns
   `StackInfo[]` for downstream consumers.
@@ -63,8 +64,9 @@ Gateway).
   websocket-server, ecs-task-runner, ecs-service-runner, ecs-network,
   cloud-map-registry, lambda-resolver, ecs-task-resolver,
   route-discovery, authorizer-resolver, lambda-authorizer, cognito-jwt,
-  sigv4-verify, rie-client, intrinsic-image, runtime-image, embed-config
-  (embed-time branding overrides for host CLIs), etc.
+  sigv4-verify, rie-client, intrinsic-image, runtime-image, target-lister
+  (`cdkl list` target enumeration), embed-config (embed-time branding
+  overrides for host CLIs), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state
@@ -230,7 +232,7 @@ vp run runtime:smoke
 - `cdk-local` is the **npm package** name (what users import / install).
 - When referring to the project in prose, use "cdk-local".
 - When referring to the CLI command in code blocks / examples, use
-  `cdkl invoke / start-api / run-task / start-service`.
+  `cdkl invoke / start-api / run-task / start-service / list`.
 - Do NOT write comparison tables against `aws-cdk-local` / `cdklocal` /
   LocalStack in committed artifacts (README, docs, JSDoc). The
   cdk-local vs LocalStack distinction is the

--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ This installs the `cdkl` command.
 
 Point cdk-local at your CDK app. It synths your stack and runs Lambda functions, API Gateway routes, and ECS tasks locally with Docker. No AWS credentials needed for the basic flow.
 
+#### Discover targets — `list` (alias `ls`)
+
+Not sure what to pass as a `<target>`? Run `cdkl list` (or `cdkl ls`) to synth your app and print every runnable target, grouped by the command that runs it. Each row shows both accepted forms — the CDK display path and the stack-qualified logical ID — so you can copy either straight into `invoke` / `start-api` / `run-task` / `start-service`.
+
+```bash
+cdkl list
+```
+
+```text
+Lambda Functions  (cdkl invoke <target>)
+  MyStack/ItemsHandler    MyStack:ItemsHandlerFB09CCF4
+
+APIs  (cdkl start-api [target])
+  MyStack/MyHttpApi       MyStack:MyHttpApi8AEAAC21
+
+ECS Services  (cdkl start-service <target...>)
+  MyStack/WebService      MyStack:WebService
+
+ECS Task Definitions  (cdkl run-task <target>)
+  MyStack/WebTask         MyStack:WebTask
+```
+
 #### Lambda — `invoke`
 
 Invoke a single Lambda function with an event payload.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,20 +7,23 @@ lifecycle, mTLS, authorizers, networking), see
 [local-emulation.md](./local-emulation.md). When something breaks, see
 [troubleshooting.md](./troubleshooting.md).
 
-cdk-local has four subcommands, all under the `cdkl` binary:
+cdk-local has five subcommands, all under the `cdkl` binary:
 
 | Subcommand | Emulates | Backed by |
 | --- | --- | --- |
+| `cdkl list` (alias `cdkl ls`) | Lists the app's runnable targets (no execution) | Synthesis only — no Docker |
 | `cdkl invoke <target>` | One-shot Lambda invoke | AWS Lambda Runtime Interface Emulator (RIE) container |
 | `cdkl start-api` | Long-running HTTP server — API Gateway (REST v1 / HTTP API / WebSocket) + Lambda Function URL | RIE container pool + `node:http` listener (one server per discovered API) |
 | `cdkl run-task <target>` | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
 | `cdkl start-service <targets...>` | Long-running ECS `Service` emulator | `run-task` machinery per replica + per-replica docker subnet allocator + restart-on-exit watcher |
 
-All four commands require Docker on the developer's machine. The first
+The four run commands (`invoke` / `start-api` / `run-task` /
+`start-service`) require Docker on the developer's machine. The first
 run pulls the relevant base image (~600MB for the language-specific
 Lambda images, ~50MB for `provided.*`, plus the ECS metadata sidecar for
 `run-task` / `start-service`). Subsequent runs reuse the cached image;
-pass `--no-pull` to skip the `docker pull` round-trip.
+pass `--no-pull` to skip the `docker pull` round-trip. `cdkl list` only
+synthesizes the app, so it needs no Docker.
 
 ## Common flags
 
@@ -40,6 +43,42 @@ Shared across every `cdkl` subcommand (declared in
 
 The `--from-cfn-stack` / `--stack-region` family is described in the
 per-command sections below.
+
+## `cdkl list` (discover runnable targets)
+
+`cdkl list` (alias `cdkl ls`) synthesizes the CDK app and prints every
+target the other subcommands can run, grouped by command. Use it when you
+don't know what to pass as a `<target>` — each row shows both accepted
+forms (the CDK display path and the stack-qualified logical ID
+`<Stack>:<LogicalId>`), so you can copy either into `invoke` /
+`start-api` / `run-task` / `start-service`.
+
+It runs synthesis only — no Docker, no AWS calls (beyond any synth-time
+context lookups your app performs) — and accepts only the
+[common flags](#common-flags) (`--app` / `--output` / `--context` /
+`--profile` / `--verbose`). There is no `<target>` argument; the command
+always lists the whole app.
+
+```text
+$ cdkl list
+Lambda Functions  (cdkl invoke <target>)
+  MyStack/ItemsHandler    MyStack:ItemsHandlerFB09CCF4
+
+APIs  (cdkl start-api [target])
+  MyStack/MyHttpApi       MyStack:MyHttpApi8AEAAC21
+
+ECS Services  (cdkl start-service <target...>)
+  MyStack/WebService      MyStack:WebService
+
+ECS Task Definitions  (cdkl run-task <target>)
+  MyStack/WebTask         MyStack:WebTask
+```
+
+Categories with no matching resources are omitted. The `APIs` group
+covers every surface `start-api` can serve — REST v1, HTTP API v2,
+Function URLs, and WebSocket APIs; a Function URL is shown under the
+backing Lambda's display path (the form `start-api` matches against)
+with the URL resource's own logical ID.
 
 ## `cdkl invoke` (run Lambda functions locally)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,11 +53,12 @@ forms (the CDK display path and the stack-qualified logical ID
 `<Stack>:<LogicalId>`), so you can copy either into `invoke` /
 `start-api` / `run-task` / `start-service`.
 
-It runs synthesis only — no Docker, no AWS calls (beyond any synth-time
-context lookups your app performs) — and accepts only the
+It needs no Docker. It synthesizes the app — which may perform context
+lookups, and (like every command) honors `--role-arn` / `CDKL_ROLE_ARN`
+by assuming that role first — and accepts only the
 [common flags](#common-flags) (`--app` / `--output` / `--context` /
-`--profile` / `--verbose`). There is no `<target>` argument; the command
-always lists the whole app.
+`--profile` / `--role-arn` / `--verbose`). There is no `<target>`
+argument; the command always lists the whole app.
 
 ```text
 $ cdkl list
@@ -76,9 +77,10 @@ ECS Task Definitions  (cdkl run-task <target>)
 
 Categories with no matching resources are omitted. The `APIs` group
 covers every surface `start-api` can serve — REST v1, HTTP API v2,
-Function URLs, and WebSocket APIs; a Function URL is shown under the
-backing Lambda's display path (the form `start-api` matches against)
-with the URL resource's own logical ID.
+Function URLs, and WebSocket APIs. A Function URL is shown under its
+backing Lambda's display path and logical ID, because that is how
+`start-api` addresses a Function URL target (so the same row may also
+appear under `Lambda Functions`, where `invoke` runs it directly).
 
 ## `cdkl invoke` (run Lambda functions locally)
 

--- a/src/cli/commands/local-list.ts
+++ b/src/cli/commands/local-list.ts
@@ -1,5 +1,12 @@
 import { Command } from 'commander';
-import { appOptions, commonOptions, contextOptions, parseContextOptions } from '../options.js';
+import {
+  appOptions,
+  commonOptions,
+  contextOptions,
+  deprecatedRegionOption,
+  parseContextOptions,
+  warnIfDeprecatedRegion,
+} from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
@@ -24,6 +31,7 @@ interface LocalListOptions {
   profile?: string;
   roleArn?: string;
   context?: string[];
+  region?: string;
 }
 
 /**
@@ -37,6 +45,8 @@ export interface CreateLocalListCommandOptions {
 async function localListCommand(options: LocalListOptions): Promise<void> {
   const logger = getLogger();
   if (options.verbose) logger.setLevel('debug');
+
+  warnIfDeprecatedRegion(options);
 
   await applyRoleArnIfSet({ roleArn: options.roleArn, region: undefined });
 
@@ -123,5 +133,6 @@ export function createLocalListCommand(opts: CreateLocalListCommandOptions = {})
     );
 
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(deprecatedRegionOption);
   return cmd;
 }

--- a/src/cli/commands/local-list.ts
+++ b/src/cli/commands/local-list.ts
@@ -1,0 +1,127 @@
+import { Command } from 'commander';
+import { appOptions, commonOptions, contextOptions, parseContextOptions } from '../options.js';
+import { getLogger } from '../../utils/logger.js';
+import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { withErrorHandling } from '../../utils/error-handler.js';
+import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import { resolveApp } from '../config-loader.js';
+import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
+import {
+  countTargets,
+  listTargets,
+  type TargetEntry,
+  type TargetListing,
+} from '../../local/target-lister.js';
+
+interface LocalListOptions {
+  app?: string;
+  output: string;
+  verbose: boolean;
+  profile?: string;
+  roleArn?: string;
+  context?: string[];
+}
+
+/**
+ * Factory options for {@link createLocalListCommand}.
+ */
+export interface CreateLocalListCommandOptions {
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
+}
+
+async function localListCommand(options: LocalListOptions): Promise<void> {
+  const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
+
+  await applyRoleArnIfSet({ roleArn: options.roleArn, region: undefined });
+
+  const appCmd = resolveApp(options.app);
+  if (!appCmd) {
+    throw new Error(
+      `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+    );
+  }
+
+  logger.info('Synthesizing CDK app...');
+  const synthesizer = new Synthesizer();
+  const context = parseContextOptions(options.context);
+  const synthOpts: SynthesisOptions = {
+    app: appCmd,
+    output: options.output,
+    ...(options.profile && { profile: options.profile }),
+    ...(Object.keys(context).length > 0 && { context }),
+  };
+  const { stacks } = await synthesizer.synthesize(synthOpts);
+
+  const listing = listTargets(stacks);
+  process.stdout.write(`${formatTargetListing(listing, getEmbedConfig().cliName)}\n`);
+}
+
+/**
+ * Render a {@link TargetListing} as the grouped, two-column text table
+ * `cdkl list` prints. Each non-empty category names the command that
+ * consumes it and lists every target's CDK display path alongside its
+ * stack-qualified logical ID. Exported so a unit test can assert the
+ * output shape without running synthesis.
+ */
+export function formatTargetListing(listing: TargetListing, cliName: string): string {
+  if (countTargets(listing) === 0) {
+    return `No runnable targets (Lambda functions, APIs, ECS services / tasks) found in this CDK app.`;
+  }
+
+  const sections: string[][] = [
+    formatSection('Lambda Functions', `${cliName} invoke <target>`, listing.lambdas),
+    formatSection('APIs', `${cliName} start-api [target]`, listing.apis),
+    formatSection('ECS Services', `${cliName} start-service <target...>`, listing.ecsServices),
+    formatSection(
+      'ECS Task Definitions',
+      `${cliName} run-task <target>`,
+      listing.ecsTaskDefinitions
+    ),
+  ];
+
+  return sections
+    .filter((lines) => lines.length > 0)
+    .map((lines) => lines.join('\n'))
+    .join('\n\n');
+}
+
+function formatSection(title: string, command: string, entries: TargetEntry[]): string[] {
+  if (entries.length === 0) return [];
+  const lines = [`${title}  (${command})`];
+  const width = Math.max(0, ...entries.map((e) => (e.displayPath ?? '').length));
+  for (const entry of entries) {
+    if (entry.displayPath) {
+      lines.push(`  ${entry.displayPath.padEnd(width)}  ${entry.qualifiedId}`);
+    } else {
+      lines.push(`  ${entry.qualifiedId}`);
+    }
+  }
+  return lines;
+}
+
+export function createLocalListCommand(opts: CreateLocalListCommandOptions = {}): Command {
+  setEmbedConfig(opts.embedConfig);
+  const cmd = new Command('list')
+    .alias('ls')
+    .description(
+      'List the runnable targets in the synthesized CDK app, grouped by the command that runs them: ' +
+        'Lambda functions (invoke), API Gateway REST v1 / HTTP v2 / Function URL / WebSocket surfaces ' +
+        '(start-api), ECS services (start-service), and ECS task definitions (run-task). Each target is ' +
+        'shown with its CDK display path and stack-qualified logical ID — copy either form as the ' +
+        '<target> argument for the matching command.'
+    )
+    .action(
+      withErrorHandling(async (options: LocalListOptions) => {
+        await localListCommand(options);
+      })
+    );
+
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  return cmd;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { createLocalInvokeCommand } from './commands/local-invoke.js';
 import { createLocalStartApiCommand } from './commands/local-start-api.js';
 import { createLocalRunTaskCommand } from './commands/local-run-task.js';
 import { createLocalStartServiceCommand } from './commands/local-start-service.js';
+import { createLocalListCommand } from './commands/local-list.js';
 
 declare const __CDK_LOCAL_VERSION__: string;
 
@@ -18,5 +19,6 @@ program.addCommand(createLocalInvokeCommand());
 program.addCommand(createLocalStartApiCommand());
 program.addCommand(createLocalRunTaskCommand());
 program.addCommand(createLocalStartServiceCommand());
+program.addCommand(createLocalListCommand());
 
 void program.parseAsync(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,23 @@ export {
   createLocalStartServiceCommand,
   type CreateLocalStartServiceCommandOptions,
 } from './cli/commands/local-start-service.js';
+export {
+  createLocalListCommand,
+  formatTargetListing,
+  type CreateLocalListCommandOptions,
+} from './cli/commands/local-list.js';
+
+/**
+ * Target enumeration — turns a synthesized Cloud Assembly into the
+ * runnable targets each `cdkl` command accepts, grouped by command.
+ * Backs `cdkl list` and is reusable for interactive target pickers.
+ */
+export {
+  listTargets,
+  countTargets,
+  type TargetEntry,
+  type TargetListing,
+} from './local/target-lister.js';
 
 export {
   createLocalStateProvider,

--- a/src/local/target-lister.ts
+++ b/src/local/target-lister.ts
@@ -1,0 +1,153 @@
+import { readCdkPath } from '../cli/cdk-path.js';
+import type { StackInfo } from '../synthesis/assembly-reader.js';
+import { getLogger } from '../utils/logger.js';
+import { discoverRoutes } from './route-discovery.js';
+import { discoverWebSocketApis } from './websocket-route-discovery.js';
+
+/**
+ * One runnable target surfaced by `cdkl list`.
+ *
+ * Both addressable forms the four `cdkl` commands accept are carried so
+ * the user can copy either: the stack-qualified logical ID
+ * ({@link qualifiedId}, valid in every app) and — when the synthesized
+ * resource carries `aws:cdk:path` metadata — the CDK Construct display
+ * path ({@link displayPath}).
+ */
+export interface TargetEntry {
+  /** CloudFormation logical ID (e.g. `OrdersServiceB12`). */
+  logicalId: string;
+  /** Physical stack name the resource lives in. */
+  stackName: string;
+  /**
+   * Stack-qualified logical ID (`<stackName>:<logicalId>`) — a target
+   * form accepted by every command, including multi-stack apps.
+   */
+  qualifiedId: string;
+  /**
+   * CDK Construct display path with a trailing `/Resource` stripped
+   * (e.g. `MyStack/OrdersService`). Omitted when the resource carries no
+   * `aws:cdk:path` metadata (hand-rolled `CfnResource`s).
+   */
+  displayPath?: string;
+}
+
+/**
+ * Runnable targets discovered in a synthesized CDK app, grouped by the
+ * command that consumes them.
+ */
+export interface TargetListing {
+  /** `AWS::Lambda::Function` — `cdkl invoke`. */
+  lambdas: TargetEntry[];
+  /**
+   * API surfaces `cdkl start-api` can serve — REST v1, HTTP API v2,
+   * Function URLs, and WebSocket APIs. Each entry is one API surface
+   * (de-duplicated across its routes).
+   */
+  apis: TargetEntry[];
+  /** `AWS::ECS::Service` — `cdkl start-service`. */
+  ecsServices: TargetEntry[];
+  /** `AWS::ECS::TaskDefinition` — `cdkl run-task`. */
+  ecsTaskDefinitions: TargetEntry[];
+}
+
+function makeEntry(stackName: string, logicalId: string, cdkPath: string | undefined): TargetEntry {
+  const entry: TargetEntry = {
+    logicalId,
+    stackName,
+    qualifiedId: `${stackName}:${logicalId}`,
+  };
+  // Mirror `cdkl invoke`'s own display-path suggestion: the L1 child a
+  // CDK L2 construct emits carries a trailing `/Resource` the target
+  // syntax does not need (the prefix rule matches the L2 ancestor).
+  const display = cdkPath ? cdkPath.replace(/\/Resource$/, '') : undefined;
+  if (display) entry.displayPath = display;
+  return entry;
+}
+
+function scanByType(stacks: readonly StackInfo[], type: string): TargetEntry[] {
+  const entries: TargetEntry[] = [];
+  for (const stack of stacks) {
+    const resources = stack.template.Resources ?? {};
+    for (const [logicalId, resource] of Object.entries(resources)) {
+      if (resource.Type !== type) continue;
+      entries.push(makeEntry(stack.stackName, logicalId, readCdkPath(resource) || undefined));
+    }
+  }
+  return entries;
+}
+
+/**
+ * Enumerate the API surfaces `cdkl start-api` can serve.
+ *
+ * Reuses the same discovery `start-api` runs (REST v1 / HTTP API v2 /
+ * Function URL routes + WebSocket APIs) so the listed identifiers are
+ * exactly the ones the `[target]` filter accepts — for a Function URL
+ * that means the backing Lambda's `aws:cdk:path`, not the URL resource's
+ * own path. Routes are collapsed to one entry per API surface.
+ *
+ * Discovery is best-effort: a malformed template that would hard-error
+ * `start-api` is downgraded to a warning here so `list` still surfaces
+ * every other target.
+ */
+function listApiSurfaces(stacks: readonly StackInfo[]): TargetEntry[] {
+  const byKey = new Map<string, TargetEntry>();
+
+  try {
+    for (const route of discoverRoutes(stacks)) {
+      if (!route.apiLogicalId || !route.apiStackName) continue;
+      const key = `${route.apiStackName}:${route.apiLogicalId}`;
+      if (byKey.has(key)) continue;
+      byKey.set(key, makeEntry(route.apiStackName, route.apiLogicalId, route.apiCdkPath));
+    }
+  } catch (err) {
+    getLogger().warn(
+      `Could not enumerate REST / HTTP / Function URL targets: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  const { apis, errors } = discoverWebSocketApis(stacks);
+  for (const api of apis) {
+    const key = `${api.apiStackName}:${api.apiLogicalId}`;
+    if (byKey.has(key)) continue;
+    byKey.set(key, makeEntry(api.apiStackName, api.apiLogicalId, api.apiCdkPath));
+  }
+  for (const e of errors) {
+    getLogger().warn(`Could not enumerate a WebSocket API target: ${e}`);
+  }
+
+  return [...byKey.values()];
+}
+
+/**
+ * Walk every synthesized stack and collect the resources the four
+ * `cdkl` commands can run locally, grouped by command.
+ *
+ * Pure over the synthesized {@link StackInfo}[] — no Docker / AWS /
+ * filesystem access — so both `cdkl list` and (future) interactive
+ * target pickers can share it.
+ */
+export function listTargets(stacks: readonly StackInfo[]): TargetListing {
+  return {
+    lambdas: sortEntries(scanByType(stacks, 'AWS::Lambda::Function')),
+    apis: sortEntries(listApiSurfaces(stacks)),
+    ecsServices: sortEntries(scanByType(stacks, 'AWS::ECS::Service')),
+    ecsTaskDefinitions: sortEntries(scanByType(stacks, 'AWS::ECS::TaskDefinition')),
+  };
+}
+
+/** Stable, human-readable ordering: by display path, falling back to the qualified ID. */
+function sortEntries(entries: TargetEntry[]): TargetEntry[] {
+  return [...entries].sort((a, b) =>
+    (a.displayPath ?? a.qualifiedId).localeCompare(b.displayPath ?? b.qualifiedId)
+  );
+}
+
+/** Total number of targets across every category. */
+export function countTargets(listing: TargetListing): number {
+  return (
+    listing.lambdas.length +
+    listing.apis.length +
+    listing.ecsServices.length +
+    listing.ecsTaskDefinitions.length
+  );
+}

--- a/src/local/target-lister.ts
+++ b/src/local/target-lister.ts
@@ -1,4 +1,4 @@
-import { readCdkPath } from '../cli/cdk-path.js';
+import { readCdkPathOrUndefined } from '../cli/cdk-path.js';
 import type { StackInfo } from '../synthesis/assembly-reader.js';
 import { getLogger } from '../utils/logger.js';
 import { discoverRoutes } from './route-discovery.js';
@@ -70,7 +70,7 @@ function scanByType(stacks: readonly StackInfo[], type: string): TargetEntry[] {
     const resources = stack.template.Resources ?? {};
     for (const [logicalId, resource] of Object.entries(resources)) {
       if (resource.Type !== type) continue;
-      entries.push(makeEntry(stack.stackName, logicalId, readCdkPath(resource) || undefined));
+      entries.push(makeEntry(stack.stackName, logicalId, readCdkPathOrUndefined(resource)));
     }
   }
   return entries;
@@ -81,9 +81,11 @@ function scanByType(stacks: readonly StackInfo[], type: string): TargetEntry[] {
  *
  * Reuses the same discovery `start-api` runs (REST v1 / HTTP API v2 /
  * Function URL routes + WebSocket APIs) so the listed identifiers are
- * exactly the ones the `[target]` filter accepts — for a Function URL
- * that means the backing Lambda's `aws:cdk:path`, not the URL resource's
- * own path. Routes are collapsed to one entry per API surface.
+ * exactly the ones the `[target]` filter accepts. For a Function URL that
+ * means the backing Lambda's logical ID and `aws:cdk:path` — start-api
+ * addresses a Function URL by its backing Lambda, not by the URL
+ * resource (see `routeMatchesIdentifier` in api-server-grouping.ts).
+ * Routes are collapsed to one entry per API surface.
  *
  * Discovery is best-effort: a malformed template that would hard-error
  * `start-api` is downgraded to a warning here so `list` still surfaces
@@ -91,13 +93,22 @@ function scanByType(stacks: readonly StackInfo[], type: string): TargetEntry[] {
  */
 function listApiSurfaces(stacks: readonly StackInfo[]): TargetEntry[] {
   const byKey = new Map<string, TargetEntry>();
+  const add = (stackName: string, logicalId: string, cdkPath: string | undefined): void => {
+    const key = `${stackName}:${logicalId}`;
+    if (!byKey.has(key)) byKey.set(key, makeEntry(stackName, logicalId, cdkPath));
+  };
 
   try {
     for (const route of discoverRoutes(stacks)) {
-      if (!route.apiLogicalId || !route.apiStackName) continue;
-      const key = `${route.apiStackName}:${route.apiLogicalId}`;
-      if (byKey.has(key)) continue;
-      byKey.set(key, makeEntry(route.apiStackName, route.apiLogicalId, route.apiCdkPath));
+      if (!route.apiStackName) continue;
+      // Mirror start-api's own identifier rule: a Function URL is keyed by
+      // its BACKING LAMBDA's logical ID, every other surface by the API
+      // resource's. Using the URL resource's own logical ID would print a
+      // `Stack:LogicalId` that `start-api [target]` rejects.
+      const logicalId =
+        route.source === 'function-url' ? route.lambdaLogicalId : route.apiLogicalId;
+      if (!logicalId) continue;
+      add(route.apiStackName, logicalId, route.apiCdkPath);
     }
   } catch (err) {
     getLogger().warn(
@@ -107,9 +118,7 @@ function listApiSurfaces(stacks: readonly StackInfo[]): TargetEntry[] {
 
   const { apis, errors } = discoverWebSocketApis(stacks);
   for (const api of apis) {
-    const key = `${api.apiStackName}:${api.apiLogicalId}`;
-    if (byKey.has(key)) continue;
-    byKey.set(key, makeEntry(api.apiStackName, api.apiLogicalId, api.apiCdkPath));
+    add(api.apiStackName, api.apiLogicalId, api.apiCdkPath);
   }
   for (const e of errors) {
     getLogger().warn(`Could not enumerate a WebSocket API target: ${e}`);

--- a/tests/unit/cli/local-list.test.ts
+++ b/tests/unit/cli/local-list.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { createLocalListCommand, formatTargetListing } from '../../../src/cli/commands/local-list.js';
+import type { TargetEntry, TargetListing } from '../../../src/local/target-lister.js';
+
+function entry(displayPath: string | undefined, qualifiedId: string): TargetEntry {
+  const [stackName, logicalId] = qualifiedId.split(':') as [string, string];
+  const e: TargetEntry = { logicalId, stackName, qualifiedId };
+  if (displayPath) e.displayPath = displayPath;
+  return e;
+}
+
+const empty: TargetListing = { lambdas: [], apis: [], ecsServices: [], ecsTaskDefinitions: [] };
+
+describe('formatTargetListing', () => {
+  it('reports a clear message when nothing is runnable', () => {
+    expect(formatTargetListing(empty, 'cdkl')).toMatch(/No runnable targets/);
+  });
+
+  it('groups each category under the command that runs it, with both target forms', () => {
+    const listing: TargetListing = {
+      lambdas: [entry('App/Handler', 'App:Handler')],
+      apis: [entry('App/HttpApi', 'App:HttpApi')],
+      ecsServices: [entry('App/OrdersService/Service', 'App:OrdersService')],
+      ecsTaskDefinitions: [entry('App/TaskDef', 'App:TaskDef')],
+    };
+    const out = formatTargetListing(listing, 'cdkl');
+    expect(out).toContain('Lambda Functions  (cdkl invoke <target>)');
+    expect(out).toContain('  App/Handler  App:Handler');
+    expect(out).toContain('APIs  (cdkl start-api [target])');
+    expect(out).toContain('ECS Services  (cdkl start-service <target...>)');
+    expect(out).toContain('  App/OrdersService/Service  App:OrdersService');
+    expect(out).toContain('ECS Task Definitions  (cdkl run-task <target>)');
+  });
+
+  it('omits categories with no targets', () => {
+    const listing: TargetListing = {
+      ...empty,
+      ecsServices: [entry('App/OrdersService', 'App:OrdersService')],
+    };
+    const out = formatTargetListing(listing, 'cdkl');
+    expect(out).toContain('ECS Services');
+    expect(out).not.toContain('Lambda Functions');
+    expect(out).not.toContain('APIs');
+    expect(out).not.toContain('ECS Task Definitions');
+  });
+
+  it('falls back to the qualified ID alone when a target has no display path', () => {
+    const listing: TargetListing = { ...empty, lambdas: [entry(undefined, 'App:Raw')] };
+    const out = formatTargetListing(listing, 'cdkl');
+    expect(out).toContain('  App:Raw');
+  });
+
+  it('aligns the display-path column within a category', () => {
+    const listing: TargetListing = {
+      ...empty,
+      lambdas: [entry('App/Short', 'App:Short'), entry('App/MuchLongerName', 'App:Long')],
+    };
+    const out = formatTargetListing(listing, 'cdkl');
+    // Both qualified IDs start at the same column (padded to the longest path).
+    const shortLine = out.split('\n').find((l) => l.includes('App:Short'))!;
+    const longLine = out.split('\n').find((l) => l.includes('App:Long'))!;
+    expect(shortLine.indexOf('App:Short')).toBe(longLine.indexOf('App:Long'));
+  });
+
+  it('renders host branding in the command labels', () => {
+    const listing: TargetListing = { ...empty, lambdas: [entry('App/Handler', 'App:Handler')] };
+    const out = formatTargetListing(listing, 'cdkd local');
+    expect(out).toContain('Lambda Functions  (cdkd local invoke <target>)');
+  });
+});
+
+describe('createLocalListCommand', () => {
+  it('registers the command as `list` with an `ls` alias', () => {
+    const cmd = createLocalListCommand();
+    expect(cmd.name()).toBe('list');
+    expect(cmd.aliases()).toContain('ls');
+  });
+});

--- a/tests/unit/cli/local-list.test.ts
+++ b/tests/unit/cli/local-list.test.ts
@@ -75,4 +75,9 @@ describe('createLocalListCommand', () => {
     expect(cmd.name()).toBe('list');
     expect(cmd.aliases()).toContain('ls');
   });
+
+  it('accepts the deprecated --region flag for parity with sibling commands', () => {
+    const cmd = createLocalListCommand();
+    expect(cmd.options.some((o) => o.long === '--region')).toBe(true);
+  });
 });

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { countTargets, listTargets } from '../../../src/local/target-lister.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+function buildStack(stackName: string, resources: Record<string, TemplateResource>): StackInfo {
+  const template: CloudFormationTemplate = { Resources: resources };
+  return {
+    stackName,
+    displayName: stackName,
+    artifactId: stackName,
+    template,
+    dependencyNames: [],
+  };
+}
+
+function withPath(resource: TemplateResource, cdkPath: string): TemplateResource {
+  return { ...resource, Metadata: { 'aws:cdk:path': cdkPath } };
+}
+
+describe('listTargets — Lambda functions', () => {
+  it('enumerates AWS::Lambda::Function with both target forms, stripping trailing /Resource', () => {
+    const stack = buildStack('App', {
+      Handler: withPath(
+        { Type: 'AWS::Lambda::Function', Properties: {} },
+        'App/Handler/Resource'
+      ),
+    });
+    const { lambdas } = listTargets([stack]);
+    expect(lambdas).toEqual([
+      {
+        logicalId: 'Handler',
+        stackName: 'App',
+        qualifiedId: 'App:Handler',
+        displayPath: 'App/Handler',
+      },
+    ]);
+  });
+
+  it('omits displayPath when the resource carries no aws:cdk:path metadata', () => {
+    const stack = buildStack('App', {
+      Raw: { Type: 'AWS::Lambda::Function', Properties: {} },
+    });
+    const { lambdas } = listTargets([stack]);
+    expect(lambdas).toEqual([
+      { logicalId: 'Raw', stackName: 'App', qualifiedId: 'App:Raw' },
+    ]);
+  });
+});
+
+describe('listTargets — ECS', () => {
+  it('separates AWS::ECS::Service (start-service) from AWS::ECS::TaskDefinition (run-task)', () => {
+    const stack = buildStack('App', {
+      OrdersService: withPath(
+        { Type: 'AWS::ECS::Service', Properties: {} },
+        'App/OrdersService/Service'
+      ),
+      OrdersTaskDef: withPath(
+        { Type: 'AWS::ECS::TaskDefinition', Properties: {} },
+        'App/OrdersService/TaskDef/Resource'
+      ),
+    });
+    const { ecsServices, ecsTaskDefinitions } = listTargets([stack]);
+    expect(ecsServices).toEqual([
+      {
+        logicalId: 'OrdersService',
+        stackName: 'App',
+        qualifiedId: 'App:OrdersService',
+        displayPath: 'App/OrdersService/Service',
+      },
+    ]);
+    expect(ecsTaskDefinitions).toEqual([
+      {
+        logicalId: 'OrdersTaskDef',
+        stackName: 'App',
+        qualifiedId: 'App:OrdersTaskDef',
+        displayPath: 'App/OrdersService/TaskDef',
+      },
+    ]);
+  });
+});
+
+describe('listTargets — APIs', () => {
+  it('collapses an HTTP API v2 to one entry across its routes', () => {
+    const api = withPath(
+      { Type: 'AWS::ApiGatewayV2::Api', Properties: { ProtocolType: 'HTTP' } },
+      'App/HttpApi/Resource'
+    );
+    const integration: TemplateResource = {
+      Type: 'AWS::ApiGatewayV2::Integration',
+      Properties: {
+        IntegrationType: 'AWS_PROXY',
+        IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+      },
+    };
+    const route = (key: string): TemplateResource => ({
+      Type: 'AWS::ApiGatewayV2::Route',
+      Properties: {
+        ApiId: { Ref: 'HttpApi' },
+        RouteKey: key,
+        Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integration' }]] },
+      },
+    });
+    const stack = buildStack('App', {
+      HttpApi: api,
+      Integration: integration,
+      RouteA: route('GET /a'),
+      RouteB: route('POST /b'),
+      Handler: { Type: 'AWS::Lambda::Function', Properties: {} },
+    });
+    const { apis } = listTargets([stack]);
+    expect(apis).toEqual([
+      {
+        logicalId: 'HttpApi',
+        stackName: 'App',
+        qualifiedId: 'App:HttpApi',
+        displayPath: 'App/HttpApi',
+      },
+    ]);
+  });
+
+  it('lists a Function URL keyed by its own logical ID but pathed to the backing Lambda', () => {
+    const stack = buildStack('App', {
+      Handler: withPath(
+        { Type: 'AWS::Lambda::Function', Properties: {} },
+        'App/Handler/Resource'
+      ),
+      HandlerUrl: {
+        Type: 'AWS::Lambda::Url',
+        Properties: { TargetFunctionArn: { 'Fn::GetAtt': ['Handler', 'Arn'] }, AuthType: 'NONE' },
+      },
+    });
+    const { apis } = listTargets([stack]);
+    // start-api matches a Function URL by the backing Lambda's cdk path,
+    // so displayPath is the Lambda's path while the logical ID is the URL.
+    expect(apis).toEqual([
+      {
+        logicalId: 'HandlerUrl',
+        stackName: 'App',
+        qualifiedId: 'App:HandlerUrl',
+        displayPath: 'App/Handler',
+      },
+    ]);
+  });
+
+  it('includes WebSocket APIs (one entry, paths to the API resource)', () => {
+    const stack = buildStack('App', {
+      WsHandler: { Type: 'AWS::Lambda::Function', Properties: {} },
+      WsApi: withPath(
+        {
+          Type: 'AWS::ApiGatewayV2::Api',
+          Properties: { ProtocolType: 'WEBSOCKET', RouteSelectionExpression: '$request.body.action' },
+        },
+        'App/WsApi/Resource'
+      ),
+      ConnectInteg: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['WsHandler', 'Arn'] },
+        },
+      },
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'ConnectInteg' }]] },
+        },
+      },
+    });
+    const { apis } = listTargets([stack]);
+    expect(apis).toEqual([
+      {
+        logicalId: 'WsApi',
+        stackName: 'App',
+        qualifiedId: 'App:WsApi',
+        displayPath: 'App/WsApi',
+      },
+    ]);
+  });
+});
+
+describe('listTargets — multi-stack + ordering', () => {
+  it('qualifies each target by its own stack and sorts by display path', () => {
+    const stackA = buildStack('Beta', {
+      ZHandler: withPath({ Type: 'AWS::Lambda::Function', Properties: {} }, 'Beta/ZHandler/Resource'),
+    });
+    const stackB = buildStack('Alpha', {
+      AHandler: withPath({ Type: 'AWS::Lambda::Function', Properties: {} }, 'Alpha/AHandler/Resource'),
+    });
+    const { lambdas } = listTargets([stackA, stackB]);
+    expect(lambdas.map((l) => l.qualifiedId)).toEqual(['Alpha:AHandler', 'Beta:ZHandler']);
+  });
+});
+
+describe('countTargets', () => {
+  it('sums every category', () => {
+    const stack = buildStack('App', {
+      Fn: { Type: 'AWS::Lambda::Function', Properties: {} },
+      Svc: { Type: 'AWS::ECS::Service', Properties: {} },
+      Td: { Type: 'AWS::ECS::TaskDefinition', Properties: {} },
+    });
+    const listing = listTargets([stack]);
+    expect(countTargets(listing)).toBe(3);
+  });
+
+  it('returns 0 for an app with no runnable targets', () => {
+    const stack = buildStack('App', {
+      Bucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+    });
+    const listing = listTargets([stack]);
+    expect(countTargets(listing)).toBe(0);
+    expect(listing).toEqual({ lambdas: [], apis: [], ecsServices: [], ecsTaskDefinitions: [] });
+  });
+});

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { countTargets, listTargets } from '../../../src/local/target-lister.js';
+import { getLogger } from '../../../src/utils/logger.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function buildStack(stackName: string, resources: Record<string, TemplateResource>): StackInfo {
   const template: CloudFormationTemplate = { Resources: resources };
@@ -131,13 +136,14 @@ describe('listTargets — APIs', () => {
       },
     });
     const { apis } = listTargets([stack]);
-    // start-api matches a Function URL by the backing Lambda's cdk path,
-    // so displayPath is the Lambda's path while the logical ID is the URL.
+    // start-api addresses a Function URL by its BACKING LAMBDA (logical ID
+    // + cdk path), not the URL resource — so both forms point at Handler,
+    // matching `routeMatchesIdentifier` in api-server-grouping.ts.
     expect(apis).toEqual([
       {
-        logicalId: 'HandlerUrl',
+        logicalId: 'Handler',
         stackName: 'App',
-        qualifiedId: 'App:HandlerUrl',
+        qualifiedId: 'App:Handler',
         displayPath: 'App/Handler',
       },
     ]);
@@ -179,6 +185,40 @@ describe('listTargets — APIs', () => {
         displayPath: 'App/WsApi',
       },
     ]);
+  });
+
+  it('downgrades a route-discovery hard error to a warning and still lists other targets', () => {
+    const warn = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const stack = buildStack('App', {
+      Handler: { Type: 'AWS::Lambda::Function', Properties: {} },
+      // Malformed HTTP API route: ApiId is not a { Ref } — discoverRoutes throws.
+      BadRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: { ApiId: 'not-a-ref', RouteKey: 'GET /x', Target: 'integrations/whatever' },
+      },
+    });
+    const { apis, lambdas } = listTargets([stack]);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(apis).toEqual([]);
+    // The Lambda category is unaffected by the API-discovery failure.
+    expect(lambdas.map((l) => l.qualifiedId)).toEqual(['App:Handler']);
+  });
+
+  it('surfaces a WebSocket discovery error as a warning without throwing', () => {
+    const warn = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const stack = buildStack('App', {
+      Handler: { Type: 'AWS::Lambda::Function', Properties: {} },
+      // WebSocket API with no routes — discoverWebSocketApis returns an error
+      // (it does not throw), which listTargets warns about per entry.
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'WEBSOCKET' },
+      },
+    });
+    const { apis, lambdas } = listTargets([stack]);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(apis).toEqual([]);
+    expect(lambdas.map((l) => l.qualifiedId)).toEqual(['App:Handler']);
   });
 });
 

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -124,7 +124,7 @@ describe('listTargets — APIs', () => {
     ]);
   });
 
-  it('lists a Function URL keyed by its own logical ID but pathed to the backing Lambda', () => {
+  it('lists a Function URL keyed and pathed by its backing Lambda (start-api target form)', () => {
     const stack = buildStack('App', {
       Handler: withPath(
         { Type: 'AWS::Lambda::Function', Properties: {} },


### PR DESCRIPTION
## Summary

- New `cdkl list` / `cdkl ls` subcommand: synthesizes the CDK app and prints every runnable target grouped by the command that runs it (`invoke` / `start-api` / `run-task` / `start-service`), each with its CDK display path and stack-qualified logical ID. Solves target-ID discoverability — finding the `<target>` to pass (especially for ECS) previously meant tracing construct paths or grepping the synthesized template.
- Pure enumeration core `src/local/target-lister.ts` (`listTargets` over `StackInfo[]`, no Docker / AWS), reusable by a planned interactive target picker.
- The `APIs` group reuses the same discovery `start-api` runs (REST v1 / HTTP v2 / Function URL routes + WebSocket APIs), so the printed identifiers are exactly what `start-api [target]` accepts — a Function URL is keyed by its backing Lambda (matching `routeMatchesIdentifier`).
- Synth-only: needs no Docker. Output goes to stdout; categories with no targets are omitted; an empty app prints a clear message. Host-branding aware.
- Docs: README discovery section, `docs/cli-reference.md` entry, `.claude/CLAUDE.md` architecture / positioning updates.

## Test plan

- [x] `vp run check` (typecheck + lint + format)
- [x] `vp run build`
- [x] `vp test run` — 780 unit tests pass, incl. new `target-lister` + `local-list` suites (enumeration, dedup, Function-URL pathing, WebSocket inclusion, multi-stack, sort, empty-app, host branding, `ls` alias, and the route / WebSocket discovery warn-downgrade paths)
- [x] Live test: `cdkl list` and `cdkl ls` run against the `local-start-service` (ECS) and `local-start-api` (Lambda + REST / HTTP / Function URL) fixtures; output verified, Function-URL rows resolve to the backing Lambda
- [x] 3-axis review (spec / code / test) — all blocker / medium items addressed

## Review notes (accepted as known cost)

- WebSocket APIs are listed under the `APIs` group for discovery, but `start-api` boots WebSocket servers unconditionally and does not filter them by `[target]`; their printed identifier is informational.
- The command action body and the no-app error branch are not unit-tested (synth-boundary seam; same as the four sibling command factories). `formatTargetListing` and the enumeration core are fully covered.
- Cross-source dedup (an HTTP/REST surface and a WebSocket API colliding on the same `Stack:LogicalId`) is handled by the shared insert helper but has no dedicated test — the collision is not producible by CDK synth.

## Follow-up (planned, separate PR)

Interactive target picker (`-i` / `--interactive`, plus auto-prompt when a required target is omitted on a TTY) reusing `listTargets`, with an arrow-key selector.
