### PR TITLE
feat(interactive): add `-i`/`--interactive` target picker to the run commands

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,8 +65,9 @@ Gateway).
   cloud-map-registry, lambda-resolver, ecs-task-resolver,
   route-discovery, authorizer-resolver, lambda-authorizer, cognito-jwt,
   sigv4-verify, rie-client, intrinsic-image, runtime-image, target-lister
-  (`cdkl list` target enumeration), embed-config (embed-time branding
-  overrides for host CLIs), etc.
+  (`cdkl list` target enumeration), target-picker (`-i/--interactive`
+  arrow-key target selection via `@clack/prompts`), embed-config
+  (embed-time branding overrides for host CLIs), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ ECS Task Definitions  (cdkl run-task <target>)
   MyStack/WebTask         MyStack:WebTask
 ```
 
+#### Pick targets interactively — `-i` / omit the target
+
+Don't want to copy a path at all? In an interactive terminal, just omit the target and `invoke` / `run-task` / `start-service` drop you into an arrow-key picker (multi-select for `start-service`). Or pass `-i` / `--interactive` explicitly on any of the four commands:
+
+```bash
+cdkl invoke              # pick the Lambda from a list
+cdkl run-task            # pick the task definition
+cdkl start-service       # multi-select one or more services
+cdkl start-api -i        # pick one API to serve (a bare `start-api` still serves them all)
+```
+
+Outside a TTY (CI, pipes) the picker can't run: the required-target commands fall back to their usual "target required" error, and `-i` errors with a clear message — pass the target explicitly there.
+
 #### Lambda — `invoke`
 
 Invoke a single Lambda function with an event payload.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,6 +44,35 @@ Shared across every `cdkl` subcommand (declared in
 The `--from-cfn-stack` / `--stack-region` family is described in the
 per-command sections below.
 
+## Interactive target selection (`-i` / `--interactive`)
+
+The four run commands — `invoke`, `run-task`, `start-service`,
+`start-api` — accept `-i` / `--interactive` to choose their target from
+an arrow-key list (powered by `@clack/prompts`) instead of typing a CDK
+path / logical ID. `start-service` uses a multi-select (pick one or more
+services); the others select one. The list is the same set `cdkl list`
+prints, so a Function URL appears under its backing Lambda.
+
+For the three required-target commands (`invoke` / `run-task` /
+`start-service`), omitting the positional target in an interactive
+terminal launches the picker automatically — `-i` is only needed to force
+it when you would otherwise pass a target. `start-api` is different: a
+bare `start-api` already has a useful default (serve every discovered
+API), so it shows the picker only with an explicit `-i`, and `-i` there
+is mutually exclusive with a positional target, `--api`, and
+`--all-stacks`.
+
+The picker requires a TTY. In a non-interactive context (CI, pipes,
+redirected stdin/stdout):
+
+- omitting a required target falls back to the command's usual
+  "target required" error;
+- passing `-i` errors with `InteractiveTtyRequiredError` — pass the
+  target explicitly instead.
+
+Ctrl+C / Esc at the prompt aborts with exit code 130 and no error noise.
+`list` has no `-i` (it always lists everything).
+
 ## `cdkl list` (discover runnable targets)
 
 `cdkl list` (alias `cdkl ls`) synthesizes the CDK app and prints every

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@aws-sdk/client-sqs": "^3.0.0",
     "@aws-sdk/client-ssm": "^3.1017.0",
     "@aws-sdk/client-sts": "^3.1016.0",
+    "@clack/prompts": "^1.4.0",
     "chokidar": "^5.0.0",
     "commander": "^12.0.0",
     "graphlib": "^2.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@aws-sdk/client-sts':
         specifier: ^3.1016.0
         version: 3.1053.0
+      '@clack/prompts':
+        specifier: ^1.4.0
+        version: 1.4.0
       aws-cdk-lib:
         specifier: ^2.0.0
         version: 2.257.0(constructs@10.6.0)
@@ -458,6 +461,14 @@ packages:
 
   '@cdklabs/tskb@0.0.4':
     resolution: {integrity: sha512-NFx1X0l7p5DyHtLLEyNeh1hPN4UN9hTkZkzFs/Mp+kFk7dpdINGmGVpCfRDjJ2DrcNSNENUmT+w8g73TvmBbTw==, tarball: https://registry.npmjs.org/@cdklabs/tskb/-/tskb-0.0.4.tgz}
+
+  '@clack/core@1.3.1':
+    resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.4.0':
+    resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+    engines: {node: '>= 20.12.0'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==, tarball: https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz}
@@ -1776,8 +1787,17 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==, tarball: https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz}
     engines: {node: '>=8.6.0'}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==, tarball: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==, tarball: https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz}
@@ -2694,6 +2714,9 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==, tarball: https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz}
     engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==, tarball: https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz}
@@ -3934,6 +3957,18 @@ snapshots:
 
   '@cdklabs/tskb@0.0.4': {}
 
+  '@clack/core@1.3.1':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.4.0':
+    dependencies:
+      '@clack/core': 1.3.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -5035,7 +5070,17 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -5855,6 +5900,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
 
   skin-tone@2.0.0:
     dependencies:

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -8,12 +8,15 @@ import {
   commonOptions,
   contextOptions,
   deprecatedRegionOption,
+  interactiveOption,
   parseContextOptions,
   warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
-import { withErrorHandling } from '../../utils/error-handler.js';
+import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
+import { listTargets } from '../../local/target-lister.js';
+import { resolveSingleTarget } from '../../local/target-picker.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { readCdkPathOrUndefined } from '../cdk-path.js';
@@ -78,6 +81,8 @@ interface LocalInvokeOptions {
   profile?: string;
   roleArn?: string;
   context?: string[];
+  /** `-i/--interactive`: pick the Lambda from a list instead of passing <target>. */
+  interactive: boolean;
   event?: string;
   eventStdin?: boolean;
   envVars?: string;
@@ -150,7 +155,7 @@ export interface CreateLocalInvokeCommandOptions {
  * synthesis / asset / construct-path plumbing.
  */
 async function localInvokeCommand(
-  target: string,
+  target: string | undefined,
   options: LocalInvokeOptions,
   extraStateProviders: ExtraStateProviders | undefined
 ): Promise<void> {
@@ -292,7 +297,20 @@ async function localInvokeCommand(
     };
     const { stacks } = await synthesizer.synthesize(synthOpts);
 
-    const lambda = resolveLambdaTarget(target, stacks);
+    const resolvedTarget = await resolveSingleTarget(target, {
+      interactive: options.interactive,
+      entries: listTargets(stacks).lambdas,
+      message: 'Select a Lambda function to invoke',
+      noun: 'Lambda functions',
+      onMissing: () =>
+        new CdkLocalError(
+          `${getEmbedConfig().cliName} invoke requires a <target> (a Lambda display path or logical ID). ` +
+            `Run \`${getEmbedConfig().cliName} list\` to see them, or pass -i to pick interactively.`,
+          'LOCAL_INVOKE_TARGET_REQUIRED'
+        ),
+    });
+
+    const lambda = resolveLambdaTarget(resolvedTarget, stacks);
     const targetLabel = lambda.kind === 'zip' ? lambda.runtime : 'container image';
     logger.info(`Target: ${lambda.stack.stackName}/${lambda.logicalId} (${targetLabel})`);
 
