### PR TITLE
feat(docker): show interactive spinner during long docker build / pull

### DIFF
--- a/src/assets/docker-build.ts
+++ b/src/assets/docker-build.ts
@@ -54,6 +54,16 @@ export interface BuildDockerImageOptions {
    * specific to the call site.
    */
   wrapError: (stderr: string) => Error;
+  /**
+   * When set, forward to `runDockerStreaming` so an interactive spinner
+   * renders for the duration of the `docker build`. Callers like
+   * `docker-image-builder.ts` (Lambda container builds) and
+   * `ecs-task-runner.ts` (ECS asset builds) set this to "Building
+   * container image '<tag>'..." so real-world multi-minute builds don't
+   * look like cdk-local hung. No-op in `executable` source mode and
+   * when stdout is non-TTY.
+   */
+  progressLabel?: string;
 }
 
 /**
@@ -147,6 +157,7 @@ export async function buildDockerImage(
       // this, BuildKit/Buildx attaches provenance attestation manifests
       // that ECR's single-arch pull path rejects.
       env: { BUILDX_NO_DEFAULT_ATTESTATIONS: '1' },
+      ...(options.progressLabel !== undefined && { progressLabel: options.progressLabel }),
     });
   } catch (err) {
     const e = err as { stderr?: string; message?: string };

--- a/src/local/agentcore-code-build.ts
+++ b/src/local/agentcore-code-build.ts
@@ -97,16 +97,10 @@ export async function buildAgentCoreCodeImage(
   const dockerfilePath = join(buildDir, 'Dockerfile');
   try {
     await writeFile(dockerfilePath, dockerfile, 'utf-8');
-    await runDockerStreaming([
-      'build',
-      '--platform',
-      platform,
-      '--tag',
-      tag,
-      '--file',
-      dockerfilePath,
-      options.sourceDir,
-    ]);
+    await runDockerStreaming(
+      ['build', '--platform', platform, '--tag', tag, '--file', dockerfilePath, options.sourceDir],
+      { progressLabel: `Building agent image (runtime=${options.runtime})` }
+    );
   } catch (err) {
     const stderr = (err as { stderr?: string }).stderr?.trim();
     throw new LocalInvokeBuildError(

--- a/src/local/docker-image-builder.ts
+++ b/src/local/docker-image-builder.ts
@@ -82,6 +82,7 @@ export async function buildContainerImage(
       new LocalInvokeBuildError(
         `docker build failed for container Lambda asset (${asset.source.directory ?? asset.source.executable?.join(' ')}): ${stderr}`
       ),
+    progressLabel: `Building container image (platform=${platform})`,
   });
   if (actualTag !== tag) {
     logger.debug(`Re-tagging executable-built image '${actualTag}' → '${tag}'`);

--- a/src/local/docker-runner.ts
+++ b/src/local/docker-runner.ts
@@ -183,9 +183,14 @@ export async function pullImage(image: string, skipPull: boolean): Promise<void>
   // Captured-mode pull: stdout/stderr collected, mirrored only when
   // --verbose is on (which the branch above already handles via
   // runDockerForeground), so streamLive: false keeps the silent
-  // contract on the default compact log level.
+  // contract on the default compact log level. The spinner shows
+  // motion during what is otherwise a multi-minute silent pull
+  // against a real-world image.
   try {
-    await runDockerStreaming(['pull', image], { streamLive: false });
+    await runDockerStreaming(['pull', image], {
+      streamLive: false,
+      progressLabel: `Pulling ${image}`,
+    });
   } catch (err) {
     const e = err as {
       exitCode?: number | null;

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -853,6 +853,7 @@ async function prepareOneImage(
           new LocalInvokeBuildError(
             `docker build failed for ECS container '${container.name}' (${asset.source.directory ?? asset.source.executable?.join(' ')}): ${stderr}`
           ),
+        progressLabel: `Building container image for '${container.name}'`,
       });
       if (actualTag !== tag) {
         // `executable` source mode returns the script's own tag — re-tag

--- a/src/local/image-override-engine.ts
+++ b/src/local/image-override-engine.ts
@@ -997,6 +997,13 @@ export async function runImageOverrideBuilds(
       await runDockerStreaming(args, {
         cwd: entry.contextDir,
         env: { BUILDX_NO_DEFAULT_ATTESTATIONS: '1' },
+        // The pre-spawn `logger.info` line above explains WHAT is being
+        // built (which target, which Dockerfile, which tag). The spinner's
+        // job is just to show MOTION so a multi-minute BuildKit build
+        // doesn't look like cdk-local hung. The shorter label keeps the
+        // spinner line readable on narrow terminals — the (tag=...) detail
+        // already shipped via the info log line and is in the scrollback.
+        progressLabel: `Building override image for '${target}'`,
       });
     } catch (err) {
       const e = err as { stderr?: string; message?: string };

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { spinner as createSpinner } from '@clack/prompts';
 import { getLogger } from './logger.js';
 import { getEmbedConfig } from '../local/embed-config.js';
 
@@ -63,6 +64,30 @@ export interface RunDockerOptions {
    * level" — matches the existing `--verbose` UX.
    */
   streamLive?: boolean;
