### PR TITLE
test(integ): cover cdkl start-api --all-stacks

### DIFF
--- a/tests/integration/local-start-api-all-stacks/.gitignore
+++ b/tests/integration/local-start-api-all-stacks/.gitignore
@@ -1,0 +1,5 @@
+# Override the parent integ .gitignore so the Lambda handler sources
+# (which must literally be index.js for the Node.js runtime) are
+# tracked.
+!lambda-a/*.js
+!lambda-b/*.js

--- a/tests/integration/local-start-api-all-stacks/.scenarios.json
+++ b/tests/integration/local-start-api-all-stacks/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-apigateway-server"
+  ]
+}

--- a/tests/integration/local-start-api-all-stacks/bin/app.ts
+++ b/tests/integration/local-start-api-all-stacks/bin/app.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { StackA } from '../lib/stack-a.ts';
+import { StackB } from '../lib/stack-b.ts';
+
+const app = new cdk.App();
+
+new StackA(app, 'CdkLocalStartApiAllStacksA', {
+  description: 'Fixture stack A for cdkl start-api --all-stacks integ test',
+});
+
+new StackB(app, 'CdkLocalStartApiAllStacksB', {
+  description: 'Fixture stack B for cdkl start-api --all-stacks integ test',
+});

--- a/tests/integration/local-start-api-all-stacks/cdk.json
+++ b/tests/integration/local-start-api-all-stacks/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-api-all-stacks/lambda-a/index.js
+++ b/tests/integration/local-start-api-all-stacks/lambda-a/index.js
@@ -1,0 +1,10 @@
+// StackA Ping handler. verify.sh greps for `"stack":"a"` to confirm
+// the curl reached this Lambda (and not StackB's PongHandler).
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    stack: 'a',
+    path: event.rawPath || event.path || null,
+  }),
+});

--- a/tests/integration/local-start-api-all-stacks/lambda-b/index.js
+++ b/tests/integration/local-start-api-all-stacks/lambda-b/index.js
@@ -1,0 +1,10 @@
+// StackB Pong handler. verify.sh greps for `"stack":"b"` to confirm
+// the curl reached this Lambda (and not StackA's PingHandler).
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    stack: 'b',
+    path: event.rawPath || event.path || null,
+  }),
+});

--- a/tests/integration/local-start-api-all-stacks/lib/stack-a.ts
+++ b/tests/integration/local-start-api-all-stacks/lib/stack-a.ts
@@ -1,0 +1,28 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import type { Construct } from 'constructs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+export class StackA extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const fn = new lambda.Function(this, 'PingHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(here, '..', 'lambda-a')),
+    });
+
+    const api = new apigwv2.HttpApi(this, 'PingApi');
+    api.addRoutes({
+      path: '/ping',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: new integrations.HttpLambdaIntegration('PingIntegration', fn),
+    });
+  }
+}

--- a/tests/integration/local-start-api-all-stacks/lib/stack-b.ts
+++ b/tests/integration/local-start-api-all-stacks/lib/stack-b.ts
@@ -1,0 +1,28 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import type { Construct } from 'constructs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+export class StackB extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const fn = new lambda.Function(this, 'PongHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(here, '..', 'lambda-b')),
+    });
+
+    const api = new apigwv2.HttpApi(this, 'PongApi');
+    api.addRoutes({
+      path: '/pong',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: new integrations.HttpLambdaIntegration('PongIntegration', fn),
+    });
+  }
+}

--- a/tests/integration/local-start-api-all-stacks/package.json
+++ b/tests/integration/local-start-api-all-stacks/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-start-api-all-stacks",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-api --all-stacks (multi-stack union routing)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.4.0"
+}

--- a/tests/integration/local-start-api-all-stacks/pnpm-lock.yaml
+++ b/tests/integration/local-start-api-all-stacks/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.169.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0':
+    resolution: {integrity: sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.28.0
+      constructs: 10.6.0
+
+  constructs@10.6.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/tests/integration/local-start-api-all-stacks/tsconfig.json
+++ b/tests/integration/local-start-api-all-stacks/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-api-all-stacks/verify.sh
+++ b/tests/integration/local-start-api-all-stacks/verify.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-api-all-stacks integ test
+#
+# Exercises `cdkl start-api --all-stacks` end-to-end against Docker + the
+# AWS Lambda Node.js base image (which bundles RIE). The fixture stands
+# up two CDK stacks, each with one HTTP API v2 + one Lambda:
+#
+#   - CdkLocalStartApiAllStacksA / PingApi  -> GET /ping -> PingHandler ("a")
+#   - CdkLocalStartApiAllStacksB / PongApi  -> GET /pong -> PongHandler ("b")
+#
+# With `--all-stacks`, cdkl serves both APIs as a union — one local HTTP
+# listener per API, each on its own auto-assigned port. The verify pipeline:
+#
+#   1. Launch `cdkl start-api --all-stacks` in the background.
+#   2. Wait for both "Server listening" lines.
+#   3. Extract the per-stack ports from the log.
+#   4. curl each route on its own port; assert the response came from the
+#      backing Lambda (greps for "stack":"a" / "stack":"b").
+#
+# Run via `/run-integ local-start-api-all-stacks` (recommended) or:
+#
+#     bash tests/integration/local-start-api-all-stacks/verify.sh
+#
+# Requires Docker.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+PORT=3737
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling ${IMAGE} (one-time, ~600MB)"
+docker pull "${IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+# Container-host on Linux is 'host.docker.internal' but only resolves
+# automatically on Docker Desktop. The server defaults to that, but
+# Linux CI hosts (or any docker daemon without the magic alias) need
+# the explicit `--add-host` plumbing — out of scope here, so we use
+# 127.0.0.1. Matches what the local-start-api integ does.
+CONTAINER_HOST="127.0.0.1"
+
+LOG_FILE="$(mktemp)"
+SERVER_PID=""
+
+term_server() {
+  local pid="$1" label="$2"
+  if [[ -n "${pid:-}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    echo "==> Sending SIGTERM to ${label} (pid ${pid})"
+    kill -TERM "${pid}" 2>/dev/null || true
+    for i in $(seq 1 120); do
+      kill -0 "${pid}" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "${pid}" 2>/dev/null; then
+      echo "==> ${label} did not exit within 120s; SIGKILL"
+      kill -KILL "${pid}" 2>/dev/null || true
+    fi
+  fi
+}
+
+cleanup() {
+  term_server "${SERVER_PID:-}" "server"
+  ORPHANS=$(docker ps --filter "name=cdkl-" --format "{{.ID}}" 2>/dev/null || true)
+  if [[ -n "${ORPHANS}" ]]; then
+    echo "==> Cleaning up orphan containers"
+    echo "${ORPHANS}" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  fi
+  rm -f "${LOG_FILE}"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Starting cdkl start-api --all-stacks on port ${PORT}"
+${CDKL} start-api \
+  --all-stacks \
+  --port "${PORT}" \
+  --container-host "${CONTAINER_HOST}" \
+  --no-pull \
+  >"${LOG_FILE}" 2>&1 &
+SERVER_PID=$!
+
+# With --all-stacks, cdkl launches one HTTP server per stack's API.
+# This fixture has 2 stacks × 1 API each = 2 servers expected.
+echo "==> Waiting for 2 servers (one per stack) to come up"
+EXPECTED_SERVERS=2
+READY=0
+for i in $(seq 1 60); do
+  # `grep -c` outputs "0" AND exits non-zero on zero matches, so a
+  # naive `|| echo 0` concatenates both into "0\n0" and trips up
+  # the `[[ ... -ge ... ]]` arithmetic. Capture stdout, then default
+  # to 0 only when grep actually failed.
+  count=$(grep -c "Server listening" "${LOG_FILE}" 2>/dev/null) || count=0
+  if [[ "${count}" -ge "${EXPECTED_SERVERS}" ]]; then
+    READY=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ "${READY}" -eq 0 ]]; then
+  echo "FAIL: only ${count}/${EXPECTED_SERVERS} servers came up within 30s. Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+echo "==> Server log preview:"
+head -40 "${LOG_FILE}" | sed 's/^/    /'
+
+# Extract per-stack ports from "Server listening on http://host:PORT  (ApiId (HTTP API v2))".
+# cdkl's listener label is the API's CDK construct ID + the API kind; the stack
+# name itself is not in the label. So we anchor by the API construct ID prefix
+# (`PingApi` / `PongApi`) — distinct across the two stacks by design — followed
+# by CDK's 8-hex-char suffix and the literal "(HTTP API v2)" kind tag, mirroring
+# the construct-ID anchor pattern the local-start-api integ uses.
+PORT_STACK_A=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(PingApi[A-F0-9]{8}\s+\(HTTP API v2\)\)' \
+  "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
+PORT_STACK_B=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(PongApi[A-F0-9]{8}\s+\(HTTP API v2\)\)' \
+  "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
+if [[ -z "${PORT_STACK_A}" || -z "${PORT_STACK_B}" ]]; then
+  echo "FAIL: could not extract per-stack ports."
+  echo "  PORT_STACK_A=${PORT_STACK_A}"
+  echo "  PORT_STACK_B=${PORT_STACK_B}"
+  echo "Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "==> Listening: StackA on ${PORT_STACK_A}, StackB on ${PORT_STACK_B}"
+
+# curl wrapper with retry — RIE container boot from cold can take several
+# seconds, so a single curl may race the readiness of the warm container.
+curl_assert() {
+  local label="$1" url="$2" expect="$3"
+  local response=""
+  for attempt in 1 2 3 4 5 6 7 8; do
+    if response=$(curl -sf "${url}" 2>&1); then
+      if echo "${response}" | grep -q "${expect}"; then
+        echo "    ok: ${label}"
+        return 0
+      fi
+      echo "FAIL: ${label} response did not contain \"${expect}\". Response: ${response}"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "FAIL: ${label} curl failed after retries. URL: ${url}, last response: ${response}"
+  return 1
+}
+
+echo "==> Smoke-testing both stacks via curl"
+curl_assert "StackA GET /ping" "http://127.0.0.1:${PORT_STACK_A}/ping" '"stack":"a"'
+curl_assert "StackB GET /pong" "http://127.0.0.1:${PORT_STACK_B}/pong" '"stack":"b"'
+
+# Cross-check isolation: StackA's port must NOT route to StackB's handler.
+echo "==> Asserting per-stack isolation (StackA port does NOT serve /pong)"
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT_STACK_A}/pong" || true)
+if [[ "${STATUS}" == "200" ]]; then
+  echo "FAIL: StackA port returned 200 for /pong — listener isolation broken"
+  exit 1
+fi
+echo "    ok: /pong on StackA port returned ${STATUS} (non-200 expected)"
+
+echo "==> All local-start-api-all-stacks tests passed"

--- a/tests/integration/local-start-api-all-stacks/verify.sh
+++ b/tests/integration/local-start-api-all-stacks/verify.sh
@@ -159,10 +159,13 @@ curl_assert "StackA GET /ping" "http://127.0.0.1:${PORT_STACK_A}/ping" '"stack":
 curl_assert "StackB GET /pong" "http://127.0.0.1:${PORT_STACK_B}/pong" '"stack":"b"'
 
 # Cross-check isolation: StackA's port must NOT route to StackB's handler.
+# Treat both "200" AND "empty" as failures — empty means curl could not even
+# reach the listener (connection refused / RIE container crashed), which would
+# otherwise pass silently.
 echo "==> Asserting per-stack isolation (StackA port does NOT serve /pong)"
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT_STACK_A}/pong" || true)
-if [[ "${STATUS}" == "200" ]]; then
-  echo "FAIL: StackA port returned 200 for /pong — listener isolation broken"
+if [[ -z "${STATUS}" || "${STATUS}" == "200" ]]; then
+  echo "FAIL: StackA port for /pong returned \"${STATUS}\" — expected non-200, non-empty"
   exit 1
 fi
 echo "    ok: /pong on StackA port returned ${STATUS} (non-200 expected)"


### PR DESCRIPTION
## Summary

Ahead of public launch: add an end-to-end Docker-driven fixture for
`cdkl start-api --all-stacks` — a flag that until now had no integ
coverage at all. The CLI side has unit tests for argument parsing
and conflict-matrix validation, but no fixture has ever proven that
two stacks' APIs come up on independent local ports and route
correctly. This PR closes that gap.

What the fixture does:

- Two CDK stacks (`StackA` / `StackB`), each with one HTTP API v2 +
  one Node 20 Lambda. Routes: `GET /ping` -> StackA, `GET /pong` ->
  StackB; each handler returns `{"stack":"a"}` / `{"stack":"b"}` so
  verify.sh can prove which Lambda actually served the request.
- `verify.sh` launches `cdkl start-api --all-stacks` in the
  background, waits for both "Server listening" lines, extracts the
  per-API ports via construct-ID + kind-tag anchors (mirrors the
  port-discovery pattern from `local-start-api/verify.sh`), curls
  each route, and cross-checks listener isolation by asserting that
  StackA's port returns non-200 for `/pong`.

The follow-up commit fixes a minor flaw the code review caught:
the isolation check originally tested only against `"200"`, which
would silently pass on a transport failure (empty `STATUS`). Now
fails loudly on both 200 AND empty.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass
- [x] `vp run build` — `dist/cli.js` produced
- [x] `vp run test` — 105 files / 1644 unit tests pass
- [x] `/run-integ local-start-api-all-stacks` — full Docker-driven
      verify.sh run, both servers came up on auto-assigned ports
      3737/3738, both routes returned their backing-stack response,
      isolation check returned 404 (correct), zero orphan
      containers / networks post-run, `integ` marker set.
- [x] Re-ran the fixture after the empty-status fix to confirm the
      fix did not regress the happy path.

## Reviewer nits — accepted as fixture-parity

The pr-code-reviewer flagged three nits that are deliberately left
to match the canonical `local-start-api/verify.sh` shape — fixing
them here without fixing the parent fixture would create
inconsistency without value:

- verify.sh count-loop comment vs iteration math — identical in
  parent fixture.
- `\s` regex literal — POSIX-incompatible with BSD grep, but the
  canonical fixture uses the same form and the project's actual
  runtime (GNU grep via mise) handles it correctly.
- Lambda handlers include a `path` field unused by any assertion —
  harmless diagnostic; matches the canonical fixture's
  diagnostic-rich handler style.