@@ -1043,9 +1061,13 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
     .description(
       'Run a Lambda function locally in a Docker container (RIE-backed). ' +
         'Target accepts a CDK display path (MyStack/MyApi/Handler) or stack-qualified logical ID ' +
-        '(MyStack:MyApiHandler1234ABCD). Single-stack apps may omit the stack prefix.'
+        '(MyStack:MyApiHandler1234ABCD). Single-stack apps may omit the stack prefix. ' +
+        'Omit <target> in an interactive terminal (or pass -i) to pick the Lambda from a list.'
     )
-    .argument('<target>', 'CDK display path or stack-qualified logical ID of the Lambda to invoke')
+    .argument(
+      '[target]',
+      'CDK display path or stack-qualified logical ID of the Lambda to invoke (omit to pick interactively in a TTY)'
+    )
     .addOption(new Option('-e, --event <file>', 'JSON event payload file (default: {})'))
     .addOption(new Option('--event-stdin', 'Read event JSON from stdin').default(false))
     .addOption(
@@ -1123,7 +1145,7 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
       )
     )
     .action(
-      withErrorHandling(async (target: string, options: LocalInvokeOptions) => {
+      withErrorHandling(async (target: string | undefined, options: LocalInvokeOptions) => {
         await localInvokeCommand(target, options, opts.extraStateProviders);
       })
     );
@@ -1131,6 +1153,7 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((option) =>
     invoke.addOption(option)
   );
+  invoke.addOption(interactiveOption);
   invoke.addOption(deprecatedRegionOption);
 
   return invoke;

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -5,12 +5,15 @@ import {
   commonOptions,
   contextOptions,
   deprecatedRegionOption,
+  interactiveOption,
   parseContextOptions,
   warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
-import { withErrorHandling } from '../../utils/error-handler.js';
+import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
+import { listTargets } from '../../local/target-lister.js';
+import { resolveSingleTarget } from '../../local/target-picker.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
@@ -59,6 +62,8 @@ interface LocalRunTaskOptions {
   profile?: string;
   roleArn?: string;
   context?: string[];
+  /** `-i/--interactive`: pick the task definition from a list instead of passing <target>. */
+  interactive: boolean;
   cluster: string;
   envVars?: string;
   containerHost: string;
@@ -118,7 +123,7 @@ export interface CreateLocalRunTaskCommandOptions {
  * container's exit code drives the CLI's exit.
  */
 async function localRunTaskCommand(
-  target: string,
+  target: string | undefined,
   options: LocalRunTaskOptions,
   extraStateProviders: ExtraStateProviders | undefined
 ): Promise<void> {
@@ -193,11 +198,24 @@ async function localRunTaskCommand(
     };
     const { stacks } = await synthesizer.synthesize(synthOpts);
 
+    const resolvedTarget = await resolveSingleTarget(target, {
+      interactive: options.interactive,
+      entries: listTargets(stacks).ecsTaskDefinitions,
+      message: 'Select an ECS task definition to run',
+      noun: 'ECS task definitions',
+      onMissing: () =>
+        new CdkLocalError(
+          `${getEmbedConfig().cliName} run-task requires a <target> (an ECS task definition display path or logical ID). ` +
+            `Run \`${getEmbedConfig().cliName} list\` to see them, or pass -i to pick interactively.`,
+          'LOCAL_RUN_TASK_TARGET_REQUIRED'
+        ),
+    });
+
     // Pick a LocalStateProvider for whichever flag the user passed
     // (--from-cfn-stack OR a host-injected extra). Constructed BEFORE the
     // candidate-stack picker so the same provider drives both the
     // image-context state-load AND the post-pass cross-stack resolver.
-    const parsed = parseEcsTarget(target);
+    const parsed = parseEcsTarget(resolvedTarget);
     const candidate = pickCandidateStack(parsed.stackPattern, stacks);
     stateProvider = createLocalStateProvider(
       options,
@@ -213,7 +231,7 @@ async function localRunTaskCommand(
     // them when at least one stack's template references the
     // placeholders.
     const imageContext = await buildEcsImageResolutionContext(candidate, stateProvider, options);
-    const task = resolveEcsTaskTarget(target, stacks, imageContext);
+    const task = resolveEcsTaskTarget(resolvedTarget, stacks, imageContext);
     logger.info(
       `Target: ${task.stack.stackName}/${task.taskDefinitionLogicalId} (family=${task.family}, containers=${task.containers.length})`
     );
@@ -610,11 +628,12 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
       'Run an AWS::ECS::TaskDefinition locally — pulls/builds images, sets up a per-task docker network ' +
         'with the AWS-published metadata-endpoints sidecar, and starts every container in dependsOn order. ' +
         'Target accepts a CDK display path (MyStack/MyService/TaskDef) or stack-qualified logical ID ' +
-        '(MyStack:MyServiceTaskDefXYZ1234). Single-stack apps may omit the stack prefix.'
+        '(MyStack:MyServiceTaskDefXYZ1234). Single-stack apps may omit the stack prefix. ' +
+        'Omit <target> in an interactive terminal (or pass -i) to pick the task definition from a list.'
     )
     .argument(
-      '<target>',
-      'CDK display path or stack-qualified logical ID of the AWS::ECS::TaskDefinition to run'
+      '[target]',
+      'CDK display path or stack-qualified logical ID of the AWS::ECS::TaskDefinition to run (omit to pick interactively in a TTY)'
     )
     .addOption(
       new Option(
@@ -701,12 +720,13 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
       )
     )
     .action(
-      withErrorHandling(async (target: string, options: LocalRunTaskOptions) => {
+      withErrorHandling(async (target: string | undefined, options: LocalRunTaskOptions) => {
         await localRunTaskCommand(target, options, opts.extraStateProviders);
       })
     );
 
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(interactiveOption);
   cmd.addOption(deprecatedRegionOption);
   return cmd;
 }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -7,6 +7,7 @@ import {
   commonOptions,
   contextOptions,
   deprecatedRegionOption,
+  interactiveOption,
   parseContextOptions,
   parseAssumeRoleToken,
   effectiveAssumeRoleArn,
@@ -15,7 +16,9 @@ import {
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
-import { withErrorHandling } from '../../utils/error-handler.js';
+import { InteractiveTtyRequiredError, withErrorHandling } from '../../utils/error-handler.js';
+import { listTargets } from '../../local/target-lister.js';
+import { isInteractive, pickOneTarget } from '../../local/target-picker.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp, resolveWatchConfig, type CdkWatchConfig } from '../config-loader.js';
 import { createGlobMatcher } from '../../utils/glob-match.js';
@@ -132,6 +135,8 @@ interface LocalStartApiOptions {
   profile?: string;
   roleArn?: string;
   context?: string[];
+  /** `-i/--interactive`: pick one API to serve from a list (opt-in; bare start-api still serves all). */
+  interactive: boolean;
   /** Bind port (default 0 = auto-allocate). */
   port: string;
   /** Bind host (default 127.0.0.1). */
@@ -286,6 +291,33 @@ async function localStartApiCommand(
     apiFilter = options.api;
   }
 
+  // `-i/--interactive` lets the user pick ONE API to serve from a list.
+  // Unlike the required-target commands, a bare `start-api` already has a
+  // useful default (serve every discovered API), so the picker is opt-in
+  // via the flag only — never auto-launched on an omitted target. It is
+  // therefore mutually exclusive with any explicit single-target selector
+  // and with `--all-stacks`. The actual prompt runs once inside
+  // `synthesizeAndBuild` (it needs the synthesized API list); `--watch`
+  // reloads reuse the first pick via `interactivePicked`.
+  if (options.interactive) {
+    if (apiFilter !== undefined || options.allStacks) {
+      throw new Error(
+        '`-i/--interactive` cannot be combined with a positional target, --api, or --all-stacks; ' +
+          'it interactively picks one API to serve. Drop the selector, or drop -i.'
+      );
+    }
+    if (!isInteractive()) {
+      throw new InteractiveTtyRequiredError(
+        '`-i/--interactive` requires an interactive terminal, but stdin/stdout is not a TTY.'
+      );
+    }
+  }
+  // Effective single-target selector — set by the interactive picker on
+  // first synth, otherwise the positional `target`. Drives the synth
+  // stack-prefix inference below.
+  let effectiveTarget = target;
+  const interactivePicked = { value: false };
+
   // Issue #55: `--all-stacks` serves every stack's API as a union, so it
   // cannot be combined with a selector that names ONE target.
   const allStacksConflictList = allStacksConflicts(options, target, apiFilter);
@@ -386,6 +418,23 @@ async function localStartApiCommand(
     };
     const { stacks } = await synthesizer.synthesize(synthOpts);
 
+    // Interactive API pick — runs ONCE (the first synth), guarded so
+    // `--watch` reloads reuse the first selection rather than re-prompting.
+    // Sets both `apiFilter` (route filter) and `effectiveTarget` (stack
+    // inference) so the picked API drives the rest of the pass.
+    if (options.interactive && !interactivePicked.value) {
+      const apis = listTargets(stacks).apis;
+      if (apis.length === 0) {
+        throw new Error(
+          `No APIs found in this CDK app to choose from. Run \`${getEmbedConfig().cliName} list\` to see what is available.`
+        );
+      }
+      const picked = await pickOneTarget('Select an API to serve', apis);
+      apiFilter = picked;
+      effectiveTarget = picked;
+      interactivePicked.value = true;
+    }
+
     // When the user passes an explicit `--from-cfn-stack <name>` AND has
     // not also passed `--stack`, infer the synth target from the CFn
     // stack name — typical CDK apps deploy each stack under its own
@@ -401,7 +450,9 @@ async function localStartApiCommand(
     // without a `/` separator (bare logical id) leave this undefined so
     // the existing single-stack auto-pick path is untouched.
     const targetStackPrefix =
-      target?.includes('/') === true ? target.slice(0, target.indexOf('/')) : undefined;
+      effectiveTarget?.includes('/') === true
+        ? effectiveTarget.slice(0, effectiveTarget.indexOf('/'))
+        : undefined;
     const targetStacks = pickTargetStacks(
       stacks,
       options.stack,
@@ -3330,7 +3381,7 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
     )
     .argument(
       '[target]',
-      `Optional API filter. Accepts the bare CDK logical id ('MyHttpApi'; single-stack apps only), stack-qualified logical id ('MyStack:MyHttpApi'), full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). When omitted, every discovered API gets its own server. Mirrors \`${getEmbedConfig().cliName} invoke\` / \`${getEmbedConfig().cliName} run-task\` target syntax.`
+      `Optional API filter. Accepts the bare CDK logical id ('MyHttpApi'; single-stack apps only), stack-qualified logical id ('MyStack:MyHttpApi'), full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). When omitted, every discovered API gets its own server (pass -i to pick one interactively instead). Mirrors \`${getEmbedConfig().cliName} invoke\` / \`${getEmbedConfig().cliName} run-task\` target syntax.`
     )
     .addOption(
       new Option('--port <port>', 'HTTP server port (default: auto-allocate)').default('0')
@@ -3472,6 +3523,7 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) =>
     startApi.addOption(opt)
   );
+  startApi.addOption(interactiveOption);
   startApi.addOption(deprecatedRegionOption);
 
   return startApi;

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -294,24 +294,12 @@ async function localStartApiCommand(
   // `-i/--interactive` lets the user pick ONE API to serve from a list.
   // Unlike the required-target commands, a bare `start-api` already has a
   // useful default (serve every discovered API), so the picker is opt-in
-  // via the flag only — never auto-launched on an omitted target. It is
-  // therefore mutually exclusive with any explicit single-target selector
-  // and with `--all-stacks`. The actual prompt runs once inside
-  // `synthesizeAndBuild` (it needs the synthesized API list); `--watch`
-  // reloads reuse the first pick via `interactivePicked`.
-  if (options.interactive) {
-    if (apiFilter !== undefined || options.allStacks) {
-      throw new Error(
-        '`-i/--interactive` cannot be combined with a positional target, --api, or --all-stacks; ' +
-          'it interactively picks one API to serve. Drop the selector, or drop -i.'
-      );
-    }
-    if (!isInteractive()) {
-      throw new InteractiveTtyRequiredError(
-        '`-i/--interactive` requires an interactive terminal, but stdin/stdout is not a TTY.'
-      );
-    }
-  }
+  // via the flag only — never auto-launched on an omitted target. The
+  // guard below rejects the contradictory combinations; the actual prompt
+  // runs once inside `synthesizeAndBuild` (it needs the synthesized API
+  // list), with `--watch` reloads reusing the first pick via
+  // `interactivePicked`.
+  assertStartApiInteractiveAllowed(options.interactive, apiFilter, options.allStacks);
   // Effective single-target selector — set by the interactive picker on
   // first synth, otherwise the positional `target`. Drives the synth
   // stack-prefix inference below.
@@ -1398,6 +1386,38 @@ export function allStacksConflicts(
     conflicts.push(`--from-cfn-stack '${options.fromCfnStack}'`);
   }
   return conflicts;
+}
+
+/**
+ * Validate `-i/--interactive` for `start-api`. The picker is opt-in here
+ * (a bare `start-api` serves every API), so `-i` is mutually exclusive
+ * with any single-target selector (`apiFilter` = positional target OR
+ * `--api`) and with `--all-stacks`, and it requires a TTY. Throws when
+ * the combination is invalid; otherwise returns and the prompt runs
+ * later inside `synthesizeAndBuild`.
+ *
+ * Extracted as a pure-ish function (TTY is read via {@link isInteractive})
+ * so the error contract is unit-testable without booting the server.
+ *
+ * @internal exported for unit tests.
+ */
+export function assertStartApiInteractiveAllowed(
+  interactive: boolean,
+  apiFilter: string | undefined,
+  allStacks: boolean | undefined
+): void {
+  if (!interactive) return;
+  if (apiFilter !== undefined || allStacks) {
+    throw new Error(
+      '`-i/--interactive` cannot be combined with a positional target, --api, or --all-stacks; ' +
+        'it interactively picks one API to serve. Drop the selector, or drop -i.'
+    );
+  }
+  if (!isInteractive()) {
+    throw new InteractiveTtyRequiredError(
+      '`-i/--interactive` requires an interactive terminal, but stdin/stdout is not a TTY.'
+    );
+  }
 }
 
 /**

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -5,12 +5,15 @@ import {
   commonOptions,
   contextOptions,
   deprecatedRegionOption,
+  interactiveOption,
   parseContextOptions,
   warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling, LocalStartServiceError } from '../../utils/error-handler.js';
+import { listTargets } from '../../local/target-lister.js';
+import { resolveMultiTarget } from '../../local/target-picker.js';
 import { singleFlight } from '../../utils/single-flight.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
@@ -73,6 +76,8 @@ interface LocalStartServiceOptions {
   profile?: string;
   roleArn?: string;
   context?: string[];
+  /** `-i/--interactive`: multi-select the services from a list instead of passing <targets...>. */
+  interactive: boolean;
   cluster: string;
   envVars?: string;
   containerHost: string;
@@ -128,33 +133,18 @@ async function localStartServiceCommand(
   // boot, and any future call site share one source of truth.
   const skipPull = options.pull === false;
 
-  if (!targets || targets.length === 0) {
-    throw new LocalStartServiceError(
-      `${getEmbedConfig().cliName} start-service requires at least one <target>. ` +
-        "Pass one or more service paths like 'Stack/Orders' 'Stack/Frontend'."
-    );
-  }
-
-  // Issue #606: reject explicit `--from-cfn-stack <name>` when multiple
-  // service targets are booted in one invocation. The explicit name
-  // would apply to every target and silently mismap logical IDs across
-  // siblings that happen to share a `Ref` key. Bare `--from-cfn-stack`
-  // is fine (each target uses its own cdkl stack name as the CFn name).
-  rejectExplicitCfnStackWithMultipleStacks(options, targets.length);
-
-  // Per-target run-state + controller, plus a shared Cloud Map
-  // registry across every service. Building everything upfront and
-  // hoisting cleanup keeps SIGINT correctness in lock-step with the
-  // pre-PR single-service shape.
+  // Per-target run-state + controller, plus a shared Cloud Map registry
+  // across every service. `perTarget` is populated AFTER synth (the
+  // interactive picker needs the synthesized service list), but the type
+  // and the `let` binding live here so the hoisted single-flight cleanup
+  // closure below captures them. It starts empty: if we fail before it is
+  // populated (e.g. a synth error), there is nothing to tear down.
   type PerTarget = {
     target: string;
     runState: ServiceRunState;
     controller?: ServiceController;
   };
-  const perTarget: PerTarget[] = targets.map((t) => ({
-    target: t,
-    runState: createServiceRunState(),
-  }));
+  let perTarget: PerTarget[] = [];
 
   let sigintHandler: (() => void) | undefined;
   let sigintCount = 0;
@@ -256,6 +246,30 @@ async function localStartServiceCommand(
       ...(Object.keys(context).length > 0 && { context }),
     };
     const { stacks } = await synthesizer.synthesize(synthOpts);
+
+    const resolvedTargets = await resolveMultiTarget(targets, {
+      interactive: options.interactive,
+      entries: listTargets(stacks).ecsServices,
+      message: 'Select one or more ECS services to run',
+      noun: 'ECS services',
+      onMissing: () =>
+        new LocalStartServiceError(
+          `${getEmbedConfig().cliName} start-service requires at least one <target>. ` +
+            "Pass one or more service paths like 'Stack/Orders' 'Stack/Frontend', " +
+            'or run it in a TTY (or with -i) to pick interactively.'
+        ),
+    });
+
+    // Issue #606: reject explicit `--from-cfn-stack <name>` when multiple
+    // service targets are booted in one invocation. The explicit name
+    // would apply to every target and silently mismap logical IDs across
+    // siblings that happen to share a `Ref` key. Bare `--from-cfn-stack`
+    // is fine (each target uses its own cdkl stack name as the CFn name).
+    rejectExplicitCfnStackWithMultipleStacks(options, resolvedTargets.length);
+    perTarget = resolvedTargets.map((t) => ({
+      target: t,
+      runState: createServiceRunState(),
+    }));
 
     // Build the shared Cloud Map index once across every stack the
     // synth produced. Per-stack lookups in the runner then pick the
@@ -784,11 +798,12 @@ export function createLocalStartServiceCommand(
         'or stack-qualified logical ID (MyStack:MyServiceXYZ); single-stack apps may omit the ' +
         'stack prefix. When two or more <target>s are supplied, every service is booted into a ' +
         'shared Cloud Map / Service Connect registry so peer services discover each other via ' +
-        'docker --add-host overlay.'
+        'docker --add-host overlay. Omit <targets> in an interactive terminal (or pass -i) to ' +
+        'multi-select the services from a list.'
     )
     .argument(
-      '<targets...>',
-      'One or more CDK display paths or stack-qualified logical IDs of the AWS::ECS::Service resources to run'
+      '[targets...]',
+      'One or more CDK display paths or stack-qualified logical IDs of the AWS::ECS::Service resources to run (omit to multi-select interactively in a TTY)'
     )
     .addOption(
       new Option(
@@ -884,6 +899,7 @@ export function createLocalStartServiceCommand(
     );
 
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(interactiveOption);
   cmd.addOption(deprecatedRegionOption);
   return cmd;
 }

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -98,6 +98,21 @@ export const contextOptions = [
 ];
 
 /**
+ * `-i, --interactive` — present an arrow-key picker to choose the
+ * target(s) for this command instead of typing a CDK path / logical ID.
+ * Added to the four run commands (NOT `list`, which lists everything).
+ * Requires a TTY; in a non-interactive shell the command errors with a
+ * clear message. The required-target commands (`invoke` / `run-task` /
+ * `start-service`) also auto-launch the picker when the target is
+ * omitted in a TTY; `start-api` shows it only with the explicit flag
+ * (a bare `start-api` keeps serving every discovered API).
+ */
+export const interactiveOption = new Option(
+  '-i, --interactive',
+  'Pick the target(s) from an interactive list instead of passing them as arguments (requires a TTY)'
+).default(false);
+
+/**
  * Per-Lambda + global `--assume-role` parser used by `cdkl start-api`.
  * Each invocation is either a bare ARN (sets / overwrites the global
  * default) or `<LogicalId>=<arn>` (per-Lambda override). Per-Lambda

--- a/src/local/target-picker.ts
+++ b/src/local/target-picker.ts
@@ -1,0 +1,115 @@
+import { isCancel, multiselect, select } from '@clack/prompts';
+import {
+  CdkLocalError,
+  InteractiveTtyRequiredError,
+  TargetSelectionCancelledError,
+} from '../utils/error-handler.js';
+import { getEmbedConfig } from './embed-config.js';
+import type { TargetEntry } from './target-lister.js';
+
+/**
+ * True when both stdin and stdout are TTYs — the precondition for any
+ * interactive prompt. In a pipe / CI / non-interactive shell this is
+ * false and the caller must fall back (error, or the command's default
+ * behavior) rather than block on a prompt that can never be answered.
+ */
+export function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function toOption(entry: TargetEntry): { value: string; label: string; hint?: string } {
+  // The display path is the recommended copy-paste form; fall back to the
+  // stack-qualified logical ID when the resource has no `aws:cdk:path`.
+  const value = entry.displayPath ?? entry.qualifiedId;
+  const option: { value: string; label: string; hint?: string } = { value, label: value };
+  if (entry.displayPath) option.hint = entry.qualifiedId;
+  return option;
+}
+
+/**
+ * Prompt for exactly one target. Caller must have already confirmed a
+ * TTY ({@link isInteractive}) and a non-empty `entries`. Throws
+ * {@link TargetSelectionCancelledError} on Ctrl+C / Esc.
+ */
+export async function pickOneTarget(message: string, entries: TargetEntry[]): Promise<string> {
+  const chosen = await select({ message, options: entries.map(toOption) });
+  if (isCancel(chosen)) throw new TargetSelectionCancelledError();
+  return chosen as string;
+}
+
+/**
+ * Prompt for one or more targets (at least one required). Caller must
+ * have already confirmed a TTY and a non-empty `entries`. Throws
+ * {@link TargetSelectionCancelledError} on Ctrl+C / Esc.
+ */
+export async function pickManyTargets(message: string, entries: TargetEntry[]): Promise<string[]> {
+  const chosen = await multiselect({ message, options: entries.map(toOption), required: true });
+  if (isCancel(chosen)) throw new TargetSelectionCancelledError();
+  return chosen as string[];
+}
+
+interface ResolveParams {
+  /** Whether `-i/--interactive` was passed. */
+  interactive: boolean;
+  /** Candidate targets for this command's category. */
+  entries: TargetEntry[];
+  /** Prompt header, e.g. "Select a Lambda function to invoke". */
+  message: string;
+  /** Plural noun for the empty-candidates error, e.g. "Lambda functions". */
+  noun: string;
+  /** The command's existing "target argument is required" error, thrown when omitted in a non-TTY context. */
+  onMissing: () => CdkLocalError;
+}
+
+function ensureCanPrompt(interactive: boolean, onMissing: () => CdkLocalError): void {
+  if (isInteractive()) return;
+  if (interactive) {
+    throw new InteractiveTtyRequiredError(
+      '`-i/--interactive` requires an interactive terminal, but stdin/stdout is not a TTY.'
+    );
+  }
+  // Target omitted in a non-interactive context — preserve the command's
+  // original "required argument" behavior.
+  throw onMissing();
+}
+
+function ensureHasCandidates(count: number, noun: string): void {
+  if (count > 0) return;
+  throw new InteractiveTtyRequiredError(
+    `No ${noun} found in this CDK app to choose from. Run \`${getEmbedConfig().cliName} list\` to see what is available.`
+  );
+}
+
+/**
+ * Resolve a single positional target, prompting interactively when the
+ * user passed `-i/--interactive` or omitted the target in a TTY.
+ *
+ * - `provided` set and no `-i` → returned as-is (no prompt).
+ * - `-i` set → always prompt (any `provided` value is ignored).
+ * - omitted, TTY → prompt.
+ * - omitted, no TTY → `onMissing()` (the command's required-arg error).
+ */
+export async function resolveSingleTarget(
+  provided: string | undefined,
+  params: ResolveParams
+): Promise<string> {
+  if (provided && !params.interactive) return provided;
+  ensureCanPrompt(params.interactive, params.onMissing);
+  ensureHasCandidates(params.entries.length, params.noun);
+  return pickOneTarget(params.message, params.entries);
+}
+
+/**
+ * Resolve one or more positional targets (the `start-service` variadic
+ * shape), prompting with a multi-select when appropriate. Same trigger
+ * rules as {@link resolveSingleTarget}.
+ */
+export async function resolveMultiTarget(
+  provided: string[],
+  params: ResolveParams
+): Promise<string[]> {
+  if (provided.length > 0 && !params.interactive) return provided;
+  ensureCanPrompt(params.interactive, params.onMissing);
+  ensureHasCandidates(params.entries.length, params.noun);
+  return pickManyTargets(params.message, params.entries);
+}

--- a/src/local/target-picker.ts
+++ b/src/local/target-picker.ts
@@ -4,6 +4,7 @@ import {
   InteractiveTtyRequiredError,
   TargetSelectionCancelledError,
 } from '../utils/error-handler.js';
+import { getLogger } from '../utils/logger.js';
 import { getEmbedConfig } from './embed-config.js';
 import type { TargetEntry } from './target-lister.js';
 
@@ -94,6 +95,11 @@ export async function resolveSingleTarget(
   params: ResolveParams
 ): Promise<string> {
   if (provided && !params.interactive) return provided;
+  if (provided && params.interactive) {
+    getLogger().warn(
+      `-i/--interactive ignores the provided target '${provided}' — pick one from the list instead.`
+    );
+  }
   ensureCanPrompt(params.interactive, params.onMissing);
   ensureHasCandidates(params.entries.length, params.noun);
   return pickOneTarget(params.message, params.entries);
@@ -109,6 +115,11 @@ export async function resolveMultiTarget(
   params: ResolveParams
 ): Promise<string[]> {
   if (provided.length > 0 && !params.interactive) return provided;
+  if (provided.length > 0 && params.interactive) {
+    getLogger().warn(
+      `-i/--interactive ignores the provided target(s) [${provided.join(', ')}] — pick from the list instead.`
+    );
+  }
   ensureCanPrompt(params.interactive, params.onMissing);
   ensureHasCandidates(params.entries.length, params.noun);
   return pickManyTargets(params.message, params.entries);

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -70,6 +70,33 @@ export class LocalStartServiceError extends CdkLocalError {
 }
 
 /**
+ * The user aborted an interactive target picker (Ctrl+C / Esc). Exits
+ * 130 (the conventional SIGINT code) and suppresses the error line —
+ * cancelling a prompt is a normal user action, not a failure.
+ */
+export class TargetSelectionCancelledError extends CdkLocalError {
+  public readonly silent = true;
+  public readonly exitCode = 130;
+  constructor() {
+    super('Target selection cancelled.', 'TARGET_SELECTION_CANCELLED');
+    this.name = 'TargetSelectionCancelledError';
+    Object.setPrototypeOf(this, TargetSelectionCancelledError.prototype);
+  }
+}
+
+/**
+ * `-i/--interactive` was passed (or a required target was omitted) but
+ * the session has no TTY, so no prompt can be shown.
+ */
+export class InteractiveTtyRequiredError extends CdkLocalError {
+  constructor(message: string) {
+    super(message, 'INTERACTIVE_TTY_REQUIRED');
+    this.name = 'InteractiveTtyRequiredError';
+    Object.setPrototypeOf(this, InteractiveTtyRequiredError.prototype);
+  }
+}
+
+/**
  * Check if error is a cdk-local error
  */
 export function isCdkLocalError(error: unknown): error is CdkLocalError {

--- a/tests/unit/cli/interactive-option.test.ts
+++ b/tests/unit/cli/interactive-option.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vite-plus/test';
+import type { Command } from 'commander';
+import { createLocalInvokeCommand } from '../../../src/cli/commands/local-invoke.js';
+import { createLocalRunTaskCommand } from '../../../src/cli/commands/local-run-task.js';
+import { createLocalStartServiceCommand } from '../../../src/cli/commands/local-start-service.js';
+import { createLocalStartApiCommand } from '../../../src/cli/commands/local-start-api.js';
+import { createLocalListCommand } from '../../../src/cli/commands/local-list.js';
+
+function hasInteractive(cmd: Command): boolean {
+  return cmd.options.some((o) => o.short === '-i' && o.long === '--interactive');
+}
+
+/** Commander marks a variadic / optional positional arg as not required. */
+function requiredArgNames(cmd: Command): string[] {
+  return (cmd as unknown as { registeredArguments: { name(): string; required: boolean }[] })
+    .registeredArguments.filter((a) => a.required)
+    .map((a) => a.name());
+}
+
+describe('-i/--interactive option', () => {
+  it('is registered on the four run commands', () => {
+    expect(hasInteractive(createLocalInvokeCommand())).toBe(true);
+    expect(hasInteractive(createLocalRunTaskCommand())).toBe(true);
+    expect(hasInteractive(createLocalStartServiceCommand())).toBe(true);
+    expect(hasInteractive(createLocalStartApiCommand())).toBe(true);
+  });
+
+  it('is NOT registered on `list` (which always lists everything)', () => {
+    expect(hasInteractive(createLocalListCommand())).toBe(false);
+  });
+});
+
+describe('target arguments are optional (so the picker can supply them)', () => {
+  it('invoke / run-task / start-service / start-api have no required positional', () => {
+    expect(requiredArgNames(createLocalInvokeCommand())).toEqual([]);
+    expect(requiredArgNames(createLocalRunTaskCommand())).toEqual([]);
+    expect(requiredArgNames(createLocalStartServiceCommand())).toEqual([]);
+    expect(requiredArgNames(createLocalStartApiCommand())).toEqual([]);
+  });
+});

--- a/tests/unit/cli/local-start-api-interactive.test.ts
+++ b/tests/unit/cli/local-start-api-interactive.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { assertStartApiInteractiveAllowed } from '../../../src/cli/commands/local-start-api.js';
+import { InteractiveTtyRequiredError } from '../../../src/utils/error-handler.js';
+
+let origStdin: boolean | undefined;
+let origStdout: boolean | undefined;
+
+function setTty(value: boolean): void {
+  (process.stdin as { isTTY?: boolean }).isTTY = value;
+  (process.stdout as { isTTY?: boolean }).isTTY = value;
+}
+
+beforeEach(() => {
+  origStdin = process.stdin.isTTY;
+  origStdout = process.stdout.isTTY;
+});
+
+afterEach(() => {
+  (process.stdin as { isTTY?: boolean }).isTTY = origStdin;
+  (process.stdout as { isTTY?: boolean }).isTTY = origStdout;
+});
+
+describe('assertStartApiInteractiveAllowed', () => {
+  it('is a no-op when -i is not set (bare start-api keeps serving every API)', () => {
+    setTty(false);
+    expect(() => assertStartApiInteractiveAllowed(false, 'MyStack/MyApi', true)).not.toThrow();
+  });
+
+  it('rejects -i combined with a positional target / --api (apiFilter set)', () => {
+    setTty(true);
+    expect(() => assertStartApiInteractiveAllowed(true, 'MyStack/MyApi', false)).toThrow(
+      /cannot be combined with a positional target, --api, or --all-stacks/
+    );
+  });
+
+  it('rejects -i combined with --all-stacks', () => {
+    setTty(true);
+    expect(() => assertStartApiInteractiveAllowed(true, undefined, true)).toThrow(
+      /cannot be combined/
+    );
+  });
+
+  it('rejects -i without a TTY', () => {
+    setTty(false);
+    expect(() => assertStartApiInteractiveAllowed(true, undefined, false)).toThrow(
+      InteractiveTtyRequiredError
+    );
+  });
+
+  it('allows -i with no conflicting selector in a TTY', () => {
+    setTty(true);
+    expect(() => assertStartApiInteractiveAllowed(true, undefined, false)).not.toThrow();
+    expect(() => assertStartApiInteractiveAllowed(true, undefined, undefined)).not.toThrow();
+  });
+});

--- a/tests/unit/local/target-picker.test.ts
+++ b/tests/unit/local/target-picker.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('@clack/prompts', () => ({
+  select: vi.fn(),
+  multiselect: vi.fn(),
+  isCancel: vi.fn(() => false),
+}));
+
+import { isCancel, multiselect, select } from '@clack/prompts';
+import {
+  isInteractive,
+  pickManyTargets,
+  pickOneTarget,
+  resolveMultiTarget,
+  resolveSingleTarget,
+} from '../../../src/local/target-picker.js';
+import {
+  CdkLocalError,
+  InteractiveTtyRequiredError,
+  TargetSelectionCancelledError,
+} from '../../../src/utils/error-handler.js';
+import type { TargetEntry } from '../../../src/local/target-lister.js';
+
+const entries: TargetEntry[] = [
+  { logicalId: 'A', stackName: 'S', qualifiedId: 'S:A', displayPath: 'S/A' },
+  { logicalId: 'B', stackName: 'S', qualifiedId: 'S:B' }, // no display path
+];
+
+let origStdin: boolean | undefined;
+let origStdout: boolean | undefined;
+
+function setTty(value: boolean): void {
+  (process.stdin as { isTTY?: boolean }).isTTY = value;
+  (process.stdout as { isTTY?: boolean }).isTTY = value;
+}
+
+beforeEach(() => {
+  origStdin = process.stdin.isTTY;
+  origStdout = process.stdout.isTTY;
+  vi.clearAllMocks();
+  vi.mocked(isCancel).mockReturnValue(false);
+});
+
+afterEach(() => {
+  (process.stdin as { isTTY?: boolean }).isTTY = origStdin;
+  (process.stdout as { isTTY?: boolean }).isTTY = origStdout;
+});
+
+const onMissing = (): CdkLocalError => new CdkLocalError('target required', 'MISSING');
+
+describe('isInteractive', () => {
+  it('is true only when both stdin and stdout are TTYs', () => {
+    setTty(true);
+    expect(isInteractive()).toBe(true);
+    (process.stdout as { isTTY?: boolean }).isTTY = false;
+    expect(isInteractive()).toBe(false);
+    setTty(false);
+    expect(isInteractive()).toBe(false);
+  });
+});
+
+describe('pickOneTarget', () => {
+  it('maps entries to options (display path label, qualified ID hint) and returns the choice', async () => {
+    vi.mocked(select).mockResolvedValue('S/A');
+    const result = await pickOneTarget('Pick one', entries);
+    expect(result).toBe('S/A');
+    expect(select).toHaveBeenCalledWith({
+      message: 'Pick one',
+      options: [
+        { value: 'S/A', label: 'S/A', hint: 'S:A' },
+        { value: 'S:B', label: 'S:B' },
+      ],
+    });
+  });
+
+  it('throws TargetSelectionCancelledError when the prompt is cancelled', async () => {
+    vi.mocked(select).mockResolvedValue(Symbol('cancel') as unknown as string);
+    vi.mocked(isCancel).mockReturnValue(true);
+    await expect(pickOneTarget('Pick one', entries)).rejects.toBeInstanceOf(
+      TargetSelectionCancelledError
+    );
+  });
+});
+
+describe('pickManyTargets', () => {
+  it('requires at least one selection and returns the chosen array', async () => {
+    vi.mocked(multiselect).mockResolvedValue(['S/A', 'S:B']);
+    const result = await pickManyTargets('Pick many', entries);
+    expect(result).toEqual(['S/A', 'S:B']);
+    expect(multiselect).toHaveBeenCalledWith({
+      message: 'Pick many',
+      options: [
+        { value: 'S/A', label: 'S/A', hint: 'S:A' },
+        { value: 'S:B', label: 'S:B' },
+      ],
+      required: true,
+    });
+  });
+
+  it('throws TargetSelectionCancelledError on cancel', async () => {
+    vi.mocked(multiselect).mockResolvedValue(Symbol('cancel') as unknown as string[]);
+    vi.mocked(isCancel).mockReturnValue(true);
+    await expect(pickManyTargets('Pick many', entries)).rejects.toBeInstanceOf(
+      TargetSelectionCancelledError
+    );
+  });
+});
+
+describe('resolveSingleTarget', () => {
+  it('returns the provided target without prompting when -i is absent', async () => {
+    setTty(true);
+    const result = await resolveSingleTarget('Stack/Given', {
+      interactive: false,
+      entries,
+      message: 'm',
+      noun: 'Lambda functions',
+      onMissing,
+    });
+    expect(result).toBe('Stack/Given');
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it('prompts even when a target is provided if -i is set', async () => {
+    setTty(true);
+    vi.mocked(select).mockResolvedValue('S/A');
+    const result = await resolveSingleTarget('Stack/Given', {
+      interactive: true,
+      entries,
+      message: 'm',
+      noun: 'Lambda functions',
+      onMissing,
+    });
+    expect(result).toBe('S/A');
+    expect(select).toHaveBeenCalledOnce();
+  });
+
+  it('throws the command onMissing error when omitted in a non-TTY without -i', async () => {
+    setTty(false);
+    await expect(
+      resolveSingleTarget(undefined, {
+        interactive: false,
+        entries,
+        message: 'm',
+        noun: 'Lambda functions',
+        onMissing,
+      })
+    ).rejects.toMatchObject({ code: 'MISSING' });
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it('throws InteractiveTtyRequiredError when -i is set without a TTY', async () => {
+    setTty(false);
+    await expect(
+      resolveSingleTarget(undefined, {
+        interactive: true,
+        entries,
+        message: 'm',
+        noun: 'Lambda functions',
+        onMissing,
+      })
+    ).rejects.toBeInstanceOf(InteractiveTtyRequiredError);
+  });
+
+  it('errors when there are no candidates to pick from', async () => {
+    setTty(true);
+    await expect(
+      resolveSingleTarget(undefined, {
+        interactive: true,
+        entries: [],
+        message: 'm',
+        noun: 'Lambda functions',
+        onMissing,
+      })
+    ).rejects.toBeInstanceOf(InteractiveTtyRequiredError);
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it('prompts when the target is omitted in a TTY', async () => {
+    setTty(true);
+    vi.mocked(select).mockResolvedValue('S:B');
+    const result = await resolveSingleTarget(undefined, {
+      interactive: false,
+      entries,
+      message: 'm',
+      noun: 'Lambda functions',
+      onMissing,
+    });
+    expect(result).toBe('S:B');
+    expect(select).toHaveBeenCalledOnce();
+  });
+});
+
+describe('resolveMultiTarget', () => {
+  it('returns provided targets without prompting when -i is absent', async () => {
+    setTty(true);
+    const result = await resolveMultiTarget(['S/A', 'S:B'], {
+      interactive: false,
+      entries,
+      message: 'm',
+      noun: 'ECS services',
+      onMissing,
+    });
+    expect(result).toEqual(['S/A', 'S:B']);
+    expect(multiselect).not.toHaveBeenCalled();
+  });
+
+  it('multi-selects when omitted in a TTY', async () => {
+    setTty(true);
+    vi.mocked(multiselect).mockResolvedValue(['S/A']);
+    const result = await resolveMultiTarget([], {
+      interactive: false,
+      entries,
+      message: 'm',
+      noun: 'ECS services',
+      onMissing,
+    });
+    expect(result).toEqual(['S/A']);
+    expect(multiselect).toHaveBeenCalledOnce();
+  });
+
+  it('throws the onMissing error when omitted in a non-TTY without -i', async () => {
+    setTty(false);
+    await expect(
+      resolveMultiTarget([], {
+        interactive: false,
+        entries,
+        message: 'm',
+        noun: 'ECS services',
+        onMissing,
+      })
+    ).rejects.toMatchObject({ code: 'MISSING' });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `-i` / `--interactive` to the four run commands so you can pick the target from an arrow-key list (via `@clack/prompts`) instead of copying a CDK path / logical ID out of `cdkl list`.
- New `src/local/target-picker.ts` — a TTY-guarded picker over the same `listTargets` enumeration `cdkl list` uses (so a Function URL is offered under its backing Lambda). Single-select for `invoke` / `run-task` / `start-api`; multi-select for `start-service`.
- Trigger rules:
  - `invoke` / `run-task` / `start-service` (required target): the positional target is now optional — omitting it in a TTY auto-launches the picker; `-i` forces it. In a non-TTY the original "target required" error is preserved; `-i` without a TTY errors clearly.
  - `start-api`: a bare `start-api` still serves every discovered API (unchanged default). The picker is opt-in via `-i` only, mutually exclusive with a positional target / `--api` / `--all-stacks`, and runs once (reused across `--watch` reloads).
- Cancelling the prompt (Ctrl+C / Esc) exits 130 cleanly with no error noise (`TargetSelectionCancelledError`, silent).
- Docs: README "Pick targets interactively" section + a cli-reference "Interactive target selection" section.

## Test plan

- [x] `vp run check` (typecheck + lint + format)
- [x] `vp run build`
- [x] `vp test run` — 868 unit tests pass, incl. the new picker-core suite (all `resolveSingleTarget` / `resolveMultiTarget` branches, option→entry mapping, multi-select, cancel, TTY guards), a structural option/arity test, and `assertStartApiInteractiveAllowed`.
- [x] Live-tested the non-TTY guard paths against fixtures: `start-service` / `invoke` omitted-target → required-target error; `-i` in non-TTY → TTY-required error; `start-api -i` + target → mutually-exclusive error; `--help` shows `-i` and the optional `[target]`.
- [x] 3-axis review (spec / code / test) — spec clean; all addressed (see below).

## Review notes

- **Addressed**: silent target-ignore with `-i` now emits a warn; `start-api`'s `-i` guard extracted into the tested `assertStartApiInteractiveAllowed`.
- **Accepted as known cost**: the actual interactive prompt cannot be exercised in CI (it needs a real TTY) — it is covered by the picker-core unit tests with `@clack/prompts` mocked, plus manual TTY verification. The per-command category bindings (invoke→lambdas, etc.) are not unit-tested beyond the structural option/arity test, matching the repo's existing no-action-body-test precedent. `start-api`'s `-i` TTY guard fails fast pre-synth while the other commands' guards fire post-synth — an acceptable minor asymmetry.

## Follow-up (planned, separate PR)

Redesign the `cdkl list` text output (clearer per-group headers, drop the wide two-column wrap for long auto-generated construct names, route synth status to stderr).
