### PR TITLE
feat(list): readable list output, interactive-first docs, picker key hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,103 +56,67 @@ This installs the `cdkl` command.
 
 Point cdk-local at your CDK app. It synths your stack and runs Lambda functions, API Gateway routes, and ECS tasks locally with Docker. No AWS credentials needed for the basic flow.
 
-#### Discover targets — `list` (alias `ls`)
+#### The quick way — run a command and pick from the list
 
-Not sure what to pass as a `<target>`? Run `cdkl list` (or `cdkl ls`) to synth your app and print every runnable target, grouped by the command that runs it. Each row shows both accepted forms — the CDK display path and the stack-qualified logical ID — so you can copy either straight into `invoke` / `start-api` / `run-task` / `start-service`.
+You almost never need to know or type a CDK path. In a terminal, just run the command with no target and cdk-local opens an arrow-key picker of the matching resources:
+
+```bash
+cdkl invoke            # pick a Lambda, then invoke it
+cdkl run-task          # pick an ECS task definition, then run it
+cdkl start-service     # multi-select one or more ECS services
+cdkl start-api -i      # pick one API to serve
+```
+
+![cdkl invoke against a local sample CDK app — no AWS account, no deploy](assets/cdkl-invoke.gif)
+
+For `invoke` / `run-task` / `start-service`, omitting the target in an interactive terminal opens the picker automatically; `-i` / `--interactive` also forces it. `start-api` keeps its default of serving **every** discovered API when run bare, so pass `-i` there to pick a single one. (In the multi-select, press space to toggle a row and enter to confirm.)
+
+Outside a TTY — CI, pipes, redirected stdin — the picker can't run: `invoke` / `run-task` / `start-service` fall back to a "target required" error, and `-i` errors clearly. Pass the target explicitly there (see [below](#passing-a-target-explicitly)).
+
+#### See what's available — `list` (alias `ls`)
+
+`cdkl list` (or `cdkl ls`) prints every runnable target, grouped by the command that runs it. Browse it, or use it to grab the exact target string for a script. Pass `-l` to also print the stack-qualified logical ID under each path. Only the list goes to stdout (synth status goes to stderr), so `cdkl list | ...` stays clean.
 
 ```bash
 cdkl list
 ```
 
 ```text
-Lambda Functions  (cdkl invoke <target>)
-  MyStack/ItemsHandler    MyStack:ItemsHandlerFB09CCF4
 
-APIs  (cdkl start-api [target])
-  MyStack/MyHttpApi       MyStack:MyHttpApi8AEAAC21
+Lambda Functions  ->  cdkl invoke <target>
+  MyStack/ItemsHandler
 
-ECS Services  (cdkl start-service <target...>)
-  MyStack/WebService      MyStack:WebService
+APIs  ->  cdkl start-api [target]
+  MyStack/MyHttpApi
 
-ECS Task Definitions  (cdkl run-task <target>)
-  MyStack/WebTask         MyStack:WebTask
+ECS Services  ->  cdkl start-service <target...>
+  MyStack/WebService
+
+ECS Task Definitions  ->  cdkl run-task <target>
+  MyStack/WebTask
 ```
 
-#### Pick targets interactively — `-i` / omit the target
+#### Passing a target explicitly
 
-Don't want to copy a path at all? In an interactive terminal, just omit the target and `invoke` / `run-task` / `start-service` drop you into an arrow-key picker (multi-select for `start-service`). Or pass `-i` / `--interactive` explicitly on any of the four commands:
-
-```bash
-cdkl invoke              # pick the Lambda from a list
-cdkl run-task            # pick the task definition
-cdkl start-service       # multi-select one or more services
-cdkl start-api -i        # pick one API to serve (a bare `start-api` still serves them all)
-```
-
-Outside a TTY (CI, pipes) the picker can't run: the required-target commands fall back to their usual "target required" error, and `-i` errors with a clear message — pass the target explicitly there.
-
-#### Lambda — `invoke`
-
-Invoke a single Lambda function with an event payload.
+When you want to name a target instead of picking — in a script, in CI, or to skip the prompt — pass it as the argument. Every target accepts the CDK display path (recommended) or a stack-qualified logical ID (`MyStack:MyFunction1234ABCD`, the SAM-compatible form, handy when copying straight out of `cdk.out/<Stack>.template.json`); single-stack apps may drop the stack prefix.
 
 ```bash
-cdkl invoke MyStack/MyFunction --event ./event.json
-```
+# Lambda — with an event payload
+cdkl invoke MyStack/ItemsHandler --event ./event.json
+cdkl invoke MyStack:ItemsHandler1234ABCD --event ./event.json   # logical ID (any app)
 
