### PR TITLE
feat(start-alb): terminate HTTPS listeners locally with BYO or auto self-signed cert

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,13 +31,19 @@ AWS managed services.
   counterpart of `start-api`: name the ALB, and it boots the ECS
   service(s) behind it plus a local front-door that round-robins each
   listener port across the replicas and routes the listener rules across
-  the backing services. All six ALB rule-condition fields are honored
-  (`path-pattern`, `host-header`, `http-header`, `http-request-method`,
-  `query-string`, `source-ip`), along with weighted forwards and
-  `redirect` / `fixed-response` actions. A `TargetType: lambda` target
-  group is served by invoking the backing Lambda locally (HTTP request
-  -> `requestContext.elb` event -> RIE -> response), so a forward can
-  mix ECS and Lambda targets
+  the backing services. HTTP **and HTTPS** listeners are served — HTTPS
+  termination uses a user-supplied (`--tls-cert` + `--tls-key`) or
+  auto-generated self-signed cert (cached under
+  `$XDG_CACHE_HOME/cdk-local/alb-https/`, default
+  `~/.cache/cdk-local/alb-https/`; `openssl` invoked once on cache miss);
+  the deployed Listener `Certificates[]` ACM ARNs are not fetched
+  because ACM private keys are not retrievable by design. All six ALB
+  rule-condition fields are honored (`path-pattern`, `host-header`,
+  `http-header`, `http-request-method`, `query-string`, `source-ip`),
+  along with weighted forwards and `redirect` / `fixed-response` actions.
+  A `TargetType: lambda` target group is served by invoking the backing
+  Lambda locally (HTTP request -> `requestContext.elb` event -> RIE ->
+  response), so a forward can mix ECS and Lambda targets
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
@@ -129,10 +135,14 @@ Gateway).
   priority ordered), alb-lambda-event (HTTP <-> ALB
   `requestContext.elb` Lambda event/response translation), front-door-pool
   (round-robin pool of live replica endpoints), front-door-lambda-runner
-  (one warm RIE container per Lambda target), front-door-server (host HTTP
-  reverse proxy that resolves a per-request RouteAction — weighted forward
-  to a replica pool or a Lambda invoke, redirect, or fixed-response —
-  behind the ALB listener port), etc.
+  (one warm RIE container per Lambda target), front-door-tls (resolves
+  TLS materials for HTTPS listeners: `--tls-cert` / `--tls-key` pair or
+  an auto-generated self-signed cert cached under XDG cache via openssl),
+  front-door-server (host HTTP / HTTPS reverse proxy that resolves a
+  per-request RouteAction — weighted forward to a replica pool or a
+  Lambda invoke, redirect, or fixed-response — behind the ALB listener
+  port; HTTPS branch flips `X-Forwarded-Proto` and the redirect
+  `#{protocol}` default to `https`), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 
 ### start-service vs start-alb — which one?
 
-`start-service` runs just the ECS service's replicas (workers, queue consumers, Service-Connect-only). `start-alb` boots the ECS service(s) behind an ALB **plus** a host-side front-door on each listener port, so external traffic reaches them the way it does in the cloud. Full resolution model: [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
+`start-service` runs just the ECS service's replicas (workers, queue consumers, Service-Connect-only). `start-alb` boots the ECS service(s) behind an ALB **plus** a host-side front-door on each listener port — HTTP and HTTPS (TLS terminated locally with `--tls-cert` / `--tls-key` or an auto-generated self-signed cert) — so external traffic reaches them the way it does in the cloud. Full resolution model: [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
 
 ## Supported resources
 
@@ -80,7 +80,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 | ECS task definitions | `run-task` |
 | ECS services | `start-service` |
 | Cloud Map / Service Connect registry | service discovery between local replicas |
-| ALB-fronted ECS / Lambda services | `start-alb` — all six listener-rule conditions, weighted forwards, redirect / fixed-response, mixed ECS + Lambda targets |
+| ALB-fronted ECS / Lambda services | `start-alb` — HTTP / HTTPS listeners, all six listener-rule conditions, weighted forwards, redirect / fixed-response, mixed ECS + Lambda targets |
 | Bedrock AgentCore Runtime agents | `invoke-agentcore` — container + `fromCodeAsset` / `fromS3` artifacts, HTTP + MCP |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1088,7 +1088,7 @@ and name the ALB.
 
 `cdkl start-alb <targets...>` is the ALB counterpart of `cdkl start-api`:
 you name the **Application Load Balancer**, and cdk-local discovers the
-ECS service(s) behind its HTTP listeners, boots their replicas
+ECS service(s) behind its HTTP and HTTPS listeners, boots their replicas
 (the same shared docker network + Cloud Map + restart watcher as
 `start-service`), and stands up a host-side **front-door** on each
 listener port that round-robins each request across the running replicas
