### PR TITLE
feat(start-service): reclaim leaked shared networks left by interrupted runs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,7 +37,7 @@ docker network ls --filter name=cdkl-svc- -q  | wc -l   # should be 0
 
 Any non-zero count = a previous `cdkl` run was interrupted and left state behind. Either:
 
-- Re-run the same command — cdk-local will reap the orphan name collision and continue.
+- Re-run the same command — cdk-local will reap the orphan name collision and continue. For `cdkl start-service` specifically, the next run automatically reclaims any leaked `cdkl-svc-*` shared network that has no live owner before it re-creates its own, so the fixed-subnet "Pool overlaps" failure no longer requires a manual `docker network rm`.
 - Or sweep manually:
   ```bash
   docker ps --filter name=cdkl- -q | xargs -r docker rm -f

--- a/src/local/ecs-network.ts
+++ b/src/local/ecs-network.ts
@@ -46,18 +46,18 @@ const DEFAULT_METADATA_ENDPOINT_SUBNET = '169.254.170.0/24';
 
 /**
  * Pure-functional subnet allocator. `cdkl run-task` uses the
- * default subnet; `cdkl start-service` walks `subnetOctet=170,
- * 171, 172, ...` (one per replica) to keep parallel docker networks
- * from clashing. The link-local 169.254.0.0/16 space is reserved AWS-
- * wide for cloud metadata so collisions with user workloads are
- * unlikely, but each replica still gets its own /24 to ensure
- * docker's `--subnet` allocator does not reject "Pool overlaps".
+ * default subnet (octet 170); `cdkl start-service` uses a SINGLE
+ * shared network at the fixed octet `SHARED_SVC_SUBNET_OCTET = 171`
+ * (one octet up from run-task so the two CLI variants can coexist on
+ * the same host). The link-local 169.254.0.0/16 space is reserved
+ * AWS-wide for cloud metadata so collisions with user workloads are
+ * unlikely, but the fixed /24 still keeps docker's `--subnet`
+ * allocator from rejecting "Pool overlaps".
  *
  * `subnetOctet` is the second-from-last byte of the network: 170 →
  * 169.254.170.0/24 (default), 171 → 169.254.171.0/24, etc. Valid
- * range is 1..254; the runner clamps to `(170 + replicaIndex) % 84`
- * + 170 in practice (rolling window) — exported here so the runner
- * keeps the allocation logic in one place.
+ * range is 1..254 — exported here so callers keep the CIDR /
+ * sidecar-IP derivation in one place.
  */
 export function buildEndpointSubnet(subnetOctet: number): {
   cidr: string;
@@ -159,6 +159,13 @@ export async function createSharedSvcNetwork(
   options: Omit<CreateTaskNetworkOptions, 'subnetOctet'> = {}
 ): Promise<TaskNetwork> {
   const prefix = options.prefix ?? getEmbedConfig().resourceNamePrefix;
+  // Reclaim any `<prefix>-svc-*` network left behind by a previous
+  // `start-service` run that was interrupted (Ctrl-C / crash) before its
+  // teardown. Because start-service pins a SINGLE fixed subnet
+  // (SHARED_SVC_SUBNET_OCTET), a leaked network blocks every later run with
+  // a "Pool overlaps" error that never self-heals — so sweep BEFORE the
+  // fixed-subnet create rather than only surfacing the error afterwards.
+  await sweepOrphanedSvcNetworks(prefix);
   const suffix = randomBytes(4).toString('hex');
   const networkName = `${prefix}-svc-${suffix}`;
   const { cidr, sidecarIp } = buildEndpointSubnet(SHARED_SVC_SUBNET_OCTET);
@@ -171,6 +178,93 @@ export async function createSharedSvcNetwork(
     ...(options.cluster !== undefined ? { cluster: options.cluster } : {}),
   });
   return { networkName, sidecarContainerId, sidecarIp, ownedByCaller: true };
+}
+
+/**
+ * Startup orphan sweep for the shared `cdkl start-service` network
+ * (Issue #93, design Option 1). When a `start-service` run is interrupted
+ * before its end-of-run teardown, the shared `<prefix>-svc-<rand>` network
+ * and its `<prefix>-svc-<rand>-metadata` sidecar LEAK. Because
+ * `start-service` pins a single fixed subnet (`SHARED_SVC_SUBNET_OCTET`),
+ * the next run's `docker network create` always fails with
+ * "Pool overlaps with other one on this address space" — a state that,
+ * unlike a port conflict, never self-heals. This sweep detects and removes
+ * leaked `<prefix>-svc-*` networks that have NO live owner before the next
+ * run re-creates the network.
+ *
+ * Classification heuristic: a `<prefix>-svc-*` network is ORPHANED when its
+ * only attached container is its own `<name>-metadata` sidecar (or it has
+ * zero attached containers). A network that still has a non-metadata
+ * (user replica) container attached is a live concurrent run and is LEFT
+ * untouched. Caveat: "only the metadata sidecar attached ⇒ orphan" can
+ * misclassify a network in the sub-second window between sidecar start and
+ * the first replica attach; this is acceptable because start-service's
+ * fixed subnet already precludes two concurrent runs, so there is never a
+ * legitimately-concurrent network to misjudge.
+ *
+ * Resilient by design: a `docker network ls` / `inspect` failure must not
+ * abort the run — it logs at debug and skips, matching the idempotent
+ * teardown style in this file. Returns the list of swept network names.
+ */
+export async function sweepOrphanedSvcNetworks(prefix: string): Promise<string[]> {
+  const logger = getLogger().child('ecs-network');
+  const filter = `${prefix}-svc-`;
+  let names: string[];
+  try {
+    const { stdout } = await execFileAsync(getDockerCmd(), [
+      'network',
+      'ls',
+      '--filter',
+      `name=${filter}`,
+      '--format',
+      '{{.Name}}',
+    ]);
+    names = stdout
+      .split('\n')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+  } catch (err) {
+    const e = err as { stderr?: string; message?: string };
+    logger.debug(`docker network ls (sweep) failed: ${e.stderr || e.message || String(err)}`);
+    return [];
+  }
+
+  const swept: string[] = [];
+  for (const name of names) {
+    let attached: string[];
+    try {
+      const { stdout } = await execFileAsync(getDockerCmd(), [
+        'network',
+        'inspect',
+        name,
+        '--format',
+        '{{range .Containers}}{{.Name}} {{end}}',
+      ]);
+      attached = stdout
+        .split(/\s+/)
+        .map((c) => c.trim())
+        .filter((c) => c.length > 0);
+    } catch (err) {
+      const e = err as { stderr?: string; message?: string };
+      logger.debug(
+        `docker network inspect ${name} (sweep) failed: ${e.stderr || e.message || String(err)}`
+      );
+      continue;
+    }
+
+    const sidecarName = `${name}-metadata`;
+    const hasLiveOwner = attached.some((c) => c !== sidecarName);
+    if (hasLiveOwner) {
+      // A user replica is still attached — this is a live concurrent run.
+      continue;
+    }
+
+    logger.info(`Reclaiming orphaned shared network ${name} (no live owner)...`);
+    await removeContainer(sidecarName);
+    await destroyNetworkOnly(name);
+    swept.push(name);
+  }
+  return swept;
 }
 
 /**

--- a/src/local/ecs-network.ts
+++ b/src/local/ecs-network.ts
@@ -198,9 +198,13 @@ export async function createSharedSvcNetwork(
  * (user replica) container attached is a live concurrent run and is LEFT
  * untouched. Caveat: "only the metadata sidecar attached ⇒ orphan" can
  * misclassify a network in the sub-second window between sidecar start and
- * the first replica attach; this is acceptable because start-service's
- * fixed subnet already precludes two concurrent runs, so there is never a
- * legitimately-concurrent network to misjudge.
+ * the first replica attach — so a second `start-service` launched in that
+ * window could reclaim a concurrently-starting run's network out from under
+ * it. This is an accepted limitation, not a benign one: start-service pins a
+ * single fixed subnet, so two concurrent same-prefix runs were never
+ * supported (the second run's `docker network create` already fails with
+ * "Pool overlaps"). The sweep therefore cannot regress a
+ * previously-working scenario.
  *
  * Resilient by design: a `docker network ls` / `inspect` failure must not
  * abort the run — it logs at debug and skips, matching the idempotent

--- a/tests/integration/local-start-service/verify.sh
+++ b/tests/integration/local-start-service/verify.sh
@@ -61,6 +61,19 @@ fi
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
 
+# Issue #93 regression — simulate a shared network leaked by a previously
+# interrupted `start-service` run. start-service pins the single fixed subnet
+# 169.254.171.0/24, so WITHOUT the startup orphan sweep this leaked network
+# makes the boot below fail with "Pool overlaps". The network carries only its
+# own metadata sidecar (no replica), so the sweep classifies it as orphaned and
+# reclaims it; reaching the boot banner proves sweepOrphanedSvcNetworks() ran.
+echo "==> Injecting a leaked orphan shared network on 169.254.171.0/24"
+ORPHAN_NET="cdkl-svc-orphanleak"
+docker network create --driver bridge --subnet 169.254.171.0/24 "${ORPHAN_NET}" >/dev/null
+docker run -d --rm --name "${ORPHAN_NET}-metadata" --network "${ORPHAN_NET}" \
+  --ip 169.254.171.2 "${SIDECAR_IMAGE}" >/dev/null
+echo "    orphan ${ORPHAN_NET} owns 169.254.171.0/24 (only its metadata sidecar attached)"
+
 echo "==> Booting service (DesiredCount=2)"
 ${CDKL} start-service CdkLocalStartServiceFixture:WebService \
   --no-pull --container-host 127.0.0.1 \
@@ -96,6 +109,16 @@ if [[ "${BOOTED}" -ne 1 ]]; then
   echo "--------------------------"
   exit 1
 fi
+
+echo "==> Asserting issue #93 sweep reclaimed the orphan network"
+# The service reached the boot banner above despite the pre-existing
+# 169.254.171.0/24 network, which already proves the sweep ran. Assert the
+# orphan is actually gone (not merely bypassed) for a precise failure message.
+if docker network inspect "${ORPHAN_NET}" >/dev/null 2>&1; then
+  echo "FAIL: orphan network ${ORPHAN_NET} survived — startup sweep did not reclaim it"
+  exit 1
+fi
+echo "    OK: orphan reclaimed; service booted on the shared subnet"
 
 echo "==> Asserting 2 replicas (4 containers: 2 web + 2 metadata sidecars)"
 # Each replica gets its own docker network + sidecar, plus 1 web container.

--- a/tests/unit/local/ecs-network.test.ts
+++ b/tests/unit/local/ecs-network.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Mock the docker boundary (node:child_process execFile) so we can assert
+// the sweep's `docker network ls` / `inspect` / `rm` choreography without
+// real Docker. `promisify(execFile)` calls execFile(cmd, args, options, cb);
+// we route through a single mock and return canned stdout per argv shape.
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+
+vi.mock('node:child_process', () => ({
+  // promisify(execFile) appends a callback as the LAST argument; callers in
+  // ecs-network.ts use both the 2-arg (cmd, args) and 3-arg (cmd, args,
+  // options) forms, so resolve the callback positionally rather than by a
+  // fixed arity.
+  execFile: (...rest: unknown[]) => {
+    const cb = rest[rest.length - 1] as (
+      err: Error | null,
+      result: { stdout: string; stderr: string }
+    ) => void;
+    const cmd = rest[0] as string;
+    const args = rest[1] as string[];
+    const options = rest.length > 3 ? rest[2] : undefined;
+    try {
+      const stdout = execFileMock(cmd, args, options) as string;
+      cb(null, { stdout: stdout ?? '', stderr: '' });
+    } catch (err) {
+      cb(err as Error, { stdout: '', stderr: '' });
+    }
+  },
+  spawn: vi.fn(),
+}));
+
+const { sweepOrphanedSvcNetworks, createSharedSvcNetwork } = await import(
+  '../../../src/local/ecs-network.js'
+);
+
+/** Classify a captured execFile call by its docker sub-command shape. */
+function kindOf(args: string[] | undefined): string {
+  if (!args) return '<no-args>';
+  if (args[0] === 'network' && args[1] === 'ls') return 'network-ls';
+  if (args[0] === 'network' && args[1] === 'inspect') return `network-inspect:${args[2]}`;
+  if (args[0] === 'network' && args[1] === 'rm') return `network-rm:${args[2]}`;
+  if (args[0] === 'network' && args[1] === 'create') return `network-create:${args[args.length - 1]}`;
+  if (args[0] === 'rm') return `container-rm:${args[2]}`;
+  if (args[0] === 'run') return 'sidecar-run';
+  if (args[0] === 'pull') return 'pull';
+  return args.join(' ');
+}
+
+describe('sweepOrphanedSvcNetworks', () => {
+  beforeEach(() => execFileMock.mockReset());
+
+  it('removes a <prefix>-svc-x whose only attached container is its own metadata sidecar', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return 'cdkl-svc-x\n';
+      if (kind === 'network-inspect:cdkl-svc-x') return 'cdkl-svc-x-metadata \n';
+      return '';
+    });
+
+    const swept = await sweepOrphanedSvcNetworks('cdkl');
+
+    expect(swept).toEqual(['cdkl-svc-x']);
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    // Sidecar force-removed by name, then the network removed.
+    expect(kinds).toContain('container-rm:cdkl-svc-x-metadata');
+    expect(kinds).toContain('network-rm:cdkl-svc-x');
+  });
+
+  it('treats a network with zero attached containers as orphaned', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return 'cdkl-svc-empty\n';
+      if (kind === 'network-inspect:cdkl-svc-empty') return '\n';
+      return '';
+    });
+
+    const swept = await sweepOrphanedSvcNetworks('cdkl');
+
+    expect(swept).toEqual(['cdkl-svc-empty']);
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    expect(kinds).toContain('network-rm:cdkl-svc-empty');
+  });
+
+  it('LEAVES a <prefix>-svc-y that has a replica container attached', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return 'cdkl-svc-y\n';
+      // metadata sidecar + a live user replica → live concurrent run.
+      if (kind === 'network-inspect:cdkl-svc-y') return 'cdkl-svc-y-metadata my-app-r0 \n';
+      return '';
+    });
+
+    const swept = await sweepOrphanedSvcNetworks('cdkl');
+
+    expect(swept).toEqual([]);
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    expect(kinds).not.toContain('network-rm:cdkl-svc-y');
+    expect(kinds).not.toContain('container-rm:cdkl-svc-y-metadata');
+  });
+
+  it('sweeps only the orphan when both an orphan and a live network exist', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return 'cdkl-svc-orphan\ncdkl-svc-live\n';
+      if (kind === 'network-inspect:cdkl-svc-orphan') return 'cdkl-svc-orphan-metadata \n';
+      if (kind === 'network-inspect:cdkl-svc-live') return 'cdkl-svc-live-metadata app-r0 \n';
+      return '';
+    });
+
+    const swept = await sweepOrphanedSvcNetworks('cdkl');
+
+    expect(swept).toEqual(['cdkl-svc-orphan']);
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    expect(kinds).toContain('network-rm:cdkl-svc-orphan');
+    expect(kinds).not.toContain('network-rm:cdkl-svc-live');
+  });
+
+  it('tolerates zero matching networks (no removal calls, returns empty)', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (kindOf(args) === 'network-ls') return '\n';
+      return '';
+    });
+
+    const swept = await sweepOrphanedSvcNetworks('cdkl');
+
+    expect(swept).toEqual([]);
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    expect(kinds).toEqual(['network-ls']);
+  });
+
+  it('does not throw when docker network ls fails (logs + returns empty)', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (kindOf(args) === 'network-ls') throw new Error('Cannot connect to the Docker daemon');
+      return '';
+    });
+
+    await expect(sweepOrphanedSvcNetworks('cdkl')).resolves.toEqual([]);
+  });
+
+  it('does not throw when docker network inspect fails — skips that network', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return 'cdkl-svc-z\n';
+      if (kind === 'network-inspect:cdkl-svc-z') throw new Error('No such network: cdkl-svc-z');
+      return '';
+    });
+
+    const swept = await sweepOrphanedSvcNetworks('cdkl');
+
+    expect(swept).toEqual([]);
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    expect(kinds).not.toContain('network-rm:cdkl-svc-z');
+  });
+});
+
+describe('createSharedSvcNetwork sweep ordering', () => {
+  beforeEach(() => execFileMock.mockReset());
+
+  it('runs the orphan sweep BEFORE issuing docker network create', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return ''; // no orphans to sweep
+      if (kind === 'sidecar-run') return 'sidecar-container-id\n';
+      return '';
+    });
+
+    // skipPull avoids the docker-pull spawn path; we only care about ordering.
+    const net = await createSharedSvcNetwork({ prefix: 'cdkl', skipPull: true });
+
+    expect(net.networkName).toMatch(/^cdkl-svc-[0-9a-f]{8}$/);
+    expect(net.ownedByCaller).toBe(true);
+
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    const lsIdx = kinds.indexOf('network-ls');
+    const createIdx = kinds.findIndex((k) => k.startsWith('network-create:'));
+    expect(lsIdx).toBeGreaterThanOrEqual(0);
+    expect(createIdx).toBeGreaterThanOrEqual(0);
+    expect(lsIdx).toBeLessThan(createIdx);
+  });
+
+  it('reclaims a leaked orphan, then creates the new shared network', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return 'cdkl-svc-leaked\n';
+      if (kind === 'network-inspect:cdkl-svc-leaked') return 'cdkl-svc-leaked-metadata \n';
+      if (kind === 'sidecar-run') return 'sidecar-container-id\n';
+      return '';
+    });
+
+    await createSharedSvcNetwork({ prefix: 'cdkl', skipPull: true });
+
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    const rmIdx = kinds.indexOf('network-rm:cdkl-svc-leaked');
+    const createIdx = kinds.findIndex((k) => k.startsWith('network-create:'));
+    expect(rmIdx).toBeGreaterThanOrEqual(0);
+    expect(createIdx).toBeGreaterThanOrEqual(0);
+    // Leaked network reclaimed before the fixed-subnet create.
+    expect(rmIdx).toBeLessThan(createIdx);
+  });
+});

--- a/tests/unit/local/ecs-network.test.ts
+++ b/tests/unit/local/ecs-network.test.ts
@@ -78,6 +78,9 @@ describe('sweepOrphanedSvcNetworks', () => {
 
     expect(swept).toEqual(['cdkl-svc-empty']);
     const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    // The sidecar is force-removed unconditionally (by name) even when nothing
+    // is attached — `docker rm -f` tolerates a not-found container.
+    expect(kinds).toContain('container-rm:cdkl-svc-empty-metadata');
     expect(kinds).toContain('network-rm:cdkl-svc-empty');
   });
 
@@ -113,6 +116,25 @@ describe('sweepOrphanedSvcNetworks', () => {
     const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
     expect(kinds).toContain('network-rm:cdkl-svc-orphan');
     expect(kinds).not.toContain('network-rm:cdkl-svc-live');
+  });
+
+  it('sweeps every orphan when several leaked networks are present', async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      const kind = kindOf(args);
+      if (kind === 'network-ls') return 'cdkl-svc-a\ncdkl-svc-b\ncdkl-svc-c\n';
+      if (kind === 'network-inspect:cdkl-svc-a') return 'cdkl-svc-a-metadata \n';
+      if (kind === 'network-inspect:cdkl-svc-b') return '\n';
+      if (kind === 'network-inspect:cdkl-svc-c') return 'cdkl-svc-c-metadata \n';
+      return '';
+    });
+
+    const swept = await sweepOrphanedSvcNetworks('cdkl');
+
+    expect(swept).toEqual(['cdkl-svc-a', 'cdkl-svc-b', 'cdkl-svc-c']);
+    const kinds = execFileMock.mock.calls.map((c) => kindOf(c[1] as string[]));
+    expect(kinds).toContain('network-rm:cdkl-svc-a');
+    expect(kinds).toContain('network-rm:cdkl-svc-b');
+    expect(kinds).toContain('network-rm:cdkl-svc-c');
   });
 
   it('tolerates zero matching networks (no removal calls, returns empty)', async () => {


### PR DESCRIPTION
## Summary

`cdkl start-service` pins a single fixed subnet (`169.254.171.0/24`,
`SHARED_SVC_SUBNET_OCTET`). When a run is interrupted (Ctrl-C / crash)
before its end-of-run teardown, its shared `cdkl-svc-<rand>` network and
`-metadata` sidecar leak — and because the subnet is fixed, every later
`start-service` then fails forever with `docker network create ... Pool
overlaps with other one on this address space`, requiring a manual
`docker network rm`. Unlike a port conflict, it never self-heals.

This adds a **startup orphan sweep**:

- New `sweepOrphanedSvcNetworks(prefix)` runs at the top of
  `createSharedSvcNetwork`, before the fixed-subnet create. It lists
  `<prefix>-svc-*` networks and reclaims those with **no live owner**
  (only their own `<name>-metadata` sidecar attached, or zero
  containers), force-removing the sidecar + the network.
- A network that still has a user-replica container attached is a live
  run and is **left untouched**.
- Fully **fail-soft**: a `docker network ls` / `inspect` failure logs at
  debug and skips — it can never abort the run. The existing "Pool
  overlaps" error stays as the fallback.
- Fixes stale JSDoc on `buildEndpointSubnet` that wrongly claimed
  `start-service` walks a subnet octet per replica (it uses one shared
  network at the fixed octet).

## Test plan

- [x] Unit (`tests/unit/local/ecs-network.test.ts`, 10 cases): orphan
      removed, zero-container orphan (sidecar still force-removed),
      live-replica network left, multiple orphans, mixed orphan+live,
      `ls`/`inspect` errors (no throw), sweep-runs-before-create ordering.
- [x] Integ (`local-start-service`): `verify.sh` now injects a leaked
      `cdkl-svc-*` network on `169.254.171.0/24` (only its metadata
      sidecar) before boot and asserts the sweep reclaims it; ran clean
      with 0 leftover docker containers / networks.
- [x] Full suite green (856 tests), `vp run check` + `vp run build` clean.
- [x] 3-axis review (spec / code / test) — no blockers; review nits
      (concurrency-caveat wording, incidental fixture manifest edit,
      extra test assertions) addressed.

Closes #93
