### PR TITLE
fix(ecs): always log the published host port

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ curl http://127.0.0.1:8080/   # round-robins across the running replicas
 
 See [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally) for `start-alb`'s resolution model and scope (single HTTP `forward`, ECS targets).
 
+When you run a container directly — `run-task`, or a single-replica `start-service` — cdk-local publishes its declared container ports on the host and logs the address (`Reach it at 127.0.0.1:<port>`), so `curl http://127.0.0.1:<port>` or a browser reaches it. The bind IP defaults to `127.0.0.1` (override with `--container-host`); `--host-port <containerPort>=<hostPort>` remaps a port (handy on macOS to avoid the Docker admin prompt for privileged ports < 1024). For an ALB-fronted service, reach the replicas through the `start-alb` front-door above instead.
+
 `invoke-agentcore` runs a Bedrock AgentCore Runtime's container locally, waits for `GET /ping`, then POSTs your `--event` (or `{}`) to `POST /invocations` and prints the response — the same request/response loop AgentCore runs in the cloud, without a deploy. v1 covers container-artifact runtimes on the HTTP protocol; the agent's own calls to Bedrock models / memory / other managed services go to real AWS.
 
 Use this for fast iteration on Lambda code, API routing checks, container task smoke tests, and agent request/response checks.

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -1049,14 +1049,13 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
       if (ephemeralPorts.has(pm.containerPort)) continue;
       const declaredHostPort = pm.hostPort ?? pm.containerPort;
       const hostPort = opts.hostPortOverrides?.[pm.containerPort] ?? declaredHostPort;
-      if (hostPort !== declaredHostPort) {
-        getLogger()
-          .child('ecs')
-          .info(
-            `Container '${container.name}' container port ${pm.containerPort} published on ` +
-              `${containerHost}:${hostPort} (--host-port override). Reach it at ${containerHost}:${hostPort}.`
-          );
-      }
+      const overrideNote = hostPort !== declaredHostPort ? ' (--host-port override)' : '';
+      getLogger()
+        .child('ecs')
+        .info(
+          `Container '${container.name}' container port ${pm.containerPort} published on ` +
+            `${containerHost}:${hostPort}${overrideNote}. Reach it at ${containerHost}:${hostPort}.`
+        );
       args.push('-p', `${containerHost}:${hostPort}:${pm.containerPort}/${pm.protocol}`);
     }
   }

--- a/tests/unit/local/ecs-publish-host-port.test.ts
+++ b/tests/unit/local/ecs-publish-host-port.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vite-plus/test';
 import { buildDockerRunArgs, parseHostPortOverrides } from '../../../src/local/ecs-task-runner.js';
 import type { ResolvedEcsContainer, ResolvedEcsTask } from '../../../src/local/ecs-task-resolver.js';
 
@@ -44,8 +44,8 @@ function containerWithPort(): ResolvedEcsContainer {
 
 const task = { family: 'fam' } as unknown as ResolvedEcsTask;
 
-function publishArg(hostPortOverrides?: Record<number, number>): string | undefined {
-  const { args } = buildDockerRunArgs({
+function baseOpts(): Parameters<typeof buildDockerRunArgs>[0] {
+  return {
     task,
     container: containerWithPort(),
     image: 'public.ecr.aws/docker/library/busybox:latest',
@@ -57,6 +57,12 @@ function publishArg(hostPortOverrides?: Record<number, number>): string | undefi
     roleArn: undefined,
     platformOverride: undefined,
     region: undefined,
+  };
+}
+
+function publishArg(hostPortOverrides?: Record<number, number>): string | undefined {
+  const { args } = buildDockerRunArgs({
+    ...baseOpts(),
     ...(hostPortOverrides && { hostPortOverrides }),
   });
   const i = args.indexOf('-p');
@@ -157,5 +163,42 @@ describe('buildDockerRunArgs ALB front-door ephemeral publish (#86)', () => {
 
   it('emits no ephemeral publish when the list is empty', () => {
     expect(allPublishArgs({ skipHostPortPublish: true })).toEqual([]);
+  });
+});
+
+describe('buildDockerRunArgs port-publish logging', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  function reachLine(): string | undefined {
+    return infoSpy.mock.calls.map((c) => String(c[0])).find((m) => m.includes('Reach it at'));
+  }
+
+  it('logs the published host:port even without a --host-port override', () => {
+    publishArg();
+    const line = reachLine();
+    expect(line).toBeDefined();
+    expect(line).toContain('Reach it at 127.0.0.1:80');
+    expect(line).not.toContain('--host-port override');
+  });
+
+  it('annotates the log with (--host-port override) when the port is remapped', () => {
+    publishArg({ 80: 8080 });
+    const line = reachLine();
+    expect(line).toBeDefined();
+    expect(line).toContain('Reach it at 127.0.0.1:8080');
+    expect(line).toContain('(--host-port override)');
+  });
+
+  it('does not log a published port when host-port publish is skipped (multi-replica)', () => {
+    buildDockerRunArgs({ ...baseOpts(), skipHostPortPublish: true });
+    expect(reachLine()).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- `buildDockerRunArgs` previously logged the `Reach it at <host>:<port>` line **only** when `--host-port` remapped the port, so a `run-task` or single-replica `start-service` that published its container port on the default host port gave the user no indication of which port to hit.
- Now the published address is **always** logged; the `(--host-port override)` note is appended only when the port was actually remapped. ALB front-door ephemeral ports are unaffected — they `continue` before the log, so `start-alb` never advertises a direct ephemeral port.
- README: documents direct container access (the published port + `Reach it at` log, `--container-host` / `--host-port`) under the ECS section. The multi-replica / load-balancer story stays owned by the `start-alb` vs `start-service` section.

## Test plan

- [x] `vp run check` (typecheck + lint + format, 92 files)
- [x] `vp run build`
- [x] `vp test run` — 92 files / 1271 unit tests pass; new `buildDockerRunArgs port-publish logging` cases cover the default-case log, the `--host-port override` annotation, and the multi-replica skip case (no log)
- [x] Live-test via the `local-run-task` integ: real `cdkl run-task` now prints `Container 'web' container port 80 published on 127.0.0.1:18080. Reach it at 127.0.0.1:18080.` and `curl` returns HTTP 200; 0 Docker orphans afterward

## Notes

- Rebased onto the merged `start-alb` work. The README paragraph was trimmed to the single-replica / direct-access slice so it neither duplicates nor contradicts the new `start-alb` section (which now owns the multi-replica + front-door story).
