### PR TITLE
feat(start-service,start-alb): --image-override family + TTY boot prompt for pinned images

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,7 +73,21 @@ AWS managed services.
   rebuild possible.` log, and the same configuration triggers a
   loud boot-time WARN per affected target so the user knows local
   source edits will not take effect before they spend time saving
-  files (issue #234). The host front-door (TLS materials, JWKS cache,
+  files (issue #234; #238 broadened the WARN to fire on any cold
+  start when an ECR pin is detected, not just under `--watch`).
+  Issue #238 also added the `--image-override` flag family to
+  `cdkl start-service` / `cdkl start-alb` (`--image-override
+  <svc>=<dockerfile>` or bare `<dockerfile>` for picker form,
+  `--image-build-arg` / `--image-build-secret` / `--image-target`
+  as global build-input pass-throughs, `--no-interactive-overrides`
+  to suppress the TTY boot prompt + multi-select picker, and
+  `--strict-overrides` to fail fast when any pinned target remains
+  uncovered): a covered pinned target is rebuilt locally from the
+  supplied Dockerfile (deterministic local-only tag
+  `cdkl-override-<svc>-<hash>:local`) and threaded through the
+  rebuild rolling primitive on `--watch` reload — the engine module
+  lives in `src/local/image-override-engine.ts`.
+  The host front-door (TLS materials, JWKS cache,
   Lambda-target RIE containers, listener sockets) is built once at
   boot and is NOT recreated on reload — only the per-service replica
   pool entries rotate. Lambda target groups behind the ALB are a
@@ -222,7 +236,14 @@ compute-locally category for Lambda + API Gateway).
   registry pin so the `--watch` emulator can WARN at boot and SKIP
   the no-op rolling primitive on each reload firing instead of
   re-pulling byte-identical content and surfacing `Reload complete.`
-  as a silent no-op), front-door-server (host HTTP / HTTPS reverse proxy
+  as a silent no-op), image-override-engine (issue #238 — parses
+  the `--image-override` / `--image-build-arg` /
+  `--image-build-secret` / `--image-target` flag family, fires the
+  `@clack/prompts` multi-select picker for picker-form Dockerfile
+  paths + the TTY boot prompt against still-uncovered pinned targets,
+  and runs `docker build` once per covered target producing the
+  deterministic local-only tag the boot path threads into each
+  runner's `imageOverrideByContainer`), front-door-server (host HTTP / HTTPS reverse proxy
   that resolves a per-request RouteAction — weighted forward to a
   replica pool or a Lambda invoke, redirect, or fixed-response — behind
   the ALB listener port; HTTPS branch flips `X-Forwarded-Proto` and the

--- a/README.md
+++ b/README.md
@@ -131,6 +131,51 @@ cdkl start-alb --watch        # roll ALB-fronted ECS replicas on save
 
 Full reload pipeline + glob defaults: [docs/local-emulation.md#hot-reload---watch](docs/local-emulation.md#hot-reload---watch).
 
+### Local build override — `--image-override`
+
+`cdkl start-service` / `cdkl start-alb` against an ECS service whose CDK source uses `ContainerImage.fromEcrRepository(...)` (typical under `--from-cfn-stack`) runs the deployed image bytes locally — local source edits don't take effect, even with `--watch`. `--image-override` swaps in a local `docker build` of a supplied Dockerfile per service target so iteration still works while real DynamoDB / Secrets / SSM stay wired in.
+
+Lead form — boot in a TTY and the command walks each detected pinned target:
+
+```bash
+cdkl start-alb --from-cfn-stack    # interactive boot prompt for each pinned target
+```
+
+```
+? Detected pinned image on 'AppService' (123…/repo:4.5.1).
+  Override with a local build? Enter a Dockerfile path, or leave blank to skip.
+> ./services/app/Dockerfile
+```
+
+Or name them up-front (CI / scripted setups):
+
+```bash
+cdkl start-alb --from-cfn-stack \
+  --image-override AppService=./services/app/Dockerfile \
+  --image-override AuthService=./services/auth/Dockerfile
+```
+
+A bare `--image-override <dockerfile>` (no `=`) opens a multi-select picker against the pinned targets — useful when one Dockerfile is shared across several services. Mix freely with explicit forms in one invocation.
+
+Pass build inputs through to every override:
+
+```bash
+cdkl start-alb --from-cfn-stack \
+  --image-override AppService=./Dockerfile \
+  --image-build-arg NODE_ENV=production \
+  --image-build-secret npmrc=./.npmrc \
+  --image-target builder
+```
+
+`--image-build-secret npmrc=./.npmrc` wires a private-registry token into a Dockerfile that uses `RUN --mount=type=secret,id=npmrc` — the canonical recipe for installing private packages during the local build.
+
+Opt-outs:
+
+- `--no-interactive-overrides` suppresses the boot prompt + the multi-select picker; the override map is whatever explicit `--image-override <svc>=<dockerfile>` flags resolved to. Useful for scripted invocations.
+- `--strict-overrides` fails fast at boot if any pinned target remains uncovered. Off by default; the per-target WARN (which now fires on any cold start when an ECR pin is detected, not just under `--watch`) still surfaces regardless.
+
+Under `--watch`, overridden targets go through the rebuild rolling primitive on each save — the new local Dockerfile build is picked up automatically.
+
 ### start-service vs start-alb — which one?
 
 Most CDK ECS apps boot multiple replicas behind an ALB. cdk-local exposes each layer separately so you can target the slice you care about:

--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ cdkl start-alb --from-cfn-stack    # interactive boot prompt for each pinned tar
 
 ```
 ? Detected pinned image on 'AppService' (123…/repo:4.5.1).
-  Override with a local build? Enter a Dockerfile path, or leave blank to skip.
+  Override with a local build? [path / N]:
 > ./services/app/Dockerfile
 ```
+
+Enter a Dockerfile path to override, or `N` (any case) / blank to skip the target.
 
 Or name them up-front (CI / scripted setups):
 
@@ -167,7 +169,7 @@ cdkl start-alb --from-cfn-stack \
   --image-target builder
 ```
 
