### PR TITLE
docs(readme): restore seed-toil bullets, drop sam-local sub-bullet block

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ cdkl invoke MyStack/Fn --from-cfn-stack    # one Lambda against real DynamoDB / 
 ## Why cdk-local
 
 - **Zero-friction local execution** — run standalone: no deploy, no IAM access, just Docker and your CDK app. Onboard new engineers, review a PR by actually running its code, or work on an OSS CDK sample without owning the maintainer's account.
-- **Iterate against your real deployed stack — including its data.** `--from-cfn-stack` reads the deployed CloudFormation stack and injects its real ARNs, Secret values, and IAM credentials into the container, so you stay on the real DynamoDB rows, S3 objects, Cognito users, and Secret values your IAM credentials reach — instead of paying to seed and anonymize a local emulator.
-- **Picks up where `sam local` leaves off:**
-  - **CDK-native** — point at `cdk.json`; no SAM template to maintain.
-  - **Wider coverage** — adds ECS, ALB front-doors, and Bedrock AgentCore on top of Lambda + API Gateway.
-  - **Real container images** — the Lambda RIE base image; ECS as real Docker. The only dependency is Docker itself.
+- **Iterate against your real deployed stack — including its data.** `--from-cfn-stack` reads the deployed CloudFormation stack and injects its real ARNs, Secret values, and IAM credentials into the container — no `.env` file to maintain, no manual ARN copy-paste — so you stay on the real DynamoDB rows, S3 objects, Cognito users, and Secret values your IAM credentials reach. An offline emulator can fake the API surface, but you'd still own the cost of seeding it:
+  - dumping production data into a local DB
+  - mirroring Secret values into local Secrets Manager
+  - anonymizing fixtures across schema changes
+  - scripting realistic Cognito test users
 
 ## What runs locally
 


### PR DESCRIPTION
## Summary

- Restore the four concrete seed-toil items under the **Iterate against your real deployed stack** Why bullet (dump prod data into a local DB / mirror Secret values into local Secrets Manager / anonymize fixtures across schema changes / script realistic Cognito test users), replacing the abstract "paying to seed and anonymize a local emulator" umbrella. Concrete enumeration scans better than an umbrella phrase — readers catch a pain they actually have.
- Re-introduce the `.env` file / manual ARN copy-paste callout in the same Why bullet. The tagline (line 8) already teases "no `.env` or local copies to maintain"; the Why bullet now expands it with the concrete mechanic, following the de-dup pattern set by #196 (light tease upstream + concrete mechanic in Why).
- Drop the **Picks up where `sam local` leaves off** sub-bullet block (CDK-native / wider coverage / real container images). Those three sub-bullets are already covered by the tagline one-liner — line 9: "A CDK-native alternative to `sam local`, covering Lambda, API Gateway, ECS, ALB-fronted services, and Bedrock AgentCore" — and the Supported resources table below. Removing the duplicated sub-bullets concentrates the Why section on cdk-local's two unique value props (zero-friction + real-deployed-stack data) and sharpens the pitch.

## Test plan

- [x] `vp check` — pass
- [x] `vp run build` — pass
- [x] `vp test run` — 111 files / 1709 tests pass
- [x] No residual references to "Picks up where" / "sam local leaves off" in docs or scripts
- [x] Tagline (line 8 / 9) still covers `.env` + sam-local positioning
