### PR TITLE
feat(start-alb): honor http-header / http-request-method / query-string / source-ip listener-rule conditions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,13 +30,14 @@ AWS managed services.
   replicas only (pure compute, no load balancer). `start-alb` is the ALB
   counterpart of `start-api`: name the ALB, and it boots the ECS
   service(s) behind it plus a local front-door that round-robins each
-  listener port across the replicas and routes the listener's
-  `path-pattern` + `host-header` rules across the backing services,
-  honoring weighted forwards and `redirect` / `fixed-response` actions.
-  A `TargetType: lambda` target group is served by invoking the backing
-  Lambda locally (HTTP request -> `requestContext.elb` event -> RIE ->
-  response), so a forward can mix ECS and Lambda targets (`http-header`
-  / `query-string` / `source-ip` conditions — deferred to #123)
+  listener port across the replicas and routes the listener rules across
+  the backing services. All six ALB rule-condition fields are honored
+  (`path-pattern`, `host-header`, `http-header`, `http-request-method`,
+  `query-string`, `source-ip`), along with weighted forwards and
+  `redirect` / `fixed-response` actions. A `TargetType: lambda` target
+  group is served by invoking the backing Lambda locally (HTTP request
+  -> `requestContext.elb` event -> RIE -> response), so a forward can
+  mix ECS and Lambda targets
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
@@ -114,11 +115,14 @@ Gateway).
   (embed-time branding overrides for host CLIs), ssm-parameter-resolver
   (resolves `AWS::SSM::Parameter::Value` template parameters via SSM under
   `--from-cfn-stack`), elb-front-door-resolver (resolves an ALB ->
-  Listeners + `path-pattern`/`host-header` ListenerRules -> forward /
-  weighted-forward / redirect / fixed-response actions -> backing ECS
-  Services or Lambda functions, into a per-listener routing table; the
-  `start-alb` entry), alb-path-matcher (ALB `*` / `?` glob matcher for
-  path + host rules, priority ordered), alb-lambda-event (HTTP <-> ALB
+  Listeners + ListenerRules across all six ALB condition fields
+  (`path-pattern` / `host-header` / `http-header` / `http-request-method`
+  / `query-string` / `source-ip`) -> forward / weighted-forward /
+  redirect / fixed-response actions -> backing ECS Services or Lambda
+  functions, into a per-listener routing table; the `start-alb` entry),
+  alb-path-matcher (ALB `*` / `?` glob matcher for path / host / header /
+  query-string rules + exact http-request-method + CIDR source-ip,
+  priority ordered), alb-lambda-event (HTTP <-> ALB
   `requestContext.elb` Lambda event/response translation), front-door-pool
   (round-robin pool of live replica endpoints), front-door-lambda-runner
   (one warm RIE container per Lambda target), front-door-server (host HTTP

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 | `cdkl start-service <Service>` | the ECS **service** | just the service's replicas (no load balancer) | workers / queue consumers / Service-Connect-only services, or to hit the containers directly |
 | `cdkl start-alb <Alb>` | the **ALB** | the ECS service(s) behind it **plus** a local **front-door** on each listener port | an `ApplicationLoadBalancedFargateService`-style service you want to reach the way external traffic does |
 
-`start-alb` discovers the ECS service(s) behind the ALB's HTTP listeners, boots their replicas, and stands up a host-side front-door on each listener port that round-robins across the replicas — one stable host endpoint, like behind a real load balancer. It honors **`path-pattern` and `host-header` listener rules**, **weighted** forwards, and **`redirect` / `fixed-response`** actions, so a listener routing `/api/*` (or `api.example.com`) to one service and everything else to another — or returning a redirect / canned response — is reproduced locally. A **`TargetType: lambda`** target group is served by invoking the backing Lambda locally (the request is translated to the ALB `requestContext.elb` event and run through the Lambda RIE), so a forward can mix ECS and Lambda targets.
+`start-alb` discovers the ECS service(s) behind the ALB's HTTP listeners, boots their replicas, and stands up a host-side front-door on each listener port that round-robins across the replicas — one stable host endpoint, like behind a real load balancer. It honors **every ALB listener-rule condition** — `path-pattern`, `host-header`, `http-header`, `http-request-method`, `query-string`, and `source-ip` — plus **weighted** forwards and **`redirect` / `fixed-response`** actions, so a listener routing `/api/*` (or `api.example.com`, or `X-Tenant: acme`, or `POST` writes, or `?version=2`, or `10.0.0.0/8`) to one service and everything else to another — or returning a redirect / canned response — is reproduced locally. A **`TargetType: lambda`** target group is served by invoking the backing Lambda locally (the request is translated to the ALB `requestContext.elb` event and run through the Lambda RIE), so a forward can mix ECS and Lambda targets.
 
 ```bash
 cdkl start-alb MyStack/WebAlb --lb-port 80=8080   # remap the privileged listener port 80 (macOS)
@@ -80,7 +80,7 @@ curl http://127.0.0.1:8080/        # default action -> the default service (roun
 curl http://127.0.0.1:8080/api/x   # path-pattern rule /api/* -> the api service
 ```
 
-Resolution model + scope (HTTP listeners, `path-pattern` + `host-header` rules, weighted forwards, `redirect` / `fixed-response`, ECS **and** Lambda targets; `http-header` / `query-string` / `source-ip` conditions deferred): [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
+Resolution model + scope (HTTP listeners, all six ALB rule-condition fields, weighted forwards, `redirect` / `fixed-response`, ECS **and** Lambda targets): [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
 
 ## Override env vars without a state source
 
@@ -104,7 +104,7 @@ Format + full precedence: [docs/cli-reference.md](docs/cli-reference.md).
 | `AWS::ECS::TaskDefinition` (run-task) | ✓ |
 | `AWS::ECS::Service` (start-service) | ✓ |
 | `AWS::ServiceDiscovery::*` (Cloud Map / Service Connect) | ✓ |
-| `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door; `path-pattern` + `host-header` rules, weighted forward, redirect / fixed-response; ECS + Lambda targets) | ✓ |
+| `AWS::ElasticLoadBalancingV2::*` (start-alb: ALB front-door; all six listener-rule condition fields, weighted forward, redirect / fixed-response; ECS + Lambda targets) | ✓ |
 | `AWS::BedrockAgentCore::Runtime` (invoke-agentcore, container + fromCodeAsset/fromS3 artifacts, HTTP + MCP) | ✓ |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1044,10 +1044,13 @@ ECS service(s) behind its HTTP listeners, boots their replicas
 `start-service`), and stands up a host-side **front-door** on each
 listener port that round-robins each request across the running replicas
 — one stable host endpoint, like behind a real load balancer. The
-front-door applies the listener's **`path-pattern` and `host-header`
-rules**, so one host port can route across several backing services (e.g.
-`/api/*` or `api.example.com` to one service, the default to another) the
-way the deployed ALB does — including **weighted** forwards and
+front-door applies the listener's rules across all six ALB condition
+fields — **`path-pattern`**, **`host-header`**, **`http-header`**,
+**`http-request-method`**, **`query-string`**, and **`source-ip`** — so
+one host port can route across several backing services (e.g. `/api/*`
+or `api.example.com` or `X-Tenant: acme` or `POST` writes or `?version=2`
+or a `10.0.0.0/8` source range to one service, the default to another)
+the way the deployed ALB does — including **weighted** forwards and
 **`redirect` / `fixed-response`** actions.
 
 `start-service` vs `start-alb` mirrors `invoke` / `run-task` (the compute
@@ -1062,19 +1065,21 @@ service you want to reach the way external traffic does.
 `start-alb` resolves the ALB you name → its
 `AWS::ElasticLoadBalancingV2::Listener`s (matched by `LoadBalancerArn`) →
 each listener's default action **and** its
-`AWS::ElasticLoadBalancingV2::ListenerRule`s with a `path-pattern` and/or
-`host-header` condition → each `forward` action's
-`AWS::ElasticLoadBalancingV2::TargetGroup`(s) → either the
+`AWS::ElasticLoadBalancingV2::ListenerRule`s (any of the six ALB condition
+fields: `path-pattern`, `host-header`, `http-header`,
+`http-request-method`, `query-string`, `source-ip`) → each `forward`
+action's `AWS::ElasticLoadBalancingV2::TargetGroup`(s) → either the
 `AWS::ECS::Service` whose `LoadBalancers[]` references that target group (a
 reverse scan — there is no direct TG → service pointer) or, for a
 `TargetType: lambda` group, the backing `AWS::Lambda::Function` it targets.
-The front-door for a listener
-port holds a routing table: each request is matched against the rules in
-`Priority` order (lower number first; ALB `*` / `?` glob, path-only +
-case-insensitive host), falling back to the default action; an unmatched
-request with no default action returns 404. A `redirect` / `fixed-response`
-action is synthesized directly; a weighted `forward` picks a target group
-by weight. Each booted
+The front-door for a listener port holds a routing table: each request is
+matched against the rules in `Priority` order (lower number first; ALB
+`*` / `?` glob for path / host / header / query-string conditions; exact
+case-sensitive uppercase match for `http-request-method`; CIDR match for
+`source-ip`), falling back to the default action; an unmatched request
+with no default action returns 404. A `redirect` / `fixed-response` action
+is synthesized directly; a weighted `forward` picks a target group by
+weight. Each booted
 replica publishes its target container port on an **ephemeral** host port
 (so N replicas never collide), and the front-door forwards to those —
 cross-platform, since traffic goes through published ports rather than
@@ -1108,21 +1113,28 @@ cdkl start-alb MyStack/WebAlb --lb-port 80=8080
 ### Scope
 
 **HTTP** listeners with **ECS** and **Lambda** targets, with priority-ordered
-listener rules matching `path-pattern` and `host-header` conditions (ALB `*` /
-`?` glob; host is matched case-insensitively, path-only excludes the query
-string). Both default actions and rule actions support single-target `forward`,
-**weighted** (multi-target) `forward` (weighted-random selection; weight 0 never
-selected; a forward may mix ECS and Lambda targets), `redirect` (301 / 302 with
-the `#{protocol|host|port|path|query}` placeholders resolved against the
+listener rules matching every ALB condition field — `path-pattern` and
+`host-header` (ALB `*` / `?` glob; host case-insensitive, path-only excludes the
+query string), `http-header` (case-insensitive name lookup + case-insensitive
+value glob), `http-request-method` (exact uppercase match, no wildcards),
+`query-string` (`{ Key?, Value }` globs, case-insensitive, percent / `+`
+decoded), and `source-ip` (IPv4 / IPv6 CIDR; IPv4-mapped IPv6 source
+addresses are unmapped before matching). Both default actions and rule
+actions support single-target `forward`, **weighted** (multi-target) `forward`
+(weighted-random selection; weight 0 never selected; a forward may mix ECS
+and Lambda targets), `redirect` (301 / 302 with the
+`#{protocol|host|port|path|query}` placeholders resolved against the
 request), and `fixed-response` (synthesized status / content-type / body). A
 `TargetType: lambda` target group invokes the backing Lambda locally — the
 request becomes the ALB `requestContext.elb` event, runs through the Lambda RIE,
 and the response is translated back (a malformed response → 502). Out of scope,
 skipped with a warning, and tracked in
-[#123](https://github.com/go-to-k/cdk-local/issues/123): the other rule
-conditions (`http-header` / `http-request-method` / `query-string` /
-`source-ip`), `authenticate-cognito` / `authenticate-oidc` actions, and HTTPS /
-TLS termination.
+[#123](https://github.com/go-to-k/cdk-local/issues/123):
+`authenticate-cognito` / `authenticate-oidc` actions, and HTTPS / TLS
+termination. The local front-door binds the request's `socket.remoteAddress`
+as the source IP, so a `source-ip` CIDR narrower than `127.0.0.0/8` will not
+match traffic that comes in on `127.0.0.1` — exercise such rules from a real
+remote, or use a permissive loopback CIDR for local smoke tests.
 
 ### `cdkl start-alb` exit codes
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -70,7 +70,12 @@ import {
   type RouteAction,
   type WeightedForwardTarget,
 } from '../../local/front-door-server.js';
-import { matchAlbPathRule, type AlbPathRule } from '../../local/alb-path-matcher.js';
+import {
+  matchAlbPathRule,
+  type AlbHttpHeaderCondition,
+  type AlbPathRule,
+  type AlbQueryStringCondition,
+} from '../../local/alb-path-matcher.js';
 import type { ResolvedLambda } from '../../local/lambda-resolver.js';
 import {
   createFrontDoorLambdaRunner,
@@ -207,11 +212,15 @@ export interface PlannedFrontDoorListener {
   hostPort: number;
   /** Default action (absent for a rules-only listener -> 404 on miss). */
   defaultAction?: PlannedAction;
-  /** Rules, evaluated by priority (lower first); each carries path + host conditions. */
+  /** Rules, evaluated by priority (lower first); each carries up to all six ALB condition fields. */
   rules: Array<{
     priority: number;
     pathPatterns: string[];
     hostPatterns: string[];
+    httpHeaderConditions: AlbHttpHeaderCondition[];
+    httpRequestMethods: string[];
+    queryStringConditions: AlbQueryStringCondition[];
+    sourceIpCidrs: string[];
     action: PlannedAction;
   }>;
 }
@@ -790,10 +799,19 @@ export async function buildFrontDoor(
         priority: r.priority,
         pathPatterns: r.pathPatterns,
         hostPatterns: r.hostPatterns,
+        httpHeaderConditions: r.httpHeaderConditions,
+        httpRequestMethods: r.httpRequestMethods,
+        queryStringConditions: r.queryStringConditions,
+        sourceIpCidrs: r.sourceIpCidrs,
         target: toRouteAction(r.action),
       }));
