### PR TITLE
refactor(integ): collapse fromS3-from-cfn two-deploy into single deploy via BucketDeployment

### DIFF
--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/.gitignore
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/.gitignore
@@ -2,5 +2,6 @@
 # is a build artifact, not a committed source (matches the sibling fixtures).
 pnpm-lock.yaml
 
-# Local build scratch for the zipped bundle verify.sh uploads to S3.
-bundle.zip
+# Local build scratch: verify.sh stages the zipped bundle here for the
+# stack's BucketDeployment asset to upload during `cdk deploy`.
+bundle-source/

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/lib/local-invoke-agentcore-froms3-from-cfn-stack.ts
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/lib/local-invoke-agentcore-froms3-from-cfn-stack.ts
@@ -1,11 +1,16 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 import {
   Runtime,
   AgentRuntimeArtifact,
   AgentCoreRuntime,
 } from 'aws-cdk-lib/aws-bedrockagentcore';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for the `cdkl invoke-agentcore` fromS3 + `--from-cfn-stack`
@@ -22,6 +27,13 @@ import {
  *
  * `removalPolicy: DESTROY` + `autoDeleteObjects: true` so `cdk destroy`
  * removes the bucket cleanly after the test (no manual S3 cleanup needed).
+ *
+ * AWS::BedrockAgentCore::Runtime validates the bundle object exists at create
+ * time, so we use `BucketDeployment` (Lambda-backed custom resource) to upload
+ * the bundle in the SAME deploy BEFORE the Runtime is created. The Runtime
+ * `addDependency`s the BucketDeployment so CFn orders them. verify.sh zips
+ * the code-agent into `bundle-source/agent.zip` BEFORE `cdk deploy` so the
+ * BucketDeployment asset picks it up.
  */
 export class LocalInvokeAgentCoreFromS3FromCfnStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -32,29 +44,34 @@ export class LocalInvokeAgentCoreFromS3FromCfnStack extends cdk.Stack {
       autoDeleteObjects: true,
     });
 
-    // Expose the deployed bucket name so verify.sh can upload the bundle to
-    // the same bucket the Ref will resolve to under --from-cfn-stack.
+    // Expose the deployed bucket name so verify.sh can read the Ref's
+    // resolved physical name (used for assertions).
     new cdk.CfnOutput(this, 'BundleBucketName', {
       value: bundleBucket.bucketName,
       description: 'Physical name of the fromS3 bundle bucket (Ref target).',
     });
 
-    // AWS::BedrockAgentCore::Runtime validates the bundle object exists at
-    // create time, so verify.sh deploys in two passes — `withRuntime=false`
-    // creates just the bucket, the bundle is uploaded, then a second deploy
-    // with `withRuntime=true` adds the Runtime. The Code.S3.Bucket reference
-    // (`bundleBucket.bucketName`) is a same-stack `Ref` intrinsic — the
-    // shape #157 resolves against --from-cfn-stack state.
-    const withRuntime = this.node.tryGetContext('withRuntime') === 'true';
-    if (withRuntime) {
-      new Runtime(this, 'S3Agent', {
-        agentRuntimeArtifact: AgentRuntimeArtifact.fromS3(
-          { bucketName: bundleBucket.bucketName, objectKey: 'bundles/agent.zip' },
-          AgentCoreRuntime.PYTHON_3_12,
-          ['app.py']
-        ),
-        environmentVariables: { GREETING: 'hello-from-s3-ref' },
-      });
-    }
+    // BucketDeployment unpacks the CDK asset zip and uploads each contained
+    // file to `<destinationKeyPrefix>/<filename>`. verify.sh stages
+    // `bundle-source/agent.zip`, so the Lambda uploads it as
+    // `bundles/agent.zip` — the key the Runtime references.
+    const bundleDeployment = new s3deploy.BucketDeployment(this, 'BundleUpload', {
+      sources: [s3deploy.Source.asset(path.join(__dirname, '../bundle-source'))],
+      destinationBucket: bundleBucket,
+      destinationKeyPrefix: 'bundles',
+    });
+
+    const runtime = new Runtime(this, 'S3Agent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromS3(
+        { bucketName: bundleBucket.bucketName, objectKey: 'bundles/agent.zip' },
+        AgentCoreRuntime.PYTHON_3_12,
+        ['app.py']
+      ),
+      environmentVariables: { GREETING: 'hello-from-s3-ref' },
+    });
+    // Force CFn to wait for the BucketDeployment custom resource to upload
+    // the bundle BEFORE creating the Runtime (which validates that the
+    // bundle exists at create time).
+    runtime.node.addDependency(bundleDeployment);
   }
 }

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
@@ -9,14 +9,11 @@
 # path (#144) can't resolve locally.
 #
 # `AWS::BedrockAgentCore::Runtime` CFn validates the bundle object exists at
