### PR TITLE
test(invoke-agentcore): real-AWS --from-cfn-stack integ (deploy + invoke + destroy)

### DIFF
--- a/tests/integration/local-invoke-agentcore-from-cfn/.gitignore
+++ b/tests/integration/local-invoke-agentcore-from-cfn/.gitignore
@@ -1,0 +1,9 @@
+# The integ runner installs deps fresh via `vp install`, so the lockfile
+# is a build artifact, not a committed source (matches local-run-task).
+pnpm-lock.yaml
+
+# Override the parent integ .gitignore so the agent container's source
+# files are tracked (the parent ignores *.js). The Dockerfile builds
+# /app/server.js into a plain node base serving the 8080 HTTP contract.
+!agent/*.js
+!agent/Dockerfile

--- a/tests/integration/local-invoke-agentcore-from-cfn/.scenarios.json
+++ b/tests/integration/local-invoke-agentcore-from-cfn/.scenarios.json
@@ -1,0 +1,6 @@
+{
+  "scenarios": [
+    "agentcore-from-cfn-ssm-substitution",
+    "agentcore-securestring-off-argv"
+  ]
+}

--- a/tests/integration/local-invoke-agentcore-from-cfn/agent/Dockerfile
+++ b/tests/integration/local-invoke-agentcore-from-cfn/agent/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/docker/library/node:20-slim
+
+WORKDIR /app
+COPY server.js /app/server.js
+
+EXPOSE 8080
+CMD ["node", "/app/server.js"]

--- a/tests/integration/local-invoke-agentcore-from-cfn/agent/server.js
+++ b/tests/integration/local-invoke-agentcore-from-cfn/agent/server.js
@@ -1,0 +1,42 @@
+// Minimal Bedrock AgentCore Runtime agent for the cdkl invoke-agentcore
+// --from-cfn-stack integ. Serves the AgentCore HTTP contract on 0.0.0.0:8080:
+//   GET  /ping        -> 200 {"status":"Healthy", ...}
+//   POST /invocations -> echoes the injected GREETING / API_KEY / STATIC_VALUE
+//                        env vars so verify.sh can assert --from-cfn-stack
+//                        resolved them (String + SecureString SSM params).
+// Compact JSON (no spaces) to match verify.sh's grep assertions. Startup
+// logs go to stderr so the host's stdout carries only the cdkl result.
+const http = require('node:http');
+
+function send(res, status, payload) {
+  const data = JSON.stringify(payload);
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Content-Length': String(data.length) });
+  res.end(data);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/ping') {
+    send(res, 200, { status: 'Healthy', time_of_last_update: Math.floor(Date.now() / 1000) });
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/invocations') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      send(res, 200, {
+        greeting: process.env.GREETING ?? 'unset',
+        apiKey: process.env.API_KEY ?? 'unset',
+        staticValue: process.env.STATIC_VALUE ?? 'unset',
+        runtime: 'agentcore-from-cfn',
+      });
+    });
+    return;
+  }
+  send(res, 404, { error: 'not found' });
+});
+
+server.listen(8080, '0.0.0.0', () => {
+  console.error('agentcore from-cfn agent listening on 0.0.0.0:8080');
+});

--- a/tests/integration/local-invoke-agentcore-from-cfn/bin/app.ts
+++ b/tests/integration/local-invoke-agentcore-from-cfn/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalInvokeAgentCoreFromCfnStack } from '../lib/local-invoke-agentcore-from-cfn-stack.ts';
+
+const app = new cdk.App();
+
+new LocalInvokeAgentCoreFromCfnStack(app, 'CdkLocalInvokeAgentCoreFromCfnFixture', {
+  description: 'Fixture stack for cdkl invoke-agentcore --from-cfn-stack integ test',
+});

--- a/tests/integration/local-invoke-agentcore-from-cfn/cdk.json
+++ b/tests/integration/local-invoke-agentcore-from-cfn/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-invoke-agentcore-from-cfn/lib/local-invoke-agentcore-from-cfn-stack.ts
+++ b/tests/integration/local-invoke-agentcore-from-cfn/lib/local-invoke-agentcore-from-cfn-stack.ts
@@ -1,0 +1,69 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * SSM parameter the fixture's `verify.sh` `put-parameter`s as a `String`
+ * BEFORE `cdk deploy` (CloudFormation resolves `AWS::SSM::Parameter::Value`
+ * parameters at deploy start). Kept in sync with verify.sh's GREETING_PARAM.
+ */
+const SSM_GREETING_PARAM = '/cdkl-integ/invoke-agentcore-from-cfn/greeting';
+
+/**
+ * SSM parameter for the SecureString case. `verify.sh` creates it as a plain
+ * `String` BEFORE deploy (CloudFormation rejects an
+ * `AWS::SSM::Parameter::Value<String>` template parameter that points at a
+ * SecureString), then SWAPS it to a `SecureString` AFTER deploy. cdkl resolves
+ * it directly via SSM `GetParameters(WithDecryption)` at invoke time, so it
+ * sees the SecureString type and must route the decrypted value off the
+ * `docker run` argv. Kept in sync with verify.sh's API_KEY_PARAM.
+ */
+const SSM_API_KEY_PARAM = '/cdkl-integ/invoke-agentcore-from-cfn/api-key';
+
+/**
+ * Fixture stack for `cdkl invoke-agentcore --from-cfn-stack` (issue #130).
+ *
+ * One AgentCore Runtime (fromAsset — a plain Node agent serving the 8080 HTTP
+ * contract) whose env references two `AWS::SSM::Parameter::Value<String>` CFn
+ * parameters (a plain String + a swapped-to-SecureString) plus a literal. Under
+ * `--from-cfn-stack`, cdkl resolves both SSM values into the LOCALLY-run agent's
+ * env and keeps the decrypted SecureString off the docker argv. Without the
+ * flag both intrinsic env vars warn-and-drop.
+ *
+ * `cdkl invoke-agentcore --from-cfn-stack` runs the agent locally and only
+ * READS this deployed stack's state, so the runtime need not be healthy — it
+ * only has to exist. Teardown is `cdk destroy` (+ verify.sh deletes the SSM
+ * params it created).
+ */
+export class LocalInvokeAgentCoreFromCfnStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    new Runtime(this, 'EchoAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromAsset(path.join(__dirname, '../agent'), {
+        platform: Platform.LINUX_ARM64,
+      }),
+      environmentVariables: {
+        // A literal env var — confirms --from-cfn-stack doesn't break the
+        // normal-case passthrough.
+        STATIC_VALUE: 'always-the-same',
+        // Ref to an AWS::SSM::Parameter::Value<String> CFn parameter (issue
+        // #130 / #94). Without --from-cfn-stack it warns-and-drops; with it,
+        // cdkl resolves the value from SSM and substitutes it (inline on argv —
+        // the plain-String control).
+        GREETING: ssm.StringParameter.valueForStringParameter(this, SSM_GREETING_PARAM),
+        // Ref to a second SSM param verify.sh swaps to a SecureString after
+        // deploy (issue #130 / #99). Under --from-cfn-stack cdkl resolves it
+        // with WithDecryption and routes the decrypted value off the docker
+        // argv (value-less `-e API_KEY`).
+        API_KEY: ssm.StringParameter.valueForStringParameter(this, SSM_API_KEY_PARAM),
+      },
+    });
+  }
+}

