### PR TITLE
fix(studio): terminate the client response when the upstream dies mid-stream (#282)

### DIFF
--- a/src/local/studio-proxy.ts
+++ b/src/local/studio-proxy.ts
@@ -137,7 +137,15 @@ export function startStudioProxy(config: StudioProxyConfig): Promise<RunningStud
             body: respBody.text(),
           })
         );
-        upstreamRes.on('error', () => emitEnd(502, 'upstream response stream error'));
+        upstreamRes.on('error', () => {
+          // The upstream died mid-response: terminate the client response so
+          // it does not hang half-open (a dangling client socket that the
+          // server's later closeAllConnections would destroy, surfacing as an
+          // unhandled error). pipe() does not auto-close the destination on a
+          // source error, so do it explicitly.
+          if (!clientRes.writableEnded) clientRes.destroy();
+          emitEnd(502, 'upstream response stream error');
+        });
       }
     );
 

--- a/tests/unit/local/studio-proxy.test.ts
+++ b/tests/unit/local/studio-proxy.test.ts
@@ -61,6 +61,12 @@ function httpReq(
         res.on('end', () =>
           resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers })
         );
+        // A mid-stream upstream death destroys this response socket; handle
+        // its 'error' so it never propagates as an unhandled rejection (which
+        // would crash the test worker) and resolve with whatever arrived.
+        res.on('error', () =>
+          resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers })
+        );
       }
     );
     req.on('error', reject);
@@ -242,7 +248,17 @@ describe('startStudioProxy', () => {
 
   it('emits exactly ONE end event when the upstream dies mid-response', async () => {
     const bus = new StudioEventBus();
-    const evs = collect(bus);
+    const ends: StudioInvocationEvent[] = [];
+    // Resolve the moment the (first) terminal event fires — deterministic,
+    // no fixed sleep — then a microtask later assert no SECOND one slipped in.
+    const firstEnd = new Promise<void>((resolve) => {
+      bus.on('invocation', (e) => {
+        if (e.status != null) {
+          ends.push(e);
+          resolve();
+        }
+      });
+    });
     const upstream = await bootUpstream((_req, res) => {
       res.writeHead(200);
       res.write('partial');
@@ -253,8 +269,8 @@ describe('startStudioProxy', () => {
     const proxy = await boot(bus, upstream);
 
     await httpReq(`${proxy.url}/die`).catch(() => undefined); // client may see a reset
-    await new Promise((r) => setTimeout(r, 50));
-    const ends = evs.filter((e) => e.status != null);
+    await firstEnd;
+    await new Promise((r) => setImmediate(r)); // let any (wrongly) queued second end fire
     expect(ends).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary

`main` went red after the slice C2 merge (#294) with a vitest forks-pool
worker crash (`[vitest-pool]: Worker forks emitted error — Worker exited
unexpectedly`, exit 1) even though all 2266 tests pass — the same class of
failure that turned `main` red after slice A (#290), but a different root.

The studio capture proxy did not close the client response when the
upstream `start-api` child died AFTER the response had started. `pipe()`
does not auto-end the destination on a source error, so the client socket
dangled half-open; the proxy unit test's `afterEach` then destroyed it via
`closeAllConnections()`, and the response's `'error'` (no handler) became
an unhandled rejection that crashed the worker on a loaded CI runner.

## Fix (both ends, at the root)

- `src/local/studio-proxy.ts`: on an upstream response-stream error,
  `clientRes.destroy()` if it has not already ended — the client gets a
  clean reset during the request instead of a half-open socket the
  teardown has to reap. This is also a correctness fix: a mid-stream
  upstream failure should terminate the client, not hang it.
- `tests/unit/local/studio-proxy.test.ts`: the keep-alive-free client
  helper handles the response `'error'` event (so a reset never escapes as
  an unhandled rejection), and the "one end event on mid-response death"
  test awaits the actual terminal bus event (then one microtask) instead
  of a fixed `setTimeout` — deterministic, not timing-dependent.

## Test plan

- Ran the full suite (151 files / 2266 tests) 3× and the proxy suite 8×
  under the forks pool: zero worker anomalies.
- Re-ran the real-Docker `local-studio` integ (serve + capture through the
  proxy + zero leftover containers): green.