-`--image-build-secret npmrc=./.npmrc` wires a private-registry token into a Dockerfile that uses `RUN --mount=type=secret,id=npmrc` — the canonical recipe for installing private packages during the local build.
+`--image-build-secret npmrc=./.npmrc` wires a private-registry token into a Dockerfile that uses `RUN --mount=type=secret,id=npmrc` — the canonical recipe for installing private packages during the local build. The `src=` path resolves against the directory you ran `cdkl` from (not the Dockerfile's parent), so `./.npmrc` means "the `.npmrc` next to your `cdk.json`" regardless of where the Dockerfile lives in the tree.
 
 Opt-outs:
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1502,12 +1502,78 @@ to deployed registry; no local rebuild possible.` log on each
 firing, and the same configuration triggers a loud boot-time WARN
 per affected target naming the pinned image URI so the user knows
 local source edits will not take effect before they spend time
-saving files. To iterate on local source for an ECR-pinned service,
-drop `--from-cfn-stack` and switch the CDK app to
-`ContainerImage.fromAsset(...)`. Env / Secrets diff propagation
-under `--from-cfn-stack` (a watcher firing legitimately picking up
-a flipped deployed env value for an ECR-pinned target) is a
-follow-up — today the skip is total.
+saving files. The boot-time WARN fires on any cold start when an
+ECR pin is detected (broadened from `--watch` only in issue #238) —
+the user has already signalled they want to run this service
+locally, so the hint that the running image is the deployed bytes
+is useful regardless. To iterate on local source for an ECR-pinned
+service, either pass `--image-override` (see below) to substitute a
+local Dockerfile build, or drop `--from-cfn-stack` and switch the
+CDK app to `ContainerImage.fromAsset(...)`. Env / Secrets diff
+propagation under `--from-cfn-stack` (a watcher firing legitimately
+picking up a flipped deployed env value for an ECR-pinned target
+without an override) is a follow-up — today the skip is total for
+uncovered pinned targets.
+
+**Override an ECR pin with a local Dockerfile build (`--image-override`, issue #238).**
+`cdkl start-service` and `cdkl start-alb` accept a flag family that
+maps a pinned service target to a local `docker build` of a
+supplied Dockerfile, so `--from-cfn-stack` keeps wiring real
+DynamoDB / Secrets / SSM into the container while the application
+image is locally iterable. Under `--watch`, an overridden target
+goes through the rebuild rolling primitive on each save — the new
+local Dockerfile build is picked up automatically (the reload-skip
+above only fires for targets that remain UNCOVERED by the override
+map). Six flags compose:
+
+- `--image-override <svc>=<dockerfile>` (explicit) or
+  `<dockerfile>` (picker-form) — repeatable. The picker-form opens
+  a `@clack/prompts` multi-select against the still-uncovered
+  pinned targets; mix explicit + picker forms freely.
+- `--image-build-arg KEY=VAL` — global, repeatable. Forwarded to
+  every overridden target's `docker build --build-arg`.
+- `--image-build-secret id=src` — global, repeatable. Forwarded to
+  `docker build --secret id=<id>,src=<src>`; the canonical recipe
+  for a Dockerfile that uses
+  `RUN --mount=type=secret,id=<id>` (private npm registries / token
+  fetches during build).
+- `--image-target <stage>` — global. Forwarded to
+  `docker build --target=<stage>` for multi-stage builds.
+- `--no-interactive-overrides` — suppress the boot prompt + the
+  picker-form multi-select. The override map is whatever the
+  explicit `--image-override <svc>=<dockerfile>` flags resolved to.
+  Useful for CI / scripted invocations.
+- `--strict-overrides` — fail fast at boot when any pinned target
+  remains uncovered after `--image-override` + the boot prompt
+  resolve. Off by default; the per-target WARN still fires
+  regardless.
+
+When `--no-interactive-overrides` is unset AND the session is a
+TTY, the engine walks each still-uncovered pinned target with a
+prompt:
+
+```
+? Detected pinned image on 'AppService' (123…/repo:4.5.1).
+  Override with a local build? Enter a Dockerfile path, or leave
+  blank to skip.
+```
+
+An empty answer (or `N`) skips the target — the boot WARN above
+still fires for it.
+
+The override engine builds each covered Dockerfile once at boot,
+tagging the resulting image with a deterministic local-only tag
+(`cdkl-override-<svcSlug>-<hash>:local` — the `:local` suffix means
+a `docker pull` against the tag fails fast, by design). The boot
+loop then mutates the resolved task's representative essential
+container's image to that tag before `docker run`. Sibling
+containers in a multi-container task are unaffected — they go
+through the normal CDK-asset / ECR / public-registry resolution.
+
+Out of scope for v1 (deferred to issue #240): per-service variants
+of `--image-build-arg` / `--image-build-secret` / `--image-target`
+(today these flags are global). Custom build-context directories
+distinct from the Dockerfile's parent dir are also deferred.
 
 Known fast-path limitations (Phase 4 trade-offs):
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1554,12 +1554,17 @@ prompt:
 
 ```
 ? Detected pinned image on 'AppService' (123…/repo:4.5.1).
-  Override with a local build? Enter a Dockerfile path, or leave
-  blank to skip.
+  Override with a local build? [path / N]:
 ```
 
-An empty answer (or `N`) skips the target — the boot WARN above
+Enter a Dockerfile path to override the target. An empty answer,
+`n`, or `no` (any case) skips the target — the boot WARN above
 still fires for it.
+
+`--image-build-secret id=<src>` resolves a relative `<src>` against
+the directory you ran `cdkl` from (not the Dockerfile's parent), so
+`./.npmrc` means "the `.npmrc` next to your `cdk.json`" regardless
+of where the Dockerfile lives in the tree.
 
 The override engine builds each covered Dockerfile once at boot,
 tagging the resulting image with a deterministic local-only tag

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -778,14 +778,7 @@ export async function runEcsServiceEmulator(
     // impossible for any target", typically in CI / scripted setups).
     // Boot WARN already fired above for the same set; this throws on
     // top of it so the user sees both diagnostics before exiting.
-    if (options.strictOverrides === true && uncoveredPinnedTargets.length > 0) {
-      throw new LocalStartServiceError(
-        `--strict-overrides set, but ${uncoveredPinnedTargets.length} pinned target(s) ` +
-          `remain uncovered: ${uncoveredPinnedTargets.join(', ')}. Pass --image-override ` +
-          '<service>=<dockerfile> for each, drop --strict-overrides, or drop ' +
-          '--from-cfn-stack to iterate on local CDK assets.'
-      );
-    }
+    enforceStrictOverrides(options.strictOverrides === true, uncoveredPinnedTargets);
 
     // Phase 1 + Phase 2 + Phase 3 of issue #214 — `cdkl start-service --watch`
     // (Phases 1-2) and `cdkl start-alb --watch` (Phase 3) source-tree
@@ -1103,10 +1096,21 @@ async function reloadAllServices(args: {
     // controller's resolved service as the ground truth for "the
     // currently-running image is a pin", because that's what the
     // skip-rationale ("re-pulling byte-identical content") rests on.
+    //
+    // Issue #238 carve-out: when `--image-override` covers this target,
+    // the running container is a LOCAL `docker build` of the supplied
+    // Dockerfile (`cdkl-override-<svc>-<hash>:local`), NOT a deployed
+    // registry pin — even though `controller.service` still holds the
+    // resolved-from-template ECR pin (the override is injected at
+    // runner level via `imageOverrideByContainer`, never by mutating
+    // the resolved service). Re-rolling IS meaningful for these
+    // targets (a Dockerfile / dependency-manifest edit would otherwise
+    // get silently skipped), so let the rolling primitive run.
     if (
       verdict.kind === 'rebuild' &&
       verdict.reason === 'target image is not a CDK docker-image asset' &&
-      !isLocalCdkAssetImage(controller.service)
+      !isLocalCdkAssetImage(controller.service) &&
+      !imageOverrideTags.has(newBoot.target)
     ) {
       logger.info(
         `Reload skipped for '${newBoot.target}' (no-op): image pinned to deployed ` +
@@ -2460,6 +2464,28 @@ async function resolveAndBuildImageOverrides(args: {
   // via the docker-runner's streamLive path; the per-target
   // "Building override image..." line surfaces ahead of each build.
   return runImageOverrideBuilds(overrides);
+}
+
+/**
+ * Issue #238 — `--strict-overrides` guard. Extracted so the boot path's
+ * fail-fast behavior can be exercised under a unit test without booting
+ * the full emulator. Throws {@link LocalStartServiceError} when `strict`
+ * is true AND at least one pinned target remains uncovered; otherwise a
+ * no-op. The error message names every uncovered target so the user can
+ * pass the corresponding `--image-override` mapping.
+ */
+export function enforceStrictOverrides(
+  strict: boolean,
+  uncoveredPinnedTargets: readonly string[]
+): void {
+  if (!strict) return;
+  if (uncoveredPinnedTargets.length === 0) return;
+  throw new LocalStartServiceError(
+    `--strict-overrides set, but ${uncoveredPinnedTargets.length} pinned target(s) ` +
+      `remain uncovered: ${uncoveredPinnedTargets.join(', ')}. Pass --image-override ` +
+      '<service>=<dockerfile> for each, drop --strict-overrides, or drop ' +
+      '--from-cfn-stack to iterate on local CDK assets.'
+  );
 }
 
 /**

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -102,6 +102,11 @@ import type { FrontDoorAuthGuard } from '../../local/elb-front-door-resolver.js'
 import { buildAuthCheck } from '../../local/front-door-auth.js';
 import { createJwksCache } from '../../local/cognito-jwt.js';
 import { describePinnedImageUri, isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
+import {
+  parseImageOverrideFlags,
+  resolveImageOverrides,
+  runImageOverrideBuilds,
+} from '../../local/image-override-engine.js';
 
 /**
  * Neutral ECS-service emulator orchestration shared by `cdkl start-service`
@@ -214,6 +219,52 @@ export interface EcsServiceEmulatorOptions {
    * `cdkl run-task`.
    */
   logs?: boolean;
+  /**
+   * Issue #238 — `--image-override <service>=<dockerfile>` or
+   * `<dockerfile>` (picker form), repeatable. Maps a pinned-image
+   * service target to a local Dockerfile build so iteration on local
+   * source still works under `--from-cfn-stack` against a
+   * `ContainerImage.fromEcrRepository(...)` service. Picker-form
+   * paths fire a multi-select against the still-uncovered pinned
+   * targets at boot. Explicit + picker forms mix freely in one
+   * invocation.
+   */
+  imageOverride?: string[];
+  /**
+   * Issue #238 — `--image-build-arg KEY=VAL` pairs, repeatable. Global
+   * (apply to every overridden target's `docker build --build-arg`).
+   * Per-service variants are intentionally out of scope for v1
+   * (tracked separately in #240).
+   */
+  imageBuildArg?: string[];
+  /**
+   * Issue #238 — `--image-build-secret id=src`, repeatable. Global.
+   * Forwarded to `docker build --secret id=<id>,src=<src>` for every
+   * overridden target so `RUN --mount=type=secret,id=<id>` works
+   * locally (the private-registry / npm-token recipe).
+   */
+  imageBuildSecret?: string[];
+  /**
+   * Issue #238 — `--image-target <stage>`. Global. Forwarded to
+   * `docker build --target=<stage>` for every overridden target.
+   */
+  imageTarget?: string;
+  /**
+   * Issue #238 — `--no-interactive-overrides`. Suppresses the boot
+   * prompt + the picker-form prompt; the override map is whatever
+   * the explicit `--image-override <svc>=<dockerfile>` flags resolve
+   * to. Commander's `--no-...` negation form: undefined when not
+   * supplied; the engine treats `interactiveOverrides === false` as
+   * "suppress every prompt".
+   */
+  interactiveOverrides?: boolean;
+  /**
+   * Issue #238 — `--strict-overrides`. After the override engine
+   * resolves, if any pinned target remains uncovered, the emulator
+   * fails fast with a {@link LocalStartServiceError} naming the
+   * still-uncovered targets. Default off: warn-and-run.
+   */
+  strictOverrides?: boolean;
   /** Host-injected extra state-source flag fields. */
   [key: string]: unknown;
 }
@@ -609,6 +660,30 @@ export async function runEcsServiceEmulator(
     process.on('SIGINT', sigintHandler);
     process.on('SIGTERM', sigintHandler);
 
+    // Issue #238 — resolve `--image-override` (+ the boot prompt for
+    // any still-uncovered pinned target in a TTY) BEFORE the boot loop
+    // so docker build budget for the override is spent up-front, and
+    // the boot path can inject the locally-built tag into the runner.
+    // Walks four stages:
+    //   1. Peek every target's resolved image to identify pinned ones
+    //      (representative essential container — same anchor the
+    //      boot WARN + reload-skip use).
+    //   2. Parse `--image-override` / `--image-build-arg` /
+    //      `--image-build-secret` / `--image-target` flag values.
+    //   3. Resolve explicit + picker-form mappings + boot prompt
+    //      against the pinned target set.
+    //   4. Build every covered Dockerfile via `docker build` and
+    //      record the resulting local-only tags.
+    // Throws on a malformed flag / missing Dockerfile / build failure
+    // — the emulator's outer try/finally tears down what was set up.
+    const imageOverrideTags = await resolveAndBuildImageOverrides({
+      perTarget: perTarget.map((pt) => pt.boot.target),
+      stacks,
+      options,
+      extraStateProviders,
+      logger,
+    });
+
     // Boot every target SEQUENTIALLY so a first-target failure surfaces before
     // we burn docker budget on the rest.
     for (const pt of perTarget) {
@@ -622,7 +697,8 @@ export async function runEcsServiceEmulator(
         extraStateProviders,
         profileCredsFile,
         frontDoorByService.get(pt.boot.target),
-        strategy.suppressLoadBalancerWarning === true
+        strategy.suppressLoadBalancerWarning === true,
+        imageOverrideTags.get(pt.boot.target)
       );
     }
 
@@ -656,40 +732,59 @@ export async function runEcsServiceEmulator(
     logEndpointsBanner(perTarget, frontDoorServers, logger);
     logger.info('Press ^C to shut down.');
 
-    // Issue #234 — when `--watch` is set, warn per booted target whose
+    // Issue #234 (broadened by #238) — warn per booted target whose
     // representative container image is NOT a local CDK docker-image
-    // asset. Such targets resolve to a deployed-registry pin (ECR via
-    // `--from-cfn-stack` against `ContainerImage.fromEcrRepository(...)`,
-    // or a public-registry pin like `ContainerImage.fromRegistry(...)`).
-    // The rolling primitive would re-pull byte-identical content on
-    // each save and report `Reload complete.` even though nothing in
-    // the running container changed — a silent no-op disguised as
-    // success. Warn UP-FRONT (per target) so the user knows local
-    // source edits will not take effect before they spend time saving
-    // files. The reload pathway also skips the no-op roll (see
-    // `reloadAllServices`); this boot-time warn is the proactive half.
+    // asset AND was NOT covered by `--image-override`. Such targets
+    // resolve to a deployed-registry pin (ECR via `--from-cfn-stack`
+    // against `ContainerImage.fromEcrRepository(...)`, or a public-
+    // registry pin like `ContainerImage.fromRegistry(...)`). The
+    // rolling primitive would re-pull byte-identical content on each
+    // save and report `Reload complete.` even though nothing in the
+    // running container changed — a silent no-op disguised as success.
+    // Warn UP-FRONT (per target) so the user knows local source edits
+    // will not take effect before they spend time saving files. The
+    // reload pathway also skips the no-op roll (see `reloadAllServices`);
+    // this boot-time warn is the proactive half.
     //
-    // The `--watch` gate (`options.watch === true && strategy.supportsWatch
-    // === true`) is hoisted into a single const so the boot-time WARN
-    // block + the watcher-wiring block downstream can never drift out of
-    // sync, and so #238's planned "broaden the WARN to fire regardless of
-    // `--watch`" follow-up is a one-line delta against the predicate
-    // instead of two.
-    const watchActive = options.watch === true && strategy.supportsWatch === true;
-    if (watchActive) {
-      for (const pt of perTarget) {
-        const service = pt.controller?.service;
-        if (!service) continue;
-        if (isLocalCdkAssetImage(service)) continue;
-        const pinnedUri = describePinnedImageUri(service);
-        const uriDisplay = pinnedUri ? `\`${pinnedUri}\`` : 'a deployed registry';
-        logger.warn(
-          `'${pt.boot.target}': \`--watch\` will not pick up local source changes — ` +
-            `running image is pinned to a deployed registry (${uriDisplay}). ` +
-            'To iterate on local source, drop `--from-cfn-stack` and switch the ' +
-            'CDK app to `ContainerImage.fromAsset(...)`.'
-        );
-      }
+    // #238 broadens the WARN to fire on ANY cold start (not gated on
+    // `--watch`). Even without `--watch`, the user has signalled they
+    // want to run this service locally; surfacing "running image is
+    // pinned to a deployed registry" up-front is the right hint
+    // regardless of whether they'd save a file later. The watch
+    // wiring stays gated separately (the watcher only fires under
+    // `--watch && supportsWatch`).
+    const uncoveredPinnedTargets: string[] = [];
+    for (const pt of perTarget) {
+      const service = pt.controller?.service;
+      if (!service) continue;
+      if (isLocalCdkAssetImage(service)) continue;
+      if (imageOverrideTags.has(pt.boot.target)) continue;
+      const pinnedUri = describePinnedImageUri(service);
+      const uriDisplay = pinnedUri ? `\`${pinnedUri}\`` : 'a deployed registry';
+      logger.warn(
+        `'${pt.boot.target}': running image is pinned to a deployed registry ` +
+          `(${uriDisplay}). To iterate on local source, either pass ` +
+          '`--image-override <dockerfile>` (or `<service>=<dockerfile>`) to substitute ' +
+          'a local build, or drop `--from-cfn-stack` and switch the CDK app to ' +
+          '`ContainerImage.fromAsset(...)`.'
+      );
+      uncoveredPinnedTargets.push(pt.boot.target);
+    }
+
+    // Issue #238 — `--strict-overrides` fail-fast guard. After the
+    // override engine has resolved + built every covered Dockerfile,
+    // if any pinned target remains uncovered, refuse to run (the
+    // user opted in to "fail when local source iteration is
+    // impossible for any target", typically in CI / scripted setups).
+    // Boot WARN already fired above for the same set; this throws on
+    // top of it so the user sees both diagnostics before exiting.
+    if (options.strictOverrides === true && uncoveredPinnedTargets.length > 0) {
+      throw new LocalStartServiceError(
+        `--strict-overrides set, but ${uncoveredPinnedTargets.length} pinned target(s) ` +
+          `remain uncovered: ${uncoveredPinnedTargets.join(', ')}. Pass --image-override ` +
+          '<service>=<dockerfile> for each, drop --strict-overrides, or drop ' +
+          '--from-cfn-stack to iterate on local CDK assets.'
+      );
     }
 
     // Phase 1 + Phase 2 + Phase 3 of issue #214 — `cdkl start-service --watch`
@@ -699,6 +794,11 @@ export async function runEcsServiceEmulator(
     // this engine from getting `--watch` implicitly. The watcher reuses the
     // start-api debounced file-watcher and predicate composition verbatim so
     // cdk.json `watch.include` / `watch.exclude` semantics are identical.
+    //
+    // Issue #238 dropped the same `watchActive` const that gated the boot
+    // WARN (now broadened to fire on any cold start). The watcher itself
+    // still needs the same predicate — only the WARN was broadened.
+    const watchActive = options.watch === true && strategy.supportsWatch === true;
     if (watchActive) {
       const watchRoot = process.cwd();
       const { ignored, shouldTrigger, excludePatterns } = createWatchPredicates({
@@ -729,6 +829,7 @@ export async function runEcsServiceEmulator(
               profileCredsFile,
               frontDoorByService,
               changedPaths,
+              imageOverrideTags,
               logger,
             })
           );
@@ -848,6 +949,15 @@ async function reloadAllServices(args: {
    * bind-mount fast path based on this set.
    */
   changedPaths: readonly string[];
+  /**
+   * Issue #238 — boot-time resolved `--image-override` map
+   * (`serviceTarget -> localImageTag`). The rolling primitive
+   * threads each entry into the new replica's runner so the
+   * shadow boot uses the locally-built image, not the deployed
+   * pin. Empty / absent entry => normal CDK-asset / ECR / public
+   * image resolution.
+   */
+  imageOverrideTags: ReadonlyMap<string, string>;
   logger: ReturnType<typeof getLogger>;
 }): Promise<void> {
   const {
@@ -864,6 +974,7 @@ async function reloadAllServices(args: {
     profileCredsFile,
     frontDoorByService,
     changedPaths,
+    imageOverrideTags,
     logger,
   } = args;
 
@@ -1015,6 +1126,9 @@ async function reloadAllServices(args: {
       frontDoorPools: frontDoorByService.get(newBoot.target),
       suppressLoadBalancerWarning: strategy.suppressLoadBalancerWarning === true,
       verdict,
+      ...(imageOverrideTags.get(newBoot.target) !== undefined && {
+        imageOverrideTag: imageOverrideTags.get(newBoot.target) as string,
+      }),
       logger,
     });
   }
@@ -1164,6 +1278,14 @@ async function rollOneTarget(args: {
    * `'rebuild'` falls through to the Phase 2/3 rolling primitive.
    */
   verdict: ReloadVerdict;
+  /**
+   * Issue #238 — boot-time-resolved local Dockerfile build tag for
+   * this service target (if any). Threaded into the new replica's
+   * `resolveServiceAndRunnerOpts` call so the shadow boot uses the
+   * locally-built image instead of the deployed pin. Undefined when
+   * the target is not under `--image-override`.
+   */
+  imageOverrideTag?: string;
   logger: ReturnType<typeof getLogger>;
 }): Promise<void> {
   const {
@@ -1178,6 +1300,7 @@ async function rollOneTarget(args: {
     frontDoorPools,
     suppressLoadBalancerWarning,
     verdict,
+    imageOverrideTag,
     logger,
   } = args;
 
@@ -1203,7 +1326,7 @@ async function rollOneTarget(args: {
         profileCredsFile,
         frontDoorPools,
         suppressLoadBalancerWarning,
-        { quiet: true }
+        { quiet: true, ...(imageOverrideTag !== undefined && { imageOverrideTag }) }
       );
     } catch (err) {
       // Resolution failure is recoverable on the next save (e.g. the
@@ -1328,7 +1451,8 @@ async function bootOneTarget(
   extraStateProviders: ExtraStateProviders | undefined,
   profileCredsFile: ProfileCredentialsFile | undefined,
   frontDoorPools: FrontDoorServicePools | undefined,
-  suppressLoadBalancerWarning: boolean
+  suppressLoadBalancerWarning: boolean,
+  imageOverrideTag: string | undefined
 ): Promise<ServiceController> {
   const parsed = parseEcsTarget(boot.target);
   const candidate = pickCandidateStack(parsed.stackPattern, stacks);
@@ -1350,7 +1474,8 @@ async function bootOneTarget(
       stateProvider,
       profileCredsFile,
       frontDoorPools,
-      suppressLoadBalancerWarning
+      suppressLoadBalancerWarning,
+      imageOverrideTag
     );
   } finally {
     if (stateProvider) stateProvider.dispose();
@@ -1367,7 +1492,8 @@ async function runOneTarget(
   stateProvider: LocalStateProvider | undefined,
   profileCredsFile: ProfileCredentialsFile | undefined,
   frontDoorPools: FrontDoorServicePools | undefined,
-  suppressLoadBalancerWarning: boolean
+  suppressLoadBalancerWarning: boolean,
+  imageOverrideTag: string | undefined
 ): Promise<ServiceController> {
   const { service, runnerOpts } = await resolveServiceAndRunnerOpts(
     boot,
@@ -1378,7 +1504,8 @@ async function runOneTarget(
     stateProvider,
     profileCredsFile,
     frontDoorPools,
-    suppressLoadBalancerWarning
+    suppressLoadBalancerWarning,
+    imageOverrideTag !== undefined ? { imageOverrideTag } : {}
   );
   return startEcsService(service, runnerOpts, runState);
 }
@@ -1416,7 +1543,7 @@ async function resolveServiceAndRunnerOpts(
   profileCredsFile: ProfileCredentialsFile | undefined,
   frontDoorPools: FrontDoorServicePools | undefined,
   suppressLoadBalancerWarning: boolean,
-  opts: { quiet?: boolean } = {}
+  opts: { quiet?: boolean; imageOverrideTag?: string } = {}
 ): Promise<{ service: ResolvedEcsService; runnerOpts: ServiceRunnerOptions }> {
   const logger = getLogger();
   const target = boot.target;
@@ -1519,6 +1646,29 @@ async function resolveServiceAndRunnerOpts(
       containerPath: profileCredsFile.containerPath,
       profileName: profileCredsFile.profileName,
     };
+  }
+
+  // Issue #238 — when an --image-override resolved a local Dockerfile
+  // build for this service target, inject the pre-built local tag
+  // into the runner's per-container override map keyed on the
+  // representative essential container's name (mirrors the same
+  // first-essential anchor `isLocalCdkAssetImage` and
+  // `loadAssetContextForTarget` use, so override + classifier verdict
+  // / pin detector all agree on which container drives the verdict).
+  // Sibling containers without an override entry still go through
+  // their normal pull / build path.
+  if (opts.imageOverrideTag !== undefined) {
+    const essential =
+      service.task.containers.find((c) => c.essential) ?? service.task.containers[0];
+    if (essential) {
+      taskOpts.imageOverrideByContainer = new Map([[essential.name, opts.imageOverrideTag]]);
+      // Skip docker pull on the override tag — it's a deterministic
+      // local-only tag the engine just built, NOT something present
+      // in any registry. The runner's prepareImages short-circuit
+      // already bypasses prepareOneImage for this container, so the
+      // global --no-pull semantics for sibling containers are
+      // unaffected.
+    }
   }
 
   // Front-door pools for THIS service (built once at the emulator level and
@@ -2205,6 +2355,114 @@ export async function resolveSharedSidecarCredentials(options: {
 }
 
 /**
+ * Issue #238 — boot-time `--image-override` resolution + build pass.
+ * Walks every booted service target's representative container image
+ * to identify the pinned set (ECR / public-registry pin — the same
+ * anchor `isLocalCdkAssetImage` uses), feeds the pinned set + raw
+ * `--image-override` / `--image-build-arg` / `--image-build-secret` /
+ * `--image-target` / `--no-interactive-overrides` flag values into
+ * the engine ({@link resolveImageOverrides}), then `docker build`s
+ * every covered Dockerfile via {@link runImageOverrideBuilds} and
+ * returns the per-target local-tag map the boot path threads into
+ * each runner.
+ *
+ * Sequential by design — most overrides share a base image, and the
+ * engine's deterministic tag plus BuildKit's layer cache make
+ * sequential builds nearly as fast as a parallel fan-out while
+ * keeping the build log readable. Throws on a parser / picker /
+ * build failure; the outer try/finally tears down what was set up.
+ *
+ * The boot prompt is fired only when STDIN+STDOUT are TTYs AND
+ * `--no-interactive-overrides` is unset; non-TTY contexts silently
+ * skip the prompt and rely on whatever the explicit flags resolved.
+ */
+async function resolveAndBuildImageOverrides(args: {
+  perTarget: string[];
+  stacks: StackInfo[];
+  options: EcsServiceEmulatorOptions;
+  extraStateProviders: ExtraStateProviders | undefined;
+  logger: ReturnType<typeof getLogger>;
+}): Promise<Map<string, string>> {
+  const { perTarget, stacks, options, extraStateProviders, logger } = args;
+
+  // Identify pinned targets via the same representative-essential anchor
+  // the boot WARN + reload-skip use. Each target is re-resolved with its
+  // own image-resolution context (so `--from-cfn-stack` substitutions
+  // are applied) — necessary to distinguish a CDK asset, an ECR pin,
+  // and a public-registry pin in the resolved template.
+  const pinnedTargets: string[] = [];
+  const pinnedLabels = new Map<string, string>();
+  for (const target of perTarget) {
+    const parsed = parseEcsTarget(target);
+    const candidate = pickCandidateStack(parsed.stackPattern, stacks);
+    const stateProvider = createLocalStateProvider(
+      options,
+      candidate?.stackName ?? '',
+      await resolveCfnFallbackRegion(options, candidate?.region),
+      extraStateProviders
+    );
+    let imageContext: EcsImageResolutionContext | undefined;
+    let service: ResolvedEcsService | undefined;
+    try {
+      imageContext = await buildEcsImageResolutionContext(target, stacks, options, stateProvider);
+      service = resolveEcsServiceTarget(target, stacks, imageContext, {
+        suppressLoadBalancerWarning: true,
+      });
+    } catch (err) {
+      logger.debug(
+        `--image-override peek failed for '${target}': ${err instanceof Error ? err.message : String(err)}.`
+      );
+      continue;
+    } finally {
+      if (stateProvider) stateProvider.dispose();
+    }
+    if (!service) continue;
+    if (isLocalCdkAssetImage(service)) continue;
+    pinnedTargets.push(target);
+    const uri = describePinnedImageUri(service);
+    if (uri) pinnedLabels.set(target, uri);
+  }
+
+  // Parse the raw flags. A parser error is reported as a clean
+  // user-error (no override is possible if the flag is malformed).
+  const rawFlags = parseImageOverrideFlags({
+    ...(options.imageOverride && { imageOverride: options.imageOverride }),
+    ...(options.imageBuildArg && { imageBuildArg: options.imageBuildArg }),
+    ...(options.imageBuildSecret && { imageBuildSecret: options.imageBuildSecret }),
+    ...(options.imageTarget && { imageTarget: options.imageTarget }),
+  });
+
+  // Short-circuit: nothing to do when no override flag was passed AND
+  // no pinned target exists to prompt about. Saves a no-op pass on the
+  // common case (local CDK assets, no flags).
+  if (
+    pinnedTargets.length === 0 &&
+    rawFlags.explicit.size === 0 &&
+    rawFlags.pickerPaths.length === 0
+  ) {
+    return new Map();
+  }
+
+  // Resolve overrides — picker prompts + boot prompt fire here when in
+  // a TTY and `--no-interactive-overrides` is unset.
+  const noInteractive = options.interactiveOverrides === false;
+  const overrides = await resolveImageOverrides({
+    rawFlags,
+    pinnedTargets,
+    pinnedLabels,
+    interactiveBootPrompt: true,
+    noInteractive,
+  });
+
+  if (overrides.size === 0) return new Map();
+
+  // Build every covered Dockerfile. Per-build progress goes to stdout
+  // via the docker-runner's streamLive path; the per-target
+  // "Building override image..." line surfaces ahead of each build.
+  return runImageOverrideBuilds(overrides);
+}
+
+/**
  * Add the CLI options shared by both ECS-service commands (`start-service` and
  * `start-alb`) to a command. The command-specific argument / description and
  * the one unique option (`--host-port` vs `--lb-port`) are added by each
@@ -2303,4 +2561,74 @@ export function addCommonEcsServiceOptions(cmd: Command): Command {
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
   cmd.addOption(deprecatedRegionOption);
   return cmd;
+}
+
+/**
+ * Issue #238 — register the `--image-override` flag family shared by
+ * `cdkl start-service` and `cdkl start-alb`. Both commands accept the
+ * same six flags; this helper keeps the wording in one place so a
+ * future copy edit lands in both surfaces simultaneously.
+ *
+ * `--image-override` is repeatable (accumulator); `--image-build-arg`
+ * and `--image-build-secret` are repeatable too; `--image-target` is a
+ * single string (the global multi-stage target); `--no-interactive-overrides`
+ * and `--strict-overrides` are booleans. The engine in
+ * {@link runEcsServiceEmulator}'s boot path consumes them.
+ *
+ * Shared between `cdkl start-service` and `cdkl start-alb` and exposed
+ * via `cdk-local/internal` so host CLIs (e.g. cdkd) that wrap the same
+ * factories inherit the flag set without duplication.
+ */
+export function addImageOverrideOptions(cmd: Command): Command {
+  return cmd
+    .addOption(
+      new Option(
+        '--image-override <service=dockerfile or dockerfile...>',
+        "Replace a service target's deployed-registry image with a local `docker build` of the " +
+          'supplied Dockerfile (repeatable). Two forms: <service>=<dockerfile> binds the service ' +
+          'explicitly; a bare <dockerfile> opens a multi-select picker against the still-uncovered ' +
+          'pinned targets (one Dockerfile across N services). Mix freely. Lets `--from-cfn-stack` ' +
+          'still reach real AWS state while you iterate locally on the application container.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--image-build-arg <KEY=VAL...>',
+        'Global `docker build --build-arg KEY=VAL` pair applied to every --image-override build ' +
+          '(repeatable). Lets a CDK Dockerfile that branches on an ARG (env target, base image tag, ' +
+          'package mirror) honor that ARG locally without editing the Dockerfile.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--image-build-secret <id=src...>',
+        'Global `docker build --secret id=<id>,src=<src>` entry applied to every --image-override ' +
+          'build (repeatable). Enables `RUN --mount=type=secret,id=<id>` in the Dockerfile — the ' +
+          'standard private-registry / npm-token recipe (e.g. ' +
+          '`--image-build-secret npmrc=./.npmrc`).'
+      )
+    )
+    .addOption(
+      new Option(
+        '--image-target <stage>',
+        'Global `docker build --target=<stage>` forwarded to every --image-override build. Useful ' +
+          'when the Dockerfile is multi-stage and you want to stop at a specific intermediate stage.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--no-interactive-overrides',
+        'Suppress the interactive boot prompt that walks each pinned target asking for a Dockerfile ' +
+          'path, and the multi-select prompt fired by `--image-override <dockerfile>` (picker form). ' +
+          'Useful for CI / scripted invocations.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--strict-overrides',
+        'Fail fast at boot when any pinned target remains uncovered after `--image-override` + the ' +
+          'boot prompt resolve. Off by default; the boot WARN per uncovered pinned target still ' +
+          'fires regardless.'
+      ).default(false)
+    );
 }

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -20,6 +20,7 @@ import {
 import type { ExtraStateProviders } from './local-state-source.js';
 import {
   addCommonEcsServiceOptions,
+  addImageOverrideOptions,
   runEcsServiceEmulator,
   type EcsServiceEmulatorOptions,
   type EmulatorStrategy,
@@ -379,6 +380,7 @@ export function createLocalStartAlbCommand(opts: CreateLocalStartAlbCommandOptio
  * clusters. Chainable: returns `cmd`.
  */
 export function addAlbSpecificOptions(cmd: Command): Command {
+  addImageOverrideOptions(cmd);
   return cmd
     .addOption(
       new Option(

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -9,6 +9,7 @@ import {
 import type { ExtraStateProviders } from './local-state-source.js';
 import {
   addCommonEcsServiceOptions,
+  addImageOverrideOptions,
   runEcsServiceEmulator,
   type EcsServiceEmulatorOptions,
   type EmulatorStrategy,
@@ -127,6 +128,7 @@ export function createLocalStartServiceCommand(
  * for that contract to live.
  */
 export function addStartServiceSpecificOptions(cmd: Command): Command {
+  addImageOverrideOptions(cmd);
   return cmd
     .addOption(
       new Option(

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -501,6 +501,7 @@ export { resolveSingleTarget } from './local/target-picker.js';
  */
 export {
   addCommonEcsServiceOptions,
+  addImageOverrideOptions,
   runEcsServiceEmulator,
   parseMaxTasks,
   parseRestartPolicy,
@@ -520,6 +521,30 @@ export {
   type PlannedLambdaForwardTarget,
   type PlannedFrontDoorListener,
 } from './cli/commands/ecs-service-emulator.js';
+
+/**
+ * Issue #238 — `cdkl start-service` / `cdkl start-alb`
+ * `--image-override` family engine. `parseImageOverrideFlags` is the
+ * pure flag parser; `resolveImageOverrides` walks the picker + boot
+ * prompt against the pinned target set; `runImageOverrideBuilds`
+ * runs the `docker build` pass per covered Dockerfile and returns
+ * the deterministic local tag per target. `buildImageOverrideTag` is
+ * exposed so a host CLI can reproduce the same tag-naming convention
+ * if it wraps the engine for a custom build orchestration. Re-exported
+ * via `cdk-local/internal` so host CLIs (e.g. cdkd) inherit the same
+ * override pipeline without a byte-identical copy.
+ */
+export {
+  parseImageOverrideFlags,
+  resolveImageOverrides,
+  runImageOverrideBuilds,
+  buildImageOverrideTag,
+  ImageOverrideError,
+  type ImageOverrideEntry,
+  type ImageOverrideMap,
+  type ImageOverrideGlobals,
+  type RawImageOverrideFlags,
+} from './local/image-override-engine.js';
 
 /**
  * `start-alb` front-door target resolver — maps an ALB target string to a

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -141,6 +141,17 @@ export interface RunEcsTaskOptions {
    */
   imagePlanByContainer?: Map<string, string>;
   /**
+   * Issue #238 — per-container `--image-override` tag map (set by the
+   * `start-service` / `start-alb` boot path when an override engine
+   * resolved a local Dockerfile build for this task's representative
+   * container). When a container's name is in this map, the runner
+   * uses the override tag verbatim and skips `prepareOneImage`'s
+   * pull / build path for that container. Sibling containers without
+   * an entry still go through their normal resolution. Distinct from
+   * {@link imagePlanByContainer} (a full short-circuit used by tests).
+   */
+  imageOverrideByContainer?: ReadonlyMap<string, string>;
+  /**
    * Optional second-from-last octet of the link-local /24 subnet for this
    * task's docker network (1..254). Default 170 (AWS-documented). `cdkl start-service` walks this per replica so concurrent replicas
    * don't collide on the same /24. See `buildEndpointSubnet` in
@@ -714,6 +725,17 @@ async function prepareImages(
   // Sequential is fine — most tasks have 1–3 containers and each
   // `docker build` / pull would saturate IO anyway.
   for (const container of task.containers) {
+    // Issue #238 — per-container --image-override tag short-circuit.
+    // The override engine already built + tagged this image locally;
+    // skip the pull / build path entirely so we never `docker pull`
+    // a deterministic local-only tag (which doesn't exist in any
+    // registry).
+    const overrideTag = options.imageOverrideByContainer?.get(container.name);
+    if (overrideTag !== undefined) {
+      out.set(container.name, overrideTag);
+      logger.debug(`Container '${container.name}' image=${overrideTag} (--image-override)`);
+      continue;
+    }
     const image = await prepareOneImage(task, container, options);
     out.set(container.name, image);
     logger.debug(`Container '${container.name}' image=${image}`);

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -716,7 +716,14 @@ function sleep(ms: number): Promise<void> {
  * populated in parallel up to the asset-manifest bound (single
  * `docker build` for shared assets is left to docker's own cache).
  */
-async function prepareImages(
+// Exported for unit testing — the `imageOverrideByContainer`
+// short-circuit (issue #238) is the load-bearing contract for
+// `--image-override` end-to-end, but `runEcsTask` is too heavy to drive
+// for a single short-circuit branch (network + secrets + docker run /
+// log stream / exit propagation). Exposing `prepareImages` lets us
+// behaviourally cover the override branch without booting the full
+// task runner.
+export async function prepareImages(
   task: ResolvedEcsTask,
   out: Map<string, string>,
   options: RunEcsTaskOptions

--- a/src/local/image-override-engine.ts
+++ b/src/local/image-override-engine.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import { isCancel, multiselect, text } from '@clack/prompts';
 import { CdkLocalError } from '../utils/error-handler.js';
@@ -204,7 +204,16 @@ export function parseImageOverrideFlags(input: {
         `Invalid --image-build-secret value "${raw}": id and src must both be non-empty.`
       );
     }
-    buildSecrets.set(id, src);
+    // Resolve `src` against `process.cwd()` (not the build context
+    // dir = Dockerfile parent, which is where `docker build`
+    // resolves a relative `--secret src=...` against). Users type
+    // these from the repo root (e.g. `--image-build-secret
+    // npmrc=./.npmrc`), expecting the path to mean what every other
+    // CLI flag means — relative to where they ran the command.
+    // Mirrors the absolute-resolution behavior of
+    // `--image-override <path>` in {@link makeEntryFromPath}.
+    const absSrc = isAbsolute(src) ? src : resolvePath(process.cwd(), src);
+    buildSecrets.set(id, absSrc);
   }
 
   const globals: ImageOverrideGlobals = { buildArgs, buildSecrets };
@@ -353,7 +362,7 @@ export async function resolveImageOverrides(args: {
       const message =
         `Detected pinned image on '${target}'` +
         (label ? ` (${label})` : '') +
-        '. Override with a local build? Enter a Dockerfile path, or leave blank to skip.';
+        '. Override with a local build? [path / N]:';
       const answer = await text({
         message,
         placeholder: '',
@@ -364,7 +373,12 @@ export async function resolveImageOverrides(args: {
         );
       }
       const value = ((answer as string | undefined) ?? '').trim();
-      if (!value || value.toUpperCase() === 'N') continue;
+      // Accept any case variant of `n` / `no` as a skip sentinel
+      // (matches the `[path / N]` hint shown to the user). Empty
+      // input also skips.
+      if (!value) continue;
+      const lower = value.toLowerCase();
+      if (lower === 'n' || lower === 'no') continue;
       out.set(target, makeEntryFromPath(value, rawFlags.globals, cwd));
     }
   }
@@ -408,17 +422,37 @@ function makeEntryFromPath(
 
 /**
  * Deterministic local-only image tag for one override entry. Fingerprints
- * the Dockerfile path + service target + build args / secrets / stage so
- * a re-run with the same inputs hits docker's layer cache.
+ * the Dockerfile path + its CONTENTS (sha256 of the bytes) + service
+ * target + build args / secrets / stage. Including the Dockerfile bytes
+ * means an edit to the Dockerfile flips the tag — the rebuild rolling
+ * primitive then boots a new container under the bumped tag instead of
+ * reusing the old build's cached layers under a stale tag. Two
+ * back-to-back runs against an unchanged Dockerfile + flags still hit
+ * the same tag so docker's layer cache works.
  *
  * Tag shape: `<resourceNamePrefix>-override-<svcSlug>-<hash>:local`.
  * `:local` is intentionally NOT `:latest` so a `docker pull` on it fails
  * fast (these images are local-build-only by design).
+ *
+ * Throws on a missing Dockerfile — the caller has already asserted
+ * existence in {@link makeEntryFromPath}, so a throw here is a
+ * programming error (or the Dockerfile vanished between resolve and
+ * build, which is a race the user wants to know about).
  */
 export function buildImageOverrideTag(serviceTarget: string, entry: ImageOverrideEntry): string {
   const hash = createHash('sha256');
   hash.update('dockerfile=');
   hash.update(entry.dockerfile);
+  hash.update('\0dockerfile-bytes-sha256=');
+  // Hash the Dockerfile contents so an edit to the file flips the tag.
+  // sha256 the file (small text, sync read is fine) and feed the digest
+  // into the outer hash. existsSync was already asserted up-front by
+  // `makeEntryFromPath`; a vanished-since-resolve race surfaces here
+  // as an exception with a clear path in the message.
+  const dockerfileBytesDigest = createHash('sha256')
+    .update(readFileSync(entry.dockerfile))
+    .digest('hex');
+  hash.update(dockerfileBytesDigest);
   hash.update('\0target=');
   hash.update(serviceTarget);
   hash.update('\0stage=');

--- a/src/local/image-override-engine.ts
+++ b/src/local/image-override-engine.ts
@@ -1,0 +1,498 @@
+import { createHash } from 'node:crypto';
+import { existsSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
+import { isCancel, multiselect, text } from '@clack/prompts';
+import { CdkLocalError } from '../utils/error-handler.js';
+import { getLogger } from '../utils/logger.js';
+import { runDockerStreaming } from '../utils/docker-cmd.js';
+import { getEmbedConfig } from './embed-config.js';
+import { isInteractive } from './target-picker.js';
+
+/**
+ * Issue #238 — `--image-override` family for `cdkl start-service` /
+ * `cdkl start-alb`. Turns "image pinned to a deployed registry" into
+ * "image built locally from a supplied Dockerfile" on a per-service-
+ * target basis, so a `--from-cfn-stack` boot can still iterate on
+ * local source for the application container while real DynamoDB /
+ * Secrets / SSM stay wired in.
+ *
+ * This module is pure orchestration: it parses the flag forms
+ * (`<svc>=<dockerfile>` explicit, `<dockerfile>` picker-form, mixed),
+ * fires `@clack/prompts` multi-selects to resolve picker-form entries
+ * against uncovered pinned targets, optionally walks an interactive
+ * boot prompt against the still-uncovered targets, runs `docker build`
+ * once per covered target tagging a deterministic local-only tag, and
+ * surfaces the resolved map back to the emulator. The emulator then
+ * mutates the resolved ECS service's representative container image
+ * to that tag (via the runner's `imageOverrideByContainer` hook) so
+ * `docker run` boots the locally-built image instead of pulling the
+ * deployed registry pin.
+ *
+ * The override goes through the rebuild rolling primitive on `--watch`
+ * reload (Phase 2/3 of issue #214) — the classifier sees a CDK-asset-
+ * like image (kind injected as `cdk-asset`-equivalent), so source-only
+ * edits trigger the rolling rebuild rather than the no-op-reload skip
+ * (#234's guard). The boot WARN that #237 introduced still fires for
+ * uncovered pinned targets, but its `--watch` gate is dropped here so
+ * the warning surfaces on any cold start when an ECR pin is detected
+ * (per #238's "WARN broadening" line in the behavior matrix).
+ *
+ * Host-side use case: cdkd and other shim hosts that wrap
+ * `runEcsServiceEmulator` re-export {@link resolveImageOverrides} +
+ * {@link buildImageOverrideTag} via `cdk-local/internal` so their
+ * `local start-service` / `local start-alb` ports inherit the override
+ * pipeline 1:1 (and the deterministic local-tag naming) without a
+ * byte-identical copy.
+ *
+ * @internal — not part of the semver-covered public surface; exposed
+ * via `cdk-local/internal` only.
+ */
+
+/**
+ * Per-target build inputs the engine collects from the CLI flags + boot
+ * prompt + picker, then hands off to {@link runImageOverrideBuilds}.
+ */
+export interface ImageOverrideEntry {
+  /** Absolute path to the Dockerfile to build from. */
+  dockerfile: string;
+  /** Absolute path to the build context directory (Dockerfile's parent for v1). */
+  contextDir: string;
+  /** `--image-build-arg KEY=VAL` pairs, applied globally to every override. */
+  buildArgs: Map<string, string>;
+  /** `--image-build-secret id=src` entries, applied globally to every override. */
+  buildSecrets: Map<string, string>;
+  /** Optional `--image-target <stage>` multi-stage build target. */
+  targetStage?: string;
+}
+
+/** The fully resolved override map: service target string -> build inputs. */
+export type ImageOverrideMap = Map<string, ImageOverrideEntry>;
+
+/**
+ * Errors surfaced by the engine. Used so the emulator can render a
+ * consistent error class to the user (the global error handler maps
+ * `CdkLocalError` subclasses to a clean stack-trace-free message).
+ */
+export class ImageOverrideError extends CdkLocalError {
+  constructor(message: string, cause?: Error) {
+    super(message, 'IMAGE_OVERRIDE_ERROR', cause);
+    this.name = 'ImageOverrideError';
+    Object.setPrototypeOf(this, ImageOverrideError.prototype);
+  }
+}
+
+/**
+ * Global build options that apply to every overridden target. v1 spec
+ * keeps these flat (no per-service variants — tracked separately in
+ * issue #240). Used inside {@link parseImageOverrideFlags} when promoting
+ * each per-target raw entry into a full {@link ImageOverrideEntry}.
+ */
+export interface ImageOverrideGlobals {
+  buildArgs: Map<string, string>;
+  buildSecrets: Map<string, string>;
+  targetStage?: string;
+}
+
+/**
+ * Raw flag-parse outcome. Per-target dockerfile assignments split into
+ * two buckets: explicit `<svc>=<dockerfile>` and picker-form
+ * `<dockerfile>` (a bare path with no `=`, resolved against uncovered
+ * pinned targets via a multi-select prompt). Both forms may appear in
+ * one invocation; the emulator's resolver collapses them into a single
+ * {@link ImageOverrideMap}.
+ */
+export interface RawImageOverrideFlags {
+  /** Service target -> Dockerfile path (explicit mapping). */
+  explicit: Map<string, string>;
+  /**
+   * Picker-form Dockerfile paths, in CLI argv order. Each fires its
+   * own multi-select against the un-picked-so-far pinned targets;
+   * earlier-occurrence picks are excluded from later pickers so one
+   * service is never bound to two Dockerfiles.
+   */
+  pickerPaths: string[];
+  globals: ImageOverrideGlobals;
+}
+
+/**
+ * Parse the raw `--image-override` / `--image-build-arg` /
+ * `--image-build-secret` / `--image-target` flag arrays Commander
+ * surfaces into the structured {@link RawImageOverrideFlags} shape.
+ * Pure (no docker / filesystem calls); throws
+ * {@link ImageOverrideError} on a malformed token so the emulator can
+ * surface a clean error before any container is touched.
+ *
+ * - `--image-override <svc>=<dockerfile>` -> `explicit.set(svc, dockerfile)`
+ * - `--image-override <dockerfile>` (no `=`) -> `pickerPaths.push(...)`
+ * - `--image-build-arg KEY=VAL` -> `globals.buildArgs.set('KEY', 'VAL')`
+ * - `--image-build-secret id=src` -> `globals.buildSecrets.set('id', 'src')`
+ * - `--image-target <stage>` -> `globals.targetStage = '<stage>'`
+ *
+ * Collision detection: a service target named more than once in
+ * `--image-override <svc>=...` is an error (last-write-wins would
+ * silently drop the earlier mapping; explicit error is clearer).
+ */
+export function parseImageOverrideFlags(input: {
+  imageOverride?: string[];
+  imageBuildArg?: string[];
+  imageBuildSecret?: string[];
+  imageTarget?: string;
+}): RawImageOverrideFlags {
+  const explicit = new Map<string, string>();
+  const pickerPaths: string[] = [];
+  for (const raw of input.imageOverride ?? []) {
+    const eq = raw.indexOf('=');
+    // No `=` -> picker form. An absolute path or a relative one both
+    // pass through verbatim; existence is checked downstream when the
+    // engine resolves which target this path binds to.
+    if (eq < 0) {
+      if (!raw) {
+        throw new ImageOverrideError(
+          'Invalid --image-override value: empty string. Pass <service>=<dockerfile> or just <dockerfile>.'
+        );
+      }
+      pickerPaths.push(raw);
+      continue;
+    }
+    const svc = raw.slice(0, eq).trim();
+    const dockerfile = raw.slice(eq + 1).trim();
+    if (!svc) {
+      throw new ImageOverrideError(
+        `Invalid --image-override value "${raw}": left side (service target) is empty.`
+      );
+    }
+    if (!dockerfile) {
+      throw new ImageOverrideError(
+        `Invalid --image-override value "${raw}": right side (Dockerfile path) is empty.`
+      );
+    }
+    if (explicit.has(svc)) {
+      throw new ImageOverrideError(
+        `Duplicate --image-override for service '${svc}': already mapped to '${explicit.get(svc)}'. ` +
+          'Pass each service target at most once in explicit form.'
+      );
+    }
+    explicit.set(svc, dockerfile);
+  }
+
+  const buildArgs = new Map<string, string>();
+  for (const raw of input.imageBuildArg ?? []) {
+    const eq = raw.indexOf('=');
+    if (eq <= 0) {
+      throw new ImageOverrideError(`Invalid --image-build-arg value "${raw}": expected KEY=VAL.`);
+    }
+    const key = raw.slice(0, eq).trim();
+    const value = raw.slice(eq + 1);
+    if (!key) {
+      throw new ImageOverrideError(`Invalid --image-build-arg value "${raw}": empty key.`);
+    }
+    buildArgs.set(key, value);
+  }
+
+  const buildSecrets = new Map<string, string>();
+  for (const raw of input.imageBuildSecret ?? []) {
+    const eq = raw.indexOf('=');
+    if (eq <= 0) {
+      throw new ImageOverrideError(
+        `Invalid --image-build-secret value "${raw}": expected id=src (e.g. npmrc=./.npmrc).`
+      );
+    }
+    const id = raw.slice(0, eq).trim();
+    const src = raw.slice(eq + 1).trim();
+    if (!id || !src) {
+      throw new ImageOverrideError(
+        `Invalid --image-build-secret value "${raw}": id and src must both be non-empty.`
+      );
+    }
+    buildSecrets.set(id, src);
+  }
+
+  const globals: ImageOverrideGlobals = { buildArgs, buildSecrets };
+  if (input.imageTarget !== undefined) {
+    if (!input.imageTarget) {
+      throw new ImageOverrideError('Invalid --image-target value: empty string.');
+    }
+    globals.targetStage = input.imageTarget;
+  }
+
+  return { explicit, pickerPaths, globals };
+}
+
+/**
+ * Resolve `--image-override` flag inputs (raw) + a list of pinned
+ * service targets into the final {@link ImageOverrideMap}. Walks four
+ * stages:
+ *
+ *   1. Apply every explicit `<svc>=<dockerfile>` mapping. A service in
+ *      `explicit` but NOT in `pinnedTargets` is a no-op warning
+ *      (logged at warn) — the user named a non-pinned target, which
+ *      probably indicates a typo or a CDK app change; we don't fail.
+ *   2. For each picker-form Dockerfile path, fire a multi-select against
+ *      the still-uncovered pinned targets. A single picker-form path
+ *      may bind to multiple targets (one Dockerfile shared across N
+ *      services); already-bound targets are excluded from later pickers.
+ *      Skipped when not in a TTY OR `noInteractive` is true — those
+ *      contexts emit a warning and skip the picker path (treated as
+ *      "no override for any target").
+ *   3. Optional boot prompt: when `interactiveBootPrompt` is true AND
+ *      we're in a TTY, walk each remaining uncovered pinned target
+ *      and ask "Override with a local build? [path / N]" via clack's
+ *      `text` prompt. A non-empty answer is treated as an additional
+ *      explicit mapping; `N` / empty / Esc skips the target.
+ *
+ * Returns the resolved override map. Throws
+ * {@link ImageOverrideError} on a malformed picker response or a
+ * Dockerfile path that doesn't exist (caught up-front before any
+ * docker build runs).
+ */
+export async function resolveImageOverrides(args: {
+  rawFlags: RawImageOverrideFlags;
+  /**
+   * Service target strings whose representative image is pinned to a
+   * deployed registry (the engine only needs the names, not the full
+   * resolved services).
+   */
+  pinnedTargets: ReadonlyArray<string>;
+  /**
+   * Display label per pinned target (typically the deployed-registry
+   * URI from {@link describePinnedImageUri}). Surfaced in the boot
+   * prompt + picker hint so the user knows which image they're
+   * overriding. Optional — falls back to the target name.
+   */
+  pinnedLabels?: ReadonlyMap<string, string>;
+  /**
+   * When true and a TTY is present AND a picker-form Dockerfile or a
+   * boot-prompt path was supplied, the engine prompts. When false /
+   * non-TTY, prompts are skipped and the resolver returns whatever
+   * the explicit map covers (possibly empty).
+   */
+  interactiveBootPrompt?: boolean;
+  /**
+   * When true, every interactive prompt is suppressed (boot prompt
+   * AND picker-form). Mirrors `--no-interactive-overrides`.
+   */
+  noInteractive?: boolean;
+  /**
+   * Working directory used to resolve relative `--image-override`
+   * paths. Defaults to `process.cwd()`. Passed in so tests can inject
+   * a tmp dir.
+   */
+  cwd?: string;
+}): Promise<ImageOverrideMap> {
+  const logger = getLogger();
+  const { rawFlags, pinnedTargets, noInteractive } = args;
+  const cwd = args.cwd ?? process.cwd();
+  const pinnedSet = new Set(pinnedTargets);
+  const labels = args.pinnedLabels ?? new Map();
+
+  // Stage 1: explicit mappings.
+  const out = new Map<string, ImageOverrideEntry>();
+  for (const [svc, dockerfileRaw] of rawFlags.explicit.entries()) {
+    if (!pinnedSet.has(svc)) {
+      logger.warn(
+        `--image-override: service '${svc}' is not in the pinned-target set ` +
+          '(no deployed-registry pin detected for it). Mapping ignored.'
+      );
+      continue;
+    }
+    out.set(svc, makeEntryFromPath(dockerfileRaw, rawFlags.globals, cwd));
+  }
+
+  // Stage 2: picker-form Dockerfile paths.
+  if (rawFlags.pickerPaths.length > 0) {
+    const canPrompt = isInteractive() && noInteractive !== true;
+    if (!canPrompt) {
+      logger.warn(
+        `--image-override <dockerfile> (picker form) requires an interactive TTY ` +
+          'and --no-interactive-overrides not to be set. Skipping picker-form mapping(s).'
+      );
+    } else {
+      for (const dockerfileRaw of rawFlags.pickerPaths) {
+        const uncovered = pinnedTargets.filter((t) => !out.has(t));
+        if (uncovered.length === 0) {
+          logger.warn(
+            `--image-override ${dockerfileRaw}: no uncovered pinned targets left to bind to. Skipped.`
+          );
+          continue;
+        }
+        const options = uncovered.map((t) => ({
+          value: t,
+          label: t,
+          ...(labels.get(t) ? { hint: labels.get(t) as string } : {}),
+        }));
+        const picked = await multiselect({
+          message:
+            `Pick the pinned target(s) to bind to ` +
+            `'${dockerfileRaw}' (space to toggle, enter to confirm; empty cancels):`,
+          options,
+          required: false,
+        });
+        if (isCancel(picked)) {
+          throw new ImageOverrideError(
+            'Image-override picker cancelled. Re-run without picker-form or with --no-interactive-overrides.'
+          );
+        }
+        const chosen = (picked as string[] | undefined) ?? [];
+        if (chosen.length === 0) {
+          logger.warn(`--image-override ${dockerfileRaw}: empty selection. Skipped.`);
+          continue;
+        }
+        const entry = makeEntryFromPath(dockerfileRaw, rawFlags.globals, cwd);
+        for (const t of chosen) out.set(t, entry);
+      }
+    }
+  }
+
+  // Stage 3: interactive boot prompt for the still-uncovered pinned
+  // targets. Gated on TTY + the caller's opt-in flag + the user not
+  // having passed --no-interactive-overrides.
+  if (args.interactiveBootPrompt === true && isInteractive() && noInteractive !== true) {
+    for (const target of pinnedTargets) {
+      if (out.has(target)) continue;
+      const label = labels.get(target);
+      const message =
+        `Detected pinned image on '${target}'` +
+        (label ? ` (${label})` : '') +
+        '. Override with a local build? Enter a Dockerfile path, or leave blank to skip.';
+      const answer = await text({
+        message,
+        placeholder: '',
+      });
+      if (isCancel(answer)) {
+        throw new ImageOverrideError(
+          'Image-override boot prompt cancelled. Re-run with --no-interactive-overrides to suppress, or pass --image-override explicitly.'
+        );
+      }
+      const value = ((answer as string | undefined) ?? '').trim();
+      if (!value || value.toUpperCase() === 'N') continue;
+      out.set(target, makeEntryFromPath(value, rawFlags.globals, cwd));
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Promote a per-target Dockerfile path + globals into a full
+ * {@link ImageOverrideEntry}. Resolves the path against `cwd`, asserts
+ * the Dockerfile exists and is a regular file (so the user sees
+ * "file not found" up-front rather than mid-`docker build`), and
+ * derives the build context as the Dockerfile's parent directory
+ * (the v1 simplification — custom contexts are tracked separately).
+ */
+function makeEntryFromPath(
+  raw: string,
+  globals: ImageOverrideGlobals,
+  cwd: string
+): ImageOverrideEntry {
+  const abs = isAbsolute(raw) ? raw : resolvePath(cwd, raw);
+  if (!existsSync(abs)) {
+    throw new ImageOverrideError(
+      `--image-override: Dockerfile '${raw}' does not exist (resolved to '${abs}').`
+    );
+  }
+  const st = statSync(abs);
+  if (!st.isFile()) {
+    throw new ImageOverrideError(
+      `--image-override: '${raw}' is not a regular file (resolved to '${abs}').`
+    );
+  }
+  return {
+    dockerfile: abs,
+    contextDir: dirname(abs),
+    buildArgs: globals.buildArgs,
+    buildSecrets: globals.buildSecrets,
+    ...(globals.targetStage !== undefined && { targetStage: globals.targetStage }),
+  };
+}
+
+/**
+ * Deterministic local-only image tag for one override entry. Fingerprints
+ * the Dockerfile path + service target + build args / secrets / stage so
+ * a re-run with the same inputs hits docker's layer cache.
+ *
+ * Tag shape: `<resourceNamePrefix>-override-<svcSlug>-<hash>:local`.
+ * `:local` is intentionally NOT `:latest` so a `docker pull` on it fails
+ * fast (these images are local-build-only by design).
+ */
+export function buildImageOverrideTag(serviceTarget: string, entry: ImageOverrideEntry): string {
+  const hash = createHash('sha256');
+  hash.update('dockerfile=');
+  hash.update(entry.dockerfile);
+  hash.update('\0target=');
+  hash.update(serviceTarget);
+  hash.update('\0stage=');
+  hash.update(entry.targetStage ?? '');
+  hash.update('\0args={');
+  for (const [k, v] of entry.buildArgs.entries()) {
+    hash.update(k);
+    hash.update('=');
+    hash.update(v);
+    hash.update(';');
+  }
+  hash.update('}\0secrets={');
+  for (const [k, v] of entry.buildSecrets.entries()) {
+    hash.update(k);
+    hash.update('=');
+    hash.update(v);
+    hash.update(';');
+  }
+  hash.update('}');
+  const svcSlug = serviceTarget
+    .replace(/[^A-Za-z0-9]+/g, '-')
+    .slice(0, 24)
+    .toLowerCase();
+  return `${getEmbedConfig().resourceNamePrefix}-override-${svcSlug}-${hash
+    .digest('hex')
+    .slice(0, 16)}:local`;
+}
+
+/**
+ * Build every overridden image via `docker build`. Returns a per-target
+ * `serviceTarget -> localTag` map the emulator threads into each
+ * runner's `imageOverrideByContainer` (mutating the resolved service's
+ * representative container's image to this tag).
+ *
+ * Each build runs sequentially (parallelism is left to docker's own
+ * BuildKit cache — most overrides share a base image, so a sequential
+ * order maximizes cache reuse). On any failure the function rejects
+ * with {@link ImageOverrideError}; the emulator surfaces this before
+ * any container is started.
+ */
+export async function runImageOverrideBuilds(
+  overrides: ImageOverrideMap
+): Promise<Map<string, string>> {
+  const logger = getLogger();
+  const out = new Map<string, string>();
+  for (const [target, entry] of overrides.entries()) {
+    const tag = buildImageOverrideTag(target, entry);
+    const args: string[] = ['build', '--tag', tag, '--file', entry.dockerfile];
+    for (const [k, v] of entry.buildArgs.entries()) {
+      args.push('--build-arg', `${k}=${v}`);
+    }
+    for (const [id, src] of entry.buildSecrets.entries()) {
+      args.push('--secret', `id=${id},src=${src}`);
+    }
+    if (entry.targetStage !== undefined) {
+      args.push('--target', entry.targetStage);
+    }
+    args.push('.');
+    logger.info(
+      `Building override image for '${target}' from '${entry.dockerfile}' (tag=${tag})...`
+    );
+    try {
+      await runDockerStreaming(args, {
+        cwd: entry.contextDir,
+        env: { BUILDX_NO_DEFAULT_ATTESTATIONS: '1' },
+      });
+    } catch (err) {
+      const e = err as { stderr?: string; message?: string };
+      throw new ImageOverrideError(
+        `docker build failed for --image-override '${target}' (Dockerfile=${entry.dockerfile}): ` +
+          (e.stderr?.trim() || e.message || String(err))
+      );
+    }
+    out.set(target, tag);
+  }
+  return out;
+}

--- a/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
@@ -48,22 +48,26 @@ describe('ecs-service-emulator image-override engine binding (issue #238)', () =
     expect(source).toMatch(/runImageOverrideBuilds/);
   });
 
-  it('boot path calls `resolveAndBuildImageOverrides` BEFORE the bootOneTarget loop', () => {
+  it('boot path calls `resolveAndBuildImageOverrides` before threading per-target tags into `bootOneTarget`', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
-    // Anchor on the boot-time block's rationale comment + the resolver
-    // helper call + the boot loop downstream of it.
-    const bootRegion = source.match(
-      /resolveAndBuildImageOverrides\([\s\S]*?for \(const pt of perTarget\) \{[\s\S]*?await bootOneTarget\(/
-    );
-    expect(bootRegion, 'boot path missing the engine call').toBeTruthy();
-  });
-
-  it('bootOneTarget receives the per-target override tag', () => {
-    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
-    const bootCall = source.match(
-      /await bootOneTarget\([\s\S]*?imageOverrideTags\.get\(pt\.boot\.target\)[\s\S]*?\);/
-    );
-    expect(bootCall, 'bootOneTarget call missing the imageOverrideTags.get(...) thread').toBeTruthy();
+    // Anchor on (a) the boot-time helper call site and (b) the
+    // bootOneTarget invocation downstream of it that consumes the
+    // per-target tag. The text between them isn't pinned (avoids the
+    // brittle `for (const pt of perTarget)` literal that recurs four
+    // times in the source); ordering is the load-bearing constraint —
+    // the tags must be resolved BEFORE the first runner boot so a
+    // covered target's representative container starts with the
+    // local-built image, not the deployed pin.
+    const resolveIdx = source.indexOf('resolveAndBuildImageOverrides(');
+    const bootCallIdx = source.indexOf('imageOverrideTags.get(pt.boot.target)');
+    expect(resolveIdx, 'resolveAndBuildImageOverrides call missing').toBeGreaterThan(-1);
+    expect(bootCallIdx, 'bootOneTarget thread of imageOverrideTags missing').toBeGreaterThan(-1);
+    expect(resolveIdx).toBeLessThan(bootCallIdx);
+    // The downstream consumer must be the `bootOneTarget` call, not
+    // some other use of the tag map.
+    expect(
+      source.slice(resolveIdx, bootCallIdx + 'imageOverrideTags.get(pt.boot.target)'.length)
+    ).toMatch(/await bootOneTarget\(/);
   });
 
   it('reloadAllServices accepts and threads `imageOverrideTags` into rollOneTarget', () => {
@@ -80,6 +84,30 @@ describe('ecs-service-emulator image-override engine binding (issue #238)', () =
     expect(body).toMatch(/imageOverrideTags\.get\(newBoot\.target\)/);
   });
 
+  it('reload-skip guard carves out overridden targets (regression: #241-B1)', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The reload-skip guard that pre-empts the rolling primitive for
+    // deployed-registry pins MUST also bypass-skip overridden targets,
+    // because the override is injected at runner level and
+    // controller.service still holds the deployed pin. Without the
+    // carve-out, every overridden target gets silently skipped on
+    // every reload and the feature is broken for its main use case.
+    const reloadFnRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadFnRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadFnRegion![0];
+    // The guard's three load-bearing clauses must all be present AND
+    // co-located inside the same if-condition with the carve-out.
+    const guardRegion = body.match(
+      /if \(\s*verdict\.kind === 'rebuild'[\s\S]*?!isLocalCdkAssetImage\(controller\.service\)[\s\S]*?!imageOverrideTags\.has\(newBoot\.target\)[\s\S]*?\) \{[\s\S]*?Reload skipped/
+    );
+    expect(
+      guardRegion,
+      'reload-skip guard missing the !imageOverrideTags.has(newBoot.target) carve-out'
+    ).toBeTruthy();
+  });
+
   it('watcher onChange forwards `imageOverrideTags` to reloadAllServices', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
     // The watcher block lives downstream of the boot WARN loop; it
@@ -91,15 +119,67 @@ describe('ecs-service-emulator image-override engine binding (issue #238)', () =
     );
     expect(watcherCall, 'watcher onChange missing the imageOverrideTags thread').toBeTruthy();
   });
+});
 
-  it('strict-overrides guard fails fast when uncovered pinned targets remain', () => {
+describe('enforceStrictOverrides (issue #238 strict-overrides guard, behavioral)', () => {
+  // Behavioral test for the strict-overrides guard. Pulled out of the
+  // boot path into a small pure helper so we don't need to mock the
+  // entire emulator (synth + resolvers + docker) just to exercise the
+  // one if-statement. The boot path's call site is locked via the
+  // source-grep test below.
+  it('throws LocalStartServiceError naming every uncovered target when strict=true', async () => {
+    const { enforceStrictOverrides } = await import(
+      '../../../src/cli/commands/ecs-service-emulator.js'
+    );
+    const { LocalStartServiceError } = await import('../../../src/utils/error-handler.js');
+    expect(() => enforceStrictOverrides(true, ['AppService', 'AuthService'])).toThrow(
+      LocalStartServiceError
+    );
+    try {
+      enforceStrictOverrides(true, ['AppService', 'AuthService']);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LocalStartServiceError);
+      const msg = (err as Error).message;
+      expect(msg).toContain('AppService');
+      expect(msg).toContain('AuthService');
+      expect(msg).toMatch(/2 pinned target\(s\)/);
+      expect(msg).toMatch(/--image-override/);
+    }
+  });
+
+  it('is a no-op when strict=false (even with uncovered targets)', async () => {
+    const { enforceStrictOverrides } = await import(
+      '../../../src/cli/commands/ecs-service-emulator.js'
+    );
+    expect(() => enforceStrictOverrides(false, ['AppService'])).not.toThrow();
+  });
+
+  it('is a no-op when strict=true but no targets are uncovered', async () => {
+    const { enforceStrictOverrides } = await import(
+      '../../../src/cli/commands/ecs-service-emulator.js'
+    );
+    expect(() => enforceStrictOverrides(true, [])).not.toThrow();
+  });
+
+  it('boot path calls enforceStrictOverrides AFTER the per-target uncovered scan', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
-    // The guard sits in the boot path after the per-target WARN loop;
-    // it MUST consult `options.strictOverrides` + `uncoveredPinnedTargets`
-    // and throw `LocalStartServiceError` so the user sees a clear exit
-    // code rather than a half-booted emulator.
-    expect(source).toMatch(/options\.strictOverrides === true/);
-    expect(source).toMatch(/uncoveredPinnedTargets/);
+    // The boot path's strict-overrides binding: the per-target scan
+    // builds up `uncoveredPinnedTargets`, then the helper is invoked
+    // with `options.strictOverrides === true` + the populated array.
+    // Pin both ends so an inlining refactor or a reordering that
+    // would fire the guard before the scan populates the array
+    // surfaces here.
+    const scanIdx = source.indexOf('uncoveredPinnedTargets.push');
+    const enforceIdx = source.indexOf('enforceStrictOverrides(');
+    expect(scanIdx, 'uncoveredPinnedTargets.push missing').toBeGreaterThan(-1);
+    expect(enforceIdx, 'enforceStrictOverrides call missing').toBeGreaterThan(-1);
+    expect(scanIdx).toBeLessThan(enforceIdx);
+    // The call site MUST forward options.strictOverrides AND the
+    // populated array — anything else is a wiring bug.
+    expect(source).toMatch(
+      /enforceStrictOverrides\(\s*options\.strictOverrides === true\s*,\s*uncoveredPinnedTargets\s*\)/
+    );
   });
 });
 

--- a/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vite-plus/test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EMULATOR_SOURCE = path.join(
+  __dirname,
+  '../../../src/cli/commands/ecs-service-emulator.ts'
+);
+
+/**
+ * Issue #238 site-level binding test (mirrors the
+ * `feedback_site_level_binding_test.md` pattern used by
+ * `ecs-service-emulator-image-pin-binding.test.ts`).
+ *
+ * `parseImageOverrideFlags` / `resolveImageOverrides` /
+ * `runImageOverrideBuilds` (in `src/local/image-override-engine.ts`)
+ * are consumed at TWO sites inside `ecs-service-emulator.ts`:
+ *
+ *   1. The boot-time `resolveAndBuildImageOverrides` helper — runs
+ *      after `boots` is resolved but BEFORE `bootOneTarget` is called,
+ *      and produces a `serviceTarget -> localTag` map the boot loop
+ *      threads into each runner.
+ *   2. The reload-time `rollOneTarget` call — passes the same map
+ *      through to the rolling primitive so a `--watch` rebuild on an
+ *      overridden target rolls against the new local Dockerfile build
+ *      instead of the deployed pin (and so the #234 reload-skip guard
+ *      doesn't fire for overridden targets, which now ARE locally
+ *      rebuildable).
+ *
+ * The engine has its own unit coverage in
+ * `tests/unit/local/image-override-engine.test.ts`, but the wiring is
+ * load-bearing and can't be exercised end-to-end without docker + a
+ * real ECS template. This source-grep test pins the bindings so a
+ * refactor that silently re-inlines the engine on one side (or drops
+ * the reload-side threading) surfaces here instead of shipping a
+ * regressed `--watch` no-op for overridden targets.
+ */
+describe('ecs-service-emulator image-override engine binding (issue #238)', () => {
+  it('imports `parseImageOverrideFlags` + `resolveImageOverrides` + `runImageOverrideBuilds` from the engine module', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    expect(source).toMatch(
+      /from\s+['"]\.\.\/\.\.\/local\/image-override-engine\.js['"]/
+    );
+    expect(source).toMatch(/parseImageOverrideFlags/);
+    expect(source).toMatch(/resolveImageOverrides/);
+    expect(source).toMatch(/runImageOverrideBuilds/);
+  });
+
+  it('boot path calls `resolveAndBuildImageOverrides` BEFORE the bootOneTarget loop', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // Anchor on the boot-time block's rationale comment + the resolver
+    // helper call + the boot loop downstream of it.
+    const bootRegion = source.match(
+      /resolveAndBuildImageOverrides\([\s\S]*?for \(const pt of perTarget\) \{[\s\S]*?await bootOneTarget\(/
+    );
+    expect(bootRegion, 'boot path missing the engine call').toBeTruthy();
+  });
+
+  it('bootOneTarget receives the per-target override tag', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    const bootCall = source.match(
+      /await bootOneTarget\([\s\S]*?imageOverrideTags\.get\(pt\.boot\.target\)[\s\S]*?\);/
+    );
+    expect(bootCall, 'bootOneTarget call missing the imageOverrideTags.get(...) thread').toBeTruthy();
+  });
+
+  it('reloadAllServices accepts and threads `imageOverrideTags` into rollOneTarget', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The reload function must declare the `imageOverrideTags` param
+    // (so the watcher's `onChange` passes it through) AND consult it
+    // inside the per-target rollOneTarget call.
+    const reloadFnRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadFnRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadFnRegion![0];
+    expect(body).toMatch(/imageOverrideTags:\s*ReadonlyMap<string,\s*string>/);
+    expect(body).toMatch(/imageOverrideTags\.get\(newBoot\.target\)/);
+  });
+
+  it('watcher onChange forwards `imageOverrideTags` to reloadAllServices', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The watcher block lives downstream of the boot WARN loop; it
+    // composes the `reloadAllServices` arg object. `imageOverrideTags`
+    // must be in that arg list verbatim, otherwise the reload-side
+    // wouldn't have an override map to consult.
+    const watcherCall = source.match(
+      /onChange:\s*\(changedPaths\)\s*=>\s*\{[\s\S]*?reloadAllServices\(\{[\s\S]*?imageOverrideTags[\s\S]*?\}\)/
+    );
+    expect(watcherCall, 'watcher onChange missing the imageOverrideTags thread').toBeTruthy();
+  });
+
+  it('strict-overrides guard fails fast when uncovered pinned targets remain', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The guard sits in the boot path after the per-target WARN loop;
+    // it MUST consult `options.strictOverrides` + `uncoveredPinnedTargets`
+    // and throw `LocalStartServiceError` so the user sees a clear exit
+    // code rather than a half-booted emulator.
+    expect(source).toMatch(/options\.strictOverrides === true/);
+    expect(source).toMatch(/uncoveredPinnedTargets/);
+  });
+});
+
+describe('addImageOverrideOptions wiring (issue #238)', () => {
+  const SERVICE_SOURCE = path.join(
+    __dirname,
+    '../../../src/cli/commands/local-start-service.ts'
+  );
+  const ALB_SOURCE = path.join(__dirname, '../../../src/cli/commands/local-start-alb.ts');
+
+  it('start-service composes addImageOverrideOptions inside its specific-options helper', () => {
+    const source = readFileSync(SERVICE_SOURCE, 'utf-8');
+    expect(source).toMatch(/addImageOverrideOptions/);
+    // The helper is called from inside addStartServiceSpecificOptions —
+    // a refactor that moves it to the factory body (bypassing the
+    // shared helper) would break host-CLI parity per the cdkd-parity
+    // convention. Pin the binding site.
+    const block = source.match(
+      /export function addStartServiceSpecificOptions\(cmd: Command\): Command \{[\s\S]*?\}/
+    );
+    expect(block, 'addStartServiceSpecificOptions block missing').toBeTruthy();
+    expect(block![0]).toMatch(/addImageOverrideOptions\(cmd\)/);
+  });
+
+  it('start-alb composes addImageOverrideOptions inside its specific-options helper', () => {
+    const source = readFileSync(ALB_SOURCE, 'utf-8');
+    expect(source).toMatch(/addImageOverrideOptions/);
+    const block = source.match(
+      /export function addAlbSpecificOptions\(cmd: Command\): Command \{[\s\S]*?\}/
+    );
+    expect(block, 'addAlbSpecificOptions block missing').toBeTruthy();
+    expect(block![0]).toMatch(/addImageOverrideOptions\(cmd\)/);
+  });
+});

--- a/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
@@ -68,12 +68,23 @@ describe('ecs-service-emulator image-pin detector binding (issue #234)', () => {
     // an `if (watchActive)` block. A regression that re-introduces such
     // a gate would silently swallow the WARN for non-watch runs, which
     // is precisely what #238 explicitly broadens.
-    const bootWarnRegion = source.match(
-      /Warn UP-FRONT[\s\S]*?for \(const pt of perTarget\) \{[\s\S]*?logger\.warn\([\s\S]*?\}[\s\S]*?(?=Phase 1 \+ Phase 2|\Z)/
-    );
-    expect(bootWarnRegion, 'boot-time WARN region missing').toBeTruthy();
+    //
+    // Anchor on the intrinsic "Warn UP-FRONT" rationale comment + the
+    // helper call site (`isLocalCdkAssetImage` / `describePinnedImageUri`
+    // / `logger.warn`) that the WARN block uniquely uses. Avoid keying
+    // on incidental landmarks like `Phase 1 + Phase 2` (which a future
+    // section-comment rewrite would silently invalidate). Take the
+    // 4-KiB window starting at "Warn UP-FRONT" — large enough to
+    // contain the entire loop, small enough that an unrelated future
+    // copy of the helpers downstream won't accidentally bleed in.
+    const warnUpFrontIdx = source.indexOf('Warn UP-FRONT');
+    expect(warnUpFrontIdx).toBeGreaterThan(-1);
+    const bootWarnRegion = source.slice(warnUpFrontIdx, warnUpFrontIdx + 4096);
+    expect(bootWarnRegion).toMatch(/isLocalCdkAssetImage/);
+    expect(bootWarnRegion).toMatch(/describePinnedImageUri/);
+    expect(bootWarnRegion).toMatch(/logger\.warn\(/);
     // The region preceding the per-target loop must not open a watch gate.
-    const preLoop = bootWarnRegion![0].split('for (const pt of perTarget)')[0]!;
+    const preLoop = bootWarnRegion.split('for (const pt of perTarget)')[0]!;
     expect(preLoop).not.toMatch(/if \(watchActive\)/);
   });
 

--- a/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
@@ -61,6 +61,22 @@ describe('ecs-service-emulator image-pin detector binding (issue #234)', () => {
     expect(bootWarnLoop, 'boot-time WARN loop missing').toBeTruthy();
   });
 
+  it('boot-time WARN is NOT gated on --watch (broadened by issue #238)', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // After #238, the boot WARN fires on any cold start (not just under
+    // `--watch`). Specifically, the WARN loop must NOT be wrapped inside
+    // an `if (watchActive)` block. A regression that re-introduces such
+    // a gate would silently swallow the WARN for non-watch runs, which
+    // is precisely what #238 explicitly broadens.
+    const bootWarnRegion = source.match(
+      /Warn UP-FRONT[\s\S]*?for \(const pt of perTarget\) \{[\s\S]*?logger\.warn\([\s\S]*?\}[\s\S]*?(?=Phase 1 \+ Phase 2|\Z)/
+    );
+    expect(bootWarnRegion, 'boot-time WARN region missing').toBeTruthy();
+    // The region preceding the per-target loop must not open a watch gate.
+    const preLoop = bootWarnRegion![0].split('for (const pt of perTarget)')[0]!;
+    expect(preLoop).not.toMatch(/if \(watchActive\)/);
+  });
+
   it('reload-time skip guard AND-s `verdict.reason` with `isLocalCdkAssetImage(controller.service)` BEFORE `rollOneTarget`', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
     // The skip guard MUST live between the classifier's verdict assignment

--- a/tests/unit/cli/ecs-service-emulator-resolve-helper-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-resolve-helper-binding.test.ts
@@ -58,8 +58,12 @@ describe('ecs-service-emulator resolveServiceAndRunnerOpts binding (Phase 2 of i
     // this would make `--watch` noisy in a noticeable but easy-to-miss
     // way (every save reprints the boot banner).
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // After #238 the reload call also threads an optional
+    // `imageOverrideTag` into the opts object alongside `quiet: true`;
+    // the regex anchors on `quiet: true` followed (in whatever bracket
+    // shape) by the end of the same call.
     expect(source).toMatch(
-      /async\s+function\s+rollOneTarget[\s\S]*?resolveServiceAndRunnerOpts\([\s\S]*?\{\s*quiet:\s*true\s*\}/
+      /async\s+function\s+rollOneTarget[\s\S]*?resolveServiceAndRunnerOpts\([\s\S]*?quiet:\s*true/
     );
   });
 });

--- a/tests/unit/cli/local-start-service-watch.test.ts
+++ b/tests/unit/cli/local-start-service-watch.test.ts
@@ -34,7 +34,19 @@ describe('start-service option surface contract (addStartServiceSpecificOptions)
     // flags. Adding or removing one without updating the list below is a
     // semver-relevant surface change.
     const flags = longFlagsOf(addStartServiceSpecificOptions(new Command()));
-    expect(flags).toEqual(['--host-port', '--watch']);
+    expect(flags).toEqual([
+      '--host-port',
+      // Issue #238 — `--image-override` family shared with start-alb
+      // via `addImageOverrideOptions`. A semver-relevant surface
+      // addition.
+      '--image-build-arg',
+      '--image-build-secret',
+      '--image-override',
+      '--image-target',
+      '--no-interactive-overrides',
+      '--strict-overrides',
+      '--watch',
+    ]);
   });
 
   it('createLocalStartServiceCommand surface equals common + start-service-specific (no inline drift)', () => {

--- a/tests/unit/local/ecs-task-runner-image-override.test.ts
+++ b/tests/unit/local/ecs-task-runner-image-override.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type {
+  ResolvedEcsContainer,
+  ResolvedEcsTask,
+} from '../../../src/local/ecs-task-resolver.js';
+
+/**
+ * Issue #238 (T2) — behavioral test for the per-container
+ * `--image-override` short-circuit inside `prepareImages`.
+ *
+ * The boot path in `start-service` / `start-alb` builds an override tag
+ * locally via `runImageOverrideBuilds`, then threads it into each
+ * runner's `RunEcsTaskOptions.imageOverrideByContainer`. When that map
+ * holds an entry for a container, the runner uses the local tag VERBATIM
+ * and skips the pull / build path entirely — otherwise a `docker pull`
+ * for a deterministic-local-only tag (which doesn't exist in any
+ * registry) would fail at boot.
+ *
+ * Mocks the heavy boundaries (`docker-runner`, `docker-build`,
+ * `ecr-puller`) so a non-override entry would call into them; the
+ * override entry MUST NOT.
+ */
+
+const { pullImageMock, pullEcrImageMock, buildDockerImageMock } = vi.hoisted(() => ({
+  pullImageMock: vi.fn(),
+  pullEcrImageMock: vi.fn(),
+  buildDockerImageMock: vi.fn(),
+}));
+
+vi.mock('../../../src/local/docker-runner.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/local/docker-runner.js')>(
+    '../../../src/local/docker-runner.js'
+  );
+  return {
+    ...actual,
+    pullImage: pullImageMock,
+  };
+});
+
+vi.mock('../../../src/local/ecr-puller.js', () => ({
+  pullEcrImage: pullEcrImageMock,
+}));
+
+vi.mock('../../../src/assets/docker-build.js', () => ({
+  buildDockerImage: buildDockerImageMock,
+}));
+
+const { prepareImages } = await import('../../../src/local/ecs-task-runner.js');
+
+function publicImageContainer(name: string, uri: string): ResolvedEcsContainer {
+  return {
+    name,
+    image: { kind: 'public', uri },
+    environment: {},
+    sensitiveEnvKeys: [],
+    secrets: [],
+    portMappings: [],
+    mountPoints: [],
+    dependsOn: [],
+    links: [],
+    essential: true,
+    ulimits: [],
+    warnings: [],
+  } as unknown as ResolvedEcsContainer;
+}
+
+describe('ecs-task-runner prepareImages --image-override short-circuit (issue #238)', () => {
+  beforeEach(() => {
+    pullImageMock.mockReset();
+    pullEcrImageMock.mockReset();
+    buildDockerImageMock.mockReset();
+    pullImageMock.mockResolvedValue(undefined);
+  });
+
+  it('uses the override tag verbatim and skips pullImage when the container has an override', async () => {
+    const container = publicImageContainer(
+      'app',
+      '123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:1.2.3'
+    );
+    const task = { containers: [container] } as unknown as ResolvedEcsTask;
+    const out = new Map<string, string>();
+    await prepareImages(task, out, {
+      // Caller-supplied override map (the same shape the start-service
+      // boot path threads through).
+      imageOverrideByContainer: new Map([['app', 'cdkl-override-app-deadbeef:local']]),
+      // Required-shape fields that aren't load-bearing for this branch.
+      keepRunning: false,
+      detach: false,
+      skipPull: false,
+    } as unknown as Parameters<typeof prepareImages>[2]);
+    expect(out.get('app')).toBe('cdkl-override-app-deadbeef:local');
+    expect(pullImageMock).not.toHaveBeenCalled();
+    expect(pullEcrImageMock).not.toHaveBeenCalled();
+    expect(buildDockerImageMock).not.toHaveBeenCalled();
+  });
+
+  it('falls through to pullImage (deployed URI) when no override entry is present for the container', async () => {
+    const container = publicImageContainer(
+      'sidecar',
+      'public.ecr.aws/docker/library/busybox:latest'
+    );
+    const task = { containers: [container] } as unknown as ResolvedEcsTask;
+    const out = new Map<string, string>();
+    await prepareImages(task, out, {
+      // Override map either empty or naming a DIFFERENT container —
+      // both should fall through. Test the "different container"
+      // case so we cover the per-container key lookup.
+      imageOverrideByContainer: new Map([['app', 'cdkl-override-app-deadbeef:local']]),
+      keepRunning: false,
+      detach: false,
+      skipPull: false,
+    } as unknown as Parameters<typeof prepareImages>[2]);
+    expect(pullImageMock).toHaveBeenCalledTimes(1);
+    expect(pullImageMock.mock.calls[0]![0]).toBe(
+      'public.ecr.aws/docker/library/busybox:latest'
+    );
+    expect(out.get('sidecar')).toBe('public.ecr.aws/docker/library/busybox:latest');
+  });
+
+  it('mixes override + fall-through across sibling containers in one task', async () => {
+    // The override map can hold a subset of the task's containers; the
+    // rest go through `prepareOneImage`'s pull/build path normally.
+    const containers = [
+      publicImageContainer('app', '123.dkr.ecr.us-east-1.amazonaws.com/app:1.0.0'),
+      publicImageContainer('logs', 'public.ecr.aws/aws-observability/aws-otel-collector:latest'),
+    ];
+    const task = { containers } as unknown as ResolvedEcsTask;
+    const out = new Map<string, string>();
+    await prepareImages(task, out, {
+      imageOverrideByContainer: new Map([['app', 'cdkl-override-app-cafef00d:local']]),
+      keepRunning: false,
+      detach: false,
+      skipPull: false,
+    } as unknown as Parameters<typeof prepareImages>[2]);
+    expect(out.get('app')).toBe('cdkl-override-app-cafef00d:local');
+    expect(out.get('logs')).toBe(
+      'public.ecr.aws/aws-observability/aws-otel-collector:latest'
+    );
+    // pullImage called exactly once — for the sidecar, not the overridden app.
+    expect(pullImageMock).toHaveBeenCalledTimes(1);
+    expect(pullImageMock.mock.calls[0]![0]).toBe(
+      'public.ecr.aws/aws-observability/aws-otel-collector:latest'
+    );
+  });
+});

--- a/tests/unit/local/image-override-engine.test.ts
+++ b/tests/unit/local/image-override-engine.test.ts
@@ -1,13 +1,34 @@
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vite-plus/test';
-import {
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// T1 — mock `runDockerStreaming` at module level so we can capture the
+// argv `runImageOverrideBuilds` hands to docker (the canonical
+// `--build-arg` / `--secret` / `--target` / `-f` shapes the spec
+// promises). The mock must be installed BEFORE the engine module is
+// imported; `vi.hoisted` keeps the spy a stable reference inside the
+// `vi.mock` factory.
+const { runDockerStreamingMock } = vi.hoisted(() => ({
+  runDockerStreamingMock: vi.fn(),
+}));
+vi.mock('../../../src/utils/docker-cmd.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/docker-cmd.js')>(
+    '../../../src/utils/docker-cmd.js'
+  );
+  return {
+    ...actual,
+    runDockerStreaming: runDockerStreamingMock,
+  };
+});
+
+const {
   buildImageOverrideTag,
   ImageOverrideError,
   parseImageOverrideFlags,
   resolveImageOverrides,
-} from '../../../src/local/image-override-engine.js';
+  runImageOverrideBuilds,
+} = await import('../../../src/local/image-override-engine.js');
 
 /**
  * Issue #238 — engine-level coverage. The picker / boot-prompt branches
@@ -87,12 +108,16 @@ describe('parseImageOverrideFlags (issue #238)', () => {
     expect(() => parseImageOverrideFlags({ imageBuildArg: ['=value'] })).toThrow(/KEY=VAL/);
   });
 
-  it('parses --image-build-secret id=src into globals.buildSecrets', () => {
+  it('parses --image-build-secret id=src into globals.buildSecrets (src resolved to abs path)', () => {
     const out = parseImageOverrideFlags({
       imageBuildSecret: ['npmrc=./.npmrc', 'token=./token.txt'],
     });
-    expect(out.globals.buildSecrets.get('npmrc')).toBe('./.npmrc');
-    expect(out.globals.buildSecrets.get('token')).toBe('./token.txt');
+    // M1: relative `src` is resolved against process.cwd() at parse
+    // time so `docker build --secret src=...` (which is relative to
+    // the build context = Dockerfile parent) doesn't misresolve when
+    // the Dockerfile lives in a subdir.
+    expect(out.globals.buildSecrets.get('npmrc')).toBe(path.resolve(process.cwd(), './.npmrc'));
+    expect(out.globals.buildSecrets.get('token')).toBe(path.resolve(process.cwd(), './token.txt'));
   });
 
   it('rejects --image-build-secret with empty id or src', () => {
@@ -164,7 +189,8 @@ describe('resolveImageOverrides Stage 1: explicit mappings (issue #238)', () => 
     });
     const entry = overrides.get('Svc');
     expect(entry?.buildArgs.get('NODE_ENV')).toBe('production');
-    expect(entry?.buildSecrets.get('npmrc')).toBe('./.npmrc');
+    // M1: secret src resolved to absolute path against process.cwd() at parse.
+    expect(entry?.buildSecrets.get('npmrc')).toBe(path.resolve(process.cwd(), './.npmrc'));
     expect(entry?.targetStage).toBe('release');
   });
 });
@@ -211,54 +237,308 @@ describe('resolveImageOverrides Stage 3: boot prompt (non-TTY skip) (issue #238)
 });
 
 describe('buildImageOverrideTag (issue #238)', () => {
-  const baseEntry = {
-    dockerfile: '/abs/Dockerfile',
-    contextDir: '/abs',
-    buildArgs: new Map<string, string>(),
-    buildSecrets: new Map<string, string>(),
-  };
+  function makeEntry(overrides: {
+    dockerfile?: string;
+    body?: string;
+    buildArgs?: Map<string, string>;
+    buildSecrets?: Map<string, string>;
+    targetStage?: string;
+  } = {}) {
+    // The tag function reads Dockerfile bytes (B2 fix), so the file
+    // must exist. Default body is `FROM scratch`; callers override
+    // when they need to test bytes-flip determinism.
+    const dockerfile =
+      overrides.dockerfile ?? makeTmpDockerfile('Dockerfile.tag-test');
+    if (overrides.body !== undefined) {
+      writeFileSync(dockerfile, overrides.body);
+    }
+    return {
+      dockerfile,
+      contextDir: path.dirname(dockerfile),
+      buildArgs: overrides.buildArgs ?? new Map<string, string>(),
+      buildSecrets: overrides.buildSecrets ?? new Map<string, string>(),
+      ...(overrides.targetStage !== undefined && { targetStage: overrides.targetStage }),
+    };
+  }
 
   it('produces a deterministic tag for the same inputs', () => {
-    const tag1 = buildImageOverrideTag('AppService', baseEntry);
-    const tag2 = buildImageOverrideTag('AppService', baseEntry);
+    const entry = makeEntry();
+    const tag1 = buildImageOverrideTag('AppService', entry);
+    const tag2 = buildImageOverrideTag('AppService', entry);
     expect(tag1).toBe(tag2);
   });
 
   it('differs by service target', () => {
-    const tagA = buildImageOverrideTag('A', baseEntry);
-    const tagB = buildImageOverrideTag('B', baseEntry);
+    const entry = makeEntry();
+    const tagA = buildImageOverrideTag('A', entry);
+    const tagB = buildImageOverrideTag('B', entry);
     expect(tagA).not.toBe(tagB);
   });
 
   it('differs when Dockerfile path differs', () => {
-    const tag1 = buildImageOverrideTag('Svc', baseEntry);
-    const tag2 = buildImageOverrideTag('Svc', { ...baseEntry, dockerfile: '/other/Dockerfile' });
+    const entry1 = makeEntry();
+    const entry2 = makeEntry();
+    const tag1 = buildImageOverrideTag('Svc', entry1);
+    const tag2 = buildImageOverrideTag('Svc', entry2);
+    // Different tmp dirs => different paths => different tags.
     expect(tag1).not.toBe(tag2);
   });
 
+  it('flips when the Dockerfile CONTENTS change (B2 fix)', () => {
+    // Same path, same flags — the only diff is the Dockerfile bytes.
+    // Before B2 the tag was stable across edits; after B2 the tag
+    // bumps so the rebuild rolling primitive boots a new container
+    // under the new tag instead of reusing the stale build.
+    const dockerfile = makeTmpDockerfile('Dockerfile.bytes-flip');
+    writeFileSync(dockerfile, 'FROM alpine:3.18\n');
+    const tagBefore = buildImageOverrideTag('Svc', {
+      dockerfile,
+      contextDir: path.dirname(dockerfile),
+      buildArgs: new Map(),
+      buildSecrets: new Map(),
+    });
+    writeFileSync(dockerfile, 'FROM alpine:3.19\n');
+    const tagAfter = buildImageOverrideTag('Svc', {
+      dockerfile,
+      contextDir: path.dirname(dockerfile),
+      buildArgs: new Map(),
+      buildSecrets: new Map(),
+    });
+    expect(tagBefore).not.toBe(tagAfter);
+  });
+
   it('differs when build args / secrets / target-stage differ', () => {
-    const tag0 = buildImageOverrideTag('Svc', baseEntry);
+    // All four entries point at the SAME Dockerfile so the only
+    // axis under test is the flag set.
+    const dockerfile = makeTmpDockerfile('Dockerfile.flag-axes');
+    const base = {
+      dockerfile,
+      contextDir: path.dirname(dockerfile),
+      buildArgs: new Map<string, string>(),
+      buildSecrets: new Map<string, string>(),
+    };
+    const tag0 = buildImageOverrideTag('Svc', base);
     const tag1 = buildImageOverrideTag('Svc', {
-      ...baseEntry,
+      ...base,
       buildArgs: new Map([['K', 'V']]),
     });
     const tag2 = buildImageOverrideTag('Svc', {
-      ...baseEntry,
+      ...base,
       buildSecrets: new Map([['s', 'v']]),
     });
-    const tag3 = buildImageOverrideTag('Svc', { ...baseEntry, targetStage: 'builder' });
+    const tag3 = buildImageOverrideTag('Svc', { ...base, targetStage: 'builder' });
     expect(new Set([tag0, tag1, tag2, tag3]).size).toBe(4);
   });
 
   it('emits a :local suffix so the tag never pretends to be a real registry', () => {
-    const tag = buildImageOverrideTag('Svc', baseEntry);
+    const tag = buildImageOverrideTag('Svc', makeEntry());
     expect(tag.endsWith(':local')).toBe(true);
   });
 
   it('slugifies a CDK path with slashes into a docker-tag-safe segment', () => {
-    const tag = buildImageOverrideTag('MyStack/AppService', baseEntry);
+    const tag = buildImageOverrideTag('MyStack/AppService', makeEntry());
     // No `/` allowed in tag NAME segment (Docker rejects it).
     const repo = tag.split(':')[0]!;
     expect(repo).not.toMatch(/\//);
+  });
+});
+
+describe('runImageOverrideBuilds argv shape (issue #238, T1)', () => {
+  beforeEach(() => {
+    runDockerStreamingMock.mockReset();
+    runDockerStreamingMock.mockResolvedValue(undefined);
+  });
+
+  it('emits canonical `--build-arg KEY=VAL` for every build-args entry', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.args');
+    const overrides = new Map([
+      [
+        'AppService',
+        {
+          dockerfile,
+          contextDir: path.dirname(dockerfile),
+          buildArgs: new Map([
+            ['NODE_ENV', 'production'],
+            ['NPM_TOKEN', 'tok'],
+          ]),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+    ]);
+    await runImageOverrideBuilds(overrides);
+    expect(runDockerStreamingMock).toHaveBeenCalledTimes(1);
+    const [args, opts] = runDockerStreamingMock.mock.calls[0]!;
+    expect(args[0]).toBe('build');
+    // --build-arg shows up as a (--build-arg, KEY=VAL) consecutive pair.
+    const buildArgIdx = (args as string[]).indexOf('--build-arg');
+    expect(buildArgIdx).toBeGreaterThan(-1);
+    expect(args).toContain('NODE_ENV=production');
+    expect(args).toContain('NPM_TOKEN=tok');
+    // BUILDX_NO_DEFAULT_ATTESTATIONS=1 lives in env, not argv.
+    expect(opts.env?.BUILDX_NO_DEFAULT_ATTESTATIONS).toBe('1');
+  });
+
+  it('emits canonical `--secret id=<id>,src=<src>` for every build-secrets entry', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.secrets');
+    const overrides = new Map([
+      [
+        'AppService',
+        {
+          dockerfile,
+          contextDir: path.dirname(dockerfile),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map([['npmrc', '/abs/.npmrc']]),
+        },
+      ],
+    ]);
+    await runImageOverrideBuilds(overrides);
+    const [args] = runDockerStreamingMock.mock.calls[0]!;
+    const secretIdx = (args as string[]).indexOf('--secret');
+    expect(secretIdx).toBeGreaterThan(-1);
+    expect(args[secretIdx + 1]).toBe('id=npmrc,src=/abs/.npmrc');
+  });
+
+  it('emits `--target <stage>` when targetStage is set, omits it otherwise', async () => {
+    const dockerfileA = makeTmpDockerfile('Dockerfile.stage-on');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.stage-off');
+    await runImageOverrideBuilds(
+      new Map([
+        [
+          'Svc',
+          {
+            dockerfile: dockerfileA,
+            contextDir: path.dirname(dockerfileA),
+            buildArgs: new Map<string, string>(),
+            buildSecrets: new Map<string, string>(),
+            targetStage: 'builder',
+          },
+        ],
+      ])
+    );
+    let [args] = runDockerStreamingMock.mock.calls[0]!;
+    let targetIdx = (args as string[]).indexOf('--target');
+    expect(targetIdx).toBeGreaterThan(-1);
+    expect(args[targetIdx + 1]).toBe('builder');
+
+    runDockerStreamingMock.mockClear();
+    await runImageOverrideBuilds(
+      new Map([
+        [
+          'Svc',
+          {
+            dockerfile: dockerfileB,
+            contextDir: path.dirname(dockerfileB),
+            buildArgs: new Map<string, string>(),
+            buildSecrets: new Map<string, string>(),
+          },
+        ],
+      ])
+    );
+    [args] = runDockerStreamingMock.mock.calls[0]!;
+    targetIdx = (args as string[]).indexOf('--target');
+    expect(targetIdx, '--target must NOT appear when targetStage is unset').toBe(-1);
+  });
+
+  it('tags with `<resourceNamePrefix>-override-<svcSlug>-<hash>:local` + uses `-f <dockerfile>` + context dot', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.shape');
+    await runImageOverrideBuilds(
+      new Map([
+        [
+          'AppService',
+          {
+            dockerfile,
+            contextDir: path.dirname(dockerfile),
+            buildArgs: new Map<string, string>(),
+            buildSecrets: new Map<string, string>(),
+          },
+        ],
+      ])
+    );
+    const [args, opts] = runDockerStreamingMock.mock.calls[0]!;
+    // --tag <local-tag> directly after `build`.
+    const tagIdx = (args as string[]).indexOf('--tag');
+    expect(tagIdx).toBeGreaterThan(-1);
+    const tag = args[tagIdx + 1] as string;
+    expect(tag).toMatch(/-override-appservice-[0-9a-f]+:local$/);
+    // -f <dockerfile>.
+    const fIdx = (args as string[]).indexOf('--file');
+    expect(fIdx).toBeGreaterThan(-1);
+    expect(args[fIdx + 1]).toBe(dockerfile);
+    // Build context = `.` (Dockerfile parent, via `cwd` opt).
+    expect(args[args.length - 1]).toBe('.');
+    expect(opts.cwd).toBe(path.dirname(dockerfile));
+  });
+
+  it('wraps a docker build failure with ImageOverrideError + stderr tail', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.fail');
+    runDockerStreamingMock.mockRejectedValueOnce(
+      Object.assign(new Error('spawn failed'), {
+        stderr: 'ERROR: failed to compute cache key: not found\n',
+      })
+    );
+    await expect(
+      runImageOverrideBuilds(
+        new Map([
+          [
+            'BadSvc',
+            {
+              dockerfile,
+              contextDir: path.dirname(dockerfile),
+              buildArgs: new Map<string, string>(),
+              buildSecrets: new Map<string, string>(),
+            },
+          ],
+        ])
+      )
+    ).rejects.toMatchObject({
+      name: 'ImageOverrideError',
+      message: expect.stringMatching(/failed to compute cache key/),
+    });
+  });
+});
+
+describe('parseImageOverrideFlags --image-build-secret src resolution (M1)', () => {
+  it('resolves a relative `src` against process.cwd()', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildSecret: ['npmrc=./.npmrc'],
+    });
+    const resolved = out.globals.buildSecrets.get('npmrc');
+    expect(resolved).toBe(path.resolve(process.cwd(), './.npmrc'));
+    expect(path.isAbsolute(resolved!)).toBe(true);
+  });
+
+  it('passes through an already-absolute `src`', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildSecret: ['token=/etc/secrets/token.txt'],
+    });
+    expect(out.globals.buildSecrets.get('token')).toBe('/etc/secrets/token.txt');
+  });
+});
+
+describe('resolveImageOverrides Stage 3 boot prompt skip sentinels (M3)', () => {
+  // The boot prompt accepts any case variant of `n` / `no` as a skip.
+  // The interactive prompt itself is TTY-gated and can't be driven in a
+  // unit-test runner; the next two tests pin the SHAPE of the skip
+  // sentinel set by reading the engine source (the loop body that
+  // decides skip vs override). This is OK as a fallback for a
+  // prompt-gated branch: behavioral coverage requires a real terminal
+  // (covered at integ level), while the sentinel set itself is what
+  // the user-facing UX depends on, so a regression that re-narrowed
+  // it to `value.toUpperCase() === 'N'` would silently break `no` /
+  // `No` / `NO` users.
+  it('engine source recognizes n / no (any case) as skip sentinels', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const ENGINE_SOURCE = path.join(here, '../../../src/local/image-override-engine.ts');
+    const source = readFileSync(ENGINE_SOURCE, 'utf-8');
+    // The Stage-3 prompt block uses a `lower` variable to normalize
+    // case + compares against both `'n'` and `'no'`. Pin both
+    // expectations explicitly.
+    expect(source).toMatch(/value\.toLowerCase\(\)/);
+    expect(source).toMatch(/lower === 'n'/);
+    expect(source).toMatch(/lower === 'no'/);
+    // And the prompt copy must contain the [path / N] hint.
+    expect(source).toMatch(/\[path \/ N\]/);
   });
 });

--- a/tests/unit/local/image-override-engine.test.ts
+++ b/tests/unit/local/image-override-engine.test.ts
@@ -1,0 +1,264 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildImageOverrideTag,
+  ImageOverrideError,
+  parseImageOverrideFlags,
+  resolveImageOverrides,
+} from '../../../src/local/image-override-engine.js';
+
+/**
+ * Issue #238 — engine-level coverage. The picker / boot-prompt branches
+ * are TTY-gated via `isInteractive()` and a real `@clack/prompts`
+ * `multiselect` / `text` would require a live terminal — exercised at
+ * the binding-test level (TTY=false short-circuit) here. The parser +
+ * Stage-1 explicit resolution + tag derivation are fully unit-tested.
+ */
+
+function makeTmpDockerfile(name = 'Dockerfile'): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'cdkl-override-engine-'));
+  const file = path.join(dir, name);
+  writeFileSync(file, 'FROM scratch\n');
+  return file;
+}
+
+describe('parseImageOverrideFlags (issue #238)', () => {
+  it('parses explicit <svc>=<dockerfile> form into the explicit map', () => {
+    const out = parseImageOverrideFlags({
+      imageOverride: ['AppService=./services/app/Dockerfile'],
+    });
+    expect(out.explicit.size).toBe(1);
+    expect(out.explicit.get('AppService')).toBe('./services/app/Dockerfile');
+    expect(out.pickerPaths).toEqual([]);
+  });
+
+  it('parses picker-form bare <dockerfile> into pickerPaths in CLI order', () => {
+    const out = parseImageOverrideFlags({
+      imageOverride: ['./a/Dockerfile', './b/Dockerfile'],
+    });
+    expect(out.explicit.size).toBe(0);
+    expect(out.pickerPaths).toEqual(['./a/Dockerfile', './b/Dockerfile']);
+  });
+
+  it('supports mixed explicit + picker-form in one invocation', () => {
+    const out = parseImageOverrideFlags({
+      imageOverride: ['Svc=./a/Dockerfile', './b/Dockerfile'],
+    });
+    expect(out.explicit.get('Svc')).toBe('./a/Dockerfile');
+    expect(out.pickerPaths).toEqual(['./b/Dockerfile']);
+  });
+
+  it('rejects an empty bare value', () => {
+    expect(() => parseImageOverrideFlags({ imageOverride: [''] })).toThrow(
+      /empty string/
+    );
+  });
+
+  it('rejects a duplicate explicit mapping for the same service', () => {
+    expect(() =>
+      parseImageOverrideFlags({
+        imageOverride: ['Svc=./a/Dockerfile', 'Svc=./b/Dockerfile'],
+      })
+    ).toThrow(ImageOverrideError);
+  });
+
+  it('rejects an explicit form with empty service or empty dockerfile side', () => {
+    expect(() => parseImageOverrideFlags({ imageOverride: ['=./a/Dockerfile'] })).toThrow();
+    expect(() => parseImageOverrideFlags({ imageOverride: ['Svc='] })).toThrow();
+  });
+
+  it('parses --image-build-arg into globals.buildArgs preserving order', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildArg: ['A=1', 'B=2'],
+    });
+    expect(Array.from(out.globals.buildArgs.entries())).toEqual([
+      ['A', '1'],
+      ['B', '2'],
+    ]);
+  });
+
+  it('rejects malformed --image-build-arg (no =)', () => {
+    expect(() => parseImageOverrideFlags({ imageBuildArg: ['BAD'] })).toThrow(/KEY=VAL/);
+  });
+
+  it('rejects --image-build-arg with empty key', () => {
+    expect(() => parseImageOverrideFlags({ imageBuildArg: ['=value'] })).toThrow(/KEY=VAL/);
+  });
+
+  it('parses --image-build-secret id=src into globals.buildSecrets', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildSecret: ['npmrc=./.npmrc', 'token=./token.txt'],
+    });
+    expect(out.globals.buildSecrets.get('npmrc')).toBe('./.npmrc');
+    expect(out.globals.buildSecrets.get('token')).toBe('./token.txt');
+  });
+
+  it('rejects --image-build-secret with empty id or src', () => {
+    expect(() => parseImageOverrideFlags({ imageBuildSecret: ['=src'] })).toThrow();
+    expect(() => parseImageOverrideFlags({ imageBuildSecret: ['id='] })).toThrow();
+  });
+
+  it('parses --image-target into globals.targetStage', () => {
+    const out = parseImageOverrideFlags({ imageTarget: 'builder' });
+    expect(out.globals.targetStage).toBe('builder');
+  });
+
+  it('rejects an empty --image-target', () => {
+    expect(() => parseImageOverrideFlags({ imageTarget: '' })).toThrow();
+  });
+});
+
+describe('resolveImageOverrides Stage 1: explicit mappings (issue #238)', () => {
+  it('binds an explicit mapping to a pinned target', async () => {
+    const dockerfile = makeTmpDockerfile();
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfile}`],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService'],
+    });
+    expect(overrides.size).toBe(1);
+    const entry = overrides.get('AppService');
+    expect(entry?.dockerfile).toBe(dockerfile);
+    expect(entry?.contextDir).toBe(path.dirname(dockerfile));
+  });
+
+  it('drops an explicit mapping naming a non-pinned target with a warning', async () => {
+    const dockerfile = makeTmpDockerfile();
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`NotPinned=${dockerfile}`],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService'],
+    });
+    expect(overrides.size).toBe(0);
+  });
+
+  it('hard-errors when the explicit Dockerfile path does not exist', async () => {
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: ['AppService=/nonexistent/path/Dockerfile'],
+    });
+    await expect(
+      resolveImageOverrides({
+        rawFlags,
+        pinnedTargets: ['AppService'],
+      })
+    ).rejects.toBeInstanceOf(ImageOverrideError);
+  });
+
+  it('threads build-args / build-secrets / target-stage globals into every entry', async () => {
+    const dockerfile = makeTmpDockerfile();
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`Svc=${dockerfile}`],
+      imageBuildArg: ['NODE_ENV=production'],
+      imageBuildSecret: ['npmrc=./.npmrc'],
+      imageTarget: 'release',
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['Svc'],
+    });
+    const entry = overrides.get('Svc');
+    expect(entry?.buildArgs.get('NODE_ENV')).toBe('production');
+    expect(entry?.buildSecrets.get('npmrc')).toBe('./.npmrc');
+    expect(entry?.targetStage).toBe('release');
+  });
+});
+
+describe('resolveImageOverrides Stage 2: picker form (non-TTY skip) (issue #238)', () => {
+  it('skips picker-form Dockerfile paths when not interactive (non-TTY context)', async () => {
+    // In the vitest runner, stdin / stdout are typically NOT TTYs, so the
+    // picker branch falls through to its non-TTY warn-and-skip path. The
+    // result: no override is produced from a picker-form path here, which
+    // is the expected CI/non-TTY behaviour.
+    const dockerfile = makeTmpDockerfile();
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [dockerfile],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService'],
+      noInteractive: true,
+    });
+    expect(overrides.size).toBe(0);
+  });
+});
+
+describe('resolveImageOverrides Stage 3: boot prompt (non-TTY skip) (issue #238)', () => {
+  it('skips the boot prompt when noInteractive=true', async () => {
+    const rawFlags = parseImageOverrideFlags({});
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['Pinned1', 'Pinned2'],
+      interactiveBootPrompt: true,
+      noInteractive: true,
+    });
+    expect(overrides.size).toBe(0);
+  });
+
+  it('returns an empty map when there are no flags and no prompt opt-in', async () => {
+    const rawFlags = parseImageOverrideFlags({});
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['Pinned1'],
+    });
+    expect(overrides.size).toBe(0);
+  });
+});
+
+describe('buildImageOverrideTag (issue #238)', () => {
+  const baseEntry = {
+    dockerfile: '/abs/Dockerfile',
+    contextDir: '/abs',
+    buildArgs: new Map<string, string>(),
+    buildSecrets: new Map<string, string>(),
+  };
+
+  it('produces a deterministic tag for the same inputs', () => {
+    const tag1 = buildImageOverrideTag('AppService', baseEntry);
+    const tag2 = buildImageOverrideTag('AppService', baseEntry);
+    expect(tag1).toBe(tag2);
+  });
+
+  it('differs by service target', () => {
+    const tagA = buildImageOverrideTag('A', baseEntry);
+    const tagB = buildImageOverrideTag('B', baseEntry);
+    expect(tagA).not.toBe(tagB);
+  });
+
+  it('differs when Dockerfile path differs', () => {
+    const tag1 = buildImageOverrideTag('Svc', baseEntry);
+    const tag2 = buildImageOverrideTag('Svc', { ...baseEntry, dockerfile: '/other/Dockerfile' });
+    expect(tag1).not.toBe(tag2);
+  });
+
+  it('differs when build args / secrets / target-stage differ', () => {
+    const tag0 = buildImageOverrideTag('Svc', baseEntry);
+    const tag1 = buildImageOverrideTag('Svc', {
+      ...baseEntry,
+      buildArgs: new Map([['K', 'V']]),
+    });
+    const tag2 = buildImageOverrideTag('Svc', {
+      ...baseEntry,
+      buildSecrets: new Map([['s', 'v']]),
+    });
+    const tag3 = buildImageOverrideTag('Svc', { ...baseEntry, targetStage: 'builder' });
+    expect(new Set([tag0, tag1, tag2, tag3]).size).toBe(4);
+  });
+
+  it('emits a :local suffix so the tag never pretends to be a real registry', () => {
+    const tag = buildImageOverrideTag('Svc', baseEntry);
+    expect(tag.endsWith(':local')).toBe(true);
+  });
+
+  it('slugifies a CDK path with slashes into a docker-tag-safe segment', () => {
+    const tag = buildImageOverrideTag('MyStack/AppService', baseEntry);
+    // No `/` allowed in tag NAME segment (Docker rejects it).
+    const repo = tag.split(':')[0]!;
+    expect(repo).not.toMatch(/\//);
+  });
+});

--- a/tests/unit/local/start-alb-binding.test.ts
+++ b/tests/unit/local/start-alb-binding.test.ts
@@ -984,8 +984,16 @@ describe('start-alb option surface contract (addCommonEcsServiceOptions + addAlb
     const flags = longFlagsOf(addAlbSpecificOptions(new Command()));
     expect(flags).toEqual([
       '--bearer-token',
+      // Issue #238 — `--image-override` family shared with start-service
+      // via `addImageOverrideOptions`. A semver-relevant surface addition.
+      '--image-build-arg',
+      '--image-build-secret',
+      '--image-override',
+      '--image-target',
       '--lb-port',
+      '--no-interactive-overrides',
       '--no-verify-auth',
+      '--strict-overrides',
       '--tls',
       '--tls-cert',
       '--tls-key',


### PR DESCRIPTION
## Summary

Closes #238.

`cdkl start-service` / `cdkl start-alb` against a CDK app that uses
`ContainerImage.fromEcrRepository(...)` (typical pairing with
`--from-cfn-stack`) could not reflect local source changes — the running
container was the deployed ECR bytes. This PR adds a flag family that
turns "image pinned to a deployed registry" into "image built locally
from a supplied Dockerfile" on a per-service-target basis, so a
`--from-cfn-stack` boot still wires real DynamoDB / Secrets / SSM into
the container while the application image is locally iterable.

## Flags (all six)

| Flag | Behavior |
|---|---|
| `--image-override <svc>=<dockerfile>` OR `<dockerfile>` | Repeatable. Explicit form binds the service; bare form opens a `@clack/prompts` multi-select against the still-uncovered pinned targets. Mix freely. |
| `--image-build-arg KEY=VAL` | Global, repeatable. Forwarded to every overridden target's `docker build --build-arg KEY=VAL`. |
| `--image-build-secret id=src` | Global, repeatable. Forwarded to `docker build --secret id=<id>,src=<src>` — covers the `RUN --mount=type=secret,id=npmrc` recipe for private-registry installs. |
| `--image-target <stage>` | Global. Forwarded to `docker build --target=<stage>` for multi-stage Dockerfiles. |
| `--no-interactive-overrides` | Suppress the TTY boot prompt + multi-select picker. CI / scripted setups. |
| `--strict-overrides` | Fail fast at boot if any pinned target remains uncovered after `--image-override` + the boot prompt resolve. Off by default. |

## Behavior matrix (from issue body)

| ECR pin | `--image-override` covers | TTY | `--no-interactive-overrides` | `--strict-overrides` | Behavior |
|:---:|:---:|:---:|:---:|:---:|---|
| Y | Y | * | * | * | local build override applied |
| Y | N | Y | N | N | boot prompt → fill in path, or skip |
| Y | N | Y | Y | N | boot WARN, ECR pin runs |
| Y | N | N | * | N | boot WARN, ECR pin runs |
| Y | N | * | * | Y | boot error (`LocalStartServiceError`) |
| N | * | * | * | * | normal local-build / CDK-asset path |

## WARN broadening from PR #237

PR #237 introduced a boot-time WARN per ECR-pinned target gated on
`--watch && supportsWatch`. This PR drops the `--watch` gate (per the
behavior matrix's "WARN regardless of `--watch`" row) — the user has
already signalled they want to run this service locally, so the hint
that the running image is the deployed bytes is useful regardless. The
watcher itself stays gated separately. A regression test pins this
broadening (the per-target loop must not be wrapped inside
`if (watchActive)`).

## Reload semantics under `--watch`

- **Overridden target.** Reload goes through the rebuild rolling primitive
  (Phase 1-3 of #214) — the new Dockerfile build is picked up
  automatically. The #234 "image pinned to a deployed registry" reload
  skip pre-empts ONLY uncovered pinned targets, so an overridden target
  rolls normally.
- **Uncovered pinned target.** Reload skip from #234 still fires.
- **Local CDK asset target.** Unchanged from existing behavior.

The boot-time-resolved `serviceTarget -> localTag` map is threaded into
the watcher's `reloadAllServices` call so a `--watch` rebuild on an
overridden target rolls against the local image, not the deployed pin.

## Implementation

- New module `src/local/image-override-engine.ts` — pure orchestration:
  parse flags, fire the picker, walk the boot prompt, run `docker build`
  per covered Dockerfile producing a deterministic local-only tag
  (`cdkl-override-<svcSlug>-<hash>:local`).
- `RunEcsTaskOptions.imageOverrideByContainer?: ReadonlyMap<string, string>`
  short-circuits `prepareOneImage` for the named containers — sibling
  containers in a multi-container task still go through normal pull /
  build resolution.
- Shared `addImageOverrideOptions(cmd: Command)` helper lives in
  `ecs-service-emulator.ts` and is composed by both
  `addStartServiceSpecificOptions` and `addAlbSpecificOptions` so a
  future copy edit on the flag wording lands in both surfaces.
- Engine + helper re-exported from `src/internal.ts` so host CLIs (cdkd)
  inherit the override pipeline.

## Test plan

- [x] `vp check` — typecheck + lint + format-check all green
- [x] `vp test run` — 1928 tests across 130 files passing
- [x] `vp run build` — clean

Unit-level coverage added:

- `tests/unit/local/image-override-engine.test.ts` — parser cases
  (explicit / picker / mixed / duplicate-service collision /
  malformed flag forms), Stage-1 explicit resolution (existing /
  non-existent Dockerfile / globals threading), Stage 2 + 3 non-TTY
  skip paths, tag determinism + collision separation.
- `tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts`
  — source-grep site-level binding test (per the
  `feedback_site_level_binding_test.md` convention) pinning the
  engine's wiring at: the boot-time `resolveAndBuildImageOverrides`
  call, `bootOneTarget`'s receipt of the per-target tag, the
  `reloadAllServices` arg signature + threading into `rollOneTarget`,
  the watcher's `onChange` arg list, the `--strict-overrides`
  fail-fast guard, and `addImageOverrideOptions` composition in both
  `addStartServiceSpecificOptions` and `addAlbSpecificOptions`.
- `tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts` —
  new test pinning the WARN broadening (no `if (watchActive)` wrap
  around the boot-WARN loop).
- Updated `tests/unit/cli/local-start-service-watch.test.ts` +
  `tests/unit/local/start-alb-binding.test.ts` option-surface-contract
  tests to include the six new flags (semver-relevant surface
  addition).
- Updated `tests/unit/cli/ecs-service-emulator-resolve-helper-binding.test.ts`
  regex to accept the additional `imageOverrideTag` field alongside
  `quiet: true` in the reload-path opts object.

Docs updated:

- README — new "Local build override — `--image-override`" section
  leading with the zero-flag TTY form (boot prompt), then explicit +
  picker forms, then build-input pass-throughs (including the
  `--image-build-secret npmrc=./.npmrc` recipe), then the opt-outs.
- `docs/local-emulation.md` — `--watch` section extended with the
  full flag family, build-tag naming, and the reload-side
  reload-skip vs rebuild rolling primitive semantics.
- `.claude/CLAUDE.md` — Architecture line names the new module;
  scope copy describes the WARN broadening + override.

## Out of scope (deferred follow-ups)

- Per-service variants of `--image-build-arg` / `--image-build-secret` /
  `--image-target` — tracked in #240. Today these flags are global.
- Custom build-context directories distinct from the Dockerfile's
  parent — deferred.
- Auto-reading `--image-build-arg` from host env (Docker's
  bare-`ARG` inheritance behavior) — deferred.
