### PR TITLE
feat(start-alb): ALB path-pattern listener-rule routing across backing services

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,9 +29,11 @@ AWS managed services.
   Service Connect / Cloud Map registry. `start-service` runs a service's
   replicas only (pure compute, no load balancer). `start-alb` is the ALB
   counterpart of `start-api`: name the ALB, and it boots the ECS
-  service(s) behind it plus a local front-door (single default-action
-  `forward`) that round-robins each listener port across the replicas
-  (full listener-rule routing — path / host / weighted — deferred to #123)
+  service(s) behind it plus a local front-door that round-robins each
+  listener port across the replicas and path-routes the listener's
+  `path-pattern` rules across the backing services (other conditions —
+  host-header / weighted / Lambda targets / redirect+fixed-response
+  actions — deferred to #123)
 - Bedrock AgentCore Runtime agents — the agent container served over the
   AgentCore HTTP contract (`POST /invocations` + `GET /ping` on port 8080),
   invoked once locally (`cdkl invoke-agentcore`); v1 covers container artifacts
@@ -88,11 +90,12 @@ Gateway).
   (embed-time branding overrides for host CLIs), ssm-parameter-resolver
   (resolves `AWS::SSM::Parameter::Value` template parameters via SSM under
   `--from-cfn-stack`), elb-front-door-resolver (resolves an ALB ->
-  Listeners -> TargetGroups -> backing ECS Services + the host listener
-  port each front-door fronts; the `start-alb` entry), front-door-pool
-  (round-robin pool of live replica endpoints), front-door-server (host
-  HTTP reverse proxy that round-robins a service's replicas behind the
-  ALB listener port), etc.
+  Listeners + path-pattern ListenerRules -> TargetGroups -> backing ECS
+  Services into a per-listener routing table; the `start-alb` entry),
+  alb-path-matcher (ALB `*` / `?` glob path-pattern matcher, priority
+  ordered), front-door-pool (round-robin pool of live replica endpoints),
+  front-door-server (host HTTP reverse proxy that path-routes each request
+  to a service's replica pool behind the ALB listener port), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For ECS there is no cluster command — locally, Docker is the placement target 
 | `cdkl start-service <Service>` | the ECS **service** | just the service's replicas (no load balancer) | workers / queue consumers / Service-Connect-only services, or to run the containers and hit them directly |
 | `cdkl start-alb <Alb>` | the **ALB** | the ECS service(s) behind the ALB **plus** a local **front-door** on each listener port | an `ApplicationLoadBalancedFargateService`-style service you want to reach the way external traffic does |
 
-`start-alb` is the ALB counterpart of `start-api`: you name the load balancer, and cdk-local discovers the ECS service(s) behind its HTTP `forward` listeners, boots their replicas, and stands up a host-side **front-door** on each listener port that round-robins requests across the running replicas — one stable host endpoint, just like behind a real load balancer. `start-service` stays a pure compute runner and never opens a front-door.
+`start-alb` is the ALB counterpart of `start-api`: you name the load balancer, and cdk-local discovers the ECS service(s) behind its HTTP listeners, boots their replicas, and stands up a host-side **front-door** on each listener port that round-robins requests across the running replicas — one stable host endpoint, just like behind a real load balancer. The front-door honors **`path-pattern` listener rules**, so a listener that routes `/api/*` to one service and everything else to another is reproduced locally: one host port, multiple backing services, path-routed per request. `start-service` stays a pure compute runner and never opens a front-door.
 
 ```bash
 # Just the service replicas (no load balancer) — a worker, or direct container debugging:
@@ -168,10 +168,11 @@ cdkl start-service MyStack/Worker
 # fronts each listener. On macOS, remap the privileged listener port 80 to a
 # non-privileged host port with --lb-port.
 cdkl start-alb MyStack/WebAlb --lb-port 80=8080
-curl http://127.0.0.1:8080/   # round-robins across the running replicas
+curl http://127.0.0.1:8080/        # default action -> the default service (round-robin)
+curl http://127.0.0.1:8080/api/x   # path-pattern rule /api/* -> the api service
 ```
 
-See [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally) for `start-alb`'s resolution model and scope (single HTTP `forward`, ECS targets).
+See [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally) for `start-alb`'s resolution model and scope (HTTP listeners, default `forward` + `path-pattern` rules, ECS targets; host-header / weighted / Lambda targets / redirect + fixed-response actions deferred).
 
 When you run a container directly — `run-task`, or a single-replica `start-service` — cdk-local publishes its declared container ports on the host and logs the address (`Reach it at 127.0.0.1:<port>`), so `curl http://127.0.0.1:<port>` or a browser reaches it. The bind IP defaults to `127.0.0.1` (override with `--container-host`); `--host-port <containerPort>=<hostPort>` remaps a port (handy on macOS to avoid the Docker admin prompt for privileged ports < 1024). For an ALB-fronted service, reach the replicas through the `start-alb` front-door above instead.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -950,11 +950,14 @@ and name the ALB.
 
 `cdkl start-alb <targets...>` is the ALB counterpart of `cdkl start-api`:
 you name the **Application Load Balancer**, and cdk-local discovers the
-ECS service(s) behind its HTTP `forward` listeners, boots their replicas
+ECS service(s) behind its HTTP listeners, boots their replicas
 (the same shared docker network + Cloud Map + restart watcher as
 `start-service`), and stands up a host-side **front-door** on each
 listener port that round-robins each request across the running replicas
-— one stable host endpoint, like behind a real load balancer.
+— one stable host endpoint, like behind a real load balancer. The
+front-door applies the listener's **`path-pattern` rules**, so one host
+port can path-route across several backing services (e.g. `/api/*` to one
+service, the default to another) the way the deployed ALB does.
 
 `start-service` vs `start-alb` mirrors `invoke` / `run-task` (the compute
 alone) vs `start-api` (the routed entry in front of the compute). Use
@@ -967,13 +970,19 @@ service you want to reach the way external traffic does.
 
 `start-alb` resolves the ALB you name → its
 `AWS::ElasticLoadBalancingV2::Listener`s (matched by `LoadBalancerArn`) →
-each listener's default `forward` `AWS::ElasticLoadBalancingV2::TargetGroup`
-→ the `AWS::ECS::Service` whose `LoadBalancers[]` references that target
-group (a reverse scan — there is no direct TG → service pointer). Each
-booted replica publishes its target container port on an **ephemeral**
-host port (so N replicas never collide), and the front-door forwards to
-those — cross-platform, since traffic goes through published ports rather
-than docker-network IPs the host can't reach on macOS Docker Desktop.
+each listener's default `forward` action **and** its
+`AWS::ElasticLoadBalancingV2::ListenerRule`s with a `path-pattern`
+condition → each action's `AWS::ElasticLoadBalancingV2::TargetGroup` →
+the `AWS::ECS::Service` whose `LoadBalancers[]` references that target
+group (a reverse scan — there is no direct TG → service pointer). The
+front-door for a listener port holds a routing table: each request is
+matched against the rules in `Priority` order (lower number first; ALB
+`*` / `?` glob semantics, path only), falling back to the default action;
+an unmatched request with no default action returns 404. Each booted
+replica publishes its target container port on an **ephemeral** host port
+(so N replicas never collide), and the front-door forwards to those —
+cross-platform, since traffic goes through published ports rather than
+docker-network IPs the host can't reach on macOS Docker Desktop.
 
 ### Target resolution
 
@@ -1000,14 +1009,15 @@ cdkl start-alb MyStack/WebAlb --lb-port 80=8080
 # then: curl http://127.0.0.1:8080/  (round-robins across replicas)
 ```
 
-### Scope (v1)
+### Scope
 
-Single default-action `forward` to an **HTTP** listener, **ECS** targets
-only. Full listener-rule routing (path / host / header / query / source-ip
-conditions, priority, weighted target groups, `redirect` / `fixed-response`),
-HTTPS / TLS termination, and Lambda targets are out of scope — listener-rule
-routing is tracked in [#123](https://github.com/go-to-k/cdk-local/issues/123).
-HTTPS listeners and Lambda target groups are skipped with a warning.
+**HTTP** listeners, **ECS** targets, single-target `forward` actions, and
+`path-pattern` listener rules (priority-ordered). Out of scope, skipped with
+a warning, and tracked in [#123](https://github.com/go-to-k/cdk-local/issues/123):
+other rule conditions (`host-header` / `http-header` / `http-request-method`
+/ `query-string` / `source-ip`), weighted (multi-target) forwards,
+`redirect` / `fixed-response` / `authenticate-*` actions, HTTPS / TLS
+termination, and Lambda target groups.
 
 ### `cdkl start-alb` exit codes
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -62,26 +62,28 @@ import {
   destroyTaskNetwork,
   type TaskNetwork,
 } from '../../local/ecs-network.js';
-import type { ResolvedFrontDoorTarget } from '../../local/elb-front-door-resolver.js';
 import { FrontDoorEndpointPool } from '../../local/front-door-pool.js';
 import {
   startFrontDoorServer,
   type StartedFrontDoorServer,
 } from '../../local/front-door-server.js';
-import type { FrontDoorRunnerContext } from '../../local/ecs-service-runner.js';
+import { matchAlbPathRule, type AlbPathRule } from '../../local/alb-path-matcher.js';
 
 /**
  * Neutral ECS-service emulator orchestration shared by `cdkl start-service`
  * (pure replica runner) and `cdkl start-alb` (ALB front-door entry). It synths,
  * lets a {@link EmulatorStrategy} pick targets and turn them into the concrete
- * set of {@link ServiceBoot}s, then boots every service replica pool (shared
- * docker network + Cloud Map registry + restart watcher) and, for any boot that
- * carries front-door targets, stands up a host-side reverse proxy per listener.
+ * set of {@link ServiceBoot}s (plus an optional {@link FrontDoorPlan}), then
+ * boots every service replica pool (shared docker network + Cloud Map registry
+ * + restart watcher) and, when a front-door plan is present, stands up ONE
+ * host-side reverse proxy per listener port that path-routes across the
+ * services it fronts.
  *
- * The front-door MECHANISM (generic "expose a service's replicas on host
- * ports") lives here; the ALB-specific resolution (which listener fronts which
- * service) lives entirely in the `start-alb` command. `start-service` passes
- * boots with no front-door targets, so it never touches the front-door path.
+ * The front-door MECHANISM (generic "expose services' replicas on host ports
+ * and path-route between them") lives here; the ALB-specific resolution (which
+ * listener fronts which service on which path) lives entirely in the
+ * `start-alb` command. `start-service` returns no front-door plan, so it never
+ * touches the front-door path.
  */
 
 /** Shared CLI option shape for both ECS-service commands. */
@@ -119,18 +121,51 @@ export interface EcsServiceEmulatorOptions {
   [key: string]: unknown;
 }
 
-/** One ECS service to boot, plus the front-door listeners (if any) to expose for it. */
+/** One ECS service to boot. Front-door wiring lives in the {@link FrontDoorPlan}. */
 export interface ServiceBoot {
   /** Service target string (`Stack:LogicalId` or `Stack/Path`). */
   target: string;
-  /** Front-door listener bindings to expose for this service (empty = pure compute). */
-  frontDoorTargets: ResolvedFrontDoorTarget[];
 }
+
+/** The backing (service target, container) a listener action forwards to. */
+export interface PlannedForwardTarget {
+  /** Service target string (`Stack:LogicalId`) whose replica pool serves this. */
+  serviceTarget: string;
+  /** Container the listener forwards to. */
+  targetContainerName: string;
+  /** Container port the target group targets. */
+  targetContainerPort: number;
+}
+
+/** One host front-door listener: a bound host port + its path-routing table. */
+export interface PlannedFrontDoorListener {
+  /** ALB listener port (for the `X-Forwarded-Port` header / logs). */
+  listenerPort: number;
+  /** Host port to bind (the listener port, or its `--lb-port` override). */
+  hostPort: number;
+  /** Default-action forward target (absent for a rules-only listener -> 404 on miss). */
+  defaultTarget?: PlannedForwardTarget;
+  /** Path-pattern rules, evaluated by priority (lower first). */
+  rules: Array<{ priority: number; pathPatterns: string[]; target: PlannedForwardTarget }>;
+}
+
+/** The full set of host front-doors to stand up for one emulator invocation. */
+export interface FrontDoorPlan {
+  listeners: PlannedFrontDoorListener[];
+}
+
+/** Mutable front-door pool list for a single service's runner (one entry per (container, port)). */
+type FrontDoorServicePools = Array<{
+  pool: FrontDoorEndpointPool;
+  targetContainerName: string;
+  targetContainerPort: number;
+}>;
 
 /**
  * Per-command behavior the neutral orchestration delegates to: how to pick
  * targets when none are passed, how to turn chosen targets into concrete
- * service boots (+ warnings), and the `--lb-port` host-port remap.
+ * service boots (+ an optional front-door plan + warnings), and the `--lb-port`
+ * host-port remap.
  */
 export interface EmulatorStrategy {
   pickEntries(stacks: StackInfo[]): TargetEntry[];
@@ -140,7 +175,7 @@ export interface EmulatorStrategy {
   resolveBoots(
     stacks: StackInfo[],
     chosenTargets: string[]
-  ): { boots: ServiceBoot[]; warnings: string[] };
+  ): { boots: ServiceBoot[]; frontDoor?: FrontDoorPlan; warnings: string[] };
   lbPortOverrides: Record<number, number>;
 }
 
@@ -169,8 +204,6 @@ export async function runEcsServiceEmulator(
     boot: ServiceBoot;
     runState: ServiceRunState;
     controller?: ServiceController;
-    /** Issue #86 v1 — host-side ALB front-door servers for this boot. */
-    frontDoorServers?: StartedFrontDoorServer[];
   };
   let perTarget: PerTarget[] = [];
 
@@ -178,6 +211,12 @@ export async function runEcsServiceEmulator(
   let sigintCount = 0;
   let sharedNetwork: TaskNetwork | undefined;
   let profileCredsFile: ProfileCredentialsFile | undefined;
+  // Host-side ALB front-door servers (one per listener port), shared across the
+  // services they front. Created once before the boot loop; torn down after all
+  // replicas are down so no request is forwarded to a vanished container.
+  let frontDoorServers: StartedFrontDoorServer[] = [];
+  // Per-service-target front-door pools to thread into each runner.
+  let frontDoorByService = new Map<string, FrontDoorServicePools>();
 
   const cleanup = singleFlight(
     async (): Promise<void> => {
@@ -198,21 +237,22 @@ export async function runEcsServiceEmulator(
               )
             );
           }
-          // Close this boot's front-door servers AFTER its replicas are down so
-          // no request is forwarded to a torn-down container. Idempotent.
-          await Promise.allSettled(
-            (pt.frontDoorServers ?? []).map((s) =>
-              s
-                .close()
-                .catch((err) =>
-                  getLogger().warn(
-                    `front-door server teardown failed: ${err instanceof Error ? err.message : String(err)}`
-                  )
-                )
-            )
-          );
         })
       );
+      // Close the front-door servers AFTER every replica is down so no in-flight
+      // request is forwarded to a torn-down container. Idempotent.
+      await Promise.allSettled(
+        frontDoorServers.map((s) =>
+          s
+            .close()
+            .catch((err) =>
+              getLogger().warn(
+                `front-door server teardown failed: ${err instanceof Error ? err.message : String(err)}`
+              )
+            )
+        )
+      );
+      frontDoorServers = [];
       if (profileCredsFile) {
         try {
           await profileCredsFile.dispose();
@@ -270,7 +310,7 @@ export async function runEcsServiceEmulator(
       onMissing: () => strategy.onMissing(),
     });
 
-    const { boots, warnings } = strategy.resolveBoots(stacks, resolvedTargets);
+    const { boots, frontDoor, warnings } = strategy.resolveBoots(stacks, resolvedTargets);
     for (const w of warnings) logger.warn(w);
     if (boots.length === 0) {
       throw new LocalStartServiceError(
@@ -313,6 +353,16 @@ export async function runEcsServiceEmulator(
       sharedNetwork,
     };
 
+    // Stand up the host front-door(s) BEFORE booting replicas: the pools start
+    // empty (so the proxy answers 503 until replicas register) and a host-port
+    // bind failure should surface before any docker budget is spent. No-op when
+    // the strategy returned no plan (start-service / pure compute).
+    if (frontDoor && frontDoor.listeners.length > 0) {
+      const built = await buildFrontDoor(frontDoor, options.containerHost, logger);
+      frontDoorServers = built.servers;
+      frontDoorByService = built.frontDoorByService;
+    }
+
     sigintHandler = (): void => {
       sigintCount += 1;
       if (sigintCount >= 2) {
@@ -328,7 +378,7 @@ export async function runEcsServiceEmulator(
     // Boot every target SEQUENTIALLY so a first-target failure surfaces before
     // we burn docker budget on the rest.
     for (const pt of perTarget) {
-      const booted = await bootOneTarget(
+      pt.controller = await bootOneTarget(
         pt.boot,
         pt.runState,
         stacks,
@@ -337,10 +387,8 @@ export async function runEcsServiceEmulator(
         skipPull,
         extraStateProviders,
         profileCredsFile,
-        strategy.lbPortOverrides
+        frontDoorByService.get(pt.boot.target)
       );
-      pt.controller = booted.controller;
-      pt.frontDoorServers = booted.frontDoorServers;
     }
 
     const summary = perTarget
@@ -362,11 +410,6 @@ export async function runEcsServiceEmulator(
   }
 }
 
-interface BootedTarget {
-  controller: ServiceController;
-  frontDoorServers: StartedFrontDoorServer[];
-}
-
 async function bootOneTarget(
   boot: ServiceBoot,
   runState: ServiceRunState,
@@ -376,8 +419,8 @@ async function bootOneTarget(
   skipPull: boolean,
   extraStateProviders: ExtraStateProviders | undefined,
   profileCredsFile: ProfileCredentialsFile | undefined,
-  lbPortOverrides: Record<number, number>
-): Promise<BootedTarget> {
+  frontDoorPools: FrontDoorServicePools | undefined
+): Promise<ServiceController> {
   const parsed = parseEcsTarget(boot.target);
   const candidate = pickCandidateStack(parsed.stackPattern, stacks);
   const stateProvider = createLocalStateProvider(
@@ -397,7 +440,7 @@ async function bootOneTarget(
       skipPull,
       stateProvider,
       profileCredsFile,
-      lbPortOverrides
+      frontDoorPools
     );
   } finally {
     if (stateProvider) stateProvider.dispose();
@@ -413,8 +456,8 @@ async function runOneTarget(
   skipPull: boolean,
   stateProvider: LocalStateProvider | undefined,
   profileCredsFile: ProfileCredentialsFile | undefined,
-  lbPortOverrides: Record<number, number>
-): Promise<BootedTarget> {
+  frontDoorPools: FrontDoorServicePools | undefined
+): Promise<ServiceController> {
   const logger = getLogger();
   const target = boot.target;
 
@@ -513,100 +556,120 @@ async function runOneTarget(
     };
   }
 
-  // Front-door: stand up a host-side reverse-proxy server per listener target.
-  // No-op for a pure-compute boot (no front-door targets — e.g. start-service).
-  const { frontDoorContext, frontDoorServers } = await startFrontDoorServers(
-    boot.frontDoorTargets,
-    service,
-    options.containerHost,
-    lbPortOverrides,
-    logger
-  );
-
+  // Front-door pools for THIS service (built once at the emulator level and
+  // shared with the listener servers). Each replica publishes + registers its
+  // ephemeral endpoint into these pools as it boots. Undefined / empty for a
+  // pure-compute boot (start-service) or a service no listener forwards to.
   const runnerOpts: ServiceRunnerOptions = {
     maxTasks: options.maxTasks,
     restartPolicy: options.restartPolicy,
     taskOptions: taskOpts,
     discovery,
-    ...(frontDoorContext ? { frontDoor: frontDoorContext } : {}),
+    ...(frontDoorPools && frontDoorPools.length > 0
+      ? { frontDoor: { pools: frontDoorPools } }
+      : {}),
   };
 
-  let controller: ServiceController;
-  try {
-    controller = await startEcsService(service, runnerOpts, runState);
-  } catch (err) {
-    await Promise.allSettled(frontDoorServers.map((s) => s.close()));
-    throw err;
-  }
-  return { controller, frontDoorServers };
+  return startEcsService(service, runnerOpts, runState);
 }
 
 /**
- * Issue #86 v1 — stand up one host-side reverse-proxy server per resolved
- * front-door listener and return the {@link FrontDoorRunnerContext} to thread
- * into the runner (so each replica publishes + registers its ephemeral
- * endpoint), plus the started servers for teardown. Pure front-door MECHANISM:
- * the ALB-specific resolution that produced `frontDoorTargets` lives in the
- * `start-alb` command. Returns an undefined context + empty servers when there
- * are no front-door targets (the pure-compute path).
+ * Stand up one host-side reverse-proxy server PER LISTENER PORT from the
+ * resolved {@link FrontDoorPlan}, path-routing each request across the services
+ * the listener fronts, and return the started servers (for teardown) plus a
+ * per-service-target pool list to thread into each service's runner (so every
+ * replica publishes + registers its ephemeral endpoint into the right pool).
+ *
+ * One `FrontDoorEndpointPool` is created per distinct (service, container,
+ * port) forward target and SHARED between the listener's routing table and the
+ * owning service's runner context — same object on both sides, so a replica
+ * registering itself is immediately reachable through the front-door.
  *
  * On a bind failure (e.g. EACCES on a privileged listener port, or the port is
  * already in use) every server started so far is closed and the error is
  * re-thrown with a `--lb-port` hint.
  */
-export async function startFrontDoorServers(
-  frontDoorTargets: ResolvedFrontDoorTarget[],
-  service: ReturnType<typeof resolveEcsServiceTarget>,
+export async function buildFrontDoor(
+  plan: FrontDoorPlan,
   containerHost: string,
-  lbPortOverrides: Record<number, number>,
   logger: ReturnType<typeof getLogger>
 ): Promise<{
-  frontDoorContext: FrontDoorRunnerContext | undefined;
-  frontDoorServers: StartedFrontDoorServer[];
+  servers: StartedFrontDoorServer[];
+  frontDoorByService: Map<string, FrontDoorServicePools>;
 }> {
-  if (frontDoorTargets.length === 0) {
-    return { frontDoorContext: undefined, frontDoorServers: [] };
-  }
+  const servers: StartedFrontDoorServer[] = [];
+  // poolKey -> { pool, target }. Built lazily so the same (service, container,
+  // port) reuses one pool across listeners / rules.
+  const registry = new Map<string, { pool: FrontDoorEndpointPool; target: PlannedForwardTarget }>();
+  const poolFor = (t: PlannedForwardTarget): FrontDoorEndpointPool => {
+    const key = `${t.serviceTarget} ${t.targetContainerName} ${t.targetContainerPort}`;
+    let entry = registry.get(key);
+    if (!entry) {
+      entry = { pool: new FrontDoorEndpointPool(), target: t };
+      registry.set(key, entry);
+    }
+    return entry.pool;
+  };
 
-  const frontDoorServers: StartedFrontDoorServer[] = [];
-  const pools: Array<{
-    pool: FrontDoorEndpointPool;
-    targetContainerName: string;
-    targetContainerPort: number;
-  }> = [];
   try {
-    for (const t of frontDoorTargets) {
-      const pool = new FrontDoorEndpointPool();
-      const hostPort = lbPortOverrides[t.listenerPort] ?? t.listenerPort;
+    for (const listener of plan.listeners) {
+      const defaultPool = listener.defaultTarget ? poolFor(listener.defaultTarget) : undefined;
+      const ruleRoutes: AlbPathRule<FrontDoorEndpointPool>[] = listener.rules.map((r) => ({
+        priority: r.priority,
+        pathPatterns: r.pathPatterns,
+        target: poolFor(r.target),
+      }));
+      const selectPool = (requestPath: string): FrontDoorEndpointPool | undefined =>
+        matchAlbPathRule(requestPath, ruleRoutes) ?? defaultPool;
+
       const server = await startFrontDoorServer({
-        pool,
-        port: hostPort,
+        selectPool,
+        port: listener.hostPort,
         host: containerHost,
-        listenerPort: t.listenerPort,
-        serviceName: service.serviceName,
+        listenerPort: listener.listenerPort,
+        label: `listener port ${listener.listenerPort}`,
       });
-      frontDoorServers.push(server);
-      pools.push({
-        pool,
-        targetContainerName: t.targetContainerName,
-        targetContainerPort: t.targetContainerPort,
-      });
+      servers.push(server);
+
       logger.info(
-        `ALB front-door: http://${server.host}:${server.port} -> ${service.serviceName} ` +
-          `(listener port ${t.listenerPort} -> container ${t.targetContainerName}:${t.targetContainerPort}, ` +
-          'round-robin across replicas)'
+        `ALB front-door: http://${server.host}:${server.port} (listener port ${listener.listenerPort})`
       );
