### PR TITLE
fix(synthesis): read --app cloud assembly directory instead of exec'ing it

### DIFF
--- a/src/synthesis/synthesizer.ts
+++ b/src/synthesis/synthesizer.ts
@@ -1,4 +1,7 @@
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { AssemblyReader, type StackInfo, type AssemblyReadOptions } from './assembly-reader.js';
+import { getLogger } from '../utils/logger.js';
 
 /**
  * Synthesis options accepted by the four `cdkl` commands.
@@ -40,10 +43,30 @@ export interface SynthesisResult {
  * Thin wrapper around {@link AssemblyReader} that mimics cdkd's
  * `Synthesizer` API so the ported `cdkl invoke` / `start-api` /
  * `run-task` / `start-service` source compiles without rewrites.
+ *
+ * When `app` resolves to an existing directory it is read as a
+ * pre-synthesized cloud assembly (no subprocess synth); otherwise it is
+ * executed as the CDK app command.
  */
 export class Synthesizer {
   async synthesize(opts: SynthesisOptions): Promise<SynthesisResult> {
     const reader = new AssemblyReader();
+
+    // CDK CLI compatibility: when `--app` points at an existing directory,
+    // treat it as a pre-synthesized cloud assembly and skip the subprocess
+    // synth — `Toolkit.fromCdkApp()` would otherwise try to exec the
+    // directory as a shell command and fail with "is a directory".
+    // (Mirrors aws-cdk's `exec.ts`: "bypass 'synth' if app points to a
+    // cloud assembly".) Context / profile / region overrides do not apply
+    // to an already-synthesized assembly, so they are intentionally ignored
+    // on this path.
+    const appPath = resolve(opts.app);
+    if (existsSync(appPath) && statSync(appPath).isDirectory()) {
+      getLogger().debug(`Using pre-synthesized cloud assembly at ${appPath}`);
+      const stacks = await reader.readFromDirectory(appPath);
+      return { stacks };
+    }
+
     const readOpts: AssemblyReadOptions = {};
     if (opts.output !== undefined) {
       readOpts.outdir = opts.output;

--- a/tests/unit/synthesis/synthesizer.test.ts
+++ b/tests/unit/synthesis/synthesizer.test.ts
@@ -1,21 +1,38 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { resolve } from 'node:path';
 
-const { mockRead, MockAssemblyReader } = vi.hoisted(() => {
-  const mockRead = vi.fn();
-  const MockAssemblyReader = vi.fn().mockImplementation(() => ({ read: mockRead }));
-  return { mockRead, MockAssemblyReader };
-});
+const { mockRead, mockReadFromDirectory, MockAssemblyReader, mockExistsSync, mockStatSync } =
+  vi.hoisted(() => {
+    const mockRead = vi.fn();
+    const mockReadFromDirectory = vi.fn();
+    const MockAssemblyReader = vi
+      .fn()
+      .mockImplementation(() => ({ read: mockRead, readFromDirectory: mockReadFromDirectory }));
+    const mockExistsSync = vi.fn();
+    const mockStatSync = vi.fn();
+    return { mockRead, mockReadFromDirectory, MockAssemblyReader, mockExistsSync, mockStatSync };
+  });
 
 vi.mock('../../../src/synthesis/assembly-reader.js', () => ({
   AssemblyReader: MockAssemblyReader,
 }));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, existsSync: mockExistsSync, statSync: mockStatSync };
+});
 
 import { Synthesizer } from '../../../src/synthesis/synthesizer.js';
 
 describe('Synthesizer.synthesize', () => {
   beforeEach(() => {
     mockRead.mockReset();
+    mockReadFromDirectory.mockReset();
     MockAssemblyReader.mockClear();
+    // Default: `app` is not an existing directory, so synthesize takes the
+    // subprocess `read()` path. Directory-branch tests override these.
+    mockExistsSync.mockReturnValue(false);
+    mockStatSync.mockReturnValue({ isDirectory: () => false });
   });
 
   it('returns { stacks } pulled from AssemblyReader.read', async () => {
@@ -182,5 +199,59 @@ describe('Synthesizer.synthesize', () => {
 
     const s = new Synthesizer();
     await expect(s.synthesize({ app: 'x' })).rejects.toThrow('boom');
+  });
+
+  describe('pre-synthesized cloud assembly directory', () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({ isDirectory: () => true });
+    });
+
+    it('reads via readFromDirectory when app is an existing directory', async () => {
+      const fakeStacks = [{ stackName: 'A' }];
+      mockReadFromDirectory.mockResolvedValue(fakeStacks);
+
+      const s = new Synthesizer();
+      const result = await s.synthesize({ app: './cdk.out' });
+
+      expect(result).toEqual({ stacks: fakeStacks });
+      expect(mockReadFromDirectory).toHaveBeenCalledTimes(1);
+      expect(mockReadFromDirectory).toHaveBeenCalledWith(resolve('./cdk.out'));
+      expect(mockRead).not.toHaveBeenCalled();
+    });
+
+    it('ignores output / profile / region / context on the directory path', async () => {
+      mockReadFromDirectory.mockResolvedValue([]);
+
+      const s = new Synthesizer();
+      await s.synthesize({
+        app: 'cdk.out',
+        output: 'custom-out',
+        profile: 'p',
+        region: 'us-east-1',
+        context: { k: 'v' },
+      });
+
+      expect(mockReadFromDirectory).toHaveBeenCalledWith(resolve('cdk.out'));
+    });
+
+    it('propagates the readFromDirectory rejection', async () => {
+      mockReadFromDirectory.mockRejectedValue(new Error('bad assembly'));
+
+      const s = new Synthesizer();
+      await expect(s.synthesize({ app: 'cdk.out' })).rejects.toThrow('bad assembly');
+    });
+  });
+
+  it('uses the read() command path when app exists but is a file (not a directory)', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({ isDirectory: () => false });
+    mockRead.mockResolvedValue([]);
+
+    const s = new Synthesizer();
+    await s.synthesize({ app: 'app.js' });
+
+    expect(mockRead).toHaveBeenCalledTimes(1);
+    expect(mockReadFromDirectory).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `cdkl <command> --app <cdk.out>` (pointing `--app` at a pre-synthesized cloud assembly directory) now skips synthesis and reads the assembly via `AssemblyReader.readFromDirectory`, instead of handing the directory to `Toolkit.fromCdkApp()` — which exec'd it as a shell command and failed with `/bin/sh: ./cdk.out: is a directory`.
- The directory form was already documented (`docs/cli-reference.md`, `docs/local-emulation.md`, the `-a, --app` option help) and `readFromDirectory` already existed; this wires `Synthesizer.synthesize` to actually route to it when `--app` resolves to an existing directory. Mirrors the aws-cdk CLI's "bypass synth if app points to a cloud assembly" behavior.
- Synth-time `--context` / `--profile` / `--region` / `--output` are intentionally ignored on the directory path, because they no longer apply to an already-synthesized assembly (context is baked in at synth time; region/account come from the assembly manifest). Runtime bindings such as `--from-cfn-stack` are handled outside the synthesizer and are unaffected.
- One fix in `Synthesizer.synthesize` covers every entry point: all command factories plus the `start-api --watch` hot-reload re-synth route through it.

## Test plan

- [x] Unit: 4 new tests in `tests/unit/synthesis/synthesizer.test.ts` (directory → `readFromDirectory`; output/profile/region/context ignored on the directory path; rejection propagation; existing-file-but-not-directory falls back to the command path). Full suite: 937 tests pass.
- [x] Integration (Docker): `local-invoke` `verify.sh` — all 5 command-app-path invokes pass (regression for the subprocess synth path); 0 orphan containers/networks.
- [x] Live (new path): `cdkl invoke CdkLocalInvokeFixture/EchoHandler --app ./cdk.out --event ...` ran a real RIE container and echoed the event payload.
- [x] `vp run check` (typecheck + lint + format), `vp run build` pass.
