### PR TITLE
fix(source-change-classifier): default TypeScript edits to rebuild (precompile setups left stale by soft-reload)

### DIFF
--- a/src/local/source-change-classifier.ts
+++ b/src/local/source-change-classifier.ts
@@ -150,11 +150,22 @@ const REBUILD_TRIGGER_BASENAMES: ReadonlySet<string> = new Set([
  * `mvn package` etc.). A copy of the source alone would leave the
  * running binary stale, so the user's intent must be a rebuild.
  *
- * Interpreted-language runtimes (Node — `.js` / `.mjs` / `.cjs` /
- * `.ts` when transpiled at runtime, Python — `.py`, Ruby — `.rb`,
- * shell — `.sh`) read source at process start, so a `docker cp` +
- * `docker restart` cycle picks them up. Those extensions are
- * NOT in this set.
+ * TypeScript source (`.ts` / `.tsx` / `.mts` / `.cts`) is treated as
+ * compiled because the dominant production-container pattern is to
+ * pre-compile the source via a Dockerfile `RUN tsc` / `RUN yarn build`
+ * step, with the runtime executing the emitted `dist/*.js`. Soft-reload
+ * would `docker cp` the new `.ts` into the container's WORKDIR while
+ * the running process keeps reading the OLD `dist/` — a silent
+ * stale-code failure that violates the file's "slow-but-correct beats
+ * fast-but-stale" default policy (lines 14-22). Setups that transpile
+ * at runtime lose the soft-reload fast path under this default; an
+ * opt-in flag to restore it is a possible follow-up but is not in
+ * scope here.
+ *
+ * Interpreted-language runtimes (Node — `.js` / `.mjs` / `.cjs`,
+ * Python — `.py`, Ruby — `.rb`, shell — `.sh`) read source at process
+ * start, so a `docker cp` + `docker restart` cycle picks them up.
+ * Those extensions are NOT in this set.
  */
 const COMPILED_LANGUAGE_EXTENSIONS: ReadonlySet<string> = new Set([
   '.go',
@@ -179,6 +190,12 @@ const COMPILED_LANGUAGE_EXTENSIONS: ReadonlySet<string> = new Set([
   '.elm',
   '.hs',
   '.dart',
+  // TypeScript — pre-compiled to `dist/*.js` inside `docker build`
+  // by the dominant production pattern; see the JSDoc above.
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
 ]);
 
 /**

--- a/tests/unit/local/source-change-classifier.test.ts
+++ b/tests/unit/local/source-change-classifier.test.ts
@@ -152,6 +152,19 @@ describe('classifySourceChange', () => {
     'Main.elm',
     'Main.hs',
     'main.dart',
+    // TypeScript — treated as compiled because the dominant
+    // production-container pattern is to pre-compile to `dist/*.js`
+    // inside a Dockerfile `RUN tsc` / `RUN yarn build` step. A
+    // `docker cp` of the new `.ts` would leave the running process
+    // reading the OLD `dist/` — a silent stale-code failure (issue
+    // #235). The 4 variants (`.ts` / `.tsx` / `.mts` / `.cts`)
+    // are all enumerated below so a future refactor that drops one
+    // trips a test instead of silently re-introducing the bug for
+    // that variant.
+    'app.ts',
+    'App.tsx',
+    'app.mts',
+    'app.cts',
   ])(
     'returns rebuild for compiled-language source: %s (soft-reload would leave the binary stale)',
     (basename) => {
@@ -177,7 +190,7 @@ describe('classifySourceChange', () => {
     expect(v.reason).toContain('Prod.Dockerfile');
   });
 
-  it.each(['.sh', '.js', '.mjs', '.cjs', '.ts', '.py', '.rb'])(
+  it.each(['.sh', '.js', '.mjs', '.cjs', '.py', '.rb'])(
     'returns soft-reload for an interpreted-language source: handler%s',
     (ext) => {
       const v = classifySourceChange([`/repo/webapp/handler${ext}`], baseCtx);


### PR DESCRIPTION
## Symptom

A CDK ECS service whose Dockerfile pre-compiles `src/*.ts` -> `dist/*.js` (e.g. `RUN yarn build` / `RUN tsc`) and runs `CMD ["dist/src/index.js"]`. Under `cdkl start-service --watch` / `cdkl start-alb --watch`, editing `src/index.ts` triggers:

```
Detected source change (1 path(s)); reloading service(s)...
Reload of '...': verdict=soft-reload (...).
Reload of '...': soft-reloading N replica(s) one at a time (docker cp source -> docker restart -> TCP-ready probe; no rebuild).
Soft-reloaded replica r0 (gen N): ...
Reload complete.
```

The new TS source is `docker cp`'d into the container's WORKDIR (`/app/src/index.ts`), but the running process is `node dist/src/index.js` -- the OLD compiled JS baked during `docker build`. New source never reflects at runtime. Silent stale-code failure.

## Root cause

`src/local/source-change-classifier.ts`'s `COMPILED_LANGUAGE_EXTENSIONS` set excluded `.ts` / `.tsx` / `.mts` / `.cts`. The accompanying JSDoc justified the exclusion as "`.ts` when transpiled at runtime" -- assuming ts-node / tsx / `--experimental-strip-types`. For a project that pre-compiles via a Dockerfile RUN step, that assumption is wrong.

This violates the classifier's own stated policy (file header lines 14-22):

> DEFAULT to `'rebuild'` whenever classification is ambiguous. A slow-but-correct reload is strictly better than a fast-but-stale one.

`.ts` is genuinely ambiguous (could be transpiled at runtime OR pre-compiled), so per the policy it must default to `'rebuild'`.

## Change

- Added `.ts` / `.tsx` / `.mts` / `.cts` to `COMPILED_LANGUAGE_EXTENSIONS` in `src/local/source-change-classifier.ts`.
- Updated the JSDoc on the set to (a) state TypeScript is treated as compiled because the dominant production-container pattern is to pre-compile via a Dockerfile `RUN tsc` / `RUN yarn build` step, (b) acknowledge the trade-off, (c) drop the stale "`.ts` when transpiled at runtime" justification.
- Added 4 new classifier test rows -- one per extension -- locking the rebuild verdict, and removed `.ts` from the interpreted-language soft-reload row so the spec stays consistent.

## Trade-off

ts-node / tsx / `--experimental-strip-types` runtime-transpile users lose the sub-second soft-reload fast path on a `.ts` edit. Their reload goes through the Phase 1-3 rebuild rolling primitive instead (multi-second). This is acceptable per the classifier's "slow-but-correct" stated policy -- the cost of a few extra seconds is paid only by runtime-transpile users, and the alternative is silent stale-code for everyone else.

## Follow-up

An opt-in flag (e.g. `--soft-reload-typescript`) could restore the sub-second fast path on demand for runtime-transpile users if anyone hits it. Out of scope for this PR -- the immediate fix is the safe default.

## Scope notes

Scope intentionally narrow: only `src/local/source-change-classifier.ts` (the set + the JSDoc) and the classifier's existing test file (4 new rows + 1 removal from the soft-reload row). Does not touch `src/cli/commands/ecs-service-emulator.ts` or anything reload-orchestration related -- that is the scope of a parallel PR (issue #234).

Closes #235
