### PR TITLE
fix(auth): per-time-window dedup for "discovery unreachable -> token accepted" warns (was: silent accept for the rest of the session)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -581,7 +581,10 @@ before the container starts:
 - **Discovery URL / JWKS unreachable** → falls back to pass-through (accept +
   warn), the same offline-dev trade-off `cdkl start-api` makes for
   unreachable Cognito JWKS. Scope / custom-claim verification does NOT run on
-  the pass-through path — every Bearer token is accepted.
+  the pass-through path — every Bearer token is accepted. The warn re-emits
+  every 5 minutes per URL (#247) so a long-running session keeps surfacing
+  the degraded state instead of silently accepting tokens for the rest of
+  the run.
 - **`--no-verify-auth`** → skips verification entirely; a `--bearer-token`,
   if given, is still forwarded.
 
@@ -1368,6 +1371,19 @@ request passes). `UserPoolArn` / `Issuer` / `ClientId` MUST be literal
 strings in the synthesized template — a `Ref` / `Fn::GetAtt` / cross-stack
 intrinsic in any of those fields drops the guard with a warning, and the
 terminal action then serves unguarded.
+
+**JWKS / OIDC discovery unreachable → token accepted without verification.**
+When the upstream JWKS endpoint (Cognito) or OIDC discovery URL is
+unreachable, the verifier falls back to pass-through accept (every Bearer
+token is accepted) to keep local dev iterating through transient network
+glitches / VPN drops / proxy outages — the same trade-off `cdkl start-api`
+makes for unreachable Cognito JWKS. The fallback emits a `warn` line
+naming the unreachable URL and re-emits it every 5 minutes per URL (#247).
+A long-running `cdkl start-alb --watch` session therefore keeps surfacing
+the degraded-auth state every 5 minutes rather than silently accepting
+tokens for the rest of the run after the first warn fires. Do NOT rely on
+this fallback in any shared environment — the dev machine accepts every
+token, including forged ones.
 
 **WebSocket `Upgrade`** is proxied for ECS forward targets. The inbound
 upgrade request goes through the same `route()` callback as a regular

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -839,14 +839,19 @@ gets a synthetic `unknown` principal and an empty claims map):
 The failure entry has a short TTL (~60s) so a transient blip doesn't
 lock pass-through for the full 1hr success TTL — the next minute's
 request retries the JWKS fetch. The pass-through warn line itself
