### PR TITLE
refactor(self-contained): scrub cdkd refs from src JSDoc and comments

### DIFF
--- a/src/assets/docker-build.ts
+++ b/src/assets/docker-build.ts
@@ -29,16 +29,16 @@ import { getLogger } from '../utils/logger.js';
  * is load-bearing for layer-cache reproducibility across both callers.
  *
  * The caller-supplied `wrapError` lets each consumer wrap the failure
- * with its own typed error class (`AssetError` for the publisher,
- * `LocalInvokeBuildError` for local invoke).
+ * with its own typed error class (`LocalInvokeBuildError` for local
+ * invoke; a host's asset-publish path supplies its own).
  */
 
 export interface BuildDockerImageOptions {
   /**
    * Local image tag (`--tag`) for `directory` mode. The caller chooses a
-   * deterministic tag so subsequent runs hit Docker's layer cache (the
-   * publisher uses `cdkd-asset-<hash>`; local-invoke uses
-   * `cdkl-invoke-<hash>`). Ignored in `executable` mode — there
+   * deterministic tag so subsequent runs hit Docker's layer cache
+   * (local-invoke uses `cdkl-invoke-<hash>`). Ignored in `executable`
+   * mode — there
    * the executable returns its own tag on stdout.
    */
   tag?: string;

--- a/src/cli/cdk-path.ts
+++ b/src/cli/cdk-path.ts
@@ -4,9 +4,6 @@ import type { CloudFormationTemplate, TemplateResource } from '../types/resource
  * Read the `aws:cdk:path` value that CDK encodes into every resource's
  * `Metadata`. Returns the empty string when not present so callers don't
  * have to special-case `undefined`.
- *
- * Hoisted out of `src/cli/commands/import.ts` so `cdkd orphan` can reuse the
- * same lookup without duplicating the metadata-walking code.
  */
 export function readCdkPath(resource: TemplateResource): string {
   const meta = resource.Metadata;
@@ -34,10 +31,9 @@ export function readCdkPathOrUndefined(resource: TemplateResource): string | und
 /**
  * Build a `Map<cdkPath, logicalId>` from a synthesized template.
  *
- * Used by `cdkd orphan <constructPath>` to translate user-supplied
- * construct paths (which mirror the upstream `cdk orphan` UX) back to the
- * logical IDs that the rest of the pipeline (state, dependency analysis,
- * provider lookup) is keyed on.
+ * Translates user-supplied construct paths (which mirror the upstream
+ * `cdk` construct-path UX) back to the logical IDs that the rest of the
+ * pipeline (state, dependency analysis, provider lookup) is keyed on.
  *
  * `AWS::CDK::Metadata` resources are excluded — the synthesized
  * `<Stack>/CDKMetadata/Default` sentinel exists in every stack but is
@@ -49,7 +45,7 @@ export function readCdkPathOrUndefined(resource: TemplateResource): string | und
  *
  * In practice each path maps to a single logical ID. If the same path
  * happens to appear twice (which would itself be a bug in the synthesized
- * template), the last entry wins — `cdkd orphan` will still surface a
+ * template), the last entry wins — callers still surface a
  * clean "path not found" diff against the indexed map rather than
  * silently grabbing both.
  */

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -167,10 +167,9 @@ async function localInvokeCommand(
   let containerId: string | undefined;
   let stopLogs: (() => void) | undefined;
   let sigintHandler: (() => void) | undefined;
-  // cdkd PR #670 (deferred follow-up from #655): synthesized AWS shared
-  // credentials file (one INI section) bind-mounted into the container so
-  // handlers using `fromIni({ profile })` explicitly resolve to the same
-  // creds. Disposed in the shared `cleanup` single-flight.
+  // Synthesized AWS shared credentials file (one INI section) bind-mounted
+  // into the container so handlers using `fromIni({ profile })` explicitly
+  // resolve to the same creds. Disposed in the shared `cleanup` single-flight.
   let profileCredsFile: ProfileCredentialsFile | undefined;
 
   /**
@@ -261,9 +260,8 @@ async function localInvokeCommand(
       ? await resolveProfileCredentials(options.profile)
       : undefined;
 
-    // cdkd PR #670 (deferred follow-up from #655): synthesize an AWS
-    // shared credentials file with the resolved creds under
-    // `[<options.profile>]` so handler code that uses
+    // Synthesize an AWS shared credentials file with the resolved creds
+    // under `[<options.profile>]` so handler code that uses
     // `fromIni({ profile: '<options.profile>' })` explicitly (instead of
     // the default credential chain) resolves to the same creds locally.
     // Mounted read-only into the container at the path pointed to by
@@ -486,8 +484,8 @@ async function localInvokeCommand(
     if (!assumeSucceeded) {
       forwardAwsEnv(dockerEnv);
       applyProfileCredentialsOverlay(dockerEnv, profileCredentials, false);
-      // cdkd PR #670 (deferred follow-up from #655): point the container's
-      // SDK chain at the bind-mounted credentials file so
+      // Point the container's SDK chain at the bind-mounted credentials
+      // file so
       // `fromIni({ profile })` calls inside the handler resolve to the
       // same creds. `AWS_PROFILE` makes `fromIni()` (no explicit arg)
       // ALSO use this profile.
@@ -521,8 +519,8 @@ async function localInvokeCommand(
       );
     }
     logger.info(`Starting container (image=${imagePlan.image}, port=${hostPort})...`);
-    // cdkd PR #670 (deferred follow-up from #655): append the profile
-    // credentials file bind-mount to the existing extraMounts (which
+    // Append the profile credentials file bind-mount to the existing
+    // extraMounts (which
     // already carry the /opt layer mount when present). Read-only — the
     // container has no business writing to its credentials file; a
     // writable mount would let a compromised handler tamper with the

--- a/src/cli/commands/local-profile-credentials-file.ts
+++ b/src/cli/commands/local-profile-credentials-file.ts
@@ -1,6 +1,6 @@
 // Profile-aware credentials file mount for cdk-local Lambda containers.
 //
-// Background: cdkd#655 / #657 forward `--profile <p>`-resolved credentials to
+// Background: cdk-local forwards `--profile <p>`-resolved credentials to
 // the Lambda container as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
 // `AWS_SESSION_TOKEN` env vars. The SDK's default credential provider chain
 // reads those env vars, so the common handler pattern
@@ -84,8 +84,8 @@ export async function writeProfileCredentialsFile(
   profileName: string,
   creds: { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
 ): Promise<ProfileCredentialsFile> {
-  // cdkd PR #670 code review finding #2: validate the profile name before
-  // interpolating into the INI section header / AWS_PROFILE env var.
+  // Validate the profile name before interpolating into the INI section
+  // header / AWS_PROFILE env var.
   // The injection surface is local-dev-only (the caller is the user's
   // own `--profile <name>` arg) so this is hardening, not security
   // boundary — but a value containing `]` would silently start a second

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -136,8 +136,9 @@ async function localRunTaskCommand(
   // extra). Hoisted so the outer `finally` can dispose it even if the
   // body throws between provider creation and the normal exit path.
   let stateProvider: LocalStateProvider | undefined;
-  // ECS analogue of cdkd PR #670: synthesized AWS shared credentials
-  // file (one INI section) bind-mounted into every user container so
+  // ECS analogue of the Lambda-container credential fix: synthesized AWS
+  // shared credentials file (one INI section) bind-mounted into every
+  // user container so
   // handlers using `fromIni({ profile })` resolve to the same creds.
   // Disposed in the cleanup chain below.
   let profileCredsFile: ProfileCredentialsFile | undefined;
@@ -305,19 +306,19 @@ async function localRunTaskCommand(
       assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
     }
 
-    // cdkd#658: when `--assume-task-role` is NOT effective but
-    // `--profile <p>` IS set, resolve the profile via the SDK's default
+    // When `--assume-task-role` is NOT effective but `--profile <p>` IS
+    // set, resolve the profile via the SDK's default
     // credential provider chain (SSO / IAM Identity Center / fromIni /
     // role-assumption) and forward the resulting `{AKID, SAK,
     // sessionToken?}` to the metadata-endpoints sidecar. Without this,
     // the sidecar starts inside a fresh container with no SSO config and
     // no `~/.aws/credentials`, so every user container that hits
     // `169.254.170.2/role/<role>` gets a credential-provider failure.
-    // Same gap class as cdkd#654/#655, which shipped the equivalent
-    // forward for `cdkl start-api`'s Lambda container path.
+    // Same gap class as the equivalent forward for `cdkl start-api`'s
+    // Lambda container path.
     const sidecarCredentials = await resolveSidecarCredentials(options, assumedCredentials);
 
-    // ECS analogue of cdkd PR #670 (Lambda-container fix-back finding #1):
+    // ECS analogue of the Lambda-container credential fix-back:
     // when `--profile <p>` is set AND `--assume-task-role` did NOT
     // produce credentials for this task, synthesize a host-side AWS
     // shared credentials file under `[<options.profile>]` and bind-
@@ -601,7 +602,7 @@ function readEnvOverridesFile(
 }
 
 /**
- * cdkd#658: pick the credentials forwarded to the AWS-published
+ * Pick the credentials forwarded to the AWS-published
  * `amazon-ecs-local-container-endpoints` sidecar. Precedence:
  *   1. `--assume-task-role <arn>` (or bare `--assume-task-role` against
  *      a resolvable `TaskRoleArn`) → STS-assumed temp creds. Highest
@@ -617,7 +618,7 @@ function readEnvOverridesFile(
  *
  * Extracted as an exported helper so a unit test can exercise every
  * branch without having to mock the full Synth + Docker + AWS pipeline
- * (the strategy cdkd#655 used for the Lambda container path).
+ * (the strategy used for the Lambda container path).
  */
 export async function resolveSidecarCredentials(
   options: { profile?: string },

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -358,8 +358,8 @@ async function localStartApiCommand(
   // shutdown path is the single owner of cleanup so leaks are
   // bounded by server lifetime).
   const layerTmpDirs = new Set<string>();
-  // cdkd PR #670 (deferred follow-up from #655): synthesized AWS shared
-  // credentials file bind-mounted into every Lambda container so handlers
+  // Synthesized AWS shared credentials file bind-mounted into every Lambda
+  // container so handlers
   // using `fromIni({ profile })` explicitly resolve to the same creds as
   // the default chain. Created ONCE at server boot (NOT on hot reload —
   // re-resolving profile creds is fine for env vars but rewriting the
@@ -630,7 +630,7 @@ async function localStartApiCommand(
     // doesn't have its own `--assume-role`. Drives the SDK's default
     // credential provider chain (SSO / IAM Identity Center / fromIni /
     // role-assumption profiles all handled uniformly — same chain that
-    // already resolves `--profile` for cdkd's own CFn / CC API clients).
+    // already resolves `--profile` for the host's own AWS SDK clients).
     // Resolved here so a stack with N Lambdas pays one STS round-trip.
     // SSO temp creds typically last 1h+; long-running `--watch` sessions
     // outliving the creds need a cdk-local restart (auto-refresh deferred,
@@ -639,8 +639,8 @@ async function localStartApiCommand(
       ? await resolveProfileCredentials(options.profile)
       : undefined;
 
-    // cdkd PR #670 (deferred follow-up from #655): when `--profile <p>`
-    // is set, ALSO synthesize a shared AWS credentials file with the
+    // When `--profile <p>` is set, ALSO synthesize a shared AWS
+    // credentials file with the
     // resolved creds under `[<p>]` and bind-mount it into every Lambda
     // container at `/cdk-local-aws/credentials`. This lets handlers that
     // use `fromIni({ profile: '<p>' })` explicitly inside their code
@@ -653,7 +653,7 @@ async function localStartApiCommand(
     // and the new env vars flow to the next cold start, but the on-disk
     // file is NOT re-written. Long-running sessions whose SSO temp creds
     // expire need a cdk-local restart (matches the auto-refresh-deferred
-    // stance for env vars from cdkd#655).
+    // stance for env vars).
     //
     // Assigned to outer-scope `profileCredsFile` so the cleanup chain
     // disposes the file at shutdown. Only ever assigned on the FIRST
@@ -1222,8 +1222,7 @@ async function localStartApiCommand(
         );
       }
     }
-    // cdkd PR #670 (deferred follow-up from #655): dispose the synthesized
-    // profile credentials file (one INI file under
+    // Dispose the synthesized profile credentials file (one INI file under
     // `/tmp/cdk-local-profile-creds-*/`). Leaving temp credential files on
     // disk after process exit is a security smell; `dispose()` rm's the
     // tempdir recursively + force, so re-entrant calls (signal-mid-finally
@@ -1891,8 +1890,8 @@ async function buildContainerSpec(args: {
    */
   profileCredentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
   /**
-   * cdkd PR #670 (deferred follow-up from #655): when set, a synthesized
-   * AWS shared credentials file (one INI section, the resolved
+   * When set, a synthesized AWS shared credentials file (one INI section,
+   * the resolved
    * `[<profile-name>]` block) the container should bind-mount + reference
    * via `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env vars. Lets
    * handlers that use `fromIni({ profile })` explicitly inside their
@@ -1986,7 +1985,7 @@ async function buildContainerSpec(args: {
   // Env vars: literal template values + --env-vars overlay. When
   // `--from-state` was passed (and state for this Lambda's stack
   // loaded), intrinsic-valued template entries are first substituted
-  // against deployed cdkd state + AWS pseudo parameters via
+  // against deployed-stack state + AWS pseudo parameters via
   // `substituteEnvVarsFromState`. Per-key failures (state missing for
   // a referenced logical id, attribute not captured at deploy time,
   // unsupported intrinsic shape) warn-and-drop with context. Keys the
@@ -2100,8 +2099,8 @@ async function buildContainerSpec(args: {
       }
     }
 
-    // cdkd PR #670 (profile-aware SDK config inside container): when the
-    // server boot synthesized a credentials file via
+    // Profile-aware SDK config inside container: when the server boot
+    // synthesized a credentials file via
     // `writeProfileCredentialsFile(options.profile, ...)`, point the
     // container's SDK chain at the bind-mounted path so
     // `fromIni({ profile: '<name>' })` calls inside the handler resolve
@@ -2114,8 +2113,7 @@ async function buildContainerSpec(args: {
     // the file path too. Without this nesting, a handler in an
     // assume-role'd Lambda that called `fromIni({ profile: '<name>' })`
     // explicitly would silently bypass the execution-role creds and use
-    // the `--profile <name>` creds — breaking the documented precedence
-    // (cdkd PR #670 code review finding #1).
+    // the `--profile <name>` creds — breaking the documented precedence.
     if (profileCredsFile) {
       dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
       dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
@@ -2849,10 +2847,10 @@ function forwardAwsEnv(env: Record<string, string>): void {
  * AWS SDK call fails with `Could not load credentials from any providers`.
  *
  * This helper constructs a transient `STSClient({ profile })` to drive
- * the SDK's default credential provider chain — same code path cdkd's
- * own CFn / CC API clients use when `--profile` is set, so SSO / IAM
+ * the SDK's default credential provider chain — same code path the
+ * host's own AWS SDK clients use when `--profile` is set, so SSO / IAM
  * Identity Center / role-assumption profiles all resolve the same way
- * they already do for cdkd's outbound calls. We then extract the
+ * they already do for the host's outbound calls. We then extract the
  * resolved `AwsCredentialIdentity` via `sts.config.credentials()` and
  * return the underlying `{ accessKeyId, secretAccessKey, sessionToken? }`
  * for env-var injection.

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -148,8 +148,9 @@ async function localStartServiceCommand(
   // Hoisted out of the try block so the single-flight cleanup closure
   // can teardown the shared network after every container is gone.
   let sharedNetwork: TaskNetwork | undefined;
-  // ECS analogue of cdkd PR #670: synthesized AWS shared credentials
-  // file bind-mounted into every service replica's containers so
+  // ECS analogue of the Lambda-container credential fix: synthesized AWS
+  // shared credentials file bind-mounted into every service replica's
+  // containers so
   // `fromIni({ profile })` handlers resolve to the same creds the
   // sidecar serves. One-per-CLI-invocation (mirrors the shared
   // sidecar's shape — `--profile` is a CLI-level concern, not a
@@ -284,8 +285,8 @@ async function localStartServiceCommand(
     // Create ONE shared docker network used by every service-replica
     // boot in this CLI invocation.
     //
-    // cdkd#658: when `--profile <p>` is set, the resolved credentials
-    // are forwarded to the AWS-published metadata-endpoints sidecar so
+    // When `--profile <p>` is set, the resolved credentials are forwarded
+    // to the AWS-published metadata-endpoints sidecar so
     // its `/role/<role-arn>` endpoint serves them to user containers.
     // Without this, the sidecar starts inside a fresh container with
     // no SSO config / no `~/.aws/credentials` and falls back to its
@@ -307,8 +308,9 @@ async function localStartServiceCommand(
         `Failed to create shared service network: ${err instanceof Error ? err.message : String(err)}`
       );
     }
-    // ECS analogue of cdkd PR #670 — when `--profile <p>` is set, write
-    // ONCE the host-side credentials file used by every replica's
+    // ECS analogue of the Lambda-container credential fix — when
+    // `--profile <p>` is set, write ONCE the host-side credentials file
+    // used by every replica's
     // containers. Mirrors the shared-sidecar shape (one-per-CLI-
     // invocation): `--profile` is a CLI-level concern. Per-service
     // `--assume-task-role <Service>=<arn>` overrides are independent
@@ -508,8 +510,8 @@ async function runOneTarget(
   if (options.profile) taskOpts.profile = options.profile;
   const hostPortOverrides = parseHostPortOverrides(options.hostPort);
   if (Object.keys(hostPortOverrides).length > 0) taskOpts.hostPortOverrides = hostPortOverrides;
-  // Per-service gating (mirrors cdkd PR #670 fix-back finding #1
-  // applied in `local-run-task.ts`): the shared credentials file is
+  // Per-service gating (mirrors the fix-back applied in
+  // `local-run-task.ts`): the shared credentials file is
   // bound ONLY to services that did NOT win an `--assume-task-role`.
   // An assume-role'd service serves its own STS creds via the
   // sidecar's `/role/<arn>` endpoint; injecting
@@ -768,7 +770,7 @@ function parseRestartPolicy(raw: string): 'on-failure' | 'always' | 'none' {
 }
 
 /**
- * cdkd#658: pick the credentials forwarded to the AWS-published
+ * Pick the credentials forwarded to the AWS-published
  * `amazon-ecs-local-container-endpoints` sidecar. `cdkl start-service`'s
  * sidecar is SHARED across every replica boot in one CLI invocation, so
  * this resolves ONCE at startup. Precedence:
@@ -789,7 +791,7 @@ function parseRestartPolicy(raw: string): 'on-failure' | 'always' | 'none' {
  *
  * Extracted as an exported helper so a unit test can exercise both
  * branches without having to mock the full Synth + Docker + AWS
- * pipeline (the strategy cdkd#655 used for the Lambda container path).
+ * pipeline (the strategy used for the Lambda container path).
  */
 export async function resolveSharedSidecarCredentials(options: {
   profile?: string;

--- a/src/cli/commands/local-state-source.ts
+++ b/src/cli/commands/local-state-source.ts
@@ -10,8 +10,8 @@
  * Host-extensible state sources (via the `extraStateProviders` option):
  *
  *   - Hosts embedding cdk-local can register additional `LocalStateProvider`
- *     factories that respond to their own CLI flags (e.g. cdkd's
- *     `--from-state` for S3-backed cdkd state). Each entry is keyed by
+ *     factories that respond to their own CLI flags (e.g. a host-registered
+ *     `--from-state` backed by an S3 state store). Each entry is keyed by
  *     the camel-case Commander option name (e.g. `'fromState'`) so the
  *     dispatcher reads the corresponding boolean / string off the parsed
  *     options bag.
@@ -40,7 +40,7 @@ import type { LocalStateProvider } from '../../local/local-state-provider.js';
  * Options each `cdkl` command gathers from its flag set. The built-in
  * `--from-cfn-stack` flag is always present; the host may add fields
  * for its own `extraStateProviders` entries (e.g. `fromState: boolean`
- * for the cdkd shim's `--from-state`).
+ * for a host's `--from-state` shim).
  */
 export interface LocalStateSourceOptions {
   /**
@@ -215,7 +215,7 @@ export function rejectExplicitCfnStackWithMultipleStacks(
  * fallback for the CFn client when no explicit region override is set.
  *
  * `extraStateProviders` is the host-supplied registry of additional
- * state sources (e.g. cdkd's `--from-state` / `S3LocalStateProvider`).
+ * state sources (e.g. a host's `--from-state` / S3-backed provider).
  * Each entry's key is the camel-case Commander option name; the
  * dispatcher activates the matching factory when the corresponding
  * options field is truthy.
@@ -234,7 +234,7 @@ export function createLocalStateProvider(
   const cfnFlagPresent = isCfnFlagPresent(options);
 
   // Mutual-exclusion: count active state sources. Both --from-cfn-stack
-  // and every host-registered extra flag (e.g. cdkd's --from-state) are
+  // and every host-registered extra flag (e.g. a host's --from-state) are
   // counted; the user must pick exactly one.
   const activeExtras: string[] = [];
   if (extraStateProviders) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -409,7 +409,7 @@ export {
 /**
  * `invoke` local container-Lambda build error. Exposed so a consuming host that
  * shims `docker-image-builder` can catch it at the shim boundary and re-throw
- * its OWN error class — the host's error base (e.g. cdkd's `CdkdError`) differs
+ * its OWN error class — the host's error base differs
  * from cdk-local's `CdkLocalError`, so the host's top-level error handler /
  * `instanceof` checks need the host's class identity, which a boundary
  * translation in the shim provides.

--- a/src/local/api-server-grouping.ts
+++ b/src/local/api-server-grouping.ts
@@ -164,9 +164,9 @@ export function groupRoutesByServer(routes: readonly RouteWithAuth[]): ApiServer
  *      exact match on the resource's `aws:cdk:path` metadata.
  *   4. **CDK Construct path prefix** — when the input is a strict
  *      ancestor of the resource's `aws:cdk:path` (i.e.
- *      `cdkPath.startsWith(input + '/')`). Mirrors the prefix rule
- *      `cdkd orphan` uses so an L2 wrapper path resolves to its L1
- *      child (`MyStack/MyHttpApi` matches `MyStack/MyHttpApi/Resource`).
+ *      `cdkPath.startsWith(input + '/')`). Mirrors the upstream CDK
+ *      construct-path prefix rule so an L2 wrapper path resolves to its
+ *      L1 child (`MyStack/MyHttpApi` matches `MyStack/MyHttpApi/Resource`).
  *
  * Routes discovered before this field set was added (or routes where
  * the synthesized template doesn't carry `aws:cdk:path` metadata —

--- a/src/local/container-pool.ts
+++ b/src/local/container-pool.ts
@@ -118,8 +118,8 @@ interface ContainerSpecBase {
    */
   extraHosts?: { host: string; ip: string }[];
   /**
-   * cdkd PR #670 (deferred follow-up from #655) — when `cdkl *` is
-   * invoked with `--profile <name>`, this is the host path of a
+   * When `cdkl *` is invoked with `--profile <name>`, this is the host
+   * path of a
    * synthesized AWS shared credentials file (one INI section, the
    * resolved `[<name>]` block). The pool bind-mounts it read-only at
    * the container path so SDK calls via `fromIni({ profile: '<name>' })`
@@ -342,8 +342,8 @@ export function createContainerPool(
       const optMount = spec.optDir
         ? [{ hostPath: spec.optDir, containerPath: '/opt', readOnly: true }]
         : [];
-      // Append the profile credentials file mount (cdkd PR #670 deferred
-      // from #655) when --profile was passed. Read-only — the container
+      // Append the profile credentials file mount when --profile was
+      // passed. Read-only — the container
       // has no business writing to its credentials file, and a writable
       // mount would let a compromised handler tamper with the host-side
       // temp file. Combined with `optMount` since Docker accepts an array

--- a/src/local/docker-image-builder.ts
+++ b/src/local/docker-image-builder.ts
@@ -14,9 +14,9 @@ import { getEmbedConfig } from './embed-config.js';
  * + build-args fingerprint, so successive `cdkl invoke` runs hit
  * Docker's layer cache instead of re-building from scratch.
  *
- * Failures are wrapped in `LocalInvokeBuildError` (mirrors the publisher's
- * `AssetError` shape) so the global error handler surfaces a class
- * specific to local-invoke instead of the more general "asset" class.
+ * Failures are wrapped in `LocalInvokeBuildError` so the global error
+ * handler surfaces a class specific to local-invoke instead of a more
+ * general asset-build error.
  */
 
 export interface BuildContainerImageOptions {

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -342,8 +342,8 @@ async function assumeRoleForEcr(
 
 /**
  * Authenticate the local docker daemon against the target ECR registry.
- * Mirrors `DockerAssetPublisher.ecrLogin` but stays in this module so the
- * local-invoke path doesn't depend on the publisher's larger surface area.
+ * Self-contained in this module so the local-invoke path stays
+ * independent of any full asset-publish path's larger surface area.
  */
 async function ecrLogin(client: ECRClient, accountId: string, region: string): Promise<void> {
   const logger = getLogger().child('ecr-puller');

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -180,7 +180,7 @@ export function derivePartitionAndUrlSuffix(region: string): {
  * parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` /
  * `${AWS::URLSuffix}`) and / or same-stack `AWS::ECR::Repository` refs are
  * resolvable at runtime when the caller can supply the account ID + region
- * (Tier 1, no state needed) and optionally the cdkd state-recorded
+ * (Tier 1, no state needed) and optionally the host state-recorded
  * `physicalId` map (Tier 2, `--from-state`).
  *
  * The CLI command resolves both blocks lazily — STS is only invoked when
@@ -533,7 +533,7 @@ export function parseEcsTarget(target: string): ParsedEcsTarget {
  * available task definition in the matched stack) on any miss.
  *
  * Optional `context` (issue #264): when the caller can supply AWS
- * pseudo-parameter values (Tier 1) and / or cdkd state-recorded resources
+ * pseudo-parameter values (Tier 1) and / or host state-recorded resources
  * (Tier 2), `Fn::Sub`-shaped ECR image URIs that reference
  * `${AWS::AccountId}` / `${AWS::Region}` / a same-stack
  * `AWS::ECR::Repository` are substituted before classification.

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -186,7 +186,7 @@ export interface RunEcsTaskOptions {
    */
   networkAliasesByContainer?: ReadonlyMap<string, ReadonlyArray<string>>;
   /**
-   * ECS analogue of the Lambda-container fix shipped in cdkd PR #670:
+   * ECS analogue of the Lambda-container credential fix:
    * synthesized AWS shared credentials file (one INI section under
    * `[<profileName>]`) bind-mounted read-only into EVERY user
    * container, plus `AWS_SHARED_CREDENTIALS_FILE` +
@@ -899,7 +899,7 @@ interface BuildDockerRunArgs {
    */
   networkAliases?: ReadonlyArray<string>;
   /**
-   * ECS analogue of the Lambda-container fix in cdkd PR #670 — bind-mounts
+   * ECS analogue of the Lambda-container credential fix — bind-mounts
    * a host-side AWS shared credentials file (one `[<profileName>]`
    * INI section) read-only into the container and sets
    * `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env vars so handler
@@ -1027,8 +1027,8 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
     }
   }
 
-  // cdkd PR #670 follow-up — bind-mount the host-side profile credentials
-  // file read-only at the fixed in-container path so `fromIni({
+  // Bind-mount the host-side profile credentials file read-only at the
+  // fixed in-container path so `fromIni({
   // profile })` handlers resolve to the same creds the sidecar
   // serves. The `:ro` flag is load-bearing: a compromised handler
   // must not be able to tamper with the host-side temp file. Set
@@ -1078,8 +1078,8 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
     ...(opts.sidecarIp !== undefined && { sidecarIp: opts.sidecarIp }),
   });
   Object.assign(finalEnv, metaEnv);
-  // cdkd PR #670 follow-up — point the container's SDK chain at the bind-
-  // mounted credentials file so `fromIni({ profile })` calls inside
+  // Point the container's SDK chain at the bind-mounted credentials file
+  // so `fromIni({ profile })` calls inside
   // the handler resolve to the same creds. `AWS_PROFILE` makes
   // `fromIni()` (no explicit arg) ALSO use this profile. Sits ABOVE
   // template / secret / --env-vars overrides so a user template that

--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -30,7 +30,7 @@ import type { TemplateResource } from '../types/resource.js';
  * `${AWS::Region}` / `${AWS::AccountId}` / `${AWS::URLSuffix}` /
  * `${AWS::Partition}`); `stateResources` covers Tier 2 (`--from-state`
  * — substitutes same-stack ECR `Ref` / `Fn::GetAtt: [<Repo>, 'Arn']`
- * against cdkd's recorded `physicalId` / `attributes`).
+ * against the host state-recorded `physicalId` / `attributes`).
  *
  * The CLI command resolves both blocks lazily — STS is only invoked when
  * at least one image references the pseudo parameters — and passes the
@@ -72,7 +72,7 @@ export interface ImageResolutionContext {
 
 /**
  * Derive the AWS pseudo parameters that are trivially knowable from the
- * deploy region alone, without any STS call or cdkd state load.
+ * deploy region alone, without any STS call or state load.
  * `urlSuffix` and `partition` follow the canonical AWS partition rules:
  *
  *   - region prefix `cn-*`        → partition `aws-cn`,     urlSuffix `amazonaws.com.cn`
@@ -144,7 +144,7 @@ export type FnJoinResolveOutcome =
  * nested `Fn::Select` / `Fn::Split` over an `Fn::GetAtt: [<Repo>, 'Arn']`
  * plus a `Ref` to the same `AWS::ECR::Repository` and a
  * `Ref: AWS::URLSuffix`. For SAME-STACK references the account-id +
- * region only exist in cdkd's S3 state (recorded at deploy time on the
+ * region only exist in the host's S3 state (recorded at deploy time on the
  * Repository's `Arn` attribute), so the resolver inherently requires
  * `--from-state` (Tier 2) for that variant. For IMPORTED repositories
  * the URI components are flat strings + `Ref: AWS::URLSuffix` and

--- a/src/local/rie-client.ts
+++ b/src/local/rie-client.ts
@@ -398,12 +398,12 @@ export async function invokeRieStreaming(
   }
 
   // Whether we synthesized a default prelude because no separator was found
-  // in the response. See the cdkd#664 fix block below for the rationale.
+  // in the response. See the fix block below for the rationale.
   let preludeSynthesized = false;
 
   if (separatorIdx < 0) {
     // No prelude/body separator found in the entire response. Two real-world
-    // scenarios produce this — empirically verified 2026-05-27 for cdkd#664
+    // scenarios produce this — empirically verified 2026-05-27
     // against `public.ecr.aws/lambda/nodejs:22`:
     //
     //   (1) The handler is wrapped by `awslambda.streamifyResponse(...)` AND

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -117,7 +117,7 @@ export interface DiscoveredRoute {
    * form (`MyStack/MyHttpApi`) with prefix-rule matching (matches
    * the input exactly OR when the input is the parent L2 path that
    * resolves down to this resource's L1 child) — mirrors the same
-   * prefix rule `cdkd orphan` uses.
+   * upstream CDK construct-path prefix rule.
    */
   apiCdkPath?: string;
   /**

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -64,10 +64,9 @@
  *   - `Fn::ImportValue: '<exportName>'` (or an intrinsic-valued argument
  *     that resolves to a string against state + pseudo parameters) —
  *     looked up via `crossStackResolver.resolveImport(exportName)`. The
- *     resolver typically reads the persistent exports index at
- *     `s3://{bucket}/cdkd/_index/{region}/exports.json` populated by
- *     `cdkl deploy`, falling back to a per-stack state.json scan on
- *     index miss (closes issue #454).
+ *     resolver typically reads the host's persistent exports index,
+ *     falling back to a per-stack state.json scan on index miss
+ *     (closes issue #454).
  *   - `Fn::GetStackOutput: { StackName, OutputName, Region? }` — looked
  *     up via `crossStackResolver.resolveGetStackOutput(stackName, region,
  *     outputName)`. The resolver typically reads the producer stack's
@@ -154,9 +153,8 @@ export interface PseudoParameters {
 export interface CrossStackResolver {
   /**
    * Look an export by name against the consumer's region. Implementations
-   * typically consult the persistent exports index at
-   * `s3://{bucket}/cdkd/_index/{region}/exports.json`, falling back to a
-   * per-stack `state.json` scan on miss.
+   * typically consult the host's persistent exports index, falling back
+   * to a per-stack `state.json` scan on miss.
    */
   resolveImport(exportName: string): Promise<string | undefined>;
   /**

--- a/src/synthesis/assembly-reader.ts
+++ b/src/synthesis/assembly-reader.ts
@@ -9,13 +9,9 @@ import type { CloudFormationTemplate } from '../types/resource.js';
 /**
  * Stack information extracted from a CDK Cloud Assembly.
  *
- * This interface mirrors the shape cdkd's `src/local/**` files import,
- * so the ported source compiles without rewrites. The backing
- * implementation differs: cdk-local parses `cdk.out/manifest.json` by hand
- * (PR #4 self-implemented synth); cdk-local delegates to
- * `@aws-cdk/toolkit-lib` (`Toolkit.fromCdkApp()` + `Toolkit.synth()`)
- * and maps each synthesized `CloudFormationStackArtifact` to a
- * `StackInfo` record.
+ * cdk-local delegates synthesis to `@aws-cdk/toolkit-lib`
+ * (`Toolkit.fromCdkApp()` + `Toolkit.synth()`) and maps each synthesized
+ * `CloudFormationStackArtifact` to a `StackInfo` record.
  */
 export interface StackInfo {
   /** Physical CloudFormation stack name (e.g., "MyStage-MyStack"). */

--- a/src/synthesis/synthesizer.ts
+++ b/src/synthesis/synthesizer.ts
@@ -6,13 +6,10 @@ import { getLogger } from '../utils/logger.js';
 /**
  * Synthesis options accepted by the four `cdkl` commands.
  *
- * Mirrors the cdkd `SynthesisOptions` shape so ported source files
- * compile without rewrites. cdk-local delegates the heavy lifting to
- * `@aws-cdk/toolkit-lib`'s `Toolkit.fromCdkApp()` (via {@link AssemblyReader}),
- * which handles subprocess execution + manifest parsing + context
- * resolution internally — there is no per-field substitution layer like
- * cdkd's hand-rolled `AppExecutor` / `ContextStore` / context-provider
- * loop.
+ * cdk-local delegates the heavy lifting to `@aws-cdk/toolkit-lib`'s
+ * `Toolkit.fromCdkApp()` (via {@link AssemblyReader}), which handles
+ * subprocess execution + manifest parsing + context resolution
+ * internally — there is no per-field substitution layer.
  */
 export interface SynthesisOptions {
   /** CDK app command or pre-synthesized assembly directory (cdk.json `app`). */
@@ -40,9 +37,9 @@ export interface SynthesisResult {
 }
 
 /**
- * Thin wrapper around {@link AssemblyReader} that mimics cdkd's
- * `Synthesizer` API so the ported `cdkl invoke` / `start-api` /
- * `run-task` / `start-service` source compiles without rewrites.
+ * Thin wrapper around {@link AssemblyReader} exposing a `Synthesizer`
+ * API used by the `cdkl invoke` / `start-api` / `run-task` /
+ * `start-service` commands.
  *
  * When `app` resolves to an existing directory it is read as a
  * pre-synthesized cloud assembly (no subprocess synth); otherwise it is

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -166,7 +166,7 @@ export interface DeleteContext {
  * `AWS::IAM::Policy` resource, not the role/user/group itself. Without
  * filtering them out, every Role/User/Group whose CDK code uses
  * `addToPolicy` / `grantRead` / `ContainerImage.fromEcrRepository`
- * fires false drift on every `cdkd drift` run.
+ * fires false drift on every drift run.
  *
  * The context carries the same-stack siblings (excluding the resource
  * being read) so the IAM providers can match `ListRolePolicies` output
@@ -180,7 +180,7 @@ export interface ReadCurrentStateContext {
   /**
    * All resources in the same stack EXCEPT the one being read.
    * Keyed by logicalId. `resourceType` and `properties` come from
-   * cdkd state (`ResourceState`); `properties` may carry intrinsics
+   * the host state (`ResourceState`); `properties` may carry intrinsics
    * unresolved for resources written by older binaries — providers
    * that consume this should match by literal values only.
    */
@@ -349,11 +349,11 @@ export interface ResourceProvider {
    * Read the **currently-deployed** properties of an existing resource as
    * seen by AWS, scoped to the property set this provider manages
    * (`handledProperties`-equivalent). The returned object is suitable for
-   * direct comparison against the `properties` field in cdkd state.
+   * direct comparison against the `properties` field in the host state.
    *
-   * Used by `cdkd drift <stack>` to detect divergence between cdkd state and
+   * Used by the host's drift command to detect divergence between state and
    * AWS reality without going through CloudFormation. Implementations should
-   * return only the keys cdk-local actually manages — the `cdkd drift` comparator
+   * return only the keys cdk-local actually manages — the drift comparator
    * already ignores keys not present in state, but returning a tighter set
    * keeps the wire payload smaller.
    *
@@ -415,9 +415,9 @@ export interface ResourceProvider {
    * the CDK template, and return its physical id + attributes so the state
    * file can be reconstructed.
    *
-   * Used by `cdkd state import` to recover state after disasters (lost state
-   * file, manual deletion, drift between cdkd and AWS) and to adopt
-   * AWS-resident resources into cdkd's management.
+   * Used by the host's state-import flow to recover state after disasters
+   * (lost state file, manual deletion, drift between state and AWS) and to
+   * adopt AWS-resident resources into the host's management.
    *
    * Lookup strategy is provider-specific. Recommended order:
    *   1. If the template's `properties` carries an explicit name field
@@ -433,8 +433,8 @@ export interface ResourceProvider {
    * surface them.
    *
    * Optional: providers without an `import` implementation are reported as
-   * unsupported by `cdkd state import` and the corresponding logical IDs are
-   * skipped with a warning.
+   * unsupported by the host's state-import flow and the corresponding
+   * logical IDs are skipped with a warning.
    */
   import?(input: ResourceImportInput): Promise<ResourceImportResult | null>;
 }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,8 +1,8 @@
 /**
  * Schema versions for the state.json the host writes via cdk-local.
  *
- * - 1 — legacy layout: `s3://{bucket}/cdkd/{stackName}/state.json` (pre PR 1).
- * - 2 — region-prefixed layout: `s3://{bucket}/cdkd/{stackName}/{region}/state.json`.
+ * - 1 — legacy layout: per-stack key with no region segment.
+ * - 2 — region-prefixed layout: the key includes the region segment.
  * - 3 — adds `ResourceState.observedProperties` (AWS-current snapshot
  *       captured at deploy/import time, used as the drift comparator's
  *       baseline). Layout is the same as v2; only the resource-level shape
@@ -22,14 +22,13 @@
  *       as v4; only the resource-level shape grew. v4 readers see v5 as
  *       `version: 5` and fail clearly.
  * - 6 — adds `StackState.parentStack` / `parentLogicalId` / `parentRegion`
- *       to support `AWS::CloudFormation::Stack` nested-stack adoption (issue
- *       [#459](https://github.com/go-to-k/cdkd/issues/459)). Child stacks
- *       record their parent's name + the child's logical id in the parent's
- *       template, so `cdkl state list` / `state show` can surface the
- *       parent → child tree and `cdkl destroy <child-only>` can reject
- *       with a clear pointer at the parent. The child's S3 key uses
- *       `cdkd/<parent>~<NestedStackLogicalId>/<region>/state.json` (the `~`
- *       separator avoids ambiguity with CDK Stage's `/`). Layout
+ *       to support `AWS::CloudFormation::Stack` nested-stack adoption.
+ *       Child stacks record their parent's name + the child's logical id
+ *       in the parent's template, so the host can surface the
+ *       parent → child tree and reject a child-only destroy with a clear
+ *       pointer at the parent. The child's S3 key embeds the parent name +
+ *       child logical id joined by `~` (the separator avoids ambiguity
+ *       with CDK Stage's `/`). Layout
  *       superset of v5; only the stack-level shape grew. v5 readers
  *       see v6 as `version: 6` and fail clearly. v6 writers always emit
  *       the new fields (undefined on top-level stacks, populated on
@@ -37,8 +36,8 @@
  *       the `NestedStackProvider` that consumes the fields lands in a
  *       follow-up.
  * - 7 — adds `ResourceState.provisionedBy: 'sdk' | 'cc-api'` to support
- *       per-resource Cloud Control API routing for silent-drop properties
- *       (issue [#614](https://github.com/go-to-k/cdkd/issues/614)). When
+ *       per-resource Cloud Control API routing for silent-drop properties.
+ *       When
  *       a fresh deploy detects a silent-drop top-level CFn property on a
  *       Tier 1 type, the resource is routed through Cloud Control API
  *       (which forwards the full property map to AWS) instead of the SDK
@@ -134,8 +133,8 @@ export interface StackState {
 
   /**
    * Parent stack's physical name when THIS state record describes a
-   * nested-stack child (issue [#459](https://github.com/go-to-k/cdkd/issues/459)).
-   * Undefined on top-level stacks. The pre-v6 reader sees the field as
+   * nested-stack child. Undefined on top-level stacks.
+   * The pre-v6 reader sees the field as
    * undefined and degrades to "I am a top-level stack" — which is correct
    * for every state file written before nested-stack support shipped.
    * v6+ writers populate this on child state records so `cdkl state list`
@@ -240,8 +239,7 @@ export interface ResourceState {
   updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate' | undefined;
 
   /**
-   * Which provisioning layer owns this resource (schema v7+, issue
-   * [#614](https://github.com/go-to-k/cdkd/issues/614)).
+   * Which provisioning layer owns this resource (schema v7+).
    *
    * - `'sdk'` — SDK Provider (the preferred fast path: direct
    *   synchronous AWS SDK calls per resource type, no polling).

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -7,7 +7,7 @@ import { getEmbedConfig } from '../local/embed-config.js';
  *
  * Two parity decisions with `aws-cdk-cli`'s `cdk-assets-lib`:
  *   1. `CDK_DOCKER` env var swaps the binary so podman / finch users can
- *      run cdk-local without code changes (`CDK_DOCKER=podman cdkd deploy`).
+ *      run cdk-local without code changes (`CDK_DOCKER=podman cdkl invoke`).
  *   2. `runDockerStreaming` uses streaming spawn rather than `execFile`'s
  *      buffered `maxBuffer` ceiling. BuildKit's progress output can run to
  *      tens of MB on multi-stage builds with `# syntax=docker/dockerfile:1`

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,12 +1,11 @@
 /**
  * Logger interface and console implementation for cdk-local.
  *
- * API-compatible with cdkd's logger (same `Logger` / `LogLevel` shape, same
- * `getLogger()` / `setLogger()` exports, same `ConsoleLogger` class with
- * `child(prefix)`). The cdk-local variant drops cdkd's multi-stack output
- * buffer (`stack-context`) and live progress renderer (`live-renderer`)
- * because cdk-local invokes a single Lambda / API / task at a time — there
- * is no parallel multi-stack output to interleave.
+ * A minimal `Logger` / `LogLevel` interface with a `ConsoleLogger`
+ * (`getLogger()` / `setLogger()` exports, `child(prefix)` for prefixed
+ * sub-loggers). cdk-local invokes a single Lambda / API / task at a time,
+ * so there is no parallel multi-stack output to interleave — a plain
+ * console logger with no output buffer or live progress renderer suffices.
  */
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';


### PR DESCRIPTION
## Summary

Scrub the residual `cdkd` references from cdk-local source comments / JSDoc so the
code reads as a self-contained local-execution CLI. Closes #52.

- **Comment / JSDoc only** — zero runtime code lines changed. The compiled `dist/*.js`
  is byte-identical to `main` (only the generated `.d.ts` JSDoc strings differ).
- **History comments**: dropped `cdkd PR #N` / `cdkd#N` prefixes while keeping the
  explanatory *why* of each comment (e.g. `cdkd PR #670 (deferred follow-up from #655): synthesized AWS shared credentials file...` -> `Synthesized AWS shared credentials file...`).
- **cdkd-command JSDoc**: `cdkd drift` / `cdkd orphan` / `cdkd state import` / `cdkd deploy`
  rewritten to neutral host wording (`the host's drift command`, the upstream CDK
  construct-path rule, `CDK_DOCKER=podman cdkl invoke`, etc.).
- **state.ts / resource.ts**: removed cdkd issue-link URLs and `cdkd/`-prefixed S3 paths;
  kept the schema-version descriptions and the "subset of the host's schema" contract note.
- **mirror / compat notes** (logger / synthesizer / assembly-reader / local-state-source /
  intrinsic-image / state-resolver / ecs-task-resolver): rewritten to describe cdk-local's
  own shape / "the host" instead of naming cdkd internals.
- **Carve-out preserved**: `src/local/embed-config.ts` and `src/index.ts` deliberately keep
  `cdkd` as the example embedding *host* (the `embedConfig` integration contract) — the only
  two files where naming cdkd is correct. The `cdkd`-internal `CdkdError` example in
  `index.ts` was still scrubbed to "the host's error base".

Category 1 (runtime error strings naming cdkd commands) and the error-handler dead-class
cleanup were already resolved by `#69` and `#77`; `#54` was verified resolved and closed
separately. This PR is the remaining comment / JSDoc sweep.

## Verification

- `vp run check` (typecheck + lint + format) / `vp run build` / `vp test run` (80 files, 1156 tests): pass
- **3-axis review** (spec / code / test): spec + test clean. The code reviewer caught two
  cdkd-concept references the literal `cdkd` grep missed — `AssetError` /
  `DockerAssetPublisher` / "the publisher" in `docker-image-builder.ts` + `ecr-puller.ts`
  (dangling references to symbols that do not exist in cdk-local). Fixed in this PR.
- **Live-test**: built CLI artifact smoke (`node dist/cli.js --version` / `--help`) healthy.
  No runtime behavior change (comment-only).
- **Docker integ**: not run. The change is comment-only (runtime `dist/*.js` identical to
  `main`), the `integ-gate` hook is not yet installed, and the local pre-flight was blocked
  by pre-existing containers from a possibly-parallel session that were left undisturbed.

## Known cost

- The spec reviewer noted minor comment line-wrap reflow left by prefix removal
  (grammatically intact, `format` passes) — accepted as cosmetic.

## Test plan

- [x] `vp run check` / `vp run build` / `vp test run`
- [x] 3-axis read-only review + fix-back
- [x] built-CLI smoke
