### PR TITLE
feat(studio): Phase 1 slice C2 — capture every served request on the timeline (#282)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -297,8 +297,10 @@ compute-locally category for Lambda + API Gateway).
   studio-ui (the framework-free web UI embedded as a string so it ships
   inside the npm package with no asset-copy build step; 3-pane: targets /
   workspace composer / timeline; Lambdas get an [Invoke] composer, APIs a
-  [Start]/[Stop] serve control with a `running ● :port` indicator),
-  studio-dispatch (issue #282 — the single-shot `POST /api/run` handler
+  [Start]/[Stop] serve control with a `running ● :port` indicator; the
+  timeline carries both Lambda invocations and captured serve requests,
+  the latter opening a read-only Request/Response detail), studio-dispatch
+  (issue #282 — the single-shot `POST /api/run` handler
   for the `lambda` kind: runs a target from the studio UI by
   spawning the SAME `cdkl invoke` the headless command runs as a child
   process — studio is a control plane over the CLI — streaming its
@@ -308,9 +310,18 @@ compute-locally category for Lambda + API Gateway).
   `cdkl start-api <target> --port 0` as a managed child, resolves
   running on the first `Server listening on <url>` line, tracks the
   running set for `/api/running`, streams container logs onto the bus,
-  and SIGTERMs the child on `/api/stop` / studio shutdown; request
-  capture + CloudWatch-granularity log binding + full-text log search
-  follow in slice C2), etc.
+  and SIGTERMs the child on `/api/stop` / studio shutdown; slice C2
+  fronts each HTTP serve endpoint with a studio-proxy so the
+  `endpoints` handed to the UI are the proxy URLs), studio-proxy
+  (issue #282, slice C2 — a capturing reverse proxy in front of each
+  HTTP serve endpoint: forwards every request verbatim to the upstream
+  `start-api` child while emitting `invocation` start/end events
+  (method / path / headers / bounded body + response status / headers /
+  bounded body) onto the bus, so every request to the served port lands
+  on the timeline regardless of source — browser / curl / pad alike
+  (decision D4a); `Upgrade` (WebSocket) requests are raw-bridged without
+  capture. Full-text log search + alb / ecs serve kinds still to come),
+  etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -739,3 +739,19 @@ export {
   type StudioStopRequest,
   type StudioServeState,
 } from './local/studio-serve-manager.js';
+
+/**
+ * `cdkl studio` capture proxy (issue #282, slice C2). A host CLI
+ * embedding studio gets this for free via the serve manager (which
+ * fronts each HTTP serve endpoint with one), but it is re-exported so a
+ * host can stand up its own capture proxy in front of any upstream:
+ * `startStudioProxy(...)` forwards each request verbatim while emitting
+ * `invocation` start/end events (request/response, bounded bodies) onto
+ * the {@link StudioEventBus} so the browser timeline observes every
+ * request to the served port (decision D4a).
+ */
+export {
+  startStudioProxy,
+  type StudioProxyConfig,
+  type RunningStudioProxy,
+} from './local/studio-proxy.js';