-fires at most once per JWKS URL per server lifecycle (the warn-set
-is constructed once at server startup, not per request).
+re-emits every 5 minutes per JWKS URL (per-time-window dedup; #247):
+back-to-back requests share one log line, but a long-running
+`cdkl start-api` / `cdkl start-alb --watch` session continues to
+surface the degraded-auth state periodically so the user notices that
+auth is not being verified for the rest of the run.
 
 This is a deliberate dev-tool tradeoff: surprising deny is worse than
 warn+allow when the developer is iterating on a function and the JWKS
 URL is blocked by a corporate proxy. **Do NOT rely on this in any
 shared environment** — the dev's machine accepts every token, including
-forged ones.
+forged ones. The 5-minute re-emit makes the degraded state visible in
+the tail of the log so the dev knows whether the local server is
+actually verifying signatures or has fallen through to accept-all.
 
 `AWS_IAM` authorization is supported with **signature-verification-only**
 semantics on BOTH REST v1 (`AuthorizationType: 'AWS_IAM'`) and Function

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -100,7 +100,7 @@ import {
 } from '../../local/front-door-lambda-runner.js';
 import type { FrontDoorAuthGuard } from '../../local/elb-front-door-resolver.js';
 import { buildAuthCheck } from '../../local/front-door-auth.js';
-import { createJwksCache } from '../../local/cognito-jwt.js';
+import { createJwksCache, type WarnedAt } from '../../local/cognito-jwt.js';
 import { isLocalCdkAssetImage, listPinnedTargets } from '../../local/image-pin-detector.js';
 import {
   enforceImageOverrideOrphans,
@@ -1835,17 +1835,19 @@ export async function buildFrontDoor(
       })
     : undefined;
 
-  // Shared JWKS cache + warn-once Set, both at buildFrontDoor scope so two
-  // rules pointing at the same Cognito JWKS URL de-dupe the "JWKS
-  // unreachable -> pass-through" warn line instead of each warning
-  // independently.
+  // Shared JWKS cache + warn-re-emit Map, both at buildFrontDoor scope so two
+  // rules pointing at the same Cognito JWKS URL share the per-time-window
+  // dedup (#247) for the "JWKS unreachable -> pass-through" warn line instead
+  // of each warning independently. The warn re-emits every
+  // WARN_REEMIT_INTERVAL_MS per URL so a long-running `--watch` session keeps
+  // surfacing the degraded-auth state.
   const jwksCache = createJwksCache();
-  const sharedWarned = new Set<string>();
+  const sharedWarnedAt: WarnedAt = new Map<string, number>();
   const authForGuard = (guard: FrontDoorAuthGuard): ReturnType<typeof buildAuthCheck> =>
     buildAuthCheck(guard, jwksCache, {
       ...(options.verifyAuth === false && { noVerifyAuth: true }),
       ...(options.bearerToken !== undefined && { bearerToken: options.bearerToken }),
-      warned: sharedWarned,
+      warnedAt: sharedWarnedAt,
     });
   const attachAuth = (action: RouteAction, guard: FrontDoorAuthGuard | undefined): RouteAction =>
     guard ? { ...action, auth: authForGuard(guard) } : action;

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -586,7 +586,7 @@ export async function resolveInboundAuthorization(
     },
     header,
     createJwksCache(),
-    { warned: new Set() }
+    { warnedAt: new Map() }
   );
   if (!result.allow) {
     throw new CdkLocalError(

--- a/src/cli/commands/local-start-alb.ts
+++ b/src/cli/commands/local-start-alb.ts
@@ -306,7 +306,7 @@ export function albStrategy(options: EcsServiceEmulatorOptions): EmulatorStrateg
     // synchronous Map mutations on the FrontDoorEndpointPool that JS's
     // single-threaded read in `next()` cannot observe mid-mutation,
     // so a continuous external request stream never sees an empty
-    // pool. TLS materials, JWKS cache + warned-set, Lambda-target
+    // pool. TLS materials, JWKS cache + warn-re-emit map, Lambda-target
     // RIE containers, and the host front-door servers are all built
     // once in `buildFrontDoor` BEFORE the watcher is installed, so
     // they are NOT recreated on reload (no re-issued cert, no re-

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -118,6 +118,7 @@ import {
   buildCognitoJwksUrl,
   buildJwksUrlFromIssuer,
   createJwksCache,
+  type WarnedAt,
 } from '../../local/cognito-jwt.js';
 import { defaultCredentialsLoader, type CredentialsLoader } from '../../local/sigv4-verify.js';
 import { singleFlight } from '../../utils/single-flight.js';
@@ -370,11 +371,14 @@ async function localStartApiCommand(
   // PR 8b: per-server-lifecycle caches. Constructed once at server
   // startup; persisted across hot reloads (PR 8c) so authorizer
   // verdicts and JWKS keys aren't re-fetched on every reload. The
-  // jwksWarnedUrls Set ensures the pass-through warn fires at most
-  // ONCE per JWKS URL per server lifecycle.
+  // jwksWarnedAt Map (URL -> last-warn-at ms; #247) ensures the
+  // "JWKS unreachable -> token accepted" warn re-emits every
+  // WARN_REEMIT_INTERVAL_MS per URL — a long-running `--watch` session
+  // keeps surfacing the degraded-auth state instead of silently accepting
+  // every token after the first warn.
   const authorizerCache = createAuthorizerCache();
   const jwksCache = createJwksCache();
-  const jwksWarnedUrls = new Set<string>();
+  const jwksWarnedAt: WarnedAt = new Map<string, number>();
   // #447: SigV4 verifier state for `AuthorizationType: 'AWS_IAM'` routes.
   // The credentials loader is constructed eagerly but the credential
   // chain itself is only hit on the first IAM-protected request — see
@@ -847,7 +851,7 @@ async function localStartApiCommand(
       port: basePort === 0 ? 0 : nextPort,
       authorizerCache,
       jwksCache,
-      jwksWarnedUrls,
+      jwksWarnedAt,
       sigV4CredentialsLoader,
       sigV4WarnedForeignIds,
       sigV4Strict: options.strictSigv4 === true,
@@ -942,7 +946,7 @@ async function localStartApiCommand(
       port: basePort === 0 ? 0 : nextPort,
       authorizerCache,
       jwksCache,
-      jwksWarnedUrls,
+      jwksWarnedAt,
       sigV4WarnedForeignIds,
       sigV4Strict: options.strictSigv4 === true,
       preDispatch: async (req, res) => {

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -82,6 +82,7 @@ export {
   type JwksCache,
   type DiscoveryJwtAuthorizer,
   type JwtCustomClaim,
+  type WarnedAt,
 } from './local/cognito-jwt.js';
 export {
   buildMethodArn,

--- a/src/local/cognito-jwt.ts
+++ b/src/local/cognito-jwt.ts
@@ -62,6 +62,57 @@ export interface JwksCache {
   clear(): void;
 }
 
+/**
+ * Per-time-window dedup map for "JWKS / OIDC discovery unreachable -> token
+ * accepted without verification" warn lines.
+ *
+ * Pre-#247 the dedup was a `Set<string>` (URL -> warned-forever-for-this-run).
+ * Once tripped, every subsequent JWT was silently accepted for the rest of
+ * the session — a long-running `cdkl start-alb --watch` user briefly off VPN
+ * at boot would never see the degraded-auth state again.
+ *
+ * Post-#247 the dedup is a `Map<string, number>` (URL -> last-warned-at unix
+ * ms). The verifier re-emits the warn every {@link WARN_REEMIT_INTERVAL_MS}
+ * so the user keeps seeing the degraded state surfaced periodically.
+ *
+ * Key shape: the URL of the unreachable endpoint (JWKS URL for the JWKS
+ * fallback, discovery URL for the OIDC-discovery fallback). Distinct IdPs
+ * therefore get independent dedup windows.
+ */
+export type WarnedAt = Map<string, number>;
+
+/**
+ * Re-emit window for unreachable-endpoint warns. 5 minutes is short enough
+ * the user notices the degraded state on a normal `--watch` session, long
+ * enough not to spam the log on every request when the upstream IdP is down.
+ */
+export const WARN_REEMIT_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Returns true iff `key`'s last warn timestamp is older than
+ * {@link WARN_REEMIT_INTERVAL_MS} (or has never been recorded). When true,
+ * `warnedAt[key]` is updated to `now` as a side effect so the next call
+ * within the window returns false.
+ *
+ * Callers that omit `warnedAt` (the per-AuthCheck local fallback in tests
+ * and the no-dedup branch in shape-only call sites) get a no-op true on
+ * every call.
+ */
+export function shouldWarn(
+  key: string,
+  warnedAt: WarnedAt | undefined,
+  now: () => number
+): boolean {
+  if (!warnedAt) return true;
+  const last = warnedAt.get(key);
+  const t = now();
+  if (last !== undefined && t - last < WARN_REEMIT_INTERVAL_MS) {
+    return false;
+  }
+  warnedAt.set(key, t);
+  return true;
+}
+
 const DEFAULT_JWKS_TTL_MS = 60 * 60 * 1000;
 /**
  * Failure-mode TTL for JWKS-unreachable entries. Pre-fix the failure
@@ -211,7 +262,7 @@ export async function verifyCognitoJwt(
   authorizer: CognitoUserPoolAuthorizer,
   authorizationHeader: string | undefined,
   jwksCache: JwksCache,
-  opts: { now?: () => number; warned?: Set<string> } = {}
+  opts: { now?: () => number; warnedAt?: WarnedAt } = {}
 ): Promise<CachedAuthorizerResult & { identityHash: string | undefined; ttlSeconds: number }> {
   const now = opts.now ?? ((): number => Date.now());
   const token = extractBearer(authorizationHeader);
@@ -285,7 +336,7 @@ export async function verifyCognitoJwt(
     undefined,
     undefined,
     jwksCache,
-    opts.warned,
+    opts.warnedAt,
     now
   );
 }
@@ -297,7 +348,7 @@ export async function verifyJwtAuthorizer(
   authorizer: JwtAuthorizer,
   authorizationHeader: string | undefined,
   jwksCache: JwksCache,
-  opts: { now?: () => number; warned?: Set<string> } = {}
+  opts: { now?: () => number; warnedAt?: WarnedAt } = {}
 ): Promise<CachedAuthorizerResult & { identityHash: string | undefined; ttlSeconds: number }> {
   const now = opts.now ?? ((): number => Date.now());
   const token = extractBearer(authorizationHeader);
@@ -318,7 +369,7 @@ export async function verifyJwtAuthorizer(
     undefined,
     undefined,
     jwksCache,
-    opts.warned,
+    opts.warnedAt,
     now
   );
 }
@@ -378,7 +429,7 @@ export async function verifyJwtViaDiscovery(
   jwksCache: JwksCache,
   opts: {
     now?: () => number;
-    warned?: Set<string>;
+    warnedAt?: WarnedAt;
     fetchImpl?: (
       url: string
     ) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
@@ -407,9 +458,11 @@ export async function verifyJwtViaDiscovery(
     jwksUri = doc.jwks_uri;
   } catch (err) {
     // Discovery unreachable / malformed → pass-through accept (offline dev),
-    // mirroring the JWKS-unreachable fallback in `createJwksCache`.
-    if (opts.warned && !opts.warned.has(authorizer.discoveryUrl)) {
-      opts.warned.add(authorizer.discoveryUrl);
+    // mirroring the JWKS-unreachable fallback in `createJwksCache`. The
+    // warn re-emits every {@link WARN_REEMIT_INTERVAL_MS} (#247) so a
+    // long-running `--watch` session keeps surfacing the degraded state
+    // instead of silently accepting tokens after the first warn.
+    if (shouldWarn(authorizer.discoveryUrl, opts.warnedAt, now)) {
       getLogger()
         .child('cognito-jwt')
         .warn(
@@ -433,7 +486,7 @@ export async function verifyJwtViaDiscovery(
     authorizer.allowedScopes,
     authorizer.customClaims,
     jwksCache,
-    opts.warned,
+    opts.warnedAt,
     now
   );
 }
@@ -446,7 +499,7 @@ async function verifyAndShape(
   requiredScopes: ReadonlyArray<string> | undefined,
   customClaims: ReadonlyArray<JwtCustomClaim> | undefined,
   jwksCache: JwksCache,
-  warned: Set<string> | undefined,
+  warnedAt: WarnedAt | undefined,
   now: () => number
 ): Promise<CachedAuthorizerResult & { identityHash: string | undefined; ttlSeconds: number }> {
   const identityHash = buildIdentityHash([token]);
@@ -460,8 +513,12 @@ async function verifyAndShape(
   const jwks = await jwksCache.fetchAndCache(jwksUrl);
 
   if (jwks.passThrough) {
-    if (warned && !warned.has(jwksUrl)) {
-      warned.add(jwksUrl);
+    // Pre-#247 the warn was gated by a `Set<string>` URL set — once warned
+    // for a URL, never again for the rest of the session. A long-running
+    // `--watch` session that lost network briefly at boot silently accepted
+    // every JWT for the rest of the afternoon. Post-#247 the warn re-emits
+    // every {@link WARN_REEMIT_INTERVAL_MS}.
+    if (shouldWarn(jwksUrl, warnedAt, now)) {
       getLogger()
         .child('cognito-jwt')
         .warn(

--- a/src/local/front-door-auth.ts
+++ b/src/local/front-door-auth.ts
@@ -1,4 +1,4 @@
-import { verifyJwtAuthorizer, type JwksCache } from './cognito-jwt.js';
+import { verifyJwtAuthorizer, type JwksCache, type WarnedAt } from './cognito-jwt.js';
 import type { AuthCheck } from './front-door-server.js';
 import type { FrontDoorAuthGuard } from './elb-front-door-resolver.js';
 import { getLogger } from '../utils/logger.js';
@@ -34,11 +34,14 @@ export function buildAuthCheck(
     /** Injected as the default `Authorization: Bearer <jwt>` when missing. */
     bearerToken?: string;
     /**
-     * Shared "JWKS warn-once" Set. Lifted to caller scope so two rules
-     * pointing at the same Cognito JWKS URL share the warn-on-first-request
-     * de-dupe instead of each warning independently.
+     * Shared "JWKS warn re-emit window" map (URL -> last-warned-at unix ms).
+     * Lifted to caller scope so two rules pointing at the same Cognito JWKS
+     * URL share the per-time-window dedup (#247) instead of each warning
+     * independently. The warn re-emits every
+     * {@link import('./cognito-jwt.js').WARN_REEMIT_INTERVAL_MS} per URL so a
+     * long-running `--watch` session keeps surfacing the degraded-auth state.
      */
-    warned?: Set<string>;
+    warnedAt?: WarnedAt;
   } = {}
 ): AuthCheck {
   const realm = guard.label;
@@ -52,8 +55,8 @@ export function buildAuthCheck(
 
   // De-dupe "JWKS unreachable -> pass-through" warn lines across requests for
   // the same authorizer URL (matches how start-api's JWT authorizers behave).
-  // Falls back to a per-AuthCheck Set when the caller did not supply one.
-  const warned = opts.warned ?? new Set<string>();
+  // Falls back to a per-AuthCheck Map when the caller did not supply one.
+  const warnedAt: WarnedAt = opts.warnedAt ?? new Map<string, number>();
   const sessionCookiePrefix = guard.sessionCookieName;
   const injectedBearer = opts.bearerToken;
 
@@ -109,7 +112,7 @@ export function buildAuthCheck(
           },
           authorization,
           jwksCache,
-          { warned }
+          { warnedAt }
         );
         if (result.allow) return { allow: true };
         return {

--- a/src/local/http-server.ts
+++ b/src/local/http-server.ts
@@ -36,7 +36,12 @@ import {
   invokeRequestAuthorizer,
   invokeTokenAuthorizer,
 } from './lambda-authorizer.js';
-import { type JwksCache, verifyCognitoJwt, verifyJwtAuthorizer } from './cognito-jwt.js';
+import {
+  type JwksCache,
+  type WarnedAt,
+  verifyCognitoJwt,
+  verifyJwtAuthorizer,
+} from './cognito-jwt.js';
 import { type CredentialsLoader, verifySigV4 } from './sigv4-verify.js';
 import {
   applyResponseParameters,
@@ -122,14 +127,18 @@ export interface StartApiServerOptions {
   /** JWKS cache (PR 8b). Required when any route has a Cognito / JWT authorizer. */
   jwksCache?: JwksCache;
   /**
-   * Per-server-lifecycle Set of JWKS URLs we have already emitted a
-   * pass-through warn line for (PR 8b post-review fix). Constructed once
-   * by the caller (`local-start-api.ts`) and threaded through to every
-   * request so the warn fires at most ONCE per JWKS URL per server.
-   * When omitted, the verifier no-ops the warn (used in tests where the
-   * server is not started through the CLI bootstrap).
+   * Per-server-lifecycle Map of JWKS URL -> last-warn-at unix ms (#247).
+   * Constructed once by the caller (`local-start-api.ts`) and threaded
+   * through to every request so the "JWKS unreachable -> token accepted"
+   * warn re-emits every
+   * {@link import('./cognito-jwt.js').WARN_REEMIT_INTERVAL_MS} per URL.
+   * Pre-#247 this was a `Set<string>` (URL -> warned-forever) which left a
+   * long-running `--watch` session silently accepting tokens for the rest
+   * of the run after the first warn fired. When omitted, the verifier
+   * no-ops the warn (used in tests where the server is not started through
+   * the CLI bootstrap).
    */
-  jwksWarnedUrls?: Set<string>;
+  jwksWarnedAt?: WarnedAt;
   /**
    * Optional mTLS configuration. When set, the server uses
    * `https.createServer({requestCert: true, rejectUnauthorized: true,
@@ -157,8 +166,11 @@ export interface StartApiServerOptions {
   /**
    * Per-server-lifecycle Set of `Credential=` access-key-ids we have
    * already emitted a warn-and-pass line for (foreign-identity SigV4
-   * requests cannot be verified against the dev's local key). Same
-   * dedup pattern as `jwksWarnedUrls`.
+   * requests cannot be verified against the dev's local key). Once-per-
+   * session dedup is appropriate here because the warn surfaces a
+   * configuration mismatch (foreign access-key-id) that does not flap
+   * with network state — distinct from the JWKS / OIDC discovery
+   * unreachable warns which #247 widened to a 5-minute re-emit window.
    */
   sigV4WarnedForeignIds?: Set<string>;
   /**
@@ -1131,7 +1143,7 @@ async function runAuthorizerPass(
   }
 
   const authHeader = headers['authorization'];
-  const jwksOpts = { ...(opts.jwksWarnedUrls && { warned: opts.jwksWarnedUrls }) };
+  const jwksOpts = { ...(opts.jwksWarnedAt && { warnedAt: opts.jwksWarnedAt }) };
   if (authorizer.kind === 'cognito') {
     if (cache && authHeader !== undefined) {
       const cached = cache.get(authorizer.logicalId, hashOne(authHeader));

--- a/tests/unit/cli/local-invoke-agentcore.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore.test.ts
@@ -835,7 +835,7 @@ describe('resolveInboundAuthorization — JWT gate', () => {
       },
       'Bearer tok',
       expect.anything(),
-      expect.objectContaining({ warned: expect.any(Set) })
+      expect.objectContaining({ warnedAt: expect.any(Map) })
     );
   });
 

--- a/tests/unit/local/cognito-jwt.test.ts
+++ b/tests/unit/local/cognito-jwt.test.ts
@@ -4,9 +4,11 @@ import {
   buildCognitoJwksUrl,
   buildJwksUrlFromIssuer,
   createJwksCache,
+  shouldWarn,
   verifyCognitoJwt,
   verifyJwtAuthorizer,
   verifyJwtViaDiscovery,
+  WARN_REEMIT_INTERVAL_MS,
 } from '../../../src/local/cognito-jwt.js';
 import type {
   CognitoUserPoolAuthorizer,
@@ -838,7 +840,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
       `Bearer ${token}`,
       cache,
-      { fetchImpl: discoveryFetch, warned: new Set() }
+      { fetchImpl: discoveryFetch, warnedAt: new Map() }
     );
     expect(r.allow).toBe(true);
     expect(discoveryFetch).toHaveBeenCalledWith(DISCOVERY);
@@ -852,7 +854,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       { discoveryUrl: DISCOVERY, allowedClients: ['client-9'] },
       `Bearer ${token}`,
       cache,
-      { fetchImpl: discoveryFetch, warned: new Set() }
+      { fetchImpl: discoveryFetch, warnedAt: new Map() }
     );
     expect(r.allow).toBe(true);
   });
@@ -865,7 +867,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
       `Bearer ${token}`,
       cache,
-      { fetchImpl: discoveryFetch, warned: new Set() }
+      { fetchImpl: discoveryFetch, warnedAt: new Map() }
     );
     expect(r.allow).toBe(false);
   });
@@ -878,7 +880,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
       `Bearer ${token}`,
       cache,
-      { fetchImpl: discoveryFetch, warned: new Set() }
+      { fetchImpl: discoveryFetch, warnedAt: new Map() }
     );
     expect(r.allow).toBe(false);
   });
@@ -891,7 +893,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
       `Bearer ${token}`,
       cache,
-      { fetchImpl: discoveryFetch, warned: new Set() }
+      { fetchImpl: discoveryFetch, warnedAt: new Map() }
     );
     expect(r.allow).toBe(false);
   });
@@ -901,7 +903,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
     const { discoveryFetch, cache } = setup(f);
     const r = await verifyJwtViaDiscovery({ discoveryUrl: DISCOVERY }, undefined, cache, {
       fetchImpl: discoveryFetch,
-      warned: new Set(),
+      warnedAt: new Map(),
     });
     expect(r.allow).toBe(false);
   });
@@ -915,7 +917,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
       `Bearer ${token}`,
       cache,
-      { fetchImpl: unreachable, warned: new Set() }
+      { fetchImpl: unreachable, warnedAt: new Map() }
     );
     expect(r.allow).toBe(true);
   });
@@ -926,7 +928,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
     const unreachable = vi.fn(async () => ({ ok: false, status: 500, text: async () => 'err' }));
     const r = await verifyJwtViaDiscovery({ discoveryUrl: DISCOVERY }, 'Bearer not-a-jwt', cache, {
       fetchImpl: unreachable,
-      warned: new Set(),
+      warnedAt: new Map(),
     });
     expect(r.allow).toBe(true);
     expect(r.principalId).toBe('unknown');
@@ -945,7 +947,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
       { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'] },
       `Bearer ${token}`,
       cache,
-      { fetchImpl: malformedDoc, warned: new Set() }
+      { fetchImpl: malformedDoc, warnedAt: new Map() }
     );
     expect(r.allow).toBe(true);
   });
@@ -962,7 +964,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read', 'write'] },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(true);
     });
@@ -975,7 +977,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read', 'write'] },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -988,7 +990,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read'] },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1001,7 +1003,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read'] },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1017,7 +1019,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         { discoveryUrl: DISCOVERY, allowedAudience: ['aud-1'], allowedScopes: ['read'] },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(true);
     });
@@ -1038,7 +1040,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(true);
     });
@@ -1057,7 +1059,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1079,7 +1081,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1098,7 +1100,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1120,7 +1122,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1142,7 +1144,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(true);
     });
@@ -1169,7 +1171,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(true);
     });
@@ -1193,7 +1195,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1212,7 +1214,7 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
@@ -1241,9 +1243,114 @@ describe('verifyJwtViaDiscovery (AgentCore customJwtAuthorizer)', () => {
         },
         `Bearer ${token}`,
         cache,
-        { fetchImpl: discoveryFetch, warned: new Set() }
+        { fetchImpl: discoveryFetch, warnedAt: new Map() }
       );
       expect(r.allow).toBe(false);
     });
+  });
+});
+
+describe('shouldWarn — per-time-window dedup helper (#247)', () => {
+  it('returns true on the first call for a key and records the timestamp', () => {
+    const warnedAt = new Map<string, number>();
+    let t = 1_000_000;
+    expect(shouldWarn('jwks-url', warnedAt, () => t)).toBe(true);
+    expect(warnedAt.get('jwks-url')).toBe(1_000_000);
+  });
+
+  it('returns false inside the re-emit window', () => {
+    const warnedAt = new Map<string, number>();
+    let t = 1_000_000;
+    shouldWarn('jwks-url', warnedAt, () => t);
+    t = 1_000_000 + WARN_REEMIT_INTERVAL_MS - 1;
+    expect(shouldWarn('jwks-url', warnedAt, () => t)).toBe(false);
+    // Timestamp NOT bumped on a suppressed call.
+    expect(warnedAt.get('jwks-url')).toBe(1_000_000);
+  });
+
+  it('returns true once the re-emit window has elapsed and bumps the timestamp', () => {
+    const warnedAt = new Map<string, number>();
+    let t = 1_000_000;
+    shouldWarn('jwks-url', warnedAt, () => t);
+    t = 1_000_000 + WARN_REEMIT_INTERVAL_MS;
+    expect(shouldWarn('jwks-url', warnedAt, () => t)).toBe(true);
+    expect(warnedAt.get('jwks-url')).toBe(t);
+  });
+
+  it('tracks each key independently', () => {
+    const warnedAt = new Map<string, number>();
+    let t = 1_000_000;
+    expect(shouldWarn('jwks-A', warnedAt, () => t)).toBe(true);
+    // Different URL is independent — its dedup window starts fresh.
+    expect(shouldWarn('jwks-B', warnedAt, () => t)).toBe(true);
+    // Same URL inside the window is still deduped.
+    expect(shouldWarn('jwks-A', warnedAt, () => t)).toBe(false);
+    expect(shouldWarn('jwks-B', warnedAt, () => t)).toBe(false);
+  });
+
+  it('is a no-op true when no warnedAt map is supplied', () => {
+    // Used by call sites that opt out of dedup entirely (e.g. test
+    // harnesses). Returns true unconditionally and has no side effect.
+    expect(shouldWarn('any-key', undefined, () => 0)).toBe(true);
+    expect(shouldWarn('any-key', undefined, () => 1_000_000)).toBe(true);
+  });
+});
+
+describe('verifyJwtViaDiscovery — warn re-emits per time window (#247)', () => {
+  const ISSUER = 'https://idp.example.com';
+  const DISCOVERY = `${ISSUER}/.well-known/openid-configuration`;
+
+  it('re-emits the "discovery unreachable" warn after WARN_REEMIT_INTERVAL_MS', async () => {
+    // Discovery fetch always rejects; the verifier falls through to
+    // pass-through accept. Pre-#247 the warn fired once for the URL and
+    // never again for the rest of the session. Post-#247 it re-emits
+    // every WARN_REEMIT_INTERVAL_MS.
+    const unreachable = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const cache = createJwksCache();
+    const warnedAt = new Map<string, number>();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      let t = 1_000_000;
+      // Call 1: warn fires.
+      const r1 = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY },
+        'Bearer t1',
+        cache,
+        { fetchImpl: unreachable, warnedAt, now: () => t }
+      );
+      expect(r1.allow).toBe(true);
+
+      // Call 2: 100ms later, well under the window — warn suppressed.
+      t = 1_000_000 + 100;
+      const r2 = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY },
+        'Bearer t2',
+        cache,
+        { fetchImpl: unreachable, warnedAt, now: () => t }
+      );
+      expect(r2.allow).toBe(true);
+
+      // Call 3: window elapsed — warn re-emits.
+      t = 1_000_000 + WARN_REEMIT_INTERVAL_MS + 1000;
+      const r3 = await verifyJwtViaDiscovery(
+        { discoveryUrl: DISCOVERY },
+        'Bearer t3',
+        cache,
+        { fetchImpl: unreachable, warnedAt, now: () => t }
+      );
+      expect(r3.allow).toBe(true);
+
+      const discoveryWarns = warnSpy.mock.calls.filter((args) =>
+        args.map((a) => String(a)).join(' ').includes('OIDC discovery unreachable')
+      );
+      // Exactly two warn lines: call 1 (initial) + call 3 (re-emit).
+      // Call 2 was suppressed by the dedup window.
+      expect(discoveryWarns).toHaveLength(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/tests/unit/local/front-door-auth.test.ts
+++ b/tests/unit/local/front-door-auth.test.ts
@@ -106,18 +106,22 @@ describe('buildAuthCheck — Bearer token verification', () => {
     expect(result.reason).toMatch(/scheme is not Bearer/);
   });
 
-  it('lets a shared `warned` Set de-dupe the JWKS-unreachable warn across guards', async () => {
-    // Same JWKS URL behind two different AuthChecks sharing one warned Set.
-    // The Set is populated by the verifier on first warn; assert that any
+  it('lets a shared `warnedAt` Map de-dupe the JWKS-unreachable warn across guards', async () => {
+    // Same JWKS URL behind two different AuthChecks sharing one warnedAt Map.
+    // The Map is populated by the verifier on first warn; assert that any
     // mutation we do here is visible to the second AuthCheck (proves the
     // reference is shared, not copied).
-    const sharedWarned = new Set<string>();
-    const checkA = buildAuthCheck(COGNITO_GUARD, passThroughJwksCache(), { warned: sharedWarned });
-    const checkB = buildAuthCheck(COGNITO_GUARD, passThroughJwksCache(), { warned: sharedWarned });
+    const sharedWarnedAt = new Map<string, number>();
+    const checkA = buildAuthCheck(COGNITO_GUARD, passThroughJwksCache(), {
+      warnedAt: sharedWarnedAt,
+    });
+    const checkB = buildAuthCheck(COGNITO_GUARD, passThroughJwksCache(), {
+      warnedAt: sharedWarnedAt,
+    });
     await checkA.check({ authorization: 'Bearer t' });
-    sharedWarned.add('marker');
-    expect(sharedWarned.has('marker')).toBe(true);
-    // Second AuthCheck sees the same Set (no error, just verifies reference identity).
+    sharedWarnedAt.set('marker', 1);
+    expect(sharedWarnedAt.has('marker')).toBe(true);
+    // Second AuthCheck sees the same Map (no error, just verifies reference identity).
     expect((await checkB.check({ authorization: 'Bearer t' })).allow).toBe(true);
   });
 });

--- a/tests/unit/local/http-server.test.ts
+++ b/tests/unit/local/http-server.test.ts
@@ -445,14 +445,14 @@ describe('startApiServer — JWKS pass-through warn fires once per server (must-
         throw new Error('unreachable');
       },
     });
-    const jwksWarnedUrls = new Set<string>();
+    const jwksWarnedAt = new Map<string, number>();
     const server = await startApiServer({
       state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
       rieTimeoutMs: 1000,
       host: '127.0.0.1',
       port: 0,
       jwksCache,
-      jwksWarnedUrls,
+      jwksWarnedAt,
     });
 
     try {
@@ -468,8 +468,9 @@ describe('startApiServer — JWKS pass-through warn fires once per server (must-
         const msg = args.map((a) => String(a)).join(' ');
         return msg.includes('JWKS pass-through mode for ');
       });
-      // Pre-fix: warn fired every request (2 lines). Post-fix: warn
-      // fires at most once per JWKS URL per server lifecycle.
+      // Pre-fix: warn fired every request (2 lines). Post-fix (#247):
+      // warn re-emits every WARN_REEMIT_INTERVAL_MS per JWKS URL, so two
+      // back-to-back requests within the window emit exactly one line.
       expect(passThroughWarns).toHaveLength(1);
     } finally {
       await server.close();


### PR DESCRIPTION
## Symptom

When `cdkl start-alb` (or any cdk-local path performing local JWT / JWKS
verification) cannot reach the upstream OIDC discovery URL / JWKS endpoint,
the verifier falls back to "accept the token without verification" — a
deliberate dev-tool tradeoff. Pre-#247 the warn line was deduped by a
`Set<string>` URL set (URL → warned-forever-for-this-run), so every JWT
from request #2 onward was silently accepted with no signal for the rest of
the session. A long-running `cdkl start-alb --watch` user briefly off VPN
at boot would never see the degraded-auth state again — auth was never
actually being verified, but the log had gone quiet.

## Fix (Option A from the issue)

Replace the boolean / once-per-session URL latch with a per-time-window
dedup keyed by URL: `Map<string, number>` (URL → last-warned-at unix ms),
re-emit window 5 minutes. The verifier re-emits the same warn every
5 minutes per URL so the user keeps seeing the degraded state surface
periodically.

New helper `shouldWarn(key, warnedAt, now): boolean` lives in
`src/local/cognito-jwt.ts` next to the new exported types `WarnedAt` and
`WARN_REEMIT_INTERVAL_MS`. Returns `true` (and bumps the timestamp) when
the key has never been warned or the window has elapsed; returns `false`
otherwise. Distinct keys (different IdP URLs) are independent.

## Sites migrated

- `src/local/cognito-jwt.ts` — `verifyCognitoJwt` / `verifyJwtAuthorizer`
  / `verifyJwtViaDiscovery` `opts.warned: Set<string>` → `opts.warnedAt:
  WarnedAt`. Both the "JWKS pass-through" warn (per-request) and the
  "OIDC discovery unreachable" warn (per-request) go through `shouldWarn`.
- `src/local/front-door-auth.ts` — the ALB front-door auth check reuses
  the same verifier chain, so its `opts.warned` option becomes
  `opts.warnedAt`. The previous on-disk Set fallback is now a per-AuthCheck
  Map.
- `src/local/http-server.ts` — `jwksWarnedUrls: Set<string>` →
  `jwksWarnedAt: WarnedAt` on `startApiServer`.
- `src/cli/commands/local-start-api.ts`,
  `src/cli/commands/ecs-service-emulator.ts` (shared by `start-service` /
  `start-alb`), `src/cli/commands/local-invoke-agentcore.ts` — caller-side
  construction of the warn-set is updated to the new Map shape.
- `src/internal.ts` — `WarnedAt` re-exported under `cdk-local/internal` so
  host CLIs threading the same verifier API stay in lockstep.

`sigV4WarnedForeignIds` (SigV4 foreign-identity warn) stays a `Set` —
that warn surfaces a configuration mismatch that doesn't flap with network
state, so once-per-session dedup is still appropriate. A comment on the
field documents the deliberate scope.

## Tests

`tests/unit/local/cognito-jwt.test.ts`:

- New `shouldWarn` suite (5 cases): first call returns true and records
  the timestamp; second call inside the window returns false (no
  side-effect bump); third call after the window returns true and bumps
  the timestamp; distinct keys are independent; no-op true when the map
  is undefined.
- New behavioral suite (1 case): mock `fetch` rejects on every call;
  three `verifyJwtViaDiscovery` calls at t=0 / t+100ms / t+window+1s emit
  exactly 2 warn lines (one at t=0, one re-emitted at t+window+1s; the
  t+100ms call is suppressed).

Existing tests migrated from `warned: Set` → `warnedAt: Map` (no
behavior change in their assertions). The dedup behavior the existing
`tests/unit/local/http-server.test.ts` test asserts (2 back-to-back
requests → exactly 1 warn line) still holds — the second request lands
well inside the 5-minute window.

## Documented posture

Updated `docs/local-emulation.md` (`start-api authorizers` section) and
`docs/cli-reference.md` (the `start-alb` `authenticate-cognito` /
`authenticate-oidc` section + the `cdkl invoke-agentcore` discovery
fallback note) to explicitly call out the new posture: "When JWKS / OIDC
discovery is unreachable, cdk-local accepts tokens without verification
(local-dev convenience). The warn re-emits every 5 minutes per URL so a
long-running session keeps surfacing the degraded state instead of
silently accepting tokens for the rest of the run." The security
tradeoff is stated up front — do not rely on the fallback in any shared
environment.

## Out of scope

- Option C from the issue (`--accept-on-unreachable` opt-in flag, with
  strict-by-default semantics): tracked separately; would be a behavior
  change.
- Other silent-debug sites flagged in #246.
- The `--profile` audit from #245.

Closes #247
