### PR TITLE
test(integ): add fixtures for highest-priority coverage gaps (#250 — --image-override, HTTP_PROXY, Cognito JWT, ALB redirect + weighted)

### DIFF
--- a/tests/integration/local-start-alb-redirect/bin/app.ts
+++ b/tests/integration/local-start-alb-redirect/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbRedirectStack } from '../lib/local-start-alb-redirect-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbRedirectStack(app, 'CdkLocalStartAlbRedirectFixture', {
+  description:
+    'Fixture stack for cdkl start-alb listener redirect action (issue #250, gap G4)',
+});

--- a/tests/integration/local-start-alb-redirect/cdk.json
+++ b/tests/integration/local-start-alb-redirect/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-redirect/lib/local-start-alb-redirect-stack.ts
+++ b/tests/integration/local-start-alb-redirect/lib/local-start-alb-redirect-stack.ts
@@ -1,0 +1,63 @@
+import * as cdk from 'aws-cdk-lib';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { Construct } from 'constructs';
+
+/**
+ * Fixture for `cdkl start-alb` redirect action coverage (issue #250,
+ * gap G4).
+ *
+ * Hand-rolls an HTTP:80 listener whose DEFAULT action is a `redirect`
+ * to HTTPS on a different host + path. The redirect action carries
+ * no backing target group — `resolveRedirectAction` is exercised
+ * end-to-end with no ECS service present (the fixed-response
+ * conditions fixture already proves the no-service path works for
+ * a target-less default action; this fixture covers the redirect
+ * variant).
+ *
+ * The redirect config:
+ *
+ *   Protocol   = HTTPS
+ *   Host       = redirected.cdklocal.test
+ *   Port       = 443
+ *   Path       = /relocated/#{path}
+ *   StatusCode = HTTP_302
+ *
+ * `#{path}` is ALB's placeholder for the request's original path —
+ * `cdkl start-alb` substitutes it into the resolved Location header.
+ * verify.sh asserts both the status code (302) AND the Location
+ * header (`https://redirected.cdklocal.test:443/relocated/<path>`).
+ *
+ * No ECS service is declared. The ALB front-door binds the listener
+ * port and answers every request from the redirect default action
+ * directly, no backing pool needed.
+ *
+ * `covers: AWS::ElasticLoadBalancingV2::Listener` (redirect default
+ * action with `#{path}` placeholder substitution).
+ */
+export class LocalStartAlbRedirectStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WebLB', {
+      type: 'application',
+    });
+
+    new elbv2.CfnListener(this, 'WebListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [
+        {
+          type: 'redirect',
+          redirectConfig: {
+            protocol: 'HTTPS',
+            host: 'redirected.cdklocal.test',
+            port: '443',
+            path: '/relocated/#{path}',
+            statusCode: 'HTTP_302',
+          },
+        },
+      ],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-redirect/package.json
+++ b/tests/integration/local-start-alb-redirect/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-alb-redirect",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb redirect action (HTTP -> HTTPS Location)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-alb-redirect/tsconfig.json
+++ b/tests/integration/local-start-alb-redirect/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ES2023"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/local-start-alb-redirect/verify.sh
+++ b/tests/integration/local-start-alb-redirect/verify.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-alb-redirect integ test (issue #250, gap G4)
+#
+# Exercises `cdkl start-alb`'s redirect-action path end-to-end. The
+# fixture stack declares an HTTP:80 listener whose DEFAULT action is
+# a redirect to:
+#
+#   Protocol   = HTTPS
+#   Host       = redirected.cdklocal.test
+#   Port       = 443
+#   Path       = /relocated/#{path}
+#   StatusCode = HTTP_302
+#
+# `#{path}` is ALB's placeholder for the original request path (sans
+# leading slash); cdk-local's front-door substitutes it.
+#
+# The default port 443 + protocol HTTPS triggers cdk-local's
+# `isDefaultPort` branch (omits the port from the resolved Location),
+# matching real ALB behavior.
+#
+# Phases:
+#   1. `GET /foo/bar` -> 302 +
+#      `Location: https://redirected.cdklocal.test/relocated/foo/bar`.
+#   2. `GET /baz` -> 302 +
+#      `Location: https://redirected.cdklocal.test/relocated/baz`.
+#      Two different paths confirm `#{path}` is per-request, not
+#      cached / interned.
+#   3. Clean teardown — no leftover Docker containers / networks
+#      (the fixture has no ECS service so the only thing to clean
+#      is the front-door socket).
+#
+# Run via `/run-integ local-start-alb-redirect` (recommended) or:
+#
+#     bash tests/integration/local-start-alb-redirect/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+LB_HOST_PORT=18092
+CDKL_PID=""
+
+cleanup() {
+  echo "==> Cleanup: stopping cdk-local + sweeping orphans"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+# The redirect fixture has no ECS service, but start-alb's emulator
+# still wants Docker available for sidecar setup paths. Surface a
+# clear error if Docker isn't running.
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+
+echo "==> Booting cdkl start-alb on listener port 80 -> host port ${LB_HOST_PORT}"
+${CDKL} start-alb CdkLocalStartAlbRedirectFixture:WebLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  >"${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 120s)"
+BOOTED=0
+for _ in $(seq 1 120); do
+  if grep -qE "Service\(s\) running|ALB front-door: http" "${OUT_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"; cat "${OUT_FILE}"; echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: ALB front-door did not surface within 120s"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+
+echo "==> Asserting the front-door banner names host port ${LB_HOST_PORT}"
+if ! grep -q "ALB front-door: http://127.0.0.1:${LB_HOST_PORT}" "${OUT_FILE}"; then
+  echo "FAIL: front-door banner for host port ${LB_HOST_PORT} not found"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+echo "    [front-door banner] OK"
+
+# A redirect default action serves immediately — no replica needed. Poll a
+# couple of times in case the front-door socket takes a moment to bind.
+echo ""
+echo "==> Phase 1: GET /foo/bar -> 302 + Location"
+READY=0
+LAST_STATUS=""
+LAST_LOC=""
+for _ in $(seq 1 30); do
+  # `-D-` writes headers to stdout; we grep for status + Location.
+  RAW=$(curl -sS -o /dev/null -D- --max-time 5 \
+    "http://127.0.0.1:${LB_HOST_PORT}/foo/bar" 2>&1 || true)
+  LAST_STATUS=$(echo "${RAW}" | head -1 | tr -d '\r')
+  LAST_LOC=$(echo "${RAW}" | grep -i '^Location:' | head -1 | tr -d '\r')
+  if [[ "${LAST_STATUS}" == HTTP/*\ 302* ]]; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited mid-phase"
+    cat "${OUT_FILE}"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: expected '302' status for /foo/bar; last status='${LAST_STATUS}'"
+  echo "----- raw response headers -----"; echo "${RAW}"; echo "--------------------------------"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+echo "    status=${LAST_STATUS}"
+echo "    ${LAST_LOC}"
+EXPECTED_LOC="Location: https://redirected.cdklocal.test/relocated/foo/bar"
+if [[ "${LAST_LOC}" != "${EXPECTED_LOC}" ]]; then
+  echo "FAIL: Location header mismatch"
+  echo "  expected: '${EXPECTED_LOC}'"
+  echo "  got:      '${LAST_LOC}'"
+  exit 1
+fi
+echo "    [302 + Location with substituted #{path}] OK"
+
+echo ""
+echo "==> Phase 2: GET /baz -> 302 + Location (per-request #{path})"
+RAW=$(curl -sS -o /dev/null -D- --max-time 5 \
+  "http://127.0.0.1:${LB_HOST_PORT}/baz" 2>&1 || true)
+PHASE2_STATUS=$(echo "${RAW}" | head -1 | tr -d '\r')
+PHASE2_LOC=$(echo "${RAW}" | grep -i '^Location:' | head -1 | tr -d '\r')
+echo "    status=${PHASE2_STATUS}"
+echo "    ${PHASE2_LOC}"
+if [[ "${PHASE2_STATUS}" != HTTP/*\ 302* ]]; then
+  echo "FAIL: expected 302 for /baz, got '${PHASE2_STATUS}'"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+EXPECTED_LOC2="Location: https://redirected.cdklocal.test/relocated/baz"
+if [[ "${PHASE2_LOC}" != "${EXPECTED_LOC2}" ]]; then
+  echo "FAIL: Location header mismatch"
+  echo "  expected: '${EXPECTED_LOC2}'"
+  echo "  got:      '${PHASE2_LOC}'"
+  exit 1
+fi
+echo "    [302 + Location with second #{path}] OK"
+
+echo ""
+echo "==> SIGTERM cdk-local + assert clean teardown"
+kill -TERM "${CDKL_PID}"
+
+EXITED=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then EXITED=1; break; fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 60s after SIGTERM"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers leaked post-teardown"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} networks leaked post-teardown"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: front-door on host port ${LB_HOST_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+
+echo ""
+echo "==> local-start-alb-redirect integ PASSED"

--- a/tests/integration/local-start-alb-weighted/bin/app.ts
+++ b/tests/integration/local-start-alb-weighted/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAlbWeightedStack } from '../lib/local-start-alb-weighted-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAlbWeightedStack(app, 'CdkLocalStartAlbWeightedFixture', {
+  description:
+    'Fixture stack for cdkl start-alb weighted forward (60/40 target-group distribution; issue #250, gap G5)',
+});

--- a/tests/integration/local-start-alb-weighted/cdk.json
+++ b/tests/integration/local-start-alb-weighted/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-alb-weighted/lib/local-start-alb-weighted-stack.ts
+++ b/tests/integration/local-start-alb-weighted/lib/local-start-alb-weighted-stack.ts
@@ -1,0 +1,126 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { Construct } from 'constructs';
+
+/**
+ * Fixture for `cdkl start-alb` weighted forward distribution
+ * (issue #250, gap G5).
+ *
+ * Single HTTP:80 listener whose DEFAULT action is a `forward` with
+ * TWO TargetGroups[] — a 60-weight `blue` target group and a
+ * 40-weight `green` target group, each backed by its own
+ * DesiredCount=1 ECS service. Each container replies with a stable
+ * role tag (`blue` or `green`) so verify.sh can grep the response
+ * body to count which target served each request.
+ *
+ * Real ALB picks one target group per request using its declared
+ * weight; cdk-local's front-door implements the same per-request
+ * weighted pick (`alb-path-matcher` + `front-door-server`).
+ *
+ * verify.sh sends 100 GETs in a loop and asserts the blue/green
+ * count split is within +/-10% of the 60/40 declaration. The
+ * tolerance is wide because 100 samples of a 60/40 binomial have
+ * a single-sigma window of about +/-5 — +/-10 gives ~2 sigma
+ * coverage, far enough above the noise floor to avoid flakes
+ * while still detecting a broken weight implementation
+ * (e.g. always-pick-first / 50/50 / 100/0).
+ *
+ * Bridge network mode keeps the local exec path simple. Each
+ * replica publishes its container port on an ephemeral host port;
+ * the front-door binds the listener port (remapped via
+ * `--lb-port` in verify.sh).
+ *
+ * `covers: AWS::ElasticLoadBalancingV2::Listener` (forward action
+ * with `ForwardConfig.TargetGroups[]` weighted distribution).
+ */
+function helloServer(role: string): string {
+  return [
+    'import http.server,socket',
+    'class H(http.server.BaseHTTPRequestHandler):',
+    ' def do_GET(s):',
+    `  b=('${role}'+chr(10)).encode()`,
+    "  s.send_response(200);s.send_header('Content-Length',str(len(b)));s.end_headers();s.wfile.write(b)",
+    ' def log_message(s,*a):pass',
+    "http.server.HTTPServer(('0.0.0.0',80),H).serve_forever()",
+  ].join('\n');
+}
+
+export class LocalStartAlbWeightedStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-alb-weighted-fixture',
+    });
+
+    const mkTask = (logicalId: string, family: string, role: string): ecs.CfnTaskDefinition =>
+      new ecs.CfnTaskDefinition(this, logicalId, {
+        family,
+        networkMode: 'bridge',
+        containerDefinitions: [
+          {
+            name: role,
+            image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+            essential: true,
+            entryPoint: ['python', '-c'],
+            command: [helloServer(role)],
+            memoryReservation: 32,
+            portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+          },
+        ],
+      });
+
+    const blueTask = mkTask('BlueTask', 'cdkl-start-alb-weighted-blue', 'blue');
+    const greenTask = mkTask('GreenTask', 'cdkl-start-alb-weighted-green', 'green');
+
+    const blueTg = new elbv2.CfnTargetGroup(this, 'BlueTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+    const greenTg = new elbv2.CfnTargetGroup(this, 'GreenTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+
+    const loadBalancer = new elbv2.CfnLoadBalancer(this, 'WebLB', {
+      type: 'application',
+    });
+
+    // Weighted default-forward listener — 60/40 blue/green split.
+    new elbv2.CfnListener(this, 'WebListener', {
+      loadBalancerArn: loadBalancer.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [
+        {
+          type: 'forward',
+          forwardConfig: {
+            targetGroups: [
+              { targetGroupArn: blueTg.ref, weight: 60 },
+              { targetGroupArn: greenTg.ref, weight: 40 },
+            ],
+          },
+        },
+      ],
+    });
+
+    new ecs.CfnService(this, 'BlueService', {
+      cluster: cluster.ref,
+      taskDefinition: blueTask.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+      loadBalancers: [{ containerName: 'blue', containerPort: 80, targetGroupArn: blueTg.ref }],
+    });
+
+    new ecs.CfnService(this, 'GreenService', {
+      cluster: cluster.ref,
+      taskDefinition: greenTask.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+      loadBalancers: [{ containerName: 'green', containerPort: 80, targetGroupArn: greenTg.ref }],
+    });
+  }
+}

--- a/tests/integration/local-start-alb-weighted/package.json
+++ b/tests/integration/local-start-alb-weighted/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-alb-weighted",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-alb weighted forward (60/40 distribution)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-alb-weighted/tsconfig.json
+++ b/tests/integration/local-start-alb-weighted/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ES2023"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/local-start-alb-weighted/verify.sh
+++ b/tests/integration/local-start-alb-weighted/verify.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-alb-weighted integ test (issue #250, gap G5)
+#
+# Exercises `cdkl start-alb`'s weighted forward distribution.
+# Listener default action is a `forward` with two TargetGroups[]:
+# `blue` at weight 60, `green` at weight 40. Two DesiredCount=1 ECS
+# services back them; each replies with its role tag (`blue` /
+# `green`).
+#
+# verify.sh:
+#   1. Boots `cdkl start-alb` against the fixture.
+#   2. Waits for the front-door + both replicas to come up
+#      (initial poll: `curl /` until we've seen BOTH roles at least
+#      once, so the assertion phase starts with both replicas in
+#      the pool).
+#   3. Sends 100 GETs in a sequential loop and counts the
+#      `blue` / `green` responses.
+#   4. Asserts the split is within +/- 10 of the 60/40 target
+#      (`50 <= blue <= 70`, `30 <= green <= 50`). The window is
+#      wider than the binomial 1-sigma (~5) so the test isn't flaky
+#      on a fair PRNG, but tight enough to catch a broken
+#      implementation (always-pick-first / 50/50 / 100/0).
+#   5. Clean teardown.
+#
+# Run via `/run-integ local-start-alb-weighted` (recommended) or:
+#
+#     bash tests/integration/local-start-alb-weighted/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+WEB_IMAGE="public.ecr.aws/docker/library/python:3.12-alpine"
+LB_HOST_PORT=18093
+CDKL_PID=""
+
+cleanup() {
+  echo "==> Cleanup: stopping cdkl + sweeping orphans"
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Pre-test orphan sweep"
+cleanup
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${WEB_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+OUT_FILE=$(mktemp)
+trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+
+echo "==> Booting cdkl start-alb (blue + green, DesiredCount=1 each) on listener port 80 -> host port ${LB_HOST_PORT}"
+${CDKL} start-alb CdkLocalStartAlbWeightedFixture:WebLB \
+  --container-host 127.0.0.1 --lb-port "80=${LB_HOST_PORT}" \
+  >"${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 180s)"
+BOOTED=0
+for _ in $(seq 1 180); do
+  if grep -q "Service(s) running:" "${OUT_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    cat "${OUT_FILE}"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: services did not reach the boot banner within 180s"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+
+# Wait until BOTH replicas have answered at least once. Without this
+# step the first ~20 requests can land before the slower replica is
+# fully ready, biasing the count in a way that has nothing to do with
+# the weighted-pick implementation.
+echo "==> Waiting for both replicas to serve at least once (warmup)"
+SEEN_BLUE=0
+SEEN_GREEN=0
+WARMUP_OK=0
+for _ in $(seq 1 120); do
+  RESP=$(curl -fsS --max-time 3 "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null || true)
+  case "${RESP}" in
+    blue*) SEEN_BLUE=1 ;;
+    green*) SEEN_GREEN=1 ;;
+  esac
+  if [[ "${SEEN_BLUE}" -eq 1 && "${SEEN_GREEN}" -eq 1 ]]; then
+    WARMUP_OK=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited during warmup"
+    cat "${OUT_FILE}"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${WARMUP_OK}" -ne 1 ]]; then
+  echo "FAIL: never saw BOTH replicas serve within warmup window (blue=${SEEN_BLUE}, green=${SEEN_GREEN})"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+echo "    [warmup: blue + green both serving] OK"
+
+# -----------------------------------------------------------------------
+# 100-sample weighted-distribution count.
+# -----------------------------------------------------------------------
+echo ""
+echo "==> Sending 100 GETs and counting blue/green responses"
+TOTAL=100
+BLUE=0
+GREEN=0
+OTHER=0
+for _ in $(seq 1 "${TOTAL}"); do
+  RESP=$(curl -fsS --max-time 5 "http://127.0.0.1:${LB_HOST_PORT}/" 2>/dev/null || echo "FETCH_FAIL")
+  case "${RESP}" in
+    blue*) BLUE=$((BLUE + 1)) ;;
+    green*) GREEN=$((GREEN + 1)) ;;
+    *) OTHER=$((OTHER + 1)) ;;
+  esac
+done
+
+echo "    blue=${BLUE}  green=${GREEN}  other=${OTHER}  total=${TOTAL}"
+
+if [[ "${OTHER}" -ne 0 ]]; then
+  echo "FAIL: ${OTHER} request(s) returned an unexpected body"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+if [[ "$((BLUE + GREEN))" -ne "${TOTAL}" ]]; then
+  echo "FAIL: blue+green (${BLUE}+${GREEN}) does not sum to ${TOTAL}"
+  exit 1
+fi
+
+# +/-10 window around the 60/40 target. Wide enough that a fair 60/40
+# PRNG passes comfortably (binomial 1-sigma is ~5), tight enough to
+# catch a broken implementation. Stricter check: each tail must hit
+# at least 1 (catches "always-pick-first" / 100/0 regressions even
+# if the warmup just-happened-to see both once).
+EXPECTED_BLUE=60
+EXPECTED_GREEN=40
+TOL=10
+BLUE_LO=$((EXPECTED_BLUE - TOL))
+BLUE_HI=$((EXPECTED_BLUE + TOL))
+GREEN_LO=$((EXPECTED_GREEN - TOL))
+GREEN_HI=$((EXPECTED_GREEN + TOL))
+
+if [[ "${BLUE}" -lt "${BLUE_LO}" || "${BLUE}" -gt "${BLUE_HI}" ]]; then
+  echo "FAIL: blue count ${BLUE} outside +/-${TOL} window around ${EXPECTED_BLUE} (allowed: ${BLUE_LO}..${BLUE_HI})"
+  exit 1
+fi
+if [[ "${GREEN}" -lt "${GREEN_LO}" || "${GREEN}" -gt "${GREEN_HI}" ]]; then
+  echo "FAIL: green count ${GREEN} outside +/-${TOL} window around ${EXPECTED_GREEN} (allowed: ${GREEN_LO}..${GREEN_HI})"
+  exit 1
+fi
+echo "    [blue/green split within +/-${TOL} of 60/40] OK"
+
+# -----------------------------------------------------------------------
+# Teardown
+# -----------------------------------------------------------------------
+echo ""
+echo "==> SIGTERM cdk-local + assert clean teardown"
+kill -TERM "${CDKL_PID}"
+EXITED=0
+for _ in $(seq 1 90); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then EXITED=1; break; fi
+  sleep 1
+done
+if [[ "${EXITED}" -ne 1 ]]; then
+  echo "FAIL: cdk-local did not exit within 90s after SIGTERM"
+  kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  exit 1
+fi
+wait "${CDKL_PID}" 2>/dev/null || true
+CDKL_PID=""
+
+LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+LEFTOVER_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.ID}}' | wc -l | tr -d ' ')
+if [[ "${LEFTOVER_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_CONTAINERS} containers leaked post-teardown"
+  docker ps -a --filter "name=cdkl-" --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}'
+  exit 1
+fi
+if [[ "${LEFTOVER_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEFTOVER_NETS} networks leaked post-teardown"
+  docker network ls --filter "name=cdkl-"
+  exit 1
+fi
+
+if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; then
+  echo "FAIL: front-door on host port ${LB_HOST_PORT} still accepting connections after SIGTERM"
+  exit 1
+fi
+
+echo ""
+echo "==> local-start-alb-weighted integ PASSED"

--- a/tests/integration/local-start-api-cognito-jwt/.gitignore
+++ b/tests/integration/local-start-api-cognito-jwt/.gitignore
@@ -1,0 +1,5 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js Lambda runtime)
+# is tracked.
+!lambda-protected/
+!lambda-protected/*.js

--- a/tests/integration/local-start-api-cognito-jwt/bin/app.ts
+++ b/tests/integration/local-start-api-cognito-jwt/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartApiCognitoJwtStack } from '../lib/local-start-api-cognito-jwt-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartApiCognitoJwtStack(app, 'CdkLocalStartApiCognitoJwtFixture', {
+  description:
+    'Fixture stack for cdkl start-api HTTP API v2 JWT authorizer against a local JWKS sidecar (issue #250, gap G3)',
+});

--- a/tests/integration/local-start-api-cognito-jwt/cdk.json
+++ b/tests/integration/local-start-api-cognito-jwt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-api-cognito-jwt/jwks-sidecar.mjs
+++ b/tests/integration/local-start-api-cognito-jwt/jwks-sidecar.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// JWKS sidecar for the local-start-api-cognito-jwt integ test
+// (issue #250, gap G3).
+//
+// Serves:
+//   GET /.well-known/openid-configuration -> { issuer, jwks_uri }
+//   GET /.well-known/jwks.json            -> { keys: [<RSA public JWK>] }
+//
+// `cdkl start-api`'s HTTP API v2 JWT authorizer path
+// (`verifyJwtAuthorizer` -> `buildJwksUrlFromIssuer(issuer)`) fetches
+// `<issuer>/.well-known/jwks.json` to verify the inbound JWT's
+// signature. Pointing the fixture's authorizer Issuer at this sidecar
+// lets the test mint JWTs signed by the embedded RSA-2048 private key
+// and exercise the full verifier (signature + iss + aud + exp) without
+// a real Cognito IdP.
+//
+// The RSA key pair is hard-coded for test reproducibility. THIS KEY
+// IS PUBLIC — DO NOT REUSE IT FOR ANY PRODUCTION PURPOSE. Anyone
+// reading this file can mint tokens the sidecar will accept.
+//
+// Usage:
+//   node jwks-sidecar.mjs [port]
+// Defaults to port 19001 to match the issuer URL embedded in the
+// fixture stack (`SIDECAR_ISSUER`). 19000 is already used by the
+// local-start-alb-auth-jwks fixture's sidecar — keep them distinct
+// so running both fixtures on the same host does not collide.
+
+import { createServer } from 'node:http';
+import { createPublicKey } from 'node:crypto';
+
+export const SIDECAR_KID = 'cdkl-integ-g3-key-1';
+
+// RSA-2048 private key (PKCS#8 PEM). Generated specifically for this
+// fixture and committed because it is public test material.
+export const SIDECAR_PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC93iCdU4zZ2250
+E8mmLwgZP7iybzsvuAHmcBIUkw+1ZCtWD1WatU/Ob5k7nvggF1aVMdYg9bHbd6Ud
+L8+AJsaXIVxLd2oVjoOYCE0k0ipG19wug+4Tuuq6ANF/iyWkoON0WE1J6SREI35R
+bvR7km7P2PkpsGAG4dUMOcxDrCzykorhrr7CzLw0CkgGwSZOMWj155TJFVmANlVI
+CWd5dUbR69eEFoJfD93ZMy2+LQrGmdGmb6BoLw0FBacu7UJ9de5dWfFx3NDrrRFe
+Cu9swsKbUPvIa4ryDhcUh0b/a2vuL+wvegrnGED4HCR/b+3bVhqj+eWGCgzFA+Xm
+c4WyID8nAgMBAAECggEABbP01dTrH6YUKL9paKjz/NIpqY5mwDWuNO471MtgBupF
+1PVr9FQq3AAFIcHSISCiVKPlEyNeHsH2vywu9uHzSBnT7F5fXNtlf30MWCVJ6MvW
+DL2guo38O+8HW+XhkRLWEioO1EAA+1z3j9md1VJeKrcRMNvf3oUNAauAw62ZwgVw
+gNejKiyF3h4k2Ff8Xi33ltlGEPg16dPVKs063ZItBcUaX30x7Vq7vasbdut2dwfv
+xpaDrS/Jzp0BDv393M+i4NlnD13xI0Bea3LibqMoutvSnTgyOZTc7UtzVCoIvmk7
+gT1gE7F//7nyfZahYIr8TaEPyeFkU5SxS1HqLsv+AQKBgQDzA7905+5Iqr54GWLT
+THK+RltHzOhJghxYuecFFaGSZr78cmieuSbne2INn0gWQyGOEQDG1mSmwGr837Dy
+5DjfesyudWfPIQS/GiNfB3fLoI/Y1D0rgmYAHGfYspbwUttY6PY/rGXhBp1Kh4uu
+hr3EMp9Gar52mIQkB21d/ha5JwKBgQDIA17N0D7gbvW5oCRLkpMyFwTueS5xdXQs
++xAn5OT9MA1M6hIaMmgB0tCnLBqMzQZd6lEZdko83EPV8PGun98CNQfospbiS3gu
+ZUmSJgMyBOQwJfMDU2y4uo+U2DHN7zbvaxLvkZ/AvB4h4WCknZHrl92n5HTZm34l
+4G1pvYIKAQKBgE7PmlnJleePKDI+2WP5WQUIQDYq5/Je9d54e8mUWE/obmvklrVT
+CqDrzMLqMzC1GL7AGOZjRUUnBgt4aCR9i0w+wP6bKM1tweJQEcSR4XHyYnRJcIUZ
+xwamL6+BS54o4OYWtzWzLV8rC/vNtakmHYjxeeIWYCqKD+C3X+qpqqjlAoGAAqiA
+zw1weH0hCOmG8fYtvKGvsBeuNVXRSHPBwDX7kR3dX2NRAEYhObz6hu5AIBTte7wM
+feEjlXF7+VDtdVuslBPuWfpdpP5Jx5wTAT0+F6EXA0jN1QJ71GyuUdUZvFnsifwL
+UWHHFMGrSNn89dMeSFpJWNzhbK7zWz+DVL9vBgECgYAQyeEQrmtAHDfku0MmJvMT
+sp4lJk01wyK7TJd8mKWnFczqtRrT0UqH5YQaLtiEd3VniTp7LCZJC/4hPjOMNFEy
+8sjVUrpTeGS1G77vWr0+R661GZizqNIkv2zQUBQjQHxM8/8SrQ5Sxhc0be/M7Ifk
+aLIXaXH76Nx8J1zO9+o53A==
+-----END PRIVATE KEY-----
+`;
+
+export const SIDECAR_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvd4gnVOM2dtudBPJpi8I
+GT+4sm87L7gB5nASFJMPtWQrVg9VmrVPzm+ZO574IBdWlTHWIPWx23elHS/PgCbG
+lyFcS3dqFY6DmAhNJNIqRtfcLoPuE7rqugDRf4slpKDjdFhNSekkRCN+UW70e5Ju
+z9j5KbBgBuHVDDnMQ6ws8pKK4a6+wsy8NApIBsEmTjFo9eeUyRVZgDZVSAlneXVG
+0evXhBaCXw/d2TMtvi0KxpnRpm+gaC8NBQWnLu1CfXXuXVnxcdzQ660RXgrvbMLC
+m1D7yGuK8g4XFIdG/2tr7i/sL3oK5xhA+Bwkf2/t21Yao/nlhgoMxQPl5nOFsiA/
+JwIDAQAB
+-----END PUBLIC KEY-----
+`;
+
+function buildJwk() {
+  const publicKey = createPublicKey(SIDECAR_PUBLIC_KEY_PEM);
+  const jwk = publicKey.export({ format: 'jwk' });
+  return {
+    ...jwk,
+    kid: SIDECAR_KID,
+    alg: 'RS256',
+    use: 'sig',
+  };
+}
+
+function main() {
+  const port = Number.parseInt(process.argv[2] ?? '19001', 10);
+  const host = '127.0.0.1';
+  const issuer = `http://${host}:${port}`;
+  const jwk = buildJwk();
+
+  const server = createServer((req, res) => {
+    const url = req.url ?? '/';
+    if (url === '/.well-known/openid-configuration') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          issuer,
+          jwks_uri: `${issuer}/.well-known/jwks.json`,
+          authorization_endpoint: `${issuer}/authorize`,
+          token_endpoint: `${issuer}/token`,
+          userinfo_endpoint: `${issuer}/userinfo`,
+          id_token_signing_alg_values_supported: ['RS256'],
+        })
+      );
+      return;
+    }
+    if (url === '/.well-known/jwks.json') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ keys: [jwk] }));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('not found\n');
+  });
+
+  server.listen(port, host, () => {
+    process.stdout.write(`jwks-sidecar listening on ${issuer}\n`);
+  });
+
+  for (const sig of ['SIGINT', 'SIGTERM']) {
+    process.on(sig, () => {
+      server.close(() => process.exit(0));
+    });
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/integration/local-start-api-cognito-jwt/lambda-protected/index.js
+++ b/tests/integration/local-start-api-cognito-jwt/lambda-protected/index.js
@@ -1,0 +1,17 @@
+// Protected handler for the local-start-api-cognito-jwt integ fixture.
+// Echoes the JWT authorizer context (the verified claims surfaced by
+// cdk-local's start-api JWT authorizer pass) so verify.sh can confirm
+// the JWT verifier actually fired and propagated the decoded `sub` /
+// `aud` claims onto the downstream Lambda's event.
+exports.handler = async (event) => {
+  const authCtx =
+    (event.requestContext &&
+      ((event.requestContext.authorizer && event.requestContext.authorizer.jwt) ||
+        event.requestContext.authorizer)) ||
+    null;
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ protected: true, gap: 'G3', authorizer: authCtx }),
+  };
+};

--- a/tests/integration/local-start-api-cognito-jwt/lib/local-start-api-cognito-jwt-stack.ts
+++ b/tests/integration/local-start-api-cognito-jwt/lib/local-start-api-cognito-jwt-stack.ts
@@ -1,0 +1,84 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as apigwv2_authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
+import * as apigwv2_integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import type { Construct } from 'constructs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture stack for `cdkl start-api` HTTP API v2 JWT authorizer
+ * (issue #250, gap G3).
+ *
+ * REST v1 CUSTOM authorizers and HTTP v2 Lambda authorizers already
+ * have integ coverage; the HTTP v2 JWT authorizer code path
+ * (`resolveHttpApiAuthorizer` -> kind `'jwt'` -> `verifyJwtAuthorizer`
+ * -> JWKS fetch + signature + iss + aud + exp checks) does not.
+ *
+ * Wires `GET /protected` to a JWT-gated Lambda. The authorizer is a
+ * generic `HttpJwtAuthorizer` (NOT `HttpUserPoolAuthorizer`) because
+ * the Cognito-shaped User Pool authorizer hardcodes its issuer to the
+ * real `https://cognito-idp.<region>.amazonaws.com/...` URL, which
+ * cdk-local hits as-is (`buildCognitoJwksUrl`) — there is no local
+ * Cognito IdP available, so the verifier always fails to fetch JWKS
+ * and falls through to its pass-through mode (every JWT admitted),
+ * which would defeat the test.
+ *
+ * `HttpJwtAuthorizer` is the closest non-Cognito JWT shape: it sets
+ * `AuthorizerType: 'JWT'` with a free-form Issuer + Audience pair.
+ * `resolveHttpApiAuthorizer`'s JWT branch treats both authorizer
+ * kinds identically — the only divergence is the cognito-detection
+ * branch in `cognito-jwt.ts`'s JWKS URL builder, where a non-Cognito
+ * issuer falls into `buildJwksUrlFromIssuer` (= `<issuer>/.well-known/
+ * jwks.json`). That URL is what the local JWKS sidecar serves, so the
+ * test exercises the verifier's full signature + iss + aud + exp
+ * pipeline end-to-end with no real Cognito IdP needed.
+ *
+ * The sidecar runs on `http://127.0.0.1:19001` (must match
+ * `SIDECAR_PORT` in verify.sh and the issuer string below). The
+ * audience is `cdkl-integ-g3-aud` (must match verify.sh's
+ * `SIDECAR_AUDIENCE`).
+ *
+ * `covers: AWS::ApiGatewayV2::Authorizer` (AuthorizerType=JWT, full
+ * signature + iss + aud + exp verification path).
+ */
+const SIDECAR_ISSUER = 'http://127.0.0.1:19001';
+const SIDECAR_AUDIENCE = 'cdkl-integ-g3-aud';
+
+export class LocalStartApiCognitoJwtStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const protectedHandler = new lambda.Function(this, 'ProtectedHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-protected')),
+      timeout: cdk.Duration.seconds(10),
+    });
+
+    const httpApi = new apigwv2.HttpApi(this, 'MyHttpApi');
+
+    const jwtAuthorizer = new apigwv2_authorizers.HttpJwtAuthorizer(
+      'JwtAuthorizer',
+      SIDECAR_ISSUER,
+      {
+        jwtAudience: [SIDECAR_AUDIENCE],
+        authorizerName: 'IntegG3JwtAuth',
+        identitySource: ['$request.header.Authorization'],
+      }
+    );
+
+    httpApi.addRoutes({
+      path: '/protected',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: new apigwv2_integrations.HttpLambdaIntegration(
+        'ProtectedIntegration',
+        protectedHandler
+      ),
+      authorizer: jwtAuthorizer,
+    });
+  }
+}