+      if (listener.defaultTarget) {
+        logger.info(`  default -> ${describeTarget(listener.defaultTarget)} (round-robin)`);
+      }
+      for (const r of [...listener.rules].sort((a, b) => a.priority - b.priority)) {
+        logger.info(
+          `  path ${r.pathPatterns.join(', ')} (priority ${r.priority}) -> ${describeTarget(r.target)}`
+        );
+      }
+      if (!listener.defaultTarget) {
+        logger.info('  (no default action: unmatched paths return 404)');
+      }
     }
   } catch (err) {
-    await Promise.allSettled(frontDoorServers.map((s) => s.close()));
+    await Promise.allSettled(servers.map((s) => s.close()));
     throw new LocalStartServiceError(
-      `Failed to start ALB front-door for service '${service.serviceName}': ` +
-        `${err instanceof Error ? err.message : String(err)}. If the listener port is privileged ` +
-        '(< 1024), remap it to a non-privileged host port with --lb-port <listenerPort>=<hostPort> ' +
-        '(e.g. --lb-port 80=8080).'
+      `Failed to start ALB front-door: ${err instanceof Error ? err.message : String(err)}. If a ` +
+        'listener port is privileged (< 1024), remap it to a non-privileged host port with ' +
+        '--lb-port <listenerPort>=<hostPort> (e.g. --lb-port 80=8080).'
     );
   }
