### PR TITLE
test(start-alb): cover resolveAlbTarget ambiguous display-path match

### DIFF
--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -61,6 +61,31 @@ describe('resolveAlbTarget', () => {
       /did not match an application Load Balancer/
     );
   });
+
+  it('errors when a display path resolves to more than one ALB (ambiguous)', () => {
+    // Two ALBs share the `AlbStack/Shared` construct-path prefix, so the path
+    // `AlbStack/Shared` resolves to both -> the user must disambiguate.
+    const twoAlbStack = {
+      stackName: 'AlbStack',
+      template: {
+        Resources: {
+          AlbA: {
+            Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+            Properties: { Type: 'application' },
+            Metadata: { 'aws:cdk:path': 'AlbStack/Shared/AlbA/Resource' },
+          },
+          AlbB: {
+            Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+            Properties: { Type: 'application' },
+            Metadata: { 'aws:cdk:path': 'AlbStack/Shared/AlbB/Resource' },
+          },
+        },
+      },
+    } as unknown as StackInfo;
+    expect(() => resolveAlbTarget('AlbStack/Shared', [twoAlbStack])).toThrow(
+      /matches 2 load balancers/
+    );
+  });
 });
 
 /** Two ALBs; `wiring` decides whether they front the same service or two. */


### PR DESCRIPTION
## Summary

Last accepted nice-to-have from the `#125` (issue `#86`) review: a unit test
locking the ambiguous-display-path branch of `resolveAlbTarget`.

`resolveAlbTarget` (in `src/cli/commands/local-start-alb.ts`) resolves a CDK
display path to **every** load balancer it covers — a path like
`AlbStack/Shared` matches both `AlbStack/Shared/AlbA/Resource` and
`AlbStack/Shared/AlbB/Resource`. When more than one ALB matches, the user must
disambiguate, so the resolver throws. That branch had no direct coverage; the
existing tests only covered the single-match and not-an-ALB cases.

This adds a test asserting the `Target '...' matches N load balancers` error
fires when a display path resolves to two application load balancers. No
production code changes.

## Test plan

- [x] `vp run check` (typecheck + lint + format) green
- [x] `vp test run` green — 92 files / 1295 tests (new ambiguous-match test passes against the un-mocked `resolveAlbTarget`)
- [x] `vp run build` green
- [x] Tests-only diff (`tests/unit/local/start-alb-binding.test.ts`, +25 lines); no `src/**` or integration-test surface touched
