### PR TITLE
feat(picker): arrow-key bulk select, confirmation, kind-grouped multi-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cdkl start-api         # multi-select APIs to serve (→ selects all)
 
 ![cdkl invoke against a local sample CDK app — no AWS account, no deploy](assets/cdkl-invoke.gif)
 
-Omitting the target in an interactive terminal opens the picker automatically. `invoke` / `run-task` pick one; `start-service` / `start-api` open a multi-select that starts with **nothing** selected. In any multi-select, press space to toggle a row, → to select all, ← to clear all, and enter to confirm — then a Y/n confirmation runs before launch. Submitting with nothing selected just exits. For `start-api`, each selected API is served on its own port. (Outside a TTY, bare `start-api` still serves every API — see below.)
+Omitting the target in an interactive terminal opens the picker automatically. `invoke` / `run-task` pick one; `start-service` / `start-api` open a multi-select that starts with **nothing** selected. In any multi-select, press space to toggle a row, → to select all, ← to clear all, and enter to confirm — then a Y/n confirmation runs before launch (declining returns you to the picker with your selection kept). Submitting with nothing selected asks whether to exit. For `start-api`, each selected API is served on its own port. (Outside a TTY, bare `start-api` still serves every API — see below.)
 
 Outside a TTY — CI, pipes, redirected stdin — the picker can't run. `invoke` / `run-task` / `start-service` fall back to a "target required" error; pass the target explicitly there (see [below](#passing-a-target-explicitly)). `start-api` is the exception: bare in a non-TTY it serves **every** API (its serve-all default needs no prompt), so scripts keep working unchanged.
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ You almost never need to know or type a CDK path. In a terminal, just run the co
 cdkl invoke            # pick a Lambda, then invoke it
 cdkl run-task          # pick an ECS task definition, then run it
 cdkl start-service     # multi-select one or more ECS services
-cdkl start-api         # multi-select APIs to serve (Enter = all)
+cdkl start-api         # multi-select APIs to serve (→ selects all)
 ```
 
 ![cdkl invoke against a local sample CDK app — no AWS account, no deploy](assets/cdkl-invoke.gif)
 
-Omitting the target in an interactive terminal opens the picker automatically. `invoke` / `run-task` pick one; `start-service` / `start-api` open a multi-select. `start-api`'s multi-select starts with **every** discovered API pre-selected — press Enter to serve them all (its long-standing default) or deselect rows to serve a subset, each on its own port. (In any multi-select, press space to toggle a row, → to select all, ← to clear all, and enter to confirm.)
+Omitting the target in an interactive terminal opens the picker automatically. `invoke` / `run-task` pick one; `start-service` / `start-api` open a multi-select that starts with **nothing** selected. In any multi-select, press space to toggle a row, → to select all, ← to clear all, and enter to confirm — then a Y/n confirmation runs before launch. Submitting with nothing selected just exits. For `start-api`, each selected API is served on its own port. (Outside a TTY, bare `start-api` still serves every API — see below.)
 
 Outside a TTY — CI, pipes, redirected stdin — the picker can't run. `invoke` / `run-task` / `start-service` fall back to a "target required" error; pass the target explicitly there (see [below](#passing-a-target-explicitly)). `start-api` is the exception: bare in a non-TTY it serves **every** API (its serve-all default needs no prompt), so scripts keep working unchanged.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cdkl start-api         # multi-select APIs to serve (Enter = all)
 
 ![cdkl invoke against a local sample CDK app — no AWS account, no deploy](assets/cdkl-invoke.gif)
 
-Omitting the target in an interactive terminal opens the picker automatically. `invoke` / `run-task` pick one; `start-service` / `start-api` open a multi-select. `start-api`'s multi-select starts with **every** discovered API pre-selected — press Enter to serve them all (its long-standing default) or deselect rows to serve a subset, each on its own port. (In any multi-select, press space to toggle a row and enter to confirm.)
+Omitting the target in an interactive terminal opens the picker automatically. `invoke` / `run-task` pick one; `start-service` / `start-api` open a multi-select. `start-api`'s multi-select starts with **every** discovered API pre-selected — press Enter to serve them all (its long-standing default) or deselect rows to serve a subset, each on its own port. (In any multi-select, press space to toggle a row, → to select all, ← to clear all, and enter to confirm.)
 
 Outside a TTY — CI, pipes, redirected stdin — the picker can't run. `invoke` / `run-task` / `start-service` fall back to a "target required" error; pass the target explicitly there (see [below](#passing-a-target-explicitly)). `start-api` is the exception: bare in a non-TTY it serves **every** API (its serve-all default needs no prompt), so scripts keep working unchanged.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -55,11 +55,12 @@ one or more). The list is the same set `cdkl list` prints, so a Function
 URL appears under its backing Lambda. (There is no `-i` / `--interactive`
 flag — bare-in-a-TTY is the trigger.)
 
-`start-api`'s multi-select starts with **every** discovered API
-pre-selected, so a bare Enter serves them all (its long-standing default)
-and deselecting rows serves a subset — each selected API on its own port.
-In any multi-select, Space toggles the current row, `→` selects all, `←`
-clears all, and Enter confirms.
+The multi-select starts with **nothing** selected. Space toggles the
+current row, `→` selects all, `←` clears all, and Enter confirms — then a
+Y/n confirmation runs before launch. Submitting with nothing selected
+exits cleanly (so a stray Enter never launches anything). For `start-api`,
+each selected API is served on its own port; to serve them all, press `→`
+then Enter (or, outside a TTY, just run bare `start-api` — see below).
 Each API row is tagged with its surface kind — `REST API v1` /
 `HTTP API v2` / `Function URL` / `WebSocket` — so otherwise-similar
 surfaces are easy to tell apart. (The picker shows the CDK display path,
@@ -410,7 +411,7 @@ but reusing cdk-local's synthesis, asset, and route-discovery
 plumbing.
 
 ```bash
-cdkl start-api                              # TTY: multi-select APIs (Enter = all); non-TTY: serve all
+cdkl start-api                              # TTY: multi-select APIs (→ all); non-TTY: serve all
 cdkl start-api --port 3000                  # first API → 3000, second API → 3001, ...
 cdkl start-api MyAdminApi                   # serve one API (logical id; single-stack apps)
 cdkl start-api MyAdminApi MyPublicApi       # serve a SUBSET (each on its own port)
@@ -443,8 +444,8 @@ Port assignment:
 
 Pass one or more positional `<targets...>` to serve exactly that
 **subset** — the union of the named APIs, each on its own port. Omit them
-to serve every API (bare in a non-TTY) or to open the pre-selected-all
-multi-select (bare in a TTY). The same target syntax `cdkl invoke` /
+to serve every API (bare in a non-TTY) or to open the multi-select picker
+(bare in a TTY). The same target syntax `cdkl invoke` /
 `cdkl run-task` use applies to each identifier:
 
 1. **Bare logical id** — `MyHttpApi`. **Single-stack apps only**.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -57,8 +57,9 @@ flag — bare-in-a-TTY is the trigger.)
 
 The multi-select starts with **nothing** selected. Space toggles the
 current row, `→` selects all, `←` clears all, and Enter confirms — then a
