### PR TITLE
test(integ): cover full JWT verification path in start-alb auth

### DIFF
--- a/tests/integration/local-start-alb-auth-jwks/.scenarios.json
+++ b/tests/integration/local-start-alb-auth-jwks/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-alb-front-door"
+  ]
+}

--- a/tests/integration/local-start-alb-auth-jwks/bin/app.ts
+++ b/tests/integration/local-start-alb-auth-jwks/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbAuthJwksStack } from '../lib/local-start-alb-auth-jwks-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbAuthJwksStack(app, 'CdkLocalStartAlbAuthJwksFixture', {
+  description:
+    'Fixture stack for cdkl start-alb authenticate-oidc full JWT-verification integ test',
+});

--- a/tests/integration/local-start-alb-auth-jwks/cdk.json
+++ b/tests/integration/local-start-alb-auth-jwks/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-auth-jwks/jwks-sidecar.mjs
+++ b/tests/integration/local-start-alb-auth-jwks/jwks-sidecar.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// JWKS sidecar for the local-start-alb-auth-jwks integ test.
+//
+// Serves the two endpoints the local front-door's authenticate-oidc
+// verifier may reach:
+//
+//   GET /.well-known/openid-configuration -> { issuer, jwks_uri }
+//   GET /.well-known/jwks.json            -> { keys: [<RSA public JWK>] }
+//
+// The front-door only fetches the JWKS endpoint for an authenticate-oidc
+// action — the discovery endpoint is here for parity with the AgentCore
+// customJwtAuthorizer flow and so a future verifier change that switches
+// to discovery would Just Work without rewiring the fixture.
+//
+// The RSA key pair is hard-coded for test reproducibility. THIS KEY IS
+// PUBLIC — DO NOT REUSE IT FOR ANY PRODUCTION PURPOSE. Anyone reading
+// this file can mint tokens that the sidecar will accept.
+//
+// Usage:
+//   node jwks-sidecar.mjs [port]
+// Defaults to port 19000. verify.sh starts it on port 19000 to match
+// the issuer URL embedded in the fixture stack
+// (lib/local-start-alb-auth-jwks-stack.ts).
+
+import { createServer } from 'node:http';
+import { createPublicKey } from 'node:crypto';
+
+// Embedded RSA-2048 private key (PEM, PKCS#8). The matching public JWK
+// is derived from it at boot so the two never drift out of sync.
+// `kid` is fixed so the verify-side signer + the JWKS response agree.
+export const SIDECAR_KID = 'cdkl-integ-key-1';
+
+export const SIDECAR_PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC93iCdU4zZ2250
+E8mmLwgZP7iybzsvuAHmcBIUkw+1ZCtWD1WatU/Ob5k7nvggF1aVMdYg9bHbd6Ud
+L8+AJsaXIVxLd2oVjoOYCE0k0ipG19wug+4Tuuq6ANF/iyWkoON0WE1J6SREI35R
+bvR7km7P2PkpsGAG4dUMOcxDrCzykorhrr7CzLw0CkgGwSZOMWj155TJFVmANlVI
+CWd5dUbR69eEFoJfD93ZMy2+LQrGmdGmb6BoLw0FBacu7UJ9de5dWfFx3NDrrRFe
+Cu9swsKbUPvIa4ryDhcUh0b/a2vuL+wvegrnGED4HCR/b+3bVhqj+eWGCgzFA+Xm
+c4WyID8nAgMBAAECggEABbP01dTrH6YUKL9paKjz/NIpqY5mwDWuNO471MtgBupF
+1PVr9FQq3AAFIcHSISCiVKPlEyNeHsH2vywu9uHzSBnT7F5fXNtlf30MWCVJ6MvW
+DL2guo38O+8HW+XhkRLWEioO1EAA+1z3j9md1VJeKrcRMNvf3oUNAauAw62ZwgVw
+gNejKiyF3h4k2Ff8Xi33ltlGEPg16dPVKs063ZItBcUaX30x7Vq7vasbdut2dwfv
+xpaDrS/Jzp0BDv393M+i4NlnD13xI0Bea3LibqMoutvSnTgyOZTc7UtzVCoIvmk7
+gT1gE7F//7nyfZahYIr8TaEPyeFkU5SxS1HqLsv+AQKBgQDzA7905+5Iqr54GWLT
+THK+RltHzOhJghxYuecFFaGSZr78cmieuSbne2INn0gWQyGOEQDG1mSmwGr837Dy
+5DjfesyudWfPIQS/GiNfB3fLoI/Y1D0rgmYAHGfYspbwUttY6PY/rGXhBp1Kh4uu
+hr3EMp9Gar52mIQkB21d/ha5JwKBgQDIA17N0D7gbvW5oCRLkpMyFwTueS5xdXQs
++xAn5OT9MA1M6hIaMmgB0tCnLBqMzQZd6lEZdko83EPV8PGun98CNQfospbiS3gu
+ZUmSJgMyBOQwJfMDU2y4uo+U2DHN7zbvaxLvkZ/AvB4h4WCknZHrl92n5HTZm34l
+4G1pvYIKAQKBgE7PmlnJleePKDI+2WP5WQUIQDYq5/Je9d54e8mUWE/obmvklrVT
+CqDrzMLqMzC1GL7AGOZjRUUnBgt4aCR9i0w+wP6bKM1tweJQEcSR4XHyYnRJcIUZ
+xwamL6+BS54o4OYWtzWzLV8rC/vNtakmHYjxeeIWYCqKD+C3X+qpqqjlAoGAAqiA
+zw1weH0hCOmG8fYtvKGvsBeuNVXRSHPBwDX7kR3dX2NRAEYhObz6hu5AIBTte7wM
+feEjlXF7+VDtdVuslBPuWfpdpP5Jx5wTAT0+F6EXA0jN1QJ71GyuUdUZvFnsifwL
+UWHHFMGrSNn89dMeSFpJWNzhbK7zWz+DVL9vBgECgYAQyeEQrmtAHDfku0MmJvMT
+sp4lJk01wyK7TJd8mKWnFczqtRrT0UqH5YQaLtiEd3VniTp7LCZJC/4hPjOMNFEy
+8sjVUrpTeGS1G77vWr0+R661GZizqNIkv2zQUBQjQHxM8/8SrQ5Sxhc0be/M7Ifk
+aLIXaXH76Nx8J1zO9+o53A==
+-----END PRIVATE KEY-----
+`;
+
+// The matching SPKI public key — handy for debugging; the served JWK is
+// derived from this. Kept in source so a casual reader can verify the
+// keypair without running Node.
+export const SIDECAR_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvd4gnVOM2dtudBPJpi8I
+GT+4sm87L7gB5nASFJMPtWQrVg9VmrVPzm+ZO574IBdWlTHWIPWx23elHS/PgCbG
+lyFcS3dqFY6DmAhNJNIqRtfcLoPuE7rqugDRf4slpKDjdFhNSekkRCN+UW70e5Ju
+z9j5KbBgBuHVDDnMQ6ws8pKK4a6+wsy8NApIBsEmTjFo9eeUyRVZgDZVSAlneXVG
+0evXhBaCXw/d2TMtvi0KxpnRpm+gaC8NBQWnLu1CfXXuXVnxcdzQ660RXgrvbMLC
+m1D7yGuK8g4XFIdG/2tr7i/sL3oK5xhA+Bwkf2/t21Yao/nlhgoMxQPl5nOFsiA/
+JwIDAQAB
+-----END PUBLIC KEY-----
+`;
+
+function buildJwk() {
+  const publicKey = createPublicKey(SIDECAR_PUBLIC_KEY_PEM);
+  const jwk = publicKey.export({ format: 'jwk' });
+  return {
+    ...jwk,
+    kid: SIDECAR_KID,
+    alg: 'RS256',
+    use: 'sig',
+  };
+}
+
+function main() {
+  const port = Number.parseInt(process.argv[2] ?? '19000', 10);
+  const host = '127.0.0.1';
+  const issuer = `http://${host}:${port}`;
+  const jwk = buildJwk();
+
+  const server = createServer((req, res) => {
+    const url = req.url ?? '/';
+    if (url === '/.well-known/openid-configuration') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          issuer,
+          jwks_uri: `${issuer}/.well-known/jwks.json`,
+          authorization_endpoint: `${issuer}/authorize`,
+          token_endpoint: `${issuer}/token`,
+          userinfo_endpoint: `${issuer}/userinfo`,
+          id_token_signing_alg_values_supported: ['RS256'],
+        })
+      );
+      return;
+    }
+    if (url === '/.well-known/jwks.json') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ keys: [jwk] }));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('not found\n');
+  });
+
+  server.listen(port, host, () => {
+    process.stdout.write(`jwks-sidecar listening on ${issuer}\n`);
+  });
+
+  for (const sig of ['SIGINT', 'SIGTERM']) {
+    process.on(sig, () => {
+      server.close(() => process.exit(0));
+    });
+  }
+}
+
+// Run when invoked directly (node jwks-sidecar.mjs). Importable for tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/integration/local-start-alb-auth-jwks/lib/local-start-alb-auth-jwks-stack.ts
+++ b/tests/integration/local-start-alb-auth-jwks/lib/local-start-alb-auth-jwks-stack.ts
@@ -1,0 +1,135 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { Construct } from 'constructs';
+
+/**
+ * Fixture for `cdkl start-alb` authenticate-oidc full JWT-verification path.
+ *
+ * Complements the sibling `local-start-alb-auth` fixture, which covers the
+ * "no token -> 401" + "--no-verify-auth -> bypass" wiring with a placeholder
+ * Cognito ARN. This fixture wires the listener's `authenticate-oidc` action
+ * at a LOCAL OIDC issuer URL backed by a JWKS sidecar that `verify.sh`
+ * spawns alongside `cdkl start-alb`. That lets the test mint JWTs the
+ * sidecar's public key can verify, exercising the real verification path
+ * (signature + `iss` + `aud` + `exp`) end-to-end.
+ *
+ * The Issuer string is the only URL the local front-door needs — the JWKS
+ * URL is computed by the verifier as `<issuer>/.well-known/jwks.json`
+ * (`src/local/cognito-jwt.ts` -> `buildJwksUrlFromIssuer`). The matching
+ * sidecar serves both:
+ *
+ *   - `GET /.well-known/openid-configuration` -> `{issuer, jwks_uri}`
+ *   - `GET /.well-known/jwks.json`           -> `{ keys: [<RSA public JWK>] }`
+ *
+ * The local front-door does NOT fetch the discovery document for an
+ * `authenticate-oidc` action (it goes straight to the JWKS URL); the
+ * discovery endpoint is there for future-proofing + parity with the
+ * AgentCore `customJwtAuthorizer` discovery flow.
+ *
+ * `authenticate-cognito` cannot be retargeted at a local issuer because
+ * the verifier hardcodes Cognito's JWKS URL to
+ * `https://cognito-idp.<region>.amazonaws.com/<userPoolId>/.well-known/jwks.json`
+ * from the UserPoolArn — there is no escape hatch. `authenticate-oidc`
+ * is the only authenticate-* shape that can point at a local JWKS, so
+ * the JWT-verification integ ships under it.
+ */
+const HELLO_SERVER = [
+  'import http.server,socket',
+  'class H(http.server.BaseHTTPRequestHandler):',
+  ' def do_GET(s):',
+  "  b=('replica '+socket.gethostname()+chr(10)).encode()",
+  "  s.send_response(200);s.send_header('Content-Length',str(len(b)));s.end_headers();s.wfile.write(b)",
+  ' def log_message(s,*a):pass',
+  "http.server.HTTPServer(('0.0.0.0',80),H).serve_forever()",
+].join('\n');
+
+/**
+ * Sidecar issuer URL. Must match `JWKS_SIDECAR_ISSUER` in verify.sh — the
+ * sidecar listens on this host:port, and the local front-door fetches
+ * `<issuer>/.well-known/jwks.json` from it.
+ */
+const SIDECAR_ISSUER = 'http://127.0.0.1:19000';
+const SIDECAR_CLIENT_ID = 'cdkl-test-client';
+
+export class LocalStartAlbAuthJwksStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-alb-auth-jwks-fixture',
+    });
+
+    const taskDef = new ecs.CfnTaskDefinition(this, 'WebTask', {
+      family: 'cdkl-start-alb-auth-jwks-web',
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'web',
+          image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+          essential: true,
+          entryPoint: ['python', '-c'],
+          command: [HELLO_SERVER],
+          memoryReservation: 32,
+          portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+        },
+      ],
+    });
+
+    const targetGroup = new elbv2.CfnTargetGroup(this, 'WebTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WebLB', {
+      type: 'application',
+    });
+
+    // HTTP listener: authenticate-oidc (order 1) gates the request against
+    // the LOCAL JWKS sidecar; forward (order 2) routes to the target group
+    // on allow.
+    new elbv2.CfnListener(this, 'WebAuthListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [
+        {
+          type: 'authenticate-oidc',
+          order: 1,
+          authenticateOidcConfig: {
+            issuer: SIDECAR_ISSUER,
+            // Cloud ALB requires all three endpoints, but the local
+            // front-door never contacts them — only the issuer + JWKS
+            // URL are touched. Placeholders are sufficient.
+            authorizationEndpoint: `${SIDECAR_ISSUER}/authorize`,
+            tokenEndpoint: `${SIDECAR_ISSUER}/token`,
+            userInfoEndpoint: `${SIDECAR_ISSUER}/userinfo`,
+            clientId: SIDECAR_CLIENT_ID,
+            clientSecret: 'placeholder-not-used-locally',
+            onUnauthenticatedRequest: 'deny',
+          },
+        },
+        {
+          type: 'forward',
+          order: 2,
+          targetGroupArn: targetGroup.ref,
+        },
+      ],
+    });
+
+    new ecs.CfnService(this, 'WebService', {
+      cluster: cluster.ref,
+      taskDefinition: taskDef.ref,
+      desiredCount: 2,
+      launchType: 'EC2',
+      loadBalancers: [
+        {
+          containerName: 'web',
+          containerPort: 80,
+          targetGroupArn: targetGroup.ref,
+        },
+      ],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-auth-jwks/package.json
+++ b/tests/integration/local-start-alb-auth-jwks/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-start-alb-auth-jwks",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb's authenticate-oidc full JWT verification (signature + iss + aud + exp) against a local JWKS sidecar",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.4.0"
+}

--- a/tests/integration/local-start-alb-auth-jwks/pnpm-lock.yaml
+++ b/tests/integration/local-start-alb-auth-jwks/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.169.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==, tarball: https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==, tarball: https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0':
+    resolution: {integrity: sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==, tarball: https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==, tarball: https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.28.0
+      constructs: 10.6.0
+
+  constructs@10.6.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/tests/integration/local-start-alb-auth-jwks/sign-jwt.mjs
+++ b/tests/integration/local-start-alb-auth-jwks/sign-jwt.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Mint a JWT signed by the JWKS sidecar's embedded RSA-2048 private key,
+// so the local front-door's authenticate-oidc verifier accepts (or, in
+// the negative-path tests, rejects) it.
+//
+// Usage:
+//   node sign-jwt.mjs --iss <issuer> --aud <audience> --exp-offset <seconds>
+//
+// `--exp-offset` is added to `now` to compute the `exp` claim. Negative
+// values mint an already-expired token (used by the expired-JWT phase).
+//
+// All claims:
+//   iss   = --iss
+//   aud   = --aud
+//   sub   = "integ-test-subject"
+//   iat   = now (seconds)
+//   exp   = now + --exp-offset (seconds)
+//   token_use = "id"
+//
+// The signed JWT is printed to stdout on a single line, no trailing
+// newline characters in the token itself.
+
+import { createSign } from 'node:crypto';
+import { SIDECAR_PRIVATE_KEY_PEM, SIDECAR_KID } from './jwks-sidecar.mjs';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key || !key.startsWith('--') || value === undefined) {
+      throw new Error(`bad arg pair near '${key}'`);
+    }
+    out[key.slice(2)] = value;
+  }
+  return out;
+}
+
+function base64UrlEncode(buf) {
+  return buf
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const iss = args['iss'];
+  const aud = args['aud'];
+  const expOffset = Number.parseInt(args['exp-offset'] ?? '300', 10);
+  if (!iss || !aud) {
+    process.stderr.write('usage: sign-jwt.mjs --iss <issuer> --aud <audience> --exp-offset <seconds>\n');
+    process.exit(2);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT', kid: SIDECAR_KID };
+  const payload = {
+    iss,
+    aud,
+    sub: 'integ-test-subject',
+    iat: now,
+    exp: now + expOffset,
+    token_use: 'id',
+  };
+
+  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(header), 'utf-8'));
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload), 'utf-8'));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(SIDECAR_PRIVATE_KEY_PEM);
+  const sigB64 = base64UrlEncode(signature);
+
+  process.stdout.write(`${signingInput}.${sigB64}`);
+}
+
+main();

