### PR TITLE
docs(readme): tighten the opening — dedup coverage list + Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd your-cdk-app               # the directory holding cdk.json
 cdkl invoke                   # pick a Lambda from the list, then run it locally
 ```
 
-`cdkl` synths your CDK app and runs the selected resource locally in Docker — Lambdas in their real AWS Lambda runtime container, ECS tasks and services as real containers, APIs on a local HTTP server. Run any command with no target and it opens an arrow-key picker, so you rarely type a CDK path.
+`cdkl` synths your CDK app and runs the selected resource locally in Docker. Run any command with no target and it opens an arrow-key picker, so you rarely type a CDK path.
 
 **Add `--from-cfn-stack`** to bind to a deployed stack — your local handler then reads and writes the same real data the deployed app does ([how it works](#why-cdk-local)).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cdkl invoke MyStack/Fn --from-cfn-stack    # one Lambda against real DynamoDB / 
 - **Iterate against your real deployed stack — including its data.** `--from-cfn-stack` reads the deployed CloudFormation stack and injects its real ARNs, Secret values, and IAM credentials into the container, so you stay on the real DynamoDB rows, S3 objects, Cognito users, and Secret values your IAM credentials reach — instead of paying to seed and anonymize a local emulator.
 - **Picks up where `sam local` leaves off:**
   - **CDK-native** — point at `cdk.json`; no SAM template to maintain.
-  - **Wider coverage** — Lambda, API Gateway, ECS run-task / service / ALB front-door, and Bedrock AgentCore.
+  - **Wider coverage** — adds ECS, ALB front-doors, and Bedrock AgentCore on top of Lambda + API Gateway.
   - **Real container images** — the Lambda RIE base image; ECS as real Docker. The only dependency is Docker itself.
 
 ## What runs locally


### PR DESCRIPTION
## What

Follow-up to #195 / #196. Two small readability fixes to the top of the README, both removing redundant re-listing of the resource set.

### 1. Reframe the "Wider coverage" Why bullet

The covered resources were listed almost verbatim in the subtitle, this Why bullet, the Commands block, and the Supported resources table. Since the bullet lives under **"Picks up where `sam local` leaves off"**, reframe it as the delta over `sam local`'s scope:

**Before** — `Wider coverage — Lambda, API Gateway, ECS run-task / service / ALB front-door, and Bedrock AgentCore.`
**After** — `Wider coverage — adds ECS, ALB front-doors, and Bedrock AgentCore on top of Lambda + API Gateway.`

### 2. Tighten the Quick start explanation

The resource list first appears in the subtitle (and is fully covered by the Supported resources table), so re-listing it in the Quick start paragraph was redundant — and its order (Lambda, ECS, API) clashed with the subtitle's.

**Before** — `cdkl synths your CDK app and runs the selected resource locally in Docker — Lambdas in their real AWS Lambda runtime container, ECS tasks and services as real containers, APIs on a local HTTP server. Run any command ...`
**After** — `cdkl synths your CDK app and runs the selected resource locally in Docker. Run any command with no target and it opens an arrow-key picker, so you rarely type a CDK path.`

## Why

The enumeration belongs in one place (the Supported resources table); repeating it in prose just slows the first screen. No information is lost — the per-type "real container" detail still lives in the "Real container images" Why bullet and the table.

https://claude.ai/code/session_01H8Gh4xes2MFdcZpVUHaVkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8Gh4xes2MFdcZpVUHaVkL)_