### PR TITLE
feat(invoke-agentcore): run CodeConfiguration (managed-runtime) artifacts from source

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,9 +34,12 @@ AWS managed services.
   `path-pattern` rules across the backing services (other conditions —
   host-header / weighted / Lambda targets / redirect+fixed-response
   actions — deferred to #123)
-- Bedrock AgentCore Runtime agents — the agent container served over its
-  protocol contract, invoked once locally (`cdkl invoke-agentcore`); covers
-  container artifacts on the HTTP and MCP protocols. HTTP runs the
+- Bedrock AgentCore Runtime agents — the agent served over its protocol
+  contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
+  container artifact and the CodeConfiguration managed-runtime artifact
+  (`fromCodeAsset` — Python 3.10-3.14 / Node 22, built from source: a generated
+  Dockerfile installs the bundle's deps and runs the EntryPoint, which
+  self-serves the contract) on the HTTP and MCP protocols. HTTP runs the
   `POST /invocations` + `GET /ping` contract on 8080: an inbound
   `customJwtAuthorizer` is enforced locally (`--bearer-token` verified against
   the runtime's OIDC discovery URL before the container starts and forwarded to

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cdkl list                                      # every runnable target, grouped 
 
 - **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`. Add **`--watch`** to re-synth and hot-reload on CDK source changes ([details](docs/local-emulation.md#hot-reload---watch)).
 - **`run-task`** / single-replica **`start-service`** publish declared container ports on the host and log `Reach it at 127.0.0.1:<port>` (`--host-port <container>=<host>` remaps; handy for privileged ports on macOS).
-- **`invoke-agentcore`** runs the agent container, waits for `GET /ping`, POSTs your `--event` to `POST /invocations`, and streams an SSE response live. A `customJwtAuthorizer` is enforced locally — pass `--bearer-token <jwt>` (verified against the runtime's OIDC discovery URL). MCP-protocol runtimes (`ProtocolConfiguration = MCP`) are also served — the `POST /mcp` Streamable-HTTP contract on 8000, with one JSON-RPC request (`tools/list` by default, or `--event`'s `{"method":...,"params":...}`).
+- **`invoke-agentcore`** runs the agent (a container, or a `fromCodeAsset` managed-runtime bundle — Python 3.10-3.14 / Node 22 — built from source), waits for `GET /ping`, POSTs your `--event` to `POST /invocations`, and streams an SSE response live. A `customJwtAuthorizer` is enforced locally — pass `--bearer-token <jwt>` (verified against the runtime's OIDC discovery URL). MCP-protocol runtimes (`ProtocolConfiguration = MCP`) are also served — the `POST /mcp` Streamable-HTTP contract on 8000, with one JSON-RPC request (`tools/list` by default, or `--event`'s `{"method":...,"params":...}`).
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
 Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.md](docs/cli-reference.md) and [docs/local-emulation.md](docs/local-emulation.md).
@@ -105,7 +105,7 @@ Format + full precedence: [docs/cli-reference.md](docs/cli-reference.md).
 | `AWS::ECS::Service` (start-service) | ✓ |
 | `AWS::ServiceDiscovery::*` (Cloud Map / Service Connect) | ✓ |
 | `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door + `path-pattern` rules) | ✓ |
-| `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container artifact, HTTP + MCP) | ✓ |
+| `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container + fromCodeAsset artifacts, HTTP + MCP) | ✓ |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,7 +13,7 @@ cdk-local has six subcommands, all under the `cdkl` binary:
 | --- | --- | --- |
 | `cdkl list` (alias `cdkl ls`) | Lists the app's runnable targets (no execution) | Synthesis only — no Docker |
 | `cdkl invoke <target>` | One-shot Lambda invoke | AWS Lambda Runtime Interface Emulator (RIE) container |
-| `cdkl invoke-agentcore <target>` | One-shot Bedrock AgentCore Runtime invoke | Agent container on its protocol contract — HTTP (`POST /invocations` + `GET /ping` on 8080) or MCP (`POST /mcp` on 8000) |
+| `cdkl invoke-agentcore <target>` | One-shot Bedrock AgentCore Runtime invoke | Agent (container or fromCodeAsset managed-runtime) on its protocol contract — HTTP (`POST /invocations` + `GET /ping` on 8080) or MCP (`POST /mcp` on 8000) |
 | `cdkl start-api` | Long-running HTTP server — API Gateway (REST v1 / HTTP API / WebSocket) + Lambda Function URL | RIE container pool + `node:http` listener (one server per discovered API) |
 | `cdkl run-task <target>` | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
 | `cdkl start-service <targets...>` | Long-running ECS `Service` emulator (replicas only, no load balancer) | `run-task` machinery per replica + shared docker network + restart-on-exit watcher |
@@ -429,17 +429,36 @@ container down. The exact contract depends on `ProtocolConfiguration`:
 
 This is the same request/response loop AgentCore runs in the cloud,
 exercised locally before deploy. It supports the **container artifact**
