### PR TITLE
feat(invoke-agentcore): deepen --from-cfn-stack + credential parity

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,7 +47,11 @@ AWS managed services.
   to stdout incrementally. MCP runs the Streamable-HTTP `POST /mcp` contract on
   8000: the session handshake (initialize -> notifications/initialized) then one
   JSON-RPC request (`tools/list` by default, or the method/params from
-  `--event`)
+  `--event`). `--from-cfn-stack` deepens to parity with `cdkl invoke` /
+  `run-task`: a same-stack ECR ContainerUri resolves to the deployed image,
+  `AWS::SSM::Parameter::Value` env values resolve (decrypted `SecureString`
+  values kept off the `docker run` argv), and bare `--assume-role` resolves an
+  intrinsic `RoleArn` from state
 - API Gateway authorizers — Lambda authorizers, Cognito User Pool JWT
   verification, IAM SigV4 verification
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -481,9 +481,9 @@ prefix. Omit the target in a TTY to pick from a list.
 | `--no-pull` | off | Skip `docker pull` (use the cached image). No-op for the local-build path. |
 | `--no-build` | off | Skip `docker build` on the local-asset path (reuse the previously-built tag). No-op for the ECR / registry pull paths. |
 | `--container-host <host>` | `127.0.0.1` | Host to bind the agent's published port to. |
-| `--assume-role [arn]` | off | Assume an execution role and forward STS temp creds. `--assume-role <arn>` uses the explicit ARN; bare `--assume-role` uses the runtime's `RoleArn` when it is a literal ARN in the template; `--no-assume-role` opts out. Off by default forwards the developer's shell credentials. |
+| `--assume-role [arn]` | off | Assume an execution role and forward STS temp creds. `--assume-role <arn>` uses the explicit ARN; bare `--assume-role` uses the runtime's `RoleArn` when it is a literal ARN, else resolves it from `--from-cfn-stack` state; `--no-assume-role` opts out. Off by default forwards the developer's shell credentials. |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR for cross-account / centralized registries. |
-| `--from-cfn-stack [name]` | — | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in env vars with the deployed physical IDs / exports. Bare form uses the resolved stack name. |
+| `--from-cfn-stack [name]` | — | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in env vars with the deployed physical IDs / exports, resolve a same-stack `AWS::ECR::Repository` ContainerUri to the deployed image, and resolve `AWS::SSM::Parameter::Value` env values (decrypted `SecureString` values are kept off the `docker run` argv). Bare form uses the resolved stack name. |
 | `--stack-region <region>` | — | Region of the state record to read; the CFn client region for `--from-cfn-stack`. |
 
 ### Credentials
@@ -493,6 +493,12 @@ the container. Precedence matches `cdkl invoke`: `--assume-role` (STS
 temp creds) wins, otherwise the developer's shell credentials are
 forwarded, overlaid with `--profile` when set (and the bind-mounted
 shared-credentials file so `fromIni({ profile })` resolves).
+
+Bare `--assume-role` (no ARN) uses the runtime's `RoleArn` when it is a
+literal ARN; when it is an intrinsic (the common L2 case — `Fn::GetAtt` to
+an auto-created role), the execution-role ARN is resolved from
+`--from-cfn-stack` state where available (a role whose ARN is not in the
+state record falls back to dev creds with a warning).
 
 ### Inbound JWT auth (`customJwtAuthorizer`)
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -23,6 +23,8 @@ import {
   resolveCfnFallbackRegion,
   type ExtraStateProviders,
 } from './local-state-source.js';
