### PR TITLE
feat(studio): Phase 1 serve-kinds — start/stop + capture for ALB and ECS service (#282)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -299,8 +299,10 @@ compute-locally category for Lambda + API Gateway).
   collision-bumps the port),
   studio-ui (the framework-free web UI embedded as a string so it ships
   inside the npm package with no asset-copy build step; 3-pane: targets /
-  workspace composer / timeline; Lambdas get an [Invoke] composer, APIs a
-  [Start]/[Stop] serve control with a `running ● :port` indicator; the
+  workspace composer / timeline; Lambdas get an [Invoke] composer, serve
+  targets (api / alb / ecs) a [Start]/[Stop] control with a `running ●
+  :port` indicator (ecs services show `running` with no port — only the
+  servable ECS *services* are runnable, not the task definitions); the
   timeline carries both Lambda invocations and captured serve requests,
   the latter opening a read-only Request/Response detail; a log search box
   queries the store and a captured request's detail shows its bound logs),
@@ -310,14 +312,18 @@ compute-locally category for Lambda + API Gateway).
   spawning the SAME `cdkl invoke` the headless command runs as a child
   process — studio is a control plane over the CLI — streaming its
   stdout/stderr to the event bus and returning the parsed Lambda
-  response), studio-serve-manager (issue #282, slice C1 — the
-  long-running serve lifecycle for the `api` kind: spawns
-  `cdkl start-api <target> --port 0` as a managed child, resolves
-  running on the first `Server listening on <url>` line, tracks the
-  running set for `/api/running`, streams container logs onto the bus,
-  and SIGTERMs the child on `/api/stop` / studio shutdown; slice C2
-  fronts each HTTP serve endpoint with a studio-proxy so the
-  `endpoints` handed to the UI are the proxy URLs), studio-proxy
+  response), studio-serve-manager (issue #282 — the
+  long-running serve lifecycle, parameterized by a per-kind
+  `ServeKindSpec`: `api` (`start-api`) + `alb` (`start-alb`) expose host
+  HTTP endpoints each fronted by a studio-proxy so the `endpoints` handed
+  to the UI are the proxy URLs (slice C2 capture), while `ecs`
+  (`start-service`) is pure compute — no host port, no capture, just the
+  running replicas + their streamed logs. Resolves running on the kind's
+  ready line (`Server listening on <url>` / `ALB front-door: <url>` /
+  `Service(s) running:`), tracks the running set for `/api/running`, and
+  SIGTERMs the child on `/api/stop` / studio shutdown with a generous
+  grace so the serve command's OWN ECS-replica + docker-network teardown
+  completes before any SIGKILL), studio-proxy
   (issue #282, slice C2 — a capturing reverse proxy in front of each
   HTTP serve endpoint: forwards every request verbatim to the upstream
   `start-api` child while emitting `invocation` start/end events

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -149,6 +149,16 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   const targetGroups = toStudioTargetGroups(listing);
   const appLabel = stacks.map((s) => s.stackName).join(', ') || appCmd;
 
+  // ECS target ids that are actually servable (services, not task
+  // definitions). The UI only wires servable rows, but a raw curl could
+  // POST a task-def with kind:'ecs' — reject it at the boundary with a
+  // clear message rather than spawning a doomed `start-service`.
+  const servableEcs = new Set(
+    targetGroups
+      .filter((g) => g.kind === 'ecs')
+      .flatMap((g) => g.entries.filter((e) => e.servable).map((e) => e.id))
+  );
+
   const bus = new StudioEventBus();
   // `process.argv[1]` is the running CLI entry (`dist/cli.js` / the `cdkl`
   // bin); both the invoke dispatcher and the serve manager spawn it again
@@ -178,12 +188,19 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     appLabel,
     cliName: getEmbedConfig().cliName,
     store,
-    // `/api/run`: a Lambda is a single-shot invoke; everything else is a
-    // long-running serve start (slice C1 supports the `api` kind, the
-    // serve manager rejects the rest with a clear message).
+    // `/api/run`: a Lambda is a single-shot invoke; api / alb / ecs are
+    // long-running serve starts (the serve manager rejects any other kind).
     onRun: (body) => {
       const req = coerceRunRequest(body);
-      return req.kind === 'lambda' ? dispatcher.run(req) : serveManager.start(req);
+      if (req.kind === 'lambda') return dispatcher.run(req);
+      if (req.kind === 'ecs' && !servableEcs.has(req.targetId)) {
+        return Promise.reject(
+          new Error(
+            `'${req.targetId}' is not a servable ECS service (an ECS task definition runs via run-task, not start-service).`
+          )
+        );
+      }
+      return serveManager.start(req);
     },
     onStop: async (body) => {
       const req = coerceStopRequest(body);

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -10,7 +10,7 @@ import {
 export interface StudioServeRequest {
   /** Target id the user picked (display path or stack-qualified id). */
   targetId: string;
-  /** Target kind. Slice C1 supports `'api'` (long-running `start-api`) only. */
+  /** Target kind — a serve kind (`api` / `alb` / `ecs`); see SERVE_SPECS. */
   kind: StudioTargetKind;
 }
 
@@ -66,7 +66,11 @@ export interface StudioServeManagerConfig {
   readyTimeoutMs?: number;
   /**
    * Ms to wait for a SIGTERM'd child to exit before sending SIGKILL.
-   * Defaults to 10_000.
+   * Generous by default so a serve command running its OWN teardown
+   * completes first — `start-alb` / `start-service` drain + remove their
+   * ECS replicas + the shared docker network, which can take well over
+   * 10s; a premature SIGKILL would orphan those containers/network.
+   * Defaults to 45_000.
    */
   stopGraceMs?: number;
   /** `setTimeout` (injectable for tests). */
@@ -100,11 +104,55 @@ export interface StudioServeManager {
   stopAll: () => Promise<void>;
 }
 
-/** Kinds the serve manager can start in this build. */
-const SERVE_SUPPORTED: readonly StudioTargetKind[] = ['api'];
+/** How the serve manager drives one long-running serve kind. */
+interface ServeKindSpec {
+  /** Headless subcommand spawned (e.g. `start-api`). */
+  command: string;
+  /** Port / host flags this command accepts (start-api binds an HTTP port). */
+  portArgs: readonly string[];
+  /**
+   * The stdout line that signals readiness. Capture group 1, when present,
+   * is the served endpoint URL (api / alb); a kind with no host endpoint
+   * (ecs service — pure compute) matches with NO capture group.
+   */
+  readyRe: RegExp;
+  /** Front each HTTP endpoint with a capture proxy (api / alb yes, ecs no). */
+  capturesHttp: boolean;
+}
 
-/** `Server listening on <url>` is the stable ready marker `start-api` prints. */
-const LISTENING_RE = /Server listening on (\S+)/;
+/**
+ * The serve lifecycle per kind. `api` + `alb` expose host HTTP endpoints
+ * the studio capture proxy fronts; `ecs` (start-service) is pure compute
+ * with no host port, so it has no endpoint and no capture — studio just
+ * runs the replicas + streams their logs.
+ */
+const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
+  api: {
+    command: 'start-api',
+    portArgs: ['--port', '0', '--host', '127.0.0.1'],
+    readyRe: /Server listening on (\S+)/,
+    capturesHttp: true,
+  },
+  alb: {
+    // start-alb binds the deployed listener ports directly (no --port);
+    // its front-door line carries the bound URL. Anchor the capture on a
+    // URL scheme: under --tls start-alb also logs `ALB front-door:
+    // generated self-signed cert at ...`, which a bare `(\S+)` would match
+    // (capturing `generated`) and flip the serve to running prematurely.
+    command: 'start-alb',
+    portArgs: [],
+    readyRe: /ALB front-door: (https?:\/\/\S+)/,
+    capturesHttp: true,
+  },
+  ecs: {
+    // start-service runs the service replicas only — no host port, no
+    // capture. `Service(s) running:` is its stable ready marker.
+    command: 'start-service',
+    portArgs: [],
+    readyRe: /Service\(s\) running:/,
+    capturesHttp: false,
+  },
+};
 
 interface ServeEntry extends StudioServeState {
   child: ChildProcessWithoutNullStreams;
@@ -137,15 +185,18 @@ interface ServeEntry extends StudioServeState {
  * Slice C2 fronts each HTTP serve endpoint with a capture proxy
  * ({@link startStudioProxy}) so every request to the served port lands
  * on the studio timeline (decision D4a); the `endpoints` the UI is
- * handed are the proxy URLs. Full-text log search and alb / ecs serve
- * kinds are still to come.
+ * handed are the proxy URLs. The serve-kinds slice generalized this to a
+ * per-kind {@link ServeKindSpec}: `api` (`start-api`) + `alb`
+ * (`start-alb`) expose host HTTP endpoints the proxy captures, while
+ * `ecs` (`start-service`) is pure compute — no host port, no capture,
+ * just the running replicas + their streamed logs.
  */
 export function createStudioServeManager(config: StudioServeManagerConfig): StudioServeManager {
   const spawnFn = config.spawnFn ?? nodeSpawn;
   const nodeBin = config.nodeBin ?? process.execPath;
   const clock = config.clock ?? Date.now;
   const readyTimeoutMs = config.readyTimeoutMs ?? 120_000;
-  const stopGraceMs = config.stopGraceMs ?? 10_000;
+  const stopGraceMs = config.stopGraceMs ?? 45_000;
   const setTimeoutFn = config.setTimeoutFn ?? setTimeout;
   const clearTimeoutFn = config.clearTimeoutFn ?? clearTimeout;
   const cwd = config.cwd ?? process.cwd();
@@ -185,8 +236,8 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
     config.bus.emit('serve', ev);
   }
 
-  function buildArgs(targetId: string): string[] {
-    const args = ['start-api', targetId, '--port', '0', '--host', '127.0.0.1'];
+  function buildArgs(targetId: string, spec: ServeKindSpec): string[] {
+    const args = [spec.command, targetId, ...spec.portArgs];
     if (config.app) args.push('--app', config.app);
     if (config.profile) args.push('--profile', config.profile);
     if (config.region) args.push('--region', config.region);
@@ -197,9 +248,10 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
   }
 
   async function start(req: StudioServeRequest): Promise<StudioServeState> {
-    if (!SERVE_SUPPORTED.includes(req.kind)) {
+    const spec = SERVE_SPECS[req.kind];
+    if (!spec) {
       throw new Error(
-        `Serving '${req.kind}' targets from studio is not supported yet (API only in this build).`
+        `Serving '${req.kind}' targets from studio is not supported (serve kinds: ${Object.keys(SERVE_SPECS).join(', ')}).`
       );
     }
     const existing = entries.get(req.targetId);
@@ -210,7 +262,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
     const startedAt = clock();
     let child: ChildProcessWithoutNullStreams;
     try {
-      child = spawnFn(nodeBin, [config.cliEntry, ...buildArgs(req.targetId)], { cwd });
+      child = spawnFn(nodeBin, [config.cliEntry, ...buildArgs(req.targetId, spec)], { cwd });
     } catch (err) {
       throw err instanceof Error ? err : new Error(String(err));
     }
@@ -237,10 +289,10 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         if (settled) return;
         settled = true;
         entry.status = 'error';
-        emitServe(entry, `Timed out after ${readyTimeoutMs}ms waiting for the server to listen.`);
-        // Graceful SIGTERM -> SIGKILL (NOT an immediate SIGKILL): `start-api`
-        // traps SIGTERM to tear down its RIE containers, so a hard kill on a
-        // half-booted child would orphan those containers.
+        emitServe(entry, `Timed out after ${readyTimeoutMs}ms waiting for the serve to be ready.`);
+        // Graceful SIGTERM -> SIGKILL (NOT an immediate SIGKILL): the serve
+        // commands trap SIGTERM to tear down their containers, so a hard kill
+        // on a half-booted child would orphan those containers.
         void stopChild(child, stopGraceMs, setTimeoutFn, clearTimeoutFn);
         void closeProxies(entry);
         entries.delete(req.targetId);
@@ -257,15 +309,16 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         resolve(publicState(entry));
       };
 
-      // Resolve a child `Server listening on <childUrl>` line into the
-      // endpoint the UI is handed: an HTTP endpoint is fronted with a
-      // capture proxy (slice C2 / decision D4a) so every request to it
-      // lands on the timeline; ws:// (and capture-off) endpoints pass the
-      // child URL straight through. The FIRST resolved endpoint flips the
-      // serve to running; later ones append + re-emit.
-      const onListening = async (childUrl: string): Promise<void> => {
+      // Handle a child ready line. `childUrl` (capture group 1) is the
+      // served endpoint for api / alb — fronted with a capture proxy (slice
+      // C2 / decision D4a) when `capturesHttp` so every request to it lands
+      // on the timeline; ws:// (and capture-off) endpoints pass straight
+      // through. An ecs service has NO endpoint (`childUrl` undefined): it
+      // just flips to running with no endpoint + no proxy. The FIRST ready
+      // line flips the serve to running; later ones append + re-emit.
+      const onReady = async (childUrl?: string): Promise<void> => {
         let endpoint = childUrl;
-        if (captureRequests && /^https?:/i.test(childUrl)) {
+        if (childUrl && spec.capturesHttp && captureRequests && /^https?:/i.test(childUrl)) {
           try {
             const proxy = await proxyFactory({
               bus: config.bus,
@@ -287,14 +340,16 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
           await closeProxies(entry);
           return;
         }
-        if (!entry.endpoints.includes(endpoint)) entry.endpoints.push(endpoint);
+        if (endpoint && !entry.endpoints.includes(endpoint)) entry.endpoints.push(endpoint);
         if (settled) emitServe(entry);
         else becomeRunning();
       };
 
       streamLines(child.stdout, (line) => {
-        const m = LISTENING_RE.exec(line);
-        if (m?.[1]) void onListening(m[1]);
+        const m = spec.readyRe.exec(line);
+        // m[1] is the endpoint URL for api / alb; undefined for ecs (no
+        // capture group) — a ready line with no host endpoint.
+        if (m) void onReady(m[1]);
         emitLog(config.bus, clock, req.targetId, line, 'stdout');
       });
       streamLines(child.stderr, (line) => {

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -18,6 +18,13 @@ export interface StudioTarget {
   qualifiedId: string;
   /** API surface kind (REST v1 / HTTP v2 / ...), only for `api` entries. */
   surface?: string;
+  /**
+   * Within a kind whose entries are not uniformly runnable, marks the ones
+   * that are. Used for the `ecs` group, which folds servable ECS *services*
+   * (`start-service`) together with ECS *task definitions* (run-task, not a
+   * serve target): only services carry `servable: true`.
+   */
+  servable?: boolean;
 }
 
 /** A category of targets, grouped by the studio kind that runs them. */
@@ -37,10 +44,14 @@ export interface StudioTargetGroup {
  * projection without booting the server.
  */
 export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[] {
-  const map = (entries: TargetListing['lambdas']): StudioTarget[] =>
+  const map = (
+    entries: TargetListing['lambdas'],
+    opts: { servable?: boolean } = {}
+  ): StudioTarget[] =>
     entries.map((e) => {
       const t: StudioTarget = { id: e.displayPath ?? e.qualifiedId, qualifiedId: e.qualifiedId };
       if (e.kind) t.surface = e.kind;
+      if (opts.servable !== undefined) t.servable = opts.servable;
       return t;
     });
   return [
@@ -49,7 +60,12 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
     {
       kind: 'ecs',
       title: 'ECS Services / Tasks',
-      entries: [...map(listing.ecsServices), ...map(listing.ecsTaskDefinitions)],
+      // ECS services are servable (`start-service`); task definitions are
+      // run-task (single-shot), not a serve target.
+      entries: [
+        ...map(listing.ecsServices, { servable: true }),
+        ...map(listing.ecsTaskDefinitions, { servable: false }),
+      ],
     },
     { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
     { kind: 'alb', title: 'Load Balancers', entries: map(listing.loadBalancers) },

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -123,6 +123,7 @@ const STUDIO_CSS = `
 
 const STUDIO_SCRIPT = `
   const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', agentcore: 'AgentCore' };
+  const SERVE_KINDS = ['api', 'alb', 'ecs']; // long-running serve targets
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event
   const logsById = new Map();      // invocationId / serve targetId -> [log lines]
@@ -153,10 +154,11 @@ const STUDIO_SCRIPT = `
         pane.appendChild(el('div', 'group-title', group.title));
         for (const entry of group.entries) {
           total += 1;
-          // Lambda targets are single-shot invokes; API targets are
-          // long-running serves (slice C1). Other kinds list but are not
-          // yet runnable.
-          const runnable = group.kind === 'lambda' || group.kind === 'api';
+          // Lambda targets are single-shot invokes; api / alb / ecs are
+          // long-running serves. Other kinds list but are not yet runnable.
+          // Within ecs, only services are servable (task defs are run-task).
+          const isServe = SERVE_KINDS.includes(group.kind) && (group.kind !== 'ecs' || entry.servable === true);
+          const runnable = group.kind === 'lambda' || isServe;
           const t = el('div', runnable ? 'target runnable' : 'target');
           const name = el('span', 'name', entry.id);
           name.title = entry.id; // full path on hover even when truncated
@@ -168,16 +170,16 @@ const STUDIO_SCRIPT = `
             t.appendChild(btn);
             t.onclick = () => selectTarget(entry.id, 'lambda');
             targetEls.set(entry.id, t);
-          } else if (group.kind === 'api') {
+          } else if (isServe) {
             // A serve target: a running-state dot + a Start/Stop button
             // slot, both refreshed by updateServeRow on serve events.
             const dot = el('span', 'run-dot');
             const btnSlot = el('span', 'btn-slot');
             t.appendChild(dot);
             t.appendChild(btnSlot);
-            t.onclick = () => selectTarget(entry.id, 'api');
+            t.onclick = () => selectTarget(entry.id, group.kind);
             targetEls.set(entry.id, t);
-            serveMeta.set(entry.id, { dot, btnSlot });
+            serveMeta.set(entry.id, { dot, btnSlot, kind: group.kind });
             updateServeRow(entry.id);
           }
           pane.appendChild(t);
@@ -218,7 +220,10 @@ const STUDIO_SCRIPT = `
     const status = st ? st.status : 'stopped';
     const running = status === 'running';
     const starting = status === 'starting';
-    meta.dot.textContent = running ? '● ' + firstPort(st.endpoints) : starting ? '○ starting' : '';
+    // A serve with a host endpoint shows the dot + :port; a pure-compute
+    // ecs service has no endpoint, so just the dot + running.
+    const port = running ? firstPort(st.endpoints) : '';
+    meta.dot.textContent = running ? (port ? '● ' + port : '● running') : starting ? '○ starting' : '';
     meta.dot.className = 'run-dot' + (starting ? ' starting' : '');
     meta.btnSlot.innerHTML = '';
     const btn = running || starting
@@ -242,7 +247,7 @@ const STUDIO_SCRIPT = `
   function selectTarget(id, kind) {
     highlightTarget(id);
     shownDetailId = null;
-    if (kind === 'api') {
+    if (SERVE_KINDS.includes(kind)) {
       shownServeId = id;
       shownInvId = null;
       active = null;
@@ -254,13 +259,17 @@ const STUDIO_SCRIPT = `
   }
 
   async function startServe(id) {
+    // The serve kind (api / alb / ecs) drives which headless command the
+    // server spawns; it is recorded on the row when the target list loads.
+    const meta = serveMeta.get(id);
+    const kind = meta ? meta.kind : 'api';
     serveState.set(id, { status: 'starting', endpoints: [] });
     updateServeRow(id);
     try {
       const res = await fetch('/api/run', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ targetId: id, kind: 'api' }),
+        body: JSON.stringify({ targetId: id, kind }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -310,6 +319,8 @@ const STUDIO_SCRIPT = `
     }
     ws.appendChild(head);
 
+    const meta = serveMeta.get(id);
+    const isEcs = meta && meta.kind === 'ecs';
     const epSec = el('div', 'section');
     epSec.appendChild(el('h3', null, 'Endpoints'));
     if (running && st.endpoints.length) {
@@ -317,6 +328,10 @@ const STUDIO_SCRIPT = `
         const link = href(url);
         epSec.appendChild(link);
       }
+    } else if (running && isEcs) {
+      // A pure-compute ECS service has no host endpoint — it just runs the
+      // replicas (reach them container-to-container via Cloud Map).
+      epSec.appendChild(el('pre', null, '(running — pure compute service, no host endpoint)'));
     } else {
       epSec.appendChild(el('pre', null, starting ? '(starting…)' : '(not running)'));
     }

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -76,12 +76,18 @@ export class LocalStudioStack extends cdk.Stack {
           image: 'public.ecr.aws/docker/library/python:3.12-alpine',
           essential: true,
           memoryReservation: 32,
+          // Serve HTTP on the container port so the studio ALB serve has a
+          // live upstream AND the service stays running (a long-running
+          // command — the image's default `python3` REPL would exit at once).
+          command: ['python', '-m', 'http.server', '80'],
           portMappings: [{ containerPort: 80, protocol: 'tcp' }],
         },
       ],
     });
 
-    // Target group + listener + ALB fronting the ECS service.
+    // Target group + listener + ALB fronting the ECS service. The listener
+    // is on a high (non-privileged) port so the studio ALB serve binds it
+    // locally without root and without a port remap.
     const targetGroup = new elbv2.CfnTargetGroup(this, 'MyTargetGroup', {
       port: 80,
       protocol: 'HTTP',
@@ -92,7 +98,7 @@ export class LocalStudioStack extends cdk.Stack {
     });
     new elbv2.CfnListener(this, 'MyListener', {
       loadBalancerArn: alb.ref,
-      port: 80,
+      port: 8080,
       protocol: 'HTTP',
       defaultActions: [{ type: 'forward', targetGroupArn: targetGroup.ref }],
     });

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -21,7 +21,10 @@
 #     `serve` SSE event fired, then POST /api/stop tears it down,
 #   - asserts the store (slice C3) serves GET /api/history, full-text
 #     GET /api/logs?q=, and per-invocation GET /api/invocations/<id>/logs,
-#     and
+#   - starts an ALB serve (`start-alb`), curls the front-door through the
+#     studio capture proxy + asserts the request is captured (kind=alb),
+#     and an ECS service serve (`start-service`) that runs pure compute
+#     with NO host endpoint (serve-kinds slice), and
 #   - tears the server down cleanly.
 #
 # Docker required — the invoke + serve slices boot real RIE containers.
@@ -388,7 +391,117 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 9. Clean shutdown on SIGTERM.
+# 9. ALB serve (serve-kinds): start `start-alb` behind studio, capture a
+#    request through the front-door proxy. The fixture ECS container serves
+#    HTTP and the listener is on 8080 (bindable without root).
+# ---------------------------------------------------------------------------
+echo "==> /api/targets marks the ECS service servable, the task definition not"
+curl -fsS "${URL}/api/targets" -o "${BODY_FILE}"
+if ! grep -qF '"MyService"' "${BODY_FILE}" && ! grep -qF 'MyService' "${BODY_FILE}"; then
+  echo "FAIL: /api/targets missing the ECS service"; cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: ecs service is listed (servable), task definition listed (not servable)"
+
+ALB_TARGET="LocalStudioFixture/MyAlb"
+echo "==> POST /api/run starts an ALB serve (boots the ECS service + front-door)"
+# Re-arm the SSE listener to capture the ALB request invocation.
+: >"${SSE_FILE}"
+curl -sN --max-time 240 "${URL}/api/events" >"${SSE_FILE}" 2>/dev/null &
+SSE_PID=$!
+sleep 1
+
+ALB_FILE=$(mktemp)
+HTTP_CODE=$(curl -s -o "${ALB_FILE}" -w '%{http_code}' --max-time 180 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ALB_TARGET}\",\"kind\":\"alb\"}" || true)
+if [[ "${HTTP_CODE}" != "200" ]] || ! grep -qF '"status":"running"' "${ALB_FILE}"; then
+  echo "FAIL: POST /api/run (alb) returned HTTP ${HTTP_CODE}"
+  echo "----- alb response -----"; cat "${ALB_FILE}"; echo "------------------------"
+  echo "----- studio log -----"; cat "${LOG_FILE}"; echo "----------------------"
+  rm -f "${ALB_FILE}"; exit 1
+fi
+ALB_SERVED=$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "${ALB_FILE}" | head -1 || true)
+rm -f "${ALB_FILE}"
+echo "    OK: ALB serve started; front-door fronted by studio proxy at ${ALB_SERVED}"
+
+echo "==> The ALB front-door answers through the studio proxy"
+# Retry: the front-door binds before the ECS replica registers in the target
+# group, so the first requests may be 503 until the replica is healthy.
+ALB_OK=0
+for _ in $(seq 1 60); do
+  RC=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${ALB_SERVED}/" || true)
+  if [[ "${RC}" == "200" ]]; then ALB_OK=1; break; fi
+  sleep 2
+done
+if [[ "${ALB_OK}" != "1" ]]; then
+  echo "FAIL: ALB front-door never returned 200 through the proxy"
+  echo "----- studio log -----"; cat "${LOG_FILE}"; echo "----------------------"
+  exit 1
+fi
+echo "    OK: GET ${ALB_SERVED}/ -> 200 through the ALB front-door"
+
+echo "==> The ALB request was captured on the timeline (SSE)"
+# Assert on the INVOCATION row's request label (`GET /`), which ONLY the
+# capture proxy emits — the `serve` lifecycle event also carries
+# `"kind":"alb"`, so matching that alone would pass without any request
+# capture. The label proves the request flowed through the proxy.
+for _ in $(seq 1 20); do
+  if grep -qF 'event: invocation' "${SSE_FILE}" && grep -qF '"label":"GET /"' "${SSE_FILE}"; then break; fi
+  sleep 0.5
+done
+if ! grep -qF '"label":"GET /"' "${SSE_FILE}" || ! grep -qF '"kind":"alb"' "${SSE_FILE}"; then
+  echo "FAIL: SSE stream did not carry the captured ALB request (invocation row)"
+  echo "----- sse capture -----"; tail -c 2000 "${SSE_FILE}"; echo "-----------------------"
+  exit 1
+fi
+echo "    OK: the ALB request was captured (GET / invocation, kind=alb) on the timeline"
+kill "${SSE_PID}" 2>/dev/null || true; SSE_PID=""
+
+echo "==> POST /api/stop tears the ALB serve down"
+curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ALB_TARGET}\"}" -o /dev/null || true
+sleep 3
+echo "    OK: ALB serve stopped"
+
+# ---------------------------------------------------------------------------
+# 10. ECS service serve (serve-kinds): pure compute — runs the replicas, no
+#     host endpoint, no capture.
+# ---------------------------------------------------------------------------
+ECS_TARGET="LocalStudioFixture/MyService"
+echo "==> POST /api/run starts an ECS service serve (pure compute, no endpoint)"
+ECS_FILE=$(mktemp)
+HTTP_CODE=$(curl -s -o "${ECS_FILE}" -w '%{http_code}' --max-time 180 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TARGET}\",\"kind\":\"ecs\"}" || true)
+if [[ "${HTTP_CODE}" != "200" ]] || ! grep -qF '"status":"running"' "${ECS_FILE}"; then
+  echo "FAIL: POST /api/run (ecs) returned HTTP ${HTTP_CODE}"
+  echo "----- ecs response -----"; cat "${ECS_FILE}"; echo "------------------------"
+  echo "----- studio log -----"; cat "${LOG_FILE}"; echo "----------------------"
+  rm -f "${ECS_FILE}"; exit 1
+fi
+# A pure-compute service has NO host endpoint.
+if ! grep -qF '"endpoints":[]' "${ECS_FILE}"; then
+  echo "FAIL: ecs serve unexpectedly reported a host endpoint"
+  cat "${ECS_FILE}"; rm -f "${ECS_FILE}"; exit 1
+fi
+rm -f "${ECS_FILE}"
+echo "    OK: ECS service running with no host endpoint"
+
+echo "==> GET /api/running reflects the ECS service (no endpoint)"
+curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
+if ! grep -qF "${ECS_TARGET}" "${BODY_FILE}"; then
+  echo "FAIL: /api/running did not list the ECS service"; cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: /api/running lists ${ECS_TARGET}"
+
+echo "==> POST /api/stop tears the ECS service down"
+curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TARGET}\"}" -o /dev/null || true
+sleep 3
+echo "    OK: ECS service stopped"
+
+# ---------------------------------------------------------------------------
+# 11. Clean shutdown on SIGTERM.
 # ---------------------------------------------------------------------------
 echo "==> Stopping studio (SIGTERM) and asserting clean exit"
 kill "${STUDIO_PID}"
@@ -404,4 +517,4 @@ STUDIO_PID=""
 echo "    OK: studio stopped cleanly"
 
 echo ""
-echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + serve start/stop + request capture + history/log-search + shutdown)"
+echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + api/alb/ecs serve + request capture + history/log-search + shutdown)"

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -176,7 +176,7 @@ describe('createStudioServeManager', () => {
     expect(logs.every((l) => l.containerId === 'MyApi' && l.target === 'MyApi')).toBe(true);
   });
 
-  it('rejects a non-api kind without spawning', async () => {
+  it('rejects a non-serve kind without spawning', async () => {
     const bus = new StudioEventBus();
     const spawnFn = vi.fn();
     const mgr = createStudioServeManager({
@@ -185,8 +185,116 @@ describe('createStudioServeManager', () => {
       spawnFn: spawnFn as never,
     });
 
-    await expect(mgr.start({ targetId: 'MySvc', kind: 'ecs' })).rejects.toThrow(/not supported/i);
+    // `agentcore` is not a serve kind (it is a single-shot invoke target).
+    await expect(mgr.start({ targetId: 'MyAgent', kind: 'agentcore' })).rejects.toThrow(
+      /not supported/i
+    );
     expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('spawns the right headless command per serve kind (api / alb / ecs)', async () => {
+    const cases: Array<{ kind: 'api' | 'alb' | 'ecs'; command: string; hasPort: boolean }> = [
+      { kind: 'api', command: 'start-api', hasPort: true },
+      { kind: 'alb', command: 'start-alb', hasPort: false },
+      { kind: 'ecs', command: 'start-service', hasPort: false },
+    ];
+    for (const c of cases) {
+      const bus = new StudioEventBus();
+      const child = makeFakeChild();
+      const spawnFn = vi.fn(() => child as never);
+      const fp = fakeProxies();
+      const mgr = createStudioServeManager({
+        cliEntry: 'cli.js',
+        bus,
+        spawnFn: spawnFn as never,
+        proxyFactory: fp.factory,
+      });
+      const p = mgr.start({ targetId: 'T', kind: c.kind });
+      // Emit the kind's ready line (alb / ecs differ from api).
+      const readyLine =
+        c.kind === 'api'
+          ? LISTENING
+          : c.kind === 'alb'
+            ? 'ALB front-door: http://127.0.0.1:8080 (listener port 8080)\n'
+            : 'Service(s) running: MyService (1 replica).\n';
+      child.stdout.emit('data', readyLine);
+      await p;
+      const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+      expect(argv[1]).toBe(c.command);
+      expect(argv.includes('--port')).toBe(c.hasPort);
+    }
+  });
+
+  it('an alb serve fronts the front-door URL with a capture proxy', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'MyAlb', kind: 'alb' });
+    child.stdout.emit('data', 'ALB front-door: http://127.0.0.1:51234 (listener port 8080)\n');
+    const state = await p;
+
+    expect(state.status).toBe('running');
+    expect(state.endpoints).toEqual([PROXIED]);
+    expect(fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+  });
+
+  it('defaults the stop grace to 45s so an ECS teardown is not SIGKILLed early', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const delays: number[] = [];
+    const setTimeoutFn = ((cb: () => void, ms: number) => {
+      delays.push(ms);
+      return { unref: () => undefined };
+    }) as unknown as typeof setTimeout;
+    const clearTimeoutFn = (() => undefined) as unknown as typeof clearTimeout;
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    const p = mgr.start({ targetId: 'A', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+    const stopP = mgr.stop({ targetId: 'A' });
+    child.emit('close', 0);
+    await stopP;
+
+    // The SIGTERM->SIGKILL grace timer was scheduled at the 45s default.
+    expect(delays).toContain(45_000);
+  });
+
+  it('an ecs service serve has NO endpoint and NO capture proxy (pure compute)', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'MySvc', kind: 'ecs' });
+    child.stdout.emit('data', 'Service(s) running: MySvc (1 replica).\n');
+    const state = await p;
+
+    expect(state.status).toBe('running');
+    expect(state.endpoints).toEqual([]); // no host port to capture
+    expect(fp.upstreams).toEqual([]); // no proxy created
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
   });
 
   it('rejects starting a target that is already running', async () => {

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -190,8 +190,10 @@ describe('toStudioTargetGroups', () => {
       qualifiedId: 'S:Api',
       surface: 'HTTP API v2',
     });
-    // ECS services and task definitions fold into the one `ecs` group.
+    // ECS services and task definitions fold into the one `ecs` group, but
+    // only the SERVICE is servable (start-service); the task def is not.
     expect(groups[2].entries.map((e) => e.id)).toEqual(['S:Svc', 'S:Task']);
+    expect(groups[2].entries.map((e) => e.servable)).toEqual([true, false]);
   });
 
   it('falls back to the qualified id when no display path exists', () => {


### PR DESCRIPTION
## Summary

Extends the `cdkl studio` serve lifecycle (part of #282) from `api` only
to the `alb` and `ecs` serve kinds — so the console can start / stop /
observe an ALB front-door (with full request capture) and an ECS service
from the browser. Still behind `CDKL_STUDIO_PREVIEW=1`.

### Per-kind `ServeKindSpec`

The serve manager is now parameterized by a per-kind spec (command +
portArgs + ready line + whether it captures):

| kind | command | ready line | capture |
|---|---|---|---|
| `api` | `start-api` | `Server listening on <url>` | yes (host HTTP) |
| `alb` | `start-alb` | `ALB front-door: <url>` | yes (front-door) |
| `ecs` | `start-service` | `Service(s) running:` | NO (pure compute) |

`alb` requests through the local front-door land on the timeline via the
same studio capture proxy as `api` (decision D4a). `ecs` (start-service) is
pure compute — no host port, no capture; studio runs the replicas and
streams their logs. Only servable ECS **services** are runnable; ECS
**task definitions** (run-task) are listed but not (a `servable` flag on
the target projection drives the UI, and `/api/run` rejects a non-servable
ecs target).

### Changes

- `src/local/studio-serve-manager.ts`: the `ServeKindSpec` table + a
  generalized ready handler (capture-group URL for api/alb, no endpoint for
  ecs). The SIGTERM->SIGKILL stop grace is raised 10s->45s so `start-alb` /
  `start-service` finish draining + removing their ECS replicas + the
  shared docker network before any SIGKILL — a premature kill orphaned the
  replica containers + network (caught by the integ, now fixed).
- `src/local/studio-server.ts`: `servable` on `StudioTarget` (services yes,
  task defs no).
- `src/cli/commands/local-studio.ts`: dispatch routes api/alb/ecs to the
  serve manager and rejects a non-servable ecs target.
- `src/local/studio-ui.ts`: api/alb/ecs serve-runnable; an ecs service
  shows `running` (no port) + a "pure compute, no host endpoint" note.
- `tests/integration/local-studio` fixture: ALB listener -> 8080
  (non-privileged) + the ECS container serves HTTP.

## Test plan

- **Unit** (2291 pass): per-kind spawn (start-api/start-alb/start-service
  argv, `--port` only for api), the alb front-door capture (endpoint = the
  proxy URL), the ecs no-endpoint + no-proxy serve, the `servable`
  projection, and the 45s default stop grace.
- **Integration** (real Docker): starts an ALB serve, curls the front-door
  through the studio capture proxy (retrying until the ECS replica
  registers) and asserts the **captured request invocation** (`GET /`,
  kind=alb) lands on the timeline; starts an ECS service serve and asserts
  it runs with `"endpoints":[]` — all torn down with ZERO leftover
  containers / networks.
- **Live-tested** end-to-end against the fixture.

## Known limitation

A privileged ALB listener port (80 / 443) needs root locally, since studio
spawns `start-alb` which binds the deployed listener port directly. A
future slice can resolve listener ports + remap to free host ports.

## cdkd parity

studio stays `CDKL_STUDIO_PREVIEW`-gated and is NOT exported from
`src/index.ts`, so cdkd cannot embed it — the changes are additive (a new
`servable` field on the already-`internal`-exported `StudioTarget`, new
serve kinds). No host-observable behavior change on the stable surface.

Part of #282.
