### PR TITLE
feat(exports): parameterize sigv4 strictness messaging via embedConfig + expose http-server/authorizer/sigv4 symbols for shim consumers

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -72,6 +72,25 @@ default, so omitting `embedConfig` (or any single field) leaves native
 `cdkl` behavior unchanged. Pass the same `embedConfig` to each factory
 the host mounts so the branding is consistent across commands.
 
+Two further optional fields tune the AWS_IAM SigV4 warn-message wording
+for a host whose `start-api` ships a different unverifiable-signature
+default than cdk-local's `warn-and-pass`:
+
+```typescript
+const embedConfig: CdkLocalEmbedConfig = {
+  // ...branding fields above...
+  sigV4StrictByDefault: true,            // host fails-closed by default (cdk-local default: false)
+  sigV4OptFlag: '--allow-unverified-sigv4', // host's strictness flag (cdk-local default: '--strict-sigv4')
+};
+```
+
+`sigV4StrictByDefault` flips the polarity of the SigV4 deny / pass warn
+messages (so a fail-closed host's advice reads "pass `<flag>` to
+warn-and-pass" instead of cdk-local's opt-in "remove `--strict-sigv4`
+…"), and `sigV4OptFlag` substitutes the host's own flag name. They affect
+only message text — the actual deny / pass decision is driven by the
+`sigV4Strict` argument the host passes to `startApiServer`.
+
 ### Shim hosts that don't use the factories
 
 A host that re-exports cdk-local's leaf modules as shims

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,13 +286,16 @@ export { materializeLayerFromArn } from './local/layer-arn-materializer.js';
 /**
  * `start-api` CORS handling — parses CFn `CorsConfiguration` (and the CloudFront
  * distribution chain) into a per-API CORS config and answers OPTIONS preflight
- * for HTTP API v2. Exposed only as the consuming host's `import` statements
- * require them.
+ * for HTTP API v2. `isFunctionUrlOacFronted` reports whether a Function URL is
+ * fronted by a CloudFront Origin Access Control distribution (the AWS_IAM
+ * authorizer relaxes SigV4 verification for such routes). Exposed only as the
+ * consuming host's `import` statements require them.
  */
 export {
   applyCorsResponseHeaders,
   buildCorsConfigByApiId,
   buildCorsConfigFromCloudFrontChain,
+  isFunctionUrlOacFronted,
   matchPreflight,
   type CorsConfig,
 } from './local/cors-handler.js';
@@ -310,6 +313,42 @@ export {
   tryResolveImageFnJoin,
   type ImageResolutionContext,
 } from './local/intrinsic-image.js';
+
+/**
+ * `start-api` local HTTP server — boots the per-API Node HTTP(S) server that
+ * routes requests to Lambda / VTL integrations, and reads the optional mTLS
+ * client-cert materials off disk. `ServerState` / `StartedApiServer` /
+ * `MtlsServerConfig` are the server-lifecycle types. Exposed only as the
+ * consuming host's `import` statements require them.
+ */
+export {
+  startApiServer,
+  readMtlsMaterialsFromDisk,
+  type ServerState,
+  type StartedApiServer,
+  type MtlsServerConfig,
+} from './local/http-server.js';
+
+/**
+ * `start-api` authorizer wiring — attaches the discovered authorizers (Lambda
+ * TOKEN / REQUEST, Cognito JWT, AWS_IAM SigV4) to the route list. `AuthorizerInfo`
+ * is the per-route resolved-authorizer descriptor; `RouteWithAuth` is a route
+ * paired with its authorizer. Exposed only as the consuming host's `import`
+ * statements require them.
+ */
+export {
+  attachAuthorizers,
+  type AuthorizerInfo,
+  type RouteWithAuth,
+} from './local/authorizer-resolver.js';
+
+/**
+ * `start-api` AWS_IAM SigV4 verification — the default local-credential loader
+ * the verifier reproduces signing keys from. `CredentialsLoader` is the loader
+ * factory signature a host can override. Exposed only as the consuming host's
+ * `import` statements require them.
+ */
+export { defaultCredentialsLoader, type CredentialsLoader } from './local/sigv4-verify.js';
 
 /**
  * `start-service` Cloud Map service-discovery index — parses the

--- a/src/local/embed-config.ts
+++ b/src/local/embed-config.ts
@@ -55,6 +55,21 @@ export interface CdkLocalEmbedConfig {
    * fallback). Default `'CDKL'`; cdkd passes `'CDKD'`.
    */
   envPrefix?: string;
+  /**
+   * Whether this host fails-closed by default on unverifiable AWS_IAM SigV4
+   * requests. cdk-local's default is warn-and-pass (`false`); a host like
+   * cdkd that ships fail-closed-by-default passes `true`. Drives the polarity
+   * of the SigV4 warn-message advice (whether the strictness flag reads as an
+   * opt-IN or opt-OUT). Default `false`.
+   */
+  sigV4StrictByDefault?: boolean;
+  /**
+   * The CLI flag a user toggles to change SigV4 strictness. With
+   * `sigV4StrictByDefault: false` it is an opt-IN flag (`'--strict-sigv4'`,
+   * the default); with `sigV4StrictByDefault: true` it is the host's opt-OUT
+   * flag (cdkd passes `'--allow-unverified-sigv4'`). Default `'--strict-sigv4'`.
+   */
+  sigV4OptFlag?: string;
 }
 
 export interface ResolvedEmbedConfig {
@@ -64,6 +79,8 @@ export interface ResolvedEmbedConfig {
   resourceNamePrefix: string;
   awsBindMountPath: string;
   envPrefix: string;
+  sigV4StrictByDefault: boolean;
+  sigV4OptFlag: string;
 }
 
 const DEFAULTS: ResolvedEmbedConfig = {
@@ -73,6 +90,8 @@ const DEFAULTS: ResolvedEmbedConfig = {
   resourceNamePrefix: 'cdkl',
   awsBindMountPath: '/cdk-local-aws',
   envPrefix: 'CDKL',
+  sigV4StrictByDefault: false,
+  sigV4OptFlag: '--strict-sigv4',
 };
 
 let current: ResolvedEmbedConfig = DEFAULTS;
@@ -91,6 +110,8 @@ export function setEmbedConfig(config?: CdkLocalEmbedConfig): void {
     resourceNamePrefix: config?.resourceNamePrefix ?? DEFAULTS.resourceNamePrefix,
     awsBindMountPath: config?.awsBindMountPath ?? DEFAULTS.awsBindMountPath,
     envPrefix: config?.envPrefix ?? DEFAULTS.envPrefix,
+    sigV4StrictByDefault: config?.sigV4StrictByDefault ?? DEFAULTS.sigV4StrictByDefault,
+    sigV4OptFlag: config?.sigV4OptFlag ?? DEFAULTS.sigV4OptFlag,
   };
 }
 

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -73,6 +73,7 @@
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import { getLogger } from '../utils/logger.js';
 import { buildIdentityHash } from './authorizer-resolver.js';
+import { getEmbedConfig } from './embed-config.js';
 import type { CachedAuthorizerResult } from './authorizer-cache.js';
 
 /**
@@ -283,19 +284,27 @@ export async function verifySigV4(
     // fail-closed. OAC-fronted routes always pass (no client signature
     // exists to verify in production).
     const reason = err instanceof Error ? err.message : String(err);
+    const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();
     if (opts.strict && !opts.oacFronted) {
       logger.warn(
-        `AWS_IAM authorizer: could not resolve local AWS credentials (${reason}), so the ` +
-          `request's SigV4 signature cannot be verified. --strict-sigv4 is set, so cdk-local ` +
-          `denies unverifiable IAM requests; remove --strict-sigv4 to warn-and-pass (the ` +
-          `default), or configure AWS credentials cdk-local can read.`
+        sigV4StrictByDefault
+          ? `AWS_IAM authorizer: could not resolve local AWS credentials (${reason}), so the ` +
+              `request's SigV4 signature cannot be verified. cdk-local denies unverifiable IAM ` +
+              `requests by default; pass ${optFlag} to warn-and-pass, or configure AWS ` +
+              `credentials cdk-local can read.`
+          : `AWS_IAM authorizer: could not resolve local AWS credentials (${reason}), so the ` +
+              `request's SigV4 signature cannot be verified. ${optFlag} is set, so cdk-local ` +
+              `denies unverifiable IAM requests; remove ${optFlag} to warn-and-pass (the ` +
+              `default), or configure AWS credentials cdk-local can read.`
       );
       return { allow: false, identityHash: undefined };
     }
     logger.warn(
       opts.oacFronted
         ? `AWS_IAM authorizer: Function URL is fronted by CloudFront OAC (CloudFront re-signs origin requests in production), and local AWS credentials could not be resolved (${reason}). Passing through with unverified principalId 'unverified-no-creds'. Do NOT trust event.requestContext.identity.accessKey in handler code.`
-        : `AWS_IAM authorizer: could not resolve local AWS credentials (${reason}), so the request's SigV4 signature cannot be verified locally (SigV4 is an HMAC shared-secret signature; the deployed API Gateway verifies it against AWS's copy of the secret). Passing through with unverified principalId 'unverified-no-creds' — cdk-local's default for unverifiable IAM requests; pass --strict-sigv4 to deny instead. Do NOT trust event.requestContext.identity.accessKey in handler code.`
+        : sigV4StrictByDefault
+          ? `AWS_IAM authorizer: could not resolve local AWS credentials (${reason}), so the request's SigV4 signature cannot be verified locally (SigV4 is an HMAC shared-secret signature; the deployed API Gateway verifies it against AWS's copy of the secret). ${optFlag} is set; passing through with unverified principalId 'unverified-no-creds'. Do NOT trust event.requestContext.identity.accessKey in handler code.`
+          : `AWS_IAM authorizer: could not resolve local AWS credentials (${reason}), so the request's SigV4 signature cannot be verified locally (SigV4 is an HMAC shared-secret signature; the deployed API Gateway verifies it against AWS's copy of the secret). Passing through with unverified principalId 'unverified-no-creds' — cdk-local's default for unverifiable IAM requests; pass ${optFlag} to deny instead. Do NOT trust event.requestContext.identity.accessKey in handler code.`
     );
     return {
       allow: true,
@@ -324,15 +333,23 @@ export async function verifySigV4(
     // warn line per case. Case-insensitive compare → case-insensitive
     // dedup. (PR #484 review MINOR.)
     const dedupKey = parsed.credentialAccessKeyId.toLowerCase();
+    const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();
     if (opts.strict && !opts.oacFronted) {
       if (!warned || !warned.has(dedupKey)) {
         logger.warn(
-          `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
-            `which differs from the AWS credentials cdk-local resolved locally — SigV4 (HMAC / ` +
-            `shared-secret) can only be verified with the signer's own credentials, never a ` +
-            `federated / Cognito Identity Pool / cross-account signer's. --strict-sigv4 is set, so ` +
-            `cdk-local denies it; remove --strict-sigv4 to warn-and-pass (the default), or sign the ` +
-            `request with the same credentials cdk-local resolves locally.`
+          sigV4StrictByDefault
+            ? `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+                `which differs from the AWS credentials cdk-local resolved locally — SigV4 (HMAC / ` +
+                `shared-secret) can only be verified with the signer's own credentials, never a ` +
+                `federated / Cognito Identity Pool / cross-account signer's. cdk-local denies it by ` +
+                `default; pass ${optFlag} to warn-and-pass, or sign the request with the same ` +
+                `credentials cdk-local resolves locally.`
+            : `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+                `which differs from the AWS credentials cdk-local resolved locally — SigV4 (HMAC / ` +
+                `shared-secret) can only be verified with the signer's own credentials, never a ` +
+                `federated / Cognito Identity Pool / cross-account signer's. ${optFlag} is set, so ` +
+                `cdk-local denies it; remove ${optFlag} to warn-and-pass (the default), or sign the ` +
+                `request with the same credentials cdk-local resolves locally.`
         );
         warned?.add(dedupKey);
       }
@@ -344,12 +361,19 @@ export async function verifySigV4(
           ? `AWS_IAM authorizer: Function URL is fronted by CloudFront OAC — in production CloudFront re-signs the origin request, so the local client's signature (access-key-id '${parsed.credentialAccessKeyId}') cannot be verified. ` +
               `Passing through with unverified principalId 'unverified-foreign-identity'. ` +
               `Do NOT trust event.requestContext.authorizer.principalId in handler code.`
-          : `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+          : sigV4StrictByDefault
+            ? `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+              `a federated / Cognito Identity Pool / cross-account signer cdk-local cannot verify ` +
+              `locally (SigV4 is an HMAC shared-secret signature; the deployed API Gateway verifies ` +
+              `it because AWS holds the secret). ${optFlag} is set; passing through with unverified ` +
+              `principalId 'unverified-foreign-identity'. Do NOT trust ` +
+              `event.requestContext.authorizer.principalId in handler code.`
+            : `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
               `a federated / Cognito Identity Pool / cross-account signer cdk-local cannot verify ` +
               `locally (SigV4 is an HMAC shared-secret signature; the deployed API Gateway verifies ` +
               `it because AWS holds the secret). Passing through with unverified principalId ` +
               `'unverified-foreign-identity' — cdk-local's default for unverifiable IAM requests; ` +
-              `pass --strict-sigv4 to deny instead. Do NOT trust ` +
+              `pass ${optFlag} to deny instead. Do NOT trust ` +
               `event.requestContext.authorizer.principalId in handler code.`
       );
       warned?.add(dedupKey);

--- a/tests/unit/local/authorizer-context.test.ts
+++ b/tests/unit/local/authorizer-context.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildAuthorizerContextShape } from '../../../src/local/authorizer-context.js';
+import type { AuthorizerInfo } from '../../../src/local/authorizer-resolver.js';
+import type { CachedAuthorizerResult } from '../../../src/local/authorizer-cache.js';
+
+/**
+ * PR #515 item 9 direct tests for the shared `buildAuthorizerContextShape`
+ * helper. The downstream wrappers `buildOverlay` (Lambda AWS_PROXY
+ * overlay) and `buildAuthorizerContextForServiceIntegration` (HTTP API
+ * v2 service-integration context) each consume this helper, and their
+ * tests in `http-server.test.ts` cover the wrapped shapes — but the
+ * helper itself deserves its own test surface so a future refactor
+ * doesn't have to read those wrapper tests inside-out.
+ */
+describe('buildAuthorizerContextShape (PR #515 item 9)', () => {
+  function lambdaTokenAuth(): AuthorizerInfo {
+    return {
+      kind: 'lambda-token',
+      logicalId: 'TokenAuth',
+      lambdaLogicalId: 'AuthFn',
+      tokenHeader: 'authorization',
+      resultTtlSeconds: 0,
+      declaredAt: 'S/Auth',
+    };
+  }
+  function lambdaRequestAuth(): AuthorizerInfo {
+    return {
+      kind: 'lambda-request',
+      logicalId: 'ReqAuth',
+      lambdaLogicalId: 'AuthFn',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: 0,
+      apiVersion: 'v2',
+      declaredAt: 'S/Auth',
+    };
+  }
+  function iamAuth(): AuthorizerInfo {
+    return {
+      kind: 'iam',
+      logicalId: 'AWS_IAM',
+      declaredAt: 'S/Auth',
+    };
+  }
+  function cognitoAuth(): AuthorizerInfo {
+    return {
+      kind: 'cognito',
+      logicalId: 'CogAuth',
+      pools: [
+        {
+          userPoolArn: 'arn:aws:cognito-idp:us-east-1:123:userpool/p',
+          region: 'us-east-1',
+          userPoolId: 'p',
+        },
+      ],
+      userPoolArn: 'arn:aws:cognito-idp:us-east-1:123:userpool/p',
+      region: 'us-east-1',
+      userPoolId: 'p',
+      identitySource: 'authorization',
+      declaredAt: 'S/Auth',
+    } as unknown as AuthorizerInfo;
+  }
+  function jwtAuth(): AuthorizerInfo {
+    return {
+      kind: 'jwt',
+      logicalId: 'JwtAuth',
+      issuer: 'https://example.com',
+      audiences: ['my-aud'],
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      declaredAt: 'S/Auth',
+    } as unknown as AuthorizerInfo;
+  }
+
+  it('Lambda TOKEN: principalId + context flat at the top level', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      principalId: 'user-42',
+      context: { tier: 'pro', email: 'a@example.com' },
+    };
+    expect(buildAuthorizerContextShape(lambdaTokenAuth(), result)).toEqual({
+      principalId: 'user-42',
+      tier: 'pro',
+      email: 'a@example.com',
+    });
+  });
+
+  it('Lambda REQUEST: same flat shape — kind is the only differentiator at the wire layer', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      principalId: 'u',
+      context: { tier: 'pro' },
+    };
+    expect(buildAuthorizerContextShape(lambdaRequestAuth(), result)).toEqual({
+      principalId: 'u',
+      tier: 'pro',
+    });
+  });
+
+  it('Lambda: omits principalId when undefined', () => {
+    const result: CachedAuthorizerResult = { allow: true, context: { tier: 'pro' } };
+    expect(buildAuthorizerContextShape(lambdaTokenAuth(), result)).toEqual({ tier: 'pro' });
+  });
+
+  it('Lambda: returns empty object when neither principalId nor context is set', () => {
+    expect(buildAuthorizerContextShape(lambdaTokenAuth(), { allow: true })).toEqual({});
+  });
+
+  it('IAM (AWS_IAM): only principalId surfaces (no policy emulation)', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      principalId: 'AKIAEXAMPLE',
+      // IAM "context" is intentionally NOT surfaced; the helper drops it.
+      context: { foreignField: 'should-not-leak' },
+    };
+    expect(buildAuthorizerContextShape(iamAuth(), result)).toEqual({
+      principalId: 'AKIAEXAMPLE',
+    });
+  });
+
+  it('Cognito: nests claims under `claims.X`', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      context: { sub: 'cog-user', email: 'b@example.com' },
+    };
+    expect(buildAuthorizerContextShape(cognitoAuth(), result)).toEqual({
+      claims: { sub: 'cog-user', email: 'b@example.com' },
+    });
+  });
+
+  it('Cognito: empty claims object when context is undefined', () => {
+    expect(buildAuthorizerContextShape(cognitoAuth(), { allow: true })).toEqual({
+      claims: {},
+    });
+  });
+
+  it('JWT: nests claims under `jwt.claims.X` with always-empty `jwt.scopes`', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      context: { sub: 'user-42', email: 'a@example.com' },
+    };
+    expect(buildAuthorizerContextShape(jwtAuth(), result)).toEqual({
+      jwt: {
+        claims: { sub: 'user-42', email: 'a@example.com' },
+        scopes: [],
+      },
+    });
+  });
+
+  it('JWT: empty claims + empty scopes when context is undefined', () => {
+    expect(buildAuthorizerContextShape(jwtAuth(), { allow: true })).toEqual({
+      jwt: { claims: {}, scopes: [] },
+    });
+  });
+
+  // Behavior-parity guard: the wrappers in `http-server.ts`
+  // (`buildAuthorizerContextForServiceIntegration` AND the relevant
+  // branches of `buildOverlay`) must produce shapes that flow from
+  // this helper. The matrix below pins every kind so a future shape
+  // change in this helper surfaces here BEFORE the downstream wrapper
+  // tests catch it inside-out.
+  it('parity: every kind returns an Object (not undefined/null) for a populated result', () => {
+    const populated: CachedAuthorizerResult = {
+      allow: true,
+      principalId: 'X',
+      context: { k: 'v' },
+    };
+    expect(typeof buildAuthorizerContextShape(lambdaTokenAuth(), populated)).toBe('object');
+    expect(typeof buildAuthorizerContextShape(lambdaRequestAuth(), populated)).toBe('object');
+    expect(typeof buildAuthorizerContextShape(iamAuth(), populated)).toBe('object');
+    expect(typeof buildAuthorizerContextShape(cognitoAuth(), populated)).toBe('object');
+    expect(typeof buildAuthorizerContextShape(jwtAuth(), populated)).toBe('object');
+  });
+});