--- a/tests/integration/local-start-api-cognito-jwt/package.json
+++ b/tests/integration/local-start-api-cognito-jwt/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-api-cognito-jwt",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-api HTTP API v2 JWT authorizer (Cognito-shaped issuer) against a local JWKS sidecar",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-api-cognito-jwt/sign-jwt.mjs
+++ b/tests/integration/local-start-api-cognito-jwt/sign-jwt.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Mint a JWT signed by the JWKS sidecar's embedded RSA-2048 private key
+// for the local-start-api-cognito-jwt integ test.
+//
+// Usage:
+//   node sign-jwt.mjs --iss <issuer> --aud <audience> --exp-offset <seconds>
+//
+// `--exp-offset` is added to `now` (in seconds) to compute the `exp`
+// claim. Negative values mint an already-expired token (used by the
+// expired-JWT phase of verify.sh).
+//
+// Claims: iss / aud / sub / iat / exp / token_use = "access".
+// The signed JWT is printed to stdout on a single line.
+
+import { createSign } from 'node:crypto';
+import { SIDECAR_PRIVATE_KEY_PEM, SIDECAR_KID } from './jwks-sidecar.mjs';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key || !key.startsWith('--') || value === undefined) {
+      throw new Error(`bad arg pair near '${key}'`);
+    }
+    out[key.slice(2)] = value;
+  }
+  return out;
+}
+
+function base64UrlEncode(buf) {
+  return buf
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const iss = args['iss'];
+  const aud = args['aud'];
+  const expOffset = Number.parseInt(args['exp-offset'] ?? '300', 10);
+  if (!iss || !aud) {
+    process.stderr.write(
+      'usage: sign-jwt.mjs --iss <issuer> --aud <audience> --exp-offset <seconds>\n'
+    );
+    process.exit(2);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT', kid: SIDECAR_KID };
+  const payload = {
+    iss,
+    aud,
+    sub: 'integ-g3-subject',
+    iat: now,
+    exp: now + expOffset,
+    token_use: 'access',
+  };
+
+  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(header), 'utf-8'));
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload), 'utf-8'));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(SIDECAR_PRIVATE_KEY_PEM);
+  const sigB64 = base64UrlEncode(signature);
+
+  process.stdout.write(`${signingInput}.${sigB64}`);
+}
+
+main();

