### PR TITLE
docs: purge third-party product names from rule text

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -106,11 +106,11 @@ AWS managed services.
 
 When writing committed artifacts (README, docs, commit messages, PR
 bodies, JSDoc), keep to this scope. Do NOT name, recommend, or compare
-against any other product (e.g. `aws-cdk-local` / `cdklocal` /
-LocalStack / similar) — no side-by-side tables, no "pair with" / "use
-alongside" recommendations, no parenthetical mentions. The only
-sanctioned tool comparison is to `sam local` (same compute-locally
-category for Lambda + API Gateway).
+against any third-party product — no side-by-side tables, no
+"pair with" / "use alongside" recommendations, no parenthetical
+mentions, no examples. State cdk-local's scope on its own terms.
+The only sanctioned tool comparison is to `sam local` (same
+compute-locally category for Lambda + API Gateway).
 
 ## Architecture
 
@@ -363,14 +363,13 @@ vp run runtime:smoke
 - When referring to the project in prose, use "cdk-local".
 - When referring to the CLI command in code blocks / examples, use
   `cdkl invoke / invoke-agentcore / start-api / run-task / start-service / start-alb / list`.
-- Do NOT name, recommend, or compare against `aws-cdk-local` /
-  `cdklocal` / LocalStack (or any other third-party product) in
-  committed artifacts (README, docs, JSDoc, CONTRIBUTING). No
+- Do NOT name, recommend, or compare against any third-party product
+  in committed artifacts (README, docs, JSDoc, CONTRIBUTING). No
   comparison tables, no "pair with" / "use alongside" recommendations,
-  no parenthetical mentions. State cdk-local's scope ("application
-  compute locally; managed services stay real AWS") on its own terms
-  without naming competing or adjacent products. `sam local` is the
-  only sanctioned exception.
+  no parenthetical mentions, no examples. State cdk-local's scope
+  ("application compute locally; managed services stay real AWS") on
+  its own terms without naming competing or adjacent products.
+  `sam local` is the only sanctioned exception.
 - Do NOT reference cdkd internal implementation (deploy / destroy /
   state schema details / provider system) in cdk-local artifacts — the
   dependency direction is cdkd -> cdk-local, and cdk-local should read

--- a/.claude/skills/check-docs/SKILL.md
+++ b/.claude/skills/check-docs/SKILL.md
@@ -36,7 +36,7 @@ Check whether documentation is up to date with recent code changes.
    - Missing mentions of new files, features, or options
    - Outdated descriptions that no longer match the code
    - Stale lists that don't match what's in the source
-   - Third-party product mentions that violate the `.claude/CLAUDE.md` "Positioning" rule (no naming, recommending, or comparing against `aws-cdk-local`/`cdklocal`/LocalStack or other competing products — `sam local` is the only sanctioned exception).
+   - Third-party product mentions that violate the `.claude/CLAUDE.md` "Positioning" rule (no naming, recommending, or comparing against any third-party product — `sam local` is the only sanctioned exception).
 
 5. **Report findings** as a checklist:
    - List each discrepancy found with the specific file and section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,10 +105,10 @@ merge to `main`.
   emulate AWS managed services. Don't recommend third-party emulators
   or other tools in committed docs.
 - The only sanctioned tool comparison in committed docs is to
-  `sam local` (same compute-locally category). Please don't mention
-  or compare against any other product (e.g. `aws-cdk-local` /
-  `cdklocal` / LocalStack) — no side-by-side tables, no "pair with"
-  recommendations.
+  `sam local` (same compute-locally category). Don't name, recommend,
+  or compare against any other third-party product — no side-by-side
+  tables, no "pair with" / "use alongside" recommendations, no
+  parenthetical mentions, no examples.
 
 ## Reporting bugs / requesting features
 


### PR DESCRIPTION
## Summary

Follow-up to #210. The Positioning / Scope rules themselves still spelled out the forbidden product names (`aws-cdk-local` / `cdklocal` / LocalStack) as inline examples — spelling them out IS a mention, which drifts the docs back toward what the rule forbids.

- `.claude/CLAUDE.md` — drop the `(e.g. ...)` examples from the **Scope** paragraph (L107-113) and the **Positioning** bullet (L366-373); rephrase each to "any third-party product" with `sam local` as the only sanctioned exception.
- `CONTRIBUTING.md` — same scrub on the **Scope reminders** bullet.
- `.claude/skills/check-docs/SKILL.md` — same scrub on the rule reference.

Own-naming (`CdkLocalError` / `CdkLocalEmbedConfig` / `CdkLocal*` fixture stack names / `cdklocal.test` RFC-reserved test domain) is left alone — it is cdk-local's own code/test surface, not a third-party reference.

## Test plan

- [x] `vp check` — pass (104 files)
- [x] `vp run build` — pass
- [x] `vp test run` — 113 files / 1723 tests pass
- [x] `grep -rEni "localstack|aws-cdk-local|\bcdklocal\b"` (excluding own-naming patterns + `cdklocal.test` test domain) returns no hits across the repo
