### PR TITLE
chore(start-alb): warn on no-match --lb-port + doc/test follow-ups

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,7 +63,7 @@ Gateway).
 `src/` layout:
 
 - `src/cli/` — Commander command factories (`createLocalInvokeCommand`,
-  `createLocalInvokeAgentCommand`, `createLocalStartApiCommand`,
+  `createLocalInvokeAgentCoreCommand`, `createLocalStartApiCommand`,
   `createLocalRunTaskCommand`, `createLocalStartServiceCommand`,
   `createLocalStartAlbCommand`, `createLocalListCommand`) + shared option
   helpers. `start-service` and `start-alb` share one neutral orchestration

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -821,14 +821,16 @@ default 3), and keeps every replica running until `^C`. Failed
 replicas restart per `--restart-policy` with exponential backoff (1s →
 30s capped) so a crash-looping container does not hammer docker.
 
-Each replica gets its own per-task docker network on a UNIQUE
-`169.254.<N>.0/24` subnet (170, 171, 172, ...) so concurrent replicas
-don't collide on a single /24 — the same metadata-endpoint sidecar
-starts at `169.254.<N>.2` per replica.
+Every replica booted in one CLI invocation joins ONE shared docker
+network (`<cluster>-svc-<rand>`, subnet `169.254.171.0/24`, with the
+metadata-endpoint sidecar at `169.254.171.2`) so peer services reach
+each other by container IP / network alias without `docker network
+connect` choreography. (`cdkl run-task` differs — it uses a per-task
+network on `169.254.170.0/24`.)
 
 When two or more `<targets>` are supplied, every service is booted into
-a shared Cloud Map / Service Connect registry so peer services discover
-each other via a `docker --add-host` DNS overlay.
+a shared Cloud Map / Service Connect registry on that one network so peer
+services discover each other via a `docker --add-host` DNS overlay.
 
 > **Host-port publishing and multi-replica services.** A
 > **single-replica** service publishes its container `PortMappings` to

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -153,6 +153,7 @@ function notFound(
  * names the API and serves its backing Lambdas.
  */
 export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrategy {
+  const lbPortOverrides = parseLbPortOverrides(options.lbPort);
   return {
     pickEntries: (stacks) => listTargets(stacks).loadBalancers,
     pickerMessage: 'Select one or more Application Load Balancers to run',
@@ -179,9 +180,24 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
           }
         }
       }
-      return { boots: [...byServiceTarget.values()], warnings };
+      const boots = [...byServiceTarget.values()];
+      // Warn about a `--lb-port <listenerPort>=...` override whose listener
+      // port matched NONE of the resolved front-door listeners — almost always
+      // a typo, and otherwise a silent no-op.
+      const resolvedPorts = new Set<number>();
+      for (const b of boots) for (const t of b.frontDoorTargets) resolvedPorts.add(t.listenerPort);
+      for (const portStr of Object.keys(lbPortOverrides)) {
+        const port = Number(portStr);
+        if (!resolvedPorts.has(port)) {
+          warnings.push(
+            `--lb-port override for listener port ${port} matched no ALB listener resolved for ` +
+              'the named target(s); it was ignored.'
+          );
+        }
+      }
+      return { boots, warnings };
     },
-    lbPortOverrides: parseLbPortOverrides(options.lbPort),
+    lbPortOverrides,
   };
 }
 

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -164,6 +164,35 @@ describe('resolveAlbFrontDoor', () => {
     expect(warnings.join('\n')).toMatch(/non-Ref TargetGroupArn/);
   });
 
+  it('warns on a non-Ref target group inside a ForwardConfig.TargetGroups[] (weighted)', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [
+            {
+              Type: 'forward',
+              ForwardConfig: {
+                TargetGroups: [
+                  {
+                    TargetGroupArn:
+                      'arn:aws:elasticloadbalancing:us-east-1:111:targetgroup/imported/abc',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(services).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/non-Ref TargetGroupArn/);
+  });
+
   it('skips a redirect-only listener silently (no warning)', () => {
     const stack = stackWith({
       [LISTENER]: {

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -145,6 +145,24 @@ describe('albStrategy.resolveBoots multi-service', () => {
   });
 });
 
+describe('albStrategy --lb-port no-match warning', () => {
+  it('warns when a --lb-port override matches no resolved listener', () => {
+    const { warnings } = albStrategy({ lbPort: ['9999=8080'] } as never).resolveBoots(
+      [albStack()],
+      ['AlbStack:WebLB']
+    );
+    expect(warnings.join('\n')).toMatch(/--lb-port override for listener port 9999 matched no/);
+  });
+
+  it('does not warn when the --lb-port override matches a resolved listener', () => {
+    const { warnings } = albStrategy({ lbPort: ['80=8080'] } as never).resolveBoots(
+      [albStack()],
+      ['AlbStack:WebLB']
+    );
+    expect(warnings.join('\n')).not.toMatch(/--lb-port override/);
+  });
+});
+
 describe('start-alb / start-service strategy binding', () => {
   it('start-alb resolves an ALB target into backing-service boots WITH front-door targets', () => {
     const strategy = albStrategy({ lbPort: ['80=8080'] } as never);


### PR DESCRIPTION
## Summary

Small follow-ups from the `#125` (issue `#86`) review's accepted nice-to-haves. No behavior change beyond one new warning.

- `start-alb` now **warns** when a `--lb-port <listenerPort>=...` override matches none of the resolved ALB listeners (almost always a typo) instead of silently ignoring it.
- Resolver test now covers the `ForwardConfig.TargetGroups[]` (weighted-forward) non-`Ref` target-group branch (only the direct `TargetGroupArn` form was tested).
- `docs/cli-reference.md`: corrected a stale claim — it said each replica gets its own per-task network on a unique `169.254.<N>.0/24` subnet, but `start-service` / `start-alb` actually use ONE shared network (`169.254.171.0/24`) per CLI invocation (as the `local-start-service` integ asserts).
- `.claude/CLAUDE.md`: fixed a factory name (`createLocalInvokeAgentCommand` -> `createLocalInvokeAgentCoreCommand`).

## Test plan

- [x] `vp run verify` (typecheck + lint + format + tests + build) green — 92 files / 1271 tests
- [x] New unit tests: the `--lb-port` no-match warning (and no false warning when it does match); the `ForwardConfig.TargetGroups[]` non-`Ref` resolver warning
- [x] The code change is resolution-time only (the warning is emitted in `resolveBoots`, before any Docker work); the Docker runtime path is unchanged and remains covered by the `local-start-alb` integ
