### PR TITLE
docs(readme): drop Get-help / contribute section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,6 @@ Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Pytho
 
 cdk-local also exports its commands as Commander factories so a host project can embed it into its own CLI, register custom state sources alongside the built-in `--from-cfn-stack`, and rebrand the embedded commands. See [docs/library-mode.md](docs/library-mode.md) for the API and an example.
 
-## Get help / contribute
-
-- **Bugs / feature requests**: file an issue at [github.com/go-to-k/cdk-local/issues](https://github.com/go-to-k/cdk-local/issues). The `bug_report` and `feature_request` templates ask for the smallest reliable repro shape.
-- **Contributing code or docs**: see [CONTRIBUTING.md](./CONTRIBUTING.md) for the dev environment setup, build / test commands, and PR checklist.
-
 ## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary

Revert the "Get help / contribute" section added in #186 per
maintainer feedback ("project is not actively soliciting external
contributions"). CONTRIBUTING.md (added in #184) remains in the repo
for anyone who DOES want to contribute, but the README no longer
advertises it from the front door.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass.
- [x] Visual diff: only the 6 lines of the "Get help / contribute"
      section are removed; nothing else changes.