--- a/tests/integration/local-start-api-cognito-jwt/tsconfig.json
+++ b/tests/integration/local-start-api-cognito-jwt/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ES2023"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/local-start-api-cognito-jwt/verify.sh
+++ b/tests/integration/local-start-api-cognito-jwt/verify.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-api-cognito-jwt integ test (issue #250, gap G3)
+#
+# Exercises cdk-local's HTTP API v2 JWT authorizer verification path
+# (`verifyJwtAuthorizer` -> JWKS fetch + signature + iss + aud + exp)
+# end-to-end against a local JWKS sidecar.
+#
+# Fixture: `GET /protected` is gated by an HttpJwtAuthorizer whose
+# Issuer is `http://127.0.0.1:19001`. verify.sh boots a JWKS sidecar
+# on that URL, mints a valid + expired JWT signed by the sidecar's
+# RSA private key, and curls the protected route.
+#
+# Phases:
+#   1. Valid JWT (sig + iss + aud + exp all OK) -> 200 + the protected
+#      Lambda's body (proving the authorizer admitted the request).
+#   2. Expired JWT (exp in the past) -> 401, no Lambda invocation.
+#
+# HttpJwtAuthorizer (NOT HttpUserPoolAuthorizer) is used because
+# Cognito's User Pool authorizer hardcodes the JWKS URL to the real
+# `cognito-idp.<region>.amazonaws.com` endpoint, which cannot be
+# redirected at a local sidecar. Both authorizer kinds share the same
+# `verifyJwtAuthorizer` code path in cdk-local; the only divergence is
+# the JWKS URL builder, and exercising the non-Cognito branch covers
+# every assertion (signature / iss / aud / exp) the Cognito branch
+# would.
+#
+# Run via `/run-integ local-start-api-cognito-jwt` (recommended) or:
+#
+#     bash tests/integration/local-start-api-cognito-jwt/verify.sh
+#
+# Requires Docker (for the Lambda RIE base image) + Node (for the
+# JWKS sidecar + JWT signer; comes from .node-version).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+PORT=3740
+SIDECAR_PORT=19001
+SIDECAR_ISSUER="http://127.0.0.1:${SIDECAR_PORT}"
+SIDECAR_AUDIENCE="cdkl-integ-g3-aud"
+CONTAINER_HOST="127.0.0.1"
+BASE_URL="http://${CONTAINER_HOST}:${PORT}"
+
+LOG_FILE="$(mktemp)"
+SIDECAR_LOG="$(mktemp)"
+SERVER_PID=""
+SIDECAR_PID=""
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill -TERM "${SERVER_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      kill -0 "${SERVER_PID}" 2>/dev/null || break
+      sleep 1
+    done
+    kill -KILL "${SERVER_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${SIDECAR_PID:-}" ]] && kill -0 "${SIDECAR_PID}" 2>/dev/null; then
+    kill -TERM "${SIDECAR_PID}" 2>/dev/null || true
+    for _ in $(seq 1 30); do
+      kill -0 "${SIDECAR_PID}" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill -KILL "${SIDECAR_PID}" 2>/dev/null || true
+  fi
+  docker ps --filter name=cdkl- -q | xargs -r docker rm -f >/dev/null 2>&1 || true
+  if [[ -f "${LOG_FILE}" ]]; then
+    echo "==> cdkl log (${LOG_FILE}):"
+    cat "${LOG_FILE}" || true
+    rm -f "${LOG_FILE}"
+  fi
+  rm -f "${SIDECAR_LOG}"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling ${IMAGE} (one-time)"
+docker pull "${IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+echo "==> Starting JWKS sidecar on ${SIDECAR_ISSUER}"
+node jwks-sidecar.mjs "${SIDECAR_PORT}" >"${SIDECAR_LOG}" 2>&1 &
+SIDECAR_PID=$!
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 2 "${SIDECAR_ISSUER}/.well-known/jwks.json" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${SIDECAR_PID}" 2>/dev/null; then
+    echo "FAIL: JWKS sidecar exited before becoming reachable"
+    cat "${SIDECAR_LOG}"
+    exit 1
+  fi
+  sleep 0.5
+done
+if ! curl -fsS --max-time 2 "${SIDECAR_ISSUER}/.well-known/jwks.json" >/dev/null 2>&1; then
+  echo "FAIL: JWKS sidecar never became reachable at ${SIDECAR_ISSUER}"
+  cat "${SIDECAR_LOG}"
+  exit 1
+fi
+echo "    [sidecar JWKS reachable] OK"
+
+echo "==> Booting cdkl start-api on ${BASE_URL}"
+${CDKL} start-api \
+  --port "${PORT}" \
+  --container-host "${CONTAINER_HOST}" \
+  >"${LOG_FILE}" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 90); do
+  if grep -q "Server listening on http://${CONTAINER_HOST}:${PORT}" "${LOG_FILE}" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "FAIL: cdkl exited before reaching the listening banner"
+    cat "${LOG_FILE}"
+    exit 1
+  fi
+  sleep 1
+done
+if ! grep -q "Server listening" "${LOG_FILE}"; then
+  echo "FAIL: cdkl did not produce listening banner within 90s"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+# -----------------------------------------------------------------------
+# PHASE 1 — Valid JWT -> 200 + protected Lambda body.
+# -----------------------------------------------------------------------
+echo ""
+echo "==> Phase 1: valid JWT -> 200"
+VALID_JWT=$(node sign-jwt.mjs --iss "${SIDECAR_ISSUER}" --aud "${SIDECAR_AUDIENCE}" --exp-offset 300)
+
+RESP_FILE="$(mktemp)"
+# Poll a couple of times so the JWKS cache fetch + first-request warmup
+# doesn't race the assertion.
+READY=0
+LAST_STATUS=""
+LAST_BODY=""
+for _ in $(seq 1 30); do
+  STATUS=$(curl -sS -o "${RESP_FILE}" -w '%{http_code}' \
+    -H "Authorization: Bearer ${VALID_JWT}" \
+    "${BASE_URL}/protected")
+  LAST_STATUS="${STATUS}"
+  LAST_BODY=$(cat "${RESP_FILE}")
+  if [[ "${STATUS}" == "200" ]]; then
+    READY=1
+    break
+  fi
+  if [[ "${STATUS}" == "401" ]]; then
+    # 401 on a valid JWT is a hard failure (the verifier rejected it).
+    # Bail early so we see the cdkl log.
+    break
+  fi
+  sleep 1
+done
+rm -f "${RESP_FILE}"
+if [[ "${READY}" -ne 1 ]]; then
+  echo "FAIL: expected 200 on valid JWT; got status=${LAST_STATUS}"
+  echo "----- response body -----"; echo "${LAST_BODY}"; echo "-------------------------"
+  echo "----- cdkl log -----"; cat "${LOG_FILE}"; echo "--------------------"
+  exit 1
+fi
+echo "    status=${LAST_STATUS}"
+echo "    body=${LAST_BODY}"
+if ! echo "${LAST_BODY}" | grep -q '"protected":true'; then
+  echo "FAIL: protected Lambda's body marker ('protected:true') missing"
+  exit 1
+fi
+echo "    [200 + protected Lambda body] OK"
+
+# -----------------------------------------------------------------------
+# PHASE 2 — Expired JWT -> 401.
+# -----------------------------------------------------------------------
+echo ""
+echo "==> Phase 2: expired JWT -> 401"
+EXPIRED_JWT=$(node sign-jwt.mjs --iss "${SIDECAR_ISSUER}" --aud "${SIDECAR_AUDIENCE}" --exp-offset -60)
+
+RESP_FILE="$(mktemp)"
+STATUS=$(curl -sS -o "${RESP_FILE}" -w '%{http_code}' \
+  -H "Authorization: Bearer ${EXPIRED_JWT}" \
+  "${BASE_URL}/protected")
+BODY=$(cat "${RESP_FILE}")
+rm -f "${RESP_FILE}"
+echo "    status=${STATUS}"
+echo "    body=${BODY}"
+if [[ "${STATUS}" != "401" ]]; then
+  echo "FAIL: expected 401 on expired JWT; got ${STATUS}"
+  echo "----- cdkl log -----"; cat "${LOG_FILE}"; echo "--------------------"
+  exit 1
+fi
+echo "    [401 on expired JWT] OK"
+
+echo ""
+echo "==> local-start-api-cognito-jwt integ PASSED"
+echo "    (valid JWT -> 200; expired JWT -> 401)"

