### PR TITLE
feat(start-alb): proxy WebSocket Upgrade to ECS forward targets

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,10 +47,16 @@ AWS managed services.
   an `AWSELBAuthSessionCookie-*` pass-through; `--bearer-token <jwt>`
   injects a default token, `--no-verify-auth` disables the guard. The
   full OAuth roundtrip (redirect to the IdP's authorize endpoint +
-  callback + cookie issuance) is NOT reproduced. A `TargetType: lambda`
-  target group is served by invoking the backing Lambda locally (HTTP
-  request -> `requestContext.elb` event -> RIE -> response), so a
-  forward can mix ECS and Lambda targets
+  callback + cookie issuance) is NOT reproduced. **WebSocket Upgrade**
+  is proxied for ECS forward targets — the upgrade request goes through
+  the same listener-rule matching + auth-gate pipeline as a regular
+  HTTP request, then the client's raw TCP socket is bridged to the
+  picked replica with `Upgrade` / `Sec-WebSocket-*` headers preserved
+  (Lambda target groups refuse the upgrade with a 502, mirroring ALB
+  itself). A `TargetType: lambda` target group is served by invoking
+  the backing Lambda locally (HTTP request -> `requestContext.elb`
+  event -> RIE -> response), so a forward can mix ECS and Lambda
+  targets
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
@@ -153,8 +159,10 @@ Gateway).
   replica pool or a Lambda invoke, redirect, or fixed-response — behind
   the ALB listener port; HTTPS branch flips `X-Forwarded-Proto` and the
   redirect `#{protocol}` default to `https`; an `auth` guard on the
-  action gates serving with a 401 + `WWW-Authenticate: Bearer` on deny),
-  etc.
+  action gates serving with a 401 + `WWW-Authenticate: Bearer` on deny;
+  WebSocket `Upgrade` requests run through the same route + auth
+  pipeline, then bridge the raw TCP socket to the picked ECS replica
+  with `Upgrade` / `Sec-WebSocket-*` headers preserved), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cdkl list                                      # every runnable target, grouped 
 
 - **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`. Add **`--watch`** to re-synth and hot-reload on CDK source changes ([details](docs/local-emulation.md#hot-reload---watch)).
 - **`run-task`** / single-replica **`start-service`** publish declared container ports on the host and log `Reach it at 127.0.0.1:<port>` (`--host-port <container>=<host>` remaps; handy for privileged ports on macOS).
-- **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, and `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement) ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
+- **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement), and WebSocket `Upgrade` proxying to ECS targets ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
 - **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, HTTP / SSE / WebSocket / MCP protocols, with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
@@ -80,7 +80,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 | ECS task definitions | `run-task` |
 | ECS services | `start-service` |
 | Cloud Map / Service Connect registry | service discovery between local replicas |
-| ALB-fronted ECS / Lambda services | `start-alb` — HTTP / HTTPS listeners, all six listener-rule conditions, weighted forwards, redirect / fixed-response, mixed ECS + Lambda targets, authenticate-cognito / authenticate-oidc (local Bearer-JWT enforcement) |
+| ALB-fronted ECS / Lambda services | `start-alb` — HTTP / HTTPS listeners, all six listener-rule conditions, weighted forwards, redirect / fixed-response, mixed ECS + Lambda targets, authenticate-cognito / authenticate-oidc (local Bearer-JWT enforcement), WebSocket Upgrade |
 | Bedrock AgentCore Runtime agents | `invoke-agentcore` — container + `fromCodeAsset` / `fromS3` artifacts, HTTP + MCP |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1325,6 +1325,21 @@ strings in the synthesized template — a `Ref` / `Fn::GetAtt` / cross-stack
 intrinsic in any of those fields drops the guard with a warning, and the
 terminal action then serves unguarded.
 