-# create time, so the test deploys in TWO PASSES:
-#   1. `cdk deploy -c withRuntime=false` creates just the bucket,
-#   2. verify.sh zips + uploads the code-agent bundle,
-#   3. `cdk deploy -c withRuntime=true` adds the Runtime referencing the
-#      now-populated bucket via `bucket.bucketName` (a same-stack `Ref`).
-#   4. `cdkl invoke-agentcore <target> --from-cfn-stack` resolves the Ref to
-#      the deployed bucket's physical name and downloads the bundle.
-#   5. `cdk destroy` removes everything (autoDeleteObjects empties the bucket).
+# create time. The stack handles this via a `BucketDeployment` custom resource
+# the Runtime `addDependency`s, so a SINGLE `cdk deploy` uploads the bundle
+# and creates the Runtime in the right order (issue #162). verify.sh just has
+# to zip the code-agent into `bundle-source/agent.zip` BEFORE the deploy so
+# the BucketDeployment asset picks it up.
 #
 # Run via `/run-integ local-invoke-agentcore-froms3-from-cfn` (recommended).
 # Requires Docker, AWS credentials with deploy + S3 permissions, and the global
@@ -62,7 +59,7 @@ cleanup() {
     (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
       --no-version-reporting --no-asset-metadata --no-path-metadata) || true
   fi
-  rm -f "${TEST_DIR}/bundle.zip"
+  rm -rf "${TEST_DIR}/bundle-source"
   [ -n "${EVENT_FILE}" ] && rm -f "${EVENT_FILE}"
   exit "${rc}"
 }
@@ -75,18 +72,22 @@ if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION
   exit 1
 fi
 
-echo "[verify] step 3a: cdk deploy (bucket-only, withRuntime=false)"
+echo "[verify] step 3: stage bundle-source/agent.zip for the BucketDeployment asset"
+rm -rf "${TEST_DIR}/bundle-source"
+mkdir -p "${TEST_DIR}/bundle-source"
+(cd "${TEST_DIR}/code-agent" && zip -qr "${TEST_DIR}/bundle-source/agent.zip" . -x '*.pyc' '__pycache__/*')
+
+echo "[verify] step 4: cdk deploy (BucketDeployment uploads bundle before the Runtime)"
 WE_CREATED_STACK=1
 cdk deploy "${STACK}" \
-  -c withRuntime=false \
   --require-approval never \
   --no-version-reporting \
   --no-asset-metadata \
   --no-path-metadata \
   --region "${REGION}"
-echo "[verify] step 3a ok: bucket deployed"
+echo "[verify] step 4 ok: bucket + bundle + Runtime deployed in one pass"
 
-echo "[verify] step 3b: read the deployed bucket name from the stack output"
+echo "[verify] step 5: read the deployed bucket name from the stack output (for the log)"
 BUCKET=$(aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" \
   --query "Stacks[0].Outputs[?OutputKey=='BundleBucketName'].OutputValue" --output text)
 if [ -z "${BUCKET}" ] || [ "${BUCKET}" = "None" ]; then
@@ -95,26 +96,9 @@ if [ -z "${BUCKET}" ] || [ "${BUCKET}" = "None" ]; then
 fi
 echo "[verify]   bundle bucket: s3://${BUCKET}"
 
-echo "[verify] step 3c: zip code-agent/ and upload as the bundle object (before Runtime create)"
-rm -f "${TEST_DIR}/bundle.zip"
-(cd "${TEST_DIR}/code-agent" && zip -qr "${TEST_DIR}/bundle.zip" . -x '*.pyc' '__pycache__/*')
-aws s3 cp "${TEST_DIR}/bundle.zip" "s3://${BUCKET}/bundles/agent.zip" --region "${REGION}" >/dev/null
-
-echo "[verify] step 3d: cdk deploy (withRuntime=true) — Runtime validates the bundle exists"
-cdk deploy "${STACK}" \
-  -c withRuntime=true \
-  --require-approval never \
-  --no-version-reporting \
-  --no-asset-metadata \
-  --no-path-metadata \
-  --region "${REGION}"
-echo "[verify] step 3d ok: Runtime deployed"
-
 echo "[verify] step 6: cdkl invoke-agentcore --from-cfn-stack (resolves Ref -> ${BUCKET})"
 set +e
-# cdkl runs the same CDK app — pass -c withRuntime=true so the synth includes
-# the Runtime resource the deployed stack also has.
-OUT_STEP6=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack -c withRuntime=true 2>&1)
+OUT_STEP6=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack 2>&1)
 RC_STEP6=$?
 set -e
 RESULT=$(echo "${OUT_STEP6}" | tail -1)