-Y/n confirmation runs before launch. Submitting with nothing selected
-exits cleanly (so a stray Enter never launches anything). For `start-api`,
+Y/n confirmation runs before launch (declining returns to the picker with
+the selection kept). Submitting with nothing selected asks whether to exit
+(so a stray Enter never launches anything). For `start-api`,
 each selected API is served on its own port; to serve them all, press `→`
 then Enter (or, outside a TTY, just run bare `start-api` — see below).
 Each API row is tagged with its surface kind — `REST API v1` /

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -58,6 +58,8 @@ flag — bare-in-a-TTY is the trigger.)
 `start-api`'s multi-select starts with **every** discovered API
 pre-selected, so a bare Enter serves them all (its long-standing default)
 and deselecting rows serves a subset — each selected API on its own port.
+In any multi-select, Space toggles the current row, `→` selects all, `←`
+clears all, and Enter confirms.
 Each API row is tagged with its surface kind — `REST API v1` /
 `HTTP API v2` / `Function URL` / `WebSocket` — so otherwise-similar
 surfaces are easy to tell apart. (The picker shows the CDK display path,

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@aws-sdk/client-sqs": "^3.0.0",
     "@aws-sdk/client-ssm": "^3.1017.0",
     "@aws-sdk/client-sts": "^3.1016.0",
+    "@clack/core": "^1.3.1",
     "@clack/prompts": "^1.4.0",
     "chokidar": "^5.0.0",
     "commander": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@aws-sdk/client-sts':
         specifier: ^3.1016.0
         version: 3.1053.0
+      '@clack/core':
+        specifier: ^1.3.1
+        version: 1.3.1
       '@clack/prompts':
         specifier: ^1.4.0
         version: 1.4.0

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -435,7 +435,7 @@ async function localStartApiCommand(
           `No APIs found in this CDK app to choose from. Run \`${getEmbedConfig().cliName} list\` to see what is available.`
         );
       }
-      const picked = await pickManyTargets('Select APIs to serve', apis, { preselectAll: true });
+      const picked = await pickManyTargets('Select APIs to serve', apis);
       apiFilters = picked;
       effectiveTargets = picked;
       interactivePicked.value = true;

