### PR TITLE
feat(invoke-agentcore): support fromS3 CodeConfiguration bundles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,9 +40,10 @@ AWS managed services.
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
-  (`fromCodeAsset` — Python 3.10-3.14 / Node 22, built from source: a generated
-  Dockerfile installs the bundle's deps and runs the EntryPoint, which
-  self-serves the contract) on the HTTP and MCP protocols. HTTP runs the
+  (`fromCodeAsset` AND `fromS3` — Python 3.10-3.14 / Node 22, built from source:
+  a generated Dockerfile installs the bundle's deps and runs the EntryPoint,
+  which self-serves the contract; a `fromS3` bundle's ZIP is downloaded from S3
+  and extracted first) on the HTTP and MCP protocols. HTTP runs the
   `POST /invocations` + `GET /ping` contract on 8080: an inbound
   `customJwtAuthorizer` is enforced locally (`--bearer-token` verified against
   the runtime's OIDC discovery URL before the container starts and forwarded to
@@ -105,7 +106,9 @@ Gateway).
   agentcore-resolver (`AWS::BedrockAgentCore::Runtime` target resolution +
   container-URI extraction) + agentcore-client (the `/ping` + `/invocations`
   HTTP-contract client for `cdkl invoke-agentcore`) + agentcore-ws-client (the
-  bidirectional `/ws` WebSocket client for `--ws`), embed-config
+  bidirectional `/ws` WebSocket client for `--ws`) + agentcore-s3-bundle
+  (downloads + extracts a fromS3 CodeConfiguration bundle for the from-source
+  build), embed-config
   (embed-time branding overrides for host CLIs), ssm-parameter-resolver
   (resolves `AWS::SSM::Parameter::Value` template parameters via SSM under
   `--from-cfn-stack`), elb-front-door-resolver (resolves an ALB ->

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cdkl list                                      # every runnable target, grouped 
 
 - **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`. Add **`--watch`** to re-synth and hot-reload on CDK source changes ([details](docs/local-emulation.md#hot-reload---watch)).
 - **`run-task`** / single-replica **`start-service`** publish declared container ports on the host and log `Reach it at 127.0.0.1:<port>` (`--host-port <container>=<host>` remaps; handy for privileged ports on macOS).
-- **`invoke-agentcore`** runs the agent (a container, or a `fromCodeAsset` managed-runtime bundle — Python 3.10-3.14 / Node 22 — built from source), waits for `GET /ping`, POSTs your `--event` to `POST /invocations`, and streams an SSE response live. `--ws` streams over the agent's bidirectional `/ws` WebSocket endpoint instead. A `customJwtAuthorizer` is enforced locally — pass `--bearer-token <jwt>` (verified against the runtime's OIDC discovery URL). MCP-protocol runtimes (`ProtocolConfiguration = MCP`) are also served — the `POST /mcp` Streamable-HTTP contract on 8000, with one JSON-RPC request (`tools/list` by default, or `--event`'s `{"method":...,"params":...}`).
+- **`invoke-agentcore`** runs the agent (a container, or a `fromCodeAsset` / `fromS3` managed-runtime bundle — Python 3.10-3.14 / Node 22 — built from source), waits for `GET /ping`, POSTs your `--event` to `POST /invocations`, and streams an SSE response live. `--ws` streams over the agent's bidirectional `/ws` WebSocket endpoint instead. A `customJwtAuthorizer` is enforced locally — pass `--bearer-token <jwt>` (verified against the runtime's OIDC discovery URL). MCP-protocol runtimes (`ProtocolConfiguration = MCP`) are also served — the `POST /mcp` Streamable-HTTP contract on 8000, with one JSON-RPC request (`tools/list` by default, or `--event`'s `{"method":...,"params":...}`).
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
 Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.md](docs/cli-reference.md) and [docs/local-emulation.md](docs/local-emulation.md).
@@ -105,7 +105,7 @@ Format + full precedence: [docs/cli-reference.md](docs/cli-reference.md).
 | `AWS::ECS::Service` (start-service) | ✓ |
 | `AWS::ServiceDiscovery::*` (Cloud Map / Service Connect) | ✓ |
 | `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door; `path-pattern` + `host-header` rules, weighted forward, redirect / fixed-response; ECS + Lambda targets) | ✓ |
-| `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container + fromCodeAsset artifacts, HTTP + MCP) | ✓ |
+| `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container + fromCodeAsset/fromS3 artifacts, HTTP + MCP) | ✓ |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,7 +13,7 @@ cdk-local has six subcommands, all under the `cdkl` binary:
 | --- | --- | --- |
 | `cdkl list` (alias `cdkl ls`) | Lists the app's runnable targets (no execution) | Synthesis only — no Docker |
 | `cdkl invoke <target>` | One-shot Lambda invoke | AWS Lambda Runtime Interface Emulator (RIE) container |
-| `cdkl invoke-agentcore <target>` | One-shot Bedrock AgentCore Runtime invoke | Agent (container or fromCodeAsset managed-runtime) on its protocol contract — HTTP (`POST /invocations` + `GET /ping` on 8080) or MCP (`POST /mcp` on 8000) |
+| `cdkl invoke-agentcore <target>` | One-shot Bedrock AgentCore Runtime invoke | Agent (container or fromCodeAsset / fromS3 managed-runtime) on its protocol contract — HTTP (`POST /invocations` + `GET /ping` on 8080) or MCP (`POST /mcp` on 8000) |
 | `cdkl start-api` | Long-running HTTP server — API Gateway (REST v1 / HTTP API / WebSocket) + Lambda Function URL | RIE container pool + `node:http` listener (one server per discovered API) |
 | `cdkl run-task <target>` | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
 | `cdkl start-service <targets...>` | Long-running ECS `Service` emulator (replicas only, no load balancer) | `run-task` machinery per replica + shared docker network + restart-on-exit watcher |
@@ -430,9 +430,9 @@ container down. The exact contract depends on `ProtocolConfiguration`:
 This is the same request/response loop AgentCore runs in the cloud,
 exercised locally before deploy. It supports the **container artifact**
 (`AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`) and the
