### PR TITLE
feat(exports): expose cloud-map + integration-response resolvers and error classes for shim consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -298,3 +298,46 @@ export {
   tryResolveImageFnJoin,
   type ImageResolutionContext,
 } from './local/intrinsic-image.js';
+
+/**
+ * `start-service` Cloud Map service-discovery index — parses the
+ * `AWS::ServiceDiscovery::PrivateDnsNamespace` / `::Service` resources in a
+ * synthesized stack into the namespace / service lookup maps the local ECS
+ * service runner resolves peers against. Exposed only as the consuming host's
+ * `import` statements require them.
+ */
+export { buildCloudMapIndex, type CloudMapIndex } from './local/cloud-map-resolver.js';
+
+/**
+ * `run-task` / `start-service` ECS target-resolution error. Exposed so a
+ * consuming host that shims `cloud-map-resolver` (which throws it) can re-export
+ * the SAME class identity from its still-local ECS engine modules — otherwise a
+ * host-side `instanceof` / `toThrow(EcsTaskResolutionError)` against the shimmed
+ * resolver's throw would compare two distinct class objects and fail.
+ */
+export { EcsTaskResolutionError } from './local/ecs-task-resolver.js';
+
+/**
+ * `start-api` REST API v1 `IntegrationResponses[]` selection — picks the
+ * matching integration response by `SelectionPattern` regex, evaluates
+ * `ResponseParameters` header mappings, and selects the response template by
+ * `Accept`. Exposed only as the consuming host's `import` statements require
+ * them.
+ */
+export {
+  evaluateResponseParameters,
+  pickResponseTemplate,
+  selectIntegrationResponse,
+  tryParseStatus,
+  type IntegrationResponseEntry,
+} from './local/integration-response-selector.js';
+
+/**
+ * `start-api` VTL evaluation error. Exposed so a consuming host that shims
+ * `integration-response-selector` (which throws it) can re-export the SAME
+ * class identity from its still-local `vtl-engine` — otherwise a host-side
+ * `instanceof VtlEvaluationError` (e.g. the REST v1 dispatcher's catch) against
+ * the shimmed selector's throw would compare two distinct class objects and
+ * fail.
+ */
+export { VtlEvaluationError } from './local/vtl-engine.js';

