### PR TITLE
feat(start-alb): ALB -> Lambda targets

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,9 +32,11 @@ AWS managed services.
   service(s) behind it plus a local front-door that round-robins each
   listener port across the replicas and routes the listener's
   `path-pattern` + `host-header` rules across the backing services,
-  honoring weighted forwards and `redirect` / `fixed-response` actions
-  (Lambda targets and `http-header` / `query-string` / `source-ip`
-  conditions — deferred to #123)
+  honoring weighted forwards and `redirect` / `fixed-response` actions.
+  A `TargetType: lambda` target group is served by invoking the backing
+  Lambda locally (HTTP request -> `requestContext.elb` event -> RIE ->
+  response), so a forward can mix ECS and Lambda targets (`http-header`
+  / `query-string` / `source-ip` conditions — deferred to #123)
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
@@ -101,12 +103,15 @@ Gateway).
   `--from-cfn-stack`), elb-front-door-resolver (resolves an ALB ->
   Listeners + `path-pattern`/`host-header` ListenerRules -> forward /
   weighted-forward / redirect / fixed-response actions -> backing ECS
-  Services, into a per-listener routing table; the `start-alb` entry),
-  alb-path-matcher (ALB `*` / `?` glob matcher for path + host rules,
-  priority ordered), front-door-pool (round-robin pool of live replica
-  endpoints), front-door-server (host HTTP reverse proxy that resolves a
-  per-request RouteAction — weighted forward to a replica pool, redirect,
-  or fixed-response — behind the ALB listener port), etc.
+  Services or Lambda functions, into a per-listener routing table; the
+  `start-alb` entry), alb-path-matcher (ALB `*` / `?` glob matcher for
+  path + host rules, priority ordered), alb-lambda-event (HTTP <-> ALB
+  `requestContext.elb` Lambda event/response translation), front-door-pool
+  (round-robin pool of live replica endpoints), front-door-lambda-runner
+  (one warm RIE container per Lambda target), front-door-server (host HTTP
+  reverse proxy that resolves a per-request RouteAction — weighted forward
+  to a replica pool or a Lambda invoke, redirect, or fixed-response —
+  behind the ALB listener port), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 | `cdkl start-service <Service>` | the ECS **service** | just the service's replicas (no load balancer) | workers / queue consumers / Service-Connect-only services, or to hit the containers directly |
 | `cdkl start-alb <Alb>` | the **ALB** | the ECS service(s) behind it **plus** a local **front-door** on each listener port | an `ApplicationLoadBalancedFargateService`-style service you want to reach the way external traffic does |
 
-`start-alb` discovers the ECS service(s) behind the ALB's HTTP listeners, boots their replicas, and stands up a host-side front-door on each listener port that round-robins across the replicas — one stable host endpoint, like behind a real load balancer. It honors **`path-pattern` and `host-header` listener rules**, **weighted** forwards, and **`redirect` / `fixed-response`** actions, so a listener routing `/api/*` (or `api.example.com`) to one service and everything else to another — or returning a redirect / canned response — is reproduced locally.
+`start-alb` discovers the ECS service(s) behind the ALB's HTTP listeners, boots their replicas, and stands up a host-side front-door on each listener port that round-robins across the replicas — one stable host endpoint, like behind a real load balancer. It honors **`path-pattern` and `host-header` listener rules**, **weighted** forwards, and **`redirect` / `fixed-response`** actions, so a listener routing `/api/*` (or `api.example.com`) to one service and everything else to another — or returning a redirect / canned response — is reproduced locally. A **`TargetType: lambda`** target group is served by invoking the backing Lambda locally (the request is translated to the ALB `requestContext.elb` event and run through the Lambda RIE), so a forward can mix ECS and Lambda targets.
 
 ```bash
 cdkl start-alb MyStack/WebAlb --lb-port 80=8080   # remap the privileged listener port 80 (macOS)
@@ -80,7 +80,7 @@ curl http://127.0.0.1:8080/        # default action -> the default service (roun
 curl http://127.0.0.1:8080/api/x   # path-pattern rule /api/* -> the api service
 ```
 
