### PR TITLE
docs: rewrite --env-vars precedence + null example + --from-cfn-stack combo

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cdkl start-alb MyStack/MyAlb --env-vars ./env.json
 ```json
 {
   "Parameters": { "LOG_LEVEL": "debug" },
-  "MyStack/Fn": { "TABLE_ENDPOINT": "http://localhost:8000" },
+  "MyStack/Fn": { "TABLE_ENDPOINT": "http://localhost:8000", "PROD_FEATURE_FLAG": null },
   "AppContainer": { "DB_HOST": "host.docker.internal", "DB_PORT": "13306" }
 }
 ```
@@ -109,9 +109,11 @@ Each top-level JSON key picks which target to overlay:
 | Every target | `Parameters` | Reserved literal; applied first to every container |
 | Lambda / AgentCore Runtime | CDK construct path (e.g. `MyStack/Fn`) | From `Metadata['aws:cdk:path']` of the resource; prefix-matched (`MyStack/Fn` also catches `MyStack/Fn/Resource`) |
 | Lambda / AgentCore Runtime | CloudFormation logical ID (e.g. `MyStackFn1A2B3C`) | Top-level resource key in the synthesized template; exact match |
-| ECS container | Container Name (e.g. `AppContainer`) | The `containerName` set in CDK (= `ContainerDefinitions[].Name`). The TaskDefinition's CDK path / logical ID is NOT accepted as a key — it would identify the TaskDef but not which container's env block to overlay |
+| ECS container | Container Name (e.g. `AppContainer`) | `ContainerDefinitions[].Name` in the synthesized TaskDefinition — explicitly set via the `containerName` option of `taskDef.addContainer(id, { containerName, ... })`, or defaults to the construct id (first arg of `addContainer`) when omitted. The TaskDefinition's CDK path / logical ID is NOT accepted as a key — it would identify the TaskDef but not which container's env block to overlay |
 
-Precedence is template literals < ECS `Secrets` < `Parameters` < target-specific, so a value sourced from Secrets Manager / SSM via a TaskDefinition `Secrets[]` entry is overridable here (the secret is still fetched first, then replaced). A `null` value clears a variable. Running standalone, env vars whose template value is an intrinsic (`Ref` / `Fn::GetAtt`) can't be resolved without a deployed stack and are dropped with a warning — `--env-vars` is how you supply a concrete value for them.
+`--env-vars` overlays the env block after the template's literals and any resolved ECS `Secrets[]` have been applied. A per-target key (from the table above) wins over `Parameters`. A `null` value clears the key — use the JSON literal `null`, not the string `"null"`.
+
+`--env-vars` can be combined with `--from-cfn-stack`: the latter resolves intrinsics (`Ref` / `Fn::ImportValue` / `Fn::GetStackOutput` / `Fn::GetAtt`) against the deployed stack first, then `--env-vars` overlays your overrides on top. Running standalone (no `--from-cfn-stack`), env vars whose template value is an intrinsic can't be resolved and are dropped with a warning — `--env-vars` is how you supply a concrete value for them.
 
 When pointing a container at a tunneled VPC resource (e.g. an Aurora cluster reached via a local port forward), use `host.docker.internal` instead of `127.0.0.1` — `127.0.0.1` inside the container is the container itself, not the host where the tunnel listens.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -259,9 +259,17 @@ TaskDefinition, not at the resource level):
 | Every target | `Parameters` | Reserved literal; applied first to every container before any per-target overlay |
 | Lambda / AgentCore Runtime | CDK construct path (e.g. `MyStack/Fn`) | Compared against the resource's `Metadata['aws:cdk:path']`; prefix-matched so `MyStack/Fn` also catches the synthesized `MyStack/Fn/Resource` |
 | Lambda / AgentCore Runtime | CloudFormation logical ID (e.g. `MyStackFn1A2B3C`) | Compared against the synthesized top-level resource key in the template; exact match |
-| ECS container | Container Name (e.g. `AppContainer`) | Compared against `ContainerDefinitions[].Name` (= the `containerName` set in CDK); exact match. The TaskDefinition's own CDK path / logical ID is NOT accepted — it would identify the TaskDef but not which container's env block to overlay |
+| ECS container | Container Name (e.g. `AppContainer`) | Compared against `ContainerDefinitions[].Name` in the synthesized TaskDefinition (= the `containerName` option of `taskDef.addContainer(id, { containerName, ... })`, or the construct id (first arg of `addContainer`) when omitted); exact match. The TaskDefinition's own CDK path / logical ID is NOT accepted — it would identify the TaskDef but not which container's env block to overlay |
 
-A `null` value clears a key (across every shape above).
+`--env-vars` overlays the env block after the template's literals and
+any resolved ECS `Secrets[]` have been applied. A per-target key wins
+over `Parameters`. A `null` value clears the key (across every shape
+above) — use the JSON literal `null`, not the string `"null"`.
+
+`--env-vars` is composable with `--from-cfn-stack`: the latter resolves
+intrinsics (`Ref` / `Fn::ImportValue` / `Fn::GetStackOutput` /
+`Fn::GetAtt`) against the deployed stack first, then `--env-vars`
+overlays your overrides on top.
 
 ### CloudFormation-driven env recovery (`--from-cfn-stack`)
 


### PR DESCRIPTION
## Summary

Tighten the `--env-vars` section in the README and `docs/cli-reference.md`. Surfaced by a debugging session where the existing prose hid four separate readability problems:

1. **Muddled precedence sentence.** The line `template literals < ECS Secrets < Parameters < target-specific` compared four items that live in two different layers (CFn-side: template Environment literals + Secrets[]; --env-vars-side: Parameters + per-target). It also re-litigated the Environment vs Secrets ordering, which is ECS's concern, not cdk-local's. The new copy frames `--env-vars` purely as an overlay applied on top of whatever the template + resolved Secrets produced, and only the overlay-internal precedence (per-target > Parameters) is cdk-local-owned.
2. **No `null` example.** The prose said "a `null` value clears a variable" but did not show it in the JSON snippet — reader could reasonably ask "the literal `null` or the string `"null"`?". Now the snippet has `"PROD_FEATURE_FLAG": null` and a prose pointer that it must be the JSON literal.
3. **`containerName` optionality unclear.** The Container Name row described the key as "the `containerName` set in CDK", which read as if `containerName` had to be explicitly set. In practice it is optional — when omitted, CDK uses the construct id (first arg of `addContainer`) as the default, and the synthesized `ContainerDefinitions[].Name` is always populated. Spelled out the default branch.
4. **`--from-cfn-stack` + `--env-vars` combinability not surfaced.** The two flags are designed to compose (`--from-cfn-stack` resolves intrinsics against the deployed stack, then `--env-vars` overlays your overrides on top) but the README's `--env-vars` section never said so. Added a one-paragraph pointer.

## Test plan

- [x] `vp check --fix` — clean (typecheck + lint + format)
- [x] `vp run build` — succeeds
- [x] `vp test run` — 1838 / 120 pass
- [x] Diff scope is purely `README.md` + `docs/cli-reference.md`; no src / tests / hooks touched
- [x] Re-read the new claims against implementation:
      - `containerName` default to construct id: confirmed in CDK's `ContainerDefinition` constructor (`this.containerName = props.containerName ?? this.node.id`)
      - `--env-vars` overlays after Secrets: [`src/local/ecs-task-runner.ts:1184-1190`](src/local/ecs-task-runner.ts#L1184-L1190)
      - `--env-vars` composable with `--from-cfn-stack`: `cdkl invoke` walkthrough at `docs/cli-reference.md:286-296`
