### PR TITLE
test(integ): cover cdkl list target enumeration

### DIFF
--- a/tests/integration/local-list/.scenarios.json
+++ b/tests/integration/local-list/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-list"
+  ]
+}

--- a/tests/integration/local-list/bin/app.ts
+++ b/tests/integration/local-list/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalListStack } from '../lib/local-list-stack.ts';
+
+const app = new cdk.App();
+
+new LocalListStack(app, 'LocalListFixture', {
+  description: 'Fixture stack for cdkl list target enumeration integ test',
+});

--- a/tests/integration/local-list/cdk.json
+++ b/tests/integration/local-list/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-list/lib/local-list-stack.ts
+++ b/tests/integration/local-list/lib/local-list-stack.ts
@@ -1,0 +1,128 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+
+/**
+ * Fixture stack for `cdkl list` target enumeration integ test.
+ *
+ * Hand-rolls one resource of each kind `cdkl list` emits a group for, using
+ * inline Lambda code + L1 resources where possible so the stack synthesizes
+ * without AWS / context / VPC lookups and without any asset bundling:
+ *
+ *   - `AWS::Lambda::Function`  (`MyHandler`)      -> Lambda Functions group
+ *   - `AWS::ApiGatewayV2::Api` + Route + Integration (HTTP API v2 wired to
+ *     `MyHandler`)                                -> APIs group
+ *   - `AWS::Lambda::Url` on `MyHandler`           -> APIs group (Function URL)
+ *   - `AWS::ECS::TaskDefinition` (`MyTask`)       -> ECS Task Definitions
+ *   - `AWS::ECS::Service` (`MyService`)           -> ECS Services
+ *   - `AWS::ElasticLoadBalancingV2::LoadBalancer` (`MyAlb`) +
+ *     `AWS::ElasticLoadBalancingV2::TargetGroup` +
+ *     `AWS::ElasticLoadBalancingV2::Listener`     -> Application Load Balancers
+ *   - `AWS::BedrockAgentCore::Runtime` (`MyAgent`) -> AgentCore Runtimes
+ *
+ * The test never executes any of these — `cdkl list` is a pure synth-time
+ * read over the cloud assembly templates, so placeholder ARNs / URIs are
+ * fine. The fixture only exists so the integ can assert each group + target
+ * label is emitted under the expected command.
+ */
+export class LocalListStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Lambda function — inline code so synth has no asset / bundling step.
+    const fn = new lambda.Function(this, 'MyHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(
+        "exports.handler = async () => ({ statusCode: 200, body: 'ok' });"
+      ),
+    });
+
+    // HTTP API v2 + a single Lambda-backed route.
+    const httpApi = new apigwv2.CfnApi(this, 'MyHttpApi', {
+      name: 'cdkl-list-fixture-http-api',
+      protocolType: 'HTTP',
+    });
+    const httpIntegration = new apigwv2.CfnIntegration(this, 'MyHttpIntegration', {
+      apiId: httpApi.ref,
+      integrationType: 'AWS_PROXY',
+      integrationUri: fn.functionArn,
+      payloadFormatVersion: '2.0',
+    });
+    new apigwv2.CfnRoute(this, 'MyHttpRoute', {
+      apiId: httpApi.ref,
+      routeKey: 'GET /hello',
+      target: cdk.Fn.join('/', ['integrations', httpIntegration.ref]),
+    });
+
+    // Function URL on the same Lambda — surfaces as an `apis` entry with
+    // `(Function URL)` kind, keyed by the BACKING LAMBDA's logical ID.
+    fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE });
+
+    // ECS cluster + bridge-mode task definition + service.
+    const cluster = new ecs.CfnCluster(this, 'MyCluster', {
+      clusterName: 'cdkl-list-fixture-cluster',
+    });
+    const taskDef = new ecs.CfnTaskDefinition(this, 'MyTask', {
+      family: 'cdkl-list-fixture-task',
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'web',
+          image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+          essential: true,
+          memoryReservation: 32,
+          portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+        },
+      ],
+    });
+
+    // Target group + listener + ALB fronting the ECS service.
+    const targetGroup = new elbv2.CfnTargetGroup(this, 'MyTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+    const alb = new elbv2.CfnLoadBalancer(this, 'MyAlb', {
+      type: 'application',
+    });
+    new elbv2.CfnListener(this, 'MyListener', {
+      loadBalancerArn: alb.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.ref }],
+    });
+    new ecs.CfnService(this, 'MyService', {
+      cluster: cluster.ref,
+      taskDefinition: taskDef.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+      loadBalancers: [
+        {
+          containerName: 'web',
+          containerPort: 80,
+          targetGroupArn: targetGroup.ref,
+        },
+      ],
+    });
+
+    // AgentCore Runtime — L1 only so no role/network resolution is needed.
+    // The container URI / role ARN are placeholders: `cdkl list` reads the
+    // resource type + path metadata only, never these properties.
+    new agentcore.CfnRuntime(this, 'MyAgent', {
+      agentRuntimeName: 'cdkl_list_fixture_agent',
+      roleArn: 'arn:aws:iam::123456789012:role/cdkl-list-fixture-agent-role',
+      networkConfiguration: { networkMode: 'PUBLIC' },
+      agentRuntimeArtifact: {
+        containerConfiguration: {
+          containerUri:
+            '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdkl-list-fixture-agent:latest',
+        },
+      },
+    });
+  }
+}

