### PR TITLE
docs(env-vars): note --env-vars composes with --from-cfn-stack; fix file-path examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ cdkl invoke MyStack/MyFunction --event ./event.json --env-vars ./env.json
 - For Lambda (`invoke`, `start-api`), function-specific keys can be either a **CDK display path** (`MyStack/MyFunction` — recommended for new files; same form `cdkl invoke` accepts as a target) or a **CloudFormation logical ID** (`MyFunctionLogicalId1234ABCD` — named in `cdk.out/<Stack>.template.json`, the SAM-compatible form). Both coexist; if both are listed for the same function, the later JSON entry wins (matching SAM's apply-in-order semantics).
 - For ECS (`run-task`, `start-service`), function-specific keys are container names from the task definition's `ContainerDefinitions[].Name` field.
 - The file format matches `sam local invoke --env-vars`, so an existing SAM env-vars file (logical-ID keys) works unchanged.
+- Composes with `--from-cfn-stack`: the state source resolves env vars first, then `--env-vars` overrides only the keys you list (unnamed keys keep their state-resolved value). Full precedence in [docs/cli-reference.md](docs/cli-reference.md).
 
 ## Supported resources
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -201,9 +201,11 @@ cdkl invoke MyStack/MyApi/Handler --from-cfn-stack MyExplicitCfnStackName
 # Cross-region CFn stack — --stack-region drives the CFn client region.
 cdkl invoke MyStack/MyApi/Handler --from-cfn-stack --stack-region eu-west-1
 
-# Combine with --env-vars to override a single key (override wins)
+# Combine with --env-vars to override a single key (override wins).
+# --env-vars takes a JSON file path; e.g. ./env.json holding
+# {"Parameters":{"DEBUG":"1"}}.
 cdkl invoke MyStack/MyApi/Handler --from-cfn-stack \
-  --env-vars '{"Parameters":{"DEBUG":"1"}}'
+  --env-vars ./env.json
 ```
 
 **What's resolved**: `Ref: <LogicalId>` against

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -186,9 +186,11 @@ cdkl invoke MyStack/MyApi/Handler --from-cfn-stack MyExplicitCfnStackName
 # Cross-region CFn stack — --stack-region drives the CFn client region.
 cdkl invoke MyStack/MyApi/Handler --from-cfn-stack --stack-region eu-west-1
 
-# Combine with --env-vars to override a single key (override wins)
+# Combine with --env-vars to override a single key (override wins).
+# --env-vars takes a JSON file path; e.g. ./env.json holding
+# {"Parameters":{"DEBUG":"1"}}.
 cdkl invoke MyStack/MyApi/Handler --from-cfn-stack \
-  --env-vars '{"Parameters":{"DEBUG":"1"}}'
+  --env-vars ./env.json
 ```
 
 **Resolution priority** (highest priority wins):


### PR DESCRIPTION
## Summary

- README: add a bullet to the `--env-vars` section noting it composes with `--from-cfn-stack` — the state source resolves env vars first, then `--env-vars` overrides only the keys you list (unnamed keys keep their state-resolved value), with a pointer to the full precedence table in `docs/cli-reference.md`.
- Fix a doc bug in the "Combine with --env-vars" examples in `docs/cli-reference.md` and `docs/local-emulation.md`: both passed inline JSON (`--env-vars '{"Parameters":{"DEBUG":"1"}}'`), but `--env-vars` takes a file path (`readFileSync` in `src/cli/commands/local-invoke.ts`), so the inline form fails with ENOENT. Changed to `--env-vars ./env.json` with the JSON content shown in a comment.

Docs-only change. No `src/**` or `tests/**` touched.

## Retrospective

- The inline-JSON `--env-vars` example was wrong in two committed docs (and the same pattern lingers in other in-flight worktrees). Proposed follow-up for discussion: a docs lint / PreToolUse hook that greps committed docs for `--env-vars '{` (a file-path flag handed inline JSON) to catch this class mechanically. Not implemented here to keep this PR docs-only.

## Test plan

- [x] `vp run check` (typecheck + lint + format) — pass
- [x] `vp run build` — pass (dist/cli.js + dist/index.js)
- [x] `vp test run` — 58 files / 846 tests pass
- [x] Live: `node dist/cli.js invoke --help` and `run-task --help` confirm the `--env-vars <file>` signature, validating the file-path doc fix
- [x] Diff touches only docs → integ marker n/a
