### PR TITLE
feat(meta): `/check-cdkd-parity` skill + markgate gate (#201)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -331,6 +331,27 @@ vp run runtime:smoke
   cloudformation` calls — leaving orphan resources after an integ
   run is never acceptable.
 
+- **cdkd parity** (host-CLI library-surface drift):
+  `cdkd-parity-gate.sh` blocks `gh pr create` when the diff touches
+  the cdk-local library surface (`src/cli/commands/**`,
+  `src/internal.ts`, `src/index.ts`) and the `cdkd-parity` marker is
+  stale. The marker is set ONLY by `/check-cdkd-parity`, which walks
+  the four host-impacting categories:
+  - **New subcommand factory** — exported from `src/index.ts`? cdkd
+    notified (issue / cross-link)?
+  - **New CLI option** — added inside the relevant
+    `add<Cmd>SpecificOptions` helper (not inline in
+    `create<Cmd>Command`)? contract test still green?
+  - **New public helper / type in `src/local/**`** — exported from
+    `src/internal.ts`? JSDoc names the host-side use case?
+  - **Behavior change** — cdkd informed? migration note in PR body?
+
+  Out-of-scope diffs (internal refactors, docs, tests) pass through
+  silently. `gh pr merge` is intentionally NOT gated — the parity
+  question is a pre-create judgment.
+  Details: [.claude/rules/hooks.md](.claude/rules/hooks.md) +
+  [.claude/skills/check-cdkd-parity/SKILL.md](.claude/skills/check-cdkd-parity/SKILL.md).
+
 ## Positioning when communicating
 
 - `cdkl` is the **binary** name (the command users type).

--- a/.claude/hooks/cdkd-parity-gate.sh
+++ b/.claude/hooks/cdkd-parity-gate.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# cdkd-parity-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr create` (and the
+# `cd <path> && gh pr create` / `gh -C <path> pr create` worktree forms)
+# when ALL of the following hold:
+#   1. The PR's diff vs origin/main touches the cdkd-parity gate's scope
+#      (`src/cli/commands/**`, `src/internal.ts`, `src/index.ts`).
+#   2. The `cdkd-parity` markgate marker is stale (digest differs / never set).
+#
+# When either condition is false (out-of-scope diff, or marker fresh), the
+# hook exits 0 and the `gh pr create` proceeds.
+#
+# Pre-create-only. The skill records a judgment, not a behavior assertion,
+# so re-checking at pre-merge time is redundant — `/verify-pr` surfaces the
+# marker stamp implicitly via its checklist.
+#
+# WHY cwd-aware: cdk-local is regularly worked in via `git worktree`, and
+# markgate stores marker state per-worktree at
+# `<git rev-parse --absolute-git-dir>/markgate/`. We resolve the target
+# working tree from the PreToolUse payload's `cwd` field plus leading
+# `cd <path>` and the last `gh -C <path>` flag, exactly mirroring
+# check-gate.sh / integ-gate.sh.
+#
+# Fail-open behavior:
+#   - `gh` missing OR `markgate` missing -> exit 0 silently. The hook is
+#     a safety net, not a hard dependency.
+#   - `git` missing or no `origin/main` ref -> exit 0 silently. We cannot
+#     compute the diff scope, so we cannot fairly block.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate `gh pr create`. `gh pr merge` is intentionally NOT gated — the
+# parity question is a pre-create judgment; once the marker has been set,
+# subsequent re-merges shouldn't re-block on a stale marker for a small
+# follow-up. Line-start anchored so `gh pr create` substrings inside quoted
+# argument bodies do NOT false-positive.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+target_dir="${hook_cwd:-$PWD}"
+
+# `cd <path>` at the start of the command shifts the target dir.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# `gh -C <path>` beats any earlier cd; pick the LAST occurrence.
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# If the resolved target dir is not a git repo, silently pass — we
+# can't audit what we can't see.
+if ! command -v git >/dev/null 2>&1; then
+  exit 0
+fi
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+cd "$target_dir" 2>/dev/null || exit 0
+
+# Fail-open if `gh` is unavailable. The gh tool is required as a hook
+# trigger (we only fire on `gh pr create`), but a missing binary at this
+# point still means we can't assert correctness, so pass through.
+if ! command -v gh >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Fail-open if origin/main is not resolvable (fresh clone with no fetch
+# yet, weird remote setup, etc.).
+if ! git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Compute the diff scope. If nothing in the gate's scope changed, the PR
+# can't drift the cdkd parity surface — pass through.
+scope_touched=$(git diff origin/main...HEAD --name-only 2>/dev/null \
+  | grep -E '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$' \
+  | head -1)
+if [ -z "$scope_touched" ]; then
+  exit 0
+fi
+
+# Prefer the `mise`-managed markgate via `mise exec --` so the repo's
+# canonical version wins; fall back to PATH; fail open if neither.
+if command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+elif command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+else
+  exit 0
+fi
+
+"${markgate[@]}" verify cdkd-parity >/dev/null 2>&1
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+fi
+
+# Extract the parenthesized reason from `markgate status cdkd-parity` so
+# the error message tells the user *why* the gate is stale (digest differs
+# vs marker never set).
+reason=$("${markgate[@]}" status cdkd-parity 2>/dev/null \
+  | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
+
+if [ -n "$reason" ]; then
+  printf "Blocked by cdkd-parity-gate: this PR touches cdk-local's library surface (src/cli/commands/** | src/internal.ts | src/index.ts) and the \`cdkd-parity\` marker is stale %s.\n\n" "$reason" >&2
+else
+  cat >&2 <<'EOF_HEAD'
+Blocked by cdkd-parity-gate: this PR touches cdk-local's library
+surface (src/cli/commands/** | src/internal.ts | src/index.ts) and
+the `cdkd-parity` marker is stale.
+
+EOF_HEAD
+fi
+
+cat >&2 <<'EOF'
+Required action — no exceptions:
+  /check-cdkd-parity
+
+The skill walks four categories that the host CLI (cdkd) needs to
+inherit when cdk-local's library surface changes:
+  1. New subcommand factory     — exported from src/index.ts?
+                                  cdkd notified?
+  2. New CLI option             — added inside add<Cmd>SpecificOptions?
+                                  contract test green?
+  3. New public helper / type   — exported from src/internal.ts?
+                                  JSDoc names host-side use case?
+  4. Behavior change            — cdkd informed? migration note in body?
+
+Only call `markgate set cdkd-parity` when every check passes or is
+explicitly N/A. Calling it directly from a shell to bypass this hook
+defeats the whole point — the gate exists because these questions were
+informally skipped twice during the ALB work.
+EOF
+exit 2

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -141,9 +141,9 @@ The hooks split into three classes:
 
 ## 3. Markgate-backed gates
 
-The four markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
-`pr-review-gate.sh`, and `integ-gate.sh`) are all
-**cwd-aware**. Each reads the PreToolUse payload's `cwd` field plus
+The five markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
+`pr-review-gate.sh`, `integ-gate.sh`, and `cdkd-parity-gate.sh`) are
+all **cwd-aware**. Each reads the PreToolUse payload's `cwd` field plus
 parses leading `cd <path>` and the last `git -C <path>` /
 `gh -C <path>` flag from the command, then `cd`s to that resolved
 target dir before invoking `markgate verify`. This preserves
@@ -257,3 +257,40 @@ today's local code path actually works.
 
 The skill is the ONLY legitimate setter of this marker — never
 call `markgate set integ` directly from a shell.
+
+### cdkd-parity-gate (pre-create)
+
+- **`cdkd-parity-gate.sh`** blocks `gh pr create` (incl.
+  `gh -C <path> pr create` / `cd <path> && gh pr create`) on PRs
+  whose diff vs `origin/main` touches the cdk-local library surface
+  (`src/cli/commands/**`, `src/internal.ts`, `src/index.ts`) when
+  the `cdkd-parity` marker is stale. The marker is set ONLY by
+  `/check-cdkd-parity`, which walks the four host-impacting
+  categories — new subcommand factory, new CLI option, new public
+  helper / type, behavior change — and asks the structured
+  questions a host CLI maintainer (cdkd) would ask before bumping
+  the `cdk-local` version:
+
+  - new subcommand factory → exported from `src/index.ts`? cdkd
+    notified?
+  - new CLI option → added inside `add<Cmd>SpecificOptions` (not
+    inline in `create<Cmd>Command`)? contract test still green?
+  - new public helper / type under `src/local/**` → exported from
+    `src/internal.ts`? JSDoc names the host-side use case?
+  - behavior change → cdkd informed (issue / cross-link)? migration
+    note in PR body?
+
+  Pre-create only — `gh pr merge` is intentionally NOT gated. The
+  parity question is a judgment recorded once at PR-create time;
+  re-blocking on a stale marker for a small follow-up commit would
+  be friction without value. Out-of-scope diffs (internal refactors
+  not touching the gate's paths, docs, tests, infra) pass through
+  silently.
+
+  Fail-open behavior: when `gh` / `markgate` are missing, or
+  `origin/main` is not resolvable, the hook exits 0 silently. The
+  gate is a safety net for the four categories above, not a hard
+  dependency.
+
+  The skill is the ONLY legitimate setter of this marker — never
+  call `markgate set cdkd-parity` directly from a shell.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -101,6 +101,13 @@
             "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*) or Bash(git merge*) or Bash(git -C * merge*) or Bash(cd * && git merge*)",
             "timeout": 15,
             "statusMessage": "Verifying integ markgate marker..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/cdkd-parity-gate.sh",
+            "if": "Bash(gh pr create*) or Bash(gh -C * pr create*) or Bash(cd * && gh pr create*)",
+            "timeout": 15,
+            "statusMessage": "Verifying cdkd-parity markgate marker..."
           }
         ]
       }

--- a/.claude/skills/check-cdkd-parity/SKILL.md
+++ b/.claude/skills/check-cdkd-parity/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: check-cdkd-parity
+description: Triggers when a PR adds a new subcommand factory, CLI option, public helper, or behavior change to cdk-local that cdkd (host CLI) may need to inherit. Walks the diff and pins each category to "exported via internal.ts / inside add<Cmd>SpecificOptions / cdkd notified" — sets the cdkd-parity marker so gh pr create can fire.
+---
+
+# cdkd Parity Check
+
+cdk-local is a library + CLI; cdkd embeds it as a library. Whenever
+cdk-local extends its public surface — new subcommand, new option, new
+exported helper, behavior change — cdkd has to either import the new
+helper, wrap the new subcommand, inherit the new option block, or
+update its own behavior to match. The mechanical part is covered by
+per-command unit-test contracts; this skill walks the judgment-level
+questions that are easy to skip: did you export it, did you put it in
+the right helper, did you tell the host?
+
+This skill is consumed by `cdkd-parity-gate.sh`, which blocks
+`gh pr create` when the diff touches the gate's scope and this marker
+is stale.
+
+## Pre-flight scope check
+
+Determine whether the PR's diff actually touches cdk-local's library
+surface. Run from the worktree:
+
+```bash
+git diff origin/main...HEAD --name-only \
+  | grep -E '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$' \
+  || echo "out-of-scope"
+```
+
+If the output is `out-of-scope` (the diff touches none of the gate's
+paths), write one line — "no library-surface touched; cdkd-parity n/a"
+— set the marker (see "Commit-gate marker" below), and stop. Do NOT
+walk the categories below for unrelated edits; the marker is correct
+to set because there is nothing for cdkd to inherit.
+
+The diff base is `origin/main`, not local `main` (see memory:
+`feedback_diff_base_origin_main`).
+
+## Category 1: New subcommand factory?
+
+A new file like `src/cli/commands/local-<verb>.ts` that exports a
+`createLocal<Verb>Command` factory is a new public CLI subcommand.
+cdkd embeds these via `src/index.ts` and wraps them with host-side
+options.
+
+**Detect**:
+
+```bash
+git diff origin/main...HEAD --name-only --diff-filter=A \
+  | grep -E '^src/cli/commands/local-[^/]+\.ts$'
+```
+
+Empty output → no new subcommand → skip to Category 2.
+
+For each new factory file:
+
+- [ ] **Exported from `src/index.ts`?** — host CLIs reach the factory
+      via the public library entry. Confirm:
+
+      ```bash
+      grep -nE 'createLocal[A-Z][A-Za-z]*Command' src/index.ts
+      ```
+
+      The new factory name must appear in the export list. If it
+      doesn't, add the export before setting the marker.
+
+- [ ] **cdkd notified?** — this is a manual step. Either file an issue
+      on the cdkd repo describing the new subcommand and the wrap point
+      (`createLocal<Verb>Command` factory + suggested host-side options
+      block), OR cross-link this PR in an existing tracking issue. Note
+      which path you took in the PR body.
+
+## Category 2: New CLI option on an existing command?
+
+A new `addOption(new Option(...))` call inside an existing
+`src/cli/commands/local-*.ts` is a new flag the host CLI must inherit.
+
+**Detect**:
+
+```bash
+git diff origin/main...HEAD -- 'src/cli/commands/*.ts' \
+  | grep -E '^\+.*addOption.*new Option'
+```
+
+Empty output → no new option → skip to Category 3.
+
+For each added option:
+
+- [ ] **Added inside the relevant `add<Cmd>SpecificOptions` helper, NOT
+      inline in `create<Cmd>Command`?** — the helper is the seam cdkd
+      reuses to inherit the option block without duplicating it.
+      Inline-in-factory means the host can't pick up the option without
+      copy-paste. Read the diff context — the `+addOption(...)` should
+      sit inside an `add<Cmd>SpecificOptions(cmd: Command)` function,
+      not in the factory body.
+
+- [ ] **Contract test still passes?** — the per-command option-contract
+      tests assert that the helper's output matches the factory's
+      attached options. `vp run test` covers this; the `check` marker's
+      freshness already implies this passed. If the option was added
+      inline in the factory, the contract test will catch it as a
+      drift.
+
+## Category 3: New public helper / type in `src/local/**`?
+
+A new exported function / class / type under `src/local/**` is a
+low-level building block. Host CLIs reach these via the
+`cdk-local/internal` subpath (`src/internal.ts`); the main entry
+`src/index.ts` does NOT re-export them. See memory:
+`feedback_internal_exports_placement`.
+
+**Detect**:
+
+```bash
+git diff origin/main...HEAD --name-only -- 'src/local/**'
+```
+
+Empty output → no helper changes → skip to Category 4.
+
+For each new export in `src/local/**`:
+
+- [ ] **Exported from `src/internal.ts`?** — the host reaches it via
+      `import { ... } from 'cdk-local/internal'`. Confirm:
+
+      ```bash
+      grep -nE "from '\./local/" src/internal.ts
+      ```
+
+      The new symbol must show up either as a named re-export or via a
+      `export *` line covering its module.
+
+- [ ] **JSDoc explains the host-side use case?** — `internal.ts` has no
+      semver guarantee, so the JSDoc on each exported symbol is the
+      only contract a host author has. Read the new symbol's JSDoc and
+      confirm it names the intended host-side use case (e.g. "consumed
+      by cdkd's `<command>` provider to ..."). Pure-implementation
+      docstrings ("returns a Foo") are not sufficient.
+
+## Category 4: Behavior change in an existing command?
+
+Behavior changes — changed defaults, new validation, changed output
+format, changed exit codes, changed error messages a host might match
+on — are silent breakage for cdkd. Purely additive changes
+(Categories 1-3) do not count here.
+
+**Detect**: walk the diff yourself. There is no mechanical grep for
+this — read every changed `src/cli/commands/*.ts` and every changed
+`src/local/**` file and ask "does the externally observable behavior
+change for an existing input?".
+
+For each behavior change:
+
+- [ ] **cdkd informed?** — file an issue on the cdkd repo OR cross-link
+      this PR in an existing tracking issue. The issue must name the
+      old behavior, the new behavior, and the migration cdkd needs to
+      apply (if any). Without this, cdkd's next release silently ships
+      the changed behavior with no host-side adjustment.
+
+- [ ] **Migration note in PR body?** — the PR body must call out the
+      behavior change in a section labeled `Behavior change` (or
+      `Breaking change` when appropriate), so anyone bumping the
+      `cdk-local` version in cdkd reads it without digging through the
+      diff.
+
+## Final step: set the marker
+
+Only call `mise exec -- markgate set cdkd-parity` when EVERY check
+above passed or was explicitly marked N/A. If any item is unresolved,
+skip the marker, list the unresolved items, and stop — the
+`cdkd-parity-gate.sh` hook will then correctly block `gh pr create`
+until the walk-through is repeated.
+
+```bash
+mise exec -- markgate set cdkd-parity
+```
+
+Run from the same worktree (cwd) where `gh pr create` will eventually
+be invoked. See `.claude/rules/hooks.md` "Markgate-backed gates" for
+the per-worktree marker convention.
+
+## Important
+
+- English-only for all committed artifacts (see `.claude/CLAUDE.md`
+  "Workflow rules").
+- Do NOT reference cdkd internal implementation in cdk-local artifacts
+  — the dependency direction is `cdkd -> cdk-local`. The skill talks
+  about "notify cdkd" / "host CLI", not about cdkd's deploy or
+  provider system.
+- The "notify cdkd" steps are manual — this skill does NOT file the
+  issue / send the message itself; it prompts the user to do so and
+  records the decision in the PR body.

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -43,7 +43,21 @@ Run each check and report pass/fail:
    - Invoke `/check-docs` skill logic: verify docs match code changes.
    - Check for stale references to removed code.
 
-6. **Docker + integ verification** (for src/** or tests/integration/** touches)
+6. **cdkd parity reviewed** (for src/cli/commands/** or src/internal.ts or src/index.ts touches)
+
+   The `cdkd-parity` markgate gate physically blocks `gh pr create` when its marker is stale AND the PR's diff touches the cdk-local library surface that cdkd (and any other host CLI) embeds. The pre-create gate covers the open path; checking the marker here closes the merge-time path structurally:
+
+   ```bash
+   # Only check when the PR diff actually touches the gate scope.
+   if git diff origin/main...HEAD --name-only \
+       | grep -qE '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$'; then
+     mise exec -- markgate verify cdkd-parity
+   fi
+   ```
+
+   If this exits non-zero (digest differs OR marker never set), run `/check-cdkd-parity` to walk the four host-impacting categories — new subcommand factory / new CLI option / new public helper / behavior change — and set the marker. See `.claude/skills/check-cdkd-parity/SKILL.md` and `.claude/rules/hooks.md` "cdkd-parity-gate (pre-create)".
+
+7. **Docker + integ verification** (for src/** or tests/integration/** touches)
 
    The `integ` markgate gate physically blocks `gh pr merge` when its marker is stale (see `.claude/hooks/integ-gate.sh` once shipped). The merge-time gate has a known blind spot: it reads the **local working tree** digest, and when `gh pr merge` runs from a parent worktree still on pre-PR `main`, the digest matches the old content and the gate passes silently — so an unverified change can reach main via the merge-from-parent path. `/verify-pr` runs in the PR's own worktree (post-PR content), so verifying the marker here closes that gap structurally:
 
@@ -58,11 +72,11 @@ Run each check and report pass/fail:
 
    For `*-from-cfn-stack` integ tests only: verify no orphan CloudFormation stack remains (`aws cloudformation describe-stacks --stack-name <FixtureStackName>` should return `Stack does not exist`).
 
-7. **No stale references**
+8. **No stale references**
    - Grep for removed imports, old module names, or deprecated references in source files.
    - Check `src/index.ts` exports are consistent.
 
-8. **Code review**
+9. **Code review**
    - **First, run `/review-pr <N>`** to get a size-appropriate review plan. The skill outputs one of:
      - **inline spot-check** (small PR, < 300 LOC OR < 5 files, no security-sensitive paths) — read the diff yourself in this step; no sub-agent dispatch.
      - **1 reviewer** (medium PR, 300-1000 LOC) — dispatch a single `pr-code-reviewer` agent (the skill emits a ready-to-paste Agent call).
@@ -80,7 +94,7 @@ Run each check and report pass/fail:
    - Verify type definitions are consistent with implementation.
    - **Shared-utility regression check**: if any file under `src/utils/**` (or another widely-imported module) changed, list every importer (`grep -rl "from '\.\./.*utils/<file>'" src tests`) and walk through each one to confirm the new behavior is correct for them. A change to a shared helper is only "done" when every caller has been considered.
 
-9. **Live-test changed behavior**
+10. **Live-test changed behavior**
    - Unit tests verify code correctness; this step verifies *feature* correctness against the runtime the user actually sees.
    - Build the latest source: `vp run build`.
    - For each user-visible change in the diff (CLI command, output format, flag, error message, runtime container behavior), run the actual command path against a real or fixture input and confirm the output matches the spec / sam-local parity claim:
@@ -91,7 +105,7 @@ Run each check and report pass/fail:
      - PreToolUse hook change (`.claude/hooks/*.sh`) → exercise it end-to-end: build a throwaway git repo (simulate the base ref via `git update-ref refs/remotes/origin/main <sha>` + `git symbolic-ref refs/remotes/origin/HEAD`), commit an offending case AND a clean case, then pipe a synthesized payload (`jq -nc '{tool_input:{command:"<gated cmd>"},cwd:"<repo>"}'`) into the hook and assert it blocks the offender (exit 2) and passes the clean case + a non-matching command (exit 0). Shell hooks have no unit-test harness, so this end-to-end run is the ONLY correctness check — a hook that silently fail-opens (e.g. an unsupported `gh` flag) looks installed but never fires.
    - "Tests passed" is not "feature works." Always run the actual command before declaring done. If you cannot live-test (no Docker daemon, no fixture available), say so explicitly rather than skip silently — the gate exits non-zero so a reviewer can decide whether to accept the trade-off.
 
-10. **Retrospective + rules update**
+11. **Retrospective + rules update**
     - Walk back over the session that produced this PR. For each surprise, friction, or correction the user had to make, ask: "is this a one-off, or a pattern that will recur?"
     - For each pattern, propose where it should be reflected so it doesn't recur:
       - **Hook** — pattern can be detected mechanically (e.g. fragile shell pattern, deprecated tool, marker-gated step). Strongest enforcement.
@@ -100,7 +114,7 @@ Run each check and report pass/fail:
     - Surface the proposals out loud (in chat, or in this PR's body) before merging. If the user agrees, write them in the same PR for code/skill/hook artifacts; memory entries are local to `~/.claude/projects/.../memory/` so they land regardless of PR boundaries.
     - The retrospective is itself one of the items the `verify-pr` marker covers — skipping this step means the marker is set on incomplete work.
 
-11. **Residual review-nit sweep**
+12. **Residual review-nit sweep**
     - For every `/review-pr` reviewer agent output during this session (including re-reviews after fix-back), walk the reviewer's "Minor / Nit / Informational" section.
     - For EACH item there, confirm ONE of the following is true BEFORE setting the `verify-pr` marker:
       - (a) **Addressed in this PR** — point at the fix commit / file:line that resolves the nit.
@@ -109,7 +123,7 @@ Run each check and report pass/fail:
     - If NONE of (a) / (b) / (c) is true for any nit, file a bundled follow-up issue NOW (one issue per session, listing every uncovered nit) and update the PR body to reference it. Do not set the `verify-pr` marker until every reviewer-flagged item is on one of those three paths.
     - **Auto-close audit**: read the PR body (`gh pr view <PR> --json body -q .body`). For every `(#N)` parens-form reference, check whether it's adjacent to a close keyword (`closes` / `fixes` / `resolves`, case-insensitive). If yes: the merge will NOT auto-close the target issue. Either rewrite to parens-free `Closes #N` (auto-close fires), OR add a manual `gh issue close <N>` step to the merge sequence and note it in the PR body. The `closes-paren-form-gate.sh` hook ALREADY blocks `gh pr merge` for the `Closes (#N)` pattern — this skill step is the human-readable backup that catches the issue BEFORE the merge attempt.
 
-12. **PR title + body freshness** (skip if no PR exists yet)
+13. **PR title + body freshness** (skip if no PR exists yet)
     - When a PR has follow-up commits after creation, both the title and body authored at PR-create time often go stale: the title was scoped to the first commit's intent only, and the body may mention reverted features, removed checks, or wrong rationale.
     - **Title check**: read `gh pr view <PR> --json title -q .title` and confirm it still describes the union of commits on the branch. Update via `gh api -X PATCH repos/{owner}/{repo}/pulls/{number} -f title="..."` (NOT `gh pr edit --title`, which fails silently due to GraphQL Projects-classic deprecation — see hook `gh-pr-edit-deprecation-gate.sh`).
     - **Body freshness commands**:
@@ -147,6 +161,7 @@ Present results as a table:
 | CI | pass/fail |
 | working tree | clean/dirty |
 | docs consistency | pass/fail |
+| cdkd-parity marker (src/cli/commands/** or src/internal.ts or src/index.ts touches) | fresh/stale/n-a |
 | integ marker (src/** or tests/integration/** touches) | fresh/stale/n-a |
 | code review (incl. shared-utility callers) | pass/issues found |
 | live-test changed behavior | pass/skipped/issues found |

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -1,6 +1,6 @@
 # markgate configuration — https://github.com/go-to-k/markgate
 #
-# Five gates back the pre-commit / pre-PR / pre-merge checks for cdk-local.
+# Six gates back the pre-commit / pre-PR / pre-merge checks for cdk-local.
 # cdk-local does NOT deploy to AWS (no destroy path, no schema migration,
 # no broad real-AWS integ matrix), so the destroy / broad / schema-migration
 # gates from cdkd are not needed.
@@ -27,6 +27,11 @@
 #                    chokidar / network behavior, dockerd semantics drift
 #                    over time, so a marker that's been clean for two
 #                    weeks no longer proves today's local code path works.
+#   cdkd-parity    — Host-CLI (cdkd) parity review for library-surface
+#                    changes (new subcommand factory / new CLI option /
+#                    new public helper / behavior change). Set ONLY by
+#                    /check-cdkd-parity. Scope is the public library
+#                    surface; out-of-scope diffs don't invalidate it.
 
 gates:
   check:
@@ -70,3 +75,15 @@ gates:
     include:
       - "src/**"
       - "tests/integration/**"
+
+  cdkd-parity:
+    hash: files
+    # Scope is the public library surface that cdkd (and any other host
+    # CLI) embeds: the CLI command factories, the unstable internal
+    # subpath, and the stable index export list. Edits anywhere else
+    # in `src/**` don't invalidate this marker — they don't affect
+    # what a host CLI sees.
+    include:
+      - "src/cli/commands/**"
+      - "src/internal.ts"
+      - "src/index.ts"


### PR DESCRIPTION
## Summary

Adds a `/check-cdkd-parity` markgate skill, the `cdkd-parity-gate.sh`
PreToolUse hook, and a `.claude/CLAUDE.md` rule that codify the
library-surface drift check between cdk-local and its embedder cdkd.

- New skill walks four host-impacting categories on PRs that touch
  cdk-local's library surface (`src/cli/commands/**`, `src/internal.ts`,
  `src/index.ts`) and pins each to a structured question:
  - new subcommand factory -> exported from `src/index.ts`? cdkd
    notified?
  - new CLI option -> added inside `add<Cmd>SpecificOptions` (not
    inline in `create<Cmd>Command`)? contract test green?
  - new public helper / type under `src/local/**` -> exported from
    `src/internal.ts`? JSDoc names the host-side use case?
  - behavior change -> cdkd informed? migration note in PR body?
- New `cdkd-parity` gate in `.markgate.yml` (scope: the three library
  surface paths). Marker set ONLY by the skill.
- New `cdkd-parity-gate.sh` blocks `gh pr create` when the diff vs
  `origin/main` touches the gate scope and the marker is stale.
  Pre-create only; `gh pr merge` is intentionally not gated (judgment
  recorded once at PR-create time; re-blocking small follow-ups would
  be friction without value).
- `/verify-pr` checklist gains a `cdkd parity reviewed` item between
  `docs consistency` and `integ marker`, and the output table now
  surfaces the marker state.
- `.claude/rules/hooks.md` documents the new hook in the
  Markgate-backed gates section.

## Why now

The mechanical part of host-side parity is already covered by
per-command unit-test contracts (#198 + follow-ups). The
judgment-level part — "did you remember to export this from
`internal.ts`?", "did you file an issue for cdkd?", "did you register
the new subcommand factory in `src/index.ts`?" — was informal and
nearly slipped twice during the ALB work. The gate physically blocks
`gh pr create` so the walk-through cannot be skipped on the open
path, matching the existing `/check` + `check-gate` and `/run-integ` +
`integ-gate` pattern.

## How the gate catches the patterns

- Adding `src/cli/commands/local-foo.ts` without re-exporting
  `createLocalFooCommand` from `src/index.ts` -> diff touches gate
  scope -> stale marker -> hook blocks `gh pr create` -> skill
  category 1 surfaces the missing export.
- Adding `addOption(new Option(...))` directly inside a
  `create<Cmd>Command` factory body instead of the
  `add<Cmd>SpecificOptions` helper -> diff touches gate scope ->
  stale marker -> hook blocks `gh pr create` -> skill category 2
  surfaces the wrong-placement.
- Adding a new helper to `src/local/foo.ts` without re-exporting from
  `src/internal.ts` -> diff touches gate scope (the `internal.ts`
  edit is required either way; if it's missing the skill flags it)
  -> stale marker -> hook blocks -> skill category 3 surfaces it.
- Silent behavior change in an existing command -> diff touches gate
  scope -> stale marker -> hook blocks -> skill category 4 forces
  the cdkd notification + migration note in the PR body before the
  marker can be set.

Out-of-scope diffs (internal refactors not touching the three paths,
docs, tests, infra) pass through silently — `git diff
origin/main...HEAD --name-only` returns no match against the scope
regex, hook exits 0.

## Hook end-to-end live-test

Per `feedback_gh_no_dash_c_and_hook_livetest`, shell hooks have no
unit-test harness — exercised end-to-end with a synthesized
PreToolUse payload across all four state combinations:

```text
==== Case 1: no scope touched (empty diff vs origin/main) -> expect 0 ====
Case 1 exit=0

==== Case 2: scope touched, marker stale -> expect 2 ====
Blocked by cdkd-parity-gate: this PR touches cdk-local's library
surface (src/cli/commands/** | src/internal.ts | src/index.ts) and
the `cdkd-parity` marker is stale.
[... full skill prompt elided ...]
Case 2 exit=2

==== Case 3: non-gated command (gh pr view) -> expect 0 ====
Case 3 exit=0

==== Case 4: marker set in TMPREPO (with .markgate.yml copied), scope still touched -> expect 0 ====
marker saved: cdkd-parity
Case 4 exit=0
```

Case 4 required the `.markgate.yml` to live inside the TMPREPO too —
without the gate definition there, `markgate verify cdkd-parity`
reports stale even after `markgate set`. That's correct production
behavior: the gate config travels with the repo.

## Test plan

- [x] `vp check --fix` clean (typecheck + lint + format)
- [x] `vp test run` — 109 files / 1695 tests pass
- [x] `vp run build` — both `dist/cli.js` and `dist/index.js`
- [x] Hook end-to-end live-test transcript (above) — 4/4 cases match
      expected exit codes
- [x] `/check-docs` skill walk — docs cross-check between the new
      skill / hook artifacts and the prose added to `.claude/CLAUDE.md`
      + `.claude/rules/hooks.md` + `/verify-pr` checklist

Closes #201
