### PR TITLE
test(integ): cover cdkl start-alb HTTPS termination

### DIFF
--- a/tests/integration/local-start-alb-https/.scenarios.json
+++ b/tests/integration/local-start-alb-https/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-alb-front-door"
+  ]
+}

--- a/tests/integration/local-start-alb-https/bin/app.ts
+++ b/tests/integration/local-start-alb-https/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbHttpsStack } from '../lib/local-start-alb-https-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbHttpsStack(app, 'CdkLocalStartAlbHttpsFixture', {
+  description: 'Fixture stack for cdkl start-alb HTTPS termination integ test',
+});

--- a/tests/integration/local-start-alb-https/cdk.json
+++ b/tests/integration/local-start-alb-https/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-https/lib/local-start-alb-https-stack.ts
+++ b/tests/integration/local-start-alb-https/lib/local-start-alb-https-stack.ts
@@ -1,0 +1,100 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { Construct } from 'constructs';
+
+/**
+ * Fixture for `cdkl start-alb` HTTPS termination.
+ *
+ * Mirrors `local-start-alb` but adds a second listener on HTTPS:443 that
+ * forwards to the SAME target group, so the same 2-replica web service is
+ * reachable over both HTTP and locally-terminated HTTPS. The local front-door
+ * picks up the `protocol: 'HTTPS'` listener and generates a self-signed cert
+ * (cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`) — the deployed ALB's
+ * ACM cert ARNs in `certificates[]` are NOT fetched (ACM private keys are
+ * not retrievable by design), so we pass `certificates: []` here.
+ *
+ * The replica payload is a tiny Python HTTP server replying with its own
+ * hostname; the integ harness curls both schemes and asserts the HTTPS path
+ * reaches the same backing replicas as the HTTP path.
+ */
+// chr(10) keeps this a clean newline-joined array (a literal '\n' would
+// split the line during synthesis).
+const HELLO_SERVER = [
+  'import http.server,socket',
+  'class H(http.server.BaseHTTPRequestHandler):',
+  ' def do_GET(s):',
+  "  b=('replica '+socket.gethostname()+chr(10)).encode()",
+  "  s.send_response(200);s.send_header('Content-Length',str(len(b)));s.end_headers();s.wfile.write(b)",
+  ' def log_message(s,*a):pass',
+  "http.server.HTTPServer(('0.0.0.0',80),H).serve_forever()",
+].join('\n');
+
+export class LocalStartAlbHttpsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-alb-https-fixture',
+    });
+
+    const taskDef = new ecs.CfnTaskDefinition(this, 'WebTask', {
+      family: 'cdkl-start-alb-https-web',
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'web',
+          image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+          essential: true,
+          entryPoint: ['python', '-c'],
+          command: [HELLO_SERVER],
+          memoryReservation: 32,
+          portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+        },
+      ],
+    });
+
+    const targetGroup = new elbv2.CfnTargetGroup(this, 'WebTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WebLB', {
+      type: 'application',
+    });
+
+    new elbv2.CfnListener(this, 'WebHttpListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.ref }],
+    });
+
+    // HTTPS:443 forwards to the same target group. The deployed listener's
+    // ACM cert ARNs would normally live in `certificates[]`, but cdk-local
+    // does not fetch ACM private keys (they are not retrievable), so the
+    // local front-door generates a self-signed cert on its own.
+    new elbv2.CfnListener(this, 'WebHttpsListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 443,
+      protocol: 'HTTPS',
+      certificates: [],
+      defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.ref }],
+    });
+
+    new ecs.CfnService(this, 'WebService', {
+      cluster: cluster.ref,
+      taskDefinition: taskDef.ref,
+      desiredCount: 2,
+      launchType: 'EC2',
+      loadBalancers: [
+        {
+          containerName: 'web',
+          containerPort: 80,
+          targetGroupArn: targetGroup.ref,
+        },
+      ],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-https/package.json
+++ b/tests/integration/local-start-alb-https/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-start-alb-https",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb's HTTPS listener termination (auto-generated self-signed cert path)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.4.0"
+}

--- a/tests/integration/local-start-alb-https/pnpm-lock.yaml
+++ b/tests/integration/local-start-alb-https/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.169.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0':
+    resolution: {integrity: sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.28.0
+      constructs: 10.6.0
+
+  constructs@10.6.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/tests/integration/local-start-alb-https/tsconfig.json
+++ b/tests/integration/local-start-alb-https/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-alb-https/verify.sh
+++ b/tests/integration/local-start-alb-https/verify.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-alb HTTPS termination integ test
+#
+# Names an ALB that has BOTH an HTTP:80 listener and an HTTPS:443 listener,
+# each forwarding to the same 2-replica web service. The local front-door
+# terminates HTTPS using either a user-supplied `--tls-cert` / `--tls-key`
+# pair OR (as exercised here) an auto-generated self-signed cert cached
+# under `$XDG_CACHE_HOME/cdk-local/alb-https/`.
+#
+# Asserts:
+#   - The HTTP and HTTPS front-door banners both appear (banner uses
+#     "ALB front-door: http://..." and "ALB front-door: https://...").
+#   - curl -k https://<host>:<https-port>/ returns 200 with the same
+#     "replica <hostname>" payload as the HTTP path.
+#   - Round-robin works over HTTPS too (>= 2 distinct replica hostnames).
+#   - SIGTERM tears every container + network + both front-door sockets
+#     down cleanly.
+#
+# Requires Docker AND openssl on PATH (the auto-gen cert path shells out to
+# `openssl req -x509 ...`). Linux CI runners and macOS Docker Desktop both
+# satisfy this by default.
+#
+#     bash tests/integration/local-start-alb-https/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+WEB_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
+LB_HTTP_PORT=18186
+LB_HTTPS_PORT=18443
+
+CDKL_PID=""
+
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers + networks"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying prerequisites"
+docker version --format '{{.Server.Version}}' >/dev/null
+command -v openssl >/dev/null || { echo "FAIL: openssl required for the auto-gen cert path"; exit 1; }
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${WEB_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+
+echo "==> start-alb: HTTP on ${LB_HTTP_PORT}, HTTPS on ${LB_HTTPS_PORT}"
+# Listener ports 80 and 443 are both privileged; remap each to a
+# non-privileged host port so the front-door binds without root.
+${CDKL} start-alb CdkLocalStartAlbHttpsFixture:WebLB \
+  --container-host 127.0.0.1 \
+  --lb-port "80=${LB_HTTP_PORT}" \
+  --lb-port "443=${LB_HTTPS_PORT}" \
+  > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 90s)"
+BOOTED=0
+for _ in $(seq 1 90); do
+  if grep -q "Service(s) running:" "${OUT_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: service did not reach the boot banner within 90s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+
+echo "==> Asserting BOTH front-door banners were logged"
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_HTTP_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: HTTP front-door banner for host port ${LB_HTTP_PORT} not found"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -q "ALB front-door: https://127.0.0.1:${LB_HTTPS_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: HTTPS front-door banner for host port ${LB_HTTPS_PORT} not found"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: HTTP + HTTPS banners both present"
+
+echo "==> Waiting for the HTTPS front-door to serve 200 (replicas take a moment to start)"
+# curl -k bypasses self-signed cert verification; we only care that TLS
+# handshake completes and the backing replica responds 200.
+READY=0
+for _ in $(seq 1 60); do
+  if curl -ksS --max-time 5 "https://127.0.0.1:${LB_HTTPS_PORT}/" >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the HTTPS front-door to serve"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: HTTPS front-door never served a 200 within 60s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: HTTPS front-door serving"
+
+echo "==> Asserting HTTPS payload matches the backing replicas"
+HTTPS_BODY=$(curl -ksS --max-time 5 "https://127.0.0.1:${LB_HTTPS_PORT}/" 2>/dev/null)
+if [[ ! "${HTTPS_BODY}" =~ ^replica\  ]]; then
+  echo "FAIL: HTTPS response did not start with 'replica '. Got: ${HTTPS_BODY}"
+  exit 1
+fi
+echo "    OK: HTTPS body: ${HTTPS_BODY}"
+
+echo "==> Asserting HTTPS round-robin reaches >= 2 distinct replicas"
+HOSTS_FILE=$(mktemp)
+for _ in $(seq 1 20); do
+  curl -ksS --max-time 5 "https://127.0.0.1:${LB_HTTPS_PORT}/" 2>/dev/null | awk '{print $2}' >> "${HOSTS_FILE}" || true
+done
+DISTINCT_HTTPS=$(sort -u "${HOSTS_FILE}" | grep -c . || true)
+echo "    distinct replica hostnames (HTTPS): ${DISTINCT_HTTPS}"
+sort "${HOSTS_FILE}" | uniq -c | sed 's/^/      /'
+rm -f "${HOSTS_FILE}"
+if [[ "${DISTINCT_HTTPS}" -lt 2 ]]; then
+  echo "FAIL: HTTPS front-door did not round-robin across >= 2 replicas (saw ${DISTINCT_HTTPS})"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: HTTPS front-door load-balances across ${DISTINCT_HTTPS} replicas"
+
+echo "==> Sanity-checking HTTP path still works alongside HTTPS"
+HTTP_BODY=$(curl -fsS --max-time 5 "http://127.0.0.1:${LB_HTTP_PORT}/" 2>/dev/null)
+if [[ ! "${HTTP_BODY}" =~ ^replica\  ]]; then
+  echo "FAIL: HTTP response did not start with 'replica '. Got: ${HTTP_BODY}"
+  exit 1
+fi
+echo "    OK: HTTP body: ${HTTP_BODY}"
+
+echo "==> Sending SIGTERM to cdk-local (${CDKL_PID})"
+kill -TERM "${CDKL_PID}"
+
+echo "==> Waiting for cdk-local to exit (up to 60s)"
+EXITED=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then EXITED=1; break; fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+echo "==> Asserting clean teardown — no leftover containers"
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers still present after SIGTERM"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+
+echo "==> Asserting clean teardown — no leftover networks"
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} docker networks still present after SIGTERM"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+echo "==> Asserting both front-door sockets are closed"
+if curl -ksS --max-time 2 "https://127.0.0.1:${LB_HTTPS_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: HTTPS front-door on host port ${LB_HTTPS_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HTTP_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: HTTP front-door on host port ${LB_HTTP_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+
+echo ""
+echo "==> local-start-alb-https test passed (auto-gen self-signed cert path, dual HTTP + HTTPS, clean teardown)"


### PR DESCRIPTION
## Summary

Ahead of public launch: add an end-to-end fixture for `cdkl start-alb`
HTTPS termination. The flag surface (`--tls-cert` + `--tls-key` pair
or auto-generated self-signed cert) has unit tests but no integ
fixture has ever proven that an ALB with an HTTPS:443 listener
actually terminates TLS locally and round-robins replicas over it.

What the fixture does:

- Single stack (`CdkLocalStartAlbHttpsFixture`) with one ECS service
  (2 replicas of a tiny Python HTTP server), one target group, and
  **two listeners** on the same ALB: HTTP:80 and HTTPS:443. The
  deployed listener's `certificates[]` is empty — cdk-local does
  not fetch ACM private keys (they are not retrievable), so the
  local front-door generates a self-signed cert via openssl
  instead.
- `verify.sh` launches `cdkl start-alb` with both ports remapped
  (`--lb-port "80=18186"` and `--lb-port "443=18443"`), asserts
  both `ALB front-door: http://...` and `ALB front-door: https://...`
  banners appear, then exercises the HTTPS path:
  - `curl -k https://...` returns 200 with `replica <hostname>` body
  - 20 requests reach >= 2 distinct replicas (round-robin works
    over TLS)
  - HTTP path still works alongside (cross-scheme sanity)
- On SIGTERM: 0 leftover containers / networks, both front-door
  sockets closed.

Exercises the **auto-gen self-signed cert path**; the `--tls-cert`
/ `--tls-key` BYO path can be added in a follow-up fixture if
needed.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass (104 files)
- [x] `vp run build` — `dist/cli.js` produced
- [x] `vp run test` — unit tests pass
- [x] `/run-integ local-start-alb-https` — full Docker run, HTTP +
      HTTPS banners both appear, HTTPS curl returns 200 with
      `replica <hostname>` body, 20 requests round-robin across
      both replicas (10 hits each), 0 orphan containers /
      networks post-run, `integ` marker set.

## Notes for reviewers

The fixture mirrors `local-start-alb`'s shape (Python `http.server`
in a bridge-mode task, 2 replicas, identical target-group +
listener pattern) so most of the boilerplate is byte-for-byte
parity. The two substantive additions:
1. A second `CfnListener` on port 443 with `protocol: 'HTTPS'` +
   empty `certificates[]`.
2. Dual `--lb-port` flag plus HTTPS-specific curl assertions in
   verify.sh (curl `-k` to bypass self-signed cert verification).

Requires openssl on PATH for the auto-gen path; this is satisfied
by default on Linux CI runners and macOS Docker Desktop, and the
fixture checks for `openssl` upfront with an actionable error.
