### PR TITLE
docs(claude-md): drop stale -i note from target-picker line

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,8 +65,9 @@ Gateway).
   cloud-map-registry, lambda-resolver, ecs-task-resolver,
   route-discovery, authorizer-resolver, lambda-authorizer, cognito-jwt,
   sigv4-verify, rie-client, intrinsic-image, runtime-image, target-lister
-  (`cdkl list` target enumeration), target-picker (`-i/--interactive`
-  arrow-key target selection via `@clack/prompts`), embed-config
+  (`cdkl list` target enumeration), target-picker (interactive arrow-key
+  target selection via `@clack/prompts` when a target is omitted in a TTY),
+  embed-config
   (embed-time branding overrides for host CLIs), ssm-parameter-resolver
   (resolves `AWS::SSM::Parameter::Value` template parameters via SSM under
   `--from-cfn-stack`), etc.


### PR DESCRIPTION
## Summary

The `-i/--interactive` flag was removed; the picker now triggers on a
bare-omitted target in a TTY. Drops the stale `-i/--interactive` mention
from the `target-picker` line in `.claude/CLAUDE.md`.

## Test plan

- [x] Docs-only (internal `.claude/CLAUDE.md`); no behavior change.
