### PR TITLE
feat(studio): Phase 1 slice A — cdkl studio control-plane console shell

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -212,11 +212,17 @@ compute-locally category for Lambda + API Gateway).
 - `src/cli/` — Commander command factories (`createLocalInvokeCommand`,
   `createLocalInvokeAgentCoreCommand`, `createLocalStartApiCommand`,
   `createLocalRunTaskCommand`, `createLocalStartServiceCommand`,
-  `createLocalStartAlbCommand`, `createLocalListCommand`) + shared option
+  `createLocalStartAlbCommand`, `createLocalListCommand`,
+  `createLocalStudioCommand`) + shared option
   helpers. `start-service` and `start-alb` share one neutral orchestration
   in `commands/ecs-service-emulator.ts` (synth + shared docker network +
   Cloud Map + restart watcher + optional front-door); each command is a
   thin strategy over it (service targets vs ALB targets).
+  `createLocalStudioCommand` (`cdkl studio`, issue #282) is the
+  interactive web console over the same target enumeration; it is built
+  incrementally and registered ONLY when `CDKL_STUDIO_PREVIEW=1` (the
+  binary keeps it hidden until the unveil slice), so it is NOT yet on the
+  README's user-facing command surface.
 - `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
   (`Toolkit.fromCdkApp()` + context store threading) that returns
   `StackInfo[]` for downstream consumers.
@@ -278,7 +284,15 @@ compute-locally category for Lambda + API Gateway).
   action gates serving with a 401 + `WWW-Authenticate: Bearer` on deny;
   WebSocket `Upgrade` requests run through the same route + auth
   pipeline, then bridge the raw TCP socket to the picked ECS replica
-  with `Upgrade` / `Sec-WebSocket-*` headers preserved), etc.
+  with `Upgrade` / `Sec-WebSocket-*` headers preserved),
+  studio-events (issue #282 — the typed in-process event bus every
+  `cdkl studio` observation flows through; the studio HTTP server
+  subscribes and forwards to the browser over SSE), studio-server
+  (the localhost HTTP server behind `cdkl studio`: serves the embedded
+  UI at `/`, the synthesized target list at `/api/targets`, and an SSE
+  stream of the event bus at `/api/events`; collision-bumps the port),
+  studio-ui (the framework-free web UI embedded as a string so it ships
+  inside the npm package with no asset-copy build step), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state
@@ -422,6 +436,19 @@ vp run runtime:smoke
   (spec compliance / code quality / test adequacy) catch different
   classes of issues. Sub-agents have read-only tools (Read / Glob /
   Grep / Bash) so they can never accidentally edit.
+
+- **Never defer integration tests to a later PR**: when a feature is
+  built incrementally across multiple PRs (slices), every slice that
+  lands on `main` MUST carry its own integration coverage green before
+  merge — NEVER ship code-then-integ-later. A slice that adds a runtime
+  code path without exercising it end-to-end (Docker / fixture) can
+  release with a latent bug behind a working-looking unit suite; that
+  is unacceptable. Each PR is a self-contained vertical: unit + integ
+  for exactly the behavior it adds. A "final integ pass" slice is a
+  design smell — fold the integ into the slice that introduces the
+  behavior. (If a slice's behavior is genuinely not yet user-reachable,
+  gate it so it cannot ship enabled — but still integ-test the real
+  code path it adds, e.g. via the gated entrypoint.)
 
 - **When running integration tests**: use `/run-integ <test-name>`
   (e.g., `/run-integ local-invoke`). Never bypass by shelling into

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -1,0 +1,197 @@
+import { spawn } from 'node:child_process';
+import { Command, Option } from 'commander';
+import {
+  appOptions,
+  commonOptions,
+  contextOptions,
+  regionOption,
+  parseContextOptions,
+} from '../options.js';
+import { getLogger } from '../../utils/logger.js';
+import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { withErrorHandling } from '../../utils/error-handler.js';
+import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import { resolveApp } from '../config-loader.js';
+import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
+import { listTargets } from '../../local/target-lister.js';
+import { StudioEventBus } from '../../local/studio-events.js';
+import {
+  startStudioServer,
+  toStudioTargetGroups,
+  type RunningStudioServer,
+} from '../../local/studio-server.js';
+
+const DEFAULT_STUDIO_PORT = 9999;
+
+/**
+ * Parse + validate the `--studio-port` value. Accepts `0` (OS-assigned)
+ * through `65535`. Exported so a unit test can assert the bounds without
+ * driving the full command. Throws on anything out of range / non-numeric.
+ */
+export function parseStudioPort(raw: string): number {
+  // `Number('')` / `Number('  ')` coerce to 0, which would pass the range
+  // check; reject blank input explicitly.
+  const port = raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`--studio-port must be 0..65535 (got ${raw}).`);
+  }
+  return port;
+}
+
+interface LocalStudioOptions {
+  app?: string;
+  output: string;
+  verbose: boolean;
+  profile?: string;
+  roleArn?: string;
+  context?: string[];
+  region?: string;
+  /** `--studio-port`: preferred listen port (bumps on collision). */
+  studioPort: string;
+  /** `--no-open`: suppress auto-opening the browser (Commander sets `open`). */
+  open: boolean;
+}
+
+/**
+ * Factory options for {@link createLocalStudioCommand}.
+ */
+export interface CreateLocalStudioCommandOptions {
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
+}
+
+async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
+  const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
+
+  const port = parseStudioPort(options.studioPort);
+
+  await applyRoleArnIfSet({
+    roleArn: options.roleArn,
+    region: undefined,
+    profile: options.profile,
+  });
+
+  const appCmd = resolveApp(options.app);
+  if (!appCmd) {
+    throw new Error(
+      `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+    );
+  }
+
+  logger.info('Synthesizing CDK app...');
+  const synthesizer = new Synthesizer();
+  const context = parseContextOptions(options.context);
+  const synthOpts: SynthesisOptions = {
+    app: appCmd,
+    output: options.output,
+    ...(options.profile && { profile: options.profile }),
+    ...(Object.keys(context).length > 0 && { context }),
+  };
+  const { stacks } = await synthesizer.synthesize(synthOpts);
+
+  const listing = listTargets(stacks);
+  const targetGroups = toStudioTargetGroups(listing);
+  const appLabel = stacks.map((s) => s.stackName).join(', ') || appCmd;
+
+  const bus = new StudioEventBus();
+  const server = await startStudioServer({
+    port,
+    bus,
+    targetGroups,
+    appLabel,
+    cliName: getEmbedConfig().cliName,
+  });
+
+  const cliName = getEmbedConfig().cliName;
+  logger.info(`${cliName} studio is running at ${server.url}`);
+  logger.info('Press Ctrl-C to stop.');
+
+  // Auto-open the browser only in an interactive terminal (never in CI /
+  // piped / integ runs) and unless --no-open was passed.
+  if (options.open && process.stdout.isTTY) {
+    openBrowser(server.url);
+  }
+
+  await blockUntilShutdown(server, cliName);
+}
+
+/** Best-effort cross-platform browser open. Failures are non-fatal. */
+function openBrowser(url: string): void {
+  const cmd =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+  try {
+    const child = spawn(cmd, [url], {
+      stdio: 'ignore',
+      detached: true,
+      shell: process.platform === 'win32',
+    });
+    child.on('error', () => undefined);
+    child.unref();
+  } catch {
+    // Opening the browser is a convenience; ignore any failure.
+  }
+}
+
+/**
+ * Block until SIGINT / SIGTERM, then close the studio server and resolve.
+ * Mirrors the long-running serve commands' graceful-shutdown contract.
+ */
+function blockUntilShutdown(server: RunningStudioServer, cliName: string): Promise<void> {
+  return new Promise<void>((resolveShutdown) => {
+    let shuttingDown = false;
+    const shutdown = (signal: string): void => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      getLogger().info(`Received ${signal}; stopping ${cliName} studio...`);
+      void server.close().finally(() => resolveShutdown());
+    };
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+  });
+}
+
+export function createLocalStudioCommand(opts: CreateLocalStudioCommandOptions = {}): Command {
+  setEmbedConfig(opts.embedConfig);
+  const cmd = new Command('studio')
+    .description(
+      "Open the local studio: a web console that lists the synthesized CDK app's runnable " +
+        'targets and lets you invoke / serve them from the browser while watching all activity ' +
+        'in one timeline. The interactive counterpart to the headless invoke / start-* commands.'
+    )
+    .action(
+      withErrorHandling(async (options: LocalStudioOptions) => {
+        await localStudioCommand(options);
+      })
+    );
+
+  addStudioSpecificOptions(cmd);
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(regionOption);
+  return cmd;
+}
+
+/**
+ * Register the option block `cdkl studio` adds on top of the shared
+ * common / app / context option helpers. Kept in a named helper (not
+ * inline in {@link createLocalStudioCommand}) so a host CLI embedding
+ * this factory inherits new studio flags without a duplicate
+ * `.addOption(...)` block, matching every other `add<Cmd>SpecificOptions`
+ * extraction. Chainable: returns `cmd`.
+ */
+export function addStudioSpecificOptions(cmd: Command): Command {
+  cmd.addOption(
+    new Option(
+      '--studio-port <port>',
+      'Preferred port for the studio web server (bumps to the next free port on collision)'
+    ).default(String(DEFAULT_STUDIO_PORT))
+  );
+  cmd.addOption(
+    new Option('--no-open', 'Do not auto-open the browser when studio starts (TTY only)')
+  );
+  return cmd;
+}

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -148,7 +148,10 @@ function blockUntilShutdown(server: RunningStudioServer, cliName: string): Promi
       if (shuttingDown) return;
       shuttingDown = true;
       getLogger().info(`Received ${signal}; stopping ${cliName} studio...`);
