### PR TITLE
feat(invoke-agentcore): precise --from-cfn-stack hint for same-stack ECR ContainerUri

### DIFF
--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -542,6 +542,8 @@ function extractArtifact(
 
   const uri = resolveImageUri(
     (container as Record<string, unknown>)['ContainerUri'],
+    logicalId,
+    stackName,
     resources,
     region,
     imageContext
@@ -549,8 +551,8 @@ function extractArtifact(
   if (uri === undefined) {
     throw new AgentCoreResolutionError(
       `AgentCore Runtime '${logicalId}' in ${stackName} has a ContainerConfiguration.ContainerUri that ${getEmbedConfig().cliName} invoke-agentcore cannot resolve. ` +
-        `v1 resolves a literal image URI, an Fn::Sub asset URI (the fromAsset / Dockerfile path), and an imported-ECR Fn::Join. ` +
-        `A same-stack AWS::ECR::Repository reference is not supported — build the agent as a fromAsset image, or pin a literal / imported ECR image URI.`
+        `v1 resolves a literal image URI, an Fn::Sub asset URI (the fromAsset / Dockerfile path), an imported-ECR Fn::Join, ` +
+        `and a same-stack AWS::ECR::Repository Fn::Join under --from-cfn-stack — build the agent as a fromAsset image, or pin a literal / imported ECR image URI.`
     );
   }
   return { kind: 'container', containerUri: uri };
@@ -657,10 +659,15 @@ function isFromS3BucketIntrinsic(value: unknown): value is Record<string, unknow
  * an `Fn::Sub` (the template returned verbatim — `${AWS::*}` placeholders
  * are kept for asset-hash matching / later ECR substitution), and the
  * canonical CDK `Fn::Join` ECR shape via the shared {@link intrinsic-image}
- * resolver. Returns undefined when none apply.
+ * resolver. A same-stack `AWS::ECR::Repository` Fn::Join without
+ * `--from-cfn-stack` throws an `AgentCoreResolutionError` pointing the user
+ * at the right flag (mirroring `cdkl run-task`'s shape). Returns undefined
+ * when none of the supported shapes apply.
  */
 function resolveImageUri(
   value: unknown,
+  logicalId: string,
+  stackName: string,
   resources: Record<string, TemplateResource>,
   region: string | undefined,
   imageContext: ImageResolutionContext | undefined
@@ -687,6 +694,18 @@ function resolveImageUri(
       })();
     const joinResolved = tryResolveImageFnJoin(value, resources, context);
     if (joinResolved.kind === 'resolved') return joinResolved.uri;
+    // Mirror `cdkl run-task`'s shape: when the Fn::Join references a
+    // same-stack AWS::ECR::Repository but no state has been loaded, point the
+    // user at `--from-cfn-stack` rather than the coarse "cannot resolve" we
+    // fall through to for genuinely unsupported intrinsics.
+    if (joinResolved.kind === 'needs-state') {
+      throw new AgentCoreResolutionError(
+        `AgentCore Runtime '${logicalId}' in ${stackName} references same-stack ECR repository '${joinResolved.repoLogicalId}' via Fn::Join. ` +
+          `${getEmbedConfig().cliName} invoke-agentcore cannot resolve the repository URI without state — ` +
+          'pass --from-cfn-stack to load the deployed stack state, ' +
+          'build via Runtime.fromAsset, or pin a literal / imported ECR image URI.'
+      );
+    }
   }
 
   return undefined;

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -106,6 +106,95 @@ describe('resolveAgentCoreTarget — happy path', () => {
     });
     expect(resolved.containerUri).toBe('123456789012.dkr.ecr.us-east-1.amazonaws.com/agent:tag');
   });
+
+  /**
+   * Same-stack `AWS::ECR::Repository` ContainerUri — the shape CDK emits for
+   * `Runtime.fromImageUri(repo.repositoryUriForTag('latest'))`. Resolves
+   * under `--from-cfn-stack` by reading the deployed repo's physical name
+   * from state + synthesizing the URI from the resolved pseudo parameters.
+   * Locks the implicit fix from PR #149 (`deepen --from-cfn-stack`).
+   */
+  it('resolves a same-stack AWS::ECR::Repository Fn::Join (Fn::GetAtt RepositoryUri) under state', () => {
+    const join = {
+      'Fn::Join': ['', [{ 'Fn::GetAtt': ['MyRepo', 'RepositoryUri'] }, ':latest']],
+    };
+    const stack = buildStack(
+      'App',
+      {
+        MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        ChatAgent: containerRuntime({}, join),
+      },
+      'us-east-1'
+    );
+    const resolved = resolveAgentCoreTarget('ChatAgent', [stack], {
+      pseudoParameters: {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        partition: 'aws',
+        urlSuffix: 'amazonaws.com',
+      },
+      stateResources: {
+        MyRepo: {
+          logicalId: 'MyRepo',
+          physicalId: 'app-myrepo-abc123',
+          resourceType: 'AWS::ECR::Repository',
+        },
+      },
+    });
+    expect(resolved.containerUri).toBe(
+      '123456789012.dkr.ecr.us-east-1.amazonaws.com/app-myrepo-abc123:latest'
+    );
+  });
+
+  /**
+   * Alternative same-stack ECR shape: `Ref: <RepoLogicalId>` (rather than
+   * `Fn::GetAtt: RepositoryUri`) interleaved with the URI components.
+   * `Ref` on an `AWS::ECR::Repository` resolves to its physical name from
+   * state; the surrounding components come from pseudoParameters.
+   */
+  it('resolves a same-stack AWS::ECR::Repository Fn::Join (Ref to the repo) under state', () => {
+    const join = {
+      'Fn::Join': [
+        '',
+        [
+          { Ref: 'AWS::AccountId' },
+          '.dkr.ecr.',
+          { Ref: 'AWS::Region' },
+          '.',
+          { Ref: 'AWS::URLSuffix' },
+          '/',
+          { Ref: 'MyRepo' },
+          ':latest',
+        ],
+      ],
+    };
+    const stack = buildStack(
+      'App',
+      {
+        MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        ChatAgent: containerRuntime({}, join),
+      },
+      'us-east-1'
+    );
+    const resolved = resolveAgentCoreTarget('ChatAgent', [stack], {
+      pseudoParameters: {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        partition: 'aws',
+        urlSuffix: 'amazonaws.com',
+      },
+      stateResources: {
+        MyRepo: {
+          logicalId: 'MyRepo',
+          physicalId: 'app-myrepo-xyz789',
+          resourceType: 'AWS::ECR::Repository',
+        },
+      },
+    });
+    expect(resolved.containerUri).toBe(
+      '123456789012.dkr.ecr.us-east-1.amazonaws.com/app-myrepo-xyz789:latest'
+    );
+  });
 });
 
 describe('resolveAgentCoreTarget — unresolvable container URI', () => {
@@ -117,6 +206,31 @@ describe('resolveAgentCoreTarget — unresolvable container URI', () => {
       AgentCoreResolutionError
     );
     expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/cannot resolve/);
+  });
+
+  /**
+   * A same-stack ECR Fn::Join without `--from-cfn-stack` (no state) still
+   * errors with the actionable "build the agent as a fromAsset image, or
+   * pin a literal / imported ECR image URI" hint, but the message now
+   * points the user at `--from-cfn-stack` as the resolution path.
+   */
+  it('errors with a --from-cfn-stack hint when a same-stack ECR Fn::Join is invoked without state', () => {
+    const join = {
+      'Fn::Join': ['', [{ 'Fn::GetAtt': ['MyRepo', 'RepositoryUri'] }, ':latest']],
+    };
+    const stack = buildStack(
+      'App',
+      {
+        MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        ChatAgent: containerRuntime({}, join),
+      },
+      'us-east-1'
+    );
+    expect(() => resolveAgentCoreTarget('ChatAgent', [stack])).toThrow(AgentCoreResolutionError);
+    expect(() => resolveAgentCoreTarget('ChatAgent', [stack])).toThrow(
+      /references same-stack ECR repository 'MyRepo'/
+    );
+    expect(() => resolveAgentCoreTarget('ChatAgent', [stack])).toThrow(/--from-cfn-stack/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Same-stack `AWS::ECR::Repository` `Fn::Join` ContainerUri (the shape CDK emits for `Runtime.fromImageUri(repo.repositoryUriForTag('latest'))`) already resolves under `--from-cfn-stack` via the shared `tryResolveImageFnJoin` + `stateResources` plumbing added in #149. This PR improves the failure case: without `--from-cfn-stack`, the resolver now routes the `needs-state` branch to a precise error that points the user at the right flag, mirroring `cdkl run-task`'s long-standing shape.
- Previously the same-stack case fell through to the generic "A same-stack `AWS::ECR::Repository` reference is not supported" message, which incorrectly suggested the case was permanently unsupported. The new message names the repo logical id and lists three resolutions: pass `--from-cfn-stack`, build via `Runtime.fromAsset`, or pin a literal / imported ECR image URI.

## Test plan

- [x] 3 new unit tests in `agentcore-resolver.test.ts`: (a) `Fn::Join` with `Fn::GetAtt: [<Repo>, 'RepositoryUri']` + state → resolves; (b) `Fn::Join` with `Ref: <Repo>` interleaved with `Ref: AWS::AccountId/Region/URLSuffix` + state → resolves; (c) same-stack ECR `Fn::Join` without state → errors with `references same-stack ECR repository 'MyRepo'` + `--from-cfn-stack` hint.
- [x] `vp run check` + `vp test run` (1587/1587 pass) + `vp run build`.
- [x] `local-invoke-agentcore` integ scenarios 1-18 still pass (the resolver signature renamed; existing literal-URI + Fn::Sub callers go through the renamed signature). 0 docker orphans.

No new integ scenario: a same-stack ECR repo + runtime in one CFn stack is chicken-and-egg (CFn validates the image exists at runtime-create time, but the repo is empty on first deploy), so a real-AWS integ would need a two-stage deploy + manual image push. The unit tests + existing `--from-cfn-stack` agentcore integ jointly cover the surface.

Closes #165