-(`AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`) on the **HTTP**
-and **MCP** protocols; `CodeConfiguration` (S3 zip + managed runtime)
-artifacts and the `A2A` / `AGUI` protocols are rejected with an actionable
-error. The agent's own calls to AWS managed services (Bedrock models,
-memory, etc.) go to real AWS — credentials are injected exactly like
-`cdkl invoke` (see below).
+(`AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`) and the
+**CodeConfiguration** managed-runtime artifact (`fromCodeAsset`, built from
+source — see [CodeConfiguration](#codeconfiguration-managed-runtime) below)
+on the **HTTP** and **MCP** protocols; the `A2A` / `AGUI` protocols are
+rejected with an actionable error. The agent's own calls to AWS managed
+services (Bedrock models, memory, etc.) go to real AWS — credentials are
+injected exactly like `cdkl invoke` (see below).
 
 The container image is resolved like a container Lambda: a local cdk.out
 asset (the `fromAsset` / Dockerfile path) is built with `docker build`;
 otherwise an ECR URI is pulled (`--ecr-role-arn` for cross-account
 registries), and a plain registry URI is `docker pull`ed.
+
+### CodeConfiguration (managed runtime)
+
+A `CodeConfiguration` artifact ships source + an `EntryPoint` + a `Runtime`
+instead of a container — AWS runs it on a managed runtime whose entrypoint
+self-serves the same HTTP (or MCP) contract (typically via the
+`bedrock-agentcore` SDK). cdk-local replicates that with a **local from-source
+build**: it reads the `fromCodeAsset` bundle from `cdk.out`, generates a
+Dockerfile for the runtime's base image (`PYTHON_3_10`-`PYTHON_3_14` →
+`python:3.x-slim`, `NODE_22` → `node:22-slim`), installs the bundle's
+dependencies (`requirements.txt` / `pyproject.toml` for Python,
+`package.json` for Node — when present), runs the `EntryPoint`, then drives
+the started container with the same protocol client as a container artifact.
+
+Only `fromCodeAsset` (a CDK-managed local code asset) is supported; a
+`fromS3` bundle (a pre-existing S3 object that would need an AWS download) is
+rejected with an actionable error. `--no-build` reuses the previously-built
+image tag.
 
 ### Target resolution
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -31,8 +31,10 @@ import {
 import {
   AGENTCORE_MCP_PROTOCOL,
   resolveAgentCoreTarget,
+  type AgentCoreCodeArtifact,
   type ResolvedAgentCoreRuntime,
 } from '../../local/agentcore-resolver.js';
+import { buildAgentCoreCodeImage } from '../../local/agentcore-code-build.js';
 import {
   invokeAgentCore,
   waitForAgentCorePing,
@@ -135,9 +137,10 @@ export interface CreateLocalInvokeAgentCoreCommandOptions {
  * locally and invoke it once over the AgentCore HTTP contract. Resolves
  * the `AWS::BedrockAgentCore::Runtime`, pulls / builds its container,
  * starts it on port 8080, waits for `GET /ping`, POSTs the event to
- * `POST /invocations`, prints the response, and tears down. v1 covers the
- * container artifact + HTTP protocol; the agent's calls to real AWS go to
- * real AWS (credentials injected like `cdkl invoke`).
+ * `POST /invocations`, prints the response, and tears down. Covers the
+ * container artifact and the CodeConfiguration managed-runtime artifact
+ * (fromCodeAsset, built from source) on the HTTP + MCP protocols; the agent's
+ * calls to real AWS go to real AWS (credentials injected like `cdkl invoke`).
  */
 async function localInvokeAgentCoreCommand(
   target: string | undefined,
@@ -398,9 +401,10 @@ export async function resolveInboundAuthorization(
 }
 
 /**
- * Acquire the agent container image. Mirrors the container-Lambda path:
- * build from a local cdk.out asset when the URI matches one, else pull
- * from ECR, else pull a plain registry image.
+ * Acquire the agent image. A CODE artifact (managed runtime) is built from
+ * source (generated Dockerfile over the bundle's cdk.out asset). A CONTAINER
+ * artifact mirrors the container-Lambda path: build from a local cdk.out asset
+ * when the URI matches one, else pull from ECR, else pull a plain registry image.
  */
 export async function resolveAgentCoreImage(
   resolved: ResolvedAgentCoreRuntime,
@@ -409,13 +413,25 @@ export async function resolveAgentCoreImage(
   const logger = getLogger();
   const architecture = platformToArchitecture(options.platform);
 
+  if (resolved.codeArtifact) {
+    return resolveAgentCoreCodeImage(resolved, resolved.codeArtifact, options, architecture);
+  }
+
+  const containerUri = resolved.containerUri;
+  if (containerUri === undefined) {
+    throw new CdkLocalError(
+      `AgentCore Runtime '${resolved.logicalId}' has neither a container image nor a code artifact to run.`,
+      'LOCAL_INVOKE_AGENTCORE_NO_ARTIFACT'
+    );
+  }
+
   const manifestPath = resolved.stack.assetManifestPath;
   if (manifestPath) {
     const cdkOutDir = dirname(manifestPath);
     const loader = new AssetManifestLoader();
     const manifest = await loader.loadManifest(cdkOutDir, resolved.stack.stackName);
     if (manifest) {
-      const entry = getDockerImageBySourceHash(manifest, resolved.containerUri);
+      const entry = getDockerImageBySourceHash(manifest, containerUri);
       if (entry) {
         return buildContainerImage(entry.asset, cdkOutDir, {
           architecture,
@@ -425,9 +441,9 @@ export async function resolveAgentCoreImage(
     }
   }
 
-  if (parseEcrUri(resolved.containerUri)) {
-    logger.info(`Pulling agent image from ECR: ${resolved.containerUri}`);
-    return pullEcrImage(resolved.containerUri, {
+  if (parseEcrUri(containerUri)) {
+    logger.info(`Pulling agent image from ECR: ${containerUri}`);
+    return pullEcrImage(containerUri, {
       skipPull: options.pull === false,
       ...(options.region !== undefined && { region: options.region }),
       ...(options.ecrRoleArn !== undefined && { ecrRoleArn: options.ecrRoleArn }),
@@ -435,8 +451,50 @@ export async function resolveAgentCoreImage(
     });
   }
 
-  await pullImage(resolved.containerUri, options.pull === false);
-  return resolved.containerUri;
+  await pullImage(containerUri, options.pull === false);
+  return containerUri;
+}
+
+/**
+ * Build a local image from a `CodeConfiguration` (managed-runtime) bundle:
+ * locate the fromCodeAsset source dir in cdk.out via its asset hash, then run
+ * the from-source build (generated Dockerfile → install deps → run EntryPoint).
+ * A bundle with no local asset (fromS3) hard-errors — not supported yet.
+ */
+async function resolveAgentCoreCodeImage(
+  resolved: ResolvedAgentCoreRuntime,
+  code: AgentCoreCodeArtifact,
+  options: LocalInvokeAgentCoreOptions,
+  architecture: 'x86_64' | 'arm64'
+): Promise<string> {
+  const manifestPath = resolved.stack.assetManifestPath;
+  if (!manifestPath) {
+    throw new CdkLocalError(
+      `AgentCore Runtime '${resolved.logicalId}' uses a code artifact, but its stack has no asset ` +
+        `manifest in cdk.out to read the bundle source from.`,
+      'LOCAL_INVOKE_AGENTCORE_CODE_NO_MANIFEST'
+    );
+  }
+  const cdkOutDir = dirname(manifestPath);
+  const loader = new AssetManifestLoader();
+  const manifest = await loader.loadManifest(cdkOutDir, resolved.stack.stackName);
+  const asset = manifest ? loader.getFileAssets(manifest).get(code.codeAssetHash) : undefined;
+  if (!asset) {
+    throw new CdkLocalError(
+      `AgentCore Runtime '${resolved.logicalId}' code bundle (asset ${code.codeAssetHash}) was not found ` +
+        `in the cdk.out asset manifest. ${getEmbedConfig().cliName} invoke-agentcore runs a local from-source ` +
+        `build of a fromCodeAsset bundle; a fromS3 bundle (a pre-existing S3 object) is not supported yet.`,
+      'LOCAL_INVOKE_AGENTCORE_CODE_ASSET_NOT_FOUND'
+    );
+  }
+  const sourceDir = loader.getAssetSourcePath(cdkOutDir, asset);
+  return buildAgentCoreCodeImage({
+    sourceDir,
+    runtime: code.runtime,
+    entryPoint: code.entryPoint,
+    architecture,
+    noBuild: options.build === false,
+  });
 }
 
 /**
@@ -768,7 +826,8 @@ export function createLocalInvokeAgentCoreCommand(
         '--event). Target accepts a CDK display path (MyStack/MyAgent) or stack-qualified logical ID ' +
         '(MyStack:MyAgentRuntime1234). Single-stack apps may omit the stack prefix. ' +
         'Omit <target> in an interactive terminal to pick from a list. ' +
-        'Supports the container artifact on the HTTP + MCP protocols; the agent calls real AWS for managed services.'
+        'Supports the container artifact and the CodeConfiguration managed-runtime artifact ' +
+        '(fromCodeAsset, built from source) on the HTTP + MCP protocols; the agent calls real AWS for managed services.'
     )
     .argument(
       '[target]',

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { Command, Option } from 'commander';
 import {
@@ -68,6 +68,7 @@ import {
   AssetManifestLoader,
   getDockerImageBySourceHash,
 } from '../../assets/asset-manifest-loader.js';
+import type { FileAsset } from '../../types/assets.js';
 import { singleFlight } from '../../utils/single-flight.js';
 import { resolveProfileCredentials } from './local-start-api.js';
 import { applyProfileCredentialsOverlay } from './local-invoke.js';
@@ -478,7 +479,15 @@ async function resolveAgentCoreCodeImage(
   const cdkOutDir = dirname(manifestPath);
   const loader = new AssetManifestLoader();
   const manifest = await loader.loadManifest(cdkOutDir, resolved.stack.stackName);
-  const asset = manifest ? loader.getFileAssets(manifest).get(code.codeAssetHash) : undefined;
+  const fileAssets = manifest ? loader.getFileAssets(manifest) : undefined;
+  // The manifest's `files` are keyed by SOURCE hash; for the default
+  // synthesizer that equals the destination objectKey hash (`<hash>.zip`), so a
+  // direct key lookup hits. Fall back to matching the destination objectKey so
+  // a synthesizer that emits a prefixed / differing objectKey still resolves.
+  const asset = fileAssets
+    ? (fileAssets.get(code.codeAssetHash) ??
+      findFileAssetByObjectKey(fileAssets, code.codeAssetHash))
+    : undefined;
   if (!asset) {
     throw new CdkLocalError(
       `AgentCore Runtime '${resolved.logicalId}' code bundle (asset ${code.codeAssetHash}) was not found ` +
@@ -488,6 +497,13 @@ async function resolveAgentCoreCodeImage(
     );
   }
   const sourceDir = loader.getAssetSourcePath(cdkOutDir, asset);
+  if (!existsSync(sourceDir) || !statSync(sourceDir).isDirectory()) {
+    throw new CdkLocalError(
+      `AgentCore Runtime '${resolved.logicalId}' code bundle source '${sourceDir}' does not exist or is not a ` +
+        `directory. Re-synthesize the app and retry.`,
+      'LOCAL_INVOKE_AGENTCORE_CODE_SOURCE_MISSING'
+    );
+  }
   return buildAgentCoreCodeImage({
     sourceDir,
     runtime: code.runtime,
@@ -495,6 +511,25 @@ async function resolveAgentCoreCodeImage(
     architecture,
     noBuild: options.build === false,
   });
+}
+
+/**
+ * Find the file asset whose destination objectKey is `<hash>.zip` (matching the
+ * `Code.S3.Prefix`'s hash) when the source-hash-keyed lookup misses — covers a
+ * synthesizer whose source hash differs from the destination objectKey.
+ */
+function findFileAssetByObjectKey(
+  fileAssets: Map<string, FileAsset>,
+  hash: string
+): FileAsset | undefined {
+  const zip = `${hash}.zip`;
+  for (const asset of fileAssets.values()) {
+    const hit = Object.values(asset.destinations).some(
+      (d) => d.objectKey === zip || d.objectKey.endsWith(`/${zip}`)
+    );
+    if (hit) return asset;
+  }
+  return undefined;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,7 +395,16 @@ export {
   AGENTCORE_MCP_PROTOCOL,
   type ResolvedAgentCoreRuntime,
   type AgentCoreJwtAuthorizer,
+  type AgentCoreCodeArtifact,
 } from './local/agentcore-resolver.js';
+export {
+  buildAgentCoreCodeImage,
+  renderCodeDockerfile,
+  toCmdArgv,
+  computeCodeImageTag,
+  SUPPORTED_CODE_RUNTIMES,
+  type BuildAgentCoreCodeImageOptions,
+} from './local/agentcore-code-build.js';
 export {
   waitForAgentCorePing,
   invokeAgentCore,

--- a/src/local/agentcore-code-build.ts
+++ b/src/local/agentcore-code-build.ts
@@ -1,0 +1,169 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runDockerStreaming } from '../utils/docker-cmd.js';
+import { LocalInvokeBuildError } from '../utils/error-handler.js';
+import { getLogger } from '../utils/logger.js';
+import { isImageInLocalCache } from './ecr-puller.js';
+import { getEmbedConfig } from './embed-config.js';
+
+/**
+ * Local from-source build for an AgentCore Runtime `CodeConfiguration`
+ * (managed-runtime) artifact.
+ *
+ * Unlike the container artifact (which ships its own Dockerfile/image), a code
+ * artifact is just source + an `EntryPoint` + a `Runtime`; AWS's managed
+ * runtime runs the entrypoint, which self-serves the AgentCore HTTP contract
+ * (`POST /invocations` + `GET /ping` on 8080) — typically via the
+ * `bedrock-agentcore` SDK. We replicate that locally: generate a Dockerfile
+ * for the runtime's base image, install the bundle's dependencies, and run the
+ * entrypoint. The resulting container speaks the same 8080 contract, so the
+ * existing HTTP client drives it unchanged.
+ */
+
+/** AgentCore CodeConfiguration `Runtime` enum → local Docker base image. */
+const RUNTIME_BASE_IMAGES: Record<string, string> = {
+  PYTHON_3_10: 'public.ecr.aws/docker/library/python:3.10-slim',
+  PYTHON_3_11: 'public.ecr.aws/docker/library/python:3.11-slim',
+  PYTHON_3_12: 'public.ecr.aws/docker/library/python:3.12-slim',
+  PYTHON_3_13: 'public.ecr.aws/docker/library/python:3.13-slim',
+  PYTHON_3_14: 'public.ecr.aws/docker/library/python:3.14-slim',
+  NODE_22: 'public.ecr.aws/docker/library/node:22-slim',
+};
+
+/** Runtimes this CLI can build a from-source image for. */
+export const SUPPORTED_CODE_RUNTIMES = Object.keys(RUNTIME_BASE_IMAGES);
+
+export interface BuildAgentCoreCodeImageOptions {
+  /** Absolute path to the extracted code-bundle source dir (the cdk.out asset). */
+  sourceDir: string;
+  /** `CodeConfiguration.Runtime` enum value. */
+  runtime: string;
+  /** `CodeConfiguration.EntryPoint` argv. */
+  entryPoint: string[];
+  /** Drives `--platform` (AgentCore requires arm64). */
+  architecture: 'x86_64' | 'arm64';
+  /** Skip the build and require the deterministic tag to already be cached. */
+  noBuild?: boolean;
+}
+
+/**
+ * Build (or, with `noBuild`, verify) a local image for a code artifact and
+ * return its tag. The generated Dockerfile is written to a temp dir and built
+ * with the source dir as the context, so the cdk.out asset is never mutated.
+ */
+export async function buildAgentCoreCodeImage(
+  options: BuildAgentCoreCodeImageOptions
+): Promise<string> {
+  const logger = getLogger();
+  const base = RUNTIME_BASE_IMAGES[options.runtime];
+  if (!base) {
+    throw new LocalInvokeBuildError(
+      `AgentCore CodeConfiguration runtime '${options.runtime}' is not supported for local execution. ` +
+        `Supported runtimes: ${SUPPORTED_CODE_RUNTIMES.join(', ')}.`
+    );
+  }
+
+  const isNode = options.runtime.startsWith('NODE');
+  const dockerfile = renderCodeDockerfile(base, options.entryPoint, isNode);
+  const tag = computeCodeImageTag(
+    options.sourceDir,
+    options.runtime,
+    options.entryPoint,
+    dockerfile
+  );
+  const platform = options.architecture === 'x86_64' ? 'linux/amd64' : 'linux/arm64';
+
+  if (options.noBuild === true) {
+    logger.info(`Skipping docker build (--no-build). Verifying ${tag} is in local registry...`);
+    if (!(await isImageInLocalCache(tag))) {
+      throw new LocalInvokeBuildError(
+        `image '${tag}' not in local registry and --no-build is set; ` +
+          'remove --no-build or run the build manually first.'
+      );
+    }
+    return tag;
+  }
+
+  logger.info(
+    `Building agent image from source (runtime=${options.runtime}, platform=${platform})...`
+  );
+  logger.debug(`Local tag: ${tag}`);
+
+  const buildDir = await mkdtemp(
+    join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-agentcore-code-`)
+  );
+  const dockerfilePath = join(buildDir, 'Dockerfile');
+  try {
+    await writeFile(dockerfilePath, dockerfile, 'utf-8');
+    await runDockerStreaming([
+      'build',
+      '--platform',
+      platform,
+      '--tag',
+      tag,
+      '--file',
+      dockerfilePath,
+      options.sourceDir,
+    ]);
+  } catch (err) {
+    const stderr = (err as { stderr?: string }).stderr?.trim();
+    throw new LocalInvokeBuildError(
+      `docker build failed for AgentCore code artifact (${options.sourceDir})${stderr ? `: ${stderr}` : ''}`
+    );
+  } finally {
+    await rm(buildDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+  return tag;
+}
+
+/**
+ * Render the generated Dockerfile. Dependencies are installed conditionally
+ * (a bundle may vendor them or ship none), and the EntryPoint is mapped to a
+ * CMD: a bare script (`app.py` / `server.js`) is run by the interpreter, while
+ * an explicit launcher (e.g. `opentelemetry-instrument`) is run verbatim.
+ */
+export function renderCodeDockerfile(base: string, entryPoint: string[], isNode: boolean): string {
+  const installStep = isNode
+    ? 'RUN if [ -f package.json ]; then npm install --omit=dev; fi'
+    : 'RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; ' +
+      'elif [ -f pyproject.toml ]; then pip install --no-cache-dir .; fi';
+  return (
+    [
+      `FROM ${base}`,
+      'WORKDIR /app',
+      'COPY . /app',
+      installStep,
+      'EXPOSE 8080',
+      `CMD ${JSON.stringify(toCmdArgv(entryPoint, isNode))}`,
+    ].join('\n') + '\n'
+  );
+}
+
+/**
+ * Map the EntryPoint argv to a Docker CMD argv. The managed runtime execs the
+ * entrypoint as the program; a bare script file is run by the language
+ * interpreter (`python` / `node`), while a non-script first token (a launcher
+ * already on PATH, e.g. `opentelemetry-instrument`) is run verbatim.
+ */
+export function toCmdArgv(entryPoint: string[], isNode: boolean): string[] {
+  const first = entryPoint[0] ?? '';
+  const isScript = isNode ? /\.[cm]?js$/.test(first) : /\.py$/.test(first);
+  if (!isScript) return entryPoint;
+  return [isNode ? 'node' : 'python', ...entryPoint];
+}
+
+/** Deterministic local tag, stable for identical source + runtime + entrypoint. */
+export function computeCodeImageTag(
+  sourceDir: string,
+  runtime: string,
+  entryPoint: string[],
+  dockerfile: string
+): string {
+  const hash = createHash('sha256')
+    .update([sourceDir, runtime, entryPoint.join(' '), dockerfile].join('\0'))
+    .digest('hex')
+    .slice(0, 16);
+  return `${getEmbedConfig().resourceNamePrefix}-agentcore-code-${hash}`;
+}

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -50,7 +50,9 @@ export interface ResolvedAgentCoreRuntime {
   resource: TemplateResource;
   /**
    * Resolved container image URI from
-   * `AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`.
+   * `AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`. Set for a
+   * CONTAINER artifact; undefined for a {@link codeArtifact} one (exactly one
+   * of the two is set).
    *
    * May still carry `${AWS::*}` placeholders when the source was an
    * `Fn::Sub` (the canonical `fromAsset` shape): the asset-hash match in
@@ -58,7 +60,14 @@ export interface ResolvedAgentCoreRuntime {
    * path substitutes them via `--from-cfn-stack` state. A literal URI
    * passes through verbatim.
    */
-  containerUri: string;
+  containerUri?: string;
+  /**
+   * Resolved `AgentRuntimeArtifact.CodeConfiguration` (managed-runtime / from
+   * source) when the runtime declares one instead of a container — the command
+   * builds a local image from the bundle's source. Undefined for a container
+   * artifact (exactly one of {@link containerUri} / `codeArtifact` is set).
+   */
+  codeArtifact?: AgentCoreCodeArtifact;
   /**
    * `Properties.EnvironmentVariables` as it appears in the template
    * (a `Record<string, unknown>` — intrinsic-valued entries are left
@@ -94,6 +103,18 @@ export interface AgentCoreJwtAuthorizer {
   discoveryUrl: string;
   allowedAudience?: string[];
   allowedClients?: string[];
+}
+
+/**
+ * A resolved `AgentRuntimeArtifact.CodeConfiguration` (managed-runtime).
+ * `codeAssetHash` is the cdk.out file-asset hash (from `Code.S3.Prefix`,
+ * `<hash>.zip`) the command looks up to find the bundle's local source dir;
+ * `entryPoint` is the `EntryPoint` argv and `runtime` the `Runtime` enum.
+ */
+export interface AgentCoreCodeArtifact {
+  runtime: string;
+  entryPoint: string[];
+  codeAssetHash: string;
 }
 
 export class AgentCoreResolutionError extends Error {
@@ -232,7 +253,7 @@ function extractRuntimeProperties(
   const props = resource.Properties ?? {};
 
   const protocol = extractProtocol(props['ProtocolConfiguration'], logicalId, stack.stackName);
-  const containerUri = extractContainerUri(
+  const artifact = extractArtifact(
     props['AgentRuntimeArtifact'],
     logicalId,
     stack.stackName,
@@ -255,7 +276,9 @@ function extractRuntimeProperties(
     stack,
     logicalId,
     resource,
-    containerUri,
+    ...(artifact.kind === 'container'
+      ? { containerUri: artifact.containerUri }
+      : { codeArtifact: artifact.codeArtifact }),
     environmentVariables,
     protocol,
     ...(roleArn !== undefined && { roleArn }),
@@ -328,19 +351,24 @@ function extractProtocol(value: unknown, logicalId: string, stackName: string): 
   return value;
 }
 
+type ExtractedArtifact =
+  | { kind: 'container'; containerUri: string }
+  | { kind: 'code'; codeArtifact: AgentCoreCodeArtifact };
+
 /**
- * Extract + resolve the container image URI from `AgentRuntimeArtifact`.
- * Rejects the `CodeConfiguration` artifact (S3 zip + managed runtime),
- * which has no Dockerfile and is deferred from v1.
+ * Resolve `AgentRuntimeArtifact` to either a container image URI or a code
+ * artifact (managed runtime). A `ContainerConfiguration` yields the resolved
+ * `ContainerUri`; a `CodeConfiguration` yields its `Runtime` / `EntryPoint` +
+ * the cdk.out asset hash the command uses to locate the bundle source.
  */
-function extractContainerUri(
+function extractArtifact(
   artifact: unknown,
   logicalId: string,
   stackName: string,
   resources: Record<string, TemplateResource>,
   region: string | undefined,
   imageContext: ImageResolutionContext | undefined
-): string {
+): ExtractedArtifact {
   if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
     throw new AgentCoreResolutionError(
       `AgentCore Runtime '${logicalId}' in ${stackName} has no AgentRuntimeArtifact.`
@@ -349,12 +377,10 @@ function extractContainerUri(
   const art = artifact as Record<string, unknown>;
 
   if (art['CodeConfiguration'] && !art['ContainerConfiguration']) {
-    throw new AgentCoreResolutionError(
-      `AgentCore Runtime '${logicalId}' in ${stackName} uses a code artifact (CodeConfiguration). ` +
-        `${getEmbedConfig().cliName} invoke-agentcore v1 runs container artifacts only — ` +
-        `running a managed-runtime code artifact locally needs a from-source build that is not yet supported. ` +
-        `Build the agent as a container (e.g. AgentCoreRuntime fromAsset / a Dockerfile) to run it locally.`
-    );
+    return {
+      kind: 'code',
+      codeArtifact: extractCodeArtifact(art['CodeConfiguration'], logicalId, stackName),
+    };
   }
 
   const container = art['ContainerConfiguration'];
@@ -377,7 +403,62 @@ function extractContainerUri(
         `A same-stack AWS::ECR::Repository reference is not supported — build the agent as a fromAsset image, or pin a literal / imported ECR image URI.`
     );
   }
-  return uri;
+  return { kind: 'container', containerUri: uri };
+}
+
+/**
+ * Extract a `CodeConfiguration` (managed-runtime) artifact. Reads `Runtime`,
+ * `EntryPoint`, and the cdk.out file-asset hash from `Code.S3.Prefix`
+ * (`<hash>.zip`, the `fromCodeAsset` shape). A non-literal `Code.S3.Prefix`
+ * (an intrinsic, or a `fromS3` object key the command can't map to a local
+ * asset) hard-errors — downloading a pre-existing S3 bundle is not supported
+ * locally yet.
+ */
+function extractCodeArtifact(
+  codeConfig: unknown,
+  logicalId: string,
+  stackName: string
+): AgentCoreCodeArtifact {
+  const cfg =
+    codeConfig && typeof codeConfig === 'object' && !Array.isArray(codeConfig)
+      ? (codeConfig as Record<string, unknown>)
+      : {};
+
+  const runtime = cfg['Runtime'];
+  if (typeof runtime !== 'string' || runtime.length === 0) {
+    throw new AgentCoreResolutionError(
+      `AgentCore Runtime '${logicalId}' in ${stackName} has a CodeConfiguration with no string Runtime.`
+    );
+  }
+
+  const entryPointRaw = cfg['EntryPoint'];
+  const entryPoint = Array.isArray(entryPointRaw)
+    ? entryPointRaw.filter((x): x is string => typeof x === 'string')
+    : [];
+  if (entryPoint.length === 0) {
+    throw new AgentCoreResolutionError(
+      `AgentCore Runtime '${logicalId}' in ${stackName} has a CodeConfiguration with no EntryPoint.`
+    );
+  }
+
+  const s3 =
+    cfg['Code'] && typeof cfg['Code'] === 'object'
+      ? (cfg['Code'] as Record<string, unknown>)['S3']
+      : undefined;
+  const prefix =
+    s3 && typeof s3 === 'object' ? (s3 as Record<string, unknown>)['Prefix'] : undefined;
+  if (typeof prefix !== 'string' || prefix.length === 0) {
+    throw new AgentCoreResolutionError(
+      `AgentCore Runtime '${logicalId}' in ${stackName} has a CodeConfiguration whose Code.S3.Prefix is not a literal string. ` +
+        `${getEmbedConfig().cliName} invoke-agentcore runs a local from-source build of the fromCodeAsset bundle; ` +
+        `downloading a pre-existing S3 bundle (fromS3) is not supported yet.`
+    );
+  }
+
+  // Prefix is `<assetHash>.zip` (possibly with a key prefix) → the cdk.out
+  // file-asset hash the command looks up to find the bundle source dir.
+  const codeAssetHash = prefix.replace(/^.*\//, '').replace(/\.zip$/, '');
+  return { runtime, entryPoint, codeAssetHash };
 }
 
 /**

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -36,10 +36,10 @@ const SUPPORTED_AGENTCORE_PROTOCOLS = [AGENTCORE_HTTP_PROTOCOL, AGENTCORE_MCP_PR
  * Result of resolving a `cdkl invoke-agentcore <target>` argument back to a
  * concrete `AWS::BedrockAgentCore::Runtime` in the synthesized assembly.
  *
- * Covers the CONTAINER artifact on the HTTP + MCP protocols — the resolver
- * hard-errors on `CodeConfiguration` artifacts (S3 zip + managed runtime)
- * and the A2A / AGUI protocols so the command never starts a container it
- * can't speak to.
+ * Covers the CONTAINER artifact and the `CodeConfiguration` (fromCodeAsset)
+ * managed-runtime artifact on the HTTP + MCP protocols — the resolver
+ * hard-errors on a fromS3 code bundle (a non-literal `Code.S3.Prefix`) and the
+ * A2A / AGUI protocols so the command never starts something it can't run.
  */
 export interface ResolvedAgentCoreRuntime {
   /** Stack the runtime belongs to. */

--- a/tests/integration/local-invoke-agentcore/code-agent/app.py
+++ b/tests/integration/local-invoke-agentcore/code-agent/app.py
@@ -1,0 +1,51 @@
+# Minimal Bedrock AgentCore Runtime CodeConfiguration (managed-runtime) agent
+# for the cdkl invoke-agentcore integ test. Authored as plain source (no
+# Dockerfile): cdkl builds it from source for the declared runtime, installs
+# requirements.txt, and runs this entrypoint, which self-serves the AgentCore
+# HTTP contract on 0.0.0.0:8080:
+#   GET  /ping        -> 200 {"status":"Healthy"}
+#   POST /invocations -> echoes the request body + the injected GREETING env var
+# Uses only the Python stdlib. Startup logs go to stderr so the host's stdout
+# carries only the cdkl result line.
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+GREETING = os.environ.get("GREETING", "unset")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # silence default stderr access logs
+        pass
+
+    def _json(self, status, payload):
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path == "/ping":
+            self._json(200, {"status": "Healthy"})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/invocations":
+            self._json(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("content-length", 0) or 0)
+        body = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            echoed = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            echoed = body
+        self._json(200, {"echoed": echoed, "greeting": GREETING, "runtime": "python-code"})
+
+
+if __name__ == "__main__":
+    print("python code agent listening on 0.0.0.0:8080", file=sys.stderr, flush=True)
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()

--- a/tests/integration/local-invoke-agentcore/code-agent/app.py
+++ b/tests/integration/local-invoke-agentcore/code-agent/app.py
@@ -20,7 +20,9 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
     def _json(self, status, payload):
-        data = json.dumps(payload).encode("utf-8")
+        # Compact separators (no spaces) so the response matches verify.sh's
+        # no-space grep assertions, like the Node fixtures' JSON.stringify output.
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(data)))

--- a/tests/integration/local-invoke-agentcore/code-agent/requirements.txt
+++ b/tests/integration/local-invoke-agentcore/code-agent/requirements.txt
@@ -1,0 +1,2 @@
+# No third-party dependencies — this agent uses only the Python stdlib.
+# Kept so `cdkl invoke-agentcore` exercises the from-source pip-install build step.

--- a/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
+++ b/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
@@ -6,6 +6,7 @@ import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import {
   Runtime,
   AgentRuntimeArtifact,
+  AgentCoreRuntime,
   RuntimeAuthorizerConfiguration,
   ProtocolType,
 } from 'aws-cdk-lib/aws-bedrockagentcore';
@@ -67,6 +68,19 @@ export class LocalInvokeAgentCoreStack extends cdk.Stack {
         platform: Platform.LINUX_ARM64,
       }),
       protocolConfiguration: ProtocolType.MCP,
+    });
+
+    // A CodeConfiguration (managed-runtime) runtime authored as plain source
+    // (no Dockerfile) via fromCodeAsset. `cdkl invoke-agentcore` builds it from
+    // source for the declared runtime (pip install + run the entrypoint), which
+    // self-serves the same 8080 HTTP contract.
+    new Runtime(this, 'CodeAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromCodeAsset({
+        path: path.join(__dirname, '../code-agent'),
+        runtime: AgentCoreRuntime.PYTHON_3_12,
+        entrypoint: ['app.py'],
+      }),
+      environmentVariables: { GREETING: 'hello-from-code' },
     });
   }
 }

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -14,7 +14,9 @@
 # event carries {"stream": true} it responds with a text/event-stream body, so
 # we can assert the SSE response is streamed to stdout incrementally. A second
 # MCP-protocol runtime (McpAgent, POST /mcp on 8000) exercises the MCP session
-# handshake + tools/list / tools/call.
+# handshake + tools/list / tools/call. A third runtime (CodeAgent) is a
+# CodeConfiguration / managed-runtime artifact authored as plain Python source
+# (fromCodeAsset) that cdkl builds from source and runs.
 #
 # Run via `/run-integ local-invoke-agentcore` (recommended) or directly:
 #
@@ -30,13 +32,16 @@ CDKL="node ../../../dist/cli.js"
 TARGET="CdkLocalInvokeAgentCoreFixture/EchoAgent"
 PROTECTED="CdkLocalInvokeAgentCoreFixture/ProtectedAgent"
 MCP="CdkLocalInvokeAgentCoreFixture/McpAgent"
+CODE="CdkLocalInvokeAgentCoreFixture/CodeAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
+CODE_BASE_IMAGE="public.ecr.aws/docker/library/python:3.12-slim"
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
-echo "==> Pulling ${BASE_IMAGE} (one-time)"
+echo "==> Pulling base images (one-time)"
 docker pull --platform linux/arm64 "${BASE_IMAGE}" >/dev/null
+docker pull --platform linux/arm64 "${CODE_BASE_IMAGE}" >/dev/null
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then
@@ -44,7 +49,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/10] Invoking EchoAgent with default empty event"
+echo "==> [1/12] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -58,7 +63,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/10] Invoking EchoAgent with --event payload"
+echo "==> [2/12] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -70,7 +75,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/10] Invoking EchoAgent with --env-vars override"
+echo "==> [3/12] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -82,7 +87,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/10] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/12] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -93,7 +98,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/10] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/12] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -114,7 +119,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/10] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/12] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -124,7 +129,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/10] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/12] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -137,7 +142,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/10] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/12] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -157,7 +162,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
-echo "==> [9/10] McpAgent (no --event) runs the handshake + tools/list"
+echo "==> [9/12] McpAgent (no --event) runs the handshake + tools/list"
 RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
@@ -166,7 +171,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 }
 
 # Test 10 — an MCP tools/call via --event returns the tool result.
-echo "==> [10/10] McpAgent with --event runs tools/call"
+echo "==> [10/12] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
@@ -177,5 +182,32 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
   exit 1
 }
 
+# Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
+# source (no Dockerfile): cdkl builds it from source (pip install + run the
+# entrypoint) and the entrypoint self-serves the 8080 HTTP contract.
+echo "==> [11/12] CodeAgent (fromCodeAsset) builds from source + responds"
+RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
+echo "    response: ${RESULT_11}"
+echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
+  echo "FAIL: expected the from-source python agent to respond, got: ${RESULT_11}"
+  exit 1
+}
+echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
+  echo "FAIL: expected greeting=hello-from-code (env injected), got: ${RESULT_11}"
+  exit 1
+}
+
+# Test 12 — a --event payload echoes through the from-source agent.
+echo "==> [12/12] CodeAgent with --event echoes the payload"
+CODE_EVENT=$(mktemp)
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
+echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
+RESULT_12=$(${CDKL} invoke-agentcore "${CODE}" --event "${CODE_EVENT}" 2>/dev/null | tail -1)
+echo "    response: ${RESULT_12}"
+echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
+  echo "FAIL: expected echoed prompt from the from-source agent, got: ${RESULT_12}"
+  exit 1
+}
+
 echo ""
-echo "==> All 10 local-invoke-agentcore tests passed"
+echo "==> All 12 local-invoke-agentcore tests passed"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -164,8 +164,13 @@ describe('resolveAgentCoreImage — acquisition fallback order', () => {
 });
 
 describe('resolveAgentCoreImage — CodeConfiguration (from source)', () => {
+  // A real dir so the command's existsSync/isDirectory source check passes.
+  let realSourceDir: string;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    realSourceDir = mkdtempSync(join(tmpdir(), 'cdkl-code-src-'));
+    getAssetSourcePathMock.mockReturnValue(realSourceDir);
   });
 
   function codeRuntime(): ResolvedAgentCoreRuntime {
@@ -182,13 +187,12 @@ describe('resolveAgentCoreImage — CodeConfiguration (from source)', () => {
   it('locates the fromCodeAsset source dir by hash and builds from source', async () => {
     loadManifestMock.mockResolvedValue({ files: {} });
     getFileAssetsMock.mockReturnValue(new Map([['h123', { source: { path: 'asset.h123' } }]]));
-    getAssetSourcePathMock.mockReturnValue('/cdk.out/asset.h123');
     buildAgentCoreCodeImageMock.mockResolvedValue('cdkl-agentcore-code-deadbeef');
 
     const image = await resolveAgentCoreImage(codeRuntime(), imageOpts());
     expect(image).toBe('cdkl-agentcore-code-deadbeef');
     expect(buildAgentCoreCodeImageMock).toHaveBeenCalledWith({
-      sourceDir: '/cdk.out/asset.h123',
+      sourceDir: realSourceDir,
       runtime: 'PYTHON_3_13',
       entryPoint: ['app.py'],
       architecture: 'arm64',
@@ -199,17 +203,47 @@ describe('resolveAgentCoreImage — CodeConfiguration (from source)', () => {
     expect(pullEcrImageMock).not.toHaveBeenCalled();
   });
 
+  it('falls back to a destination objectKey match when the source-hash key misses', async () => {
+    loadManifestMock.mockResolvedValue({ files: {} });
+    // Keyed by a DIFFERENT source hash, but the destination objectKey is h123.zip.
+    getFileAssetsMock.mockReturnValue(
+      new Map([
+        ['srcHashXYZ', { source: { path: 'asset.x' }, destinations: { current: { objectKey: 'h123.zip' } } }],
+      ])
+    );
+    buildAgentCoreCodeImageMock.mockResolvedValue('tag');
+    await resolveAgentCoreImage(codeRuntime(), imageOpts());
+    expect(buildAgentCoreCodeImageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceDir: realSourceDir })
+    );
+  });
+
   it('errors (fromS3 not supported) when the code asset is not in the manifest', async () => {
     loadManifestMock.mockResolvedValue({ files: {} });
-    getFileAssetsMock.mockReturnValue(new Map()); // no asset with the hash
+    getFileAssetsMock.mockReturnValue(new Map()); // no asset by hash or objectKey
     await expect(resolveAgentCoreImage(codeRuntime(), imageOpts())).rejects.toThrow(/fromS3/);
+    expect(buildAgentCoreCodeImageMock).not.toHaveBeenCalled();
+  });
+
+  it('errors when the resolved source dir does not exist (stale cdk.out)', async () => {
+    loadManifestMock.mockResolvedValue({ files: {} });
+    getFileAssetsMock.mockReturnValue(new Map([['h123', { source: { path: 'asset.h123' } }]]));
+    getAssetSourcePathMock.mockReturnValue('/cdk.out/does-not-exist-xyz');
+    await expect(resolveAgentCoreImage(codeRuntime(), imageOpts())).rejects.toThrow(
+      /does not exist or is not a directory/
+    );
+    expect(buildAgentCoreCodeImageMock).not.toHaveBeenCalled();
+  });
+
+  it('errors when the stack has no asset manifest', async () => {
+    const noManifest = { ...codeRuntime(), stack: { stackName: 'App' } as never };
+    await expect(resolveAgentCoreImage(noManifest, imageOpts())).rejects.toThrow(/no asset/);
     expect(buildAgentCoreCodeImageMock).not.toHaveBeenCalled();
   });
 
   it('threads --no-build through to the code builder', async () => {
     loadManifestMock.mockResolvedValue({ files: {} });
     getFileAssetsMock.mockReturnValue(new Map([['h123', { source: { path: 'asset.h123' } }]]));
-    getAssetSourcePathMock.mockReturnValue('/cdk.out/asset.h123');
     buildAgentCoreCodeImageMock.mockResolvedValue('tag');
     await resolveAgentCoreImage(codeRuntime(), imageOpts({ build: false }));
     expect(buildAgentCoreCodeImageMock).toHaveBeenCalledWith(

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -2,8 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 const {
   loadManifestMock,
+  getFileAssetsMock,
+  getAssetSourcePathMock,
   getDockerImageBySourceHashMock,
   buildContainerImageMock,
+  buildAgentCoreCodeImageMock,
   parseEcrUriMock,
   pullEcrImageMock,
   pullImageMock,
@@ -11,8 +14,11 @@ const {
   verifyJwtViaDiscoveryMock,
 } = vi.hoisted(() => ({
   loadManifestMock: vi.fn(),
+  getFileAssetsMock: vi.fn(),
+  getAssetSourcePathMock: vi.fn(),
   getDockerImageBySourceHashMock: vi.fn(),
   buildContainerImageMock: vi.fn(),
+  buildAgentCoreCodeImageMock: vi.fn(),
   parseEcrUriMock: vi.fn(),
   pullEcrImageMock: vi.fn(),
   pullImageMock: vi.fn(),
@@ -40,6 +46,12 @@ vi.mock('../../../src/assets/asset-manifest-loader.js', async (importActual) => 
       async loadManifest(): Promise<unknown> {
         return loadManifestMock();
       }
+      getFileAssets(manifest: unknown): unknown {
+        return getFileAssetsMock(manifest);
+      }
+      getAssetSourcePath(dir: string, asset: unknown): unknown {
+        return getAssetSourcePathMock(dir, asset);
+      }
     },
     getDockerImageBySourceHash: getDockerImageBySourceHashMock,
   };
@@ -48,6 +60,11 @@ vi.mock('../../../src/assets/asset-manifest-loader.js', async (importActual) => 
 vi.mock('../../../src/local/docker-image-builder.js', async (importActual) => ({
   ...(await importActual<object>()),
   buildContainerImage: buildContainerImageMock,
+}));
+
+vi.mock('../../../src/local/agentcore-code-build.js', async (importActual) => ({
+  ...(await importActual<object>()),
+  buildAgentCoreCodeImage: buildAgentCoreCodeImageMock,
 }));
 
 vi.mock('../../../src/local/ecr-puller.js', async (importActual) => ({
@@ -143,6 +160,61 @@ describe('resolveAgentCoreImage — acquisition fallback order', () => {
     expect(image).toBe(uri);
     expect(pullImageMock).toHaveBeenCalledWith(uri, true);
     expect(pullEcrImageMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveAgentCoreImage — CodeConfiguration (from source)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function codeRuntime(): ResolvedAgentCoreRuntime {
+    return {
+      stack: { stackName: 'App', assetManifestPath: '/cdk.out/App.assets.json' } as never,
+      logicalId: 'CodeAgent',
+      resource: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      environmentVariables: {},
+      protocol: 'HTTP',
+      codeArtifact: { runtime: 'PYTHON_3_13', entryPoint: ['app.py'], codeAssetHash: 'h123' },
+    };
+  }
+
+  it('locates the fromCodeAsset source dir by hash and builds from source', async () => {
+    loadManifestMock.mockResolvedValue({ files: {} });
+    getFileAssetsMock.mockReturnValue(new Map([['h123', { source: { path: 'asset.h123' } }]]));
+    getAssetSourcePathMock.mockReturnValue('/cdk.out/asset.h123');
+    buildAgentCoreCodeImageMock.mockResolvedValue('cdkl-agentcore-code-deadbeef');
+
+    const image = await resolveAgentCoreImage(codeRuntime(), imageOpts());
+    expect(image).toBe('cdkl-agentcore-code-deadbeef');
+    expect(buildAgentCoreCodeImageMock).toHaveBeenCalledWith({
+      sourceDir: '/cdk.out/asset.h123',
+      runtime: 'PYTHON_3_13',
+      entryPoint: ['app.py'],
+      architecture: 'arm64',
+      noBuild: false,
+    });
+    // The container path must NOT run for a code artifact.
+    expect(buildContainerImageMock).not.toHaveBeenCalled();
+    expect(pullEcrImageMock).not.toHaveBeenCalled();
+  });
+
+  it('errors (fromS3 not supported) when the code asset is not in the manifest', async () => {
+    loadManifestMock.mockResolvedValue({ files: {} });
+    getFileAssetsMock.mockReturnValue(new Map()); // no asset with the hash
+    await expect(resolveAgentCoreImage(codeRuntime(), imageOpts())).rejects.toThrow(/fromS3/);
+    expect(buildAgentCoreCodeImageMock).not.toHaveBeenCalled();
+  });
+
+  it('threads --no-build through to the code builder', async () => {
+    loadManifestMock.mockResolvedValue({ files: {} });
+    getFileAssetsMock.mockReturnValue(new Map([['h123', { source: { path: 'asset.h123' } }]]));
+    getAssetSourcePathMock.mockReturnValue('/cdk.out/asset.h123');
+    buildAgentCoreCodeImageMock.mockResolvedValue('tag');
+    await resolveAgentCoreImage(codeRuntime(), imageOpts({ build: false }));
+    expect(buildAgentCoreCodeImageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ noBuild: true })
+    );
   });
 });
 

--- a/tests/unit/local/agentcore-code-build.test.ts
+++ b/tests/unit/local/agentcore-code-build.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+const { runDockerStreamingMock, isImageInLocalCacheMock } = vi.hoisted(() => ({
+  runDockerStreamingMock: vi.fn(),
+  isImageInLocalCacheMock: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/docker-cmd.js', async (importActual) => ({
+  ...(await importActual<object>()),
+  runDockerStreaming: runDockerStreamingMock,
+}));
+vi.mock('../../../src/local/ecr-puller.js', async (importActual) => ({
+  ...(await importActual<object>()),
+  isImageInLocalCache: isImageInLocalCacheMock,
+}));
+
+const {
+  buildAgentCoreCodeImage,
+  renderCodeDockerfile,
+  toCmdArgv,
+  computeCodeImageTag,
+} = await import('../../../src/local/agentcore-code-build.js');
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('toCmdArgv', () => {
+  it('prepends the python interpreter for a bare .py entrypoint', () => {
+    expect(toCmdArgv(['app.py'], false)).toEqual(['python', 'app.py']);
+  });
+
+  it('prepends node for a bare .js/.mjs entrypoint', () => {
+    expect(toCmdArgv(['server.js'], true)).toEqual(['node', 'server.js']);
+    expect(toCmdArgv(['server.mjs'], true)).toEqual(['node', 'server.mjs']);
+  });
+
+  it('runs an explicit launcher (e.g. opentelemetry-instrument) verbatim', () => {
+    expect(toCmdArgv(['opentelemetry-instrument', 'main.py'], false)).toEqual([
+      'opentelemetry-instrument',
+      'main.py',
+    ]);
+  });
+});
+
+describe('renderCodeDockerfile', () => {
+  it('generates a Python Dockerfile with conditional pip install + interpreter CMD', () => {
+    const df = renderCodeDockerfile('python:3.12-slim', ['app.py'], false);
+    expect(df).toContain('FROM python:3.12-slim');
+    expect(df).toContain('COPY . /app');
+    expect(df).toContain('pip install --no-cache-dir -r requirements.txt');
+    expect(df).toContain('pyproject.toml');
+    expect(df).toContain('EXPOSE 8080');
+    expect(df).toContain('CMD ["python","app.py"]');
+  });
+
+  it('generates a Node Dockerfile with npm install + node CMD', () => {
+    const df = renderCodeDockerfile('node:22-slim', ['server.js'], true);
+    expect(df).toContain('FROM node:22-slim');
+    expect(df).toContain('npm install --omit=dev');
+    expect(df).toContain('CMD ["node","server.js"]');
+  });
+});
+
+describe('computeCodeImageTag', () => {
+  it('is deterministic and carries the cdkl-agentcore-code prefix', () => {
+    const a = computeCodeImageTag('/src', 'PYTHON_3_12', ['app.py'], 'FROM x');
+    const b = computeCodeImageTag('/src', 'PYTHON_3_12', ['app.py'], 'FROM x');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^cdkl-agentcore-code-[0-9a-f]{16}$/);
+  });
+
+  it('changes when the runtime / entrypoint / dockerfile changes', () => {
+    const base = computeCodeImageTag('/src', 'PYTHON_3_12', ['app.py'], 'FROM x');
+    expect(computeCodeImageTag('/src', 'PYTHON_3_13', ['app.py'], 'FROM x')).not.toBe(base);
+    expect(computeCodeImageTag('/src', 'PYTHON_3_12', ['main.py'], 'FROM x')).not.toBe(base);
+  });
+});
+
+describe('buildAgentCoreCodeImage', () => {
+  it('rejects an unsupported runtime before any docker work', async () => {
+    await expect(
+      buildAgentCoreCodeImage({
+        sourceDir: '/src',
+        runtime: 'RUBY_3_3',
+        entryPoint: ['app.rb'],
+        architecture: 'arm64',
+      })
+    ).rejects.toThrow(/runtime 'RUBY_3_3' is not supported/);
+    expect(runDockerStreamingMock).not.toHaveBeenCalled();
+  });
+
+  it('builds with the generated Dockerfile (-f temp) + the source dir as context', async () => {
+    runDockerStreamingMock.mockResolvedValue({ stdout: '', stderr: '' });
+    const tag = await buildAgentCoreCodeImage({
+      sourceDir: '/abs/src',
+      runtime: 'PYTHON_3_12',
+      entryPoint: ['app.py'],
+      architecture: 'arm64',
+    });
+    expect(tag).toMatch(/^cdkl-agentcore-code-[0-9a-f]{16}$/);
+    expect(runDockerStreamingMock).toHaveBeenCalledTimes(1);
+    const args = runDockerStreamingMock.mock.calls[0]?.[0] as string[];
+    expect(args[0]).toBe('build');
+    expect(args).toContain('--platform');
+    expect(args[args.indexOf('--platform') + 1]).toBe('linux/arm64');
+    expect(args).toContain('--tag');
+    expect(args[args.indexOf('--tag') + 1]).toBe(tag);
+    expect(args).toContain('--file'); // generated Dockerfile path
+    expect(args[args.length - 1]).toBe('/abs/src'); // build context = source dir
+  });
+
+  it('maps --platform linux/amd64 for x86_64', async () => {
+    runDockerStreamingMock.mockResolvedValue({ stdout: '', stderr: '' });
+    await buildAgentCoreCodeImage({
+      sourceDir: '/s',
+      runtime: 'NODE_22',
+      entryPoint: ['server.js'],
+      architecture: 'x86_64',
+    });
+    const args = runDockerStreamingMock.mock.calls[0]?.[0] as string[];
+    expect(args[args.indexOf('--platform') + 1]).toBe('linux/amd64');
+  });
+
+  it('wraps a docker build failure with the captured stderr', async () => {
+    const err = Object.assign(new Error('exit 1'), { stderr: 'pip: not found' });
+    runDockerStreamingMock.mockRejectedValue(err);
+    await expect(
+      buildAgentCoreCodeImage({
+        sourceDir: '/s',
+        runtime: 'PYTHON_3_12',
+        entryPoint: ['app.py'],
+        architecture: 'arm64',
+      })
+    ).rejects.toThrow(/docker build failed.*pip: not found/);
+  });
+
+  it('with noBuild verifies the cached tag instead of building', async () => {
+    isImageInLocalCacheMock.mockResolvedValue(true);
+    const tag = await buildAgentCoreCodeImage({
+      sourceDir: '/s',
+      runtime: 'PYTHON_3_12',
+      entryPoint: ['app.py'],
+      architecture: 'arm64',
+      noBuild: true,
+    });
+    expect(runDockerStreamingMock).not.toHaveBeenCalled();
+    expect(isImageInLocalCacheMock).toHaveBeenCalledWith(tag);
+  });
+
+  it('with noBuild throws when the tag is not cached', async () => {
+    isImageInLocalCacheMock.mockResolvedValue(false);
+    await expect(
+      buildAgentCoreCodeImage({
+        sourceDir: '/s',
+        runtime: 'PYTHON_3_12',
+        entryPoint: ['app.py'],
+        architecture: 'arm64',
+        noBuild: true,
+      })
+    ).rejects.toThrow(/not in local registry/);
+  });
+});

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -153,21 +153,76 @@ describe('resolveAgentCoreTarget — target matching', () => {
   });
 });
 
-describe('resolveAgentCoreTarget — out-of-scope artifacts', () => {
-  it('rejects a CodeConfiguration (managed-runtime) artifact', () => {
+describe('resolveAgentCoreTarget — CodeConfiguration (managed runtime)', () => {
+  function codeRuntime(code: Record<string, unknown>): TemplateResource {
+    return {
+      Type: 'AWS::BedrockAgentCore::Runtime',
+      Properties: {
+        AgentRuntimeName: 'my-agent',
+        ProtocolConfiguration: 'HTTP',
+        AgentRuntimeArtifact: { CodeConfiguration: code },
+      },
+    };
+  }
+
+  it('extracts runtime, entryPoint, and the fromCodeAsset hash (Prefix <hash>.zip)', () => {
     const stack = buildStack('App', {
-      ChatAgent: containerRuntime({
-        AgentRuntimeArtifact: {
-          CodeConfiguration: {
-            Code: { S3: { Bucket: 'b', Prefix: 'p' } },
-            EntryPoint: ['app.py'],
-            Runtime: 'PYTHON_3_12',
-          },
-        },
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: { 'Fn::Sub': 'cdk-assets-${AWS::AccountId}' }, Prefix: 'abc123def456.zip' } },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_13',
       }),
     });
-    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/container artifacts only/);
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.containerUri).toBeUndefined();
+    expect(resolved.codeArtifact).toEqual({
+      runtime: 'PYTHON_3_13',
+      entryPoint: ['app.py'],
+      codeAssetHash: 'abc123def456',
+    });
   });
+
+  it('strips a key prefix from Code.S3.Prefix when deriving the hash', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: 'b', Prefix: 'assets/abc123.zip' } },
+        EntryPoint: ['opentelemetry-instrument', 'main.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.codeArtifact?.codeAssetHash).toBe('abc123');
+    expect(resolved.codeArtifact?.entryPoint).toEqual(['opentelemetry-instrument', 'main.py']);
+  });
+
+  it('throws when Runtime is missing', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({ Code: { S3: { Bucket: 'b', Prefix: 'h.zip' } }, EntryPoint: ['app.py'] }),
+    });
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/no string Runtime/);
+  });
+
+  it('throws when EntryPoint is missing/empty', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({ Code: { S3: { Bucket: 'b', Prefix: 'h.zip' } }, Runtime: 'PYTHON_3_12' }),
+    });
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/no EntryPoint/);
+  });
+
+  it('throws (fromS3 not supported) when Code.S3.Prefix is a non-literal intrinsic', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: 'b', Prefix: { Ref: 'SomeParam' } } },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/not a literal string/);
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/fromS3/);
+  });
+});
+
+describe('resolveAgentCoreTarget — out-of-scope artifacts', () => {
 
   it('rejects the A2A protocol with a not-served-yet error', () => {
     const stack = buildStack('App', {


### PR DESCRIPTION
## Summary

Implements #127: `cdkl invoke-agentcore` now runs an AgentCore Runtime
**CodeConfiguration** (managed-runtime) artifact locally — previously only the
container artifact ran, and a code artifact hard-errored. v1 covers
**`fromCodeAsset`** (a local code bundle); `fromS3` is deferred to (#144).

When a runtime declares `AgentRuntimeArtifact.CodeConfiguration` (source +
`EntryPoint` + `Runtime`, no Dockerfile), cdk-local builds it **from source** —
the same way AWS's managed runtime runs it, where the entrypoint self-serves the
AgentCore HTTP contract (no injected harness):

- the resolver extracts `Runtime` / `EntryPoint` + the cdk.out file-asset hash
  (`Code.S3.Prefix` `<hash>.zip`) as `resolved.codeArtifact` (the resolved type
  now carries `containerUri` **or** `codeArtifact`),
- `agentcore-code-build` generates a Dockerfile for the runtime's base image
  (`PYTHON_3_10`-`PYTHON_3_14` -> `python:3.x-slim`, `NODE_22` -> `node:22-slim`),
  installs the bundle's deps (`requirements.txt` / `pyproject.toml` /
  `package.json` when present), and runs the `EntryPoint` (a bare script via the
  interpreter; an explicit launcher like `opentelemetry-instrument` verbatim).
  The generated Dockerfile is written to a temp dir and built with the source
  dir as the context, so cdk.out is never mutated,
- the command locates the `fromCodeAsset` source dir by hash (with a destination
  objectKey fallback) and builds it; the started container self-serves the same
  HTTP/MCP contract, so the existing client drives it unchanged.

Only `fromCodeAsset` is supported; a `fromS3` bundle (a pre-existing S3 object
needing an AWS download) is rejected with an actionable error.

## Test plan

- [x] `vp run verify` green — 1366 unit tests pass.
- [x] Unit: the from-source builder (`toCmdArgv` script-vs-launcher,
  `renderCodeDockerfile` python/node, deterministic tag, unsupported-runtime +
  stderr-wrapped build failure + `noBuild` cached/missing); resolver
  code-artifact extraction (hash from `<hash>.zip`, key-prefix strip, missing
  Runtime/EntryPoint, non-literal Prefix=fromS3 reject); the command code-image
  branch (locate-by-hash, objectKey fallback, missing-source-dir, no-manifest,
  `--no-build`).
- [x] Real-Docker integ `tests/integration/local-invoke-agentcore/`: a Python
  `fromCodeAsset` `CodeAgent` built from source (pip-install step exercised via a
  present `requirements.txt`; the entrypoint self-serves 8080) — default + env
  injection (test 11) + `--event` echo (test 12). 12/12 pass, 0 orphans.

## Reviewer notes

3-axis review (spec / code / test). Spec: clean — all contract points verified.
Code: no blockers; the two minors were fixed in a follow-up commit:

- the resolved fromCodeAsset source dir is now validated (exists + is a
  directory) before `docker build`, with a clear "re-synthesize" error (parity
  with the Lambda asset path),
- the file-asset lookup falls back to matching the destination objectKey
  (`<hash>.zip`) when the source-hash-keyed lookup misses (robustness for a
  synthesizer whose source hash differs from the objectKey),
- fixed stale JSDoc that claimed CodeConfiguration is rejected.

Accepted as known cost (not blockers):

- the local base images are Debian-`slim`, not AWS's AL2023 managed-runtime base
  — the local build is an approximation; pure-Python/pip apps build identically,
  only native-extension deps compiled against glibc could differ.
- the `NODE_22`, `pyproject.toml`-only, and `opentelemetry-instrument`-launcher
  paths are unit-asserted (the rendered Dockerfile / CMD argv) but not exercised
  end-to-end in the integ (the integ fixture is Python + `requirements.txt`).

`A2A` / `AG-UI` protocols are tracked in (#140); `fromS3` code bundles in (#144).

Closes #127
