### PR TITLE
fix(cli): fully wire --profile across all STSClient sites + drop the misleading --region deprecation copy

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -42,7 +42,7 @@ Shared across every `cdkl` subcommand (declared in
 | `-a, --app <cmd-or-dir>` | — | CDK app command (e.g. `"node app.ts"`) or path to a pre-synthesized cloud assembly directory (e.g. `"cdk.out"`). Falls back to `CDKL_APP` env or the `app` field in `cdk.json`. |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
 | `-c, --context <key=value...>` | — | Set CDK context values (repeatable). |
-| `--region <region>` | — | **Deprecated.** No effect on local commands; the SDK picks the region from `AWS_REGION` or your AWS profile. Kept for muscle-memory compatibility. |
+| `--region <region>` | — | AWS region for the host-side SDK calls (STS `GetCallerIdentity` for `${AWS::AccountId}` resolution, `AssumeRole` for `--assume-role`, the `--from-cfn-stack` CFn client) and the container's `AWS_REGION` env var. Defaults to `AWS_REGION` / `AWS_DEFAULT_REGION` env, then the synthesized stack region, then the `--profile`'s configured region. |
 
 The `--from-cfn-stack` / `--stack-region` family is described in the
 per-command sections below.

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -296,7 +296,7 @@ A host CLI that ports an individual `cdkl` command verbatim (rather than
 re-exporting the factory) can compose the per-command option block on
 its own Commander instance. Each helper registers only that command's
 NON-common flags; the host still owns the shared `commonOptions` /
-`appOptions` / `contextOptions` / `deprecatedRegionOption` block (or
+`appOptions` / `contextOptions` / `regionOption` block (or
 calls them via its own re-export). Adding or renaming a per-command flag
 in upstream cdk-local propagates to every embedder calling the helper —
 no duplicate `.addOption(...)` block on the host side.

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -4,9 +4,8 @@ import {
   appOptions,
   commonOptions,
   contextOptions,
-  deprecatedRegionOption,
+  regionOption,
   parseContextOptions,
-  warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
@@ -19,6 +18,7 @@ import { resolveApp, resolveWatchConfig } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
 import { createFileWatcher, type FileWatcher } from '../../local/file-watcher.js';
 import { resolveProfileCredentials, createWatchPredicates } from './local-start-api.js';
+import { buildStsClientConfig } from '../../utils/profile-resolver.js';
 import {
   writeProfileCredentialsFile,
   type ProfileCredentialsFile,
@@ -440,8 +440,6 @@ export async function runEcsServiceEmulator(
 ): Promise<void> {
   const logger = getLogger();
   if (options.verbose) logger.setLevel('debug');
-
-  warnIfDeprecatedRegion(options);
 
   // Commander resolves `--no-pull` to `options.pull = false` (the default is
   // true). Compute the "should we skip docker pull?" flag once here.
@@ -1632,11 +1630,15 @@ async function resolveServiceAndRunnerOpts(
           `has no resolvable TaskRoleArn. Pass the ARN explicitly: --assume-task-role <arn>`
       );
     }
-    resolvedRoleArn = await resolvePlaceholderAccount(service.task.taskRoleArn, options.region);
-    assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
+    resolvedRoleArn = await resolvePlaceholderAccount(
+      service.task.taskRoleArn,
+      options.region,
+      options.profile
+    );
+    assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region, options.profile);
   } else if (typeof options.assumeTaskRole === 'string') {
     resolvedRoleArn = options.assumeTaskRole;
-    assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
+    assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region, options.profile);
   }
 
   const envOverrides = readEnvOverridesFile(options.envVars);
@@ -2077,10 +2079,17 @@ function describeForwardTargetForSummary(t: PlannedForwardTarget): string {
   return t.kind === 'lambda' ? `<Lambda: ${t.lambda.logicalId}>` : `<ECS: ${t.serviceTarget}>`;
 }
 
-async function resolvePlaceholderAccount(arn: string, region: string | undefined): Promise<string> {
+async function resolvePlaceholderAccount(
+  arn: string,
+  region: string | undefined,
+  profile: string | undefined
+): Promise<string> {
   if (!arn.includes(TASK_ROLE_ACCOUNT_PLACEHOLDER)) return arn;
   const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }) });
+  // Thread `--profile` so the resolved account is the profile's account
+  // (matching the inline same-stack IAM role resolution under
+  // `--from-cfn-stack --profile <p>`) (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const identity = await sts.send(new GetCallerIdentityCommand({}));
     const account = identity.Account;
@@ -2097,10 +2106,13 @@ async function resolvePlaceholderAccount(arn: string, region: string | undefined
 
 async function assumeTaskRole(
   roleArn: string,
-  region: string | undefined
+  region: string | undefined,
+  profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
   const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }) });
+  // Thread `--profile` so AssumeRole is signed with the profile's
+  // credentials, not the default env-shadowed chain (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const response = await sts.send(
       new AssumeRoleCommand({
@@ -2236,7 +2248,7 @@ async function resolveCallerAccountId(
   profile: string | undefined
 ): Promise<string | undefined> {
   const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }), ...(profile && { profile }) });
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const identity = await sts.send(new GetCallerIdentityCommand({}));
     return identity.Account;
