### PR TITLE
docs(readme): give `--watch` its own block (hot reload is a top-line feature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,19 @@ cdkl list                                      # every runnable target, grouped 
 
 ![cdkl invoke against a local sample CDK app — standalone, no deploy](assets/cdkl-invoke.gif)
 
-- **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`. Add **`--watch`** to re-synth and hot-reload on CDK source changes ([details](docs/local-emulation.md#hot-reload---watch)).
+- **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`.
 - **`run-task`** / single-replica **`start-service`** publish declared container ports on the host (`--host-port <container>=<host>` remaps; handy for privileged ports on macOS). **`start-service`** / **`start-alb`** also list each host URL in a `Service endpoints:` banner after boot so the access URL stays visible.
 - **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement), and WebSocket `Upgrade` proxying to ECS targets ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
 - **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, HTTP / SSE / WebSocket / MCP protocols, with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
 Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.md](docs/cli-reference.md) and [docs/local-emulation.md](docs/local-emulation.md).
+
+### Hot reload — `--watch`
+
+`cdkl start-api --watch` re-synths your CDK app and reloads routes when the source changes, so editing a handler is reflected on the next request without restarting the server. Synth failures keep the previous version serving (warn-and-continue). Honors `cdk.json`'s `watch.include` / `watch.exclude` globs, so no separate `cdk watch` process is needed.
+
+Full reload pipeline + glob defaults: [docs/local-emulation.md#hot-reload---watch](docs/local-emulation.md#hot-reload---watch).
 
 ### start-service vs start-alb — which one?
 


### PR DESCRIPTION
## Summary

Promote the `--watch` hot-reload story from a parenthetical inside the start-api Commands bullet to its own `### Hot reload — \`--watch\`` subsection between the Commands list and `start-service vs start-alb`.

Editing a handler and having it picked up on the next request without restarting the local server is one of the central ergonomic wins of a local execution tool — burying it as a side note on the start-api bullet means most readers miss it on first scan.

- Add a focused 3-line subsection: what it does, the warn-and-continue behavior on synth failure, and that it honors `cdk.json`'s `watch.include` / `watch.exclude` globs (so no separate watcher process is needed).
- Link out to [docs/local-emulation.md#hot-reload---watch](docs/local-emulation.md#hot-reload---watch) for the full reload pipeline + glob defaults.
- Drop the trailing `Add --watch ...` parenthetical from the start-api bullet so the new section is the single source of truth.

Scope: `start-api` only. Watch mode for `start-service` / `start-alb` is a separate planned follow-up (rolling-deploy semantics) and is intentionally not advertised in this block.

## Test plan

- [x] `vp check` — pass (104 files)
- [x] `vp run build` — pass
- [x] `vp test run` — 113 files / 1723 tests pass
- [x] Visual scan: section header renders, link target `#hot-reload---watch` matches the docs/local-emulation.md anchor (`### Hot reload (\`--watch\`)` → `hot-reload---watch`)
