### PR TITLE
feat(studio): Phase 1 slice C1 — start/stop a long-running API serve from the studio UI (#282)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -286,19 +286,31 @@ compute-locally category for Lambda + API Gateway).
   pipeline, then bridge the raw TCP socket to the picked ECS replica
   with `Upgrade` / `Sec-WebSocket-*` headers preserved),
   studio-events (issue #282 — the typed in-process event bus every
-  `cdkl studio` observation flows through; the studio HTTP server
+  `cdkl studio` observation flows through (`invocation` / `log` /
+  `serve` events); the studio HTTP server
   subscribes and forwards to the browser over SSE), studio-server
   (the localhost HTTP server behind `cdkl studio`: serves the embedded
-  UI at `/`, the synthesized target list at `/api/targets`, and an SSE
-  stream of the event bus at `/api/events`; collision-bumps the port),
+  UI at `/`, the synthesized target list at `/api/targets`, an SSE
+  stream of the event bus at `/api/events`, `POST /api/run` (single-shot
+  invoke / serve start), `POST /api/stop` (serve stop), and
+  `GET /api/running` (running serve snapshot); collision-bumps the port),
   studio-ui (the framework-free web UI embedded as a string so it ships
   inside the npm package with no asset-copy build step; 3-pane: targets /
-  workspace composer / timeline), studio-dispatch (issue #282 — the
-  `POST /api/run` handler that runs a target from the studio UI by
+  workspace composer / timeline; Lambdas get an [Invoke] composer, APIs a
+  [Start]/[Stop] serve control with a `running ● :port` indicator),
+  studio-dispatch (issue #282 — the single-shot `POST /api/run` handler
+  for the `lambda` kind: runs a target from the studio UI by
   spawning the SAME `cdkl invoke` the headless command runs as a child
   process — studio is a control plane over the CLI — streaming its
-  stdout/stderr to the event bus and returning the parsed Lambda response;
-  slice B is Lambda single-shot invoke), etc.
+  stdout/stderr to the event bus and returning the parsed Lambda
+  response), studio-serve-manager (issue #282, slice C1 — the
+  long-running serve lifecycle for the `api` kind: spawns
+  `cdkl start-api <target> --port 0` as a managed child, resolves
+  running on the first `Server listening on <url>` line, tracks the
+  running set for `/api/running`, streams container logs onto the bus,
+  and SIGTERMs the child on `/api/stop` / studio shutdown; request
+  capture + CloudWatch-granularity log binding + full-text log search
+  follow in slice C2), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -25,6 +25,11 @@ import {
   type RunningStudioServer,
 } from '../../local/studio-server.js';
 import { createStudioDispatcher, type StudioRunRequest } from '../../local/studio-dispatch.js';
+import {
+  createStudioServeManager,
+  type StudioServeManager,
+  type StudioStopRequest,
+} from '../../local/studio-serve-manager.js';
 
 const STUDIO_TARGET_KINDS: readonly StudioTargetKind[] = [
   'lambda',
@@ -52,6 +57,22 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     throw new Error(`Request body "kind" must be one of: ${STUDIO_TARGET_KINDS.join(', ')}.`);
   }
   return { targetId, kind: kind as StudioTargetKind, event };
+}
+
+/**
+ * Validate + narrow the untyped `POST /api/stop` body into a
+ * {@link StudioStopRequest}. Throws (→ 400 from the server) on a missing
+ * / empty target id.
+ */
+export function coerceStopRequest(body: unknown): StudioStopRequest {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('Request body must be a JSON object.');
+  }
+  const { targetId } = body as Record<string, unknown>;
+  if (typeof targetId !== 'string' || targetId.trim() === '') {
+    throw new Error('Request body must include a non-empty "targetId" string.');
+  }
+  return { targetId };
 }
 
 const DEFAULT_STUDIO_PORT = 9999;
@@ -128,17 +149,22 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   const appLabel = stacks.map((s) => s.stackName).join(', ') || appCmd;
 
   const bus = new StudioEventBus();
-  const dispatcher = createStudioDispatcher({
-    // `process.argv[1]` is the running CLI entry (`dist/cli.js` / the `cdkl`
-    // bin); the dispatcher spawns it again as `cdkl invoke <target>`.
-    cliEntry: process.argv[1] ?? '',
+  // `process.argv[1]` is the running CLI entry (`dist/cli.js` / the `cdkl`
+  // bin); both the invoke dispatcher and the serve manager spawn it again
+  // (`cdkl invoke <target>` / `cdkl start-api <target>`) — studio is a
+  // control plane over the CLI.
+  const cliEntry = process.argv[1] ?? '';
+  const childConfig = {
+    cliEntry,
     bus,
     cwd: process.cwd(),
     ...(appCmd ? { app: appCmd } : {}),
     ...(options.profile ? { profile: options.profile } : {}),
     ...(options.region ? { region: options.region } : {}),
     ...(Object.keys(context).length > 0 ? { context } : {}),
-  });
+  };
+  const dispatcher = createStudioDispatcher(childConfig);
+  const serveManager = createStudioServeManager(childConfig);
 
   const server = await startStudioServer({
     port,
@@ -146,7 +172,19 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     targetGroups,
     appLabel,
     cliName: getEmbedConfig().cliName,
-    onRun: (body) => dispatcher.run(coerceRunRequest(body)),
+    // `/api/run`: a Lambda is a single-shot invoke; everything else is a
+    // long-running serve start (slice C1 supports the `api` kind, the
+    // serve manager rejects the rest with a clear message).
+    onRun: (body) => {
+      const req = coerceRunRequest(body);
+      return req.kind === 'lambda' ? dispatcher.run(req) : serveManager.start(req);
+    },
+    onStop: async (body) => {
+      const req = coerceStopRequest(body);
+      await serveManager.stop(req);
+      return { stopped: req.targetId };
+    },
+    getRunning: () => ({ running: serveManager.list() }),
   });
 
   const cliName = getEmbedConfig().cliName;
@@ -159,7 +197,7 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     openBrowser(server.url);
   }
 
-  await blockUntilShutdown(server, cliName);
+  await blockUntilShutdown(server, serveManager, cliName);
 }
 
 /** Best-effort cross-platform browser open. Failures are non-fatal. */
@@ -180,18 +218,27 @@ function openBrowser(url: string): void {
 }
 
 /**
- * Block until SIGINT / SIGTERM, then close the studio server and resolve.
- * Mirrors the long-running serve commands' graceful-shutdown contract.
+ * Block until SIGINT / SIGTERM, then stop every running serve child,
+ * close the studio server, and resolve. Mirrors the long-running serve
+ * commands' graceful-shutdown contract — the serve children are killed
+ * BEFORE the server closes so their RIE containers are torn down rather
+ * than orphaned.
  */
