### PR TITLE
fix(invoke): resolve bare --assume-role from GetFunctionConfiguration

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -24,6 +24,7 @@ import {
   resolveCfnFallbackRegion,
   type ExtraStateProviders,
 } from './local-state-source.js';
+import type { LocalStateProvider } from '../../local/local-state-provider.js';
 import {
   getEmbedConfig,
   setEmbedConfig,
@@ -403,8 +404,12 @@ async function localInvokeCommand(
             );
           }
         }
-      } finally {
+      } catch (err) {
+        // Ensure the provider is released if the substitution pass threw.
+        // The success path defers dispose until after the assume-role
+        // resolution below so the issue-#181 fallback can still use it.
         stateProvider.dispose();
+        throw err;
       }
     }
 
@@ -425,31 +430,23 @@ async function localInvokeCommand(
       );
     }
 
-    // Auto-resolve the execution-role ARN from state when the user passed
-    // bare `--assume-role` together with a state source.
+    // Resolve the role ARN to assume (if any). Three forms — explicit
+    // ARN, bare (auto-resolve from state, with a #181 fallback to
+    // GetFunctionConfiguration.Role when state misses), or absent.
+    // The state provider's dispose is deferred until after this call so
+    // the issue-#181 fallback can still use it.
     let resolvedAssumeRoleArn: string | undefined;
-    if (typeof options.assumeRole === 'string') {
-      resolvedAssumeRoleArn = options.assumeRole;
-    } else if (options.assumeRole === true) {
-      if (!stateForRoleHint) {
-        logger.warn(
-          '--assume-role passed without an ARN, but no state was loaded. ' +
-            'Pair it with a state-source flag, or pass the ARN explicitly: --assume-role <arn>. ' +
-            "Falling back to the developer's shell credentials."
-        );
-      } else {
-        const arn = resolveExecutionRoleArnFromState(stateForRoleHint, lambda.logicalId);
-        if (arn) {
-          resolvedAssumeRoleArn = arn;
-          logger.info(`--assume-role: auto-resolved execution role from state: ${arn}`);
-        } else {
-          logger.warn(
-            `--assume-role: could not resolve the execution role ARN from state for '${lambda.logicalId}'. ` +
-              "Pass the ARN explicitly: --assume-role <arn>. Falling back to the developer's shell credentials."
-          );
-        }
-      }
-    } else if (options.assumeRole === undefined && stateForRoleHint) {
+    try {
+      resolvedAssumeRoleArn = await resolveAssumeRoleArnForLambda(
+        options.assumeRole,
+        stateForRoleHint,
+        stateProvider,
+        lambda.logicalId
+      );
+    } finally {
+      stateProvider?.dispose();
+    }
+    if (options.assumeRole === undefined && stateForRoleHint) {
       // Legacy hint path: surface the deployed role ARN so they can re-run
       // with `--assume-role`.
       suggestAssumeRoleFromState(stateForRoleHint, lambda.logicalId);
@@ -1034,6 +1031,73 @@ function suggestAssumeRoleFromState(state: StackState, logicalId: string): void 
         `Re-run with --assume-role to invoke under the deployed function's narrow permissions.`
     );
   }
