### PR TITLE
docs: add README badges + GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Report a problem with cdk-local (the `cdkl` CLI or library)
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! cdk-local runs your CDK app's compute in Docker
+        and (with `--from-cfn-stack`) talks to real AWS, so most issues hinge on
+        the environment. Please include the versions and the exact command below —
+        it lets us reproduce quickly.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen, and what happened instead?
+      placeholder: Expected the route to return 200; got a 502 with "..." in the logs.
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: The exact `cdkl` command you ran (redact any real ARNs / account IDs / secrets).
+      placeholder: cdkl start-api --from-cfn-stack MyStack --port 8080
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output / logs
+      description: Re-run with `--verbose` and paste the relevant output. Redact secrets.
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: cdkl-version
+    attributes:
+      label: cdk-local version
+      description: From `cdkl --version`, or the version in your package.json / lockfile.
+      placeholder: 0.35.1
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / architecture
+      placeholder: macOS 14.5 (arm64) / Ubuntu 22.04 (x86_64)
+    validations:
+      required: true
+  - type: input
+    id: docker-version
+    attributes:
+      label: Docker version
+      description: From `docker version --format '{{.Server.Version}}'`.
+      placeholder: "27.1.1"
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: From `node --version`.
+      placeholder: v20.11.0
+    validations:
+      required: true
+  - type: textarea
+    id: cdk-context
+    attributes:
+      label: Relevant CDK app context
+      description: >-
+        The relevant construct snippet and/or your `cdk.json` `app` command.
+        A minimal CDK app that reproduces the issue is the fastest path to a fix.
+      render: typescript
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a capability or improvement for cdk-local
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        cdk-local runs your **application compute** locally and talks to real AWS
+        for managed services — it deliberately does NOT emulate managed services.
+        Requests that fit that scope (Lambda / API Gateway / ECS coverage, the
+        `--from-cfn-stack` binding, CLI ergonomics) are the best fit.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that cdk-local doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like cdk-local to do? A CLI sketch helps.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other tools you compared against.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # cdk-local
 
+[![npm version](https://img.shields.io/npm/v/cdk-local.svg)](https://www.npmjs.com/package/cdk-local)
+[![CI](https://github.com/go-to-k/cdk-local/actions/workflows/ci.yml/badge.svg)](https://github.com/go-to-k/cdk-local/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/npm/l/cdk-local.svg)](./LICENSE)
+
 Local runner for your CDK app's Lambda functions, API Gateway, and ECS tasks/services. Run it with no AWS account, or bind it to your deployed stack to hit real AWS resources and data. A native, CDK-first alternative to `sam local`.
 
 ![cdkl start-api serving a local CDK app's HTTP API; curl in the right pane reaches the local Lambda](assets/cdkl-start-api.gif)


### PR DESCRIPTION
## Summary

Release-hygiene polish for the public package (no functional change):

- **README badges** under the title: npm version, CI status, and license.
- **GitHub issue forms** (`.github/ISSUE_TEMPLATE/`):
  - **Bug report** — asks for the exact `cdkl` command plus cdk-local / OS / Docker / Node versions and a minimal repro, since most issues are environment-specific (Docker + AWS).
  - **Feature request** — scoped to cdk-local's compute-local / `--from-cfn-stack` surface.

## Test plan

- [x] `vp run check` / `vp run build` / `vp test run` (82 files, 1173 tests) pass — no `src/`/`tests/` touched.
- [x] Badge URLs are the standard shields.io / GitHub-Actions endpoints for the published package + the existing `ci.yml` workflow.
- [x] Issue forms follow GitHub's issue-form schema (GitHub validates them on push).