-**CodeConfiguration** managed-runtime artifact (`fromCodeAsset`, built from
-source — see [CodeConfiguration](#codeconfiguration-managed-runtime) below)
-on the **HTTP** and **MCP** protocols; the `A2A` / `AGUI` protocols are
+**CodeConfiguration** managed-runtime artifact (`fromCodeAsset` AND `fromS3`,
+built from source — see [CodeConfiguration](#codeconfiguration-managed-runtime)
+below) on the **HTTP** and **MCP** protocols; the `A2A` / `AGUI` protocols are
 rejected with an actionable error. The agent's own calls to AWS managed
 services (Bedrock models, memory, etc.) go to real AWS — credentials are
 injected exactly like `cdkl invoke` (see below).
@@ -448,17 +448,27 @@ A `CodeConfiguration` artifact ships source + an `EntryPoint` + a `Runtime`
 instead of a container — AWS runs it on a managed runtime whose entrypoint
 self-serves the same HTTP (or MCP) contract (typically via the
 `bedrock-agentcore` SDK). cdk-local replicates that with a **local from-source
-build**: it reads the `fromCodeAsset` bundle from `cdk.out`, generates a
-Dockerfile for the runtime's base image (`PYTHON_3_10`-`PYTHON_3_14` →
-`python:3.x-slim`, `NODE_22` → `node:22-slim`), installs the bundle's
-dependencies (`requirements.txt` / `pyproject.toml` for Python,
-`package.json` for Node — when present), runs the `EntryPoint`, then drives
-the started container with the same protocol client as a container artifact.
+build**: it gets the bundle source, generates a Dockerfile for the runtime's
+base image (`PYTHON_3_10`-`PYTHON_3_14` → `python:3.x-slim`, `NODE_22` →
+`node:22-slim`), installs the bundle's dependencies (`requirements.txt` /
+`pyproject.toml` for Python, `package.json` for Node — when present), runs the
+`EntryPoint`, then drives the started container with the same protocol client
+as a container artifact.
 
-Only `fromCodeAsset` (a CDK-managed local code asset) is supported; a
-`fromS3` bundle (a pre-existing S3 object that would need an AWS download) is
-rejected with an actionable error. `--no-build` reuses the previously-built
-image tag.
+Both bundle shapes are supported:
+
+- **`fromCodeAsset`** (a CDK-managed local code asset) — read straight from
+  `cdk.out`.
+- **`fromS3`** (a pre-existing S3 object) — the bundle ZIP is downloaded from
+  `Code.S3` and extracted to a temp dir, then built the same way. The download
+  uses the resolved region (`--stack-region` / `--region` / env / the stack's
+  region) and credentials (`--assume-role` STS temp creds when set, else
+  `--profile` / the default chain). The S3 read needs credentials that can
+  `s3:GetObject` the bundle object. Only a literal `Code.S3.Bucket` is resolved
+  locally; a bucket that is an unresolved intrinsic (a `Ref` to a stack bucket)
+  is a follow-up.
+
+`--no-build` reuses the previously-built image tag.
 
 ### Target resolution
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@aws-sdk/client-eventbridge": "^3.1017.0",
     "@aws-sdk/client-kinesis": "^3.1018.0",
     "@aws-sdk/client-lambda": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.1053.0",
     "@aws-sdk/client-secrets-manager": "^3.1017.0",
     "@aws-sdk/client-sfn": "^3.1017.0",
     "@aws-sdk/client-sns": "^3.1017.0",
@@ -76,6 +77,7 @@
     "@clack/prompts": "^1.4.0",
     "chokidar": "^5.0.0",
     "commander": "^12.0.0",
+    "fflate": "^0.8.3",
     "graphlib": "^2.1.8",
     "ws": "^8.20.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@aws-sdk/client-lambda':
         specifier: ^3.0.0
         version: 3.1053.0
+      '@aws-sdk/client-s3':
+        specifier: ^3.1053.0
+        version: 3.1053.0
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.1017.0
         version: 3.1053.0
@@ -65,6 +68,9 @@ importers:
       constructs:
         specifier: ^10.0.0
         version: 10.6.0
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       graphlib:
         specifier: ^2.1.8
         version: 2.1.8
@@ -201,10 +207,10 @@ packages:
     engines: {node: '>=16.0.0'}
 
   '@aws-crypto/supports-web-crypto@5.2.0':
-    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==, tarball: https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz}
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
 
   '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==, tarball: https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz}
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
   '@aws-sdk/client-appsync@3.1053.0':
     resolution: {integrity: sha512-mplDzpa/R14rVYY1b7iuWQrCAFKukfCm1wJIYnAXuZXeSLRHCoyC5GxLZu6iLg1CmtU39mBQdOfSIR/PO/MxuQ==, tarball: https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.1053.0.tgz}
@@ -275,7 +281,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-s3@3.1053.0':
-    resolution: {integrity: sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg==, tarball: https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1053.0.tgz}
+    resolution: {integrity: sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-secrets-manager@3.1053.0':
@@ -307,7 +313,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.9':
-    resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==, tarball: https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz}
+    resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.36':
@@ -361,19 +367,19 @@ packages:
       '@aws-sdk/client-s3': ^3.1053.0
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.15':
-    resolution: {integrity: sha512-O2HDANa+MrvbxpaRVQDiH3T13uAa9AkMjKyZmDygwauAmmvqZ5B0iRmKW+fuVGW6NPXuyXurFgIx69lSvmAWGA==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.15.tgz}
+    resolution: {integrity: sha512-O2HDANa+MrvbxpaRVQDiH3T13uAa9AkMjKyZmDygwauAmmvqZ5B0iRmKW+fuVGW6NPXuyXurFgIx69lSvmAWGA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-expect-continue@3.972.13':
-    resolution: {integrity: sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.13.tgz}
+    resolution: {integrity: sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-flexible-checksums@3.974.21':
-    resolution: {integrity: sha512-alAu9heyiBK/OmRNXVxq8mmPTgeW2AQ6EYjRsI38kPZa1MZvt2Jh+BlGq7/GG9OVXOaEgD7DlGj/Lzfy5OmuEg==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.21.tgz}
+    resolution: {integrity: sha512-alAu9heyiBK/OmRNXVxq8mmPTgeW2AQ6EYjRsI38kPZa1MZvt2Jh+BlGq7/GG9OVXOaEgD7DlGj/Lzfy5OmuEg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-location-constraint@3.972.11':
-    resolution: {integrity: sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz}
+    resolution: {integrity: sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-ec2@3.972.27':
@@ -385,7 +391,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-s3@3.972.42':
-    resolution: {integrity: sha512-/xNqNGXv9LaxZd25L9VV4pnSOw9OdDNO4rAHamM+h3KQBSITljIH9vk3dveGga1I2j36lQd0rdG3gjNEXvtNew==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.42.tgz}
+    resolution: {integrity: sha512-/xNqNGXv9LaxZd25L9VV4pnSOw9OdDNO4rAHamM+h3KQBSITljIH9vk3dveGga1I2j36lQd0rdG3gjNEXvtNew==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-sqs@3.972.25':
@@ -393,7 +399,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-ssec@3.972.11':
-    resolution: {integrity: sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz}
+    resolution: {integrity: sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.11':
@@ -401,7 +407,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.28':
-    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==, tarball: https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz}
+    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1052.0':
@@ -413,7 +419,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
-    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==, tarball: https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz}
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.25':
@@ -1050,7 +1056,7 @@ packages:
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.24.4':
-    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==, tarball: https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz}
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.3.4':
@@ -1058,11 +1064,11 @@ packages:
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.4.4':
-    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==, tarball: https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz}
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==, tarball: https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz}
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
   '@smithy/middleware-endpoint@4.5.4':
@@ -1074,7 +1080,7 @@ packages:
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.7.4':
-    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==, tarball: https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz}
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.3.4':
@@ -1090,11 +1096,11 @@ packages:
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.2':
-    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==, tarball: https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz}
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==, tarball: https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz}
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
   '@smithy/util-retry@4.4.4':
@@ -1102,7 +1108,7 @@ packages:
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==, tarball: https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz}
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
   '@smithy/util-waiter@4.4.4':
@@ -1820,6 +1826,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==, tarball: https://registry.npmjs.org/figures/-/figures-2.0.0.tgz}
@@ -2941,7 +2950,7 @@ packages:
         optional: true
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==, tarball: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz}
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==, tarball: https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz}
@@ -5104,6 +5113,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   figures@2.0.0:
     dependencies:

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -38,6 +38,7 @@ import {
   type ResolvedAgentCoreRuntime,
 } from '../../local/agentcore-resolver.js';
 import { buildAgentCoreCodeImage } from '../../local/agentcore-code-build.js';