-function blockUntilShutdown(server: RunningStudioServer, cliName: string): Promise<void> {
+function blockUntilShutdown(
+  server: RunningStudioServer,
+  serveManager: StudioServeManager,
+  cliName: string
+): Promise<void> {
   return new Promise<void>((resolveShutdown) => {
     let shuttingDown = false;
     const shutdown = (signal: string): void => {
       if (shuttingDown) return;
       shuttingDown = true;
       getLogger().info(`Received ${signal}; stopping ${cliName} studio...`);
-      void server
-        .close()
+      void serveManager
+        .stopAll()
+        .catch((err: unknown) => getLogger().warn(`Error stopping serve targets: ${String(err)}`))
+        .then(() => server.close())
         .catch((err: unknown) => getLogger().warn(`Error stopping studio server: ${String(err)}`))
         .finally(() => resolveShutdown());
     };

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -691,6 +691,7 @@ export {
   StudioEventBus,
   type StudioInvocationEvent,
   type StudioLogEvent,
+  type StudioServeEvent,
   type StudioTargetKind,
 } from './local/studio-events.js';
 export {
@@ -718,4 +719,23 @@ export {
   type StudioRunRequest,
   type StudioRunResult,
 } from './local/studio-dispatch.js';
-export { coerceRunRequest } from './cli/commands/local-studio.js';
+export { coerceRunRequest, coerceStopRequest } from './cli/commands/local-studio.js';
+
+/**
+ * `cdkl studio` serve manager (issue #282, slice C1). A host CLI
+ * embedding studio wires `createStudioServeManager(...)` so the browser's
+ * `POST /api/run` for a long-running target (the `api` kind) starts the
+ * host's own `start-api` subcommand as a managed child process — studio
+ * is a control plane over the CLI — and `POST /api/stop` /
+ * `GET /api/running` drive its lifecycle. The manager emits `serve`
+ * events onto the {@link StudioEventBus} so the UI reflects running state
+ * over SSE. `coerceStopRequest` validates the untyped `/api/stop` body.
+ */
+export {
+  createStudioServeManager,
+  type StudioServeManager,
+  type StudioServeManagerConfig,
+  type StudioServeRequest,
+  type StudioStopRequest,
+  type StudioServeState,
+} from './local/studio-serve-manager.js';

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -60,11 +60,43 @@ export interface StudioLogEvent {
 }
 
 /**
+ * Lifecycle of a long-running served target (`api` / `alb` / `ecs`
+ * service) the studio started. Unlike {@link StudioInvocationEvent}
+ * (one per request), a serve emits one event per status TRANSITION:
+ * `starting` when the child is spawned, `running` once it is listening
+ * (with the served endpoints), `stopped` after a clean stop, `error`
+ * when it failed to come up or crashed. The UI keys these by
+ * {@link StudioServeEvent.target} to drive the per-target `running ●
+ * :port [Stop]` affordance.
+ */
+export interface StudioServeEvent {
+  /** Wall-clock epoch ms when the status was observed. */
+  ts: number;
+  /** Target id of the served target (stack-qualified or display path). */
+  target: string;
+  /** The served target's kind. */
+  kind: StudioTargetKind;
+  /** Lifecycle status this event reports. */
+  status: 'starting' | 'running' | 'stopped' | 'error';
+  /**
+   * Served endpoint URLs, present on `running` (e.g.
+   * `['http://127.0.0.1:51234']`). A single served target can expose
+   * several (multiple APIs / WebSocket listeners), so this is a list.
+   */
+  endpoints?: string[];
+  /** Child process id, present from `starting` onward. */
+  pid?: number;
+  /** Status / error detail (e.g. the failure reason on `error`). */
+  message?: string;
+}
+
+/**
  * Map of event name -> listener argument, for the typed wrapper below.
  */
 interface StudioEventMap {
   invocation: [StudioInvocationEvent];
   log: [StudioLogEvent];
+  serve: [StudioServeEvent];
 }
 
 /**

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -1,0 +1,392 @@
+import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { StudioEventBus, type StudioServeEvent, type StudioTargetKind } from './studio-events.js';
+
+/** A request to start serving a target, as the studio UI posts it. */
+export interface StudioServeRequest {
+  /** Target id the user picked (display path or stack-qualified id). */
+  targetId: string;
+  /** Target kind. Slice C1 supports `'api'` (long-running `start-api`) only. */
+  kind: StudioTargetKind;
+}
+
+/** A request to stop a running served target. */
+export interface StudioStopRequest {
+  /** Target id of the serve to stop. */
+  targetId: string;
+}
+
+/** The public state of one running served target (returned to the UI). */
+export interface StudioServeState {
+  /** Target id of the served target. */
+  targetId: string;
+  /** The served target's kind. */
+  kind: StudioTargetKind;
+  /** Lifecycle status. */
+  status: 'starting' | 'running' | 'stopped' | 'error';
+  /** Served endpoint URLs, populated once running. */
+  endpoints: string[];
+  /** Child process id. */
+  pid?: number;
+  /** Wall-clock epoch ms when the serve started. */
+  startedAt: number;
+}
+
+/** Config for {@link createStudioServeManager}. */
+export interface StudioServeManagerConfig {
+  /** Path to the `cdkl` CLI entry (`dist/cli.js`) — usually `process.argv[1]`. */
+  cliEntry: string;
+  /** The shared event bus; serve + log events are emitted onto it. */
+  bus: StudioEventBus;
+  /** Working directory for the child serve (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** `--app` value to thread into the child serve, if studio was given one. */
+  app?: string;
+  /** `-c key=value` context overrides to thread through. */
+  context?: Record<string, string>;
+  /** `--profile` to thread through. */
+  profile?: string;
+  /** `--region` to thread through. */
+  region?: string;
+  /** Node binary to spawn (defaults to `process.execPath`; injectable for tests). */
+  nodeBin?: string;
+  /** Spawn implementation (injectable for tests). */
+  spawnFn?: typeof nodeSpawn;
+  /** Clock (injectable for tests; defaults to `Date.now`). */
+  clock?: () => number;
+  /**
+   * Max ms to wait for the first `Server listening on ...` line before
+   * giving up and killing the child. Generous by default to cover the
+   * first-run base-image pull `start-api` triggers. Defaults to 120_000.
+   */
+  readyTimeoutMs?: number;
+  /**
+   * Ms to wait for a SIGTERM'd child to exit before sending SIGKILL.
+   * Defaults to 10_000.
+   */
+  stopGraceMs?: number;
+  /** `setTimeout` (injectable for tests). */
+  setTimeoutFn?: typeof setTimeout;
+  /** `clearTimeout` (injectable for tests). */
+  clearTimeoutFn?: typeof clearTimeout;
+}
+
+/** A bound serve manager exposing the start / stop / list surface. */
+export interface StudioServeManager {
+  /** Start serving a target; resolves once it is listening (or rejects). */
+  start: (req: StudioServeRequest) => Promise<StudioServeState>;
+  /** Stop a running served target; resolves once the child has exited. */
+  stop: (req: StudioStopRequest) => Promise<void>;
+  /** Snapshot of every running served target. */
+  list: () => StudioServeState[];
+  /** Stop every running served target (graceful shutdown). */
+  stopAll: () => Promise<void>;
+}
+
+/** Kinds the serve manager can start in this build. */
+const SERVE_SUPPORTED: readonly StudioTargetKind[] = ['api'];
+
+/** `Server listening on <url>` is the stable ready marker `start-api` prints. */
+const LISTENING_RE = /Server listening on (\S+)/;
+
+interface ServeEntry extends StudioServeState {
+  child: ChildProcessWithoutNullStreams;
+  /**
+   * Set by `stop()` when it tears the child down WHILE it is still
+   * `starting` (the ready promise has not settled). The child's `close`
+   * handler reads it so a user-initiated stop is not misreported as a
+   * boot failure (no `error` event, no `start()` reject as a crash).
+   */
+  stopping?: boolean;
+}
+
+/**
+ * Build the studio serve manager. Slice C1 drives a long-running
+ * `cdkl start-api <target>` child — studio is a control plane over the
+ * CLI (the same pattern as the single-shot invoke dispatcher), so it
+ * spawns the SAME headless serve command rather than re-wiring its
+ * internals. This preserves byte-for-byte parity and isolates the
+ * server's process-global behavior in a child.
+ *
+ * `start()` spawns the child with `--port 0` (OS-assigned, collision
+ * free), streams its stdout/stderr onto the bus as `log` events keyed by
+ * the target id, and resolves once the child prints its first
+ * `Server listening on <url>` line — emitting a `serve` `running` event
+ * with the discovered endpoints. `stop()` SIGTERMs the child (SIGKILL
+ * after a grace window) and emits `stopped`.
+ *
+ * Request capture for traffic to the served port (decision D4a / D5) and
+ * full-text log search arrive in slice C2; C1 is lifecycle + log
+ * streaming only.
+ */
+export function createStudioServeManager(config: StudioServeManagerConfig): StudioServeManager {
+  const spawnFn = config.spawnFn ?? nodeSpawn;
+  const nodeBin = config.nodeBin ?? process.execPath;
+  const clock = config.clock ?? Date.now;
+  const readyTimeoutMs = config.readyTimeoutMs ?? 120_000;
+  const stopGraceMs = config.stopGraceMs ?? 10_000;
+  const setTimeoutFn = config.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = config.clearTimeoutFn ?? clearTimeout;
+  const cwd = config.cwd ?? process.cwd();
+
+  const entries = new Map<string, ServeEntry>();
+
+  function publicState(e: ServeEntry): StudioServeState {
+    const s: StudioServeState = {
+      targetId: e.targetId,
+      kind: e.kind,
+      status: e.status,
+      endpoints: [...e.endpoints],
+      startedAt: e.startedAt,
+    };
+    if (e.pid !== undefined) s.pid = e.pid;
+    return s;
+  }
+
+  function emitServe(e: ServeEntry, message?: string): void {
+    const ev: StudioServeEvent = {
+      ts: clock(),
+      target: e.targetId,
+      kind: e.kind,
+      status: e.status,
+      endpoints: [...e.endpoints],
+    };
+    if (e.pid !== undefined) ev.pid = e.pid;
+    if (message !== undefined) ev.message = message;
+    config.bus.emit('serve', ev);
+  }
+
+  function buildArgs(targetId: string): string[] {
+    const args = ['start-api', targetId, '--port', '0', '--host', '127.0.0.1'];
+    if (config.app) args.push('--app', config.app);
+    if (config.profile) args.push('--profile', config.profile);
+    if (config.region) args.push('--region', config.region);
+    for (const [k, v] of Object.entries(config.context ?? {})) {
+      args.push('-c', `${k}=${v}`);
+    }
+    return args;
+  }
+
+  async function start(req: StudioServeRequest): Promise<StudioServeState> {
+    if (!SERVE_SUPPORTED.includes(req.kind)) {
+      throw new Error(
+        `Serving '${req.kind}' targets from studio is not supported yet (API only in this build).`
+      );
+    }
+    const existing = entries.get(req.targetId);
+    if (existing && existing.status !== 'stopped' && existing.status !== 'error') {
+      throw new Error(`'${req.targetId}' is already running.`);
+    }
+
+    const startedAt = clock();
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawnFn(nodeBin, [config.cliEntry, ...buildArgs(req.targetId)], { cwd });
+    } catch (err) {
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+
+    const entry: ServeEntry = {
+      targetId: req.targetId,
+      kind: req.kind,
+      status: 'starting',
+      endpoints: [],
+      startedAt,
+      child,
+    };
+    if (child.pid !== undefined) entry.pid = child.pid;
+    entries.set(req.targetId, entry);
+    emitServe(entry);
+
+    return new Promise<StudioServeState>((resolve, reject) => {
+      let settled = false;
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+
+      const timer = setTimeoutFn(() => {
+        if (settled) return;
+        settled = true;
+        entry.status = 'error';
+        emitServe(entry, `Timed out after ${readyTimeoutMs}ms waiting for the server to listen.`);
+        // Graceful SIGTERM -> SIGKILL (NOT an immediate SIGKILL): `start-api`
+        // traps SIGTERM to tear down its RIE containers, so a hard kill on a
+        // half-booted child would orphan those containers.
+        void stopChild(child, stopGraceMs, setTimeoutFn, clearTimeoutFn);
+        entries.delete(req.targetId);
+        reject(new Error(`'${req.targetId}' did not start within ${readyTimeoutMs}ms.`));
+      }, readyTimeoutMs);
+      timer.unref?.();
+
+      const becomeRunning = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeoutFn(timer);
+        entry.status = 'running';
+        emitServe(entry);
+        resolve(publicState(entry));
+      };
+
+      streamLines(child.stdout, (line) => {
+        const m = LISTENING_RE.exec(line);
+        if (m?.[1]) {
+          if (!entry.endpoints.includes(m[1])) entry.endpoints.push(m[1]);
+          // First listening line flips the serve to running; later lines
+          // (multi-listener apps) append + re-emit so the UI's endpoint
+          // list fills in.
+          if (settled) emitServe(entry);
+          else becomeRunning();
+        }
+        emitLog(config.bus, clock, req.targetId, line, 'stdout');
+      });
+      streamLines(child.stderr, (line) => {
+        emitLog(config.bus, clock, req.targetId, line, 'stderr');
+      });
+
+      child.on('error', (err) => {
+        if (settled) {
+          // Post-ready spawn error: mark the entry errored for the UI.
+          entry.status = 'error';
+          emitServe(entry, err.message);
+          entries.delete(req.targetId);
+          return;
+        }
+        settled = true;
+        clearTimeoutFn(timer);
+        entry.status = 'error';
+        emitServe(entry, err.message);
+        entries.delete(req.targetId);
+        reject(err);
+      });
+
+      child.on('close', (code) => {
+        if (!settled) {
+          settled = true;
+          clearTimeoutFn(timer);
+          if (entry.stopping) {
+            // A user `stop()` raced the still-starting child: not a boot
+            // failure. `stop()` emits the `stopped` event + resolves itself,
+            // so here we only reject the pending `start()` (the /api/run POST)
+            // with an honest "cancelled" message and emit nothing.
+            reject(new Error(`'${req.targetId}' was stopped before it finished starting.`));
+            return;
+          }
+          // Exited before ever listening — a boot failure.
+          entry.status = 'error';
+          const msg = `Server exited before listening (code ${code ?? 'null'}).`;
+          emitServe(entry, msg);
+          entries.delete(req.targetId);
+          reject(new Error(msg));
+          return;
+        }
+        // Exited while running (crash or our own stop()). If still tracked
+        // as running, surface it as stopped; stop() removes the entry
+        // itself before this fires in the graceful path.
+        const tracked = entries.get(req.targetId);
+        if (tracked === entry && entry.status === 'running') {
+          entry.status = 'stopped';
+          emitServe(entry, `Server process exited (code ${code ?? 'null'}).`);
+          entries.delete(req.targetId);
+        }
+      });
+    });
+  }
+
+  async function stop(req: StudioStopRequest): Promise<void> {
+    const entry = entries.get(req.targetId);
+    if (!entry) {
+      throw new Error(`'${req.targetId}' is not running.`);
+    }
+    // Flag so the child's `close` handler treats this as a user stop, not a
+    // boot failure, when the serve was still `starting` (#1).
+    entry.stopping = true;
+    entries.delete(req.targetId);
+    await stopChild(entry.child, stopGraceMs, setTimeoutFn, clearTimeoutFn);
+    entry.status = 'stopped';
+    emitServe(entry);
+  }
+
+  function list(): StudioServeState[] {
+    return [...entries.values()].map(publicState);
+  }
+
+  async function stopAll(): Promise<void> {
+    const targets = [...entries.keys()];
+    // `stop()` itself always resolves for a tracked target (stopChild
+    // escalates SIGTERM -> SIGKILL and resolves on close); the only reject
+    // path is the "not running" race if a sibling stop already evicted the
+    // key. The catch keeps one such race from aborting the rest of the
+    // shutdown sweep.
+    await Promise.all(targets.map((targetId) => stop({ targetId }).catch(() => undefined)));
+  }
+
+  return { start, stop, list, stopAll };
+}
+
+/** Emit one container log line onto the bus, keyed by the serve target id. */
+function emitLog(
+  bus: StudioEventBus,
+  clock: () => number,
+  target: string,
+  line: string,
+  stream: 'stdout' | 'stderr'
+): void {
+  bus.emit('log', { ts: clock(), containerId: target, target, line, stream });
+}
+
+/**
+ * Line-buffer a child stream and invoke `onLine` per complete line
+ * (trailing newline stripped, blank lines dropped). Flushes any partial
+ * final line on stream end.
+ */
+function streamLines(stream: NodeJS.ReadableStream, onLine: (line: string) => void): void {
+  let buf = '';
+  stream.on('data', (chunk: string) => {
+    buf += chunk;
+    let nl = buf.indexOf('\n');
+    while (nl !== -1) {
+      const line = buf.slice(0, nl).replace(/\r$/, '');
+      buf = buf.slice(nl + 1);
+      if (line.length > 0) onLine(line);
+      nl = buf.indexOf('\n');
+    }
+  });
+  stream.on('end', () => {
+    const line = buf.replace(/\r$/, '');
+    if (line.length > 0) onLine(line);
+    buf = '';
+  });
+}
+
+/**
+ * SIGTERM a child and resolve once it exits, escalating to SIGKILL after
+ * `graceMs`. Resolves immediately if the child has already exited.
+ */
+function stopChild(
+  child: ChildProcessWithoutNullStreams,
+  graceMs: number,
+  setTimeoutFn: typeof setTimeout,
+  clearTimeoutFn: typeof clearTimeout
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let done = false;
+    let kill: ReturnType<typeof setTimeout> | undefined;
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      if (kill) clearTimeoutFn(kill);
+      resolve();
+    };
+    // Attach the `close` listener BEFORE the already-exited check so a child
+    // that exits in the window between the check and the listener attach is
+    // not missed (which would leave the promise pending forever). #4
+    child.once('close', finish);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      finish();
+      return;
+    }
+    kill = setTimeoutFn(() => {
+      if (!done) child.kill('SIGKILL');
+    }, graceMs);
+    kill.unref?.();
+    child.kill('SIGTERM');
+  });
+}

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -4,6 +4,7 @@ import {
   StudioEventBus,
   type StudioInvocationEvent,
   type StudioLogEvent,
+  type StudioServeEvent,
 } from './studio-events.js';
 import { renderStudioHtml } from './studio-ui.js';
 import type { TargetListing } from './target-lister.js';
