### PR TITLE
feat(start-service): add `--watch` hot reload (Phase 1 of #214)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,7 +27,11 @@ AWS managed services.
   served by a local HTTP server
 - ECS tasks and services — real Docker containers with awsvpc /
   Service Connect / Cloud Map registry. `start-service` runs a service's
-  replicas only (pure compute, no load balancer). `start-alb` is the ALB
+  replicas only (pure compute, no load balancer). `start-service --watch`
+  re-synths + per-target tears the old replica down before booting a new
+  one when the CDK source changes (Phase 1 of issue #214 — single-replica
+  only; multi-replica rolling reload + `start-alb --watch` are later
+  phases). `start-alb` is the ALB
   counterpart of `start-api`: name the ALB, and it boots the ECS
   service(s) behind it plus a local front-door that round-robins each
   listener port across the replicas and routes the listener rules across

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 
 `cdkl start-api --watch` re-synths your CDK app and reloads routes when the source changes, so editing a handler is reflected on the next request without restarting the server. Synth failures keep the previous version serving (warn-and-continue). Honors `cdk.json`'s `watch.include` / `watch.exclude` globs, so no separate `cdk watch` process is needed.
 
+`cdkl start-service --watch` brings the same edit-and-go loop to ECS services: re-synth + per-target tear down the old replica + boot a fresh one on save. Single-replica services only in v1 (multi-replica rolling reload is a follow-up); the previous replica keeps serving when synth fails mid-reload.
+
 Full reload pipeline + glob defaults: [docs/local-emulation.md#hot-reload---watch](docs/local-emulation.md#hot-reload---watch).
 
 ### start-service vs start-alb — which one?

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1153,6 +1153,7 @@ error.
 | `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
 | `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `ListStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI. Bare form uses the CDK stack name (per target when multiple `<targets...>` are supplied). `Fn::GetAtt` is warn-and-dropped in v1. Same shape as `cdkl run-task --from-cfn-stack`. |
 | `--stack-region <region>` | — | Region of the state record to read. Drives the CFn client region for `--from-cfn-stack`. |
+| `--watch` | off | Hot reload: re-synth + re-resolve every booted service and replace its single replica when the CDK app's source changes (mirrors `cdkl start-api --watch` semantics; honors `cdk.json` `watch.include` / `watch.exclude`). **Single-replica services only in v1** — an effective replica count > 1 errors out (multi-replica rolling reload is Phase 2 of issue #214). Synth failures keep the previous replica serving (warn-and-continue). Per-target trade-off: the old replica is torn down before the new one boots, so there is a brief downtime window per save. Off by default. |
 
 Plus the [common flags](#common-flags): `-a/--app`, `--output`,
 `-c/--context`, `--profile`, `--role-arn`, `--verbose`, `-y/--yes`.
@@ -1248,7 +1249,10 @@ Same option set as `cdkl start-service` (`--cluster`, `--max-tasks`,
 `--restart-policy`, `--env-vars`, `--container-host`, `--assume-task-role`,
 `--ecr-role-arn`, `--platform`, `--no-pull`, `--from-cfn-stack`,
 `--stack-region`, plus the [common flags](#common-flags)), except
-`--host-port` is replaced by:
+`--host-port` is replaced by the front-door flags below. `--watch` is
+NOT exposed here in v1 — `cdkl start-alb --watch` is Phase 3 of
+issue #214 (needs the front-door pool's atomic-swap support); use
+`cdkl start-service --watch` for the pure-compute reload loop today.
 
 | Flag | Default | Behavior |
 | --- | --- | --- |

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1386,6 +1386,42 @@ error.
 | `--no-pull` | off | Skip `docker pull` on every container image and the metadata sidecar. |
 | `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Bare form uses the CDK stack name (per target when multiple `<targets...>` are supplied). `Fn::GetAtt` is warn-and-dropped in v1. Same shape as `cdkl run-task --from-cfn-stack`. |
 | `--stack-region <region>` | — | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
+| `--watch` | off | Hot reload: re-synth + re-resolve every booted service and replace its single replica when the CDK app's source changes. Honors `cdk.json` `watch.include` / `watch.exclude` (mirrors `cdk watch`); `cdk.out/`, `node_modules`, and `.git` are always excluded so the reload's own re-synth writes never re-trigger it. 500ms debounce. **Single-replica services only in v1** — a service whose effective replica count (`min(template DesiredCount, --max-tasks)`) exceeds 1 errors out (multi-replica rolling reload is Phase 2 of issue #214). Synth failures keep the previous replica serving (warn-and-continue, never crashes the emulator). Per-target trade-off: the old replica is torn down before the new one boots, so there is a brief downtime window per save; Phase 2 will overlap via rolling deploy. |
+
+### `start-service --watch` (hot reload)
+
+When `--watch` is set, `cdkl start-service` installs the same
+debounced [chokidar](https://github.com/paulmillr/chokidar)-backed
+file watcher that `cdkl start-api --watch` uses, rooted at the synth
+working directory (where `cdk.json` lives). On a debounced firing
+(500ms after the last save) the emulator re-synths, re-resolves every
+booted service against the new stacks, and per-target tears the old
+replica down before booting a new one from the new task definition.
+No second terminal running `cdk watch` / `cdk synth` is needed; an
+edit to a container handler or task definition flows through to the
+next request without `^C` / re-launch.
+
+The watch set honors `cdk.json`'s `watch.include` / `watch.exclude`
+globs the same way `start-api --watch` does — see the
+[Hot reload (`--watch`)](#hot-reload---watch) section above for the
+exact include / exclude / synth-failure semantics; they are
+identical here.
+
+Phase 1 trade-offs (issue #214):
+
+- **Single-replica only.** A service whose effective replica count
+  (`min(template DesiredCount, --max-tasks)`) is > 1 errors out with
+  an actionable hint — lower `--max-tasks` to 1, drop the
+  `DesiredCount`, or drop `--watch`. Phase 2 of #214 adds the
+  multi-replica rolling deploy.
+- **Brief downtime per save.** The Phase 1 reload tears the old
+  replica down before booting the new one (single-replica services
+  have no second replica to forward to). Phase 2 will overlap via
+  rolling deploy across multiple replicas.
+- **No bind-mount fast path.** Every reload rebuilds the image (the
+  same path the initial boot takes). Phase 4 of #214 adds an opt-in
+  bind-mount source mode that skips the rebuild for source-only
+  changes.
 
 ### `start-service` lifecycle
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -655,7 +655,15 @@ export async function runEcsServiceEmulator(
               logger,
             })
           );
-          reloadChain = next.catch(() => undefined);
+          // Surface any unhandled throw from `reloadAllServices` (e.g. a
+          // future refactor adds a step outside the function's existing
+          // synth + per-target try/catches) instead of swallowing it
+          // silently — otherwise the emulator goes quietly stale.
+          reloadChain = next.catch((err) => {
+            logger.error(
+              `reloadAllServices threw: ${err instanceof Error ? err.message : String(err)}`
+            );
+          });
         },
       });
       logger.info(
@@ -834,12 +842,25 @@ async function reloadAllServices(args: {
         strategy.suppressLoadBalancerWarning === true
       );
     } catch (err) {
-      logger.error(
-        `Reload: re-boot of '${pt.boot.target}' failed ` +
-          `(${err instanceof Error ? err.message : String(err)}). ` +
-          'The previous replica was torn down; save again with a clean boot to re-start it, or ^C ' +
-          'and re-run start-service.'
-      );
+      // A `LocalStartServiceError` thrown by the boot already names the
+      // actionable fix (most often `assertSingleReplicaForWatch` tripping
+      // when the user bumped `DesiredCount` mid-watch). Surface that
+      // message verbatim instead of the generic "save again with a clean
+      // boot" hint, which would otherwise loop the user — saving again
+      // with the same multi-replica template will fail the gate the same
+      // way every time. The generic hint stays for unexpected boot
+      // failures (docker errors, asset-build failures, etc.) where
+      // re-saving plausibly recovers.
+      if (err instanceof LocalStartServiceError) {
+        logger.error(`Reload of '${pt.boot.target}' was rejected: ${err.message}`);
+      } else {
+        logger.error(
+          `Reload: re-boot of '${pt.boot.target}' failed ` +
+            `(${err instanceof Error ? err.message : String(err)}). ` +
+            'The previous replica was torn down; save again with a clean boot to re-start it, or ^C ' +
+            'and re-run start-service.'
+        );
+      }
       // Tear down any partial docker state that the failed boot left in
       // `newRunState.replicas` so cleanup() doesn't observe two states
       // for the same `pt` slot. The `pt.controller` reference is left

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -15,9 +15,10 @@ import { resolveMultiTarget } from '../../local/target-picker.js';
 import type { TargetEntry } from '../../local/target-lister.js';
 import { singleFlight } from '../../utils/single-flight.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
-import { resolveApp } from '../config-loader.js';
+import { resolveApp, resolveWatchConfig } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
-import { resolveProfileCredentials } from './local-start-api.js';
+import { createFileWatcher, type FileWatcher } from '../../local/file-watcher.js';
+import { resolveProfileCredentials, createWatchPredicates } from './local-start-api.js';
 import {
   writeProfileCredentialsFile,
   type ProfileCredentialsFile,
@@ -32,6 +33,7 @@ import {
 } from '../../local/ecs-task-resolver.js';
 import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
 import {
+  computeReplicaCount,
   createServiceRunState,
   startEcsService,
   type ServiceController,
@@ -172,6 +174,14 @@ export interface EcsServiceEmulatorOptions {
    */
   fromCfnStack?: string | boolean;
   stackRegion?: string;
+  /**
+   * Issue #214 Phase 1 — `cdkl start-service --watch`. Re-synth and replace
+   * each booted service's single replica when the CDK app source changes.
+   * Wired only via the `start-service` command (the flag is declared in
+   * `addStartServiceSpecificOptions`); the start-alb path leaves this
+   * undefined.
+   */
+  watch?: boolean;
   /** Host-injected extra state-source flag fields. */
   [key: string]: unknown;
 }
@@ -309,6 +319,17 @@ export interface EmulatorStrategy {
    * it falsy.
    */
   suppressLoadBalancerWarning?: boolean;
+  /**
+   * Phase 1 of issue #214 — opt this strategy into the emulator's
+   * `--watch` reload pathway. `serviceStrategy()` sets this true so a
+   * `cdkl start-service --watch` re-synths + re-replaces each booted
+   * service's single replica on source change. `start-alb`'s strategy
+   * leaves this falsy (Phase 3 will turn it on once the front-door pool
+   * supports atomic swap) — the gate prevents a host CLI that wires
+   * `start-alb` through this engine from accidentally exposing watch
+   * via the shared options block.
+   */
+  supportsWatch?: boolean;
 }
 
 /**
@@ -353,9 +374,31 @@ export async function runEcsServiceEmulator(
   // down alongside the front-door servers so no request is dispatched to a
   // vanished container.
   let frontDoorLambdaRunners: FrontDoorLambdaRunner[] = [];
+  // Phase 1 of issue #214 — `cdkl start-service --watch` file watcher + the
+  // chain promise that serializes reload events. Set when the watcher is wired
+  // (only when `options.watch && strategy.supportsWatch`); the cleanup path
+  // closes the watcher AND awaits the in-flight reload before tearing down
+  // services so a reload never races shutdown.
+  let watcher: FileWatcher | undefined;
+  let reloadChain: Promise<unknown> = Promise.resolve();
 
   const cleanup = singleFlight(
     async (): Promise<void> => {
+      // Phase 1 of issue #214 — close the watcher BEFORE awaiting the
+      // existing reload-chain so no new reload is queued after shutdown
+      // started, then drain the in-flight reload so cleanup doesn't race
+      // a partial `pt.controller` swap.
+      if (watcher) {
+        try {
+          await watcher.close();
+        } catch (err) {
+          getLogger().warn(
+            `watcher.close() failed: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        watcher = undefined;
+      }
+      await reloadChain.catch(() => undefined);
       await Promise.allSettled(
         perTarget.map(async (pt) => {
           if (pt.controller) {
@@ -577,15 +620,65 @@ export async function runEcsServiceEmulator(
     logEndpointsBanner(perTarget, frontDoorServers, logger);
     logger.info('Press ^C to shut down.');
 
-    if (perTarget.length > 0) {
-      await Promise.all(perTarget.map((pt) => pt.controller!.waitForShutdown()));
-    } else {
-      // Block on a SIGINT/SIGTERM that resolves via the cleanup -> process.exit
-      // path. The front-door + Lambda containers keep serving until then.
-      await new Promise<void>(() => {
-        /* resolved only by the SIGINT/SIGTERM handler's process.exit */
+    // Phase 1 of issue #214 — `cdkl start-service --watch` source-tree watcher.
+    // Only the service strategy opts in (start-alb's strategy intentionally
+    // leaves `supportsWatch` falsy; Phase 3 turns it on). The watcher reuses
+    // the start-api debounced file-watcher and predicate composition verbatim
+    // so cdk.json `watch.include` / `watch.exclude` semantics are identical.
+    if (options.watch === true && strategy.supportsWatch === true) {
+      const watchRoot = process.cwd();
+      const { ignored, shouldTrigger, excludePatterns } = createWatchPredicates({
+        watchRoot,
+        output: options.output,
+        watchConfig: resolveWatchConfig(),
       });
+      watcher = createFileWatcher({
+        paths: [watchRoot],
+        ignored,
+        shouldTrigger,
+        onChange: () => {
+          logger.info('Detected source change; reloading service(s)...');
+          const next = reloadChain.then(() =>
+            reloadAllServices({
+              perTarget,
+              synthesizer,
+              synthOpts,
+              strategy,
+              resolvedTargets,
+              cloudMapIndexByStack,
+              options,
+              discovery,
+              skipPull,
+              extraStateProviders,
+              profileCredsFile,
+              frontDoorByService,
+              logger,
+            })
+          );
+          reloadChain = next.catch(() => undefined);
+        },
+      });
+      logger.info(
+        `Watching ${watchRoot} for source changes (excluding ${excludePatterns.join(', ')}).`
+      );
     }
+
+    // Block on a SIGINT/SIGTERM that resolves via the cleanup -> process.exit
+    // path. The replicas + front-door + Lambda containers keep serving until
+    // then. The pre-#214 shape used
+    // `Promise.all(perTarget.map(pt => pt.controller!.waitForShutdown()))` —
+    // equivalent in non-watch mode because `controller.shutdown()` is only
+    // invoked from the SIGINT handler / cleanup() pass — but the `--watch`
+    // reload pathway calls `oldController.shutdown()` mid-run to swap a
+    // replica, which would resolve the OLD controller's `waitForShutdown`
+    // and unblock the main loop prematurely. Block on a forever-promise
+    // instead and let `cleanup() -> process.exit` be the only termination
+    // path; degraded replicas mark themselves shutting-down but never
+    // resolve the controller's promise, so this matches the pre-#214
+    // behavior for the watch-off case.
+    await new Promise<void>(() => {
+      /* resolved only by the SIGINT/SIGTERM handler's process.exit */
+    });
   } finally {
     if (sigintHandler) {
       process.off('SIGINT', sigintHandler);
@@ -593,6 +686,178 @@ export async function runEcsServiceEmulator(
     }
     await cleanup();
   }
+}
+
+/**
+ * Phase 1 of issue #214 — refuse a `--watch` run when the resolved service's
+ * effective replica count (`min(template DesiredCount, --max-tasks)`) is > 1.
+ * The Phase 1 reload pathway tears the single replica down before booting the
+ * new one; multi-replica services would therefore drop multiple connections at
+ * once and lose any in-memory state. Multi-replica rolling reload is Phase 2
+ * of issue #214. Exposed for the unit test that locks the gating logic
+ * (the integ test only covers the single-replica happy path).
+ *
+ * @internal
+ */
+export function assertSingleReplicaForWatch(
+  service: { serviceName: string; desiredCount: number },
+  options: Pick<EcsServiceEmulatorOptions, 'watch' | 'maxTasks'>
+): void {
+  if (options.watch !== true) return;
+  const effective = computeReplicaCount(service.desiredCount, options.maxTasks);
+  if (effective > 1) {
+    throw new LocalStartServiceError(
+      `--watch is single-replica only in v1; service '${service.serviceName}' resolves to ` +
+        `${effective} replica(s) (template DesiredCount=${service.desiredCount}, ` +
+        `--max-tasks=${options.maxTasks}). Lower --max-tasks to 1, drop the DesiredCount in your ` +
+        'CDK code, or drop --watch. Multi-replica rolling reload is Phase 2 of issue #214.'
+    );
+  }
+}
+
+/**
+ * Phase 1 of issue #214 — single-replica rebuild-on-change reload cycle.
+ * Mirrors start-api's `reloadAllServers` shape but per-ECS-service:
+ *
+ *   1. Re-runs `synthesizer.synthesize(synthOpts)` once (failure → warn +
+ *      keep every replica serving).
+ *   2. Re-runs `strategy.resolveBoots(stacks, resolvedTargets)` so a
+ *      target that disappears from the CDK code is detected (warn + keep
+ *      previous).
+ *   3. Refreshes `cloudMapIndexByStack` from the new stacks so a peer
+ *      service's namespace / discovery-name rename is picked up by the
+ *      next replica's Cloud Map publish.
+ *   4. Per-target: tear the existing controller down, boot a fresh one
+ *      against the new stacks. A per-target boot failure logs warn and
+ *      leaves that target dark until the next save with a clean boot.
+ *
+ * Phase 1 trade-off: each target's replica briefly stops (between old
+ * `controller.shutdown()` and new `bootOneTarget()` finishing). Phase 2 of
+ * #214 swaps that for a rolling deploy across multiple replicas.
+ */
+async function reloadAllServices(args: {
+  perTarget: Array<{
+    boot: ServiceBoot;
+    runState: ServiceRunState;
+    controller?: ServiceController;
+  }>;
+  synthesizer: Synthesizer;
+  synthOpts: SynthesisOptions;
+  strategy: EmulatorStrategy;
+  resolvedTargets: string[];
+  cloudMapIndexByStack: Map<string, CloudMapIndex>;
+  options: EcsServiceEmulatorOptions;
+  discovery: ServiceDiscoveryContext;
+  skipPull: boolean;
+  extraStateProviders: ExtraStateProviders | undefined;
+  profileCredsFile: ProfileCredentialsFile | undefined;
+  frontDoorByService: Map<string, FrontDoorServicePools>;
+  logger: ReturnType<typeof getLogger>;
+}): Promise<void> {
+  const {
+    perTarget,
+    synthesizer,
+    synthOpts,
+    strategy,
+    resolvedTargets,
+    cloudMapIndexByStack,
+    options,
+    discovery,
+    skipPull,
+    extraStateProviders,
+    profileCredsFile,
+    frontDoorByService,
+    logger,
+  } = args;
+
+  let stacks: StackInfo[];
+  try {
+    ({ stacks } = await synthesizer.synthesize(synthOpts));
+  } catch (err) {
+    logger.warn(
+      `cdk synth failed during reload; keeping previous version. (${err instanceof Error ? err.message : String(err)})`
+    );
+    return;
+  }
+
+  const { boots: newBoots, warnings } = strategy.resolveBoots(stacks, resolvedTargets);
+  for (const w of warnings) logger.warn(w);
+  const newBootByTarget = new Map(newBoots.map((b) => [b.target, b] as const));
+
+  // Refresh the per-stack Cloud Map index in place so the bootReplica
+  // publish path reads the new namespace / discovery-name shape on
+  // reload (the discovery object holds the same map reference).
+  cloudMapIndexByStack.clear();
+  for (const stack of stacks) {
+    const index = buildCloudMapIndex(stack);
+    cloudMapIndexByStack.set(stack.stackName, index);
+    for (const w of index.warnings) logger.warn(w);
+  }
+
+  // Per-target sequential reload — keep docker churn predictable.
+  for (const pt of perTarget) {
+    const newBoot = newBootByTarget.get(pt.boot.target);
+    if (!newBoot) {
+      logger.warn(
+        `Reload: target '${pt.boot.target}' no longer resolves to a service in the synthesized ` +
+          'app; keeping the previous replica serving.'
+      );
+      continue;
+    }
+    const oldController = pt.controller;
+    try {
+      // Tear the previous replica down BEFORE booting the new one so the
+      // single-replica `--host-port` publish does not collide on the
+      // host port. Brief downtime per target is the Phase 1 trade-off;
+      // Phase 2 of #214 will overlap via rolling deploy across multiple
+      // replicas.
+      if (oldController) await oldController.shutdown();
+    } catch (err) {
+      logger.warn(
+        `Reload: shutdown of previous '${pt.boot.target}' controller failed ` +
+          `(${err instanceof Error ? err.message : String(err)}); attempting re-boot anyway.`
+      );
+    }
+    const newRunState = createServiceRunState();
+    let newController: ServiceController;
+    try {
+      newController = await bootOneTarget(
+        newBoot,
+        newRunState,
+        stacks,
+        options,
+        discovery,
+        skipPull,
+        extraStateProviders,
+        profileCredsFile,
+        frontDoorByService.get(newBoot.target),
+        strategy.suppressLoadBalancerWarning === true
+      );
+    } catch (err) {
+      logger.error(
+        `Reload: re-boot of '${pt.boot.target}' failed ` +
+          `(${err instanceof Error ? err.message : String(err)}). ` +
+          'The previous replica was torn down; save again with a clean boot to re-start it, or ^C ' +
+          'and re-run start-service.'
+      );
+      // Tear down any partial docker state that the failed boot left in
+      // `newRunState.replicas` so cleanup() doesn't observe two states
+      // for the same `pt` slot. The `pt.controller` reference is left
+      // pointing at the (already-shutdown) old controller; its
+      // `shutdown()` is idempotent, so the eventual cleanup pass safely
+      // re-invokes it without resurrecting any docker resources.
+      await Promise.allSettled(
+        newRunState.replicas.map((r) =>
+          cleanupEcsRun(r.state, { keepRunning: false }).catch(() => undefined)
+        )
+      );
+      continue;
+    }
+    pt.runState = newRunState;
+    pt.controller = newController;
+  }
+
+  logger.info('Reload complete.');
 }
 
 async function bootOneTarget(
@@ -658,6 +923,7 @@ async function runOneTarget(
       `(service=${service.serviceName}, desiredCount=${service.desiredCount}, ` +
       `task=${service.task.taskDefinitionLogicalId})`
   );
+  assertSingleReplicaForWatch(service, options);
   if (service.serviceConnect) {
     logger.info(
       `Service Connect: namespace='${service.serviceConnect.namespaceName}', ` +

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -35,6 +35,11 @@ export interface CreateLocalStartServiceCommandOptions {
  * `AWS::ECS::Service` targets and boots each with NO front-door (the ALB
  * front-door is its own command, `cdkl start-alb`). This keeps `start-service`
  * a leaf compute runner, symmetric with `invoke` / `run-task`.
+ *
+ * `supportsWatch: true` opts this strategy into the emulator's `--watch`
+ * reload pathway (Phase 1 of issue #214 — single-replica rebuild-on-change).
+ * `start-alb`'s strategy intentionally does NOT set this so a `--watch` flag
+ * never leaks into the ALB-front-door path (Phase 3).
  */
 export function serviceStrategy(): EmulatorStrategy {
   return {
@@ -52,6 +57,7 @@ export function serviceStrategy(): EmulatorStrategy {
       warnings: [],
     }),
     lbPortOverrides: {},
+    supportsWatch: true,
   };
 }
 
@@ -84,6 +90,39 @@ export function createLocalStartServiceCommand(
       '[targets...]',
       'One or more CDK display paths or stack-qualified logical IDs of the AWS::ECS::Service resources to run (omit to multi-select interactively in a TTY)'
     )
+    .action(
+      withErrorHandling(async (targets: string[], options: EcsServiceEmulatorOptions) => {
+        await runEcsServiceEmulator(targets, options, serviceStrategy(), opts.extraStateProviders);
+      })
+    );
+
+  addStartServiceSpecificOptions(cmd);
+  return addCommonEcsServiceOptions(cmd);
+}
+
+/**
+ * Register the option block that `cdkl start-service` adds on top of the
+ * shared {@link addCommonEcsServiceOptions} ECS-service common block — the
+ * flags that only make sense for a pure-compute service emulator (no front
+ * door). Shared between `cdkl start-service` and any host CLI (e.g. cdkd's
+ * `local start-service`) that wraps {@link runEcsServiceEmulator} with the
+ * {@link serviceStrategy}, so adding or renaming a `start-service`-only flag
+ * here propagates to every embedder without duplicate `.addOption(...)`
+ * blocks.
+ *
+ * Calling order only affects `--help` presentation (Commander parses
+ * insertion-order-independent). The host-CLI convention is host-specific
+ * options first, then this helper, then {@link addCommonEcsServiceOptions}
+ * — host flags / start-service flags / common flags grouped in three
+ * `--help` clusters. Chainable: returns `cmd`.
+ *
+ * `--watch` is intentionally NOT in the shared
+ * {@link addCommonEcsServiceOptions} block: `start-alb --watch` is not yet
+ * implemented (Phase 3 of issue #214), and the shared block must not
+ * advertise a flag one of its consumers does not honor.
+ */
+export function addStartServiceSpecificOptions(cmd: Command): Command {
+  return cmd
     .addOption(
       new Option(
         '--host-port <containerPort=hostPort...>',
@@ -94,11 +133,15 @@ export function createLocalStartServiceCommand(
           'services do not publish host ports.)'
       )
     )
-    .action(
-      withErrorHandling(async (targets: string[], options: EcsServiceEmulatorOptions) => {
-        await runEcsServiceEmulator(targets, options, serviceStrategy(), opts.extraStateProviders);
-      })
+    .addOption(
+      new Option(
+        '--watch',
+        'Hot-reload: re-synth + re-resolve every booted service and replace its single replica ' +
+          "when the CDK app's source changes (honors cdk.json watch.include/exclude; cdk.out, " +
+          'node_modules, .git are always excluded). Single-replica services only in v1 — a service ' +
+          'with effective replica count > 1 errors out (multi-replica rolling deploy is Phase 2 of ' +
+          'issue #214). Off by default; the previous replica keeps serving when synth fails ' +
+          'mid-reload.'
+      ).default(false)
     );
-
-  return addCommonEcsServiceOptions(cmd);
 }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -534,3 +534,7 @@ export { addRunTaskSpecificOptions } from './cli/commands/local-run-task.js';
 export { addInvokeSpecificOptions } from './cli/commands/local-invoke.js';
 export { addInvokeAgentCoreSpecificOptions } from './cli/commands/local-invoke-agentcore.js';
 export { addStartApiSpecificOptions } from './cli/commands/local-start-api.js';
+export {
+  addStartServiceSpecificOptions,
+  serviceStrategy,
+} from './cli/commands/local-start-service.js';

--- a/tests/integration/local-start-service-watch/bin/app.ts
+++ b/tests/integration/local-start-service-watch/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartServiceWatchStack } from '../lib/watch-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartServiceWatchStack(app, 'CdkLocalStartServiceWatchFixture', {
+  description: 'Fixture stack for cdkl start-service --watch (Phase 1 of issue #214)',
+});

--- a/tests/integration/local-start-service-watch/cdk.json
+++ b/tests/integration/local-start-service-watch/cdk.json
@@ -1,0 +1,16 @@
+{
+  "app": "node bin/app.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "**/*.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "node_modules",
+      "dist"
+    ]
+  }
+}

--- a/tests/integration/local-start-service-watch/lib/watch-stack.ts
+++ b/tests/integration/local-start-service-watch/lib/watch-stack.ts
@@ -1,0 +1,60 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import { Construct } from 'constructs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture stack for `cdkl start-service --watch` integ test
+ * (Phase 1 of issue #214 — single-replica rebuild-on-change).
+ *
+ * One `AWS::ECS::Service` with `DesiredCount=1` (single replica is the
+ * Phase 1 constraint; multi-replica rolling reload is Phase 2). The
+ * single container is a busybox image built from a local `webapp/`
+ * asset; the asset's `server.sh` runs `httpd -p 8080 -h /www` after
+ * writing a one-line `index.html` with the version marker. verify.sh
+ * mutates `server.sh` to bump the marker (v1 -> v2) and asserts
+ * `curl http://127.0.0.1:8080/` returns the new value after a single
+ * hot reload — proving the watcher re-synths, rebuilds the asset
+ * image, and replaces the single replica without a `^C` / re-launch.
+ *
+ * `covers: AWS::ECS::Service` (start-service --watch path).
+ */
+export class LocalStartServiceWatchStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-service-watch',
+    });
+
+    // Asset image built from the local `webapp/` directory. CDK computes
+    // an asset hash from the directory contents during synth — editing
+    // `webapp/server.sh` flips the hash, which is exactly the signal
+    // cdk-local's `--watch` reload needs to pick up the new image.
+    const image = ecs.ContainerImage.fromAsset(path.join(__dirname, '../webapp'));
+
+    const taskDef = new ecs.TaskDefinition(this, 'WebTask', {
+      compatibility: ecs.Compatibility.EC2,
+      networkMode: ecs.NetworkMode.BRIDGE,
+    });
+    taskDef.addContainer('web', {
+      image,
+      memoryReservationMiB: 32,
+      portMappings: [{ containerPort: 8080 }],
+    });
+
+    // Use L1 CfnService directly so the fixture stays tiny (no VPC /
+    // launch-type / placement constraints). cdk-local doesn't talk to
+    // AWS for any of this — the cluster name surfaces only to the
+    // metadata sidecar.
+    new ecs.CfnService(this, 'WebService', {
+      cluster: cluster.ref,
+      taskDefinition: (taskDef.node.defaultChild as ecs.CfnTaskDefinition).ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+    });
+  }
+}

--- a/tests/integration/local-start-service-watch/package.json
+++ b/tests/integration/local-start-service-watch/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-start-service-watch",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-service --watch (Phase 1 of issue #214)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.5.0"
+}

--- a/tests/integration/local-start-service-watch/tsconfig.json
+++ b/tests/integration/local-start-service-watch/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-service-watch/verify.sh
+++ b/tests/integration/local-start-service-watch/verify.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-service-watch integ test
+# (Phase 1 of issue #214 — single-replica rebuild-on-change)
+#
+# Exercises `cdkl start-service --watch` end-to-end against real Docker.
+# Deploys nothing.
+#
+# What it proves:
+#   1. Editing the CDK app's asset SOURCE (webapp/server.sh) re-synths,
+#      rebuilds the asset image, and replaces the single replica — the
+#      served response changes from v1 to v2 without a `^C` / re-launch.
+#   2. Loop-safety: the reload's own re-synth writes into cdk.out/ do
+#      NOT re-trigger the watcher. Exactly ONE reload fires per source
+#      edit.
+#   3. cdk.json `watch.exclude` is honored: touching an excluded path
+#      (a *.md file) triggers no reload.
+#   4. Clean teardown on SIGTERM: no leftover cdkl-* containers /
+#      networks after the emulator exits.
+#
+# Run via `/run-integ local-start-service-watch` (recommended) or
+# directly:
+#
+#     bash tests/integration/local-start-service-watch/verify.sh
+#
+# Requires Docker.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+BUSYBOX_IMAGE="public.ecr.aws/docker/library/busybox:1.36"
+HOST_PORT=8086
+
+SERVER_SH="webapp/server.sh"
+SERVER_SH_BACKUP="$(mktemp)"
+cp "${SERVER_SH}" "${SERVER_SH_BACKUP}"
+PROBE_EXCLUDED="probe-excluded.md"
+
+LOG_FILE="$(mktemp)"
+CDKL_PID=""
+
+term_server() {
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "==> Sending SIGTERM to cdk-local (pid ${CDKL_PID})"
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 120); do
+      kill -0 "${CDKL_PID}" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "${CDKL_PID}" 2>/dev/null; then
+      echo "==> cdk-local did not exit within 120s; SIGKILL"
+      kill -KILL "${CDKL_PID}" 2>/dev/null || true
+    fi
+  fi
+}
+
+restore_source() {
+  # Put the committed v1 source back so the working tree is unchanged
+  # whether the test passed, failed, or was interrupted mid-edit.
+  if [[ -f "${SERVER_SH_BACKUP}" ]]; then
+    cp "${SERVER_SH_BACKUP}" "${SERVER_SH}"
+    rm -f "${SERVER_SH_BACKUP}"
+  fi
+  rm -f "${PROBE_EXCLUDED}"
+}
+
+cleanup() {
+  term_server
+  restore_source
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+  rm -f "${LOG_FILE}"
+}
+trap cleanup EXIT INT TERM
+
+# Pre-test orphan sweep — a failed previous run can leak cdkl-* state.
+echo "==> Pre-test orphan sweep"
+docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+  | xargs -r docker rm -f >/dev/null 2>&1 || true
+docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+  | xargs -r docker network rm >/dev/null 2>&1 || true
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${BUSYBOX_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+reload_count() {
+  local n
+  n=$(grep -c "Detected source change" "${LOG_FILE}" 2>/dev/null) || n=0
+  echo "${n}"
+}
+
+reload_complete_count() {
+  local n
+  n=$(grep -c "Reload complete" "${LOG_FILE}" 2>/dev/null) || n=0
+  echo "${n}"
+}
+
+echo "==> Booting service (DesiredCount=1) with --watch on host port ${HOST_PORT}"
+${CDKL} start-service CdkLocalStartServiceWatchFixture:WebService \
+  --watch \
+  --no-pull \
+  --host-port "8080=${HOST_PORT}" \
+  --container-host 127.0.0.1 \
+  >"${LOG_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 180s; first boot builds the asset image)"
+BOOTED=0
+for _ in $(seq 1 180); do
+  if grep -q "Service(s) running:" "${LOG_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"
+    cat "${LOG_FILE}"
+    echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: service did not reach the boot banner within 180s"
+  echo "----- service output -----"
+  cat "${LOG_FILE}"
+  echo "--------------------------"
+  exit 1
+fi
+
+# The boot line must name source-tree watching (not cdk.out watching).
+if ! grep -q "for source changes" "${LOG_FILE}"; then
+  echo "FAIL: startup did not announce source-tree watching"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+URL="http://127.0.0.1:${HOST_PORT}/"
+
+# Poll a URL until the response body contains a needle, or fail. busybox
+# httpd is fork-per-request but the first request after replica boot
+# races docker's port mapping — retry generously.
+curl_until() {
+  local label="$1" url="$2" needle="$3" tries="$4"
+  local response=""
+  for _ in $(seq 1 "${tries}"); do
+    if response=$(curl -sf --max-time 3 "${url}" 2>&1); then
+      if echo "${response}" | grep -q "${needle}"; then
+        echo "    [${label}] OK (response: ${response})"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  echo "FAIL: ${label} never matched '${needle}'. Last response: '${response}'"
+  echo "----- service output -----"
+  cat "${LOG_FILE}"
+  echo "--------------------------"
+  return 1
+}
+
+echo "==> Asserting the service serves v1 before any edit"
+curl_until "GET / (v1)" "${URL}" '^v1$' 60
+
+RELOADS_BEFORE_EDIT="$(reload_count)"
+echo "==> Reload count before edit: ${RELOADS_BEFORE_EDIT} (expect 0)"
+if [[ "${RELOADS_BEFORE_EDIT}" != "0" ]]; then
+  echo "FAIL: a reload fired before any source edit"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+echo "==> Editing webapp/server.sh (v1 -> v2) to trigger a hot reload"
+cat >"${SERVER_SH}" <<'EOF'
+#!/bin/sh
+# server.sh — mutated to v2 by verify.sh
+set -eu
+VERSION=v2
+mkdir -p /www
+printf '%s' "${VERSION}" > /www/index.html
+exec httpd -f -p 8080 -h /www
+EOF
+chmod +x "${SERVER_SH}"
+
+echo "==> Asserting the watcher detected the source change"
+DETECTED=0
+for _ in $(seq 1 60); do
+  if [[ "$(reload_count)" -ge 1 ]]; then
+    DETECTED=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ "${DETECTED}" -eq 0 ]]; then
+  echo "FAIL: source edit did not trigger a reload within 30s"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    [source change detected] OK"
+
+echo "==> Waiting for the reload-complete marker"
+COMPLETED=0
+for _ in $(seq 1 180); do
+  if [[ "$(reload_complete_count)" -ge 1 ]]; then
+    COMPLETED=1
+    break
+  fi
+  sleep 1
+done
+if [[ "${COMPLETED}" -eq 0 ]]; then
+  echo "FAIL: reload did not complete within 180s"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    [reload complete] OK"
+
+echo "==> Asserting the service now serves v2 (re-synth + asset rebuild + replica swap)"
+curl_until "GET / (v2)" "${URL}" '^v2$' 60
+
+# Loop-safety: the reload re-synths INTO cdk.out/, which is excluded from
+# the watch. Those writes must NOT re-trigger the watcher. Give any
+# runaway loop a few seconds to manifest, then assert exactly one reload.
+echo "==> Asserting loop-safety (re-synth writes do not re-trigger the watcher)"
+sleep 4
+RELOADS_AFTER_EDIT="$(reload_count)"
+echo "    reload count after one edit: ${RELOADS_AFTER_EDIT} (expect 1)"
+if [[ "${RELOADS_AFTER_EDIT}" != "1" ]]; then
+  echo "FAIL: expected exactly 1 reload, got ${RELOADS_AFTER_EDIT} (cdk.out writes likely re-triggered the watcher)"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    [loop-safe: exactly 1 reload] OK"
+
+# Excluded path: cdk.json watch.exclude lists *.md. Writing one must NOT
+# trigger a reload.
+echo "==> Asserting watch.exclude is honored (*.md write triggers no reload)"
+echo "excluded change at $(date)" >"${PROBE_EXCLUDED}"
+sleep 3
+RELOADS_AFTER_EXCLUDED="$(reload_count)"
+echo "    reload count after excluded write: ${RELOADS_AFTER_EXCLUDED} (expect 1)"
+if [[ "${RELOADS_AFTER_EXCLUDED}" != "1" ]]; then
+  echo "FAIL: an excluded (*.md) write triggered a reload"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+rm -f "${PROBE_EXCLUDED}"
+echo "    [watch.exclude honored] OK"
+
+echo "==> Sending SIGTERM to cdk-local"
+kill -TERM "${CDKL_PID}"
+
+echo "==> Waiting for cdk-local to exit (up to 60s)"
+EXITED=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    EXITED=1
+    break
+  fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
+  cat "${LOG_FILE}"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+echo "==> Asserting clean teardown — no leftover containers"
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers still present after SIGTERM"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+
+echo "==> Asserting clean teardown — no leftover networks"
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} docker networks still present after SIGTERM"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+echo ""
+echo "==> All local-start-service-watch smoke tests passed"

