### PR TITLE
docs(readme): include `invoke-agentcore` in the arrow-key picker list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The locally executable resources are listed under [Supported resources](#support
 
 Run every `cdkl` command from your CDK project root (the directory containing `cdk.json`).
 
-Run any command with no target for an arrow-key picker (`invoke` / `run-task` pick one; `start-service` / `start-alb` / `start-api` multi-select). Or name a target — the CDK display path (recommended) or a stack-qualified logical ID (`MyStack:Fn1234ABCD`, the SAM-compatible form); single-stack apps may drop the stack prefix.
+Run any command with no target for an arrow-key picker (`invoke` / `invoke-agentcore` / `run-task` pick one; `start-service` / `start-alb` / `start-api` multi-select). Or name a target — the CDK display path (recommended) or a stack-qualified logical ID (`MyStack:Fn1234ABCD`, the SAM-compatible form); single-stack apps may drop the stack prefix.
 
 ```bash
 cdkl invoke MyStack/Fn --event ./event.json   # Lambda (ZIP or container image)


### PR DESCRIPTION
## Summary

`cdkl invoke-agentcore` supports the same arrow-key target picker (via `@clack/prompts`) as `invoke` / `run-task` — when `<target>` is omitted in a TTY, the user is prompted to `Select an AgentCore Runtime to invoke` (see `src/cli/commands/local-invoke-agentcore.ts` calling `resolveSingleTarget`).

The README L54 picker list mentioned `invoke` / `run-task` but forgot `invoke-agentcore`. One-word fix.

Closes nothing — pure docs typo fix.