### PR TITLE
feat(from-cfn-stack): resolve AWS::SSM::Parameter::Value parameters from SSM

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,7 +67,9 @@ Gateway).
   sigv4-verify, rie-client, intrinsic-image, runtime-image, target-lister
   (`cdkl list` target enumeration), target-picker (`-i/--interactive`
   arrow-key target selection via `@clack/prompts`), embed-config
-  (embed-time branding overrides for host CLIs), etc.
+  (embed-time branding overrides for host CLIs), ssm-parameter-resolver
+  (resolves `AWS::SSM::Parameter::Value` template parameters via SSM under
+  `--from-cfn-stack`), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Once your stack is deployed to AWS (via the AWS CDK CLI or any other tool), pass
 
 For Lambda (`invoke`, `start-api`), this also recovers env-var values that CloudFormation resolved at deploy time but `ListStackResources` does not expose — e.g. `SIBLING_ARN: Fn::GetAtt <OtherFunction>.Arn`. cdk-local reads the deployed function's own resolved `Environment.Variables` (via `lambda:GetFunctionConfiguration`) and fills those keys, so a Lambda that calls a sibling Lambda by ARN runs locally without a manual `--env-vars` entry. (These values enter the local container env in plaintext; Lambda env vars are a non-secret property, so this exposes nothing the deployed function doesn't already surface to any caller with `lambda:GetFunctionConfiguration`.)
 
+`--from-cfn-stack` also resolves env vars that reference an SSM-backed CloudFormation parameter — the `AWS::SSM::Parameter::Value<String>` (and `List<String>`) type CDK synthesizes for `ssm.StringParameter.valueForStringParameter(...)`. cdk-local reads the parameter's current value from SSM Parameter Store (via `ssm:GetParameters`, using the same credentials/region as the stack lookup) and injects it, so a Lambda or ECS container whose env `Ref`s such a parameter runs locally without a manual `--env-vars` entry. If the SSM read fails (no permission, parameter not created), the key falls back to the usual warn-and-drop.
+
 #### HTTP APIs & Function URLs — `start-api` (the headline use case)
 
 A local API talking to real AWS — point a frontend at it for end-to-end debugging, including real Cognito JWT verification.

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -351,6 +351,18 @@ async function localInvokeCommand(
             const pseudo = await resolvePseudoParametersForInvoke(lambda.stack.region, options);
             if (pseudo) subContext.pseudoParameters = pseudo;
           }
