### PR TITLE
fix(start-service,start-alb): warn + skip noop --watch when image is pinned to a deployed registry

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,9 +61,19 @@ AWS managed services.
   port observes zero connection refusals across the reload (Phase 1 +
   Phase 2 + Phase 3 of issue #214; the soft-reload path is similarly
   per-replica sequenced). The classifier defaults to rebuild on
-  any ambiguity (target isn't a CDK docker-image asset, asset manifest
-  unreadable, unrecognized change) — slow-but-correct beats
-  fast-but-stale. The host front-door (TLS materials, JWKS cache,
+  any ambiguity (asset manifest unreadable, unrecognized change) —
+  slow-but-correct beats fast-but-stale. The one ambiguity-default
+  the reload pathway pre-empts is "target image is not a CDK docker-
+  image asset" (deployed-registry pin under `--from-cfn-stack`
+  against `ContainerImage.fromEcrRepository(...)`, or a public-
+  registry pin): the rolling primitive would re-pull byte-identical
+  content and surface `Reload complete.` as a silent no-op, so the
+  reload SKIPS the roll for that target with a `Reload skipped for
+  '<target>' (no-op): image pinned to deployed registry; no local
+  rebuild possible.` log, and the same configuration triggers a
+  loud boot-time WARN per affected target so the user knows local
+  source edits will not take effect before they spend time saving
+  files (issue #234). The host front-door (TLS materials, JWKS cache,
   Lambda-target RIE containers, listener sockets) is built once at
   boot and is NOT recreated on reload — only the per-service replica
   pool entries rotate. Lambda target groups behind the ALB are a
@@ -207,7 +217,12 @@ compute-locally category for Lambda + API Gateway).
   rebuild on ambiguity, requires the asset hash to actually flip
   before returning soft-reload so a CDK construct edit that changed
   the task spec doesn't get silently soft-reloaded with the OLD
