### PR TITLE
fix(start-service): print the shutdown prompt on its own line

### DIFF
--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -363,7 +363,8 @@ async function localStartServiceCommand(
           `${pt.controller!.service.serviceName} (${pt.controller!.activeReplicaCount()} replica(s))`
       )
       .join(', ');
-    logger.info(`Service(s) running: ${summary}. Press ^C to shut down.`);
+    logger.info(`Service(s) running: ${summary}.`);
+    logger.info('Press ^C to shut down.');
 
     // Block until ALL services shut down.
     await Promise.all(perTarget.map((pt) => pt.controller!.waitForShutdown()));


### PR DESCRIPTION
## Summary

Split the start-service boot banner so `Press ^C to shut down.` prints on its own line instead of being appended to the `Service(s) running: ...` summary, making the shutdown hint easier to spot.

## Test plan

- [x] Unit suite green (no test asserted the combined single-line banner).
- [x] `local-start-service` integ: service still boots (the `Service(s) running:` boot-marker grep is unaffected) and tears down clean.
