### PR TITLE
docs(hooks): mark integ-gate / verify-pr-gate as installed

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -262,7 +262,7 @@ vp run runtime:smoke
   pre-flight + verify.sh + post-run orphan sweep + (for
   `*-from-cfn-stack` tests) AWS stack orphan check in one block.
   Skipping any step risks setting the `integ` marker on incomplete
-  verification. The matching `integ-gate.sh` hook (TODO) will block
+  verification. The `integ-gate.sh` hook blocks
   `gh pr merge` when `src/**` or `tests/integration/**` is touched
   and the marker is stale.
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -142,7 +142,7 @@ The hooks split into three classes:
 ## 3. Markgate-backed gates
 
 The four markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
-`pr-review-gate.sh`, and the planned `integ-gate.sh`) are all
+`pr-review-gate.sh`, and `integ-gate.sh`) are all
 **cwd-aware**. Each reads the PreToolUse payload's `cwd` field plus
 parses leading `cd <path>` and the last `git -C <path>` /
 `gh -C <path>` flag from the command, then `cd`s to that resolved
@@ -240,13 +240,13 @@ construction.
   sentinel (next `/review-pr` run) and `markgate verify` reports
   stale automatically. No bespoke sha tracking inside the hook.
 
-### integ-gate (pre-merge, TODO)
+### integ-gate (pre-merge)
 
-The `integ` markgate marker is wired (set by `/run-integ` when the
+The `integ` markgate marker is set by `/run-integ` when the
 Docker-based fixture run is clean and all orphan sweeps return
-empty), but the matching gate hook is not yet installed.
+empty. `integ-gate.sh` is installed and consults it.
 
-When shipped, `integ-gate.sh` will block `gh pr merge` on PRs whose
+`integ-gate.sh` blocks `gh pr merge` on PRs whose
 diff touches `src/**` or `tests/integration/**` when the `integ`
 marker is stale (digest differs OR expired by the 14-day TTL).
 The 14d TTL is on top of the file-scope check — Docker base-image

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -168,7 +168,7 @@ mise exec -- markgate set docs
 mise exec -- markgate set verify-pr
 ```
 
-The `verify-pr` marker is the one consulted by `.claude/hooks/verify-pr-gate.sh` (to ship in a follow-up PR) to allow `gh pr create` and `gh pr merge`. It is intentionally settable ONLY by this skill — running it by hand from a shell to bypass the gate defeats the whole point. If a check legitimately cannot pass right now (e.g. the live-test cannot run because Docker is unavailable), say so explicitly in the report and DO NOT set the marker — the gate exits non-zero so the human can decide whether to override.
+The `verify-pr` marker is the one consulted by `.claude/hooks/verify-pr-gate.sh` to allow `gh pr create` and `gh pr merge`. It is intentionally settable ONLY by this skill — running it by hand from a shell to bypass the gate defeats the whole point. If a check legitimately cannot pass right now (e.g. the live-test cannot run because Docker is unavailable), say so explicitly in the report and DO NOT set the marker — the gate exits non-zero so the human can decide whether to override.
 
 Then, if there are uncommitted changes (e.g., lint fixes, doc updates made during this run), commit them and push to the remote. This ensures the remote branch is always up to date when reporting "PR is ready to merge."
 


### PR DESCRIPTION
## Summary

All 14 PreToolUse gate hooks (including `integ-gate.sh`, `verify-pr-gate.sh`, `pr-review-gate.sh`) are registered in `.claude/settings.json`, but three docs still described some as TODO / "not yet installed" / "to ship in a follow-up PR". Corrected to present tense:

- `.claude/rules/hooks.md` — the integ-gate section header + body (was "(pre-merge, TODO)" / "not yet installed"), and the "planned `integ-gate.sh`" mention in the cwd-aware intro.
- `.claude/CLAUDE.md` — the "When running integration tests" bullet (was "`integ-gate.sh` hook (TODO) will block").
- `.claude/skills/verify-pr/SKILL.md` — dropped the stale "(to ship in a follow-up PR)" on verify-pr-gate.

## Test plan

- [x] `vp run check` green
- [x] Docs-only diff (3 `.claude/**` files); verified every gate hook named is actually registered in `.claude/settings.json`
- [x] No remaining "TODO / not yet installed / to ship" gate-status claims