### PR TITLE
feat(start-alb): serve cloud-HTTPS listeners over plain HTTP by default; gate real TLS behind `--tls`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,13 +31,18 @@ AWS managed services.
   counterpart of `start-api`: name the ALB, and it boots the ECS
   service(s) behind it plus a local front-door that round-robins each
   listener port across the replicas and routes the listener rules across
-  the backing services. HTTP **and HTTPS** listeners are served — HTTPS
-  termination uses a user-supplied (`--tls-cert` + `--tls-key`) or
-  auto-generated self-signed cert (cached under
+  the backing services. HTTP **and HTTPS** listeners are served — a
+  cloud-HTTPS listener is served over plain HTTP locally by default
+  (with `X-Forwarded-Proto: https` preserved + redirect `#{protocol}`
+  resolving to `https`, so the upstream app still sees the deployed
+  listener protocol; the degradation is logged per-listener so it is
+  never silent). `--tls` (or `--tls-cert` / `--tls-key`, which imply
+  `--tls`) opts in to real TLS termination, using the user-supplied
+  PEM pair or an auto-generated self-signed cert (cached under
   `$XDG_CACHE_HOME/cdk-local/alb-https/`, default
-  `~/.cache/cdk-local/alb-https/`; `openssl` invoked once on cache miss);
-  the deployed Listener `Certificates[]` ACM ARNs are not fetched
-  because ACM private keys are not retrievable by design. All six ALB
+  `~/.cache/cdk-local/alb-https/`; `openssl` invoked once on cache
+  miss). The deployed Listener `Certificates[]` ACM ARNs are not
+  fetched because ACM private keys are not retrievable by design. All six ALB
   rule-condition fields are honored (`path-pattern`, `host-header`,
   `http-header`, `http-request-method`, `query-string`, `source-ip`),
   along with weighted forwards and `redirect` / `fixed-response` actions.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 
 ### start-service vs start-alb — which one?
 
