### PR TITLE
feat(cli): extract `add<Cmd>SpecificOptions` helpers for the remaining 5 commands (#200)

### DIFF
--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -289,3 +289,49 @@ ALB target string into a listener-by-listener routing table:
 - `isApplicationLoadBalancer` — type-narrowing predicate that
   disambiguates ApplicationLoadBalancer from NetworkLoadBalancer when
   picking targets.
+
+## Per-command option blocks (host CLIs that wrap a single command)
+
+A host CLI that ports an individual `cdkl` command verbatim (rather than
+re-exporting the factory) can compose the per-command option block on
+its own Commander instance. Each helper registers only that command's
+NON-common flags; the host still owns the shared `commonOptions` /
+`appOptions` / `contextOptions` / `deprecatedRegionOption` block (or
+calls them via its own re-export). Adding or renaming a per-command flag
+in upstream cdk-local propagates to every embedder calling the helper —
+no duplicate `.addOption(...)` block on the host side.
+
+- `addInvokeSpecificOptions(cmd)` — `cdkl invoke` flags
+  (`--event`, `--event-stdin`, `--env-vars`, `--no-pull`, `--no-build`,
+  `--debug-port`, `--container-host`, `--assume-role`, `--layer-role-arn`,
+  `--ecr-role-arn`, `--from-cfn-stack`, `--stack-region`).
+- `addInvokeAgentCoreSpecificOptions(cmd)` — `cdkl invoke-agentcore`
+  flags (`--event`, `--event-stdin`, `--env-vars`, `--session-id`,
+  `--ws`, `--ws-interactive`, `--bearer-token`, `--no-verify-auth`,
+  `--sigv4`, `--platform`, `--no-pull`, `--no-build`, `--container-host`,
+  `--timeout`, `--assume-role`, `--ecr-role-arn`, `--from-cfn-stack`,
+  `--stack-region`).
+- `addStartApiSpecificOptions(cmd)` — `cdkl start-api` flags
+  (`--port`, `--host`, `--stack`, `--all-stacks`, `--warm`,
+  `--per-lambda-concurrency`, `--no-pull`, `--container-host`,
+  `--debug-port-base`, `--env-vars`, `--assume-role`, `--watch`,
+  `--stage`, `--api`, `--layer-role-arn`, `--from-cfn-stack`,
+  `--stack-region`, `--mtls-truststore`, `--mtls-cert`, `--mtls-key`,
+  `--strict-sigv4`).
+- `addRunTaskSpecificOptions(cmd)` — `cdkl run-task` flags
+  (`--cluster`, `--env-vars`, `--container-host`, `--host-port`,
+  `--assume-task-role`, `--no-pull`, `--ecr-role-arn`, `--platform`,
+  `--keep-running`, `--detach`, `--from-cfn-stack`, `--stack-region`).
+  Does NOT compose with `addCommonEcsServiceOptions` — the single-task
+  surface intentionally diverges from the multi-replica service surface
+  (no `--max-tasks` / `--restart-policy`).
+- `addListSpecificOptions(cmd)` — `cdkl list` flag (`-l, --long`).
+  Intentionally minimal so the surface-contract test pattern stays
+  uniform across every per-command helper.
+
+Each helper is chainable (returns `cmd`); the upstream `cdkl` factories
+themselves call the helper to avoid duplicating the option block,
+so the helper and the factory cannot drift apart silently (the
+`tests/unit/cli/option-surface-contracts.test.ts` drift guards fail
+the moment someone adds a flag inline in `create<Cmd>Command` instead
+of inside the matching `add<Cmd>SpecificOptions` helper).

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -1551,6 +1551,37 @@ export function createLocalInvokeAgentCoreCommand(
       '[target]',
       'CDK display path or stack-qualified logical ID of the AgentCore Runtime to invoke (omit to pick interactively in a TTY)'
     )
+    .action(
+      withErrorHandling(
+        async (target: string | undefined, options: LocalInvokeAgentCoreOptions) => {
+          await localInvokeAgentCoreCommand(target, options, opts.extraStateProviders);
+        }
+      )
+    );
+
+  addInvokeAgentCoreSpecificOptions(cmd);
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(deprecatedRegionOption);
+  return cmd;
+}
+
+/**
+ * Register the option block that `cdkl invoke-agentcore` adds on top of
+ * the shared common / app / context option helpers. Shared between
+ * `cdkl invoke-agentcore` and any host CLI (e.g. cdkd's
+ * `local invoke-agentcore`) that wraps the single-shot AgentCore Runtime
+ * container runner, so adding or renaming an `invoke-agentcore`-only flag
+ * here propagates to every embedder without duplicate `.addOption(...)`
+ * blocks.
+ *
+ * Calling order only affects `--help` presentation (Commander parses
+ * insertion-order-independent). The host-CLI convention is host-specific
+ * options first, then this helper, then the shared common / app / context
+ * options — host flags / invoke-agentcore flags / common flags grouped
+ * in three `--help` clusters. Chainable: returns `cmd`.
+ */
+export function addInvokeAgentCoreSpecificOptions(cmd: Command): Command {
+  return cmd
     .addOption(new Option('-e, --event <file>', 'JSON event payload file (default: {})'))
     .addOption(new Option('--event-stdin', 'Read event JSON from stdin').default(false))
     .addOption(
@@ -1668,16 +1699,5 @@ export function createLocalInvokeAgentCoreCommand(
         '--stack-region <region>',
         'Region of the state record to read. Used with --from-cfn-stack as the CFn client region.'
       )
-    )
-    .action(
-      withErrorHandling(
-        async (target: string | undefined, options: LocalInvokeAgentCoreOptions) => {
-          await localInvokeAgentCoreCommand(target, options, opts.extraStateProviders);
-        }
-      )
     );
-
-  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
-  cmd.addOption(deprecatedRegionOption);
-  return cmd;
 }

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -1148,6 +1148,37 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
       '[target]',
       'CDK display path or stack-qualified logical ID of the Lambda to invoke (omit to pick interactively in a TTY)'
     )