--- a/tests/unit/local/embed-config.test.ts
+++ b/tests/unit/local/embed-config.test.ts
@@ -29,6 +29,8 @@ describe('embed-config', () => {
       resourceNamePrefix: 'cdkl',
       awsBindMountPath: '/cdk-local-aws',
       envPrefix: 'CDKL',
+      sigV4StrictByDefault: false,
+      sigV4OptFlag: '--strict-sigv4',
     });
   });
 
@@ -40,6 +42,8 @@ describe('embed-config', () => {
       resourceNamePrefix: 'cdkd-local',
       awsBindMountPath: '/cdkd-aws',
       envPrefix: 'CDKD',
+      sigV4StrictByDefault: true,
+      sigV4OptFlag: '--allow-unverified-sigv4',
     });
     expect(getEmbedConfig()).toEqual({
       cliName: 'cdkd local',
@@ -48,6 +52,8 @@ describe('embed-config', () => {
       resourceNamePrefix: 'cdkd-local',
       awsBindMountPath: '/cdkd-aws',
       envPrefix: 'CDKD',
+      sigV4StrictByDefault: true,
+      sigV4OptFlag: '--allow-unverified-sigv4',
     });
   });
 
@@ -60,6 +66,8 @@ describe('embed-config', () => {
       resourceNamePrefix: 'cdkd-local',
       awsBindMountPath: '/cdk-local-aws',
       envPrefix: 'CDKL',
+      sigV4StrictByDefault: false,
+      sigV4OptFlag: '--strict-sigv4',
     });
   });
 