--- a/tests/integration/local-list/package.json
+++ b/tests/integration/local-list/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-list",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl list (target enumeration)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-list/tsconfig.json
+++ b/tests/integration/local-list/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-list/verify.sh
+++ b/tests/integration/local-list/verify.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl list target-enumeration integ test (pure synth, no Docker).
+#
+# `cdkl list` reads the synthesized cloud assembly and prints every runnable
+# target grouped by the command that consumes it. The interactive
+# target-picker (`cdkl invoke` / `start-api` / etc. without a target in a TTY)
+# shares the same target-lister underneath — so a regression in list semantics
+# would silently break the picker too. Lock in the surface here.
+#
+# Asserts against a single fixture stack rich enough to emit every group:
+#   - Lambda Functions   ->  cdkl invoke <target>            (MyHandler)
+#   - APIs               ->  cdkl start-api [target...]      (MyHttpApi HTTP API v2 + MyHandler Function URL)
+#   - ECS Services       ->  cdkl start-service <target...>  (MyService)
+#   - ECS Task Definitions -> cdkl run-task <target>         (MyTask)
+#   - AgentCore Runtimes ->  cdkl invoke-agentcore <target>  (MyAgent)
+#   - Application Load Balancers -> cdkl start-alb <target...> (MyAlb)
+#
+# Also locks down:
+#   - `cdkl ls` (alias) produces the same output as `cdkl list`.
+#   - `cdkl list --help` exits 0 and surfaces the documented description.
+#
+# No Docker required — pure synth-time read.
+#
+#   bash tests/integration/local-list/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+ALIAS_OUT_FILE=$(mktemp)
+HELP_FILE=$(mktemp)
+cleanup() { rm -f "${OUT_FILE}" "${ALIAS_OUT_FILE}" "${HELP_FILE}"; }
+trap cleanup EXIT
+
+echo "==> cdkl list against the fixture (capturing stdout)"
+${CDKL} list > "${OUT_FILE}" 2>/dev/null
+
+echo "==> Asserting every expected group header is emitted"
+for header in \
+  'Lambda Functions  ->  cdkl invoke <target>' \
+  'APIs  ->  cdkl start-api [target...]' \
+  'ECS Services  ->  cdkl start-service <target...>' \
+  'ECS Task Definitions  ->  cdkl run-task <target>' \
+  'AgentCore Runtimes  ->  cdkl invoke-agentcore <target>' \
+  'Application Load Balancers  ->  cdkl start-alb <target...>'
+do
+  if ! grep -qF "${header}" "${OUT_FILE}"; then
+    echo "FAIL: missing group header: ${header}"
+    echo "----- list output -----"; cat "${OUT_FILE}"; echo "-----------------------"
+    exit 1
+  fi
+  echo "    OK: ${header}"
+done
+
+echo "==> Asserting every expected target appears under its group"
+# CDK display path (no /Resource suffix) is what `cdkl list` prints when the
+# resource carries `aws:cdk:path` metadata — which every L1/L2 in this fixture
+# does. The Function URL line carries the `(Function URL)` kind suffix and is
+# keyed by the BACKING LAMBDA's logical ID, mirroring the start-api dispatcher.
+for line in \
+  '  LocalListFixture/MyHandler' \
+  '  LocalListFixture/MyHttpApi  (HTTP API v2)' \
+  '  LocalListFixture/MyHandler  (Function URL)' \
+  '  LocalListFixture/MyService' \
+  '  LocalListFixture/MyTask' \
+  '  LocalListFixture/MyAgent' \
+  '  LocalListFixture/MyAlb'
+do
+  if ! grep -qF "${line}" "${OUT_FILE}"; then
+    echo "FAIL: missing target line: '${line}'"
+    echo "----- list output -----"; cat "${OUT_FILE}"; echo "-----------------------"
+    exit 1
+  fi
+  echo "    OK: ${line}"
+done
+
+echo "==> cdkl ls (alias) — asserting identical stdout"
+${CDKL} ls > "${ALIAS_OUT_FILE}" 2>/dev/null
+if ! diff -u "${OUT_FILE}" "${ALIAS_OUT_FILE}"; then
+  echo "FAIL: cdkl ls produced different output from cdkl list"
+  exit 1
+fi
+echo "    OK: alias produces identical output"
+
+echo "==> cdkl list -l (--long) — asserting stack-qualified IDs are emitted"
+LONG_OUT_FILE=$(mktemp)
+trap 'rm -f "${OUT_FILE}" "${ALIAS_OUT_FILE}" "${HELP_FILE}" "${LONG_OUT_FILE}"' EXIT
+${CDKL} list -l > "${LONG_OUT_FILE}" 2>/dev/null
+# In long mode each entry with a display path gets a second indented line
+# containing the stack-qualified logical ID. Assert one such line per
+# distinct resource group (CDK auto-suffixes logical IDs, so anchor on the
+# `LocalListFixture:My...` prefix rather than the full ID).
+for qid_prefix in \
+  '      LocalListFixture:MyHandler' \
+  '      LocalListFixture:MyHttpApi' \
+  '      LocalListFixture:MyService' \
+  '      LocalListFixture:MyTask' \
+  '      LocalListFixture:MyAgent' \
+  '      LocalListFixture:MyAlb'
+do
+  if ! grep -q "^${qid_prefix}" "${LONG_OUT_FILE}"; then
+    echo "FAIL: --long mode missing qualified-ID line for prefix: '${qid_prefix}'"
+    echo "----- list -l output -----"; cat "${LONG_OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  echo "    OK: --long emitted ${qid_prefix}*"
+done
+
+echo "==> cdkl list --help — asserting help surface is intact"
+${CDKL} list --help > "${HELP_FILE}"
+if ! grep -q "List the runnable targets" "${HELP_FILE}"; then
+  echo "FAIL: --help output missing canonical description"
+  cat "${HELP_FILE}"
+  exit 1
+fi
+if ! grep -q -- "-l, --long" "${HELP_FILE}"; then
+  echo "FAIL: --help output missing -l/--long option"
+  cat "${HELP_FILE}"
+  exit 1
+fi
+echo "    OK: --help surface intact"
+
+echo ""
+echo "==> local-list test passed (every target group + alias + --long + --help)"