+    .action(
+      withErrorHandling(async (target: string | undefined, options: LocalInvokeOptions) => {
+        await localInvokeCommand(target, options, opts.extraStateProviders);
+      })
+    );
+
+  addInvokeSpecificOptions(invoke);
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((option) =>
+    invoke.addOption(option)
+  );
+  invoke.addOption(deprecatedRegionOption);
+
+  return invoke;
+}
+
+/**
+ * Register the option block that `cdkl invoke` adds on top of the shared
+ * common / app / context option helpers. Shared between `cdkl invoke` and
+ * any host CLI (e.g. cdkd's `local invoke`) that wraps the single-shot
+ * RIE-backed Lambda runner, so adding or renaming an `invoke`-only flag
+ * here propagates to every embedder without duplicate `.addOption(...)`
+ * blocks.
+ *
+ * Calling order only affects `--help` presentation (Commander parses
+ * insertion-order-independent). The host-CLI convention is host-specific
+ * options first, then this helper, then the shared common / app / context
+ * options — host flags / invoke flags / common flags grouped in three
+ * `--help` clusters. Chainable: returns `cmd`.
+ */
+export function addInvokeSpecificOptions(cmd: Command): Command {
+  return cmd
     .addOption(new Option('-e, --event <file>', 'JSON event payload file (default: {})'))
     .addOption(new Option('--event-stdin', 'Read event JSON from stdin').default(false))
     .addOption(
@@ -1223,17 +1254,5 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
         '--stack-region <region>',
         'Region of the state record to read. Used with --from-cfn-stack as the CFn client region.'
       )
-    )
-    .action(
-      withErrorHandling(async (target: string | undefined, options: LocalInvokeOptions) => {
-        await localInvokeCommand(target, options, opts.extraStateProviders);
-      })
     );
-
-  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((option) =>
-    invoke.addOption(option)
-  );
-  invoke.addOption(deprecatedRegionOption);
-
-  return invoke;
 }

--- a/src/cli/commands/local-list.ts
+++ b/src/cli/commands/local-list.ts
@@ -186,19 +186,41 @@ export function createLocalListCommand(opts: CreateLocalListCommandOptions = {})
         'usually do not need to copy these — just run the command (e.g. `invoke`) with no target in a ' +
         'terminal and pick from the list.'
     )
-    .addOption(
-      new Option(
-        '-l, --long',
-        "Also print each target's stack-qualified logical ID (<Stack>:<LogicalId>) beneath it"
-      ).default(false)
-    )
     .action(
       withErrorHandling(async (options: LocalListOptions) => {
         await localListCommand(options);
       })
     );
 
