### PR TITLE
feat(invoke-agentcore): verify inbound JWT auth (customJwtAuthorizer)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,7 +30,9 @@ AWS managed services.
 - Bedrock AgentCore Runtime agents — the agent container served over the
   AgentCore HTTP contract (`POST /invocations` + `GET /ping` on port 8080),
   invoked once locally (`cdkl invoke-agentcore`); v1 covers container artifacts
-  on the HTTP protocol
+  on the HTTP protocol. An inbound `customJwtAuthorizer` is enforced locally —
+  `--bearer-token` is verified against the runtime's OIDC discovery URL before
+  the container starts and forwarded to `/invocations`
 - API Gateway authorizers — Lambda authorizers, Cognito User Pool JWT
   verification, IAM SigV4 verification
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cdkl invoke-agentcore MyStack/ChatAgent --event ./event.json
 
 For ECS there is no cluster command — locally, Docker is the placement target a cluster abstracts away. Both `run-task` and `start-service` accept an optional `--cluster <name>`; `start-service` also wires Service Connect / Cloud Map registry. See [docs/cli-reference.md](docs/cli-reference.md) for the full ECS option list.
 
-`invoke-agentcore` runs a Bedrock AgentCore Runtime's container locally, waits for `GET /ping`, then POSTs your `--event` (or `{}`) to `POST /invocations` and prints the response — the same request/response loop AgentCore runs in the cloud, without a deploy. v1 covers container-artifact runtimes on the HTTP protocol; the agent's own calls to Bedrock models / memory / other managed services go to real AWS.
+`invoke-agentcore` runs a Bedrock AgentCore Runtime's container locally, waits for `GET /ping`, then POSTs your `--event` (or `{}`) to `POST /invocations` and prints the response — the same request/response loop AgentCore runs in the cloud, without a deploy. v1 covers container-artifact runtimes on the HTTP protocol; the agent's own calls to Bedrock models / memory / other managed services go to real AWS. When the runtime declares a JWT authorizer (`customJwtAuthorizer`), pass `--bearer-token <jwt>` — it's verified against the runtime's OIDC discovery URL (signature / issuer / expiry / audience) and forwarded to `/invocations`, the way AgentCore gates inbound requests; a missing or invalid token is rejected before the container starts (use `--no-verify-auth` to skip for local dev).
 
 Use this for fast iteration on Lambda code, API routing checks, container task smoke tests, and agent request/response checks.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -447,6 +447,8 @@ prefix. Omit the target in a TTY to pick from a list.
 | `--event-stdin` | off | Read the event JSON from stdin instead of a file (mutually exclusive with `--event`). |
 | `--env-vars <file>` | — | JSON env-var overrides, SAM-compatible shape: `{"LogicalId":{"KEY":"VALUE"}}` plus an optional top-level `"Parameters"` block. `null` clears a key. |
 | `--session-id <id>` | random UUID | Value for the `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` request header. |
+| `--bearer-token <jwt>` | — | Bearer JWT to present when the runtime declares a `customJwtAuthorizer`. Verified against the runtime's OIDC discovery URL (signature / `iss` / `exp` / audience) before the container starts, then forwarded to `/invocations` as `Authorization: Bearer <jwt>`. |
+| `--no-verify-auth` | off (verify on) | Skip inbound JWT verification even when the runtime declares a `customJwtAuthorizer` (local-dev escape hatch). A `--bearer-token`, if given, is still forwarded. |
 | `--platform <platform>` | `linux/arm64` | `docker --platform` for the agent container (AgentCore requires ARM64; override to `linux/amd64` if needed). |
 | `--no-pull` | off | Skip `docker pull` (use the cached image). No-op for the local-build path. |
 | `--no-build` | off | Skip `docker build` on the local-asset path (reuse the previously-built tag). No-op for the ECR / registry pull paths. |
@@ -463,6 +465,29 @@ the container. Precedence matches `cdkl invoke`: `--assume-role` (STS
 temp creds) wins, otherwise the developer's shell credentials are
 forwarded, overlaid with `--profile` when set (and the bind-mounted
 shared-credentials file so `fromIni({ profile })` resolves).
+
+### Inbound JWT auth (`customJwtAuthorizer`)
+
+When the runtime declares an `AuthorizerConfiguration.CustomJWTAuthorizer`,
+`cdkl invoke-agentcore` enforces it the way AgentCore does in the cloud —
+before the container starts:
+
+- **No `--bearer-token`** → rejected (AgentCore returns 401). Pass a token,
+  or `--no-verify-auth` to skip for local dev.
+- **`--bearer-token <jwt>`** → the token is verified against the runtime's
+  OIDC discovery URL: the discovery document is fetched for its `issuer` +
+  `jwks_uri`, then the JWT's RS256 signature, `iss`, `exp`, and audience are
+  checked (the audience allowlist is `allowedAudience` ∪ `allowedClients`,
+  matched against `aud` / `client_id`). An invalid token is rejected
+  (AgentCore returns 403); a valid one is forwarded to `/invocations` as
+  `Authorization: Bearer <jwt>`.
+- **Discovery URL / JWKS unreachable** → falls back to pass-through (accept +
+  warn), the same offline-dev trade-off `cdkl start-api` makes for
+  unreachable Cognito JWKS.
+- **`--no-verify-auth`** → skips verification entirely; a `--bearer-token`,
+  if given, is still forwarded.
+
+`allowedScopes` + `customClaims` validation is not yet enforced (follow-up).
 
 ### Streaming responses
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -37,6 +37,7 @@ import {
   waitForAgentCorePing,
   type AgentCoreInvokeResult,
 } from '../../local/agentcore-client.js';