--- a/src/local/studio-proxy.ts
+++ b/src/local/studio-proxy.ts
@@ -1,0 +1,274 @@
+import { createServer, request as httpRequest, type IncomingMessage } from 'node:http';
+import { connect as netConnect, type Socket } from 'node:net';
+import type { AddressInfo } from 'node:net';
+import { StudioEventBus, type StudioTargetKind } from './studio-events.js';
+
+/** Config for {@link startStudioProxy}. */
+export interface StudioProxyConfig {
+  /** The shared event bus; `invocation` start/end events are emitted onto it. */
+  bus: StudioEventBus;
+  /** Serve target id the proxied traffic belongs to. */
+  target: string;
+  /** The served target's kind (the timeline row's per-kind affordance). */
+  kind: StudioTargetKind;
+  /** Upstream base URL to forward to, e.g. `http://127.0.0.1:51234`. */
+  upstream: string;
+  /** Listen host. Defaults to `127.0.0.1` (localhost-only). */
+  host?: string;
+  /** Clock (injectable for tests; defaults to `Date.now`). */
+  clock?: () => number;
+  /** Per-request id factory (injectable for tests). */
+  idFactory?: () => string;
+  /**
+   * Max bytes of each captured request / response body retained for the
+   * timeline (the FULL body is still streamed through untouched — only
+   * the captured copy is bounded). Defaults to 64 KiB.
+   */
+  maxCaptureBytes?: number;
+}
+
+/** A running studio capture proxy. */
+export interface RunningStudioProxy {
+  /** The URL the proxy listens on (hand this to the user instead of upstream). */
+  url: string;
+  /** The actually-bound port. */
+  port: number;
+  /** Stop the proxy and release the port. */
+  close: () => Promise<void>;
+}
+
+let proxyIdCounter = 0;
+
+/**
+ * Start a capturing reverse proxy in front of a studio serve target
+ * (decision D4a: because every request to the served port flows through
+ * `cdkl studio`, the timeline observes them regardless of source —
+ * browser, curl, or the in-UI pad alike).
+ *
+ * Each HTTP request is forwarded to `upstream` and, in parallel,
+ * captured (method / path / headers / bounded body) and emitted as an
+ * `invocation` start event; when the upstream response completes, an end
+ * event carries the status / headers / bounded body / duration. The full
+ * bodies stream through untouched — only the captured copies are bounded.
+ * `Upgrade` (WebSocket) requests are bridged raw to the upstream without
+ * capture so they keep working.
+ *
+ * Studio is a control plane over the CLI, so this proxy sits in front of
+ * the long-running `cdkl start-api` child the serve manager spawned; it
+ * does NOT re-implement any routing — it forwards verbatim.
+ */
+export function startStudioProxy(config: StudioProxyConfig): Promise<RunningStudioProxy> {
+  const host = config.host ?? '127.0.0.1';
+  const clock = config.clock ?? Date.now;
+  const maxCapture = config.maxCaptureBytes ?? 64 * 1024;
+  const idFactory =
+    config.idFactory ??
+    (() => {
+      proxyIdCounter += 1;
+      return `req-${clock()}-${proxyIdCounter}`;
+    });
+
+  const upstreamUrl = new URL(config.upstream);
+  const upstreamHost = upstreamUrl.hostname;
+  const upstreamPort = Number(upstreamUrl.port) || 80;
+
+  const server = createServer((clientReq, clientRes) => {
+    const id = idFactory();
+    const startedAt = clock();
+    const path = clientReq.url ?? '/';
+    const method = clientReq.method ?? 'GET';
+    const label = `${method} ${path.split('?')[0]}`;
+
+    // Capture the request body (bounded) while it streams to the upstream.
+    const reqBody = boundedCollector(maxCapture);
+
+    config.bus.emit('invocation', {
+      id,
+      ts: startedAt,
+      target: config.target,
+      kind: config.kind,
+      label,
+      request: { method, path, headers: { ...clientReq.headers } },
+    });
+
+    // Exactly ONE end event per request — whether it ends via the upstream
+    // response, an upstream error, or a client abort. A second terminal
+    // event (e.g. upstream socket erroring AFTER the response started) would
+    // overwrite the real status on the timeline.
+    let ended = false;
+    const emitEnd = (status: number, response: unknown): void => {
+      if (ended) return;
+      ended = true;
+      config.bus.emit('invocation', {
+        id,
+        ts: startedAt,
+        target: config.target,
+        kind: config.kind,
+        label,
+        request: { method, path, headers: { ...clientReq.headers }, body: reqBody.text() },
+        response,
+        status,
+        durationMs: clock() - startedAt,
+      });
+    };
+
+    const upstreamReq = httpRequest(
+      {
+        host: upstreamHost,
+        port: upstreamPort,
+        method,
+        path,
+        headers: clientReq.headers,
+      },
+      (upstreamRes) => {
+        const respBody = boundedCollector(maxCapture);
+        // Strip hop-by-hop headers before forwarding: `transfer-encoding` /
+        // `connection` describe THIS connection, not the entity, and Node's
+        // client already decoded a chunked body — re-declaring it (or a
+        // stale `content-length`) can hang the client. `content-length` is
+        // end-to-end and kept.
+        clientRes.writeHead(upstreamRes.statusCode ?? 502, stripHopByHop(upstreamRes.headers));
+        upstreamRes.on('data', (chunk: Buffer) => respBody.push(chunk));
+        upstreamRes.pipe(clientRes);
+        upstreamRes.on('end', () =>
+          emitEnd(upstreamRes.statusCode ?? 502, {
+            status: upstreamRes.statusCode,
+            headers: { ...upstreamRes.headers },
+            body: respBody.text(),
+          })
+        );
+        upstreamRes.on('error', () => emitEnd(502, 'upstream response stream error'));
+      }
+    );
+
+    upstreamReq.on('error', (err) => {
+      if (!clientRes.headersSent) clientRes.writeHead(502, { 'content-type': 'text/plain' });
+      clientRes.end(`studio proxy: upstream error: ${err.message}`);
+      emitEnd(502, `upstream error: ${err.message}`);
+    });
+
+    clientReq.on('data', (chunk: Buffer) => reqBody.push(chunk));
+    clientReq.on('error', () => {
+      // The client hung up mid-flight — tear down the upstream and close the
+      // timeline row (499, the "client closed request" convention) so it
+      // does not dangle as pending forever.
+      upstreamReq.destroy();
+      emitEnd(499, 'client aborted the request');
+    });
+    clientReq.pipe(upstreamReq);
+  });
+
+  // WebSocket / other `Upgrade` requests: bridge the raw socket to the
+  // upstream without capture so they keep working through the proxy.
+  // Hijacked upgrade sockets are detached from the server's request flow,
+  // so track them and destroy them on close() (otherwise a live WebSocket
+  // keeps the server from closing).
+  const upgradeSockets = new Set<Socket>();
+  server.on('upgrade', (req, clientSocket, head) => {
+    const sock = clientSocket as Socket;
+    upgradeSockets.add(sock);
+    sock.on('close', () => upgradeSockets.delete(sock));
+    bridgeUpgrade(req, sock, head, upstreamHost, upstreamPort);
+  });
+
+  return new Promise<RunningStudioProxy>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, host, () => {
+      server.removeListener('error', reject);
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://${host}:${port}`,
+        port,
+        close: () =>
+          new Promise<void>((resolveClose, rejectClose) => {
+            for (const sock of upgradeSockets) sock.destroy();
+            upgradeSockets.clear();
+            server.close((err) => (err ? rejectClose(err) : resolveClose()));
+            server.closeAllConnections?.();
+          }),
+      });
+    });
+  });
+}
+
+/** RFC 7230 hop-by-hop headers — never forwarded across a proxy. */
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+/** Copy `headers` without the hop-by-hop ones (which describe one connection). */
+function stripHopByHop(
+  headers: Record<string, string | string[] | undefined>
+): Record<string, string | string[] | undefined> {
+  const out: Record<string, string | string[] | undefined> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (!HOP_BY_HOP.has(k.toLowerCase())) out[k] = v;
+  }
+  return out;
+}
+
+/** A bounded byte collector that decodes to a (possibly truncated) utf8 string. */
+function boundedCollector(maxBytes: number): { push: (c: Buffer) => void; text: () => string } {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  let truncated = false;
+  return {
+    push: (c: Buffer): void => {
+      if (size >= maxBytes) {
+        truncated = true;
+        return;
+      }
+      const room = maxBytes - size;
+      if (c.length > room) {
+        chunks.push(c.subarray(0, room));
+        size = maxBytes;
+        truncated = true;
+      } else {
+        chunks.push(c);
+        size += c.length;
+      }
+    },
+    text: (): string => {
+      const s = Buffer.concat(chunks).toString('utf8');
+      return truncated ? `${s}… (truncated)` : s;
+    },
+  };
+}
+
+/** Raw-bridge an `Upgrade` request (e.g. WebSocket) to the upstream. */
+function bridgeUpgrade(
+  req: IncomingMessage,
+  clientSocket: Socket,
+  head: Buffer,
+  upstreamHost: string,
+  upstreamPort: number
+): void {
+  const upstream = netConnect(upstreamPort, upstreamHost, () => {
+    let raw = `${req.method} ${req.url} HTTP/1.1\r\n`;
+    for (let i = 0; i < req.rawHeaders.length; i += 2) {
+      raw += `${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}\r\n`;
+    }
+    raw += '\r\n';
+    upstream.write(raw);
+    if (head && head.length > 0) upstream.write(head);
+    clientSocket.pipe(upstream);
+    upstream.pipe(clientSocket);
+  });
+  const teardown = (): void => {
+    clientSocket.destroy();
+    upstream.destroy();
+  };
+  // Tear down BOTH sockets when either errors OR closes — a clean half-open
+  // close (FIN, no error) on one side must not leave the peer dangling.
+  upstream.on('error', teardown);
+  upstream.on('close', teardown);
+  clientSocket.on('error', teardown);
+  clientSocket.on('close', teardown);
+}

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -1,5 +1,10 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { StudioEventBus, type StudioServeEvent, type StudioTargetKind } from './studio-events.js';
+import {
+  startStudioProxy,
+  type RunningStudioProxy,
+  type StudioProxyConfig,
+} from './studio-proxy.js';
 
 /** A request to start serving a target, as the studio UI posts it. */
 export interface StudioServeRequest {
@@ -68,6 +73,19 @@ export interface StudioServeManagerConfig {
   setTimeoutFn?: typeof setTimeout;
   /** `clearTimeout` (injectable for tests). */
   clearTimeoutFn?: typeof clearTimeout;
+  /**
+   * Factory for the capture proxy fronting each HTTP serve endpoint
+   * (slice C2). Injectable for tests; defaults to {@link startStudioProxy}.
+   * When `captureRequests` is false this is never called.
+   */
+  proxyFactory?: (config: StudioProxyConfig) => Promise<RunningStudioProxy>;
+  /**
+   * Front each HTTP serve endpoint with a capture proxy so every request
+   * to the served port lands on the studio timeline (decision D4a).
+   * Defaults to true; set false to hand the child's port through
+   * unproxied (the slice C1 behavior).
+   */
+  captureRequests?: boolean;
 }
 
 /** A bound serve manager exposing the start / stop / list surface. */
@@ -90,6 +108,8 @@ const LISTENING_RE = /Server listening on (\S+)/;
 
 interface ServeEntry extends StudioServeState {
   child: ChildProcessWithoutNullStreams;
+  /** Capture proxies fronting this serve's HTTP endpoints (slice C2). */
+  proxies: RunningStudioProxy[];
   /**
    * Set by `stop()` when it tears the child down WHILE it is still
    * `starting` (the ready promise has not settled). The child's `close`
@@ -114,9 +134,11 @@ interface ServeEntry extends StudioServeState {
  * with the discovered endpoints. `stop()` SIGTERMs the child (SIGKILL
  * after a grace window) and emits `stopped`.
  *
- * Request capture for traffic to the served port (decision D4a / D5) and
- * full-text log search arrive in slice C2; C1 is lifecycle + log
- * streaming only.
+ * Slice C2 fronts each HTTP serve endpoint with a capture proxy
+ * ({@link startStudioProxy}) so every request to the served port lands
+ * on the studio timeline (decision D4a); the `endpoints` the UI is
+ * handed are the proxy URLs. Full-text log search and alb / ecs serve
+ * kinds are still to come.
  */
 export function createStudioServeManager(config: StudioServeManagerConfig): StudioServeManager {
   const spawnFn = config.spawnFn ?? nodeSpawn;
@@ -127,8 +149,16 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
   const setTimeoutFn = config.setTimeoutFn ?? setTimeout;
   const clearTimeoutFn = config.clearTimeoutFn ?? clearTimeout;
   const cwd = config.cwd ?? process.cwd();
+  const proxyFactory = config.proxyFactory ?? startStudioProxy;
+  const captureRequests = config.captureRequests ?? true;
 
   const entries = new Map<string, ServeEntry>();
+
+  /** Close every capture proxy fronting `e` (best-effort; idempotent). */
+  async function closeProxies(e: ServeEntry): Promise<void> {
+    const proxies = e.proxies.splice(0);
+    await Promise.all(proxies.map((p) => p.close().catch(() => undefined)));
+  }
 
   function publicState(e: ServeEntry): StudioServeState {
     const s: StudioServeState = {
@@ -192,6 +222,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       endpoints: [],
       startedAt,
       child,
+      proxies: [],
     };
     if (child.pid !== undefined) entry.pid = child.pid;
     entries.set(req.targetId, entry);
@@ -211,6 +242,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         // traps SIGTERM to tear down its RIE containers, so a hard kill on a
         // half-booted child would orphan those containers.
         void stopChild(child, stopGraceMs, setTimeoutFn, clearTimeoutFn);
+        void closeProxies(entry);
         entries.delete(req.targetId);
         reject(new Error(`'${req.targetId}' did not start within ${readyTimeoutMs}ms.`));
       }, readyTimeoutMs);
@@ -225,16 +257,44 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         resolve(publicState(entry));
       };
 
+      // Resolve a child `Server listening on <childUrl>` line into the
+      // endpoint the UI is handed: an HTTP endpoint is fronted with a
+      // capture proxy (slice C2 / decision D4a) so every request to it
+      // lands on the timeline; ws:// (and capture-off) endpoints pass the
+      // child URL straight through. The FIRST resolved endpoint flips the
+      // serve to running; later ones append + re-emit.
+      const onListening = async (childUrl: string): Promise<void> => {
+        let endpoint = childUrl;
+        if (captureRequests && /^https?:/i.test(childUrl)) {
+          try {
+            const proxy = await proxyFactory({
+              bus: config.bus,
+              target: req.targetId,
+              kind: req.kind,
+              upstream: childUrl,
+            });
+            entry.proxies.push(proxy);
+            endpoint = proxy.url;
+          } catch {
+            // Proxy failed to bind — fall back to the direct child URL so
+            // the serve is still usable (just uncaptured).
+            endpoint = childUrl;
+          }
+        }
+        // A stop() may have raced the async proxy startup; if so, drop the
+        // now-orphan proxy and do not resurrect the torn-down serve.
+        if (entry.stopping || (settled && !entries.has(req.targetId))) {
+          await closeProxies(entry);
+          return;
+        }
+        if (!entry.endpoints.includes(endpoint)) entry.endpoints.push(endpoint);
+        if (settled) emitServe(entry);
+        else becomeRunning();
+      };
+
       streamLines(child.stdout, (line) => {
         const m = LISTENING_RE.exec(line);
-        if (m?.[1]) {
-          if (!entry.endpoints.includes(m[1])) entry.endpoints.push(m[1]);
-          // First listening line flips the serve to running; later lines
-          // (multi-listener apps) append + re-emit so the UI's endpoint
-          // list fills in.
-          if (settled) emitServe(entry);
-          else becomeRunning();
-        }
+        if (m?.[1]) void onListening(m[1]);
         emitLog(config.bus, clock, req.targetId, line, 'stdout');
       });
       streamLines(child.stderr, (line) => {
@@ -246,6 +306,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
           // Post-ready spawn error: mark the entry errored for the UI.
           entry.status = 'error';
           emitServe(entry, err.message);
+          void closeProxies(entry);
           entries.delete(req.targetId);
           return;
         }
@@ -253,6 +314,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         clearTimeoutFn(timer);
         entry.status = 'error';
         emitServe(entry, err.message);
+        void closeProxies(entry);
         entries.delete(req.targetId);
         reject(err);
       });