@@ -74,14 +75,26 @@ export interface StudioServerOptions {
    */
   maxPortBump?: number;
   /**
-   * Handler for `POST /api/run` — runs a target (slice B: a single-shot
-   * Lambda invoke) and returns the result. When omitted, `/api/run`
-   * answers 501 (the observe-only shell). The body is the parsed JSON
-   * request; the handler emits its own invocation / log events onto the
-   * bus, so the UI's timeline updates over SSE independently of the
+   * Handler for `POST /api/run` — runs a target (single-shot Lambda
+   * invoke, or start a long-running serve target) and returns the
+   * result. When omitted, `/api/run` answers 501 (the observe-only
+   * shell). The body is the parsed JSON request; the handler emits its
+   * own invocation / serve / log events onto the bus, so the UI's
+   * timeline + running state update over SSE independently of the
    * response.
    */
   onRun?: (body: unknown) => Promise<unknown>;
+  /**
+   * Handler for `POST /api/stop` — stop a running serve target. When
+   * omitted, `/api/stop` answers 501. The body identifies the target.
+   */
+  onStop?: (body: unknown) => Promise<unknown>;
+  /**
+   * Snapshot of the currently-running serve targets, served at
+   * `GET /api/running`. When omitted, the endpoint returns an empty
+   * list (the observe-only shell never runs anything).
+   */
+  getRunning?: () => unknown;
 }
 
 /** A running studio server. */
