### PR TITLE
feat(invoke-agentcore): verify customJwtAuthorizer allowedScopes + customClaims

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,8 +49,9 @@ AWS managed services.
   intrinsic resolved against state) on the HTTP and MCP protocols. HTTP runs the
   `POST /invocations` + `GET /ping` contract on 8080: an inbound
   `customJwtAuthorizer` is enforced locally (`--bearer-token` verified against
-  the runtime's OIDC discovery URL before the container starts and forwarded to
-  `/invocations`), and a streaming SSE (`text/event-stream`) response is printed
+  the runtime's OIDC discovery URL before the container starts — signature +
+  issuer + expiry + audience + `allowedScopes` + `customClaims` — and forwarded
+  to `/invocations`), and a streaming SSE (`text/event-stream`) response is printed
   to stdout incrementally. `--ws` instead streams over the agent's bidirectional
   `/ws` WebSocket endpoint on the same 8080 container — the event is sent as the
   first frame and received frames are printed to stdout until the agent closes.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -524,18 +524,29 @@ before the container starts:
   or `--no-verify-auth` to skip for local dev.
 - **`--bearer-token <jwt>`** → the token is verified against the runtime's
   OIDC discovery URL: the discovery document is fetched for its `issuer` +
-  `jwks_uri`, then the JWT's RS256 signature, `iss`, `exp`, and audience are
-  checked (the audience allowlist is `allowedAudience` ∪ `allowedClients`,
-  matched against `aud` / `client_id`). An invalid token is rejected
-  (AgentCore returns 403); a valid one is forwarded to `/invocations` as
+  `jwks_uri`, then the JWT's RS256 signature, `iss`, `exp`, audience,
+  `allowedScopes`, and `customClaims` are checked:
+  - **Audience** — `aud` (ID tokens) or `client_id` (access tokens) must
+    match the `allowedAudience` ∪ `allowedClients` allowlist.
+  - **`allowedScopes`** — the token's `scope` claim (OAuth space-separated
+    string, or an array) must include EVERY required scope.
+  - **`customClaims`** — every declared rule must hold against the token's
+    matching claim:
+    - `STRING` + `EQUALS` — claim string-equals the configured value;
+    - `STRING_ARRAY` + `CONTAINS` — claim array includes the configured
+      value;
+    - `STRING_ARRAY` + `CONTAINS_ANY` — claim array shares at least one
+      entry with the configured list.
+
+  An invalid token is rejected (AgentCore returns 403); a valid one is
+  forwarded to `/invocations` (or the `/ws` upgrade) as
   `Authorization: Bearer <jwt>`.
 - **Discovery URL / JWKS unreachable** → falls back to pass-through (accept +
   warn), the same offline-dev trade-off `cdkl start-api` makes for
-  unreachable Cognito JWKS.
+  unreachable Cognito JWKS. Scope / custom-claim verification does NOT run on
+  the pass-through path — every Bearer token is accepted.
 - **`--no-verify-auth`** → skips verification entirely; a `--bearer-token`,
   if given, is still forwarded.
