### PR TITLE
feat(invoke-agentcore): support A2A + AGUI protocols locally

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -426,14 +426,23 @@ container down. The exact contract depends on `ProtocolConfiguration`:
   header) and prints the response body.
 - **MCP** — starts on port 8000, then speaks the Model Context Protocol over
   Streamable HTTP at `POST /mcp`: see [MCP protocol](#mcp-protocol) below.
+- **A2A** — starts on port 9000, then speaks Agent2Agent JSON-RPC 2.0 at
+  `POST /` (the root). One JSON-RPC round-trip per invocation; default
+  method is `agent/getCard` (the agent's discovery card). See
+  [A2A protocol](#a2a-protocol) below.
+- **AGUI** — starts on port 8080 (the AG-UI wire reuses the HTTP container
+  port), serves SSE on `POST /invocations` and a bidirectional WebSocket on
+  `/ws`. Routes through the same client path as HTTP — the SSE / WS
+  handlers stream the AG-UI typed event envelope to stdout transparently
+  (pipe through `jq` for pretty-printing). See [AGUI protocol](#agui-protocol)
+  below.
 
 This is the same request/response loop AgentCore runs in the cloud,
 exercised locally before deploy. It supports the **container artifact**
 (`AgentRuntimeArtifact.ContainerConfiguration.ContainerUri`) and the
 **CodeConfiguration** managed-runtime artifact (`fromCodeAsset` AND `fromS3`,
 built from source — see [CodeConfiguration](#codeconfiguration-managed-runtime)
-below) on the **HTTP** and **MCP** protocols; the `A2A` / `AGUI` protocols are
-rejected with an actionable error. The agent's own calls to AWS managed
+below) on all four protocols. The agent's own calls to AWS managed
 services (Bedrock models, memory, etc.) go to real AWS — credentials are
 injected exactly like `cdkl invoke` (see below).
 
@@ -663,19 +672,61 @@ The JSON-RPC response is printed (handling both an `application/json` and a
 MCP**: the AgentCore session header and inbound OAuth bearer are managed-plane
 concerns the cloud front door maps to MCP's own `Mcp-Session-Id`, so they are
 not applied to a direct local `/mcp` call (`--bearer-token` / `--session-id`
-are HTTP-protocol options and are ignored for MCP). The `A2A` / `AGUI`
-protocols are not supported yet.
+are HTTP-protocol options and are ignored for MCP).
+
+### A2A protocol
+
+When `ProtocolConfiguration = A2A`, the runtime's container serves the
+Agent2Agent JSON-RPC 2.0 contract at `POST /` (the root) on port 9000.
+Unlike MCP there is no session lifecycle: each invocation is one POST that
+carries the JSON-RPC request and the response is read back from the same
+POST. `cdkl invoke-agentcore` POSTs the method/params from `--event`,
+defaulting to `agent/getCard` (the agent's discovery card) when none is
+supplied:
+
+```bash
+cdkl invoke-agentcore MyA2aAgent                                     # agent/getCard
+cdkl invoke-agentcore MyA2aAgent --event ./tasks-send.json           # tasks/send
+```
+
+Where `tasks-send.json` is e.g.
+`{"method":"tasks/send","params":{"id":"task-1","message":{...}}}`. The
+JSON-RPC response is pretty-printed; a top-level JSON-RPC `error` exits
+non-zero (matching the MCP path). Talking to the local container is
+**vanilla A2A** — the AgentCore session header and inbound OAuth bearer are
+managed-plane concerns layered on top in the cloud, so `--bearer-token` /
+`--session-id` are HTTP-protocol options and are ignored for A2A.
+
+### AGUI protocol
+
+When `ProtocolConfiguration = AGUI`, the runtime's container serves the
+AG-UI HTTP-compatible contract on port 8080 — SSE on `POST /invocations`,
+WebSocket on `/ws`. `cdkl invoke-agentcore` routes AGUI through the same
+client path as **HTTP**: it waits for `GET /ping`, POSTs `--event` to
+`/invocations`, and streams the response body to stdout as it arrives. AG-UI
+emits typed events (`RUN_STARTED`, `MESSAGE_CONTENT`, `RUN_FINISHED`, ...)
+as one `data:` line each — pipe through `jq -c .` (or any JSON line tool)
+for structured pretty-printing:
+
+```bash
+cdkl invoke-agentcore MyAguiAgent --event ./prompt.json | jq -c .
+```
+
+`--ws` / `--ws-interactive` / `--bearer-token` / `--no-verify-auth` /
+`--sigv4` all apply unchanged — AGUI's wire is the same shape as HTTP's, so
+the entire HTTP option surface carries over.
 
 ### Per-request timeout (`--timeout`)
 
-The default per-request timeout is 120 seconds. It applies to all three
-transports:
+The default per-request timeout is 120 seconds. It applies to every
+transport:
 
-- HTTP `POST /invocations` — the streaming sink keeps writing chunks while
-  the response body arrives, but the open-to-final-byte window is bounded
-  by `--timeout`.
+- HTTP / AGUI `POST /invocations` — the streaming sink keeps writing chunks
+  while the response body arrives, but the open-to-final-byte window is
+  bounded by `--timeout`.
 - MCP `POST /mcp` — applied to both the `notifications/initialized` POST
   and the one JSON-RPC request POST.
+- A2A `POST /` — applied to the JSON-RPC POST.
 - `/ws` — bounds the open-to-close window (the agent closes the stream).
 
 Raise it for long-running agents whose response exceeds 120s:

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -31,6 +31,8 @@ import {
   type CdkLocalEmbedConfig,
 } from '../../local/embed-config.js';
 import {
+  AGENTCORE_A2A_PROTOCOL,
+  AGENTCORE_AGUI_PROTOCOL,
   AGENTCORE_MCP_PROTOCOL,
   pickAgentCoreCandidateStack,
   resolveAgentCoreTarget,
@@ -55,6 +57,13 @@ import {
   type McpInvokeResult,
   type McpJsonRpcRequest,
 } from '../../local/agentcore-mcp-client.js';
+import {
+  a2aInvokeOnce,
+  A2A_CONTAINER_PORT,
+  A2A_PATH,
+  type A2aInvokeResult,
+  type A2aJsonRpcRequest,
+} from '../../local/agentcore-a2a-client.js';
 import { invokeAgentCoreWs, type AgentCoreWsResult } from '../../local/agentcore-ws-client.js';
 import { createJwksCache, verifyJwtViaDiscovery } from '../../local/cognito-jwt.js';
 import { resolveEnvVars, type EnvOverrideFile } from '../../local/env-resolver.js';
@@ -328,16 +337,30 @@ async function localInvokeAgentCoreCommand(
     const resolved = resolveAgentCoreTarget(resolvedTarget, stacks, imageContext);
     logger.info(`Target: ${resolved.stack.stackName}/${resolved.logicalId} (${resolved.protocol})`);
     const isMcp = resolved.protocol === AGENTCORE_MCP_PROTOCOL;
-    if (isMcp && options.ws) {
-      logger.warn('--ws applies only to the HTTP protocol; ignoring it for this MCP runtime.');
+    const isA2a = resolved.protocol === AGENTCORE_A2A_PROTOCOL;
+    const isAgui = resolved.protocol === AGENTCORE_AGUI_PROTOCOL;
+    if (isAgui) {
+      // AG-UI's wire shape is HTTP-compatible: SSE on `POST /invocations` and a
+      // bidirectional WebSocket on `/ws`, both on port 8080. So an AG-UI
+      // runtime routes through the same client path as HTTP — the existing
+      // SSE / WS handlers stream bytes transparently. Surface this in the
+      // log so users aren't surprised the AGUI runtime "becomes" HTTP.
+      logger.info(
+        'AGUI runtime: routing through the HTTP /invocations + /ws path (AG-UI wire is SSE / WebSocket on port 8080).'
+      );
+    }
+    if ((isMcp || isA2a) && options.ws) {
+      logger.warn(
+        `--ws applies only to the HTTP / AGUI protocols; ignoring it for this ${resolved.protocol} runtime.`
+      );
     }
     if (options.wsInteractive && !options.ws) {
       logger.warn('--ws-interactive is meaningful only with --ws; ignoring.');
     }
-    if (options.sigv4 && (isMcp || options.ws)) {
+    if (options.sigv4 && (isMcp || isA2a || options.ws)) {
       logger.warn(
         '--sigv4 signs the HTTP /invocations request only; ignoring it for the ' +
-          (isMcp ? 'MCP' : '/ws WebSocket') +
+          (isMcp ? 'MCP' : isA2a ? 'A2A' : '/ws WebSocket') +
           ' path.'
       );
     }
@@ -350,19 +373,23 @@ async function localInvokeAgentCoreCommand(
     // For MCP, parse the event into a JSON-RPC request up front so a malformed
     // one fails fast too (default: tools/list).
     const mcpRequest = isMcp ? buildMcpRequest(event) : undefined;
+    // A2A is JSON-RPC 2.0 too: parse the event up front into a method/params
+    // (default: agent/getCard — the agent's discovery card).
+    const a2aRequest = isA2a ? buildA2aRequest(event) : undefined;
 
     // Inbound JWT auth: when the runtime declares a customJwtAuthorizer,
     // verify the supplied bearer token against its OIDC discovery URL BEFORE
     // any Docker work — rejecting a missing / invalid token the way AgentCore
     // does. Returns the `Authorization` header to forward to the container.
-    // MCP talks vanilla MCP directly to the container; its bearer / session is
-    // an AgentCore managed-plane concern the front door maps to Mcp-Session-Id,
-    // so it is not applied to a direct local /mcp call.
+    // MCP / A2A talk vanilla JSON-RPC directly to the container; their
+    // bearer / session is an AgentCore managed-plane concern the front door
+    // layers on top, so it is not applied to a direct local POST.
     let authorization: string | undefined;
-    if (isMcp) {
+    if (isMcp || isA2a) {
       if (resolved.jwtAuthorizer || options.bearerToken) {
+        const pathLabel = isMcp ? MCP_PATH : A2A_PATH;
         logger.info(
-          `MCP runtime: invoking the local container's ${MCP_PATH} directly (vanilla MCP). ` +
+          `${resolved.protocol} runtime: invoking the local container's ${pathLabel} directly (vanilla ${resolved.protocol}). ` +
             `An inbound JWT / --bearer-token is an AgentCore managed-plane concern and is not applied locally.`
         );
       }
@@ -396,7 +423,12 @@ async function localInvokeAgentCoreCommand(
     // if the process is killed before teardown — unlike a one-shot Lambda
     // invoke, the agent container runs a long-lived HTTP server.
     const containerName = `${getEmbedConfig().resourceNamePrefix}-agentcore-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
-    const containerPortLabel = isMcp ? `${MCP_CONTAINER_PORT}${MCP_PATH}` : '8080';
+    const containerPort = isMcp ? MCP_CONTAINER_PORT : isA2a ? A2A_CONTAINER_PORT : undefined;
+    const containerPortLabel = isMcp
+      ? `${MCP_CONTAINER_PORT}${MCP_PATH}`
+      : isA2a
+        ? `${A2A_CONTAINER_PORT}${A2A_PATH}`
+        : '8080';
     logger.info(
       `Starting agent container (image=${image}, port=${hostPort} -> ${containerPortLabel})...`
     );
@@ -409,7 +441,7 @@ async function localInvokeAgentCoreCommand(
       host: containerHost,
       platform: options.platform,
       name: containerName,
-      ...(isMcp && { containerPort: MCP_CONTAINER_PORT }),
+      ...(containerPort !== undefined && { containerPort }),
       // Keep decrypted SecureString SSM env values off the `docker run` argv.
       ...(sensitiveEnvKeys.size > 0 && { sensitiveEnvKeys }),
     });
@@ -431,6 +463,15 @@ async function localInvokeAgentCoreCommand(
       // Settle so container logs flush before teardown.
       await new Promise((r) => setTimeout(r, 250));
       emitMcpResult(mcp);
+    } else if (isA2a && a2aRequest) {
+      // A2A has no /ping either: a2aInvokeOnce folds the boot-wait into a
+      // retried POST. One JSON-RPC round-trip — vanilla A2A.
+      logger.info(`A2A request: ${a2aRequest.method}`);
+      const a2a = await a2aInvokeOnce(containerHost, hostPort, a2aRequest, {
+        requestTimeoutMs: options.timeout,
+      });
+      await new Promise((r) => setTimeout(r, 250));
+      emitA2aResult(a2a);
     } else if (options.ws) {
       // Bidirectional `/ws` (same 8080 container as /invocations): send the
       // event as the first frame, stream every received frame to stdout, then
@@ -1276,6 +1317,47 @@ export function buildMcpRequest(event: unknown): McpJsonRpcRequest {
 export function emitMcpResult(result: McpInvokeResult): void {
   if (!result.ok) {
     getLogger().warn('MCP server returned a JSON-RPC error.');
+    process.exitCode = 1;
+  }
+  process.stdout.write(`${result.raw}\n`);
+}
+
+/**
+ * Build the JSON-RPC request to send to an A2A runtime from `--event`:
+ *   - no `--event` (empty object) → `agent/getCard` (discover the agent's card),
+ *   - an object with a string `method` → that method + its `params`,
+ *   - anything else → a fail-fast error.
+ *
+ * Exported for unit testing.
+ */
+export function buildA2aRequest(event: unknown): A2aJsonRpcRequest {
+  if (event === undefined || event === null) return { method: 'agent/getCard', params: {} };
+  if (typeof event !== 'object' || Array.isArray(event)) {
+    throw new CdkLocalError(
+      'A2A --event must be a JSON object describing a JSON-RPC request ' +
+        '(e.g. {"method":"tasks/send","params":{"id":"...","message":{...}}}).',
+      'LOCAL_INVOKE_AGENTCORE_A2A_EVENT_INVALID'
+    );
+  }
+  const obj = event as Record<string, unknown>;
+  if (Object.keys(obj).length === 0) return { method: 'agent/getCard', params: {} };
+  if (typeof obj['method'] !== 'string') {
+    throw new CdkLocalError(
+      'A2A --event must include a string "method" (a JSON-RPC method such as ' +
+        `"agent/getCard" or "tasks/send"). Got keys: ${Object.keys(obj).join(', ')}.`,
+      'LOCAL_INVOKE_AGENTCORE_A2A_EVENT_INVALID'
+    );
+  }
+  return {
+    method: obj['method'],
+    ...(obj['params'] !== undefined && { params: obj['params'] }),
+  };
+}
+
+/** Print the A2A JSON-RPC response; exit 1 when it carried a JSON-RPC error. */
+export function emitA2aResult(result: A2aInvokeResult): void {
+  if (!result.ok) {
+    getLogger().warn('A2A server returned a JSON-RPC error.');
     process.exitCode = 1;
   }
   process.stdout.write(`${result.raw}\n`);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -301,6 +301,8 @@ export {
   AGENTCORE_RUNTIME_TYPE,
   AGENTCORE_HTTP_PROTOCOL,
   AGENTCORE_MCP_PROTOCOL,
+  AGENTCORE_A2A_PROTOCOL,
+  AGENTCORE_AGUI_PROTOCOL,
   type ResolvedAgentCoreRuntime,
   type AgentCoreJwtAuthorizer,
   type AgentCoreCustomClaim,
@@ -336,6 +338,14 @@ export {
   type InvokeAgentCoreWsOptions,
   type AgentCoreWsResult,
 } from './local/agentcore-ws-client.js';
+export {
+  a2aInvokeOnce,
+  A2A_CONTAINER_PORT,
+  A2A_PATH,
+  type A2aInvokeResult,
+  type A2aInvokeOptions,
+  type A2aJsonRpcRequest,
+} from './local/agentcore-a2a-client.js';
 export {
   downloadAndExtractS3Bundle,
   type S3BundleLocation,

--- a/src/local/agentcore-a2a-client.ts
+++ b/src/local/agentcore-a2a-client.ts
@@ -1,0 +1,155 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+/**
+ * Client for the Bedrock AgentCore Runtime A2A protocol contract.
+ *
+ * An A2A-protocol AgentCore Runtime container listens on `0.0.0.0:9000` and
+ * serves the Agent2Agent JSON-RPC 2.0 contract at `POST /` (the root). Each
+ * call is one JSON-RPC request and one JSON-RPC response. Unlike MCP there is
+ * no session lifecycle to negotiate — the request is sent directly. `cdkl
+ * invoke-agentcore` POSTs the method/params from `--event` (defaults to
+ * `agent/getCard`, the agent's discovery card) and prints the response.
+ *
+ * Talking to the local container is **vanilla A2A**: the
+ * `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header and the inbound OAuth
+ * bearer are AgentCore managed-plane concerns the front door layers on top,
+ * so a direct local client does not send them.
+ */
+
+/** Container port an A2A-protocol AgentCore Runtime listens on. */
+export const A2A_CONTAINER_PORT = 9000;
+/** HTTP path of the A2A JSON-RPC endpoint. */
+export const A2A_PATH = '/';
+
+/** A JSON-RPC request to send to an A2A agent (id + jsonrpc are added). */
+export interface A2aJsonRpcRequest {
+  method: string;
+  params?: unknown;
+}
+
+export interface A2aInvokeResult {
+  /** True when the JSON-RPC response carried no top-level `error`. */
+  ok: boolean;
+  /** The JSON-RPC response message, pretty-printed for display. */
+  raw: string;
+}
+
+export interface A2aInvokeOptions {
+  /**
+   * Total ms to keep retrying the POST while the container boots (A2A has no
+   * dedicated readiness endpoint, so a successful POST IS the readiness
+   * signal). Default 30s.
+   */
+  readyTimeoutMs?: number;
+  /** Per-request abort timeout once the server is reachable. Default 120s. */
+  requestTimeoutMs?: number;
+  /** Injected `fetch` for tests. Defaults to the global. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Send one JSON-RPC request to a local A2A container and return the parsed
+ * response. The POST is retried while the container boots (there is no
+ * separate readiness endpoint), so this also serves as the wait-for-ready step.
+ */
+export async function a2aInvokeOnce(
+  host: string,
+  port: number,
+  request: A2aJsonRpcRequest,
+  options: A2aInvokeOptions = {}
+): Promise<A2aInvokeResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `http://${host}:${port}${A2A_PATH}`;
+  const requestTimeoutMs = options.requestTimeoutMs ?? 120_000;
+  const readyTimeoutMs = options.readyTimeoutMs ?? 30_000;
+
+  const body = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: request.method,
+    ...(request.params !== undefined && { params: request.params }),
+  };
+
+  const message = await postWithReadyRetry(fetchImpl, url, body, requestTimeoutMs, readyTimeoutMs);
+  const ok = !(message !== null && typeof message === 'object' && 'error' in message);
+  return { ok, raw: JSON.stringify(message ?? null, null, 2) };
+}
+
+/**
+ * POST a JSON-RPC message, retrying transient connect failures + reachable-
+ * but-non-2xx responses until the container is up. The retry window is
+ * `readyTimeoutMs`; the per-attempt abort during the readiness window is 5s
+ * (so a stuck POST doesn't blow the whole window). Once the window expires
+ * any further failure is fatal.
+ *
+ * On the first successful 2xx response the body is parsed and returned. A
+ * proper request-level timeout (`requestTimeoutMs`) would only matter once
+ * one good POST has completed; in v1 we only have a single round-trip per
+ * invocation, so the 5s readiness abort is sufficient — the post-ready
+ * timeout is unused here but kept for symmetry with the MCP client API.
+ */
+async function postWithReadyRetry(
+  fetchImpl: typeof fetch,
+  url: string,
+  body: { jsonrpc: string; id: number; method: string; params?: unknown },
+  requestTimeoutMs: number,
+  readyTimeoutMs: number
+): Promise<unknown> {
+  const deadline = Date.now() + readyTimeoutMs;
+  let lastDetail = '';
+
+  while (Date.now() < deadline) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), Math.min(5_000, requestTimeoutMs));
+    try {
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      if (response.status >= 200 && response.status < 300) {
+        return text ? safeJsonParse(text) : undefined;
+      }
+      // Reachable-but-non-2xx during the readiness window is treated as
+      // "framework still wiring its / route" (mirroring MCP); after the
+      // window it bubbles out as the final error below.
+      lastDetail = `A2A POST returned HTTP ${response.status}`;
+    } catch (err) {
+      if (!isTransientNetworkError(err)) throw err;
+      lastDetail = err instanceof Error ? err.message : String(err);
+    } finally {
+      clearTimeout(timer);
+    }
+    await delay(150);
+  }
+
+  throw new Error(
+    `A2A server did not become ready on ${url} within ${readyTimeoutMs}ms` +
+      `${lastDetail ? `: ${lastDetail}` : ''}. ` +
+      `The container may have exited early or may not serve POST ${A2A_PATH} — check 'docker logs'.`
+  );
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'AbortError') return true;
+  if (err.name === 'TypeError' && err.message === 'fetch failed') return true;
+  const cause = (err as { cause?: { code?: string } }).cause;
+  if (cause?.code === 'ECONNRESET') return true;
+  if (cause?.code === 'ECONNREFUSED') return true;
+  if (cause?.code === 'UND_ERR_SOCKET') return true;
+  return false;
+}

--- a/src/local/agentcore-a2a-client.ts
+++ b/src/local/agentcore-a2a-client.ts
@@ -41,7 +41,11 @@ export interface A2aInvokeOptions {
    * signal). Default 30s.
    */
   readyTimeoutMs?: number;
-  /** Per-request abort timeout once the server is reachable. Default 120s. */
+  /**
+   * Per-attempt abort timeout. Bounds each POST (including the user's real
+   * agent call), so a legitimately slow first response isn't misreported as
+   * "not ready". Default 120s.
+   */
   requestTimeoutMs?: number;
   /** Injected `fetch` for tests. Defaults to the global. */
   fetchImpl?: typeof fetch;
@@ -78,15 +82,13 @@ export async function a2aInvokeOnce(
 /**
  * POST a JSON-RPC message, retrying transient connect failures + reachable-
  * but-non-2xx responses until the container is up. The retry window is
- * `readyTimeoutMs`; the per-attempt abort during the readiness window is 5s
- * (so a stuck POST doesn't blow the whole window). Once the window expires
- * any further failure is fatal.
- *
- * On the first successful 2xx response the body is parsed and returned. A
- * proper request-level timeout (`requestTimeoutMs`) would only matter once
- * one good POST has completed; in v1 we only have a single round-trip per
- * invocation, so the 5s readiness abort is sufficient — the post-ready
- * timeout is unused here but kept for symmetry with the MCP client API.
+ * `readyTimeoutMs`; each attempt is bounded by `requestTimeoutMs` (the
+ * per-attempt abort), which protects the user's real (potentially slow)
+ * agent call without misreporting it as "not ready". Connect failures
+ * (ECONNREFUSED) propagate immediately regardless of the abort timer, so
+ * the retry cadence keeps working during boot. The loop exits once a 2xx
+ * arrives (returning the parsed body) or once `readyTimeoutMs` elapses
+ * (throwing the final "did not become ready" error below).
  */
 async function postWithReadyRetry(
   fetchImpl: typeof fetch,
@@ -100,7 +102,7 @@ async function postWithReadyRetry(
 
   while (Date.now() < deadline) {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), Math.min(5_000, requestTimeoutMs));
+    const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
     try {
       const response = await fetchImpl(url, {
         method: 'POST',
@@ -113,11 +115,21 @@ async function postWithReadyRetry(
       });
       const text = await response.text();
       if (response.status >= 200 && response.status < 300) {
-        return text ? safeJsonParse(text) : undefined;
+        if (!text) return undefined;
+        const parsed = safeJsonParse(text);
+        if (parsed === undefined) {
+          // 2xx but the body isn't valid JSON — a framing error from the
+          // agent, not a transient warmup state. Fail fast with the bytes
+          // we saw rather than silently reporting ok=true / raw="null".
+          throw new Error(
+            `A2A POST at ${url} returned HTTP ${response.status} with a non-JSON body: ${text.slice(0, 200)}`
+          );
+        }
+        return parsed;
       }
       // Reachable-but-non-2xx during the readiness window is treated as
-      // "framework still wiring its / route" (mirroring MCP); after the
-      // window it bubbles out as the final error below.
+      // "framework still wiring its / route" (mirroring MCP); the loop
+      // bails out below with this detail when the window expires.
       lastDetail = `A2A POST returned HTTP ${response.status}`;
     } catch (err) {
       if (!isTransientNetworkError(err)) throw err;

--- a/src/local/agentcore-resolver.ts
+++ b/src/local/agentcore-resolver.ts
@@ -23,23 +23,32 @@ export const AGENTCORE_RUNTIME_TYPE = 'AWS::BedrockAgentCore::Runtime';
  *
  * - `HTTP` — the agent contract (`POST /invocations` + `GET /ping` on 8080).
  * - `MCP` — Model Context Protocol over Streamable HTTP (`POST /mcp` on 8000).
- *
- * `A2A` / `AGUI` declare yet other wire contracts and are not served yet.
+ * - `A2A` — Agent2Agent JSON-RPC 2.0 over HTTP (`POST /` on 9000).
+ * - `AGUI` — Agent-User Interaction event streams (SSE on `POST /invocations`,
+ *   WebSocket on `/ws`); reuses the HTTP path's container port (8080) and its
+ *   incremental SSE / WS streaming.
  */
 export const AGENTCORE_HTTP_PROTOCOL = 'HTTP';
 export const AGENTCORE_MCP_PROTOCOL = 'MCP';
+export const AGENTCORE_A2A_PROTOCOL = 'A2A';
+export const AGENTCORE_AGUI_PROTOCOL = 'AGUI';
 
 /** Protocols this CLI can run a container for. */
-const SUPPORTED_AGENTCORE_PROTOCOLS = [AGENTCORE_HTTP_PROTOCOL, AGENTCORE_MCP_PROTOCOL] as const;
+const SUPPORTED_AGENTCORE_PROTOCOLS = [
+  AGENTCORE_HTTP_PROTOCOL,
+  AGENTCORE_MCP_PROTOCOL,
+  AGENTCORE_A2A_PROTOCOL,
+  AGENTCORE_AGUI_PROTOCOL,
+] as const;
 
 /**
  * Result of resolving a `cdkl invoke-agentcore <target>` argument back to a
  * concrete `AWS::BedrockAgentCore::Runtime` in the synthesized assembly.
  *
  * Covers the CONTAINER artifact and the `CodeConfiguration` managed-runtime
- * artifact (fromCodeAsset AND fromS3) on the HTTP + MCP protocols — the
- * resolver hard-errors on a non-literal `Code.S3.Prefix` and the A2A / AGUI
- * protocols so the command never starts something it can't run.
+ * artifact (fromCodeAsset AND fromS3) on all four protocols — HTTP / MCP /
+ * A2A / AGUI. The resolver hard-errors on a non-literal `Code.S3.Prefix`
+ * so the command never starts something it can't run.
  */
 export interface ResolvedAgentCoreRuntime {
   /** Stack the runtime belongs to. */
@@ -81,7 +90,7 @@ export interface ResolvedAgentCoreRuntime {
    * an intrinsic role falls back to an explicit `--assume-role <arn>`.
    */
   roleArn?: string;
-  /** `HTTP` or `MCP` (validated at resolution time). */
+  /** `HTTP` / `MCP` / `A2A` / `AGUI` (validated at resolution time). */
   protocol: string;
   /**
    * `Properties.AuthorizerConfiguration.CustomJWTAuthorizer` when present
@@ -479,9 +488,9 @@ function extractCustomClaims(raw: unknown, logicalId: string): AgentCoreCustomCl
 }
 
 /**
- * Validate `ProtocolConfiguration`. Serves `HTTP` (the default when absent)
- * and `MCP`; `A2A` / `AGUI` speak other wire contracts and hard-error with a
- * pointer to the follow-up.
+ * Validate `ProtocolConfiguration`. Serves the four AgentCore protocols
+ * (HTTP / MCP / A2A / AGUI); an unrecognized value hard-errors with the
+ * supported list so the command never starts something it can't run.
  */
 function extractProtocol(value: unknown, logicalId: string, stackName: string): string {
   if (value === undefined || value === null) return AGENTCORE_HTTP_PROTOCOL;
@@ -494,8 +503,7 @@ function extractProtocol(value: unknown, logicalId: string, stackName: string): 
   if (!(SUPPORTED_AGENTCORE_PROTOCOLS as readonly string[]).includes(value)) {
     throw new AgentCoreResolutionError(
       `AgentCore Runtime '${logicalId}' in ${stackName} uses the ${value} protocol. ` +
-        `${getEmbedConfig().cliName} invoke-agentcore supports the ${SUPPORTED_AGENTCORE_PROTOCOLS.join(' / ')} protocols ` +
-        `(A2A / AGUI speak different wire contracts and are not served yet).`
+        `${getEmbedConfig().cliName} invoke-agentcore supports the ${SUPPORTED_AGENTCORE_PROTOCOLS.join(' / ')} protocols.`
     );
   }
   return value;

--- a/tests/integration/local-invoke-agentcore/.gitignore
+++ b/tests/integration/local-invoke-agentcore/.gitignore
@@ -4,9 +4,16 @@ pnpm-lock.yaml
 
 # Override the parent integ .gitignore so the agent containers' source
 # files are tracked. Each Dockerfile builds against its /app/server.js inside
-# a plain node base image: agent/ serves the AgentCore HTTP contract on 8080,
-# mcp-agent/ serves the MCP Streamable-HTTP contract on 8000.
+# a plain node base image:
+#   agent/      — AgentCore HTTP contract on 8080
+#   mcp-agent/  — MCP Streamable-HTTP contract on 8000
+#   a2a-agent/  — Agent2Agent JSON-RPC 2.0 on 9000
+#   agui-agent/ — AG-UI SSE on 8080
 !agent/*.js
 !agent/Dockerfile
 !mcp-agent/*.js
 !mcp-agent/Dockerfile
+!a2a-agent/*.js
+!a2a-agent/Dockerfile
+!agui-agent/*.js
+!agui-agent/Dockerfile

--- a/tests/integration/local-invoke-agentcore/a2a-agent/Dockerfile
+++ b/tests/integration/local-invoke-agentcore/a2a-agent/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/docker/library/node:20-slim
+
+WORKDIR /app
+COPY server.js /app/server.js
+
+EXPOSE 9000
+CMD ["node", "/app/server.js"]

--- a/tests/integration/local-invoke-agentcore/a2a-agent/server.js
+++ b/tests/integration/local-invoke-agentcore/a2a-agent/server.js
@@ -1,0 +1,60 @@
+// Minimal Bedrock AgentCore Runtime A2A-protocol agent for the cdkl
+// invoke-agentcore integ test. Serves the Agent2Agent JSON-RPC 2.0 contract on
+// 0.0.0.0:9000 at POST / (the root):
+//   agent/getCard       -> 200 a minimal agent card
+//   tasks/send          -> 200 echoes the task id + message back
+//   anything else       -> a JSON-RPC -32601 "Method not found" error
+// Startup logs go to stderr so the host's stdout carries only the cdkl result.
+const http = require('node:http');
+
+function sendJsonRpc(res, id, payload) {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ jsonrpc: '2.0', id, ...payload }));
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method !== 'POST' || req.url !== '/') {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+    return;
+  }
+  let body = '';
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    let msg;
+    try {
+      msg = JSON.parse(body || '{}');
+    } catch {
+      msg = {};
+    }
+    const { id, method, params } = msg;
+
+    if (method === 'agent/getCard') {
+      sendJsonRpc(res, id, {
+        result: {
+          name: 'fixture-a2a-agent',
+          description: 'integ-test A2A agent',
+          version: '1.0.0',
+          url: 'http://localhost:9000',
+          capabilities: { streaming: false },
+        },
+      });
+      return;
+    }
+    if (method === 'tasks/send') {
+      const taskId = (params && params.id) || 'unknown';
+      const message = (params && params.message) || null;
+      sendJsonRpc(res, id, {
+        result: { id: taskId, status: { state: 'completed' }, echoedMessage: message },
+      });
+      return;
+    }
+    sendJsonRpc(res, id, { error: { code: -32601, message: 'Method not found' } });
+  });
+});
+
+server.listen(9000, '0.0.0.0', () => {
+  console.error('a2a fixture listening on 0.0.0.0:9000');
+});

--- a/tests/integration/local-invoke-agentcore/agui-agent/Dockerfile
+++ b/tests/integration/local-invoke-agentcore/agui-agent/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/docker/library/node:20-slim
+
+WORKDIR /app
+COPY server.js /app/server.js
+
+EXPOSE 8080
+CMD ["node", "/app/server.js"]

--- a/tests/integration/local-invoke-agentcore/agui-agent/server.js
+++ b/tests/integration/local-invoke-agentcore/agui-agent/server.js
@@ -32,6 +32,9 @@ function streamAguiEvents(res) {
     clearInterval(timer);
     res.end();
   }, 50);
+  // Host-side abort during the stream: stop firing into a closed socket.
+  res.on('close', () => clearInterval(timer));
+  res.on('error', () => clearInterval(timer));
 }
 
 const server = http.createServer((req, res) => {

--- a/tests/integration/local-invoke-agentcore/agui-agent/server.js
+++ b/tests/integration/local-invoke-agentcore/agui-agent/server.js
@@ -1,0 +1,59 @@
+// Minimal Bedrock AgentCore Runtime AGUI-protocol agent for the cdkl
+// invoke-agentcore integ test. Serves the AG-UI HTTP-compatible contract on
+// 0.0.0.0:8080:
+//   GET  /ping        -> 200 {"status":"Healthy"} so the existing HTTP
+//                        readiness wait succeeds (AG-UI builds on the
+//                        same 8080 contract as HTTP-protocol agents)
+//   POST /invocations -> 200 text/event-stream of three AG-UI events
+//                        (RUN_STARTED, MESSAGE_CONTENT, RUN_FINISHED),
+//                        exercising the HTTP path's incremental SSE
+//                        streaming for the AGUI protocol routing.
+// Startup logs go to stderr.
+const http = require('node:http');
+
+function streamAguiEvents(res) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  const events = [
+    { type: 'RUN_STARTED', threadId: 't1', runId: 'r1' },
+    { type: 'MESSAGE_CONTENT', messageId: 'm1', content: 'hello-from-agui' },
+    { type: 'RUN_FINISHED', threadId: 't1', runId: 'r1' },
+  ];
+  let i = 0;
+  const timer = setInterval(() => {
+    if (i < events.length) {
+      res.write(`data: ${JSON.stringify(events[i])}\n\n`);
+      i += 1;
+      return;
+    }
+    clearInterval(timer);
+    res.end();
+  }, 50);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/ping') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({ status: 'Healthy', time_of_last_update: Math.floor(Date.now() / 1000) })
+    );
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/invocations') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => streamAguiEvents(res));
+    return;
+  }
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'not found' }));
+});
+
+server.listen(8080, '0.0.0.0', () => {
+  console.error('agui fixture listening on 0.0.0.0:8080');
+});

--- a/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
+++ b/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
@@ -106,5 +106,29 @@ export class LocalInvokeAgentCoreStack extends cdk.Stack {
       }),
       environmentVariables: { GREETING: 'hello-from-code' },
     });
+
+    // An A2A-protocol runtime (ProtocolConfiguration = A2A). The container
+    // serves the Agent2Agent JSON-RPC 2.0 contract on 9000 at POST / (no
+    // /ping). `cdkl invoke-agentcore` POSTs one JSON-RPC request — defaults
+    // to `agent/getCard` (the agent's discovery card), or the method/params
+    // from --event.
+    new Runtime(this, 'A2aAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromAsset(path.join(__dirname, '../a2a-agent'), {
+        platform: Platform.LINUX_ARM64,
+      }),
+      protocolConfiguration: ProtocolType.A2A,
+    });
+
+    // An AGUI-protocol runtime (ProtocolConfiguration = AGUI). The container
+    // serves the AG-UI HTTP-compatible contract on 8080 (GET /ping + POST
+    // /invocations); /invocations returns a text/event-stream of AG-UI events
+    // (RUN_STARTED, MESSAGE_CONTENT, RUN_FINISHED). The HTTP-path SSE handler
+    // streams these incrementally — AGUI reuses the HTTP routing transparently.
+    new Runtime(this, 'AguiAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromAsset(path.join(__dirname, '../agui-agent'), {
+        platform: Platform.LINUX_ARM64,
+      }),
+      protocolConfiguration: ProtocolType.AGUI,
+    });
   }
 }

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -37,6 +37,8 @@ PROTECTED="CdkLocalInvokeAgentCoreFixture/ProtectedAgent"
 PROTECTED_CLAIMS="CdkLocalInvokeAgentCoreFixture/ProtectedAgentClaims"
 MCP="CdkLocalInvokeAgentCoreFixture/McpAgent"
 CODE="CdkLocalInvokeAgentCoreFixture/CodeAgent"
+A2A="CdkLocalInvokeAgentCoreFixture/A2aAgent"
+AGUI="CdkLocalInvokeAgentCoreFixture/AguiAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
 CODE_BASE_IMAGE="public.ecr.aws/docker/library/python:3.12-slim"
 
@@ -53,7 +55,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/18] Invoking EchoAgent with default empty event"
+echo "==> [1/20] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -67,7 +69,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/18] Invoking EchoAgent with --event payload"
+echo "==> [2/20] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -79,7 +81,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/18] Invoking EchoAgent with --env-vars override"
+echo "==> [3/20] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -91,7 +93,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/18] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/20] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -102,7 +104,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/18] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/20] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -123,7 +125,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/18] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/20] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -133,7 +135,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/18] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/20] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -146,7 +148,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/18] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/20] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -166,7 +168,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
-echo "==> [9/18] McpAgent (no --event) runs the handshake + tools/list"
+echo "==> [9/20] McpAgent (no --event) runs the handshake + tools/list"
 RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
@@ -175,7 +177,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 }
 
 # Test 10 — an MCP tools/call via --event returns the tool result.
-echo "==> [10/18] McpAgent with --event runs tools/call"
+echo "==> [10/20] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
@@ -189,7 +191,7 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 # Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
 # source (no Dockerfile): cdkl builds it from source (pip install + run the
 # entrypoint) and the entrypoint self-serves the 8080 HTTP contract.
-echo "==> [11/18] CodeAgent (fromCodeAsset) builds from source + responds"
+echo "==> [11/20] CodeAgent (fromCodeAsset) builds from source + responds"
 RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_11}"
 echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
@@ -202,7 +204,7 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 }
 
 # Test 12 — a --event payload echoes through the from-source agent.
-echo "==> [12/18] CodeAgent with --event echoes the payload"
+echo "==> [12/20] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
@@ -217,7 +219,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # the first frame and streams every received frame to stdout until the agent
 # closes. The fixture agent replies with one JSON frame (echo + session id +
 # Authorization + GREETING) then a second text frame, then closes.
-echo "==> [13/18] EchoAgent over the /ws WebSocket (--ws)"
+echo "==> [13/20] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
@@ -242,7 +244,7 @@ echo "${RESULT_13}" | grep -q 'ws-frame-2' || {
 
 # Test 14 — --ws is HTTP-only: against an MCP runtime it warns and is ignored,
 # falling through to the normal MCP path (tools/list still returns).
-echo "==> [14/18] McpAgent with --ws warns + still runs the MCP path"
+echo "==> [14/20] McpAgent with --ws warns + still runs the MCP path"
 set +e
 OUT_14=$(${CDKL} invoke-agentcore "${MCP}" --ws 2>/tmp/cdkl-ws-mcp-stderr; cat /tmp/cdkl-ws-mcp-stderr >&2)
 RC_14=$?
@@ -258,7 +260,7 @@ echo "${OUT_14}" | grep -q '"name": "add_numbers"' || {
   echo "FAIL: expected MCP --ws to fall through to tools/list, got: ${OUT_14}"
   exit 1
 }
-echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP protocol' || {
+echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP / AGUI protocols' || {
   echo "FAIL: expected an MCP --ws ignored warning on stderr, got: ${ERR_14}"
   exit 1
 }
@@ -269,7 +271,7 @@ echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP protocol' || {
 # invoke succeeds even with a placeholder bearer token. (The verifier's actual
 # scope / claim checks are covered by the unit tests, which sign real RS256
 # tokens against mock JWKS.)
-echo "==> [15/18] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
+echo "==> [15/20] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
 RESULT_15=$(${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_15}"
 echo "${RESULT_15}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -289,7 +291,7 @@ echo "${RESULT_15}" | grep -q '"authorization":"Bearer h.p.s"' || {
 # agent never validates the signature against AWS, it just echoes the header.
 # A second --sigv4 + --bearer-token sub-check confirms the mutually-exclusive
 # gate rejects pre-container.
-echo "==> [16/18] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
+echo "==> [16/20] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
 RESULT_16=$(AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
   AWS_REGION=us-east-1 \
@@ -304,7 +306,7 @@ echo "${RESULT_16}" | grep -q '/us-east-1/bedrock-agentcore/aws4_request' || {
   exit 1
 }
 
-echo "==> [16/18] --sigv4 + --bearer-token together rejected (mutually exclusive)"
+echo "==> [16/20] --sigv4 + --bearer-token together rejected (mutually exclusive)"
 set +e
 OUT_16B=$(${CDKL} invoke-agentcore "${TARGET}" --sigv4 --bearer-token "h.p.s" 2>&1)
 RC_16B=$?
@@ -324,7 +326,7 @@ echo "${OUT_16B}" | grep -q 'mutually exclusive' || {
 # responds (the flag is parsed + threaded into the client call, not silently
 # ignored). The negative sub-check confirms the parser rejects a non-positive
 # value pre-container.
-echo "==> [17/18] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
+echo "==> [17/20] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
 RESULT_17=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 60000 2>/dev/null | tail -1)
 echo "    response: ${RESULT_17}"
 echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -332,7 +334,7 @@ echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
   exit 1
 }
 
-echo "==> [17/18] --timeout 0 rejected by the parser (positive integer required)"
+echo "==> [17/20] --timeout 0 rejected by the parser (positive integer required)"
 set +e
 OUT_17B=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 0 2>&1)
 RC_17B=$?
@@ -346,11 +348,59 @@ echo "${OUT_17B}" | grep -q 'positive integer' || {
   exit 1
 }
 
+# Test 19 — A2A protocol runtime: the container serves the Agent2Agent
+# JSON-RPC 2.0 contract at POST / on 9000. With no --event, `cdkl
+# invoke-agentcore` defaults to `agent/getCard` (the agent discovery card).
+echo "==> [19/20] A2aAgent (no --event) runs the JSON-RPC agent/getCard request"
+RESULT_19=$(${CDKL} invoke-agentcore "${A2A}" 2>/dev/null)
+echo "    response: ${RESULT_19}"
+echo "${RESULT_19}" | grep -q '"name": "fixture-a2a-agent"' || {
+  echo "FAIL: expected the A2A agent card with name fixture-a2a-agent, got: ${RESULT_19}"
+  exit 1
+}
+
+# Test 19 — A2A with --event runs the tasks/send method.
+echo "==> [19/20] A2aAgent with --event runs tasks/send"
+A2A_EVENT=$(mktemp -t cdkl-a2a-event-XXXX.json)
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${A2A_EVENT}"' EXIT
+echo '{"method":"tasks/send","params":{"id":"task-1","message":{"text":"hello a2a"}}}' > "${A2A_EVENT}"
+RESULT_19B=$(${CDKL} invoke-agentcore "${A2A}" --event "${A2A_EVENT}" 2>/dev/null)
+echo "    response: ${RESULT_19B}"
+echo "${RESULT_19B}" | grep -q '"id": "task-1"' || {
+  echo "FAIL: expected tasks/send result echoing id=task-1, got: ${RESULT_19B}"
+  exit 1
+}
+echo "${RESULT_19B}" | grep -q '"state": "completed"' || {
+  echo "FAIL: expected tasks/send to report completed state, got: ${RESULT_19B}"
+  exit 1
+}
+
+# Test 20 — AGUI protocol runtime: the container serves the AG-UI
+# HTTP-compatible contract (GET /ping + POST /invocations text/event-stream of
+# AG-UI events). `cdkl invoke-agentcore` routes through the existing HTTP path
+# and streams each event line to stdout. The agent emits three events in order
+# (RUN_STARTED, MESSAGE_CONTENT, RUN_FINISHED).
+echo "==> [20/20] AguiAgent SSE event stream surfaces RUN_STARTED + MESSAGE_CONTENT + RUN_FINISHED"
+RESULT_20=$(${CDKL} invoke-agentcore "${AGUI}" 2>/dev/null)
+echo "    response (head): $(echo "${RESULT_20}" | head -c 300)..."
+echo "${RESULT_20}" | grep -q '"type":"RUN_STARTED"' || {
+  echo "FAIL: expected RUN_STARTED event in AGUI SSE stream, got: ${RESULT_20}"
+  exit 1
+}
+echo "${RESULT_20}" | grep -q '"content":"hello-from-agui"' || {
+  echo "FAIL: expected MESSAGE_CONTENT event with hello-from-agui in AGUI SSE stream, got: ${RESULT_20}"
+  exit 1
+}
+echo "${RESULT_20}" | grep -q '"type":"RUN_FINISHED"' || {
+  echo "FAIL: expected RUN_FINISHED event in AGUI SSE stream, got: ${RESULT_20}"
+  exit 1
+}
+
 # Test 18 — `--ws-interactive` REPL mode: the initial --event opens loop mode
 # in the EchoAgent (it stays open + echoes each subsequent text frame), then
 # two stdin lines are sent as follow-up frames. The agent echoes each as
 # `loop-echo:<line>`, and the client closes the WS when stdin EOFs.
-echo "==> [18/18] EchoAgent --ws --ws-interactive sends two stdin lines as follow-up WS frames"
+echo "==> [18/20] EchoAgent --ws --ws-interactive sends two stdin lines as follow-up WS frames"
 LOOP_EVENT_FILE=$(mktemp -t cdkl-ws-loop-event-XXXX.json)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}"' EXIT
 echo '{"loop":true}' > "${LOOP_EVENT_FILE}"
@@ -372,4 +422,4 @@ echo "${RESULT_18}" | grep -q 'loop-echo:line-B' || {
   exit 1
 }
 echo ""
-echo "==> All 18 local-invoke-agentcore tests passed"
+echo "==> All 20 local-invoke-agentcore tests passed"

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -115,6 +115,8 @@ const {
   resolveFromS3BucketIntrinsic,
   buildSigV4HeadersIfRequested,
   parseTimeoutMs,
+  buildA2aRequest,
+  emitA2aResult,
 } = await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -510,6 +512,63 @@ describe('emitMcpResult — exit codes', () => {
 
   it('sets exit code 1 (but still prints) on a JSON-RPC error', () => {
     emitMcpResult({ ok: false, raw: '{"error":{"message":"nope"}}' });
+    expect(writeSpy).toHaveBeenCalledWith('{"error":{"message":"nope"}}\n');
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe('buildA2aRequest', () => {
+  it('defaults to agent/getCard when no --event was given (empty object)', () => {
+    expect(buildA2aRequest({})).toEqual({ method: 'agent/getCard', params: {} });
+  });
+
+  it('defaults to agent/getCard for an absent event (undefined / null)', () => {
+    expect(buildA2aRequest(undefined)).toEqual({ method: 'agent/getCard', params: {} });
+    expect(buildA2aRequest(null)).toEqual({ method: 'agent/getCard', params: {} });
+  });
+
+  it('passes a method + params through verbatim', () => {
+    expect(
+      buildA2aRequest({ method: 'tasks/send', params: { id: 't1', message: { text: 'hi' } } })
+    ).toEqual({ method: 'tasks/send', params: { id: 't1', message: { text: 'hi' } } });
+  });
+
+  it('omits params when the event has only a method', () => {
+    expect(buildA2aRequest({ method: 'agent/getCard' })).toEqual({ method: 'agent/getCard' });
+  });
+
+  it('rejects a non-object event', () => {
+    expect(() => buildA2aRequest('plain')).toThrow(/JSON object/);
+    expect(() => buildA2aRequest([1, 2])).toThrow(/JSON object/);
+  });
+
+  it('rejects an object that has keys but no string method', () => {
+    expect(() => buildA2aRequest({ params: {} })).toThrow(/string "method"/);
+  });
+});
+
+describe('emitA2aResult — exit codes', () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+  const savedExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    process.exitCode = savedExitCode;
+  });
+
+  it('prints the JSON-RPC response and leaves exit code unset when ok', () => {
+    emitA2aResult({ ok: true, raw: '{"result":{"name":"my-agent"}}' });
+    expect(writeSpy).toHaveBeenCalledWith('{"result":{"name":"my-agent"}}\n');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('sets exit code 1 (but still prints) on a JSON-RPC error', () => {
+    emitA2aResult({ ok: false, raw: '{"error":{"message":"nope"}}' });
     expect(writeSpy).toHaveBeenCalledWith('{"error":{"message":"nope"}}\n');
     expect(process.exitCode).toBe(1);
   });

--- a/tests/unit/local/agentcore-a2a-client.test.ts
+++ b/tests/unit/local/agentcore-a2a-client.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import {
+  a2aInvokeOnce,
+  A2A_CONTAINER_PORT,
+  A2A_PATH,
+} from '../../../src/local/agentcore-a2a-client.js';
+
+describe('a2aInvokeOnce', () => {
+  it('POSTs the JSON-RPC request to / and returns the parsed JSON response', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(String(input)).toBe(`http://127.0.0.1:${A2A_CONTAINER_PORT}${A2A_PATH}`);
+      expect(init?.method).toBe('POST');
+      const headers = init?.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBe('application/json');
+      const sent = JSON.parse(String(init?.body));
+      expect(sent.jsonrpc).toBe('2.0');
+      expect(sent.method).toBe('agent/getCard');
+      return new Response(
+        JSON.stringify({ jsonrpc: '2.0', id: 1, result: { name: 'my-agent', version: '1' } }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    });
+    const result = await a2aInvokeOnce(
+      '127.0.0.1',
+      A2A_CONTAINER_PORT,
+      { method: 'agent/getCard' },
+      { fetchImpl }
+    );
+    expect(result.ok).toBe(true);
+    expect(result.raw).toContain('"name": "my-agent"');
+  });
+
+  it('reports ok=false when the response carries a top-level JSON-RPC error', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: -32601, message: 'method not found' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    const result = await a2aInvokeOnce(
+      '127.0.0.1',
+      A2A_CONTAINER_PORT,
+      { method: 'bogus' },
+      { fetchImpl }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.raw).toContain('"method not found"');
+  });
+
+  it('retries transient TypeError "fetch failed" during the readiness window', async () => {
+    let attempt = 0;
+    const fetchImpl = vi.fn(async () => {
+      attempt += 1;
+      if (attempt < 2) {
+        const err = new TypeError('fetch failed');
+        (err as { cause?: { code?: string } }).cause = { code: 'ECONNREFUSED' };
+        throw err;
+      }
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'ok' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const result = await a2aInvokeOnce(
+      '127.0.0.1',
+      A2A_CONTAINER_PORT,
+      { method: 'agent/getCard' },
+      { fetchImpl, readyTimeoutMs: 5_000 }
+    );
+    expect(result.ok).toBe(true);
+    expect(attempt).toBeGreaterThanOrEqual(2);
+  });
+
+  it('throws with a clear "did not become ready" message when the readiness window expires', async () => {
+    const fetchImpl = vi.fn(async () => {
+      const err = new TypeError('fetch failed');
+      (err as { cause?: { code?: string } }).cause = { code: 'ECONNREFUSED' };
+      throw err;
+    });
+    await expect(
+      a2aInvokeOnce(
+        '127.0.0.1',
+        A2A_CONTAINER_PORT,
+        { method: 'agent/getCard' },
+        { fetchImpl, readyTimeoutMs: 200 }
+      )
+    ).rejects.toThrow(/did not become ready/);
+  });
+
+  it('retries while the server returns 5xx during the readiness window', async () => {
+    let attempt = 0;
+    const fetchImpl = vi.fn(async () => {
+      attempt += 1;
+      if (attempt < 2) {
+        return new Response('starting', { status: 503 });
+      }
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'ready' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const result = await a2aInvokeOnce(
+      '127.0.0.1',
+      A2A_CONTAINER_PORT,
+      { method: 'agent/getCard' },
+      { fetchImpl, readyTimeoutMs: 5_000 }
+    );
+    expect(result.ok).toBe(true);
+    expect(attempt).toBeGreaterThanOrEqual(2);
+  });
+
+  it('omits params from the JSON-RPC body when not supplied', async () => {
+    let sent: { params?: unknown } = {};
+    const fetchImpl = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      sent = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    await a2aInvokeOnce(
+      '127.0.0.1',
+      A2A_CONTAINER_PORT,
+      { method: 'agent/getCard' },
+      { fetchImpl }
+    );
+    expect('params' in sent).toBe(false);
+  });
+});

--- a/tests/unit/local/agentcore-a2a-client.test.ts
+++ b/tests/unit/local/agentcore-a2a-client.test.ts
@@ -6,12 +6,13 @@ import {
 } from '../../../src/local/agentcore-a2a-client.js';
 
 describe('a2aInvokeOnce', () => {
-  it('POSTs the JSON-RPC request to / and returns the parsed JSON response', async () => {
+  it('POSTs the JSON-RPC request to / with the right Accept + Content-Type headers and returns the parsed JSON response', async () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       expect(String(input)).toBe(`http://127.0.0.1:${A2A_CONTAINER_PORT}${A2A_PATH}`);
       expect(init?.method).toBe('POST');
       const headers = init?.headers as Record<string, string>;
       expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['Accept']).toBe('application/json');
       const sent = JSON.parse(String(init?.body));
       expect(sent.jsonrpc).toBe('2.0');
       expect(sent.method).toBe('agent/getCard');
@@ -111,6 +112,37 @@ describe('a2aInvokeOnce', () => {
     );
     expect(result.ok).toBe(true);
     expect(attempt).toBeGreaterThanOrEqual(2);
+  });
+
+  it('throws a clear framing error when the server returns 200 with a non-JSON body', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response('not-json-payload', { status: 200, headers: { 'content-type': 'text/plain' } })
+    );
+    await expect(
+      a2aInvokeOnce(
+        '127.0.0.1',
+        A2A_CONTAINER_PORT,
+        { method: 'agent/getCard' },
+        { fetchImpl }
+      )
+    ).rejects.toThrow(/non-JSON body: not-json-payload/);
+  });
+
+  it('rethrows a non-transient fetch error immediately instead of retrying', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new SyntaxError('unexpected token');
+    });
+    await expect(
+      a2aInvokeOnce(
+        '127.0.0.1',
+        A2A_CONTAINER_PORT,
+        { method: 'agent/getCard' },
+        { fetchImpl, readyTimeoutMs: 5_000 }
+      )
+    ).rejects.toThrow(/unexpected token/);
+    // The non-transient error path bails out immediately, so fetch should
+    // be called exactly once (not retried).
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('omits params from the JSON-RPC body when not supplied', async () => {

--- a/tests/unit/local/agentcore-resolver.test.ts
+++ b/tests/unit/local/agentcore-resolver.test.ts
@@ -436,21 +436,27 @@ describe('resolveAgentCoreTarget — CodeConfiguration (managed runtime)', () =>
   });
 });
 
-describe('resolveAgentCoreTarget — out-of-scope artifacts', () => {
-
-  it('rejects the A2A protocol with a not-served-yet error', () => {
+describe('resolveAgentCoreTarget — A2A + AGUI protocols', () => {
+  it('resolves an A2A-protocol runtime', () => {
     const stack = buildStack('App', {
       ChatAgent: containerRuntime({ ProtocolConfiguration: 'A2A' }),
     });
-    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/A2A protocol/);
-    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/not served yet/);
+    expect(resolveAgentCoreTarget('ChatAgent', [stack]).protocol).toBe('A2A');
   });
 
-  it('rejects the AGUI protocol', () => {
+  it('resolves an AGUI-protocol runtime', () => {
     const stack = buildStack('App', {
       ChatAgent: containerRuntime({ ProtocolConfiguration: 'AGUI' }),
     });
-    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/AGUI protocol/);
+    expect(resolveAgentCoreTarget('ChatAgent', [stack]).protocol).toBe('AGUI');
+  });
+
+  it('rejects an unknown protocol with a supported-protocols list', () => {
+    const stack = buildStack('App', {
+      ChatAgent: containerRuntime({ ProtocolConfiguration: 'CUSTOM' }),
+    });
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/CUSTOM protocol/);
+    expect(() => resolveAgentCoreTarget('App:ChatAgent', [stack])).toThrow(/HTTP \/ MCP \/ A2A \/ AGUI/);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the last remaining AgentCore protocol gap. `cdkl invoke-agentcore` now serves all four `ProtocolConfiguration` values (HTTP / MCP / A2A / AGUI).

- **A2A** — new minimal JSON-RPC 2.0 client (`agentcore-a2a-client.ts`) POSTing to `/` on port 9000. The connect-failure / non-2xx loop is retried during a 30s readiness window, mirroring the MCP client's `initialize` retry — there is no `/ping` for A2A either. Each attempt is bounded by `requestTimeoutMs` (default 120s) so a slow legitimate first response isn't misreported as "not ready". Default method is `agent/getCard` (the agent's discovery card); `--event` supplies an alternative method + params (e.g. `tasks/send`).
- **AGUI** — routes through the existing HTTP path. The AG-UI wire is SSE on `POST /invocations` + WebSocket on `/ws`, both on port 8080 — the same container shape HTTP-protocol agents already use. The existing HTTP client streams the AG-UI typed event envelope to stdout transparently (pipe through `jq -c .` for pretty-printing); `--ws` / `--ws-interactive` / `--bearer-token` / `--no-verify-auth` / `--sigv4` all carry over.
- The resolver now accepts A2A + AGUI (previously hard-errored with "not served yet"). The MCP / A2A vanilla-protocol direct-call note is also extended: an inbound JWT / `--bearer-token` is a managed-plane concern not applied to a direct local A2A call (matching the existing MCP behavior).

## Test plan

- [x] 8 new unit tests in `agentcore-a2a-client.test.ts` covering POST shape (Content-Type + Accept), ok / not-ok JSON-RPC responses, transient ECONNREFUSED retry, readiness-window expiration, 5xx-during-warmup retry, `params` omission, non-JSON 200 framing error, and non-transient error rethrow without retry.
- [x] Resolver tests: removed the "not served yet" rejection tests; added 3 new tests (A2A accepted, AGUI accepted, unknown protocol still rejected with the supported-list hint).
- [x] Command-helper tests: added `buildA2aRequest` (6 tests) + `emitA2aResult` (2 tests) mirroring the MCP shape.
- [x] `vp run check` + `vp test run` (1604/1604 pass) + `vp run build`.
- [x] Integ scenarios 19 + 20 in `tests/integration/local-invoke-agentcore/verify.sh`. Scenario 19 (A2A): no-arg defaults to `agent/getCard` and returns the agent card; `--event` runs `tasks/send` and the response carries `id=task-1` + `state=completed`. Scenario 20 (AGUI): the SSE stream surfaces `RUN_STARTED` + `MESSAGE_CONTENT` (`hello-from-agui`) + `RUN_FINISHED` events. All 20 scenarios green; 0 docker orphans.
- [x] Updated `docs/cli-reference.md` with new "A2A protocol" + "AGUI protocol" sections and the `--timeout` table now lists all four transports.

## Reviewer findings

3-axis review run; addressed inline:

- **Code reviewer Minor 1** — per-attempt abort now `requestTimeoutMs` instead of 5s, so a slow legitimate first response isn't misreported as "not ready". Doc comments updated to match.
- **Code reviewer Minor 2** — a 200 with a non-JSON body now throws a clear "non-JSON body: ..." diagnostic instead of silently reporting `ok=true` / raw `"null"`.
- **Code reviewer Minor 3** — stale comment about "fatal once window expires" rewritten to match the actual loop semantics.
- **Code reviewer Nit 4** — `requestTimeoutMs` is now wired (no longer dead).
- **Code reviewer Nit 5** — AGUI fixture `setInterval` listens for `res.close` / `res.error` so a host-side abort during the stream doesn't fire into a closed socket.
- **Test reviewer Gap 2 + Gap 3 + anti-pattern** — added the missing non-JSON-body + non-transient-rethrow tests; the existing header test now asserts both `Content-Type` and `Accept`.

Accepted as known cost:
- **Test reviewer Gap 4** (AGUI command-layer routing not unit-tested): isolating the routing branches without mocking the full docker / fetch / synth pipeline would be a substantial refactor; integ scenario 20 exercises the binding end-to-end against a real container.
- **Test reviewer Gap 1 + Gap 5** (low-severity: AbortError unit-coverage / JSON-RPC error integ): the unit suite covers `ok=false` shape + exit-code 1 via `emitA2aResult`; the integ adds little incremental confidence.

Closes #140
