### PR TITLE
fix(start-alb,start-service): drop stale "deferred to a follow-up PR" LB warning

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -301,6 +301,14 @@ export interface EmulatorStrategy {
     chosenTargets: string[]
   ): { boots: ServiceBoot[]; frontDoor?: FrontDoorPlan; warnings: string[] };
   lbPortOverrides: Record<number, number>;
+  /**
+   * When true, the service resolver does not emit the `LoadBalancers but
+   * no local listener` hint for booted services. `start-alb` sets this:
+   * by construction every service booted under it is fronted by the
+   * local front-door, so the hint is misleading. `start-service` leaves
+   * it falsy.
+   */
+  suppressLoadBalancerWarning?: boolean;
 }
 
 /**
@@ -534,7 +542,8 @@ export async function runEcsServiceEmulator(
         skipPull,
         extraStateProviders,
         profileCredsFile,
-        frontDoorByService.get(pt.boot.target)
+        frontDoorByService.get(pt.boot.target),
+        strategy.suppressLoadBalancerWarning === true
       );
     }
 
@@ -595,7 +604,8 @@ async function bootOneTarget(
   skipPull: boolean,
   extraStateProviders: ExtraStateProviders | undefined,
   profileCredsFile: ProfileCredentialsFile | undefined,
-  frontDoorPools: FrontDoorServicePools | undefined
+  frontDoorPools: FrontDoorServicePools | undefined,
+  suppressLoadBalancerWarning: boolean
 ): Promise<ServiceController> {
   const parsed = parseEcsTarget(boot.target);
   const candidate = pickCandidateStack(parsed.stackPattern, stacks);
@@ -616,7 +626,8 @@ async function bootOneTarget(
       skipPull,
       stateProvider,
       profileCredsFile,
-      frontDoorPools
+      frontDoorPools,
+      suppressLoadBalancerWarning
     );
   } finally {
     if (stateProvider) stateProvider.dispose();
@@ -632,13 +643,16 @@ async function runOneTarget(
   skipPull: boolean,
   stateProvider: LocalStateProvider | undefined,
   profileCredsFile: ProfileCredentialsFile | undefined,
-  frontDoorPools: FrontDoorServicePools | undefined
+  frontDoorPools: FrontDoorServicePools | undefined,
+  suppressLoadBalancerWarning: boolean
 ): Promise<ServiceController> {
   const logger = getLogger();
   const target = boot.target;
 
   const imageContext = await buildEcsImageResolutionContext(target, stacks, options, stateProvider);
-  const service = resolveEcsServiceTarget(target, stacks, imageContext);
+  const service = resolveEcsServiceTarget(target, stacks, imageContext, {
+    suppressLoadBalancerWarning,
+  });
   logger.info(
     `Target: ${service.stack.stackName}/${service.serviceLogicalId} ` +
       `(service=${service.serviceName}, desiredCount=${service.desiredCount}, ` +

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -294,6 +294,9 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
       };
     },
     lbPortOverrides,
+    // Under `start-alb` every booted service is fronted by the local
+    // front-door — silence the resolver's `no local listener` hint.
+    suppressLoadBalancerWarning: true,
   };
 }
 

--- a/src/local/ecs-service-resolver.ts
+++ b/src/local/ecs-service-resolver.ts
@@ -23,10 +23,12 @@ import { getEmbedConfig } from './embed-config.js';
  * so the Cloud Map registry can publish each replica's endpoint for
  * peer discovery via the docker `--add-host` DNS overlay.
  *
- * `LoadBalancers[]` is intentionally NOT surfaced in v1 — local
- * load-balancer emulation is deferred to a follow-up PR per the issue's
- * own PR-split recommendation (see CLAUDE.md "cdkl start-service"
- * bullet for the deferral list).
+ * `LoadBalancers[]` is intentionally NOT surfaced under `start-service`:
+ * the command runs the replicas only, with no local LB in front. The ALB
+ * counterpart `start-alb` boots the same replicas behind a local
+ * front-door, so when `extractServiceProperties` is called via that
+ * path, the LB-deferral warning is suppressed via
+ * `ResolveServiceOptions.suppressLoadBalancerWarning`.
  */
 /**
  * Resolved `AWS::ECS::Service.ServiceConnectConfiguration` (Phase 3 of #262).
@@ -167,10 +169,28 @@ export interface ResolvedEcsService {
  * resources (Tier 2). The CLI builds it lazily when the candidate
  * service's task definition actually needs substitution.
  */
