### PR TITLE
fix(cdkd-parity-gate): also trigger on new `.ts` files under `src/local/**`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -332,10 +332,14 @@ vp run runtime:smoke
   run is never acceptable.
 
 - **cdkd parity** (host-CLI library-surface drift):
-  `cdkd-parity-gate.sh` blocks `gh pr create` when the diff touches
-  the cdk-local library surface (`src/cli/commands/**`,
-  `src/internal.ts`, `src/index.ts`) and the `cdkd-parity` marker is
-  stale. The marker is set ONLY by `/check-cdkd-parity`, which walks
+  `cdkd-parity-gate.sh` blocks `gh pr create` when the `cdkd-parity`
+  marker is stale AND the diff touches the cdk-local library surface
+  — defined as any change under `src/cli/commands/**` /
+  `src/internal.ts` / `src/index.ts`, OR a NEW `.ts` file added under
+  `src/local/**` (`--diff-filter=A`; the new-file branch catches
+  helpers that may need to be re-exported from `src/internal.ts`,
+  while edits to existing `src/local/**` files are excluded so
+  internal refactors don't trigger noise). The marker is set ONLY by `/check-cdkd-parity`, which walks
   the four host-impacting categories:
   - **New subcommand factory** — exported from `src/index.ts`? cdkd
     notified (issue / cross-link)?

--- a/.claude/hooks/cdkd-parity-gate.sh
+++ b/.claude/hooks/cdkd-parity-gate.sh
@@ -4,8 +4,15 @@
 # PreToolUse hook. Blocks `gh pr create` (and the
 # `cd <path> && gh pr create` / `gh -C <path> pr create` worktree forms)
 # when ALL of the following hold:
-#   1. The PR's diff vs origin/main touches the cdkd-parity gate's scope
-#      (`src/cli/commands/**`, `src/internal.ts`, `src/index.ts`).
+#   1. The PR's diff vs origin/main touches the cdkd-parity gate's scope:
+#      - any change under `src/cli/commands/**`, `src/internal.ts`, or
+#        `src/index.ts` (the library-surface scope), OR
+#      - a NEW `.ts` file added under `src/local/**`
+#        (`--diff-filter=A`). Edits to existing `src/local/**` files
+#        are intentionally NOT in scope, since most touches there are
+#        internal refactors that don't change host-CLI surface — but a
+#        brand-new file is the strongest signal that a host-facing
+#        helper may need to be exported from `src/internal.ts`.
 #   2. The `cdkd-parity` markgate marker is stale (digest differs / never set).
 #
 # When either condition is false (out-of-scope diff, or marker fresh), the
@@ -99,10 +106,24 @@ fi
 
 # Compute the diff scope. If nothing in the gate's scope changed, the PR
 # can't drift the cdkd parity surface — pass through.
+#
+# Two independent signals trigger the gate:
+#   - Any path under `src/cli/commands/**`, `src/internal.ts`, or
+#     `src/index.ts` (the library-surface scope).
+#   - A NEW `.ts` file added under `src/local/**`
+#     (`--diff-filter=A`). A new file there is the strongest signal
+#     that a host-facing helper may have been introduced without an
+#     explicit `src/internal.ts` re-export — exactly the case
+#     `/check-cdkd-parity`'s category 3 walk-through is meant to catch.
+#     Edits to EXISTING `src/local/**` files (`M` / `D`) are excluded
+#     so internal refactors don't fire the gate.
 scope_touched=$(git diff origin/main...HEAD --name-only 2>/dev/null \
   | grep -E '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$' \
   | head -1)
-if [ -z "$scope_touched" ]; then
+new_local_file=$(git diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
+  | grep -E '^src/local/.+\.ts$' \
+  | head -1)
+if [ -z "$scope_touched" ] && [ -z "$new_local_file" ]; then
   exit 0
 fi
 
@@ -129,15 +150,15 @@ fi
 reason=$("${markgate[@]}" status cdkd-parity 2>/dev/null \
   | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
 
-if [ -n "$reason" ]; then
-  printf "Blocked by cdkd-parity-gate: this PR touches cdk-local's library surface (src/cli/commands/** | src/internal.ts | src/index.ts) and the \`cdkd-parity\` marker is stale %s.\n\n" "$reason" >&2
-else
-  cat >&2 <<'EOF_HEAD'
-Blocked by cdkd-parity-gate: this PR touches cdk-local's library
-surface (src/cli/commands/** | src/internal.ts | src/index.ts) and
-the `cdkd-parity` marker is stale.
+trigger_desc="cdk-local's library surface (src/cli/commands/** | src/internal.ts | src/index.ts)"
+if [ -z "$scope_touched" ] && [ -n "$new_local_file" ]; then
+  trigger_desc="a NEW file under src/local/** (potential host-facing helper)"
+fi
 
-EOF_HEAD
+if [ -n "$reason" ]; then
+  printf "Blocked by cdkd-parity-gate: this PR touches %s and the \`cdkd-parity\` marker is stale %s.\n\n" "$trigger_desc" "$reason" >&2
+else
+  printf "Blocked by cdkd-parity-gate: this PR touches %s and\nthe \`cdkd-parity\` marker is stale.\n\n" "$trigger_desc" >&2
 fi
 
 cat >&2 <<'EOF'

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -263,8 +263,18 @@ call `markgate set integ` directly from a shell.
 - **`cdkd-parity-gate.sh`** blocks `gh pr create` (incl.
   `gh -C <path> pr create` / `cd <path> && gh pr create`) on PRs
   whose diff vs `origin/main` touches the cdk-local library surface
-  (`src/cli/commands/**`, `src/internal.ts`, `src/index.ts`) when
-  the `cdkd-parity` marker is stale. The marker is set ONLY by
+  and the `cdkd-parity` marker is stale. Two independent signals
+  trigger the gate:
+
+  - any change under `src/cli/commands/**`, `src/internal.ts`, or
+    `src/index.ts` (the library-surface scope), OR
+  - a NEW `.ts` file added under `src/local/**` (`--diff-filter=A`).
+    Edits to existing `src/local/**` files are intentionally NOT in
+    scope — most touches there are internal refactors that don't
+    change host-CLI surface. A brand-new file is the strongest
+    signal that a host-facing helper may have been introduced
+    without an explicit `src/internal.ts` re-export, which is
+    exactly the `/check-cdkd-parity` category 3 walk-through. The marker is set ONLY by
   `/check-cdkd-parity`, which walks the four host-impacting
   categories — new subcommand factory, new CLI option, new public
   helper / type, behavior change — and asks the structured

--- a/.claude/skills/check-cdkd-parity/SKILL.md
+++ b/.claude/skills/check-cdkd-parity/SKILL.md
@@ -21,19 +21,33 @@ is stale.
 ## Pre-flight scope check
 
 Determine whether the PR's diff actually touches cdk-local's library
-surface. Run from the worktree:
+surface. Two signals trigger the gate:
+
+1. Any path under `src/cli/commands/**`, `src/internal.ts`, or
+   `src/index.ts` (the library-surface scope).
+2. A NEW `.ts` file added under `src/local/**` (`--diff-filter=A`).
+   Edits to existing `src/local/**` files are deliberately out of
+   scope — internal refactors are noise — but a brand-new file is
+   the strongest signal that a host-facing helper may have been
+   introduced without an explicit `src/internal.ts` re-export.
+
+Run from the worktree:
 
 ```bash
-git diff origin/main...HEAD --name-only \
-  | grep -E '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$' \
+{
+  git diff origin/main...HEAD --name-only \
+    | grep -E '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$'
+  git diff origin/main...HEAD --diff-filter=A --name-only \
+    | grep -E '^src/local/.+\.ts$'
+} | head -1 \
   || echo "out-of-scope"
 ```
 
-If the output is `out-of-scope` (the diff touches none of the gate's
-paths), write one line — "no library-surface touched; cdkd-parity n/a"
-— set the marker (see "Commit-gate marker" below), and stop. Do NOT
-walk the categories below for unrelated edits; the marker is correct
-to set because there is nothing for cdkd to inherit.
+If the output is `out-of-scope` (neither signal fires), write one
+line — "no library-surface touched; cdkd-parity n/a" — set the
+marker (see "Final step" below), and stop. Do NOT walk the
+categories below for unrelated edits; the marker is correct to set
+because there is nothing for cdkd to inherit.
 
 The diff base is `origin/main`, not local `main` (see memory:
 `feedback_diff_base_origin_main`).
@@ -114,6 +128,11 @@ low-level building block. Host CLIs reach these via the
 **Detect**:
 
 ```bash
+# A new file in src/local/** is the strongest signal — it's also the
+# scope trigger that fires the gate independently of internal.ts edits.
+git diff origin/main...HEAD --diff-filter=A --name-only \
+  | grep -E '^src/local/.+\.ts$'
+# And any edits to src/local/** files that may have added exports.
 git diff origin/main...HEAD --name-only -- 'src/local/**'
 ```
 


### PR DESCRIPTION
## Summary

Close a gap surfaced after (#204) merged: a new helper file in `src/local/foo.ts` paired with a missed `src/internal.ts` re-export slipped through the original `cdkd-parity-gate` scope (`src/cli/commands/**` / `src/internal.ts` / `src/index.ts`), so category 3 of the `/check-cdkd-parity` walk-through ("new public helper → exported from `src/internal.ts`?") never got prompted.

Extend the gate's diff-scope check to ALSO fire when a NEW `.ts` file is added under `src/local/**` (`--diff-filter=A`). Edits to existing `src/local/**` files stay out of scope — most touches there are internal refactors and the gate should not fire on every one of them — but a brand-new file is the strongest signal that a host-facing helper may have been introduced without an explicit re-export.

The block-message now distinguishes the two triggers ("cdk-local's library surface" vs "a NEW file under `src/local/**` (potential host-facing helper)") so the user knows which branch fired.

## Files changed

- `.claude/hooks/cdkd-parity-gate.sh` — new-file branch in the scope check; branch-aware block message
- `.claude/skills/check-cdkd-parity/SKILL.md` — pre-flight scope check grep updated; category 3 detection adds `--diff-filter=A` recipe
- `.claude/CLAUDE.md` "cdkd parity" subsection — scope description updated
- `.claude/rules/hooks.md` "cdkd-parity-gate" section — scope description updated with rationale for the new-file vs edits asymmetry

## Test plan

Live-tested end-to-end against a throwaway git repo (5 scenarios, transcript below):

| # | Scenario | Expected | Actual |
|---|---|---|---|
| 1 | empty diff | exit 0 (pass) | 0 |
| 2 | edit existing `src/local/**` file | exit 0 (refactor pass-through) | 0 |
| 3 | NEW `src/local/foo.ts` | exit 2 (block) | 2 |
| 4 | edit `src/internal.ts` (original scope) | exit 2 (block) | 2 |
| 5 | `gh pr view 1` (non-gated command) | exit 0 | 0 |

Block-message transcript for case 3 (the new branch this PR adds):

```
Blocked by cdkd-parity-gate: this PR touches a NEW file under src/local/** (potential host-facing helper) and
the `cdkd-parity` marker is stale.

Required action — no exceptions:
  /check-cdkd-parity
...
exit=2
```

Block-message transcript for case 4 (the original scope branch, regression check):

```
Blocked by cdkd-parity-gate: this PR touches cdk-local's library surface (src/cli/commands/** | src/internal.ts | src/index.ts) and
the `cdkd-parity` marker is stale.
...
exit=2
```

## Context

Follow-up tightening of the gate introduced in (#204). The original tracking issue (#201) for that gate stays closed — this PR is the post-merge gap fix the user identified verbatim ("`src/local/**` is NOT in the scope, so a new helper that's never exported won't trigger the skill"). No new issue filed; the change is self-explanatory.