-      void server.close().finally(() => resolveShutdown());
+      void server
+        .close()
+        .catch((err: unknown) => getLogger().warn(`Error stopping studio server: ${String(err)}`))
+        .finally(() => resolveShutdown());
     };
     process.on('SIGINT', () => shutdown('SIGINT'));
     process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,8 +8,18 @@ import { createLocalRunTaskCommand } from './commands/local-run-task.js';
 import { createLocalStartServiceCommand } from './commands/local-start-service.js';
 import { createLocalStartAlbCommand } from './commands/local-start-alb.js';
 import { createLocalListCommand } from './commands/local-list.js';
+import { createLocalStudioCommand } from './commands/local-studio.js';
 
 declare const __CDK_LOCAL_VERSION__: string;
+
+/**
+ * `cdkl studio` is built incrementally and is NOT yet user-ready, so it
+ * is registered ONLY when `CDKL_STUDIO_PREVIEW=1`. This keeps a
+ * half-finished command from shipping enabled while each slice lands on
+ * main, while still letting the integration suite drive the real binary
+ * end-to-end. The gate is removed in the final "unveil" slice.
+ */
+const STUDIO_PREVIEW_ENABLED = process.env['CDKL_STUDIO_PREVIEW'] === '1';
 
 const program = new Command();
 program
@@ -24,5 +34,8 @@ program.addCommand(createLocalRunTaskCommand());
 program.addCommand(createLocalStartServiceCommand());
 program.addCommand(createLocalStartAlbCommand());
 program.addCommand(createLocalListCommand());
+if (STUDIO_PREVIEW_ENABLED) {
+  program.addCommand(createLocalStudioCommand());
+}
 
 void program.parseAsync(process.argv);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -674,3 +674,31 @@ export {
  * `{ ...(region && { region }) }` shape callers used to write by hand.
  */
 export { resolveProfileCredentials, buildStsClientConfig } from './utils/profile-resolver.js';
+
+export { addStudioSpecificOptions } from './cli/commands/local-studio.js';
+
+/**
+ * `cdkl studio` building blocks (issue #282). The studio web console is
+ * an interactive front over the same target enumeration + runners the
+ * headless commands use; a host CLI embedding studio re-exports these to
+ * boot the server and subscribe to the observation bus. The
+ * `createLocalStudioCommand` factory is intentionally NOT yet on the
+ * stable `cdk-local` entry while studio is built behind the
+ * `CDKL_STUDIO_PREVIEW` gate — it graduates to `src/index.ts` in the
+ * unveil slice.
+ */
+export {
+  StudioEventBus,
+  type StudioInvocationEvent,
+  type StudioLogEvent,
+  type StudioTargetKind,
+} from './local/studio-events.js';
+export {
+  startStudioServer,
+  toStudioTargetGroups,
+  type StudioServerOptions,
+  type RunningStudioServer,
+  type StudioTarget,
+  type StudioTargetGroup,
+} from './local/studio-server.js';
+export { renderStudioHtml } from './local/studio-ui.js';

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -1,0 +1,107 @@
+import { EventEmitter } from 'node:events';
+
+/**
+ * The kind of runnable target an invocation ran against. Mirrors the
+ * categories `cdkl list` / the studio target list expose.
+ */
+export type StudioTargetKind = 'lambda' | 'api' | 'alb' | 'ecs' | 'agentcore';
+
+/**
+ * One request observed by `cdkl studio` — a single-shot invoke or one
+ * request to a served target. Emitted twice per request: once at start
+ * (status/durationMs/response absent) and once at end (filled in). The
+ * UI threads the two by {@link StudioInvocationEvent.id}.
+ *
+ * Slice A defines the shape; the dispatch layer that emits populated
+ * events lands with the invoke / serve slices.
+ */
+export interface StudioInvocationEvent {
+  /** Correlation id, unique per request. Stable across the start/end pair. */
+  id: string;
+  /** Wall-clock epoch ms when the request started. */
+  ts: number;
+  /** Target id the request ran against (stack-qualified or display path). */
+  target: string;
+  /** The target's kind, for the UI's per-kind affordances. */
+  kind: StudioTargetKind;
+  /** Short request label for the timeline row (e.g. `GET /orders`). */
+  label: string;
+  /** The request payload (Lambda event JSON or the HTTP request shape). */
+  request?: unknown;
+  /** Response payload, set on the end event. */
+  response?: unknown;
+  /** HTTP status / invoke outcome code, set on the end event. */
+  status?: number;
+  /** Wall-clock duration in ms, set on the end event. */
+  durationMs?: number;
+  /**
+   * When this invocation is a re-run of an earlier one (Phase 3), the id
+   * of the source invocation. The UI links the new row to its origin.
+   */
+  reinvokeOf?: string;
+}
+
+/**
+ * One container stdout/stderr line, tagged with its emitting container
+ * so the detail panel can scope logs at CloudWatch granularity (Lambda
+ * per-invocation, ECS per-container).
+ */
+export interface StudioLogEvent {
+  /** Wall-clock epoch ms when the line was observed. */
+  ts: number;
+  /** Container id that emitted the line. */
+  containerId: string;
+  /** Target id the container backs, for the UI grouping. */
+  target: string;
+  /** The raw log line (without trailing newline). */
+  line: string;
+  /** Parsed stream, when known. */
+  stream?: 'stdout' | 'stderr';
+}
+
+/**
+ * Map of event name -> listener argument, for the typed wrapper below.
+ */
+interface StudioEventMap {
+  invocation: [StudioInvocationEvent];
+  log: [StudioLogEvent];
+}
+
+/**
+ * In-process event bus that every studio observation flows through. The
+ * studio HTTP server subscribes and forwards events to the browser over
+ * SSE; the dispatch / log-streaming layers emit onto it.
+ *
+ * A thin typed wrapper over {@link EventEmitter} so producers and the
+ * server agree on the event shapes without `any`. Re-exported from
+ * `cdk-local/internal` so a host CLI embedding studio can subscribe.
+ */
+export class StudioEventBus {
+  private readonly emitter = new EventEmitter();
+
+  constructor() {
+    // The bus can accumulate many SSE subscribers across a long session;
+    // raise the cap so Node does not warn about a suspected leak.
+    this.emitter.setMaxListeners(0);
+  }
+
+  emit<E extends keyof StudioEventMap>(event: E, ...args: StudioEventMap[E]): void {
+    this.emitter.emit(event, ...args);
+  }
+
+  on<E extends keyof StudioEventMap>(
+    event: E,
+    listener: (...args: StudioEventMap[E]) => void
+  ): this {
+    this.emitter.on(event, listener as (...args: unknown[]) => void);
+    return this;
+  }
+
+  off<E extends keyof StudioEventMap>(
+    event: E,
+    listener: (...args: StudioEventMap[E]) => void
+  ): this {
+    this.emitter.off(event, listener as (...args: unknown[]) => void);
+    return this;
+  }
+}

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -104,4 +104,13 @@ export class StudioEventBus {
     this.emitter.off(event, listener as (...args: unknown[]) => void);
     return this;
   }
+
+  /**
+   * Number of listeners currently subscribed to `event`. Exposed so the
+   * SSE server's subscribe / unsubscribe symmetry can be asserted (a
+   * dropped client must not leak a listener).
+   */
+  listenerCount<E extends keyof StudioEventMap>(event: E): number {
+    return this.emitter.listenerCount(event);
+  }
 }

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -154,28 +154,55 @@ function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus
     'cache-control': 'no-cache, no-transform',
     connection: 'keep-alive',
   });