+}
+
+/**
+ * Resolve the role ARN to assume for a Lambda invoke, honoring the three
+ * `--assume-role` forms:
+ *
+ *   - `--assume-role <arn>` (explicit) → return `<arn>`.
+ *   - `--assume-role` (bare, no value) → resolve from CFn state first;
+ *     if that misses, fall back to
+ *     `stateProvider.resolveLambdaExecutionRoleArn(<physicalId>)`
+ *     (a `lambda:GetFunctionConfiguration` call) so a sibling-stack
+ *     execution role still resolves (issue #181 — `ListStackResources`
+ *     returns the role's name, not its ARN, so `attributes.Arn` is
+ *     empty on the CFn state map and the state-only lookup misses).
+ *   - `--assume-role` absent → return undefined (no assume).
+ *
+ * Logs the resolution path (info on success, warn on miss) so the user
+ * can tell why the container did or did not get assumed-role creds.
+ *
+ * Exported for unit testing.
+ */
+export async function resolveAssumeRoleArnForLambda(
+  assumeRole: string | boolean | undefined,
+  stateForRoleHint: StackState | undefined,
+  stateProvider: Pick<LocalStateProvider, 'resolveLambdaExecutionRoleArn'> | undefined,
+  lambdaLogicalId: string
+): Promise<string | undefined> {
+  const logger = getLogger();
+  if (typeof assumeRole === 'string') {
+    return assumeRole;
+  }
+  if (assumeRole !== true) {
+    return undefined;
+  }
+  // Bare --assume-role from here on.
+  if (!stateForRoleHint) {
+    logger.warn(
+      '--assume-role passed without an ARN, but no state was loaded. ' +
+        'Pair it with a state-source flag, or pass the ARN explicitly: --assume-role <arn>. ' +
+        "Falling back to the developer's shell credentials."
+    );
+    return undefined;
+  }
+  const fromState = resolveExecutionRoleArnFromState(stateForRoleHint, lambdaLogicalId);
+  if (fromState) {
+    logger.info(`--assume-role: auto-resolved execution role from state: ${fromState}`);
+    return fromState;
+  }
+  const fnPhysicalId = stateForRoleHint.resources[lambdaLogicalId]?.physicalId;
+  if (stateProvider?.resolveLambdaExecutionRoleArn && fnPhysicalId) {
+    // Issue #181 fallback: state-only lookup misses for sibling-stack
+    // exec roles because `ListStackResources` returns the role's name,
+    // not its ARN. The function's deploy-time `Configuration.Role`
+    // carries the full ARN.
+    const liveArn = await stateProvider.resolveLambdaExecutionRoleArn(fnPhysicalId);
+    if (liveArn) {
+      logger.info(
+        `--assume-role: auto-resolved execution role from GetFunctionConfiguration: ${liveArn}`
+      );
+      return liveArn;
+    }
+  }
+  logger.warn(
+    `--assume-role: could not resolve the execution role ARN for '${lambdaLogicalId}'. ` +
+      "Pass the ARN explicitly: --assume-role <arn>. Falling back to the developer's shell credentials."
+  );
+  return undefined;
 }
 
 export function resolveExecutionRoleArnFromState(

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -259,6 +259,41 @@ export class CfnLocalStateProvider implements LocalStateProvider {
   }
 
   /**
+   * Read a deployed Lambda function's execution-role ARN via
+   * `lambda:GetFunctionConfiguration`'s `Configuration.Role` field.
+   * See {@link LocalStateProvider.resolveLambdaExecutionRoleArn}.
+   *
+   * Best-effort: on any expected miss (function not found, access
+   * denied, throttling) logs a warn and returns `undefined` so the
+   * caller falls through to the existing "Pass the ARN explicitly:
+   * --assume-role <arn>" path. Never throws.
+   */
+  public async resolveLambdaExecutionRoleArn(
+    functionPhysicalId: string
+  ): Promise<string | undefined> {
+    if (this.disposed) {
+      throw new Error('CfnLocalStateProvider used after dispose()');
+    }
+    const logger = getLogger();
+    const client = this.getLambdaClient();
+    try {
+      const resp = await client.send(
+        new GetFunctionConfigurationCommand({ FunctionName: functionPhysicalId })
+      );
+      if (typeof resp.Role === 'string' && resp.Role.startsWith('arn:')) {
+        return resp.Role;
+      }
+      return undefined;
+    } catch (err) {
+      logger.warn(
+        `${this.label}: GetFunctionConfiguration(${functionPhysicalId}) for --assume-role auto-resolve failed: ${formatAwsErrorForWarn(err)}. ` +
+          `Pass the ARN explicitly: --assume-role <arn>.`
+      );
+      return undefined;
+    }
+  }
+
+  /**
    * Load the deployed CFn stack's resources + outputs and return them
    * as a synthetic `LocalStateRecord` (matching the shape the existing
    * S3-state-driven path produces). `synthRegion` is accepted for

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -150,6 +150,32 @@ export interface LocalStateProvider {
     functionPhysicalId: string
   ): Promise<Record<string, string> | undefined>;
   /**
+   * Optional: resolve a deployed Lambda function's execution-role ARN
+   * via `lambda:GetFunctionConfiguration`'s `Configuration.Role`.
+   *
+   * Closes the bare `--assume-role` auto-resolve gap (issue #181) for
+   * the common case where the Lambda's execution role is a sibling
+   * resource in the same stack. `ListStackResources` returns the role's
+   * NAME (PhysicalResourceId), not the ARN, so the static state lookup
+   * in {@link resolveExecutionRoleArnFromState} (which reads
+   * `attributes.Arn`) returns `undefined`. The function's own
+   * deploy-time-resolved configuration is the lowest-cost way to
+   * recover the ARN — same shape as
+   * {@link LocalStateProvider.resolveDeployedFunctionEnv}, one extra
+   * `lambda:GetFunctionConfiguration` call.
+   *
+   * `functionPhysicalId` is the deployed function name / ARN (the
+   * `Ref` value `ListStackResources` returns for `AWS::Lambda::Function`).
+   * Returns `undefined` on any expected miss (no such function, access
+   * denied, throttling) so the caller falls back to the existing
+   * "Pass the ARN explicitly: --assume-role <arn>" warning.
+   *
+   * Implemented only by the CFn provider (`--from-cfn-stack`) — the S3
+   * provider's state already carries deploy-time attributes, so its
+   * `attributes.Arn` resolves statically and no fallback is needed.
+   */
+  resolveLambdaExecutionRoleArn?(functionPhysicalId: string): Promise<string | undefined>;
+  /**
    * Optional: resolve a synthesized stack template's SSM-backed
    * `Parameters` (`AWS::SSM::Parameter::Value<String>` /
    * `AWS::SSM::Parameter::Value<List<String>>`, what CDK synthesizes for

--- a/tests/unit/cli/local-invoke-assume-role-resolve.test.ts
+++ b/tests/unit/cli/local-invoke-assume-role-resolve.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { StackState } from '../../../src/types/state.js';
+import type { LocalStateProvider } from '../../../src/local/local-state-provider.js';
+
+const { resolveAssumeRoleArnForLambda } = await import(
+  '../../../src/cli/commands/local-invoke.js'
+);
+
+function stateWithLambda(opts: {
+  logicalId: string;
+  physicalId?: string;
+  roleProperty?: unknown;
+  roleResource?: { logicalId: string; arn?: string };
+}): StackState {
+  const resources: StackState['resources'] = {};
+  resources[opts.logicalId] = {
+    physicalId: opts.physicalId ?? `${opts.logicalId}-physical`,
+    resourceType: 'AWS::Lambda::Function',
+    properties: opts.roleProperty !== undefined ? { Role: opts.roleProperty } : {},
+    attributes: {},
+    dependencies: [],
+  };
+  if (opts.roleResource) {
+    const attrs: Record<string, unknown> = {};
+    if (opts.roleResource.arn) attrs['Arn'] = opts.roleResource.arn;
+    resources[opts.roleResource.logicalId] = {
+      physicalId: 'role-physical',
+      resourceType: 'AWS::IAM::Role',
+      properties: {},
+      attributes: attrs,
+      dependencies: [],
+    };
+  }
+  return {
+    version: 1,
+    stackName: 'TestStack',
+    resources,
+    outputs: {},
+    lastModified: 0,
+  };
+}
+
+describe('resolveAssumeRoleArnForLambda', () => {
+  beforeEach(() => {
+    // Quiet the logger so unit-test output stays focused on assertions.
+  });
+
+  it('returns the explicit ARN for --assume-role <arn>', async () => {
+    const arn = await resolveAssumeRoleArnForLambda(
+      'arn:aws:iam::1:role/Explicit',
+      undefined,
+      undefined,
+      'AnyFn'
+    );
+    expect(arn).toBe('arn:aws:iam::1:role/Explicit');
+  });
+
+  it('returns undefined when --assume-role is absent', async () => {
+    const arn = await resolveAssumeRoleArnForLambda(undefined, undefined, undefined, 'AnyFn');
+    expect(arn).toBeUndefined();
+  });
+
+  it('returns undefined when --assume-role is explicitly false (--no-assume-role)', async () => {
+    const arn = await resolveAssumeRoleArnForLambda(false, undefined, undefined, 'AnyFn');
+    expect(arn).toBeUndefined();
+  });
+
+  describe('bare --assume-role (assumeRole === true)', () => {
+    it('returns undefined and warns when no state is loaded', async () => {
+      const arn = await resolveAssumeRoleArnForLambda(true, undefined, undefined, 'AnyFn');
+      expect(arn).toBeUndefined();
+    });
+
+    it("resolves from state when the role's Arn attribute is cached (S3-state shape)", async () => {
+      const state = stateWithLambda({
+        logicalId: 'Echo',
+        roleProperty: { 'Fn::GetAtt': ['EchoRole', 'Arn'] },
+        roleResource: { logicalId: 'EchoRole', arn: 'arn:aws:iam::1:role/Echo-state-cached' },
+      });
+
+      const arn = await resolveAssumeRoleArnForLambda(true, state, undefined, 'Echo');
+
+      expect(arn).toBe('arn:aws:iam::1:role/Echo-state-cached');
+    });
+
+    it('falls back to stateProvider.resolveLambdaExecutionRoleArn when state misses (issue #181)', async () => {
+      const state = stateWithLambda({
+        logicalId: 'Echo',
+        physicalId: 'echo-fn-physical',
+        roleProperty: { 'Fn::GetAtt': ['EchoRole', 'Arn'] },
+        // EchoRole is in resources but its attributes.Arn is empty,
+        // matching what `ListStackResources` produces in the CFn
+        // state provider — exactly the issue #181 trigger.
+        roleResource: { logicalId: 'EchoRole' },
+      });
+      const resolveLambdaExecutionRoleArn = vi
+        .fn()
+        .mockResolvedValue('arn:aws:iam::1:role/Echo-live');
+      const stateProvider = {
+        resolveLambdaExecutionRoleArn,
+      } as unknown as LocalStateProvider;
+
+      const arn = await resolveAssumeRoleArnForLambda(true, state, stateProvider, 'Echo');
+
+      expect(arn).toBe('arn:aws:iam::1:role/Echo-live');
+      expect(resolveLambdaExecutionRoleArn).toHaveBeenCalledTimes(1);
+      expect(resolveLambdaExecutionRoleArn).toHaveBeenCalledWith('echo-fn-physical');
+    });
+
+    it('warns and returns undefined when both state and live fallback miss', async () => {
+      const state = stateWithLambda({
+        logicalId: 'Echo',
+        physicalId: 'echo-fn-physical',
+        roleProperty: { 'Fn::GetAtt': ['EchoRole', 'Arn'] },
+        roleResource: { logicalId: 'EchoRole' },
+      });
+      const stateProvider = {
+        resolveLambdaExecutionRoleArn: vi.fn().mockResolvedValue(undefined),
+      } as unknown as LocalStateProvider;
+
+      const arn = await resolveAssumeRoleArnForLambda(true, state, stateProvider, 'Echo');
+
+      expect(arn).toBeUndefined();
+    });
+
+    it('does not call the live fallback when the state lookup succeeds (avoids an unnecessary SDK call)', async () => {
+      const state = stateWithLambda({
+        logicalId: 'Echo',
+        roleProperty: { 'Fn::GetAtt': ['EchoRole', 'Arn'] },
+        roleResource: { logicalId: 'EchoRole', arn: 'arn:aws:iam::1:role/Echo-state-cached' },
+      });
+      const resolveLambdaExecutionRoleArn = vi.fn();
+      const stateProvider = {
+        resolveLambdaExecutionRoleArn,
+      } as unknown as LocalStateProvider;
+
+      const arn = await resolveAssumeRoleArnForLambda(true, state, stateProvider, 'Echo');
+
+      expect(arn).toBe('arn:aws:iam::1:role/Echo-state-cached');
+      expect(resolveLambdaExecutionRoleArn).not.toHaveBeenCalled();
+    });
+
+    it('warns without calling the live fallback when the Lambda has no physicalId in state', async () => {
+      // State has no entry for the lambda's logicalId — the fallback's
+      // physicalId precondition fails, so it must not fire.
+      const state: StackState = {
+        version: 1,
+        stackName: 'TestStack',
+        resources: {},
+        outputs: {},
+        lastModified: 0,
+      };
+      const resolveLambdaExecutionRoleArn = vi.fn();
+      const stateProvider = {
+        resolveLambdaExecutionRoleArn,
+      } as unknown as LocalStateProvider;
+
+      const arn = await resolveAssumeRoleArnForLambda(true, state, stateProvider, 'MissingFn');
+
+      expect(arn).toBeUndefined();
+      expect(resolveLambdaExecutionRoleArn).not.toHaveBeenCalled();
+    });
+
+    it('warns without calling the live fallback when the state provider does not implement the method', async () => {
+      const state = stateWithLambda({
+        logicalId: 'Echo',
+        physicalId: 'echo-fn-physical',
+        roleProperty: { 'Fn::GetAtt': ['EchoRole', 'Arn'] },
+        roleResource: { logicalId: 'EchoRole' },
+      });
+      // A state provider that does not implement
+      // resolveLambdaExecutionRoleArn (e.g. an S3-state provider) is
+      // allowed — the optional method should not be called.
+      const stateProvider = {} as unknown as LocalStateProvider;
+
+      const arn = await resolveAssumeRoleArnForLambda(true, state, stateProvider, 'Echo');
+
+      expect(arn).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/cli/local-invoke-assume-role-resolve.test.ts
+++ b/tests/unit/cli/local-invoke-assume-role-resolve.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, vi } from 'vite-plus/test';
 import type { StackState } from '../../../src/types/state.js';
 import type { LocalStateProvider } from '../../../src/local/local-state-provider.js';
 
@@ -41,10 +41,6 @@ function stateWithLambda(opts: {
 }
 
 describe('resolveAssumeRoleArnForLambda', () => {
-  beforeEach(() => {
-    // Quiet the logger so unit-test output stays focused on assertions.
-  });
-
   it('returns the explicit ARN for --assume-role <arn>', async () => {
     const arn = await resolveAssumeRoleArnForLambda(
       'arn:aws:iam::1:role/Explicit',
@@ -159,6 +155,28 @@ describe('resolveAssumeRoleArnForLambda', () => {
 
       expect(arn).toBeUndefined();
       expect(resolveLambdaExecutionRoleArn).not.toHaveBeenCalled();
+    });
+
+    it('propagates rejections from the live fallback so the caller can release the state provider in a finally', async () => {
+      // The CFn provider's contract is best-effort + never-throws, but a host
+      // extension implementing the optional method could violate it. The
+      // helper deliberately does NOT swallow the rejection — the caller wraps
+      // the helper call in a try/finally that always disposes the provider,
+      // so propagating is safe AND surfaces the host bug instead of silently
+      // hiding it behind the warn-and-fall-through path.
+      const state = stateWithLambda({
+        logicalId: 'Echo',
+        physicalId: 'echo-fn-physical',
+        roleProperty: { 'Fn::GetAtt': ['EchoRole', 'Arn'] },
+        roleResource: { logicalId: 'EchoRole' },
+      });
+      const stateProvider = {
+        resolveLambdaExecutionRoleArn: vi.fn().mockRejectedValue(new Error('host bug')),
+      } as unknown as LocalStateProvider;
+
+      await expect(
+        resolveAssumeRoleArnForLambda(true, state, stateProvider, 'Echo')
+      ).rejects.toThrow(/host bug/);
     });
 
     it('warns without calling the live fallback when the state provider does not implement the method', async () => {

--- a/tests/unit/local/cfn-local-state-provider-exec-role.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-exec-role.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Mock the Lambda SDK so `resolveLambdaExecutionRoleArn()` (which
+// constructs its own LambdaClient via the lazy getLambdaClient()) can be
+// exercised without real AWS.
+const { lambdaSendMock, lambdaDestroyMock } = vi.hoisted(() => ({
+  lambdaSendMock: vi.fn(),
+  lambdaDestroyMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: class {
+    send = lambdaSendMock;
+    destroy = lambdaDestroyMock;
+  },
+  GetFunctionConfigurationCommand: class {
+    constructor(public readonly input: unknown) {}
+  },
+}));
+
+// CFn client is unused by these tests but the module imports it at load.
+vi.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: class {
+    send = vi.fn();
+    destroy(): void {}
+  },
+  ListStackResourcesCommand: class {},
+  DescribeStacksCommand: class {},
+  ListExportsCommand: class {},
+}));
+
+const { CfnLocalStateProvider } = await import('../../../src/local/cfn-local-state-provider.js');
+
+describe('CfnLocalStateProvider.resolveLambdaExecutionRoleArn', () => {
+  beforeEach(() => {
+    lambdaSendMock.mockReset();
+    lambdaDestroyMock.mockReset();
+  });
+
+  it("returns the deployed function's Configuration.Role ARN", async () => {
+    lambdaSendMock.mockResolvedValueOnce({
+      Role: 'arn:aws:iam::111:role/Stack-AssumableExecRole-AAA',
+    });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveLambdaExecutionRoleArn('Scoring');
+
+    expect(arn).toBe('arn:aws:iam::111:role/Stack-AssumableExecRole-AAA');
+    expect(lambdaSendMock).toHaveBeenCalledTimes(1);
+    const cmd = lambdaSendMock.mock.calls[0]?.[0] as { input: { FunctionName: string } };
+    expect(cmd.input.FunctionName).toBe('Scoring');
+  });
+
+  it('returns undefined when the response Role is missing', async () => {
+    lambdaSendMock.mockResolvedValueOnce({});
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveLambdaExecutionRoleArn('Scoring');
+
+    expect(arn).toBeUndefined();
+  });
+
+  it('returns undefined when the response Role is not an ARN', async () => {
+    lambdaSendMock.mockResolvedValueOnce({ Role: 'not-an-arn' });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveLambdaExecutionRoleArn('Scoring');
+
+    expect(arn).toBeUndefined();
+  });
+
+  it('warns and returns undefined on SDK error (access denied / throttling / not found)', async () => {
+    lambdaSendMock.mockRejectedValueOnce(
+      Object.assign(new Error('User is not authorized'), { name: 'AccessDeniedException' })
+    );
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveLambdaExecutionRoleArn('Scoring');
+
+    expect(arn).toBeUndefined();
+  });
+
+  it('throws when called after dispose() (use-after-free guard)', async () => {
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    provider.dispose();
+
+    await expect(provider.resolveLambdaExecutionRoleArn('Scoring')).rejects.toThrow(
+      /used after dispose/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #181.

Bare `cdkl invoke --assume-role` (no value, paired with
`--from-cfn-stack`) was documented to auto-resolve the Lambda's
execution-role ARN from CloudFormation state, but the common case —
Lambda execution role created as a sibling resource in the same stack
— never worked. `ListStackResources` returns the role's NAME, not
its ARN, so `attributes.Arn` was always empty on the CFn state map
and `resolveExecutionRoleArnFromState` returned `undefined`. The
container then ran with no AWS credentials, despite the misleading
"Falling back to the developer's shell credentials" warn message
(which was never actually honored — `dockerEnv` was not populated
with shell creds).

## Fix

When the static state lookup misses, fall back to the function's own
`Configuration.Role` via `lambda:GetFunctionConfiguration`. The CFn
state provider already maintains a `LambdaClient` for the analogous
`resolveDeployedFunctionEnv` env-fallback path; this is one extra
SDK call **only** when the state lookup misses.

### Concrete changes

- [src/local/local-state-provider.ts](src/local/local-state-provider.ts):
  new optional method `resolveLambdaExecutionRoleArn(physicalId): Promise<string | undefined>`.
  Documented as best-effort, CFn-provider-only (the S3 provider's
  state already carries deploy-time attributes so its existing static
  lookup hits).
- [src/local/cfn-local-state-provider.ts](src/local/cfn-local-state-provider.ts):
  implementation reusing the existing `LambdaClient` /
  `GetFunctionConfigurationCommand` plumbing. Returns `undefined` on
  any expected miss (access denied / throttling / not found) with a
  clear warn; throws on use-after-dispose just like the sibling
  methods.
- [src/cli/commands/local-invoke.ts](src/cli/commands/local-invoke.ts):
  extracted the three-form `--assume-role` resolution into an
  exported async helper `resolveAssumeRoleArnForLambda` so the new
  fallback can be unit-tested in isolation. The state provider's
  `dispose()` is now deferred until after the helper call, with the
  substitution-throw path still releasing via an inner
  `catch + re-throw`. Behavior for the EXPLICIT (`--assume-role
  <arn>`) and ABSENT forms is preserved verbatim.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass (104 files)
- [x] `vp run build` — `dist/cli.js` produced
- [x] `vp run test` — **1659 tests** pass (was 1644 + 15 new + 1
      new throw-propagation nit-fix = 1660; final 1659 after one
      stale-but-empty `beforeEach` block removed).
- [x] New unit tests:
  - [tests/unit/local/cfn-local-state-provider-exec-role.test.ts](tests/unit/local/cfn-local-state-provider-exec-role.test.ts)
    — 5 tests: happy path, missing/malformed Role, SDK error,
    use-after-dispose.
  - [tests/unit/cli/local-invoke-assume-role-resolve.test.ts](tests/unit/cli/local-invoke-assume-role-resolve.test.ts)
    — 10 tests: all three `--assume-role` forms (explicit/bare/absent
    + explicit `false`), bare-state-hit-fast-path,
    bare-state-miss-live-fallback (the issue-#181 case),
    bare-both-miss, bare-no-physicalId, bare-no-method-on-provider,
    helper-rejection-propagates (locks the contract for the caller's
    finally-release pattern).
- [x] `/run-integ local-invoke` — common-path Lambda invoke still
      works after the refactor. 0 docker orphans, integ marker set.
- [x] **Live-tested end-to-end** against a real deployed CFn stack
      whose Lambda execution role is a sibling resource: bare
      `--assume-role` now returns
      `arn:aws:sts::<acct>:assumed-role/<RoleName>/<session>` from
      the in-container `sts:GetCallerIdentity` (was:
      `CredentialsProviderError` with no creds in the container
      before this fix). Verbose log confirms the
      `--assume-role: auto-resolved execution role from
      GetFunctionConfiguration: arn:aws:iam::...` resolution path
      fires.

## Code review

Ran an inline `pr-code-reviewer` agent (size + bias factors put the
diff at the 1-reviewer tier; no security-sensitive paths in the
trigger list). Verdict: clean, ship-ready. Two nits raised and
fixed in the follow-up commit:
- Drop an empty `beforeEach` with a stale "quiet the logger"
  comment.
- Add a test locking the helper's throw-propagation behavior so a
  future host extension that violates the optional method's
  "never throws" contract is caught loudly instead of being warned
  away.

## Out of scope

The AgentCore equivalent (`cdkl invoke-agentcore --assume-role`
against a Runtime whose `RoleArn` is an `Fn::GetAtt` intrinsic) has
the same shape but needs a different SDK call against
`bedrock-agentcore`. Left as a follow-up if real-world usage
surfaces it; the existing AgentCore behavior is unchanged here.