--- a/tests/integration/local-start-service-watch/webapp/Dockerfile
+++ b/tests/integration/local-start-service-watch/webapp/Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/docker/library/busybox:1.36
+WORKDIR /app
+COPY server.sh /app/server.sh
+RUN chmod +x /app/server.sh
+EXPOSE 8080
+CMD ["/bin/sh", "/app/server.sh"]

--- a/tests/integration/local-start-service-watch/webapp/server.sh
+++ b/tests/integration/local-start-service-watch/webapp/server.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# server.sh — webapp server for the local-start-service-watch integ
+# fixture. verify.sh rewrites this whole file mid-run to bump the
+# `VERSION` marker (v1 -> v2) and asserts the served response changes
+# after a single hot reload. Keep the script trivial so the asset
+# re-stages quickly on re-synth.
+set -eu
+VERSION=v1
+mkdir -p /www
+printf '%s' "${VERSION}" > /www/index.html
+exec httpd -f -p 8080 -h /www

--- a/tests/unit/cli/local-start-service-watch.test.ts
+++ b/tests/unit/cli/local-start-service-watch.test.ts
@@ -105,6 +105,18 @@ describe('assertSingleReplicaForWatch (Phase 1 of issue #214)', () => {
     ).not.toThrow();
   });
 
+  it('passes when --watch is on AND DesiredCount is 0 (computeReplicaCount floors to 1)', () => {
+    // `computeReplicaCount` returns 1 when `desiredCount <= 0` so a
+    // local dev who scaled their service down to 0 in CDK code still
+    // gets one replica running. The watch gate must reflect the same
+    // floor — locking this prevents an accidental regression that
+    // would otherwise let a DesiredCount=0 service skip the gate's
+    // pass branch via a different code path.
+    expect(() =>
+      assertSingleReplicaForWatch(fakeService(0), baseOptions({ watch: true }))
+    ).not.toThrow();
+  });
+
   it('throws LocalStartServiceError when --watch is on AND effective replica count > 1', () => {
     expect(() =>
       assertSingleReplicaForWatch(fakeService(2), baseOptions({ watch: true }))

--- a/tests/unit/cli/local-start-service-watch.test.ts
+++ b/tests/unit/cli/local-start-service-watch.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { Command } from 'commander';
+import {
+  addStartServiceSpecificOptions,
+  createLocalStartServiceCommand,
+  serviceStrategy,
+} from '../../../src/cli/commands/local-start-service.js';
+import {
+  addCommonEcsServiceOptions,
+  assertSingleReplicaForWatch,
+  type EcsServiceEmulatorOptions,
+} from '../../../src/cli/commands/ecs-service-emulator.js';
+import { LocalStartServiceError } from '../../../src/utils/error-handler.js';
+
+/**
+ * Phase 1 of issue #214 — locks the `cdkl start-service --watch` wiring.
+ * The integ fixture (`tests/integration/local-start-service-watch/`) covers
+ * the live reload behavior end-to-end; these unit tests just guard the
+ * option-surface contract + the synchronous single-replica gate.
+ */
+
+function longFlagsOf(cmd: Command): string[] {
+  return cmd.options
+    .map((o) => o.long)
+    .filter((l): l is string => typeof l === 'string')
+    .sort();
+}
+
+describe('start-service option surface contract (addStartServiceSpecificOptions)', () => {
+  it('addStartServiceSpecificOptions registers exactly the known start-service-only flags', () => {
+    // Lock the helper's contract: cdkd imports it expecting THIS set of long
+    // flags. Adding or removing one without updating the list below is a
+    // semver-relevant surface change.
+    const flags = longFlagsOf(addStartServiceSpecificOptions(new Command()));
+    expect(flags).toEqual(['--host-port', '--watch']);
+  });
+
+  it('createLocalStartServiceCommand surface equals common + start-service-specific (no inline drift)', () => {
+    // The full CLI surface MUST be the union of the two helpers — never a
+    // proper superset. A proper superset would mean someone added an option
+    // inline in `createLocalStartServiceCommand`, which a host CLI (cdkd)
+    // calling the helpers directly would silently miss.
+    const full = longFlagsOf(createLocalStartServiceCommand());
+    const expected = Array.from(
+      new Set([
+        ...longFlagsOf(addCommonEcsServiceOptions(new Command())),
+        ...longFlagsOf(addStartServiceSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+
+  it('--watch defaults to false', () => {
+    // Locks the boolean default (off by default per the issue + the README
+    // "off by default" copy). A flipped default would silently install a
+    // chokidar watcher for every start-service invocation.
+    const cmd = addStartServiceSpecificOptions(new Command());
+    const watch = cmd.options.find((o) => o.long === '--watch');
+    expect(watch?.defaultValue).toBe(false);
+  });
+});
+
+describe('serviceStrategy', () => {
+  it('opts into the emulator --watch reload pathway via supportsWatch=true', () => {
+    // start-alb's strategy intentionally leaves `supportsWatch` falsy (its
+    // own --watch is Phase 3 of issue #214). Flipping this off on
+    // `serviceStrategy()` would silently disable `cdkl start-service --watch`
+    // — the emulator's watcher install is gated on this exact field.
+    expect(serviceStrategy().supportsWatch).toBe(true);
+  });
+});
+
+describe('assertSingleReplicaForWatch (Phase 1 of issue #214)', () => {
+  // The synthetic shape only needs the two fields the helper reads — the
+  // resolver's full `ResolvedEcsService` is much larger but irrelevant for
+  // this gate's logic.
+  function fakeService(
+    desiredCount: number,
+    serviceName = 'WebSvc'
+  ): { serviceName: string; desiredCount: number } {
+    return { serviceName, desiredCount };
+  }
+
+  function baseOptions(
+    over: Partial<Pick<EcsServiceEmulatorOptions, 'watch' | 'maxTasks'>> = {}
+  ): Pick<EcsServiceEmulatorOptions, 'watch' | 'maxTasks'> {
+    return { maxTasks: 3, ...over };
+  }
+
+  it('passes when --watch is off (multi-replica + no watch is fine)', () => {
+    expect(() => assertSingleReplicaForWatch(fakeService(2), baseOptions())).not.toThrow();
+    expect(() =>
+      assertSingleReplicaForWatch(fakeService(10), baseOptions({ watch: false }))
+    ).not.toThrow();
+  });
+
+  it('passes when --watch is on AND the effective replica count is 1', () => {
+    expect(() =>
+      assertSingleReplicaForWatch(fakeService(1), baseOptions({ watch: true }))
+    ).not.toThrow();
+    // Effective count is clamped by --max-tasks; a DesiredCount=5 capped to
+    // --max-tasks=1 also resolves to 1 → pass.
+    expect(() =>
+      assertSingleReplicaForWatch(fakeService(5), baseOptions({ watch: true, maxTasks: 1 }))
+    ).not.toThrow();
+  });
+
+  it('throws LocalStartServiceError when --watch is on AND effective replica count > 1', () => {
+    expect(() =>
+      assertSingleReplicaForWatch(fakeService(2), baseOptions({ watch: true }))
+    ).toThrow(LocalStartServiceError);
+    expect(() =>
+      assertSingleReplicaForWatch(fakeService(2), baseOptions({ watch: true }))
+    ).toThrow(/single-replica only/);
+  });
+
+  it('the thrown error names the service + counts + points to Phase 2 of issue #214', () => {
+    // The error message is part of the user-facing contract — a developer
+    // hitting it needs to know WHICH service tripped the gate, the effective
+    // count, AND where the multi-replica story is going (Phase 2). Locking
+    // the message prevents an accidental message regression that strips the
+    // actionable hint.
+    try {
+      assertSingleReplicaForWatch(
+        fakeService(4, 'OrdersSvc'),
+        baseOptions({ watch: true, maxTasks: 3 })
+      );
+      throw new Error('expected assertSingleReplicaForWatch to throw');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toMatch(/OrdersSvc/);
+      expect(msg).toMatch(/3 replica\(s\)/);
+      expect(msg).toMatch(/DesiredCount=4/);
+      expect(msg).toMatch(/--max-tasks=3/);
+      expect(msg).toMatch(/Phase 2 of issue #214/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of #214 — add `--watch` hot reload to `cdkl start-service` for the single-replica case.

On a debounced source change (500ms), the emulator:
1. Re-synths the CDK app.
2. Per booted target, tears the single replica down and boots a fresh one from the new task definition. Asset images are rebuilt automatically when the asset hash flips.
3. Synth failures keep the previous replica serving (warn-and-continue), mirroring `start-api --watch`.

Honors `cdk.json`'s `watch.include` / `watch.exclude` globs; `cdk.out/`, `node_modules`, and `.git` are always excluded.

### Phase 1 trade-offs (locked in by `assertSingleReplicaForWatch`)

- **Single-replica only.** A service whose effective replica count (`min(template DesiredCount, --max-tasks)`) is > 1 errors out with an actionable hint (lower `--max-tasks` to 1, drop `DesiredCount`, or drop `--watch`). Multi-replica rolling deploy is **Phase 2**.
- **Brief downtime per save.** The old replica is torn down before the new one boots (single-replica services have no second replica to forward to). Phase 2 will overlap via rolling deploy.
- **No bind-mount fast path.** Every reload rebuilds the asset image (the same path the initial boot takes). **Phase 4** adds an opt-in bind-mount source mode.
- **`cdkl start-alb --watch` is NOT in scope.** Phase 3 turns it on once the front-door pool supports atomic swap.

The new `EmulatorStrategy.supportsWatch` field gates the watcher install — only `serviceStrategy()` opts in, so the `start-alb` path is untouched even if a host CLI accidentally threads `options.watch` through.

### Structural cleanup

The previously-inline `--host-port` flag is moved into a new `addStartServiceSpecificOptions` helper alongside `--watch`, mirroring the existing `add<Cmd>SpecificOptions` pattern so host CLIs (cdkd) auto-inherit both flags without a duplicate `.addOption(...)` block. A surface-contract test (`local-start-service-watch.test.ts`) locks the flag set and the no-inline-drift invariant.

### Bug fix on the way

The pre-#214 main-loop wait `await Promise.all(perTarget.map(pt => pt.controller!.waitForShutdown()))` was equivalent to a forever-wait in non-watch mode (nothing called `controller.shutdown()` outside the SIGINT path), but the reload pathway calls `oldController.shutdown()` mid-run to swap a replica — which would resolve the OLD controller's promise and unblock the main loop prematurely. Replaced with `await new Promise<never>()` matching the `start-api` pattern; behavior is identical for the watch-off case (the SIGINT handler still drives cleanup + `process.exit`).

## Test plan

- [x] Unit: `tests/unit/cli/local-start-service-watch.test.ts` — surface contract + `serviceStrategy().supportsWatch === true` + `assertSingleReplicaForWatch` pass/throw branches (1, 5/clamped-to-1, and 0/floored-to-1).
- [x] Integ (real Docker): `tests/integration/local-start-service-watch/` — boot v1 → edit `webapp/server.sh` → assert `Detected source change` → assert `Reload complete.` → `curl` returns v2 → assert loop-safety (exactly 1 reload after re-synth writes into `cdk.out/`) → assert `watch.exclude` honored (`*.md` write triggers no reload) → SIGTERM → assert zero leftover containers / networks.
- [x] Live-test (manual): same flow exercised against the fixture before integ. Asset hash flipped `dd3dfdec...` → `e9f706de...` after the source edit, proving the rebuild path runs.
- [x] `cdkl start-alb --help` confirms `--watch` is NOT advertised there (Phase 3 boundary).

## Follow-ups (Phase 2-4)

These stay open under #214:
- Phase 2: multi-replica rolling deploy (atomic Cloud Map / front-door pool swap per replica).
- Phase 3: `cdkl start-alb --watch` (needs the Phase 2 pool-swap support).
- Phase 4 (optional): bind-mount source fast path for source-only changes, skipping the rebuild.

Part of #214 (Phase 1).