+/**
+ * Caller knobs that are orthogonal to the per-target image-substitution
+ * `EcsImageResolutionContext`. Keeps the image-context narrow while
+ * giving callers a way to tell the resolver "the LB is being fronted
+ * locally; skip the deferred-LB warning" (the `start-alb` path).
+ */
+export interface ResolveServiceOptions {
+  /**
+   * When true, the resolver does not emit the LoadBalancers-not-emulated
+   * warning. `start-alb` sets this because it boots a local front-door
+   * for each ALB listener, so the cloud LB is in fact emulated locally.
+   * `start-service` leaves it false: it runs only the replicas, with
+   * no local LB in front.
+   */
+  suppressLoadBalancerWarning?: boolean;
+}
+
 export function resolveEcsServiceTarget(
   target: string,
   stacks: StackInfo[],
-  context?: EcsImageResolutionContext
+  context?: EcsImageResolutionContext,
+  options?: ResolveServiceOptions
 ): ResolvedEcsService {
   if (stacks.length === 0) {
     throw new EcsTaskResolutionError('No stacks found in the synthesized assembly.');
@@ -220,7 +240,14 @@ export function resolveEcsServiceTarget(
     );
   }
 
-  return extractServiceProperties(stack, serviceLogicalId, serviceResource, stacks, context);
+  return extractServiceProperties(
+    stack,
+    serviceLogicalId,
+    serviceResource,
+    stacks,
+    context,
+    options
+  );
 }
 
 /**
@@ -233,7 +260,8 @@ export function extractServiceProperties(
   serviceLogicalId: string,
   resource: TemplateResource,
   stacks: StackInfo[],
-  context?: EcsImageResolutionContext
+  context?: EcsImageResolutionContext,
+  options?: ResolveServiceOptions
 ): ResolvedEcsService {
   const props = (resource.Properties ?? {}) as Record<string, unknown>;
   const warnings: string[] = [];
@@ -258,13 +286,21 @@ export function extractServiceProperties(
   );
   const serviceName = parseServiceName(props['ServiceName'], serviceLogicalId);
 
-  // Surface deferred-feature warnings so users learn what's NOT
-  // emulated locally without reading source.
-  if (Array.isArray(props['LoadBalancers']) && (props['LoadBalancers'] as unknown[]).length > 0) {
+  // Surface a hint when the service declares LoadBalancers but the
+  // caller did not opt into the local-LB front-door (`start-service`).
+  // `start-alb` sets `suppressLoadBalancerWarning` because it IS the
+  // local LB.
+  if (
+    !options?.suppressLoadBalancerWarning &&
+    Array.isArray(props['LoadBalancers']) &&
+    (props['LoadBalancers'] as unknown[]).length > 0
+  ) {
+    const { cliName } = getEmbedConfig();
     warnings.push(
-      `ECS Service '${serviceLogicalId}' declares LoadBalancers, but local load-balancer ` +
-        'emulation is deferred to a follow-up PR. Containers are NOT registered to a local ' +
-        'listener; reach them via their published ports.'
+      `ECS Service '${serviceLogicalId}' declares LoadBalancers, but \`${cliName} start-service\` ` +
+        'runs the replicas only; no local listener fronts them. Reach the containers via their ' +
+        `published ports, or run \`${cliName} start-alb <Stack>/<Alb>\` to boot the same replicas ` +
+        'behind a local front-door that round-robins the listener rules.'
     );
   }
 

--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -40,11 +40,14 @@ import { getEmbedConfig } from './embed-config.js';
  * design's §O5 "--no-envoy by default" recommendation.
  *
  * Deferred to follow-up PRs:
- *   - Local load-balancer emulation (LB listener + target-group health
- *     check + round-robin) — separate PR per the issue's PR-split.
  *   - Envoy sidecar for Service Connect L7 routing / retries / circuit
  *     breaking (Cloud Map DNS-only mode ships now).
  *   - Rolling deployment (`--reload` / `--watch`).
+ *
+ * Local load-balancer emulation is now first-class via `start-alb`, which
+ * boots the same replicas behind a local front-door that mirrors the
+ * deployed ALB's listener-rule / forward / redirect / fixed-response /
+ * authenticate-* surface; `start-service` runs the replicas only.
  */
 
 export class EcsServiceRunnerError extends Error {

--- a/tests/unit/local/ecs-service-resolver-lb-warning.test.ts
+++ b/tests/unit/local/ecs-service-resolver-lb-warning.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  extractServiceProperties,
+  type ResolveServiceOptions,
+} from '../../../src/local/ecs-service-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { TemplateResource } from '../../../src/types/resource.js';
+
+function stackWithService(): { stack: StackInfo; resource: TemplateResource } {
+  const taskDef: TemplateResource = {
+    Type: 'AWS::ECS::TaskDefinition',
+    Properties: {
+      Family: 'web',
+      NetworkMode: 'awsvpc',
+      ContainerDefinitions: [
+        { Name: 'web', Image: 'public.ecr.aws/docker/library/nginx:1.27' },
+      ],
+    },
+  };
+  const service: TemplateResource = {
+    Type: 'AWS::ECS::Service',
+    Properties: {
+      TaskDefinition: { Ref: 'WebTaskDef' },
+      DesiredCount: 1,
+      LoadBalancers: [{ ContainerName: 'web', ContainerPort: 80, TargetGroupArn: 'arn:tg' }],
+    },
+  };
+  const stack = {
+    stackName: 'S',
+    template: {
+      Resources: {
+        WebTaskDef: taskDef,
+        WebService: service,
+      },
+    },
+  } as unknown as StackInfo;
+  return { stack, resource: service };
+}
+
+function extract(options?: ResolveServiceOptions): string[] {
+  const { stack, resource } = stackWithService();
+  return extractServiceProperties(stack, 'WebService', resource, [stack], undefined, options)
+    .warnings;
+}
+
+describe('ecs-service-resolver LoadBalancers warning', () => {
+  it('emits a current-text hint pointing at `start-alb` under the default (start-service) path', () => {
+    const warnings = extract();
+    expect(warnings).toHaveLength(1);
+    const w = warnings[0]!;
+    // The warning must NOT carry the stale "deferred to a follow-up PR" wording.
+    expect(w).not.toMatch(/deferred to a follow-up PR/);
+    // It must mention the booted service name + the command surface that
+    // would emulate the LB locally, so the user has an actionable next step.
+    expect(w).toContain("ECS Service 'WebService'");
+    expect(w).toMatch(/start-service/);
+    expect(w).toMatch(/start-alb/);
+  });
+
+  it('suppresses the LB warning when called via the start-alb path (suppressLoadBalancerWarning: true)', () => {
+    const warnings = extract({ suppressLoadBalancerWarning: true });
+    expect(warnings.filter((w) => w.includes('LoadBalancers'))).toEqual([]);
+  });
+
+  it('omits the LB warning entirely when the Service declares no LoadBalancers (no false positive under either mode)', () => {
+    const stack = {
+      stackName: 'S',
+      template: {
+        Resources: {
+          WebTaskDef: {
+            Type: 'AWS::ECS::TaskDefinition',
+            Properties: {
+              Family: 'web',
+              NetworkMode: 'awsvpc',
+              ContainerDefinitions: [
+                { Name: 'web', Image: 'public.ecr.aws/docker/library/nginx:1.27' },
+              ],
+            },
+          },
+          WebService: {
+            Type: 'AWS::ECS::Service',
+            Properties: { TaskDefinition: { Ref: 'WebTaskDef' }, DesiredCount: 1 },
+          },
+        },
+      },
+    } as unknown as StackInfo;
+    const noLb = stack.template.Resources!['WebService']!;
+    expect(
+      extractServiceProperties(stack, 'WebService', noLb, [stack]).warnings.filter((w) =>
+        w.includes('LoadBalancers')
+      )
+    ).toEqual([]);
+    expect(
+      extractServiceProperties(stack, 'WebService', noLb, [stack], undefined, {
+        suppressLoadBalancerWarning: true,
+      }).warnings.filter((w) => w.includes('LoadBalancers'))
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -354,6 +354,16 @@ describe('start-alb / start-service strategy binding', () => {
     expect(strategy.lbPortOverrides).toEqual({});
   });
 
+  it('start-alb opts into suppressLoadBalancerWarning; start-service does not (LB hint relevance)', () => {
+    // The resolver emits a `LoadBalancers declared but no local listener fronts
+    // them` hint by default. Under `start-alb` the local front-door IS the
+    // listener, so the hint is misleading and the strategy opts out. Under
+    // `start-service` it remains relevant (replicas run with no LB in front).
+    // Locks the strategy-flag wiring per `feedback_site_level_binding_test`.
+    expect(albStrategy({} as never).suppressLoadBalancerWarning).toBe(true);
+    expect(serviceStrategy().suppressLoadBalancerWarning).toBeFalsy();
+  });
+
   it('start-alb threads an authenticate-cognito guard from the template into the planned listener', () => {
     const COGNITO_ARN = 'arn:aws:cognito-idp:us-east-1:111122223333:userpool/us-east-1_abcDEF';
     const stack = {


### PR DESCRIPTION
## Summary

The ecs-service resolver emitted

> `ECS Service '<name>' declares LoadBalancers, but local load-balancer emulation is deferred to a follow-up PR. Containers are NOT registered to a local listener; reach them via their published ports.`

for any service with a `LoadBalancers` block, regardless of the calling command. Two issues:

- Under **`cdkl start-alb`** the local front-door IS the load balancer, so the warning was outright wrong.
- The **"deferred to a follow-up PR"** wording was stale under **`cdkl start-service`** too — `start-alb` shipped and is the documented way to front the replicas locally.

### Fix

- Add `suppressLoadBalancerWarning?: boolean` to `EmulatorStrategy`; thread it through `bootOneTarget` / `runOneTarget` into `resolveEcsServiceTarget`'s new `ResolveServiceOptions` knob.
- `albStrategy` sets `suppressLoadBalancerWarning: true` — every service it boots is fronted by the local front-door by construction.
- Update the `start-service` text to point users at `cdkl start-alb <Stack>/<Alb>` instead of a non-existent follow-up.
- Drop the matching stale entry from the `startEcsService` JSDoc's "Deferred to follow-up PRs" list (Local LB emulation is now first-class via `start-alb`).

### Live-test (against `tests/integration/local-start-alb` fixture, single service with `LoadBalancers`)

- `cdkl start-service CdkLocalStartAlbFixture:WebService` → emits the new warning pointing at `cdkl start-alb`; no "deferred to a follow-up PR" wording.
- `cdkl start-alb CdkLocalStartAlbFixture:WebLB --lb-port 80=18080 --lb-port 443=18443` → boots through `startEcsService` with NO `LoadBalancers` warning in the log (the unrelated HTTPS-degradation warning still fires for the cloud-HTTPS listener served over plain HTTP, as expected).

## Test plan

- [x] `vp run check` — typecheck + lint + format
- [x] `vp run build`
- [x] `vp test run` — 110 files / 1699 tests pass (new `ecs-service-resolver-lb-warning.test.ts` covers default emits new text / suppress hides / no-LB no false positive; updated `start-alb-binding.test.ts` locks `albStrategy.suppressLoadBalancerWarning === true` and `serviceStrategy` falsy)
- [x] Live-test against `tests/integration/local-start-alb` fixture under both commands (see Summary)
- [x] `markgate verify integ` fresh (no `tests/integration/**` source changes)
