### PR TITLE
test(integ): cover cdkl start-alb authenticate-cognito guard wiring

### DIFF
--- a/tests/integration/local-start-alb-auth/.scenarios.json
+++ b/tests/integration/local-start-alb-auth/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-alb-front-door"
+  ]
+}

--- a/tests/integration/local-start-alb-auth/bin/app.ts
+++ b/tests/integration/local-start-alb-auth/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbAuthStack } from '../lib/local-start-alb-auth-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbAuthStack(app, 'CdkLocalStartAlbAuthFixture', {
+  description: 'Fixture stack for cdkl start-alb authenticate-cognito + --no-verify-auth integ test',
+});

--- a/tests/integration/local-start-alb-auth/cdk.json
+++ b/tests/integration/local-start-alb-auth/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-auth/lib/local-start-alb-auth-stack.ts
+++ b/tests/integration/local-start-alb-auth/lib/local-start-alb-auth-stack.ts
@@ -1,0 +1,114 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { Construct } from 'constructs';
+
+/**
+ * Fixture for `cdkl start-alb` authenticate-cognito guarding.
+ *
+ * Mirrors `local-start-alb` but wraps the default action with an
+ * `authenticate-cognito` action so the local front-door's auth check
+ * runs before any forward. The local check is wired by
+ * `src/local/front-door-auth.ts`:
+ *
+ *   - No Authorization header (and no `--bearer-token`) -> 401 with a
+ *     `WWW-Authenticate: Bearer` header.
+ *   - `--no-verify-auth` -> short-circuit to allow.
+ *
+ * The Cognito userPoolDomain / userPoolArn values are NEVER contacted
+ * by these two paths (the 401 branch fires before the JWKS lookup, and
+ * `--no-verify-auth` bypasses the entire check), so the fixture uses
+ * placeholder ARNs and a placeholder domain. JWT-verification paths
+ * (signature / iss / aud / exp) are unit-tested in
+ * `tests/unit/local/cognito-jwt.test.ts`; this integ covers the wiring.
+ */
+const HELLO_SERVER = [
+  'import http.server,socket',
+  'class H(http.server.BaseHTTPRequestHandler):',
+  ' def do_GET(s):',
+  "  b=('replica '+socket.gethostname()+chr(10)).encode()",
+  "  s.send_response(200);s.send_header('Content-Length',str(len(b)));s.end_headers();s.wfile.write(b)",
+  ' def log_message(s,*a):pass',
+  "http.server.HTTPServer(('0.0.0.0',80),H).serve_forever()",
+].join('\n');
+
+export class LocalStartAlbAuthStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-alb-auth-fixture',
+    });
+
+    const taskDef = new ecs.CfnTaskDefinition(this, 'WebTask', {
+      family: 'cdkl-start-alb-auth-web',
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'web',
+          image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+          essential: true,
+          entryPoint: ['python', '-c'],
+          command: [HELLO_SERVER],
+          memoryReservation: 32,
+          portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+        },
+      ],
+    });
+
+    const targetGroup = new elbv2.CfnTargetGroup(this, 'WebTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WebLB', {
+      type: 'application',
+    });
+
+    // HTTP listener with TWO default actions: authenticate-cognito (order 1)
+    // gates the request; forward (order 2) routes to the target group on
+    // allow. The cloud-side ALB requires authenticate-* actions to precede
+    // the terminal forward, and the local front-door follows the same
+    // order: only when AuthCheck.allow is true does the forward fire.
+    new elbv2.CfnListener(this, 'WebAuthListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [
+        {
+          type: 'authenticate-cognito',
+          order: 1,
+          authenticateCognitoConfig: {
+            // The local 401-branch fires before any JWKS lookup, and
+            // --no-verify-auth bypasses the check entirely, so these
+            // placeholder values never produce network traffic.
+            userPoolArn: 'arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_PLACEHOLDER',
+            userPoolClientId: 'placeholder-client-id',
+            userPoolDomain: 'placeholder-domain-does-not-resolve',
+            onUnauthenticatedRequest: 'deny',
+          },
+        },
+        {
+          type: 'forward',
+          order: 2,
+          targetGroupArn: targetGroup.ref,
+        },
+      ],
+    });
+
+    new ecs.CfnService(this, 'WebService', {
+      cluster: cluster.ref,
+      taskDefinition: taskDef.ref,
+      desiredCount: 2,
+      launchType: 'EC2',
+      loadBalancers: [
+        {
+          containerName: 'web',
+          containerPort: 80,
+          targetGroupArn: targetGroup.ref,
+        },
+      ],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-auth/package.json
+++ b/tests/integration/local-start-alb-auth/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-start-alb-auth",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb's authenticate-cognito guard (401 without token + --no-verify-auth bypass)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.4.0"
+}

--- a/tests/integration/local-start-alb-auth/pnpm-lock.yaml
+++ b/tests/integration/local-start-alb-auth/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.169.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0':
+    resolution: {integrity: sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.28.0
+      constructs: 10.6.0
+
+  constructs@10.6.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/tests/integration/local-start-alb-auth/tsconfig.json
+++ b/tests/integration/local-start-alb-auth/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-alb-auth/verify.sh
+++ b/tests/integration/local-start-alb-auth/verify.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-alb authenticate-cognito guard integ test
+#
+# Names an ALB whose default action is `authenticate-cognito` -> `forward`,
+# and walks the two ends of the local guard:
+#
+#   PHASE A — guard ENFORCING (default):
+#     `cdkl start-alb` (no --no-verify-auth)
+#     curl http://...  WITHOUT Authorization -> 401 + WWW-Authenticate: Bearer
+#
+#   PHASE B — guard BYPASSED:
+#     `cdkl start-alb --no-verify-auth`
+#     curl http://...  WITHOUT Authorization -> 200 "replica <hostname>"
+#
+# Together these prove the auth-check is wired into the front-door (401
+# fires before forward) AND that `--no-verify-auth` short-circuits the
+# whole check for local-dev convenience. JWT verification paths
+# (signature / iss / aud / exp against the JWKS / OIDC discovery URL)
+# are covered by `tests/unit/local/cognito-jwt.test.ts` — out of scope
+# here.
+#
+# Requires Docker.
+#
+#     bash tests/integration/local-start-alb-auth/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+WEB_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
+LB_HOST_PORT=18280
+
+CDKL_PID=""
+
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers + networks"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${WEB_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+# wait_for_boot — poll the cdkl log for the boot banner, then for the
+# front-door to start serving (which may take a few seconds longer than
+# the banner under slow Docker daemons).
+wait_for_boot() {
+  local out_file="$1"
+  for _ in $(seq 1 90); do
+    if grep -q "Service(s) running:" "${out_file}" 2>/dev/null; then
+      return 0
+    fi
+    if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+      echo "FAIL: cdk-local exited before reaching the boot banner"
+      echo "----- cdk-local output -----"; cat "${out_file}"; echo "----------------------------"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "FAIL: cdk-local did not reach the boot banner within 90s"
+  echo "----- cdk-local output -----"; cat "${out_file}"; echo "----------------------------"
+  return 1
+}
+
+# term_cdkl — gracefully tear down the currently-running cdkl front-door
+# between phase A and phase B so each phase starts from a clean slate.
+term_cdkl() {
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 1
+    done
+    wait "${CDKL_PID}" 2>/dev/null || true
+  fi
+  CDKL_PID=""
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+
+# =============================================================================
+# PHASE A — guard ENFORCING: no --no-verify-auth, no Authorization header.
+# =============================================================================
+PHASE_A_LOG=$(mktemp)
+trap 'rm -f "${PHASE_A_LOG}" "${PHASE_B_LOG:-}"; cleanup' EXIT
+
+echo ""
+echo "==> Phase A: cdkl start-alb (guard ENFORCING, no --no-verify-auth)"
+${CDKL} start-alb CdkLocalStartAlbAuthFixture:WebLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  > "${PHASE_A_LOG}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner"
+wait_for_boot "${PHASE_A_LOG}"
+
+# The front-door binds the listener port immediately after the boot banner.
+# Wait until the socket is accepting connections (any HTTP response code
+# is fine here — 401 is the expected one, and that proves the guard fires).
+echo "==> Waiting for the front-door to respond on host port ${LB_HOST_PORT}"
+SAW_RESPONSE=0
+for _ in $(seq 1 60); do
+  STATUS=$(curl -s -o /dev/null --max-time 5 -w '%{http_code}' "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null || true)
+  if [[ -n "${STATUS}" && "${STATUS}" != "000" ]]; then
+    SAW_RESPONSE=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the front-door"
+    echo "----- cdk-local output -----"; cat "${PHASE_A_LOG}"; echo "----------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${SAW_RESPONSE}" -ne 1 ]]; then
+  echo "FAIL: front-door never returned a response within 60s"
+  cat "${PHASE_A_LOG}"
+  exit 1
+fi
+
+echo "==> Asserting unauthenticated GET returns 401"
+# `-i` includes headers so we can also assert the WWW-Authenticate response
+# header tells the caller HOW to authenticate (Bearer realm).
+RESP=$(curl -sS -i --max-time 5 "http://127.0.0.1:${LB_HOST_PORT}/" 2>&1)
+STATUS_LINE=$(echo "${RESP}" | head -1)
+if ! echo "${STATUS_LINE}" | grep -qE 'HTTP/[0-9.]+ 401'; then
+  echo "FAIL: expected 401 from guard-enforcing front-door, got: ${STATUS_LINE}"
+  echo "----- response -----"; echo "${RESP}"; echo "--------------------"
+  exit 1
+fi
+if ! echo "${RESP}" | grep -qiE '^WWW-Authenticate:[[:space:]]*Bearer'; then
+  echo "FAIL: expected WWW-Authenticate: Bearer header on 401 response, got:"
+  echo "${RESP}"
+  exit 1
+fi
+echo "    OK: 401 + WWW-Authenticate: Bearer (guard fires before forward)"
+
+echo "==> Phase A: tearing down before phase B"
+term_cdkl
+rm -f "${PHASE_A_LOG}"
+
+# =============================================================================
+# PHASE B — guard BYPASSED: --no-verify-auth, no Authorization header.
+# =============================================================================
+PHASE_B_LOG=$(mktemp)
+
+echo ""
+echo "==> Phase B: cdkl start-alb --no-verify-auth (guard BYPASSED)"
+${CDKL} start-alb CdkLocalStartAlbAuthFixture:WebLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  --no-verify-auth \
+  > "${PHASE_B_LOG}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner"
+wait_for_boot "${PHASE_B_LOG}"
+
+echo "==> curl-ing the front-door until it serves 200 (replicas take a moment)"
+READY=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 5 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the bypassed front-door to serve"
+    cat "${PHASE_B_LOG}"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: bypassed front-door never returned a 200 within 60s"
+  cat "${PHASE_B_LOG}"
+  exit 1
+fi
+
+echo "==> Asserting unauthenticated GET returns 200 with replica body"
+BODY=$(curl -fsS --max-time 5 "http://127.0.0.1:${LB_HOST_PORT}/" 2>&1)
+if [[ ! "${BODY}" =~ ^replica\  ]]; then
+  echo "FAIL: bypassed front-door response did not start with 'replica '. Got: ${BODY}"
+  exit 1
+fi
+echo "    OK: 200 with body \"${BODY}\" (--no-verify-auth bypassed the guard)"
+
+echo "==> Phase B: tearing down"
+term_cdkl
+rm -f "${PHASE_B_LOG}"
+
+echo ""
+echo "==> local-start-alb-auth tests passed (guard 401 + --no-verify-auth bypass)"


### PR DESCRIPTION
## Summary

Last of the pre-launch integ-coverage punch list. `cdkl start-alb`'s
`authenticate-cognito` / `authenticate-oidc` action support had unit
tests for the JWT verification logic but no integ fixture proving the
guard is actually wired into the local front-door.

The fixture walks both ends of the auth-check contract in a single
verify.sh:

- **Phase A — guard ENFORCING** (`cdkl start-alb`, default): an
  unauthenticated `curl GET /` returns `401` with a
  `WWW-Authenticate: Bearer` response header. Proves the auth-check
  fires BEFORE the terminal forward action (the cloud-side ALB's
  authenticate-* -> forward ordering), and that the `WWW-Authenticate`
  header is correctly emitted on the deny branch.
- **Phase B — guard BYPASSED** (`cdkl start-alb --no-verify-auth`):
  same unauthenticated `curl GET /` returns `200` with the backing
  replica's `replica <hostname>` payload. Proves the bypass flag
  short-circuits the entire check.

## Scope choice

This fixture covers the **wiring**, not the cryptographic JWT path.
A meaningful Bearer-JWT test would require a mock JWKS / OIDC discovery
server with deterministic signing keys — significant scaffolding for a
verifier that is already covered by
`tests/unit/local/cognito-jwt.test.ts`. The wiring (auth-check is
invoked, the deny branch returns 401 with the right header, and
`--no-verify-auth` reaches its short-circuit) is exactly the layer the
unit tests do NOT exercise, so the two together produce full coverage
without duplicating effort.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass (104 files)
- [x] `vp run build` — `dist/cli.js` produced
- [x] `vp run test` — unit tests pass
- [x] `/run-integ local-start-alb-auth` — full Docker run, phase A
      returned `HTTP/1.1 401` + `WWW-Authenticate: Bearer`, phase B
      returned `200` with `replica 30356f9ea4fb`, 0 orphan
      containers / networks post-run, `integ` marker set.

## Notes for reviewers

The fixture uses placeholder `userPoolArn` / `userPoolDomain` /
`userPoolClientId` values because neither path makes a JWKS lookup —
the 401 branch fires before any network call and `--no-verify-auth`
skips the verifier entirely. This is the same pattern the
`front-door-auth.ts` source itself comments on (see the file header).

Two cdkl runs in one verify.sh (phase A teardown -> phase B start)
mirrors the multi-launch pattern from
`tests/integration/local-start-api/verify.sh`'s `--strict-sigv4`
sub-server.
