### PR TITLE
fix(invoke-agentcore): validate --event before starting the container

### DIFF
--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -215,6 +215,12 @@ async function localInvokeAgentCoreCommand(
     const resolved = resolveAgentCoreTarget(resolvedTarget, stacks);
     logger.info(`Target: ${resolved.stack.stackName}/${resolved.logicalId} (${resolved.protocol})`);
 
+    // Read + validate the event (and resolve the session id) BEFORE any
+    // Docker work, so a bad --event / --event-stdin fails fast instead of
+    // after paying for an image build + container boot.
+    const sessionId = options.sessionId ?? randomUUID();
+    const event = await readEvent(options);
+
     const image = await resolveAgentCoreImage(resolved, options);
 
     const dockerEnv = await buildContainerEnv(
@@ -253,8 +259,6 @@ async function localInvokeAgentCoreCommand(
 
     await waitForAgentCorePing(containerHost, hostPort);
 
-    const sessionId = options.sessionId ?? randomUUID();
-    const event = await readEvent(options);
     const result = await invokeAgentCore(containerHost, hostPort, event, {
       sessionId,
       timeoutMs: 120_000,
@@ -470,7 +474,7 @@ export function emitResult(result: AgentCoreInvokeResult): void {
 }
 
 /** Map a `--platform` value to the architecture `buildContainerImage` expects. */
-function platformToArchitecture(platform: string): 'x86_64' | 'arm64' {
+export function platformToArchitecture(platform: string): 'x86_64' | 'arm64' {
   return platform === 'linux/amd64' ? 'x86_64' : 'arm64';
 }
 
@@ -516,7 +520,7 @@ async function assumeAgentCoreExecutionRole(
   }
 }
 
-async function readEvent(options: LocalInvokeAgentCoreOptions): Promise<unknown> {
+export async function readEvent(options: LocalInvokeAgentCoreOptions): Promise<unknown> {
   if (options.event && options.eventStdin) {
     throw new Error('--event and --event-stdin are mutually exclusive.');
   }
@@ -524,7 +528,15 @@ async function readEvent(options: LocalInvokeAgentCoreOptions): Promise<unknown>
     return parseEvent(await readStdin(), '<stdin>');
   }
   if (options.event) {
-    return parseEvent(readFileSync(options.event, 'utf-8'), options.event);
+    let raw: string;
+    try {
+      raw = readFileSync(options.event, 'utf-8');
+    } catch (err) {
+      throw new Error(
+        `Failed to read --event file '${options.event}': ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    return parseEvent(raw, options.event);
   }
   return {};
 }
@@ -547,7 +559,7 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString('utf-8');
 }
 
-function readEnvOverridesFile(filePath: string | undefined): EnvOverrideFile | undefined {
+export function readEnvOverridesFile(filePath: string | undefined): EnvOverrideFile | undefined {
   if (!filePath) return undefined;
   let raw: string;
   try {

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -53,9 +53,17 @@ vi.mock('../../../src/local/docker-runner.js', async (importActual) => ({
   pullImage: pullImageMock,
 }));
 
-const { resolveAgentCoreImage, emitResult, buildContainerEnv } = await import(
-  '../../../src/cli/commands/local-invoke-agentcore.js'
-);
+const {
+  resolveAgentCoreImage,
+  emitResult,
+  buildContainerEnv,
+  readEvent,
+  readEnvOverridesFile,
+  platformToArchitecture,
+} = await import('../../../src/cli/commands/local-invoke-agentcore.js');
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-resolver.js';
 
 function runtime(
@@ -189,5 +197,86 @@ describe('buildContainerEnv — --from-cfn-stack env substitution', () => {
     expect(fakeProvider.load).toHaveBeenCalled();
     expect(fakeProvider.dispose).toHaveBeenCalled();
     expect(dockerEnv['TABLE_NAME']).toBe('tbl-123');
+  });
+});
+
+const opts = (o: Record<string, unknown>) => o as unknown as Parameters<typeof readEvent>[0];
+
+describe('readEvent', () => {
+  it('defaults to {} when no event is given', async () => {
+    expect(await readEvent(opts({}))).toEqual({});
+  });
+
+  it('rejects when --event and --event-stdin are both set', async () => {
+    await expect(readEvent(opts({ event: 'e.json', eventStdin: true }))).rejects.toThrow(
+      /mutually exclusive/
+    );
+  });
+
+  it('reads + parses a JSON --event file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-agentcore-event-'));
+    const file = join(dir, 'event.json');
+    writeFileSync(file, '{"prompt":"hi","n":3}', 'utf-8');
+    expect(await readEvent(opts({ event: file }))).toEqual({ prompt: 'hi', n: 3 });
+  });
+
+  it('throws a clear error for a malformed --event JSON file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-agentcore-event-'));
+    const file = join(dir, 'bad.json');
+    writeFileSync(file, '{not json', 'utf-8');
+    await expect(readEvent(opts({ event: file }))).rejects.toThrow(/Failed to parse event payload/);
+  });
+
+  it('throws a clear error when the --event file cannot be read', async () => {
+    await expect(readEvent(opts({ event: '/no/such/cdkl-agentcore-event.json' }))).rejects.toThrow(
+      /Failed to read --event file/
+    );
+  });
+});
+
+describe('readEnvOverridesFile', () => {
+  it('returns undefined when no path is given', () => {
+    expect(readEnvOverridesFile(undefined)).toBeUndefined();
+  });
+
+  it('throws when the file cannot be read', () => {
+    expect(() => readEnvOverridesFile('/no/such/cdkl-agentcore-env.json')).toThrow(
+      /Failed to read --env-vars file/
+    );
+  });
+
+  it('throws on malformed JSON', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-agentcore-env-'));
+    const file = join(dir, 'bad.json');
+    writeFileSync(file, '{nope', 'utf-8');
+    expect(() => readEnvOverridesFile(file)).toThrow(/Failed to parse --env-vars file/);
+  });
+
+  it('throws when the top level is not a JSON object', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-agentcore-env-'));
+    const file = join(dir, 'arr.json');
+    writeFileSync(file, '["a","b"]', 'utf-8');
+    expect(() => readEnvOverridesFile(file)).toThrow(/must contain a JSON object/);
+  });
+
+  it('parses a valid SAM-shape override object', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-agentcore-env-'));
+    const file = join(dir, 'ok.json');
+    writeFileSync(file, '{"Parameters":{"GREETING":"hi"}}', 'utf-8');
+    expect(readEnvOverridesFile(file)).toEqual({ Parameters: { GREETING: 'hi' } });
+  });
+});
+
+describe('platformToArchitecture', () => {
+  it('maps linux/amd64 to x86_64', () => {
+    expect(platformToArchitecture('linux/amd64')).toBe('x86_64');
+  });
+
+  it('maps linux/arm64 to arm64', () => {
+    expect(platformToArchitecture('linux/arm64')).toBe('arm64');
+  });
+
+  it('defaults any other value to arm64 (AgentCore-required arch)', () => {
+    expect(platformToArchitecture('something-else')).toBe('arm64');
   });
 });


### PR DESCRIPTION
## Summary

Addresses the review nit from (#126): `cdkl invoke-agentcore` validated the
`--event` payload only after building + starting the agent container, so a
typo'd path or malformed JSON cost a full container boot before failing.

- Read + validate the event (and resolve the session id) right after target
  resolution — **before** image acquisition / container run / readiness wait —
  so bad `--event` / `--event-stdin` input fails fast.
- Wrap the `--event` file read in a clear `Failed to read --event file '<path>'`
  error, matching the existing `--env-vars` behavior (previously a raw ENOENT).
- Export `readEvent` / `readEnvOverridesFile` / `platformToArchitecture` and add
  unit tests for their previously-uncovered branches (mutual-exclusion, file
  read / JSON parse / non-object failures, and the amd64 -> x86_64 / default
  arm64 mapping).

No behavior change to the success path; the agent container still runs, pings,
and is invoked exactly as before.

## Test plan

- [x] `vp run verify` (typecheck + lint + format + build + unit tests) — 1221 tests pass.
- [x] New unit tests cover the event/env file error branches + platform mapping.
- [x] Live fail-fast check: `invoke-agentcore <target> --event /nonexistent.json`
  now errors after synth but before any `docker build` / container start (0
  containers created).
- [x] Real-Docker integ `tests/integration/local-invoke-agentcore/` still green
  (4/4: echo + session-id header + env injection + `--session-id`), 0 orphans.