--- a/tests/integration/local-start-alb-auth-jwks/tsconfig.json
+++ b/tests/integration/local-start-alb-auth-jwks/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-alb-auth-jwks/verify.sh
+++ b/tests/integration/local-start-alb-auth-jwks/verify.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-alb authenticate-oidc full JWT-verification integ test
+#
+# Complements `local-start-alb-auth` (which covers the no-token -> 401
+# wiring + --no-verify-auth bypass) by exercising the verifier's real
+# signature + iss + aud + exp checks against a LOCAL JWKS sidecar.
+#
+# The fixture stack declares an authenticate-oidc action whose Issuer is
+# `http://127.0.0.1:19000`. A Node sidecar (jwks-sidecar.mjs) running on
+# that URL serves:
+#
+#   GET /.well-known/openid-configuration -> { issuer, jwks_uri }
+#   GET /.well-known/jwks.json            -> { keys: [<RSA public JWK>] }
+#
+# `sign-jwt.mjs` mints JWTs signed by the sidecar's embedded RSA-2048
+# private key. The local front-door fetches the JWKS from the sidecar
+# and verifies the token end-to-end (no real Cognito / IdP needed).
+#
+# Phases:
+#
+#   PHASE 1 — valid JWT signed by the sidecar's key -> 200 (signature
+#             + iss + aud + exp all check out).
+#   PHASE 2 — expired JWT (exp in the past) -> 401.
+#   PHASE 3 — wrong-aud JWT (signed correctly but `aud` not the
+#             configured client id) -> 401.
+#
+# Requires Docker (for the ECS replicas) + Node (for the sidecar +
+# signer; comes from .node-version).
+#
+#     bash tests/integration/local-start-alb-auth-jwks/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+WEB_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
+LB_HOST_PORT=18290
+SIDECAR_PORT=19000
+SIDECAR_ISSUER="http://127.0.0.1:${SIDECAR_PORT}"
+SIDECAR_AUDIENCE="cdkl-test-client"
+
+CDKL_PID=""
+SIDECAR_PID=""
+
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers + networks + sidecar"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${SIDECAR_PID:-}" ]] && kill -0 "${SIDECAR_PID}" 2>/dev/null; then
+    kill -TERM "${SIDECAR_PID}" 2>/dev/null || true
+    for _ in $(seq 1 30); do
+      if ! kill -0 "${SIDECAR_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${SIDECAR_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${WEB_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+# Boot the JWKS sidecar in the background. The local front-door will
+# fetch `<issuer>/.well-known/jwks.json` from it during JWT verification.
+echo "==> Starting JWKS sidecar on port ${SIDECAR_PORT}"
+SIDECAR_LOG=$(mktemp)
+node jwks-sidecar.mjs "${SIDECAR_PORT}" > "${SIDECAR_LOG}" 2>&1 &
+SIDECAR_PID=$!
+
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 2 "${SIDECAR_ISSUER}/.well-known/jwks.json" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${SIDECAR_PID}" 2>/dev/null; then
+    echo "FAIL: JWKS sidecar exited before becoming reachable"
+    echo "----- sidecar output -----"; cat "${SIDECAR_LOG}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 0.5
+done
+if ! curl -fsS --max-time 2 "${SIDECAR_ISSUER}/.well-known/jwks.json" >/dev/null 2>&1; then
+  echo "FAIL: JWKS sidecar never became reachable at ${SIDECAR_ISSUER}"
+  cat "${SIDECAR_LOG}"
+  exit 1
+fi
+echo "    OK: sidecar serving JWKS at ${SIDECAR_ISSUER}"
+
+# wait_for_boot — poll the cdkl log for the boot banner.
+wait_for_boot() {
+  local out_file="$1"
+  for _ in $(seq 1 90); do
+    if grep -q "Service(s) running:" "${out_file}" 2>/dev/null; then
+      return 0
+    fi
+    if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+      echo "FAIL: cdk-local exited before reaching the boot banner"
+      echo "----- cdk-local output -----"; cat "${out_file}"; echo "----------------------------"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "FAIL: cdk-local did not reach the boot banner within 90s"
+  echo "----- cdk-local output -----"; cat "${out_file}"; echo "----------------------------"
+  return 1
+}
+
+# Boot the front-door once and run all three JWT phases against it.
+CDKL_LOG=$(mktemp)
+echo ""
+echo "==> Starting cdkl start-alb (authenticate-oidc enforcing)"
+${CDKL} start-alb CdkLocalStartAlbAuthJwksFixture:WebLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  > "${CDKL_LOG}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner"
+wait_for_boot "${CDKL_LOG}"
+
+# Wait for the front-door socket to accept connections (any HTTP status
+# proves the listener is bound — 401 is the expected unauthenticated
+# response and confirms the guard fires).
+echo "==> Waiting for the front-door to respond on host port ${LB_HOST_PORT}"
+SAW_RESPONSE=0
+for _ in $(seq 1 60); do
+  STATUS=$(curl -s -o /dev/null --max-time 5 -w '%{http_code}' "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null || true)
+  if [[ -n "${STATUS}" && "${STATUS}" != "000" ]]; then
+    SAW_RESPONSE=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the front-door"
+    cat "${CDKL_LOG}"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${SAW_RESPONSE}" -ne 1 ]]; then
+  echo "FAIL: front-door never returned a response within 60s"
+  cat "${CDKL_LOG}"
+  exit 1
+fi
+
+# =============================================================================
+# PHASE 1 — Valid JWT (signature + iss + aud + exp all valid) -> 200.
+# =============================================================================
+echo ""
+echo "==> Phase 1: valid JWT -> 200"
+VALID_JWT=$(node sign-jwt.mjs --iss "${SIDECAR_ISSUER}" --aud "${SIDECAR_AUDIENCE}" --exp-offset 300)
+
+# Replicas may take a few seconds to come up; poll until a 200 with the
+# expected body is served, but bail early if the response is a 401
+# (would mean JWT verification failed, not just that replicas aren't
+# ready yet).
+READY=0
+for _ in $(seq 1 60); do
+  RESP=$(curl -sS -i --max-time 5 -H "Authorization: Bearer ${VALID_JWT}" "http://127.0.0.1:${LB_HOST_PORT}/" 2>&1 || true)
+  STATUS_LINE=$(echo "${RESP}" | head -1)
+  if echo "${STATUS_LINE}" | grep -qE 'HTTP/[0-9.]+ 200'; then
+    BODY=$(echo "${RESP}" | awk 'BEGIN{p=0} /^\r?$/{p=1;next} p{print}')
+    if [[ "${BODY}" == replica\ * ]]; then
+      READY=1
+      break
+    fi
+  fi
+  if echo "${STATUS_LINE}" | grep -qE 'HTTP/[0-9.]+ 401'; then
+    echo "FAIL: valid JWT was rejected with 401"
+    echo "----- response -----"; echo "${RESP}"; echo "--------------------"
+    echo "----- cdk-local log -----"; cat "${CDKL_LOG}"; echo "-------------------------"
+    exit 1
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited mid-phase"
+    cat "${CDKL_LOG}"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: valid JWT never produced a 200 + replica body within 60s"
+  echo "----- last response -----"; echo "${RESP}"; echo "-------------------------"
+  echo "----- cdk-local log -----"; cat "${CDKL_LOG}"; echo "-------------------------"
+  exit 1
+fi
+echo "    OK: 200 + replica body (signature + iss + aud + exp all verified)"
+
+# =============================================================================
+# PHASE 2 — Expired JWT (exp in the past, signature still valid) -> 401.
+# =============================================================================
+echo ""
+echo "==> Phase 2: expired JWT -> 401"
+EXPIRED_JWT=$(node sign-jwt.mjs --iss "${SIDECAR_ISSUER}" --aud "${SIDECAR_AUDIENCE}" --exp-offset -60)
+RESP=$(curl -sS -i --max-time 5 -H "Authorization: Bearer ${EXPIRED_JWT}" "http://127.0.0.1:${LB_HOST_PORT}/" 2>&1)
+STATUS_LINE=$(echo "${RESP}" | head -1)
+if ! echo "${STATUS_LINE}" | grep -qE 'HTTP/[0-9.]+ 401'; then
+  echo "FAIL: expected 401 for expired JWT, got: ${STATUS_LINE}"
+  echo "----- response -----"; echo "${RESP}"; echo "--------------------"
+  exit 1
+fi
+echo "    OK: 401 for expired JWT (exp claim in the past rejected)"
+
+# =============================================================================
+# PHASE 3 — Wrong-aud JWT (signature + iss + exp valid, aud mismatch) -> 401.
+# =============================================================================
+echo ""
+echo "==> Phase 3: wrong-aud JWT -> 401"
+WRONG_AUD_JWT=$(node sign-jwt.mjs --iss "${SIDECAR_ISSUER}" --aud "some-other-client" --exp-offset 300)
+RESP=$(curl -sS -i --max-time 5 -H "Authorization: Bearer ${WRONG_AUD_JWT}" "http://127.0.0.1:${LB_HOST_PORT}/" 2>&1)
+STATUS_LINE=$(echo "${RESP}" | head -1)
+if ! echo "${STATUS_LINE}" | grep -qE 'HTTP/[0-9.]+ 401'; then
+  echo "FAIL: expected 401 for wrong-aud JWT, got: ${STATUS_LINE}"
+  echo "----- response -----"; echo "${RESP}"; echo "--------------------"
+  exit 1
+fi
+echo "    OK: 401 for wrong-aud JWT (audience allowlist mismatch rejected)"
+
+# All three phases passed.
+echo ""
+echo "==> local-start-alb-auth-jwks tests passed"
+echo "    (valid JWT -> 200; expired JWT -> 401; wrong-aud JWT -> 401)"
+
+# Cleanup runs via the EXIT trap.
+rm -f "${CDKL_LOG}" "${SIDECAR_LOG}"


### PR DESCRIPTION
## Summary

- Closes the JWT-verification integ gap left by PR #183, which covered
  `start-alb` authenticate-cognito wiring (no-token -> 401 +
  `--no-verify-auth` bypass) but explicitly skipped the verifier's
  signature / `iss` / `aud` / `exp` checks because the cognito-jwt
  verifier hardcodes the JWKS URL to AWS Cognito with no override seam.
- Adds a sibling fixture `tests/integration/local-start-alb-auth-jwks/`
  that wires the listener with `authenticate-oidc` pointing at a local
  JWKS sidecar. The sidecar is a Node `http` server serving the OIDC
  discovery document + the JWKS for an embedded RSA-2048 key pair;
  `sign-jwt.mjs` mints JWTs signed by the matching private key.
- `verify.sh` exercises three phases end-to-end against one
  `cdkl start-alb` instance:
  - valid JWT (signature + `iss` + `aud` + `exp` all valid) -> 200
  - expired JWT (`exp` in the past) -> 401
  - wrong-aud JWT (audience allowlist mismatch) -> 401

`authenticate-cognito` cannot be retargeted at a local issuer (the
verifier builds the JWKS URL from the `UserPoolArn` with no escape
hatch), so the JWT-verification integ ships under `authenticate-oidc`,
which is the only authenticate-* shape that can point at a local JWKS
URL.

## Test plan

- [x] `bash tests/integration/local-start-alb-auth-jwks/verify.sh`
      passes all three phases against a freshly-built `dist/cli.js`.
- [x] Sidecar + cdkl both start and stop cleanly (post-run
      `docker ps --filter name=cdkl-` / `docker network ls --filter
      name=cdkl-` are empty).
- [x] `vp run verify` (typecheck + lint + format + 1660 unit tests
      + build) green.
- [ ] CI green on the new branch.
