### PR TITLE
docs: sharpen standalone value + document --env-vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cdkl invoke MyStack/Fn --from-cfn-stack    # one Lambda against real DynamoDB / 
 
 ## Why cdk-local
 
-- **Zero-friction local execution** — run standalone with just Docker and your CDK app, no AWS account needed. Onboard a new engineer or review a PR by actually running its code, exercising the parts that don't touch AWS:
+- **Zero-friction local execution** — run standalone with just Docker and your CDK app, no AWS account or deploy needed. Verify the parts of your app that don't touch AWS in seconds — handy as a zero-setup first run, or in CI where no credentials are available:
   - API Gateway routing and request shaping
   - Lambda authorizers, running in real local containers
   - pure handler logic — validation, transforms, branching

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ cdkl invoke MyStack/Fn --from-cfn-stack    # one Lambda against real DynamoDB / 
 
 ## Why cdk-local
 
-- **Zero-friction local execution** — run standalone: no deploy, just Docker and your CDK app. Onboard new engineers, or review a PR by actually running its code.
+- **Zero-friction local execution** — run standalone with just Docker and your CDK app, no AWS account needed. Onboard a new engineer or review a PR by actually running its code, exercising the parts that don't touch AWS:
+  - API Gateway routing and request shaping
+  - Lambda authorizers, running in real local containers
+  - pure handler logic — validation, transforms, branching
 - **Iterate against your real deployed stack — including its data.** `--from-cfn-stack` reads the deployed CloudFormation stack and injects its real ARNs, Secret values, and IAM credentials into the container — no `.env` file to maintain, no manual ARN copy-paste — so you stay on the real DynamoDB rows, S3 objects, Cognito users, and Secret values your IAM credentials reach. An offline emulator can fake the API surface, but you'd still own the cost of seeding it:
   - dumping production data into a local DB
   - mirroring Secret values into local Secrets Manager
@@ -67,6 +70,23 @@ cdkl list                                      # every runnable target, grouped 
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
 Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.md](docs/cli-reference.md) and [docs/local-emulation.md](docs/local-emulation.md).
+
+### Environment variables — `--env-vars`
+
+Every command accepts `--env-vars <file>`, a SAM-shape JSON file that overlays the container's environment — point a handler at a different backend for a local run, or supply a value the synthesized template only knows as an intrinsic:
+
+```bash
+cdkl invoke MyStack/Fn --env-vars ./env.json
+```
+
+```json
+{
+  "Parameters": { "LOG_LEVEL": "debug" },
+  "MyStack/Fn": { "TABLE_ENDPOINT": "http://localhost:8000" }
+}
+```
+
+`Parameters` applies to every function; a key matching a function's CDK path or CloudFormation logical ID overrides just that one. Precedence is template literals < `Parameters` < function-specific, and a `null` value clears a variable. Running standalone, env vars whose template value is an intrinsic (`Ref` / `Fn::GetAtt`) can't be resolved without a deployed stack and are dropped with a warning — `--env-vars` is how you supply a concrete value for them.
 
 ### Hot reload — `--watch`
 


### PR DESCRIPTION
## What

Two README changes, docs-only, no behavior change.

### 1. Sharpen the standalone value (Why cdk-local)

The "Zero-friction" bullet named *who* benefits (onboarding, PR review) but not *what* you can actually verify without AWS — and those human scenarios oversold the no-AWS mode (most handlers fail at their first SDK call without credentials, and onboarding / PR review are really the `--from-cfn-stack` story). Reframed the bullet around its honest value — fast, zero-setup verification of the AWS-free parts, plus the credential-less CI / first-run case — with a concrete sub-list:

- API Gateway routing and request shaping
- Lambda authorizers, running in real local containers
- pure handler logic — validation, transforms, branching

### 2. Document `--env-vars` (new subsection under Commands)

The flag was undocumented in the README despite being available on every command. The new "Environment variables — `--env-vars`" subsection covers:

- the SAM-shape file: `Parameters` (global) vs function-specific keys (CDK path or logical ID), precedence (template literals < `Parameters` < function-specific), and `null`-to-clear
- the two payoffs — redirecting a handler's backend for a local run, and supplying concrete values for intrinsic-valued env vars that standalone synth drops with a warning

The example passes `--env-vars ./env.json` (a file path) with the JSON shown in a separate block, avoiding the inline-JSON-as-flag-value footgun.

## Notes

- Standalone coverage is exercised by the existing `tests/integration/local-start-api` test (no `--from-cfn-stack`): route discovery, curl smoke, Lambda authorizer deny/allow, and request classification. `--env-vars` itself is covered by `local-invoke` (Parameters + display-path keys), `local-invoke-python` / `-ruby` / `-container`, and `local-invoke-agentcore`. No new tests needed.

https://claude.ai/code/session_01QEA4DruxTVzMKbJn3UuoGS