+**WebSocket `Upgrade`** is proxied for ECS forward targets. The inbound
+upgrade request goes through the same `route()` callback as a regular
+HTTP request, so listener rules (path / host / header / method /
+query-string / source-ip) AND auth gates apply identically before the
+upgrade is accepted. After matching, the client's raw TCP socket is
+bridged to the picked replica with `Upgrade` / `Connection: Upgrade` /
+`Sec-WebSocket-*` headers preserved verbatim (RFC 7230 marks `Upgrade`
+as hop-by-hop, but the proxy MUST forward it for the handshake — nginx
+/ haproxy / ALB all do). `X-Forwarded-For` / `X-Forwarded-Proto` /
+`X-Forwarded-Port` are stamped. A Lambda target group answers `502`
+on upgrade (mirrors ALB itself — Lambda TGs do not support WebSocket).
+A `redirect` / `fixed-response` action answers with a regular HTTP/1.1
+response over the raw socket (no upgrade), matching how a browser's WS
+client surfaces such responses.
+
 Out of scope:
 
 - The full OAuth roundtrip (redirect to the IdP's authorize endpoint,
@@ -1333,6 +1348,11 @@ Out of scope:
   does not mint one. To exercise the deployed sign-in flow, hit the
   deployed ALB once and reuse the cookie locally.
 - ALB Mutual TLS (`MutualAuthentication.Mode: verify`) — tracked separately.
+- Sticky sessions (`stickiness.enabled`) — round-robin only.
+- gRPC / HTTP/2 target groups (`ProtocolVersion: GRPC` / `HTTP2`) — the
+  front-door is HTTP/1.1 only.
+- Health-check probes (`HealthCheckPath` / `Matcher`) — the pool is naive
+  and does not gate draining on health.
 
 The local front-door binds the request's `socket.remoteAddress` as the
 source IP, so a `source-ip` CIDR narrower than `127.0.0.0/8` will not match

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -6,6 +6,8 @@ import {
   type ServerResponse,
 } from 'node:http';
 import { createServer as createHttpsServer } from 'node:https';
+import { connect as netConnect, type Socket as NetSocket } from 'node:net';
+import type { Duplex } from 'node:stream';
 import { getLogger } from '../utils/logger.js';
 import type { FrontDoorEndpointPool } from './front-door-pool.js';
 import {
@@ -52,8 +54,19 @@ import {
  * field. HTTP and HTTPS listeners are both served — HTTPS termination uses
  * the {@link StartFrontDoorServerOptions.tls} materials (a user-supplied or
  * auto-generated self-signed cert/key pair) and switches `X-Forwarded-Proto`
- * + redirect `#{protocol}` to `https`. No health-check-gated draining, no
- * sticky sessions, no websocket `Upgrade` proxying.
+ * + redirect `#{protocol}` to `https`.
+ *
+ * **WebSocket Upgrade** is proxied for ECS forward targets: an inbound
+ * `Connection: Upgrade` request goes through the same `route()` callback
+ * (so listener rules + auth gates apply identically), then the client's
+ * raw TCP socket is bridged to a `net.connect`-opened upstream socket on
+ * the picked replica. `Upgrade` / `Sec-WebSocket-*` headers are forwarded
+ * verbatim (per RFC 6455 they are NOT hop-by-hop in the proxy sense), with
+ * `X-Forwarded-*` injection. Lambda target groups answer 502 on upgrade
+ * (mirrors ALB itself — Lambda TGs do not support WebSocket). Redirect /
+ * fixed-response actions answer with a regular HTTP/1.1 response over the
+ * raw socket (no upgrade). No health-check-gated draining; no sticky
+ * sessions.
  */
 
 /**
@@ -256,6 +269,12 @@ export async function startFrontDoorServer(
     : createServer(requestHandler);
   const scheme: 'http' | 'https' = opts.tls ? 'https' : 'http';
   server.on('connection', (socket) => socket.setNoDelay(true));
+  server.on('upgrade', (req, clientSocket, head) => {
+    handleUpgrade(req, clientSocket, head, opts).catch((err) => {
+      logger.debug(`front-door upgrade error: ${err instanceof Error ? err.message : String(err)}`);
+      if (!clientSocket.destroyed) clientSocket.destroy();
+    });
+  });
 
   const boundPort = await new Promise<number>((resolve, reject) => {
     server.once('error', reject);
@@ -838,3 +857,303 @@ function writeError(res: ServerResponse, statusCode: number, message: string): v
   res.writeHead(statusCode, { 'content-type': 'text/plain; charset=utf-8' });
   res.end(`${message}\n`);
 }
+
+/**
+ * Handle an HTTP `Upgrade` request (WebSocket). Goes through the same
+ * `route()` callback so listener-rule matching + auth gates apply
+ * identically. ECS forward targets get a raw TCP bridge to the picked
+ * replica; Lambda forward targets answer 502 (Lambda TGs do not support
+ * WS); redirect / fixed-response actions synthesize a regular HTTP/1.1
+ * response over the upgrade socket and close. Errors at every stage
+ * destroy the client socket cleanly.
+ */
+function handleUpgrade(
+  req: IncomingMessage,
+  clientSocket: Duplex,
+  head: Buffer,
+  opts: StartFrontDoorServerOptions
+): Promise<void> {
+  // `Duplex` does not declare `setNoDelay`, but the runtime instance under
+  // `http.Server.on('upgrade', ...)` is always a `net.Socket` (or
+  // `tls.TLSSocket` on the HTTPS branch), both of which expose it.
+  const maybeNetSocket = clientSocket as Duplex & { setNoDelay?: (b: boolean) => unknown };
+  maybeNetSocket.setNoDelay?.(true);
+  if (!opts.route) {
+    writeRawHttpError(clientSocket, 404, 'Not Found');
+    return Promise.resolve();
+  }
+  const action = opts.route({
+    path: req.url ?? '/',
+    ...hostHeader(req),
+    headers: req.headers,
+    ...(req.method !== undefined && { method: req.method }),
+    ...(req.socket.remoteAddress !== undefined && { sourceIp: req.socket.remoteAddress }),
+  });
+  if (!action) {
+    writeRawHttpError(clientSocket, 404, 'No listener rule matched the upgrade request.');
+    return Promise.resolve();
+  }
+
+  const proceed = (): Promise<void> => {
+    if (action.kind === 'redirect') {
+      writeRawHttpRedirect(
+        clientSocket,
+        action,
+        req,
+        opts.listenerPort,
+        opts.tls ? 'https' : 'http'
+      );
+      return Promise.resolve();
+    }
+    if (action.kind === 'fixed-response') {
+      writeRawHttpFixedResponse(clientSocket, action);
+      return Promise.resolve();
+    }
+
+    // forward
+    const picked = pickWeightedTarget(action.pools);
+    if (!picked) {
+      writeRawHttpError(
+        clientSocket,
+        502,
+        `No forward target selected behind ${opts.label} (every weighted target has weight 0).`
+      );
+      return Promise.resolve();
+    }
+    if ('lambda' in picked) {
+      // ALB itself does not support WebSocket to Lambda target groups, so
+      // refuse the upgrade with a 502 mirroring the cloud-side behavior.
+      writeRawHttpError(
+        clientSocket,
+        502,
+        `WebSocket upgrade is not supported for Lambda target groups (${picked.lambda.label}).`
+      );
+      return Promise.resolve();
+    }
+    return bridgeWebSocket(req, clientSocket, head, picked.pool, opts);
+  };
+
+  if (action.auth) {
+    const auth = action.auth;
+    return auth
+      .check(req.headers)
+      .then((result) => {
+        if (!result.allow) {
+          writeRawHttpUnauthorized(clientSocket, auth.realm, result.reason);
+          return;
+        }
+        return proceed();
+      })
+      .catch((err) => {
+        getLogger()
+          .child('front-door')
+          .debug(`upgrade auth gate error: ${err instanceof Error ? err.message : String(err)}`);
+        writeRawHttpUnauthorized(clientSocket, auth.realm, 'auth check failed');
+      });
+  }
+  return proceed();
+}
+
+/**
+ * Bridge a WebSocket upgrade onto an ECS replica. Opens a raw TCP socket
+ * to the picked endpoint, replays the upgrade request (with `X-Forwarded-*`
+ * stamped on), forwards any pre-read `head` bytes, then pipes the two
+ * sockets in both directions. `Upgrade` / `Connection: Upgrade` / the
+ * `Sec-WebSocket-*` headers are forwarded verbatim — RFC 7230 marks
+ * `Upgrade` as hop-by-hop, but for the upgrade handshake itself the proxy
+ * MUST preserve them (nginx / haproxy / ALB all do).
+ */
+function bridgeWebSocket(
+  req: IncomingMessage,
+  clientSocket: Duplex,
+  head: Buffer,
+  pool: FrontDoorEndpointPool,
+  opts: StartFrontDoorServerOptions
+): Promise<void> {
+  const logger = getLogger().child('front-door');
+  return new Promise<void>((resolve) => {
+    const endpoint = pool.next();
+    if (!endpoint) {
+      writeRawHttpError(
+        clientSocket,
+        503,
+        `No running replicas behind ${opts.label} for the matched target.`
+      );
+      resolve();
+      return;
+    }
+
+    const upstream: NetSocket = netConnect({ host: endpoint.host, port: endpoint.port });
+    upstream.setNoDelay(true);
+
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
+    upstream.on('connect', () => {
+      const headers: NodeJS.Dict<string | string[]> = { ...req.headers };
+      // Do NOT strip hop-by-hop: `Upgrade` / `Connection: Upgrade` are the
+      // whole point of this code path. Only stamp the X-Forwarded-* set.
+      appendForwardedHeaders(headers, req, opts.listenerPort, opts.tls ? 'https' : 'http');
+
+      const requestLine = `${req.method ?? 'GET'} ${req.url ?? '/'} HTTP/${req.httpVersion}`;
+      const lines: string[] = [requestLine];
+      for (const [name, value] of Object.entries(headers)) {
+        if (value === undefined) continue;
+        if (Array.isArray(value)) {
+          for (const v of value) lines.push(`${name}: ${v}`);
+        } else {
+          lines.push(`${name}: ${value}`);
+        }
+      }
+      upstream.write(`${lines.join('\r\n')}\r\n\r\n`);
+      if (head.length > 0) upstream.write(head);
+
+      clientSocket.pipe(upstream);
+      upstream.pipe(clientSocket);
+    });
+
+    upstream.on('error', (err) => {
+      logger.debug(
+        `WS upstream error (${endpoint.host}:${endpoint.port}): ${err instanceof Error ? err.message : String(err)}`
+      );
+      if (!clientSocket.destroyed) {
+        // If the client never saw any bytes, surface a 502; otherwise the
+        // headers are already flushed, so just destroy.
+        try {
+          writeRawHttpError(
+            clientSocket,
+            502,
+            `Failed to reach replica ${endpoint.host}:${endpoint.port} behind ${opts.label}.`
+          );
+        } catch {
+          /* socket already partially written / closed */
+        }
+        clientSocket.destroy();
+      }
+      done();
+    });
+
+    upstream.on('close', () => {
+      if (!clientSocket.destroyed) clientSocket.destroy();
+      done();
+    });
+    clientSocket.on('error', () => {
+      if (!upstream.destroyed) upstream.destroy();
+      done();
+    });
+    clientSocket.on('close', () => {
+      if (!upstream.destroyed) upstream.destroy();
+      done();
+    });
+  });
+}
+
+/**
+ * Write a minimal HTTP/1.1 error response over a raw upgrade socket and
+ * close it. Used for the pre-101-Switching-Protocols failure paths
+ * (no rule match, no replica, Lambda target, etc.).
+ */
+function writeRawHttpError(socket: Duplex, statusCode: number, message: string): void {
+  if (socket.destroyed) return;
+  const body = `${message}\n`;
+  const statusText = STATUS_TEXT[statusCode] ?? 'Error';
+  const lines = [
+    `HTTP/1.1 ${statusCode} ${statusText}`,
+    'content-type: text/plain; charset=utf-8',
+    `content-length: ${Buffer.byteLength(body)}`,
+    'connection: close',
+    '',
+    '',
+  ];
+  try {
+    socket.write(lines.join('\r\n') + body);
+  } catch {
+    /* socket may have errored mid-write; the end() below still tries */
+  }
+  socket.end();
+}
+
+/** Write a 401 over a raw upgrade socket with the WS-aware `WWW-Authenticate` header. */
+function writeRawHttpUnauthorized(socket: Duplex, realm: string, reason?: string): void {
+  if (socket.destroyed) return;
+  const body = `${reason && reason !== '' ? reason : 'Unauthorized'}\n`;
+  const lines = [
+    'HTTP/1.1 401 Unauthorized',
+    'content-type: text/plain; charset=utf-8',
+    `content-length: ${Buffer.byteLength(body)}`,
+    `www-authenticate: Bearer realm="${escapeRealmQuotes(realm)}"`,
+    'connection: close',
+    '',
+    '',
+  ];
+  try {
+    socket.write(lines.join('\r\n') + body);
+  } catch {
+    /* see writeRawHttpError */
+  }
+  socket.end();
+}
+
+/** Write an ALB-style 301 / 302 redirect over a raw upgrade socket. */
+function writeRawHttpRedirect(
+  socket: Duplex,
+  action: RedirectRouteAction,
+  req: IncomingMessage,
+  listenerPort: number,
+  scheme: 'http' | 'https'
+): void {
+  if (socket.destroyed) return;
+  const location = buildRedirectLocation(action, req, listenerPort, scheme);
+  const statusText = action.statusCode === 301 ? 'Moved Permanently' : 'Found';
+  const lines = [
+    `HTTP/1.1 ${action.statusCode} ${statusText}`,
+    `location: ${location}`,
+    'content-type: text/plain; charset=utf-8',
+    'content-length: 0',
+    'connection: close',
+    '',
+    '',
+  ];
+  try {
+    socket.write(lines.join('\r\n'));
+  } catch {
+    /* see writeRawHttpError */
+  }
+  socket.end();
+}
+
+/** Write an ALB-style fixed-response over a raw upgrade socket. */
+function writeRawHttpFixedResponse(socket: Duplex, action: FixedResponseRouteAction): void {
+  if (socket.destroyed) return;
+  const body = action.messageBody ?? '';
+  const statusText = STATUS_TEXT[action.statusCode] ?? '';
+  const lines = [
+    `HTTP/1.1 ${action.statusCode}${statusText ? ` ${statusText}` : ''}`,
+    `content-type: ${action.contentType ?? 'text/plain; charset=utf-8'}`,
+    `content-length: ${Buffer.byteLength(body)}`,
+    'connection: close',
+    '',
+    '',
+  ];
+  try {
+    socket.write(lines.join('\r\n') + body);
+  } catch {
+    /* see writeRawHttpError */
+  }
+  socket.end();
+}
+
+/** Minimal HTTP/1.1 status text map for the codes the raw writers emit. */
+const STATUS_TEXT: Record<number, string> = {
+  200: 'OK',
+  301: 'Moved Permanently',
+  302: 'Found',
+  401: 'Unauthorized',
+  404: 'Not Found',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+};

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -992,8 +992,15 @@ function bridgeWebSocket(
       settled = true;
       resolve();
     };
+    // Tracks whether the upstream `connect` event has fired. Before connect,
+    // an error means the bridge never opened and a synthetic 502 over the
+    // client socket is safe (no WS frames flowed yet). After connect, the
+    // bridge is pipe-streaming bytes either way — injecting a synthetic
+    // `HTTP/1.1 502` block would corrupt the live WebSocket frame channel.
+    let upstreamConnected = false;
 
     upstream.on('connect', () => {
+      upstreamConnected = true;
       const headers: NodeJS.Dict<string | string[]> = { ...req.headers };
       // Do NOT strip hop-by-hop: `Upgrade` / `Connection: Upgrade` are the
       // whole point of this code path. Only stamp the X-Forwarded-* set.
@@ -1021,16 +1028,19 @@ function bridgeWebSocket(
         `WS upstream error (${endpoint.host}:${endpoint.port}): ${err instanceof Error ? err.message : String(err)}`
       );
       if (!clientSocket.destroyed) {
-        // If the client never saw any bytes, surface a 502; otherwise the
-        // headers are already flushed, so just destroy.
-        try {
-          writeRawHttpError(
-            clientSocket,
-            502,
-            `Failed to reach replica ${endpoint.host}:${endpoint.port} behind ${opts.label}.`
-          );
-        } catch {
-          /* socket already partially written / closed */
+        // Only synthesize a 502 BEFORE the bridge pipe started. After
+        // connect the WS frame channel is live, and writing HTTP text
+        // into it would corrupt the WebSocket parser on the client.
+        if (!upstreamConnected) {
+          try {
+            writeRawHttpError(
+              clientSocket,
+              502,
+              `Failed to reach replica ${endpoint.host}:${endpoint.port} behind ${opts.label}.`
+            );
+          } catch {
+            /* socket already partially written / closed */
+          }
         }
         clientSocket.destroy();
       }
@@ -1131,9 +1141,17 @@ function writeRawHttpFixedResponse(socket: Duplex, action: FixedResponseRouteAct
   if (socket.destroyed) return;
   const body = action.messageBody ?? '';
   const statusText = STATUS_TEXT[action.statusCode] ?? '';
+  // CRLF in `contentType` (sourced from a CFn-literal `ContentType` field)
+  // would inject extra response headers when raw-written below. Strip any
+  // control bytes defensively — Node's `res.writeHead` does this on the
+  // regular HTTP path; the raw-socket path mirrors it.
+  const contentType = sanitizeRawHeaderValue(action.contentType ?? 'text/plain; charset=utf-8');
   const lines = [
-    `HTTP/1.1 ${action.statusCode}${statusText ? ` ${statusText}` : ''}`,
-    `content-type: ${action.contentType ?? 'text/plain; charset=utf-8'}`,
+    // RFC 7230 status-line: `HTTP-version SP Status-Code SP Reason-Phrase
+    // CRLF`. The SP after the status-code is required even when the
+    // reason-phrase is empty.
+    `HTTP/1.1 ${action.statusCode} ${statusText}`,
+    `content-type: ${contentType}`,
     `content-length: ${Buffer.byteLength(body)}`,
     'connection: close',
     '',
@@ -1147,9 +1165,16 @@ function writeRawHttpFixedResponse(socket: Duplex, action: FixedResponseRouteAct
   socket.end();
 }
 
+/** Strip CR / LF / NUL from a raw HTTP header value to prevent header injection. */
+function sanitizeRawHeaderValue(value: string): string {
+  // The ` ` literal in the class is the NUL byte; CRLF + NUL are the
+  // three header-injection-relevant control bytes that bypass the header
+  // grammar when raw-written over the upgrade socket.
+  return value.replace(/[\r\n ]/g, ' ');
+}
+
 /** Minimal HTTP/1.1 status text map for the codes the raw writers emit. */
 const STATUS_TEXT: Record<number, string> = {
-  200: 'OK',
   301: 'Moved Permanently',
   302: 'Found',
   401: 'Unauthorized',

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -1243,3 +1243,106 @@ describe('startFrontDoorServer — WebSocket Upgrade over HTTPS', () => {
     expect(echoed).toBe('tls-ws');
   });
 });
+
+describe('startFrontDoorServer — WebSocket Upgrade resilience', () => {
+  it('does NOT inject HTTP/1.1 502 text into the WS frame stream when the upstream RSTs mid-stream', async () => {
+    // Spin a vanilla `ws` upstream that completes the handshake but then
+    // destroys the TCP socket the instant the client sends a frame. Without
+    // the upstreamConnected guard the front-door would write `HTTP/1.1 502
+    // Bad Gateway...` into the live WS frame channel; the assertion below
+    // sniffs the client-side bytes and fails if that text appears.
+    const { WebSocketServer, WebSocket } = await import('ws');
+    const upstreamHttp = createServer();
+    const wss = new WebSocketServer({ server: upstreamHttp });
+    wss.on('connection', (ws, req) => {
+      // Destroy the underlying socket immediately on any message — emulates
+      // a backend that crashed mid-session.
+      ws.on('message', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req.socket as unknown as { destroy: () => void }).destroy();
+      });
+    });
+    await new Promise<void>((r) => upstreamHttp.listen(0, '127.0.0.1', r));
+    const upstreamPort = (upstreamHttp.address() as AddressInfo).port;
+    cleanups.push(
+      () => new Promise<void>((r) => wss.close(() => upstreamHttp.close(() => r())))
+    );
+
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstreamPort });
+    const front = await startFrontDoorServer({
+      route: () => ({ kind: 'forward', pools: [{ pool, weight: 1 }] }),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+    });
+    cleanups.push(() => front.close());
+
+    // Sniff the raw bytes received from the front-door after the upgrade.
+    const received: Buffer[] = [];
+    const closed = new Promise<void>((resolve) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${front.port}/`);
+      ws.on('open', () => {
+        // Hook the underlying socket to capture every byte AFTER the 101.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const raw = (ws as unknown as { _socket: NodeJS.ReadableStream })._socket;
+        raw.on('data', (chunk: Buffer) => received.push(chunk));
+        ws.send('trigger-rst');
+      });
+      ws.on('close', () => resolve());
+      ws.on('error', () => resolve());
+    });
+    await closed;
+
+    const bytes = Buffer.concat(received).toString('utf-8');
+    expect(bytes).not.toContain('HTTP/1.1 502');
+    expect(bytes).not.toContain('Failed to reach replica');
+  });
+
+  it('sanitizes CR / LF in a fixed-response contentType so it cannot inject extra headers', async () => {
+    const front = await startFrontDoorServer({
+      route: () => ({
+        kind: 'fixed-response',
+        statusCode: 200,
+        contentType: 'text/plain\r\nx-injected: yes',
+        messageBody: 'ok',
+      }),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+    });
+    cleanups.push(() => front.close());
+
+    // Hit the upgrade path (which uses the raw socket writer) and capture
+    // the raw response bytes from the front-door.
+    const sock = await new Promise<import('node:net').Socket>((resolve, reject) => {
+      const s = (
+        require('node:net') as typeof import('node:net')
+      ).connect({ port: front.port, host: '127.0.0.1' }, () => resolve(s));
+      s.on('error', reject);
+    });
+    sock.write(
+      [
+        'GET / HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+        'Sec-WebSocket-Version: 13',
+        '',
+        '',
+      ].join('\r\n')
+    );
+    const raw = await new Promise<string>((resolve) => {
+      const chunks: Buffer[] = [];
+      sock.on('data', (c: Buffer) => chunks.push(c));
+      sock.on('close', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    });
+
+    expect(raw).toContain('content-type: text/plain  x-injected: yes');
+    // The injection attempt MUST NOT produce a separate header line.
+    expect(raw).not.toMatch(/^x-injected: yes/m);
+  });
+});

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -1034,3 +1034,212 @@ describe('startFrontDoorServer — auth gate', () => {
     expect(result.status).toBe(401);
   });
 });
+
+describe('startFrontDoorServer — WebSocket Upgrade', () => {
+  /** Spin a plain-HTTP upstream that runs a `ws` echo server. */
+  async function startWsEchoUpstream(): Promise<{ port: number }> {
+    const { WebSocketServer } = await import('ws');
+    const httpServer = createServer();
+    const wss = new WebSocketServer({ server: httpServer });
+    wss.on('connection', (ws) => {
+      ws.on('message', (data) => ws.send(data));
+    });
+    await new Promise<void>((r) => httpServer.listen(0, '127.0.0.1', r));
+    const port = (httpServer.address() as AddressInfo).port;
+    cleanups.push(
+      () =>
+        new Promise<void>((r) => {
+          wss.close(() => httpServer.close(() => r()));
+        })
+    );
+    return { port };
+  }
+
+  async function startFrontDoorRoute(
+    route: NonNullable<Parameters<typeof startFrontDoorServer>[0]['route']>,
+    extra?: { tls?: Parameters<typeof startFrontDoorServer>[0]['tls'] }
+  ): Promise<StartedFrontDoorServer> {
+    const front = await startFrontDoorServer({
+      route,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+      ...(extra?.tls && { tls: extra.tls }),
+    });
+    cleanups.push(() => front.close());
+    return front;
+  }
+
+  /** Connect via `ws`, send one message, await the echoed reply, close. */
+  async function wsEchoRoundtrip(url: string, message: string): Promise<string> {
+    const { WebSocket } = await import('ws');
+    return new Promise<string>((resolve, reject) => {
+      const ws = new WebSocket(url, { rejectUnauthorized: false });
+      ws.on('open', () => ws.send(message));
+      ws.on('message', (data) => {
+        ws.close();
+        resolve(data.toString());
+      });
+      ws.on('error', reject);
+    });
+  }
+
+  /** Expect a non-101 response from the front-door (the upgrade is refused). */
+  async function wsExpectReject(
+    url: string
+  ): Promise<{ statusCode?: number; wwwAuth?: string }> {
+    const { WebSocket } = await import('ws');
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url, { rejectUnauthorized: false });
+      ws.on('unexpected-response', (_req, res) => {
+        const wwwAuth = res.headers['www-authenticate'];
+        resolve({
+          ...(typeof res.statusCode === 'number' && { statusCode: res.statusCode }),
+          ...(typeof wwwAuth === 'string' && { wwwAuth }),
+        });
+        res.resume();
+      });
+      ws.on('open', () => {
+        ws.close();
+        reject(new Error('expected the front-door to reject the upgrade, but it succeeded'));
+      });
+      ws.on('error', () => {
+        /* swallowed; `unexpected-response` resolves the promise first */
+      });
+    });
+  }
+
+  it('proxies a WebSocket handshake to an ECS pool and round-trips a message', async () => {
+    const upstream = await startWsEchoUpstream();
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstream.port });
+    const front = await startFrontDoorRoute(() => ({
+      kind: 'forward',
+      pools: [{ pool, weight: 1 }],
+    }));
+
+    const echoed = await wsEchoRoundtrip(`ws://127.0.0.1:${front.port}/`, 'hello-ws');
+    expect(echoed).toBe('hello-ws');
+  });
+
+  it('answers 404 over the raw socket when no rule matches the upgrade', async () => {
+    const front = await startFrontDoorRoute(() => undefined);
+    const result = await wsExpectReject(`ws://127.0.0.1:${front.port}/nope`);
+    expect(result.statusCode).toBe(404);
+  });
+
+  it('answers 503 when the pool has no live replica', async () => {
+    const pool = new FrontDoorEndpointPool();
+    const front = await startFrontDoorRoute(() => ({
+      kind: 'forward',
+      pools: [{ pool, weight: 1 }],
+    }));
+    const result = await wsExpectReject(`ws://127.0.0.1:${front.port}/`);
+    expect(result.statusCode).toBe(503);
+  });
+
+  it('answers 502 when the picked forward target is a Lambda target (Lambda TG does not support WS)', async () => {
+    const front = await startFrontDoorRoute(() => ({
+      kind: 'forward',
+      pools: [
+        {
+          lambda: {
+            targetGroupArn: 'tg',
+            multiValueHeaders: false,
+            label: 'EchoFn',
+            invoke: async () => ({ statusCode: 200 }),
+          },
+          weight: 1,
+        },
+      ],
+    }));
+    const result = await wsExpectReject(`ws://127.0.0.1:${front.port}/`);
+    expect(result.statusCode).toBe(502);
+  });
+
+  it('runs the auth gate before bridging: deny -> 401 with WWW-Authenticate', async () => {
+    const upstream = await startWsEchoUpstream();
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstream.port });
+    const front = await startFrontDoorRoute(() => ({
+      kind: 'forward',
+      pools: [{ pool, weight: 1 }],
+      auth: {
+        realm: 'authenticate-cognito (UserPool=us-east-1_test)',
+        check: async () => ({ allow: false }),
+      },
+    }));
+    const result = await wsExpectReject(`ws://127.0.0.1:${front.port}/`);
+    expect(result.statusCode).toBe(401);
+    expect(result.wwwAuth).toBe(
+      'Bearer realm="authenticate-cognito (UserPool=us-east-1_test)"'
+    );
+  });
+
+  it('runs the auth gate before bridging: allow -> handshake succeeds', async () => {
+    const upstream = await startWsEchoUpstream();
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstream.port });
+    const front = await startFrontDoorRoute(() => ({
+      kind: 'forward',
+      pools: [{ pool, weight: 1 }],
+      auth: { realm: 'r', check: async () => ({ allow: true }) },
+    }));
+    const echoed = await wsEchoRoundtrip(`ws://127.0.0.1:${front.port}/`, 'allowed-ws');
+    expect(echoed).toBe('allowed-ws');
+  });
+});
+
+describe('startFrontDoorServer — WebSocket Upgrade over HTTPS', () => {
+  let tls: FrontDoorTlsMaterials;
+  let tlsCacheDir: string;
+
+  beforeAll(async () => {
+    tlsCacheDir = mkdtempSync(join(tmpdir(), 'cdkl-front-door-ws-tls-'));
+    tls = await resolveFrontDoorTlsMaterials({
+      certPath: undefined,
+      keyPath: undefined,
+      cacheDir: tlsCacheDir,
+    });
+  });
+
+  afterAll(() => {
+    rmSync(tlsCacheDir, { recursive: true, force: true });
+  });
+
+  it('terminates TLS locally and bridges the WS upgrade to a plain HTTP upstream', async () => {
+    const { WebSocketServer, WebSocket } = await import('ws');
+    const upstreamHttp = createServer();
+    const wss = new WebSocketServer({ server: upstreamHttp });
+    wss.on('connection', (ws) => ws.on('message', (m) => ws.send(m)));
+    await new Promise<void>((r) => upstreamHttp.listen(0, '127.0.0.1', r));
+    const upstreamPort = (upstreamHttp.address() as AddressInfo).port;
+    cleanups.push(
+      () => new Promise<void>((r) => wss.close(() => upstreamHttp.close(() => r())))
+    );
+
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstreamPort });
+    const front = await startFrontDoorServer({
+      route: () => ({ kind: 'forward', pools: [{ pool, weight: 1 }] }),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      tls,
+    });
+    cleanups.push(() => front.close());
+
+    const echoed = await new Promise<string>((resolve, reject) => {
+      const ws = new WebSocket(`wss://127.0.0.1:${front.port}/`, { rejectUnauthorized: false });
+      ws.on('open', () => ws.send('tls-ws'));
+      ws.on('message', (data) => {
+        ws.close();
+        resolve(data.toString());
+      });
+      ws.on('error', reject);
+    });
+    expect(echoed).toBe('tls-ws');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl start-alb`'s host-side front-door now proxies WebSocket `Upgrade` requests for ECS forward targets, so real-time apps behind an ALB (Socket.IO, ASP.NET SignalR, chat / streaming UIs) can be exercised locally.

Before this PR a `Connection: Upgrade` request landed on the default HTTP request handler — the matched action got served over HTTP/1.1, no upgrade ever fired, and the WS client disconnected with "unexpected response".

## Architecture

- `src/local/front-door-server.ts` registers a `server.on('upgrade', ...)` handler that runs the SAME `route()` callback as the regular HTTP path — so all six listener-rule condition fields + the auth gate apply identically.
- Per-action dispatch:
  - **`forward` to an ECS pool**: `net.connect` a raw TCP socket to the picked replica, replay the upgrade request with `X-Forwarded-*` stamped on, then `pipe` the two sockets in both directions. `Upgrade` / `Connection: Upgrade` / `Sec-WebSocket-*` headers are forwarded verbatim (RFC 7230 marks them hop-by-hop, but RFC 6455 mandates the proxy preserve them for the handshake — nginx / haproxy / ALB all do).
  - **`forward` to a Lambda target**: refuse the upgrade with a `502` over the raw socket. Lambda target groups don't support WebSocket on ALB itself; we mirror that.
  - **`redirect` / `fixed-response`**: synthesize the HTTP/1.1 response over the raw socket (no upgrade), matching how a browser's WS client surfaces such responses.
- Auth gate runs BEFORE the bridge: deny answers `401 Unauthorized` with `WWW-Authenticate: Bearer realm="..."` over the raw socket — same realm + reason format as the regular HTTP path. A check throw answers `401` (not 500) — safe security default.
- HTTPS listeners work the same way: the upgrade fires on a `TLSSocket`, TLS terminates at the front-door, the upstream leg is plain HTTP.

## Test plan

- [x] `vp run verify` — 1642 unit tests pass.
- [x] `tests/unit/local/front-door-server.test.ts` (+7 tests via the `ws` package):
  - Happy path: real `ws` upstream + real `WebSocket` client through the front-door; `send()` echo round-trips.
  - No matching rule → 404 over the raw socket (asserted via the client's `unexpected-response` event).
  - Empty pool → 503.
  - Lambda target → 502.
  - Auth deny → 401 + `WWW-Authenticate` realm matches.
  - Auth allow → handshake succeeds + echo.
  - HTTPS termination + WS Upgrade end-to-end (`wss://...`, real openssl-generated cert, real TLS handshake).
- [x] `/run-integ local-start-alb-routing-conditions` — HTTP regression integ green; 0 docker / network / svc orphans. The Docker layer is opaque to the WS code (just `net.connect(host, port)`).
- [x] Live-test against the running `node dist/cli.js start-alb` binary:
  - `ws://127.0.0.1:18088/` (default action) → `status=418 default-fixed` — proves the upgrade handler is wired AND correctly synthesizes a `fixed-response` action over the raw socket.
  - `ws://127.0.0.1:18088/` with `Host: api.cdklocal.test` (forward rule) → `status=200` from the upstream Python `http.server` (which doesn't understand `Upgrade`, so it answers with a normal 200; a real WS upstream would 101-Switching-Protocols here). This exercises the FULL forward pipeline: `route()` → host-header rule match → ECS pool pick → real `net.connect` to a real Docker container → bridge the response back through the raw socket.
- [x] In-fixture live-test against a real WS upstream is acceptable to skip: the unit tests already drive `startFrontDoorServer` with a REAL `ws` upstream (not a mock) end-to-end including TLS termination, and the cdkl-binary live-test above proves the forward path actually runs `net.connect` against a real Docker container. The only gap is "what happens when the upstream is itself a WS server" — that's a one-line difference from the HTTP-200 case (upstream answers 101 instead of 200; the byte-pipe code is the same).

## Scope (alongside the existing scope-out items)

- **Out of scope, NOW documented**: sticky sessions (`stickiness.enabled`), gRPC / HTTP/2 target groups (`ProtocolVersion: GRPC|HTTP2`), health-gated draining (`HealthCheckPath` / `Matcher`). The front-door is HTTP/1.1, round-robin, no health check probing — all promoted from "implicit gap" to "documented out-of-scope" in `docs/cli-reference.md` so future readers know exactly what is and isn't honored.
- **Still out of scope** (unchanged): the full OAuth roundtrip for authenticate-*, ALB Mutual TLS.

## Review-fix log

Code reviewer (1-reviewer tier, 576 LOC / 5 files, no security-bias paths) caught one **blocker** + two **minor** items + one nit. All addressed in the fix-up commit:

- **Blocker**: `bridgeWebSocket`'s `upstream.on('error')` previously wrote `HTTP/1.1 502 Bad Gateway` over the client socket unconditionally. After the upstream `connect` event the bridge is pipe-streaming bytes — a mid-stream RST would inject HTTP text into a live WS frame channel and corrupt the client's WS parser. The `try/catch` did NOT save us because `socket.write()` queues synchronously. Fixed by tracking an `upstreamConnected` boolean (set inside the `connect` handler) and only emitting the synthetic 502 BEFORE the pipe started. New unit test sniffs the raw client-side bytes after the upstream RSTs mid-session and asserts no HTTP text appears in the byte stream.
- **Minor**: `writeRawHttpFixedResponse` interpolated `action.contentType` into the response without escaping — CRLF in a CFn-literal `ContentType` would inject extra response headers. Added `sanitizeRawHeaderValue` (CR / LF / NUL → space). New unit test sends an upgrade request to a listener whose `fixed-response` carries `contentType: 'text/plain\r\nx-injected: yes'` and asserts the injection does NOT produce a separate header line.
- **Minor**: RFC 7230 status-line was missing the trailing space when `STATUS_TEXT` missed (`HTTP/1.1 418` instead of `HTTP/1.1 418 `). Per RFC the SP after the status-code is required even with an empty reason-phrase. Fixed.
- **Nit**: dropped the unused `200: 'OK'` entry from `STATUS_TEXT`.

## Retrospective

No new rule / hook / memory proposals — the workflow patterns established in the prior PRs (#169 HTTPS, #174 authenticate-*) all reused cleanly. The site-binding test memory continues to be the strongest signal for "real wiring works"; the unit tests in this PR drive end-to-end behavior with REAL upstreams (not mocks), which is the same shape.
