### PR TITLE
feat(exports): expose file-watcher + watch-predicates + watch-config for watch-source shim consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -415,3 +415,21 @@ export {
  * translation in the shim provides.
  */
 export { LocalInvokeBuildError } from './utils/error-handler.js';
+
+/**
+ * `start-api --watch` source-tree file watcher + the watch-target predicates
+ * and `cdk.json` `watch` config resolution. `createFileWatcher` debounces
+ * chokidar events; `createWatchPredicates` derives the watch root + the
+ * `ignored` / `shouldTrigger` filters that exclude `cdk.out` / `node_modules` /
+ * `.git` and honor `cdk.json` `watch.include` / `watch.exclude`;
+ * `resolveWatchConfig` reads that block from the cwd's `cdk.json`. Exposed so a
+ * consuming host whose `start-api` command adopts the watch-source model can
+ * wire its watcher to the app SOURCE tree (re-synth on edit) the same way.
+ */
+export {
+  createFileWatcher,
+  type FileWatcher,
+  type FileWatcherOptions,
+} from './local/file-watcher.js';
+export { createWatchPredicates, type WatchPredicates } from './cli/commands/local-start-api.js';
+export { resolveWatchConfig, type CdkWatchConfig } from './cli/config-loader.js';


### PR DESCRIPTION
Exposes the symbols a consuming host (cdkd) needs to adopt cdk-local's `start-api --watch` watch-source model + shim its `file-watcher.ts`: `createFileWatcher` / `FileWatcher` / `FileWatcherOptions` (the debounced source-tree watcher), `createWatchPredicates` / `WatchPredicates` (watch-root + ignored/shouldTrigger filters that exclude cdk.out/node_modules/.git and honor cdk.json watch.include/exclude), and `resolveWatchConfig` / `CdkWatchConfig` (reads the cdk.json `watch` block from cwd). index-only re-exports; cdk-local already carries the file-watcher + watch-predicates unit tests. No runtime behavior change.

## Test plan
- [x] vp run check (84 files clean)
- [x] vp run test - 1148 pass
- [x] vp run build - all 6 new symbols in dist/index.d.ts
- [ ] Docker integ (local-invoke) for the integ gate