### PR TITLE
test(http-server): drive start-api HTTP-server tests over a keep-alive-free client (#282)

### DIFF
--- a/tests/helpers/agentless-http.ts
+++ b/tests/helpers/agentless-http.ts
@@ -1,0 +1,78 @@
+import { request as httpRequest } from 'node:http';
+
+/**
+ * A keep-alive-FREE HTTP test client (`agent: false`) — an alternative to
+ * global `fetch` (undici) for tests that hit a local `http.Server` they
+ * later close.
+ *
+ * Why this exists: undici pools the idle keep-alive socket after a `fetch`;
+ * when the test then closes its server with `server.closeAllConnections()`
+ * (studio-server, start-api's HTTP server, the studio proxy all do), that
+ * pooled socket is destroyed from the SERVER side and undici raises an
+ * UNHANDLED rejection on the client side. Node exits the worker on an
+ * unhandled rejection, which crashes the vitest forks pool (`[vitest-pool]:
+ * Worker forks emitted error`, exit 1) on a loaded CI box — even though
+ * every test passed. It turned `main` red repeatedly across the studio
+ * slices (#290, #297). `agent: false` opens a fresh socket per request that
+ * closes on response end, so nothing is ever pooled and
+ * `closeAllConnections()` has no client socket to destroy.
+ */
+export interface AgentlessResponse {
+  status: number;
+  /** Mirrors the `fetch` `Headers` subset the tests use. */
+  headers: { get: (k: string) => string | null; getSetCookie: () => string[] };
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}
+
+/** Perform one keep-alive-free request. Mirrors a minimal `fetch`. */
+export function http(
+  url: string,
+  opts: { method?: string; body?: string; headers?: Record<string, string> } = {}
+): Promise<AgentlessResponse> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const headers: Record<string, string> =
+      opts.body != null ? { 'content-type': 'application/json', ...opts.headers } : { ...opts.headers };
+    const req = httpRequest(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname + u.search,
+        method: opts.method ?? 'GET',
+        agent: false,
+        headers,
+      },
+      (res) => {
+        let data = '';
+        res.setEncoding('utf8');
+        res.on('data', (c) => (data += c));
+        const finish = (): void =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: {
+              // `fetch`'s `Headers.get` returns `null` (not undefined) for a
+              // missing header, and joins a multi-value header with ', '.
+              get: (k) => {
+                const v = res.headers[k.toLowerCase()];
+                if (v === undefined) return null;
+                return Array.isArray(v) ? v.join(', ') : v;
+              },
+              // `fetch` exposes multi-valued Set-Cookie via getSetCookie().
+              getSetCookie: () => {
+                const v = res.headers['set-cookie'];
+                return Array.isArray(v) ? v : v ? [v] : [];
+              },
+            },
+            json: () => Promise.resolve(JSON.parse(data)),
+            text: () => Promise.resolve(data),
+          });
+        res.on('end', finish);
+        res.on('error', finish);
+      }
+    );
+    req.on('error', reject);
+    if (opts.body != null) req.write(opts.body);
+    req.end();
+  });
+}

