### PR TITLE
fix(invoke-agentcore): `--ws` interactive REPL UX — trailing newline + `>` prompt + skip empty Enter (#276)

### DIFF
--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -646,7 +646,7 @@ async function localInvokeAgentCoreCommand(
         const wsResult = await invokeAgentCoreWs(containerHost, hostPort, event, {
           sessionId,
           timeoutMs: options.timeout,
-          onMessage: (text) => process.stdout.write(text),
+          onMessage: wrapWsOnMessage((text) => process.stdout.write(text), interactive),
           ...(authorization && { authorization }),
           ...(frameSource && { frameSource }),
         });
@@ -1669,11 +1669,51 @@ export async function* readStdinLines(): AsyncIterable<string> {
   const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
   try {
     for await (const line of rl) {
+      // Issue #276 — skip strictly-empty lines in interactive mode.
+      // Without this, pressing Enter without typing sends an empty WS text
+      // frame; a loop-mode agent (e.g. the integ fixture's EchoAgent) then
+      // replies with a half-line like `loop-echo:` that visually corrupts
+      // the REPL. A whitespace-only line is NOT skipped — sending spaces
+      // can be a deliberate signal for some agents.
+      if (line.length === 0) continue;
       yield line;
     }
   } finally {
     rl.close();
   }
+}
+
+/**
+ * Issue #276 — REPL prompt indicator for the auto-detected TTY mode.
+ * Written to stdout (no trailing newline) after each received agent frame,
+ * so the user has a clear visual signal that the REPL is waiting for input.
+ */
+export const WS_REPL_PROMPT = '> ';
+
+/**
+ * Issue #276 — wrap `onMessage` so each agent WS text frame lands on its
+ * own line when the auto-REPL is active AND a `>` prompt indicator
+ * follows. WS frames carry no trailing `\n` by protocol (each frame is a
+ * discrete message); the cloud `/ws` endpoint behaves the same. That's
+ * correct on the wire but visually run-on in an interactive terminal —
+ * the user's next keystroke concatenates onto the last frame's tail char
+ * and they have no signal that the REPL is waiting for input. In
+ * interactive mode we append `\n` (unless already present) and then write
+ * a `>` prompt, so each agent message is presented as its own line and
+ * the next input prompt is visible.
+ *
+ * Non-interactive (piped / CI) is unchanged — the raw stdout shape is
+ * what scripts rely on, and the WS-protocol-faithful pass-through stays.
+ */
+export function wrapWsOnMessage(
+  sink: (text: string) => void,
+  interactive: boolean
+): (text: string) => void {
+  if (!interactive) return sink;
+  return (text) => {
+    sink(text.endsWith('\n') ? text : `${text}\n`);
+    sink(WS_REPL_PROMPT);
+  };
 }
 
 export function readEnvOverridesFile(filePath: string | undefined): EnvOverrideFile | undefined {
@@ -1967,7 +2007,7 @@ export async function runAgentCoreWatchLoop(args: {
         const result = await wsInvoker(args.containerHost, currentHostPort, args.event, {
           sessionId: args.sessionId,
           timeoutMs: args.timeoutMs,
-          onMessage: (text) => process.stdout.write(text),
+          onMessage: wrapWsOnMessage((text) => process.stdout.write(text), args.interactive),
           abortSignal: abort.signal,
           ...(args.authorization && { authorization: args.authorization }),
           ...(frameSource && { frameSource }),

--- a/tests/unit/cli/local-invoke-agentcore-watch.test.ts
+++ b/tests/unit/cli/local-invoke-agentcore-watch.test.ts
@@ -61,6 +61,7 @@ import {
   createLocalInvokeAgentCoreCommand,
   runAgentCoreWatchLoop,
   softReloadAgentContainer,
+  wrapWsOnMessage,
 } from '../../../src/cli/commands/local-invoke-agentcore.js';
 import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
@@ -520,5 +521,48 @@ describe('softReloadAgentContainer — docker cp + docker restart wiring', () =>
     await expect(softReloadAgentContainer('cid_gone', '/src')).rejects.toThrow(
       /No such container: cid_gone/
     );
+  });
+});
+
+describe('wrapWsOnMessage — interactive newline policy (issue #276)', () => {
+  it('non-interactive: passes the frame through verbatim (WS-protocol-faithful)', () => {
+    // CI / piped path. The raw WS-protocol shape is what scripts rely on,
+    // so no newline coercion is applied.
+    const captured: string[] = [];
+    const wrapped = wrapWsOnMessage((t) => captured.push(t), false);
+    wrapped('frame-one');
+    wrapped('frame-two');
+    expect(captured).toEqual(['frame-one', 'frame-two']);
+  });
+
+  it('interactive: appends `\\n` to a frame that does not already end with one + writes a `>` prompt', () => {
+    // The fix: each agent message lands on its own line AND a prompt
+    // indicator follows so the user knows the REPL is waiting for input.
+    // Without this, frames run together visually and there is no signal
+    // that input is expected (issue #276 reproduction).
+    const captured: string[] = [];
+    const wrapped = wrapWsOnMessage((t) => captured.push(t), true);
+    wrapped('frame-one');
+    wrapped('frame-two');
+    expect(captured).toEqual(['frame-one\n', '> ', 'frame-two\n', '> ']);
+  });
+
+  it('interactive: does NOT double-append `\\n` when the frame already ends with one; prompt still written', () => {
+    // Some agents send line-terminated frames already. Don't add a second
+    // newline — that would produce gratuitous blank lines in the REPL.
+    // The `>` prompt still follows so the next-input cue is consistent.
+    const captured: string[] = [];
+    const wrapped = wrapWsOnMessage((t) => captured.push(t), true);
+    wrapped('already-terminated\n');
+    expect(captured).toEqual(['already-terminated\n', '> ']);
+  });
+
+  it('interactive: empty frame still gets a trailing `\\n` + prompt', () => {
+    // The wrap policy is per-frame; an empty frame from the agent should
+    // still produce a blank line + prompt, not a no-op.
+    const captured: string[] = [];
+    const wrapped = wrapWsOnMessage((t) => captured.push(t), true);
+    wrapped('');
+    expect(captured).toEqual(['\n', '> ']);
   });
 });


### PR DESCRIPTION
## Summary

Closes #276. Three small UX fixes to the auto-detected TTY REPL on `cdkl invoke-agentcore --ws` (issue #273's Option B). User-confirmed working against the integ fixture in a real terminal before this PR was opened.

## Reproduction (pre-fix)

```bash
cdkl invoke-agentcore --watch --ws CdkLocalInvokeAgentCoreFixture/EchoAgent --event ./loop.json
```

```
Opening the agent /ws WebSocket (interactive — stdin lines = follow-up frames; Ctrl-D to end)...
{"ws":true,"echoed":{"loop":true},"sessionId":"...","authorization":null,"greeting":"hello-from-agent"}hello   ← user typed `hello`, but it concatenated onto the agent's last `}` char
loop-echo:hello
loop-echo:                ← user pressed Enter without typing → empty WS frame → noisy half-line from loop-mode agent
```

Two protocol-correct but visually broken behaviors at the WS client layer.

## Fixes

| # | Fix | Site |
|---|-----|------|
| 1 | Append `\n` to each received WS frame in interactive mode (unless the frame already ends with one). The cloud `/ws` endpoint sends frames without trailing newlines too — correct on the wire, broken as a REPL. | `wrapWsOnMessage` (new helper) |
| 2 | Write a `>` prompt (no trailing newline) after each frame. The user sees "REPL is waiting for input" right where they will type. | `wrapWsOnMessage` + `WS_REPL_PROMPT` const |
| 3 | `readStdinLines` skips strictly-empty lines so pressing Enter without typing is a no-op (no empty WS frame sent). Whitespace-only input still sends — deliberate space content stays observable. | `readStdinLines` |

The non-interactive (piped / CI) path is **untouched** — the raw WS-protocol stdout shape is what scripts rely on, and the empty-line corner case is moot (the path doesn't read stdin at all).

## What landed

1. **`src/cli/commands/local-invoke-agentcore.ts`**:
   - Export `const WS_REPL_PROMPT = '> '`.
   - Export `wrapWsOnMessage(sink, interactive)`: returns the raw sink unchanged in non-interactive mode; in interactive mode wraps it so each call writes `<frame>\n` (or `<frame>` if already terminated) plus `> `.
   - `readStdinLines` adds `if (line.length === 0) continue;` so empty Enter doesn't send a WS frame.
   - Both `--ws` dispatch sites (non-watch path + watch loop's per-iteration WS open) now thread `wrapWsOnMessage((text) => process.stdout.write(text), interactive)` instead of the raw write.
2. **`tests/unit/cli/local-invoke-agentcore-watch.test.ts`** adds 4 rows pinning the `wrapWsOnMessage` policy: non-interactive verbatim pass-through; interactive appends `\n` + `> `; no double-`\n` on already-terminated frames; empty frame still produces `\n> `.

## After (post-fix)

```
Opening the agent /ws WebSocket (interactive — stdin lines = follow-up frames; Ctrl-D to end)...
{"ws":true,"echoed":{"loop":true},...,"greeting":"hello-from-agent"}
> test                ← user typed cleanly on its own line after the prompt
loop-echo:test
> aaa
loop-echo:aaa
> 
```

Empty Enter is a no-op (no WS frame sent, no agent reply).

## Live verification

User-confirmed on the integ fixture in a real terminal against the locally-built binary (`vp run build` then `node dist/cli.js`) before this PR was opened. The actual transcript:

```
Opening the agent /ws WebSocket (interactive — stdin lines = follow-up frames; Ctrl-D to end)...
{"ws":true,"echoed":{"loop":true},...,"greeting":"hello-from-agent"}
> test
loop-echo:test
> aaa
loop-echo:aaa
> 
```

## Tests

Full suite: 144 files / 2169 tests pass.

Integ: 19/19 pass on `local-invoke-agentcore`; docker 0 orphans.

## cdkd parity

Category 4 — additive interactive-only behavior change. The `--ws` flag's wire semantics are unchanged; only the local TTY-side rendering / empty-Enter handling improves. cdkd inherits via `addInvokeAgentCoreSpecificOptions` (no surface change). No migration needed.

Closes #276