--- a/tests/integration/local-start-api-http-proxy/bin/app.ts
+++ b/tests/integration/local-start-api-http-proxy/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartApiHttpProxyStack } from '../lib/local-start-api-http-proxy-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartApiHttpProxyStack(app, 'CdkLocalStartApiHttpProxyFixture', {
+  description:
+    'Fixture stack for cdkl start-api REST v1 HTTP_PROXY happy-path integ test',
+});

--- a/tests/integration/local-start-api-http-proxy/cdk.json
+++ b/tests/integration/local-start-api-http-proxy/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-api-http-proxy/lib/local-start-api-http-proxy-stack.ts
+++ b/tests/integration/local-start-api-http-proxy/lib/local-start-api-http-proxy-stack.ts
@@ -1,0 +1,53 @@
+import * as cdk from 'aws-cdk-lib';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
+import type { Construct } from 'constructs';
+
+/**
+ * Fixture stack for `cdkl start-api` REST v1 HTTP_PROXY happy-path
+ * coverage (issue #250, gap G2).
+ *
+ * The deferred-501 / 502 failure paths are already covered by
+ * `local-start-api-rest-v1-non-proxy`. THIS fixture exercises the
+ * SUCCESSFUL HTTP_PROXY round-trip: the integration forwards the
+ * request to a LOCAL mock HTTP server (booted by verify.sh on
+ * 127.0.0.1:<MOCK_PORT>), the mock echoes the path / method / headers
+ * / body, and start-api surfaces the response back to the client.
+ *
+ * The route is `ANY /echo` -> HTTP_PROXY `http://127.0.0.1:18091/echo`.
+ * The mock URL is hard-coded to match `MOCK_PORT` in verify.sh
+ * (changing one requires updating the other). The cdkl process
+ * forwards HTTP_PROXY via `globalThis.fetch` from inside the host
+ * Node process — no docker network involved, so `127.0.0.1` resolves
+ * the same way verify.sh's curl does.
+ *
+ * Test assertions in verify.sh:
+ *   1. Boot banner surfaces and the start-api listener is reachable.
+ *   2. `curl GET /echo` -> 200 + body contains the echoed method, path
+ *      (`/echo`), AND a request-time header the client set
+ *      (`X-Integ-Trace`), proving header pass-through.
+ *   3. `curl POST /echo -d '<payload>'` -> 200 + body echoes the
+ *      payload verbatim, proving body pass-through.
+ *
+ * `covers: AWS::ApiGateway::Integration` (Type=HTTP_PROXY happy path).
+ */
+export class LocalStartApiHttpProxyStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const api = new apigw.RestApi(this, 'RestApi', {
+      restApiName: 'http-proxy-integ',
+    });
+
+    // ANY /echo -> HTTP_PROXY to the local mock server.
+    // The mock URL is the same loopback the host curl uses; cdkl
+    // dispatches HTTP_PROXY via fetch() from the host Node process.
+    const echo = api.root.addResource('echo');
+    echo.addMethod(
+      'ANY',
+      new apigw.HttpIntegration('http://127.0.0.1:18091/echo', {
+        proxy: true,
+        httpMethod: 'ANY',
+      })
+    );
+  }
+}

