### PR TITLE
docs: scrub third-party product mentions from user-facing docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,15 +102,15 @@ AWS managed services.
     container
   - `--from-cfn-stack <stack>` to bind to a deployed CloudFormation
     stack and inject its real ARNs / Secret values into Lambda env
-- cdk-local does NOT bundle a managed-service emulator. If you need
-  offline emulation, pair cdk-local with a service emulator like
-  LocalStack — they are complementary, not competing.
+- cdk-local does NOT bundle a managed-service emulator.
 
 When writing committed artifacts (README, docs, commit messages, PR
-bodies, JSDoc), keep to this scope. Do NOT add comparison tables vs
-`aws-cdk-local` or LocalStack. The only public comparison the docs may
-make is to `sam local` (same compute-locally category for Lambda + API
-Gateway).
+bodies, JSDoc), keep to this scope. Do NOT name, recommend, or compare
+against any other product (e.g. `aws-cdk-local` / `cdklocal` /
+LocalStack / similar) — no side-by-side tables, no "pair with" / "use
+alongside" recommendations, no parenthetical mentions. The only
+sanctioned tool comparison is to `sam local` (same compute-locally
+category for Lambda + API Gateway).
 
 ## Architecture
 
@@ -363,11 +363,14 @@ vp run runtime:smoke
 - When referring to the project in prose, use "cdk-local".
 - When referring to the CLI command in code blocks / examples, use
   `cdkl invoke / invoke-agentcore / start-api / run-task / start-service / start-alb / list`.
-- Do NOT write comparison tables against `aws-cdk-local` / `cdklocal` /
-  LocalStack in committed artifacts (README, docs, JSDoc). The
-  cdk-local vs LocalStack distinction is the
-  "compute vs managed services" one above; lead with that, not with
-  side-by-side tables.
+- Do NOT name, recommend, or compare against `aws-cdk-local` /
+  `cdklocal` / LocalStack (or any other third-party product) in
+  committed artifacts (README, docs, JSDoc, CONTRIBUTING). No
+  comparison tables, no "pair with" / "use alongside" recommendations,
+  no parenthetical mentions. State cdk-local's scope ("application
+  compute locally; managed services stay real AWS") on its own terms
+  without naming competing or adjacent products. `sam local` is the
+  only sanctioned exception.
 - Do NOT reference cdkd internal implementation (deploy / destroy /
   state schema details / provider system) in cdk-local artifacts — the
   dependency direction is cdkd -> cdk-local, and cdk-local should read

--- a/.claude/skills/check-docs/SKILL.md
+++ b/.claude/skills/check-docs/SKILL.md
@@ -36,7 +36,7 @@ Check whether documentation is up to date with recent code changes.
    - Missing mentions of new files, features, or options
    - Outdated descriptions that no longer match the code
    - Stale lists that don't match what's in the source
-   - Comparison-table additions that violate the `.claude/CLAUDE.md` "Positioning" rule (no comparisons vs `aws-cdk-local`/`cdklocal`/LocalStack beyond the "compute vs managed services" lead).
+   - Third-party product mentions that violate the `.claude/CLAUDE.md` "Positioning" rule (no naming, recommending, or comparing against `aws-cdk-local`/`cdklocal`/LocalStack or other competing products — `sam local` is the only sanctioned exception).
 
 5. **Report findings** as a checklist:
    - List each discrepancy found with the specific file and section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,11 +102,13 @@ merge to `main`.
 ## Scope reminders for docs / messages
 
 - cdk-local runs your **application compute** locally; it does NOT
-  emulate AWS managed services. Pair it with a service emulator like
-  LocalStack if you need offline DynamoDB / S3 / etc.
+  emulate AWS managed services. Don't recommend third-party emulators
+  or other tools in committed docs.
 - The only sanctioned tool comparison in committed docs is to
-  `sam local` (same compute-locally category). Please don't add side-by-side
-  tables vs other tools.
+  `sam local` (same compute-locally category). Please don't mention
+  or compare against any other product (e.g. `aws-cdk-local` /
+  `cdklocal` / LocalStack) — no side-by-side tables, no "pair with"
+  recommendations.
 
 ## Reporting bugs / requesting features
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cdkl invoke MyStack/Fn --from-cfn-stack    # one Lambda against real DynamoDB / 
 
 ## What runs locally
 
