### PR TITLE
feat(invoke-agentcore): `--ws-interactive` REPL mode for --ws

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -489,6 +489,7 @@ prefix. Omit the target in a TTY to pick from a list.
 | `--env-vars <file>` | — | JSON env-var overrides, SAM-compatible shape: `{"LogicalId":{"KEY":"VALUE"}}` plus an optional top-level `"Parameters"` block. `null` clears a key. |
 | `--session-id <id>` | random UUID | Value for the `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` request header. |
 | `--ws` | off | Stream over the HTTP-protocol agent's bidirectional `/ws` WebSocket endpoint (on 8080) instead of `POST /invocations`: send `--event` as the first frame and print every received frame to stdout until the agent closes. See [WebSocket transport](#websocket-transport---ws) below. Ignored for an MCP runtime. |
+| `--ws-interactive` | off | REPL mode for `--ws`: after the initial `--event` frame, read additional frames from stdin (one frame per line, trailing newline stripped) and send each as a text frame until stdin EOFs (Ctrl-D) or the agent closes. Only meaningful with `--ws`. See [Interactive REPL (`--ws-interactive`)](#interactive-repl---ws-interactive) below. |
 | `--bearer-token <jwt>` | — | Bearer JWT to present when the runtime declares a `customJwtAuthorizer`. Verified against the runtime's OIDC discovery URL (signature / `iss` / `exp` / audience) before the container starts, then forwarded to `/invocations` (or the `/ws` upgrade) as `Authorization: Bearer <jwt>`. |
 | `--no-verify-auth` | off (verify on) | Skip inbound JWT verification even when the runtime declares a `customJwtAuthorizer` (local-dev escape hatch). A `--bearer-token`, if given, is still forwarded. |
 | `--sigv4` | off | Sign the `/invocations` POST with AWS SigV4 (service `bedrock-agentcore`) using the resolved credentials — the same `Authorization: AWS4-HMAC-SHA256 ...` + `X-Amz-*` headers the cloud receives when the runtime declares no `customJwtAuthorizer`. Opt-in: default unsigned. Mutually exclusive with `--bearer-token`; ignored on a JWT-protected runtime. See [Inbound SigV4 (`--sigv4`)](#inbound-sigv4---sigv4) below. |
@@ -614,6 +615,33 @@ registers it). `--ws` exercises it:
 The over-the-wire framing on `/ws` is agent-defined — AWS pipes bytes
 transparently — so `cdkl` mirrors that and does not interpret the frames.
 `--ws` is HTTP-only; it is ignored (with a warning) for an MCP runtime.
+
+### Interactive REPL (`--ws-interactive`)
+
+The default `--ws` is one-shot: send `--event` as the first frame, stream
+received frames, and exit when the agent closes. For a chat-style agent
+you want to talk back to (send a follow-up message after seeing the
+response), `--ws-interactive` adds a REPL on top of the same connection:
+
+1. send `--event` (default `{}`) as the first frame, just as one-shot mode
+   does,
+2. then read `process.stdin` line-buffered — each line (trailing `\r?\n`
+   stripped) becomes one follow-up text frame,
+3. stop when stdin EOFs (Ctrl-D at a terminal, end-of-pipe for a piped
+   stdin), then gracefully close the WebSocket.
+
+Pipe a script:
+
+```bash
+printf 'what is 2+2\nand 3+3\n' | \
+  cdkl invoke-agentcore MyChatAgent --ws --ws-interactive --event ./open.json
+```
+
+Or run it interactively from a terminal and type replies as the agent
+responds. Server-side close (agent closes the stream) ends the session
+early — the iterator is released and stdin reading stops.
+
+`--ws-interactive` is only meaningful with `--ws`; it is otherwise ignored.
 
 ### MCP protocol
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -115,6 +115,13 @@ interface LocalInvokeAgentCoreOptions {
    * first frame and stream received frames to stdout until the agent closes.
    */
   ws?: boolean;
+  /**
+   * `--ws-interactive`: after the initial `--event` frame, read additional
+   * frames from stdin (one frame per line, trailing newline stripped) and
+   * send each as a text frame to the agent until stdin EOFs (Ctrl-D) or the
+   * agent closes the connection. Only meaningful with `--ws`.
+   */
+  wsInteractive?: boolean;
   /** Session id forwarded via the AgentCore session-id header (auto-generated when omitted). */
   sessionId?: string;
   /**
@@ -424,14 +431,23 @@ async function localInvokeAgentCoreCommand(
     } else if (options.ws) {
       // Bidirectional `/ws` (same 8080 container as /invocations): send the
       // event as the first frame, stream every received frame to stdout, then
-      // resolve when the agent closes the stream.
+      // resolve when the agent closes the stream. With `--ws-interactive` we
+      // additionally wire `process.stdin` (line-buffered) as a frame source,
+      // so each typed line becomes a follow-up text frame until EOF / agent
+      // close — a REPL on top of the same connection.
       await waitForAgentCorePing(containerHost, hostPort);
-      logger.info('Opening the agent /ws WebSocket and streaming frames...');
+      const frameSource = options.wsInteractive ? readStdinLines() : undefined;
+      logger.info(
+        options.wsInteractive
+          ? 'Opening the agent /ws WebSocket (interactive — stdin lines = follow-up frames; Ctrl-D to end)...'
+          : 'Opening the agent /ws WebSocket and streaming frames...'
+      );
       const wsResult = await invokeAgentCoreWs(containerHost, hostPort, event, {
         sessionId,
         timeoutMs: options.timeout,
         onMessage: (text) => process.stdout.write(text),
         ...(authorization && { authorization }),
+        ...(frameSource && { frameSource }),
       });
       // Settle so container logs flush before teardown.
       await new Promise((r) => setTimeout(r, 250));
@@ -1348,6 +1364,27 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString('utf-8');
 }
 
+/**
+ * Read `process.stdin` line-buffered and yield each line as a string (trailing
+ * `\r?\n` stripped). The async iterable completes when stdin EOFs (Ctrl-D /
+ * end-of-pipe), and surrenders the underlying stream when its `return()` is
+ * called — so the WS client can close down the source when the server closes
+ * first without leaving stdin held open.
+ *
+ * Exported so a unit test can drive the iterable shape directly.
+ */
+export async function* readStdinLines(): AsyncIterable<string> {
+  const { createInterface } = await import('node:readline');
+  const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      yield line;
+    }
+  } finally {
+    rl.close();
+  }
+}
+
 export function readEnvOverridesFile(filePath: string | undefined): EnvOverrideFile | undefined {
   if (!filePath) return undefined;
   let raw: string;
@@ -1413,6 +1450,14 @@ export function createLocalInvokeAgentCoreCommand(
         "Stream over the HTTP-protocol agent's bidirectional /ws WebSocket endpoint (on 8080) " +
           'instead of POST /invocations: send --event as the first frame and print every received ' +
           'frame to stdout until the agent closes. Ignored for an MCP runtime.'
+      ).default(false)
+    )
+    .addOption(
+      new Option(
+        '--ws-interactive',
+        'REPL mode for --ws: after the initial --event frame, read additional frames from stdin ' +
+          '(one frame per line, trailing newline stripped) and send each as a text frame until ' +
+          'stdin EOFs (Ctrl-D) or the agent closes. Only meaningful with --ws.'
       ).default(false)
     )
     .addOption(

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -331,6 +331,9 @@ async function localInvokeAgentCoreCommand(
     if (isMcp && options.ws) {
       logger.warn('--ws applies only to the HTTP protocol; ignoring it for this MCP runtime.');
     }
+    if (options.wsInteractive && !options.ws) {
+      logger.warn('--ws-interactive is meaningful only with --ws; ignoring.');
+    }
     if (options.sigv4 && (isMcp || options.ws)) {
       logger.warn(
         '--sigv4 signs the HTTP /invocations request only; ignoring it for the ' +

--- a/src/local/agentcore-ws-client.ts
+++ b/src/local/agentcore-ws-client.ts
@@ -6,13 +6,16 @@ import { AGENTCORE_SESSION_ID_HEADER } from './agentcore-client.js';
  * endpoint (bidirectional streaming, on the same 8080 container as
  * `POST /invocations` + `GET /ping`).
  *
- * v1 is a one-shot send-and-stream transparent pipe: connect to
- * `ws://host:8080/ws`, send the `--event` as the first frame, then stream every
- * received frame to the sink until the server closes the connection. The wire
- * framing over `/ws` is agent-defined (AWS pipes bytes transparently), so this
- * mirrors that — it does not interpret the frames. The AgentCore session id is
- * sent on the upgrade as {@link AGENTCORE_SESSION_ID_HEADER}, the way the cloud
- * front door does. An interactive stdin<->ws loop is a follow-up.
+ * Connect to `ws://host:8080/ws`, send the `--event` as the first frame, and
+ * stream every received frame to the sink. When a {@link
+ * InvokeAgentCoreWsOptions.frameSource} is supplied (the `--ws-interactive`
+ * REPL path), additional frames from that async iterable are sent after the
+ * initial event, and the client closes the stream when the iterable is
+ * exhausted (or when the server closes first — whichever happens first). The
+ * wire framing over `/ws` is agent-defined (AWS pipes bytes transparently),
+ * so this mirrors that — it does not interpret the frames. The AgentCore
+ * session id is sent on the upgrade as {@link AGENTCORE_SESSION_ID_HEADER},
+ * the way the cloud front door does.
  */
 
 const WS_PATH = '/ws';
@@ -31,6 +34,16 @@ export interface InvokeAgentCoreWsOptions {
    * as in the cloud.
    */
   authorization?: string;
+  /**
+   * Optional async iterable of additional text frames to send after the
+   * initial `event`. Used by `--ws-interactive` to wire `process.stdin`
+   * (line-buffered) to the WebSocket — each yielded string becomes one text
+   * frame. The connection is closed gracefully when the iterable is
+   * exhausted; if the server closes first, iteration is stopped via the
+   * iterator's `return()` method. Errors thrown by the iterable propagate as
+   * the function's rejection.
+   */
+  frameSource?: AsyncIterable<string>;
   /** Injected WebSocket implementation for tests. Defaults to `ws`. */
   webSocketImpl?: typeof WebSocket;
 }
@@ -74,6 +87,7 @@ export async function invokeAgentCoreWs(
 
     const timer = setTimeout(() => {
       finish(() => {
+        stopIterator();
         try {
           ws.terminate();
         } catch {
@@ -88,8 +102,49 @@ export async function invokeAgentCoreWs(
       });
     }, options.timeoutMs);
 
+    let iterator: AsyncIterator<string> | undefined;
+    const stopIterator = (): void => {
+      if (iterator?.return) {
+        try {
+          // Fire-and-forget: a return() that rejects is fine, we are tearing down.
+          void iterator.return();
+        } catch {
+          /* iterator already exhausted */
+        }
+      }
+      iterator = undefined;
+    };
+
     ws.on('open', () => {
       ws.send(body);
+      if (!options.frameSource) return;
+      // Kick off the additional-frames pump in the background. Each yielded
+      // string becomes one text frame; when the iterable is exhausted we close
+      // the WS gracefully so the agent sees a clean close.
+      void (async (): Promise<void> => {
+        try {
+          iterator = options.frameSource![Symbol.asyncIterator]();
+          while (!settled) {
+            const next = await iterator.next();
+            if (settled || next.done) break;
+            // `ws.send` is async via the OS socket buffer; the callback is the
+            // only way to surface a queue write error before the next iteration.
+            await new Promise<void>((res, rej) => {
+              ws.send(next.value, (err) => (err ? rej(err) : res()));
+            });
+          }
+          if (!settled) ws.close();
+        } catch (err) {
+          finish(() => {
+            try {
+              ws.terminate();
+            } catch {
+              /* already closing */
+            }
+            reject(err instanceof Error ? err : new Error(String(err)));
+          });
+        }
+      })();
     });
     ws.on('message', (data: RawData) => {
       frames += 1;
@@ -103,10 +158,16 @@ export async function invokeAgentCoreWs(
       options.onMessage(buf.toString('utf-8'));
     });
     ws.on('close', () => {
-      finish(() => resolve({ frames }));
+      finish(() => {
+        stopIterator();
+        resolve({ frames });
+      });
     });
     ws.on('error', (err: Error) => {
-      finish(() => reject(err));
+      finish(() => {
+        stopIterator();
+        reject(err);
+      });
     });
   });
 }

--- a/tests/integration/local-invoke-agentcore/agent/server.js
+++ b/tests/integration/local-invoke-agentcore/agent/server.js
@@ -11,6 +11,10 @@
 //                        sends one JSON frame echoing the frame + session-id +
 //                        Authorization + GREETING, then a second text frame, then
 //                        closes — exercising `cdkl invoke-agentcore --ws`.
+//                        When the first frame's payload contains {"loop": true},
+//                        instead enters a REPL mode: echoes each subsequent text
+//                        frame as `loop-echo:<payload>` and stays open until the
+//                        client closes — exercising `--ws-interactive`.
 // The WebSocket handshake + framing is implemented over the built-in `http`
 // `upgrade` event so the container needs no npm deps.
 // Startup logs go to stderr so the host's stdout carries only the cdkl
@@ -112,11 +116,11 @@ function handleUpgrade(req, socket) {
   );
 
   let buf = Buffer.alloc(0);
-  let replied = false;
+  let firstFrameSeen = false;
+  let loopMode = false;
   socket.on('data', (chunk) => {
-    if (replied) return;
     // A frame can span TCP reads (or several frames can share one read), so
-    // accumulate and drain complete frames until the first text frame arrives.
+    // accumulate and drain complete frames as they arrive.
     buf = Buffer.concat([buf, chunk]);
     let frame;
     while ((frame = decodeFrame(buf)) !== null) {
@@ -126,25 +130,37 @@ function handleUpgrade(req, socket) {
         return;
       }
       if (frame.opcode !== 0x1) continue; // skip ping/pong/continuation control frames
-      replied = true;
-      let echoed;
-      try {
-        echoed = JSON.parse(frame.payload.toString('utf-8') || '{}');
-      } catch {
-        echoed = frame.payload.toString('utf-8');
+      const payloadText = frame.payload.toString('utf-8');
+      if (!firstFrameSeen) {
+        firstFrameSeen = true;
+        let echoed;
+        try {
+          echoed = JSON.parse(payloadText || '{}');
+        } catch {
+          echoed = payloadText;
+        }
+        const reply = JSON.stringify({
+          ws: true,
+          echoed,
+          sessionId: req.headers[SESSION_HEADER] ?? null,
+          authorization: req.headers['authorization'] ?? null,
+          greeting: process.env.GREETING ?? 'unset',
+        });
+        socket.write(encodeTextFrame(reply));
+        if (echoed && typeof echoed === 'object' && echoed.loop === true) {
+          // REPL mode: echo each subsequent text frame as `loop-echo:<text>`
+          // and stay open until the client sends a close frame.
+          loopMode = true;
+          continue;
+        }
+        socket.write(encodeTextFrame('ws-frame-2'));
+        socket.write(encodeCloseFrame());
+        socket.end();
+        return;
       }
-      const reply = JSON.stringify({
-        ws: true,
-        echoed,
-        sessionId: req.headers[SESSION_HEADER] ?? null,
-        authorization: req.headers['authorization'] ?? null,
-        greeting: process.env.GREETING ?? 'unset',
-      });
-      socket.write(encodeTextFrame(reply));
-      socket.write(encodeTextFrame('ws-frame-2'));
-      socket.write(encodeCloseFrame());
-      socket.end();
-      return;
+      if (loopMode) {
+        socket.write(encodeTextFrame(`loop-echo:${payloadText}`));
+      }
     }
   });
   socket.on('error', () => socket.destroy());

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -53,7 +53,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/17] Invoking EchoAgent with default empty event"
+echo "==> [1/18] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -67,7 +67,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/17] Invoking EchoAgent with --event payload"
+echo "==> [2/18] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -79,7 +79,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/17] Invoking EchoAgent with --env-vars override"
+echo "==> [3/18] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -91,7 +91,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/17] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/18] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -102,7 +102,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/17] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/18] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -123,7 +123,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/17] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/18] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -133,7 +133,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/17] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/18] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -146,7 +146,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/17] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/18] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -166,7 +166,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
-echo "==> [9/17] McpAgent (no --event) runs the handshake + tools/list"
+echo "==> [9/18] McpAgent (no --event) runs the handshake + tools/list"
 RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
@@ -175,7 +175,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 }
 
 # Test 10 — an MCP tools/call via --event returns the tool result.
-echo "==> [10/17] McpAgent with --event runs tools/call"
+echo "==> [10/18] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
@@ -189,7 +189,7 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 # Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
 # source (no Dockerfile): cdkl builds it from source (pip install + run the
 # entrypoint) and the entrypoint self-serves the 8080 HTTP contract.
-echo "==> [11/17] CodeAgent (fromCodeAsset) builds from source + responds"
+echo "==> [11/18] CodeAgent (fromCodeAsset) builds from source + responds"
 RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_11}"
 echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
@@ -202,7 +202,7 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 }
 
 # Test 12 — a --event payload echoes through the from-source agent.
-echo "==> [12/17] CodeAgent with --event echoes the payload"
+echo "==> [12/18] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
@@ -217,7 +217,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # the first frame and streams every received frame to stdout until the agent
 # closes. The fixture agent replies with one JSON frame (echo + session id +
 # Authorization + GREETING) then a second text frame, then closes.
-echo "==> [13/17] EchoAgent over the /ws WebSocket (--ws)"
+echo "==> [13/18] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
@@ -242,7 +242,7 @@ echo "${RESULT_13}" | grep -q 'ws-frame-2' || {
 
 # Test 14 — --ws is HTTP-only: against an MCP runtime it warns and is ignored,
 # falling through to the normal MCP path (tools/list still returns).
-echo "==> [14/17] McpAgent with --ws warns + still runs the MCP path"
+echo "==> [14/18] McpAgent with --ws warns + still runs the MCP path"
 set +e
 OUT_14=$(${CDKL} invoke-agentcore "${MCP}" --ws 2>/tmp/cdkl-ws-mcp-stderr; cat /tmp/cdkl-ws-mcp-stderr >&2)
 RC_14=$?
@@ -269,7 +269,7 @@ echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP protocol' || {
 # invoke succeeds even with a placeholder bearer token. (The verifier's actual
 # scope / claim checks are covered by the unit tests, which sign real RS256
 # tokens against mock JWKS.)
-echo "==> [15/17] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
+echo "==> [15/18] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
 RESULT_15=$(${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_15}"
 echo "${RESULT_15}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -289,7 +289,7 @@ echo "${RESULT_15}" | grep -q '"authorization":"Bearer h.p.s"' || {
 # agent never validates the signature against AWS, it just echoes the header.
 # A second --sigv4 + --bearer-token sub-check confirms the mutually-exclusive
 # gate rejects pre-container.
-echo "==> [16/17] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
+echo "==> [16/18] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
 RESULT_16=$(AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
   AWS_REGION=us-east-1 \
@@ -304,7 +304,7 @@ echo "${RESULT_16}" | grep -q '/us-east-1/bedrock-agentcore/aws4_request' || {
   exit 1
 }
 
-echo "==> [16/17] --sigv4 + --bearer-token together rejected (mutually exclusive)"
+echo "==> [16/18] --sigv4 + --bearer-token together rejected (mutually exclusive)"
 set +e
 OUT_16B=$(${CDKL} invoke-agentcore "${TARGET}" --sigv4 --bearer-token "h.p.s" 2>&1)
 RC_16B=$?
@@ -324,7 +324,7 @@ echo "${OUT_16B}" | grep -q 'mutually exclusive' || {
 # responds (the flag is parsed + threaded into the client call, not silently
 # ignored). The negative sub-check confirms the parser rejects a non-positive
 # value pre-container.
-echo "==> [17/17] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
+echo "==> [17/18] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
 RESULT_17=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 60000 2>/dev/null | tail -1)
 echo "    response: ${RESULT_17}"
 echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -332,7 +332,7 @@ echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
   exit 1
 }
 
-echo "==> [17/17] --timeout 0 rejected by the parser (positive integer required)"
+echo "==> [17/18] --timeout 0 rejected by the parser (positive integer required)"
 set +e
 OUT_17B=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 0 2>&1)
 RC_17B=$?
@@ -346,5 +346,33 @@ echo "${OUT_17B}" | grep -q 'positive integer' || {
   exit 1
 }
 
+# Test 18 — `--ws-interactive` REPL mode: the initial --event opens loop mode
+# in the EchoAgent (it stays open + echoes each subsequent text frame), then
+# two stdin lines are sent as follow-up frames. The agent echoes each as
+# `loop-echo:<line>`, and the client closes the WS when stdin EOFs.
+echo "==> [18/18] EchoAgent --ws --ws-interactive sends two stdin lines as follow-up WS frames"
+LOOP_EVENT_FILE=$(mktemp -t cdkl-ws-loop-event-XXXX.json)
+trap 'rm -f "${LOOP_EVENT_FILE}"' EXIT
+echo '{"loop":true}' > "${LOOP_EVENT_FILE}"
+RESULT_18=$(printf 'line-A\nline-B\n' | \
+  ${CDKL} invoke-agentcore "${TARGET}" --ws --ws-interactive --event "${LOOP_EVENT_FILE}" 2>/dev/null)
+echo "    response: ${RESULT_18}"
+# Initial frame echo (first frame's loop:true is acknowledged by the agent):
+echo "${RESULT_18}" | grep -q '"echoed":{"loop":true}' || {
+  echo "FAIL: expected initial ack of the loop event in the WS response, got: ${RESULT_18}"
+  exit 1
+}
+# Both follow-up frames echoed back via loop-echo:<line>:
+echo "${RESULT_18}" | grep -q 'loop-echo:line-A' || {
+  echo "FAIL: expected loop-echo:line-A from the agent, got: ${RESULT_18}"
+  exit 1
+}
+echo "${RESULT_18}" | grep -q 'loop-echo:line-B' || {
+  echo "FAIL: expected loop-echo:line-B from the agent, got: ${RESULT_18}"
+  exit 1
+}
+rm -f "${LOOP_EVENT_FILE}"
+trap - EXIT
+
 echo ""
-echo "==> All 17 local-invoke-agentcore tests passed"
+echo "==> All 18 local-invoke-agentcore tests passed"

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -352,7 +352,7 @@ echo "${OUT_17B}" | grep -q 'positive integer' || {
 # `loop-echo:<line>`, and the client closes the WS when stdin EOFs.
 echo "==> [18/18] EchoAgent --ws --ws-interactive sends two stdin lines as follow-up WS frames"
 LOOP_EVENT_FILE=$(mktemp -t cdkl-ws-loop-event-XXXX.json)
-trap 'rm -f "${LOOP_EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}"' EXIT
 echo '{"loop":true}' > "${LOOP_EVENT_FILE}"
 RESULT_18=$(printf 'line-A\nline-B\n' | \
   ${CDKL} invoke-agentcore "${TARGET}" --ws --ws-interactive --event "${LOOP_EVENT_FILE}" 2>/dev/null)
@@ -371,8 +371,5 @@ echo "${RESULT_18}" | grep -q 'loop-echo:line-B' || {
   echo "FAIL: expected loop-echo:line-B from the agent, got: ${RESULT_18}"
   exit 1
 }
-rm -f "${LOOP_EVENT_FILE}"
-trap - EXIT
-
 echo ""
 echo "==> All 18 local-invoke-agentcore tests passed"

--- a/tests/unit/local/agentcore-ws-client.test.ts
+++ b/tests/unit/local/agentcore-ws-client.test.ts
@@ -41,6 +41,34 @@ async function startServer(
   return { port, lastHeaders: () => headers };
 }
 
+/**
+ * Variant of {@link startServer} that handles EVERY received frame (not just
+ * the first). Used by the `frameSource` REPL-loop tests where the client sends
+ * multiple frames and the server echoes each.
+ */
+async function startMultiFrameServer(
+  onFrame: (ws: WebSocket, frame: string, index: number) => void
+): Promise<StartedServer> {
+  const wss = new WebSocketServer({ port: 0, path: '/ws' });
+  servers.push(wss);
+  let headers: Record<string, string | string[] | undefined> = {};
+  wss.on('connection', (ws, req) => {
+    headers = req.headers;
+    let index = 0;
+    ws.on('message', (data) => {
+      onFrame(ws, data.toString(), index);
+      index += 1;
+    });
+  });
+  await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
+  const port = (wss.address() as AddressInfo).port;
+  return { port, lastHeaders: () => headers };
+}
+
+async function* fromArray<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) yield item;
+}
+
 describe('invokeAgentCoreWs', () => {
   it('sends the event as the first frame, streams received frames, and resolves with the frame count', async () => {
     const server = await startServer((ws, firstFrame) => {
@@ -141,5 +169,108 @@ describe('invokeAgentCoreWs', () => {
         onMessage: () => {},
       })
     ).rejects.toThrow(/timed out after 150ms/);
+  });
+
+  describe('frameSource (interactive REPL)', () => {
+    it('sends each yielded string as a follow-up text frame and gracefully closes when the iterable is exhausted', async () => {
+      const received: string[] = [];
+      const server = await startMultiFrameServer((ws, frame) => {
+        received.push(frame);
+        ws.send(`ack:${frame}`);
+      });
+
+      const fromClient: string[] = [];
+      const result = await invokeAgentCoreWs(
+        '127.0.0.1',
+        server.port,
+        { hello: true },
+        {
+          sessionId: 's',
+          timeoutMs: 5000,
+          onMessage: (t) => fromClient.push(t),
+          frameSource: fromArray(['line-1', 'line-2', 'line-3']),
+        }
+      );
+
+      // Server saw the initial event + 3 follow-up frames.
+      expect(received).toEqual(['{"hello":true}', 'line-1', 'line-2', 'line-3']);
+      // Client received an ack for each.
+      expect(fromClient).toEqual([
+        'ack:{"hello":true}',
+        'ack:line-1',
+        'ack:line-2',
+        'ack:line-3',
+      ]);
+      expect(result.frames).toBe(4);
+    });
+
+    it('stops iterating the frameSource when the server closes first', async () => {
+      // Server sends one ack then closes — the client iterator should be
+      // released via its return() so a real stdin readline tears down.
+      const server = await startMultiFrameServer((ws, frame, index) => {
+        ws.send(`ack:${frame}`);
+        if (index === 0) ws.close();
+      });
+
+      let yielded = 0;
+      let returnedEarly = false;
+      const iterable: AsyncIterable<string> = {
+        async *[Symbol.asyncIterator](): AsyncIterator<string> {
+          try {
+            while (true) {
+              yielded += 1;
+              yield `frame-${yielded}`;
+              // Slow the iteration so the server's close lands before we
+              // produce the next frame.
+              await new Promise((r) => setTimeout(r, 50));
+            }
+          } finally {
+            returnedEarly = true;
+          }
+        },
+      };
+
+      const result = await invokeAgentCoreWs(
+        '127.0.0.1',
+        server.port,
+        { hi: true },
+        {
+          sessionId: 's',
+          timeoutMs: 5000,
+          onMessage: () => {},
+          frameSource: iterable,
+        }
+      );
+
+      expect(result.frames).toBeGreaterThan(0);
+      // The async generator is suspended in `await setTimeout(50)` when the
+      // server closes; iterator.return() unblocks it on the next tick, which
+      // runs the `finally`. Wait briefly past the pending setTimeout.
+      await new Promise((r) => setTimeout(r, 100));
+      // The iterator's finally ran — it was torn down on server close.
+      expect(returnedEarly).toBe(true);
+    });
+
+    it('propagates an error thrown by the frameSource as the function rejection', async () => {
+      const server = await startMultiFrameServer((ws, frame) => {
+        ws.send(`ack:${frame}`);
+      });
+
+      const iterable: AsyncIterable<string> = {
+        async *[Symbol.asyncIterator](): AsyncIterator<string> {
+          yield 'first';
+          throw new Error('boom from frame source');
+        },
+      };
+
+      await expect(
+        invokeAgentCoreWs('127.0.0.1', server.port, {}, {
+          sessionId: 's',
+          timeoutMs: 5000,
+          onMessage: () => {},
+          frameSource: iterable,
+        })
+      ).rejects.toThrow(/boom from frame source/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Extends the one-shot `--ws` transport with `--ws-interactive`, an REPL loop. After the initial `--event` frame, each stdin line (trailing `\r?\n` stripped) becomes one follow-up text frame; the WebSocket is closed gracefully on stdin EOF (Ctrl-D / end-of-pipe) or when the agent closes first.
- `invokeAgentCoreWs` gains an optional `frameSource: AsyncIterable<string>` for follow-up frames. The CLI wires `process.stdin` (line-buffered via `readline.createInterface`) to it when `--ws-interactive` is set.
- Server-side close releases the iterator via its `return()`, so stdin reading and any pending `await` are torn down without leaking the readline handle.

## Test plan

- [x] 3 new unit tests in `agentcore-ws-client.test.ts` cover: multi-frame sends + acks via a real `WebSocketServer`, iterator release when the server closes first (the iterator's `finally` block runs), and iterable error propagating as the function's rejection.
- [x] `vp run check` + `vp test run` (1565/1565 pass) + `vp run build`.
- [x] Integ scenario 18 in `tests/integration/local-invoke-agentcore/verify.sh`: pipes `line-A\nline-B\n` into the EchoAgent in loop mode and asserts both `loop-echo:line-A` and `loop-echo:line-B` come back. All 18 scenarios green; 0 docker orphans.

## Reviewer nits

The `pr-code-reviewer` agent flagged 5 minor / nit issues; addressed (1) + (4) inline (warn on `--ws-interactive` without `--ws`; restore the chained trap pattern in `verify.sh`). Accepted (2) + (3) + (5) as known cost: they are documentation suggestions about subtle async-coordination edge cases (iterator teardown is fire-and-forget — suitable for one-shot CLI usage; late iterable error after server close silently swallowed by the `settled` guard — correct behavior; `finish()` idempotency comment) that don't affect functional behavior.

Closes #163