+  addListSpecificOptions(cmd);
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
   cmd.addOption(deprecatedRegionOption);
   return cmd;
+}
+
+/**
+ * Register the option block that `cdkl list` adds on top of the shared
+ * common / app / context option helpers. Shared between `cdkl list` and any
+ * host CLI (e.g. cdkd's `local list`) that wraps the synthesis-driven
+ * target enumeration, so adding or renaming a `list`-only flag here
+ * propagates to every embedder without duplicate `.addOption(...)` blocks.
+ *
+ * Calling order only affects `--help` presentation (Commander parses
+ * insertion-order-independent). The host-CLI convention is host-specific
+ * options first, then this helper, then the shared common / app / context
+ * options — host flags / list flags / common flags grouped in three
+ * `--help` clusters. Chainable: returns `cmd`.
+ *
+ * Today `cdkl list` only contributes one non-common flag (`-l, --long`),
+ * but the helper is still exposed so the surface-contract test pattern
+ * (helper + common == createLocalListCommand) is uniform across every
+ * `add<Cmd>SpecificOptions` extraction.
+ */
+export function addListSpecificOptions(cmd: Command): Command {
+  return cmd.addOption(
+    new Option(
+      '-l, --long',
+      "Also print each target's stack-qualified logical ID (<Stack>:<LogicalId>) beneath it"
+    ).default(false)
+  );
 }

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -653,6 +653,41 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
       '[target]',
       'CDK display path or stack-qualified logical ID of the AWS::ECS::TaskDefinition to run (omit to pick interactively in a TTY)'
     )
+    .action(
+      withErrorHandling(async (target: string | undefined, options: LocalRunTaskOptions) => {
+        await localRunTaskCommand(target, options, opts.extraStateProviders);
+      })
+    );
+
+  addRunTaskSpecificOptions(cmd);
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(deprecatedRegionOption);
+  return cmd;
+}
+
+/**
+ * Register the option block that `cdkl run-task` adds on top of the shared
+ * common / app / context option helpers. Shared between `cdkl run-task` and
+ * any host CLI (e.g. cdkd's `local run-task`) that wraps the single-task
+ * ECS local runner, so adding or renaming a `run-task`-only flag here
+ * propagates to every embedder without duplicate `.addOption(...)` blocks.
+ *
+ * Calling order only affects `--help` presentation (Commander parses
+ * insertion-order-independent). The host-CLI convention is host-specific
+ * options first, then this helper, then the shared common / app / context
+ * options — host flags / run-task flags / common flags grouped in three
+ * `--help` clusters. Chainable: returns `cmd`.
+ *
+ * NOTE: `run-task` does NOT compose with {@link addCommonEcsServiceOptions}
+ * even though many flags overlap. The two ECS surfaces (single-task vs
+ * multi-replica service) have intentionally divergent defaults
+ * (`run-task` has no `--max-tasks` / `--restart-policy`; `start-service`
+ * / `start-alb` have no `--host-port` / `--keep-running` / `--detach`),
+ * and folding `run-task` into the service common block would mutate the
+ * surface non-trivially. Each command keeps its own helper.
+ */
+export function addRunTaskSpecificOptions(cmd: Command): Command {
+  return cmd
     .addOption(
       new Option(
         '--cluster <name>',
@@ -736,14 +771,5 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
         '--stack-region <region>',
         'Region of the state record to read. Used with --from-cfn-stack as the CFn client region.'
       )
-    )
-    .action(
-      withErrorHandling(async (target: string | undefined, options: LocalRunTaskOptions) => {
-        await localRunTaskCommand(target, options, opts.extraStateProviders);
-      })
     );
-
-  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
-  cmd.addOption(deprecatedRegionOption);
-  return cmd;
 }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -3607,6 +3607,37 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
       '[targets...]',
       `Optional API subset filter. Pass one or more identifiers to serve exactly that subset (the union; each on its own port). Each accepts the bare CDK logical id ('MyHttpApi'; single-stack apps only), stack-qualified logical id ('MyStack:MyHttpApi'), full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). When omitted in a TTY, a multi-select picker opens with every API pre-selected (Enter serves all, deselect to pick a subset); when omitted in a non-TTY (CI / pipe) every discovered API is served. Mirrors \`${getEmbedConfig().cliName} invoke\` / \`${getEmbedConfig().cliName} run-task\` target syntax.`
     )