-cdk-local runs your **application compute** in Docker, using your CDK app as the source of truth. It deliberately does NOT emulate AWS managed services: your code reaches DynamoDB / S3 / Secrets Manager / Cognito / SNS / SQS / etc. as **real AWS** through your IAM credentials (`--assume-role`, or `--from-cfn-stack` to bind to a deployed stack). Want those offline too? Pair cdk-local with a service emulator like [LocalStack](https://www.localstack.cloud/) — it does not bundle one.
+cdk-local runs your **application compute** in Docker, using your CDK app as the source of truth. It deliberately does NOT emulate AWS managed services: your code reaches DynamoDB / S3 / Secrets Manager / Cognito / SNS / SQS / etc. as **real AWS** through your IAM credentials (`--assume-role`, or `--from-cfn-stack` to bind to a deployed stack).
 
 The locally executable resources are listed under [Supported resources](#supported-resources).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,10 +119,8 @@ The picker opens again; pick `HelloHandler` and the payload lands in
   URL + WebSocket + ECS run-task + ECS service + ECS ALB + Bedrock
   AgentCore vs SAM's Lambda + REST v1 only), and works against your
   CDK construct paths instead of CloudFormation logical IDs.
-- **Pair with a managed-service emulator if you need one** — cdk-local
-  does NOT emulate AWS managed services. It runs your **application
-  compute** locally and lets your Lambda code talk to real DynamoDB /
-  S3 / Secrets Manager / Cognito / etc. via your IAM credentials. If
-  you need offline emulation of those managed services too, pair
-  cdk-local with a service emulator like LocalStack — the two are
-  complementary, not competing.
+- **cdk-local does NOT emulate AWS managed services.** It runs your
+  **application compute** locally and lets your Lambda code talk to
+  real DynamoDB / S3 / Secrets Manager / Cognito / etc. via your IAM
+  credentials. For offline emulation of the managed services
+  themselves, reach for a separate emulator alongside cdk-local.

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -12,8 +12,7 @@ Gateway endpoints, ECS tasks/services) locally in Docker, using your
 CDK app as the source of truth. It does NOT emulate AWS managed
 services (DynamoDB, S3, Secrets Manager, SNS, SQS, EventBridge, etc.) —
 your handler code calls those over the public AWS APIs using your IAM
-credentials. If you want offline emulation of managed services, pair
-cdk-local with a service emulator like LocalStack.
+credentials.
 
 ## Subcommands
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,7 +120,7 @@ The Lambda RIE base image pull is one-time. After the first run on a given Docke
 
 ### `start-service` / `run-task` ECS scale isn't realistic
 
-cdk-local runs ECS tasks as plain Docker containers. There is no autoscaling, no placement strategy, no health-check-based replacement. If you need production-shape ECS behavior, deploy to a real cluster (or pair cdk-local with LocalStack's ECS emulation).
+cdk-local runs ECS tasks as plain Docker containers. There is no autoscaling, no placement strategy, no health-check-based replacement. If you need production-shape ECS behavior, deploy to a real cluster.
 
 ## When to file an issue
 


### PR DESCRIPTION
## Summary

- Drop every "pair with LocalStack" / "LocalStack's ECS emulation" / "reach for another tool" sentence from user-facing docs: **README.md** (line 43 — Want those offline too? Pair... sentence), **CONTRIBUTING.md** (Scope reminders bullet), **docs/local-emulation.md** (the closing pair-with line), **docs/getting-started.md** (the "Pair with a managed-service emulator" bullet), **docs/troubleshooting.md** (the parenthetical "or pair cdk-local with LocalStack's ECS emulation"). cdk-local's docs should pitch the tool on its own terms — naming a third-party product reads as an endorsement and dilutes the positioning.
- Strengthen the `.claude/CLAUDE.md` Positioning rule from **"no comparison tables vs `aws-cdk-local` / `cdklocal` / LocalStack"** to **"no naming, recommending, or comparing against any third-party product"**: covers side-by-side tables, "pair with" / "use alongside" recommendations, and parenthetical mentions. `sam local` remains the only sanctioned comparison (same compute-locally category for Lambda + API Gateway). The matching `/check-docs` skill reference is updated to point at the broader rule.

## Test plan

- [x] `vp check` — pass (104 files formatted / lint-clean)
- [x] `vp run build` — pass
- [x] `vp test run` — 111 files / 1709 tests pass
- [x] `grep -rni "localstack\|aws-cdk-local\|cdklocal"` across user-facing docs returns only the rule-text mentions in `.claude/CLAUDE.md` / CONTRIBUTING.md / `.claude/skills/check-docs/SKILL.md` and the unrelated `CdkLocalEmbedConfig` type in `docs/library-mode.md`. No prose recommendations remain.