+  /**
+   * When set, show an interactive {@link createSpinner | clack spinner}
+   * with this label for the duration of the spawn — so a long-running
+   * `docker build` / `docker pull` against a real-world image doesn't
+   * look like cdk-local hung. The spinner only renders when:
+   *
+   *   - `streamLive` is false (live BuildKit output already shows motion;
+   *     overlaying a spinner on top would visually clash and the line
+   *     overwriting would mangle the build log), AND
+   *   - `process.stdout` is a TTY (non-TTY callers such as integ-test
+   *     fixtures or CI runs already log linearly; a spinner there would
+   *     emit raw ANSI escapes into the captured log).
+   *
+   * In either skipped case the spawn proceeds as if `progressLabel` were
+   * undefined — the caller's pre-spawn `logger.info(...)` "Building X..."
+   * line continues to be the only progress signal, which is the
+   * pre-spinner behavior and matches what scripts / CI expect.
+   *
+   * On exit code 0 the spinner stops with the same label and a check
+   * mark; on non-zero exit it stops with an error mark before the
+   * rejection propagates, so the caller's `try {} catch {}` wrap still
+   * sees a clean spinner-less stderr.
+   */
+  progressLabel?: string;
 }
 
 /**
@@ -95,6 +120,7 @@ export async function spawnStreaming(
 ): Promise<SpawnResult> {
   const streamLive = options.streamLive ?? getLogger().getLevel() === 'debug';
   const env = options.env ? mergeEnv(options.env) : undefined;
+  const spin = startProgressSpinner(options.progressLabel, streamLive);
 
   return new Promise<SpawnResult>((resolve, reject) => {
     const child = spawn(cmd, args, {
@@ -116,6 +142,7 @@ export async function spawnStreaming(
     });
 
     child.once('error', (err: NodeJS.ErrnoException) => {
+      stopProgressSpinner(spin, options.progressLabel);
       if (err.code === 'ENOENT') {
         const usingOverride = process.env['CDK_DOCKER'] === cmd && cmd !== 'docker';
         reject(
@@ -136,8 +163,10 @@ export async function spawnStreaming(
       const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
       const stderr = Buffer.concat(stderrChunks).toString('utf-8');
       if (code === 0) {
+        stopProgressSpinner(spin, options.progressLabel);
         resolve({ stdout, stderr });
       } else {
+        stopProgressSpinner(spin, options.progressLabel);
         const message =
           stderr.trim() || stdout.trim() || `${cmd} ${args[0] ?? ''} exited with code ${code}`;
         const err = new Error(message) as SpawnError;
@@ -163,6 +192,38 @@ export async function spawnStreaming(
       child.stdin!.end();
     }
   });
+}
+
+type ClackSpinner = ReturnType<typeof createSpinner>;
+
+/**
+ * Start an interactive clack spinner for the spawn, but only when the
+ * current shell would actually render it (TTY) and the caller isn't
+ * already streaming live output. Returns `undefined` when either
+ * precondition fails — `stopProgressSpinner` then is a no-op.
+ *
+ * Test seam: the integration with `@clack/prompts` is mocked in
+ * `tests/unit/utils/docker-cmd-progress-spinner.test.ts`.
+ */
+function startProgressSpinner(
+  label: string | undefined,
+  streamLive: boolean
+): ClackSpinner | undefined {
+  if (label === undefined || streamLive || process.stdout.isTTY !== true) return undefined;
+  const spin = createSpinner();
+  spin.start(label);
+  return spin;
+}
+
+function stopProgressSpinner(spin: ClackSpinner | undefined, label: string | undefined): void {
+  // `@clack/prompts`' `spinner().stop(message?)` only takes the message at
+  // the TS-level signature (the runtime impl ignores the optional `code`
+  // second arg, hard-coding success), so we mirror its public API. The
+  // upstream caller's wrapped error / rejection still surfaces the
+  // failure detail; the spinner's only job here is to stop animating
+  // cleanly so the error stderr renders on its own fresh line.
+  if (spin === undefined) return;
+  spin.stop(label ?? '');
 }
 
 /**

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -86,6 +86,18 @@ export interface RunDockerOptions {
    * mark; on non-zero exit it stops with an error mark before the
    * rejection propagates, so the caller's `try {} catch {}` wrap still
    * sees a clean spinner-less stderr.
+   *
+   * Concurrency: each `@clack/prompts` spinner instance registers its own
+   * `SIGINT` / `SIGTERM` / `exit` / `uncaughtExceptionMonitor` /
+   * `unhandledRejection` listeners against `process`. Callers must
+   * serialize concurrent spinner-bearing `spawnStreaming` invocations on
+   * the same `process.stdout` — two simultaneous spinners overwrite each
+   * other's frame line AND accumulate listeners (Node trips its default
+   * 10-listener warning at ~3 concurrent spinners). Every cdk-local call
+   * site as of this PR is strictly sequential
+   * (`runImageOverrideBuilds` for-of, `prepareImages` for-of, ECS
+   * Lambda asset builds are one-per-invoke); the future parallel-build
+   * path should either drop the label or memoize a single shared spinner.
    */
   progressLabel?: string;
 }
