### PR TITLE
feat(exports): expose pickAgentCoreCandidateStack + resolveSingleTarget for shim consumers

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -297,6 +297,7 @@ export { EcsTaskResolutionError } from './local/ecs-task-resolver.js';
  */
 export {
   resolveAgentCoreTarget,
+  pickAgentCoreCandidateStack,
   AgentCoreResolutionError,
   AGENTCORE_RUNTIME_TYPE,
   AGENTCORE_HTTP_PROTOCOL,
@@ -426,3 +427,13 @@ export {
 } from './local/file-watcher.js';
 export { createWatchPredicates, type WatchPredicates } from './cli/commands/local-start-api.js';
 export { resolveWatchConfig, type CdkWatchConfig } from './cli/config-loader.js';
+
+/**
+ * Target picker — interactive `clack`-backed selector for an omitted positional
+ * target. `resolveSingleTarget` returns the user-provided value as-is, prompts
+ * in a TTY when omitted, or calls `onMissing()` (the command's required-arg
+ * error) when no TTY is available. Exposed for hosts that own their command
+ * tree but want cdk-local's picker UX for missing targets — e.g. cdkd's
+ * `local-invoke-agentcore` port.
+ */
+export { resolveSingleTarget } from './local/target-picker.js';


### PR DESCRIPTION
## Summary

Expose 2 more internal symbols from `src/internal.ts` for shim consumers — specifically cdkd's planned `local-invoke-agentcore` command port (follow-up to cdkd PR #713 that migrated cdkd's import surface to the `cdk-local/internal` subpath).

- **`pickAgentCoreCandidateStack`** (`./local/agentcore-resolver.js`) — derives the candidate stack for image-uri intrinsic resolution. Pure helper, ~10 lines, mirrors `run-task`'s `pickCandidateStack` in spirit. Without this exposed, a shim host would have to reimplement the helper inline, duplicating `parseTarget` / `matchStacks` plumbing that this module already owns.

- **`resolveSingleTarget`** (`./local/target-picker.js`) — interactive `clack`-backed selector for an omitted positional target. Returns the user-provided value as-is, prompts in a TTY when omitted, or calls `onMissing()` (the command's required-arg error) when no TTY. Without this exposed, a shim host loses the picker UX or has to reimplement the entire 236-line target-picker module locally.

## Non-goals

No behavior change. No new test coverage required — the symbols' existing module-own test files (`tests/unit/local/agentcore-resolver.test.ts`, `tests/unit/local/target-picker.test.ts`) continue to cover them; this PR only widens the export surface.

The shim consumer (cdkd) carries its own port-side coverage — the cdkd PR that consumes this release will add cdkd-side unit tests + integ fixtures verifying the end-to-end command path. Following the same split established by cdk-local 0.34 export PRs where shim consumers' integ tests cover the live-runtime path.

## Test plan

- [x] `vp run typecheck`: pass
- [x] `vp run test`: pass (no errors, same suite as main)
- [x] `vp run build`: pass (17 files, 3.51 MB total)
- [x] Pure additive: existing consumers unaffected — `index.ts` (public) is unchanged; `internal.ts` only adds 2 export lines + a JSDoc block
