### PR TITLE
feat(invoke-agentcore): run MCP-protocol runtimes locally (POST /mcp)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,14 +34,17 @@ AWS managed services.
   `path-pattern` rules across the backing services (other conditions —
   host-header / weighted / Lambda targets / redirect+fixed-response
   actions — deferred to #123)
-- Bedrock AgentCore Runtime agents — the agent container served over the
-  AgentCore HTTP contract (`POST /invocations` + `GET /ping` on port 8080),
-  invoked once locally (`cdkl invoke-agentcore`); v1 covers container artifacts
-  on the HTTP protocol. An inbound `customJwtAuthorizer` is enforced locally —
-  `--bearer-token` is verified against the runtime's OIDC discovery URL before
-  the container starts and forwarded to `/invocations`. A streaming SSE
-  (`text/event-stream`) response is printed to stdout incrementally as it
-  arrives
+- Bedrock AgentCore Runtime agents — the agent container served over its
+  protocol contract, invoked once locally (`cdkl invoke-agentcore`); covers
+  container artifacts on the HTTP and MCP protocols. HTTP runs the
+  `POST /invocations` + `GET /ping` contract on 8080: an inbound
+  `customJwtAuthorizer` is enforced locally (`--bearer-token` verified against
+  the runtime's OIDC discovery URL before the container starts and forwarded to
+  `/invocations`), and a streaming SSE (`text/event-stream`) response is printed
+  to stdout incrementally. MCP runs the Streamable-HTTP `POST /mcp` contract on
+  8000: the session handshake (initialize -> notifications/initialized) then one
+  JSON-RPC request (`tools/list` by default, or the method/params from
+  `--event`)
 - API Gateway authorizers — Lambda authorizers, Cognito User Pool JWT
   verification, IAM SigV4 verification
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/go-to-k/cdk-local/actions/workflows/ci.yml/badge.svg)](https://github.com/go-to-k/cdk-local/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/npm/l/cdk-local.svg)](./LICENSE)
 
-Run your CDK app's Lambda functions, API Gateway, and ECS tasks/services on your own machine — with **no AWS account**, or bound to your **deployed stack to hit real AWS resources and data**. A native, CDK-first alternative to `sam local`.
+Run your CDK app's Lambda functions, API Gateway, ECS tasks/services, and Bedrock AgentCore agents on your own machine — with **no AWS account**, or bound to your **deployed stack to hit real AWS resources and data**. A native, CDK-first alternative to `sam local`.
 
 ![cdkl start-api serving a local CDK app's HTTP API; curl in the right pane reaches the local Lambda](assets/cdkl-start-api.gif)
 
@@ -62,7 +62,7 @@ cdk-local runs your **application compute** locally in Docker, using your CDK ap
 - **Lambda functions** — your code in a real `public.ecr.aws/lambda/*` container via the Lambda Runtime Interface Emulator
 - **HTTP APIs & Function URLs** — API Gateway REST v1 / HTTP v2 / WebSocket and Lambda Function URLs served by a local HTTP server
 - **ECS** — tasks and services as real Docker containers (awsvpc / Service Connect / Cloud Map registry)
-- **Bedrock AgentCore Runtime** — your agent container served over the AgentCore HTTP contract (`POST /invocations` + `GET /ping` on 8080), invoked once locally before deploy
+- **Bedrock AgentCore Runtime** — your agent container served over its protocol contract — HTTP (`POST /invocations` + `GET /ping` on 8080) or MCP (`POST /mcp` Streamable HTTP on 8000) — invoked once locally before deploy
 - **Authorizers** — Lambda authorizers, Cognito User Pool JWT verification, IAM SigV4 verification
 
 **Calls real AWS (managed services):**
@@ -176,7 +176,7 @@ See [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fron
 
 When you run a container directly — `run-task`, or a single-replica `start-service` — cdk-local publishes its declared container ports on the host and logs the address (`Reach it at 127.0.0.1:<port>`), so `curl http://127.0.0.1:<port>` or a browser reaches it. The bind IP defaults to `127.0.0.1` (override with `--container-host`); `--host-port <containerPort>=<hostPort>` remaps a port (handy on macOS to avoid the Docker admin prompt for privileged ports < 1024). For an ALB-fronted service, reach the replicas through the `start-alb` front-door above instead.
 
-`invoke-agentcore` runs a Bedrock AgentCore Runtime's container locally, waits for `GET /ping`, then POSTs your `--event` (or `{}`) to `POST /invocations` and prints the response — the same request/response loop AgentCore runs in the cloud, without a deploy. v1 covers container-artifact runtimes on the HTTP protocol; the agent's own calls to Bedrock models / memory / other managed services go to real AWS. When the runtime declares a JWT authorizer (`customJwtAuthorizer`), pass `--bearer-token <jwt>` — it's verified against the runtime's OIDC discovery URL (signature / issuer / expiry / audience) and forwarded to `/invocations`, the way AgentCore gates inbound requests; a missing or invalid token is rejected before the container starts (use `--no-verify-auth` to skip for local dev). A streaming SSE (`text/event-stream`) response is printed incrementally as it arrives, so a token-streaming agent shows live.
+`invoke-agentcore` runs a Bedrock AgentCore Runtime's container locally, waits for `GET /ping`, then POSTs your `--event` (or `{}`) to `POST /invocations` and prints the response — the same request/response loop AgentCore runs in the cloud, without a deploy. v1 covers container-artifact runtimes on the HTTP protocol; the agent's own calls to Bedrock models / memory / other managed services go to real AWS. When the runtime declares a JWT authorizer (`customJwtAuthorizer`), pass `--bearer-token <jwt>` — it's verified against the runtime's OIDC discovery URL (signature / issuer / expiry / audience) and forwarded to `/invocations`, the way AgentCore gates inbound requests; a missing or invalid token is rejected before the container starts (use `--no-verify-auth` to skip for local dev). A streaming SSE (`text/event-stream`) response is printed incrementally as it arrives, so a token-streaming agent shows live. An **MCP-protocol** runtime (`ProtocolConfiguration = MCP`) is also supported: cdk-local runs the container's `POST /mcp` Streamable-HTTP contract on 8000, performs the MCP session handshake, then sends one JSON-RPC request — `tools/list` by default, or the `{"method":...,"params":...}` from `--event` (e.g. `tools/call`) — and prints the response. (A2A / AG-UI protocols are not supported yet.)
 
 Use this for fast iteration on Lambda code, API routing checks, container task smoke tests, and agent request/response checks.
 
@@ -267,7 +267,7 @@ cdkl invoke MyStack/MyFunction --event ./event.json --env-vars ./env.json
 | `AWS::ECS::TaskDefinition` (run-task) | ✓ |
 | `AWS::ECS::Service` (start-service) | ✓ |
 | `AWS::ServiceDiscovery::*` (Cloud Map / Service Connect) | ✓ |
-| `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container artifact + HTTP) | ✓ |
+| `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container artifact, HTTP + MCP) | ✓ |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,7 +13,7 @@ cdk-local has six subcommands, all under the `cdkl` binary:
 | --- | --- | --- |
 | `cdkl list` (alias `cdkl ls`) | Lists the app's runnable targets (no execution) | Synthesis only — no Docker |
 | `cdkl invoke <target>` | One-shot Lambda invoke | AWS Lambda Runtime Interface Emulator (RIE) container |
-| `cdkl invoke-agentcore <target>` | One-shot Bedrock AgentCore Runtime invoke | Agent container + the AgentCore HTTP contract (`POST /invocations` + `GET /ping` on 8080) |
+| `cdkl invoke-agentcore <target>` | One-shot Bedrock AgentCore Runtime invoke | Agent container on its protocol contract — HTTP (`POST /invocations` + `GET /ping` on 8080) or MCP (`POST /mcp` on 8000) |
 | `cdkl start-api` | Long-running HTTP server — API Gateway (REST v1 / HTTP API / WebSocket) + Lambda Function URL | RIE container pool + `node:http` listener (one server per discovered API) |
 | `cdkl run-task <target>` | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
 | `cdkl start-service <targets...>` | Long-running ECS `Service` emulator (replicas only, no load balancer) | `run-task` machinery per replica + shared docker network + restart-on-exit watcher |
@@ -416,20 +416,25 @@ same sized `/tmp`.
 ## `cdkl invoke-agentcore` (run Bedrock AgentCore Runtime agents locally)
 
 `cdkl invoke-agentcore <target>` runs an `AWS::BedrockAgentCore::Runtime`
-agent container locally and invokes it once over the AgentCore HTTP
-contract. It resolves the runtime, pulls / builds its container, starts
-it on port 8080, waits for `GET /ping` to return a 2xx, POSTs the event
-to `POST /invocations` (with the session-id header), prints the response
-body, and tears the container down.
+agent container locally and invokes it once over its protocol contract. It
+resolves the runtime, pulls / builds its container, starts it, waits for it
+to become ready, sends one request, prints the response, and tears the
+container down. The exact contract depends on `ProtocolConfiguration`:
+
+- **HTTP** (default) — starts on port 8080, waits for `GET /ping` to return
+  a 2xx, then POSTs the event to `POST /invocations` (with the session-id
+  header) and prints the response body.
+- **MCP** — starts on port 8000, then speaks the Model Context Protocol over
+  Streamable HTTP at `POST /mcp`: see [MCP protocol](#mcp-protocol) below.
 
 This is the same request/response loop AgentCore runs in the cloud,
-exercised locally before deploy. v1 supports the **container artifact**
-(`AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`) on the
-**HTTP** protocol only; `CodeConfiguration` (S3 zip + managed runtime)
-artifacts and the `MCP` / `A2A` / `AGUI` protocols are rejected with an
-actionable error. The agent's own calls to AWS managed services (Bedrock
-models, memory, etc.) go to real AWS — credentials are injected exactly
-like `cdkl invoke` (see below).
+exercised locally before deploy. It supports the **container artifact**
+(`AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`) on the **HTTP**
+and **MCP** protocols; `CodeConfiguration` (S3 zip + managed runtime)
+artifacts and the `A2A` / `AGUI` protocols are rejected with an actionable
+error. The agent's own calls to AWS managed services (Bedrock models,
+memory, etc.) go to real AWS — credentials are injected exactly like
+`cdkl invoke` (see below).
 
 The container image is resolved like a container Lambda: a local cdk.out
 asset (the `fromAsset` / Dockerfile path) is built with `docker build`;
@@ -495,18 +500,43 @@ before the container starts:
 
 ### Streaming responses
 
-A JSON (`application/json`) response is printed verbatim once the request
-completes. A streaming SSE (`text/event-stream`) response is written to
-stdout chunk-by-chunk as it arrives — so a token-streaming agent shows
-incrementally, the same UX AgentCore gives in the cloud — rather than all
-at once at the end. Bidirectional `/ws` WebSocket streaming is a follow-up.
+(HTTP protocol.) A JSON (`application/json`) response is printed verbatim
+once the request completes. A streaming SSE (`text/event-stream`) response
+is written to stdout chunk-by-chunk as it arrives — so a token-streaming
+agent shows incrementally, the same UX AgentCore gives in the cloud —
+rather than all at once at the end. Bidirectional `/ws` WebSocket streaming
+is a follow-up.
+
+### MCP protocol
+
+When `ProtocolConfiguration = MCP`, the runtime's container serves the Model
+Context Protocol over Streamable HTTP at `POST /mcp` on port 8000 (there is
+no `GET /ping` — readiness is a successful `initialize`). `cdkl
+invoke-agentcore` runs the minimal MCP session lifecycle:
+
+1. `initialize` (retried while the container boots — this is the readiness
+   wait); the server may assign an `Mcp-Session-Id` that subsequent requests
+   echo,
+2. `notifications/initialized`,
+3. one JSON-RPC request — **`tools/list` by default**, or the
+   `{"method": ..., "params": ...}` from `--event` (e.g.
+   `{"method":"tools/call","params":{"name":"...","arguments":{...}}}`).
+
+The JSON-RPC response is printed (handling both an `application/json` and a
+`text/event-stream` reply). Talking to the local container is **vanilla
+MCP**: the AgentCore session header and inbound OAuth bearer are managed-plane
+concerns the cloud front door maps to MCP's own `Mcp-Session-Id`, so they are
+not applied to a direct local `/mcp` call (`--bearer-token` / `--session-id`
+are HTTP-protocol options and are ignored for MCP). The `A2A` / `AGUI`
+protocols are not supported yet.
 
 ### `cdkl invoke-agentcore` exit codes
 
-- `0` — the agent answered `POST /invocations` with a 2xx status.
-- `1` — the agent returned a 4xx/5xx from `/invocations`, OR a
-  cdk-local-side error: Docker not installed, image build / pull failed,
-  target not found, the agent never became ready on `GET /ping` within
+- `0` — the agent answered with a success: a 2xx from `POST /invocations`
+  (HTTP), or a JSON-RPC response with no top-level `error` (MCP).
+- `1` — the agent returned a 4xx/5xx from `/invocations` or a JSON-RPC
+  `error` (MCP), OR a cdk-local-side error: Docker not installed, image
+  build / pull failed, target not found, the agent never became ready within
   the readiness window, or the container exited before responding.
 
 ## `cdkl start-api` (long-running local API server)

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -29,6 +29,7 @@ import {
   type CdkLocalEmbedConfig,
 } from '../../local/embed-config.js';
 import {
+  AGENTCORE_MCP_PROTOCOL,
   resolveAgentCoreTarget,
   type ResolvedAgentCoreRuntime,
 } from '../../local/agentcore-resolver.js';
@@ -37,6 +38,13 @@ import {
   waitForAgentCorePing,
   type AgentCoreInvokeResult,
 } from '../../local/agentcore-client.js';
+import {
+  mcpInvokeOnce,
+  MCP_CONTAINER_PORT,
+  MCP_PATH,
+  type McpInvokeResult,
+  type McpJsonRpcRequest,
+} from '../../local/agentcore-mcp-client.js';
 import { createJwksCache, verifyJwtViaDiscovery } from '../../local/cognito-jwt.js';
 import { resolveEnvVars, type EnvOverrideFile } from '../../local/env-resolver.js';
 import {
@@ -227,18 +235,35 @@ async function localInvokeAgentCoreCommand(
 
     const resolved = resolveAgentCoreTarget(resolvedTarget, stacks);
     logger.info(`Target: ${resolved.stack.stackName}/${resolved.logicalId} (${resolved.protocol})`);
+    const isMcp = resolved.protocol === AGENTCORE_MCP_PROTOCOL;
 
     // Read + validate the event (and resolve the session id) BEFORE any
     // Docker work, so a bad --event / --event-stdin fails fast instead of
     // after paying for an image build + container boot.
     const sessionId = options.sessionId ?? randomUUID();
     const event = await readEvent(options);
+    // For MCP, parse the event into a JSON-RPC request up front so a malformed
+    // one fails fast too (default: tools/list).
+    const mcpRequest = isMcp ? buildMcpRequest(event) : undefined;
 
     // Inbound JWT auth: when the runtime declares a customJwtAuthorizer,
     // verify the supplied bearer token against its OIDC discovery URL BEFORE
     // any Docker work — rejecting a missing / invalid token the way AgentCore
     // does. Returns the `Authorization` header to forward to the container.
-    const authorization = await resolveInboundAuthorization(resolved, options);
+    // MCP talks vanilla MCP directly to the container; its bearer / session is
+    // an AgentCore managed-plane concern the front door maps to Mcp-Session-Id,
+    // so it is not applied to a direct local /mcp call.
+    let authorization: string | undefined;
+    if (isMcp) {
+      if (resolved.jwtAuthorizer || options.bearerToken) {
+        logger.info(
+          `MCP runtime: invoking the local container's ${MCP_PATH} directly (vanilla MCP). ` +
+            `An inbound JWT / --bearer-token is an AgentCore managed-plane concern and is not applied locally.`
+        );
+      }
+    } else {
+      authorization = await resolveInboundAuthorization(resolved, options);
+    }
 
     const image = await resolveAgentCoreImage(resolved, options);
 
@@ -257,7 +282,10 @@ async function localInvokeAgentCoreCommand(
     // if the process is killed before teardown — unlike a one-shot Lambda
     // invoke, the agent container runs a long-lived HTTP server.
     const containerName = `${getEmbedConfig().resourceNamePrefix}-agentcore-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
-    logger.info(`Starting agent container (image=${image}, port=${hostPort})...`);
+    const containerPortLabel = isMcp ? `${MCP_CONTAINER_PORT}${MCP_PATH}` : '8080';
+    logger.info(
+      `Starting agent container (image=${image}, port=${hostPort} -> ${containerPortLabel})...`
+    );
     containerId = await runDetached({
       image,
       mounts: [],
@@ -267,6 +295,7 @@ async function localInvokeAgentCoreCommand(
       host: containerHost,
       platform: options.platform,
       name: containerName,
+      ...(isMcp && { containerPort: MCP_CONTAINER_PORT }),
     });
 
     stopLogs = streamLogs(containerId);
@@ -276,20 +305,30 @@ async function localInvokeAgentCoreCommand(
     };
     process.on('SIGINT', sigintHandler);
 
-    await waitForAgentCorePing(containerHost, hostPort);
+    if (isMcp && mcpRequest) {
+      // MCP has no /ping: mcpInvokeOnce folds the boot-wait into a retried
+      // `initialize`, then runs the session handshake + the one request.
+      logger.info(`MCP request: ${mcpRequest.method}`);
+      const mcp = await mcpInvokeOnce(containerHost, hostPort, mcpRequest);
+      // Settle so container logs flush before teardown.
+      await new Promise((r) => setTimeout(r, 250));
+      emitMcpResult(mcp);
+    } else {
+      await waitForAgentCorePing(containerHost, hostPort);
 
-    const result = await invokeAgentCore(containerHost, hostPort, event, {
-      sessionId,
-      timeoutMs: 120_000,
-      // Stream a text/event-stream response to stdout as it arrives, so a
-      // token-streaming agent shows incrementally rather than all at once.
-      onChunk: (text) => process.stdout.write(text),
-      ...(authorization && { authorization }),
-    });
+      const result = await invokeAgentCore(containerHost, hostPort, event, {
+        sessionId,
+        timeoutMs: 120_000,
+        // Stream a text/event-stream response to stdout as it arrives, so a
+        // token-streaming agent shows incrementally rather than all at once.
+        onChunk: (text) => process.stdout.write(text),
+        ...(authorization && { authorization }),
+      });
 
-    // Settle so container logs flush before teardown.
-    await new Promise((r) => setTimeout(r, 250));
-    emitResult(result);
+      // Settle so container logs flush before teardown.
+      await new Promise((r) => setTimeout(r, 250));
+      emitResult(result);
+    }
   } finally {
     if (sigintHandler) process.off('SIGINT', sigintHandler);
     await cleanup();
@@ -564,6 +603,47 @@ export function emitResult(result: AgentCoreInvokeResult): void {
   process.stdout.write(`${result.raw}\n`);
 }
 
+/**
+ * Build the JSON-RPC request to send to an MCP runtime from `--event`:
+ *   - no `--event` (empty object) → `tools/list` (discover the server's tools),
+ *   - an object with a string `method` → that method + its `params`,
+ *   - anything else → a fail-fast error.
+ *
+ * Exported for unit testing.
+ */
+export function buildMcpRequest(event: unknown): McpJsonRpcRequest {
+  if (event === undefined || event === null) return { method: 'tools/list', params: {} };
+  if (typeof event !== 'object' || Array.isArray(event)) {
+    throw new CdkLocalError(
+      'MCP --event must be a JSON object describing a JSON-RPC request ' +
+        '(e.g. {"method":"tools/call","params":{"name":"...","arguments":{...}}}).',
+      'LOCAL_INVOKE_AGENTCORE_MCP_EVENT_INVALID'
+    );
+  }
+  const obj = event as Record<string, unknown>;
+  if (Object.keys(obj).length === 0) return { method: 'tools/list', params: {} };
+  if (typeof obj['method'] !== 'string') {
+    throw new CdkLocalError(
+      'MCP --event must include a string "method" (a JSON-RPC method such as ' +
+        `"tools/list" or "tools/call"). Got keys: ${Object.keys(obj).join(', ')}.`,
+      'LOCAL_INVOKE_AGENTCORE_MCP_EVENT_INVALID'
+    );
+  }
+  return {
+    method: obj['method'],
+    ...(obj['params'] !== undefined && { params: obj['params'] }),
+  };
+}
+
+/** Print the MCP JSON-RPC response; exit 1 when it carried a JSON-RPC error. */
+export function emitMcpResult(result: McpInvokeResult): void {
+  if (!result.ok) {
+    getLogger().warn('MCP server returned a JSON-RPC error.');
+    process.exitCode = 1;
+  }
+  process.stdout.write(`${result.raw}\n`);
+}
+
 /** Map a `--platform` value to the architecture `buildContainerImage` expects. */
 export function platformToArchitecture(platform: string): 'x86_64' | 'arm64' {
   return platform === 'linux/amd64' ? 'x86_64' : 'arm64';
@@ -680,13 +760,15 @@ export function createLocalInvokeAgentCoreCommand(
   setEmbedConfig(opts.embedConfig);
   const cmd = new Command('invoke-agentcore')
     .description(
-      'Run a Bedrock AgentCore Runtime container locally and invoke it once over the AgentCore HTTP ' +
-        'contract (POST /invocations + GET /ping on port 8080). Resolves the AWS::BedrockAgentCore::Runtime, ' +
-        'pulls/builds its container, injects env vars + AWS credentials, and prints the response. ' +
-        'Target accepts a CDK display path (MyStack/MyAgent) or stack-qualified logical ID ' +
+      'Run a Bedrock AgentCore Runtime container locally and invoke it once over its protocol ' +
+        'contract: HTTP (POST /invocations + GET /ping on 8080) or MCP (POST /mcp Streamable HTTP ' +
+        'on 8000). Resolves the AWS::BedrockAgentCore::Runtime, pulls/builds its container, injects ' +
+        'env vars + AWS credentials, and prints the response. For an MCP runtime, runs the session ' +
+        'handshake then sends one JSON-RPC request (tools/list by default, or the method/params from ' +
+        '--event). Target accepts a CDK display path (MyStack/MyAgent) or stack-qualified logical ID ' +
         '(MyStack:MyAgentRuntime1234). Single-stack apps may omit the stack prefix. ' +
         'Omit <target> in an interactive terminal to pick from a list. ' +
-        'v1 supports the container artifact + HTTP protocol; the agent calls real AWS for managed services.'
+        'Supports the container artifact on the HTTP + MCP protocols; the agent calls real AWS for managed services.'
     )
     .argument(
       '[target]',

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,17 +380,19 @@ export { buildCloudMapIndex, type CloudMapIndex } from './local/cloud-map-resolv
 export { EcsTaskResolutionError } from './local/ecs-task-resolver.js';
 
 /**
- * `invoke-agentcore` Bedrock AgentCore Runtime resolution + HTTP-contract
- * client. `resolveAgentCoreTarget` maps a target argument to a runnable
- * container runtime; `waitForAgentCorePing` / `invokeAgentCore` speak the
- * `GET /ping` + `POST /invocations` contract. Exposed only as the
- * consuming host's `import` statements require them.
+ * `invoke-agentcore` Bedrock AgentCore Runtime resolution + protocol clients.
+ * `resolveAgentCoreTarget` maps a target argument to a runnable container
+ * runtime; `waitForAgentCorePing` / `invokeAgentCore` speak the HTTP
+ * `GET /ping` + `POST /invocations` contract; `mcpInvokeOnce` speaks the MCP
+ * Streamable-HTTP `POST /mcp` contract. Exposed only as the consuming host's
+ * `import` statements require them.
  */
 export {
   resolveAgentCoreTarget,
   AgentCoreResolutionError,
   AGENTCORE_RUNTIME_TYPE,
   AGENTCORE_HTTP_PROTOCOL,
+  AGENTCORE_MCP_PROTOCOL,
   type ResolvedAgentCoreRuntime,
   type AgentCoreJwtAuthorizer,
 } from './local/agentcore-resolver.js';
@@ -401,6 +403,16 @@ export {
   type AgentCoreInvokeResult,
   type InvokeAgentCoreOptions,
 } from './local/agentcore-client.js';
+export {
+  mcpInvokeOnce,
+  parseSseForJsonRpc,
+  MCP_CONTAINER_PORT,
+  MCP_PATH,
+  MCP_PROTOCOL_VERSION,
+  type McpInvokeResult,
+  type McpInvokeOptions,
+  type McpJsonRpcRequest,
+} from './local/agentcore-mcp-client.js';
 
 /**
  * `start-api` REST API v1 `IntegrationResponses[]` selection — picks the

--- a/src/local/agentcore-mcp-client.ts
+++ b/src/local/agentcore-mcp-client.ts
@@ -1,0 +1,273 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+/**
+ * Client for the Bedrock AgentCore Runtime MCP protocol contract.
+ *
+ * An MCP-protocol AgentCore Runtime container listens on `0.0.0.0:8000` and
+ * serves the Model Context Protocol over **Streamable HTTP** at `POST /mcp`
+ * (no `GET /ping` — unlike the HTTP protocol). Each JSON-RPC message is its
+ * own POST. `cdkl invoke-agentcore` performs the minimal session lifecycle:
+ *
+ *   1. `initialize`            — negotiate; the server MAY return an
+ *                                `Mcp-Session-Id` header to echo thereafter.
+ *   2. `notifications/initialized` — required before any request (202, no body).
+ *   3. one request             — `tools/list` by default, or the method/params
+ *                                from `--event` (e.g. `tools/call`).
+ *
+ * Talking to the local container is **vanilla MCP**: the
+ * `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header and the inbound OAuth
+ * bearer are AgentCore managed-plane concerns the front door maps to MCP's own
+ * `Mcp-Session-Id`, so a direct local client does not send them.
+ */
+
+/** Container port an MCP-protocol AgentCore Runtime listens on. */
+export const MCP_CONTAINER_PORT = 8000;
+/** HTTP path of the MCP Streamable-HTTP endpoint. */
+export const MCP_PATH = '/mcp';
+/** MCP protocol version this client negotiates. */
+export const MCP_PROTOCOL_VERSION = '2025-06-18';
+
+const SESSION_ID_HEADER = 'mcp-session-id';
+const PROTOCOL_VERSION_HEADER = 'MCP-Protocol-Version';
+
+/** A JSON-RPC request to send after the handshake (id + jsonrpc are added). */
+export interface McpJsonRpcRequest {
+  method: string;
+  params?: unknown;
+}
+
+export interface McpInvokeResult {
+  /** True when the JSON-RPC response carried no top-level `error`. */
+  ok: boolean;
+  /** The JSON-RPC response message, pretty-printed for display. */
+  raw: string;
+}
+
+export interface McpInvokeOptions {
+  /**
+   * Total ms to keep retrying the initial `initialize` POST while the
+   * container boots (MCP has no `/ping`, so a successful initialize IS the
+   * readiness signal). Default 30s.
+   */
+  readyTimeoutMs?: number;
+  /** Per-request abort timeout once the server is reachable. Default 120s. */
+  requestTimeoutMs?: number;
+  /** Injected `fetch` for tests. Defaults to the global. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Run the MCP session lifecycle against a local container and return the
+ * single request's JSON-RPC response. The initial `initialize` POST is
+ * retried for `readyTimeoutMs` to absorb container boot (there is no separate
+ * readiness endpoint), so this also serves as the wait-for-ready step.
+ */
+export async function mcpInvokeOnce(
+  host: string,
+  port: number,
+  request: McpJsonRpcRequest,
+  options: McpInvokeOptions = {}
+): Promise<McpInvokeResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `http://${host}:${port}${MCP_PATH}`;
+  const requestTimeoutMs = options.requestTimeoutMs ?? 120_000;
+
+  const sessionId = await initializeWithRetry(fetchImpl, url, options.readyTimeoutMs ?? 30_000);
+
+  await postMcp(
+    fetchImpl,
+    url,
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    sessionId,
+    requestTimeoutMs
+  );
+
+  const result = await postMcp(
+    fetchImpl,
+    url,
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: request.method,
+      ...(request.params !== undefined && { params: request.params }),
+    },
+    sessionId,
+    requestTimeoutMs
+  );
+
+  const message = result.message;
+  const ok = !(message !== null && typeof message === 'object' && 'error' in message);
+  return { ok, raw: JSON.stringify(message ?? null, null, 2) };
+}
+
+/**
+ * POST `initialize`, retrying transient connect failures until the container
+ * is up or `readyTimeoutMs` elapses. Returns the `Mcp-Session-Id` the server
+ * assigned (undefined for a stateless server that omits it).
+ */
+async function initializeWithRetry(
+  fetchImpl: typeof fetch,
+  url: string,
+  readyTimeoutMs: number
+): Promise<string | undefined> {
+  const deadline = Date.now() + readyTimeoutMs;
+  const body = {
+    jsonrpc: '2.0',
+    id: 0,
+    method: 'initialize',
+    params: {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'cdkl', version: '1' },
+    },
+  };
+  let lastDetail = '';
+
+  while (Date.now() < deadline) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    try {
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      // Any HTTP response (even an error status) means the server is up; we
+      // only retry while the socket itself is refused/reset during boot.
+      await response.text().catch(() => undefined);
+      if (response.status >= 200 && response.status < 300) {
+        return response.headers.get(SESSION_ID_HEADER) ?? undefined;
+      }
+      lastDetail = `initialize returned HTTP ${response.status}`;
+      throw new Error(lastDetail);
+    } catch (err) {
+      if (!isTransientNetworkError(err)) {
+        // A non-transient error after the server is reachable is fatal.
+        if (lastDetail) {
+          throw new Error(
+            `MCP initialize at ${url} failed: ${lastDetail}. Check 'docker logs' output.`
+          );
+        }
+        throw err;
+      }
+      lastDetail = err instanceof Error ? err.message : String(err);
+    } finally {
+      clearTimeout(timer);
+    }
+    await delay(150);
+  }
+
+  throw new Error(
+    `MCP server did not become ready on ${url} within ${readyTimeoutMs}ms` +
+      `${lastDetail ? `: ${lastDetail}` : ''}. ` +
+      `The container may have exited early or may not serve POST ${MCP_PATH} — check 'docker logs'.`
+  );
+}
+
+/**
+ * POST one JSON-RPC message and, for a request (one with an `id`), return the
+ * parsed JSON-RPC response — handling both an `application/json` body and a
+ * `text/event-stream` (the server picks either per the Streamable-HTTP spec).
+ * A notification (no `id`) returns 202 with no body and yields no message.
+ */
+async function postMcp(
+  fetchImpl: typeof fetch,
+  url: string,
+  body: { jsonrpc: string; id?: number; method: string; params?: unknown },
+  sessionId: string | undefined,
+  timeoutMs: number
+): Promise<{ status: number; message?: unknown }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        [PROTOCOL_VERSION_HEADER]: MCP_PROTOCOL_VERSION,
+        ...(sessionId && { 'Mcp-Session-Id': sessionId }),
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const text = await response.text();
+    // Notification: no response payload to parse (server returns 202).
+    if (body.id === undefined) return { status: response.status };
+
+    const contentType = response.headers.get('content-type') ?? '';
+    const message = contentType.includes('text/event-stream')
+      ? parseSseForJsonRpc(text, body.id)
+      : text
+        ? safeJsonParse(text)
+        : undefined;
+    return { status: response.status, message };
+  } catch (err) {
+    if ((err as { name?: string }).name === 'AbortError') {
+      throw new Error(
+        `MCP request '${body.method}' at ${url} timed out after ${timeoutMs}ms. ` +
+          `The server may be hung; check container logs.`
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Extract the JSON-RPC message matching `id` from an SSE body. Frames are
+ * separated by blank lines; a frame's `data:` lines are concatenated and
+ * parsed as JSON. Returns the id-matching message, else the last parseable
+ * one (servers typically send a single frame carrying the response).
+ */
+export function parseSseForJsonRpc(text: string, id: number): unknown {
+  let last: unknown;
+  for (const frame of text.split(/\r?\n\r?\n/)) {
+    const data = frame
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice('data:'.length).trimStart())
+      .join('\n');
+    if (!data) continue;
+    const parsed = safeJsonParse(data);
+    if (parsed === undefined) continue;
+    last = parsed;
+    if (parsed !== null && typeof parsed === 'object' && (parsed as { id?: unknown }).id === id) {
+      return parsed;
+    }
+  }
+  return last;
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `fetch()` failures during container boot manifest as a generic
+ * `TypeError: fetch failed` whose `.cause` carries the underlying
+ * `ECONNRESET` / `ECONNREFUSED` / `UND_ERR_SOCKET`; an `AbortError` is the
+ * per-attempt timeout. Treat all of those — plus the synthetic non-2xx retry
+ * — as "not ready, retry".
+ */
+function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'AbortError') return true;
+  if (err.name === 'TypeError' && err.message === 'fetch failed') return true;
+  if (err.message.startsWith('initialize returned HTTP')) return true;
+  const cause = (err as { cause?: { code?: string } }).cause;
+  if (cause?.code === 'ECONNRESET') return true;
+  if (cause?.code === 'ECONNREFUSED') return true;
+  if (cause?.code === 'UND_ERR_SOCKET') return true;
+  return false;
+}

--- a/src/local/agentcore-mcp-client.ts
+++ b/src/local/agentcore-mcp-client.ts
@@ -136,12 +136,15 @@ async function initializeWithRetry(
         body: JSON.stringify(body),
         signal: controller.signal,
       });