@@ -273,6 +335,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
           entry.status = 'error';
           const msg = `Server exited before listening (code ${code ?? 'null'}).`;
           emitServe(entry, msg);
+          void closeProxies(entry);
           entries.delete(req.targetId);
           reject(new Error(msg));
           return;
@@ -284,6 +347,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         if (tracked === entry && entry.status === 'running') {
           entry.status = 'stopped';
           emitServe(entry, `Server process exited (code ${code ?? 'null'}).`);
+          void closeProxies(entry);
           entries.delete(req.targetId);
         }
       });
@@ -299,7 +363,14 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
     // boot failure, when the serve was still `starting` (#1).
     entry.stopping = true;
     entries.delete(req.targetId);
-    await stopChild(entry.child, stopGraceMs, setTimeoutFn, clearTimeoutFn);
+    // Tear down the capture proxies and SIGTERM the child concurrently —
+    // both are initiated synchronously (stopChild attaches its `close`
+    // listener + sends SIGTERM in the same tick) so neither races the
+    // child's exit.
+    await Promise.all([
+      closeProxies(entry),
+      stopChild(entry.child, stopGraceMs, setTimeoutFn, clearTimeoutFn),
+    ]);
     entry.status = 'stopped';
     emitServe(entry);
   }

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -12,8 +12,10 @@
  *     event composer (textarea + Invoke button) with the latest run's
  *     Request / Response / Logs shown below; for an API, a Start/Stop
  *     control with the served endpoints + streaming logs.
