### PR TITLE
feat(exports)!: restrict internal building blocks to the cdk-local/internal subpath

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -178,8 +178,8 @@ vp run runtime:smoke
 
 - **Library + CLI dual entry**: `src/index.ts` (stable public library
   exports), `src/internal.ts` (unstable low-level building blocks for
-  shim hosts, exposed as the `cdk-local/internal` subpath — NO semver
-  guarantee; the main entry re-exports them for back-compat), and
+  shim hosts, reachable ONLY via the `cdk-local/internal` subpath — NO
+  semver guarantee; the main entry does NOT re-export them), and
   `src/cli/index.ts` (binary entrypoint). `vp pack` produces
   `dist/index.js` (library), `dist/internal.js` (internal), and
   `dist/cli.js` (CLI).

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -130,9 +130,8 @@ import { pickRefLogicalId } from 'cdk-local/internal';
 **No semver guarantee.** Everything under `cdk-local/internal` is
 implementation detail of the `cdkl` CLI and may change or be removed
 without a major version bump — only the main `cdk-local` entry
-documented above is semver-covered. (For backward compatibility the
-main entry currently still re-exports these symbols, but new shim hosts
-should import them from `cdk-local/internal`.)
+documented above is semver-covered. These symbols are reachable ONLY via
+`cdk-local/internal`; the main `cdk-local` entry does not re-export them.
 
 Most hosts only need the command factories above. A host that instead
 re-exports cdk-local's individual `src/local/**` modules verbatim

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,12 +98,7 @@ export {
   type ResolvedSsmParameters,
 } from './local/ssm-parameter-resolver.js';
 
-/**
- * Low-level local-execution building blocks (`cdk-local/internal`),
- * re-exported here so the main entry remains the full union for hosts
- * that shim cdk-local's `src/local/**` modules verbatim (e.g. cdkd).
- * These carry NO SEMVER GUARANTEE — see `src/internal.ts`. New shim
- * hosts should import them from `cdk-local/internal` directly; this
- * re-export keeps existing `cdk-local` imports working unchanged.
- */
-export * from './internal.js';
+// Low-level local-execution building blocks are intentionally NOT
+// re-exported here; they live behind the `cdk-local/internal` subpath
+// (`src/internal.ts`) and carry no semver guarantee. Shim hosts (e.g.
+// cdkd) import them from `cdk-local/internal` directly.

--- a/tests/unit/export-surface.test.ts
+++ b/tests/unit/export-surface.test.ts
@@ -31,13 +31,12 @@ describe('package export surface', () => {
     expect(internal).toHaveProperty('resolveLambdaArnIntrinsic');
   });
 
-  it('re-exports every internal symbol from the main entry (non-breaking union)', () => {
-    // The main entry re-exports `cdk-local/internal` so existing shim-host
-    // imports from `cdk-local` keep working. If someone drops the
-    // `export * from './internal.js'` re-export, this breaks loudly.
-    const missing = Object.keys(internal).filter((key) => !(key in main));
-    expect(missing, `internal symbols missing from the main entry: ${missing.join(', ')}`).toEqual(
-      [],
-    );
+  it('does NOT leak internal building blocks into the main entry', () => {
+    // The internal surface is reachable ONLY via `cdk-local/internal`; the
+    // main entry must not re-export it (otherwise those symbols would be
+    // frozen into the semver-covered public API). If someone re-adds an
+    // `export * from './internal.js'` to the main entry, this breaks loudly.
+    const leaked = Object.keys(internal).filter((key) => key in main);
+    expect(leaked, `internal symbols leaked into the main entry: ${leaked.join(', ')}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of #150 (phase 1 was PR #153, which added the `cdk-local/internal`
subpath). This removes the `export * from './internal.js'` re-export from the
main `src/index.ts`, so the low-level local-execution building blocks are now
reachable **only** via `cdk-local/internal` and are no longer part of the
semver-covered public API.

- Main entry drops from 119 exports to **27** (public-only: command factories,
  `listTargets`/`countTargets`, the `--from-cfn-stack` state-source helpers,
  embed-config, public types).
- The ~93 internal building blocks (route discovery, intrinsic resolution, the
  API-Gateway event/response builders, `cognito-jwt` / `sigv4-verify` /
  `lambda-authorizer` primitives, `docker-image-builder`, the file-watcher, …)
  stay behind `cdk-local/internal` (unchanged).
- The export-surface test is **inverted** to lock the new invariant: internal
  symbols must NOT leak into the main entry — re-adding an
  `export * from './internal.js'` breaks it loudly.
- Docs (`docs/library-mode.md`, `.claude/CLAUDE.md`) updated to drop the
  back-compat re-export note.

**Breaking, but safe to land now.** This is a `feat(exports)!` (minor bump per
`.releaserc.json`'s `breaking -> minor` rule — no 1.0.0 jump). cdk-local is
pre-launch; the only known consumer (cdkd) pins `cdk-local@0.34.0` and is
insulated by that version pin — it does not break until it bumps, at which point
it migrates its internal imports to `cdk-local/internal` (tracked in #150).

## Test plan

- [x] `vp run check` + `vp run build` green
- [x] `vp test run` — 100 files / 1460 tests (incl. the inverted
      `export-surface.test.ts`)
- [x] Runtime smoke: `dist/index.js` exposes 27 symbols, `dist/internal.js` 93,
      **0** internal symbols leak into main; `dist/cli.js --help` lists all 7
      commands; public `createLocalStartAlbCommand` present, `pickRefLogicalId`
      gone from main / still on `cdk-local/internal`
- [x] `/run-integ local-invoke` — 5/5 passed, 0 docker orphans
- [x] Inline review (4 files, +15/-22): clean removal + correctly inverted test
      + matching doc updates

## Accepted nit (inherited from PR #153 review)

The export-surface test asserts via `Object.keys()`, which enumerates only
runtime value exports. Moot here: with the `export *` re-export removed, the
main entry has no path to leak internal symbols (value or type), so value-key
coverage fully proves the invariant. Only revisit if the main entry ever gains
an explicit named re-export of the internal surface.