-      // Any HTTP response (even an error status) means the server is up; we
-      // only retry while the socket itself is refused/reset during boot.
       await response.text().catch(() => undefined);
       if (response.status >= 200 && response.status < 300) {
         return response.headers.get(SESSION_ID_HEADER) ?? undefined;
       }
+      // A reachable-but-non-2xx initialize is treated as "up but not ready to
+      // handle the protocol yet" (e.g. a framework still wiring its /mcp
+      // route) and retried like a connect error — mirroring how the HTTP
+      // path's GET /ping retries a non-2xx while the server warms up. The last
+      // status is surfaced in the readiness error if the window expires.
       lastDetail = `initialize returned HTTP ${response.status}`;
       throw new Error(lastDetail);
     } catch (err) {

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -19,20 +19,27 @@ import { getLogger } from '../utils/logger.js';
 export const AGENTCORE_RUNTIME_TYPE = 'AWS::BedrockAgentCore::Runtime';
 
 /**
- * The only protocol `cdkl invoke-agentcore` serves in v1. AgentCore Runtimes
- * may also declare `MCP` / `A2A` / `AGUI`, which speak different wire
- * contracts and are out of scope here.
+ * AgentCore Runtime protocols `cdkl invoke-agentcore` can serve.
+ *
+ * - `HTTP` — the agent contract (`POST /invocations` + `GET /ping` on 8080).
+ * - `MCP` — Model Context Protocol over Streamable HTTP (`POST /mcp` on 8000).
+ *
+ * `A2A` / `AGUI` declare yet other wire contracts and are not served yet.
  */
 export const AGENTCORE_HTTP_PROTOCOL = 'HTTP';
+export const AGENTCORE_MCP_PROTOCOL = 'MCP';
+
+/** Protocols this CLI can run a container for. */
+const SUPPORTED_AGENTCORE_PROTOCOLS = [AGENTCORE_HTTP_PROTOCOL, AGENTCORE_MCP_PROTOCOL] as const;
 
 /**
  * Result of resolving a `cdkl invoke-agentcore <target>` argument back to a
  * concrete `AWS::BedrockAgentCore::Runtime` in the synthesized assembly.
  *
- * v1 covers the CONTAINER artifact + HTTP protocol only — the resolver
+ * Covers the CONTAINER artifact on the HTTP + MCP protocols — the resolver
  * hard-errors on `CodeConfiguration` artifacts (S3 zip + managed runtime)
- * and non-HTTP protocols so the command never starts a container it can't
- * speak to.
+ * and the A2A / AGUI protocols so the command never starts a container it
+ * can't speak to.
  */
 export interface ResolvedAgentCoreRuntime {
   /** Stack the runtime belongs to. */
@@ -65,7 +72,7 @@ export interface ResolvedAgentCoreRuntime {
    * an intrinsic role falls back to an explicit `--assume-role <arn>`.
    */
   roleArn?: string;
-  /** Always `HTTP` in v1 (validated at resolution time). */
+  /** `HTTP` or `MCP` (validated at resolution time). */
   protocol: string;
   /**
    * `Properties.AuthorizerConfiguration.CustomJWTAuthorizer` when present
@@ -299,23 +306,23 @@ function extractJwtAuthorizer(
 }
 
 /**
- * Validate `ProtocolConfiguration`. v1 serves only `HTTP`; absent is
- * treated as `HTTP` (the runtime contract's default request/response
- * shape). Any explicit non-HTTP value hard-errors.
+ * Validate `ProtocolConfiguration`. Serves `HTTP` (the default when absent)
+ * and `MCP`; `A2A` / `AGUI` speak other wire contracts and hard-error with a
+ * pointer to the follow-up.
  */
 function extractProtocol(value: unknown, logicalId: string, stackName: string): string {
   if (value === undefined || value === null) return AGENTCORE_HTTP_PROTOCOL;
   if (typeof value !== 'string') {
     throw new AgentCoreResolutionError(
       `AgentCore Runtime '${logicalId}' in ${stackName} has a non-string ProtocolConfiguration. ` +
-        `${getEmbedConfig().cliName} invoke-agentcore supports the ${AGENTCORE_HTTP_PROTOCOL} protocol only in v1.`
+        `${getEmbedConfig().cliName} invoke-agentcore supports the ${SUPPORTED_AGENTCORE_PROTOCOLS.join(' / ')} protocols.`
     );
   }
-  if (value !== AGENTCORE_HTTP_PROTOCOL) {
+  if (!(SUPPORTED_AGENTCORE_PROTOCOLS as readonly string[]).includes(value)) {
     throw new AgentCoreResolutionError(
       `AgentCore Runtime '${logicalId}' in ${stackName} uses the ${value} protocol. ` +
-        `${getEmbedConfig().cliName} invoke-agentcore supports the ${AGENTCORE_HTTP_PROTOCOL} protocol only in v1 ` +
-        `(MCP / A2A / AGUI speak different wire contracts).`
+        `${getEmbedConfig().cliName} invoke-agentcore supports the ${SUPPORTED_AGENTCORE_PROTOCOLS.join(' / ')} protocols ` +
+        `(A2A / AGUI speak different wire contracts and are not served yet).`
     );
   }
   return value;

--- a/src/local/docker-runner.ts
+++ b/src/local/docker-runner.ts
@@ -71,8 +71,15 @@ export interface DockerRunOptions {
    * image's own CMD is sufficient.
    */
   cmd: string[];
-  /** Host port to bind the RIE port (8080) to. */
+  /** Host port to bind the container port ({@link containerPort}) to. */
   hostPort: number;
+  /**
+   * Container port to publish {@link hostPort} to. Defaults to `8080` (the
+   * Lambda RIE port + the AgentCore HTTP contract port). `cdkl
+   * invoke-agentcore` overrides it to `8000` for an MCP-protocol runtime,
+   * whose container serves `POST /mcp` on `0.0.0.0:8000`.
+   */
+  containerPort?: number;
   /** Host to bind to (default `127.0.0.1`). */
   host?: string;
   /**
@@ -228,7 +235,7 @@ export async function runDetached(opts: DockerRunOptions): Promise<string> {
   }
 
   const host = opts.host ?? '127.0.0.1';
-  args.push('-p', `${host}:${opts.hostPort}:8080`);
+  args.push('-p', `${host}:${opts.hostPort}:${opts.containerPort ?? 8080}`);
   if (opts.debugPort !== undefined) {
     args.push('-p', `${host}:${opts.debugPort}:${opts.debugPort}`);
   }

--- a/tests/integration/local-invoke-agentcore/.gitignore
+++ b/tests/integration/local-invoke-agentcore/.gitignore
@@ -2,8 +2,11 @@
 # is a build artifact, not a committed source (matches local-run-task).
 pnpm-lock.yaml
 
-# Override the parent integ .gitignore so the agent container's source
-# files are tracked. The Dockerfile builds against /app/server.js inside
-# a plain node base image that serves the AgentCore HTTP contract on 8080.
+# Override the parent integ .gitignore so the agent containers' source
+# files are tracked. Each Dockerfile builds against its /app/server.js inside
+# a plain node base image: agent/ serves the AgentCore HTTP contract on 8080,
+# mcp-agent/ serves the MCP Streamable-HTTP contract on 8000.
 !agent/*.js
 !agent/Dockerfile
+!mcp-agent/*.js
+!mcp-agent/Dockerfile

--- a/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
+++ b/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
@@ -7,6 +7,7 @@ import {
   Runtime,
   AgentRuntimeArtifact,
   RuntimeAuthorizerConfiguration,
+  ProtocolType,
 } from 'aws-cdk-lib/aws-bedrockagentcore';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -55,6 +56,17 @@ export class LocalInvokeAgentCoreStack extends cdk.Stack {
         ['client-9'],
         ['aud-1']
       ),
+    });
+
+    // An MCP-protocol runtime (ProtocolConfiguration = MCP). Its container
+    // serves the MCP Streamable-HTTP contract on 8000 at POST /mcp (no /ping).
+    // `cdkl invoke-agentcore` runs the session handshake then one JSON-RPC
+    // request — tools/list by default, or the method/params from --event.
+    new Runtime(this, 'McpAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromAsset(path.join(__dirname, '../mcp-agent'), {
+        platform: Platform.LINUX_ARM64,
+      }),
+      protocolConfiguration: ProtocolType.MCP,
     });
   }
 }

--- a/tests/integration/local-invoke-agentcore/mcp-agent/Dockerfile
+++ b/tests/integration/local-invoke-agentcore/mcp-agent/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/docker/library/node:20-slim
+
+WORKDIR /app
+COPY server.js /app/server.js
+
+EXPOSE 8000
+CMD ["node", "/app/server.js"]

--- a/tests/integration/local-invoke-agentcore/mcp-agent/server.js
+++ b/tests/integration/local-invoke-agentcore/mcp-agent/server.js
@@ -1,0 +1,104 @@
+// Minimal Bedrock AgentCore Runtime MCP-protocol agent for the cdkl
+// invoke-agentcore integ test. Serves the MCP Streamable-HTTP contract on
+// 0.0.0.0:8000 at POST /mcp:
+//   initialize                 -> 200 InitializeResult (+ Mcp-Session-Id header)
+//   notifications/initialized  -> 202, no body
+//   tools/list                 -> 200 a one-tool list
+//   tools/call(add_numbers)    -> 200 the sum as text content
+// There is no GET /ping (MCP has no health endpoint — readiness is a
+// successful initialize). Startup logs go to stderr so the host's stdout
+// carries only the cdkl result.
+const http = require('node:http');
+
+function send(res, status, headers, body) {
+  res.writeHead(status, headers);
+  res.end(body);
+}
+
+function sendJsonRpc(res, id, payload) {
+  send(
+    res,
+    200,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({ jsonrpc: '2.0', id, ...payload })
+  );
+}
+
+// A Streamable-HTTP server MAY answer a request with an SSE stream instead of
+// a single JSON object; the response is one `message` event carrying the
+// JSON-RPC reply. tools/list uses this path so the integ exercises the
+// client's text/event-stream branch end-to-end (tools/call stays JSON).
+function sendSseJsonRpc(res, id, payload) {
+  res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' });
+  res.end(`event: message\ndata: ${JSON.stringify({ jsonrpc: '2.0', id, ...payload })}\n\n`);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method !== 'POST' || req.url !== '/mcp') {
+    send(res, 404, { 'Content-Type': 'application/json' }, JSON.stringify({ error: 'not found' }));
+    return;
+  }
+  let body = '';
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    let msg;
+    try {
+      msg = JSON.parse(body || '{}');
+    } catch {
+      msg = {};
+    }
+    const { id, method, params } = msg;
+
+    if (method === 'initialize') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Mcp-Session-Id': 'fixture-session-1' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'fixture-mcp', version: '1.0.0' },
+          },
+        })
+      );
+      return;
+    }
+    if (method === 'notifications/initialized') {
+      send(res, 202, {}, '');
+      return;
+    }
+    if (method === 'tools/list') {
+      sendSseJsonRpc(res, id, {
+        result: {
+          tools: [
+            {
+              name: 'add_numbers',
+              description: 'Add two numbers',
+              inputSchema: {
+                type: 'object',
+                properties: { a: { type: 'number' }, b: { type: 'number' } },
+              },
+            },
+          ],
+        },
+      });
+      return;
+    }
+    if (method === 'tools/call') {
+      const args = (params && params.arguments) || {};
+      const sum = (Number(args.a) || 0) + (Number(args.b) || 0);
+      sendJsonRpc(res, id, {
+        result: { content: [{ type: 'text', text: String(sum) }], isError: false },
+      });
+      return;
+    }
+    sendJsonRpc(res, id, { error: { code: -32601, message: 'Method not found' } });
+  });
+});
+
+server.listen(8000, '0.0.0.0', () => {
+  console.error('mcp fixture listening on 0.0.0.0:8000');
+});

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -12,7 +12,9 @@
 # header, and the injected GREETING env var, so we can assert the full
 # request/response contract + env injection + session-id binding. When the
 # event carries {"stream": true} it responds with a text/event-stream body, so
-# we can assert the SSE response is streamed to stdout incrementally.
+# we can assert the SSE response is streamed to stdout incrementally. A second
+# MCP-protocol runtime (McpAgent, POST /mcp on 8000) exercises the MCP session
+# handshake + tools/list / tools/call.
 #
 # Run via `/run-integ local-invoke-agentcore` (recommended) or directly:
 #
@@ -27,6 +29,7 @@ cd "$(dirname "$0")"
 CDKL="node ../../../dist/cli.js"
 TARGET="CdkLocalInvokeAgentCoreFixture/EchoAgent"
 PROTECTED="CdkLocalInvokeAgentCoreFixture/ProtectedAgent"
+MCP="CdkLocalInvokeAgentCoreFixture/McpAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
 
 echo "==> Verifying Docker is available"
@@ -41,7 +44,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/8] Invoking EchoAgent with default empty event"
+echo "==> [1/10] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -55,7 +58,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/8] Invoking EchoAgent with --event payload"
+echo "==> [2/10] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -67,7 +70,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/8] Invoking EchoAgent with --env-vars override"
+echo "==> [3/10] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -79,7 +82,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/8] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/10] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -90,7 +93,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/8] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/10] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -111,7 +114,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/8] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/10] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -121,7 +124,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/8] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/10] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -134,7 +137,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/8] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/10] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -151,5 +154,28 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
   exit 1
 }
 
+# Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
+# the default tools/list request returns the server's tools. The container
+# serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
+echo "==> [9/10] McpAgent (no --event) runs the handshake + tools/list"
+RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
+echo "    response: ${RESULT_9}"
+echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
+  echo "FAIL: expected tools/list to return the add_numbers tool, got: ${RESULT_9}"
+  exit 1
+}
+
+# Test 10 — an MCP tools/call via --event returns the tool result.
+echo "==> [10/10] McpAgent with --event runs tools/call"
+CALL_EVENT=$(mktemp)
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
+echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
+RESULT_10=$(${CDKL} invoke-agentcore "${MCP}" --event "${CALL_EVENT}" 2>/dev/null)
+echo "    response: ${RESULT_10}"
+echo "${RESULT_10}" | grep -q '"text": "5"' || {
+  echo "FAIL: expected tools/call add_numbers(2,3) to return text \"5\", got: ${RESULT_10}"
+  exit 1
+}
+
 echo ""
-echo "==> All 8 local-invoke-agentcore tests passed"
+echo "==> All 10 local-invoke-agentcore tests passed"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -64,6 +64,8 @@ vi.mock('../../../src/local/docker-runner.js', async (importActual) => ({
 const {
   resolveAgentCoreImage,
   emitResult,
+  emitMcpResult,
+  buildMcpRequest,
   buildContainerEnv,
   readEvent,
   readEnvOverridesFile,
@@ -182,6 +184,57 @@ describe('emitResult — exit codes', () => {
     expect(writeSpy).toHaveBeenCalledTimes(1);
     expect(writeSpy).toHaveBeenCalledWith('\n');
     expect(process.exitCode).toBeUndefined();
+  });
+});
+
+describe('buildMcpRequest', () => {
+  it('defaults to tools/list when no --event was given (empty object)', () => {
+    expect(buildMcpRequest({})).toEqual({ method: 'tools/list', params: {} });
+  });
+
+  it('passes a method + params through verbatim', () => {
+    expect(
+      buildMcpRequest({ method: 'tools/call', params: { name: 'add', arguments: { a: 1 } } })
+    ).toEqual({ method: 'tools/call', params: { name: 'add', arguments: { a: 1 } } });
+  });
+
+  it('omits params when the event has only a method', () => {
+    expect(buildMcpRequest({ method: 'tools/list' })).toEqual({ method: 'tools/list' });
+  });
+
+  it('rejects a non-object event', () => {
+    expect(() => buildMcpRequest([1, 2])).toThrow(/JSON object/);
+  });
+
+  it('rejects an object that has keys but no string method', () => {
+    expect(() => buildMcpRequest({ params: {} })).toThrow(/string "method"/);
+  });
+});
+
+describe('emitMcpResult — exit codes', () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+  const savedExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    process.exitCode = savedExitCode;
+  });
+
+  it('prints the JSON-RPC response and leaves exit code unset when ok', () => {
+    emitMcpResult({ ok: true, raw: '{"result":{"tools":[]}}' });
+    expect(writeSpy).toHaveBeenCalledWith('{"result":{"tools":[]}}\n');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('sets exit code 1 (but still prints) on a JSON-RPC error', () => {
+    emitMcpResult({ ok: false, raw: '{"error":{"message":"nope"}}' });
+    expect(writeSpy).toHaveBeenCalledWith('{"error":{"message":"nope"}}\n');
+    expect(process.exitCode).toBe(1);
   });
 });
 

--- a/tests/unit/local/agentcore-mcp-client.test.ts
+++ b/tests/unit/local/agentcore-mcp-client.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import {
+  mcpInvokeOnce,
+  parseSseForJsonRpc,
+  MCP_PATH,
+} from '../../../src/local/agentcore-mcp-client.js';
+
+interface Captured {
+  url: string;
+  body: { jsonrpc: string; id?: number; method: string; params?: unknown };
+  headers: Record<string, string>;
+}
+
+/**
+ * A minimal in-memory MCP Streamable-HTTP server. Replies to `initialize`
+ * (optionally assigning a session id), `notifications/initialized` (202), and
+ * the request method (JSON or SSE), capturing every call for assertions.
+ */
+function makeServer(opts: {
+  sessionId?: string;
+  sse?: boolean;
+  requestResponse?: unknown;
+  failInitializeTimes?: number;
+}): { fetchImpl: typeof fetch; calls: Captured[] } {
+  const calls: Captured[] = [];
+  let initFailsLeft = opts.failInitializeTimes ?? 0;
+
+  const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body));
+    calls.push({ url: String(url), body, headers: (init?.headers ?? {}) as Record<string, string> });
+
+    if (body.method === 'initialize') {
+      if (initFailsLeft > 0) {
+        initFailsLeft -= 1;
+        const err = new TypeError('fetch failed');
+        (err as { cause?: unknown }).cause = { code: 'ECONNREFUSED' };
+        throw err;
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: '2.0', id: 0, result: { protocolVersion: '2025-06-18' } }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            ...(opts.sessionId ? { 'mcp-session-id': opts.sessionId } : {}),
+          },
+        }
+      );
+    }
+    if (body.method === 'notifications/initialized') {
+      return new Response(null, { status: 202 });
+    }
+    const payload = opts.requestResponse ?? {
+      jsonrpc: '2.0',
+      id: body.id,
+      result: { tools: [{ name: 'add_numbers' }] },
+    };
+    if (opts.sse) {
+      return new Response(`event: message\ndata: ${JSON.stringify(payload)}\n\n`, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    }
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+
+  return { fetchImpl, calls };
+}
+
+describe('mcpInvokeOnce', () => {
+  it('runs initialize -> notifications/initialized -> request and returns the JSON response', async () => {
+    const { fetchImpl, calls } = makeServer({ sessionId: 'sess-123' });
+
+    const result = await mcpInvokeOnce(
+      '127.0.0.1',
+      8000,
+      { method: 'tools/list', params: {} },
+      { fetchImpl }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.raw).toContain('add_numbers');
+
+    // Three POSTs, all to /mcp, in lifecycle order.
+    expect(calls.map((c) => c.body.method)).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/list',
+    ]);
+    expect(calls.every((c) => c.url.endsWith(MCP_PATH))).toBe(true);
+
+    // initialize MUST NOT carry a session id (none exists yet).
+    expect(calls[0]?.headers['Mcp-Session-Id']).toBeUndefined();
+    // Post-initialize calls echo the assigned session id + the protocol version.
+    expect(calls[1]?.headers['Mcp-Session-Id']).toBe('sess-123');
+    expect(calls[2]?.headers['Mcp-Session-Id']).toBe('sess-123');
+    expect(calls[2]?.headers['MCP-Protocol-Version']).toBe('2025-06-18');
+
+    // The request body is a well-formed JSON-RPC request with an id.
+    expect(calls[2]?.body).toMatchObject({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+  });
+
+  it('parses a text/event-stream response (server may pick SSE)', async () => {
+    const { fetchImpl } = makeServer({ sessionId: 'sess-1', sse: true });
+    const result = await mcpInvokeOnce('127.0.0.1', 8000, { method: 'tools/list' }, { fetchImpl });
+    expect(result.ok).toBe(true);
+    expect(result.raw).toContain('add_numbers');
+  });
+
+  it('works against a stateless server that omits Mcp-Session-Id', async () => {
+    const { fetchImpl, calls } = makeServer({}); // no sessionId
+    const result = await mcpInvokeOnce('127.0.0.1', 8000, { method: 'tools/list' }, { fetchImpl });
+    expect(result.ok).toBe(true);
+    // No session id was assigned, so none is echoed.
+    expect(calls[2]?.headers['Mcp-Session-Id']).toBeUndefined();
+  });
+
+  it('forwards a tools/call method + params verbatim', async () => {
+    const { fetchImpl, calls } = makeServer({ sessionId: 's' });
+    await mcpInvokeOnce(
+      '127.0.0.1',
+      8000,
+      { method: 'tools/call', params: { name: 'add_numbers', arguments: { a: 1, b: 2 } } },
+      { fetchImpl }
+    );
+    expect(calls[2]?.body).toMatchObject({
+      method: 'tools/call',
+      params: { name: 'add_numbers', arguments: { a: 1, b: 2 } },
+    });
+  });
+
+  it('reports a JSON-RPC error response as not ok', async () => {
+    const { fetchImpl } = makeServer({
+      sessionId: 's',
+      requestResponse: { jsonrpc: '2.0', id: 1, error: { code: -32601, message: 'Method not found' } },
+    });
+    const result = await mcpInvokeOnce('127.0.0.1', 8000, { method: 'bogus' }, { fetchImpl });
+    expect(result.ok).toBe(false);
+    expect(result.raw).toContain('Method not found');
+  });
+
+  it('retries a transient connect failure on initialize while the container boots', async () => {
+    const { fetchImpl, calls } = makeServer({ sessionId: 's', failInitializeTimes: 1 });
+    const result = await mcpInvokeOnce('127.0.0.1', 8000, { method: 'tools/list' }, { fetchImpl });
+    expect(result.ok).toBe(true);
+    // Two initialize attempts (one refused, one ok) + initialized + request.
+    expect(calls.filter((c) => c.body.method === 'initialize').length).toBe(2);
+  });
+
+  it('throws a clear readiness error when initialize never succeeds in time', async () => {
+    const fetchImpl = vi.fn(async () => {
+      const err = new TypeError('fetch failed');
+      (err as { cause?: unknown }).cause = { code: 'ECONNREFUSED' };
+      throw err;
+    }) as unknown as typeof fetch;
+    await expect(
+      mcpInvokeOnce('127.0.0.1', 8000, { method: 'tools/list' }, { fetchImpl, readyTimeoutMs: 200 })
+    ).rejects.toThrow(/did not become ready/);
+  });
+});
+
+describe('parseSseForJsonRpc', () => {
+  it('returns the frame whose JSON-RPC id matches', () => {
+    const text =
+      'event: message\ndata: {"jsonrpc":"2.0","id":9,"result":{"v":1}}\n\n' +
+      'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"v":2}}\n\n';
+    expect(parseSseForJsonRpc(text, 1)).toMatchObject({ id: 1, result: { v: 2 } });
+  });
+
+  it('falls back to the last parseable frame when no id matches', () => {
+    const text = 'data: {"jsonrpc":"2.0","id":7,"result":{"v":3}}\n\n';
+    expect(parseSseForJsonRpc(text, 1)).toMatchObject({ id: 7 });
+  });
+
+  it('ignores non-JSON data lines', () => {
+    const text = 'data: : keep-alive\n\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n';
+    expect(parseSseForJsonRpc(text, 1)).toMatchObject({ id: 1 });
+  });
+});

--- a/tests/unit/local/agentcore-mcp-client.test.ts
+++ b/tests/unit/local/agentcore-mcp-client.test.ts
@@ -92,8 +92,10 @@ describe('mcpInvokeOnce', () => {
     ]);
     expect(calls.every((c) => c.url.endsWith(MCP_PATH))).toBe(true);
 
-    // initialize MUST NOT carry a session id (none exists yet).
+    // initialize MUST NOT carry a session id (none exists yet) NOR the
+    // negotiated protocol-version header (it is being negotiated here).
     expect(calls[0]?.headers['Mcp-Session-Id']).toBeUndefined();
+    expect(calls[0]?.headers['MCP-Protocol-Version']).toBeUndefined();
     // Post-initialize calls echo the assigned session id + the protocol version.
     expect(calls[1]?.headers['Mcp-Session-Id']).toBe('sess-123');
     expect(calls[2]?.headers['Mcp-Session-Id']).toBe('sess-123');
@@ -159,6 +161,41 @@ describe('mcpInvokeOnce', () => {
     await expect(
       mcpInvokeOnce('127.0.0.1', 8000, { method: 'tools/list' }, { fetchImpl, readyTimeoutMs: 200 })
     ).rejects.toThrow(/did not become ready/);
+  });
+
+  it('retries a reachable-but-non-2xx initialize, surfacing the status in the readiness error', async () => {
+    // A server that is up but answers initialize with a steady 500 (e.g. still
+    // wiring its /mcp route) is retried until the window expires; the last
+    // HTTP status is reported so the failure is diagnosable.
+    let attempts = 0;
+    const fetchImpl = vi.fn(async () => {
+      attempts += 1;
+      return new Response('boom', { status: 500 });
+    }) as unknown as typeof fetch;
+    await expect(
+      mcpInvokeOnce('127.0.0.1', 8000, { method: 'tools/list' }, { fetchImpl, readyTimeoutMs: 200 })
+    ).rejects.toThrow(/did not become ready[\s\S]*initialize returned HTTP 500/);
+    expect(attempts).toBeGreaterThan(1); // retried, not failed on first non-2xx
+  });
+
+  it('maps a per-request timeout (AbortError) to a clear timeout error', async () => {
+    // initialize + initialized succeed; the real request aborts (timeout).
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      if (body.method === 'initialize') {
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: 0, result: {} }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (body.method === 'notifications/initialized') return new Response(null, { status: 202 });
+      const err = new Error('The operation was aborted');
+      (err as { name?: string }).name = 'AbortError';
+      throw err;
+    }) as unknown as typeof fetch;
+    await expect(
+      mcpInvokeOnce('127.0.0.1', 8000, { method: 'tools/list' }, { fetchImpl, requestTimeoutMs: 50 })
+    ).rejects.toThrow(/timed out after 50ms/);
   });
 });
 

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -169,11 +169,28 @@ describe('resolveAgentCoreTarget — out-of-scope artifacts', () => {
     expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/container artifacts only/);
   });
 
