### PR TITLE
fix(local-dev): surface auth / watcher / HTTPv2 / classifier rejection reasons (no more silent debug-log fallbacks)

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -1194,7 +1194,13 @@ export async function loadAssetContextForTarget(args: {
   // image isn't a CDK asset.
   const parsed = parseEcsTarget(target);
   const candidate = pickCandidateStack(parsed.stackPattern, stacks);
-  if (!candidate) return undefined;
+  if (!candidate) {
+    logger.debug(
+      `loadAssetContext: stack pattern '${parsed.stackPattern}' from target '${target}' ` +
+        `not in the assembly. Classifier will see no asset context (rebuild).`
+    );
+    return undefined;
+  }
   let newService: ResolvedEcsService;
   try {
     newService = resolveEcsServiceTarget(target, stacks, undefined, {
@@ -1202,7 +1208,7 @@ export async function loadAssetContextForTarget(args: {
     });
   } catch (err) {
     logger.debug(
-      `loadAssetContextForTarget: target '${target}' could not be re-resolved against ` +
+      `loadAssetContext: resolveEcsServiceTarget threw for target '${target}' against ` +
         `the new stacks: ${err instanceof Error ? err.message : String(err)}. ` +
         'Classifier will see no asset context (rebuild).'
     );
@@ -1215,18 +1221,47 @@ export async function loadAssetContextForTarget(args: {
   // representative.
   const essential =
     newService.task.containers.find((c) => c.essential) ?? newService.task.containers[0];
-  if (!essential) return undefined;
+  if (!essential) {
+    logger.debug(
+      `loadAssetContext: task definition for target '${target}' has no containers. ` +
+        'Classifier will see no asset context (rebuild).'
+    );
+    return undefined;
+  }
   if (essential.image.kind !== 'cdk-asset' || !essential.image.assetHash) {
+    const assetHashStr =
+      essential.image.kind === 'cdk-asset' ? (essential.image.assetHash ?? 'undefined') : 'n/a';
+    logger.debug(
+      `loadAssetContext: target '${target}' essential image is not a CDK asset ` +
+        `(kind='${essential.image.kind}', assetHash=${assetHashStr}). ` +
+        'Classifier will see no asset context (rebuild).'
+    );
     return undefined;
   }
   const newAssetHash = essential.image.assetHash;
   const manifest = await assetLoader.loadManifest(cdkOutDir, candidate.stackName);
-  if (!manifest) return undefined;
+  if (!manifest) {
+    logger.debug(
+      `loadAssetContext: asset manifest missing for stack '${candidate.stackName}' under ` +
+        `'${cdkOutDir}'. Classifier will see no asset context (rebuild).`
+    );
+    return undefined;
+  }
   const newDockerImage = manifest.dockerImages?.[newAssetHash];
-  if (!newDockerImage) return undefined;
+  if (!newDockerImage) {
+    logger.debug(
+      `loadAssetContext: asset hash '${newAssetHash}' not present in stack ` +
+        `'${candidate.stackName}' dockerImages. Classifier will see no asset context (rebuild).`
+    );
+    return undefined;
+  }
   if (!newDockerImage.source.directory) {
     // `executable`-mode docker asset (custom build script). No staged
     // source directory to copy from.
+    logger.debug(
+      `loadAssetContext: docker asset '${newAssetHash}' for stack '${candidate.stackName}' ` +
+        `is executable-mode (no source.directory). Classifier will see no asset context (rebuild).`
+    );
     return undefined;
   }
   const newAssetSourceDir = path.resolve(cdkOutDir, newDockerImage.source.directory);

--- a/src/local/file-watcher.ts
+++ b/src/local/file-watcher.ts
@@ -79,10 +79,13 @@ const DEFAULT_DEBOUNCE_MS = 500;
  * (chokidar starts listening before this function returns); the
  * caller does not need to `await` ready.
  *
- * Errors from chokidar (typically "ENOENT: path doesn't exist") are
- * logged at debug and otherwise swallowed — the start-api server
- * should keep serving even when one of the watched asset directories
- * goes missing during a reload.
+ * Errors from chokidar (typically "ENOENT: path doesn't exist", or
+ * EMFILE on macOS when watching a deep tree) are logged at WARN and
+ * otherwise swallowed — the start-api server should keep serving even
+ * when one of the watched asset directories goes missing during a
+ * reload, but the user gets a visible signal that `--watch` may have
+ * stopped firing so they don't sit there waiting for a reload that
+ * will never come.
  */
 export function createFileWatcher(options: FileWatcherOptions): FileWatcher {
   const logger = getLogger().child('start-api-watch');
@@ -152,8 +155,10 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcher {
   watcher.on('unlink', onEvent);
 
   watcher.on('error', (err) => {
-    logger.debug(
-      `chokidar error: ${err instanceof Error ? err.message : String(err)}. Continuing.`
+    logger.warn(
+      `chokidar error: ${err instanceof Error ? err.message : String(err)}. ` +
+        `--watch may be degraded for the remainder of this session — file changes ` +
+        `may no longer trigger reloads. Restart cdkl to recover.`
     );
   });
 

--- a/src/local/front-door-auth.ts
+++ b/src/local/front-door-auth.ts
@@ -117,10 +117,18 @@ export function buildAuthCheck(
           reason: 'Bearer token rejected (signature / iss / aud / exp check failed).',
         };
       } catch (err) {
+        const errClass = err instanceof Error ? err.constructor.name : typeof err;
+        const errMessage = err instanceof Error ? err.message : String(err);
         getLogger()
           .child('front-door-auth')
-          .debug(`auth check threw: ${err instanceof Error ? err.message : String(err)}`);
-        return { allow: false, reason: 'Auth check failed.' };
+          .warn(
+            `Bearer JWT verification threw (${errClass}): ${errMessage}. ` +
+              `Returning 401 to client. Check the JWKS URL is reachable and the token is well-formed.`
+          );
+        return {
+          allow: false,
+          reason: `Auth check failed: ${errClass} — ${errMessage}`,
+        };
       }
     },
   };

--- a/src/local/front-door-auth.ts
+++ b/src/local/front-door-auth.ts
@@ -119,6 +119,16 @@ export function buildAuthCheck(
       } catch (err) {
         const errClass = err instanceof Error ? err.constructor.name : typeof err;
         const errMessage = err instanceof Error ? err.message : String(err);
+        // Cap the client-visible reason: a pathological upstream
+        // error message could reflect arbitrary bytes (potentially
+        // including token-adjacent content from a future verifier)
+        // into the 401 body otherwise. The internal warn keeps the
+        // full message for dev diagnostics.
+        const REASON_MESSAGE_CAP = 200;
+        const clientMessage =
+          errMessage.length > REASON_MESSAGE_CAP
+            ? `${errMessage.slice(0, REASON_MESSAGE_CAP)}...`
+            : errMessage;
         getLogger()
           .child('front-door-auth')
           .warn(
@@ -127,7 +137,7 @@ export function buildAuthCheck(
           );
         return {
           allow: false,
-          reason: `Auth check failed: ${errClass} — ${errMessage}`,
+          reason: `Auth check failed: ${errClass} — ${clientMessage}`,
         };
       }
     },

--- a/src/local/httpv2-service-integration.ts
+++ b/src/local/httpv2-service-integration.ts
@@ -590,7 +590,10 @@ export function applyResponseParameters(
     const op = headerMatch[1].toLowerCase();
     const name = headerMatch[2].toLowerCase();
     if (isReservedHeader(name)) {
-      logger.debug(
+      // Mirrors the unmatched-key path above: surface the drop at warn
+      // (not debug) so the user notices a reserved header silently
+      // disappearing from the configured response mapping.
+      logger.warn(
         `ResponseParameters: header '${name}' is reserved by API Gateway and was skipped`
       );
       continue;

--- a/src/local/httpv2-service-integration.ts
+++ b/src/local/httpv2-service-integration.ts
@@ -579,7 +579,14 @@ export function applyResponseParameters(
       continue;
     }
     const headerMatch = /^(append|overwrite|remove):header\.(.+)$/i.exec(key);
-    if (!headerMatch || !headerMatch[1] || !headerMatch[2]) continue;
+    if (!headerMatch || !headerMatch[1] || !headerMatch[2]) {
+      logger.warn(
+        `ResponseParameters: key '${key}' does not match the expected shape ` +
+          `'(append|overwrite|remove):header.<name>' or 'overwrite:statuscode'; ` +
+          `the value was dropped. Check for typos (e.g. 'appen:' vs 'append:').`
+      );
+      continue;
+    }
     const op = headerMatch[1].toLowerCase();
     const name = headerMatch[2].toLowerCase();
     if (isReservedHeader(name)) {

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -230,19 +230,27 @@ export async function verifySigV4(
   try {
     parsed = parseAuthorizationHeader(authHeader);
   } catch (err) {
-    logger.debug(
-      `AWS_IAM authorizer: malformed Authorization header — ${err instanceof Error ? err.message : String(err)}`
+    logger.info(
+      `AWS_IAM authorizer: rejecting request — malformed Authorization header ` +
+        `(${err instanceof Error ? err.message : String(err)}). Expected shape: ` +
+        `'AWS4-HMAC-SHA256 Credential=<AKID>/<YYYYMMDD>/<region>/<service>/aws4_request, ` +
+        `SignedHeaders=<h1>;<h2>;..., Signature=<hex>'.`
     );
     return { allow: false, identityHash: undefined };
   }
 
   if (parsed.algorithm !== 'AWS4-HMAC-SHA256') {
-    logger.debug(`AWS_IAM authorizer: unsupported algorithm '${parsed.algorithm}'`);
+    logger.info(
+      `AWS_IAM authorizer: rejecting request — unsupported Authorization algorithm ` +
+        `'${parsed.algorithm}'. Expected 'AWS4-HMAC-SHA256'.`
+    );
     return { allow: false, identityHash: undefined };
   }
   if (parsed.credentialTerminator !== 'aws4_request') {
-    logger.debug(
-      `AWS_IAM authorizer: invalid credential scope terminator '${parsed.credentialTerminator}'`
+    logger.info(
+      `AWS_IAM authorizer: rejecting request — invalid credential-scope terminator ` +
+        `'${parsed.credentialTerminator}'. Expected 'aws4_request' (the last '/' segment ` +
+        `of the Credential= value).`
     );
     return { allow: false, identityHash: undefined };
   }
@@ -252,12 +260,18 @@ export async function verifySigV4(
   // to `date` for compatibility with curl --aws-sigv4 etc.
   const amzDate = pickHeader(req.headers, 'x-amz-date') ?? pickHeader(req.headers, 'date');
   if (!amzDate) {
-    logger.debug('AWS_IAM authorizer: missing x-amz-date / date header');
+    logger.info(
+      'AWS_IAM authorizer: rejecting request — missing x-amz-date / date header. ' +
+        "Expected ISO-8601 basic 'YYYYMMDDTHHMMSSZ' in 'x-amz-date' (AWS SDK default) " +
+        "or RFC 1123 in 'date' (curl --aws-sigv4)."
+    );
     return { allow: false, identityHash: undefined };
   }
   if (!validateAmzDateMatchesCredentialDate(amzDate, parsed.credentialDate)) {
-    logger.debug(
-      `AWS_IAM authorizer: x-amz-date '${amzDate}' does not match credential scope date '${parsed.credentialDate}'`
+    logger.info(
+      `AWS_IAM authorizer: rejecting request — x-amz-date '${amzDate}' does not match ` +
+        `credential-scope date '${parsed.credentialDate}'. The 'YYYYMMDD' prefix of ` +
+        `x-amz-date must equal the date segment of Credential=<AKID>/<YYYYMMDD>/...`
     );
     return { allow: false, identityHash: undefined };
   }
@@ -267,7 +281,11 @@ export async function verifySigV4(
   // that here — a missing `now` defaults to real time.
   const now = (opts.now ?? ((): Date => new Date()))();
   if (amzDateOutsideSkew(amzDate, now)) {
-    logger.debug(`AWS_IAM authorizer: x-amz-date '${amzDate}' outside 15-min clock skew`);
+    logger.info(
+      `AWS_IAM authorizer: rejecting request — x-amz-date '${amzDate}' is outside the ` +
+        `15-minute clock-skew window (local now=${now.toISOString()}). Re-sign the ` +
+        `request with the current time or sync the local clock.`
+    );
     return { allow: false, identityHash: undefined };
   }
 
@@ -391,8 +409,11 @@ export async function verifySigV4(
   // key, recompute the signature, compare.
   const recomputed = computeSignature(req, parsed, local.secretAccessKey, amzDate);
   if (!constantTimeEqual(recomputed, parsed.signature)) {
-    logger.debug(
-      `AWS_IAM authorizer: signature mismatch (expected '${recomputed}', got '${parsed.signature}')`
+    logger.info(
+      `AWS_IAM authorizer: rejecting request — Signature= mismatch (recomputed ` +
+        `'${recomputed}', got '${parsed.signature}'). The request was signed with the ` +
+        `expected access-key-id but the HMAC does not verify — check the SignedHeaders ` +
+        `list, request body, and canonical-request normalization on the signer side.`
     );
     return { allow: false, identityHash: undefined };
   }

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -306,8 +306,9 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
         } catch {
           /* ignore */
         }
-        logger.debug(
-          `WebSocket $connect denied for connection ${connectionId} on ${cfg.api.declaredAt}`
+        logger.info(
+          `WebSocket $connect denied for connection ${connectionId} on ${cfg.api.declaredAt} ` +
+            `— authorizer returned a non-allow verdict. Client was closed with code 1008.`
         );
         return;
       }

--- a/tests/unit/cli/ecs-service-emulator-load-asset-context.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-load-asset-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 
 const { hoisted } = vi.hoisted(() => ({
   hoisted: {
@@ -354,5 +354,186 @@ describe('loadAssetContextForTarget (Phase 4 follow-up of #214, #218)', () => {
     // edit to `dockerfiles/Prod.Dockerfile` would silently route to
     // soft-reload.
     expect((ctx as { dockerFile: string }).dockerFile).toBe('Prod.Dockerfile');
+  });
+});
+
+/**
+ * Issue #246 site 6 — the six `return undefined` branches in
+ * `loadAssetContextForTarget` used to all collapse silently to the same
+ * downstream verdict `rebuild ("classifier not consulted")`. Future
+ * `--verbose` runs need to pinpoint WHICH condition fired in <10 seconds.
+ * These rows lock that each branch emits a DISTINCT `logger.debug`
+ * message. This is intentionally debug-level (not warn) — the verdict
+ * defaults to rebuild (safe), so the signal is only needed under
+ * `--verbose`.
+ */
+describe('loadAssetContextForTarget — distinct debug messages per branch (issue #246)', () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let testLogger: ReturnType<typeof getLogger>['child'] extends (n: string) => infer R ? R : never;
+
+  beforeEach(() => {
+    hoisted.resolveMode = 'happy';
+    hoisted.manifest = {
+      version: '1.0.0',
+      files: {},
+      dockerImages: {
+        newhash: {
+          displayName: 'WebTask:web',
+          source: { directory: 'asset.newhash' },
+          destinations: {},
+        },
+      },
+    };
+    hoisted.loadManifestCalls = [];
+    testLogger = getLogger().child('test');
+    debugSpy = vi.spyOn(testLogger, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function callWith(opts: {
+    target?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stacks?: any[];
+  }): Promise<unknown> {
+    return loadAssetContextForTarget({
+      target: opts.target ?? 'AppStack:WebService',
+      controller: fakeControllerWithOldAssetHash('oldhash', 'omit'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stacks: (opts.stacks ?? [fakeStack()]) as any,
+      cdkOutDir: '/tmp/cdk.out',
+      assetLoader: new AssetManifestLoader(),
+      logger: testLogger,
+    });
+  }
+
+  function debugMessages(): string[] {
+    return debugSpy.mock.calls.map((c) => String(c[0]));
+  }
+
+  it('branch 1: no candidate stack → distinct debug naming the missing stack', async () => {
+    await callWith({ stacks: [], target: 'NoSuchStack:Svc' });
+    const msgs = debugMessages();
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0]).toContain('loadAssetContext');
+    expect(msgs[0]).toContain('NoSuchStack');
+    expect(msgs[0]).toMatch(/not in the assembly/);
+  });
+
+  it('branch 2: resolveEcsServiceTarget throws → distinct debug naming the throw', async () => {
+    hoisted.resolveMode = 'throw';
+    await callWith({});
+    const msgs = debugMessages();
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0]).toContain('loadAssetContext');
+    expect(msgs[0]).toContain('resolveEcsServiceTarget threw');
+    expect(msgs[0]).toContain('synthetic resolveEcsServiceTarget throw');
+  });
+
+  it('branch 3: no essential container → distinct debug naming the empty task', async () => {
+    hoisted.resolveMode = 'no-containers';
+    await callWith({});
+    const msgs = debugMessages();
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0]).toContain('loadAssetContext');
+    expect(msgs[0]).toContain('no containers');
+  });
+
+  it('branch 4: image is not a CDK asset (ECR pin) → distinct debug naming the image kind', async () => {
+    hoisted.resolveMode = 'non-cdk-asset';
+    await callWith({});
+    const msgs = debugMessages();
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0]).toContain('loadAssetContext');
+    expect(msgs[0]).toContain('not a CDK asset');
+    expect(msgs[0]).toContain("kind='ecr'");
+  });
+
+  it('branch 5: asset manifest missing → distinct debug naming the stack + cdkOutDir', async () => {
+    hoisted.manifest = null;
+    await callWith({});
+    const msgs = debugMessages();
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0]).toContain('loadAssetContext');
+    expect(msgs[0]).toContain('asset manifest missing');
+    expect(msgs[0]).toContain('AppStack');
+    expect(msgs[0]).toContain('/tmp/cdk.out');
+  });
+
+  it('branch 6: asset hash not in manifest dockerImages → distinct debug naming the hash', async () => {
+    hoisted.manifest = { version: '1.0.0', files: {}, dockerImages: {} };
+    await callWith({});
+    const msgs = debugMessages();
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0]).toContain('loadAssetContext');
+    expect(msgs[0]).toContain("'newhash'");
+    expect(msgs[0]).toContain('not present');
+  });
+
+  it('branch 7: executable-mode docker asset (no source.directory) → distinct debug naming executable-mode', async () => {
+    hoisted.manifest = {
+      version: '1.0.0',
+      files: {},
+      dockerImages: {
+        newhash: {
+          displayName: 'WebTask:web',
+          source: { executable: ['my-builder.sh'] },
+          destinations: {},
+        },
+      },
+    };
+    await callWith({});
+    const msgs = debugMessages();
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[0]).toContain('loadAssetContext');
+    expect(msgs[0]).toContain('executable-mode');
+  });
+
+  it('every branch message contains the loadAssetContext prefix so a --verbose grep finds them all', async () => {
+    // Drive every branch in one suite to assert the common prefix.
+    const branches: Array<() => Promise<void>> = [
+      async () => {
+        await callWith({ stacks: [], target: 'NoSuchStack:Svc' });
+      },
+      async () => {
+        hoisted.resolveMode = 'throw';
+        await callWith({});
+      },
+      async () => {
+        hoisted.resolveMode = 'no-containers';
+        await callWith({});
+      },
+      async () => {
+        hoisted.resolveMode = 'non-cdk-asset';
+        await callWith({});
+      },
+      async () => {
+        hoisted.manifest = null;
+        await callWith({});
+      },
+      async () => {
+        hoisted.manifest = { version: '1.0.0', files: {}, dockerImages: {} };
+        await callWith({});
+      },
+      async () => {
+        hoisted.manifest = {
+          version: '1.0.0',
+          files: {},
+          dockerImages: {
+            newhash: { displayName: 'WebTask:web', source: { executable: ['x'] } },
+          },
+        };
+        await callWith({});
+      },
+    ];
+    for (const b of branches) {
+      debugSpy.mockReset();
+      await b();
+      const msgs = debugMessages();
+      expect(msgs.length).toBeGreaterThan(0);
+      expect(msgs[0]).toContain('loadAssetContext');
+    }
   });
 });

--- a/tests/unit/local/file-watcher.test.ts
+++ b/tests/unit/local/file-watcher.test.ts
@@ -5,6 +5,7 @@ const { watchMock } = vi.hoisted(() => ({ watchMock: vi.fn() }));
 vi.mock('chokidar', () => ({ watch: watchMock }));
 
 import { createFileWatcher } from '../../../src/local/file-watcher.js';
+import { ConsoleLogger } from '../../../src/utils/logger.js';
 
 interface FakeWatcher {
   capturedPaths: unknown;
@@ -138,6 +139,42 @@ describe('createFileWatcher', () => {
     expect(onChange).toHaveBeenCalledTimes(2);
     expect(onChange.mock.calls[0]![0]).toEqual(['/root/a.ts']);
     expect(onChange.mock.calls[1]![0]).toEqual(['/root/b.ts']);
+  });
+
+  // Issue #246 site 5 — chokidar 'error' events (EMFILE on macOS when
+  // nesting deep, watch root unmounted, etc.) used to log at
+  // `logger.debug`. The user would see `--watch active` at boot but no
+  // reload ever fired; default-level cdkl output stayed quiet. Lock
+  // the bump to `logger.warn` so the user gets a visible signal +
+  // mention that --watch may be degraded for the rest of the session.
+  it('logs chokidar error events at warn (not debug) so --watch degradation is visible', () => {
+    // Spy on the prototype so the file-watcher's own
+    // `getLogger().child('start-api-watch')` (a fresh child instance)
+    // trips the spy.
+    const warnSpy = vi
+      .spyOn(ConsoleLogger.prototype, 'warn')
+      .mockImplementation(() => {});
+    const debugSpy = vi
+      .spyOn(ConsoleLogger.prototype, 'debug')
+      .mockImplementation(() => {});
+
+    createFileWatcher({ paths: ['/root'], onChange: () => {} });
+
+    // Drive the chokidar error path with a representative EMFILE error.
+    const err = new Error('EMFILE: too many open files');
+    // The on('error', ...) callback is registered on the fake.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (fake as any).emit('error', err as any);
+
+    const warns = warnSpy.mock.calls.map((c) => String(c[0]));
+    const errLine = warns.find((w) => w.includes('chokidar error'));
+    expect(errLine).toBeDefined();
+    expect(errLine!).toContain('EMFILE');
+    expect(errLine!).toContain('--watch');
+
+    // The pre-fix debug path is gone.
+    const debugs = debugSpy.mock.calls.map((c) => String(c[0]));
+    expect(debugs.some((d) => d.includes('chokidar error'))).toBe(false);
   });
 
   it('drops shouldTrigger-rejected paths from the changed-set the callback sees', () => {

--- a/tests/unit/local/front-door-auth-throw-warn.test.ts
+++ b/tests/unit/local/front-door-auth-throw-warn.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+
+/**
+ * Issue #246 site 4 — when the ALB `authenticate-cognito` /
+ * `authenticate-oidc` verifier threw (network blip, malformed JWKS
+ * cache entry, etc.), the front-door used to:
+ *   a) log the exception at `logger.debug` (invisible at default log level);
+ *   b) return `reason: 'Auth check failed.'` to the client (generic 401
+ *      message — the user can't tell whether JWKS was unreachable, the
+ *      token shape was wrong, or the verifier crashed).
+ *
+ * Lock the bump to `logger.warn` (sticky signal mirroring `cognito-jwt.ts:133`'s
+ * JWKS-unreachable shape) AND include the exception class + message head in
+ * the user-facing `reason` so the client gets an actionable 401.
+ */
+
+vi.mock('../../../src/local/cognito-jwt.js', async (importActual) => {
+  const actual = await importActual<object>();
+  return {
+    ...actual,
+    verifyJwtAuthorizer: vi.fn(),
+  };
+});
+
+import * as cognitoJwt from '../../../src/local/cognito-jwt.js';
+import { buildAuthCheck } from '../../../src/local/front-door-auth.js';
+import { createJwksCache } from '../../../src/local/cognito-jwt.js';
+import type { FrontDoorAuthGuard } from '../../../src/local/elb-front-door-resolver.js';
+import { ConsoleLogger } from '../../../src/utils/logger.js';
+
+const verifyMock = cognitoJwt.verifyJwtAuthorizer as unknown as ReturnType<typeof vi.fn>;
+
+const COGNITO_GUARD: FrontDoorAuthGuard = {
+  kind: 'authenticate-cognito',
+  issuer: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abcDEF',
+  audience: 'client-abc',
+  region: 'us-east-1',
+  userPoolId: 'us-east-1_abcDEF',
+  sessionCookieName: 'AWSELBAuthSessionCookie',
+  label: 'authenticate-cognito (UserPool=us-east-1_abcDEF)',
+};
+
+describe('buildAuthCheck — verifier throw surfaces at warn with actionable reason (issue #246)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    verifyMock.mockReset();
+  });
+
+  it('logs the exception class + message at warn (not debug)', async () => {
+    class JwksFetchError extends Error {
+      constructor(msg: string) {
+        super(msg);
+        this.name = 'JwksFetchError';
+      }
+    }
+    verifyMock.mockRejectedValue(new JwksFetchError('connect ECONNREFUSED 127.0.0.1:443'));
+
+    // Spy on the prototype so the front-door-auth's
+    // `getLogger().child('front-door-auth')` (a fresh child per call)
+    // trips the spy regardless of identity.
+    const warnSpy = vi
+      .spyOn(ConsoleLogger.prototype, 'warn')
+      .mockImplementation(() => {});
+    const debugSpy = vi
+      .spyOn(ConsoleLogger.prototype, 'debug')
+      .mockImplementation(() => {});
+
+    const check = buildAuthCheck(COGNITO_GUARD, createJwksCache());
+    const result = await check.check({ authorization: 'Bearer dummy-jwt' });
+
+    expect(result.allow).toBe(false);
+    // The user-facing reason must name the exception so the 401 surface is
+    // actionable (vs the pre-fix 'Auth check failed.' that hid everything).
+    expect(result.reason).toContain('JwksFetchError');
+    expect(result.reason).toContain('ECONNREFUSED');
+
+    // The warn line must include the exception class — the test pins the
+    // shape so a future refactor can't silently revert to a stringly
+    // 'something went wrong' message.
+    const warns = warnSpy.mock.calls.map((c) => String(c[0]));
+    const verifierWarn = warns.find((w) => w.includes('Bearer JWT verification threw'));
+    expect(verifierWarn).toBeDefined();
+    expect(verifierWarn!).toContain('JwksFetchError');
+    expect(verifierWarn!).toContain('ECONNREFUSED');
+
+    // And no debug log on this path (regression guard for the pre-fix shape).
+    const debugs = debugSpy.mock.calls.map((c) => String(c[0]));
+    expect(debugs.join('\n')).not.toContain('auth check threw');
+  });
+
+  it('handles non-Error throws (string thrown) without crashing', async () => {
+    verifyMock.mockRejectedValue('plain-string-error');
+    const warnSpy = vi
+      .spyOn(ConsoleLogger.prototype, 'warn')
+      .mockImplementation(() => {});
+    const check = buildAuthCheck(COGNITO_GUARD, createJwksCache());
+    const result = await check.check({ authorization: 'Bearer dummy-jwt' });
+    expect(result.allow).toBe(false);
+    expect(result.reason).toContain('plain-string-error');
+    const warns = warnSpy.mock.calls.map((c) => String(c[0]));
+    const verifierWarn = warns.find((w) => w.includes('Bearer JWT verification threw'));
+    expect(verifierWarn).toBeDefined();
+    expect(verifierWarn!).toContain('plain-string-error');
+  });
+});

--- a/tests/unit/local/httpv2-response-parameters-unmatched-key.test.ts
+++ b/tests/unit/local/httpv2-response-parameters-unmatched-key.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+import {
+  applyResponseParameters,
+  type ResponseParameterContext,
+} from '../../../src/local/httpv2-service-integration.js';
+import { getLogger } from '../../../src/utils/logger.js';
+
+/**
+ * Issue #246 site 1 — `ResponseParameters` keys that do not match the
+ * `(append|overwrite|remove):header.<name>` shape were silently dropped at
+ * `logger.debug`, leaving the user staring at a missing header with no
+ * cdkl output line to explain why. This file locks the bump to
+ * `logger.warn` and asserts the offending key surfaces in the warning so
+ * the user can spot the typo.
+ */
+describe('applyResponseParameters — unmatched key surfaces a warn', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const ctx: ResponseParameterContext = {
+    context: {},
+    stageVariables: {},
+  };
+
+  it('warns (not debugs) when a ResponseParameters key does not match the expected shape', () => {
+    const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+    const result = applyResponseParameters(
+      { statusCode: 200, body: 'ok', headers: {} },
+      {
+        '200': {
+          // Typical typo: 'appen' instead of 'append'.
+          'appen:header.x-custom': 'value',
+        },
+      },
+      ctx
+    );
+    // The unmatched key is dropped (correct), but the user must SEE that.
+    expect(result.statusCode).toBe(200);
+    expect(result.headers).toEqual({});
+    const warns = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(warns.length).toBeGreaterThan(0);
+    expect(warns[0]).toContain("'appen:header.x-custom'");
+    expect(warns[0]).toContain('append|overwrite|remove');
+    // The path should NOT silently fall through debug.
+    const debugs = debugSpy.mock.calls.map((c) => String(c[0]));
+    expect(debugs.join('\n')).not.toContain("'appen:header.x-custom'");
+  });
+
+  it('keeps the reserved-header skip path as a separate warn (regression guard)', () => {
+    // The reserved-header branch at line 587 already used `warn`. We want
+    // to make sure the new unmatched-key warn coexists with it and they
+    // log distinct messages.
+    const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    applyResponseParameters(
+      { statusCode: 200, body: 'ok', headers: {} },
+      {
+        '200': {
+          // Reserved header (Connection / Transfer-Encoding / etc.) — the
+          // reserved-header skip warn fires regardless of the new branch.
+          'overwrite:header.content-length': '42',
+        },
+      },
+      ctx
+    );
+    const warns = warnSpy.mock.calls.map((c) => String(c[0]));
+    // The reserved branch logs its own line (already warn) — assert the
+    // unmatched-key warn did NOT fire on this well-formed key.
+    expect(warns.some((w) => w.includes('does not match the expected shape'))).toBe(false);
+  });
+
+  it('does NOT warn for a well-formed key (overwrite:header.foo applies and stays quiet)', () => {
+    const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const result = applyResponseParameters(
+      { statusCode: 200, body: 'ok', headers: {} },
+      { '200': { 'overwrite:header.x-custom': 'value' } },
+      ctx
+    );
+    expect(result.headers['x-custom']).toBe('value');
+    const warns = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((w) => w.includes('does not match the expected shape'))).toBe(false);
+  });
+});

--- a/tests/unit/local/httpv2-response-parameters-unmatched-key.test.ts
+++ b/tests/unit/local/httpv2-response-parameters-unmatched-key.test.ts
@@ -48,25 +48,27 @@ describe('applyResponseParameters — unmatched key surfaces a warn', () => {
     expect(debugs.join('\n')).not.toContain("'appen:header.x-custom'");
   });
 
-  it('keeps the reserved-header skip path as a separate warn (regression guard)', () => {
-    // The reserved-header branch at line 587 already used `warn`. We want
-    // to make sure the new unmatched-key warn coexists with it and they
-    // log distinct messages.
+  it('reserved-header skip path fires its own warn (mirrors unmatched-key warn for symmetry)', () => {
+    // Reserved headers (Connection / Transfer-Encoding / Content-Length etc.)
+    // are silently dropped by API Gateway. We surface the drop at `warn`
+    // (the same level as the unmatched-key warn above) so the user notices
+    // a reserved header silently disappearing from the configured mapping.
     const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
     applyResponseParameters(
       { statusCode: 200, body: 'ok', headers: {} },
       {
         '200': {
-          // Reserved header (Connection / Transfer-Encoding / etc.) — the
-          // reserved-header skip warn fires regardless of the new branch.
+          // Reserved header — the reserved-header skip warn fires.
           'overwrite:header.content-length': '42',
         },
       },
       ctx
     );
     const warns = warnSpy.mock.calls.map((c) => String(c[0]));
-    // The reserved branch logs its own line (already warn) — assert the
-    // unmatched-key warn did NOT fire on this well-formed key.
+    // Assert the reserved-header warn fired with its distinct message.
+    expect(warns.some((w) => w.includes("'content-length' is reserved"))).toBe(true);
+    // Assert the unmatched-key warn did NOT fire on this well-formed key
+    // (the two warns log distinct messages).
     expect(warns.some((w) => w.includes('does not match the expected shape'))).toBe(false);
   });
 

--- a/tests/unit/local/sigv4-verify-rejection-paths-info.test.ts
+++ b/tests/unit/local/sigv4-verify-rejection-paths-info.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+import {
+  verifySigV4,
+  type SigV4VerifyRequest,
+  type ResolvedCredentials,
+} from '../../../src/local/sigv4-verify.js';
+import { getLogger } from '../../../src/utils/logger.js';
+
+/**
+ * Issue #246 site 2 — seven SigV4 rejection paths used to log at
+ * `logger.debug` and silently return `{ allow: false }`, leaving the
+ * local-dev user with only the API Gateway 403 and no actionable signal
+ * in cdkl output. This file locks each path to `logger.info` (per-request
+ * signal, mirroring `cognito-jwt.ts:133`'s JWKS-unreachable shape) and
+ * asserts the user-facing message names the failing field + the expected
+ * shape so the user can fix their request without re-reading the SigV4
+ * spec.
+ *
+ * The seven paths under test (file-line references match issue #246
+ * spec, line numbers may drift):
+ *   1. Malformed Authorization header (parseAuthorizationHeader throw).
+ *   2. Unsupported algorithm (parsed.algorithm !== 'AWS4-HMAC-SHA256').
+ *   3. Bad credential-scope terminator
+ *      (parsed.credentialTerminator !== 'aws4_request').
+ *   4. Missing x-amz-date / date header.
+ *   5. x-amz-date does NOT match the credential-scope date.
+ *   6. x-amz-date outside the 15-minute clock-skew window.
+ *   7. Signature mismatch (recomputed != parsed).
+ */
+const NOW = new Date('2026-01-01T00:00:00Z');
+
+const LOCAL_CREDS: ResolvedCredentials = {
+  accessKeyId: 'AKIALOCALEXAMPLE',
+  secretAccessKey: 'secret',
+};
+
+const loadLocal = async (): Promise<ResolvedCredentials> => LOCAL_CREDS;
+
+function spyInfo(): { calls: () => string[]; restore: () => void } {
+  const spy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+  return {
+    calls: () => spy.mock.calls.map((c) => String(c[0])),
+    restore: () => spy.mockRestore(),
+  };
+}
+
+function spyDebug(): { calls: () => string[]; restore: () => void } {
+  const spy = vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+  return {
+    calls: () => spy.mock.calls.map((c) => String(c[0])),
+    restore: () => spy.mockRestore(),
+  };
+}
+
+function baseHeaders(authorization: string): Record<string, string> {
+  return {
+    host: '127.0.0.1:65483',
+    'x-amz-date': '20260101T000000Z',
+    authorization,
+  };
+}
+
+describe('verifySigV4 — 7 rejection paths surface at info (issue #246)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('1. malformed Authorization header logs at info with the parse error + expected shape', async () => {
+    const info = spyInfo();
+    const debug = spyDebug();
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: baseHeaders('this-is-not-a-valid-sigv4-header'),
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = info.calls().join('\n');
+    // The reject-path emits info, NOT debug, so a default-level cdkl run shows it.
+    expect(infos).toMatch(/malformed Authorization header/);
+    expect(infos).toMatch(/AWS4-HMAC-SHA256 Credential=/);
+    // The old debug-only path is gone.
+    expect(debug.calls().join('\n')).not.toContain('malformed Authorization header');
+    info.restore();
+    debug.restore();
+  });
+
+  it('2. unsupported algorithm logs at info naming the algorithm + expected value', async () => {
+    const info = spyInfo();
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: baseHeaders(
+        'AWS4-HMAC-SHA512 Credential=AKID/20260101/us-east-1/execute-api/aws4_request, SignedHeaders=host, Signature=abcd'
+      ),
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = info.calls().join('\n');
+    expect(infos).toMatch(/unsupported Authorization algorithm/);
+    expect(infos).toContain("'AWS4-HMAC-SHA512'");
+    expect(infos).toContain("'AWS4-HMAC-SHA256'");
+    info.restore();
+  });
+
+  it('3. invalid credential-scope terminator logs at info naming the terminator + expected', async () => {
+    const info = spyInfo();
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: baseHeaders(
+        'AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/execute-api/aws3_request, SignedHeaders=host, Signature=abcd'
+      ),
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = info.calls().join('\n');
+    expect(infos).toMatch(/invalid credential-scope terminator/);
+    expect(infos).toContain("'aws3_request'");
+    expect(infos).toContain("'aws4_request'");
+    info.restore();
+  });
+
+  it('4. missing x-amz-date / date header logs at info with the expected shape', async () => {
+    const info = spyInfo();
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: {
+        host: '127.0.0.1:65483',
+        // No x-amz-date and no date.
+        authorization:
+          'AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/execute-api/aws4_request, SignedHeaders=host, Signature=abcd',
+      },
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = info.calls().join('\n');
+    expect(infos).toMatch(/missing x-amz-date \/ date header/);
+    expect(infos).toMatch(/YYYYMMDDTHHMMSSZ/);
+    info.restore();
+  });
+
+  it('5. x-amz-date does not match credential-scope date logs at info with both values', async () => {
+    const info = spyInfo();
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: {
+        host: '127.0.0.1:65483',
+        // Date in header = Jan 2nd, credential scope date = Jan 1st.
+        'x-amz-date': '20260102T000000Z',
+        authorization:
+          'AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/execute-api/aws4_request, SignedHeaders=host, Signature=abcd',
+      },
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = info.calls().join('\n');
+    expect(infos).toMatch(/does not match/);
+    expect(infos).toContain("'20260102T000000Z'");
+    expect(infos).toContain("'20260101'");
+    info.restore();
+  });
+
+  it('6. x-amz-date outside 15-minute skew logs at info with both timestamps', async () => {
+    const info = spyInfo();
+    // x-amz-date 2025-12-31 (1 day ago), local now 2026-01-01.
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: {
+        host: '127.0.0.1:65483',
+        'x-amz-date': '20251231T000000Z',
+        authorization:
+          'AWS4-HMAC-SHA256 Credential=AKID/20251231/us-east-1/execute-api/aws4_request, SignedHeaders=host, Signature=abcd',
+      },
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = info.calls().join('\n');
+    expect(infos).toMatch(/outside the 15-minute clock-skew window/);
+    expect(infos).toContain('20251231T000000Z');
+    info.restore();
+  });
+
+  it('7. signature mismatch (matching AKID, bad Signature=) logs at info with both signatures', async () => {
+    const info = spyInfo();
+    // Match LOCAL_CREDS.accessKeyId so we reach the "same identity"
+    // recompute branch, then supply a clearly wrong Signature= so the
+    // constant-time compare fails.
+    const credential = `${LOCAL_CREDS.accessKeyId}/20260101/us-east-1/execute-api/aws4_request`;
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: {
+        host: '127.0.0.1:65483',
+        'x-amz-date': '20260101T000000Z',
+        authorization:
+          `AWS4-HMAC-SHA256 Credential=${credential}, ` +
+          'SignedHeaders=host;x-amz-date, Signature=0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = info.calls().join('\n');
+    expect(infos).toMatch(/Signature= mismatch/);
+    // Both the recomputed and the offered signatures should appear so the
+    // user can spot the divergence at a glance.
+    expect(infos).toMatch(/recomputed/);
+    expect(infos).toMatch(/0{64}/);
+    info.restore();
+  });
+});

--- a/tests/unit/local/websocket-server-connect-deny-info.test.ts
+++ b/tests/unit/local/websocket-server-connect-deny-info.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { createServer, type Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+/**
+ * Issue #246 site 3 — `$connect` authorizer deny used to log at
+ * `logger.debug`, so the local-dev user saw a closed WebSocket (code
+ * 1008) but no signal in the cdkl tail explaining why. Lock the bump
+ * to `logger.info` so the deny appears next to the normal
+ * `$connect` / `$disconnect` lines.
+ */
+vi.mock('../../../src/local/rie-client.js', () => ({
+  invokeRie: vi.fn(),
+}));
+
+import * as rieClient from '../../../src/local/rie-client.js';
+import { attachWebSocketServer } from '../../../src/local/websocket-server.js';
+import type { DiscoveredWebSocketApi } from '../../../src/local/websocket-route-discovery.js';
+import { ConsoleLogger } from '../../../src/utils/logger.js';
+
+const invokeRieMock = rieClient.invokeRie as unknown as ReturnType<typeof vi.fn>;
+
+function buildApi(): DiscoveredWebSocketApi {
+  return {
+    apiLogicalId: 'WsApi',
+    apiStackName: 'AppStack',
+    declaredAt: 'AppStack/WsApi',
+    routeSelectionExpression: '$request.body.action',
+    stage: 'local',
+    routes: [
+      {
+        routeKey: '$connect',
+        targetLambdaLogicalId: 'ConnectFn',
+        lambdaStackName: 'AppStack',
+        declaredAt: 'AppStack/ConnectRoute',
+      },
+    ],
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fakePool(): any {
+  return {
+    acquire: async () => ({ containerHost: '127.0.0.1', hostPort: 1234 }),
+    release: () => {},
+    dispose: async () => {},
+  };
+}
+
+describe('attachWebSocketServer — $connect deny surfaces at info (issue #246)', () => {
+  let httpServer: HttpServer;
+  let port: number;
+  let close: undefined | (() => Promise<void>);
+
+  beforeEach(async () => {
+    invokeRieMock.mockReset();
+    httpServer = createServer();
+    await new Promise<void>((r) => httpServer.listen(0, '127.0.0.1', r));
+    port = (httpServer.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (close) await close();
+    await new Promise<void>((r) => httpServer.close(() => r()));
+  });
+
+  it("logs the $connect deny at info (not debug) so the user sees it in default-level cdkl output", async () => {
+    // Spy on the prototype so both the global logger and any child loggers
+    // (the websocket-server uses `getLogger().child('start-api/ws')`)
+    // trip the spy.
+    const infoSpy = vi
+      .spyOn(ConsoleLogger.prototype, 'info')
+      .mockImplementation(() => {});
+    const debugSpy = vi
+      .spyOn(ConsoleLogger.prototype, 'debug')
+      .mockImplementation(() => {});
+
+    // Authorizer returns 403 → invokeRouteAndDecideAuth returns false → deny path.
+    invokeRieMock.mockResolvedValue({ payload: { statusCode: 403 } });
+
+    const attached = attachWebSocketServer({
+      httpServer,
+      apis: [{ api: buildApi(), apiPath: '/' }],
+      pool: fakePool(),
+      rieTimeoutMs: 5_000,
+    });
+    close = () => attached.close();
+
+    const { WebSocket } = await import('ws');
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      ws.on('close', (code) => {
+        // Deny closes with 1008 (policy violation).
+        try {
+          expect(code).toBe(1008);
+          resolve();
+        } catch (err) {
+          reject(err as Error);
+        }
+      });
+      ws.on('error', () => {
+        /* ignore — close handler resolves first */
+      });
+    });
+
+    // Find the info log message naming the deny — there is exactly one
+    // per denied connection.
+    const infoLines = infoSpy.mock.calls.map((c) => String(c[0]));
+    const denyLine = infoLines.find((l) => l.includes('$connect denied'));
+    expect(denyLine).toBeDefined();
+    expect(denyLine!).toContain('AppStack/WsApi');
+    expect(denyLine!).toContain('code 1008');
+
+    // The pre-fix debug path is gone.
+    const debugLines = debugSpy.mock.calls.map((c) => String(c[0]));
+    expect(debugLines.some((l) => l.includes('$connect denied'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #246. cdk-local had a recurring pattern of rejecting / failing
silently at `logger.debug` level — the user saw an unexplained 4xx, a
closed WebSocket, a dropped header, or a watcher that stopped firing,
with nothing in cdkl output to explain why. This PR bumps the 6 sites
called out in the issue from `debug` to `info` / `warn` (as
appropriate) and, where the user-facing surface returned a generic
reason, includes enough detail (offending key, exception class,
failing field name + expected shape) that the user can act on it
without re-reading a spec.

## Per-site fixes

### Site 1: `src/local/httpv2-service-integration.ts` — unmatched `ResponseParameters` key

`debug` -> `warn`. A typo like `appen:header.foo` or
`overrite:header.bar` used to be no-op'd with zero log line; the warn
now names the offending key + the expected shape
(`(append|overwrite|remove):header.<name>` or
`overwrite:statuscode`). Mirrors the existing reserved-header skip
warn (line 587).

### Site 2: `src/local/sigv4-verify.ts` — 7 SigV4 rejection paths

All 7 paths (malformed Authorization, unsupported algorithm, bad
credential-scope terminator, missing `x-amz-date` / `date`,
date-mismatch, clock-skew, signature mismatch) `debug` -> `info`. The
deployed-API-Gateway-side 403 was the only previous signal; the new
info-level message names the failing field + the expected shape so
the user can fix their request without re-reading the SigV4 spec.
Chose `info` (per-request signal) over `warn` (sticky signal) because
these fire per inbound request — `warn`-spamming on every request
would drown out the more important sticky warns. Mirrors the
JWKS-unreachable shape in `cognito-jwt.ts:133`.

### Site 3: `src/local/websocket-server.ts` — `$connect` authorizer deny

`debug` -> `info`. The deny now appears alongside the normal
`$connect` / `$disconnect` lines in the running tail. Also names
the close code (1008) so the user can correlate with the client's
observed close event.

### Site 4: `src/local/front-door-auth.ts` — ALB `authenticate-*` verifier exception

`debug` -> `warn` AND the exception class + message head is now
included in the user-facing 401 `reason`. Pre-fix, the client got
`Auth check failed.` (no signal whether JWKS was unreachable, the
token shape was wrong, or the verifier crashed). Now: `Auth check
failed: <ErrClass> — <message>`. Mirrors the JWKS-unreachable warn
shape from `cognito-jwt.ts:133`.

### Site 5: `src/local/file-watcher.ts` — chokidar `error` event

`debug` -> `warn`. EMFILE on macOS / unmounted watch root / etc.
used to silently kill the watcher while the boot banner still
advertised `--watch active`. The warn now names the error +
indicates `--watch` may be degraded for the remainder of the session.
The JSDoc above `createFileWatcher` is updated to match.

### Site 6: `src/cli/commands/ecs-service-emulator.ts` — `loadAssetContextForTarget` 6+ branches

Each of the 6 distinct `return undefined` branches now emits one
distinct `logger.debug` line naming which condition fired
(`loadAssetContext: stack <name> not in the assembly`,
`loadAssetContext: resolveEcsServiceTarget threw ...`,
`loadAssetContext: task definition ... has no containers`,
`loadAssetContext: ... not a CDK asset (kind='ecr', ...)`,
`loadAssetContext: asset manifest missing for stack ...`,
`loadAssetContext: asset hash '<hash>' not present ...`, and
`loadAssetContext: docker asset ... is executable-mode (no
source.directory)`). Intentionally stays at `debug` — the verdict
defaults to rebuild (safe), so user-visible signal isn't required;
this is for `--verbose` runs.

## Test coverage

Per-site unit tests:

- `tests/unit/local/httpv2-response-parameters-unmatched-key.test.ts`
- `tests/unit/local/sigv4-verify-rejection-paths-info.test.ts`
- `tests/unit/local/websocket-server-connect-deny-info.test.ts`
- `tests/unit/local/front-door-auth-throw-warn.test.ts`
- `tests/unit/local/file-watcher.test.ts` (extended)
- `tests/unit/cli/ecs-service-emulator-load-asset-context.test.ts`
  (extended — branch-distinct debug messages section)

Each asserts:

1. The log emits at `info` / `warn` (NOT `debug`) for sites 1-5;
   site 6 stays at `debug` but with distinct messages per branch.
2. For sites 2 + 4: the user-facing reason / log message includes
   the actionable detail (offending key / exception class / failing
   field).

## Out of scope (per issue)

- The OIDC dev-fallback dedup pattern (#247).
- The `--profile` family fixes (#245).

## Optional follow-up

Site 5 mentions flagging the boot banner as `--watch DEGRADED` after a
chokidar error so the running banner reflects the watcher's actual
state. Not implemented in this PR — the warn line is the
direct contract for the issue, and the banner-degradation signal
would touch the start-api / start-service / start-alb boot paths
across multiple files. Punt to a follow-up if the warn alone proves
insufficient in practice.

## Test plan

- [x] `vp run check` (typecheck + lint + format) — pass
- [x] `vp run build` — pass
- [x] `vp test run` — 135 files, 2014 tests, all passing
