### PR TITLE
fix(start-service,start-alb): bump shadow-ready timeout to 60s + add --shadow-ready-timeout flag (#265)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ cdkl start-alb --watch        # roll ALB-fronted ECS replicas on save
 
 `cdkl start-service --watch` and `cdkl start-alb --watch` bring the same edit-and-go loop to ECS services. A source-only edit on an interpreted-language handler (Node / Python / Ruby / shell) takes a sub-second fast path; a Dockerfile / dependency / compiled-source change triggers a rolling rebuild. Either way replicas roll one at a time, so the service stays available — an external request stream against the ALB listener port sees zero connection refusals, even on multi-replica services. Synth failures keep the previous replica(s) serving.
 
+The rebuild path waits for the freshly-built shadow replica's first essential-container port to accept a TCP connection before swapping registrations. The default budget is 60s, which covers realistic prod-shaped Node app cold-starts (TS->JS compile, full `node_modules` graph, framework boot, DB pool init). If the reload log surfaces `TCP probe <ip>:<port> did not accept within <N>ms`, bump it via `--shadow-ready-timeout 120000` (or set `CDKL_SHADOW_READY_TIMEOUT_MS=120000`) — typical for Java / heavy ORM init / `--inspect-brk` attach pauses.
+
 Full reload pipeline + glob defaults: [docs/local-emulation.md#hot-reload---watch](docs/local-emulation.md#hot-reload---watch).
 
 ### Local build override — `--image-override`

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1401,8 +1401,9 @@ error.
 | `--no-pull` | off | Skip `docker pull` on every container image and the metadata sidecar. |
 | `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack and substitute `Ref` / `Fn::ImportValue` / supported `Fn::Sub` / `Fn::Join` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Bare form uses the CDK stack name (per target when multiple `<targets...>` are supplied). `Fn::GetAtt` is warn-and-dropped in v1. Same shape as `cdkl run-task --from-cfn-stack`. |
 | `--stack-region <region>` | — | Region used to construct the CloudFormation client for `--from-cfn-stack`. |
-| `--watch` | off | Hot reload: re-synth + per-replica rolling deploy when the CDK app's source changes. Honors `cdk.json` `watch.include` / `watch.exclude` (mirrors `cdk watch`); `cdk.out/`, `node_modules`, and `.git` are always excluded so the reload's own re-synth writes never re-trigger it. 500ms debounce. Each replica is rolled one at a time — boot a shadow replica with the new image under a bumped generation suffix, wait for a TCP-ready probe on the container port, atomically swap Service-Connect / Cloud Map registrations, then retire the old container — so peer services see zero connection refusals across the reload even on multi-replica services. Synth failures keep the previous replica(s) serving (warn-and-continue, never crashes the emulator). |
+| `--watch` | off | Hot reload: re-synth + per-replica rolling deploy when the CDK app's source changes. Honors `cdk.json` `watch.include` / `watch.exclude` (mirrors `cdk watch`); `cdk.out/`, `node_modules`, and `.git` are always excluded so the reload's own re-synth writes never re-trigger it. 500ms debounce. Each replica is rolled one at a time — boot a shadow replica with the new image under a bumped generation suffix, wait for a TCP-ready probe on the container port (default 60s; tunable via `--shadow-ready-timeout`), atomically swap Service-Connect / Cloud Map registrations, then retire the old container — so peer services see zero connection refusals across the reload even on multi-replica services. Synth failures keep the previous replica(s) serving (warn-and-continue, never crashes the emulator). |
 | `--no-logs` | off | Disable foreground streaming of each replica container stdout/stderr. By default every booted replica streams its docker logs to the host terminal with a `[svc=<service> r=<replica-index> c=<container>]` prefix, matching `cdkl run-task`'s log surface so application `console.log` calls are visible without a side `docker logs -f`. The streamer follows replicas across `--watch` reloads (both the rebuild rolling primitive and the soft-reload `docker restart` path). Pass `--no-logs` for multi-replica / multi-service runs whose interleaved log volume is unreadable; `docker logs -f <id>` in a separate terminal stays available. |
+| `--shadow-ready-timeout <ms>` | `60000` | Milliseconds the `--watch` rolling primitive waits for a shadow replica's first essential-container port to accept a TCP connection before swapping registrations off the old replica. Default 60s covers realistic prod-shaped Node app cold-starts (TS->JS compile, full `node_modules` graph, framework boot, DB pool init). Bump higher (e.g. `120000`) when the reload log surfaces `TCP probe <ip>:<port> did not accept within <N>ms` — typical for Java / heavy ORM init / `--inspect-brk` attach pauses. Env var: `CDKL_SHADOW_READY_TIMEOUT_MS` (flag wins over env, env wins over default). Issue #265. |
 
 ### `start-service --watch` (hot reload)
 
@@ -1428,12 +1429,18 @@ For each replica `i` in the old set:
    docker / registry names don't collide with the dying old replica's.
 2. **TCP-ready probe.** The shadow's first essential-container port
    is probed via TCP-connect on the shadow's docker network IP, polled
-   every 100ms up to 10s. Without this gate, the swap could land
-   before the app inside the new image binds its listener, causing
-   peer requests routed to the shadow to see ECONNREFUSED for the
-   first few hundred ms after the roll. A timeout warns + swaps anyway
-   (the dying old replica's image is about to be torn down — the
-   shadow's new image is the user's intent).
+   every 100ms up to the shadow-ready timeout (default 60s; issue #265
+   bumped from 10s after prod-shaped Node apps with non-trivial
+   cold-start tripped the lower ceiling on every save). Without this
+   gate, the swap could land before the app inside the new image binds
+   its listener, causing peer requests routed to the shadow to see
+   ECONNREFUSED for the first few hundred ms after the roll. A timeout
+   warns + swaps anyway (the dying old replica's image is about to be
+   torn down — the shadow's new image is the user's intent). Override
+   the budget via `--shadow-ready-timeout <ms>` or the
+   `CDKL_SHADOW_READY_TIMEOUT_MS` env var (flag wins over env, env
+   wins over the 60s default) when the canonical "TCP probe did not
+   accept within" warning surfaces.
 3. **Atomic registry swap.** The shadow is already registered in
    Cloud Map / Service Connect under a fresh ownerKey (the runner's
    normal publish path). The old replica's registrations are dropped

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -34,7 +34,9 @@ import {
 import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
 import {
   createServiceRunState,
+  DEFAULT_SHADOW_READY_TIMEOUT_MS,
   rollServiceReplica,
+  setShadowReadyTimeoutMs,
   softReloadReplica,
   startEcsService,
   type ServiceController,
@@ -273,6 +275,16 @@ export interface EcsServiceEmulatorOptions {
    * still-uncovered targets. Default off: warn-and-run.
    */
   strictOverrides?: boolean;
+  /**
+   * Issue #265 — `--shadow-ready-timeout <ms>`. Per-invocation
+   * override of the shadow-replica TCP-ready probe budget used by
+   * the `--watch` rolling primitive. Resolved precedence: flag wins
+   * over the `${envPrefix}_SHADOW_READY_TIMEOUT_MS` env var, env wins
+   * over the {@link DEFAULT_SHADOW_READY_TIMEOUT_MS} default (60s).
+   * Positive integer milliseconds; the CLI parser rejects 0 / negative /
+   * non-integer values up-front.
+   */
+  shadowReadyTimeout?: number;
   /** Host-injected extra state-source flag fields. */
   [key: string]: unknown;
 }
@@ -445,6 +457,19 @@ export async function runEcsServiceEmulator(
   // Commander resolves `--no-pull` to `options.pull = false` (the default is
   // true). Compute the "should we skip docker pull?" flag once here.
   const skipPull = options.pull === false;
+
+  // Issue #265 — resolve `--shadow-ready-timeout` / `${envPrefix}_SHADOW_READY_TIMEOUT_MS`
+  // / default precedence ONCE at boot and stamp it onto the runner's
+  // module-level state. The runner's rolling + soft-reload pathways
+  // read `shadowReadyTimeoutMs` (set by `setShadowReadyTimeoutMs`)
+  // on every probe, so a per-invocation value sticks for the entire
+  // session. Done BEFORE any docker / synth budget so an invalid env
+  // value surfaces its warn early.
+  const resolvedShadowReadyTimeoutMs = resolveShadowReadyTimeoutMs(
+    options,
+    getEmbedConfig().envPrefix
+  );
+  setShadowReadyTimeoutMs(resolvedShadowReadyTimeoutMs);
 
   type PerTarget = {
     boot: ServiceBoot;
@@ -2471,6 +2496,53 @@ export function parseRestartPolicy(raw: string): 'on-failure' | 'always' | 'none
 }
 
 /**
+ * Issue #265 — parser for `--shadow-ready-timeout <ms>`. Positive
+ * integer milliseconds; rejects 0 / negative / non-integer / NaN
+ * values up-front so the runner's `setShadowReadyTimeoutMs` guard
+ * is a second line of defense rather than the primary surface.
+ */
+export function parseShadowReadyTimeout(raw: string): number {
+  return parsePositiveInt(raw, '--shadow-ready-timeout');
+}
+
+/**
+ * Issue #265 — resolve the shadow-replica TCP-ready probe budget
+ * from the precedence chain: `--shadow-ready-timeout` flag wins
+ * over the `${envPrefix}_SHADOW_READY_TIMEOUT_MS` env var, env wins
+ * over the {@link DEFAULT_SHADOW_READY_TIMEOUT_MS} default. Exported
+ * so a unit test can verify the precedence without standing up the
+ * full emulator.
+ *
+ * Invalid env values (non-positive / non-integer) are warned about
+ * and dropped — the env var is a convenience knob; a typo there
+ * should NOT fail the whole boot. The flag form is parsed by
+ * Commander's argParser and errors out at parse time, so it is
+ * trusted as a positive integer by the time it reaches here.
+ */
+export function resolveShadowReadyTimeoutMs(
+  options: { shadowReadyTimeout?: number },
+  envPrefix: string,
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  if (typeof options.shadowReadyTimeout === 'number') {
+    return options.shadowReadyTimeout;
+  }
+  const envKey = `${envPrefix}_SHADOW_READY_TIMEOUT_MS`;
+  const raw = env[envKey];
+  if (raw !== undefined && raw !== '') {
+    const parsed = Number(raw);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+    getLogger().warn(
+      `${envKey}='${raw}' is not a positive integer; ignoring and using the ` +
+        `default ${DEFAULT_SHADOW_READY_TIMEOUT_MS}ms shadow-ready timeout.`
+    );
+  }
+  return DEFAULT_SHADOW_READY_TIMEOUT_MS;
+}
+
+/**
  * Resolve the credentials forwarded to the AWS-published metadata-endpoints
  * sidecar (shared across every replica boot in one CLI invocation). `--profile`
  * resolves via the SDK default chain; unset yields `undefined`. Per-service
@@ -2744,6 +2816,20 @@ export function addCommonEcsServiceOptions(cmd: Command): Command {
           'Pass --no-logs for multi-replica / multi-service runs whose interleaved log volume ' +
           'is unreadable; `docker logs -f <id>` in a separate terminal stays available.'
       )
+    )
+    .addOption(
+      new Option(
+        '--shadow-ready-timeout <ms>',
+        "Issue #265 — milliseconds the `--watch` rolling primitive waits for a shadow replica's " +
+          'first essential-container port to accept a TCP connection before swapping Cloud Map + ' +
+          'front-door registrations off the old replica. Defaults to 60000 (60s) which covers ' +
+          'realistic prod-shaped Node app cold-starts (TS->JS compile, full node_modules graph, ' +
+          'framework boot, DB pool init). Bump higher when the reload log surfaces ' +
+          `"TCP probe ${'<ip>:<port>'} did not accept within ${'<N>ms'}" — typical for Java / ` +
+          'heavy ORM init / `--inspect-brk` attach pauses. Honored by ' +
+          `--watch on \`${getEmbedConfig().binaryName} start-service\` and \`${getEmbedConfig().binaryName} start-alb\`. ` +
+          `Env var: \`${getEmbedConfig().envPrefix}_SHADOW_READY_TIMEOUT_MS\` (flag wins over env).`
+      ).argParser(parseShadowReadyTimeout)
     );
 
   [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -2464,8 +2464,17 @@ export function logEndpointsBanner(
 }
 
 function parsePositiveInt(raw: string, flagName: string): number {
-  const parsed = parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
+  // Use `Number` (not `parseInt`) so trailing garbage, decimals, and
+  // scientific notation are rejected rather than silently truncated:
+  //   parseInt('1.5', 10)    -> 1        (silent truncate)
+  //   parseInt('1e6', 10)    -> 1        (parses just the '1')
+  //   parseInt('45000abc')   -> 45000    (trailing garbage)
+  //   Number('1.5')          -> 1.5      -> rejected by isInteger
+  //   Number('1e6')          -> 1000000  -> accepted (correct)
+  //   Number('45000abc')     -> NaN      -> rejected
+  // Plus the leading-empty case: Number('') -> 0 which we reject below.
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
     throw new LocalStartServiceError(`${flagName} must be a positive integer (got '${raw}').`);
   }
   return parsed;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -457,6 +457,21 @@ export {
  * via the symbol import.
  */
 export { SOFT_RELOAD_COMPLETION_LOG_SUFFIX } from './local/ecs-service-runner.js';
+
+/**
+ * Issue #265 — shadow-replica TCP-ready probe budget for the
+ * `--watch` rolling primitive. Host CLIs (cdkd) that wrap
+ * `runEcsServiceEmulator` and expose their own `--shadow-ready-timeout`
+ * flag / `${envPrefix}_SHADOW_READY_TIMEOUT_MS` env var resolve
+ * precedence locally and then call {@link setShadowReadyTimeoutMs}
+ * to stamp the value onto the runner before booting. The
+ * {@link DEFAULT_SHADOW_READY_TIMEOUT_MS} constant is the canonical
+ * fallback when neither flag nor env is supplied.
+ */
+export {
+  DEFAULT_SHADOW_READY_TIMEOUT_MS,
+  setShadowReadyTimeoutMs,
+} from './local/ecs-service-runner.js';
 export { createWatchPredicates, type WatchPredicates } from './cli/commands/local-start-api.js';
 
 /**

--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -1079,17 +1079,64 @@ function unregisterReplicaFromFrontDoor(
 }
 
 /**
- * Phase 2 of issue #214 — shadow-replica readiness probe budget. Tested
- * with busybox httpd's ~50ms listen window and a non-trivial Node
- * Express startup (~1-3s) — 10s caps the rare slow-start app without
- * blocking the roll for typo'd configurations that will never listen.
+ * Phase 2 of issue #214 — shadow-replica readiness probe budget.
+ * Issue #265 bumped the default from 10s to 60s after multiple
+ * production-shaped Node apps (TS->JS compile, full `node_modules`
+ * graph, framework cold-start, DB pool init) tripped the 10s ceiling
+ * on every save under `--watch`, breaking the rolling primitive's
+ * zero-connection-refusal guarantee. 60s covers the realistic
+ * 3-15s prod-shaped cold-start range plus outliers (heavy ORM /
+ * Spring-style boot, debug `--inspect-brk` attach pause) without
+ * tuning. Users with edge cases override via the per-command
+ * `--shadow-ready-timeout <ms>` flag or the `${envPrefix}_SHADOW_READY_TIMEOUT_MS`
+ * env var (e.g. `CDKL_SHADOW_READY_TIMEOUT_MS=120000`); the
+ * `start-service` / `start-alb` boot path calls
+ * {@link setShadowReadyTimeoutMs} once it has resolved the flag /
+ * env / default precedence.
+ *
+ * The cost of an extra wait for a truly-broken container is bounded:
+ * a crashed container surfaces via the runner's container-exit path
+ * immediately — the TCP timeout branch only fires for "container UP
+ * but not yet binding". A genuinely slow-binding app then gets a
+ * clean swap.
  *
  * Mutable so unit tests can shrink the timeout window without
  * standing up a real clock; production callers leave the defaults.
- * Exposed via {@link __setShadowReadyConfig} below.
+ * Exposed via {@link __setShadowReadyConfig} (test-only) and
+ * {@link setShadowReadyTimeoutMs} (boot path).
  */
-let shadowReadyTimeoutMs = 10_000;
+let shadowReadyTimeoutMs = 60_000;
 let shadowReadyIntervalMs = 100;
+
+/**
+ * Default shadow-replica TCP-ready probe budget when no
+ * `--shadow-ready-timeout` flag and no `${envPrefix}_SHADOW_READY_TIMEOUT_MS`
+ * env var are set. Mirrored in JSDoc above {@link shadowReadyTimeoutMs}.
+ */
+export const DEFAULT_SHADOW_READY_TIMEOUT_MS = 60_000;
+
+/**
+ * Boot-path setter for the shadow-replica TCP-ready probe budget.
+ * Called once from `runEcsServiceEmulator` after resolving the
+ * `--shadow-ready-timeout <ms>` flag and the
+ * `${envPrefix}_SHADOW_READY_TIMEOUT_MS` env var (flag wins over env,
+ * env wins over the {@link DEFAULT_SHADOW_READY_TIMEOUT_MS} default).
+ *
+ * Re-exported from `cdk-local/internal` so host CLIs (cdkd) that
+ * wrap `runEcsServiceEmulator` can adopt the same flag / env
+ * surface.
+ *
+ * @param timeoutMs Positive integer milliseconds; values <= 0 are
+ * rejected by the CLI parser before reaching here.
+ */
+export function setShadowReadyTimeoutMs(timeoutMs: number): void {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `setShadowReadyTimeoutMs: timeoutMs must be a positive finite number; got ${timeoutMs}.`
+    );
+  }
+  shadowReadyTimeoutMs = timeoutMs;
+}
 
 /**
  * Test-only hook to shrink the shadow-replica TCP-ready probe's
@@ -1103,7 +1150,7 @@ export function __setShadowReadyConfig(
   config: { timeoutMs: number; intervalMs: number } | undefined
 ): void {
   if (config === undefined) {
-    shadowReadyTimeoutMs = 10_000;
+    shadowReadyTimeoutMs = 60_000;
     shadowReadyIntervalMs = 100;
     return;
   }
@@ -1962,12 +2009,18 @@ async function waitForReplicaTcpReady(
   }
 
   const port = essential.portMappings[0]!.containerPort;
-  const deadline = Date.now() + opts.timeoutMs;
+  const startedAt = Date.now();
+  const deadline = startedAt + opts.timeoutMs;
   let lastErr: string | undefined;
   while (Date.now() < deadline) {
     try {
       await tcpProbeImpl(ip, port);
-      logger.debug(`${label}: TCP probe ${ip}:${port} accepted.`);
+      // Issue #265 — surface the elapsed-ms on success so users
+      // tuning `--shadow-ready-timeout` (or
+      // `${envPrefix}_SHADOW_READY_TIMEOUT_MS`) know what budget to
+      // set. Kept at debug level so it only shows under verbose.
+      const elapsedMs = Date.now() - startedAt;
+      logger.debug(`${label}: TCP probe ${ip}:${port} accepted in ${elapsedMs}ms.`);
       return;
     } catch (err) {
       lastErr = err instanceof Error ? err.message : String(err);

--- a/tests/unit/cli/ecs-service-emulator-shadow-ready-timeout.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-shadow-ready-timeout.test.ts
@@ -31,13 +31,21 @@ describe('shadow-ready-timeout resolution (issue #265)', () => {
       expect(parseShadowReadyTimeout('45000')).toBe(45000);
       expect(parseShadowReadyTimeout('1')).toBe(1);
       expect(parseShadowReadyTimeout('120000')).toBe(120000);
+      // Scientific notation expands to an integer — accepted (so a
+      // user who genuinely types `1e6` gets 1,000,000ms, not a silent
+      // truncation to 1 like `parseInt` would produce).
+      expect(parseShadowReadyTimeout('1e6')).toBe(1_000_000);
     });
 
-    it('rejects 0 / negative / non-numeric input', () => {
+    it('rejects 0 / negative / non-numeric / trailing-garbage / decimal input', () => {
       expect(() => parseShadowReadyTimeout('0')).toThrow();
       expect(() => parseShadowReadyTimeout('-1')).toThrow();
       expect(() => parseShadowReadyTimeout('abc')).toThrow();
       expect(() => parseShadowReadyTimeout('')).toThrow();
+      // Reviewer-flagged foot-guns previously silently accepted via
+      // `parseInt`'s lenient parsing — now strict.
+      expect(() => parseShadowReadyTimeout('1.5')).toThrow();
+      expect(() => parseShadowReadyTimeout('45000abc')).toThrow();
     });
   });
 

--- a/tests/unit/cli/ecs-service-emulator-shadow-ready-timeout.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-shadow-ready-timeout.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import {
+  parseShadowReadyTimeout,
+  resolveShadowReadyTimeoutMs,
+} from '../../../src/cli/commands/ecs-service-emulator.js';
+import { resetEmbedConfig, setEmbedConfig } from '../../../src/local/embed-config.js';
+import {
+  DEFAULT_SHADOW_READY_TIMEOUT_MS,
+  setShadowReadyTimeoutMs,
+} from '../../../src/local/ecs-service-runner.js';
+
+/**
+ * Issue #265 — `--shadow-ready-timeout <ms>` flag + env-var precedence
+ * for the `--watch` rolling primitive's shadow-replica TCP-ready
+ * probe budget. The flag wires through `addCommonEcsServiceOptions`
+ * onto both `start-service` and `start-alb`; this file pins the
+ * resolution helper (default, env, flag-wins-over-env) and the
+ * boot-path setter independently of the full emulator harness.
+ */
+
+describe('shadow-ready-timeout resolution (issue #265)', () => {
+  beforeEach(() => {
+    resetEmbedConfig();
+  });
+  afterEach(() => {
+    resetEmbedConfig();
+  });
+
+  describe('parseShadowReadyTimeout (--shadow-ready-timeout argParser)', () => {
+    it('accepts a positive integer milliseconds value', () => {
+      expect(parseShadowReadyTimeout('45000')).toBe(45000);
+      expect(parseShadowReadyTimeout('1')).toBe(1);
+      expect(parseShadowReadyTimeout('120000')).toBe(120000);
+    });
+
+    it('rejects 0 / negative / non-numeric input', () => {
+      expect(() => parseShadowReadyTimeout('0')).toThrow();
+      expect(() => parseShadowReadyTimeout('-1')).toThrow();
+      expect(() => parseShadowReadyTimeout('abc')).toThrow();
+      expect(() => parseShadowReadyTimeout('')).toThrow();
+    });
+  });
+
+  describe('resolveShadowReadyTimeoutMs precedence', () => {
+    it('returns the 60s default when no flag and no env var are set', () => {
+      const resolved = resolveShadowReadyTimeoutMs({}, 'CDKL', {});
+      expect(resolved).toBe(60_000);
+      expect(resolved).toBe(DEFAULT_SHADOW_READY_TIMEOUT_MS);
+    });
+
+    it('resolves the env-var value when no flag is supplied', () => {
+      const resolved = resolveShadowReadyTimeoutMs(
+        {},
+        'CDKL',
+        { CDKL_SHADOW_READY_TIMEOUT_MS: '45000' }
+      );
+      expect(resolved).toBe(45_000);
+    });
+
+    it('flag wins over env when both are set', () => {
+      const resolved = resolveShadowReadyTimeoutMs(
+        { shadowReadyTimeout: 30_000 },
+        'CDKL',
+        { CDKL_SHADOW_READY_TIMEOUT_MS: '90000' }
+      );
+      expect(resolved).toBe(30_000);
+    });
+
+    it('honors a host-supplied envPrefix (e.g. CDKD)', () => {
+      const resolved = resolveShadowReadyTimeoutMs(
+        {},
+        'CDKD',
+        { CDKD_SHADOW_READY_TIMEOUT_MS: '75000' }
+      );
+      expect(resolved).toBe(75_000);
+    });
+
+    it('falls back to the default + warns on an invalid env value', async () => {
+      const { getLogger } = await import('../../../src/utils/logger.js');
+      const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+      try {
+        const resolved = resolveShadowReadyTimeoutMs(
+          {},
+          'CDKL',
+          { CDKL_SHADOW_READY_TIMEOUT_MS: 'banana' }
+        );
+        expect(resolved).toBe(DEFAULT_SHADOW_READY_TIMEOUT_MS);
+        const matched = warnSpy.mock.calls.find((args) =>
+          String(args[0]).includes("CDKL_SHADOW_READY_TIMEOUT_MS='banana'")
+        );
+        expect(matched).toBeDefined();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('falls back to the default on a zero / negative env value (silent + warn)', async () => {
+      const { getLogger } = await import('../../../src/utils/logger.js');
+      const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+      try {
+        const zero = resolveShadowReadyTimeoutMs(
+          {},
+          'CDKL',
+          { CDKL_SHADOW_READY_TIMEOUT_MS: '0' }
+        );
+        const neg = resolveShadowReadyTimeoutMs(
+          {},
+          'CDKL',
+          { CDKL_SHADOW_READY_TIMEOUT_MS: '-5' }
+        );
+        expect(zero).toBe(DEFAULT_SHADOW_READY_TIMEOUT_MS);
+        expect(neg).toBe(DEFAULT_SHADOW_READY_TIMEOUT_MS);
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('treats an empty-string env value the same as unset', () => {
+      const resolved = resolveShadowReadyTimeoutMs(
+        {},
+        'CDKL',
+        { CDKL_SHADOW_READY_TIMEOUT_MS: '' }
+      );
+      expect(resolved).toBe(DEFAULT_SHADOW_READY_TIMEOUT_MS);
+    });
+  });
+
+  describe('addCommonEcsServiceOptions wiring', () => {
+    it('registers --shadow-ready-timeout on both start-service and start-alb command surfaces', async () => {
+      const { Command } = await import('commander');
+      const { addCommonEcsServiceOptions } = await import(
+        '../../../src/cli/commands/ecs-service-emulator.js'
+      );
+      const svc = addCommonEcsServiceOptions(new Command('start-service'));
+      const alb = addCommonEcsServiceOptions(new Command('start-alb'));
+      const svcOpt = svc.options.find((o) => o.long === '--shadow-ready-timeout');
+      const albOpt = alb.options.find((o) => o.long === '--shadow-ready-timeout');
+      expect(svcOpt).toBeDefined();
+      expect(albOpt).toBeDefined();
+      // The help text MUST cite the canonical warning so users grep
+      // their reload log -> find the flag.
+      expect(svcOpt!.description).toMatch(/TCP probe/);
+      expect(svcOpt!.description).toMatch(/did not accept within/);
+      // Env-var hint must surface in --help so the env-var precedence
+      // is discoverable.
+      expect(svcOpt!.description).toMatch(/CDKL_SHADOW_READY_TIMEOUT_MS/);
+    });
+
+    it('parses --shadow-ready-timeout 45000 into options.shadowReadyTimeout = 45000', async () => {
+      const { Command } = await import('commander');
+      const { addCommonEcsServiceOptions } = await import(
+        '../../../src/cli/commands/ecs-service-emulator.js'
+      );
+      const cmd = addCommonEcsServiceOptions(new Command('start-service')).action(() => {});
+      cmd.exitOverride();
+      cmd.parse(['node', 'cdkl', '--shadow-ready-timeout', '45000'], { from: 'user' });
+      expect(cmd.opts().shadowReadyTimeout).toBe(45000);
+    });
+
+    it('uses the configured envPrefix in the --help text when embed-config is overridden', async () => {
+      setEmbedConfig({ envPrefix: 'CDKD' });
+      const { Command } = await import('commander');
+      const { addCommonEcsServiceOptions } = await import(
+        '../../../src/cli/commands/ecs-service-emulator.js'
+      );
+      const cmd = addCommonEcsServiceOptions(new Command('start-service'));
+      const opt = cmd.options.find((o) => o.long === '--shadow-ready-timeout');
+      expect(opt!.description).toMatch(/CDKD_SHADOW_READY_TIMEOUT_MS/);
+    });
+  });
+
+  describe('setShadowReadyTimeoutMs guard', () => {
+    afterEach(() => {
+      // Restore the production default so sibling tests in this file
+      // don't leak the override.
+      setShadowReadyTimeoutMs(DEFAULT_SHADOW_READY_TIMEOUT_MS);
+    });
+
+    it('accepts a positive finite value', () => {
+      expect(() => setShadowReadyTimeoutMs(1)).not.toThrow();
+      expect(() => setShadowReadyTimeoutMs(60_000)).not.toThrow();
+    });
+
+    it('rejects 0 / negative / non-finite values (defense-in-depth)', () => {
+      expect(() => setShadowReadyTimeoutMs(0)).toThrow();
+      expect(() => setShadowReadyTimeoutMs(-1)).toThrow();
+      expect(() => setShadowReadyTimeoutMs(Number.NaN)).toThrow();
+      expect(() => setShadowReadyTimeoutMs(Number.POSITIVE_INFINITY)).toThrow();
+    });
+  });
+});

--- a/tests/unit/local/ecs-service-runner-rolling.test.ts
+++ b/tests/unit/local/ecs-service-runner-rolling.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { FrontDoorEndpointPool } from '../../../src/local/front-door-pool.js';
 import { CloudMapRegistry } from '../../../src/local/cloud-map-registry.js';
+import { ConsoleLogger } from '../../../src/utils/logger.js';
 
 /**
  * Phase 2 of issue #214 — locks `rollServiceReplica` semantics (the
@@ -340,6 +341,40 @@ describe('rollServiceReplica (Phase 2 of issue #214)', () => {
     expect(pool.size()).toBe(2);
 
     await controller.shutdown();
+  });
+
+  it('TCP-ready probe success: debug log surfaces the elapsed-ms (issue #265)', async () => {
+    // Issue #265 — the probe used to log only on FAIL. On success it
+    // now surfaces `${label}: TCP probe <ip>:<port> accepted in <N>ms`
+    // at debug level so users tuning `--shadow-ready-timeout` know
+    // what budget to set. The fake probe always resolves immediately
+    // (see beforeEach) so the elapsed-ms is a small non-negative
+    // integer.
+    const debugSpy = vi.spyOn(ConsoleLogger.prototype, 'debug').mockImplementation(() => {});
+
+    const pool = new FrontDoorEndpointPool();
+    const registry = new CloudMapRegistry();
+    const runState = createServiceRunState();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = frontDoorOptions(pool, registry) as any;
+    const controller = await startEcsService(fakeServiceConnectService(), opts, runState);
+    expect(controller.runState.replicas.length).toBe(2);
+
+    await rollServiceReplica({
+      controller,
+      oldReplicaIndex: 0,
+      newService: fakeServiceConnectService(),
+      newOptions: opts,
+    });
+
+    const debugLines = debugSpy.mock.calls.map((c) => String(c[0]));
+    const match = debugLines.find((l) =>
+      /TCP probe [\d.]+:\d+ accepted in \d+ms\.$/.test(l)
+    );
+    expect(match).toBeDefined();
+
+    await controller.shutdown();
+    debugSpy.mockRestore();
   });
 
   it('TCP-ready probe timing out: warns + swaps anyway (the new image is the user intent)', async () => {


### PR DESCRIPTION
## Symptom

Under `cdkl start-service --watch` / `cdkl start-alb --watch` against a production-shaped Node container (TS->JS compile, full `node_modules` graph, framework bootstrap, DB pool init), the shadow replica's TCP-ready probe timed out within 10 seconds on every save:

```
Shadow replica r0 (gen 1): TCP probe 169.254.171.3:80 did not accept within 10000ms (last: connect ETIMEDOUT 169.254.171.3:80). Proceeding anyway — the new source is the user intent. Initial requests may 502 until the app finishes binding.
```

cdkl swapped Cloud Map + front-door registrations anyway, so requests routed to the freshly-booted replica returned **502 for ~5-10 seconds after every save**. This broke the Phase 1-3 zero-connection-refusal guarantee that the rolling primitive's documentation promises.

## Root cause

`src/local/ecs-service-runner.ts` carried a hard-coded `shadowReadyTimeoutMs = 10_000`. 10 seconds is fine for a hello-world Node container but tight for any real-world prod app: framework bootstrap + DB pool init + `node_modules` resolution typically run 3-15s, with outliers (Java / Spring, heavy ORM init, `--inspect-brk` attach pause) up to 60s. The only override was a test-only `__setShadowReadyConfig` — no CLI flag, no env var, no user-facing knob.

## Fix (4 parts)

1. **Default bumped to 60s.** `shadowReadyTimeoutMs` defaults to 60_000 (new exported `DEFAULT_SHADOW_READY_TIMEOUT_MS` constant). Covers ~99% of realistic prod-shaped apps without tuning. The cost of an extra wait for a truly-broken container is bounded: a crashed container surfaces via the runner's container-exit path immediately; the TCP timeout branch only fires for "container UP but not yet binding". A genuinely slow-binding app then gets a clean swap.

2. **`--shadow-ready-timeout <ms>` flag added to both `cdkl start-service` and `cdkl start-alb`.** Wired once via the shared `addCommonEcsServiceOptions` helper so it lands on both commands in one place. Positive-integer argParser rejects 0 / negative / non-numeric values up-front.

3. **`${envPrefix}_SHADOW_READY_TIMEOUT_MS` env var** (e.g. `CDKL_SHADOW_READY_TIMEOUT_MS=120000`, or `CDKD_SHADOW_READY_TIMEOUT_MS` for the cdkd embed). Precedence: flag wins over env, env wins over default. A new `resolveShadowReadyTimeoutMs` helper is called once at the top of `runEcsServiceEmulator` and stamps the value onto the runner via a new non-internal `setShadowReadyTimeoutMs(ms)`. Invalid env values warn-and-fall-back to the default rather than aborting the boot.

4. **Probe-success log now surfaces the elapsed-ms.** The debug-level success line went from `TCP probe <ip>:<port> accepted.` to `TCP probe <ip>:<port> accepted in <N>ms.`, kept at debug level so it only shows under verbose. Users tuning the budget now know what value to set.

## Surface details

- `setShadowReadyTimeoutMs` + `DEFAULT_SHADOW_READY_TIMEOUT_MS` are re-exported from `cdk-local/internal` so host CLIs (cdkd) that wrap `runEcsServiceEmulator` can adopt the same flag + env surface.
- `--help` text cites the canonical `"TCP probe ... did not accept within"` warning so users grep their reload log -> find the flag.
- README + `docs/local-emulation.md` updated near the `--watch` section with the 60s default + the override recipe.

## Test plan

New / extended unit tests:

- `tests/unit/cli/ecs-service-emulator-shadow-ready-timeout.test.ts`:
  - default = 60_000 when no flag / env set (also asserts equality with `DEFAULT_SHADOW_READY_TIMEOUT_MS`)
  - env-var value resolves when flag absent (`CDKL_SHADOW_READY_TIMEOUT_MS=45000` -> 45000)
  - flag wins over env when both set
  - host-supplied envPrefix honored (`CDKD_SHADOW_READY_TIMEOUT_MS`)
  - invalid / zero / negative env value falls back to default + warns
  - empty-string env value treated as unset
  - `parseShadowReadyTimeout` rejects 0 / negative / non-numeric inputs
  - `--shadow-ready-timeout` is registered on BOTH `start-service` and `start-alb` command surfaces
  - `--help` text contains `TCP probe`, `did not accept within`, and `CDKL_SHADOW_READY_TIMEOUT_MS`
  - `--shadow-ready-timeout 45000` is parsed into `options.shadowReadyTimeout = 45000`
  - `--help` text reflects an overridden envPrefix (`CDKD_SHADOW_READY_TIMEOUT_MS`)
  - `setShadowReadyTimeoutMs` accepts positive finite values, rejects 0 / negative / NaN / Infinity
- `tests/unit/local/ecs-service-runner-rolling.test.ts`:
  - new "probe-success log surfaces elapsed-ms" case spies on `ConsoleLogger.prototype.debug` and asserts the runner emits `TCP probe <ip>:<port> accepted in <N>ms.` on a successful shadow boot
  - existing `__setShadowReadyConfig`-driven tests still pass — the test-only restore path now defaults to 60_000 (matching the new production default)

Manual repro recipe:

1. Boot any multi-replica Node service via `cdkl start-service --watch <Target>` against a fixture that takes 12s to bind (e.g. add `await new Promise(r => setTimeout(r, 12_000))` before `app.listen(...)`).
2. Edit a handler file; without the fix, the reload log surfaces the 10000ms timeout warning and curl against the listener port hits 502 for 5-10s. With the fix, the swap waits up to 60s and curl never sees a 502.
3. Override with `--shadow-ready-timeout 5000` (or `CDKL_SHADOW_READY_TIMEOUT_MS=5000`) and confirm the warning fires again (precedence sanity-check).

Closes #265