-
-`allowedScopes` + `customClaims` validation is not yet enforced (follow-up).
 
 ### Streaming responses
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -458,6 +458,8 @@ export async function resolveInboundAuthorization(
       discoveryUrl: authorizer.discoveryUrl,
       ...(authorizer.allowedAudience && { allowedAudience: authorizer.allowedAudience }),
       ...(authorizer.allowedClients && { allowedClients: authorizer.allowedClients }),
+      ...(authorizer.allowedScopes && { allowedScopes: authorizer.allowedScopes }),
+      ...(authorizer.customClaims && { customClaims: authorizer.customClaims }),
     },
     header,
     createJwksCache(),

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -81,6 +81,7 @@ export {
   verifyJwtViaDiscovery,
   type JwksCache,
   type DiscoveryJwtAuthorizer,
+  type JwtCustomClaim,
 } from './local/cognito-jwt.js';
 export {
   buildMethodArn,
@@ -302,6 +303,7 @@ export {
   AGENTCORE_MCP_PROTOCOL,
   type ResolvedAgentCoreRuntime,
   type AgentCoreJwtAuthorizer,
+  type AgentCoreCustomClaim,
   type AgentCoreCodeArtifact,
 } from './local/agentcore-resolver.js';
 export {

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -97,12 +97,37 @@ export interface ResolvedAgentCoreRuntime {
  * (`AuthorizerConfiguration.CustomJWTAuthorizer`). `discoveryUrl` is the
  * OIDC discovery document URL (`.well-known/openid-configuration`);
  * `allowedAudience` / `allowedClients` are the `aud` / `client_id`
- * allowlists the token must satisfy.
+ * allowlists the token must satisfy;
+ * `allowedScopes` are OAuth scopes the token's `scope` claim must include;
+ * `customClaims` are per-claim equality / membership rules the token must
+ * satisfy in addition to the standard checks.
  */
 export interface AgentCoreJwtAuthorizer {
   discoveryUrl: string;
   allowedAudience?: string[];
   allowedClients?: string[];
+  allowedScopes?: string[];
+  customClaims?: AgentCoreCustomClaim[];
+}
+
+/**
+ * A single `CustomClaims` rule from
+ * `AuthorizerConfiguration.CustomJWTAuthorizer.CustomClaims[]`. Drives
+ * per-claim verification:
+ *
+ * - `valueType: STRING` + `operator: EQUALS` — the token claim must
+ *   string-equal `value` (a single string).
+ * - `valueType: STRING_ARRAY` + `operator: CONTAINS` — the token claim must
+ *   be an array containing `value` (a single string).
+ * - `valueType: STRING_ARRAY` + `operator: CONTAINS_ANY` — the token claim
+ *   must be an array sharing at least one entry with `value` (an array of
+ *   strings).
+ */
+export interface AgentCoreCustomClaim {
+  name: string;
+  valueType: 'STRING' | 'STRING_ARRAY';
+  operator: 'EQUALS' | 'CONTAINS' | 'CONTAINS_ANY';
+  value: string | string[];
 }
 
 /**
@@ -365,12 +390,92 @@ function extractJwtAuthorizer(
     Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : undefined;
   const allowedAudience = toStringArray(cfg['AllowedAudience']);
   const allowedClients = toStringArray(cfg['AllowedClients']);
+  const allowedScopes = toStringArray(cfg['AllowedScopes']);
+  const customClaims = extractCustomClaims(cfg['CustomClaims'], logicalId);
 
   return {
     discoveryUrl,
     ...(allowedAudience && allowedAudience.length > 0 && { allowedAudience }),
     ...(allowedClients && allowedClients.length > 0 && { allowedClients }),
+    ...(allowedScopes && allowedScopes.length > 0 && { allowedScopes }),
+    ...(customClaims && customClaims.length > 0 && { customClaims }),
   };
+}
+
+/**
+ * Parse a `CustomJWTAuthorizer.CustomClaims[]` array into
+ * {@link AgentCoreCustomClaim}s. The template shape (synthesized by the L2):
+ *
+ * ```
+ * {
+ *   InboundTokenClaimName: <claim name>,
+ *   InboundTokenClaimValueType: 'STRING' | 'STRING_ARRAY',
+ *   AuthorizingClaimMatchValue: {
+ *     ClaimMatchOperator: 'EQUALS' | 'CONTAINS' | 'CONTAINS_ANY',
+ *     ClaimMatchValue: { MatchValueString?: ..., MatchValueStringList?: [...] }
+ *   }
+ * }
+ * ```
+ *
+ * Each entry that fails to parse (missing name / unknown type / unknown
+ * operator / wrong value shape) is warn-and-skipped — the deployed runtime
+ * would reject a token that violates ANY claim rule, so dropping a rule we
+ * can't evaluate is the safer side (under-restrictive in `--no-verify-auth`
+ * paths, fine elsewhere because the surviving rules still gate the token).
+ */
+function extractCustomClaims(raw: unknown, logicalId: string): AgentCoreCustomClaim[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: AgentCoreCustomClaim[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+    const name = e['InboundTokenClaimName'];
+    const valueType = e['InboundTokenClaimValueType'];
+    const matchObj = e['AuthorizingClaimMatchValue'];
+    if (typeof name !== 'string' || name.length === 0) continue;
+    if (valueType !== 'STRING' && valueType !== 'STRING_ARRAY') {
+      getLogger().warn(
+        `AgentCore Runtime '${logicalId}' CustomClaims entry '${name}' has unsupported ` +
+          `InboundTokenClaimValueType '${String(valueType)}' (expected STRING / STRING_ARRAY); skipping.`
+      );
+      continue;
+    }
+    if (!matchObj || typeof matchObj !== 'object' || Array.isArray(matchObj)) continue;
+    const m = matchObj as Record<string, unknown>;
+    const operator = m['ClaimMatchOperator'];
+    const matchValue = m['ClaimMatchValue'];
+    if (operator !== 'EQUALS' && operator !== 'CONTAINS' && operator !== 'CONTAINS_ANY') {
+      getLogger().warn(
+        `AgentCore Runtime '${logicalId}' CustomClaims entry '${name}' has unsupported ` +
+          `ClaimMatchOperator '${String(operator)}' (expected EQUALS / CONTAINS / CONTAINS_ANY); skipping.`
+      );
+      continue;
+    }
+    if (!matchValue || typeof matchValue !== 'object' || Array.isArray(matchValue)) continue;
+    const mv = matchValue as Record<string, unknown>;
+    // STRING + EQUALS and STRING_ARRAY + CONTAINS use MatchValueString (single
+    // string); STRING_ARRAY + CONTAINS_ANY uses MatchValueStringList (array).
+    let value: string | string[] | undefined;
+    if (operator === 'CONTAINS_ANY') {
+      const list = mv['MatchValueStringList'];
+      if (Array.isArray(list)) {
+        value = list.filter((x): x is string => typeof x === 'string');
+        if ((value as string[]).length === 0) value = undefined;
+      }
+    } else {
+      const s = mv['MatchValueString'];
+      if (typeof s === 'string' && s.length > 0) value = s;
+    }
+    if (value === undefined) {
+      getLogger().warn(
+        `AgentCore Runtime '${logicalId}' CustomClaims entry '${name}' has no usable ` +
+          `MatchValueString / MatchValueStringList for operator ${operator}; skipping.`
+      );
+      continue;
+    }
+    out.push({ name, valueType, operator, value });
+  }
+  return out;
 }
 
 /**

--- a/src/local/cognito-jwt.ts
+++ b/src/local/cognito-jwt.ts
@@ -277,7 +277,17 @@ export async function verifyCognitoJwt(
   // single configured pool).
   const jwksUrl = buildCognitoJwksUrl(selectedPool.region, selectedPool.userPoolId);
   const expectedIssuer = buildCognitoIssuer(selectedPool.region, selectedPool.userPoolId);
-  return verifyAndShape(token, jwksUrl, expectedIssuer, undefined, jwksCache, opts.warned, now);
+  return verifyAndShape(
+    token,
+    jwksUrl,
+    expectedIssuer,
+    undefined,
+    undefined,
+    undefined,
+    jwksCache,
+    opts.warned,
+    now
+  );
 }
 
 /**
@@ -305,6 +315,8 @@ export async function verifyJwtAuthorizer(
     jwksUrl,
     authorizer.issuer.replace(/\/+$/, ''),
     authorizer.audience,
+    undefined,
+    undefined,
     jwksCache,
     opts.warned,
     now
@@ -323,6 +335,26 @@ export interface DiscoveryJwtAuthorizer {
   allowedAudience?: readonly string[];
   /** Allowed `client_id` values. */
   allowedClients?: readonly string[];
+  /**
+   * OAuth scopes the token's `scope` claim must include (space-separated
+   * scope strings; the token must carry every entry in this allowlist).
+   */
+  allowedScopes?: readonly string[];
+  /** Per-claim equality / membership rules the token must satisfy. */
+  customClaims?: readonly JwtCustomClaim[];
+}
+
+/**
+ * A single `CustomJWTAuthorizer.CustomClaims[]` rule the verifier evaluates
+ * against the token's claims. Mirrors {@link AgentCoreCustomClaim} in the
+ * resolver — kept structurally identical so the resolver -> verifier hand-off
+ * is a direct field copy.
+ */
+export interface JwtCustomClaim {
+  name: string;
+  valueType: 'STRING' | 'STRING_ARRAY';
+  operator: 'EQUALS' | 'CONTAINS' | 'CONTAINS_ANY';
+  value: string | string[];
 }
 
 /**
@@ -398,6 +430,8 @@ export async function verifyJwtViaDiscovery(
     jwksUri,
     issuer.replace(/\/+$/, ''),
     allowlist.length > 0 ? allowlist : undefined,
+    authorizer.allowedScopes,
+    authorizer.customClaims,
     jwksCache,
     opts.warned,
     now
@@ -409,6 +443,8 @@ async function verifyAndShape(
   jwksUrl: string,
   expectedIssuer: string,
   expectedAudience: ReadonlyArray<string> | undefined,
+  requiredScopes: ReadonlyArray<string> | undefined,
+  customClaims: ReadonlyArray<JwtCustomClaim> | undefined,
   jwksCache: JwksCache,
   warned: Set<string> | undefined,
   now: () => number
@@ -489,7 +525,70 @@ async function verifyAndShape(
     }
   }
 
+  // Validate `scope`. AgentCore's `AllowedScopes` is a required-scope
+  // allowlist: the token's `scope` claim (OAuth space-separated) must include
+  // every entry. A token with no `scope` claim fails when scopes are required.
+  if (requiredScopes && requiredScopes.length > 0) {
+    if (!verifyRequiredScopes(claims['scope'], requiredScopes)) {
+      return { allow: false, identityHash, ttlSeconds: 0 };
+    }
+  }
+
+  // Validate custom claims. Every rule must hold against the token's
+  // matching claim value; a token missing a referenced claim fails.
+  if (customClaims && customClaims.length > 0) {
+    for (const rule of customClaims) {
+      if (!verifyCustomClaim(claims[rule.name], rule)) {
+        return { allow: false, identityHash, ttlSeconds: 0 };
+      }
+    }
+  }
+
   return shapeAllowResult(parsed, identityHash, now);
+}
+
+/**
+ * The OAuth `scope` claim is a space-separated string. The token is allowed
+ * iff every required scope is present (allowlist as REQUIRED, not OR).
+ */
+function verifyRequiredScopes(scopeClaim: unknown, requiredScopes: ReadonlyArray<string>): boolean {
+  const tokenScopes =
+    typeof scopeClaim === 'string'
+      ? scopeClaim.split(/\s+/).filter((s) => s.length > 0)
+      : Array.isArray(scopeClaim)
+        ? scopeClaim.filter((s): s is string => typeof s === 'string')
+        : [];
+  return requiredScopes.every((s) => tokenScopes.includes(s));
+}
+
+/**
+ * Verify a single `CustomJWTAuthorizer.CustomClaims` rule against the token's
+ * claim value:
+ *
+ * - `STRING` + `EQUALS` — claim is a string equal to `value`.
+ * - `STRING_ARRAY` + `CONTAINS` — claim is an array containing `value`.
+ * - `STRING_ARRAY` + `CONTAINS_ANY` — claim is an array sharing at least one
+ *   entry with `value` (an array of allowed strings).
+ *
+ * A missing or wrong-typed claim fails the rule.
+ */
+function verifyCustomClaim(claimValue: unknown, rule: JwtCustomClaim): boolean {
+  if (rule.valueType === 'STRING') {
+    if (rule.operator !== 'EQUALS' || typeof rule.value !== 'string') return false;
+    return typeof claimValue === 'string' && claimValue === rule.value;
+  }
+  // STRING_ARRAY
+  if (!Array.isArray(claimValue)) return false;
+  const tokenValues = claimValue.filter((v): v is string => typeof v === 'string');
+  if (rule.operator === 'CONTAINS') {
+    if (typeof rule.value !== 'string') return false;
+    return tokenValues.includes(rule.value);
+  }
+  if (rule.operator === 'CONTAINS_ANY') {
+    if (!Array.isArray(rule.value)) return false;
+    return rule.value.some((v) => tokenValues.includes(v));
+  }
+  return false;
 }
 
 /**

--- a/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
+++ b/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
@@ -8,6 +8,7 @@ import {
   AgentRuntimeArtifact,
   AgentCoreRuntime,
   RuntimeAuthorizerConfiguration,
+  RuntimeCustomClaim,
   ProtocolType,
 } from 'aws-cdk-lib/aws-bedrockagentcore';
 
@@ -68,6 +69,29 @@ export class LocalInvokeAgentCoreStack extends cdk.Stack {
         platform: Platform.LINUX_ARM64,
       }),
       protocolConfiguration: ProtocolType.MCP,
+    });
+
+    // A JWT-protected runtime whose customJwtAuthorizer also declares
+    // `allowedScopes` + `customClaims` — exercises the resolver's extraction
+    // of the new fields end-to-end (the discovery URL is again deliberately
+    // unreachable; the verifier's pass-through path then accepts every Bearer
+    // token without firing the scope / claim checks). The unit tests cover the
+    // verifier behavior with a working discovery + JWKS + signed token.
+    new Runtime(this, 'ProtectedAgentClaims', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromAsset(path.join(__dirname, '../agent'), {
+        platform: Platform.LINUX_ARM64,
+      }),
+      environmentVariables: { GREETING: 'hello-from-agent' },
+      authorizerConfiguration: RuntimeAuthorizerConfiguration.usingJWT(
+        'https://127.0.0.1:1/.well-known/openid-configuration',
+        ['client-9'],
+        ['aud-1'],
+        ['read', 'write'],
+        [
+          RuntimeCustomClaim.withStringValue('department', 'engineering'),
+          RuntimeCustomClaim.withStringArrayValue('groups', ['admins']),
+        ]
+      ),
     });
 
     // A CodeConfiguration (managed-runtime) runtime authored as plain source

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -34,6 +34,7 @@ cd "$(dirname "$0")"
 CDKL="node ../../../dist/cli.js"
 TARGET="CdkLocalInvokeAgentCoreFixture/EchoAgent"
 PROTECTED="CdkLocalInvokeAgentCoreFixture/ProtectedAgent"
+PROTECTED_CLAIMS="CdkLocalInvokeAgentCoreFixture/ProtectedAgentClaims"
 MCP="CdkLocalInvokeAgentCoreFixture/McpAgent"
 CODE="CdkLocalInvokeAgentCoreFixture/CodeAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
@@ -52,7 +53,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/14] Invoking EchoAgent with default empty event"
+echo "==> [1/15] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -66,7 +67,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/14] Invoking EchoAgent with --event payload"
+echo "==> [2/15] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -78,7 +79,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/14] Invoking EchoAgent with --env-vars override"
+echo "==> [3/15] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -90,7 +91,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/14] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/15] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -101,7 +102,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/14] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/15] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -122,7 +123,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/14] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/15] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -132,7 +133,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/14] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/15] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -145,7 +146,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/14] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/15] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -165,7 +166,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
-echo "==> [9/14] McpAgent (no --event) runs the handshake + tools/list"
+echo "==> [9/15] McpAgent (no --event) runs the handshake + tools/list"
 RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
@@ -174,7 +175,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 }
 
 # Test 10 — an MCP tools/call via --event returns the tool result.
-echo "==> [10/14] McpAgent with --event runs tools/call"
+echo "==> [10/15] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
@@ -188,7 +189,7 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 # Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
 # source (no Dockerfile): cdkl builds it from source (pip install + run the
 # entrypoint) and the entrypoint self-serves the 8080 HTTP contract.
-echo "==> [11/14] CodeAgent (fromCodeAsset) builds from source + responds"
+echo "==> [11/15] CodeAgent (fromCodeAsset) builds from source + responds"
 RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_11}"
 echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
@@ -201,7 +202,7 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 }
 
 # Test 12 — a --event payload echoes through the from-source agent.
-echo "==> [12/14] CodeAgent with --event echoes the payload"
+echo "==> [12/15] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
@@ -216,7 +217,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # the first frame and streams every received frame to stdout until the agent
 # closes. The fixture agent replies with one JSON frame (echo + session id +
 # Authorization + GREETING) then a second text frame, then closes.
-echo "==> [13/14] EchoAgent over the /ws WebSocket (--ws)"
+echo "==> [13/15] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
@@ -241,7 +242,7 @@ echo "${RESULT_13}" | grep -q 'ws-frame-2' || {
 
 # Test 14 — --ws is HTTP-only: against an MCP runtime it warns and is ignored,
 # falling through to the normal MCP path (tools/list still returns).
-echo "==> [14/14] McpAgent with --ws warns + still runs the MCP path"
+echo "==> [14/15] McpAgent with --ws warns + still runs the MCP path"
 set +e
 OUT_14=$(${CDKL} invoke-agentcore "${MCP}" --ws 2>/tmp/cdkl-ws-mcp-stderr; cat /tmp/cdkl-ws-mcp-stderr >&2)
 RC_14=$?
@@ -262,5 +263,23 @@ echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP protocol' || {
   exit 1
 }
 
+# Test 15 — ProtectedAgentClaims declares AllowedScopes + CustomClaims in the
+# template. The resolver must extract them without crashing; with the
+# unreachable discovery URL the verifier falls back to pass-through, so the
+# invoke succeeds even with a placeholder bearer token. (The verifier's actual
+# scope / claim checks are covered by the unit tests, which sign real RS256
+# tokens against mock JWKS.)
+echo "==> [15/15] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
+RESULT_15=$(${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s" 2>/dev/null | tail -1)
+echo "    response: ${RESULT_15}"
+echo "${RESULT_15}" | grep -q '"greeting":"hello-from-agent"' || {
+  echo "FAIL: expected ProtectedAgentClaims to invoke under pass-through, got: ${RESULT_15}"
+  exit 1
+}
+echo "${RESULT_15}" | grep -q '"authorization":"Bearer h.p.s"' || {
+  echo "FAIL: expected the bearer token forwarded as Authorization: Bearer h.p.s, got: ${RESULT_15}"
+  exit 1
+}
+
 echo ""
-echo "==> All 14 local-invoke-agentcore tests passed"
+echo "==> All 15 local-invoke-agentcore tests passed"

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -501,7 +501,7 @@ describe('resolveAgentCoreTarget — JWT authorizer extraction', () => {
     ]);
   });
 
-  it('skips a CustomClaims entry with an unknown operator / value type (warn-and-keep-rest)', () => {
+  it('skips a CustomClaims entry with an unknown ClaimMatchOperator (warn-and-keep-rest)', () => {
     const stack = buildStack('App', {
       ChatAgent: containerRuntime({
         AuthorizerConfiguration: {
@@ -532,6 +532,140 @@ describe('resolveAgentCoreTarget — JWT authorizer extraction', () => {
     const claims = resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims;
     expect(claims).toEqual([
       { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+    ]);
+  });
+
+  it('skips a CustomClaims entry with an unknown InboundTokenClaimValueType (warn-and-keep-rest)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                InboundTokenClaimName: 'unknown-type',
+                InboundTokenClaimValueType: 'NUMBER',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'EQUALS',
+                  ClaimMatchValue: { MatchValueString: 'x' },
+                },
+              },
+              {
+                InboundTokenClaimName: 'department',
+                InboundTokenClaimValueType: 'STRING',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'EQUALS',
+                  ClaimMatchValue: { MatchValueString: 'eng' },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    const claims = resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims;
+    expect(claims).toEqual([
+      { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+    ]);
+  });
+
+  it('skips a CONTAINS_ANY entry whose MatchValueStringList is missing or empty', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                InboundTokenClaimName: 'roles',
+                InboundTokenClaimValueType: 'STRING_ARRAY',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'CONTAINS_ANY',
+                  ClaimMatchValue: { MatchValueStringList: [] },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    expect(
+      resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims
+    ).toBeUndefined();
+  });
+
+  it('skips a CustomClaims entry with no InboundTokenClaimName', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                // missing InboundTokenClaimName
+                InboundTokenClaimValueType: 'STRING',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'EQUALS',
+                  ClaimMatchValue: { MatchValueString: 'x' },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    expect(
+      resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when CustomClaims is not an array (defensive default)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: 'not-an-array',
+          },
+        },
+      }),
+    });
+    expect(
+      resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims
+    ).toBeUndefined();
+  });
+
+  it('keeps every valid rule when CustomClaims has multiple entries', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                InboundTokenClaimName: 'department',
+                InboundTokenClaimValueType: 'STRING',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'EQUALS',
+                  ClaimMatchValue: { MatchValueString: 'eng' },
+                },
+              },
+              {
+                InboundTokenClaimName: 'groups',
+                InboundTokenClaimValueType: 'STRING_ARRAY',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'CONTAINS',
+                  ClaimMatchValue: { MatchValueString: 'admins' },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims).toEqual([
+      { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+      { name: 'groups', valueType: 'STRING_ARRAY', operator: 'CONTAINS', value: 'admins' },
     ]);
   });
 });

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -400,6 +400,140 @@ describe('resolveAgentCoreTarget — JWT authorizer extraction', () => {
     });
     expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer).toBeUndefined();
   });
+
+  it('extracts AllowedScopes', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            AllowedScopes: ['read', 'write'],
+          },
+        },
+      }),
+    });
+    const resolved = resolveAgentCoreTarget('App:ChatAgent', [stack]);
+    expect(resolved.jwtAuthorizer?.allowedScopes).toEqual(['read', 'write']);
+  });
+
+  it('extracts CustomClaims (STRING + EQUALS)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                InboundTokenClaimName: 'department',
+                InboundTokenClaimValueType: 'STRING',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'EQUALS',
+                  ClaimMatchValue: { MatchValueString: 'engineering' },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims).toEqual([
+      {
+        name: 'department',
+        valueType: 'STRING',
+        operator: 'EQUALS',
+        value: 'engineering',
+      },
+    ]);
+  });
+
+  it('extracts CustomClaims (STRING_ARRAY + CONTAINS)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                InboundTokenClaimName: 'groups',
+                InboundTokenClaimValueType: 'STRING_ARRAY',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'CONTAINS',
+                  ClaimMatchValue: { MatchValueString: 'admins' },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims).toEqual([
+      { name: 'groups', valueType: 'STRING_ARRAY', operator: 'CONTAINS', value: 'admins' },
+    ]);
+  });
+
+  it('extracts CustomClaims (STRING_ARRAY + CONTAINS_ANY uses MatchValueStringList)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                InboundTokenClaimName: 'roles',
+                InboundTokenClaimValueType: 'STRING_ARRAY',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'CONTAINS_ANY',
+                  ClaimMatchValue: { MatchValueStringList: ['admin', 'maintainer'] },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    expect(resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims).toEqual([
+      {
+        name: 'roles',
+        valueType: 'STRING_ARRAY',
+        operator: 'CONTAINS_ANY',
+        value: ['admin', 'maintainer'],
+      },
+    ]);
+  });
+
+  it('skips a CustomClaims entry with an unknown operator / value type (warn-and-keep-rest)', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({
+        AuthorizerConfiguration: {
+          CustomJWTAuthorizer: {
+            DiscoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            CustomClaims: [
+              {
+                InboundTokenClaimName: 'unknown-op',
+                InboundTokenClaimValueType: 'STRING',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'NOT_A_REAL_OP',
+                  ClaimMatchValue: { MatchValueString: 'x' },
+                },
+              },
+              {
+                InboundTokenClaimName: 'department',
+                InboundTokenClaimValueType: 'STRING',
+                AuthorizingClaimMatchValue: {
+                  ClaimMatchOperator: 'EQUALS',
+                  ClaimMatchValue: { MatchValueString: 'eng' },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+    const claims = resolveAgentCoreTarget('App:ChatAgent', [stack]).jwtAuthorizer?.customClaims;
+    expect(claims).toEqual([
+      { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+    ]);
+  });
 });
 
 describe('pickAgentCoreCandidateStack', () => {

--- a/tests/unit/local/cognito-jwt.test.ts
+++ b/tests/unit/local/cognito-jwt.test.ts
@@ -993,6 +993,19 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       expect(r.allow).toBe(false);
     });
 
+    it('denies when the scope claim is neither a string nor an array (e.g. a number)', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1', scope: 42 });
+      const r = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read'] },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
     it('accepts a scope claim that is an array (not the canonical space-separated string)', async () => {
       const f = makeJwtFixture();
       const { discoveryFetch, cache } = setup(f);
@@ -1034,6 +1047,69 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       const f = makeJwtFixture();
       const { discoveryFetch, cache } = setup(f);
       const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1', department: 'sales' });
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('STRING_ARRAY + CONTAINS — denies when the claim array does NOT contain the value', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign(
+        {},
+        { iss: ISSUER, exp: future(), aud: 'aud-1', groups: ['users', 'guests'] }
+      );
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'groups', valueType: 'STRING_ARRAY', operator: 'CONTAINS', value: 'admins' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('STRING_ARRAY rule denies when the token claim is a (wrong-typed) string', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1', groups: 'admins' });
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'groups', valueType: 'STRING_ARRAY', operator: 'CONTAINS', value: 'admins' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('STRING rule denies when the token claim is a (wrong-typed) array', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign(
+        {},
+        { iss: ISSUER, exp: future(), aud: 'aud-1', department: ['eng'] }
+      );
       const r = await verifyJwtViaDiscovery(
         {
           discoveryUrl: DISCOVERY,

--- a/tests/unit/local/cognito-jwt.test.ts
+++ b/tests/unit/local/cognito-jwt.test.ts
@@ -949,4 +949,225 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
     );
     expect(r.allow).toBe(true);
   });
+
+  describe('allowedScopes', () => {
+    it('allows a token whose space-separated scope claim includes every required scope', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign(
+        {},
+        { iss: ISSUER, exp: future(), aud: 'aud-1', scope: 'read write admin' }
+      );
+      const r = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read', 'write'] },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(true);
+    });
+
+    it('denies when a required scope is missing from the scope claim', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1', scope: 'read' });
+      const r = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read', 'write'] },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('denies when the scope claim is missing entirely', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1' });
+      const r = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read'] },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('accepts a scope claim that is an array (not the canonical space-separated string)', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign(
+        {},
+        { iss: ISSUER, exp: future(), aud: 'aud-1', scope: ['read', 'write'] }
+      );
+      const r = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read'] },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(true);
+    });
+  });
+
+  describe('customClaims', () => {
+    it('STRING + EQUALS — allows when the claim equals the expected value', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1', department: 'eng' });
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(true);
+    });
+
+    it('STRING + EQUALS — denies on mismatch', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1', department: 'sales' });
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('STRING_ARRAY + CONTAINS — allows when the claim array contains the value', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign(
+        {},
+        { iss: ISSUER, exp: future(), aud: 'aud-1', groups: ['users', 'admins'] }
+      );
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'groups', valueType: 'STRING_ARRAY', operator: 'CONTAINS', value: 'admins' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(true);
+    });
+
+    it('STRING_ARRAY + CONTAINS_ANY — allows when the claim array intersects the allowlist', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign(
+        {},
+        { iss: ISSUER, exp: future(), aud: 'aud-1', roles: ['maintainer'] }
+      );
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            {
+              name: 'roles',
+              valueType: 'STRING_ARRAY',
+              operator: 'CONTAINS_ANY',
+              value: ['admin', 'maintainer'],
+            },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(true);
+    });
+
+    it('STRING_ARRAY + CONTAINS_ANY — denies on empty intersection', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1', roles: ['guest'] });
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            {
+              name: 'roles',
+              valueType: 'STRING_ARRAY',
+              operator: 'CONTAINS_ANY',
+              value: ['admin', 'maintainer'],
+            },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('denies when the referenced claim is missing entirely', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign({}, { iss: ISSUER, exp: future(), aud: 'aud-1' });
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+
+    it('denies when ANY rule fails (all must pass)', async () => {
+      const f = makeJwtFixture();
+      const { discoveryFetch, cache } = setup(f);
+      const token = f.sign(
+        {},
+        {
+          iss: ISSUER,
+          exp: future(),
+          aud: 'aud-1',
+          department: 'eng',
+          groups: ['users'], // missing 'admins'
+        }
+      );
+      const r = await verifyJwtViaDiscovery(
+        {
+          discoveryUrl: DISCOVERY,
+          allowedAudience: ['aud-1'],
+          customClaims: [
+            { name: 'department', valueType: 'STRING', operator: 'EQUALS', value: 'eng' },
+            { name: 'groups', valueType: 'STRING_ARRAY', operator: 'CONTAINS', value: 'admins' },
+          ],
+        },
+        `Bearer ${token}`,
+        cache,
+        { fetchImpl: discoveryFetch, warned: new Set() }
+      );
+      expect(r.allow).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes the remaining JWT auth gap from #129: the customJwtAuthorizer
verifier now enforces `AllowedScopes` and `CustomClaims` in addition to the
existing signature + `iss` + `exp` + audience checks.

- **`AllowedScopes`** — the token's `scope` claim (OAuth space-separated
  string, OR an array of strings) must include EVERY required scope. A
  missing / non-string / non-array `scope` claim denies when scopes are
  required.
- **`CustomClaims`** — every declared rule must hold against the token's
  matching claim:
  - `STRING` + `EQUALS` — claim string-equals the configured value;
  - `STRING_ARRAY` + `CONTAINS` — claim array includes the configured value;
  - `STRING_ARRAY` + `CONTAINS_ANY` — claim array intersects the configured
    allowlist.

A token that fails either gate is rejected with the existing
`LOCAL_INVOKE_AGENTCORE_AUTH_DENIED` error. The pass-through fallback
(discovery / JWKS unreachable) still accepts every Bearer token without
firing the new gates — same offline-dev trade-off the audience check makes.

- Resolver: `AgentCoreJwtAuthorizer` gains `allowedScopes` + `customClaims`;
  `extractCustomClaims` parses the L2-synthesized template shape
  (`InboundTokenClaimName` / `InboundTokenClaimValueType` /
  `AuthorizingClaimMatchValue.ClaimMatchOperator` / `ClaimMatchValue.*`).
  Malformed entries (unknown operator / value-type, missing name, empty
  match value) are warn-and-skipped per-entry.
- Verifier: `DiscoveryJwtAuthorizer` + `verifyAndShape` accept the new
  allowlists; new `verifyRequiredScopes` + `verifyCustomClaim` helpers
  handle the per-rule checks.
- Command: `resolveInboundAuthorization` threads the new fields through to
  `verifyJwtViaDiscovery`.
- Integ fixture: a new `ProtectedAgentClaims` runtime declares
  `allowedScopes` + `customClaims`; scenario 15 invokes it under the
  offline-dev pass-through path, proving the resolver pipeline handles the
  new fields end-to-end. The verifier's actual deny path is covered by the
  unit tests.

## Review notes

3-axis review run (spec / code / test). Spec: clean. Test gaps closed in
the follow-up commit (STRING_ARRAY+CONTAINS denial, wrong-typed claim
defenses, non-string/non-array scope, several resolver early-exit branches,
multi-rule pass-through, renamed an overclaiming test).

Accepted as known cost (review nits, no behavior bug — `src/**` edits
would invalidate the integ marker and force a real-AWS re-run for cosmetic
changes):

- An `AllowedScopes` entry that's the empty string (e.g.
  `AllowedScopes: ['', 'read']`) passes resolver filtering as a "required
  scope of empty string". The verifier's `scope`-claim split filters empty
  segments, so this fails closed — no token can satisfy it. Pathological
  input safely denies; not worth a re-run.
- Pass-through mode (discovery / JWKS unreachable) allows BEFORE the new
  scope / claim gates run. This matches the existing audience-check
  behavior and the design intent documented in the source — every Bearer
  token is accepted on the offline-dev fallback path.
- The integ exercises only the resolver pipeline end-to-end (the verifier
  short-circuits to pass-through because the fixture's discovery URL is
  deliberately unreachable). The verifier's deny path is covered by the
  unit tests with real RS256-signed tokens against mock JWKS. A
  live-verifier integ would need an in-process OIDC server — filed as a
  potential follow-up rather than added here.

## Test plan

- [x] `vp run check` (typecheck + lint + format) green
- [x] `vp run test` — 101 files, 1542 tests pass (new: 11 verifier cases for
      scopes + customClaims, 9 resolver-extraction cases, 5 resolver
      early-exit cases, 1 multi-rule pass-through)
- [x] `vp run build`
- [x] `/run-integ local-invoke-agentcore` — 15/15 scenarios pass, 0 Docker
      orphans (scenario 15 invokes ProtectedAgentClaims under pass-through)

Closes #160