--- a/tests/integration/local-invoke-agentcore-from-cfn/package.json
+++ b/tests/integration/local-invoke-agentcore-from-cfn/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-invoke-agentcore-from-cfn",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl invoke-agentcore --from-cfn-stack",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.257.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-invoke-agentcore-from-cfn/tsconfig.json
+++ b/tests/integration/local-invoke-agentcore-from-cfn/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-invoke-agentcore-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-from-cfn/verify.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkl invoke-agentcore --from-cfn-stack`
+# (issue #130, follow-up #147).
+#
+# `cdkl invoke-agentcore --from-cfn-stack` runs the agent LOCALLY and only
+# READS the deployed stack's state, so the deployed AgentCore Runtime need
+# not be healthy — it only has to exist. This exercises the --from-cfn-stack
+# SSM resolution end-to-end against real AWS:
+#   - GREETING: a Ref to an AWS::SSM::Parameter::Value<String> CFn parameter
+#     (plain String) — resolved from SSM, kept inline on the docker argv.
+#   - API_KEY:  a second SSM param swapped to a SecureString after deploy —
+#     resolved with WithDecryption AND kept OFF the docker argv (issue #99
+#     mechanism, mirrored for invoke-agentcore).
+#   - STATIC_VALUE: a literal — confirms the normal-case passthrough.
+#
+# Steps: deploy via upstream cdk -> swap api-key to SecureString -> baseline
+# invoke (both SSM env vars drop) -> --from-cfn-stack invoke (both resolve)
+# -> --verbose off-argv assertion -> cdk destroy + delete SSM params.
+#
+# Run via `/run-integ local-invoke-agentcore-from-cfn` (recommended).
+# Requires Docker, AWS credentials with deploy permissions, and the global
+# `cdk` CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalInvokeAgentCoreFromCfnFixture"
+TARGET="${STACK}/EchoAgent"
+BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
+
+GREETING_PARAM="/cdkl-integ/invoke-agentcore-from-cfn/greeting"
+GREETING_VALUE="hello-from-ssm-state"
+API_KEY_PARAM="/cdkl-integ/invoke-agentcore-from-cfn/api-key"
+API_KEY_PLACEHOLDER="placeholder-not-secret"
+API_KEY_VALUE="s3cr3t-agentcore-9f3a2b"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-agentcore-from-cfn"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed)"
+
+echo "[verify] step 1a: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+
+echo "[verify] step 1b: verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "[verify] step 1c: pulling ${BASE_IMAGE} (one-time)"
+docker pull --platform linux/arm64 "${BASE_IMAGE}" >/dev/null
+
+echo "[verify] step 1d: installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+WE_CREATED_STACK=0
+WE_CREATED_PARAM=0
+cleanup() {
+  rc=$?
+  if [ "${rc}" -ne 0 ] && [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] FAIL (exit ${rc}) — attempting cdk destroy to clean up"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  if [ "${WE_CREATED_PARAM}" -eq 1 ]; then
+    aws ssm delete-parameter --name "${GREETING_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
+    aws ssm delete-parameter --name "${API_KEY_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
+  fi
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists — clean up first via:"
+  echo "          aws cloudformation delete-stack --stack-name ${STACK} --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 2b: put the SSM parameters (Strings, pre-deploy)"
+WE_CREATED_PARAM=1
+aws ssm put-parameter --name "${GREETING_PARAM}" --value "${GREETING_VALUE}" \
+  --type String --overwrite --region "${REGION}" >/dev/null
+echo "[verify]   put ${GREETING_PARAM}=${GREETING_VALUE}"
+# api-key starts as a plain String — CloudFormation rejects an
+# AWS::SSM::Parameter::Value<String> template parameter that points at a
+# SecureString. Swapped to a SecureString after deploy.
+aws ssm put-parameter --name "${API_KEY_PARAM}" --value "${API_KEY_PLACEHOLDER}" \
+  --type String --overwrite --region "${REGION}" >/dev/null
+echo "[verify]   put ${API_KEY_PARAM}=${API_KEY_PLACEHOLDER} (String, pre-deploy)"
+
+echo "[verify] step 3: cdk deploy (upstream CDK CLI)"
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 3 ok: cdk deploy completed"
+
+echo "[verify] step 3b: swap the api-key SSM parameter to a SecureString"
+aws ssm delete-parameter --name "${API_KEY_PARAM}" --region "${REGION}" >/dev/null
+aws ssm put-parameter --name "${API_KEY_PARAM}" --value "${API_KEY_VALUE}" \
+  --type SecureString --region "${REGION}" >/dev/null
+echo "[verify]   swapped ${API_KEY_PARAM} -> SecureString"
+
+invoke_with_retry() {
+  local args=("$@")
+  local attempts=3
+  local i=1
+  while [ $i -le $attempts ]; do
+    if out=$(${CLI} invoke-agentcore "${args[@]}" 2>/dev/null | tail -1) && \
+       echo "${out}" | grep -q '"runtime":"agentcore-from-cfn"'; then
+      printf '%s' "${out}"
+      return 0
+    fi
+    if [ $i -lt $attempts ]; then
+      echo "[verify]   invoke attempt ${i} failed, retrying..." >&2
+      sleep 2
+    fi
+    i=$((i + 1))
+  done
+  echo "[verify]   all ${attempts} invoke attempts failed; last stderr below:" >&2
+  ${CLI} invoke-agentcore "${args[@]}" 2>&1 | tail -15 >&2
+  return 1
+}
+
+echo "[verify] step 4: baseline invoke (no --from-cfn-stack) — SSM env vars drop"
+RESULT_BASELINE=$(invoke_with_retry "${TARGET}")
+echo "[verify]   response: ${RESULT_BASELINE}"
+echo "${RESULT_BASELINE}" | grep -q '"greeting":"unset"' || {
+  echo "[verify] FAIL: expected GREETING dropped (intrinsic warn-and-drop) without --from-cfn-stack, got: ${RESULT_BASELINE}"
+  exit 1
+}
+echo "${RESULT_BASELINE}" | grep -q '"apiKey":"unset"' || {
+  echo "[verify] FAIL: expected API_KEY dropped without --from-cfn-stack, got: ${RESULT_BASELINE}"
+  exit 1
+}
+echo "${RESULT_BASELINE}" | grep -q '"staticValue":"always-the-same"' || {
+  echo "[verify] FAIL: expected STATIC_VALUE=always-the-same in baseline, got: ${RESULT_BASELINE}"
+  exit 1
+}
+
+echo "[verify] step 5: --from-cfn-stack invoke — SSM values resolve into env"
+RESULT_FROM_CFN=$(invoke_with_retry "${TARGET}" --from-cfn-stack)
+echo "[verify]   response: ${RESULT_FROM_CFN}"
+echo "${RESULT_FROM_CFN}" | grep -q "\"greeting\":\"${GREETING_VALUE}\"" || {
+  echo "[verify] FAIL: expected GREETING=${GREETING_VALUE} (SSM String resolved), got: ${RESULT_FROM_CFN}"
+  exit 1
+}
+echo "${RESULT_FROM_CFN}" | grep -q "\"apiKey\":\"${API_KEY_VALUE}\"" || {
+  echo "[verify] FAIL: expected API_KEY=${API_KEY_VALUE} (decrypted SecureString resolved fresh), got: ${RESULT_FROM_CFN}"
+  exit 1
+}
+echo "${RESULT_FROM_CFN}" | grep -q '"staticValue":"always-the-same"' || {
+  echo "[verify] FAIL: STATIC_VALUE regressed under --from-cfn-stack, got: ${RESULT_FROM_CFN}"
+  exit 1
+}
+
+echo "[verify] step 6: assert the decrypted SecureString is kept OFF the docker argv"
+DEBUG_OUT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack --verbose 2>&1 || true)
+DOCKER_RUN_LINE=$(echo "${DEBUG_OUT}" | grep -E '(^| )run .* -e ' | grep -- '-e API_KEY' | head -1)
+if [ -z "${DOCKER_RUN_LINE}" ]; then
+  echo "[verify] FAIL: could not find the 'docker run' debug line carrying -e API_KEY in --verbose output"
+  echo "${DEBUG_OUT}" | tail -20
+  exit 1
+fi
+echo "${DOCKER_RUN_LINE}" | grep -qE -- '-e API_KEY( |$)' || {
+  echo "[verify] FAIL: API_KEY not in the value-less '-e API_KEY' form on the docker argv: ${DOCKER_RUN_LINE}"
+  exit 1
+}
+if echo "${DOCKER_RUN_LINE}" | grep -q "${API_KEY_VALUE}"; then
+  echo "[verify] FAIL: decrypted SecureString value LEAKED onto the docker run argv: ${DOCKER_RUN_LINE}"
+  exit 1
+fi
+# Control: the plain String GREETING keeps the inline form.
+echo "${DOCKER_RUN_LINE}" | grep -q "GREETING=${GREETING_VALUE}" || {
+  echo "[verify] FAIL: expected the plain String GREETING to stay inline as -e GREETING=<value> (control), got: ${DOCKER_RUN_LINE}"
+  exit 1
+}
+echo "[verify]   SecureString API_KEY routed off the argv; String GREETING stayed inline (control)."
+
+echo "[verify] step 7: cdk destroy"
+cdk destroy "${STACK}" --force --region "${REGION}" \
+  --no-version-reporting --no-asset-metadata --no-path-metadata
+WE_CREATED_STACK=0
+echo "[verify]   destroyed ${STACK}"
+
+echo ""
+echo "[verify] All local-invoke-agentcore-from-cfn checks passed"


### PR DESCRIPTION
## Summary

Adds a real-AWS integ proving `cdkl invoke-agentcore --from-cfn-stack`
end-to-end — the deferred verification for the `--from-cfn-stack` parity work
(#130). Tests-only (a new `tests/integration/local-invoke-agentcore-from-cfn`
fixture); no source changes.

The fixture deploys an AgentCore Runtime (`fromAsset`) via the upstream `cdk`
CLI, with two env vars referencing `AWS::SSM::Parameter::Value<String>` CFn
parameters + a literal, then verifies:

- **baseline** (no `--from-cfn-stack`): both SSM-backed env vars warn-and-drop
  (`"unset"`); the literal passes through.
- **`--from-cfn-stack`**: `GREETING` resolves from an SSM **String**, and
  `API_KEY` resolves from an SSM **SecureString** (swapped to SecureString
  after deploy, read fresh with `WithDecryption`) — Pattern 2 of #130 against
  real AWS.
- **`--verbose`**: the decrypted SecureString is kept **off** the `docker run`
  argv (value-less `-e API_KEY`), with the plain-String `GREETING` inline as the
  control.

`cdkl invoke-agentcore --from-cfn-stack` runs the agent **locally** and only
reads the deployed stack's state, so the runtime need not be healthy — it only
has to exist. Mirrors the proven `local-invoke-from-cfn-stack` fixture
(pre-flight orphan scan, sentinel-gated cleanup trap, String->SecureString swap,
`cdk destroy`).

## Test plan

- [x] `vp run check` green (97 files).
- [x] Real-AWS run (us-east-1): `cdk deploy` -> SecureString swap -> baseline
  invoke (both drop) -> `--from-cfn-stack` invoke (GREETING + API_KEY resolve)
  -> `--verbose` off-argv assertion (SecureString off argv, String inline) ->
  `cdk destroy`. All checks passed; 0 orphan stack / SSM params / containers
  afterward.

## Notes

This closes the real-AWS integ gap noted in (#130). Pattern 1 (same-stack ECR
ContainerUri from state) and Pattern 3 (intrinsic RoleArn from state) remain
unit-tested only — Pattern 1's same-stack-ECR image is a push-before-create
chicken-and-egg, and the CFn provider's `ListStackResources` leaves `attributes`
empty so an `Fn::GetAtt` role ARN only resolves from host/S3 state (same
limitation as `cdkl invoke`).

Closes #147