-`start-service` runs just the ECS service's replicas (workers, queue consumers, Service-Connect-only). `start-alb` boots the ECS service(s) behind an ALB **plus** a host-side front-door on each listener port — HTTP and HTTPS (TLS terminated locally with `--tls-cert` / `--tls-key` or an auto-generated self-signed cert) — so external traffic reaches them the way it does in the cloud. Full resolution model: [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
+`start-service` runs just the ECS service's replicas (workers, queue consumers, Service-Connect-only). `start-alb` boots the ECS service(s) behind an ALB **plus** a host-side front-door on each listener port — HTTP, and HTTPS served over plain HTTP locally by default (with `X-Forwarded-Proto: https` preserved so the upstream app still sees `https`); pass `--tls` (or `--tls-cert` / `--tls-key`) to terminate TLS locally — so external traffic reaches them the way it does in the cloud. Full resolution model: [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
 
 ## Supported resources
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1253,8 +1253,9 @@ Same option set as `cdkl start-service` (`--cluster`, `--max-tasks`,
 | Flag | Default | Behavior |
 | --- | --- | --- |
 | `--lb-port <listenerPort=hostPort>` | — | Bind the front-door on a specific host port (e.g. `80=8080`); repeatable. Default: host port == ALB listener port. Remap a privileged listener port (< 1024) to a non-privileged host port on macOS. |
-| `--tls-cert <path>` | unset | PEM-encoded server certificate for HTTPS front-door listeners. Must be set together with `--tls-key`. Omit both flags to auto-generate a self-signed cert (cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`, defaulting to `~/.cache/cdk-local/alb-https/`); requires `openssl` on PATH. The deployed Listener `Certificates[]` are NOT fetched — ACM private keys are not retrievable by design. |
-| `--tls-key <path>` | unset | PEM-encoded server private key matching `--tls-cert`. Must be set together with `--tls-cert`. |
+| `--tls` | off | Terminate TLS locally for cloud-HTTPS listeners. Default: a cloud-HTTPS listener is served over plain HTTP locally (with `X-Forwarded-Proto: https` preserved so the upstream app still sees the deployed listener protocol). Implied by `--tls-cert` / `--tls-key`. Use this when local-dev cookies need `Secure` / `SameSite=None`, when the upstream app inspects TLS metadata, or for mTLS / SNI testing — otherwise plain HTTP is friendlier (no self-signed cert warnings in `curl` / browser). |
+| `--tls-cert <path>` | unset | PEM-encoded server certificate for HTTPS front-door listeners. Implies `--tls`. Must be set together with `--tls-key`. Pass `--tls` alone (without `--tls-cert` / `--tls-key`) to auto-generate a self-signed cert (cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`, defaulting to `~/.cache/cdk-local/alb-https/`); requires `openssl` on PATH. The deployed Listener `Certificates[]` are NOT fetched — ACM private keys are not retrievable by design. |
+| `--tls-key <path>` | unset | PEM-encoded server private key matching `--tls-cert`. Implies `--tls`. Must be set together with `--tls-cert`. |
 | `--no-verify-auth` | (verify enabled) | Disable local enforcement of `authenticate-cognito` / `authenticate-oidc` actions. Every request is served as if the guard passed. Useful for local dev that does not want to mint a Bearer token. |
 | `--bearer-token <jwt>` | unset | Default Bearer JWT injected as `Authorization: Bearer <jwt>` when the inbound request has none. Verified against the same JWKS / OIDC discovery URL the deployed ALB would (signature + `iss` + `aud` + `exp`). Cookie pass-through (`AWSELBAuthSessionCookie-*`) also bypasses the guard. |
 
@@ -1263,12 +1264,16 @@ Same option set as `cdkl start-service` (`--cluster`, `--max-tasks`,
 cdkl start-alb MyStack/WebAlb --lb-port 80=8080
 # then: curl http://127.0.0.1:8080/  (round-robins across replicas)
 
-# HTTPS listener on :443 with auto-generated self-signed cert + a
-# non-privileged host port
+# Cloud-HTTPS listener on :443 served over plain HTTP locally (default)
 cdkl start-alb MyStack/WebAlb --lb-port 443=8443
+# then: curl http://127.0.0.1:8443/
+# (the upstream app still sees X-Forwarded-Proto: https)
+
+# Opt in to real TLS termination with an auto-generated self-signed cert
+cdkl start-alb MyStack/WebAlb --lb-port 443=8443 --tls
 # then: curl --insecure https://127.0.0.1:8443/
 
-# HTTPS with a BYO cert (must be set together)
+# Opt in to real TLS with a BYO cert (must be set together; implies --tls)
 cdkl start-alb MyStack/WebAlb --tls-cert ./server.pem --tls-key ./server-key.pem
 
 # Authenticate-cognito: inject a pre-minted JWT as the default Authorization
@@ -1297,15 +1302,26 @@ request — `#{protocol}` defaults to the listener's own scheme), and
 request becomes the ALB `requestContext.elb` event, runs through the Lambda RIE,
 and the response is translated back (a malformed response → 502).
 
-For HTTPS listeners the front-door terminates TLS locally using a user-supplied
-cert (`--tls-cert` + `--tls-key`, set together) or an auto-generated self-signed
-cert cached under `~/.cache/cdk-local/alb-https/`. The deployed Listener's
-`Certificates[]` ACM ARNs are not fetched — ACM private keys are not retrievable
-by design, so the local front-door always uses its own cert and warns once that
-the ACM cert was bypassed. Clients should use `curl --insecure` (or trust the
-generated cert) since the cert is self-signed. The `SslPolicy` cipher policy
-is not enforced; the upstream is dialed over plain HTTP (TLS terminated at the
-front-door, not re-encrypted).
+Cloud-HTTPS listeners are served over plain HTTP locally by default. The
+listener-rule pipeline (path / host / header / method / query / source-ip
+matching, weighted forwards, redirect / fixed-response, `authenticate-*`
+gating, WebSocket upgrades) does not depend on TLS, and the ALB itself owns
+TLS termination at the edge — the container behind it speaks plain HTTP in
+either world. `X-Forwarded-Proto` is stamped as `https` for these listeners
+(and the redirect `#{protocol}` default resolves to `https`) so the upstream
+app still observes the deployed listener protocol. A warning lists each
+cloud-HTTPS listener that is being served as HTTP locally so the degradation
+is never silent.
+
+Pass `--tls` (or `--tls-cert` / `--tls-key`, which imply `--tls`) to opt in to
+real TLS termination locally. Under `--tls` the front-door uses the
+user-supplied cert pair, or an auto-generated self-signed cert cached under
+`~/.cache/cdk-local/alb-https/` when neither is supplied. The deployed
+Listener's `Certificates[]` ACM ARNs are not fetched — ACM private keys are
+not retrievable by design, so the local front-door always uses its own cert.
+Clients should use `curl --insecure` (or trust the generated cert). The
+`SslPolicy` cipher policy is not enforced; the upstream is dialed over plain
+HTTP (TLS terminated at the front-door, not re-encrypted).
 
 `authenticate-cognito` and `authenticate-oidc` actions are enforced locally
 with a Bearer-JWT check — the same `iss` + `aud` + `exp` + signature pipeline

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -204,3 +204,88 @@ The `invoke` / `start-api` env-var and stage layers, plus the
 These are stable, side-effect-free utilities; they are exposed for
 1:1 re-export and are not a recommended way to build a custom CLI (use
 the factories for that).
+
+## ECS service emulator engine (`start-service` / `start-alb` hosts)
+
+A host CLI that ports `cdkl start-service` and / or `cdkl start-alb`
+verbatim (rather than re-exporting the factory) wraps the shared
+orchestrator directly. The engine boots the ECS replicas, attaches the
+shared docker network + Cloud Map / Service Connect overlay, optionally
+stands up the ALB front-door per listener, and tears everything down on
+SIGINT — every CLI behavior the upstream `cdkl` commands have:
+
+- `runEcsServiceEmulator(targets, options, strategy, extraStateProviders?)`
+  — the entry point both upstream CLI commands wrap. `strategy` decides
+  per-command behavior (target selection, picker prompts, front-door plan
+  resolution); `serviceStrategy` and `albStrategy` are the two strategies
+  the upstream CLI ships.
+- `addCommonEcsServiceOptions(cmd)` — option block shared by both
+  commands (`--cluster`, `--max-tasks`, `--container-host`,
+  `--from-cfn-stack`, etc.). Compose with `addAlbSpecificOptions(cmd)`
+  for an ALB-fronted host CLI; `start-service` hosts only need the
+  common block.
+- `addAlbSpecificOptions(cmd)` — ALB-only option block (`--lb-port`,
+  `--tls`, `--tls-cert`, `--tls-key`, `--no-verify-auth`,
+  `--bearer-token`). Calling this from a host's `start-alb` keeps the
+  option set in sync as upstream cdk-local adds or renames ALB-only
+  flags; no duplicate `.addOption(...)` blocks.
+- `albStrategy(options)` / `resolveAlbTarget(target, stacks)` /
+  `parseLbPortOverrides(values)` — the matching `EmulatorStrategy` plus
+  the target / port-override resolvers a host calls directly when it
+  composes a custom `start-alb` command around `runEcsServiceEmulator`.
+- `parseMaxTasks` / `parseRestartPolicy` — option parsers that pair with
+  `--max-tasks` and `--restart-policy` from the common block.
+- `resolveSharedSidecarCredentials` / `buildEcsImageResolutionContext`
+  — pre-boot helpers for hosts that need to materialize sidecar creds
+  or image-resolution context before delegating to the engine
+  (e.g. test setup).
+- `MAX_TASKS_SUBNET_RANGE_CAP` — the per-network replica cap the engine
+  enforces; surfaced so a host CLI can validate `--max-tasks` against
+  the same ceiling.
+- `EcsServiceEmulatorOptions` / `EmulatorStrategy` / `ServiceBoot` /
+  `FrontDoorPlan` / `PlannedAction` / `PlannedForwardAction` /
+  `PlannedRedirectAction` / `PlannedFixedResponseAction` /
+  `PlannedForwardTarget` / `PlannedEcsForwardTarget` /
+  `PlannedLambdaForwardTarget` / `PlannedFrontDoorListener` — the
+  engine's option + pre-boot-plan types.
+
+Host CLIs that wrap `start-alb` for an ALB-fronted workload typically
+look like:
+
+```ts
+import {
+  addCommonEcsServiceOptions,
+  addAlbSpecificOptions,
+  albStrategy,
+  runEcsServiceEmulator,
+  type EcsServiceEmulatorOptions,
+} from 'cdk-local/internal';
+
+const cmd = new Command('start-alb')
+  .description(...)
+  .argument('[targets...]', ...)
+  // ... host-specific options ...
+  .action(async (targets: string[], options: EcsServiceEmulatorOptions) => {
+    await runEcsServiceEmulator(targets, options, albStrategy(options));
+  });
+addAlbSpecificOptions(cmd);
+addCommonEcsServiceOptions(cmd);
+```
+
+`addAlbSpecificOptions` after host-specific options keeps the host's
+flags in their own `--help` cluster; Commander itself is
+insertion-order-independent for parsing.
+
+## ALB front-door target resolution
+
+A host wrapping `start-alb` also needs the resolver layer that turns an
+ALB target string into a listener-by-listener routing table:
+
+- `resolveAlbFrontDoor` (+ `ResolvedListenerAction` /
+  `FrontDoorForwardTarget`) — ALB → listeners → ListenerRules
+  (path / host / header / method / query / source-ip) → forward (single
+  or weighted) / redirect / fixed-response → backing ECS Services or
+  Lambda functions.
+- `isApplicationLoadBalancer` — type-narrowing predicate that
+  disambiguates ApplicationLoadBalancer from NetworkLoadBalancer when
+  picking targets.

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -127,15 +127,25 @@ export interface EcsServiceEmulatorOptions {
   /** `--lb-port <listenerPort=hostPort>` front-door overrides (start-alb; repeatable). */
   lbPort?: string[];
   /**
+   * Terminate TLS locally for HTTPS front-door listeners (start-alb).
+   * Defaults to `false`: a cloud-HTTPS listener is served over plain HTTP
+   * locally (with `X-Forwarded-Proto: https` preserved so the upstream app
+   * still sees `https`). When `true` (or implied by `--tls-cert` /
+   * `--tls-key`), the listener terminates TLS using the supplied PEM pair
+   * or an auto-generated self-signed cert.
+   */
+  tls?: boolean;
+  /**
    * Path to a PEM-encoded server cert for HTTPS front-door listeners
-   * (start-alb). Must be set together with `--tls-key`. Absent =
-   * auto-generated self-signed cert (cached under
-   * `$XDG_CACHE_HOME/cdk-local/alb-https/`).
+   * (start-alb). Must be set together with `--tls-key`. Implies
+   * {@link tls}. Absent (with `--tls` alone) = auto-generated self-signed
+   * cert cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`.
    */
   tlsCert?: string;
   /**
    * Path to a PEM-encoded server private key for HTTPS front-door listeners
-   * (start-alb). Must be set together with `--tls-cert`.
+   * (start-alb). Must be set together with `--tls-cert`. Implies
+   * {@link tls}.
    */
   tlsKey?: string;
   /**
@@ -841,13 +851,24 @@ export async function buildFrontDoor(
     };
   };
 
-  // Resolve TLS materials once, up front, when any HTTPS listener is in the
-  // plan. Kept OUTSIDE the surrounding try/catch so a TLS resolution failure
-  // (e.g. openssl missing, BYO PEM unreadable) surfaces its own actionable
-  // error instead of being re-wrapped in the generic `--lb-port` port-bind
-  // envelope below. A single resolve is shared across every HTTPS listener.
+  // Decide whether HTTPS listeners terminate TLS locally. Opting in requires
+  // either an explicit `--tls`, or supplying `--tls-cert` / `--tls-key`
+  // (passing the cert pair is treated as a strong signal that the user wants
+  // real TLS — they would not have bothered otherwise). The default leaves
+  // cloud-HTTPS listeners on plain HTTP locally; `X-Forwarded-Proto: https`
+  // is preserved further down so upstream apps still see the deployed
+  // listener protocol.
   const hasHttpsListener = plan.listeners.some((l) => l.protocol === 'HTTPS');
-  const tlsMaterials: FrontDoorTlsMaterials | undefined = hasHttpsListener
+  const wantTls =
+    options.tls === true || options.tlsCert !== undefined || options.tlsKey !== undefined;
+  const needsTlsMaterials = hasHttpsListener && wantTls;
+  // Resolve TLS materials once, up front, when any HTTPS listener will
+  // actually terminate TLS locally. Kept OUTSIDE the surrounding try/catch
+  // so a TLS resolution failure (e.g. openssl missing, BYO PEM unreadable)
+  // surfaces its own actionable error instead of being re-wrapped in the
+  // generic `--lb-port` port-bind envelope below. A single resolve is
+  // shared across every HTTPS listener.
+  const tlsMaterials: FrontDoorTlsMaterials | undefined = needsTlsMaterials
     ? await resolveFrontDoorTlsMaterials({
         certPath: options.tlsCert,
         keyPath: options.tlsKey,
@@ -892,13 +913,16 @@ export async function buildFrontDoor(
         sourceIp?: string;
       }): RouteAction | undefined => matchAlbPathRule(req, ruleRoutes) ?? defaultRoute;
 
-      const tls = listener.protocol === 'HTTPS' ? tlsMaterials : undefined;
+      const tls = listener.protocol === 'HTTPS' && wantTls ? tlsMaterials : undefined;
+      const forwardedProto: 'http' | 'https' = listener.protocol === 'HTTPS' ? 'https' : 'http';
+      const degradedHttps = listener.protocol === 'HTTPS' && !wantTls;
       const server = await startFrontDoorServer({
         route,
         port: listener.hostPort,
         host: containerHost,
         listenerPort: listener.listenerPort,
         label: `listener port ${listener.listenerPort}`,
+        forwardedProto,
         ...(tls ? { tls } : {}),
       });
       servers.push(server);
@@ -906,6 +930,13 @@ export async function buildFrontDoor(
       logger.info(
         `ALB front-door: ${server.scheme}://${server.host}:${server.port} (listener port ${listener.listenerPort})`
       );
+      if (degradedHttps) {
+        logger.warn(
+          `  WARN: listener port ${listener.listenerPort} is HTTPS in the cloud but serving HTTP ` +
+            'locally (X-Forwarded-Proto: https preserved). Pass --tls to terminate TLS locally ' +
+            'with a self-signed or user-supplied cert.'
+        );
+      }
       if (listener.defaultAction) {
         logger.info(`  default -> ${describeAction(listener.defaultAction)}`);
       }

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -314,8 +314,10 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
         'backing services — a stable host endpoint, like behind a real load balancer. The ' +
         'symmetric ALB counterpart of `start-api`. Each <target> accepts a CDK display path ' +
         '(MyStack/MyAlb) or stack-qualified logical ID; single-stack apps may omit the stack ' +
-        'prefix. Supports HTTP and HTTPS listeners (TLS terminated locally with --tls-cert/' +
-        '--tls-key or an auto-generated self-signed cert); all six ALB rule-condition fields ' +
+        'prefix. Supports HTTP and HTTPS listeners — by default a cloud-HTTPS listener is ' +
+        'served over plain HTTP locally (with X-Forwarded-Proto: https preserved). Pass --tls ' +
+        '(or --tls-cert / --tls-key) to terminate TLS locally with a self-signed or ' +
+        'user-supplied cert. All six ALB rule-condition fields are honored ' +
         '(path-pattern / host-header / http-header / http-request-method / query-string / ' +
         'source-ip); forward (single and weighted), redirect, and fixed-response actions; and ' +
         'ECS or Lambda targets (a Lambda target group is invoked locally via the Lambda RIE). ' +
@@ -329,6 +331,37 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
       '[targets...]',
       'One or more CDK display paths or stack-qualified logical IDs of the AWS::ElasticLoadBalancingV2::LoadBalancer resources to run (omit to multi-select interactively in a TTY)'
     )
+    .action(
+      withErrorHandling(async (targets: string[], options: EcsServiceEmulatorOptions) => {
+        await runEcsServiceEmulator(
+          targets,
+          options,
+          albStrategy(options),
+          opts.extraStateProviders
+        );
+      })
+    );
+
+  addAlbSpecificOptions(cmd);
+  return addCommonEcsServiceOptions(cmd);
+}
+
+/**
+ * Register the option block that `start-alb` adds on top of
+ * {@link addCommonEcsServiceOptions} — the flags that only make sense for an
+ * ALB-fronted local emulator (front-door port mapping, TLS termination,
+ * authenticate-* gating). Shared between `cdkl start-alb` and any host CLI
+ * (e.g. cdkd's `local start-alb`) that wraps {@link runEcsServiceEmulator}
+ * with the ALB strategy, so adding or renaming an ALB-only flag here
+ * propagates to every embedder without duplicate `.addOption(...)` blocks.
+ *
+ * Call this AFTER any host-specific options and BEFORE
+ * {@link addCommonEcsServiceOptions} (Commander's internal state is
+ * insertion-order-independent, so the actual order only affects `--help`
+ * presentation). Chainable: returns `cmd`.
+ */
+export function addAlbSpecificOptions(cmd: Command): Command {
+  return cmd
     .addOption(
       new Option(
         '--lb-port <listenerPort=hostPort...>',
@@ -339,21 +372,33 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
     )
     .addOption(
       new Option(
+        '--tls',
+        'Terminate TLS locally for cloud-HTTPS listeners. Default: a cloud-HTTPS listener is ' +
+          'served over plain HTTP locally (X-Forwarded-Proto: https is preserved so the upstream ' +
+          'app still sees the deployed listener protocol). Implied by --tls-cert / --tls-key. ' +
+          'Use this when local-dev cookies need Secure / SameSite=None, when the upstream app ' +
+          'inspects TLS metadata, or for mTLS / SNI testing — otherwise plain HTTP is friendlier ' +
+          '(no self-signed cert warnings in curl / browser).'
+      )
+    )
+    .addOption(
+      new Option(
         '--tls-cert <path>',
-        'PEM-encoded server certificate for HTTPS front-door listeners. Must be set together ' +
-          'with --tls-key. Omit both flags to auto-generate a self-signed cert ' +
-          '(cached under $XDG_CACHE_HOME/cdk-local/alb-https/, default ~/.cache/cdk-local/' +
-          'alb-https/); requires openssl on PATH. The deployed Listener Certificates[] are NOT ' +
-          'fetched (ACM private keys are not retrievable by design). The auto-generated cert ' +
-          'lists DNS:localhost,IP:127.0.0.1 as SubjectAltName, so a client validating a ' +
-          'non-loopback --container-host will fail the SAN check — pass --tls-cert / --tls-key ' +
-          'with a SAN covering that host instead.'
+        'PEM-encoded server certificate for HTTPS front-door listeners. Implies --tls. Must be ' +
+          'set together with --tls-key. Pass --tls alone (without --tls-cert / --tls-key) to ' +
+          'auto-generate a self-signed cert (cached under $XDG_CACHE_HOME/cdk-local/alb-https/, ' +
+          'default ~/.cache/cdk-local/alb-https/); requires openssl on PATH. The deployed ' +
+          'Listener Certificates[] are NOT fetched (ACM private keys are not retrievable by ' +
+          'design). The auto-generated cert lists DNS:localhost,IP:127.0.0.1 as SubjectAltName, ' +
+          'so a client validating a non-loopback --container-host will fail the SAN check — pass ' +
+          '--tls-cert / --tls-key with a SAN covering that host instead.'
       )
     )
     .addOption(
       new Option(
         '--tls-key <path>',
-        'PEM-encoded server private key matching --tls-cert. Must be set together with --tls-cert.'
+        'PEM-encoded server private key matching --tls-cert. Implies --tls. Must be set ' +
+          'together with --tls-cert.'
       )
     )
     .addOption(
@@ -372,17 +417,5 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
           '(signature + iss + aud + exp). Local-dev convenience; cookie pass-through ' +
           '(AWSELBAuthSessionCookie-*) also works.'
       )
-    )
-    .action(
-      withErrorHandling(async (targets: string[], options: EcsServiceEmulatorOptions) => {
-        await runEcsServiceEmulator(
-          targets,
-          options,
-          albStrategy(options),
-          opts.extraStateProviders
-        );
-      })
     );
-
-  return addCommonEcsServiceOptions(cmd);
 }

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -355,10 +355,11 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
  * with the ALB strategy, so adding or renaming an ALB-only flag here
  * propagates to every embedder without duplicate `.addOption(...)` blocks.
  *
- * Call this AFTER any host-specific options and BEFORE
- * {@link addCommonEcsServiceOptions} (Commander's internal state is
- * insertion-order-independent, so the actual order only affects `--help`
- * presentation). Chainable: returns `cmd`.
+ * Calling order only affects `--help` presentation (Commander parses
+ * insertion-order-independent). The host-CLI convention is host-specific
+ * options first, then this helper, then {@link addCommonEcsServiceOptions}
+ * — host flags / ALB flags / common flags grouped in three `--help`
+ * clusters. Chainable: returns `cmd`.
  */
 export function addAlbSpecificOptions(cmd: Command): Command {
   return cmd

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -492,3 +492,22 @@ export {
   type ResolvedListenerAction,
   type FrontDoorForwardTarget,
 } from './local/elb-front-door-resolver.js';
+
+/**
+ * `start-alb` ALB-specific option block + strategy entry points. The flags
+ * `addAlbSpecificOptions` registers (`--lb-port`, `--tls`, `--tls-cert`,
+ * `--tls-key`, `--no-verify-auth`, `--bearer-token`) are the ones that only
+ * apply to an ALB-fronted local emulator and sit on top of
+ * {@link addCommonEcsServiceOptions}. Sharing the block keeps host CLIs
+ * (e.g. cdkd's `local start-alb`) auto-inheriting any new ALB-only flag the
+ * upstream cdk-local CLI adds — no manual `.addOption(...)` duplication.
+ * `albStrategy` / `resolveAlbTarget` / `parseLbPortOverrides` are the
+ * matching strategy + target-resolution helpers a host wrapping
+ * `runEcsServiceEmulator` calls directly.
+ */
+export {
+  addAlbSpecificOptions,
+  albStrategy,
+  resolveAlbTarget,
+  parseLbPortOverrides,
+} from './cli/commands/local-start-alb.js';

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -53,8 +53,12 @@ import {
  * invokers), redirect / fixed-response synthesis, every ALB rule-condition
  * field. HTTP and HTTPS listeners are both served — HTTPS termination uses
  * the {@link StartFrontDoorServerOptions.tls} materials (a user-supplied or
- * auto-generated self-signed cert/key pair) and switches `X-Forwarded-Proto`
- * + redirect `#{protocol}` to `https`.
+ * auto-generated self-signed cert/key pair). `X-Forwarded-Proto` and the
+ * redirect `#{protocol}` default come from
+ * {@link StartFrontDoorServerOptions.forwardedProto}, which is decoupled from
+ * the wire so a cloud-HTTPS listener can be served over plain HTTP locally
+ * while still presenting `https` upstream (the wire defaults to TLS presence
+ * when the override is omitted).
  *
  * **WebSocket Upgrade** is proxied for ECS forward targets: an inbound
  * `Connection: Upgrade` request goes through the same `route()` callback
@@ -215,11 +219,17 @@ export interface StartFrontDoorServerOptions {
   label: string;
   /**
    * When set, the front-door listens over HTTPS using these PEM materials
-   * (server cert + private key). `X-Forwarded-Proto` switches to `https`
-   * and redirect `#{protocol}` placeholders resolve to `https`. Absent =
-   * plain HTTP listener (the default).
+   * (server cert + private key). Absent = plain HTTP listener (the default).
    */
   tls?: { certPem: Buffer; keyPem: Buffer };
+  /**
+   * Explicit scheme stamped onto `X-Forwarded-Proto` and used as the default
+   * for redirect `#{protocol}` placeholders. Decouples the deployed-listener
+   * protocol from the local wire so a cloud-HTTPS listener can be served
+   * over plain HTTP locally while still presenting `https` to the upstream
+   * app. Defaults to `'https'` when {@link tls} is set, otherwise `'http'`.
+   */
+  forwardedProto?: 'http' | 'https';
   /**
    * Per-request upstream timeout (ms). A replica that accepts the connection
    * but never responds (deadlocked app, half-open socket) must not hang the
@@ -251,16 +261,19 @@ export async function startFrontDoorServer(
   const logger = getLogger().child('front-door');
   const host = opts.host ?? '127.0.0.1';
 
+  const forwardedProto: 'http' | 'https' = opts.forwardedProto ?? (opts.tls ? 'https' : 'http');
+  const effectiveOpts: StartFrontDoorServerOptions = { ...opts, forwardedProto };
   const requestHandler = (req: IncomingMessage, res: ServerResponse): void => {
-    handleProxyRequest(req, res, opts).catch((err) => {
+    handleProxyRequest(req, res, effectiveOpts).catch((err) => {
       logger.debug(`front-door request error: ${err instanceof Error ? err.message : String(err)}`);
       if (!res.headersSent) writeError(res, 502, 'Bad Gateway');
     });
   };
   // HTTPS branch: `https.createServer` with the supplied PEM materials. The
   // request handler is the same — TLS only adds the handshake at the socket
-  // layer. `X-Forwarded-Proto` is stamped based on `tls` presence so a
-  // downstream app reads the right scheme.
+  // layer. `X-Forwarded-Proto` is stamped from {@link forwardedProto}, which
+  // defaults to the wire scheme but may be overridden so a cloud-HTTPS
+  // listener served over plain HTTP still presents `https` upstream.
   const server: Server = opts.tls
     ? (createHttpsServer(
         { cert: opts.tls.certPem, key: opts.tls.keyPem },
@@ -270,7 +283,7 @@ export async function startFrontDoorServer(
   const scheme: 'http' | 'https' = opts.tls ? 'https' : 'http';
   server.on('connection', (socket) => socket.setNoDelay(true));
   server.on('upgrade', (req, clientSocket, head) => {
-    handleUpgrade(req, clientSocket, head, opts).catch((err) => {
+    handleUpgrade(req, clientSocket, head, effectiveOpts).catch((err) => {
       logger.debug(`front-door upgrade error: ${err instanceof Error ? err.message : String(err)}`);
       if (!clientSocket.destroyed) clientSocket.destroy();
     });
@@ -395,7 +408,7 @@ function serveAction(
     // keep-alive socket reuse, then synthesize the response with no backend.
     req.resume();
     if (action.kind === 'redirect') {
-      writeRedirect(res, action, req, opts.listenerPort, opts.tls ? 'https' : 'http');
+      writeRedirect(res, action, req, opts.listenerPort, resolveForwardedProto(opts));
     } else {
       writeFixedResponse(res, action);
     }
@@ -485,7 +498,7 @@ function handlePoolRequest(
 
     const headers = { ...req.headers };
     stripHopByHopHeaders(headers);
-    appendForwardedHeaders(headers, req, opts.listenerPort, opts.tls ? 'https' : 'http');
+    appendForwardedHeaders(headers, req, opts.listenerPort, resolveForwardedProto(opts));
 
     const proxyReq = httpRequest(
       {
@@ -834,6 +847,15 @@ function stripHopByHopHeaders(headers: NodeJS.Dict<string | string[]>): void {
 }
 
 /**
+ * Resolve the scheme to stamp on `X-Forwarded-Proto` and to default
+ * redirect `#{protocol}` to: an explicit {@link StartFrontDoorServerOptions.forwardedProto}
+ * override wins, otherwise it follows the wire (TLS = `https`, no TLS = `http`).
+ */
+function resolveForwardedProto(opts: StartFrontDoorServerOptions): 'http' | 'https' {
+  return opts.forwardedProto ?? (opts.tls ? 'https' : 'http');
+}
+
+/**
  * Inject the ALB-style forwarding headers a downstream app may read. Appends
  * the client IP to any existing `X-Forwarded-For` chain (ALB appends rather
  * than replaces) and stamps the scheme / listener port. `scheme` follows the
@@ -1004,7 +1026,7 @@ function bridgeWebSocket(
       const headers: NodeJS.Dict<string | string[]> = { ...req.headers };
       // Do NOT strip hop-by-hop: `Upgrade` / `Connection: Upgrade` are the
       // whole point of this code path. Only stamp the X-Forwarded-* set.
-      appendForwardedHeaders(headers, req, opts.listenerPort, opts.tls ? 'https' : 'http');
+      appendForwardedHeaders(headers, req, opts.listenerPort, resolveForwardedProto(opts));
 
       const requestLine = `${req.method ?? 'GET'} ${req.url ?? '/'} HTTP/${req.httpVersion}`;
       const lines: string[] = [requestLine];

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -768,7 +768,7 @@ function handleLambdaRequest(
             forwardHeaders,
             req,
             opts.listenerPort,
-            opts.tls ? 'https' : 'http'
+            resolveForwardedProto(opts)
           );
           const snapshot = snapshotFromIncoming(req, body);
           for (const [name, value] of Object.entries(forwardHeaders)) {
@@ -923,7 +923,7 @@ function handleUpgrade(
         action,
         req,
         opts.listenerPort,
-        opts.tls ? 'https' : 'http'
+        resolveForwardedProto(opts)
       );
       return Promise.resolve();
     }

--- a/tests/integration/local-start-alb/lib/local-start-alb-stack.ts
+++ b/tests/integration/local-start-alb/lib/local-start-alb-stack.ts
@@ -84,6 +84,19 @@ export class LocalStartAlbStack extends cdk.Stack {
       defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.ref }],
     });
 
+    // A second listener whose deployed protocol is HTTPS. Backs the #198 test
+    // matrix: without --tls, cdkl serves this listener over plain HTTP locally
+    // (with X-Forwarded-Proto: https preserved); with --tls cdkl terminates
+    // TLS locally using the auto-generated self-signed cert. ACM Certificates[]
+    // are intentionally omitted — cdk-local can't reproduce ACM private keys
+    // anyway, so the test exercises the auto-self-signed fallback.
+    new elbv2.CfnListener(this, 'WebListenerHttps', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 443,
+      protocol: 'HTTPS',
+      defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.ref }],
+    });
+
     new ecs.CfnService(this, 'WebService', {
       cluster: cluster.ref,
       taskDefinition: taskDef.ref,

--- a/tests/integration/local-start-alb/verify.sh
+++ b/tests/integration/local-start-alb/verify.sh
@@ -19,6 +19,7 @@ CDKL="node ../../../dist/cli.js"
 SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
 WEB_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
 LB_HOST_PORT=18086 # non-privileged host port the front-door binds (listener port 80 remapped)
+LB_HOST_PORT_HTTPS=18443 # non-privileged host port for the cloud-HTTPS:443 listener (#198)
 
 cleanup() {
   echo "==> Cleanup: stopping any leftover containers + networks"
@@ -55,11 +56,15 @@ fi
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
 
-echo "==> start-alb: naming the ALB (DesiredCount=2 backing service), front-door on host port ${LB_HOST_PORT}"
-# Remap the privileged listener port 80 to a non-privileged host port so the
-# front-door binds without root (the macOS Docker Desktop privileged-port path).
+echo "==> start-alb: naming the ALB (DesiredCount=2 backing service); HTTP:80 -> :${LB_HOST_PORT}, HTTPS:443 -> :${LB_HOST_PORT_HTTPS}"
+# Remap both privileged listener ports (80 / 443) to non-privileged host ports
+# so the front-door binds without root (the macOS Docker Desktop privileged-port
+# path). No --tls flag: the HTTPS:443 listener exercises the #198 default —
+# served over plain HTTP locally, with X-Forwarded-Proto: https preserved.
 ${CDKL} start-alb CdkLocalStartAlbFixture:WebLB \
-  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  --container-host 127.0.0.1 \
+  --lb-port "80=${LB_HOST_PORT}" \
+  --lb-port "443=${LB_HOST_PORT_HTTPS}" \
   > "${OUT_FILE}" 2>&1 &
 CDKL_PID=$!
 
@@ -83,13 +88,29 @@ if [[ "${BOOTED}" -ne 1 ]]; then
   exit 1
 fi
 
-echo "==> Asserting the front-door banner was logged"
+echo "==> Asserting the HTTP front-door banner was logged"
 if ! grep -q "ALB front-door: http://127.0.0.1:${LB_HOST_PORT}" "${OUT_FILE}"; then
   echo "FAIL: front-door banner for host port ${LB_HOST_PORT} not found"
   echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
   exit 1
 fi
-echo "    OK: front-door banner present"
+echo "    OK: HTTP front-door banner present"
+
+echo "==> Asserting the cloud-HTTPS listener is served over HTTP locally + the degradation warning fired (#198)"
+# Without --tls the cloud-HTTPS:443 listener must come up as `http://...` on
+# the wire (NOT `https://...`) and the per-listener warning must be logged so
+# the degradation is never silent.
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_HOST_PORT_HTTPS}" "${OUT_FILE}"; then
+  echo "FAIL: cloud-HTTPS listener was not served over plain HTTP on host port ${LB_HOST_PORT_HTTPS}"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+if ! grep -qE "listener port 443 is HTTPS in the cloud but serving HTTP locally" "${OUT_FILE}"; then
+  echo "FAIL: HTTPS-degraded warning for listener port 443 not present"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+echo "    OK: cloud-HTTPS:443 served over HTTP + degradation warning logged"
 
 echo "==> curl-ing the front-door until it serves 200 (replicas take a moment to start the HTTP server)"
 READY=0
@@ -130,6 +151,25 @@ if [[ "${DISTINCT}" -lt 2 ]]; then
 fi
 echo "    OK: front-door load-balances across ${DISTINCT} replicas"
 
+echo "==> curl-ing the cloud-HTTPS listener's host port over plain HTTP (no -k); asserting X-Forwarded-Proto: https reaches the upstream"
+# #198 default: cloud-HTTPS listener served over HTTP locally. The replica
+# echoes only its hostname (not headers), so we assert (a) plain HTTP succeeds
+# and (b) explicitly that an attempt to negotiate TLS fails fast — which would
+# be the case before #198 (when the listener bound HTTPS with a self-signed
+# cert that lacked the local trust chain).
+if ! curl -fsS --max-time 5 "http://127.0.0.1:${LB_HOST_PORT_HTTPS}/" >/dev/null 2>&1; then
+  echo "FAIL: plain HTTP curl against the cloud-HTTPS host port ${LB_HOST_PORT_HTTPS} failed"
+  echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+  exit 1
+fi
+# curl will report SSL handshake failure when the server speaks plain HTTP —
+# the exact symptom the local-dev wanted: NO TLS friction on the HTTPS port.
+if curl -fsS --max-time 5 "https://127.0.0.1:${LB_HOST_PORT_HTTPS}/" >/dev/null 2>&1; then
+  echo "FAIL: cloud-HTTPS host port ${LB_HOST_PORT_HTTPS} accepted an HTTPS handshake — expected plain HTTP"
+  exit 1
+fi
+echo "    OK: cloud-HTTPS:443 listener is reachable over HTTP and rejects an HTTPS handshake"
+
 echo "==> Sending SIGTERM to cdk-local (${CDKL_PID})"
 kill -TERM "${CDKL_PID}"
 
@@ -163,9 +203,13 @@ if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
   exit 1
 fi
 
-echo "==> Asserting the front-door socket is closed"
+echo "==> Asserting the front-door sockets are closed"
 if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
   echo "FAIL: front-door on host port ${LB_HOST_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT_HTTPS}/" >/dev/null 2>&1; then
+  echo "FAIL: cloud-HTTPS front-door on host port ${LB_HOST_PORT_HTTPS} still accepting connections after SIGTERM"
   exit 1
 fi
 

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -662,6 +662,41 @@ describe('startFrontDoorServer — Lambda dispatch (#123)', () => {
     const res = await postRequest(front.port, '/nope', '');
     expect(res.status).toBe(404);
   });
+
+  it('stamps X-Forwarded-Proto from forwardedProto on the ALB Lambda event (#198 degraded HTTPS)', async () => {
+    // Companion to the pool / redirect / WS tests below: when a cloud-HTTPS
+    // listener serves over plain HTTP locally (`forwardedProto: 'https'` set
+    // without `tls`), the synthesized ALB Lambda event MUST carry
+    // `x-forwarded-proto: https` so handler logic that inspects it (Secure
+    // cookie flag, OAuth callback URL synthesis) still sees the deployed
+    // listener protocol.
+    let capturedEvent: Record<string, unknown> | undefined;
+    const front = await startFrontDoorServer({
+      selectTarget: () => ({
+        kind: 'lambda',
+        lambda: {
+          targetGroupArn: 'tg',
+          multiValueHeaders: false,
+          label: 'EchoFn',
+          invoke: async (event) => {
+            capturedEvent = event;
+            return { statusCode: 200 };
+          },
+        },
+      }),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      forwardedProto: 'https',
+    });
+    cleanups.push(() => front.close());
+
+    await postRequest(front.port, '/', '');
+    const headers = capturedEvent!['headers'] as Record<string, string>;
+    expect(headers['x-forwarded-proto']).toBe('https');
+    expect(headers['x-forwarded-port']).toBe('443');
+  });
 });
 
 describe('startFrontDoorServer — weighted forward mixing ECS + Lambda (#123)', () => {
@@ -1257,6 +1292,94 @@ describe('startFrontDoorServer — WebSocket Upgrade', () => {
     }));
     const echoed = await wsEchoRoundtrip(`ws://127.0.0.1:${front.port}/`, 'allowed-ws');
     expect(echoed).toBe('allowed-ws');
+  });
+
+  it('bridges the upgrade with X-Forwarded-Proto: https when forwardedProto is set on a plain-HTTP wire (#198)', async () => {
+    // Cloud-HTTPS WS listener served over plain HTTP locally: the upgrade
+    // request reaching the upstream replica must still carry
+    // `x-forwarded-proto: https` so an app inspecting the header on the
+    // upgrade frame matches its deployed-ALB behavior.
+    const { WebSocketServer } = await import('ws');
+    const httpServer = createServer();
+    const wss = new WebSocketServer({ server: httpServer });
+    let capturedProto: string | string[] | undefined;
+    wss.on('connection', (ws, req) => {
+      capturedProto = req.headers['x-forwarded-proto'];
+      ws.on('message', (data) => ws.send(data));
+    });
+    await new Promise<void>((r) => httpServer.listen(0, '127.0.0.1', r));
+    const upstreamPort = (httpServer.address() as AddressInfo).port;
+    cleanups.push(
+      () =>
+        new Promise<void>((r) => {
+          wss.close(() => httpServer.close(() => r()));
+        })
+    );
+
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstreamPort });
+    const front = await startFrontDoorServer({
+      route: () => ({ kind: 'forward', pools: [{ pool, weight: 1 }] }),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      forwardedProto: 'https',
+    });
+    cleanups.push(() => front.close());
+
+    const echoed = await wsEchoRoundtrip(`ws://127.0.0.1:${front.port}/`, 'degraded-ws');
+    expect(echoed).toBe('degraded-ws');
+    expect(capturedProto).toBe('https');
+  });
+
+  it('redirects an upgrade with a https:// Location when forwardedProto is set on a plain-HTTP wire (#198)', async () => {
+    // Companion to the regular-HTTP redirect path: the WS-upgrade branch
+    // synthesizes its own redirect over the raw socket (writeRawHttpRedirect),
+    // and the `#{protocol}` default must follow forwardedProto so a
+    // cloud-HTTPS listener served over plain HTTP still emits `https://...`
+    // in the upgrade-rejection Location header.
+    const action: RedirectRouteAction = {
+      kind: 'redirect',
+      statusCode: 301,
+      host: 'new.example.com',
+    };
+    const front = await startFrontDoorServer({
+      route: () => action,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      forwardedProto: 'https',
+    });
+    cleanups.push(() => front.close());
+
+    // The upgrade fails (the server answers a 301 instead of 101); read the
+    // synthesized `Location` from the same `unexpected-response` channel
+    // wsExpectReject uses for 404 / 401 / 502 / 503.
+    const { WebSocket } = await import('ws');
+    const result = await new Promise<{ status?: number; location?: string }>(
+      (resolve, reject) => {
+        const ws = new WebSocket(`ws://127.0.0.1:${front.port}/`);
+        ws.on('unexpected-response', (_req, res) => {
+          const loc = res.headers.location;
+          resolve({
+            ...(typeof res.statusCode === 'number' && { status: res.statusCode }),
+            ...(typeof loc === 'string' && { location: loc }),
+          });
+          res.resume();
+        });
+        ws.on('open', () => {
+          ws.close();
+          reject(new Error('expected the front-door to redirect the upgrade'));
+        });
+        ws.on('error', () => {
+          /* swallowed; `unexpected-response` resolves the promise first */
+        });
+      }
+    );
+    expect(result.status).toBe(301);
+    expect(result.location).toMatch(/^https:\/\/new\.example\.com\//);
   });
 });
 

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -877,6 +877,75 @@ describe('startFrontDoorServer — HTTPS termination', () => {
     await fetchText(front.port);
     expect(upstream.lastHeaders?.['x-forwarded-proto']).toBe('http');
   });
