### PR TITLE
fix(invoke-agentcore): resolve bare --assume-role for same-stack Runtime exec roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@aws-cdk/cloud-assembly-api": "^2.2.0",
     "@aws-cdk/toolkit-lib": "^1.26.0",
     "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-sdk/client-bedrock-agentcore-control": "^3.1057.0",
     "@aws-sdk/client-cloudformation": "^3.1017.0",
     "@aws-sdk/client-ecr": "^3.1019.0",
     "@aws-sdk/client-eventbridge": "^3.1017.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@aws-crypto/sha256-js':
         specifier: ^5.2.0
         version: 5.2.0
+      '@aws-sdk/client-bedrock-agentcore-control':
+        specifier: ^3.1057.0
+        version: 3.1057.0
       '@aws-sdk/client-cloudformation':
         specifier: ^3.1017.0
         version: 3.1053.0
@@ -223,7 +226,11 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock-agentcore-control@3.1053.0':
-    resolution: {integrity: sha512-iqh1BW3fhaL9oxaVCWAWIlo7/95puii6DK8W4Al19fzCEYs+yrIJDmhs9G4X5SSdbQLI7uDcE8swh3GELhdkFg==, tarball: https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore-control/-/client-bedrock-agentcore-control-3.1053.0.tgz}
+    resolution: {integrity: sha512-iqh1BW3fhaL9oxaVCWAWIlo7/95puii6DK8W4Al19fzCEYs+yrIJDmhs9G4X5SSdbQLI7uDcE8swh3GELhdkFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-bedrock-agentcore-control@3.1057.0':
+    resolution: {integrity: sha512-REASfgMI9i8k55OJSdSWn7rcoJIKllWMfffoR/tbu4+JLcbrV9j7uPKQg085d0w3Vx3NRrjoNlBjijq7W2dIeQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cloudcontrol@3.1053.0':
@@ -318,6 +325,10 @@ packages:
     resolution: {integrity: sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==, tarball: https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.15':
+    resolution: {integrity: sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/crc64-nvme@3.972.9':
     resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
     engines: {node: '>=20.0.0'}
@@ -330,32 +341,64 @@ packages:
     resolution: {integrity: sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.41':
+    resolution: {integrity: sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.41':
     resolution: {integrity: sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    resolution: {integrity: sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.43':
     resolution: {integrity: sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.46':
+    resolution: {integrity: sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.43':
     resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    resolution: {integrity: sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.44':
     resolution: {integrity: sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.47':
+    resolution: {integrity: sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.39':
     resolution: {integrity: sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    resolution: {integrity: sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.43':
     resolution: {integrity: sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    resolution: {integrity: sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    resolution: {integrity: sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.1053.0':
@@ -412,12 +455,24 @@ packages:
     resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==, tarball: https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.13':
+    resolution: {integrity: sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.28':
     resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    resolution: {integrity: sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1052.0':
     resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==, tarball: https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1056.0':
+    resolution: {integrity: sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.9':
@@ -430,6 +485,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.25':
     resolution: {integrity: sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==, tarball: https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1065,12 +1124,24 @@ packages:
     resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.5':
+    resolution: {integrity: sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.3.4':
     resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==, tarball: https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/credential-provider-imds@4.3.6':
+    resolution: {integrity: sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/fetch-http-handler@5.4.4':
     resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.5':
+    resolution: {integrity: sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -1089,6 +1160,10 @@ packages:
     resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.5':
+    resolution: {integrity: sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.3.4':
     resolution: {integrity: sha512-ozP4y+MVRgiJJ1WEkT3/cFHungnv7g1ED9A9lVFlIlOUc9QkEfEYOu+AKUpyRqS9lxKWsdWWcdgSvX6aoRxV/A==, tarball: https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.3.4.tgz}
     engines: {node: '>=18.0.0'}
@@ -1099,6 +1174,10 @@ packages:
 
   '@smithy/signature-v4@5.4.4':
     resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.5':
+    resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.2':
@@ -3373,6 +3452,19 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/client-bedrock-agentcore-control@3.1057.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-node': 3.972.47
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-cloudcontrol@3.1053.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -3683,6 +3775,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.15':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.5
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.9':
     dependencies:
       '@smithy/types': 4.14.2
@@ -3704,6 +3807,14 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.41':
     dependencies:
       '@aws-sdk/core': 3.974.13
@@ -3711,6 +3822,16 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
       '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3730,12 +3851,37 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.46':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-login': 3.972.45
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.6
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.43':
     dependencies:
       '@aws-sdk/core': 3.974.13
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3753,11 +3899,33 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.47':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-ini': 3.972.46
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.6
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.39':
     dependencies:
       '@aws-sdk/core': 3.974.13
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3771,12 +3939,31 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/token-providers': 3.1056.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     dependencies:
       '@aws-sdk/core': 3.974.13
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3902,11 +4089,31 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.13':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/signature-v4-multi-region': 3.996.30
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.28':
     dependencies:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3916,6 +4123,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1056.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -3931,6 +4147,12 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.25':
     dependencies:
       '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
       '@smithy/types': 4.14.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
@@ -4449,15 +4671,33 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.3.4':
     dependencies:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/credential-provider-imds@4.3.6':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/fetch-http-handler@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -4481,6 +4721,12 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.3.4':
     dependencies:
       '@smithy/core': 3.24.4
@@ -4494,6 +4740,12 @@ snapshots:
   '@smithy/signature-v4@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -404,7 +404,7 @@ async function localInvokeAgentCoreCommand(
     // every cross-stack intrinsic the env path supports is supported here too.
     await resolveFromS3BucketIntrinsic(resolved, stateProvider, loadedState, imageContext);
 
-    const image = await resolveAgentCoreImage(resolved, options, loadedState);
+    const image = await resolveAgentCoreImage(resolved, options, loadedState, stateProvider);
 
     const { env: dockerEnv, sensitiveEnvKeys } = await buildContainerEnv(
       resolved,
@@ -511,7 +511,8 @@ async function localInvokeAgentCoreCommand(
         containerHost,
         hostPort,
         event,
-        sessionId
+        sessionId,
+        stateProvider
       );
 
       const result = await invokeAgentCore(containerHost, hostPort, event, {
@@ -617,7 +618,8 @@ export async function buildSigV4HeadersIfRequested(
   host: string,
   port: number,
   event: unknown,
-  sessionId: string
+  sessionId: string,
+  stateProvider?: LocalStateProvider
 ): Promise<Record<string, string> | undefined> {
   if (!options.sigv4) return undefined;
   if (options.bearerToken) {
@@ -645,7 +647,13 @@ export async function buildSigV4HeadersIfRequested(
       'LOCAL_INVOKE_AGENTCORE_SIGV4_NO_REGION'
     );
   }
-  const credentials = await resolveHostCredentialsForSigV4(options, resolved, loaded, region);
+  const credentials = await resolveHostCredentialsForSigV4(
+    options,
+    resolved,
+    loaded,
+    region,
+    stateProvider
+  );
   const signed = await signAgentCoreInvocation({
     credentials,
     region,
@@ -679,10 +687,11 @@ async function resolveHostCredentialsForSigV4(
   options: LocalInvokeAgentCoreOptions,
   resolved: ResolvedAgentCoreRuntime,
   loaded: LocalStateRecord | undefined,
-  region: string
+  region: string,
+  stateProvider: LocalStateProvider | undefined
 ): Promise<SigV4Credentials> {
   const logger = getLogger();
-  const assumeRoleArn = resolveAssumeRoleArn(options, resolved, loaded);
+  const assumeRoleArn = await resolveAssumeRoleArn(options, resolved, loaded, stateProvider);
   if (assumeRoleArn) {
     try {
       return await assumeAgentCoreExecutionRole(assumeRoleArn, region);
@@ -730,12 +739,15 @@ async function resolveHostCredentialsForSigV4(
  *
  * `loaded` is the `--from-cfn-stack` state record (when available) — threaded
  * through so a bare `--assume-role` can resolve the execution-role ARN from
- * state for the fromS3 download.
+ * state for the fromS3 download. `stateProvider` enables the issue-#187
+ * live-fallback to `bedrock-agentcore-control:GetAgentRuntime` when the
+ * static state lookup misses.
  */
 export async function resolveAgentCoreImage(
   resolved: ResolvedAgentCoreRuntime,
   options: LocalInvokeAgentCoreOptions,
-  loaded?: LocalStateRecord
+  loaded?: LocalStateRecord,
+  stateProvider?: LocalStateProvider
 ): Promise<string> {
   const logger = getLogger();
   const architecture = platformToArchitecture(options.platform);
@@ -746,7 +758,8 @@ export async function resolveAgentCoreImage(
       resolved.codeArtifact,
       options,
       architecture,
-      loaded
+      loaded,
+      stateProvider
     );
   }
 
@@ -802,7 +815,8 @@ async function resolveAgentCoreCodeImage(
   code: AgentCoreCodeArtifact,
   options: LocalInvokeAgentCoreOptions,
   architecture: 'x86_64' | 'arm64',
-  loaded?: LocalStateRecord
+  loaded?: LocalStateRecord,
+  stateProvider?: LocalStateProvider
 ): Promise<string> {
   if (code.s3Source) {
     return resolveAgentCoreCodeImageFromS3(
@@ -811,7 +825,8 @@ async function resolveAgentCoreCodeImage(
       code.s3Source,
       options,
       architecture,
-      loaded
+      loaded,
+      stateProvider
     );
   }
 
@@ -877,7 +892,8 @@ async function resolveAgentCoreCodeImageFromS3(
   s3Source: NonNullable<AgentCoreCodeArtifact['s3Source']>,
   options: LocalInvokeAgentCoreOptions,
   architecture: 'x86_64' | 'arm64',
-  loaded: LocalStateRecord | undefined
+  loaded: LocalStateRecord | undefined,
+  stateProvider: LocalStateProvider | undefined
 ): Promise<string> {
   const logger = getLogger();
   // The bucket should be a literal string by this point — a template-literal
@@ -902,7 +918,7 @@ async function resolveAgentCoreCodeImageFromS3(
     process.env['AWS_DEFAULT_REGION'] ??
     resolved.stack.region;
 
-  const assumeRoleArn = resolveAssumeRoleArn(options, resolved, loaded);
+  const assumeRoleArn = await resolveAssumeRoleArn(options, resolved, loaded, stateProvider);
   let credentials:
     | { accessKeyId: string; secretAccessKey: string; sessionToken: string }
     | undefined;
@@ -1024,7 +1040,7 @@ export async function buildContainerEnv(
   }
 
   const dockerEnv: Record<string, string> = { ...envResult.resolved };
-  const assumeRoleArn = resolveAssumeRoleArn(options, resolved, loaded);
+  const assumeRoleArn = await resolveAssumeRoleArn(options, resolved, loaded, stateProvider);
   await applyAgentCoreCredentialEnv(dockerEnv, {
     ...(assumeRoleArn !== undefined && { assumeRoleArn }),
     ...(options.region !== undefined && { region: options.region }),
@@ -1226,33 +1242,53 @@ export async function applyAgentCoreCredentialEnv(
  * Resolve the role ARN to assume, honoring the three `--assume-role` forms.
  * Bare `--assume-role` uses the runtime's literal `RoleArn`; when that is an
  * intrinsic (the common L2 case — `Fn::GetAtt` to an auto-created role) it
- * resolves the execution-role ARN from `--from-cfn-stack` state, and only
- * warns + falls back to dev creds when neither is available.
+ * resolves the execution-role ARN from `--from-cfn-stack` state first; when
+ * that misses (issue #187 — `ListStackResources` returns the role's name,
+ * not its ARN, so `attributes.Arn` is empty on the CFn state map) it falls
+ * back to `stateProvider.resolveAgentCoreRuntimeRoleArn(<physicalId>)`
+ * (a `bedrock-agentcore-control:GetAgentRuntime` call) so a same-stack
+ * execution role still resolves. Only warns + falls back to dev creds
+ * when all of those miss.
  */
-export function resolveAssumeRoleArn(
+export async function resolveAssumeRoleArn(
   options: LocalInvokeAgentCoreOptions,
   resolved: ResolvedAgentCoreRuntime,
-  loaded: LocalStateRecord | undefined
-): string | undefined {
+  loaded: LocalStateRecord | undefined,
+  stateProvider?: Pick<LocalStateProvider, 'resolveAgentCoreRuntimeRoleArn'>
+): Promise<string | undefined> {
   if (typeof options.assumeRole === 'string') return options.assumeRole;
-  if (options.assumeRole === true) {
-    if (resolved.roleArn) return resolved.roleArn;
-    if (loaded) {
-      const fromState = resolveExecutionRoleArnFromState(loaded, resolved.logicalId, 'RoleArn');
-      if (fromState) {
-        getLogger().debug(`--assume-role: resolved RoleArn from state: ${fromState}`);
-        return fromState;
+  if (options.assumeRole !== true) return undefined;
+  // Bare --assume-role from here on.
+  if (resolved.roleArn) return resolved.roleArn;
+  if (loaded) {
+    const fromState = resolveExecutionRoleArnFromState(loaded, resolved.logicalId, 'RoleArn');
+    if (fromState) {
+      getLogger().debug(`--assume-role: resolved RoleArn from state: ${fromState}`);
+      return fromState;
+    }
+    // Issue #187 fallback: state-only lookup misses for sibling-stack
+    // exec roles because `ListStackResources` returns the role's name,
+    // not its ARN. The runtime's deploy-time `roleArn` carries the
+    // full ARN — read it via `bedrock-agentcore-control:GetAgentRuntime`.
+    const runtimePhysicalId = loaded.resources[resolved.logicalId]?.physicalId;
+    if (stateProvider?.resolveAgentCoreRuntimeRoleArn && runtimePhysicalId) {
+      const liveArn = await stateProvider.resolveAgentCoreRuntimeRoleArn(runtimePhysicalId);
+      if (liveArn) {
+        getLogger().info(
+          `--assume-role: auto-resolved execution role from GetAgentRuntime: ${liveArn}`
+        );
+        return liveArn;
       }
     }
-    getLogger().warn(
-      "--assume-role passed without an ARN, but the runtime's RoleArn is not a literal ARN in the template " +
-        (loaded
-          ? 'and could not be resolved from the deployed stack state. '
-          : 'and no --from-cfn-stack state is available to resolve it. ') +
-        'Pass the ARN explicitly: --assume-role <arn>. ' +
-        "Falling back to the developer's shell credentials."
-    );
   }
+  getLogger().warn(
+    "--assume-role passed without an ARN, but the runtime's RoleArn is not a literal ARN in the template " +
+      (loaded
+        ? 'and could not be resolved from the deployed stack state. '
+        : 'and no --from-cfn-stack state is available to resolve it. ') +
+      'Pass the ARN explicitly: --assume-role <arn>. ' +
+      "Falling back to the developer's shell credentials."
+  );
   return undefined;
 }
 

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -69,6 +69,10 @@ import {
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
 import { LambdaClient, GetFunctionConfigurationCommand } from '@aws-sdk/client-lambda';
+import {
+  BedrockAgentCoreControlClient,
+  GetAgentRuntimeCommand,
+} from '@aws-sdk/client-bedrock-agentcore-control';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { getLogger } from '../utils/logger.js';
 import { collectSsmParameterRefs, resolveSsmParameters } from './ssm-parameter-resolver.js';
@@ -131,6 +135,11 @@ export class CfnLocalStateProvider implements LocalStateProvider {
   // declare no `AWS::SSM::Parameter::Value` parameters don't open a
   // needless client.
   private ssmClient: SSMClient | undefined;
+  // The Bedrock AgentCore control client is constructed lazily on the
+  // first `resolveAgentCoreRuntimeRoleArn` call so invocations that
+  // never need the deployed-role fallback for an AgentCore Runtime
+  // don't open a needless client.
+  private agentCoreControlClient: BedrockAgentCoreControlClient | undefined;
   private readonly clientOptions: { region: string; profile?: string };
   // Issue #611 NIT 2: `dispose()` is terminal. The lazy `getClient()`
   // path would otherwise resurrect the client on a post-dispose
@@ -178,6 +187,19 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       });
     }
     return this.lambdaClient;
+  }
+
+  private getAgentCoreControlClient(): BedrockAgentCoreControlClient {
+    if (this.disposed) {
+      throw new Error('CfnLocalStateProvider used after dispose()');
+    }
+    if (!this.agentCoreControlClient) {
+      this.agentCoreControlClient = new BedrockAgentCoreControlClient({
+        region: this.region,
+        ...(this.clientOptions.profile !== undefined && { profile: this.clientOptions.profile }),
+      });
+    }
+    return this.agentCoreControlClient;
   }
 
   private getSsmClient(): SSMClient {
@@ -287,6 +309,41 @@ export class CfnLocalStateProvider implements LocalStateProvider {
     } catch (err) {
       logger.warn(
         `${this.label}: GetFunctionConfiguration(${functionPhysicalId}) for --assume-role auto-resolve failed: ${formatAwsErrorForWarn(err)}. ` +
+          `Pass the ARN explicitly: --assume-role <arn>.`
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Read a deployed AgentCore Runtime's execution-role ARN via
+   * `bedrock-agentcore-control:GetAgentRuntime`'s `roleArn` field.
+   * See {@link LocalStateProvider.resolveAgentCoreRuntimeRoleArn}.
+   *
+   * Best-effort: on any expected miss (runtime not found, access
+   * denied, throttling) logs a warn and returns `undefined` so the
+   * caller falls through to the existing "Pass the ARN explicitly:
+   * --assume-role <arn>" path. Never throws.
+   */
+  public async resolveAgentCoreRuntimeRoleArn(
+    runtimePhysicalId: string
+  ): Promise<string | undefined> {
+    if (this.disposed) {
+      throw new Error('CfnLocalStateProvider used after dispose()');
+    }
+    const logger = getLogger();
+    const client = this.getAgentCoreControlClient();
+    try {
+      const resp = await client.send(
+        new GetAgentRuntimeCommand({ agentRuntimeId: runtimePhysicalId })
+      );
+      if (typeof resp.roleArn === 'string' && resp.roleArn.startsWith('arn:')) {
+        return resp.roleArn;
+      }
+      return undefined;
+    } catch (err) {
+      logger.warn(
+        `${this.label}: GetAgentRuntime(${runtimePhysicalId}) for --assume-role auto-resolve failed: ${formatAwsErrorForWarn(err)}. ` +
           `Pass the ARN explicitly: --assume-role <arn>.`
       );
       return undefined;
@@ -444,6 +501,10 @@ export class CfnLocalStateProvider implements LocalStateProvider {
     if (this.ssmClient) {
       this.ssmClient.destroy();
       this.ssmClient = undefined;
+    }
+    if (this.agentCoreControlClient) {
+      this.agentCoreControlClient.destroy();
+      this.agentCoreControlClient = undefined;
     }
   }
 }

--- a/src/local/local-state-provider.ts
+++ b/src/local/local-state-provider.ts
@@ -176,6 +176,34 @@ export interface LocalStateProvider {
    */
   resolveLambdaExecutionRoleArn?(functionPhysicalId: string): Promise<string | undefined>;
   /**
+   * Optional: resolve a deployed AgentCore Runtime's execution-role ARN
+   * via `bedrock-agentcore-control:GetAgentRuntime`'s `roleArn` field.
+   *
+   * Closes the bare `--assume-role` auto-resolve gap (issue #187) for
+   * the common case where the Runtime's execution role is a sibling
+   * resource in the same stack (`new bedrock.AgentCoreRuntime(...)` with
+   * the L2's auto-created default execution role). `ListStackResources`
+   * returns the role's NAME (PhysicalResourceId), not the ARN, so the
+   * static state lookup in {@link resolveExecutionRoleArnFromState} (which
+   * reads `attributes.Arn`) returns `undefined`. The runtime's own
+   * deploy-time-resolved configuration is the lowest-cost way to recover
+   * the ARN — same shape as
+   * {@link LocalStateProvider.resolveLambdaExecutionRoleArn}, one extra
+   * `bedrock-agentcore-control:GetAgentRuntime` call.
+   *
+   * `runtimePhysicalId` is the deployed runtime's `agentRuntimeId` (the
+   * `Ref` value `ListStackResources` returns for
+   * `AWS::BedrockAgentCore::Runtime`).
+   * Returns `undefined` on any expected miss (no such runtime, access
+   * denied, throttling) so the caller falls back to the existing
+   * "Pass the ARN explicitly: --assume-role <arn>" warning.
+   *
+   * Implemented only by the CFn provider (`--from-cfn-stack`) — the S3
+   * provider's state already carries deploy-time attributes, so its
+   * `attributes.Arn` resolves statically and no fallback is needed.
+   */
+  resolveAgentCoreRuntimeRoleArn?(runtimePhysicalId: string): Promise<string | undefined>;
+  /**
    * Optional: resolve a synthesized stack template's SSM-backed
    * `Parameters` (`AWS::SSM::Parameter::Value<String>` /
    * `AWS::SSM::Parameter::Value<List<String>>`, what CDK synthesizes for

--- a/tests/unit/cli/local-invoke-agentcore-creds.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore-creds.test.ts
@@ -18,6 +18,7 @@ vi.mock('@aws-sdk/client-sts', () => ({
 const { applyAgentCoreCredentialEnv, resolveAssumeRoleArn, buildAgentCoreImageContext } =
   await import('../../../src/cli/commands/local-invoke-agentcore.js');
 import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-resolver.js';
+import type { LocalStateProvider, LocalStateRecord } from '../../../src/local/local-state-provider.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
 function runtime(roleArn?: string): ResolvedAgentCoreRuntime {
@@ -37,26 +38,152 @@ const opts = (assumeRole: string | boolean | undefined): Parameters<typeof resol
   ({ assumeRole }) as unknown as Parameters<typeof resolveAssumeRoleArn>[0];
 
 describe('resolveAssumeRoleArn — three --assume-role forms', () => {
-  it('returns the explicit ARN for --assume-role <arn>', () => {
-    expect(resolveAssumeRoleArn(opts('arn:aws:iam::1:role/X'), runtime(), undefined)).toBe(
+  it('returns the explicit ARN for --assume-role <arn>', async () => {
+    expect(await resolveAssumeRoleArn(opts('arn:aws:iam::1:role/X'), runtime(), undefined)).toBe(
       'arn:aws:iam::1:role/X'
     );
   });
 
-  it("uses the runtime's literal RoleArn for bare --assume-role", () => {
-    expect(resolveAssumeRoleArn(opts(true), runtime('arn:aws:iam::1:role/Agent'), undefined)).toBe(
-      'arn:aws:iam::1:role/Agent'
-    );
-  });
-
-  it('returns undefined for bare --assume-role when RoleArn is not a literal (no state)', () => {
-    expect(resolveAssumeRoleArn(opts(true), runtime(undefined), undefined)).toBeUndefined();
-  });
-
-  it('returns undefined when --assume-role is absent', () => {
+  it("uses the runtime's literal RoleArn for bare --assume-role", async () => {
     expect(
-      resolveAssumeRoleArn(opts(undefined), runtime('arn:aws:iam::1:role/Agent'), undefined)
+      await resolveAssumeRoleArn(opts(true), runtime('arn:aws:iam::1:role/Agent'), undefined)
+    ).toBe('arn:aws:iam::1:role/Agent');
+  });
+
+  it('returns undefined for bare --assume-role when RoleArn is not a literal (no state)', async () => {
+    expect(
+      await resolveAssumeRoleArn(opts(true), runtime(undefined), undefined)
     ).toBeUndefined();
+  });
+
+  it('returns undefined when --assume-role is absent', async () => {
+    expect(
+      await resolveAssumeRoleArn(opts(undefined), runtime('arn:aws:iam::1:role/Agent'), undefined)
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveAssumeRoleArn — bare --assume-role state-miss live fallback (issue #187)', () => {
+  function stateWithRuntime(opts: {
+    logicalId: string;
+    physicalId?: string;
+    roleProperty?: unknown;
+    roleResource?: { logicalId: string; arn?: string };
+  }): LocalStateRecord {
+    const resources: LocalStateRecord['resources'] = {};
+    resources[opts.logicalId] = {
+      physicalId: opts.physicalId ?? `${opts.logicalId}-physical`,
+      resourceType: 'AWS::BedrockAgentCore::Runtime',
+      properties: opts.roleProperty !== undefined ? { RoleArn: opts.roleProperty } : {},
+      attributes: {},
+      dependencies: [],
+    };
+    if (opts.roleResource) {
+      const attrs: Record<string, unknown> = {};
+      if (opts.roleResource.arn) attrs['Arn'] = opts.roleResource.arn;
+      resources[opts.roleResource.logicalId] = {
+        physicalId: 'role-physical',
+        resourceType: 'AWS::IAM::Role',
+        properties: {},
+        attributes: attrs,
+        dependencies: [],
+      };
+    }
+    return { resources, outputs: {}, region: 'us-east-1' };
+  }
+
+  it('takes the state-only fast path when attributes.Arn is cached (no SDK call)', async () => {
+    const state = stateWithRuntime({
+      logicalId: 'ChatAgent',
+      roleProperty: { 'Fn::GetAtt': ['AgentRole', 'Arn'] },
+      roleResource: { logicalId: 'AgentRole', arn: 'arn:aws:iam::1:role/Agent-state-cached' },
+    });
+    const resolveAgentCoreRuntimeRoleArn = vi.fn();
+    const stateProvider = {
+      resolveAgentCoreRuntimeRoleArn,
+    } as unknown as LocalStateProvider;
+
+    const arn = await resolveAssumeRoleArn(opts(true), runtime(undefined), state, stateProvider);
+
+    expect(arn).toBe('arn:aws:iam::1:role/Agent-state-cached');
+    expect(resolveAgentCoreRuntimeRoleArn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to stateProvider.resolveAgentCoreRuntimeRoleArn when state misses (issue #187)', async () => {
+    const state = stateWithRuntime({
+      logicalId: 'ChatAgent',
+      physicalId: 'agent-runtime-abc123',
+      roleProperty: { 'Fn::GetAtt': ['AgentRole', 'Arn'] },
+      // AgentRole is in resources but its attributes.Arn is empty,
+      // matching what `ListStackResources` produces in the CFn state
+      // provider — exactly the issue #187 trigger.
+      roleResource: { logicalId: 'AgentRole' },
+    });
+    const resolveAgentCoreRuntimeRoleArn = vi
+      .fn()
+      .mockResolvedValue('arn:aws:iam::1:role/Agent-live');
+    const stateProvider = {
+      resolveAgentCoreRuntimeRoleArn,
+    } as unknown as LocalStateProvider;
+
+    const arn = await resolveAssumeRoleArn(opts(true), runtime(undefined), state, stateProvider);
+
+    expect(arn).toBe('arn:aws:iam::1:role/Agent-live');
+    expect(resolveAgentCoreRuntimeRoleArn).toHaveBeenCalledTimes(1);
+    expect(resolveAgentCoreRuntimeRoleArn).toHaveBeenCalledWith('agent-runtime-abc123');
+  });
+
+  it('warns and returns undefined when both state and live fallback miss', async () => {
+    const state = stateWithRuntime({
+      logicalId: 'ChatAgent',
+      physicalId: 'agent-runtime-abc123',
+      roleProperty: { 'Fn::GetAtt': ['AgentRole', 'Arn'] },
+      roleResource: { logicalId: 'AgentRole' },
+    });
+    const stateProvider = {
+      resolveAgentCoreRuntimeRoleArn: vi.fn().mockResolvedValue(undefined),
+    } as unknown as LocalStateProvider;
+
+    const arn = await resolveAssumeRoleArn(opts(true), runtime(undefined), state, stateProvider);
+
+    expect(arn).toBeUndefined();
+  });
+
+  it('propagates rejections from the live fallback (caller decides recovery)', async () => {
+    // The CFn provider's contract is best-effort + never-throws, but a host
+    // extension implementing the optional method could violate it. The
+    // helper deliberately does NOT swallow the rejection so the host bug
+    // surfaces instead of silently falling back to dev creds.
+    const state = stateWithRuntime({
+      logicalId: 'ChatAgent',
+      physicalId: 'agent-runtime-abc123',
+      roleProperty: { 'Fn::GetAtt': ['AgentRole', 'Arn'] },
+      roleResource: { logicalId: 'AgentRole' },
+    });
+    const stateProvider = {
+      resolveAgentCoreRuntimeRoleArn: vi.fn().mockRejectedValue(new Error('host bug')),
+    } as unknown as LocalStateProvider;
+
+    await expect(
+      resolveAssumeRoleArn(opts(true), runtime(undefined), state, stateProvider)
+    ).rejects.toThrow(/host bug/);
+  });
+
+  it('does not call the live fallback when the state provider does not implement the method', async () => {
+    const state = stateWithRuntime({
+      logicalId: 'ChatAgent',
+      physicalId: 'agent-runtime-abc123',
+      roleProperty: { 'Fn::GetAtt': ['AgentRole', 'Arn'] },
+      roleResource: { logicalId: 'AgentRole' },
+    });
+    // A state provider that does not implement
+    // resolveAgentCoreRuntimeRoleArn (e.g. an S3-state provider) is
+    // allowed — the optional method should not be called.
+    const stateProvider = {} as unknown as LocalStateProvider;
+
+    const arn = await resolveAssumeRoleArn(opts(true), runtime(undefined), state, stateProvider);
+
+    expect(arn).toBeUndefined();
   });
 });
 

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -650,15 +650,19 @@ describe('resolveAssumeRoleArn — bare --assume-role + state', () => {
       ...over,
     }) as never;
 
-  it('returns the explicit ARN for --assume-role <arn>', () => {
-    expect(resolveAssumeRoleArn({ assumeRole: 'arn:aws:iam::1:role/x' } as never, resolved(), undefined)).toBe(
-      'arn:aws:iam::1:role/x'
-    );
+  it('returns the explicit ARN for --assume-role <arn>', async () => {
+    expect(
+      await resolveAssumeRoleArn(
+        { assumeRole: 'arn:aws:iam::1:role/x' } as never,
+        resolved(),
+        undefined
+      )
+    ).toBe('arn:aws:iam::1:role/x');
   });
 
-  it('uses the literal RoleArn for bare --assume-role when present', () => {
+  it('uses the literal RoleArn for bare --assume-role when present', async () => {
     expect(
-      resolveAssumeRoleArn(
+      await resolveAssumeRoleArn(
         { assumeRole: true } as never,
         resolved({ roleArn: 'arn:aws:iam::1:role/lit' }),
         undefined
@@ -666,24 +670,28 @@ describe('resolveAssumeRoleArn — bare --assume-role + state', () => {
     ).toBe('arn:aws:iam::1:role/lit');
   });
 
-  it('resolves an intrinsic RoleArn from --from-cfn-stack state for bare --assume-role', () => {
+  it('resolves an intrinsic RoleArn from --from-cfn-stack state for bare --assume-role', async () => {
     const loaded = {
       resources: {
         ChatAgent: { properties: { RoleArn: { 'Fn::GetAtt': ['AgentRole', 'Arn'] } } },
         AgentRole: { attributes: { Arn: 'arn:aws:iam::1:role/from-state' } },
       },
     };
-    expect(resolveAssumeRoleArn({ assumeRole: true } as never, resolved(), loaded as never)).toBe(
-      'arn:aws:iam::1:role/from-state'
-    );
+    expect(
+      await resolveAssumeRoleArn({ assumeRole: true } as never, resolved(), loaded as never)
+    ).toBe('arn:aws:iam::1:role/from-state');
   });
 
-  it('returns undefined (warn + dev-creds fallback) when bare --assume-role cannot resolve', () => {
-    expect(resolveAssumeRoleArn({ assumeRole: true } as never, resolved(), undefined)).toBeUndefined();
+  it('returns undefined (warn + dev-creds fallback) when bare --assume-role cannot resolve', async () => {
+    expect(
+      await resolveAssumeRoleArn({ assumeRole: true } as never, resolved(), undefined)
+    ).toBeUndefined();
   });
 
-  it('returns undefined when --assume-role is not set', () => {
-    expect(resolveAssumeRoleArn({} as never, resolved(), undefined)).toBeUndefined();
+  it('returns undefined when --assume-role is not set', async () => {
+    expect(
+      await resolveAssumeRoleArn({} as never, resolved(), undefined)
+    ).toBeUndefined();
   });
 });
 

--- a/tests/unit/local/cfn-local-state-provider-agentcore-role.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-agentcore-role.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Mock the AgentCore control SDK so `resolveAgentCoreRuntimeRoleArn()`
+// (which constructs its own BedrockAgentCoreControlClient via the lazy
+// getAgentCoreControlClient()) can be exercised without real AWS.
+const { acSendMock, acDestroyMock } = vi.hoisted(() => ({
+  acSendMock: vi.fn(),
+  acDestroyMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-bedrock-agentcore-control', () => ({
+  BedrockAgentCoreControlClient: class {
+    send = acSendMock;
+    destroy = acDestroyMock;
+  },
+  GetAgentRuntimeCommand: class {
+    constructor(public readonly input: unknown) {}
+  },
+}));
+
+// Lambda client is unused by these tests but the module imports it at load.
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: class {
+    send = vi.fn();
+    destroy(): void {}
+  },
+  GetFunctionConfigurationCommand: class {},
+}));
+
+// CFn client is unused by these tests but the module imports it at load.
+vi.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: class {
+    send = vi.fn();
+    destroy(): void {}
+  },
+  ListStackResourcesCommand: class {},
+  DescribeStacksCommand: class {},
+  ListExportsCommand: class {},
+}));
+
+const { CfnLocalStateProvider } = await import('../../../src/local/cfn-local-state-provider.js');
+
+describe('CfnLocalStateProvider.resolveAgentCoreRuntimeRoleArn', () => {
+  beforeEach(() => {
+    acSendMock.mockReset();
+    acDestroyMock.mockReset();
+  });
+
+  it("returns the deployed runtime's roleArn", async () => {
+    acSendMock.mockResolvedValueOnce({
+      roleArn: 'arn:aws:iam::111:role/Stack-AgentRuntimeExecRole-AAA',
+    });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveAgentCoreRuntimeRoleArn('agent-runtime-abc123');
+
+    expect(arn).toBe('arn:aws:iam::111:role/Stack-AgentRuntimeExecRole-AAA');
+    expect(acSendMock).toHaveBeenCalledTimes(1);
+    const cmd = acSendMock.mock.calls[0]?.[0] as { input: { agentRuntimeId: string } };
+    expect(cmd.input.agentRuntimeId).toBe('agent-runtime-abc123');
+  });
+
+  it('returns undefined when the response roleArn is missing', async () => {
+    acSendMock.mockResolvedValueOnce({});
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveAgentCoreRuntimeRoleArn('agent-runtime-abc123');
+
+    expect(arn).toBeUndefined();
+  });
+
+  it('returns undefined when the response roleArn is not an ARN', async () => {
+    acSendMock.mockResolvedValueOnce({ roleArn: 'not-an-arn' });
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveAgentCoreRuntimeRoleArn('agent-runtime-abc123');
+
+    expect(arn).toBeUndefined();
+  });
+
+  it('warns and returns undefined on SDK error (access denied / throttling / not found)', async () => {
+    acSendMock.mockRejectedValueOnce(
+      Object.assign(new Error('User is not authorized'), { name: 'AccessDeniedException' })
+    );
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+
+    const arn = await provider.resolveAgentCoreRuntimeRoleArn('agent-runtime-abc123');
+
+    expect(arn).toBeUndefined();
+  });
+
+  it('throws when called after dispose() (use-after-free guard)', async () => {
+    const provider = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+    provider.dispose();
+
+    await expect(provider.resolveAgentCoreRuntimeRoleArn('agent-runtime-abc123')).rejects.toThrow(
+      /used after dispose/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #187.

Bare `cdkl invoke-agentcore --assume-role` (paired with `--from-cfn-stack`)
had the same shape as the Lambda case fixed in #185 / #181: when the
AgentCore Runtime's `RoleArn` property is an `Fn::GetAtt` intrinsic to an
auto-created role in the same stack (the common CDK L2 case), the static
state lookup missed because `ListStackResources` returns the role's NAME
(PhysicalResourceId), not its ARN — so `attributes.Arn` was empty on the
CFn state map. The container then ran without assumed-role credentials,
behind a misleading "Falling back to the developer's shell credentials"
warning that didn't actually fall back.

This is a mechanical mirror of #185 for the AgentCore Runtime path.

## Changes

- Add optional `resolveAgentCoreRuntimeRoleArn(runtimePhysicalId)` on
  `LocalStateProvider`. Mirrors the JSDoc + contract of the existing
  `resolveLambdaExecutionRoleArn`.
- Implement it on `CfnLocalStateProvider` via the new
  `@aws-sdk/client-bedrock-agentcore-control@^3.1057.0` SDK's
  `GetAgentRuntimeCommand`, reading `response.roleArn`. Best-effort:
  validates the `arn:` prefix, lazy `BedrockAgentCoreControlClient`,
  warn-and-return-undefined on any SDK error, throws on use-after-dispose
  — same shape as the Lambda equivalent.
- Make `resolveAssumeRoleArn` async and accept an optional `stateProvider`.
  After the existing literal-RoleArn + state-based lookup misses, call
  `stateProvider.resolveAgentCoreRuntimeRoleArn(<physicalId>)` before
  warning and falling back to dev credentials.
- Thread the state provider through `resolveAgentCoreImage`,
  `resolveAgentCoreCodeImage`, `resolveAgentCoreCodeImageFromS3`,
  `buildContainerEnv`, `buildSigV4HeadersIfRequested`, and
  `resolveHostCredentialsForSigV4` — every caller of
  `resolveAssumeRoleArn`.
- Dispose ordering: `local-invoke-agentcore.ts` already disposes the
  state provider via the single-flight `cleanup()` that runs at the very
  end of the command (not in a tight `try/finally` like
  `local-invoke.ts`), so the state provider is already alive across all
  uses of `resolveAssumeRoleArn`. No dispose-ordering edit was needed
  for this command.

## Tests

- New `tests/unit/local/cfn-local-state-provider-agentcore-role.test.ts`
  (5 tests, mirroring `cfn-local-state-provider-exec-role.test.ts`):
  happy path, missing `roleArn`, malformed `roleArn`, SDK error,
  use-after-dispose.
- New describe block in
  `tests/unit/cli/local-invoke-agentcore-creds.test.ts` (5 tests):
  state-hit fast path (no SDK call), state-miss live fallback (the
  issue-#187 case), both-miss, helper-rejection-propagates, no-method
  pass-through.
- Updated existing `resolveAssumeRoleArn` cases (now async) in
  `tests/unit/cli/local-invoke-agentcore-creds.test.ts` and
  `tests/unit/cli/local-invoke-agentcore.test.ts`.

Test count: 1659 → 1670 (+11). `vp run check` + `vp run test` + `vp run
build` all green locally.

## No live AWS integ

Deploying a real `AWS::BedrockAgentCore::Runtime` is significantly heavier
than the Lambda fixture in `local-invoke-assume-role`. The unit tests +
the proven #185 / #181 pattern (already live-tested end-to-end against a
deployed Lambda stack) give sufficient confidence for this mechanical
translation. Issue #187 explicitly defers a paired live AgentCore deploy
fixture to a follow-up.

## Test plan

- [x] `vp run check` passes
- [x] `vp run test` passes (1670 tests)
- [x] `vp run build` produces dist/cli.js + dist/index.js + dist/internal.js
- [ ] CI green