--- a/tests/unit/local/cloud-map-resolver.test.ts
+++ b/tests/unit/local/cloud-map-resolver.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildCloudMapIndex } from '../../../src/local/cloud-map-resolver.js';
+import { EcsTaskResolutionError } from '../../../src/local/ecs-task-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+function buildStack(name: string, resources: Record<string, TemplateResource>): StackInfo {
+  const template: CloudFormationTemplate = { Resources: resources };
+  return {
+    stackName: name,
+    displayName: name,
+    artifactId: name,
+    template,
+    dependencyNames: [],
+  };
+}
+
+describe('buildCloudMapIndex', () => {
+  it('returns empty index when no Cloud Map resources are present', () => {
+    const stack = buildStack('Stack', {});
+    const index = buildCloudMapIndex(stack);
+    expect(index.namespacesByLogicalId.size).toBe(0);
+    expect(index.namespacesByName.size).toBe(0);
+    expect(index.servicesByLogicalId.size).toBe(0);
+    expect(index.warnings).toEqual([]);
+  });
+
+  it('parses a single PrivateDnsNamespace', () => {
+    const stack = buildStack('Stack', {
+      Ns: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: 'cdkd-local.local', Vpc: { Ref: 'Vpc' } },
+      },
+    });
+    const index = buildCloudMapIndex(stack);
+    expect(index.namespacesByLogicalId.get('Ns')).toEqual({
+      logicalId: 'Ns',
+      name: 'cdkd-local.local',
+    });
+    expect(index.namespacesByName.get('cdkd-local.local')?.logicalId).toBe('Ns');
+  });
+
+  it('parses an AWS::ServiceDiscovery::Service whose NamespaceId is Fn::GetAtt', () => {
+    const stack = buildStack('Stack', {
+      Ns: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: 'cdkd-local.local' },
+      },
+      OrdersSvc: {
+        Type: 'AWS::ServiceDiscovery::Service',
+        Properties: {
+          Name: 'orders',
+          NamespaceId: { 'Fn::GetAtt': ['Ns', 'Id'] },
+          DnsConfig: {
+            DnsRecords: [
+              { TTL: 60, Type: 'A' },
+              { TTL: 60, Type: 'SRV' },
+            ],
+            NamespaceId: { 'Fn::GetAtt': ['Ns', 'Id'] },
+          },
+        },
+      },
+    });
+    const index = buildCloudMapIndex(stack);
+    const svc = index.servicesByLogicalId.get('OrdersSvc');
+    expect(svc?.namespaceLogicalId).toBe('Ns');
+    expect(svc?.namespaceName).toBe('cdkd-local.local');
+    expect(svc?.name).toBe('orders');
+    expect(svc?.dnsRecords).toEqual([
+      { type: 'A', ttlSeconds: 60 },
+      { type: 'SRV', ttlSeconds: 60 },
+    ]);
+  });
+
+  it('accepts NamespaceId as Ref shape (defensive fallback)', () => {
+    const stack = buildStack('Stack', {
+      Ns: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: 'cdkd-local.local' },
+      },
+      Svc: {
+        Type: 'AWS::ServiceDiscovery::Service',
+        Properties: {
+          Name: 'svc',
+          NamespaceId: { Ref: 'Ns' },
+          DnsConfig: { DnsRecords: [{ Type: 'A', TTL: 60 }] },
+        },
+      },
+    });
+    const index = buildCloudMapIndex(stack);
+    expect(index.servicesByLogicalId.get('Svc')?.namespaceName).toBe('cdkd-local.local');
+  });
+
+  it('rejects PublicDnsNamespace with an actionable error', () => {
+    const stack = buildStack('Stack', {
+      Ns: { Type: 'AWS::ServiceDiscovery::PublicDnsNamespace', Properties: { Name: 'public.com' } },
+    });
+    expect(() => buildCloudMapIndex(stack)).toThrow(EcsTaskResolutionError);
+    expect(() => buildCloudMapIndex(stack)).toThrow(/PublicDnsNamespace.*not supported/);
+  });
+
+  it('rejects HttpNamespace with an actionable error', () => {
+    const stack = buildStack('Stack', {
+      Ns: { Type: 'AWS::ServiceDiscovery::HttpNamespace', Properties: { Name: 'cdkd' } },
+    });
+    expect(() => buildCloudMapIndex(stack)).toThrow(/HttpNamespace.*not supported/);
+  });
+
+  it('rejects a PrivateDnsNamespace with no literal Name', () => {
+    const stack = buildStack('Stack', {
+      Ns: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: { 'Fn::Sub': 'foo.${AWS::Region}' } },
+      },
+    });
+    expect(() => buildCloudMapIndex(stack)).toThrow(/no literal Name/);
+  });
+
+  it('rejects a Service whose NamespaceId references a missing namespace', () => {
+    const stack = buildStack('Stack', {
+      Svc: {
+        Type: 'AWS::ServiceDiscovery::Service',
+        Properties: {
+          Name: 'svc',
+          NamespaceId: { 'Fn::GetAtt': ['GoneNs', 'Id'] },
+          DnsConfig: { DnsRecords: [{ Type: 'A', TTL: 60 }] },
+        },
+      },
+    });
+    expect(() => buildCloudMapIndex(stack)).toThrow(/no PrivateDnsNamespace with that logical id/);
+  });
+
+  it('rejects a Service whose NamespaceId is an unsupported intrinsic', () => {
+    const stack = buildStack('Stack', {
+      Ns: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: 'cdkd-local.local' },
+      },
+      Svc: {
+        Type: 'AWS::ServiceDiscovery::Service',
+        Properties: {
+          Name: 'svc',
+          NamespaceId: { 'Fn::Sub': '${Ns.Id}' },
+          DnsConfig: { DnsRecords: [{ Type: 'A', TTL: 60 }] },
+        },
+      },
+    });
+    expect(() => buildCloudMapIndex(stack)).toThrow(/unsupported NamespaceId reference shape/);
+  });
+
+  it('warns when two namespaces share the same Name in one stack', () => {
+    const stack = buildStack('Stack', {
+      NsA: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: 'cdkd-local.local' },
+      },
+      NsB: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: 'cdkd-local.local' },
+      },
+    });
+    const index = buildCloudMapIndex(stack);
+    expect(index.warnings.length).toBe(1);
+    expect(index.warnings[0]).toContain('NsA');
+    expect(index.warnings[0]).toContain('NsB');
+  });
+
+  it('skips AAAA / CNAME record types and tolerates string-typed TTLs', () => {
+    const stack = buildStack('Stack', {
+      Ns: {
+        Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace',
+        Properties: { Name: 'cdkd-local.local' },
+      },
+      Svc: {
+        Type: 'AWS::ServiceDiscovery::Service',
+        Properties: {
+          Name: 'svc',
+          NamespaceId: { 'Fn::GetAtt': ['Ns', 'Id'] },
+          DnsConfig: {
+            DnsRecords: [
+              { Type: 'A', TTL: '30' }, // string TTL
+              { Type: 'AAAA', TTL: 60 }, // skipped
+            ],
+          },
+        },
+      },
+    });
+    const records = buildCloudMapIndex(stack).servicesByLogicalId.get('Svc')?.dnsRecords;
+    expect(records?.length).toBe(1);
+    expect(records?.[0]).toEqual({ type: 'A', ttlSeconds: 30 });
+  });
+});