-  // Open the stream so EventSource fires `open` immediately.
-  res.write(':ok\n\n');
 
-  const onInvocation = (ev: StudioInvocationEvent): void => {
-    res.write(`event: invocation\ndata: ${JSON.stringify(ev)}\n\n`);
-  };
-  const onLog = (ev: StudioLogEvent): void => {
-    res.write(`event: log\ndata: ${JSON.stringify(ev)}\n\n`);
-  };
-  bus.on('invocation', onInvocation);
-  bus.on('log', onLog);
-
-  const heartbeat = setInterval(() => res.write(':hb\n\n'), SSE_HEARTBEAT_MS);
+  let closed = false;
+  const heartbeat = setInterval(() => safeWrite(':hb\n\n'), SSE_HEARTBEAT_MS);
   heartbeat.unref?.();
 
-  const cleanup = (): void => {
+  const onInvocation = (ev: StudioInvocationEvent): void => {
+    safeWrite(`event: invocation\ndata: ${JSON.stringify(ev)}\n\n`);
+  };
+  const onLog = (ev: StudioLogEvent): void => {
+    safeWrite(`event: log\ndata: ${JSON.stringify(ev)}\n\n`);
+  };
+
+  // Idempotent teardown: unsubscribe from the bus + stop the heartbeat so
+  // a dropped EventSource client never leaks a listener.
+  function cleanup(): void {
+    if (closed) return;
+    closed = true;
     clearInterval(heartbeat);
     bus.off('invocation', onInvocation);
     bus.off('log', onLog);
-  };
+  }
+
+  // Guard every write: on shutdown `close()` destroys live SSE sockets
+  // (closeAllConnections), and a bus emit / heartbeat tick can race that
+  // destroy. Writing to a destroyed socket emits an unhandled `error` on
+  // the response — which, with no top-level uncaughtException handler on
+  // the studio path, would crash the process on Ctrl-C. Drop the write
+  // (and tear down) instead.
+  function safeWrite(chunk: string): void {
+    if (closed || res.writableEnded || res.destroyed) {
+      cleanup();
+      return;
+    }
+    res.write(chunk);
+  }
+
+  bus.on('invocation', onInvocation);
+  bus.on('log', onLog);
+
+  // `close` fires on client disconnect AND on server-side socket destroy;
+  // `error` fires if a write loses the race with the destroy. All three
+  // route through the idempotent cleanup so the bus listeners + heartbeat
+  // never leak and a write error never propagates as uncaught.
   req.on('close', cleanup);
   res.on('close', cleanup);
+  res.on('error', cleanup);
+
+  // Open the stream so EventSource fires `open` immediately.
+  safeWrite(':ok\n\n');
 }
 
 /**

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -1,0 +1,214 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  StudioEventBus,
+  type StudioInvocationEvent,
+  type StudioLogEvent,
+} from './studio-events.js';
+import { renderStudioHtml } from './studio-ui.js';
+import type { TargetListing } from './target-lister.js';
+
+/** One target as the studio UI consumes it (`GET /api/targets`). */
+export interface StudioTarget {
+  /** Stable target id — the display path when available, else qualified id. */
+  id: string;
+  /** Stack-qualified `<Stack>:<LogicalId>` for disambiguation. */
+  qualifiedId: string;
+  /** API surface kind (REST v1 / HTTP v2 / ...), only for `api` entries. */
+  surface?: string;
+}
+
+/** A category of targets, grouped by the studio kind that runs them. */
+export interface StudioTargetGroup {
+  /** Studio kind discriminator shared with {@link StudioInvocationEvent}. */
+  kind: 'lambda' | 'api' | 'alb' | 'ecs' | 'agentcore';
+  /** Human-readable group heading. */
+  title: string;
+  entries: StudioTarget[];
+}
+
+/**
+ * Project a {@link TargetListing} (the same enumeration `cdkl list`
+ * prints) into the grouped shape the studio UI renders. ECS services and
+ * task definitions are folded into one `ecs` group; everything else maps
+ * one category to one group. Exported so a unit test can assert the
+ * projection without booting the server.
+ */
+export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[] {
+  const map = (entries: TargetListing['lambdas']): StudioTarget[] =>
+    entries.map((e) => {
+      const t: StudioTarget = { id: e.displayPath ?? e.qualifiedId, qualifiedId: e.qualifiedId };
+      if (e.kind) t.surface = e.kind;
+      return t;
+    });
+  return [
+    { kind: 'lambda', title: 'Lambda Functions', entries: map(listing.lambdas) },
+    { kind: 'api', title: 'APIs', entries: map(listing.apis) },
+    {
+      kind: 'ecs',
+      title: 'ECS Services / Tasks',
+      entries: [...map(listing.ecsServices), ...map(listing.ecsTaskDefinitions)],
+    },
+    { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
+    { kind: 'alb', title: 'Load Balancers', entries: map(listing.loadBalancers) },
+  ];
+}
+
+/** Inputs to {@link startStudioServer}. */
+export interface StudioServerOptions {
+  /** Preferred listen port; bumps on collision (decision: collision-safe). */
+  port: number;
+  /** Listen host. Defaults to `127.0.0.1` (localhost-only). */
+  host?: string;
+  /** The shared event bus the SSE stream forwards. */
+  bus: StudioEventBus;
+  /** Target groups to serve at `GET /api/targets`. */
+  targetGroups: StudioTargetGroup[];
+  /** Header label for the running app / stack context. */
+  appLabel: string;
+  /** CLI brand name (`cdkl`, or a host rebrand). */
+  cliName: string;
+  /**
+   * Max consecutive ports to try on `EADDRINUSE` before giving up.
+   * Defaults to 20.
+   */
+  maxPortBump?: number;
+}
+
+/** A running studio server. */
+export interface RunningStudioServer {
+  /** The URL the UI is served at, e.g. `http://127.0.0.1:9999`. */
+  url: string;
+  /** The actually-bound port (may differ from the requested one). */
+  port: number;
+  /** Stop the server and release the port. */
+  close: () => Promise<void>;
+}
+
+const SSE_HEARTBEAT_MS = 15_000;
+
+/**
+ * Boot the studio HTTP server: serves the embedded UI at `/`, the target
+ * list at `/api/targets`, and a Server-Sent-Events stream of the bus's
+ * `invocation` / `log` events at `/api/events`. Localhost-only by
+ * default. Resolves once the socket is listening.
+ */
+export async function startStudioServer(
+  options: StudioServerOptions
+): Promise<RunningStudioServer> {
+  const host = options.host ?? '127.0.0.1';
+  const maxBump = options.maxPortBump ?? 20;
+  const html = renderStudioHtml(options.appLabel, options.cliName);
+  const targetsJson = JSON.stringify({ groups: options.targetGroups });
+
+  const server = createServer((req, res) =>
+    handleRequest(req, res, options.bus, html, targetsJson)
+  );
+
+  const boundPort = await listenWithBump(server, host, options.port, maxBump);
+
+  return {
+    url: `http://${host}:${boundPort}`,
+    port: boundPort,
+    close: () =>
+      new Promise<void>((resolveClose, reject) => {
+        server.close((err) => (err ? reject(err) : resolveClose()));
+        // closeAllConnections exists on Node 18.2+; SSE keeps sockets open
+        // so without this `close()` would hang on live EventSource clients.
+        server.closeAllConnections?.();
+      }),
+  };
+}
+
+function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  bus: StudioEventBus,
+  html: string,
+  targetsJson: string
+): void {
+  const url = req.url ?? '/';
+  const path = url.split('?')[0];
+
+  if (req.method === 'GET' && (path === '/' || path === '/index.html')) {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(html);
+    return;
+  }
+  if (req.method === 'GET' && path === '/api/targets') {
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(targetsJson);
+    return;
+  }
+  if (req.method === 'GET' && path === '/api/events') {
+    serveSse(req, res, bus);
+    return;
+  }
+  res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+  res.end('Not found');
+}
+
+function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus): void {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-cache, no-transform',
+    connection: 'keep-alive',
+  });
+  // Open the stream so EventSource fires `open` immediately.
+  res.write(':ok\n\n');
+
+  const onInvocation = (ev: StudioInvocationEvent): void => {
+    res.write(`event: invocation\ndata: ${JSON.stringify(ev)}\n\n`);
+  };
+  const onLog = (ev: StudioLogEvent): void => {
+    res.write(`event: log\ndata: ${JSON.stringify(ev)}\n\n`);
+  };
+  bus.on('invocation', onInvocation);
+  bus.on('log', onLog);
+
+  const heartbeat = setInterval(() => res.write(':hb\n\n'), SSE_HEARTBEAT_MS);
+  heartbeat.unref?.();
+
+  const cleanup = (): void => {
+    clearInterval(heartbeat);
+    bus.off('invocation', onInvocation);
+    bus.off('log', onLog);
+  };
+  req.on('close', cleanup);
+  res.on('close', cleanup);
+}
+
+/**
+ * Listen on `port`, retrying `port+1`, `port+2`, ... on `EADDRINUSE` up
+ * to `maxBump` extra attempts. Resolves with the bound port.
+ */
+function listenWithBump(
+  server: Server,
+  host: string,
+  port: number,
+  maxBump: number
+): Promise<number> {
+  return new Promise<number>((resolveListen, reject) => {
+    let attempt = 0;
+    const tryListen = (p: number): void => {
+      const onError = (err: NodeJS.ErrnoException): void => {
+        if (err.code === 'EADDRINUSE' && attempt < maxBump) {
+          attempt += 1;
+          server.removeListener('error', onError);
+          tryListen(p + 1);
+          return;
+        }
+        reject(err);
+      };
+      server.once('error', onError);
+      server.listen(p, host, () => {
+        server.removeListener('error', onError);
+        // Resolve with the ACTUAL bound port from the socket — when the
+        // requested port is 0 the OS assigns a free one, which `p` does
+        // not reflect.
+        resolveListen((server.address() as AddressInfo).port);
+      });
+    };
+    tryListen(port);
+  });
+}

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -2,7 +2,7 @@
  * The studio web UI, embedded as a string so it ships inside the
  * `cdk-local` npm package (decision D9) with no asset-copy build step —
  * `tsdown` bundles this module like any other source file. Served by