-![cdkl invoke against a local sample CDK app — no AWS account, no deploy](assets/cdkl-invoke.gif)
-
-Every target argument (across `invoke`, `run-task`, `start-service`) accepts
-either form — the CDK display path is the recommended default, but a
-CloudFormation logical ID works too, which is handy when copying it straight
-out of `cdk.out/<Stack>.template.json` beats tracing the construct path (and
-matches what a SAM background expects):
-
-```bash
-# CDK display path (recommended)
-cdkl invoke MyStack/MyFunction --event ./event.json
-
-# Stack-qualified logical ID (works in any app)
-cdkl invoke MyStack:MyFunction1234ABCD --event ./event.json
-
-# Bare logical ID (single-stack apps — the stack is auto-detected)
-cdkl invoke MyFunction1234ABCD --event ./event.json
-```
-
-#### HTTP APIs & Function URLs — `start-api`
-
-Serve your app's HTTP surface locally — API Gateway routes (REST v1 / HTTP v2 / WebSocket) and Lambda Function URLs — on a local HTTP server.
-
-```bash
-# Single-stack app: serve every API in the stack (each on its own port)
-cdkl start-api
-
-# Or target one API
-cdkl start-api MyStack/MyApi
-```
-
-In a multi-stack app, a bare `cdkl start-api` errors out rather than serving every stack's API at once (so a side-stack's API is never booted by accident). Either serve them all explicitly, or pick one stack with the first selector you supply:
-
-```bash
-# Serve every stack's API (each on its own port)
-cdkl start-api --all-stacks
-```
-
-- `--stack <name>` — the synth stack name, matched against your CDK app.
-- `--from-cfn-stack <name>` — the deployed CloudFormation stack name; doubles as the stack selector (see [section 2](#2-bound-to-a-deployed-stack)).
-- a stack-qualified target like `MyStack/MyApi` — the `MyStack` prefix selects the stack.
-
-`--all-stacks` is mutually exclusive with those single-target selectors (the bare `--from-cfn-stack` flag stays compatible). See [docs/cli-reference.md](docs/cli-reference.md) for the full precedence rules.
-
-#### ECS — `run-task` / `start-service`
-
-Run an ECS task definition once, or start a long-running service with Service Connect / Cloud Map registry.
-
-```bash
+# ECS — run a task once, or start one or more long-running services
 cdkl run-task MyStack/MyTask
-cdkl start-service MyStack/MyService
+cdkl start-service MyStack/OrdersService MyStack/Frontend
+
+# API Gateway / Function URLs — one API, or every API in the stack
+cdkl start-api MyStack/MyApi
+cdkl start-api
 ```
 
-There is no cluster command — locally, Docker is the placement target a cluster abstracts away, so there is nothing to run. Both commands accept an optional `--cluster <name>` to set the cluster name surfaced to `ECS_CONTAINER_METADATA_URI_V4` (also used as the local Docker network prefix). See [docs/cli-reference.md](docs/cli-reference.md) for the full ECS option list.
+`start-api` serves your app's HTTP surface (API Gateway REST v1 / HTTP v2 / WebSocket + Lambda Function URLs) on a local HTTP server, one server per API. In a multi-stack app a bare `cdkl start-api` errors rather than serving every stack's API at once (so a side-stack's API is never booted by accident); serve them all with `--all-stacks`, or select one stack with `--stack <name>`, `--from-cfn-stack <name>`, or a stack-qualified target like `MyStack/MyApi`. `--all-stacks` is mutually exclusive with those single-target selectors (the bare `--from-cfn-stack` flag stays compatible). See [docs/cli-reference.md](docs/cli-reference.md) for the full precedence rules.
+
+For ECS there is no cluster command — locally, Docker is the placement target a cluster abstracts away. Both `run-task` and `start-service` accept an optional `--cluster <name>` (surfaced to `ECS_CONTAINER_METADATA_URI_V4` and used as the local Docker network prefix); `start-service` also wires Service Connect / Cloud Map registry. See [docs/cli-reference.md](docs/cli-reference.md) for the full ECS option list.
 
 Use this for fast iteration on Lambda code, API routing checks, and container task smoke tests.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -76,40 +76,58 @@ Ctrl+C / Esc at the prompt aborts with exit code 130 and no error noise.
 ## `cdkl list` (discover runnable targets)
 
 `cdkl list` (alias `cdkl ls`) synthesizes the CDK app and prints every
-target the other subcommands can run, grouped by command. Use it when you
-don't know what to pass as a `<target>` — each row shows both accepted
-forms (the CDK display path and the stack-qualified logical ID
-`<Stack>:<LogicalId>`), so you can copy either into `invoke` /
-`start-api` / `run-task` / `start-service`.
+target the other subcommands can run, grouped by command. Most of the
+time you do not need it — running a command with no target (or `-i`)
+opens an interactive picker (see the "Interactive target selection"
+section above). Reach for `list` to browse what exists, or to grab the
+exact target string for a script.
+
+Each target is printed by its CDK display path (the recommended,
+readable target form). Pass `-l` / `--long` to additionally print the
+stack-qualified logical ID (`<Stack>:<LogicalId>`) on an indented line
+beneath each path — useful for the SAM-style logical-ID form or for any
+resource without an `aws:cdk:path`.
 
 It needs no Docker. It synthesizes the app — which may perform context
 lookups, and (like every command) honors `--role-arn` / `CDKL_ROLE_ARN`
-by assuming that role first — and accepts only the
+by assuming that role first — and otherwise accepts only the
 [common flags](#common-flags) (`--app` / `--output` / `--context` /
 `--profile` / `--role-arn` / `--verbose`). There is no `<target>`
-argument; the command always lists the whole app.
+argument; the command always lists the whole app. Only the list is
+written to stdout; the `Synthesizing...` status and toolkit synth
+messages go to stderr, so `cdkl list | ...` stays clean.
 
 ```text
 $ cdkl list
-Lambda Functions  (cdkl invoke <target>)
-  MyStack/ItemsHandler    MyStack:ItemsHandlerFB09CCF4
 
-APIs  (cdkl start-api [target])
-  MyStack/MyHttpApi       MyStack:MyHttpApi8AEAAC21
+Lambda Functions  ->  cdkl invoke <target>
+  MyStack/ItemsHandler
 
-ECS Services  (cdkl start-service <target...>)
-  MyStack/WebService      MyStack:WebService
+APIs  ->  cdkl start-api [target]
+  MyStack/MyHttpApi
 
-ECS Task Definitions  (cdkl run-task <target>)
-  MyStack/WebTask         MyStack:WebTask
+ECS Services  ->  cdkl start-service <target...>
+  MyStack/WebService
+
+ECS Task Definitions  ->  cdkl run-task <target>
+  MyStack/WebTask
+```
+
+```text
+$ cdkl list -l
+...
+Lambda Functions  ->  cdkl invoke <target>
+  MyStack/ItemsHandler
+      MyStack:ItemsHandlerFB09CCF4
+...
 ```
 
 Categories with no matching resources are omitted. The `APIs` group
 covers every surface `start-api` can serve — REST v1, HTTP API v2,
 Function URLs, and WebSocket APIs. A Function URL is shown under its
-backing Lambda's display path and logical ID, because that is how
-`start-api` addresses a Function URL target (so the same row may also
-appear under `Lambda Functions`, where `invoke` runs it directly).
+backing Lambda's display path (and logical ID, with `-l`), because that
+is how `start-api` addresses a Function URL target (so the same row may
+also appear under `Lambda Functions`, where `invoke` runs it directly).
 
 ## `cdkl invoke` (run Lambda functions locally)
 

--- a/src/cli/commands/local-list.ts
+++ b/src/cli/commands/local-list.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import {
   appOptions,
   commonOptions,
@@ -32,6 +32,8 @@ interface LocalListOptions {
   roleArn?: string;
   context?: string[];
   region?: string;
+  /** `-l/--long`: also print each target's stack-qualified logical ID. */
+  long: boolean;
 }
 
 /**
@@ -57,7 +59,10 @@ async function localListCommand(options: LocalListOptions): Promise<void> {
     );
   }
 
-  logger.info('Synthesizing CDK app...');
+  // Status goes to stderr so `cdkl list` stdout is ONLY the target list
+  // (clean for `cdkl list | ...`). Synthesis progress from toolkit-lib is
+  // routed to stderr too (see CdklIoHost).
+  process.stderr.write('Synthesizing CDK app...\n');
   const synthesizer = new Synthesizer();
   const context = parseContextOptions(options.context);
   const synthOpts: SynthesisOptions = {
@@ -69,47 +74,85 @@ async function localListCommand(options: LocalListOptions): Promise<void> {
   const { stacks } = await synthesizer.synthesize(synthOpts);
 
   const listing = listTargets(stacks);
-  process.stdout.write(`${formatTargetListing(listing, getEmbedConfig().cliName)}\n`);
+  process.stdout.write(
+    `${formatTargetListing(listing, getEmbedConfig().cliName, { long: options.long })}\n`
+  );
+}
+
+/** Options for {@link formatTargetListing}. */
+export interface FormatTargetListingOptions {
+  /**
+   * Also print each target's stack-qualified logical ID (`-l/--long`).
+   * Off by default: the CDK display path alone is the recommended,
+   * readable target form, and the wide two-column layout wrapped badly
+   * for the long auto-generated names CDK emits.
+   */
+  long?: boolean;
 }
 
 /**
- * Render a {@link TargetListing} as the grouped, two-column text table
- * `cdkl list` prints. Each non-empty category names the command that
- * consumes it and lists every target's CDK display path alongside its
- * stack-qualified logical ID. Exported so a unit test can assert the
- * output shape without running synthesis.
+ * Render a {@link TargetListing} as the grouped text list `cdkl list`
+ * prints. Each non-empty category is preceded by a blank line and a
+ * header naming the command that runs it, then one target per line by
+ * CDK display path. With {@link FormatTargetListingOptions.long}, each
+ * target's stack-qualified logical ID is printed on an indented line
+ * beneath it. Exported so a unit test can assert the output shape
+ * without running synthesis.
  */
-export function formatTargetListing(listing: TargetListing, cliName: string): string {
+export function formatTargetListing(
+  listing: TargetListing,
+  cliName: string,
+  options: FormatTargetListingOptions = {}
+): string {
   if (countTargets(listing) === 0) {
     return `No runnable targets (Lambda functions, APIs, ECS services / tasks) found in this CDK app.`;
   }
 
+  const long = options.long ?? false;
   const sections: string[][] = [
-    formatSection('Lambda Functions', `${cliName} invoke <target>`, listing.lambdas),
-    formatSection('APIs', `${cliName} start-api [target]`, listing.apis),
-    formatSection('ECS Services', `${cliName} start-service <target...>`, listing.ecsServices),
+    formatSection('Lambda Functions', `${cliName} invoke <target>`, listing.lambdas, long),
+    formatSection('APIs', `${cliName} start-api [target]`, listing.apis, long),
+    formatSection(
+      'ECS Services',
+      `${cliName} start-service <target...>`,
+      listing.ecsServices,
+      long
+    ),
     formatSection(
       'ECS Task Definitions',
       `${cliName} run-task <target>`,
-      listing.ecsTaskDefinitions
+      listing.ecsTaskDefinitions,
+      long
     ),
   ];
 
-  return sections
-    .filter((lines) => lines.length > 0)
-    .map((lines) => lines.join('\n'))
-    .join('\n\n');
+  // Leading blank line + a blank line between groups so each header is a
+  // clear landmark (and the first group is separated from the synth
+  // status that precedes it on stderr).
+  return (
+    '\n' +
+    sections
+      .filter((lines) => lines.length > 0)
+      .map((lines) => lines.join('\n'))
+      .join('\n\n')
+  );
 }
 
-function formatSection(title: string, command: string, entries: TargetEntry[]): string[] {
+function formatSection(
+  title: string,
+  command: string,
+  entries: TargetEntry[],
+  long: boolean
+): string[] {
   if (entries.length === 0) return [];
-  const lines = [`${title}  (${command})`];
-  const width = Math.max(0, ...entries.map((e) => (e.displayPath ?? '').length));
+  const lines = [`${title}  ->  ${command}`];
   for (const entry of entries) {
-    if (entry.displayPath) {
-      lines.push(`  ${entry.displayPath.padEnd(width)}  ${entry.qualifiedId}`);
-    } else {
-      lines.push(`  ${entry.qualifiedId}`);
+    const primary = entry.displayPath ?? entry.qualifiedId;
+    lines.push(`  ${primary}`);
+    // The qualified ID is only extra info when a display path was shown;
+    // when it IS the primary, don't repeat it.
+    if (long && entry.displayPath) {
+      lines.push(`      ${entry.qualifiedId}`);
     }
   }
   return lines;
@@ -123,8 +166,15 @@ export function createLocalListCommand(opts: CreateLocalListCommandOptions = {})
       'List the runnable targets in the synthesized CDK app, grouped by the command that runs them: ' +
         'Lambda functions (invoke), API Gateway REST v1 / HTTP v2 / Function URL / WebSocket surfaces ' +
         '(start-api), ECS services (start-service), and ECS task definitions (run-task). Each target is ' +
-        'shown with its CDK display path and stack-qualified logical ID — copy either form as the ' +
-        '<target> argument for the matching command.'
+        'shown by its CDK display path; pass -l to also print the stack-qualified logical ID. Tip: you ' +
+        'usually do not need to copy these — just run the command (e.g. `invoke`) and pick from the list, ' +
+        'or pass -i.'
+    )
+    .addOption(
+      new Option(
+        '-l, --long',
+        "Also print each target's stack-qualified logical ID (<Stack>:<LogicalId>) beneath it"
+      ).default(false)
     )
     .action(
       withErrorHandling(async (options: LocalListOptions) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
   createLocalListCommand,
   formatTargetListing,
   type CreateLocalListCommandOptions,
+  type FormatTargetListingOptions,
 } from './cli/commands/local-list.js';
 
 /**

--- a/src/local/target-picker.ts
+++ b/src/local/target-picker.ts
@@ -33,7 +33,10 @@ function toOption(entry: TargetEntry): { value: string; label: string; hint?: st
  * {@link TargetSelectionCancelledError} on Ctrl+C / Esc.
  */
 export async function pickOneTarget(message: string, entries: TargetEntry[]): Promise<string> {
-  const chosen = await select({ message, options: entries.map(toOption) });
+  const chosen = await select({
+    message: `${message} (up/down to move, enter to select)`,
+    options: entries.map(toOption),
+  });
   if (isCancel(chosen)) throw new TargetSelectionCancelledError();
   return chosen as string;
 }
@@ -42,9 +45,17 @@ export async function pickOneTarget(message: string, entries: TargetEntry[]): Pr
  * Prompt for one or more targets (at least one required). Caller must
  * have already confirmed a TTY and a non-empty `entries`. Throws
  * {@link TargetSelectionCancelledError} on Ctrl+C / Esc.
+ *
+ * The key hint is baked into the message because multi-select's
+ * space-to-toggle is not discoverable — users expect enter to pick the
+ * highlighted row and miss that nothing is selected yet.
  */
 export async function pickManyTargets(message: string, entries: TargetEntry[]): Promise<string[]> {
-  const chosen = await multiselect({ message, options: entries.map(toOption), required: true });
+  const chosen = await multiselect({
+    message: `${message} (space to select, enter to confirm)`,
+    options: entries.map(toOption),
+    required: true,
+  });
   if (isCancel(chosen)) throw new TargetSelectionCancelledError();
   return chosen as string[];
 }

--- a/src/synthesis/cdkl-io-host.ts
+++ b/src/synthesis/cdkl-io-host.ts
@@ -18,10 +18,24 @@ import { NonInteractiveIoHost, type IoMessage } from '@aws-cdk/toolkit-lib';
  * subprocess exits non-zero and the parent throws straight out of
  * `Synthesizer.synthesize()`. The only change here is the color of the
  * progress lines mid-synth.
+ *
+ * It also re-classifies the synth-success notifications
+ * (`CDK_TOOLKIT_I1901` single-stack / `CDK_TOOLKIT_I1902` multi-stack,
+ * "Successfully synthesized to ...") from `result` level to `info`.
+ * toolkit-lib sends `result`-level messages to stdout, which pollutes
+ * the stdout of commands whose primary output IS stdout — most
+ * importantly `cdkl list` (parseable target list) and `cdkl invoke`
+ * (Lambda response). As `info` they go to stderr in a normal terminal,
+ * leaving stdout to the command's own data. These are status lines no
+ * caller parses from cdk-local's stdout.
  */
 export class CdklIoHost extends NonInteractiveIoHost {
   async notify(msg: IoMessage<unknown>): Promise<void> {
-    if (msg.code === 'CDK_ASSEMBLY_E1002') {
+    if (
+      msg.code === 'CDK_ASSEMBLY_E1002' ||
+      msg.code === 'CDK_TOOLKIT_I1901' ||
+      msg.code === 'CDK_TOOLKIT_I1902'
+    ) {
       return super.notify({ ...msg, level: 'info' });
     }
     return super.notify(msg);

--- a/src/synthesis/cdkl-io-host.ts
+++ b/src/synthesis/cdkl-io-host.ts
@@ -22,11 +22,12 @@ import { NonInteractiveIoHost, type IoMessage } from '@aws-cdk/toolkit-lib';
  * It also re-classifies the synth-success notifications
  * (`CDK_TOOLKIT_I1901` single-stack / `CDK_TOOLKIT_I1902` multi-stack,
  * "Successfully synthesized to ...") from `result` level to `info`.
- * toolkit-lib sends `result`-level messages to stdout, which pollutes
- * the stdout of commands whose primary output IS stdout — most
- * importantly `cdkl list` (parseable target list) and `cdkl invoke`
- * (Lambda response). As `info` they go to stderr in a normal terminal,
- * leaving stdout to the command's own data. These are status lines no
+ * toolkit-lib sends `result`-level messages to stdout unconditionally,
+ * which pollutes the stdout of every synthesizing command. Re-leveling
+ * to `info` routes them to stderr in a normal terminal. This matters
+ * most for `cdkl list`, whose stdout is a parseable target list — that
+ * command additionally writes its own `Synthesizing...` status to
+ * stderr so its stdout is exactly the list. These are status lines no
  * caller parses from cdk-local's stdout.
  */
 export class CdklIoHost extends NonInteractiveIoHost {

--- a/tests/unit/cli/local-list.test.ts
+++ b/tests/unit/cli/local-list.test.ts
@@ -16,7 +16,7 @@ describe('formatTargetListing', () => {
     expect(formatTargetListing(empty, 'cdkl')).toMatch(/No runnable targets/);
   });
 
-  it('groups each category under the command that runs it, with both target forms', () => {
+  it('groups each category under a header naming the command that runs it', () => {
     const listing: TargetListing = {
       lambdas: [entry('App/Handler', 'App:Handler')],
       apis: [entry('App/HttpApi', 'App:HttpApi')],
@@ -24,12 +24,36 @@ describe('formatTargetListing', () => {
       ecsTaskDefinitions: [entry('App/TaskDef', 'App:TaskDef')],
     };
     const out = formatTargetListing(listing, 'cdkl');
-    expect(out).toContain('Lambda Functions  (cdkl invoke <target>)');
-    expect(out).toContain('  App/Handler  App:Handler');
-    expect(out).toContain('APIs  (cdkl start-api [target])');
-    expect(out).toContain('ECS Services  (cdkl start-service <target...>)');
-    expect(out).toContain('  App/OrdersService/Service  App:OrdersService');
-    expect(out).toContain('ECS Task Definitions  (cdkl run-task <target>)');
+    expect(out).toContain('Lambda Functions  ->  cdkl invoke <target>');
+    expect(out).toContain('APIs  ->  cdkl start-api [target]');
+    expect(out).toContain('ECS Services  ->  cdkl start-service <target...>');
+    expect(out).toContain('ECS Task Definitions  ->  cdkl run-task <target>');
+  });
+
+  it('lists one target per line by display path, without the logical ID by default', () => {
+    const listing: TargetListing = { ...empty, lambdas: [entry('App/Handler', 'App:Handler')] };
+    const out = formatTargetListing(listing, 'cdkl');
+    expect(out).toContain('  App/Handler');
+    // The stack-qualified logical ID is NOT shown unless --long is set.
+    expect(out).not.toContain('App:Handler');
+  });
+
+  it('prints the logical ID on an indented line beneath the path with { long: true }', () => {
+    const listing: TargetListing = { ...empty, lambdas: [entry('App/Handler', 'App:Handler')] };
+    const out = formatTargetListing(listing, 'cdkl', { long: true });
+    expect(out).toContain('  App/Handler');
+    expect(out).toContain('      App:Handler');
+  });
+
+  it('separates each group with a blank line and leads with one', () => {
+    const listing: TargetListing = {
+      ...empty,
+      lambdas: [entry('App/Handler', 'App:Handler')],
+      ecsServices: [entry('App/Svc', 'App:Svc')],
+    };
+    const out = formatTargetListing(listing, 'cdkl');
+    expect(out.startsWith('\n')).toBe(true);
+    expect(out).toContain('\n\nECS Services  ->  ');
   });
 
   it('omits categories with no targets', () => {
@@ -44,28 +68,23 @@ describe('formatTargetListing', () => {
     expect(out).not.toContain('ECS Task Definitions');
   });
 
-  it('falls back to the qualified ID alone when a target has no display path', () => {
+  it('falls back to the qualified ID as the primary line when a target has no display path', () => {
     const listing: TargetListing = { ...empty, lambdas: [entry(undefined, 'App:Raw')] };
     const out = formatTargetListing(listing, 'cdkl');
     expect(out).toContain('  App:Raw');
   });
 
-  it('aligns the display-path column within a category', () => {
-    const listing: TargetListing = {
-      ...empty,
-      lambdas: [entry('App/Short', 'App:Short'), entry('App/MuchLongerName', 'App:Long')],
-    };
-    const out = formatTargetListing(listing, 'cdkl');
-    // Both qualified IDs start at the same column (padded to the longest path).
-    const shortLine = out.split('\n').find((l) => l.includes('App:Short'))!;
-    const longLine = out.split('\n').find((l) => l.includes('App:Long'))!;
-    expect(shortLine.indexOf('App:Short')).toBe(longLine.indexOf('App:Long'));
+  it('does not duplicate the qualified ID for a no-display-path target under --long', () => {
+    const listing: TargetListing = { ...empty, lambdas: [entry(undefined, 'App:Raw')] };
+    const out = formatTargetListing(listing, 'cdkl', { long: true });
+    // Only the primary line — no indented repeat of the same ID.
+    expect(out.match(/App:Raw/g)?.length).toBe(1);
   });
 
   it('renders host branding in the command labels', () => {
     const listing: TargetListing = { ...empty, lambdas: [entry('App/Handler', 'App:Handler')] };
     const out = formatTargetListing(listing, 'cdkd local');
-    expect(out).toContain('Lambda Functions  (cdkd local invoke <target>)');
+    expect(out).toContain('Lambda Functions  ->  cdkd local invoke <target>');
   });
 });
 
@@ -79,5 +98,10 @@ describe('createLocalListCommand', () => {
   it('accepts the deprecated --region flag for parity with sibling commands', () => {
     const cmd = createLocalListCommand();
     expect(cmd.options.some((o) => o.long === '--region')).toBe(true);
+  });
+
+  it('registers the -l/--long flag', () => {
+    const cmd = createLocalListCommand();
+    expect(cmd.options.some((o) => o.short === '-l' && o.long === '--long')).toBe(true);
   });
 });

--- a/tests/unit/local/target-picker.test.ts
+++ b/tests/unit/local/target-picker.test.ts
@@ -60,12 +60,12 @@ describe('isInteractive', () => {
 });
 
 describe('pickOneTarget', () => {
-  it('maps entries to options (display path label, qualified ID hint) and returns the choice', async () => {
+  it('maps entries to options (display path label, qualified ID hint), appends a key hint, and returns the choice', async () => {
     vi.mocked(select).mockResolvedValue('S/A');
     const result = await pickOneTarget('Pick one', entries);
     expect(result).toBe('S/A');
     expect(select).toHaveBeenCalledWith({
-      message: 'Pick one',
+      message: 'Pick one (up/down to move, enter to select)',
       options: [
         { value: 'S/A', label: 'S/A', hint: 'S:A' },
         { value: 'S:B', label: 'S:B' },
@@ -88,7 +88,7 @@ describe('pickManyTargets', () => {
     const result = await pickManyTargets('Pick many', entries);
     expect(result).toEqual(['S/A', 'S:B']);
     expect(multiselect).toHaveBeenCalledWith({
-      message: 'Pick many',
+      message: 'Pick many (space to select, enter to confirm)',
       options: [
         { value: 'S/A', label: 'S/A', hint: 'S:A' },
         { value: 'S:B', label: 'S:B' },


### PR DESCRIPTION
## Summary

Polish for the `cdkl list` / interactive-picker UX after dogfooding.

- **Readable `cdkl list` output**: each group now has a header preceded by a blank line (a clear landmark), and prints **one target per line by CDK display path** instead of the old wide two-column path + logical-ID layout that wrapped badly for the long auto-generated construct names CDK emits. New `-l` / `--long` prints the stack-qualified logical ID on an indented line beneath each path.
- **Clean stdout**: `cdkl list` writes its `Synthesizing...` status to stderr, and `CdklIoHost` re-classifies toolkit synth-success messages (`CDK_TOOLKIT_I1901` / `I1902`) from `result` to `info` so they go to stderr too. `cdkl list | ...` now sees only the list.
- **Discoverable picker keys**: the prompts spell out the keys in the message — multi-select shows "(space to select, enter to confirm)" since space-to-toggle was not obvious.
- **Interactive-first README**: "run the command and pick from the list" is now the headline flow; passing an explicit target is documented as the rare/scripting case. cli-reference `list` section updated for the new format + `-l`.

## Test plan

- [x] `vp run check` (typecheck + lint + format)
- [x] `vp run build`
- [x] `vp test run` — 937 unit tests pass (format tests rewritten for the new single-column + `-l` layout; picker message-hint assertions updated; `-l` flag registration test added).
- [x] Live-tested against the `local-start-api` fixture: `cdkl ls` and `cdkl ls -l` (stdout verified clean with `2>/dev/null` — only the list, no synth noise); `--help` shows `-l, --long`.
- [x] Code review (1-reviewer tier) — no blockers; both nits addressed (exported `FormatTargetListingOptions`, corrected the io-host comment).

## Notes

- The `CdklIoHost` reclassify is a shared change affecting every synthesizing command's stdout (the synth-success line moves to stderr in a normal terminal); nothing in the repo parses those lines from stdout. Verified against the toolkit-lib `NonInteractiveIoHost` routing (`result`→stdout always; `info`→stderr when not in CI).
- The interactive prompt itself needs a real TTY, so it is covered by unit tests with `@clack/prompts` mocked; the non-TTY paths and the list format were live-tested.
