### PR TITLE
feat(invoke-agentcore): `--timeout <ms>` flag (default 120000)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -496,6 +496,7 @@ prefix. Omit the target in a TTY to pick from a list.
 | `--no-pull` | off | Skip `docker pull` (use the cached image). No-op for the local-build path. |
 | `--no-build` | off | Skip `docker build` on the local-asset path (reuse the previously-built tag). No-op for the ECR / registry pull paths. |
 | `--container-host <host>` | `127.0.0.1` | Host to bind the agent's published port to. |
+| `--timeout <ms>` | `120000` | Per-request timeout in milliseconds. Applied to `POST /invocations`, `POST /mcp`, and the `/ws` open-to-close window. Raise this for long-running agent calls that exceed the default. |
 | `--assume-role [arn]` | off | Assume an execution role and forward STS temp creds. `--assume-role <arn>` uses the explicit ARN; bare `--assume-role` uses the runtime's `RoleArn` when it is a literal ARN, else resolves it from `--from-cfn-stack` state; `--no-assume-role` opts out. Off by default forwards the developer's shell credentials. |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR for cross-account / centralized registries. |
 | `--from-cfn-stack [name]` | — | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in env vars with the deployed physical IDs / exports, resolve a same-stack `AWS::ECR::Repository` ContainerUri to the deployed image, and resolve `AWS::SSM::Parameter::Value` env values (decrypted `SecureString` values are kept off the `docker run` argv). Bare form uses the resolved stack name. |
@@ -636,6 +637,27 @@ concerns the cloud front door maps to MCP's own `Mcp-Session-Id`, so they are
 not applied to a direct local `/mcp` call (`--bearer-token` / `--session-id`
 are HTTP-protocol options and are ignored for MCP). The `A2A` / `AGUI`
 protocols are not supported yet.
