### PR TITLE
docs(verify-pr): require end-to-end live-test of changed PreToolUse hooks

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -88,6 +88,7 @@ Run each check and report pass/fail:
      - Lambda runtime change → run `cdkl invoke` against `tests/integration/local-invoke/` (or the matching language fixture) and check the output.
      - HTTP server change → run `cdkl start-api` against `tests/integration/local-start-api/` and curl one route.
      - Library-only change → run a minimal repro that imports the new code path.
+     - PreToolUse hook change (`.claude/hooks/*.sh`) → exercise it end-to-end: build a throwaway git repo (simulate the base ref via `git update-ref refs/remotes/origin/main <sha>` + `git symbolic-ref refs/remotes/origin/HEAD`), commit an offending case AND a clean case, then pipe a synthesized payload (`jq -nc '{tool_input:{command:"<gated cmd>"},cwd:"<repo>"}'`) into the hook and assert it blocks the offender (exit 2) and passes the clean case + a non-matching command (exit 0). Shell hooks have no unit-test harness, so this end-to-end run is the ONLY correctness check — a hook that silently fail-opens (e.g. an unsupported `gh` flag) looks installed but never fires.
    - "Tests passed" is not "feature works." Always run the actual command before declaring done. If you cannot live-test (no Docker daemon, no fixture available), say so explicitly rather than skip silently — the gate exits non-zero so a reviewer can decide whether to accept the trade-off.
 
 10. **Retrospective + rules update**


### PR DESCRIPTION
## Summary

Add a sub-bullet to `/verify-pr` step 9 (live-test): when the diff changes a PreToolUse hook (`.claude/hooks/*.sh`), exercise it end-to-end with a synthesized payload and assert it blocks an offender (exit 2) and passes a clean case + a non-matching command (exit 0).

Motivation: shell hooks have no unit-test harness, so a hook that silently fail-opens (as `non-english-text-gate.sh` did with an unsupported `gh -C` flag) looks installed but never fires. Codifying the end-to-end check in the gate's own checklist prevents that class from recurring.

## Test plan

- [x] `vp run check` — pass
- [x] `vp run build` — pass
- [x] `vp test run` — 69 files / 988 tests pass (unchanged; skill-doc only)
- [x] Skills-only change; no `src/**` / `tests/**` / hooks touched → integ marker n/a, live-test n/a (guidance text, no runtime behavior)