@@ -136,7 +120,7 @@ echo "${RESULT}" | grep -q '"greeting":"hello-from-s3-ref"' || {
 
 echo "[verify] step 7: WITHOUT --from-cfn-stack, intrinsic Code.S3.Bucket fails fast"
 set +e
-OUT_NO_STATE=$(${CLI} invoke-agentcore "${TARGET}" -c withRuntime=true 2>&1)
+OUT_NO_STATE=$(${CLI} invoke-agentcore "${TARGET}" 2>&1)
 RC_NO_STATE=$?
 set -e
 [[ ${RC_NO_STATE} -ne 0 ]] || {
@@ -151,7 +135,7 @@ echo "${OUT_NO_STATE}" | grep -q -- "--from-cfn-stack" || {
 echo "[verify] step 8: --event payload echoes through the fromS3-via-Ref agent"
 EVENT_FILE="$(mktemp)"
 echo '{"prompt":"hello froms3 ref"}' > "${EVENT_FILE}"
-RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack -c withRuntime=true --event "${EVENT_FILE}" 2>/dev/null | tail -1)
+RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack --event "${EVENT_FILE}" 2>/dev/null | tail -1)
 echo "[verify]   response: ${RESULT_EVENT}"
 echo "${RESULT_EVENT}" | grep -q '"prompt":"hello froms3 ref"' || {
   echo "[verify] FAIL: expected the echoed event from the fromS3-via-Ref agent, got: ${RESULT_EVENT}"


### PR DESCRIPTION
## Summary

Closes #162. Replaces the two-deploy context-flagged flow in the
`local-invoke-agentcore-froms3-from-cfn` integ with a single deploy using
`BucketDeployment`.

The old flow shipped in #158 because `AWS::BedrockAgentCore::Runtime` CFn
validates the bundle object exists at create time. A single deploy that
created the bucket alongside the Runtime failed (the bucket is brand new
at create time, no bundle uploaded yet). Workaround: a context flag
`-c withRuntime=false` deployed just the bucket, verify.sh uploaded the
bundle, then `-c withRuntime=true` added the Runtime. cdkl invocations
also had to pass `-c withRuntime=true` so the synth matched the deployed
stack.

This PR replaces that with `s3deploy.BucketDeployment`: a Lambda-backed
CFn custom resource that uploads the bundle in the SAME deploy, BEFORE
the Runtime is created. The Runtime `addDependency`s the BucketDeployment
so CFn orders them.

- Stack: new `s3deploy.BucketDeployment` reading from `../bundle-source/`,
  `destinationKeyPrefix: 'bundles'`. `runtime.node.addDependency(bundleDeployment)`
  forces the CFn ordering. Drops the `-c withRuntime` context flag.
- verify.sh: stage `bundle-source/agent.zip` BEFORE `cdk deploy` (so the
  asset hash is stable), then one deploy → cdkl invoke → destroy. Drops
  the two-pass cdk deploy + the post-deploy `aws s3 cp` + the
  `-c withRuntime=true` thread-through on cdkl invocations.
- `.gitignore`: swap `bundle.zip` for `bundle-source/`.

No `src/**` change; no cdkl behavior change; only the fixture/integ
shape changes. CFn now deploys exactly one stack in one pass; the Runtime
correctly waits for the bundle via the explicit dependency.

## Test plan

- [x] `vp run check` (typecheck + lint + format) green
- [x] `vp run build`
- [x] Synth sanity: stack synthesizes with the Runtime's `DependsOn` listing
      `BundleUploadCustomResource` + `BundleUploadAwsCliLayer`.
- [x] `/run-integ local-invoke-agentcore-froms3-from-cfn` — real-AWS:
      single `cdk deploy` brings up bucket + BucketDeployment (which
      uploads `bundles/agent.zip`) + Runtime; cdkl with `--from-cfn-stack`
      resolves the Ref to the deployed bucket name and downloads the
      bundle; `cdk destroy` removes everything (autoDeleteObjects empties
      the bucket). 0 Docker orphans, 0 leftover CFn stacks, 0 leftover S3
      buckets.

Closes #162