-      const route = (req: { path: string; host?: string }): RouteAction | undefined =>
-        matchAlbPathRule(req, ruleRoutes) ?? defaultRoute;
+      const route = (req: {
+        path: string;
+        host?: string;
+        headers?: NodeJS.Dict<string | string[]>;
+        method?: string;
+        sourceIp?: string;
+      }): RouteAction | undefined => matchAlbPathRule(req, ruleRoutes) ?? defaultRoute;
 
       const server = await startFrontDoorServer({
         route,
@@ -851,12 +869,33 @@ export async function buildFrontDoor(
   return { servers, frontDoorByService, lambdaRunners: [...lambdaRegistry.values()] };
 }
 
-/** Human-readable summary of a planned rule's path / host conditions (for the boot banner). */
-function describeConditions(rule: { pathPatterns: string[]; hostPatterns: string[] }): string {
+/** Human-readable summary of a planned rule's six ALB condition fields (for the boot banner). */
+function describeConditions(rule: {
+  pathPatterns: string[];
+  hostPatterns: string[];
+  httpHeaderConditions: AlbHttpHeaderCondition[];
+  httpRequestMethods: string[];
+  queryStringConditions: AlbQueryStringCondition[];
+  sourceIpCidrs: string[];
+}): string {
   const parts: string[] = [];
   if (rule.pathPatterns.length > 0) parts.push(`path ${rule.pathPatterns.join(', ')}`);
   if (rule.hostPatterns.length > 0) parts.push(`host ${rule.hostPatterns.join(', ')}`);
+  for (const h of rule.httpHeaderConditions) {
+    parts.push(`header ${h.name}: ${h.values.join(', ')}`);
+  }
+  if (rule.httpRequestMethods.length > 0) {
+    parts.push(`method ${rule.httpRequestMethods.join(', ')}`);
+  }
+  if (rule.queryStringConditions.length > 0) {
+    parts.push(`query ${rule.queryStringConditions.map(describeQueryStringCondition).join(', ')}`);
+  }
+  if (rule.sourceIpCidrs.length > 0) parts.push(`source-ip ${rule.sourceIpCidrs.join(', ')}`);
   return parts.join(' AND ') || '(no condition)';
+}
+
+function describeQueryStringCondition(c: AlbQueryStringCondition): string {
+  return c.key !== undefined ? `${c.key}=${c.value}` : c.value;
 }
 
 /** Human-readable summary of a planned action (for the boot banner). */

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -258,6 +258,10 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
               priority: r.priority,
               pathPatterns: r.pathPatterns,
               hostPatterns: r.hostPatterns,
+              httpHeaderConditions: r.httpHeaderConditions,
+              httpRequestMethods: r.httpRequestMethods,
+              queryStringConditions: r.queryStringConditions,
+              sourceIpCidrs: r.sourceIpCidrs,
               action: qualify(r.action),
             })),
           });

--- a/src/local/alb-path-matcher.ts
+++ b/src/local/alb-path-matcher.ts
@@ -1,8 +1,10 @@
 /**
  * Issue #123 — match a request against an ALB listener's rules, in priority
- * order. Covers `path-pattern` (path glob) and `host-header` (Host glob)
- * conditions; a rule may carry one of each and both must match (ALB ANDs
- * conditions of different fields).
+ * order. Covers all six ALB rule-condition fields: `path-pattern` (path glob),
+ * `host-header` (Host glob), `http-header` (named-header glob), `http-request-method`
+ * (exact method), `query-string` (key / value glob pairs), and `source-ip`
+ * (CIDR). A rule may carry up to one of each and all present conditions must
+ * match (ALB ANDs conditions of different fields).
  *
  * ALB path-pattern semantics (NOT the same as API Gateway route matching, so
  * this is a dedicated matcher rather than a reuse of `route-matcher.ts`):
@@ -22,12 +24,63 @@
  *     before matching, mirroring ALB's host comparison.
  *   - Same `*` / `?` glob alphabet as path-pattern, anchored both ends.
  *
+ * ALB http-header semantics:
+ *
+ *   - A condition names one HTTP header (e.g. `User-Agent`) and one or more
+ *     value globs (`*` / `?`, case-insensitive). The condition matches when
+ *     ANY value of that header (a multi-valued header is treated as the list
+ *     of its values) matches ANY glob.
+ *   - Header NAME lookup is case-insensitive (HTTP).
+ *   - A rule may carry multiple http-header conditions (different names);
+ *     they AND.
+ *
+ * ALB http-request-method semantics:
+ *
+ *   - One condition with a list of method names (OR-matched). **Exact match,
+ *     no wildcards**, case-sensitive uppercase (ALB requires uppercase).
+ *
+ * ALB query-string semantics:
+ *
+ *   - One condition with a list of `{ Key?, Value }` pairs (OR-matched). Both
+ *     `Key` (optional) and `Value` accept the `*` / `?` glob alphabet;
+ *     matching is case-insensitive. When `Key` is omitted, ANY key with a
+ *     value matching the `Value` glob satisfies the entry.
+ *   - Repeated query-string parameters (`?a=1&a=2`) match if ANY value
+ *     satisfies the entry.
+ *
+ * ALB source-ip semantics:
+ *
+ *   - One condition with a list of CIDR ranges (OR-matched). Each value is an
+ *     IPv4 or IPv6 CIDR. The request matches when the connection's source IP
+ *     falls inside ANY listed range. IPv4-mapped IPv6 source addresses (the
+ *     `::ffff:a.b.c.d` form Node reports for IPv4 on a dual-stack listener)
+ *     are unmapped before matching.
+ *   - Local-front-door caveat: a request that comes in on `127.0.0.1` is what
+ *     the rule sees; CIDR rules narrower than `127.0.0.0/8` will not match
+ *     locally without `X-Forwarded-For` plumbing (deferred).
+ *
  * Rule precedence: ALB evaluates listener rules in ascending `Priority`
  * (lower number = higher priority); the first rule whose condition(s) match
- * wins. A `path-pattern` / `host-header` condition can carry multiple values,
- * each matched as an OR within the condition. When no rule matches, the caller
- * falls back to the listener's default action.
+ * wins. A condition with multiple values OR-matches; conditions of different
+ * fields AND. When no rule matches, the caller falls back to the listener's
+ * default action.
  */