--- a/tests/unit/local/http-server-cors.test.ts
+++ b/tests/unit/local/http-server-cors.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { http } from '../../helpers/agentless-http.js';
 import { startApiServer, type ServerState } from '../../../src/local/http-server.js';
 import type {
   ContainerPool,
@@ -93,7 +94,7 @@ async function preflight(
   extraHeaders: Record<string, string> = {}
 ): Promise<{ status: number; headers: Headers; body: string }> {
   const url = `http://${host}:${port}${path}`;
-  const res = await fetch(url, {
+  const res = await http(url, {
     method: 'OPTIONS',
     headers: {
       origin: 'https://example.com',
@@ -225,7 +226,7 @@ describe('http-server CORS preflight integration', () => {
     // route dispatch — but the routes don't include OPTIONS for /items,
     // so it 404s.
     const url = `http://${server.host}:${server.port}/items`;
-    const res = await fetch(url, {
+    const res = await http(url, {
       method: 'OPTIONS',
       headers: { origin: 'https://example.com' },
     });

--- a/tests/unit/local/http-server-service-integration-auth.test.ts
+++ b/tests/unit/local/http-server-service-integration-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { http } from '../../helpers/agentless-http.js';
 
 // vi.hoisted so the spies are available inside the vi.mock factory below
 // (vi.mock is hoisted to file-top — top-level consts captured by the
@@ -174,7 +175,7 @@ describe('PR #515 item 8: service-integration route + authorizer-deny → SDK ne
 
     try {
       const url = `http://${server.host}:${server.port}/protected-sqs`;
-      const resp = await fetch(url, {
+      const resp = await http(url, {
         method: 'POST',
         body: 'message-body',
         headers: { authorization: 'Bearer wrong-token', 'content-type': 'text/plain' },
@@ -212,7 +213,7 @@ describe('PR #515 item 8: service-integration route + authorizer-deny → SDK ne
 
     try {
       const url = `http://${server.host}:${server.port}/protected-sqs`;
-      const resp = await fetch(url, {
+      const resp = await http(url, {
         method: 'POST',
         body: 'message-body',
         // No `authorization` header — Lambda REQUEST identity source missing.
@@ -253,7 +254,7 @@ describe('PR #515 item 8: service-integration route + authorizer-deny → SDK ne
 
     try {
       const url = `http://${server.host}:${server.port}/protected-sqs`;
-      const resp = await fetch(url, {
+      const resp = await http(url, {
         method: 'POST',
         body: 'message-body',
         headers: { authorization: 'Bearer xyz', 'content-type': 'text/plain' },
@@ -299,7 +300,7 @@ describe('PR #515 item 8: service-integration route + authorizer-deny → SDK ne
       // does not match anything `verifyJwtAuthorizer` would accept; the
       // mock returns deny regardless.
       const forgedJwt = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjMifQ.bogus';
-      const resp = await fetch(url, {
+      const resp = await http(url, {
         method: 'POST',
         body: 'message-body',
         headers: { authorization: `Bearer ${forgedJwt}`, 'content-type': 'text/plain' },

--- a/tests/unit/local/http-server.test.ts
+++ b/tests/unit/local/http-server.test.ts
@@ -1,4 +1,5 @@
 import { createHash, createHmac } from 'node:crypto';
+import { http } from '../../helpers/agentless-http.js';
 import type { ServerResponse } from 'node:http';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vite-plus/test';
 import {
@@ -126,7 +127,7 @@ describe('writeAuthRejection', () => {
 /**
  * End-to-end tests for the per-request authorizer pass via `startApiServer`.
  * We boot a real `node:http` server on an ephemeral port and curl-equivalent
- * `fetch()` it; the route handler + authorizer are mocked via `invokeRie`.
+ * `http()` it; the route handler + authorizer are mocked via `invokeRie`.
  */
 function makePool(): ContainerPool {
   const acquire = vi.fn(async () => ({
@@ -219,9 +220,9 @@ describe('startApiServer — REQUEST authorizer cache (must-fix #1)', () => {
       // Two requests with the same identity → authorizer Lambda invoked
       // exactly once (cache reuses verdict for the second).
       const url = `http://${server.host}:${server.port}/items/42`;
-      const r1 = await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      const r1 = await http(url, { headers: { authorization: 'Bearer xyz' } });
       expect(r1.status).toBe(200);
-      const r2 = await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      const r2 = await http(url, { headers: { authorization: 'Bearer xyz' } });
       expect(r2.status).toBe(200);
 
       const authorizerInvocations = invokeRieMock.mock.calls.filter(
@@ -267,8 +268,8 @@ describe('startApiServer — REQUEST authorizer cache (must-fix #1)', () => {
 
     try {
       const url = `http://${server.host}:${server.port}/items/42`;
-      await fetch(url, { headers: { authorization: 'Bearer A' } });
-      await fetch(url, { headers: { authorization: 'Bearer B' } });
+      await http(url, { headers: { authorization: 'Bearer A' } });
+      await http(url, { headers: { authorization: 'Bearer B' } });
       const authorizerInvocations = invokeRieMock.mock.calls.filter(
         (c) => (c[2] as { type?: string }).type === 'REQUEST'
       );
@@ -318,8 +319,8 @@ describe('startApiServer — REQUEST authorizer cache (must-fix #1)', () => {
 
     try {
       const url = `http://${server.host}:${server.port}/items/42`;
-      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
-      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      await http(url, { headers: { authorization: 'Bearer xyz' } });
+      await http(url, { headers: { authorization: 'Bearer xyz' } });
       const authorizerInvocations = invokeRieMock.mock.calls.filter(
         (c) => (c[2] as { type?: string }).type === 'REQUEST'
       );
@@ -373,7 +374,7 @@ describe('startApiServer — narrow-Resource cache leak (must-fix #2)', () => {
     try {
       const baseUrl = `http://${server.host}:${server.port}`;
       // 1st request: hits /items/42 (narrow Resource matches) → 200.
-      const r1 = await fetch(`${baseUrl}/items/42`, {
+      const r1 = await http(`${baseUrl}/items/42`, {
         headers: { authorization: 'Bearer xyz' },
       });
       expect(r1.status).toBe(200);
@@ -382,7 +383,7 @@ describe('startApiServer — narrow-Resource cache leak (must-fix #2)', () => {
       // /items/999 does NOT match the narrow Resource → must deny.
       // Pre-fix this returned 200 (cache stored the verdict directly,
       // no per-request Resource re-eval).
-      const r2 = await fetch(`${baseUrl}/items/999`, {
+      const r2 = await http(`${baseUrl}/items/999`, {
         headers: { authorization: 'Bearer xyz' },
       });
       expect(r2.status).toBe(403);
@@ -458,8 +459,8 @@ describe('startApiServer — JWKS pass-through warn fires once per server (must-
     try {
       const url = `http://${server.host}:${server.port}/protected`;
       // Use any-old Bearer token; pass-through accepts.
-      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
-      await fetch(url, { headers: { authorization: 'Bearer xyz' } });
+      await http(url, { headers: { authorization: 'Bearer xyz' } });
+      await http(url, { headers: { authorization: 'Bearer xyz' } });
 
       // Count warn lines about pass-through. The logger emits other
       // warn lines (JWKS unreachable at startup) — only count the
@@ -509,7 +510,7 @@ describe('startApiServer — unsupported route (deferred 501)', () => {
     });
     try {
       const url = `http://${server.host}:${server.port}/admin`;
-      const r = await fetch(url);
+      const r = await http(url);
       expect(r.status).toBe(501);
       const body = (await r.json()) as { message: string; reason: string };
       expect(body.message).toBe('Not Implemented');
@@ -539,7 +540,7 @@ describe('startApiServer — unsupported route (deferred 501)', () => {
       authorizerCache: createAuthorizerCache(),
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/items/42`, {
+      const r = await http(`http://${server.host}:${server.port}/items/42`, {
         headers: { authorization: 'Bearer x' },
       });
       expect(r.status).toBe(501);
@@ -585,7 +586,7 @@ describe('startApiServer — mockCors preflight', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/items`, { method: 'OPTIONS' });
+      const r = await http(`http://${server.host}:${server.port}/items`, { method: 'OPTIONS' });
       expect(r.status).toBe(204);
       expect(r.headers.get('access-control-allow-origin')).toBe('*');
       expect(r.headers.get('access-control-allow-methods')).toBe('OPTIONS,GET,POST');
@@ -634,7 +635,7 @@ describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      const r = await http(`http://${server.host}:${server.port}/anything`);
       expect(r.status).toBe(200);
       expect(r.headers.get('content-type')).toBe('text/plain');
       expect(r.headers.get('x-custom')).toBe('hello');
@@ -680,7 +681,7 @@ describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      const r = await http(`http://${server.host}:${server.port}/anything`);
       // Node's fetch / undici exposes multi-valued Set-Cookie via getSetCookie().
       const cookies = r.headers.getSetCookie();
       expect(cookies).toEqual(['a=1; Path=/', 'b=2; Path=/']);
@@ -714,7 +715,7 @@ describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      const r = await http(`http://${server.host}:${server.port}/anything`);
       expect(r.status).toBe(200);
       expect(await r.text()).toBe('buffered-response');
       expect(invokeRieMock).toHaveBeenCalledTimes(1);
@@ -747,7 +748,7 @@ describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      const r = await http(`http://${server.host}:${server.port}/anything`);
       expect(r.status).toBe(502);
       // Pool must be released so the warm container can serve the next request.
       expect((pool.release as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
@@ -800,7 +801,7 @@ describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      const r = await http(`http://${server.host}:${server.port}/anything`);
       // Outer catch reports 502 (no headers were sent before the throw).
       expect(r.status).toBe(502);
       // (a) Pool must be released so the warm container can serve again.
@@ -852,7 +853,7 @@ describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      const r = await http(`http://${server.host}:${server.port}/anything`);
       expect(r.status).toBe(200);
       // Node emits Transfer-Encoding: chunked automatically when no
       // Content-Length is set. The handler's "gzip" stays stripped.
@@ -905,7 +906,7 @@ describe('startApiServer — RESPONSE_STREAM dispatch (#467)', () => {
       port: 0,
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/anything`);
+      const r = await http(`http://${server.host}:${server.port}/anything`);
       expect(r.status).toBe(200);
       expect(r.headers.get('content-length')).toBeNull();
       // Node still emits chunked automatically.
@@ -1261,7 +1262,7 @@ describe('startApiServer — Function URL AWS_IAM (#621)', () => {
         region: 'us-east-1',
         amzDate,
       });
-      const r = await fetch(`http://${server.host}:${server.port}${path}`, {
+      const r = await http(`http://${server.host}:${server.port}${path}`, {
         headers: { authorization, ...headers },
       });
       expect(r.status).toBe(200);
@@ -1296,7 +1297,7 @@ describe('startApiServer — Function URL AWS_IAM (#621)', () => {
       sigV4CredentialsLoader: stubCredentialsLoader({ accessKeyId, secretAccessKey }),
     });
     try {
-      const r = await fetch(`http://${server.host}:${server.port}/items/42`);
+      const r = await http(`http://${server.host}:${server.port}/items/42`);
       expect(r.status).toBe(403);
       const body = (await r.json()) as { Message: string };
       expect(body.Message).toBe('Forbidden');
@@ -1333,7 +1334,7 @@ describe('startApiServer — Function URL AWS_IAM (#621)', () => {
       const tampered = authorization.replace(/Signature=([0-9a-f])/, (_m, c: string) =>
         `Signature=${c === '0' ? '1' : '0'}`
       );
-      const r = await fetch(`http://${server.host}:${server.port}${path}`, {
+      const r = await http(`http://${server.host}:${server.port}${path}`, {
         headers: { authorization: tampered, ...headers },
       });
       expect(r.status).toBe(403);
@@ -1385,7 +1386,7 @@ describe('startApiServer — Function URL AWS_IAM (#621)', () => {
         // informational" contract documented in #626.
         service: 'execute-api',
       });
-      const r = await fetch(`http://${server.host}:${server.port}${path}`, {
+      const r = await http(`http://${server.host}:${server.port}${path}`, {
         headers: { authorization, ...headers },
       });
       expect(r.status).toBe(200);


### PR DESCRIPTION
test(http-server): drive the start-api HTTP-server tests over a keep-alive-free client (#282)

`main`'s recurring vitest forks-pool worker crash (`[vitest-pool]: Worker
forks emitted error — Worker exited unexpectedly`, exit 1, while every test
passes) traces to global `fetch` (undici) against a local `http.Server`
that the test later closes with `server.closeAllConnections()`: the idle
keep-alive socket undici pooled is destroyed server-side, undici raises an
unhandled rejection, and Node exits the worker — only on a loaded CI box.
#290 and #297 fixed the studio SSE + studio-server surfaces; the start-api
HTTP-server tests were the remaining undici-fetch surface, and they tip the
crash as the suite grows.

Extract the keep-alive-free client used by the studio-proxy / studio-server
tests into a shared `tests/helpers/agentless-http.ts` (`agent: false`
`node:http`, mirroring the `fetch` `Headers.get` / `getSetCookie` subset the
tests use), and route `http-server.test.ts`,
`http-server-cors.test.ts`, and `http-server-service-integration-auth.test.ts`
through it. A fresh socket per request closes on response end, so nothing is
pooled and `closeAllConnections()` has no client socket to destroy.

Test-only change. Verified the full suite + the converted files repeatedly
under the forks pool with zero worker anomalies.
