### PR TITLE
docs: rewrite start-service vs start-alb — surface the simple-app-logic case

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,20 @@ Full reload pipeline + glob defaults: [docs/local-emulation.md#hot-reload---watc
 
 ### start-service vs start-alb — which one?
 
-`start-service` runs just the ECS service's replicas (workers, queue consumers, Service-Connect-only). `start-alb` boots the ECS service(s) behind an ALB **plus** a host-side front-door on each listener port — HTTP, and HTTPS served over plain HTTP locally by default (with `X-Forwarded-Proto: https` preserved so the upstream app still sees `https`); pass `--tls` (or `--tls-cert` / `--tls-key`) to terminate TLS locally — so external traffic reaches them the way it does in the cloud. Full resolution model: [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
+Most CDK ECS apps boot multiple replicas behind an ALB. cdk-local exposes each layer separately so you can target the slice you care about:
+
+| Goal | Command | How to reach |
+|---|---|---|
+| App logic / DB / response shape — hit the handler directly | `cdkl start-service --max-tasks 1 --host-port 80=8080` | `curl http://127.0.0.1:8080/...` |
+| ALB routing — listener rules, host-header / path / method, default actions, redirects, fixed-response, weighted forwards, authenticate-cognito / authenticate-oidc | `cdkl start-alb --lb-port 443=8443` | `curl -H 'Host: api.example.com' http://127.0.0.1:8443/...` |
+| Multi-replica rolling-reload + Cloud Map service discovery | `cdkl start-service` (multi-replica default) | Sibling container on the `cdkl-svc-` network |
+
+**Why the extra flags on the simple case?** The template's `DesiredCount` (typically 3 in production) is honored locally by default, but N replicas can't all bind the same host port — so `start-service` skips host publishing for multi-replica runs and the app is reachable only from inside the `cdkl-svc-` docker network. To get the simple `curl http://127.0.0.1:...` access path:
+
+- `--max-tasks 1` clamps the local replica count to 1 without touching your CDK code.
+- `--host-port <containerPort>=<hostPort>` remaps the container port to a non-privileged host port (macOS Docker Desktop needs `sudo` for ports < 1024).
+
+`start-alb` uses the symmetric `--lb-port <listenerPort>=<hostPort>` for privileged listener ports like 80 / 443, and `--tls` (or `--tls-cert` / `--tls-key`) to terminate TLS locally instead of serving the HTTPS listener over plain HTTP (the default). Full resolution model: [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
 
 ## Supported resources
 


### PR DESCRIPTION
## Summary

Rewrite the existing `start-service vs start-alb — which one?` README section to surface the most common ECS dev path that the prior copy hid: "I just want to hit my app handler and check it."

The prior single-paragraph copy described what each command does but did not name the dev path's required flags. With the template's `DesiredCount` honored locally (typically 3), `cdkl start-service` falls into the multi-replica "no host port published" mode (host-port conflict across N replicas), and the user has no `curl http://127.0.0.1:...` path without knowing about `--max-tasks 1 --host-port`.

The new shape is goal-oriented:

- 3-row table (app logic / ALB routing / multi-replica + Cloud Map) with the exact command + access pattern per row.
- An explanation block naming `--max-tasks 1`, `--host-port <containerPort>=<hostPort>`, and the symmetric `--lb-port <listenerPort>=<hostPort>` for `start-alb`'s privileged listener ports.
- The cli-reference deep-model link moved to the end of the explanation so the reader can jump for the front-door rules / TLS / weighted forwards detail.

## Test plan

- [x] `vp check --fix` — clean
- [x] `vp run build` — succeeds
- [x] `vp test run` — 1877 / 126 pass
- [x] Diff scope is purely `README.md`; no src / tests / hooks / cli-reference touched
- [x] Re-read the claims against implementation:
      - `start-service` skips host-port publish when replica count > 1: [src/local/ecs-service-runner.ts:751](src/local/ecs-service-runner.ts#L751) (`skipHostPortPublish = replicaCount > 1`)
      - `--max-tasks` clamps `DesiredCount` locally: [src/cli/commands/ecs-service-emulator.ts:2177-2186](src/cli/commands/ecs-service-emulator.ts#L2177-L2186)
      - `--host-port <containerPort>=<hostPort>` exists on `start-service`: [src/cli/commands/local-start-service.ts:131-140](src/cli/commands/local-start-service.ts#L131-L140)
      - `--lb-port <listenerPort>=<hostPort>` exists on `start-alb` with default 1:1: [src/cli/commands/local-start-alb.ts:42-70,242](src/cli/commands/local-start-alb.ts#L42-L70)