--- a/tests/unit/local/http-server-cors.test.ts
+++ b/tests/unit/local/http-server-cors.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { startApiServer, type ServerState } from '../../../src/local/http-server.js';
+import type {
+  ContainerPool,
+  ContainerHandle,
+  ContainerSpec,
+} from '../../../src/local/container-pool.js';
+import type { CorsConfig } from '../../../src/local/cors-handler.js';
+import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+import type { RouteWithAuth } from '../../../src/local/authorizer-resolver.js';
+
+/**
+ * End-to-end coverage for the CORS preflight interception path inside
+ * the HTTP server's request handler.
+ *
+ * `maybeHandleCorsPreflight` is private — exercised via real HTTP
+ * requests against a live `startApiServer`. We use a stub ContainerPool
+ * that records every `acquire()` call so each test can assert preflight
+ * was intercepted (acquire NOT called) vs. fell through to route
+ * dispatch (acquire called). Lambda-side execution is mocked away by
+ * having the pool's acquire reject — the request body never reaches
+ * `invokeRie` because we want to test only the preflight path.
+ */
+
+interface StubPool extends ContainerPool {
+  acquireCalls: string[];
+}
+
+function stubPool(): StubPool {
+  const acquireCalls: string[] = [];
+  const pool = {
+    acquireCalls,
+    acquire: vi.fn(async (logicalId: string): Promise<ContainerHandle> => {
+      acquireCalls.push(logicalId);
+      // Make every actual route dispatch a 502 so tests that DON'T expect
+      // preflight interception can still observe a clear non-204 path.
+      throw new Error('stub-acquire-failed');
+    }),
+    release: vi.fn(),
+    dispose: vi.fn(async (): Promise<void> => undefined),
+  } as unknown as StubPool;
+  Object.defineProperty(pool, '__cdklSpecs', {
+    value: new Map<string, ContainerSpec>(),
+    enumerable: false,
+    configurable: true,
+  });
+  return pool;
+}
+
+function v2Route(over: Partial<DiscoveredRoute> = {}): RouteWithAuth {
+  return {
+    route: {
+      method: 'POST', // matches the preflight's access-control-request-method
+      pathPattern: '/items',
+      lambdaLogicalId: 'L_v2',
+      source: 'http-api',
+      apiVersion: 'v2',
+      stage: '$default',
+      apiLogicalId: 'ApiV2',
+      declaredAt: 'S/Items',
+      ...over,
+    },
+  };
+}
+
+function v1Route(over: Partial<DiscoveredRoute> = {}): RouteWithAuth {
+  return {
+    route: {
+      method: 'OPTIONS',
+      pathPattern: '/items',
+      lambdaLogicalId: 'L_v1',
+      source: 'rest-v1',
+      apiVersion: 'v1',
+      stage: '$default',
+      apiLogicalId: 'ApiV1',
+      declaredAt: 'S/ItemsV1',
+      ...over,
+    },
+  };
+}
+
+const corsConfig: CorsConfig = {
+  AllowOrigins: ['https://example.com'],
+  AllowMethods: ['GET', 'POST'],
+  AllowHeaders: ['Content-Type'],
+  ExposeHeaders: [],
+};
+
+async function preflight(
+  port: number,
+  host: string,
+  path: string,
+  extraHeaders: Record<string, string> = {}
+): Promise<{ status: number; headers: Headers; body: string }> {
+  const url = `http://${host}:${port}${path}`;
+  const res = await fetch(url, {
+    method: 'OPTIONS',
+    headers: {
+      origin: 'https://example.com',
+      'access-control-request-method': 'POST',
+      ...extraHeaders,
+    },
+  });
+  const body = await res.text();
+  return { status: res.status, headers: res.headers, body };
+}
+
+describe('http-server CORS preflight integration', () => {
+  let server: Awaited<ReturnType<typeof startApiServer>> | undefined;
+
+  beforeEach(() => {
+    server = undefined;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = undefined;
+    }
+  });
+
+  it('intercepts preflight on a CORS-configured HTTP API v2 route', async () => {
+    const pool = stubPool();
+    const state: ServerState = {
+      routes: [v2Route()],
+      pool,
+      corsConfigByApiId: new Map([['ApiV2', corsConfig]]),
+    };
+    server = await startApiServer({ state, rieTimeoutMs: 5_000, host: '127.0.0.1', port: 0 });
+    const r = await preflight(server.port, server.host, '/items');
+    expect(r.status).toBe(204);
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://example.com');
+    expect(r.headers.get('vary')).toBe('Origin');
+    // Preflight does NOT acquire a container (Lambda not invoked).
+    expect(pool.acquireCalls).toEqual([]);
+  });
+
+  it('preflight on API A is NOT suppressed by an explicit OPTIONS route on API B (cross-API contamination guard)', async () => {
+    const pool = stubPool();
+    // Two APIs sharing the path /items: API v2 has CORS config; v1 has
+    // an explicit OPTIONS route. Pre-fix the v1 OPTIONS route would
+    // suppress preflight on the v2 API; post-fix the apiLogicalId
+    // filter scopes the explicit-OPTIONS check to the matched route's
+    // own API.
+    const state: ServerState = {
+      routes: [
+        v2Route(), // GET /items on ApiV2 (with CORS)
+        v1Route(), // OPTIONS /items on ApiV1 (different API)
+      ],
+      pool,
+      corsConfigByApiId: new Map([['ApiV2', corsConfig]]),
+    };
+    server = await startApiServer({ state, rieTimeoutMs: 5_000, host: '127.0.0.1', port: 0 });
+    const r = await preflight(server.port, server.host, '/items');
+    expect(r.status).toBe(204);
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://example.com');
+    expect(pool.acquireCalls).toEqual([]);
+  });
+
+  it('falls through to route dispatch when an explicit OPTIONS route exists on the SAME API', async () => {
+    const pool = stubPool();
+    // Two routes on the same v2 API: GET /items (would match preflight)
+    // and OPTIONS /items (user owns CORS for this path). The explicit
+    // OPTIONS should suppress interception so the user's Lambda is
+    // dispatched (which then 502s due to our stub).
+    const state: ServerState = {
+      routes: [
+        v2Route(),
+        v2Route({ method: 'OPTIONS', lambdaLogicalId: 'L_v2_options' }),
+      ],
+      pool,
+      corsConfigByApiId: new Map([['ApiV2', corsConfig]]),
+    };
+    server = await startApiServer({ state, rieTimeoutMs: 5_000, host: '127.0.0.1', port: 0 });
+    const r = await preflight(server.port, server.host, '/items');
+    expect(r.status).toBe(502);
+    // Lambda was dispatched.
+    expect(pool.acquireCalls).toEqual(['L_v2_options']);
+  });
+
+  it('falls through to 404 when no route matches the requested method (surrogateMatch fail)', async () => {
+    const pool = stubPool();
+    const state: ServerState = {
+      routes: [v2Route({ pathPattern: '/other' })], // path doesn't match
+      pool,
+      corsConfigByApiId: new Map([['ApiV2', corsConfig]]),
+    };
+    server = await startApiServer({ state, rieTimeoutMs: 5_000, host: '127.0.0.1', port: 0 });
+    const r = await preflight(server.port, server.host, '/items');
+    expect(r.status).toBe(404);
+    expect(pool.acquireCalls).toEqual([]);
+  });
+
+  it('falls through to route dispatch when the matched route is REST v1 (preflight not handled for v1)', async () => {
+    const pool = stubPool();
+    const state: ServerState = {
+      // Only a v1 route on /items — preflight should NOT be intercepted
+      // (REST v1 CORS via Mock OPTIONS is out of scope). The route's
+      // method must match the preflight's `Access-Control-Request-Method`
+      // (POST) for surrogateMatch to find it; we use ANY here so the
+      // route matches any method.
+      routes: [v1Route({ method: 'ANY', lambdaLogicalId: 'L_v1' })],
+      pool,
+      corsConfigByApiId: new Map([['ApiV1', corsConfig]]), // even if cors map has v1 entry
+    };
+    server = await startApiServer({ state, rieTimeoutMs: 5_000, host: '127.0.0.1', port: 0 });
+    const r = await preflight(server.port, server.host, '/items');
+    // Falls through to route dispatch; the actual OPTIONS request hits
+    // matchRoute again — ANY matches OPTIONS too, so we end up
+    // dispatching the v1 Lambda. Stub pool's acquire rejects, so we get
+    // a 502.
+    expect(r.status).toBe(502);
+    expect(pool.acquireCalls).toEqual(['L_v1']);
+  });
+
+  it('returns early (no preflight) when access-control-request-method header is missing', async () => {
+    const pool = stubPool();
+    const state: ServerState = {
+      routes: [v2Route()],
+      pool,
+      corsConfigByApiId: new Map([['ApiV2', corsConfig]]),
+    };
+    server = await startApiServer({ state, rieTimeoutMs: 5_000, host: '127.0.0.1', port: 0 });
+    // OPTIONS without access-control-request-method. Falls through to
+    // route dispatch — but the routes don't include OPTIONS for /items,
+    // so it 404s.
+    const url = `http://${server.host}:${server.port}/items`;
+    const res = await fetch(url, {
+      method: 'OPTIONS',
+      headers: { origin: 'https://example.com' },
+    });
+    expect(res.status).toBe(404);
+    expect(pool.acquireCalls).toEqual([]);
+  });
+
+  it('matches greedy {proxy+} pattern when checking explicit-OPTIONS suppression on the same API', async () => {
+    const pool = stubPool();
+    // POST /api/{proxy+} would match preflight (preflight asks for
+    // POST); OPTIONS /api/{proxy+} on the SAME API should suppress
+    // interception. The greedy pattern is exercised because the
+    // request path `/api/items/123` has more segments than the literal
+    // prefix.
+    const state: ServerState = {
+      routes: [
+        v2Route({ pathPattern: '/api/{proxy+}', method: 'POST' }),
+        v2Route({
+          pathPattern: '/api/{proxy+}',
+          method: 'OPTIONS',
+          lambdaLogicalId: 'L_v2_options',
+        }),
+      ],
+      pool,
+      corsConfigByApiId: new Map([['ApiV2', corsConfig]]),
+    };
+    server = await startApiServer({ state, rieTimeoutMs: 5_000, host: '127.0.0.1', port: 0 });
+    const r = await preflight(server.port, server.host, '/api/items/123');
+    // Preflight suppressed — falls through to route dispatch (stub 502).
+    expect(r.status).toBe(502);
+    expect(pool.acquireCalls).toEqual(['L_v2_options']);
+  });
+});

