### PR TITLE
feat(exports): expose ecs-service-emulator + elb-front-door-resolver for shim consumers

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -437,3 +437,58 @@ export { resolveWatchConfig, type CdkWatchConfig } from './cli/config-loader.js'
  * `local-invoke-agentcore` port.
  */
 export { resolveSingleTarget } from './local/target-picker.js';
+
+/**
+ * `start-service` + `start-alb` shared ECS service emulator engine — the
+ * core orchestrator that boots ECS replicas on docker, attaches the per-stack
+ * Cloud Map / Service Connect overlay, optionally fronts the replicas with
+ * the local ALB front-door HTTP(S) server (`--alb-listener`), and tears
+ * down on SIGINT. `runEcsServiceEmulator` is the entry point both CLI
+ * commands wrap. `addCommonEcsServiceOptions` is the shared option-block
+ * factory both commands compose. `parseMaxTasks` / `parseRestartPolicy`
+ * are the option-parser helpers. `resolveSharedSidecarCredentials` and
+ * `buildEcsImageResolutionContext` are pre-boot helpers exposed for hosts
+ * that wrap the engine for their own test setup. `MAX_TASKS_SUBNET_RANGE_CAP`
+ * documents the per-network replica cap. The `Planned*` / `ServiceBoot`
+ * / `EmulatorStrategy` / `FrontDoorPlan` types describe the engine's
+ * pre-boot plan + strategy hook surface for shim hosts (e.g. cdkd) that
+ * port the CLI commands themselves but reuse the engine. Exposed only as
+ * the consuming host's `import` statements require them.
+ */
+export {
+  addCommonEcsServiceOptions,
+  runEcsServiceEmulator,
+  parseMaxTasks,
+  parseRestartPolicy,
+  resolveSharedSidecarCredentials,
+  buildEcsImageResolutionContext,
+  MAX_TASKS_SUBNET_RANGE_CAP,
+  type EcsServiceEmulatorOptions,
+  type EmulatorStrategy,
+  type ServiceBoot,
+  type FrontDoorPlan,
+  type PlannedAction,
+  type PlannedForwardAction,
+  type PlannedRedirectAction,
+  type PlannedFixedResponseAction,
+  type PlannedForwardTarget,
+  type PlannedEcsForwardTarget,
+  type PlannedLambdaForwardTarget,
+  type PlannedFrontDoorListener,
+} from './cli/commands/ecs-service-emulator.js';
+
+/**
+ * `start-alb` front-door target resolver — maps an ALB target string to a
+ * `ResolvedFrontDoor` (listener-by-listener forwarded targets, listener-rule
+ * conditions, redirect / fixed-response actions, plus `default_action`).
+ * `resolveAlbFrontDoor` is the entry point; `isApplicationLoadBalancer`
+ * is the type-narrowing predicate the resolver uses for ApplicationLoadBalancer
+ * vs NetworkLoadBalancer disambiguation. Exposed only as the consuming
+ * host's `import` statements require them.
+ */
+export {
+  resolveAlbFrontDoor,
+  isApplicationLoadBalancer,
+  type ResolvedListenerAction,
+  type FrontDoorForwardTarget,
+} from './local/elb-front-door-resolver.js';


### PR DESCRIPTION
## Summary

Expose the `start-service` + `start-alb` shared ECS service emulator engine + the ALB front-door target resolver from `cdk-local/internal` for shim consumers — specifically cdkd, whose planned `local-start-alb` port (plus the parallel `local-start-service` refactor) needs them.

Follow-up to [#177](https://github.com/go-to-k/cdk-local/pull/177) (released as cdk-local 0.61.0), which cdkd consumed for the `local-invoke-agentcore` port ([cdkd #717](https://github.com/go-to-k/cdkd/pull/717), merged earlier today).

## Exports added (`src/internal.ts`)

From **`cli/commands/ecs-service-emulator.ts`** (the shared engine both `local-start-service` and `local-start-alb` wrap):

- `runEcsServiceEmulator` — engine entry point
- `addCommonEcsServiceOptions` — shared option-block factory
- `parseMaxTasks` / `parseRestartPolicy` — option parsers
- `resolveSharedSidecarCredentials` / `buildEcsImageResolutionContext` — pre-boot helpers
- `MAX_TASKS_SUBNET_RANGE_CAP` — documented per-network replica cap
- Pre-boot plan + strategy hook surface: `EcsServiceEmulatorOptions` / `EmulatorStrategy` / `ServiceBoot` / `FrontDoorPlan` / `PlannedAction` / `PlannedForwardAction` / `PlannedRedirectAction` / `PlannedFixedResponseAction` / `PlannedForwardTarget` / `PlannedEcsForwardTarget` / `PlannedLambdaForwardTarget` / `PlannedFrontDoorListener` types

From **`local/elb-front-door-resolver.ts`**:

- `resolveAlbFrontDoor` — entry point that maps an ALB target to per-listener forwarded targets
- `isApplicationLoadBalancer` — type-narrowing predicate
- `ResolvedListenerAction` / `FrontDoorForwardTarget` — types

## Non-goals

- **Transitive ALB module surface stays unexposed** — `front-door-server` / `front-door-pool` / `front-door-lambda-runner` / `alb-lambda-event` / `alb-path-matcher` are reachable only through the engine entry point. Consuming hosts that want fine-grained access can ask for it in a follow-up PR.
- No behavior change. Existing consumers unaffected.

## Test plan

- [x] `vp run typecheck`: pass
- [x] `vp run test`: pass
- [x] `vp run build`: pass
- [x] `/run-integ local-start-alb` (from this worktree): pass — front-door round-robined 2 replicas, clean teardown (sidecar + ECS replicas + ALB front-door socket all torn down on SIGTERM)
