### PR TITLE
test(integ): cover cdkl invoke --assume-role (explicit ARN form)

### DIFF
--- a/tests/integration/local-invoke-assume-role/.gitignore
+++ b/tests/integration/local-invoke-assume-role/.gitignore
@@ -1,0 +1,4 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is
+# tracked.
+!lambda/*.js

--- a/tests/integration/local-invoke-assume-role/.scenarios.json
+++ b/tests/integration/local-invoke-assume-role/.scenarios.json
@@ -1,0 +1,6 @@
+{
+  "scenarios": [
+    "local-assume-role",
+    "local-from-cfn-stack-substitution"
+  ]
+}

--- a/tests/integration/local-invoke-assume-role/bin/app.ts
+++ b/tests/integration/local-invoke-assume-role/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalInvokeAssumeRoleStack } from '../lib/local-invoke-assume-role-stack.ts';
+
+const app = new cdk.App();
+
+new LocalInvokeAssumeRoleStack(app, 'CdkLocalInvokeAssumeRoleFixture', {
+  description:
+    'Fixture stack for cdkl invoke --assume-role (explicit ARN + bare auto-resolve from CFn state)',
+});

--- a/tests/integration/local-invoke-assume-role/cdk.json
+++ b/tests/integration/local-invoke-assume-role/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-invoke-assume-role/lambda/index.js
+++ b/tests/integration/local-invoke-assume-role/lambda/index.js
@@ -1,0 +1,16 @@
+// Returns the caller identity STS reports for whatever AWS credentials
+// reached the container. The verify.sh harness greps for the
+// "assumed-role/<RoleName>/<session>" pattern that --assume-role
+// produces, and for the developer's plain user ARN in the baseline
+// (no --assume-role) case.
+const { STSClient, GetCallerIdentityCommand } = require('@aws-sdk/client-sts');
+
+exports.handler = async () => {
+  const sts = new STSClient({});
+  const identity = await sts.send(new GetCallerIdentityCommand({}));
+  return {
+    arn: identity.Arn,
+    accountId: identity.Account,
+    userId: identity.UserId,
+  };
+};

--- a/tests/integration/local-invoke-assume-role/lib/local-invoke-assume-role-stack.ts
+++ b/tests/integration/local-invoke-assume-role/lib/local-invoke-assume-role-stack.ts
@@ -1,0 +1,66 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import type { Construct } from 'constructs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture stack for `cdkl invoke --assume-role`.
+ *
+ * Defines one Lambda whose handler calls `sts:GetCallerIdentity` and
+ * returns the result, plus an execution role with a CUSTOM trust policy
+ * that also lets the developer's account (the caller of `cdk deploy`)
+ * `sts:AssumeRole` into it. cdkl's `--assume-role` injects the assumed
+ * role's STS credentials as the AWS env vars seen by the Lambda
+ * container, so the in-container STS call reports an
+ * `arn:aws:sts::<account>:assumed-role/<RoleName>/<session>` identity —
+ * a marker the integ harness greps for.
+ *
+ * The custom trust policy adds an `AccountRootPrincipal()` alongside the
+ * standard `ServicePrincipal('lambda.amazonaws.com')`, so:
+ *
+ *   - Lambda continues to be allowed to use this role at deploy time
+ *     (`cdk deploy` succeeds).
+ *   - The deploying developer (or any caller in the same account) can
+ *     `AssumeRole` it locally — what `cdkl --assume-role` needs.
+ *
+ * The default execution role CDK would generate trusts only the Lambda
+ * service principal, so `--assume-role` against it would fail with
+ * `AccessDenied`. The custom role makes the fixture self-contained.
+ */
+export class LocalInvokeAssumeRoleStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const executionRole = new iam.Role(this, 'AssumableExecRole', {
+      assumedBy: new iam.CompositePrincipal(
+        new iam.ServicePrincipal('lambda.amazonaws.com'),
+        new iam.AccountRootPrincipal(),
+      ),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          'service-role/AWSLambdaBasicExecutionRole',
+        ),
+      ],
+    });
+
+    new lambda.Function(this, 'EchoIdentityHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(here, '..', 'lambda')),
+      role: executionRole,
+      timeout: cdk.Duration.seconds(15),
+    });
+
+    // Surface the role ARN as a stack output so verify.sh can pass it to
+    // the explicit `--assume-role <arn>` test case without an extra
+    // describe-stack-resources hop.
+    new cdk.CfnOutput(this, 'ExecRoleArn', {
+      value: executionRole.roleArn,
+      description: 'ARN of the role that the Lambda runs as and that --assume-role assumes',
+    });
+  }
+}

