### PR TITLE
docs: sync CLAUDE.md soft-reload prose with the actual log line

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,13 +36,18 @@ AWS managed services.
   handler — Node / Python / Ruby / shell — no Dockerfile, no
   dependency manifest, no compiled-language source) `docker cp` the
   freshly-synthed asset directory's contents into each replica's
-  WORKDIR + `docker restart`: no `docker build`, no shadow boot, no
-  Cloud Map / front-door pool swap (the container's docker network IP
-  and host port are preserved across the restart). Reload log
-  surfaces `verdict=soft-reload (...)` and per-replica
-  `Soft-reloaded replica ... restart + TCP-ready probe complete;
-  registrations unchanged`. Typical end-to-end latency well under a
-  second. Dockerfile / dependency manifest / compiled-language source
+  WORKDIR + `docker restart`: no `docker build`, no shadow boot. The
+  container's docker network IP and host port are preserved across
+  the restart, so the pre-restart drain of Cloud Map handles + the
+  front-door pool entry and the post-TCP-ready re-publish under the
+  SAME per-replica owner key are a no-op at the end-state contract
+  level — but the drain-then-republish round trip is what preserves
+  the multi-replica zero-connection-refusal guarantee while the
+  SIGTERM'd container is restarting. Reload log surfaces
+  `verdict=soft-reload (...)` and per-replica `Soft-reloaded replica
+  ... restart + TCP-ready probe complete; Cloud Map + front-door
+  re-published`. Typical end-to-end latency well under a second.
+  Dockerfile / dependency manifest / compiled-language source
   / ambiguous edits fall through to the rebuild path — boot a shadow
   replica under a bumped generation suffix, atomically swap Cloud Map
   / front-door pool registrations off the dying replica (after a


### PR DESCRIPTION
## Summary

Sync `.claude/CLAUDE.md`'s soft-reload paragraph with the actual runtime log line. Phase 4 (#219) shipped a drain-then-republish round trip on the soft-reload path — the runtime log correctly says `Cloud Map + front-door re-published`, but the prose description was authored against an earlier draft that called the registrations `unchanged`. That phrasing is true only at the end-state contract level (the IP + host port DO survive `docker restart`) but misleading about the mid-flight drain that holds the multi-replica zero-connection-refusal guarantee.

This PR rewrites the paragraph to match the code:

- The container's docker network IP and host port ARE preserved across `docker restart`, so the post-TCP-ready re-publish lands on the same endpoint.
- The drain-then-republish round trip IS what holds the zero-refusal guarantee while the container's PID 1 is mid-restart.
- The log line text in the prose now reads `Cloud Map + front-door re-published`, matching `src/local/ecs-service-runner.ts:1541`.

No code change. Pure docs prose. Part of #214.

## Test plan

- [x] `vp run check` + `vp run build` + `vp test run` — clean (no src delta, so this is a sanity gate, not a coverage check).
- [x] `grep -n "Cloud Map + front-door re-published" src/local/ecs-service-runner.ts` returns the live log-line emit — the new prose matches verbatim.
- [x] No other doc mentions of `registrations unchanged` remain (`grep -rn "registrations unchanged" .` returns zero hits).