+import { createJwksCache, verifyJwtViaDiscovery } from '../../local/cognito-jwt.js';
 import { resolveEnvVars, type EnvOverrideFile } from '../../local/env-resolver.js';
 import {
   substituteEnvVarsFromStateAsync,
@@ -83,6 +84,18 @@ interface LocalInvokeAgentCoreOptions {
   platform: string;
   /** Session id forwarded via the AgentCore session-id header (auto-generated when omitted). */
   sessionId?: string;
+  /**
+   * Bearer JWT to present when the runtime declares a `customJwtAuthorizer`.
+   * Verified against the runtime's OIDC discovery URL before the container
+   * starts, then forwarded to `/invocations` as `Authorization: Bearer <jwt>`.
+   */
+  bearerToken?: string;
+  /**
+   * Commander maps `--no-verify-auth` to `verifyAuth: boolean` (default
+   * `true`). When `false`, skip inbound JWT verification entirely (local-dev
+   * escape hatch) — the token, if any, is still forwarded.
+   */
+  verifyAuth: boolean;
   /**
    * Optional execution role to assume before invoking. Commander's `[arn]`
    * maps to `string | boolean`:
@@ -221,6 +234,12 @@ async function localInvokeAgentCoreCommand(
     const sessionId = options.sessionId ?? randomUUID();
     const event = await readEvent(options);
 
+    // Inbound JWT auth: when the runtime declares a customJwtAuthorizer,
+    // verify the supplied bearer token against its OIDC discovery URL BEFORE
+    // any Docker work — rejecting a missing / invalid token the way AgentCore
+    // does. Returns the `Authorization` header to forward to the container.
+    const authorization = await resolveInboundAuthorization(resolved, options);
+
     const image = await resolveAgentCoreImage(resolved, options);
 
     const dockerEnv = await buildContainerEnv(
@@ -262,6 +281,7 @@ async function localInvokeAgentCoreCommand(
     const result = await invokeAgentCore(containerHost, hostPort, event, {
       sessionId,
       timeoutMs: 120_000,
+      ...(authorization && { authorization }),
     });
 
     // Settle so container logs flush before teardown.
@@ -271,6 +291,68 @@ async function localInvokeAgentCoreCommand(
     if (sigintHandler) process.off('SIGINT', sigintHandler);
     await cleanup();
   }
+}
+
+/**
+ * Enforce the runtime's inbound JWT authorizer (when declared) and return
+ * the `Authorization` header to forward to `/invocations`.
+ *
+ * - No authorizer → forward the token verbatim if one was given (no-op
+ *   otherwise).
+ * - `--no-verify-auth` → warn + forward without verifying (local-dev escape).
+ * - Authorizer + no token → reject (AgentCore returns 401).
+ * - Authorizer + token → verify against the OIDC discovery URL; reject on
+ *   failure (AgentCore returns 403); forward on success. An unreachable
+ *   discovery URL falls back to pass-through accept (offline-dev fallback in
+ *   {@link verifyJwtViaDiscovery}).
+ *
+ * Exported so a unit test can drive the gate without the full Docker pipeline.
+ */
+export async function resolveInboundAuthorization(
+  resolved: ResolvedAgentCoreRuntime,
+  options: { bearerToken?: string; verifyAuth: boolean }
+): Promise<string | undefined> {
+  const logger = getLogger();
+  const authorizer = resolved.jwtAuthorizer;
+  const header = options.bearerToken ? `Bearer ${options.bearerToken}` : undefined;
+
+  if (!authorizer) return header;
+
+  if (options.verifyAuth === false) {
+    logger.warn(
+      `Runtime '${resolved.logicalId}' declares a customJwtAuthorizer, but --no-verify-auth was set — ` +
+        `skipping inbound JWT verification (local-dev escape hatch).`
+    );
+    return header;
+  }
+
+  if (!header) {
+    throw new CdkLocalError(
+      `Runtime '${resolved.logicalId}' requires an inbound JWT (customJwtAuthorizer). ` +
+        `Pass --bearer-token <jwt>, or --no-verify-auth to skip verification for local dev.`,
+      'LOCAL_INVOKE_AGENTCORE_AUTH_REQUIRED'
+    );
+  }
+
+  const result = await verifyJwtViaDiscovery(
+    {
+      discoveryUrl: authorizer.discoveryUrl,
+      ...(authorizer.allowedAudience && { allowedAudience: authorizer.allowedAudience }),
+      ...(authorizer.allowedClients && { allowedClients: authorizer.allowedClients }),
+    },
+    header,
+    createJwksCache(),
+    { warned: new Set() }
+  );
+  if (!result.allow) {
+    throw new CdkLocalError(
+      `Inbound JWT rejected by the runtime's customJwtAuthorizer ` +
+        `(signature / issuer / expiry / audience check failed against ${authorizer.discoveryUrl}).`,
+      'LOCAL_INVOKE_AGENTCORE_AUTH_DENIED'
+    );
+  }
+  logger.info(`Inbound JWT verified against ${authorizer.discoveryUrl}.`);
+  return header;
 }
 
 /**
@@ -613,6 +695,22 @@ export function createLocalInvokeAgentCoreCommand(
       new Option(
         '--session-id <id>',
         'AgentCore runtime session id header value (default: a random UUID)'
+      )
+    )
+    .addOption(
+      new Option(
+        '--bearer-token <jwt>',
+        'Bearer JWT to present when the runtime declares a customJwtAuthorizer. ' +
+          'Verified against the runtime OIDC discovery URL (signature / issuer / expiry / ' +
+          'audience) before the container starts, then forwarded to /invocations as ' +
+          'Authorization: Bearer <jwt>.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--no-verify-auth',
+        'Skip inbound JWT verification even when the runtime declares a customJwtAuthorizer ' +
+          '(local-dev escape hatch). A --bearer-token, if given, is still forwarded.'
       )
     )
     .addOption(

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,9 @@ export {
   buildJwksUrlFromIssuer,
   verifyCognitoJwt,
   verifyJwtAuthorizer,
+  verifyJwtViaDiscovery,
   type JwksCache,
+  type DiscoveryJwtAuthorizer,
 } from './local/cognito-jwt.js';
 export {
   buildMethodArn,
@@ -386,6 +388,7 @@ export {
   AGENTCORE_RUNTIME_TYPE,
   AGENTCORE_HTTP_PROTOCOL,
   type ResolvedAgentCoreRuntime,
+  type AgentCoreJwtAuthorizer,
 } from './local/agentcore-resolver.js';
 export {
   waitForAgentCorePing,

--- a/src/local/agentcore-client.ts
+++ b/src/local/agentcore-client.ts
@@ -127,6 +127,12 @@ export interface InvokeAgentCoreOptions {
   sessionId: string;
   /** Abort the request after this many ms. */
   timeoutMs: number;
+  /**
+   * Optional `Authorization` header to forward (e.g. `Bearer <jwt>`). Real
+   * AgentCore forwards the validated request to the container, so agents
+   * that read the header behave the same locally. Omitted when unset.
+   */
+  authorization?: string;
 }
 
 /**
@@ -155,6 +161,7 @@ export async function invokeAgentCore(
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
         [AGENTCORE_SESSION_ID_HEADER]: options.sessionId,
+        ...(options.authorization && { Authorization: options.authorization }),
       },
       body,
       signal: controller.signal,

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -10,6 +10,7 @@ import {
 } from './intrinsic-image.js';
 import { parseTarget, type ParsedTarget } from './lambda-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
+import { getLogger } from '../utils/logger.js';
 
 /**
  * CloudFormation resource type for a Bedrock AgentCore Runtime.
@@ -66,6 +67,26 @@ export interface ResolvedAgentCoreRuntime {
   roleArn?: string;
   /** Always `HTTP` in v1 (validated at resolution time). */
   protocol: string;
+  /**
+   * `Properties.AuthorizerConfiguration.CustomJWTAuthorizer` when present
+   * with a literal `DiscoveryUrl` — the inbound JWT (OAuth / OIDC) authorizer
+   * AgentCore uses to gate `/invocations`. Undefined when the runtime is
+   * unauthenticated, or when `DiscoveryUrl` is an unresolved intrinsic.
+   */
+  jwtAuthorizer?: AgentCoreJwtAuthorizer;
+}
+
+/**
+ * The inbound custom-JWT authorizer config a runtime declares
+ * (`AuthorizerConfiguration.CustomJWTAuthorizer`). `discoveryUrl` is the
+ * OIDC discovery document URL (`.well-known/openid-configuration`);
+ * `allowedAudience` / `allowedClients` are the `aud` / `client_id`
+ * allowlists the token must satisfy.
+ */
+export interface AgentCoreJwtAuthorizer {
+  discoveryUrl: string;
+  allowedAudience?: string[];
+  allowedClients?: string[];
 }
 
 export class AgentCoreResolutionError extends Error {
@@ -221,6 +242,7 @@ function extractRuntimeProperties(
       : {};
 
   const roleArn = typeof props['RoleArn'] === 'string' ? props['RoleArn'] : undefined;
+  const jwtAuthorizer = extractJwtAuthorizer(props['AuthorizerConfiguration'], logicalId);
 
   return {
     stack,
@@ -230,6 +252,49 @@ function extractRuntimeProperties(
     environmentVariables,
     protocol,
     ...(roleArn !== undefined && { roleArn }),
+    ...(jwtAuthorizer !== undefined && { jwtAuthorizer }),
+  };
+}
+
+/**
+ * Extract a literal `CustomJWTAuthorizer` from `AuthorizerConfiguration`.
+ * Returns undefined when there is no authorizer, or when `DiscoveryUrl` is
+ * not a literal string (an unresolved intrinsic) — verification needs a
+ * concrete URL to fetch, so an intrinsic is warn-and-skipped by the caller.
+ */
+function extractJwtAuthorizer(
+  authorizerConfig: unknown,
+  logicalId: string
+): AgentCoreJwtAuthorizer | undefined {
+  if (
+    !authorizerConfig ||
+    typeof authorizerConfig !== 'object' ||
+    Array.isArray(authorizerConfig)
+  ) {
+    return undefined;
+  }
+  const jwt = (authorizerConfig as Record<string, unknown>)['CustomJWTAuthorizer'];
+  if (!jwt || typeof jwt !== 'object' || Array.isArray(jwt)) return undefined;
+  const cfg = jwt as Record<string, unknown>;
+
+  const discoveryUrl = cfg['DiscoveryUrl'];
+  if (typeof discoveryUrl !== 'string' || discoveryUrl.length === 0) {
+    getLogger().warn(
+      `AgentCore Runtime '${logicalId}' declares a CustomJWTAuthorizer whose DiscoveryUrl is not a literal string; ` +
+        `${getEmbedConfig().cliName} invoke-agentcore cannot verify inbound JWTs against it and will skip auth.`
+    );
+    return undefined;
+  }
+
+  const toStringArray = (v: unknown): string[] | undefined =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : undefined;
+  const allowedAudience = toStringArray(cfg['AllowedAudience']);
+  const allowedClients = toStringArray(cfg['AllowedClients']);
+
+  return {
+    discoveryUrl,
+    ...(allowedAudience && allowedAudience.length > 0 && { allowedAudience }),
+    ...(allowedClients && allowedClients.length > 0 && { allowedClients }),
   };
 }
 

--- a/src/local/cognito-jwt.ts
+++ b/src/local/cognito-jwt.ts
@@ -311,6 +311,99 @@ export async function verifyJwtAuthorizer(
   );
 }
 
+/**
+ * Inbound custom-JWT authorizer fronted by an OIDC discovery URL — the
+ * shape Bedrock AgentCore Runtime declares
+ * (`AuthorizerConfiguration.CustomJWTAuthorizer`).
+ */
+export interface DiscoveryJwtAuthorizer {
+  /** OIDC discovery document URL (`.well-known/openid-configuration`). */
+  discoveryUrl: string;
+  /** Allowed `aud` values. */
+  allowedAudience?: readonly string[];
+  /** Allowed `client_id` values. */
+  allowedClients?: readonly string[];
+}
+
+/**
+ * Verify a Bearer JWT against an OIDC-discovery-URL authorizer (Bedrock
+ * AgentCore Runtime's `customJwtAuthorizer`).
+ *
+ * Fetches the discovery document to learn the `issuer` + `jwks_uri`, then
+ * delegates to {@link verifyAndShape} for the RS256 signature + `iss` +
+ * `exp` + audience checks. The audience allowlist is
+ * `allowedAudience ∪ allowedClients`, matched against the token's `aud`
+ * (ID tokens) or `client_id` (access tokens).
+ *
+ * Failure modes mirror the JWKS-unreachable behavior: an absent / malformed
+ * Bearer token is denied, but an unreachable / malformed discovery document
+ * falls back to pass-through (accept + warn) so offline local dev still
+ * works — the same trade-off `cdkl start-api` makes for unreachable JWKS.
+ */
+export async function verifyJwtViaDiscovery(
+  authorizer: DiscoveryJwtAuthorizer,
+  authorizationHeader: string | undefined,
+  jwksCache: JwksCache,
+  opts: {
+    now?: () => number;
+    warned?: Set<string>;
+    fetchImpl?: (
+      url: string
+    ) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+  } = {}
+): Promise<CachedAuthorizerResult & { identityHash: string | undefined; ttlSeconds: number }> {
+  const now = opts.now ?? ((): number => Date.now());
+  const token = extractBearer(authorizationHeader);
+  if (!token) {
+    return { allow: false, identityHash: undefined, ttlSeconds: 0 };
+  }
+  const fetchImpl =
+    opts.fetchImpl ?? (async (url): ReturnType<typeof globalThis.fetch> => globalThis.fetch(url));
+
+  let issuer: string;
+  let jwksUri: string;
+  try {
+    const response = await fetchImpl(authorizer.discoveryUrl);
+    if (!response.ok) {
+      throw new Error(`discovery fetch returned HTTP ${response.status}`);
+    }
+    const doc = JSON.parse(await response.text()) as { issuer?: unknown; jwks_uri?: unknown };
+    if (typeof doc.issuer !== 'string' || typeof doc.jwks_uri !== 'string') {
+      throw new Error('discovery document missing issuer / jwks_uri');
+    }
+    issuer = doc.issuer;
+    jwksUri = doc.jwks_uri;
+  } catch (err) {
+    // Discovery unreachable / malformed → pass-through accept (offline dev),
+    // mirroring the JWKS-unreachable fallback in `createJwksCache`.
+    if (opts.warned && !opts.warned.has(authorizer.discoveryUrl)) {
+      opts.warned.add(authorizer.discoveryUrl);
+      getLogger()
+        .child('cognito-jwt')
+        .warn(
+          `OIDC discovery unreachable at ${authorizer.discoveryUrl}: ${
+            err instanceof Error ? err.message : String(err)
+          }. Token accepted without verification — local dev fallback.`
+        );
+    }
+    const identityHash = buildIdentityHash([token]);
+    const parsed = parseJwt(token);
+    if (parsed) return shapeAllowResult(parsed, identityHash, now);
+    return { allow: true, principalId: 'unknown', context: {}, identityHash, ttlSeconds: 0 };
+  }
+
+  const allowlist = [...(authorizer.allowedAudience ?? []), ...(authorizer.allowedClients ?? [])];
+  return verifyAndShape(
+    token,
+    jwksUri,
+    issuer.replace(/\/+$/, ''),
+    allowlist.length > 0 ? allowlist : undefined,
+    jwksCache,
+    opts.warned,
+    now
+  );
+}
+
 async function verifyAndShape(
   token: string,
   jwksUrl: string,

--- a/tests/integration/local-invoke-agentcore/agent/server.js
+++ b/tests/integration/local-invoke-agentcore/agent/server.js
@@ -2,7 +2,8 @@
 // test. Serves the AgentCore HTTP contract on 0.0.0.0:8080:
 //   GET  /ping        -> 200 {"status":"Healthy", ...}
 //   POST /invocations -> echoes the request body, the received session-id
-//                        header, and the injected GREETING env var.
+//                        header, the received Authorization header, and the
+//                        injected GREETING env var.
 // Startup logs go to stderr so the host's stdout carries only the cdkl
 // result line.
 const http = require('node:http');
@@ -33,6 +34,7 @@ const server = http.createServer((req, res) => {
         JSON.stringify({
           echoed,
           sessionId: req.headers[SESSION_HEADER] ?? null,
+          authorization: req.headers['authorization'] ?? null,
           greeting: process.env.GREETING ?? 'unset',
         })
       );

--- a/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
+++ b/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
@@ -3,7 +3,11 @@ import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
-import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore';
+import {
+  Runtime,
+  AgentRuntimeArtifact,
+  RuntimeAuthorizerConfiguration,
+} from 'aws-cdk-lib/aws-bedrockagentcore';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -33,6 +37,24 @@ export class LocalInvokeAgentCoreStack extends cdk.Stack {
         platform: Platform.LINUX_ARM64,
       }),
       environmentVariables: { GREETING: 'hello-from-agent' },
+    });
+
+    // A JWT-protected runtime for the inbound-auth tests. The discovery URL
+    // is deliberately unreachable (localhost:1), so `cdkl invoke-agentcore`
+    // falls back to JWKS/discovery pass-through (accept + warn) — exercising
+    // the auth wiring end-to-end offline: a missing token is rejected before
+    // the container starts, `--no-verify-auth` skips, and `--bearer-token` is
+    // forwarded to /invocations.
+    new Runtime(this, 'ProtectedAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromAsset(path.join(__dirname, '../agent'), {
+        platform: Platform.LINUX_ARM64,
+      }),
+      environmentVariables: { GREETING: 'hello-from-agent' },
+      authorizerConfiguration: RuntimeAuthorizerConfiguration.usingJWT(
+        'https://127.0.0.1:1/.well-known/openid-configuration',
+        ['client-9'],
+        ['aud-1']
+      ),
     });
   }
 }

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -24,6 +24,7 @@ cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
 TARGET="CdkLocalInvokeAgentCoreFixture/EchoAgent"
