### PR TITLE
test(integ): cover cdkl start-alb WebSocket Upgrade proxy

### DIFF
--- a/tests/integration/local-start-alb-websocket/.gitignore
+++ b/tests/integration/local-start-alb-websocket/.gitignore
@@ -1,0 +1,3 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is tracked.
+!lambda/*.js

--- a/tests/integration/local-start-alb-websocket/.scenarios.json
+++ b/tests/integration/local-start-alb-websocket/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-alb-front-door"
+  ]
+}

--- a/tests/integration/local-start-alb-websocket/bin/app.ts
+++ b/tests/integration/local-start-alb-websocket/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbWebSocketStack } from '../lib/local-start-alb-websocket-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbWebSocketStack(app, 'CdkLocalStartAlbWebSocketFixture', {
+  description: 'Fixture stack for cdkl start-alb WebSocket Upgrade proxy integ test (#176)',
+});

--- a/tests/integration/local-start-alb-websocket/cdk.json
+++ b/tests/integration/local-start-alb-websocket/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-websocket/lambda/index.js
+++ b/tests/integration/local-start-alb-websocket/lambda/index.js
@@ -1,0 +1,16 @@
+// ALB Lambda-target handler for the start-alb WebSocket Upgrade integ (#176).
+// Returns a plain HTTP 200; the front-door is expected to short-circuit any
+// inbound `Upgrade: websocket` request with a 502 BEFORE it reaches this
+// handler (Lambda target groups do not support WebSocket; mirrors ALB itself).
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    statusDescription: '200 OK',
+    isBase64Encoded: false,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Handler': 'alb-ws-lambda-fixture',
+    },
+    body: 'plain-http-response-not-a-ws-handshake\n',
+  };
+};

--- a/tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts
+++ b/tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts
@@ -1,0 +1,152 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture for `cdkl start-alb` -> WebSocket Upgrade proxy (#176).
+ *
+ * Two listeners on the same synthetic ALB exercise both branches of the
+ * upgrade dispatch the front-door has to handle:
+ *
+ *   - Listener port 80 -> ECS forward target. The container runs a tiny
+ *     Python `websockets` echo server on container port 8080. The
+ *     front-door is expected to bridge the inbound upgrade request through
+ *     to the picked replica so a `ws://127.0.0.1:<lb-port-80>/...` round
+ *     trips a frame.
+ *   - Listener port 81 -> Lambda forward target (`TargetType: lambda`).
+ *     The Lambda just returns plain HTTP; the front-door is expected to
+ *     refuse the upgrade with 502 over the raw TCP socket BEFORE the
+ *     Lambda is ever invoked (mirrors ALB itself — Lambda TGs do not
+ *     support WebSocket).
+ *
+ * Hand-rolled L1 ELBv2 / ECS resources so the fixture stays VPC-free and
+ * deterministic (cdk-local only reads the template; it never deploys to AWS).
+ *
+ * `covers: AWS::ECS::Service, AWS::Lambda::Function` (the front-door bridges
+ * the WS upgrade to an ECS replica and refuses upgrade on a Lambda target).
+ */
+// Inline Python WebSocket echo server. Keep the program as a newline-joined
+// array so a stray '\n' literal here cannot accidentally split the line.
+//
+// The container starts by pip-installing `websockets` (a tiny pure-Python
+// package), then exec's a one-shot asyncio echo server on container port 8080.
+// `gethostname()` is included in the greeting message so a future round-robin
+// test could distinguish replicas, but the current verify.sh only asserts on
+// the echoed payload (Test 1 / Test 3).
+const WS_ECHO_SERVER = [
+  'import asyncio,os,socket',
+  'from websockets.asyncio.server import serve',
+  'async def handler(ws):',
+  '  hello=("ready "+socket.gethostname()).encode()',
+  '  await ws.send(hello)',
+  '  async for msg in ws:',
+  '    await ws.send(msg)',
+  'async def main():',
+  '  async with serve(handler,"0.0.0.0",8080):',
+  '    await asyncio.Future()',
+  'asyncio.run(main())',
+].join('\n');
+
+const WS_BOOT = [
+  'set -e',
+  // `--quiet --quiet` so the container log stays readable while the
+  // websockets wheel is downloaded once on cold start. The image already
+  // ships pip; no apk add needed.
+  'pip install --quiet --quiet --disable-pip-version-check websockets',
+  `exec python -c "${WS_ECHO_SERVER.replace(/"/g, '\\"')}"`,
+].join('\n');
+
+export class LocalStartAlbWebSocketStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // --- ECS service: a WebSocket echo backend on container port 8080 ---
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-alb-ws-fixture',
+    });
+
+    const taskDef = new ecs.CfnTaskDefinition(this, 'WsTask', {
+      family: 'cdkl-start-alb-ws-echo',
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'wsecho',
+          image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+          essential: true,
+          entryPoint: ['sh', '-c'],
+          command: [WS_BOOT],
+          memoryReservation: 64,
+          portMappings: [{ containerPort: 8080, protocol: 'tcp' }],
+        },
+      ],
+    });
+
+    // --- Synthetic ALB shell (no real VPC needed; cdk-local only reads template) ---
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WsLB', {
+      type: 'application',
+    });
+
+    // ECS target group bound to container port 8080.
+    const wsTargetGroup = new elbv2.CfnTargetGroup(this, 'WsTargetGroup', {
+      port: 8080,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+
+    // ECS listener on ALB port 80 (default action -> WS echo target group).
+    new elbv2.CfnListener(this, 'WsListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [{ type: 'forward', targetGroupArn: wsTargetGroup.ref }],
+    });
+
+    new ecs.CfnService(this, 'WsService', {
+      cluster: cluster.ref,
+      taskDefinition: taskDef.ref,
+      desiredCount: 2,
+      launchType: 'EC2',
+      loadBalancers: [
+        {
+          containerName: 'wsecho',
+          containerPort: 8080,
+          targetGroupArn: wsTargetGroup.ref,
+        },
+      ],
+    });
+
+    // --- Lambda target on a separate listener to exercise the 502-on-upgrade branch ---
+    const lambdaCode = lambda.Code.fromAsset(path.join(__dirname, '../lambda'));
+
+    const plainFn = new lambda.Function(this, 'PlainFn', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambdaCode,
+      timeout: cdk.Duration.seconds(10),
+    });
+    plainFn.addPermission('AlbInvoke', {
+      principal: new cdk.aws_iam.ServicePrincipal('elasticloadbalancing.amazonaws.com'),
+    });
+
+    const plainTg = new elbv2.CfnTargetGroup(this, 'PlainTargetGroup', {
+      targetType: 'lambda',
+      targets: [{ id: plainFn.functionArn }],
+    });
+
+    // Lambda listener on ALB port 81 (default action -> plain Lambda).
+    // A WS upgrade to this listener must be refused with 502 by the
+    // front-door (mirrors ALB; Lambda TGs do not support WebSocket).
+    new elbv2.CfnListener(this, 'PlainListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 81,
+      protocol: 'HTTP',
+      defaultActions: [{ type: 'forward', targetGroupArn: plainTg.ref }],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-websocket/package.json
+++ b/tests/integration/local-start-alb-websocket/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cdkl-integ-local-start-alb-websocket",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb WebSocket Upgrade proxy (#176)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.0.0",
+    "ws": "^8.21.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-alb-websocket/tsconfig.json
+++ b/tests/integration/local-start-alb-websocket/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-alb-websocket/verify.sh
+++ b/tests/integration/local-start-alb-websocket/verify.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-alb WebSocket Upgrade proxy integ test (#176, no AWS deploy)
+#
+# Names an Application Load Balancer with two listeners on the same synthetic
+# ALB:
+#   - Listener 80 -> ECS forward TG (DesiredCount=2 Python websockets echo).
+#   - Listener 81 -> Lambda forward TG (plain HTTP handler).
+# Asserts:
+#   - The host-side ALB front-door comes up on both --lb-port host ports.
+#   - Test 1: a WebSocket upgrade against the ECS listener completes the
+#     handshake (HTTP/1.1 101) and a sent frame is echoed back verbatim.
+#   - Test 2: a WebSocket upgrade against the Lambda listener is refused with
+#     HTTP/1.1 502 (mirrors ALB itself — Lambda TGs do not support WebSocket).
+#   - SIGTERM tears every container + network + front-door socket down.
+#
+#     bash tests/integration/local-start-alb-websocket/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+PYTHON_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
+LAMBDA_IMAGE="public.ecr.aws/lambda/nodejs:20"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+LB_ECS_PORT=18176   # non-privileged host port for ALB listener 80 (ECS)
+LB_LAMBDA_PORT=18177 # non-privileged host port for ALB listener 81 (Lambda)
+
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers + networks"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${PYTHON_IMAGE}"
+docker pull "${LAMBDA_IMAGE}"
+docker pull "${SIDECAR_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+CLIENT_SCRIPT="$(pwd)/.ws-client.mjs"
+trap 'rm -f "${OUT_FILE}" "${CLIENT_SCRIPT}"; cleanup' EXIT
+
+# The WebSocket client lives inside the fixture directory so `import 'ws'`
+# resolves against the fixture's pnpm-installed node_modules. The script has
+# two modes:
+#   echo   -- open a ws:// connection, send a message, assert the echo, exit 0.
+#   refuse -- open a ws:// connection, assert the server returned a non-101
+#             response with the expected status code, exit 0.
+cat > "${CLIENT_SCRIPT}" <<'NODE'
+import { WebSocket } from 'ws';
+
+const [, , mode, url, payloadOrStatus] = process.argv;
+if (!mode || !url) {
+  console.error('Usage: .ws-client.mjs <echo|refuse> <ws-url> <payload|expected-status>');
+  process.exit(2);
+}
+
+function timeout(ms, label) {
+  return new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(`Timeout after ${ms}ms waiting for ${label}`)), ms)
+  );
+}
+
+async function echoMode() {
+  const payload = payloadOrStatus ?? 'hello-ws';
+  const ws = new WebSocket(url);
+  const echoed = await Promise.race([
+    new Promise((resolve, reject) => {
+      let greetingSeen = false;
+      ws.on('open', () => {
+        // Wait one frame for the server's "ready <host>" greeting,
+        // then send our payload and resolve on the echo.
+      });
+      ws.on('message', (data) => {
+        const text = data.toString('utf-8');
+        if (!greetingSeen) {
+          greetingSeen = true;
+          if (!text.startsWith('ready ')) {
+            reject(new Error(`expected greeting prefix 'ready ', got: ${text}`));
+            return;
+          }
+          ws.send(payload);
+          return;
+        }
+        resolve(text);
+        ws.close();
+      });
+      ws.on('error', reject);
+    }),
+    timeout(30_000, 'WS echo'),
+  ]);
+  if (echoed !== payload) {
+    console.error(`FAIL: echoed payload mismatch. sent=${payload} got=${echoed}`);
+    process.exit(1);
+  }
+  console.log(`echo OK: ${echoed}`);
+}
+
+async function refuseMode() {
+  const expectedStatus = Number.parseInt(payloadOrStatus ?? '502', 10);
+  const ws = new WebSocket(url);
+  const status = await Promise.race([
+    new Promise((resolve, reject) => {
+      ws.on('unexpected-response', (_req, res) => {
+        resolve(res.statusCode ?? 0);
+        res.resume();
+      });
+      ws.on('open', () => {
+        ws.close();
+        reject(new Error('expected the front-door to REFUSE the upgrade, but it completed (101)'));
+      });
+      ws.on('error', (err) => {
+        // Swallowed: `unexpected-response` resolves first; if we get here
+        // without that path, surface the error.
+        setTimeout(() => reject(err), 100);
+      });
+    }),
+    timeout(30_000, 'WS refuse'),
+  ]);
+  if (status !== expectedStatus) {
+    console.error(`FAIL: expected HTTP ${expectedStatus}, got HTTP ${status}`);
+    process.exit(1);
+  }
+  console.log(`refuse OK: HTTP ${status}`);
+}
+
+if (mode === 'echo') {
+  await echoMode();
+} else if (mode === 'refuse') {
+  await refuseMode();
+} else {
+  console.error(`unknown mode: ${mode}`);
+  process.exit(2);
+}
+NODE
+
+echo "==> start-alb: naming the ALB (2 listeners; ECS + Lambda), front-door on host ports ${LB_ECS_PORT}/${LB_LAMBDA_PORT}"
+# Remap both privileged listener ports to non-privileged host ports so the
+# front-door binds without root (the macOS Docker Desktop privileged-port path).
+${CDKL} start-alb CdkLocalStartAlbWebSocketFixture:WsLB \
+  --container-host 127.0.0.1 \
+  --lb-port "80=${LB_ECS_PORT}" \
+  --lb-port "81=${LB_LAMBDA_PORT}" \
+  > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 180s — websockets wheel install on cold container)"
+BOOTED=0
+for _ in $(seq 1 180); do
+  if grep -q "Service(s) running:" "${OUT_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: front-door did not reach the boot banner within 180s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+
+echo "==> Asserting both front-door banners were logged"
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_ECS_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: ECS-listener front-door banner for host port ${LB_ECS_PORT} not found"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_LAMBDA_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: Lambda-listener front-door banner for host port ${LB_LAMBDA_PORT} not found"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: both front-door banners present"
+
+echo "==> Waiting for the WebSocket echo server to accept connections (replicas pip-install + start)"
+# Probe via a real WS handshake — the upstream `websockets` server does NOT
+# answer plain HTTP GET cleanly (it drops the TCP connection on a malformed
+# upgrade), so an HTTP probe is unreliable. The probe script exits 0 as soon
+# as the upgrade completes (the server even sends a `ready <host>` greeting
+# frame, which is enough to confirm bridging).
+PROBE_SCRIPT="$(pwd)/.ws-probe.mjs"
+trap 'rm -f "${OUT_FILE}" "${CLIENT_SCRIPT}" "${PROBE_SCRIPT}"; cleanup' EXIT
+cat > "${PROBE_SCRIPT}" <<'NODE'
+import { WebSocket } from 'ws';
+const url = process.argv[2];
+const ws = new WebSocket(url);
+ws.on('open', () => { ws.close(); process.exit(0); });
+ws.on('message', () => { ws.close(); process.exit(0); });
+ws.on('error', () => process.exit(1));
+ws.on('unexpected-response', () => process.exit(1));
+setTimeout(() => process.exit(2), 3000);
+NODE
+
+READY=0
+for _ in $(seq 1 180); do
+  if node "${PROBE_SCRIPT}" "ws://127.0.0.1:${LB_ECS_PORT}/" 2>/dev/null; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the upstream WS server to come up"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: upstream WS server never reached a serving state within 180s"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: upstream WS handshake completes (front-door bridges to a live replica)"
+
+echo "==> Test 1 — WebSocket upgrade to the ECS listener echoes a frame"
+if ! node "${CLIENT_SCRIPT}" echo "ws://127.0.0.1:${LB_ECS_PORT}/" "alb-ws-payload"; then
+  echo "FAIL: ECS WS echo round-trip did not complete"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: ECS forward target bridged the WS upgrade and echoed the frame"
+
+echo "==> Test 2 — WebSocket upgrade to the Lambda listener is refused with HTTP 502"
+if ! node "${CLIENT_SCRIPT}" refuse "ws://127.0.0.1:${LB_LAMBDA_PORT}/" 502; then
+  echo "FAIL: Lambda listener did not refuse the WS upgrade with 502"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: Lambda target group refused the upgrade with 502 over the raw socket"
+
+echo "==> Sending SIGTERM to cdk-local (${CDKL_PID})"
+kill -TERM "${CDKL_PID}"
+
+echo "==> Waiting for cdk-local to exit (up to 60s)"
+EXITED=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then EXITED=1; break; fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+echo "==> Asserting clean teardown — no leftover containers"
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers still present after SIGTERM"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+
+echo "==> Asserting clean teardown — no leftover networks"
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} docker networks still present after SIGTERM"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+echo "==> Asserting the front-door sockets are closed"
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_ECS_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: ECS-listener front-door on host port ${LB_ECS_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_LAMBDA_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: Lambda-listener front-door on host port ${LB_LAMBDA_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+
+echo ""
+echo "==> local-start-alb-websocket test passed (ECS upgrade echoes; Lambda upgrade -> 502; clean teardown)"


### PR DESCRIPTION
## Summary

PR #176 wired WebSocket Upgrade proxying into the local ALB front-door (ECS forward targets bridge raw TCP, Lambda target groups refuse with 502 — mirroring ALB itself), but only unit tests in `tests/unit/local/front-door-server.test.ts` exercised it. This closes the Docker-driven end-to-end gap.

- New fixture `tests/integration/local-start-alb-websocket/` mirrors the canonical `local-start-alb` / `local-start-alb-lambda` shape (bin/ + lib/ + Lambda asset + verify.sh, no AWS deploy).
- Stack: one synthetic ALB with two listeners on the same load balancer.
  - Listener 80 -> ECS forward target group. The container runs a tiny Python `websockets` echo server on container port 8080 (DesiredCount=2; `python:3.12-alpine` base; `pip install --quiet websockets` then an asyncio `serve()`).
  - Listener 81 -> Lambda forward target group. The Lambda just returns plain HTTP and must never be reached by a WS upgrade.
- `verify.sh` brings cdkl up with `--lb-port 80=18176 81=18177`, waits for both front-door banners, polls upstream readiness via a real WS handshake probe (the `websockets` library does not answer a plain HTTP probe cleanly), then runs the two acceptance assertions and asserts clean teardown.

## Acceptance assertions

- **Test 1 — ECS WebSocket upgrade succeeds**: open `ws://127.0.0.1:18176/`, send `alb-ws-payload`, assert the same payload is echoed back. Confirms the handshake completes (HTTP/1.1 101) AND raw TCP bytes bridge to the picked replica.
- **Test 2 — Lambda target refuses with 502**: open `ws://127.0.0.1:18177/`, assert the front-door answers HTTP/1.1 502 over the raw socket BEFORE the Lambda is invoked (mirrors ALB's Lambda-TG behavior).

## Test plan

- [x] `vp run check` (typecheck / lint / format) — pass
- [x] `vp run test` — 1660 unit tests pass
- [x] `vp run build` — clean
- [x] `/run-integ local-start-alb-websocket` — pass; 0 leftover containers / networks; integ marker set
- [x] Live output captured in commit body:
  - `echo OK: alb-ws-payload` (ECS bridge)
  - `refuse OK: HTTP 502` (Lambda upgrade)

Closes the integ gap for #176.