+          // Resolve SSM-backed template parameters
+          // (`AWS::SSM::Parameter::Value<String>`) so a `Ref` to such a
+          // parameter in an env var resolves to its SSM value instead of
+          // being warn-and-dropped (issue #94). Only the CFn provider
+          // implements this; the resolved map feeds the substitution
+          // context's `parameters` field consulted by `resolveRef`.
+          if (envHasIntrinsicValue(templateEnv) && stateProvider.resolveTemplateSsmParameters) {
+            const ssmParams = await stateProvider.resolveTemplateSsmParameters(
+              lambda.stack.template
+            );
+            if (Object.keys(ssmParams).length > 0) subContext.parameters = ssmParams;
+          }
           if (envHasCrossStackIntrinsic(templateEnv)) {
             const resolver = await stateProvider.buildCrossStackResolver(loaded.region);
             if (resolver) {

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -257,6 +257,9 @@ async function localRunTaskCommand(
           ...(imageContext?.pseudoParameters && {
             pseudoParameters: imageContext.pseudoParameters,
           }),
+          ...(imageContext?.stateParameters && {
+            parameters: imageContext.stateParameters,
+          }),
           consumerRegion,
           crossStackResolver: resolver,
         };
@@ -453,7 +456,7 @@ async function assumeTaskRole(
  * Returns `undefined` when no container's `Image` field needs
  * substitution — the resolver behaves as before in that case.
  */
-async function buildEcsImageResolutionContext(
+export async function buildEcsImageResolutionContext(
   candidate: StackInfo | undefined,
   stateProvider: LocalStateProvider | undefined,
   options: LocalRunTaskOptions
@@ -510,6 +513,16 @@ async function buildEcsImageResolutionContext(
     const loaded = await stateProvider.load(candidate.stackName, candidate.region);
     if (loaded) {
       ctx.stateResources = loaded.resources;
+    }
+    // Resolve SSM-backed template parameters
+    // (`AWS::SSM::Parameter::Value<String>`) so a `Ref` to such a
+    // parameter in a container Environment / Secrets entry resolves to
+    // its SSM value instead of being warn-and-dropped (issue #94). Only
+    // the CFn provider implements this; gated on env/secret substitution
+    // being needed so image-only resolutions skip the SSM round-trip.
+    if (needs.needsEnvOrSecretSubstitution && stateProvider.resolveTemplateSsmParameters) {
+      const ssmParameters = await stateProvider.resolveTemplateSsmParameters(candidate.template);
+      if (Object.keys(ssmParameters).length > 0) ctx.stateParameters = ssmParameters;
     }
   } else if (!stateProvider && needs.needsStateResources) {
     logger.warn(

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1845,6 +1845,9 @@ async function buildContainerSpec(args: {
     if (stateBundle.pseudoParameters) {
       context.pseudoParameters = stateBundle.pseudoParameters;
     }
+    if (stateBundle.ssmParameters) {
+      context.parameters = stateBundle.ssmParameters;
+    }
     const { env, audit } = substituteEnvVarsFromState(templateEnv, context);
     templateEnv = env;
     for (const key of audit.resolvedKeys) {
@@ -3117,6 +3120,16 @@ interface StackStateBundle {
    * provider implements the deployed-env fallback (e.g. `--from-state`).
    */
   deployedEnvByLambda?: Map<string, Record<string, string>>;
+  /**
+   * Resolved SSM-backed template `Parameters`
+   * (`AWS::SSM::Parameter::Value<String>`), keyed by the parameter's
+   * logical ID. Fed into the substitution context's `parameters` field so
+   * a `Ref` to such a parameter resolves to its SSM value instead of
+   * being warn-and-dropped (issue #94). `undefined`/absent when the stack
+   * declares no SSM-backed parameters or no provider implements the SSM
+   * resolution (e.g. `--from-state`).
+   */
+  ssmParameters?: Record<string, string>;
 }
 
 /**
@@ -3278,6 +3291,17 @@ export async function loadStateForRoutedStacks(
           if (deployedEnv) deployedEnvByLambda.set(logicalId, deployedEnv);
         }
         if (deployedEnvByLambda.size > 0) bundle.deployedEnvByLambda = deployedEnvByLambda;
+      }
+      // Resolve SSM-backed template parameters
+      // (`AWS::SSM::Parameter::Value<String>`) once per stack so a `Ref`
+      // to such a parameter in a reachable Lambda's env resolves to its
+      // SSM value (issue #94). Gated on the stack actually having an
+      // intrinsic-valued env entry (same gate as the pseudo-parameter
+      // hop) so literal-only stacks skip the SSM round-trip. Only the
+      // CFn provider implements `resolveTemplateSsmParameters`.
+      if (stackHasIntrinsicEnv(stackName) && provider.resolveTemplateSsmParameters) {
+        const ssmParameters = await provider.resolveTemplateSsmParameters(stack.template);
+        if (Object.keys(ssmParameters).length > 0) bundle.ssmParameters = ssmParameters;
       }
       out.set(stackName, bundle);
       logger.debug(`${provider.label}: loaded state for ${stackName} (${loaded.region})`);

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -461,6 +461,9 @@ async function runOneTarget(
         ...(imageContext?.pseudoParameters && {
           pseudoParameters: imageContext.pseudoParameters,
         }),
+        ...(imageContext?.stateParameters && {
+          parameters: imageContext.stateParameters,
+        }),
         consumerRegion,
         crossStackResolver: resolver,
       };
@@ -644,6 +647,16 @@ async function buildEcsImageResolutionContext(
     const loaded = await stateProvider.load(candidate.stackName, candidate.region);
     if (loaded) {
       ctx.stateResources = loaded.resources;
+    }
+    // Resolve SSM-backed template parameters
+    // (`AWS::SSM::Parameter::Value<String>`) so a `Ref` to such a
+    // parameter in a container Environment / Secrets entry resolves to
+    // its SSM value instead of being warn-and-dropped (issue #94). Only
+    // the CFn provider implements this; gated on env/secret substitution
+    // being needed so image-only resolutions skip the SSM round-trip.
+    if (needs.needsEnvOrSecretSubstitution && stateProvider.resolveTemplateSsmParameters) {
+      const ssmParameters = await stateProvider.resolveTemplateSsmParameters(candidate.template);
+      if (Object.keys(ssmParameters).length > 0) ctx.stateParameters = ssmParameters;
     }
   } else if (!stateProvider && needs.needsStateResources) {
     logger.warn(

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -586,8 +586,12 @@ async function assumeTaskRole(
 
 /**
  * Build the substitution context the ECS resolver consumes.
+ *
+ * Exported for the site-level binding test that locks the `--from-cfn-stack`
+ * SSM-parameter resolution call (issue #94) into this start-service call site
+ * (mirrors `local-run-task`'s exported helper).
  */
-async function buildEcsImageResolutionContext(
+export async function buildEcsImageResolutionContext(
   target: string,
   stacks: StackInfo[],
   options: LocalStartServiceOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,12 @@ export {
   type CfnLocalStateProviderOptions,
 } from './local/cfn-local-state-provider.js';
 
+export {
+  collectSsmParameterRefs,
+  resolveSsmParameters,
+  type SsmParameterRef,
+} from './local/ssm-parameter-resolver.js';
+
 /**
  * Low-level local-execution building blocks re-exported for hosts that
  * shim cdk-local's `src/local/**` modules verbatim (e.g. cdkd). These

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -69,7 +69,10 @@ import {
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
 import { LambdaClient, GetFunctionConfigurationCommand } from '@aws-sdk/client-lambda';
+import { SSMClient } from '@aws-sdk/client-ssm';
 import { getLogger } from '../utils/logger.js';
+import { collectSsmParameterRefs, resolveSsmParameters } from './ssm-parameter-resolver.js';
+import type { CloudFormationTemplate } from '../types/resource.js';
 import type { ResourceState } from '../types/state.js';
 import type { CrossStackResolver } from './state-resolver.js';
 import type { LocalStateProvider, LocalStateRecord } from './local-state-provider.js';
@@ -122,6 +125,11 @@ export class CfnLocalStateProvider implements LocalStateProvider {
   // deployed-env fallback (no unresolvable intrinsic in any consumer
   // Lambda's env) don't open a needless client.
   private lambdaClient: LambdaClient | undefined;
+  // The SSM client is constructed lazily on the first
+  // `resolveTemplateSsmParameters` call so invocations whose templates
+  // declare no `AWS::SSM::Parameter::Value` parameters don't open a
+  // needless client.
+  private ssmClient: SSMClient | undefined;
   private readonly clientOptions: { region: string; profile?: string };
   // Issue #611 NIT 2: `dispose()` is terminal. The lazy `getClient()`
   // path would otherwise resurrect the client on a post-dispose
@@ -169,6 +177,47 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       });
     }
     return this.lambdaClient;
+  }
+
+  private getSsmClient(): SSMClient {
+    if (this.disposed) {
+      throw new Error('CfnLocalStateProvider used after dispose()');
+    }
+    if (!this.ssmClient) {
+      // Reuse the SAME region + profile threading as the CFn / Lambda
+      // clients so the SSM read targets the same account / region the
+      // `--from-cfn-stack` state load used (issue #628 / #94). A second
+      // credential resolution path would risk reading SSM from the
+      // default account while CFn read from the named profile's account.
+      this.ssmClient = new SSMClient({
+        region: this.region,
+        ...(this.clientOptions.profile !== undefined && { profile: this.clientOptions.profile }),
+      });
+    }
+    return this.ssmClient;
+  }
+
+  /**
+   * Resolve the synthesized template's SSM-backed `Parameters`
+   * (`AWS::SSM::Parameter::Value<String>` /
+   * `AWS::SSM::Parameter::Value<List<String>>`) into a
+   * `parameterLogicalId -> value` map via SSM Parameter Store. See
+   * {@link LocalStateProvider.resolveTemplateSsmParameters}.
+   *
+   * Returns an empty map (and opens no SSM client) when the template
+   * declares no SSM-backed parameters. Best-effort: SSM failures are
+   * absorbed inside {@link resolveSsmParameters} with a per-chunk warn.
+   */
+  public async resolveTemplateSsmParameters(
+    template: CloudFormationTemplate
+  ): Promise<Record<string, string>> {
+    if (this.disposed) {
+      throw new Error('CfnLocalStateProvider used after dispose()');
+    }
+    const refs = collectSsmParameterRefs(template);
+    if (refs.length === 0) return {};
+    const client = this.getSsmClient();
+    return resolveSsmParameters(client, refs, this.label);
   }
 
   /**
@@ -355,6 +404,10 @@ export class CfnLocalStateProvider implements LocalStateProvider {
     if (this.lambdaClient) {
       this.lambdaClient.destroy();
       this.lambdaClient = undefined;
+    }
+    if (this.ssmClient) {
+      this.ssmClient.destroy();
+      this.ssmClient = undefined;
     }
   }
 }

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -966,6 +966,9 @@ function buildSubstitutionContextFromImageContext(
   if (context.pseudoParameters) {
     subContext.pseudoParameters = { ...context.pseudoParameters };
   }
+  if (context.stateParameters) {
+    subContext.parameters = { ...context.stateParameters };
+  }
   return subContext;
 }
 

--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -57,6 +57,17 @@ export interface ImageResolutionContext {
    * shapes. Undefined when `--from-state` is not in effect.
    */
   stateResources?: Record<string, ResourceState>;
+  /**
+   * Resolved SSM-backed template `Parameters`
+   * (`AWS::SSM::Parameter::Value<String>`), keyed by parameter logical ID.
+   * Fed into `state-resolver.ts`'s `SubstitutionContext.parameters` so a
+   * `Ref` to such a parameter in a container `Environment` / `Secrets`
+   * entry resolves to its SSM value instead of being warn-and-dropped
+   * (issue #94). The CLI resolves these out-of-band via SSM Parameter
+   * Store under `--from-cfn-stack`. Undefined when the stack declares no
+   * SSM-backed parameters / no state source is in effect.
+   */
+  stateParameters?: Record<string, string>;
 }
 
 /**

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -33,6 +33,7 @@
  * could in principle drive both flags in the future.
  */
 
+import type { CloudFormationTemplate } from '../types/resource.js';
 import type { ResourceState } from '../types/state.js';
 import type { CrossStackResolver } from './state-resolver.js';
 
@@ -147,6 +148,32 @@ export interface LocalStateProvider {
   resolveDeployedFunctionEnv?(
     functionPhysicalId: string
   ): Promise<Record<string, string> | undefined>;
+  /**
+   * Optional: resolve a synthesized stack template's SSM-backed
+   * `Parameters` (`AWS::SSM::Parameter::Value<String>` /
+   * `AWS::SSM::Parameter::Value<List<String>>`, what CDK synthesizes for
+   * `ssm.StringParameter.valueForStringParameter(...)`) into a
+   * `parameterLogicalId -> value` map by reading each parameter's SSM
+   * name (from the template entry's `Default`) out of SSM Parameter
+   * Store. `List<String>` values are surfaced comma-joined.
+   *
+   * The returned map is fed into the substitution context's `parameters`
+   * field so a `Ref` to such a parameter resolves to the value instead of
+   * being dropped — these parameters are CloudFormation PARAMETERS, not
+   * resources, so they never appear in the `load()` resource map (built
+   * from `ListStackResources`).
+   *
+   * Implemented only by the CFn provider (`--from-cfn-stack`) — it owns
+   * the region / credential context the SSM read needs, the same one its
+   * `CloudFormationClient` uses. Returns an empty map when the template
+   * declares no SSM-backed parameters, and is best-effort: an SSM failure
+   * logs a warn and returns whatever it could resolve (possibly nothing)
+   * so the caller falls back to warn-and-drop. Never throws.
+   *
+   * Note: SSM parameter VALUES land in the local container env (env-var
+   * substitution). Callers must never log the values.
+   */
+  resolveTemplateSsmParameters?(template: CloudFormationTemplate): Promise<Record<string, string>>;
   /**
    * Release any AWS clients the provider owns. Always called by the
    * CLI layer in the outer `finally`. Idempotent.

--- a/src/local/ssm-parameter-resolver.ts
+++ b/src/local/ssm-parameter-resolver.ts
@@ -1,0 +1,182 @@
+/**
+ * Resolve CloudFormation template `Parameters` of the SSM-backed types
+ * `AWS::SSM::Parameter::Value<String>` / `AWS::SSM::Parameter::Value<List<String>>`
+ * (what CDK synthesizes for `ssm.StringParameter.valueForStringParameter(...)`)
+ * into their deployed values via SSM Parameter Store.
+ *
+ * Motivation (issue #94): a container / Lambda env var that `Ref`s such a
+ * parameter cannot be resolved from the `--from-cfn-stack` state source.
+ * That source is built from `ListStackResources` (deployed RESOURCES); a
+ * CloudFormation PARAMETER is not a resource, so the `Ref` misses
+ * `context.resources[<id>]` in `state-resolver.ts` and the env var is
+ * warn-and-dropped. The synthesized template, however, carries the SSM
+ * parameter NAME in each entry's `Default`:
+ *
+ *   "Parameters": {
+ *     "SsmParameterValue...Parameter": {
+ *       "Type": "AWS::SSM::Parameter::Value<String>",
+ *       "Default": "/path/to/the/parameter"
+ *     }
+ *   }
+ *
+ * and the run already has working AWS credentials / region (the same ones
+ * `--from-cfn-stack` uses for `ListStackResources`). This module reads each
+ * parameter NAME from `Default`, batch-resolves the values via SSM
+ * `GetParameters`, and returns a `logicalId -> value` map the CLI feeds
+ * into the substitution context so a `Ref` to the parameter's logical id
+ * resolves to the value instead of being dropped.
+ *
+ * Best-effort by design: on any SSM failure (no credentials, access
+ * denied, throttling) the helper logs a warn and returns whatever it
+ * could resolve (possibly nothing) — the caller then falls back to the
+ * existing warn-and-drop behavior on the affected `Ref`s. It NEVER throws
+ * out of the substitution pass.
+ */
+
+import { SSMClient, GetParametersCommand } from '@aws-sdk/client-ssm';
+import { getLogger } from '../utils/logger.js';
+import type { CloudFormationTemplate } from '../types/resource.js';
+
+/** SSM-backed CFn parameter types CDK synthesizes for SSM lookups. */
+const SSM_STRING_TYPE = 'AWS::SSM::Parameter::Value<String>';
+const SSM_LIST_TYPE = 'AWS::SSM::Parameter::Value<List<String>>';
+
+/**
+ * A template `Parameters` entry that points at an SSM parameter and so
+ * can be resolved from Parameter Store.
+ */
+export interface SsmParameterRef {
+  /** Logical ID of the CFn parameter (the `Ref` target). */
+  logicalId: string;
+  /** SSM parameter name, read from the entry's `Default`. */
+  ssmName: string;
+  /** `true` for the `List<String>` variant (the value is comma-joined). */
+  isList: boolean;
+}
+
+/**
+ * Scan a synthesized template's `Parameters` block for entries whose
+ * `Type` is one of the SSM-backed parameter types AND whose `Default`
+ * carries a usable SSM parameter name. Pure — no AWS calls.
+ *
+ * Entries without a non-empty string `Default` are skipped (CDK always
+ * synthesizes the parameter name into `Default` for the
+ * `valueForStringParameter` shape; a parameter declared without a default
+ * has no name we can resolve, so it stays warn-and-drop).
+ *
+ * Exported for unit testing.
+ */
+export function collectSsmParameterRefs(
+  template: Pick<CloudFormationTemplate, 'Parameters'> | undefined
+): SsmParameterRef[] {
+  const params = template?.Parameters;
+  if (!params) return [];
+  const out: SsmParameterRef[] = [];
+  for (const [logicalId, entry] of Object.entries(params)) {
+    if (!entry || typeof entry !== 'object') continue;
+    const type = entry.Type;
+    const isList = type === SSM_LIST_TYPE;
+    if (type !== SSM_STRING_TYPE && !isList) continue;
+    const ssmName = entry.Default;
+    if (typeof ssmName !== 'string' || ssmName.length === 0) continue;
+    out.push({ logicalId, ssmName, isList });
+  }
+  return out;
+}
+
+/**
+ * Batch-resolve a set of {@link SsmParameterRef}s via SSM `GetParameters`
+ * and return a `logicalId -> resolved value` map. `List<String>`
+ * parameters are comma-joined (CloudFormation surfaces the list type as a
+ * comma-delimited string when the value is consumed as a `Ref`).
+ *
+ * `GetParameters` accepts up to 10 names per call, so the refs are
+ * chunked. Names that SSM reports as invalid (`InvalidParameters`) are
+ * left out of the result map so the caller falls back to warn-and-drop
+ * on the corresponding `Ref`. `WithDecryption: true` is set so Secure
+ * String parameters resolve too (matching how CloudFormation resolves
+ * the `AWS::SSM::Parameter::Value<String>` type at deploy time).
+ *
+ * Best-effort: a failed `GetParameters` chunk logs a warn and is skipped
+ * (the other chunks still contribute their values); the function never
+ * throws.
+ *
+ * `label` is the state-source label (e.g. `--from-cfn-stack`) used to
+ * prefix warns so the user can tell which source produced them.
+ *
+ * Exported for unit testing.
+ */
+export async function resolveSsmParameters(
+  client: SSMClient,
+  refs: readonly SsmParameterRef[],
+  label: string
+): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  if (refs.length === 0) return out;
+
+  const logger = getLogger();
+
+  // GetParameters accepts at most 10 names per call.
+  const CHUNK = 10;
+  // Map SSM name -> the refs that requested it (multiple logical IDs may
+  // point at the same SSM name).
+  const byName = new Map<string, SsmParameterRef[]>();
+  for (const ref of refs) {
+    const list = byName.get(ref.ssmName);
+    if (list) list.push(ref);
+    else byName.set(ref.ssmName, [ref]);
+  }
+  const uniqueNames = [...byName.keys()];
+
+  for (let i = 0; i < uniqueNames.length; i += CHUNK) {
+    const names = uniqueNames.slice(i, i + CHUNK);
+    let resolved: Array<{ Name?: string | undefined; Value?: string | undefined }>;
+    try {
+      const resp = await client.send(
+        new GetParametersCommand({ Names: names, WithDecryption: true })
+      );
+      resolved = resp.Parameters ?? [];
+      const invalid = resp.InvalidParameters ?? [];
+      if (invalid.length > 0) {
+        logger.warn(
+          `${label}: SSM GetParameters reported invalid parameter name(s): ${invalid.join(', ')}. ` +
+            `Ref to the matching CloudFormation parameter(s) will warn-and-drop (was the SSM parameter created?).`
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        `${label}: SSM GetParameters(${names.join(', ')}) failed: ${formatSsmError(err)}. ` +
+          `Ref to the matching CloudFormation parameter(s) will warn-and-drop (grant ssm:GetParameters or override via --env-vars).`
+      );
+      continue;
+    }
+
+    for (const p of resolved) {
+      if (typeof p.Name !== 'string' || typeof p.Value !== 'string') continue;
+      const requesters = byName.get(p.Name);
+      if (!requesters) continue;
+      for (const ref of requesters) {
+        // CloudFormation surfaces a `List<String>` SSM value as a
+        // comma-delimited string when referenced; SSM returns the value
+        // already comma-joined for StringList parameters, so we pass it
+        // through verbatim — the `isList` flag is retained for clarity
+        // and future divergence but needs no transform here.
+        out[ref.logicalId] = p.Value;
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Format an SSM SDK error as `<name>: <message>` so the warn names the
+ * error class (e.g. `AccessDeniedException`, `ThrottlingException`).
+ * Mirrors `formatAwsErrorForWarn` in `cfn-local-state-provider.ts`.
+ * Exported for unit testing.
+ */
+export function formatSsmError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const name = err.name && err.name !== 'Error' ? err.name : undefined;
+  return name !== undefined ? `${name}: ${err.message}` : err.message;
+}

--- a/src/local/ssm-parameter-resolver.ts
+++ b/src/local/ssm-parameter-resolver.ts
@@ -97,6 +97,16 @@ export function collectSsmParameterRefs(
  * String parameters resolve too (matching how CloudFormation resolves
  * the `AWS::SSM::Parameter::Value<String>` type at deploy time).
  *
+ * Security note: a decrypted SecureString value resolved here is then
+ * baked into the container's `Environment` like any other resolved env
+ * value, so it follows the standard plaintext-env exposure path — it can
+ * appear on the `docker run -e KEY=VALUE` argv (visible in host `ps`) and
+ * is not redacted by `redactAwsCredentialsInArgs` (which only covers
+ * `SENSITIVE_ENV_KEYS`). This mirrors the deployed Lambda/ECS env and is
+ * the same inherent exposure documented in `docker-runner`; routing
+ * SecureString-resolved values through the value-from-process-env form is
+ * tracked as a follow-up.
+ *
  * Best-effort: a failed `GetParameters` chunk logs a warn and is skipped
  * (the other chunks still contribute their values); the function never
  * throws.

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -176,6 +176,19 @@ export interface CrossStackResolver {
 export interface SubstitutionContext {
   /** State-recorded resources for `Ref` / `Fn::GetAtt` / `${LogicalId}` lookups. */
   resources: Record<string, ResourceState>;
+  /**
+   * Resolved CloudFormation template `Parameters`, keyed by parameter
+   * logical ID. Consulted by `Ref` (and `${LogicalId}` inside `Fn::Sub`)
+   * when the logical ID is not a resource — covers
+   * `AWS::SSM::Parameter::Value<String>` parameters (what CDK synthesizes
+   * for `ssm.StringParameter.valueForStringParameter(...)`), which are
+   * CloudFormation PARAMETERS, not resources, so they never appear in
+   * `resources` (built from `ListStackResources`). The CLI layer resolves
+   * these values out-of-band via SSM Parameter Store (see
+   * `ssm-parameter-resolver.ts`) and threads the map in here. Optional;
+   * absent when no SSM-backed parameter was resolved.
+   */
+  parameters?: Record<string, string>;
   /** Optional pseudo-parameter bag for AWS::* placeholders. */
   pseudoParameters?: PseudoParameters;
   /**
@@ -301,13 +314,26 @@ function resolveRef(arg: unknown, context: SubstitutionContext): StateSubstituti
     return resolvePseudoParameter(arg, context.pseudoParameters);
   }
   const resource = context.resources[arg];
-  if (!resource) {
-    return {
-      kind: 'unresolved',
-      reason: `Ref '${arg}': no record in the state source (was the resource deployed?)`,
-    };
+  if (resource) {
+    return { kind: 'literal', value: resource.physicalId };
   }
-  return { kind: 'literal', value: resource.physicalId };
+  // Not a resource — try the resolved CloudFormation parameters map. This
+  // covers `AWS::SSM::Parameter::Value<String>` parameters (CDK's
+  // `ssm.StringParameter.valueForStringParameter(...)` shape), which are
+  // CloudFormation PARAMETERS, not resources, and so never appear in
+  // `resources` (built from `ListStackResources`). The CLI resolves their
+  // values via SSM and feeds them in on `context.parameters`.
+  const parameterValue = context.parameters?.[arg];
+  if (parameterValue !== undefined) {
+    return { kind: 'literal', value: parameterValue };
+  }
+  return {
+    kind: 'unresolved',
+    reason:
+      `Ref '${arg}': no record in the state source ` +
+      `(was the resource deployed, or is it a CloudFormation parameter that could not be resolved — ` +
+      `e.g. an SSM-backed AWS::SSM::Parameter::Value parameter whose SSM value was not readable?)`,
+  };
 }
 
 function resolvePseudoParameter(

--- a/tests/integration/local-invoke-from-cfn-stack/lambda/index.js
+++ b/tests/integration/local-invoke-from-cfn-stack/lambda/index.js
@@ -1,12 +1,14 @@
 // Echoes back the env vars the container saw. The integ asserts that
-// TABLE_NAME is the deployed DynamoDB table's actual physical name and
-// SIBLING_ARN is the deployed sibling function's actual ARN (not the
-// literal "${Token[...]}" or the unresolved intrinsic shape).
+// TABLE_NAME is the deployed DynamoDB table's actual physical name,
+// SIBLING_ARN is the deployed sibling function's actual ARN, and DB_HOST
+// is the value of the SSM parameter the AWS::SSM::Parameter::Value<String>
+// CFn parameter points at (issue #94) — not the unresolved intrinsic shape.
 exports.handler = async (event) => {
   return {
     tableName: process.env.TABLE_NAME ?? 'unset',
     siblingArn: process.env.SIBLING_ARN ?? 'unset',
     staticValue: process.env.STATIC_VALUE ?? 'unset',
+    dbHost: process.env.DB_HOST ?? 'unset',
     event,
   };
 };

--- a/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
@@ -4,8 +4,17 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * SSM parameter name the fixture's `verify.sh` `put-parameter`s BEFORE
+ * `cdk deploy` (CloudFormation resolves `AWS::SSM::Parameter::Value<String>`
+ * parameters at the start of a deploy, so the SSM value must already exist).
+ * Kept in sync with `verify.sh`'s `SSM_PARAM_NAME`.
+ */
+const SSM_DB_HOST_PARAM = '/cdkl-integ/invoke-from-cfn-stack/db-host';
 
 /**
  * Fixture stack for `cdkl invoke --from-cfn-stack` (issue #606).
@@ -67,6 +76,13 @@ export class LocalInvokeFromCfnStackStack extends cdk.Stack {
         // A literal env var to confirm --from-cfn-stack doesn't break
         // normal-case behavior on its way through.
         STATIC_VALUE: 'always-the-same',
+        // issue #94: a `Ref` to an `AWS::SSM::Parameter::Value<String>`
+        // CloudFormation parameter (what `valueForStringParameter`
+        // synthesizes). ListStackResources cannot resolve this (it is a
+        // CFn PARAMETER, not a resource), so without --from-cfn-stack it
+        // warns-and-drops; with it, the new SSM resolver reads the value
+        // from SSM and substitutes it.
+        DB_HOST: ssm.StringParameter.valueForStringParameter(this, SSM_DB_HOST_PARAM),
       },
       timeout: cdk.Duration.seconds(10),
     });

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -37,6 +37,16 @@ export AWS_REGION="${REGION}"
 STACK="CdkLocalInvokeFromCfnStackFixture"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
+# issue #94: the stack's DB_HOST env var is a Ref to an
+# AWS::SSM::Parameter::Value<String> CFn parameter (synthesized by
+# `ssm.StringParameter.valueForStringParameter`). CloudFormation resolves
+# that parameter at the START of `cdk deploy`, so the SSM parameter must
+# already exist — verify.sh `put-parameter`s it before deploy and deletes
+# it on exit. SSM_PARAM_NAME is kept in sync with the stack's
+# SSM_DB_HOST_PARAM constant.
+SSM_PARAM_NAME="/cdkl-integ/invoke-from-cfn-stack/db-host"
+SSM_PARAM_VALUE="db.internal.example"
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-from-cfn-stack"
 CLI="node ${REPO_ROOT}/dist/cli.js"
@@ -61,12 +71,19 @@ docker pull "${IMAGE}"
 # and run `cdk destroy` on a stack we did NOT create, silently deleting
 # user resources. The sentinel is set only after `cdk deploy` succeeds.
 WE_CREATED_STACK=0
+WE_CREATED_PARAM=0
 cleanup() {
   rc=$?
   if [ "${rc}" -ne 0 ] && [ "${WE_CREATED_STACK}" -eq 1 ]; then
     echo "[verify] FAIL (exit ${rc}) — attempting cdk destroy to clean up"
     (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
       --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  # The SSM parameter is created OUTSIDE the stack (CloudFormation must see
+  # it BEFORE deploy), so delete it on EVERY exit — success or failure —
+  # gated only on "we created it". Best-effort.
+  if [ "${WE_CREATED_PARAM}" -eq 1 ]; then
+    aws ssm delete-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   fi
   exit "${rc}"
 }
@@ -78,6 +95,19 @@ if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION
   echo "          aws cloudformation delete-stack --stack-name ${STACK} --region ${REGION}"
   exit 1
 fi
+
+echo "[verify] step 2b: put the SSM parameter the stack's DB_HOST resolves to"
+# Must exist BEFORE cdk deploy: CloudFormation resolves the stack's
+# AWS::SSM::Parameter::Value<String> parameter at deploy start. `--overwrite`
+# keeps the put idempotent across reruns; cleanup() deletes it on exit.
+WE_CREATED_PARAM=1
+aws ssm put-parameter \
+  --name "${SSM_PARAM_NAME}" \
+  --value "${SSM_PARAM_VALUE}" \
+  --type String \
+  --overwrite \
+  --region "${REGION}" >/dev/null
+echo "[verify]   put ${SSM_PARAM_NAME}=${SSM_PARAM_VALUE}"
 
 echo "[verify] step 3: cdk deploy (upstream CDK CLI)"
 # The fixture deliberately uses upstream `cdk deploy` so the resulting
@@ -173,6 +203,10 @@ echo "${RESULT_BASELINE}" | grep -q '"siblingArn":"unset"' || {
   echo "[verify] FAIL: expected SIBLING_ARN to be dropped (GetAtt warn-and-drop), got: ${RESULT_BASELINE}"
   exit 1
 }
+echo "${RESULT_BASELINE}" | grep -q '"dbHost":"unset"' || {
+  echo "[verify] FAIL: expected DB_HOST to be dropped (SSM-param Ref warn-and-drop without --from-cfn-stack), got: ${RESULT_BASELINE}"
+  exit 1
+}
 echo "${RESULT_BASELINE}" | grep -q '"staticValue":"always-the-same"' || {
   echo "[verify] FAIL: expected STATIC_VALUE=always-the-same in baseline response, got: ${RESULT_BASELINE}"
   exit 1
@@ -192,6 +226,10 @@ echo "${RESULT_FROM_CFN}" | grep -q "\"siblingArn\":\"${DEPLOYED_SIBLING_ARN}\""
   echo "[verify] FAIL: expected SIBLING_ARN=${DEPLOYED_SIBLING_ARN} (deployed-env GetAtt fallback), got: ${RESULT_FROM_CFN}"
   exit 1
 }
+echo "${RESULT_FROM_CFN}" | grep -q "\"dbHost\":\"${SSM_PARAM_VALUE}\"" || {
+  echo "[verify] FAIL: expected DB_HOST=${SSM_PARAM_VALUE} (AWS::SSM::Parameter::Value resolved from SSM, issue #94), got: ${RESULT_FROM_CFN}"
+  exit 1
+}
 echo "${RESULT_FROM_CFN}" | grep -q '"staticValue":"always-the-same"' || {
   echo "[verify] FAIL: STATIC_VALUE regressed under --from-cfn-stack, got: ${RESULT_FROM_CFN}"
   exit 1
@@ -203,5 +241,6 @@ cdk destroy "${STACK}" --force --region "${REGION}" \
 
 echo ""
 echo "[verify] All checks passed:"
-echo "[verify]   - existing behavior intact: TABLE_NAME (Ref) substituted, STATIC_VALUE (literal) passed through, baseline drops both intrinsics."
-echo "[verify]   - new behavior: SIBLING_ARN (Fn::GetAtt .Arn) recovered from the deployed function's resolved env."
+echo "[verify]   - existing behavior intact: TABLE_NAME (Ref) substituted, STATIC_VALUE (literal) passed through, baseline drops the intrinsics."
+echo "[verify]   - GetAtt fallback: SIBLING_ARN (Fn::GetAtt .Arn) recovered from the deployed function's resolved env."
+echo "[verify]   - issue #94: DB_HOST (Ref to AWS::SSM::Parameter::Value<String>) resolved from SSM under --from-cfn-stack, dropped without it."

--- a/tests/unit/cli/local-run-task-ssm-parameters.test.ts
+++ b/tests/unit/cli/local-run-task-ssm-parameters.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { LocalStateProvider } from '../../../src/local/local-state-provider.js';
+
+// Site-level binding test for the `--from-cfn-stack` SSM-parameter
+// resolution wired into `cdkl run-task`'s ECS image-resolution context
+// (issue #94 — the exact error the issue shows is the ECS container
+// `Environment 'FOO' dropped: Ref ...` shape). This locks the CALL SITE:
+// `buildEcsImageResolutionContext` passes the candidate stack's TEMPLATE
+// to the provider's `resolveTemplateSsmParameters` and stashes the result
+// on `ctx.stateParameters` (which `buildSubstitutionContextFromImageContext`
+// then copies into `SubstitutionContext.parameters`).
+
+const { stsSendMock } = vi.hoisted(() => ({ stsSendMock: vi.fn() }));
+
+// `buildEcsImageResolutionContext` issues one `sts:GetCallerIdentity` for
+// the pseudo-parameter bag when env/secret substitution is needed; stub
+// it so the test stays hermetic.
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    send = stsSendMock;
+    destroy(): void {}
+  },
+  GetCallerIdentityCommand: class {},
+}));
+
+const { buildEcsImageResolutionContext } = await import(
+  '../../../src/cli/commands/local-run-task.js'
+);
+
+function taskStackWithSsmParam(): StackInfo {
+  return {
+    stackName: 'MyStack',
+    region: 'us-east-1',
+    template: {
+      Parameters: {
+        SsmDbHost: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/app/db-host' },
+      },
+      Resources: {
+        TaskDef: {
+          Type: 'AWS::ECS::TaskDefinition',
+          Properties: {
+            ContainerDefinitions: [
+              { Name: 'app', Environment: [{ Name: 'DB_HOST', Value: { Ref: 'SsmDbHost' } }] },
+            ],
+          },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
+describe('buildEcsImageResolutionContext SSM-parameter resolution (site binding)', () => {
+  beforeEach(() => {
+    stsSendMock.mockReset();
+    stsSendMock.mockResolvedValue({ Account: '111111111111' });
+  });
+
+  it('passes the stack template to resolveTemplateSsmParameters and stashes ctx.stateParameters', async () => {
+    const provider = {
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      resolveTemplateSsmParameters: vi.fn().mockResolvedValue({ SsmDbHost: 'db.internal' }),
+      dispose: vi.fn(),
+    } as unknown as LocalStateProvider & {
+      resolveTemplateSsmParameters: ReturnType<typeof vi.fn>;
+    };
+
+    const ctx = await buildEcsImageResolutionContext(taskStackWithSsmParam(), provider, {} as never);
+
+    expect(provider.resolveTemplateSsmParameters).toHaveBeenCalledTimes(1);
+    const passed = provider.resolveTemplateSsmParameters.mock.calls[0]![0] as {
+      Parameters?: Record<string, unknown>;
+    };
+    expect(passed.Parameters?.['SsmDbHost']).toBeDefined();
+    expect(ctx?.stateParameters).toEqual({ SsmDbHost: 'db.internal' });
+  });
+
+  it('leaves stateParameters absent when the provider resolves nothing', async () => {
+    const provider = {
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      resolveTemplateSsmParameters: vi.fn().mockResolvedValue({}),
+      dispose: vi.fn(),
+    } as unknown as LocalStateProvider;
+
+    const ctx = await buildEcsImageResolutionContext(taskStackWithSsmParam(), provider, {} as never);
+    expect(ctx?.stateParameters).toBeUndefined();
+  });
+
+  it('skips SSM resolution cleanly for a provider without resolveTemplateSsmParameters', async () => {
+    const provider = {
+      label: '--from-state',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn(),
+    } as unknown as LocalStateProvider;
+
+    const ctx = await buildEcsImageResolutionContext(taskStackWithSsmParam(), provider, {} as never);
+    expect(ctx?.stateParameters).toBeUndefined();
+  });
+});

--- a/tests/unit/cli/local-start-api-ssm-parameters.test.ts
+++ b/tests/unit/cli/local-start-api-ssm-parameters.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+
+// Site-level binding test for the `--from-cfn-stack` SSM-parameter
+// resolution wired into `loadStateForRoutedStacks` (issue #94). The pure
+// helper (collectSsmParameterRefs / resolveSsmParameters) and the
+// provider method (resolveTemplateSsmParameters) are unit-tested
+// elsewhere; this locks the CALL SITE so a future refactor that drops the
+// call fails a test: the stack TEMPLATE (carrying Parameters) is passed,
+// the resolution happens while the provider is alive (before dispose()),
+// the result is stashed on `bundle.ssmParameters`, and a provider that
+// does NOT implement the optional method is skipped cleanly.
+
+const { createProviderMock, rejectMock, stsSendMock, fallbackRegionMock } = vi.hoisted(() => ({
+  createProviderMock: vi.fn(),
+  rejectMock: vi.fn(),
+  stsSendMock: vi.fn(),
+  fallbackRegionMock: vi.fn(),
+}));
+
+vi.mock('../../../src/cli/commands/local-state-source.js', () => ({
+  createLocalStateProvider: createProviderMock,
+  rejectExplicitCfnStackWithMultipleStacks: rejectMock,
+  isCfnFlagPresent: vi.fn(() => false),
+  resolveCfnFallbackRegion: fallbackRegionMock,
+}));
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    send = stsSendMock;
+    destroy(): void {}
+  },
+  GetCallerIdentityCommand: class {},
+}));
+
+const { loadStateForRoutedStacks } = await import('../../../src/cli/commands/local-start-api.js');
+
+// A reachable Lambda whose env Refs an SSM-backed CloudFormation
+// parameter, plus the matching `Parameters` block CDK synthesizes.
+function lambdaStackWithSsmParam(): StackInfo {
+  return {
+    stackName: 'MyStack',
+    region: 'us-east-1',
+    template: {
+      Parameters: {
+        SsmDbHost: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/app/db-host' },
+      },
+      Resources: {
+        EchoFn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Environment: { Variables: { DB_HOST: { Ref: 'SsmDbHost' } } },
+          },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
+function routeTo(logicalId: string): DiscoveredRoute {
+  return {
+    method: 'GET',
+    pathPattern: '/x',
+    lambdaLogicalId: logicalId,
+    source: 'http-api',
+    apiVersion: 'v2',
+    stage: '$default',
+    unsupported: false,
+    mockCors: false,
+    serviceIntegration: false,
+  } as unknown as DiscoveredRoute;
+}
+
+describe('loadStateForRoutedStacks SSM-parameter resolution (site binding)', () => {
+  beforeEach(() => {
+    createProviderMock.mockReset();
+    rejectMock.mockReset();
+    stsSendMock.mockReset();
+    stsSendMock.mockResolvedValue({ Account: '111111111111' });
+    fallbackRegionMock.mockReset();
+    fallbackRegionMock.mockImplementation(
+      async (_options: unknown, synthRegion: string | undefined) => synthRegion
+    );
+  });
+
+  it('resolves the stack template Parameters via the provider and stashes them on bundle.ssmParameters', async () => {
+    const provider = {
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      resolveTemplateSsmParameters: vi.fn().mockResolvedValue({ SsmDbHost: 'db.internal' }),
+      dispose: vi.fn(),
+    };
+    createProviderMock.mockReturnValue(provider);
+
+    const result = await loadStateForRoutedStacks(
+      [lambdaStackWithSsmParam()],
+      [routeTo('EchoFn')],
+      [],
+      {} as never,
+      undefined
+    );
+
+    // Bound: the SYNTHESIZED TEMPLATE (with its Parameters block) is what
+    // gets passed — not the resource map / stack name.
+    expect(provider.resolveTemplateSsmParameters).toHaveBeenCalledTimes(1);
+    const passed = provider.resolveTemplateSsmParameters.mock.calls[0]![0] as {
+      Parameters?: Record<string, unknown>;
+    };
+    expect(passed.Parameters?.['SsmDbHost']).toBeDefined();
+
+    // Resolved while the provider (and its AWS client) is still alive.
+    expect(provider.resolveTemplateSsmParameters.mock.invocationCallOrder[0]).toBeLessThan(
+      provider.dispose.mock.invocationCallOrder[0]!
+    );
+
+    // Stashed for buildContainerSpec to feed the substitution context.
+    expect(result.get('MyStack')?.ssmParameters).toEqual({ SsmDbHost: 'db.internal' });
+    expect(provider.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves ssmParameters absent when the provider resolves nothing', async () => {
+    const provider = {
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      resolveTemplateSsmParameters: vi.fn().mockResolvedValue({}),
+      dispose: vi.fn(),
+    };
+    createProviderMock.mockReturnValue(provider);
+
+    const result = await loadStateForRoutedStacks(
+      [lambdaStackWithSsmParam()],
+      [routeTo('EchoFn')],
+      [],
+      {} as never,
+      undefined
+    );
+
+    expect(provider.resolveTemplateSsmParameters).toHaveBeenCalledTimes(1);
+    expect(result.get('MyStack')?.ssmParameters).toBeUndefined();
+  });
+
+  it('skips the SSM resolution cleanly for a provider without resolveTemplateSsmParameters', async () => {
+    const provider = {
+      label: '--from-state',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn(),
+      // no resolveTemplateSsmParameters
+    };
+    createProviderMock.mockReturnValue(provider);
+
+    const result = await loadStateForRoutedStacks(
+      [lambdaStackWithSsmParam()],
+      [routeTo('EchoFn')],
+      [],
+      {} as never,
+      undefined
+    );
+
+    expect(result.get('MyStack')?.ssmParameters).toBeUndefined();
+    expect(provider.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/cli/local-start-service-ssm-parameters.test.ts
+++ b/tests/unit/cli/local-start-service-ssm-parameters.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { LocalStateProvider } from '../../../src/local/local-state-provider.js';
+
+// Site-level binding test for the `--from-cfn-stack` SSM-parameter
+// resolution wired into `cdkl start-service`'s ECS image-resolution
+// context (issue #94 — the ECS container `Environment 'FOO' dropped:
+// Ref ...` symptom). This locks the CALL SITE: `buildEcsImageResolutionContext`
+// passes the candidate stack's TEMPLATE to the provider's
+// `resolveTemplateSsmParameters` and stashes the result on
+// `ctx.stateParameters` (which `buildSubstitutionContextFromImageContext`
+// then copies into `SubstitutionContext.parameters`). Mirrors the
+// run-task binding test.
+
+const { stsSendMock } = vi.hoisted(() => ({ stsSendMock: vi.fn() }));
+
+// `buildEcsImageResolutionContext` issues one `sts:GetCallerIdentity` for
+// the pseudo-parameter bag when env/secret substitution is needed; stub
+// it so the test stays hermetic.
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    send = stsSendMock;
+    destroy(): void {}
+  },
+  GetCallerIdentityCommand: class {},
+}));
+
+const { buildEcsImageResolutionContext } = await import(
+  '../../../src/cli/commands/local-start-service.js'
+);
+
+function serviceStackWithSsmParam(): StackInfo {
+  return {
+    stackName: 'MyStack',
+    region: 'us-east-1',
+    template: {
+      Parameters: {
+        SsmDbHost: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/app/db-host' },
+      },
+      Resources: {
+        TaskDef: {
+          Type: 'AWS::ECS::TaskDefinition',
+          Properties: {
+            ContainerDefinitions: [
+              { Name: 'app', Environment: [{ Name: 'DB_HOST', Value: { Ref: 'SsmDbHost' } }] },
+            ],
+          },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
+describe('start-service buildEcsImageResolutionContext SSM-parameter resolution (site binding)', () => {
+  beforeEach(() => {
+    stsSendMock.mockReset();
+    stsSendMock.mockResolvedValue({ Account: '111111111111' });
+  });
+
+  it('passes the stack template to resolveTemplateSsmParameters and stashes ctx.stateParameters', async () => {
+    const provider = {
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      resolveTemplateSsmParameters: vi.fn().mockResolvedValue({ SsmDbHost: 'db.internal' }),
+      dispose: vi.fn(),
+    } as unknown as LocalStateProvider & {
+      resolveTemplateSsmParameters: ReturnType<typeof vi.fn>;
+    };
+
+    const ctx = await buildEcsImageResolutionContext(
+      'MyStack:WebService',
+      [serviceStackWithSsmParam()],
+      {} as never,
+      provider
+    );
+
+    expect(provider.resolveTemplateSsmParameters).toHaveBeenCalledTimes(1);
+    const passed = provider.resolveTemplateSsmParameters.mock.calls[0]![0] as {
+      Parameters?: Record<string, unknown>;
+    };
+    expect(passed.Parameters?.['SsmDbHost']).toBeDefined();
+    expect(ctx?.stateParameters).toEqual({ SsmDbHost: 'db.internal' });
+  });
+
+  it('leaves stateParameters absent when the provider resolves nothing', async () => {
+    const provider = {
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      resolveTemplateSsmParameters: vi.fn().mockResolvedValue({}),
+      dispose: vi.fn(),
+    } as unknown as LocalStateProvider;
+
+    const ctx = await buildEcsImageResolutionContext(
+      'MyStack:WebService',
+      [serviceStackWithSsmParam()],
+      {} as never,
+      provider
+    );
+    expect(ctx?.stateParameters).toBeUndefined();
+  });
+
+  it('skips SSM resolution cleanly for a provider without resolveTemplateSsmParameters', async () => {
+    const provider = {
+      label: '--from-state',
+      load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn(),
+    } as unknown as LocalStateProvider;
+
+    const ctx = await buildEcsImageResolutionContext(
+      'MyStack:WebService',
+      [serviceStackWithSsmParam()],
+      {} as never,
+      provider
+    );
+    expect(ctx?.stateParameters).toBeUndefined();
+  });
+});

--- a/tests/unit/local/cfn-local-state-provider-ssm-parameters.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-ssm-parameters.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Mock the SSM SDK so `resolveTemplateSsmParameters()` (which constructs
+// its own SSMClient via the lazy getSsmClient()) can be exercised without
+// real AWS. Capture the constructor config so we can assert that the
+// CLI's --profile / --region thread through to the client.
+const { ssmSendMock, ssmDestroyMock, ssmCtorMock } = vi.hoisted(() => ({
+  ssmSendMock: vi.fn(),
+  ssmDestroyMock: vi.fn(),
+  ssmCtorMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-ssm', () => ({
+  SSMClient: class {
+    send = ssmSendMock;
+    destroy = ssmDestroyMock;
+    constructor(config: unknown) {
+      ssmCtorMock(config);
+    }
+  },
+  GetParametersCommand: class {
+    constructor(public readonly input: unknown) {}
+  },
+}));
+
+// The CFn / Lambda clients are unused by these tests but the provider
+// imports them at load time, so provide no-op stubs.
+vi.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: class {
+    send = vi.fn();
+    destroy(): void {}
+  },
+  ListStackResourcesCommand: class {},
+  DescribeStacksCommand: class {},
+  ListExportsCommand: class {},
+}));
+
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: class {
+    send = vi.fn();
+    destroy(): void {}
+  },
+  GetFunctionConfigurationCommand: class {},
+}));
+
+const { CfnLocalStateProvider } = await import('../../../src/local/cfn-local-state-provider.js');
+
+type Tmpl = Parameters<
+  NonNullable<
+    InstanceType<typeof CfnLocalStateProvider>['resolveTemplateSsmParameters']
+  >
+>[0];
+
+function templateWithSsmString(): Tmpl {
+  return {
+    Resources: {},
+    Parameters: {
+      SsmDbHost: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/app/db-host' },
+    },
+  } as Tmpl;
+}
+
+describe('CfnLocalStateProvider.resolveTemplateSsmParameters', () => {
+  beforeEach(() => {
+    ssmSendMock.mockReset();
+    ssmDestroyMock.mockReset();
+    ssmCtorMock.mockReset();
+  });
+
+  it('resolves an SSM::Parameter::Value<String> param into the value map', async () => {
+    ssmSendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/app/db-host', Value: 'db.internal' }],
+      InvalidParameters: [],
+    });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const out = await provider.resolveTemplateSsmParameters(templateWithSsmString());
+
+    expect(out).toEqual({ SsmDbHost: 'db.internal' });
+    expect(ssmSendMock).toHaveBeenCalledTimes(1);
+    provider.dispose();
+  });
+
+  it('comma-joins the List<String> variant (passed through from SSM)', async () => {
+    ssmSendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/app/subnets', Value: 'subnet-a,subnet-b' }],
+      InvalidParameters: [],
+    });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const out = await provider.resolveTemplateSsmParameters({
+      Resources: {},
+      Parameters: {
+        SsmSubnets: { Type: 'AWS::SSM::Parameter::Value<List<String>>', Default: '/app/subnets' },
+      },
+    } as Tmpl);
+
+    expect(out).toEqual({ SsmSubnets: 'subnet-a,subnet-b' });
+    provider.dispose();
+  });
+
+  it('returns {} and opens no SSM client when the template has no SSM params', async () => {
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const out = await provider.resolveTemplateSsmParameters({
+      Resources: {},
+      Parameters: { Plain: { Type: 'String', Default: 'x' } },
+    } as Tmpl);
+
+    expect(out).toEqual({});
+    expect(ssmCtorMock).not.toHaveBeenCalled();
+    expect(ssmSendMock).not.toHaveBeenCalled();
+    provider.dispose();
+  });
+
+  it('falls back to {} (no throw) when GetParameters fails', async () => {
+    ssmSendMock.mockRejectedValueOnce(
+      Object.assign(new Error('denied'), { name: 'AccessDeniedException' })
+    );
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    expect(await provider.resolveTemplateSsmParameters(templateWithSsmString())).toEqual({});
+    provider.dispose();
+  });
+
+  it('threads --region and --profile into the SSM client and destroys it on dispose', async () => {
+    ssmSendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/app/db-host', Value: 'db.internal' }],
+      InvalidParameters: [],
+    });
+    const provider = new CfnLocalStateProvider({
+      cfnStackName: 'S',
+      region: 'ap-northeast-1',
+      profile: 'mates_dev',
+    });
+
+    await provider.resolveTemplateSsmParameters(templateWithSsmString());
+    expect(ssmCtorMock).toHaveBeenCalledTimes(1);
+    expect(ssmCtorMock.mock.calls[0]![0]).toEqual({
+      region: 'ap-northeast-1',
+      profile: 'mates_dev',
+    });
+
+    provider.dispose();
+    expect(ssmDestroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the profile from the SSM client config when --profile is unset', async () => {
+    ssmSendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/app/db-host', Value: 'db.internal' }],
+      InvalidParameters: [],
+    });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    await provider.resolveTemplateSsmParameters(templateWithSsmString());
+    expect(ssmCtorMock.mock.calls[0]![0]).toEqual({ region: 'us-east-1' });
+    provider.dispose();
+  });
+
+  it('throws on use after dispose()', async () => {
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    provider.dispose();
+    await expect(provider.resolveTemplateSsmParameters(templateWithSsmString())).rejects.toThrow(
+      /after dispose/
+    );
+  });
+});

--- a/tests/unit/local/ssm-parameter-resolver.test.ts
+++ b/tests/unit/local/ssm-parameter-resolver.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Capture the SSMClient constructor config + script the shared `send`
+// mock so `resolveSsmParameters` can be exercised without real AWS.
+const { sendMock, ctorMock } = vi.hoisted(() => ({
+  sendMock: vi.fn(),
+  ctorMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-ssm', () => ({
+  SSMClient: class {
+    send = sendMock;
+    destroy(): void {}
+    constructor(config: unknown) {
+      ctorMock(config);
+    }
+  },
+  GetParametersCommand: class {
+    constructor(public readonly input: unknown) {}
+  },
+}));
+
+const { collectSsmParameterRefs, resolveSsmParameters, formatSsmError } = await import(
+  '../../../src/local/ssm-parameter-resolver.js'
+);
+const { SSMClient } = await import('@aws-sdk/client-ssm');
+
+describe('collectSsmParameterRefs', () => {
+  it('collects AWS::SSM::Parameter::Value<String> entries with a string Default', () => {
+    const refs = collectSsmParameterRefs({
+      Parameters: {
+        SsmStr: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/app/db-host' },
+      },
+    });
+    expect(refs).toEqual([{ logicalId: 'SsmStr', ssmName: '/app/db-host', isList: false }]);
+  });
+
+  it('flags the List<String> variant via isList', () => {
+    const refs = collectSsmParameterRefs({
+      Parameters: {
+        SsmList: { Type: 'AWS::SSM::Parameter::Value<List<String>>', Default: '/app/subnets' },
+      },
+    });
+    expect(refs).toEqual([{ logicalId: 'SsmList', ssmName: '/app/subnets', isList: true }]);
+  });
+
+  it('ignores non-SSM parameter types and SSM entries without a string Default', () => {
+    const refs = collectSsmParameterRefs({
+      Parameters: {
+        Plain: { Type: 'String', Default: 'literal' },
+        NoDefault: { Type: 'AWS::SSM::Parameter::Value<String>' },
+        EmptyDefault: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '' },
+      },
+    });
+    expect(refs).toEqual([]);
+  });
+
+  it('returns [] when there is no Parameters block', () => {
+    expect(collectSsmParameterRefs({})).toEqual([]);
+    expect(collectSsmParameterRefs(undefined)).toEqual([]);
+  });
+});
+
+describe('resolveSsmParameters', () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    ctorMock.mockReset();
+  });
+
+  it('resolves a String parameter into the logicalId -> value map', async () => {
+    sendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/app/db-host', Value: 'db.internal' }],
+      InvalidParameters: [],
+    });
+    const client = new SSMClient({ region: 'us-east-1' });
+    const out = await resolveSsmParameters(
+      client,
+      [{ logicalId: 'SsmStr', ssmName: '/app/db-host', isList: false }],
+      '--from-cfn-stack'
+    );
+    expect(out).toEqual({ SsmStr: 'db.internal' });
+    // WithDecryption must be set so SecureString parameters resolve.
+    const cmd = sendMock.mock.calls[0]![0] as { input: { Names: string[]; WithDecryption: boolean } };
+    expect(cmd.input).toEqual({ Names: ['/app/db-host'], WithDecryption: true });
+  });
+
+  it('passes the comma-joined List<String> value through verbatim', async () => {
+    sendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/app/subnets', Value: 'subnet-a,subnet-b' }],
+      InvalidParameters: [],
+    });
+    const client = new SSMClient({ region: 'us-east-1' });
+    const out = await resolveSsmParameters(
+      client,
+      [{ logicalId: 'SsmList', ssmName: '/app/subnets', isList: true }],
+      '--from-cfn-stack'
+    );
+    expect(out).toEqual({ SsmList: 'subnet-a,subnet-b' });
+  });
+
+  it('maps multiple logical IDs that share one SSM name', async () => {
+    sendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/shared', Value: 'one' }],
+      InvalidParameters: [],
+    });
+    const client = new SSMClient({ region: 'us-east-1' });
+    const out = await resolveSsmParameters(
+      client,
+      [
+        { logicalId: 'A', ssmName: '/shared', isList: false },
+        { logicalId: 'B', ssmName: '/shared', isList: false },
+      ],
+      '--from-cfn-stack'
+    );
+    expect(out).toEqual({ A: 'one', B: 'one' });
+    // De-duped to one SSM name -> one GetParameters call.
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('chunks names into batches of 10', async () => {
+    const refs = Array.from({ length: 12 }, (_, i) => ({
+      logicalId: `P${i}`,
+      ssmName: `/p/${i}`,
+      isList: false,
+    }));
+    sendMock
+      .mockResolvedValueOnce({
+        Parameters: refs.slice(0, 10).map((r) => ({ Name: r.ssmName, Value: `v${r.logicalId}` })),
+        InvalidParameters: [],
+      })
+      .mockResolvedValueOnce({
+        Parameters: refs.slice(10).map((r) => ({ Name: r.ssmName, Value: `v${r.logicalId}` })),
+        InvalidParameters: [],
+      });
+    const client = new SSMClient({ region: 'us-east-1' });
+    const out = await resolveSsmParameters(client, refs, '--from-cfn-stack');
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(Object.keys(out)).toHaveLength(12);
+    expect(out['P11']).toBe('vP11');
+  });
+
+  it('omits invalid parameter names from the result (warn-and-drop)', async () => {
+    sendMock.mockResolvedValueOnce({
+      Parameters: [{ Name: '/ok', Value: 'good' }],
+      InvalidParameters: ['/missing'],
+    });
+    const client = new SSMClient({ region: 'us-east-1' });
+    const out = await resolveSsmParameters(
+      client,
+      [
+        { logicalId: 'Ok', ssmName: '/ok', isList: false },
+        { logicalId: 'Missing', ssmName: '/missing', isList: false },
+      ],
+      '--from-cfn-stack'
+    );
+    expect(out).toEqual({ Ok: 'good' });
+  });
+
+  it('falls back to an empty map (no throw) when GetParameters fails', async () => {
+    sendMock.mockRejectedValueOnce(
+      Object.assign(new Error('denied'), { name: 'AccessDeniedException' })
+    );
+    const client = new SSMClient({ region: 'us-east-1' });
+    const out = await resolveSsmParameters(
+      client,
+      [{ logicalId: 'SsmStr', ssmName: '/app/db-host', isList: false }],
+      '--from-cfn-stack'
+    );
+    expect(out).toEqual({});
+  });
+
+  it('keeps resolving other chunks when one chunk fails', async () => {
+    const refs = Array.from({ length: 11 }, (_, i) => ({
+      logicalId: `P${i}`,
+      ssmName: `/p/${i}`,
+      isList: false,
+    }));
+    sendMock
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValueOnce({
+        Parameters: refs.slice(10).map((r) => ({ Name: r.ssmName, Value: 'late' })),
+        InvalidParameters: [],
+      });
+    const client = new SSMClient({ region: 'us-east-1' });
+    const out = await resolveSsmParameters(client, refs, '--from-cfn-stack');
+    // First chunk (10) failed; second chunk (1) succeeded.
+    expect(out).toEqual({ P10: 'late' });
+  });
+
+  it('returns {} without calling SSM when there are no refs', async () => {
+    const client = new SSMClient({ region: 'us-east-1' });
+    expect(await resolveSsmParameters(client, [], '--from-cfn-stack')).toEqual({});
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatSsmError', () => {
+  it('prefixes the error name when present', () => {
+    expect(formatSsmError(Object.assign(new Error('nope'), { name: 'ThrottlingException' }))).toBe(
+      'ThrottlingException: nope'
+    );
+  });
+  it('falls back to the bare message for a plain Error', () => {
+    expect(formatSsmError(new Error('boom'))).toBe('boom');
+  });
+  it('stringifies non-Error throwables', () => {
+    expect(formatSsmError('weird')).toBe('weird');
+  });
+});

--- a/tests/unit/local/state-resolver-parameters.test.ts
+++ b/tests/unit/local/state-resolver-parameters.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vite-plus/test';
+
+import {
+  substituteAgainstState,
+  substituteEnvVarsFromState,
+  type SubstitutionContext,
+} from '../../../src/local/state-resolver.js';
+
+describe('state-resolver: SubstitutionContext.parameters (SSM-backed Refs)', () => {
+  it("resolves a Ref to a resolved parameter when it isn't a resource", () => {
+    const context: SubstitutionContext = {
+      resources: {},
+      parameters: { SsmDbHost: 'db.internal' },
+    };
+    expect(substituteAgainstState({ Ref: 'SsmDbHost' }, context)).toEqual({
+      kind: 'literal',
+      value: 'db.internal',
+    });
+  });
+
+  it('prefers a resource over a same-id parameter (resources win)', () => {
+    const context: SubstitutionContext = {
+      resources: {
+        Thing: { physicalId: 'res-1', resourceType: 'X', properties: {}, attributes: {}, dependencies: [] },
+      },
+      parameters: { Thing: 'param-value' },
+    };
+    expect(substituteAgainstState({ Ref: 'Thing' }, context)).toEqual({
+      kind: 'literal',
+      value: 'res-1',
+    });
+  });
+
+  it('resolves a comma-joined List<String> parameter value as-is', () => {
+    const context: SubstitutionContext = {
+      resources: {},
+      parameters: { SsmSubnets: 'subnet-a,subnet-b' },
+    };
+    expect(substituteAgainstState({ Ref: 'SsmSubnets' }, context)).toEqual({
+      kind: 'literal',
+      value: 'subnet-a,subnet-b',
+    });
+  });
+
+  it('substitutes ${LogicalId} inside Fn::Sub from the parameters map', () => {
+    const context: SubstitutionContext = {
+      resources: {},
+      parameters: { SsmDbHost: 'db.internal' },
+    };
+    expect(substituteAgainstState({ 'Fn::Sub': 'host=${SsmDbHost}' }, context)).toEqual({
+      kind: 'literal',
+      value: 'host=db.internal',
+    });
+  });
+
+  it('warn-and-drops with a reworded reason that mentions CloudFormation parameters', () => {
+    const result = substituteAgainstState({ Ref: 'Unknown' }, { resources: {} });
+    expect(result.kind).toBe('unresolved');
+    if (result.kind === 'unresolved') {
+      expect(result.reason).toContain('no record in the state source');
+      expect(result.reason).toContain('CloudFormation parameter');
+      expect(result.reason).toContain('AWS::SSM::Parameter::Value');
+    }
+  });
+
+  it('wires the parameters map through substituteEnvVarsFromState end-to-end', () => {
+    const { env, audit } = substituteEnvVarsFromState(
+      { DB_HOST: { Ref: 'SsmDbHost' }, OTHER: { Ref: 'NopeParam' } },
+      { resources: {}, parameters: { SsmDbHost: 'db.internal' } }
+    );
+    expect(env).toEqual({ DB_HOST: 'db.internal' });
+    expect(audit.resolvedKeys).toEqual(['DB_HOST']);
+    expect(audit.unresolved.map((u) => u.key)).toEqual(['OTHER']);
+  });
+});


### PR DESCRIPTION
## Summary

Under `--from-cfn-stack`, an env var / property that `Ref`s a
CloudFormation **Parameter** of type `AWS::SSM::Parameter::Value<String>`
(what CDK synthesizes for `ssm.StringParameter.valueForStringParameter`)
was warn-and-dropped — the state source is built from
`ListStackResources` (deployed *resources*) and a CFn *parameter* is not a
resource. This resolves those parameters from SSM and feeds them into the
substitution context so the `Ref` resolves.

- New `src/local/ssm-parameter-resolver.ts`: `collectSsmParameterRefs`
  (pure scan of the template `Parameters`) + `resolveSsmParameters`
  (batched `GetParameters`, chunks of 10, de-dup, `List<String>`
  comma-join, `InvalidParameters` skipped, never-throws).
- New `resolveTemplateSsmParameters` provider method on
  `CfnLocalStateProvider`, using a lazy SSM client that reuses the same
  region + `--profile` as the CFn/Lambda clients.
- `SubstitutionContext.parameters` map, consulted by `resolveRef` when a
  logical id is not a resource (resources win on collision). Wired into
  all four commands (invoke / start-api / run-task / start-service).
- Reworded the misleading "(was the resource deployed?)" `resolveRef`
  warning to mention SSM-backed CFn parameters.

## Test plan

- [x] Unit: resolver branches (chunking, de-dup, List join,
      InvalidParameters, SSM-error fallback), provider method incl.
      `--profile`/`--region` threading + post-dispose, `resolveRef`
      parameters precedence + reworded warning, and site-level binding
      tests for start-api / run-task / start-service.
- [x] Real-AWS integ (`local-invoke-from-cfn-stack`, extended): deploys a
      stack whose `DB_HOST` is a `Ref` to an
      `AWS::SSM::Parameter::Value<String>`, asserts it drops without
      `--from-cfn-stack` and resolves to the SSM value with it. Ran clean
      (stack + SSM parameter created and torn down, 0 orphans). This is
      the end-to-end site binding for the `cdkl invoke --from-cfn-stack`
      path.
- [x] Full unit suite green; `vp run check` + `vp run build` clean.

## Review notes (3-axis)

- Spec + code: clean, no blockers.
- Test: the two flagged site-binding gaps are closed — start-service via a
  new unit binding test, local-invoke via the real-AWS integ above.
- Accepted as known cost: the `isList` flag is retained for future
  divergence; the `buildSubstitutionContextFromImageContext` guard couples
  `stateParameters` to `stateResources` (unreachable in practice since
  `load()` always sets `stateResources`).
- Follow-up filed for hardening decrypted SecureString values off the
  docker argv (see issue 99).

Closes #94