- *   - right  = the timeline (history) of every invocation; clicking a
- *     row loads it back into the workspace.
+ *   - right  = the timeline (history) of every invocation AND every
+ *     captured serve request (slice C2); clicking a Lambda row reloads
+ *     it into the composer, clicking a captured request row opens a
+ *     read-only Request / Response detail.
  *
  * The center workspace is deliberately adjacent to the left target list
  * (short eye-travel: pick a target -> compose right next to it), and is
@@ -114,8 +116,9 @@ const STUDIO_SCRIPT = `
   const serveMeta = new Map();     // serve targetId -> { dot, btnSlot } row controls
   const serveState = new Map();    // serve targetId -> { status, endpoints }
   let active = null;               // { id, kind, ta, btn, msg, result }
-  let shownInvId = null;           // invocation whose result is in the workspace
+  let shownInvId = null;           // lambda invocation whose result is in the workspace
   let shownServeId = null;         // serve target whose workspace is shown
+  let shownDetailId = null;        // captured request whose read-only detail is shown
 
   function el(tag, cls, text) {
     const e = document.createElement(tag);
@@ -224,6 +227,7 @@ const STUDIO_SCRIPT = `
 
   function selectTarget(id, kind) {
     highlightTarget(id);
+    shownDetailId = null;
     if (kind === 'api') {
       shownServeId = id;
       shownInvId = null;
@@ -348,6 +352,7 @@ const STUDIO_SCRIPT = `
     active = { id, kind, ta, btn, msg, result };
     btn.onclick = () => runInvoke();
     shownInvId = null;
+    shownDetailId = null;
     ta.focus();
   }
 
@@ -448,8 +453,9 @@ const STUDIO_SCRIPT = `
         : '…';
     statusEl.className = 'status' + (merged.status != null && (merged.status < 200 || merged.status >= 300) ? ' err' : '');
 
-    // Live-refresh the workspace result if it is showing this invocation.
+    // Live-refresh the workspace if it is showing this invocation.
     if (shownInvId === ev.id) renderResult(ev.id);
+    if (shownDetailId === ev.id) renderCapturedDetail(ev.id);
   }
 
   function loadInvocation(id) {
@@ -459,9 +465,49 @@ const STUDIO_SCRIPT = `
     const row = rowsById.get(id);
     if (row) row.classList.add('sel');
     highlightTarget(ev.target);
-    renderComposer(ev.target, ev.kind, ev.request != null ? fmt(ev.request) : '{}');
-    shownInvId = id;
-    renderResult(id);
+    if (ev.kind === 'lambda') {
+      // A Lambda invocation row reloads into the re-invokable composer.
+      shownDetailId = null;
+      shownServeId = null;
+      renderComposer(ev.target, ev.kind, ev.request != null ? fmt(ev.request) : '{}');
+      shownInvId = id;
+      renderResult(id);
+    } else {
+      // A captured serve request (slice C2) opens a READ-ONLY detail —
+      // re-invoking a captured request is Phase 3.
+      shownInvId = null;
+      shownServeId = null;
+      active = null;
+      renderCapturedDetail(id);
+    }
+  }
+
+  // Read-only Request / Response detail for a captured serve request.
+  function renderCapturedDetail(id) {
+    shownDetailId = id;
+    const ev = invById.get(id);
+    const ws = document.getElementById('workspace');
+    ws.innerHTML = '';
+    if (!ev) return;
+
+    const head = el('div', 'composer');
+    head.appendChild(el('div', 'target-name', (ev.label || 'request') + '  —  ' + (ev.target || '')));
+    ws.appendChild(head);
+
+    const reqSec = el('div', 'section');
+    reqSec.appendChild(el('h3', null, 'Request'));
+    reqSec.appendChild(el('pre', null, ev.request != null ? fmt(ev.request) : '(none)'));
+    ws.appendChild(reqSec);
+
+    const respSec = el('div', 'section');
+    const h = el('h3', null, 'Response');
+    if (ev.status != null) {
+      const cls = ev.status >= 200 && ev.status < 300 ? 'ok' : 'bad';
+      h.appendChild(el('span', cls, '  ' + ev.status + (ev.durationMs != null ? ' · ' + ev.durationMs + 'ms' : '')));
+    }
+    respSec.appendChild(h);
+    respSec.appendChild(el('pre', null, ev.response != null ? fmt(ev.response) : '(pending…)'));
+    ws.appendChild(respSec);
   }
 
   function connect() {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -15,9 +15,10 @@
 #   - asserts the command is HIDDEN without the preview env gate,
 #   - drives POST /api/run to invoke a Lambda in a RIE container (slice B),
 #   - drives POST /api/run to START a long-running `start-api` serve, curls
-#     the served route through it, asserts GET /api/running reflects it +
-#     a `serve` SSE event fired, then POST /api/stop tears it down (slice
-#     C1), and
+#     the served route through it (the served endpoint is the studio
+#     CAPTURE PROXY — slice C2), asserts the request is captured on the
+#     timeline as an `invocation` row, GET /api/running reflects it + a
+#     `serve` SSE event fired, then POST /api/stop tears it down, and
 #   - tears the server down cleanly.
 #
 # Docker required — the invoke + serve slices boot real RIE containers.
@@ -268,6 +269,29 @@ fi
 rm -f "${ROUTE_FILE}"
 echo "    OK: GET ${SERVED}/hello -> 200 ok"
 
+# The served endpoint is the studio CAPTURE PROXY (slice C2): the request
+# we just made must surface on the timeline as an `invocation` row with the
+# method/path label + the 200 status, proving every request to the served
+# port flows through studio (decision D4a).
+echo "==> The served request was captured on the timeline (SSE)"
+for _ in $(seq 1 20); do
+  if grep -qF 'event: invocation' "${SSE_FILE}" && grep -qF '"label":"GET /hello"' "${SSE_FILE}"; then
+    break
+  fi
+  sleep 0.5
+done
+if ! grep -qF '"label":"GET /hello"' "${SSE_FILE}"; then
+  echo "FAIL: SSE stream did not carry the captured GET /hello request"
+  echo "----- sse capture -----"; cat "${SSE_FILE}"; echo "-----------------------"
+  exit 1
+fi
+if ! grep -qF '"status":200' "${SSE_FILE}"; then
+  echo "FAIL: captured request did not carry the 200 status"
+  echo "----- sse capture -----"; cat "${SSE_FILE}"; echo "-----------------------"
+  exit 1
+fi
+echo "    OK: GET /hello captured on the timeline with status 200"
+
 echo "==> GET /api/running reflects the running serve"
 curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
 if ! grep -qF "${API_TARGET}" "${BODY_FILE}" || ! grep -qF '"status":"running"' "${BODY_FILE}"; then
@@ -333,4 +357,4 @@ STUDIO_PID=""
 echo "    OK: studio stopped cleanly"
 
 echo ""
-echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + serve start/stop + shutdown)"
+echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + serve start/stop + request capture + shutdown)"

--- a/tests/unit/local/studio-proxy.test.ts
+++ b/tests/unit/local/studio-proxy.test.ts
@@ -1,0 +1,292 @@
+import { createServer, request as httpRequest, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, it, expect, afterEach } from 'vite-plus/test';
+import { StudioEventBus, type StudioInvocationEvent } from '../../../src/local/studio-events.js';
+import { startStudioProxy, type RunningStudioProxy } from '../../../src/local/studio-proxy.js';
+
+const upstreams: Server[] = [];
+const proxies: RunningStudioProxy[] = [];
+
+afterEach(async () => {
+  await Promise.all(proxies.splice(0).map((p) => p.close()));
+  await Promise.all(
+    upstreams.splice(0).map(
+      (s) =>
+        new Promise<void>((r) => {
+          s.close(() => r());
+          // Force-destroy any lingering connections (e.g. a hijacked
+          // WebSocket upgrade socket) so close() does not hang.
+          s.closeAllConnections?.();
+        })
+    )
+  );
+});
+
+/** Boot a throwaway upstream HTTP server with the given handler. */
+function bootUpstream(handler: Parameters<typeof createServer>[1]): Promise<string> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    upstreams.push(server);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * A keep-alive-free HTTP client (`agent: false`) so each request uses a
+ * fresh socket that closes — sidesteps undici's connection pool entirely
+ * (no `closeAllConnections`-vs-pooled-socket worker crash).
+ */
+function httpReq(
+  url: string,
+  opts: { method?: string; body?: string } = {}
+): Promise<{ status: number; body: string; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = httpRequest(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname + u.search,
+        method: opts.method ?? 'GET',
+        agent: false,
+        headers: opts.body != null ? { 'content-type': 'text/plain' } : {},
+      },
+      (res) => {
+        let data = '';
+        res.setEncoding('utf8');
+        res.on('data', (c) => (data += c));
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers })
+        );
+      }
+    );
+    req.on('error', reject);
+    if (opts.body != null) req.write(opts.body);
+    req.end();
+  });
+}
+
+function collect(bus: StudioEventBus): StudioInvocationEvent[] {
+  const evs: StudioInvocationEvent[] = [];
+  bus.on('invocation', (e) => evs.push(e));
+  return evs;
+}
+
+async function boot(
+  bus: StudioEventBus,
+  upstream: string,
+  overrides: Partial<Parameters<typeof startStudioProxy>[0]> = {}
+): Promise<RunningStudioProxy> {
+  const proxy = await startStudioProxy({
+    bus,
+    target: 'MyApi',
+    kind: 'api',
+    upstream,
+    idFactory: () => 'req-1',
+    ...overrides,
+  });
+  proxies.push(proxy);
+  return proxy;
+}
+
+describe('startStudioProxy', () => {
+  it('forwards a GET and captures request + response as start/end invocation events', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('hello');
+    });
+    const proxy = await boot(bus, upstream);
+
+    const resp = await httpReq(`${proxy.url}/hello?q=1`);
+    expect(resp.status).toBe(200);
+    expect(resp.body).toBe('hello');
+
+    // Two events keyed by the same id: a start (no status) then an end.
+    expect(evs).toHaveLength(2);
+    expect(evs[0].id).toBe('req-1');
+    expect(evs[0].status).toBeUndefined();
+    expect(evs[0].label).toBe('GET /hello'); // query stripped from the label
+    expect(evs[1].id).toBe('req-1');
+    expect(evs[1].status).toBe(200);
+    expect(evs[1].durationMs).toBeGreaterThanOrEqual(0);
+    const req = evs[1].request as { method: string; path: string };
+    expect(req.method).toBe('GET');
+    expect(req.path).toBe('/hello?q=1');
+    const res = evs[1].response as { status: number; body: string };
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('hello');
+  });
+
+  it('forwards + captures a POST request body', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const upstream = await bootUpstream((req, res) => {
+      let b = '';
+      req.on('data', (c) => (b += c));
+      req.on('end', () => {
+        res.writeHead(200);
+        res.end(`echo:${b}`);
+      });
+    });
+    const proxy = await boot(bus, upstream);
+
+    const resp = await httpReq(`${proxy.url}/submit`, { method: 'POST', body: 'ping' });
+    expect(resp.body).toBe('echo:ping');
+
+    const end = evs.find((e) => e.status != null)!;
+    expect((end.request as { body: string }).body).toBe('ping');
+    expect((end.response as { body: string }).body).toBe('echo:ping');
+  });
+
+  it('carries a non-2xx upstream status onto the timeline', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(404);
+      res.end('nope');
+    });
+    const proxy = await boot(bus, upstream);
+
+    const resp = await httpReq(`${proxy.url}/missing`);
+    expect(resp.status).toBe(404);
+    expect(evs.find((e) => e.status != null)?.status).toBe(404);
+  });
+
+  it('answers 502 + emits an error end event when the upstream is unreachable', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    // Boot an upstream to grab a real URL, then close it so the port is dead.
+    const deadUrl = await bootUpstream((_req, res) => res.end());
+    const dead = upstreams.pop()!;
+    await new Promise<void>((r) => dead.close(() => r()));
+    const proxy = await boot(bus, deadUrl);
+
+    const resp = await httpReq(`${proxy.url}/x`);
+    expect(resp.status).toBe(502);
+    const end = evs.find((e) => e.status != null);
+    expect(end?.status).toBe(502);
+    expect(String(end?.response)).toMatch(/upstream error/i);
+  });
+
+  it('bounds the CAPTURED body but streams the full body through', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const big = 'x'.repeat(1000);
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(200);
+      res.end(big);
+    });
+    const proxy = await boot(bus, upstream, { maxCaptureBytes: 10 });
+
+    const resp = await httpReq(`${proxy.url}/big`);
+    // The CLIENT still receives the full body.
+    expect(resp.body).toBe(big);
+    // The CAPTURED copy is truncated.
+    const captured = (evs.find((e) => e.status != null)?.response as { body: string }).body;
+    expect(captured.startsWith('xxxxxxxxxx')).toBe(true);
+    expect(captured).toMatch(/truncated/);
+    expect(captured.length).toBeLessThan(big.length);
+  });
+
+  it('captures a body exactly at the cap WITHOUT marking it truncated', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const exact = 'abcdefghij'; // exactly 10 bytes
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(200);
+      res.end(exact);
+    });
+    const proxy = await boot(bus, upstream, { maxCaptureBytes: 10 });
+
+    await httpReq(`${proxy.url}/exact`);
+    const captured = (evs.find((e) => e.status != null)?.response as { body: string }).body;
+    expect(captured).toBe(exact); // no "(truncated)" suffix at the boundary
+  });
+
+  it('truncates the REQUEST body too (not just the response)', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const upstream = await bootUpstream((req, res) => {
+      req.resume(); // drain
+      req.on('end', () => res.end('ok'));
+    });
+    const proxy = await boot(bus, upstream, { maxCaptureBytes: 5 });
+
+    await httpReq(`${proxy.url}/up`, { method: 'POST', body: 'abcdefghij' });
+    const capturedReq = (evs.find((e) => e.status != null)?.request as { body: string }).body;
+    expect(capturedReq.startsWith('abcde')).toBe(true);
+    expect(capturedReq).toMatch(/truncated/);
+  });
+
+  it('does NOT forward hop-by-hop response headers to the client', async () => {
+    const bus = new StudioEventBus();
+    const upstream = await bootUpstream((_req, res) => {
+      res.setHeader('keep-alive', 'timeout=5');
+      res.setHeader('x-kept', 'yes');
+      res.writeHead(200);
+      res.end('h');
+    });
+    const proxy = await boot(bus, upstream);
+
+    const resp = await httpReq(`${proxy.url}/h`);
+    // `keep-alive` is hop-by-hop and must be stripped; an ordinary header
+    // is preserved.
+    expect(resp.headers['keep-alive']).toBeUndefined();
+    expect(resp.headers['x-kept']).toBe('yes');
+  });
+
+  it('emits exactly ONE end event when the upstream dies mid-response', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(200);
+      res.write('partial');
+      // Kill the socket mid-body: the upstream response stream errors AND
+      // the request can error — the dedup guard must keep it to one event.
+      res.socket?.destroy();
+    });
+    const proxy = await boot(bus, upstream);
+
+    await httpReq(`${proxy.url}/die`).catch(() => undefined); // client may see a reset
+    await new Promise((r) => setTimeout(r, 50));
+    const ends = evs.filter((e) => e.status != null);
+    expect(ends).toHaveLength(1);
+  });
+
+  it('keeps captured bodies isolated across concurrent requests', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const upstream = await bootUpstream((req, res) => {
+      let b = '';
+      req.on('data', (c) => (b += c));
+      req.on('end', () => res.end(`got:${b}`));
+    });
+    let n = 0;
+    const proxy = await boot(bus, upstream, { idFactory: () => `req-${(n += 1)}` });
+
+    await Promise.all([
+      httpReq(`${proxy.url}/a`, { method: 'POST', body: 'aaa' }),
+      httpReq(`${proxy.url}/b`, { method: 'POST', body: 'bbb' }),
+    ]);
+
+    const ends = evs.filter((e) => e.status != null);
+    expect(ends).toHaveLength(2);
+    const bodies = ends.map((e) => (e.request as { body: string }).body).sort();
+    expect(bodies).toEqual(['aaa', 'bbb']); // no cross-talk between the two
+    expect(new Set(ends.map((e) => e.id)).size).toBe(2); // distinct ids
+  });
+
+  // NOTE: the WebSocket `Upgrade` raw-socket bridge (`bridgeUpgrade`) is
+  // intentionally NOT unit-tested here. A raw `net` client driving an
+  // upgrade handshake against an in-process server does not round-trip
+  // under this test runner's worker (the HTTP path above works because it
+  // uses a full `http` client), so the assertion is unreliable. The bridge
+  // is verified out-of-band (a standalone handshake + echo round-trip
+  // passes) and mirrors the already-tested `front-door-server` WS bridge;
+  // the gap is tracked as an accepted known cost in the PR body.
+});

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -80,7 +80,37 @@ function manualTimers(): {
   return { setTimeoutFn, clearTimeoutFn, fireLast, fireAll };
 }
 
+/**
+ * A fake capture-proxy factory: maps each HTTP upstream to a deterministic
+ * distinct proxy URL (`:512xx` -> `:612xx`) without binding a real socket,
+ * and records every `close` + `upstream` so tests can assert proxy
+ * lifecycle. Injected so the serve manager's default real proxy never runs.
+ */
+function fakeProxies(): {
+  factory: (config: { upstream: string }) => Promise<{
+    url: string;
+    port: number;
+    close: ReturnType<typeof vi.fn>;
+  }>;
+  closes: Array<ReturnType<typeof vi.fn>>;
+  upstreams: string[];
+} {
+  const closes: Array<ReturnType<typeof vi.fn>> = [];
+  const upstreams: string[] = [];
+  const factory = (config: { upstream: string }) => {
+    upstreams.push(config.upstream);
+    const u = new URL(config.upstream);
+    const proxyPort = Number('6' + u.port.slice(1));
+    const close = vi.fn(() => Promise.resolve());
+    closes.push(close);
+    return Promise.resolve({ url: `http://${u.hostname}:${proxyPort}`, port: proxyPort, close });
+  };
+  return { factory, closes, upstreams };
+}
+
 const LISTENING = 'Server listening on http://127.0.0.1:51234  (MyApi)\n';