+PROTECTED="CdkLocalInvokeAgentCoreFixture/ProtectedAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
 
 echo "==> Verifying Docker is available"
@@ -38,7 +39,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/4] Invoking EchoAgent with default empty event"
+echo "==> [1/7] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -52,7 +53,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/4] Invoking EchoAgent with --event payload"
+echo "==> [2/7] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -64,7 +65,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/4] Invoking EchoAgent with --env-vars override"
+echo "==> [3/7] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -76,7 +77,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/4] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/7] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -85,5 +86,47 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
   exit 1
 }
 
+# Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
+# BEFORE any container starts (AgentCore returns 401 in the cloud).
+echo "==> [5/7] ProtectedAgent without --bearer-token must be rejected pre-container"
+set +e
+OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
+RC_5=$?
+set -e
+echo "    exit=${RC_5}"
+[[ ${RC_5} -ne 0 ]] || {
+  echo "FAIL: expected a non-zero exit for the protected runtime with no token, got 0. Output: ${OUT_5}"
+  exit 1
+}
+echo "${OUT_5}" | grep -q "requires an inbound JWT" || {
+  echo "FAIL: expected an 'requires an inbound JWT' error, got: ${OUT_5}"
+  exit 1
+}
+RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
+[[ "${RUNNING}" == "0" ]] || {
+  echo "FAIL: a container was created despite the pre-container auth rejection (${RUNNING} found)"
+  exit 1
+}
+
+# Test 6 — --no-verify-auth skips verification and proceeds.
+echo "==> [6/7] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
+echo "    response: ${RESULT_6}"
+echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
+  echo "FAIL: expected the agent to respond under --no-verify-auth, got: ${RESULT_6}"
+  exit 1
+}
+
+# Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
+# is verified and forwarded to /invocations as the Authorization header.
+echo "==> [7/7] ProtectedAgent with --bearer-token forwards the Authorization header"
+TOKEN="header.payload.sig"
+RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
+echo "    response: ${RESULT_7}"
+echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
+  echo "FAIL: expected the bearer token forwarded as Authorization: Bearer ${TOKEN}, got: ${RESULT_7}"
+  exit 1
+}
+
 echo ""
