### PR TITLE
feat(invoke-agentcore): --sigv4 opt-in inbound SigV4 signing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -51,7 +51,10 @@ AWS managed services.
   `customJwtAuthorizer` is enforced locally (`--bearer-token` verified against
   the runtime's OIDC discovery URL before the container starts — signature +
   issuer + expiry + audience + `allowedScopes` + `customClaims` — and forwarded
-  to `/invocations`), and a streaming SSE (`text/event-stream`) response is printed
+  to `/invocations`; `--sigv4` is an opt-in alternative that signs the
+  `/invocations` POST with AWS SigV4 — service `bedrock-agentcore` — when no
+  customJwtAuthorizer is declared, forwarding the same `Authorization` /
+  `X-Amz-*` headers the cloud receives), and a streaming SSE (`text/event-stream`) response is printed
   to stdout incrementally. `--ws` instead streams over the agent's bidirectional
   `/ws` WebSocket endpoint on the same 8080 container — the event is sent as the
   first frame and received frames are printed to stdout until the agent closes.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -491,6 +491,7 @@ prefix. Omit the target in a TTY to pick from a list.
 | `--ws` | off | Stream over the HTTP-protocol agent's bidirectional `/ws` WebSocket endpoint (on 8080) instead of `POST /invocations`: send `--event` as the first frame and print every received frame to stdout until the agent closes. See [WebSocket transport](#websocket-transport---ws) below. Ignored for an MCP runtime. |
 | `--bearer-token <jwt>` | — | Bearer JWT to present when the runtime declares a `customJwtAuthorizer`. Verified against the runtime's OIDC discovery URL (signature / `iss` / `exp` / audience) before the container starts, then forwarded to `/invocations` (or the `/ws` upgrade) as `Authorization: Bearer <jwt>`. |
 | `--no-verify-auth` | off (verify on) | Skip inbound JWT verification even when the runtime declares a `customJwtAuthorizer` (local-dev escape hatch). A `--bearer-token`, if given, is still forwarded. |