@@ -111,7 +124,7 @@ export async function startStudioServer(
   const targetsJson = JSON.stringify({ groups: options.targetGroups });
 
   const server = createServer((req, res) =>
-    handleRequest(req, res, options.bus, html, targetsJson, options.onRun)
+    handleRequest(req, res, options.bus, html, targetsJson, options)
   );
 
   const boundPort = await listenWithBump(server, host, options.port, maxBump);
@@ -135,7 +148,7 @@ function handleRequest(
   bus: StudioEventBus,
   html: string,
   targetsJson: string,
-  onRun?: (body: unknown) => Promise<unknown>
+  options: StudioServerOptions
 ): void {
   const url = req.url ?? '/';
   const path = url.split('?')[0];
@@ -150,12 +163,22 @@ function handleRequest(
     res.end(targetsJson);
     return;
   }
+  if (req.method === 'GET' && path === '/api/running') {
+    const running = options.getRunning ? options.getRunning() : { running: [] };
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify(running));
+    return;
+  }
   if (req.method === 'GET' && path === '/api/events') {
     serveSse(req, res, bus);
     return;
   }
   if (req.method === 'POST' && path === '/api/run') {
-    void handleRun(req, res, onRun);
+    void handleDispatch(req, res, options.onRun);
+    return;
+  }
+  if (req.method === 'POST' && path === '/api/stop') {
+    void handleDispatch(req, res, options.onStop);
     return;
   }
   res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
@@ -164,18 +187,23 @@ function handleRequest(
 
 const MAX_RUN_BODY_BYTES = 5 * 1024 * 1024;
 
-/** Reply to `POST /api/run`: parse the JSON body, dispatch via `onRun`. */
-async function handleRun(
+/**
+ * Reply to a JSON POST endpoint (`/api/run` / `/api/stop`): parse the
+ * bounded JSON body and dispatch via `handler`. 501 when no handler is
+ * wired (the observe-only shell), 400 on a malformed body, 500 when the
+ * handler throws.
+ */
+async function handleDispatch(
   req: IncomingMessage,
   res: ServerResponse,
-  onRun?: (body: unknown) => Promise<unknown>
+  handler?: (body: unknown) => Promise<unknown>
 ): Promise<void> {
   const sendJson = (statusCode: number, payload: unknown): void => {
     res.writeHead(statusCode, { 'content-type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify(payload));
   };
 
-  if (!onRun) {
+  if (!handler) {
     // The observe-only shell (no dispatcher wired) cannot run targets.
     sendJson(501, { error: 'Running targets is not supported by this studio server.' });
     return;
@@ -190,7 +218,7 @@ async function handleRun(
   }
 
   try {
-    const result = await onRun(body);
+    const result = await handler(body);
     sendJson(200, result);
   } catch (err) {
     sendJson(500, { error: err instanceof Error ? err.message : String(err) });
@@ -256,6 +284,9 @@ function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus
   const onLog = (ev: StudioLogEvent): void => {
     safeWrite(`event: log\ndata: ${JSON.stringify(ev)}\n\n`);
   };
+  const onServe = (ev: StudioServeEvent): void => {
+    safeWrite(`event: serve\ndata: ${JSON.stringify(ev)}\n\n`);
+  };
 
   // Idempotent teardown: unsubscribe from the bus + stop the heartbeat so
   // a dropped EventSource client never leaks a listener.
@@ -265,6 +296,7 @@ function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus
     clearInterval(heartbeat);
     bus.off('invocation', onInvocation);
     bus.off('log', onLog);
+    bus.off('serve', onServe);
   }
 
   // Guard every write: on shutdown `close()` destroys live SSE sockets
@@ -283,6 +315,7 @@ function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus
 
   bus.on('invocation', onInvocation);
   bus.on('log', onLog);
+  bus.on('serve', onServe);
 
   // `close` fires on client disconnect AND on server-side socket destroy;
   // `error` fires if a write loses the race with the destroy. All three

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -5,12 +5,13 @@
  * the studio HTTP server (`startStudioServer`) at `GET /`.
  *
  * 3-pane shell (decision D6), framework-free vanilla JS (decision D7):
- *   - left   = target list (from `GET /api/targets`); each runnable
- *     Lambda has an [Invoke] button and a selected-highlight.
- *   - center = the WORKSPACE for the selected target: an event composer
- *     (textarea + Invoke button) with the latest run's Request /
- *     Response / Logs shown BELOW it, so you can edit and re-invoke
- *     repeatedly without losing the composer.
+ *   - left   = target list (from `GET /api/targets`); each Lambda has an
+ *     [Invoke] button, each API a [Start] / [Stop] serve control with a
+ *     `running ● :port` indicator (slice C1), plus a selected-highlight.
+ *   - center = the WORKSPACE for the selected target: for a Lambda, an
+ *     event composer (textarea + Invoke button) with the latest run's
+ *     Request / Response / Logs shown below; for an API, a Start/Stop
+ *     control with the served endpoints + streaming logs.
  *   - right  = the timeline (history) of every invocation; clicking a
  *     row loads it back into the workspace.
  *
@@ -59,6 +60,13 @@ const STUDIO_CSS = `
   }
   .target .invoke-btn:hover { background: #6fe097; }
   .target.sel .invoke-btn { background: #6fe097; }
+  .target .stop-btn {
+    padding: 2px 10px; font: 11px ui-monospace, Menlo, monospace; font-weight: 700;
+    color: #2a0d0d; background: #e0707a; border: 0; border-radius: 3px; cursor: pointer;
+  }
+  .target .stop-btn:hover { background: #ec8a92; }
+  .target .run-dot { color: #7bd88f; font-size: 11px; white-space: nowrap; }
+  .target .run-dot.starting { color: #e0b54e; }
   .empty { padding: 16px 12px; color: #666; }
   .row {
     padding: 5px 12px; border-bottom: 1px solid #222; cursor: pointer;
@@ -90,6 +98,8 @@ const STUDIO_CSS = `
   .section h3 .ok { color: #7bd88f; }
   .section h3 .bad { color: #e0707a; }
   .section pre { margin: 0; white-space: pre-wrap; word-break: break-word; color: #cfcfcf; }
+  .endpoint { display: block; color: #6aa9ff; text-decoration: none; padding: 2px 0; }
+  .endpoint:hover { text-decoration: underline; }
   #conn { font-size: 11px; }
   #conn.up { color: #7bd88f; }
   #conn.down { color: #e0707a; }
@@ -99,10 +109,13 @@ const STUDIO_SCRIPT = `
   const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', agentcore: 'AgentCore' };
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event
-  const logsById = new Map();      // invocationId -> [log lines]
+  const logsById = new Map();      // invocationId / serve targetId -> [log lines]
   const targetEls = new Map();     // targetId -> left-pane element
+  const serveMeta = new Map();     // serve targetId -> { dot, btnSlot } row controls
+  const serveState = new Map();    // serve targetId -> { status, endpoints }
   let active = null;               // { id, kind, ta, btn, msg, result }
   let shownInvId = null;           // invocation whose result is in the workspace
+  let shownServeId = null;         // serve target whose workspace is shown
 
   function el(tag, cls, text) {
     const e = document.createElement(tag);
@@ -123,20 +136,32 @@ const STUDIO_SCRIPT = `
         pane.appendChild(el('div', 'group-title', group.title));
         for (const entry of group.entries) {
           total += 1;
-          // Slice B: only Lambda targets are runnable from the UI (single-shot
-          // invoke). Other kinds list but are not yet selectable.
-          const runnable = group.kind === 'lambda';
+          // Lambda targets are single-shot invokes; API targets are
+          // long-running serves (slice C1). Other kinds list but are not
+          // yet runnable.
+          const runnable = group.kind === 'lambda' || group.kind === 'api';
           const t = el('div', runnable ? 'target runnable' : 'target');
           const name = el('span', 'name', entry.id);
           name.title = entry.id; // full path on hover even when truncated
           t.appendChild(name);
           t.appendChild(el('span', 'kind', '(' + (KIND_LABEL[group.kind] || group.kind) + ')'));
-          if (runnable) {
+          if (group.kind === 'lambda') {
             const btn = el('button', 'invoke-btn', 'Invoke');
-            btn.onclick = (e) => { e.stopPropagation(); selectTarget(entry.id, group.kind); };
+            btn.onclick = (e) => { e.stopPropagation(); selectTarget(entry.id, 'lambda'); };
             t.appendChild(btn);
-            t.onclick = () => selectTarget(entry.id, group.kind);
+            t.onclick = () => selectTarget(entry.id, 'lambda');
             targetEls.set(entry.id, t);
+          } else if (group.kind === 'api') {
+            // A serve target: a running-state dot + a Start/Stop button
+            // slot, both refreshed by updateServeRow on serve events.
+            const dot = el('span', 'run-dot');
+            const btnSlot = el('span', 'btn-slot');
+            t.appendChild(dot);
+            t.appendChild(btnSlot);
+            t.onclick = () => selectTarget(entry.id, 'api');
+            targetEls.set(entry.id, t);
+            serveMeta.set(entry.id, { dot, btnSlot });
+            updateServeRow(entry.id);
           }
           pane.appendChild(t);
         }
@@ -147,6 +172,50 @@ const STUDIO_SCRIPT = `
     }
   }
 
+  // Pull any already-running serves (e.g. after a UI reload) so the rows
+  // and workspace reflect them without waiting for a fresh serve event.
+  async function loadRunning() {
+    try {
+      const res = await fetch('/api/running');
+      const data = await res.json();
+      for (const s of (data.running || [])) {
+        serveState.set(s.targetId, { status: s.status, endpoints: s.endpoints || [] });
+        updateServeRow(s.targetId);
+      }
+    } catch (err) {
+      /* best-effort; the serve SSE stream still drives live updates */
+    }
+  }
+
+  function firstPort(endpoints) {
+    const u = (endpoints || [])[0];
+    if (!u) return '';
+    const m = /:(\\d+)/.exec(u);
+    return m ? ':' + m[1] : '';
+  }
+
+  function updateServeRow(id) {
+    const meta = serveMeta.get(id);
+    if (!meta) return;
+    const st = serveState.get(id);
+    const status = st ? st.status : 'stopped';
+    const running = status === 'running';
+    const starting = status === 'starting';
+    meta.dot.textContent = running ? '● ' + firstPort(st.endpoints) : starting ? '○ starting' : '';
+    meta.dot.className = 'run-dot' + (starting ? ' starting' : '');
+    meta.btnSlot.innerHTML = '';
+    const btn = running || starting
+      ? el('button', 'stop-btn', 'Stop')
+      : el('button', 'invoke-btn', 'Start');
+    btn.onclick = (e) => {
+      e.stopPropagation();
+      if (running || starting) stopServe(id); else startServe(id);
+    };
+    meta.btnSlot.appendChild(btn);
+    // Refresh the workspace if it is showing this serve.
+    if (shownServeId === id) renderServeWorkspace(id);
+  }
+
   function highlightTarget(id) {
     document.querySelectorAll('.target.sel').forEach((n) => n.classList.remove('sel'));
     const t = targetEls.get(id);
@@ -155,7 +224,104 @@ const STUDIO_SCRIPT = `
 
   function selectTarget(id, kind) {
     highlightTarget(id);
-    renderComposer(id, kind, '{}');
+    if (kind === 'api') {
+      shownServeId = id;
+      shownInvId = null;
+      active = null;
+      renderServeWorkspace(id);
+    } else {
+      shownServeId = null;
+      renderComposer(id, kind, '{}');
+    }
+  }
+
+  async function startServe(id) {
+    serveState.set(id, { status: 'starting', endpoints: [] });
+    updateServeRow(id);
+    try {
+      const res = await fetch('/api/run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ targetId: id, kind: 'api' }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        // Roll back the optimistic 'starting' on a rejected start.
+        serveState.set(id, { status: 'error', endpoints: [] });
+        updateServeRow(id);
+        if (shownServeId === id) renderServeWorkspace(id, data.error || ('HTTP ' + res.status));
+      }
+      // On success the serve SSE 'running' event fills in the endpoints.
+    } catch (err) {
+      serveState.set(id, { status: 'error', endpoints: [] });
+      updateServeRow(id);
+      if (shownServeId === id) renderServeWorkspace(id, String(err));
+    }
+  }
+
+  async function stopServe(id) {
+    try {
+      await fetch('/api/stop', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ targetId: id }),
+      });
+      // The serve SSE 'stopped' event clears the running state.
+    } catch (err) {
+      /* the stop SSE event (or a later refresh) reconciles state */
+    }
+  }
+
+  function renderServeWorkspace(id, errMsg) {
+    const ws = document.getElementById('workspace');
+    ws.innerHTML = '';
+    const st = serveState.get(id) || { status: 'stopped', endpoints: [] };
+    const running = st.status === 'running';
+    const starting = st.status === 'starting';
+
+    const head = el('div', 'composer');
+    head.appendChild(el('div', 'target-name', 'Serve ' + id));
+    const btn = running || starting
+      ? el('button', null, 'Stop')
+      : el('button', null, starting ? 'Starting…' : 'Start');
+    btn.onclick = () => { if (running || starting) stopServe(id); else startServe(id); };
+    head.appendChild(btn);
+    if (errMsg) {
+      const m = el('div', 'err', errMsg);
+      head.appendChild(m);
+    }
+    ws.appendChild(head);
+
+    const epSec = el('div', 'section');
+    epSec.appendChild(el('h3', null, 'Endpoints'));
+    if (running && st.endpoints.length) {
+      for (const url of st.endpoints) {
+        const link = href(url);
+        epSec.appendChild(link);
+      }
+    } else {
+      epSec.appendChild(el('pre', null, starting ? '(starting…)' : '(not running)'));
+    }
+    ws.appendChild(epSec);
+
+    const logs = logsById.get(id) || [];
+    const logSec = el('div', 'section');
+    logSec.appendChild(el('h3', null, 'Logs'));
+    logSec.appendChild(el('pre', null, logs.length ? logs.join('\\n') : '(none)'));
+    ws.appendChild(logSec);
+  }
+
+  // Build an <a> that opens an http(s) endpoint in a new tab; ws:// URLs
+  // are shown as plain text (not navigable in a browser tab).
+  function href(url) {
+    if (/^https?:/.test(url)) {
+      const a = el('a', 'endpoint', url);
+      a.href = url;
+      a.target = '_blank';
+      a.rel = 'noopener';
+      return a;
+    }
+    return el('div', 'endpoint', url);
   }
 
   function renderComposer(id, kind, eventText) {
@@ -304,13 +470,26 @@ const STUDIO_SCRIPT = `
     es.addEventListener('open', () => { conn.textContent = '● live'; conn.className = 'up'; });
     es.addEventListener('error', () => { conn.textContent = '● disconnected'; conn.className = 'down'; });
     es.addEventListener('invocation', (e) => addInvocation(JSON.parse(e.data)));
+    es.addEventListener('serve', (e) => onServeEvent(JSON.parse(e.data)));
     es.addEventListener('log', (e) => {
       const ev = JSON.parse(e.data);
       const arr = logsById.get(ev.containerId) || [];
       arr.push(ev.line);
       logsById.set(ev.containerId, arr);
       if (shownInvId === ev.containerId) renderResult(ev.containerId);
+      if (shownServeId === ev.containerId) renderServeWorkspace(ev.containerId);
     });
+  }
+
+  function onServeEvent(ev) {
+    // A 'stopped' / 'error' transition clears the running state; otherwise
+    // record the latest status + endpoints for the row + workspace.
+    if (ev.status === 'stopped' || ev.status === 'error') {
+      serveState.set(ev.target, { status: ev.status, endpoints: [] });
+    } else {
+      serveState.set(ev.target, { status: ev.status, endpoints: ev.endpoints || [] });
+    }
+    updateServeRow(ev.target);
   }
 
   function initSplitters() {
@@ -343,7 +522,7 @@ const STUDIO_SCRIPT = `
     wire('split-right', (dx, l0, r0) => { right = clamp(r0 - dx); });
   }
 
-  loadTargets();
+  loadTargets().then(loadRunning);
   connect();
   initSplitters();
 `;
@@ -373,7 +552,7 @@ export function renderStudioHtml(appLabel: string, cliName: string): string {
 <main>
   <section class="pane" id="targets"><h2>Targets</h2></section>
   <div class="splitter" id="split-left"></div>
-  <section class="pane" id="workspace"><div class="empty">Pick a Lambda on the left to invoke it.</div></section>
+  <section class="pane" id="workspace"><div class="empty">Pick a Lambda to invoke, or an API to serve, on the left.</div></section>
   <div class="splitter" id="split-right"></div>
   <section class="pane" id="timeline"><h2>Timeline</h2><div class="empty">No requests yet.</div></section>
 </main>

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -12,11 +12,15 @@
 #   - asserts the UI HTML is served at GET /,
 #   - asserts GET /api/targets lists the fixture's targets,
 #   - asserts GET /api/events opens a text/event-stream (SSE),
-#   - asserts the command is HIDDEN without the preview env gate, and
+#   - asserts the command is HIDDEN without the preview env gate,
+#   - drives POST /api/run to invoke a Lambda in a RIE container (slice B),
+#   - drives POST /api/run to START a long-running `start-api` serve, curls
+#     the served route through it, asserts GET /api/running reflects it +
+#     a `serve` SSE event fired, then POST /api/stop tears it down (slice
+#     C1), and
 #   - tears the server down cleanly.
 #
-# No Docker required — Phase 1 is a pure synth + HTTP read. (The invoke /
-# serve slices add Docker-backed timeline coverage.)
+# Docker required — the invoke + serve slices boot real RIE containers.
 #
 #   bash tests/integration/local-studio/verify.sh
 
@@ -204,7 +208,116 @@ fi
 echo "    OK: invocation observed on the SSE timeline"
 
 # ---------------------------------------------------------------------------
-# 7. Clean shutdown on SIGTERM.
+# 7. POST /api/run STARTS a long-running `start-api` serve (slice C1); curl
+#    the served route; assert running state + a serve SSE event; stop it.
+# ---------------------------------------------------------------------------
+API_TARGET="LocalStudioFixture/MyHttpApi"
+echo "==> POST /api/run starts a serve for ${API_TARGET}"
+
+# Capture serve SSE events from before the start so we observe the running
+# transition.
+curl -sN --max-time 200 "${URL}/api/events" >"${SSE_FILE}" 2>/dev/null &
+SSE_PID=$!
+sleep 1
+
+# Starting the serve boots a local HTTP server (the RIE container starts on
+# the first request, so the listening line — and this response — come back
+# quickly; the generous timeout only covers a slow synth).
+SERVE_FILE=$(mktemp)
+HTTP_CODE=$(curl -s -o "${SERVE_FILE}" -w '%{http_code}' --max-time 120 \
+  -X POST "${URL}/api/run" \
+  -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${API_TARGET}\",\"kind\":\"api\"}" || true)
+
+if [[ "${HTTP_CODE}" != "200" ]]; then
+  echo "FAIL: POST /api/run (serve) returned HTTP ${HTTP_CODE}"
+  echo "----- serve response -----"; cat "${SERVE_FILE}"; echo "--------------------------"
+  echo "----- studio log -----"; cat "${LOG_FILE}"; echo "----------------------"
+  rm -f "${SERVE_FILE}"
+  exit 1
+fi
+for needle in '"status":"running"' '"kind":"api"'; do
+  if ! grep -qF "${needle}" "${SERVE_FILE}"; then
+    echo "FAIL: serve response missing: ${needle}"
+    echo "----- serve response -----"; cat "${SERVE_FILE}"; echo "--------------------------"
+    rm -f "${SERVE_FILE}"
+    exit 1
+  fi
+done
+SERVED=$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "${SERVE_FILE}" | head -1 || true)
+rm -f "${SERVE_FILE}"
+if [[ -z "${SERVED}" ]]; then
+  echo "FAIL: could not parse the served endpoint from the run response"
+  exit 1
+fi
+echo "    OK: serve started at ${SERVED}"
+
+echo "==> The served route answers through the studio-managed start-api"
+# First request boots the RIE container for MyHandler — generous timeout.
+ROUTE_FILE=$(mktemp)
+# The fixture handler returns the exact body `ok` — match it as a whole
+# line (not a loose substring) so a stray `tokens` / `not ok` cannot pass.
+ROUTE_CODE=$(curl -s -o "${ROUTE_FILE}" -w '%{http_code}' --max-time 180 "${SERVED}/hello" || true)
+if [[ "${ROUTE_CODE}" != "200" ]] || ! grep -qx 'ok' "${ROUTE_FILE}"; then
+  echo "FAIL: served route did not return 200 ok (HTTP ${ROUTE_CODE})"
+  echo "----- route body -----"; cat "${ROUTE_FILE}"; echo "----------------------"
+  echo "----- studio log -----"; cat "${LOG_FILE}"; echo "----------------------"
+  rm -f "${ROUTE_FILE}"
+  exit 1
+fi
+rm -f "${ROUTE_FILE}"
+echo "    OK: GET ${SERVED}/hello -> 200 ok"
+
+echo "==> GET /api/running reflects the running serve"
+curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
+if ! grep -qF "${API_TARGET}" "${BODY_FILE}" || ! grep -qF '"status":"running"' "${BODY_FILE}"; then
+  echo "FAIL: /api/running did not list the running serve"
+  cat "${BODY_FILE}"
+  exit 1
+fi
+echo "    OK: /api/running lists ${API_TARGET}"
+
+echo "==> A serve event was broadcast over SSE"
+for _ in $(seq 1 20); do
+  if grep -qF 'event: serve' "${SSE_FILE}" && grep -qF '"status":"running"' "${SSE_FILE}"; then
+    break
+  fi
+  sleep 0.5
+done
+if ! grep -qF 'event: serve' "${SSE_FILE}" || ! grep -qF '"status":"running"' "${SSE_FILE}"; then
+  echo "FAIL: SSE stream did not carry the serve running event"
+  echo "----- sse capture -----"; cat "${SSE_FILE}"; echo "-----------------------"
+  exit 1
+fi
+echo "    OK: serve running event observed on the SSE timeline"
+
+echo "==> POST /api/stop tears the serve down"
+STOP_CODE=$(curl -s -o "${BODY_FILE}" -w '%{http_code}' --max-time 30 \
+  -X POST "${URL}/api/stop" \
+  -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${API_TARGET}\"}" || true)
+if [[ "${STOP_CODE}" != "200" ]]; then
+  echo "FAIL: POST /api/stop returned HTTP ${STOP_CODE}"
+  cat "${BODY_FILE}"
+  exit 1
+fi
+kill "${SSE_PID}" 2>/dev/null || true
+SSE_PID=""
+# After the stop, the running list must be empty again.
+for _ in $(seq 1 20); do
+  curl -fsS "${URL}/api/running" -o "${BODY_FILE}" 2>/dev/null || true
+  if ! grep -qF "${API_TARGET}" "${BODY_FILE}"; then break; fi
+  sleep 0.5
+done
+if grep -qF "${API_TARGET}" "${BODY_FILE}"; then
+  echo "FAIL: /api/running still lists ${API_TARGET} after stop"
+  cat "${BODY_FILE}"
+  exit 1
+fi
+echo "    OK: serve stopped; /api/running is empty"
+
+# ---------------------------------------------------------------------------
+# 8. Clean shutdown on SIGTERM.
 # ---------------------------------------------------------------------------
 echo "==> Stopping studio (SIGTERM) and asserting clean exit"
 kill "${STUDIO_PID}"
@@ -220,4 +333,4 @@ STUDIO_PID=""
 echo "    OK: studio stopped cleanly"
 
 echo ""
-echo "==> local-studio test passed (gate + boot + UI + targets + SSE + shutdown)"
+echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + serve start/stop + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
   coerceRunRequest,
+  coerceStopRequest,
   createLocalStudioCommand,
   parseStudioPort,
 } from '../../../src/cli/commands/local-studio.js';
@@ -70,6 +71,23 @@ describe('coerceRunRequest', () => {
     'rejects a missing/unknown kind %p',
     (body) => {
       expect(() => coerceRunRequest(body)).toThrow(/"kind" must be one of/);
+    }
+  );
+});
+
+describe('coerceStopRequest', () => {
+  it('accepts a well-formed stop request', () => {
+    expect(coerceStopRequest({ targetId: 'MyApi' })).toEqual({ targetId: 'MyApi' });
+  });
+
+  it.each([null, 42, 'str', undefined])('rejects a non-object body %p', (body) => {
+    expect(() => coerceStopRequest(body)).toThrow(/must be a JSON object/);
+  });
+
+  it.each([{}, { targetId: '' }, { targetId: '   ' }])(
+    'rejects a missing/empty targetId %p',
+    (body) => {
+      expect(() => coerceStopRequest(body)).toThrow(/non-empty "targetId"/);
     }
   );
 });

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -1,0 +1,418 @@
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi } from 'vite-plus/test';
+import {
+  StudioEventBus,
+  type StudioLogEvent,
+  type StudioServeEvent,
+} from '../../../src/local/studio-events.js';
+import { createStudioServeManager } from '../../../src/local/studio-serve-manager.js';
+
+/** A minimal stand-in for a long-running spawned serve child. */
+function makeFakeChild(pid = 4242): EventEmitter & {
+  stdout: EventEmitter & { setEncoding: () => void };
+  stderr: EventEmitter & { setEncoding: () => void };
+  kill: ReturnType<typeof vi.fn>;
+  pid: number;
+  exitCode: number | null;
+  signalCode: string | null;
+} {
+  const stdout = Object.assign(new EventEmitter(), { setEncoding: () => undefined });
+  const stderr = Object.assign(new EventEmitter(), { setEncoding: () => undefined });
+  return Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    kill: vi.fn(),
+    pid,
+    exitCode: null as number | null,
+    signalCode: null as string | null,
+  });
+}
+
+function collect(bus: StudioEventBus): { serves: StudioServeEvent[]; logs: StudioLogEvent[] } {
+  const serves: StudioServeEvent[] = [];
+  const logs: StudioLogEvent[] = [];
+  bus.on('serve', (e) => serves.push(e));
+  bus.on('log', (e) => logs.push(e));
+  return { serves, logs };
+}
+
+const fixedClock = (): (() => number) => {
+  let t = 1000;
+  return () => (t += 10);
+};
+
+/**
+ * A controllable timer pair: `setTimeoutFn` records callbacks instead of
+ * scheduling them; `fireLast` / `fireAll` invoke them on demand so tests
+ * can drive the ready-timeout + SIGKILL-escalation timers deterministically.
+ */
+function manualTimers(): {
+  setTimeoutFn: typeof setTimeout;
+  clearTimeoutFn: typeof clearTimeout;
+  fireLast: () => void;
+  fireAll: () => void;
+} {
+  const pending = new Map<number, () => void>();
+  let nextId = 1;
+  const setTimeoutFn = ((cb: () => void) => {
+    const id = nextId++;
+    pending.set(id, cb);
+    return { __id: id, unref: () => undefined };
+  }) as unknown as typeof setTimeout;
+  const clearTimeoutFn = ((t: { __id?: number }) => {
+    if (t && t.__id != null) pending.delete(t.__id);
+  }) as unknown as typeof clearTimeout;
+  const fireLast = (): void => {
+    const ids = [...pending.keys()];
+    const id = ids[ids.length - 1];
+    if (id != null) {
+      const cb = pending.get(id);
+      pending.delete(id);
+      cb?.();
+    }
+  };
+  const fireAll = (): void => {
+    for (const [id, cb] of [...pending]) {
+      pending.delete(id);
+      cb();
+    }
+  };
+  return { setTimeoutFn, clearTimeoutFn, fireLast, fireAll };
+}
+
+const LISTENING = 'Server listening on http://127.0.0.1:51234  (MyApi)\n';
+
+describe('createStudioServeManager', () => {
+  it('spawns `cdkl start-api <target> --port 0` and resolves running on the listening line', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      nodeBin: '/usr/bin/node',
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    const state = await p;
+
+    const [bin, argv] = spawnFn.mock.calls[0] as unknown as [string, string[]];
+    expect(bin).toBe('/usr/bin/node');
+    expect(argv[0]).toBe('/path/to/cli.js');
+    expect(argv.slice(1, 6)).toEqual(['start-api', 'MyApi', '--port', '0', '--host']);
+
+    expect(state.status).toBe('running');
+    expect(state.endpoints).toEqual(['http://127.0.0.1:51234']);
+    expect(state.pid).toBe(4242);
+
+    // serve events: starting then running.
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
+    expect(serves[1].endpoints).toEqual(['http://127.0.0.1:51234']);
+  });
+
+  it('streams child stdout AND stderr lines onto the bus as log events keyed by the target', async () => {
+    const bus = new StudioEventBus();
+    const { logs } = collect(bus);
+    const child = makeFakeChild();
+
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stderr.emit('data', 'warming container\n');
+    child.stdout.emit('data', LISTENING);
+    await p;
+    child.stdout.emit('data', 'GET /health 200\n');
+
+    const lines = logs.map((l) => l.line);
+    expect(lines).toContain('warming container');
+    expect(lines).toContain('GET /health 200');
+    // The listening line itself is also surfaced as a log line.
+    expect(lines.some((l) => l.startsWith('Server listening on'))).toBe(true);
+    expect(logs.every((l) => l.containerId === 'MyApi' && l.target === 'MyApi')).toBe(true);
+  });
+
+  it('rejects a non-api kind without spawning', async () => {
+    const bus = new StudioEventBus();
+    const spawnFn = vi.fn();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+    });
+
+    await expect(mgr.start({ targetId: 'MySvc', kind: 'ecs' })).rejects.toThrow(/not supported/i);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects starting a target that is already running', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+
+    await expect(mgr.start({ targetId: 'MyApi', kind: 'api' })).rejects.toThrow(/already running/i);
+  });
+
+  it('rejects + emits error when the child exits before ever listening', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.emit('close', 1);
+
+    await expect(p).rejects.toThrow(/exited before listening/i);
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'error']);
+    // A failed boot is not tracked as running.
+    expect(mgr.list()).toEqual([]);
+  });
+
+  it('rejects when spawn throws synchronously', async () => {
+    const bus = new StudioEventBus();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => {
+        throw new Error('ENOENT: node not found');
+      }) as never,
+    });
+
+    await expect(mgr.start({ targetId: 'MyApi', kind: 'api' })).rejects.toThrow(/ENOENT/);
+    expect(mgr.list()).toEqual([]);
+  });
+
+  it('rejects when the child emits an error event before ready', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.emit('error', new Error('spawn EACCES'));
+    await expect(p).rejects.toThrow(/EACCES/);
+  });
+
+  it('gracefully stops (SIGTERM->SIGKILL) the child + rejects on the ready timeout', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const { setTimeoutFn, clearTimeoutFn, fireLast, fireAll } = manualTimers();
+
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      readyTimeoutMs: 5,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    fireLast(); // fire the ready-timeout timer
+    await expect(p).rejects.toThrow(/did not start/i);
+    // The timeout must SIGTERM (graceful) first — NOT an immediate SIGKILL,
+    // so start-api can tear down its RIE containers (#3).
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
+    fireAll(); // fire the SIGKILL-escalation grace timer
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(serves.some((s) => s.status === 'error')).toBe(true);
+  });
+
+  it('reports a crash WHILE running (close not via stop) as stopped + evicts it', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+    child.emit('close', 1); // the server process crashed on its own
+
+    expect(serves.at(-1)?.status).toBe('stopped');
+    expect(serves.at(-1)?.message).toMatch(/exited/i);
+    expect(mgr.list()).toEqual([]);
+  });
+
+  it('marks a post-ready child error as errored + evicts it', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+    child.emit('error', new Error('post-ready boom'));
+
+    expect(serves.at(-1)?.status).toBe('error');
+    expect(serves.at(-1)?.message).toContain('post-ready boom');
+    expect(mgr.list()).toEqual([]);
+  });
+
+  it('stopping a still-STARTING serve is a clean stop, not a boot failure (#1)', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const { setTimeoutFn, clearTimeoutFn } = manualTimers();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    // Start but never emit a listening line — the serve stays `starting`.
+    const startP = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    const stopP = mgr.stop({ targetId: 'MyApi' });
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    child.emit('close', 0); // child exits in response to the stop's SIGTERM
+
+    await expect(startP).rejects.toThrow(/stopped before it finished starting/i);
+    await stopP;
+
+    // Exactly starting -> stopped; NO `error` event for a user-initiated stop.
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'stopped']);
+  });
+
+  it('appends a second listening endpoint and re-emits running', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+    child.stdout.emit('data', 'Server listening on ws://127.0.0.1:51235/ws  (MyWs)\n');
+
+    const running = serves.filter((s) => s.status === 'running');
+    expect(running).toHaveLength(2);
+    expect(running[1].endpoints).toEqual([
+      'http://127.0.0.1:51234',
+      'ws://127.0.0.1:51235/ws',
+    ]);
+    expect(mgr.list()[0].endpoints).toHaveLength(2);
+  });
+
+  it('stop() SIGTERMs the child, emits stopped, and drops it from the running list', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+    expect(mgr.list().map((s) => s.targetId)).toEqual(['MyApi']);
+
+    const stopP = mgr.stop({ targetId: 'MyApi' });
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    child.emit('close', 0); // child exits in response to SIGTERM
+    await stopP;
+
+    expect(mgr.list()).toEqual([]);
+    expect(serves.at(-1)?.status).toBe('stopped');
+  });
+
+  it('stop() escalates to SIGKILL when the child ignores SIGTERM', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const { setTimeoutFn, clearTimeoutFn, fireAll } = manualTimers();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+
+    const stopP = mgr.stop({ targetId: 'MyApi' });
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    fireAll(); // child ignored SIGTERM -> the grace timer escalates
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    child.emit('close', null); // finally dies from the SIGKILL
+    await stopP;
+    expect(mgr.list()).toEqual([]);
+  });
+
+  it('stop() rejects for a target that is not running', async () => {
+    const bus = new StudioEventBus();
+    const mgr = createStudioServeManager({ cliEntry: 'cli.js', bus, spawnFn: (() => makeFakeChild()) as never });
+    await expect(mgr.stop({ targetId: 'Nope' })).rejects.toThrow(/not running/i);
+  });
+
+  it('stopAll() stops every running serve', async () => {
+    const bus = new StudioEventBus();
+    const children = [makeFakeChild(1), makeFakeChild(2)];
+    let i = 0;
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => children[i++]) as never,
+    });
+
+    const p1 = mgr.start({ targetId: 'ApiA', kind: 'api' });
+    children[0].stdout.emit('data', LISTENING);
+    await p1;
+    const p2 = mgr.start({ targetId: 'ApiB', kind: 'api' });
+    children[1].stdout.emit('data', LISTENING);
+    await p2;
+    expect(mgr.list()).toHaveLength(2);
+
+    const allP = mgr.stopAll();
+    children[0].emit('close', 0);
+    children[1].emit('close', 0);
+    await allP;
+
+    expect(mgr.list()).toEqual([]);
+    expect(children[0].kill).toHaveBeenCalledWith('SIGTERM');
+    expect(children[1].kill).toHaveBeenCalledWith('SIGTERM');
+  });
+});

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -194,9 +194,10 @@ describe('startStudioServer', () => {
     const res = await resP;
     const reader = res.body!.getReader();
     await reader.read(); // open the stream so the server subscribes
-    // Subscribed: one invocation + one log listener.
+    // Subscribed: one invocation + one log + one serve listener.
     expect(bus.listenerCount('invocation')).toBe(1);
     expect(bus.listenerCount('log')).toBe(1);
+    expect(bus.listenerCount('serve')).toBe(1);
 
     abort(); // client disconnect (destroys the connection)
 
@@ -207,6 +208,7 @@ describe('startStudioServer', () => {
     }
     expect(bus.listenerCount('invocation')).toBe(0);
     expect(bus.listenerCount('log')).toBe(0);
+    expect(bus.listenerCount('serve')).toBe(0);
   });
 
   it('POST /api/run dispatches to onRun and returns its result as JSON', async () => {
@@ -260,6 +262,85 @@ describe('startStudioServer', () => {
     expect(res.status).toBe(500);
     const data = (await res.json()) as { error: string };
     expect(data.error).toContain('dispatch blew up');
+  });
+
+  it('POST /api/stop dispatches to onStop and returns its result as JSON', async () => {
+    let received: unknown;
+    const onStop = (body: unknown): Promise<unknown> => {
+      received = body;
+      return Promise.resolve({ stopped: 'MyApi' });
+    };
+    const server = await boot({ onStop });
+
+    const res = await fetch(`${server.url}/api/stop`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ targetId: 'MyApi' }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { stopped: string };
+    expect(data.stopped).toBe('MyApi');
+    expect(received).toEqual({ targetId: 'MyApi' });
+  });
+
+  it('POST /api/stop answers 501 when no onStop handler is wired', async () => {
+    const server = await boot(); // observe-only shell
+    const res = await fetch(`${server.url}/api/stop`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(501);
+    await res.text();
+  });
+
+  it('GET /api/running returns the getRunning snapshot', async () => {
+    const server = await boot({
+      getRunning: () => ({ running: [{ targetId: 'MyApi', kind: 'api', status: 'running' }] }),
+    });
+    const res = await fetch(`${server.url}/api/running`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { running: { targetId: string }[] };
+    expect(data.running).toEqual([{ targetId: 'MyApi', kind: 'api', status: 'running' }]);
+  });
+
+  it('GET /api/running returns an empty list when no getRunning is wired', async () => {
+    const server = await boot(); // observe-only shell
+    const res = await fetch(`${server.url}/api/running`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { running: unknown[] };
+    expect(data.running).toEqual([]);
+  });
+
+  it('streams an emitted serve event over the SSE channel', async () => {
+    const bus = new StudioEventBus();
+    const server = await boot({ bus });
+
+    const { res: resP, abort } = openSse(`${server.url}/api/events`);
+    const res = await resP;
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    await reader.read(); // opening `:ok`
+
+    bus.emit('serve', {
+      ts: 1,
+      target: 'MyApi',
+      kind: 'api',
+      status: 'running',
+      endpoints: ['http://127.0.0.1:51234'],
+    });
+
+    let buf = '';
+    while (!buf.includes('event: serve')) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+    }
+    abort();
+
+    expect(buf).toContain('event: serve');
+    expect(buf).toContain('"status":"running"');
+    expect(buf).toContain('http://127.0.0.1:51234');
   });
 
   it('close() resolves even with a live SSE client connected', async () => {


### PR DESCRIPTION
## Summary

Slice **C1** of `cdkl studio` (Phase 1, part of #282): make the studio
console drive **long-running serve targets**, not just single-shot
invokes. Pick an API on the left, click **[Start]**, and studio boots a
real `cdkl start-api` for it — the served endpoint becomes a clickable
link, container logs stream into the workspace, and **[Stop]** tears it
down. Running state shows as `running ● :port` on the target row and is
broadcast over SSE. Still behind `CDKL_STUDIO_PREVIEW=1` (graduates at
the unveil slice).

### Design — control plane over the CLI

Just as slice B spawns `cdkl invoke` for a Lambda, a serve start spawns
the SAME long-running `cdkl start-api <target> --port 0` as a managed
CHILD process rather than re-wiring the server internals — byte-for-byte
parity, and all of `start-api`'s process-global behavior stays isolated
in a subprocess. The serve manager resolves "running" off the child's
first `Server listening on <url>` line and SIGTERMs it on stop / studio
shutdown so the child's own RIE-container cleanup runs.

Scope is the **`api` kind only**; alb / ecs serve are additive (the
manager is kind-parameterized and rejects the rest with a clear message).
Request capture for traffic to the served port (decision D4a / D5),
CloudWatch-granularity per-request log binding, and full-text log search
are deferred to **slice C2**.

### Changes

- `src/local/studio-serve-manager.ts` (new) — the serve lifecycle:
  `start` / `stop` / `list` / `stopAll`, `serve` lifecycle events,
  SIGTERM→SIGKILL teardown.
- `src/local/studio-events.ts` — new `serve` event + `StudioServeEvent`.
- `src/local/studio-server.ts` — `POST /api/stop` + `GET /api/running`;
  `serve` events forwarded over SSE; shared run/stop POST handler.
- `src/cli/commands/local-studio.ts` — `/api/run` branches lambda→invoke
  dispatcher, api→serve manager; serve children stopped before the server
  closes on Ctrl-C; `coerceStopRequest`.
- `src/local/studio-ui.ts` — API targets get a [Start]/[Stop] control +
  `running ● :port` indicator + clickable endpoints + streaming logs.
- `src/internal.ts` — re-export the serve building blocks for host CLIs.

### Lifecycle hardening (from this PR's 3-axis review)

- Ready-timeout now SIGTERM→SIGKILLs the stuck child (graceful) instead
  of an immediate SIGKILL, so a half-booted `start-api` still tears down
  its RIE containers rather than orphaning them.
- A `stop()` that races a still-`starting` serve reads as a clean stop,
  not a boot failure (no spurious `error` event).
- `stopChild` attaches its `close` listener before the already-exited
  check so a child exiting in that window can't leave the stop pending.

## Test plan

- **Unit** (2254 pass): serve-manager lifecycle (mocked spawn + a
  controllable timer) covering ready-on-listening, graceful ready-timeout
  + SIGKILL escalation, crash-while-running, child error before/after
  ready, stop-during-starting, stop SIGTERM + SIGKILL escalation +
  eviction, multi-endpoint, stopAll; `/api/stop` + `/api/running` + serve
  SSE on the server; `coerceStopRequest`.
- **Integration** (real Docker, `tests/integration/local-studio`): drives
  the REAL binary — `POST /api/run` starts a `start-api` serve, curls the
  served route through the studio-managed child (200 `ok` via a RIE
  container), asserts `/api/running` + a `serve` SSE event, then
  `POST /api/stop` tears it down with **zero leftover containers**.
- **Live-tested** end-to-end against the fixture before the integ.

## Reviewer nits accepted as known cost

- Same-tick `listening`-line-then-`close` interleave would fall to the
  ready-timeout path — unrealistic for a long-running HTTP server, and
  the timeout is a correct backstop.
- The ready-timeout path does not detach the (now-dead) child's stream
  listeners — harmless; the entry is dropped and the child object is
  GC'd. No leak.
- Low-severity untested branches (stopChild already-exited short-circuit,
  `streamLines` newline-less final-line flush, restart-after-stopped) are
  defensive paths; the primary lifecycle exits are all covered.

## cdkd parity

`createLocalStudioCommand` stays `CDKL_STUDIO_PREVIEW`-gated and is NOT
exported from `src/index.ts` (it graduates at the unveil slice), so cdkd
cannot embed studio yet — no host-observable behavior change. The new
`createStudioServeManager` + types are re-exported from
`cdk-local/internal` (unstable surface) with host-use JSDoc.

Part of #282.