-echo "==> All 4 local-invoke-agentcore tests passed"
+echo "==> All 7 local-invoke-agentcore tests passed"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -8,6 +8,7 @@ const {
   pullEcrImageMock,
   pullImageMock,
   createLocalStateProviderMock,
+  verifyJwtViaDiscoveryMock,
 } = vi.hoisted(() => ({
   loadManifestMock: vi.fn(),
   getDockerImageBySourceHashMock: vi.fn(),
@@ -16,6 +17,13 @@ const {
   pullEcrImageMock: vi.fn(),
   pullImageMock: vi.fn(),
   createLocalStateProviderMock: vi.fn(),
+  verifyJwtViaDiscoveryMock: vi.fn(),
+}));
+
+vi.mock('../../../src/local/cognito-jwt.js', async (importActual) => ({
+  ...(await importActual<object>()),
+  createJwksCache: vi.fn(() => ({ fetchAndCache: vi.fn(), peek: vi.fn(), clear: vi.fn() })),
+  verifyJwtViaDiscovery: verifyJwtViaDiscoveryMock,
 }));
 
 vi.mock('../../../src/cli/commands/local-state-source.js', async (importActual) => ({
@@ -60,6 +68,7 @@ const {
   readEvent,
   readEnvOverridesFile,
   platformToArchitecture,
+  resolveInboundAuthorization,
 } = await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -278,5 +287,76 @@ describe('platformToArchitecture', () => {
 
   it('defaults any other value to arm64 (AgentCore-required arch)', () => {
     expect(platformToArchitecture('something-else')).toBe('arm64');
+  });
+});
+
+describe('resolveInboundAuthorization — JWT gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const withAuthorizer = (over: Partial<ResolvedAgentCoreRuntime> = {}) =>
+    runtime('repo:tag', {
+      jwtAuthorizer: {
+        discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+        allowedAudience: ['aud-1'],
+      },
+      ...over,
+    });
+
+  it('forwards a token unchanged when no authorizer is configured (no verify)', async () => {
+    const header = await resolveInboundAuthorization(runtime('repo:tag'), {
+      bearerToken: 'tok',
+      verifyAuth: true,
+    });
+    expect(header).toBe('Bearer tok');
+    expect(verifyJwtViaDiscoveryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when no authorizer and no token', async () => {
+    expect(
+      await resolveInboundAuthorization(runtime('repo:tag'), { verifyAuth: true })
+    ).toBeUndefined();
+  });
+
+  it('skips verification with --no-verify-auth (forwards token, no verify)', async () => {
+    const header = await resolveInboundAuthorization(withAuthorizer(), {
+      bearerToken: 'tok',
+      verifyAuth: false,
+    });
+    expect(header).toBe('Bearer tok');
+    expect(verifyJwtViaDiscoveryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects (pre-container) when the authorizer is set but no token is given', async () => {
+    await expect(
+      resolveInboundAuthorization(withAuthorizer(), { verifyAuth: true })
+    ).rejects.toThrow(/requires an inbound JWT/);
+    expect(verifyJwtViaDiscoveryMock).not.toHaveBeenCalled();
+  });
+
+  it('verifies + forwards when the token is accepted', async () => {
+    verifyJwtViaDiscoveryMock.mockResolvedValue({ allow: true, identityHash: 'h', ttlSeconds: 0 });
+    const header = await resolveInboundAuthorization(withAuthorizer(), {
+      bearerToken: 'tok',
+      verifyAuth: true,
+    });
+    expect(header).toBe('Bearer tok');
+    expect(verifyJwtViaDiscoveryMock).toHaveBeenCalledWith(
+      {
+        discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+        allowedAudience: ['aud-1'],
+      },
+      'Bearer tok',
+      expect.anything(),
+      expect.objectContaining({ warned: expect.any(Set) })
+    );
+  });
+
+  it('rejects when the token is denied by the authorizer', async () => {
+    verifyJwtViaDiscoveryMock.mockResolvedValue({ allow: false, identityHash: undefined, ttlSeconds: 0 });
+    await expect(
+      resolveInboundAuthorization(withAuthorizer(), { bearerToken: 'bad', verifyAuth: true })
+    ).rejects.toThrow(/rejected by the runtime's customJwtAuthorizer/);
   });
 });

--- a/tests/unit/local/agentcore-client.test.ts
+++ b/tests/unit/local/agentcore-client.test.ts
@@ -72,9 +72,28 @@ describe('invokeAgentCore', () => {
       'session-1234567890abcdefghijklmnopqrstuv'
     );
     expect(captured?.init.body).toBe('{"prompt":"hello"}');
+    expect(headers['Authorization']).toBeUndefined();
     expect(result.status).toBe(200);
     expect(result.contentType).toBe('application/json');
     expect(result.raw).toBe('{"response":"hi","status":"success"}');
+  });
+
+  it('forwards the Authorization header when supplied', async () => {
+    let captured: { init: RequestInit } | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      captured = { init };
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await invokeAgentCore('127.0.0.1', 9000, {}, {
+      sessionId: 's',
+      timeoutMs: 5000,
+      authorization: 'Bearer the.jwt.token',
+    });
+
+    const headers = captured?.init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer the.jwt.token');
   });
 
   it('passes an SSE response body through verbatim', async () => {

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -176,3 +176,56 @@ describe('resolveAgentCoreTarget — out-of-scope artifacts', () => {
     expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/MCP protocol/);
   });
 });
+
+describe('resolveAgentCoreTarget — JWT authorizer extraction', () => {
+  it('extracts discoveryUrl + allowedAudience + allowedClients', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            AllowedAudience: ['aud-1', 'aud-2'],
+            AllowedClients: ['client-9'],
+          },
+        },
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.jwtAuthorizer).toEqual({
+      discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+      allowedAudience: ['aud-1', 'aud-2'],
+      allowedClients: ['client-9'],
+    });
+  });
+
+  it('returns undefined when there is no AuthorizerConfiguration', () => {
+    const stack = buildStack('App', { ChatAgent: containerRuntime() });
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer).toBeUndefined();
+  });
+
+  it('omits the audience/client allowlists when absent (discoveryUrl only)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+          },
+        },
+      }),
+    });
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer).toEqual({
+      discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+    });
+  });
+
+  it('skips (undefined) when DiscoveryUrl is an unresolved intrinsic', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: { DiscoveryUrl: { Ref: 'SomeParam' } },
+        },
+      }),
+    });
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer).toBeUndefined();
+  });
+});

