### PR TITLE
feat(studio): session-global --from-cfn-stack / --assume-role threaded to children (#301)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -223,7 +223,11 @@ compute-locally category for Lambda + API Gateway).
   plane that spawns the SAME `invoke` / `start-api` / `start-alb` /
   `start-service` runners as child processes. It is on the user-facing
   command surface (the unveil slice removed the `CDKL_STUDIO_PREVIEW`
-  gate) and exported from `src/index.ts` for host CLIs.
+  gate) and exported from `src/index.ts` for host CLIs. Issue #301
+  slice 1 added the session-global `--from-cfn-stack [name]` /
+  `--assume-role <arn>` flags to `cdkl studio`: they bind the whole
+  session and are forwarded verbatim to every spawned child (built in
+  `src/local/studio-child-args.ts`).
 - `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
   (`Toolkit.fromCdkApp()` + context store threading) that returns
   `StackInfo[]` for downstream consumers.
@@ -320,6 +324,12 @@ compute-locally category for Lambda + API Gateway).
   silenced in the child; the studio LOGS panel then shows only the
   Lambda container's runtime logs, which stream straight from
   `docker logs` and are unaffected by the level, plus the response),
+  studio-child-args (issue #301 slice 1 — `buildSharedChildArgs`, the
+  single place that turns studio's session-global config (`--app` /
+  `--profile` / `--region` / `-c` / `--from-cfn-stack` / `--assume-role`)
+  into the argv fragment both studio-dispatch and studio-serve-manager
+  forward to their spawned child commands, so the two spawn sites cannot
+  drift),
   studio-serve-manager (issue #282 — the
   long-running serve lifecycle, parameterized by a per-kind
   `ServeKindSpec`: `api` (`start-api`) + `alb` (`start-alb`) expose host

--- a/README.md
+++ b/README.md
@@ -70,11 +70,20 @@ cdkl studio                                    # interactive web console over ev
 
 ![cdkl invoke against a local sample CDK app — standalone, no deploy](assets/cdkl-invoke.gif)
 
+`invoke` runs one Lambda in a real RIE container; the options you reach for most:
+
+```bash
+cdkl invoke MyStack/Fn --event ./event.json             # run with a JSON event payload
+cdkl invoke MyStack/Fn --env-vars ./env.json            # overlay env vars (SAM-shape file)
+cdkl invoke MyStack/Fn --from-cfn-stack                 # bind env to the deployed stack's real values
+cdkl invoke MyStack/Fn --from-cfn-stack --assume-role   # ...and run as its deployed execution role
+```
+
 - **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`.
 - **`run-task`** / single-replica **`start-service`** publish declared container ports on the host (`--host-port <container>=<host>` remaps; handy for privileged ports on macOS). **`start-service`** / **`start-alb`** also list each host URL in a `Service endpoints:` banner after boot so the access URL stays visible.
 - **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement), and WebSocket `Upgrade` proxying to ECS targets ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
 - **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, all four runtime protocols (HTTP and AGUI on 8080, MCP on 8000, A2A on 9000; SSE and WebSocket are HTTP wire-shape variants on the same 8080 container), with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
-- **`studio`** opens a local web console over the same synthesized targets: pick a Lambda and invoke it, start / stop a `start-api` / `start-alb` / `start-service` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs — a point-and-click front over the same CLI runners. It takes no target (it lists them all); `--no-open` skips the browser launch and `--studio-port` pins the port.
+- **`studio`** opens a local web console over the same synthesized targets: pick a Lambda and invoke it, start / stop a `start-api` / `start-alb` / `start-service` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs — a point-and-click front over the same CLI runners. It takes no target (it lists them all); `--no-open` skips the browser launch and `--studio-port` pins the port. Add `--from-cfn-stack` (and `--assume-role`) to bind the whole session to a deployed stack — every invoke / serve from the UI then runs against its real ARNs / Secrets.
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
 Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.md](docs/cli-reference.md) and [docs/local-emulation.md](docs/local-emulation.md).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1481,10 +1481,15 @@ The console is a three-pane layout:
 | --- | --- | --- |
 | `--studio-port <port>` | `9999` | Preferred port for the studio web server; bumps to the next free port on collision. |
 | `--no-open` | (auto-opens) | Do not auto-open the browser when studio starts (TTY only). |
