### PR TITLE
feat(studio): Phase 1 slice C3 — session history, full-text log search, per-request logs (#282)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -292,14 +292,19 @@ compute-locally category for Lambda + API Gateway).
   (the localhost HTTP server behind `cdkl studio`: serves the embedded
   UI at `/`, the synthesized target list at `/api/targets`, an SSE
   stream of the event bus at `/api/events`, `POST /api/run` (single-shot
-  invoke / serve start), `POST /api/stop` (serve stop), and
-  `GET /api/running` (running serve snapshot); collision-bumps the port),
+  invoke / serve start), `POST /api/stop` (serve stop),
+  `GET /api/running` (running serve snapshot), and the slice-C3 store
+  endpoints `GET /api/history` / `GET /api/logs?q=` (full-text log
+  search) / `GET /api/invocations/<id>/logs` (per-request log binding);
+  collision-bumps the port),
   studio-ui (the framework-free web UI embedded as a string so it ships
   inside the npm package with no asset-copy build step; 3-pane: targets /
   workspace composer / timeline; Lambdas get an [Invoke] composer, APIs a
   [Start]/[Stop] serve control with a `running ● :port` indicator; the
   timeline carries both Lambda invocations and captured serve requests,
-  the latter opening a read-only Request/Response detail), studio-dispatch
+  the latter opening a read-only Request/Response detail; a log search box
+  queries the store and a captured request's detail shows its bound logs),
+  studio-dispatch
   (issue #282 — the single-shot `POST /api/run` handler
   for the `lambda` kind: runs a target from the studio UI by
   spawning the SAME `cdkl invoke` the headless command runs as a child
@@ -320,8 +325,14 @@ compute-locally category for Lambda + API Gateway).
   bounded body) onto the bus, so every request to the served port lands
   on the timeline regardless of source — browser / curl / pad alike
   (decision D4a); `Upgrade` (WebSocket) requests are raw-bridged without
-  capture. Full-text log search + alb / ecs serve kinds still to come),
-  etc.
+  capture), studio-store (issue #282, slice C3 — the in-memory event
+  store: subscribes to the bus and retains a bounded, newest-wins window
+  of invocations + log lines so the server can answer history on
+  (re)connect, full-text log search across the session, and
+  per-invocation log binding at CloudWatch granularity (decision D5 — a
+  Lambda binds strictly by container id; a captured serve request binds
+  best-effort by target + time window). alb / ecs serve kinds still to
+  come), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,
   `CloudFormationTemplate`) — shaped as a strict subset of cdkd's state

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -19,6 +19,7 @@ import {
 } from '../../local/embed-config.js';
 import { listTargets } from '../../local/target-lister.js';
 import { StudioEventBus, type StudioTargetKind } from '../../local/studio-events.js';
+import { createStudioStore, type StudioStore } from '../../local/studio-store.js';
 import {
   startStudioServer,
   toStudioTargetGroups,
@@ -165,6 +166,10 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   };
   const dispatcher = createStudioDispatcher(childConfig);
   const serveManager = createStudioServeManager(childConfig);
+  // Retain a bounded window of invocations + logs so the browser can render
+  // history on (re)connect, search logs full-text, and bind a request's
+  // logs at CloudWatch granularity (slice C3).
+  const store = createStudioStore(bus);
 
   const server = await startStudioServer({
     port,
@@ -172,6 +177,7 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     targetGroups,
     appLabel,
     cliName: getEmbedConfig().cliName,
+    store,
     // `/api/run`: a Lambda is a single-shot invoke; everything else is a
     // long-running serve start (slice C1 supports the `api` kind, the
     // serve manager rejects the rest with a clear message).
@@ -197,7 +203,7 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     openBrowser(server.url);
   }
 
-  await blockUntilShutdown(server, serveManager, cliName);
+  await blockUntilShutdown(server, serveManager, store, cliName);
 }
 
 /** Best-effort cross-platform browser open. Failures are non-fatal. */