--- a/tests/unit/local/cognito-jwt.test.ts
+++ b/tests/unit/local/cognito-jwt.test.ts
@@ -1,11 +1,12 @@
 import { generateKeyPairSync, createSign } from 'node:crypto';
-import { describe, expect, it } from 'vite-plus/test';
+import { describe, expect, it, vi } from 'vite-plus/test';
 import {
   buildCognitoJwksUrl,
   buildJwksUrlFromIssuer,
   createJwksCache,
   verifyCognitoJwt,
   verifyJwtAuthorizer,
+  verifyJwtViaDiscovery,
 } from '../../../src/local/cognito-jwt.js';
 import type {
   CognitoUserPoolAuthorizer,
@@ -796,5 +797,126 @@ describe('verifyCognitoJwt — multi-pool federation', () => {
     const resultB = await verifyCognitoJwt(auth, `Bearer ${tokenB}`, cache);
     expect(resultB.allow).toBe(true);
     expect(bFetched).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
+  const ISSUER = 'https://idp.example.com';
+  const DISCOVERY = `${ISSUER}/.well-known/openid-configuration`;
+  // Deliberately NOT the `<issuer>/.well-known/jwks.json` convention URL, so
+  // the test proves the jwks_uri is read from the discovery document.
+  const JWKS_URI = `${ISSUER}/oauth2/keys`;
+
+  function setup(fixture: ReturnType<typeof makeJwtFixture>): {
+    discoveryFetch: ReturnType<typeof vi.fn>;
+    cache: ReturnType<typeof createJwksCache>;
+  } {
+    const discoveryDoc = JSON.stringify({ issuer: ISSUER, jwks_uri: JWKS_URI });
+    const discoveryFetch = vi.fn(async (url: string) => ({
+      ok: url === DISCOVERY,
+      status: url === DISCOVERY ? 200 : 404,
+      text: async () => (url === DISCOVERY ? discoveryDoc : '{}'),
+    }));
+    const jwksBody = JSON.stringify({ keys: [fixture.jwk] });
+    const cache = createJwksCache({
+      fetchImpl: async (url: string) => ({
+        ok: url === JWKS_URI,
+        status: url === JWKS_URI ? 200 : 404,
+        text: async () => (url === JWKS_URI ? jwksBody : '{}'),
+      }),
+    });
+    return { discoveryFetch, cache };
+  }
+
+  const future = (): number => Math.floor(Date.now() / 1000) + 3600;
+
+  it('allows a valid token, reading jwks_uri + issuer from the discovery doc', async () => {
+    const f = makeJwtFixture();
+    const { discoveryFetch, cache } = setup(f);
+    const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1' });
+    const r = await verifyJwtViaDiscovery(
+      { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
+      `Bearer ${token}`,
+      cache,
+      { fetchImpl: discoveryFetch, warned: new Set() }
+    );
+    expect(r.allow).toBe(true);
+    expect(discoveryFetch).toHaveBeenCalledWith(DISCOVERY);
+  });
+
+  it('allows when client_id matches allowedClients', async () => {
+    const f = makeJwtFixture();
+    const { discoveryFetch, cache } = setup(f);
+    const token = f.sign({}, { iss: ISSUER, exp: future(), client_id: 'client-9' });
+    const r = await verifyJwtViaDiscovery(
+      { discoveryUrl: DISCOVERY, allowedClients: ['client-9'] },
+      `Bearer ${token}`,
+      cache,
+      { fetchImpl: discoveryFetch, warned: new Set() }
+    );
+    expect(r.allow).toBe(true);
+  });
+
+  it('denies a token whose audience is not allowed', async () => {
+    const f = makeJwtFixture();
+    const { discoveryFetch, cache } = setup(f);
+    const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'other' });
+    const r = await verifyJwtViaDiscovery(
+      { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
+      `Bearer ${token}`,
+      cache,
+      { fetchImpl: discoveryFetch, warned: new Set() }
+    );
+    expect(r.allow).toBe(false);
+  });
+
+  it('denies an expired token', async () => {
+    const f = makeJwtFixture();
+    const { discoveryFetch, cache } = setup(f);
+    const token = f.sign({}, { iss: ISSUER, exp: Math.floor(Date.now() / 1000) - 10, aud: 'aud-1' });
+    const r = await verifyJwtViaDiscovery(
+      { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
+      `Bearer ${token}`,
+      cache,
+      { fetchImpl: discoveryFetch, warned: new Set() }
+    );
+    expect(r.allow).toBe(false);
+  });
+
+  it('denies a token with the wrong issuer', async () => {
+    const f = makeJwtFixture();
+    const { discoveryFetch, cache } = setup(f);
+    const token = f.sign({}, { iss: 'https://evil.example.com', exp: future(), aud: 'aud-1' });
+    const r = await verifyJwtViaDiscovery(
+      { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
+      `Bearer ${token}`,
+      cache,
+      { fetchImpl: discoveryFetch, warned: new Set() }
+    );
+    expect(r.allow).toBe(false);
+  });
+
+  it('denies when no bearer token is supplied', async () => {
+    const f = makeJwtFixture();
+    const { discoveryFetch, cache } = setup(f);
+    const r = await verifyJwtViaDiscovery({ discoveryUrl: DISCOVERY }, undefined, cache, {
+      fetchImpl: discoveryFetch,
+      warned: new Set(),
+    });
+    expect(r.allow).toBe(false);
+  });
+
+  it('falls back to pass-through accept when the discovery doc is unreachable', async () => {
+    const f = makeJwtFixture();
+    const { cache } = setup(f);
+    const unreachable = vi.fn(async () => ({ ok: false, status: 500, text: async () => 'err' }));
+    const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1' });
+    const r = await verifyJwtViaDiscovery(
+      { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
+      `Bearer ${token}`,
+      cache,
+      { fetchImpl: unreachable, warned: new Set() }
+    );
+    expect(r.allow).toBe(true);
   });
 });

--- a/tests/unit/local/cognito-jwt.test.ts
+++ b/tests/unit/local/cognito-jwt.test.ts
@@ -919,4 +919,34 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
     );
     expect(r.allow).toBe(true);
   });
+
+  it('pass-through accepts a malformed (non-JWT) token when discovery is unreachable', async () => {
+    const f = makeJwtFixture();
+    const { cache } = setup(f);
+    const unreachable = vi.fn(async () => ({ ok: false, status: 500, text: async () => 'err' }));
+    const r = await verifyJwtViaDiscovery({ discoveryUrl: DISCOVERY }, 'Bearer not-a-jwt', cache, {
+      fetchImpl: unreachable,
+      warned: new Set(),
+    });
+    expect(r.allow).toBe(true);
+    expect(r.principalId).toBe('unknown');
+  });
+
+  it('pass-through accepts when the discovery doc is missing issuer / jwks_uri', async () => {
+    const f = makeJwtFixture();
+    const { cache } = setup(f);
+    const malformedDoc = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '{"not":"an-oidc-doc"}',
+    }));
+    const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1' });
+    const r = await verifyJwtViaDiscovery(
+      { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
+      `Bearer ${token}`,
+      cache,
+      { fetchImpl: malformedDoc, warned: new Set() }
+    );
+    expect(r.allow).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Implements issue #129: `cdkl invoke-agentcore` now enforces a runtime's
inbound JWT authorizer (`AuthorizerConfiguration.CustomJWTAuthorizer`)
locally, the way AgentCore gates `/invocations` in the cloud.

- New `--bearer-token <jwt>` flag (+ `--no-verify-auth` escape hatch).
- When the runtime declares a `customJwtAuthorizer`, **before the container
  starts**:
  - no token → reject (AgentCore returns 401),
  - invalid token → reject (AgentCore returns 403),
  - valid token → proceed and forward `Authorization: Bearer <jwt>` to
    `/invocations`.
- Verification: fetch the runtime's OIDC discovery document for its `issuer`
  + `jwks_uri`, then check the RS256 signature, `iss`, `exp`, and audience
  (allowlist = `allowedAudience` ∪ `allowedClients`, matched against `aud` /
  `client_id`). Reuses the `cdkl start-api` JWT stack — a new
  `verifyJwtViaDiscovery` in `cognito-jwt.ts` delegates to the existing
  `verifyAndShape` core + `JwksCache`.
- Offline fallback: an unreachable / malformed discovery doc or JWKS
  pass-through-accepts (+ warn), matching `start-api`'s existing behavior.

## Test plan

- [x] `vp run verify` (typecheck + lint + format + build + unit tests) green.
- [x] Unit: `verifyJwtViaDiscovery` (valid; wrong audience / expired / wrong
  issuer / no token → deny; `client_id` via `allowedClients`; discovery
  unreachable + malformed-token / missing-issuer → pass-through) using a real
  RS256 signing fixture; resolver `jwtAuthorizer` extraction; client
  `Authorization` forwarding; the command `resolveInboundAuthorization` gate
  (no-token reject / `--no-verify-auth` skip / verify+forward / deny).
- [x] Real-Docker integ `tests/integration/local-invoke-agentcore/`: a
  JWT-protected `ProtectedAgent` — no token rejected **before** any container
  is created (asserts exit≠0 + 0 containers), `--no-verify-auth` proceeds, and
  `--bearer-token` is forwarded (the echo agent returns the Authorization
  header). 7/7 pass, 0 orphans. Real signature verification is unit-tested
  (offline integ uses pass-through).

## Reviewer notes

3-axis review (spec / code / tests) — no blockers. Accepted as documented
cost:

- The offline pass-through accept surfaces the token's *unverified* claims as
  the principal — same trade-off as the existing Cognito JWKS pass-through,
  fires only when the discovery URL / JWKS is unreachable, and is warned.
- `DiscoveryJwtAuthorizer` (in `cognito-jwt.ts`) and `AgentCoreJwtAuthorizer`
  (in `agentcore-resolver.ts`) are near-identical by design — keeping the
  general JWT type in the lower-level `cognito-jwt` avoids a layering
  inversion (the resolver's AgentCore-specific shape is structurally
  assignable to it).

The two review-flagged test gaps (pass-through with a malformed token / a
discovery doc missing issuer+jwks_uri) are covered in this PR.

`allowedScopes` + `customClaims` validation is deferred (a follow-up).

Closes #129