-  it('rejects a non-HTTP protocol', () => {
+  it('rejects the A2A protocol with a not-served-yet error', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({ ProtocolConfiguration: 'A2A' }),
+    });
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/A2A protocol/);
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/not served yet/);
+  });
+
+  it('rejects the AGUI protocol', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({ ProtocolConfiguration: 'AGUI' }),
+    });
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/AGUI protocol/);
+  });
+});
+
+describe('resolveAgentCoreTarget — MCP protocol', () => {
+  it('resolves an MCP-protocol runtime', () => {
     const stack = buildStack('App', {
       ChatAgent: containerRuntime({ ProtocolConfiguration: 'MCP' }),
     });
-    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/MCP protocol/);
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).protocol).toBe('MCP');
   });
 });
 

--- a/tests/unit/local/docker-runner-container-port.test.ts
+++ b/tests/unit/local/docker-runner-container-port.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Capture the execFile invocation to assert the published `-p host:hostPort:containerPort`.
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+
+vi.mock('node:child_process', () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    options: unknown,
+    cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
+  ) => {
+    execFileMock(cmd, args, options);
+    cb(null, { stdout: 'cid\n', stderr: '' });
+  },
+  spawn: vi.fn(),
+}));
+
+const { runDetached } = await import('../../../src/local/docker-runner.js');
+
+function publishArg(): string {
+  const [, args] = execFileMock.mock.calls[0] as [string, string[], unknown];
+  const i = args.indexOf('-p');
+  return args[i + 1] as string;
+}
+
+describe('runDetached container-port publishing', () => {
+  beforeEach(() => execFileMock.mockReset());
+
+  it('defaults the container port to 8080 (Lambda RIE / AgentCore HTTP)', async () => {
+    await runDetached({
+      image: 'img',
+      mounts: [],
+      env: {},
+      cmd: [],
+      hostPort: 9100,
+      host: '127.0.0.1',
+    });
+    expect(publishArg()).toBe('127.0.0.1:9100:8080');
+  });
+
+  it('publishes to the given container port (8000 for an MCP runtime)', async () => {
+    await runDetached({
+      image: 'img',
+      mounts: [],
+      env: {},
+      cmd: [],
+      hostPort: 9200,
+      host: '127.0.0.1',
+      containerPort: 8000,
+    });
+    expect(publishArg()).toBe('127.0.0.1:9200:8000');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the MCP half of #128: `cdkl invoke-agentcore` now runs an
**MCP-protocol** AgentCore Runtime locally, the way it already runs HTTP-protocol
ones. When a runtime declares `ProtocolConfiguration = MCP`, its container serves
the Model Context Protocol over **Streamable HTTP** at `POST /mcp` on port 8000
(no `GET /ping`).

- **Resolver** accepts `MCP` (and still rejects `A2A` / `AGUI` with a
  not-served-yet pointer).
- **`docker-runner`** gains an optional `containerPort` (default 8080; MCP
  publishes 8000) — backward-compatible for every existing caller.
- **New `agentcore-mcp-client`** runs the session lifecycle: `initialize`
  (retried while the container boots — there is no `/ping`, so a successful
  initialize is the readiness signal) → `notifications/initialized` → one
  JSON-RPC request, parsing **both** an `application/json` and a
  `text/event-stream` reply. It echoes the server's `Mcp-Session-Id` and sends
  `MCP-Protocol-Version` on post-initialize requests.
- **Command** branches on protocol; `buildMcpRequest` builds the request from
  `--event` — **`tools/list` by default**, or the `{"method":...,"params":...}`
  the user supplies (e.g. `tools/call`) — and prints the JSON-RPC response
  (exit 1 on a JSON-RPC error).

Talking to the local container is vanilla MCP: the AgentCore session header and
inbound bearer are managed-plane concerns the cloud front door maps to MCP's own
`Mcp-Session-Id`, so they are not applied to a direct local `/mcp` call
(`--bearer-token` / `--session-id` are HTTP-protocol options, ignored for MCP).

## Test plan

- [x] `vp run verify` (typecheck + lint + format + build + unit) green — 1343
  unit tests pass.
- [x] Unit: the MCP client handshake (lifecycle order, session-id echo,
  protocol-version header, initialize omitting it), `application/json` vs
  `text/event-stream` response parsing, stateless server (no session id),
  `tools/call` params, JSON-RPC error, boot-retry (transient connect + a
  reachable-but-non-2xx that surfaces its status), per-request timeout;
  `parseSseForJsonRpc`; resolver MCP-accept + A2A/AGUI-reject; `runDetached`
  container-port mapping (8080 default, 8000 for MCP); `buildMcpRequest` /
  `emitMcpResult`.
- [x] Real-Docker integ `tests/integration/local-invoke-agentcore/`: a new
  MCP-protocol `McpAgent` — `tools/list` (default, served over **SSE** so the
  client's `text/event-stream` branch is exercised end-to-end) and `tools/call`
  via `--event` (served over JSON). 10/10 pass, 0 orphan containers/networks.

## Reviewer notes

3-axis review (spec / code / test). Spec: clean — every wire-contract clause
verified. Blockers/mediums fixed in the follow-up commit:

- **(blocker)** the MCP fixture's `server.js` was hidden by the parent integ
  `.gitignore` `*.js` rule (only `agent/` was negated) — the Dockerfile `COPY`
  would have failed in CI / a clean checkout. Now negated + tracked.
- the integ fixture now answers `tools/list` over `text/event-stream`, so the
  SSE response branch is integ-verified against a real container (not only
  unit-level hand-built SSE).
- a reachable-but-non-2xx `initialize` is intentionally retried (server up but
  not ready, mirroring the HTTP `/ping` warmup retry); comment clarified + test
  added asserting the last status reaches the readiness error.

Accepted as known minor cost (not blockers):

- the 250ms post-invoke settle is an inline literal in both the HTTP and MCP
  branches (pre-existing pattern, not a new const).
- a degenerate 200-with-empty-body request response maps to `ok: true` /
  `raw: "null"` — untested (abnormal for a JSON-RPC request).

Retrospective: the `.gitignore` un-commit trap above is recorded in local memory
so a future new agent-source subdir gets its `!<dir>/*.js` negation from the
start.

`A2A` + `AG-UI` protocols are deferred to (#140).

Closes #128
