### PR TITLE
ci(release): serialize Release workflow with a `concurrency:` group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
 
+# Serialize Release workflow runs so a back-to-back merge (#204 + #205
+# landed within ~30s and the earlier run's `git push --tags HEAD:main`
+# raced the later commit's fast-forward, exiting 1 with `! [rejected]
+# (fetch first)`). Queue the runs instead — `cancel-in-progress: false`
+# preserves every release, just runs them one at a time.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary

Add a `concurrency:` group to `.github/workflows/release.yml` so two `Release` runs queue serially instead of racing the same git ref.

## Why

PRs (#204) and (#205) merged within ~30 seconds of each other earlier today. The Release workflow run triggered by (#204) finished `semantic-release`'s `git push --tags HEAD:main` *after* (#205)'s commit had already fast-forwarded `main`, so the push exited 1 with `! [rejected] (fetch first)` and the (#204) run shows red in the Actions UI. The (#205) run picked up both commits and successfully published v0.65.0, so the only fallout is the red dot on the prior run — no published-artifact impact. This change prevents the same trap from re-firing.

## Behavior

- `group: release` — single queue for every Release workflow run, regardless of the triggering commit.
- `cancel-in-progress: false` — never drop a Release. We want both runs to happen, just one at a time. (The `true` setting would race against `semantic-release`'s own commit; we'd lose the changelog/tag for the cancelled run.)

## Test plan

- [x] YAML is valid (no other change to the workflow file; CI parses it on the next push to main).
- [x] `vp run check` + build + tests pass locally (1705 tests).
- [ ] Verified post-merge by observing the next two adjacent merges queue rather than race.
