### PR TITLE
feat(image-override): per-service variants of build-arg / build-secret / target

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -79,14 +79,21 @@ AWS managed services.
   `cdkl start-service` / `cdkl start-alb` (`--image-override
   <svc>=<dockerfile>` or bare `<dockerfile>` for picker form,
   `--image-build-arg` / `--image-build-secret` / `--image-target`
-  as global build-input pass-throughs, `--no-interactive-overrides`
+  as build-input pass-throughs, `--no-interactive-overrides`
   to suppress the TTY boot prompt + multi-select picker, and
   `--strict-overrides` to fail fast when any pinned target remains
   uncovered): a covered pinned target is rebuilt locally from the
   supplied Dockerfile (deterministic local-only tag
   `cdkl-override-<svc>-<hash>:local`) and threaded through the
   rebuild rolling primitive on `--watch` reload — the engine module
-  lives in `src/local/image-override-engine.ts`.
+  lives in `src/local/image-override-engine.ts`. Issue #240 added
+  per-service variants of the three build-input flags
+  (`<svc>:KEY=VAL` for build-arg / build-secret, `<svc>=stage` for
+  target); the per-service form overrides the global per-key on the
+  named target, and an orphan validator
+  (`enforceImageOverrideOrphans`) fails the boot when a per-service
+  flag names a service the resolved override map does NOT cover
+  (typo / forgotten `--image-override` mapping).
   The host front-door (TLS materials, JWKS cache,
   Lambda-target RIE containers, listener sockets) is built once at
   boot and is NOT recreated on reload — only the per-service replica

--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ cdkl start-alb --from-cfn-stack \
 
 `--image-build-arg KEY=` (empty value) is accepted and forwarded verbatim to `docker build --build-arg KEY=` — the canonical way to unset a Dockerfile `ARG`'s default. Empty KEY (e.g. `--image-build-arg =val`) is rejected.
 
+**Per-service build inputs (monorepo case).** When two overridden services need different build args, secrets, or target stages, prefix the value with the service name. The per-service form wins over the global on the same target:
+
+```bash
+cdkl start-alb --from-cfn-stack \
+  --image-override AppService=./services/app/Dockerfile \
+  --image-override Reporting=./services/reporting/Dockerfile \
+  --image-build-secret AppService:npmrc=./.npmrc-private \
+  --image-build-secret Reporting:npmrc=./.npmrc-public \
+  --image-target AppService=builder \
+  --image-target Reporting=runtime
+```
+
+Syntax convention: flags whose payload already contains `=` (`--image-build-arg`, `--image-build-secret`) use `:` to separate the service prefix from the `<key>=<value>` payload — `<service>:<key>=<value>`. Flags whose payload is a single token (`--image-target`) use `=` — `<service>=<stage>` (matches the `--image-override <service>=<dockerfile>` convention). A per-service flag whose service name has no matching `--image-override` mapping (and no boot-prompt-injected mapping) is a boot error so a typo can't silently get ignored.
+
 Opt-outs:
 
 - `--no-interactive-overrides` suppresses the boot prompt + the multi-select picker; the override map is whatever explicit `--image-override <svc>=<dockerfile>` flags resolved to. Useful for scripted invocations.

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1575,10 +1575,42 @@ container's image to that tag before `docker run`. Sibling
 containers in a multi-container task are unaffected — they go
 through the normal CDK-asset / ECR / public-registry resolution.
 