- * {@link import('./studio-server.js').StudioServer} at `GET /`.
+ * the studio HTTP server (`startStudioServer`) at `GET /`.
  *
  * Slice A renders the 3-pane shell (decision D6): left = target list
  * (from `GET /api/targets`), center = live timeline (from the

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -1,0 +1,185 @@
+/**
+ * The studio web UI, embedded as a string so it ships inside the
+ * `cdk-local` npm package (decision D9) with no asset-copy build step —
+ * `tsdown` bundles this module like any other source file. Served by
+ * {@link import('./studio-server.js').StudioServer} at `GET /`.
+ *
+ * Slice A renders the 3-pane shell (decision D6): left = target list
+ * (from `GET /api/targets`), center = live timeline (from the
+ * `GET /api/events` SSE stream — empty until the invoke / serve slices
+ * emit invocations), right = detail panel (filled on row click). It is
+ * intentionally framework-free vanilla JS (decision D7).
+ */
+
+const STUDIO_CSS = `
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: #e6e6e6; background: #1a1a1a; height: 100vh; overflow: hidden;
+  }
+  header {
+    padding: 8px 14px; background: #111; border-bottom: 1px solid #333;
+    display: flex; align-items: center; gap: 10px;
+  }
+  header .brand { font-weight: 700; color: #fff; }
+  header .meta { color: #888; font-size: 12px; }
+  main { display: grid; grid-template-columns: 280px 1fr 360px; height: calc(100vh - 38px); }
+  .pane { overflow: auto; border-right: 1px solid #333; }
+  .pane:last-child { border-right: 0; }
+  .pane h2 {
+    margin: 0; padding: 8px 12px; font-size: 11px; text-transform: uppercase;
+    letter-spacing: 0.5px; color: #888; background: #151515;
+    position: sticky; top: 0; border-bottom: 1px solid #2a2a2a;
+  }
+  .group-title { padding: 8px 12px 2px; color: #6aa9ff; font-size: 11px; }
+  .target { padding: 5px 12px; cursor: default; border-bottom: 1px solid #222; }
+  .target .name { color: #ddd; }
+  .target .kind { color: #777; font-size: 11px; }
+  .empty { padding: 16px 12px; color: #666; }
+  .row {
+    padding: 5px 12px; border-bottom: 1px solid #222; cursor: pointer;
+    display: flex; gap: 8px; white-space: nowrap;
+  }
+  .row:hover { background: #222; }
+  .row.sel { background: #2a3550; }
+  .row .ts { color: #777; }
+  .row .label { color: #ddd; flex: 1; overflow: hidden; text-overflow: ellipsis; }
+  .row .status { color: #7bd88f; }
+  #detail .section { padding: 8px 12px; border-bottom: 1px solid #222; }
+  #detail .section h3 { margin: 0 0 6px; font-size: 11px; color: #888; text-transform: uppercase; }
+  #detail pre { margin: 0; white-space: pre-wrap; word-break: break-word; color: #cfcfcf; }
+  #conn { font-size: 11px; }
+  #conn.up { color: #7bd88f; }
+  #conn.down { color: #e0707a; }
+`;
+
+const STUDIO_SCRIPT = `
+  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', agentcore: 'AgentCore' };
+  const rowsById = new Map();
+
+  function el(tag, cls, text) {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = text;
+    return e;
+  }
+
+  async function loadTargets() {
+    const pane = document.getElementById('targets');
+    try {
+      const res = await fetch('/api/targets');
+      const data = await res.json();
+      pane.querySelectorAll('.group-title,.target,.empty').forEach((n) => n.remove());
+      let total = 0;
+      for (const group of data.groups) {
+        if (!group.entries.length) continue;
+        pane.appendChild(el('div', 'group-title', group.title));
+        for (const entry of group.entries) {
+          total += 1;
+          const t = el('div', 'target');
+          t.appendChild(el('span', 'name', entry.id));
+          t.appendChild(document.createTextNode('  '));
+          t.appendChild(el('span', 'kind', '(' + (KIND_LABEL[group.kind] || group.kind) + ')'));
+          pane.appendChild(t);
+        }
+      }
+      if (!total) pane.appendChild(el('div', 'empty', 'No runnable targets found.'));
+    } catch (err) {
+      pane.appendChild(el('div', 'empty', 'Failed to load targets: ' + err));
+    }
+  }
+
+  function addInvocation(ev) {
+    const timeline = document.getElementById('timeline');
+    const placeholder = timeline.querySelector('.empty');
+    if (placeholder) placeholder.remove();
+    let row = rowsById.get(ev.id);
+    if (!row) {
+      row = el('div', 'row');
+      row.appendChild(el('span', 'ts'));
+      row.appendChild(el('span', 'label'));
+      row.appendChild(el('span', 'status'));
+      row.onclick = () => selectRow(ev.id);
+      rowsById.set(ev.id, row);
+      timeline.appendChild(row);
+    }
+    row._ev = Object.assign(row._ev || {}, ev);
+    const d = new Date(ev.ts);
+    row.querySelector('.ts').textContent = d.toLocaleTimeString();
+    row.querySelector('.label').textContent = (ev.kind ? ev.target + '  ' : '') + (ev.label || '');
+    row.querySelector('.status').textContent =
+      ev.status != null ? ev.status + (ev.durationMs != null ? '  ' + ev.durationMs + 'ms' : '') : '...';
+  }
+
+  function selectRow(id) {
+    document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'));
+    const row = rowsById.get(id);
+    if (row) row.classList.add('sel');
+    const ev = row && row._ev;
+    const detail = document.getElementById('detail');
+    detail.innerHTML = '';
+    if (!ev) return;
+    const sec = (title, body) => {
+      const s = el('div', 'section');
+      s.appendChild(el('h3', null, title));
+      const pre = el('pre');
+      pre.textContent = typeof body === 'string' ? body : JSON.stringify(body, null, 2);
+      s.appendChild(pre);
+      detail.appendChild(s);
+    };
+    sec('Request', ev.request != null ? ev.request : '(none)');
+    sec('Response', ev.response != null ? ev.response : '(pending)');
+  }
+
+  function connect() {
+    const conn = document.getElementById('conn');
+    const es = new EventSource('/api/events');
+    es.addEventListener('open', () => { conn.textContent = '● live'; conn.className = 'up'; });
+    es.addEventListener('error', () => { conn.textContent = '● disconnected'; conn.className = 'down'; });
+    es.addEventListener('invocation', (e) => addInvocation(JSON.parse(e.data)));
+  }
+
+  loadTargets();
+  connect();
+`;
+
+/**
+ * Render the full studio HTML document. `appLabel` is shown in the
+ * header (the CDK app / stack context); `cliName` brands the title for
+ * host CLIs that rebrand `cdkl`.
+ */
+export function renderStudioHtml(appLabel: string, cliName: string): string {
+  const safeApp = escapeHtml(appLabel);
+  const safeCli = escapeHtml(cliName);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${safeCli} studio</title>
+<style>${STUDIO_CSS}</style>
+</head>
+<body>
+<header>
+  <span class="brand">${safeCli} studio</span>
+  <span class="meta">${safeApp}</span>
+  <span id="conn" class="down">● connecting</span>
+</header>
+<main>
+  <section class="pane" id="targets"><h2>Targets</h2></section>
+  <section class="pane" id="timeline"><h2>Timeline</h2><div class="empty">No requests yet. Invoke or serve a target to see activity.</div></section>
+  <section class="pane" id="detail"><h2>Detail</h2><div class="empty">Select a request.</div></section>
+</main>
+<script>${STUDIO_SCRIPT}</script>
+</body>
+</html>`;
+}
+
+/** Minimal HTML-escape for the few interpolated text values. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/tests/integration/local-studio/.scenarios.json
+++ b/tests/integration/local-studio/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-studio"
+  ]
+}

--- a/tests/integration/local-studio/bin/app.ts
+++ b/tests/integration/local-studio/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStudioStack } from '../lib/local-studio-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStudioStack(app, 'LocalStudioFixture', {
+  description: 'Fixture stack for cdkl studio Phase 1 integ test',
+});

--- a/tests/integration/local-studio/cdk.json
+++ b/tests/integration/local-studio/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -1,0 +1,128 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+
+/**
+ * Fixture stack for `cdkl studio` target enumeration integ test.
+ *
+ * Hand-rolls one resource of each kind `cdkl studio` emits a group for, using
+ * inline Lambda code + L1 resources where possible so the stack synthesizes
+ * without AWS / context / VPC lookups and without any asset bundling:
+ *
+ *   - `AWS::Lambda::Function`  (`MyHandler`)      -> Lambda Functions group
+ *   - `AWS::ApiGatewayV2::Api` + Route + Integration (HTTP API v2 wired to
+ *     `MyHandler`)                                -> APIs group
+ *   - `AWS::Lambda::Url` on `MyHandler`           -> APIs group (Function URL)
+ *   - `AWS::ECS::TaskDefinition` (`MyTask`)       -> ECS Task Definitions
+ *   - `AWS::ECS::Service` (`MyService`)           -> ECS Services
+ *   - `AWS::ElasticLoadBalancingV2::LoadBalancer` (`MyAlb`) +
+ *     `AWS::ElasticLoadBalancingV2::TargetGroup` +
+ *     `AWS::ElasticLoadBalancingV2::Listener`     -> Application Load Balancers
+ *   - `AWS::BedrockAgentCore::Runtime` (`MyAgent`) -> AgentCore Runtimes
+ *
+ * The test never executes any of these — `cdkl studio` is a pure synth-time
+ * read over the cloud assembly templates, so placeholder ARNs / URIs are
+ * fine. The fixture only exists so the integ can assert each group + target
+ * label is emitted under the expected command.
+ */
+export class LocalStudioStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Lambda function — inline code so synth has no asset / bundling step.
+    const fn = new lambda.Function(this, 'MyHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(
+        "exports.handler = async () => ({ statusCode: 200, body: 'ok' });"
+      ),
+    });
+
+    // HTTP API v2 + a single Lambda-backed route.
+    const httpApi = new apigwv2.CfnApi(this, 'MyHttpApi', {
+      name: 'cdkl-studio-fixture-http-api',
+      protocolType: 'HTTP',
+    });
+    const httpIntegration = new apigwv2.CfnIntegration(this, 'MyHttpIntegration', {
+      apiId: httpApi.ref,
+      integrationType: 'AWS_PROXY',
+      integrationUri: fn.functionArn,
+      payloadFormatVersion: '2.0',
+    });
+    new apigwv2.CfnRoute(this, 'MyHttpRoute', {
+      apiId: httpApi.ref,
+      routeKey: 'GET /hello',
+      target: cdk.Fn.join('/', ['integrations', httpIntegration.ref]),
+    });
+
+    // Function URL on the same Lambda — surfaces as an `apis` entry with
+    // `(Function URL)` kind, keyed by the BACKING LAMBDA's logical ID.
+    fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE });
+
+    // ECS cluster + bridge-mode task definition + service.
+    const cluster = new ecs.CfnCluster(this, 'MyCluster', {
+      clusterName: 'cdkl-studio-fixture-cluster',
+    });
+    const taskDef = new ecs.CfnTaskDefinition(this, 'MyTask', {
+      family: 'cdkl-studio-fixture-task',
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'web',
+          image: 'public.ecr.aws/docker/library/python:3.12-alpine',
+          essential: true,
+          memoryReservation: 32,
+          portMappings: [{ containerPort: 80, protocol: 'tcp' }],
+        },
+      ],
+    });
+
+    // Target group + listener + ALB fronting the ECS service.
+    const targetGroup = new elbv2.CfnTargetGroup(this, 'MyTargetGroup', {
+      port: 80,
+      protocol: 'HTTP',
+      targetType: 'instance',
+    });
+    const alb = new elbv2.CfnLoadBalancer(this, 'MyAlb', {
+      type: 'application',
+    });
+    new elbv2.CfnListener(this, 'MyListener', {
+      loadBalancerArn: alb.ref,
+      port: 80,
+      protocol: 'HTTP',
+      defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.ref }],
+    });
+    new ecs.CfnService(this, 'MyService', {
+      cluster: cluster.ref,
+      taskDefinition: taskDef.ref,
+      desiredCount: 1,
+      launchType: 'EC2',
+      loadBalancers: [
+        {
+          containerName: 'web',
+          containerPort: 80,
+          targetGroupArn: targetGroup.ref,
+        },
+      ],
+    });
+
+    // AgentCore Runtime — L1 only so no role/network resolution is needed.
+    // The container URI / role ARN are placeholders: `cdkl studio` reads the
+    // resource type + path metadata only, never these properties.
+    new agentcore.CfnRuntime(this, 'MyAgent', {
+      agentRuntimeName: 'cdkl_list_fixture_agent',
+      roleArn: 'arn:aws:iam::123456789012:role/cdkl-studio-fixture-agent-role',
+      networkConfiguration: { networkMode: 'PUBLIC' },
+      agentRuntimeArtifact: {
+        containerConfiguration: {
+          containerUri:
+            '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdkl-studio-fixture-agent:latest',
+        },
+      },
+    });
+  }
+}

--- a/tests/integration/local-studio/package.json
+++ b/tests/integration/local-studio/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-studio",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl studio (Phase 1: control-plane console)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-studio/tsconfig.json
+++ b/tests/integration/local-studio/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl studio Phase 1 control-plane console integ test.
+#
+# studio is the interactive front over the same synth + target enumeration
+# the headless commands use. Phase 1 (this slice) boots a local web server
+# that lists the synthesized app's runnable targets and streams a live
+# activity timeline over SSE. This test drives the REAL cdkl binary
+# end-to-end (no unit-level stubbing) against a fixture app rich enough to
+# emit every target group:
+#
+#   - boots `cdkl studio` behind the CDKL_STUDIO_PREVIEW gate,
+#   - asserts the UI HTML is served at GET /,
+#   - asserts GET /api/targets lists the fixture's targets,
+#   - asserts GET /api/events opens a text/event-stream (SSE),
+#   - asserts the command is HIDDEN without the preview env gate, and
+#   - tears the server down cleanly.
+#
+# No Docker required — Phase 1 is a pure synth + HTTP read. (The invoke /
+# serve slices add Docker-backed timeline coverage.)
+#
+#   bash tests/integration/local-studio/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+HOST="127.0.0.1"
+PORT="0" # 0 => OS-assigned; the bound URL is parsed from the boot log.
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+LOG_FILE=$(mktemp)
+BODY_FILE=$(mktemp)
+STUDIO_PID=""
+cleanup() {
+  if [[ -n "${STUDIO_PID}" ]] && kill -0 "${STUDIO_PID}" 2>/dev/null; then
+    kill "${STUDIO_PID}" 2>/dev/null || true
+    wait "${STUDIO_PID}" 2>/dev/null || true
+  fi
+  rm -f "${LOG_FILE}" "${BODY_FILE}"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# 1. The command must be HIDDEN without the preview gate (no half-finished
+#    command shipping enabled).
+# ---------------------------------------------------------------------------
+echo "==> Asserting 'cdkl studio' is hidden without CDKL_STUDIO_PREVIEW"
+# Commander prints root help (exit 0) for an unknown subcommand, so assert on
+# the registered-command listing rather than on exit status: studio must be
+# absent from `--help` without the gate and present with it.
+if ${CDKL} --help 2>&1 | grep -qE '^\s*studio\b'; then
+  echo "FAIL: 'cdkl studio' is listed without CDKL_STUDIO_PREVIEW=1"
+  exit 1
+fi
+if ! CDKL_STUDIO_PREVIEW=1 ${CDKL} --help 2>&1 | grep -qE '^\s*studio\b'; then
+  echo "FAIL: 'cdkl studio' is NOT listed even with CDKL_STUDIO_PREVIEW=1"
+  exit 1
+fi
+echo "    OK: command is gated off by default, on under the preview flag"
+
+# ---------------------------------------------------------------------------
+# 2. Boot studio behind the gate; parse the bound URL from the boot log.
+# ---------------------------------------------------------------------------
+echo "==> Booting cdkl studio (preview gate on)"
+CDKL_STUDIO_PREVIEW=1 ${CDKL} studio --no-open --studio-port "${PORT}" >"${LOG_FILE}" 2>&1 &
+STUDIO_PID=$!
+
+URL=""
+for _ in $(seq 1 60); do
+  if ! kill -0 "${STUDIO_PID}" 2>/dev/null; then
+    echo "FAIL: studio process exited during boot"
+    echo "----- boot log -----"; cat "${LOG_FILE}"; echo "--------------------"
+    exit 1
+  fi
+  URL=$(grep -oE "http://${HOST}:[0-9]+" "${LOG_FILE}" | head -1 || true)
+  if [[ -n "${URL}" ]]; then
+    # Confirm the socket actually answers before proceeding.
+    if curl -fsS "${URL}/api/targets" -o /dev/null 2>/dev/null; then
+      break
+    fi
+  fi
+  sleep 0.5
+done
+
+if [[ -z "${URL}" ]]; then
+  echo "FAIL: could not parse studio URL from boot log"
+  echo "----- boot log -----"; cat "${LOG_FILE}"; echo "--------------------"
+  exit 1
+fi
+echo "    OK: studio is running at ${URL}"
+
+# ---------------------------------------------------------------------------
+# 3. GET / serves the UI HTML.
+# ---------------------------------------------------------------------------
+echo "==> GET / serves the studio UI"
+curl -fsS "${URL}/" -o "${BODY_FILE}"
+if ! grep -qF "cdkl studio" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not return the studio UI"
+  cat "${BODY_FILE}"
+  exit 1
+fi
+if ! grep -qF "LocalStudioFixture" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not surface the app/stack label"
+  cat "${BODY_FILE}"
+  exit 1
+fi
+echo "    OK: UI HTML served with the stack label"
+
+# ---------------------------------------------------------------------------
+# 4. GET /api/targets lists the fixture's targets.
+# ---------------------------------------------------------------------------
+echo "==> GET /api/targets lists every target group"
+curl -fsS "${URL}/api/targets" -o "${BODY_FILE}"
+for needle in \
+  '"kind":"lambda"' \
+  '"kind":"api"' \
+  '"kind":"ecs"' \
+  '"kind":"agentcore"' \
+  '"kind":"alb"' \
+  'LocalStudioFixture/MyHandler'
+do
+  if ! grep -qF "${needle}" "${BODY_FILE}"; then
+    echo "FAIL: /api/targets missing: ${needle}"
+    cat "${BODY_FILE}"
+    exit 1
+  fi
+  echo "    OK: ${needle}"
+done
+
+# ---------------------------------------------------------------------------
+# 5. GET /api/events opens a Server-Sent-Events stream.
+# ---------------------------------------------------------------------------
+echo "==> GET /api/events opens an SSE stream"
+SSE_HEADERS=$(curl -fsS -D - --max-time 2 "${URL}/api/events" -o /dev/null 2>/dev/null || true)
+if ! grep -qiF "content-type: text/event-stream" <<<"${SSE_HEADERS}"; then
+  echo "FAIL: /api/events did not return a text/event-stream content-type"
+  echo "${SSE_HEADERS}"
+  exit 1
+fi
+echo "    OK: SSE stream opened"
+
+# ---------------------------------------------------------------------------
+# 6. Clean shutdown on SIGTERM.
+# ---------------------------------------------------------------------------
+echo "==> Stopping studio (SIGTERM) and asserting clean exit"
+kill "${STUDIO_PID}"
+for _ in $(seq 1 20); do
+  if ! kill -0 "${STUDIO_PID}" 2>/dev/null; then break; fi
+  sleep 0.25
+done
+if kill -0 "${STUDIO_PID}" 2>/dev/null; then
+  echo "FAIL: studio did not exit on SIGTERM"
+  exit 1
+fi
+STUDIO_PID=""
+echo "    OK: studio stopped cleanly"
+
+echo ""
+echo "==> local-studio test passed (gate + boot + UI + targets + SSE + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  createLocalStudioCommand,
+  parseStudioPort,
+} from '../../../src/cli/commands/local-studio.js';
+
+describe('createLocalStudioCommand', () => {
+  it('is named "studio"', () => {
+    expect(createLocalStudioCommand().name()).toBe('studio');
+  });
+
+  it('exposes --studio-port (default 9999) and --no-open', () => {
+    const cmd = createLocalStudioCommand();
+    const longs = cmd.options.map((o) => o.long);
+    expect(longs).toContain('--studio-port');
+    expect(longs).toContain('--no-open');
+    const portOpt = cmd.options.find((o) => o.long === '--studio-port');
+    expect(portOpt?.defaultValue).toBe('9999');
+  });
+});
+
+describe('parseStudioPort', () => {
+  it('accepts a valid port', () => {
+    expect(parseStudioPort('9999')).toBe(9999);
+  });
+
+  it('accepts 0 (OS-assigned)', () => {
+    expect(parseStudioPort('0')).toBe(0);
+  });
+
+  it('accepts the upper bound 65535', () => {
+    expect(parseStudioPort('65535')).toBe(65535);
+  });
+
+  it.each(['-1', '65536', 'abc', '', '80.5'])('rejects %p', (raw) => {
+    expect(() => parseStudioPort(raw)).toThrow(/--studio-port must be 0\.\.65535/);
+  });
+});

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -26,6 +26,10 @@ import {
   addStartApiSpecificOptions,
   createLocalStartApiCommand,
 } from '../../../src/cli/commands/local-start-api.js';
+import {
+  addStudioSpecificOptions,
+  createLocalStudioCommand,
+} from '../../../src/cli/commands/local-studio.js';
 
 /**
  * Return the sorted long-flag set for a Commander command. Mirrors the
@@ -122,6 +126,24 @@ describe('run-task option surface contract (addRunTaskSpecificOptions)', () => {
       new Set([
         ...commonAppContextRegionFlags(),
         ...longFlagsOf(addRunTaskSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+});
+
+describe('studio option surface contract (addStudioSpecificOptions)', () => {
+  it('addStudioSpecificOptions registers exactly the known studio-only flags', () => {
+    const flags = longFlagsOf(addStudioSpecificOptions(new Command()));
+    expect(flags).toEqual(['--no-open', '--studio-port']);
+  });
+
+  it('createLocalStudioCommand surface equals common + studio-specific (no inline drift)', () => {
+    const full = longFlagsOf(createLocalStudioCommand());
+    const expected = Array.from(
+      new Set([
+        ...commonAppContextRegionFlags(),
+        ...longFlagsOf(addStudioSpecificOptions(new Command())),
       ])
     ).sort();
     expect(full).toEqual(expected);

--- a/tests/unit/local/studio-events.test.ts
+++ b/tests/unit/local/studio-events.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  StudioEventBus,
+  type StudioInvocationEvent,
+  type StudioLogEvent,
+} from '../../../src/local/studio-events.js';
+
+describe('StudioEventBus', () => {
+  it('delivers invocation events to a subscribed listener', () => {
+    const bus = new StudioEventBus();
+    const received: StudioInvocationEvent[] = [];
+    bus.on('invocation', (ev) => received.push(ev));
+
+    const ev: StudioInvocationEvent = {
+      id: 'a1',
+      ts: 1000,
+      target: 'Stack:Handler',
+      kind: 'lambda',
+      label: 'invoke',
+    };
+    bus.emit('invocation', ev);
+
+    expect(received).toEqual([ev]);
+  });
+
+  it('delivers log events to a subscribed listener', () => {
+    const bus = new StudioEventBus();
+    const received: StudioLogEvent[] = [];
+    bus.on('log', (ev) => received.push(ev));
+
+    const ev: StudioLogEvent = {
+      ts: 2000,
+      containerId: 'c1',
+      target: 'Stack:Svc',
+      line: 'hello',
+      stream: 'stdout',
+    };
+    bus.emit('log', ev);
+
+    expect(received).toEqual([ev]);
+  });
+
+  it('keeps invocation and log channels independent', () => {
+    const bus = new StudioEventBus();
+    let invocations = 0;
+    let logs = 0;
+    bus.on('invocation', () => (invocations += 1));
+    bus.on('log', () => (logs += 1));
+
+    bus.emit('invocation', { id: 'x', ts: 0, target: 't', kind: 'api', label: 'GET /' });
+    expect(invocations).toBe(1);
+    expect(logs).toBe(0);
+  });
+
+  it('stops delivering after off()', () => {
+    const bus = new StudioEventBus();
+    let count = 0;
+    const listener = (): void => {
+      count += 1;
+    };
+    bus.on('invocation', listener);
+    bus.emit('invocation', { id: '1', ts: 0, target: 't', kind: 'lambda', label: 'a' });
+    bus.off('invocation', listener);
+    bus.emit('invocation', { id: '2', ts: 0, target: 't', kind: 'lambda', label: 'b' });
+
+    expect(count).toBe(1);
+  });
+
+  it('supports many concurrent subscribers without a max-listener warning', () => {
+    const bus = new StudioEventBus();
+    const counts = Array.from({ length: 50 }, () => 0);
+    counts.forEach((_, i) => bus.on('invocation', () => (counts[i] += 1)));
+    bus.emit('invocation', { id: 'm', ts: 0, target: 't', kind: 'ecs', label: 'x' });
+    expect(counts.every((c) => c === 1)).toBe(true);
+  });
+});

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -144,6 +144,45 @@ describe('startStudioServer', () => {
     expect(second.port).toBe(first.port + 1);
   });
 
+  it('rejects when the preferred port is taken and no bumps are allowed', async () => {
+    const first = await boot({ port: 0 });
+    // maxPortBump: 0 => the first EADDRINUSE rejects immediately rather
+    // than bumping. Exercises the give-up branch of listenWithBump.
+    const bus = new StudioEventBus();
+    await expect(
+      startStudioServer({
+        port: first.port,
+        bus,
+        targetGroups: [],
+        appLabel: 'X',
+        cliName: 'cdkl',
+        maxPortBump: 0,
+      })
+    ).rejects.toMatchObject({ code: 'EADDRINUSE' });
+  });
+
+  it('unsubscribes the bus listeners when an SSE client disconnects', async () => {
+    const bus = new StudioEventBus();
+    const server = await boot({ bus });
+
+    const res = await fetch(`${server.url}/api/events`);
+    const reader = res.body!.getReader();
+    await reader.read(); // open the stream so the server subscribes
+    // Subscribed: one invocation + one log listener.
+    expect(bus.listenerCount('invocation')).toBe(1);
+    expect(bus.listenerCount('log')).toBe(1);
+
+    await reader.cancel(); // client disconnect
+
+    // The server's req/res `close` handler must unsubscribe. Poll briefly
+    // since the disconnect propagates asynchronously.
+    for (let i = 0; i < 40 && bus.listenerCount('invocation') > 0; i += 1) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(bus.listenerCount('invocation')).toBe(0);
+    expect(bus.listenerCount('log')).toBe(0);
+  });
+
   it('close() resolves even with a live SSE client connected', async () => {
     const server = await boot();
     const res = await fetch(`${server.url}/api/events`);

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach } from 'vite-plus/test';
+import { StudioEventBus } from '../../../src/local/studio-events.js';
+import {
+  startStudioServer,
+  toStudioTargetGroups,
+  type RunningStudioServer,
+} from '../../../src/local/studio-server.js';
+import type { TargetListing } from '../../../src/local/target-lister.js';
+
+const running: RunningStudioServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(running.splice(0).map((s) => s.close()));
+});
+
+async function boot(
+  overrides: Partial<Parameters<typeof startStudioServer>[0]> = {}
+): Promise<RunningStudioServer> {
+  const bus = overrides.bus ?? new StudioEventBus();
+  const server = await startStudioServer({
+    port: 0, // 0 = let the OS pick a free port for the test
+    bus,
+    targetGroups: [
+      {
+        kind: 'lambda',
+        title: 'Lambda Functions',
+        entries: [{ id: 'MyStack/Handler', qualifiedId: 'MyStack:Handler' }],
+      },
+    ],
+    appLabel: 'MyStack',
+    cliName: 'cdkl',
+    ...overrides,
+  });
+  running.push(server);
+  return server;
+}
+
+const emptyListing = (): TargetListing => ({
+  lambdas: [],
+  apis: [],
+  ecsServices: [],
+  ecsTaskDefinitions: [],
+  agentCoreRuntimes: [],
+  loadBalancers: [],
+});
+
+describe('toStudioTargetGroups', () => {
+  it('projects a TargetListing into the five studio groups', () => {
+    const listing: TargetListing = {
+      ...emptyListing(),
+      lambdas: [{ qualifiedId: 'S:Fn', displayPath: 'S/Fn' }],
+      apis: [{ qualifiedId: 'S:Api', displayPath: 'S/Api', kind: 'HTTP API v2' }],
+      ecsServices: [{ qualifiedId: 'S:Svc' }],
+      ecsTaskDefinitions: [{ qualifiedId: 'S:Task' }],
+    };
+    const groups = toStudioTargetGroups(listing);
+
+    expect(groups.map((g) => g.kind)).toEqual(['lambda', 'api', 'ecs', 'agentcore', 'alb']);
+    expect(groups[0].entries).toEqual([{ id: 'S/Fn', qualifiedId: 'S:Fn' }]);
+    // API surface kind is carried onto the entry.
+    expect(groups[1].entries[0]).toEqual({
+      id: 'S/Api',
+      qualifiedId: 'S:Api',
+      surface: 'HTTP API v2',
+    });
+    // ECS services and task definitions fold into the one `ecs` group.
+    expect(groups[2].entries.map((e) => e.id)).toEqual(['S:Svc', 'S:Task']);
+  });
+
+  it('falls back to the qualified id when no display path exists', () => {
+    const listing: TargetListing = {
+      ...emptyListing(),
+      lambdas: [{ qualifiedId: 'S:Fn' }],
+    };
+    expect(toStudioTargetGroups(listing)[0].entries[0]).toEqual({ id: 'S:Fn', qualifiedId: 'S:Fn' });
+  });
+});
+
+describe('startStudioServer', () => {
+  it('serves the UI HTML at GET /', async () => {
+    const server = await boot();
+    const res = await fetch(`${server.url}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('cdkl studio');
+    expect(body).toContain('MyStack');
+  });
+
+  it('serves the target groups at GET /api/targets', async () => {
+    const server = await boot();
+    const res = await fetch(`${server.url}/api/targets`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const data = (await res.json()) as { groups: { kind: string; entries: unknown[] }[] };
+    const lambda = data.groups.find((g) => g.kind === 'lambda');
+    expect(lambda?.entries).toEqual([{ id: 'MyStack/Handler', qualifiedId: 'MyStack:Handler' }]);
+  });
+
+  it('404s an unknown path', async () => {
+    const server = await boot();
+    const res = await fetch(`${server.url}/nope`);
+    expect(res.status).toBe(404);
+  });
+
+  it('streams an emitted invocation over the SSE channel', async () => {
+    const bus = new StudioEventBus();
+    const server = await boot({ bus });
+
+    const res = await fetch(`${server.url}/api/events`);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    // The server writes an opening `:ok` comment; read it so we know the
+    // subscription is live before emitting.
+    await reader.read();
+    bus.emit('invocation', {
+      id: 'sse1',
+      ts: 123,
+      target: 'MyStack:Handler',
+      kind: 'lambda',
+      label: 'invoke',
+    });
+
+    let buf = '';
+    while (!buf.includes('event: invocation')) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+    }
+    await reader.cancel();
+
+    expect(buf).toContain('event: invocation');
+    expect(buf).toContain('"id":"sse1"');
+  });
+
+  it('bumps to the next free port when the preferred port is taken', async () => {
+    const first = await boot({ port: 0 });
+    // Re-request the SAME concrete port the first server bound; the bump
+    // logic must pick a different one rather than throwing EADDRINUSE.
+    const second = await boot({ port: first.port });
+    expect(second.port).not.toBe(first.port);
+    expect(second.port).toBe(first.port + 1);
+  });
+
+  it('close() resolves even with a live SSE client connected', async () => {
+    const server = await boot();
+    const res = await fetch(`${server.url}/api/events`);
+    const reader = res.body!.getReader();
+    await reader.read(); // open the stream
+    // close() must not hang on the open keep-alive socket.
+    await expect(server.close()).resolves.toBeUndefined();
+    running.splice(running.indexOf(server), 1);
+    await reader.cancel().catch(() => undefined);
+  });
+});

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { renderStudioHtml } from '../../../src/local/studio-ui.js';
+
+describe('renderStudioHtml', () => {
+  it('renders a full HTML document branded with the CLI name', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('cdkl studio');
+    expect(html).toContain('MyStack');
+    // The three panes are present.
+    expect(html).toContain('id="targets"');
+    expect(html).toContain('id="timeline"');
+    expect(html).toContain('id="detail"');
+  });
+
+  it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {
+    const html = renderStudioHtml('<script>alert(1)</script>', '"&<>');
+    // The raw markup must never appear verbatim in the document.
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).toContain('&quot;&amp;&lt;&gt;');
+  });
+});