+| `--from-cfn-stack [name]` | (off) | Bind the whole studio session to a deployed CloudFormation stack — every invoke / serve started from the UI runs against the stack's real ARNs / Secret values. Bare flag auto-resolves a single-stack app; pass a name to pick the stack. Forwarded to each child command. |
+| `--assume-role <arn>` | (off) | IAM role ARN to assume for every invoke / serve started from the UI; the temporary credentials are forwarded into the containers. Forwarded to each child command. |
 
-`cdkl studio` also accepts the shared app / context / region / profile
-flags (`--app`, `-c key=value`, `--region`, `--profile`, etc.) — they are
-threaded into the synth and into every child runner it spawns.
+`--from-cfn-stack` and `--assume-role` are **session-global**: they apply
+to every target you run from the UI, so they sit on `cdkl studio` itself
+rather than being set per-target. `cdkl studio` also accepts the shared app
+/ context / region / profile flags (`--app`, `-c key=value`, `--region`,
+`--profile`, etc.) — they are threaded into the synth and into every child
+runner it spawns.
 
 Booting studio itself needs no Docker (it only synthesizes the app and
 serves the UI); Docker is required the moment you invoke or serve a target

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -105,6 +105,14 @@ interface LocalStudioOptions {
   studioPort: string;
   /** `--no-open`: suppress auto-opening the browser (Commander sets `open`). */
   open: boolean;
+  /**
+   * `--from-cfn-stack [name]`: bind the whole studio session to a deployed
+   * stack. Commander maps the bare flag to `true` and a named value to the
+   * string; forwarded verbatim to every child command.
+   */
+  fromCfnStack?: string | boolean;
+  /** `--assume-role <arn>`: explicit role ARN forwarded to every child command. */
+  assumeRole?: string;
 }
 
 /**
@@ -173,6 +181,8 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     ...(options.profile ? { profile: options.profile } : {}),
     ...(options.region ? { region: options.region } : {}),
     ...(Object.keys(context).length > 0 ? { context } : {}),
+    ...(options.fromCfnStack !== undefined ? { fromCfnStack: options.fromCfnStack } : {}),
+    ...(options.assumeRole ? { assumeRole: options.assumeRole } : {}),
   };
   const dispatcher = createStudioDispatcher(childConfig);
   const serveManager = createStudioServeManager(childConfig);
@@ -311,6 +321,21 @@ export function addStudioSpecificOptions(cmd: Command): Command {
   );
   cmd.addOption(
     new Option('--no-open', 'Do not auto-open the browser when studio starts (TTY only)')
+  );
+  cmd.addOption(
+    new Option(
+      '--from-cfn-stack [cfn-stack-name]',
+      'Bind the whole studio session to a deployed CloudFormation stack: every invoke / serve ' +
+        'started from the UI runs against the deployed stack real ARNs / Secret values. Bare flag ' +
+        'auto-resolves a single-stack app; pass a name to pick the stack. Forwarded to each child command.'
+    )
+  );
+  cmd.addOption(
+    new Option(
+      '--assume-role <arn>',
+      'IAM role ARN to assume for every invoke / serve started from the UI (temp credentials ' +
+        'forwarded into the containers). Forwarded to each child command.'
+    )
   );
   return cmd;
 }

--- a/src/local/studio-child-args.ts
+++ b/src/local/studio-child-args.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared CLI args `cdkl studio` threads into every child command it
+ * spawns (the single-shot `cdkl invoke` in studio-dispatch and the
+ * long-running `cdkl start-api` / `start-alb` / `start-service` in
+ * studio-serve-manager). studio is a control plane over the CLI, so
+ * session-global flags set on `cdkl studio` are forwarded verbatim to
+ * each child rather than re-implemented.
+ *
+ * Centralizing the arg construction keeps the two spawn sites from
+ * drifting (they previously each hand-rolled the same app / profile /
+ * region / context pushes) and is the single place where a new
+ * session-global flag is wired through.
+ */
+
+/** Session-global config forwarded to every studio child command. */
+export interface SharedChildConfig {
+  /** `--app` value, if studio was given one. */
+  app?: string;
+  /** `--profile` to thread through. */
+  profile?: string;
+  /** `--region` to thread through. */
+  region?: string;
+  /** `-c key=value` context overrides. */
+  context?: Record<string, string>;
+  /**
+   * `--from-cfn-stack` session binding. Commander's optional-value form
+   * maps a bare flag to `true` and `--from-cfn-stack <name>` to the
+   * string; both are forwarded as-is (every child command accepts the
+   * bare and named forms).
+   */
+  fromCfnStack?: string | boolean;
+  /**
+   * `--assume-role <arn>` — explicit ARN only. studio does NOT expose the
+   * bare auto-resolve form because the child commands disagree on it
+   * (`start-api` takes `<arn-or-pair>` with a separate `--assume-role-auto`
+   * flag), so a value-only flag threads cleanly to all of them.
+   */
+  assumeRole?: string;
+}
+
+/**
+ * Build the shared `--app` / `--profile` / `--region` / `-c` /
+ * `--from-cfn-stack` / `--assume-role` args for a studio child command.
+ * Returns a flat argv fragment to spread after the subcommand + target.
+ */
+export function buildSharedChildArgs(config: SharedChildConfig): string[] {
+  const args: string[] = [];
+  if (config.app) args.push('--app', config.app);
+  if (config.profile) args.push('--profile', config.profile);
+  if (config.region) args.push('--region', config.region);
+  for (const [k, v] of Object.entries(config.context ?? {})) {
+    args.push('-c', `${k}=${v}`);
+  }
+  // `--from-cfn-stack`: bare flag (true) vs named stack (string).
+  if (config.fromCfnStack === true) {
+    args.push('--from-cfn-stack');
+  } else if (typeof config.fromCfnStack === 'string' && config.fromCfnStack !== '') {
+    args.push('--from-cfn-stack', config.fromCfnStack);
+  }
+  // `--assume-role <arn>`: explicit ARN only.
+  if (typeof config.assumeRole === 'string' && config.assumeRole !== '') {
+    args.push('--assume-role', config.assumeRole);
+  }
+  return args;
+}

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { StudioEventBus, type StudioTargetKind } from './studio-events.js';
+import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
 
 /** A request to run a target, as the studio UI posts it to `/api/run`. */
 export interface StudioRunRequest {
@@ -37,21 +38,13 @@ export interface StudioRunResult {
 }
 
 /** Config for {@link createStudioDispatcher}. */
-export interface StudioDispatchConfig {
+export interface StudioDispatchConfig extends SharedChildConfig {
   /** Path to the `cdkl` CLI entry (`dist/cli.js`) — usually `process.argv[1]`. */
   cliEntry: string;
   /** The shared event bus; invocation + log events are emitted onto it. */
   bus: StudioEventBus;
   /** Working directory for the child invoke (defaults to `process.cwd()`). */
   cwd?: string;
-  /** `--app` value to thread into the child invoke, if studio was given one. */
-  app?: string;
-  /** `-c key=value` context overrides to thread through. */
-  context?: Record<string, string>;
-  /** `--profile` to thread through. */
-  profile?: string;
-  /** `--region` to thread through. */
-  region?: string;
   /** Node binary to spawn (defaults to `process.execPath`; injectable for tests). */
   nodeBin?: string;
   /** Spawn implementation (injectable for tests). */
@@ -133,13 +126,7 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
       const eventFile = join(dir, 'event.json');
       writeFileSync(eventFile, JSON.stringify(req.event ?? {}));
 
-      const args = ['invoke', req.targetId, '--event', eventFile];
-      if (config.app) args.push('--app', config.app);
-      if (config.profile) args.push('--profile', config.profile);
-      if (config.region) args.push('--region', config.region);
-      for (const [k, v] of Object.entries(config.context ?? {})) {
-        args.push('-c', `${k}=${v}`);
-      }
+      const args = ['invoke', req.targetId, '--event', eventFile, ...buildSharedChildArgs(config)];
 
       const { code, stdout, stderr } = await runChild(
         spawnFn,

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -5,6 +5,7 @@ import {
   type RunningStudioProxy,
   type StudioProxyConfig,
 } from './studio-proxy.js';
+import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
 
 /** A request to start serving a target, as the studio UI posts it. */
 export interface StudioServeRequest {
@@ -37,21 +38,13 @@ export interface StudioServeState {
 }
 
 /** Config for {@link createStudioServeManager}. */
-export interface StudioServeManagerConfig {
+export interface StudioServeManagerConfig extends SharedChildConfig {
   /** Path to the `cdkl` CLI entry (`dist/cli.js`) — usually `process.argv[1]`. */
   cliEntry: string;
   /** The shared event bus; serve + log events are emitted onto it. */
   bus: StudioEventBus;
   /** Working directory for the child serve (defaults to `process.cwd()`). */
   cwd?: string;
-  /** `--app` value to thread into the child serve, if studio was given one. */
-  app?: string;
-  /** `-c key=value` context overrides to thread through. */
-  context?: Record<string, string>;
-  /** `--profile` to thread through. */
-  profile?: string;
-  /** `--region` to thread through. */
-  region?: string;
   /** Node binary to spawn (defaults to `process.execPath`; injectable for tests). */
   nodeBin?: string;
   /** Spawn implementation (injectable for tests). */
@@ -237,14 +230,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
   }
 
   function buildArgs(targetId: string, spec: ServeKindSpec): string[] {
-    const args = [spec.command, targetId, ...spec.portArgs];
-    if (config.app) args.push('--app', config.app);
-    if (config.profile) args.push('--profile', config.profile);
-    if (config.region) args.push('--region', config.region);
-    for (const [k, v] of Object.entries(config.context ?? {})) {
-      args.push('-c', `${k}=${v}`);
-    }
-    return args;
+    return [spec.command, targetId, ...spec.portArgs, ...buildSharedChildArgs(config)];
   }
 
   async function start(req: StudioServeRequest): Promise<StudioServeState> {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -536,5 +536,79 @@ fi
 STUDIO_PID=""
 echo "    OK: studio stopped cleanly"
 
+# ---------------------------------------------------------------------------
+# 12. Session-global flag threading (issue #301 slice 1): `cdkl studio
+#     --from-cfn-stack <name> --assume-role <arn>` forwards both flags to the
+#     child commands it spawns. Boot studio bound to a BOGUS stack + role (no
+#     deploy, no cleanup): the child's `--from-cfn-stack` attempt logs the
+#     stack name then GRACEFULLY falls back, so we assert (a) the invoke still
+#     succeeds and (b) the bound per-invocation logs name the bogus stack —
+#     proof the flag threaded CLI -> child end-to-end. The child's actual
+#     from-cfn-stack binding is covered by local-invoke-from-cfn-stack.
+# ---------------------------------------------------------------------------
+echo "==> --from-cfn-stack / --assume-role thread through to the spawned child"
+BOGUS_STACK="BOGUSNONEXISTENTSTACK301"
+BOGUS_ROLE="arn:aws:iam::123456789012:role/bogus-studio-301"
+LOG_FILE2=$(mktemp)
+${CDKL} studio --no-open --studio-port "${PORT}" \
+  --from-cfn-stack "${BOGUS_STACK}" --assume-role "${BOGUS_ROLE}" \
+  >"${LOG_FILE2}" 2>&1 &
+STUDIO_PID=$!
+URL2=""
+for _ in $(seq 1 60); do
+  if ! kill -0 "${STUDIO_PID}" 2>/dev/null; then
+    echo "FAIL: studio (flag-threading boot) exited during startup"
+    cat "${LOG_FILE2}"; rm -f "${LOG_FILE2}"; exit 1
+  fi
+  URL2=$(grep -oE "http://${HOST}:[0-9]+" "${LOG_FILE2}" | head -1 || true)
+  if [[ -n "${URL2}" ]] && curl -fsS "${URL2}/api/targets" -o /dev/null 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+if [[ -z "${URL2}" ]]; then
+  echo "FAIL: flag-threading studio never bound a URL"; cat "${LOG_FILE2}"; rm -f "${LOG_FILE2}"; exit 1
+fi
+
+RUN_FILE2=$(mktemp)
+HTTP_CODE2=$(curl -s -o "${RUN_FILE2}" -w '%{http_code}' --max-time 180 \
+  -X POST "${URL2}/api/run" \
+  -H 'content-type: application/json' \
+  -d '{"targetId":"LocalStudioFixture/MyHandler","kind":"lambda","event":{}}' || true)
+# Graceful fallback: the bogus binding must NOT break the invoke.
+if [[ "${HTTP_CODE2}" != "200" ]] || ! grep -qF '"ok":true' "${RUN_FILE2}"; then
+  echo "FAIL: invoke under bogus --from-cfn-stack did not gracefully succeed (HTTP ${HTTP_CODE2})"
+  cat "${RUN_FILE2}"; rm -f "${LOG_FILE2}" "${RUN_FILE2}"; exit 1
+fi
+INV2=$(grep -oE '"invocationId":"[^"]+"' "${RUN_FILE2}" | head -1 | sed 's/.*"invocationId":"//;s/"//')
+if [[ -z "${INV2}" ]]; then
+  echo "FAIL: no invocationId from the flag-threading invoke"
+  cat "${RUN_FILE2}"; rm -f "${LOG_FILE2}" "${RUN_FILE2}"; exit 1
+fi
+# Both flags name themselves in the child's (warn-level, un-suppressed)
+# fallback output, streamed onto the bus and bound to the invocation:
+#   --from-cfn-stack -> 'ListStackResources(<stack>) failed ... Falling back.'
+#   --assume-role    -> 'STS AssumeRole(<arn>) failed ... '
+# Their presence proves BOTH flags threaded CLI -> child end-to-end.
+curl -fsS "${URL2}/api/invocations/${INV2}/logs" -o "${BODY_FILE}"
+if ! grep -qF "${BOGUS_STACK}" "${BODY_FILE}"; then
+  echo "FAIL: --from-cfn-stack did not reach the child (bogus stack name absent from bound logs)"
+  echo "----- bound logs -----"; head -c 2000 "${BODY_FILE}"; echo; echo "----------------------"
+  echo "----- studio log -----"; head -c 2000 "${LOG_FILE2}"; echo; echo "----------------------"
+  rm -f "${LOG_FILE2}" "${RUN_FILE2}"; exit 1
+fi
+if ! grep -qF "${BOGUS_ROLE}" "${BODY_FILE}"; then
+  echo "FAIL: --assume-role did not reach the child (bogus role ARN absent from bound logs)"
+  echo "----- bound logs -----"; head -c 2000 "${BODY_FILE}"; echo; echo "----------------------"
+  echo "----- studio log -----"; head -c 2000 "${LOG_FILE2}"; echo; echo "----------------------"
+  rm -f "${LOG_FILE2}" "${RUN_FILE2}"; exit 1
+fi
+echo "    OK: --from-cfn-stack '${BOGUS_STACK}' + --assume-role threaded to the child; invoke fell back gracefully"
+
+kill "${STUDIO_PID}" 2>/dev/null || true
+wait "${STUDIO_PID}" 2>/dev/null || true
+STUDIO_PID=""
+rm -f "${LOG_FILE2}" "${RUN_FILE2}"
+
 echo ""
-echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + api/alb/ecs serve + request capture + history/log-search + shutdown)"
+echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + api/alb/ecs serve + request capture + history/log-search + flag-threading + shutdown)"

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -135,7 +135,7 @@ describe('run-task option surface contract (addRunTaskSpecificOptions)', () => {
 describe('studio option surface contract (addStudioSpecificOptions)', () => {
   it('addStudioSpecificOptions registers exactly the known studio-only flags', () => {
     const flags = longFlagsOf(addStudioSpecificOptions(new Command()));
-    expect(flags).toEqual(['--no-open', '--studio-port']);
+    expect(flags).toEqual(['--assume-role', '--from-cfn-stack', '--no-open', '--studio-port']);
   });
 
   it('createLocalStudioCommand surface equals common + studio-specific (no inline drift)', () => {

--- a/tests/unit/local/studio-child-args.test.ts
+++ b/tests/unit/local/studio-child-args.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { buildSharedChildArgs } from '../../../src/local/studio-child-args.js';
+
+describe('buildSharedChildArgs', () => {
+  it('returns no args for an empty config', () => {
+    expect(buildSharedChildArgs({})).toEqual([]);
+  });
+
+  it('threads app / profile / region / context', () => {
+    expect(
+      buildSharedChildArgs({
+        app: 'node app.ts',
+        profile: 'dev',
+        region: 'us-west-2',
+        context: { stage: 'dev', foo: 'bar' },
+      })
+    ).toEqual([
+      '--app',
+      'node app.ts',
+      '--profile',
+      'dev',
+      '--region',
+      'us-west-2',
+      '-c',
+      'stage=dev',
+      '-c',
+      'foo=bar',
+    ]);
+  });
+
+  it('forwards a bare --from-cfn-stack (true) without a value', () => {
+    expect(buildSharedChildArgs({ fromCfnStack: true })).toEqual(['--from-cfn-stack']);
+  });
+
+  it('forwards a named --from-cfn-stack with its value', () => {
+    expect(buildSharedChildArgs({ fromCfnStack: 'MyStack' })).toEqual([
+      '--from-cfn-stack',
+      'MyStack',
+    ]);
+  });
+
+  it('omits --from-cfn-stack when false / empty-string', () => {
+    expect(buildSharedChildArgs({ fromCfnStack: false })).toEqual([]);
+    expect(buildSharedChildArgs({ fromCfnStack: '' })).toEqual([]);
+  });
+
+  it('forwards --assume-role with its ARN value (no bare form)', () => {
+    expect(buildSharedChildArgs({ assumeRole: 'arn:aws:iam::123456789012:role/app' })).toEqual([
+      '--assume-role',
+      'arn:aws:iam::123456789012:role/app',
+    ]);
+  });
+
+  it('omits --assume-role for an empty string', () => {
+    expect(buildSharedChildArgs({ assumeRole: '' })).toEqual([]);
+  });
+
+  it('composes every flag in a stable order', () => {
+    expect(
+      buildSharedChildArgs({
+        app: 'cdk.out',
+        profile: 'prod',
+        region: 'eu-west-1',
+        context: { k: 'v' },
+        fromCfnStack: 'Stack',
+        assumeRole: 'arn:aws:iam::1:role/r',
+      })
+    ).toEqual([
+      '--app',
+      'cdk.out',
+      '--profile',
+      'prod',
+      '--region',
+      'eu-west-1',
+      '-c',
+      'k=v',
+      '--from-cfn-stack',
+      'Stack',
+      '--assume-role',
+      'arn:aws:iam::1:role/r',
+    ]);
+  });
+});

--- a/tests/unit/local/studio-dispatch.test.ts
+++ b/tests/unit/local/studio-dispatch.test.ts
@@ -198,6 +198,60 @@ describe('createStudioDispatcher', () => {
     expect(argv).toContain('env=prod');
   });
 
+  it('threads --from-cfn-stack <name> + --assume-role <arn> into the child argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      fromCfnStack: 'MyStack',
+      assumeRole: 'arn:aws:iam::123456789012:role/app',
+      idFactory: () => 'inv-cfn',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stdout.emit('data', '{}');
+    child.emit('close', 0);
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const i = argv.indexOf('--from-cfn-stack');
+    expect(i).toBeGreaterThan(-1);
+    expect(argv[i + 1]).toBe('MyStack');
+    const j = argv.indexOf('--assume-role');
+    expect(j).toBeGreaterThan(-1);
+    expect(argv[j + 1]).toBe('arn:aws:iam::123456789012:role/app');
+  });
+
+  it('threads a bare --from-cfn-stack (true) with no value into the child argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      fromCfnStack: true,
+      idFactory: () => 'inv-cfn-bare',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stdout.emit('data', '{}');
+    child.emit('close', 0);
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const i = argv.indexOf('--from-cfn-stack');
+    expect(i).toBeGreaterThan(-1);
+    // Bare flag: the next token must NOT be a stray value (it's the end or another flag).
+    expect(argv[i + 1] === undefined || argv[i + 1]?.startsWith('--')).toBe(true);
+    expect(argv).not.toContain('--assume-role');
+  });
+
   it('extracts the LAST JSON line as the response even when a log line trails it', async () => {
     const bus = new StudioEventBus();
     const { invocations, logs } = collect(bus);

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -149,6 +149,35 @@ describe('createStudioServeManager', () => {
     expect(serves[1].endpoints).toEqual([PROXIED]);
   });
 
+  it('threads --from-cfn-stack <name> + --assume-role <arn> into the serve child argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+      fromCfnStack: 'MyStack',
+      assumeRole: 'arn:aws:iam::123456789012:role/svc',
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const i = argv.indexOf('--from-cfn-stack');
+    expect(i).toBeGreaterThan(-1);
+    expect(argv[i + 1]).toBe('MyStack');
+    const j = argv.indexOf('--assume-role');
+    expect(j).toBeGreaterThan(-1);
+    expect(argv[j + 1]).toBe('arn:aws:iam::123456789012:role/svc');
+  });
+
   it('streams child stdout AND stderr lines onto the bus as log events keyed by the target', async () => {
     const bus = new StudioEventBus();
     const { logs } = collect(bus);


### PR DESCRIPTION
## Summary

Slice 1 of `cdkl studio` option support (#301): bind a whole studio
session to a deployed stack (or an assumed role) from the `cdkl studio`
command, forwarded to every child command studio spawns.

- **`src/local/studio-child-args.ts`** (new) — `buildSharedChildArgs`,
  the single place that turns studio's session-global config (app /
  profile / region / context / from-cfn-stack / assume-role) into the
  child argv fragment. Consolidates the app/profile/region/context pushes
  the dispatch + serve-manager previously hand-rolled (so the two spawn
  sites cannot drift) and adds the two new flags.
- **`src/local/studio-dispatch.ts` + `studio-serve-manager.ts`** — their
  configs extend `SharedChildConfig` and build the shared args via the
  helper.
- **`src/cli/commands/local-studio.ts`** — `addStudioSpecificOptions`
  registers `--from-cfn-stack [name]` and `--assume-role <arn>`
  (session-global), threaded into the shared child config. `--assume-role`
  is value-only (explicit ARN) because the child commands disagree on the
  bare auto-resolve form (`start-api` uses `<arn-or-pair>` plus a separate
  `--assume-role-auto`), so a value-only flag threads cleanly to all four.

Docs: README studio bullet + a compact `invoke` options example, and the
`docs/cli-reference.md` studio options table + `.claude/CLAUDE.md`.

## Behavior change

Additive — two new opt-in flags on `cdkl studio`, off by default. The
`buildSharedChildArgs` refactor produces the identical app / profile /
region / context args the two spawn sites built inline before (covered by
the existing threading tests).

## Host (cdkd) parity

The new flags live in `addStudioSpecificOptions`, so a host CLI wrapping
`createLocalStudioCommand` inherits them automatically. `studio-child-args`
is studio-internal plumbing — not re-exported from `cdk-local/internal`
(cdkd embeds the whole studio command, not this helper).

## Test plan

- `vp run verify` (check + lint + format + typecheck + build + 154 test
  files / 2311 tests) green. New unit tests: `studio-child-args` (bare /
  named / empty forms), dispatch + serve-manager threading assertions,
  and the studio option-surface contract.
- `tests/integration/local-studio/verify.sh` green on real Docker — boots
  studio bound to a BOGUS stack + role (no deploy, no cleanup, no cost),
  asserts the invoke gracefully falls back AND the bound per-invocation
  logs name the bogus stack: proof the flag threaded CLI -> child
  end-to-end. The child's actual from-cfn-stack binding stays covered by
  `local-invoke-from-cfn-stack`. Zero leftover containers / networks.

Part of the studio option work (#301); follow-up slices add the per-target
UI options, the editable session panel, and the target-list filter.