+import type { LocalStateProvider, LocalStateRecord } from '../../local/local-state-provider.js';
+import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import {
   getEmbedConfig,
   setEmbedConfig,
@@ -30,6 +32,7 @@ import {
 } from '../../local/embed-config.js';
 import {
   AGENTCORE_MCP_PROTOCOL,
+  pickAgentCoreCandidateStack,
   resolveAgentCoreTarget,
   type AgentCoreCodeArtifact,
   type ResolvedAgentCoreRuntime,
@@ -53,7 +56,10 @@ import {
   substituteEnvVarsFromStateAsync,
   type SubstitutionContext,
 } from '../../local/state-resolver.js';
-import { derivePseudoParametersFromRegion } from '../../local/intrinsic-image.js';
+import {
+  derivePseudoParametersFromRegion,
+  type ImageResolutionContext,
+} from '../../local/intrinsic-image.js';
 import {
   ensureDockerAvailable,
   pickFreePort,
@@ -71,7 +77,10 @@ import {
 import type { FileAsset } from '../../types/assets.js';
 import { singleFlight } from '../../utils/single-flight.js';
 import { resolveProfileCredentials } from './local-start-api.js';
-import { applyProfileCredentialsOverlay } from './local-invoke.js';
+import {
+  applyProfileCredentialsOverlay,
+  resolveExecutionRoleArnFromState,
+} from './local-invoke.js';
 import {
   writeProfileCredentialsFile,
   type ProfileCredentialsFile,
@@ -157,9 +166,19 @@ async function localInvokeAgentCoreCommand(
   let stopLogs: (() => void) | undefined;
   let sigintHandler: (() => void) | undefined;
   let profileCredsFile: ProfileCredentialsFile | undefined;
+  let stateProvider: LocalStateProvider | undefined;
 
   const cleanup = singleFlight(
     async (): Promise<void> => {
+      if (stateProvider) {
+        try {
+          stateProvider.dispose();
+        } catch (err) {
+          getLogger().debug(
+            `state provider dispose failed: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
       if (stopLogs) {
         try {
           stopLogs();
@@ -237,7 +256,23 @@ async function localInvokeAgentCoreCommand(
         ),
     });
 
-    const resolved = resolveAgentCoreTarget(resolvedTarget, stacks);
+    // Build a `--from-cfn-stack` image-resolution context BEFORE resolving the
+    // target, so a same-stack AWS::ECR::Repository Fn::Join ContainerUri (or an
+    // Fn::Sub asset URI) reduces to the deployed image URI. The state load is
+    // shared with the env-substitution + role-from-state steps below.
+    const candidate = pickAgentCoreCandidateStack(resolvedTarget, stacks);
+    stateProvider = createLocalStateProvider(
+      options,
+      candidate?.stackName ?? '',
+      await resolveCfnFallbackRegion(options, candidate?.region),
+      extraStateProviders
+    );
+    const { context: imageContext, loaded: loadedState } =
+      stateProvider && candidate
+        ? await buildAgentCoreImageContext(candidate, stateProvider, options)
+        : { context: undefined, loaded: undefined };
+
+    const resolved = resolveAgentCoreTarget(resolvedTarget, stacks, imageContext);
     logger.info(`Target: ${resolved.stack.stackName}/${resolved.logicalId} (${resolved.protocol})`);
     const isMcp = resolved.protocol === AGENTCORE_MCP_PROTOCOL;
 
@@ -271,12 +306,14 @@ async function localInvokeAgentCoreCommand(
 
     const image = await resolveAgentCoreImage(resolved, options);
 
-    const dockerEnv = await buildContainerEnv(
+    const { env: dockerEnv, sensitiveEnvKeys } = await buildContainerEnv(
       resolved,
       options,
       profileCredentials,
       profileCredsFile,
-      extraStateProviders
+      stateProvider,
+      loadedState,
+      imageContext
     );
 
     const hostPort = await pickFreePort();
@@ -300,6 +337,8 @@ async function localInvokeAgentCoreCommand(
       platform: options.platform,
       name: containerName,
       ...(isMcp && { containerPort: MCP_CONTAINER_PORT }),
+      // Keep decrypted SecureString SSM env values off the `docker run` argv.
+      ...(sensitiveEnvKeys.size > 0 && { sensitiveEnvKeys }),
     });
 
     stopLogs = streamLogs(containerId);
@@ -533,9 +572,16 @@ function findFileAssetByObjectKey(
 }
 
 /**
- * Build the container env: resolved template env vars (+ `--env-vars`
- * overrides, + `--from-cfn-stack` state substitution) plus AWS credentials
- * (`--assume-role` STS temp creds, else `--profile` / dev creds).
+ * Build the container env + the set of env keys to keep off the `docker run`
+ * argv. Substitutes `--from-cfn-stack` state into the template env (reusing the
+ * shared state load + image-resolution context — Ref / Fn::Sub / Fn::Join +
+ * SSM parameters, with decrypted SecureString values flagged sensitive),
+ * applies `--env-vars` overrides, then injects AWS credentials (`--assume-role`
+ * STS temp creds — resolving an intrinsic RoleArn from state for bare
+ * `--assume-role` — else `--profile` / dev creds).
+ *
+ * The state provider + loaded record + image context are built once by the
+ * caller and shared here, so this does not re-load state.
  */
 export async function buildContainerEnv(
   resolved: ResolvedAgentCoreRuntime,
@@ -544,43 +590,40 @@ export async function buildContainerEnv(
     | { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
     | undefined,
   profileCredsFile: ProfileCredentialsFile | undefined,
-  extraStateProviders: ExtraStateProviders | undefined
-): Promise<Record<string, string>> {
+  stateProvider: LocalStateProvider | undefined,
+  loaded: LocalStateRecord | undefined,
+  imageContext: ImageResolutionContext | undefined
+): Promise<{ env: Record<string, string>; sensitiveEnvKeys: Set<string> }> {
   const logger = getLogger();
   let templateEnv: Record<string, unknown> = resolved.environmentVariables;
+  const sensitiveEnvKeys = new Set<string>();
 
-  const stateProvider = createLocalStateProvider(
-    options,
-    resolved.stack.stackName,
-    await resolveCfnFallbackRegion(options, resolved.stack.region),
-    extraStateProviders
-  );
-  if (stateProvider) {
-    try {
-      const loaded = await stateProvider.load(resolved.stack.stackName, resolved.stack.region);
-      if (loaded) {
-        const subContext: SubstitutionContext = {
-          resources: loaded.resources,
-          consumerRegion: loaded.region,
-        };
-        const pseudo = derivePseudoParametersFromRegion(loaded.region);
-        if (pseudo) subContext.pseudoParameters = pseudo;
-        const resolver = await stateProvider.buildCrossStackResolver(loaded.region);
-        if (resolver) subContext.crossStackResolver = resolver;
-        const { env, audit } = await substituteEnvVarsFromStateAsync(templateEnv, subContext);
-        templateEnv = env;
-        for (const key of audit.resolvedKeys) {
-          logger.debug(`${stateProvider.label}: substituted env var ${key}`);
-        }
-        for (const { key, reason } of audit.unresolved) {
-          logger.warn(
-            `${stateProvider.label}: could not substitute env var ${key} (${reason}). ` +
-              `Override it via --env-vars or it will be dropped.`
-          );
-        }
-      }
-    } finally {
-      stateProvider.dispose();
+  if (stateProvider && loaded) {
+    const subContext: SubstitutionContext = {
+      resources: imageContext?.stateResources ?? loaded.resources,
+      consumerRegion: loaded.region,
+    };
+    const pseudo =
+      imageContext?.pseudoParameters ?? derivePseudoParametersFromRegion(loaded.region);
+    if (pseudo) subContext.pseudoParameters = pseudo;
+    if (imageContext?.stateParameters) subContext.parameters = imageContext.stateParameters;
+    if (imageContext?.stateSensitiveParameters?.length) {
+      subContext.sensitiveParameters = new Set(imageContext.stateSensitiveParameters);
+    }
+    const resolver = await stateProvider.buildCrossStackResolver(loaded.region);
+    if (resolver) subContext.crossStackResolver = resolver;
+    const { env, audit } = await substituteEnvVarsFromStateAsync(templateEnv, subContext);
+    templateEnv = env;
+    for (const key of audit.resolvedKeys) {
+      logger.debug(`${stateProvider.label}: substituted env var ${key}`);
+    }
+    // Decrypted SecureString SSM values: keep them off the `docker run` argv.
+    for (const key of audit.sensitiveKeys) sensitiveEnvKeys.add(key);
+    for (const { key, reason } of audit.unresolved) {
+      logger.warn(
+        `${stateProvider.label}: could not substitute env var ${key} (${reason}). ` +
+          `Override it via --env-vars or it will be dropped.`
+      );
     }
   }
 
@@ -597,7 +640,7 @@ export async function buildContainerEnv(
   }
 
   const dockerEnv: Record<string, string> = { ...envResult.resolved };
-  const assumeRoleArn = resolveAssumeRoleArn(options, resolved);
+  const assumeRoleArn = resolveAssumeRoleArn(options, resolved, loaded);
   await applyAgentCoreCredentialEnv(dockerEnv, {
     ...(assumeRoleArn !== undefined && { assumeRoleArn }),
     ...(options.region !== undefined && { region: options.region }),
@@ -609,7 +652,69 @@ export async function buildContainerEnv(
       },
     }),
   });
-  return dockerEnv;
+  return { env: dockerEnv, sensitiveEnvKeys };
+}
+
+/**
+ * Build the `--from-cfn-stack` image-resolution context + return the loaded
+ * state record (loaded once, reused by env substitution + role resolution).
+ * Mirrors `run-task`'s `buildEcsImageResolutionContext`: pseudo parameters
+ * (region + STS account id), the deployed resources, and SSM template
+ * parameters (decrypted SecureString logical ids flagged sensitive).
+ */
+async function buildAgentCoreImageContext(
+  candidate: StackInfo,
+  stateProvider: LocalStateProvider,
+  options: LocalInvokeAgentCoreOptions
+): Promise<{ context: ImageResolutionContext | undefined; loaded: LocalStateRecord | undefined }> {
+  const logger = getLogger();
+  const region =
+    options.region ??
+    process.env['AWS_REGION'] ??
+    process.env['AWS_DEFAULT_REGION'] ??
+    candidate.region;
+
+  let accountId: string | undefined;
+  try {
+    accountId = await resolveCallerAccountId(region, options.profile);
+  } catch (err) {
+    logger.warn(
+      `--from-cfn-stack: STS GetCallerIdentity failed: ${err instanceof Error ? err.message : String(err)}. ` +
+        'A same-stack ECR image URI referencing ${AWS::AccountId} may not resolve.'
+    );
+  }
+
+  const context: ImageResolutionContext = {};
+  const pseudo = derivePseudoParametersFromRegion(region, accountId);
+  if (pseudo) context.pseudoParameters = pseudo;
+
+  const loaded = await stateProvider.load(candidate.stackName, candidate.region);
+  if (loaded) {
+    context.stateResources = loaded.resources;
+    if (stateProvider.resolveTemplateSsmParameters) {
+      const ssm = await stateProvider.resolveTemplateSsmParameters(candidate.template);
+      if (Object.keys(ssm.values).length > 0) context.stateParameters = ssm.values;
+      if (ssm.secureStringLogicalIds.length > 0) {
+        context.stateSensitiveParameters = ssm.secureStringLogicalIds;
+      }
+    }
+  }
+  return { context, loaded: loaded ?? undefined };
+}
+
+/** STS `GetCallerIdentity` for the `${AWS::AccountId}` pseudo parameter (threads `--profile`). */
+async function resolveCallerAccountId(
+  region: string | undefined,
+  profile: string | undefined
+): Promise<string | undefined> {
+  const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
+  const sts = new STSClient({ ...(region && { region }), ...(profile && { profile }) });
+  try {
+    const identity = await sts.send(new GetCallerIdentityCommand({}));
+    return identity.Account;
+  } finally {
+    sts.destroy();
+  }
 }
 
 /**
@@ -662,18 +767,31 @@ export async function applyAgentCoreCredentialEnv(
 
 /**
  * Resolve the role ARN to assume, honoring the three `--assume-role` forms.
- * Bare `--assume-role` uses the runtime's literal `RoleArn`; warns when it
- * is an intrinsic (no ARN to assume) and falls back to dev creds.
+ * Bare `--assume-role` uses the runtime's literal `RoleArn`; when that is an
+ * intrinsic (the common L2 case — `Fn::GetAtt` to an auto-created role) it
+ * resolves the execution-role ARN from `--from-cfn-stack` state, and only
+ * warns + falls back to dev creds when neither is available.
  */
 export function resolveAssumeRoleArn(
   options: LocalInvokeAgentCoreOptions,
-  resolved: ResolvedAgentCoreRuntime
+  resolved: ResolvedAgentCoreRuntime,
+  loaded: LocalStateRecord | undefined
 ): string | undefined {
   if (typeof options.assumeRole === 'string') return options.assumeRole;
   if (options.assumeRole === true) {
     if (resolved.roleArn) return resolved.roleArn;
+    if (loaded) {
+      const fromState = resolveExecutionRoleArnFromState(loaded, resolved.logicalId, 'RoleArn');
+      if (fromState) {
+        getLogger().debug(`--assume-role: resolved RoleArn from state: ${fromState}`);
+        return fromState;
+      }
+    }
     getLogger().warn(
-      "--assume-role passed without an ARN, but the runtime's RoleArn is not a literal ARN in the template. " +
+      "--assume-role passed without an ARN, but the runtime's RoleArn is not a literal ARN in the template " +
+        (loaded
+          ? 'and could not be resolved from the deployed stack state. '
+          : 'and no --from-cfn-stack state is available to resolve it. ') +
         'Pass the ARN explicitly: --assume-role <arn>. ' +
         "Falling back to the developer's shell credentials."
     );

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -662,7 +662,7 @@ export async function buildContainerEnv(
  * (region + STS account id), the deployed resources, and SSM template
  * parameters (decrypted SecureString logical ids flagged sensitive).
  */
-async function buildAgentCoreImageContext(
+export async function buildAgentCoreImageContext(
   candidate: StackInfo,
   stateProvider: LocalStateProvider,
   options: LocalInvokeAgentCoreOptions

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -1037,13 +1037,14 @@ function suggestAssumeRoleFromState(state: StackState, logicalId: string): void 
 }
 
 export function resolveExecutionRoleArnFromState(
-  state: StackState,
-  logicalId: string
+  state: Pick<StackState, 'resources'>,
+  logicalId: string,
+  roleProperty = 'Role'
 ): string | undefined {
   const lambda = state.resources[logicalId];
   if (!lambda) return undefined;
 
-  const roleRef = lambda.properties?.['Role'] ?? lambda.observedProperties?.['Role'];
+  const roleRef = lambda.properties?.[roleProperty] ?? lambda.observedProperties?.[roleProperty];
   if (typeof roleRef === 'string' && roleRef.startsWith('arn:')) {
     return roleRef;
   }

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -162,6 +162,28 @@ export function resolveAgentCoreTarget(
 }
 
 /**
+ * Best-effort pick of the candidate stack a target lives in, BEFORE full
+ * resolution — so the command can build a `--from-cfn-stack` image-resolution
+ * context (state load + pseudo parameters) and thread it into
+ * {@link resolveAgentCoreTarget} so a same-stack `AWS::ECR::Repository`
+ * `Fn::Join` ContainerUri resolves to the deployed URI. Returns undefined when
+ * the stack is ambiguous (multi-stack app, no prefix) — the caller proceeds
+ * without a context and the resolver surfaces its own error if one is needed.
+ * Mirrors `run-task`'s `pickCandidateStack`.
+ */
+export function pickAgentCoreCandidateStack(
+  target: string,
+  stacks: StackInfo[]
+): StackInfo | undefined {
+  const parsed = parseTarget(target);
+  if (parsed.stackPattern === null) {
+    return stacks.length === 1 ? stacks[0] : undefined;
+  }
+  const matched = matchStacks(stacks, [parsed.stackPattern]);
+  return matched.length === 1 ? matched[0] : undefined;
+}
+
+/**
  * Single-stack auto-detect: if the app has exactly one stack the user may
  * omit the stack prefix; otherwise an explicit stack pattern is required.
  * Mirrors the Lambda / ECS resolvers' behavior via the shared

--- a/tests/unit/cli/local-invoke-agentcore-creds.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore-creds.test.ts
@@ -10,12 +10,15 @@ vi.mock('@aws-sdk/client-sts', () => ({
   AssumeRoleCommand: class {
     constructor(public input: unknown) {}
   },
+  GetCallerIdentityCommand: class {
+    constructor(public input: unknown) {}
+  },
 }));
 
-const { applyAgentCoreCredentialEnv, resolveAssumeRoleArn } = await import(
-  '../../../src/cli/commands/local-invoke-agentcore.js'
-);
+const { applyAgentCoreCredentialEnv, resolveAssumeRoleArn, buildAgentCoreImageContext } =
+  await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
 function runtime(roleArn?: string): ResolvedAgentCoreRuntime {
   return {
@@ -35,23 +38,79 @@ const opts = (assumeRole: string | boolean | undefined): Parameters<typeof resol
 
 describe('resolveAssumeRoleArn — three --assume-role forms', () => {
   it('returns the explicit ARN for --assume-role <arn>', () => {
-    expect(resolveAssumeRoleArn(opts('arn:aws:iam::1:role/X'), runtime())).toBe(
+    expect(resolveAssumeRoleArn(opts('arn:aws:iam::1:role/X'), runtime(), undefined)).toBe(
       'arn:aws:iam::1:role/X'
     );
   });
 
   it("uses the runtime's literal RoleArn for bare --assume-role", () => {
-    expect(resolveAssumeRoleArn(opts(true), runtime('arn:aws:iam::1:role/Agent'))).toBe(
+    expect(resolveAssumeRoleArn(opts(true), runtime('arn:aws:iam::1:role/Agent'), undefined)).toBe(
       'arn:aws:iam::1:role/Agent'
     );
   });
 
-  it('returns undefined for bare --assume-role when RoleArn is not a literal', () => {
-    expect(resolveAssumeRoleArn(opts(true), runtime(undefined))).toBeUndefined();
+  it('returns undefined for bare --assume-role when RoleArn is not a literal (no state)', () => {
+    expect(resolveAssumeRoleArn(opts(true), runtime(undefined), undefined)).toBeUndefined();
   });
 
   it('returns undefined when --assume-role is absent', () => {
-    expect(resolveAssumeRoleArn(opts(undefined), runtime('arn:aws:iam::1:role/Agent'))).toBeUndefined();
+    expect(
+      resolveAssumeRoleArn(opts(undefined), runtime('arn:aws:iam::1:role/Agent'), undefined)
+    ).toBeUndefined();
+  });
+});
+
+describe('buildAgentCoreImageContext', () => {
+  beforeEach(() => sendMock.mockReset());
+
+  const candidate = (): StackInfo =>
+    ({
+      stackName: 'App',
+      displayName: 'App',
+      artifactId: 'App',
+      template: { Resources: {} },
+      dependencyNames: [],
+      region: 'us-east-1',
+    }) as unknown as StackInfo;
+
+  const provider = (over: Record<string, unknown> = {}) =>
+    ({
+      label: '--from-cfn-stack',
+      load: vi.fn().mockResolvedValue({ resources: { T: { physicalId: 't1' } }, region: 'us-east-1', outputs: {} }),
+      resolveTemplateSsmParameters: vi
+        .fn()
+        .mockResolvedValue({ values: { Secret: 's3cr3t' }, secureStringLogicalIds: ['Secret'] }),
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn(),
+      ...over,
+    }) as never;
+
+  const opt = { region: 'us-east-1' } as never;
+
+  it('builds pseudo params (with STS account), state resources, and SSM params', async () => {
+    sendMock.mockResolvedValue({ Account: '123456789012' });
+    const { context, loaded } = await buildAgentCoreImageContext(candidate(), provider(), opt);
+    expect(context?.pseudoParameters).toMatchObject({
+      accountId: '123456789012',
+      region: 'us-east-1',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(context?.stateResources).toEqual({ T: { physicalId: 't1' } });
+    expect(context?.stateParameters).toEqual({ Secret: 's3cr3t' });
+    expect(context?.stateSensitiveParameters).toEqual(['Secret']);
+    expect(loaded).toBeDefined();
+  });
+
+  it('omits stateResources when the state record is absent', async () => {
+    sendMock.mockResolvedValue({ Account: '1' });
+    const { context, loaded } = await buildAgentCoreImageContext(
+      candidate(),
+      provider({ load: vi.fn().mockResolvedValue(undefined) }),
+      opt
+    );
+    expect(context?.stateResources).toBeUndefined();
+    expect(loaded).toBeUndefined();
   });
 });
 

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -88,6 +88,7 @@ const {
   readEnvOverridesFile,
   platformToArchitecture,
   resolveInboundAuthorization,
+  resolveAssumeRoleArn,
 } = await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -349,36 +350,111 @@ describe('buildContainerEnv — --from-cfn-stack env substitution', () => {
     vi.clearAllMocks();
   });
 
-  it('substitutes a Ref env var against the deployed state and injects it', async () => {
-    const fakeProvider = {
-      label: '--from-cfn-stack',
-      load: vi.fn().mockResolvedValue({
-        resources: {
-          MyTable: { physicalId: 'tbl-123', resourceType: 'AWS::DynamoDB::Table', properties: {} },
-        },
-        region: 'us-east-1',
-        outputs: {},
-      }),
-      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
-      dispose: vi.fn(),
-    };
-    createLocalStateProviderMock.mockReturnValue(fakeProvider);
+  const provider = () => ({
+    label: '--from-cfn-stack',
+    buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+  });
+  const cfnOpts = { fromCfnStack: 'App', platform: 'linux/arm64', pull: true, build: true } as never;
 
+  it('substitutes a Ref env var against the shared loaded state and injects it', async () => {
     const resolved = runtime('repo:tag', {
       environmentVariables: { TABLE_NAME: { Ref: 'MyTable' } },
     });
+    const loaded = {
+      resources: {
+        MyTable: { physicalId: 'tbl-123', resourceType: 'AWS::DynamoDB::Table', properties: {} },
+      },
+      region: 'us-east-1',
+      outputs: {},
+    };
 
-    const dockerEnv = await buildContainerEnv(
+    const { env, sensitiveEnvKeys } = await buildContainerEnv(
       resolved,
-      { fromCfnStack: 'App', platform: 'linux/arm64', pull: true, build: true } as never,
+      cfnOpts,
       undefined,
       undefined,
-      undefined
+      provider() as never,
+      loaded as never,
+      { stateResources: loaded.resources } as never
     );
 
-    expect(fakeProvider.load).toHaveBeenCalled();
-    expect(fakeProvider.dispose).toHaveBeenCalled();
-    expect(dockerEnv['TABLE_NAME']).toBe('tbl-123');
+    expect(env['TABLE_NAME']).toBe('tbl-123');
+    expect(sensitiveEnvKeys.size).toBe(0);
+  });
+
+  it('routes a decrypted SecureString SSM env value off the argv (sensitiveEnvKeys)', async () => {
+    const resolved = runtime('repo:tag', {
+      environmentVariables: { API_KEY: { Ref: 'SecretParam' } },
+    });
+    const loaded = { resources: {}, region: 'us-east-1', outputs: {} };
+    const imageContext = {
+      stateResources: {},
+      stateParameters: { SecretParam: 's3cr3t-value' },
+      stateSensitiveParameters: ['SecretParam'],
+    };
+
+    const { env, sensitiveEnvKeys } = await buildContainerEnv(
+      resolved,
+      cfnOpts,
+      undefined,
+      undefined,
+      provider() as never,
+      loaded as never,
+      imageContext as never
+    );
+
+    expect(env['API_KEY']).toBe('s3cr3t-value');
+    // The value resolved from a SecureString param, so the env key must be
+    // flagged sensitive (kept off the docker run argv).
+    expect(sensitiveEnvKeys.has('API_KEY')).toBe(true);
+  });
+});
+
+describe('resolveAssumeRoleArn — bare --assume-role + state', () => {
+  const resolved = (over: Record<string, unknown> = {}) =>
+    ({
+      logicalId: 'ChatAgent',
+      stack: { stackName: 'App' },
+      environmentVariables: {},
+      protocol: 'HTTP',
+      ...over,
+    }) as never;
+
+  it('returns the explicit ARN for --assume-role <arn>', () => {
+    expect(resolveAssumeRoleArn({ assumeRole: 'arn:aws:iam::1:role/x' } as never, resolved(), undefined)).toBe(
+      'arn:aws:iam::1:role/x'
+    );
+  });
+
+  it('uses the literal RoleArn for bare --assume-role when present', () => {
+    expect(
+      resolveAssumeRoleArn(
+        { assumeRole: true } as never,
+        resolved({ roleArn: 'arn:aws:iam::1:role/lit' }),
+        undefined
+      )
+    ).toBe('arn:aws:iam::1:role/lit');
+  });
+
+  it('resolves an intrinsic RoleArn from --from-cfn-stack state for bare --assume-role', () => {
+    const loaded = {
+      resources: {
+        ChatAgent: { properties: { RoleArn: { 'Fn::GetAtt': ['AgentRole', 'Arn'] } } },
+        AgentRole: { attributes: { Arn: 'arn:aws:iam::1:role/from-state' } },
+      },
+    };
+    expect(resolveAssumeRoleArn({ assumeRole: true } as never, resolved(), loaded as never)).toBe(
+      'arn:aws:iam::1:role/from-state'
+    );
+  });
+
+  it('returns undefined (warn + dev-creds fallback) when bare --assume-role cannot resolve', () => {
+    expect(resolveAssumeRoleArn({ assumeRole: true } as never, resolved(), undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when --assume-role is not set', () => {
+    expect(resolveAssumeRoleArn({} as never, resolved(), undefined)).toBeUndefined();
   });
 });
 

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
   AgentCoreResolutionError,
+  pickAgentCoreCandidateStack,
   resolveAgentCoreTarget,
 } from '../../../src/local/agentcore-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
@@ -299,5 +300,29 @@ describe('resolveAgentCoreTarget — JWT authorizer extraction', () => {
       }),
     });
     expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer).toBeUndefined();
+  });
+});
+
+describe('pickAgentCoreCandidateStack', () => {
+  it('returns the only stack when no prefix is given (single-stack app)', () => {
+    const stack = buildStack('App', { ChatAgent: containerRuntime() });
+    expect(pickAgentCoreCandidateStack('ChatAgent', [stack])?.stackName).toBe('App');
+  });
+
+  it('returns undefined when the prefix is omitted in a multi-stack app (ambiguous)', () => {
+    const a = buildStack('A', { ChatAgent: containerRuntime() });
+    const b = buildStack('B', { Other: containerRuntime() });
+    expect(pickAgentCoreCandidateStack('ChatAgent', [a, b])).toBeUndefined();
+  });
+
+  it('resolves the stack from a stack-qualified target', () => {
+    const a = buildStack('A', { ChatAgent: containerRuntime() });
+    const b = buildStack('B', { Other: containerRuntime() });
+    expect(pickAgentCoreCandidateStack('B:Other', [a, b])?.stackName).toBe('B');
+  });
+
+  it('returns undefined when the stack pattern matches nothing', () => {
+    const stack = buildStack('App', { ChatAgent: containerRuntime() });
+    expect(pickAgentCoreCandidateStack('Missing:ChatAgent', [stack])).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Implements #130: brings `cdkl invoke-agentcore --from-cfn-stack` to credential +
state parity with `cdkl invoke` / `run-task`, reusing their established
patterns. The state provider is created + loaded **once** in the command and
shared across three resolutions:

1. **Container image URI from deployed state** — a `--from-cfn-stack`
   image-resolution context (pseudo params via STS + region, deployed resources,
   SSM template params) is built BEFORE resolving the target (new
   `pickAgentCoreCandidateStack` picks the candidate stack first) and threaded
   into `resolveAgentCoreTarget`, so a same-stack `AWS::ECR::Repository`
   `Fn::Join` ContainerUri resolves to the deployed image. Mirrors run-task's
   `buildEcsImageResolutionContext`.
2. **SSM SecureString env values off the argv** — `AWS::SSM::Parameter::Value`
   env refs resolve against state; decrypted `SecureString` values are flagged
   (the substitution audit's `sensitiveKeys`) and routed through
   `runDetached({ sensitiveEnvKeys })` so they never appear inline on the
   `docker run` argv. Mirrors `cdkl invoke` (#94/#99).
3. **Bare `--assume-role` from state** — when `RoleArn` is an intrinsic
   (`Fn::GetAtt` to an auto-created role), the execution-role ARN is resolved
   from state via the shared `resolveExecutionRoleArnFromState` (parametrized for
   the `RoleArn` property), instead of warning + falling back to dev creds.

`buildContainerEnv` no longer creates its own provider — it receives the shared
provider + loaded record + image context and returns `{ env, sensitiveEnvKeys }`.
The provider is disposed once via the command's `cleanup` single-flight.

## Test plan

- [x] `vp run verify` green — 1378 unit tests pass.
- [x] Unit: `pickAgentCoreCandidateStack` (single-stack / ambiguous→undefined /
  stack-qualified / no-match); `buildAgentCoreImageContext` (STS account →
  pseudo params, deployed resources, SSM params; state-absent path);
  `buildContainerEnv` (Ref substitution from shared state; **SecureString →
  `sensitiveEnvKeys`** — asserts the decrypted value reaches env AND the key is
  flagged); `resolveAssumeRoleArn` (explicit ARN / literal RoleArn /
  intrinsic-resolved-from-state / fallback-undefined / not-set).
- [x] Real-Docker **regression** integ `local-invoke-agentcore` 12/12, 0
  orphans — confirms the command's flow refactor (state-load reordering +
  `buildContainerEnv` signature change) did NOT break the local / MCP /
  code-artifact paths (the critical risk of this change).

## Reviewer notes

3-axis review (security-sensitive: credential resolution + SecureString
handling). Spec: clean (all 3 patterns mirror run-task/invoke). Code: no
blockers — SecureString-off-argv flow, the create-once/dispose-once provider
lifecycle (verified safe on the error/SIGINT paths), credential precedence, and
the backward-compatible `resolveExecutionRoleArnFromState` signature widening
(all Lambda callers pass full `StackState` + default `'Role'`) were verified.

Accepted as known cost (not blockers):

- **Real-AWS `--from-cfn-stack` integ deferred to #147**: all three patterns
  resist a clean single-`cdk deploy` fixture — Pattern 1's same-stack ECR image
  is a push-before-create chicken-and-egg, CloudFormation refuses to deploy a
  `SecureString` referenced as an `AWS::SSM::Parameter::Value<String>` template
  param (the reason cdk-local resolves it client-side), and the CFn provider's
  `ListStackResources` leaves `attributes` empty so an `Fn::GetAtt` role ARN
  only resolves from host/S3 state. The behavior is locked by unit tests + the
  reuse of proven invoke/run-task code; #147 tracks a real-AWS integ that works
  around these.
- Low-severity test gaps left as-is: the candidate-undefined consumption (a
  trivial ternary; `pickAgentCoreCandidateStack` itself is unit-tested), a
  `--env-vars` override of a sensitive key (stays flagged — over-hiding, never
  leaking), and the dispose-in-cleanup debug-log branch (lifecycle verified in
  review).

Closes #130