### PR DESCRIPTION
## Summary

First slice of `cdkl studio` — the interactive web console over the same
target enumeration the headless commands use. This slice ships the
**observation shell**; invoke/serve dispatch, the input composer, re-invoke,
and per-invocation logs land in following slices.

Slice A of the studio Phase 1 work — see #282 (umbrella: see #280).

### What's in this slice

- **`src/local/studio-events.ts`** — typed in-process event bus
  (`invocation` / `log`) every studio observation flows through;
  re-exported from `cdk-local/internal`.
- **`src/local/studio-server.ts`** — localhost HTTP server: serves the
  embedded UI at `/`, the synthesized target list at `/api/targets`, and an
  SSE stream of the bus at `/api/events`; collision-bumps the port.
- **`src/local/studio-ui.ts`** — framework-free (vanilla) 3-pane UI embedded
  as a string so it ships inside the npm package with no asset-copy build
  step.
- **`src/cli/commands/local-studio.ts`** — the `cdkl studio` command factory
  (synth + target enumeration + boot server + graceful shutdown), with
  `--studio-port` / `--no-open`.

### Design decisions implemented (from the umbrella design pass)

- D1 control-plane command (its own `cdkl studio`, not a `--studio` flag)
- D2 on-demand (target list renders; timeline empty until activity arrives;
  nothing auto-boots)