@@ -123,11 +135,25 @@ export async function spawnStreaming(
   const spin = startProgressSpinner(options.progressLabel, streamLive);
 
   return new Promise<SpawnResult>((resolve, reject) => {
-    const child = spawn(cmd, args, {
-      cwd: options.cwd,
-      env,
-      stdio: [options.input ? 'pipe' : 'ignore', 'pipe', 'pipe'],
-    });
+    // Defensive: a synchronous throw from `spawn` (e.g. Node's
+    // `ERR_INVALID_ARG_TYPE` on a non-string `cmd`) bypasses the close /
+    // error handlers below — without this try/catch the spinner would be
+    // left animating until process exit. Today unreachable
+    // (`getDockerCmd()` always returns a string + all call-site `args`
+    // are `string[]`), but the wrap is free defense-in-depth on a
+    // process-launch helper.
+    let child;
+    try {
+      child = spawn(cmd, args, {
+        cwd: options.cwd,
+        env,
+        stdio: [options.input ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      stopProgressSpinner(spin, options.progressLabel);
+      reject(err as Error);
+      return;
+    }
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];

--- a/tests/unit/local/image-override-engine.test.ts
+++ b/tests/unit/local/image-override-engine.test.ts
@@ -392,6 +392,24 @@ describe('runImageOverrideBuilds argv shape (issue #238, T1)', () => {
     expect(opts.env?.BUILDX_NO_DEFAULT_ATTESTATIONS).toBe('1');
   });
 
+  it('passes a per-target progressLabel through to runDockerStreaming so the multi-minute build animates', async () => {
+    const dockerfile = makeTmpDockerfile('Dockerfile.progress');
+    const overrides = new Map([
+      [
+        'AppService',
+        {
+          dockerfile,
+          contextDir: path.dirname(dockerfile),
+          buildArgs: new Map<string, string>(),
+          buildSecrets: new Map<string, string>(),
+        },
+      ],
+    ]);
+    await runImageOverrideBuilds(overrides);
+    const [, opts] = runDockerStreamingMock.mock.calls[0]!;
+    expect(opts.progressLabel).toBe(`Building override image for 'AppService'`);
+  });
+
   it('emits canonical `--secret id=<id>,src=<src>` for every build-secrets entry', async () => {
     const dockerfile = makeTmpDockerfile('Dockerfile.secrets');
     const overrides = new Map([

--- a/tests/unit/utils/docker-cmd-progress-spinner.test.ts
+++ b/tests/unit/utils/docker-cmd-progress-spinner.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for the `progressLabel` spinner integration in `spawnStreaming`.
+ *
+ * User-reported gap (image-override path): a multi-minute `docker build`
+ * looked like cdk-local had hung — `logger.info("Building override
+ * image...")` fired once and nothing animated until the build completed
+ * or failed. The spinner is the visible motion that closes that gap.
+ *
+ * The mocked surface:
+ *   - `node:child_process.spawn` — control exit code + stream events.
+ *   - `@clack/prompts.spinner` — count `.start` / `.stop` calls.
+ *   - `process.stdout.isTTY` — toggle the TTY precondition.
+ */
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runDockerStreaming } from '../../../src/utils/docker-cmd.js';
+import { getLogger } from '../../../src/utils/logger.js';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+
+const spinnerStartMock = vi.hoisted(() => vi.fn());
+const spinnerStopMock = vi.hoisted(() => vi.fn());
+const spinnerFactoryMock = vi.hoisted(() =>
+  vi.fn(() => ({ start: spinnerStartMock, stop: spinnerStopMock }))
+);
+vi.mock('@clack/prompts', () => ({ spinner: spinnerFactoryMock }));
+
+type FakeChild = EventEmitter & {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: { on: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+};
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = Readable.from([]);
+  child.stderr = Readable.from([]);
+  child.stdin = { on: vi.fn(), write: vi.fn(), end: vi.fn() };
+  return child;
+}
+
+describe('spawnStreaming progressLabel spinner', () => {
+  const originalIsTTY = process.stdout.isTTY;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spinnerStartMock.mockReset();
+    spinnerStopMock.mockReset();
+    spinnerFactoryMock.mockClear();
+    // Logger at info level so streamLive defaults to false.
+    getLogger().setLevel('info');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+  });
+
+  it('starts + stops a spinner with the given label on success when TTY + non-streamLive + label set', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runDockerStreaming(['build', '.'], { progressLabel: 'Building foo' });
+    // Emit close(0) on the next tick so the listener attaches first.
+    setImmediate(() => child.emit('close', 0));
+    await promise;
+
+    expect(spinnerFactoryMock).toHaveBeenCalledTimes(1);
+    expect(spinnerStartMock).toHaveBeenCalledWith('Building foo');
+    expect(spinnerStopMock).toHaveBeenCalledWith('Building foo');
+  });
+
+  it('stops the spinner on non-zero exit so the upstream error stderr renders cleanly', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runDockerStreaming(['build', '.'], { progressLabel: 'Building foo' });
+    setImmediate(() => child.emit('close', 1));
+    await expect(promise).rejects.toBeInstanceOf(Error);
+
+    expect(spinnerStartMock).toHaveBeenCalledWith('Building foo');
+    expect(spinnerStopMock).toHaveBeenCalledWith('Building foo');
+  });
+
+  it('stops the spinner on spawn ENOENT before the rejection propagates', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runDockerStreaming(['build', '.'], { progressLabel: 'Building foo' });
+    setImmediate(() => {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      child.emit('error', err);
+    });
+    await expect(promise).rejects.toThrow(/Install Docker/);
+
+    expect(spinnerStartMock).toHaveBeenCalledWith('Building foo');
+    expect(spinnerStopMock).toHaveBeenCalledWith('Building foo');
+  });
+
+  it('does NOT start a spinner when stdout is not a TTY (CI / piped invocations)', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runDockerStreaming(['build', '.'], { progressLabel: 'Building foo' });
+    setImmediate(() => child.emit('close', 0));
+    await promise;
+
+    expect(spinnerFactoryMock).not.toHaveBeenCalled();
+    expect(spinnerStartMock).not.toHaveBeenCalled();
+    expect(spinnerStopMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT start a spinner when streamLive is true (live BuildKit output already shows motion)', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runDockerStreaming(['build', '.'], {
+      progressLabel: 'Building foo',
+      streamLive: true,
+    });
+    setImmediate(() => child.emit('close', 0));
+    await promise;
+
+    expect(spinnerFactoryMock).not.toHaveBeenCalled();
+    expect(spinnerStartMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT start a spinner when progressLabel is undefined (pre-spinner default behavior)', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runDockerStreaming(['build', '.'], {});
+    setImmediate(() => child.emit('close', 0));
+    await promise;
+
+    expect(spinnerFactoryMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/docker-cmd-progress-spinner.test.ts
+++ b/tests/unit/utils/docker-cmd-progress-spinner.test.ts
@@ -132,6 +132,23 @@ describe('spawnStreaming progressLabel spinner', () => {
     expect(spinnerStartMock).not.toHaveBeenCalled();
   });
 
+  it('stops the spinner on a synchronous spawn throw so it does not animate until process exit', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    spawnMock.mockImplementation(() => {
+      const err: NodeJS.ErrnoException = Object.assign(new Error('ERR_INVALID_ARG_TYPE'), {
+        code: 'ERR_INVALID_ARG_TYPE',
+      });
+      throw err;
+    });
+
+    await expect(
+      runDockerStreaming(['build', '.'], { progressLabel: 'Building foo' })
+    ).rejects.toThrow(/ERR_INVALID_ARG_TYPE/);
+
+    expect(spinnerStartMock).toHaveBeenCalledWith('Building foo');
+    expect(spinnerStopMock).toHaveBeenCalledWith('Building foo');
+  });
+
   it('does NOT start a spinner when progressLabel is undefined (pre-spinner default behavior)', async () => {
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
     const child = makeChild();


### PR DESCRIPTION
## Summary

User-reported gap: `cdkl start-service --watch --image-override ./Dockerfile` against a real-world Node container (TS->JS compile + `yarn install --frozen-lockfile` + private-registry `RUN --mount=type=secret`) runs `docker build` for minutes with zero terminal motion. The pre-spawn `logger.info("Building override image for '<svc>' (tag=<hash>)...")` fires once and then nothing animates until the build completes or fails — looks like cdk-local has hung. Same shape on cold `docker pull` of a hefty `public.ecr.aws/lambda/*` base image and on AgentCore code-asset builds.

This PR threads an interactive `@clack/prompts` spinner through `spawnStreaming` so long Docker operations show motion. No flag changes, no documented behavior changes — pure UX.

## Changes

- `src/utils/docker-cmd.ts` — new `progressLabel?: string` on `RunDockerOptions`. When set AND `streamLive` is false AND `process.stdout.isTTY === true`, wrap the spawn with a clack spinner; stop on exit (success / non-zero / ENOENT).
- `src/assets/docker-build.ts` — forward `progressLabel` from `BuildDockerImageOptions` to `runDockerStreaming`.
- 5 caller sites pass per-target labels:
  - `image-override-engine.ts` -> `Building override image for '<target>'` (the user-reported site).
  - `docker-image-builder.ts` (Lambda container builds) -> `Building container image (platform=<p>)`.
  - `ecs-task-runner.ts` (per-ECS-container asset builds) -> `Building container image for '<container>'`.
  - `docker-runner.ts` non-verbose pull -> `Pulling <image>`.
  - `agentcore-code-build.ts` from-source build -> `Building agent image (runtime=<runtime>)`.

## Behavior gates (so the spinner doesn't break existing flows)

- **non-TTY (CI, piped to `tail` / `grep`, integ-test fixtures)** -> no spinner. The pre-spinner silent / log-only behavior is preserved.
- **`streamLive: true` (`--verbose` mode)** -> no spinner. Live BuildKit progress output would overwrite the spinner line and mangle the build log.
- **no `progressLabel`** -> no spinner. All non-build short docker calls (`docker tag`, `docker network`, `docker stop`, etc.) keep their pre-spinner behavior.

## Tests

`tests/unit/utils/docker-cmd-progress-spinner.test.ts` (new — 6 tests):

- spinner starts + stops with the right label on TTY + non-streamLive + label set
- spinner stops on non-zero exit (upstream stderr renders cleanly)
- spinner stops on ENOENT before the "Install Docker" rejection
- no spinner on non-TTY
- no spinner when `streamLive: true`
- no spinner without `progressLabel`

`tests/unit/local/image-override-engine.test.ts` (extension — 1 binding test):
- `runImageOverrideBuilds` passes the per-target `Building override image for '<target>'` label through to `runDockerStreaming` (site-level binding regression guard).

Full suite: 141 files / 2122 tests pass (+1 file / +7 tests).

## Live-test note

The spinner only renders when stdout is a TTY. Piping `node dist/cli.js ...` through `tail` / `head` (the only live-test path available through this skill's Bash tool) sets `isTTY === false`, which short-circuits the spinner — so I can't exercise the visible-motion path through tool pipes. The unit tests pin the wiring with mocked `spawn` + mocked `@clack/prompts.spinner`; the clack library's own TTY rendering is library code. The user reproduced the silence the spinner closes, so visual confirmation will land on the next `cdkl start-service --watch --image-override` run from their terminal.

## Integ marker

This PR touches `src/**` so the `integ` markgate gate fires on merge. The behavior change is purely a UX overlay around the existing spawn — the unit tests assert no regression in non-TTY / `streamLive` / no-label flows (the captured-mode silent contract is preserved). Run `/run-integ local-start-api` (or `local-invoke-container`) before merge to refresh the marker. The `integ-gate.sh` hook will block the merge until the marker is fresh.
