### PR TITLE
docs: align README + docs/ + JSDoc with shipped behavior (AgentCore A2A/AGUI protocols, ALB --tls example, --env-vars display-path keys, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cdkl list                                      # every runnable target, grouped 
 - **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`.
 - **`run-task`** / single-replica **`start-service`** publish declared container ports on the host (`--host-port <container>=<host>` remaps; handy for privileged ports on macOS). **`start-service`** / **`start-alb`** also list each host URL in a `Service endpoints:` banner after boot so the access URL stays visible.
 - **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement), and WebSocket `Upgrade` proxying to ECS targets ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
-- **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, HTTP / SSE / WebSocket / MCP protocols, with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
+- **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, all four runtime protocols (HTTP / MCP / A2A / AGUI; SSE and WebSocket are HTTP wire-shape variants on the same port 8080), with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
 Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.md](docs/cli-reference.md) and [docs/local-emulation.md](docs/local-emulation.md).
@@ -201,7 +201,7 @@ Most CDK ECS apps boot multiple replicas behind an ALB. cdk-local exposes each l
 | Goal | Command | How to reach |
 |---|---|---|
 | App logic / DB / response shape — hit the handler directly | `cdkl start-service --max-tasks 1 --host-port 80=8080` | `curl http://127.0.0.1:8080/...` |
-| ALB routing — listener rules, host-header / path / method, default actions, redirects, fixed-response, weighted forwards, authenticate-cognito / authenticate-oidc | `cdkl start-alb --lb-port 443=8443` | `curl -H 'Host: api.example.com' http://127.0.0.1:8443/...` |
+| ALB routing — listener rules, host-header / path / method, default actions, redirects, fixed-response, weighted forwards, authenticate-cognito / authenticate-oidc | `cdkl start-alb --lb-port 443=8443 --tls` | `curl -H 'Host: api.example.com' https://127.0.0.1:8443/...` |
 | Multi-replica rolling-reload + Cloud Map service discovery | `cdkl start-service` (multi-replica default) | Sibling container on the `cdkl-svc-` network |
 
 **Why the extra flags on the simple case?** The template's `DesiredCount` (typically 3 in production) is honored locally by default, but N replicas can't all bind the same host port — so `start-service` skips host publishing for multi-replica runs and the app is reachable only from inside the `cdkl-svc-` docker network. To get the simple `curl http://127.0.0.1:...` access path:

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -325,6 +325,12 @@ no duplicate `.addOption(...)` block on the host side.
   Does NOT compose with `addCommonEcsServiceOptions` — the single-task
   surface intentionally diverges from the multi-replica service surface
   (no `--max-tasks` / `--restart-policy`).
+- `addStartServiceSpecificOptions(cmd)` — `cdkl start-service`
+  flags (`--host-port`, `--watch`, plus the `--image-override` family:
+  `--image-override`, `--image-build-arg`, `--image-build-secret`,
+  `--image-target`, `--no-interactive-overrides`, `--strict-overrides`).
+  Compose with `addCommonEcsServiceOptions` (no `addAlbSpecificOptions` —
+  `start-service` runs replicas only, no load balancer).
 - `addListSpecificOptions(cmd)` — `cdkl list` flag (`-l, --long`).
   Intentionally minimal so the surface-contract test pattern stays
   uniform across every per-command helper.

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -41,8 +41,12 @@ Shared across all subcommands:
   to iterate faster.
 - `--env-vars <file>` — SAM-compatible JSON override:
   `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. `null` clears a
-  key. Keys MUST be logical IDs today; display-path keys are tracked as
-  issue [#27](https://github.com/go-to-k/cdk-local/issues/27).
+  key. Top-level keys accept the **CFn logical ID** (exact match) OR
+  the **CDK construct path** from `Metadata['aws:cdk:path']`
+  (prefix-matched, so `MyStack/Fn` also catches
+  `MyStack/Fn/Resource`); for ECS containers the key is the
+  `ContainerDefinitions[].Name`. `Parameters` is reserved and applied
+  first to every target; a per-target key wins.
 - `--no-pull` — Skip `docker pull` (per-command semantics differ;
   consult each section).
 - `--from-cfn-stack [cfn-stack-name]` — Bind the local run to a
@@ -1133,7 +1137,7 @@ resolves to the synthesized L1 child (`MyStack/MyService/TaskDef/Resource`).
 | `--container-host <ip>` | `127.0.0.1` | Bind IP for `PortMappings` published ports. Must be a numeric IP — Docker rejects hostnames in `-p <ip>:<port>:<port>`. |
 | `--host-port <containerPort=hostPort>` | — | Publish a container port on a specific host port (e.g. `80=8080`); repeatable. Default: host port == container port. Map a privileged container port (< 1024) to a non-privileged host port to avoid macOS Docker Desktop's admin-password prompt. |
 | `--assume-task-role [<arn>]` | unset (host creds pass through) | Bare flag uses the task definition's `TaskRoleArn`. Resolves a flat-string ARN directly; for `{Ref: <Role>}` / `{Fn::GetAtt: [<Role>, 'Arn']}` against a same-stack `AWS::IAM::Role`, cdk-local substitutes the caller's account id (via STS `GetCallerIdentity`) into `arn:aws:iam::<account>:role/<RoleLogicalId>`. Pass an explicit ARN to override. Either way, `sts:AssumeRole` runs once at startup; the resulting creds are exposed via the local metadata sidecar at `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `ListStackResources` does not return per-attribute values). See "Env / Secrets substitution" below. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Bare form uses the CDK stack name; pass an explicit value when the CFn stack name differs. `Fn::GetAtt` in container `Environment[].Value` is warn-and-dropped (CFn `ListStackResources` does not return per-attribute values, and unlike Lambda there is no ECS-side equivalent of `lambda:GetFunctionConfiguration`). See "Env / Secrets substitution" below. |
 | `--stack-region <region>` | unset | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
 | `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before authenticating against ECR for cross-account / centralized registry pulls. Issues `sts:AssumeRole` via the CLI's resolved credentials (honoring `--profile`) and uses the resulting temp creds for `ecr:GetAuthorizationToken` + `docker pull` on every container whose `Image` resolves to an `<acct>.dkr.ecr.<region>.amazonaws.com/...` URI. Required when the caller's identity does not already have cross-account access to the target repository. Same-account / same-region pulls do not need this flag. No-op when `--no-pull` is set. |
@@ -1216,7 +1220,14 @@ parameters:
 | `Fn::Join: [<delim>, [<elements>]]` | recursive substitution of every element, then `Array.join` |
 | `Ref: AWS::AccountId` / `AWS::Region` / `AWS::Partition` / `AWS::URLSuffix` | STS `GetCallerIdentity` (lazy, cached) + the resolved region + region-derived partition / URL suffix |
 
-`Fn::GetAtt` is warn-and-dropped in v1 (CFn API limitation).
+`Fn::GetAtt` in ECS container `Environment[].Value` is warn-and-dropped
+(CFn `ListStackResources` does not return per-attribute values, and
+there is no ECS-side equivalent of `lambda:GetFunctionConfiguration`
+that would resolve attributes off a deployed task / service). Lambda
+env recovers (`cdkl invoke --from-cfn-stack` resolves `Fn::GetAtt`
+from the deployed function's `Environment.Variables` via
+`lambda:GetFunctionConfiguration` — see "CloudFormation-driven env
+recovery" above); ECS env drops.
 
 Per-key best-effort: when a substitution can't be produced (CFn
 resource missing, attribute not exposed via CFn, unsupported
@@ -1302,7 +1313,6 @@ torn down. Use to `docker exec` into a stopped container post-mortem.
 | Out of scope | Why |
 | --- | --- |
 | `AWS::ECS::Service` / `DesiredCount` / `LaunchType` | Use `cdkl start-service` instead |
-| ALB / NLB target group registration / listener rules | Deferred follow-up — needs an HTTP proxy emulator |
 | Service Connect / Cloud Map | Implemented for `cdkl start-service` via `--add-host` DNS overlay. `cdkl run-task` is single-task by design; cross-service discovery is meaningful only with multiple long-running services, so it stays out of scope here. |
 | Auto Scaling / Deployment Strategy | Not meaningful locally |
 | Fargate vs EC2 launch-type differences (PID namespace, `awsvpc`-only, ephemeral storage cap) | Local Docker can't enforce these |
@@ -1660,8 +1670,8 @@ immediately so users have an escape hatch when docker hangs.
 
 | Deferred | Tracked in / Why |
 | --- | --- |
-| Local load-balancer emulator (listener + round-robin + target-group health check) | Follow-up PR — needs an HTTP/TCP proxy emulator. Today's start-service does NOT register replicas to a local listener; reach a single-replica service via its published container ports, or any replica via its docker network IP / alias (multi-replica services skip the host-port publish — see the host-port note above). |
-| Envoy sidecar (L7 routing / retries / circuit breaking / mTLS) | Deferred follow-up — Cloud Map DNS overlay covers ~80% of debugging use cases; the missing 20% requires the AWS-published Envoy image (~120MB / task). DNS-only mode is the default; an opt-in `--envoy` flag will ship with the sidecar. |
+| Local load-balancer emulator (listener + round-robin + ALB listener-rule routing) | Use `cdkl start-alb` instead — it boots the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, and authenticate-cognito / authenticate-oidc. `cdkl start-service` on its own stays pure-compute: a single-replica service is reached via its published container ports; any replica is reached via its docker network IP / alias (multi-replica services skip the host-port publish — see the host-port note above). NLB and target-group health checks remain out of scope. |
+| Envoy sidecar (L7 routing / retries / circuit breaking / mTLS) | Deferred follow-up — Cloud Map DNS overlay covers ~80% of debugging use cases; the missing 20% requires the AWS-published Envoy image (~120MB / task). DNS-only mode is the default. |
 | Rolling deployment strategy (`DeploymentConfiguration.MaximumPercent` etc.) | Follow-up — meaningful only with the LB emulator. |
 | `HealthCheckGracePeriodSeconds` runtime semantics | Field is parsed and surfaced on `ResolvedEcsService` but not yet acted on. Becomes load-bearing when the LB emulator ships (today's restart policy fires on essential-container exit code, not health-check failure). |
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -2601,7 +2601,9 @@ export function addCommonEcsServiceOptions(cmd: Command): Command {
           'in container env vars / secrets / image URIs with the deployed physical IDs / exports. ' +
           'Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). ' +
           `Bare form uses the ${getEmbedConfig().binaryName} stack name; pass an explicit value when the CFn stack name differs. ` +
-          'Fn::GetAtt is warn-and-dropped in v1 (CFn ListStackResources does not return per-attribute values).'
+          'Fn::GetAtt in container Environment[].Value is warn-and-dropped: CFn ListStackResources does not return per-attribute values, ' +
+          'and unlike Lambda (where `cdkl invoke --from-cfn-stack` recovers Fn::GetAtt from the deployed function via lambda:GetFunctionConfiguration), ' +
+          'no ECS-side equivalent resolves attributes off a deployed task / service.'
       )
     )
     .addOption(

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -1544,15 +1544,16 @@ export function createLocalInvokeAgentCoreCommand(
   const cmd = new Command('invoke-agentcore')
     .description(
       'Run a Bedrock AgentCore Runtime container locally and invoke it once over its protocol ' +
-        'contract: HTTP (POST /invocations + GET /ping on 8080) or MCP (POST /mcp Streamable HTTP ' +
-        'on 8000). Resolves the AWS::BedrockAgentCore::Runtime, pulls/builds its container, injects ' +
+        'contract: HTTP (POST /invocations + GET /ping on 8080; SSE / WebSocket are HTTP wire-shape ' +
+        'variants on the same port), MCP (POST /mcp Streamable HTTP on 8000), A2A, or AGUI. ' +
+        'Resolves the AWS::BedrockAgentCore::Runtime, pulls/builds its container, injects ' +
         'env vars + AWS credentials, and prints the response. For an MCP runtime, runs the session ' +
         'handshake then sends one JSON-RPC request (tools/list by default, or the method/params from ' +
         '--event). Target accepts a CDK display path (MyStack/MyAgent) or stack-qualified logical ID ' +
         '(MyStack:MyAgentRuntime1234). Single-stack apps may omit the stack prefix. ' +
         'Omit <target> in an interactive terminal to pick from a list. ' +
         'Supports the container artifact and the CodeConfiguration managed-runtime artifact ' +
-        '(fromCodeAsset, built from source) on the HTTP + MCP protocols; the agent calls real AWS for managed services.'
+        '(fromCodeAsset, built from source) on all four protocols; the agent calls real AWS for managed services.'
     )
     .argument(
       '[target]',

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -1190,8 +1190,11 @@ export function addInvokeSpecificOptions(cmd: Command): Command {
     .addOption(
       new Option(
         '--no-pull',
-        'Skip docker pull (use cached image) — no-op for IMAGE local-build path; ' +
-          '`docker build` does not pull base layers by default'
+        'Skip docker pull. Semantics differ by code path: ZIP Lambdas skip pulling the public ' +
+          'Lambda base image; Container Lambdas on the local-build path are a no-op (docker build ' +
+          'does not refresh the FROM cache by default); Container Lambdas on the ECR-pull fallback ' +
+          'skip docker pull AND error if the image is not in the local cache (re-run without ' +
+          '--no-pull or pre-pull manually).'
       )
     )
     .addOption(

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -770,7 +770,9 @@ export function addRunTaskSpecificOptions(cmd: Command): Command {
           'in container env vars / secrets / image URIs with the deployed physical IDs / exports. ' +
           'Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). ' +
           `Bare form uses the ${getEmbedConfig().binaryName} stack name; pass an explicit value when the CFn stack name differs. ` +
-          'Fn::GetAtt is warn-and-dropped in v1 (CFn ListStackResources does not return per-attribute values).'
+          'Fn::GetAtt in container Environment[].Value is warn-and-dropped: CFn ListStackResources does not return per-attribute values, ' +
+          'and unlike Lambda (where `cdkl invoke --from-cfn-stack` recovers Fn::GetAtt from the deployed function via lambda:GetFunctionConfiguration), ' +
+          'no ECS-side equivalent resolves attributes off a deployed task / service.'
       )
     )
     .addOption(

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -240,7 +240,11 @@ interface LocalStartApiOptions {
  *     container does NOT get attached to the deployed VPC.
  *
  * PR 8c additions (issue #235):
- *   - `--watch` enables hot reload on `cdk.out/` + asset-dir changes.
+ *   - `--watch` enables hot reload: re-synths the CDK app and reloads
+ *     routes when the source tree changes. Honors `cdk.json`'s
+ *     `watch.include` / `watch.exclude` globs; `cdk.out/`,
+ *     `node_modules`, and `.git` are ALWAYS excluded regardless of
+ *     glob config.
  *   - HTTP API v2 OPTIONS preflight is intercepted when the API has a
  *     `CorsConfiguration`; REST v1 CORS (Mock OPTIONS method) stays
  *     out of scope.


### PR DESCRIPTION
## Summary

Closes #248. Aligns the user-facing docs + a handful of in-source `--help` / JSDoc strings with the actual shipped behavior. Two blockers (A1 + A2 — both materially mislead a first-time user) plus nine staleness items the A-audit caught. No source-behavior changes; the `src/**` edits are inside `--help` descriptions / JSDoc only.

## Blockers

- [x] **A1 — AgentCore protocols**: `README.md` "invoke-agentcore" bullet AND `createLocalInvokeAgentCoreCommand` `--help` description aligned with the runtime contract (HTTP / MCP / A2A / AGUI; SSE and WebSocket called out as HTTP wire-shape variants on port 8080 rather than peer protocols).
- [x] **A2 — `--lb-port 443=8443` example**: README "start-service vs start-alb" table row updated to `cdkl start-alb --lb-port 443=8443 --tls`, and the matching client URL flipped to `https://`. The command is now self-consistent with the natural "443 = HTTPS" reading.

## Staleness sweep

- [x] **A3** — `docs/library-mode.md` per-command helper list now includes `addStartServiceSpecificOptions` (matches the `addAlbSpecificOptions` entry shape).
- [x] **A4** — `docs/local-emulation.md` "Common flags" `--env-vars` paragraph rewritten to match `README.md`'s current shape: CDK construct path keys with prefix matching are first-class (alongside CFn logical IDs); the "issue #27 deferred" wording is gone.
- [x] **A5** — `docs/local-emulation.md` "start-service deferred follow-ups" Local-LB row now points at `cdkl start-alb` for the LB story (all six listener-rule conditions, weighted forwards, redirect / fixed-response, authenticate-cognito / authenticate-oidc); start-service stays pure compute.
- [x] **A6** — `Fn::GetAtt` warn-and-drop wording differentiated at all three sites (`docs/local-emulation.md` ECS run-task + table row, `src/cli/commands/local-run-task.ts`, `src/cli/commands/ecs-service-emulator.ts`): Lambda env recovers (`lambda:GetFunctionConfiguration`); ECS env drops (no ECS-side equivalent).
- [ ] **A7** — Skipped per the issue's "informational; skip if it makes the row noisy" guidance. The `--tls` annotation already lengthened the row visibly; a second `--lb-port` mapping would push it past the readable width.
- [x] **A8** — `src/cli/commands/local-invoke.ts` `--no-pull` help now lists all three semantics (ZIP skip / IMAGE local-build no-op / IMAGE ECR-pull skip-and-error-if-uncached) so `--help` matches `docs/local-emulation.md:134`.
- [x] **A9** — `src/cli/commands/local-start-api.ts` JSDoc `--watch` description rewritten: removed the stale "`cdk.out/` + asset-dir changes" framing; added the explicit "`cdk.out/`, `node_modules`, `.git` are ALWAYS excluded" sentence (confirmed against `src/local/source-change-classifier.ts:80`).
- [x] **A10** — `docs/local-emulation.md` run-task deferred table: dropped the "ALB / NLB target group registration / listener rules" row (start-alb ships exactly this; the row was load-bearing pre-`start-alb`).
- [x] **A11** — `docs/local-emulation.md` Envoy-sidecar row: removed the "an opt-in `--envoy` flag will ship with the sidecar" promissory copy (no `--envoy` flag exists).

## Verification

- `vp run check` — clean (108 files, no warnings).
- `vp test run` — 131 files / 1992 tests pass; no type errors.
- `vp run build` — clean (15 files, 3.91 MB).
- No `src/**` behavior changes; the `src/**` edits are confined to `--help` strings and JSDoc comments.

## Test plan

- [x] `vp run check`
- [x] `vp test run`
- [x] `vp run build`
- [ ] Visual sanity check on the rendered README + `docs/library-mode.md` + `docs/local-emulation.md` for the edited sections.
