### PR TITLE
chore: address #218 Phase 4 follow-up items (test coverage + chatty oldHash + watcher race)

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -944,7 +944,14 @@ async function reloadAllServices(args: {
  * {@link AssetManifestLoader}) so the caller can fall back to rebuild
  * with a warn line that explains why the classifier couldn't run.
  */
-async function loadAssetContextForTarget(args: {
+/**
+ * @internal — exported for unit tests of the fall-through branches
+ * (the 6 `return undefined` paths + the catch arm on
+ * `resolveEcsServiceTarget` throw). Not part of the semver-covered
+ * public surface; the only legitimate caller is `reloadAllServices`
+ * inside this file.
+ */
+export async function loadAssetContextForTarget(args: {
   target: string;
   controller: ServiceController;
   stacks: StackInfo[];
@@ -996,14 +1003,27 @@ async function loadAssetContextForTarget(args: {
     return undefined;
   }
   const newAssetSourceDir = path.resolve(cdkOutDir, newDockerImage.source.directory);
-  // OLD hash is purely diagnostic; pull from the controller's
-  // captured-at-boot service descriptor when available.
+  // Phase 4 follow-up (#218) — read the OLD asset hash from the
+  // LIVE replica's `lastDeployedAssetHash` stamp, not from
+  // `controller.service` (the boot-time descriptor, which never
+  // updates across rolling reloads). The first non-shutting-down
+  // replica is the source of truth for "what's running right now"
+  // because the rolling primitive sequences swaps one replica at a
+  // time; in steady state every replica carries the same hash. Falls
+  // back to the boot-time descriptor for replicas whose stamp is
+  // missing (defensive — e.g. when a host CLI hand-builds the run
+  // state and skips the stamp).
   let oldAssetHash: string | undefined;
-  const oldEssential =
-    controller.service.task.containers.find((c) => c.essential) ??
-    controller.service.task.containers[0];
-  if (oldEssential?.image.kind === 'cdk-asset') {
-    oldAssetHash = oldEssential.image.assetHash;
+  const liveReplica = controller.runState.replicas.find((r) => !r.shuttingDown);
+  if (liveReplica?.lastDeployedAssetHash !== undefined) {
+    oldAssetHash = liveReplica.lastDeployedAssetHash;
+  } else {
+    const oldEssential =
+      controller.service.task.containers.find((c) => c.essential) ??
+      controller.service.task.containers[0];
+    if (oldEssential?.image.kind === 'cdk-asset') {
+      oldAssetHash = oldEssential.image.assetHash;
+    }
   }
   return {
     ...(oldAssetHash !== undefined && { oldAssetHash }),

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -445,6 +445,17 @@ export {
   type ReloadAssetContext,
   type ReloadVerdict,
 } from './local/source-change-classifier.js';
+
+/**
+ * Phase 4 of issue #214 — completion-log suffix the soft-reload
+ * primitive emits after the per-replica `Soft-reloaded replica r<i>
+ * (gen <g>): ` prefix. Exposed so host CLIs (cdkd) that wrap
+ * `runEcsServiceEmulator` and own their own integ scripts can grep
+ * against the canonical constant instead of hand-copying the
+ * wording. A future re-wording of the runner's emit stays detectable
+ * via the symbol import.
+ */
+export { SOFT_RELOAD_COMPLETION_LOG_SUFFIX } from './local/ecs-service-runner.js';
 export { createWatchPredicates, type WatchPredicates } from './cli/commands/local-start-api.js';
 export { resolveWatchConfig, type CdkWatchConfig } from './cli/config-loader.js';
 

--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -58,6 +58,24 @@ export class EcsServiceRunnerError extends Error {
   }
 }
 
+/**
+ * Phase 4 (#214) — completion-log suffix the soft-reload primitive
+ * emits AFTER `Soft-reloaded replica r<i> (gen <g>): ` to confirm
+ * the docker restart + TCP-ready probe + Cloud Map / front-door
+ * re-publish round trip is done.
+ *
+ * Exported so integ fixtures + unit tests can grep against the
+ * canonical text instead of hand-copying the wording — a future
+ * refactor that rewords this line stays detectable via the symbol
+ * import instead of silently breaking every test's regex.
+ *
+ * Per-repo memory (#218 / test reviewer N4): log-line text is part
+ * of the public contract for `--watch` integ scripts, so it earns a
+ * constant.
+ */
+export const SOFT_RELOAD_COMPLETION_LOG_SUFFIX =
+  'restart + TCP-ready probe complete; Cloud Map + front-door re-published.';
+
 export interface ServiceRunnerOptions {
   /**
    * Hard cap on local replica count. Even when the service's
@@ -232,6 +250,50 @@ export interface ServiceReplicaInstance {
    * is never wedged).
    */
   softReloadInProgress?: boolean;
+  /**
+   * Phase 4 follow-up (#218 code reviewer Nit #4) — monotonic
+   * counter incremented at the START of each {@link softReloadReplica}
+   * cycle. The watcher snapshots this BEFORE `waitForExitImpl` and
+   * compares on resume; any mismatch means a soft-reload happened
+   * mid-wait (even if it has since completed and cleared
+   * {@link softReloadInProgress}), so the watcher treats the
+   * waitForExit return as a controlled restart and re-arms instead
+   * of falling into the restart-policy branch.
+   *
+   * Closes the race the Phase 4 PR's review surfaced: under docker
+   * daemon backpressure, `docker wait` can lag the actual
+   * SIGTERM-to-restart-complete cycle by ~10s+. If the lag exceeds
+   * the soft-reload's runtime (sub-second typical), the flag has
+   * cleared by the time `waitForExitImpl` resolves and the
+   * `softReloadInProgress` check alone is not sufficient.
+   *
+   * Defaults to 0 at boot; bumped once per soft-reload entry.
+   * Numbers are not load-bearing; only the change-vs-snapshot
+   * comparison matters.
+   */
+  softReloadGeneration?: number;
+  /**
+   * Phase 4 follow-up (#218) — CDK asset hash of the image this
+   * replica is currently running. Updated AFTER each successful
+   * boot ({@link bootReplica}) and AFTER each successful soft-reload
+   * ({@link softReloadReplica}'s re-publish step). Consulted by the
+   * emulator's `loadAssetContextForTarget` as the `oldAssetHash`
+   * baseline so the classifier's hash-unchanged guard reads the
+   * LIVE replica's hash, not the boot-time descriptor.
+   *
+   * Pre-Phase-4 the loader read from `controller.service` (the
+   * boot-time `ResolvedEcsService`), which was never updated when a
+   * rolling reload swapped the replica to a new image. The stale
+   * baseline caused soft-reload to fire on reload #2-after-rebuild
+   * even when the synth produced identical content — wasteful but
+   * correct (`docker cp` of identical bytes + `docker restart`). The
+   * per-replica field closes that gap.
+   *
+   * `undefined` when the image isn't a CDK asset (ECR / public pin)
+   * — the classifier already routes those to rebuild via the no-ctx
+   * branch.
+   */
+  lastDeployedAssetHash?: string | undefined;
   /**
    * Last error from a failed run, if any. Surfaced in the shutdown
    * summary so users know why a degraded service ended up degraded.
@@ -711,6 +773,39 @@ async function bootReplica(
       ownerKeyPrefix
     );
   }
+
+  // Phase 4 follow-up (#218) — stamp the live CDK asset hash on the
+  // instance AFTER a successful boot. The emulator's
+  // `loadAssetContextForTarget` reads this as the `oldAssetHash`
+  // baseline so the classifier's hash-unchanged guard sees the LIVE
+  // replica's hash, not the boot-time descriptor (which never
+  // updates across rolling reloads). Undefined when the image isn't
+  // a CDK asset — the classifier already routes those to rebuild.
+  instance.lastDeployedAssetHash = pickEssentialAssetHash(service);
+}
+
+/**
+ * Phase 4 follow-up (#218) — extract the CDK asset hash from a
+ * resolved service's first essential container (with the same
+ * fallback the watcher uses: first essential, else first container).
+ * Returns `undefined` when the image isn't a CDK asset OR carries
+ * no hash. Pure helper so the boot + rolling + soft-reload paths
+ * share one source of truth for "what's running right now".
+ *
+ * Exported for unit tests; not part of the semver-covered public
+ * surface.
+ *
+ * @internal
+ */
+export function pickEssentialAssetHash(service: ResolvedEcsService): string | undefined {
+  const essential = service.task.containers.find((c) => c.essential) ?? service.task.containers[0];
+  if (!essential) return undefined;
+  // Defensive: existing test fixtures + hand-built run states may
+  // omit `image` entirely (the runtime contract requires it, but
+  // the stamp is best-effort + non-functional for those paths).
+  const image = essential.image as { kind?: string; assetHash?: string } | undefined;
+  if (image?.kind !== 'cdk-asset') return undefined;
+  return image.assetHash;
 }
 
 /**
@@ -1443,6 +1538,14 @@ export async function softReloadReplica(args: {
   unregisterReplicaFromFrontDoor(instance, controllerOptions.frontDoor);
 
   instance.softReloadInProgress = true;
+  // Phase 4 follow-up (#218 code reviewer Nit #4) — bump the
+  // soft-reload generation so the watcher's pre-`waitForExitImpl`
+  // snapshot catches any soft-reload that runs to completion
+  // during the wait (docker daemon backpressure can lag
+  // `docker wait` past restart completion + flag clear). The
+  // comparison runs in the watcher loop; the value itself is not
+  // load-bearing.
+  instance.softReloadGeneration = (instance.softReloadGeneration ?? 0) + 1;
   try {
     logger.info(
       `Soft-reloading replica r${instance.index} (gen ${instance.generation}): ` +
@@ -1536,9 +1639,13 @@ export async function softReloadReplica(args: {
         ownerKeyPrefix
       );
     }
+    // Phase 4 follow-up (#218) — stamp the post-soft-reload asset
+    // hash on the instance so the next reload's classifier reads the
+    // CURRENT image's hash, not the boot-time descriptor's. Closes
+    // the chatty-soft-reload-after-rebuild loop.
+    instance.lastDeployedAssetHash = pickEssentialAssetHash(newService);
     logger.info(
-      `Soft-reloaded replica r${instance.index} (gen ${instance.generation}): restart + ` +
-        'TCP-ready probe complete; Cloud Map + front-door re-published.'
+      `Soft-reloaded replica r${instance.index} (gen ${instance.generation}): ${SOFT_RELOAD_COMPLETION_LOG_SUFFIX}`
     );
   } finally {
     // Always clear the flag — the watcher's defer-loop polls this
@@ -1891,6 +1998,15 @@ async function watchReplica(
       await sleep(500);
       continue;
     }
+    // Phase 4 follow-up (#218 code reviewer Nit #4) — snapshot the
+    // soft-reload generation BEFORE the (potentially long) docker
+    // wait so we can detect a soft-reload that ran end-to-end during
+    // the wait. The `softReloadInProgress` check alone is not
+    // sufficient: under docker daemon backpressure, `docker wait`
+    // can lag past the soft-reload's flag clear (~10s+), leaving
+    // the watcher to enter the restart-policy branch against a
+    // healthy, just-re-registered container.
+    const softReloadGenBeforeWait = instance.softReloadGeneration ?? 0;
     let exitCode: number;
     try {
       exitCode = await waitForExitImpl(essentialId);
@@ -1908,14 +2024,22 @@ async function watchReplica(
 
     // Phase 4 of issue #214 — soft-reload pathway: `docker restart`
     // fires SIGTERM at PID 1, which resolves `waitForExitImpl` here
-    // even though the container is being intentionally cycled. If
-    // `softReloadReplica` is mid-flight, wait until it clears the
-    // flag (after its own post-restart TCP-ready probe), then loop
-    // back to re-arm `docker wait` on the (same-id) restarted
-    // container. A real crash that lands DURING a soft-reload still
-    // gets handled by the soft-reload's own error path; the watcher
+    // even though the container is being intentionally cycled.
+    //
+    // Two paths to defer:
+    //   1. `softReloadInProgress` is still set — soft-reload is
+    //      mid-flight. Wait until it clears, then re-arm.
+    //   2. `softReloadGeneration` changed during the wait — a
+    //      complete soft-reload happened between waitForExit's
+    //      arming and its return (the daemon-lag race). Same outcome:
+    //      treat as a controlled restart, re-arm.
+    //
+    // A real crash that lands DURING a soft-reload still gets
+    // handled by the soft-reload's own error path; the watcher
     // doesn't need to second-guess it here.
-    if (instance.softReloadInProgress) {
+    const softReloadHappenedMidWait =
+      (instance.softReloadGeneration ?? 0) !== softReloadGenBeforeWait;
+    if (instance.softReloadInProgress || softReloadHappenedMidWait) {
       while (instance.softReloadInProgress && !instance.shuttingDown && !runState.shuttingDown) {
         await sleep(100);
       }

--- a/tests/unit/cli/ecs-service-emulator-load-asset-context.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-load-asset-context.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { hoisted } = vi.hoisted(() => ({
+  hoisted: {
+    /** Toggle the `resolveEcsServiceTarget` mock between success / throw / different containers. */
+    resolveMode: 'happy' as 'happy' | 'throw' | 'no-containers' | 'non-cdk-asset' | 'no-asset-hash',
+    /** Loaded asset manifest. `null` simulates the "manifest missing" branch. */
+    manifest: null as Record<string, unknown> | null,
+    /** Tracks the manifest loader's hash arg so we can assert it. */
+    loadManifestCalls: [] as Array<{ cdkOutDir: string; stackName: string }>,
+  },
+}));
+
+vi.mock('../../../src/local/ecs-service-resolver.js', async (importActual) => {
+  const actual = await importActual<object>();
+  return {
+    ...actual,
+    resolveEcsServiceTarget: () => {
+      switch (hoisted.resolveMode) {
+        case 'throw':
+          throw new Error('synthetic resolveEcsServiceTarget throw');
+        case 'no-containers':
+          return {
+            stack: { stackName: 'AppStack' },
+            serviceLogicalId: 'Svc',
+            task: {
+              taskDefinitionLogicalId: 'TD',
+              containers: [],
+              warnings: [],
+            },
+            warnings: [],
+          };
+        case 'non-cdk-asset':
+          return {
+            stack: { stackName: 'AppStack' },
+            serviceLogicalId: 'Svc',
+            task: {
+              taskDefinitionLogicalId: 'TD',
+              containers: [
+                {
+                  name: 'web',
+                  essential: true,
+                  image: { kind: 'ecr', uri: 'public.ecr.aws/foo:bar' },
+                },
+              ],
+              warnings: [],
+            },
+            warnings: [],
+          };
+        case 'no-asset-hash':
+          return {
+            stack: { stackName: 'AppStack' },
+            serviceLogicalId: 'Svc',
+            task: {
+              taskDefinitionLogicalId: 'TD',
+              containers: [
+                {
+                  name: 'web',
+                  essential: true,
+                  image: { kind: 'cdk-asset' },
+                },
+              ],
+              warnings: [],
+            },
+            warnings: [],
+          };
+        default:
+          return {
+            stack: { stackName: 'AppStack' },
+            serviceLogicalId: 'Svc',
+            task: {
+              taskDefinitionLogicalId: 'TD',
+              containers: [
+                {
+                  name: 'web',
+                  essential: true,
+                  image: { kind: 'cdk-asset', assetHash: 'newhash' },
+                },
+              ],
+              warnings: [],
+            },
+            warnings: [],
+          };
+      }
+    },
+  };
+});
+
+vi.mock('../../../src/assets/asset-manifest-loader.js', async (importActual) => {
+  const actual = await importActual<object>();
+  return {
+    ...actual,
+    AssetManifestLoader: class {
+      async loadManifest(cdkOutDir: string, stackName: string): Promise<unknown> {
+        hoisted.loadManifestCalls.push({ cdkOutDir, stackName });
+        return hoisted.manifest;
+      }
+    },
+  };
+});
+
+const { loadAssetContextForTarget } = await import(
+  '../../../src/cli/commands/ecs-service-emulator.js'
+);
+const { AssetManifestLoader } = await import('../../../src/assets/asset-manifest-loader.js');
+const { getLogger } = await import('../../../src/utils/logger.js');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fakeStack(): any {
+  return {
+    stackName: 'AppStack',
+    region: 'us-east-1',
+    template: { Resources: {} },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fakeControllerWithOldAssetHash(
+  oldHash: string | undefined,
+  // Phase 4 follow-up (#218) — `liveStamp` is the
+  // `lastDeployedAssetHash` on the first non-shutting-down replica
+  // (the new source of truth post-#218). Pass `undefined` to skip
+  // the per-replica stamp and force the loader's fall-back to
+  // `controller.service.task.containers[essential].image.assetHash`.
+  liveStamp: string | 'omit' | undefined = 'omit'
+): any {
+  const containers = oldHash
+    ? [
+        {
+          name: 'web',
+          essential: true,
+          image: { kind: 'cdk-asset', assetHash: oldHash },
+        },
+      ]
+    : [
+        {
+          name: 'web',
+          essential: true,
+          image: { kind: 'ecr', uri: 'public.ecr.aws/foo:bar' },
+        },
+      ];
+  const replica: Record<string, unknown> = {
+    index: 0,
+    generation: 0,
+    shuttingDown: false,
+  };
+  if (liveStamp !== 'omit') {
+    replica['lastDeployedAssetHash'] = liveStamp;
+  }
+  return {
+    service: {
+      stack: { stackName: 'AppStack' },
+      serviceLogicalId: 'Svc',
+      task: {
+        taskDefinitionLogicalId: 'TD',
+        containers,
+        warnings: [],
+      },
+      warnings: [],
+    },
+    runState: { replicas: [replica], shuttingDown: false },
+  };
+}
+
+/**
+ * Phase 4 follow-up (#218 test reviewer M1, M2) — `loadAssetContextForTarget`
+ * has six distinct `return undefined` branches + a catch arm on
+ * `resolveEcsServiceTarget` throw + a happy path. Each fall-through
+ * maps the classifier to `'rebuild'`; the integ fixture covers only
+ * the happy path. These rows lock the branch contract at the unit
+ * level so a refactor that reorders or drops a guard surfaces here
+ * instead of silently shipping a wrong verdict.
+ */
+describe('loadAssetContextForTarget (Phase 4 follow-up of #214, #218)', () => {
+  beforeEach(() => {
+    hoisted.resolveMode = 'happy';
+    hoisted.manifest = {
+      version: '1.0.0',
+      files: {},
+      dockerImages: {
+        newhash: {
+          displayName: 'WebTask:web',
+          source: { directory: 'asset.newhash' },
+          destinations: {},
+        },
+      },
+    };
+    hoisted.loadManifestCalls = [];
+  });
+
+  function call(
+    options: {
+      stacks?: unknown[];
+      target?: string;
+      oldHash?: string | undefined;
+      liveStamp?: string | 'omit' | undefined;
+    } = {}
+  ): Promise<unknown> {
+    const stacks = options.stacks ?? [fakeStack()];
+    const target = options.target ?? 'AppStack:WebService';
+    const oldHash = 'oldHash' in options ? options.oldHash : 'oldhash';
+    const liveStamp = 'liveStamp' in options ? options.liveStamp : 'omit';
+    return loadAssetContextForTarget({
+      target,
+      controller: fakeControllerWithOldAssetHash(oldHash, liveStamp),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stacks: stacks as any,
+      cdkOutDir: '/tmp/cdk.out',
+      assetLoader: new AssetManifestLoader(),
+      logger: getLogger().child('test'),
+    });
+  }
+
+  it('returns undefined when pickCandidateStack finds no match (empty stacks)', async () => {
+    const ctx = await call({ stacks: [] });
+    expect(ctx).toBeUndefined();
+    // Bail-out happened BEFORE the manifest load — loader was not touched.
+    expect(hoisted.loadManifestCalls).toEqual([]);
+  });
+
+  it('returns undefined when resolveEcsServiceTarget throws (mid-edit construct code)', async () => {
+    hoisted.resolveMode = 'throw';
+    const ctx = await call();
+    expect(ctx).toBeUndefined();
+    expect(hoisted.loadManifestCalls).toEqual([]);
+  });
+
+  it('returns undefined when the service has no containers', async () => {
+    hoisted.resolveMode = 'no-containers';
+    const ctx = await call();
+    expect(ctx).toBeUndefined();
+    expect(hoisted.loadManifestCalls).toEqual([]);
+  });
+
+  it('returns undefined when the essential image is not a CDK asset (ECR pin)', async () => {
+    hoisted.resolveMode = 'non-cdk-asset';
+    const ctx = await call();
+    expect(ctx).toBeUndefined();
+    expect(hoisted.loadManifestCalls).toEqual([]);
+  });
+
+  it('returns undefined when a CDK-asset image has no assetHash', async () => {
+    hoisted.resolveMode = 'no-asset-hash';
+    const ctx = await call();
+    expect(ctx).toBeUndefined();
+    expect(hoisted.loadManifestCalls).toEqual([]);
+  });
+
+  it('returns undefined when the asset manifest file is missing (loadManifest → null)', async () => {
+    hoisted.manifest = null;
+    const ctx = await call();
+    expect(ctx).toBeUndefined();
+    // Loader WAS consulted — confirms we reached the manifest step.
+    expect(hoisted.loadManifestCalls.length).toBe(1);
+    expect(hoisted.loadManifestCalls[0]?.stackName).toBe('AppStack');
+  });
+
+  it('returns undefined when the asset hash is not in manifest.dockerImages', async () => {
+    hoisted.manifest = { version: '1.0.0', files: {}, dockerImages: {} };
+    const ctx = await call();
+    expect(ctx).toBeUndefined();
+    expect(hoisted.loadManifestCalls.length).toBe(1);
+  });
+
+  it('returns undefined for an executable-mode docker asset (no source.directory)', async () => {
+    hoisted.manifest = {
+      version: '1.0.0',
+      files: {},
+      dockerImages: {
+        newhash: {
+          displayName: 'WebTask:web',
+          source: { executable: ['my-builder.sh'] },
+          destinations: {},
+        },
+      },
+    };
+    const ctx = await call();
+    expect(ctx).toBeUndefined();
+    expect(hoisted.loadManifestCalls.length).toBe(1);
+  });
+
+  it('returns a complete ReloadAssetContext on the happy path (CDK asset + manifest hit)', async () => {
+    const ctx = await call();
+    expect(ctx).toEqual({
+      oldAssetHash: 'oldhash',
+      newAssetHash: 'newhash',
+      // Absolute path under the cdkOutDir + the manifest's source.directory.
+      newAssetSourceDir: '/tmp/cdk.out/asset.newhash',
+      // Defaults to 'Dockerfile' when manifest omits source.dockerFile.
+      dockerFile: 'Dockerfile',
+    });
+  });
+
+  it('omits oldAssetHash when the previously-booted image was not a CDK asset', async () => {
+    const ctx = await call({ oldHash: undefined });
+    expect(ctx).toBeDefined();
+    expect(ctx as Record<string, unknown>).not.toHaveProperty('oldAssetHash');
+    expect((ctx as { newAssetHash: string }).newAssetHash).toBe('newhash');
+  });
+
+  // Phase 4 follow-up (#218 code reviewer Nit #2) — oldAssetHash
+  // baseline now reads from the LIVE replica's
+  // `lastDeployedAssetHash` stamp (per-replica state) instead of
+  // `controller.service` (boot-time descriptor that never updates).
+  // After reload #1 swaps the replica's image, reload #2 reading the
+  // boot-time descriptor would see oldHash=A + newHash=B even when
+  // synth produced identical content for B — wasteful soft-reload.
+  // The per-replica stamp closes that loop.
+
+  it('reads oldAssetHash from the live replica stamp (post-rebuild reload sees current hash, not boot-time)', async () => {
+    // Simulate the state after a prior rebuild reload: the boot-time
+    // descriptor still carries the OLD hash, but the live replica
+    // has been rolled to a NEWER image and stamped accordingly.
+    const ctx = await call({ oldHash: 'oldhash-boottime', liveStamp: 'newhash' });
+    // The classifier guard `oldAssetHash === newAssetHash` now sees
+    // the LIVE hash matching the synth's hash → routes to rebuild
+    // (which is the correct "no-op" outcome instead of a wasteful
+    // soft-reload of identical bytes).
+    expect((ctx as { oldAssetHash: string }).oldAssetHash).toBe('newhash');
+  });
+
+  it('falls back to controller.service.task when the live stamp is missing (defensive)', async () => {
+    // Older host CLIs that hand-build run state without the
+    // `lastDeployedAssetHash` stamp should still get the boot-time
+    // descriptor's hash, not undefined.
+    const ctx = await call({ oldHash: 'oldhash', liveStamp: 'omit' });
+    expect((ctx as { oldAssetHash: string }).oldAssetHash).toBe('oldhash');
+  });
+
+  it('falls back to controller.service.task when the live stamp is explicitly undefined', async () => {
+    // A replica whose image isn't a CDK asset will stamp
+    // `lastDeployedAssetHash = undefined` (the helper returns
+    // undefined for ECR / public images). The loader should fall
+    // back to the boot-time descriptor in that case.
+    const ctx = await call({ oldHash: 'oldhash', liveStamp: undefined });
+    expect((ctx as { oldAssetHash: string }).oldAssetHash).toBe('oldhash');
+  });
+
+  it('normalizes a custom Dockerfile basename that includes a relative path', async () => {
+    hoisted.manifest = {
+      version: '1.0.0',
+      files: {},
+      dockerImages: {
+        newhash: {
+          displayName: 'WebTask:web',
+          source: { directory: 'asset.newhash', dockerFile: 'dockerfiles/Prod.Dockerfile' },
+          destinations: {},
+        },
+      },
+    };
+    const ctx = await call();
+    // The classifier compares against `path.basename(changedPath)`, so
+    // the loader MUST normalize before populating ctx — otherwise an
+    // edit to `dockerfiles/Prod.Dockerfile` would silently route to
+    // soft-reload.
+    expect((ctx as { dockerFile: string }).dockerFile).toBe('Prod.Dockerfile');
+  });
+});

--- a/tests/unit/local/ecs-service-runner-soft-reload.test.ts
+++ b/tests/unit/local/ecs-service-runner-soft-reload.test.ts
@@ -97,6 +97,7 @@ const {
   __setDockerInspectWorkdirImpl,
   __setDockerCpImpl,
   __setDockerRestartImpl,
+  SOFT_RELOAD_COMPLETION_LOG_SUFFIX,
 } = await import('../../../src/local/ecs-service-runner.js');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -497,6 +498,271 @@ describe('softReloadReplica (Phase 4 of issue #214)', () => {
 
     // No docker work ran — we failed before flipping the flag.
     expect(hoisted.inspectCalls).toEqual([]);
+
+    await controller.shutdown();
+  });
+
+  // Phase 4 follow-up (#218 test reviewer S3, S4) — branches inside
+  // the `containersToCycle` resolution that the existing test rows
+  // don't reach.
+
+  it('falls back to the first container when no container is flagged essential (mirrors the watcher picker)', async () => {
+    const pool = new FrontDoorEndpointPool();
+    const registry = new CloudMapRegistry();
+    const runState = createServiceRunState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = fakeOptions(pool, registry) as any;
+    const controller = await startEcsService(fakeService(), opts, runState);
+
+    // Cook a "new" service whose ONLY container is NOT flagged
+    // essential. The primitive should fall back to the first
+    // container in template order — same heuristic the watcher's
+    // `pickEssentialContainerId` uses.
+    const newService = fakeService();
+    newService.task.containers[0].essential = false;
+
+    await softReloadReplica({
+      controller,
+      oldReplicaIndex: 0,
+      newService,
+      sourceDirToCopy: '/tmp/cdk.out/asset.h',
+    });
+
+    // The single non-essential container is the one cycled.
+    expect(hoisted.inspectCalls.length).toBe(1);
+    expect(hoisted.cpCalls.length).toBe(1);
+    expect(hoisted.restartCalls.length).toBe(1);
+
+    await controller.shutdown();
+  });
+
+  it('throws "no containers to cycle" when the new service has zero containers', async () => {
+    const pool = new FrontDoorEndpointPool();
+    const registry = new CloudMapRegistry();
+    const runState = createServiceRunState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = fakeOptions(pool, registry) as any;
+    const controller = await startEcsService(fakeService(), opts, runState);
+
+    // Cook a "new" service descriptor with an EMPTY containers
+    // array. Should never happen in practice (the resolver guards
+    // earlier) but the defensive guard inside softReloadReplica
+    // needs to be locked so a future refactor doesn't drop it.
+    const newService = fakeService();
+    newService.task.containers = [];
+
+    await expect(
+      softReloadReplica({
+        controller,
+        oldReplicaIndex: 0,
+        newService,
+        sourceDirToCopy: '/tmp/cdk.out/asset.h',
+      })
+    ).rejects.toThrow(/no containers to cycle/);
+
+    // Failed BEFORE the flag flip and BEFORE the docker hooks fired.
+    expect(hoisted.inspectCalls).toEqual([]);
+    expect(hoisted.cpCalls).toEqual([]);
+    expect(hoisted.restartCalls).toEqual([]);
+
+    await controller.shutdown();
+  });
+
+  // Phase 4 follow-up (#218 test reviewer S5) — locks the watcher
+  // defer behavior at the unit level. The integ multi-replica
+  // fixture (2721 samples / FAIL=0) covers the end-to-end zero-
+  // refusal contract; this row makes the per-replica state machine
+  // verifiable without docker.
+  // Phase 4 follow-up (#218 code reviewer Nit #2) — the runner
+  // stamps `lastDeployedAssetHash` on the instance after a
+  // successful boot AND after a successful soft-reload re-publish.
+  // The emulator's classifier-context loader reads this stamp as
+  // the `oldAssetHash` baseline so the next reload sees the CURRENT
+  // image's hash, not the boot-time descriptor's.
+  // Phase 4 follow-up (#218 code reviewer Nit #4) — under docker
+  // daemon backpressure, `docker wait` can lag past the soft-
+  // reload's flag clear. The `softReloadGeneration` counter catches
+  // that case: the watcher snapshots it before waitForExitImpl and
+  // detects any mismatch on resume, treating it as a controlled
+  // restart even when the flag is already false.
+  it('bumps softReloadGeneration once per soft-reload entry (watcher race protection)', async () => {
+    const pool = new FrontDoorEndpointPool();
+    const registry = new CloudMapRegistry();
+    const runState = createServiceRunState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = fakeOptions(pool, registry) as any;
+    const controller = await startEcsService(fakeService(), opts, runState);
+    const r0 = controller.runState.replicas[0]!;
+
+    // Boot default: counter is undefined OR 0.
+    expect(r0.softReloadGeneration ?? 0).toBe(0);
+
+    await softReloadReplica({
+      controller,
+      oldReplicaIndex: 0,
+      newService: fakeService(),
+      sourceDirToCopy: '/tmp/cdk.out/asset.h',
+    });
+    expect(r0.softReloadGeneration).toBe(1);
+
+    await softReloadReplica({
+      controller,
+      oldReplicaIndex: 0,
+      newService: fakeService(),
+      sourceDirToCopy: '/tmp/cdk.out/asset.h',
+    });
+    expect(r0.softReloadGeneration).toBe(2);
+
+    await controller.shutdown();
+  });
+
+  it('stamps lastDeployedAssetHash after a successful soft-reload (closes the chatty oldHash loop)', async () => {
+    const pool = new FrontDoorEndpointPool();
+    const registry = new CloudMapRegistry();
+    const runState = createServiceRunState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = fakeOptions(pool, registry) as any;
+    // Pre-test: the fakeService() helper declares the essential
+    // image as `image: undefined` (no asset metadata) — bootReplica
+    // stamps undefined. Cook a service whose container carries a
+    // hash so we can prove the stamp lands after a soft-reload.
+    const svc = fakeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (svc.task.containers[0] as any).image = {
+      kind: 'cdk-asset',
+      assetHash: 'boothash',
+    };
+    const controller = await startEcsService(svc, opts, runState);
+    const r0 = controller.runState.replicas[0]!;
+    // Boot stamp lands.
+    expect(r0.lastDeployedAssetHash).toBe('boothash');
+
+    const newSvc = fakeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (newSvc.task.containers[0] as any).image = {
+      kind: 'cdk-asset',
+      assetHash: 'newhash-after-reload',
+    };
+
+    await softReloadReplica({
+      controller,
+      oldReplicaIndex: 0,
+      newService: newSvc,
+      sourceDirToCopy: '/tmp/cdk.out/asset.h',
+    });
+
+    // Post-soft-reload stamp updated.
+    expect(r0.lastDeployedAssetHash).toBe('newhash-after-reload');
+
+    await controller.shutdown();
+  });
+
+  it('stamps lastDeployedAssetHash = undefined when the new image is not a CDK asset', async () => {
+    const pool = new FrontDoorEndpointPool();
+    const registry = new CloudMapRegistry();
+    const runState = createServiceRunState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = fakeOptions(pool, registry) as any;
+    const svc = fakeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (svc.task.containers[0] as any).image = {
+      kind: 'cdk-asset',
+      assetHash: 'boothash',
+    };
+    const controller = await startEcsService(svc, opts, runState);
+    const r0 = controller.runState.replicas[0]!;
+    expect(r0.lastDeployedAssetHash).toBe('boothash');
+
+    const newSvc = fakeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (newSvc.task.containers[0] as any).image = {
+      kind: 'ecr',
+      uri: 'public.ecr.aws/foo:bar',
+    };
+
+    await softReloadReplica({
+      controller,
+      oldReplicaIndex: 0,
+      newService: newSvc,
+      sourceDirToCopy: '/tmp/cdk.out/asset.h',
+    });
+
+    // Non-CDK-asset image → stamp cleared to undefined; the loader
+    // will fall back to the boot-time descriptor (and the
+    // classifier will route subsequent reloads to rebuild because
+    // there's no asset to soft-reload anyway).
+    expect(r0.lastDeployedAssetHash).toBeUndefined();
+
+    await controller.shutdown();
+  });
+
+  // Phase 4 follow-up (#218 test reviewer N4) — exported constant
+  // for the integ scripts' grep target. The runner's emit MUST stay
+  // bound to this constant; the constant itself MUST stay bound to
+  // the grep regex in `tests/integration/local-start-service-watch-fast/verify.sh`
+  // and the path-agnostic regex in the watch-multi / alb-watch
+  // fixtures. A wording change in the runner that doesn't update the
+  // constant trips this row.
+  it('exposes SOFT_RELOAD_COMPLETION_LOG_SUFFIX matching the integ-script grep contract', () => {
+    expect(SOFT_RELOAD_COMPLETION_LOG_SUFFIX).toBe(
+      'restart + TCP-ready probe complete; Cloud Map + front-door re-published.'
+    );
+    // The integ scripts grep for this fragment as a regex
+    // (`Soft-reloaded replica .*restart \+ TCP-ready probe complete`);
+    // confirm the constant CONTAINS that fragment so a future tweak
+    // to the constant (e.g. dropping the semicolon) doesn't silently
+    // break the integ regex.
+    expect(SOFT_RELOAD_COMPLETION_LOG_SUFFIX).toMatch(
+      /^restart \+ TCP-ready probe complete/
+    );
+  });
+
+  it('sets softReloadInProgress BEFORE docker cp and clears it AFTER the re-publish (watcher-defer contract)', async () => {
+    const observed: Array<{
+      step: 'inspect' | 'cp' | 'restart';
+      flag: boolean;
+    }> = [];
+    const pool = new FrontDoorEndpointPool();
+    const registry = new CloudMapRegistry();
+    const runState = createServiceRunState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = fakeOptions(pool, registry) as any;
+    const controller = await startEcsService(fakeService(), opts, runState);
+    const r0 = controller.runState.replicas[0]!;
+
+    // Re-install spies that capture the flag value at each step.
+    __setDockerInspectWorkdirImpl(async () => {
+      observed.push({ step: 'inspect', flag: !!r0.softReloadInProgress });
+      return '/app';
+    });
+    __setDockerCpImpl(async () => {
+      observed.push({ step: 'cp', flag: !!r0.softReloadInProgress });
+    });
+    __setDockerRestartImpl(async () => {
+      observed.push({ step: 'restart', flag: !!r0.softReloadInProgress });
+    });
+
+    expect(r0.softReloadInProgress).toBeFalsy(); // initial state
+
+    await softReloadReplica({
+      controller,
+      oldReplicaIndex: 0,
+      newService: fakeService(),
+      sourceDirToCopy: '/tmp/cdk.out/asset.h',
+    });
+
+    // The watcher's defer-loop polls this flag every 100ms. It MUST
+    // be true throughout the cp + restart window — otherwise a SIGTERM
+    // unblocking `docker wait` mid-window would fall through to the
+    // restart-on-exit branch and race against the in-flight restart.
+    expect(observed).toEqual([
+      { step: 'inspect', flag: true },
+      { step: 'cp', flag: true },
+      { step: 'restart', flag: true },
+    ]);
+    // And cleared on completion so the watcher's NEXT iteration can
+    // re-arm waitForExitImpl on the restarted container.
+    expect(r0.softReloadInProgress).toBe(false);
 
     await controller.shutdown();
   });


### PR DESCRIPTION
## Summary

Closes #218. Tackles the 6 deferred Phase 4 follow-up items from PR #219's 3-axis review in one PR with item-scoped diffs. **Zero behavior change** for end users — the only user-visible delta is fewer wasted `docker cp` operations on idempotent reloads.

## Items

### Test coverage gaps (test reviewer M1, M2, S3, S4, S5, N4)

1. **`loadAssetContextForTarget` unit coverage** — NEW `tests/unit/cli/ecs-service-emulator-load-asset-context.test.ts` locks the 6 fall-through branches + the catch arm. Each undefined-return path is exercised independently of the integ fixture, with mocked `resolveEcsServiceTarget` + `AssetManifestLoader`. The function is now `@internal`-exported for direct unit testability.

2. **`softReloadReplica` edge-case rows** — added to the existing test file:
   - The no-essential-fallback branch (every container `essential: false` → first container gets cycled).
   - The empty-`containersToCycle` throw path.
   - A watcher-defer contract row asserting `softReloadInProgress` is `true` at each docker step (inspect → cp → restart) in order, and `false` after re-publish.

3. **`SOFT_RELOAD_COMPLETION_LOG_SUFFIX`** — exported from `src/local/ecs-service-runner.ts` and re-exported from `src/internal.ts` (for host CLIs like cdkd that own their own integ scripts). Unit row binds the constant to the runner's emit AND to the integ scripts' grep regex prefix so a future reword stays detectable via the symbol import.

### Code review nits (code reviewer Nit #2, Nit #4)

4. **`ServiceReplicaInstance.lastDeployedAssetHash`** — new field, stamped after each successful `bootReplica` AND after each successful `softReloadReplica` re-publish, read by `loadAssetContextForTarget` as the `oldAssetHash` baseline. Closes the chatty-soft-reload-after-rebuild loop where reloads post-rebuild would see `oldHash=A` (boot-time descriptor) vs `newHash=B` (synth) even when B's content was identical to the running replica's current image (B), triggering a wasteful soft-reload of identical bytes. New pure helper `pickEssentialAssetHash` centralizes the "what's the live asset hash" lookup; the loader falls back to the boot-time descriptor when the stamp is missing (defensive for host CLIs that hand-build run state).

5. **`softReloadGeneration` counter** — new monotonic counter incremented at each `softReloadReplica` entry; `watchReplica` snapshots it before `waitForExitImpl` and detects any mismatch on resume. Closes the watcher race where docker daemon backpressure could lag `docker wait` past the soft-reload's flag clear, causing the watcher to enter the restart-policy branch against a healthy, just-re-registered container.

## Test plan

- [x] `vp run check` + `vp run build` — clean (no lint / format / type / build errors).
- [x] `vp test run` — **1834 unit tests pass** (up from 1813 on main; 21 new rows). Includes the new file + the extended soft-reload test file.
- [x] Integ regression: `tests/integration/local-start-service-watch-fast/` — fast path arm (`verdict=soft-reload` + sub-second v1→v2) and rebuild fallback arm (`verdict=rebuild (Dockerfile edit ...)` + v1→v3) both still green. Clean teardown (zero leftover containers / networks).
- [x] Multi-replica behavior unchanged — the per-replica state machine additions (`softReloadGeneration`, `lastDeployedAssetHash`) are additive and orthogonal to the rolling primitive's sequencing.

## cdkd parity (Category 3)

- One new public helper exported from `src/internal.ts`: `SOFT_RELOAD_COMPLETION_LOG_SUFFIX`. JSDoc explicitly names the host-CLI use case (integ scripts grep against the constant instead of hand-copying the wording).
- No new subcommand factory, no new CLI option.
- Behavior change is purely internal (chatty → correct on idempotent reloads). User-visible log lines and verdict surface are unchanged.

## Files touched

- `src/local/ecs-service-runner.ts` — new fields + exports + race protection.
- `src/cli/commands/ecs-service-emulator.ts` — `loadAssetContextForTarget` exported as `@internal`; reads `lastDeployedAssetHash` from the live replica.
- `src/internal.ts` — re-exports `SOFT_RELOAD_COMPLETION_LOG_SUFFIX`.
- `tests/unit/cli/ecs-service-emulator-load-asset-context.test.ts` (NEW).
- `tests/unit/local/ecs-service-runner-soft-reload.test.ts` (extended).

Closes #218.