+
+### Per-request timeout (`--timeout`)
+
+The default per-request timeout is 120 seconds. It applies to all three
+transports:
+
+- HTTP `POST /invocations` — the streaming sink keeps writing chunks while
+  the response body arrives, but the open-to-final-byte window is bounded
+  by `--timeout`.
+- MCP `POST /mcp` — applied to both the `notifications/initialized` POST
+  and the one JSON-RPC request POST.
+- `/ws` — bounds the open-to-close window (the agent closes the stream).
+
+Raise it for long-running agents whose response exceeds 120s:
+
+```bash
+cdkl invoke-agentcore MyAgent --event ./long-running.json --timeout 600000
+```
+
+Lower it in a CI smoke test to fail fast. The flag rejects zero, negatives,
+and non-integer values pre-container.
 
 ### `cdkl invoke-agentcore` exit codes
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -153,8 +153,30 @@ interface LocalInvokeAgentCoreOptions {
   ecrRoleArn?: string;
   fromCfnStack?: string | boolean;
   stackRegion?: string;
+  /**
+   * Per-request timeout in milliseconds, applied to the HTTP `/invocations`
+   * POST, the MCP `POST /mcp` request, and the `/ws` open-to-close window.
+   * Default 120000 (120s). Raise this for long-running agent calls that
+   * exceed the default — the cloud's AgentCore quota goes well above 120s.
+   */
+  timeout: number;
   /** Host-injected extra state-source flag fields. */
   [key: string]: unknown;
+}
+
+/**
+ * Parser for `--timeout <ms>`. Accepts a positive integer; rejects 0,
+ * negatives, fractions, and non-numeric input.
+ */
+export function parseTimeoutMs(raw: string): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new CdkLocalError(
+      `--timeout must be a positive integer number of milliseconds (got '${raw}').`,
+      'LOCAL_INVOKE_AGENTCORE_TIMEOUT_INVALID'
+    );
+  }
+  return parsed;
 }
 
 /**
@@ -393,7 +415,9 @@ async function localInvokeAgentCoreCommand(
       // MCP has no /ping: mcpInvokeOnce folds the boot-wait into a retried
       // `initialize`, then runs the session handshake + the one request.
       logger.info(`MCP request: ${mcpRequest.method}`);
-      const mcp = await mcpInvokeOnce(containerHost, hostPort, mcpRequest);
+      const mcp = await mcpInvokeOnce(containerHost, hostPort, mcpRequest, {
+        requestTimeoutMs: options.timeout,
+      });
       // Settle so container logs flush before teardown.
       await new Promise((r) => setTimeout(r, 250));
       emitMcpResult(mcp);
@@ -405,7 +429,7 @@ async function localInvokeAgentCoreCommand(
       logger.info('Opening the agent /ws WebSocket and streaming frames...');
       const wsResult = await invokeAgentCoreWs(containerHost, hostPort, event, {
         sessionId,
-        timeoutMs: 120_000,
+        timeoutMs: options.timeout,
         onMessage: (text) => process.stdout.write(text),
         ...(authorization && { authorization }),
       });
@@ -432,7 +456,7 @@ async function localInvokeAgentCoreCommand(
 
       const result = await invokeAgentCore(containerHost, hostPort, event, {
         sessionId,
-        timeoutMs: 120_000,
+        timeoutMs: options.timeout,
         // Stream a text/event-stream response to stdout as it arrives, so a
         // token-streaming agent shows incrementally rather than all at once.
         onChunk: (text) => process.stdout.write(text),
@@ -1437,6 +1461,15 @@ export function createLocalInvokeAgentCoreCommand(
     )
     .addOption(
       new Option('--container-host <host>', 'Host to bind the agent port to').default('127.0.0.1')
+    )
+    .addOption(
+      new Option(
+        '--timeout <ms>',
+        'Per-request timeout in milliseconds. Applied to POST /invocations, POST /mcp, and the ' +
+          '/ws open-to-close window. Raise this for long-running agent calls that exceed the default.'
+      )
+        .default(120000)
+        .argParser(parseTimeoutMs)
     )
     .addOption(
       new Option(

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -53,7 +53,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/16] Invoking EchoAgent with default empty event"
+echo "==> [1/17] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -67,7 +67,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/16] Invoking EchoAgent with --event payload"
+echo "==> [2/17] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -79,7 +79,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/16] Invoking EchoAgent with --env-vars override"
+echo "==> [3/17] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -91,7 +91,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/16] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/17] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -102,7 +102,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/16] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/17] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -123,7 +123,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/16] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/17] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -133,7 +133,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/16] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/17] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -146,7 +146,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/16] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/17] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -166,7 +166,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
-echo "==> [9/16] McpAgent (no --event) runs the handshake + tools/list"
+echo "==> [9/17] McpAgent (no --event) runs the handshake + tools/list"
 RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
@@ -175,7 +175,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 }
 
 # Test 10 — an MCP tools/call via --event returns the tool result.
-echo "==> [10/16] McpAgent with --event runs tools/call"
+echo "==> [10/17] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
@@ -189,7 +189,7 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 # Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
 # source (no Dockerfile): cdkl builds it from source (pip install + run the
 # entrypoint) and the entrypoint self-serves the 8080 HTTP contract.
-echo "==> [11/16] CodeAgent (fromCodeAsset) builds from source + responds"
+echo "==> [11/17] CodeAgent (fromCodeAsset) builds from source + responds"
 RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_11}"
 echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
@@ -202,7 +202,7 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 }
 
 # Test 12 — a --event payload echoes through the from-source agent.
-echo "==> [12/16] CodeAgent with --event echoes the payload"
+echo "==> [12/17] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
@@ -217,7 +217,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # the first frame and streams every received frame to stdout until the agent
 # closes. The fixture agent replies with one JSON frame (echo + session id +
 # Authorization + GREETING) then a second text frame, then closes.
-echo "==> [13/16] EchoAgent over the /ws WebSocket (--ws)"
+echo "==> [13/17] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
@@ -242,7 +242,7 @@ echo "${RESULT_13}" | grep -q 'ws-frame-2' || {
 
 # Test 14 — --ws is HTTP-only: against an MCP runtime it warns and is ignored,
 # falling through to the normal MCP path (tools/list still returns).
-echo "==> [14/16] McpAgent with --ws warns + still runs the MCP path"
+echo "==> [14/17] McpAgent with --ws warns + still runs the MCP path"
 set +e
 OUT_14=$(${CDKL} invoke-agentcore "${MCP}" --ws 2>/tmp/cdkl-ws-mcp-stderr; cat /tmp/cdkl-ws-mcp-stderr >&2)
 RC_14=$?
@@ -269,7 +269,7 @@ echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP protocol' || {
 # invoke succeeds even with a placeholder bearer token. (The verifier's actual
 # scope / claim checks are covered by the unit tests, which sign real RS256
 # tokens against mock JWKS.)
-echo "==> [15/16] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
+echo "==> [15/17] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
 RESULT_15=$(${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_15}"
 echo "${RESULT_15}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -289,7 +289,7 @@ echo "${RESULT_15}" | grep -q '"authorization":"Bearer h.p.s"' || {
 # agent never validates the signature against AWS, it just echoes the header.
 # A second --sigv4 + --bearer-token sub-check confirms the mutually-exclusive
 # gate rejects pre-container.
-echo "==> [16/16] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
+echo "==> [16/17] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
 RESULT_16=$(AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
   AWS_REGION=us-east-1 \
@@ -304,7 +304,7 @@ echo "${RESULT_16}" | grep -q '/us-east-1/bedrock-agentcore/aws4_request' || {
   exit 1
 }
 
-echo "==> [16/16] --sigv4 + --bearer-token together rejected (mutually exclusive)"
+echo "==> [16/17] --sigv4 + --bearer-token together rejected (mutually exclusive)"
 set +e
 OUT_16B=$(${CDKL} invoke-agentcore "${TARGET}" --sigv4 --bearer-token "h.p.s" 2>&1)
 RC_16B=$?
@@ -318,5 +318,33 @@ echo "${OUT_16B}" | grep -q 'mutually exclusive' || {
   exit 1
 }
 
+# Test 17 — `--timeout` overrides the per-request timeout. The default is 120s;
+# raise it for long-running agents, or lower it to fail fast in a CI smoke test.
+# The positive sub-check passes an explicit 60000 ms and asserts the agent still
+# responds (the flag is parsed + threaded into the client call, not silently
+# ignored). The negative sub-check confirms the parser rejects a non-positive
+# value pre-container.
+echo "==> [17/17] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
+RESULT_17=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 60000 2>/dev/null | tail -1)
+echo "    response: ${RESULT_17}"
+echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
+  echo "FAIL: expected EchoAgent to invoke under --timeout 60000, got: ${RESULT_17}"
+  exit 1
+}
+
+echo "==> [17/17] --timeout 0 rejected by the parser (positive integer required)"
+set +e
+OUT_17B=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 0 2>&1)
+RC_17B=$?
+set -e
+[[ ${RC_17B} -ne 0 ]] || {
+  echo "FAIL: expected a non-zero exit for --timeout 0, got 0. Output: ${OUT_17B}"
+  exit 1
+}
+echo "${OUT_17B}" | grep -q 'positive integer' || {
+  echo "FAIL: expected a 'positive integer' error message, got: ${OUT_17B}"
+  exit 1
+}
+
 echo ""
-echo "==> All 16 local-invoke-agentcore tests passed"
+echo "==> All 17 local-invoke-agentcore tests passed"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -114,6 +114,7 @@ const {
   resolveAssumeRoleArn,
   resolveFromS3BucketIntrinsic,
   buildSigV4HeadersIfRequested,
+  parseTimeoutMs,
 } = await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -1048,5 +1049,43 @@ describe('buildSigV4HeadersIfRequested — --sigv4 gate', () => {
       'sess'
     );
     expect(headers?.['Authorization']).toContain('/ap-northeast-1/bedrock-agentcore/aws4_request');
+  });
+});
+
+describe('parseTimeoutMs', () => {
+  it('accepts a positive integer string', () => {
+    expect(parseTimeoutMs('1')).toBe(1);
+    expect(parseTimeoutMs('120000')).toBe(120000);
+    expect(parseTimeoutMs('600000')).toBe(600000);
+  });
+
+  it('rejects zero', () => {
+    expect(() => parseTimeoutMs('0')).toThrowError(
+      /--timeout must be a positive integer/
+    );
+  });
+
+  it('rejects a negative integer', () => {
+    expect(() => parseTimeoutMs('-1')).toThrowError(
+      /--timeout must be a positive integer/
+    );
+  });
+
+  it('rejects a non-integer numeric', () => {
+    expect(() => parseTimeoutMs('1.5')).toThrowError(
+      /--timeout must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric string', () => {
+    expect(() => parseTimeoutMs('abc')).toThrowError(
+      /--timeout must be a positive integer/
+    );
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => parseTimeoutMs('')).toThrowError(
+      /--timeout must be a positive integer/
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Adds `--timeout <ms>` to `cdkl invoke-agentcore` (default 120000), applied to all three transports: HTTP `POST /invocations`, MCP `POST /mcp`, and the `/ws` open-to-close window. Previously each call site had `120_000` hard-coded, so an agent whose response legitimately exceeds 120s could not be invoked locally.
- Parser rejects zero / negative / fractional / non-numeric values pre-container (`LOCAL_INVOKE_AGENTCORE_TIMEOUT_INVALID`), so typos fail fast instead of after the image build.

## Test plan

- [x] 6 unit tests in `parseTimeoutMs` covering positive int, zero, negative, fractional, non-numeric, empty string.
- [x] `vp run check` (typecheck + lint + format) + `vp test run` (1562/1562 pass) + `vp run build`.
- [x] Integ scenario 17 in `tests/integration/local-invoke-agentcore/verify.sh`: `--timeout 60000` succeeds end-to-end (EchoAgent returns the expected greeting), and `--timeout 0` exits non-zero with `positive integer` error pre-container. All 17 local-invoke-agentcore scenarios green.
- [x] `node dist/cli.js invoke-agentcore --help` shows the new row; the live `--timeout 0` / `--timeout abc` / `--timeout -5` paths reject with the expected error.

Closes #164
