### PR TITLE
fix(image-override): re-build covered overrides on --watch reload so source edits propagate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -86,7 +86,15 @@ AWS managed services.
   supplied Dockerfile (deterministic local-only tag
   `cdkl-override-<svc>-<hash>:local`) and threaded through the
   rebuild rolling primitive on `--watch` reload — the engine module
-  lives in `src/local/image-override-engine.ts`. Issue #240 added
+  lives in `src/local/image-override-engine.ts`. Issue #262 retained
+  the post-Stage-3 `ImageOverrideMap` so every `--watch` reload firing
+  re-invokes `runImageOverrideBuilds` per covered target (no Stage 1
+  picker re-fire, no Stage 3 prompt re-fire, no orphan re-validation
+  — those are boot-time-only); a source edit under the covered
+  Dockerfile's context flips the content-addressed tag and the
+  rolling primitive boots a shadow against the freshly-built image
+  (per-target rebuild failure logs a warn + keeps the old replica
+  serving + lets sibling targets continue rolling). Issue #240 added
   per-service variants of the three build-input flags
   (`<svc>:KEY=VAL` for build-arg / build-secret, `<svc>=stage` for
   target); the per-service form overrides the global per-key on the

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Opt-outs:
 - `--no-interactive-overrides` suppresses the boot prompt + the multi-select picker; the override map is whatever explicit `--image-override <svc>=<dockerfile>` flags resolved to. Useful for scripted invocations.
 - `--strict-overrides` fails fast at boot if any pinned target remains uncovered. Off by default; the per-target WARN (which now fires on any cold start when an ECR pin is detected, not just under `--watch`) still surfaces regardless.
 
-Under `--watch`, overridden targets go through the rebuild rolling primitive on each save — the new local Dockerfile build is picked up automatically.
+Under `--watch`, every reload re-runs `docker build` for each covered Dockerfile, then rolls the replicas through the rebuild primitive — so a source edit picked up by the Dockerfile's `COPY` flips the content-addressed tag and the new image bytes serve immediately. The Stage 1 picker / Stage 3 boot prompt are NOT re-fired on reload (resolved once at boot); a per-target rebuild failure logs a warn and keeps the old replica serving while sibling targets continue rolling.
 
 ### start-service vs start-alb — which one?
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1535,11 +1535,17 @@ uncovered pinned targets.
 maps a pinned service target to a local `docker build` of a
 supplied Dockerfile, so `--from-cfn-stack` keeps wiring real
 DynamoDB / Secrets / SSM into the container while the application