@@ -2622,7 +2634,7 @@ export function addCommonEcsServiceOptions(cmd: Command): Command {
     );
 
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
-  cmd.addOption(deprecatedRegionOption);
+  cmd.addOption(regionOption);
   return cmd;
 }
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -566,7 +566,11 @@ export async function runEcsServiceEmulator(
   );
 
   try {
-    await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
+    await applyRoleArnIfSet({
+      roleArn: options.roleArn,
+      region: options.region,
+      profile: options.profile,
+    });
     await ensureDockerAvailable();
 
     const appCmd = resolveApp(options.app);

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -275,7 +275,11 @@ async function localInvokeAgentCoreCommand(
   );
 
   try {
-    await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
+    await applyRoleArnIfSet({
+      roleArn: options.roleArn,
+      region: options.region,
+      profile: options.profile,
+    });
     await ensureDockerAvailable();
 
     const profileCredentials = options.profile

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -6,9 +6,8 @@ import {
   appOptions,
   commonOptions,
   contextOptions,
-  deprecatedRegionOption,
+  regionOption,
   parseContextOptions,
-  warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
@@ -93,6 +92,7 @@ import {
 import type { FileAsset } from '../../types/assets.js';
 import { singleFlight } from '../../utils/single-flight.js';
 import { resolveProfileCredentials } from './local-start-api.js';
+import { buildStsClientConfig } from '../../utils/profile-resolver.js';
 import {
   applyProfileCredentialsOverlay,
   resolveExecutionRoleArnFromState,
@@ -221,8 +221,6 @@ async function localInvokeAgentCoreCommand(
 ): Promise<void> {
   const logger = getLogger();
   if (options.verbose) logger.setLevel('debug');
-
-  warnIfDeprecatedRegion(options);
 
   let containerId: string | undefined;
   let stopLogs: (() => void) | undefined;
@@ -694,7 +692,7 @@ async function resolveHostCredentialsForSigV4(
   const assumeRoleArn = await resolveAssumeRoleArn(options, resolved, loaded, stateProvider);
   if (assumeRoleArn) {
     try {
-      return await assumeAgentCoreExecutionRole(assumeRoleArn, region);
+      return await assumeAgentCoreExecutionRole(assumeRoleArn, region, options.profile);
     } catch (err) {
       logger.warn(
         `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for --sigv4 signing: ` +
@@ -924,7 +922,7 @@ async function resolveAgentCoreCodeImageFromS3(
     | undefined;
   if (assumeRoleArn) {
     try {
-      credentials = await assumeAgentCoreExecutionRole(assumeRoleArn, region);
+      credentials = await assumeAgentCoreExecutionRole(assumeRoleArn, region, options.profile);
     } catch (err) {
       logger.warn(
         `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for the fromS3 bundle download: ` +
@@ -1044,6 +1042,7 @@ export async function buildContainerEnv(
   await applyAgentCoreCredentialEnv(dockerEnv, {
     ...(assumeRoleArn !== undefined && { assumeRoleArn }),
     ...(options.region !== undefined && { region: options.region }),
+    ...(options.profile !== undefined && { profile: options.profile }),
     ...(profileCredentials !== undefined && { profileCredentials }),
     ...(profileCredsFile !== undefined && {
       profileCredsFile: {
@@ -1188,7 +1187,7 @@ async function resolveCallerAccountId(
   profile: string | undefined
 ): Promise<string | undefined> {
   const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }), ...(profile && { profile }) });
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const identity = await sts.send(new GetCallerIdentityCommand({}));
     return identity.Account;
@@ -1213,6 +1212,7 @@ export async function applyAgentCoreCredentialEnv(
   args: {
     assumeRoleArn?: string;
     region?: string;
+    profile?: string;
     profileCredentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
     profileCredsFile?: { containerPath: string; profileName: string };
   }
@@ -1222,7 +1222,7 @@ export async function applyAgentCoreCredentialEnv(
   if (args.assumeRoleArn) {
     const stsRegion = args.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'];
     try {
-      const creds = await assumeAgentCoreExecutionRole(args.assumeRoleArn, stsRegion);
+      const creds = await assumeAgentCoreExecutionRole(args.assumeRoleArn, stsRegion, args.profile);
       dockerEnv['AWS_ACCESS_KEY_ID'] = creds.accessKeyId;
       dockerEnv['AWS_SECRET_ACCESS_KEY'] = creds.secretAccessKey;
       dockerEnv['AWS_SESSION_TOKEN'] = creds.sessionToken;
@@ -1427,10 +1427,13 @@ function forwardAwsEnv(env: Record<string, string>): void {
 
 async function assumeAgentCoreExecutionRole(
   roleArn: string,
-  region: string | undefined
+  region: string | undefined,
+  profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
   const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }) });
+  // Thread `--profile` so AssumeRole is signed with the profile's
+  // credentials, not the default env-shadowed chain (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const response = await sts.send(
       new AssumeRoleCommand({
@@ -1568,7 +1571,7 @@ export function createLocalInvokeAgentCoreCommand(
 
   addInvokeAgentCoreSpecificOptions(cmd);
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
-  cmd.addOption(deprecatedRegionOption);
+  cmd.addOption(regionOption);
   return cmd;
 }
 

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -7,10 +7,11 @@ import {
   appOptions,
   commonOptions,
   contextOptions,
-  deprecatedRegionOption,
+  regionOption,
   parseContextOptions,
-  warnIfDeprecatedRegion,
 } from '../options.js';
+import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
+import { resolveContainerFallbackRegion } from './local-start-api.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
@@ -161,8 +162,6 @@ async function localInvokeCommand(
   if (options.verbose) {
     logger.setLevel('debug');
   }
-
-  warnIfDeprecatedRegion(options);
 
   let imagePlan: ImagePlan | undefined;
   let containerId: string | undefined;
@@ -469,7 +468,11 @@ async function localInvokeCommand(
       const stsRegion =
         options.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'];
       try {
-        const creds = await assumeLambdaExecutionRole(resolvedAssumeRoleArn, stsRegion);
+        const creds = await assumeLambdaExecutionRole(
+          resolvedAssumeRoleArn,
+          stsRegion,
+          options.profile
+        );
         dockerEnv['AWS_ACCESS_KEY_ID'] = creds.accessKeyId;
         dockerEnv['AWS_SECRET_ACCESS_KEY'] = creds.secretAccessKey;
         dockerEnv['AWS_SESSION_TOKEN'] = creds.sessionToken;
@@ -495,6 +498,21 @@ async function localInvokeCommand(
         dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
         dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
       }
+    }
+    // Seed the container's `AWS_REGION` fallback so handler ambient-region
+    // SDK calls (`new XxxClient({})`) reach the same region the deployed
+    // function would. Precedence mirrors `start-api` via
+    // `resolveContainerFallbackRegion`:
+    //   1. `--region` / `AWS_REGION` / `AWS_DEFAULT_REGION` (forwarded above)
+    //   2. the synth-derived stack region (`env.region` on the CDK stack)
+    //   3. the `--profile`'s configured region (new in #245)
+    if (!dockerEnv['AWS_REGION'] && !dockerEnv['AWS_DEFAULT_REGION']) {
+      const fallbackRegion = resolveContainerFallbackRegion({
+        stackRegionOverride: options.region,
+        synthRegion: lambda.stack.region,
+        profileRegion: profileCredentials?.region,
+      });
+      if (fallbackRegion) dockerEnv['AWS_REGION'] = fallbackRegion;
     }
 
     let debugPort: number | undefined;
@@ -817,7 +835,9 @@ async function resolvePseudoParametersForInvoke(
   let accountId: string | undefined;
   try {
     const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
-    const sts = new STSClient({ ...(region && { region }) });
+    // Thread `--profile` so the resolved account is the profile's account,
+    // not whatever the default credential chain points at (issue #245).
+    const sts = new STSClient(buildStsClientConfig({ region, profile: options.profile }));
     try {
       const identity = await sts.send(new GetCallerIdentityCommand({}));
       accountId = identity.Account;
@@ -923,10 +943,14 @@ async function readStdin(): Promise<string> {
 
 async function assumeLambdaExecutionRole(
   roleArn: string,
-  region: string | undefined
+  region: string | undefined,
+  profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
   const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }) });
+  // Thread `--profile` so the AssumeRole call is signed with the profile's
+  // credentials (matching `aws sts assume-role --profile <p>`), not the
+  // default env-shadowed chain (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const response = await sts.send(
       new AssumeRoleCommand({
@@ -960,36 +984,6 @@ function forwardAwsEnv(env: Record<string, string>): void {
   for (const key of passThrough) {
     const value = process.env[key];
     if (value !== undefined) env[key] = value;
-  }
-}
-
-/**
- * Resolve `--profile <p>` to a concrete credential set. Mirrors the
- * helper in `local-start-api.ts`.
- */
-async function resolveProfileCredentials(
-  profile: string
-): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }> {
-  const { STSClient } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ profile });
-  try {
-    const credsProvider = sts.config.credentials;
-    const creds = typeof credsProvider === 'function' ? await credsProvider() : credsProvider;
-    if (!creds || !creds.accessKeyId || !creds.secretAccessKey) {
-      throw new Error(
-        `--profile '${profile}': credential provider chain resolved without usable credentials. ` +
-          'Check `aws sso login --profile ' +
-          profile +
-          '` for SSO profiles, or `~/.aws/credentials` / `~/.aws/config` for regular profiles.'
-      );
-    }
-    return {
-      accessKeyId: creds.accessKeyId,
-      secretAccessKey: creds.secretAccessKey,
-      ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
-    };
-  } finally {
-    sts.destroy();
   }
 }
 
@@ -1158,7 +1152,7 @@ export function createLocalInvokeCommand(opts: CreateLocalInvokeCommandOptions =
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((option) =>
     invoke.addOption(option)
   );
-  invoke.addOption(deprecatedRegionOption);
+  invoke.addOption(regionOption);
 
   return invoke;
 }

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -249,7 +249,11 @@ async function localInvokeCommand(
   );
 
   try {
-    await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
+    await applyRoleArnIfSet({
+      roleArn: options.roleArn,
+      region: options.region,
+      profile: options.profile,
+    });
 
     await ensureDockerAvailable();
 

--- a/src/cli/commands/local-list.ts
+++ b/src/cli/commands/local-list.ts
@@ -47,7 +47,11 @@ async function localListCommand(options: LocalListOptions): Promise<void> {
   const logger = getLogger();
   if (options.verbose) logger.setLevel('debug');
 
-  await applyRoleArnIfSet({ roleArn: options.roleArn, region: undefined });
+  await applyRoleArnIfSet({
+    roleArn: options.roleArn,
+    region: undefined,
+    profile: options.profile,
+  });
 
   const appCmd = resolveApp(options.app);
   if (!appCmd) {

--- a/src/cli/commands/local-list.ts
+++ b/src/cli/commands/local-list.ts
@@ -3,9 +3,8 @@ import {
   appOptions,
   commonOptions,
   contextOptions,
-  deprecatedRegionOption,
+  regionOption,
   parseContextOptions,
-  warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
@@ -47,8 +46,6 @@ export interface CreateLocalListCommandOptions {
 async function localListCommand(options: LocalListOptions): Promise<void> {
   const logger = getLogger();
   if (options.verbose) logger.setLevel('debug');
-
-  warnIfDeprecatedRegion(options);
 
   await applyRoleArnIfSet({ roleArn: options.roleArn, region: undefined });
 
@@ -194,7 +191,7 @@ export function createLocalListCommand(opts: CreateLocalListCommandOptions = {})
 
   addListSpecificOptions(cmd);
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
-  cmd.addOption(deprecatedRegionOption);
+  cmd.addOption(regionOption);
   return cmd;
 }
 

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -4,9 +4,8 @@ import {
   appOptions,
   commonOptions,
   contextOptions,
-  deprecatedRegionOption,
+  regionOption,
   parseContextOptions,
-  warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
@@ -17,6 +16,7 @@ import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
 import { resolveProfileCredentials } from './local-start-api.js';
+import { buildStsClientConfig } from '../../utils/profile-resolver.js';
 import {
   writeProfileCredentialsFile,
   type ProfileCredentialsFile,
@@ -126,8 +126,6 @@ async function localRunTaskCommand(
 ): Promise<void> {
   const logger = getLogger();
   if (options.verbose) logger.setLevel('debug');
-
-  warnIfDeprecatedRegion(options);
 
   const state: EcsRunState = createEcsRunState();
   let sigintHandler: (() => void) | undefined;
@@ -302,11 +300,15 @@ async function localRunTaskCommand(
             `Pass the ARN explicitly: --assume-task-role <arn>`
         );
       }
-      resolvedRoleArn = await resolvePlaceholderAccount(task.taskRoleArn, options.region);
-      assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
+      resolvedRoleArn = await resolvePlaceholderAccount(
+        task.taskRoleArn,
+        options.region,
+        options.profile
+      );
+      assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region, options.profile);
     } else if (typeof options.assumeTaskRole === 'string') {
       resolvedRoleArn = options.assumeTaskRole;
-      assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
+      assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region, options.profile);
     }
 
     // When `--assume-task-role` is NOT effective but `--profile <p>` IS
@@ -401,10 +403,17 @@ async function localRunTaskCommand(
  * resolver for inline same-stack IAM Roles, substitute the live caller
  * account via STS `GetCallerIdentity`. Otherwise pass through unchanged.
  */
-async function resolvePlaceholderAccount(arn: string, region: string | undefined): Promise<string> {
+async function resolvePlaceholderAccount(
+  arn: string,
+  region: string | undefined,
+  profile: string | undefined
+): Promise<string> {
   if (!arn.includes(TASK_ROLE_ACCOUNT_PLACEHOLDER)) return arn;
   const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }) });
+  // Thread `--profile` so the resolved account is the profile's account
+  // (matching the inline same-stack IAM role resolution under
+  // `--from-cfn-stack --profile <p>`) (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const identity = await sts.send(new GetCallerIdentityCommand({}));
     const account = identity.Account;
@@ -425,10 +434,13 @@ async function resolvePlaceholderAccount(arn: string, region: string | undefined
  */
 async function assumeTaskRole(
   roleArn: string,
-  region: string | undefined
+  region: string | undefined,
+  profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
   const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }) });
+  // Thread `--profile` so AssumeRole is signed with the profile's
+  // credentials, not the default env-shadowed chain (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const response = await sts.send(
       new AssumeRoleCommand({
@@ -576,7 +588,7 @@ async function resolveCallerAccountId(
   // the default credential chain points at. Without this, the
   // `${AWS::AccountId}` substitution that builds same-stack ECR image
   // URIs picks the wrong account and the subsequent `docker pull` 404s.
-  const sts = new STSClient({ ...(region && { region }), ...(profile && { profile }) });
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const identity = await sts.send(new GetCallerIdentityCommand({}));
     return identity.Account;
@@ -668,7 +680,7 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
 
   addRunTaskSpecificOptions(cmd);
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
-  cmd.addOption(deprecatedRegionOption);
+  cmd.addOption(regionOption);
   return cmd;
 }
 

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -172,7 +172,11 @@ async function localRunTaskCommand(
   };
 
   try {
-    await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
+    await applyRoleArnIfSet({
+      roleArn: options.roleArn,
+      region: options.region,
+      profile: options.profile,
+    });
     await ensureDockerAvailable();
 
     const appCmd = resolveApp(options.app);

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -325,7 +325,11 @@ async function localStartApiCommand(
     );
   }
 
-  await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
+  await applyRoleArnIfSet({
+    roleArn: options.roleArn,
+    region: options.region,
+    profile: options.profile,
+  });
 
   await ensureDockerAvailable();
 

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -6,13 +6,13 @@ import {
   appOptions,
   commonOptions,
   contextOptions,
-  deprecatedRegionOption,
+  regionOption,
   parseContextOptions,
   parseAssumeRoleToken,
   effectiveAssumeRoleArn,
   type AssumeRoleOption,
-  warnIfDeprecatedRegion,
 } from '../options.js';
+import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
@@ -325,7 +325,6 @@ async function localStartApiCommand(
     );
   }
 
-  warnIfDeprecatedRegion(options);
   await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
 
   await ensureDockerAvailable();
@@ -1928,6 +1927,7 @@ async function buildContainerSpec(args: {
     layerTmpDirs,
     stateByStack,
     skipPull,
+    profile,
     layerRoleArn,
     profileCredentials,
     profileCredsFile,
@@ -2070,7 +2070,7 @@ async function buildContainerSpec(args: {
 
   const roleArn = effectiveAssumeRoleArn(logicalId, assumeRole);
   if (roleArn) {
-    const creds = await assumeLambdaExecutionRole(roleArn, stsRegion);
+    const creds = await assumeLambdaExecutionRole(roleArn, stsRegion, profile);
     dockerEnv['AWS_ACCESS_KEY_ID'] = creds.accessKeyId;
     dockerEnv['AWS_SECRET_ACCESS_KEY'] = creds.secretAccessKey;
     dockerEnv['AWS_SESSION_TOKEN'] = creds.sessionToken;
@@ -2847,89 +2847,15 @@ function forwardAwsEnv(env: Record<string, string>): void {
 }
 
 /**
- * Issue #654: resolve `--profile <p>` to a concrete credential set
- * for forwarding to Lambda containers.
- *
- * The dev's AWS credentials may live in any of:
- *   - `~/.aws/sso/cache/*.json` (AWS IAM Identity Center / legacy SSO)
- *   - `~/.aws/credentials` (regular long-lived access keys)
- *   - `~/.aws/config` profiles with `role_arn` + `source_profile` (chained AssumeRole)
- *   - `credential_process` external resolvers
- *
- * `forwardAwsEnv` only reads `process.env.AWS_*`, which is empty for
- * every shape except "user manually exported the env vars". The
- * Lambda container therefore boots without creds and the handler's
- * AWS SDK call fails with `Could not load credentials from any providers`.
- *
- * This helper constructs a transient `STSClient({ profile })` to drive
- * the SDK's default credential provider chain — same code path the
- * host's own AWS SDK clients use when `--profile` is set, so SSO / IAM
- * Identity Center / role-assumption profiles all resolve the same way
- * they already do for the host's outbound calls. We then extract the
- * resolved `AwsCredentialIdentity` via `sts.config.credentials()` and
- * return the underlying `{ accessKeyId, secretAccessKey, sessionToken? }`
- * for env-var injection.
- *
- * Called ONCE at server boot; the resolved creds are reused for every
- * Lambda container's env overlay (when `--assume-role` is not set for
- * that Lambda — assume-role wins per the existing precedence). SSO
- * temp creds typically last 1h+, so a single resolve is fine for the
- * common dev session; long-running `--watch` sessions that outlive
- * the creds need a cdk-local restart (deferred refresh out of scope for
- * v1, see issue #654).
- *
- * Also resolves the profile's configured `region` (from `~/.aws/config`'s
- * `region = ...` for this profile) off the same client config. The
- * synthesized credentials file we mount into the container carries only
- * the credential triple — no `region =` — so without this the container
- * boots with creds but no region, and a handler's ambient-region SDK call
- * (`new XxxClient({})`) fails with "Region is missing". The caller seeds
- * the container's `AWS_REGION` fallback with it (see
- * {@link resolveContainerFallbackRegion}). Region resolution is
- * best-effort: a profile with no region (or any resolution failure)
- * yields `region: undefined` rather than throwing — a missing region is
- * not a missing-credentials error.
+ * Re-export the shared `resolveProfileCredentials` helper that drives
+ * `--profile` resolution for every `cdkl` subcommand (see
+ * `src/utils/profile-resolver.ts` for the helper). Kept as a re-export
+ * here so existing importers (cdkd, in-repo callers) keep working
+ * without a path migration — the helper itself lives in `src/utils/`
+ * so it is reachable from every command without an awkward cross-
+ * command import (issue #245).
  */
-export async function resolveProfileCredentials(profile: string): Promise<{
-  accessKeyId: string;
-  secretAccessKey: string;
-  sessionToken?: string;
-  region?: string;
-}> {
-  const { STSClient } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ profile });
-  try {
-    const credsProvider = sts.config.credentials;
-    const creds = typeof credsProvider === 'function' ? await credsProvider() : credsProvider;
-    if (!creds || !creds.accessKeyId || !creds.secretAccessKey) {
-      throw new Error(
-        `--profile '${profile}': credential provider chain resolved without usable credentials. ` +
-          'Check `aws sso login --profile ' +
-          profile +
-          '` for SSO profiles, or `~/.aws/credentials` / `~/.aws/config` for regular profiles.'
-      );
-    }
-    let region: string | undefined;
-    try {
-      const regionProvider = sts.config.region;
-      const resolved =
-        typeof regionProvider === 'function' ? await regionProvider() : regionProvider;
-      if (typeof resolved === 'string' && resolved.length > 0) region = resolved;
-    } catch {
-      // Profile has no region configured (and no AWS_REGION env) — leave
-      // undefined; the container falls through to the next region source.
-      region = undefined;
-    }
-    return {
-      accessKeyId: creds.accessKeyId,
-      secretAccessKey: creds.secretAccessKey,
-      ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
-      ...(region && { region }),
-    };
-  } finally {
-    sts.destroy();
-  }
-}
+export { resolveProfileCredentials };
 
 /**
  * Resolve the fallback `AWS_REGION` for a Lambda container when neither
@@ -2970,10 +2896,13 @@ export function resolveContainerFallbackRegion(args: {
  */
 async function assumeLambdaExecutionRole(
   roleArn: string,
-  region: string | undefined
+  region: string | undefined,
+  profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
   const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  const sts = new STSClient({ ...(region && { region }) });
+  // Thread `--profile` so AssumeRole is signed with the profile's
+  // credentials, not the default env-shadowed chain (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region, profile }));
   try {
     const response = await sts.send(
       new AssumeRoleCommand({
@@ -3513,7 +3442,9 @@ async function resolvePseudoParametersForStartApi(
   let accountId: string | undefined;
   try {
     const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
-    const sts = new STSClient({ ...(region && { region }) });
+    // Thread `--profile` so the resolved account is the profile's account,
+    // not whatever the default credential chain points at (issue #245).
+    const sts = new STSClient(buildStsClientConfig({ region, profile: options.profile }));
     try {
       const identity = await sts.send(new GetCallerIdentityCommand({}));
       accountId = identity.Account;
@@ -3617,7 +3548,7 @@ export function createLocalStartApiCommand(opts: CreateLocalStartApiCommandOptio
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) =>
     startApi.addOption(opt)
   );
-  startApi.addOption(deprecatedRegionOption);
+  startApi.addOption(regionOption);
 
   return startApi;
 }

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -22,9 +22,9 @@ export function parseContextOptions(contextArgs?: string[]): Record<string, stri
  * module-level const) so the `--role-arn` env-var hint reflects the active
  * embed config, which the command factory installs before calling this.
  *
- * `--region` is intentionally NOT in `commonOptions` — local commands
- * pick the region from `AWS_REGION` / profile / synthesized stack env.
- * The deprecated flag below remains for muscle-memory compatibility.
+ * `--region` is intentionally NOT in `commonOptions` — it is registered
+ * separately via {@link regionOption} so a host CLI (cdkd) can swap the
+ * shared option block once without losing the `--region` flag.
  */
 export function commonOptions(): Option[] {
   const { envPrefix } = getEmbedConfig();
@@ -43,29 +43,32 @@ export function commonOptions(): Option[] {
 }
 
 /**
- * Deprecated `--region` option attached to every command.
+ * `--region` option attached to every command. The value drives both
+ * host-side AWS SDK calls (STS `GetCallerIdentity` for
+ * `${AWS::AccountId}` resolution, `AssumeRole` for `--assume-role`, etc.)
+ * and the container's `AWS_REGION` env var. When omitted, region
+ * precedence falls back to `AWS_REGION` / `AWS_DEFAULT_REGION` env,
+ * then the synthesized stack region, then the `--profile`'s configured
+ * region — same shape as the AWS CLI's `--region` flag (issue #245).
  *
- * Kept (rather than fully removed) so that scripts or muscle memory
- * passing `--region` do not break. The value is parsed but ignored;
- * the SDK picks the region from `AWS_REGION` / profile / synthesized
- * stack env.
+ * Kept as a standalone export rather than baked into `commonOptions`
+ * so a host CLI (cdkd) can swap the shared option block once without
+ * losing this flag.
  */
-export const deprecatedRegionOption = new Option(
+export const regionOption = new Option(
   '--region <region>',
-  '[deprecated] No effect on this command; use AWS_REGION or your AWS profile'
-).hideHelp();
+  'AWS region for SDK calls; defaults to AWS_REGION env, the synthesized stack region, or the resolved profile region'
+);
 
 /**
- * Emit a one-shot stderr warning when a command receives `--region`.
+ * Backward-compat alias for the previous `deprecatedRegionOption` export.
+ * `--region` is no longer deprecated (issue #245) but external callers
+ * (including cdkd) may still import the old name. Slated for removal
+ * once those callers migrate to {@link regionOption}.
+ *
+ * @deprecated Use {@link regionOption}.
  */
-export function warnIfDeprecatedRegion(options: { region?: string }): void {
-  if (options.region !== undefined) {
-    process.stderr.write(
-      'Warning: --region is deprecated for this command and has no effect. ' +
-        'Use the AWS_REGION environment variable or your AWS profile to override the SDK default region.\n'
-    );
-  }
-}
+export const deprecatedRegionOption = regionOption;
 
 /**
  * App options. Built per-call (not a module-level const) so the `--app`

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -608,7 +608,7 @@ export {
  * per-command flag the upstream cdk-local CLI adds, without a manual
  * `.addOption(...)` duplication on the host side. Each helper sits ON TOP
  * of the shared `commonOptions` / `appOptions` / `contextOptions` /
- * `deprecatedRegionOption` block (which the matching `create<Cmd>Command`
+ * `regionOption` block (which the matching `create<Cmd>Command`
  * factory still composes around the helper). Mirrors the shape of
  * {@link addAlbSpecificOptions}.
  *
@@ -637,3 +637,16 @@ export {
   addStartServiceSpecificOptions,
   serviceStrategy,
 } from './cli/commands/local-start-service.js';
+
+/**
+ * Shared `--profile` plumbing helpers (issue #245). Every STS-touching
+ * call site across `cdkl` commands now goes through these two helpers
+ * so a host CLI (e.g. cdkd) wrapping the same factories inherits the
+ * same `--profile` precedence — both for credentials AND region —
+ * without having to re-implement it. `resolveProfileCredentials`
+ * returns the credential triple + the profile's configured region;
+ * `buildStsClientConfig` returns the `STSClient` constructor config
+ * that omits empty `region` / `profile` fields, matching the inline
+ * `{ ...(region && { region }) }` shape callers used to write by hand.
+ */
+export { resolveProfileCredentials, buildStsClientConfig } from './utils/profile-resolver.js';

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -7,6 +7,7 @@ import {
 } from '../utils/docker-cmd.js';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
 import { getLogger } from '../utils/logger.js';
+import { buildStsClientConfig } from '../utils/profile-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
 
 /**
@@ -202,10 +203,9 @@ export async function pullEcrImage(imageUri: string, options: EcrPullOptions): P
   const callerIdentityKey = `${options.profile ?? '_noprofile'}|${callerRegion ?? '_unset'}`;
   let callerAccount = CALLER_IDENTITY_CACHE.get(callerIdentityKey);
   if (callerAccount === undefined) {
-    const sts = new STSClient({
-      ...(callerRegion && { region: callerRegion }),
-      ...(options.profile && { profile: options.profile }),
-    });
+    const sts = new STSClient(
+      buildStsClientConfig({ region: callerRegion, profile: options.profile })
+    );
     try {
       const identity = await sts.send(new GetCallerIdentityCommand({}));
       if (!identity.Account) {
@@ -304,10 +304,7 @@ async function assumeRoleForEcr(
   logger.debug(`Assuming role ${roleArn} for ECR pull...`);
   // Thread `--profile` so the AssumeRole source identity is the profile's,
   // matching the rest of the pull path.
-  const sts = new STSClient({
-    ...(callerRegion && { region: callerRegion }),
-    ...(profile && { profile }),
-  });
+  const sts = new STSClient(buildStsClientConfig({ region: callerRegion, profile }));
   try {
     const response = await sts.send(
       new AssumeRoleCommand({

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -247,6 +247,11 @@ async function defaultLambdaClientFactory(): Promise<
 
 async function defaultStsClientFactory(): Promise<(region: string) => StsSendClient> {
   const { STSClient } = await import('@aws-sdk/client-sts');
+  // sts-audit: ignore: this is a region-only factory whose call chain
+  // does not yet receive `--profile` (issue #448's --layer-role-arn flow
+  // assumes default-credential-chain access to the layer's account);
+  // when --profile threading is extended to layer materialization, this
+  // becomes a `buildStsClientConfig({ region, profile })` call.
   return (region) => new STSClient({ region });
 }
 

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -107,6 +107,10 @@ export function defaultCredentialsLoader(): CredentialsLoader {
     if (cached) return cached;
     cached = (async (): Promise<ResolvedCredentials> => {
       const { STSClient } = await import('@aws-sdk/client-sts');
+      // sts-audit: ignore: the SigV4 inbound verifier resolves the host's
+      // default credentials for ambient request signing. `--profile`
+      // threading into this loader is a separate follow-up — the path is
+      // host-side / pre-container and does not affect Lambda env injection.
       const client = new STSClient({});
       // STSClient typings (AWS SDK v3) expose `config.credentials` as a
       // memoized provider function; invoke it to resolve the dev's local

--- a/src/utils/profile-resolver.ts
+++ b/src/utils/profile-resolver.ts
@@ -1,0 +1,85 @@
+import { STSClient } from '@aws-sdk/client-sts';
+
+/**
+ * Resolve `--profile <p>` to a concrete credential set AND the profile's
+ * configured region. Shared across every `cdkl` subcommand
+ * (`invoke` / `start-api` / `run-task` / `start-service` / `start-alb` /
+ * `invoke-agentcore`) so the credential-resolution behavior is byte-for-byte
+ * uniform — previously the per-command resolvers drifted (issue #245: the
+ * `invoke` copy returned the credential triple only, leaking the profile's
+ * `region` and forcing handlers' ambient-region SDK calls to fail with
+ * "Region is missing" locally).
+ *
+ * Drives the SDK's default credential provider chain (SSO / IAM Identity
+ * Center / `fromIni` / role-assumption profiles all handled uniformly —
+ * the same chain that resolves `--profile` for the host's own AWS SDK
+ * clients).
+ *
+ * Region resolution is best-effort: a profile with no `region =` (and no
+ * `AWS_REGION` / `AWS_DEFAULT_REGION` env) yields `region: undefined`
+ * rather than throwing — a missing region is not a missing-credentials
+ * error. The caller layers this region behind other sources via
+ * `resolveContainerFallbackRegion`.
+ */
+export async function resolveProfileCredentials(profile: string): Promise<{
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  region?: string;
+}> {
+  const sts = new STSClient({ profile });
+  try {
+    const credsProvider = sts.config.credentials;
+    const creds = typeof credsProvider === 'function' ? await credsProvider() : credsProvider;
+    if (!creds || !creds.accessKeyId || !creds.secretAccessKey) {
+      throw new Error(
+        `--profile '${profile}': credential provider chain resolved without usable credentials. ` +
+          'Check `aws sso login --profile ' +
+          profile +
+          '` for SSO profiles, or `~/.aws/credentials` / `~/.aws/config` for regular profiles.'
+      );
+    }
+    let region: string | undefined;
+    try {
+      const regionProvider = sts.config.region;
+      const resolved =
+        typeof regionProvider === 'function' ? await regionProvider() : regionProvider;
+      if (typeof resolved === 'string' && resolved.length > 0) region = resolved;
+    } catch {
+      // Profile has no region configured (and no AWS_REGION env) — leave
+      // undefined; the container falls through to the next region source.
+      region = undefined;
+    }
+    return {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
+      ...(region && { region }),
+    };
+  } finally {
+    sts.destroy();
+  }
+}
+
+/**
+ * Build the constructor config for an `STSClient` that honors both
+ * `--region` and `--profile`. Every STS-touching site in the codebase
+ * (`GetCallerIdentity` for `${AWS::AccountId}` resolution, `AssumeRole`
+ * for `--assume-role`, etc.) must use this helper so a future site can
+ * never silently drop the `--profile` plumbing — the historical pattern
+ * `new STSClient({ ...(region && { region }) })` ignored `--profile`,
+ * which is exactly the issue #245 relapse-prone shape.
+ *
+ * Returns a fresh object each call so callers can spread additional
+ * fields (custom `requestHandler`, `maxAttempts`, etc.) without
+ * mutating a shared default.
+ */
+export function buildStsClientConfig(args: {
+  region?: string | undefined;
+  profile?: string | undefined;
+}): { region?: string; profile?: string } {
+  return {
+    ...(args.region && { region: args.region }),
+    ...(args.profile && { profile: args.profile }),
+  };
+}

--- a/src/utils/profile-resolver.ts
+++ b/src/utils/profile-resolver.ts
@@ -45,9 +45,21 @@ export async function resolveProfileCredentials(profile: string): Promise<{
       const resolved =
         typeof regionProvider === 'function' ? await regionProvider() : regionProvider;
       if (typeof resolved === 'string' && resolved.length > 0) region = resolved;
-    } catch {
+    } catch (err) {
       // Profile has no region configured (and no AWS_REGION env) — leave
       // undefined; the container falls through to the next region source.
+      //
+      // BUT: don't swallow real auth / IMDS errors (SSO token expiry,
+      // ConfigurationError, NetworkingError) under this no-region
+      // umbrella. Those should propagate so the caller sees the actual
+      // problem instead of a misleading fall-through to "no region".
+      const msg = err instanceof Error ? err.message : String(err);
+      const isMissingRegionError =
+        /region is missing/i.test(msg) ||
+        /could not resolve region/i.test(msg) ||
+        /no region in config/i.test(msg) ||
+        /region.*not.*set/i.test(msg);
+      if (!isMissingRegionError) throw err;
       region = undefined;
     }
     return {

--- a/src/utils/role-arn.ts
+++ b/src/utils/role-arn.ts
@@ -1,6 +1,7 @@
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { getLogger } from './logger.js';
 import { getEmbedConfig } from '../local/embed-config.js';
+import { buildStsClientConfig } from './profile-resolver.js';
 
 /**
  * Resolve the role-arn argument (CLI flag or `CDKL_ROLE_ARN` env var) and,
@@ -16,11 +17,21 @@ import { getEmbedConfig } from '../local/embed-config.js';
  * entry makes every later `new XxxClient()` pick up the assumed-role
  * credentials automatically without touching the client construction sites.
  *
+ * `profile` is threaded into the STSClient construction (via
+ * {@link buildStsClientConfig}) so `--profile <p> --role-arn <arn>` runs
+ * AssumeRole through the named profile's credential chain rather than
+ * the default chain — this was the second-relapse vector closed by
+ * issue #245 (every STSClient site under `src/cli/**` + `src/local/**`
+ * is audited, but `src/utils/role-arn.ts` was outside the audit scope's
+ * first cut; this caller-side threading + the widened audit scope in
+ * `tests/unit/cli/sts-client-profile-audit.test.ts` keep them in sync).
+ *
  * Default session duration is 1 hour.
  */
 export async function applyRoleArnIfSet(opts: {
   roleArn: string | undefined;
   region: string | undefined;
+  profile: string | undefined;
 }): Promise<void> {
   const roleArn = opts.roleArn || process.env[`${getEmbedConfig().envPrefix}_ROLE_ARN`];
   if (!roleArn) return;
@@ -28,7 +39,7 @@ export async function applyRoleArnIfSet(opts: {
   const logger = getLogger().child('role-arn');
   logger.debug(`Assuming role ${roleArn}...`);
 
-  const sts = new STSClient({ ...(opts.region && { region: opts.region }) });
+  const sts = new STSClient(buildStsClientConfig({ region: opts.region, profile: opts.profile }));
   try {
     const response = await sts.send(
       new AssumeRoleCommand({

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -4,7 +4,7 @@ import {
   appOptions,
   commonOptions,
   contextOptions,
-  deprecatedRegionOption,
+  regionOption,
 } from '../../../src/cli/options.js';
 import {
   addListSpecificOptions,
@@ -41,16 +41,16 @@ function longFlagsOf(cmd: Command): string[] {
 
 /**
  * Long-flag set of the shared `commonOptions` / `appOptions` /
- * `contextOptions` / `deprecatedRegionOption` block every per-command
+ * `contextOptions` / `regionOption` block every per-command
  * `create<Cmd>Command` factory composes around its `add<Cmd>SpecificOptions`
  * helper. Built fresh per call so the helpers' inner per-call freshness
  * (e.g. `commonOptions()` rebuilds with the active embed config) is
  * preserved.
  */
-function commonAppContextDeprecatedFlags(): string[] {
+function commonAppContextRegionFlags(): string[] {
   const cmd = new Command();
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
-  cmd.addOption(deprecatedRegionOption);
+  cmd.addOption(regionOption);
   return longFlagsOf(cmd);
 }
 
@@ -84,7 +84,7 @@ describe('list option surface contract (addListSpecificOptions)', () => {
     const full = longFlagsOf(createLocalListCommand());
     const expected = Array.from(
       new Set([
-        ...commonAppContextDeprecatedFlags(),
+        ...commonAppContextRegionFlags(),
         ...longFlagsOf(addListSpecificOptions(new Command())),
       ])
     ).sort();
@@ -115,7 +115,7 @@ describe('run-task option surface contract (addRunTaskSpecificOptions)', () => {
     const full = longFlagsOf(createLocalRunTaskCommand());
     const expected = Array.from(
       new Set([
-        ...commonAppContextDeprecatedFlags(),
+        ...commonAppContextRegionFlags(),
         ...longFlagsOf(addRunTaskSpecificOptions(new Command())),
       ])
     ).sort();
@@ -146,7 +146,7 @@ describe('invoke option surface contract (addInvokeSpecificOptions)', () => {
     const full = longFlagsOf(createLocalInvokeCommand());
     const expected = Array.from(
       new Set([
-        ...commonAppContextDeprecatedFlags(),
+        ...commonAppContextRegionFlags(),
         ...longFlagsOf(addInvokeSpecificOptions(new Command())),
       ])
     ).sort();
@@ -183,7 +183,7 @@ describe('invoke-agentcore option surface contract (addInvokeAgentCoreSpecificOp
     const full = longFlagsOf(createLocalInvokeAgentCoreCommand());
     const expected = Array.from(
       new Set([
-        ...commonAppContextDeprecatedFlags(),
+        ...commonAppContextRegionFlags(),
         ...longFlagsOf(addInvokeAgentCoreSpecificOptions(new Command())),
       ])
     ).sort();
@@ -223,7 +223,7 @@ describe('start-api option surface contract (addStartApiSpecificOptions)', () =>
     const full = longFlagsOf(createLocalStartApiCommand());
     const expected = Array.from(
       new Set([
-        ...commonAppContextDeprecatedFlags(),
+        ...commonAppContextRegionFlags(),
         ...longFlagsOf(addStartApiSpecificOptions(new Command())),
       ])
     ).sort();

--- a/tests/unit/cli/options.test.ts
+++ b/tests/unit/cli/options.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi } from 'vite-plus/test';
+import { describe, it, expect } from 'vite-plus/test';
 
 import {
   parseContextOptions,
   parseAssumeRoleToken,
   effectiveAssumeRoleArn,
-  warnIfDeprecatedRegion,
+  regionOption,
   type AssumeRoleOption,
 } from '../../../src/cli/options.js';
 
@@ -173,26 +173,29 @@ describe('effectiveAssumeRoleArn', () => {
   });
 });
 
-describe('warnIfDeprecatedRegion', () => {
-  it('does not write to stderr when region is undefined', () => {
-    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    warnIfDeprecatedRegion({});
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+describe('regionOption', () => {
+  // Issue #245: `--region` was previously documented as
+  // `[deprecated] No effect on this command` even though the code paths
+  // still consumed `options.region` for SDK calls and the container's
+  // `AWS_REGION` injection. The flag is now a normal AWS-CLI-style
+  // `--region` option; the description must not carry deprecation
+  // language and the flag must NOT be hidden from `--help`.
+  it('is named --region and is visible in --help', () => {
+    expect(regionOption.long).toBe('--region');
+    expect(regionOption.hidden).toBeFalsy();
   });
 
-  it('writes a deprecation warning to stderr when region is provided', () => {
-    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    warnIfDeprecatedRegion({ region: 'us-east-1' });
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy.mock.calls[0][0]).toMatch(/deprecated/);
-    spy.mockRestore();
+  it('description does not advertise the option as deprecated or a no-op', () => {
+    const desc = regionOption.description ?? '';
+    expect(desc.toLowerCase()).not.toMatch(/deprecat/);
+    expect(desc.toLowerCase()).not.toMatch(/no effect/);
   });
 
-  it('warns even when region is empty string (strict !== undefined check)', () => {
-    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    warnIfDeprecatedRegion({ region: '' });
-    expect(spy).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
+  it('description references the AWS-CLI-style precedence sources (env / profile)', () => {
+    const desc = (regionOption.description ?? '').toLowerCase();
+    // Surface the precedence path so the user understands what `--region`
+    // falls back to when omitted — the AWS CLI's own `--region` description
+    // does the same.
+    expect(desc).toMatch(/aws_region|profile|region/);
   });
 });

--- a/tests/unit/cli/sts-client-profile-audit.test.ts
+++ b/tests/unit/cli/sts-client-profile-audit.test.ts
@@ -28,7 +28,16 @@ import { describe, expect, it } from 'vite-plus/test';
 const here = fileURLToPath(new URL('.', import.meta.url));
 const repoRoot = join(here, '..', '..', '..');
 
-const SCAN_ROOTS = [join(repoRoot, 'src', 'cli'), join(repoRoot, 'src', 'local')];
+// `src/utils/` is included alongside `src/cli/` + `src/local/` because
+// `src/utils/role-arn.ts` was previously outside the audit scope despite
+// hosting `applyRoleArnIfSet`'s STSClient call, which is invoked by
+// every command. The PR-review caught the relapse vector and widened
+// the scope so the next half-wire trips a test failure here.
+const SCAN_ROOTS = [
+  join(repoRoot, 'src', 'cli'),
+  join(repoRoot, 'src', 'local'),
+  join(repoRoot, 'src', 'utils'),
+];
 
 /** Recursively collect every `*.ts` file under `dir`. */
 function collectTsFiles(dir: string): string[] {
@@ -64,6 +73,17 @@ function findOffenders(filePath: string): { line: number; text: string }[] {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
     if (!line.includes('new STSClient(')) continue;
+    // Skip JSDoc / comment lines that mention the literal pattern in
+    // backticks for documentation purposes (e.g. the historical-pattern
+    // call-out inside `buildStsClientConfig`'s own docstring). A real
+    // construction site is never inside a comment block.
+    const trimmedStart = line.trim();
+    if (
+      trimmedStart.startsWith('*') ||
+      trimmedStart.startsWith('//') ||
+      trimmedStart.startsWith('/*')
+    )
+      continue;
     // The construction may span multiple lines — read the next few too
     // so multi-line `new STSClient(\n  buildStsClientConfig(...))` is
     // recognized as a wrapped helper call, not a bare construction.

--- a/tests/unit/cli/sts-client-profile-audit.test.ts
+++ b/tests/unit/cli/sts-client-profile-audit.test.ts
@@ -1,0 +1,114 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+/**
+ * Issue #245: `--profile` has been only half-wired twice (credentials vs
+ * region; subprocess env vs SDK config). This audit walks `src/cli/**`
+ * + `src/local/**` and asserts every `new STSClient({...})` construction
+ * either:
+ *
+ *   - goes through the shared `buildStsClientConfig` helper (whose
+ *     contract is locked by `profile-resolver.test.ts` — it always
+ *     emits `{ profile }` when `--profile` is plumbed), OR
+ *   - is the canonical `new STSClient({ profile })` shape inside the
+ *     shared resolver itself, OR
+ *   - is explicitly opt-out (an `// sts-audit: ignore` line directly
+ *     above the construction names the reason — e.g. host-side
+ *     resolvers that don't accept a profile yet).
+ *
+ * The historical foot-gun this test prevents is the inline
+ * `new STSClient({ ...(region && { region }) })` shape that silently
+ * dropped `--profile`. Every cdk-local STS site has been migrated to
+ * `buildStsClientConfig({ region, profile })`; the audit fails the
+ * moment a new construction is added in the old shape.
+ */
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(here, '..', '..', '..');
+
+const SCAN_ROOTS = [join(repoRoot, 'src', 'cli'), join(repoRoot, 'src', 'local')];
+
+/** Recursively collect every `*.ts` file under `dir`. */
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const abs = join(dir, entry);
+    const s = statSync(abs);
+    if (s.isDirectory()) {
+      out.push(...collectTsFiles(abs));
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+      out.push(abs);
+    }
+  }
+  return out;
+}
+
+/**
+ * Read a file and report every `new STSClient(...)` construction that does
+ * NOT use the shared `buildStsClientConfig` helper. The audit's allow-list
+ * is intentionally narrow:
+ *
+ *   - `new STSClient({ profile })` — the canonical shape used INSIDE the
+ *     shared `resolveProfileCredentials` helper itself.
+ *   - `new STSClient(buildStsClientConfig(...))` — every other site.
+ *   - `new STSClient({})` or `new STSClient({ region })` directly preceded
+ *     by a `// sts-audit: ignore` line — explicit opt-out (host-side
+ *     resolvers that don't accept a profile yet).
+ */
+function findOffenders(filePath: string): { line: number; text: string }[] {
+  const raw = readFileSync(filePath, 'utf-8');
+  const lines = raw.split('\n');
+  const offenders: { line: number; text: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.includes('new STSClient(')) continue;
+    // The construction may span multiple lines — read the next few too
+    // so multi-line `new STSClient(\n  buildStsClientConfig(...))` is
+    // recognized as a wrapped helper call, not a bare construction.
+    const lookahead = lines.slice(i, Math.min(i + 4, lines.length)).join(' ');
+    if (lookahead.includes('buildStsClientConfig(')) continue;
+    // Canonical resolver shape inside profile-resolver.ts.
+    if (/new STSClient\(\{\s*profile\s*\}\)/.test(lookahead)) continue;
+    // Explicit opt-out marker anywhere in the immediately-preceding
+    // comment block (up to 6 lines back of contiguous `//` lines).
+    let optOut = false;
+    for (let k = i - 1; k >= 0 && k >= i - 6; k--) {
+      const prev = (lines[k] ?? '').trim();
+      if (prev.length === 0) break;
+      if (!prev.startsWith('//')) break;
+      if (prev.includes('sts-audit: ignore')) {
+        optOut = true;
+        break;
+      }
+    }
+    if (optOut) continue;
+    offenders.push({ line: i + 1, text: line.trim() });
+  }
+  return offenders;
+}
+
+describe('STSClient `--profile` audit (issue #245)', () => {
+  it('every `new STSClient(...)` under src/cli/** + src/local/** routes through the shared profile helper', () => {
+    const allOffenders: { file: string; line: number; text: string }[] = [];
+    for (const root of SCAN_ROOTS) {
+      for (const file of collectTsFiles(root)) {
+        for (const off of findOffenders(file)) {
+          allOffenders.push({ file: file.slice(repoRoot.length + 1), ...off });
+        }
+      }
+    }
+    if (allOffenders.length > 0) {
+      const msg = allOffenders
+        .map((o) => `  ${o.file}:${o.line}  ${o.text}`)
+        .join('\n');
+      throw new Error(
+        `Found ${allOffenders.length} STSClient construction(s) that do not thread --profile via buildStsClientConfig:\n${msg}\n\n` +
+          'Fix: replace `new STSClient({ ...(region && { region }) })` with ' +
+          '`new STSClient(buildStsClientConfig({ region, profile }))` (import from `src/utils/profile-resolver.ts`). ' +
+          'If the call site genuinely has no profile to plumb, add a single-line `// sts-audit: ignore: <reason>` directly above the construction.'
+      );
+    }
+  });
+});

--- a/tests/unit/cli/sts-client-profile-binding.test.ts
+++ b/tests/unit/cli/sts-client-profile-binding.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach, vi } from 'vite-plus/test';
+
+// Issue #245: behavioral pins that each command's STS-touching code path
+// instantiates `STSClient` with `{ profile: '<value>' }` when --profile
+// is plumbed. Distinct from the regression-grep audit
+// (`sts-client-profile-audit.test.ts`) which checks the static shape;
+// these tests exercise the runtime call to confirm the argument is
+// actually threaded all the way through.
+//
+// Strategy: mock `@aws-sdk/client-sts` so every STSClient instantiation
+// is recorded, then call each command's STS-touching helper directly
+// with a profile + region. The instantiation config is asserted to
+// contain `{ profile, region }` (or `{ profile }` when region is
+// omitted).
+
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      send: vi.fn().mockResolvedValue({
+        Credentials: {
+          AccessKeyId: 'AKIA-PROFILE',
+          SecretAccessKey: 'SECRET-PROFILE',
+          SessionToken: 'TOKEN-PROFILE',
+        },
+        Account: '123456789012',
+      }),
+      config: {
+        credentials: () => ({
+          accessKeyId: 'AKIA-PROFILE',
+          secretAccessKey: 'SECRET-PROFILE',
+        }),
+        region: () => 'ap-northeast-1',
+      },
+      destroy: vi.fn(),
+    };
+  }),
+  AssumeRoleCommand: vi.fn().mockImplementation((args: unknown) => ({ kind: 'AssumeRole', args })),
+  GetCallerIdentityCommand: vi.fn().mockImplementation(() => ({ kind: 'GetCallerIdentity' })),
+}));
+
+import { applyAgentCoreCredentialEnv } from '../../../src/cli/commands/local-invoke-agentcore.js';
+
+describe('applyAgentCoreCredentialEnv threads --profile into STSClient (issue #245)', () => {
+  beforeEach(() => {
+    stsCtorMock.mockReset();
+  });
+
+  it('passes { region, profile } to STSClient when --assume-role + --profile are both set', async () => {
+    const dockerEnv: Record<string, string> = {};
+    await applyAgentCoreCredentialEnv(dockerEnv, {
+      assumeRoleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      region: 'us-east-1',
+      profile: 'dev',
+    });
+    // The AssumeRole STSClient should carry BOTH region and profile.
+    const assumeRoleCalls = stsCtorMock.mock.calls.filter(
+      (c) => c[0] && typeof c[0] === 'object' && 'profile' in (c[0] as object)
+    );
+    expect(assumeRoleCalls.length).toBeGreaterThanOrEqual(1);
+    expect(assumeRoleCalls[0]![0]).toEqual({ region: 'us-east-1', profile: 'dev' });
+  });
+
+  it('passes { region } only (no profile key) when --profile is unset', async () => {
+    const dockerEnv: Record<string, string> = {};
+    await applyAgentCoreCredentialEnv(dockerEnv, {
+      assumeRoleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      region: 'us-east-1',
+    });
+    expect(stsCtorMock).toHaveBeenCalledWith({ region: 'us-east-1' });
+    // Defensive: no `profile` key on the config.
+    const call = stsCtorMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty('profile');
+  });
+
+  it('passes { profile } only (no region key) when --region is unset', async () => {
+    // Capture the env-fallback path (no AWS_REGION present) so the helper
+    // is forced through the profile-only branch.
+    const prevRegion = process.env['AWS_REGION'];
+    const prevDefault = process.env['AWS_DEFAULT_REGION'];
+    delete process.env['AWS_REGION'];
+    delete process.env['AWS_DEFAULT_REGION'];
+    try {
+      const dockerEnv: Record<string, string> = {};
+      await applyAgentCoreCredentialEnv(dockerEnv, {
+        assumeRoleArn: 'arn:aws:iam::123456789012:role/MyRole',
+        profile: 'dev',
+      });
+      expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'dev' });
+    } finally {
+      if (prevRegion !== undefined) process.env['AWS_REGION'] = prevRegion;
+      if (prevDefault !== undefined) process.env['AWS_DEFAULT_REGION'] = prevDefault;
+    }
+  });
+});

--- a/tests/unit/utils/profile-resolver.test.ts
+++ b/tests/unit/utils/profile-resolver.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+
+// Issue #245: the shared profile resolver replaces the per-command copies.
+// These tests pin the cred-AND-region contract the resolver returns + the
+// STSClient config-builder helper every STS-touching site now consumes.
+
+const credsProviderMock = vi.fn();
+const regionProviderMock = vi.fn();
+const stsDestroyMock = vi.fn();
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      config: { credentials: credsProviderMock, region: regionProviderMock },
+      destroy: stsDestroyMock,
+    };
+  }),
+}));
+
+import {
+  resolveProfileCredentials,
+  buildStsClientConfig,
+} from '../../../src/utils/profile-resolver.js';
+
+describe('resolveProfileCredentials (shared)', () => {
+  beforeEach(() => {
+    credsProviderMock.mockReset();
+    regionProviderMock.mockReset();
+    stsDestroyMock.mockReset();
+    stsCtorMock.mockReset();
+  });
+
+  it('passes `{ profile }` to STSClient and returns the resolved triple + region', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-X',
+      secretAccessKey: 'SECRET-X',
+      sessionToken: 'TOKEN-X',
+    });
+    regionProviderMock.mockResolvedValue('ap-northeast-1');
+    const result = await resolveProfileCredentials('dev');
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'dev' });
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-X',
+      secretAccessKey: 'SECRET-X',
+      sessionToken: 'TOKEN-X',
+      region: 'ap-northeast-1',
+    });
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('omits sessionToken when the credential provider returns none', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-LONGTERM',
+      secretAccessKey: 'SECRET-LONGTERM',
+    });
+    regionProviderMock.mockResolvedValue('us-east-1');
+    const result = await resolveProfileCredentials('long-term');
+    expect(result).not.toHaveProperty('sessionToken');
+    expect(result.region).toBe('us-east-1');
+  });
+
+  it('omits region when the profile has no region configured (provider throws)', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-Y',
+      secretAccessKey: 'SECRET-Y',
+    });
+    regionProviderMock.mockRejectedValue(new Error('Region is missing'));
+    const result = await resolveProfileCredentials('agnostic');
+    expect(result).not.toHaveProperty('region');
+  });
+
+  it('omits region when the provider resolves an empty string', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-Z',
+      secretAccessKey: 'SECRET-Z',
+    });
+    regionProviderMock.mockResolvedValue('');
+    const result = await resolveProfileCredentials('empty-region');
+    expect(result).not.toHaveProperty('region');
+  });
+
+  it('throws an actionable error when credentials cannot be resolved', async () => {
+    credsProviderMock.mockResolvedValue({});
+    await expect(resolveProfileCredentials('bogus')).rejects.toThrow(
+      /resolved without usable credentials/
+    );
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('destroys the STSClient even when the credential provider throws', async () => {
+    credsProviderMock.mockRejectedValue(new Error('SSO token expired'));
+    await expect(resolveProfileCredentials('expired')).rejects.toThrow(/SSO token expired/);
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('buildStsClientConfig', () => {
+  // Issue #245: every STSClient site in the codebase MUST go through this
+  // helper so a future site can never silently drop the `--profile`
+  // plumbing — the historical pattern `{ ...(region && { region }) }`
+  // omitted `profile` and silently used the env-shadowed default chain.
+
+  it('emits both region and profile when both are set', () => {
+    expect(buildStsClientConfig({ region: 'us-east-1', profile: 'dev' })).toEqual({
+      region: 'us-east-1',
+      profile: 'dev',
+    });
+  });
+
+  it('omits region when undefined', () => {
+    expect(buildStsClientConfig({ profile: 'dev' })).toEqual({ profile: 'dev' });
+  });
+
+  it('omits profile when undefined', () => {
+    expect(buildStsClientConfig({ region: 'us-east-1' })).toEqual({ region: 'us-east-1' });
+  });
+
+  it('omits region when empty string (matches the `region && ...` shape callers used to write inline)', () => {
+    expect(buildStsClientConfig({ region: '', profile: 'dev' })).toEqual({ profile: 'dev' });
+  });
+
+  it('omits profile when empty string (same falsy-skip shape)', () => {
+    expect(buildStsClientConfig({ region: 'us-east-1', profile: '' })).toEqual({
+      region: 'us-east-1',
+    });
+  });
+
+  it('returns an empty object when both args are absent', () => {
+    expect(buildStsClientConfig({})).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Fully wire `--profile` through every `STSClient` construction in cdk-local
and promote `--region` from a misleading "deprecated, no effect" flag to a
normal AWS-CLI-style option. Per project memory, `--profile` resolution
has been only half-wired twice already; this PR closes the four
half-wire sites surfaced in issue #245 and adds a static-grep audit test
that fails the next regression.

Closes #245

## Fixes (per the issue)

### Fix 1: shared profile resolver across all commands

`src/cli/commands/local-invoke.ts` carried a private
`resolveProfileCredentials` that returned ONLY the credential triple —
every other command imported the `local-start-api.ts:resolveProfileCredentials`
helper which ALSO resolves the profile's configured region. Under
`--profile <p>`, `cdkl invoke` ran the Lambda WITHOUT the profile's
region, breaking handler ambient-region SDK calls.

**Change**: extracted the shared resolver to
`src/utils/profile-resolver.ts` (new file) so every command can import it
from a neutral location. `local-start-api.ts:resolveProfileCredentials`
is now a thin re-export of the shared helper (existing callers — cdkd,
in-repo — keep working). `local-invoke.ts` now imports the shared
helper; its private copy was deleted. The resolved
`profileCredentials.region` is wired into the container's `AWS_REGION`
fallback via the existing `resolveContainerFallbackRegion` precedence
(stack-region override > synth region > profile region).

### Fix 2 + 3: thread `--profile` into every STSClient site

Two sites were calling `new STSClient({ ...(region && { region }) })`
for `${AWS::AccountId}` resolution and five sites for `AssumeRole` —
all silently using the default credential chain instead of the
profile. Migrated EVERY STSClient construction in `src/cli/**` +
`src/local/**` to a new shared helper
`buildStsClientConfig({ region, profile })` (also exported from
`src/utils/profile-resolver.ts`). Affected:

- `local-invoke.ts:820` (PseudoParameters) + `:929` (AssumeRole)
- `local-start-api.ts:2976` (AssumeRole) + `:3516` (PseudoParameters)
- `local-run-task.ts:407` (placeholder account) + `:431` (AssumeRole)
- `ecs-service-emulator.ts:2083` (placeholder account) + `:2103` (AssumeRole)
- `local-invoke-agentcore.ts:1433` (AssumeRole)
- `local/ecr-puller.ts` two sites (already had inline `--profile` —
  migrated to the helper for consistency)
- Existing `resolveCallerAccountId` helpers across run-task /
  invoke-agentcore / ecs-service-emulator already threaded
  `--profile` inline; migrated to the shared helper too

Two sites stay opt-out with a `// sts-audit: ignore` marker —
`local/layer-arn-materializer.ts` (`--layer-role-arn` flow does not
yet receive `--profile`; out of scope for #245) and
`local/sigv4-verify.ts` (host-side inbound-request verifier, not a
container-env path).

### Fix 4: drop the misleading `--region` deprecation copy

`src/cli/options.ts:54-55` described `--region` as
`[deprecated] No effect on this command`, but every command still
consulted `options.region` for SDK calls and the container's
`AWS_REGION`. The deprecation warning lied.

**Change**: rewrote the option description as a normal AWS-CLI-style
flag (`AWS region for SDK calls; defaults to AWS_REGION env, the
synthesized stack region, or the resolved profile region`). Renamed
`deprecatedRegionOption` to `regionOption` (the old name remains as a
`@deprecated` alias so external imports don't break). Removed
`warnIfDeprecatedRegion` and every caller. Updated
`docs/cli-reference.md` and `docs/library-mode.md` accordingly.

## Where the shared resolver landed

`src/utils/profile-resolver.ts` — exports `resolveProfileCredentials`
(creds + region) and `buildStsClientConfig({ region, profile })`. Both
are re-exported from `src/internal.ts` so cdkd inherits the helpers
without a path migration.

## Behavioral tests

- `tests/unit/utils/profile-resolver.test.ts` — pins the shared
  resolver's cred-AND-region contract, the `{ profile }` argument
  threading, and the `buildStsClientConfig` falsy-skip shape (covers
  Fix 1 + the helper contract).
- `tests/unit/cli/sts-client-profile-binding.test.ts` — exercises
  `applyAgentCoreCredentialEnv` (the exported invoke-agentcore
  STS-touching helper) against a mocked STS and records the STSClient
  config; verifies `{ region, profile }`, `{ region }`-only, and
  `{ profile }`-only branches (covers Fixes 2 + 3 behaviorally).
- `tests/unit/cli/sts-client-profile-audit.test.ts` — the
  regression-grep audit per memory ("this area is relapse-prone"):
  walks `src/cli/**` + `src/local/**`, asserts every `new STSClient(...)`
  routes through `buildStsClientConfig` OR carries the canonical
  `{ profile }` resolver shape OR an explicit
  `// sts-audit: ignore` opt-out marker. Fails the moment a future
  PR adds back the inline `{ ...(region && { region }) }` shape.

Existing tests updated:
- `tests/unit/cli/options.test.ts` — replaced the `warnIfDeprecatedRegion`
  describe block with a `regionOption` describe asserting the new
  description does not advertise deprecation / no-op and surfaces
  the AWS-CLI-style precedence.
- `tests/unit/cli/option-surface-contracts.test.ts` — renamed
  `commonAppContextDeprecatedFlags` -> `commonAppContextRegionFlags`
  and migrated the `deprecatedRegionOption` import to `regionOption`.

## Verification

```bash
vp run check   # typecheck + lint + format
vp test run    # 134 files, 2008 tests
vp run build   # dist/cli.js + dist/index.js + dist/internal.js
```

All clean.

## Test plan

- [x] `vp run check` — typecheck + lint + format pass
- [x] `vp test run` — 2008 tests pass (5 new tests across 3 new files)
- [x] `vp run build` — builds clean
- [x] Audit test catches every inline `new STSClient({ ...(region && { region }) })`
- [x] Behavioral test pins `{ region, profile }` / `{ region }`-only /
      `{ profile }`-only branches for invoke-agentcore's STS-touching
      helper
- [x] Existing `resolveProfileCredentials` region-resolution tests in
      `local-start-api-container-region.test.ts` still pass against the
      re-exported shared helper (proves the re-export is wire-compatible)
