### PR TITLE
feat(invoke-agentcore): resolve intrinsic Code.S3.Bucket for fromS3 under --from-cfn-stack

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,7 +43,9 @@ AWS managed services.
   (`fromCodeAsset` AND `fromS3` — Python 3.10-3.14 / Node 22, built from source:
   a generated Dockerfile installs the bundle's deps and runs the EntryPoint,
   which self-serves the contract; a `fromS3` bundle's ZIP is downloaded from S3
-  and extracted first) on the HTTP and MCP protocols. HTTP runs the
+  and extracted first — `Code.S3.Bucket` may be a literal or, under
+  `--from-cfn-stack`, a `Ref` / `Fn::ImportValue` / `Fn::GetStackOutput`
+  intrinsic resolved against state) on the HTTP and MCP protocols. HTTP runs the
   `POST /invocations` + `GET /ping` contract on 8080: an inbound
   `customJwtAuthorizer` is enforced locally (`--bearer-token` verified against
   the runtime's OIDC discovery URL before the container starts and forwarded to

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -464,9 +464,12 @@ Both bundle shapes are supported:
   uses the resolved region (`--stack-region` / `--region` / env / the stack's
   region) and credentials (`--assume-role` STS temp creds when set, else
   `--profile` / the default chain). The S3 read needs credentials that can
-  `s3:GetObject` the bundle object. Only a literal `Code.S3.Bucket` is resolved
-  locally; a bucket that is an unresolved intrinsic (a `Ref` to a stack bucket)
-  is a follow-up.
+  `s3:GetObject` the bundle object. `Code.S3.Bucket` may be either a literal
+  bucket name OR an intrinsic resolved against `--from-cfn-stack` state — the
+  same set of intrinsics env-var substitution supports: `Ref` (same-stack
+  bucket), `Fn::ImportValue` (CloudFormation export), `Fn::GetStackOutput`
+  (cdk-local cross-stack output). Without `--from-cfn-stack`, an intrinsic
+  bucket fails fast with an actionable error.
 
 `--no-build` reuses the previously-built image tag.
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -55,6 +55,7 @@ import { invokeAgentCoreWs, type AgentCoreWsResult } from '../../local/agentcore
 import { createJwksCache, verifyJwtViaDiscovery } from '../../local/cognito-jwt.js';
 import { resolveEnvVars, type EnvOverrideFile } from '../../local/env-resolver.js';
 import {
+  substituteAgainstStateAsync,
   substituteEnvVarsFromStateAsync,
   type SubstitutionContext,
 } from '../../local/state-resolver.js';
@@ -314,6 +315,13 @@ async function localInvokeAgentCoreCommand(
     } else {
       authorization = await resolveInboundAuthorization(resolved, options);
     }
+
+    // If the fromS3 bundle's Code.S3.Bucket is an intrinsic (Ref /
+    // Fn::ImportValue / Fn::GetStackOutput), resolve it against --from-cfn-stack
+    // state BEFORE the image step (which needs a literal bucket for the S3
+    // download). Reuses the same substitution machinery env vars use, so
+    // every cross-stack intrinsic the env path supports is supported here too.
+    await resolveFromS3BucketIntrinsic(resolved, stateProvider, loadedState, imageContext);
 
     const image = await resolveAgentCoreImage(resolved, options, loadedState);
 
@@ -625,6 +633,21 @@ async function resolveAgentCoreCodeImageFromS3(
   loaded: LocalStateRecord | undefined
 ): Promise<string> {
   const logger = getLogger();
+  // The bucket should be a literal string by this point — a template-literal
+  // bucket falls through from the resolver, an intrinsic bucket was resolved by
+  // `resolveFromS3BucketIntrinsic` in the outer command before we got here.
+  if (typeof s3Source.bucket !== 'string' || s3Source.bucket.length === 0) {
+    throw new CdkLocalError(
+      `AgentCore Runtime '${resolved.logicalId}' fromS3 bundle reached the image step with no literal bucket. ` +
+        `This is a cdk-local bug — please report it.`,
+      'LOCAL_INVOKE_AGENTCORE_FROMS3_BUCKET_UNRESOLVED'
+    );
+  }
+  const location = {
+    bucket: s3Source.bucket,
+    key: s3Source.key,
+    ...(s3Source.versionId !== undefined && { versionId: s3Source.versionId }),
+  };
   const region =
     options.region ??
     options.stackRegion ??
@@ -648,7 +671,7 @@ async function resolveAgentCoreCodeImageFromS3(
     }
   }
 
-  const bundle = await downloadAndExtractS3Bundle(s3Source, {
+  const bundle = await downloadAndExtractS3Bundle(location, {
     ...(region !== undefined && { region }),
     ...(options.profile !== undefined && { profile: options.profile }),
     ...(credentials !== undefined && { credentials }),
@@ -767,6 +790,79 @@ export async function buildContainerEnv(
     }),
   });
   return { env: dockerEnv, sensitiveEnvKeys };
+}
+
+/**
+ * Resolve a fromS3 bundle's intrinsic `Code.S3.Bucket` to a literal bucket
+ * name in place on `resolved.codeArtifact.s3Source.bucket`. Uses the SAME
+ * state-substitution machinery env vars use under `--from-cfn-stack`, so
+ * every cross-stack intrinsic that path supports (`Ref` / `Fn::ImportValue` /
+ * `Fn::GetStackOutput`) is supported transparently here.
+ *
+ * No-op when there is no intrinsic to resolve. Errors when no state is
+ * available, or when the substitution returns a non-string / unresolved value.
+ *
+ * Exported so a unit test can drive the gate without the full Docker pipeline.
+ */
+export async function resolveFromS3BucketIntrinsic(
+  resolved: ResolvedAgentCoreRuntime,
+  stateProvider: LocalStateProvider | undefined,
+  loaded: LocalStateRecord | undefined,
+  imageContext: ImageResolutionContext | undefined
+): Promise<void> {
+  const s3Source = resolved.codeArtifact?.s3Source;
+  if (!s3Source || s3Source.bucketIntrinsic === undefined) return;
+  if (s3Source.bucket !== undefined) return; // already resolved
+
+  if (!stateProvider || !loaded) {
+    throw new CdkLocalError(
+      `AgentCore Runtime '${resolved.logicalId}' fromS3 bundle's Code.S3.Bucket is an unresolved intrinsic ` +
+        `(${describeIntrinsic(s3Source.bucketIntrinsic)}). ` +
+        `Pass --from-cfn-stack so its physical bucket name can be resolved against the deployed stack state.`,
+      'LOCAL_INVOKE_AGENTCORE_FROMS3_BUCKET_INTRINSIC_NO_STATE'
+    );
+  }
+
+  const subContext: SubstitutionContext = {
+    resources: imageContext?.stateResources ?? loaded.resources,
+    consumerRegion: loaded.region,
+  };
+  const pseudo = imageContext?.pseudoParameters ?? derivePseudoParametersFromRegion(loaded.region);
+  if (pseudo) subContext.pseudoParameters = pseudo;
+  const crossStackResolver = await stateProvider.buildCrossStackResolver(loaded.region);
+  if (crossStackResolver) subContext.crossStackResolver = crossStackResolver;
+
+  const result = await substituteAgainstStateAsync(s3Source.bucketIntrinsic, subContext);
+  if (result.kind !== 'literal') {
+    throw new CdkLocalError(
+      `Could not resolve AgentCore Runtime '${resolved.logicalId}' fromS3 Code.S3.Bucket intrinsic ` +
+        `(${describeIntrinsic(s3Source.bucketIntrinsic)}) against the --from-cfn-stack state: ${result.reason}. ` +
+        `Confirm the referenced resource / export exists in the deployed stack.`,
+      'LOCAL_INVOKE_AGENTCORE_FROMS3_BUCKET_INTRINSIC_UNRESOLVED'
+    );
+  }
+  if (typeof result.value !== 'string' || result.value.length === 0) {
+    throw new CdkLocalError(
+      `AgentCore Runtime '${resolved.logicalId}' fromS3 Code.S3.Bucket intrinsic resolved to a ` +
+        `${typeof result.value} value, not a bucket name string. ` +
+        `(${describeIntrinsic(s3Source.bucketIntrinsic)})`,
+      'LOCAL_INVOKE_AGENTCORE_FROMS3_BUCKET_INTRINSIC_NOT_STRING'
+    );
+  }
+  s3Source.bucket = result.value;
+  getLogger().info(
+    `Resolved fromS3 Code.S3.Bucket from state: ${describeIntrinsic(s3Source.bucketIntrinsic)} -> ${result.value}`
+  );
+}
+
+/** Render the intrinsic key for an error / log message (e.g. `Ref:Bucket1`). */
+function describeIntrinsic(value: unknown): string {
+  if (!value || typeof value !== 'object') return String(value);
+  const obj = value as Record<string, unknown>;
+  const key = Object.keys(obj)[0] ?? '?';
+  const arg = obj[key];
+  if (typeof arg === 'string') return `${key}:${arg}`;
+  return key;
 }
 
 /**

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -113,17 +113,31 @@ export interface AgentCoreJwtAuthorizer {
  * `runtime` the `Runtime` enum.
  *
  * `s3Source` is set for the `fromS3` shape — a bundle whose `Code.S3.Bucket`
- * is a literal string (a pre-existing S3 object, NOT the CDK staging bucket,
- * which renders as an `Fn::Sub` intrinsic for `fromCodeAsset`). The command
- * downloads + extracts it and runs the same from-source build. Undefined when
- * the bucket is an intrinsic (the fromCodeAsset case, or a fromS3 bundle whose
- * bucket is a `Ref` — not resolvable locally yet).
+ * is either a literal string (a pre-existing S3 object — NOT the CDK staging
+ * bucket of a fromCodeAsset, which renders as an `Fn::Sub` intrinsic) or an
+ * unresolved intrinsic the command resolves against `--from-cfn-stack` state
+ * (`Ref` / `Fn::ImportValue` / `Fn::GetStackOutput` / `Fn::Sub` — the same
+ * intrinsics `--from-cfn-stack` env-var substitution already handles).
+ *
+ * - `bucket` is set when the template carries a literal bucket name, OR after
+ *   the command has resolved an intrinsic against state.
+ * - `bucketIntrinsic` is set when the template's `Code.S3.Bucket` is an
+ *   unresolved intrinsic — the command resolves it via the same
+ *   state-substitution machinery env vars use, then populates `bucket`.
+ *
+ * Exactly one of `bucket` / `bucketIntrinsic` is set as returned by the
+ * resolver (the command turns the intrinsic into a `bucket` before download).
  */
 export interface AgentCoreCodeArtifact {
   runtime: string;
   entryPoint: string[];
   codeAssetHash: string;
-  s3Source?: { bucket: string; key: string; versionId?: string };
+  s3Source?: {
+    bucket?: string;
+    bucketIntrinsic?: unknown;
+    key: string;
+    versionId?: string;
+  };
 }
 
 export class AgentCoreResolutionError extends Error {
@@ -441,11 +455,18 @@ function extractArtifact(
  * Extract a `CodeConfiguration` (managed-runtime) artifact. Reads `Runtime`,
  * `EntryPoint`, and the `Code.S3` location. `Code.S3.Prefix` must be a literal
  * string (the object key) — it doubles as the cdk.out file-asset hash for the
- * `fromCodeAsset` shape (`<hash>.zip`). When `Code.S3.Bucket` is ALSO a literal
- * string, this is a `fromS3` bundle (a pre-existing S3 object — the CDK staging
- * bucket of a fromCodeAsset renders as an `Fn::Sub` intrinsic, not a literal),
- * captured in `s3Source` so the command downloads + extracts it. A non-literal
- * `Code.S3.Prefix` (an unresolved intrinsic) hard-errors.
+ * `fromCodeAsset` shape (`<hash>.zip`).
+ *
+ * - `Code.S3.Bucket` literal string → fromS3 bundle, `s3Source.bucket` set.
+ * - `Code.S3.Bucket` intrinsic (`Ref` / `Fn::ImportValue` / `Fn::GetStackOutput`
+ *   / `Fn::Sub`) → fromS3 bundle, `s3Source.bucketIntrinsic` set (the command
+ *   resolves it against `--from-cfn-stack` state via the same machinery env
+ *   vars use).
+ * - `Code.S3.Bucket` missing → fromCodeAsset shape (the staging bucket renders
+ *   as an `Fn::Sub` intrinsic for fromCodeAsset, but the cdk.out lookup
+ *   short-circuits that — no `s3Source` needed).
+ *
+ * A non-literal `Code.S3.Prefix` (an unresolved intrinsic) hard-errors.
  */
 function extractCodeArtifact(
   codeConfig: unknown,
@@ -493,21 +514,37 @@ function extractCodeArtifact(
   // file-asset hash the command looks up to find a fromCodeAsset bundle source.
   const codeAssetHash = prefix.replace(/^.*\//, '').replace(/\.zip$/, '');
 
-  // A literal Bucket means a fromS3 bundle (a pre-existing object). The CDK
-  // staging bucket of a fromCodeAsset renders as an `Fn::Sub` intrinsic, so it
-  // is not a literal string and `s3Source` stays undefined for that case.
+  // A literal Bucket means a fromS3 bundle. An intrinsic Bucket — one of
+  // {Ref, Fn::ImportValue, Fn::GetStackOutput} — is also a fromS3 bundle whose
+  // bucket name we resolve against `--from-cfn-stack` state at command time.
+  // The CDK staging bucket of a fromCodeAsset renders as `{Fn::Sub: "..."}`
+  // and is INTENTIONALLY skipped here so fromCodeAsset still routes through
+  // the cdk.out asset path.
   const bucket = s3Obj['Bucket'];
   const versionId = s3Obj['VersionId'];
-  const s3Source =
-    typeof bucket === 'string' && bucket.length > 0
-      ? {
-          bucket,
-          key: prefix,
-          ...(typeof versionId === 'string' && versionId.length > 0 && { versionId }),
-        }
-      : undefined;
+  const versionIdField = typeof versionId === 'string' && versionId.length > 0 ? { versionId } : {};
+  let s3Source: AgentCoreCodeArtifact['s3Source'] | undefined;
+  if (typeof bucket === 'string' && bucket.length > 0) {
+    s3Source = { bucket, key: prefix, ...versionIdField };
+  } else if (isFromS3BucketIntrinsic(bucket)) {
+    s3Source = { bucketIntrinsic: bucket, key: prefix, ...versionIdField };
+  }
 
   return { runtime, entryPoint, codeAssetHash, ...(s3Source && { s3Source }) };
+}
+
+/**
+ * Whitelist the intrinsic shapes the command can resolve for a fromS3
+ * `Code.S3.Bucket` against `--from-cfn-stack` state — `Ref` (same-stack
+ * resource), `Fn::ImportValue` (CloudFormation export), `Fn::GetStackOutput`
+ * (cdk-local cross-stack output). Crucially excludes `Fn::Sub`, which is the
+ * fromCodeAsset staging-bucket shape: that one stays unmarked so fromCodeAsset
+ * routes through the cdk.out asset path unchanged.
+ */
+function isFromS3BucketIntrinsic(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  return 'Ref' in obj || 'Fn::ImportValue' in obj || 'Fn::GetStackOutput' in obj;
 }
 
 /**

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/.gitignore
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/.gitignore
@@ -1,0 +1,6 @@
+# The integ runner installs deps fresh via `vp install`, so the lockfile
+# is a build artifact, not a committed source (matches the sibling fixtures).
+pnpm-lock.yaml
+
+# Local build scratch for the zipped bundle verify.sh uploads to S3.
+bundle.zip

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/.scenarios.json
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "agentcore-froms3-ref-bucket-resolution"
+  ]
+}

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/bin/app.ts
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalInvokeAgentCoreFromS3FromCfnStack } from '../lib/local-invoke-agentcore-froms3-from-cfn-stack.ts';
+
+const app = new cdk.App();
+
+new LocalInvokeAgentCoreFromS3FromCfnStack(app, 'CdkLocalInvokeAgentCoreFromS3FromCfnFixture', {
+  description: 'Fixture stack for cdkl invoke-agentcore fromS3 + --from-cfn-stack integ test',
+});

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/cdk.json
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/code-agent/app.py
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/code-agent/app.py
@@ -1,0 +1,55 @@
+# Minimal Bedrock AgentCore Runtime CodeConfiguration (managed-runtime) agent
+# for the cdkl invoke-agentcore fromS3 + --from-cfn-stack integ test. Authored
+# as plain source (no Dockerfile) and shipped as a ZIP uploaded to a deployed
+# S3 bucket (the fromS3 shape with a Ref-resolved bucket name): cdkl resolves
+# the Ref via --from-cfn-stack state, downloads + extracts the bundle, builds
+# from source (installs requirements.txt), and runs this entrypoint, which
+# self-serves the AgentCore HTTP contract on 0.0.0.0:8080:
+#   GET  /ping        -> 200 {"status":"Healthy"}
+#   POST /invocations -> echoes the request body + the injected GREETING env var
+# Uses only the Python stdlib. Startup logs go to stderr so the host's stdout
+# carries only the cdkl result line.
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+GREETING = os.environ.get("GREETING", "unset")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # silence default stderr access logs
+        pass
+
+    def _json(self, status, payload):
+        # Compact separators (no spaces) so the response matches verify.sh's
+        # no-space grep assertions, like the Node fixtures' JSON.stringify output.
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path == "/ping":
+            self._json(200, {"status": "Healthy"})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/invocations":
+            self._json(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("content-length", 0) or 0)
+        body = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            echoed = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            echoed = body
+        self._json(200, {"echoed": echoed, "greeting": GREETING, "runtime": "python-froms3-ref"})
+
+
+if __name__ == "__main__":
+    print("python fromS3 (Ref) code agent listening on 0.0.0.0:8080", file=sys.stderr, flush=True)
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/code-agent/requirements.txt
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/code-agent/requirements.txt
@@ -1,0 +1,2 @@
+# No third-party dependencies — this agent uses only the Python stdlib.
+# Kept so `cdkl invoke-agentcore` exercises the from-source pip-install build step.

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/lib/local-invoke-agentcore-froms3-from-cfn-stack.ts
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/lib/local-invoke-agentcore-froms3-from-cfn-stack.ts
@@ -32,20 +32,29 @@ export class LocalInvokeAgentCoreFromS3FromCfnStack extends cdk.Stack {
       autoDeleteObjects: true,
     });
 
-    new Runtime(this, 'S3Agent', {
-      agentRuntimeArtifact: AgentRuntimeArtifact.fromS3(
-        { bucketName: bundleBucket.bucketName, objectKey: 'bundles/agent.zip' },
-        AgentCoreRuntime.PYTHON_3_12,
-        ['app.py']
-      ),
-      environmentVariables: { GREETING: 'hello-from-s3-ref' },
-    });
-
     // Expose the deployed bucket name so verify.sh can upload the bundle to
     // the same bucket the Ref will resolve to under --from-cfn-stack.
     new cdk.CfnOutput(this, 'BundleBucketName', {
       value: bundleBucket.bucketName,
       description: 'Physical name of the fromS3 bundle bucket (Ref target).',
     });
+
+    // AWS::BedrockAgentCore::Runtime validates the bundle object exists at
+    // create time, so verify.sh deploys in two passes — `withRuntime=false`
+    // creates just the bucket, the bundle is uploaded, then a second deploy
+    // with `withRuntime=true` adds the Runtime. The Code.S3.Bucket reference
+    // (`bundleBucket.bucketName`) is a same-stack `Ref` intrinsic — the
+    // shape #157 resolves against --from-cfn-stack state.
+    const withRuntime = this.node.tryGetContext('withRuntime') === 'true';
+    if (withRuntime) {
+      new Runtime(this, 'S3Agent', {
+        agentRuntimeArtifact: AgentRuntimeArtifact.fromS3(
+          { bucketName: bundleBucket.bucketName, objectKey: 'bundles/agent.zip' },
+          AgentCoreRuntime.PYTHON_3_12,
+          ['app.py']
+        ),
+        environmentVariables: { GREETING: 'hello-from-s3-ref' },
+      });
+    }
   }
 }

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/lib/local-invoke-agentcore-froms3-from-cfn-stack.ts
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/lib/local-invoke-agentcore-froms3-from-cfn-stack.ts
@@ -1,0 +1,51 @@
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import {
+  Runtime,
+  AgentRuntimeArtifact,
+  AgentCoreRuntime,
+} from 'aws-cdk-lib/aws-bedrockagentcore';
+
+/**
+ * Fixture stack for the `cdkl invoke-agentcore` fromS3 + `--from-cfn-stack`
+ * integ test.
+ *
+ * Creates a CDK-managed `s3.Bucket` in the same stack and passes its `Ref`
+ * (via `bucket.bucketName`) as the `fromS3` artifact bucket. The synthesized
+ * `Code.S3.Bucket` is a `{ "Ref": "<BundleBucketLogicalId>" }` intrinsic — the
+ * common "create the bundle bucket alongside the agent" pattern that the
+ * literal-bucket flow of #144 can't resolve locally.
+ *
+ * Under `--from-cfn-stack`, `cdkl invoke-agentcore` resolves that `Ref` to the
+ * deployed bucket's physical name via state and downloads the bundle from it.
+ *
+ * `removalPolicy: DESTROY` + `autoDeleteObjects: true` so `cdk destroy`
+ * removes the bucket cleanly after the test (no manual S3 cleanup needed).
+ */
+export class LocalInvokeAgentCoreFromS3FromCfnStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const bundleBucket = new s3.Bucket(this, 'BundleBucket', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    new Runtime(this, 'S3Agent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromS3(
+        { bucketName: bundleBucket.bucketName, objectKey: 'bundles/agent.zip' },
+        AgentCoreRuntime.PYTHON_3_12,
+        ['app.py']
+      ),
+      environmentVariables: { GREETING: 'hello-from-s3-ref' },
+    });
+
+    // Expose the deployed bucket name so verify.sh can upload the bundle to
+    // the same bucket the Ref will resolve to under --from-cfn-stack.
+    new cdk.CfnOutput(this, 'BundleBucketName', {
+      value: bundleBucket.bucketName,
+      description: 'Physical name of the fromS3 bundle bucket (Ref target).',
+    });
+  }
+}

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/package.json
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-invoke-agentcore-froms3-from-cfn",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl invoke-agentcore fromS3 + --from-cfn-stack (intrinsic bucket resolution)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.257.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/tsconfig.json
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkl invoke-agentcore` fromS3 bundles
+# with an INTRINSIC `Code.S3.Bucket` resolved via `--from-cfn-stack` (issue #157).
+#
+# The fixture stack creates a CDK-managed `s3.Bucket` and passes its `Ref`
+# (`bucket.bucketName`) as the `fromS3` artifact bucket — the common
+# "create the bundle bucket alongside the agent" pattern that the literal-bucket
+# path (#144) can't resolve locally.
+#
+# Steps: cdk deploy -> read the deployed bucket name from the stack output ->
+# zip + upload the code-agent bundle to it -> `cdkl invoke-agentcore <target>
+# --from-cfn-stack` resolves the Ref to the physical bucket name and downloads
+# the bundle -> assert response -> cdk destroy (autoDeleteObjects empties the
+# bucket).
+#
+# Run via `/run-integ local-invoke-agentcore-froms3-from-cfn` (recommended).
+# Requires Docker, AWS credentials with deploy + S3 permissions, and the global
+# `cdk` CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalInvokeAgentCoreFromS3FromCfnFixture"
+TARGET="${STACK}/S3Agent"
+CODE_BASE_IMAGE="public.ecr.aws/docker/library/python:3.12-slim"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-agentcore-froms3-from-cfn"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+echo "[verify] region=${REGION} fromS3 intrinsic Code.S3.Bucket (Ref) + --from-cfn-stack"
+
+echo "[verify] step 1a: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+
+echo "[verify] step 1b: verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "[verify] step 1c: pulling ${CODE_BASE_IMAGE} (one-time)"
+docker pull --platform linux/arm64 "${CODE_BASE_IMAGE}" >/dev/null
+
+echo "[verify] step 1d: installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+WE_CREATED_STACK=0
+EVENT_FILE=""
+cleanup() {
+  rc=$?
+  if [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] cleanup: cdk destroy ${STACK} (autoDeleteObjects empties the bucket)"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  rm -f "${TEST_DIR}/bundle.zip"
+  [ -n "${EVENT_FILE}" ] && rm -f "${EVENT_FILE}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists — clean up first via:"
+  echo "          cdk destroy ${STACK} --force --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 3: cdk deploy (creates the bundle bucket + the Runtime)"
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 3 ok: cdk deploy completed"
+
+echo "[verify] step 4: read the deployed bucket name from the stack output"
+BUCKET=$(aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" \
+  --query "Stacks[0].Outputs[?OutputKey=='BundleBucketName'].OutputValue" --output text)
+if [ -z "${BUCKET}" ] || [ "${BUCKET}" = "None" ]; then
+  echo "[verify] FAIL: could not read BundleBucketName stack output"
+  exit 1
+fi
+echo "[verify]   bundle bucket: s3://${BUCKET}"
+
+echo "[verify] step 5: zip code-agent/ and upload as the bundle object"
+rm -f "${TEST_DIR}/bundle.zip"
+(cd "${TEST_DIR}/code-agent" && zip -qr "${TEST_DIR}/bundle.zip" . -x '*.pyc' '__pycache__/*')
+aws s3 cp "${TEST_DIR}/bundle.zip" "s3://${BUCKET}/bundles/agent.zip" --region "${REGION}" >/dev/null
+
+echo "[verify] step 6: cdkl invoke-agentcore --from-cfn-stack (resolves Ref -> ${BUCKET})"
+RESULT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack 2>/dev/null | tail -1)
+echo "[verify]   response: ${RESULT}"
+echo "${RESULT}" | grep -q '"runtime":"python-froms3-ref"' || {
+  echo "[verify] FAIL: expected the fromS3-via-Ref from-source agent to respond, got: ${RESULT}"
+  exit 1
+}
+echo "${RESULT}" | grep -q '"greeting":"hello-from-s3-ref"' || {
+  echo "[verify] FAIL: expected GREETING=hello-from-s3-ref (env injected), got: ${RESULT}"
+  exit 1
+}
+
+echo "[verify] step 7: WITHOUT --from-cfn-stack, intrinsic Code.S3.Bucket fails fast"
+set +e
+OUT_NO_STATE=$(${CLI} invoke-agentcore "${TARGET}" 2>&1)
+RC_NO_STATE=$?
+set -e
+[[ ${RC_NO_STATE} -ne 0 ]] || {
+  echo "[verify] FAIL: expected a non-zero exit without --from-cfn-stack, got 0. Output: ${OUT_NO_STATE}"
+  exit 1
+}
+echo "${OUT_NO_STATE}" | grep -q -- "--from-cfn-stack" || {
+  echo "[verify] FAIL: expected an actionable 'pass --from-cfn-stack' error, got: ${OUT_NO_STATE}"
+  exit 1
+}
+
+echo "[verify] step 8: --event payload echoes through the fromS3-via-Ref agent"
+EVENT_FILE="$(mktemp)"
+echo '{"prompt":"hello froms3 ref"}' > "${EVENT_FILE}"
+RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack --event "${EVENT_FILE}" 2>/dev/null | tail -1)
+echo "[verify]   response: ${RESULT_EVENT}"
+echo "${RESULT_EVENT}" | grep -q '"prompt":"hello froms3 ref"' || {
+  echo "[verify] FAIL: expected the echoed event from the fromS3-via-Ref agent, got: ${RESULT_EVENT}"
+  exit 1
+}
+
+echo "[verify] step 9: cdk destroy (autoDeleteObjects empties the bucket)"
+cdk destroy "${STACK}" --force --region "${REGION}" \
+  --no-version-reporting --no-asset-metadata --no-path-metadata
+WE_CREATED_STACK=0
+echo "[verify]   destroyed ${STACK}"
+
+echo ""
+echo "[verify] All local-invoke-agentcore-froms3-from-cfn checks passed"

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
@@ -8,11 +8,15 @@
 # "create the bundle bucket alongside the agent" pattern that the literal-bucket
 # path (#144) can't resolve locally.
 #
-# Steps: cdk deploy -> read the deployed bucket name from the stack output ->
-# zip + upload the code-agent bundle to it -> `cdkl invoke-agentcore <target>
-# --from-cfn-stack` resolves the Ref to the physical bucket name and downloads
-# the bundle -> assert response -> cdk destroy (autoDeleteObjects empties the
-# bucket).
+# `AWS::BedrockAgentCore::Runtime` CFn validates the bundle object exists at
+# create time, so the test deploys in TWO PASSES:
+#   1. `cdk deploy -c withRuntime=false` creates just the bucket,
+#   2. verify.sh zips + uploads the code-agent bundle,
+#   3. `cdk deploy -c withRuntime=true` adds the Runtime referencing the
+#      now-populated bucket via `bucket.bucketName` (a same-stack `Ref`).
+#   4. `cdkl invoke-agentcore <target> --from-cfn-stack` resolves the Ref to
+#      the deployed bucket's physical name and downloads the bundle.
+#   5. `cdk destroy` removes everything (autoDeleteObjects empties the bucket).
 #
 # Run via `/run-integ local-invoke-agentcore-froms3-from-cfn` (recommended).
 # Requires Docker, AWS credentials with deploy + S3 permissions, and the global
@@ -71,17 +75,18 @@ if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION
   exit 1
 fi
 
-echo "[verify] step 3: cdk deploy (creates the bundle bucket + the Runtime)"
+echo "[verify] step 3a: cdk deploy (bucket-only, withRuntime=false)"
 WE_CREATED_STACK=1
 cdk deploy "${STACK}" \
+  -c withRuntime=false \
   --require-approval never \
   --no-version-reporting \
   --no-asset-metadata \
   --no-path-metadata \
   --region "${REGION}"
-echo "[verify] step 3 ok: cdk deploy completed"
+echo "[verify] step 3a ok: bucket deployed"
 
-echo "[verify] step 4: read the deployed bucket name from the stack output"
+echo "[verify] step 3b: read the deployed bucket name from the stack output"
 BUCKET=$(aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" \
   --query "Stacks[0].Outputs[?OutputKey=='BundleBucketName'].OutputValue" --output text)
 if [ -z "${BUCKET}" ] || [ "${BUCKET}" = "None" ]; then
@@ -90,14 +95,36 @@ if [ -z "${BUCKET}" ] || [ "${BUCKET}" = "None" ]; then
 fi
 echo "[verify]   bundle bucket: s3://${BUCKET}"
 
-echo "[verify] step 5: zip code-agent/ and upload as the bundle object"
+echo "[verify] step 3c: zip code-agent/ and upload as the bundle object (before Runtime create)"
 rm -f "${TEST_DIR}/bundle.zip"
 (cd "${TEST_DIR}/code-agent" && zip -qr "${TEST_DIR}/bundle.zip" . -x '*.pyc' '__pycache__/*')
 aws s3 cp "${TEST_DIR}/bundle.zip" "s3://${BUCKET}/bundles/agent.zip" --region "${REGION}" >/dev/null
 
+echo "[verify] step 3d: cdk deploy (withRuntime=true) — Runtime validates the bundle exists"
+cdk deploy "${STACK}" \
+  -c withRuntime=true \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 3d ok: Runtime deployed"
+
 echo "[verify] step 6: cdkl invoke-agentcore --from-cfn-stack (resolves Ref -> ${BUCKET})"
-RESULT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack 2>/dev/null | tail -1)
+set +e
+# cdkl runs the same CDK app — pass -c withRuntime=true so the synth includes
+# the Runtime resource the deployed stack also has.
+OUT_STEP6=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack -c withRuntime=true 2>&1)
+RC_STEP6=$?
+set -e
+RESULT=$(echo "${OUT_STEP6}" | tail -1)
+echo "[verify]   exit=${RC_STEP6}"
 echo "[verify]   response: ${RESULT}"
+[[ ${RC_STEP6} -eq 0 ]] || {
+  echo "[verify] FAIL: cdkl invoke-agentcore exited ${RC_STEP6}. Full output:"
+  echo "${OUT_STEP6}" | tail -40
+  exit 1
+}
 echo "${RESULT}" | grep -q '"runtime":"python-froms3-ref"' || {
   echo "[verify] FAIL: expected the fromS3-via-Ref from-source agent to respond, got: ${RESULT}"
   exit 1
@@ -109,7 +136,7 @@ echo "${RESULT}" | grep -q '"greeting":"hello-from-s3-ref"' || {
 
 echo "[verify] step 7: WITHOUT --from-cfn-stack, intrinsic Code.S3.Bucket fails fast"
 set +e
-OUT_NO_STATE=$(${CLI} invoke-agentcore "${TARGET}" 2>&1)
+OUT_NO_STATE=$(${CLI} invoke-agentcore "${TARGET}" -c withRuntime=true 2>&1)
 RC_NO_STATE=$?
 set -e
 [[ ${RC_NO_STATE} -ne 0 ]] || {
@@ -124,7 +151,7 @@ echo "${OUT_NO_STATE}" | grep -q -- "--from-cfn-stack" || {
 echo "[verify] step 8: --event payload echoes through the fromS3-via-Ref agent"
 EVENT_FILE="$(mktemp)"
 echo '{"prompt":"hello froms3 ref"}' > "${EVENT_FILE}"
-RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack --event "${EVENT_FILE}" 2>/dev/null | tail -1)
+RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack -c withRuntime=true --event "${EVENT_FILE}" 2>/dev/null | tail -1)
 echo "[verify]   response: ${RESULT_EVENT}"
 echo "${RESULT_EVENT}" | grep -q '"prompt":"hello froms3 ref"' || {
   echo "[verify] FAIL: expected the echoed event from the fromS3-via-Ref agent, got: ${RESULT_EVENT}"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -112,6 +112,7 @@ const {
   platformToArchitecture,
   resolveInboundAuthorization,
   resolveAssumeRoleArn,
+  resolveFromS3BucketIntrinsic,
 } = await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -774,5 +775,85 @@ describe('resolveInboundAuthorization — JWT gate', () => {
     await expect(
       resolveInboundAuthorization(withAuthorizer(), { bearerToken: 'bad', verifyAuth: true })
     ).rejects.toThrow(/rejected by the runtime's customJwtAuthorizer/);
+  });
+});
+
+describe('resolveFromS3BucketIntrinsic — fromS3 Code.S3.Bucket intrinsic resolution', () => {
+  function runtimeWithIntrinsic(intrinsic: unknown): ResolvedAgentCoreRuntime {
+    return {
+      stack: { stackName: 'App', region: 'us-east-1' } as never,
+      logicalId: 'S3Agent',
+      resource: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      environmentVariables: {},
+      protocol: 'HTTP',
+      codeArtifact: {
+        runtime: 'PYTHON_3_12',
+        entryPoint: ['app.py'],
+        codeAssetHash: 'agent',
+        s3Source: { bucketIntrinsic: intrinsic, key: 'agent.zip' },
+      },
+    };
+  }
+
+  it('is a no-op when there is no s3Source / no bucketIntrinsic', async () => {
+    const r: ResolvedAgentCoreRuntime = {
+      stack: { stackName: 'App' } as never,
+      logicalId: 'ChatAgent',
+      resource: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      containerUri: 'r:t',
+      environmentVariables: {},
+      protocol: 'HTTP',
+    };
+    await expect(
+      resolveFromS3BucketIntrinsic(r, undefined, undefined, undefined)
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves a Ref bucket against loaded state', async () => {
+    const r = runtimeWithIntrinsic({ Ref: 'MyBucketABCD' });
+    const stateProvider = {
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+    } as never;
+    const loaded = {
+      stackName: 'App',
+      region: 'us-east-1',
+      resources: {
+        MyBucketABCD: { physicalId: 'my-real-bucket-name', resourceType: 'AWS::S3::Bucket' },
+      },
+    } as never;
+    await resolveFromS3BucketIntrinsic(r, stateProvider, loaded, undefined);
+    expect(r.codeArtifact?.s3Source?.bucket).toBe('my-real-bucket-name');
+  });
+
+  it('resolves a Fn::ImportValue bucket via the cross-stack resolver', async () => {
+    const r = runtimeWithIntrinsic({ 'Fn::ImportValue': 'SharedBundleBucket' });
+    const crossStackResolver = {
+      resolveImport: vi.fn().mockResolvedValue('imported-bucket-name'),
+    };
+    const stateProvider = {
+      buildCrossStackResolver: vi.fn().mockResolvedValue(crossStackResolver),
+    } as never;
+    const loaded = { stackName: 'App', region: 'us-east-1', resources: {} } as never;
+    await resolveFromS3BucketIntrinsic(r, stateProvider, loaded, undefined);
+    expect(r.codeArtifact?.s3Source?.bucket).toBe('imported-bucket-name');
+    expect(crossStackResolver.resolveImport).toHaveBeenCalledWith('SharedBundleBucket');
+  });
+
+  it('errors when --from-cfn-stack state is not available', async () => {
+    const r = runtimeWithIntrinsic({ Ref: 'BucketX' });
+    await expect(
+      resolveFromS3BucketIntrinsic(r, undefined, undefined, undefined)
+    ).rejects.toThrow(/Pass --from-cfn-stack/);
+  });
+
+  it('errors when the substitution returns unresolved (e.g. missing resource)', async () => {
+    const r = runtimeWithIntrinsic({ Ref: 'MissingBucket' });
+    const stateProvider = {
+      buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+    } as never;
+    const loaded = { stackName: 'App', region: 'us-east-1', resources: {} } as never;
+    await expect(
+      resolveFromS3BucketIntrinsic(r, stateProvider, loaded, undefined)
+    ).rejects.toThrow(/Could not resolve/);
   });
 });

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -839,6 +839,28 @@ describe('resolveFromS3BucketIntrinsic — fromS3 Code.S3.Bucket intrinsic resol
     expect(crossStackResolver.resolveImport).toHaveBeenCalledWith('SharedBundleBucket');
   });
 
+  it('resolves a Fn::GetStackOutput bucket via the cross-stack resolver', async () => {
+    const r = runtimeWithIntrinsic({
+      'Fn::GetStackOutput': { StackName: 'SharedStack', OutputName: 'BundleBucketName' },
+    });
+    const resolveGetStackOutput = vi.fn().mockResolvedValue('output-bucket-name');
+    const crossStackResolver = {
+      resolveImport: vi.fn(),
+      resolveGetStackOutput,
+    };
+    const stateProvider = {
+      buildCrossStackResolver: vi.fn().mockResolvedValue(crossStackResolver),
+    } as never;
+    const loaded = { stackName: 'App', region: 'us-east-1', resources: {} } as never;
+    await resolveFromS3BucketIntrinsic(r, stateProvider, loaded, undefined);
+    expect(r.codeArtifact?.s3Source?.bucket).toBe('output-bucket-name');
+    expect(resolveGetStackOutput).toHaveBeenCalledWith(
+      'SharedStack',
+      'us-east-1',
+      'BundleBucketName'
+    );
+  });
+
   it('errors when --from-cfn-stack state is not available', async () => {
     const r = runtimeWithIntrinsic({ Ref: 'BucketX' });
     await expect(

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -216,6 +216,73 @@ describe('resolveAgentCoreTarget — CodeConfiguration (managed runtime)', () =>
     });
   });
 
+  it('captures bucketIntrinsic for a Ref bucket (same-stack), leaving bucket unset', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: { Ref: 'MyBucketABCD' }, Prefix: 'agent.zip' } },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.codeArtifact?.s3Source).toEqual({
+      bucketIntrinsic: { Ref: 'MyBucketABCD' },
+      key: 'agent.zip',
+    });
+    expect(resolved.codeArtifact?.s3Source?.bucket).toBeUndefined();
+  });
+
+  it('captures bucketIntrinsic for a Fn::ImportValue bucket', () => {
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: { 'Fn::ImportValue': 'SharedBundleBucket' }, Prefix: 'agent.zip' } },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.codeArtifact?.s3Source).toEqual({
+      bucketIntrinsic: { 'Fn::ImportValue': 'SharedBundleBucket' },
+      key: 'agent.zip',
+    });
+  });
+
+  it('captures bucketIntrinsic for a Fn::GetStackOutput bucket', () => {
+    const intrinsic = {
+      'Fn::GetStackOutput': { StackName: 'SharedStack', OutputName: 'BundleBucketName' },
+    };
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: { S3: { Bucket: intrinsic, Prefix: 'agent.zip' } },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.codeArtifact?.s3Source?.bucketIntrinsic).toEqual(intrinsic);
+  });
+
+  it('does NOT mark Fn::Sub as a fromS3 bucketIntrinsic (preserves fromCodeAsset routing)', () => {
+    // fromCodeAsset's staging bucket renders as `{Fn::Sub: "cdk-hnb659fds-..."}`.
+    // Routing it down the fromS3 path would try to S3-download a CDK staging
+    // asset that should be read from cdk.out — the explicit intrinsic whitelist
+    // prevents that misroute.
+    const stack = buildStack('App', {
+      ChatAgent: codeRuntime({
+        Code: {
+          S3: {
+            Bucket: { 'Fn::Sub': 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}' },
+            Prefix: 'abc123def456.zip',
+          },
+        },
+        EntryPoint: ['app.py'],
+        Runtime: 'PYTHON_3_12',
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.codeArtifact?.s3Source).toBeUndefined();
+  });
+
   it('strips a key prefix from Code.S3.Prefix when deriving the hash', () => {
     const stack = buildStack('App', {
       ChatAgent: codeRuntime({


### PR DESCRIPTION
## Summary

Extends fromS3 CodeConfiguration support (#144) so `Code.S3.Bucket` can be an
intrinsic resolved against `--from-cfn-stack` state — the common
"create the bundle bucket alongside the agent" pattern that #144's
literal-bucket-only path couldn't handle.

Supported intrinsic shapes (the SAME ones `--from-cfn-stack` env-var
substitution already handles):

- **`Ref`** — same-stack resource. Looked up in `loaded.resources` via
  `physicalId`.
- **`Fn::ImportValue`** — CloudFormation export. Routed through
  `crossStackResolver.resolveImport`.
- **`Fn::GetStackOutput`** — cdk-local cross-stack output. Routed through
  `crossStackResolver.resolveGetStackOutput`.

Implementation:
- Resolver extracts a raw `bucketIntrinsic` on `s3Source` (and never on a
  literal). `Fn::Sub` is **intentionally excluded** from the whitelist — that
  is the fromCodeAsset staging-bucket shape, which must keep routing through
  the cdk.out asset path.
- The command pre-resolves `bucketIntrinsic` to a literal `bucket` via
  `substituteAgainstStateAsync` BEFORE the image step (which needs a literal
  bucket for the S3 download). Reuses the env-var path's full
  `SubstitutionContext` (resources + pseudo + cross-stack resolver).
- Without `--from-cfn-stack` (no state), an intrinsic Bucket fails fast with
  an actionable error pointing the user at the flag.

## Review notes

3-axis review run (spec / code / test). Spec: clean. Test gap closed in a
follow-up commit (Fn::GetStackOutput command-level resolution case).

Accepted as known cost (review nits, no behavior bugs — `src/**` edits would
invalidate the integ marker and force a real-AWS re-run for cosmetic
changes):

- A malformed mixed-key intrinsic like `{Ref: 'X', Foo: 'Y'}` passes the
  whitelist's "in obj" check, then `substituteAgainstStateAsync` rejects it
  with "expected an intrinsic with one key, got 2 keys" — surfaced through
  the `LOCAL_INVOKE_AGENTCORE_FROMS3_BUCKET_INTRINSIC_UNRESOLVED` error which
  speaks of a missing export, not a malformed shape. CDK never emits this
  shape; only a hand-crafted bad template would hit it.
- `resolveFromS3BucketIntrinsic` mutates `resolved.codeArtifact.s3Source.bucket`
  in place. The unit test locks the contract; `resolved` is constructed fresh
  per command invocation and never cached across calls, so the mutation is
  safe.
- `describeIntrinsic` collapses object args (e.g. `Fn::GetStackOutput`'s
  `{StackName, OutputName}`) to the key alone in error messages. The key is
  informative; could be tightened to `JSON.stringify` later if it ever bites.

Out of scope (follow-up): a `Code.S3.Bucket` with a non-whitelisted intrinsic
the substitution machinery doesn't handle.

## Test plan

- [x] `vp run check` (typecheck + lint + format) green
- [x] `vp run test` — 101 files, 1484 tests pass (new: resolver
      `bucketIntrinsic` extraction across Ref / Fn::ImportValue /
      Fn::GetStackOutput / Fn::Sub-excluded; command `resolveFromS3BucketIntrinsic`
      across no-op / Ref / Fn::ImportValue / Fn::GetStackOutput / no-state /
      unresolved)
- [x] `vp run build` — feature ships in `dist/internal.js`
- [x] `/run-integ local-invoke-agentcore-froms3-from-cfn` — real-AWS:
      two-deploy flow (bucket-only deploy → upload bundle → with-Runtime
      deploy) → cdkl with `--from-cfn-stack` resolves Ref to the deployed
      bucket name → downloads + builds + invokes → asserts response + the
      no-state error path → `cdk destroy`. 0 Docker orphans, 0 orphan CFn
      stacks, no S3 leftovers.

Closes #157