+
+  it('honors an explicit forwardedProto=https override over a plain-HTTP wire', async () => {
+    // Cloud-HTTPS-but-local-HTTP degradation (#198): the wire is HTTP (no
+    // tls materials), but `forwardedProto: 'https'` lets the caller preserve
+    // the deployed listener protocol on `X-Forwarded-Proto`, so the upstream
+    // app still observes `https` and a redirect's `#{protocol}` resolves to
+    // `https` by default.
+    const upstream = await startUpstream('degraded-https');
+    const pool = new FrontDoorEndpointPool();
+    pool.register('svc:r0', { host: '127.0.0.1', port: upstream.port });
+    const front = await startFrontDoorServer({
+      route: () => forward(pool),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      forwardedProto: 'https',
+    });
+    cleanups.push(() => front.close());
+
+    expect(front.scheme).toBe('http');
+    await fetchText(front.port);
+    expect(upstream.lastHeaders?.['x-forwarded-proto']).toBe('https');
+    expect(upstream.lastHeaders?.['x-forwarded-port']).toBe('443');
+  });
+
+  it('defaults a redirect `#{protocol}` to forwardedProto on a degraded HTTPS listener', async () => {
+    // Companion to the wire-vs-forwarded test above: redirect synthesis must
+    // also follow `forwardedProto`, not the wire scheme, so an HTTPS-in-cloud
+    // listener served over plain HTTP still emits `https://...` Location.
+    const action: RedirectRouteAction = {
+      kind: 'redirect',
+      statusCode: 301,
+      host: 'new.example.com',
+    };
+    const front = await startFrontDoorServer({
+      route: () => action,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      forwardedProto: 'https',
+    });
+    cleanups.push(() => front.close());
+
+    const result = await new Promise<{ status: number; location?: string }>((resolve, reject) => {
+      const req = get(
+        {
+          host: '127.0.0.1',
+          port: front.port,
+          path: '/',
+          headers: { host: 'old.example.com' },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              ...(typeof res.headers.location === 'string' && { location: res.headers.location }),
+            })
+          );
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(result.status).toBe(301);
+    expect(result.location).toMatch(/^https:\/\/new\.example\.com\//);
+  });
 });
 
 describe('startFrontDoorServer — auth gate', () => {

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -1,10 +1,20 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { Command } from 'commander';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { resolveAlbTarget, parseLbPortOverrides, albStrategy } from '../../../src/cli/commands/local-start-alb.js';
+import {
+  resolveAlbTarget,
+  parseLbPortOverrides,
+  albStrategy,
+  createLocalStartAlbCommand,
+  addAlbSpecificOptions,
+} from '../../../src/cli/commands/local-start-alb.js';
 import { serviceStrategy } from '../../../src/cli/commands/local-start-service.js';
-import { buildFrontDoor } from '../../../src/cli/commands/ecs-service-emulator.js';
+import {
+  buildFrontDoor,
+  addCommonEcsServiceOptions,
+} from '../../../src/cli/commands/ecs-service-emulator.js';
 import { resolveFrontDoorTlsMaterials } from '../../../src/local/front-door-tls.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
@@ -660,6 +670,114 @@ describe('buildFrontDoor', () => {
         )
       ).rejects.toThrow(/--tls-cert is set but --tls-key is missing/);
     });