### PR DESCRIPTION
## Summary

- Adds an end-to-end integration test for `cdkl list` — the command had
  143 LOC of unit coverage but zero integ. Because the interactive
  `target-picker` shares the same `target-lister` underneath, a
  regression in list semantics would silently break the picker too;
  this integ closes that gap.
- The fixture is a single stack (`LocalListFixture`) hand-rolled with
  L1 resources + an inline Lambda so it synthesizes with no AWS, no
  Docker, no asset bundling. It exercises every target kind `cdkl list`
  emits a group for: Lambda function, HTTP API v2 + Function URL,
  ECS task definition + service, AgentCore Runtime, and
  ALB-fronted ECS service.
- `verify.sh` is pure synth-time — no `docker pull`, no `docker run`,
  no AWS deploy. It runs `cdkl list` against the fixture and asserts
  every group header + target line, then locks down the `ls` alias
  (asserted byte-identical to `list`), the `-l/--long` qualified-ID
  lines, and the `--help` surface.

## Test plan

- [x] `bash tests/integration/local-list/verify.sh` exits 0 locally —
      every group header, every target line, alias parity, `--long`
      mode, and `--help` surface all assert green.
- [x] `vp check` clean (typecheck + lint + format).
- [x] `vp test run` clean (1660 unit tests pass).
- [ ] CI green.