-Resolution model + scope (HTTP listeners, `path-pattern` + `host-header` rules, weighted forwards, `redirect` / `fixed-response`, ECS targets; Lambda targets and `http-header` / `query-string` / `source-ip` conditions deferred): [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
+Resolution model + scope (HTTP listeners, `path-pattern` + `host-header` rules, weighted forwards, `redirect` / `fixed-response`, ECS **and** Lambda targets; `http-header` / `query-string` / `source-ip` conditions deferred): [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
 
 ## Override env vars without a state source
 
@@ -104,7 +104,7 @@ Format + full precedence: [docs/cli-reference.md](docs/cli-reference.md).
 | `AWS::ECS::TaskDefinition` (run-task) | ✓ |
 | `AWS::ECS::Service` (start-service) | ✓ |
 | `AWS::ServiceDiscovery::*` (Cloud Map / Service Connect) | ✓ |
-| `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door; `path-pattern` + `host-header` rules, weighted forward, redirect / fixed-response) | ✓ |
+| `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door; `path-pattern` + `host-header` rules, weighted forward, redirect / fixed-response; ECS + Lambda targets) | ✓ |
 | `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container + fromCodeAsset artifacts, HTTP + MCP) | ✓ |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1025,9 +1025,11 @@ service you want to reach the way external traffic does.
 each listener's default action **and** its
 `AWS::ElasticLoadBalancingV2::ListenerRule`s with a `path-pattern` and/or
 `host-header` condition → each `forward` action's
-`AWS::ElasticLoadBalancingV2::TargetGroup`(s) → the `AWS::ECS::Service`
-whose `LoadBalancers[]` references that target group (a reverse scan —
-there is no direct TG → service pointer). The front-door for a listener
+`AWS::ElasticLoadBalancingV2::TargetGroup`(s) → either the
+`AWS::ECS::Service` whose `LoadBalancers[]` references that target group (a
+reverse scan — there is no direct TG → service pointer) or, for a
+`TargetType: lambda` group, the backing `AWS::Lambda::Function` it targets.
+The front-door for a listener
 port holds a routing table: each request is matched against the rules in
 `Priority` order (lower number first; ALB `*` / `?` glob, path-only +
 case-insensitive host), falling back to the default action; an unmatched
@@ -1066,18 +1068,22 @@ cdkl start-alb MyStack/WebAlb --lb-port 80=8080
 
 ### Scope
 
-**HTTP** listeners and **ECS** targets, with priority-ordered listener rules
-matching `path-pattern` and `host-header` conditions (ALB `*` / `?` glob;
-host is matched case-insensitively, path-only excludes the query string). Both
-default actions and rule actions support single-target `forward`, **weighted**
-(multi-target) `forward` (weighted-random pool selection; weight 0 never
-selected), `redirect` (301 / 302 with the `#{protocol|host|port|path|query}`
-placeholders resolved against the request), and `fixed-response` (synthesized
-status / content-type / body). Out of scope, skipped with a warning, and
-tracked in [#123](https://github.com/go-to-k/cdk-local/issues/123): the other
-rule conditions (`http-header` / `http-request-method` / `query-string` /
-`source-ip`), `authenticate-cognito` / `authenticate-oidc` actions, HTTPS / TLS
-termination, and Lambda target groups.
+**HTTP** listeners with **ECS** and **Lambda** targets, with priority-ordered
+listener rules matching `path-pattern` and `host-header` conditions (ALB `*` /
+`?` glob; host is matched case-insensitively, path-only excludes the query
+string). Both default actions and rule actions support single-target `forward`,
+**weighted** (multi-target) `forward` (weighted-random selection; weight 0 never
+selected; a forward may mix ECS and Lambda targets), `redirect` (301 / 302 with
+the `#{protocol|host|port|path|query}` placeholders resolved against the
+request), and `fixed-response` (synthesized status / content-type / body). A
+`TargetType: lambda` target group invokes the backing Lambda locally — the
+request becomes the ALB `requestContext.elb` event, runs through the Lambda RIE,
+and the response is translated back (a malformed response → 502). Out of scope,
+skipped with a warning, and tracked in
+[#123](https://github.com/go-to-k/cdk-local/issues/123): the other rule
+conditions (`http-header` / `http-request-method` / `query-string` /
+`source-ip`), `authenticate-cognito` / `authenticate-oidc` actions, and HTTPS /
+TLS termination.
 
 ### `cdkl start-alb` exit codes
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -65,11 +65,17 @@ import {
 import { FrontDoorEndpointPool } from '../../local/front-door-pool.js';
 import {
   startFrontDoorServer,
+  type FrontDoorDispatchTarget,
   type StartedFrontDoorServer,
   type RouteAction,
-  type WeightedPool,
+  type WeightedForwardTarget,
 } from '../../local/front-door-server.js';
 import { matchAlbPathRule, type AlbPathRule } from '../../local/alb-path-matcher.js';
+import type { ResolvedLambda } from '../../local/lambda-resolver.js';
+import {
+  createFrontDoorLambdaRunner,
+  type FrontDoorLambdaRunner,
+} from '../../local/front-door-lambda-runner.js';
 
 /**
  * Neutral ECS-service emulator orchestration shared by `cdkl start-service`
@@ -129,8 +135,16 @@ export interface ServiceBoot {
   target: string;
 }
 
-/** The backing (service target, container) one weighted forward target routes to. */
-export interface PlannedForwardTarget {
+/**
+ * The backing target one weighted forward target routes to: either an ECS
+ * service (round-robin a replica pool) or a Lambda function (invoke locally per
+ * request, #123). A single weighted forward may mix both.
+ */
+export type PlannedForwardTarget = PlannedEcsForwardTarget | PlannedLambdaForwardTarget;
+
+/** The backing (service target, container) an ECS weighted forward target routes to. */
+export interface PlannedEcsForwardTarget {
+  kind: 'ecs';
   /** Service target string (`Stack:LogicalId`) whose replica pool serves this. */
   serviceTarget: string;
   /** Container the listener forwards to. */
@@ -141,7 +155,20 @@ export interface PlannedForwardTarget {
   weight: number;
 }
 
-/** A planned forward action: one or more weighted backing targets. */
+/** A Lambda weighted forward target (#123): a resolved function invoked locally per request. */
+export interface PlannedLambdaForwardTarget {
+  kind: 'lambda';
+  /** The resolved Lambda the front-door boots + invokes. */
+  lambda: ResolvedLambda;
+  /** Target-group ARN-or-id surfaced under the event's `requestContext.elb`. */
+  targetGroupArn: string;
+  /** Whether the TG has `lambda.multi_value_headers.enabled=true`. */
+  multiValueHeaders: boolean;
+  /** Forward weight for weighted routing (single-target forward = 1). */
+  weight: number;
+}
+
+/** A planned forward action: one or more weighted backing targets (ECS and/or Lambda). */
 export interface PlannedForwardAction {
   kind: 'forward';
   targets: PlannedForwardTarget[];
@@ -257,6 +284,10 @@ export async function runEcsServiceEmulator(
   let frontDoorServers: StartedFrontDoorServer[] = [];
   // Per-service-target front-door pools to thread into each runner.
   let frontDoorByService = new Map<string, FrontDoorServicePools>();
+  // Long-lived Lambda-target containers behind the front-door (#123). Torn
+  // down alongside the front-door servers so no request is dispatched to a
+  // vanished container.
+  let frontDoorLambdaRunners: FrontDoorLambdaRunner[] = [];
 
   const cleanup = singleFlight(
     async (): Promise<void> => {
@@ -293,6 +324,20 @@ export async function runEcsServiceEmulator(
         )
       );
       frontDoorServers = [];
+      // Stop the Lambda-target containers AFTER the front-door servers are
+      // closed so no in-flight request lands on a torn-down RIE container.
+      await Promise.allSettled(
+        frontDoorLambdaRunners.map((r) =>
+          r
+            .stop()
+            .catch((err) =>
+              getLogger().warn(
+                `front-door Lambda target teardown failed: ${err instanceof Error ? err.message : String(err)}`
+              )
+            )
+        )
+      );
+      frontDoorLambdaRunners = [];
       if (profileCredsFile) {
         try {
           await profileCredsFile.dispose();
@@ -352,9 +397,13 @@ export async function runEcsServiceEmulator(
 
     const { boots, frontDoor, warnings } = strategy.resolveBoots(stacks, resolvedTargets);
     for (const w of warnings) logger.warn(w);
-    if (boots.length === 0) {
+    // A front-door whose listeners forward ONLY to Lambda targets (#123) has no
+    // ECS service to boot; it is still runnable (the Lambda containers live
+    // behind the front-door). Only error when there is nothing to run at all.
+    const hasFrontDoorListeners = !!frontDoor && frontDoor.listeners.length > 0;
+    if (boots.length === 0 && !hasFrontDoorListeners) {
       throw new LocalStartServiceError(
-        `No runnable ECS service resolved from ${resolvedTargets.join(', ')}.`
+        `No runnable target resolved from ${resolvedTargets.join(', ')}.`
       );
     }
 
@@ -398,9 +447,10 @@ export async function runEcsServiceEmulator(
     // bind failure should surface before any docker budget is spent. No-op when
     // the strategy returned no plan (start-service / pure compute).
     if (frontDoor && frontDoor.listeners.length > 0) {
-      const built = await buildFrontDoor(frontDoor, options.containerHost, logger);
+      const built = await buildFrontDoor(frontDoor, options, logger);
       frontDoorServers = built.servers;
       frontDoorByService = built.frontDoorByService;
+      frontDoorLambdaRunners = built.lambdaRunners;
     }
 
     sigintHandler = (): void => {
@@ -431,16 +481,32 @@ export async function runEcsServiceEmulator(
       );
     }
 
-    const summary = perTarget
-      .map(
-        (pt) =>
-          `${pt.controller!.service.serviceName} (${pt.controller!.activeReplicaCount()} replica(s))`
-      )
-      .join(', ');
-    logger.info(`Service(s) running: ${summary}.`);
+    if (perTarget.length > 0) {
+      const summary = perTarget
+        .map(
+          (pt) =>
+            `${pt.controller!.service.serviceName} (${pt.controller!.activeReplicaCount()} replica(s))`
+        )
+        .join(', ');
+      logger.info(`Service(s) running: ${summary}.`);
+    } else {
+      // Lambda-target-only front-door (#123): no ECS replicas, just the
+      // Lambda container(s) behind the front-door.
+      logger.info(
+        `Service(s) running: ${frontDoorLambdaRunners.length} Lambda target(s) behind the ALB front-door.`
+      );
+    }
     logger.info('Press ^C to shut down.');
 
-    await Promise.all(perTarget.map((pt) => pt.controller!.waitForShutdown()));
+    if (perTarget.length > 0) {
+      await Promise.all(perTarget.map((pt) => pt.controller!.waitForShutdown()));
+    } else {
+      // Block on a SIGINT/SIGTERM that resolves via the cleanup -> process.exit
+      // path. The front-door + Lambda containers keep serving until then.
+      await new Promise<void>(() => {
+        /* resolved only by the SIGINT/SIGTERM handler's process.exit */
+      });
+    }
   } finally {
     if (sigintHandler) {
       process.off('SIGINT', sigintHandler);
@@ -631,33 +697,69 @@ async function runOneTarget(
  */
 export async function buildFrontDoor(
   plan: FrontDoorPlan,
-  containerHost: string,
+  options: EcsServiceEmulatorOptions,
   logger: ReturnType<typeof getLogger>
 ): Promise<{
   servers: StartedFrontDoorServer[];
   frontDoorByService: Map<string, FrontDoorServicePools>;
+  lambdaRunners: FrontDoorLambdaRunner[];
 }> {
+  const containerHost = options.containerHost;
   const servers: StartedFrontDoorServer[] = [];
-  // poolKey -> { pool, target }. Built lazily so the same (service, container,
-  // port) reuses one pool across listeners / rules.
-  const registry = new Map<string, { pool: FrontDoorEndpointPool; target: PlannedForwardTarget }>();
-  const poolFor = (t: PlannedForwardTarget): FrontDoorEndpointPool => {
+  // ECS poolKey -> { pool, target }. Built lazily so the same (service,
+  // container, port) reuses one pool across listeners / rules.
+  const poolRegistry = new Map<
+    string,
+    { pool: FrontDoorEndpointPool; target: PlannedEcsForwardTarget }
+  >();
+  // Lambda logicalId -> one warm runner, reused across listeners / rules.
+  const lambdaRegistry = new Map<string, FrontDoorLambdaRunner>();
+
+  const dispatchFor = (t: PlannedForwardTarget): FrontDoorDispatchTarget => {
+    if (t.kind === 'lambda') {
+      let runner = lambdaRegistry.get(t.lambda.logicalId);
+      if (!runner) {
+        runner = createFrontDoorLambdaRunner(t.lambda, {
+          containerHost,
+          skipPull: options.pull === false,
+          ...(options.platform !== undefined && { platformOverride: options.platform }),
+          ...(options.ecrRoleArn !== undefined && { ecrRoleArn: options.ecrRoleArn }),
+          ...(options.region !== undefined && { region: options.region }),
+        });
+        lambdaRegistry.set(t.lambda.logicalId, runner);
+      }
+      const boundRunner = runner;
+      return {
+        kind: 'lambda',
+        lambda: {
+          targetGroupArn: t.targetGroupArn,
+          multiValueHeaders: t.multiValueHeaders,
+          label: t.lambda.logicalId,
+          invoke: (event) => boundRunner.invoke(event),
+        },
+      };
+    }
     const key = `${t.serviceTarget} ${t.targetContainerName} ${t.targetContainerPort}`;
-    let entry = registry.get(key);
+    let entry = poolRegistry.get(key);
     if (!entry) {
       entry = { pool: new FrontDoorEndpointPool(), target: t };
-      registry.set(key, entry);
+      poolRegistry.set(key, entry);
     }
-    return entry.pool;
+    return { kind: 'pool', pool: entry.pool };
+  };
+  // Build / reuse the weighted dispatch entry for one planned forward target:
+  // an ECS pool or a Lambda invoker, carrying the target's forward weight.
+  const weightedTargetFor = (t: PlannedForwardTarget): WeightedForwardTarget => {
+    const dispatch = dispatchFor(t);
+    return dispatch.kind === 'lambda'
+      ? { lambda: dispatch.lambda, weight: t.weight }
+      : { pool: dispatch.pool, weight: t.weight };
   };
   // Convert a planned action into the front-door's RouteAction, building /
-  // reusing a pool per weighted forward target.
+  // reusing a pool or Lambda runner per weighted forward target.
   const toRouteAction = (action: PlannedAction): RouteAction => {
     if (action.kind === 'forward') {
-      const pools: WeightedPool[] = action.targets.map((t) => ({
-        pool: poolFor(t),
-        weight: t.weight,
-      }));
+      const pools: WeightedForwardTarget[] = action.targets.map(weightedTargetFor);
       return { kind: 'forward', pools };
     }
     if (action.kind === 'redirect') {
@@ -717,8 +819,18 @@ export async function buildFrontDoor(
         logger.info('  (no default action: unmatched requests return 404)');
       }
     }
+
+    // Boot every distinct Lambda-target container before returning so the
+    // front-door is invokable as soon as it accepts connections. A boot
+    // failure tears down everything started so far (servers + earlier
+    // runners) and propagates with the same `--lb-port` hint envelope.
+    for (const runner of lambdaRegistry.values()) {
+      logger.info(`Booting Lambda target '${runner.logicalId}' behind the ALB front-door...`);
+      await runner.start();
+    }
   } catch (err) {
     await Promise.allSettled(servers.map((s) => s.close()));
+    await Promise.allSettled([...lambdaRegistry.values()].map((r) => r.stop()));
     throw new LocalStartServiceError(
       `Failed to start ALB front-door: ${err instanceof Error ? err.message : String(err)}. If a ` +
         'listener port is privileged (< 1024), remap it to a non-privileged host port with ' +
@@ -727,7 +839,7 @@ export async function buildFrontDoor(
   }
 
   const frontDoorByService = new Map<string, FrontDoorServicePools>();
-  for (const { pool, target } of registry.values()) {
+  for (const { pool, target } of poolRegistry.values()) {
     const list = frontDoorByService.get(target.serviceTarget) ?? [];
     list.push({
       pool,
@@ -736,7 +848,7 @@ export async function buildFrontDoor(
     });
     frontDoorByService.set(target.serviceTarget, list);
   }
-  return { servers, frontDoorByService };
+  return { servers, frontDoorByService, lambdaRunners: [...lambdaRegistry.values()] };
 }
 
 /** Human-readable summary of a planned rule's path / host conditions (for the boot banner). */
@@ -756,11 +868,23 @@ function describeAction(action: PlannedAction): string {
     return `fixed-response ${action.statusCode}`;
   }
   if (action.targets.length === 1) {
-    const t = action.targets[0]!;
-    return `${t.serviceTarget} (container ${t.targetContainerName}:${t.targetContainerPort}) (round-robin)`;
+    return describeTarget(action.targets[0]!);
   }
-  const weights = action.targets.map((t) => `${t.serviceTarget}@${t.weight}`).join(', ');
+  const weights = action.targets.map((t) => `${describeTargetShort(t)}@${t.weight}`).join(', ');
   return `weighted forward [${weights}]`;
+}
+
+/** One forward target, described in full (for a single-target forward banner). */
+function describeTarget(t: PlannedForwardTarget): string {
+  if (t.kind === 'lambda') {
+    return `Lambda ${t.lambda.logicalId} (invoke)`;
+  }
+  return `${t.serviceTarget} (container ${t.targetContainerName}:${t.targetContainerPort}) (round-robin)`;
+}
+
+/** One forward target, described compactly (for a weighted-forward banner). */
+function describeTargetShort(t: PlannedForwardTarget): string {
+  return t.kind === 'lambda' ? `Lambda ${t.lambda.logicalId}` : t.serviceTarget;
 }
 
 async function resolvePlaceholderAccount(arn: string, region: string | undefined): Promise<string> {

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -8,12 +8,14 @@ import {
 } from '../../local/embed-config.js';
 import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import { parseEcsTarget } from '../../local/ecs-task-resolver.js';
+import { resolveLambdaTarget } from '../../local/lambda-resolver.js';
 import { matchStacks } from '../stack-matcher.js';
 import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cdk-path.js';
 import {
   resolveAlbFrontDoor,
   isApplicationLoadBalancer,
   type ResolvedListenerAction,
+  type FrontDoorForwardTarget,
 } from '../../local/elb-front-door-resolver.js';
 import type { ExtraStateProviders } from './local-state-source.js';
 import {
@@ -23,6 +25,7 @@ import {
   type EmulatorStrategy,
   type ServiceBoot,
   type PlannedAction,
+  type PlannedForwardTarget,
   type PlannedFrontDoorListener,
 } from './ecs-service-emulator.js';
 
@@ -179,25 +182,42 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
         const resolution = resolveAlbFrontDoor(stack, albLogicalId);
         warnings.push(...resolution.warnings);
 
-        // Qualify a resolver action into a planned action: forward targets get
-        // their `serviceLogicalId` qualified into a `Stack:LogicalId`
-        // service-boot target (and recorded as a service we must run);
-        // redirect / fixed-response carry no service.
+        // Qualify a resolver target into the front-door plan's target union,
+        // carrying its forward weight. An ECS target becomes a `Stack:LogicalId`
+        // service-boot target (and is recorded as a service we must run); a
+        // Lambda target (#123) is resolved to its `ResolvedLambda` here so the
+        // front-door can boot + invoke it locally (no ECS service to run for it).
+        const qualifyTarget = (t: FrontDoorForwardTarget): PlannedForwardTarget => {
+          if (t.kind === 'lambda') {
+            const lambda = resolveLambdaTarget(`${stack.stackName}:${t.lambdaLogicalId}`, stacks);
+            return {
+              kind: 'lambda',
+              lambda,
+              // The local front-door has no real target-group ARN; surface the
+              // logical id (qualified) so `requestContext.elb.targetGroupArn`
+              // is stable + identifiable in handler logs.
+              targetGroupArn: `${stack.stackName}:${t.targetGroupLogicalId}`,
+              multiValueHeaders: t.multiValueHeaders,
+              weight: t.weight,
+            };
+          }
+          const serviceTarget = `${stack.stackName}:${t.serviceLogicalId}`;
+          serviceTargets.add(serviceTarget);
+          return {
+            kind: 'ecs',
+            serviceTarget,
+            targetContainerName: t.targetContainerName,
+            targetContainerPort: t.targetContainerPort,
+            weight: t.weight,
+          };
+        };
+
+        // Qualify a resolver action into a planned action: a forward qualifies
+        // each weighted target (ECS or Lambda); redirect / fixed-response carry
+        // no backing target.
         const qualify = (action: ResolvedListenerAction): PlannedAction => {
           if (action.kind === 'forward') {
-            return {
-              kind: 'forward',
-              targets: action.targets.map((t) => {
-                const serviceTarget = `${stack.stackName}:${t.serviceLogicalId}`;
-                serviceTargets.add(serviceTarget);
-                return {
-                  serviceTarget,
-                  targetContainerName: t.targetContainerName,
-                  targetContainerPort: t.targetContainerPort,
-                  weight: t.weight,
-                };
-              }),
-            };
+            return { kind: 'forward', targets: action.targets.map(qualifyTarget) };
           }
           if (action.kind === 'redirect') {
             return {

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -308,10 +308,11 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
         'symmetric ALB counterpart of `start-api`. Each <target> accepts a CDK display path ' +
         '(MyStack/MyAlb) or stack-qualified logical ID; single-stack apps may omit the stack ' +
         'prefix. Supports HTTP listeners; path-pattern and host-header rule conditions; forward ' +
-        '(single and weighted), redirect, and fixed-response actions. HTTPS listeners, Lambda ' +
-        'target groups, the other rule conditions (http-header / query-string / source-ip / ' +
-        'http-request-method), and authenticate-* actions are skipped with a warning. Omit ' +
-        '<targets> in an interactive terminal to multi-select the load balancers from a list.'
+        '(single and weighted), redirect, and fixed-response actions; and ECS or Lambda targets ' +
+        '(a Lambda target group is invoked locally via the Lambda RIE). HTTPS listeners, the ' +
+        'other rule conditions (http-header / query-string / source-ip / http-request-method), ' +
+        'and authenticate-* actions are skipped with a warning. Omit <targets> in an interactive ' +
+        'terminal to multi-select the load balancers from a list.'
     )
     .argument(
       '[targets...]',

--- a/src/local/alb-lambda-event.ts
+++ b/src/local/alb-lambda-event.ts
@@ -1,0 +1,325 @@
+import type { IncomingMessage } from 'node:http';
+
+/**
+ * Issue #123 (Lambda-target slice) — translate an inbound HTTP request into the
+ * Application Load Balancer Lambda-target invocation event, and translate the
+ * handler's response back into HTTP components.
+ *
+ * This is the **ALB** Lambda event shape, NOT the API Gateway one (`start-api`
+ * owns that via `api-gateway-event.ts`). The shapes are deliberately distinct:
+ *
+ * Request event (confirmed against the AWS docs
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html):
+ *
+ * ```
+ * {
+ *   "requestContext": { "elb": { "targetGroupArn": "<tg-arn>" } },
+ *   "httpMethod": "GET",
+ *   "path": "/",
+ *   // single-value form (default):
+ *   "queryStringParameters": { "k": "v2" },   // last value wins on dup keys
+ *   "headers":               { "k": "v2" },   // last value wins on dup keys
+ *   // multi-value form (target-group attribute lambda.multi_value_headers.enabled=true):
+ *   "multiValueQueryStringParameters": { "k": ["v1", "v2"] },
+ *   "multiValueHeaders":              { "k": ["v1", "v2"] },
+ *   "body": "<string>",
+ *   "isBase64Encoded": false
+ * }
+ * ```
+ *
+ * Exactly ONE of the single-value / multi-value variants is present, chosen by
+ * the target group's `lambda.multi_value_headers.enabled` attribute. ALB also
+ * stamps `x-amzn-trace-id`, `x-forwarded-for`, `x-forwarded-port`, and
+ * `x-forwarded-proto` on every request — the front-door server already appends
+ * the `x-forwarded-*` set, so the request snapshot reaching this builder carries
+ * them.
+ *
+ * Body base64: when the `content-encoding` header is present, OR the
+ * content-type is not one of `text/*`, `application/json`,
+ * `application/javascript`, `application/xml`, the body is base64-encoded and
+ * `isBase64Encoded` is `true` (mirrors ALB).
+ *
+ * Response (the handler must return): `{ statusCode, statusDescription?,
+ * headers | multiValueHeaders, body?, isBase64Encoded? }`. A malformed response
+ * (no numeric `statusCode`, or a Lambda runtime error envelope) maps to HTTP
+ * 502 — mirroring how a real ALB answers when a Lambda target returns an
+ * invalid response.
+ */
+
+/**
+ * The HTTP request shape the ALB event-builder consumes. Decoupled from
+ * `node:http` so the builder stays pure / unit-testable. Header names are
+ * passed in their on-wire case (lowercased by the builder).
+ */
+export interface AlbHttpRequestSnapshot {
+  /** HTTP method, uppercased (`GET` / `POST` / ...). */
+  method: string;
+  /** Full URL path including query string, NOT decoded. e.g. `/items?a=1&a=2`. */
+  rawUrl: string;
+  /** Headers as a key -> array map (multiple values per name preserved). */
+  headers: Record<string, string[]>;
+  /** Request body as a Buffer. Empty body -> zero-length Buffer. */
+  body: Buffer;
+}
+
+/** Content types ALB treats as text (body sent verbatim, `isBase64Encoded: false`). */
+function isTextualContentType(contentType: string): boolean {
+  const ct = contentType.toLowerCase();
+  return (
+    ct.startsWith('text/') ||
+    ct.startsWith('application/json') ||
+    ct.startsWith('application/javascript') ||
+    ct.startsWith('application/xml')
+  );
+}
+
+/**
+ * Build a `AlbHttpRequestSnapshot` from a live `node:http` request plus the
+ * already-buffered body. Header values arrive as `string | string[]`; this
+ * normalizes them to `string[]` (preserving multi-value) the builder expects.
+ */
+export function snapshotFromIncoming(req: IncomingMessage, body: Buffer): AlbHttpRequestSnapshot {
+  const headers: Record<string, string[]> = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    headers[name] = Array.isArray(value) ? value : [value];
+  }
+  return {
+    method: (req.method ?? 'GET').toUpperCase(),
+    rawUrl: req.url ?? '/',
+    headers,
+    body,
+  };
+}
+
+/** Split a raw URL into its path (query-stripped, not decoded) and raw query string. */
+function splitRawUrl(rawUrl: string): { path: string; rawQuery: string } {
+  const hashIdx = rawUrl.indexOf('#');
+  const noHash = hashIdx === -1 ? rawUrl : rawUrl.slice(0, hashIdx);
+  const qIdx = noHash.indexOf('?');
+  if (qIdx === -1) return { path: noHash, rawQuery: '' };
+  return { path: noHash.slice(0, qIdx), rawQuery: noHash.slice(qIdx + 1) };
+}
+
+/**
+ * Parse a raw query string into single + multi-value maps. ALB does NOT decode
+ * query parameters (the docs explicitly say "If the query parameters are
+ * URL-encoded, the load balancer does not decode them"), so values are kept
+ * verbatim. A bare `?flag` key yields the empty string value.
+ */
+function parseQuery(rawQuery: string): {
+  single: Record<string, string>;
+  multi: Record<string, string[]>;
+} {
+  const single: Record<string, string> = {};
+  const multi: Record<string, string[]> = {};
+  if (rawQuery.length === 0) return { single, multi };
+  for (const pair of rawQuery.split('&')) {
+    if (pair.length === 0) continue;
+    const eq = pair.indexOf('=');
+    const key = eq === -1 ? pair : pair.slice(0, eq);
+    const value = eq === -1 ? '' : pair.slice(eq + 1);
+    // single: last value wins (ALB default-format semantics).
+    single[key] = value;
+    (multi[key] ??= []).push(value);
+  }
+  return { single, multi };
+}
+
+/**
+ * Build the single + multi-value header maps. Names are lowercased; the single
+ * map keeps the LAST value (ALB default-format), the multi map keeps every
+ * value in arrival order.
+ */
+function buildHeaderMaps(headers: Record<string, string[]>): {
+  single: Record<string, string>;
+  multi: Record<string, string[]>;
+} {
+  const single: Record<string, string> = {};
+  const multi: Record<string, string[]> = {};
+  for (const [name, values] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    const list = values.slice();
+    multi[lower] = list;
+    if (list.length > 0) single[lower] = list[list.length - 1]!;
+  }
+  return { single, multi };
+}
+
+/** Header lookup that tolerates the case-folded multi-value request map. */
+function firstHeader(headers: Record<string, string[]>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === lower) return v[0];
+  }
+  return undefined;
+}
+
+export interface BuildAlbLambdaEventOptions {
+  /** The resolved target-group ARN-or-logical-id surfaced under `requestContext.elb`. */
+  targetGroupArn: string;
+  /**
+   * Whether the target group has `lambda.multi_value_headers.enabled=true`.
+   * `true` -> emit `multiValueHeaders` / `multiValueQueryStringParameters`;
+   * `false` (default) -> emit `headers` / `queryStringParameters` (last-wins).
+   */
+  multiValueHeaders: boolean;
+}
+
+/**
+ * Build the ALB Lambda-target invocation event from an HTTP request snapshot.
+ * Emits exactly the single-value OR multi-value variant per
+ * `opts.multiValueHeaders`.
+ */
+export function buildAlbLambdaEvent(
+  req: AlbHttpRequestSnapshot,
+  opts: BuildAlbLambdaEventOptions
+): Record<string, unknown> {
+  const { path, rawQuery } = splitRawUrl(req.rawUrl);
+  const query = parseQuery(rawQuery);
+  const headerMaps = buildHeaderMaps(req.headers);
+
+  const contentEncoding = firstHeader(req.headers, 'content-encoding');
+  const contentType = firstHeader(req.headers, 'content-type') ?? '';
+  const isBase64Encoded =
+    req.body.length > 0 &&
+    (contentEncoding !== undefined ? true : !isTextualContentType(contentType));
+  const body = isBase64Encoded ? req.body.toString('base64') : req.body.toString('utf-8');
+
+  const event: Record<string, unknown> = {
+    requestContext: { elb: { targetGroupArn: opts.targetGroupArn } },
+    httpMethod: req.method,
+    path,
+    isBase64Encoded,
+    body,
+  };
+
+  if (opts.multiValueHeaders) {
+    event['multiValueHeaders'] = headerMaps.multi;
+    event['multiValueQueryStringParameters'] = query.multi;
+  } else {
+    event['headers'] = headerMaps.single;
+    event['queryStringParameters'] = query.single;
+  }
+
+  return event;
+}
+
+/** HTTP response components translated from a Lambda ALB-target response. */
+export interface TranslatedAlbResponse {
+  statusCode: number;
+  /** Optional human status line (ALB `statusDescription`); undefined -> Node default. */
+  statusDescription?: string;
+  /**
+   * Headers as a key -> array map so the server can emit one wire header per
+   * value (e.g. multiple `set-cookie` lines). Names are lowercased.
+   */
+  headers: Record<string, string[]>;
+  /** Body bytes ready to write to the socket. */
+  body: Buffer;
+}
+
+/** A Lambda RIE error envelope (`{errorMessage, errorType, ...}`) with no statusCode. */
+function isErrorEnvelope(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  const obj = payload as Record<string, unknown>;
+  if ('statusCode' in obj) return false;
+  return typeof obj['errorMessage'] === 'string';
+}
+
+/**
+ * The canonical 502 a real ALB returns when a Lambda target's response is
+ * malformed (missing/invalid `statusCode`, non-object payload, or a runtime
+ * error envelope). Plain-text body, mirroring ALB's own 502 page shape closely
+ * enough for local dev.
+ */
+function badGatewayResponse(): TranslatedAlbResponse {
+  const body = Buffer.from('<html><body><h1>502 Bad Gateway</h1></body></html>', 'utf-8');
+  return {
+    statusCode: 502,
+    statusDescription: '502 Bad Gateway',
+    headers: {
+      'content-type': ['text/html'],
+      'content-length': [String(body.length)],
+    },
+    body,
+  };
+}
+
+function stringifyHeaderValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return JSON.stringify(value) ?? '';
+}
+
+/**
+ * Translate a Lambda ALB-target response payload into HTTP components.
+ *
+ * A well-formed response is an object with a numeric `statusCode`. Headers come
+ * from `headers` (single-value) and/or `multiValueHeaders` (array-valued); ALB
+ * accepts either regardless of the request-side multi-value setting, so both
+ * are honored here (multiValueHeaders extend / append to the single map).
+ * `body` is optional; `isBase64Encoded: true` means the body is base64 and is
+ * decoded to raw bytes.
+ *
+ * Anything else -> 502 (matching a real ALB), incl. a runtime error envelope.
+ */
+export function translateAlbLambdaResponse(payload: unknown): TranslatedAlbResponse {
+  if (isErrorEnvelope(payload)) return badGatewayResponse();
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return badGatewayResponse();
+  }
+  const obj = payload as Record<string, unknown>;
+  const statusRaw = obj['statusCode'];
+  if (typeof statusRaw !== 'number' || !Number.isFinite(statusRaw)) {
+    return badGatewayResponse();
+  }
+  const statusCode = Math.trunc(statusRaw);
+
+  const isBase64 = obj['isBase64Encoded'] === true;
+  const rawBody = obj['body'];
+  let body: Buffer;
+  if (rawBody === undefined || rawBody === null) {
+    body = Buffer.alloc(0);
+  } else if (typeof rawBody === 'string') {
+    body = isBase64 ? Buffer.from(rawBody, 'base64') : Buffer.from(rawBody, 'utf-8');
+  } else {
+    body = Buffer.from(JSON.stringify(rawBody), 'utf-8');
+  }
+
+  const headers: Record<string, string[]> = {};
+  const addHeader = (name: string, value: string): void => {
+    const lower = name.toLowerCase();
+    (headers[lower] ??= []).push(value);
+  };
+
+  const singleHeaders = obj['headers'];
+  if (singleHeaders && typeof singleHeaders === 'object' && !Array.isArray(singleHeaders)) {
+    for (const [name, value] of Object.entries(singleHeaders as Record<string, unknown>)) {
+      addHeader(name, stringifyHeaderValue(value));
+    }
+  }
+
+  const multiHeaders = obj['multiValueHeaders'];
+  if (multiHeaders && typeof multiHeaders === 'object' && !Array.isArray(multiHeaders)) {
+    for (const [name, values] of Object.entries(multiHeaders as Record<string, unknown>)) {
+      if (!Array.isArray(values)) continue;
+      for (const v of values) addHeader(name, stringifyHeaderValue(v));
+    }
+  }
+
+  // content-length is informational; emit a correct one from the actual body
+  // bytes so a partial / mismatched length from the handler doesn't lie on the
+  // wire (ALB recomputes it too).
+  headers['content-length'] = [String(body.length)];
+
+  const result: TranslatedAlbResponse = { statusCode, headers, body };
+  const statusDescription = obj['statusDescription'];
+  if (typeof statusDescription === 'string' && statusDescription.length > 0) {
+    result.statusDescription = statusDescription;
+  }
+  return result;
+}

--- a/src/local/elb-front-door-resolver.ts
+++ b/src/local/elb-front-door-resolver.ts
@@ -38,11 +38,13 @@ import type { TemplateResource } from '../types/resource.js';
  * its path / host conditions.
  *
  * Scope: HTTP listeners; `path-pattern` + `host-header` conditions; `forward`
- * (single or weighted) to ECS services; `redirect` / `fixed-response` actions.
- * Skipped with a warning: HTTPS/TLS listeners, `TargetType:"lambda"` target
- * groups, the other condition fields (http-header / http-request-method /
- * query-string / source-ip), and `authenticate-cognito` / `authenticate-oidc`
- * actions. Those remaining listener-rule features are tracked in #123.
+ * (single or weighted) to ECS services AND/OR Lambda functions
+ * (`TargetType:"lambda"` target groups — #123: the TG -> backing
+ * `AWS::Lambda::Function` is resolved and the front-door invokes it locally per
+ * request); `redirect` / `fixed-response` actions. A single weighted forward may
+ * mix ECS and Lambda targets. Skipped with a warning: HTTPS/TLS listeners, the
+ * other condition fields (http-header / http-request-method / query-string /
+ * source-ip), and `authenticate-cognito` / `authenticate-oidc` actions.
  */
 
 const ALB_TYPE = 'AWS::ElasticLoadBalancingV2::LoadBalancer';
@@ -50,9 +52,20 @@ const LISTENER_TYPE = 'AWS::ElasticLoadBalancingV2::Listener';
 const LISTENER_RULE_TYPE = 'AWS::ElasticLoadBalancingV2::ListenerRule';
 const TARGET_GROUP_TYPE = 'AWS::ElasticLoadBalancingV2::TargetGroup';
 const SERVICE_TYPE = 'AWS::ECS::Service';
+const LAMBDA_FUNCTION_TYPE = 'AWS::Lambda::Function';
 
-/** The backing (service, container) one forward target group routes to, plus its weight. */
-export interface FrontDoorForwardTarget {
+/**
+ * The backing target one forward target group routes to, plus its weight. A
+ * discriminated union: either an ECS service (the original `start-alb` path) or
+ * a Lambda function (`TargetType: lambda` target groups, #123). A single
+ * weighted forward may mix both. The front-door dispatches an ECS target to a
+ * replica pool and a Lambda target to a locally-invoked RIE container.
+ */
+export type FrontDoorForwardTarget = FrontDoorEcsTarget | FrontDoorLambdaTarget;
+
+/** A weighted forward target backed by an ECS service behind the target group. */
+export interface FrontDoorEcsTarget {
+  kind: 'ecs';
   /** Logical id of the `AWS::ECS::Service` behind the target group. */
   serviceLogicalId: string;
   /** Container the action forwards to (`LoadBalancers[].ContainerName`). */
@@ -61,6 +74,39 @@ export interface FrontDoorForwardTarget {
   targetContainerPort: number;
   /** Logical id of the resolved target group (diagnostics). */
   targetGroupLogicalId: string;
+  /**
+   * Forward weight for weighted routing. A single-target forward defaults to 1;
+   * a `ForwardConfig.TargetGroups[]` entry carries its declared `Weight`
+   * (weight 0 means "never routed", per ALB semantics).
+   */
+  weight: number;
+}
+
+/**
+ * A weighted forward target backed by a Lambda function (a `TargetType: lambda`
+ * target group, #123). The synthesized linkage:
+ *
+ * ```
+ * ElasticLoadBalancingV2::TargetGroup : { TargetType:"lambda",
+ *     Targets:[{ Id:{ "Fn::GetAtt":[<FnLogicalId>, "Arn"] } }],
+ *     TargetGroupAttributes?:[{ Key:"lambda.multi_value_headers.enabled", Value:"true" }] }
+ * Lambda::Permission                  : grants elasticloadbalancing principal invoke
+ * ```
+ *
+ * The backing function is read from `Targets[0].Id.Fn::GetAtt[0]`.
+ */
+export interface FrontDoorLambdaTarget {
+  kind: 'lambda';
+  /** Logical id of the backing `AWS::Lambda::Function`. */
+  lambdaLogicalId: string;
+  /** Logical id of the resolved target group (diagnostics + `requestContext.elb`). */
+  targetGroupLogicalId: string;
+  /**
+   * `lambda.multi_value_headers.enabled` target-group attribute. `true` ->
+   * the ALB event uses `multiValueHeaders` / `multiValueQueryStringParameters`;
+   * `false` (default) -> single-value `headers` / `queryStringParameters`.
+   */
+  multiValueHeaders: boolean;
   /**
    * Forward weight for weighted routing. A single-target forward defaults to 1;
    * a `ForwardConfig.TargetGroups[]` entry carries its declared `Weight`
@@ -312,7 +358,12 @@ function resolveAction(
   return undefined;
 }
 
-/** Resolve a `forward` action into one or more weighted ECS-service targets. */
+/**
+ * Resolve a `forward` action into one or more weighted targets. Each target
+ * group is either an ECS service (the original `start-alb` path) or a
+ * `TargetType: lambda` group backed by an in-stack Lambda (#123); a single
+ * weighted forward may mix both.
+ */
 function resolveForwardAction(
   action: Record<string, unknown>,
   resources: Record<string, TemplateResource>,
@@ -342,12 +393,19 @@ function resolveForwardAction(
       );
       continue;
     }
-    const tgType = (tg.Properties as Record<string, unknown> | undefined)?.['TargetType'];
+    const tgProps = (tg.Properties as Record<string, unknown> | undefined) ?? {};
+    const tgType = tgProps['TargetType'];
     if (tgType === 'lambda') {
-      warnings.push(
-        `${label} forwards to a Lambda target group '${tgRef}' (TargetType: lambda). The local ALB ` +
-          'front-door supports ECS targets only; Lambda targets are deferred. Skipping that target group.'
+      // #123 Lambda-target slice: resolve the TG -> backing Lambda function.
+      const lambdaTarget = resolveLambdaForwardTarget(
+        tgProps,
+        tgRef,
+        resources,
+        stackName,
+        label,
+        warnings
       );
+      if (lambdaTarget) targets.push({ ...lambdaTarget, weight });
       continue;
     }
     const backing = tgToService.get(tgRef);
@@ -360,6 +418,7 @@ function resolveForwardAction(
       continue;
     }
     targets.push({
+      kind: 'ecs',
       serviceLogicalId: backing.serviceLogicalId,
       targetContainerName: backing.containerName,
       targetContainerPort: backing.containerPort,
@@ -370,6 +429,45 @@ function resolveForwardAction(
 
   if (targets.length === 0) return undefined; // every target group was skipped (already warned)
   return { kind: 'forward', targets };
+}
+
+/**
+ * Resolve a `TargetType: lambda` target group into its `FrontDoorLambdaTarget`
+ * (weight applied by the caller), or `undefined` (with a warning) when the
+ * backing function is not an in-stack `AWS::Lambda::Function` reference.
+ */
+function resolveLambdaForwardTarget(
+  tgProps: Record<string, unknown>,
+  tgRef: string,
+  resources: Record<string, TemplateResource>,
+  stackName: string,
+  label: string,
+  warnings: string[]
+): Omit<FrontDoorLambdaTarget, 'weight'> | undefined {
+  const lambdaLogicalId = resolveLambdaTargetLogicalId(tgProps['Targets']);
+  if (!lambdaLogicalId) {
+    warnings.push(
+      `${label} forwards to a Lambda target group '${tgRef}', but its Targets[].Id is not an ` +
+        'in-stack { "Fn::GetAtt": [<FnLogicalId>, "Arn"] } reference; the local ALB front-door ' +
+        'supports an in-stack Lambda target only (literal / imported ARNs deferred). Skipping that target group.'
+    );
+    return undefined;
+  }
+  const lambda = resources[lambdaLogicalId];
+  if (!lambda || lambda.Type !== LAMBDA_FUNCTION_TYPE) {
+    warnings.push(
+      `${label} forwards to Lambda target group '${tgRef}', whose target resolves to ` +
+        `'${lambdaLogicalId}', but no ${LAMBDA_FUNCTION_TYPE} with that logical id exists in ` +
+        `${stackName}. Skipping that target group.`
+    );
+    return undefined;
+  }
+  return {
+    kind: 'lambda',
+    lambdaLogicalId,
+    targetGroupLogicalId: tgRef,
+    multiValueHeaders: readMultiValueHeadersAttribute(tgProps['TargetGroupAttributes']),
+  };
 }
 
 /** Resolve a `redirect` action into its `Location`-template fields + status code. */
@@ -405,6 +503,45 @@ function resolveFixedResponseAction(
   if (typeof c['ContentType'] === 'string') out.contentType = c['ContentType'];
   if (typeof c['MessageBody'] === 'string') out.messageBody = c['MessageBody'];
   return out;
+}
+
+/**
+ * Resolve a `TargetType: lambda` target group's backing Lambda logical id from
+ * its `Targets[].Id`. CDK synthesizes the registration as
+ * `Targets: [{ Id: { "Fn::GetAtt": [<FnLogicalId>, "Arn"] } }]`; a `Ref` to the
+ * function (its name) is also accepted. Returns the logical id, or `undefined`
+ * when the target is a literal / imported ARN (not an in-stack reference).
+ */
+function resolveLambdaTargetLogicalId(targets: unknown): string | undefined {
+  if (!Array.isArray(targets) || targets.length === 0) return undefined;
+  const first = targets[0];
+  if (!first || typeof first !== 'object') return undefined;
+  const id = (first as Record<string, unknown>)['Id'];
+  if (!id || typeof id !== 'object' || Array.isArray(id)) return undefined;
+  const idObj = id as Record<string, unknown>;
+  const getAtt = idObj['Fn::GetAtt'];
+  if (Array.isArray(getAtt) && typeof getAtt[0] === 'string' && getAtt[0].length > 0) {
+    return getAtt[0];
+  }
+  const ref = idObj['Ref'];
+  if (typeof ref === 'string' && ref.length > 0) return ref;
+  return undefined;
+}
+
+/**
+ * Read the `lambda.multi_value_headers.enabled` target-group attribute (a
+ * string `"true"` / `"false"` in CFn). Defaults to `false` when absent.
+ */
+function readMultiValueHeadersAttribute(attributes: unknown): boolean {
+  if (!Array.isArray(attributes)) return false;
+  for (const attr of attributes) {
+    if (!attr || typeof attr !== 'object') continue;
+    const a = attr as Record<string, unknown>;
+    if (a['Key'] === 'lambda.multi_value_headers.enabled') {
+      return String(a['Value']).toLowerCase() === 'true';
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/local/front-door-lambda-runner.ts
+++ b/src/local/front-door-lambda-runner.ts
@@ -1,0 +1,335 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { getLogger } from '../utils/logger.js';
+import {
+  pickFreePort,
+  pullImage,
+  removeContainer,
+  runDetached,
+  streamLogs,
+} from './docker-runner.js';
+import { architectureToPlatform, buildContainerImage } from './docker-image-builder.js';
+import { pullEcrImage, parseEcrUri } from './ecr-puller.js';
+import { invokeRie, waitForRieReady } from './rie-client.js';
+import {
+  resolveRuntimeCodeMountPath,
+  resolveRuntimeFileExtension,
+  resolveRuntimeImage,
+} from './runtime-image.js';
+import {
+  AssetManifestLoader,
+  getDockerImageBySourceHash,
+} from '../assets/asset-manifest-loader.js';
+import type { ResolvedImageLambda, ResolvedLambda, ResolvedZipLambda } from './lambda-resolver.js';
+import { getEmbedConfig } from './embed-config.js';
+
+/**
+ * Issue #123 (Lambda-target slice) — boot a single Lambda function in a
+ * long-lived RIE container behind a local ALB front-door, and invoke it per
+ * request. This is the Lambda counterpart of the ECS `FrontDoorEndpointPool`:
+ * where an ECS forward target round-robins live replica ports, a Lambda forward
+ * target keeps ONE warm RIE container and invokes it via the same machinery
+ * `cdkl invoke` / `start-api` use (`runDetached` -> `waitForRieReady` ->
+ * `invokeRie`).
+ *
+ * Lifecycle:
+ *   - `start()` resolves the image plan (ZIP base image + bind mount, or a
+ *     built/pulled container image), `docker run`s it detached, and waits for
+ *     RIE to come up. Idempotent — a second `start()` is a no-op.
+ *   - `invoke(event)` POSTs the event to RIE and returns the parsed payload.
+ *     The container serializes invokes on its own (one warm container, like a
+ *     concurrency-1 Lambda locally); the front-door's per-request handling is
+ *     what concurrency the dev loop needs.
+ *   - `stop()` tears the container down + removes any materialized tmpdirs.
+ *     Idempotent.
+ *
+ * Scope: the common ZIP (asset / inline) and IMAGE (local-build / ECR-pull)
+ * cases. Lambda Layers are intentionally NOT mounted here in v1 (the front-door
+ * Lambda-target path targets simple request handlers; layered functions remain
+ * reachable via `cdkl invoke` / `start-api`). Env-var / state substitution and
+ * `--assume-role` credential injection are also out of scope for the v1
+ * front-door Lambda target — the handler runs with the dev shell's forwarded
+ * AWS env (same default as `cdkl invoke` without `--assume-role`).
+ */
+
+export interface FrontDoorLambdaRunnerOptions {
+  /** Host interface to bind the RIE port to (the `--container-host` value). */
+  containerHost: string;
+  /** Skip `docker pull` for the base image (the `--no-pull` flag). */
+  skipPull?: boolean;
+  /** Force `docker run --platform` for the IMAGE path. */
+  platformOverride?: string;
+  /** Role ARN to assume before authenticating against ECR (IMAGE ECR-pull path). */
+  ecrRoleArn?: string;
+  /** Region passed to the ECR-pull fallback. */
+  region?: string;
+  /** Whether to attach `docker logs -f`. Default true. */
+  streamLogs?: boolean;
+}
+
+interface ImagePlan {
+  image: string;
+  mounts: { hostPath: string; containerPath: string; readOnly?: boolean }[];
+  cmd: string[];
+  platform?: string;
+  entryPoint?: string[];
+  workingDir?: string;
+  /** Temp dir to remove on stop (materialized inline ZIP code). */
+  inlineTmpDir?: string;
+}
+
+/** Forward the dev shell's AWS credential / region env into the Lambda container. */
+function forwardAwsEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  const passThrough = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_REGION',
+    'AWS_DEFAULT_REGION',
+  ] as const;
+  for (const key of passThrough) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+/**
+ * Materialize an inline (`Code.ZipFile`) ZIP Lambda's source into a temp dir at
+ * the path implied by `handler`, returning the dir to bind-mount. Mirrors
+ * `local-invoke.ts:materializeInlineCode`.
+ */
+function materializeInlineCode(handler: string, source: string, fileExtension: string): string {
+  const lastDot = handler.lastIndexOf('.');
+  if (lastDot <= 0) {
+    throw new Error(`Handler '${handler}' is malformed: expected '<modulePath>.<exportName>'.`);
+  }
+  const modulePath = handler.substring(0, lastDot);
+  const dir = mkdtempSync(
+    path.join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-alb-lambda-`)
+  );
+  const filePath = path.join(dir, `${modulePath}${fileExtension}`);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, source, 'utf-8');
+  return dir;
+}
+
+async function resolveZipImagePlan(
+  lambda: ResolvedZipLambda,
+  opts: FrontDoorLambdaRunnerOptions
+): Promise<ImagePlan> {
+  let inlineTmpDir: string | undefined;
+  let codeDir = lambda.codePath;
+  if (codeDir === null) {
+    inlineTmpDir = materializeInlineCode(
+      lambda.handler,
+      lambda.inlineCode ?? '',
+      resolveRuntimeFileExtension(lambda.runtime)
+    );
+    codeDir = inlineTmpDir;
+  }
+  const image = resolveRuntimeImage(lambda.runtime);
+  await pullImage(image, opts.skipPull === true);
+  const containerCodePath = resolveRuntimeCodeMountPath(lambda.runtime);
+  return {
+    image,
+    mounts: [{ hostPath: codeDir, containerPath: containerCodePath, readOnly: true }],
+    cmd: [lambda.handler],
+    ...(inlineTmpDir !== undefined && { inlineTmpDir }),
+  };
+}
+
+async function resolveContainerImagePlan(
+  lambda: ResolvedImageLambda,
+  opts: FrontDoorLambdaRunnerOptions
+): Promise<ImagePlan> {
+  const logger = getLogger().child('front-door-lambda');
+  const platform = opts.platformOverride ?? architectureToPlatform(lambda.architecture);
+
+  const manifestPath = lambda.stack.assetManifestPath;
+  let imageRef: string;
+  let localBuilt = false;
+  if (manifestPath) {
+    const cdkOutDir = path.dirname(manifestPath);
+    const loader = new AssetManifestLoader();
+    const manifest = await loader.loadManifest(cdkOutDir, lambda.stack.stackName);
+    const entry = manifest ? getDockerImageBySourceHash(manifest, lambda.imageUri) : undefined;
+    if (entry) {
+      imageRef = await buildContainerImage(entry.asset, cdkOutDir, {
+        architecture: lambda.architecture,
+      });
+      localBuilt = true;
+    }
+  }
+  if (!localBuilt) {
+    if (!parseEcrUri(lambda.imageUri)) {
+      throw new Error(
+        `Container Lambda '${lambda.logicalId}' has no matching asset in cdk.out, and Code.ImageUri ` +
+          `'${lambda.imageUri}' is not an ECR URI ${getEmbedConfig().binaryName} can authenticate against. ` +
+          'Re-synthesize the CDK app or deploy the image to ECR first.'
+      );
+    }
+    logger.info(`No matching cdk.out asset for ${lambda.imageUri}; falling back to ECR pull...`);
+    imageRef = await pullEcrImage(lambda.imageUri, {
+      skipPull: opts.skipPull === true,
+      ...(opts.region !== undefined && { region: opts.region }),
+      ...(opts.ecrRoleArn !== undefined && { ecrRoleArn: opts.ecrRoleArn }),
+    });
+  }
+
+  return {
+    image: imageRef!,
+    mounts: [],
+    cmd: lambda.imageConfig.command ?? [],
+    platform,
+    ...(lambda.imageConfig.entryPoint &&
+      lambda.imageConfig.entryPoint.length > 0 && {
+        entryPoint: lambda.imageConfig.entryPoint,
+      }),
+    ...(lambda.imageConfig.workingDirectory !== undefined && {
+      workingDir: lambda.imageConfig.workingDirectory,
+    }),
+  };
+}
+
+/**
+ * A booted, invokable Lambda behind the front-door. Reuses the same RIE
+ * container machinery as `cdkl invoke`. Construct via {@link createFrontDoorLambdaRunner}.
+ */
+export interface FrontDoorLambdaRunner {
+  /** Logical id of the backing `AWS::Lambda::Function` (diagnostics). */
+  readonly logicalId: string;
+  /** Boot the RIE container (idempotent). Throws if the container never becomes ready. */
+  start(): Promise<void>;
+  /** Invoke the warm container with the ALB event; returns the parsed RIE payload. */
+  invoke(event: unknown, timeoutMs?: number): Promise<unknown>;
+  /** Tear the container down + remove any materialized tmpdirs (idempotent). */
+  stop(): Promise<void>;
+}
+
+/**
+ * Build a {@link FrontDoorLambdaRunner} for a resolved Lambda. Construction is
+ * pure (no docker work); `start()` does the boot. The invoke timeout defaults
+ * to `max(30s, timeoutSec * 2 * 1000)` — same formula as `cdkl invoke`.
+ */
+export function createFrontDoorLambdaRunner(
+  lambda: ResolvedLambda,
+  opts: FrontDoorLambdaRunnerOptions
+): FrontDoorLambdaRunner {
+  const logger = getLogger().child('front-door-lambda');
+  const defaultTimeoutMs = Math.max(30_000, lambda.timeoutSec * 2 * 1000);
+
+  let plan: ImagePlan | undefined;
+  let containerId: string | undefined;
+  let hostPort: number | undefined;
+  let stopLogStream: (() => void) | undefined;
+  let starting: Promise<void> | undefined;
+  let stopped = false;
+
+  async function doStart(): Promise<void> {
+    plan =
+      lambda.kind === 'zip'
+        ? await resolveZipImagePlan(lambda, opts)
+        : await resolveContainerImagePlan(lambda, opts);
+    const port = await pickFreePort();
+    hostPort = port;
+    const name = `${getEmbedConfig().resourceNamePrefix}-alblambda-${lambda.logicalId}-${process.pid}-${Math.floor(
+      Math.random() * 1_000_000
+    )}`;
+    const env: Record<string, string> = {
+      AWS_LAMBDA_FUNCTION_NAME: lambda.logicalId,
+      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: String(lambda.memoryMb),
+      AWS_LAMBDA_FUNCTION_TIMEOUT: String(lambda.timeoutSec),
+      AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
+      AWS_LAMBDA_LOG_GROUP_NAME: `/aws/lambda/${lambda.logicalId}`,
+      AWS_LAMBDA_LOG_STREAM_NAME: 'local',
+      ...forwardAwsEnv(),
+    };
+    logger.info(
+      `Starting Lambda target container for ${lambda.logicalId} (image=${plan.image}, port=${port})...`
+    );
+    const id = await runDetached({
+      image: plan.image,
+      mounts: plan.mounts,
+      env,
+      cmd: plan.cmd,
+      hostPort: port,
+      host: opts.containerHost,
+      name,
+      ...(plan.platform !== undefined && { platform: plan.platform }),
+      ...(plan.entryPoint !== undefined && { entryPoint: plan.entryPoint }),
+      ...(plan.workingDir !== undefined && { workingDir: plan.workingDir }),
+    });
+    containerId = id;
+    stopLogStream = opts.streamLogs === false ? undefined : streamLogs(id);
+    try {
+      await waitForRieReady(opts.containerHost, port, 30_000);
+    } catch (err) {
+      // RIE never came up — clean up before propagating so we don't leak.
+      try {
+        stopLogStream?.();
+      } catch {
+        /* swallow */
+      }
+      await removeContainer(id).catch(() => undefined);
+      containerId = undefined;
+      throw err;
+    }
+  }
+
+  return {
+    logicalId: lambda.logicalId,
+    async start(): Promise<void> {
+      if (stopped) throw new Error('FrontDoorLambdaRunner.start called after stop');
+      if (containerId) return;
+      if (!starting) starting = doStart();
+      await starting;
+    },
+    async invoke(event: unknown, timeoutMs?: number): Promise<unknown> {
+      if (!containerId || hostPort === undefined) {
+        throw new Error(
+          `FrontDoorLambdaRunner('${lambda.logicalId}').invoke called before start() completed.`
+        );
+      }
+      const result = await invokeRie(
+        opts.containerHost,
+        hostPort,
+        event,
+        timeoutMs ?? defaultTimeoutMs
+      );
+      return result.payload;
+    },
+    async stop(): Promise<void> {
+      if (stopped) return;
+      stopped = true;
+      try {
+        stopLogStream?.();
+      } catch (err) {
+        logger.debug(
+          `stopLogStream(${lambda.logicalId}) failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      if (containerId) {
+        try {
+          await removeContainer(containerId);
+        } catch (err) {
+          logger.warn(
+            `Failed to remove Lambda target container for ${lambda.logicalId}: ${err instanceof Error ? err.message : String(err)}. Continuing cleanup.`
+          );
+        }
+        containerId = undefined;
+      }
+      if (plan?.inlineTmpDir) {
+        try {
+          rmSync(plan.inlineTmpDir, { recursive: true, force: true });
+        } catch (err) {
+          logger.debug(
+            `Failed to remove inline-code tmpdir ${plan.inlineTmpDir}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    },
+  };
+}

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -7,6 +7,12 @@ import {
 } from 'node:http';
 import { getLogger } from '../utils/logger.js';
 import type { FrontDoorEndpointPool } from './front-door-pool.js';
+import {
+  buildAlbLambdaEvent,
+  snapshotFromIncoming,
+  translateAlbLambdaResponse,
+  type TranslatedAlbResponse,
+} from './alb-lambda-event.js';
 
 /**
  * Host-side ALB front-door. A plain HTTP reverse proxy bound to the ALB's
@@ -25,18 +31,50 @@ import type { FrontDoorEndpointPool } from './front-door-pool.js';
  *     default action (`undefined` when neither matches, which the proxy answers
  *     with 404 — like an ALB rule miss with no default).
  *
- * The replicas publish their target container port on ephemeral host ports
- * (the daemon-in-a-VM reality on macOS means the host can't reach container
- * IPs directly), so the proxy forwards to `127.0.0.1:<ephemeralPort>` rather
- * than to docker-network addresses — cross-platform by construction.
+ * A weighted `forward` action's targets are EITHER an ECS replica pool
+ * ({@link FrontDoorEndpointPool}) OR a Lambda invoker (#123 Lambda-target slice),
+ * and a single forward may mix both. The weighted pick selects one target per
+ * request. For an ECS pool, the proxy round-robins a live replica and
+ * reverse-proxies the raw HTTP request to `127.0.0.1:<ephemeralPort>` (the
+ * daemon-in-a-VM reality on macOS means the host can't reach container IPs
+ * directly, so replicas publish their target port on ephemeral host ports). For
+ * a Lambda target, the proxy translates the request into the ALB Lambda-target
+ * event, invokes the function locally, and translates the response back — a
+ * malformed handler response yields 502, mirroring a real ALB.
  *
- * Scope: per-request round-robin + weighted forward, redirect / fixed-response
- * synthesis, HTTP only, `path-pattern` + `host-header` rule routing. No
- * health-check-gated draining, no sticky sessions, no websocket `Upgrade`
- * proxying, no TLS termination (tracked in #123).
+ * Callers that only ever route to a single ECS-or-Lambda target per path may use
+ * the simpler {@link StartFrontDoorServerOptions.selectTarget} /
+ * {@link StartFrontDoorServerOptions.selectPool} selectors instead of `route`.
+ *
+ * Scope: per-request round-robin + weighted forward (ECS pools and/or Lambda
+ * invokers), redirect / fixed-response synthesis, HTTP only, `path-pattern` +
+ * `host-header` rule routing. No health-check-gated draining, no sticky
+ * sessions, no websocket `Upgrade` proxying, no TLS termination.
  */
 
-/** One weighted member of a forward action's pool set. */
+/**
+ * A Lambda forward target the front-door invokes locally per request. The
+ * `invoke` callback boots-lazily / reuses a warm RIE container under the hood
+ * (see `front-door-lambda-runner.ts`); this interface keeps the server decoupled
+ * from the container machinery for testability.
+ */
+export interface FrontDoorLambdaTarget {
+  /** The resolved target-group ARN-or-id surfaced under `requestContext.elb`. */
+  targetGroupArn: string;
+  /** Whether the TG has `lambda.multi_value_headers.enabled=true`. */
+  multiValueHeaders: boolean;
+  /** Invoke the backing Lambda with the ALB event; resolves the parsed payload. */
+  invoke: (event: Record<string, unknown>) => Promise<unknown>;
+  /** Human label for log lines (e.g. the Lambda logical id). */
+  label: string;
+}
+
+/** A resolved front-door dispatch target: an ECS replica pool or a Lambda invoker. */
+export type FrontDoorDispatchTarget =
+  | { kind: 'pool'; pool: FrontDoorEndpointPool }
+  | { kind: 'lambda'; lambda: FrontDoorLambdaTarget };
+
+/** One weighted member of a forward action backed by an ECS replica pool. */
 export interface WeightedPool {
   /** The live-replica pool for one (service, container, port) target group. */
   pool: FrontDoorEndpointPool;
@@ -44,11 +82,26 @@ export interface WeightedPool {
   weight: number;
 }
 
-/** A resolved forward action: pick a pool by weight, then round-robin its replicas. */
+/** One weighted member of a forward action backed by a Lambda invoker (#123). */
+export interface WeightedLambda {
+  /** The Lambda invoker for one `TargetType: lambda` target group. */
+  lambda: FrontDoorLambdaTarget;
+  /** Forward weight (>= 0; weight 0 is never selected, per ALB semantics). */
+  weight: number;
+}
+
+/** One weighted forward target: an ECS pool OR a Lambda invoker. */
+export type WeightedForwardTarget = WeightedPool | WeightedLambda;
+
+/**
+ * A resolved forward action: pick a target by weight, then dispatch it (an ECS
+ * pool round-robins a replica; a Lambda invoker is invoked locally). A single
+ * forward may mix ECS and Lambda targets.
+ */
 export interface ForwardRouteAction {
   kind: 'forward';
-  /** Weighted pools (length >= 1; a single-target forward is one entry, weight 1). */
-  pools: WeightedPool[];
+  /** Weighted targets (length >= 1; a single-target forward is one entry, weight 1). */
+  pools: WeightedForwardTarget[];
 }
 
 /** A resolved redirect action: synthesize a 301 / 302 with a `Location` header. */
@@ -85,9 +138,23 @@ export interface StartFrontDoorServerOptions {
   /**
    * Resolve the action to serve a request, given its path + Host header.
    * Returns `undefined` when no rule matched and there is no default action
-   * (the proxy then replies 404).
+   * (the proxy then replies 404). This is the full router: a `forward` action's
+   * weighted targets may mix ECS pools and Lambda invokers, plus `redirect` /
+   * `fixed-response` actions and host-header matching. Takes precedence over the
+   * single-target {@link selectTarget} / {@link selectPool} selectors.
    */
-  route: (req: FrontDoorRouteRequest) => RouteAction | undefined;
+  route?: (req: FrontDoorRouteRequest) => RouteAction | undefined;
+  /**
+   * Single-target selector (ECS pool only) for a request path. Returns
+   * `undefined` -> 404. A convenience for callers that never weight / redirect.
+   */
+  selectPool?: (requestPath: string) => FrontDoorEndpointPool | undefined;
+  /**
+   * Generalized single-target selection (#123): choose either an ECS pool or a
+   * Lambda invoker for a request path. Returns `undefined` -> 404. When several
+   * selectors are provided, `route` wins, then `selectTarget`, then `selectPool`.
+   */
+  selectTarget?: (requestPath: string) => FrontDoorDispatchTarget | undefined;
   /** Host port to bind (the listener port, or its `--lb-port` override). */
   port: number;
   /** Host interface to bind. Defaults to `127.0.0.1`. */
@@ -161,26 +228,37 @@ export async function startFrontDoorServer(
   };
 }
 
+/**
+ * Resolve the dispatch target for a request path from whichever selector the
+ * caller supplied. `selectTarget` (#123, ECS-or-Lambda) wins over the
+ * pool-only `selectPool`; a `selectPool` hit is adapted to a `kind: 'pool'`
+ * target so the request handler has a single code path.
+ */
+function resolveDispatchTarget(
+  opts: StartFrontDoorServerOptions,
+  requestPath: string
+): FrontDoorDispatchTarget | undefined {
+  if (opts.selectTarget) return opts.selectTarget(requestPath);
+  if (opts.selectPool) {
+    const pool = opts.selectPool(requestPath);
+    return pool ? { kind: 'pool', pool } : undefined;
+  }
+  return undefined;
+}
+
 function handleProxyRequest(
   req: IncomingMessage,
   res: ServerResponse,
   opts: StartFrontDoorServerOptions
 ): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const url = req.url ?? '/';
+  const url = req.url ?? '/';
+
+  // The full router path (host-header rules, weighted forward, redirect /
+  // fixed-response) takes precedence. The single-target selectors are a
+  // convenience for callers that never weight / redirect.
+  if (opts.route) {
     const action = opts.route({ path: url, ...hostHeader(req) });
-    if (!action) {
-      // No rule matched and no default action — mirror an ALB listener with no
-      // matching rule and no default (404).
-      writeError(
-        res,
-        404,
-        `No listener rule matched '${url}' on ${opts.label}, and the listener has no ` +
-          'default action forwarding to a local target.'
-      );
-      resolve();
-      return;
-    }
+    if (!action) return reply404(req, res, opts);
 
     if (action.kind === 'redirect' || action.kind === 'fixed-response') {
       // Drain any request body (ALB serves redirect / fixed-response for every
@@ -189,22 +267,54 @@ function handleProxyRequest(
       req.resume();
       if (action.kind === 'redirect') writeRedirect(res, action, req, opts.listenerPort);
       else writeFixedResponse(res, action);
-      resolve();
-      return;
+      return Promise.resolve();
     }
 
-    const pool = pickWeightedPool(action.pools);
-    if (!pool) {
-      // Every pool has weight 0 (or none) — mirror an ALB whose rule forwards
+    const picked = pickWeightedTarget(action.pools);
+    if (!picked) {
+      // Every target has weight 0 (or none) — mirror an ALB whose rule forwards
       // nowhere usable (502, like a misconfigured forward).
       writeError(
         res,
         502,
         `No forward target selected behind ${opts.label} (every weighted target has weight 0).`
       );
-      resolve();
-      return;
+      return Promise.resolve();
     }
+    if ('lambda' in picked) return handleLambdaRequest(req, res, picked.lambda, opts);
+    return handlePoolRequest(req, res, picked.pool, opts);
+  }
+
+  const target = resolveDispatchTarget(opts, url);
+  if (!target) return reply404(req, res, opts);
+  if (target.kind === 'lambda') {
+    return handleLambdaRequest(req, res, target.lambda, opts);
+  }
+  return handlePoolRequest(req, res, target.pool, opts);
+}
+
+/** Reply 404 — an ALB listener with no matching rule and no default action. */
+function reply404(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: StartFrontDoorServerOptions
+): Promise<void> {
+  writeError(
+    res,
+    404,
+    `No listener rule matched '${req.url ?? '/'}' on ${opts.label}, and the listener has no ` +
+      'default action forwarding to a local target.'
+  );
+  return Promise.resolve();
+}
+
+function handlePoolRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pool: FrontDoorEndpointPool,
+  opts: StartFrontDoorServerOptions
+): Promise<void> {
+  return new Promise<void>((resolve) => {
     const endpoint = pool.next();
     if (!endpoint) {
       // No live replica — mirror an ALB with no healthy targets (503).
@@ -302,30 +412,43 @@ function hostHeader(req: IncomingMessage): { host?: string } {
 }
 
 /**
- * Pick one pool from a weighted set: weighted random over the non-zero weights.
- * A single-entry set short-circuits to that pool. Returns `undefined` when
- * every weight is 0 (an ALB-valid but un-routable forward).
+ * Pick one weighted target from a forward set: weighted random over the
+ * non-zero weights. A single-entry set short-circuits to that entry. Returns
+ * `undefined` when every weight is 0 (an ALB-valid but un-routable forward).
+ * Used for forwards that may mix ECS pools and Lambda invokers.
+ */
+export function pickWeightedTarget(
+  targets: readonly WeightedForwardTarget[]
+): WeightedForwardTarget | undefined {
+  if (targets.length === 0) return undefined;
+  if (targets.length === 1) return targets[0]!.weight > 0 ? targets[0]! : undefined;
+  const total = targets.reduce((sum, t) => sum + Math.max(0, t.weight), 0);
+  if (total <= 0) return undefined;
+  let roll = Math.random() * total;
+  for (const t of targets) {
+    const w = Math.max(0, t.weight);
+    if (w === 0) continue;
+    roll -= w;
+    if (roll < 0) return t;
+  }
+  // Floating-point edge: roll landed exactly at the total. Return the last
+  // non-zero-weight target.
+  for (let i = targets.length - 1; i >= 0; i--) {
+    if (Math.max(0, targets[i]!.weight) > 0) return targets[i]!;
+  }
+  return undefined;
+}
+
+/**
+ * Pick one pool from a weighted pool set (ECS-only forwards): a convenience
+ * over {@link pickWeightedTarget} that returns just the pool. Returns
+ * `undefined` when every weight is 0.
  */
 export function pickWeightedPool(
   pools: readonly WeightedPool[]
 ): FrontDoorEndpointPool | undefined {
-  if (pools.length === 0) return undefined;
-  if (pools.length === 1) return pools[0]!.weight > 0 ? pools[0]!.pool : undefined;
-  const total = pools.reduce((sum, p) => sum + Math.max(0, p.weight), 0);
-  if (total <= 0) return undefined;
-  let roll = Math.random() * total;
-  for (const p of pools) {
-    const w = Math.max(0, p.weight);
-    if (w === 0) continue;
-    roll -= w;
-    if (roll < 0) return p.pool;
-  }
-  // Floating-point edge: roll landed exactly at the total. Return the last
-  // non-zero-weight pool.
-  for (let i = pools.length - 1; i >= 0; i--) {
-    if (Math.max(0, pools[i]!.weight) > 0) return pools[i]!.pool;
-  }
-  return undefined;
+  const picked = pickWeightedTarget(pools);
+  return picked && 'pool' in picked ? picked.pool : undefined;
 }
 
 /**
@@ -405,6 +528,117 @@ function writeFixedResponse(res: ServerResponse, action: FixedResponseRouteActio
     'content-length': String(Buffer.byteLength(body)),
   });
   res.end(body);
+}
+
+/** Maximum request body the ALB Lambda-target path buffers (ALB's own limit is 1 MB). */
+const ALB_LAMBDA_MAX_BODY_BYTES = 1024 * 1024;
+
+/**
+ * Serve a request that resolved to a Lambda forward target (#123). Buffers the
+ * request body (ALB caps the Lambda-target request body at 1 MB), translates
+ * the request into the ALB Lambda-target event, invokes the function locally,
+ * and writes the translated response. A malformed handler response or an
+ * invoke failure surfaces as 502 — mirroring a real ALB.
+ */
+function handleLambdaRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  lambda: FrontDoorLambdaTarget,
+  opts: StartFrontDoorServerOptions
+): Promise<void> {
+  const logger = getLogger().child('front-door');
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let aborted = false;
+    req.on('data', (chunk: Buffer) => {
+      if (aborted) return;
+      total += chunk.length;
+      if (total > ALB_LAMBDA_MAX_BODY_BYTES) {
+        aborted = true;
+        // ALB returns 413 when the request body exceeds the 1 MB Lambda-target
+        // limit; mirror that locally.
+        writeError(
+          res,
+          413,
+          `Request body exceeds the ${ALB_LAMBDA_MAX_BODY_BYTES}-byte Lambda-target limit on ${opts.label}.`
+        );
+        req.destroy();
+        done();
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on('error', () => {
+      if (!res.headersSent) writeError(res, 400, `Failed to read request body on ${opts.label}.`);
+      done();
+    });
+
+    req.on('end', () => {
+      if (aborted) return;
+      // Self-contained async task; every failure path (invoke rejection,
+      // unexpected synchronous throw) lands on a 502 + `done()` INSIDE the
+      // function via the surrounding try/catch, so it never rejects — invoked
+      // with `void`, no promise callback the linter would flag.
+      const serveLambda = async (): Promise<void> => {
+        try {
+          const body = Buffer.concat(chunks);
+          // ALB stamps the x-forwarded-* set onto the Lambda event; reuse the
+          // same header injection as the ECS proxy path so the event a handler
+          // sees locally matches production.
+          const forwardHeaders: NodeJS.Dict<string | string[]> = { ...req.headers };
+          appendForwardedHeaders(forwardHeaders, req, opts.listenerPort);
+          const snapshot = snapshotFromIncoming(req, body);
+          for (const [name, value] of Object.entries(forwardHeaders)) {
+            if (value === undefined) continue;
+            snapshot.headers[name] = Array.isArray(value) ? value : [value];
+          }
+          const event = buildAlbLambdaEvent(snapshot, {
+            targetGroupArn: lambda.targetGroupArn,
+            multiValueHeaders: lambda.multiValueHeaders,
+          });
+
+          const payload = await lambda.invoke(event);
+          const translated: TranslatedAlbResponse = translateAlbLambdaResponse(payload);
+
+          if (res.headersSent || res.writableEnded) {
+            done();
+            return;
+          }
+          const outHeaders: Record<string, string | string[]> = {};
+          for (const [name, values] of Object.entries(translated.headers)) {
+            outHeaders[name] = values.length === 1 ? values[0]! : values;
+          }
+          if (translated.statusDescription) {
+            res.writeHead(translated.statusCode, translated.statusDescription, outHeaders);
+          } else {
+            res.writeHead(translated.statusCode, outHeaders);
+          }
+          res.end(translated.body);
+          done();
+        } catch (err) {
+          logger.debug(
+            `Lambda target '${lambda.label}' request failed: ${err instanceof Error ? err.message : String(err)}`
+          );
+          if (!res.headersSent) {
+            writeError(res, 502, `Lambda target '${lambda.label}' behind ${opts.label} failed.`);
+          } else if (!res.writableEnded) {
+            res.destroy();
+          }
+          done();
+        }
+      };
+      void serveLambda();
+    });
+  });
 }
 
 /** Standard hop-by-hop headers (RFC 7230 §6.1) — a proxy must not forward these. */

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -595,6 +595,10 @@ function handleLambdaRequest(
           // same header injection as the ECS proxy path so the event a handler
           // sees locally matches production.
           const forwardHeaders: NodeJS.Dict<string | string[]> = { ...req.headers };
+          // Strip hop-by-hop headers (as the ECS proxy path does) so the Lambda
+          // event's headers match what a real ALB forwards — no connection /
+          // transfer-encoding / keep-alive leaking into the handler.
+          stripHopByHopHeaders(forwardHeaders);
           appendForwardedHeaders(forwardHeaders, req, opts.listenerPort);
           const snapshot = snapshotFromIncoming(req, body);
           for (const [name, value] of Object.entries(forwardHeaders)) {

--- a/tests/integration/local-start-alb-lambda/.gitignore
+++ b/tests/integration/local-start-alb-lambda/.gitignore
@@ -1,0 +1,3 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is tracked.
+!lambda/*.js

--- a/tests/integration/local-start-alb-lambda/bin/app.ts
+++ b/tests/integration/local-start-alb-lambda/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbLambdaStack } from '../lib/local-start-alb-lambda-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbLambdaStack(app, 'CdkLocalStartAlbLambdaFixture', {
+  description: 'Fixture stack for cdkl start-alb -> Lambda target group integ test (#123)',
+});

--- a/tests/integration/local-start-alb-lambda/cdk.json
+++ b/tests/integration/local-start-alb-lambda/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-lambda/lambda/index.js
+++ b/tests/integration/local-start-alb-lambda/lambda/index.js
@@ -1,0 +1,25 @@
+// ALB Lambda-target handler (#123). Echoes the parts of the ALB event the
+// integ harness asserts on, so verify.sh can confirm the HTTP -> ALB-event
+// translation AND the response -> HTTP translation round-trip.
+exports.handler = async (event) => {
+  const body = JSON.stringify({
+    role: 'lambda',
+    // Confirms the front-door built the ALB Lambda-target event shape.
+    hasElbContext: !!(event.requestContext && event.requestContext.elb),
+    httpMethod: event.httpMethod,
+    path: event.path,
+    queryStringParameters: event.queryStringParameters ?? null,
+    multiValueQueryStringParameters: event.multiValueQueryStringParameters ?? null,
+    greeting: process.env.GREETING ?? 'unset',
+  });
+  return {
+    statusCode: 200,
+    statusDescription: '200 OK',
+    isBase64Encoded: false,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Handler': 'alb-lambda-fixture',
+    },
+    body,
+  };
+};

--- a/tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts
+++ b/tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts
@@ -1,0 +1,95 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Construct } from 'constructs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture for `cdkl start-alb` -> Lambda target groups (#123 Lambda-target
+ * slice).
+ *
+ * Hand-rolls the synthesized shape of an ALB whose single HTTP:80 listener
+ * forwards to Lambda functions (`TargetType: lambda` target groups), using L1
+ * ELBv2 resources so the fixture stays VPC-free and deterministic (cdk-local
+ * only reads the template; it never deploys to AWS):
+ *
+ *   - `EchoFn` (asset-backed Node.js Lambda) behind `EchoTargetGroup` — the
+ *     listener DEFAULT action forwards here. The handler echoes the ALB event
+ *     it received (httpMethod / path / query / requestContext.elb presence) so
+ *     the harness can assert the HTTP -> ALB-Lambda-event translation.
+ *   - `ApiFn` (asset-backed, shares the same code) behind `ApiTargetGroup`
+ *     (with `lambda.multi_value_headers.enabled=true`) — a
+ *     `AWS::ElasticLoadBalancingV2::ListenerRule` (priority 10, `path-pattern`
+ *     `/api/*`) path-routes here, exercising the multiValueQueryStringParameters
+ *     event variant.
+ *
+ * The synth linkage mirrors a real `TargetType: lambda` target group:
+ *   TargetGroup.Targets[].Id = { "Fn::GetAtt": [<FnLogicalId>, "Arn"] }
+ *   + an AWS::Lambda::Permission for the elasticloadbalancing principal.
+ *
+ * `covers: AWS::Lambda::Function` (matrix opt-in marker — the front-door boots
+ * a Lambda target locally via RIE).
+ */
+export class LocalStartAlbLambdaStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const code = lambda.Code.fromAsset(path.join(__dirname, '../lambda'));
+
+    const echoFn = new lambda.Function(this, 'EchoFn', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code,
+      environment: { GREETING: 'hello' },
+      timeout: cdk.Duration.seconds(10),
+    });
+    const apiFn = new lambda.Function(this, 'ApiFn', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code,
+      environment: { GREETING: 'api-hello' },
+      timeout: cdk.Duration.seconds(10),
+    });
+
+    // ALB front-door is invoked directly (no real network); the ELBv2 L1
+    // resources only need the shape cdk-local reads.
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'AlbLB', { type: 'application' });
+
+    const echoTg = new elbv2.CfnTargetGroup(this, 'EchoTargetGroup', {
+      targetType: 'lambda',
+      targets: [{ id: echoFn.functionArn }],
+    });
+    const apiTg = new elbv2.CfnTargetGroup(this, 'ApiTargetGroup', {
+      targetType: 'lambda',
+      targets: [{ id: apiFn.functionArn }],
+      targetGroupAttributes: [{ key: 'lambda.multi_value_headers.enabled', value: 'true' }],
+    });
+
+    // ALB invoke permissions (realistic synth; cdk-local does not enforce them
+    // locally, but a real template carries them).
+    echoFn.addPermission('AlbInvoke', {
+      principal: new cdk.aws_iam.ServicePrincipal('elasticloadbalancing.amazonaws.com'),
+    });
+    apiFn.addPermission('AlbInvoke', {
+      principal: new cdk.aws_iam.ServicePrincipal('elasticloadbalancing.amazonaws.com'),
+    });
+
+    const listener = new elbv2.CfnListener(this, 'AlbListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      // Default action -> echo Lambda; the path rule below carves `/api/*` out.
+      defaultActions: [{ type: 'forward', targetGroupArn: echoTg.ref }],
+    });
+
+    new elbv2.CfnListenerRule(this, 'ApiRule', {
+      listenerArn: listener.ref,
+      priority: 10,
+      conditions: [{ field: 'path-pattern', pathPatternConfig: { values: ['/api/*'] } }],
+      actions: [{ type: 'forward', targetGroupArn: apiTg.ref }],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-lambda/package.json
+++ b/tests/integration/local-start-alb-lambda/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-alb-lambda",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb -> Lambda target groups (#123)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-alb-lambda/tsconfig.json
+++ b/tests/integration/local-start-alb-lambda/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-alb-lambda/verify.sh
+++ b/tests/integration/local-start-alb-lambda/verify.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-alb -> Lambda target groups integ test (#123, no AWS deploy)
+#
+# Names an Application Load Balancer whose single HTTP:80 listener forwards to
+# Lambda functions (TargetType: lambda target groups):
+#   - default action       -> EchoFn (asset-backed Node.js Lambda), echoes the
+#                             ALB event it received.
+#   - path-pattern /api/*   -> ApiFn (multi_value_headers.enabled=true).
+# Asserts:
+#   - The host-side ALB front-door endpoint comes up on the --lb-port host port.
+#   - GET /?a=1 -> reaches the echo Lambda, which sees the ALB Lambda-target
+#     event (requestContext.elb present, httpMethod=GET, path=/, query a=1).
+#   - GET /api/ping?x=1&x=2 -> path-routed to ApiFn, which sees the multi-value
+#     query variant (multiValueQueryStringParameters present).
+#   - SIGTERM tears every container + network + front-door socket down.
+#
+#     bash tests/integration/local-start-alb-lambda/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+LAMBDA_IMAGE="public.ecr.aws/lambda/nodejs:20"
+LB_HOST_PORT=18088 # non-privileged host port the front-door binds (listener port 80 remapped)
+
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers + networks"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture Lambda base image"
+docker pull "${LAMBDA_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+
+echo "==> start-alb: naming the ALB (Lambda targets), front-door on host port ${LB_HOST_PORT}"
+# Remap the privileged listener port 80 to a non-privileged host port so the
+# front-door binds without root (the macOS Docker Desktop privileged-port path).
+${CDKL} start-alb CdkLocalStartAlbLambdaFixture:AlbLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 120s)"
+BOOTED=0
+for _ in $(seq 1 120); do
+  if grep -q "Service(s) running:" "${OUT_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: front-door did not reach the boot banner within 120s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+
+echo "==> Asserting the front-door banner + the Lambda targets were logged"
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_HOST_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: front-door banner for host port ${LB_HOST_PORT} not found"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -q "Lambda EchoFn" "${OUT_FILE}"; then
+  echo "FAIL: EchoFn Lambda target not logged in the front-door routing table"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -q "path /api/\*" "${OUT_FILE}"; then
+  echo "FAIL: path rule '/api/*' not logged in the front-door routing table"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: front-door banner + Lambda targets present"
+
+echo "==> curl-ing /?a=1 until the front-door serves 200 (Lambda container takes a moment)"
+READY=0
+ROOT_RESP=""
+for _ in $(seq 1 90); do
+  ROOT_RESP=$(curl -fsS "http://127.0.0.1:${LB_HOST_PORT}/?a=1" 2>/dev/null || true)
+  if [[ -n "${ROOT_RESP}" ]]; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the front-door to serve"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: front-door never served a 200 on /?a=1 within 90s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    / response: ${ROOT_RESP}"
+
+echo "==> Asserting GET / reached the echo Lambda with the ALB Lambda-target event shape"
+# The echo handler returns JSON with role/hasElbContext/httpMethod/path/query.
+if ! echo "${ROOT_RESP}" | grep -q '"role":"lambda"'; then
+  echo "FAIL: GET / did not reach the echo Lambda (no role:lambda in body)"
+  exit 1
+fi
+if ! echo "${ROOT_RESP}" | grep -q '"hasElbContext":true'; then
+  echo "FAIL: the Lambda did not receive requestContext.elb (ALB event shape)"
+  exit 1
+fi
+if ! echo "${ROOT_RESP}" | grep -q '"httpMethod":"GET"'; then
+  echo "FAIL: the Lambda event httpMethod was not GET"
+  exit 1
+fi
+if ! echo "${ROOT_RESP}" | grep -q '"path":"/"'; then
+  echo "FAIL: the Lambda event path was not '/'"
+  exit 1
+fi
+if ! echo "${ROOT_RESP}" | grep -q '"a":"1"'; then
+  echo "FAIL: the Lambda event did not carry queryStringParameters {a:1}"
+  exit 1
+fi
+echo "    OK: echo Lambda saw the ALB Lambda-target event (elb context + method + path + query)"
+
+echo "==> Asserting the response headers were translated back to HTTP"
+HEADERS=$(curl -fsS -D - -o /dev/null "http://127.0.0.1:${LB_HOST_PORT}/?a=1" 2>/dev/null || true)
+if ! echo "${HEADERS}" | grep -qi 'x-handler: alb-lambda-fixture'; then
+  echo "FAIL: the Lambda response header X-Handler was not relayed to the client"
+  echo "${HEADERS}"
+  exit 1
+fi
+echo "    OK: response headers relayed (X-Handler present)"
+
+echo "==> Asserting GET /api/ping?x=1&x=2 is path-routed to ApiFn (multi-value query variant)"
+API_RESP=""
+for _ in $(seq 1 60); do
+  API_RESP=$(curl -fsS "http://127.0.0.1:${LB_HOST_PORT}/api/ping?x=1&x=2" 2>/dev/null || true)
+  if [[ -n "${API_RESP}" ]]; then break; fi
+  sleep 1
+done
+echo "    /api/ping response: ${API_RESP}"
+if ! echo "${API_RESP}" | grep -q '"path":"/api/ping"'; then
+  echo "FAIL: /api/ping was not path-routed to a Lambda target (wrong path echoed)"
+  exit 1
+fi
+# multi_value_headers.enabled=true -> the event uses multiValueQueryStringParameters.
+if ! echo "${API_RESP}" | grep -q '"multiValueQueryStringParameters":{"x":\["1","2"\]}'; then
+  echo "FAIL: ApiFn did not receive the multi-value query variant for the multi-value-headers TG"
+  exit 1
+fi
+echo "    OK: /api/ping path-routed to ApiFn with the multi-value query event variant"
+
+echo "==> Sending SIGTERM to cdk-local (${CDKL_PID})"
+kill -TERM "${CDKL_PID}"
+
+echo "==> Waiting for cdk-local to exit (up to 60s)"
+EXITED=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then EXITED=1; break; fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+echo "==> Asserting clean teardown — no leftover containers"
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers still present after SIGTERM"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+
+echo "==> Asserting clean teardown — no leftover networks"
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} docker networks still present after SIGTERM"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+echo "==> Asserting the front-door socket is closed"
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: front-door on host port ${LB_HOST_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+
+echo ""
+echo "==> local-start-alb-lambda test passed (default -> EchoFn, /api/* -> ApiFn multi-value, clean teardown)"

--- a/tests/unit/local/alb-lambda-event.test.ts
+++ b/tests/unit/local/alb-lambda-event.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  buildAlbLambdaEvent,
+  translateAlbLambdaResponse,
+  snapshotFromIncoming,
+  type AlbHttpRequestSnapshot,
+} from '../../../src/local/alb-lambda-event.js';
+import type { IncomingMessage } from 'node:http';
+
+const TG_ARN =
+  'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-tg/6d0ecf831eec9f09';
+
+function snap(overrides: Partial<AlbHttpRequestSnapshot> = {}): AlbHttpRequestSnapshot {
+  return {
+    method: 'GET',
+    rawUrl: '/',
+    headers: {},
+    body: Buffer.alloc(0),
+    ...overrides,
+  };
+}
+
+describe('buildAlbLambdaEvent (request -> ALB Lambda event)', () => {
+  it('builds the single-value form with requestContext.elb + path + last-wins query/headers', () => {
+    const event = buildAlbLambdaEvent(
+      snap({
+        method: 'POST',
+        rawUrl: '/items?k=v1&k=v2&other=x',
+        headers: {
+          'Content-Type': ['application/json'],
+          Accept: ['text/html', 'application/xml'],
+        },
+        body: Buffer.from('{"a":1}', 'utf-8'),
+      }),
+      { targetGroupArn: TG_ARN, multiValueHeaders: false }
+    );
+
+    expect(event['requestContext']).toEqual({ elb: { targetGroupArn: TG_ARN } });
+    expect(event['httpMethod']).toBe('POST');
+    expect(event['path']).toBe('/items');
+    // last value wins on dup keys in the single-value form.
+    expect(event['queryStringParameters']).toEqual({ k: 'v2', other: 'x' });
+    // header names lowercased; last value wins (Accept had two).
+    expect(event['headers']).toEqual({
+      'content-type': 'application/json',
+      accept: 'application/xml',
+    });
+    expect(event).not.toHaveProperty('multiValueHeaders');
+    expect(event).not.toHaveProperty('multiValueQueryStringParameters');
+    expect(event['isBase64Encoded']).toBe(false);
+    expect(event['body']).toBe('{"a":1}');
+  });
+
+  it('builds the multi-value form when the target group enables multi-value headers', () => {
+    const event = buildAlbLambdaEvent(
+      snap({
+        rawUrl: '/x?k=v1&k=v2',
+        headers: { Cookie: ['a=1', 'b=2'], Host: ['example.com'] },
+      }),
+      { targetGroupArn: TG_ARN, multiValueHeaders: true }
+    );
+    expect(event['multiValueQueryStringParameters']).toEqual({ k: ['v1', 'v2'] });
+    expect(event['multiValueHeaders']).toEqual({
+      cookie: ['a=1', 'b=2'],
+      host: ['example.com'],
+    });
+    expect(event).not.toHaveProperty('headers');
+    expect(event).not.toHaveProperty('queryStringParameters');
+  });
+
+  it('does NOT decode URL-encoded query parameters (ALB passes them verbatim)', () => {
+    const event = buildAlbLambdaEvent(snap({ rawUrl: '/s?q=a%20b%26c' }), {
+      targetGroupArn: TG_ARN,
+      multiValueHeaders: false,
+    });
+    expect(event['queryStringParameters']).toEqual({ q: 'a%20b%26c' });
+  });
+
+  it('base64-encodes a binary body (non-textual content-type) and flags isBase64Encoded', () => {
+    const bin = Buffer.from([0x89, 0x50, 0x4e, 0x47]); // PNG magic
+    const event = buildAlbLambdaEvent(
+      snap({ method: 'POST', headers: { 'content-type': ['image/png'] }, body: bin }),
+      { targetGroupArn: TG_ARN, multiValueHeaders: false }
+    );
+    expect(event['isBase64Encoded']).toBe(true);
+    expect(event['body']).toBe(bin.toString('base64'));
+  });
+
+  it('base64-encodes whenever content-encoding is present even for a textual type', () => {
+    const event = buildAlbLambdaEvent(
+      snap({
+        method: 'POST',
+        headers: { 'content-type': ['text/plain'], 'content-encoding': ['gzip'] },
+        body: Buffer.from('compressed-bytes'),
+      }),
+      { targetGroupArn: TG_ARN, multiValueHeaders: false }
+    );
+    expect(event['isBase64Encoded']).toBe(true);
+  });
+
+  it('treats an empty body as a plain (non-base64) empty string', () => {
+    const event = buildAlbLambdaEvent(snap({ headers: { 'content-type': ['image/png'] } }), {
+      targetGroupArn: TG_ARN,
+      multiValueHeaders: false,
+    });
+    expect(event['isBase64Encoded']).toBe(false);
+    expect(event['body']).toBe('');
+  });
+
+  it('handles a bare query flag (no =) and a query-less path', () => {
+    const withFlag = buildAlbLambdaEvent(snap({ rawUrl: '/p?flag' }), {
+      targetGroupArn: TG_ARN,
+      multiValueHeaders: false,
+    });
+    expect(withFlag['queryStringParameters']).toEqual({ flag: '' });
+    const noQuery = buildAlbLambdaEvent(snap({ rawUrl: '/p' }), {
+      targetGroupArn: TG_ARN,
+      multiValueHeaders: false,
+    });
+    expect(noQuery['queryStringParameters']).toEqual({});
+    expect(noQuery['path']).toBe('/p');
+  });
+});
+
+describe('snapshotFromIncoming', () => {
+  it('normalizes IncomingMessage header values to string arrays + uppercases the method', () => {
+    const req = {
+      method: 'post',
+      url: '/a?b=c',
+      headers: { 'x-single': 'one', 'set-cookie': ['a=1', 'b=2'] },
+    } as unknown as IncomingMessage;
+    const s = snapshotFromIncoming(req, Buffer.from('body'));
+    expect(s.method).toBe('POST');
+    expect(s.rawUrl).toBe('/a?b=c');
+    expect(s.headers['x-single']).toEqual(['one']);
+    expect(s.headers['set-cookie']).toEqual(['a=1', 'b=2']);
+    expect(s.body.toString()).toBe('body');
+  });
+});
+
+describe('translateAlbLambdaResponse (response -> HTTP)', () => {
+  it('translates a shaped response with single-value headers + statusDescription', () => {
+    const out = translateAlbLambdaResponse({
+      statusCode: 201,
+      statusDescription: '201 Created',
+      headers: { 'Content-Type': 'application/json', 'X-Custom': 1 },
+      body: '{"ok":true}',
+    });
+    expect(out.statusCode).toBe(201);
+    expect(out.statusDescription).toBe('201 Created');
+    expect(out.headers['content-type']).toEqual(['application/json']);
+    expect(out.headers['x-custom']).toEqual(['1']);
+    expect(out.body.toString()).toBe('{"ok":true}');
+    // content-length recomputed from the actual bytes.
+    expect(out.headers['content-length']).toEqual([String(out.body.length)]);
+  });
+
+  it('emits one header entry per multiValueHeaders value (e.g. multiple Set-cookie)', () => {
+    const out = translateAlbLambdaResponse({
+      statusCode: 200,
+      multiValueHeaders: {
+        'Set-cookie': ['a=1; HttpOnly', 'b=2'],
+        'Content-Type': ['application/json'],
+      },
+      body: 'x',
+    });
+    expect(out.headers['set-cookie']).toEqual(['a=1; HttpOnly', 'b=2']);
+    expect(out.headers['content-type']).toEqual(['application/json']);
+  });
+
+  it('decodes a base64 body when isBase64Encoded is true', () => {
+    const raw = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+    const out = translateAlbLambdaResponse({
+      statusCode: 200,
+      isBase64Encoded: true,
+      body: raw.toString('base64'),
+    });
+    expect(Buffer.compare(out.body, raw)).toBe(0);
+  });
+
+  it('treats a missing body as an empty body', () => {
+    const out = translateAlbLambdaResponse({ statusCode: 204 });
+    expect(out.statusCode).toBe(204);
+    expect(out.body.length).toBe(0);
+  });
+
+  it('returns 502 for a Lambda runtime error envelope', () => {
+    const out = translateAlbLambdaResponse({
+      errorMessage: 'boom',
+      errorType: 'Error',
+      stackTrace: ['at handler'],
+    });
+    expect(out.statusCode).toBe(502);
+  });
+
+  it('returns 502 for a malformed response (no numeric statusCode)', () => {
+    expect(translateAlbLambdaResponse({ body: 'no status' }).statusCode).toBe(502);
+    expect(translateAlbLambdaResponse({ statusCode: 'oops' }).statusCode).toBe(502);
+    expect(translateAlbLambdaResponse('a plain string').statusCode).toBe(502);
+    expect(translateAlbLambdaResponse(null).statusCode).toBe(502);
+    expect(translateAlbLambdaResponse([1, 2, 3]).statusCode).toBe(502);
+  });
+
+  it('serializes a non-string JSON body', () => {
+    const out = translateAlbLambdaResponse({ statusCode: 200, body: { a: 1 } });
+    expect(out.body.toString()).toBe('{"a":1}');
+  });
+});

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -2,9 +2,17 @@ import { describe, it, expect } from 'vite-plus/test';
 import {
   resolveAlbFrontDoor,
   isApplicationLoadBalancer,
+  type FrontDoorEcsTarget,
+  type FrontDoorForwardTarget,
 } from '../../../src/local/elb-front-door-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { TemplateResource } from '../../../src/types/resource.js';
+
+/** Narrow a resolved forward target to its ECS variant (test ergonomics). */
+function ecsTarget(t: FrontDoorForwardTarget | undefined): FrontDoorEcsTarget {
+  if (!t || t.kind !== 'ecs') throw new Error(`expected an ECS forward target, got: ${t?.kind}`);
+  return t;
+}
 
 const ALB = 'WebLB';
 const TG = 'WebTargetGroup';
@@ -68,8 +76,18 @@ const apiServiceResources: Record<string, unknown> = {
   },
 };
 
-/** Convenience: the single forward target of a resolved action (throws if not a forward). */
-function forwardTarget(action: import('../../../src/local/elb-front-door-resolver.js').ResolvedListenerAction | undefined) {
+/** Convenience: the single ECS forward target of a resolved action (throws if not a forward). */
+function forwardTarget(
+  action: import('../../../src/local/elb-front-door-resolver.js').ResolvedListenerAction | undefined
+): FrontDoorEcsTarget {
+  if (action?.kind !== 'forward') throw new Error(`expected a forward action, got ${action?.kind}`);
+  return ecsTarget(action.targets[0]);
+}
+
+/** Convenience: the single forward target of a resolved action, NOT narrowed (mixed tests). */
+function forwardTargetRaw(
+  action: import('../../../src/local/elb-front-door-resolver.js').ResolvedListenerAction | undefined
+): FrontDoorForwardTarget {
   if (action?.kind !== 'forward') throw new Error(`expected a forward action, got ${action?.kind}`);
   return action.targets[0]!;
 }
@@ -87,6 +105,7 @@ describe('resolveAlbFrontDoor', () => {
           kind: 'forward',
           targets: [
             {
+              kind: 'ecs',
               serviceLogicalId: SERVICE,
               targetContainerName: 'web',
               targetContainerPort: 80,
@@ -146,6 +165,7 @@ describe('resolveAlbFrontDoor', () => {
           kind: 'forward',
           targets: [
             {
+              kind: 'ecs',
               serviceLogicalId: API_SERVICE,
               targetContainerName: 'api',
               targetContainerPort: 8080,
@@ -228,7 +248,7 @@ describe('resolveAlbFrontDoor', () => {
     const action = listeners[0]!.defaultAction;
     expect(action?.kind).toBe('forward');
     if (action?.kind === 'forward') {
-      expect(action.targets.map((t) => [t.serviceLogicalId, t.weight])).toEqual([
+      expect(action.targets.map((t) => [ecsTarget(t).serviceLogicalId, t.weight])).toEqual([
         [SERVICE, 80],
         [API_SERVICE, 20],
       ]);
@@ -493,7 +513,7 @@ describe('resolveAlbFrontDoor', () => {
     expect(action?.kind).toBe('forward');
     if (action?.kind === 'forward') {
       // The Lambda target group is dropped; the ECS one survives.
-      expect(action.targets.map((t) => t.serviceLogicalId)).toEqual([API_SERVICE]);
+      expect(action.targets.map((t) => ecsTarget(t).serviceLogicalId)).toEqual([API_SERVICE]);
     }
     expect(warnings.join('\n')).toMatch(/Lambda target group/);
   });
@@ -560,16 +580,139 @@ describe('resolveAlbFrontDoor', () => {
     expect(warnings.join('\n')).toMatch(/HTTPS/);
   });
 
-  it('skips + warns on a Lambda target group (deferred follow-up)', () => {
+  it('resolves a Lambda target group (default action) to its backing function (#123)', () => {
     const stack = stackWith({
       [TG]: {
         Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
-        Properties: { TargetType: 'lambda' },
+        Properties: {
+          TargetType: 'lambda',
+          Targets: [{ Id: { 'Fn::GetAtt': ['EchoFn1234', 'Arn'] } }],
+        },
       },
+      // No ECS service references the TG; the function is the backing target.
+      [SERVICE]: undefined,
+      EchoFn1234: { Type: 'AWS::Lambda::Function', Properties: {} },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners).toHaveLength(1);
+    expect(forwardTargetRaw(listeners[0]!.defaultAction)).toEqual({
+      kind: 'lambda',
+      lambdaLogicalId: 'EchoFn1234',
+      targetGroupLogicalId: TG,
+      multiValueHeaders: false,
+      weight: 1,
+    });
+  });
+
+  it('honors the lambda.multi_value_headers.enabled target-group attribute (#123)', () => {
+    const stack = stackWith({
+      [TG]: {
+        Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+        Properties: {
+          TargetType: 'lambda',
+          Targets: [{ Id: { 'Fn::GetAtt': ['EchoFn1234', 'Arn'] } }],
+          TargetGroupAttributes: [
+            { Key: 'lambda.multi_value_headers.enabled', Value: 'true' },
+            { Key: 'other.attr', Value: 'x' },
+          ],
+        },
+      },
+      [SERVICE]: undefined,
+      EchoFn1234: { Type: 'AWS::Lambda::Function', Properties: {} },
+    });
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    const target = forwardTargetRaw(listeners[0]!.defaultAction);
+    expect(target.kind).toBe('lambda');
+    expect((target as { multiValueHeaders: boolean }).multiValueHeaders).toBe(true);
+  });
+
+  it('resolves a Lambda target via a Ref (function-name) registration (#123)', () => {
+    const stack = stackWith({
+      [TG]: {
+        Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+        Properties: {
+          TargetType: 'lambda',
+          Targets: [{ Id: { Ref: 'EchoFn1234' } }],
+        },
+      },
+      [SERVICE]: undefined,
+      EchoFn1234: { Type: 'AWS::Lambda::Function', Properties: {} },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(
+      (forwardTargetRaw(listeners[0]!.defaultAction) as { lambdaLogicalId: string }).lambdaLogicalId
+    ).toBe('EchoFn1234');
+  });
+
+  it('warns when a Lambda target group registration is a non-in-stack ARN (#123)', () => {
+    const stack = stackWith({
+      [TG]: {
+        Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+        Properties: {
+          TargetType: 'lambda',
+          Targets: [{ Id: 'arn:aws:lambda:us-east-1:111122223333:function:imported' }],
+        },
+      },
+      [SERVICE]: undefined,
     });
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
     expect(listeners).toEqual([]);
-    expect(warnings.join('\n')).toMatch(/Lambda target/);
+    expect(warnings.join('\n')).toMatch(/in-stack Lambda target only/);
+  });
+
+  it('warns when a Lambda target group references a missing function logical id (#123)', () => {
+    const stack = stackWith({
+      [TG]: {
+        Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+        Properties: {
+          TargetType: 'lambda',
+          Targets: [{ Id: { 'Fn::GetAtt': ['GhostFn', 'Arn'] } }],
+        },
+      },
+      [SERVICE]: undefined,
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/no AWS::Lambda::Function with that logical id/);
+  });
+
+  it('routes a path-rule Lambda target alongside an ECS default (#123 mixed)', () => {
+    const stack = stackWith({
+      ...apiServiceResources, // ApiService not used here; the rule forwards to a Lambda TG
+      [API_TG]: {
+        Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+        Properties: {
+          TargetType: 'lambda',
+          Targets: [{ Id: { 'Fn::GetAtt': ['ApiFn', 'Arn'] } }],
+        },
+      },
+      [API_SERVICE]: undefined,
+      ApiFn: { Type: 'AWS::Lambda::Function', Properties: {} },
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [{ Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*'] } }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners).toHaveLength(1);
+    // Default still ECS (the web service), the /api/* rule routes to the Lambda.
+    expect(forwardTargetRaw(listeners[0]!.defaultAction).kind).toBe('ecs');
+    expect(listeners[0]!.rules).toHaveLength(1);
+    expect(forwardTargetRaw(listeners[0]!.rules[0]!.action)).toEqual({
+      kind: 'lambda',
+      lambdaLogicalId: 'ApiFn',
+      targetGroupLogicalId: API_TG,
+      multiValueHeaders: false,
+      weight: 1,
+    });
   });
 
   it('warns when no ECS service references the target group', () => {

--- a/tests/unit/local/front-door-lambda-runner.test.ts
+++ b/tests/unit/local/front-door-lambda-runner.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ResolvedZipLambda } from '../../../src/local/lambda-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+// Mock the docker / RIE boundary so the runner can be exercised without Docker.
+const {
+  runDetachedMock,
+  pickFreePortMock,
+  removeContainerMock,
+  pullImageMock,
+  streamLogsMock,
+  waitForRieReadyMock,
+  invokeRieMock,
+} = vi.hoisted(() => ({
+  runDetachedMock: vi.fn(),
+  pickFreePortMock: vi.fn(),
+  removeContainerMock: vi.fn(),
+  pullImageMock: vi.fn(),
+  streamLogsMock: vi.fn(() => () => undefined),
+  waitForRieReadyMock: vi.fn(),
+  invokeRieMock: vi.fn(),
+}));
+
+vi.mock('../../../src/local/docker-runner.js', () => ({
+  runDetached: runDetachedMock,
+  pickFreePort: pickFreePortMock,
+  removeContainer: removeContainerMock,
+  pullImage: pullImageMock,
+  streamLogs: streamLogsMock,
+}));
+
+vi.mock('../../../src/local/rie-client.js', () => ({
+  waitForRieReady: waitForRieReadyMock,
+  invokeRie: invokeRieMock,
+}));
+
+vi.mock('../../../src/local/runtime-image.js', () => ({
+  resolveRuntimeImage: vi.fn(() => 'public.ecr.aws/lambda/nodejs:20'),
+  resolveRuntimeCodeMountPath: vi.fn(() => '/var/task'),
+  resolveRuntimeFileExtension: vi.fn(() => '.js'),
+}));
+
+const { createFrontDoorLambdaRunner } = await import(
+  '../../../src/local/front-door-lambda-runner.js'
+);
+
+function zipLambda(overrides: Partial<ResolvedZipLambda> = {}): ResolvedZipLambda {
+  return {
+    kind: 'zip',
+    stack: { stackName: 'S' } as unknown as StackInfo,
+    logicalId: 'EchoFn',
+    resource: { Type: 'AWS::Lambda::Function', Properties: {} },
+    memoryMb: 128,
+    timeoutSec: 10,
+    layers: [],
+    runtime: 'nodejs20.x',
+    handler: 'index.handler',
+    codePath: '/tmp/code',
+    ...overrides,
+  } as ResolvedZipLambda;
+}
+
+beforeEach(() => {
+  runDetachedMock.mockReset().mockResolvedValue('container-abc');
+  pickFreePortMock.mockReset().mockResolvedValue(54321);
+  removeContainerMock.mockReset().mockResolvedValue(undefined);
+  pullImageMock.mockReset().mockResolvedValue(undefined);
+  waitForRieReadyMock.mockReset().mockResolvedValue(undefined);
+  invokeRieMock.mockReset().mockResolvedValue({ payload: { statusCode: 200 }, raw: '{}' });
+});
+
+describe('createFrontDoorLambdaRunner', () => {
+  it('boots a ZIP Lambda container (pull + run + wait for RIE) on start()', async () => {
+    const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
+    await runner.start();
+
+    expect(pullImageMock).toHaveBeenCalledWith('public.ecr.aws/lambda/nodejs:20', false);
+    expect(runDetachedMock).toHaveBeenCalledTimes(1);
+    const runArgs = runDetachedMock.mock.calls[0]![0];
+    expect(runArgs.image).toBe('public.ecr.aws/lambda/nodejs:20');
+    expect(runArgs.cmd).toEqual(['index.handler']);
+    expect(runArgs.mounts).toEqual([
+      { hostPath: '/tmp/code', containerPath: '/var/task', readOnly: true },
+    ]);
+    expect(runArgs.hostPort).toBe(54321);
+    expect(runArgs.env.AWS_LAMBDA_FUNCTION_NAME).toBe('EchoFn');
+    expect(waitForRieReadyMock).toHaveBeenCalledWith('127.0.0.1', 54321, 30_000);
+  });
+
+  it('is idempotent — a second start() does not boot a second container', async () => {
+    const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
+    await runner.start();
+    await runner.start();
+    expect(runDetachedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes skipPull through when --no-pull is set', async () => {
+    const runner = createFrontDoorLambdaRunner(zipLambda(), {
+      containerHost: '127.0.0.1',
+      skipPull: true,
+    });
+    await runner.start();
+    expect(pullImageMock).toHaveBeenCalledWith('public.ecr.aws/lambda/nodejs:20', true);
+  });
+
+  it('invoke() POSTs the event to RIE and returns the parsed payload', async () => {
+    invokeRieMock.mockResolvedValue({ payload: { statusCode: 201, body: 'hi' }, raw: '{}' });
+    const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
+    await runner.start();
+    const payload = await runner.invoke({ path: '/' });
+    expect(invokeRieMock).toHaveBeenCalledTimes(1);
+    const [host, port, event, timeoutMs] = invokeRieMock.mock.calls[0]!;
+    expect(host).toBe('127.0.0.1');
+    expect(port).toBe(54321);
+    expect(event).toEqual({ path: '/' });
+    // default timeout = max(30s, timeoutSec*2*1000) = 30s for timeoutSec=10.
+    expect(timeoutMs).toBe(30_000);
+    expect(payload).toEqual({ statusCode: 201, body: 'hi' });
+  });
+
+  it('invoke() before start() throws (rather than hitting an undefined port)', async () => {
+    const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
+    await expect(runner.invoke({})).rejects.toThrow(/before start/);
+  });
+
+  it('cleans up the container when RIE never becomes ready', async () => {
+    waitForRieReadyMock.mockRejectedValue(new Error('RIE timeout'));
+    const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
+    await expect(runner.start()).rejects.toThrow(/RIE timeout/);
+    expect(removeContainerMock).toHaveBeenCalledWith('container-abc');
+  });
+
+  it('stop() removes the container and is idempotent', async () => {
+    const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
+    await runner.start();
+    await runner.stop();
+    await runner.stop();
+    expect(removeContainerMock).toHaveBeenCalledTimes(1);
+    expect(removeContainerMock).toHaveBeenCalledWith('container-abc');
+  });
+
+  it('rejects start() after stop()', async () => {
+    const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
+    await runner.stop();
+    await expect(runner.start()).rejects.toThrow(/after stop/);
+  });
+});

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -482,3 +482,211 @@ describe('buildRedirectLocation', () => {
     );
   });
 });
+
+import { request as httpRequest } from 'node:http';
+import type { FrontDoorDispatchTarget } from '../../../src/local/front-door-server.js';
+
+/** POST a request and capture status / headers / body. */
+function postRequest(
+  port: number,
+  path: string,
+  body: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; headers: IncomingMessage['headers']; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port, path, method: 'POST', headers },
+      (res) => {
+        let out = '';
+        res.on('data', (c) => (out += c));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers, body: out }));
+      }
+    );
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+async function startFrontTarget(
+  selectTarget: (requestPath: string) => FrontDoorDispatchTarget | undefined
+): Promise<StartedFrontDoorServer> {
+  const front = await startFrontDoorServer({
+    selectTarget,
+    port: 0,
+    host: '127.0.0.1',
+    listenerPort: 80,
+    label: 'listener port 80',
+  });
+  cleanups.push(() => front.close());
+  return front;
+}
+
+describe('startFrontDoorServer — Lambda dispatch (#123)', () => {
+  it('translates the request -> ALB event, invokes the Lambda, and writes the response', async () => {
+    let capturedEvent: Record<string, unknown> | undefined;
+    const front = await startFrontTarget(() => ({
+      kind: 'lambda',
+      lambda: {
+        targetGroupArn: 'tg-arn',
+        multiValueHeaders: false,
+        label: 'EchoFn',
+        invoke: async (event) => {
+          capturedEvent = event;
+          return {
+            statusCode: 201,
+            statusDescription: '201 Created',
+            headers: { 'content-type': 'application/json', 'x-echo': 'yes' },
+            body: '{"ok":true}',
+          };
+        },
+      },
+    }));
+
+    const res = await postRequest(front.port, '/items?a=1', '{"hello":"world"}', {
+      'content-type': 'application/json',
+    });
+    expect(res.status).toBe(201);
+    expect(res.headers['content-type']).toBe('application/json');
+    expect(res.headers['x-echo']).toBe('yes');
+    expect(res.body).toBe('{"ok":true}');
+
+    // The event the handler saw is the ALB Lambda-target shape.
+    expect(capturedEvent!['requestContext']).toEqual({ elb: { targetGroupArn: 'tg-arn' } });
+    expect(capturedEvent!['httpMethod']).toBe('POST');
+    expect(capturedEvent!['path']).toBe('/items');
+    expect(capturedEvent!['queryStringParameters']).toEqual({ a: '1' });
+    expect(capturedEvent!['body']).toBe('{"hello":"world"}');
+    // ALB stamps x-forwarded-* onto the event headers.
+    const evHeaders = capturedEvent!['headers'] as Record<string, string>;
+    expect(evHeaders['x-forwarded-proto']).toBe('http');
+    expect(evHeaders['x-forwarded-port']).toBe('80');
+  });
+
+  it('returns 502 when the Lambda returns a malformed response', async () => {
+    const front = await startFrontTarget(() => ({
+      kind: 'lambda',
+      lambda: {
+        targetGroupArn: 'tg-arn',
+        multiValueHeaders: false,
+        label: 'BadFn',
+        invoke: async () => ({ body: 'no statusCode' }),
+      },
+    }));
+    const res = await postRequest(front.port, '/', '');
+    expect(res.status).toBe(502);
+  });
+
+  it('returns 502 when the Lambda invoke throws', async () => {
+    const front = await startFrontTarget(() => ({
+      kind: 'lambda',
+      lambda: {
+        targetGroupArn: 'tg-arn',
+        multiValueHeaders: false,
+        label: 'ThrowFn',
+        invoke: async () => {
+          throw new Error('container gone');
+        },
+      },
+    }));
+    const res = await postRequest(front.port, '/', '');
+    expect(res.status).toBe(502);
+  });
+
+  it('emits multiple Set-cookie lines from a multiValueHeaders response', async () => {
+    const front = await startFrontTarget(() => ({
+      kind: 'lambda',
+      lambda: {
+        targetGroupArn: 'tg-arn',
+        multiValueHeaders: true,
+        label: 'CookieFn',
+        invoke: async () => ({
+          statusCode: 200,
+          multiValueHeaders: { 'set-cookie': ['a=1', 'b=2'] },
+          body: 'ok',
+        }),
+      },
+    }));
+    const res = await postRequest(front.port, '/', '');
+    expect(res.status).toBe(200);
+    expect(res.headers['set-cookie']).toEqual(['a=1', 'b=2']);
+  });
+
+  it('returns 404 when selectTarget yields nothing (rule miss, no default)', async () => {
+    const front = await startFrontTarget(() => undefined);
+    const res = await postRequest(front.port, '/nope', '');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('startFrontDoorServer — weighted forward mixing ECS + Lambda (#123)', () => {
+  it('dispatches an ECS pool target or a Lambda target by weight via route()', async () => {
+    const ecs = await startUpstream('ecs-replica');
+    const ecsPool = new FrontDoorEndpointPool();
+    ecsPool.register('ecs:r0', { host: '127.0.0.1', port: ecs.port });
+    let lambdaHits = 0;
+    // A weighted forward whose targets are an ECS pool AND a Lambda invoker;
+    // both have positive weight, so over many requests both are exercised.
+    const action: RouteAction = {
+      kind: 'forward',
+      pools: [
+        { pool: ecsPool, weight: 50 },
+        {
+          lambda: {
+            targetGroupArn: 'tg-arn',
+            multiValueHeaders: false,
+            label: 'MixFn',
+            invoke: async () => {
+              lambdaHits += 1;
+              return { statusCode: 200, headers: { 'content-type': 'text/plain' }, body: 'lambda' };
+            },
+          },
+          weight: 50,
+        },
+      ],
+    };
+    const front = await startFrontWith(() => action);
+
+    const counts: Record<string, number> = { 'ecs-replica': 0, lambda: 0 };
+    for (let i = 0; i < 60; i++) {
+      const body = (await fetchText(front.port)).body;
+      counts[body] = (counts[body] ?? 0) + 1;
+    }
+    // Both backends answered (a 50/50 split makes a zero on either side
+    // astronomically unlikely), proving ECS-pool and Lambda dispatch coexist in
+    // one weighted forward.
+    expect(counts['ecs-replica']!).toBeGreaterThan(0);
+    expect(counts['lambda']!).toBeGreaterThan(0);
+    expect(counts['ecs-replica']! + counts['lambda']!).toBe(60);
+    expect(lambdaHits).toBe(counts['lambda']);
+  });
+
+  it('never routes to a weight-0 Lambda target in a mixed weighted forward', async () => {
+    const ecs = await startUpstream('ecs-only');
+    const ecsPool = new FrontDoorEndpointPool();
+    ecsPool.register('ecs:r0', { host: '127.0.0.1', port: ecs.port });
+    let lambdaHits = 0;
+    const action: RouteAction = {
+      kind: 'forward',
+      pools: [
+        { pool: ecsPool, weight: 100 },
+        {
+          lambda: {
+            targetGroupArn: 'tg-arn',
+            multiValueHeaders: false,
+            label: 'ZeroFn',
+            invoke: async () => {
+              lambdaHits += 1;
+              return { statusCode: 200, body: 'lambda' };
+            },
+          },
+          weight: 0,
+        },
+      ],
+    };
+    const front = await startFrontWith(() => action);
+    for (let i = 0; i < 20; i++) {
+      expect((await fetchText(front.port)).body).toBe('ecs-only');
+    }
+    expect(lambdaHits).toBe(0);
+  });
+});

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -44,6 +44,49 @@ function albStack(): StackInfo {
   } as unknown as StackInfo;
 }
 
+/**
+ * An ALB whose single HTTP:80 listener default action forwards to a
+ * `TargetType: lambda` target group backed by an inline ZIP Lambda (#123).
+ * Inline code keeps the function resolvable without a cdk.out asset dir.
+ */
+function albLambdaStack(): StackInfo {
+  return {
+    stackName: 'AlbStack',
+    template: {
+      Resources: {
+        [ALB]: {
+          Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+          Properties: { Type: 'application' },
+        },
+        [TG]: {
+          Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+          Properties: {
+            TargetType: 'lambda',
+            Targets: [{ Id: { 'Fn::GetAtt': ['EchoFn', 'Arn'] } }],
+          },
+        },
+        WebListener: {
+          Type: 'AWS::ElasticLoadBalancingV2::Listener',
+          Properties: {
+            LoadBalancerArn: { Ref: ALB },
+            Port: 80,
+            Protocol: 'HTTP',
+            DefaultActions: [{ Type: 'forward', TargetGroupArn: { Ref: TG } }],
+          },
+        },
+        EchoFn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Runtime: 'nodejs20.x',
+            Handler: 'index.handler',
+            Code: { ZipFile: 'exports.handler = async () => ({ statusCode: 200 });' },
+          },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
 describe('resolveAlbTarget', () => {
   it('resolves an ALB by stack-qualified logical id', () => {
     const { stack, albLogicalId } = resolveAlbTarget('AlbStack:WebLB', [albStack()]);
@@ -164,7 +207,9 @@ describe('albStrategy.resolveBoots multi-service', () => {
       const action = l.defaultAction;
       expect(action?.kind).toBe('forward');
       if (action?.kind === 'forward') {
-        expect(action.targets[0]?.serviceTarget).toBe('Multi:Svc1');
+        const target = action.targets[0]!;
+        expect(target.kind).toBe('ecs');
+        if (target.kind === 'ecs') expect(target.serviceTarget).toBe('Multi:Svc1');
       }
     }
   });
@@ -271,6 +316,7 @@ describe('start-alb / start-service strategy binding', () => {
           kind: 'forward',
           targets: [
             {
+              kind: 'ecs',
               serviceTarget: 'AlbStack:WebService',
               targetContainerName: 'web',
               targetContainerPort: 80,
@@ -292,12 +338,36 @@ describe('start-alb / start-service strategy binding', () => {
     expect(frontDoor).toBeUndefined();
     expect(strategy.lbPortOverrides).toEqual({});
   });
+
+  it('start-alb resolves a Lambda target group into a front-door Lambda target with NO ECS boot (#123)', () => {
+    const strategy = albStrategy({} as never);
+    const { boots, frontDoor, warnings } = strategy.resolveBoots(
+      [albLambdaStack()],
+      ['AlbStack:WebLB']
+    );
+    expect(warnings).toEqual([]);
+    // A Lambda-only ALB boots no ECS services.
+    expect(boots).toEqual([]);
+    expect(frontDoor!.listeners).toHaveLength(1);
+    const action = frontDoor!.listeners[0]!.defaultAction;
+    expect(action?.kind).toBe('forward');
+    if (action?.kind !== 'forward') throw new Error('expected a forward action');
+    const target = action.targets[0]!;
+    expect(target.kind).toBe('lambda');
+    if (target.kind !== 'lambda') throw new Error('expected a lambda target');
+    expect(target.lambda.logicalId).toBe('EchoFn');
+    expect(target.targetGroupArn).toBe('AlbStack:WebTargetGroup');
+    expect(target.multiValueHeaders).toBe(false);
+    expect(target.weight).toBe(1);
+  });
 });
 
 describe('buildFrontDoor', () => {
+  const fdOptions = { containerHost: '127.0.0.1', pull: true } as never;
+
   it('binds one server per listener and groups pools by service target', async () => {
     const logger = { info: () => {}, warn: () => {} } as never;
-    const { servers, frontDoorByService } = await buildFrontDoor(
+    const { servers, frontDoorByService, lambdaRunners } = await buildFrontDoor(
       {
         listeners: [
           {
@@ -307,6 +377,7 @@ describe('buildFrontDoor', () => {
               kind: 'forward',
               targets: [
                 {
+                  kind: 'ecs',
                   serviceTarget: 'S:Web',
                   targetContainerName: 'web',
                   targetContainerPort: 80,
@@ -323,6 +394,7 @@ describe('buildFrontDoor', () => {
                   kind: 'forward',
                   targets: [
                     {
+                      kind: 'ecs',
                       serviceTarget: 'S:Api',
                       targetContainerName: 'api',
                       targetContainerPort: 8080,
@@ -335,11 +407,12 @@ describe('buildFrontDoor', () => {
           },
         ],
       },
-      '127.0.0.1',
+      fdOptions,
       logger
     );
     try {
       expect(servers).toHaveLength(1);
+      expect(lambdaRunners).toEqual([]);
       // One pool per (service, container, port); grouped by service target.
       expect([...frontDoorByService.keys()].sort()).toEqual(['S:Api', 'S:Web']);
       expect(frontDoorByService.get('S:Web')).toEqual([


### PR DESCRIPTION
## Summary

Adds **ALB → Lambda targets** to `cdkl start-alb` — the second `(#123)`
follow-up, composed onto the merged routing model (`#146`: path-pattern /
host-header rules, weighted forward, redirect / fixed-response).

A listener `forward` whose target group is `TargetType: lambda` now resolves the
backing `AWS::Lambda::Function` and serves it locally:
- the HTTP request is translated to the **ALB target-group Lambda event**
  (`requestContext.elb.targetGroupArn`, `httpMethod`, `path`,
  `queryStringParameters` | `multiValueQueryStringParameters`, `headers` |
  `multiValueHeaders` — single vs multi chosen by the TG's
  `lambda.multi_value_headers.enabled` attribute, `body`, `isBase64Encoded`);
- it is invoked via the existing Lambda RIE machinery (one warm container per
  Lambda target, reusing the `cdkl invoke` path);
- the response (`statusCode` / `statusDescription` / headers / `body` /
  `isBase64Encoded`) is translated back to HTTP; a malformed response → 502.

**Composition**: a `forward` action's weighted targets are now each an ECS
replica pool **or** a Lambda invoke, so a single forward can mix both; a
Lambda-only listener boots no ECS service. Redirect / fixed-response /
host-header / path-pattern from `#146` are unchanged.

New: `src/local/alb-lambda-event.ts` (event/response translation),
`src/local/front-door-lambda-runner.ts` (per-target RIE container). Docs
(README / cli-reference / CLAUDE.md) updated to mark Lambda targets supported.

Still deferred to `(#123)`: `http-header` / `http-request-method` /
`query-string` / `source-ip` conditions, `authenticate-*` actions, and HTTPS /
TLS termination.

## Test plan

- [x] `vp run check` + `vp test run` green — 98 files / 1437 tests (event
      translation incl. base64 + multi-value + all the 502 paths; runner
      boot/dedup/cleanup with the docker+RIE boundary mocked; resolver
      `Fn::GetAtt` + `Ref` lambda-TG; mixed ECS+Lambda weighted forward;
      Lambda-only listener with no ECS boot)
- [x] `vp run build` green
- [x] `/run-integ local-start-alb-lambda` (asset-backed echo Lambdas) — `GET /`
      reaches the echo Lambda with the `requestContext.elb` event shape, headers
      relayed back, `/api/*` path-routed to a second Lambda with the multi-value
      query variant; 0 orphans
- [x] `/run-integ local-start-alb-routing-conditions` (ECS host-header +
      fixed-response) — still passes after the compose, 0 orphans
- [x] 3-axis review: spec clean, no code blockers; fix-back stripped hop-by-hop
      headers on the Lambda path (matching the ECS path + real ALB) and corrected
      the stale `--help` text

## Accepted nits (from the 3-axis review)

- A `^C` during the initial front-door container-boot loop (before the
  SIGINT handler is installed) can leak a detached `--rm` Lambda container — a
  pre-existing shape (the shared network + ECS boot have the same window) that
  the Lambda image build/pull widens; the normal post-boot SIGINT path tears
  everything down cleanly.
- A failed Lambda-runner `start()` is not retryable (benign — the emulator
  aborts the whole boot on failure); object-valued response headers are
  JSON-stringified (degenerate-handler only).
- The `buildFrontDoor` Lambda-runner dedup/teardown wiring, the container-image
  Lambda plan, and inline-ZIP materialization are covered by the runner's own
  unit tests + the integ fixture rather than a `buildFrontDoor` site-level mock.