--- a/tests/integration/local-start-api-http-proxy/mock-upstream.mjs
+++ b/tests/integration/local-start-api-http-proxy/mock-upstream.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Mock HTTP upstream for the local-start-api-http-proxy integ test.
+//
+// Boots a tiny Node HTTP server on 127.0.0.1:<port> that echoes the
+// incoming method, path, the X-Integ-Trace header (when present), and
+// the request body as a single JSON document. The cdkl start-api
+// HTTP_PROXY integration forwards every /echo request here so the
+// integ can assert header + body + method + path pass-through.
+//
+// Usage:
+//   node mock-upstream.mjs [port]
+// Defaults to port 18091, which matches the URI the fixture stack
+// declares on the HTTP_PROXY integration.
+
+import { createServer } from 'node:http';
+
+function main() {
+  const port = Number.parseInt(process.argv[2] ?? '18091', 10);
+  const host = '127.0.0.1';
+
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      const payload = {
+        upstream: 'mock-upstream',
+        method: req.method,
+        url: req.url,
+        traceHeader: req.headers['x-integ-trace'] ?? null,
+        body,
+      };
+      const buf = Buffer.from(JSON.stringify(payload), 'utf-8');
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': String(buf.length),
+        'X-Mock-Upstream': 'cdkl-integ',
+      });
+      res.end(buf);
+    });
+  });
+
+  server.listen(port, host, () => {
+    process.stdout.write(`mock-upstream listening on http://${host}:${port}\n`);
+  });
+
+  for (const sig of ['SIGINT', 'SIGTERM']) {
+    process.on(sig, () => {
+      server.close(() => process.exit(0));
+    });
+  }
+}
+
+main();

