### PR TITLE
feat(exports): expose bufferToBody from websocket-body for shim consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,14 @@ export {
 } from './local/websocket-mgmt-api.js';
 
 /**
+ * `start-api` WebSocket frame-body codec — converts a ws-emitted message
+ * buffer into the AWS-canonical `{ body, isBase64Encoded }` shape (text
+ * frames pass through as UTF-8, binary frames are base64-encoded). Exposed
+ * only as the consuming host's `import` statements require it.
+ */
+export { bufferToBody } from './local/websocket-body.js';
+
+/**
  * `start-api` Docker host-gateway version probe — gates the
  * `--add-host=...:host-gateway` mapping WebSocket Lambda containers need to
  * reach the host server on Linux native dockerd. Exposed only as the

--- a/tests/unit/local/websocket-body.test.ts
+++ b/tests/unit/local/websocket-body.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { bufferToBody } from '../../../src/local/websocket-body.js';
+
+// bufferToBody returns the discriminated `{body, isBase64Encoded}` shape so
+// binary frames surface as base64 + the flag, and text frames surface as
+// UTF-8 + flag=false. Pre-fix the function returned a bare string and the
+// discriminator was hardcoded `false` downstream (cdkd Issue #526 / #537).
+describe('bufferToBody', () => {
+  it('returns text body + isBase64Encoded=false for text frames', () => {
+    const buf = Buffer.from('hello world', 'utf-8');
+    expect(bufferToBody(buf, false)).toEqual({
+      body: 'hello world',
+      isBase64Encoded: false,
+    });
+  });
+
+  it('returns base64 body + isBase64Encoded=true for binary frames', () => {
+    const buf = Buffer.from([0x00, 0x01, 0xff, 0xfe, 0x80]);
+    expect(bufferToBody(buf, true)).toEqual({
+      body: buf.toString('base64'),
+      isBase64Encoded: true,
+    });
+  });
+
+  it('preserves bytes > 0x7F across binary round-trip (the original bug class)', () => {
+    // 0xFE / 0xFF are NOT valid UTF-8; pre-fix decoding them as UTF-8
+    // would surface as U+FFFD (replacement char), corrupting the
+    // handler's `Buffer.from(event.body, 'utf8')` decode.
+    const original = Buffer.from([0xff, 0xfe, 0x80, 0x7f, 0x00]);
+    const { body, isBase64Encoded } = bufferToBody(original, true);
+    expect(isBase64Encoded).toBe(true);
+    const roundTrip = Buffer.from(body, 'base64');
+    expect(roundTrip.equals(original)).toBe(true);
+  });
+
+  it('concatenates fragmented Buffer[] input before encoding', () => {
+    const fragments = [Buffer.from([0x01, 0x02]), Buffer.from([0x03, 0x04])];
+    const { body, isBase64Encoded } = bufferToBody(fragments, true);
+    expect(isBase64Encoded).toBe(true);
+    expect(Buffer.from(body, 'base64')).toEqual(Buffer.from([0x01, 0x02, 0x03, 0x04]));
+  });
+
+  it('handles ArrayBuffer input', () => {
+    const ab = new ArrayBuffer(3);
+    new Uint8Array(ab).set([0x41, 0x42, 0x43]); // "ABC"
+    expect(bufferToBody(ab, false)).toEqual({
+      body: 'ABC',
+      isBase64Encoded: false,
+    });
+  });
+
+  // Zero-byte binary frame should produce `{body: '', isBase64Encoded: true}`
+  // (NOT throw, NOT silently coerce to text). Empty Buffers come up in
+  // WebSocket protocols that use a zero-length frame as a sentinel.
+  it('returns empty body + isBase64Encoded=true for zero-byte binary frames', () => {
+    expect(bufferToBody(Buffer.from([]), true)).toEqual({
+      body: '',
+      isBase64Encoded: true,
+    });
+  });
+  it('returns empty body + isBase64Encoded=false for zero-byte text frames', () => {
+    expect(bufferToBody(Buffer.from([]), false)).toEqual({
+      body: '',
+      isBase64Encoded: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Expose `bufferToBody` from the package entry (`src/index.ts`) so shim consumers (cdkd) can re-export it.
- Port the `bufferToBody` unit tests into `tests/unit/local/websocket-body.test.ts` (cdk-local owns the implementation, so it owns the tests).

## Context

`bufferToBody` (in `src/local/websocket-body.ts`) converts a ws-emitted message buffer into the AWS-canonical `{ body, isBase64Encoded }` shape — text frames pass through as UTF-8, binary frames are base64-encoded. cdk-local already had the implementation but did not expose it from the package entry. This is the cdk-local half of the cdkd `websocket-body` shim slice: cdkd will consume `bufferToBody` from cdk-local via a thin spy-friendly local wrapper (a bare re-export binding is a non-configurable getter that cdkd's `websocket-server.test.ts` `vi.spyOn` seam cannot redefine).

No runtime behavior change — this only adds a public export plus its ported test.

## Test plan

- [x] `vp run typecheck` / `vp run lint` / `vp run build`
- [x] `vp run test` — 991 unit tests pass (includes the new `websocket-body` test file)
- [x] Docker `local-invoke` integ — green, zero orphan containers/networks
