### PR TITLE
docs: add README section for `--from-cfn-stack` shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ cdkl list                                      # every runnable target, grouped 
 
 Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.md](docs/cli-reference.md) and [docs/local-emulation.md](docs/local-emulation.md).
 
+### Deployed stack binding — `--from-cfn-stack`
+
+`--from-cfn-stack` binds to the deployed CloudFormation stack whose name matches your CDK stack. The bare form resolves the stack name from the target; pass an explicit name only when the deployed CFn stack name differs (e.g. CDK's `stackName` prop was overridden):
+
+```bash
+cdkl invoke MyStack/Fn --from-cfn-stack                              # bare: uses resolved stack name
+cdkl invoke MyStack/Fn --from-cfn-stack MyExplicitCfnName            # explicit when names differ
+cdkl invoke MyStack/Fn --from-cfn-stack --stack-region eu-west-1     # cross-region CFn client
+cdkl invoke MyStack/Fn --from-cfn-stack --assume-role                # auto-assume deployed execution role
+```
+
+Substitutes `Ref` / `Fn::ImportValue` / `Fn::GetStackOutput` in env vars with the deployed physical IDs / exports, decrypts `AWS::SSM::Parameter::Value` entries (kept off the `docker run` argv), and resolves same-stack ECR `ContainerUri` to the deployed image. `Fn::GetAtt` in the Lambda's own env is recovered from the deployed function's resolved `Environment.Variables` via `lambda:GetFunctionConfiguration`. Full resolution rules: [docs/cli-reference.md#cloudformation-driven-env-recovery---from-cfn-stack](docs/cli-reference.md#cloudformation-driven-env-recovery---from-cfn-stack).
+
 ### Environment variables — `--env-vars`
 
 Every command accepts `--env-vars <file>`, a SAM-shape JSON file that overlays the container's environment — point a handler at a different backend for a local run, or supply a value the synthesized template only knows as an intrinsic:


### PR DESCRIPTION
## Summary

- Add a `### Deployed stack binding — \`--from-cfn-stack\`` subsection to README.md, parallel to the existing `--env-vars` one.
- `--from-cfn-stack` is the headline value prop, but the README only showed the bare form. The optional explicit-name argument (`--from-cfn-stack [cfn-stack-name]`), the cross-region `--stack-region`, and the auto-assume-role pairing (bare `--assume-role` resolving the deployed `RoleArn` from the state source) were all docs-only.
- The new block covers the four useful shapes in a single code fence (bare / explicit name / cross-region / auto-assume) and a one-line summary of what gets substituted: `Ref` / `Fn::ImportValue` / `Fn::GetStackOutput` in env vars, decrypted SSM `AWS::SSM::Parameter::Value` entries (kept off the `docker run` argv), same-stack ECR `ContainerUri`, and `Fn::GetAtt` recovery via `lambda:GetFunctionConfiguration` for the Lambda's own env.
- Links to [docs/cli-reference.md#cloudformation-driven-env-recovery---from-cfn-stack](docs/cli-reference.md#cloudformation-driven-env-recovery---from-cfn-stack) for the full resolution rules — same anchor the docs table at L223 already uses.

## Test plan

- [x] `vp run check` (typecheck + lint + format) — pass
- [x] `vp run build` — pass
- [x] `vp test run` — 120 files / 1834 tests pass
- [x] Live-test: `node dist/cli.js invoke --help` confirms `--from-cfn-stack [cfn-stack-name]`, `--stack-region <region>`, and `--assume-role [arn]` are all present with the spellings the README uses.
- [x] Anchor `#cloudformation-driven-env-recovery---from-cfn-stack` resolves to the existing `### CloudFormation-driven env recovery (\`--from-cfn-stack\`)` heading at [docs/cli-reference.md:249](docs/cli-reference.md#L249).