--- a/tests/integration/local-invoke-assume-role/package.json
+++ b/tests/integration/local-invoke-assume-role/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-invoke-assume-role",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl invoke --assume-role (explicit ARN and bare auto-resolve forms)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.4.0"
+}

--- a/tests/integration/local-invoke-assume-role/pnpm-lock.yaml
+++ b/tests/integration/local-invoke-assume-role/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.169.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0':
+    resolution: {integrity: sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.28.0
+      constructs: 10.6.0
+
+  constructs@10.6.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/tests/integration/local-invoke-assume-role/tsconfig.json
+++ b/tests/integration/local-invoke-assume-role/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-invoke-assume-role/verify.sh
+++ b/tests/integration/local-invoke-assume-role/verify.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkl invoke --assume-role` in both
+# the EXPLICIT (`--assume-role <arn>`) and BARE (`--assume-role` +
+# `--from-cfn-stack`) forms.
+#
+# The fixture deploys a CFn stack with one Lambda whose execution role
+# trusts both `lambda.amazonaws.com` AND the deploying account's root,
+# so a developer can `sts:AssumeRole` into it locally. The Lambda's
+# handler calls `sts:GetCallerIdentity` and returns the result; verify.sh
+# greps for the `assumed-role/<RoleName>` pattern that proves cdkl wrote
+# the assumed-role STS credentials into the container's AWS_* env vars.
+#
+# Two test cases:
+#   1. Baseline: `cdkl invoke --from-cfn-stack <stack>` (no --assume-role)
+#      -> By design, cdkl does NOT inject the developer's shell credentials
+#         into the container; the in-container STS call fails with
+#         CredentialsProviderError. The assertion is just that no implicit
+#         assumed-role identity leaks in.
+#   2. Explicit: `cdkl invoke --from-cfn-stack <stack> --assume-role <arn>`
+#      -> Lambda sees `arn:aws:sts::<account>:assumed-role/<RoleName>/<...>`.
+#
+# The bare form (`--assume-role` with no value) is NOT covered here. With
+# the current CFn state provider it auto-resolves to `undefined` for any
+# Lambda whose execution role is a sibling resource in the same stack —
+# `attributes.Arn` is never populated from `ListStackResources` (which
+# returns PhysicalResourceId, the role NAME, not the ARN). Tracked as
+# issue #181 so this fixture covers what does work today.
+#
+# Run via `/run-integ local-invoke-assume-role` (recommended) or directly:
+#
+#     bash tests/integration/local-invoke-assume-role/verify.sh
+#
+# Requires Docker + AWS credentials with deploy permissions in the target
+# account, plus the upstream `cdk` CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalInvokeAssumeRoleFixture"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-assume-role"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed)"
+
+echo "[verify] step 1a: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+
+echo "[verify] step 1b: verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "[verify] step 1c: pulling ${IMAGE} (one-time, ~600MB if not cached)"
+docker pull "${IMAGE}"
+
+# Sentinel gates the cleanup trap: only run `cdk destroy` on a stack
+# THIS run created, never on a pre-existing one with the same name.
+WE_CREATED_STACK=0
+cleanup() {
+  rc=$?
+  if [ "${rc}" -ne 0 ] && [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] FAIL (exit ${rc}) — attempting cdk destroy to clean up"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists in CloudFormation — clean up first via:"
+  echo "          aws cloudformation delete-stack --stack-name ${STACK} --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 3: cdk deploy (upstream CDK CLI)"
+# Set the sentinel BEFORE `cdk deploy` so an early-failure path still
+# triggers the destroy attempt — pre-flight has already verified the
+# namespace is clean, so we own it from this point on. Mirrors the
+# pattern in local-invoke-from-cfn-stack.
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 3 ok: cdk deploy completed"
+
+echo "[verify] step 4: read deployed role ARN from CFn outputs + account id"
+ROLE_ARN=$(aws cloudformation describe-stacks \
+  --stack-name "${STACK}" \
+  --region "${REGION}" \
+  --query 'Stacks[0].Outputs[?OutputKey==`ExecRoleArn`].OutputValue | [0]' \
+  --output text)
+if [ -z "${ROLE_ARN}" ] || [ "${ROLE_ARN}" = "None" ]; then
+  echo "[verify] FAIL: could not read ExecRoleArn output from ${STACK}"
+  exit 1
+fi
+ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)
+ROLE_NAME="${ROLE_ARN##*/}"
+echo "[verify]   role: ${ROLE_ARN}"
+echo "[verify]   account: ${ACCOUNT}"
+
+# IAM role propagation is eventually consistent — sts:AssumeRole can
+# fail with "no identity-based policy allows the action" for ~5-10s
+# after the role is created. Retry up to 30s before failing.
+echo "[verify] step 4b: wait for sts:AssumeRole to succeed (IAM propagation)"
+PROPAGATED=0
+for _ in $(seq 1 15); do
+  if aws sts assume-role --role-arn "${ROLE_ARN}" --role-session-name cdkl-integ-probe \
+       --duration-seconds 900 >/dev/null 2>&1; then
+    PROPAGATED=1
+    break
+  fi
+  sleep 2
+done
+if [ "${PROPAGATED}" -ne 1 ]; then
+  echo "[verify] FAIL: sts:AssumeRole into ${ROLE_ARN} did not succeed within 30s"
+  aws sts assume-role --role-arn "${ROLE_ARN}" --role-session-name cdkl-integ-probe \
+    --duration-seconds 900 2>&1 | head -5
+  exit 1
+fi
+echo "[verify]   IAM trust propagated"
+
+invoke_capture() {
+  # Run cdkl invoke and return the last JSON-looking line on stdout.
+  # `--no-pull` skips docker pull (image already cached by step 1c) so the
+  # repeat invocations are fast. Stderr is dropped; if assertion fails we
+  # re-run without the drop for diagnostics in the FAIL branch.
+  ${CLI} invoke "$@" --no-pull 2>/dev/null | tail -1
+}
+
+echo "[verify] step 5: baseline — cdkl invoke --from-cfn-stack (no --assume-role)"
+# By design, cdkl does NOT inject the developer's shell credentials into
+# the container; it injects credentials ONLY when --assume-role is on.
+# So the Lambda sees no AWS_ACCESS_KEY_ID / etc. at all and the in-container
+# STS call fails with CredentialsProviderError. The negative assertion that
+# matters: no assumed-role marker appears (cdkl did NOT secretly assume
+# anything on the user's behalf).
+RESULT_BASELINE=$(invoke_capture "${STACK}/EchoIdentityHandler" --from-cfn-stack)
+echo "[verify]   response: ${RESULT_BASELINE}"
+echo "${RESULT_BASELINE}" | grep -q 'CredentialsProviderError' || {
+  echo "[verify] FAIL: baseline expected CredentialsProviderError (no creds in container by default), got: ${RESULT_BASELINE}"
+  echo "[verify]   stderr re-run:"
+  ${CLI} invoke "${STACK}/EchoIdentityHandler" --from-cfn-stack --no-pull 2>&1 | tail -10
+  exit 1
+}
+if echo "${RESULT_BASELINE}" | grep -q ':assumed-role/'; then
+  echo "[verify] FAIL: baseline unexpectedly saw an assumed-role ARN: ${RESULT_BASELINE}"
+  exit 1
+fi
+echo "[verify]   ok: baseline container has no AWS creds (no implicit credential injection)"
+
+echo "[verify] step 6: explicit ARN — cdkl invoke --assume-role <arn>"
+echo "[verify]   expect assumed-role/${ROLE_NAME} marker in the Lambda's STS identity"
+RESULT_EXPLICIT=$(invoke_capture "${STACK}/EchoIdentityHandler" --from-cfn-stack --assume-role "${ROLE_ARN}")
+echo "[verify]   response: ${RESULT_EXPLICIT}"
+ASSUMED_RE="arn:aws:sts::${ACCOUNT}:assumed-role/${ROLE_NAME}/"
+echo "${RESULT_EXPLICIT}" | grep -q "${ASSUMED_RE}" || {
+  echo "[verify] FAIL: expected assumed-role pattern ${ASSUMED_RE}*, got: ${RESULT_EXPLICIT}"
+  echo "[verify]   stderr re-run:"
+  ${CLI} invoke "${STACK}/EchoIdentityHandler" --from-cfn-stack --assume-role "${ROLE_ARN}" --no-pull 2>&1 | tail -10
+  exit 1
+}
+echo "[verify]   ok: explicit --assume-role <arn> assumed the role; Lambda saw assumed-role identity"
+
+echo "[verify] step 7: cdk destroy --force"
+cdk destroy "${STACK}" --force --region "${REGION}" \
+  --no-version-reporting --no-asset-metadata --no-path-metadata
+WE_CREATED_STACK=0
+
+echo ""
+echo "[verify] All checks passed:"
+echo "[verify]   - baseline (no --assume-role): container has no AWS creds (cdkl does not auto-inject the shell credentials); STS fails with CredentialsProviderError."
+echo "[verify]   - explicit --assume-role <arn>: Lambda sees arn:aws:sts::<acct>:assumed-role/<RoleName>/<session>."


### PR DESCRIPTION
## Summary

Ahead of public launch: add an end-to-end fixture for
`cdkl invoke --assume-role`, which was previously uncovered. The
fixture also surfaced a real cdk-local bug — tracked as #181 below.

The fixture:

- Deploys a CFn stack with one Lambda + one custom execution role
  whose trust policy lets both `lambda.amazonaws.com` AND the
  deploying account `sts:AssumeRole` into it.
- The Lambda's handler calls `sts:GetCallerIdentity` and returns the
  result; verify.sh greps for the assumed-role marker that proves
  cdkl wrote the assumed-role STS credentials into the container's
  `AWS_*` env vars.
- Test 1 — baseline `cdkl invoke --from-cfn-stack` (no
  `--assume-role`): container has no AWS creds (cdkl deliberately does
  NOT auto-inject shell credentials), STS fails with
  `CredentialsProviderError`. The assertion guards against implicit
  credential leaks.
- Test 2 — explicit `cdkl invoke --from-cfn-stack --assume-role <arn>`:
  Lambda sees `arn:aws:sts::<acct>:assumed-role/<RoleName>/cdkl-invoke-<ts>`
  — proves the assumed-role STS credentials reached the container.

## Bug surfaced by writing this fixture

The originally-planned third test case (bare `--assume-role` +
`--from-cfn-stack` auto-resolve) is intentionally **not** covered.
While building it I discovered that bare-form auto-resolve does not
work for the common case (Lambda exec role is a sibling resource in
the same stack): the CFn state provider never populates
`attributes.Arn` for `AWS::IAM::Role` resources, so
`resolveExecutionRoleArnFromState` returns `undefined` and the
container runs with no credentials. Filed as #181 with a proposed fix.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass (104 files)
- [x] `vp run build` — `dist/cli.js` produced
- [x] `vp run test` — unit tests pass
- [x] `/run-integ local-invoke-assume-role` — full real-AWS round-trip:
      cdk deploy succeeded, IAM trust propagated, baseline gave
      CredentialsProviderError, explicit `--assume-role <arn>`
      returned `arn:aws:sts::531991745243:assumed-role/CdkLocalInvokeAssumeRoleF-AssumableExecRole593EF03D-Wkx188FEoXhw/cdkl-invoke-1780137604371`,
      cdk destroy succeeded, 0 docker orphans, 0 AWS orphan stacks,
      `integ` marker set.

## Notes for reviewers

This is a real-AWS fixture (deploys an IAM role + Lambda; ~50 s deploy
+ ~5 s destroy). Pattern mirrors the existing `local-invoke-from-cfn-stack`
fixture: same sentinel-gated cdk-destroy cleanup, same upstream-cdk-CLI
deploy path, same pre-flight orphan-stack scan. The Lambda handler
needs `@aws-sdk/client-sts` — Node 20 base image bundles it, so no
fixture-side install.
