### PR TITLE
docs(readme): inline LocalStack link + add Get-help section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cdkl invoke MyStack/Fn --from-cfn-stack    # one Lambda against real DynamoDB / 
 
 ## What runs locally
 
-cdk-local runs your **application compute** in Docker, using your CDK app as the source of truth. It deliberately does NOT emulate AWS managed services: your code reaches DynamoDB / S3 / Secrets Manager / Cognito / SNS / SQS / etc. as **real AWS** through your IAM credentials (`--assume-role`, or `--from-cfn-stack` to bind to a deployed stack). Want those offline too? Pair cdk-local with a service emulator like LocalStack — it does not bundle one.
+cdk-local runs your **application compute** in Docker, using your CDK app as the source of truth. It deliberately does NOT emulate AWS managed services: your code reaches DynamoDB / S3 / Secrets Manager / Cognito / SNS / SQS / etc. as **real AWS** through your IAM credentials (`--assume-role`, or `--from-cfn-stack` to bind to a deployed stack). Want those offline too? Pair cdk-local with a service emulator like [LocalStack](https://www.localstack.cloud/) — it does not bundle one.
 
 The locally executable resources are listed under [Supported resources](#supported-resources).
 
@@ -89,6 +89,11 @@ Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Pytho
 ## Programmatic use
 
 cdk-local also exports its commands as Commander factories so a host project can embed it into its own CLI, register custom state sources alongside the built-in `--from-cfn-stack`, and rebrand the embedded commands. See [docs/library-mode.md](docs/library-mode.md) for the API and an example.
+
+## Get help / contribute
+
+- **Bugs / feature requests**: file an issue at [github.com/go-to-k/cdk-local/issues](https://github.com/go-to-k/cdk-local/issues). The `bug_report` and `feature_request` templates ask for the smallest reliable repro shape.
+- **Contributing code or docs**: see [CONTRIBUTING.md](./CONTRIBUTING.md) for the dev environment setup, build / test commands, and PR checklist.
 
 ## License
 


### PR DESCRIPTION
## Summary

Last bit of pre-launch README polish — the post-#178/#184 README is
already in good shape (3-bullet "Picks up where", invoke-agentcore in
the tagline, library-mode link present), so this PR only addresses the
two remaining first-time-visitor gaps:

- **Inline LocalStack link**. The "Pair cdk-local with a service
  emulator like LocalStack" line now links to
  <https://www.localstack.cloud/> so the reader can follow up without
  leaving the README.
- **New "Get help / contribute" section** right before License,
  pointing at the issues tab (where the bug_report / feature_request
  templates live) and CONTRIBUTING.md. Closes the gap where a visitor
  who wants to file a bug or contribute had no in-README pointer to
  where to go.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass (104 files)
- [x] Visual diff of README confirmed: only the two intended changes.
  No regressions in tone, structure, or section ordering.

## Out of scope

The initial README review also flagged optional polish that
subsequent work (#170 "trim README appeal flow" + #178 + #184)
already addressed: 3-bullet "Picks up where", invoke-agentcore in
the tagline, library-mode.md link in Programmatic use, downloads
badge. Re-checked fresh; no further polish needed for launch.