+
+/** One http-header condition: a header name + its OR-matched value globs. */
+export interface AlbHttpHeaderCondition {
+  /** Header name (case-insensitive lookup). */
+  name: string;
+  /** OR-matched value globs (`*` / `?`, case-insensitive). */
+  values: readonly string[];
+}
+
+/** One query-string condition value: an optional key glob + a required value glob. */
+export interface AlbQueryStringCondition {
+  /** Optional key glob; absent = any key. */
+  key?: string;
+  /** Required value glob. */
+  value: string;
+}
 
 /** One routing rule, generic over the target it selects. */
 export interface AlbPathRule<T> {
@@ -37,16 +90,30 @@ export interface AlbPathRule<T> {
   pathPatterns: string[];
   /** The rule's `host-header` condition values (OR-matched). Empty = no host constraint. */
   hostPatterns?: string[];
+  /** The rule's `http-header` conditions (each AND'd; values within OR). Empty = no header constraint. */
+  httpHeaderConditions?: readonly AlbHttpHeaderCondition[];
+  /** The rule's `http-request-method` values (OR-matched, exact). Empty = no method constraint. */
+  httpRequestMethods?: readonly string[];
+  /** The rule's `query-string` `{ Key?, Value }` pairs (OR-matched). Empty = no query-string constraint. */
+  queryStringConditions?: readonly AlbQueryStringCondition[];
+  /** The rule's `source-ip` CIDR values (OR-matched). Empty = no source-IP constraint. */
+  sourceIpCidrs?: readonly string[];
   /** What this rule routes to (e.g. a pool, a resolved target). */
   target: T;
 }
 
 /** The request facts a rule is evaluated against. */
 export interface AlbRequestMatch {
-  /** Request URL path (query string is stripped before matching). */
+  /** Request URL path (query string is split out before matching path-pattern). */
   path: string;
   /** Request `Host` header (port suffix is stripped before host matching). */
   host?: string;
+  /** Raw incoming request headers (multi-value supported); names are looked up case-insensitively. */
+  headers?: NodeJS.Dict<string | string[]>;
+  /** HTTP request method (e.g. `GET`); compared case-sensitively to the rule's uppercase values. */
+  method?: string;
+  /** Connection source IP for source-ip rule matching. */
+  sourceIp?: string;
 }
 
 /**
@@ -55,32 +122,36 @@ export interface AlbRequestMatch {
  * evaluated in ascending priority; the input order is irrelevant.
  *
  * Accepts either a request facts object or a bare path string (the path-only
- * form keeps the original signature working for callers that have no Host).
+ * form keeps the original signature working for callers that have no Host /
+ * headers / method / source IP).
  */
 export function matchAlbPathRule<T>(
   req: AlbRequestMatch | string,
   rules: readonly AlbPathRule<T>[]
 ): T | undefined {
-  const { path, host } = typeof req === 'string' ? { path: req, host: undefined } : req;
-  const requestPath = pathOf(path);
-  const requestHost = host !== undefined ? hostOf(host) : undefined;
+  const facts: AlbRequestMatch = typeof req === 'string' ? { path: req } : req;
+  const requestPath = pathOf(facts.path);
+  const requestQuery = queryOf(facts.path);
+  const requestHost = facts.host !== undefined ? hostOf(facts.host) : undefined;
   const ordered = [...rules].sort((a, b) => a.priority - b.priority);
   for (const rule of ordered) {
-    if (ruleMatches(rule, requestPath, requestHost)) return rule.target;
+    if (ruleMatches(rule, requestPath, requestQuery, requestHost, facts)) return rule.target;
   }
   return undefined;
 }
 
 /**
- * Whether a single rule's conditions all match. A `path-pattern` /
- * `host-header` condition is satisfied when ANY of its values match (OR); a
- * rule with both fields requires both to match (AND). An empty pattern list
- * for a field means "no constraint on that field" (the condition was absent).
+ * Whether a single rule's conditions all match. Each present condition field
+ * is OR-matched within (multiple values) and AND'd across fields. An empty /
+ * absent condition list means "no constraint on that field" (the condition was
+ * absent on the rule).
  */
 function ruleMatches<T>(
   rule: AlbPathRule<T>,
   requestPath: string,
-  requestHost: string | undefined
+  requestQuery: string,
+  requestHost: string | undefined,
+  facts: AlbRequestMatch
 ): boolean {
   if (rule.pathPatterns.length > 0) {
     if (!rule.pathPatterns.some((pattern) => globToRegExp(pattern, false).test(requestPath))) {
@@ -89,11 +160,34 @@ function ruleMatches<T>(
   }
   const hostPatterns = rule.hostPatterns ?? [];
   if (hostPatterns.length > 0) {
-    // No Host header to match against -> a host-constrained rule cannot match.
     if (requestHost === undefined) return false;
     if (!hostPatterns.some((pattern) => globToRegExp(pattern, true).test(requestHost))) {
       return false;
     }
+  }
+  const headerConditions = rule.httpHeaderConditions ?? [];
+  if (headerConditions.length > 0) {
+    if (!headerConditions.every((cond) => httpHeaderConditionMatches(cond, facts.headers))) {
+      return false;
+    }
+  }
+  const methods = rule.httpRequestMethods ?? [];
+  if (methods.length > 0) {
+    if (facts.method === undefined) return false;
+    if (!methods.includes(facts.method)) return false;
+  }
+  const queryConditions = rule.queryStringConditions ?? [];
+  if (queryConditions.length > 0) {
+    const params = parseQueryParams(requestQuery);
+    if (!queryConditions.some((cond) => queryStringConditionMatches(cond, params))) {
+      return false;
+    }
+  }
+  const cidrs = rule.sourceIpCidrs ?? [];
+  if (cidrs.length > 0) {
+    if (facts.sourceIp === undefined) return false;
+    const ip = unmapV4MappedV6(facts.sourceIp);
+    if (!cidrs.some((cidr) => albCidrMatches(cidr, ip))) return false;
   }
   return true;
 }
@@ -115,6 +209,59 @@ export function albHostPatternMatches(pattern: string, requestHost: string): boo
   return globToRegExp(pattern, true).test(hostOf(requestHost));
 }
 
+/**
+ * Whether an `http-header` condition matches the request's headers. The
+ * header name is looked up case-insensitively; each listed value glob is
+ * matched case-insensitively against every value of that header (multi-valued
+ * headers count each value separately).
+ */
+export function httpHeaderConditionMatches(
+  cond: AlbHttpHeaderCondition,
+  headers: NodeJS.Dict<string | string[]> | undefined
+): boolean {
+  if (!headers) return false;
+  const targetName = cond.name.toLowerCase();
+  const rawValue = headerLookup(headers, targetName);
+  if (rawValue === undefined) return false;
+  const headerValues = Array.isArray(rawValue) ? rawValue : [rawValue];
+  return cond.values.some((glob) => {
+    const re = globToRegExp(glob, true);
+    return headerValues.some((v) => re.test(v.toLowerCase()));
+  });
+}
+
+/**
+ * Whether a single `query-string` condition `{ Key?, Value }` matches the
+ * request's parsed query parameters. Both Key and Value are case-insensitive
+ * `*` / `?` globs; when `Key` is absent, ANY parameter whose value matches the
+ * Value glob satisfies the condition.
+ */
+export function queryStringConditionMatches(
+  cond: AlbQueryStringCondition,
+  params: ReadonlyArray<{ key: string; value: string }>
+): boolean {
+  const valueRe = globToRegExp(cond.value, true);
+  const keyRe = cond.key !== undefined ? globToRegExp(cond.key, true) : undefined;
+  return params.some((p) => {
+    if (keyRe !== undefined && !keyRe.test(p.key.toLowerCase())) return false;
+    return valueRe.test(p.value.toLowerCase());
+  });
+}
+
+/**
+ * Whether an IPv4 or IPv6 address falls inside an IPv4 or IPv6 CIDR. Returns
+ * `false` for mismatched families (an IPv4 address tested against an IPv6
+ * CIDR, or vice versa) and for unparseable input.
+ */
+export function albCidrMatches(cidr: string, ip: string): boolean {
+  const parsed = parseCidr(cidr);
+  if (!parsed) return false;
+  const addr = parseIpAddress(ip);
+  if (!addr) return false;
+  if (parsed.family !== addr.family) return false;
+  return matchBitPrefix(parsed.bytes, addr.bytes, parsed.prefixLength);
+}
+
 /** Strip the query string / fragment so only the URL path is matched. */
 function pathOf(url: string): string {
   let end = url.length;
@@ -123,6 +270,45 @@ function pathOf(url: string): string {
   const h = url.indexOf('#');
   if (h !== -1 && h < end) end = h;
   return url.slice(0, end);
+}
+
+/**
+ * Pull the raw query string (`a=1&b=2`) out of a URL. Returns the empty string
+ * when the URL has no `?`. The fragment is dropped.
+ */
+function queryOf(url: string): string {
+  const q = url.indexOf('?');
+  if (q === -1) return '';
+  const rest = url.slice(q + 1);
+  const h = rest.indexOf('#');
+  return h === -1 ? rest : rest.slice(0, h);
+}
+
+/**
+ * Decode a raw query string into a flat list of `{ key, value }` entries
+ * (preserving repeats), URI-decoding both sides and treating `+` as a space
+ * (the `application/x-www-form-urlencoded` convention browsers use). Pairs
+ * with no `=` are treated as `{ key, value: '' }`.
+ */
+function parseQueryParams(query: string): Array<{ key: string; value: string }> {
+  if (!query) return [];
+  const out: Array<{ key: string; value: string }> = [];
+  for (const pair of query.split('&')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    const rawKey = eq === -1 ? pair : pair.slice(0, eq);
+    const rawValue = eq === -1 ? '' : pair.slice(eq + 1);
+    out.push({ key: decodeQueryPart(rawKey), value: decodeQueryPart(rawValue) });
+  }
+  return out;
+}
+
+function decodeQueryPart(s: string): string {
+  try {
+    return decodeURIComponent(s.replace(/\+/g, ' '));
+  } catch {
+    return s;
+  }
 }
 
 /**
@@ -143,14 +329,28 @@ function hostOf(host: string): string {
   return bare.toLowerCase();
 }
 
+/** Case-insensitive header lookup against a Node-style headers dict. */
+function headerLookup(
+  headers: NodeJS.Dict<string | string[]>,
+  lowerCaseName: string
+): string | string[] | undefined {
+  // Most callers already pass lower-cased keys (Node's IncomingMessage does),
+  // so a direct lookup is the fast path; fall back to a scan otherwise.
+  const direct = headers[lowerCaseName];
+  if (direct !== undefined) return direct;
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lowerCaseName) return headers[key];
+  }
+  return undefined;
+}
+
 const REGEXP_META = /[.+^${}()|[\]\\]/;
 
 /**
  * Translate an ALB `*` / `?` glob into an anchored RegExp: `*` -> `.*`,
- * `?` -> `.`, every other character is escaped and matched literally. Host
- * patterns match case-insensitively (the `i` flag) and the pattern is
- * lower-cased to pair with the lower-cased host; path patterns are
- * case-sensitive.
+ * `?` -> `.`, every other character is escaped and matched literally. The
+ * `caseInsensitive` form lower-cases the pattern (callers pair it with a
+ * lower-cased input); path patterns are case-sensitive.
  */
 function globToRegExp(pattern: string, caseInsensitive: boolean): RegExp {
   const source = caseInsensitive ? pattern.toLowerCase() : pattern;
@@ -162,4 +362,152 @@ function globToRegExp(pattern: string, caseInsensitive: boolean): RegExp {
     else body += ch;
   }
   return new RegExp(`^${body}$`);
+}
+
+interface CidrParsed {
+  family: 'v4' | 'v6';
+  bytes: Uint8Array;
+  prefixLength: number;
+}
+
+interface IpParsed {
+  family: 'v4' | 'v6';
+  bytes: Uint8Array;
+}
+
+/** Parse a CIDR (`ip/prefix`) into its address bytes + prefix length. */
+function parseCidr(cidr: string): CidrParsed | undefined {
+  const slash = cidr.indexOf('/');
+  if (slash === -1) return undefined;
+  const addrPart = cidr.slice(0, slash);
+  const prefixPart = cidr.slice(slash + 1);
+  if (!/^\d+$/.test(prefixPart)) return undefined;
+  const prefixLength = parseInt(prefixPart, 10);
+  const addr = parseIpAddress(addrPart);
+  if (!addr) return undefined;
+  const maxPrefix = addr.family === 'v4' ? 32 : 128;
+  if (prefixLength < 0 || prefixLength > maxPrefix) return undefined;
+  return { family: addr.family, bytes: addr.bytes, prefixLength };
+}
+
+/** Parse an IPv4 (`1.2.3.4`) or IPv6 address into its byte representation. */
+function parseIpAddress(ip: string): IpParsed | undefined {
+  if (ip.includes('.') && !ip.includes(':')) {
+    return parseIpv4(ip);
+  }
+  if (ip.includes(':')) {
+    return parseIpv6(ip);
+  }
+  return undefined;
+}
+
+function parseIpv4(ip: string): IpParsed | undefined {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return undefined;
+  const bytes = new Uint8Array(4);
+  for (let i = 0; i < 4; i++) {
+    const part = parts[i]!;
+    if (!/^\d+$/.test(part)) return undefined;
+    const n = parseInt(part, 10);
+    if (n < 0 || n > 255) return undefined;
+    bytes[i] = n;
+  }
+  return { family: 'v4', bytes };
+}
+
+/**
+ * Parse a textual IPv6 address (incl. `::` shorthand and IPv4-suffix form like
+ * `::ffff:1.2.3.4`) into its 16-byte representation.
+ */
+function parseIpv6(ip: string): IpParsed | undefined {
+  // Strip bracketed form (`[::1]` -> `::1`).
+  let s = ip;
+  if (s.startsWith('[') && s.endsWith(']')) s = s.slice(1, -1);
+
+  // Split off an embedded IPv4 suffix (`::ffff:1.2.3.4`).
+  let v4Suffix: Uint8Array | undefined;
+  const lastColon = s.lastIndexOf(':');
+  if (lastColon !== -1 && s.slice(lastColon + 1).includes('.')) {
+    const v4Part = s.slice(lastColon + 1);
+    const parsed = parseIpv4(v4Part);
+    if (!parsed) return undefined;
+    v4Suffix = parsed.bytes;
+    s = s.slice(0, lastColon) + ':0:0';
+  }
+
+  const doubleColon = s.indexOf('::');
+  let head: string[];
+  let tail: string[];
+  if (doubleColon === -1) {
+    head = s.split(':');
+    tail = [];
+  } else {
+    head = s.slice(0, doubleColon) === '' ? [] : s.slice(0, doubleColon).split(':');
+    tail = s.slice(doubleColon + 2) === '' ? [] : s.slice(doubleColon + 2).split(':');
+  }
+  if (head.length + tail.length > 8) return undefined;
+  if (doubleColon === -1 && head.length !== 8) return undefined;
+
+  const groups: number[] = new Array(8).fill(0);
+  for (let i = 0; i < head.length; i++) {
+    const g = parseHexGroup(head[i]!);
+    if (g === undefined) return undefined;
+    groups[i] = g;
+  }
+  for (let i = 0; i < tail.length; i++) {
+    const g = parseHexGroup(tail[tail.length - 1 - i]!);
+    if (g === undefined) return undefined;
+    groups[7 - i] = g;
+  }
+
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 8; i++) {
+    bytes[i * 2] = (groups[i]! >> 8) & 0xff;
+    bytes[i * 2 + 1] = groups[i]! & 0xff;
+  }
+  if (v4Suffix) {
+    bytes[12] = v4Suffix[0]!;
+    bytes[13] = v4Suffix[1]!;
+    bytes[14] = v4Suffix[2]!;
+    bytes[15] = v4Suffix[3]!;
+  }
+  return { family: 'v6', bytes };
+}
+
+function parseHexGroup(g: string): number | undefined {
+  if (g.length === 0 || g.length > 4) return undefined;
+  if (!/^[0-9a-fA-F]+$/.test(g)) return undefined;
+  return parseInt(g, 16);
+}
+
+/**
+ * Unmap an IPv4-mapped IPv6 source IP (`::ffff:a.b.c.d` or `::ffff:NNNN:NNNN`)
+ * to its bare IPv4 form. Node reports `::ffff:127.0.0.1` for an IPv4 client on
+ * a dual-stack listener; rules that name a v4 CIDR should still match.
+ */
+function unmapV4MappedV6(ip: string): string {
+  const m = /^::ffff:(.+)$/i.exec(ip);
+  if (!m) return ip;
+  const suffix = m[1]!;
+  if (suffix.includes('.')) return suffix;
+  // `::ffff:7f00:1` form -> reconstruct dotted quad.
+  const parts = suffix.split(':');
+  if (parts.length !== 2) return ip;
+  const high = parseInt(parts[0]!, 16);
+  const low = parseInt(parts[1]!, 16);
+  if (!Number.isFinite(high) || !Number.isFinite(low)) return ip;
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+}
+
+/** Whether the first `prefixLength` bits of `a` equal those of `b`. */
+function matchBitPrefix(a: Uint8Array, b: Uint8Array, prefixLength: number): boolean {
+  if (a.length !== b.length) return false;
+  const fullBytes = Math.floor(prefixLength / 8);
+  for (let i = 0; i < fullBytes; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  const remainingBits = prefixLength % 8;
+  if (remainingBits === 0) return true;
+  const mask = 0xff << (8 - remainingBits);
+  return (a[fullBytes]! & mask) === (b[fullBytes]! & mask);
 }

--- a/src/local/elb-front-door-resolver.ts
+++ b/src/local/elb-front-door-resolver.ts
@@ -680,7 +680,15 @@ function parseRuleConditions(
     } else if (field === 'http-request-method') {
       out.httpRequestMethods.push(...conditionValues(c, 'HttpRequestMethodConfig'));
     } else if (field === 'query-string') {
-      out.queryStringConditions.push(...parseQueryStringConditionValues(c));
+      const { parsed, hadEntries } = parseQueryStringConditionValues(c);
+      if (hadEntries && parsed.length === 0) {
+        warnings.push(
+          `${ruleLabel} query-string condition has no parseable { Key?, Value } entries; skipping ` +
+            'the rule.'
+        );
+        return undefined;
+      }
+      out.queryStringConditions.push(...parsed);
     } else if (field === 'source-ip') {
       const values = conditionValues(c, 'SourceIpConfig');
       const invalid = values.filter((v) => !isValidCidr(v));
@@ -723,9 +731,15 @@ function parseHttpHeaderCondition(
  * Parse a `query-string` condition's `Values` into `{ key?, value }` pairs.
  * ALB accepts either object entries (`{ Key?, Value }`) or bare strings
  * (legacy v1 shape: a string is treated as `{ value }`). Non-string `Key` /
- * `Value` fields are dropped; an entry with no `Value` is dropped.
+ * `Value` fields are dropped; an entry with no `Value` is dropped. Returns
+ * `hadEntries` so the caller can distinguish an absent / empty `Values` array
+ * (drop the field silently) from one whose entries were all unparseable
+ * (warn + skip the whole rule — silently dropping would widen routing).
  */
-function parseQueryStringConditionValues(cond: Record<string, unknown>): AlbQueryStringCondition[] {
+function parseQueryStringConditionValues(cond: Record<string, unknown>): {
+  parsed: AlbQueryStringCondition[];
+  hadEntries: boolean;
+} {
   const cfg = cond['QueryStringConfig'];
   const rawValues =
     cfg && typeof cfg === 'object' && Array.isArray((cfg as Record<string, unknown>)['Values'])
@@ -733,19 +747,19 @@ function parseQueryStringConditionValues(cond: Record<string, unknown>): AlbQuer
       : Array.isArray(cond['Values'])
         ? (cond['Values'] as unknown[])
         : [];
-  const out: AlbQueryStringCondition[] = [];
+  const parsed: AlbQueryStringCondition[] = [];
   for (const v of rawValues) {
     if (typeof v === 'string') {
-      out.push({ value: v });
+      parsed.push({ value: v });
     } else if (v && typeof v === 'object') {
       const e = v as Record<string, unknown>;
       const value = e['Value'];
       if (typeof value !== 'string') continue;
       const key = e['Key'];
-      out.push(typeof key === 'string' ? { key, value } : { value });
+      parsed.push(typeof key === 'string' ? { key, value } : { value });
     }
   }
-  return out;
+  return { parsed, hadEntries: rawValues.length > 0 };
 }
 
 /**

--- a/src/local/elb-front-door-resolver.ts
+++ b/src/local/elb-front-door-resolver.ts
@@ -1,5 +1,6 @@
 import type { StackInfo } from '../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../types/resource.js';
+import type { AlbHttpHeaderCondition, AlbQueryStringCondition } from './alb-path-matcher.js';
 
 /**
  * Resolve an `AWS::ElasticLoadBalancingV2::LoadBalancer` (an ALB) into the
@@ -17,7 +18,11 @@ import type { TemplateResource } from '../types/resource.js';
  *     DefaultActions:[ <action> ] }
  * ElasticLoadBalancingV2::ListenerRule  : { ListenerArn:{Ref:<Listener>}, Priority,
  *     Conditions:[{ Field:"path-pattern", PathPatternConfig:{ Values:["/api/*"] } },
- *                 { Field:"host-header",  HostHeaderConfig:{ Values:["api.example.com"] } }],
+ *                 { Field:"host-header",  HostHeaderConfig:{ Values:["api.example.com"] } },
+ *                 { Field:"http-header",  HttpHeaderConfig:{ HttpHeaderName:"X-API", Values:["*"] } },
+ *                 { Field:"http-request-method", HttpRequestMethodConfig:{ Values:["POST"] } },
+ *                 { Field:"query-string", QueryStringConfig:{ Values:[{ Key:"v", Value:"1" }] } },
+ *                 { Field:"source-ip",    SourceIpConfig:{ Values:["10.0.0.0/8"] } }],
  *     Actions:[ <action> ] }
  * ElasticLoadBalancingV2::TargetGroup   : { Port, Protocol, TargetType:"ip" }
  * ECS::Service.LoadBalancers[]          -> { ContainerName, ContainerPort, TargetGroupArn:{Ref:<TG>} }
@@ -35,16 +40,16 @@ import type { TemplateResource } from '../types/resource.js';
  * `LoadBalancers[]` references each target group (a reverse scan; there is no
  * direct TG -> service pointer). Output is a per-listener routing table: a
  * default action plus the ordered rules, each carrying its resolved action and
- * its path / host conditions.
+ * its full set of routing conditions.
  *
- * Scope: HTTP listeners; `path-pattern` + `host-header` conditions; `forward`
- * (single or weighted) to ECS services AND/OR Lambda functions
- * (`TargetType:"lambda"` target groups — #123: the TG -> backing
+ * Scope: HTTP listeners; all six ALB rule-condition fields (`path-pattern`,
+ * `host-header`, `http-header`, `http-request-method`, `query-string`,
+ * `source-ip`); `forward` (single or weighted) to ECS services AND/OR Lambda
+ * functions (`TargetType:"lambda"` target groups — #123: the TG -> backing
  * `AWS::Lambda::Function` is resolved and the front-door invokes it locally per
  * request); `redirect` / `fixed-response` actions. A single weighted forward may
- * mix ECS and Lambda targets. Skipped with a warning: HTTPS/TLS listeners, the
- * other condition fields (http-header / http-request-method / query-string /
- * source-ip), and `authenticate-cognito` / `authenticate-oidc` actions.
+ * mix ECS and Lambda targets. Skipped with a warning: HTTPS/TLS listeners and
+ * `authenticate-cognito` / `authenticate-oidc` actions.
  */
 
 const ALB_TYPE = 'AWS::ElasticLoadBalancingV2::LoadBalancer';
@@ -156,7 +161,7 @@ export type ResolvedListenerAction =
   | FrontDoorRedirectAction
   | FrontDoorFixedResponseAction;
 
-/** One resolved routing rule on a listener (path / host conditions + an action). */
+/** One resolved routing rule on a listener — all six ALB condition fields + an action. */
 export interface ResolvedListenerRule {
   /** ALB rule priority (lower = evaluated first). */
   priority: number;
@@ -164,6 +169,14 @@ export interface ResolvedListenerRule {
   pathPatterns: string[];
   /** The rule's `host-header` condition values (OR-matched; empty = no host constraint). */
   hostPatterns: string[];
+  /** The rule's `http-header` conditions (each AND'd; values within OR; empty = no header constraint). */
+  httpHeaderConditions: AlbHttpHeaderCondition[];
+  /** The rule's `http-request-method` values (OR-matched, exact; empty = no method constraint). */
+  httpRequestMethods: string[];
+  /** The rule's `query-string` `{ Key?, Value }` pairs (OR-matched; empty = no query-string constraint). */
+  queryStringConditions: AlbQueryStringCondition[];
+  /** The rule's `source-ip` CIDR values (OR-matched; empty = no source-IP constraint). */
+  sourceIpCidrs: string[];
   /** The action this rule performs when its conditions match. */
   action: ResolvedListenerAction;
 }
@@ -243,18 +256,27 @@ export function resolveAlbFrontDoor(
     for (const { ruleLogicalId, ruleProps } of rulesByListener.get(listenerLogicalId) ?? []) {
       const priority = parsePriority(ruleProps['Priority']);
       const ruleLabel = `Listener rule '${ruleLogicalId}' (priority ${priority})`;
-      const { pathPatterns, hostPatterns, unsupported } = parseRuleConditions(
-        ruleProps['Conditions']
-      );
-      if (unsupported.length > 0) {
-        warnings.push(
-          `${ruleLabel} uses unsupported condition(s): ${unsupported.join(', ')}. The local ALB ` +
-            'front-door supports path-pattern and host-header conditions only (http-header / ' +
-            'query-string / http-request-method / source-ip deferred). Skipping it.'
-        );
+      const parsed = parseRuleConditions(ruleProps['Conditions'], ruleLabel, warnings);
+      if (!parsed) {
+        // parseRuleConditions warned about an unsupported / malformed condition.
         continue;
       }
-      if (pathPatterns.length === 0 && hostPatterns.length === 0) {
+      const {
+        pathPatterns,
+        hostPatterns,
+        httpHeaderConditions,
+        httpRequestMethods,
+        queryStringConditions,
+        sourceIpCidrs,
+      } = parsed;
+      const hasAnyCondition =
+        pathPatterns.length > 0 ||
+        hostPatterns.length > 0 ||
+        httpHeaderConditions.length > 0 ||
+        httpRequestMethods.length > 0 ||
+        queryStringConditions.length > 0 ||
+        sourceIpCidrs.length > 0;
+      if (!hasAnyCondition) {
         // No supported condition to route on (an empty / catch-all rule).
         continue;
       }
@@ -267,7 +289,16 @@ export function resolveAlbFrontDoor(
         warnings
       );
       if (!action) continue; // resolveAction already warned (or it was an authenticate-* action)
-      rules.push({ priority, pathPatterns, hostPatterns, action });
+      rules.push({
+        priority,
+        pathPatterns,
+        hostPatterns,
+        httpHeaderConditions,
+        httpRequestMethods,
+        queryStringConditions,
+        sourceIpCidrs,
+        action,
+      });
     }
 
     if (!defaultAction && rules.length === 0) {
@@ -590,35 +621,155 @@ function indexRulesByListener(
   return index;
 }
 
-/**
- * Parse a ListenerRule's `Conditions` into its supported `path-pattern` and
- * `host-header` values plus the field names of any unsupported conditions
- * (which make the rule unsupported). ALB ANDs conditions of different fields,
- * so a rule with an unsupported field cannot be honored locally. Multiple
- * conditions of the same field merge their values (each field OR-matches).
- */
-function parseRuleConditions(conditions: unknown): {
+interface ParsedRuleConditions {
   pathPatterns: string[];
   hostPatterns: string[];
-  unsupported: string[];
-} {
-  const pathPatterns: string[] = [];
-  const hostPatterns: string[] = [];
-  const unsupported: string[] = [];
-  if (!Array.isArray(conditions)) return { pathPatterns, hostPatterns, unsupported };
+  httpHeaderConditions: AlbHttpHeaderCondition[];
+  httpRequestMethods: string[];
+  queryStringConditions: AlbQueryStringCondition[];
+  sourceIpCidrs: string[];
+}
+
+/**
+ * Parse a ListenerRule's `Conditions` into the six supported fields. Returns
+ * `undefined` when an unknown field is encountered or a known field is
+ * malformed enough that honoring the rule would silently drop a constraint
+ * — both surface a warning and skip the whole rule (ALB ANDs conditions of
+ * different fields, so dropping any condition would route requests it should
+ * not).
+ *
+ * Multiple `http-header` conditions on different names are kept (they AND).
+ * Multiple `path-pattern` / `host-header` / `http-request-method` /
+ * `query-string` / `source-ip` conditions on the same field merge their
+ * values (each field OR-matches). A `source-ip` value that does not parse as
+ * a CIDR makes the whole rule unsupported (the rule's authoring intent was
+ * specific; dropping the invalid range would silently widen the allow list).
+ */
+function parseRuleConditions(
+  conditions: unknown,
+  ruleLabel: string,
+  warnings: string[]
+): ParsedRuleConditions | undefined {
+  const out: ParsedRuleConditions = {
+    pathPatterns: [],
+    hostPatterns: [],
+    httpHeaderConditions: [],
+    httpRequestMethods: [],
+    queryStringConditions: [],
+    sourceIpCidrs: [],
+  };
+  if (!Array.isArray(conditions)) return out;
   for (const cond of conditions) {
     if (!cond || typeof cond !== 'object') continue;
     const c = cond as Record<string, unknown>;
     const field = typeof c['Field'] === 'string' ? c['Field'] : '(unknown)';
     if (field === 'path-pattern') {
-      pathPatterns.push(...conditionValues(c, 'PathPatternConfig'));
+      out.pathPatterns.push(...conditionValues(c, 'PathPatternConfig'));
     } else if (field === 'host-header') {
-      hostPatterns.push(...conditionValues(c, 'HostHeaderConfig'));
+      out.hostPatterns.push(...conditionValues(c, 'HostHeaderConfig'));
+    } else if (field === 'http-header') {
+      const parsed = parseHttpHeaderCondition(c);
+      if (!parsed) {
+        warnings.push(
+          `${ruleLabel} has an http-header condition with no HttpHeaderName / Values; skipping ` +
+            'the rule.'
+        );
+        return undefined;
+      }
+      out.httpHeaderConditions.push(parsed);
+    } else if (field === 'http-request-method') {
+      out.httpRequestMethods.push(...conditionValues(c, 'HttpRequestMethodConfig'));
+    } else if (field === 'query-string') {
+      out.queryStringConditions.push(...parseQueryStringConditionValues(c));
+    } else if (field === 'source-ip') {
+      const values = conditionValues(c, 'SourceIpConfig');
+      const invalid = values.filter((v) => !isValidCidr(v));
+      if (invalid.length > 0) {
+        warnings.push(
+          `${ruleLabel} source-ip condition has unparseable CIDR(s): ${invalid.join(', ')}. ` +
+            'The local ALB front-door requires valid IPv4 / IPv6 CIDRs; skipping the rule.'
+        );
+        return undefined;
+      }
+      out.sourceIpCidrs.push(...values);
     } else {
-      unsupported.push(field);
+      warnings.push(`${ruleLabel} uses unsupported condition field '${field}'. Skipping the rule.`);
+      return undefined;
     }
   }
-  return { pathPatterns, hostPatterns, unsupported };
+  return out;
+}
+
+/**
+ * Parse an `http-header` condition into its `{ name, values }` form. Returns
+ * `undefined` when `HttpHeaderName` is missing / non-string or `Values` is
+ * empty (either makes the rule's authoring intent unrecoverable).
+ */
+function parseHttpHeaderCondition(
+  cond: Record<string, unknown>
+): AlbHttpHeaderCondition | undefined {
+  const cfg = cond['HttpHeaderConfig'];
+  if (!cfg || typeof cfg !== 'object') return undefined;
+  const c = cfg as Record<string, unknown>;
+  const name = c['HttpHeaderName'];
+  if (typeof name !== 'string' || name.length === 0) return undefined;
+  const rawValues = Array.isArray(c['Values']) ? (c['Values'] as unknown[]) : [];
+  const values = rawValues.filter((v): v is string => typeof v === 'string');
+  if (values.length === 0) return undefined;
+  return { name, values };
+}
+
+/**
+ * Parse a `query-string` condition's `Values` into `{ key?, value }` pairs.
+ * ALB accepts either object entries (`{ Key?, Value }`) or bare strings
+ * (legacy v1 shape: a string is treated as `{ value }`). Non-string `Key` /
+ * `Value` fields are dropped; an entry with no `Value` is dropped.
+ */
+function parseQueryStringConditionValues(cond: Record<string, unknown>): AlbQueryStringCondition[] {
+  const cfg = cond['QueryStringConfig'];
+  const rawValues =
+    cfg && typeof cfg === 'object' && Array.isArray((cfg as Record<string, unknown>)['Values'])
+      ? ((cfg as Record<string, unknown>)['Values'] as unknown[])
+      : Array.isArray(cond['Values'])
+        ? (cond['Values'] as unknown[])
+        : [];
+  const out: AlbQueryStringCondition[] = [];
+  for (const v of rawValues) {
+    if (typeof v === 'string') {
+      out.push({ value: v });
+    } else if (v && typeof v === 'object') {
+      const e = v as Record<string, unknown>;
+      const value = e['Value'];
+      if (typeof value !== 'string') continue;
+      const key = e['Key'];
+      out.push(typeof key === 'string' ? { key, value } : { value });
+    }
+  }
+  return out;
+}
+
+/**
+ * Cheap CIDR validity check used at parse time. Mirrors the more permissive
+ * matcher (`albCidrMatches`) but only confirms shape; we do not need to
+ * remember the parsed bytes here.
+ */
+function isValidCidr(value: string): boolean {
+  const slash = value.indexOf('/');
+  if (slash === -1) return false;
+  const addr = value.slice(0, slash);
+  const prefix = value.slice(slash + 1);
+  if (!/^\d+$/.test(prefix)) return false;
+  const prefixLen = parseInt(prefix, 10);
+  if (addr.includes('.') && !addr.includes(':')) {
+    const parts = addr.split('.');
+    if (parts.length !== 4) return false;
+    if (!parts.every((p) => /^\d+$/.test(p) && parseInt(p, 10) <= 255)) return false;
+    return prefixLen >= 0 && prefixLen <= 32;
+  }
+  if (addr.includes(':')) {
+    return prefixLen >= 0 && prefixLen <= 128;
+  }
+  return false;
 }
 
 /**

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -126,12 +126,22 @@ export interface FixedResponseRouteAction {
 /** What the front-door does for a request: forward / redirect / fixed-response. */
 export type RouteAction = ForwardRouteAction | RedirectRouteAction | FixedResponseRouteAction;
 
-/** The request facts the route resolver is handed (path + Host header). */
+/**
+ * The request facts the route resolver is handed (path + Host header + all
+ * other ALB-condition-relevant fields). The matcher strips the query for
+ * path-pattern matching but uses it for query-string conditions.
+ */
 export interface FrontDoorRouteRequest {
   /** Request URL (path + query); the matcher strips the query for path-pattern. */
   path: string;
   /** Request `Host` header (for host-header rule matching). */
   host?: string;
+  /** Raw incoming request headers (for http-header rule matching). */
+  headers?: NodeJS.Dict<string | string[]>;
+  /** Request method (e.g. `GET`) for http-request-method rule matching. */
+  method?: string;
+  /** Connection source IP for source-ip rule matching. */
+  sourceIp?: string;
 }
 
 export interface StartFrontDoorServerOptions {
@@ -257,7 +267,13 @@ function handleProxyRequest(
   // fixed-response) takes precedence. The single-target selectors are a
   // convenience for callers that never weight / redirect.
   if (opts.route) {
-    const action = opts.route({ path: url, ...hostHeader(req) });
+    const action = opts.route({
+      path: url,
+      ...hostHeader(req),
+      headers: req.headers,
+      ...(req.method !== undefined && { method: req.method }),
+      ...(req.socket.remoteAddress !== undefined && { sourceIp: req.socket.remoteAddress }),
+    });
     if (!action) return reply404(req, res, opts);
 
     if (action.kind === 'redirect' || action.kind === 'fixed-response') {

--- a/tests/unit/local/alb-path-matcher.test.ts
+++ b/tests/unit/local/alb-path-matcher.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
-  albPathPatternMatches,
+  albCidrMatches,
   albHostPatternMatches,
+  albPathPatternMatches,
+  httpHeaderConditionMatches,
   matchAlbPathRule,
+  queryStringConditionMatches,
   type AlbPathRule,
 } from '../../../src/local/alb-path-matcher.js';
 
@@ -145,5 +148,244 @@ describe('matchAlbPathRule with host-header conditions', () => {
 
   it('matches the Host header case-insensitively and ignores the :port', () => {
     expect(matchAlbPathRule({ path: '/', host: 'API.EXAMPLE.COM:8080' }, rules)).toBe('api-host');
+  });
+});
+
+describe('httpHeaderConditionMatches', () => {
+  it('looks up the header case-insensitively', () => {
+    expect(
+      httpHeaderConditionMatches({ name: 'X-Tenant', values: ['acme'] }, { 'x-tenant': 'acme' })
+    ).toBe(true);
+    expect(
+      httpHeaderConditionMatches({ name: 'X-TENANT', values: ['acme'] }, { 'X-Tenant': 'acme' })
+    ).toBe(true);
+  });
+
+  it('OR-matches the value globs (case-insensitive value comparison)', () => {
+    const cond = { name: 'X-Plan', values: ['ENTERPRISE', 'team*'] };
+    expect(httpHeaderConditionMatches(cond, { 'x-plan': 'enterprise' })).toBe(true);
+    expect(httpHeaderConditionMatches(cond, { 'x-plan': 'TEAM-LITE' })).toBe(true);
+    expect(httpHeaderConditionMatches(cond, { 'x-plan': 'free' })).toBe(false);
+  });
+
+  it('matches when ANY value of a multi-valued header satisfies the glob', () => {
+    const cond = { name: 'Accept', values: ['application/json'] };
+    expect(httpHeaderConditionMatches(cond, { accept: ['text/html', 'application/json'] })).toBe(
+      true
+    );
+    expect(httpHeaderConditionMatches(cond, { accept: ['text/html'] })).toBe(false);
+  });
+
+  it('returns false when the header is missing or the headers dict is undefined', () => {
+    expect(httpHeaderConditionMatches({ name: 'X-Tenant', values: ['*'] }, undefined)).toBe(false);
+    expect(httpHeaderConditionMatches({ name: 'X-Tenant', values: ['*'] }, {})).toBe(false);
+  });
+});
+
+describe('queryStringConditionMatches', () => {
+  it('matches a Key+Value pair (case-insensitive)', () => {
+    expect(
+      queryStringConditionMatches({ key: 'Version', value: '2' }, [{ key: 'version', value: '2' }])
+    ).toBe(true);
+    expect(
+      queryStringConditionMatches({ key: 'version', value: 'V2' }, [{ key: 'version', value: 'v2' }])
+    ).toBe(true);
+  });
+
+  it('honors * / ? wildcards in both Key and Value', () => {
+    expect(
+      queryStringConditionMatches({ key: 'tag-*', value: 'beta*' }, [
+        { key: 'tag-rollout', value: 'beta-3' },
+      ])
+    ).toBe(true);
+    expect(
+      queryStringConditionMatches({ key: 'tag-?', value: '?' }, [{ key: 'tag-x', value: 'b' }])
+    ).toBe(true);
+  });
+
+  it('matches ANY key when Key is omitted', () => {
+    const cond = { value: 'beta' };
+    expect(queryStringConditionMatches(cond, [{ key: 'flag', value: 'beta' }])).toBe(true);
+    expect(queryStringConditionMatches(cond, [{ key: 'other', value: 'beta' }])).toBe(true);
+    expect(queryStringConditionMatches(cond, [{ key: 'flag', value: 'alpha' }])).toBe(false);
+  });
+
+  it('returns false when no parameter matches', () => {
+    expect(
+      queryStringConditionMatches({ key: 'v', value: '1' }, [{ key: 'v', value: '2' }])
+    ).toBe(false);
+    expect(queryStringConditionMatches({ key: 'v', value: '1' }, [])).toBe(false);
+  });
+});
+
+describe('albCidrMatches', () => {
+  it('matches an IPv4 address inside a /24', () => {
+    expect(albCidrMatches('192.0.2.0/24', '192.0.2.42')).toBe(true);
+    expect(albCidrMatches('192.0.2.0/24', '192.0.3.1')).toBe(false);
+  });
+
+  it('matches an exact IPv4 with /32', () => {
+    expect(albCidrMatches('192.0.2.42/32', '192.0.2.42')).toBe(true);
+    expect(albCidrMatches('192.0.2.42/32', '192.0.2.43')).toBe(false);
+  });
+
+  it('matches the full IPv4 range with /0', () => {
+    expect(albCidrMatches('0.0.0.0/0', '8.8.8.8')).toBe(true);
+  });
+
+  it('matches an IPv6 address inside a /32', () => {
+    expect(albCidrMatches('2001:db8::/32', '2001:db8:1234::1')).toBe(true);
+    expect(albCidrMatches('2001:db8::/32', '2001:db9::1')).toBe(false);
+  });
+
+  it('matches an IPv6 ::1 inside ::/0', () => {
+    expect(albCidrMatches('::/0', '::1')).toBe(true);
+  });
+
+  it('does not cross-match IPv4 against IPv6 or vice versa', () => {
+    expect(albCidrMatches('192.0.2.0/24', '::1')).toBe(false);
+    expect(albCidrMatches('2001:db8::/32', '192.0.2.1')).toBe(false);
+  });
+
+  it('returns false for unparseable input', () => {
+    expect(albCidrMatches('not-a-cidr', '192.0.2.1')).toBe(false);
+    expect(albCidrMatches('192.0.2.0/33', '192.0.2.1')).toBe(false);
+    expect(albCidrMatches('192.0.2.0/24', 'not-an-ip')).toBe(false);
+  });
+});
+
+describe('matchAlbPathRule with new condition fields', () => {
+  it('honors an http-header condition (one rule, OR-matched values)', () => {
+    const rules: AlbPathRule<string>[] = [
+      {
+        priority: 5,
+        pathPatterns: [],
+        httpHeaderConditions: [{ name: 'X-Tenant', values: ['acme'] }],
+        target: 'tenant-acme',
+      },
+    ];
+    expect(matchAlbPathRule({ path: '/', headers: { 'x-tenant': 'acme' } }, rules)).toBe(
+      'tenant-acme'
+    );
+    expect(matchAlbPathRule({ path: '/', headers: { 'x-tenant': 'other' } }, rules)).toBeUndefined();
+    expect(matchAlbPathRule({ path: '/' }, rules)).toBeUndefined();
+  });
+
+  it('ANDs multiple http-header conditions on one rule', () => {
+    const rules: AlbPathRule<string>[] = [
+      {
+        priority: 5,
+        pathPatterns: [],
+        httpHeaderConditions: [
+          { name: 'X-Tenant', values: ['acme'] },
+          { name: 'X-Env', values: ['prod'] },
+        ],
+        target: 'acme-prod',
+      },
+    ];
+    expect(
+      matchAlbPathRule({ path: '/', headers: { 'x-tenant': 'acme', 'x-env': 'prod' } }, rules)
+    ).toBe('acme-prod');
+    expect(
+      matchAlbPathRule({ path: '/', headers: { 'x-tenant': 'acme', 'x-env': 'dev' } }, rules)
+    ).toBeUndefined();
+  });
+
+  it('honors an http-request-method condition (OR-matched, exact, case-sensitive)', () => {
+    const rules: AlbPathRule<string>[] = [
+      { priority: 5, pathPatterns: [], httpRequestMethods: ['POST', 'PUT'], target: 'writes' },
+    ];
+    expect(matchAlbPathRule({ path: '/', method: 'POST' }, rules)).toBe('writes');
+    expect(matchAlbPathRule({ path: '/', method: 'PUT' }, rules)).toBe('writes');
+    expect(matchAlbPathRule({ path: '/', method: 'GET' }, rules)).toBeUndefined();
+    // ALB is case-sensitive uppercase; lower-case is NOT auto-matched.
+    expect(matchAlbPathRule({ path: '/', method: 'post' }, rules)).toBeUndefined();
+  });
+
+  it('honors a query-string condition (OR-matched Key+Value entries)', () => {
+    const rules: AlbPathRule<string>[] = [
+      {
+        priority: 5,
+        pathPatterns: [],
+        queryStringConditions: [{ key: 'v', value: '2' }, { value: '*beta*' }],
+        target: 'q-match',
+      },
+    ];
+    expect(matchAlbPathRule({ path: '/?v=2' }, rules)).toBe('q-match');
+    expect(matchAlbPathRule({ path: '/?flag=mybeta1' }, rules)).toBe('q-match');
+    expect(matchAlbPathRule({ path: '/?v=1' }, rules)).toBeUndefined();
+    expect(matchAlbPathRule({ path: '/' }, rules)).toBeUndefined();
+  });
+
+  it('decodes percent-encoded query parameters before matching', () => {
+    const rules: AlbPathRule<string>[] = [
+      {
+        priority: 5,
+        pathPatterns: [],
+        queryStringConditions: [{ key: 'name', value: 'a b' }],
+        target: 'q-decoded',
+      },
+    ];
+    expect(matchAlbPathRule({ path: '/?name=a%20b' }, rules)).toBe('q-decoded');
+    expect(matchAlbPathRule({ path: '/?name=a+b' }, rules)).toBe('q-decoded');
+  });
+
+  it('honors a source-ip condition (OR-matched CIDRs, IPv4 + IPv6)', () => {
+    const rules: AlbPathRule<string>[] = [
+      {
+        priority: 5,
+        pathPatterns: [],
+        sourceIpCidrs: ['10.0.0.0/8', '2001:db8::/32'],
+        target: 'internal',
+      },
+    ];
+    expect(matchAlbPathRule({ path: '/', sourceIp: '10.1.2.3' }, rules)).toBe('internal');
+    expect(matchAlbPathRule({ path: '/', sourceIp: '2001:db8:42::1' }, rules)).toBe('internal');
+    expect(matchAlbPathRule({ path: '/', sourceIp: '8.8.8.8' }, rules)).toBeUndefined();
+    expect(matchAlbPathRule({ path: '/' }, rules)).toBeUndefined();
+  });
+
+  it('unmaps an IPv4-mapped IPv6 source IP (::ffff:127.0.0.1) for IPv4 CIDR matching', () => {
+    const rules: AlbPathRule<string>[] = [
+      { priority: 5, pathPatterns: [], sourceIpCidrs: ['127.0.0.0/8'], target: 'loopback' },
+    ];
+    expect(matchAlbPathRule({ path: '/', sourceIp: '::ffff:127.0.0.1' }, rules)).toBe('loopback');
+  });
+
+  it('ANDs path-pattern + http-header + http-request-method + query-string + source-ip on one rule', () => {
+    const rules: AlbPathRule<string>[] = [
+      {
+        priority: 5,
+        pathPatterns: ['/api/*'],
+        httpHeaderConditions: [{ name: 'X-API', values: ['v2'] }],
+        httpRequestMethods: ['POST'],
+        queryStringConditions: [{ key: 'v', value: '1' }],
+        sourceIpCidrs: ['10.0.0.0/8'],
+        target: 'full-match',
+      },
+    ];
+    expect(
+      matchAlbPathRule(
+        {
+          path: '/api/x?v=1',
+          method: 'POST',
+          headers: { 'x-api': 'v2' },
+          sourceIp: '10.1.2.3',
+        },
+        rules
+      )
+    ).toBe('full-match');
+    // Drop just the method -> the rule no longer matches.
+    expect(
+      matchAlbPathRule(
+        {
+          path: '/api/x?v=1',
+          method: 'GET',
+          headers: { 'x-api': 'v2' },
+          sourceIp: '10.1.2.3',
+        },
+        rules
+      )
+    ).toBeUndefined();
   });
 });

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -161,6 +161,10 @@ describe('resolveAlbFrontDoor', () => {
         priority: 10,
         pathPatterns: ['/api/*'],
         hostPatterns: [],
+        httpHeaderConditions: [],
+        httpRequestMethods: [],
+        queryStringConditions: [],
+        sourceIpCidrs: [],
         action: {
           kind: 'forward',
           targets: [
@@ -457,7 +461,26 @@ describe('resolveAlbFrontDoor', () => {
     expect(listeners[0]!.rules[0]!.pathPatterns).toEqual(['/legacy/*']);
   });
 
-  it('skips + warns on a rule with a still-unsupported condition field (http-header)', () => {
+  it('skips + warns on a rule with an unknown condition field', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [{ Field: 'not-a-real-field', Values: ['x'] }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    // The listener still resolves via its default forward; only the rule is dropped.
+    expect(listeners[0]!.rules).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/unsupported condition field 'not-a-real-field'/);
+  });
+
+  it('resolves an http-header condition (name + values)', () => {
     const stack = stackWith({
       ...apiServiceResources,
       [RULE]: {
@@ -468,7 +491,7 @@ describe('resolveAlbFrontDoor', () => {
           Conditions: [
             {
               Field: 'http-header',
-              HttpHeaderConfig: { HttpHeaderName: 'X-Custom', Values: ['yes'] },
+              HttpHeaderConfig: { HttpHeaderName: 'X-Tenant', Values: ['acme', 'globex'] },
             },
           ],
           Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
@@ -476,9 +499,172 @@ describe('resolveAlbFrontDoor', () => {
       },
     });
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
-    // The listener still resolves via its default forward; only the rule is dropped.
+    expect(warnings).toEqual([]);
+    expect(listeners[0]!.rules[0]!.httpHeaderConditions).toEqual([
+      { name: 'X-Tenant', values: ['acme', 'globex'] },
+    ]);
+  });
+
+  it('ANDs multiple http-header conditions (different names)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [
+            { Field: 'http-header', HttpHeaderConfig: { HttpHeaderName: 'X-Tenant', Values: ['acme'] } },
+            { Field: 'http-header', HttpHeaderConfig: { HttpHeaderName: 'X-Env', Values: ['prod'] } },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners[0]!.rules[0]!.httpHeaderConditions).toEqual([
+      { name: 'X-Tenant', values: ['acme'] },
+      { name: 'X-Env', values: ['prod'] },
+    ]);
+  });
+
+  it('skips + warns on an http-header condition with no HttpHeaderName / Values', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [{ Field: 'http-header', HttpHeaderConfig: { Values: ['x'] } }],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
     expect(listeners[0]!.rules).toEqual([]);
-    expect(warnings.join('\n')).toMatch(/unsupported condition\(s\): http-header/);
+    expect(warnings.join('\n')).toMatch(/http-header condition with no HttpHeaderName/);
+  });
+
+  it('resolves an http-request-method condition (OR-matched values)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [
+            {
+              Field: 'http-request-method',
+              HttpRequestMethodConfig: { Values: ['POST', 'PUT'] },
+            },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners[0]!.rules[0]!.httpRequestMethods).toEqual(['POST', 'PUT']);
+  });
+
+  it('resolves a query-string condition (Key+Value and bare-Value entries)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [
+            {
+              Field: 'query-string',
+              QueryStringConfig: {
+                Values: [{ Key: 'version', Value: '2' }, { Value: '*beta*' }],
+              },
+            },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners[0]!.rules[0]!.queryStringConditions).toEqual([
+      { key: 'version', value: '2' },
+      { value: '*beta*' },
+    ]);
+  });
+
+  it('resolves a source-ip condition (IPv4 + IPv6 CIDRs)', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [
+            {
+              Field: 'source-ip',
+              SourceIpConfig: { Values: ['10.0.0.0/8', '2001:db8::/32'] },
+            },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    expect(listeners[0]!.rules[0]!.sourceIpCidrs).toEqual(['10.0.0.0/8', '2001:db8::/32']);
+  });
+
+  it('skips + warns on a source-ip condition with an unparseable CIDR', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [
+            { Field: 'source-ip', SourceIpConfig: { Values: ['not-a-cidr', '10.0.0.0/8'] } },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners[0]!.rules).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/unparseable CIDR\(s\): not-a-cidr/);
+  });
+
+  it('ANDs path-pattern + http-header + http-request-method + query-string + source-ip on one rule', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 5,
+          Conditions: [
+            { Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*'] } },
+            { Field: 'http-header', HttpHeaderConfig: { HttpHeaderName: 'X-API', Values: ['v2'] } },
+            { Field: 'http-request-method', HttpRequestMethodConfig: { Values: ['POST'] } },
+            { Field: 'query-string', QueryStringConfig: { Values: [{ Key: 'v', Value: '1' }] } },
+            { Field: 'source-ip', SourceIpConfig: { Values: ['10.0.0.0/8'] } },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(warnings).toEqual([]);
+    const rule = listeners[0]!.rules[0]!;
+    expect(rule.pathPatterns).toEqual(['/api/*']);
+    expect(rule.httpHeaderConditions).toEqual([{ name: 'X-API', values: ['v2'] }]);
+    expect(rule.httpRequestMethods).toEqual(['POST']);
+    expect(rule.queryStringConditions).toEqual([{ key: 'v', value: '1' }]);
+    expect(rule.sourceIpCidrs).toEqual(['10.0.0.0/8']);
   });
 
   it('drops only the unsupported target group inside a weighted forward (others kept)', () => {

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -595,6 +595,30 @@ describe('resolveAlbFrontDoor', () => {
     ]);
   });
 
+  it('skips + warns on a query-string condition whose entries are all malformed', () => {
+    const stack = stackWith({
+      ...apiServiceResources,
+      [RULE]: {
+        Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
+        Properties: {
+          ListenerArn: { Ref: LISTENER },
+          Priority: 10,
+          Conditions: [
+            {
+              Field: 'query-string',
+              // Non-string `Value` on the only entry -> 0 parseable entries.
+              QueryStringConfig: { Values: [{ Key: 'v', Value: 42 }] },
+            },
+          ],
+          Actions: [{ Type: 'forward', TargetGroupArn: { Ref: API_TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners[0]!.rules).toEqual([]);
+    expect(warnings.join('\n')).toMatch(/query-string condition has no parseable/);
+  });
+
   it('resolves a source-ip condition (IPv4 + IPv6 CIDRs)', () => {
     const stack = stackWith({
       ...apiServiceResources,

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -52,7 +52,13 @@ async function startFront(
 }
 
 async function startFrontWith(
-  route: (req: { path: string; host?: string }) => RouteAction | undefined,
+  route: (req: {
+    path: string;
+    host?: string;
+    headers?: NodeJS.Dict<string | string[]>;
+    method?: string;
+    sourceIp?: string;
+  }) => RouteAction | undefined,
   upstreamTimeoutMs?: number
 ): Promise<StartedFrontDoorServer> {
   const front = await startFrontDoorServer({
@@ -256,6 +262,38 @@ describe('startFrontDoorServer', () => {
     // The case-insensitive host comparison still matches.
     expect((await fetchTextWithHost(front.port, '/', 'API.EXAMPLE.COM')).body).toBe('api-host');
     expect((await fetchTextWithHost(front.port, '/', 'other.example.com')).body).toBe('web-host');
+  });
+
+  it('threads method / headers / sourceIp into the route() callback (binding)', async () => {
+    const upstream = await startUpstream('match');
+    const pool = new FrontDoorEndpointPool();
+    pool.register('r0', { host: '127.0.0.1', port: upstream.port });
+
+    const seenReqs: Array<{
+      path: string;
+      host?: string;
+      method?: string;
+      sourceIp?: string;
+      hasHeaders: boolean;
+    }> = [];
+    const front = await startFrontWith((req) => {
+      seenReqs.push({
+        path: req.path,
+        ...(req.host !== undefined && { host: req.host }),
+        ...(req.method !== undefined && { method: req.method }),
+        ...(req.sourceIp !== undefined && { sourceIp: req.sourceIp }),
+        hasHeaders: Object.keys(req.headers ?? {}).length > 0,
+      });
+      return forward(pool);
+    });
+
+    await fetchText(front.port, '/probe');
+    expect(seenReqs).toHaveLength(1);
+    const seen = seenReqs[0]!;
+    expect(seen.path).toBe('/probe');
+    expect(seen.method).toBe('GET');
+    expect(seen.hasHeaders).toBe(true);
+    expect(seen.sourceIp).toMatch(/^(127\.0\.0\.1|::1|::ffff:127\.0\.0\.1)$/);
   });
 
   it('synthesizes a fixed-response action without an upstream', async () => {

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -390,6 +390,10 @@ describe('buildFrontDoor', () => {
                 priority: 10,
                 pathPatterns: ['/api/*'],
                 hostPatterns: [],
+                httpHeaderConditions: [],
+                httpRequestMethods: [],
+                queryStringConditions: [],
+                sourceIpCidrs: [],
                 action: {
                   kind: 'forward',
                   targets: [


### PR DESCRIPTION
## Summary

Wires up the remaining four ALB listener-rule condition fields the local front-door used to skip with a "deferred" warning — `http-header`, `http-request-method`, `query-string`, and `source-ip` — so a synthesized rule like:

```ts
listener.addAction('admin', {
  conditions: [
    ListenerCondition.httpHeader('X-Tenant', ['acme']),
    ListenerCondition.httpRequestMethods(['POST']),
    ListenerCondition.queryStrings([{ key: 'v', value: '1' }]),
    ListenerCondition.sourceIps(['10.0.0.0/8']),
  ],
  action: ListenerAction.forward([adminTg]),
});
```

is honored locally. Combined with the previously shipped `path-pattern` (#139), `host-header` + weighted forwards + `redirect` / `fixed-response` (#146), and ALB → Lambda targets (#148), `cdkl start-alb` now reproduces every ALB rule-condition field a CDK app can synthesize.

## Behavior details

- **`http-header`** — case-insensitive header-name lookup, case-insensitive `*` / `?` glob match against any value of that header. Multiple `http-header` conditions on a rule AND across header names (per AWS spec).
- **`http-request-method`** — exact, case-sensitive uppercase match (`POST`, `PUT`, etc.). No wildcards — matching ALB's spec.
- **`query-string`** — `{ Key?, Value }` pairs OR-matched. Both Key and Value accept `*` / `?` globs, case-insensitive. Percent / `+` decoding applied before matching. When `Key` is omitted, ANY query parameter whose value matches the Value glob satisfies the condition.
- **`source-ip`** — IPv4 + IPv6 CIDR OR-matched. IPv4-mapped IPv6 source addresses (`::ffff:127.0.0.1`) are unmapped before matching, so a CIDR like `127.0.0.0/8` still hits an IPv4 client on a dual-stack listener.

A rule that names multiple condition fields ANDs them (path AND host AND header AND method AND query AND source-ip), matching ALB.

## Validation behavior

- An `http-header` condition with no `HttpHeaderName` / `Values` invalidates the whole rule with a warning (silently dropping it would widen the routing).
- A `source-ip` condition with an unparseable CIDR invalidates the whole rule with a warning, same reason.
- A `query-string` condition whose `Values` are all unparseable invalidates the whole rule with a warning, same reason.
- An unknown condition field (e.g. a future ALB field) drops the whole rule with a warning, instead of silently keeping the rule with the unknown constraint dropped.

## Caveat (documented in cli-reference.md)

The local front-door binds the connection's `socket.remoteAddress` as the source IP (no `X-Forwarded-For` plumbing), so a `source-ip` CIDR narrower than `127.0.0.0/8` will not match traffic that comes in on `127.0.0.1` — exercise such rules from a real remote, or use a permissive loopback CIDR for local smoke tests.

## Files

- `src/local/alb-path-matcher.ts` — new condition fields on `AlbPathRule`, matcher logic, IPv4 / IPv6 CIDR matcher, glob extensions
- `src/local/elb-front-door-resolver.ts` — `parseRuleConditions` parses every ALB field; malformed conditions invalidate the whole rule
- `src/local/front-door-server.ts` — threads `method` / `headers` / `sourceIp` into the `route()` callback
- `src/cli/commands/ecs-service-emulator.ts` + `local-start-alb.ts` — propagate the four new fields end-to-end + boot-banner formatting
- README.md + .claude/CLAUDE.md + docs/cli-reference.md — scope text rewritten; only `authenticate-*` + HTTPS/TLS remain deferred

## Test plan

- [x] `vp run check` (typecheck + lint + format) — pass
- [x] `vp run build` — pass
- [x] `vp test run` — 101 files, 1517 tests pass (was 1485; +14 resolver, +13 matcher, +1 front-door binding, +4 shape parity)
- [x] `/run-integ local-start-alb-routing-conditions` — green (resolver → matcher → front-door → Docker pipeline exercised via host-header; clean teardown)
- [x] Manual smoke against the matcher exports via `dist/internal.js` — covered by the binding test + unit tests; no dedicated Docker fixture for the four new fields (acceptable, see "Residual review nits" below)

## Residual review nits (accepted as known cost; tracked here for completeness)

Code-review pass (no blockers) + test-review pass (no blockers) flagged these low-severity items; shipping as-is:

- **`isValidCidr` permissive for `1.2.3.4:abc/64`** — a CIDR with both `.` and `:` in the address part falls into the IPv6 prefix-length-only branch and parses as valid; the runtime matcher then returns false. Net effect: such a rule silently never matches rather than failing at parse time. Synthesized CFn never emits this shape; not worth tightening for the cost of widening surface.
- **`parseIpv4` accepts leading-zero octets** (`010.0.0.1` → 10). No octal interpretation (`parseInt(..., 10)`); functionally correct.
- **`describeConditions` banner output (`ecs-service-emulator.ts`) has no snapshot test** for the new `header` / `method` / `query` / `source-ip` formatting branches. Pure formatter; the runtime banner is exercised by the integ.
- **`front-door-server.ts` threads both `hostHeader(req)` and `headers: req.headers`** — `host` is duplicated in two facts fields. Matcher reads them from independent code paths; no conflict in practice.
- **`httpHeaderConditionMatches` returns false when `headers` is undefined** — current wiring always passes the Node `req.headers` dict; this defensive branch is reachable only by direct callers (none in-tree).
- **No dedicated integ fixture for the four new condition types** — the existing `local-start-alb-routing-conditions` integ exercises the same resolver / matcher / front-door pipeline through `host-header`; the field-specific parsing has strong unit coverage; the front-door-server binding test locks the new request facts thread end-to-end. A dedicated multi-condition fixture is sensible follow-up.

Refs: #123