+| `--sigv4` | off | Sign the `/invocations` POST with AWS SigV4 (service `bedrock-agentcore`) using the resolved credentials — the same `Authorization: AWS4-HMAC-SHA256 ...` + `X-Amz-*` headers the cloud receives when the runtime declares no `customJwtAuthorizer`. Opt-in: default unsigned. Mutually exclusive with `--bearer-token`; ignored on a JWT-protected runtime. See [Inbound SigV4 (`--sigv4`)](#inbound-sigv4---sigv4) below. |
 | `--platform <platform>` | `linux/arm64` | `docker --platform` for the agent container (AgentCore requires ARM64; override to `linux/amd64` if needed). |
 | `--no-pull` | off | Skip `docker pull` (use the cached image). No-op for the local-build path. |
 | `--no-build` | off | Skip `docker build` on the local-asset path (reuse the previously-built tag). No-op for the ECR / registry pull paths. |
@@ -547,6 +548,43 @@ before the container starts:
   the pass-through path — every Bearer token is accepted.
 - **`--no-verify-auth`** → skips verification entirely; a `--bearer-token`,
   if given, is still forwarded.
+
+### Inbound SigV4 (`--sigv4`)
+
+In the cloud, an AgentCore Runtime that declares no `customJwtAuthorizer`
+authenticates inbound `/invocations` requests via AWS IAM (SigV4) — the
+caller signs the request and AgentCore verifies the signature against the
+caller's IAM credentials. Locally the agent container has no AWS
+public-key infrastructure to validate signatures against; passing
+`--sigv4` opts into HEADER PARITY with the cloud so an agent that
+introspects the inbound `Authorization` header (e.g. through the
+`bedrock-agentcore` SDK's request context) sees the same shape it would in
+production.
+
+`--sigv4` signs the `POST /invocations` request with the resolved
+credentials and forwards the full signed header set to the agent:
+
+- `Authorization: AWS4-HMAC-SHA256 Credential=<accessKeyId>/<date>/<region>/bedrock-agentcore/aws4_request, SignedHeaders=..., Signature=...`
+- `X-Amz-Date: <ISO-8601 basic>`
+- `X-Amz-Content-Sha256: <body sha256 hex>`
+- `X-Amz-Security-Token: <token>` (only when the credentials are STS-issued)
+
+Credentials precedence (same chain as the rest of the command):
+
+1. `--assume-role <arn>` → STS temp creds (warn + fall through on STS failure);
+2. `--profile <name>` → profile creds (with `aws_session_token` when present);
+3. shell env `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional
+   `AWS_SESSION_TOKEN`).
+
+With none of the above set, `--sigv4` fails fast with an actionable error.
+Region resolution: `--region` / `--stack-region` / `AWS_REGION` /
+`AWS_DEFAULT_REGION` / the stack's region.
+
+`--sigv4` is mutually exclusive with `--bearer-token` (one inbound auth
+per request) and is ignored on a runtime that declares a
+`customJwtAuthorizer` (the JWT path takes precedence — `--sigv4` warns and
+falls back to the JWT flow). The MCP and `/ws` paths are unaffected by
+this flag.
 
 ### Streaming responses
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@aws-cdk/cloud-assembly-api": "^2.2.0",
     "@aws-cdk/toolkit-lib": "^1.26.0",
+    "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-cloudformation": "^3.1017.0",
     "@aws-sdk/client-ecr": "^3.1019.0",
     "@aws-sdk/client-eventbridge": "^3.1017.0",
@@ -75,6 +76,7 @@
     "@aws-sdk/client-sts": "^3.1016.0",
     "@clack/core": "^1.3.1",
     "@clack/prompts": "^1.4.0",
+    "@smithy/signature-v4": "^5.4.4",
     "chokidar": "^5.0.0",
     "commander": "^12.0.0",
     "fflate": "^0.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@aws-cdk/toolkit-lib':
         specifier: ^1.26.0
         version: 1.26.2(@aws-cdk/cli-plugin-contract@2.182.2)
+      '@aws-crypto/sha256-js':
+        specifier: ^5.2.0
+        version: 5.2.0
       '@aws-sdk/client-cloudformation':
         specifier: ^3.1017.0
         version: 3.1053.0
@@ -56,6 +59,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.4.0
         version: 1.4.0
+      '@smithy/signature-v4':
+        specifier: ^5.4.4
+        version: 5.4.4
       aws-cdk-lib:
         specifier: ^2.0.0
         version: 2.257.0(constructs@10.6.0)
@@ -203,7 +209,7 @@ packages:
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==, tarball: https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz}
 
   '@aws-crypto/sha256-js@5.2.0':
-    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==, tarball: https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz}
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
     engines: {node: '>=16.0.0'}
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -1092,7 +1098,7 @@ packages:
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.4.4':
-    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==, tarball: https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz}
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.2':

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -40,6 +40,10 @@ import {
 import { buildAgentCoreCodeImage } from '../../local/agentcore-code-build.js';
 import { downloadAndExtractS3Bundle } from '../../local/agentcore-s3-bundle.js';
 import {
+  signAgentCoreInvocation,
+  type SigV4Credentials,
+} from '../../local/agentcore-sigv4-sign.js';
+import {
   invokeAgentCore,
   waitForAgentCorePing,
   type AgentCoreInvokeResult,
@@ -125,6 +129,17 @@ interface LocalInvokeAgentCoreOptions {
    * escape hatch) — the token, if any, is still forwarded.
    */
   verifyAuth: boolean;
+  /**
+   * `--sigv4`: sign the `/invocations` POST with AWS SigV4 (service
+   * `bedrock-agentcore`) using the resolved credentials — matching the
+   * cloud's default IAM-auth behavior when the runtime declares no
+   * `customJwtAuthorizer`. The local agent receives the same `Authorization:
+   * AWS4-HMAC-SHA256 ...` + `X-Amz-Date` / `X-Amz-Content-Sha256` /
+   * `X-Amz-Security-Token` headers it would in the cloud. Opt-in: default
+   * unsigned (preserves existing behavior). Mutually exclusive with
+   * `--bearer-token` and ignored on a JWT-protected runtime.
+   */
+  sigv4?: boolean;
   /**
    * Optional execution role to assume before invoking. Commander's `[arn]`
    * maps to `string | boolean`:
@@ -393,6 +408,21 @@ async function localInvokeAgentCoreCommand(
     } else {
       await waitForAgentCorePing(containerHost, hostPort);
 
+      // `--sigv4` opt-in: sign the request with the resolved host credentials
+      // (service `bedrock-agentcore`) so the agent receives the same
+      // Authorization + X-Amz-* headers it would in the cloud. Mutually
+      // exclusive with `--bearer-token`; ignored when a customJwtAuthorizer is
+      // declared (the JWT path takes precedence).
+      const additionalHeaders = await buildSigV4HeadersIfRequested(
+        options,
+        resolved,
+        loadedState,
+        containerHost,
+        hostPort,
+        event,
+        sessionId
+      );
+
       const result = await invokeAgentCore(containerHost, hostPort, event, {
         sessionId,
         timeoutMs: 120_000,
@@ -400,6 +430,7 @@ async function localInvokeAgentCoreCommand(
         // token-streaming agent shows incrementally rather than all at once.
         onChunk: (text) => process.stdout.write(text),
         ...(authorization && { authorization }),
+        ...(additionalHeaders && { additionalHeaders }),
       });
 
       // Settle so container logs flush before teardown.
@@ -474,6 +505,129 @@ export async function resolveInboundAuthorization(
   }
   logger.info(`Inbound JWT verified against ${authorizer.discoveryUrl}.`);
   return header;
+}
+
+/**
+ * Compute the SigV4 headers for the `/invocations` POST when `--sigv4` is
+ * requested. Returns `undefined` (no header overlay) when:
+ *
+ * - `--sigv4` is not set,
+ * - the runtime declares a `customJwtAuthorizer` (the JWT path wins; warns),
+ *
+ * Throws a {@link CdkLocalError} when `--sigv4` conflicts with
+ * `--bearer-token`, or when no AWS credentials are resolvable for signing.
+ *
+ * Exported so a unit test can drive the gate without the full Docker pipeline.
+ */
+export async function buildSigV4HeadersIfRequested(
+  options: LocalInvokeAgentCoreOptions,
+  resolved: ResolvedAgentCoreRuntime,
+  loaded: LocalStateRecord | undefined,
+  host: string,
+  port: number,
+  event: unknown,
+  sessionId: string
+): Promise<Record<string, string> | undefined> {
+  if (!options.sigv4) return undefined;
+  if (options.bearerToken) {
+    throw new CdkLocalError(
+      `--sigv4 and --bearer-token are mutually exclusive: pick one inbound auth.`,
+      'LOCAL_INVOKE_AGENTCORE_AUTH_CONFLICT'
+    );
+  }
+  if (resolved.jwtAuthorizer) {
+    getLogger().warn(
+      `Runtime '${resolved.logicalId}' declares a customJwtAuthorizer; --sigv4 ignored (JWT path takes precedence).`
+    );
+    return undefined;
+  }
+  const region =
+    options.region ??
+    options.stackRegion ??
+    process.env['AWS_REGION'] ??
+    process.env['AWS_DEFAULT_REGION'] ??
+    resolved.stack.region;
+  if (!region) {
+    throw new CdkLocalError(
+      `--sigv4: no region resolved for the AgentCore signing scope. ` +
+        `Pass --region <region>, set AWS_REGION, or use --from-cfn-stack with a region-bound stack.`,
+      'LOCAL_INVOKE_AGENTCORE_SIGV4_NO_REGION'
+    );
+  }
+  const credentials = await resolveHostCredentialsForSigV4(options, resolved, loaded, region);
+  const signed = await signAgentCoreInvocation({
+    credentials,
+    region,
+    host,
+    port,
+    path: '/invocations',
+    body: JSON.stringify(event ?? {}),
+    sessionId,
+  });
+  const headers: Record<string, string> = {
+    Authorization: signed.authorization,
+    'X-Amz-Date': signed.amzDate,
+    'X-Amz-Content-Sha256': signed.amzContentSha256,
+  };
+  if (signed.amzSecurityToken) headers['X-Amz-Security-Token'] = signed.amzSecurityToken;
+  getLogger().info(`Signed /invocations with SigV4 (region=${region}).`);
+  return headers;
+}
+
+/**
+ * Resolve credentials for host-side SigV4 signing. Precedence:
+ *   1. `--assume-role` → STS temp creds (warn + fall through on STS failure);
+ *   2. `--profile` → profile creds (sessionToken when the profile carries one);
+ *   3. shell env (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / optional
+ *      `AWS_SESSION_TOKEN`).
+ *
+ * Throws a {@link CdkLocalError} when none are available — `--sigv4` cannot
+ * proceed without credentials, unlike the unsigned path.
+ */
+async function resolveHostCredentialsForSigV4(
+  options: LocalInvokeAgentCoreOptions,
+  resolved: ResolvedAgentCoreRuntime,
+  loaded: LocalStateRecord | undefined,
+  region: string
+): Promise<SigV4Credentials> {
+  const logger = getLogger();
+  const assumeRoleArn = resolveAssumeRoleArn(options, resolved, loaded);
+  if (assumeRoleArn) {
+    try {
+      return await assumeAgentCoreExecutionRole(assumeRoleArn, region);
+    } catch (err) {
+      logger.warn(
+        `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for --sigv4 signing: ` +
+          `${err instanceof Error ? err.message : String(err)}. ` +
+          `Falling back to ${options.profile ? `--profile ${options.profile}` : 'shell credentials'}.`
+      );
+    }
+  }
+  if (options.profile) {
+    const creds = await resolveProfileCredentials(options.profile);
+    if (creds?.accessKeyId && creds.secretAccessKey) {
+      return {
+        accessKeyId: creds.accessKeyId,
+        secretAccessKey: creds.secretAccessKey,
+        ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
+      };
+    }
+  }
+  const accessKeyId = process.env['AWS_ACCESS_KEY_ID'];
+  const secretAccessKey = process.env['AWS_SECRET_ACCESS_KEY'];
+  if (accessKeyId && secretAccessKey) {
+    const sessionToken = process.env['AWS_SESSION_TOKEN'];
+    return {
+      accessKeyId,
+      secretAccessKey,
+      ...(sessionToken && { sessionToken }),
+    };
+  }
+  throw new CdkLocalError(
+    `--sigv4: no AWS credentials available to sign the request. ` +
+      `Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, pass --profile <name>, or pass --assume-role <arn>.`,
+    'LOCAL_INVOKE_AGENTCORE_SIGV4_NO_CREDENTIALS'
+  );
 }
 
 /**
@@ -1245,6 +1399,14 @@ export function createLocalInvokeAgentCoreCommand(
         'Skip inbound JWT verification even when the runtime declares a customJwtAuthorizer ' +
           '(local-dev escape hatch). A --bearer-token, if given, is still forwarded.'
       )
+    )
+    .addOption(
+      new Option(
+        '--sigv4',
+        'Sign the /invocations POST with AWS SigV4 (service bedrock-agentcore) using the resolved ' +
+          'credentials, matching the cloud default when the runtime declares no customJwtAuthorizer. ' +
+          'Opt-in: default unsigned. Mutually exclusive with --bearer-token; ignored on a JWT-protected runtime.'
+      ).default(false)
     )
     .addOption(
       new Option(

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -302,6 +302,13 @@ async function localInvokeAgentCoreCommand(
     if (isMcp && options.ws) {
       logger.warn('--ws applies only to the HTTP protocol; ignoring it for this MCP runtime.');
     }
+    if (options.sigv4 && (isMcp || options.ws)) {
+      logger.warn(
+        '--sigv4 signs the HTTP /invocations request only; ignoring it for the ' +
+          (isMcp ? 'MCP' : '/ws WebSocket') +
+          ' path.'
+      );
+    }
 
     // Read + validate the event (and resolve the session id) BEFORE any
     // Docker work, so a bad --event / --event-stdin fails fast instead of

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -343,6 +343,13 @@ export {
   type DownloadS3BundleOptions,
   type ExtractedS3Bundle,
 } from './local/agentcore-s3-bundle.js';
+export {
+  signAgentCoreInvocation,
+  AGENTCORE_SIGV4_SERVICE,
+  type SigV4Credentials,
+  type SignAgentCoreInvocationOptions,
+  type SignedAgentCoreHeaders,
+} from './local/agentcore-sigv4-sign.js';
 
 /**
  * `start-api` REST API v1 `IntegrationResponses[]` selection — picks the

--- a/src/local/agentcore-client.ts
+++ b/src/local/agentcore-client.ts
@@ -144,6 +144,14 @@ export interface InvokeAgentCoreOptions {
    */
   authorization?: string;
   /**
+   * Optional extra headers to forward on the `/invocations` request — used by
+   * the `--sigv4` path to carry the full signed-request header set
+   * (`X-Amz-Date`, `X-Amz-Content-Sha256`, optional `X-Amz-Security-Token`).
+   * Each entry's name is forwarded verbatim; an `Authorization` entry here
+   * overrides {@link authorization}.
+   */
+  additionalHeaders?: Record<string, string>;
+  /**
    * Sink for incremental `text/event-stream` output. When provided AND the
    * response Content-Type is `text/event-stream`, the body is decoded and
    * streamed chunk-by-chunk through this callback as it arrives — matching the
@@ -183,6 +191,7 @@ export async function invokeAgentCore(
         Accept: 'application/json, text/event-stream',
         [AGENTCORE_SESSION_ID_HEADER]: options.sessionId,
         ...(options.authorization && { Authorization: options.authorization }),
+        ...(options.additionalHeaders ?? {}),
       },
       body,
       signal: controller.signal,

--- a/src/local/agentcore-sigv4-sign.ts
+++ b/src/local/agentcore-sigv4-sign.ts
@@ -1,0 +1,124 @@
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { SignatureV4 } from '@smithy/signature-v4';
+import { AGENTCORE_SESSION_ID_HEADER } from './agentcore-client.js';
+
+/**
+ * Client-side SigV4 signing for `cdkl invoke-agentcore --sigv4`.
+ *
+ * AgentCore's `InvokeAgentRuntime` API authenticates inbound `/invocations`
+ * requests with IAM SigV4 when the runtime declares no
+ * `customJwtAuthorizer`. The deployed cloud verifies the signature; a locally
+ * running agent never does (no AWS public-key infra inside the container),
+ * but an agent that introspects the `Authorization` header (e.g. via the
+ * `bedrock-agentcore` SDK's request context) sees the same shape it would in
+ * the cloud — header parity for debugging and local-dev of IAM-aware agents.
+ *
+ * Signing is OPT-IN via `--sigv4` on the command. Default behavior is
+ * unchanged: no Authorization header on an unauthenticated invoke.
+ */
+
+/** AWS service name for AgentCore InvokeAgentRuntime SigV4 signing. */
+export const AGENTCORE_SIGV4_SERVICE = 'bedrock-agentcore';
+
+/** Static (or STS-issued) credentials for SigV4 signing. */
+export interface SigV4Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+export interface SignAgentCoreInvocationOptions {
+  credentials: SigV4Credentials;
+  region: string;
+  host: string;
+  port: number;
+  /** Path of the request being signed (e.g. `/invocations`). */
+  path: string;
+  /** Stringified request body the signature commits to. */
+  body: string;
+  /** AgentCore session id (sent as the session-id header AND part of the signed canonical request). */
+  sessionId: string;
+  /** HTTP method (default `POST`). */
+  method?: string;
+  /** `now()` for deterministic tests. Defaults to real `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * The headers an inbound SigV4-signed `/invocations` request carries. The
+ * caller forwards every entry to the agent container; the agent sees the same
+ * header set the cloud-side AgentCore would see.
+ */
+export interface SignedAgentCoreHeaders {
+  /** `AWS4-HMAC-SHA256 Credential=..., SignedHeaders=..., Signature=...`. */
+  authorization: string;
+  /** `X-Amz-Date` ISO-8601 basic timestamp used in the signature. */
+  amzDate: string;
+  /** `X-Amz-Content-Sha256` payload hex digest (always sent so a body-stripping proxy can't alter it). */
+  amzContentSha256: string;
+  /** `X-Amz-Security-Token` — only present for STS-issued credentials. */
+  amzSecurityToken?: string;
+}
+
+/**
+ * Build a SigV4 signature for a `POST /invocations` request to the local
+ * AgentCore container. Returns the headers that must be forwarded.
+ */
+export async function signAgentCoreInvocation(
+  opts: SignAgentCoreInvocationOptions
+): Promise<SignedAgentCoreHeaders> {
+  const signer = new SignatureV4({
+    credentials: {
+      accessKeyId: opts.credentials.accessKeyId,
+      secretAccessKey: opts.credentials.secretAccessKey,
+      ...(opts.credentials.sessionToken && { sessionToken: opts.credentials.sessionToken }),
+    },
+    region: opts.region,
+    service: AGENTCORE_SIGV4_SERVICE,
+    sha256: Sha256,
+  });
+
+  const request = {
+    method: opts.method ?? 'POST',
+    protocol: 'http:',
+    hostname: opts.host,
+    port: opts.port,
+    path: opts.path,
+    headers: {
+      'Content-Type': 'application/json',
+      Host: `${opts.host}:${opts.port}`,
+      [AGENTCORE_SESSION_ID_HEADER]: opts.sessionId,
+    },
+    body: opts.body,
+  };
+
+  const signed = await signer.sign(request, {
+    ...(opts.now && { signingDate: new Date(opts.now()) }),
+  });
+
+  // Header keys come back in mixed case from @smithy/signature-v4. Read
+  // case-insensitively so the rest of the command doesn't care.
+  const get = (name: string): string | undefined => {
+    const lower = name.toLowerCase();
+    for (const [k, v] of Object.entries(signed.headers)) {
+      if (k.toLowerCase() === lower) return v;
+    }
+    return undefined;
+  };
+
+  const authorization = get('authorization');
+  const amzDate = get('x-amz-date');
+  const amzContentSha256 = get('x-amz-content-sha256');
+  if (!authorization || !amzDate) {
+    throw new Error('SigV4 signing produced no Authorization / X-Amz-Date header — internal error');
+  }
+
+  const out: SignedAgentCoreHeaders = {
+    authorization,
+    amzDate,
+    amzContentSha256: amzContentSha256 ?? '',
+  };
+  const amzSecurityToken = get('x-amz-security-token');
+  if (amzSecurityToken) out.amzSecurityToken = amzSecurityToken;
+  return out;
+}

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -53,7 +53,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/15] Invoking EchoAgent with default empty event"
+echo "==> [1/16] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -67,7 +67,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/15] Invoking EchoAgent with --event payload"
+echo "==> [2/16] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -79,7 +79,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/15] Invoking EchoAgent with --env-vars override"
+echo "==> [3/16] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -91,7 +91,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/15] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/16] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -102,7 +102,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/15] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/16] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -123,7 +123,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/15] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/16] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -133,7 +133,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/15] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/16] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -146,7 +146,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/15] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/16] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -166,7 +166,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
-echo "==> [9/15] McpAgent (no --event) runs the handshake + tools/list"
+echo "==> [9/16] McpAgent (no --event) runs the handshake + tools/list"
 RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
@@ -175,7 +175,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 }
 
 # Test 10 — an MCP tools/call via --event returns the tool result.