-Out of scope for v1 (deferred to issue #240): per-service variants
-of `--image-build-arg` / `--image-build-secret` / `--image-target`
-(today these flags are global). Custom build-context directories
-distinct from the Dockerfile's parent dir are also deferred.
+**Per-service variants (issue #240).** A monorepo whose overridden
+services need different build inputs (private vs public npm tokens,
+different multi-stage stages, env-specific ARGs) can prefix each
+build-input flag with the service name. The per-service form
+overrides the global on the same target; the global still applies
+to every OTHER overridden target:
+
+- `--image-build-arg <service>:KEY=VAL` — per-service build arg.
+  Syntax uses `:` to separate the service prefix from the
+  `<key>=<value>` payload (the payload already contains `=`).
+- `--image-build-secret <service>:id=src` — per-service build
+  secret. Same `<service>:<rest>` convention; the `src` resolves
+  to an absolute path against `process.cwd()` as it does for the
+  global form.
+- `--image-target <service>=<stage>` — per-service target stage.
+  Single-token payload, so uses `=` (matches
+  `--image-override <service>=<dockerfile>`).
+
+A per-service flag whose service name is NOT covered by
+`--image-override` (or the boot prompt's in-memory injection)
+fails the boot with a `LocalStartServiceError` naming the
+offending flag(s) — surfacing typo'd service names up-front
+instead of silently dropping the value.
+
+```bash
+cdkl start-alb --from-cfn-stack \
+  --image-override AppService=./services/app/Dockerfile \
+  --image-override Reporting=./services/reporting/Dockerfile \
+  --image-build-secret AppService:npmrc=./.npmrc-private \
+  --image-build-secret Reporting:npmrc=./.npmrc-public \
+  --image-target AppService=builder \
+  --image-target Reporting=runtime
+```
+
+Custom build-context directories distinct from the Dockerfile's
+parent dir are still deferred (also tracked under #240's siblings).
 
 Known fast-path limitations (Phase 4 trade-offs):
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -103,6 +103,7 @@ import { buildAuthCheck } from '../../local/front-door-auth.js';
 import { createJwksCache } from '../../local/cognito-jwt.js';
 import { isLocalCdkAssetImage, listPinnedTargets } from '../../local/image-pin-detector.js';
 import {
+  enforceImageOverrideOrphans,
   parseImageOverrideFlags,
   resolveImageOverrides,
   runImageOverrideBuilds,
@@ -231,24 +232,30 @@ export interface EcsServiceEmulatorOptions {
    */
   imageOverride?: string[];
   /**
-   * Issue #238 — `--image-build-arg KEY=VAL` pairs, repeatable. Global
-   * (apply to every overridden target's `docker build --build-arg`).
-   * Per-service variants are intentionally out of scope for v1
-   * (tracked separately in #240).
+   * Issue #238 / #240 — `--image-build-arg KEY=VAL` (global) or
+   * `<svc>:KEY=VAL` (per-service, issue #240), repeatable. Global
+   * applies to every overridden target's `docker build --build-arg`;
+   * per-service overrides the global per-key on the named target.
    */
   imageBuildArg?: string[];
   /**
-   * Issue #238 — `--image-build-secret id=src`, repeatable. Global.
-   * Forwarded to `docker build --secret id=<id>,src=<src>` for every
-   * overridden target so `RUN --mount=type=secret,id=<id>` works
-   * locally (the private-registry / npm-token recipe).
+   * Issue #238 / #240 — `--image-build-secret id=src` (global) or
+   * `<svc>:id=src` (per-service, issue #240), repeatable. Global
+   * forwards to `docker build --secret id=<id>,src=<src>` for every
+   * overridden target; per-service overrides the global per-id on
+   * the named target so a monorepo can mount different `npmrc`
+   * tokens per service Dockerfile.
    */
   imageBuildSecret?: string[];
   /**
-   * Issue #238 — `--image-target <stage>`. Global. Forwarded to
-   * `docker build --target=<stage>` for every overridden target.
+   * Issue #238 / #240 — `--image-target <stage>` (global) or
+   * `<svc>=<stage>` (per-service, issue #240). Repeatable now that
+   * per-service variants exist (each occurrence may be a different
+   * shape). Forwarded to `docker build --target=<stage>` for every
+   * overridden target (or the named one when the per-service form
+   * is used).
    */
-  imageTarget?: string;
+  imageTarget?: string[];
   /**
    * Issue #238 — `--no-interactive-overrides`. Suppresses the boot
    * prompt + the picker-form prompt; the override map is whatever
@@ -2468,6 +2475,16 @@ async function resolveAndBuildImageOverrides(args: {
     noInteractive,
   });
 
+  // Issue #240 — orphan validation runs AFTER Stage 3 (boot prompt
+  // complete). A per-service flag (`--image-build-arg <svc>:KEY=VAL`,
+  // `--image-build-secret <svc>:id=src`, `--image-target <svc>=stage`)
+  // that names a service still not covered in `overrides` is a hard
+  // error — the user typo'd or forgot the corresponding
+  // `--image-override <svc>=<dockerfile>`. Wrapped as
+  // `LocalStartServiceError` inside the engine so the global error
+  // handler renders it cleanly.
+  enforceImageOverrideOrphans(rawFlags, overrides);
+
   if (overrides.size === 0) return new Map();
 
   // Build every covered Dockerfile. Per-build progress goes to stdout
@@ -2646,9 +2663,11 @@ export function addImageOverrideOptions(cmd: Command): Command {
     )
     .addOption(
       new Option(
-        '--image-target <stage>',
-        'Global `docker build --target=<stage>` forwarded to every --image-override build. Useful ' +
-          'when the Dockerfile is multi-stage and you want to stop at a specific intermediate stage.'
+        '--image-target <stage or svc=stage...>',
+        'Repeatable. Bare `<stage>` is a global --target for every --image-override build; ' +
+          '`<service>=<stage>` (issue #240) scopes the --target to one overridden target so a ' +
+          'monorepo with different multi-stage Dockerfiles per service can stop each at its own ' +
+          'intermediate stage. Per-service form overrides the global on the named target.'
       )
     )
     .addOption(

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -2456,10 +2456,20 @@ async function resolveAndBuildImageOverrides(args: {
   // Short-circuit: nothing to do when no override flag was passed AND
   // no pinned target exists to prompt about. Saves a no-op pass on the
   // common case (local CDK assets, no flags).
+  //
+  // Per-service build-input flags (`--image-build-arg <svc>:KEY=VAL`,
+  // `--image-build-secret <svc>:id=src`, `--image-target <svc>=stage`)
+  // are intentionally NOT eligible for short-circuit: a user who passes
+  // a per-service flag alone but no `--image-override` for that service
+  // has a typo or forgotten mapping that the orphan validator
+  // (`enforceImageOverrideOrphans`, called below) MUST surface as a
+  // hard `LocalStartServiceError`. Short-circuiting before the
+  // validator runs would silently drop those flags.
   if (
     pinnedTargets.length === 0 &&
     rawFlags.explicit.size === 0 &&
-    rawFlags.pickerPaths.length === 0
+    rawFlags.pickerPaths.length === 0 &&
+    rawFlags.perService.size === 0
   ) {
     return new Map();
   }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -528,26 +528,41 @@ export {
 } from './cli/commands/ecs-service-emulator.js';
 
 /**
- * Issue #238 — `cdkl start-service` / `cdkl start-alb`
+ * Issue #238 / #240 — `cdkl start-service` / `cdkl start-alb`
  * `--image-override` family engine. `parseImageOverrideFlags` is the
  * pure flag parser; `resolveImageOverrides` walks the picker + boot
  * prompt against the pinned target set; `runImageOverrideBuilds`
  * runs the `docker build` pass per covered Dockerfile and returns
  * the deterministic local tag per target. `buildImageOverrideTag` is
  * exposed so a host CLI can reproduce the same tag-naming convention
- * if it wraps the engine for a custom build orchestration. Re-exported
- * via `cdk-local/internal` so host CLIs (e.g. cdkd) inherit the same
- * override pipeline without a byte-identical copy.
+ * if it wraps the engine for a custom build orchestration.
+ *
+ * Issue #240 additions: `enforceImageOverrideOrphans` is the
+ * orphan-validation pass that fires after Stage 3 (boot prompt) — a
+ * per-service flag (`<svc>:KEY=VAL` etc.) naming a service the
+ * resolved override map does NOT cover throws `LocalStartServiceError`.
+ * `mergeForService` produces the effective build inputs for one
+ * service target by layering its per-service overlay on top of the
+ * globals (per-service wins on key collision); host CLIs reuse it
+ * when they bypass `resolveImageOverrides` and assemble entries
+ * directly. `PerServiceBuildInputs` is the per-service overlay type
+ * referenced from `RawImageOverrideFlags.perService`.
+ *
+ * Re-exported via `cdk-local/internal` so host CLIs (e.g. cdkd)
+ * inherit the same override pipeline without a byte-identical copy.
  */
 export {
   parseImageOverrideFlags,
   resolveImageOverrides,
   runImageOverrideBuilds,
   buildImageOverrideTag,
+  enforceImageOverrideOrphans,
+  mergeForService,
   ImageOverrideError,
   type ImageOverrideEntry,
   type ImageOverrideMap,
   type ImageOverrideGlobals,
+  type PerServiceBuildInputs,
   type RawImageOverrideFlags,
 } from './local/image-override-engine.js';
 

--- a/src/local/image-override-engine.ts
+++ b/src/local/image-override-engine.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import { isCancel, multiselect, text } from '@clack/prompts';
-import { CdkLocalError } from '../utils/error-handler.js';
+import { CdkLocalError, LocalStartServiceError } from '../utils/error-handler.js';
 import { getLogger } from '../utils/logger.js';
 import { runDockerStreaming } from '../utils/docker-cmd.js';
 import { getEmbedConfig } from './embed-config.js';
@@ -51,17 +51,35 @@ import { isInteractive } from './target-picker.js';
 /**
  * Per-target build inputs the engine collects from the CLI flags + boot
  * prompt + picker, then hands off to {@link runImageOverrideBuilds}.
+ *
+ * `buildArgs` / `buildSecrets` / `targetStage` are the EFFECTIVE inputs
+ * for THIS target's `docker build` — already a merge of the global
+ * (`--image-build-arg KEY=VAL` etc.) AND the per-service
+ * (`<svc>:KEY=VAL` etc.) flag forms (issue #240). The per-service form
+ * overrides the global per key when both match the target.
  */
 export interface ImageOverrideEntry {
   /** Absolute path to the Dockerfile to build from. */
   dockerfile: string;
   /** Absolute path to the build context directory (Dockerfile's parent for v1). */
   contextDir: string;
-  /** `--image-build-arg KEY=VAL` pairs, applied globally to every override. */
+  /**
+   * Effective build args for this target — global + per-service merged
+   * (per-service wins on key collision). Order: globals first, then
+   * per-service entries (Map iteration order = insertion order, so a
+   * per-service override on a globally-set key keeps its own position
+   * because the merge re-assigns the key in place).
+   */
   buildArgs: Map<string, string>;
-  /** `--image-build-secret id=src` entries, applied globally to every override. */
+  /**
+   * Effective build secrets for this target — global + per-service
+   * merged (per-service wins on id collision).
+   */
   buildSecrets: Map<string, string>;
-  /** Optional `--image-target <stage>` multi-stage build target. */
+  /**
+   * Effective `--target <stage>` value. Per-service `<svc>=<stage>`
+   * wins over the global `--image-target <stage>` when both are set.
+   */
   targetStage?: string;
 }
 
@@ -82,12 +100,33 @@ export class ImageOverrideError extends CdkLocalError {
 }
 
 /**
- * Global build options that apply to every overridden target. v1 spec
- * keeps these flat (no per-service variants — tracked separately in
- * issue #240). Used inside {@link parseImageOverrideFlags} when promoting
- * each per-target raw entry into a full {@link ImageOverrideEntry}.
+ * Global build options that apply to EVERY overridden target. Issue
+ * #240 added per-service variants (see {@link PerServiceBuildInputs}
+ * on {@link RawImageOverrideFlags}); the global form remains the
+ * baseline that per-service entries layer on top of (per-service wins
+ * on key collision).
  */
 export interface ImageOverrideGlobals {
+  buildArgs: Map<string, string>;
+  buildSecrets: Map<string, string>;
+  targetStage?: string;
+}
+
+/**
+ * Issue #240 — per-service build inputs collected from the prefixed
+ * flag forms (`<svc>:KEY=VAL` for build-arg / build-secret;
+ * `<svc>=stage` for target). One entry per named service; missing
+ * fields fall through to the corresponding {@link ImageOverrideGlobals}
+ * value at merge time.
+ *
+ * Service-name validation happens in {@link enforceImageOverrideOrphans}
+ * AFTER picker + boot-prompt resolve — a per-service flag that names a
+ * service with no `--image-override` mapping (and no boot-prompt-
+ * injected mapping) is a hard error so the user can't silently get
+ * "my AppService:KEY=val flag was ignored because I forgot to add
+ * --image-override AppService".
+ */
+export interface PerServiceBuildInputs {
   buildArgs: Map<string, string>;
   buildSecrets: Map<string, string>;
   targetStage?: string;
@@ -100,6 +139,12 @@ export interface ImageOverrideGlobals {
  * pinned targets via a multi-select prompt). Both forms may appear in
  * one invocation; the emulator's resolver collapses them into a single
  * {@link ImageOverrideMap}.
+ *
+ * Issue #240 added the `perService` bucket: prefixed forms of the
+ * build-input flags (`<svc>:KEY=VAL`, `<svc>:id=src`, `<svc>=stage`)
+ * land here keyed by service name. The global counterparts stay in
+ * {@link ImageOverrideGlobals}; the resolver merges global + per-service
+ * per-target when promoting into {@link ImageOverrideEntry}.
  */
 export interface RawImageOverrideFlags {
   /** Service target -> Dockerfile path (explicit mapping). */
@@ -112,6 +157,13 @@ export interface RawImageOverrideFlags {
    */
   pickerPaths: string[];
   globals: ImageOverrideGlobals;
+  /**
+   * Issue #240 — per-service overlay on top of {@link globals}. Keyed
+   * by service name (the part LEFT of the leading `:` for build-arg /
+   * build-secret; LEFT of `=` for target). Empty when no per-service
+   * flag form appears in the invocation.
+   */
+  perService: Map<string, PerServiceBuildInputs>;
 }
 
 /**
@@ -125,34 +177,88 @@ export interface RawImageOverrideFlags {
  * - `--image-override <svc>=<dockerfile>` -> `explicit.set(svc, dockerfile)`
  * - `--image-override <dockerfile>` (no `=`) -> `pickerPaths.push(...)`
  * - `--image-build-arg KEY=VAL` -> `globals.buildArgs.set('KEY', 'VAL')`
+ * - `--image-build-arg <svc>:KEY=VAL` -> `perService(svc).buildArgs.set('KEY', 'VAL')` (issue #240)
  * - `--image-build-secret id=src` -> `globals.buildSecrets.set('id', 'src')`
+ * - `--image-build-secret <svc>:id=src` -> `perService(svc).buildSecrets.set('id', 'src')` (issue #240)
  * - `--image-target <stage>` -> `globals.targetStage = '<stage>'`
+ * - `--image-target <svc>=<stage>` -> `perService(svc).targetStage = '<stage>'` (issue #240)
+ *
+ * Per-service syntax convention (issue #240):
+ * - Flags whose payload already contains `=` (build-arg, build-secret)
+ *   use `:` to separate the service prefix from the `<key>=<value>`
+ *   payload — `<svc>:KEY=VAL`. The FIRST `:` before the FIRST `=` (if
+ *   any) is treated as the prefix delimiter.
+ * - Flags whose payload is a single token (target) use `=` to separate
+ *   the service prefix from the stage — `<svc>=stage`. Matches the
+ *   `--image-override <svc>=<dockerfile>` convention.
+ * - Per-service entries override the global entry per-key when both
+ *   forms set the same key on the same target. Globals still apply to
+ *   every OTHER overridden target.
  *
  * Collision detection: a service target named more than once in
  * `--image-override <svc>=...` is an error (last-write-wins would
  * silently drop the earlier mapping; explicit error is clearer).
+ * Repeated per-service `--image-build-arg <svc>:KEY=...` entries on
+ * the same `<svc>:KEY` pair are last-write-wins (the same shape the
+ * global form already uses for repeated `KEY=...` entries — both
+ * forms behave identically inside their respective bucket).
  *
  * Empty-value semantics:
  * - `--image-build-arg KEY=` (empty value) is ACCEPTED. The empty
  *   string is forwarded verbatim to `docker build --build-arg KEY=`,
  *   which docker itself accepts (the canonical way to unset a
  *   Dockerfile `ARG`'s default). `KEY=` (empty key) is rejected.
+ *   Per-service form `<svc>:KEY=` is similarly accepted (same empty-
+ *   value semantics applied to the per-service entry).
  * - `--image-target ""` (empty value) is REJECTED — an empty
  *   `--target` is meaningless to `docker build` (`--target` is a
- *   single stage name, not a list).
+ *   single stage name, not a list). Per-service `<svc>=` is similarly
+ *   rejected (empty stage).
  * - `--image-override <svc>=` and `--image-override =<dockerfile>`
  *   are REJECTED — both halves must be non-empty.
  * - `--image-build-secret id=` and `--image-build-secret =src` are
- *   REJECTED — both halves must be non-empty.
+ *   REJECTED — both halves must be non-empty. Per-service form
+ *   `<svc>:id=` and `<svc>:=src` are similarly rejected.
  */
 export function parseImageOverrideFlags(input: {
   imageOverride?: string[];
   imageBuildArg?: string[];
   imageBuildSecret?: string[];
-  imageTarget?: string;
+  /**
+   * `--image-target` may now be repeated to support per-service forms
+   * alongside a global. Accepts the legacy single-string shape too,
+   * so existing call sites that pass a scalar don't break.
+   */
+  imageTarget?: string | string[];
 }): RawImageOverrideFlags {
   const explicit = new Map<string, string>();
   const pickerPaths: string[] = [];
+  const perService = new Map<string, PerServiceBuildInputs>();
+  // Lazily fetch / create a per-service bucket. Centralized so we don't
+  // forget to initialize a new `PerServiceBuildInputs` on the first
+  // touch of a service name.
+  const getPerSvc = (svc: string): PerServiceBuildInputs => {
+    let entry = perService.get(svc);
+    if (!entry) {
+      entry = { buildArgs: new Map(), buildSecrets: new Map() };
+      perService.set(svc, entry);
+    }
+    return entry;
+  };
+  // Split a `<svc>:<rest>` raw token at the FIRST `:` BEFORE the FIRST
+  // `=` (if any). Returns null when the raw value carries no leading
+  // service prefix (i.e. the value is the legacy global form).
+  // The `:` MUST precede the `=` to count as a per-service prefix —
+  // otherwise a `KEY=val:with:colons` value would be misparsed.
+  const splitPerServicePrefix = (raw: string): { svc: string; rest: string } | null => {
+    const colon = raw.indexOf(':');
+    const eq = raw.indexOf('=');
+    if (colon < 0) return null;
+    if (eq >= 0 && eq < colon) return null;
+    const svc = raw.slice(0, colon).trim();
+    if (!svc) return null;
+    return { svc, rest: raw.slice(colon + 1) };
+  };
   for (const raw of input.imageOverride ?? []) {
     const eq = raw.indexOf('=');
     // No `=` -> picker form. An absolute path or a relative one both
@@ -190,6 +296,27 @@ export function parseImageOverrideFlags(input: {
 
   const buildArgs = new Map<string, string>();
   for (const raw of input.imageBuildArg ?? []) {
+    const prefix = splitPerServicePrefix(raw);
+    if (prefix) {
+      // Per-service form `<svc>:KEY=VAL`. Validate KEY=VAL inside the
+      // post-prefix `rest` portion under the same rules the global
+      // form uses (empty VAL OK, empty KEY rejected).
+      const eq = prefix.rest.indexOf('=');
+      if (eq <= 0) {
+        throw new ImageOverrideError(
+          `Invalid --image-build-arg value "${raw}": expected <service>:KEY=VAL.`
+        );
+      }
+      const key = prefix.rest.slice(0, eq).trim();
+      const value = prefix.rest.slice(eq + 1);
+      if (!key) {
+        throw new ImageOverrideError(
+          `Invalid --image-build-arg value "${raw}": empty key (after service prefix).`
+        );
+      }
+      getPerSvc(prefix.svc).buildArgs.set(key, value);
+      continue;
+    }
     const eq = raw.indexOf('=');
     if (eq <= 0) {
       throw new ImageOverrideError(`Invalid --image-build-arg value "${raw}": expected KEY=VAL.`);
@@ -204,6 +331,27 @@ export function parseImageOverrideFlags(input: {
 
   const buildSecrets = new Map<string, string>();
   for (const raw of input.imageBuildSecret ?? []) {
+    const prefix = splitPerServicePrefix(raw);
+    if (prefix) {
+      // Per-service form `<svc>:id=src`. Validate id=src inside `rest`
+      // under the same rules as global (both halves non-empty).
+      const eq = prefix.rest.indexOf('=');
+      if (eq <= 0) {
+        throw new ImageOverrideError(
+          `Invalid --image-build-secret value "${raw}": expected <service>:id=src (e.g. AppService:npmrc=./.npmrc).`
+        );
+      }
+      const id = prefix.rest.slice(0, eq).trim();
+      const src = prefix.rest.slice(eq + 1).trim();
+      if (!id || !src) {
+        throw new ImageOverrideError(
+          `Invalid --image-build-secret value "${raw}": id and src must both be non-empty (after service prefix).`
+        );
+      }
+      const absSrcPS = isAbsolute(src) ? src : resolvePath(process.cwd(), src);
+      getPerSvc(prefix.svc).buildSecrets.set(id, absSrcPS);
+      continue;
+    }
     const eq = raw.indexOf('=');
     if (eq <= 0) {
       throw new ImageOverrideError(
@@ -230,14 +378,46 @@ export function parseImageOverrideFlags(input: {
   }
 
   const globals: ImageOverrideGlobals = { buildArgs, buildSecrets };
-  if (input.imageTarget !== undefined) {
-    if (!input.imageTarget) {
+  // `--image-target` accepts either a single scalar (legacy / global)
+  // or an array (per-service variants + an optional global). Coerce
+  // to an array up-front so the loop body handles both shapes.
+  const imageTargetList: string[] =
+    input.imageTarget === undefined
+      ? []
+      : Array.isArray(input.imageTarget)
+        ? input.imageTarget
+        : [input.imageTarget];
+  for (const raw of imageTargetList) {
+    if (raw === undefined || raw === null) continue;
+    if (!raw) {
       throw new ImageOverrideError('Invalid --image-target value: empty string.');
     }
-    globals.targetStage = input.imageTarget;
+    const eq = raw.indexOf('=');
+    if (eq < 0) {
+      // Global form: a bare stage name. Last write wins when the user
+      // repeated the flag with multiple bare values (parser is liberal
+      // so an accidental `--image-target a --image-target b` doesn't
+      // hard-error; the latter overrides).
+      globals.targetStage = raw;
+      continue;
+    }
+    // Per-service form: `<svc>=<stage>`. Both halves must be non-empty.
+    const svc = raw.slice(0, eq).trim();
+    const stage = raw.slice(eq + 1).trim();
+    if (!svc) {
+      throw new ImageOverrideError(
+        `Invalid --image-target value "${raw}": left side (service target) is empty.`
+      );
+    }
+    if (!stage) {
+      throw new ImageOverrideError(
+        `Invalid --image-target value "${raw}": right side (stage) is empty.`
+      );
+    }
+    getPerSvc(svc).targetStage = stage;
   }
 
-  return { explicit, pickerPaths, globals };
+  return { explicit, pickerPaths, globals, perService };
 }
 
 /**
@@ -317,7 +497,7 @@ export async function resolveImageOverrides(args: {
       );
       continue;
     }
-    out.set(svc, makeEntryFromPath(dockerfileRaw, rawFlags.globals, cwd));
+    out.set(svc, makeEntryFromPath(dockerfileRaw, svc, rawFlags, cwd));
   }
 
   // Stage 2: picker-form Dockerfile paths.
@@ -359,8 +539,11 @@ export async function resolveImageOverrides(args: {
           logger.warn(`--image-override ${dockerfileRaw}: empty selection. Skipped.`);
           continue;
         }
-        const entry = makeEntryFromPath(dockerfileRaw, rawFlags.globals, cwd);
-        for (const t of chosen) out.set(t, entry);
+        // Picker form may bind one Dockerfile to MULTIPLE targets. Each
+        // target merges its own per-service overlay (no cross-talk),
+        // so the entries differ per target whenever a per-service flag
+        // touches one of the picked services.
+        for (const t of chosen) out.set(t, makeEntryFromPath(dockerfileRaw, t, rawFlags, cwd));
       }
     }
   }
@@ -392,7 +575,7 @@ export async function resolveImageOverrides(args: {
       if (!value) continue;
       const lower = value.toLowerCase();
       if (lower === 'n' || lower === 'no') continue;
-      out.set(target, makeEntryFromPath(value, rawFlags.globals, cwd));
+      out.set(target, makeEntryFromPath(value, target, rawFlags, cwd));
     }
   }
 
@@ -400,16 +583,54 @@ export async function resolveImageOverrides(args: {
 }
 
 /**
- * Promote a per-target Dockerfile path + globals into a full
+ * Issue #240 — produce the EFFECTIVE per-target build inputs by layering
+ * a per-service overlay on top of the global baseline. Per-service
+ * entries override the global per-key (and per-service `targetStage`
+ * overrides the global `targetStage`).
+ *
+ * The returned Maps are fresh copies — the caller may mutate the
+ * resulting {@link ImageOverrideEntry}'s Maps without bleeding back
+ * into the shared global Maps inside {@link RawImageOverrideFlags}.
+ * Per-service entries are merged AFTER globals so a key shared between
+ * the two ends up with the per-service value (Map's `set` overwrites
+ * on duplicate key).
+ */
+export function mergeForService(
+  serviceTarget: string,
+  globals: ImageOverrideGlobals,
+  perService: ReadonlyMap<string, PerServiceBuildInputs>
+): { buildArgs: Map<string, string>; buildSecrets: Map<string, string>; targetStage?: string } {
+  const buildArgs = new Map<string, string>(globals.buildArgs);
+  const buildSecrets = new Map<string, string>(globals.buildSecrets);
+  let targetStage = globals.targetStage;
+  const overlay = perService.get(serviceTarget);
+  if (overlay) {
+    for (const [k, v] of overlay.buildArgs.entries()) buildArgs.set(k, v);
+    for (const [k, v] of overlay.buildSecrets.entries()) buildSecrets.set(k, v);
+    if (overlay.targetStage !== undefined) targetStage = overlay.targetStage;
+  }
+  return {
+    buildArgs,
+    buildSecrets,
+    ...(targetStage !== undefined && { targetStage }),
+  };
+}
+
+/**
+ * Promote a per-target Dockerfile path + raw flags into a full
  * {@link ImageOverrideEntry}. Resolves the path against `cwd`, asserts
  * the Dockerfile exists and is a regular file (so the user sees
  * "file not found" up-front rather than mid-`docker build`), and
  * derives the build context as the Dockerfile's parent directory
  * (the v1 simplification — custom contexts are tracked separately).
+ *
+ * Issue #240 — `serviceTarget` is now part of the entry-construction
+ * input so the global + per-service merge runs per target.
  */
 function makeEntryFromPath(
   raw: string,
-  globals: ImageOverrideGlobals,
+  serviceTarget: string,
+  rawFlags: RawImageOverrideFlags,
   cwd: string
 ): ImageOverrideEntry {
   const abs = isAbsolute(raw) ? raw : resolvePath(cwd, raw);
@@ -424,12 +645,13 @@ function makeEntryFromPath(
       `--image-override: '${raw}' is not a regular file (resolved to '${abs}').`
     );
   }
+  const merged = mergeForService(serviceTarget, rawFlags.globals, rawFlags.perService);
   return {
     dockerfile: abs,
     contextDir: dirname(abs),
-    buildArgs: globals.buildArgs,
-    buildSecrets: globals.buildSecrets,
-    ...(globals.targetStage !== undefined && { targetStage: globals.targetStage }),
+    buildArgs: merged.buildArgs,
+    buildSecrets: merged.buildSecrets,
+    ...(merged.targetStage !== undefined && { targetStage: merged.targetStage }),
   };
 }
 
@@ -577,4 +799,68 @@ export async function runImageOverrideBuilds(
     builtTags.push(tag);
   }
   return out;
+}
+
+/**
+ * Issue #240 — orphan validation. A per-service build-input flag
+ * (`--image-build-arg <svc>:KEY=VAL`, `--image-build-secret
+ * <svc>:id=src`, or `--image-target <svc>=stage`) names a service that
+ * MUST appear in the resolved override map — otherwise the per-service
+ * value silently gets discarded because no `docker build` runs for
+ * that service.
+ *
+ * Called AFTER {@link resolveImageOverrides} (Stage 3 boot prompt
+ * complete) so a service the user added via the prompt counts as
+ * covered. A still-orphan per-service flag at this point means the
+ * user typo'd the service name OR forgot a corresponding
+ * `--image-override <svc>=<dockerfile>` mapping (and either chose `N`
+ * in the boot prompt or ran with `--no-interactive-overrides`).
+ *
+ * Throws {@link LocalStartServiceError} naming every offending
+ * `<flag>` + `<service>` pair so the user can fix all in one go
+ * (matches the `enforceStrictOverrides` pattern). Mutates nothing.
+ *
+ * Host-side use case: cdkd and other shim hosts that wrap the engine
+ * re-export this via `cdk-local/internal` and call it right after
+ * their own `resolveImageOverrides` invocation to inherit the same
+ * orphan-detection semantics.
+ *
+ * @param rawFlags Output of {@link parseImageOverrideFlags}.
+ * @param resolvedOverrides Output of {@link resolveImageOverrides}
+ *   (after the boot prompt has run).
+ */
+export function enforceImageOverrideOrphans(
+  rawFlags: RawImageOverrideFlags,
+  resolvedOverrides: ImageOverrideMap
+): void {
+  if (rawFlags.perService.size === 0) return;
+  const offenders: string[] = [];
+  for (const [svc, overlay] of rawFlags.perService.entries()) {
+    if (resolvedOverrides.has(svc)) continue;
+    // Surface one line per offending FLAG kind so the user sees every
+    // piece they need to fix, not just the first.
+    if (overlay.buildArgs.size > 0) {
+      const keys = Array.from(overlay.buildArgs.keys()).join(', ');
+      offenders.push(
+        `--image-build-arg ${svc}:${keys} references a service with no --image-override mapping.`
+      );
+    }
+    if (overlay.buildSecrets.size > 0) {
+      const ids = Array.from(overlay.buildSecrets.keys()).join(', ');
+      offenders.push(
+        `--image-build-secret ${svc}:${ids} references a service with no --image-override mapping.`
+      );
+    }
+    if (overlay.targetStage !== undefined) {
+      offenders.push(
+        `--image-target ${svc}=${overlay.targetStage} references a service with no --image-override mapping.`
+      );
+    }
+  }
+  if (offenders.length === 0) return;
+  throw new LocalStartServiceError(
+    `Per-service image-override flag(s) target a service with no --image-override ` +
+      `coverage. Add the matching --image-override <service>=<dockerfile>, drop the ` +
+      `per-service flag, or fix the service name:\n  ${offenders.join('\n  ')}`
+  );
 }

--- a/src/local/image-override-engine.ts
+++ b/src/local/image-override-engine.ts
@@ -397,8 +397,10 @@ export function parseImageOverrideFlags(input: {
       // Global form: a bare stage name. Last write wins when the user
       // repeated the flag with multiple bare values (parser is liberal
       // so an accidental `--image-target a --image-target b` doesn't
-      // hard-error; the latter overrides).
-      globals.targetStage = raw;
+      // hard-error; the latter overrides). Trim mirrors the per-service
+      // branch below so `--image-target ' builder '` is treated the same
+      // way regardless of which form the user picked.
+      globals.targetStage = raw.trim();
       continue;
     }
     // Per-service form: `<svc>=<stage>`. Both halves must be non-empty.

--- a/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
@@ -183,6 +183,43 @@ describe('enforceStrictOverrides (issue #238 strict-overrides guard, behavioral)
   });
 });
 
+describe('enforceImageOverrideOrphans (issue #240 orphan validator, wiring)', () => {
+  // Behavioral coverage for the helper itself lives in
+  // tests/unit/local/image-override-engine.test.ts. This block pins
+  // the boot-path wiring so a refactor that drops, reorders, or
+  // short-circuits past the call site surfaces here.
+
+  it('boot path calls enforceImageOverrideOrphans AFTER resolveImageOverrides (post-Stage 3 prompt)', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The Stage 3 boot prompt fires inside resolveImageOverrides;
+    // the orphan validator MUST run AFTER so prompt-injected mappings
+    // count as "covered" and the check fires only on genuine typos /
+    // forgotten --image-override mappings.
+    const resolveIdx = source.indexOf('await resolveImageOverrides(');
+    const enforceIdx = source.indexOf('enforceImageOverrideOrphans(');
+    expect(resolveIdx, 'resolveImageOverrides call missing').toBeGreaterThan(-1);
+    expect(enforceIdx, 'enforceImageOverrideOrphans call missing').toBeGreaterThan(-1);
+    expect(resolveIdx).toBeLessThan(enforceIdx);
+    // The call MUST forward rawFlags + the resolved overrides map.
+    expect(source).toMatch(
+      /enforceImageOverrideOrphans\(\s*rawFlags\s*,\s*overrides\s*\)/
+    );
+  });
+
+  it('boot-path short-circuit gates on rawFlags.perService.size === 0 (per-service typos must reach the orphan validator)', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The short-circuit condition that returns an empty override map
+    // when there's nothing to do MUST include `rawFlags.perService.size
+    // === 0`. A user who passes only `--image-build-arg <svc>:KEY=val`
+    // (per-service form, no `--image-override`) would otherwise have
+    // their typo silently dropped instead of surfaced as a
+    // LocalStartServiceError by enforceImageOverrideOrphans.
+    expect(source).toMatch(
+      /pinnedTargets\.length === 0[\s\S]{0,400}rawFlags\.perService\.size === 0/
+    );
+  });
+});
+
 describe('addImageOverrideOptions wiring (issue #238)', () => {
   const SERVICE_SOURCE = path.join(
     __dirname,

--- a/tests/unit/local/image-override-engine.test.ts
+++ b/tests/unit/local/image-override-engine.test.ts
@@ -24,11 +24,14 @@ vi.mock('../../../src/utils/docker-cmd.js', async () => {
 
 const {
   buildImageOverrideTag,
+  enforceImageOverrideOrphans,
   ImageOverrideError,
+  mergeForService,
   parseImageOverrideFlags,
   resolveImageOverrides,
   runImageOverrideBuilds,
 } = await import('../../../src/local/image-override-engine.js');
+const { LocalStartServiceError } = await import('../../../src/utils/error-handler.js');
 
 /**
  * Issue #238 — engine-level coverage. The picker / boot-prompt branches
@@ -793,5 +796,435 @@ describe('resolveImageOverrides Stage 3 boot prompt skip sentinels (M3)', () => 
     expect(source).toMatch(/lower === 'no'/);
     // And the prompt copy must contain the [path / N] hint.
     expect(source).toMatch(/\[path \/ N\]/);
+  });
+});
+
+// =============================================================================
+// Issue #240 — per-service variants of --image-build-arg /
+// --image-build-secret / --image-target.
+// =============================================================================
+
+describe('parseImageOverrideFlags per-service form (issue #240)', () => {
+  it('parses --image-build-arg <svc>:KEY=VAL into perService', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildArg: ['AppService:NODE_ENV=production'],
+    });
+    expect(out.globals.buildArgs.size).toBe(0);
+    expect(out.perService.size).toBe(1);
+    const overlay = out.perService.get('AppService');
+    expect(overlay?.buildArgs.get('NODE_ENV')).toBe('production');
+  });
+
+  it('parses --image-build-secret <svc>:id=src into perService (src resolved abs)', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildSecret: ['AppService:npmrc=./.npmrc-private'],
+    });
+    expect(out.globals.buildSecrets.size).toBe(0);
+    const overlay = out.perService.get('AppService');
+    expect(overlay?.buildSecrets.get('npmrc')).toBe(path.resolve(process.cwd(), './.npmrc-private'));
+  });
+
+  it('parses --image-target <svc>=<stage> into perService', () => {
+    const out = parseImageOverrideFlags({
+      imageTarget: ['AppService=builder'],
+    });
+    expect(out.globals.targetStage).toBeUndefined();
+    expect(out.perService.get('AppService')?.targetStage).toBe('builder');
+  });
+
+  it('mixes global + per-service for --image-build-arg in one invocation', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildArg: ['KEY=global', 'AppService:KEY=appOnly', 'OtherSvc:OTHER=val'],
+    });
+    expect(out.globals.buildArgs.get('KEY')).toBe('global');
+    expect(out.perService.get('AppService')?.buildArgs.get('KEY')).toBe('appOnly');
+    expect(out.perService.get('OtherSvc')?.buildArgs.get('OTHER')).toBe('val');
+  });
+
+  it('accepts --image-target as an array (global + per-service mix)', () => {
+    const out = parseImageOverrideFlags({
+      imageTarget: ['builder', 'AppService=release', 'Reporting=runtime'],
+    });
+    expect(out.globals.targetStage).toBe('builder');
+    expect(out.perService.get('AppService')?.targetStage).toBe('release');
+    expect(out.perService.get('Reporting')?.targetStage).toBe('runtime');
+  });
+
+  it('rejects --image-build-arg <svc>:= (empty key after prefix)', () => {
+    expect(() => parseImageOverrideFlags({ imageBuildArg: ['AppService:=val'] })).toThrow(
+      /<service>:KEY=VAL/
+    );
+  });
+
+  it('accepts --image-build-arg <svc>:KEY= (empty VALUE) per global semantics', () => {
+    // Empty VALUE is canonical "unset the ARG default". Per-service form
+    // mirrors that semantic.
+    const out = parseImageOverrideFlags({
+      imageBuildArg: ['AppService:UNSET='],
+    });
+    expect(out.perService.get('AppService')?.buildArgs.get('UNSET')).toBe('');
+  });
+
+  it('rejects --image-build-secret <svc>:id= or <svc>:=src (both halves required)', () => {
+    expect(() =>
+      parseImageOverrideFlags({ imageBuildSecret: ['AppService:id='] })
+    ).toThrow(/non-empty/);
+    expect(() =>
+      parseImageOverrideFlags({ imageBuildSecret: ['AppService:=src'] })
+    ).toThrow();
+  });
+
+  it('rejects --image-target <svc>= (empty stage)', () => {
+    expect(() => parseImageOverrideFlags({ imageTarget: ['AppService='] })).toThrow(
+      /right side .* is empty/
+    );
+  });
+
+  it('rejects --image-target =stage (empty service)', () => {
+    expect(() => parseImageOverrideFlags({ imageTarget: ['=stage'] })).toThrow(
+      /left side .* is empty/
+    );
+  });
+
+  it('keeps a `KEY=val:with:colons` global form un-misparsed (= before :)', () => {
+    // The `:` after the `=` is part of the VALUE, not a service prefix.
+    // Pin this so a future refactor of the splitter cannot silently
+    // start treating `=val:bar` as a per-service form.
+    const out = parseImageOverrideFlags({
+      imageBuildArg: ['KEY=val:with:colons'],
+    });
+    expect(out.globals.buildArgs.get('KEY')).toBe('val:with:colons');
+    expect(out.perService.size).toBe(0);
+  });
+
+  it('last-write-wins for repeated per-service entries on same <svc>:KEY', () => {
+    const out = parseImageOverrideFlags({
+      imageBuildArg: ['AppService:KEY=first', 'AppService:KEY=second'],
+    });
+    expect(out.perService.get('AppService')?.buildArgs.get('KEY')).toBe('second');
+  });
+});
+
+describe('mergeForService precedence (issue #240)', () => {
+  it('per-service buildArgs overrides global on key collision', () => {
+    const merged = mergeForService(
+      'AppService',
+      { buildArgs: new Map([['KEY', 'global']]), buildSecrets: new Map() },
+      new Map([
+        [
+          'AppService',
+          { buildArgs: new Map([['KEY', 'perSvc']]), buildSecrets: new Map() },
+        ],
+      ])
+    );
+    expect(merged.buildArgs.get('KEY')).toBe('perSvc');
+  });
+
+  it('non-overlapping keys merge — global K1 + per-service K2 both present', () => {
+    const merged = mergeForService(
+      'AppService',
+      { buildArgs: new Map([['K1', 'g']]), buildSecrets: new Map() },
+      new Map([
+        [
+          'AppService',
+          { buildArgs: new Map([['K2', 'p']]), buildSecrets: new Map() },
+        ],
+      ])
+    );
+    expect(merged.buildArgs.get('K1')).toBe('g');
+    expect(merged.buildArgs.get('K2')).toBe('p');
+  });
+
+  it('per-service buildSecrets overrides global on id collision', () => {
+    const merged = mergeForService(
+      'AppService',
+      {
+        buildArgs: new Map(),
+        buildSecrets: new Map([['npmrc', '/abs/global']]),
+      },
+      new Map([
+        [
+          'AppService',
+          {
+            buildArgs: new Map(),
+            buildSecrets: new Map([['npmrc', '/abs/perSvc']]),
+          },
+        ],
+      ])
+    );
+    expect(merged.buildSecrets.get('npmrc')).toBe('/abs/perSvc');
+  });
+
+  it('per-service targetStage overrides global', () => {
+    const merged = mergeForService(
+      'AppService',
+      { buildArgs: new Map(), buildSecrets: new Map(), targetStage: 'builder' },
+      new Map([
+        [
+          'AppService',
+          {
+            buildArgs: new Map(),
+            buildSecrets: new Map(),
+            targetStage: 'release',
+          },
+        ],
+      ])
+    );
+    expect(merged.targetStage).toBe('release');
+  });
+
+  it('falls back to global when the per-service overlay omits targetStage', () => {
+    const merged = mergeForService(
+      'AppService',
+      { buildArgs: new Map(), buildSecrets: new Map(), targetStage: 'builder' },
+      new Map([
+        [
+          'AppService',
+          { buildArgs: new Map([['K', 'v']]), buildSecrets: new Map() },
+        ],
+      ])
+    );
+    expect(merged.targetStage).toBe('builder');
+  });
+
+  it('returns a FRESH map (mutations do not bleed into the shared globals)', () => {
+    const globals = { buildArgs: new Map([['K', 'g']]), buildSecrets: new Map() };
+    const merged = mergeForService('X', globals, new Map());
+    merged.buildArgs.set('K', 'mutated');
+    expect(globals.buildArgs.get('K')).toBe('g');
+  });
+
+  it('global passes through unchanged when the service has no overlay', () => {
+    const merged = mergeForService(
+      'UnrelatedService',
+      { buildArgs: new Map([['K', 'g']]), buildSecrets: new Map(), targetStage: 'builder' },
+      new Map([
+        [
+          'AppService',
+          { buildArgs: new Map([['K', 'pp']]), buildSecrets: new Map() },
+        ],
+      ])
+    );
+    expect(merged.buildArgs.get('K')).toBe('g');
+    expect(merged.targetStage).toBe('builder');
+  });
+});
+
+describe('resolveImageOverrides — per-service overlay threads into entry (issue #240)', () => {
+  it('a per-service buildArg lands on its target only; global covers others', async () => {
+    const dockerfileA = makeTmpDockerfile('Dockerfile.app');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.auth');
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfileA}`, `AuthService=${dockerfileB}`],
+      imageBuildArg: ['NODE_ENV=production', 'AppService:NPM_TOKEN=secret123'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService', 'AuthService'],
+    });
+    const app = overrides.get('AppService');
+    const auth = overrides.get('AuthService');
+    // Both get the global NODE_ENV.
+    expect(app?.buildArgs.get('NODE_ENV')).toBe('production');
+    expect(auth?.buildArgs.get('NODE_ENV')).toBe('production');
+    // Only AppService gets the per-service NPM_TOKEN.
+    expect(app?.buildArgs.get('NPM_TOKEN')).toBe('secret123');
+    expect(auth?.buildArgs.get('NPM_TOKEN')).toBeUndefined();
+  });
+
+  it('per-service value overrides global on the same key for the named target', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.coll');
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfile}`],
+      imageBuildArg: ['KEY=global', 'AppService:KEY=appOnly'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService'],
+    });
+    expect(overrides.get('AppService')?.buildArgs.get('KEY')).toBe('appOnly');
+  });
+
+  it('per-service targetStage overrides global on the named target', async () => {
+    const dockerfileA = makeTmpDockerfile('Dockerfile.stageA');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.stageB');
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfileA}`, `Reporting=${dockerfileB}`],
+      imageTarget: ['builder', 'Reporting=runtime'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService', 'Reporting'],
+    });
+    expect(overrides.get('AppService')?.targetStage).toBe('builder');
+    expect(overrides.get('Reporting')?.targetStage).toBe('runtime');
+  });
+});
+
+describe('runImageOverrideBuilds — per-service argv assembly (issue #240)', () => {
+  beforeEach(() => {
+    runDockerStreamingMock.mockReset();
+    runDockerStreamingMock.mockResolvedValue(undefined);
+  });
+
+  it('emits the correct --build-arg pair per target (per-service does not bleed)', async () => {
+    const dockerfileA = makeTmpDockerfile('Dockerfile.argA');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.argB');
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfileA}`, `AuthService=${dockerfileB}`],
+      imageBuildArg: ['NODE_ENV=production', 'AppService:NPM_TOKEN=secret'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService', 'AuthService'],
+    });
+    await runImageOverrideBuilds(overrides);
+    expect(runDockerStreamingMock).toHaveBeenCalledTimes(2);
+    const calls = runDockerStreamingMock.mock.calls.map(([a]) => a as string[]);
+    // Determine which build invocation was App vs Auth by `--file` value.
+    const appCall = calls.find((a) => a[a.indexOf('--file') + 1] === dockerfileA)!;
+    const authCall = calls.find((a) => a[a.indexOf('--file') + 1] === dockerfileB)!;
+    expect(appCall).toContain('NODE_ENV=production');
+    expect(appCall).toContain('NPM_TOKEN=secret');
+    expect(authCall).toContain('NODE_ENV=production');
+    // AuthService MUST NOT carry the per-service NPM_TOKEN.
+    expect(authCall).not.toContain('NPM_TOKEN=secret');
+  });
+
+  it('emits the correct --secret pair per target (per-service overrides on id collision)', async () => {
+    const dockerfileA = makeTmpDockerfile('Dockerfile.secA');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.secB');
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfileA}`, `Reporting=${dockerfileB}`],
+      imageBuildSecret: [
+        'AppService:npmrc=/abs/.npmrc-private',
+        'Reporting:npmrc=/abs/.npmrc-public',
+      ],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService', 'Reporting'],
+    });
+    await runImageOverrideBuilds(overrides);
+    const calls = runDockerStreamingMock.mock.calls.map(([a]) => a as string[]);
+    const appCall = calls.find((a) => a[a.indexOf('--file') + 1] === dockerfileA)!;
+    const repCall = calls.find((a) => a[a.indexOf('--file') + 1] === dockerfileB)!;
+    expect(appCall).toContain('id=npmrc,src=/abs/.npmrc-private');
+    expect(repCall).toContain('id=npmrc,src=/abs/.npmrc-public');
+  });
+
+  it('emits --target per-service when only one target carries a per-service stage', async () => {
+    const dockerfileA = makeTmpDockerfile('Dockerfile.tA');
+    const dockerfileB = makeTmpDockerfile('Dockerfile.tB');
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfileA}`, `Reporting=${dockerfileB}`],
+      imageTarget: ['Reporting=runtime'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService', 'Reporting'],
+    });
+    await runImageOverrideBuilds(overrides);
+    const calls = runDockerStreamingMock.mock.calls.map(([a]) => a as string[]);
+    const appCall = calls.find((a) => a[a.indexOf('--file') + 1] === dockerfileA)!;
+    const repCall = calls.find((a) => a[a.indexOf('--file') + 1] === dockerfileB)!;
+    expect(appCall.indexOf('--target')).toBe(-1);
+    const tIdx = repCall.indexOf('--target');
+    expect(tIdx).toBeGreaterThan(-1);
+    expect(repCall[tIdx + 1]).toBe('runtime');
+  });
+});
+
+describe('enforceImageOverrideOrphans (issue #240)', () => {
+  function dockerfile(): string {
+    return makeTmpDockerfile('Dockerfile.orphan');
+  }
+
+  it('no-op when no per-service flag was passed', async () => {
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfile()}`],
+      imageBuildArg: ['NODE_ENV=production'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService'],
+    });
+    expect(() => enforceImageOverrideOrphans(rawFlags, overrides)).not.toThrow();
+  });
+
+  it('throws LocalStartServiceError when a per-service build-arg names an uncovered service', async () => {
+    // `--image-build-arg AppService:KEY=val` but `--image-override` only
+    // covers AuthService — AppService is an orphan.
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AuthService=${dockerfile()}`],
+      imageBuildArg: ['AppService:KEY=val'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AuthService'],
+    });
+    expect(() => enforceImageOverrideOrphans(rawFlags, overrides)).toThrow(
+      LocalStartServiceError
+    );
+    try {
+      enforceImageOverrideOrphans(rawFlags, overrides);
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/--image-build-arg AppService:KEY/);
+      expect(msg).toMatch(/no --image-override mapping/);
+    }
+  });
+
+  it('throws naming every offending flag kind for the same orphan service', async () => {
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AuthService=${dockerfile()}`],
+      imageBuildArg: ['AppService:K=v'],
+      imageBuildSecret: ['AppService:npmrc=/abs/.npmrc'],
+      imageTarget: ['AppService=builder'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AuthService'],
+    });
+    try {
+      enforceImageOverrideOrphans(rawFlags, overrides);
+      expect.fail('should have thrown');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/--image-build-arg AppService/);
+      expect(msg).toMatch(/--image-build-secret AppService/);
+      expect(msg).toMatch(/--image-target AppService=builder/);
+    }
+  });
+
+  it('does NOT throw when the per-service flag names a covered service', async () => {
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`AppService=${dockerfile()}`],
+      imageBuildArg: ['AppService:KEY=val'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['AppService'],
+    });
+    expect(() => enforceImageOverrideOrphans(rawFlags, overrides)).not.toThrow();
+  });
+
+  it('lists multiple orphan services in one message', async () => {
+    const rawFlags = parseImageOverrideFlags({
+      imageOverride: [`Covered=${dockerfile()}`],
+      imageBuildArg: ['Orphan1:K=v', 'Orphan2:K=v'],
+    });
+    const overrides = await resolveImageOverrides({
+      rawFlags,
+      pinnedTargets: ['Covered'],
+    });
+    try {
+      enforceImageOverrideOrphans(rawFlags, overrides);
+      expect.fail('should have thrown');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/Orphan1/);
+      expect(msg).toMatch(/Orphan2/);
+    }
   });
 });

--- a/tests/unit/local/image-override-engine.test.ts
+++ b/tests/unit/local/image-override-engine.test.ts
@@ -133,6 +133,14 @@ describe('parseImageOverrideFlags (issue #238)', () => {
     expect(out.globals.targetStage).toBe('builder');
   });
 
+  it('trims surrounding whitespace from a bare global --image-target (parity with per-service form trim)', () => {
+    // The per-service branch (`<svc>=<stage>`) trims both halves; the
+    // bare global form trims too so `--image-target ' builder '`
+    // behaves the same way regardless of which form the user picked.
+    const out = parseImageOverrideFlags({ imageTarget: '  builder  ' });
+    expect(out.globals.targetStage).toBe('builder');
+  });
+
   it('rejects an empty --image-target', () => {
     expect(() => parseImageOverrideFlags({ imageTarget: '' })).toThrow();
   });


### PR DESCRIPTION
## Summary

Closes #240.

Adds per-service variants alongside the existing global form of the
three build-input flags in the `--image-override` family. Lets a
monorepo whose overridden services need different build args /
secrets / target stages keep them straight in one `cdkl start-alb`
invocation instead of running each service in its own.

**Non-breaking: the existing global syntax is untouched** — every
`--image-build-arg KEY=VAL` / `--image-build-secret id=src` /
`--image-target stage` invocation that worked before keeps working.

## Syntax

| Flag | Global (existing, unchanged) | Per-service (NEW) |
|---|---|---|
| `--image-build-arg` | `KEY=VAL` | `<service>:KEY=VAL` |
| `--image-build-secret` | `id=src` | `<service>:id=src` |
| `--image-target` | `stage` | `<service>=stage` |

Convention rule: flags whose payload already contains `=`
(build-arg, build-secret) use `:` to separate the service prefix
from the `<key>=<value>` payload. Flags whose payload is a single
token (target) use `=` — matches `--image-override`'s convention.

## Precedence

Per-service overrides global on the same target, per key. The
global still applies to every OTHER overridden target.

```
--image-build-arg KEY=global \
--image-build-arg AppService:KEY=appOnly
```

→ `AppService`'s `docker build` gets `--build-arg KEY=appOnly`; all
other overridden targets get `--build-arg KEY=global`.

## Validation — orphan flag detection

A per-service flag whose service name has no `--image-override`
mapping (and no boot-prompt-injected mapping) is a boot error:

```
Per-service image-override flag(s) target a service with no --image-override coverage. ...
  --image-build-arg AppService:KEY references a service with no --image-override mapping.
```

Surfaced via `LocalStartServiceError` so the global error handler
renders it cleanly (matches the `enforceStrictOverrides` pattern).
Runs AFTER Stage 3 boot prompt so a service the user added via the
prompt counts as covered — a still-orphan flag at that point is a
typo or a forgotten `--image-override <svc>=<dockerfile>`.

## Example — monorepo with private + public npm tokens

```bash
cdkl start-alb --from-cfn-stack \
  --image-override AppService=./services/app/Dockerfile \
  --image-override Reporting=./services/reporting/Dockerfile \
  --image-build-secret AppService:npmrc=./.npmrc-private \
  --image-build-secret Reporting:npmrc=./.npmrc-public \
  --image-target AppService=builder \
  --image-target Reporting=runtime
```

## Implementation

- `src/local/image-override-engine.ts`:
  - `parseImageOverrideFlags` recognizes the per-service form for all
    three flags. The `<svc>:<rest>` prefix is detected by the FIRST
    `:` BEFORE the FIRST `=` (so a `KEY=val:with:colons` value stays
    a global). `--image-target` accepts an array now (Commander
    variadic) so per-service + global values can both appear in one
    invocation; the legacy single-string shape is still accepted by
    the parser for older call sites.
  - New `PerServiceBuildInputs` overlay type lives on
    `RawImageOverrideFlags.perService`.
  - New exported `mergeForService(serviceTarget, globals, perService)`
    helper produces the EFFECTIVE per-target build inputs (globals
    first, per-service overlays on top — overlay wins on key
    collision). `makeEntryFromPath` now takes the per-target service
    name + the whole `RawImageOverrideFlags` so each
    `ImageOverrideEntry` carries the merged result. No change to
    `runImageOverrideBuilds`' argv assembly: it walks the merged
    Map per entry and emits the canonical `--build-arg` / `--secret`
    / `--target` shapes.
  - New exported `enforceImageOverrideOrphans(rawFlags,
    resolvedOverrides)` throws `LocalStartServiceError` listing
    every offending per-service `<flag> <svc>:<rest>` pair. Called
    by the emulator right after `resolveImageOverrides` completes
    (after Stage 3 boot prompt).

- `src/cli/commands/ecs-service-emulator.ts`:
  - Wires the orphan check into `resolveAndBuildImageOverrides`
    right after the resolver returns.
  - `EcsServiceEmulatorOptions.imageTarget` widened to
    `string[]` (was `string`); the helper Option metavar updated to
    `<stage or svc=stage...>` so Commander accumulates per-service
    + global occurrences across multiple `--image-target ...`
    invocations.

- `src/internal.ts`: re-exports the new
  `enforceImageOverrideOrphans` + `mergeForService` symbols and the
  `PerServiceBuildInputs` type via `cdk-local/internal` so host CLIs
  inherit the validator and the merge convention without copying.

## Docs

- README — new sub-section under the existing `--image-override`
  block leading with the monorepo "different secrets per service"
  example and naming the syntax convention.
- `docs/local-emulation.md` — equivalent expansion of the existing
  `--image-build-arg` family text with the per-service flag matrix +
  the orphan-validation contract.
- `.claude/CLAUDE.md` — Architecture line updated to name the
  per-service form + the orphan validator.

## Test plan

- [x] `vp run check` — typecheck + lint + format all green.
- [x] `vp test run` — 1989 tests passing across 131 files (was 1959
      pre-change; +30 new rows covering parser per-service forms,
      `mergeForService` precedence grid, `resolveImageOverrides`
      end-to-end overlay threading, `runImageOverrideBuilds` argv
      assembly per target, and `enforceImageOverrideOrphans` happy
      / multi-flag / multi-service paths).
- [x] `vp run build` — clean dist artifacts.
- [x] Non-breaking: existing global form unchanged; every existing
      engine test (44 rows pre-#240) still passes against the same
      assertions.

Coverage added in
`tests/unit/local/image-override-engine.test.ts`:

- `parseImageOverrideFlags per-service form` — explicit colon /
  explicit `=`, mixed with global, last-write-wins, empty-value
  semantics (empty VAL allowed, empty KEY/id/svc/stage rejected),
  and the `KEY=val:with:colons` no-misparse pin.
- `mergeForService precedence` — per-service wins on key collision
  for build-arg / build-secret / targetStage, non-overlapping keys
  merge, fresh-map isolation (mutation does not bleed back to
  globals), and unaffected services see only globals.
- `resolveImageOverrides — per-service overlay threads into entry`
  — per-target entry carries its own merged build-args /
  build-secrets / targetStage; sibling targets are unaffected.
- `runImageOverrideBuilds — per-service argv assembly` — verifies
  the canonical `--build-arg` / `--secret` / `--target` argv shapes
  land on the right `docker build` invocation per target and do not
  bleed across.
- `enforceImageOverrideOrphans` — no-op when no per-service flag,
  throws `LocalStartServiceError` naming the offending flag +
  service, lists all three flag kinds for the same orphan in one
  message, lists multiple orphan services, passes when the service
  is covered.

## Out of scope (deferred follow-ups)

- Custom build context directories distinct from Dockerfile parent
  (also out of scope in #240 itself).
- Host-env `--image-build-arg` inheritance (Docker's bare-`ARG`
  behavior).
- Picker / boot-prompt integration for per-service build options
  (i.e. prompt for each target's build args — too invasive).