+    .action(
+      withErrorHandling(async (targets: string[], options: LocalStartApiOptions) => {
+        await localStartApiCommand(targets, options, opts.extraStateProviders);
+      })
+    );
+
+  addStartApiSpecificOptions(startApi);
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) =>
+    startApi.addOption(opt)
+  );
+  startApi.addOption(deprecatedRegionOption);
+
+  return startApi;
+}
+
+/**
+ * Register the option block that `cdkl start-api` adds on top of the shared
+ * common / app / context option helpers. Shared between `cdkl start-api`
+ * and any host CLI (e.g. cdkd's `local start-api`) that wraps the
+ * long-running API-Gateway-fronted local HTTP server, so adding or
+ * renaming a `start-api`-only flag here propagates to every embedder
+ * without duplicate `.addOption(...)` blocks.
+ *
+ * Calling order only affects `--help` presentation (Commander parses
+ * insertion-order-independent). The host-CLI convention is host-specific
+ * options first, then this helper, then the shared common / app / context
+ * options — host flags / start-api flags / common flags grouped in three
+ * `--help` clusters. Chainable: returns `cmd`.
+ */
+export function addStartApiSpecificOptions(cmd: Command): Command {
+  return cmd
     .addOption(
       new Option('--port <port>', 'HTTP server port (default: auto-allocate)').default('0')
     )
@@ -3737,17 +3768,5 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
           'principalId so local dev exercises app logic without reproducing an auth boundary it ' +
           'cannot fully emulate. OAC-fronted Function URLs always warn-and-pass regardless.'
       ).default(false)
-    )
-    .action(
-      withErrorHandling(async (targets: string[], options: LocalStartApiOptions) => {
-        await localStartApiCommand(targets, options, opts.extraStateProviders);
-      })
     );
-
-  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) =>
-    startApi.addOption(opt)
-  );
-  startApi.addOption(deprecatedRegionOption);
-
-  return startApi;
 }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -511,3 +511,25 @@ export {
   resolveAlbTarget,
   parseLbPortOverrides,
 } from './cli/commands/local-start-alb.js';