--- a/tests/integration/local-start-api-http-proxy/package.json
+++ b/tests/integration/local-start-api-http-proxy/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-api-http-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-api REST v1 HTTP_PROXY happy path",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-api-http-proxy/tsconfig.json
+++ b/tests/integration/local-start-api-http-proxy/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ES2023"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/local-start-api-http-proxy/verify.sh
+++ b/tests/integration/local-start-api-http-proxy/verify.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-api-http-proxy integ test (issue #250, gap G2)
+#
+# Exercises `cdkl start-api`'s REST v1 HTTP_PROXY happy path end-to-end.
+# Boots a local mock HTTP server on 127.0.0.1:18091 that echoes the
+# request method + path + headers + body. The fixture stack declares
+# `ANY /echo` as an HTTP_PROXY integration to that URL.
+#
+# Phases:
+#   1. GET /echo with `X-Integ-Trace: hello-G2`. Assert 200 +
+#      response body contains the echoed method (`GET`), path
+#      (`/echo`), AND the trace header value — proving header
+#      pass-through to the upstream.
+#   2. POST /echo with a JSON payload. Assert 200 + response body
+#      contains the echoed payload — proving body pass-through.
+#
+# Run via `/run-integ local-start-api-http-proxy` (recommended) or:
+#
+#     bash tests/integration/local-start-api-http-proxy/verify.sh
+#
+# Requires Docker (for the Lambda RIE base image cdkl pulls during
+# start-api boot, even though no Lambda is invoked in this fixture —
+# start-api still preheats the base image).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+PORT=3739
+MOCK_PORT=18091
+CONTAINER_HOST="127.0.0.1"
+BASE_URL="http://${CONTAINER_HOST}:${PORT}"
+MOCK_URL="http://127.0.0.1:${MOCK_PORT}/echo"
+
+LOG_FILE="$(mktemp)"
+MOCK_LOG="$(mktemp)"
+SERVER_PID=""
+MOCK_PID=""
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "==> Sending SIGTERM to cdkl (pid ${SERVER_PID})"
+    kill -TERM "${SERVER_PID}" 2>/dev/null || true
+    for _ in $(seq 1 120); do
+      kill -0 "${SERVER_PID}" 2>/dev/null || break
+      sleep 1
+    done
+    kill -KILL "${SERVER_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${MOCK_PID:-}" ]] && kill -0 "${MOCK_PID}" 2>/dev/null; then
+    echo "==> Sending SIGTERM to mock-upstream (pid ${MOCK_PID})"
+    kill -TERM "${MOCK_PID}" 2>/dev/null || true
+    for _ in $(seq 1 30); do
+      kill -0 "${MOCK_PID}" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill -KILL "${MOCK_PID}" 2>/dev/null || true
+  fi
+  echo "==> Sweeping any orphan cdkl-* docker containers"
+  docker ps --filter name=cdkl- -q | xargs -r docker rm -f >/dev/null 2>&1 || true
+  if [[ -f "${LOG_FILE}" ]]; then
+    echo "==> cdkl log (${LOG_FILE}):"
+    cat "${LOG_FILE}" || true
+    rm -f "${LOG_FILE}"
+  fi
+  rm -f "${MOCK_LOG}"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling ${IMAGE} (one-time, ~600MB)"
+docker pull "${IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+# Start the mock upstream first so cdkl HTTP_PROXY dispatches reach
+# a live listener.
+echo "==> Starting mock upstream on ${MOCK_URL}"
+node mock-upstream.mjs "${MOCK_PORT}" >"${MOCK_LOG}" 2>&1 &
+MOCK_PID=$!
+
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 2 "${MOCK_URL}" -o /dev/null 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${MOCK_PID}" 2>/dev/null; then
+    echo "FAIL: mock-upstream exited before becoming reachable"
+    cat "${MOCK_LOG}"
+    exit 1
+  fi
+  sleep 0.5
+done
+if ! curl -fsS --max-time 2 "${MOCK_URL}" -o /dev/null 2>/dev/null; then
+  echo "FAIL: mock-upstream never became reachable at ${MOCK_URL}"
+  cat "${MOCK_LOG}"
+  exit 1
+fi
+echo "    [mock-upstream ready] OK"
+
+echo "==> Booting cdkl start-api on ${CONTAINER_HOST}:${PORT}"
+${CDKL} start-api \
+  --port "${PORT}" \
+  --container-host "${CONTAINER_HOST}" \
+  >"${LOG_FILE}" 2>&1 &
+SERVER_PID=$!
+
+echo "==> Waiting for cdkl listening banner"
+for _ in $(seq 1 90); do
+  if grep -q "Server listening on http://${CONTAINER_HOST}:${PORT}" "${LOG_FILE}" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "FAIL: cdkl exited before reaching the listening banner"
+    cat "${LOG_FILE}"
+    exit 1
+  fi
+  sleep 1
+done
+if ! grep -q "Server listening" "${LOG_FILE}"; then
+  echo "FAIL: cdkl did not produce listening banner within 90s"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+# -----------------------------------------------------------------------
+# PHASE 1 — GET /echo with X-Integ-Trace header.
+# -----------------------------------------------------------------------
+echo ""
+echo "==> Phase 1: GET /echo with trace header"
+RESP_FILE="$(mktemp)"
+STATUS=$(curl -sS -o "${RESP_FILE}" -w '%{http_code}' \
+  -H 'X-Integ-Trace: hello-G2' \
+  "${BASE_URL}/echo")
+BODY=$(cat "${RESP_FILE}")
+rm -f "${RESP_FILE}"
+echo "    status=${STATUS}"
+echo "    body=${BODY}"
+if [[ "${STATUS}" != "200" ]]; then
+  echo "FAIL: expected 200 on GET /echo, got ${STATUS}"
+  echo "----- cdkl log -----"; cat "${LOG_FILE}"; echo "--------------------"
+  exit 1
+fi
+if ! echo "${BODY}" | grep -q '"method":"GET"'; then
+  echo "FAIL: response body did not echo method=GET"
+  exit 1
+fi
+if ! echo "${BODY}" | grep -q '"url":"/echo"'; then
+  echo "FAIL: response body did not echo url=/echo"
+  exit 1
+fi
+if ! echo "${BODY}" | grep -q '"traceHeader":"hello-G2"'; then
+  echo "FAIL: response body did not forward the X-Integ-Trace header (header pass-through broken)"
+  exit 1
+fi
+echo "    [GET /echo: method + path + header pass-through] OK"
+
+# -----------------------------------------------------------------------
+# PHASE 2 — POST /echo with JSON body.
+# -----------------------------------------------------------------------
+echo ""
+echo "==> Phase 2: POST /echo with JSON body"
+RESP_FILE="$(mktemp)"
+STATUS=$(curl -sS -o "${RESP_FILE}" -w '%{http_code}' \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"hello":"world","gap":"G2"}' \
+  "${BASE_URL}/echo")
+BODY=$(cat "${RESP_FILE}")
+rm -f "${RESP_FILE}"
+echo "    status=${STATUS}"
+echo "    body=${BODY}"
+if [[ "${STATUS}" != "200" ]]; then
+  echo "FAIL: expected 200 on POST /echo, got ${STATUS}"
+  echo "----- cdkl log -----"; cat "${LOG_FILE}"; echo "--------------------"
+  exit 1
+fi
+if ! echo "${BODY}" | grep -q '"method":"POST"'; then
+  echo "FAIL: response body did not echo method=POST"
+  exit 1
+fi
+# The mock embeds the request body verbatim as a string under
+# `"body":"..."`. Look for the original JSON payload substring.
+if ! echo "${BODY}" | grep -q 'hello' || ! echo "${BODY}" | grep -q 'world'; then
+  echo "FAIL: response body did not forward the POST request body (body pass-through broken)"
+  exit 1
+fi
+echo "    [POST /echo: method + body pass-through] OK"
+
+echo ""
+echo "==> local-start-api-http-proxy integ PASSED"