+/** The proxy URL `fakeProxies` maps the LISTENING upstream to. */
+const PROXIED = 'http://127.0.0.1:61234';
 
 describe('createStudioServeManager', () => {
   it('spawns `cdkl start-api <target> --port 0` and resolves running on the listening line', async () => {
@@ -88,6 +118,7 @@ describe('createStudioServeManager', () => {
     const { serves } = collect(bus);
     const child = makeFakeChild();
     const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
 
     const mgr = createStudioServeManager({
       cliEntry: '/path/to/cli.js',
@@ -95,6 +126,7 @@ describe('createStudioServeManager', () => {
       nodeBin: '/usr/bin/node',
       spawnFn: spawnFn as never,
       clock: fixedClock(),
+      proxyFactory: fp.factory,
     });
 
     const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
@@ -107,23 +139,27 @@ describe('createStudioServeManager', () => {
     expect(argv.slice(1, 6)).toEqual(['start-api', 'MyApi', '--port', '0', '--host']);
 
     expect(state.status).toBe('running');
-    expect(state.endpoints).toEqual(['http://127.0.0.1:51234']);
+    // The endpoint handed to the UI is the CAPTURE PROXY, fronting the child.
+    expect(state.endpoints).toEqual([PROXIED]);
+    expect(fp.upstreams).toEqual(['http://127.0.0.1:51234']);
     expect(state.pid).toBe(4242);
 
     // serve events: starting then running.
     expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
-    expect(serves[1].endpoints).toEqual(['http://127.0.0.1:51234']);
+    expect(serves[1].endpoints).toEqual([PROXIED]);
   });
 
   it('streams child stdout AND stderr lines onto the bus as log events keyed by the target', async () => {
     const bus = new StudioEventBus();
     const { logs } = collect(bus);
     const child = makeFakeChild();
+    const fp = fakeProxies();
 
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
     });
 
     const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
@@ -156,10 +192,12 @@ describe('createStudioServeManager', () => {
   it('rejects starting a target that is already running', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();
+    const fp = fakeProxies();
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
     });
 
     const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
@@ -243,14 +281,16 @@ describe('createStudioServeManager', () => {
     expect(serves.some((s) => s.status === 'error')).toBe(true);
   });
 
-  it('reports a crash WHILE running (close not via stop) as stopped + evicts it', async () => {
+  it('reports a crash WHILE running (close not via stop) as stopped + evicts it + closes the proxy', async () => {
     const bus = new StudioEventBus();
     const { serves } = collect(bus);
     const child = makeFakeChild();
+    const fp = fakeProxies();
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
     });
 
     const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
@@ -261,16 +301,20 @@ describe('createStudioServeManager', () => {
     expect(serves.at(-1)?.status).toBe('stopped');
     expect(serves.at(-1)?.message).toMatch(/exited/i);
     expect(mgr.list()).toEqual([]);
+    // The capture proxy must be torn down when the serve crashes.
+    expect(fp.closes[0]).toHaveBeenCalled();
   });
 
   it('marks a post-ready child error as errored + evicts it', async () => {
     const bus = new StudioEventBus();
     const { serves } = collect(bus);
     const child = makeFakeChild();
+    const fp = fakeProxies();
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
     });
 
     const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
@@ -309,38 +353,44 @@ describe('createStudioServeManager', () => {
     expect(serves.map((s) => s.status)).toEqual(['starting', 'stopped']);
   });
 
-  it('appends a second listening endpoint and re-emits running', async () => {
+  it('proxies an HTTP endpoint but passes a ws:// endpoint through, re-emitting running', async () => {
     const bus = new StudioEventBus();
     const { serves } = collect(bus);
     const child = makeFakeChild();
+    const fp = fakeProxies();
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
     });
 
     const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
     child.stdout.emit('data', LISTENING);
     await p;
     child.stdout.emit('data', 'Server listening on ws://127.0.0.1:51235/ws  (MyWs)\n');
+    // The ws path has no await, but yield once so the async onListening runs.
+    await Promise.resolve();
 
     const running = serves.filter((s) => s.status === 'running');
     expect(running).toHaveLength(2);
-    expect(running[1].endpoints).toEqual([
-      'http://127.0.0.1:51234',
-      'ws://127.0.0.1:51235/ws',
-    ]);
+    // The HTTP endpoint is fronted by the proxy; the ws:// endpoint passes
+    // through unproxied (an http capture proxy can't front a raw ws listener).
+    expect(running[1].endpoints).toEqual([PROXIED, 'ws://127.0.0.1:51235/ws']);
+    expect(fp.upstreams).toEqual(['http://127.0.0.1:51234']);
     expect(mgr.list()[0].endpoints).toHaveLength(2);
   });
 
-  it('stop() SIGTERMs the child, emits stopped, and drops it from the running list', async () => {
+  it('stop() closes the proxy, SIGTERMs the child, emits stopped, and drops it from the running list', async () => {
     const bus = new StudioEventBus();
     const { serves } = collect(bus);
     const child = makeFakeChild();
+    const fp = fakeProxies();
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
     });
 
     const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
@@ -349,22 +399,65 @@ describe('createStudioServeManager', () => {
     expect(mgr.list().map((s) => s.targetId)).toEqual(['MyApi']);
 
     const stopP = mgr.stop({ targetId: 'MyApi' });
-    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
     child.emit('close', 0); // child exits in response to SIGTERM
     await stopP;
 
+    expect(fp.closes[0]).toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
     expect(mgr.list()).toEqual([]);
     expect(serves.at(-1)?.status).toBe('stopped');
+  });
+
+  it('captureRequests:false hands the child URL through unproxied', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
+      captureRequests: false,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    const state = await p;
+
+    expect(state.endpoints).toEqual(['http://127.0.0.1:51234']);
+    expect(fp.upstreams).toEqual([]); // no proxy created
+  });
+
+  it('falls back to the direct child URL when the proxy fails to bind', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const failingFactory = (): Promise<never> => Promise.reject(new Error('EADDRINUSE'));
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      proxyFactory: failingFactory as never,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    const state = await p;
+
+    // The serve is still usable on the child URL, just uncaptured.
+    expect(state.status).toBe('running');
+    expect(state.endpoints).toEqual(['http://127.0.0.1:51234']);
   });
 
   it('stop() escalates to SIGKILL when the child ignores SIGTERM', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();
+    const fp = fakeProxies();
     const { setTimeoutFn, clearTimeoutFn, fireAll } = manualTimers();
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
       setTimeoutFn,
       clearTimeoutFn,
     });
@@ -391,11 +484,13 @@ describe('createStudioServeManager', () => {
   it('stopAll() stops every running serve', async () => {
     const bus = new StudioEventBus();
     const children = [makeFakeChild(1), makeFakeChild(2)];
+    const fp = fakeProxies();
     let i = 0;
     const mgr = createStudioServeManager({
       cliEntry: 'cli.js',
       bus,
       spawnFn: (() => children[i++]) as never,
+      proxyFactory: fp.factory,
     });
 
     const p1 = mgr.start({ targetId: 'ApiA', kind: 'api' });


### PR DESCRIPTION
## Summary

Slice **C2** of `cdkl studio` (Phase 1, part of #282): make the studio
console OBSERVE serve traffic, not just start/stop it. Each HTTP serve
endpoint is now fronted by a capturing reverse proxy, so every request to
the served port — from the browser, curl, or anything else — lands on the
timeline as a row you can click to inspect its Request / Response
(decision D4a). Still behind `CDKL_STUDIO_PREVIEW=1`.

### Design — capture proxy in front of the spawned child

studio stays a control plane over the CLI. The proxy forwards each request
verbatim to the long-running `cdkl start-api` child the serve manager
(slice C1) spawned — no routing is re-implemented. The endpoint the UI is
handed is the proxy URL, so all traffic flows through studio and is
captured regardless of source.

Scope: the **request-capture proxy** for the `api` kind. DEFERRED to later
slices: full-text log search, per-request CloudWatch-granularity log
binding, and alb / ecs serve kinds.

### Changes

- `src/local/studio-proxy.ts` (new) — the capture proxy. Emits an
  `invocation` start (method / path / headers) then end (status / headers
  + bounded request & response bodies + duration); full bodies stream
  through untouched (only the captured copies are bounded, 64 KiB
  default). Strips hop-by-hop response headers before forwarding; emits
  exactly one terminal event per request (incl. 502 on a dead upstream and
  499 on a client abort). `Upgrade` (WebSocket) requests are raw-bridged.
- `src/local/studio-serve-manager.ts` — fronts each HTTP serve endpoint
  with a proxy and hands the UI the proxy URL (ws:// + capture-off pass
  through; falls back to the child URL if the proxy can't bind); proxies
  are torn down on stop / timeout / crash / error alongside the child.
- `src/local/studio-ui.ts` — the timeline carries captured serve requests;
  clicking a Lambda row reloads the re-invokable composer, clicking a
  captured request row opens a READ-ONLY Request / Response detail
  (re-invoking a captured request is Phase 3).
- `src/internal.ts` — re-export `startStudioProxy` for host CLIs.

## Test plan

- **Unit** (2266 pass): proxy capture (real upstream + a keep-alive-free
  client — GET/POST forward + capture, non-2xx, 502 on a dead upstream,
  bounded-body capture while the full body streams through, exact-cap
  boundary, request-body truncation, hop-by-hop stripping, single-end-event
  guard on mid-response upstream death, per-request body isolation across
  concurrent requests) + serve-manager proxy integration (endpoint becomes
  the proxy URL, fronts the child, ws:// passes through, capture-off +
  proxy-bind-failure fall back, proxy torn down on stop / crash).
- **Integration** (real Docker): curls the served route THROUGH the studio
  capture proxy and asserts a `GET /hello` invocation row with status 200
  lands on the SSE timeline, then stops with zero leftover containers.
- **Live-tested** end-to-end against the fixture.

## Accepted known cost

The WebSocket `Upgrade` raw-socket bridge is NOT unit-tested: a raw `net`
client driving an upgrade handshake against an in-process server does not
round-trip under the test runner's worker (the HTTP path tests fine
because it uses a full `http` client). The bridge is verified out-of-band
(a standalone handshake + echo round-trip passes) and mirrors the
already-tested `front-door-server` WebSocket bridge. A future integ with a
real WS client could regression-lock it.

## cdkd parity

studio stays `CDKL_STUDIO_PREVIEW`-gated and is NOT exported from
`src/index.ts`, so cdkd cannot embed it yet — no host-observable behavior
change on the stable surface. `startStudioProxy` is re-exported from
`cdk-local/internal` (unstable, no semver) with host-use JSDoc. Behavior
change recorded for whenever studio graduates: the serve manager's
`endpoints` now return capture-proxy URLs (capture on by default).

Part of #282.
