### PR TITLE
feat(studio): Phase 1 slice B — invoke a Lambda from the studio UI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -292,7 +292,13 @@ compute-locally category for Lambda + API Gateway).
   UI at `/`, the synthesized target list at `/api/targets`, and an SSE
   stream of the event bus at `/api/events`; collision-bumps the port),
   studio-ui (the framework-free web UI embedded as a string so it ships
-  inside the npm package with no asset-copy build step), etc.
+  inside the npm package with no asset-copy build step; 3-pane: targets /
+  workspace composer / timeline), studio-dispatch (issue #282 — the
+  `POST /api/run` handler that runs a target from the studio UI by
+  spawning the SAME `cdkl invoke` the headless command runs as a child
+  process — studio is a control plane over the CLI — streaming its
+  stdout/stderr to the event bus and returning the parsed Lambda response;
+  slice B is Lambda single-shot invoke), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -18,12 +18,41 @@ import {
   type CdkLocalEmbedConfig,
 } from '../../local/embed-config.js';
 import { listTargets } from '../../local/target-lister.js';
-import { StudioEventBus } from '../../local/studio-events.js';
+import { StudioEventBus, type StudioTargetKind } from '../../local/studio-events.js';
 import {
   startStudioServer,
   toStudioTargetGroups,
   type RunningStudioServer,
 } from '../../local/studio-server.js';
+import { createStudioDispatcher, type StudioRunRequest } from '../../local/studio-dispatch.js';
+
+const STUDIO_TARGET_KINDS: readonly StudioTargetKind[] = [
+  'lambda',
+  'api',
+  'alb',
+  'ecs',
+  'agentcore',
+];
+
+/**
+ * Validate + narrow the untyped `POST /api/run` body into a
+ * {@link StudioRunRequest}. Throws (→ 400 from the server) on a malformed
+ * body so a bad UI / curl payload fails loudly rather than spawning an
+ * `invoke` for an empty target.
+ */
+export function coerceRunRequest(body: unknown): StudioRunRequest {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('Request body must be a JSON object.');
+  }
+  const { targetId, kind, event } = body as Record<string, unknown>;
+  if (typeof targetId !== 'string' || targetId.trim() === '') {
+    throw new Error('Request body must include a non-empty "targetId" string.');
+  }
+  if (typeof kind !== 'string' || !STUDIO_TARGET_KINDS.includes(kind as StudioTargetKind)) {
+    throw new Error(`Request body "kind" must be one of: ${STUDIO_TARGET_KINDS.join(', ')}.`);
+  }
+  return { targetId, kind: kind as StudioTargetKind, event };
+}
 
 const DEFAULT_STUDIO_PORT = 9999;
 
@@ -99,12 +128,25 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   const appLabel = stacks.map((s) => s.stackName).join(', ') || appCmd;
 
   const bus = new StudioEventBus();
+  const dispatcher = createStudioDispatcher({
+    // `process.argv[1]` is the running CLI entry (`dist/cli.js` / the `cdkl`
+    // bin); the dispatcher spawns it again as `cdkl invoke <target>`.
+    cliEntry: process.argv[1] ?? '',
+    bus,
+    cwd: process.cwd(),
+    ...(appCmd ? { app: appCmd } : {}),
+    ...(options.profile ? { profile: options.profile } : {}),
+    ...(options.region ? { region: options.region } : {}),
+    ...(Object.keys(context).length > 0 ? { context } : {}),
+  });
+
   const server = await startStudioServer({
     port,
     bus,
     targetGroups,
     appLabel,
     cliName: getEmbedConfig().cliName,
+    onRun: (body) => dispatcher.run(coerceRunRequest(body)),
   });
 
   const cliName = getEmbedConfig().cliName;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -702,3 +702,20 @@ export {
   type StudioTargetGroup,
 } from './local/studio-server.js';
 export { renderStudioHtml } from './local/studio-ui.js';
