### PR TITLE
feat(start-alb): explain which fields were evaluated in the no-rule-matched 404

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -77,6 +77,8 @@ import { FrontDoorEndpointPool } from '../../local/front-door-pool.js';
 import {
   startFrontDoorServer,
   type FrontDoorDispatchTarget,
+  type FrontDoorRuleConditionSummary,
+  type FrontDoorRuleSummary,
   type StartedFrontDoorServer,
   type RouteAction,
   type WeightedForwardTarget,
@@ -1609,6 +1611,10 @@ export async function buildFrontDoor(
       const tls = listener.protocol === 'HTTPS' && wantTls ? tlsMaterials : undefined;
       const forwardedProto: 'http' | 'https' = listener.protocol === 'HTTPS' ? 'https' : 'http';
       const degradedHttps = listener.protocol === 'HTTPS' && !wantTls;
+      // Per-listener rule summary surfaced in the no-rule-matched 404 body so a
+      // user whose request missed on (say) the Host header sees every rule's
+      // condition + action target, not just the request path (issue #228).
+      const rulesSummary: FrontDoorRuleSummary[] = listener.rules.map(buildRuleSummary);
       const server = await startFrontDoorServer({
         route,
         port: listener.hostPort,
@@ -1616,6 +1622,7 @@ export async function buildFrontDoor(
         listenerPort: listener.listenerPort,
         label: `listener port ${listener.listenerPort}`,
         forwardedProto,
+        rulesSummary,
         ...(tls ? { tls } : {}),
       });
       servers.push(server);
@@ -1729,6 +1736,80 @@ function describeTarget(t: PlannedForwardTarget): string {
 /** One forward target, described compactly (for a weighted-forward banner). */
 function describeTargetShort(t: PlannedForwardTarget): string {
   return t.kind === 'lambda' ? `Lambda ${t.lambda.logicalId}` : t.serviceTarget;
+}
+
+/**
+ * Build the per-rule summary the front-door surfaces in its no-rule-matched
+ * 404 body (issue #228). One condition row per constrained ALB field, plus a
+ * pre-formatted action target. Distinct from {@link describeConditions} /
+ * {@link describeAction} (which produce a single-line boot-banner string) —
+ * the 404 body needs the rule decomposed into its constituent fields so the
+ * formatter can render `field in [values]` rows.
+ */
+function buildRuleSummary(rule: {
+  priority: number;
+  pathPatterns: string[];
+  hostPatterns: string[];
+  httpHeaderConditions: AlbHttpHeaderCondition[];
+  httpRequestMethods: string[];
+  queryStringConditions: AlbQueryStringCondition[];
+  sourceIpCidrs: string[];
+  action: PlannedAction;
+}): FrontDoorRuleSummary {
+  const conditions: FrontDoorRuleConditionSummary[] = [];
+  if (rule.pathPatterns.length > 0) {
+    conditions.push({ field: 'path-pattern', values: rule.pathPatterns });
+  }
+  if (rule.hostPatterns.length > 0) {
+    conditions.push({ field: 'host-header', values: rule.hostPatterns });
+  }
+  for (const h of rule.httpHeaderConditions) {
+    conditions.push({ field: 'http-header', values: [`${h.name}: ${h.values.join(', ')}`] });
+  }
+  if (rule.httpRequestMethods.length > 0) {
+    conditions.push({ field: 'http-request-method', values: rule.httpRequestMethods });
+  }
+  if (rule.queryStringConditions.length > 0) {
+    conditions.push({
+      field: 'query-string',
+      values: rule.queryStringConditions.map(describeQueryStringCondition),
+    });
+  }
+  if (rule.sourceIpCidrs.length > 0) {
+    conditions.push({ field: 'source-ip', values: rule.sourceIpCidrs });
+  }
+  return {
+    priority: rule.priority,
+    conditions,
+    action: describeRuleActionForSummary(rule.action),
+  };
+}
+
+/**
+ * Describe a planned action for the no-rule-matched 404 body (issue #228).
+ * Uses the `<ECS: ...>` / `<Lambda: ...>` shape the issue body proposes so a
+ * user can read each rule's target at a glance.
+ */
+function describeRuleActionForSummary(action: PlannedAction): string {
+  if (action.kind === 'redirect') return `redirect ${action.statusCode}`;
+  if (action.kind === 'fixed-response') return `fixed-response ${action.statusCode}`;
+  if (action.targets.length === 1) {
+    return `forward to ${describeForwardTargetForSummary(action.targets[0]!)}`;
+  }
+  const weights = action.targets
+    .map((t) => `${describeForwardTargetForSummary(t)}@${t.weight}`)
+    .join(', ');
+  return `forward weighted [${weights}]`;
+}
+
+/**
+ * One forward target named the way the 404 body shows it: `<ECS: Service>` or
+ * `<Lambda: LogicalId>` — distinct from the boot-banner format (which also
+ * prints the container / port / round-robin hint) so the 404 body stays
+ * scannable.
+ */
+function describeForwardTargetForSummary(t: PlannedForwardTarget): string {
+  return t.kind === 'lambda' ? `<Lambda: ${t.lambda.logicalId}>` : `<ECS: ${t.serviceTarget}>`;
 }
 
 async function resolvePlaceholderAccount(arn: string, region: string | undefined): Promise<string> {

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -188,6 +188,47 @@ export interface FrontDoorRouteRequest {
   sourceIp?: string;
 }
 
+/**
+ * One condition row of a {@link FrontDoorRuleSummary}, surfaced in the
+ * no-rule-matched 404 body so the user can see at a glance what each rule
+ * expects on every ALB condition field. `field` names the ALB condition
+ * field; `values` are the human-readable match values for it (the call site
+ * pre-formats them — e.g. `["X-API: v1, v2"]` for an `http-header` row,
+ * `["k=v"]` for a `query-string` row).
+ */
+export interface FrontDoorRuleConditionSummary {
+  /** The ALB condition field this row describes. */
+  field:
+    | 'path-pattern'
+    | 'host-header'
+    | 'http-header'
+    | 'http-request-method'
+    | 'query-string'
+    | 'source-ip';
+  /** Pre-formatted match values for the field (length >= 1). */
+  values: string[];
+}
+
+/**
+ * A summary of one listener rule, surfaced in the no-rule-matched 404 body so
+ * the user can spot at a glance which rule they were close to matching and on
+ * which ALB condition field. The call site fills this in once at server start;
+ * the front-door reads it at 404 time. Diagnostics-only — the matcher itself
+ * does not consume this.
+ */
+export interface FrontDoorRuleSummary {
+  /** Rule priority (lower = evaluated first). */
+  priority: number;
+  /** One entry per ALB condition field the rule constrains (empty = catch-all). */
+  conditions: FrontDoorRuleConditionSummary[];
+  /**
+   * Pre-formatted action target (e.g. `forward to <ECS: BackendApi>`,
+   * `redirect 301`, `fixed-response 404`). The call site produces this so the
+   * front-door does not need to know the planner's target-naming convention.
+   */
+  action: string;
+}
+
 export interface StartFrontDoorServerOptions {
   /**
    * Resolve the action to serve a request, given its path + Host header.
@@ -237,6 +278,16 @@ export interface StartFrontDoorServerOptions {
    * client gets a 504. Defaults to {@link DEFAULT_UPSTREAM_TIMEOUT_MS}.
    */
   upstreamTimeoutMs?: number;
+  /**
+   * Per-listener rule summary, surfaced in the no-rule-matched 404 body so the
+   * 404 body spells out which fields were evaluated (method, host, path) AND
+   * every rule's priority + conditions + action target. Without this the body
+   * only names the request path, which misleads a debugging user when the
+   * actual non-matching condition was the Host header, an HTTP method, a query
+   * string, or a source IP (see issue #228). Optional — when absent, the 404
+   * body falls back to the original path-only shape.
+   */
+  rulesSummary?: FrontDoorRuleSummary[];
 }
 
 /** Default per-request upstream timeout — a hung replica yields a 504, not a hang. */
@@ -457,13 +508,71 @@ function reply404(
   res: ServerResponse,
   opts: StartFrontDoorServerOptions
 ): Promise<void> {
-  writeError(
-    res,
-    404,
-    `No listener rule matched '${req.url ?? '/'}' on ${opts.label}, and the listener has no ` +
+  writeError(res, 404, buildNoRuleMatched404Body(req, opts));
+  return Promise.resolve();
+}
+
+/**
+ * Build the no-rule-matched 404 body. When the call site supplied a
+ * {@link StartFrontDoorServerOptions.rulesSummary}, the body lists every
+ * ALB condition field that WAS evaluated (method, host, path) plus every
+ * configured rule's priority + conditions + action target — so a user
+ * whose request missed on, say, the Host header can spot the mismatch
+ * without inspecting the synthesized template. Header conditions are
+ * NOT spelled out in the evaluated section (too noisy) but ARE listed
+ * in each rule's condition row when the rule constrains them. Without a
+ * summary the body falls back to the original path-only shape (preserves
+ * the behavior for direct callers that wire the proxy with just a
+ * `selectPool` / `selectTarget`).
+ */
+function buildNoRuleMatched404Body(
+  req: IncomingMessage,
+  opts: StartFrontDoorServerOptions
+): string {
+  const requestPath = req.url ?? '/';
+  const summary = opts.rulesSummary;
+  if (!summary) {
+    return (
+      `No listener rule matched '${requestPath}' on ${opts.label}, and the listener has no ` +
+      'default action forwarding to a local target.'
+    );
+  }
+
+  const rawHost = req.headers.host;
+  const hostValue = Array.isArray(rawHost) ? rawHost[0] : rawHost;
+  const lines: string[] = [];
+  lines.push(
+    `No listener rule matched the request on ${opts.label}, and the listener has no ` +
       'default action forwarding to a local target.'
   );
-  return Promise.resolve();
+  lines.push('');
+  lines.push('  Evaluated:');
+  lines.push(`    Method:  ${req.method ?? '(unknown)'}`);
+  lines.push(`    Host:    ${hostValue ?? '(no Host header)'}`);
+  lines.push(`    Path:    ${requestPath}`);
+  lines.push('');
+
+  if (summary.length === 0) {
+    lines.push('  Listener has 0 rule(s).');
+  } else {
+    lines.push(`  Listener has ${summary.length} rule(s):`);
+    // Display by priority order so the user reads them in evaluation order;
+    // ties keep the supplied order (stable sort).
+    const ordered = [...summary].sort((a, b) => a.priority - b.priority);
+    for (const rule of ordered) {
+      const conditions =
+        rule.conditions.length === 0
+          ? '(no condition)'
+          : rule.conditions.map(formatRuleConditionSummary).join(' AND ');
+      lines.push(`    [priority=${rule.priority}] ${conditions}  -> ${rule.action}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Format one condition row of a {@link FrontDoorRuleSummary} for the 404 body. */
+function formatRuleConditionSummary(c: FrontDoorRuleConditionSummary): string {
+  return `${c.field} in [${c.values.join(', ')}]`;
 }
 
 function handlePoolRequest(

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -13,6 +13,7 @@ import {
   type StartedFrontDoorServer,
   type RouteAction,
   type RedirectRouteAction,
+  type FrontDoorRuleSummary,
 } from '../../../src/local/front-door-server.js';
 import { matchAlbPathRule, type AlbPathRule } from '../../../src/local/alb-path-matcher.js';
 import {
@@ -231,6 +232,136 @@ describe('startFrontDoorServer', () => {
     const res = await fetchText(front.port, '/nope');
     expect(res.status).toBe(404);
     expect(res.body).toMatch(/No listener rule matched/);
+  });
+
+  it('404 body spells out evaluated fields + every rule when rulesSummary is supplied (issue #228)', async () => {
+    // The trap this fixes: a curl from 127.0.0.1:<port> hits a listener whose
+    // only rule gates on host-header. Without the rule summary the 404 body
+    // names only the path, so the user spends time debugging path patterns
+    // that don't exist. With rulesSummary, the body lists method/host/path
+    // AND every rule's [priority] field-in-[values] -> action target.
+    const rulesSummary: FrontDoorRuleSummary[] = [
+      {
+        priority: 1,
+        conditions: [{ field: 'host-header', values: ['api.example.com'] }],
+        action: 'forward to <ECS: BackendApi>',
+      },
+      {
+        priority: 2,
+        conditions: [
+          { field: 'path-pattern', values: ['/admin/*'] },
+          { field: 'http-request-method', values: ['POST'] },
+        ],
+        action: 'redirect 301',
+      },
+    ];
+    const front = await startFrontDoorServer({
+      route: () => undefined,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 443,
+      label: 'listener port 443',
+      rulesSummary,
+    });
+    cleanups.push(() => front.close());
+
+    const res = await fetchTextWithHost(front.port, '/graphql', '127.0.0.1:8443');
+    expect(res.status).toBe(404);
+    // Evaluated section: every value the route resolver was handed.
+    expect(res.body).toMatch(/Evaluated:/);
+    expect(res.body).toMatch(/Method:\s+GET/);
+    expect(res.body).toMatch(/Host:\s+127\.0\.0\.1:8443/);
+    expect(res.body).toMatch(/Path:\s+\/graphql/);
+    // Per-rule summary: priority + condition rows (every constrained ALB
+    // field) + the action target.
+    expect(res.body).toMatch(/Listener has 2 rule\(s\):/);
+    expect(res.body).toMatch(
+      /\[priority=1\] host-header in \[api\.example\.com\]\s+-> forward to <ECS: BackendApi>/
+    );
+    expect(res.body).toMatch(
+      /\[priority=2\] path-pattern in \[\/admin\/\*\] AND http-request-method in \[POST\]\s+-> redirect 301/
+    );
+  });
+
+  it('404 body falls back to the path-only shape when rulesSummary is omitted', async () => {
+    // Direct callers wiring the proxy with just a selectPool / selectTarget
+    // (no rulesSummary) keep the original behavior — the enriched body opts
+    // in via the new field, so this is a binding test for the fallback.
+    const front = await startFrontDoorServer({
+      route: () => undefined,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+      // no rulesSummary
+    });
+    cleanups.push(() => front.close());
+
+    const res = await fetchText(front.port, '/anywhere');
+    expect(res.status).toBe(404);
+    expect(res.body).toMatch(/No listener rule matched '\/anywhere' on listener port 80/);
+    // The enriched sections are absent.
+    expect(res.body).not.toMatch(/Evaluated:/);
+    expect(res.body).not.toMatch(/Listener has/);
+  });
+
+  it('404 body sorts rules by priority + handles an empty-rules listener', async () => {
+    // Empty rulesSummary still drops the path-only shape — the user gets the
+    // evaluated-fields section and a "Listener has 0 rule(s)." line, which is
+    // a clearer diagnosis than "no path matched".
+    const front = await startFrontDoorServer({
+      route: () => undefined,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+      rulesSummary: [],
+    });
+    cleanups.push(() => front.close());
+
+    const res = await fetchText(front.port);
+    expect(res.status).toBe(404);
+    expect(res.body).toMatch(/Evaluated:/);
+    expect(res.body).toMatch(/Listener has 0 rule\(s\)\./);
+  });
+
+  it('404 body orders rules by priority regardless of input order', async () => {
+    // The summary may arrive in any order; the body must render lowest
+    // priority first so the user reads them in evaluation order.
+    const rulesSummary: FrontDoorRuleSummary[] = [
+      {
+        priority: 30,
+        conditions: [{ field: 'path-pattern', values: ['/c/*'] }],
+        action: 'forward to <ECS: C>',
+      },
+      {
+        priority: 10,
+        conditions: [{ field: 'path-pattern', values: ['/a/*'] }],
+        action: 'forward to <ECS: A>',
+      },
+      {
+        priority: 20,
+        conditions: [{ field: 'path-pattern', values: ['/b/*'] }],
+        action: 'forward to <ECS: B>',
+      },
+    ];
+    const front = await startFrontDoorServer({
+      route: () => undefined,
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+      rulesSummary,
+    });
+    cleanups.push(() => front.close());
+
+    const res = await fetchText(front.port);
+    const aIdx = res.body.indexOf('priority=10');
+    const bIdx = res.body.indexOf('priority=20');
+    const cIdx = res.body.indexOf('priority=30');
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(bIdx).toBeGreaterThan(aIdx);
+    expect(cIdx).toBeGreaterThan(bIdx);
   });
 
   it('routes through the real matchAlbPathRule honoring rule priority (no default -> 404)', async () => {


### PR DESCRIPTION
## Summary

The ALB front-door's no-rule-matched 404 body previously named only the
request path, even when the actual non-matching condition was the Host
header, an HTTP method, a query string, or a source IP. A first-time
user reading that message starts debugging path patterns that don't
exist on any rule.

Surface the values that were evaluated (method, host, path) AND a
per-rule summary (priority, every constrained ALB condition field, and
action target) so the user can spot at a glance which rule they were
close to matching and on which field they missed:

```
No listener rule matched the request on listener port 80, and the listener has no default action forwarding to a local target.

  Evaluated:
    Method:  GET
    Host:    127.0.0.1:18228
    Path:    /graphql

  Listener has 2 rule(s):
    [priority=1] host-header in [api.example.com]  -> forward to <ECS: Issue228LiveTest:BackendApi>
    [priority=2] path-pattern in [/admin/*] AND http-request-method in [POST]  -> redirect 301
```

Threaded via a new optional `rulesSummary` field on
`StartFrontDoorServerOptions`. When the field is absent (direct callers
that wire the proxy with just a `selectPool` / `selectTarget`), the
body falls back to the original path-only shape — opt-in by the call
site, no behavior change for non-ALB consumers.

Closes #228

## Behavior change

The no-rule-matched 404 body format is now multi-line and no longer
embeds the request path in the first sentence. The original shape was
`No listener rule matched '<path>' on <label>, ...`; the new shape is
`No listener rule matched the request on <label>, ...` followed by the
`Evaluated:` and `Listener has N rule(s):` sections. Any host CLI that
pinned diagnostics on the literal-path substring in the first line
will need to read the `Path:` row inside the `Evaluated:` section
instead.

## Test plan

- [x] Unit tests cover the enriched body shape (issue #228 scenario),
      the fallback when `rulesSummary` is omitted, an empty-rules
      listener, and priority-order rendering across out-of-order input.
- [x] `vp run check` (typecheck + lint + format) passes.
- [x] `vp test run` — 120 files / 1838 tests pass.
- [x] `vp run build` succeeds.
- [x] `bash tests/integration/local-start-alb/verify.sh` passes
      (Docker-driven; clean teardown).
- [x] Live-tested against a one-off fixture exercising the issue's
      exact repro (listener with empty `DefaultActions[]` + two rules:
      host-header `api.example.com`, path `/admin/*` + method `POST`):
  - `curl http://127.0.0.1:<port>/graphql` -> 404 with the new
    Evaluated + per-rule summary body.
  - `curl -X POST http://127.0.0.1:<port>/admin/dashboard` ->
    matched priority-2 rule, 301 redirect to `admin.example.com`.
  - `curl -H 'Host: api.example.com' http://127.0.0.1:<port>/`
    -> 200 forwarded to the ECS replica (proves the host-header rule
    still wins when matched, no routing regression).
  - `curl -X POST -H 'Host: api.example.com' http://127.0.0.1:<port>/admin/foo`
    -> priority-1 host-header rule wins over priority-2 (forwarded to
    ECS), proving priority order is preserved.