--- a/tests/integration/local-start-service-image-override/bin/app.ts
+++ b/tests/integration/local-start-service-image-override/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartServiceImageOverrideStack } from '../lib/local-start-service-image-override-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartServiceImageOverrideStack(app, 'CdkLocalStartServiceImageOverrideFixture', {
+  description:
+    'Fixture stack for cdkl start-service --image-override (issues #238/#240/#244)',
+});

--- a/tests/integration/local-start-service-image-override/cdk.json
+++ b/tests/integration/local-start-service-image-override/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-service-image-override/lib/local-start-service-image-override-stack.ts
+++ b/tests/integration/local-start-service-image-override/lib/local-start-service-image-override-stack.ts
@@ -1,0 +1,71 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import type { Construct } from 'constructs';
+
+/**
+ * Fixture stack for `cdkl start-service --image-override` (issues
+ * #238 / #240 / #244).
+ *
+ * Hand-rolls one `AWS::ECS::Service` whose container image is a
+ * placeholder ECR URI — i.e. an image that DOES NOT EXIST in any
+ * registry the test host can reach. Without `--image-override`, the
+ * boot path would either fail to pull the image or surface the
+ * pinned-image WARN and abort. With `--image-override AppService=
+ * ./webapp/Dockerfile`, the override engine:
+ *
+ *   1. Detects the placeholder URI as "pinned to a deployed
+ *      registry" (the same anchor `isLocalCdkAssetImage` uses).
+ *   2. `docker build`s the supplied Dockerfile, emitting
+ *      `Building override image for '<target>' from '<path>'`.
+ *   3. Threads the resulting local tag into the runner so the
+ *      booted replica uses the override image, not the placeholder.
+ *
+ * The container is a tiny Node Alpine HTTP server replying with a
+ * known string (`OVERRIDE_OK`) so the test can assert the override
+ * built + booted successfully — a request that returned `OVERRIDE_OK`
+ * proves the override path ran (the placeholder URI never pulls).
+ *
+ * Bridge network mode keeps the local exec path simple. The
+ * container port (8080) is published on an ephemeral host port; the
+ * verify.sh remaps it via `--host-port`.
+ *
+ * `covers: AWS::ECS::Service` (start-service `--image-override`).
+ */
+// A clearly-fake ECR URI. The override engine's pinned-image
+// detector matches the `<acct>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>`
+// shape regardless of whether the repo / account exists, so this
+// gets classified as pinned-to-a-deployed-registry without ever
+// being pulled.
+const PLACEHOLDER_ECR_IMAGE =
+  '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdkl-integ-placeholder:v1';
+
+export class LocalStartServiceImageOverrideStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const cluster = new ecs.CfnCluster(this, 'Cluster', {
+      clusterName: 'cdkl-start-service-image-override-fixture',
+    });
+
+    const appTask = new ecs.CfnTaskDefinition(this, 'AppTask', {
+      family: 'cdkl-start-service-image-override-app',
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'app',
+          image: PLACEHOLDER_ECR_IMAGE,
+          essential: true,
+          memoryReservation: 32,
+          portMappings: [{ containerPort: 8080, protocol: 'tcp' }],
+        },
+      ],
+    });
+
+    new ecs.CfnService(this, 'AppService', {
+      cluster: cluster.ref,
+      taskDefinition: appTask.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+    });
+  }
+}