-  return { frontDoorContext: { pools }, frontDoorServers };
+
+  const frontDoorByService = new Map<string, FrontDoorServicePools>();
+  for (const { pool, target } of registry.values()) {
+    const list = frontDoorByService.get(target.serviceTarget) ?? [];
+    list.push({
+      pool,
+      targetContainerName: target.targetContainerName,
+      targetContainerPort: target.targetContainerPort,
+    });
+    frontDoorByService.set(target.serviceTarget, list);
+  }
+  return { servers, frontDoorByService };
+}
+
+function describeTarget(t: PlannedForwardTarget): string {
+  return `${t.serviceTarget} (container ${t.targetContainerName}:${t.targetContainerPort})`;
 }
 
 async function resolvePlaceholderAccount(arn: string, region: string | undefined): Promise<string> {

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -13,6 +13,7 @@ import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cdk-path.js';
 import {
   resolveAlbFrontDoor,
   isApplicationLoadBalancer,
+  type FrontDoorForwardTarget,
 } from '../../local/elb-front-door-resolver.js';
 import type { ExtraStateProviders } from './local-state-source.js';
 import {
@@ -21,6 +22,8 @@ import {
   type EcsServiceEmulatorOptions,
   type EmulatorStrategy,
   type ServiceBoot,
+  type PlannedForwardTarget,
+  type PlannedFrontDoorListener,
 } from './ecs-service-emulator.js';
 
 /**
@@ -164,28 +167,61 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
           "Pass one or more ALB paths like 'Stack/MyAlb', or run it in a TTY to pick interactively."
       ),
     resolveBoots: (stacks, chosenTargets) => {
-      const byServiceTarget = new Map<string, ServiceBoot>();
       const warnings: string[] = [];
+      // Services to boot (deduped) + the per-listener host front-door plan.
+      const serviceTargets = new Set<string>();
+      const listeners: PlannedFrontDoorListener[] = [];
+      // hostPort -> the listener port that claimed it (to explain a collision).
+      const claimedHostPorts = new Map<number, number>();
+
       for (const albTarget of chosenTargets) {
         const { stack, albLogicalId } = resolveAlbTarget(albTarget, stacks);
         const resolution = resolveAlbFrontDoor(stack, albLogicalId);
         warnings.push(...resolution.warnings);
-        for (const svc of resolution.services) {
-          const target = `${stack.stackName}:${svc.serviceLogicalId}`;
-          const existing = byServiceTarget.get(target);
-          if (existing) {
-            existing.frontDoorTargets.push(...svc.targets);
-          } else {
-            byServiceTarget.set(target, { target, frontDoorTargets: [...svc.targets] });
+
+        // Qualify a resolver target (`serviceLogicalId`) into a `Stack:LogicalId`
+        // service-boot target and record it as a service we must run.
+        const qualify = (t: FrontDoorForwardTarget): PlannedForwardTarget => {
+          const serviceTarget = `${stack.stackName}:${t.serviceLogicalId}`;
+          serviceTargets.add(serviceTarget);
+          return {
+            serviceTarget,
+            targetContainerName: t.targetContainerName,
+            targetContainerPort: t.targetContainerPort,
+          };
+        };
+
+        for (const listener of resolution.listeners) {
+          const hostPort = lbPortOverrides[listener.listenerPort] ?? listener.listenerPort;
+          const claimedBy = claimedHostPorts.get(hostPort);
+          if (claimedBy !== undefined) {
+            warnings.push(
+              `Listener port ${listener.listenerPort} would bind host port ${hostPort}, already ` +
+                `claimed by listener port ${claimedBy}; the local front-door fronts only the ` +
+                'first. Use --lb-port to remap one of them.'
+            );
+            continue;
           }
+          claimedHostPorts.set(hostPort, listener.listenerPort);
+          listeners.push({
+            listenerPort: listener.listenerPort,
+            hostPort,
+            ...(listener.defaultTarget ? { defaultTarget: qualify(listener.defaultTarget) } : {}),
+            rules: listener.rules.map((r) => ({
+              priority: r.priority,
+              pathPatterns: r.pathPatterns,
+              target: qualify(r.target),
+            })),
+          });
         }
       }
-      const boots = [...byServiceTarget.values()];
+
+      const boots: ServiceBoot[] = [...serviceTargets].map((target) => ({ target }));
+
       // Warn about a `--lb-port <listenerPort>=...` override whose listener
       // port matched NONE of the resolved front-door listeners — almost always
       // a typo, and otherwise a silent no-op.
-      const resolvedPorts = new Set<number>();
-      for (const b of boots) for (const t of b.frontDoorTargets) resolvedPorts.add(t.listenerPort);
+      const resolvedPorts = new Set(listeners.map((l) => l.listenerPort));
       for (const portStr of Object.keys(lbPortOverrides)) {
         const port = Number(portStr);
         if (!resolvedPorts.has(port)) {
@@ -195,7 +231,12 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
           );
         }
       }
-      return { boots, warnings };
+
+      return {
+        boots,
+        ...(listeners.length > 0 ? { frontDoor: { listeners } } : {}),
+        warnings,
+      };
     },
     lbPortOverrides,
   };
@@ -213,14 +254,15 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
   const cmd = new Command('start-alb')
     .description(
       'Run an Application Load Balancer locally: name the ALB, and cdk-local boots the ECS ' +
-        'service(s) behind its HTTP forward listeners and stands up a local front-door on each ' +
-        'listener port that round-robins across the running replicas — a single stable host ' +
-        'endpoint, like behind a real load balancer. The symmetric ALB counterpart of ' +
-        '`start-api`. Each <target> accepts a CDK display path (MyStack/MyAlb) or stack-qualified ' +
-        'logical ID; single-stack apps may omit the stack prefix. v1 supports a single ' +
-        'default-action forward to an HTTP listener; HTTPS listeners and Lambda target groups are ' +
-        'skipped with a warning, and listener-rule routing is tracked separately. Omit <targets> ' +
-        'in an interactive terminal to multi-select the load balancers from a list.'
+        'service(s) behind its HTTP listeners and stands up a local front-door on each listener ' +
+        'port that round-robins across the running replicas and path-routes its path-pattern ' +
+        'rules across the backing services — a stable host endpoint, like behind a ' +
+        'real load balancer. The symmetric ALB counterpart of `start-api`. Each <target> accepts ' +
+        'a CDK display path (MyStack/MyAlb) or stack-qualified logical ID; single-stack apps may ' +
+        'omit the stack prefix. Supports HTTP listeners, single-target forward actions, and ' +
+        'path-pattern rules; HTTPS listeners, Lambda target groups, weighted forwards, other rule ' +
+        'conditions, and redirect/fixed-response actions are skipped with a warning. Omit ' +
+        '<targets> in an interactive terminal to multi-select the load balancers from a list.'
     )
     .argument(
       '[targets...]',

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -48,7 +48,7 @@ export function serviceStrategy(): EmulatorStrategy {
           'or run it in a TTY to pick interactively.'
       ),
     resolveBoots: (_stacks, chosenTargets) => ({
-      boots: chosenTargets.map((target) => ({ target, frontDoorTargets: [] })),
+      boots: chosenTargets.map((target) => ({ target })),
       warnings: [],
     }),
     lbPortOverrides: {},

--- a/src/local/alb-path-matcher.ts
+++ b/src/local/alb-path-matcher.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #123 (path-pattern slice) — match a request path against an ALB
+ * listener's `path-pattern` rules, in priority order.
+ *
+ * ALB path-pattern semantics (NOT the same as API Gateway route matching, so
+ * this is a dedicated matcher rather than a reuse of `route-matcher.ts`):
+ *
+ *   - Matched against the **path only** — the query string is excluded.
+ *   - **Case-sensitive**.
+ *   - Two wildcards: `*` matches 0 or more characters (including `/`), and `?`
+ *     matches exactly 1 character. Every other character is literal.
+ *   - The pattern matches the **entire** path (anchored both ends), so
+ *     `/api/*` matches `/api/` and `/api/v1/x` but not `/api` (no trailing
+ *     character for `*` to begin after the slash) and not `/apix`.
+ *
+ * Rule precedence: ALB evaluates listener rules in ascending `Priority`
+ * (lower number = higher priority); the first rule whose condition matches
+ * wins. A rule's `path-pattern` condition can carry multiple values, matched
+ * as an OR. When no rule matches, the caller falls back to the listener's
+ * default action.
+ */
+
+/** One path-pattern routing rule, generic over the target it selects. */
+export interface AlbPathRule<T> {
+  /** ALB rule priority (lower = evaluated first). */
+  priority: number;
+  /** The rule's `path-pattern` condition values (OR-matched). */
+  pathPatterns: string[];
+  /** What this rule routes to (e.g. a pool, a resolved target). */
+  target: T;
+}
+
+/**
+ * Return the target of the highest-priority rule whose `path-pattern` matches
+ * `requestPath`, or `undefined` when none match (caller uses the default).
+ * Rules are evaluated in ascending priority; the input order is irrelevant.
+ */
+export function matchAlbPathRule<T>(
+  requestPath: string,
+  rules: readonly AlbPathRule<T>[]
+): T | undefined {
+  const path = pathOf(requestPath);
+  const ordered = [...rules].sort((a, b) => a.priority - b.priority);
+  for (const rule of ordered) {
+    if (rule.pathPatterns.some((pattern) => albPathPatternMatches(pattern, path))) {
+      return rule.target;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether a single ALB `path-pattern` value matches a request path. The path
+ * must already be query-stripped, or pass a raw URL and it is stripped here.
+ */
+export function albPathPatternMatches(pattern: string, requestPath: string): boolean {
+  return globToRegExp(pattern).test(pathOf(requestPath));
+}
+
+/** Strip the query string / fragment so only the URL path is matched. */
+function pathOf(url: string): string {
+  let end = url.length;
+  const q = url.indexOf('?');
+  if (q !== -1) end = q;
+  const h = url.indexOf('#');
+  if (h !== -1 && h < end) end = h;
+  return url.slice(0, end);
+}
+
+const REGEXP_META = /[.+^${}()|[\]\\]/;
+
+/**
+ * Translate an ALB path-pattern glob into an anchored, case-sensitive RegExp:
+ * `*` -> `.*`, `?` -> `.`, every other character is escaped and matched
+ * literally.
+ */
+function globToRegExp(pattern: string): RegExp {
+  let body = '';
+  for (const ch of pattern) {
+    if (ch === '*') body += '.*';
+    else if (ch === '?') body += '.';
+    else if (REGEXP_META.test(ch)) body += `\\${ch}`;
+    else body += ch;
+  }
+  return new RegExp(`^${body}$`);
+}

--- a/src/local/elb-front-door-resolver.ts
+++ b/src/local/elb-front-door-resolver.ts
@@ -2,72 +2,98 @@ import type { StackInfo } from '../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../types/resource.js';
 
 /**
- * Issue #86 v1 — resolve an `AWS::ElasticLoadBalancingV2::LoadBalancer` (an
- * ALB) into the backing ECS service(s) and the host listener port(s) a local
- * front-door should expose for each. This is the `cdkl start-alb` entry: you
- * name the ALB, and cdk-local discovers the services behind it (mirroring how
- * `start-api` names the API and discovers the backing Lambdas).
+ * Resolve an `AWS::ElasticLoadBalancingV2::LoadBalancer` (an ALB) into the
+ * backing ECS service(s) and the host listener port(s) a local front-door
+ * should expose. This is the `cdkl start-alb` entry: you name the ALB, and
+ * cdk-local discovers the services behind it (mirroring how `start-api` names
+ * the API and discovers the backing Lambdas).
  *
  * The synthesized linkage (confirmed against real `cdk synth` of
- * `ApplicationLoadBalancedFargateService`):
+ * `ApplicationLoadBalancedFargateService` + an `addAction` path rule):
  *
  * ```
  * ElasticLoadBalancingV2::LoadBalancer  (the ALB you name)
  * ElasticLoadBalancingV2::Listener      : { LoadBalancerArn:{Ref:<ALB>}, Port, Protocol,
  *     DefaultActions:[{ Type:"forward", TargetGroupArn:{Ref:<TG>} }] }
+ * ElasticLoadBalancingV2::ListenerRule  : { ListenerArn:{Ref:<Listener>}, Priority,
+ *     Conditions:[{ Field:"path-pattern", PathPatternConfig:{ Values:["/api/*"] } }],
+ *     Actions:[{ Type:"forward", TargetGroupArn:{Ref:<TG>} }] }
  * ElasticLoadBalancingV2::TargetGroup   : { Port, Protocol, TargetType:"ip" }
  * ECS::Service.LoadBalancers[]          -> { ContainerName, ContainerPort, TargetGroupArn:{Ref:<TG>} }
  * ```
  *
- * Resolution walks ALB -> listeners (by `LoadBalancerArn` Ref) -> default
- * `forward` target groups -> the ECS Service whose `LoadBalancers[]` references
- * that target group (a reverse scan; there is no direct TG -> service pointer).
+ * Resolution walks ALB -> listeners (by `LoadBalancerArn` Ref) -> their default
+ * `forward` action AND any `path-pattern` ListenerRules -> the ECS Service whose
+ * `LoadBalancers[]` references each target group (a reverse scan; there is no
+ * direct TG -> service pointer). Output is a per-listener routing table: a
+ * default forward target (when the default action is a resolvable forward) plus
+ * the ordered path-pattern rules.
  *
- * v1 scope (single forward): only listener `DefaultActions` are honored.
- * `AWS::ElasticLoadBalancingV2::ListenerRule` (path / host / weighted routing)
- * is ignored — tracked in #123. HTTPS / TLS listeners and `TargetType:"lambda"`
- * target groups are skipped with a warning.
+ * Scope: HTTP listeners, `path-pattern` conditions, single-target `forward`
+ * actions to ECS services. Skipped with a warning: HTTPS/TLS listeners,
+ * `TargetType:"lambda"` target groups, weighted (multi-target) forwards, rules
+ * with non-`path-pattern` conditions (host-header / http-header / query-string
+ * / etc.), and `redirect` / `fixed-response` / `authenticate-*` actions. Those
+ * remaining listener-rule features are tracked in #123.
  */
 
 const ALB_TYPE = 'AWS::ElasticLoadBalancingV2::LoadBalancer';
 const LISTENER_TYPE = 'AWS::ElasticLoadBalancingV2::Listener';
+const LISTENER_RULE_TYPE = 'AWS::ElasticLoadBalancingV2::ListenerRule';
 const TARGET_GROUP_TYPE = 'AWS::ElasticLoadBalancingV2::TargetGroup';
 const SERVICE_TYPE = 'AWS::ECS::Service';
 
-/** One resolved host front-door: a listener port forwarding to a service's replica pool. */
-export interface ResolvedFrontDoorTarget {
-  /** Listener port declared on the ALB (the stable host endpoint port). */
-  listenerPort: number;
-  /** Listener protocol — always `HTTP` in v1 (HTTPS is skipped upstream). */
-  listenerProtocol: 'HTTP';
-  /** Container the listener forwards to (`LoadBalancers[].ContainerName`). */
+/** The backing (service, container) a listener action forwards to. */
+export interface FrontDoorForwardTarget {
+  /** Logical id of the `AWS::ECS::Service` behind the target group. */
+  serviceLogicalId: string;
+  /** Container the action forwards to (`LoadBalancers[].ContainerName`). */
   targetContainerName: string;
   /** Container port the target group targets (`LoadBalancers[].ContainerPort`). */
   targetContainerPort: number;
   /** Logical id of the resolved target group (diagnostics). */
   targetGroupLogicalId: string;
-  /** Logical id of the fronting listener (diagnostics). */
-  listenerLogicalId: string;
 }
 
-/** A backing ECS service behind the ALB, plus the listener(s) that front it. */
-export interface AlbBackingService {
-  /** Logical id of the `AWS::ECS::Service` (a `Stack:LogicalId` target). */
-  serviceLogicalId: string;
-  /** The listener -> container front-door bindings that target this service. */
-  targets: ResolvedFrontDoorTarget[];
+/** One resolved path-pattern routing rule on a listener. */
+export interface ResolvedListenerRule {
+  /** ALB rule priority (lower = evaluated first). */
+  priority: number;
+  /** The rule's `path-pattern` condition values (OR-matched). */
+  pathPatterns: string[];
+  /** The backing forward target this rule routes to. */
+  target: FrontDoorForwardTarget;
+}
+
+/** A resolved listener front-door: one host port, an optional default target + path rules. */
+export interface ResolvedListenerFrontDoor {
+  /** Listener port declared on the ALB (the stable host endpoint port). */
+  listenerPort: number;
+  /** Listener protocol — always `HTTP` here (HTTPS is skipped upstream). */
+  listenerProtocol: 'HTTP';
+  /** Logical id of the listener (diagnostics). */
+  listenerLogicalId: string;
+  /**
+   * Default-action forward target. Present when the listener's `DefaultActions`
+   * is a resolvable single `forward` to an ECS service; absent when the default
+   * is a `fixed-response` / `redirect` (a rules-only listener) — unmatched
+   * requests then get a 404 from the front-door.
+   */
+  defaultTarget?: FrontDoorForwardTarget;
+  /** Path-pattern rules (unordered here; the matcher evaluates by priority). */
+  rules: ResolvedListenerRule[];
 }
 
 export interface AlbFrontDoorResolution {
-  /** Backing services discovered behind the ALB, each with its front-door targets. */
-  services: AlbBackingService[];
+  /** Front-door listeners discovered on the ALB, each with its routing table. */
+  listeners: ResolvedListenerFrontDoor[];
   /** Non-fatal warnings (the CLI surfaces these and proceeds). */
   warnings: string[];
 }
 
 /**
- * Resolve an ALB into its backing services + front-door targets. Pure — reads
- * only the supplied stack template. Returns an empty `services` array (with
+ * Resolve an ALB into its front-door listeners + routing tables. Pure — reads
+ * only the supplied stack template. Returns an empty `listeners` array (with
  * warnings) when the ALB fronts nothing cdk-local can serve locally.
  */
 export function resolveAlbFrontDoor(
@@ -76,14 +102,14 @@ export function resolveAlbFrontDoor(
 ): AlbFrontDoorResolution {
   const warnings: string[] = [];
   const resources = stack.template.Resources ?? {};
+  const stackName = stack.stackName;
 
   // TG logical id -> backing ECS service (reverse of Service.LoadBalancers[]).
   const tgToService = indexTargetGroupToService(resources);
+  // Listener logical id -> its ListenerRules.
+  const rulesByListener = indexRulesByListener(resources);
 
-  // Per-service accumulation, keyed by service logical id. A service fronted by
-  // multiple listeners gets multiple targets.
-  const byService = new Map<string, ResolvedFrontDoorTarget[]>();
-  const seenPortsByService = new Map<string, Set<number>>();
+  const listeners: ResolvedListenerFrontDoor[] = [];
 
   for (const [listenerLogicalId, resource] of Object.entries(resources)) {
     if (resource.Type !== LISTENER_TYPE) continue;
@@ -93,90 +119,65 @@ export function resolveAlbFrontDoor(
     const port = parsePort(props['Port']);
     if (port === undefined) continue;
     const protocol = typeof props['Protocol'] === 'string' ? props['Protocol'] : 'HTTP';
-    const tgRefs = collectForwardTargetGroupRefs(props['DefaultActions']);
-    if (tgRefs.size === 0) {
-      // A forward action whose TargetGroupArn is a literal / cross-stack /
-      // imported (non-Ref) arn can't be resolved locally — warn so it isn't a
-      // silent no-op. Listeners with no forward action at all (e.g. a
-      // redirect-only HTTP->HTTPS listener) are skipped silently.
-      if (hasUnresolvableForward(props['DefaultActions'])) {
-        warnings.push(
-          `Listener '${listenerLogicalId}' on port ${port} forwards to a non-Ref TargetGroupArn ` +
-            '(literal / cross-stack / imported); the local front-door only supports in-stack ' +
-            'target groups. Skipping it.'
-        );
-      }
-      continue;
-    }
-
     if (protocol !== 'HTTP') {
       warnings.push(
         `Listener '${listenerLogicalId}' on port ${port} uses protocol ${protocol}; the local ` +
-          'ALB front-door supports HTTP listeners only in v1 (TLS termination is deferred). ' +
-          'Skipping it.'
+          'ALB front-door supports HTTP listeners only (TLS termination is deferred). Skipping it.'
       );
       continue;
     }
 
-    for (const tgRef of tgRefs) {
-      const tg = resources[tgRef];
-      if (!tg || tg.Type !== TARGET_GROUP_TYPE) {
-        warnings.push(
-          `Listener '${listenerLogicalId}' forwards to target group '${tgRef}', but no ` +
-            `${TARGET_GROUP_TYPE} with that logical id exists in ${stack.stackName}. Skipping it.`
-        );
-        continue;
-      }
-      const tgType = (tg.Properties as Record<string, unknown> | undefined)?.['TargetType'];
-      if (tgType === 'lambda') {
-        warnings.push(
-          `Target group '${tgRef}' is a Lambda target (TargetType: lambda). The local ALB ` +
-            'front-door supports ECS targets only in v1; Lambda targets are deferred to a ' +
-            'follow-up. Skipping it.'
-        );
-        continue;
-      }
-      const backing = tgToService.get(tgRef);
-      if (!backing) {
-        warnings.push(
-          `Target group '${tgRef}' (listener '${listenerLogicalId}', port ${port}) is not ` +
-            `referenced by any ${SERVICE_TYPE}.LoadBalancers[] in ${stack.stackName}; cdk-local ` +
-            'has no ECS service to front behind it. Skipping it.'
-        );
-        continue;
-      }
+    const defaultTarget = resolveForwardTarget(
+      props['DefaultActions'],
+      resources,
+      tgToService,
+      stackName,
+      `Listener '${listenerLogicalId}' (port ${port}) default action`,
+      warnings
+    );
 
-      const seenPorts = seenPortsByService.get(backing.serviceLogicalId) ?? new Set<number>();
-      if (seenPorts.has(port)) {
+    const rules: ResolvedListenerRule[] = [];
+    for (const { ruleLogicalId, ruleProps } of rulesByListener.get(listenerLogicalId) ?? []) {
+      const priority = parsePriority(ruleProps['Priority']);
+      const ruleLabel = `Listener rule '${ruleLogicalId}' (priority ${priority})`;
+      const { patterns, unsupported } = parseRulePathPatterns(ruleProps['Conditions']);
+      if (unsupported.length > 0) {
         warnings.push(
-          `Service '${backing.serviceLogicalId}' is fronted by more than one listener on host ` +
-            `port ${port}; the local front-door fronts only the first.`
+          `${ruleLabel} uses unsupported condition(s): ${unsupported.join(', ')}. The local ALB ` +
+            'front-door supports path-pattern conditions only (host-header / http-header / ' +
+            'query-string / http-request-method / source-ip deferred). Skipping it.'
         );
         continue;
       }
-      seenPorts.add(port);
-      seenPortsByService.set(backing.serviceLogicalId, seenPorts);
-
-      const targets = byService.get(backing.serviceLogicalId) ?? [];
-      targets.push({
-        listenerPort: port,
-        listenerProtocol: 'HTTP',
-        targetContainerName: backing.containerName,
-        targetContainerPort: backing.containerPort,
-        targetGroupLogicalId: tgRef,
-        listenerLogicalId,
-      });
-      byService.set(backing.serviceLogicalId, targets);
+      if (patterns.length === 0) continue; // no path-pattern values to route on
+      const target = resolveForwardTarget(
+        ruleProps['Actions'],
+        resources,
+        tgToService,
+        stackName,
+        `${ruleLabel} action`,
+        warnings
+      );
+      if (!target) continue; // resolveForwardTarget already warned
+      rules.push({ priority, pathPatterns: patterns, target });
     }
+
+    if (!defaultTarget && rules.length === 0) {
+      // The listener forwards to nothing cdk-local can serve (e.g. a
+      // redirect-only listener, or every action was skipped above).
+      continue;
+    }
+
+    listeners.push({
+      listenerPort: port,
+      listenerProtocol: 'HTTP',
+      listenerLogicalId,
+      ...(defaultTarget ? { defaultTarget } : {}),
+      rules,
+    });
   }
 
-  const services: AlbBackingService[] = [...byService.entries()].map(
-    ([serviceLogicalId, targets]) => ({
-      serviceLogicalId,
-      targets,
-    })
-  );
-  return { services, warnings };
+  return { listeners, warnings };
 }
 
 /** True when the resource is an application Load Balancer (the `start-alb` target type). */
@@ -191,6 +192,72 @@ interface BackingServiceRef {
   serviceLogicalId: string;
   containerName: string;
   containerPort: number;
+}
+
+/**
+ * Resolve a listener / rule `Actions` (or `DefaultActions`) array to a single
+ * ECS-service forward target, or `undefined` when it is not a resolvable
+ * single forward (warning emitted for the cases worth surfacing).
+ */
+function resolveForwardTarget(
+  actions: unknown,
+  resources: Record<string, TemplateResource>,
+  tgToService: Map<string, BackingServiceRef>,
+  stackName: string,
+  label: string,
+  warnings: string[]
+): FrontDoorForwardTarget | undefined {
+  const tgRefs = collectForwardTargetGroupRefs(actions);
+  if (tgRefs.size === 0) {
+    // No forward at all (redirect / fixed-response — silent) or a non-Ref
+    // forward we cannot resolve to an in-stack target group (worth a warning).
+    if (hasUnresolvableForward(actions)) {
+      warnings.push(
+        `${label} forwards to a non-Ref TargetGroupArn (literal / cross-stack / imported); the ` +
+          'local front-door only supports in-stack target groups. Skipping it.'
+      );
+    }
+    return undefined;
+  }
+  if (tgRefs.size > 1) {
+    warnings.push(
+      `${label} is a weighted forward (multiple target groups); the local front-door supports a ` +
+        'single target group per action (weighted routing deferred). Skipping it.'
+    );
+    return undefined;
+  }
+  const tgRef = [...tgRefs][0]!;
+  const tg = resources[tgRef];
+  if (!tg || tg.Type !== TARGET_GROUP_TYPE) {
+    warnings.push(
+      `${label} forwards to target group '${tgRef}', but no ${TARGET_GROUP_TYPE} with that logical ` +
+        `id exists in ${stackName}. Skipping it.`
+    );
+    return undefined;
+  }
+  const tgType = (tg.Properties as Record<string, unknown> | undefined)?.['TargetType'];
+  if (tgType === 'lambda') {
+    warnings.push(
+      `${label} forwards to a Lambda target group '${tgRef}' (TargetType: lambda). The local ALB ` +
+        'front-door supports ECS targets only; Lambda targets are deferred. Skipping it.'
+    );
+    return undefined;
+  }
+  const backing = tgToService.get(tgRef);
+  if (!backing) {
+    warnings.push(
+      `${label} forwards to target group '${tgRef}', which is not referenced by any ` +
+        `${SERVICE_TYPE}.LoadBalancers[] in ${stackName}; cdk-local has no ECS service to front ` +
+        'behind it. Skipping it.'
+    );
+    return undefined;
+  }
+  return {
+    serviceLogicalId: backing.serviceLogicalId,
+    targetContainerName: backing.containerName,
+    targetContainerPort: backing.containerPort,
+    targetGroupLogicalId: tgRef,
+  };
 }
 
 /**
@@ -219,10 +286,61 @@ function indexTargetGroupToService(
   return index;
 }
 
-function collectForwardTargetGroupRefs(defaultActions: unknown): Set<string> {
+/** Group every `AWS::ElasticLoadBalancingV2::ListenerRule` by the listener it references. */
+function indexRulesByListener(
+  resources: Record<string, TemplateResource>
+): Map<string, Array<{ ruleLogicalId: string; ruleProps: Record<string, unknown> }>> {
+  const index = new Map<
+    string,
+    Array<{ ruleLogicalId: string; ruleProps: Record<string, unknown> }>
+  >();
+  for (const [ruleLogicalId, resource] of Object.entries(resources)) {
+    if (resource.Type !== LISTENER_RULE_TYPE) continue;
+    const ruleProps = (resource.Properties ?? {}) as Record<string, unknown>;
+    const listenerRef = refOf(ruleProps['ListenerArn']);
+    if (!listenerRef) continue;
+    const list = index.get(listenerRef) ?? [];
+    list.push({ ruleLogicalId, ruleProps });
+    index.set(listenerRef, list);
+  }
+  return index;
+}
+
+/**
+ * Parse a ListenerRule's `Conditions` into its `path-pattern` values plus the
+ * field names of any non-`path-pattern` conditions (which make the rule
+ * unsupported in this version). A rule is only usable when every condition is a
+ * `path-pattern` — ALB ANDs conditions together, and we cannot honor the others
+ * locally yet.
+ */
+function parseRulePathPatterns(conditions: unknown): { patterns: string[]; unsupported: string[] } {
+  const patterns: string[] = [];
+  const unsupported: string[] = [];
+  if (!Array.isArray(conditions)) return { patterns, unsupported };
+  for (const cond of conditions) {
+    if (!cond || typeof cond !== 'object') continue;
+    const c = cond as Record<string, unknown>;
+    const field = typeof c['Field'] === 'string' ? c['Field'] : '(unknown)';
+    if (field !== 'path-pattern') {
+      unsupported.push(field);
+      continue;
+    }
+    const cfg = c['PathPatternConfig'];
+    const values =
+      cfg && typeof cfg === 'object' && Array.isArray((cfg as Record<string, unknown>)['Values'])
+        ? ((cfg as Record<string, unknown>)['Values'] as unknown[])
+        : Array.isArray(c['Values'])
+          ? (c['Values'] as unknown[])
+          : [];
+    for (const v of values) if (typeof v === 'string') patterns.push(v);
+  }
+  return { patterns, unsupported };
+}
+
+function collectForwardTargetGroupRefs(actions: unknown): Set<string> {
   const refs = new Set<string>();
-  if (!Array.isArray(defaultActions)) return refs;
-  for (const action of defaultActions) {
+  if (!Array.isArray(actions)) return refs;
+  for (const action of actions) {
     if (!action || typeof action !== 'object') continue;
     const a = action as Record<string, unknown>;
     if (a['Type'] !== 'forward') continue;
@@ -244,14 +362,14 @@ function collectForwardTargetGroupRefs(defaultActions: unknown): Set<string> {
 }
 
 /**
- * True when `DefaultActions` has at least one `forward` action that references
- * a target group via a NON-`Ref` arn (literal / `Fn::GetAtt` / cross-stack) —
- * i.e. a forward we could not resolve to an in-stack target group. Used to warn
- * rather than silently skip such a listener.
+ * True when `actions` has at least one `forward` action that references a target
+ * group via a NON-`Ref` arn (literal / `Fn::GetAtt` / cross-stack) — i.e. a
+ * forward we could not resolve to an in-stack target group. Used to warn rather
+ * than silently skip such a listener / rule.
  */
-function hasUnresolvableForward(defaultActions: unknown): boolean {
-  if (!Array.isArray(defaultActions)) return false;
-  for (const action of defaultActions) {
+function hasUnresolvableForward(actions: unknown): boolean {
+  if (!Array.isArray(actions)) return false;
+  for (const action of actions) {
     if (!action || typeof action !== 'object') continue;
     const a = action as Record<string, unknown>;
     if (a['Type'] !== 'forward') continue;
@@ -290,4 +408,15 @@ function parsePort(raw: unknown): number | undefined {
 
 function parseContainerPort(raw: unknown): number | undefined {
   return parsePort(raw);
+}
+
+/**
+ * Parse a ListenerRule `Priority` (ALB priorities are 1-50000, lower = higher
+ * precedence). A missing / unparseable priority sorts last so an explicitly
+ * prioritized rule always wins over it.
+ */
+function parsePriority(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string' && /^\d+$/.test(raw)) return parseInt(raw, 10);
+  return Number.MAX_SAFE_INTEGER;
 }

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -155,6 +155,7 @@ function handleProxyRequest(
     };
 
     const headers = { ...req.headers };
+    stripHopByHopHeaders(headers);
     appendForwardedHeaders(headers, req, opts.listenerPort);
 
     const proxyReq = httpRequest(
@@ -166,7 +167,9 @@ function handleProxyRequest(
         headers,
       },
       (proxyRes) => {
-        res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+        const resHeaders = { ...proxyRes.headers };
+        stripHopByHopHeaders(resHeaders);
+        res.writeHead(proxyRes.statusCode ?? 502, resHeaders);
         proxyRes.pipe(res);
         proxyRes.on('end', done);
         proxyRes.on('error', () => {
@@ -215,6 +218,37 @@ function handleProxyRequest(
 
     req.pipe(proxyReq);
   });
+}
+
+/** Standard hop-by-hop headers (RFC 7230 §6.1) — a proxy must not forward these. */
+const HOP_BY_HOP_HEADERS = [
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+];
+
+/**
+ * Strip hop-by-hop headers before relaying a request to / a response from the
+ * upstream, mirroring what a real ALB does. Forwarding the upstream's
+ * `Transfer-Encoding` / `Connection` verbatim while Node re-frames the body can
+ * produce a malformed response; the headers named in a `Connection` token list
+ * are also hop-by-hop and removed. Mutates `headers` in place.
+ */
+function stripHopByHopHeaders(headers: NodeJS.Dict<string | string[]>): void {
+  const connection = headers['connection'];
+  const connectionValue = Array.isArray(connection) ? connection.join(',') : connection;
+  if (connectionValue) {
+    for (const token of connectionValue.split(',')) {
+      const name = token.trim().toLowerCase();
+      if (name) delete headers[name];
+    }
+  }
+  for (const name of HOP_BY_HOP_HEADERS) delete headers[name];
 }
 
 /**

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -9,33 +9,44 @@ import { getLogger } from '../utils/logger.js';
 import type { FrontDoorEndpointPool } from './front-door-pool.js';
 
 /**
- * Issue #86 v1 — host-side ALB front-door. A plain HTTP reverse proxy bound to
- * the ALB's declared listener port that round-robins each request across the
- * service's live replica pool (`FrontDoorEndpointPool`). Mirrors the
+ * Host-side ALB front-door. A plain HTTP reverse proxy bound to the ALB's
+ * declared listener port that, per request, selects a live replica pool
+ * (`FrontDoorEndpointPool`) and round-robins across it. Mirrors the
  * `startApiServer` lifecycle in `http-server.ts` (createServer + setNoDelay +
  * listen + close/closeAllConnections).
+ *
+ * Pool selection is delegated to {@link StartFrontDoorServerOptions.selectPool}:
+ *   - single default-forward listener -> a constant pool for every request;
+ *   - a listener with `path-pattern` rules -> the matched rule's pool, falling
+ *     back to the default-action pool (`undefined` when neither matches, which
+ *     the proxy answers with 404 — like an ALB rule miss with no default).
  *
  * The replicas publish their target container port on ephemeral host ports
  * (the daemon-in-a-VM reality on macOS means the host can't reach container
  * IPs directly), so the proxy forwards to `127.0.0.1:<ephemeralPort>` rather
  * than to docker-network addresses — cross-platform by construction.
  *
- * v1 scope: per-request round-robin, HTTP only. No listener-rule routing
- * (#123), no health-check-gated draining, no sticky sessions, no websocket
- * `Upgrade` proxying, no TLS termination.
+ * Scope: per-request round-robin, HTTP only, `path-pattern` rule routing. No
+ * host-header / weighted routing, no health-check-gated draining, no sticky
+ * sessions, no websocket `Upgrade` proxying, no TLS termination (tracked in
+ * #123).
  */
 
 export interface StartFrontDoorServerOptions {
-  /** Live replica endpoint pool fed by the service runner. */
-  pool: FrontDoorEndpointPool;
+  /**
+   * Choose the replica pool to serve a request from, given its URL path.
+   * Returns `undefined` when no rule matched and there is no default action
+   * (the proxy then replies 404).
+   */
+  selectPool: (requestPath: string) => FrontDoorEndpointPool | undefined;
   /** Host port to bind (the listener port, or its `--lb-port` override). */
   port: number;
   /** Host interface to bind. Defaults to `127.0.0.1`. */
   host?: string;
   /** ALB listener port (for the `X-Forwarded-Port` header / logs). */
   listenerPort: number;
-  /** Service name for log lines. */
-  serviceName: string;
+  /** Human label for log / error lines (e.g. `listener port 80`). */
+  label: string;
   /**
    * Per-request upstream timeout (ms). A replica that accepts the connection
    * but never responds (deadlocked app, half-open socket) must not hang the
@@ -107,14 +118,27 @@ function handleProxyRequest(
   opts: StartFrontDoorServerOptions
 ): Promise<void> {
   return new Promise<void>((resolve) => {
-    const endpoint = opts.pool.next();
+    const pool = opts.selectPool(req.url ?? '/');
+    if (!pool) {
+      // No rule matched and no default action — mirror an ALB listener with no
+      // matching rule and no default (404).
+      writeError(
+        res,
+        404,
+        `No listener rule matched '${req.url ?? '/'}' on ${opts.label}, and the listener has no ` +
+          'default action forwarding to a local target.'
+      );
+      resolve();
+      return;
+    }
+    const endpoint = pool.next();
     if (!endpoint) {
       // No live replica — mirror an ALB with no healthy targets (503).
       writeError(
         res,
         503,
-        `No running replicas for service '${opts.serviceName}'. The front-door has no healthy ` +
-          'target to forward to.'
+        `No running replicas behind ${opts.label} for the matched target. The front-door has no ` +
+          'healthy target to forward to.'
       );
       resolve();
       return;
@@ -161,8 +185,7 @@ function handleProxyRequest(
         writeError(
           res,
           504,
-          `Replica ${endpoint.host}:${endpoint.port} for service '${opts.serviceName}' did not ` +
-            'respond in time.'
+          `Replica ${endpoint.host}:${endpoint.port} behind ${opts.label} did not respond in time.`
         );
       } else if (!res.writableEnded) {
         res.destroy();
@@ -176,8 +199,7 @@ function handleProxyRequest(
         writeError(
           res,
           502,
-          `Failed to reach replica ${endpoint.host}:${endpoint.port} for service ` +
-            `'${opts.serviceName}'.`
+          `Failed to reach replica ${endpoint.host}:${endpoint.port} behind ${opts.label}.`
         );
       } else if (!res.writableEnded) {
         res.destroy();

--- a/tests/integration/local-start-alb-routing/bin/app.ts
+++ b/tests/integration/local-start-alb-routing/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbRoutingStack } from '../lib/local-start-alb-routing-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbRoutingStack(app, 'CdkLocalStartAlbRoutingFixture', {
+  description: 'Fixture stack for cdkl start-alb path-pattern routing integ test (#123)',
+});

--- a/tests/integration/local-start-alb-routing/cdk.json
+++ b/tests/integration/local-start-alb-routing/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-routing/lib/local-start-alb-routing-stack.ts
+++ b/tests/integration/local-start-alb-routing/lib/local-start-alb-routing-stack.ts
@@ -1,0 +1,118 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Construct } from 'constructs';
+
+/**
+ * Fixture for `cdkl start-alb` path-pattern routing (#123 path-pattern slice).
+ *
+ * Hand-rolls the synthesized shape of an ALB whose single HTTP:80 listener
+ * path-routes across TWO ECS services, using L1 resources so the fixture stays
+ * VPC-free and deterministic (cdk-local only reads the template; it never
+ * deploys to AWS):
+ *
+ *   - `web` service (DesiredCount=2) behind `WebTargetGroup` — the listener
+ *     DEFAULT action forwards here.
+ *   - `api` service (DesiredCount=1) behind `ApiTargetGroup` — a
+ *     `AWS::ElasticLoadBalancingV2::ListenerRule` (priority 10,
+ *     `path-pattern` `/api/*`) forwards here.
+ *
+ * Each container is a tiny Python HTTP server that replies with
+ * `<role> <hostname>` (role = `web` / `api`, hostname = the docker container
+ * id), so the integ harness can assert that `/` reaches the web replicas
+ * (round-robin across 2) while `/api/...` is path-routed to the api service.
+ *
+ * Bridge network mode keeps the local exec path simple. The container port is
+ * published on an ephemeral host port per replica; the front-door binds the
+ * listener port (remapped to a non-privileged host port via `--lb-port` in
+ * verify.sh).
+ *
+ * `covers: AWS::ElasticLoadBalancingV2::ListenerRule` (matrix opt-in marker).
+ */
+// chr(10) is a newline in the response body; kept as chr(10) so the program
+// stays a clean newline-joined array (a literal '\n' here would split the line).
+function helloServer(role: string): string {
+  return [
+    'import http.server,socket',
+    'class H(http.server.BaseHTTPRequestHandler):',
+    ' def do_GET(s):',
+    `  b=('${role} '+socket.gethostname()+chr(10)).encode()`,
+    "  s.send_response(200);s.send_header('Content-Length',str(len(b)));s.end_headers();s.wfile.write(b)",
+    ' def log_message(s,*a):pass',
+    "http.server.HTTPServer(('0.0.0.0',80),H).serve_forever()",
+  ].join('\n');
+}
+
+export class LocalStartAlbRoutingStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-alb-routing-fixture',
+    });
+
+    const mkTask = (logicalId: string, family: string, role: string): ecs.CfnTaskDefinition =>
+      new ecs.CfnTaskDefinition(this, logicalId, {
+        family,
+        networkMode: 'bridge',
+        containerDefinitions: [
+          {
+            name: role,
+            image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+            essential: true,
+            entryPoint: ['python', '-c'],
+            command: [helloServer(role)],
+            memoryReservation: 32,
+            portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+          },
+        ],
+      });
+
+    const webTask = mkTask('WebTask', 'cdkl-start-alb-routing-web', 'web');
+    const apiTask = mkTask('ApiTask', 'cdkl-start-alb-routing-api', 'api');
+
+    const webTg = new elbv2.CfnTargetGroup(this, 'WebTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+    const apiTg = new elbv2.CfnTargetGroup(this, 'ApiTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WebLB', { type: 'application' });
+
+    const listener = new elbv2.CfnListener(this, 'WebListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      // Default action -> web; the path rule below carves `/api/*` out to api.
+      defaultActions: [{ type: 'forward', targetGroupArn: webTg.ref }],
+    });
+
+    new elbv2.CfnListenerRule(this, 'ApiRule', {
+      listenerArn: listener.ref,
+      priority: 10,
+      conditions: [{ field: 'path-pattern', pathPatternConfig: { values: ['/api/*'] } }],
+      actions: [{ type: 'forward', targetGroupArn: apiTg.ref }],
+    });
+
+    new ecs.CfnService(this, 'WebService', {
+      cluster: cluster.ref,
+      taskDefinition: webTask.ref,
+      desiredCount: 2,
+      launchType: 'EC2',
+      loadBalancers: [{ containerName: 'web', containerPort: 80, targetGroupArn: webTg.ref }],
+    });
+
+    new ecs.CfnService(this, 'ApiService', {
+      cluster: cluster.ref,
+      taskDefinition: apiTask.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+      loadBalancers: [{ containerName: 'api', containerPort: 80, targetGroupArn: apiTg.ref }],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-routing/package.json
+++ b/tests/integration/local-start-alb-routing/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-alb-routing",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb path-pattern routing (#123)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-alb-routing/tsconfig.json
+++ b/tests/integration/local-start-alb-routing/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-alb-routing/verify.sh
+++ b/tests/integration/local-start-alb-routing/verify.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-alb path-pattern routing integ test (#123, no AWS deploy)
+#
+# Names an Application Load Balancer whose single HTTP:80 listener path-routes
+# across TWO ECS services:
+#   - default action  -> web service (DesiredCount=2), replies "web <hostname>"
+#   - path-pattern /api/* (ListenerRule priority 10) -> api service (DesiredCount=1),
+#     replies "api <hostname>"
+# Asserts:
+#   - The host-side ALB front-door endpoint comes up on the --lb-port host port.
+#   - GET /            -> reaches the web service AND round-robins >= 2 replicas.
+#   - GET /api/ping    -> path-routed to the api service ("api ...").
+#   - GET /            and GET /api/ping reach DIFFERENT services.
+#   - SIGTERM tears every container + network + front-door socket down.
+#
+#     bash tests/integration/local-start-alb-routing/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+WEB_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
+LB_HOST_PORT=18087 # non-privileged host port the front-door binds (listener port 80 remapped)
+
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers + networks"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${WEB_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+
+echo "==> start-alb: naming the ALB (web DesiredCount=2 + api DesiredCount=1), front-door on host port ${LB_HOST_PORT}"
+# Remap the privileged listener port 80 to a non-privileged host port so the
+# front-door binds without root (the macOS Docker Desktop privileged-port path).
+${CDKL} start-alb CdkLocalStartAlbRoutingFixture:WebLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 120s)"
+BOOTED=0
+for _ in $(seq 1 120); do
+  if grep -q "Service(s) running:" "${OUT_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: services did not reach the boot banner within 120s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+
+echo "==> Asserting the front-door banner + the /api/* rule were logged"
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_HOST_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: front-door banner for host port ${LB_HOST_PORT} not found"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -q "path /api/\*" "${OUT_FILE}"; then
+  echo "FAIL: path rule '/api/*' not logged in the front-door routing table"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: front-door banner + /api/* rule present"
+
+echo "==> curl-ing / until the front-door serves 200 (replicas take a moment to start)"
+READY=0
+for _ in $(seq 1 90); do
+  if curl -fsS "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the front-door to serve"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: front-door never served a 200 on / within 90s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: front-door serving"
+
+echo "==> Asserting GET / reaches the WEB service and round-robins >= 2 replicas"
+WEB_HOSTS_FILE=$(mktemp)
+for _ in $(seq 1 20); do
+  curl -fsS "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null >> "${WEB_HOSTS_FILE}" || true
+done
+echo "    sample / responses:"; sort "${WEB_HOSTS_FILE}" | uniq -c | sed 's/^/      /'
+if grep -qv '^web ' "${WEB_HOSTS_FILE}"; then
+  echo "FAIL: GET / returned a non-web response (default action should route to the web service)"
+  cat "${WEB_HOSTS_FILE}"
+  exit 1
+fi
+WEB_DISTINCT=$(awk '{print $2}' "${WEB_HOSTS_FILE}" | sort -u | grep -c . || true)
+rm -f "${WEB_HOSTS_FILE}"
+echo "    distinct web replica hostnames: ${WEB_DISTINCT}"
+if [[ "${WEB_DISTINCT}" -lt 2 ]]; then
+  echo "FAIL: expected / to round-robin across >= 2 web replicas, saw ${WEB_DISTINCT}"
+  exit 1
+fi
+echo "    OK: / round-robins ${WEB_DISTINCT} web replicas"
+
+echo "==> Asserting GET /api/ping is path-routed to the API service"
+API_READY=0
+API_RESP=""
+for _ in $(seq 1 60); do
+  API_RESP=$(curl -fsS "http://127.0.0.1:${LB_HOST_PORT}/api/ping" 2>/dev/null || true)
+  if [[ -n "${API_RESP}" ]]; then
+    API_READY=1
+    break
+  fi
+  sleep 1
+done
+if [[ "${API_READY}" -ne 1 ]]; then
+  echo "FAIL: /api/ping never served a 200 within 60s (api replica not ready / not routed)"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    /api/ping response: ${API_RESP}"
+if [[ "${API_RESP}" != api\ * ]]; then
+  echo "FAIL: /api/ping was not path-routed to the api service (got: ${API_RESP})"
+  exit 1
+fi
+echo "    OK: /api/ping path-routed to the api service"
+
+echo "==> Sending SIGTERM to cdk-local (${CDKL_PID})"
+kill -TERM "${CDKL_PID}"
+
+echo "==> Waiting for cdk-local to exit (up to 60s)"
+EXITED=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then EXITED=1; break; fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+echo "==> Asserting clean teardown — no leftover containers"
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers still present after SIGTERM"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+
+echo "==> Asserting clean teardown — no leftover networks"
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} docker networks still present after SIGTERM"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+echo "==> Asserting the front-door socket is closed"
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: front-door on host port ${LB_HOST_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+
+echo ""
+echo "==> local-start-alb-routing test passed (default -> web round-robin, /api/* -> api, clean teardown)"

--- a/tests/unit/local/alb-path-matcher.test.ts
+++ b/tests/unit/local/alb-path-matcher.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  albPathPatternMatches,
+  matchAlbPathRule,
+  type AlbPathRule,
+} from '../../../src/local/alb-path-matcher.js';
+
+describe('albPathPatternMatches', () => {
+  it('matches an exact literal path', () => {
+    expect(albPathPatternMatches('/health', '/health')).toBe(true);
+    expect(albPathPatternMatches('/health', '/healthz')).toBe(false);
+    expect(albPathPatternMatches('/health', '/health/')).toBe(false);
+  });
+
+  it('treats * as zero-or-more characters, including slashes', () => {
+    expect(albPathPatternMatches('/api/*', '/api/')).toBe(true);
+    expect(albPathPatternMatches('/api/*', '/api/v1/users')).toBe(true);
+    expect(albPathPatternMatches('/api/*', '/api')).toBe(false); // needs the trailing slash + 0 chars
+    expect(albPathPatternMatches('/api*', '/api')).toBe(true); // 0 chars after the prefix
+    expect(albPathPatternMatches('*', '/anything/at/all')).toBe(true);
+  });
+
+  it('treats ? as exactly one character', () => {
+    expect(albPathPatternMatches('/img?', '/imgs')).toBe(true);
+    expect(albPathPatternMatches('/img?', '/img')).toBe(false);
+    expect(albPathPatternMatches('/img?', '/imgss')).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    expect(albPathPatternMatches('/API/*', '/api/x')).toBe(false);
+    expect(albPathPatternMatches('/API/*', '/API/x')).toBe(true);
+  });
+
+  it('matches the path only, ignoring the query string', () => {
+    expect(albPathPatternMatches('/search', '/search?q=hello')).toBe(true);
+    expect(albPathPatternMatches('/search', '/search#frag')).toBe(true);
+  });
+
+  it('escapes regex metacharacters in the literal portion', () => {
+    expect(albPathPatternMatches('/a.b', '/a.b')).toBe(true);
+    expect(albPathPatternMatches('/a.b', '/axb')).toBe(false); // '.' is literal, not "any char"
+  });
+});
+
+describe('matchAlbPathRule', () => {
+  const rules: AlbPathRule<string>[] = [
+    { priority: 20, pathPatterns: ['/api/*'], target: 'api' },
+    { priority: 10, pathPatterns: ['/api/admin/*'], target: 'admin' },
+    { priority: 30, pathPatterns: ['/static/*', '/assets/*'], target: 'static' },
+  ];
+
+  it('returns the highest-priority (lowest number) matching rule', () => {
+    // Both /api/admin/* (priority 10) and /api/* (priority 20) match; 10 wins.
+    expect(matchAlbPathRule('/api/admin/users', rules)).toBe('admin');
+    expect(matchAlbPathRule('/api/orders', rules)).toBe('api');
+  });
+
+  it('evaluates priority irrespective of input order', () => {
+    const shuffled = [rules[1]!, rules[2]!, rules[0]!];
+    expect(matchAlbPathRule('/api/admin/x', shuffled)).toBe('admin');
+  });
+
+  it('OR-matches a rule with multiple path-pattern values', () => {
+    expect(matchAlbPathRule('/static/app.js', rules)).toBe('static');
+    expect(matchAlbPathRule('/assets/logo.png', rules)).toBe('static');
+  });
+
+  it('returns undefined when no rule matches (caller uses the default)', () => {
+    expect(matchAlbPathRule('/', rules)).toBeUndefined();
+    expect(matchAlbPathRule('/health', rules)).toBeUndefined();
+  });
+
+  it('strips the query string before matching', () => {
+    expect(matchAlbPathRule('/api/orders?page=2', rules)).toBe('api');
+  });
+});

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -11,6 +11,10 @@ const TG = 'WebTargetGroup';
 const LISTENER = 'WebListener';
 const SERVICE = 'WebService';
 
+const API_TG = 'ApiTargetGroup';
+const API_SERVICE = 'ApiService';
+const RULE = 'ApiRule';
+
 /**
  * Mirrors the real `ApplicationLoadBalancedFargateService` synth shape: ALB ->
  * Listener (forward) -> TargetGroup <- Service.LoadBalancers[]. Resources merge
@@ -48,28 +52,43 @@ function stackWith(overrides: Record<string, unknown> = {}): StackInfo {
   return { stackName: 'AlbStack', template: { Resources: base } } as unknown as StackInfo;
 }
 
+/** A second backing service (`api`) + target group, for path-rule routing tests. */
+const apiServiceResources: Record<string, unknown> = {
+  [API_TG]: {
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+    Properties: { Port: 80, Protocol: 'HTTP', TargetType: 'ip' },
+  },
+  [API_SERVICE]: {
+    Type: 'AWS::ECS::Service',
+    Properties: {
+      LoadBalancers: [
+        { ContainerName: 'api', ContainerPort: 8080, TargetGroupArn: { Ref: API_TG } },
+      ],
+    },
+  },
+};
+
 describe('resolveAlbFrontDoor', () => {
-  it('resolves ALB -> listener -> target group -> backing ECS service', () => {
-    const { services, warnings } = resolveAlbFrontDoor(stackWith(), ALB);
+  it('resolves ALB -> listener default forward -> backing ECS service', () => {
+    const { listeners, warnings } = resolveAlbFrontDoor(stackWith(), ALB);
     expect(warnings).toEqual([]);
-    expect(services).toEqual([
+    expect(listeners).toEqual([
       {
-        serviceLogicalId: SERVICE,
-        targets: [
-          {
-            listenerPort: 80,
-            listenerProtocol: 'HTTP',
-            targetContainerName: 'web',
-            targetContainerPort: 80,
-            targetGroupLogicalId: TG,
-            listenerLogicalId: LISTENER,
-          },
-        ],
+        listenerPort: 80,
+        listenerProtocol: 'HTTP',
+        listenerLogicalId: LISTENER,
+        defaultTarget: {
+          serviceLogicalId: SERVICE,
+          targetContainerName: 'web',
+          targetContainerPort: 80,
+          targetGroupLogicalId: TG,
+        },
+        rules: [],
       },
     ]);
   });
 
-  it('resolves the ForwardConfig.TargetGroups[] (weighted) shape too', () => {
+  it('resolves a single-target ForwardConfig.TargetGroups[] default action', () => {
     const stack = stackWith({
       [LISTENER]: {
         Type: 'AWS::ElasticLoadBalancingV2::Listener',
@@ -83,9 +102,131 @@ describe('resolveAlbFrontDoor', () => {
         },
       },
     });
-    const { services } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toHaveLength(1);
-    expect(services[0]!.targets[0]!.listenerPort).toBe(8080);
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]!.listenerPort).toBe(8080);
+    expect(listeners[0]!.defaultTarget?.serviceLogicalId).toBe(SERVICE);
+  });
+
+  it('resolves path-pattern ListenerRules into a routing table (default + rule, two services)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [{ Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*'] } }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]!.defaultTarget?.serviceLogicalId).toBe(SERVICE);
+    expect(listeners[0]!.rules).toEqual([
+      {
+        priority: 10,
+        pathPatterns: ['/api/*'],
+        target: {
+          serviceLogicalId: API_SERVICE,
+          targetContainerName: 'api',
+          targetContainerPort: 8080,
+          targetGroupLogicalId: API_TG,
+        },
+      },
+    ]);
+  });
+
+  it('reads the legacy top-level Conditions[].Values path-pattern shape', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 5,
+          Conditions: [{ Field: 'path-pattern', Values: ['/legacy/*'] }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners[0]!.rules[0]!.pathPatterns).toEqual(['/legacy/*']);
+  });
+
+  it('skips + warns on a rule with an unsupported (non-path-pattern) condition', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [{ Field: 'host-header', HostHeaderConfig: { Values: ['api.example.com'] } }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    // The listener still resolves via its default forward; only the rule is dropped.
+    expect(listeners[0]!.rules).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/unsupported condition\(s\): host-header/);
+  });
+
+  it('skips + warns on a weighted (multi-target) forward', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [
+            {
+              Type: 'forward',
+              ForwardConfig: {
+                TargetGroups: [{ TargetGroupArn: { Ref: TG } }, { TargetGroupArn: { Ref: API_TG } }],
+              },
+            },
+          ],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/weighted forward/);
+  });
+
+  it('serves a rules-only listener (fixed-response default + path rule -> no defaultTarget)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [{ Type: 'fixed-response', FixedResponseConfig: { StatusCode: '404' } }],
+        },
+      },
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [{ Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*'] } }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]!.defaultTarget).toBeUndefined();
+    expect(listeners[0]!.rules[0]!.target.serviceLogicalId).toBe(API_SERVICE);
   });
 
   it('ignores listeners belonging to a different ALB', () => {
@@ -100,12 +241,11 @@ describe('resolveAlbFrontDoor', () => {
         },
       },
     });
-    const { services } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toHaveLength(1);
-    expect(services[0]!.targets.map((t) => t.listenerPort)).toEqual([80]);
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners.map((l) => l.listenerPort)).toEqual([80]);
   });
 
-  it('skips + warns on an HTTPS listener (HTTP only in v1)', () => {
+  it('skips + warns on an HTTPS listener (HTTP only)', () => {
     const stack = stackWith({
       [LISTENER]: {
         Type: 'AWS::ElasticLoadBalancingV2::Listener',
@@ -117,8 +257,8 @@ describe('resolveAlbFrontDoor', () => {
         },
       },
     });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toEqual([]);
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
     expect(warnings.join('\n')).toMatch(/HTTPS/);
   });
 
@@ -129,16 +269,16 @@ describe('resolveAlbFrontDoor', () => {
         Properties: { TargetType: 'lambda' },
       },
     });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toEqual([]);
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
     expect(warnings.join('\n')).toMatch(/Lambda target/);
   });
 
   it('warns when no ECS service references the target group', () => {
     const stack = stackWith({ [SERVICE]: undefined });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toEqual([]);
-    expect(warnings.join('\n')).toMatch(/not\s+referenced by any AWS::ECS::Service/);
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/not referenced by any AWS::ECS::Service/);
   });
 
   it('warns when a forward listener uses a non-Ref (literal / cross-stack) target group arn', () => {
@@ -159,12 +299,12 @@ describe('resolveAlbFrontDoor', () => {
         },
       },
     });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toEqual([]);
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
     expect(warnings.join('\n')).toMatch(/non-Ref TargetGroupArn/);
   });
 
-  it('warns on a non-Ref target group inside a ForwardConfig.TargetGroups[] (weighted)', () => {
+  it('warns on a non-Ref target group inside a ForwardConfig.TargetGroups[]', () => {
     const stack = stackWith({
       [LISTENER]: {
         Type: 'AWS::ElasticLoadBalancingV2::Listener',
@@ -188,8 +328,8 @@ describe('resolveAlbFrontDoor', () => {
         },
       },
     });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toEqual([]);
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
     expect(warnings.join('\n')).toMatch(/non-Ref TargetGroupArn/);
   });
 
@@ -205,34 +345,16 @@ describe('resolveAlbFrontDoor', () => {
         },
       },
     });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toEqual([]);
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
     expect(warnings).toEqual([]);
   });
 
   it('warns when the forwarded target group is missing from the template', () => {
     const stack = stackWith({ [TG]: undefined });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toEqual([]);
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
     expect(warnings.join('\n')).toMatch(/no AWS::ElasticLoadBalancingV2::TargetGroup/);
-  });
-
-  it('keeps only the first front-door when two listeners hit the same service on one port', () => {
-    const stack = stackWith({
-      SecondListener: {
-        Type: 'AWS::ElasticLoadBalancingV2::Listener',
-        Properties: {
-          LoadBalancerArn: { Ref: ALB },
-          Port: 80,
-          Protocol: 'HTTP',
-          DefaultActions: [{ Type: 'forward', TargetGroupArn: { Ref: TG } }],
-        },
-      },
-    });
-    const { services, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(services).toHaveLength(1);
-    expect(services[0]!.targets).toHaveLength(1);
-    expect(warnings.join('\n')).toMatch(/more than one listener on host port 80/);
   });
 });
 

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -139,6 +139,23 @@ describe('resolveAlbFrontDoor', () => {
     ]);
   });
 
+  it('sorts a rule with no Priority last (Number.MAX_SAFE_INTEGER fallback)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          // No Priority -> must fall back to MAX_SAFE_INTEGER (loses to any numbered rule).
+          ListenerArn: { Ref: LISTENER },
+          Conditions: [{ Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*'] } }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners[0]!.rules[0]!.priority).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
   it('reads the legacy top-level Conditions[].Values path-pattern shape', () => {
     const stack = stackWith({
       ...apiServiceResources,

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -6,6 +6,7 @@ import {
   startFrontDoorServer,
   type StartedFrontDoorServer,
 } from '../../../src/local/front-door-server.js';
+import { matchAlbPathRule, type AlbPathRule } from '../../../src/local/alb-path-matcher.js';
 
 interface Upstream {
   server: Server;
@@ -167,5 +168,84 @@ describe('startFrontDoorServer', () => {
     const res = await fetchText(front.port, '/nope');
     expect(res.status).toBe(404);
     expect(res.body).toMatch(/No listener rule matched/);
+  });
+
+  it('routes through the real matchAlbPathRule honoring rule priority (no default -> 404)', async () => {
+    const admin = await startUpstream('admin');
+    const api = await startUpstream('api');
+    const adminPool = new FrontDoorEndpointPool();
+    adminPool.register('admin:r0', { host: '127.0.0.1', port: admin.port });
+    const apiPool = new FrontDoorEndpointPool();
+    apiPool.register('api:r0', { host: '127.0.0.1', port: api.port });
+    // /api/admin/* (priority 10) must win over /api/* (priority 20) for an
+    // overlapping path — the exact integration the matcher guarantees.
+    const rules: AlbPathRule<FrontDoorEndpointPool>[] = [
+      { priority: 20, pathPatterns: ['/api/*'], target: apiPool },
+      { priority: 10, pathPatterns: ['/api/admin/*'], target: adminPool },
+    ];
+    const front = await startFrontWith((path) => matchAlbPathRule(path, rules));
+
+    expect((await fetchText(front.port, '/api/admin/users')).body).toBe('admin');
+    expect((await fetchText(front.port, '/api/orders')).body).toBe('api');
+    expect((await fetchText(front.port, '/')).status).toBe(404); // no default action
+  });
+
+  it('strips hop-by-hop request headers, including those named in Connection', async () => {
+    const up = await startUpstream('up');
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: up.port });
+    const front = await startFront(pool);
+
+    // `Connection: x-hop` marks `x-hop` itself as hop-by-hop -> both must be
+    // dropped before forwarding; an ordinary header passes through. (Node
+    // re-adds its own `Connection` for the upstream hop, so we don't assert on
+    // `connection` directly — we assert the token-listed header is gone.)
+    await new Promise<void>((resolve, reject) => {
+      const req = get(
+        {
+          host: '127.0.0.1',
+          port: front.port,
+          path: '/',
+          headers: { connection: 'x-hop', 'x-hop': 'secret', 'x-keep': 'kept' },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', () => resolve());
+        }
+      );
+      req.on('error', reject);
+    });
+    expect(up.lastHeaders?.['x-hop']).toBeUndefined();
+    expect(up.lastHeaders?.['x-keep']).toBe('kept');
+  });
+
+  it('strips hop-by-hop headers from the upstream response', async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, {
+        // `proxy-authenticate` is hop-by-hop and is neither added nor stripped
+        // by Node's own server machinery (unlike `connection` / `keep-alive`),
+        // so it is a clean signal that the proxy removed it.
+        'proxy-authenticate': 'Basic',
+        'x-app': 'kept',
+        'content-type': 'text/plain',
+      });
+      res.end('ok');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const upPort = (server.address() as AddressInfo).port;
+    cleanups.push(() => new Promise<void>((r) => server.close(() => r())));
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upPort });
+    const front = await startFront(pool);
+
+    const headers = await new Promise<IncomingMessage['headers']>((resolve, reject) => {
+      const req = get({ host: '127.0.0.1', port: front.port, path: '/' }, (res) => {
+        res.resume();
+        res.on('end', () => resolve(res.headers));
+      });
+      req.on('error', reject);
+    });
+    expect(headers['proxy-authenticate']).toBeUndefined();
+    expect(headers['x-app']).toBe('kept'); // non-hop-by-hop headers pass through
   });
 });

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -38,12 +38,19 @@ async function startFront(
   pool: FrontDoorEndpointPool,
   upstreamTimeoutMs?: number
 ): Promise<StartedFrontDoorServer> {
+  return startFrontWith(() => pool, upstreamTimeoutMs);
+}
+
+async function startFrontWith(
+  selectPool: (requestPath: string) => FrontDoorEndpointPool | undefined,
+  upstreamTimeoutMs?: number
+): Promise<StartedFrontDoorServer> {
   const front = await startFrontDoorServer({
-    pool,
+    selectPool,
     port: 0,
     host: '127.0.0.1',
     listenerPort: 80,
-    serviceName: 'TestSvc',
+    label: 'listener port 80',
     ...(upstreamTimeoutMs !== undefined && { upstreamTimeoutMs }),
   });
   cleanups.push(() => front.close());
@@ -65,10 +72,11 @@ async function startHungUpstream(): Promise<Upstream> {
 
 function fetchText(
   port: number,
+  path = '/',
   host = '127.0.0.1'
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
-    const req = get({ host, port, path: '/' }, (res) => {
+    const req = get({ host, port, path }, (res) => {
       let body = '';
       res.on('data', (c) => (body += c));
       res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
@@ -135,5 +143,29 @@ describe('startFrontDoorServer', () => {
 
     const res = await fetchText(front.port);
     expect(res.status).toBe(504);
+  });
+
+  it('path-routes each request to the pool selectPool returns', async () => {
+    const web = await startUpstream('web');
+    const api = await startUpstream('api');
+    const webPool = new FrontDoorEndpointPool();
+    webPool.register('web:r0', { host: '127.0.0.1', port: web.port });
+    const apiPool = new FrontDoorEndpointPool();
+    apiPool.register('api:r0', { host: '127.0.0.1', port: api.port });
+    // `/api/*` -> apiPool, everything else -> webPool (the default).
+    const front = await startFrontWith((path) =>
+      path.startsWith('/api/') ? apiPool : webPool
+    );
+
+    expect((await fetchText(front.port, '/')).body).toBe('web');
+    expect((await fetchText(front.port, '/index.html')).body).toBe('web');
+    expect((await fetchText(front.port, '/api/users')).body).toBe('api');
+  });
+
+  it('returns 404 when selectPool finds no matching rule and no default', async () => {
+    const front = await startFrontWith(() => undefined);
+    const res = await fetchText(front.port, '/nope');
+    expect(res.status).toBe(404);
+    expect(res.body).toMatch(/No listener rule matched/);
   });
 });

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { resolveAlbTarget, parseLbPortOverrides, albStrategy } from '../../../src/cli/commands/local-start-alb.js';
 import { serviceStrategy } from '../../../src/cli/commands/local-start-service.js';
-import { startFrontDoorServers } from '../../../src/cli/commands/ecs-service-emulator.js';
+import { buildFrontDoor } from '../../../src/cli/commands/ecs-service-emulator.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
 const ALB = 'WebLB';
@@ -149,16 +149,20 @@ function twoAlbStack(wiring: 'same-service' | 'two-services'): StackInfo {
 }
 
 describe('albStrategy.resolveBoots multi-service', () => {
-  it('merges two ALBs fronting the SAME service into one boot with both listeners', () => {
-    const { boots } = albStrategy({} as never).resolveBoots(
+  it('boots one service but stands up both listeners when two ALBs front the SAME service', () => {
+    // Alb1 listener (port 80) and Alb2 listener (port 8080) both forward to
+    // Svc1 -> one boot, two listeners on distinct host ports (no collision).
+    const { boots, frontDoor } = albStrategy({} as never).resolveBoots(
       [twoAlbStack('same-service')],
       ['Multi:Alb1', 'Multi:Alb2']
     );
-    expect(boots).toHaveLength(1);
-    expect(boots[0]!.target).toBe('Multi:Svc1');
-    expect(boots[0]!.frontDoorTargets.map((t) => t.listenerPort).sort((a, b) => a - b)).toEqual([
+    expect(boots).toEqual([{ target: 'Multi:Svc1' }]);
+    expect(frontDoor!.listeners.map((l) => l.listenerPort).sort((a, b) => a - b)).toEqual([
       80, 8080,
     ]);
+    for (const l of frontDoor!.listeners) {
+      expect(l.defaultTarget?.serviceTarget).toBe('Multi:Svc1');
+    }
   });
 
   it('produces two boots when two ALBs front two different services', () => {
@@ -189,42 +193,73 @@ describe('albStrategy --lb-port no-match warning', () => {
 });
 
 describe('start-alb / start-service strategy binding', () => {
-  it('start-alb resolves an ALB target into backing-service boots WITH front-door targets', () => {
+  it('start-alb resolves an ALB target into a service boot + a front-door plan', () => {
     const strategy = albStrategy({ lbPort: ['80=8080'] } as never);
-    const { boots, warnings } = strategy.resolveBoots([albStack()], ['AlbStack:WebLB']);
+    const { boots, frontDoor, warnings } = strategy.resolveBoots([albStack()], ['AlbStack:WebLB']);
     expect(warnings).toEqual([]);
-    expect(boots).toHaveLength(1);
-    expect(boots[0]!.target).toBe('AlbStack:WebService');
-    expect(boots[0]!.frontDoorTargets).toEqual([
-      expect.objectContaining({
+    expect(boots).toEqual([{ target: 'AlbStack:WebService' }]);
+    expect(frontDoor!.listeners).toEqual([
+      {
         listenerPort: 80,
-        targetContainerName: 'web',
-        targetContainerPort: 80,
-      }),
+        hostPort: 8080, // remapped by --lb-port 80=8080
+        defaultTarget: {
+          serviceTarget: 'AlbStack:WebService',
+          targetContainerName: 'web',
+          targetContainerPort: 80,
+        },
+        rules: [],
+      },
     ]);
     // --lb-port is parsed by the ALB strategy (start-service has no such flag).
     expect(strategy.lbPortOverrides).toEqual({ 80: 8080 });
   });
 
-  it('start-service produces pure-compute boots with NO front-door targets', () => {
+  it('start-service produces pure-compute boots with NO front-door plan', () => {
     const strategy = serviceStrategy();
-    const { boots } = strategy.resolveBoots([albStack()], ['AlbStack:WebService']);
-    expect(boots).toEqual([{ target: 'AlbStack:WebService', frontDoorTargets: [] }]);
+    const { boots, frontDoor } = strategy.resolveBoots([albStack()], ['AlbStack:WebService']);
+    expect(boots).toEqual([{ target: 'AlbStack:WebService' }]);
+    expect(frontDoor).toBeUndefined();
     expect(strategy.lbPortOverrides).toEqual({});
   });
 });
 
-describe('startFrontDoorServers (pure-compute path)', () => {
-  it('returns no front-door context when there are no front-door targets', async () => {
-    const result = await startFrontDoorServers(
-      [],
-      { serviceName: 'X' } as never,
+describe('buildFrontDoor', () => {
+  it('binds one server per listener and groups pools by service target', async () => {
+    const logger = { info: () => {}, warn: () => {} } as never;
+    const { servers, frontDoorByService } = await buildFrontDoor(
+      {
+        listeners: [
+          {
+            listenerPort: 80,
+            hostPort: 0, // ephemeral: avoid privileged-port binding in the unit test
+            defaultTarget: {
+              serviceTarget: 'S:Web',
+              targetContainerName: 'web',
+              targetContainerPort: 80,
+            },
+            rules: [
+              {
+                priority: 10,
+                pathPatterns: ['/api/*'],
+                target: { serviceTarget: 'S:Api', targetContainerName: 'api', targetContainerPort: 8080 },
+              },
+            ],
+          },
+        ],
+      },
       '127.0.0.1',
-      {},
-      { info: () => {}, warn: () => {} } as never
+      logger
     );
-    expect(result.frontDoorContext).toBeUndefined();
-    expect(result.frontDoorServers).toEqual([]);
+    try {
+      expect(servers).toHaveLength(1);
+      // One pool per (service, container, port); grouped by service target.
+      expect([...frontDoorByService.keys()].sort()).toEqual(['S:Api', 'S:Web']);
+      expect(frontDoorByService.get('S:Web')).toEqual([
+        expect.objectContaining({ targetContainerName: 'web', targetContainerPort: 80 }),
+      ]);
+    } finally {
+      await Promise.all(servers.map((s) => s.close()));
+    }
   });
 });
 

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -172,6 +172,67 @@ describe('albStrategy.resolveBoots multi-service', () => {
     );
     expect(boots.map((b) => b.target).sort()).toEqual(['Multi:Svc1', 'Multi:Svc2']);
   });
+
+  it('keeps only the first listener when two listeners claim the same host port', () => {
+    // Both ALBs expose a listener on port 80 (no --lb-port remap), so they
+    // would bind the same host port -> the second is skipped with a warning.
+    const collisionStack = {
+      stackName: 'Multi',
+      template: {
+        Resources: {
+          Alb1: { Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer', Properties: { Type: 'application' } },
+          Alb2: { Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer', Properties: { Type: 'application' } },
+          Tg1: {
+            Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+            Properties: { Port: 80, Protocol: 'HTTP', TargetType: 'ip' },
+          },
+          Tg2: {
+            Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+            Properties: { Port: 80, Protocol: 'HTTP', TargetType: 'ip' },
+          },
+          L1: {
+            Type: 'AWS::ElasticLoadBalancingV2::Listener',
+            Properties: {
+              LoadBalancerArn: { Ref: 'Alb1' },
+              Port: 80,
+              Protocol: 'HTTP',
+              DefaultActions: [{ Type: 'forward', TargetGroupArn: { Ref: 'Tg1' } }],
+            },
+          },
+          L2: {
+            Type: 'AWS::ElasticLoadBalancingV2::Listener',
+            Properties: {
+              LoadBalancerArn: { Ref: 'Alb2' },
+              Port: 80,
+              Protocol: 'HTTP',
+              DefaultActions: [{ Type: 'forward', TargetGroupArn: { Ref: 'Tg2' } }],
+            },
+          },
+          Svc1: {
+            Type: 'AWS::ECS::Service',
+            Properties: {
+              LoadBalancers: [{ ContainerName: 'web', ContainerPort: 80, TargetGroupArn: { Ref: 'Tg1' } }],
+            },
+          },
+          Svc2: {
+            Type: 'AWS::ECS::Service',
+            Properties: {
+              LoadBalancers: [{ ContainerName: 'api', ContainerPort: 80, TargetGroupArn: { Ref: 'Tg2' } }],
+            },
+          },
+        },
+      },
+    } as unknown as StackInfo;
+
+    const { boots, frontDoor, warnings } = albStrategy({} as never).resolveBoots(
+      [collisionStack],
+      ['Multi:Alb1', 'Multi:Alb2']
+    );
+    // Only the first listener is fronted -> only its backing service is booted.
+    expect(frontDoor!.listeners).toHaveLength(1);
+    expect(boots).toEqual([{ target: 'Multi:Svc1' }]);
+    expect(warnings.join('\n')).toMatch(/already.*claimed by listener port 80/);
+  });
 });
 
 describe('albStrategy --lb-port no-match warning', () => {


### PR DESCRIPTION
## Summary

Implements the **`path-pattern` routing slice** of (#123) on top of the v1
`start-alb` front-door (#86). The local ALB front-door now applies a listener's
`path-pattern` listener rules, so a single listener port can path-route across
several backing ECS services — e.g. `/api/*` to one service, the default action
to another — the way the deployed ALB does, instead of only a single default
`forward`.

- **Resolver** (`elb-front-door-resolver`) now produces a per-listener routing
  table: an optional default forward target + priority-ordered `path-pattern`
  rules, each resolving (via the reverse `TargetGroup -> Service.LoadBalancers[]`
  scan) to a backing (service, container, port).
- **New `alb-path-matcher`**: ALB `*` / `?` glob path-pattern matching
  (path-only, case-sensitive, full-anchored), evaluated by `Priority` (lower
  first); first match wins, else the default action, else 404.
- **Front-door server** selects a pool per request via a `selectPool(path)`
  callback and now strips hop-by-hop headers (RFC 7230 §6.1) both ways, like a
  real ALB.
- **Front-door creation is hoisted to the emulator level**: ONE reverse-proxy
  server per listener port, shared across the services it fronts, with one pool
  per distinct (service, container, port) — the same pool object on both the
  listener routing table and the owning service's runner. `start-service`
  returns no front-door plan (pure compute, unchanged).
- Host-port collision across listeners (e.g. two ALBs both on port 80) warns and
  keeps the first.

### Scope

In: HTTP listeners, single-target `forward` actions, `path-pattern` rules
(priority-ordered), ECS targets. Out (skipped with a warning, still tracked in
(#123)): other rule conditions (host-header / http-header / http-request-method
/ query-string / source-ip), weighted (multi-target) forwards, `redirect` /
`fixed-response` / `authenticate-*` actions, HTTPS / TLS, Lambda target groups.
This PR does NOT close (#123) — the remaining listener-rule features stay open.

## Test plan

- [x] `vp run check` (typecheck + lint + format) green
- [x] `vp test run` green — 93 files / 1317 tests (new: `alb-path-matcher`
      matcher tests; resolver reworked to per-listener shape + path-rule /
      legacy-`Values` / unsupported-condition / weighted / lambda /
      rules-only-default / missing-`Priority` coverage; front-door-server
      path-routing-through-the-real-matcher + 404 + hop-by-hop strip;
      `buildFrontDoor` pool-grouping; host-port collision)
- [x] `vp run build` green
- [x] `/run-integ local-start-alb-routing` (new fixture: web default + `/api/*`
      -> api) — `/` round-robins 2 web replicas, `/api/ping` path-routes to the
      api service, clean teardown, 0 orphans
- [x] `/run-integ local-start-alb` (single-forward) — still passes (regression),
      0 orphans

## Accepted nits (from the 3-axis review)

- A ListenerRule with a missing/unparseable `Priority` sorts last via
  `Number.MAX_SAFE_INTEGER`; multiple such rules then resolve by template key
  order. CloudFormation forbids duplicate priorities per listener, so this only
  affects hand-rolled templates — acceptable.
- `buildFrontDoor` sorts rules by priority once for the log line and the matcher
  sorts again at match time; two independent sorts of the same small list,
  harmless.
- `matchAlbPathRule` re-sorts the rule list on every request rather than once up
  front. Negligible for a local-dev tool (low RPS, tiny rule lists), and keeping
  the sort inside the matcher preserves its "callers pass unsorted rules"
  contract.