+import { downloadAndExtractS3Bundle } from '../../local/agentcore-s3-bundle.js';
 import {
   invokeAgentCore,
   waitForAgentCorePing,
@@ -314,7 +315,7 @@ async function localInvokeAgentCoreCommand(
       authorization = await resolveInboundAuthorization(resolved, options);
     }
 
-    const image = await resolveAgentCoreImage(resolved, options);
+    const image = await resolveAgentCoreImage(resolved, options, loadedState);
 
     const { env: dockerEnv, sensitiveEnvKeys } = await buildContainerEnv(
       resolved,
@@ -467,19 +468,31 @@ export async function resolveInboundAuthorization(
 
 /**
  * Acquire the agent image. A CODE artifact (managed runtime) is built from
- * source (generated Dockerfile over the bundle's cdk.out asset). A CONTAINER
- * artifact mirrors the container-Lambda path: build from a local cdk.out asset
- * when the URI matches one, else pull from ECR, else pull a plain registry image.
+ * source — a fromCodeAsset bundle from its cdk.out asset, a fromS3 bundle
+ * downloaded + extracted from S3. A CONTAINER artifact mirrors the
+ * container-Lambda path: build from a local cdk.out asset when the URI matches
+ * one, else pull from ECR, else pull a plain registry image.
+ *
+ * `loaded` is the `--from-cfn-stack` state record (when available) — threaded
+ * through so a bare `--assume-role` can resolve the execution-role ARN from
+ * state for the fromS3 download.
  */
 export async function resolveAgentCoreImage(
   resolved: ResolvedAgentCoreRuntime,
-  options: LocalInvokeAgentCoreOptions
+  options: LocalInvokeAgentCoreOptions,
+  loaded?: LocalStateRecord
 ): Promise<string> {
   const logger = getLogger();
   const architecture = platformToArchitecture(options.platform);
 
   if (resolved.codeArtifact) {
-    return resolveAgentCoreCodeImage(resolved, resolved.codeArtifact, options, architecture);
+    return resolveAgentCoreCodeImage(
+      resolved,
+      resolved.codeArtifact,
+      options,
+      architecture,
+      loaded
+    );
   }
 
   const containerUri = resolved.containerUri;
@@ -521,17 +534,32 @@ export async function resolveAgentCoreImage(
 }
 
 /**
- * Build a local image from a `CodeConfiguration` (managed-runtime) bundle:
- * locate the fromCodeAsset source dir in cdk.out via its asset hash, then run
- * the from-source build (generated Dockerfile → install deps → run EntryPoint).
- * A bundle with no local asset (fromS3) hard-errors — not supported yet.
+ * Build a local image from a `CodeConfiguration` (managed-runtime) bundle.
+ *
+ * - fromS3 (`code.s3Source` set, a literal S3 object): download + extract the
+ *   bundle, then run the from-source build over the extracted dir.
+ * - fromCodeAsset: locate the source dir in cdk.out via its asset hash, then
+ *   run the same from-source build (generated Dockerfile → install deps → run
+ *   EntryPoint).
  */
 async function resolveAgentCoreCodeImage(
   resolved: ResolvedAgentCoreRuntime,
   code: AgentCoreCodeArtifact,
   options: LocalInvokeAgentCoreOptions,
-  architecture: 'x86_64' | 'arm64'
+  architecture: 'x86_64' | 'arm64',
+  loaded?: LocalStateRecord
 ): Promise<string> {
+  if (code.s3Source) {
+    return resolveAgentCoreCodeImageFromS3(
+      resolved,
+      code,
+      code.s3Source,
+      options,
+      architecture,
+      loaded
+    );
+  }
+
   const manifestPath = resolved.stack.assetManifestPath;
   if (!manifestPath) {
     throw new CdkLocalError(
@@ -556,7 +584,8 @@ async function resolveAgentCoreCodeImage(
     throw new CdkLocalError(
       `AgentCore Runtime '${resolved.logicalId}' code bundle (asset ${code.codeAssetHash}) was not found ` +
         `in the cdk.out asset manifest. ${getEmbedConfig().cliName} invoke-agentcore runs a local from-source ` +
-        `build of a fromCodeAsset bundle; a fromS3 bundle (a pre-existing S3 object) is not supported yet.`,
+        `build of a fromCodeAsset bundle — re-synthesize the app so the asset is staged in cdk.out and retry. ` +
+        `(A fromS3 bundle is downloaded from S3 instead; this runtime has no literal Code.S3.Bucket.)`,
       'LOCAL_INVOKE_AGENTCORE_CODE_ASSET_NOT_FOUND'
     );
   }
@@ -575,6 +604,66 @@ async function resolveAgentCoreCodeImage(
     architecture,
     noBuild: options.build === false,
   });
+}
+
+/**
+ * Build a local image from a fromS3 CodeConfiguration bundle: download +
+ * extract the S3 object, run the from-source build over the extracted dir, then
+ * clean up the temp dir.
+ *
+ * Credentials mirror the rest of the command: an `--assume-role` ARN (explicit,
+ * or resolved from `--from-cfn-stack` state for the bare form) yields STS temp
+ * creds for the download; otherwise `--profile` / the default chain is used.
+ * The region is `--region` / `--stack-region` / env / the stack's region.
+ */
+async function resolveAgentCoreCodeImageFromS3(
+  resolved: ResolvedAgentCoreRuntime,
+  code: AgentCoreCodeArtifact,
+  s3Source: NonNullable<AgentCoreCodeArtifact['s3Source']>,
+  options: LocalInvokeAgentCoreOptions,
+  architecture: 'x86_64' | 'arm64',
+  loaded: LocalStateRecord | undefined
+): Promise<string> {
+  const logger = getLogger();
+  const region =
+    options.region ??
+    options.stackRegion ??
+    process.env['AWS_REGION'] ??
+    process.env['AWS_DEFAULT_REGION'] ??
+    resolved.stack.region;
+
+  const assumeRoleArn = resolveAssumeRoleArn(options, resolved, loaded);
+  let credentials:
+    | { accessKeyId: string; secretAccessKey: string; sessionToken: string }
+    | undefined;
+  if (assumeRoleArn) {
+    try {
+      credentials = await assumeAgentCoreExecutionRole(assumeRoleArn, region);
+    } catch (err) {
+      logger.warn(
+        `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for the fromS3 bundle download: ` +
+          `${err instanceof Error ? err.message : String(err)}. ` +
+          `Falling back to ${options.profile ? `--profile ${options.profile}` : 'the default credentials'}.`
+      );
+    }
+  }
+
+  const bundle = await downloadAndExtractS3Bundle(s3Source, {
+    ...(region !== undefined && { region }),
+    ...(options.profile !== undefined && { profile: options.profile }),
+    ...(credentials !== undefined && { credentials }),
+  });
+  try {
+    return await buildAgentCoreCodeImage({
+      sourceDir: bundle.dir,
+      runtime: code.runtime,
+      entryPoint: code.entryPoint,
+      architecture,
+      noBuild: options.build === false,
+    });
+  } finally {
+    await bundle.cleanup();
+  }
 }
 
 /**

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -334,6 +334,13 @@ export {
   type InvokeAgentCoreWsOptions,
   type AgentCoreWsResult,
 } from './local/agentcore-ws-client.js';
+export {
+  downloadAndExtractS3Bundle,
+  type S3BundleLocation,
+  type S3BundleCredentials,
+  type DownloadS3BundleOptions,
+  type ExtractedS3Bundle,
+} from './local/agentcore-s3-bundle.js';
 
 /**
  * `start-api` REST API v1 `IntegrationResponses[]` selection — picks the

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -36,10 +36,10 @@ const SUPPORTED_AGENTCORE_PROTOCOLS = [AGENTCORE_HTTP_PROTOCOL, AGENTCORE_MCP_PR
  * Result of resolving a `cdkl invoke-agentcore <target>` argument back to a
  * concrete `AWS::BedrockAgentCore::Runtime` in the synthesized assembly.
  *
- * Covers the CONTAINER artifact and the `CodeConfiguration` (fromCodeAsset)
- * managed-runtime artifact on the HTTP + MCP protocols — the resolver
- * hard-errors on a fromS3 code bundle (a non-literal `Code.S3.Prefix`) and the
- * A2A / AGUI protocols so the command never starts something it can't run.
+ * Covers the CONTAINER artifact and the `CodeConfiguration` managed-runtime
+ * artifact (fromCodeAsset AND fromS3) on the HTTP + MCP protocols — the
+ * resolver hard-errors on a non-literal `Code.S3.Prefix` and the A2A / AGUI
+ * protocols so the command never starts something it can't run.
  */
 export interface ResolvedAgentCoreRuntime {
   /** Stack the runtime belongs to. */
@@ -108,13 +108,22 @@ export interface AgentCoreJwtAuthorizer {
 /**
  * A resolved `AgentRuntimeArtifact.CodeConfiguration` (managed-runtime).
  * `codeAssetHash` is the cdk.out file-asset hash (from `Code.S3.Prefix`,
- * `<hash>.zip`) the command looks up to find the bundle's local source dir;
- * `entryPoint` is the `EntryPoint` argv and `runtime` the `Runtime` enum.
+ * `<hash>.zip`) the command looks up to find the bundle's local source dir
+ * (the `fromCodeAsset` shape); `entryPoint` is the `EntryPoint` argv and
+ * `runtime` the `Runtime` enum.
+ *
+ * `s3Source` is set for the `fromS3` shape — a bundle whose `Code.S3.Bucket`
+ * is a literal string (a pre-existing S3 object, NOT the CDK staging bucket,
+ * which renders as an `Fn::Sub` intrinsic for `fromCodeAsset`). The command
+ * downloads + extracts it and runs the same from-source build. Undefined when
+ * the bucket is an intrinsic (the fromCodeAsset case, or a fromS3 bundle whose
+ * bucket is a `Ref` — not resolvable locally yet).
  */
 export interface AgentCoreCodeArtifact {
   runtime: string;
   entryPoint: string[];
   codeAssetHash: string;
+  s3Source?: { bucket: string; key: string; versionId?: string };
 }
 
 export class AgentCoreResolutionError extends Error {
@@ -430,11 +439,13 @@ function extractArtifact(
 
 /**
  * Extract a `CodeConfiguration` (managed-runtime) artifact. Reads `Runtime`,
- * `EntryPoint`, and the cdk.out file-asset hash from `Code.S3.Prefix`
- * (`<hash>.zip`, the `fromCodeAsset` shape). A non-literal `Code.S3.Prefix`
- * (an intrinsic, or a `fromS3` object key the command can't map to a local
- * asset) hard-errors — downloading a pre-existing S3 bundle is not supported
- * locally yet.
+ * `EntryPoint`, and the `Code.S3` location. `Code.S3.Prefix` must be a literal
+ * string (the object key) — it doubles as the cdk.out file-asset hash for the
+ * `fromCodeAsset` shape (`<hash>.zip`). When `Code.S3.Bucket` is ALSO a literal
+ * string, this is a `fromS3` bundle (a pre-existing S3 object — the CDK staging
+ * bucket of a fromCodeAsset renders as an `Fn::Sub` intrinsic, not a literal),
+ * captured in `s3Source` so the command downloads + extracts it. A non-literal
+ * `Code.S3.Prefix` (an unresolved intrinsic) hard-errors.
  */
 function extractCodeArtifact(
   codeConfig: unknown,
@@ -467,20 +478,36 @@ function extractCodeArtifact(
     cfg['Code'] && typeof cfg['Code'] === 'object'
       ? (cfg['Code'] as Record<string, unknown>)['S3']
       : undefined;
-  const prefix =
-    s3 && typeof s3 === 'object' ? (s3 as Record<string, unknown>)['Prefix'] : undefined;
+  const s3Obj =
+    s3 && typeof s3 === 'object' && !Array.isArray(s3) ? (s3 as Record<string, unknown>) : {};
+  const prefix = s3Obj['Prefix'];
   if (typeof prefix !== 'string' || prefix.length === 0) {
     throw new AgentCoreResolutionError(
       `AgentCore Runtime '${logicalId}' in ${stackName} has a CodeConfiguration whose Code.S3.Prefix is not a literal string. ` +
-        `${getEmbedConfig().cliName} invoke-agentcore runs a local from-source build of the fromCodeAsset bundle; ` +
-        `downloading a pre-existing S3 bundle (fromS3) is not supported yet.`
+        `${getEmbedConfig().cliName} invoke-agentcore needs a literal object key — re-synthesize a fromCodeAsset bundle, ` +
+        `or pass a literal bucket + key for a fromS3 bundle.`
     );
   }
 
   // Prefix is `<assetHash>.zip` (possibly with a key prefix) → the cdk.out
-  // file-asset hash the command looks up to find the bundle source dir.
+  // file-asset hash the command looks up to find a fromCodeAsset bundle source.
   const codeAssetHash = prefix.replace(/^.*\//, '').replace(/\.zip$/, '');
-  return { runtime, entryPoint, codeAssetHash };
+
+  // A literal Bucket means a fromS3 bundle (a pre-existing object). The CDK
+  // staging bucket of a fromCodeAsset renders as an `Fn::Sub` intrinsic, so it
+  // is not a literal string and `s3Source` stays undefined for that case.
+  const bucket = s3Obj['Bucket'];
+  const versionId = s3Obj['VersionId'];
+  const s3Source =
+    typeof bucket === 'string' && bucket.length > 0
+      ? {
+          bucket,
+          key: prefix,
+          ...(typeof versionId === 'string' && versionId.length > 0 && { versionId }),
+        }
+      : undefined;
+
+  return { runtime, entryPoint, codeAssetHash, ...(s3Source && { s3Source }) };
 }
 
 /**

--- a/src/local/agentcore-s3-bundle.ts
+++ b/src/local/agentcore-s3-bundle.ts
@@ -1,0 +1,162 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, normalize, sep } from 'node:path';
+import { unzipSync } from 'fflate';
+import { CdkLocalError } from '../utils/error-handler.js';
+import { getLogger } from '../utils/logger.js';
+import { getEmbedConfig } from './embed-config.js';
+
+/**
+ * Download + extract a `fromS3` AgentCore CodeConfiguration bundle.
+ *
+ * A `fromS3` runtime points `AgentRuntimeArtifact.CodeConfiguration.Code.S3` at
+ * a pre-existing S3 object (a ZIP of the agent source). `cdkl invoke-agentcore`
+ * fetches it with the resolved credentials, extracts it to a temp dir, and runs
+ * the SAME from-source build the `fromCodeAsset` path uses
+ * ({@link buildAgentCoreCodeImage}) — so the only new surface here is the
+ * download + unzip; the build + run + protocol-client path is unchanged.
+ */
+
+/** Literal S3 object location of a fromS3 code bundle. */
+export interface S3BundleLocation {
+  bucket: string;
+  key: string;
+  versionId?: string;
+}
+
+/** Static / STS-issued credentials for the S3 download. */
+export interface S3BundleCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+export interface DownloadS3BundleOptions {
+  /** Region for the S3 client (resolved from `--stack-region` / `--region` / env). */
+  region?: string;
+  /** `--profile` to authenticate the download (ignored when `credentials` is set). */
+  profile?: string;
+  /** Explicit credentials (e.g. STS temp creds from `--assume-role`); win over `profile`. */
+  credentials?: S3BundleCredentials;
+  /** Injected object fetcher for tests — bypasses the AWS SDK entirely. */
+  fetchObject?: (location: S3BundleLocation) => Promise<Uint8Array>;
+}
+
+export interface ExtractedS3Bundle {
+  /** Temp dir the bundle was extracted into (feed to the from-source build). */
+  dir: string;
+  /** Remove the temp dir (best-effort). */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Download the bundle object, unzip it to a fresh temp dir, and return the dir
+ * (plus a `cleanup`). The caller feeds `dir` to {@link buildAgentCoreCodeImage}
+ * and calls `cleanup()` once the build is done.
+ */
+export async function downloadAndExtractS3Bundle(
+  location: S3BundleLocation,
+  options: DownloadS3BundleOptions = {}
+): Promise<ExtractedS3Bundle> {
+  const ref = formatRef(location);
+  getLogger().info(`Downloading fromS3 code bundle ${ref}...`);
+
+  const bytes = await (options.fetchObject ?? defaultFetchObject(options))(location);
+
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(bytes);
+  } catch (err) {
+    throw new CdkLocalError(
+      `Failed to unzip the fromS3 code bundle ${ref}: ${err instanceof Error ? err.message : String(err)}. ` +
+        `The object must be a ZIP archive of the agent source.`,
+      'LOCAL_INVOKE_AGENTCORE_S3_BUNDLE_UNZIP_FAILED'
+    );
+  }
+
+  const dir = await mkdtemp(join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-agentcore-s3-`));
+  try {
+    let wrote = 0;
+    for (const [name, content] of Object.entries(files)) {
+      if (name.endsWith('/')) continue; // directory entry — no file content
+      const dest = resolveSafeEntryPath(dir, name);
+      await mkdir(dirname(dest), { recursive: true });
+      await writeFile(dest, content);
+      wrote += 1;
+    }
+    if (wrote === 0) {
+      throw new CdkLocalError(
+        `The fromS3 code bundle ${ref} contained no files.`,
+        'LOCAL_INVOKE_AGENTCORE_S3_BUNDLE_EMPTY'
+      );
+    }
+  } catch (err) {
+    await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    throw err;
+  }
+
+  return {
+    dir,
+    cleanup: () => rm(dir, { recursive: true, force: true }).then(() => undefined),
+  };
+}
+
+function formatRef(location: S3BundleLocation): string {
+  const version = location.versionId ? `?versionId=${location.versionId}` : '';
+  return `s3://${location.bucket}/${location.key}${version}`;
+}
+
+/**
+ * Guard against zip-slip: reject an entry whose normalized path escapes the
+ * extraction root (e.g. `../../etc/passwd`).
+ */
+function resolveSafeEntryPath(root: string, entry: string): string {
+  const dest = normalize(join(root, entry));
+  const rootWithSep = root.endsWith(sep) ? root : root + sep;
+  if (dest !== root && !dest.startsWith(rootWithSep)) {
+    throw new CdkLocalError(
+      `Refusing to extract a fromS3 bundle entry that escapes the target dir: '${entry}'.`,
+      'LOCAL_INVOKE_AGENTCORE_S3_BUNDLE_ZIP_SLIP'
+    );
+  }
+  return dest;
+}
+
+function defaultFetchObject(
+  options: DownloadS3BundleOptions
+): (location: S3BundleLocation) => Promise<Uint8Array> {
+  return async (location) => {
+    const { S3Client, GetObjectCommand } = await import('@aws-sdk/client-s3');
+    const client = new S3Client({
+      ...(options.region && { region: options.region }),
+      ...(options.profile && !options.credentials && { profile: options.profile }),
+      ...(options.credentials && {
+        credentials: {
+          accessKeyId: options.credentials.accessKeyId,
+          secretAccessKey: options.credentials.secretAccessKey,
+          ...(options.credentials.sessionToken && {
+            sessionToken: options.credentials.sessionToken,
+          }),
+        },
+      }),
+    });
+    try {
+      const res = await client.send(
+        new GetObjectCommand({
+          Bucket: location.bucket,
+          Key: location.key,
+          ...(location.versionId && { VersionId: location.versionId }),
+        })
+      );
+      if (!res.Body) {
+        throw new CdkLocalError(
+          `S3 GetObject for ${formatRef(location)} returned an empty body.`,
+          'LOCAL_INVOKE_AGENTCORE_S3_BUNDLE_EMPTY_BODY'
+        );
+      }
+      return await res.Body.transformToByteArray();
+    } finally {
+      client.destroy();
+    }
+  };
+}

--- a/tests/integration/local-invoke-agentcore-froms3/.gitignore
+++ b/tests/integration/local-invoke-agentcore-froms3/.gitignore
@@ -1,0 +1,6 @@
+# The integ runner installs deps fresh via `vp install`, so the lockfile
+# is a build artifact, not a committed source (matches the sibling fixtures).
+pnpm-lock.yaml
+
+# Local build scratch for the zipped bundle verify.sh uploads to S3.
+bundle.zip

--- a/tests/integration/local-invoke-agentcore-froms3/.scenarios.json
+++ b/tests/integration/local-invoke-agentcore-froms3/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "agentcore-froms3-download-build-invoke"
+  ]
+}

--- a/tests/integration/local-invoke-agentcore-froms3/bin/app.ts
+++ b/tests/integration/local-invoke-agentcore-froms3/bin/app.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalInvokeAgentCoreFromS3Stack } from '../lib/local-invoke-agentcore-froms3-stack.ts';
+
+const app = new cdk.App();
+
+// The bundle's S3 location is injected at synth time (`-c bundleBucket=... -c
+// bundleKey=...`) by verify.sh, which creates the bucket + uploads the zipped
+// code-agent first. fromS3 needs a literal bucket + key in the template, which
+// is exactly what these literal context values produce.
+const bundleBucket = app.node.tryGetContext('bundleBucket');
+const bundleKey = app.node.tryGetContext('bundleKey');
+if (typeof bundleBucket !== 'string' || typeof bundleKey !== 'string') {
+  throw new Error(
+    'Pass -c bundleBucket=<name> -c bundleKey=<key> (the uploaded fromS3 bundle location).'
+  );
+}
+
+new LocalInvokeAgentCoreFromS3Stack(app, 'CdkLocalInvokeAgentCoreFromS3Fixture', {
+  description: 'Fixture stack for cdkl invoke-agentcore fromS3 integ test',
+  bundleBucket,
+  bundleKey,
+});

--- a/tests/integration/local-invoke-agentcore-froms3/cdk.json
+++ b/tests/integration/local-invoke-agentcore-froms3/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-invoke-agentcore-froms3/code-agent/app.py
+++ b/tests/integration/local-invoke-agentcore-froms3/code-agent/app.py
@@ -1,0 +1,54 @@
+# Minimal Bedrock AgentCore Runtime CodeConfiguration (managed-runtime) agent
+# for the cdkl invoke-agentcore fromS3 integ test. Authored as plain source
+# (no Dockerfile) and shipped as a ZIP uploaded to S3 (the fromS3 shape): cdkl
+# downloads + extracts the bundle, builds it from source for the declared
+# runtime (installs requirements.txt), and runs this entrypoint, which
+# self-serves the AgentCore HTTP contract on 0.0.0.0:8080:
+#   GET  /ping        -> 200 {"status":"Healthy"}
+#   POST /invocations -> echoes the request body + the injected GREETING env var
+# Uses only the Python stdlib. Startup logs go to stderr so the host's stdout
+# carries only the cdkl result line.
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+GREETING = os.environ.get("GREETING", "unset")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # silence default stderr access logs
+        pass
+
+    def _json(self, status, payload):
+        # Compact separators (no spaces) so the response matches verify.sh's
+        # no-space grep assertions, like the Node fixtures' JSON.stringify output.
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path == "/ping":
+            self._json(200, {"status": "Healthy"})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/invocations":
+            self._json(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("content-length", 0) or 0)
+        body = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            echoed = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            echoed = body
+        self._json(200, {"echoed": echoed, "greeting": GREETING, "runtime": "python-froms3"})
+
+
+if __name__ == "__main__":
+    print("python fromS3 code agent listening on 0.0.0.0:8080", file=sys.stderr, flush=True)
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()

--- a/tests/integration/local-invoke-agentcore-froms3/code-agent/requirements.txt
+++ b/tests/integration/local-invoke-agentcore-froms3/code-agent/requirements.txt
@@ -1,0 +1,2 @@
+# No third-party dependencies — this agent uses only the Python stdlib.
+# Kept so `cdkl invoke-agentcore` exercises the from-source pip-install build step.

--- a/tests/integration/local-invoke-agentcore-froms3/lib/local-invoke-agentcore-froms3-stack.ts
+++ b/tests/integration/local-invoke-agentcore-froms3/lib/local-invoke-agentcore-froms3-stack.ts
@@ -1,0 +1,43 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import {
+  Runtime,
+  AgentRuntimeArtifact,
+  AgentCoreRuntime,
+} from 'aws-cdk-lib/aws-bedrockagentcore';
+
+export interface LocalInvokeAgentCoreFromS3StackProps extends cdk.StackProps {
+  /** Literal S3 bucket holding the uploaded fromS3 code bundle. */
+  readonly bundleBucket: string;
+  /** Literal S3 object key of the uploaded bundle ZIP. */
+  readonly bundleKey: string;
+}
+
+/**
+ * Fixture stack for the `cdkl invoke-agentcore` fromS3 integ test.
+ *
+ * Uses the stable L2 `Runtime` construct + `AgentRuntimeArtifact.fromS3` — the
+ * shape a real user authors for a pre-existing S3 bundle. The bucket + key are
+ * literal context values (verify.sh creates the bucket + uploads the zipped
+ * `code-agent/` first), so the synthesized template carries a literal
+ * `Code.S3.Bucket` / `Code.S3.Prefix` — the fromS3 shape cdk-local resolves.
+ *
+ * No CloudFormation deploy: `cdkl invoke-agentcore` downloads the bundle from
+ * S3, extracts it, runs the same from-source build the fromCodeAsset path uses
+ * (pip install + run the entrypoint), and the entrypoint self-serves the 8080
+ * HTTP contract.
+ */
+export class LocalInvokeAgentCoreFromS3Stack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: LocalInvokeAgentCoreFromS3StackProps) {
+    super(scope, id, props);
+
+    new Runtime(this, 'S3Agent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromS3(
+        { bucketName: props.bundleBucket, objectKey: props.bundleKey },
+        AgentCoreRuntime.PYTHON_3_12,
+        ['app.py']
+      ),
+      environmentVariables: { GREETING: 'hello-from-s3' },
+    });
+  }
+}

--- a/tests/integration/local-invoke-agentcore-froms3/package.json
+++ b/tests/integration/local-invoke-agentcore-froms3/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-invoke-agentcore-froms3",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl invoke-agentcore fromS3 CodeConfiguration bundles",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.257.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-invoke-agentcore-froms3/tsconfig.json
+++ b/tests/integration/local-invoke-agentcore-froms3/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-invoke-agentcore-froms3/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3/verify.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkl invoke-agentcore` fromS3
+# CodeConfiguration bundles (issue #144).
+#
+# A fromS3 runtime points `AgentRuntimeArtifact.CodeConfiguration.Code.S3` at a
+# pre-existing S3 object (a ZIP of the agent source). This test exercises the
+# new download + extract + from-source build path against real S3:
+#   - create a uniquely-named S3 bucket,
+#   - zip the local `code-agent/` source and upload it as the bundle object,
+#   - synth a stack whose `fromS3(...)` points at that literal bucket + key,
+#   - `cdkl invoke-agentcore` downloads + extracts the bundle, builds it from
+#     source (pip install + run the entrypoint), runs it on 8080, and POSTs the
+#     event to /invocations,
+#   - assert the response (runtime marker + injected GREETING + echoed event),
+#   - delete the object + bucket.
+#
+# No CloudFormation deploy — fromS3 only needs the S3 object to exist; the
+# template just references it. The agent itself runs locally in Docker.
+#
+# Run via `/run-integ local-invoke-agentcore-froms3` (recommended).
+# Requires Docker and AWS credentials with s3:CreateBucket / PutObject /
+# GetObject / DeleteObject / DeleteBucket on a fresh bucket.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalInvokeAgentCoreFromS3Fixture"
+TARGET="${STACK}/S3Agent"
+CODE_BASE_IMAGE="public.ecr.aws/docker/library/python:3.12-slim"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-agentcore-froms3"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+echo "[verify] region=${REGION} fromS3 bundle download + from-source build"
+
+echo "[verify] step 1a: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+
+echo "[verify] step 1b: verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "[verify] step 1c: pulling ${CODE_BASE_IMAGE} (one-time)"
+docker pull --platform linux/arm64 "${CODE_BASE_IMAGE}" >/dev/null
+
+echo "[verify] step 1d: installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+SUFFIX="$(date +%s)-${RANDOM}"
+BUCKET="cdkl-integ-froms3-${ACCOUNT_ID}-${REGION}-${SUFFIX}"
+KEY="bundles/agent-${SUFFIX}.zip"
+
+WE_CREATED_BUCKET=0
+EVENT_FILE=""
+cleanup() {
+  rc=$?
+  if [ "${WE_CREATED_BUCKET}" -eq 1 ]; then
+    echo "[verify] cleanup: removing s3://${BUCKET}"
+    aws s3 rm "s3://${BUCKET}" --recursive --region "${REGION}" >/dev/null 2>&1 || true
+    aws s3api delete-bucket --bucket "${BUCKET}" --region "${REGION}" >/dev/null 2>&1 || true
+  fi
+  rm -f "${TEST_DIR}/bundle.zip"
+  [ -n "${EVENT_FILE}" ] && rm -f "${EVENT_FILE}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] step 2: create bucket s3://${BUCKET}"
+WE_CREATED_BUCKET=1
+if [ "${REGION}" = "us-east-1" ]; then
+  aws s3api create-bucket --bucket "${BUCKET}" --region "${REGION}" >/dev/null
+else
+  aws s3api create-bucket --bucket "${BUCKET}" --region "${REGION}" \
+    --create-bucket-configuration "LocationConstraint=${REGION}" >/dev/null
+fi
+
+echo "[verify] step 3: zip code-agent/ and upload as the bundle object"
+rm -f "${TEST_DIR}/bundle.zip"
+(cd "${TEST_DIR}/code-agent" && zip -qr "${TEST_DIR}/bundle.zip" . -x '*.pyc' '__pycache__/*')
+aws s3 cp "${TEST_DIR}/bundle.zip" "s3://${BUCKET}/${KEY}" --region "${REGION}" >/dev/null
+echo "[verify]   uploaded s3://${BUCKET}/${KEY}"
+
+echo "[verify] step 4: cdkl invoke-agentcore (fromS3 download + build + run)"
+RESULT=$(${CLI} invoke-agentcore "${TARGET}" \
+  -c "bundleBucket=${BUCKET}" -c "bundleKey=${KEY}" 2>/dev/null | tail -1)
+echo "[verify]   response: ${RESULT}"
+echo "${RESULT}" | grep -q '"runtime":"python-froms3"' || {
+  echo "[verify] FAIL: expected the fromS3 from-source agent to respond, got: ${RESULT}"
+  exit 1
+}
+echo "${RESULT}" | grep -q '"greeting":"hello-from-s3"' || {
+  echo "[verify] FAIL: expected GREETING=hello-from-s3 (env injected), got: ${RESULT}"
+  exit 1
+}
+
+echo "[verify] step 5: --event payload echoes through the fromS3 agent"
+EVENT_FILE="$(mktemp)"
+echo '{"prompt":"hello froms3"}' > "${EVENT_FILE}"
+RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" \
+  -c "bundleBucket=${BUCKET}" -c "bundleKey=${KEY}" --event "${EVENT_FILE}" 2>/dev/null | tail -1)
+echo "[verify]   response: ${RESULT_EVENT}"
+echo "${RESULT_EVENT}" | grep -q '"prompt":"hello froms3"' || {
+  echo "[verify] FAIL: expected the echoed event from the fromS3 agent, got: ${RESULT_EVENT}"
+  exit 1
+}
+
+echo ""
+echo "[verify] All local-invoke-agentcore-froms3 checks passed"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -7,6 +7,7 @@ const {
   getDockerImageBySourceHashMock,
   buildContainerImageMock,
   buildAgentCoreCodeImageMock,
+  downloadAndExtractS3BundleMock,
   parseEcrUriMock,
   pullEcrImageMock,
   pullImageMock,
@@ -19,6 +20,7 @@ const {
   getDockerImageBySourceHashMock: vi.fn(),
   buildContainerImageMock: vi.fn(),
   buildAgentCoreCodeImageMock: vi.fn(),
+  downloadAndExtractS3BundleMock: vi.fn(),
   parseEcrUriMock: vi.fn(),
   pullEcrImageMock: vi.fn(),
   pullImageMock: vi.fn(),
@@ -65,6 +67,11 @@ vi.mock('../../../src/local/docker-image-builder.js', async (importActual) => ({
 vi.mock('../../../src/local/agentcore-code-build.js', async (importActual) => ({
   ...(await importActual<object>()),
   buildAgentCoreCodeImage: buildAgentCoreCodeImageMock,
+}));
+
+vi.mock('../../../src/local/agentcore-s3-bundle.js', async (importActual) => ({
+  ...(await importActual<object>()),
+  downloadAndExtractS3Bundle: downloadAndExtractS3BundleMock,
 }));
 
 vi.mock('../../../src/local/ecr-puller.js', async (importActual) => ({
@@ -220,10 +227,10 @@ describe('resolveAgentCoreImage — CodeConfiguration (from source)', () => {
     );
   });
 
-  it('errors (fromS3 not supported) when the code asset is not in the manifest', async () => {
+  it('errors (re-synthesize) when a fromCodeAsset bundle is not in the manifest', async () => {
     loadManifestMock.mockResolvedValue({ files: {} });
     getFileAssetsMock.mockReturnValue(new Map()); // no asset by hash or objectKey
-    await expect(resolveAgentCoreImage(codeRuntime(), imageOpts())).rejects.toThrow(/fromS3/);
+    await expect(resolveAgentCoreImage(codeRuntime(), imageOpts())).rejects.toThrow(/re-synthesize/);
     expect(buildAgentCoreCodeImageMock).not.toHaveBeenCalled();
   });
 
@@ -250,6 +257,74 @@ describe('resolveAgentCoreImage — CodeConfiguration (from source)', () => {
     await resolveAgentCoreImage(codeRuntime(), imageOpts({ build: false }));
     expect(buildAgentCoreCodeImageMock).toHaveBeenCalledWith(
       expect.objectContaining({ noBuild: true })
+    );
+  });
+});
+
+describe('resolveAgentCoreImage — CodeConfiguration fromS3 (download + build)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function s3CodeRuntime(): ResolvedAgentCoreRuntime {
+    return {
+      stack: { stackName: 'App', region: 'us-west-2' } as never,
+      logicalId: 'S3Agent',
+      resource: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      environmentVariables: {},
+      protocol: 'HTTP',
+      codeArtifact: {
+        runtime: 'PYTHON_3_12',
+        entryPoint: ['app.py'],
+        codeAssetHash: 'agent',
+        s3Source: { bucket: 'my-bundles', key: 'agents/agent.zip' },
+      },
+    };
+  }
+
+  it('downloads + extracts the fromS3 bundle, builds from the extracted dir, then cleans up', async () => {
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    downloadAndExtractS3BundleMock.mockResolvedValue({ dir: '/tmp/extracted-xyz', cleanup });
+    buildAgentCoreCodeImageMock.mockResolvedValue('cdkl-agentcore-code-froms3');
+
+    const image = await resolveAgentCoreImage(s3CodeRuntime(), imageOpts({ profile: 'dev' }));
+
+    expect(image).toBe('cdkl-agentcore-code-froms3');
+    expect(downloadAndExtractS3BundleMock).toHaveBeenCalledWith(
+      { bucket: 'my-bundles', key: 'agents/agent.zip' },
+      expect.objectContaining({ profile: 'dev' })
+    );
+    expect(buildAgentCoreCodeImageMock).toHaveBeenCalledWith({
+      sourceDir: '/tmp/extracted-xyz',
+      runtime: 'PYTHON_3_12',
+      entryPoint: ['app.py'],
+      architecture: 'arm64',
+      noBuild: false,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    // The fromCodeAsset cdk.out path must NOT run for a fromS3 bundle.
+    expect(loadManifestMock).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the temp dir even when the build fails', async () => {
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    downloadAndExtractS3BundleMock.mockResolvedValue({ dir: '/tmp/extracted-zzz', cleanup });
+    buildAgentCoreCodeImageMock.mockRejectedValue(new Error('docker build boom'));
+
+    await expect(resolveAgentCoreImage(s3CodeRuntime(), imageOpts())).rejects.toThrow(
+      /docker build boom/
+    );
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers --stack-region for the download region', async () => {
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    downloadAndExtractS3BundleMock.mockResolvedValue({ dir: '/tmp/x', cleanup });
+    buildAgentCoreCodeImageMock.mockResolvedValue('tag');
+    await resolveAgentCoreImage(s3CodeRuntime(), imageOpts({ stackRegion: 'eu-central-1' }));
+    expect(downloadAndExtractS3BundleMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ region: 'eu-central-1' })
     );
   });
 });

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -13,6 +13,7 @@ const {
   pullImageMock,
   createLocalStateProviderMock,
   verifyJwtViaDiscoveryMock,
+  stsSendMock,
 } = vi.hoisted(() => ({
   loadManifestMock: vi.fn(),
   getFileAssetsMock: vi.fn(),
@@ -26,6 +27,20 @@ const {
   pullImageMock: vi.fn(),
   createLocalStateProviderMock: vi.fn(),
   verifyJwtViaDiscoveryMock: vi.fn(),
+  stsSendMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    send = stsSendMock;
+    destroy(): void {}
+  },
+  AssumeRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+  GetCallerIdentityCommand: class {
+    constructor(public input: unknown) {}
+  },
 }));
 
 vi.mock('../../../src/local/cognito-jwt.js', async (importActual) => ({
@@ -326,6 +341,60 @@ describe('resolveAgentCoreImage — CodeConfiguration fromS3 (download + build)'
       expect.anything(),
       expect.objectContaining({ region: 'eu-central-1' })
     );
+  });
+
+  it('prefers --region over --stack-region for the download region', async () => {
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    downloadAndExtractS3BundleMock.mockResolvedValue({ dir: '/tmp/x', cleanup });
+    buildAgentCoreCodeImageMock.mockResolvedValue('tag');
+    await resolveAgentCoreImage(
+      s3CodeRuntime(),
+      imageOpts({ region: 'ap-south-1', stackRegion: 'eu-central-1' })
+    );
+    expect(downloadAndExtractS3BundleMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ region: 'ap-south-1' })
+    );
+  });
+
+  it('threads --assume-role STS temp creds into the fromS3 download', async () => {
+    stsSendMock.mockResolvedValue({
+      Credentials: { AccessKeyId: 'AK', SecretAccessKey: 'SK', SessionToken: 'ST' },
+    });
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    downloadAndExtractS3BundleMock.mockResolvedValue({ dir: '/tmp/x', cleanup });
+    buildAgentCoreCodeImageMock.mockResolvedValue('tag');
+
+    await resolveAgentCoreImage(
+      s3CodeRuntime(),
+      imageOpts({ assumeRole: 'arn:aws:iam::1:role/Agent' })
+    );
+
+    expect(downloadAndExtractS3BundleMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        credentials: { accessKeyId: 'AK', secretAccessKey: 'SK', sessionToken: 'ST' },
+      })
+    );
+  });
+
+  it('falls back to --profile creds when the fromS3 download AssumeRole fails', async () => {
+    stsSendMock.mockRejectedValue(new Error('access denied'));
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    downloadAndExtractS3BundleMock.mockResolvedValue({ dir: '/tmp/x', cleanup });
+    buildAgentCoreCodeImageMock.mockResolvedValue('tag');
+
+    await resolveAgentCoreImage(
+      s3CodeRuntime(),
+      imageOpts({ assumeRole: 'arn:aws:iam::1:role/Agent', profile: 'dev' })
+    );
+
+    const passed = downloadAndExtractS3BundleMock.mock.calls[0]?.[1] as {
+      credentials?: unknown;
+      profile?: string;
+    };
+    expect(passed.credentials).toBeUndefined();
+    expect(passed.profile).toBe('dev');
   });
 });
 

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -166,7 +166,7 @@ describe('resolveAgentCoreTarget — CodeConfiguration (managed runtime)', () =>
     };
   }
 
-  it('extracts runtime, entryPoint, and the fromCodeAsset hash (Prefix <hash>.zip)', () => {
+  it('extracts runtime, entryPoint, and the fromCodeAsset hash (Prefix <hash>.zip); intrinsic Bucket => no s3Source', () => {
     const stack = buildStack('App', {
       ChatAgent: codeRuntime({
         Code: { S3: { Bucket: { 'Fn::Sub': 'cdk-assets-${AWS::AccountId}' }, Prefix: 'abc123def456.zip' } },
@@ -180,6 +180,39 @@ describe('resolveAgentCoreTarget — CodeConfiguration (managed runtime)', () =>
       runtime: 'PYTHON_3_13',
       entryPoint: ['app.py'],
       codeAssetHash: 'abc123def456',
+    });
+    // The CDK staging bucket is an Fn::Sub intrinsic, so this is fromCodeAsset.
+    expect(resolved.codeArtifact?.s3Source).toBeUndefined();
+  });
+
+  it('carries s3Source for a fromS3 bundle (literal Bucket + Prefix)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: 'my-bundles', Prefix: 'agents/chat.zip' } },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.codeArtifact?.s3Source).toEqual({
+      bucket: 'my-bundles',
+      key: 'agents/chat.zip',
+    });
+  });
+
+  it('captures a Code.S3.VersionId on the fromS3 s3Source', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: 'my-bundles', Prefix: 'chat.zip', VersionId: 'v-42' } },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.codeArtifact?.s3Source).toEqual({
+      bucket: 'my-bundles',
+      key: 'chat.zip',
+      versionId: 'v-42',
     });
   });
 
@@ -210,7 +243,7 @@ describe('resolveAgentCoreTarget — CodeConfiguration (managed runtime)', () =>
     expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/no EntryPoint/);
   });
 
-  it('throws (fromS3 not supported) when Code.S3.Prefix is a non-literal intrinsic', () => {
+  it('throws when Code.S3.Prefix is a non-literal intrinsic', () => {
     const stack = buildStack('App', {
       ChatAgent: codeRuntime({
         Code: { S3: { Bucket: 'b', Prefix: { Ref: 'SomeParam' } } },
@@ -219,7 +252,6 @@ describe('resolveAgentCoreTarget — CodeConfiguration (managed runtime)', () =>
       }),
     });
     expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/not a literal string/);
-    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/fromS3/);
   });
 });
 

--- a/tests/unit/local/agentcore-s3-bundle.test.ts
+++ b/tests/unit/local/agentcore-s3-bundle.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { zipSync, strToU8 } from 'fflate';
+import { downloadAndExtractS3Bundle } from '../../../src/local/agentcore-s3-bundle.js';
+
+/**
+ * Drives the real extraction path against a real in-memory ZIP built with
+ * fflate, fed through the injected `fetchObject` (no AWS / network). Only the
+ * cleanup is async-awaited per test so no temp dirs leak.
+ */
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((c) => c().catch(() => undefined)));
+});
+
+/** Build a ZIP byte array from a {path: contents} map. */
+function zip(files: Record<string, string>): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const [name, content] of Object.entries(files)) entries[name] = strToU8(content);
+  return zipSync(entries);
+}
+
+function fetchReturning(bytes: Uint8Array): () => Promise<Uint8Array> {
+  return async () => bytes;
+}
+
+describe('downloadAndExtractS3Bundle', () => {
+  it('extracts every file (incl. nested dirs) to a temp dir', async () => {
+    const bytes = zip({
+      'app.py': 'print("hi")',
+      'requirements.txt': 'bedrock-agentcore\n',
+      'pkg/util.py': 'X = 1',
+    });
+    const bundle = await downloadAndExtractS3Bundle(
+      { bucket: 'b', key: 'agent.zip' },
+      { fetchObject: fetchReturning(bytes) }
+    );
+    cleanups.push(bundle.cleanup);
+
+    expect(readFileSync(join(bundle.dir, 'app.py'), 'utf-8')).toBe('print("hi")');
+    expect(readFileSync(join(bundle.dir, 'requirements.txt'), 'utf-8')).toBe('bedrock-agentcore\n');
+    expect(readFileSync(join(bundle.dir, 'pkg', 'util.py'), 'utf-8')).toBe('X = 1');
+  });
+
+  it('passes the location to the injected fetcher', async () => {
+    let seen: { bucket: string; key: string; versionId?: string } | undefined;
+    const bundle = await downloadAndExtractS3Bundle(
+      { bucket: 'my-bkt', key: 'k/agent.zip', versionId: 'v9' },
+      {
+        fetchObject: async (loc) => {
+          seen = loc;
+          return zip({ 'app.py': 'x' });
+        },
+      }
+    );
+    cleanups.push(bundle.cleanup);
+    expect(seen).toEqual({ bucket: 'my-bkt', key: 'k/agent.zip', versionId: 'v9' });
+  });
+
+  it('cleanup() removes the temp dir', async () => {
+    const bundle = await downloadAndExtractS3Bundle(
+      { bucket: 'b', key: 'a.zip' },
+      { fetchObject: fetchReturning(zip({ 'app.py': 'x' })) }
+    );
+    expect(existsSync(bundle.dir)).toBe(true);
+    await bundle.cleanup();
+    expect(existsSync(bundle.dir)).toBe(false);
+  });
+
+  it('rejects a zip-slip entry that escapes the target dir', async () => {
+    const bytes = zip({ '../escape.txt': 'pwned', 'app.py': 'x' });
+    await expect(
+      downloadAndExtractS3Bundle({ bucket: 'b', key: 'a.zip' }, { fetchObject: fetchReturning(bytes) })
+    ).rejects.toThrow(/escapes the target dir/);
+  });
+
+  it('throws when the bundle contains no files', async () => {
+    // A zip with only a directory entry (no file content).
+    const bytes = zip({ 'emptydir/': '' });
+    await expect(
+      downloadAndExtractS3Bundle({ bucket: 'b', key: 'a.zip' }, { fetchObject: fetchReturning(bytes) })
+    ).rejects.toThrow(/contained no files/);
+  });
+
+  it('throws a clear error when the object is not a valid ZIP', async () => {
+    const notZip = strToU8('this is not a zip archive');
+    await expect(
+      downloadAndExtractS3Bundle({ bucket: 'b', key: 'a.zip' }, { fetchObject: fetchReturning(notZip) })
+    ).rejects.toThrow(/must be a ZIP archive/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds fromS3 CodeConfiguration support to `cdkl invoke-agentcore` — a runtime
whose `AgentRuntimeArtifact.CodeConfiguration.Code.S3` points at a pre-existing
S3 object (a ZIP of the agent source) instead of a CDK-managed local asset.
Previously this was rejected with "fromS3 not supported".

- **Resolver** carries a literal `s3Source` (bucket / key / versionId) on the
  code artifact. The CDK staging bucket of a fromCodeAsset renders as an
  `Fn::Sub` intrinsic, so a literal `Code.S3.Bucket` reliably distinguishes a
  fromS3 bundle.
- **New `agentcore-s3-bundle` module** downloads the object via the S3 SDK and
  extracts the ZIP (fflate) to a temp dir, guarding against zip-slip / empty /
  non-ZIP objects. The command routes a fromS3 bundle through it, runs the SAME
  from-source build the fromCodeAsset path uses, then cleans up the temp dir
  (even on build failure).
- **Credentials / region**: the download honors `--assume-role` (STS temp creds,
  explicit ARN or bare-from-state), else `--profile` / the default chain; the
  region is `--region` / `--stack-region` / env / the stack's region.
- **Deps**: `@aws-sdk/client-s3` (sibling to the existing aws-sdk clients) +
  `fflate` (tiny pure-JS unzip; Node has no native ZIP extraction).

Exported from `cdk-local/internal` (`downloadAndExtractS3Bundle` + types).

## Review notes

3-axis review run (spec / code / test). Spec: clean. Test gaps closed in a
follow-up commit (fromS3 `--assume-role` STS threading + fallback; `--region`
over `--stack-region` precedence). Accepted as known cost (cosmetic, no
behavior impact):

- The fromS3 download's region chain includes `--stack-region` while the
  global-STS sites for container creds do not — the download needs the bundle
  bucket's real S3 region, so this is intentional, not a divergence.
- A bare `--assume-role` + fromS3 invoke does two STS AssumeRole calls (one for
  the download, one for the container env) — both are needed at different times
  and creds are short-lived.
- The default S3 fetcher (real `S3Client` + `GetObjectCommand`) is exercised by
  the real-AWS integ rather than unit-mocked.

Out of scope (follow-up): a fromS3 bundle whose `Code.S3.Bucket` is an
unresolved intrinsic (a `Ref` to a stack bucket) — only a literal bucket is
resolved locally.

## Test plan

- [x] `vp run check` (typecheck + lint + format) green
- [x] `vp run test` — 101 files, 1474 tests pass (new: `agentcore-s3-bundle`
      unit tests against real fflate ZIPs via an injected fetcher; resolver
      `s3Source` extraction; command fromS3 routing + cleanup + creds/region)
- [x] `vp run build` — `downloadAndExtractS3Bundle` present in
      `dist/internal.js` + `dist/index.js`
- [x] `/run-integ local-invoke-agentcore-froms3` — real-AWS: creates an S3
      bucket, uploads the zipped code-agent, runs `cdkl invoke-agentcore`
      through download + from-source build + invoke (default + `--event`),
      deletes the bucket. 0 Docker orphans, 0 leftover buckets.

Closes #144
