### PR TITLE
docs: tabulate --env-vars override key shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,16 @@ cdkl start-alb MyStack/MyAlb --env-vars ./env.json
 }
 ```
 
-`Parameters` applies to every target; a per-target key matches a Lambda's CDK path / logical ID, or an ECS container's `ContainerDefinitions[].Name`. Precedence is template literals < ECS `Secrets` < `Parameters` < target-specific, so a value sourced from Secrets Manager / SSM via a TaskDefinition `Secrets[]` entry is overridable here (the secret is still fetched first, then replaced). A `null` value clears a variable. Running standalone, env vars whose template value is an intrinsic (`Ref` / `Fn::GetAtt`) can't be resolved without a deployed stack and are dropped with a warning — `--env-vars` is how you supply a concrete value for them.
+Each top-level JSON key picks which target to overlay:
+
+| Target | Key shape | Notes |
+| --- | --- | --- |
+| Every target | `Parameters` | Reserved literal; applied first to every container |
+| Lambda / AgentCore Runtime | CDK construct path (e.g. `MyStack/Fn`) | From `Metadata['aws:cdk:path']` of the resource; prefix-matched (`MyStack/Fn` also catches `MyStack/Fn/Resource`) |
+| Lambda / AgentCore Runtime | CloudFormation logical ID (e.g. `MyStackFn1A2B3C`) | Top-level resource key in the synthesized template; exact match |
+| ECS container | Container Name (e.g. `AppContainer`) | The `containerName` set in CDK (= `ContainerDefinitions[].Name`). The TaskDefinition's CDK path / logical ID is NOT accepted as a key — it would identify the TaskDef but not which container's env block to overlay |
+
+Precedence is template literals < ECS `Secrets` < `Parameters` < target-specific, so a value sourced from Secrets Manager / SSM via a TaskDefinition `Secrets[]` entry is overridable here (the secret is still fetched first, then replaced). A `null` value clears a variable. Running standalone, env vars whose template value is an intrinsic (`Ref` / `Fn::GetAtt`) can't be resolved without a deployed stack and are dropped with a warning — `--env-vars` is how you supply a concrete value for them.
 
 When pointing a container at a tunneled VPC resource (e.g. an Aurora cluster reached via a local port forward), use `host.docker.internal` instead of `127.0.0.1` — `127.0.0.1` inside the container is the container itself, not the host where the tunnel listens.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -246,6 +246,23 @@ Standard Lambda runtime env vars are always set:
 `AWS_LAMBDA_LOG_GROUP_NAME`, `AWS_LAMBDA_LOG_STREAM_NAME`. The
 handler's `context.*` fields look real.
 
+### `--env-vars` override keys
+
+Each top-level JSON key in an `--env-vars` file picks which target to
+overlay. The matching rules differ between Lambda / AgentCore (whose
+construct path and logical ID both identify a single env block) and
+ECS (whose env block lives inside a container element of the
+TaskDefinition, not at the resource level):
+
+| Target | Key shape | Match rule |
+| --- | --- | --- |
+| Every target | `Parameters` | Reserved literal; applied first to every container before any per-target overlay |
+| Lambda / AgentCore Runtime | CDK construct path (e.g. `MyStack/Fn`) | Compared against the resource's `Metadata['aws:cdk:path']`; prefix-matched so `MyStack/Fn` also catches the synthesized `MyStack/Fn/Resource` |
+| Lambda / AgentCore Runtime | CloudFormation logical ID (e.g. `MyStackFn1A2B3C`) | Compared against the synthesized top-level resource key in the template; exact match |
+| ECS container | Container Name (e.g. `AppContainer`) | Compared against `ContainerDefinitions[].Name` (= the `containerName` set in CDK); exact match. The TaskDefinition's own CDK path / logical ID is NOT accepted — it would identify the TaskDef but not which container's env block to overlay |
+
+A `null` value clears a key (across every shape above).
+
 ### CloudFormation-driven env recovery (`--from-cfn-stack`)
 
 For CDK apps deployed via the upstream CDK CLI (`cdk deploy` →


### PR DESCRIPTION
## Summary

Replace the prose listing of per-target `--env-vars` key shapes with a small table, in both the README and `docs/cli-reference.md`.

Surfaced by a real user question in a debugging session: why does ECS use `ContainerDefinitions[].Name` while Lambda uses CDK path / logical ID, and can the TaskDefinition's own CDK path / logical ID also be used? The table answers both at a glance.

| Target | Key shape | Notes |
| --- | --- | --- |
| Every target | `Parameters` | Reserved literal; applied first |
| Lambda / AgentCore Runtime | CDK construct path (e.g. `MyStack/Fn`) | `Metadata['aws:cdk:path']`; prefix-matched |
| Lambda / AgentCore Runtime | CloudFormation logical ID (e.g. `MyStackFn1A2B3C`) | Synthesized top-level resource key; exact match |
| ECS container | Container Name (e.g. `AppContainer`) | `ContainerDefinitions[].Name`. The TaskDef's CDK path / logical ID is NOT accepted — it would identify the TaskDef but not which container's env block to overlay |

The asymmetry is structural — Lambda / AgentCore are "resource = single env block" so a resource-level identifier resolves the overlay target unambiguously; ECS is "resource = N containers each with its own env block" so a TaskDef-level identifier cannot pick a container.

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) — clean
- [x] `vp run build` — succeeds
- [x] `vp test run` — 1834 / 120 pass
- [x] Diff scope is purely `README.md` + `docs/cli-reference.md`; no src / tests / hooks touched
- [x] Re-read the table claims against the implementation:
      - Lambda / AgentCore matching: [`src/local/env-resolver.ts:93-117`](src/local/env-resolver.ts#L93-L117) (exact logical ID OR exact display path OR prefix-match `displayPath.startsWith(key + '/')`)
      - ECS matching: [`src/local/ecs-task-runner.ts:1187-1190`](src/local/ecs-task-runner.ts#L1187-L1190) (exact on `container.name`)