-image is locally iterable. Under `--watch`, an overridden target
-goes through the rebuild rolling primitive on each save — the new
-local Dockerfile build is picked up automatically (the reload-skip
-above only fires for targets that remain UNCOVERED by the override
-map). Six flags compose:
+image is locally iterable. Under `--watch`, every reload re-runs
+`docker build` per covered Dockerfile (issue #262), then rolls each
+replica through the rebuild primitive — a source edit picked up by
+the Dockerfile's `COPY` flips the content-addressed tag and the
+shadow boots against the freshly-built image. The Stage 1 picker /
+Stage 3 boot prompt are NOT re-fired (resolved once at boot); the
+orphan validator is NOT re-run (the `ImageOverrideMap` shape is
+stable post-boot); a per-target rebuild failure logs a warn and
+keeps the OLD replica serving while sibling targets continue
+rolling. The reload-skip above only fires for targets that remain
+UNCOVERED by the override map. Six flags compose:
 
 - `--image-override <svc>=<dockerfile>` (explicit) or
   `<dockerfile>` (picker-form) — repeatable. The picker-form opens

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -107,6 +107,7 @@ import {
   parseImageOverrideFlags,
   resolveImageOverrides,
   runImageOverrideBuilds,
+  type ImageOverrideMap,
 } from '../../local/image-override-engine.js';
 
 /**
@@ -685,13 +686,14 @@ export async function runEcsServiceEmulator(
     //      record the resulting local-only tags.
     // Throws on a malformed flag / missing Dockerfile / build failure
     // — the emulator's outer try/finally tears down what was set up.
-    const imageOverrideTags = await resolveAndBuildImageOverrides({
-      perTarget: perTarget.map((pt) => pt.boot.target),
-      stacks,
-      options,
-      extraStateProviders,
-      logger,
-    });
+    const { tags: imageOverrideTags, overrides: imageOverrideMap } =
+      await resolveAndBuildImageOverrides({
+        perTarget: perTarget.map((pt) => pt.boot.target),
+        stacks,
+        options,
+        extraStateProviders,
+        logger,
+      });
 
     // Boot every target SEQUENTIALLY so a first-target failure surfaces before
     // we burn docker budget on the rest.
@@ -838,6 +840,7 @@ export async function runEcsServiceEmulator(
               frontDoorByService,
               changedPaths,
               imageOverrideTags,
+              imageOverrideMap,
               logger,
             })
           );
@@ -964,8 +967,27 @@ async function reloadAllServices(args: {
    * shadow boot uses the locally-built image, not the deployed
    * pin. Empty / absent entry => normal CDK-asset / ECR / public
    * image resolution.
+   *
+   * Issue #262 — this map is REFRESHED on every reload from the
+   * retained `imageOverrideMap` (re-running
+   * {@link runImageOverrideBuilds}) so a source edit under a
+   * covered Dockerfile actually propagates. The original
+   * boot-time tags are discarded on success; on per-target rebuild
+   * failure the boot-time value for THAT target survives so the
+   * old replica stays serving.
    */
   imageOverrideTags: ReadonlyMap<string, string>;
+  /**
+   * Issue #262 — the post-Stage-3 resolved override map retained
+   * from boot. Re-fed to {@link runImageOverrideBuilds} on every
+   * reload so a covered Dockerfile's content-addressed tag flips
+   * when the source / Dockerfile bytes change, and the rolling
+   * primitive picks up the freshly-built image. The interactive
+   * Stage 1 (picker) and Stage 3 (boot prompt) re-runs are
+   * intentionally skipped — those resolved once at boot. Empty
+   * map => no covered overrides, nothing to re-build.
+   */
+  imageOverrideMap: ImageOverrideMap;
   logger: ReturnType<typeof getLogger>;
 }): Promise<void> {
   const {
@@ -982,7 +1004,8 @@ async function reloadAllServices(args: {
     profileCredsFile,
     frontDoorByService,
     changedPaths,
-    imageOverrideTags,
+    imageOverrideTags: boottimeImageOverrideTags,
+    imageOverrideMap,
     logger,
   } = args;
 
@@ -994,6 +1017,43 @@ async function reloadAllServices(args: {
       `cdk synth failed during reload; keeping previous version. (${err instanceof Error ? err.message : String(err)})`
     );
     return;
+  }
+
+  // Issue #262 — re-build each covered `--image-override` Dockerfile so
+  // a source edit under the override Dockerfile's context propagates.
+  // The boot-time tags map is seeded as the fallback (so a per-target
+  // build failure here doesn't strand the rolling primitive with no
+  // image: the OLD tag stays valid + the OLD replica keeps serving).
+  // We invoke `runImageOverrideBuilds` per-entry rather than over the
+  // whole map so one target's `docker build` failure (Dockerfile
+  // deleted mid-watch, syntax error in user source, missing secret
+  // file) doesn't abort the rebuilds for sibling targets — mirror
+  // the per-target try/catch shape the classifier already uses below.
+  //
+  // Skipped on reload: Stage 1 picker (interactive, resolved at boot),
+  // Stage 3 boot prompt (interactive, resolved at boot), and
+  // `enforceImageOverrideOrphans` (the `ImageOverrideMap` shape is
+  // stable post-boot, so re-validating would be a tautology).
+  const imageOverrideTags = new Map<string, string>(boottimeImageOverrideTags);
+  for (const [target, entry] of imageOverrideMap.entries()) {
+    try {
+      const oneTagMap = await runImageOverrideBuilds(new Map([[target, entry]]));
+      const newTag = oneTagMap.get(target);
+      if (newTag !== undefined) imageOverrideTags.set(target, newTag);
+    } catch (err) {
+      // Match the synth-failure warn shape above: name the trigger +
+      // error head, then continue. The boot-time tag stays in
+      // `imageOverrideTags` so the per-target roll below either rolls
+      // against the old image (verdict !== skip) or falls through to
+      // the source-change classifier's normal path. The OLD replicas
+      // for this target keep serving regardless because the rolling
+      // primitive's shadow-boot-then-swap order means the old
+      // container only goes away after a healthy shadow comes up.
+      logger.warn(
+        `Reload of '${target}': --image-override rebuild failed; keeping the previous local image. ` +
+          `(${err instanceof Error ? err.message : String(err)})`
+      );
+    }
   }
 
   // The new `frontDoor` plan is intentionally discarded: `reloadAllServices`
@@ -2452,7 +2512,7 @@ async function resolveAndBuildImageOverrides(args: {
   options: EcsServiceEmulatorOptions;
   extraStateProviders: ExtraStateProviders | undefined;
   logger: ReturnType<typeof getLogger>;
-}): Promise<Map<string, string>> {
+}): Promise<{ tags: Map<string, string>; overrides: ImageOverrideMap }> {
   const { perTarget, stacks, options, extraStateProviders, logger } = args;
 
   // Issue #242 / N1 — collect every target's resolved service first,
@@ -2524,7 +2584,7 @@ async function resolveAndBuildImageOverrides(args: {
     rawFlags.pickerPaths.length === 0 &&
     rawFlags.perService.size === 0
   ) {
-    return new Map();
+    return { tags: new Map(), overrides: new Map() };
   }
 
   // Resolve overrides — picker prompts + boot prompt fire here when in
@@ -2548,12 +2608,22 @@ async function resolveAndBuildImageOverrides(args: {
   // handler renders it cleanly.
   enforceImageOverrideOrphans(rawFlags, overrides);
 
-  if (overrides.size === 0) return new Map();
+  if (overrides.size === 0) return { tags: new Map(), overrides: new Map() };
 
   // Build every covered Dockerfile. Per-build progress goes to stdout
   // via the docker-runner's streamLive path; the per-target
   // "Building override image..." line surfaces ahead of each build.
-  return runImageOverrideBuilds(overrides);
+  //
+  // Issue #262 — retain the resolved `overrides` map (the post-Stage-3
+  // `ImageOverrideMap`) alongside the per-target tag map. The watcher's
+  // reload pathway calls `runImageOverrideBuilds(overrides)` AGAIN per
+  // reload firing so a source edit under a covered Dockerfile flips
+  // the content-addressed tag and the rolling primitive boots a shadow
+  // from the freshly-built image. Without retention, the reload reuses
+  // the stale boot-time tag and the user's source edit silently never
+  // reaches the running container.
+  const tags = await runImageOverrideBuilds(overrides);
+  return { tags, overrides };
 }
 
 /**

--- a/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
@@ -121,6 +121,151 @@ describe('ecs-service-emulator image-override engine binding (issue #238)', () =
   });
 });
 
+describe('reload-time --image-override rebuild (issue #262)', () => {
+  // Issue #262 — the boot-time tag map is stale on every `--watch`
+  // reload because `runImageOverrideBuilds` only ran once at boot.
+  // Source edits under a covered Dockerfile therefore never reached
+  // the running container — the rolling primitive booted a shadow
+  // from the SAME local tag, which still pointed at the boot-time
+  // image bytes.
+  //
+  // The fix retains the post-Stage-3 `ImageOverrideMap` (alongside
+  // the boot-time tag map), threads it through to
+  // `reloadAllServices`, and re-runs `runImageOverrideBuilds`
+  // per-target on every reload so a content-addressed tag flip
+  // boots the shadow against the freshly-built image. Stage 1
+  // (picker) and Stage 3 (boot prompt) interactive paths AND the
+  // orphan validator are intentionally NOT re-run — they were
+  // resolved at boot and don't change.
+  //
+  // These source-grep bindings pin the four load-bearing pieces a
+  // future refactor could silently drop:
+  //   1. The boot-time helper returns BOTH `tags` and `overrides`,
+  //      and the caller destructures both.
+  //   2. The watcher's `onChange` forwards the retained
+  //      `imageOverrideMap` to `reloadAllServices` next to the tag
+  //      map.
+  //   3. `reloadAllServices` re-invokes `runImageOverrideBuilds` on
+  //      `imageOverrideMap` BEFORE the per-target classifier /
+  //      skip / roll loop fires.
+  //   4. The re-build is wrapped in a per-target try/catch so a
+  //      single failure logs a warn + keeps the OLD replica
+  //      serving + lets sibling targets continue rolling.
+
+  it('resolveAndBuildImageOverrides returns BOTH `tags` and `overrides`, caller destructures both', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // Return type names both fields.
+    expect(source).toMatch(
+      /Promise<\{\s*tags:\s*Map<string,\s*string>;\s*overrides:\s*ImageOverrideMap\s*\}>/
+    );
+    // Boot path destructures both — anchored on the destructure
+    // line containing `tags: imageOverrideTags` AND
+    // `overrides: imageOverrideMap`.
+    expect(source).toMatch(
+      /\{\s*tags:\s*imageOverrideTags,\s*overrides:\s*imageOverrideMap\s*\}\s*=\s*await\s+resolveAndBuildImageOverrides\(/
+    );
+  });
+
+  it('watcher onChange forwards `imageOverrideMap` to reloadAllServices alongside `imageOverrideTags`', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The watcher block must thread the retained map to the reload
+    // function — without it, the reload pathway has no input to
+    // re-feed `runImageOverrideBuilds`.
+    const watcherCall = source.match(
+      /onChange:\s*\(changedPaths\)\s*=>\s*\{[\s\S]*?reloadAllServices\(\{[\s\S]*?imageOverrideMap[\s\S]*?\}\)/
+    );
+    expect(
+      watcherCall,
+      'watcher onChange missing the imageOverrideMap thread (issue #262)'
+    ).toBeTruthy();
+  });
+
+  it('reloadAllServices accepts the `imageOverrideMap` param of type ImageOverrideMap', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    const reloadFnRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadFnRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadFnRegion![0];
+    expect(body).toMatch(/imageOverrideMap:\s*ImageOverrideMap/);
+  });
+
+  it('reloadAllServices re-invokes runImageOverrideBuilds BEFORE the per-target roll loop', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    const reloadFnRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadFnRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadFnRegion![0];
+    // The re-build call must exist AND walk `imageOverrideMap`
+    // entries (per-target so one failure doesn't abort siblings).
+    expect(body).toMatch(/for\s*\(\s*const\s+\[target,\s*entry\]\s+of\s+imageOverrideMap\.entries/);
+    expect(body).toMatch(/await\s+runImageOverrideBuilds\(\s*new\s+Map\(\[\[target,\s*entry\]\]\)\s*\)/);
+    // It must precede the per-target classifier / skip / roll loop.
+    const rebuildIdx = body.search(/await\s+runImageOverrideBuilds\(/);
+    const rollLoopIdx = body.indexOf('for (const pt of perTarget)');
+    expect(rebuildIdx, 'reload-time runImageOverrideBuilds call missing').toBeGreaterThan(-1);
+    expect(rollLoopIdx, 'per-target roll loop missing').toBeGreaterThan(-1);
+    expect(rebuildIdx).toBeLessThan(rollLoopIdx);
+  });
+
+  it('reload-time rebuild is wrapped in try/catch so one target failure does not abort siblings', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    const reloadFnRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadFnRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadFnRegion![0];
+    // The per-target rebuild block must have a try { runImageOverrideBuilds(...) }
+    // catch shape that logs a warn naming the target + error head,
+    // and the catch must NOT throw so the loop continues.
+    const tryCatchRegion = body.match(
+      /for\s*\(\s*const\s+\[target,\s*entry\]\s+of\s+imageOverrideMap\.entries[\s\S]*?try\s*\{[\s\S]*?runImageOverrideBuilds[\s\S]*?\}\s*catch\s*\(err\)\s*\{[\s\S]*?logger\.warn\(/
+    );
+    expect(
+      tryCatchRegion,
+      'reload-time rebuild try/catch + logger.warn missing'
+    ).toBeTruthy();
+  });
+
+  it('reload-time rebuild does NOT re-fire interactive stages or orphan validator', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    const reloadFnRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadFnRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadFnRegion![0];
+    // Stage 1 (picker) + Stage 3 (boot prompt) live inside
+    // `resolveImageOverrides`; the orphan check lives in
+    // `enforceImageOverrideOrphans`. None of the three should appear
+    // inside the reload function body — they were all resolved at
+    // boot, and re-firing the interactive prompts mid-watch would
+    // be a UX foot-gun.
+    expect(body).not.toMatch(/resolveImageOverrides\(/);
+    expect(body).not.toMatch(/enforceImageOverrideOrphans\(/);
+    expect(body).not.toMatch(/parseImageOverrideFlags\(/);
+  });
+
+  it('seeds the per-reload tags map from the boot-time map so a per-target rebuild failure preserves the old tag', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    const reloadFnRegion = source.match(
+      /async function reloadAllServices\(args:[\s\S]*?logger\.info\('Reload complete\.'\);/
+    );
+    expect(reloadFnRegion, 'reloadAllServices body missing').toBeTruthy();
+    const body = reloadFnRegion![0];
+    // The destructure renames the incoming param to
+    // `boottimeImageOverrideTags`, then a fresh `imageOverrideTags`
+    // Map is seeded from it. A per-target rebuild failure leaves
+    // the boot-time tag in place for that target, so the rolling
+    // primitive still has a valid local image to consult (and the
+    // OLD replica keeps serving until a healthy shadow comes up).
+    expect(body).toMatch(/imageOverrideTags:\s*boottimeImageOverrideTags/);
+    expect(body).toMatch(
+      /const\s+imageOverrideTags\s*=\s*new\s+Map<string,\s*string>\(\s*boottimeImageOverrideTags\s*\)/
+    );
+  });
+});
+
 describe('enforceStrictOverrides (issue #238 strict-overrides guard, behavioral)', () => {
   // Behavioral test for the strict-overrides guard. Pulled out of the
   // boot path into a small pure helper so we don't need to mock the

--- a/tests/unit/local/image-override-engine.test.ts
+++ b/tests/unit/local/image-override-engine.test.ts
@@ -483,6 +483,36 @@ describe('runImageOverrideBuilds argv shape (issue #238, T1)', () => {
     expect(opts.cwd).toBe(path.dirname(dockerfile));
   });
 
+  it('re-invoked after Dockerfile bytes change produces a DIFFERENT tag (issue #262 reload-rebuild)', async () => {
+    // Issue #262 — the watcher's reload pathway calls
+    // `runImageOverrideBuilds` again per firing so a source edit under
+    // a covered Dockerfile flips the content-addressed tag and the
+    // rolling primitive boots a shadow against the freshly-built
+    // image. This row pins the tag-bytes-flip contract at the engine
+    // boundary: the SAME entry shape, only the Dockerfile bytes
+    // changed -> the returned tag MUST differ.
+    const dockerfile = makeTmpDockerfile('Dockerfile.reload-flip');
+    writeFileSync(dockerfile, 'FROM alpine:3.18\n');
+    const entry = {
+      dockerfile,
+      contextDir: path.dirname(dockerfile),
+      buildArgs: new Map<string, string>(),
+      buildSecrets: new Map<string, string>(),
+    };
+    const overrides = new Map([['Svc', entry]]);
+    const before = await runImageOverrideBuilds(overrides);
+    // Same entry shape, Dockerfile bytes change (sim. of a `src/`
+    // edit that the user's Dockerfile COPYs into the image — at the
+    // engine boundary the bytes axis is the Dockerfile itself).
+    writeFileSync(dockerfile, 'FROM alpine:3.19\n');
+    const after = await runImageOverrideBuilds(overrides);
+    const tagBefore = before.get('Svc');
+    const tagAfter = after.get('Svc');
+    expect(tagBefore).toBeDefined();
+    expect(tagAfter).toBeDefined();
+    expect(tagAfter).not.toBe(tagBefore);
+  });
+
   it('wraps a docker build failure with ImageOverrideError + stderr tail', async () => {
     const dockerfile = makeTmpDockerfile('Dockerfile.fail');
     runDockerStreamingMock.mockRejectedValueOnce(


### PR DESCRIPTION
Closes #262.

## Symptom

`cdkl start-service --watch --image-override <svc>=<dockerfile>` (or the boot-prompt-injected equivalent under `--from-cfn-stack`) booted the override container correctly — first run was iterable. But the FIRST source edit silently never reached the running container. The `--watch` reload fired, the rolling primitive re-rolled the replica, the user saw `Reload complete.`, and the running bytes were UNCHANGED from boot.

Originating user hit it while iterating on `aim-at-api` against a deployed stack:

```bash
cdkl start-service --from-cfn-stack --env-vars ./env.json --watch \
    --image-build-secret npmrc=~/.npmrc \
    -c IMAGE_TAG="4.5.1_<sha>" \
    --profile mates_dev
```

No `--image-override` on the command — boot prompt fired, Dockerfile picked. Edit `src/index.ts`, save, reload — new code NOT reflected.

## Root cause (per the issue body)

`resolveAndBuildImageOverrides` called `runImageOverrideBuilds` ONCE at boot. The resulting `Map<service, tag>` was threaded into the watcher's `onChange` + `reloadAllServices`, and the SAME stale map was passed to the rolling primitive on every reload. Since `buildImageOverrideTag` is content-addressed (PR #243), the tag would have flipped on a Dockerfile / source bytes change — but `runImageOverrideBuilds` was NEVER re-invoked on reload, so the engine never re-hashed and the rolling primitive re-rolled against the boot-time image bytes.

## Fix

Four-step thread, matching the issue's "Fix proposal" section:

1. `resolveAndBuildImageOverrides` now returns BOTH the `Map<service, tag>` AND the post-Stage-3 `ImageOverrideMap` (`Map<service, ImageOverrideEntry>`) it previously dropped. The retained map is the input the reload pathway needs to re-feed `runImageOverrideBuilds`.
2. The watcher's `onChange` forwards the retained `imageOverrideMap` to `reloadAllServices` alongside `imageOverrideTags`.
3. `reloadAllServices` re-invokes `runImageOverrideBuilds` per-target BEFORE the per-target classifier / skip / roll loop. The freshly-built tags replace the stale boot-time entries; the rolling primitive picks them up via the existing `imageOverrideTag` thread into `rollOneTarget`.
4. The reload-time per-target rebuild is wrapped in a try/catch so a single Dockerfile / source failure (Dockerfile deleted mid-watch, syntax error in user code, missing secret file) logs a `logger.warn` and continues — the OLD tag for that target stays in the per-reload map, sibling targets continue rolling, and the old replica keeps serving until a future reload either succeeds or the user `^C`s. Mirrors the `cdk synth failed during reload; keeping previous version.` warn shape at the top of `reloadAllServices`.

## Out of scope on reload (intentional)

- Stage 1 (picker) — interactive, resolved at boot.
- Stage 3 (boot prompt) — interactive, resolved at boot.
- `enforceImageOverrideOrphans` — the `ImageOverrideMap` shape is stable post-boot.

Only `runImageOverrideBuilds(overrides)` re-runs on reload; the other engine stages stay boot-time-only.

## Tests added

- `tests/unit/local/image-override-engine.test.ts` — new row asserting `runImageOverrideBuilds` re-invoked after Dockerfile bytes flip produces a DIFFERENT tag (reuses the `bytes-flip` shape from the existing `buildImageOverrideTag` block). Pins the engine-level contract the reload pathway relies on.
- `tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts` — six new source-grep bindings (matches the existing site-level binding pattern used for #234 / #238 / #240) pinning:
  - `resolveAndBuildImageOverrides` returns BOTH `tags` and `overrides`; the caller destructures both.
  - The watcher's `onChange` forwards `imageOverrideMap` to `reloadAllServices`.
  - `reloadAllServices` accepts the `imageOverrideMap: ImageOverrideMap` param.
  - `reloadAllServices` re-invokes `runImageOverrideBuilds` per-target BEFORE the roll loop.
  - The reload-time rebuild is wrapped in try/catch + `logger.warn` so one failure doesn't abort siblings.
  - The reload function does NOT re-fire `resolveImageOverrides` / `enforceImageOverrideOrphans` / `parseImageOverrideFlags` (Stage 1 / Stage 3 / orphan validator are boot-time-only).
  - The per-reload tags map is seeded from the boot-time map (`boottimeImageOverrideTags`) so a per-target rebuild failure preserves the old tag.

## Docs

- `.claude/CLAUDE.md` — scope copy on `--image-override` extended with the #262 retain + per-reload re-build semantics.
- `README.md` — the `--image-override` section's `--watch` paragraph sharpened to spell out the per-save re-build + per-target failure isolation.
- `docs/local-emulation.md` — `--image-override` block updated with the same.

## Verify

- `vp run check` — typecheck + lint + format-check all green.
- `vp test run` — 2063 tests across 138 files (was 2056 pre-change; +7 new rows).
- `vp run build` — clean dist artifacts.

## Manual repro recipe (originating user's command)

```bash
cdkl start-service --from-cfn-stack --env-vars ./env.json --watch \
    --image-build-secret npmrc=~/.npmrc \
    -c IMAGE_TAG="4.5.1_<sha>" \
    --profile mates_dev
```

Pick `./Dockerfile` at the boot prompt. Edit `src/index.ts`, save. Before this PR: reload completes, running container serves the boot-time bytes. After this PR: reload re-builds the Dockerfile (the content-addressed tag flips), the rolling primitive boots the shadow against the new image, and the edited code serves.

## Follow-up (out of scope for this PR)

- Integ fixture extension under `tests/integration/local-start-service-watch-fast/` exercising the reload-rebuild path end-to-end (cited in the issue body's "Tests" section as non-blocking).
- A `--no-reload-rebuild` opt-out flag if any user asks to keep the boot-time tag stable across reloads (premature today; can ship if requested).