@@ -227,6 +233,7 @@ function openBrowser(url: string): void {
 function blockUntilShutdown(
   server: RunningStudioServer,
   serveManager: StudioServeManager,
+  store: StudioStore,
   cliName: string
 ): Promise<void> {
   return new Promise<void>((resolveShutdown) => {
@@ -235,6 +242,9 @@ function blockUntilShutdown(
       if (shuttingDown) return;
       shuttingDown = true;
       getLogger().info(`Received ${signal}; stopping ${cliName} studio...`);
+      // Unsubscribe the store from the bus so a host CLI that restarts
+      // studio in a long-lived process does not accumulate listeners.
+      store.dispose();
       void serveManager
         .stopAll()
         .catch((err: unknown) => getLogger().warn(`Error stopping serve targets: ${String(err)}`))

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -755,3 +755,20 @@ export {
   type StudioProxyConfig,
   type RunningStudioProxy,
 } from './local/studio-proxy.js';
+
+/**
+ * `cdkl studio` in-memory event store (issue #282, slice C3). A host CLI
+ * embedding studio wires `createStudioStore(bus)` and passes it to
+ * `startStudioServer({ store })` so the browser's history (`GET
+ * /api/history`), full-text log search (`GET /api/logs?q=`), and
+ * per-request log binding at CloudWatch granularity (`GET
+ * /api/invocations/<id>/logs`) are served from a bounded, newest-wins
+ * window of the {@link StudioEventBus} events.
+ */
+export {
+  createStudioStore,
+  type StudioStore,
+  type StudioStoreOptions,
+  type StudioHistory,
+  type StudioLogSearchOptions,
+} from './local/studio-store.js';

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -7,6 +7,7 @@ import {
   type StudioServeEvent,
 } from './studio-events.js';
 import { renderStudioHtml } from './studio-ui.js';
+import type { StudioStore } from './studio-store.js';
 import type { TargetListing } from './target-lister.js';
 
 /** One target as the studio UI consumes it (`GET /api/targets`). */
@@ -95,6 +96,13 @@ export interface StudioServerOptions {
    * list (the observe-only shell never runs anything).
    */
   getRunning?: () => unknown;
+  /**
+   * In-memory event/log store (slice C3) backing the history + log-search
+   * + per-request-log endpoints (`GET /api/history`, `GET /api/logs`,
+   * `GET /api/invocations/<id>/logs`). When omitted those endpoints return
+   * empty results.
+   */
+  store?: StudioStore;
 }
 
 /** A running studio server. */
@@ -167,6 +175,35 @@ function handleRequest(
     const running = options.getRunning ? options.getRunning() : { running: [] };
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify(running));
+    return;
+  }
+  if (req.method === 'GET' && path === '/api/history') {
+    const history = options.store ? options.store.history() : { invocations: [], logs: [] };
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify(history));
+    return;
+  }
+  if (req.method === 'GET' && path === '/api/logs') {
+    const params = new URLSearchParams(url.split('?')[1] ?? '');
+    const query = params.get('q') ?? '';
+    // `|| undefined`: a bare `target=` (empty) means "no filter", not
+    // "logs whose target is the empty string".
+    const target = params.get('target') || undefined;
+    const logs = options.store
+      ? options.store.searchLogs(query, target !== undefined ? { target } : {})
+      : [];
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify({ logs }));
+    return;
+  }
+  // `GET /api/invocations/<id>/logs` — the request's logs at CloudWatch
+  // granularity (decision D5).
+  const invLogsMatch = /^\/api\/invocations\/([^/]+)\/logs$/.exec(path ?? '');
+  if (req.method === 'GET' && invLogsMatch) {
+    const id = decodeURIComponent(invLogsMatch[1] ?? '');
+    const logs = options.store ? options.store.logsForInvocation(id) : [];
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify({ logs }));
     return;
   }
   if (req.method === 'GET' && path === '/api/events') {

--- a/src/local/studio-store.ts
+++ b/src/local/studio-store.ts
@@ -1,0 +1,151 @@
+import {
+  StudioEventBus,
+  type StudioInvocationEvent,
+  type StudioLogEvent,
+} from './studio-events.js';
+
+/** Options for {@link createStudioStore}. */
+export interface StudioStoreOptions {
+  /** Max invocations retained (newest-wins eviction). Defaults to 200. */
+  maxInvocations?: number;
+  /** Max log lines retained (newest-wins eviction). Defaults to 5000. */
+  maxLogs?: number;
+  /**
+   * Grace window (ms) added after an invocation's duration when binding
+   * serve-request logs by time window — container lines often flush a beat
+   * after the response. Defaults to 250.
+   */
+  bindGraceMs?: number;
+}
+
+/** A point-in-time snapshot of the retained events. */
+export interface StudioHistory {
+  /** Retained invocations, oldest first. */
+  invocations: StudioInvocationEvent[];
+  /** Retained log lines, oldest first. */
+  logs: StudioLogEvent[];
+}
+
+/** Options for {@link StudioStore.searchLogs}. */
+export interface StudioLogSearchOptions {
+  /** Restrict to one target id. */
+  target?: string;
+  /** Max matches returned (newest first). Defaults to 200. */
+  limit?: number;
+}
+
+/**
+ * The in-memory event store behind `cdkl studio`. Subscribes to the event
+ * bus and retains a bounded, newest-wins window of invocations + log
+ * lines so the UI can render history on (re)connect, run a full-text log
+ * search across the whole session, and bind a request's logs at
+ * CloudWatch granularity (decision D5).
+ */
+export interface StudioStore {
+  /** Snapshot of the retained invocations + logs (oldest first). */
+  history: () => StudioHistory;
+  /**
+   * Full-text (case-insensitive substring) search over retained log
+   * lines. Returns the newest matches first, capped by `opts.limit`.
+   */
+  searchLogs: (query: string, opts?: StudioLogSearchOptions) => StudioLogEvent[];
+  /**
+   * Logs bound to one invocation at CloudWatch granularity (decision D5):
+   * a Lambda invocation binds STRICTLY by container id (the dispatcher
+   * keys each line to the invocation); a captured serve request — whose
+   * logs are keyed to the long-running serve, not the request — binds
+   * best-effort by the request's `target` + time window.
+   */
+  logsForInvocation: (id: string) => StudioLogEvent[];
+  /** The retained invocation with `id`, if still in the window. */
+  invocation: (id: string) => StudioInvocationEvent | undefined;
+  /** Stop subscribing to the bus (idempotent). */
+  dispose: () => void;
+}
+
+/**
+ * Build the studio store and subscribe it to `bus`. The store merges the
+ * start/end pair of each invocation (keyed by id) and keeps a ring of log
+ * lines; both windows evict oldest-first past their caps.
+ */
+export function createStudioStore(
+  bus: StudioEventBus,
+  options: StudioStoreOptions = {}
+): StudioStore {
+  const maxInvocations = options.maxInvocations ?? 200;
+  const maxLogs = options.maxLogs ?? 5000;
+  const bindGraceMs = options.bindGraceMs ?? 250;
+
+  // Insertion-ordered map: re-setting an existing id (the end event) keeps
+  // its original position, so the start/end pair stays one entry.
+  const invocations = new Map<string, StudioInvocationEvent>();
+  const logs: StudioLogEvent[] = [];
+
+  const onInvocation = (ev: StudioInvocationEvent): void => {
+    invocations.set(ev.id, { ...invocations.get(ev.id), ...ev });
+    if (invocations.size > maxInvocations) {
+      // Evict the oldest (first-inserted) entry.
+      const oldest = invocations.keys().next().value;
+      if (oldest !== undefined) invocations.delete(oldest);
+    }
+  };
+
+  const onLog = (ev: StudioLogEvent): void => {
+    logs.push(ev);
+    if (logs.length > maxLogs) logs.shift();
+  };
+
+  bus.on('invocation', onInvocation);
+  bus.on('log', onLog);
+
+  let disposed = false;
+
+  return {
+    history: (): StudioHistory => ({
+      invocations: [...invocations.values()],
+      logs: [...logs],
+    }),
+
+    searchLogs: (query, opts = {}): StudioLogEvent[] => {
+      const needle = query.toLowerCase();
+      const limit = opts.limit ?? 200;
+      const matches: StudioLogEvent[] = [];
+      // Walk newest-first so a tight limit keeps the most recent matches.
+      for (let i = logs.length - 1; i >= 0 && matches.length < limit; i -= 1) {
+        const log = logs[i];
+        if (!log) continue;
+        if (opts.target !== undefined && log.target !== opts.target) continue;
+        if (needle === '' || log.line.toLowerCase().includes(needle)) matches.push(log);
+      }
+      return matches;
+    },
+
+    logsForInvocation: (id): StudioLogEvent[] => {
+      const inv = invocations.get(id);
+      if (!inv) return [];
+      // Bind by KIND, not by "did the strict filter match anything". A
+      // Lambda's lines are keyed to the invocation id, so bind STRICTLY by
+      // container id — even when the invocation emitted none (an empty
+      // result is correct; falling back to a time window would surface a
+      // DIFFERENT invocation's logs of the same function).
+      if (inv.kind === 'lambda') {
+        return logs.filter((l) => l.containerId === id);
+      }
+      // A captured serve request's logs are keyed to the long-running serve
+      // (not the request), so bind best-effort by target + the request's
+      // time window (D5).
+      const from = inv.ts;
+      const to = inv.ts + (inv.durationMs ?? 0) + bindGraceMs;
+      return logs.filter((l) => l.target === inv.target && l.ts >= from && l.ts <= to);
+    },
+
+    invocation: (id): StudioInvocationEvent | undefined => invocations.get(id),
+
+    dispose: (): void => {
+      if (disposed) return;
+      disposed = true;
+      bus.off('invocation', onInvocation);
+      bus.off('log', onLog);
+    },
+  };
+}

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -102,6 +102,20 @@ const STUDIO_CSS = `
   .section pre { margin: 0; white-space: pre-wrap; word-break: break-word; color: #cfcfcf; }
   .endpoint { display: block; color: #6aa9ff; text-decoration: none; padding: 2px 0; }
   .endpoint:hover { text-decoration: underline; }
+  .searchbar { padding: 6px 10px; border-bottom: 1px solid #2a2a2a; background: #151515;
+    position: sticky; top: 28px; z-index: 1; }
+  .searchbar input {
+    width: 100%; background: #111; color: #ddd; border: 1px solid #333; border-radius: 3px;
+    padding: 5px 8px; font: 12px ui-monospace, Menlo, monospace;
+  }
+  .searchbar input:focus { outline: none; border-color: #4ec97a; }
+  #log-results { display: none; }
+  #log-results.active { display: block; }
+  .log-hit { padding: 4px 12px; border-bottom: 1px solid #222; white-space: pre-wrap;
+    word-break: break-word; }
+  .log-hit .lt { color: #777; }
+  .log-hit .lg { color: #6aa9ff; }
+  .log-hits-meta { padding: 6px 12px; color: #888; font-size: 11px; }
   #conn { font-size: 11px; }
   #conn.up { color: #7bd88f; }
   #conn.down { color: #e0707a; }
@@ -428,7 +442,7 @@ const STUDIO_SCRIPT = `
 
   function addInvocation(ev) {
     invById.set(ev.id, Object.assign(invById.get(ev.id) || {}, ev));
-    const timeline = document.getElementById('timeline');
+    const timeline = document.getElementById('timeline-rows');
     const placeholder = timeline.querySelector('.empty');
     if (placeholder) placeholder.remove();
 
@@ -508,6 +522,84 @@ const STUDIO_SCRIPT = `
     respSec.appendChild(h);
     respSec.appendChild(el('pre', null, ev.response != null ? fmt(ev.response) : '(pending…)'));
     ws.appendChild(respSec);
+
+    // Logs bound to THIS request at CloudWatch granularity (D5), fetched
+    // from the server store.
+    const logSec = el('div', 'section');
+    logSec.appendChild(el('h3', null, 'Logs'));
+    const logPre = el('pre', null, '(loading…)');
+    logSec.appendChild(logPre);
+    ws.appendChild(logSec);
+    fetchInvocationLogs(id, logPre);
+  }
+
+  async function fetchInvocationLogs(id, pre) {
+    try {
+      const res = await fetch('/api/invocations/' + encodeURIComponent(id) + '/logs');
+      const data = await res.json();
+      const lines = (data.logs || []).map((l) => l.line);
+      if (shownDetailId === id) pre.textContent = lines.length ? lines.join('\\n') : '(none)';
+    } catch (err) {
+      if (shownDetailId === id) pre.textContent = '(failed to load logs)';
+    }
+  }
+
+  // Full-text log search over the server store. A non-empty query shows
+  // matching log lines INSTEAD of the timeline rows; clearing restores them.
+  let searchTimer = null;
+  function wireLogSearch() {
+    const input = document.getElementById('log-search');
+    const rows = document.getElementById('timeline-rows');
+    const results = document.getElementById('log-results');
+    input.addEventListener('input', () => {
+      if (searchTimer) clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => runLogSearch(input.value.trim(), rows, results), 180);
+    });
+  }
+
+  async function runLogSearch(query, rows, results) {
+    if (query === '') {
+      results.classList.remove('active');
+      rows.style.display = '';
+      results.innerHTML = '';
+      return;
+    }
+    rows.style.display = 'none';
+    results.classList.add('active');
+    try {
+      const res = await fetch('/api/logs?q=' + encodeURIComponent(query));
+      const data = await res.json();
+      const hits = data.logs || [];
+      results.innerHTML = '';
+      results.appendChild(el('div', 'log-hits-meta', hits.length + ' match' + (hits.length === 1 ? '' : 'es')));
+      for (const h of hits) {
+        const row = el('div', 'log-hit');
+        row.appendChild(el('span', 'lt', new Date(h.ts).toLocaleTimeString() + '  '));
+        row.appendChild(el('span', 'lg', (h.target || '') + '  '));
+        row.appendChild(document.createTextNode(h.line));
+        results.appendChild(row);
+      }
+    } catch (err) {
+      results.innerHTML = '';
+      results.appendChild(el('div', 'log-hits-meta', 'Search failed: ' + err));
+    }
+  }
+
+  // Pull retained history on (re)connect so the timeline + logs reflect the
+  // whole session, not just events since this page loaded.
+  async function loadHistory() {
+    try {
+      const res = await fetch('/api/history');
+      const data = await res.json();
+      for (const log of (data.logs || [])) {
+        const arr = logsById.get(log.containerId) || [];
+        arr.push(log.line);
+        logsById.set(log.containerId, arr);
+      }
+      for (const inv of (data.invocations || [])) addInvocation(inv);
+    } catch (err) {
+      /* live SSE still drives the timeline; history is best-effort */
+    }
   }
 
   function connect() {
@@ -569,8 +661,10 @@ const STUDIO_SCRIPT = `
   }
 
   loadTargets().then(loadRunning);
+  loadHistory();
   connect();
   initSplitters();
+  wireLogSearch();
 `;
 
 /**
@@ -600,7 +694,12 @@ export function renderStudioHtml(appLabel: string, cliName: string): string {
   <div class="splitter" id="split-left"></div>
   <section class="pane" id="workspace"><div class="empty">Pick a Lambda to invoke, or an API to serve, on the left.</div></section>
   <div class="splitter" id="split-right"></div>
-  <section class="pane" id="timeline"><h2>Timeline</h2><div class="empty">No requests yet.</div></section>
+  <section class="pane" id="timeline">
+    <h2>Timeline</h2>
+    <div class="searchbar"><input id="log-search" type="search" placeholder="Search logs…" autocomplete="off" spellcheck="false" /></div>
+    <div id="timeline-rows"><div class="empty">No requests yet.</div></div>
+    <div id="log-results"></div>
+  </section>
 </main>
 <script>${STUDIO_SCRIPT}</script>
 </body>

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -18,7 +18,10 @@
 #     the served route through it (the served endpoint is the studio
 #     CAPTURE PROXY — slice C2), asserts the request is captured on the
 #     timeline as an `invocation` row, GET /api/running reflects it + a
-#     `serve` SSE event fired, then POST /api/stop tears it down, and
+#     `serve` SSE event fired, then POST /api/stop tears it down,
+#   - asserts the store (slice C3) serves GET /api/history, full-text
+#     GET /api/logs?q=, and per-invocation GET /api/invocations/<id>/logs,
+#     and
 #   - tears the server down cleanly.
 #
 # Docker required — the invoke + serve slices boot real RIE containers.
@@ -190,6 +193,10 @@ for needle in '"ok":true' '"status":200' '"statusCode":200'; do
   fi
   echo "    OK: run response has ${needle}"
 done
+# Capture the Lambda invocation id for the slice-C3 per-invocation log
+# binding assertion below.
+LAMBDA_INV_ID=$(grep -oE '"invocationId":"[^"]+"' "${RUN_FILE}" | head -1 | sed 's/.*"invocationId":"//;s/"//')
+echo "    (lambda invocationId=${LAMBDA_INV_ID})"
 
 echo "==> The invocation was broadcast over SSE"
 # Give the SSE listener a moment to receive the end event, then stop it.
@@ -341,7 +348,47 @@ fi
 echo "    OK: serve stopped; /api/running is empty"
 
 # ---------------------------------------------------------------------------
-# 8. Clean shutdown on SIGTERM.
+# 8. The store (slice C3): history + full-text log search + per-invocation
+#    log binding (decision D5) are served from the retained event window.
+# ---------------------------------------------------------------------------
+echo "==> GET /api/history retains the session's invocations + logs"
+curl -fsS "${URL}/api/history" -o "${BODY_FILE}"
+# Both the Lambda invoke and the captured serve request must be retained.
+if ! grep -qF 'MyHandler' "${BODY_FILE}" || ! grep -qF 'GET /hello' "${BODY_FILE}"; then
+  echo "FAIL: /api/history did not retain the session's invocations"
+  echo "----- history -----"; head -c 2000 "${BODY_FILE}"; echo; echo "-------------------"
+  exit 1
+fi
+echo "    OK: history retains the Lambda invoke + the captured serve request"
+
+echo "==> GET /api/logs?q= full-text searches the retained logs"
+# The serve child prints a stable 'Server listening on ...' line, streamed
+# onto the bus as a log event — search must find it.
+curl -fsS "${URL}/api/logs?q=Server%20listening" -o "${BODY_FILE}"
+if ! grep -qF 'Server listening on' "${BODY_FILE}"; then
+  echo "FAIL: /api/logs search did not find the serve listening line"
+  echo "----- logs -----"; head -c 2000 "${BODY_FILE}"; echo; echo "----------------"
+  exit 1
+fi
+echo "    OK: log search found the serve listening line"
+
+if [[ -n "${LAMBDA_INV_ID}" ]]; then
+  echo "==> GET /api/invocations/<id>/logs binds the Lambda's logs (D5)"
+  curl -fsS "${URL}/api/invocations/${LAMBDA_INV_ID}/logs" -o "${BODY_FILE}"
+  # The fixture handler runs in a RIE container that prints START/REPORT
+  # lines; the strict per-invocation bind must return a non-empty list.
+  if ! grep -qF '"line"' "${BODY_FILE}"; then
+    echo "FAIL: /api/invocations/<id>/logs returned no bound logs"
+    echo "----- bound logs -----"; head -c 2000 "${BODY_FILE}"; echo; echo "----------------------"
+    exit 1
+  fi
+  echo "    OK: the Lambda invocation's logs are bound at per-invocation granularity"
+else
+  echo "    (skipping per-invocation log bind: no invocationId parsed)"
+fi
+
+# ---------------------------------------------------------------------------
+# 9. Clean shutdown on SIGTERM.
 # ---------------------------------------------------------------------------
 echo "==> Stopping studio (SIGTERM) and asserting clean exit"
 kill "${STUDIO_PID}"
@@ -357,4 +404,4 @@ STUDIO_PID=""
 echo "    OK: studio stopped cleanly"
 
 echo ""
-echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + serve start/stop + request capture + shutdown)"
+echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + serve start/stop + request capture + history/log-search + shutdown)"

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -5,6 +5,7 @@ import {
   toStudioTargetGroups,
   type RunningStudioServer,
 } from '../../../src/local/studio-server.js';
+import { createStudioStore } from '../../../src/local/studio-store.js';
 import type { TargetListing } from '../../../src/local/target-lister.js';
 
 const running: RunningStudioServer[] = [];
@@ -310,6 +311,71 @@ describe('startStudioServer', () => {
     expect(res.status).toBe(200);
     const data = (await res.json()) as { running: unknown[] };
     expect(data.running).toEqual([]);
+  });
+
+  it('GET /api/history returns the store snapshot', async () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus);
+    bus.emit('invocation', { id: 'a', ts: 1, target: 'T', kind: 'lambda', label: 'invoke' });
+    bus.emit('log', { ts: 1, containerId: 'a', target: 'T', line: 'hello', stream: 'stdout' });
+    const server = await boot({ bus, store });
+
+    const res = await fetch(`${server.url}/api/history`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { invocations: { id: string }[]; logs: { line: string }[] };
+    expect(data.invocations.map((i) => i.id)).toEqual(['a']);
+    expect(data.logs.map((l) => l.line)).toEqual(['hello']);
+  });
+
+  it('GET /api/history returns empty when no store is wired', async () => {
+    const server = await boot();
+    const res = await fetch(`${server.url}/api/history`);
+    const data = (await res.json()) as { invocations: unknown[]; logs: unknown[] };
+    expect(data).toEqual({ invocations: [], logs: [] });
+  });
+
+  it('GET /api/logs?q= full-text searches the store', async () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus);
+    bus.emit('log', { ts: 1, containerId: 'c', target: 'T', line: 'GET /hello 200', stream: 'stdout' });
+    bus.emit('log', { ts: 2, containerId: 'c', target: 'T', line: 'unrelated', stream: 'stdout' });
+    const server = await boot({ bus, store });
+
+    const res = await fetch(`${server.url}/api/logs?q=${encodeURIComponent('/hello')}`);
+    const data = (await res.json()) as { logs: { line: string }[] };
+    expect(data.logs.map((l) => l.line)).toEqual(['GET /hello 200']);
+  });
+
+  it('GET /api/logs treats a bare target= as no filter (not target==="")', async () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus);
+    bus.emit('log', { ts: 1, containerId: 'c', target: 'T', line: 'kept', stream: 'stdout' });
+    const server = await boot({ bus, store });
+
+    // A bare `target=` must NOT filter to logs whose target is the empty string.
+    const res = await fetch(`${server.url}/api/logs?q=kept&target=`);
+    const data = (await res.json()) as { logs: { line: string }[] };
+    expect(data.logs.map((l) => l.line)).toEqual(['kept']);
+  });
+
+  it('GET /api/invocations/<id>/logs binds a Lambda invocation by container id', async () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus);
+    bus.emit('invocation', { id: 'inv-9', ts: 1, target: 'T', kind: 'lambda', label: 'invoke' });
+    bus.emit('log', { ts: 1, containerId: 'inv-9', target: 'T', line: 'mine', stream: 'stdout' });
+    bus.emit('log', { ts: 1, containerId: 'other', target: 'T', line: 'theirs', stream: 'stdout' });
+    const server = await boot({ bus, store });
+
+    const res = await fetch(`${server.url}/api/invocations/inv-9/logs`);
+    const data = (await res.json()) as { logs: { line: string }[] };
+    expect(data.logs.map((l) => l.line)).toEqual(['mine']);
+  });
+
+  it('GET /api/logs returns empty when no store is wired', async () => {
+    const server = await boot();
+    const res = await fetch(`${server.url}/api/logs?q=anything`);
+    const data = (await res.json()) as { logs: unknown[] };
+    expect(data.logs).toEqual([]);
   });
 
   it('streams an emitted serve event over the SSE channel', async () => {

--- a/tests/unit/local/studio-store.test.ts
+++ b/tests/unit/local/studio-store.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  StudioEventBus,
+  type StudioInvocationEvent,
+  type StudioLogEvent,
+} from '../../../src/local/studio-events.js';
+import { createStudioStore } from '../../../src/local/studio-store.js';
+
+function inv(over: Partial<StudioInvocationEvent> & { id: string }): StudioInvocationEvent {
+  return {
+    ts: 1000,
+    target: 'Stack/Fn',
+    kind: 'lambda',
+    label: 'invoke',
+    ...over,
+  };
+}
+
+function log(over: Partial<StudioLogEvent> & { line: string }): StudioLogEvent {
+  return {
+    ts: 1000,
+    containerId: 'c1',
+    target: 'Stack/Fn',
+    stream: 'stdout',
+    ...over,
+  };
+}
+
+describe('createStudioStore', () => {
+  it('records invocations + logs from the bus and returns them oldest-first', () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus);
+
+    bus.emit('invocation', inv({ id: 'a', ts: 1 }));
+    bus.emit('invocation', inv({ id: 'b', ts: 2 }));
+    bus.emit('log', log({ line: 'one', ts: 1 }));
+    bus.emit('log', log({ line: 'two', ts: 2 }));
+
+    const h = store.history();
+    expect(h.invocations.map((i) => i.id)).toEqual(['a', 'b']);
+    expect(h.logs.map((l) => l.line)).toEqual(['one', 'two']);
+  });
+
+  it('merges the start/end pair of an invocation into one entry, keeping order', () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus);
+
+    bus.emit('invocation', inv({ id: 'x', ts: 5 })); // start
+    bus.emit('invocation', inv({ id: 'y', ts: 6 }));
+    bus.emit('invocation', inv({ id: 'x', ts: 5, status: 200, durationMs: 12 })); // end
+
+    const h = store.history();
+    expect(h.invocations.map((i) => i.id)).toEqual(['x', 'y']); // x kept its slot
+    expect(store.invocation('x')?.status).toBe(200);
+    expect(store.invocation('x')?.durationMs).toBe(12);
+  });
+
+  it('evicts the oldest invocations past maxInvocations', () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus, { maxInvocations: 2 });
+
+    bus.emit('invocation', inv({ id: 'a' }));
+    bus.emit('invocation', inv({ id: 'b' }));
+    bus.emit('invocation', inv({ id: 'c' }));
+
+    expect(store.history().invocations.map((i) => i.id)).toEqual(['b', 'c']);
+    expect(store.invocation('a')).toBeUndefined();
+  });
+
+  it('evicts the oldest logs past maxLogs', () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus, { maxLogs: 2 });
+
+    bus.emit('log', log({ line: '1' }));
+    bus.emit('log', log({ line: '2' }));
+    bus.emit('log', log({ line: '3' }));
+
+    expect(store.history().logs.map((l) => l.line)).toEqual(['2', '3']);
+  });
+
+  it('retains EXACTLY maxLogs / maxInvocations at the boundary (no premature eviction, G2)', () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus, { maxLogs: 3, maxInvocations: 2 });
+
+    bus.emit('log', log({ line: '1' }));
+    bus.emit('log', log({ line: '2' }));
+    bus.emit('log', log({ line: '3' })); // exactly at cap — none evicted
+    bus.emit('invocation', inv({ id: 'a' }));
+    bus.emit('invocation', inv({ id: 'b' })); // exactly at cap
+
+    expect(store.history().logs.map((l) => l.line)).toEqual(['1', '2', '3']);
+    expect(store.history().invocations.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  describe('searchLogs', () => {
+    it('matches a case-insensitive substring, newest-first', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus);
+      bus.emit('log', log({ line: 'GET /hello 200', ts: 1 }));
+      bus.emit('log', log({ line: 'Server LISTENING on http://x', ts: 2 }));
+      bus.emit('log', log({ line: 'unrelated', ts: 3 }));
+
+      const hits = store.searchLogs('listening');
+      expect(hits.map((l) => l.line)).toEqual(['Server LISTENING on http://x']);
+    });
+
+    it('restricts to a target and honors the limit', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus);
+      bus.emit('log', log({ line: 'hit a', target: 'A', ts: 1 }));
+      bus.emit('log', log({ line: 'hit b', target: 'B', ts: 2 }));
+      bus.emit('log', log({ line: 'hit a2', target: 'A', ts: 3 }));
+
+      expect(store.searchLogs('hit', { target: 'A' }).map((l) => l.line)).toEqual([
+        'hit a2',
+        'hit a',
+      ]);
+      expect(store.searchLogs('hit', { limit: 1 })).toHaveLength(1);
+    });
+
+    it('an empty query returns the most recent lines (no filter)', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus);
+      bus.emit('log', log({ line: 'a', ts: 1 }));
+      bus.emit('log', log({ line: 'b', ts: 2 }));
+      expect(store.searchLogs('').map((l) => l.line)).toEqual(['b', 'a']);
+    });
+  });
+
+  describe('logsForInvocation (D5 binding)', () => {
+    it('binds a Lambda invocation STRICTLY by container id', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus);
+      bus.emit('invocation', inv({ id: 'inv-1', kind: 'lambda', ts: 100 }));
+      bus.emit('log', log({ line: 'mine', containerId: 'inv-1', ts: 100 }));
+      bus.emit('log', log({ line: 'other', containerId: 'inv-2', ts: 100 }));
+
+      expect(store.logsForInvocation('inv-1').map((l) => l.line)).toEqual(['mine']);
+    });
+
+    it('binds a captured serve request best-effort by target + time window', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus, { bindGraceMs: 50 });
+      // A served request from ts=200 lasting 100ms, against the serve target.
+      bus.emit('invocation', inv({ id: 'req-1', kind: 'api', target: 'Stack/Api', ts: 200, durationMs: 100 }));
+      // Serve logs are keyed to the long-running serve (containerId=target).
+      bus.emit('log', log({ line: 'before', containerId: 'Stack/Api', target: 'Stack/Api', ts: 150 }));
+      bus.emit('log', log({ line: 'during', containerId: 'Stack/Api', target: 'Stack/Api', ts: 250 }));
+      bus.emit('log', log({ line: 'within-grace', containerId: 'Stack/Api', target: 'Stack/Api', ts: 330 }));
+      bus.emit('log', log({ line: 'after', containerId: 'Stack/Api', target: 'Stack/Api', ts: 400 }));
+      bus.emit('log', log({ line: 'other-target', containerId: 'Stack/Other', target: 'Stack/Other', ts: 250 }));
+
+      const bound = store.logsForInvocation('req-1').map((l) => l.line);
+      expect(bound).toEqual(['during', 'within-grace']); // [200, 200+100+50]
+    });
+
+    it('binds a zero-log Lambda to [] and NEVER borrows another invocation logs (G1)', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus, { bindGraceMs: 50 });
+      // A Lambda that emitted no logs of its own...
+      bus.emit('invocation', inv({ id: 'inv-empty', kind: 'lambda', target: 'Stack/Fn', ts: 100, durationMs: 100 }));
+      // ...with a DIFFERENT invocation's log of the SAME function inside its
+      // time window. The kind-based bind must NOT fall back to the window.
+      bus.emit('log', log({ line: 'other-inv', containerId: 'inv-other', target: 'Stack/Fn', ts: 150 }));
+      expect(store.logsForInvocation('inv-empty')).toEqual([]);
+    });
+
+    it('the serve time-window bind is INCLUSIVE at exactly from and to (G3)', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus, { bindGraceMs: 50 });
+      // window = [200, 200+100+50] = [200, 350]
+      bus.emit('invocation', inv({ id: 'req', kind: 'api', target: 'Stack/Api', ts: 200, durationMs: 100 }));
+      const at = (line: string, ts: number) =>
+        bus.emit('log', log({ line, containerId: 'Stack/Api', target: 'Stack/Api', ts }));
+      at('just-before', 199);
+      at('at-from', 200);
+      at('at-to', 350);
+      at('just-after', 351);
+      expect(store.logsForInvocation('req').map((l) => l.line)).toEqual(['at-from', 'at-to']);
+    });
+
+    it('a serve request with no durationMs uses a [ts, ts+grace] window (G4)', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus, { bindGraceMs: 50 });
+      bus.emit('invocation', inv({ id: 'req', kind: 'api', target: 'Stack/Api', ts: 200 })); // no durationMs
+      bus.emit('log', log({ line: 'in', containerId: 'Stack/Api', target: 'Stack/Api', ts: 230 })); // <= 250
+      bus.emit('log', log({ line: 'out', containerId: 'Stack/Api', target: 'Stack/Api', ts: 260 })); // > 250
+      expect(store.logsForInvocation('req').map((l) => l.line)).toEqual(['in']);
+    });
+
+    it('returns [] for an unknown invocation', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus);
+      expect(store.logsForInvocation('nope')).toEqual([]);
+    });
+  });
+
+  it('dispose() unsubscribes from the bus', () => {
+    const bus = new StudioEventBus();
+    const store = createStudioStore(bus);
+    expect(bus.listenerCount('invocation')).toBe(1);
+    expect(bus.listenerCount('log')).toBe(1);
+
+    store.dispose();
+    expect(bus.listenerCount('invocation')).toBe(0);
+    expect(bus.listenerCount('log')).toBe(0);
+
+    // No further recording after dispose.
+    bus.emit('log', log({ line: 'late' }));
+    expect(store.history().logs).toEqual([]);
+  });
+});

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -11,6 +11,11 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('id="targets"');
     expect(html).toContain('id="workspace"');
     expect(html).toContain('id="timeline"');
+    // Slice C3: the log search box + history/search wiring are present.
+    expect(html).toContain('id="log-search"');
+    expect(html).toContain('/api/logs?q=');
+    expect(html).toContain('/api/history');
+    expect(html).toContain('/api/invocations/');
   });
 
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {


### PR DESCRIPTION
## Summary

Slice **C3** of `cdkl studio` (Phase 1, part of #282): give the console a
memory. An in-memory event store retains a bounded window of every
invocation + log line, so studio can render the whole session on
(re)connect, search logs full-text across it, and show a request's logs
bound at CloudWatch granularity (decision D5) — not just the events since
the page loaded. Still behind `CDKL_STUDIO_PREVIEW=1`.

### Changes

- `src/local/studio-store.ts` (new): subscribes to the event bus, keeps a
  newest-wins ring of invocations (start/end merged by id) + log lines.
  `history()`, `searchLogs(q, {target, limit})`, `logsForInvocation(id)`,
  `invocation(id)`, `dispose()`.
- `src/local/studio-server.ts`: `GET /api/history`,
  `GET /api/logs?q=&target=`, `GET /api/invocations/<id>/logs` — all
  store-backed, all empty when no store is wired.
- `src/cli/commands/local-studio.ts`: creates the store, passes it to the
  server, and disposes it on shutdown.
- `src/local/studio-ui.ts`: a log search box (a query shows matching log
  lines instead of the timeline rows; clearing restores them); a captured
  request's detail fetches + shows its bound logs; the timeline loads
  `/api/history` on connect.
- `src/internal.ts`: re-export `createStudioStore`.

### D5 binding

A Lambda binds STRICTLY by container id (the dispatcher keys each line to
the invocation) — even when it emitted zero logs (an empty result is
correct). A captured serve request binds best-effort by the request's
target + `[ts, ts + duration + grace]` time window (its logs are keyed to
the long-running serve, not the request — the same per-request-within-a-
task limitation AWS has).

## Test plan

- **Unit** (2287 pass): store record / start-end merge / oldest-wins
  eviction incl. the exact-at-cap boundary, full-text search (case /
  target / limit / empty), D5 binding for Lambda-strict + serve-window
  incl. inclusivity at exactly `[from, to]`, the zero-log-Lambda-binds-to-
  `[]` case, the no-`durationMs` window, dispose; the four server
  endpoints incl. bare-`target=`-is-no-filter + empty-when-no-store.
- **Integration** (real Docker): after a Lambda invoke + a captured serve
  request, asserts `GET /api/history` retains both, `GET /api/logs?q=Server
  listening` finds the serve listening line, and `GET
  /api/invocations/<lambda-id>/logs` binds the Lambda's container logs —
  then tears down with zero leftover containers.
- **Live-tested** end-to-end against the fixture.

### Review-fix note

A 3-axis review of this slice caught a real correctness bug — a zero-log
Lambda invocation fell into the serve time-window branch and surfaced a
different invocation's logs; fixed by binding on kind, not on whether the
strict filter matched. Also fixed: a bare `target=` now means "no filter",
and the store is disposed on shutdown.

Accepted as a known cost: `GET /api/logs` does not thread a `limit` param
(the store's 200-cap is the only bound; the UI does not page yet).

## cdkd parity

studio stays `CDKL_STUDIO_PREVIEW`-gated and is NOT exported from
`src/index.ts`, so cdkd cannot embed it yet — the new endpoints are purely
additive, no host-observable behavior change on the stable surface.
`createStudioStore` is re-exported from `cdk-local/internal` (unstable, no
semver) with host-use JSDoc.

Part of #282.