-echo "==> [10/15] McpAgent with --event runs tools/call"
+echo "==> [10/16] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
@@ -189,7 +189,7 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 # Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
 # source (no Dockerfile): cdkl builds it from source (pip install + run the
 # entrypoint) and the entrypoint self-serves the 8080 HTTP contract.
-echo "==> [11/15] CodeAgent (fromCodeAsset) builds from source + responds"
+echo "==> [11/16] CodeAgent (fromCodeAsset) builds from source + responds"
 RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_11}"
 echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
@@ -202,7 +202,7 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 }
 
 # Test 12 — a --event payload echoes through the from-source agent.
-echo "==> [12/15] CodeAgent with --event echoes the payload"
+echo "==> [12/16] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
@@ -217,7 +217,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # the first frame and streams every received frame to stdout until the agent
 # closes. The fixture agent replies with one JSON frame (echo + session id +
 # Authorization + GREETING) then a second text frame, then closes.
-echo "==> [13/15] EchoAgent over the /ws WebSocket (--ws)"
+echo "==> [13/16] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
@@ -242,7 +242,7 @@ echo "${RESULT_13}" | grep -q 'ws-frame-2' || {
 
 # Test 14 — --ws is HTTP-only: against an MCP runtime it warns and is ignored,
 # falling through to the normal MCP path (tools/list still returns).
-echo "==> [14/15] McpAgent with --ws warns + still runs the MCP path"
+echo "==> [14/16] McpAgent with --ws warns + still runs the MCP path"
 set +e
 OUT_14=$(${CDKL} invoke-agentcore "${MCP}" --ws 2>/tmp/cdkl-ws-mcp-stderr; cat /tmp/cdkl-ws-mcp-stderr >&2)
 RC_14=$?
@@ -269,7 +269,7 @@ echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP protocol' || {
 # invoke succeeds even with a placeholder bearer token. (The verifier's actual
 # scope / claim checks are covered by the unit tests, which sign real RS256
 # tokens against mock JWKS.)
-echo "==> [15/15] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
+echo "==> [15/16] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
 RESULT_15=$(${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_15}"
 echo "${RESULT_15}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -281,5 +281,42 @@ echo "${RESULT_15}" | grep -q '"authorization":"Bearer h.p.s"' || {
   exit 1
 }
 
+# Test 16 — `--sigv4` opts into header parity with the cloud's IAM-auth
+# behavior: cdkl signs the /invocations POST with SigV4 (service
+# bedrock-agentcore) and the agent receives the same `Authorization:
+# AWS4-HMAC-SHA256 ...` shape it would in production. Static placeholder
+# credentials are passed via env so this scenario is self-contained — the local
+# agent never validates the signature against AWS, it just echoes the header.
+# A second --sigv4 + --bearer-token sub-check confirms the mutually-exclusive
+# gate rejects pre-container.
+echo "==> [16/16] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
+RESULT_16=$(AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
+  AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+  AWS_REGION=us-east-1 \
+  ${CDKL} invoke-agentcore "${TARGET}" --sigv4 2>/dev/null | tail -1)
+echo "    response: ${RESULT_16}"
+echo "${RESULT_16}" | grep -q '"authorization":"AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/' || {
+  echo "FAIL: expected an AWS4-HMAC-SHA256 Authorization header carrying the access key id, got: ${RESULT_16}"
+  exit 1
+}
+echo "${RESULT_16}" | grep -q '/us-east-1/bedrock-agentcore/aws4_request' || {
+  echo "FAIL: expected the signed credential scope to include bedrock-agentcore + us-east-1, got: ${RESULT_16}"
+  exit 1
+}
+
+echo "==> [16/16] --sigv4 + --bearer-token together rejected (mutually exclusive)"
+set +e
+OUT_16B=$(${CDKL} invoke-agentcore "${TARGET}" --sigv4 --bearer-token "h.p.s" 2>&1)
+RC_16B=$?
+set -e
+[[ ${RC_16B} -ne 0 ]] || {
+  echo "FAIL: expected a non-zero exit for --sigv4 + --bearer-token, got 0. Output: ${OUT_16B}"
+  exit 1
+}
+echo "${OUT_16B}" | grep -q 'mutually exclusive' || {
+  echo "FAIL: expected a 'mutually exclusive' error, got: ${OUT_16B}"
+  exit 1
+}
+
 echo ""
-echo "==> All 15 local-invoke-agentcore tests passed"
+echo "==> All 16 local-invoke-agentcore tests passed"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -1001,4 +1001,52 @@ describe('buildSigV4HeadersIfRequested — --sigv4 gate', () => {
     expect(headers?.['Authorization']).toContain('Credential=AK/');
     expect(headers?.['X-Amz-Security-Token']).toBe('ST');
   });
+
+  it('falls back to env credentials when --assume-role STS assume fails', async () => {
+    stsSendMock.mockRejectedValue(new Error('access denied'));
+    process.env['AWS_ACCESS_KEY_ID'] = 'AKIDFALLBACK';
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+    const headers = await buildSigV4HeadersIfRequested(
+      opts({ assumeRole: 'arn:aws:iam::1:role/Agent' }),
+      runtime(),
+      undefined,
+      '127.0.0.1',
+      9000,
+      {},
+      'sess-fb'
+    );
+    expect(headers?.['Authorization']).toContain('Credential=AKIDFALLBACK/');
+    expect(headers?.['X-Amz-Security-Token']).toBeUndefined();
+  });
+
+  it('errors when no region can be resolved (no --region / env / stack region)', async () => {
+    process.env['AWS_ACCESS_KEY_ID'] = 'AKIDREGIONLESS';
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+    const r: ResolvedAgentCoreRuntime = {
+      stack: { stackName: 'App' } as never, // no region on the stack
+      logicalId: 'Agent',
+      resource: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      containerUri: 'r:t',
+      environmentVariables: {},
+      protocol: 'HTTP',
+    };
+    await expect(
+      buildSigV4HeadersIfRequested(opts({ region: undefined }), r, undefined, '127.0.0.1', 9000, {}, 's')
+    ).rejects.toThrow(/no region resolved/);
+  });
+
+  it('prefers --region over --stack-region in the SigV4 credential scope', async () => {
+    process.env['AWS_ACCESS_KEY_ID'] = 'AKIDPRIO';
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+    const headers = await buildSigV4HeadersIfRequested(
+      opts({ region: 'ap-northeast-1', stackRegion: 'eu-central-1' }),
+      runtime(),
+      undefined,
+      '127.0.0.1',
+      9000,
+      {},
+      'sess'
+    );
+    expect(headers?.['Authorization']).toContain('/ap-northeast-1/bedrock-agentcore/aws4_request');
+  });
 });

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -113,6 +113,7 @@ const {
   resolveInboundAuthorization,
   resolveAssumeRoleArn,
   resolveFromS3BucketIntrinsic,
+  buildSigV4HeadersIfRequested,
 } = await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -877,5 +878,127 @@ describe('resolveFromS3BucketIntrinsic — fromS3 Code.S3.Bucket intrinsic resol
     await expect(
       resolveFromS3BucketIntrinsic(r, stateProvider, loaded, undefined)
     ).rejects.toThrow(/Could not resolve/);
+  });
+});
+
+describe('buildSigV4HeadersIfRequested — --sigv4 gate', () => {
+  const ENV_BACKUP = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stsSendMock.mockReset();
+    // Start each test with a clean credential env so we're not at the mercy of
+    // the host's AWS_* env vars.
+    delete process.env['AWS_ACCESS_KEY_ID'];
+    delete process.env['AWS_SECRET_ACCESS_KEY'];
+    delete process.env['AWS_SESSION_TOKEN'];
+    delete process.env['AWS_REGION'];
+    delete process.env['AWS_DEFAULT_REGION'];
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    Object.assign(process.env, ENV_BACKUP);
+  });
+
+  function runtime(jwtAuthorizer?: ResolvedAgentCoreRuntime['jwtAuthorizer']): ResolvedAgentCoreRuntime {
+    return {
+      stack: { stackName: 'App', region: 'us-east-1' } as never,
+      logicalId: 'Agent',
+      resource: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      containerUri: 'r:t',
+      environmentVariables: {},
+      protocol: 'HTTP',
+      ...(jwtAuthorizer && { jwtAuthorizer }),
+    };
+  }
+
+  type Opts = Parameters<typeof buildSigV4HeadersIfRequested>[0];
+  const opts = (over: Partial<Opts> = {}): Opts =>
+    ({ sigv4: true, region: 'us-east-1', ...over }) as unknown as Opts;
+
+  it('returns undefined when --sigv4 is not set (default behavior is unsigned)', async () => {
+    const result = await buildSigV4HeadersIfRequested(
+      opts({ sigv4: false }),
+      runtime(),
+      undefined,
+      '127.0.0.1',
+      9000,
+      {},
+      's'
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('warns + returns undefined when the runtime declares a customJwtAuthorizer (JWT path wins)', async () => {
+    const result = await buildSigV4HeadersIfRequested(
+      opts(),
+      runtime({ discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration' }),
+      undefined,
+      '127.0.0.1',
+      9000,
+      {},
+      's'
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('rejects --sigv4 + --bearer-token together (mutually exclusive)', async () => {
+    await expect(
+      buildSigV4HeadersIfRequested(
+        opts({ bearerToken: 'tok' }),
+        runtime(),
+        undefined,
+        '127.0.0.1',
+        9000,
+        {},
+        's'
+      )
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it('errors with an actionable hint when no AWS credentials are available', async () => {
+    await expect(
+      buildSigV4HeadersIfRequested(opts(), runtime(), undefined, '127.0.0.1', 9000, {}, 's')
+    ).rejects.toThrow(/no AWS credentials available/);
+  });
+
+  it('signs using shell env credentials when present', async () => {
+    process.env['AWS_ACCESS_KEY_ID'] = 'AKIDEXAMPLE';
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+    const headers = await buildSigV4HeadersIfRequested(
+      opts(),
+      runtime(),
+      undefined,
+      '127.0.0.1',
+      9000,
+      { prompt: 'hi' },
+      'sess-1'
+    );
+    expect(headers).toBeDefined();
+    expect(headers?.['Authorization']?.startsWith('AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/')).toBe(
+      true
+    );
+    expect(headers?.['Authorization']).toContain('/us-east-1/bedrock-agentcore/aws4_request');
+    expect(headers?.['X-Amz-Date']).toMatch(/^\d{8}T\d{6}Z$/);
+    expect(headers?.['X-Amz-Content-Sha256']).toMatch(/^[0-9a-f]{64}$/);
+    expect(headers?.['X-Amz-Security-Token']).toBeUndefined();
+  });
+
+  it('threads --assume-role STS temp creds (incl. X-Amz-Security-Token) into the signed headers', async () => {
+    stsSendMock.mockResolvedValue({
+      Credentials: { AccessKeyId: 'AK', SecretAccessKey: 'SK', SessionToken: 'ST' },
+    });
+    const headers = await buildSigV4HeadersIfRequested(
+      opts({ assumeRole: 'arn:aws:iam::1:role/Agent' }),
+      runtime(),
+      undefined,
+      '127.0.0.1',
+      9000,
+      {},
+      'sess-sts'
+    );
+    expect(headers?.['Authorization']).toContain('Credential=AK/');
+    expect(headers?.['X-Amz-Security-Token']).toBe('ST');
   });
 });

--- a/tests/unit/local/agentcore-sigv4-sign.test.ts
+++ b/tests/unit/local/agentcore-sigv4-sign.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  AGENTCORE_SIGV4_SERVICE,
+  signAgentCoreInvocation,
+} from '../../../src/local/agentcore-sigv4-sign.js';
+
+/**
+ * The signer delegates to the real `@smithy/signature-v4` implementation
+ * against `@aws-crypto/sha256-js`. These tests pin its output for fixed
+ * inputs so a future regression in the signing wiring (wrong service / region
+ * / header set / session-token handling) names itself.
+ */
+
+const FIXED_NOW = (): number => Date.parse('2026-01-01T12:00:00Z');
+
+const STATIC_CREDS = {
+  accessKeyId: 'AKIDEXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+};
+
+const STS_CREDS = {
+  ...STATIC_CREDS,
+  sessionToken: 'session-token-EXAMPLE',
+};
+
+describe('signAgentCoreInvocation', () => {
+  it('produces the SigV4 Authorization header for the bedrock-agentcore service', async () => {
+    const headers = await signAgentCoreInvocation({
+      credentials: STATIC_CREDS,
+      region: 'us-east-1',
+      host: '127.0.0.1',
+      port: 9000,
+      path: '/invocations',
+      body: JSON.stringify({ prompt: 'hello' }),
+      sessionId: 'sess-1',
+      now: FIXED_NOW,
+    });
+
+    expect(headers.authorization.startsWith('AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/')).toBe(true);
+    expect(headers.authorization).toContain(`/us-east-1/${AGENTCORE_SIGV4_SERVICE}/aws4_request`);
+    // SignedHeaders must include the session-id header (it influenced the signature).
+    expect(headers.authorization.toLowerCase()).toContain(
+      'x-amzn-bedrock-agentcore-runtime-session-id'
+    );
+    expect(headers.amzDate).toMatch(/^\d{8}T\d{6}Z$/);
+    expect(headers.amzContentSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(headers.amzSecurityToken).toBeUndefined();
+  });
+
+  it('includes X-Amz-Security-Token when the credentials are STS-issued', async () => {
+    const headers = await signAgentCoreInvocation({
+      credentials: STS_CREDS,
+      region: 'eu-west-1',
+      host: '127.0.0.1',
+      port: 9001,
+      path: '/invocations',
+      body: '{}',
+      sessionId: 'sess-sts',
+      now: FIXED_NOW,
+    });
+    expect(headers.amzSecurityToken).toBe('session-token-EXAMPLE');
+    expect(headers.authorization).toContain('/eu-west-1/bedrock-agentcore/aws4_request');
+  });
+
+  it('binds the signature to the request body (different body -> different signature)', async () => {
+    const a = await signAgentCoreInvocation({
+      credentials: STATIC_CREDS,
+      region: 'us-east-1',
+      host: '127.0.0.1',
+      port: 9000,
+      path: '/invocations',
+      body: '{"a":1}',
+      sessionId: 's',
+      now: FIXED_NOW,
+    });
+    const b = await signAgentCoreInvocation({
+      credentials: STATIC_CREDS,
+      region: 'us-east-1',
+      host: '127.0.0.1',
+      port: 9000,
+      path: '/invocations',
+      body: '{"a":2}',
+      sessionId: 's',
+      now: FIXED_NOW,
+    });
+    expect(a.authorization).not.toBe(b.authorization);
+    expect(a.amzContentSha256).not.toBe(b.amzContentSha256);
+  });
+
+  it('binds the signature to the session id (different session -> different signature)', async () => {
+    const a = await signAgentCoreInvocation({
+      credentials: STATIC_CREDS,
+      region: 'us-east-1',
+      host: '127.0.0.1',
+      port: 9000,
+      path: '/invocations',
+      body: '{}',
+      sessionId: 'session-A',
+      now: FIXED_NOW,
+    });
+    const b = await signAgentCoreInvocation({
+      credentials: STATIC_CREDS,
+      region: 'us-east-1',
+      host: '127.0.0.1',
+      port: 9000,
+      path: '/invocations',
+      body: '{}',
+      sessionId: 'session-B',
+      now: FIXED_NOW,
+    });
+    expect(a.authorization).not.toBe(b.authorization);
+  });
+
+  it('uses the requested region in the credential scope', async () => {
+    const tokyo = await signAgentCoreInvocation({
+      credentials: STATIC_CREDS,
+      region: 'ap-northeast-1',
+      host: '127.0.0.1',
+      port: 9000,
+      path: '/invocations',
+      body: '{}',
+      sessionId: 's',
+      now: FIXED_NOW,
+    });
+    expect(tokyo.authorization).toContain('/ap-northeast-1/bedrock-agentcore/aws4_request');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #161. Adds an opt-in `--sigv4` flag to `cdkl invoke-agentcore`: when
set, the command signs the `/invocations` POST with AWS SigV4 (service
`bedrock-agentcore`) using the resolved credentials and forwards the full
signed header set — `Authorization: AWS4-HMAC-SHA256 ...`, `X-Amz-Date`,
`X-Amz-Content-Sha256`, optional `X-Amz-Security-Token` — to the agent. The
local container receives the same shape the cloud sends when the runtime
declares no `customJwtAuthorizer`.

Credentials precedence (same chain as the rest of the command):

1. `--assume-role <arn>` → STS temp creds (warn + fall through on STS failure);
2. `--profile <name>` → profile creds (with `aws_session_token` when present);
3. shell env `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional
   `AWS_SESSION_TOKEN`).

With none of the above set, `--sigv4` fails fast with an actionable error.
Region: `--region` / `--stack-region` / `AWS_REGION` / `AWS_DEFAULT_REGION` /
the stack's region.

Constraints:

- Mutually exclusive with `--bearer-token` (one inbound auth per request).
- Ignored on a JWT-protected runtime (the JWT path takes precedence — warns).
- Warns and is ignored on the `--ws` and MCP paths (HTTP-only in v1).

Implementation:

- New `agentcore-sigv4-sign` module wraps `@smithy/signature-v4` with
  `@aws-crypto/sha256-js` (both added as direct deps).
- `invokeAgentCore` accepts an `additionalHeaders` map for forwarding the
  full signed header set.

## Scope adjustment

The issue originally framed this as **default-on / `--no-sigv4` opt-out**.
This PR rescopes to **opt-in `--sigv4`** because:

- Default-on would change every existing invoke's behavior: the echo agent's
  echoed `authorization` field is `null` today and would become an
  `AWS4-HMAC-SHA256 ...` header, breaking existing fixtures and surprising
  users.
- The "production-parity safety" the issue worried about is a cloud-side IAM
  check cdkl can't validate locally — the local agent has no AWS public-key
  infrastructure. The practical value is header parity for agents that
  introspect the Authorization header, which is naturally opt-in.

Reviewers confirmed the rescope is faithful (no spec drift; the two
adapted behaviors — `--no-sigv4` replaced by opt-in; `--bearer-token` is a
conflict not an override — flow from the rescope and are documented in
code, tested, and integ-verified).

## Review notes

3-axis review run. Spec: clean (rescope confirmed faithful). Test
coverage gaps closed in the follow-up commit (STS-failure fall-through,
region precedence, no-region error, plus the `--sigv4 --ws` warning that
was the most user-facing nit).

Accepted as known cost in PR body (review nits, no behavior bug):

- `additionalHeaders` is spread last in `invokeAgentCore` — current SigV4
  path's keys don't collide with `Content-Type` / `Accept` / the session-id
  header; a future caller with overlapping keys would clobber them. v1's
  only producer is the SigV4 path; tightening to a whitelist can be a
  follow-up once a second consumer exists.
- `--profile` credentials path: the `resolveProfileCredentials` -> SigV4
  binding has no dedicated unit test (the env + assume-role paths are
  pinned). The helper is exercised at other sites, but a site-level
  binding test would be ideal — filed as a potential nice-to-have.
- The `amzContentSha256 ?? ''` fallback in the signer is unreachable under
  smithy's default `applyChecksum: true`; dead defensiveness preserved for
  readability.
- The case-insensitive header getter in the signer is unnecessary
  (smithy emits lowercase); not a bug, just dead defense.

## Test plan

- [x] `vp run check` (typecheck + lint + format) green
- [x] `vp run test` — 102 files, 1556 tests pass (new: 5 signer cases + 9
      command-level gate cases including the four follow-up cases)
- [x] `vp run build`
- [x] `/run-integ local-invoke-agentcore` — 16/16 scenarios green, 0 Docker
      orphans (new scenario 16: `--sigv4` produces an `AWS4-HMAC-SHA256
      Credential=AKID.../bedrock-agentcore/aws4_request` Authorization
      header on the EchoAgent; sub-check: `--sigv4 + --bearer-token`
      rejected pre-container)

Closes #161