- D6 3-pane single-page layout (targets / timeline / detail)
- D7 vanilla TS, no framework
- D9 UI bundled inside the npm package as an embedded string

### Preview gate

The command is registered ONLY when `CDKL_STUDIO_PREVIEW=1`, so the
half-finished command cannot ship enabled while slices land on main; the
integration suite still drives the real binary end-to-end through the gate.
The gate is removed in the unveil slice. For the same reason
`createLocalStudioCommand` is intentionally NOT exported from the stable
`src/index.ts` yet (it graduates at unveil); the low-level building blocks
ARE re-exported from `cdk-local/internal`.

### Workflow rule added

`.claude/CLAUDE.md` gains a rule: integration tests must never be deferred
to a later PR — each slice carries its own integ green before merge.

## Test plan

- **Unit** (148 files / 2198 tests green): event bus (incl. listener
  symmetry), server endpoints (`/`, `/api/targets`, `/api/events` SSE, 404,
  port collision-bump, give-up branch, close-with-live-SSE,
  disconnect-unsubscribe), target-group projection, command surface +
  option contract, `parseStudioPort` bounds, and `renderStudioHtml` HTML
  escaping.
- **Integration** (`tests/integration/local-studio`, Docker-free): drives
  the real `dist/cli.js` binary end-to-end — asserts the command is hidden
  without the preview gate and present with it, boots the server, `GET /`
  serves the UI, `/api/targets` lists every group, `/api/events` opens an
  SSE stream, and SIGTERM shuts down cleanly.
- **Live-test**: ran `cdkl studio` against the fixture and confirmed the
  3-pane UI, target list, live SSE indicator, and empty timeline in a
  browser.

## Review

3-axis review (spec / code / test). Spec: clean. Code: one blocker — the SSE
handler could crash the process on shutdown via a write-after-destroy race —
fixed (write guard + `error` listener + idempotent cleanup). Test: two
coverage gaps filled (port-bump give-up, SSE disconnect unsubscribe) plus an
HTML-escape assertion.

Accepted-as-known minors (not changed): the `closeAllConnections?.()`
optional chain is harmless belt-and-suspenders under engines >=20; the win32
`openBrowser` `start` invocation only ever receives the fixed
`http://127.0.0.1:<port>` URL (not user-tainted).

## cdkd parity

New subcommand factory (`createLocalStudioCommand`) + new `src/local/**`
helpers. Parity walk: options live in `addStudioSpecificOptions` (not inline,
contract test green); the helpers are re-exported from `src/internal.ts` with
host-use JSDoc; no behavior change to existing commands. The factory is
deliberately NOT yet on `src/index.ts` and cdkd is intentionally not notified
— studio is preview-gated and not a host-embeddable surface until the unveil
slice.