--- a/tests/unit/local/http-server-mtls.test.ts
+++ b/tests/unit/local/http-server-mtls.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for `cdkl start-api` mTLS support (issue #446).
+ *
+ * Covers:
+ *   - `peerCertificateToAws` shape extraction from Node's PeerCertificate
+ *     (the load-bearing pure-functional conversion).
+ *   - `extractClientCert` socket-type guard (returns undefined on
+ *     non-TLS sockets, which is the safety net for the mtls === undefined
+ *     branch).
+ *   - `readMtlsMaterialsFromDisk` PEM-read failure mode (missing file
+ *     gets a typed error naming the offending flag).
+ *   - End-to-end scheme reporting: a plain HTTP server reports
+ *     `scheme: 'http'`; the https branch is verified by spawning
+ *     openssl to generate a real cert pair when available, skipped
+ *     otherwise (the integ test at `tests/integration/local-start-api/`
+ *     covers the handshake-rejects-unknown-CA end-to-end).
+ *
+ * The TLS handshake itself (rejection of unknown-CA / self-signed
+ * client certs) is enforced by Node's `tls` module; we do NOT
+ * re-implement that check in cdk-local, so the unit tests focus on the
+ * pure-functional helpers + the plumbing into the event shape.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { IncomingMessage } from 'node:http';
+import type { PeerCertificate } from 'node:tls';
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import {
+  extractClientCert,
+  peerCertificateToAws,
+  readMtlsMaterialsFromDisk,
+  startApiServer,
+  type ServerState,
+  type MtlsServerConfig,
+} from '../../../src/local/http-server.js';
+import type { ContainerPool } from '../../../src/local/container-pool.js';
+
+vi.mock('../../../src/local/rie-client.js', () => ({
+  invokeRie: vi.fn(),
+}));
+
+function makePool(): ContainerPool {
+  return {
+    acquire: vi.fn(async () => ({
+      containerId: 'c1',
+      containerHost: '127.0.0.1',
+      hostPort: 1234,
+      logicalId: 'X',
+      release: vi.fn(),
+    })),
+    release: vi.fn(),
+    dispose: vi.fn(async () => undefined),
+  } as unknown as ContainerPool;
+}
+
+function makeState(): ServerState {
+  return {
+    routes: [],
+    pool: makePool(),
+    corsConfigByApiId: new Map(),
+  };
+}
+
+/**
+ * Try to find an openssl binary on PATH. Returns the path on success,
+ * `undefined` when openssl is unavailable (in which case the
+ * scheme=https test self-skips).
+ */
+function findOpenssl(): string | undefined {
+  // Try the common locations; covers macOS Homebrew + Linux defaults.
+  for (const candidate of ['openssl', '/usr/bin/openssl', '/opt/homebrew/bin/openssl']) {
+    try {
+      execFileSync(candidate, ['version'], { stdio: 'ignore' });
+      return candidate;
+    } catch {
+      /* try next */
+    }
+  }
+  return undefined;
+}
+
+describe('peerCertificateToAws', () => {
+  it('converts a populated PeerCertificate to the AWS clientCert shape', () => {
+    // Synthetic 4-byte "DER" so we can assert the base64 PEM wrap.
+    const rawDer = Buffer.from([0x30, 0x82, 0x01, 0x02]);
+    const cert: Partial<PeerCertificate> = {
+      subject: { CN: 'client', O: 'example', C: 'US' } as PeerCertificate['subject'],
+      issuer: { CN: 'My CA', O: 'example', C: 'US' } as PeerCertificate['issuer'],
+      serialNumber: '0123456789ABCDEF',
+      valid_from: 'May 22 03:30:00 2026 GMT',
+      valid_to: 'May 22 03:30:00 2027 GMT',
+      raw: rawDer,
+    };
+    const out = peerCertificateToAws(cert as PeerCertificate);
+    expect(out).toBeDefined();
+    expect(out!['subjectDN']).toBe('CN=client,O=example,C=US');
+    expect(out!['issuerDN']).toBe('CN=My CA,O=example,C=US');
+    expect(out!['serialNumber']).toBe('0123456789ABCDEF');
+    expect(out!['validity']).toEqual({
+      notBefore: 'May 22 03:30:00 2026 GMT',
+      notAfter: 'May 22 03:30:00 2027 GMT',
+    });
+    const pem = out!['clientCertPem'] as string;
+    expect(pem.startsWith('-----BEGIN CERTIFICATE-----')).toBe(true);
+    expect(pem.includes(rawDer.toString('base64'))).toBe(true);
+    expect(pem.endsWith('-----END CERTIFICATE-----\n')).toBe(true);
+  });
+
+  it('orders DN fields canonical (CN, OU, O, L, ST, C) and skips missing fields', () => {
+    const cert: Partial<PeerCertificate> = {
+      subject: { C: 'US', CN: 'client', OU: 'engineering' } as PeerCertificate['subject'],
+      issuer: { CN: 'CA' } as PeerCertificate['issuer'],
+      serialNumber: 'AA',
+      valid_from: 'X',
+      valid_to: 'Y',
+      raw: Buffer.alloc(0),
+    };
+    const out = peerCertificateToAws(cert as PeerCertificate);
+    expect(out!['subjectDN']).toBe('CN=client,OU=engineering,C=US');
+    expect(out!['issuerDN']).toBe('CN=CA');
+  });
+
+  it('returns undefined on an empty cert object (handshake passed but no peer cert)', () => {
+    expect(peerCertificateToAws({})).toBeUndefined();
+  });
+
+  it('returns undefined on null / undefined input', () => {
+    expect(peerCertificateToAws(undefined)).toBeUndefined();
+    expect(peerCertificateToAws(null)).toBeUndefined();
+  });
+
+  it('falls back to empty strings on missing subject/issuer/serial/validity fields', () => {
+    const out = peerCertificateToAws({ raw: Buffer.from([0x00]) } as unknown as PeerCertificate);
+    expect(out).toBeDefined();
+    expect(out!['subjectDN']).toBe('');
+    expect(out!['issuerDN']).toBe('');
+    expect(out!['serialNumber']).toBe('');
+    expect(out!['validity']).toEqual({ notBefore: '', notAfter: '' });
+  });
+
+  it('emits empty clientCertPem when `raw` is not a Buffer (parsed-metadata-only path)', () => {
+    const out = peerCertificateToAws({
+      subject: { CN: 'x' },
+      issuer: { CN: 'y' },
+      serialNumber: 'aa',
+      valid_from: 'a',
+      valid_to: 'b',
+    } as unknown as PeerCertificate);
+    expect(out!['clientCertPem']).toBe('');
+  });
+});
+
+describe('extractClientCert', () => {
+  it('returns undefined when the socket is not a TLSSocket (no getPeerCertificate method)', () => {
+    // Plain `net.Socket` shape — no `getPeerCertificate`.
+    const req = { socket: {} } as unknown as IncomingMessage;
+    expect(extractClientCert(req)).toBeUndefined();
+  });
+
+  it('routes through peerCertificateToAws when the socket exposes getPeerCertificate', () => {
+    const fakeCert: Partial<PeerCertificate> = {
+      subject: { CN: 'client' } as PeerCertificate['subject'],
+      issuer: { CN: 'My CA' } as PeerCertificate['issuer'],
+      serialNumber: 'AA',
+      valid_from: 'X',
+      valid_to: 'Y',
+      raw: Buffer.from([0x00]),
+    };
+    const req = {
+      socket: {
+        getPeerCertificate: () => fakeCert,
+      },
+    } as unknown as IncomingMessage;
+    const out = extractClientCert(req);
+    expect(out).toBeDefined();
+    expect(out!['subjectDN']).toBe('CN=client');
+    expect(out!['issuerDN']).toBe('CN=My CA');
+  });
+
+  it('returns undefined when the TLSSocket reports an empty cert', () => {
+    const req = {
+      socket: {
+        getPeerCertificate: () => ({}),
+      },
+    } as unknown as IncomingMessage;
+    expect(extractClientCert(req)).toBeUndefined();
+  });
+});
+
+describe('readMtlsMaterialsFromDisk', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'cdkl-mtls-test-'));
+  });
+
+  it('reads three valid PEM files', () => {
+    const ca = join(tmp, 'ca.pem');
+    const cert = join(tmp, 'cert.pem');
+    const key = join(tmp, 'key.pem');
+    writeFileSync(ca, 'CA');
+    writeFileSync(cert, 'CERT');
+    writeFileSync(key, 'KEY');
+    const out = readMtlsMaterialsFromDisk({
+      truststorePath: ca,
+      certPath: cert,
+      keyPath: key,
+    });
+    expect(out.caPem.toString()).toBe('CA');
+    expect(out.certPem.toString()).toBe('CERT');
+    expect(out.keyPem.toString()).toBe('KEY');
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('surfaces a clear error naming the offending flag + path on ENOENT', () => {
+    expect(() =>
+      readMtlsMaterialsFromDisk({
+        truststorePath: join(tmp, 'missing.pem'),
+        certPath: join(tmp, 'cert.pem'),
+        keyPath: join(tmp, 'key.pem'),
+      })
+    ).toThrow(/--mtls-truststore: cannot read PEM file at/);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe('startApiServer scheme reporting', () => {
+  it('plain HTTP server reports scheme=http', async () => {
+    const server = await startApiServer({
+      state: makeState(),
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      expect(server.scheme).toBe('http');
+    } finally {
+      await server.close();
+    }
+  });
+
+  // The mTLS scheme test needs a real RSA private key + matching cert
+  // for `https.createServer` to accept. We generate it once via openssl
+  // at test start. When openssl is unavailable (uncommon — every CI
+  // image we target ships it), the test self-skips with a clear message
+  // so the suite stays green on minimal environments. The
+  // handshake-against-unknown-CA path is the integ test's responsibility
+  // (`tests/integration/local-start-api/` --mtls variant).
+  const opensslBin = findOpenssl();
+  const itMaybe = opensslBin ? it : it.skip;
+  itMaybe('mTLS server reports scheme=https', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'cdkl-mtls-bootscheme-'));
+    try {
+      const certPath = join(tmp, 'cert.pem');
+      const keyPath = join(tmp, 'key.pem');
+      // Generate a one-shot self-signed RSA cert for localhost. The
+      // -nodes flag leaves the key unencrypted so Node's tls module
+      // can read it without a passphrase callback.
+      execFileSync(
+        opensslBin!,
+        [
+          'req',
+          '-x509',
+          '-newkey',
+          'rsa:2048',
+          '-nodes',
+          '-keyout',
+          keyPath,
+          '-out',
+          certPath,
+          '-subj',
+          '/CN=localhost',
+          '-days',
+          '1',
+        ],
+        { stdio: 'ignore' }
+      );
+      // Sanity-check both files were written.
+      expect(existsSync(certPath)).toBe(true);
+      expect(existsSync(keyPath)).toBe(true);
+      const mtls: MtlsServerConfig = {
+        caPem: readFileSync(certPath),
+        certPem: readFileSync(certPath),
+        keyPem: readFileSync(keyPath),
+      };
+      const server = await startApiServer({
+        state: makeState(),
+        rieTimeoutMs: 1000,
+        host: '127.0.0.1',
+        port: 0,
+        mtls,
+      });
+      try {
+        expect(server.scheme).toBe('https');
+      } finally {
+        await server.close();
+      }
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/local/http-server-service-integration-auth.test.ts
+++ b/tests/unit/local/http-server-service-integration-auth.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+
+// vi.hoisted so the spies are available inside the vi.mock factory below
+// (vi.mock is hoisted to file-top — top-level consts captured by the
+// factory are referenced before they're initialized otherwise).
+const { dispatchSpy, verifyJwtAuthorizerSpy } = vi.hoisted(() => ({
+  dispatchSpy: vi.fn(),
+  verifyJwtAuthorizerSpy: vi.fn(),
+}));
+
+// Mock the service-integration SDK adapter so we can prove the
+// authorizer-deny path NEVER invokes it. Using `vi.importActual` to
+// preserve every other export from the module (the dispatcher is the
+// ONLY function we want to spy on; `applyResponseParameters` /
+// `resolveServiceIntegrationParameters` / etc. must keep their real
+// implementations because http-server.ts calls them on the auth-allow
+// path).
+vi.mock('../../../src/local/httpv2-service-integration.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/local/httpv2-service-integration.js')>(
+    '../../../src/local/httpv2-service-integration.js'
+  );
+  return {
+    ...actual,
+    dispatchServiceIntegration: dispatchSpy,
+  };
+});
+
+vi.mock('../../../src/local/rie-client.js', () => ({
+  invokeRie: vi.fn(),
+  invokeRieStreaming: vi.fn(),
+}));
+
+// Mock the JWT-verify entry points so a JWT-deny verdict can be injected
+// without standing up a real JWKS endpoint. `createJwksCache` keeps its
+// real impl (the server's `opts.jwksCache` shape must round-trip), so we
+// preserve every other export via `vi.importActual`.
+vi.mock('../../../src/local/cognito-jwt.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/local/cognito-jwt.js')>(
+    '../../../src/local/cognito-jwt.js'
+  );
+  return {
+    ...actual,
+    verifyJwtAuthorizer: verifyJwtAuthorizerSpy,
+  };
+});
+
+import { startApiServer } from '../../../src/local/http-server.js';
+import type { RouteWithAuth } from '../../../src/local/authorizer-resolver.js';
+import type { ContainerPool } from '../../../src/local/container-pool.js';
+import { createAuthorizerCache } from '../../../src/local/authorizer-cache.js';
+import { createJwksCache } from '../../../src/local/cognito-jwt.js';
+import * as rieClient from '../../../src/local/rie-client.js';
+
+const invokeRieMock = rieClient.invokeRie as unknown as ReturnType<typeof vi.fn>;
+
+/**
+ * PR #515 item 8: end-to-end deny-path coverage for service-integration
+ * routes. The unit-level behavior of
+ * `buildAuthorizerContextForServiceIntegration` is covered in
+ * `http-server.test.ts`, but the load-bearing security claim from PR
+ * #514 — "auth-deny → SDK never fires" — only surfaces at the
+ * `handleRequest` -> `runAuthorizerPass` -> `handleServiceIntegrationRequest`
+ * dispatch chain. These tests wire that chain end-to-end against BOTH
+ * authorizer kinds the service-integration auth-pass guards — a Lambda
+ * REQUEST authorizer (deny verdict / missing identity / handler crash)
+ * AND a JWT authorizer (forged-signature deny) — and assert the spy on
+ * `dispatchServiceIntegration` is never called.
+ */
+function makePool(): ContainerPool {
+  const acquire = vi.fn(async () => ({
+    containerId: 'c1',
+    containerHost: '127.0.0.1',
+    hostPort: 1234,
+    logicalId: 'AuthFn',
+    release: vi.fn(),
+  }));
+  const release = vi.fn();
+  return {
+    acquire,
+    release,
+    dispose: vi.fn(async () => undefined),
+  } as unknown as ContainerPool;
+}
+
+function makeServiceRoute(): RouteWithAuth {
+  return {
+    route: {
+      method: 'POST',
+      pathPattern: '/protected-sqs',
+      lambdaLogicalId: '',
+      source: 'http-api',
+      apiVersion: 'v2',
+      stage: '$default',
+      declaredAt: 'S/Route-ProtectedSqs',
+      serviceIntegration: {
+        subtype: 'SQS-SendMessage',
+        requestParameters: {
+          QueueUrl: 'https://sqs.us-east-1.amazonaws.com/123456789012/queue',
+          MessageBody: '$request.body',
+        },
+      },
+    },
+    authorizer: {
+      kind: 'lambda-request',
+      logicalId: 'ReqAuth',
+      lambdaLogicalId: 'AuthFn',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: 0,
+      apiVersion: 'v2',
+      declaredAt: 'S/Route-ProtectedSqs',
+    },
+  };
+}
+
+function makeJwtServiceRoute(): RouteWithAuth {
+  return {
+    route: {
+      method: 'POST',
+      pathPattern: '/protected-sqs',
+      lambdaLogicalId: '',
+      source: 'http-api',
+      apiVersion: 'v2',
+      stage: '$default',
+      declaredAt: 'S/Route-ProtectedSqs',
+      serviceIntegration: {
+        subtype: 'SQS-SendMessage',
+        requestParameters: {
+          QueueUrl: 'https://sqs.us-east-1.amazonaws.com/123456789012/queue',
+          MessageBody: '$request.body',
+        },
+      },
+    },
+    authorizer: {
+      kind: 'jwt',
+      logicalId: 'JwtAuth',
+      issuer: 'https://issuer.example.com',
+      audience: ['my-client-id'],
+      declaredAt: 'S/Route-ProtectedSqs',
+    },
+  };
+}
+
+describe('PR #515 item 8: service-integration route + authorizer-deny → SDK never fires', () => {
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+    dispatchSpy.mockReset();
+    verifyJwtAuthorizerSpy.mockReset();
+  });
+
+  it('Lambda REQUEST authorizer denies → HTTP 401 + dispatchServiceIntegration NOT called', async () => {
+    // Authorizer Lambda returns a non-Allow verdict. HTTP API v2 simple
+    // shape: `{ isAuthorized: false }` means deny.
+    invokeRieMock.mockImplementation(async (_h, _p, event) => {
+      const isAuthorizer = (event as { type?: string }).type === 'REQUEST';
+      if (isAuthorizer) {
+        return {
+          raw: '',
+          payload: { isAuthorized: false },
+        };
+      }
+      throw new Error('handler must never be invoked on deny');
+    });
+
+    const route = makeServiceRoute();
+    const cache = createAuthorizerCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+      defaultRegion: 'us-east-1',
+    });
+
+    try {
+      const url = `http://${server.host}:${server.port}/protected-sqs`;
+      const resp = await fetch(url, {
+        method: 'POST',
+        body: 'message-body',
+        headers: { authorization: 'Bearer wrong-token', 'content-type': 'text/plain' },
+      });
+      // HTTP API v2 collapses both deny kinds to 401.
+      expect(resp.status).toBe(401);
+      // The load-bearing security invariant: deny → no SDK fire.
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('Lambda REQUEST authorizer missing identity → 401 + dispatch never invoked', async () => {
+    // The route's identity source is the `authorization` header; we
+    // omit it entirely so the authorizer pass sees no identity. AWS API
+    // Gateway short-circuits this case BEFORE invoking the Lambda — the
+    // assert here is that the SDK adapter spy ALSO never fires.
+    invokeRieMock.mockImplementation(async (_h, _p, _event) => {
+      // If the Lambda ever runs, the test should fail loudly. The
+      // missing-identity path should short-circuit before this.
+      throw new Error('authorizer Lambda must not run on missing-identity');
+    });
+
+    const route = makeServiceRoute();
+    const cache = createAuthorizerCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+      defaultRegion: 'us-east-1',
+    });
+
+    try {
+      const url = `http://${server.host}:${server.port}/protected-sqs`;
+      const resp = await fetch(url, {
+        method: 'POST',
+        body: 'message-body',
+        // No `authorization` header — Lambda REQUEST identity source missing.
+        headers: { 'content-type': 'text/plain' },
+      });
+      expect(resp.status).toBe(401);
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('Lambda REQUEST authorizer throws → 401 + dispatch never invoked', async () => {
+    // Authorizer Lambda itself throws (HTTP API v2 treats this as
+    // policy-deny → 401). The load-bearing claim is unchanged: deny
+    // path of any flavor MUST short-circuit before any SDK call fires.
+    invokeRieMock.mockImplementation(async (_h, _p, event) => {
+      const isAuthorizer = (event as { type?: string }).type === 'REQUEST';
+      if (isAuthorizer) {
+        // A non-deterministic Lambda error (e.g. handler crash). The
+        // http-server's runAuthorizerPass catches and routes to
+        // writeAuthRejection('policy-deny') = 401 on HTTP v2.
+        throw new Error('authorizer Lambda crashed');
+      }
+      throw new Error('handler must never be invoked');
+    });
+
+    const route = makeServiceRoute();
+    const cache = createAuthorizerCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+      defaultRegion: 'us-east-1',
+    });
+
+    try {
+      const url = `http://${server.host}:${server.port}/protected-sqs`;
+      const resp = await fetch(url, {
+        method: 'POST',
+        body: 'message-body',
+        headers: { authorization: 'Bearer xyz', 'content-type': 'text/plain' },
+      });
+      expect(resp.status).toBe(401);
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('JWT authorizer rejects forged signature → 401 + dispatch never invoked', async () => {
+    // JWT-deny mirrors the security claim across the other authorizer
+    // kind the service-integration auth-pass guards. The forged token is
+    // shaped like a real JWT (`header.payload.signature` base64url
+    // segments) so it gets past `extractBearer` and into the JWKS-backed
+    // verifier; the mocked `verifyJwtAuthorizer` returns the canonical
+    // signature-mismatch verdict (`allow: false`). The load-bearing
+    // invariant is the same as the Lambda REQUEST cases: deny → no SDK
+    // fire.
+    verifyJwtAuthorizerSpy.mockResolvedValue({
+      allow: false,
+      identityHash: undefined,
+      ttlSeconds: 0,
+    });
+
+    const route = makeJwtServiceRoute();
+    const cache = createAuthorizerCache();
+    const jwksCache = createJwksCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+      jwksCache,
+      defaultRegion: 'us-east-1',
+    });
+
+    try {
+      const url = `http://${server.host}:${server.port}/protected-sqs`;
+      // Plausible-shaped JWT (three base64url segments). The signature
+      // does not match anything `verifyJwtAuthorizer` would accept; the
+      // mock returns deny regardless.
+      const forgedJwt = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjMifQ.bogus';
+      const resp = await fetch(url, {
+        method: 'POST',
+        body: 'message-body',
+        headers: { authorization: `Bearer ${forgedJwt}`, 'content-type': 'text/plain' },
+      });
+      // HTTP API v2 collapses every deny kind to 401.
+      expect(resp.status).toBe(401);
+      // The load-bearing security invariant: JWT-deny → no SDK fire.
+      expect(dispatchSpy).not.toHaveBeenCalled();
+      // The mocked verifier was reached (proves the auth pass DID run on
+      // the JWT route; the route wasn't accidentally bypassed before
+      // reaching the verify step).
+      expect(verifyJwtAuthorizerSpy).toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/tests/unit/local/http-server.test.ts
+++ b/tests/unit/local/http-server.test.ts
@@ -1,0 +1,1396 @@
+import { createHash, createHmac } from 'node:crypto';
+import type { ServerResponse } from 'node:http';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vite-plus/test';
+import {
+  buildAuthorizerContextForServiceIntegration,
+  parseQueryStringSingular,
+  startApiServer,
+  writeAuthRejection,
+} from '../../../src/local/http-server.js';
+import type { AuthorizerInfo, RouteWithAuth } from '../../../src/local/authorizer-resolver.js';
+import type { CachedAuthorizerResult } from '../../../src/local/authorizer-cache.js';
+import type { ContainerPool } from '../../../src/local/container-pool.js';
+import { createAuthorizerCache } from '../../../src/local/authorizer-cache.js';
+import { createJwksCache } from '../../../src/local/cognito-jwt.js';
+import {
+  canonicalizePath,
+  canonicalizeQueryString,
+  type CredentialsLoader,
+  type ResolvedCredentials,
+} from '../../../src/local/sigv4-verify.js';
+
+vi.mock('../../../src/local/rie-client.js', () => ({
+  invokeRie: vi.fn(),
+  invokeRieStreaming: vi.fn(),
+}));
+import * as rieClient from '../../../src/local/rie-client.js';
+const invokeRieMock = rieClient.invokeRie as unknown as ReturnType<typeof vi.fn>;
+const invokeRieStreamingMock = rieClient.invokeRieStreaming as unknown as ReturnType<typeof vi.fn>;
+
+/**
+ * Construct a minimal `ServerResponse` stand-in that records `statusCode`
+ * and the final body. We don't need a real `node:http` socket for the
+ * `writeAuthRejection` unit tests.
+ */
+function makeResponse(): ServerResponse & {
+  capturedBody: string;
+  capturedHeaders: Map<string, string>;
+} {
+  const headers = new Map<string, string>();
+  let body = '';
+  const stub = {
+    statusCode: 0,
+    setHeader(name: string, value: string | string[]) {
+      headers.set(String(name).toLowerCase(), Array.isArray(value) ? value.join(',') : String(value));
+    },
+    end(payload?: string | Buffer) {
+      body = payload ? payload.toString() : '';
+    },
+    get capturedBody() {
+      return body;
+    },
+    get capturedHeaders() {
+      return headers;
+    },
+  } as unknown as ServerResponse & { capturedBody: string; capturedHeaders: Map<string, string> };
+  return stub;
+}
+
+describe('writeAuthRejection', () => {
+  it('REST v1 + missing-identity → 401 Unauthorized', () => {
+    const res = makeResponse();
+    writeAuthRejection(res, 'v1', 'missing-identity');
+    expect(res.statusCode).toBe(401);
+    expect(res.capturedBody).toBe('{"message":"Unauthorized"}');
+  });
+
+  it('REST v1 + policy-deny → 403 Forbidden', () => {
+    const res = makeResponse();
+    writeAuthRejection(res, 'v1', 'policy-deny');
+    expect(res.statusCode).toBe(403);
+    expect(res.capturedBody).toBe('{"message":"Forbidden"}');
+  });
+
+  it('HTTP v2 + missing-identity → 401 Unauthorized', () => {
+    const res = makeResponse();
+    writeAuthRejection(res, 'v2', 'missing-identity');
+    expect(res.statusCode).toBe(401);
+    expect(res.capturedBody).toBe('{"message":"Unauthorized"}');
+  });
+
+  it('HTTP v2 + policy-deny → 401 Unauthorized', () => {
+    const res = makeResponse();
+    writeAuthRejection(res, 'v2', 'policy-deny');
+    expect(res.statusCode).toBe(401);
+    expect(res.capturedBody).toBe('{"message":"Unauthorized"}');
+  });
+
+  it('Function URL (v2 + IAM) + missing-identity → 403 Forbidden (#621)', () => {
+    // Function URL with AWS_IAM is v2-shaped but the AWS-deployed response
+    // is 403 (the SigV4 layer rejects), not API Gateway v2's default 401.
+    const res = makeResponse();
+    writeAuthRejection(res, 'v2', 'missing-identity', 'iam');
+    expect(res.statusCode).toBe(403);
+    expect(res.capturedBody).toBe('{"Message":"Forbidden"}');
+  });
+
+  it('Function URL (v2 + IAM) + policy-deny → 403 Forbidden (#621)', () => {
+    const res = makeResponse();
+    writeAuthRejection(res, 'v2', 'policy-deny', 'iam');
+    expect(res.statusCode).toBe(403);
+    expect(res.capturedBody).toBe('{"Message":"Forbidden"}');
+  });
+
+  it('REST v1 + IAM + missing-identity → 403 Missing Authentication Token (#625)', () => {
+    // REST v1 with AWS_IAM also rejects unsigned requests with 403, not
+    // the v1 default 401. Body uses lowercase `message` — distinct from
+    // Function URL's capital `Message` — and the deployed REST v1 surface
+    // returns "Missing Authentication Token" when no signature is present.
+    const res = makeResponse();
+    writeAuthRejection(res, 'v1', 'missing-identity', 'iam');
+    expect(res.statusCode).toBe(403);
+    expect(res.capturedBody).toBe('{"message":"Missing Authentication Token"}');
+  });
+
+  it('REST v1 + IAM + policy-deny → 403 Forbidden (#625)', () => {
+    // REST v1 with AWS_IAM, SigV4 verification ran and failed (bad
+    // signature / wrong account / policy deny). Status mirrors AWS API
+    // Gateway's deployed REST v1 IAM rejection: 403 + lowercase `message`.
+    const res = makeResponse();
+    writeAuthRejection(res, 'v1', 'policy-deny', 'iam');
+    expect(res.statusCode).toBe(403);
+    expect(res.capturedBody).toBe('{"message":"Forbidden"}');
+  });
+});
+
+/**
+ * End-to-end tests for the per-request authorizer pass via `startApiServer`.
+ * We boot a real `node:http` server on an ephemeral port and curl-equivalent
+ * `fetch()` it; the route handler + authorizer are mocked via `invokeRie`.
+ */
+function makePool(): ContainerPool {
+  const acquire = vi.fn(async () => ({
+    containerId: 'c1',
+    containerHost: '127.0.0.1',
+    hostPort: 1234,
+    logicalId: 'X',
+    release: vi.fn(),
+  }));
+  const release = vi.fn();
+  return {
+    acquire,
+    release,
+    dispose: vi.fn(async () => undefined),
+  } as unknown as ContainerPool;
+}
+
+function makeRequestRoute(opts: {
+  authorizerLogicalId: string;
+  resultTtlSeconds?: number;
+}): RouteWithAuth {
+  return {
+    route: {
+      method: 'GET',
+      pathPattern: '/items/{id}',
+      lambdaLogicalId: 'HandlerFn',
+      source: 'rest-v1',
+      apiVersion: 'v1',
+      stage: 'prod',
+      declaredAt: 'S/Method-X',
+    },
+    authorizer: {
+      kind: 'lambda-request',
+      logicalId: opts.authorizerLogicalId,
+      lambdaLogicalId: 'AuthFn',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: opts.resultTtlSeconds ?? 300,
+      apiVersion: 'v1',
+      declaredAt: 'S/Method-X',
+    },
+  };
+}
+
+describe('startApiServer — REQUEST authorizer cache (must-fix #1)', () => {
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+  });
+
+  it('caches REQUEST authorizer verdicts: 2 same-identity requests invoke the Lambda exactly once', async () => {
+    const route = makeRequestRoute({ authorizerLogicalId: 'Auth' });
+    // The authorizer Lambda is invoked first per request (when cache
+    // misses); the route handler is invoked after Allow.
+    invokeRieMock.mockImplementation(async (host, port, event) => {
+      // The route handler request has no `type: 'REQUEST'`; the
+      // authorizer event does. Branch on that.
+      const isAuthorizer = (event as { type?: string }).type === 'REQUEST';
+      if (isAuthorizer) {
+        return {
+          raw: '',
+          payload: {
+            principalId: 'u',
+            policyDocument: {
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Resource: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/*',
+                },
+              ],
+            },
+            context: { tier: 'pro' },
+          },
+        };
+      }
+      return {
+        raw: '',
+        payload: { statusCode: 200, body: 'ok' },
+      };
+    });
+
+    const cache = createAuthorizerCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+    });
+
+    try {
+      // Two requests with the same identity → authorizer Lambda invoked
+      // exactly once (cache reuses verdict for the second).
+      const url = `http://${server.host}:${server.port}/items/42`;
+      const r1 = await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      expect(r1.status).toBe(200);
+      const r2 = await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      expect(r2.status).toBe(200);
+
+      const authorizerInvocations = invokeRieMock.mock.calls.filter(
+        (c) => (c[2] as { type?: string }).type === 'REQUEST'
+      );
+      expect(authorizerInvocations).toHaveLength(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('cache key is per-identity: different headers → 2 authorizer invocations', async () => {
+    const route = makeRequestRoute({ authorizerLogicalId: 'Auth' });
+    invokeRieMock.mockImplementation(async (_h, _p, event) => {
+      const isAuthorizer = (event as { type?: string }).type === 'REQUEST';
+      if (isAuthorizer) {
+        return {
+          raw: '',
+          payload: {
+            principalId: 'u',
+            policyDocument: {
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Resource: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/*',
+                },
+              ],
+            },
+          },
+        };
+      }
+      return { raw: '', payload: { statusCode: 200, body: 'ok' } };
+    });
+
+    const cache = createAuthorizerCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+    });
+
+    try {
+      const url = `http://${server.host}:${server.port}/items/42`;
+      await fetch(url, { headers: { authorization: 'Bearer A' } });
+      await fetch(url, { headers: { authorization: 'Bearer B' } });
+      const authorizerInvocations = invokeRieMock.mock.calls.filter(
+        (c) => (c[2] as { type?: string }).type === 'REQUEST'
+      );
+      expect(authorizerInvocations).toHaveLength(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('cache disabled when ttl=0 (HTTP v2 default)', async () => {
+    const route: RouteWithAuth = {
+      route: {
+        method: 'GET',
+        pathPattern: '/items/{id}',
+        lambdaLogicalId: 'HandlerFn',
+        source: 'http-api',
+        apiVersion: 'v2',
+        stage: '$default',
+        declaredAt: 'S/Route-X',
+      },
+      authorizer: {
+        kind: 'lambda-request',
+        logicalId: 'Auth',
+        lambdaLogicalId: 'AuthFn',
+        identitySources: [{ kind: 'header', name: 'authorization' }],
+        resultTtlSeconds: 0, // No caching
+        apiVersion: 'v2',
+        declaredAt: 'S/Route-X',
+      },
+    };
+    invokeRieMock.mockImplementation(async (_h, _p, event) => {
+      const isAuthorizer = (event as { type?: string }).type === 'REQUEST';
+      if (isAuthorizer) {
+        return { raw: '', payload: { isAuthorized: true } };
+      }
+      return { raw: '', payload: { statusCode: 200, body: 'ok' } };
+    });
+
+    const cache = createAuthorizerCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+    });
+
+    try {
+      const url = `http://${server.host}:${server.port}/items/42`;
+      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      const authorizerInvocations = invokeRieMock.mock.calls.filter(
+        (c) => (c[2] as { type?: string }).type === 'REQUEST'
+      );
+      // ttl=0 → no caching → 2 invocations.
+      expect(authorizerInvocations).toHaveLength(2);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('startApiServer — narrow-Resource cache leak (must-fix #2)', () => {
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+  });
+
+  it('cached Allow with narrow Resource is denied for a different methodArn', async () => {
+    // Route /items/{id} matches both /items/42 and /items/999.
+    const route = makeRequestRoute({ authorizerLogicalId: 'Auth' });
+    invokeRieMock.mockImplementation(async (_h, _p, event) => {
+      const isAuthorizer = (event as { type?: string }).type === 'REQUEST';
+      if (isAuthorizer) {
+        return {
+          raw: '',
+          payload: {
+            principalId: 'u',
+            policyDocument: {
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  // Narrow: only /items/42 is allowed.
+                  Resource: 'arn:aws:execute-api:local:123456789012:local/prod/GET/items/42',
+                },
+              ],
+            },
+          },
+        };
+      }
+      return { raw: '', payload: { statusCode: 200, body: 'ok' } };
+    });
+
+    const cache = createAuthorizerCache();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: cache,
+    });
+
+    try {
+      const baseUrl = `http://${server.host}:${server.port}`;
+      // 1st request: hits /items/42 (narrow Resource matches) → 200.
+      const r1 = await fetch(`${baseUrl}/items/42`, {
+        headers: { authorization: 'Bearer xyz' },
+      });
+      expect(r1.status).toBe(200);
+
+      // 2nd request: same identity → cache hit, BUT new methodArn
+      // /items/999 does NOT match the narrow Resource → must deny.
+      // Pre-fix this returned 200 (cache stored the verdict directly,
+      // no per-request Resource re-eval).
+      const r2 = await fetch(`${baseUrl}/items/999`, {
+        headers: { authorization: 'Bearer xyz' },
+      });
+      expect(r2.status).toBe(403);
+
+      // Authorizer Lambda invoked exactly once: cache hit for r2 (we're
+      // NOT re-invoking; Resource re-eval is a CPU-only path off the
+      // cached verdict).
+      const authorizerInvocations = invokeRieMock.mock.calls.filter(
+        (c) => (c[2] as { type?: string }).type === 'REQUEST'
+      );
+      expect(authorizerInvocations).toHaveLength(1);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('startApiServer — JWKS pass-through warn fires once per server (must-fix #3)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+    // Capture warnings via the global console.warn channel — the logger
+    // routes warn lines through console.warn.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('JWKS unreachable + 2 requests → exactly 1 pass-through warn line', async () => {
+    const route: RouteWithAuth = {
+      route: {
+        method: 'GET',
+        pathPattern: '/protected',
+        lambdaLogicalId: 'HandlerFn',
+        source: 'rest-v1',
+        apiVersion: 'v1',
+        stage: 'prod',
+        declaredAt: 'S/Method-Y',
+      },
+      authorizer: {
+        kind: 'cognito',
+        logicalId: 'Auth',
+        userPoolArn: 'arn:aws:cognito-idp:us-east-1:111:userpool/us-east-1_x',
+        region: 'us-east-1',
+        userPoolId: 'us-east-1_x',
+        declaredAt: 'S/Method-Y',
+      },
+    };
+    invokeRieMock.mockImplementation(async () => ({
+      raw: '',
+      payload: { statusCode: 200, body: 'ok' },
+    }));
+
+    // JWKS cache that always fails fetch → pass-through.
+    const jwksCache = createJwksCache({
+      fetchImpl: async () => {
+        throw new Error('unreachable');
+      },
+    });
+    const jwksWarnedUrls = new Set<string>();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      jwksCache,
+      jwksWarnedUrls,
+    });
+
+    try {
+      const url = `http://${server.host}:${server.port}/protected`;
+      // Use any-old Bearer token; pass-through accepts.
+      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+
+      // Count warn lines about pass-through. The logger emits other
+      // warn lines (JWKS unreachable at startup) — only count the
+      // request-time pass-through line.
+      const passThroughWarns = warnSpy.mock.calls.filter((args) => {
+        const msg = args.map((a) => String(a)).join(' ');
+        return msg.includes('JWKS pass-through mode for ');
+      });
+      // Pre-fix: warn fired every request (2 lines). Post-fix: warn
+      // fires at most once per JWKS URL per server lifecycle.
+      expect(passThroughWarns).toHaveLength(1);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('startApiServer — unsupported route (deferred 501)', () => {
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+  });
+
+  it('returns HTTP 501 + reason in JSON body without invoking any Lambda', async () => {
+    const route: RouteWithAuth = {
+      route: {
+        method: 'GET',
+        pathPattern: '/admin',
+        lambdaLogicalId: '',
+        source: 'rest-v1',
+        apiVersion: 'v1',
+        stage: 'prod',
+        apiLogicalId: 'Api',
+        apiStackName: 'S',
+        declaredAt: 'S/AdminMethod',
+        unsupported: {
+          reason: 'S/AdminMethod: MOCK integration is not emulated (only the CORS preflight subset).',
+        },
+      },
+    };
+    const pool = makePool();
+    const server = await startApiServer({
+      state: { routes: [route], pool, corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const url = `http://${server.host}:${server.port}/admin`;
+      const r = await fetch(url);
+      expect(r.status).toBe(501);
+      const body = (await r.json()) as { message: string; reason: string };
+      expect(body.message).toBe('Not Implemented');
+      expect(body.reason).toMatch(/MOCK integration is not emulated/);
+      // Crucial: no container acquire, no Lambda invoke.
+      expect(invokeRieMock).not.toHaveBeenCalled();
+      expect((pool.acquire as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('does not run the authorizer pass on an unsupported route', async () => {
+    // Reach for the authorizer-attached route fixture, then flag it
+    // unsupported. The authorizer Lambda must NOT be invoked (we
+    // short-circuit before the authorizer pass).
+    const baseRoute = makeRequestRoute({ authorizerLogicalId: 'Auth' });
+    const route: RouteWithAuth = {
+      ...baseRoute,
+      route: { ...baseRoute.route, unsupported: { reason: 'flagged for testing' } },
+    };
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      authorizerCache: createAuthorizerCache(),
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/items/42`, {
+        headers: { authorization: 'Bearer x' },
+      });
+      expect(r.status).toBe(501);
+      expect(invokeRieMock).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('startApiServer — mockCors preflight', () => {
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+  });
+
+  it('returns the captured status + headers on OPTIONS without invoking any Lambda', async () => {
+    const route: RouteWithAuth = {
+      route: {
+        method: 'OPTIONS',
+        pathPattern: '/items',
+        lambdaLogicalId: '',
+        source: 'rest-v1',
+        apiVersion: 'v1',
+        stage: 'prod',
+        apiLogicalId: 'Api',
+        apiStackName: 'S',
+        declaredAt: 'S/CorsMethod',
+        mockCors: {
+          statusCode: 204,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'OPTIONS,GET,POST',
+            'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+          },
+        },
+      },
+    };
+    const pool = makePool();
+    const server = await startApiServer({
+      state: { routes: [route], pool, corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/items`, { method: 'OPTIONS' });
+      expect(r.status).toBe(204);
+      expect(r.headers.get('access-control-allow-origin')).toBe('*');
+      expect(r.headers.get('access-control-allow-methods')).toBe('OPTIONS,GET,POST');
+      expect(r.headers.get('access-control-allow-headers')).toBe('Content-Type,Authorization');
+      expect(invokeRieMock).not.toHaveBeenCalled();
+      expect((pool.acquire as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+    invokeRieStreamingMock.mockReset();
+  });
+
+  it('routes invokeMode=RESPONSE_STREAM to invokeRieStreaming and pipes the body with chunked encoding', async () => {
+    const { Readable } = await import('node:stream');
+    invokeRieStreamingMock.mockImplementation(async () => ({
+      prelude: {
+        statusCode: 200,
+        headers: { 'Content-Type': 'text/plain', 'X-Custom': 'hello' },
+      },
+      body: Readable.from([Buffer.from('chunk-0\n'), Buffer.from('chunk-1\n')]),
+    }));
+    const route: RouteWithAuth = {
+      route: {
+        method: 'ANY',
+        pathPattern: '/{proxy+}',
+        lambdaLogicalId: 'Fn',
+        source: 'function-url',
+        apiVersion: 'v2',
+        stage: '$default',
+        apiStackName: 'S',
+        declaredAt: 'S/Url',
+        invokeMode: 'RESPONSE_STREAM',
+      },
+    };
+    const pool = makePool();
+    const server = await startApiServer({
+      state: { routes: [route], pool, corsConfigByApiId: new Map() },
+      rieTimeoutMs: 5000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      expect(r.status).toBe(200);
+      expect(r.headers.get('content-type')).toBe('text/plain');
+      expect(r.headers.get('x-custom')).toBe('hello');
+      // Node sets Transfer-Encoding: chunked automatically when no Content-Length.
+      expect(r.headers.get('transfer-encoding')).toBe('chunked');
+      const body = await r.text();
+      expect(body).toBe('chunk-0\nchunk-1\n');
+      // Buffered path NOT used.
+      expect(invokeRieMock).not.toHaveBeenCalled();
+      expect(invokeRieStreamingMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('emits multiple Set-Cookie headers from the prelude cookies array', async () => {
+    const { Readable } = await import('node:stream');
+    invokeRieStreamingMock.mockImplementation(async () => ({
+      prelude: {
+        statusCode: 200,
+        headers: {},
+        cookies: ['a=1; Path=/', 'b=2; Path=/'],
+      },
+      body: Readable.from([Buffer.from('ok')]),
+    }));
+    const route: RouteWithAuth = {
+      route: {
+        method: 'ANY',
+        pathPattern: '/{proxy+}',
+        lambdaLogicalId: 'Fn',
+        source: 'function-url',
+        apiVersion: 'v2',
+        stage: '$default',
+        apiStackName: 'S',
+        declaredAt: 'S/Url',
+        invokeMode: 'RESPONSE_STREAM',
+      },
+    };
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 5000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      // Node's fetch / undici exposes multi-valued Set-Cookie via getSetCookie().
+      const cookies = r.headers.getSetCookie();
+      expect(cookies).toEqual(['a=1; Path=/', 'b=2; Path=/']);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('falls back to buffered invokeRie when invokeMode is BUFFERED (default)', async () => {
+    invokeRieMock.mockResolvedValue({
+      payload: { statusCode: 200, body: 'buffered-response' },
+      raw: '{}',
+    });
+    const route: RouteWithAuth = {
+      route: {
+        method: 'ANY',
+        pathPattern: '/{proxy+}',
+        lambdaLogicalId: 'Fn',
+        source: 'function-url',
+        apiVersion: 'v2',
+        stage: '$default',
+        apiStackName: 'S',
+        declaredAt: 'S/Url',
+        invokeMode: 'BUFFERED',
+      },
+    };
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 5000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      expect(r.status).toBe(200);
+      expect(await r.text()).toBe('buffered-response');
+      expect(invokeRieMock).toHaveBeenCalledTimes(1);
+      expect(invokeRieStreamingMock).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 502 + releases the pool when streaming invoke throws before any headers', async () => {
+    invokeRieStreamingMock.mockRejectedValue(new Error('rie boom'));
+    const pool = makePool();
+    const route: RouteWithAuth = {
+      route: {
+        method: 'ANY',
+        pathPattern: '/{proxy+}',
+        lambdaLogicalId: 'Fn',
+        source: 'function-url',
+        apiVersion: 'v2',
+        stage: '$default',
+        apiStackName: 'S',
+        declaredAt: 'S/Url',
+        invokeMode: 'RESPONSE_STREAM',
+      },
+    };
+    const server = await startApiServer({
+      state: { routes: [route], pool, corsConfigByApiId: new Map() },
+      rieTimeoutMs: 5000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      expect(r.status).toBe(502);
+      // Pool must be released so the warm container can serve the next request.
+      expect((pool.release as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('destroys the body Readable + releases the pool when writeStreamingResponse throws synchronously on a malformed prelude header', async () => {
+    // Regression for the PR #501 review blocker: when `res.writeHead(...)`
+    // throws synchronously (e.g. on a header value containing CRLF — Node
+    // rejects it with ERR_INVALID_CHAR), the body Readable from
+    // `invokeRieStreaming` had no consumer attached yet (the `'error'`
+    // / `'close'` listeners are installed AFTER `writeHead` succeeds
+    // inside `writeStreamingResponse`). Without the fix, the IIFE in
+    // `invokeRieStreaming` would keep pushing chunks into an orphan
+    // Readable forever and the pool entry would never be returned.
+    const { Readable } = await import('node:stream');
+    let bodyStream: import('node:stream').Readable | undefined;
+    invokeRieStreamingMock.mockImplementation(async () => {
+      bodyStream = Readable.from([Buffer.from('chunk-0\n')]);
+      return {
+        prelude: {
+          statusCode: 200,
+          // Invalid CRLF in a header value: Node's writeHead rejects
+          // synchronously with ERR_INVALID_CHAR.
+          headers: { 'X-Bad': 'broken\r\nvalue' },
+        },
+        body: bodyStream,
+      };
+    });
+    const pool = makePool();
+    const route: RouteWithAuth = {
+      route: {
+        method: 'ANY',
+        pathPattern: '/{proxy+}',
+        lambdaLogicalId: 'Fn',
+        source: 'function-url',
+        apiVersion: 'v2',
+        stage: '$default',
+        apiStackName: 'S',
+        declaredAt: 'S/Url',
+        invokeMode: 'RESPONSE_STREAM',
+      },
+    };
+    const server = await startApiServer({
+      state: { routes: [route], pool, corsConfigByApiId: new Map() },
+      rieTimeoutMs: 5000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      // Outer catch reports 502 (no headers were sent before the throw).
+      expect(r.status).toBe(502);
+      // (a) Pool must be released so the warm container can serve again.
+      expect((pool.release as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+      // (b) Body Readable must be destroyed so the underlying fetch reader
+      // is released and the `invokeRieStreaming` IIFE stops pushing.
+      expect(bodyStream).toBeDefined();
+      expect(bodyStream!.destroyed).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('strips Content-Length and Transfer-Encoding from the prelude headers (issue #503 item 3)', async () => {
+    // A handler that defensively sets `Content-Length` or
+    // `Transfer-Encoding` in its prelude must not break the chunked-
+    // encoding contract Node enforces automatically. Both headers
+    // (case-insensitive) are stripped before `res.writeHead(...)`.
+    const { Readable } = await import('node:stream');
+    invokeRieStreamingMock.mockImplementation(async () => ({
+      prelude: {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'text/plain',
+          'Content-Length': '9999',
+          'Transfer-Encoding': 'gzip',
+          'X-Preserved': 'kept',
+        },
+      },
+      body: Readable.from([Buffer.from('hello-world')]),
+    }));
+    const route: RouteWithAuth = {
+      route: {
+        method: 'ANY',
+        pathPattern: '/{proxy+}',
+        lambdaLogicalId: 'Fn',
+        source: 'function-url',
+        apiVersion: 'v2',
+        stage: '$default',
+        apiStackName: 'S',
+        declaredAt: 'S/Url',
+        invokeMode: 'RESPONSE_STREAM',
+      },
+    };
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 5000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      expect(r.status).toBe(200);
+      // Node emits Transfer-Encoding: chunked automatically when no
+      // Content-Length is set. The handler's "gzip" stays stripped.
+      expect(r.headers.get('transfer-encoding')).toBe('chunked');
+      // Conflicting Content-Length is stripped (no actual length sent).
+      // undici exposes `null` for absent headers.
+      expect(r.headers.get('content-length')).toBeNull();
+      // Sibling headers pass through intact.
+      expect(r.headers.get('content-type')).toBe('text/plain');
+      expect(r.headers.get('x-preserved')).toBe('kept');
+      const body = await r.text();
+      expect(body).toBe('hello-world');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('strips Content-Length and Transfer-Encoding case-insensitively (issue #503 item 3)', async () => {
+    // Same as above but with lowercase / mixed-case keys to assert the
+    // strip is case-insensitive.
+    const { Readable } = await import('node:stream');
+    invokeRieStreamingMock.mockImplementation(async () => ({
+      prelude: {
+        statusCode: 200,
+        headers: {
+          'content-length': '9999',
+          'transfer-encoding': 'chunked',
+          'X-Kept': 'yes',
+        },
+      },
+      body: Readable.from([Buffer.from('lc')]),
+    }));
+    const route: RouteWithAuth = {
+      route: {
+        method: 'ANY',
+        pathPattern: '/{proxy+}',
+        lambdaLogicalId: 'Fn',
+        source: 'function-url',
+        apiVersion: 'v2',
+        stage: '$default',
+        apiStackName: 'S',
+        declaredAt: 'S/Url',
+        invokeMode: 'RESPONSE_STREAM',
+      },
+    };
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 5000,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      expect(r.status).toBe(200);
+      expect(r.headers.get('content-length')).toBeNull();
+      // Node still emits chunked automatically.
+      expect(r.headers.get('transfer-encoding')).toBe('chunked');
+      expect(r.headers.get('x-kept')).toBe('yes');
+      expect(await r.text()).toBe('lc');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('parseQueryStringSingular — multi-value comma-join (PR #500 minor)', () => {
+  it('comma-joins repeated keys in declaration order', () => {
+    // `?foo=a&foo=b` -> `foo: 'a,b'` matches the contract documented at
+    // `src/local/parameter-mapping.ts:14` ("multi-values comma-joined")
+    // AND deployed API Gateway behavior. Pre-fix the implementation did
+    // last-wins (`foo: 'b'`) which silently dropped earlier values for
+    // service-integration RequestParameters.
+    expect(parseQueryStringSingular('/path?foo=a&foo=b')).toEqual({ foo: 'a,b' });
+  });
+
+  it('comma-joins three or more repetitions, preserves order', () => {
+    expect(parseQueryStringSingular('/?id=1&id=2&id=3&id=4')).toEqual({ id: '1,2,3,4' });
+  });
+
+  it('leaves single-value keys untouched (no extra commas)', () => {
+    expect(parseQueryStringSingular('/?a=1&b=2')).toEqual({ a: '1', b: '2' });
+  });
+
+  it('mixes single-value + multi-value keys cleanly', () => {
+    expect(parseQueryStringSingular('/?foo=a&bar=x&foo=b')).toEqual({
+      foo: 'a,b',
+      bar: 'x',
+    });
+  });
+
+  it('URL-decodes each value before joining', () => {
+    expect(parseQueryStringSingular('/?q=hello%20world&q=goodbye%21')).toEqual({
+      q: 'hello world,goodbye!',
+    });
+  });
+
+  it('returns empty map on no query string', () => {
+    expect(parseQueryStringSingular('/path')).toEqual({});
+    expect(parseQueryStringSingular('/path?')).toEqual({});
+  });
+
+  it('handles empty values cleanly', () => {
+    expect(parseQueryStringSingular('/?foo=&foo=bar')).toEqual({ foo: ',bar' });
+  });
+});
+
+describe('buildAuthorizerContextForServiceIntegration (closes #502)', () => {
+  function lambdaTokenAuth(): AuthorizerInfo {
+    return {
+      kind: 'lambda-token',
+      logicalId: 'TokenAuth',
+      lambdaLogicalId: 'AuthFn',
+      tokenHeader: 'authorization',
+      resultTtlSeconds: 0,
+      declaredAt: 'S/Auth',
+    };
+  }
+  function lambdaRequestAuth(): AuthorizerInfo {
+    return {
+      kind: 'lambda-request',
+      logicalId: 'ReqAuth',
+      lambdaLogicalId: 'AuthFn',
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      resultTtlSeconds: 0,
+      apiVersion: 'v2',
+      declaredAt: 'S/Auth',
+    };
+  }
+  function jwtAuth(): AuthorizerInfo {
+    return {
+      kind: 'jwt',
+      logicalId: 'JwtAuth',
+      issuer: 'https://example.com',
+      audiences: ['my-aud'],
+      identitySources: [{ kind: 'header', name: 'authorization' }],
+      declaredAt: 'S/Auth',
+    } as unknown as AuthorizerInfo;
+  }
+  function cognitoAuth(): AuthorizerInfo {
+    return {
+      kind: 'cognito',
+      logicalId: 'CogAuth',
+      pools: [
+        {
+          userPoolArn: 'arn:aws:cognito-idp:us-east-1:123:userpool/p',
+          region: 'us-east-1',
+          userPoolId: 'p',
+        },
+      ],
+      userPoolArn: 'arn:aws:cognito-idp:us-east-1:123:userpool/p',
+      region: 'us-east-1',
+      userPoolId: 'p',
+      identitySource: 'authorization',
+      declaredAt: 'S/Auth',
+    } as unknown as AuthorizerInfo;
+  }
+  function iamAuth(): AuthorizerInfo {
+    return {
+      kind: 'iam',
+      logicalId: 'AWS_IAM',
+      declaredAt: 'S/Auth',
+    };
+  }
+
+  it('returns undefined when no authorizer fired', () => {
+    expect(buildAuthorizerContextForServiceIntegration(undefined, undefined)).toBeUndefined();
+    expect(
+      buildAuthorizerContextForServiceIntegration(lambdaTokenAuth(), undefined)
+    ).toBeUndefined();
+    expect(
+      buildAuthorizerContextForServiceIntegration(undefined, { allow: true } as CachedAuthorizerResult)
+    ).toBeUndefined();
+  });
+
+  it('Lambda TOKEN: flattens principalId + context fields at the top level', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      principalId: 'user-42',
+      context: { tier: 'pro', email: 'a@example.com' },
+    };
+    expect(buildAuthorizerContextForServiceIntegration(lambdaTokenAuth(), result)).toEqual({
+      principalId: 'user-42',
+      tier: 'pro',
+      email: 'a@example.com',
+    });
+  });
+
+  it('Lambda REQUEST: flattens principalId + context at the top level', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      principalId: 'u',
+      context: { tier: 'pro' },
+    };
+    expect(buildAuthorizerContextForServiceIntegration(lambdaRequestAuth(), result)).toEqual({
+      principalId: 'u',
+      tier: 'pro',
+    });
+  });
+
+  it('Lambda authorizer: omits principalId when absent', () => {
+    const result: CachedAuthorizerResult = { allow: true, context: { tier: 'pro' } };
+    expect(buildAuthorizerContextForServiceIntegration(lambdaTokenAuth(), result)).toEqual({
+      tier: 'pro',
+    });
+  });
+
+  it('Lambda authorizer: empty record when result has neither principal nor context', () => {
+    const result: CachedAuthorizerResult = { allow: true };
+    expect(buildAuthorizerContextForServiceIntegration(lambdaTokenAuth(), result)).toEqual({});
+  });
+
+  it('IAM (AWS_IAM): surfaces principalId only (no policy emulation)', () => {
+    const result: CachedAuthorizerResult = { allow: true, principalId: 'AKIA...' };
+    expect(buildAuthorizerContextForServiceIntegration(iamAuth(), result)).toEqual({
+      principalId: 'AKIA...',
+    });
+  });
+
+  it('Cognito: nests claims under `claims.X`', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      context: { sub: 'cog-user', email: 'b@example.com' },
+    };
+    expect(buildAuthorizerContextForServiceIntegration(cognitoAuth(), result)).toEqual({
+      claims: { sub: 'cog-user', email: 'b@example.com' },
+    });
+  });
+
+  it('Cognito: empty claims object when no context', () => {
+    const result: CachedAuthorizerResult = { allow: true };
+    expect(buildAuthorizerContextForServiceIntegration(cognitoAuth(), result)).toEqual({
+      claims: {},
+    });
+  });
+
+  it('JWT: nests claims under `jwt.claims.X` with empty `jwt.scopes`', () => {
+    const result: CachedAuthorizerResult = {
+      allow: true,
+      context: { sub: 'user-42', email: 'a@example.com' },
+    };
+    expect(buildAuthorizerContextForServiceIntegration(jwtAuth(), result)).toEqual({
+      jwt: {
+        claims: { sub: 'user-42', email: 'a@example.com' },
+        scopes: [],
+      },
+    });
+  });
+});
+
+/**
+ * End-to-end tests for Lambda Function URL `AuthType: 'AWS_IAM'`
+ * (issue #621). The infrastructure for SigV4 verification shipped in
+ * PR #447 for REST v1; this issue wires Function URL routes through the
+ * same `IamAuthorizer` plumbing so they share the verifier rather than
+ * being rejected at boot.
+ *
+ * Tests boot a real `node:http` server with a Function URL route
+ * (v2-shaped) carrying an IAM authorizer, then exercise three
+ * end-to-end shapes: valid SigV4 (200), missing Authorization header
+ * (403), and tampered signature (403). The 403 status (vs API Gateway
+ * v2's default 401) matches Lambda's deployed Function URL IAM response.
+ */
+function signFunctionUrlRequest(opts: {
+  method: string;
+  path: string;
+  query?: string;
+  headers: Record<string, string>;
+  body?: Buffer;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  amzDate: string;
+  /**
+   * Service name embedded in the SigV4 credential scope. AWS SDK clients
+   * use `service=lambda` when signing Function URL requests, but the
+   * verifier does NOT pin the service name — it only checks the
+   * access-key-id matches the dev's local creds and the canonical-request
+   * hash matches. Tests pass `service: 'execute-api'` (or other non-
+   * `'lambda'` values) to lock down that "service name is informational"
+   * contract. Defaults to `'lambda'` for backward compatibility.
+   */
+  service?: string;
+}): { authorization: string; headers: Record<string, string> } {
+  const headers = { ...opts.headers };
+  if (!headers['x-amz-date']) headers['x-amz-date'] = opts.amzDate;
+  const body = opts.body ?? Buffer.alloc(0);
+  const payloadHash = createHash('sha256').update(body).digest('hex');
+
+  const signedHeaderNames = Object.keys(headers)
+    .map((h) => h.toLowerCase())
+    .sort();
+  const headerLines = signedHeaderNames
+    .map((h) => `${h}:${headers[h]!.trim().replace(/\s+/g, ' ')}\n`)
+    .join('');
+  const canonicalQuery = opts.query ? canonicalizeQueryString(opts.query) : '';
+  const canonicalUri = canonicalizePath(opts.path);
+
+  const canonicalRequest = [
+    opts.method.toUpperCase(),
+    canonicalUri,
+    canonicalQuery,
+    headerLines,
+    signedHeaderNames.join(';'),
+    payloadHash,
+  ].join('\n');
+
+  const date = opts.amzDate.slice(0, 8);
+  // Function URL uses service=lambda when signed by an AWS SDK client;
+  // the verifier only checks the access-key-id matches the dev's local
+  // creds and the canonical-request hash matches, so the service name
+  // in the credential scope is not load-bearing for the verify step.
+  const service = opts.service ?? 'lambda';
+  const credentialScope = `${date}/${opts.region}/${service}/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    opts.amzDate,
+    credentialScope,
+    createHash('sha256').update(canonicalRequest, 'utf8').digest('hex'),
+  ].join('\n');
+
+  const kDate = createHmac('sha256', `AWS4${opts.secretAccessKey}`).update(date).digest();
+  const kRegion = createHmac('sha256', kDate).update(opts.region).digest();
+  const kService = createHmac('sha256', kRegion).update(service).digest();
+  const kSigning = createHmac('sha256', kService).update('aws4_request').digest();
+  const signature = createHmac('sha256', kSigning).update(stringToSign, 'utf8').digest('hex');
+
+  const authorization =
+    `AWS4-HMAC-SHA256 Credential=${opts.accessKeyId}/${credentialScope}, ` +
+    `SignedHeaders=${signedHeaderNames.join(';')}, Signature=${signature}`;
+  return { authorization, headers };
+}
+
+function nowAmzDate(): string {
+  // YYYYMMDDTHHmmssZ — what AWS SDKs put in `x-amz-date`. Use the
+  // current clock so the verifier's 15-min skew check passes against
+  // the real wall clock that `startApiServer` reads (the http-server
+  // does NOT pass a `now` override to `verifySigV4`).
+  const d = new Date();
+  const yyyy = d.getUTCFullYear().toString().padStart(4, '0');
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const dd = d.getUTCDate().toString().padStart(2, '0');
+  const hh = d.getUTCHours().toString().padStart(2, '0');
+  const mi = d.getUTCMinutes().toString().padStart(2, '0');
+  const ss = d.getUTCSeconds().toString().padStart(2, '0');
+  return `${yyyy}${mm}${dd}T${hh}${mi}${ss}Z`;
+}
+
+function stubCredentialsLoader(creds: ResolvedCredentials): CredentialsLoader {
+  return async () => creds;
+}
+
+function functionUrlIamRoute(): RouteWithAuth {
+  return {
+    route: {
+      method: 'ANY',
+      pathPattern: '/{proxy+}',
+      lambdaLogicalId: 'HandlerFn',
+      source: 'function-url',
+      apiVersion: 'v2',
+      stage: '$default',
+      apiStackName: 'S',
+      declaredAt: 'S/Url',
+      invokeMode: 'BUFFERED',
+    },
+    authorizer: {
+      kind: 'iam',
+      logicalId: 'AWS_IAM',
+      declaredAt: 'S/Url',
+    },
+  };
+}
+
+describe('startApiServer — Function URL AWS_IAM (#621)', () => {
+  const accessKeyId = 'AKIDEXAMPLE';
+  const secretAccessKey = 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY';
+
+  beforeEach(() => {
+    invokeRieMock.mockReset();
+  });
+
+  it('valid SigV4 → 200 (request reaches the Lambda handler)', async () => {
+    invokeRieMock.mockImplementation(async () => ({
+      raw: '',
+      payload: { statusCode: 200, body: 'ok' },
+    }));
+    const route = functionUrlIamRoute();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      sigV4CredentialsLoader: stubCredentialsLoader({ accessKeyId, secretAccessKey }),
+    });
+    try {
+      const path = '/items/42';
+      const amzDate = nowAmzDate();
+      const { authorization, headers } = signFunctionUrlRequest({
+        method: 'GET',
+        path,
+        // The verifier rebuilds the canonical request from the request
+        // signed-header list. The Host header at the client side is
+        // `127.0.0.1:<port>`; signing it here keeps the hashes aligned.
+        headers: { host: `${server.host}:${server.port}` },
+        accessKeyId,
+        secretAccessKey,
+        region: 'us-east-1',
+        amzDate,
+      });
+      const r = await fetch(`http://${server.host}:${server.port}${path}`, {
+        headers: { authorization, ...headers },
+      });
+      expect(r.status).toBe(200);
+      expect(invokeRieMock).toHaveBeenCalledTimes(1);
+      // Function URL + AWS_IAM does NOT emit a `buildOverlay` block —
+      // AWS-deployed Function URLs write principal context under
+      // `event.requestContext.authorizer.iam.{accessKey, accountId, ...}`,
+      // NOT `.lambda`. cdk-local has no local IAM data plane to synthesize
+      // the `.iam` block, so the safest answer is no overlay at all:
+      // the base v2 event's `authorizer: null` survives intact (PR body
+      // honors this with "no Function URL identity context" out-of-scope).
+      // A regression that wrote principalId under `.lambda.principalId`
+      // would mislead handlers that defensive-read `.iam ?? {}` — this
+      // assertion catches it.
+      const passedEvent = invokeRieMock.mock.calls[0]?.[2] as
+        | { requestContext?: { authorizer?: Record<string, unknown> | null } }
+        | undefined;
+      expect(passedEvent?.requestContext?.authorizer).toBeNull();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('missing Authorization header → 403 Forbidden (no Lambda invoke)', async () => {
+    const route = functionUrlIamRoute();
+    const pool = makePool();
+    const server = await startApiServer({
+      state: { routes: [route], pool, corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      sigV4CredentialsLoader: stubCredentialsLoader({ accessKeyId, secretAccessKey }),
+    });
+    try {
+      const r = await fetch(`http://${server.host}:${server.port}/items/42`);
+      expect(r.status).toBe(403);
+      const body = (await r.json()) as { Message: string };
+      expect(body.Message).toBe('Forbidden');
+      expect(invokeRieMock).not.toHaveBeenCalled();
+      expect((pool.acquire as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('tampered signature → 403 Forbidden (no Lambda invoke)', async () => {
+    const route = functionUrlIamRoute();
+    const pool = makePool();
+    const server = await startApiServer({
+      state: { routes: [route], pool, corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      sigV4CredentialsLoader: stubCredentialsLoader({ accessKeyId, secretAccessKey }),
+    });
+    try {
+      const path = '/items/42';
+      const amzDate = nowAmzDate();
+      const { authorization, headers } = signFunctionUrlRequest({
+        method: 'GET',
+        path,
+        headers: { host: `${server.host}:${server.port}` },
+        accessKeyId,
+        secretAccessKey,
+        region: 'us-east-1',
+        amzDate,
+      });
+      // Flip one hex character in the signature so the verifier rejects.
+      const tampered = authorization.replace(/Signature=([0-9a-f])/, (_m, c: string) =>
+        `Signature=${c === '0' ? '1' : '0'}`
+      );
+      const r = await fetch(`http://${server.host}:${server.port}${path}`, {
+        headers: { authorization: tampered, ...headers },
+      });
+      expect(r.status).toBe(403);
+      const body = (await r.json()) as { Message: string };
+      expect(body.Message).toBe('Forbidden');
+      expect(invokeRieMock).not.toHaveBeenCalled();
+      expect((pool.acquire as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  // Locks down the verifier's documented "service name in the credential
+  // scope is informational, not load-bearing" contract (#626). The signer
+  // that AWS SDK clients use for Function URLs sets `service=lambda`, but
+  // curl `--aws-sigv4` and other dev tooling routinely sign with off-
+  // service values (e.g. `service=execute-api`). The verifier reconstructs
+  // the canonical request from the same `(date, region, service)` scope
+  // the request itself carries — it does NOT pin `service` to any
+  // particular value — so a request signed with `service=execute-api`
+  // must reach the Lambda handler the same way `service=lambda` does. A
+  // future verifier change that silently starts pinning service would
+  // flip this test from green to red.
+  it('valid SigV4 with off-service credential scope (execute-api) → 200', async () => {
+    invokeRieMock.mockImplementation(async () => ({
+      raw: '',
+      payload: { statusCode: 200, body: 'ok' },
+    }));
+    const route = functionUrlIamRoute();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      sigV4CredentialsLoader: stubCredentialsLoader({ accessKeyId, secretAccessKey }),
+    });
+    try {
+      const path = '/items/42';
+      const amzDate = nowAmzDate();
+      const { authorization, headers } = signFunctionUrlRequest({
+        method: 'GET',
+        path,
+        headers: { host: `${server.host}:${server.port}` },
+        accessKeyId,
+        secretAccessKey,
+        region: 'us-east-1',
+        amzDate,
+        // Deliberately NOT 'lambda' — locks down the "service is
+        // informational" contract documented in #626.
+        service: 'execute-api',
+      });
+      const r = await fetch(`http://${server.host}:${server.port}${path}`, {
+        headers: { authorization, ...headers },
+      });
+      expect(r.status).toBe(200);
+      expect(invokeRieMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/tests/unit/local/sigv4-verify.test.ts
+++ b/tests/unit/local/sigv4-verify.test.ts
@@ -5,6 +5,7 @@ import {
   type ResolvedCredentials,
 } from '../../../src/local/sigv4-verify.js';
 import { getLogger } from '../../../src/utils/logger.js';
+import { setEmbedConfig, resetEmbedConfig } from '../../../src/local/embed-config.js';
 
 const NOW = new Date('2026-01-01T00:00:00Z');
 
@@ -154,6 +155,47 @@ describe('verifySigV4 — warn-and-pass default + --strict-sigv4 opt-in', () => 
       now: () => NOW,
     });
     expect(result.allow).toBe(false);
+    warn.restore();
+  });
+});
+
+describe('verifySigV4 — embedConfig-driven flag polarity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // The strictness-flag wording is sourced from the active embed config, so
+    // any test that overrides it MUST restore cdk-local's defaults — otherwise
+    // a later test asserting `--strict-sigv4` would see the host flag leak.
+    resetEmbedConfig();
+  });
+
+  it('renders the host opt-OUT flag in the foreign-id DENY message when sigV4StrictByDefault is set', async () => {
+    // A host like cdkd that fails-closed by default passes its own opt-OUT
+    // flag. The deny-path advice must read in the host's polarity: name the
+    // host flag, never cdk-local's opt-IN `--strict-sigv4`.
+    setEmbedConfig({ sigV4StrictByDefault: true, sigV4OptFlag: '--allow-unverified-sigv4' });
+    const warn = spyWarn();
+    const result = await verifySigV4(makeRequest('AKIAFOREIGN'), loadLocal, {
+      strict: true,
+      now: () => NOW,
+    });
+    expect(result.allow).toBe(false);
+    const warns = warn.calls().join('\n');
+    expect(warns).toContain('--allow-unverified-sigv4');
+    expect(warns).not.toContain('--strict-sigv4');
+    warn.restore();
+  });
+
+  it('renders the host opt-OUT flag in the no-creds DENY message when sigV4StrictByDefault is set', async () => {
+    setEmbedConfig({ sigV4StrictByDefault: true, sigV4OptFlag: '--allow-unverified-sigv4' });
+    const warn = spyWarn();
+    const result = await verifySigV4(makeRequest('AKIAFOREIGN'), loadThrows, {
+      strict: true,
+      now: () => NOW,
+    });
+    expect(result.allow).toBe(false);
+    const warns = warn.calls().join('\n');
+    expect(warns).toContain('--allow-unverified-sigv4');
+    expect(warns).not.toContain('--strict-sigv4');
     warn.restore();
   });
 });


### PR DESCRIPTION
## Summary

Unblocks a consuming host (cdkd) from shimming its `http-server` / `lambda-authorizer` / `authorizer-resolver` / `authorizer-context` / `sigv4-verify` modules while keeping its OWN AWS_IAM SigV4 default (cdkd ships fail-closed; cdk-local ships warn-and-pass).

**1. embedConfig SigV4 messaging parameterization.** Adds two optional `CdkLocalEmbedConfig` fields:
- `sigV4StrictByDefault` (default `false`) — flips the polarity of the SigV4 deny/pass warn-message advice. cdk-local's flag is opt-IN (`--strict-sigv4`); a fail-closed host's flag is opt-OUT.
- `sigV4OptFlag` (default `'--strict-sigv4'`) — substitutes the host's own strictness flag name into those messages.

The 4 flag-referencing `sigv4-verify.ts` warn messages (no-creds deny/pass, foreign-id deny/pass) are now polarity-aware. Under the cdk-local defaults they render **byte-for-byte identical** to before (existing `sigv4-verify` tests pass unchanged); a host setting `sigV4StrictByDefault: true` + `sigV4OptFlag: '--allow-unverified-sigv4'` gets correct opt-out wording. Message text only — the deny/pass decision is still driven by the `sigV4Strict` argument to `startApiServer`.

**2. Exports for shim consumers.** Exposes from the package entry the symbols cdkd's still-local `local-start-api.ts` imports from the soon-to-be-shimmed modules: `startApiServer` / `readMtlsMaterialsFromDisk` / `ServerState` / `StartedApiServer` / `MtlsServerConfig` (http-server); `attachAuthorizers` / `AuthorizerInfo` / `RouteWithAuth` (authorizer-resolver); `defaultCredentialsLoader` / `CredentialsLoader` (sigv4-verify); and `isFunctionUrlOacFronted` (cors-handler — was missing from index).

**3. Test coverage.** Ports the host-server + authorizer-context test suites cdk-local lacked (`http-server` + `-cors` / `-mtls` / `-service-integration-auth` variants, `authorizer-context`) and adds a polarity-message test. authorizer-resolver / lambda-authorizer / sigv4-verify already had coverage.

## Test plan

- [x] `vp run check` (84 files, 0 lint/type errors)
- [x] `vp run test` — 1132 tests pass (incl. ported suites + polarity test; existing sigv4 tests unchanged)
- [x] `vp run build` — all new symbols present in `dist/index.d.ts`
- [ ] Docker integ (`local-invoke`) for the `integ` gate