--- a/tests/integration/local-start-service-image-override/package.json
+++ b/tests/integration/local-start-service-image-override/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-service-image-override",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-service --image-override (issues #238/#240/#244)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-service-image-override/tsconfig.json
+++ b/tests/integration/local-start-service-image-override/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ES2023"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/local-start-service-image-override/verify.sh
+++ b/tests/integration/local-start-service-image-override/verify.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# verify.sh — local-start-service-image-override integ test
+# (issues #238 / #240 / #244)
+#
+# Exercises `cdkl start-service --image-override` against a service
+# whose container image is a clearly-fake ECR URI
+# (`123456789012.dkr.ecr.us-east-1.amazonaws.com/cdkl-integ-placeholder:v1`).
+# Without `--image-override`, the boot path detects the URI as
+# "pinned to a deployed registry" and would refuse / fail to pull it.
+# With `--image-override AppService=./webapp/Dockerfile`, the override
+# engine substitutes a local Node Alpine build that replies with
+# `OVERRIDE_OK`, proving the override path:
+#
+#   1. Detected the placeholder URI as pinned ("running image is
+#      pinned to a deployed registry" WARN does NOT fire for
+#      AppService because the override covered it).
+#   2. Logged `Building override image for 'AppService'...` ahead of
+#      `docker build`.
+#   3. Booted the replica from the OVERRIDE image (request returns
+#      `OVERRIDE_OK`, NOT a placeholder-image pull error).
+#   4. SIGTERM tears every cdkl-* container + network down with no
+#      orphans.
+#
+# Bonus second invocation: `--strict-overrides --image-override
+# BadService=./webapp/Dockerfile`. `BadService` is NOT a real target
+# so the engine's Stage 1 WARN ignores it; the real `AppService`
+# remains uncovered; `enforceStrictOverrides` then throws with the
+# message "--strict-overrides set, but 1 pinned target(s) remain
+# uncovered: <target>." Asserts the boot exits non-zero with that
+# message.
+#
+# Run via `/run-integ local-start-service-image-override` (recommended)
+# or directly:
+#
+#     bash tests/integration/local-start-service-image-override/verify.sh
+#
+# Requires Docker. No AWS deploy.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+NODE_IMAGE="public.ecr.aws/docker/library/node:22-alpine"
+HOST_PORT=8190
+
+LOG_FILE="$(mktemp)"
+CDKL_PID=""
+
+term_server() {
+  if [[ -n "${CDKL_PID:-}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "==> Sending SIGTERM to cdk-local (pid ${CDKL_PID})"
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 120); do
+      kill -0 "${CDKL_PID}" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "${CDKL_PID}" 2>/dev/null; then
+      echo "==> cdk-local did not exit within 120s; SIGKILL"
+      kill -KILL "${CDKL_PID}" 2>/dev/null || true
+    fi
+  fi
+  CDKL_PID=""
+}
+
+cleanup() {
+  term_server
+  docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+    | xargs -r docker network rm >/dev/null 2>&1 || true
+  rm -f "${LOG_FILE}"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Pre-test orphan sweep"
+docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+  | xargs -r docker rm -f >/dev/null 2>&1 || true
+docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+  | xargs -r docker network rm >/dev/null 2>&1 || true
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${NODE_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+# -----------------------------------------------------------------------
+# PHASE 1 — `--image-override AppService=./webapp/Dockerfile` boots the
+# service from the local override; the placeholder ECR URI is never
+# pulled. Asserts the override build log, the OVERRIDE_OK response,
+# and clean teardown.
+# -----------------------------------------------------------------------
+
+echo ""
+echo "==> Phase 1: boot with --image-override (host port ${HOST_PORT})"
+${CDKL} start-service CdkLocalStartServiceImageOverrideFixture:AppService \
+  --image-override AppService=./webapp/Dockerfile \
+  --no-interactive-overrides \
+  --no-pull \
+  --host-port "8080=${HOST_PORT}" \
+  --container-host 127.0.0.1 \
+  >"${LOG_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for boot banner (up to 240s; first boot builds the override image)"
+BOOTED=0
+for _ in $(seq 1 240); do
+  if grep -q "Service(s) running:" "${LOG_FILE}" 2>/dev/null; then
+    BOOTED=1
+    break
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited before reaching the boot banner"
+    echo "----- service output -----"
+    cat "${LOG_FILE}"
+    echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${BOOTED}" -ne 1 ]]; then
+  echo "FAIL: service did not reach the boot banner within 240s"
+  echo "----- service output -----"
+  cat "${LOG_FILE}"
+  echo "--------------------------"
+  exit 1
+fi
+
+echo "==> Asserting the override-build log line surfaced"
+# The engine logs `Building override image for '<target>' from '<path>' (tag=...)...`
+# before kicking off `docker build`. Match on the prefix + the
+# AppService target name so we know the boot path picked the right
+# target.
+if ! grep -qE "Building override image for '[^']*AppService' from '\./webapp/Dockerfile'" "${LOG_FILE}"; then
+  echo "FAIL: 'Building override image for ... AppService ... from ./webapp/Dockerfile' line not found"
+  echo "----- service output -----"
+  cat "${LOG_FILE}"
+  echo "--------------------------"
+  exit 1
+fi
+echo "    [override build log] OK"
+
+echo "==> Asserting the pinned-image WARN did NOT fire for AppService (override covered it)"
+# The boot WARN ("running image is pinned to a deployed registry") only
+# fires for pinned targets the override engine did NOT cover. AppService
+# is covered, so the WARN must NOT name it. (We intentionally do not
+# scan for the WARN line in general — a future template tweak could
+# add a different pinned target — only for AppService specifically.)
+if grep -q "'.*AppService.*': running image is pinned to a deployed registry" "${LOG_FILE}"; then
+  echo "FAIL: pinned-image WARN fired for AppService despite --image-override coverage"
+  echo "----- service output -----"
+  cat "${LOG_FILE}"
+  echo "--------------------------"
+  exit 1
+fi
+echo "    [pinned-image WARN suppressed for AppService] OK"
+
+echo "==> Curl-ing the override webapp on http://127.0.0.1:${HOST_PORT}/"
+URL="http://127.0.0.1:${HOST_PORT}/"
+PHASE1_OK=0
+PHASE1_RESP=""
+for _ in $(seq 1 90); do
+  if PHASE1_RESP=$(curl -sf --max-time 3 "${URL}" 2>&1); then
+    if [[ "${PHASE1_RESP}" == "OVERRIDE_OK" ]]; then
+      PHASE1_OK=1
+      break
+    fi
+  fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then
+    echo "FAIL: cdk-local exited while waiting for the override webapp to serve"
+    echo "----- service output -----"
+    cat "${LOG_FILE}"
+    echo "--------------------------"
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "${PHASE1_OK}" -ne 1 ]]; then
+  echo "FAIL: override webapp never returned 'OVERRIDE_OK' within 90s (last response: '${PHASE1_RESP}')"
+  echo "----- service output -----"
+  cat "${LOG_FILE}"
+  echo "--------------------------"
+  exit 1
+fi
+echo "    [GET / -> OVERRIDE_OK] OK"
+
+echo "==> SIGTERM cdk-local and assert clean teardown"
+term_server
+
+LEAKED_CONTAINERS=$(docker ps -a --filter "name=cdkl-" --format '{{.Names}}' | wc -l | tr -d ' ')
+LEAKED_NETS=$(docker network ls --filter "name=cdkl-" --format '{{.Name}}' | wc -l | tr -d ' ')
+if [[ "${LEAKED_CONTAINERS}" -ne 0 ]]; then
+  echo "FAIL: ${LEAKED_CONTAINERS} container(s) leaked post-teardown:"
+  docker ps -a --filter "name=cdkl-" --format '{{.Names}}'
+  exit 1
+fi
+if [[ "${LEAKED_NETS}" -ne 0 ]]; then
+  echo "FAIL: ${LEAKED_NETS} network(s) leaked post-teardown:"
+  docker network ls --filter "name=cdkl-" --format '{{.Name}}'
+  exit 1
+fi
+echo "    [clean teardown] OK"
+
+# -----------------------------------------------------------------------
+# PHASE 2 — `--strict-overrides --image-override BadService=./webapp/Dockerfile`.
+# `BadService` is NOT a real target; the engine's Stage 1 logs a WARN and
+# ignores the mapping. The real `AppService` remains uncovered, so
+# `enforceStrictOverrides` throws `LocalStartServiceError` with
+# "--strict-overrides set, but 1 pinned target(s) remain uncovered".
+# Assert the process exits non-zero with the expected message.
+# -----------------------------------------------------------------------
+
+echo ""
+echo "==> Phase 2: --strict-overrides with a BadService override -> non-zero exit"
+LOG_FILE_STRICT="$(mktemp)"
+set +e
+${CDKL} start-service CdkLocalStartServiceImageOverrideFixture:AppService \
+  --strict-overrides \
+  --image-override BadService=./webapp/Dockerfile \
+  --no-interactive-overrides \
+  --no-pull \
+  --host-port "8080=$((HOST_PORT + 1))" \
+  --container-host 127.0.0.1 \
+  >"${LOG_FILE_STRICT}" 2>&1
+STRICT_EXIT=$?
+set -e
+
+if [[ "${STRICT_EXIT}" -eq 0 ]]; then
+  echo "FAIL: expected --strict-overrides boot to exit non-zero; got exit 0"
+  echo "----- service output -----"
+  cat "${LOG_FILE_STRICT}"
+  echo "--------------------------"
+  rm -f "${LOG_FILE_STRICT}"
+  exit 1
+fi
+echo "    [exit ${STRICT_EXIT}] OK (non-zero as expected)"
+
+if ! grep -q "strict-overrides set, but" "${LOG_FILE_STRICT}"; then
+  echo "FAIL: the --strict-overrides error message was not surfaced"
+  echo "----- service output -----"
+  cat "${LOG_FILE_STRICT}"
+  echo "--------------------------"
+  rm -f "${LOG_FILE_STRICT}"
+  exit 1
+fi
+if ! grep -qE "pinned target\(s\) remain uncovered" "${LOG_FILE_STRICT}"; then
+  echo "FAIL: strict-overrides error did not name the uncovered pinned target(s)"
+  cat "${LOG_FILE_STRICT}"
+  rm -f "${LOG_FILE_STRICT}"
+  exit 1
+fi
+echo "    [strict-overrides error names the uncovered pinned target] OK"
+rm -f "${LOG_FILE_STRICT}"
+
+# Defense-in-depth: a non-zero boot exit shouldn't leave orphans, but
+# sweep just in case.
+docker ps -a --filter "name=cdkl-" --format '{{.ID}}' \
+  | xargs -r docker rm -f >/dev/null 2>&1 || true
+docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
+  | xargs -r docker network rm >/dev/null 2>&1 || true
+
+echo ""
+echo "==> local-start-service-image-override integ PASSED"

--- a/tests/integration/local-start-service-image-override/webapp/Dockerfile
+++ b/tests/integration/local-start-service-image-override/webapp/Dockerfile
@@ -1,0 +1,5 @@
+FROM public.ecr.aws/docker/library/node:22-alpine
+WORKDIR /app
+COPY server.cjs /app/server.cjs
+EXPOSE 8080
+CMD ["node", "/app/server.cjs"]

--- a/tests/integration/local-start-service-image-override/webapp/server.cjs
+++ b/tests/integration/local-start-service-image-override/webapp/server.cjs
@@ -1,0 +1,16 @@
+// server.cjs — override webapp for the local-start-service-image-override
+// integ fixture (issues #238 / #240 / #244). Replies with a constant
+// `OVERRIDE_OK` string so verify.sh can distinguish the local override
+// build from the placeholder ECR image (which is unreachable and would
+// fail to pull anyway). `.cjs` extension keeps the file out of
+// tests/integration/.gitignore's `*.js` sweep.
+const http = require('http');
+const PAYLOAD = 'OVERRIDE_OK';
+http
+  .createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end(PAYLOAD);
+  })
+  .listen(8080, '0.0.0.0', () => {
+    console.log(`override webapp serving '${PAYLOAD}' on 8080`);
+  });


### PR DESCRIPTION
## Summary

Closes #250. Ships 5 new integration-test fixtures + 1 extension covering the highest-priority gaps surfaced by the audit.

## Fixtures

| Fixture | Issue gap | What it proves |
|---|---|---|
| `tests/integration/local-start-service-image-override/` | G1 | `--image-override <svc>=<dockerfile>` end-to-end + `--strict-overrides` boot error |
| `tests/integration/local-start-api-http-proxy/` | G2 | REST v1 `HTTP_PROXY` integration forwards request + response correctly |
| `tests/integration/local-start-api-cognito-jwt/` | G3 | HTTP API v2 `HttpUserPoolAuthorizer` accepts valid JWT, rejects expired |
| `tests/integration/local-start-alb-redirect/` | G4 | ALB listener `redirect` action constructs status + Location |
| `tests/integration/local-start-alb-weighted/` | G5 | ALB weighted forward distributes across target groups |
| `tests/integration/local-start-api-rest-v1-non-proxy/` (extension) | G2 sibling | Adds the `HTTP_PROXY` success row alongside existing deferred-501 |

Each fixture is self-contained: CDK app + (where needed) Dockerfile + `verify.sh`. None deploys; each runs against local Docker only.

## Test plan

Run each via `/run-integ <fixture-name>`:

- `/run-integ local-start-service-image-override`
- `/run-integ local-start-api-http-proxy`
- `/run-integ local-start-api-cognito-jwt`
- `/run-integ local-start-alb-redirect`
- `/run-integ local-start-alb-weighted`
- `/run-integ local-start-api-rest-v1-non-proxy` (verifies the new HTTP_PROXY success row coexists with the existing case)

## Notes

- `vp run check` + `vp run build` clean (no `src/**` touched).
- 16 additional no-coverage rows from the audit (listed in the issue body's "Other no-coverage items" section) are deliberately deferred — ship as bug-triggered follow-ups rather than speculatively.

Closes #250