+
+/**
+ * `cdkl studio` run dispatcher (issue #282, slice B). A host CLI embedding
+ * studio wires `createStudioDispatcher(...).run` as the `startStudioServer`
+ * `onRun` handler so the browser's `POST /api/run` runs a target by spawning
+ * the host's own `invoke` subcommand as a child process (studio is a control
+ * plane over the CLI). `coerceRunRequest` validates the untyped request body
+ * a host's `onRun` receives into a typed {@link StudioRunRequest}.
+ */
+export {
+  createStudioDispatcher,
+  type StudioDispatcher,
+  type StudioDispatchConfig,
+  type StudioRunRequest,
+  type StudioRunResult,
+} from './local/studio-dispatch.js';
+export { coerceRunRequest } from './cli/commands/local-studio.js';

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -1,0 +1,315 @@
+import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { StudioEventBus, type StudioTargetKind } from './studio-events.js';
+
+/** A request to run a target, as the studio UI posts it to `/api/run`. */
+export interface StudioRunRequest {
+  /** Target id the user picked (display path or stack-qualified id). */
+  targetId: string;
+  /** Target kind. Slice B handles `'lambda'` (single-shot invoke) only. */
+  kind: StudioTargetKind;
+  /** The event payload to invoke with. */
+  event: unknown;
+}
+
+/** The outcome of a single-shot run, returned from `/api/run`. */
+export interface StudioRunResult {
+  /** Correlation id shared with the emitted invocation events. */
+  invocationId: string;
+  /** Whether the underlying `cdkl invoke` exited 0. */
+  ok: boolean;
+  /**
+   * Synthetic status for the timeline: 200 when the invoke succeeded,
+   * 500 when it failed. A direct Lambda invoke has no HTTP status; this
+   * is the UI's success/failure signal only.
+   */
+  status: number;
+  /** Parsed Lambda response (JSON when parseable, else the raw string). */
+  response?: unknown;
+  /** Raw stdout payload from `cdkl invoke`. */
+  raw?: string;
+  /** Error summary when the invoke failed. */
+  error?: string;
+  /** Wall-clock duration in ms. */
+  durationMs: number;
+}
+
+/** Config for {@link createStudioDispatcher}. */
+export interface StudioDispatchConfig {
+  /** Path to the `cdkl` CLI entry (`dist/cli.js`) — usually `process.argv[1]`. */
+  cliEntry: string;
+  /** The shared event bus; invocation + log events are emitted onto it. */
+  bus: StudioEventBus;
+  /** Working directory for the child invoke (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** `--app` value to thread into the child invoke, if studio was given one. */
+  app?: string;
+  /** `-c key=value` context overrides to thread through. */
+  context?: Record<string, string>;
+  /** `--profile` to thread through. */
+  profile?: string;
+  /** `--region` to thread through. */
+  region?: string;
+  /** Node binary to spawn (defaults to `process.execPath`; injectable for tests). */
+  nodeBin?: string;
+  /** Spawn implementation (injectable for tests). */
+  spawnFn?: typeof nodeSpawn;
+  /** Clock (injectable for tests; defaults to `Date.now`). */
+  clock?: () => number;
+  /** Invocation-id factory (injectable for tests). */
+  idFactory?: () => string;
+}
+
+/** A bound dispatcher exposing the `/api/run` handler. */
+export interface StudioDispatcher {
+  run: (req: StudioRunRequest) => Promise<StudioRunResult>;
+}
+
+let idCounter = 0;
+
+/**
+ * Build the studio run dispatcher. Slice B drives a single-shot Lambda
+ * invoke by spawning the SAME `cdkl invoke` the headless command runs —
+ * studio is a control plane over the CLI, so re-using the whole command
+ * (rather than re-wiring its internals) guarantees byte-for-byte parity
+ * and keeps all of `cdkl invoke`'s process-global behavior
+ * (`process.exit`, env mutation, stdin) isolated in a child process.
+ *
+ * The child's stdout is the Lambda response payload; its stderr (status
+ * + container logs) is streamed line-by-line onto the bus as `log`
+ * events. An `invocation` start event is emitted before spawn and an end
+ * event (with response + status + duration) after exit, both keyed by
+ * the same correlation id so the UI threads them into one timeline row.
+ */
+export function createStudioDispatcher(config: StudioDispatchConfig): StudioDispatcher {
+  const spawnFn = config.spawnFn ?? nodeSpawn;
+  const nodeBin = config.nodeBin ?? process.execPath;
+  const clock = config.clock ?? Date.now;
+  const idFactory =
+    config.idFactory ??
+    (() => {
+      idCounter += 1;
+      return `inv-${clock()}-${idCounter}`;
+    });
+
+  async function run(req: StudioRunRequest): Promise<StudioRunResult> {
+    const invocationId = idFactory();
+    const startedAt = clock();
+
+    if (req.kind !== 'lambda') {
+      // Serve targets (API / ALB / ECS) arrive in slice C; reject clearly
+      // rather than silently mis-dispatching.
+      const error = `Running '${req.kind}' targets from studio is not supported yet (Lambda only).`;
+      config.bus.emit('invocation', {
+        id: invocationId,
+        ts: startedAt,
+        target: req.targetId,
+        kind: req.kind,
+        label: 'invoke',
+        request: req.event,
+        response: error,
+        status: 501,
+        durationMs: clock() - startedAt,
+      });
+      return { invocationId, ok: false, status: 501, error, durationMs: clock() - startedAt };
+    }
+
+    config.bus.emit('invocation', {
+      id: invocationId,
+      ts: startedAt,
+      target: req.targetId,
+      kind: req.kind,
+      label: 'invoke',
+      request: req.event,
+    });
+
+    // `dir` is created inside the try so a `writeFileSync` / `JSON.stringify`
+    // throw still hits the finally that cleans it up.
+    let dir: string | undefined;
+    try {
+      dir = mkdtempSync(join(tmpdir(), 'cdkl-studio-run-'));
+      const eventFile = join(dir, 'event.json');
+      writeFileSync(eventFile, JSON.stringify(req.event ?? {}));
+
+      const args = ['invoke', req.targetId, '--event', eventFile];
+      if (config.app) args.push('--app', config.app);
+      if (config.profile) args.push('--profile', config.profile);
+      if (config.region) args.push('--region', config.region);
+      for (const [k, v] of Object.entries(config.context ?? {})) {
+        args.push('-c', `${k}=${v}`);
+      }
+
+      const { code, stdout, stderr } = await runChild(
+        spawnFn,
+        nodeBin,
+        [config.cliEntry, ...args],
+        config.cwd ?? process.cwd(),
+        invocationId,
+        req.targetId,
+        config.bus,
+        clock
+      );
+
+      const durationMs = clock() - startedAt;
+      const ok = code === 0;
+      const failure = stderr.trim() || `cdkl invoke exited ${code}`;
+
+      // `cdkl invoke` interleaves synth progress + streamed container logs on
+      // stdout and writes the Lambda response there too. The RIE response is
+      // always a single line of valid JSON (the serialized handler return
+      // value or error object), whereas progress / container lines
+      // (`Synthesizing…`, `Starting container…`, `START/END/REPORT`) are NOT
+      // JSON — so the response is the LAST JSON-parseable stdout line, which is
+      // robust against a container log line flushing AFTER the response. Every
+      // other stdout line is surfaced as a log event. Falls back to the last
+      // line when nothing parses (an unusual non-JSON / empty response).
+      const stdoutLines = stdout
+        .split('\n')
+        .map((l) => l.replace(/\r$/, '').trimEnd())
+        .filter((l) => l.trim().length > 0);
+
+      let responseIdx = -1;
+      let response: unknown;
+      if (ok) {
+        for (let i = stdoutLines.length - 1; i >= 0; i -= 1) {
+          const parsed = tryParseJson(stdoutLines[i] ?? '');
+          if (parsed.ok) {
+            responseIdx = i;
+            response = parsed.value;
+            break;
+          }
+        }
+        if (responseIdx === -1 && stdoutLines.length > 0) {
+          responseIdx = stdoutLines.length - 1;
+          response = stdoutLines[responseIdx];
+        }
+      } else {
+        response = failure;
+      }
+
+      // Every stdout line that is not the response line is a log line.
+      stdoutLines.forEach((line, i) => {
+        if (i === responseIdx) return;
+        config.bus.emit('log', {
+          ts: clock(),
+          containerId: invocationId,
+          target: req.targetId,
+          line,
+          stream: 'stdout',
+        });
+      });
+
+      const raw = responseIdx >= 0 ? (stdoutLines[responseIdx] ?? '') : '';
+      const status = ok ? 200 : 500;
+
+      config.bus.emit('invocation', {
+        id: invocationId,
+        ts: startedAt,
+        target: req.targetId,
+        kind: req.kind,
+        label: 'invoke',
+        request: req.event,
+        response,
+        status,
+        durationMs,
+      });
+
+      const result: StudioRunResult = { invocationId, ok, status, durationMs };
+      if (raw) result.raw = raw;
+      if (response !== undefined) result.response = response;
+      if (!ok) result.error = failure;
+      return result;
+    } finally {
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  return { run };
+}
+
+interface ChildOutcome {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Spawn the child invoke, accumulate stdout, and stream stderr to the
+ * bus line-by-line as `log` events. Resolves on process close.
+ */
+function runChild(
+  spawnFn: typeof nodeSpawn,
+  nodeBin: string,
+  argv: string[],
+  cwd: string,
+  invocationId: string,
+  target: string,
+  bus: StudioEventBus,
+  clock: () => number
+): Promise<ChildOutcome> {
+  return new Promise<ChildOutcome>((resolve, reject) => {
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawnFn(nodeBin, argv, { cwd });
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let lineBuf = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+      lineBuf += chunk;
+      let nl = lineBuf.indexOf('\n');
+      while (nl !== -1) {
+        const line = lineBuf.slice(0, nl);
+        lineBuf = lineBuf.slice(nl + 1);
+        if (line.length > 0) {
+          bus.emit('log', {
+            ts: clock(),
+            containerId: invocationId,
+            target,
+            line,
+            stream: 'stderr',
+          });
+        }
+        nl = lineBuf.indexOf('\n');
+      }
+    });
+
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (lineBuf.length > 0) {
+        bus.emit('log', {
+          ts: clock(),
+          containerId: invocationId,
+          target,
+          line: lineBuf,
+          stream: 'stderr',
+        });
+      }
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+/** Try to JSON-parse `raw`; `ok` distinguishes a parsed value from a failure. */
+function tryParseJson(raw: string): { ok: boolean; value: unknown } {
+  if (raw === '') return { ok: false, value: undefined };
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch {
+    return { ok: false, value: undefined };
+  }
+}

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -73,6 +73,15 @@ export interface StudioServerOptions {
    * Defaults to 20.
    */
   maxPortBump?: number;
+  /**
+   * Handler for `POST /api/run` — runs a target (slice B: a single-shot
+   * Lambda invoke) and returns the result. When omitted, `/api/run`
+   * answers 501 (the observe-only shell). The body is the parsed JSON
+   * request; the handler emits its own invocation / log events onto the
+   * bus, so the UI's timeline updates over SSE independently of the
+   * response.
+   */
+  onRun?: (body: unknown) => Promise<unknown>;
 }
 
 /** A running studio server. */
@@ -102,7 +111,7 @@ export async function startStudioServer(
   const targetsJson = JSON.stringify({ groups: options.targetGroups });
 
   const server = createServer((req, res) =>
-    handleRequest(req, res, options.bus, html, targetsJson)
+    handleRequest(req, res, options.bus, html, targetsJson, options.onRun)
   );
 
   const boundPort = await listenWithBump(server, host, options.port, maxBump);
@@ -125,7 +134,8 @@ function handleRequest(
   res: ServerResponse,
   bus: StudioEventBus,
   html: string,
-  targetsJson: string
+  targetsJson: string,
+  onRun?: (body: unknown) => Promise<unknown>
 ): void {
   const url = req.url ?? '/';
   const path = url.split('?')[0];
@@ -144,8 +154,89 @@ function handleRequest(
     serveSse(req, res, bus);
     return;
   }
+  if (req.method === 'POST' && path === '/api/run') {
+    void handleRun(req, res, onRun);
+    return;
+  }
   res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
   res.end('Not found');
+}
+
+const MAX_RUN_BODY_BYTES = 5 * 1024 * 1024;
+
+/** Reply to `POST /api/run`: parse the JSON body, dispatch via `onRun`. */
+async function handleRun(
+  req: IncomingMessage,
+  res: ServerResponse,
+  onRun?: (body: unknown) => Promise<unknown>
+): Promise<void> {
+  const sendJson = (statusCode: number, payload: unknown): void => {
+    res.writeHead(statusCode, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify(payload));
+  };
+
+  if (!onRun) {
+    // The observe-only shell (no dispatcher wired) cannot run targets.
+    sendJson(501, { error: 'Running targets is not supported by this studio server.' });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    body = await readJsonBody(req);
+  } catch (err) {
+    sendJson(400, { error: err instanceof Error ? err.message : String(err) });
+    return;
+  }
+
+  try {
+    const result = await onRun(body);
+    sendJson(200, result);
+  } catch (err) {
+    sendJson(500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+/** Read + JSON-parse a request body, bounded to {@link MAX_RUN_BODY_BYTES}. */
+function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise<unknown>((resolveBody, reject) => {
+    let raw = '';
+    let bytes = 0;
+    // Single-flight: once the promise settles (over-limit / end / error) the
+    // handlers short-circuit so a late chunk or the destroy-triggered `error`
+    // cannot re-settle it.
+    let done = false;
+    const settle = (fn: () => void): void => {
+      if (done) return;
+      done = true;
+      fn();
+    };
+    req.setEncoding('utf8');
+    req.on('data', (chunk: string) => {
+      if (done) return;
+      bytes += Buffer.byteLength(chunk);
+      if (bytes > MAX_RUN_BODY_BYTES) {
+        settle(() => reject(new Error('Request body too large.')));
+        req.destroy();
+        return;
+      }
+      raw += chunk;
+    });
+    req.on('end', () => {
+      settle(() => {
+        if (raw.trim() === '') {
+          resolveBody(undefined);
+          return;
+        }
+        try {
+          resolveBody(JSON.parse(raw));
+        } catch {
+          reject(new Error('Invalid JSON body.'));
+        }
+      });
+    });
+    req.on('error', (err) => settle(() => reject(err)));
+  });
 }
 
 function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus): void {

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -4,11 +4,19 @@
  * `tsdown` bundles this module like any other source file. Served by
  * the studio HTTP server (`startStudioServer`) at `GET /`.
  *
- * Slice A renders the 3-pane shell (decision D6): left = target list
- * (from `GET /api/targets`), center = live timeline (from the
- * `GET /api/events` SSE stream — empty until the invoke / serve slices
- * emit invocations), right = detail panel (filled on row click). It is
- * intentionally framework-free vanilla JS (decision D7).
+ * 3-pane shell (decision D6), framework-free vanilla JS (decision D7):
+ *   - left   = target list (from `GET /api/targets`); each runnable
+ *     Lambda has an [Invoke] button and a selected-highlight.
+ *   - center = the WORKSPACE for the selected target: an event composer
+ *     (textarea + Invoke button) with the latest run's Request /
+ *     Response / Logs shown BELOW it, so you can edit and re-invoke
+ *     repeatedly without losing the composer.
+ *   - right  = the timeline (history) of every invocation; clicking a
+ *     row loads it back into the workspace.
+ *
+ * The center workspace is deliberately adjacent to the left target list
+ * (short eye-travel: pick a target -> compose right next to it), and is
+ * the primary surface — the timeline is secondary history.
  */
 
 const STUDIO_CSS = `
@@ -23,18 +31,34 @@ const STUDIO_CSS = `
   }
   header .brand { font-weight: 700; color: #fff; }
   header .meta { color: #888; font-size: 12px; }
-  main { display: grid; grid-template-columns: 280px 1fr 360px; height: calc(100vh - 38px); }
-  .pane { overflow: auto; border-right: 1px solid #333; }
-  .pane:last-child { border-right: 0; }
+  main {
+    display: grid; grid-template-columns: 280px 5px 1fr 5px 320px;
+    height: calc(100vh - 38px);
+  }
+  .pane { overflow: auto; }
+  .splitter { background: #2a2a2a; cursor: col-resize; }
+  .splitter:hover, .splitter.dragging { background: #4ec97a; }
   .pane h2 {
     margin: 0; padding: 8px 12px; font-size: 11px; text-transform: uppercase;
     letter-spacing: 0.5px; color: #888; background: #151515;
-    position: sticky; top: 0; border-bottom: 1px solid #2a2a2a;
+    position: sticky; top: 0; border-bottom: 1px solid #2a2a2a; z-index: 1;
   }
   .group-title { padding: 8px 12px 2px; color: #6aa9ff; font-size: 11px; }
-  .target { padding: 5px 12px; cursor: default; border-bottom: 1px solid #222; }
-  .target .name { color: #ddd; }
+  .target {
+    padding: 6px 12px; border-bottom: 1px solid #222; display: flex;
+    align-items: center; gap: 8px;
+  }
+  .target.runnable { cursor: pointer; }
+  .target.runnable:hover { background: #202020; }
+  .target.sel { background: #2a3550; }
+  .target .name { color: #ddd; flex: 1; overflow: hidden; text-overflow: ellipsis; }
   .target .kind { color: #777; font-size: 11px; }
+  .target .invoke-btn {
+    padding: 2px 10px; font: 11px ui-monospace, Menlo, monospace; font-weight: 700;
+    color: #0d1f12; background: #4ec97a; border: 0; border-radius: 3px; cursor: pointer;
+  }
+  .target .invoke-btn:hover { background: #6fe097; }
+  .target.sel .invoke-btn { background: #6fe097; }
   .empty { padding: 16px 12px; color: #666; }
   .row {
     padding: 5px 12px; border-bottom: 1px solid #222; cursor: pointer;
@@ -45,9 +69,27 @@ const STUDIO_CSS = `
   .row .ts { color: #777; }
   .row .label { color: #ddd; flex: 1; overflow: hidden; text-overflow: ellipsis; }
   .row .status { color: #7bd88f; }
-  #detail .section { padding: 8px 12px; border-bottom: 1px solid #222; }
-  #detail .section h3 { margin: 0 0 6px; font-size: 11px; color: #888; text-transform: uppercase; }
-  #detail pre { margin: 0; white-space: pre-wrap; word-break: break-word; color: #cfcfcf; }
+  .row .status.err { color: #e0707a; }
+  #workspace { padding: 0 0 24px; }
+  .composer { padding: 10px 12px; border-bottom: 1px solid #2a2a2a; }
+  .composer .target-name { color: #fff; font-weight: 700; margin-bottom: 6px; }
+  .composer textarea {
+    width: 100%; min-height: 130px; resize: vertical; background: #111; color: #ddd;
+    border: 1px solid #333; border-radius: 3px; padding: 6px;
+    font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .composer button {
+    margin-top: 8px; padding: 6px 18px; background: #2a7d46; color: #fff;
+    border: 0; border-radius: 3px; cursor: pointer; font: inherit; font-weight: 700;
+  }
+  .composer button:hover { background: #339152; }
+  .composer button:disabled { background: #333; color: #888; cursor: default; }
+  .composer .err { color: #e0707a; margin-top: 6px; min-height: 18px; }
+  .section { padding: 8px 12px; border-bottom: 1px solid #222; }
+  .section h3 { margin: 0 0 6px; font-size: 11px; color: #888; text-transform: uppercase; }
+  .section h3 .ok { color: #7bd88f; }
+  .section h3 .bad { color: #e0707a; }
+  .section pre { margin: 0; white-space: pre-wrap; word-break: break-word; color: #cfcfcf; }
   #conn { font-size: 11px; }
   #conn.up { color: #7bd88f; }
   #conn.down { color: #e0707a; }
@@ -55,7 +97,12 @@ const STUDIO_CSS = `
 
 const STUDIO_SCRIPT = `
   const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', agentcore: 'AgentCore' };
-  const rowsById = new Map();
+  const rowsById = new Map();      // invocationId -> timeline row element
+  const invById = new Map();       // invocationId -> latest invocation event
+  const logsById = new Map();      // invocationId -> [log lines]
+  const targetEls = new Map();     // targetId -> left-pane element
+  let active = null;               // { id, kind, ta, btn, msg, result }
+  let shownInvId = null;           // invocation whose result is in the workspace
 
   function el(tag, cls, text) {
     const e = document.createElement(tag);
@@ -76,10 +123,21 @@ const STUDIO_SCRIPT = `
         pane.appendChild(el('div', 'group-title', group.title));
         for (const entry of group.entries) {
           total += 1;
-          const t = el('div', 'target');
-          t.appendChild(el('span', 'name', entry.id));
-          t.appendChild(document.createTextNode('  '));
+          // Slice B: only Lambda targets are runnable from the UI (single-shot
+          // invoke). Other kinds list but are not yet selectable.
+          const runnable = group.kind === 'lambda';
+          const t = el('div', runnable ? 'target runnable' : 'target');
+          const name = el('span', 'name', entry.id);
+          name.title = entry.id; // full path on hover even when truncated
+          t.appendChild(name);
           t.appendChild(el('span', 'kind', '(' + (KIND_LABEL[group.kind] || group.kind) + ')'));
+          if (runnable) {
+            const btn = el('button', 'invoke-btn', 'Invoke');
+            btn.onclick = (e) => { e.stopPropagation(); selectTarget(entry.id, group.kind); };
+            t.appendChild(btn);
+            t.onclick = () => selectTarget(entry.id, group.kind);
+            targetEls.set(entry.id, t);
+          }
           pane.appendChild(t);
         }
       }
@@ -89,46 +147,155 @@ const STUDIO_SCRIPT = `
     }
   }
 
+  function highlightTarget(id) {
+    document.querySelectorAll('.target.sel').forEach((n) => n.classList.remove('sel'));
+    const t = targetEls.get(id);
+    if (t) t.classList.add('sel');
+  }
+
+  function selectTarget(id, kind) {
+    highlightTarget(id);
+    renderComposer(id, kind, '{}');
+  }
+
+  function renderComposer(id, kind, eventText) {
+    const ws = document.getElementById('workspace');
+    ws.innerHTML = '';
+
+    const composer = el('div', 'composer');
+    composer.appendChild(el('div', 'target-name', 'Invoke ' + id));
+    const ta = el('textarea');
+    ta.value = eventText;
+    ta.spellcheck = false;
+    composer.appendChild(ta);
+    composer.appendChild(document.createElement('br'));
+    const btn = el('button', null, 'Invoke');
+    const msg = el('div', 'err');
+    composer.appendChild(btn);
+    composer.appendChild(msg);
+
+    const result = el('div', 'result');
+
+    ws.appendChild(composer);
+    ws.appendChild(result);
+
+    active = { id, kind, ta, btn, msg, result };
+    btn.onclick = () => runInvoke();
+    shownInvId = null;
+    ta.focus();
+  }
+
+  async function runInvoke() {
+    if (!active) return;
+    const { id, kind, ta, btn, msg, result } = active;
+    let event;
+    try {
+      event = ta.value.trim() === '' ? {} : JSON.parse(ta.value);
+    } catch (err) {
+      msg.textContent = 'Invalid JSON: ' + err.message;
+      return;
+    }
+    msg.textContent = '';
+    btn.disabled = true;
+    btn.textContent = 'Invoking...';
+    result.innerHTML = '';
+    try {
+      const res = await fetch('/api/run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ targetId: id, kind, event }),
+      });
+      const data = await res.json();
+      if (data.invocationId) {
+        shownInvId = data.invocationId;
+        renderResult(shownInvId);
+      }
+      if (!res.ok || data.ok === false) {
+        msg.textContent = 'Invoke failed: ' + (data.error || ('HTTP ' + res.status));
+      }
+    } catch (err) {
+      msg.textContent = 'Request failed: ' + err;
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Invoke';
+    }
+  }
+
+  function fmt(body) {
+    return typeof body === 'string' ? body : JSON.stringify(body, null, 2);
+  }
+
+  function renderResult(invId) {
+    if (!active) return;
+    const result = active.result;
+    result.innerHTML = '';
+    const ev = invById.get(invId);
+    if (!ev) return;
+
+    const reqSec = el('div', 'section');
+    reqSec.appendChild(el('h3', null, 'Request'));
+    reqSec.appendChild(el('pre', null, ev.request != null ? fmt(ev.request) : '(none)'));
+    result.appendChild(reqSec);
+
+    const respSec = el('div', 'section');
+    const h = el('h3', null, 'Response');
+    if (ev.status != null) {
+      const cls = ev.status >= 200 && ev.status < 300 ? 'ok' : 'bad';
+      const meta = el('span', cls, '  ' + ev.status + (ev.durationMs != null ? ' · ' + ev.durationMs + 'ms' : ''));
+      h.appendChild(meta);
+    }
+    respSec.appendChild(h);
+    respSec.appendChild(el('pre', null, ev.response != null ? fmt(ev.response) : '(pending…)'));
+    result.appendChild(respSec);
+
+    const logs = logsById.get(invId) || [];
+    const logSec = el('div', 'section');
+    logSec.appendChild(el('h3', null, 'Logs'));
+    logSec.appendChild(el('pre', null, logs.length ? logs.join('\\n') : '(none)'));
+    result.appendChild(logSec);
+  }
+
   function addInvocation(ev) {
+    invById.set(ev.id, Object.assign(invById.get(ev.id) || {}, ev));
     const timeline = document.getElementById('timeline');
     const placeholder = timeline.querySelector('.empty');
     if (placeholder) placeholder.remove();
+
     let row = rowsById.get(ev.id);
     if (!row) {
       row = el('div', 'row');
       row.appendChild(el('span', 'ts'));
       row.appendChild(el('span', 'label'));
       row.appendChild(el('span', 'status'));
-      row.onclick = () => selectRow(ev.id);
+      row.onclick = () => loadInvocation(ev.id);
       rowsById.set(ev.id, row);
-      timeline.appendChild(row);
+      timeline.insertBefore(row, timeline.querySelector('.row')); // newest on top
     }
-    row._ev = Object.assign(row._ev || {}, ev);
-    const d = new Date(ev.ts);
+    const merged = invById.get(ev.id);
+    const d = new Date(merged.ts);
     row.querySelector('.ts').textContent = d.toLocaleTimeString();
-    row.querySelector('.label').textContent = (ev.kind ? ev.target + '  ' : '') + (ev.label || '');
-    row.querySelector('.status').textContent =
-      ev.status != null ? ev.status + (ev.durationMs != null ? '  ' + ev.durationMs + 'ms' : '') : '...';
+    row.querySelector('.label').textContent = (merged.target || '') + '  ' + (merged.label || '');
+    const statusEl = row.querySelector('.status');
+    statusEl.textContent =
+      merged.status != null
+        ? merged.status + (merged.durationMs != null ? '  ' + merged.durationMs + 'ms' : '')
+        : '…';
+    statusEl.className = 'status' + (merged.status != null && (merged.status < 200 || merged.status >= 300) ? ' err' : '');
+
+    // Live-refresh the workspace result if it is showing this invocation.
+    if (shownInvId === ev.id) renderResult(ev.id);
   }
 
-  function selectRow(id) {
+  function loadInvocation(id) {
+    const ev = invById.get(id);
+    if (!ev) return;
     document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'));
     const row = rowsById.get(id);
     if (row) row.classList.add('sel');
-    const ev = row && row._ev;
-    const detail = document.getElementById('detail');
-    detail.innerHTML = '';
-    if (!ev) return;
-    const sec = (title, body) => {
-      const s = el('div', 'section');
-      s.appendChild(el('h3', null, title));
-      const pre = el('pre');
-      pre.textContent = typeof body === 'string' ? body : JSON.stringify(body, null, 2);
-      s.appendChild(pre);
-      detail.appendChild(s);
-    };
-    sec('Request', ev.request != null ? ev.request : '(none)');
-    sec('Response', ev.response != null ? ev.response : '(pending)');
+    highlightTarget(ev.target);
+    renderComposer(ev.target, ev.kind, ev.request != null ? fmt(ev.request) : '{}');
+    shownInvId = id;
+    renderResult(id);
   }
 
   function connect() {
@@ -137,10 +304,48 @@ const STUDIO_SCRIPT = `
     es.addEventListener('open', () => { conn.textContent = '● live'; conn.className = 'up'; });
     es.addEventListener('error', () => { conn.textContent = '● disconnected'; conn.className = 'down'; });
     es.addEventListener('invocation', (e) => addInvocation(JSON.parse(e.data)));
+    es.addEventListener('log', (e) => {
+      const ev = JSON.parse(e.data);
+      const arr = logsById.get(ev.containerId) || [];
+      arr.push(ev.line);
+      logsById.set(ev.containerId, arr);
+      if (shownInvId === ev.containerId) renderResult(ev.containerId);
+    });
+  }
+
+  function initSplitters() {
+    const main = document.querySelector('main');
+    let left = 280, right = 320;
+    const apply = () => {
+      main.style.gridTemplateColumns = left + 'px 5px 1fr 5px ' + right + 'px';
+    };
+    const wire = (splitterId, onMove) => {
+      const s = document.getElementById(splitterId);
+      s.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        const startX = e.clientX;
+        const l0 = left, r0 = right;
+        s.classList.add('dragging');
+        document.body.style.userSelect = 'none';
+        const move = (ev) => { onMove(ev.clientX - startX, l0, r0); apply(); };
+        const up = () => {
+          s.classList.remove('dragging');
+          document.body.style.userSelect = '';
+          document.removeEventListener('mousemove', move);
+          document.removeEventListener('mouseup', up);
+        };
+        document.addEventListener('mousemove', move);
+        document.addEventListener('mouseup', up);
+      });
+    };
+    const clamp = (v) => Math.max(160, Math.min(760, v));
+    wire('split-left', (dx, l0) => { left = clamp(l0 + dx); });
+    wire('split-right', (dx, l0, r0) => { right = clamp(r0 - dx); });
   }
 
   loadTargets();
   connect();
+  initSplitters();
 `;
 
 /**
@@ -167,8 +372,10 @@ export function renderStudioHtml(appLabel: string, cliName: string): string {
 </header>
 <main>
   <section class="pane" id="targets"><h2>Targets</h2></section>
-  <section class="pane" id="timeline"><h2>Timeline</h2><div class="empty">No requests yet. Invoke or serve a target to see activity.</div></section>
-  <section class="pane" id="detail"><h2>Detail</h2><div class="empty">Select a request.</div></section>
+  <div class="splitter" id="split-left"></div>
+  <section class="pane" id="workspace"><div class="empty">Pick a Lambda on the left to invoke it.</div></section>
+  <div class="splitter" id="split-right"></div>
+  <section class="pane" id="timeline"><h2>Timeline</h2><div class="empty">No requests yet.</div></section>
 </main>
 <script>${STUDIO_SCRIPT}</script>
 </body>

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -35,13 +35,19 @@ fi
 
 LOG_FILE=$(mktemp)
 BODY_FILE=$(mktemp)
+RUN_FILE=$(mktemp)
+SSE_FILE=$(mktemp)
 STUDIO_PID=""
+SSE_PID=""
 cleanup() {
+  if [[ -n "${SSE_PID}" ]] && kill -0 "${SSE_PID}" 2>/dev/null; then
+    kill "${SSE_PID}" 2>/dev/null || true
+  fi
   if [[ -n "${STUDIO_PID}" ]] && kill -0 "${STUDIO_PID}" 2>/dev/null; then
     kill "${STUDIO_PID}" 2>/dev/null || true
     wait "${STUDIO_PID}" 2>/dev/null || true
   fi
-  rm -f "${LOG_FILE}" "${BODY_FILE}"
+  rm -f "${LOG_FILE}" "${BODY_FILE}" "${RUN_FILE}" "${SSE_FILE}"
 }
 trap cleanup EXIT
 
@@ -145,7 +151,60 @@ fi
 echo "    OK: SSE stream opened"
 
 # ---------------------------------------------------------------------------
-# 6. Clean shutdown on SIGTERM.
+# 6. POST /api/run invokes a real Lambda in Docker (slice B) and the
+#    invocation is broadcast over SSE.
+# ---------------------------------------------------------------------------
+echo "==> POST /api/run invokes the fixture Lambda in Docker"
+
+# Start a background SSE listener BEFORE the invoke so it captures the
+# invocation events the dispatch emits.
+curl -sN --max-time 180 "${URL}/api/events" >"${SSE_FILE}" 2>/dev/null &
+SSE_PID=$!
+sleep 1 # let the SSE subscription establish
+
+# The dispatch spawns `cdkl invoke LocalStudioFixture/MyHandler` which boots a
+# RIE Node container — generous timeout to cover the first-run base-image pull.
+HTTP_CODE=$(curl -s -o "${RUN_FILE}" -w '%{http_code}' --max-time 180 \
+  -X POST "${URL}/api/run" \
+  -H 'content-type: application/json' \
+  -d '{"targetId":"LocalStudioFixture/MyHandler","kind":"lambda","event":{}}' || true)
+
+if [[ "${HTTP_CODE}" != "200" ]]; then
+  echo "FAIL: POST /api/run returned HTTP ${HTTP_CODE}"
+  echo "----- run response -----"; cat "${RUN_FILE}"; echo "------------------------"
+  echo "----- studio log -----"; cat "${LOG_FILE}"; echo "----------------------"
+  exit 1
+fi
+# The fixture handler returns { statusCode: 200, body: 'ok' }; the studio run
+# result wraps it as { ok: true, status: 200, response: {...} }.
+for needle in '"ok":true' '"status":200' '"statusCode":200'; do
+  if ! grep -qF "${needle}" "${RUN_FILE}"; then
+    echo "FAIL: /api/run response missing: ${needle}"
+    echo "----- run response -----"; cat "${RUN_FILE}"; echo "------------------------"
+    exit 1
+  fi
+  echo "    OK: run response has ${needle}"
+done
+
+echo "==> The invocation was broadcast over SSE"
+# Give the SSE listener a moment to receive the end event, then stop it.
+for _ in $(seq 1 20); do
+  if grep -qF 'event: invocation' "${SSE_FILE}" && grep -qF 'MyHandler' "${SSE_FILE}"; then
+    break
+  fi
+  sleep 0.5
+done
+kill "${SSE_PID}" 2>/dev/null || true
+SSE_PID=""
+if ! grep -qF 'event: invocation' "${SSE_FILE}" || ! grep -qF 'MyHandler' "${SSE_FILE}"; then
+  echo "FAIL: SSE stream did not carry the MyHandler invocation"
+  echo "----- sse capture -----"; cat "${SSE_FILE}"; echo "-----------------------"
+  exit 1
+fi
+echo "    OK: invocation observed on the SSE timeline"
+
+# ---------------------------------------------------------------------------
+# 7. Clean shutdown on SIGTERM.
 # ---------------------------------------------------------------------------
 echo "==> Stopping studio (SIGTERM) and asserting clean exit"
 kill "${STUDIO_PID}"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
+  coerceRunRequest,
   createLocalStudioCommand,
   parseStudioPort,
 } from '../../../src/cli/commands/local-studio.js';
@@ -35,4 +36,40 @@ describe('parseStudioPort', () => {
   it.each(['-1', '65536', 'abc', '', '80.5'])('rejects %p', (raw) => {
     expect(() => parseStudioPort(raw)).toThrow(/--studio-port must be 0\.\.65535/);
   });
+});
+
+describe('coerceRunRequest', () => {
+  it('accepts a well-formed run request', () => {
+    expect(coerceRunRequest({ targetId: 'Stack/Fn', kind: 'lambda', event: { a: 1 } })).toEqual({
+      targetId: 'Stack/Fn',
+      kind: 'lambda',
+      event: { a: 1 },
+    });
+  });
+
+  it('allows an absent event (undefined)', () => {
+    expect(coerceRunRequest({ targetId: 'T', kind: 'lambda' })).toEqual({
+      targetId: 'T',
+      kind: 'lambda',
+      event: undefined,
+    });
+  });
+
+  it.each([null, 42, 'str', undefined])('rejects a non-object body %p', (body) => {
+    expect(() => coerceRunRequest(body)).toThrow(/must be a JSON object/);
+  });
+
+  it.each([{}, { targetId: '' }, { targetId: '  ', kind: 'lambda' }, { kind: 'lambda' }])(
+    'rejects a missing/empty targetId %p',
+    (body) => {
+      expect(() => coerceRunRequest(body)).toThrow(/non-empty "targetId"/);
+    }
+  );
+
+  it.each([{ targetId: 'T' }, { targetId: 'T', kind: 'nope' }, { targetId: 'T', kind: 5 }])(
+    'rejects a missing/unknown kind %p',
+    (body) => {
+      expect(() => coerceRunRequest(body)).toThrow(/"kind" must be one of/);
+    }
+  );
 });

--- a/tests/unit/local/studio-dispatch.test.ts
+++ b/tests/unit/local/studio-dispatch.test.ts
@@ -1,0 +1,295 @@
+import { EventEmitter } from 'node:events';
+import { readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { StudioEventBus, type StudioInvocationEvent, type StudioLogEvent } from '../../../src/local/studio-events.js';
+import { createStudioDispatcher } from '../../../src/local/studio-dispatch.js';
+
+/** A minimal stand-in for a spawned child process. */
+function makeFakeChild(): EventEmitter & {
+  stdout: EventEmitter & { setEncoding: () => void };
+  stderr: EventEmitter & { setEncoding: () => void };
+} {
+  const stdout = Object.assign(new EventEmitter(), { setEncoding: () => undefined });
+  const stderr = Object.assign(new EventEmitter(), { setEncoding: () => undefined });
+  return Object.assign(new EventEmitter(), { stdout, stderr });
+}
+
+function collect(bus: StudioEventBus): {
+  invocations: StudioInvocationEvent[];
+  logs: StudioLogEvent[];
+} {
+  const invocations: StudioInvocationEvent[] = [];
+  const logs: StudioLogEvent[] = [];
+  bus.on('invocation', (e) => invocations.push(e));
+  bus.on('log', (e) => logs.push(e));
+  return { invocations, logs };
+}
+
+const fixedClock = (): (() => number) => {
+  let t = 1000;
+  return () => (t += 10);
+};
+
+describe('createStudioDispatcher', () => {
+  it('spawns `cdkl invoke <target>` and returns the parsed response', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      nodeBin: '/usr/bin/node',
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-1',
+    });
+
+    const p = dispatcher.run({ targetId: 'Stack/Fn', kind: 'lambda', event: { a: 1 } });
+    // Listeners are attached synchronously inside run() before the await.
+    child.stdout.emit('data', '{"statusCode":200,"body":"ok"}');
+    child.emit('close', 0);
+    const result = await p;
+
+    // The CLI binary is invoked with the right argv shape.
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    const [bin, argv] = spawnFn.mock.calls[0] as unknown as [string, string[]];
+    expect(bin).toBe('/usr/bin/node');
+    expect(argv[0]).toBe('/path/to/cli.js');
+    expect(argv.slice(1, 3)).toEqual(['invoke', 'Stack/Fn']);
+    expect(argv).toContain('--event');
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.response).toEqual({ statusCode: 200, body: 'ok' });
+    expect(result.invocationId).toBe('inv-1');
+  });
+
+  it('emits an invocation start then end event keyed by the same id', async () => {
+    const bus = new StudioEventBus();
+    const { invocations } = collect(bus);
+    const child = makeFakeChild();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-x',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stdout.emit('data', '"done"');
+    child.emit('close', 0);
+    await p;
+
+    expect(invocations).toHaveLength(2);
+    expect(invocations[0].id).toBe('inv-x');
+    expect(invocations[0].status).toBeUndefined(); // start: no status yet
+    expect(invocations[1].id).toBe('inv-x');
+    expect(invocations[1].status).toBe(200); // end: filled in
+    expect(invocations[1].response).toBe('done');
+    expect(invocations[1].durationMs).toBeGreaterThan(0);
+  });
+
+  it('streams child stderr lines onto the bus as log events', async () => {
+    const bus = new StudioEventBus();
+    const { logs } = collect(bus);
+    const child = makeFakeChild();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      idFactory: () => 'inv-l',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stderr.emit('data', 'line one\nline two\n');
+    child.stderr.emit('data', 'partial');
+    child.emit('close', 0);
+    await p;
+
+    expect(logs.map((l) => l.line)).toEqual(['line one', 'line two', 'partial']);
+    expect(logs.every((l) => l.containerId === 'inv-l' && l.target === 'T')).toBe(true);
+  });
+
+  it('marks a non-zero exit as failed (status 500) with the stderr as the error', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      idFactory: () => 'inv-e',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stderr.emit('data', 'boom: it failed\n');
+    child.emit('close', 1);
+    const result = await p;
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(500);
+    expect(result.error).toContain('boom: it failed');
+  });
+
+  it('rejects a non-lambda kind with 501 without spawning', async () => {
+    const bus = new StudioEventBus();
+    const { invocations } = collect(bus);
+    const spawnFn = vi.fn();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      idFactory: () => 'inv-501',
+    });
+
+    const result = await dispatcher.run({ targetId: 'MyApi', kind: 'api', event: {} });
+
+    expect(spawnFn).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(501);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0].status).toBe(501);
+  });
+
+  it('threads --app / --profile / --region / -c context into the child argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      app: 'node bin/app.ts',
+      profile: 'dev',
+      region: 'us-east-1',
+      context: { env: 'prod' },
+      idFactory: () => 'inv-cfg',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stdout.emit('data', '{}');
+    child.emit('close', 0);
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv).toContain('--app');
+    expect(argv).toContain('node bin/app.ts');
+    expect(argv).toContain('--profile');
+    expect(argv).toContain('dev');
+    expect(argv).toContain('--region');
+    expect(argv).toContain('us-east-1');
+    expect(argv).toContain('-c');
+    expect(argv).toContain('env=prod');
+  });
+
+  it('extracts the LAST JSON line as the response even when a log line trails it', async () => {
+    const bus = new StudioEventBus();
+    const { invocations, logs } = collect(bus);
+    const child = makeFakeChild();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-ml',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    // Realistic `cdkl invoke` stdout: synth progress + RIE START + the JSON
+    // response + a trailing REPORT container-log line AFTER the response.
+    child.stdout.emit(
+      'data',
+      'Synthesizing CDK app...\n' +
+        'START RequestId: abc\n' +
+        '{"statusCode":200,"body":"ok"}\n' +
+        'REPORT RequestId: abc Duration: 1ms\n'
+    );
+    child.emit('close', 0);
+    const result = await p;
+
+    // The JSON line is the response, NOT the trailing REPORT log line.
+    expect(result.response).toEqual({ statusCode: 200, body: 'ok' });
+    expect(invocations[1].response).toEqual({ statusCode: 200, body: 'ok' });
+    // The three non-response stdout lines are surfaced as stdout log events.
+    const stdoutLogs = logs.filter((l) => l.stream === 'stdout').map((l) => l.line);
+    expect(stdoutLogs).toEqual([
+      'Synthesizing CDK app...',
+      'START RequestId: abc',
+      'REPORT RequestId: abc Duration: 1ms',
+    ]);
+  });
+
+  it('rejects when spawn throws synchronously', async () => {
+    const bus = new StudioEventBus();
+    const spawnFn = vi.fn(() => {
+      throw new Error('ENOENT: node not found');
+    });
+    const before = countRunDirs();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      idFactory: () => 'inv-throw',
+    });
+
+    await expect(dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} })).rejects.toThrow(
+      /ENOENT/
+    );
+    // The temp dir created before the (failed) spawn must be cleaned up.
+    expect(countRunDirs()).toBe(before);
+  });
+
+  it('rejects when the child emits an error event (failed to start)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      idFactory: () => 'inv-cerr',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.emit('error', new Error('spawn EACCES'));
+    await expect(p).rejects.toThrow(/EACCES/);
+  });
+
+  it('removes the temp event dir after a successful run', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const before = countRunDirs();
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      idFactory: () => 'inv-clean',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: { a: 1 } });
+    child.stdout.emit('data', '{}');
+    child.emit('close', 0);
+    await p;
+
+    expect(countRunDirs()).toBe(before);
+  });
+});
+
+/** Count leftover `cdkl-studio-run-*` temp dirs (for cleanup assertions). */
+function countRunDirs(): number {
+  try {
+    return readdirSync(tmpdir()).filter((n) => n.startsWith('cdkl-studio-run-')).length;
+  } catch {
+    return 0;
+  }
+}

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -209,6 +209,59 @@ describe('startStudioServer', () => {
     expect(bus.listenerCount('log')).toBe(0);
   });
 
+  it('POST /api/run dispatches to onRun and returns its result as JSON', async () => {
+    const onRun = (body: unknown): Promise<unknown> =>
+      Promise.resolve({ echoed: body, ok: true });
+    const server = await boot({ onRun });
+
+    const res = await fetch(`${server.url}/api/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ targetId: 'T', kind: 'lambda', event: { a: 1 } }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { echoed: unknown; ok: boolean };
+    expect(data.ok).toBe(true);
+    expect(data.echoed).toEqual({ targetId: 'T', kind: 'lambda', event: { a: 1 } });
+  });
+
+  it('POST /api/run answers 501 when no onRun handler is wired', async () => {
+    const server = await boot(); // observe-only shell, no onRun
+    const res = await fetch(`${server.url}/api/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(501);
+    await res.text();
+  });
+
+  it('POST /api/run answers 400 on an invalid JSON body', async () => {
+    const server = await boot({ onRun: () => Promise.resolve({}) });
+    const res = await fetch(`${server.url}/api/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not json',
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toMatch(/invalid json/i);
+  });
+
+  it('POST /api/run answers 500 when the handler throws', async () => {
+    const server = await boot({
+      onRun: () => Promise.reject(new Error('dispatch blew up')),
+    });
+    const res = await fetch(`${server.url}/api/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(500);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('dispatch blew up');
+  });
+
   it('close() resolves even with a live SSE client connected', async () => {
     const server = await boot();
     const { res: resP, abort } = openSse(`${server.url}/api/events`);

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -7,10 +7,10 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('<!doctype html>');
     expect(html).toContain('cdkl studio');
     expect(html).toContain('MyStack');
-    // The three panes are present.
+    // The three panes are present (targets / workspace / timeline).
     expect(html).toContain('id="targets"');
+    expect(html).toContain('id="workspace"');
     expect(html).toContain('id="timeline"');
-    expect(html).toContain('id="detail"');
   });
 
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {


### PR DESCRIPTION
## Summary

Slice B of `cdkl studio` (see #282) — make the console actionable: pick a
Lambda on the left, compose an event, Invoke it from the browser, and see
the result + container logs in a center workspace you can re-run from; every
invocation streams onto the timeline live.

Design: studio is a control plane over the CLI, so a run spawns the SAME
`cdkl invoke` the headless command runs as a CHILD process rather than
re-wiring its internals — byte-for-byte parity, and all of `cdkl invoke`'s
process-global behavior (`process.exit`, env mutation, stdin) stays isolated
in a subprocess. Slice B handles Lambda single-shot invoke; serve targets
(API / ALB / ECS) are slice C (the dispatcher rejects them with 501).

### What's in this slice

- `src/local/studio-dispatch.ts` (new) — spawns `cdkl invoke <target>
  --event <tmp>` (threading `--app` / `--profile` / `--region` / `-c`),
  emits an `invocation` start before spawn + end (parsed response + status +
  duration) after exit, and streams the child's stderr/stdout to the bus as
  `log` events.
- `src/local/studio-server.ts` — `POST /api/run`: bounded JSON body read,
  dispatch via an injected `onRun` (501 no handler / 400 bad JSON / 500
  handler throw).
- `src/cli/commands/local-studio.ts` — wires the dispatcher as `onRun`
  (`process.argv[1]` as the CLI entry to re-spawn); `coerceRunRequest`
  validates the untyped body.
- `src/local/studio-ui.ts` — 3-pane rework: targets (left, bright [Invoke]
  button + selected highlight + full-path tooltip), WORKSPACE (center: a
  persistent event composer with Request / Response / Logs below it so you
  edit + re-invoke repeatedly), timeline (right, history). Panes are
  drag-resizable so long target paths can be read in full.

### Response recovery (review-hardened)

`cdkl invoke` interleaves synth progress + streamed container logs + the
response on stdout. The dispatcher recovers the response as the LAST
JSON-parseable stdout line (the RIE response is always single-line JSON;
progress / `START/END/REPORT` lines are not), which is robust against a
container log line flushing after the response; every other line is
surfaced as a log. A fully machine-readable response channel (so studio
never parses stdout) is a deferred hardening pass — filed as see #291,
since it changes the headless `cdkl invoke` contract (out of slice-B scope).

### Preview gate / parity

Still behind `CDKL_STUDIO_PREVIEW=1`; `createLocalStudioCommand` stays off
`src/index.ts` (graduates at unveil). cdkd parity: the new `studio-dispatch`
helpers are re-exported from `src/internal.ts` with host-use JSDoc; no new
CLI options; no behavior change to existing commands. cdkd is intentionally
not notified — studio is not a host-embeddable surface until unveil.

## Test plan

- Unit (149 files / 2225 tests): dispatcher (mocked spawn — argv shape,
  start/end events, stderr log streaming, non-zero exit, non-lambda 501,
  flag threading, **multi-line stdout -> last-JSON-line response + preceding
  lines as logs**, **spawn throw -> reject + temp-dir cleanup**, **child
  error event -> reject**, **temp-dir removed after success**), `POST
  /api/run` (200 / 501 / 400 / 500), `coerceRunRequest` validation.
- Integration (`tests/integration/local-studio`, real Docker): `POST
  /api/run` invokes the fixture Lambda in a RIE container; asserts the HTTP
  response (`ok:true` / `status:200` / `statusCode:200`) AND that the
  invocation is broadcast over SSE. (This integ caught a real
  response-extraction bug the mocked unit tests missed.)
- Live-tested the UI invoke -> workspace result loop in a browser.

## Review

3-axis. Spec: clean. Code: one blocker — the response-extraction heuristic
was fragile against trailing container logs — hardened to last-JSON-line +
residual filed as see #291; three minors fixed (temp-dir leak on a write
throw, `readJsonBody` single-flight guard, de-duplicated failure string).
Test: four coverage gaps filled (multi-line extraction, spawn throw, child
error, temp-dir cleanup).