-  spec), front-door-server (host HTTP / HTTPS reverse proxy
+  spec), image-pin-detector (issue #234 — classifies a booted ECS
+  service's representative image as local CDK asset vs deployed-
+  registry pin so the `--watch` emulator can WARN at boot and SKIP
+  the no-op rolling primitive on each reload firing instead of
+  re-pulling byte-identical content and surfacing `Reload complete.`
+  as a silent no-op), front-door-server (host HTTP / HTTPS reverse proxy
   that resolves a per-request RouteAction — weighted forward to a
   replica pool or a Lambda invoke, redirect, or fixed-response — behind
   the ALB listener port; HTTPS branch flips `X-Forwarded-Proto` and the

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1482,12 +1482,32 @@ and routes the firing through one of two per-replica primitives:
   retire-old. The reload-log line surfaces the verdict as
   `verdict=rebuild (...)` naming the trigger.
 
-The classifier defaults to `rebuild` on ANY ambiguity (target image
-isn't a CDK docker-image asset, asset manifest can't be loaded,
-unrecognized change). A slow-but-correct reload is strictly better
-than a fast-but-stale one — a missed Dockerfile / dependency edit
-would leave the running container on the previous image while the
-source files said otherwise.
+The classifier defaults to `rebuild` on ANY ambiguity (asset manifest
+can't be loaded, unrecognized change). A slow-but-correct reload is
+strictly better than a fast-but-stale one — a missed Dockerfile /
+dependency edit would leave the running container on the previous
+image while the source files said otherwise.
+
+The one ambiguity-default the reload pathway pre-empts is "target
+image is not a CDK docker-image asset" (typical under
+`--from-cfn-stack` against a service whose CDK source uses
+`ContainerImage.fromEcrRepository(repo, tag)`, or a hand-pinned
+public-registry image): the rolling primitive would re-pull
+byte-identical content from the deployed registry on every save and
+surface `Reload complete.` even though nothing in the running
+container changed — a silent no-op disguised as success. To avoid
+that footgun (issue #234), the reload SKIPS the roll for such
+targets with a `Reload skipped for '<target>' (no-op): image pinned
+to deployed registry; no local rebuild possible.` log on each
+firing, and the same configuration triggers a loud boot-time WARN
+per affected target naming the pinned image URI so the user knows
+local source edits will not take effect before they spend time
+saving files. To iterate on local source for an ECR-pinned service,
+drop `--from-cfn-stack` and switch the CDK app to
+`ContainerImage.fromAsset(...)`. Env / Secrets diff propagation
+under `--from-cfn-stack` (a watcher firing legitimately picking up
+a flipped deployed env value for an ECR-pinned target) is a
+follow-up — today the skip is total.
 
 Known fast-path limitations (Phase 4 trade-offs):
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -101,6 +101,7 @@ import {
 import type { FrontDoorAuthGuard } from '../../local/elb-front-door-resolver.js';
 import { buildAuthCheck } from '../../local/front-door-auth.js';
 import { createJwksCache } from '../../local/cognito-jwt.js';
+import { describePinnedImageUri, isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
 
 /**
  * Neutral ECS-service emulator orchestration shared by `cdkl start-service`
@@ -655,6 +656,34 @@ export async function runEcsServiceEmulator(
     logEndpointsBanner(perTarget, frontDoorServers, logger);
     logger.info('Press ^C to shut down.');
 
+    // Issue #234 — when `--watch` is set, warn per booted target whose
+    // representative container image is NOT a local CDK docker-image
+    // asset. Such targets resolve to a deployed-registry pin (ECR via
+    // `--from-cfn-stack` against `ContainerImage.fromEcrRepository(...)`,
+    // or a public-registry pin like `ContainerImage.fromRegistry(...)`).
+    // The rolling primitive would re-pull byte-identical content on
+    // each save and report `Reload complete.` even though nothing in
+    // the running container changed — a silent no-op disguised as
+    // success. Warn UP-FRONT (per target) so the user knows local
+    // source edits will not take effect before they spend time saving
+    // files. The reload pathway also skips the no-op roll (see
+    // `reloadAllServices`); this boot-time warn is the proactive half.
+    if (options.watch === true && strategy.supportsWatch === true) {
+      for (const pt of perTarget) {
+        const service = pt.controller?.service;
+        if (!service) continue;
+        if (isLocalCdkAssetImage(service)) continue;
+        const pinnedUri = describePinnedImageUri(service);
+        const uriDisplay = pinnedUri ? `\`${pinnedUri}\`` : 'a deployed registry';
+        logger.warn(
+          `'${pt.boot.target}': \`--watch\` will not pick up local source changes — ` +
+            `running image is pinned to a deployed registry (${uriDisplay}). ` +
+            'To iterate on local source, drop `--from-cfn-stack` and switch the ' +
+            'CDK app to `ContainerImage.fromAsset(...)`.'
+        );
+      }
+    }
+
     // Phase 1 + Phase 2 + Phase 3 of issue #214 — `cdkl start-service --watch`
     // (Phases 1-2) and `cdkl start-alb --watch` (Phase 3) source-tree
     // watcher. Both `serviceStrategy()` and `albStrategy()` opt in via
@@ -923,6 +952,34 @@ async function reloadAllServices(args: {
         kind: 'rebuild',
         reason: 'classifier context unavailable; falling back to rebuild',
       };
+    }
+    // Issue #234 — when the classifier returns `rebuild` with the
+    // "target image is not a CDK docker-image asset" reason, the
+    // rolling primitive would re-pull a byte-identical deployed
+    // image (ECR pin / public-registry pin — typical under
+    // `--from-cfn-stack` against `ContainerImage.fromEcrRepository
+    // (...)`). The roll docker-pulls the same bytes, swaps, retires
+    // the old replica — a no-op disguised as `Reload complete.`.
+    // Skip the roll for THIS target; the boot-time WARN already
+    // told the user this `--watch` configuration can't pick up
+    // local source changes. The rest of the per-target loop still
+    // rolls peer targets whose images ARE local CDK assets.
+    //
+    // Follow-up (out of scope for #234): env / Secrets diff under
+    // `--from-cfn-stack` is the one signal a reload could
+    // legitimately propagate here (deployed stack flipped a
+    // SecureString / env value); plumb a fast-path env-only reload
+    // for ECR-pinned targets so a watcher firing can still apply
+    // such changes without booting a shadow container.
+    if (
+      verdict.kind === 'rebuild' &&
+      verdict.reason === 'target image is not a CDK docker-image asset'
+    ) {
+      logger.info(
+        `Reload skipped for '${newBoot.target}' (no-op): image pinned to deployed ` +
+          'registry; no local rebuild possible.'
+      );
+      continue;
     }
     await rollOneTarget({
       controller,

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -668,7 +668,15 @@ export async function runEcsServiceEmulator(
     // source edits will not take effect before they spend time saving
     // files. The reload pathway also skips the no-op roll (see
     // `reloadAllServices`); this boot-time warn is the proactive half.
-    if (options.watch === true && strategy.supportsWatch === true) {
+    //
+    // The `--watch` gate (`options.watch === true && strategy.supportsWatch
+    // === true`) is hoisted into a single const so the boot-time WARN
+    // block + the watcher-wiring block downstream can never drift out of
+    // sync, and so #238's planned "broaden the WARN to fire regardless of
+    // `--watch`" follow-up is a one-line delta against the predicate
+    // instead of two.
+    const watchActive = options.watch === true && strategy.supportsWatch === true;
+    if (watchActive) {
       for (const pt of perTarget) {
         const service = pt.controller?.service;
         if (!service) continue;
@@ -691,7 +699,7 @@ export async function runEcsServiceEmulator(
     // this engine from getting `--watch` implicitly. The watcher reuses the
     // start-api debounced file-watcher and predicate composition verbatim so
     // cdk.json `watch.include` / `watch.exclude` semantics are identical.
-    if (options.watch === true && strategy.supportsWatch === true) {
+    if (watchActive) {
       const watchRoot = process.cwd();
       const { ignored, shouldTrigger, excludePatterns } = createWatchPredicates({
         watchRoot,
@@ -971,9 +979,23 @@ async function reloadAllServices(args: {
     // SecureString / env value); plumb a fast-path env-only reload
     // for ECR-pinned targets so a watcher firing can still apply
     // such changes without booting a shadow container.
+    //
+    // Narrow the skip to the actual "image is a deployed-registry
+    // pin" case. `loadAssetContextForTarget` returns `undefined` (and
+    // the classifier defaults to `rebuild` with the reason below) for
+    // SEVEN distinct conditions — only one of which is "image is not a
+    // CDK asset". The other six (no candidate stack, resolver throw,
+    // no containers in the synthed task, manifest unreadable, asset
+    // hash drift, executable-mode asset) are degradation / race paths
+    // where the rolling primitive should still try to run and surface
+    // the underlying failure to the user. We use the booted
+    // controller's resolved service as the ground truth for "the
+    // currently-running image is a pin", because that's what the
+    // skip-rationale ("re-pulling byte-identical content") rests on.
     if (
       verdict.kind === 'rebuild' &&
-      verdict.reason === 'target image is not a CDK docker-image asset'
+      verdict.reason === 'target image is not a CDK docker-image asset' &&
+      !isLocalCdkAssetImage(controller.service)
     ) {
       logger.info(
         `Reload skipped for '${newBoot.target}' (no-op): image pinned to deployed ` +

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -457,6 +457,19 @@ export {
  */
 export { SOFT_RELOAD_COMPLETION_LOG_SUFFIX } from './local/ecs-service-runner.js';
 export { createWatchPredicates, type WatchPredicates } from './cli/commands/local-start-api.js';
+
+/**
+ * Issue #234 — per-target image-kind classifier the
+ * `cdkl start-service --watch` / `cdkl start-alb --watch` reload
+ * pathway consults to detect "the deployed image is pinned to a
+ * registry, so a local source edit can't possibly take effect"
+ * upfront (boot-time WARN) and to skip a no-op rolling primitive on
+ * each reload firing. Host CLIs (cdkd) that wrap
+ * `runEcsServiceEmulator` reuse the same helpers so their `--watch`
+ * UX matches cdk-local's instead of silently inheriting the
+ * "Reload complete." disguised-no-op symptom.
+ */
+export { isLocalCdkAssetImage, describePinnedImageUri } from './local/image-pin-detector.js';
 export { resolveWatchConfig, type CdkWatchConfig } from './cli/config-loader.js';
 
 /**

--- a/src/local/image-pin-detector.ts
+++ b/src/local/image-pin-detector.ts
@@ -1,0 +1,83 @@
+import type { ResolvedEcsService } from './ecs-service-resolver.js';
+import type { ResolvedEcsImage } from './ecs-task-resolver.js';
+
+/**
+ * Issue #234 — detect whether a booted ECS service's representative
+ * container image is a local CDK docker-image asset (i.e. one the
+ * `--watch` reload pathway can actually rebuild from local source) or
+ * a deployed-registry pin (ECR / public registry) the rolling primitive
+ * would re-pull byte-identical from on every save.
+ *
+ * The "representative" container picks the first essential container,
+ * falling back to the first container if no container is marked
+ * essential — same heuristic {@link loadAssetContextForTarget} (the
+ * source-change classifier's context loader) uses for picking the
+ * image whose asset hash drives the rebuild-vs-soft-reload decision.
+ * Multi-essential tasks with mixed image kinds are rare; both call
+ * sites of this helper (the boot-time `--watch` warn + the reload-time
+ * skip guard) match on that same first-essential anchor so the
+ * verdict surfaced to the user aligns with what the classifier sees.
+ *
+ * Host-side use case: cdkd and other shim hosts that wrap
+ * `runEcsServiceEmulator` reuse this helper to produce the same
+ * boot-time WARN + reload-time skip diagnostics under `--watch` when
+ * the deployed image is pinned by `--from-cfn-stack` against a
+ * `ContainerImage.fromEcrRepository(...)` service. Without this
+ * helper a host would silently inherit the same no-op-disguised-as-
+ * success symptom issue #234 documents.
+ *
+ * @internal — not part of the semver-covered public surface; exposed
+ * via `cdk-local/internal` only. The stable entry point for hosts is
+ * the emulator (`runEcsServiceEmulator`); call this directly only if
+ * you need to reproduce the per-target image-kind classification.
+ */
+
+/**
+ * Returns the first essential container's image, falling back to the
+ * first container if none are marked essential. `undefined` when the
+ * service has no containers (degenerate; the resolver would have
+ * already warned).
+ */
+function representativeImage(service: ResolvedEcsService): ResolvedEcsImage | undefined {
+  const essential = service.task.containers.find((c) => c.essential) ?? service.task.containers[0];
+  return essential?.image;
+}
+
+/**
+ * Returns true when the service's representative container image is a
+ * local CDK docker-image asset (`ContainerImage.fromAsset(...)`-style)
+ * — i.e. the `--watch` reload pathway has a local source tree to
+ * rebuild from. Returns false when the image is an ECR pin
+ * (`ContainerImage.fromEcrRepository(repo, tag)`-style; typically
+ * surfaced under `--from-cfn-stack`) or a public-registry pin
+ * (`ContainerImage.fromRegistry('nginx:latest')`-style). In both
+ * "false" cases the rolling primitive would re-pull byte-identical
+ * content on every save and disguise a no-op as a successful reload.
+ *
+ * Mirrors the bail-out branch in {@link loadAssetContextForTarget}:
+ * when this returns false, the source-change classifier sees
+ * `undefined` for the asset context and returns
+ * `{ kind: 'rebuild', reason: 'target image is not a CDK docker-image asset' }`.
+ */
+export function isLocalCdkAssetImage(service: ResolvedEcsService): boolean {
+  const image = representativeImage(service);
+  return image !== undefined && image.kind === 'cdk-asset';
+}
+
+/**
+ * Returns a short human-readable label for the deployed-registry URI
+ * the representative container image is pinned to, or `undefined`
+ * when the image IS a local CDK asset (in which case the boot-time
+ * warn does not fire). For `ecr` images this surfaces the full
+ * `<acct>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>` URI; for
+ * `public` images this surfaces the registry URI as-is
+ * (e.g. `public.ecr.aws/foo/bar:tag` or `nginx:latest`). The boot-time
+ * warn includes this so the user can see which image is pinning the
+ * service to a no-source-edit-pickup configuration.
+ */
+export function describePinnedImageUri(service: ResolvedEcsService): string | undefined {
+  const image = representativeImage(service);
+  if (!image) return undefined;
+  if (image.kind === 'cdk-asset') return undefined;
+  return image.uri;
+}

--- a/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vite-plus/test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EMULATOR_SOURCE = path.join(
+  __dirname,
+  '../../../src/cli/commands/ecs-service-emulator.ts'
+);
+
+/**
+ * Issue #234 site-level binding test (per
+ * `feedback_site_level_binding_test.md`).
+ *
+ * `isLocalCdkAssetImage` / `describePinnedImageUri` (in
+ * `src/local/image-pin-detector.ts`) are consumed at TWO sites inside
+ * `ecs-service-emulator.ts`:
+ *
+ *   1. The boot-time `--watch` warn loop (runs once after every target
+ *      has booted, before the file watcher is wired) — surfaces a per-
+ *      target WARN naming the deployed-registry URI when the image is
+ *      pinned.
+ *   2. The reload-time skip guard inside `reloadAllServices` — emits
+ *      `Reload skipped for '<target>' (no-op)...` and `continue`s past
+ *      `rollOneTarget` when the classifier verdict says
+ *      `'target image is not a CDK docker-image asset'`.
+ *
+ * The helper has its own unit coverage in
+ * `tests/unit/local/image-pin-detector.test.ts`, but neither caller is
+ * exercised by an emulator-level vitest (booting `runEcsServiceEmulator`
+ * end-to-end would require docker + a real ECS template). This source-
+ * grep test pins the bindings so a refactor that silently re-inlines
+ * the image-kind check on one side (or drops one) surfaces here instead
+ * of shipping a regressed `--watch` no-op symptom that issue #234
+ * documented.
+ */
+describe('ecs-service-emulator image-pin detector binding (issue #234)', () => {
+  it('imports `isLocalCdkAssetImage` + `describePinnedImageUri` from the local helper module', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    expect(source).toMatch(
+      /from\s+['"]\.\.\/\.\.\/local\/image-pin-detector\.js['"]/
+    );
+    expect(source).toMatch(/isLocalCdkAssetImage/);
+    expect(source).toMatch(/describePinnedImageUri/);
+  });
+
+  it('boot-time WARN fires `isLocalCdkAssetImage` AND `describePinnedImageUri` inside the `--watch` gate', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The boot-time WARN block is bracketed by the `--watch` gate
+    // (`options.watch === true && strategy.supportsWatch === true`)
+    // and BOTH helpers MUST appear before the `Phase 1 + Phase 2 +
+    // Phase 3` watcher-wiring comment. A refactor that drops either
+    // call would silently ship the no-op-disguised-as-success bug
+    // back into the boot stream.
+    const bootWarnRegion = source.match(
+      /options\.watch === true && strategy\.supportsWatch === true\)\s*\{[\s\S]*?Phase 1 \+ Phase 2 \+ Phase 3/
+    );
+    expect(bootWarnRegion, 'boot-time WARN region missing').toBeTruthy();
+    expect(bootWarnRegion![0]).toMatch(/isLocalCdkAssetImage\s*\(/);
+    expect(bootWarnRegion![0]).toMatch(/describePinnedImageUri\s*\(/);
+    expect(bootWarnRegion![0]).toMatch(/logger\.warn\(/);
+  });
+
+  it('reload-time skip guard checks `verdict.reason` BEFORE the `rollOneTarget` call site', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The skip guard MUST live between the classifier's verdict assignment
+    // and the `await rollOneTarget(...)` call in `reloadAllServices`.
+    // The "Reload skipped" log line is the user-facing surface; the
+    // `continue` keyword is the load-bearing semantic.
+    const reloadRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadRegion![0];
+    expect(body).toMatch(/target image is not a CDK docker-image asset/);
+    expect(body).toMatch(/Reload skipped for '\$\{newBoot\.target\}'/);
+    // Ordering: the skip log + `continue` MUST appear before the
+    // `rollOneTarget` call so the no-op pre-empts the rolling primitive.
+    const skipIdx = body.indexOf('Reload skipped for ');
+    const rollIdx = body.indexOf('rollOneTarget({');
+    expect(skipIdx).toBeGreaterThan(-1);
+    expect(rollIdx).toBeGreaterThan(-1);
+    expect(skipIdx).toBeLessThan(rollIdx);
+  });
+});

--- a/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
@@ -45,35 +45,39 @@ describe('ecs-service-emulator image-pin detector binding (issue #234)', () => {
     expect(source).toMatch(/describePinnedImageUri/);
   });
 
-  it('boot-time WARN fires `isLocalCdkAssetImage` AND `describePinnedImageUri` inside the `--watch` gate', () => {
+  it('boot-time WARN loop calls `isLocalCdkAssetImage` + `describePinnedImageUri` + `logger.warn` together', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
-    // The boot-time WARN block is bracketed by the `--watch` gate
-    // (`options.watch === true && strategy.supportsWatch === true`)
-    // and BOTH helpers MUST appear before the `Phase 1 + Phase 2 +
-    // Phase 3` watcher-wiring comment. A refactor that drops either
-    // call would silently ship the no-op-disguised-as-success bug
-    // back into the boot stream.
-    const bootWarnRegion = source.match(
-      /options\.watch === true && strategy\.supportsWatch === true\)\s*\{[\s\S]*?Phase 1 \+ Phase 2 \+ Phase 3/
+    // Anchor on the unique boot-WARN rationale comment ("Warn UP-FRONT")
+    // and verify the per-target loop downstream of it calls both
+    // helpers AND surfaces the warning via `logger.warn`. The outer
+    // gate (a hoisted `watchActive` const today; could be inlined back
+    // or renamed by a future refactor) intentionally isn't pinned here
+    // — what matters for issue #234 is that the loop body has the
+    // right shape. A refactor that drops either call would silently
+    // ship the no-op-disguised-as-success bug back into the boot stream.
+    const bootWarnLoop = source.match(
+      /Warn UP-FRONT[\s\S]*?for \(const pt of perTarget\) \{[\s\S]*?isLocalCdkAssetImage[\s\S]*?describePinnedImageUri[\s\S]*?logger\.warn\(/
     );
-    expect(bootWarnRegion, 'boot-time WARN region missing').toBeTruthy();
-    expect(bootWarnRegion![0]).toMatch(/isLocalCdkAssetImage\s*\(/);
-    expect(bootWarnRegion![0]).toMatch(/describePinnedImageUri\s*\(/);
-    expect(bootWarnRegion![0]).toMatch(/logger\.warn\(/);
+    expect(bootWarnLoop, 'boot-time WARN loop missing').toBeTruthy();
   });
 
-  it('reload-time skip guard checks `verdict.reason` BEFORE the `rollOneTarget` call site', () => {
+  it('reload-time skip guard AND-s `verdict.reason` with `isLocalCdkAssetImage(controller.service)` BEFORE `rollOneTarget`', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
     // The skip guard MUST live between the classifier's verdict assignment
-    // and the `await rollOneTarget(...)` call in `reloadAllServices`.
-    // The "Reload skipped" log line is the user-facing surface; the
-    // `continue` keyword is the load-bearing semantic.
+    // and the `await rollOneTarget(...)` call in `reloadAllServices`. As
+    // refined by the #237 review (PR feedback), the guard ANDs the
+    // verdict reason with `!isLocalCdkAssetImage(controller.service)` so
+    // degradation / race cases where the classifier defaults to
+    // `rebuild` but the booted controller's image IS a CDK asset
+    // (manifest race, missing asset hash, executable-mode asset, etc.)
+    // do NOT trip a misleading "image pinned to deployed registry" skip.
     const reloadRegion = source.match(
       /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
     );
     expect(reloadRegion, 'reloadAllServices body missing').toBeTruthy();
     const body = reloadRegion![0];
     expect(body).toMatch(/target image is not a CDK docker-image asset/);
+    expect(body).toMatch(/!isLocalCdkAssetImage\(controller\.service\)/);
     expect(body).toMatch(/Reload skipped for '\$\{newBoot\.target\}'/);
     // Ordering: the skip log + `continue` MUST appear before the
     // `rollOneTarget` call so the no-op pre-empts the rolling primitive.

--- a/tests/unit/local/image-pin-detector.test.ts
+++ b/tests/unit/local/image-pin-detector.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  isLocalCdkAssetImage,
+  describePinnedImageUri,
+} from '../../../src/local/image-pin-detector.js';
+import type { ResolvedEcsService } from '../../../src/local/ecs-service-resolver.js';
+import type { ResolvedEcsContainer, ResolvedEcsImage } from '../../../src/local/ecs-task-resolver.js';
+
+/**
+ * Issue #234 — minimal fake `ResolvedEcsService` shaped just enough
+ * for the image-pin detector to read `task.containers[i].image` and
+ * `task.containers[i].essential`. The actual `ResolvedEcsService`
+ * interface is wide; we don't need 90% of it for this helper.
+ */
+function fakeService(containers: Array<Partial<ResolvedEcsContainer>>): ResolvedEcsService {
+  return {
+    task: {
+      containers: containers.map(
+        (c, i) =>
+          ({
+            name: c.name ?? `c${i}`,
+            essential: c.essential ?? false,
+            image: c.image ?? ({ kind: 'cdk-asset' } as ResolvedEcsImage),
+            environment: {},
+            sensitiveEnvKeys: [],
+            secrets: [],
+            portMappings: [],
+            mountPoints: [],
+            dependsOn: [],
+            links: [],
+            ulimits: [],
+            warnings: [],
+          }) as ResolvedEcsContainer
+      ),
+      // The detector only reads `task.containers`; the rest is unused.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('isLocalCdkAssetImage (issue #234)', () => {
+  it('returns true for a CDK-asset essential container', () => {
+    const service = fakeService([{ essential: true, image: { kind: 'cdk-asset', assetHash: 'h' } }]);
+    expect(isLocalCdkAssetImage(service)).toBe(true);
+  });
+
+  it('returns false for an ECR-pinned essential container (`--from-cfn-stack` typical)', () => {
+    const service = fakeService([
+      {
+        essential: true,
+        image: {
+          kind: 'ecr',
+          uri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:4.5.1',
+          account: '123456789012',
+          region: 'us-east-1',
+        },
+      },
+    ]);
+    expect(isLocalCdkAssetImage(service)).toBe(false);
+  });
+
+  it('returns false for a public-registry pin', () => {
+    const service = fakeService([
+      { essential: true, image: { kind: 'public', uri: 'nginx:latest' } },
+    ]);
+    expect(isLocalCdkAssetImage(service)).toBe(false);
+  });
+
+  it('picks the FIRST essential when multiple containers are present (sidecar after main)', () => {
+    // First container is a non-essential sidecar with a CDK asset; main
+    // (essential, ECR pin) is second. The detector should classify the
+    // service on the essential main, not the sidecar.
+    const service = fakeService([
+      { essential: false, image: { kind: 'cdk-asset', assetHash: 'sidecar' } },
+      {
+        essential: true,
+        image: {
+          kind: 'ecr',
+          uri: '111111111111.dkr.ecr.us-east-1.amazonaws.com/main:tag',
+          account: '111111111111',
+          region: 'us-east-1',
+        },
+      },
+    ]);
+    expect(isLocalCdkAssetImage(service)).toBe(false);
+  });
+
+  it('falls back to the first container when nothing is marked essential', () => {
+    const service = fakeService([
+      { essential: false, image: { kind: 'cdk-asset', assetHash: 'h' } },
+      {
+        essential: false,
+        image: { kind: 'ecr', uri: 'x', account: 'a', region: 'r' },
+      },
+    ]);
+    expect(isLocalCdkAssetImage(service)).toBe(true);
+  });
+
+  it('returns false when the service has no containers (degenerate)', () => {
+    const service = fakeService([]);
+    expect(isLocalCdkAssetImage(service)).toBe(false);
+  });
+});
+
+describe('describePinnedImageUri (issue #234)', () => {
+  it('returns the full ECR URI for an ECR-pinned essential container', () => {
+    const service = fakeService([
+      {
+        essential: true,
+        image: {
+          kind: 'ecr',
+          uri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:4.5.1',
+          account: '123456789012',
+          region: 'us-east-1',
+        },
+      },
+    ]);
+    expect(describePinnedImageUri(service)).toBe(
+      '123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:4.5.1'
+    );
+  });
+
+  it('returns the literal URI for a public-registry pin', () => {
+    const service = fakeService([
+      { essential: true, image: { kind: 'public', uri: 'public.ecr.aws/foo/bar:1.2.3' } },
+    ]);
+    expect(describePinnedImageUri(service)).toBe('public.ecr.aws/foo/bar:1.2.3');
+  });
+
+  it('returns undefined for a local CDK-asset image (warn does not fire)', () => {
+    const service = fakeService([{ essential: true, image: { kind: 'cdk-asset', assetHash: 'h' } }]);
+    expect(describePinnedImageUri(service)).toBeUndefined();
+  });
+
+  it('returns undefined when the service has no containers (degenerate)', () => {
+    const service = fakeService([]);
+    expect(describePinnedImageUri(service)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #234.

`cdkl start-service --watch` / `cdkl start-alb --watch` against a
deployed ECS service whose CDK source uses
`ContainerImage.fromEcrRepository(repo, IMAGE_TAG)` (typical pairing
with `--from-cfn-stack`) was silently dropping local source edits
behind a `Reload complete.` log line. The classifier returned
`rebuild` with reason `'target image is not a CDK docker-image asset'`
(`src/local/source-change-classifier.ts:218-219`), the rolling
primitive then booted a shadow replica from the same ECR pin →
docker-pulled byte-identical content → swapped registrations →
retired the old replica. A docker-pull-restart cycle with zero
behavior change, surfaced as success.

This PR makes the no-op LOUD on both ends of the lifecycle:

- **Boot-time WARN per pinned target** (issued from
  `ecs-service-emulator.ts` after the boot loop, only when `--watch`
  is set). Names the pinned image URI so the user sees up-front that
  local source edits will not take effect under this configuration.
  Suggests dropping `--from-cfn-stack` and switching the CDK app to
  `ContainerImage.fromAsset(...)` to iterate locally.
- **Reload-time SKIP per pinned target** (inside
  `reloadAllServices`). When the classifier returns `rebuild` with
  the magic `'target image is not a CDK docker-image asset'` reason,
  the rolling primitive is bypassed and a
  `Reload skipped for '<target>' (no-op): image pinned to deployed
  registry; no local rebuild possible.` line is logged instead. Peer
  targets in the same emulator run whose images ARE local CDK
  assets continue rolling normally.

Detection is centralized in a new
`src/local/image-pin-detector.ts` helper
(`isLocalCdkAssetImage` + `describePinnedImageUri`), re-exported
from `cdk-local/internal` so host CLIs that wrap
`runEcsServiceEmulator` inherit the fix automatically and can
reproduce the same diagnostics if they wire a different reload
surface. The helper picks the first essential container (falling
back to the first container) — same heuristic
`loadAssetContextForTarget` uses, so the boot WARN, the reload SKIP,
and the classifier verdict always anchor on the same container.

## Behavior change

Two NEW user-visible log lines for `cdkl start-service --watch` /
`cdkl start-alb --watch` against a target whose image is a deployed-
registry pin (ECR via `--from-cfn-stack` against
`ContainerImage.fromEcrRepository(...)`, or a hand-pinned public
registry image):

1. Boot-time, per affected target:
   ```
   '<target>': `--watch` will not pick up local source changes — running image is pinned to a deployed registry (`<uri>`). To iterate on local source, drop `--from-cfn-stack` and switch the CDK app to `ContainerImage.fromAsset(...)`.
   ```
2. Reload-time, per firing per affected target:
   ```
   Reload skipped for '<target>' (no-op): image pinned to deployed registry; no local rebuild possible.
   ```

Existing logs for CDK-asset targets are unchanged. Host CLIs that
embed `runEcsServiceEmulator` inherit both lines automatically; no
host-side migration is required.

## Out of scope (deliberate follow-up)

Env / Secrets diff handling under `--from-cfn-stack` (the one signal
a reload could legitimately propagate for an ECR-pinned target — the
deployed stack's `SecureString` / env value flipped) is NOT plumbed
in this PR. A watcher firing on such a configuration still skips
totally. A fast-path env-only reload for ECR-pinned targets would
plug the gap; tracked as a follow-up in the
`reloadAllServices` skip-guard comment.

## Verification

Local quality checks (in this worktree):

- `vp run check` — typecheck + lint + format-check: pass
- `vp test run` — 128 files, 1890 tests: pass
- `vp run build` — clean

Unit-level coverage added:

- `tests/unit/local/image-pin-detector.test.ts` — 10 tests pinning
  the helper's image-kind classification (CDK asset / ECR pin /
  public-registry pin / sidecar-then-essential / fallback-to-first
  / no-containers).
- `tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts` —
  source-grep site-level binding test pinning that BOTH the
  boot-time WARN (inside the `--watch` gate) AND the reload-time
  skip guard (before `rollOneTarget` in `reloadAllServices`)
  actually consume the helper. Mirrors the existing
  `ecs-service-emulator-resolve-helper-binding.test.ts` pattern per
  the project's "site-level binding test for shared helpers" rule.

End-to-end manual repro (requires real AWS — same shape as #234's
ticket reproduces the bug):

```bash
# Deploy any CDK app whose service uses
#   ContainerImage.fromEcrRepository(repo, IMAGE_TAG)
# e.g. a ChartStack pinning to a published ECR image tag.

cdkl start-alb --lb-port 443=8443 --from-cfn-stack --watch \
  -c IMAGE_TAG="<sha>" --profile <p>
```

Expected new output during boot (after `Service(s) running:` /
`Press ^C to shut down.`):

```
WARN '<target>': `--watch` will not pick up local source changes —
     running image is pinned to a deployed registry
     (`<acct>.dkr.ecr.<region>.amazonaws.com/<repo>:<sha>`).
     To iterate on local source, drop `--from-cfn-stack` and switch
     the CDK app to `ContainerImage.fromAsset(...)`.
```

Then save any local source file. Expected new output on each
firing:

```
Detected source change (1 path(s)); reloading service(s)...
Reload of '<target>': verdict=rebuild (target image is not a CDK docker-image asset).
Reload skipped for '<target>' (no-op): image pinned to deployed registry; no local rebuild possible.
Reload complete.
```

The rolling primitive is NOT entered for the pinned target.
A peer target in the same run whose image IS a local CDK asset
still rolls normally — only the pinned target is skipped.

## Test plan

- [x] `vp run check`
- [x] `vp test run`
- [x] `vp run build`
- [x] New helper unit test exercises CDK-asset / ECR-pin / public-
      pin / sidecar-then-essential / fallback / no-containers paths
- [x] Site-level binding test pins both call sites
- [ ] Manual verification per the recipe above on a real
      `--from-cfn-stack` + ECR-pinned ECS service