@@ -1152,38 +1152,61 @@ Same option set as `cdkl start-service` (`--cluster`, `--max-tasks`,
 | Flag | Default | Behavior |
 | --- | --- | --- |
 | `--lb-port <listenerPort=hostPort>` | — | Bind the front-door on a specific host port (e.g. `80=8080`); repeatable. Default: host port == ALB listener port. Remap a privileged listener port (< 1024) to a non-privileged host port on macOS. |
+| `--tls-cert <path>` | unset | PEM-encoded server certificate for HTTPS front-door listeners. Must be set together with `--tls-key`. Omit both flags to auto-generate a self-signed cert (cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`, defaulting to `~/.cache/cdk-local/alb-https/`); requires `openssl` on PATH. The deployed Listener `Certificates[]` are NOT fetched — ACM private keys are not retrievable by design. |
+| `--tls-key <path>` | unset | PEM-encoded server private key matching `--tls-cert`. Must be set together with `--tls-cert`. |
 
 ```bash
 # ALB listener on :80 -> remap to a non-privileged host port on macOS
 cdkl start-alb MyStack/WebAlb --lb-port 80=8080
 # then: curl http://127.0.0.1:8080/  (round-robins across replicas)
+
+# HTTPS listener on :443 with auto-generated self-signed cert + a
+# non-privileged host port
+cdkl start-alb MyStack/WebAlb --lb-port 443=8443
+# then: curl --insecure https://127.0.0.1:8443/
+
+# HTTPS with a BYO cert (must be set together)
+cdkl start-alb MyStack/WebAlb --tls-cert ./server.pem --tls-key ./server-key.pem
 ```
 
 ### Scope
 
-**HTTP** listeners with **ECS** and **Lambda** targets, with priority-ordered
-listener rules matching every ALB condition field — `path-pattern` and
-`host-header` (ALB `*` / `?` glob; host case-insensitive, path-only excludes the
-query string), `http-header` (case-insensitive name lookup + case-insensitive
-value glob), `http-request-method` (exact uppercase match, no wildcards),
-`query-string` (`{ Key?, Value }` globs, case-insensitive, percent / `+`
-decoded), and `source-ip` (IPv4 / IPv6 CIDR; IPv4-mapped IPv6 source
-addresses are unmapped before matching). Both default actions and rule
+**HTTP** and **HTTPS** listeners with **ECS** and **Lambda** targets, with
+priority-ordered listener rules matching every ALB condition field —
+`path-pattern` and `host-header` (ALB `*` / `?` glob; host case-insensitive,
+path-only excludes the query string), `http-header` (case-insensitive name
+lookup + case-insensitive value glob), `http-request-method` (exact uppercase
+match, no wildcards), `query-string` (`{ Key?, Value }` globs, case-insensitive,
+percent / `+` decoded), and `source-ip` (IPv4 / IPv6 CIDR; IPv4-mapped IPv6
+source addresses are unmapped before matching). Both default actions and rule
 actions support single-target `forward`, **weighted** (multi-target) `forward`
 (weighted-random selection; weight 0 never selected; a forward may mix ECS
 and Lambda targets), `redirect` (301 / 302 with the
 `#{protocol|host|port|path|query}` placeholders resolved against the
-request), and `fixed-response` (synthesized status / content-type / body). A
+request — `#{protocol}` defaults to the listener's own scheme), and
+`fixed-response` (synthesized status / content-type / body). A
 `TargetType: lambda` target group invokes the backing Lambda locally — the
 request becomes the ALB `requestContext.elb` event, runs through the Lambda RIE,
-and the response is translated back (a malformed response → 502). Out of scope,
-skipped with a warning, and tracked in
+and the response is translated back (a malformed response → 502).
+
+For HTTPS listeners the front-door terminates TLS locally using a user-supplied
+cert (`--tls-cert` + `--tls-key`, set together) or an auto-generated self-signed
+cert cached under `~/.cache/cdk-local/alb-https/`. The deployed Listener's
+`Certificates[]` ACM ARNs are not fetched — ACM private keys are not retrievable
+by design, so the local front-door always uses its own cert and warns once that
+the ACM cert was bypassed. Clients should use `curl --insecure` (or trust the
+generated cert) since the cert is self-signed. The `SslPolicy` cipher policy
+is not enforced; the upstream is dialed over plain HTTP (TLS terminated at the
+front-door, not re-encrypted).
+
+Out of scope, skipped with a warning, and tracked in
 [#123](https://github.com/go-to-k/cdk-local/issues/123):
-`authenticate-cognito` / `authenticate-oidc` actions, and HTTPS / TLS
-termination. The local front-door binds the request's `socket.remoteAddress`
-as the source IP, so a `source-ip` CIDR narrower than `127.0.0.0/8` will not
-match traffic that comes in on `127.0.0.1` — exercise such rules from a real
-remote, or use a permissive loopback CIDR for local smoke tests.
+`authenticate-cognito` / `authenticate-oidc` actions; ALB Mutual TLS
+(`MutualAuthentication.Mode: verify`). The local front-door binds the
+request's `socket.remoteAddress` as the source IP, so a `source-ip` CIDR
+narrower than `127.0.0.0/8` will not match traffic that comes in on
+`127.0.0.1` — exercise such rules from a real remote, or use a permissive
+loopback CIDR for local smoke tests.
 
 ### `cdkl start-alb` exit codes
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -76,6 +76,10 @@ import {
   type AlbPathRule,
   type AlbQueryStringCondition,
 } from '../../local/alb-path-matcher.js';
+import {
+  resolveFrontDoorTlsMaterials,
+  type FrontDoorTlsMaterials,
+} from '../../local/front-door-tls.js';
 import type { ResolvedLambda } from '../../local/lambda-resolver.js';
 import {
   createFrontDoorLambdaRunner,
@@ -119,6 +123,18 @@ export interface EcsServiceEmulatorOptions {
   hostPort?: string[];
   /** `--lb-port <listenerPort=hostPort>` front-door overrides (start-alb; repeatable). */
   lbPort?: string[];
+  /**
+   * Path to a PEM-encoded server cert for HTTPS front-door listeners
+   * (start-alb). Must be set together with `--tls-key`. Absent =
+   * auto-generated self-signed cert (cached under
+   * `$XDG_CACHE_HOME/cdk-local/alb-https/`).
+   */
+  tlsCert?: string;
+  /**
+   * Path to a PEM-encoded server private key for HTTPS front-door listeners
+   * (start-alb). Must be set together with `--tls-cert`.
+   */
+  tlsKey?: string;
   platform?: string;
   /** Cap on local replica count regardless of template `DesiredCount`. */
   maxTasks: number;
@@ -210,6 +226,8 @@ export interface PlannedFrontDoorListener {
   listenerPort: number;
   /** Host port to bind (the listener port, or its `--lb-port` override). */
   hostPort: number;
+  /** Listener protocol (`HTTP` or `HTTPS`); drives TLS termination + X-Forwarded-Proto. */
+  protocol: 'HTTP' | 'HTTPS';
   /** Default action (absent for a rules-only listener -> 404 on miss). */
   defaultAction?: PlannedAction;
   /** Rules, evaluated by priority (lower first); each carries up to all six ALB condition fields. */
@@ -790,6 +808,18 @@ export async function buildFrontDoor(
     };
   };
 
+  // Resolve TLS materials lazily — only when an HTTPS listener is in the plan.
+  // Cached after first resolve so multiple HTTPS listeners share one cert.
+  let tlsMaterials: FrontDoorTlsMaterials | undefined;
+  const getTlsMaterials = async (): Promise<FrontDoorTlsMaterials> => {
+    if (tlsMaterials) return tlsMaterials;
+    tlsMaterials = await resolveFrontDoorTlsMaterials({
+      certPath: options.tlsCert,
+      keyPath: options.tlsKey,
+    });
+    return tlsMaterials;
+  };
+
   try {
     for (const listener of plan.listeners) {
       const defaultRoute = listener.defaultAction
@@ -813,17 +843,19 @@ export async function buildFrontDoor(
         sourceIp?: string;
       }): RouteAction | undefined => matchAlbPathRule(req, ruleRoutes) ?? defaultRoute;
 
+      const tls = listener.protocol === 'HTTPS' ? await getTlsMaterials() : undefined;
       const server = await startFrontDoorServer({
         route,
         port: listener.hostPort,
         host: containerHost,
         listenerPort: listener.listenerPort,
         label: `listener port ${listener.listenerPort}`,
+        ...(tls ? { tls } : {}),
       });
       servers.push(server);
 
       logger.info(
-        `ALB front-door: http://${server.host}:${server.port} (listener port ${listener.listenerPort})`
+        `ALB front-door: ${server.scheme}://${server.host}:${server.port} (listener port ${listener.listenerPort})`
       );
       if (listener.defaultAction) {
         logger.info(`  default -> ${describeAction(listener.defaultAction)}`);

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -808,17 +808,18 @@ export async function buildFrontDoor(
     };
   };
 
-  // Resolve TLS materials lazily — only when an HTTPS listener is in the plan.
-  // Cached after first resolve so multiple HTTPS listeners share one cert.
-  let tlsMaterials: FrontDoorTlsMaterials | undefined;
-  const getTlsMaterials = async (): Promise<FrontDoorTlsMaterials> => {
-    if (tlsMaterials) return tlsMaterials;
-    tlsMaterials = await resolveFrontDoorTlsMaterials({
-      certPath: options.tlsCert,
-      keyPath: options.tlsKey,
-    });
-    return tlsMaterials;
-  };
+  // Resolve TLS materials once, up front, when any HTTPS listener is in the
+  // plan. Kept OUTSIDE the surrounding try/catch so a TLS resolution failure
+  // (e.g. openssl missing, BYO PEM unreadable) surfaces its own actionable
+  // error instead of being re-wrapped in the generic `--lb-port` port-bind
+  // envelope below. A single resolve is shared across every HTTPS listener.
+  const hasHttpsListener = plan.listeners.some((l) => l.protocol === 'HTTPS');
+  const tlsMaterials: FrontDoorTlsMaterials | undefined = hasHttpsListener
+    ? await resolveFrontDoorTlsMaterials({
+        certPath: options.tlsCert,
+        keyPath: options.tlsKey,
+      })
+    : undefined;
 
   try {
     for (const listener of plan.listeners) {
@@ -843,7 +844,7 @@ export async function buildFrontDoor(
         sourceIp?: string;
       }): RouteAction | undefined => matchAlbPathRule(req, ruleRoutes) ?? defaultRoute;
 
-      const tls = listener.protocol === 'HTTPS' ? await getTlsMaterials() : undefined;
+      const tls = listener.protocol === 'HTTPS' ? tlsMaterials : undefined;
       const server = await startFrontDoorServer({
         route,
         port: listener.hostPort,

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -339,7 +339,10 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
           'with --tls-key. Omit both flags to auto-generate a self-signed cert ' +
           '(cached under $XDG_CACHE_HOME/cdk-local/alb-https/, default ~/.cache/cdk-local/' +
           'alb-https/); requires openssl on PATH. The deployed Listener Certificates[] are NOT ' +
-          'fetched (ACM private keys are not retrievable by design).'
+          'fetched (ACM private keys are not retrievable by design). The auto-generated cert ' +
+          'lists DNS:localhost,IP:127.0.0.1 as SubjectAltName, so a client validating a ' +
+          'non-loopback --container-host will fail the SAN check — pass --tls-cert / --tls-key ' +
+          'with a SAN covering that host instead.'
       )
     )
     .addOption(

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -253,6 +253,7 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
           listeners.push({
             listenerPort: listener.listenerPort,
             hostPort,
+            protocol: listener.listenerProtocol,
             ...(listener.defaultAction ? { defaultAction: qualify(listener.defaultAction) } : {}),
             rules: listener.rules.map((r) => ({
               priority: r.priority,
@@ -306,17 +307,18 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
   const cmd = new Command('start-alb')
     .description(
       'Run an Application Load Balancer locally: name the ALB, and cdk-local boots the ECS ' +
-        'service(s) behind its HTTP listeners and stands up a local front-door on each listener ' +
-        'port that round-robins across the running replicas and routes its listener rules across ' +
-        'the backing services — a stable host endpoint, like behind a real load balancer. The ' +
+        'service(s) behind its listeners and stands up a local front-door on each listener port ' +
+        'that round-robins across the running replicas and routes its listener rules across the ' +
+        'backing services — a stable host endpoint, like behind a real load balancer. The ' +
         'symmetric ALB counterpart of `start-api`. Each <target> accepts a CDK display path ' +
         '(MyStack/MyAlb) or stack-qualified logical ID; single-stack apps may omit the stack ' +
-        'prefix. Supports HTTP listeners; path-pattern and host-header rule conditions; forward ' +
-        '(single and weighted), redirect, and fixed-response actions; and ECS or Lambda targets ' +
-        '(a Lambda target group is invoked locally via the Lambda RIE). HTTPS listeners, the ' +
-        'other rule conditions (http-header / query-string / source-ip / http-request-method), ' +
-        'and authenticate-* actions are skipped with a warning. Omit <targets> in an interactive ' +
-        'terminal to multi-select the load balancers from a list.'
+        'prefix. Supports HTTP and HTTPS listeners (TLS terminated locally with --tls-cert/' +
+        '--tls-key or an auto-generated self-signed cert); all six ALB rule-condition fields ' +
+        '(path-pattern / host-header / http-header / http-request-method / query-string / ' +
+        'source-ip); forward (single and weighted), redirect, and fixed-response actions; and ' +
+        'ECS or Lambda targets (a Lambda target group is invoked locally via the Lambda RIE). ' +
+        'authenticate-cognito / authenticate-oidc actions are skipped with a warning. Omit ' +
+        '<targets> in an interactive terminal to multi-select the load balancers from a list.'
     )
     .argument(
       '[targets...]',
@@ -328,6 +330,22 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
         'Bind the local front-door on a specific host port (e.g. 80=8080); repeatable. ' +
           'Default: host port == ALB listener port. Use this on macOS to remap a privileged ' +
           'listener port (< 1024) to a non-privileged host port.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--tls-cert <path>',
+        'PEM-encoded server certificate for HTTPS front-door listeners. Must be set together ' +
+          'with --tls-key. Omit both flags to auto-generate a self-signed cert ' +
+          '(cached under $XDG_CACHE_HOME/cdk-local/alb-https/, default ~/.cache/cdk-local/' +
+          'alb-https/); requires openssl on PATH. The deployed Listener Certificates[] are NOT ' +
+          'fetched (ACM private keys are not retrievable by design).'
+      )
+    )
+    .addOption(
+      new Option(
+        '--tls-key <path>',
+        'PEM-encoded server private key matching --tls-cert. Must be set together with --tls-cert.'
       )
     )
     .action(

--- a/src/local/elb-front-door-resolver.ts
+++ b/src/local/elb-front-door-resolver.ts
@@ -48,8 +48,12 @@ import type { AlbHttpHeaderCondition, AlbQueryStringCondition } from './alb-path
  * functions (`TargetType:"lambda"` target groups — #123: the TG -> backing
  * `AWS::Lambda::Function` is resolved and the front-door invokes it locally per
  * request); `redirect` / `fixed-response` actions. A single weighted forward may
- * mix ECS and Lambda targets. Skipped with a warning: HTTPS/TLS listeners and
- * `authenticate-cognito` / `authenticate-oidc` actions.
+ * mix ECS and Lambda targets. HTTPS listeners are served — local TLS
+ * termination uses a user-supplied or auto-generated self-signed cert/key
+ * pair (the deployed `Listener.Certificates[]` ACM ARNs are not fetched,
+ * because ACM private keys are not retrievable by design). Skipped with a
+ * warning: TLS listeners (NLB-style, not ALB) and `authenticate-cognito` /
+ * `authenticate-oidc` actions.
  */
 
 const ALB_TYPE = 'AWS::ElasticLoadBalancingV2::LoadBalancer';
@@ -185,8 +189,8 @@ export interface ResolvedListenerRule {
 export interface ResolvedListenerFrontDoor {
   /** Listener port declared on the ALB (the stable host endpoint port). */
   listenerPort: number;
-  /** Listener protocol — always `HTTP` here (HTTPS is skipped upstream). */
-  listenerProtocol: 'HTTP';
+  /** Listener protocol — `HTTP` or `HTTPS`. */
+  listenerProtocol: 'HTTP' | 'HTTPS';
   /** Logical id of the listener (diagnostics). */
   listenerLogicalId: string;
   /**
@@ -235,12 +239,28 @@ export function resolveAlbFrontDoor(
     const port = parsePort(props['Port']);
     if (port === undefined) continue;
     const protocol = typeof props['Protocol'] === 'string' ? props['Protocol'] : 'HTTP';
-    if (protocol !== 'HTTP') {
+    if (protocol !== 'HTTP' && protocol !== 'HTTPS') {
       warnings.push(
         `Listener '${listenerLogicalId}' on port ${port} uses protocol ${protocol}; the local ` +
-          'ALB front-door supports HTTP listeners only (TLS termination is deferred). Skipping it.'
+          'ALB front-door supports HTTP and HTTPS listeners only (TLS / NLB-style listeners are ' +
+          'not served). Skipping it.'
       );
       continue;
+    }
+    if (
+      protocol === 'HTTPS' &&
+      Array.isArray(props['Certificates']) &&
+      props['Certificates'].length > 0
+    ) {
+      // The deployed Listener's ACM-backed Certificates[] is not fetched: ACM
+      // private keys are not retrievable, by design. The local front-door
+      // terminates TLS with a user-supplied or auto-generated self-signed
+      // cert instead.
+      warnings.push(
+        `Listener '${listenerLogicalId}' on port ${port} declares ACM Certificates which are not ` +
+          'retrievable locally. The front-door terminates TLS with --tls-cert/--tls-key or an ' +
+          'auto-generated self-signed cert.'
+      );
     }
 
     const defaultAction = resolveAction(
@@ -309,7 +329,7 @@ export function resolveAlbFrontDoor(
 
     listeners.push({
       listenerPort: port,
-      listenerProtocol: 'HTTP',
+      listenerProtocol: protocol,
       listenerLogicalId,
       ...(defaultAction ? { defaultAction } : {}),
       rules,

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -5,6 +5,7 @@ import {
   type Server,
   type ServerResponse,
 } from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
 import { getLogger } from '../utils/logger.js';
 import type { FrontDoorEndpointPool } from './front-door-pool.js';
 import {
@@ -47,9 +48,12 @@ import {
  * {@link StartFrontDoorServerOptions.selectPool} selectors instead of `route`.
  *
  * Scope: per-request round-robin + weighted forward (ECS pools and/or Lambda
- * invokers), redirect / fixed-response synthesis, HTTP only, `path-pattern` +
- * `host-header` rule routing. No health-check-gated draining, no sticky
- * sessions, no websocket `Upgrade` proxying, no TLS termination.
+ * invokers), redirect / fixed-response synthesis, every ALB rule-condition
+ * field. HTTP and HTTPS listeners are both served — HTTPS termination uses
+ * the {@link StartFrontDoorServerOptions.tls} materials (a user-supplied or
+ * auto-generated self-signed cert/key pair) and switches `X-Forwarded-Proto`
+ * + redirect `#{protocol}` to `https`. No health-check-gated draining, no
+ * sticky sessions, no websocket `Upgrade` proxying.
  */
 
 /**
@@ -174,6 +178,13 @@ export interface StartFrontDoorServerOptions {
   /** Human label for log / error lines (e.g. `listener port 80`). */
   label: string;
   /**
+   * When set, the front-door listens over HTTPS using these PEM materials
+   * (server cert + private key). `X-Forwarded-Proto` switches to `https`
+   * and redirect `#{protocol}` placeholders resolve to `https`. Absent =
+   * plain HTTP listener (the default).
+   */
+  tls?: { certPem: Buffer; keyPem: Buffer };
+  /**
    * Per-request upstream timeout (ms). A replica that accepts the connection
    * but never responds (deadlocked app, half-open socket) must not hang the
    * request forever; on timeout the upstream socket is destroyed and the
@@ -190,6 +201,8 @@ export interface StartedFrontDoorServer {
   port: number;
   /** Actual bound host. */
   host: string;
+  /** `'https'` when started with `tls`, otherwise `'http'`. Used by log banners. */
+  scheme: 'http' | 'https';
   /** Underlying server (for diagnostics). */
   server: Server;
   /** Drain + close. Idempotent. */
@@ -202,12 +215,23 @@ export async function startFrontDoorServer(
   const logger = getLogger().child('front-door');
   const host = opts.host ?? '127.0.0.1';
 
-  const server = createServer((req, res) => {
+  const requestHandler = (req: IncomingMessage, res: ServerResponse): void => {
     handleProxyRequest(req, res, opts).catch((err) => {
       logger.debug(`front-door request error: ${err instanceof Error ? err.message : String(err)}`);
       if (!res.headersSent) writeError(res, 502, 'Bad Gateway');
     });
-  });
+  };
+  // HTTPS branch: `https.createServer` with the supplied PEM materials. The
+  // request handler is the same — TLS only adds the handshake at the socket
+  // layer. `X-Forwarded-Proto` is stamped based on `tls` presence so a
+  // downstream app reads the right scheme.
+  const server: Server = opts.tls
+    ? (createHttpsServer(
+        { cert: opts.tls.certPem, key: opts.tls.keyPem },
+        requestHandler
+      ) as unknown as Server)
+    : createServer(requestHandler);
+  const scheme: 'http' | 'https' = opts.tls ? 'https' : 'http';
   server.on('connection', (socket) => socket.setNoDelay(true));
 
   const boundPort = await new Promise<number>((resolve, reject) => {
@@ -226,6 +250,7 @@ export async function startFrontDoorServer(
   return {
     port: boundPort,
     host,
+    scheme,
     server,
     close: async (): Promise<void> => {
       if (closed) return;
@@ -281,8 +306,11 @@ function handleProxyRequest(
       // method, incl. POST) so an unconsumed body doesn't stall HTTP/1.1
       // keep-alive socket reuse, then synthesize the response with no backend.
       req.resume();
-      if (action.kind === 'redirect') writeRedirect(res, action, req, opts.listenerPort);
-      else writeFixedResponse(res, action);
+      if (action.kind === 'redirect') {
+        writeRedirect(res, action, req, opts.listenerPort, opts.tls ? 'https' : 'http');
+      } else {
+        writeFixedResponse(res, action);
+      }
       return Promise.resolve();
     }
 
@@ -356,7 +384,7 @@ function handlePoolRequest(
 
     const headers = { ...req.headers };
     stripHopByHopHeaders(headers);
-    appendForwardedHeaders(headers, req, opts.listenerPort);
+    appendForwardedHeaders(headers, req, opts.listenerPort, opts.tls ? 'https' : 'http');
 
     const proxyReq = httpRequest(
       {
@@ -477,9 +505,10 @@ function writeRedirect(
   res: ServerResponse,
   action: RedirectRouteAction,
   req: IncomingMessage,
-  listenerPort: number
+  listenerPort: number,
+  scheme: 'http' | 'https'
 ): void {
-  const location = buildRedirectLocation(action, req, listenerPort);
+  const location = buildRedirectLocation(action, req, listenerPort, scheme);
   res.writeHead(action.statusCode, {
     location,
     'content-type': 'text/plain; charset=utf-8',
@@ -488,11 +517,17 @@ function writeRedirect(
   res.end();
 }
 
-/** Build the `Location` URL for a redirect action, resolving ALB `#{...}` placeholders. */
+/**
+ * Build the `Location` URL for a redirect action, resolving ALB `#{...}`
+ * placeholders. `scheme` is the receiving listener's protocol — it sets the
+ * default for `#{protocol}` so an HTTPS listener redirects to `https://...`
+ * by default, matching what a real ALB does.
+ */
 export function buildRedirectLocation(
   action: RedirectRouteAction,
   req: { url?: string | undefined; headers: NodeJS.Dict<string | string[]> },
-  listenerPort: number
+  listenerPort: number,
+  scheme: 'http' | 'https' = 'http'
 ): string {
   const url = req.url ?? '/';
   const qIndex = url.indexOf('?');
@@ -503,7 +538,7 @@ export function buildRedirectLocation(
   const reqHostName = (hostHeaderValue ?? '').split(':')[0] ?? '';
 
   const placeholders: Record<string, string> = {
-    protocol: 'http',
+    protocol: scheme,
     host: reqHostName,
     port: String(listenerPort),
     path: reqPath.replace(/^\//, ''), // ALB's #{path} excludes the leading slash
@@ -615,7 +650,12 @@ function handleLambdaRequest(
           // event's headers match what a real ALB forwards — no connection /
           // transfer-encoding / keep-alive leaking into the handler.
           stripHopByHopHeaders(forwardHeaders);
-          appendForwardedHeaders(forwardHeaders, req, opts.listenerPort);
+          appendForwardedHeaders(
+            forwardHeaders,
+            req,
+            opts.listenerPort,
+            opts.tls ? 'https' : 'http'
+          );
           const snapshot = snapshotFromIncoming(req, body);
           for (const [name, value] of Object.entries(forwardHeaders)) {
             if (value === undefined) continue;
@@ -695,18 +735,20 @@ function stripHopByHopHeaders(headers: NodeJS.Dict<string | string[]>): void {
 /**
  * Inject the ALB-style forwarding headers a downstream app may read. Appends
  * the client IP to any existing `X-Forwarded-For` chain (ALB appends rather
- * than replaces) and stamps the scheme / listener port.
+ * than replaces) and stamps the scheme / listener port. `scheme` follows the
+ * listener's protocol so an HTTPS listener stamps `x-forwarded-proto: https`.
  */
 function appendForwardedHeaders(
   headers: NodeJS.Dict<string | string[]>,
   req: IncomingMessage,
-  listenerPort: number
+  listenerPort: number,
+  scheme: 'http' | 'https'
 ): void {
   const clientIp = req.socket.remoteAddress ?? '';
   const existing = headers['x-forwarded-for'];
   const chain = Array.isArray(existing) ? existing.join(', ') : existing;
   headers['x-forwarded-for'] = chain ? `${chain}, ${clientIp}` : clientIp;
-  headers['x-forwarded-proto'] = 'http';
+  headers['x-forwarded-proto'] = scheme;
   headers['x-forwarded-port'] = String(listenerPort);
 }
 

--- a/src/local/front-door-tls.ts
+++ b/src/local/front-door-tls.ts
@@ -1,8 +1,8 @@
 import { execFile } from 'node:child_process';
 import { X509Certificate } from 'node:crypto';
-import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, statSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { getLogger } from '../utils/logger.js';
 
@@ -96,6 +96,21 @@ async function ensureSelfSignedCert(opts: SelfSignedOptions): Promise<FrontDoorT
   }
 
   mkdirSync(opts.cacheDir, { recursive: true });
+  // Defensive: if a previous run left a half-written cert / key (e.g. openssl
+  // crashed mid-write), `openssl req -x509 ...` will overwrite them, but a
+  // residual non-cert file could keep failing the X509Certificate parse on
+  // the next cachedPairIsFresh check and trigger a regen loop. Remove them
+  // up front so a failed regen does not poison subsequent reads.
+  try {
+    unlinkSync(certPath);
+  } catch {
+    /* missing is fine */
+  }
+  try {
+    unlinkSync(keyPath);
+  } catch {
+    /* missing is fine */
+  }
   try {
     await runOpenssl([
       'req',
@@ -177,24 +192,4 @@ function readPemOrThrow(path: string, flagName: string): Buffer {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`${flagName}: cannot read PEM file at '${path}': ${msg}`);
   }
-}
-
-/**
- * Write a freshly generated cert/key pair to disk under `dir` and return
- * the paths. Used by tests so the helper code path stays the same as the
- * runtime path.
- */
-export function _writeSelfSignedForTest(
-  dir: string,
-  materials: FrontDoorTlsMaterials
-): {
-  certPath: string;
-  keyPath: string;
-} {
-  mkdirSync(dirname(join(dir, CERT_FILENAME)), { recursive: true });
-  const certPath = join(dir, CERT_FILENAME);
-  const keyPath = join(dir, KEY_FILENAME);
-  writeFileSync(certPath, materials.certPem);
-  writeFileSync(keyPath, materials.keyPem);
-  return { certPath, keyPath };
 }

--- a/src/local/front-door-tls.ts
+++ b/src/local/front-door-tls.ts
@@ -1,0 +1,200 @@
+import { execFile } from 'node:child_process';
+import { X509Certificate } from 'node:crypto';
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { getLogger } from '../utils/logger.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * PEM materials for an HTTPS front-door listener: a server cert + its private
+ * key. Buffers so they pass straight to `https.createServer({ cert, key })`.
+ */
+export interface FrontDoorTlsMaterials {
+  certPem: Buffer;
+  keyPem: Buffer;
+}
+
+/**
+ * Resolve a single global cert/key pair for HTTPS front-door listeners. When
+ * BOTH `certPath` and `keyPath` are supplied, those PEM files are read from
+ * disk. When neither is supplied, a long-lived self-signed cert is cached
+ * under `$XDG_CACHE_HOME/cdk-local/alb-https/` (defaulting to
+ * `~/.cache/cdk-local/alb-https/`) and reused across boots; it is regenerated
+ * when missing or within `regenerateWithinDays` of expiry. Pairing is enforced
+ * — supplying exactly one of `--tls-cert` / `--tls-key` is rejected with a
+ * clear error before the server starts.
+ *
+ * The self-signed cert path subprocesses `openssl req -x509 ...`. `openssl`
+ * is on macOS / Linux dev boxes and Docker base images by default; absence
+ * surfaces as an actionable error pointing at the BYO recipe.
+ */
+export async function resolveFrontDoorTlsMaterials(opts: {
+  certPath: string | undefined;
+  keyPath: string | undefined;
+  cacheDir?: string;
+  /** Days before expiry at which the cached cert is regenerated. Default 30. */
+  regenerateWithinDays?: number;
+  /** Validity period for a freshly generated cert, in days. Default 825. */
+  validityDays?: number;
+}): Promise<FrontDoorTlsMaterials> {
+  const hasCert = opts.certPath !== undefined && opts.certPath !== '';
+  const hasKey = opts.keyPath !== undefined && opts.keyPath !== '';
+  if (hasCert !== hasKey) {
+    const set = hasCert ? '--tls-cert' : '--tls-key';
+    const missing = hasCert ? '--tls-key' : '--tls-cert';
+    throw new Error(
+      `${set} is set but ${missing} is missing. ` +
+        'Both --tls-cert and --tls-key must be set together, or both left unset to use an ' +
+        'auto-generated self-signed cert.'
+    );
+  }
+  if (hasCert && hasKey) {
+    return {
+      certPem: readPemOrThrow(opts.certPath!, '--tls-cert'),
+      keyPem: readPemOrThrow(opts.keyPath!, '--tls-key'),
+    };
+  }
+  return ensureSelfSignedCert({
+    cacheDir: opts.cacheDir ?? defaultCacheDir(),
+    regenerateWithinDays: opts.regenerateWithinDays ?? 30,
+    validityDays: opts.validityDays ?? 825,
+  });
+}
+
+/** Default cache dir for the auto-generated self-signed cert. */
+export function defaultCacheDir(): string {
+  const xdg = process.env['XDG_CACHE_HOME'];
+  const base = xdg && xdg !== '' ? xdg : join(homedir(), '.cache');
+  return join(base, 'cdk-local', 'alb-https');
+}
+
+const CERT_FILENAME = 'cert.pem';
+const KEY_FILENAME = 'key.pem';
+
+interface SelfSignedOptions {
+  cacheDir: string;
+  regenerateWithinDays: number;
+  validityDays: number;
+}
+
+async function ensureSelfSignedCert(opts: SelfSignedOptions): Promise<FrontDoorTlsMaterials> {
+  const logger = getLogger().child('front-door-tls');
+  const certPath = join(opts.cacheDir, CERT_FILENAME);
+  const keyPath = join(opts.cacheDir, KEY_FILENAME);
+
+  // Reuse the cached pair when both files exist AND the cert is not expiring
+  // soon. A near-expiry regeneration keeps long-running shells healthy
+  // without forcing a manual cleanup.
+  if (cachedPairIsFresh(certPath, keyPath, opts.regenerateWithinDays)) {
+    return {
+      certPem: readFileSync(certPath),
+      keyPem: readFileSync(keyPath),
+    };
+  }
+
+  mkdirSync(opts.cacheDir, { recursive: true });
+  try {
+    await runOpenssl([
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-nodes',
+      '-keyout',
+      keyPath,
+      '-out',
+      certPath,
+      '-subj',
+      '/CN=localhost',
+      '-days',
+      String(opts.validityDays),
+      '-addext',
+      'subjectAltName=DNS:localhost,IP:127.0.0.1',
+    ]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to auto-generate a self-signed cert via openssl: ${msg}. ` +
+        'Install openssl, or supply --tls-cert <path> + --tls-key <path> with your own PEM files. ' +
+        'Recipe: openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem ' +
+        '-subj "/CN=localhost" -days 365.'
+    );
+  }
+  logger.info(
+    `ALB front-door: generated self-signed cert at ${certPath} (valid ${opts.validityDays} days)`
+  );
+  return {
+    certPem: readFileSync(certPath),
+    keyPem: readFileSync(keyPath),
+  };
+}
+
+function cachedPairIsFresh(certPath: string, keyPath: string, regenWithinDays: number): boolean {
+  try {
+    statSync(certPath);
+    statSync(keyPath);
+  } catch {
+    return false;
+  }
+  try {
+    const notAfter = readCertNotAfter(certPath);
+    if (notAfter === undefined) return false;
+    const renewAt = notAfter.getTime() - regenWithinDays * 86_400_000;
+    return Date.now() < renewAt;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a cert's `notAfter` expiry timestamp. Used to decide whether to
+ * regenerate the cached self-signed cert proactively. Returns `undefined`
+ * when the cert is unreadable (caller then regenerates).
+ */
+function readCertNotAfter(certPath: string): Date | undefined {
+  try {
+    // `crypto.X509Certificate` parses a PEM/DER cert and exposes the `validTo`
+    // string. Available since Node 15.6 — well within the >=20 engine floor.
+    const cert = new X509Certificate(readFileSync(certPath));
+    const parsed = new Date(cert.validTo);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+async function runOpenssl(args: string[]): Promise<void> {
+  await execFileAsync('openssl', args, { timeout: 30_000 });
+}
+
+function readPemOrThrow(path: string, flagName: string): Buffer {
+  try {
+    return readFileSync(path);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`${flagName}: cannot read PEM file at '${path}': ${msg}`);
+  }
+}
+
+/**
+ * Write a freshly generated cert/key pair to disk under `dir` and return
+ * the paths. Used by tests so the helper code path stays the same as the
+ * runtime path.
+ */
+export function _writeSelfSignedForTest(
+  dir: string,
+  materials: FrontDoorTlsMaterials
+): {
+  certPath: string;
+  keyPath: string;
+} {
+  mkdirSync(dirname(join(dir, CERT_FILENAME)), { recursive: true });
+  const certPath = join(dir, CERT_FILENAME);
+  const keyPath = join(dir, KEY_FILENAME);
+  writeFileSync(certPath, materials.certPem);
+  writeFileSync(keyPath, materials.keyPem);
+  return { certPath, keyPath };
+}

--- a/tests/unit/local/elb-front-door-resolver.test.ts
+++ b/tests/unit/local/elb-front-door-resolver.test.ts
@@ -773,7 +773,7 @@ describe('resolveAlbFrontDoor', () => {
     expect(listeners.map((l) => l.listenerPort)).toEqual([80]);
   });
 
-  it('skips + warns on an HTTPS listener (HTTP only)', () => {
+  it('serves an HTTPS listener with listenerProtocol=HTTPS (no warning)', () => {
     const stack = stackWith({
       [LISTENER]: {
         Type: 'AWS::ElasticLoadBalancingV2::Listener',
@@ -786,8 +786,45 @@ describe('resolveAlbFrontDoor', () => {
       },
     });
     const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toHaveLength(1);
+    expect(listeners[0]!.listenerProtocol).toBe('HTTPS');
+    expect(listeners[0]!.listenerPort).toBe(443);
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns once when an HTTPS listener declares ACM Certificates (not retrievable locally)', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 443,
+          Protocol: 'HTTPS',
+          Certificates: [{ CertificateArn: 'arn:aws:acm:us-east-1:111:certificate/abc' }],
+          DefaultActions: [{ Type: 'forward', TargetGroupArn: { Ref: TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
+    expect(listeners).toHaveLength(1);
+    expect(warnings.join('\n')).toMatch(/ACM Certificates/);
+  });
+
+  it('skips + warns on a non-HTTP/HTTPS listener (TLS / NLB-style)', () => {
+    const stack = stackWith({
+      [LISTENER]: {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          LoadBalancerArn: { Ref: ALB },
+          Port: 443,
+          Protocol: 'TLS',
+          DefaultActions: [{ Type: 'forward', TargetGroupArn: { Ref: TG } }],
+        },
+      },
+    });
+    const { listeners, warnings } = resolveAlbFrontDoor(stack, ALB);
     expect(listeners).toEqual([]);
-    expect(warnings.join('\n')).toMatch(/HTTPS/);
+    expect(warnings.join('\n')).toMatch(/TLS/);
   });
 
   it('resolves a Lambda target group (default action) to its backing function (#123)', () => {

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, afterEach } from 'vite-plus/test';
+import { describe, it, expect, afterEach, afterAll, beforeAll } from 'vite-plus/test';
 import { createServer, get, request, type IncomingMessage, type Server } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { AddressInfo } from 'node:net';
 import { FrontDoorEndpointPool } from '../../../src/local/front-door-pool.js';
 import {
@@ -11,6 +15,10 @@ import {
   type RedirectRouteAction,
 } from '../../../src/local/front-door-server.js';
 import { matchAlbPathRule, type AlbPathRule } from '../../../src/local/alb-path-matcher.js';
+import {
+  resolveFrontDoorTlsMaterials,
+  type FrontDoorTlsMaterials,
+} from '../../../src/local/front-door-tls.js';
 
 interface Upstream {
   server: Server;
@@ -726,5 +734,147 @@ describe('startFrontDoorServer — weighted forward mixing ECS + Lambda (#123)',
       expect((await fetchText(front.port)).body).toBe('ecs-only');
     }
     expect(lambdaHits).toBe(0);
+  });
+});
+
+describe('startFrontDoorServer — HTTPS termination', () => {
+  let tls: FrontDoorTlsMaterials;
+  let tlsCacheDir: string;
+
+  beforeAll(async () => {
+    tlsCacheDir = mkdtempSync(join(tmpdir(), 'cdkl-front-door-tls-'));
+    tls = await resolveFrontDoorTlsMaterials({
+      certPath: undefined,
+      keyPath: undefined,
+      cacheDir: tlsCacheDir,
+    });
+  });
+
+  afterAll(() => {
+    rmSync(tlsCacheDir, { recursive: true, force: true });
+  });
+
+  function fetchHttpsText(port: number): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = httpsRequest(
+        {
+          host: '127.0.0.1',
+          port,
+          path: '/',
+          method: 'GET',
+          rejectUnauthorized: false, // self-signed cert
+        },
+        (res) => {
+          let body = '';
+          res.on('data', (c) => (body += c));
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  it('binds an HTTPS server when tls materials are supplied (scheme=https)', async () => {
+    const upstream = await startUpstream('https-upstream');
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstream.port });
+    const front = await startFrontDoorServer({
+      route: () => forward(pool),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      tls,
+    });
+    cleanups.push(() => front.close());
+
+    expect(front.scheme).toBe('https');
+    const res = await fetchHttpsText(front.port);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('https-upstream');
+  });
+
+  it('stamps X-Forwarded-Proto: https on the upstream request when tls is set', async () => {
+    const upstream = await startUpstream('xfwd-proto');
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstream.port });
+    const front = await startFrontDoorServer({
+      route: () => forward(pool),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      tls,
+    });
+    cleanups.push(() => front.close());
+
+    await fetchHttpsText(front.port);
+    expect(upstream.lastHeaders?.['x-forwarded-proto']).toBe('https');
+    expect(upstream.lastHeaders?.['x-forwarded-port']).toBe('443');
+  });
+
+  it('defaults a redirect action `#{protocol}` to https when the listener is HTTPS', async () => {
+    const action: RedirectRouteAction = {
+      kind: 'redirect',
+      statusCode: 301,
+      // `#{protocol}` left to default — must resolve to `https` for an HTTPS listener.
+      host: 'new.example.com',
+    };
+    const front = await startFrontDoorServer({
+      route: () => action,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      tls,
+    });
+    cleanups.push(() => front.close());
+
+    const result = await new Promise<{ status: number; location?: string }>((resolve, reject) => {
+      const req = httpsRequest(
+        {
+          host: '127.0.0.1',
+          port: front.port,
+          path: '/',
+          method: 'GET',
+          headers: { host: 'old.example.com' },
+          rejectUnauthorized: false,
+        },
+        (res) => {
+          res.resume();
+          res.on('end', () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              ...(typeof res.headers.location === 'string' && { location: res.headers.location }),
+            })
+          );
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(result.status).toBe(301);
+    expect(result.location).toMatch(/^https:\/\/new\.example\.com\//);
+  });
+
+  it('falls back to HTTP (scheme=http) and X-Forwarded-Proto: http when tls is omitted', async () => {
+    // Regression for the boolean toggle: an HTTP listener side by side with the
+    // HTTPS one must still stamp `http`.
+    const upstream = await startUpstream('plain-http');
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstream.port });
+    const front = await startFrontDoorServer({
+      route: () => forward(pool),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+    });
+    cleanups.push(() => front.close());
+
+    expect(front.scheme).toBe('http');
+    await fetchText(front.port);
+    expect(upstream.lastHeaders?.['x-forwarded-proto']).toBe('http');
   });
 });

--- a/tests/unit/local/front-door-tls.test.ts
+++ b/tests/unit/local/front-door-tls.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  resolveFrontDoorTlsMaterials,
+  defaultCacheDir,
+} from '../../../src/local/front-door-tls.js';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'cdkl-tls-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('resolveFrontDoorTlsMaterials — pairing validation', () => {
+  it('rejects --tls-cert without --tls-key', async () => {
+    await expect(
+      resolveFrontDoorTlsMaterials({ certPath: '/some/cert.pem', keyPath: undefined })
+    ).rejects.toThrow(/--tls-cert is set but --tls-key is missing/);
+  });
+
+  it('rejects --tls-key without --tls-cert', async () => {
+    await expect(
+      resolveFrontDoorTlsMaterials({ certPath: undefined, keyPath: '/some/key.pem' })
+    ).rejects.toThrow(/--tls-key is set but --tls-cert is missing/);
+  });
+
+  it('reads BYO PEM materials when both --tls-cert and --tls-key are set', async () => {
+    const certPath = join(tmpRoot, 'cert.pem');
+    const keyPath = join(tmpRoot, 'key.pem');
+    writeFileSync(certPath, Buffer.from('-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----'));
+    writeFileSync(keyPath, Buffer.from('-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----'));
+
+    const mats = await resolveFrontDoorTlsMaterials({ certPath, keyPath });
+    expect(mats.certPem.toString()).toContain('BEGIN CERTIFICATE');
+    expect(mats.keyPem.toString()).toContain('BEGIN PRIVATE KEY');
+  });
+
+  it('reports the missing PEM path when --tls-cert is unreadable', async () => {
+    await expect(
+      resolveFrontDoorTlsMaterials({
+        certPath: join(tmpRoot, 'missing-cert.pem'),
+        keyPath: join(tmpRoot, 'missing-key.pem'),
+      })
+    ).rejects.toThrow(/--tls-cert: cannot read PEM file/);
+  });
+});
+
+describe('resolveFrontDoorTlsMaterials — self-signed cache', () => {
+  it('generates a self-signed cert into the cache dir on first call (no BYO flags)', async () => {
+    const mats = await resolveFrontDoorTlsMaterials({
+      certPath: undefined,
+      keyPath: undefined,
+      cacheDir: tmpRoot,
+    });
+    expect(mats.certPem.toString()).toContain('BEGIN CERTIFICATE');
+    expect(mats.keyPem.toString()).toContain('BEGIN PRIVATE KEY');
+    expect(existsSync(join(tmpRoot, 'cert.pem'))).toBe(true);
+    expect(existsSync(join(tmpRoot, 'key.pem'))).toBe(true);
+  });
+
+  it('reuses the cached pair on a second call (cert.pem mtime is preserved)', async () => {
+    await resolveFrontDoorTlsMaterials({
+      certPath: undefined,
+      keyPath: undefined,
+      cacheDir: tmpRoot,
+    });
+    const firstCert = readFileSync(join(tmpRoot, 'cert.pem'));
+
+    await resolveFrontDoorTlsMaterials({
+      certPath: undefined,
+      keyPath: undefined,
+      cacheDir: tmpRoot,
+    });
+    const secondCert = readFileSync(join(tmpRoot, 'cert.pem'));
+
+    // Same bytes means the second call hit the cache (no regeneration).
+    expect(secondCert.equals(firstCert)).toBe(true);
+  });
+
+  it('regenerates a near-expiry cached cert (regenerateWithinDays > validityDays)', async () => {
+    // Seed a 1-day cert, then ask for a 2-day "regenerate-within" — the
+    // cached one is already inside the regen window so it must be rewritten.
+    await resolveFrontDoorTlsMaterials({
+      certPath: undefined,
+      keyPath: undefined,
+      cacheDir: tmpRoot,
+      validityDays: 1,
+    });
+    const seed = readFileSync(join(tmpRoot, 'cert.pem'));
+
+    await resolveFrontDoorTlsMaterials({
+      certPath: undefined,
+      keyPath: undefined,
+      cacheDir: tmpRoot,
+      regenerateWithinDays: 2,
+      validityDays: 365,
+    });
+    const regenerated = readFileSync(join(tmpRoot, 'cert.pem'));
+
+    expect(regenerated.equals(seed)).toBe(false);
+  });
+});
+
+describe('defaultCacheDir', () => {
+  it('honors $XDG_CACHE_HOME when set', () => {
+    const prev = process.env['XDG_CACHE_HOME'];
+    process.env['XDG_CACHE_HOME'] = '/xdg-fake';
+    try {
+      expect(defaultCacheDir()).toBe('/xdg-fake/cdk-local/alb-https');
+    } finally {
+      if (prev === undefined) delete process.env['XDG_CACHE_HOME'];
+      else process.env['XDG_CACHE_HOME'] = prev;
+    }
+  });
+
+  it('falls back to ~/.cache when $XDG_CACHE_HOME is unset', () => {
+    const prev = process.env['XDG_CACHE_HOME'];
+    delete process.env['XDG_CACHE_HOME'];
+    try {
+      expect(defaultCacheDir()).toMatch(/\/\.cache\/cdk-local\/alb-https$/);
+    } finally {
+      if (prev !== undefined) process.env['XDG_CACHE_HOME'] = prev;
+    }
+  });
+});

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { resolveAlbTarget, parseLbPortOverrides, albStrategy } from '../../../src/cli/commands/local-start-alb.js';
 import { serviceStrategy } from '../../../src/cli/commands/local-start-service.js';
 import { buildFrontDoor } from '../../../src/cli/commands/ecs-service-emulator.js';
+import { resolveFrontDoorTlsMaterials } from '../../../src/local/front-door-tls.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
 const ALB = 'WebLB';
@@ -374,6 +378,7 @@ describe('buildFrontDoor', () => {
           {
             listenerPort: 80,
             hostPort: 0, // ephemeral: avoid privileged-port binding in the unit test
+            protocol: 'HTTP',
             defaultAction: {
               kind: 'forward',
               targets: [
@@ -436,6 +441,7 @@ describe('buildFrontDoor', () => {
           {
             listenerPort: 80,
             hostPort: 0,
+            protocol: 'HTTP',
             defaultAction: {
               kind: 'forward',
               targets: [
@@ -458,6 +464,145 @@ describe('buildFrontDoor', () => {
     }
   });
 
+  describe('HTTPS listener binding (--tls-cert / --tls-key + auto self-signed)', () => {
+    let tlsTmpDir: string;
+    let certPath: string;
+    let keyPath: string;
+
+    beforeAll(async () => {
+      // Pre-bake a real self-signed cert/key pair so the BYO path executes
+      // inside `buildFrontDoor` -> `resolveFrontDoorTlsMaterials` without
+      // invoking openssl a second time.
+      tlsTmpDir = mkdtempSync(join(tmpdir(), 'cdkl-start-alb-binding-tls-'));
+      const mats = await resolveFrontDoorTlsMaterials({
+        certPath: undefined,
+        keyPath: undefined,
+        cacheDir: tlsTmpDir,
+      });
+      certPath = join(tlsTmpDir, 'byo-cert.pem');
+      keyPath = join(tlsTmpDir, 'byo-key.pem');
+      writeFileSync(certPath, mats.certPem);
+      writeFileSync(keyPath, mats.keyPem);
+    });
+
+    afterAll(() => {
+      rmSync(tlsTmpDir, { recursive: true, force: true });
+    });
+
+    it('threads HTTPS protocol into a server with scheme=https when --tls-cert / --tls-key are set', async () => {
+      const logger = { info: () => {}, warn: () => {} } as never;
+      const { servers } = await buildFrontDoor(
+        {
+          listeners: [
+            {
+              listenerPort: 443,
+              hostPort: 0,
+              protocol: 'HTTPS',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+          ],
+        },
+        { containerHost: '127.0.0.1', pull: true, tlsCert: certPath, tlsKey: keyPath } as never,
+        logger
+      );
+      try {
+        expect(servers).toHaveLength(1);
+        expect(servers[0]!.scheme).toBe('https');
+      } finally {
+        await Promise.all(servers.map((s) => s.close()));
+      }
+    });
+
+    it('shares one cert across multiple HTTPS listeners (pre-resolved once)', async () => {
+      const logger = { info: () => {}, warn: () => {} } as never;
+      const { servers } = await buildFrontDoor(
+        {
+          listeners: [
+            {
+              listenerPort: 443,
+              hostPort: 0,
+              protocol: 'HTTPS',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+            {
+              listenerPort: 8443,
+              hostPort: 0,
+              protocol: 'HTTPS',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+          ],
+        },
+        { containerHost: '127.0.0.1', pull: true, tlsCert: certPath, tlsKey: keyPath } as never,
+        logger
+      );
+      try {
+        expect(servers).toHaveLength(2);
+        expect(servers.every((s) => s.scheme === 'https')).toBe(true);
+      } finally {
+        await Promise.all(servers.map((s) => s.close()));
+      }
+    });
+
+    it('mixes HTTP + HTTPS listeners on the same ALB', async () => {
+      const logger = { info: () => {}, warn: () => {} } as never;
+      const { servers } = await buildFrontDoor(
+        {
+          listeners: [
+            {
+              listenerPort: 80,
+              hostPort: 0,
+              protocol: 'HTTP',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+            {
+              listenerPort: 443,
+              hostPort: 0,
+              protocol: 'HTTPS',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+          ],
+        },
+        { containerHost: '127.0.0.1', pull: true, tlsCert: certPath, tlsKey: keyPath } as never,
+        logger
+      );
+      try {
+        const schemes = servers.map((s) => s.scheme).sort();
+        expect(schemes).toEqual(['http', 'https']);
+      } finally {
+        await Promise.all(servers.map((s) => s.close()));
+      }
+    });
+
+    it('surfaces a TLS pairing failure cleanly (not wrapped in the --lb-port port-bind envelope)', async () => {
+      const logger = { info: () => {}, warn: () => {} } as never;
+      // Set only --tls-cert (key missing) -> resolveFrontDoorTlsMaterials throws
+      // its own pairing error before any server tries to bind. The buildFrontDoor
+      // try/catch must NOT re-wrap this as a port-bind issue.
+      await expect(
+        buildFrontDoor(
+          {
+            listeners: [
+              {
+                listenerPort: 443,
+                hostPort: 0,
+                protocol: 'HTTPS',
+                defaultAction: { kind: 'fixed-response', statusCode: 204 },
+                rules: [],
+              },
+            ],
+          },
+          { containerHost: '127.0.0.1', pull: true, tlsCert: certPath } as never, // tlsKey omitted
+          logger
+        )
+      ).rejects.toThrow(/--tls-cert is set but --tls-key is missing/);
+    });
+  });
+
   it('stands up a fixed-response-default listener with no backing pool', async () => {
     const logger = { info: () => {}, warn: () => {} } as never;
     const { servers, frontDoorByService } = await buildFrontDoor(
@@ -466,6 +611,7 @@ describe('buildFrontDoor', () => {
           {
             listenerPort: 80,
             hostPort: 0,
+            protocol: 'HTTP',
             defaultAction: { kind: 'fixed-response', statusCode: 404, messageBody: 'nope' },
             rules: [],
           },

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -312,6 +312,7 @@ describe('start-alb / start-service strategy binding', () => {
       {
         listenerPort: 80,
         hostPort: 8080, // remapped by --lb-port 80=8080
+        protocol: 'HTTP',
         defaultAction: {
           kind: 'forward',
           targets: [


### PR DESCRIPTION
## Summary

`cdkl start-alb` now terminates HTTPS listeners locally, closing the second-to-last item on #123 (only `authenticate-cognito` / `authenticate-oidc` remain after this PR).

- HTTPS listeners are no longer warn-and-skipped — `Listener.Protocol === 'HTTPS'` is served end-to-end through the existing front-door routing pipeline. `X-Forwarded-Proto` and the redirect-action `#{protocol}` placeholder default flip to `https`.
- Two new flags on `cdkl start-alb`: `--tls-cert <path>` and `--tls-key <path>` (pair-validated). Both omitted = auto-generated self-signed cert cached under `$XDG_CACHE_HOME/cdk-local/alb-https/` (default `~/.cache/cdk-local/alb-https/`) via an `openssl req -x509` subprocess (`openssl` must be on PATH; clear actionable error otherwise). The cached cert is reused across boots and proactively regenerated within 30 days of expiry.
- Deployed `Listener.Certificates[]` ACM ARNs are NOT fetched — ACM private keys are not retrievable by design — and a one-shot warning is emitted naming the listener.

Refs: #123

## Architecture

- `src/local/front-door-tls.ts` (new): TLS material resolution. BYO read + pairing validation + cache-dir auto-gen via openssl subprocess + `X509Certificate`-based freshness check + defensive `unlinkSync` before regen so a corrupt residual file can never trigger a regen loop.
- `src/local/front-door-server.ts`: optional `tls?: { certPem; keyPem }` option; `https.createServer` branch; `scheme: 'http' | 'https'` on `StartedFrontDoorServer`; scheme threaded through `X-Forwarded-Proto` (pool + Lambda paths) + redirect `#{protocol}` placeholder default.
- `src/local/elb-front-door-resolver.ts`: `listenerProtocol` widens to `'HTTP' | 'HTTPS'`; HTTPS no longer skipped; one warning per HTTPS listener that declares ACM `Certificates[]`.
- `src/cli/commands/local-start-alb.ts`: `--tls-cert` / `--tls-key` options; threads `listener.listenerProtocol` into the plan; the command description is refreshed (it had gone stale post-#159).
- `src/cli/commands/ecs-service-emulator.ts`: `PlannedFrontDoorListener.protocol` required; TLS materials resolved ONCE up front when any HTTPS listener is in the plan (kept outside the surrounding try/catch so a pairing / openssl failure surfaces its own actionable error instead of the generic `--lb-port` port-bind hint).
- Docs: README quickstart + supported-resources table + `.claude/CLAUDE.md` "Runs locally" + `docs/cli-reference.md` `start-alb` scope + new flag rows + HTTPS quickstart curl example.

## Out of scope (will close #123 in a follow-up PR)

- `authenticate-cognito` / `authenticate-oidc` listener actions — still warn-and-skip; the next PR closes #123.

## Out of scope (separate issue planned)

- ALB Mutual TLS (`MutualAuthentication.Mode: verify`) — needs IAM trust-store wiring; separate issue.
- `--tls-cert-listener <port>=<path>` per-listener cert override — single global cert is the v1 surface.

## Test plan

- [x] `vp run verify` (typecheck + lint + format + build + 1561 unit tests) — green.
- [x] `front-door-tls.test.ts` (new, 9 tests): pairing validation, BYO read, self-signed cache, regen on near-expiry, `defaultCacheDir` XDG honoring + `~/.cache` fallback.
- [x] `front-door-server.test.ts` (extended, 4 HTTPS tests): real openssl-generated cert + real `https.createServer` + real TLS handshake via `httpsRequest`. Asserts scheme=https, `X-Forwarded-Proto: https`, redirect `#{protocol}` defaults to `https`, and the HTTP regression that an `opts.tls`-less listener still gets scheme=http + `X-Forwarded-Proto: http`.
- [x] `elb-front-door-resolver.test.ts` (modified): the prior "HTTPS skipped" test is replaced with HTTPS-served + ACM-Certificates-warned + non-HTTP/HTTPS-skipped triplet.
- [x] `start-alb-binding.test.ts` (extended): 4 new HTTPS site-binding tests — `protocol: 'HTTPS'` → resolved TLS → `scheme=https`; multi-HTTPS-listener cert sharing; mixed HTTP+HTTPS plan; TLS-pairing-failure error envelope (does NOT come back as a port-bind hint).
- [x] `/run-integ local-start-alb-routing-conditions` — HTTP regression integ green (0 docker / network / svc orphans).
- [x] Live-test in a temporary fixture edit: ran `node dist/cli.js start-alb` against the routing-conditions fixture with an added HTTPS:443 listener (with a dummy ACM Certificates entry); confirmed the ACM warn line, the auto-generated self-signed cert log line, the `https://127.0.0.1:18443` boot banner, `curl --insecure https://...` returning `418 https-fixed`, and the HTTP regression `curl http://127.0.0.1:18088/` still returning `418 default-fixed`. Reverted the fixture before commit.

## Review-nit acceptance log

The 2-axis review (code-reviewer + test-reviewer, dispatched in parallel; spec-reviewer skipped per `/review-pr` heuristic — no design doc) surfaced 9 minor items. 5 were addressed in the fix-up commit; 4 are accepted as ship-worthy:

- `defaultCacheDir()` uses `~/.cache` on macOS instead of `~/Library/Caches/` — XDG-style cross-platform convention; matches pnpm / fnm.
- `buildRedirectLocation`'s new `scheme` param defaults to `'http'` — preserves the public-export 3-arg call shape.
- openssl-missing failure path has no test — would require injecting an `execFile` seam through `front-door-tls.ts` for a single error-message check; the message template is straightforward and the success path is exercised in every other front-door-tls test.
- `Properties.Certificates` declared on a `Protocol: 'HTTP'` listener silently passes the resolver — nonsensical hand-rolled-template-only case; CFn rejects it on deploy, so the local resolver tolerating it is informational.