--- a/src/local/target-lister.ts
+++ b/src/local/target-lister.ts
@@ -168,17 +168,35 @@ function listApiSurfaces(stacks: readonly StackInfo[]): TargetEntry[] {
 export function listTargets(stacks: readonly StackInfo[]): TargetListing {
   return {
     lambdas: sortEntries(scanByType(stacks, 'AWS::Lambda::Function')),
-    apis: sortEntries(listApiSurfaces(stacks)),
+    apis: sortApiEntries(listApiSurfaces(stacks)),
     ecsServices: sortEntries(scanByType(stacks, 'AWS::ECS::Service')),
     ecsTaskDefinitions: sortEntries(scanByType(stacks, 'AWS::ECS::TaskDefinition')),
   };
 }
 
+const pathOf = (e: TargetEntry): string => e.displayPath ?? e.qualifiedId;
+
 /** Stable, human-readable ordering: by display path, falling back to the qualified ID. */
 function sortEntries(entries: TargetEntry[]): TargetEntry[] {
-  return [...entries].sort((a, b) =>
-    (a.displayPath ?? a.qualifiedId).localeCompare(b.displayPath ?? b.qualifiedId)
-  );
+  return [...entries].sort((a, b) => pathOf(a).localeCompare(pathOf(b)));
+}
+
+/** Display order for API surface kinds; entries are grouped in this order. */
+const API_KIND_ORDER = ['HTTP API v2', 'REST API v1', 'Function URL', 'WebSocket'];
+
+/**
+ * Group API surfaces by kind (in {@link API_KIND_ORDER}), then sort by display
+ * path within each kind — so the `cdkl list` output and the interactive picker
+ * present REST / HTTP / Function URL / WebSocket as readable blocks. Exported
+ * for unit testing.
+ */
+export function sortApiEntries(entries: TargetEntry[]): TargetEntry[] {
+  return [...entries].sort((a, b) => {
+    const ka = API_KIND_ORDER.indexOf(a.kind ?? '');
+    const kb = API_KIND_ORDER.indexOf(b.kind ?? '');
+    if (ka !== kb) return ka - kb;
+    return pathOf(a).localeCompare(pathOf(b));
+  });
 }
 
 /** Total number of targets across every category. */

--- a/src/local/target-lister.ts
+++ b/src/local/target-lister.ts
@@ -185,13 +185,14 @@ function sortEntries(entries: TargetEntry[]): TargetEntry[] {
 const API_KIND_ORDER = ['HTTP API v2', 'REST API v1', 'Function URL', 'WebSocket'];
 
 /**
- * Group API surfaces by kind (in {@link API_KIND_ORDER}), then sort by display
- * path within each kind — so the `cdkl list` output and the interactive picker
- * present REST / HTTP / Function URL / WebSocket as readable blocks. Exported
- * for unit testing.
+ * Order API surfaces by stack, then kind (in {@link API_KIND_ORDER}), then
+ * display path — so a multi-stack app shows each stack's APIs as a block,
+ * grouped by kind inside it (single-stack apps are simply kind-grouped). Used
+ * by both `cdkl list` and the interactive picker. Exported for unit testing.
  */
 export function sortApiEntries(entries: TargetEntry[]): TargetEntry[] {
   return [...entries].sort((a, b) => {
+    if (a.stackName !== b.stackName) return a.stackName.localeCompare(b.stackName);
     const ka = API_KIND_ORDER.indexOf(a.kind ?? '');
     const kb = API_KIND_ORDER.indexOf(b.kind ?? '');
     if (ka !== kb) return ka - kb;

--- a/src/local/target-picker.ts
+++ b/src/local/target-picker.ts
@@ -103,59 +103,77 @@ function kindTags(opts: PickerOption[]): string[] {
 export async function pickManyTargets(message: string, entries: TargetEntry[]): Promise<string[]> {
   const opts: PickerOption[] = entries.map(toOption);
   const tags = kindTags(opts);
+  // `[kind] label` per value, for the confirmation bullet list.
+  const displayByValue = new Map(
+    opts.map((o) => [o.value, o.hint ? `[${o.hint}] ${o.label}` : o.label])
+  );
 
-  const prompt = new MultiSelectPrompt<PickerOption>({
-    options: opts,
-    // Allow an empty submit — handled below as "exit", rather than clack's
-    // built-in "select at least one" error, which the user found confusing.
-    required: false,
-    render() {
-      const header = `${S_BAR_START}  ${message}`;
-      if (this.state === 'submit' || this.state === 'cancel') {
-        const n = (this.value ?? []).length;
-        return `${header}\n${S_BAR}  ${`${n} selected`}`;
-      }
-      const selected = new Set(this.value ?? []);
-      const rows = this.options.map((opt, i) => {
-        const isActive = i === this.cursor;
-        const isSelected = selected.has(opt.value);
-        const box = isSelected
-          ? S_CHECKBOX_SELECTED
-          : isActive
-            ? S_CHECKBOX_ACTIVE
-            : S_CHECKBOX_INACTIVE;
-        // Whole row coloured by state: active = cyan, selected = green,
-        // otherwise plain (the terminal's default fg — never dim/grey, which
-        // is hard to read). The `[kind]` tag follows the row's colour.
-        const text = `${tags[i]}${opt.label}`;
-        const coloured = isActive ? ANSI.cyan(text) : isSelected ? ANSI.green(text) : text;
-        return `${S_BAR}  ${box} ${coloured}`;
-      });
-      const keys = ANSI.dim('space toggle · → all · ← none · enter confirm');
-      return `${header}\n${rows.join('\n')}\n${S_BAR}  ${keys}\n${S_BAR_END}`;
-    },
-  });
+  // Loop so that declining the confirmation returns to the picker with the
+  // current selection preserved (via `initialValues`).
+  let initialValues: string[] = [];
+  for (;;) {
+    const prompt = new MultiSelectPrompt<PickerOption>({
+      options: opts,
+      // Allow an empty submit — handled below (confirm "exit?"), rather than
+      // clack's built-in "select at least one" error.
+      required: false,
+      ...(initialValues.length > 0 ? { initialValues } : {}),
+      render() {
+        if (this.state === 'submit' || this.state === 'cancel') {
+          return `${S_BAR_START}  ${message}\n${S_BAR}  ${(this.value ?? []).length} selected`;
+        }
+        // Key hints live on the message line, `action: key` form, `|`-separated.
+        const header = `${S_BAR_START}  ${message} (toggle: space | all: → | none: ← | confirm: enter)`;
+        const selected = new Set(this.value ?? []);
+        const rows = this.options.map((opt, i) => {
+          const isActive = i === this.cursor;
+          const isSelected = selected.has(opt.value);
+          // Checked box is green (matching the confirm prompt's check colour);
+          // the cursor row's box is cyan; otherwise the default checkbox.
+          const box = isSelected
+            ? ANSI.green(S_CHECKBOX_SELECTED)
+            : isActive
+              ? ANSI.cyan(S_CHECKBOX_ACTIVE)
+              : S_CHECKBOX_INACTIVE;
+          // Row text: active = cyan, selected = green, otherwise the default
+          // fg (white) — never dim/grey, which is hard to read. The `[kind]`
+          // tag follows the row's colour.
+          const text = `${tags[i]}${opt.label}`;
+          const coloured = isActive ? ANSI.cyan(text) : isSelected ? ANSI.green(text) : text;
+          return `${S_BAR}  ${box} ${coloured}`;
+        });
+        return `${header}\n${rows.join('\n')}\n${S_BAR_END}`;
+      },
+    });
 
-  // Right selects every row; Left clears. MultiSelectPrompt uses Up/Down for
-  // the cursor and Space to toggle, so Left/Right are free. Setting
-  // `prompt.value` is exactly how the built-in toggleAll works; the prompt
-  // re-renders after each keypress.
-  prompt.on('key', (_char, info) => {
-    if (info?.name === 'right') prompt.value = bulkSelectValues(opts, 'all');
-    else if (info?.name === 'left') prompt.value = bulkSelectValues(opts, 'none');
-  });
+    // Right selects every row; Left clears. MultiSelectPrompt uses Up/Down for
+    // the cursor and Space to toggle, so Left/Right are free. Setting
+    // `prompt.value` is exactly how the built-in toggleAll works; the prompt
+    // re-renders after each keypress.
+    prompt.on('key', (_char, info) => {
+      if (info?.name === 'right') prompt.value = bulkSelectValues(opts, 'all');
+      else if (info?.name === 'left') prompt.value = bulkSelectValues(opts, 'none');
+    });
 
-  const picked = await prompt.prompt();
-  if (isCancel(picked)) throw new TargetSelectionCancelledError();
-  const values = (picked as string[] | undefined) ?? [];
-  // Nothing selected -> exit cleanly instead of doing something surprising.
-  if (values.length === 0) throw new TargetSelectionCancelledError();
+    const picked = await prompt.prompt();
+    if (isCancel(picked)) throw new TargetSelectionCancelledError();
+    const values = (picked as string[] | undefined) ?? [];
 
-  // Confirmation step before committing to the (possibly large) run.
-  const summary = values.length === 1 ? '1 target' : `${values.length} targets`;
-  const ok = await confirm({ message: `Run ${summary}?` });
-  if (isCancel(ok) || ok !== true) throw new TargetSelectionCancelledError();
-  return values;
+    if (values.length === 0) {
+      const exit = await confirm({ message: 'Nothing selected. Exit without running anything?' });
+      if (isCancel(exit)) throw new TargetSelectionCancelledError();
+      if (exit === true) throw new TargetSelectionCancelledError();
+      initialValues = [];
+      continue; // back to the picker
+    }
+
+    const bullets = values.map((v) => `  • ${displayByValue.get(v) ?? v}`).join('\n');
+    const noun = values.length === 1 ? 'this target' : `these ${values.length} targets`;
+    const ok = await confirm({ message: `Run ${noun}?\n${bullets}` });
+    if (isCancel(ok)) throw new TargetSelectionCancelledError();
+    if (ok === true) return values;
+    initialValues = values; // declined -> back to the picker, selection kept
+  }
 }
 
 interface ResolveParams {

--- a/src/local/target-picker.ts
+++ b/src/local/target-picker.ts
@@ -22,7 +22,6 @@ import type { TargetEntry } from './target-lister.js';
 // logger uses raw escapes too). Kept local to the picker render.
 const ANSI = {
   cyan: (s: string): string => `\x1b[36m${s}\x1b[0m`,
-  dim: (s: string): string => `\x1b[2m${s}\x1b[0m`,
   green: (s: string): string => `\x1b[32m${s}\x1b[0m`,
 };
 
@@ -146,13 +145,15 @@ export async function pickManyTargets(message: string, entries: TargetEntry[]): 
       },
     });
 
-    // Right selects every row; Left clears. MultiSelectPrompt uses Up/Down for
-    // the cursor and Space to toggle, so Left/Right are free. Setting
-    // `prompt.value` is exactly how the built-in toggleAll works; the prompt
-    // re-renders after each keypress.
+    // Right selects every row; Left clears. Setting `prompt.value` is exactly
+    // how the built-in `toggleAll` works; the prompt re-renders after each
+    // keypress. Note: MultiSelectPrompt ALSO maps Left/Right onto its cursor
+    // (as Up/Down) and that fires before this handler, so after a bulk change
+    // we pin the cursor to the top for a stable, predictable position.
     prompt.on('key', (_char, info) => {
-      if (info?.name === 'right') prompt.value = bulkSelectValues(opts, 'all');
-      else if (info?.name === 'left') prompt.value = bulkSelectValues(opts, 'none');
+      if (info?.name !== 'right' && info?.name !== 'left') return;
+      prompt.value = bulkSelectValues(opts, info.name === 'right' ? 'all' : 'none');
+      prompt.cursor = 0;
     });
 
     const picked = await prompt.prompt();

--- a/src/local/target-picker.ts
+++ b/src/local/target-picker.ts
@@ -1,5 +1,6 @@
 import { MultiSelectPrompt } from '@clack/core';
 import {
+  confirm,
   isCancel,
   select,
   S_BAR,
@@ -74,10 +75,18 @@ export function bulkSelectValues(options: PickerOption[], action: 'all' | 'none'
   return action === 'all' ? options.map((o) => o.value) : [];
 }
 
+/** Pre-compute the aligned `[kind] ` tag per option (blank when no kind). */
+function kindTags(opts: PickerOption[]): string[] {
+  const raw = opts.map((o) => (o.hint ? `[${o.hint}] ` : ''));
+  const width = Math.max(0, ...raw.map((t) => t.length));
+  return raw.map((t) => t.padEnd(width));
+}
+
 /**
- * Prompt for one or more targets (at least one required). Caller must
- * have already confirmed a TTY and a non-empty `entries`. Throws
- * {@link TargetSelectionCancelledError} on Ctrl+C / Esc.
+ * Prompt for one or more targets. Caller must have already confirmed a TTY
+ * and a non-empty `entries`. Throws {@link TargetSelectionCancelledError}
+ * on Ctrl+C / Esc, on an empty selection (the user chose nothing), or when
+ * the confirmation step is declined.
  *
  * Built on `@clack/core`'s `MultiSelectPrompt` (rather than the high-level
  * `multiselect`) so it can add bulk-selection keys the high-level wrapper
@@ -86,27 +95,25 @@ export function bulkSelectValues(options: PickerOption[], action: 'all' | 'none'
  * selection in `this.value`, so the Right/Left handlers set it directly —
  * the same mechanism the built-in `toggleAll` uses.
  *
- * When `preselectAll` is true, every row starts selected so a bare Enter
- * confirms the whole set — used by `start-api`, whose long-standing default
- * is "serve every discovered API". The user clears (Left) or deselects rows
- * to serve a subset.
+ * Rows start UNSELECTED. Each row is prefixed with its surface kind
+ * (`[HTTP API v2] MyApi`) — always shown, padded so labels align. Submitting
+ * with nothing selected exits cleanly; a non-empty selection goes through a
+ * Y/n confirmation before returning.
  */
-export async function pickManyTargets(
-  message: string,
-  entries: TargetEntry[],
-  options: { preselectAll?: boolean } = {}
-): Promise<string[]> {
+export async function pickManyTargets(message: string, entries: TargetEntry[]): Promise<string[]> {
   const opts: PickerOption[] = entries.map(toOption);
+  const tags = kindTags(opts);
 
   const prompt = new MultiSelectPrompt<PickerOption>({
     options: opts,
-    required: true,
-    ...(options.preselectAll ? { initialValues: bulkSelectValues(opts, 'all') } : {}),
+    // Allow an empty submit — handled below as "exit", rather than clack's
+    // built-in "select at least one" error, which the user found confusing.
+    required: false,
     render() {
       const header = `${S_BAR_START}  ${message}`;
       if (this.state === 'submit' || this.state === 'cancel') {
         const n = (this.value ?? []).length;
-        return `${header}\n${S_BAR}  ${ANSI.dim(`${n} selected`)}`;
+        return `${header}\n${S_BAR}  ${`${n} selected`}`;
       }
       const selected = new Set(this.value ?? []);
       const rows = this.options.map((opt, i) => {
@@ -117,13 +124,12 @@ export async function pickManyTargets(
           : isActive
             ? S_CHECKBOX_ACTIVE
             : S_CHECKBOX_INACTIVE;
-        const label = isActive
-          ? ANSI.cyan(opt.label)
-          : isSelected
-            ? ANSI.green(opt.label)
-            : ANSI.dim(opt.label);
-        const hint = opt.hint && isActive ? ANSI.dim(` (${opt.hint})`) : '';
-        return `${S_BAR}  ${box} ${label}${hint}`;
+        // Whole row coloured by state: active = cyan, selected = green,
+        // otherwise plain (the terminal's default fg — never dim/grey, which
+        // is hard to read). The `[kind]` tag follows the row's colour.
+        const text = `${tags[i]}${opt.label}`;
+        const coloured = isActive ? ANSI.cyan(text) : isSelected ? ANSI.green(text) : text;
+        return `${S_BAR}  ${box} ${coloured}`;
       });
       const keys = ANSI.dim('space toggle · → all · ← none · enter confirm');
       return `${header}\n${rows.join('\n')}\n${S_BAR}  ${keys}\n${S_BAR_END}`;
@@ -139,9 +145,17 @@ export async function pickManyTargets(
     else if (info?.name === 'left') prompt.value = bulkSelectValues(opts, 'none');
   });
 
-  const result = await prompt.prompt();
-  if (isCancel(result)) throw new TargetSelectionCancelledError();
-  return result as string[];
+  const picked = await prompt.prompt();
+  if (isCancel(picked)) throw new TargetSelectionCancelledError();
+  const values = (picked as string[] | undefined) ?? [];
+  // Nothing selected -> exit cleanly instead of doing something surprising.
+  if (values.length === 0) throw new TargetSelectionCancelledError();
+
+  // Confirmation step before committing to the (possibly large) run.
+  const summary = values.length === 1 ? '1 target' : `${values.length} targets`;
+  const ok = await confirm({ message: `Run ${summary}?` });
+  if (isCancel(ok) || ok !== true) throw new TargetSelectionCancelledError();
+  return values;
 }
 
 interface ResolveParams {

--- a/src/local/target-picker.ts
+++ b/src/local/target-picker.ts
@@ -1,4 +1,14 @@
-import { isCancel, multiselect, select } from '@clack/prompts';
+import { MultiSelectPrompt } from '@clack/core';
+import {
+  isCancel,
+  select,
+  S_BAR,
+  S_BAR_END,
+  S_BAR_START,
+  S_CHECKBOX_ACTIVE,
+  S_CHECKBOX_INACTIVE,
+  S_CHECKBOX_SELECTED,
+} from '@clack/prompts';
 import {
   CdkLocalError,
   InteractiveTtyRequiredError,
@@ -6,6 +16,16 @@ import {
 } from '../utils/error-handler.js';
 import { getEmbedConfig } from './embed-config.js';
 import type { TargetEntry } from './target-lister.js';
+
+// Minimal raw-ANSI helpers (cdk-local has no color-lib dependency; the
+// logger uses raw escapes too). Kept local to the picker render.
+const ANSI = {
+  cyan: (s: string): string => `\x1b[36m${s}\x1b[0m`,
+  dim: (s: string): string => `\x1b[2m${s}\x1b[0m`,
+  green: (s: string): string => `\x1b[32m${s}\x1b[0m`,
+};
+
+type PickerOption = { value: string; label: string; hint?: string };
 
 /**
  * True when both stdin and stdout are TTYs — the precondition for any
@@ -46,33 +66,82 @@ export async function pickOneTarget(message: string, entries: TargetEntry[]): Pr
 }
 
 /**
+ * The selected-value array after a bulk action — `all` selects every
+ * option, `none` clears the selection. Pure (no prompt state) so the
+ * arrow-key bulk-select wiring is unit-testable without a TTY.
+ */
+export function bulkSelectValues(options: PickerOption[], action: 'all' | 'none'): string[] {
+  return action === 'all' ? options.map((o) => o.value) : [];
+}
+
+/**
  * Prompt for one or more targets (at least one required). Caller must
  * have already confirmed a TTY and a non-empty `entries`. Throws
  * {@link TargetSelectionCancelledError} on Ctrl+C / Esc.
  *
- * The key hint is baked into the message because multi-select's
- * space-to-toggle is not discoverable — users expect enter to pick the
- * highlighted row and miss that nothing is selected yet.
+ * Built on `@clack/core`'s `MultiSelectPrompt` (rather than the high-level
+ * `multiselect`) so it can add bulk-selection keys the high-level wrapper
+ * does not expose: Up/Down move, Space toggles, **Right selects all**,
+ * **Left clears all**, Enter confirms. `MultiSelectPrompt` tracks the
+ * selection in `this.value`, so the Right/Left handlers set it directly —
+ * the same mechanism the built-in `toggleAll` uses.
  *
- * When `preselectAll` is true, every row starts selected (via
- * `@clack/prompts` `initialValues`) so a bare Enter confirms the whole
- * set — used by `start-api`, whose long-standing default is "serve every
- * discovered API". The user deselects rows to serve a subset.
+ * When `preselectAll` is true, every row starts selected so a bare Enter
+ * confirms the whole set — used by `start-api`, whose long-standing default
+ * is "serve every discovered API". The user clears (Left) or deselects rows
+ * to serve a subset.
  */
 export async function pickManyTargets(
   message: string,
   entries: TargetEntry[],
   options: { preselectAll?: boolean } = {}
 ): Promise<string[]> {
-  const opts = entries.map(toOption);
-  const chosen = await multiselect({
-    message: `${message} (space to select, enter to confirm)`,
+  const opts: PickerOption[] = entries.map(toOption);
+
+  const prompt = new MultiSelectPrompt<PickerOption>({
     options: opts,
     required: true,
-    ...(options.preselectAll && { initialValues: opts.map((o) => o.value) }),
+    ...(options.preselectAll ? { initialValues: bulkSelectValues(opts, 'all') } : {}),
+    render() {
+      const header = `${S_BAR_START}  ${message}`;
+      if (this.state === 'submit' || this.state === 'cancel') {
+        const n = (this.value ?? []).length;
+        return `${header}\n${S_BAR}  ${ANSI.dim(`${n} selected`)}`;
+      }
+      const selected = new Set(this.value ?? []);
+      const rows = this.options.map((opt, i) => {
+        const isActive = i === this.cursor;
+        const isSelected = selected.has(opt.value);
+        const box = isSelected
+          ? S_CHECKBOX_SELECTED
+          : isActive
+            ? S_CHECKBOX_ACTIVE
+            : S_CHECKBOX_INACTIVE;
+        const label = isActive
+          ? ANSI.cyan(opt.label)
+          : isSelected
+            ? ANSI.green(opt.label)
+            : ANSI.dim(opt.label);
+        const hint = opt.hint && isActive ? ANSI.dim(` (${opt.hint})`) : '';
+        return `${S_BAR}  ${box} ${label}${hint}`;
+      });
+      const keys = ANSI.dim('space toggle · → all · ← none · enter confirm');
+      return `${header}\n${rows.join('\n')}\n${S_BAR}  ${keys}\n${S_BAR_END}`;
+    },
   });
-  if (isCancel(chosen)) throw new TargetSelectionCancelledError();
-  return chosen as string[];
+
+  // Right selects every row; Left clears. MultiSelectPrompt uses Up/Down for
+  // the cursor and Space to toggle, so Left/Right are free. Setting
+  // `prompt.value` is exactly how the built-in toggleAll works; the prompt
+  // re-renders after each keypress.
+  prompt.on('key', (_char, info) => {
+    if (info?.name === 'right') prompt.value = bulkSelectValues(opts, 'all');
+    else if (info?.name === 'left') prompt.value = bulkSelectValues(opts, 'none');
+  });
+
+  const result = await prompt.prompt();
+  if (isCancel(result)) throw new TargetSelectionCancelledError();
+  return result as string[];
 }
 
 interface ResolveParams {

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -1,8 +1,39 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
-import { countTargets, listTargets } from '../../../src/local/target-lister.js';
+import {
+  countTargets,
+  listTargets,
+  sortApiEntries,
+  type TargetEntry,
+} from '../../../src/local/target-lister.js';
 import { getLogger } from '../../../src/utils/logger.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+describe('sortApiEntries', () => {
+  it('groups by kind (HTTP -> REST -> Function URL -> WebSocket), then path within a kind', () => {
+    const e = (logicalId: string, kind: string): TargetEntry => ({
+      logicalId,
+      stackName: 'App',
+      qualifiedId: `App:${logicalId}`,
+      displayPath: `App/${logicalId}`,
+      kind,
+    });
+    const sorted = sortApiEntries([
+      e('OacUrl', 'Function URL'),
+      e('MyRest', 'REST API v1'),
+      e('IamUrl', 'Function URL'),
+      e('MyHttp', 'HTTP API v2'),
+      e('Ws', 'WebSocket'),
+    ]);
+    expect(sorted.map((x) => x.logicalId)).toEqual([
+      'MyHttp', // HTTP API v2
+      'MyRest', // REST API v1
+      'IamUrl', // Function URL, path-sorted (App/IamUrl < App/OacUrl)
+      'OacUrl',
+      'Ws', // WebSocket
+    ]);
+  });
+});
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -33,6 +33,29 @@ describe('sortApiEntries', () => {
       'Ws', // WebSocket
     ]);
   });
+
+  it('orders by stack first in a multi-stack app, then kind, then path', () => {
+    const e = (stackName: string, logicalId: string, kind: string): TargetEntry => ({
+      logicalId,
+      stackName,
+      qualifiedId: `${stackName}:${logicalId}`,
+      displayPath: `${stackName}/${logicalId}`,
+      kind,
+    });
+    const sorted = sortApiEntries([
+      e('Beta', 'BFn', 'Function URL'),
+      e('Alpha', 'AFn', 'Function URL'),
+      e('Beta', 'BHttp', 'HTTP API v2'),
+      e('Alpha', 'AHttp', 'HTTP API v2'),
+    ]);
+    // Alpha block (kind-grouped) first, then Beta block.
+    expect(sorted.map((x) => `${x.stackName}:${x.logicalId}`)).toEqual([
+      'Alpha:AHttp',
+      'Alpha:AFn',
+      'Beta:BHttp',
+      'Beta:BFn',
+    ]);
+  });
 });
 
 afterEach(() => {

--- a/tests/unit/local/target-picker.test.ts
+++ b/tests/unit/local/target-picker.test.ts
@@ -1,13 +1,63 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
-vi.mock('@clack/prompts', () => ({
-  select: vi.fn(),
-  multiselect: vi.fn(),
-  isCancel: vi.fn(() => false),
+interface MsInstance {
+  opts: {
+    options: { value: string; label: string; hint?: string }[];
+    initialValues?: string[];
+    required?: boolean;
+    render: () => string;
+  };
+  options: { value: string }[];
+  value: string[];
+  state: string;
+  cursor: number;
+  handlers: Record<string, (key: string | undefined, info: { name: string }) => void>;
+}
+
+const { msState } = vi.hoisted(() => ({
+  msState: { instances: [] as MsInstance[], result: undefined as unknown },
 }));
 
-import { isCancel, multiselect, select } from '@clack/prompts';
+// `pickManyTargets` builds a custom prompt on `@clack/core`'s
+// `MultiSelectPrompt`; mock it so we can assert the constructed options /
+// initialValues, drive the Right/Left key handlers, and smoke the render.
+vi.mock('@clack/core', () => ({
+  MultiSelectPrompt: class {
+    opts: MsInstance['opts'];
+    options: { value: string }[];
+    value: string[];
+    state = 'active';
+    cursor = 0;
+    handlers: MsInstance['handlers'] = {};
+    constructor(opts: MsInstance['opts']) {
+      this.opts = opts;
+      this.options = opts.options;
+      this.value = opts.initialValues ?? [];
+      msState.instances.push(this as unknown as MsInstance);
+    }
+    on(event: string, cb: (key: string | undefined, info: { name: string }) => void): void {
+      this.handlers[event] = cb;
+    }
+    prompt(): Promise<unknown> {
+      return Promise.resolve(msState.result);
+    }
+  },
+}));
+
+vi.mock('@clack/prompts', () => ({
+  select: vi.fn(),
+  isCancel: vi.fn(() => false),
+  S_BAR: '|',
+  S_BAR_START: 'T',
+  S_BAR_END: 'L',
+  S_CHECKBOX_ACTIVE: '>',
+  S_CHECKBOX_INACTIVE: 'o',
+  S_CHECKBOX_SELECTED: 'x',
+}));
+
+import { isCancel, select } from '@clack/prompts';
 import {
+  bulkSelectValues,
   isInteractive,
   pickManyTargets,
   pickOneTarget,
@@ -39,6 +89,8 @@ beforeEach(() => {
   origStdout = process.stdout.isTTY;
   vi.clearAllMocks();
   vi.mocked(isCancel).mockReturnValue(false);
+  msState.instances = [];
+  msState.result = undefined;
 });
 
 afterEach(() => {
@@ -82,45 +134,66 @@ describe('pickOneTarget', () => {
   });
 });
 
+describe('bulkSelectValues', () => {
+  it('returns every option value for "all" and an empty array for "none"', () => {
+    const opts = [{ value: 'a' }, { value: 'b' }] as { value: string }[];
+    expect(bulkSelectValues(opts as never, 'all')).toEqual(['a', 'b']);
+    expect(bulkSelectValues(opts as never, 'none')).toEqual([]);
+  });
+});
+
 describe('pickManyTargets', () => {
-  it('requires at least one selection and returns the chosen array', async () => {
-    vi.mocked(multiselect).mockResolvedValue(['S/A', 'S:B']);
+  it('builds the prompt with kind-hinted options and returns the chosen array', async () => {
+    msState.result = ['S/A', 'S:B'];
     const result = await pickManyTargets('Pick many', entries);
     expect(result).toEqual(['S/A', 'S:B']);
-    expect(multiselect).toHaveBeenCalledWith({
-      message: 'Pick many (space to select, enter to confirm)',
-      options: [
-        { value: 'S/A', label: 'S/A', hint: 'HTTP API v2' },
-        { value: 'S:B', label: 'S:B' },
-      ],
-      required: true,
-    });
+    const inst = msState.instances.at(-1)!;
+    expect(inst.opts.options).toEqual([
+      { value: 'S/A', label: 'S/A', hint: 'HTTP API v2' },
+      { value: 'S:B', label: 'S:B' },
+    ]);
+    expect(inst.opts.required).toBe(true);
+    expect(inst.opts.initialValues).toBeUndefined();
   });
 
   it('pre-selects every row via initialValues when preselectAll is set (Enter = all)', async () => {
-    vi.mocked(multiselect).mockResolvedValue(['S/A', 'S:B']);
-    const result = await pickManyTargets('Pick many', entries, { preselectAll: true });
-    expect(result).toEqual(['S/A', 'S:B']);
-    expect(multiselect).toHaveBeenCalledWith({
-      message: 'Pick many (space to select, enter to confirm)',
-      options: [
-        { value: 'S/A', label: 'S/A', hint: 'HTTP API v2' },
-        { value: 'S:B', label: 'S:B' },
-      ],
-      required: true,
-      initialValues: ['S/A', 'S:B'],
-    });
+    msState.result = ['S/A', 'S:B'];
+    await pickManyTargets('Pick many', entries, { preselectAll: true });
+    const inst = msState.instances.at(-1)!;
+    expect(inst.opts.initialValues).toEqual(['S/A', 'S:B']);
   });
 
-  it('omits initialValues when preselectAll is not set (no pre-selection)', async () => {
-    vi.mocked(multiselect).mockResolvedValue(['S/A']);
+  it('Right selects all and Left clears, via the key handler', async () => {
+    msState.result = ['S/A'];
     await pickManyTargets('Pick many', entries);
-    const callArg = vi.mocked(multiselect).mock.calls[0]?.[0] as { initialValues?: unknown };
-    expect(callArg.initialValues).toBeUndefined();
+    const inst = msState.instances.at(-1)!;
+    inst.value = [];
+    inst.handlers.key?.(undefined, { name: 'right' });
+    expect(inst.value).toEqual(['S/A', 'S:B']);
+    inst.handlers.key?.(undefined, { name: 'left' });
+    expect(inst.value).toEqual([]);
+  });
+
+  it('leaves the selection unchanged on other keys', async () => {
+    msState.result = ['S/A'];
+    await pickManyTargets('Pick many', entries);
+    const inst = msState.instances.at(-1)!;
+    inst.value = ['S/A'];
+    inst.handlers.key?.(undefined, { name: 'down' });
+    expect(inst.value).toEqual(['S/A']);
+  });
+
+  it('render returns a string in the active and submit states (smoke)', async () => {
+    msState.result = ['S/A'];
+    await pickManyTargets('Pick many', entries);
+    const inst = msState.instances.at(-1)!;
+    expect(typeof inst.opts.render.call(inst)).toBe('string');
+    inst.state = 'submit';
+    expect(typeof inst.opts.render.call(inst)).toBe('string');
   });
 
   it('throws TargetSelectionCancelledError on cancel', async () => {
-    vi.mocked(multiselect).mockResolvedValue(Symbol('cancel') as unknown as string[]);
+    msState.result = Symbol('cancel');
     vi.mocked(isCancel).mockReturnValue(true);
     await expect(pickManyTargets('Pick many', entries)).rejects.toBeInstanceOf(
       TargetSelectionCancelledError
@@ -203,12 +276,12 @@ describe('resolveMultiTarget', () => {
       onMissing,
     });
     expect(result).toEqual(['S/A', 'S:B']);
-    expect(multiselect).not.toHaveBeenCalled();
+    expect(msState.instances).toHaveLength(0);
   });
 
   it('multi-selects when omitted in a TTY', async () => {
     setTty(true);
-    vi.mocked(multiselect).mockResolvedValue(['S/A']);
+    msState.result = ['S/A'];
     const result = await resolveMultiTarget([], {
       entries,
       message: 'm',
@@ -216,7 +289,7 @@ describe('resolveMultiTarget', () => {
       onMissing,
     });
     expect(result).toEqual(['S/A']);
-    expect(multiselect).toHaveBeenCalledOnce();
+    expect(msState.instances).toHaveLength(1);
   });
 
   it('throws the onMissing error when omitted in a non-TTY', async () => {

--- a/tests/unit/local/target-picker.test.ts
+++ b/tests/unit/local/target-picker.test.ts
@@ -205,24 +205,30 @@ describe('pickManyTargets', () => {
     expect(msState.instances[1]!.opts.initialValues).toEqual(['S/A']);
   });
 
-  it('Right selects all and Left clears, via the key handler', async () => {
+  it('Right selects all and Left clears, pinning the cursor to the top', async () => {
     msState.results = [['S/A']];
     await pickManyTargets('Pick many', entries);
     const inst = msState.instances.at(-1)!;
     inst.value = [];
+    inst.cursor = 2;
     inst.handlers.key?.(undefined, { name: 'right' });
     expect(inst.value).toEqual(['S/A', 'S:B']);
+    expect(inst.cursor).toBe(0); // bulk op resets the cursor (arrows also move it)
+    inst.cursor = 2;
     inst.handlers.key?.(undefined, { name: 'left' });
     expect(inst.value).toEqual([]);
+    expect(inst.cursor).toBe(0);
   });
 
-  it('leaves the selection unchanged on other keys', async () => {
+  it('leaves the selection and cursor unchanged on other keys', async () => {
     msState.results = [['S/A']];
     await pickManyTargets('Pick many', entries);
     const inst = msState.instances.at(-1)!;
     inst.value = ['S/A'];
+    inst.cursor = 2;
     inst.handlers.key?.(undefined, { name: 'down' });
     expect(inst.value).toEqual(['S/A']);
+    expect(inst.cursor).toBe(2);
   });
 
   it('render returns a string in the active and submit states (smoke)', async () => {

--- a/tests/unit/local/target-picker.test.ts
+++ b/tests/unit/local/target-picker.test.ts
@@ -46,6 +46,7 @@ vi.mock('@clack/core', () => ({
 
 vi.mock('@clack/prompts', () => ({
   select: vi.fn(),
+  confirm: vi.fn(),
   isCancel: vi.fn(() => false),
   S_BAR: '|',
   S_BAR_START: 'T',
@@ -55,7 +56,7 @@ vi.mock('@clack/prompts', () => ({
   S_CHECKBOX_SELECTED: 'x',
 }));
 
-import { isCancel, select } from '@clack/prompts';
+import { confirm, isCancel, select } from '@clack/prompts';
 import {
   bulkSelectValues,
   isInteractive,
@@ -89,6 +90,7 @@ beforeEach(() => {
   origStdout = process.stdout.isTTY;
   vi.clearAllMocks();
   vi.mocked(isCancel).mockReturnValue(false);
+  vi.mocked(confirm).mockResolvedValue(true);
   msState.instances = [];
   msState.result = undefined;
 });
@@ -143,7 +145,7 @@ describe('bulkSelectValues', () => {
 });
 
 describe('pickManyTargets', () => {
-  it('builds the prompt with kind-hinted options and returns the chosen array', async () => {
+  it('builds an unselected, optional prompt and returns the confirmed selection', async () => {
     msState.result = ['S/A', 'S:B'];
     const result = await pickManyTargets('Pick many', entries);
     expect(result).toEqual(['S/A', 'S:B']);
@@ -152,15 +154,28 @@ describe('pickManyTargets', () => {
       { value: 'S/A', label: 'S/A', hint: 'HTTP API v2' },
       { value: 'S:B', label: 'S:B' },
     ]);
-    expect(inst.opts.required).toBe(true);
+    // Rows start unselected (no initialValues) and an empty submit is allowed
+    // (required: false) so it can be treated as "exit".
+    expect(inst.opts.required).toBe(false);
     expect(inst.opts.initialValues).toBeUndefined();
+    expect(inst.value).toEqual([]);
+    expect(confirm).toHaveBeenCalledOnce();
   });
 
-  it('pre-selects every row via initialValues when preselectAll is set (Enter = all)', async () => {
-    msState.result = ['S/A', 'S:B'];
-    await pickManyTargets('Pick many', entries, { preselectAll: true });
-    const inst = msState.instances.at(-1)!;
-    expect(inst.opts.initialValues).toEqual(['S/A', 'S:B']);
+  it('exits (throws) when nothing is selected', async () => {
+    msState.result = [];
+    await expect(pickManyTargets('Pick many', entries)).rejects.toBeInstanceOf(
+      TargetSelectionCancelledError
+    );
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it('throws when the confirmation is declined', async () => {
+    msState.result = ['S/A'];
+    vi.mocked(confirm).mockResolvedValue(false);
+    await expect(pickManyTargets('Pick many', entries)).rejects.toBeInstanceOf(
+      TargetSelectionCancelledError
+    );
   });
 
   it('Right selects all and Left clears, via the key handler', async () => {

--- a/tests/unit/local/target-picker.test.ts
+++ b/tests/unit/local/target-picker.test.ts
@@ -15,7 +15,10 @@ interface MsInstance {
 }
 
 const { msState } = vi.hoisted(() => ({
-  msState: { instances: [] as MsInstance[], result: undefined as unknown },
+  // `results` is a queue: each `prompt()` call shifts the next picker result,
+  // so a confirm-decline loop can be driven across iterations. Throwing when
+  // it is empty turns an accidental infinite loop into a clear test failure.
+  msState: { instances: [] as MsInstance[], results: [] as unknown[] },
 }));
 
 // `pickManyTargets` builds a custom prompt on `@clack/core`'s
@@ -39,7 +42,10 @@ vi.mock('@clack/core', () => ({
       this.handlers[event] = cb;
     }
     prompt(): Promise<unknown> {
-      return Promise.resolve(msState.result);
+      if (msState.results.length === 0) {
+        throw new Error('mock MultiSelectPrompt: no queued result (would infinite-loop)');
+      }
+      return Promise.resolve(msState.results.shift());
     }
   },
 }));
@@ -92,7 +98,7 @@ beforeEach(() => {
   vi.mocked(isCancel).mockReturnValue(false);
   vi.mocked(confirm).mockResolvedValue(true);
   msState.instances = [];
-  msState.result = undefined;
+  msState.results = [];
 });
 
 afterEach(() => {
@@ -144,9 +150,13 @@ describe('bulkSelectValues', () => {
   });
 });
 
+function confirmMessage(call: number): string {
+  return (vi.mocked(confirm).mock.calls[call]![0] as { message: string }).message;
+}
+
 describe('pickManyTargets', () => {
   it('builds an unselected, optional prompt and returns the confirmed selection', async () => {
-    msState.result = ['S/A', 'S:B'];
+    msState.results = [['S/A', 'S:B']];
     const result = await pickManyTargets('Pick many', entries);
     expect(result).toEqual(['S/A', 'S:B']);
     const inst = msState.instances.at(-1)!;
@@ -162,24 +172,41 @@ describe('pickManyTargets', () => {
     expect(confirm).toHaveBeenCalledOnce();
   });
 
-  it('exits (throws) when nothing is selected', async () => {
-    msState.result = [];
-    await expect(pickManyTargets('Pick many', entries)).rejects.toBeInstanceOf(
-      TargetSelectionCancelledError
-    );
-    expect(confirm).not.toHaveBeenCalled();
+  it('lists the selected targets in the confirmation message', async () => {
+    msState.results = [['S/A', 'S:B']];
+    await pickManyTargets('Pick many', entries);
+    const msg = confirmMessage(0);
+    expect(msg).toContain('• [HTTP API v2] S/A');
+    expect(msg).toContain('• S:B');
   });
 
-  it('throws when the confirmation is declined', async () => {
-    msState.result = ['S/A'];
-    vi.mocked(confirm).mockResolvedValue(false);
+  it('asks to confirm exit when nothing is selected; Yes exits (throws)', async () => {
+    msState.results = [[]];
     await expect(pickManyTargets('Pick many', entries)).rejects.toBeInstanceOf(
       TargetSelectionCancelledError
     );
+    expect(confirmMessage(0)).toMatch(/nothing selected/i);
+  });
+
+  it('returns to the picker when the empty-exit confirm is declined', async () => {
+    msState.results = [[], ['S/A']]; // empty -> "exit?" no -> loop -> pick S/A
+    vi.mocked(confirm).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const result = await pickManyTargets('Pick many', entries);
+    expect(result).toEqual(['S/A']);
+    expect(msState.instances).toHaveLength(2);
+  });
+
+  it('returns to the picker (selection preserved) when the run confirm is declined', async () => {
+    msState.results = [['S/A'], ['S/A', 'S:B']];
+    vi.mocked(confirm).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const result = await pickManyTargets('Pick many', entries);
+    expect(result).toEqual(['S/A', 'S:B']);
+    expect(msState.instances).toHaveLength(2);
+    expect(msState.instances[1]!.opts.initialValues).toEqual(['S/A']);
   });
 
   it('Right selects all and Left clears, via the key handler', async () => {
-    msState.result = ['S/A'];
+    msState.results = [['S/A']];
     await pickManyTargets('Pick many', entries);
     const inst = msState.instances.at(-1)!;
     inst.value = [];
@@ -190,7 +217,7 @@ describe('pickManyTargets', () => {
   });
 
   it('leaves the selection unchanged on other keys', async () => {
-    msState.result = ['S/A'];
+    msState.results = [['S/A']];
     await pickManyTargets('Pick many', entries);
     const inst = msState.instances.at(-1)!;
     inst.value = ['S/A'];
@@ -199,7 +226,7 @@ describe('pickManyTargets', () => {
   });
 
   it('render returns a string in the active and submit states (smoke)', async () => {
-    msState.result = ['S/A'];
+    msState.results = [['S/A']];
     await pickManyTargets('Pick many', entries);
     const inst = msState.instances.at(-1)!;
     expect(typeof inst.opts.render.call(inst)).toBe('string');
@@ -208,7 +235,7 @@ describe('pickManyTargets', () => {
   });
 
   it('throws TargetSelectionCancelledError on cancel', async () => {
-    msState.result = Symbol('cancel');
+    msState.results = [Symbol('cancel')];
     vi.mocked(isCancel).mockReturnValue(true);
     await expect(pickManyTargets('Pick many', entries)).rejects.toBeInstanceOf(
       TargetSelectionCancelledError
@@ -296,7 +323,7 @@ describe('resolveMultiTarget', () => {
 
   it('multi-selects when omitted in a TTY', async () => {
     setTty(true);
-    msState.result = ['S/A'];
+    msState.results = [['S/A']];
     const result = await resolveMultiTarget([], {
       entries,
       message: 'm',


### PR DESCRIPTION
## Summary

Overhauls the interactive multi-select target picker (used by
`start-service` and `start-api`), built on `@clack/core`'s
`MultiSelectPrompt` so it can add keys the high-level `multiselect` does
not expose.

- **Bulk keys**: `→` selects all, `←` clears all (Up/Down move, Space
  toggles, Enter confirms). Hints live on the message line:
  `(toggle: space | all: → | none: ← | confirm: enter)`.
- **Starts unselected.** Submitting with nothing selected asks whether to
  exit (so a stray Enter never launches everything).
- **Confirmation** before launch lists the chosen targets as bullets;
  declining returns to the picker with the selection kept (loop).
- **Readability**: each API row shows its surface kind as an aligned
  `[kind]` prefix (always, not just the cursor row); the checked box is
  green, unselected rows + hints use the default fg (white), the cursor row
  is cyan.
- **Ordering**: API targets are grouped by stack, then kind (HTTP API v2 /
  REST API v1 / Function URL / WebSocket), then path — in both the picker
  and `cdkl list`.
- Adds `@clack/core` as a direct dependency (the sanctioned clack
  extension surface; pinned to the same version `@clack/prompts` resolves,
  single copy in the tree).

## Test plan

- [x] Unit (1156 green): `bulkSelectValues`; the picker's constructed
      options / `required: false` / no-`initialValues`; `→`/`←` key wiring;
      the confirm-with-list, decline-loops-back, and empty-then-exit-confirm
      flows; a render smoke test; and `sortApiEntries` single- and
      multi-stack ordering.
- [x] Real-Docker integ (`local-start-api`): boots, serves a 2-target
      subset, ignores a typo'd id with a warn, clean teardown — 0 orphans.
- [x] Interactive picker **visually verified in a terminal** (rendering,
      colours, keys, confirm flow) — the part unit tests cannot cover.

Closes #111
