### PR TITLE
chore(image-override): close #242 follow-up — minor cleanup + test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ cdkl start-alb --from-cfn-stack \
 
 `--image-build-secret npmrc=./.npmrc` wires a private-registry token into a Dockerfile that uses `RUN --mount=type=secret,id=npmrc` — the canonical recipe for installing private packages during the local build. The `src=` path resolves against the directory you ran `cdkl` from (not the Dockerfile's parent), so `./.npmrc` means "the `.npmrc` next to your `cdk.json`" regardless of where the Dockerfile lives in the tree.
 
+`--image-build-arg KEY=` (empty value) is accepted and forwarded verbatim to `docker build --build-arg KEY=` — the canonical way to unset a Dockerfile `ARG`'s default. Empty KEY (e.g. `--image-build-arg =val`) is rejected.
+
 Opt-outs:
 
 - `--no-interactive-overrides` suppresses the boot prompt + the multi-select picker; the override map is whatever explicit `--image-override <svc>=<dockerfile>` flags resolved to. Useful for scripted invocations.

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -101,7 +101,7 @@ import {
 import type { FrontDoorAuthGuard } from '../../local/elb-front-door-resolver.js';
 import { buildAuthCheck } from '../../local/front-door-auth.js';
 import { createJwksCache } from '../../local/cognito-jwt.js';
-import { describePinnedImageUri, isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
+import { isLocalCdkAssetImage, listPinnedTargets } from '../../local/image-pin-detector.js';
 import {
   parseImageOverrideFlags,
   resolveImageOverrides,
@@ -753,22 +753,28 @@ export async function runEcsServiceEmulator(
     // regardless of whether they'd save a file later. The watch
     // wiring stays gated separately (the watcher only fires under
     // `--watch && supportsWatch`).
+    // Issue #242 / N1 — derive the pinned set through `listPinnedTargets`
+    // so the WARN loop walks the same one-shot helper the override
+    // engine's pre-boot resolution consumed. Source-only iteration of
+    // `perTarget` here is unchanged; the per-target isLocalCdkAsset +
+    // describePinnedImageUri pair is now collapsed into one helper call.
     const uncoveredPinnedTargets: string[] = [];
-    for (const pt of perTarget) {
-      const service = pt.controller?.service;
-      if (!service) continue;
-      if (isLocalCdkAssetImage(service)) continue;
-      if (imageOverrideTags.has(pt.boot.target)) continue;
-      const pinnedUri = describePinnedImageUri(service);
-      const uriDisplay = pinnedUri ? `\`${pinnedUri}\`` : 'a deployed registry';
+    const pinnedEntries = listPinnedTargets(
+      perTarget
+        .filter((pt) => pt.controller?.service)
+        .map((pt) => ({ target: pt.boot.target, service: pt.controller!.service }))
+    );
+    for (const entry of pinnedEntries) {
+      if (imageOverrideTags.has(entry.target)) continue;
+      const uriDisplay = entry.label ? `\`${entry.label}\`` : 'a deployed registry';
       logger.warn(
-        `'${pt.boot.target}': running image is pinned to a deployed registry ` +
+        `'${entry.target}': running image is pinned to a deployed registry ` +
           `(${uriDisplay}). To iterate on local source, either pass ` +
           '`--image-override <dockerfile>` (or `<service>=<dockerfile>`) to substitute ' +
           'a local build, or drop `--from-cfn-stack` and switch the CDK app to ' +
           '`ContainerImage.fromAsset(...)`.'
       );
-      uncoveredPinnedTargets.push(pt.boot.target);
+      uncoveredPinnedTargets.push(entry.target);
     }
 
     // Issue #238 — `--strict-overrides` fail-fast guard. After the
@@ -2389,13 +2395,14 @@ async function resolveAndBuildImageOverrides(args: {
 }): Promise<Map<string, string>> {
   const { perTarget, stacks, options, extraStateProviders, logger } = args;
 
-  // Identify pinned targets via the same representative-essential anchor
-  // the boot WARN + reload-skip use. Each target is re-resolved with its
-  // own image-resolution context (so `--from-cfn-stack` substitutions
-  // are applied) — necessary to distinguish a CDK asset, an ECR pin,
-  // and a public-registry pin in the resolved template.
-  const pinnedTargets: string[] = [];
-  const pinnedLabels = new Map<string, string>();
+  // Issue #242 / N1 — collect every target's resolved service first,
+  // then hand the whole list to `listPinnedTargets` so the pinned set +
+  // labels are derived through the same helper the post-boot WARN
+  // loop consumes. Each target is re-resolved with its own image-
+  // resolution context (so `--from-cfn-stack` substitutions are
+  // applied) — necessary to distinguish a CDK asset, an ECR pin, and
+  // a public-registry pin in the resolved template.
+  const resolvedForPeek: Array<{ target: string; service: ResolvedEcsService }> = [];
   for (const target of perTarget) {
     const parsed = parseEcsTarget(target);
     const candidate = pickCandidateStack(parsed.stackPattern, stacks);
@@ -2421,10 +2428,13 @@ async function resolveAndBuildImageOverrides(args: {
       if (stateProvider) stateProvider.dispose();
     }
     if (!service) continue;
-    if (isLocalCdkAssetImage(service)) continue;
-    pinnedTargets.push(target);
-    const uri = describePinnedImageUri(service);
-    if (uri) pinnedLabels.set(target, uri);
+    resolvedForPeek.push({ target, service });
+  }
+  const pinnedEntries = listPinnedTargets(resolvedForPeek);
+  const pinnedTargets: string[] = pinnedEntries.map((e) => e.target);
+  const pinnedLabels = new Map<string, string>();
+  for (const entry of pinnedEntries) {
+    if (entry.label !== undefined) pinnedLabels.set(entry.target, entry.label);
   }
 
   // Parse the raw flags. A parser error is reported as a clean

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -469,7 +469,12 @@ export { createWatchPredicates, type WatchPredicates } from './cli/commands/loca
  * UX matches cdk-local's instead of silently inheriting the
  * "Reload complete." disguised-no-op symptom.
  */
-export { isLocalCdkAssetImage, describePinnedImageUri } from './local/image-pin-detector.js';
+export {
+  isLocalCdkAssetImage,
+  describePinnedImageUri,
+  listPinnedTargets,
+  type PinnedTargetEntry,
+} from './local/image-pin-detector.js';
 export { resolveWatchConfig, type CdkWatchConfig } from './cli/config-loader.js';
 
 /**

--- a/src/local/image-override-engine.ts
+++ b/src/local/image-override-engine.ts
@@ -131,6 +131,19 @@ export interface RawImageOverrideFlags {
  * Collision detection: a service target named more than once in
  * `--image-override <svc>=...` is an error (last-write-wins would
  * silently drop the earlier mapping; explicit error is clearer).
+ *
+ * Empty-value semantics:
+ * - `--image-build-arg KEY=` (empty value) is ACCEPTED. The empty
+ *   string is forwarded verbatim to `docker build --build-arg KEY=`,
+ *   which docker itself accepts (the canonical way to unset a
+ *   Dockerfile `ARG`'s default). `KEY=` (empty key) is rejected.
+ * - `--image-target ""` (empty value) is REJECTED — an empty
+ *   `--target` is meaningless to `docker build` (`--target` is a
+ *   single stage name, not a list).
+ * - `--image-override <svc>=` and `--image-override =<dockerfile>`
+ *   are REJECTED — both halves must be non-empty.
+ * - `--image-build-secret id=` and `--image-build-secret =src` are
+ *   REJECTED — both halves must be non-empty.
  */
 export function parseImageOverrideFlags(input: {
   imageOverride?: string[];
@@ -492,12 +505,32 @@ export function buildImageOverrideTag(serviceTarget: string, entry: ImageOverrid
  * order maximizes cache reuse). On any failure the function rejects
  * with {@link ImageOverrideError}; the emulator surfaces this before
  * any container is started.
+ *
+ * Partial-failure rollback (issue #242 / N3): when build N (1-indexed)
+ * fails, the 1..(N-1) successfully built local-only tags from THIS run
+ * are best-effort `docker image rm`'d before re-throwing. Not a leak
+ * (the tags are deterministic per
+ * {@link buildImageOverrideTag} so a re-run collides safely with any
+ * leftover), but the cleanup keeps the local Docker daemon tidy after
+ * a failed boot — disk-pressure scenarios that occasionally surface
+ * on dev laptops never accumulate orphan override images across a
+ * day of iterations. Cleanup failures are logged at `debug` (another
+ * container could be using the image, the image could already have
+ * been removed by a parallel `docker system prune`, etc.) and the
+ * loop continues so one un-removable tag doesn't shadow the others.
+ * The originating {@link ImageOverrideError} is always the thrown
+ * value — a cleanup-step error never replaces it.
  */
 export async function runImageOverrideBuilds(
   overrides: ImageOverrideMap
 ): Promise<Map<string, string>> {
   const logger = getLogger();
   const out = new Map<string, string>();
+  // Track every successfully built tag from THIS invocation so a
+  // mid-run failure can `docker image rm` them (N3). Distinct from
+  // `out` for clarity — `out` is the success-path return value;
+  // `builtTags` is the rollback bookkeeping.
+  const builtTags: string[] = [];
   for (const [target, entry] of overrides.entries()) {
     const tag = buildImageOverrideTag(target, entry);
     const args: string[] = ['build', '--tag', tag, '--file', entry.dockerfile];
@@ -521,12 +554,27 @@ export async function runImageOverrideBuilds(
       });
     } catch (err) {
       const e = err as { stderr?: string; message?: string };
-      throw new ImageOverrideError(
+      const wrapped = new ImageOverrideError(
         `docker build failed for --image-override '${target}' (Dockerfile=${entry.dockerfile}): ` +
           (e.stderr?.trim() || e.message || String(err))
       );
+      // Best-effort rollback: remove every tag built earlier in this
+      // run. Per-tag failures are logged at debug + swallowed so the
+      // originating build error stays the surfaced one.
+      for (const priorTag of builtTags) {
+        try {
+          await runDockerStreaming(['image', 'rm', priorTag], {});
+        } catch (rmErr) {
+          logger.debug(
+            `Image-override rollback: \`docker image rm ${priorTag}\` failed: ` +
+              `${rmErr instanceof Error ? rmErr.message : String(rmErr)}.`
+          );
+        }
+      }
+      throw wrapped;
     }
     out.set(target, tag);
+    builtTags.push(tag);
   }
   return out;
 }

--- a/src/local/image-pin-detector.ts
+++ b/src/local/image-pin-detector.ts
@@ -81,3 +81,55 @@ export function describePinnedImageUri(service: ResolvedEcsService): string | un
   if (image.kind === 'cdk-asset') return undefined;
   return image.uri;
 }
+
+/**
+ * Per-target outcome from {@link listPinnedTargets}: the target name +
+ * an optional deployed-registry URI label (undefined when the image is
+ * a local CDK asset and so is NOT pinned).
+ */
+export interface PinnedTargetEntry {
+  /** ECS service target string (e.g. `StackName/ServiceConstructPath`). */
+  target: string;
+  /**
+   * Human-readable deployed-registry URI for the pinned image, or
+   * `undefined` when the helper bucketed the target as NOT pinned (the
+   * caller filters by presence of this entry — entries are only emitted
+   * for targets whose representative image is NOT a local CDK asset).
+   */
+  label?: string;
+}
+/**
+ * Issue #242 / N1 — dedupe pinned-target detection across the two
+ * sites that need it during a `cdkl start-service` / `cdkl start-alb`
+ * boot:
+ *
+ *   1. The `--image-override` engine's pre-boot resolution
+ *      ({@link resolveImageOverrides}) — needs the pinned set + per-
+ *      target deployed-registry URI labels so the picker + boot-prompt
+ *      hint can name the image the user is overriding.
+ *   2. The post-boot WARN loop in `runEcsServiceEmulator` — surfaces a
+ *      per-target WARN naming the deployed-registry URI for every
+ *      pinned target the override engine did NOT cover.
+ *
+ * Before this helper both sites re-walked `isLocalCdkAssetImage` +
+ * `describePinnedImageUri` independently. The semantic computation is
+ * identical — given a `ResolvedEcsService`, decide pinned vs local-
+ * asset and (for pinned targets) surface the URI label. Hoisting the
+ * walk here keeps the two call sites in lock-step and gives both a
+ * single test surface.
+ *
+ * Returns one entry per pinned target in the input's iteration order.
+ * Targets whose representative image is a local CDK asset are
+ * filtered out — the caller never sees them.
+ */
+export function listPinnedTargets(
+  resolvedServices: Iterable<{ target: string; service: ResolvedEcsService }>
+): PinnedTargetEntry[] {
+  const out: PinnedTargetEntry[] = [];
+  for (const { target, service } of resolvedServices) {
+    if (isLocalCdkAssetImage(service)) continue;
+    const label = describePinnedImageUri(service);
+    out.push({ target, ...(label !== undefined && { label }) });
+  }
+  return out;
+}

--- a/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
@@ -36,27 +36,35 @@ const EMULATOR_SOURCE = path.join(
  * documented.
  */
 describe('ecs-service-emulator image-pin detector binding (issue #234)', () => {
-  it('imports `isLocalCdkAssetImage` + `describePinnedImageUri` from the local helper module', () => {
+  it('imports `isLocalCdkAssetImage` + `listPinnedTargets` from the local helper module', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
     expect(source).toMatch(
       /from\s+['"]\.\.\/\.\.\/local\/image-pin-detector\.js['"]/
     );
+    // `isLocalCdkAssetImage` is still consumed by the reload-time skip
+    // guard in `reloadAllServices` (issue #234), and `listPinnedTargets`
+    // is the issue #242 / N1 dedupe consumed by both the override
+    // engine's pre-boot peek + the post-boot WARN loop. The detector
+    // module also exports `describePinnedImageUri`, but the emulator no
+    // longer imports it directly — every call site now flows through
+    // `listPinnedTargets`.
     expect(source).toMatch(/isLocalCdkAssetImage/);
-    expect(source).toMatch(/describePinnedImageUri/);
+    expect(source).toMatch(/listPinnedTargets/);
   });
 
-  it('boot-time WARN loop calls `isLocalCdkAssetImage` + `describePinnedImageUri` + `logger.warn` together', () => {
+  it('boot-time WARN loop derives the pinned set via `listPinnedTargets` and surfaces it through `logger.warn`', () => {
     const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
     // Anchor on the unique boot-WARN rationale comment ("Warn UP-FRONT")
-    // and verify the per-target loop downstream of it calls both
-    // helpers AND surfaces the warning via `logger.warn`. The outer
+    // and verify the per-target block downstream of it derives the
+    // pinned set through the `listPinnedTargets` helper (issue #242 N1
+    // dedupe) AND surfaces the warning via `logger.warn`. The outer
     // gate (a hoisted `watchActive` const today; could be inlined back
     // or renamed by a future refactor) intentionally isn't pinned here
     // — what matters for issue #234 is that the loop body has the
-    // right shape. A refactor that drops either call would silently
+    // right shape. A refactor that drops the helper call would silently
     // ship the no-op-disguised-as-success bug back into the boot stream.
     const bootWarnLoop = source.match(
-      /Warn UP-FRONT[\s\S]*?for \(const pt of perTarget\) \{[\s\S]*?isLocalCdkAssetImage[\s\S]*?describePinnedImageUri[\s\S]*?logger\.warn\(/
+      /Warn UP-FRONT[\s\S]*?listPinnedTargets\([\s\S]*?logger\.warn\(/
     );
     expect(bootWarnLoop, 'boot-time WARN loop missing').toBeTruthy();
   });
@@ -70,22 +78,71 @@ describe('ecs-service-emulator image-pin detector binding (issue #234)', () => {
     // is precisely what #238 explicitly broadens.
     //
     // Anchor on the intrinsic "Warn UP-FRONT" rationale comment + the
-    // helper call site (`isLocalCdkAssetImage` / `describePinnedImageUri`
-    // / `logger.warn`) that the WARN block uniquely uses. Avoid keying
-    // on incidental landmarks like `Phase 1 + Phase 2` (which a future
-    // section-comment rewrite would silently invalidate). Take the
-    // 4-KiB window starting at "Warn UP-FRONT" — large enough to
-    // contain the entire loop, small enough that an unrelated future
-    // copy of the helpers downstream won't accidentally bleed in.
+    // helper call site (`listPinnedTargets` / `logger.warn`) that the
+    // WARN block uniquely uses. Avoid keying on incidental landmarks
+    // like `Phase 1 + Phase 2` (which a future section-comment rewrite
+    // would silently invalidate). Take the 4-KiB window starting at
+    // "Warn UP-FRONT" — large enough to contain the entire loop, small
+    // enough that an unrelated future copy of the helpers downstream
+    // won't accidentally bleed in.
+    //
+    // Issue #242 anti-pattern follow-up: drop the previous
+    // `.split('for (const pt of perTarget)')` landmark — a rename of
+    // `perTarget` would silently widen a split-based assertion to
+    // cover the whole region, shadowing a regression. Instead bound
+    // the WARN region with two semantic anchors:
+    //
+    //   - START: the intrinsic `Warn UP-FRONT` rationale comment
+    //     (unique to the WARN block).
+    //   - END: the `enforceStrictOverrides(` call site that
+    //     immediately follows the WARN loop. Cutting at that call
+    //     keeps the unrelated `--watch` watcher block (which legitly
+    //     opens an `if (watchActive)` gate later) out of the region,
+    //     so a `not.toMatch(/if \(watchActive\)/)` assertion stays
+    //     scoped to the WARN gate question.
+    //
+    // A regression that re-hoists `if (watchActive)` over the boot
+    // WARN must land BEFORE `enforceStrictOverrides(...)` runs (the
+    // WARN populates the `uncoveredPinnedTargets` array that
+    // `enforceStrictOverrides` consumes), so the boundary's
+    // safe.
     const warnUpFrontIdx = source.indexOf('Warn UP-FRONT');
     expect(warnUpFrontIdx).toBeGreaterThan(-1);
-    const bootWarnRegion = source.slice(warnUpFrontIdx, warnUpFrontIdx + 4096);
-    expect(bootWarnRegion).toMatch(/isLocalCdkAssetImage/);
-    expect(bootWarnRegion).toMatch(/describePinnedImageUri/);
+    const strictIdx = source.indexOf('enforceStrictOverrides(', warnUpFrontIdx);
+    expect(strictIdx).toBeGreaterThan(warnUpFrontIdx);
+    const bootWarnRegion = source.slice(warnUpFrontIdx, strictIdx);
+    expect(bootWarnRegion).toMatch(/listPinnedTargets/);
     expect(bootWarnRegion).toMatch(/logger\.warn\(/);
-    // The region preceding the per-target loop must not open a watch gate.
-    const preLoop = bootWarnRegion.split('for (const pt of perTarget)')[0]!;
-    expect(preLoop).not.toMatch(/if \(watchActive\)/);
+    expect(bootWarnRegion).not.toMatch(/if \(watchActive\)/);
+  });
+
+  it('both pinned-detection call sites consume the SAME `listPinnedTargets` helper (issue #242 / N1 dedupe)', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The N1 dedupe lifts the two independent walks (engine pre-boot
+    // resolution + post-boot WARN loop) onto a single `listPinnedTargets`
+    // helper. Site-level binding: both regions must call it. A future
+    // refactor that re-inlines one side would surface a regression here
+    // (and silently drift the two pinned-set verdicts apart).
+    //
+    // Engine pre-boot site: anchored on the comment that names the
+    // dedupe rationale (the "Issue #242 / N1" tag inside
+    // `resolveAndBuildImageOverrides`).
+    const engineRegion = source.match(
+      /Issue #242 \/ N1 — collect every target's resolved service[\s\S]{0,3072}listPinnedTargets\(/
+    );
+    expect(engineRegion, 'engine pre-boot listPinnedTargets call missing').toBeTruthy();
+    // Post-boot WARN site: same helper, separately anchored on the
+    // Warn UP-FRONT rationale comment so the two call-site checks
+    // can't accidentally overlap into one region.
+    const warnUpFrontIdx = source.indexOf('Warn UP-FRONT');
+    const warnRegion = source.slice(warnUpFrontIdx, warnUpFrontIdx + 4096);
+    expect(warnRegion).toMatch(/listPinnedTargets\(/);
+    // Sanity: the engine pre-boot region anchor and the WARN region
+    // anchor are distinct (the helper call appears in both).
+    const engineIdx = source.indexOf("Issue #242 / N1 — collect every target's resolved service");
+    expect(engineIdx).toBeGreaterThan(-1);
+    expect(warnUpFrontIdx).toBeGreaterThan(-1);
+    expect(engineIdx).not.toBe(warnUpFrontIdx);
   });
 
   it('reload-time skip guard AND-s `verdict.reason` with `isLocalCdkAssetImage(controller.service)` BEFORE `rollOneTarget`', () => {

--- a/tests/unit/local/image-override-engine.test.ts
+++ b/tests/unit/local/image-override-engine.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 // T1 — mock `runDockerStreaming` at module level so we can capture the
 // argv `runImageOverrideBuilds` hands to docker (the canonical
@@ -512,6 +512,259 @@ describe('parseImageOverrideFlags --image-build-secret src resolution (M1)', () 
       imageBuildSecret: ['token=/etc/secrets/token.txt'],
     });
     expect(out.globals.buildSecrets.get('token')).toBe('/etc/secrets/token.txt');
+  });
+});
+
+describe('parseImageOverrideFlags --image-build-arg empty-value semantics (issue #242 / M2)', () => {
+  // Issue #242 M2: `--image-build-arg KEY=` (empty VALUE) is accepted
+  // and forwarded verbatim to `docker build --build-arg KEY=`, which
+  // docker itself accepts (the canonical way to unset a Dockerfile
+  // `ARG`'s default). Empty KEY is still rejected.
+  it('accepts an empty value (`KEY=`) and surfaces it as the empty string', () => {
+    const out = parseImageOverrideFlags({ imageBuildArg: ['KEY='] });
+    expect(out.globals.buildArgs.get('KEY')).toBe('');
+  });
+
+  it('still rejects an empty key (`=value`)', () => {
+    expect(() => parseImageOverrideFlags({ imageBuildArg: ['=value'] })).toThrow(/KEY=VAL/);
+  });
+
+  it('mixes empty-value and populated entries in one invocation', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildArg: ['UNSET=', 'NODE_ENV=production'],
+    });
+    expect(Array.from(out.globals.buildArgs.entries())).toEqual([
+      ['UNSET', ''],
+      ['NODE_ENV', 'production'],
+    ]);
+  });
+});
+
+describe('makeEntryFromPath path-resolution edge cases (issue #242)', () => {
+  // The `makeEntryFromPath` helper is exercised through `resolveImageOverrides`
+  // (Stage 1 explicit mapping is the simplest covered call site). The next
+  // three tests pin two branches the existing grid covered only on the happy
+  // path: absolute paths pass through, relative paths resolve against `cwd`,
+  // and a path that resolves to a DIRECTORY raises the "not a regular file"
+  // ImageOverrideError up-front (before any docker build runs).
+
+  const dirsToCleanup: string[] = [];
+  afterEach(() => {
+    for (const dir of dirsToCleanup.splice(0)) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('passes an absolute Dockerfile path through unchanged', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.abs');
+    expect(path.isAbsolute(dockerfile)).toBe(true);
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`Svc=${dockerfile}`],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['Svc'],
+    });
+    expect(overrides.get('Svc')?.dockerfile).toBe(dockerfile);
+    expect(overrides.get('Svc')?.contextDir).toBe(path.dirname(dockerfile));
+  });
+
+  it('resolves a relative Dockerfile path against the supplied `cwd`', async () => {
+    // makeTmpDockerfile gives us an absolute path under a tmp dir; we
+    // re-derive a RELATIVE form (basename) and feed `cwd=<tmp>` so the
+    // resolver lands at the same absolute path the helper produced.
+    const dockerfile = makeTmpDockerfile('Dockerfile.rel');
+    const baseDir = path.dirname(dockerfile);
+    const baseName = path.basename(dockerfile);
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`Svc=${baseName}`],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['Svc'],
+      cwd: baseDir,
+    });
+    expect(overrides.get('Svc')?.dockerfile).toBe(path.resolve(baseDir, baseName));
+    expect(overrides.get('Svc')?.contextDir).toBe(baseDir);
+  });
+
+  it('rejects a path that resolves to a directory with "not a regular file"', async () => {
+    // mkdtempSync gives an absolute directory path; passing it where a
+    // Dockerfile is expected must surface the existsSync-passes-but-
+    // isFile-fails branch in `makeEntryFromPath`. The test asserts the
+    // ImageOverrideError + the message names the directory anchor so a
+    // future refactor that swallows the branch into a generic "missing"
+    // surface is caught.
+    const dirPath = mkdtempSync(path.join(tmpdir(), 'cdkl-override-dir-'));
+    dirsToCleanup.push(dirPath);
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`Svc=${dirPath}`],
+    });
+    await expect(
+      resolveImageOverrides({ rawFlags, pinnedTargets: ['Svc'] })
+    ).rejects.toMatchObject({
+      name: 'ImageOverrideError',
+      message: expect.stringMatching(/not a regular file/),
+    });
+  });
+});
+
+describe('runImageOverrideBuilds partial-failure rollback (issue #242 / N3)', () => {
+  // N3: when the Nth build fails, the 1..(N-1) previously built tags are
+  // best-effort `docker image rm`'d before the ImageOverrideError is
+  // re-thrown. Cleanup failures are swallowed at debug — the original
+  // build error stays the surfaced one.
+
+  beforeEach(() => {
+    runDockerStreamingMock.mockReset();
+  });
+
+  it('runs `docker image rm <tag>` for every previously built tag on mid-run failure', async () => {
+    // Three targets; the 2nd build fails. The 1st target's tag should
+    // receive a `docker image rm` cleanup call; the 3rd never builds
+    // (the loop throws before reaching it).
+    const dockerfileA = makeTmpDockerfile('Dockerfile.rb-a');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.rb-b');
+    const dockerfileC = makeTmpDockerfile('Dockerfile.rb-c');
+    let callIdx = 0;
+    runDockerStreamingMock.mockImplementation((args: string[]) => {
+      callIdx += 1;
+      if (args[0] === 'build' && callIdx === 2) {
+        // 2nd build (target B) — fail.
+        return Promise.reject(
+          Object.assign(new Error('spawn failed'), {
+            stderr: 'ERROR: cache key not found\n',
+          })
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+    const overrides = new Map([
+      [
+        'A',
+        {
+          dockerfile: dockerfileA,
+          contextDir: path.dirname(dockerfileA),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+      [
+        'B',
+        {
+          dockerfile: dockerfileB,
+          contextDir: path.dirname(dockerfileB),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+      [
+        'C',
+        {
+          dockerfile: dockerfileC,
+          contextDir: path.dirname(dockerfileC),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+    ]);
+    await expect(runImageOverrideBuilds(overrides)).rejects.toBeInstanceOf(ImageOverrideError);
+    // Inspect the recorded calls. Expect:
+    //   - build A (success)
+    //   - build B (failure)
+    //   - image rm <tag-A> (rollback)
+    // C never builds; only A's tag is in the rollback list.
+    const calls = runDockerStreamingMock.mock.calls.map(([args]) => args as string[]);
+    const rmCalls = calls.filter((a) => a[0] === 'image' && a[1] === 'rm');
+    expect(rmCalls.length).toBe(1);
+    // Tag-A shape: derived from buildImageOverrideTag for the A entry.
+    const tagA = buildImageOverrideTag('A', {
+      dockerfile: dockerfileA,
+      contextDir: path.dirname(dockerfileA),
+      buildArgs: new Map<string, string>(),
+      buildSecrets: new Map<string, string>(),
+    });
+    expect(rmCalls[0]![2]).toBe(tagA);
+  });
+
+  it('propagates the ORIGINAL ImageOverrideError when the cleanup step itself fails', async () => {
+    // Build A succeeds, build B fails, then `image rm tag-A` ALSO fails.
+    // The thrown value MUST be the build-failure ImageOverrideError (not
+    // the cleanup error) so the user sees the actionable build message.
+    const dockerfileA = makeTmpDockerfile('Dockerfile.rb-orig-a');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.rb-orig-b');
+    let callIdx = 0;
+    runDockerStreamingMock.mockImplementation((args: string[]) => {
+      callIdx += 1;
+      if (args[0] === 'build' && callIdx === 2) {
+        return Promise.reject(
+          Object.assign(new Error('spawn failed'), {
+            stderr: 'ERROR: original build failure stderr\n',
+          })
+        );
+      }
+      if (args[0] === 'image' && args[1] === 'rm') {
+        return Promise.reject(new Error('rm failed: image is in use'));
+      }
+      return Promise.resolve(undefined);
+    });
+    const overrides = new Map([
+      [
+        'A',
+        {
+          dockerfile: dockerfileA,
+          contextDir: path.dirname(dockerfileA),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+      [
+        'B',
+        {
+          dockerfile: dockerfileB,
+          contextDir: path.dirname(dockerfileB),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+    ]);
+    await expect(runImageOverrideBuilds(overrides)).rejects.toMatchObject({
+      name: 'ImageOverrideError',
+      // The thrown error must carry the BUILD failure stderr, not the
+      // cleanup error's "rm failed" message.
+      message: expect.stringMatching(/original build failure stderr/),
+    });
+  });
+
+  it('does NOT call `docker image rm` when the FIRST build fails (no prior tags to clean up)', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.rb-first');
+    runDockerStreamingMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'build') {
+        return Promise.reject(
+          Object.assign(new Error('boom'), { stderr: 'first build failed\n' })
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+    const overrides = new Map([
+      [
+        'Solo',
+        {
+          dockerfile,
+          contextDir: path.dirname(dockerfile),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+    ]);
+    await expect(runImageOverrideBuilds(overrides)).rejects.toBeInstanceOf(ImageOverrideError);
+    const calls = runDockerStreamingMock.mock.calls.map(([args]) => args as string[]);
+    const rmCalls = calls.filter((a) => a[0] === 'image' && a[1] === 'rm');
+    expect(rmCalls.length).toBe(0);
   });
 });
 

--- a/tests/unit/local/image-pin-detector.test.ts
+++ b/tests/unit/local/image-pin-detector.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vite-plus/test';
 import {
   isLocalCdkAssetImage,
   describePinnedImageUri,
+  listPinnedTargets,
 } from '../../../src/local/image-pin-detector.js';
 import type { ResolvedEcsService } from '../../../src/local/ecs-service-resolver.js';
 import type { ResolvedEcsContainer, ResolvedEcsImage } from '../../../src/local/ecs-task-resolver.js';
@@ -136,5 +137,78 @@ describe('describePinnedImageUri (issue #234)', () => {
   it('returns undefined when the service has no containers (degenerate)', () => {
     const service = fakeService([]);
     expect(describePinnedImageUri(service)).toBeUndefined();
+  });
+});
+
+describe('listPinnedTargets (issue #242 / N1 dedupe)', () => {
+  function ecrService(uri: string): ResolvedEcsService {
+    return fakeService([
+      {
+        essential: true,
+        image: { kind: 'ecr', uri, account: '000000000000', region: 'us-east-1' },
+      },
+    ]);
+  }
+  function assetService(): ResolvedEcsService {
+    return fakeService([{ essential: true, image: { kind: 'cdk-asset', assetHash: 'h' } }]);
+  }
+  function publicService(uri: string): ResolvedEcsService {
+    return fakeService([{ essential: true, image: { kind: 'public', uri } }]);
+  }
+
+  it('returns one entry per pinned target with the URI label preserved', () => {
+    const out = listPinnedTargets([
+      { target: 'StackA/AppService', service: ecrService('111.dkr.ecr.us-east-1.amazonaws.com/a:1') },
+      { target: 'StackA/AuthService', service: ecrService('111.dkr.ecr.us-east-1.amazonaws.com/b:2') },
+    ]);
+    expect(out).toEqual([
+      { target: 'StackA/AppService', label: '111.dkr.ecr.us-east-1.amazonaws.com/a:1' },
+      { target: 'StackA/AuthService', label: '111.dkr.ecr.us-east-1.amazonaws.com/b:2' },
+    ]);
+  });
+
+  it('filters out CDK-asset targets (only pinned targets surface)', () => {
+    const out = listPinnedTargets([
+      { target: 'StackA/AssetSvc', service: assetService() },
+      { target: 'StackA/AssetSvc2', service: assetService() },
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it('handles a mixed set: pinned + asset interleaved', () => {
+    const out = listPinnedTargets([
+      { target: 'AppSvc', service: assetService() },
+      { target: 'AuthSvc', service: ecrService('111.dkr.ecr.us-east-1.amazonaws.com/auth:1') },
+      { target: 'WebSvc', service: assetService() },
+      { target: 'BgSvc', service: publicService('nginx:latest') },
+    ]);
+    expect(out).toEqual([
+      { target: 'AuthSvc', label: '111.dkr.ecr.us-east-1.amazonaws.com/auth:1' },
+      { target: 'BgSvc', label: 'nginx:latest' },
+    ]);
+  });
+
+  it('returns [] for an empty iterable (no booted services on the controller)', () => {
+    expect(listPinnedTargets([])).toEqual([]);
+  });
+
+  it('preserves caller-supplied iteration order across pinned entries', () => {
+    const order: Array<{ target: string; service: ResolvedEcsService }> = [
+      { target: 'Z', service: ecrService('e.com/z:1') },
+      { target: 'A', service: ecrService('e.com/a:1') },
+      { target: 'M', service: ecrService('e.com/m:1') },
+    ];
+    expect(listPinnedTargets(order).map((e) => e.target)).toEqual(['Z', 'A', 'M']);
+  });
+
+  it('omits the `label` property when the service has no containers (degenerate)', () => {
+    // No containers => describePinnedImageUri returns undefined, but the
+    // target is still NOT a local CDK asset (no image at all), so it
+    // surfaces as a pinned-target entry sans label. The WARN loop falls
+    // back to "a deployed registry" prose when label is undefined.
+    const empty = fakeService([]);
+    expect(listPinnedTargets([{ target: 'Empty', service: empty }])).toEqual([
+      { target: 'Empty' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Bundled follow-up for the non-blocker items deferred from PR #241
(the `--image-override` family v1). None of these are
behavior-breaking; the changes round out the test grid and tidy two
small implementation rough edges that surfaced in the 3-axis review.

### M2: document empty-value `--image-build-arg KEY=`

- ACCEPT (current behavior) + document. Rationale: docker itself
  accepts empty build-args (`docker build --build-arg KEY=` is the
  canonical way to unset a Dockerfile `ARG`'s default), so keeping
  the parser consistent with the underlying tool is less surprising
  than rejecting.
- JSDoc on `parseImageOverrideFlags` now spells out the empty-value
  semantics for every flag (`--image-build-arg KEY=` accepted,
  `--image-target ""` rejected, `--image-override <svc>=` rejected,
  `--image-build-secret id=` rejected) so the policy is visible in
  one place.
- README's `--image-build-arg` section calls out the empty-value
  forwarding behavior in one sentence.

### N1: dedupe pinned-target detection

- New `listPinnedTargets` helper in `src/local/image-pin-detector.ts`
  takes a list of `{ target, service }` pairs and returns the pinned
  subset with the deployed-registry URI label attached. Both the
  override engine's pre-boot peek and the post-boot WARN loop now
  flow through this single helper instead of independently re-walking
  `isLocalCdkAssetImage` + `describePinnedImageUri`.
- Re-exported via `src/internal.ts` for host CLIs.
- Site-level binding test pins that BOTH call sites consume the same
  helper (catches a future refactor that re-inlines one side).

### N3: cleanup on partial `runImageOverrideBuilds` failure

- `runImageOverrideBuilds` now tracks every successfully-built tag
  within the current invocation. On a mid-run build failure the
  rollback loop best-effort `docker image rm`'s each previously
  built tag before re-throwing the original `ImageOverrideError`.
- Cleanup-step failures are logged at `debug` and swallowed so the
  user always sees the actionable build error (not a tangential
  "image in use" cleanup error).
- Uses the existing `runDockerStreaming` utility — no raw
  `child_process`.

### Test coverage additions

- `parseImageOverrideFlags` empty-value (`KEY=`) row + a "mixed
  empty + populated" row.
- `makeEntryFromPath` directory-target row: passing a directory path
  surfaces "not a regular file" up-front (instead of mid-`docker build`).
- Build-context path resolution: absolute passthrough + relative
  resolution against the engine's `cwd` arg.
- `runImageOverrideBuilds` rollback rows: 2nd-of-3 failure issues a
  cleanup for the 1st target's tag; cleanup-step failure still
  propagates the original `ImageOverrideError`; first-build failure
  emits NO cleanup calls (nothing to roll back).
- `listPinnedTargets` unit grid: all-pinned, none-pinned, mixed,
  empty-input, order-preserving, degenerate-no-containers.

**Skipped from #242 (TTY-gated)**: Stage 3 boot-prompt non-skip
branches (`'N'` skip, `isCancel` cancel-as-error, valid-path injection)
and the Picker post-TTY edges (`isCancel` raise, empty multiselect,
"no uncovered pinned targets left to bind to"). These are TTY-gated;
behavioral coverage would require terminal emulation. The source-grep
"engine source recognizes n / no" sentinel test that already shipped
is the established pattern for this class of branch.

### Test anti-pattern follow-up

- `tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts`'s
  `boot-time WARN is NOT gated on --watch` test dropped its
  `.split('for (const pt of perTarget)')` landmark. The region is now
  bounded by two semantic anchors: the `Warn UP-FRONT` rationale
  comment (start) and the `enforceStrictOverrides(` call site that
  immediately follows the WARN loop (end). A rename of `perTarget`
  no longer silently widens the assertion region.

## Test plan

- [x] `vp run check` — green (typecheck + lint + format).
- [x] `vp test run` — 1959 tests green (was 1948 pre-change; +11 new
      rows across the four categories above).
- [x] `vp run build` — clean dist artifacts.
- [x] No behavior change for the success path (the override engine
      still produces the same per-target tag map; the WARN loop still
      surfaces the same per-target message; the dedupe is internal
      computation only).
- [x] N3 rollback is best-effort + idempotent — re-running after a
      previous partial failure builds against the same deterministic
      tags and the rollback call is a no-op if the image was already
      cleaned up.

Closes #242