+
+    it('serves a cloud-HTTPS listener over plain HTTP by default (no --tls / --tls-cert)', async () => {
+      // #198: TLS termination is opt-in. With neither --tls nor --tls-cert /
+      // --tls-key the local wire is HTTP — the deployed listener protocol
+      // surfaces as X-Forwarded-Proto: https further down the stack (see
+      // front-door-server.test.ts), but the bound server is a plain HTTP one
+      // so users can curl it without certificate-warning friction.
+      const warns: string[] = [];
+      const logger = {
+        info: () => {},
+        warn: (m: string) => warns.push(m),
+      } as never;
+      const { servers } = await buildFrontDoor(
+        {
+          listeners: [
+            {
+              listenerPort: 443,
+              hostPort: 0,
+              protocol: 'HTTPS',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+          ],
+        },
+        { containerHost: '127.0.0.1', pull: true } as never, // no --tls anywhere
+        logger
+      );
+      try {
+        expect(servers).toHaveLength(1);
+        expect(servers[0]!.scheme).toBe('http');
+        // The degradation must be logged so it is never silent.
+        expect(
+          warns.some(
+            (m) => m.includes('HTTPS in the cloud') && m.includes('serving HTTP locally')
+          )
+        ).toBe(true);
+      } finally {
+        await Promise.all(servers.map((s) => s.close()));
+      }
+    });
+
+    it('terminates TLS locally on --tls alone (auto self-signed cert, no --tls-cert / --tls-key)', async () => {
+      // The opt-in flag without a BYO cert pair routes through
+      // resolveFrontDoorTlsMaterials' self-signed path. The pre-baked cache
+      // dir (XDG_CACHE_HOME) avoids invoking openssl a second time.
+      const prevXdg = process.env['XDG_CACHE_HOME'];
+      process.env['XDG_CACHE_HOME'] = join(tlsTmpDir, 'xdg');
+      try {
+        const logger = { info: () => {}, warn: () => {} } as never;
+        const { servers } = await buildFrontDoor(
+          {
+            listeners: [
+              {
+                listenerPort: 443,
+                hostPort: 0,
+                protocol: 'HTTPS',
+                defaultAction: { kind: 'fixed-response', statusCode: 204 },
+                rules: [],
+              },
+            ],
+          },
+          { containerHost: '127.0.0.1', pull: true, tls: true } as never,
+          logger
+        );
+        try {
+          expect(servers).toHaveLength(1);
+          expect(servers[0]!.scheme).toBe('https');
+        } finally {
+          await Promise.all(servers.map((s) => s.close()));
+        }
+      } finally {
+        if (prevXdg === undefined) delete process.env['XDG_CACHE_HOME'];
+        else process.env['XDG_CACHE_HOME'] = prevXdg;
+      }
+    });
+
+    it('does not warn about HTTPS-degraded for an HTTP listener (no false positives)', async () => {
+      // Companion guard rail: the degradation warning must fire only when the
+      // cloud-side protocol is HTTPS. A pure HTTP listener is the dominant
+      // path; spurious warnings here would train users to ignore the signal.
+      const warns: string[] = [];
+      const logger = {
+        info: () => {},
+        warn: (m: string) => warns.push(m),
+      } as never;
+      const { servers } = await buildFrontDoor(
+        {
+          listeners: [
+            {
+              listenerPort: 80,
+              hostPort: 0,
+              protocol: 'HTTP',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+          ],
+        },
+        { containerHost: '127.0.0.1', pull: true } as never,
+        logger
+      );
+      try {
+        expect(servers).toHaveLength(1);
+        expect(servers[0]!.scheme).toBe('http');
+        expect(warns.some((m) => m.includes('HTTPS in the cloud'))).toBe(false);
+      } finally {
+        await Promise.all(servers.map((s) => s.close()));
+      }
+    });
   });
 
   it('stands up a fixed-response-default listener with no backing pool', async () => {
@@ -796,5 +914,53 @@ describe('parseLbPortOverrides', () => {
   it('throws on a malformed value or out-of-range port', () => {
     expect(() => parseLbPortOverrides(['8080'])).toThrow(/Expected <listenerPort>=<hostPort>/);
     expect(() => parseLbPortOverrides(['80=0'])).toThrow(/host port must be 1-65535/);
+  });
+});
+
+/**
+ * Drift guards for the `addCommonEcsServiceOptions` + `addAlbSpecificOptions`
+ * decomposition. The decomposition exists so cdkd (and any other host wrapping
+ * `runEcsServiceEmulator` with the ALB strategy) auto-inherits ALB-only flags
+ * without a duplicate `.addOption(...)` block. These tests fail the moment
+ * someone adds an ALB-specific flag inline in `createLocalStartAlbCommand`
+ * instead of inside `addAlbSpecificOptions` — which would silently break the
+ * inheritance the helper is supposed to guarantee.
+ */
+describe('start-alb option surface contract (addCommonEcsServiceOptions + addAlbSpecificOptions)', () => {
+  function longFlagsOf(cmd: Command): string[] {
+    return cmd.options
+      .map((o) => o.long)
+      .filter((l): l is string => typeof l === 'string')
+      .sort();
+  }
+
+  it('addAlbSpecificOptions registers exactly the known ALB-only flags', () => {
+    // Lock the helper's contract: cdkd imports it expecting THIS set of long
+    // flags. Adding or removing one without updating the list below is a
+    // semver-relevant surface change.
+    const flags = longFlagsOf(addAlbSpecificOptions(new Command()));
+    expect(flags).toEqual([
+      '--bearer-token',
+      '--lb-port',
+      '--no-verify-auth',
+      '--tls',
+      '--tls-cert',
+      '--tls-key',
+    ]);
+  });
+
+  it('createLocalStartAlbCommand surface equals common + alb-specific (no inline drift)', () => {
+    // The full CLI surface MUST be the union of the two helpers — never a
+    // proper superset. A proper superset would mean someone added an option
+    // inline in `createLocalStartAlbCommand`, which a host CLI (cdkd) calling
+    // the helpers directly would silently miss.
+    const full = longFlagsOf(createLocalStartAlbCommand());
+    const expected = Array.from(
+      new Set([
+        ...longFlagsOf(addCommonEcsServiceOptions(new Command())),
+        ...longFlagsOf(addAlbSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
   });
 });

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -746,6 +746,39 @@ describe('buildFrontDoor', () => {
       }
     });
 
+    it('passing --tls-cert / --tls-key (without --tls) implies --tls and terminates TLS locally (#198)', async () => {
+      // The implication is critical for back-compat: a user who already passed
+      // --tls-cert / --tls-key under the old default must keep getting an
+      // HTTPS-wire listener. The earlier "scheme=https when --tls-cert /
+      // --tls-key are set" test accidentally covers this, but is named for
+      // the cert path; this one names the implication explicitly so a
+      // regression of the OR-condition fails an obviously-named test.
+      const logger = { info: () => {}, warn: () => {} } as never;
+      const { servers } = await buildFrontDoor(
+        {
+          listeners: [
+            {
+              listenerPort: 443,
+              hostPort: 0,
+              protocol: 'HTTPS',
+              defaultAction: { kind: 'fixed-response', statusCode: 204 },
+              rules: [],
+            },
+          ],
+        },
+        // Note: `tls: true` is NOT set — only the cert pair. The implication
+        // is what's under test.
+        { containerHost: '127.0.0.1', pull: true, tlsCert: certPath, tlsKey: keyPath } as never,
+        logger
+      );
+      try {
+        expect(servers).toHaveLength(1);
+        expect(servers[0]!.scheme).toBe('https');
+      } finally {
+        await Promise.all(servers.map((s) => s.close()));
+      }
+    });
+
     it('does not warn about HTTPS-degraded for an HTTP listener (no false positives)', async () => {
       // Companion guard rail: the degradation warning must fire only when the
       // cloud-side protocol is HTTPS. A pure HTTP listener is the dominant


### PR DESCRIPTION
## Summary

`cdkl start-alb` now serves cloud-HTTPS listeners over plain HTTP locally by default. `X-Forwarded-Proto: https` and the redirect `#{protocol}` default still resolve to `https` so the upstream app keeps seeing the deployed listener protocol; a per-listener warning is logged so the degradation is never silent. `--tls` (or `--tls-cert` / `--tls-key`, which imply `--tls`) opts in to real TLS termination locally — the existing user-supplied PEM / auto-self-signed flow runs unchanged.

The user-visible symptom this fixes: `curl https://127.0.0.1:8443` against a deployed-HTTPS listener used to fail with `SSL certificate problem: self signed certificate`. After this PR, `curl http://127.0.0.1:8443` (no `-k`) works against the same host port and the upstream app still sees `X-Forwarded-Proto: https`.

### Decoupling at the runtime layer

- `StartFrontDoorServerOptions.forwardedProto` overrides `X-Forwarded-Proto` (and the redirect `#{protocol}` default) independent of the TLS materials. The wire scheme still follows `tls` presence; only the upstream-facing scheme is decoupled.
- `resolveForwardedProto(opts)` centralizes the derivation. All five appendForwarded / write-redirect call sites in `front-door-server.ts` use it: HTTP pool dispatch, HTTP redirect, Lambda dispatch, WebSocket bridge, WebSocket-upgrade redirect.

### Companion: `addAlbSpecificOptions` extraction (cdkd shim host request)

- New `addAlbSpecificOptions(cmd: Command): Command` helper in `src/cli/commands/local-start-alb.ts` registers `--lb-port`, `--tls`, `--tls-cert`, `--tls-key`, `--no-verify-auth`, `--bearer-token`.
- Re-exported from `cdk-local/internal` alongside `albStrategy` / `resolveAlbTarget` / `parseLbPortOverrides` so a host CLI (cdkd's `local start-alb`) auto-inherits ALB-only flags without duplicate `.addOption(...)` blocks.
- Drift guard: a unit test asserts `createLocalStartAlbCommand`'s long-flag surface equals the union of `addCommonEcsServiceOptions` and `addAlbSpecificOptions`. Adding an option inline in `createLocalStartAlbCommand` (the near-miss that triggered the extraction) fails CI immediately.

The drift-guard pattern motivates two follow-up issues filed during the PR:

- [#200](https://github.com/go-to-k/cdk-local/issues/200) extract `add<Cmd>SpecificOptions` for the remaining 5 commands + per-command contract tests.
- [#201](https://github.com/go-to-k/cdk-local/issues/201) `/check-cdkd-parity` skill + markgate gate + CLAUDE.md rule, covering judgment-level cross-repo parity (new subcommand factories / behavior changes / new helper exports).

### Docs

- `README.md` start-service-vs-start-alb section explains the new default + `--tls` opt-in.
- `docs/cli-reference.md` flag table, examples, and the HTTPS scope paragraph reflect the new default.
- `docs/library-mode.md` gains an "ECS service emulator engine" section covering the previously undocumented host-side exports (`runEcsServiceEmulator`, `addCommonEcsServiceOptions`, `addAlbSpecificOptions`, `albStrategy`, the `Planned*` types) plus an "ALB front-door target resolution" section.
- `.claude/CLAUDE.md` scope description updated.

### Migration

`--tls` reproduces the old behavior identically. Users who already pass `--tls-cert` / `--tls-key` keep getting an HTTPS-wire listener with no flag change (the implication is locked by a named unit test).

## Test plan

- [x] `vp run check` typecheck + lint + format
- [x] `vp run build` `dist/cli.js` + `dist/index.js`
- [x] `vp test run` 1695 unit tests pass (109 files)
- [x] Coverage check 4 src files touched, 4 test files updated; the `src/internal.ts` re-export carries no logic
- [x] 3-axis code review (`pr-spec-reviewer` / `pr-code-reviewer` / `pr-test-reviewer`) 2 BLOCKERs caught + addressed in commit `c587f58`; reviewer nits addressed or accepted (see below)
- [x] `local-start-alb` integ fixture extended with a second cloud-HTTPS listener; `verify.sh` asserts the host port serves HTTP without `--tls`, refuses an HTTPS handshake, and the degradation warning fires
- [x] No leftover Docker containers / networks after integ
- [x] Docs consistency vs. code

### Reviewer-nit disposition

Convergent BLOCKERs from spec + code reviewers (Lambda dispatch / WS-upgrade redirect still on `opts.tls ? 'https' : 'http'`): **addressed** in commit `c587f58` both switched to `resolveForwardedProto(opts)`. New unit tests in `tests/unit/local/front-door-server.test.ts` cover the Lambda + WS-bridge + WS-redirect degraded-HTTPS paths.

Code reviewer notable gap (WS-Upgrade `forwardedProto` plumbing uncovered): **addressed** in commit `c587f58`. A regression that reverted just the WS-bridge or WS-redirect branch to the old line would now fail one of the two new WebSocket Upgrade tests.

Code reviewer NIT (dead local `const forwardedProto` at `front-door-server.ts:264`): **accepted as known cost** the local is only consumed once to build `effectiveOpts`, but the named intermediate reads more clearly than inlining the spread and is once-per-server-start (negligible).

Code reviewer NIT (pre-existing `wantTls` accepts a single-cert input without an HTTPS listener): **accepted as pre-existing**. The TLS pairing helper rejects it with a clear error when an HTTPS listener exists; the no-HTTPS-listener path is silent like before this PR.

Test reviewer minor gap (integ `verify.sh` does not directly capture `X-Forwarded-Proto`): **accepted as known cost** the replica image is a hostname-echo server, not a header-echo server. The unit tests in `tests/unit/local/front-door-server.test.ts` cover the header plumbing through a header-capturing upstream.

Closes #198
