### PR TITLE
feat(start-alb): host-header + weighted forward + redirect/fixed-response routing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,10 +30,11 @@ AWS managed services.
   replicas only (pure compute, no load balancer). `start-alb` is the ALB
   counterpart of `start-api`: name the ALB, and it boots the ECS
   service(s) behind it plus a local front-door that round-robins each
-  listener port across the replicas and path-routes the listener's
-  `path-pattern` rules across the backing services (other conditions —
-  host-header / weighted / Lambda targets / redirect+fixed-response
-  actions — deferred to #123)
+  listener port across the replicas and routes the listener's
+  `path-pattern` + `host-header` rules across the backing services,
+  honoring weighted forwards and `redirect` / `fixed-response` actions
+  (Lambda targets and `http-header` / `query-string` / `source-ip`
+  conditions — deferred to #123)
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
@@ -98,12 +99,14 @@ Gateway).
   (embed-time branding overrides for host CLIs), ssm-parameter-resolver
   (resolves `AWS::SSM::Parameter::Value` template parameters via SSM under
   `--from-cfn-stack`), elb-front-door-resolver (resolves an ALB ->
-  Listeners + path-pattern ListenerRules -> TargetGroups -> backing ECS
-  Services into a per-listener routing table; the `start-alb` entry),
-  alb-path-matcher (ALB `*` / `?` glob path-pattern matcher, priority
-  ordered), front-door-pool (round-robin pool of live replica endpoints),
-  front-door-server (host HTTP reverse proxy that path-routes each request
-  to a service's replica pool behind the ALB listener port), etc.
+  Listeners + `path-pattern`/`host-header` ListenerRules -> forward /
+  weighted-forward / redirect / fixed-response actions -> backing ECS
+  Services, into a per-listener routing table; the `start-alb` entry),
+  alb-path-matcher (ALB `*` / `?` glob matcher for path + host rules,
+  priority ordered), front-door-pool (round-robin pool of live replica
+  endpoints), front-door-server (host HTTP reverse proxy that resolves a
+  per-request RouteAction — weighted forward to a replica pool, redirect,
+  or fixed-response — behind the ALB listener port), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 | `cdkl start-service <Service>` | the ECS **service** | just the service's replicas (no load balancer) | workers / queue consumers / Service-Connect-only services, or to hit the containers directly |
 | `cdkl start-alb <Alb>` | the **ALB** | the ECS service(s) behind it **plus** a local **front-door** on each listener port | an `ApplicationLoadBalancedFargateService`-style service you want to reach the way external traffic does |
 
-`start-alb` discovers the ECS service(s) behind the ALB's HTTP listeners, boots their replicas, and stands up a host-side front-door on each listener port that round-robins across the replicas — one stable host endpoint, like behind a real load balancer. It honors **`path-pattern` listener rules**, so a listener routing `/api/*` to one service and everything else to another is reproduced locally.
+`start-alb` discovers the ECS service(s) behind the ALB's HTTP listeners, boots their replicas, and stands up a host-side front-door on each listener port that round-robins across the replicas — one stable host endpoint, like behind a real load balancer. It honors **`path-pattern` and `host-header` listener rules**, **weighted** forwards, and **`redirect` / `fixed-response`** actions, so a listener routing `/api/*` (or `api.example.com`) to one service and everything else to another — or returning a redirect / canned response — is reproduced locally.
 
 ```bash
 cdkl start-alb MyStack/WebAlb --lb-port 80=8080   # remap the privileged listener port 80 (macOS)
@@ -80,7 +80,7 @@ curl http://127.0.0.1:8080/        # default action -> the default service (roun
 curl http://127.0.0.1:8080/api/x   # path-pattern rule /api/* -> the api service
 ```
 
-Resolution model + scope (HTTP listeners, default `forward` + `path-pattern` rules, ECS targets; host-header / weighted / Lambda targets / redirect + fixed-response actions deferred): [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
+Resolution model + scope (HTTP listeners, `path-pattern` + `host-header` rules, weighted forwards, `redirect` / `fixed-response`, ECS targets; Lambda targets and `http-header` / `query-string` / `source-ip` conditions deferred): [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
 
 ## Override env vars without a state source
 
@@ -104,7 +104,7 @@ Format + full precedence: [docs/cli-reference.md](docs/cli-reference.md).
 | `AWS::ECS::TaskDefinition` (run-task) | ✓ |
 | `AWS::ECS::Service` (start-service) | ✓ |
 | `AWS::ServiceDiscovery::*` (Cloud Map / Service Connect) | ✓ |
-| `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door + `path-pattern` rules) | ✓ |
+| `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door; `path-pattern` + `host-header` rules, weighted forward, redirect / fixed-response) | ✓ |
 | `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container + fromCodeAsset artifacts, HTTP + MCP) | ✓ |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1005,9 +1005,11 @@ ECS service(s) behind its HTTP listeners, boots their replicas
 `start-service`), and stands up a host-side **front-door** on each
 listener port that round-robins each request across the running replicas
 — one stable host endpoint, like behind a real load balancer. The
-front-door applies the listener's **`path-pattern` rules**, so one host
-port can path-route across several backing services (e.g. `/api/*` to one
-service, the default to another) the way the deployed ALB does.
+front-door applies the listener's **`path-pattern` and `host-header`
+rules**, so one host port can route across several backing services (e.g.
+`/api/*` or `api.example.com` to one service, the default to another) the
+way the deployed ALB does — including **weighted** forwards and
+**`redirect` / `fixed-response`** actions.
 
 `start-service` vs `start-alb` mirrors `invoke` / `run-task` (the compute
 alone) vs `start-api` (the routed entry in front of the compute). Use
@@ -1020,15 +1022,18 @@ service you want to reach the way external traffic does.
 
 `start-alb` resolves the ALB you name → its
 `AWS::ElasticLoadBalancingV2::Listener`s (matched by `LoadBalancerArn`) →
-each listener's default `forward` action **and** its
-`AWS::ElasticLoadBalancingV2::ListenerRule`s with a `path-pattern`
-condition → each action's `AWS::ElasticLoadBalancingV2::TargetGroup` →
-the `AWS::ECS::Service` whose `LoadBalancers[]` references that target
-group (a reverse scan — there is no direct TG → service pointer). The
-front-door for a listener port holds a routing table: each request is
-matched against the rules in `Priority` order (lower number first; ALB
-`*` / `?` glob semantics, path only), falling back to the default action;
-an unmatched request with no default action returns 404. Each booted
+each listener's default action **and** its
+`AWS::ElasticLoadBalancingV2::ListenerRule`s with a `path-pattern` and/or
+`host-header` condition → each `forward` action's
+`AWS::ElasticLoadBalancingV2::TargetGroup`(s) → the `AWS::ECS::Service`
+whose `LoadBalancers[]` references that target group (a reverse scan —
+there is no direct TG → service pointer). The front-door for a listener
+port holds a routing table: each request is matched against the rules in
+`Priority` order (lower number first; ALB `*` / `?` glob, path-only +
+case-insensitive host), falling back to the default action; an unmatched
+request with no default action returns 404. A `redirect` / `fixed-response`
+action is synthesized directly; a weighted `forward` picks a target group
+by weight. Each booted
 replica publishes its target container port on an **ephemeral** host port
 (so N replicas never collide), and the front-door forwards to those —
 cross-platform, since traffic goes through published ports rather than
@@ -1061,12 +1066,17 @@ cdkl start-alb MyStack/WebAlb --lb-port 80=8080
 
 ### Scope
 
-**HTTP** listeners, **ECS** targets, single-target `forward` actions, and
-`path-pattern` listener rules (priority-ordered). Out of scope, skipped with
-a warning, and tracked in [#123](https://github.com/go-to-k/cdk-local/issues/123):
-other rule conditions (`host-header` / `http-header` / `http-request-method`
-/ `query-string` / `source-ip`), weighted (multi-target) forwards,
-`redirect` / `fixed-response` / `authenticate-*` actions, HTTPS / TLS
+**HTTP** listeners and **ECS** targets, with priority-ordered listener rules
+matching `path-pattern` and `host-header` conditions (ALB `*` / `?` glob;
+host is matched case-insensitively, path-only excludes the query string). Both
+default actions and rule actions support single-target `forward`, **weighted**
+(multi-target) `forward` (weighted-random pool selection; weight 0 never
+selected), `redirect` (301 / 302 with the `#{protocol|host|port|path|query}`
+placeholders resolved against the request), and `fixed-response` (synthesized
+status / content-type / body). Out of scope, skipped with a warning, and
+tracked in [#123](https://github.com/go-to-k/cdk-local/issues/123): the other
+rule conditions (`http-header` / `http-request-method` / `query-string` /
+`source-ip`), `authenticate-cognito` / `authenticate-oidc` actions, HTTPS / TLS
 termination, and Lambda target groups.
 
 ### `cdkl start-alb` exit codes

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -66,6 +66,8 @@ import { FrontDoorEndpointPool } from '../../local/front-door-pool.js';
 import {
   startFrontDoorServer,
   type StartedFrontDoorServer,
+  type RouteAction,
+  type WeightedPool,
 } from '../../local/front-door-server.js';
 import { matchAlbPathRule, type AlbPathRule } from '../../local/alb-path-matcher.js';
 
@@ -127,7 +129,7 @@ export interface ServiceBoot {
   target: string;
 }
 
-/** The backing (service target, container) a listener action forwards to. */
+/** The backing (service target, container) one weighted forward target routes to. */
 export interface PlannedForwardTarget {
   /** Service target string (`Stack:LogicalId`) whose replica pool serves this. */
   serviceTarget: string;
@@ -135,18 +137,56 @@ export interface PlannedForwardTarget {
   targetContainerName: string;
   /** Container port the target group targets. */
   targetContainerPort: number;
+  /** Forward weight for weighted routing (single-target forward = 1). */
+  weight: number;
 }
 
-/** One host front-door listener: a bound host port + its path-routing table. */
+/** A planned forward action: one or more weighted backing targets. */
+export interface PlannedForwardAction {
+  kind: 'forward';
+  targets: PlannedForwardTarget[];
+}
+
+/** A planned redirect action (no backing pool). */
+export interface PlannedRedirectAction {
+  kind: 'redirect';
+  statusCode: 301 | 302;
+  protocol?: string;
+  host?: string;
+  port?: string;
+  path?: string;
+  query?: string;
+}
+
+/** A planned fixed-response action (no backing pool). */
+export interface PlannedFixedResponseAction {
+  kind: 'fixed-response';
+  statusCode: number;
+  contentType?: string;
+  messageBody?: string;
+}
+
+/** Any planned listener / rule action (the strategy-side mirror of the front-door's RouteAction). */
+export type PlannedAction =
+  | PlannedForwardAction
+  | PlannedRedirectAction
+  | PlannedFixedResponseAction;
+
+/** One host front-door listener: a bound host port + its routing table. */
 export interface PlannedFrontDoorListener {
   /** ALB listener port (for the `X-Forwarded-Port` header / logs). */
   listenerPort: number;
   /** Host port to bind (the listener port, or its `--lb-port` override). */
   hostPort: number;
-  /** Default-action forward target (absent for a rules-only listener -> 404 on miss). */
-  defaultTarget?: PlannedForwardTarget;
-  /** Path-pattern rules, evaluated by priority (lower first). */
-  rules: Array<{ priority: number; pathPatterns: string[]; target: PlannedForwardTarget }>;
+  /** Default action (absent for a rules-only listener -> 404 on miss). */
+  defaultAction?: PlannedAction;
+  /** Rules, evaluated by priority (lower first); each carries path + host conditions. */
+  rules: Array<{
+    priority: number;
+    pathPatterns: string[];
+    hostPatterns: string[];
+    action: PlannedAction;
+  }>;
 }
 
 /** The full set of host front-doors to stand up for one emulator invocation. */
@@ -610,20 +650,51 @@ export async function buildFrontDoor(
     }
     return entry.pool;
   };
+  // Convert a planned action into the front-door's RouteAction, building /
+  // reusing a pool per weighted forward target.
+  const toRouteAction = (action: PlannedAction): RouteAction => {
+    if (action.kind === 'forward') {
+      const pools: WeightedPool[] = action.targets.map((t) => ({
+        pool: poolFor(t),
+        weight: t.weight,
+      }));
+      return { kind: 'forward', pools };
+    }
+    if (action.kind === 'redirect') {
+      return {
+        kind: 'redirect',
+        statusCode: action.statusCode,
+        ...(action.protocol !== undefined && { protocol: action.protocol }),
+        ...(action.host !== undefined && { host: action.host }),
+        ...(action.port !== undefined && { port: action.port }),
+        ...(action.path !== undefined && { path: action.path }),
+        ...(action.query !== undefined && { query: action.query }),
+      };
+    }
+    return {
+      kind: 'fixed-response',
+      statusCode: action.statusCode,
+      ...(action.contentType !== undefined && { contentType: action.contentType }),
+      ...(action.messageBody !== undefined && { messageBody: action.messageBody }),
+    };
+  };
 
   try {
     for (const listener of plan.listeners) {
-      const defaultPool = listener.defaultTarget ? poolFor(listener.defaultTarget) : undefined;
-      const ruleRoutes: AlbPathRule<FrontDoorEndpointPool>[] = listener.rules.map((r) => ({
+      const defaultRoute = listener.defaultAction
+        ? toRouteAction(listener.defaultAction)
+        : undefined;
+      const ruleRoutes: AlbPathRule<RouteAction>[] = listener.rules.map((r) => ({
         priority: r.priority,
         pathPatterns: r.pathPatterns,
-        target: poolFor(r.target),
+        hostPatterns: r.hostPatterns,
+        target: toRouteAction(r.action),
       }));
-      const selectPool = (requestPath: string): FrontDoorEndpointPool | undefined =>
-        matchAlbPathRule(requestPath, ruleRoutes) ?? defaultPool;
+      const route = (req: { path: string; host?: string }): RouteAction | undefined =>
+        matchAlbPathRule(req, ruleRoutes) ?? defaultRoute;
 
       const server = await startFrontDoorServer({
-        selectPool,
+        route,
         port: listener.hostPort,
         host: containerHost,
         listenerPort: listener.listenerPort,
@@ -634,16 +705,16 @@ export async function buildFrontDoor(
       logger.info(
         `ALB front-door: http://${server.host}:${server.port} (listener port ${listener.listenerPort})`
       );
-      if (listener.defaultTarget) {
-        logger.info(`  default -> ${describeTarget(listener.defaultTarget)} (round-robin)`);
+      if (listener.defaultAction) {
+        logger.info(`  default -> ${describeAction(listener.defaultAction)}`);
       }
       for (const r of [...listener.rules].sort((a, b) => a.priority - b.priority)) {
         logger.info(
-          `  path ${r.pathPatterns.join(', ')} (priority ${r.priority}) -> ${describeTarget(r.target)}`
+          `  ${describeConditions(r)} (priority ${r.priority}) -> ${describeAction(r.action)}`
         );
       }
-      if (!listener.defaultTarget) {
-        logger.info('  (no default action: unmatched paths return 404)');
+      if (!listener.defaultAction) {
+        logger.info('  (no default action: unmatched requests return 404)');
       }
     }
   } catch (err) {
@@ -668,8 +739,28 @@ export async function buildFrontDoor(
   return { servers, frontDoorByService };
 }
 
-function describeTarget(t: PlannedForwardTarget): string {
-  return `${t.serviceTarget} (container ${t.targetContainerName}:${t.targetContainerPort})`;
+/** Human-readable summary of a planned rule's path / host conditions (for the boot banner). */
+function describeConditions(rule: { pathPatterns: string[]; hostPatterns: string[] }): string {
+  const parts: string[] = [];
+  if (rule.pathPatterns.length > 0) parts.push(`path ${rule.pathPatterns.join(', ')}`);
+  if (rule.hostPatterns.length > 0) parts.push(`host ${rule.hostPatterns.join(', ')}`);
+  return parts.join(' AND ') || '(no condition)';
+}
+
+/** Human-readable summary of a planned action (for the boot banner). */
+function describeAction(action: PlannedAction): string {
+  if (action.kind === 'redirect') {
+    return `redirect ${action.statusCode}`;
+  }
+  if (action.kind === 'fixed-response') {
+    return `fixed-response ${action.statusCode}`;
+  }
+  if (action.targets.length === 1) {
+    const t = action.targets[0]!;
+    return `${t.serviceTarget} (container ${t.targetContainerName}:${t.targetContainerPort}) (round-robin)`;
+  }
+  const weights = action.targets.map((t) => `${t.serviceTarget}@${t.weight}`).join(', ');
+  return `weighted forward [${weights}]`;
 }
 
 async function resolvePlaceholderAccount(arn: string, region: string | undefined): Promise<string> {

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -13,7 +13,7 @@ import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cdk-path.js';
 import {
   resolveAlbFrontDoor,
   isApplicationLoadBalancer,
-  type FrontDoorForwardTarget,
+  type ResolvedListenerAction,
 } from '../../local/elb-front-door-resolver.js';
 import type { ExtraStateProviders } from './local-state-source.js';
 import {
@@ -22,7 +22,7 @@ import {
   type EcsServiceEmulatorOptions,
   type EmulatorStrategy,
   type ServiceBoot,
-  type PlannedForwardTarget,
+  type PlannedAction,
   type PlannedFrontDoorListener,
 } from './ecs-service-emulator.js';
 
@@ -179,15 +179,42 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
         const resolution = resolveAlbFrontDoor(stack, albLogicalId);
         warnings.push(...resolution.warnings);
 
-        // Qualify a resolver target (`serviceLogicalId`) into a `Stack:LogicalId`
-        // service-boot target and record it as a service we must run.
-        const qualify = (t: FrontDoorForwardTarget): PlannedForwardTarget => {
-          const serviceTarget = `${stack.stackName}:${t.serviceLogicalId}`;
-          serviceTargets.add(serviceTarget);
+        // Qualify a resolver action into a planned action: forward targets get
+        // their `serviceLogicalId` qualified into a `Stack:LogicalId`
+        // service-boot target (and recorded as a service we must run);
+        // redirect / fixed-response carry no service.
+        const qualify = (action: ResolvedListenerAction): PlannedAction => {
+          if (action.kind === 'forward') {
+            return {
+              kind: 'forward',
+              targets: action.targets.map((t) => {
+                const serviceTarget = `${stack.stackName}:${t.serviceLogicalId}`;
+                serviceTargets.add(serviceTarget);
+                return {
+                  serviceTarget,
+                  targetContainerName: t.targetContainerName,
+                  targetContainerPort: t.targetContainerPort,
+                  weight: t.weight,
+                };
+              }),
+            };
+          }
+          if (action.kind === 'redirect') {
+            return {
+              kind: 'redirect',
+              statusCode: action.statusCode,
+              ...(action.protocol !== undefined && { protocol: action.protocol }),
+              ...(action.host !== undefined && { host: action.host }),
+              ...(action.port !== undefined && { port: action.port }),
+              ...(action.path !== undefined && { path: action.path }),
+              ...(action.query !== undefined && { query: action.query }),
+            };
+          }
           return {
-            serviceTarget,
-            targetContainerName: t.targetContainerName,
-            targetContainerPort: t.targetContainerPort,
+            kind: 'fixed-response',
+            statusCode: action.statusCode,
+            ...(action.contentType !== undefined && { contentType: action.contentType }),
+            ...(action.messageBody !== undefined && { messageBody: action.messageBody }),
           };
         };
 
@@ -206,11 +233,12 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
           listeners.push({
             listenerPort: listener.listenerPort,
             hostPort,
-            ...(listener.defaultTarget ? { defaultTarget: qualify(listener.defaultTarget) } : {}),
+            ...(listener.defaultAction ? { defaultAction: qualify(listener.defaultAction) } : {}),
             rules: listener.rules.map((r) => ({
               priority: r.priority,
               pathPatterns: r.pathPatterns,
-              target: qualify(r.target),
+              hostPatterns: r.hostPatterns,
+              action: qualify(r.action),
             })),
           });
         }
@@ -255,13 +283,14 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
     .description(
       'Run an Application Load Balancer locally: name the ALB, and cdk-local boots the ECS ' +
         'service(s) behind its HTTP listeners and stands up a local front-door on each listener ' +
-        'port that round-robins across the running replicas and path-routes its path-pattern ' +
-        'rules across the backing services — a stable host endpoint, like behind a ' +
-        'real load balancer. The symmetric ALB counterpart of `start-api`. Each <target> accepts ' +
-        'a CDK display path (MyStack/MyAlb) or stack-qualified logical ID; single-stack apps may ' +
-        'omit the stack prefix. Supports HTTP listeners, single-target forward actions, and ' +
-        'path-pattern rules; HTTPS listeners, Lambda target groups, weighted forwards, other rule ' +
-        'conditions, and redirect/fixed-response actions are skipped with a warning. Omit ' +
+        'port that round-robins across the running replicas and routes its listener rules across ' +
+        'the backing services — a stable host endpoint, like behind a real load balancer. The ' +
+        'symmetric ALB counterpart of `start-api`. Each <target> accepts a CDK display path ' +
+        '(MyStack/MyAlb) or stack-qualified logical ID; single-stack apps may omit the stack ' +
+        'prefix. Supports HTTP listeners; path-pattern and host-header rule conditions; forward ' +
+        '(single and weighted), redirect, and fixed-response actions. HTTPS listeners, Lambda ' +
+        'target groups, the other rule conditions (http-header / query-string / source-ip / ' +
+        'http-request-method), and authenticate-* actions are skipped with a warning. Omit ' +
         '<targets> in an interactive terminal to multi-select the load balancers from a list.'
     )
     .argument(

--- a/src/local/alb-path-matcher.ts
+++ b/src/local/alb-path-matcher.ts
@@ -1,6 +1,8 @@
 /**
- * Issue #123 (path-pattern slice) — match a request path against an ALB
- * listener's `path-pattern` rules, in priority order.
+ * Issue #123 — match a request against an ALB listener's rules, in priority
+ * order. Covers `path-pattern` (path glob) and `host-header` (Host glob)
+ * conditions; a rule may carry one of each and both must match (ALB ANDs
+ * conditions of different fields).
  *
  * ALB path-pattern semantics (NOT the same as API Gateway route matching, so
  * this is a dedicated matcher rather than a reuse of `route-matcher.ts`):
@@ -13,40 +15,87 @@
  *     `/api/*` matches `/api/` and `/api/v1/x` but not `/api` (no trailing
  *     character for `*` to begin after the slash) and not `/apix`.
  *
+ * ALB host-header semantics:
+ *
+ *   - Matched against the request `Host` header, **case-insensitive** (DNS
+ *     hostnames are case-insensitive). The port suffix (`:8080`) is stripped
+ *     before matching, mirroring ALB's host comparison.
+ *   - Same `*` / `?` glob alphabet as path-pattern, anchored both ends.
+ *
  * Rule precedence: ALB evaluates listener rules in ascending `Priority`
- * (lower number = higher priority); the first rule whose condition matches
- * wins. A rule's `path-pattern` condition can carry multiple values, matched
- * as an OR. When no rule matches, the caller falls back to the listener's
- * default action.
+ * (lower number = higher priority); the first rule whose condition(s) match
+ * wins. A `path-pattern` / `host-header` condition can carry multiple values,
+ * each matched as an OR within the condition. When no rule matches, the caller
+ * falls back to the listener's default action.
  */
 
-/** One path-pattern routing rule, generic over the target it selects. */
+/** One routing rule, generic over the target it selects. */
 export interface AlbPathRule<T> {
   /** ALB rule priority (lower = evaluated first). */
   priority: number;
-  /** The rule's `path-pattern` condition values (OR-matched). */
+  /** The rule's `path-pattern` condition values (OR-matched). Empty = no path constraint. */
   pathPatterns: string[];
+  /** The rule's `host-header` condition values (OR-matched). Empty = no host constraint. */
+  hostPatterns?: string[];
   /** What this rule routes to (e.g. a pool, a resolved target). */
   target: T;
 }
 
+/** The request facts a rule is evaluated against. */
+export interface AlbRequestMatch {
+  /** Request URL path (query string is stripped before matching). */
+  path: string;
+  /** Request `Host` header (port suffix is stripped before host matching). */
+  host?: string;
+}
+
 /**
- * Return the target of the highest-priority rule whose `path-pattern` matches
- * `requestPath`, or `undefined` when none match (caller uses the default).
- * Rules are evaluated in ascending priority; the input order is irrelevant.
+ * Return the target of the highest-priority rule whose conditions all match
+ * `req`, or `undefined` when none match (caller uses the default). Rules are
+ * evaluated in ascending priority; the input order is irrelevant.
+ *
+ * Accepts either a request facts object or a bare path string (the path-only
+ * form keeps the original signature working for callers that have no Host).
  */
 export function matchAlbPathRule<T>(
-  requestPath: string,
+  req: AlbRequestMatch | string,
   rules: readonly AlbPathRule<T>[]
 ): T | undefined {
-  const path = pathOf(requestPath);
+  const { path, host } = typeof req === 'string' ? { path: req, host: undefined } : req;
+  const requestPath = pathOf(path);
+  const requestHost = host !== undefined ? hostOf(host) : undefined;
   const ordered = [...rules].sort((a, b) => a.priority - b.priority);
   for (const rule of ordered) {
-    if (rule.pathPatterns.some((pattern) => albPathPatternMatches(pattern, path))) {
-      return rule.target;
-    }
+    if (ruleMatches(rule, requestPath, requestHost)) return rule.target;
   }
   return undefined;
+}
+
+/**
+ * Whether a single rule's conditions all match. A `path-pattern` /
+ * `host-header` condition is satisfied when ANY of its values match (OR); a
+ * rule with both fields requires both to match (AND). An empty pattern list
+ * for a field means "no constraint on that field" (the condition was absent).
+ */
+function ruleMatches<T>(
+  rule: AlbPathRule<T>,
+  requestPath: string,
+  requestHost: string | undefined
+): boolean {
+  if (rule.pathPatterns.length > 0) {
+    if (!rule.pathPatterns.some((pattern) => globToRegExp(pattern, false).test(requestPath))) {
+      return false;
+    }
+  }
+  const hostPatterns = rule.hostPatterns ?? [];
+  if (hostPatterns.length > 0) {
+    // No Host header to match against -> a host-constrained rule cannot match.
+    if (requestHost === undefined) return false;
+    if (!hostPatterns.some((pattern) => globToRegExp(pattern, true).test(requestHost))) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**
@@ -54,7 +103,16 @@ export function matchAlbPathRule<T>(
  * must already be query-stripped, or pass a raw URL and it is stripped here.
  */
 export function albPathPatternMatches(pattern: string, requestPath: string): boolean {
-  return globToRegExp(pattern).test(pathOf(requestPath));
+  return globToRegExp(pattern, false).test(pathOf(requestPath));
+}
+
+/**
+ * Whether a single ALB `host-header` value matches a request Host. Both the
+ * pattern and the host are lower-cased (host comparison is case-insensitive),
+ * and the host's port suffix is stripped.
+ */
+export function albHostPatternMatches(pattern: string, requestHost: string): boolean {
+  return globToRegExp(pattern, true).test(hostOf(requestHost));
 }
 
 /** Strip the query string / fragment so only the URL path is matched. */
@@ -67,16 +125,37 @@ function pathOf(url: string): string {
   return url.slice(0, end);
 }
 
+/**
+ * Normalize a `Host` header for matching: drop any `:port` suffix and lower-case
+ * it (DNS hostnames are case-insensitive). IPv6 literals (`[::1]:8080`) keep the
+ * bracketed address and only the trailing port is removed.
+ */
+function hostOf(host: string): string {
+  const trimmed = host.trim();
+  if (trimmed.startsWith('[')) {
+    // IPv6 literal: `[addr]` or `[addr]:port`.
+    const close = trimmed.indexOf(']');
+    if (close !== -1) return trimmed.slice(0, close + 1).toLowerCase();
+    return trimmed.toLowerCase();
+  }
+  const colon = trimmed.indexOf(':');
+  const bare = colon === -1 ? trimmed : trimmed.slice(0, colon);
+  return bare.toLowerCase();
+}
+
 const REGEXP_META = /[.+^${}()|[\]\\]/;
 
 /**
- * Translate an ALB path-pattern glob into an anchored, case-sensitive RegExp:
- * `*` -> `.*`, `?` -> `.`, every other character is escaped and matched
- * literally.
+ * Translate an ALB `*` / `?` glob into an anchored RegExp: `*` -> `.*`,
+ * `?` -> `.`, every other character is escaped and matched literally. Host
+ * patterns match case-insensitively (the `i` flag) and the pattern is
+ * lower-cased to pair with the lower-cased host; path patterns are
+ * case-sensitive.
  */
-function globToRegExp(pattern: string): RegExp {
+function globToRegExp(pattern: string, caseInsensitive: boolean): RegExp {
+  const source = caseInsensitive ? pattern.toLowerCase() : pattern;
   let body = '';
-  for (const ch of pattern) {
+  for (const ch of source) {
     if (ch === '*') body += '.*';
     else if (ch === '?') body += '.';
     else if (REGEXP_META.test(ch)) body += `\\${ch}`;

--- a/src/local/elb-front-door-resolver.ts
+++ b/src/local/elb-front-door-resolver.ts
@@ -8,33 +8,41 @@ import type { TemplateResource } from '../types/resource.js';
  * cdk-local discovers the services behind it (mirroring how `start-api` names
  * the API and discovers the backing Lambdas).
  *
- * The synthesized linkage (confirmed against real `cdk synth` of
- * `ApplicationLoadBalancedFargateService` + an `addAction` path rule):
+ * The synthesized linkage (confirmed against real `cdk synth` of an
+ * `ApplicationLoadBalancer` + `addAction` rules):
  *
  * ```
  * ElasticLoadBalancingV2::LoadBalancer  (the ALB you name)
  * ElasticLoadBalancingV2::Listener      : { LoadBalancerArn:{Ref:<ALB>}, Port, Protocol,
- *     DefaultActions:[{ Type:"forward", TargetGroupArn:{Ref:<TG>} }] }
+ *     DefaultActions:[ <action> ] }
  * ElasticLoadBalancingV2::ListenerRule  : { ListenerArn:{Ref:<Listener>}, Priority,
- *     Conditions:[{ Field:"path-pattern", PathPatternConfig:{ Values:["/api/*"] } }],
- *     Actions:[{ Type:"forward", TargetGroupArn:{Ref:<TG>} }] }
+ *     Conditions:[{ Field:"path-pattern", PathPatternConfig:{ Values:["/api/*"] } },
+ *                 { Field:"host-header",  HostHeaderConfig:{ Values:["api.example.com"] } }],
+ *     Actions:[ <action> ] }
  * ElasticLoadBalancingV2::TargetGroup   : { Port, Protocol, TargetType:"ip" }
  * ECS::Service.LoadBalancers[]          -> { ContainerName, ContainerPort, TargetGroupArn:{Ref:<TG>} }
  * ```
  *
+ * Each `<action>` is one of:
+ *   - `forward` — `{ Type:"forward", TargetGroupArn:{Ref} }` (single target) OR
+ *     `{ Type:"forward", ForwardConfig:{ TargetGroups:[{ TargetGroupArn:{Ref}, Weight }] } }`
+ *     (one or more weighted targets);
+ *   - `redirect` — `{ Type:"redirect", RedirectConfig:{ Protocol/Host/Port/Path/Query/StatusCode } }`;
+ *   - `fixed-response` — `{ Type:"fixed-response", FixedResponseConfig:{ StatusCode/ContentType/MessageBody } }`.
+ *
  * Resolution walks ALB -> listeners (by `LoadBalancerArn` Ref) -> their default
- * `forward` action AND any `path-pattern` ListenerRules -> the ECS Service whose
+ * action AND any ListenerRules -> for each `forward`, the ECS Service whose
  * `LoadBalancers[]` references each target group (a reverse scan; there is no
  * direct TG -> service pointer). Output is a per-listener routing table: a
- * default forward target (when the default action is a resolvable forward) plus
- * the ordered path-pattern rules.
+ * default action plus the ordered rules, each carrying its resolved action and
+ * its path / host conditions.
  *
- * Scope: HTTP listeners, `path-pattern` conditions, single-target `forward`
- * actions to ECS services. Skipped with a warning: HTTPS/TLS listeners,
- * `TargetType:"lambda"` target groups, weighted (multi-target) forwards, rules
- * with non-`path-pattern` conditions (host-header / http-header / query-string
- * / etc.), and `redirect` / `fixed-response` / `authenticate-*` actions. Those
- * remaining listener-rule features are tracked in #123.
+ * Scope: HTTP listeners; `path-pattern` + `host-header` conditions; `forward`
+ * (single or weighted) to ECS services; `redirect` / `fixed-response` actions.
+ * Skipped with a warning: HTTPS/TLS listeners, `TargetType:"lambda"` target
+ * groups, the other condition fields (http-header / http-request-method /
+ * query-string / source-ip), and `authenticate-cognito` / `authenticate-oidc`
+ * actions. Those remaining listener-rule features are tracked in #123.
  */
 
 const ALB_TYPE = 'AWS::ElasticLoadBalancingV2::LoadBalancer';
@@ -43,7 +51,7 @@ const LISTENER_RULE_TYPE = 'AWS::ElasticLoadBalancingV2::ListenerRule';
 const TARGET_GROUP_TYPE = 'AWS::ElasticLoadBalancingV2::TargetGroup';
 const SERVICE_TYPE = 'AWS::ECS::Service';
 
-/** The backing (service, container) a listener action forwards to. */
+/** The backing (service, container) one forward target group routes to, plus its weight. */
 export interface FrontDoorForwardTarget {
   /** Logical id of the `AWS::ECS::Service` behind the target group. */
   serviceLogicalId: string;
@@ -53,19 +61,68 @@ export interface FrontDoorForwardTarget {
   targetContainerPort: number;
   /** Logical id of the resolved target group (diagnostics). */
   targetGroupLogicalId: string;
+  /**
+   * Forward weight for weighted routing. A single-target forward defaults to 1;
+   * a `ForwardConfig.TargetGroups[]` entry carries its declared `Weight`
+   * (weight 0 means "never routed", per ALB semantics).
+   */
+  weight: number;
 }
 
-/** One resolved path-pattern routing rule on a listener. */
+/** A resolved `redirect` action (ALB builds a `Location` from these + request placeholders). */
+export interface FrontDoorRedirectAction {
+  kind: 'redirect';
+  /** HTTP status (301 permanent / 302 found). ALB emits `HTTP_301` / `HTTP_302`. */
+  statusCode: 301 | 302;
+  /** `#{protocol}` (default) / `HTTP` / `HTTPS`. */
+  protocol?: string;
+  /** `#{host}` (default) or a literal host. */
+  host?: string;
+  /** `#{port}` (default) or a literal port. */
+  port?: string;
+  /** `/#{path}` (default) or a literal path; ALB requires a leading `/`. */
+  path?: string;
+  /** `#{query}` (default) or a literal query (without the leading `?`). */
+  query?: string;
+}
+
+/** A resolved `fixed-response` action (ALB synthesizes the whole response). */
+export interface FrontDoorFixedResponseAction {
+  kind: 'fixed-response';
+  /** HTTP status code (ALB stores it as a numeric string, e.g. `"404"`). */
+  statusCode: number;
+  /** Response `Content-Type` (defaults to `text/plain` when absent). */
+  contentType?: string;
+  /** Response body (empty when absent). */
+  messageBody?: string;
+}
+
+/** A resolved `forward` action: one or more weighted ECS-service targets. */
+export interface FrontDoorForwardAction {
+  kind: 'forward';
+  /** The weighted forward targets (length >= 1; single-target forward = one entry, weight 1). */
+  targets: FrontDoorForwardTarget[];
+}
+
+/** Any resolved listener / rule action the local front-door can serve. */
+export type ResolvedListenerAction =
+  | FrontDoorForwardAction
+  | FrontDoorRedirectAction
+  | FrontDoorFixedResponseAction;
+
+/** One resolved routing rule on a listener (path / host conditions + an action). */
 export interface ResolvedListenerRule {
   /** ALB rule priority (lower = evaluated first). */
   priority: number;
-  /** The rule's `path-pattern` condition values (OR-matched). */
+  /** The rule's `path-pattern` condition values (OR-matched; empty = no path constraint). */
   pathPatterns: string[];
-  /** The backing forward target this rule routes to. */
-  target: FrontDoorForwardTarget;
+  /** The rule's `host-header` condition values (OR-matched; empty = no host constraint). */
+  hostPatterns: string[];
+  /** The action this rule performs when its conditions match. */
+  action: ResolvedListenerAction;
 }
 
-/** A resolved listener front-door: one host port, an optional default target + path rules. */
+/** A resolved listener front-door: one host port, an optional default action + rules. */
 export interface ResolvedListenerFrontDoor {
   /** Listener port declared on the ALB (the stable host endpoint port). */
   listenerPort: number;
@@ -74,13 +131,13 @@ export interface ResolvedListenerFrontDoor {
   /** Logical id of the listener (diagnostics). */
   listenerLogicalId: string;
   /**
-   * Default-action forward target. Present when the listener's `DefaultActions`
-   * is a resolvable single `forward` to an ECS service; absent when the default
-   * is a `fixed-response` / `redirect` (a rules-only listener) — unmatched
-   * requests then get a 404 from the front-door.
+   * Default action. Present when the listener's `DefaultActions` is a resolvable
+   * forward / redirect / fixed-response; absent only when every default action
+   * was skipped (e.g. an authenticate-* default) — unmatched requests then get
+   * a 404 from the front-door.
    */
-  defaultTarget?: FrontDoorForwardTarget;
-  /** Path-pattern rules (unordered here; the matcher evaluates by priority). */
+  defaultAction?: ResolvedListenerAction;
+  /** Rules (unordered here; the matcher evaluates by priority). */
   rules: ResolvedListenerRule[];
 }
 
@@ -127,7 +184,7 @@ export function resolveAlbFrontDoor(
       continue;
     }
 
-    const defaultTarget = resolveForwardTarget(
+    const defaultAction = resolveAction(
       props['DefaultActions'],
       resources,
       tgToService,
@@ -140,17 +197,22 @@ export function resolveAlbFrontDoor(
     for (const { ruleLogicalId, ruleProps } of rulesByListener.get(listenerLogicalId) ?? []) {
       const priority = parsePriority(ruleProps['Priority']);
       const ruleLabel = `Listener rule '${ruleLogicalId}' (priority ${priority})`;
-      const { patterns, unsupported } = parseRulePathPatterns(ruleProps['Conditions']);
+      const { pathPatterns, hostPatterns, unsupported } = parseRuleConditions(
+        ruleProps['Conditions']
+      );
       if (unsupported.length > 0) {
         warnings.push(
           `${ruleLabel} uses unsupported condition(s): ${unsupported.join(', ')}. The local ALB ` +
-            'front-door supports path-pattern conditions only (host-header / http-header / ' +
+            'front-door supports path-pattern and host-header conditions only (http-header / ' +
             'query-string / http-request-method / source-ip deferred). Skipping it.'
         );
         continue;
       }
-      if (patterns.length === 0) continue; // no path-pattern values to route on
-      const target = resolveForwardTarget(
+      if (pathPatterns.length === 0 && hostPatterns.length === 0) {
+        // No supported condition to route on (an empty / catch-all rule).
+        continue;
+      }
+      const action = resolveAction(
         ruleProps['Actions'],
         resources,
         tgToService,
@@ -158,13 +220,13 @@ export function resolveAlbFrontDoor(
         `${ruleLabel} action`,
         warnings
       );
-      if (!target) continue; // resolveForwardTarget already warned
-      rules.push({ priority, pathPatterns: patterns, target });
+      if (!action) continue; // resolveAction already warned (or it was an authenticate-* action)
+      rules.push({ priority, pathPatterns, hostPatterns, action });
     }
 
-    if (!defaultTarget && rules.length === 0) {
-      // The listener forwards to nothing cdk-local can serve (e.g. a
-      // redirect-only listener, or every action was skipped above).
+    if (!defaultAction && rules.length === 0) {
+      // The listener serves nothing cdk-local can route (e.g. an authenticate-*
+      // default and every rule skipped above).
       continue;
     }
 
@@ -172,7 +234,7 @@ export function resolveAlbFrontDoor(
       listenerPort: port,
       listenerProtocol: 'HTTP',
       listenerLogicalId,
-      ...(defaultTarget ? { defaultTarget } : {}),
+      ...(defaultAction ? { defaultAction } : {}),
       rules,
     });
   }
@@ -195,23 +257,73 @@ interface BackingServiceRef {
 }
 
 /**
- * Resolve a listener / rule `Actions` (or `DefaultActions`) array to a single
- * ECS-service forward target, or `undefined` when it is not a resolvable
- * single forward (warning emitted for the cases worth surfacing).
+ * Resolve a listener / rule `Actions` (or `DefaultActions`) array to the single
+ * action the local front-door serves, or `undefined` when it is not resolvable
+ * (a warning is emitted for the cases worth surfacing). ALB allows exactly one
+ * non-authenticate terminal action per action set, optionally preceded by
+ * authenticate-* actions (which the local front-door does not enforce — they
+ * are skipped with a warning and the terminal action is honored).
  */
-function resolveForwardTarget(
+function resolveAction(
   actions: unknown,
   resources: Record<string, TemplateResource>,
   tgToService: Map<string, BackingServiceRef>,
   stackName: string,
   label: string,
   warnings: string[]
-): FrontDoorForwardTarget | undefined {
-  const tgRefs = collectForwardTargetGroupRefs(actions);
-  if (tgRefs.size === 0) {
-    // No forward at all (redirect / fixed-response — silent) or a non-Ref
-    // forward we cannot resolve to an in-stack target group (worth a warning).
-    if (hasUnresolvableForward(actions)) {
+): ResolvedListenerAction | undefined {
+  if (!Array.isArray(actions)) return undefined;
+
+  let sawAuthenticate = false;
+  for (const action of actions) {
+    if (!action || typeof action !== 'object') continue;
+    const a = action as Record<string, unknown>;
+    const type = a['Type'];
+
+    if (type === 'authenticate-cognito' || type === 'authenticate-oidc') {
+      sawAuthenticate = true;
+      continue;
+    }
+    if (type === 'forward') {
+      return resolveForwardAction(a, resources, tgToService, stackName, label, warnings);
+    }
+    if (type === 'redirect') {
+      const redirect = resolveRedirectAction(a, label, warnings);
+      if (redirect) return redirect;
+      continue;
+    }
+    if (type === 'fixed-response') {
+      return resolveFixedResponseAction(a);
+    }
+    if (typeof type === 'string') {
+      warnings.push(
+        `${label} uses an unsupported action type '${type}'. The local ALB front-door supports ` +
+          'forward / redirect / fixed-response actions only. Skipping it.'
+      );
+    }
+  }
+
+  if (sawAuthenticate) {
+    warnings.push(
+      `${label} is an authenticate-* action with no local-servable terminal action. The local ALB ` +
+        'front-door does not enforce authenticate-cognito / authenticate-oidc; skipping it.'
+    );
+  }
+  return undefined;
+}
+
+/** Resolve a `forward` action into one or more weighted ECS-service targets. */
+function resolveForwardAction(
+  action: Record<string, unknown>,
+  resources: Record<string, TemplateResource>,
+  tgToService: Map<string, BackingServiceRef>,
+  stackName: string,
+  label: string,
+  warnings: string[]
+): FrontDoorForwardAction | undefined {
+  const refs = collectForwardTargetGroupRefs(action);
+  if (refs.length === 0) {
+    if (hasUnresolvableForward(action)) {
       warnings.push(
         `${label} forwards to a non-Ref TargetGroupArn (literal / cross-stack / imported); the ` +
           'local front-door only supports in-stack target groups. Skipping it.'
@@ -219,45 +331,80 @@ function resolveForwardTarget(
     }
     return undefined;
   }
-  if (tgRefs.size > 1) {
-    warnings.push(
-      `${label} is a weighted forward (multiple target groups); the local front-door supports a ` +
-        'single target group per action (weighted routing deferred). Skipping it.'
-    );
+
+  const targets: FrontDoorForwardTarget[] = [];
+  for (const { tgRef, weight } of refs) {
+    const tg = resources[tgRef];
+    if (!tg || tg.Type !== TARGET_GROUP_TYPE) {
+      warnings.push(
+        `${label} forwards to target group '${tgRef}', but no ${TARGET_GROUP_TYPE} with that ` +
+          `logical id exists in ${stackName}. Skipping that target group.`
+      );
+      continue;
+    }
+    const tgType = (tg.Properties as Record<string, unknown> | undefined)?.['TargetType'];
+    if (tgType === 'lambda') {
+      warnings.push(
+        `${label} forwards to a Lambda target group '${tgRef}' (TargetType: lambda). The local ALB ` +
+          'front-door supports ECS targets only; Lambda targets are deferred. Skipping that target group.'
+      );
+      continue;
+    }
+    const backing = tgToService.get(tgRef);
+    if (!backing) {
+      warnings.push(
+        `${label} forwards to target group '${tgRef}', which is not referenced by any ` +
+          `${SERVICE_TYPE}.LoadBalancers[] in ${stackName}; cdk-local has no ECS service to front ` +
+          'behind it. Skipping that target group.'
+      );
+      continue;
+    }
+    targets.push({
+      serviceLogicalId: backing.serviceLogicalId,
+      targetContainerName: backing.containerName,
+      targetContainerPort: backing.containerPort,
+      targetGroupLogicalId: tgRef,
+      weight,
+    });
+  }
+
+  if (targets.length === 0) return undefined; // every target group was skipped (already warned)
+  return { kind: 'forward', targets };
+}
+
+/** Resolve a `redirect` action into its `Location`-template fields + status code. */
+function resolveRedirectAction(
+  action: Record<string, unknown>,
+  label: string,
+  warnings: string[]
+): FrontDoorRedirectAction | undefined {
+  const cfg = action['RedirectConfig'];
+  if (!cfg || typeof cfg !== 'object') {
+    warnings.push(`${label} is a redirect with no RedirectConfig; skipping it.`);
     return undefined;
   }
-  const tgRef = [...tgRefs][0]!;
-  const tg = resources[tgRef];
-  if (!tg || tg.Type !== TARGET_GROUP_TYPE) {
-    warnings.push(
-      `${label} forwards to target group '${tgRef}', but no ${TARGET_GROUP_TYPE} with that logical ` +
-        `id exists in ${stackName}. Skipping it.`
-    );
-    return undefined;
-  }
-  const tgType = (tg.Properties as Record<string, unknown> | undefined)?.['TargetType'];
-  if (tgType === 'lambda') {
-    warnings.push(
-      `${label} forwards to a Lambda target group '${tgRef}' (TargetType: lambda). The local ALB ` +
-        'front-door supports ECS targets only; Lambda targets are deferred. Skipping it.'
-    );
-    return undefined;
-  }
-  const backing = tgToService.get(tgRef);
-  if (!backing) {
-    warnings.push(
-      `${label} forwards to target group '${tgRef}', which is not referenced by any ` +
-        `${SERVICE_TYPE}.LoadBalancers[] in ${stackName}; cdk-local has no ECS service to front ` +
-        'behind it. Skipping it.'
-    );
-    return undefined;
-  }
-  return {
-    serviceLogicalId: backing.serviceLogicalId,
-    targetContainerName: backing.containerName,
-    targetContainerPort: backing.containerPort,
-    targetGroupLogicalId: tgRef,
-  };
+  const c = cfg as Record<string, unknown>;
+  const statusCode = parseRedirectStatusCode(c['StatusCode']);
+  const out: FrontDoorRedirectAction = { kind: 'redirect', statusCode };
+  if (typeof c['Protocol'] === 'string') out.protocol = c['Protocol'];
+  if (typeof c['Host'] === 'string') out.host = c['Host'];
+  if (typeof c['Port'] === 'string') out.port = c['Port'];
+  if (typeof c['Path'] === 'string') out.path = c['Path'];
+  if (typeof c['Query'] === 'string') out.query = c['Query'];
+  return out;
+}
+
+/** Resolve a `fixed-response` action into its status / content-type / body. */
+function resolveFixedResponseAction(
+  action: Record<string, unknown>
+): FrontDoorFixedResponseAction | undefined {
+  const cfg = action['FixedResponseConfig'];
+  const c = cfg && typeof cfg === 'object' ? (cfg as Record<string, unknown>) : {};
+  const statusCode = parseFixedResponseStatusCode(c['StatusCode']);
+  const out: FrontDoorFixedResponseAction = { kind: 'fixed-response', statusCode };
+  if (typeof c['ContentType'] === 'string') out.contentType = c['ContentType'];
+  if (typeof c['MessageBody'] === 'string') out.messageBody = c['MessageBody'];
+  return out;
 }
 
 /**
@@ -307,82 +454,91 @@ function indexRulesByListener(
 }
 
 /**
- * Parse a ListenerRule's `Conditions` into its `path-pattern` values plus the
- * field names of any non-`path-pattern` conditions (which make the rule
- * unsupported in this version). A rule is only usable when every condition is a
- * `path-pattern` — ALB ANDs conditions together, and we cannot honor the others
- * locally yet.
+ * Parse a ListenerRule's `Conditions` into its supported `path-pattern` and
+ * `host-header` values plus the field names of any unsupported conditions
+ * (which make the rule unsupported). ALB ANDs conditions of different fields,
+ * so a rule with an unsupported field cannot be honored locally. Multiple
+ * conditions of the same field merge their values (each field OR-matches).
  */
-function parseRulePathPatterns(conditions: unknown): { patterns: string[]; unsupported: string[] } {
-  const patterns: string[] = [];
+function parseRuleConditions(conditions: unknown): {
+  pathPatterns: string[];
+  hostPatterns: string[];
+  unsupported: string[];
+} {
+  const pathPatterns: string[] = [];
+  const hostPatterns: string[] = [];
   const unsupported: string[] = [];
-  if (!Array.isArray(conditions)) return { patterns, unsupported };
+  if (!Array.isArray(conditions)) return { pathPatterns, hostPatterns, unsupported };
   for (const cond of conditions) {
     if (!cond || typeof cond !== 'object') continue;
     const c = cond as Record<string, unknown>;
     const field = typeof c['Field'] === 'string' ? c['Field'] : '(unknown)';
-    if (field !== 'path-pattern') {
+    if (field === 'path-pattern') {
+      pathPatterns.push(...conditionValues(c, 'PathPatternConfig'));
+    } else if (field === 'host-header') {
+      hostPatterns.push(...conditionValues(c, 'HostHeaderConfig'));
+    } else {
       unsupported.push(field);
-      continue;
-    }
-    const cfg = c['PathPatternConfig'];
-    const values =
-      cfg && typeof cfg === 'object' && Array.isArray((cfg as Record<string, unknown>)['Values'])
-        ? ((cfg as Record<string, unknown>)['Values'] as unknown[])
-        : Array.isArray(c['Values'])
-          ? (c['Values'] as unknown[])
-          : [];
-    for (const v of values) if (typeof v === 'string') patterns.push(v);
-  }
-  return { patterns, unsupported };
-}
-
-function collectForwardTargetGroupRefs(actions: unknown): Set<string> {
-  const refs = new Set<string>();
-  if (!Array.isArray(actions)) return refs;
-  for (const action of actions) {
-    if (!action || typeof action !== 'object') continue;
-    const a = action as Record<string, unknown>;
-    if (a['Type'] !== 'forward') continue;
-    const direct = refOf(a['TargetGroupArn']);
-    if (direct) refs.add(direct);
-    const forwardConfig = a['ForwardConfig'];
-    if (forwardConfig && typeof forwardConfig === 'object') {
-      const groups = (forwardConfig as Record<string, unknown>)['TargetGroups'];
-      if (Array.isArray(groups)) {
-        for (const g of groups) {
-          if (!g || typeof g !== 'object') continue;
-          const ref = refOf((g as Record<string, unknown>)['TargetGroupArn']);
-          if (ref) refs.add(ref);
-        }
-      }
     }
   }
-  return refs;
+  return { pathPatterns, hostPatterns, unsupported };
 }
 
 /**
- * True when `actions` has at least one `forward` action that references a target
- * group via a NON-`Ref` arn (literal / `Fn::GetAtt` / cross-stack) — i.e. a
- * forward we could not resolve to an in-stack target group. Used to warn rather
- * than silently skip such a listener / rule.
+ * Extract a condition's string values from either the typed `<Field>Config`
+ * sub-object's `Values` or the legacy top-level `Values` array.
  */
-function hasUnresolvableForward(actions: unknown): boolean {
-  if (!Array.isArray(actions)) return false;
-  for (const action of actions) {
-    if (!action || typeof action !== 'object') continue;
-    const a = action as Record<string, unknown>;
-    if (a['Type'] !== 'forward') continue;
-    if (a['TargetGroupArn'] !== undefined && refOf(a['TargetGroupArn']) === undefined) return true;
-    const forwardConfig = a['ForwardConfig'];
-    if (forwardConfig && typeof forwardConfig === 'object') {
-      const groups = (forwardConfig as Record<string, unknown>)['TargetGroups'];
-      if (Array.isArray(groups)) {
-        for (const g of groups) {
-          if (!g || typeof g !== 'object') continue;
-          const arn = (g as Record<string, unknown>)['TargetGroupArn'];
-          if (arn !== undefined && refOf(arn) === undefined) return true;
-        }
+function conditionValues(cond: Record<string, unknown>, configKey: string): string[] {
+  const cfg = cond[configKey];
+  const raw =
+    cfg && typeof cfg === 'object' && Array.isArray((cfg as Record<string, unknown>)['Values'])
+      ? ((cfg as Record<string, unknown>)['Values'] as unknown[])
+      : Array.isArray(cond['Values'])
+        ? (cond['Values'] as unknown[])
+        : [];
+  return raw.filter((v): v is string => typeof v === 'string');
+}
+
+/** Collect a forward action's `(targetGroupRef, weight)` pairs (single + ForwardConfig forms). */
+function collectForwardTargetGroupRefs(
+  action: Record<string, unknown>
+): Array<{ tgRef: string; weight: number }> {
+  const out: Array<{ tgRef: string; weight: number }> = [];
+  const direct = refOf(action['TargetGroupArn']);
+  if (direct) out.push({ tgRef: direct, weight: 1 });
+  const forwardConfig = action['ForwardConfig'];
+  if (forwardConfig && typeof forwardConfig === 'object') {
+    const groups = (forwardConfig as Record<string, unknown>)['TargetGroups'];
+    if (Array.isArray(groups)) {
+      for (const g of groups) {
+        if (!g || typeof g !== 'object') continue;
+        const gObj = g as Record<string, unknown>;
+        const ref = refOf(gObj['TargetGroupArn']);
+        if (ref) out.push({ tgRef: ref, weight: parseWeight(gObj['Weight']) });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * True when `action` is a `forward` that references a target group via a
+ * NON-`Ref` arn (literal / `Fn::GetAtt` / cross-stack) — i.e. a forward we
+ * could not resolve to an in-stack target group. Used to warn rather than
+ * silently skip.
+ */
+function hasUnresolvableForward(action: Record<string, unknown>): boolean {
+  if (action['TargetGroupArn'] !== undefined && refOf(action['TargetGroupArn']) === undefined) {
+    return true;
+  }
+  const forwardConfig = action['ForwardConfig'];
+  if (forwardConfig && typeof forwardConfig === 'object') {
+    const groups = (forwardConfig as Record<string, unknown>)['TargetGroups'];
+    if (Array.isArray(groups)) {
+      for (const g of groups) {
+        if (!g || typeof g !== 'object') continue;
+        const arn = (g as Record<string, unknown>)['TargetGroupArn'];
+        if (arn !== undefined && refOf(arn) === undefined) return true;
       }
     }
   }
@@ -408,6 +564,30 @@ function parsePort(raw: unknown): number | undefined {
 
 function parseContainerPort(raw: unknown): number | undefined {
   return parsePort(raw);
+}
+
+/**
+ * Parse a `ForwardConfig.TargetGroups[].Weight`. ALB weights are 0-999; a
+ * missing weight defaults to 1 (CDK's `weightedForward` always emits one, but
+ * a hand-rolled template may omit it). Negative / non-numeric clamps to 0.
+ */
+function parseWeight(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw < 0 ? 0 : raw;
+  if (typeof raw === 'string' && /^\d+$/.test(raw)) return parseInt(raw, 10);
+  return 1;
+}
+
+/** ALB emits redirect status as `HTTP_301` / `HTTP_302`; default to 302 when absent / unknown. */
+function parseRedirectStatusCode(raw: unknown): 301 | 302 {
+  if (raw === 'HTTP_301' || raw === '301' || raw === 301) return 301;
+  return 302;
+}
+
+/** Parse a `FixedResponseConfig.StatusCode` (a numeric string); default 200 when absent. */
+function parseFixedResponseStatusCode(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isInteger(raw)) return raw;
+  if (typeof raw === 'string' && /^\d+$/.test(raw)) return parseInt(raw, 10);
+  return 200;
 }
 
 /**

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -182,13 +182,13 @@ function handleProxyRequest(
       return;
     }
 
-    if (action.kind === 'redirect') {
-      writeRedirect(res, action, req, opts.listenerPort);
-      resolve();
-      return;
-    }
-    if (action.kind === 'fixed-response') {
-      writeFixedResponse(res, action);
+    if (action.kind === 'redirect' || action.kind === 'fixed-response') {
+      // Drain any request body (ALB serves redirect / fixed-response for every
+      // method, incl. POST) so an unconsumed body doesn't stall HTTP/1.1
+      // keep-alive socket reuse, then synthesize the response with no backend.
+      req.resume();
+      if (action.kind === 'redirect') writeRedirect(res, action, req, opts.listenerPort);
+      else writeFixedResponse(res, action);
       resolve();
       return;
     }

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -10,35 +10,84 @@ import type { FrontDoorEndpointPool } from './front-door-pool.js';
 
 /**
  * Host-side ALB front-door. A plain HTTP reverse proxy bound to the ALB's
- * declared listener port that, per request, selects a live replica pool
- * (`FrontDoorEndpointPool`) and round-robins across it. Mirrors the
- * `startApiServer` lifecycle in `http-server.ts` (createServer + setNoDelay +
- * listen + close/closeAllConnections).
+ * declared listener port that, per request, resolves a {@link RouteAction} and
+ * serves it: a `forward` action round-robins a (weighted) replica pool set, a
+ * `redirect` answers a 301 / 302 with a synthesized `Location`, and a
+ * `fixed-response` answers a synthesized status / body — mirroring what a real
+ * ALB does for the matched rule / default action. Lifecycle mirrors
+ * `startApiServer` in `http-server.ts`.
  *
- * Pool selection is delegated to {@link StartFrontDoorServerOptions.selectPool}:
- *   - single default-forward listener -> a constant pool for every request;
- *   - a listener with `path-pattern` rules -> the matched rule's pool, falling
- *     back to the default-action pool (`undefined` when neither matches, which
- *     the proxy answers with 404 — like an ALB rule miss with no default).
+ * Route selection is delegated to {@link StartFrontDoorServerOptions.route},
+ * which receives the request path AND its `Host` header (host-header rules need
+ * the latter):
+ *   - single default-forward listener -> a constant `forward` action;
+ *   - a listener with rules -> the matched rule's action, falling back to the
+ *     default action (`undefined` when neither matches, which the proxy answers
+ *     with 404 — like an ALB rule miss with no default).
  *
  * The replicas publish their target container port on ephemeral host ports
  * (the daemon-in-a-VM reality on macOS means the host can't reach container
  * IPs directly), so the proxy forwards to `127.0.0.1:<ephemeralPort>` rather
  * than to docker-network addresses — cross-platform by construction.
  *
- * Scope: per-request round-robin, HTTP only, `path-pattern` rule routing. No
- * host-header / weighted routing, no health-check-gated draining, no sticky
- * sessions, no websocket `Upgrade` proxying, no TLS termination (tracked in
- * #123).
+ * Scope: per-request round-robin + weighted forward, redirect / fixed-response
+ * synthesis, HTTP only, `path-pattern` + `host-header` rule routing. No
+ * health-check-gated draining, no sticky sessions, no websocket `Upgrade`
+ * proxying, no TLS termination (tracked in #123).
  */
+
+/** One weighted member of a forward action's pool set. */
+export interface WeightedPool {
+  /** The live-replica pool for one (service, container, port) target group. */
+  pool: FrontDoorEndpointPool;
+  /** Forward weight (>= 0; weight 0 is never selected, per ALB semantics). */
+  weight: number;
+}
+
+/** A resolved forward action: pick a pool by weight, then round-robin its replicas. */
+export interface ForwardRouteAction {
+  kind: 'forward';
+  /** Weighted pools (length >= 1; a single-target forward is one entry, weight 1). */
+  pools: WeightedPool[];
+}
+
+/** A resolved redirect action: synthesize a 301 / 302 with a `Location` header. */
+export interface RedirectRouteAction {
+  kind: 'redirect';
+  statusCode: 301 | 302;
+  protocol?: string;
+  host?: string;
+  port?: string;
+  path?: string;
+  query?: string;
+}
+
+/** A resolved fixed-response action: synthesize the whole response. */
+export interface FixedResponseRouteAction {
+  kind: 'fixed-response';
+  statusCode: number;
+  contentType?: string;
+  messageBody?: string;
+}
+
+/** What the front-door does for a request: forward / redirect / fixed-response. */
+export type RouteAction = ForwardRouteAction | RedirectRouteAction | FixedResponseRouteAction;
+
+/** The request facts the route resolver is handed (path + Host header). */
+export interface FrontDoorRouteRequest {
+  /** Request URL (path + query); the matcher strips the query for path-pattern. */
+  path: string;
+  /** Request `Host` header (for host-header rule matching). */
+  host?: string;
+}
 
 export interface StartFrontDoorServerOptions {
   /**
-   * Choose the replica pool to serve a request from, given its URL path.
+   * Resolve the action to serve a request, given its path + Host header.
    * Returns `undefined` when no rule matched and there is no default action
    * (the proxy then replies 404).
    */
-  selectPool: (requestPath: string) => FrontDoorEndpointPool | undefined;
+  route: (req: FrontDoorRouteRequest) => RouteAction | undefined;
   /** Host port to bind (the listener port, or its `--lb-port` override). */
   port: number;
   /** Host interface to bind. Defaults to `127.0.0.1`. */
@@ -118,15 +167,40 @@ function handleProxyRequest(
   opts: StartFrontDoorServerOptions
 ): Promise<void> {
   return new Promise<void>((resolve) => {
-    const pool = opts.selectPool(req.url ?? '/');
-    if (!pool) {
+    const url = req.url ?? '/';
+    const action = opts.route({ path: url, ...hostHeader(req) });
+    if (!action) {
       // No rule matched and no default action — mirror an ALB listener with no
       // matching rule and no default (404).
       writeError(
         res,
         404,
-        `No listener rule matched '${req.url ?? '/'}' on ${opts.label}, and the listener has no ` +
+        `No listener rule matched '${url}' on ${opts.label}, and the listener has no ` +
           'default action forwarding to a local target.'
+      );
+      resolve();
+      return;
+    }
+
+    if (action.kind === 'redirect') {
+      writeRedirect(res, action, req, opts.listenerPort);
+      resolve();
+      return;
+    }
+    if (action.kind === 'fixed-response') {
+      writeFixedResponse(res, action);
+      resolve();
+      return;
+    }
+
+    const pool = pickWeightedPool(action.pools);
+    if (!pool) {
+      // Every pool has weight 0 (or none) — mirror an ALB whose rule forwards
+      // nowhere usable (502, like a misconfigured forward).
+      writeError(
+        res,
+        502,
+        `No forward target selected behind ${opts.label} (every weighted target has weight 0).`
       );
       resolve();
       return;
@@ -218,6 +292,119 @@ function handleProxyRequest(
 
     req.pipe(proxyReq);
   });
+}
+
+/** Extract the request `Host` header (string) for host-header rule matching. */
+function hostHeader(req: IncomingMessage): { host?: string } {
+  const raw = req.headers.host;
+  const host = Array.isArray(raw) ? raw[0] : raw;
+  return host ? { host } : {};
+}
+
+/**
+ * Pick one pool from a weighted set: weighted random over the non-zero weights.
+ * A single-entry set short-circuits to that pool. Returns `undefined` when
+ * every weight is 0 (an ALB-valid but un-routable forward).
+ */
+export function pickWeightedPool(
+  pools: readonly WeightedPool[]
+): FrontDoorEndpointPool | undefined {
+  if (pools.length === 0) return undefined;
+  if (pools.length === 1) return pools[0]!.weight > 0 ? pools[0]!.pool : undefined;
+  const total = pools.reduce((sum, p) => sum + Math.max(0, p.weight), 0);
+  if (total <= 0) return undefined;
+  let roll = Math.random() * total;
+  for (const p of pools) {
+    const w = Math.max(0, p.weight);
+    if (w === 0) continue;
+    roll -= w;
+    if (roll < 0) return p.pool;
+  }
+  // Floating-point edge: roll landed exactly at the total. Return the last
+  // non-zero-weight pool.
+  for (let i = pools.length - 1; i >= 0; i--) {
+    if (Math.max(0, pools[i]!.weight) > 0) return pools[i]!.pool;
+  }
+  return undefined;
+}
+
+/**
+ * Synthesize an ALB-style redirect (301 / 302). ALB builds the `Location` from
+ * the action fields with `#{protocol}` / `#{host}` / `#{port}` / `#{path}` /
+ * `#{query}` placeholders filled from the incoming request. We resolve those
+ * placeholders against the request the front-door received.
+ */
+function writeRedirect(
+  res: ServerResponse,
+  action: RedirectRouteAction,
+  req: IncomingMessage,
+  listenerPort: number
+): void {
+  const location = buildRedirectLocation(action, req, listenerPort);
+  res.writeHead(action.statusCode, {
+    location,
+    'content-type': 'text/plain; charset=utf-8',
+    'content-length': '0',
+  });
+  res.end();
+}
+
+/** Build the `Location` URL for a redirect action, resolving ALB `#{...}` placeholders. */
+export function buildRedirectLocation(
+  action: RedirectRouteAction,
+  req: { url?: string | undefined; headers: NodeJS.Dict<string | string[]> },
+  listenerPort: number
+): string {
+  const url = req.url ?? '/';
+  const qIndex = url.indexOf('?');
+  const reqPath = qIndex === -1 ? url : url.slice(0, qIndex);
+  const reqQuery = qIndex === -1 ? '' : url.slice(qIndex + 1);
+  const rawHost = req.headers['host'];
+  const hostHeaderValue = Array.isArray(rawHost) ? rawHost[0] : rawHost;
+  const reqHostName = (hostHeaderValue ?? '').split(':')[0] ?? '';
+
+  const placeholders: Record<string, string> = {
+    protocol: 'http',
+    host: reqHostName,
+    port: String(listenerPort),
+    path: reqPath.replace(/^\//, ''), // ALB's #{path} excludes the leading slash
+    query: reqQuery,
+  };
+  const fill = (template: string): string =>
+    template.replace(
+      /#\{(protocol|host|port|path|query)\}/g,
+      (_m, key: string) => placeholders[key] ?? ''
+    );
+
+  const protocol = (
+    action.protocol ? fill(action.protocol) : placeholders['protocol']!
+  ).toLowerCase();
+  const host = action.host ? fill(action.host) : placeholders['host']!;
+  const port = action.port ? fill(action.port) : placeholders['port']!;
+  // ALB Path defaults to `/#{path}`; it always starts with a `/`.
+  const pathTemplate = action.path ?? '/#{path}';
+  const path = fill(pathTemplate);
+  const queryTemplate = action.query ?? '#{query}';
+  const query = fill(queryTemplate);
+
+  // Omit the port when it is the protocol default (80/http, 443/https), matching
+  // how an ALB-built Location reads.
+  const isDefaultPort =
+    (protocol === 'http' && port === '80') || (protocol === 'https' && port === '443');
+  const authority = isDefaultPort || port === '' ? host : `${host}:${port}`;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const queryPart = query ? `?${query}` : '';
+  return `${protocol}://${authority}${normalizedPath}${queryPart}`;
+}
+
+/** Synthesize an ALB-style fixed-response. */
+function writeFixedResponse(res: ServerResponse, action: FixedResponseRouteAction): void {
+  const body = action.messageBody ?? '';
+  res.writeHead(action.statusCode, {
+    'content-type': action.contentType ?? 'text/plain; charset=utf-8',
+    'content-length': String(Buffer.byteLength(body)),
+  });
+  res.end(body);
 }
 
 /** Standard hop-by-hop headers (RFC 7230 §6.1) — a proxy must not forward these. */

--- a/tests/integration/local-start-alb-routing-conditions/bin/app.ts
+++ b/tests/integration/local-start-alb-routing-conditions/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbRoutingConditionsStack } from '../lib/local-start-alb-routing-conditions-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbRoutingConditionsStack(app, 'CdkLocalStartAlbRoutingConditionsFixture', {
+  description:
+    'Fixture stack for cdkl start-alb host-header + fixed-response rule routing integ test (#123)',
+});

--- a/tests/integration/local-start-alb-routing-conditions/cdk.json
+++ b/tests/integration/local-start-alb-routing-conditions/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-routing-conditions/lib/local-start-alb-routing-conditions-stack.ts
+++ b/tests/integration/local-start-alb-routing-conditions/lib/local-start-alb-routing-conditions-stack.ts
@@ -1,0 +1,142 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Construct } from 'constructs';
+
+/**
+ * Fixture for `cdkl start-alb` host-header + fixed-response rule routing
+ * (#123 deferred listener-rule slice).
+ *
+ * Hand-rolls the synthesized shape of an ALB whose single HTTP:80 listener
+ * routes by the request `Host` header across TWO ECS services, with a
+ * fixed-response default action for requests that match neither host. L1
+ * resources keep the fixture VPC-free and deterministic (cdk-local only reads
+ * the template; it never deploys to AWS):
+ *
+ *   - listener DEFAULT action -> `fixed-response` (418, body `default-fixed`)
+ *     so a request whose Host matches no rule gets a synthesized response with
+ *     NO backing pool.
+ *   - `host-header` `api.cdklocal.test` (ListenerRule priority 10) -> `api`
+ *     service (DesiredCount=1), replies `api <hostname>`.
+ *   - `host-header` `web.cdklocal.test` (ListenerRule priority 20) -> `web`
+ *     service (DesiredCount=1), replies `web <hostname>`.
+ *
+ * Each container is a tiny Python HTTP server that replies with
+ * `<role> <hostname>`, so the integ harness can assert that a request with
+ * `Host: api.cdklocal.test` reaches the api service, `Host: web.cdklocal.test`
+ * reaches the web service, and a request with an unmatched Host gets the
+ * fixed-response default (synthesized by the front-door, no proxy).
+ *
+ * Bridge network mode keeps the local exec path simple. The container port is
+ * published on an ephemeral host port per replica; the front-door binds the
+ * listener port (remapped to a non-privileged host port via `--lb-port` in
+ * verify.sh).
+ *
+ * `covers: AWS::ElasticLoadBalancingV2::ListenerRule` (matrix opt-in marker).
+ */
+// chr(10) is a newline in the response body; kept as chr(10) so the program
+// stays a clean newline-joined array (a literal '\n' here would split the line).
+function helloServer(role: string): string {
+  return [
+    'import http.server,socket',
+    'class H(http.server.BaseHTTPRequestHandler):',
+    ' def do_GET(s):',
+    `  b=('${role} '+socket.gethostname()+chr(10)).encode()`,
+    "  s.send_response(200);s.send_header('Content-Length',str(len(b)));s.end_headers();s.wfile.write(b)",
+    ' def log_message(s,*a):pass',
+    "http.server.HTTPServer(('0.0.0.0',80),H).serve_forever()",
+  ].join('\n');
+}
+
+export class LocalStartAlbRoutingConditionsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-alb-routing-conditions-fixture',
+    });
+
+    const mkTask = (logicalId: string, family: string, role: string): ecs.CfnTaskDefinition =>
+      new ecs.CfnTaskDefinition(this, logicalId, {
+        family,
+        networkMode: 'bridge',
+        containerDefinitions: [
+          {
+            name: role,
+            image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+            essential: true,
+            entryPoint: ['python', '-c'],
+            command: [helloServer(role)],
+            memoryReservation: 32,
+            portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+          },
+        ],
+      });
+
+    const webTask = mkTask('WebTask', 'cdkl-start-alb-conditions-web', 'web');
+    const apiTask = mkTask('ApiTask', 'cdkl-start-alb-conditions-api', 'api');
+
+    const webTg = new elbv2.CfnTargetGroup(this, 'WebTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+    const apiTg = new elbv2.CfnTargetGroup(this, 'ApiTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WebLB', { type: 'application' });
+
+    const listener = new elbv2.CfnListener(this, 'WebListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      // Default action: a fixed-response with NO backing pool. A request whose
+      // Host matches neither host-header rule gets this synthesized response.
+      defaultActions: [
+        {
+          type: 'fixed-response',
+          fixedResponseConfig: {
+            statusCode: '418',
+            contentType: 'text/plain',
+            messageBody: 'default-fixed',
+          },
+        },
+      ],
+    });
+
+    // host-header api.cdklocal.test -> api service.
+    new elbv2.CfnListenerRule(this, 'ApiHostRule', {
+      listenerArn: listener.ref,
+      priority: 10,
+      conditions: [{ field: 'host-header', hostHeaderConfig: { values: ['api.cdklocal.test'] } }],
+      actions: [{ type: 'forward', targetGroupArn: apiTg.ref }],
+    });
+
+    // host-header web.cdklocal.test -> web service.
+    new elbv2.CfnListenerRule(this, 'WebHostRule', {
+      listenerArn: listener.ref,
+      priority: 20,
+      conditions: [{ field: 'host-header', hostHeaderConfig: { values: ['web.cdklocal.test'] } }],
+      actions: [{ type: 'forward', targetGroupArn: webTg.ref }],
+    });
+
+    new ecs.CfnService(this, 'WebService', {
+      cluster: cluster.ref,
+      taskDefinition: webTask.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+      loadBalancers: [{ containerName: 'web', containerPort: 80, targetGroupArn: webTg.ref }],
+    });
+
+    new ecs.CfnService(this, 'ApiService', {
+      cluster: cluster.ref,
+      taskDefinition: apiTask.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+      loadBalancers: [{ containerName: 'api', containerPort: 80, targetGroupArn: apiTg.ref }],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-routing-conditions/package.json
+++ b/tests/integration/local-start-alb-routing-conditions/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-alb-routing-conditions",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb host-header + fixed-response rule routing (#123)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-alb-routing-conditions/tsconfig.json
+++ b/tests/integration/local-start-alb-routing-conditions/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-alb-routing-conditions/verify.sh
+++ b/tests/integration/local-start-alb-routing-conditions/verify.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-alb host-header + fixed-response routing integ test
+# (#123 deferred listener-rule slice, no AWS deploy)
+#
+# Names an Application Load Balancer whose single HTTP:80 listener routes by the
+# request Host header across TWO ECS services, with a fixed-response default:
+#   - default action            -> fixed-response 418, body "default-fixed"
+#   - host-header api.cdklocal.test (ListenerRule priority 10) -> api service
+#   - host-header web.cdklocal.test (ListenerRule priority 20) -> web service
+# Asserts:
+#   - The host-side ALB front-door endpoint comes up on the --lb-port host port.
+#   - The host-header rules were logged in the front-door routing table.
+#   - GET / with Host: api.cdklocal.test -> reaches the api service.
+#   - GET / with Host: web.cdklocal.test -> reaches the web service (different svc).
+#   - GET / with an unmatched Host        -> the fixed-response default (418
+#     "default-fixed"), synthesized by the front-door with no backing replica.
+#   - SIGTERM tears every container + network + front-door socket down.
+#
+#     bash tests/integration/local-start-alb-routing-conditions/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+WEB_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
+LB_HOST_PORT=18088 # non-privileged host port the front-door binds (listener port 80 remapped)
+
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers + networks"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${WEB_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+
+echo "==> start-alb: naming the ALB (web + api, DesiredCount=1 each), front-door on host port ${LB_HOST_PORT}"
+# Remap the privileged listener port 80 to a non-privileged host port so the
+# front-door binds without root (the macOS Docker Desktop privileged-port path).
+${CDKL} start-alb CdkLocalStartAlbRoutingConditionsFixture:WebLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 120s)"
+BOOTED=0
+for _ in $(seq 1 120); do
+  if grep -q "Service(s) running:" "${OUT_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: services did not reach the boot banner within 120s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+
+echo "==> Asserting the front-door banner + the host-header rules + fixed-response default were logged"
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_HOST_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: front-door banner for host port ${LB_HOST_PORT} not found"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -q "host api.cdklocal.test" "${OUT_FILE}"; then
+  echo "FAIL: host-header rule 'api.cdklocal.test' not logged in the front-door routing table"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -q "default -> fixed-response 418" "${OUT_FILE}"; then
+  echo "FAIL: fixed-response default action not logged in the front-door routing table"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: front-door banner + host-header rules + fixed-response default present"
+
+echo "==> Asserting the fixed-response default serves immediately (no backing replica needed)"
+# The front-door binds before any replica is up; a fixed-response default needs
+# no pool, so an unmatched-Host request should return 418 "default-fixed" at once.
+FIXED_READY=0
+for _ in $(seq 1 30); do
+  FIXED_CODE=$(curl -s -o /tmp/cdkl-cond-fixed.$$ -w '%{http_code}' \
+    -H 'Host: nomatch.cdklocal.test' "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null || true)
+  if [[ "${FIXED_CODE}" == "418" ]]; then
+    FIXED_READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the fixed-response default"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+FIXED_BODY=$(cat /tmp/cdkl-cond-fixed.$$ 2>/dev/null || true)
+rm -f /tmp/cdkl-cond-fixed.$$
+if [[ "${FIXED_READY}" -ne 1 ]]; then
+  echo "FAIL: unmatched-Host request never returned the fixed-response 418 within 30s (got '${FIXED_CODE}')"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if [[ "${FIXED_BODY}" != "default-fixed" ]]; then
+  echo "FAIL: fixed-response body mismatch (expected 'default-fixed', got '${FIXED_BODY}')"
+  exit 1
+fi
+echo "    OK: unmatched Host -> fixed-response 418 'default-fixed'"
+
+echo "==> curl-ing the api host until a replica answers (replicas take a moment to start)"
+API_READY=0
+API_RESP=""
+for _ in $(seq 1 90); do
+  API_RESP=$(curl -fsS -H 'Host: api.cdklocal.test' "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null || true)
+  if [[ -n "${API_RESP}" ]]; then
+    API_READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the api host to serve"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${API_READY}" -ne 1 ]]; then
+  echo "FAIL: Host: api.cdklocal.test never served a 200 within 90s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    api host response: ${API_RESP}"
+if [[ "${API_RESP}" != api\ * ]]; then
+  echo "FAIL: Host: api.cdklocal.test was not host-routed to the api service (got: ${API_RESP})"
+  exit 1
+fi
+echo "    OK: Host: api.cdklocal.test host-routed to the api service"
+
+echo "==> Asserting Host: web.cdklocal.test is host-routed to the WEB service"
+WEB_READY=0
+WEB_RESP=""
+for _ in $(seq 1 60); do
+  WEB_RESP=$(curl -fsS -H 'Host: web.cdklocal.test' "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null || true)
+  if [[ -n "${WEB_RESP}" ]]; then
+    WEB_READY=1
+    break
+  fi
+  sleep 1
+done
+if [[ "${WEB_READY}" -ne 1 ]]; then
+  echo "FAIL: Host: web.cdklocal.test never served a 200 within 60s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    web host response: ${WEB_RESP}"
+if [[ "${WEB_RESP}" != web\ * ]]; then
+  echo "FAIL: Host: web.cdklocal.test was not host-routed to the web service (got: ${WEB_RESP})"
+  exit 1
+fi
+echo "    OK: Host: web.cdklocal.test host-routed to the web service"
+
+echo "==> Asserting the two hosts reach DIFFERENT services"
+if [[ "${API_RESP%% *}" == "${WEB_RESP%% *}" ]]; then
+  echo "FAIL: both hosts reached the same service role (api='${API_RESP}', web='${WEB_RESP}')"
+  exit 1
+fi
+echo "    OK: api host and web host reach different services"
+
+echo "==> Sending SIGTERM to cdk-local (${CDKL_PID})"
+kill -TERM "${CDKL_PID}"
+
+echo "==> Waiting for cdk-local to exit (up to 60s)"
+EXITED=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then EXITED=1; break; fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+echo "==> Asserting clean teardown — no leftover containers"
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers still present after SIGTERM"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+
+echo "==> Asserting clean teardown — no leftover networks"
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} docker networks still present after SIGTERM"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+echo "==> Asserting the front-door socket is closed"
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: front-door on host port ${LB_HOST_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+
+echo ""
+echo "==> local-start-alb-routing-conditions test passed (host-header -> api/web, fixed-response default, clean teardown)"

--- a/tests/unit/local/alb-path-matcher.test.ts
+++ b/tests/unit/local/alb-path-matcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
   albPathPatternMatches,
+  albHostPatternMatches,
   matchAlbPathRule,
   type AlbPathRule,
 } from '../../../src/local/alb-path-matcher.js';
@@ -42,6 +43,36 @@ describe('albPathPatternMatches', () => {
   });
 });
 
+describe('albHostPatternMatches', () => {
+  it('matches a literal host case-insensitively', () => {
+    expect(albHostPatternMatches('api.example.com', 'api.example.com')).toBe(true);
+    expect(albHostPatternMatches('api.example.com', 'API.EXAMPLE.COM')).toBe(true);
+    expect(albHostPatternMatches('API.example.com', 'api.example.com')).toBe(true);
+    expect(albHostPatternMatches('api.example.com', 'web.example.com')).toBe(false);
+  });
+
+  it('strips the :port suffix from the request host before matching', () => {
+    expect(albHostPatternMatches('api.example.com', 'api.example.com:8080')).toBe(true);
+    expect(albHostPatternMatches('api.example.com', 'api.example.com:443')).toBe(true);
+  });
+
+  it('treats * / ? as wildcards (subdomain / single-char)', () => {
+    expect(albHostPatternMatches('*.example.com', 'api.example.com')).toBe(true);
+    expect(albHostPatternMatches('*.example.com', 'a.b.example.com')).toBe(true);
+    expect(albHostPatternMatches('*.example.com', 'example.com')).toBe(false); // needs a subdomain
+    expect(albHostPatternMatches('img?.example.com', 'img1.example.com')).toBe(true);
+    expect(albHostPatternMatches('img?.example.com', 'img.example.com')).toBe(false);
+  });
+
+  it('escapes the literal dots (not "any char")', () => {
+    expect(albHostPatternMatches('a.example.com', 'axexample.com')).toBe(false);
+  });
+
+  it('strips the port from an IPv6 literal host', () => {
+    expect(albHostPatternMatches('[::1]', '[::1]:8080')).toBe(true);
+  });
+});
+
 describe('matchAlbPathRule', () => {
   const rules: AlbPathRule<string>[] = [
     { priority: 20, pathPatterns: ['/api/*'], target: 'api' },
@@ -72,5 +103,47 @@ describe('matchAlbPathRule', () => {
 
   it('strips the query string before matching', () => {
     expect(matchAlbPathRule('/api/orders?page=2', rules)).toBe('api');
+  });
+
+  it('accepts a bare path string (path-only form, no Host)', () => {
+    expect(matchAlbPathRule('/api/orders', rules)).toBe('api');
+  });
+});
+
+describe('matchAlbPathRule with host-header conditions', () => {
+  const rules: AlbPathRule<string>[] = [
+    // host-only rule
+    { priority: 10, pathPatterns: [], hostPatterns: ['api.example.com'], target: 'api-host' },
+    // host AND path rule (both must match)
+    {
+      priority: 5,
+      pathPatterns: ['/admin/*'],
+      hostPatterns: ['api.example.com'],
+      target: 'api-admin',
+    },
+    // path-only rule
+    { priority: 30, pathPatterns: ['/static/*'], target: 'static' },
+  ];
+
+  it('matches a host-only rule against the Host header', () => {
+    expect(matchAlbPathRule({ path: '/anything', host: 'api.example.com' }, rules)).toBe('api-host');
+  });
+
+  it('matches the AND rule only when both host and path match (priority 5 wins)', () => {
+    expect(matchAlbPathRule({ path: '/admin/users', host: 'api.example.com' }, rules)).toBe(
+      'api-admin'
+    );
+    // Path matches the AND rule but host does not -> falls to no match (no other rule fits).
+    expect(matchAlbPathRule({ path: '/admin/users', host: 'web.example.com' }, rules)).toBeUndefined();
+  });
+
+  it('does not match a host-constrained rule when no Host header is present', () => {
+    expect(matchAlbPathRule({ path: '/anything' }, rules)).toBeUndefined();
+    // A path-only rule still matches without a Host header.
+    expect(matchAlbPathRule({ path: '/static/app.js' }, rules)).toBe('static');
+  });
+
+  it('matches the Host header case-insensitively and ignores the :port', () => {
+    expect(matchAlbPathRule({ path: '/', host: 'API.EXAMPLE.COM:8080' }, rules)).toBe('api-host');
   });
 });

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -303,6 +303,87 @@ describe('resolveAlbFrontDoor', () => {
     });
   });
 
+  it('carries a Weight: 0 target through resolution (the seam to the 502 path)', () => {
+    // The real synth can emit Weight: 0; it must survive into target.weight so
+    // the front-door's "every weighted target has weight 0 -> 502" path fires.
+    const stack = stackWith({
+      ...apiServiceResources,
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [
+            {
+              Type: 'forward',
+              ForwardConfig: {
+                TargetGroups: [
+                  { TargetGroupArn: { Ref: TG }, Weight: 0 },
+                  { TargetGroupArn: { Ref: API_TG }, Weight: '0' },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+    const action = resolveAlbFrontDoor(stack, ALB).listeners[0]!.defaultAction;
+    expect(action?.kind).toBe('forward');
+    if (action?.kind === 'forward') {
+      expect(action.targets.map((t) => t.weight)).toEqual([0, 0]);
+    }
+  });
+
+  it('defaults a redirect with no StatusCode to 302', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [{ Type: 'redirect', RedirectConfig: { Path: '/elsewhere' } }],
+        },
+      },
+    });
+    const action = resolveAlbFrontDoor(stack, ALB).listeners[0]!.defaultAction;
+    expect(action).toMatchObject({ kind: 'redirect', statusCode: 302, path: '/elsewhere' });
+  });
+
+  it('warns and skips a redirect action with no RedirectConfig', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [{ Type: 'redirect' }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/redirect/i);
+  });
+
+  it('defaults a fixed-response with no FixedResponseConfig to status 200', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [{ Type: 'fixed-response' }],
+        },
+      },
+    });
+    const action = resolveAlbFrontDoor(stack, ALB).listeners[0]!.defaultAction;
+    expect(action).toEqual({ kind: 'fixed-response', statusCode: 200 });
+  });
+
   it('honors a forward terminal action preceded by an authenticate-* action', () => {
     const stack = stackWith({
       [LISTENER]: {

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -68,6 +68,12 @@ const apiServiceResources: Record<string, unknown> = {
   },
 };
 
+/** Convenience: the single forward target of a resolved action (throws if not a forward). */
+function forwardTarget(action: import('../../../src/local/elb-front-door-resolver.js').ResolvedListenerAction | undefined) {
+  if (action?.kind !== 'forward') throw new Error(`expected a forward action, got ${action?.kind}`);
+  return action.targets[0]!;
+}
+
 describe('resolveAlbFrontDoor', () => {
   it('resolves ALB -> listener default forward -> backing ECS service', () => {
     const { listeners, warnings } = resolveAlbFrontDoor(stackWith(), ALB);
@@ -77,11 +83,17 @@ describe('resolveAlbFrontDoor', () => {
         listenerPort: 80,
         listenerProtocol: 'HTTP',
         listenerLogicalId: LISTENER,
-        defaultTarget: {
-          serviceLogicalId: SERVICE,
-          targetContainerName: 'web',
-          targetContainerPort: 80,
-          targetGroupLogicalId: TG,
+        defaultAction: {
+          kind: 'forward',
+          targets: [
+            {
+              serviceLogicalId: SERVICE,
+              targetContainerName: 'web',
+              targetContainerPort: 80,
+              targetGroupLogicalId: TG,
+              weight: 1,
+            },
+          ],
         },
         rules: [],
       },
@@ -105,7 +117,7 @@ describe('resolveAlbFrontDoor', () => {
     const { listeners } = resolveAlbFrontDoor(stack, ALB);
     expect(listeners).toHaveLength(1);
     expect(listeners[0]!.listenerPort).toBe(8080);
-    expect(listeners[0]!.defaultTarget?.serviceLogicalId).toBe(SERVICE);
+    expect(forwardTarget(listeners[0]!.defaultAction).serviceLogicalId).toBe(SERVICE);
   });
 
   it('resolves path-pattern ListenerRules into a routing table (default + rule, two services)', () => {
@@ -124,19 +136,190 @@ describe('resolveAlbFrontDoor', () => {
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
     expect(warnings).toEqual([]);
     expect(listeners).toHaveLength(1);
-    expect(listeners[0]!.defaultTarget?.serviceLogicalId).toBe(SERVICE);
+    expect(forwardTarget(listeners[0]!.defaultAction).serviceLogicalId).toBe(SERVICE);
     expect(listeners[0]!.rules).toEqual([
       {
         priority: 10,
         pathPatterns: ['/api/*'],
-        target: {
-          serviceLogicalId: API_SERVICE,
-          targetContainerName: 'api',
-          targetContainerPort: 8080,
-          targetGroupLogicalId: API_TG,
+        hostPatterns: [],
+        action: {
+          kind: 'forward',
+          targets: [
+            {
+              serviceLogicalId: API_SERVICE,
+              targetContainerName: 'api',
+              targetContainerPort: 8080,
+              targetGroupLogicalId: API_TG,
+              weight: 1,
+            },
+          ],
         },
       },
     ]);
+  });
+
+  it('resolves a host-header condition (and an ANDed path-pattern) on a rule', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [
+            { Field: 'host-header', HostHeaderConfig: { Values: ['api.example.com'] } },
+            { Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*'] } },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners[0]!.rules[0]!.pathPatterns).toEqual(['/api/*']);
+    expect(listeners[0]!.rules[0]!.hostPatterns).toEqual(['api.example.com']);
+    expect(forwardTarget(listeners[0]!.rules[0]!.action).serviceLogicalId).toBe(API_SERVICE);
+  });
+
+  it('resolves a host-header-only rule (no path constraint)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 5,
+          Conditions: [{ Field: 'host-header', HostHeaderConfig: { Values: ['*.api.example.com'] } }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners[0]!.rules[0]!.pathPatterns).toEqual([]);
+    expect(listeners[0]!.rules[0]!.hostPatterns).toEqual(['*.api.example.com']);
+  });
+
+  it('resolves a weighted (multi-target) forward into all targets with weights', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [
+            {
+              Type: 'forward',
+              ForwardConfig: {
+                TargetGroups: [
+                  { TargetGroupArn: { Ref: TG }, Weight: 80 },
+                  { TargetGroupArn: { Ref: API_TG }, Weight: 20 },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    const action = listeners[0]!.defaultAction;
+    expect(action?.kind).toBe('forward');
+    if (action?.kind === 'forward') {
+      expect(action.targets.map((t) => [t.serviceLogicalId, t.weight])).toEqual([
+        [SERVICE, 80],
+        [API_SERVICE, 20],
+      ]);
+    }
+  });
+
+  it('resolves a redirect default action (HTTP_301 -> statusCode 301)', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [
+            {
+              Type: 'redirect',
+              RedirectConfig: {
+                Protocol: 'HTTPS',
+                Host: 'new.example.com',
+                Port: '443',
+                Path: '/#{path}',
+                Query: '#{query}',
+                StatusCode: 'HTTP_301',
+              },
+            },
+          ],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners[0]!.defaultAction).toEqual({
+      kind: 'redirect',
+      statusCode: 301,
+      protocol: 'HTTPS',
+      host: 'new.example.com',
+      port: '443',
+      path: '/#{path}',
+      query: '#{query}',
+    });
+  });
+
+  it('resolves a fixed-response default action (status / content-type / body)', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [
+            {
+              Type: 'fixed-response',
+              FixedResponseConfig: {
+                StatusCode: '410',
+                ContentType: 'application/json',
+                MessageBody: '{"gone":true}',
+              },
+            },
+          ],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners[0]!.defaultAction).toEqual({
+      kind: 'fixed-response',
+      statusCode: 410,
+      contentType: 'application/json',
+      messageBody: '{"gone":true}',
+    });
+  });
+
+  it('honors a forward terminal action preceded by an authenticate-* action', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [
+            { Type: 'authenticate-cognito', AuthenticateCognitoConfig: {}, Order: 1 },
+            { Type: 'forward', TargetGroupArn: { Ref: TG }, Order: 2 },
+          ],
+        },
+      },
+    });
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(forwardTarget(listeners[0]!.defaultAction).serviceLogicalId).toBe(SERVICE);
   });
 
   it('sorts a rule with no Priority last (Number.MAX_SAFE_INTEGER fallback)', () => {
@@ -173,7 +356,7 @@ describe('resolveAlbFrontDoor', () => {
     expect(listeners[0]!.rules[0]!.pathPatterns).toEqual(['/legacy/*']);
   });
 
-  it('skips + warns on a rule with an unsupported (non-path-pattern) condition', () => {
+  it('skips + warns on a rule with a still-unsupported condition field (http-header)', () => {
     const stack = stackWith({
       ...apiServiceResources,
       [RULE]: {
@@ -181,7 +364,12 @@ describe('resolveAlbFrontDoor', () => {
         Properties: {
           ListenerArn: { Ref: LISTENER },
           Priority: 10,
-          Conditions: [{ Field: 'host-header', HostHeaderConfig: { Values: ['api.example.com'] } }],
+          Conditions: [
+            {
+              Field: 'http-header',
+              HttpHeaderConfig: { HttpHeaderName: 'X-Custom', Values: ['yes'] },
+            },
+          ],
           Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
         },
       },
@@ -189,12 +377,16 @@ describe('resolveAlbFrontDoor', () => {
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
     // The listener still resolves via its default forward; only the rule is dropped.
     expect(listeners[0]!.rules).toEqual([]);
-    expect(warnings.join('\n')).toMatch(/unsupported condition\(s\): host-header/);
+    expect(warnings.join('\n')).toMatch(/unsupported condition\(s\): http-header/);
   });
 
-  it('skips + warns on a weighted (multi-target) forward', () => {
+  it('drops only the unsupported target group inside a weighted forward (others kept)', () => {
     const stack = stackWith({
       ...apiServiceResources,
+      LambdaTg: {
+        Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+        Properties: { TargetType: 'lambda' },
+      },
       [LISTENER]: {
         Type: 'AWS::ElasticLoadBalancingV2::Listener',
         Properties: {
@@ -205,7 +397,10 @@ describe('resolveAlbFrontDoor', () => {
             {
               Type: 'forward',
               ForwardConfig: {
-                TargetGroups: [{ TargetGroupArn: { Ref: TG } }, { TargetGroupArn: { Ref: API_TG } }],
+                TargetGroups: [
+                  { TargetGroupArn: { Ref: API_TG }, Weight: 70 },
+                  { TargetGroupArn: { Ref: 'LambdaTg' }, Weight: 30 },
+                ],
               },
             },
           ],
@@ -213,11 +408,16 @@ describe('resolveAlbFrontDoor', () => {
       },
     });
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(listeners).toEqual([]);
-    expect(warnings.join('\n')).toMatch(/weighted forward/);
+    const action = listeners[0]!.defaultAction;
+    expect(action?.kind).toBe('forward');
+    if (action?.kind === 'forward') {
+      // The Lambda target group is dropped; the ECS one survives.
+      expect(action.targets.map((t) => t.serviceLogicalId)).toEqual([API_SERVICE]);
+    }
+    expect(warnings.join('\n')).toMatch(/Lambda target group/);
   });
 
-  it('serves a rules-only listener (fixed-response default + path rule -> no defaultTarget)', () => {
+  it('serves a rules-only listener (fixed-response default + path rule)', () => {
     const stack = stackWith({
       ...apiServiceResources,
       [LISTENER]: {
@@ -242,8 +442,8 @@ describe('resolveAlbFrontDoor', () => {
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
     expect(warnings).toEqual([]);
     expect(listeners).toHaveLength(1);
-    expect(listeners[0]!.defaultTarget).toBeUndefined();
-    expect(listeners[0]!.rules[0]!.target.serviceLogicalId).toBe(API_SERVICE);
+    expect(listeners[0]!.defaultAction).toEqual({ kind: 'fixed-response', statusCode: 404 });
+    expect(forwardTarget(listeners[0]!.rules[0]!.action).serviceLogicalId).toBe(API_SERVICE);
   });
 
   it('ignores listeners belonging to a different ALB', () => {
@@ -350,8 +550,10 @@ describe('resolveAlbFrontDoor', () => {
     expect(warnings.join('\n')).toMatch(/non-Ref TargetGroupArn/);
   });
 
-  it('skips a redirect-only listener silently (no warning)', () => {
+  it('serves a redirect-only listener (no backing service) without warnings', () => {
     const stack = stackWith({
+      // No backing service needed for a pure-redirect listener.
+      [SERVICE]: undefined,
       [LISTENER]: {
         Type: 'AWS::ElasticLoadBalancingV2::Listener',
         Properties: {
@@ -363,8 +565,27 @@ describe('resolveAlbFrontDoor', () => {
       },
     });
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
-    expect(listeners).toEqual([]);
     expect(warnings).toEqual([]);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]!.defaultAction?.kind).toBe('redirect');
+  });
+
+  it('skips + warns on an authenticate-only default action (no terminal action)', () => {
+    const stack = stackWith({
+      [SERVICE]: undefined,
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 80,
+          Protocol: 'HTTP',
+          DefaultActions: [{ Type: 'authenticate-oidc', AuthenticateOidcConfig: {} }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/authenticate-/);
   });
 
   it('warns when the forwarded target group is missing from the template', () => {

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, afterEach } from 'vite-plus/test';
-import { createServer, get, type IncomingMessage, type Server } from 'node:http';
+import { createServer, get, request, type IncomingMessage, type Server } from 'node:http';
 import { AddressInfo } from 'node:net';
 import { FrontDoorEndpointPool } from '../../../src/local/front-door-pool.js';
 import {
   startFrontDoorServer,
+  buildRedirectLocation,
+  pickWeightedPool,
   type StartedFrontDoorServer,
+  type RouteAction,
+  type RedirectRouteAction,
 } from '../../../src/local/front-door-server.js';
 import { matchAlbPathRule, type AlbPathRule } from '../../../src/local/alb-path-matcher.js';
 
@@ -35,19 +39,24 @@ async function startUpstream(id: string): Promise<Upstream> {
   return up;
 }
 
+/** Wrap a single pool into a constant forward route (the default-action case). */
+function forward(pool: FrontDoorEndpointPool): RouteAction {
+  return { kind: 'forward', pools: [{ pool, weight: 1 }] };
+}
+
 async function startFront(
   pool: FrontDoorEndpointPool,
   upstreamTimeoutMs?: number
 ): Promise<StartedFrontDoorServer> {
-  return startFrontWith(() => pool, upstreamTimeoutMs);
+  return startFrontWith(() => forward(pool), upstreamTimeoutMs);
 }
 
 async function startFrontWith(
-  selectPool: (requestPath: string) => FrontDoorEndpointPool | undefined,
+  route: (req: { path: string; host?: string }) => RouteAction | undefined,
   upstreamTimeoutMs?: number
 ): Promise<StartedFrontDoorServer> {
   const front = await startFrontDoorServer({
-    selectPool,
+    route,
     port: 0,
     host: '127.0.0.1',
     listenerPort: 80,
@@ -83,6 +92,46 @@ function fetchText(
       res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
     });
     req.on('error', reject);
+  });
+}
+
+/** Like `fetchText` but sends an explicit `Host` header (for host-header rule tests). */
+function fetchTextWithHost(
+  port: number,
+  path: string,
+  hostHeader: string
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = get({ host: '127.0.0.1', port, path, headers: { host: hostHeader } }, (res) => {
+      let body = '';
+      res.on('data', (c) => (body += c));
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on('error', reject);
+  });
+}
+
+/** Issue a request and capture the status + `Location` header (for redirect tests). */
+function fetchHead(
+  port: number,
+  path: string,
+  hostHeader: string
+): Promise<{ status: number; location?: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { host: '127.0.0.1', port, path, method: 'GET', headers: { host: hostHeader } },
+      (res) => {
+        res.resume();
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            ...(typeof res.headers.location === 'string' && { location: res.headers.location }),
+          })
+        );
+      }
+    );
+    req.on('error', reject);
+    req.end();
   });
 }
 
@@ -146,7 +195,7 @@ describe('startFrontDoorServer', () => {
     expect(res.status).toBe(504);
   });
 
-  it('path-routes each request to the pool selectPool returns', async () => {
+  it('path-routes each request to the action route() returns', async () => {
     const web = await startUpstream('web');
     const api = await startUpstream('api');
     const webPool = new FrontDoorEndpointPool();
@@ -154,8 +203,8 @@ describe('startFrontDoorServer', () => {
     const apiPool = new FrontDoorEndpointPool();
     apiPool.register('api:r0', { host: '127.0.0.1', port: api.port });
     // `/api/*` -> apiPool, everything else -> webPool (the default).
-    const front = await startFrontWith((path) =>
-      path.startsWith('/api/') ? apiPool : webPool
+    const front = await startFrontWith(({ path }) =>
+      path.startsWith('/api/') ? forward(apiPool) : forward(webPool)
     );
 
     expect((await fetchText(front.port, '/')).body).toBe('web');
@@ -163,7 +212,7 @@ describe('startFrontDoorServer', () => {
     expect((await fetchText(front.port, '/api/users')).body).toBe('api');
   });
 
-  it('returns 404 when selectPool finds no matching rule and no default', async () => {
+  it('returns 404 when route() finds no matching rule and no default', async () => {
     const front = await startFrontWith(() => undefined);
     const res = await fetchText(front.port, '/nope');
     expect(res.status).toBe(404);
@@ -179,15 +228,62 @@ describe('startFrontDoorServer', () => {
     apiPool.register('api:r0', { host: '127.0.0.1', port: api.port });
     // /api/admin/* (priority 10) must win over /api/* (priority 20) for an
     // overlapping path — the exact integration the matcher guarantees.
-    const rules: AlbPathRule<FrontDoorEndpointPool>[] = [
-      { priority: 20, pathPatterns: ['/api/*'], target: apiPool },
-      { priority: 10, pathPatterns: ['/api/admin/*'], target: adminPool },
+    const rules: AlbPathRule<RouteAction>[] = [
+      { priority: 20, pathPatterns: ['/api/*'], target: forward(apiPool) },
+      { priority: 10, pathPatterns: ['/api/admin/*'], target: forward(adminPool) },
     ];
-    const front = await startFrontWith((path) => matchAlbPathRule(path, rules));
+    const front = await startFrontWith((req) => matchAlbPathRule(req, rules));
 
     expect((await fetchText(front.port, '/api/admin/users')).body).toBe('admin');
     expect((await fetchText(front.port, '/api/orders')).body).toBe('api');
     expect((await fetchText(front.port, '/')).status).toBe(404); // no default action
+  });
+
+  it('host-routes through the real matchAlbPathRule (Host header -> the matching pool)', async () => {
+    const apiHost = await startUpstream('api-host');
+    const webHost = await startUpstream('web-host');
+    const apiPool = new FrontDoorEndpointPool();
+    apiPool.register('api:r0', { host: '127.0.0.1', port: apiHost.port });
+    const webPool = new FrontDoorEndpointPool();
+    webPool.register('web:r0', { host: '127.0.0.1', port: webHost.port });
+    // host-header api.example.com -> apiPool; default -> webPool.
+    const rules: AlbPathRule<RouteAction>[] = [
+      { priority: 10, pathPatterns: [], hostPatterns: ['api.example.com'], target: forward(apiPool) },
+    ];
+    const front = await startFrontWith((req) => matchAlbPathRule(req, rules) ?? forward(webPool));
+
+    expect((await fetchTextWithHost(front.port, '/', 'api.example.com')).body).toBe('api-host');
+    // The case-insensitive host comparison still matches.
+    expect((await fetchTextWithHost(front.port, '/', 'API.EXAMPLE.COM')).body).toBe('api-host');
+    expect((await fetchTextWithHost(front.port, '/', 'other.example.com')).body).toBe('web-host');
+  });
+
+  it('synthesizes a fixed-response action without an upstream', async () => {
+    const front = await startFrontWith(() => ({
+      kind: 'fixed-response',
+      statusCode: 410,
+      contentType: 'application/json',
+      messageBody: '{"gone":true}',
+    }));
+    const res = await fetchText(front.port, '/gone/x');
+    expect(res.status).toBe(410);
+    expect(res.body).toBe('{"gone":true}');
+  });
+
+  it('synthesizes a 301 redirect with a Location built from the request', async () => {
+    const action: RedirectRouteAction = {
+      kind: 'redirect',
+      statusCode: 301,
+      protocol: 'HTTPS',
+      host: 'new.example.com',
+      port: '443',
+      path: '/#{path}',
+      query: '#{query}',
+    };
+    const front = await startFrontWith(() => action);
+    const res = await fetchHead(front.port, '/old/page?x=1', 'orig.example.com');
+    expect(res.status).toBe(301);
+    expect(res.location).toBe('https://new.example.com/old/page?x=1');
   });
 
   it('strips hop-by-hop request headers, including those named in Connection', async () => {
@@ -247,5 +343,142 @@ describe('startFrontDoorServer', () => {
     });
     expect(headers['proxy-authenticate']).toBeUndefined();
     expect(headers['x-app']).toBe('kept'); // non-hop-by-hop headers pass through
+  });
+
+  it('distributes a weighted forward across pools roughly by weight', async () => {
+    const heavy = await startUpstream('heavy');
+    const light = await startUpstream('light');
+    const heavyPool = new FrontDoorEndpointPool();
+    heavyPool.register('heavy:r0', { host: '127.0.0.1', port: heavy.port });
+    const lightPool = new FrontDoorEndpointPool();
+    lightPool.register('light:r0', { host: '127.0.0.1', port: light.port });
+    const action: RouteAction = {
+      kind: 'forward',
+      pools: [
+        { pool: heavyPool, weight: 90 },
+        { pool: lightPool, weight: 10 },
+      ],
+    };
+    const front = await startFrontWith(() => action);
+
+    const counts: Record<string, number> = { heavy: 0, light: 0 };
+    for (let i = 0; i < 200; i++) {
+      const body = (await fetchText(front.port)).body;
+      counts[body] = (counts[body] ?? 0) + 1;
+    }
+    // 90/10 split: the heavy pool should dominate by a wide margin. The bound is
+    // loose enough to be robust to the random sample but still proves weighting.
+    expect(counts['heavy']!).toBeGreaterThan(counts['light']!);
+    expect(counts['heavy']!).toBeGreaterThan(120);
+    expect(counts['light']!).toBeGreaterThan(0); // weight 10 is still occasionally hit
+  });
+
+  it('never routes to a weight-0 pool in a weighted forward', async () => {
+    const live = await startUpstream('live');
+    const livePool = new FrontDoorEndpointPool();
+    livePool.register('live:r0', { host: '127.0.0.1', port: live.port });
+    const zeroPool = new FrontDoorEndpointPool();
+    zeroPool.register('zero:r0', { host: '127.0.0.1', port: live.port }); // would also answer
+    const action: RouteAction = {
+      kind: 'forward',
+      pools: [
+        { pool: livePool, weight: 100 },
+        { pool: zeroPool, weight: 0 },
+      ],
+    };
+    const front = await startFrontWith(() => action);
+    for (let i = 0; i < 20; i++) {
+      expect((await fetchText(front.port)).body).toBe('live');
+    }
+  });
+
+  it('returns 502 when every weighted forward pool has weight 0', async () => {
+    const dead = new FrontDoorEndpointPool();
+    const action: RouteAction = { kind: 'forward', pools: [{ pool: dead, weight: 0 }] };
+    const front = await startFrontWith(() => action);
+    const res = await fetchText(front.port);
+    expect(res.status).toBe(502);
+    expect(res.body).toMatch(/weight 0/);
+  });
+});
+
+describe('pickWeightedPool', () => {
+  const a = new FrontDoorEndpointPool();
+  const b = new FrontDoorEndpointPool();
+
+  it('returns the single pool when its weight is positive', () => {
+    expect(pickWeightedPool([{ pool: a, weight: 1 }])).toBe(a);
+  });
+
+  it('returns undefined for an empty set or all-zero weights', () => {
+    expect(pickWeightedPool([])).toBeUndefined();
+    expect(pickWeightedPool([{ pool: a, weight: 0 }])).toBeUndefined();
+    expect(
+      pickWeightedPool([
+        { pool: a, weight: 0 },
+        { pool: b, weight: 0 },
+      ])
+    ).toBeUndefined();
+  });
+
+  it('skips weight-0 members and only ever returns a positive-weight pool', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(
+        pickWeightedPool([
+          { pool: a, weight: 0 },
+          { pool: b, weight: 5 },
+        ])
+      ).toBe(b);
+    }
+  });
+});
+
+describe('buildRedirectLocation', () => {
+  const req = (url: string, host = 'orig.example.com'): { url: string; headers: { host: string } } => ({
+    url,
+    headers: { host },
+  });
+
+  it('fills #{path} / #{query} from the request and omits a default port', () => {
+    const action: RedirectRouteAction = {
+      kind: 'redirect',
+      statusCode: 301,
+      protocol: 'HTTPS',
+      host: 'new.example.com',
+      port: '443',
+      path: '/#{path}',
+      query: '#{query}',
+    };
+    expect(buildRedirectLocation(action, req('/old/page?a=1&b=2'), 80)).toBe(
+      'https://new.example.com/old/page?a=1&b=2'
+    );
+    expect(buildRedirectLocation(action, req('/old/page'), 80)).toBe(
+      'https://new.example.com/old/page'
+    );
+  });
+
+  it('defaults to the request host/path/query and the listener port when unset', () => {
+    // A bare redirect to HTTPS keeps host + path; the listener port 80 is the
+    // default for http, so a same-scheme redirect would carry it, but here the
+    // protocol is unset (defaults to http) and port 8080 is non-default -> kept.
+    const action: RedirectRouteAction = { kind: 'redirect', statusCode: 302 };
+    expect(buildRedirectLocation(action, req('/a/b?x=1'), 8080)).toBe(
+      'http://orig.example.com:8080/a/b?x=1'
+    );
+  });
+
+  it('keeps a non-default explicit port and honors a literal host/path', () => {
+    const action: RedirectRouteAction = {
+      kind: 'redirect',
+      statusCode: 302,
+      protocol: 'HTTPS',
+      host: 'cdn.example.com',
+      port: '8443',
+      path: '/static/index.html',
+      query: '',
+    };
+    expect(buildRedirectLocation(action, req('/whatever?drop=me'), 80)).toBe(
+      'https://cdn.example.com:8443/static/index.html'
+    );
   });
 });

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -161,7 +161,11 @@ describe('albStrategy.resolveBoots multi-service', () => {
       80, 8080,
     ]);
     for (const l of frontDoor!.listeners) {
-      expect(l.defaultTarget?.serviceTarget).toBe('Multi:Svc1');
+      const action = l.defaultAction;
+      expect(action?.kind).toBe('forward');
+      if (action?.kind === 'forward') {
+        expect(action.targets[0]?.serviceTarget).toBe('Multi:Svc1');
+      }
     }
   });
 
@@ -263,10 +267,16 @@ describe('start-alb / start-service strategy binding', () => {
       {
         listenerPort: 80,
         hostPort: 8080, // remapped by --lb-port 80=8080
-        defaultTarget: {
-          serviceTarget: 'AlbStack:WebService',
-          targetContainerName: 'web',
-          targetContainerPort: 80,
+        defaultAction: {
+          kind: 'forward',
+          targets: [
+            {
+              serviceTarget: 'AlbStack:WebService',
+              targetContainerName: 'web',
+              targetContainerPort: 80,
+              weight: 1,
+            },
+          ],
         },
         rules: [],
       },
@@ -293,16 +303,33 @@ describe('buildFrontDoor', () => {
           {
             listenerPort: 80,
             hostPort: 0, // ephemeral: avoid privileged-port binding in the unit test
-            defaultTarget: {
-              serviceTarget: 'S:Web',
-              targetContainerName: 'web',
-              targetContainerPort: 80,
+            defaultAction: {
+              kind: 'forward',
+              targets: [
+                {
+                  serviceTarget: 'S:Web',
+                  targetContainerName: 'web',
+                  targetContainerPort: 80,
+                  weight: 1,
+                },
+              ],
             },
             rules: [
               {
                 priority: 10,
                 pathPatterns: ['/api/*'],
-                target: { serviceTarget: 'S:Api', targetContainerName: 'api', targetContainerPort: 8080 },
+                hostPatterns: [],
+                action: {
+                  kind: 'forward',
+                  targets: [
+                    {
+                      serviceTarget: 'S:Api',
+                      targetContainerName: 'api',
+                      targetContainerPort: 8080,
+                      weight: 1,
+                    },
+                  ],
+                },
               },
             ],
           },
@@ -318,6 +345,61 @@ describe('buildFrontDoor', () => {
       expect(frontDoorByService.get('S:Web')).toEqual([
         expect.objectContaining({ targetContainerName: 'web', targetContainerPort: 80 }),
       ]);
+    } finally {
+      await Promise.all(servers.map((s) => s.close()));
+    }
+  });
+
+  it('builds one pool per weighted forward target and groups them by service', async () => {
+    const logger = { info: () => {}, warn: () => {} } as never;
+    const { servers, frontDoorByService } = await buildFrontDoor(
+      {
+        listeners: [
+          {
+            listenerPort: 80,
+            hostPort: 0,
+            defaultAction: {
+              kind: 'forward',
+              targets: [
+                { serviceTarget: 'S:Blue', targetContainerName: 'app', targetContainerPort: 80, weight: 80 },
+                { serviceTarget: 'S:Green', targetContainerName: 'app', targetContainerPort: 80, weight: 20 },
+              ],
+            },
+            rules: [],
+          },
+        ],
+      },
+      '127.0.0.1',
+      logger
+    );
+    try {
+      // Each weighted target group gets its own pool, grouped by service target.
+      expect([...frontDoorByService.keys()].sort()).toEqual(['S:Blue', 'S:Green']);
+    } finally {
+      await Promise.all(servers.map((s) => s.close()));
+    }
+  });
+
+  it('stands up a fixed-response-default listener with no backing pool', async () => {
+    const logger = { info: () => {}, warn: () => {} } as never;
+    const { servers, frontDoorByService } = await buildFrontDoor(
+      {
+        listeners: [
+          {
+            listenerPort: 80,
+            hostPort: 0,
+            defaultAction: { kind: 'fixed-response', statusCode: 404, messageBody: 'nope' },
+            rules: [],
+          },
+        ],
+      },
+      '127.0.0.1',
+      logger
+    );
+    try {
+      expect(servers).toHaveLength(1);
+      // A fixed-response action has no forward target -> no service pools.
+      expect(frontDoorByService.size).toBe(0);
     } finally {
       await Promise.all(servers.map((s) => s.close()));
     }


### PR DESCRIPTION
## Summary

Extends the local ALB front-door (`cdkl start-alb`) beyond single-target
`path-pattern` forwards to the rest of the common listener-rule surface — the
first of two `(#123)` follow-ups (the second adds Lambda targets).

- **host-header conditions** — ALB `*`/`?` glob, matched case-insensitively
  against the request Host header (port stripped); a rule may AND a
  `path-pattern` and a `host-header` condition.
- **weighted forward** (`ForwardConfig.TargetGroups[]` with `Weight`) — each
  target group resolves to its backing service; the front-door picks a pool by
  weighted-random (weight 0 never selected; all-zero → 502).
- **`redirect` / `fixed-response` actions** — on a default action OR a rule:
  `redirect` answers 301/302 with a `Location` built by resolving ALB
  `#{protocol|host|port|path|query}` placeholders against the request;
  `fixed-response` synthesizes the status / content-type / body. Neither needs
  a backing pool.

The routing-target model is generalized: `selectPool(path)` became
`route({ path, host }) -> RouteAction` (a `forward` (weighted pools) /
`redirect` / `fixed-response` discriminated union); resolver mirrors it as
`ResolvedListenerAction`, strategy as `PlannedAction`; `buildFrontDoor` converts
to `RouteAction` and `front-door-server` synthesizes redirect/fixed-response
directly.

Still deferred to `(#123)` (skipped with a warning): `http-header` /
`http-request-method` / `query-string` / `source-ip` conditions,
`authenticate-cognito` / `authenticate-oidc` actions, HTTPS/TLS, and Lambda
target groups. Docs (README / cli-reference / CLAUDE.md) updated to move the new
features from "deferred" to "supported".

## Test plan

- [x] `vp run check` + `vp test run` green — 95 files / 1378 tests (host glob /
      case / port-strip / path-AND-host; weighted resolve + distribution +
      weight-0; redirect placeholders + default 302; fixed-response synth +
      defaults; priority + 404 through the real matcher)
- [x] `vp run build` green
- [x] `/run-integ local-start-alb-routing-conditions` (new fixture: host-header
      → api/web + a fixed-response 418 default) — passes, 0 orphans
- [x] `/run-integ local-start-alb-routing` (path-routing) — still passes
      (regression), 0 orphans
- [x] 3-axis review: spec clean, no code blockers, test coverage strong;
      fix-back drained the request body on redirect/fixed-response and added the
      `Weight: 0` / redirect-302 / fixed-response-default / no-RedirectConfig
      resolver branch tests

## Accepted nits (from the 3-axis review)

- A sole `ForwardConfig` target group with `Weight: 0` yields 502 (the matcher's
  all-zero path) and its banner line reads `(round-robin)`, and a weight-0-only
  target still boots its replicas. CDK never emits a single weight-0 forward
  (weight is only meaningful relative to peers), so these only affect
  hand-rolled templates — acceptable.