+
+/**
+ * Per-command "specific" option blocks for the remaining `cdkl` commands —
+ * extracted so host CLIs (e.g. cdkd) that wrap the same factories can
+ * compose `add<Cmd>SpecificOptions(cmd)` and auto-inherit every new
+ * per-command flag the upstream cdk-local CLI adds, without a manual
+ * `.addOption(...)` duplication on the host side. Each helper sits ON TOP
+ * of the shared `commonOptions` / `appOptions` / `contextOptions` /
+ * `deprecatedRegionOption` block (which the matching `create<Cmd>Command`
+ * factory still composes around the helper). Mirrors the shape of
+ * {@link addAlbSpecificOptions}.
+ *
+ * `addListSpecificOptions` is intentionally minimal (only `-l, --long`) so
+ * the surface-contract test pattern (helper + common == factory output)
+ * is uniform across every command, even when the per-command block is a
+ * single flag.
+ */
+export { addListSpecificOptions } from './cli/commands/local-list.js';
+export { addRunTaskSpecificOptions } from './cli/commands/local-run-task.js';
+export { addInvokeSpecificOptions } from './cli/commands/local-invoke.js';
+export { addInvokeAgentCoreSpecificOptions } from './cli/commands/local-invoke-agentcore.js';
+export { addStartApiSpecificOptions } from './cli/commands/local-start-api.js';

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { Command } from 'commander';
+import {
+  appOptions,
+  commonOptions,
+  contextOptions,
+  deprecatedRegionOption,
+} from '../../../src/cli/options.js';
+import {
+  addListSpecificOptions,
+  createLocalListCommand,
+} from '../../../src/cli/commands/local-list.js';
+import {
+  addRunTaskSpecificOptions,
+  createLocalRunTaskCommand,
+} from '../../../src/cli/commands/local-run-task.js';
+import {
+  addInvokeSpecificOptions,
+  createLocalInvokeCommand,
+} from '../../../src/cli/commands/local-invoke.js';
+import {
+  addInvokeAgentCoreSpecificOptions,
+  createLocalInvokeAgentCoreCommand,
+} from '../../../src/cli/commands/local-invoke-agentcore.js';
+import {
+  addStartApiSpecificOptions,
+  createLocalStartApiCommand,
+} from '../../../src/cli/commands/local-start-api.js';
+
+/**
+ * Return the sorted long-flag set for a Commander command. Mirrors the
+ * helper in `tests/unit/local/start-alb-binding.test.ts` so a host CLI's
+ * matching binding test stays a copy-paste away.
+ */
+function longFlagsOf(cmd: Command): string[] {
+  return cmd.options
+    .map((o) => o.long)
+    .filter((l): l is string => typeof l === 'string')
+    .sort();
+}
+
+/**
+ * Long-flag set of the shared `commonOptions` / `appOptions` /
+ * `contextOptions` / `deprecatedRegionOption` block every per-command
+ * `create<Cmd>Command` factory composes around its `add<Cmd>SpecificOptions`
+ * helper. Built fresh per call so the helpers' inner per-call freshness
+ * (e.g. `commonOptions()` rebuilds with the active embed config) is
+ * preserved.
+ */
+function commonAppContextDeprecatedFlags(): string[] {
+  const cmd = new Command();
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(deprecatedRegionOption);
+  return longFlagsOf(cmd);
+}
+
+/**
+ * Drift guards for the `add<Cmd>SpecificOptions` extractions. The
+ * decomposition exists so cdkd (and any other host CLI wrapping the same
+ * factories) auto-inherits per-command flags without a duplicate
+ * `.addOption(...)` block. These tests fail the moment someone adds a
+ * command-specific flag inline in `create<Cmd>Command` instead of inside
+ * the matching `add<Cmd>SpecificOptions` helper — which would silently
+ * break the inheritance the helpers are supposed to guarantee.
+ *
+ * Mirrors the `start-alb` pattern in
+ * `tests/unit/local/start-alb-binding.test.ts` (the "start-alb option
+ * surface contract" describe block).
+ */
+describe('list option surface contract (addListSpecificOptions)', () => {
+  it('addListSpecificOptions registers exactly the known list-only flags', () => {
+    // Lock the helper's contract: cdkd imports it expecting THIS set of long
+    // flags. Adding or removing one without updating the list below is a
+    // semver-relevant surface change.
+    const flags = longFlagsOf(addListSpecificOptions(new Command()));
+    expect(flags).toEqual(['--long']);
+  });
+
+  it('createLocalListCommand surface equals common + list-specific (no inline drift)', () => {
+    // The full CLI surface MUST be the union of the two helpers — never a
+    // proper superset. A proper superset would mean someone added an option
+    // inline in `createLocalListCommand`, which a host CLI (cdkd) calling
+    // the helpers directly would silently miss.
+    const full = longFlagsOf(createLocalListCommand());
+    const expected = Array.from(
+      new Set([
+        ...commonAppContextDeprecatedFlags(),
+        ...longFlagsOf(addListSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+});
+
+describe('run-task option surface contract (addRunTaskSpecificOptions)', () => {
+  it('addRunTaskSpecificOptions registers exactly the known run-task-only flags', () => {
+    const flags = longFlagsOf(addRunTaskSpecificOptions(new Command()));
+    expect(flags).toEqual([
+      '--assume-task-role',
+      '--cluster',
+      '--container-host',
+      '--detach',
+      '--ecr-role-arn',
+      '--env-vars',
+      '--from-cfn-stack',
+      '--host-port',
+      '--keep-running',
+      '--no-pull',
+      '--platform',
+      '--stack-region',
+    ]);
+  });
+
+  it('createLocalRunTaskCommand surface equals common + run-task-specific (no inline drift)', () => {
+    const full = longFlagsOf(createLocalRunTaskCommand());
+    const expected = Array.from(
+      new Set([
+        ...commonAppContextDeprecatedFlags(),
+        ...longFlagsOf(addRunTaskSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+});
+
+describe('invoke option surface contract (addInvokeSpecificOptions)', () => {
+  it('addInvokeSpecificOptions registers exactly the known invoke-only flags', () => {
+    const flags = longFlagsOf(addInvokeSpecificOptions(new Command()));
+    expect(flags).toEqual([
+      '--assume-role',
+      '--container-host',
+      '--debug-port',
+      '--ecr-role-arn',
+      '--env-vars',
+      '--event',
+      '--event-stdin',
+      '--from-cfn-stack',
+      '--layer-role-arn',
+      '--no-build',
+      '--no-pull',
+      '--stack-region',
+    ]);
+  });
+
+  it('createLocalInvokeCommand surface equals common + invoke-specific (no inline drift)', () => {
+    const full = longFlagsOf(createLocalInvokeCommand());
+    const expected = Array.from(
+      new Set([
+        ...commonAppContextDeprecatedFlags(),
+        ...longFlagsOf(addInvokeSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+});
+
+describe('invoke-agentcore option surface contract (addInvokeAgentCoreSpecificOptions)', () => {
+  it('addInvokeAgentCoreSpecificOptions registers exactly the known invoke-agentcore-only flags', () => {
+    const flags = longFlagsOf(addInvokeAgentCoreSpecificOptions(new Command()));
+    expect(flags).toEqual([
+      '--assume-role',
+      '--bearer-token',
+      '--container-host',
+      '--ecr-role-arn',
+      '--env-vars',
+      '--event',
+      '--event-stdin',
+      '--from-cfn-stack',
+      '--no-build',
+      '--no-pull',
+      '--no-verify-auth',
+      '--platform',
+      '--session-id',
+      '--sigv4',
+      '--stack-region',
+      '--timeout',
+      '--ws',
+      '--ws-interactive',
+    ]);
+  });
+
+  it('createLocalInvokeAgentCoreCommand surface equals common + invoke-agentcore-specific (no inline drift)', () => {
+    const full = longFlagsOf(createLocalInvokeAgentCoreCommand());
+    const expected = Array.from(
+      new Set([
+        ...commonAppContextDeprecatedFlags(),
+        ...longFlagsOf(addInvokeAgentCoreSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+});
+
+describe('start-api option surface contract (addStartApiSpecificOptions)', () => {
+  it('addStartApiSpecificOptions registers exactly the known start-api-only flags', () => {
+    const flags = longFlagsOf(addStartApiSpecificOptions(new Command()));
+    expect(flags).toEqual([
+      '--all-stacks',
+      '--api',
+      '--assume-role',
+      '--container-host',
+      '--debug-port-base',
+      '--env-vars',
+      '--from-cfn-stack',
+      '--host',
+      '--layer-role-arn',
+      '--mtls-cert',
+      '--mtls-key',
+      '--mtls-truststore',
+      '--no-pull',
+      '--per-lambda-concurrency',
+      '--port',
+      '--stack',
+      '--stack-region',
+      '--stage',
+      '--strict-sigv4',
+      '--warm',
+      '--watch',
+    ]);
+  });
+
+  it('createLocalStartApiCommand surface equals common + start-api-specific (no inline drift)', () => {
+    const full = longFlagsOf(createLocalStartApiCommand());
+    const expected = Array.from(
+      new Set([
+        ...commonAppContextDeprecatedFlags(),
+        ...longFlagsOf(addStartApiSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `addAlbSpecificOptions` extraction landed in #198 for the
five remaining `cdkl` commands so host CLIs (e.g. cdkd) auto-inherit
every new per-command flag the upstream cdk-local CLI adds, without a
duplicate `.addOption(...)` block on the host side. Each
`create<Cmd>Command` factory now composes its
`add<Cmd>SpecificOptions(cmd)` helper around the shared common / app /
context / deprecated-region option block. Each helper is also re-exported
from `cdk-local/internal` next to `addAlbSpecificOptions`.

`cdkl <cmd> --help` output is **byte-identical** before and after for
every affected command — verified by capturing the pre-edit `--help`
text and diffing against the post-build output across all 5 commands.

### Helpers added

| Helper | Long flags |
|---|---|
| `addListSpecificOptions` | `--long` |
| `addRunTaskSpecificOptions` | `--cluster`, `--env-vars`, `--container-host`, `--host-port`, `--assume-task-role`, `--no-pull`, `--ecr-role-arn`, `--platform`, `--keep-running`, `--detach`, `--from-cfn-stack`, `--stack-region` |
| `addInvokeSpecificOptions` | `--event`, `--event-stdin`, `--env-vars`, `--no-pull`, `--no-build`, `--debug-port`, `--container-host`, `--assume-role`, `--layer-role-arn`, `--ecr-role-arn`, `--from-cfn-stack`, `--stack-region` |
| `addInvokeAgentCoreSpecificOptions` | `--event`, `--event-stdin`, `--env-vars`, `--session-id`, `--ws`, `--ws-interactive`, `--bearer-token`, `--no-verify-auth`, `--sigv4`, `--platform`, `--no-pull`, `--no-build`, `--container-host`, `--timeout`, `--assume-role`, `--ecr-role-arn`, `--from-cfn-stack`, `--stack-region` |
| `addStartApiSpecificOptions` | `--port`, `--host`, `--stack`, `--all-stacks`, `--warm`, `--per-lambda-concurrency`, `--no-pull`, `--container-host`, `--debug-port-base`, `--env-vars`, `--assume-role`, `--watch`, `--stage`, `--api`, `--layer-role-arn`, `--from-cfn-stack`, `--stack-region`, `--mtls-truststore`, `--mtls-cert`, `--mtls-key`, `--strict-sigv4` |

Each helper is chainable (returns `cmd`) and has JSDoc explaining the
host-CLI inheritance pattern.

### Run-task does NOT compose with `addCommonEcsServiceOptions`

The issue text suggested sharing `addCommonEcsServiceOptions` for run-task,
but the single-task surface intentionally diverges from the multi-replica
service surface (no `--max-tasks` / `--restart-policy` defaults). Folding
the two would CHANGE the public `cdkl run-task --help` output, breaking
the byte-identical-`--help` acceptance check. The helper-level
decomposition gives cdkd the same auto-inheritance guarantee without
mutating the public surface; `addRunTaskSpecificOptions`'s JSDoc
explicitly documents the divergence.

### Contract tests

`tests/unit/cli/option-surface-contracts.test.ts` (10 tests, mirroring
the `start-alb` pattern in `tests/unit/local/start-alb-binding.test.ts`)
adds two tests per command:

1. The helper registers EXACTLY the known long-flag list (pinned
   alphabetically).
2. `createXxxCommand()` long-flag set equals the union of common-block
   flags + the helper's flags — no proper superset, which would mean
   someone added an inline `.addOption(...)` in the factory.

The drift guards fail the moment someone adds a per-command flag inline
in `createXxxCommand` instead of inside the matching
`addXxxSpecificOptions` helper — which would silently break the
inheritance host CLIs rely on.

### Docs

`docs/library-mode.md` gains a "Per-command option blocks" section next
to the existing ECS engine / ALB sections, documenting each helper's
flag list and the run-task non-composition rationale.

### Why integ is skipped

This PR is a pure mechanical refactor: every `.addOption(...)` block was
moved verbatim from `createXxxCommand` into `addXxxSpecificOptions`,
and each factory now calls the helper instead of inlining. None of the
runtime code paths (Docker, RIE, route discovery, ECS networking,
AgentCore protocol) are touched. Correctness is structurally proven by:

1. Byte-identical `cdkl <cmd> --help` output across all 5 commands
   (`diff /tmp/help-before-<cmd>.txt /tmp/help-after-<cmd>.txt` returns
   empty for every command).
2. The full 110-file / 1705-test unit suite passes.
3. The new contract tests pin each helper's exact flag list AND prove
   each `createXxxCommand()` surface equals the helper-plus-common
   union.

An integ run would re-exercise Docker against fixtures whose runtime
behavior cannot change here — so it would not add information.

## Test plan

- [x] `vp run check` — typecheck + lint + format all clean.
- [x] `vp run build` — succeeds; `dist/internal.js` re-exports all 5
      new helpers.
- [x] `vp test run` — 110 files / 1705 tests pass (no flakes).
- [x] New contract tests (10 total in
      `tests/unit/cli/option-surface-contracts.test.ts`) pass.
- [x] Byte-identical `--help` diff confirmed for `list`, `run-task`,
      `invoke`, `invoke-agentcore`, `start-api`.
- [x] Live-test: each helper imported from `dist/internal.js` is
      callable, chainable, and registers the expected flag count.

Closes #200
