### PR TITLE
test(integ): restore bare --assume-role coverage after #185 fix

### DIFF
--- a/tests/integration/local-invoke-assume-role/verify.sh
+++ b/tests/integration/local-invoke-assume-role/verify.sh
@@ -19,13 +19,12 @@
 #         assumed-role identity leaks in.
 #   2. Explicit: `cdkl invoke --from-cfn-stack <stack> --assume-role <arn>`
 #      -> Lambda sees `arn:aws:sts::<account>:assumed-role/<RoleName>/<...>`.
-#
-# The bare form (`--assume-role` with no value) is NOT covered here. With
-# the current CFn state provider it auto-resolves to `undefined` for any
-# Lambda whose execution role is a sibling resource in the same stack —
-# `attributes.Arn` is never populated from `ListStackResources` (which
-# returns PhysicalResourceId, the role NAME, not the ARN). Tracked as
-# issue #181 so this fixture covers what does work today.
+#   3. Bare:     `cdkl invoke --from-cfn-stack <stack> --assume-role`
+#      -> cdkl auto-resolves the exec-role ARN. The static state lookup
+#         misses on a sibling-stack role (`ListStackResources` returns the
+#         role's name, not its ARN), so the live fallback via
+#         `lambda:GetFunctionConfiguration.Role` covers this case (#181 /
+#         #185). Same assumed-role marker as test 2.
 #
 # Run via `/run-integ local-invoke-assume-role` (recommended) or directly:
 #
@@ -172,7 +171,19 @@ echo "${RESULT_EXPLICIT}" | grep -q "${ASSUMED_RE}" || {
 }
 echo "[verify]   ok: explicit --assume-role <arn> assumed the role; Lambda saw assumed-role identity"
 
-echo "[verify] step 7: cdk destroy --force"
+echo "[verify] step 7: bare --assume-role — auto-resolve from CFn state + GetFunctionConfiguration fallback (#185)"
+echo "[verify]   expect the same assumed-role/${ROLE_NAME} marker, but via auto-resolution"
+RESULT_BARE=$(invoke_capture "${STACK}/EchoIdentityHandler" --from-cfn-stack --assume-role)
+echo "[verify]   response: ${RESULT_BARE}"
+echo "${RESULT_BARE}" | grep -q "${ASSUMED_RE}" || {
+  echo "[verify] FAIL: expected assumed-role pattern ${ASSUMED_RE}* under bare --assume-role (auto-resolve fallback), got: ${RESULT_BARE}"
+  echo "[verify]   stderr re-run (look for 'auto-resolved execution role from GetFunctionConfiguration' info line):"
+  ${CLI} invoke "${STACK}/EchoIdentityHandler" --from-cfn-stack --assume-role --no-pull 2>&1 | tail -15
+  exit 1
+}
+echo "[verify]   ok: bare --assume-role auto-resolved via GetFunctionConfiguration; Lambda saw assumed-role identity"
+
+echo "[verify] step 8: cdk destroy --force"
 cdk destroy "${STACK}" --force --region "${REGION}" \
   --no-version-reporting --no-asset-metadata --no-path-metadata
 WE_CREATED_STACK=0
@@ -181,3 +192,4 @@ echo ""
 echo "[verify] All checks passed:"
 echo "[verify]   - baseline (no --assume-role): container has no AWS creds (cdkl does not auto-inject the shell credentials); STS fails with CredentialsProviderError."
 echo "[verify]   - explicit --assume-role <arn>: Lambda sees arn:aws:sts::<acct>:assumed-role/<RoleName>/<session>."
+echo "[verify]   - bare --assume-role (auto-resolve): same marker; the GetFunctionConfiguration.Role live fallback (#185) covers the sibling-stack-role case the static state lookup misses."


### PR DESCRIPTION
## Summary

Follow-up to #185 (the bare `--assume-role` fix). When the
`local-invoke-assume-role` fixture landed in #182 the bare-form test
case was intentionally dropped because the auto-resolve path was
broken for the common same-stack exec-role case (filed as #181). #185
fixed that gap by adding a `GetFunctionConfiguration.Role` live
fallback, so the bare-form test is now meaningful again.

This PR restores it as step 7 of the integ. The fixture now covers
all three documented `--assume-role` forms end-to-end against a real
deployed CFn stack:

- Step 5 — baseline (no `--assume-role`): container has no AWS creds;
  STS fails with `CredentialsProviderError`. Guards against implicit
  credential injection.
- Step 6 — explicit `--assume-role <arn>`: Lambda sees
  `arn:aws:sts::<acct>:assumed-role/<RoleName>/<session>`.
- Step 7 (**new**) — bare `--assume-role`: static state lookup misses
  (the role is a sibling resource in the same stack); the
  `lambda:GetFunctionConfiguration.Role` live fallback (added in #185)
  recovers the ARN; Lambda sees the same assumed-role marker as step 6.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass (104 files).
- [x] `vp run build` — `dist/cli.js` produced.
- [x] `/run-integ local-invoke-assume-role` — all three steps passed
      against a real deployed stack. The bare-form response was
      `arn:aws:sts::531991745243:assumed-role/CdkLocalInvokeAssumeRoleF-AssumableExecRole593EF03D-qOlpALnna19K/cdkl-invoke-1780141230693`
      — exactly the assumed-role marker the live fallback should
      produce. `cdk destroy` succeeded, 0 docker orphans, 0 AWS orphan
      stacks, `integ` marker set.

## Notes for reviewers

This is the regression test for the #185 fix: a future refactor that
silently re-broke the `GetFunctionConfiguration.Role` fallback path
would fail this integ. Pairs naturally with the unit tests added in
#185 (which lock the helper's behavior without needing AWS).