--- a/tests/unit/local/integration-response-selector.test.ts
+++ b/tests/unit/local/integration-response-selector.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for IntegrationResponses[] selection logic (#457).
+ *
+ * Covers `selectIntegrationResponse`, `evaluateResponseParameters`, and
+ * `pickResponseTemplate` from `src/local/integration-response-selector.ts`.
+ *
+ * PR #505 review fix 14: `selectIntegrationResponse` now ALWAYS runs
+ * the regex loop regardless of upstream success / error, so a
+ * `SelectionPattern: '200'` entry actually matches a 200 upstream
+ * response. Tests updated to assert that behavior end-to-end.
+ */
+
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  evaluateResponseParameters,
+  pickResponseTemplate,
+  selectIntegrationResponse,
+  type IntegrationResponseEntry,
+} from '../../../src/local/integration-response-selector.js';
+
+describe('selectIntegrationResponse', () => {
+  const responses: IntegrationResponseEntry[] = [
+    { StatusCode: '200' /* default — no SelectionPattern */ },
+    { StatusCode: '404', SelectionPattern: '.*Not Found.*' },
+    { StatusCode: '500', SelectionPattern: '.*Internal.*' },
+  ];
+
+  it('returns default entry when no SelectionPattern matches', () => {
+    // Lambda success sentinel — no user-written pattern matches `success`.
+    const r = selectIntegrationResponse(responses, 'success', 200);
+    expect(r.statusCode).toBe(200);
+    expect(r.entry?.StatusCode).toBe('200');
+  });
+  it('picks regex-matching entry on error', () => {
+    const r = selectIntegrationResponse(responses, 'Item Not Found locally', 500);
+    expect(r.statusCode).toBe(404);
+  });
+  it('falls back to default on error when no pattern matches', () => {
+    const r = selectIntegrationResponse(responses, 'something else', 500);
+    expect(r.statusCode).toBe(200);
+  });
+  it('returns null entry + fallback when entries array is undefined', () => {
+    const r = selectIntegrationResponse(undefined, 'success', 200);
+    expect(r.entry).toBeNull();
+    expect(r.statusCode).toBe(200);
+  });
+  it('returns null entry + fallback when entries array is empty', () => {
+    const r = selectIntegrationResponse([], 'X', 500);
+    expect(r.entry).toBeNull();
+    expect(r.statusCode).toBe(500);
+  });
+  it('skips entries with invalid regex (does not abort)', () => {
+    const r = selectIntegrationResponse(
+      [
+        { StatusCode: '200' },
+        { StatusCode: '418', SelectionPattern: '[invalid(regex' },
+        { StatusCode: '500', SelectionPattern: '.*Boom.*' },
+      ],
+      'Boom!',
+      200
+    );
+    expect(r.statusCode).toBe(500);
+  });
+  it('anchors regex with ^ and $', () => {
+    const r = selectIntegrationResponse(
+      [{ StatusCode: '404', SelectionPattern: 'Not Found' }],
+      'Not Found something',
+      500
+    );
+    // 'Not Found' anchored should NOT match 'Not Found something'.
+    expect(r.entry).toBeNull();
+  });
+
+  // PR #505 fix 14 — SelectionPattern matches upstream OK status too.
+  describe('always-applied regex (fix 14)', () => {
+    it('matches SelectionPattern against a successful 200 upstream', () => {
+      const r = selectIntegrationResponse(
+        [
+          { StatusCode: '200' /* default */ },
+          { StatusCode: '201', SelectionPattern: '200' },
+        ],
+        '200',
+        200
+      );
+      expect(r.entry?.StatusCode).toBe('201');
+      expect(r.statusCode).toBe(201);
+    });
+    it('matches SelectionPattern against a 2xx wildcard', () => {
+      const r = selectIntegrationResponse(
+        [
+          { StatusCode: '500' /* default — picked when no regex matches */ },
+          { StatusCode: '200', SelectionPattern: '2\\d\\d' },
+        ],
+        '201',
+        201
+      );
+      expect(r.entry?.StatusCode).toBe('200');
+      expect(r.statusCode).toBe(200);
+    });
+    it('first matching pattern wins (entry order respected)', () => {
+      const r = selectIntegrationResponse(
+        [
+          { StatusCode: '418', SelectionPattern: '4\\d\\d' },
+          { StatusCode: '499', SelectionPattern: '404' },
+        ],
+        '404',
+        500
+      );
+      // The 4\d\d pattern is declared first and also matches.
+      expect(r.entry?.StatusCode).toBe('418');
+    });
+  });
+});
+
+describe('evaluateResponseParameters', () => {
+  it('extracts single-quoted literal header values (keys lowercased — PR #511 review fix-back)', () => {
+    const out = evaluateResponseParameters({
+      'method.response.header.X-Custom': "'literal-value'",
+      'method.response.header.Content-Type': "'application/json'",
+    });
+    // PR #511 review fix-back: ResponseParameters keys are lowercased so
+    // they share the dispatcher's default-initializer namespace and AWS-
+    // deployed single-header semantics. Pre-fix this returned PascalCase
+    // keys which collided with the default `content-type` lowercase key.
+    expect(out).toEqual({
+      'x-custom': 'literal-value',
+      'content-type': 'application/json',
+    });
+  });
+  it('skips and surfaces mapping expressions (keys lowercased — PR #511 review fix-back)', () => {
+    const seen: Array<{ key: string; reason: string }> = [];
+    const out = evaluateResponseParameters(
+      {
+        'method.response.header.X': 'integration.response.body.field',
+        'method.response.header.Y': "'literal'",
+      },
+      { onUnsupported: (key, _v, reason) => seen.push({ key, reason }) }
+    );
+    expect(out).toEqual({ y: 'literal' });
+    expect(seen[0]?.key).toBe('method.response.header.X');
+  });
+  it('returns empty map when input undefined', () => {
+    expect(evaluateResponseParameters(undefined)).toEqual({});
+  });
+  it('skips non-method.response.header keys', () => {
+    const seen: string[] = [];
+    const out = evaluateResponseParameters(
+      { 'some.weird.key': "'value'" },
+      { onUnsupported: (key) => seen.push(key) }
+    );
+    expect(out).toEqual({});
+    expect(seen).toContain('some.weird.key');
+  });
+});
+
+describe('pickResponseTemplate', () => {
+  it('picks application/json by default', () => {
+    const out = pickResponseTemplate(
+      { 'application/json': '{}', 'text/plain': 'hi' },
+      undefined
+    );
+    expect(out?.contentType).toBe('application/json');
+  });
+  it('respects Accept header when matching', () => {
+    const out = pickResponseTemplate(
+      { 'application/json': '{}', 'text/plain': 'hi' },
+      'text/plain'
+    );
+    expect(out?.contentType).toBe('text/plain');
+  });
+  it('falls back to first when Accept does not match and no JSON entry', () => {
+    const out = pickResponseTemplate({ 'text/xml': '<x/>' }, 'image/jpeg');
+    expect(out?.contentType).toBe('text/xml');
+  });
+  it('returns undefined when input is empty', () => {
+    expect(pickResponseTemplate(undefined, 'application/json')).toBeUndefined();
+    expect(pickResponseTemplate({}, 'application/json')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Expose the symbols a consuming host (cdkd) needs to convert its duplicate `cloud-map-resolver` + `integration-response-selector` modules into thin `cdk-local` re-export shims:

- `cloud-map-resolver`: `buildCloudMapIndex`, `CloudMapIndex` (type) — `start-service` Cloud Map service-discovery index.
- `integration-response-selector`: `selectIntegrationResponse`, `evaluateResponseParameters`, `pickResponseTemplate`, `tryParseStatus`, `IntegrationResponseEntry` (type) — `start-api` REST v1 `IntegrationResponses[]` selection.
- `EcsTaskResolutionError` (from `ecs-task-resolver`) and `VtlEvaluationError` (from `vtl-engine`) — the error classes those two resolvers throw. Exposed so the host can re-export the SAME class identity from its still-local engine modules; otherwise a host-side `instanceof` / `toThrow` against the shimmed resolver's throw would compare two distinct class objects across the package boundary and fail.

Ports the two modules' unit tests (`cloud-map-resolver.test.ts`, `integration-response-selector.test.ts`) verbatim from cdkd into `tests/unit/local/` so cdk-local owns the tests for the implementation it now owns. No runtime behavior change — index re-exports only.

## Test plan

- [x] `vp run check` (format + lint + typecheck) clean
- [x] `vp run test` — 1024 tests pass (incl. the 2 ported tests)
- [x] `vp run build` — all 9 new symbols present in `dist/index.d.ts`
- [ ] Docker integ (`local-invoke`) for the `integ` gate
