### PR TITLE
feat(studio): editable Session bar — live-edit from-cfn-stack / assume-role (#301)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -227,7 +227,13 @@ compute-locally category for Lambda + API Gateway).
   slice 1 added the session-global `--from-cfn-stack [name]` /
   `--assume-role <arn>` flags to `cdkl studio`: they bind the whole
   session and are forwarded verbatim to every spawned child (built in
-  `src/local/studio-child-args.ts`).
+  `src/local/studio-child-args.ts`). Issue #301 slice 3 made the
+  run-time bindings (`from-cfn-stack` / `assume-role`) editable from the
+  UI Session bar: the `childConfig` the dispatcher + serve-manager read
+  per-run is mutable, `GET /api/config` exposes it (with the read-only
+  synth-time `profile` / `region` / `app`), and `PATCH /api/config`
+  (`applyConfigPatch`) edits the bindings so the change applies to
+  subsequent runs without a restart.
 - `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
   (`Toolkit.fromCdkApp()` + context store threading) that returns
   `StackInfo[]` for downstream consumers.
@@ -298,10 +304,12 @@ compute-locally category for Lambda + API Gateway).
   UI at `/`, the synthesized target list at `/api/targets`, an SSE
   stream of the event bus at `/api/events`, `POST /api/run` (single-shot
   invoke / serve start), `POST /api/stop` (serve stop),
-  `GET /api/running` (running serve snapshot), and the slice-C3 store
+  `GET /api/running` (running serve snapshot), the slice-C3 store
   endpoints `GET /api/history` / `GET /api/logs?q=` (full-text log
-  search) / `GET /api/invocations/<id>/logs` (per-request log binding);
-  collision-bumps the port),
+  search) / `GET /api/invocations/<id>/logs` (per-request log binding),
+  and the slice-3 session config `GET /api/config` (read-only synth
+  context + editable bindings) / `PATCH /api/config` (edit the run-time
+  bindings); collision-bumps the port),
   studio-ui (the framework-free web UI embedded as a string so it ships
   inside the npm package with no asset-copy build step; 3-pane: targets /
   workspace composer / timeline; Lambdas get an [Invoke] composer, serve

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1458,6 +1458,13 @@ cdkl studio --studio-port 4000    # pin the port
 cdkl studio --no-open             # do not auto-open the browser (CI / headless)
 ```
 
+A **Session bar** under the header shows the read-only synth-time context
+(`profile` / `region` / `app` — the target list was synthesized with them,
+so they are fixed for the session) and lets you edit the run-time bindings
+`--from-cfn-stack` and `--assume-role` live: a change applies to every
+subsequent invoke / serve started from the UI, no restart needed (the CLI
+flags set the initial values).
+
 The console is a three-pane layout:
 
 - **Targets** — every synthesized target, grouped by command. Lambdas get

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -98,6 +98,51 @@ export function coerceStopRequest(body: unknown): StudioStopRequest {
   return { targetId };
 }
 
+/** The session config served at `GET /api/config` (issue #301 slice 3). */
+export interface SessionConfigSnapshot {
+  /** Read-only synth-time context the target list was synthesized with. */
+  synth: { profile?: string | undefined; region?: string | undefined; app?: string | undefined };
+  /** Editable run-time binding — `--from-cfn-stack` (bare `true` / named). */
+  fromCfnStack?: string | boolean | undefined;
+  /** Editable run-time binding — `--assume-role <arn>`. */
+  assumeRole?: string | undefined;
+}
+
+/** The editable run-time bindings {@link applyConfigPatch} mutates in place. */
+export interface EditableSessionBindings {
+  fromCfnStack?: string | boolean;
+  assumeRole?: string;
+}
+
+/**
+ * Validate a `PATCH /api/config` body and apply the editable run-time
+ * bindings (`fromCfnStack` / `assumeRole`) onto `target` in place. Only the
+ * keys PRESENT in the body are touched (a partial update); `null` / `false` /
+ * `''` clears a binding. Throws on a malformed body / value so a bad patch
+ * fails loudly rather than silently mis-binding subsequent runs — the studio
+ * server surfaces a thrown handler error as a 500 (same as every other
+ * `/api/*` dispatch). The read-only synth context (profile / region / app) is
+ * never patchable.
+ */
+export function applyConfigPatch(body: unknown, target: EditableSessionBindings): void {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw new Error('Request body must be a JSON object.');
+  }
+  const b = body as Record<string, unknown>;
+  if ('fromCfnStack' in b) {
+    const v = b['fromCfnStack'];
+    if (v === null || v === false || v === '') delete target.fromCfnStack;
+    else if (v === true || typeof v === 'string') target.fromCfnStack = v;
+    else throw new Error('"fromCfnStack" must be a string, boolean, or null.');
+  }
+  if ('assumeRole' in b) {
+    const v = b['assumeRole'];
+    if (v === null || v === '') delete target.assumeRole;
+    else if (typeof v === 'string') target.assumeRole = v;
+    else throw new Error('"assumeRole" must be a string or null.');
+  }
+}
+
 const DEFAULT_STUDIO_PORT = 9999;
 
 /**
@@ -195,7 +240,23 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   // (`cdkl invoke <target>` / `cdkl start-api <target>`) — studio is a
   // control plane over the CLI.
   const cliEntry = process.argv[1] ?? '';
-  const childConfig = {
+  // The MUTABLE session-run config. The dispatcher + serve-manager hold this
+  // SAME object by reference and read it per-run, so editing the run-time
+  // bindings (`fromCfnStack` / `assumeRole`) via `PATCH /api/config` applies
+  // to subsequent invokes / serves without a restart (issue #301 slice 3).
+  // `profile` / `region` / `app` are synth-time context (the target list was
+  // synthed with them) — read-only, surfaced for display only.
+  const childConfig: {
+    cliEntry: string;
+    bus: StudioEventBus;
+    cwd: string;
+    app?: string;
+    profile?: string;
+    region?: string;
+    context?: Record<string, string>;
+    fromCfnStack?: string | boolean;
+    assumeRole?: string;
+  } = {
     cliEntry,
     bus,
     cwd: process.cwd(),
@@ -208,6 +269,12 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   };
   const dispatcher = createStudioDispatcher(childConfig);
   const serveManager = createStudioServeManager(childConfig);
+
+  const sessionConfigSnapshot = (): SessionConfigSnapshot => ({
+    synth: { profile: childConfig.profile, region: childConfig.region, app: childConfig.app },
+    fromCfnStack: childConfig.fromCfnStack,
+    assumeRole: childConfig.assumeRole,
+  });
   // Retain a bounded window of invocations + logs so the browser can render
   // history on (re)connect, search logs full-text, and bind a request's
   // logs at CloudWatch granularity (slice C3).
@@ -240,6 +307,13 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
       return { stopped: req.targetId };
     },
     getRunning: () => ({ running: serveManager.list() }),
+    getConfig: () => sessionConfigSnapshot(),
+    patchConfig: (body) => {
+      // Mutates the shared childConfig the dispatcher + serve-manager read
+      // per-run, so the new binding applies to subsequent invokes / serves.
+      applyConfigPatch(body, childConfig);
+      return Promise.resolve(sessionConfigSnapshot());
+    },
   });
 
   const cliName = getEmbedConfig().cliName;

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -119,6 +119,20 @@ export interface StudioServerOptions {
    * empty results.
    */
   store?: StudioStore;
+  /**
+   * Session config snapshot served at `GET /api/config` (issue #301 slice 3)
+   * — the read-only synth-time context (profile / region / app) plus the
+   * editable run-time bindings (from-cfn-stack / assume-role). When omitted
+   * the endpoint returns an empty config.
+   */
+  getConfig?: () => unknown;
+  /**
+   * Handler for `PATCH /api/config` — update the editable run-time bindings
+   * (from-cfn-stack / assume-role); the change applies to subsequent runs.
+   * Returns the updated config. When omitted, `/api/config` is read-only and
+   * a PATCH answers 501.
+   */
+  patchConfig?: (body: unknown) => Promise<unknown>;
 }
 
 /** A running studio server. */
@@ -220,6 +234,16 @@ function handleRequest(
     const logs = options.store ? options.store.logsForInvocation(id) : [];
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify({ logs }));
+    return;
+  }
+  if (req.method === 'GET' && path === '/api/config') {
+    const config = options.getConfig ? options.getConfig() : {};
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify(config));
+    return;
+  }
+  if (req.method === 'PATCH' && path === '/api/config') {
+    void handleDispatch(req, res, options.patchConfig);
     return;
   }
   if (req.method === 'GET' && path === '/api/events') {

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -29,6 +29,7 @@ const STUDIO_CSS = `
   body {
     margin: 0; font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
     color: #e6e6e6; background: #1a1a1a; height: 100vh; overflow: hidden;
+    display: flex; flex-direction: column;
   }
   header {
     padding: 8px 14px; background: #111; border-bottom: 1px solid #333;
@@ -36,9 +37,30 @@ const STUDIO_CSS = `
   }
   header .brand { font-weight: 700; color: #fff; }
   header .meta { color: #888; font-size: 12px; }
+  #session-bar {
+    display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+    padding: 5px 14px; background: #141414; border-bottom: 1px solid #2a2a2a;
+    font-size: 12px;
+  }
+  #session-bar .sess-title { color: #888; text-transform: uppercase; font-size: 11px; }
+  #session-bar .sess-bind { color: #bbb; display: inline-flex; align-items: center; gap: 4px; }
+  #session-bar input[type=text] {
+    background: #111; color: #ddd; border: 1px solid #333; border-radius: 3px;
+    padding: 3px 6px; font: 12px ui-monospace, Menlo, monospace; min-width: 180px;
+  }
+  #session-bar input:focus { outline: none; border-color: #4ec97a; }
+  #session-bar button {
+    background: #2a3a2c; color: #7bd88f; border: 1px solid #2f4030; border-radius: 3px;
+    cursor: pointer; padding: 3px 12px; font: 12px ui-monospace, monospace;
+  }
+  #session-bar button:hover { background: #314b34; }
+  #session-bar #sess-msg { color: #7bd88f; min-width: 40px; }
+  #session-bar .sess-synth { color: #777; margin-left: auto; }
   main {
     display: grid; grid-template-columns: 280px 5px 1fr 5px 320px;
-    height: calc(100vh - 38px);
+    /* Body is a flex column (header + session-bar + main); main fills the
+       rest so the height is computed — no magic constant, wrap-safe. */
+    flex: 1; min-height: 0;
   }
   .pane { overflow: auto; }
   .splitter { background: #2a2a2a; cursor: col-resize; }
@@ -860,11 +882,78 @@ const STUDIO_SCRIPT = `
     wire('split-right', (dx, l0, r0) => { right = clamp(r0 - dx); });
   }
 
+  // Session config (issue #301 slice 3): synth-time context is read-only;
+  // the run-time bindings (from-cfn-stack / assume-role) are editable and
+  // apply to subsequent invokes / serves.
+  async function loadConfig() {
+    try {
+      const res = await fetch('/api/config');
+      const c = await res.json();
+      const cfn = document.getElementById('sess-cfn');
+      const cfnName = document.getElementById('sess-cfn-name');
+      const role = document.getElementById('sess-role');
+      const on = c.fromCfnStack !== undefined && c.fromCfnStack !== false;
+      cfn.checked = on;
+      cfnName.value = typeof c.fromCfnStack === 'string' ? c.fromCfnStack : '';
+      cfnName.style.display = on ? '' : 'none';
+      role.value = c.assumeRole || '';
+      const s = c.synth || {};
+      const parts = [];
+      if (s.profile) parts.push('profile=' + s.profile);
+      if (s.region) parts.push('region=' + s.region);
+      if (s.app) parts.push('app=' + s.app);
+      document.getElementById('sess-synth').textContent = parts.length ? '(' + parts.join(' \\u00b7 ') + ')' : '';
+    } catch (err) {
+      /* best-effort; the session bar is non-critical */
+    }
+  }
+
+  async function saveConfig() {
+    const cfn = document.getElementById('sess-cfn');
+    const cfnName = document.getElementById('sess-cfn-name');
+    const role = document.getElementById('sess-role');
+    const msg = document.getElementById('sess-msg');
+    const body = {
+      fromCfnStack: cfn.checked ? cfnName.value.trim() || true : null,
+      assumeRole: role.value.trim() || null,
+    };
+    msg.textContent = 'Saving...';
+    try {
+      const res = await fetch('/api/config', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const e = await res.json().catch(function () { return {}; });
+        msg.textContent = 'Error: ' + (e.error || ('HTTP ' + res.status));
+        return;
+      }
+      msg.textContent = 'Saved';
+      setTimeout(function () { msg.textContent = ''; }, 1500);
+      await loadConfig();
+    } catch (err) {
+      msg.textContent = 'Failed: ' + err;
+    }
+  }
+
+  function wireSession() {
+    const cfn = document.getElementById('sess-cfn');
+    const cfnName = document.getElementById('sess-cfn-name');
+    cfn.addEventListener('change', function () {
+      cfnName.style.display = cfn.checked ? '' : 'none';
+      if (cfn.checked) cfnName.focus();
+    });
+    document.getElementById('sess-save').onclick = saveConfig;
+  }
+
   loadTargets().then(loadRunning);
   loadHistory();
+  loadConfig();
   connect();
   initSplitters();
   wireLogSearch();
+  wireSession();
 `;
 
 /**
@@ -893,6 +982,16 @@ export function renderStudioHtml(appLabel: string, cliName: string): string {
   <span class="meta">${safeApp}</span>
   <span id="conn" class="down">● connecting</span>
 </header>
+<div id="session-bar">
+  <span class="sess-title">Session</span>
+  <label class="sess-bind"><input type="checkbox" id="sess-cfn" /> from-cfn-stack</label>
+  <input id="sess-cfn-name" type="text" placeholder="stack name (blank = auto)" style="display:none" />
+  <label class="sess-bind" for="sess-role">assume-role</label>
+  <input id="sess-role" type="text" placeholder="arn:aws:iam::…:role/…" />
+  <button id="sess-save" type="button">Save</button>
+  <span id="sess-msg"></span>
+  <span id="sess-synth" class="sess-synth"></span>
+</div>
 <main>
   <section class="pane" id="targets"><h2>Targets</h2></section>
   <div class="splitter" id="split-left"></div>

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -242,6 +242,47 @@ rm -f "${OPT_FILE}"
 echo "    OK: --env-vars KEY/VALUE option threaded through to the Lambda container"
 
 # ---------------------------------------------------------------------------
+# 6c. Editable Session config (issue #301 slice 3): GET /api/config exposes
+#     the read-only synth context; PATCH /api/config sets a run-time binding
+#     (--from-cfn-stack) that applies to SUBSEQUENT runs. PATCH a BOGUS stack
+#     (no deploy), then invoke and assert the child's --from-cfn-stack attempt
+#     names it in the bound logs — proof the edited binding threaded through.
+# ---------------------------------------------------------------------------
+echo "==> GET /api/config exposes the session config"
+curl -fsS "${URL}/api/config" -o "${BODY_FILE}"
+if ! grep -qF '"synth"' "${BODY_FILE}"; then
+  echo "FAIL: /api/config did not return a session config"; cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: /api/config served"
+
+echo "==> PATCH /api/config sets --from-cfn-stack; it applies to the next invoke"
+CFG_STACK="BOGUSSESSIONSTACK301"
+PATCH_FILE=$(mktemp)
+HTTP_PATCH=$(curl -s -o "${PATCH_FILE}" -w '%{http_code}' -X PATCH "${URL}/api/config" \
+  -H 'content-type: application/json' -d "{\"fromCfnStack\":\"${CFG_STACK}\"}" || true)
+if [[ "${HTTP_PATCH}" != "200" ]] || ! grep -qF "${CFG_STACK}" "${PATCH_FILE}"; then
+  echo "FAIL: PATCH /api/config did not echo the updated binding (HTTP ${HTTP_PATCH})"
+  cat "${PATCH_FILE}"; rm -f "${PATCH_FILE}"; exit 1
+fi
+rm -f "${PATCH_FILE}"
+CFG_RUN=$(mktemp)
+curl -s -o "${CFG_RUN}" --max-time 180 -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d '{"targetId":"LocalStudioFixture/MyHandler","kind":"lambda","event":{}}' >/dev/null || true
+CFG_INV=$(grep -oE '"invocationId":"[^"]+"' "${CFG_RUN}" | head -1 | sed 's/.*"invocationId":"//;s/"//')
+rm -f "${CFG_RUN}"
+if [[ -z "${CFG_INV}" ]]; then echo "FAIL: no invocationId after a config-bound invoke"; exit 1; fi
+curl -fsS "${URL}/api/invocations/${CFG_INV}/logs" -o "${BODY_FILE}"
+if ! grep -qF "${CFG_STACK}" "${BODY_FILE}"; then
+  echo "FAIL: the PATCHed --from-cfn-stack binding did not reach the child (stack absent from logs)"
+  echo "----- bound logs -----"; head -c 2000 "${BODY_FILE}"; echo; echo "----------------------"
+  exit 1
+fi
+echo "    OK: edited Session binding '${CFG_STACK}' applied to the subsequent invoke"
+# Reset the binding so later serve sections are unaffected.
+curl -s -X PATCH "${URL}/api/config" -H 'content-type: application/json' \
+  -d '{"fromCfnStack":null}' -o /dev/null || true
+
+# ---------------------------------------------------------------------------
 # 7. POST /api/run STARTS a long-running `start-api` serve (slice C1); curl
 #    the served route; assert running state + a serve SSE event; stop it.
 # ---------------------------------------------------------------------------
@@ -659,4 +700,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + api/alb/ecs serve + request capture + history/log-search + per-target-options + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + boot + UI + targets + SSE + invoke + api/alb/ecs serve + request capture + history/log-search + per-target-options + session-config + flag-threading + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
+  applyConfigPatch,
   coerceRunRequest,
   coerceStopRequest,
   createLocalStudioCommand,
   parseStudioPort,
+  type EditableSessionBindings,
 } from '../../../src/cli/commands/local-studio.js';
 
 describe('createLocalStudioCommand', () => {
@@ -105,6 +107,45 @@ describe('coerceRunRequest', () => {
     expect(() =>
       coerceRunRequest({ targetId: 'T', kind: 'lambda', options: { '--env-vars': '{bad' } })
     ).toThrow(/not valid JSON/);
+  });
+});
+
+describe('applyConfigPatch', () => {
+  it('sets a named from-cfn-stack + an assume-role ARN', () => {
+    const cfg: EditableSessionBindings = {};
+    applyConfigPatch({ fromCfnStack: 'MyStack', assumeRole: 'arn:aws:iam::1:role/r' }, cfg);
+    expect(cfg).toEqual({ fromCfnStack: 'MyStack', assumeRole: 'arn:aws:iam::1:role/r' });
+  });
+
+  it('sets a bare from-cfn-stack (true)', () => {
+    const cfg: EditableSessionBindings = {};
+    applyConfigPatch({ fromCfnStack: true }, cfg);
+    expect(cfg.fromCfnStack).toBe(true);
+  });
+
+  it('clears a binding on null / false / empty-string', () => {
+    const cfg: EditableSessionBindings = { fromCfnStack: 'X', assumeRole: 'arn:...' };
+    applyConfigPatch({ fromCfnStack: null, assumeRole: '' }, cfg);
+    expect('fromCfnStack' in cfg).toBe(false);
+    expect('assumeRole' in cfg).toBe(false);
+  });
+
+  it('only touches the keys present in the body (partial update)', () => {
+    const cfg: EditableSessionBindings = { fromCfnStack: 'Keep', assumeRole: 'arn:keep' };
+    applyConfigPatch({ assumeRole: 'arn:new' }, cfg);
+    expect(cfg).toEqual({ fromCfnStack: 'Keep', assumeRole: 'arn:new' });
+  });
+
+  it.each([null, 42, 'str', [1]])('rejects a non-object body %p', (body) => {
+    expect(() => applyConfigPatch(body, {})).toThrow(/must be a JSON object/);
+  });
+
+  it('rejects a non-string/boolean from-cfn-stack value', () => {
+    expect(() => applyConfigPatch({ fromCfnStack: 42 }, {})).toThrow(/"fromCfnStack" must be/);
+  });
+
+  it('rejects a non-string assume-role value', () => {
+    expect(() => applyConfigPatch({ assumeRole: 42 }, {})).toThrow(/"assumeRole" must be/);
   });
 });
 

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -527,3 +527,59 @@ describe('startStudioServer', () => {
     abort();
   });
 });
+
+describe('startStudioServer — session config (issue #301 slice 3)', () => {
+  it('GET /api/config returns the getConfig() snapshot', async () => {
+    const server = await boot({
+      getConfig: () => ({ synth: { profile: 'dev', region: 'us-east-1' }, fromCfnStack: 'MyStack' }),
+    });
+    const res = await http(`${server.url}/api/config`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      synth: { profile: 'dev', region: 'us-east-1' },
+      fromCfnStack: 'MyStack',
+    });
+  });
+
+  it('GET /api/config returns {} when no getConfig is wired', async () => {
+    const server = await boot();
+    const res = await http(`${server.url}/api/config`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  it('PATCH /api/config dispatches the body to patchConfig and returns its result', async () => {
+    let received: unknown;
+    const server = await boot({
+      patchConfig: (body) => {
+        received = body;
+        return Promise.resolve({ fromCfnStack: 'Patched' });
+      },
+    });
+    const res = await http(`${server.url}/api/config`, {
+      method: 'PATCH',
+      body: JSON.stringify({ fromCfnStack: 'Patched' }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ fromCfnStack: 'Patched' });
+    expect(received).toEqual({ fromCfnStack: 'Patched' });
+  });
+
+  it('PATCH /api/config returns 500 when patchConfig throws (validation error)', async () => {
+    const server = await boot({
+      patchConfig: () => Promise.reject(new Error('"assumeRole" must be a string or null.')),
+    });
+    const res = await http(`${server.url}/api/config`, {
+      method: 'PATCH',
+      body: JSON.stringify({ assumeRole: 42 }),
+    });
+    expect(res.status).toBe(500);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: expect.stringContaining('assumeRole') });
+  });
+
+  it('PATCH /api/config answers 501 when no patchConfig is wired', async () => {
+    const server = await boot();
+    const res = await http(`${server.url}/api/config`, { method: 'PATCH', body: '{}' });
+    expect(res.status).toBe(501);
+  });
+});

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -29,6 +29,15 @@ describe('renderStudioHtml', () => {
     expect(html).not.toMatch(/__OPTION_SPECS__ = [^;]*<\//);
   });
 
+  it('renders the editable Session bar (issue #301 slice 3)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    expect(html).toContain('id="session-bar"');
+    expect(html).toContain('id="sess-cfn"'); // from-cfn-stack toggle
+    expect(html).toContain('id="sess-role"'); // assume-role input
+    expect(html).toContain('id="sess-save"'); // Save button
+    expect(html).toContain('/api/config'); // reads + writes the config endpoint
+  });
+
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {
     const html = renderStudioHtml('<script>alert(1)</script>', '"&<>');
     // The raw markup must never appear verbatim in the document.


### PR DESCRIPTION
## Summary

Slice 3 of `cdkl studio` option support (#301): the session-global
run-time bindings (set as CLI flags in slice 1) become editable from a UI
**Session bar** — a change applies to subsequent invokes / serves without
a restart.

- **`src/cli/commands/local-studio.ts`** — `childConfig` (read by the
  dispatcher + serve-manager per run) is now a mutable object.
  `GET /api/config` serves `sessionConfigSnapshot()`: the read-only
  synth-time context (`profile` / `region` / `app` — the target list was
  synthesized with them) plus the editable bindings (`from-cfn-stack` /
  `assume-role`). `PATCH /api/config` applies `applyConfigPatch` (partial
  update; `null` / `false` / `''` clears a binding; validates types) onto
  `childConfig`, so the next run picks it up.
- **`src/local/studio-server.ts`** — `getConfig` / `patchConfig` options +
  `GET` / `PATCH /api/config` routes (PATCH reuses the bounded-JSON
  dispatch helper).
- **`src/local/studio-ui.ts`** — a Session bar under the header: a
  from-cfn-stack checkbox + stack-name input, an assume-role input, a Save
  button, and the read-only synth-context display. `loadConfig()` populates
  it; `saveConfig()` PATCHes it.

The synth-time context is **read-only** (it is fixed for the session — the
target list was already synthesized with it); only the run-time bindings
are editable.

## Behavior change

Additive — two new endpoints (`GET` / `PATCH /api/config`). The CLI flags
(`--from-cfn-stack` / `--assume-role`) now seed the *initial* values, which
the UI can then edit. No host-facing CLI option / library surface change.

## Test plan

- `vp run verify` (check + lint + format + typecheck + build + 155 test
  files / 2353 tests) green. New unit tests: `applyConfigPatch` (named /
  bare / clear / partial / invalid), studio-server `GET` + `PATCH
  /api/config` (dispatch result, 500-on-throw, 501 when unwired), and the
  `renderStudioHtml` Session-bar embed.
- `tests/integration/local-studio/verify.sh` green on real Docker:
  `GET /api/config` is served, then a `PATCH` of a BOGUS `--from-cfn-stack`
  (no deploy) makes the SUBSEQUENT invoke's child name it in the bound logs
  — proof the edited binding applied end-to-end. Zero leftover containers.
- Live-tested: PATCH `{fromCfnStack:"X"}` then invoke -> the child ran with
  `--from-cfn-stack X` (named in the bound logs).

Part of the studio option work (#301); the remaining slice adds the
target-list filter, and (issue #303) the AgentCore + WebSocket surfaces.

## Review notes

1-reviewer (code) — core clean (the by-reference `childConfig` mutation
path was verified correct: a PATCH applies to subsequent runs, an
already-running serve is untouched). Two findings, both **fixed**:

1. The `applyConfigPatch` JSDoc said "→ 400", but a thrown handler error
   surfaces as a 500 via `handleDispatch` (same as every `/api/*`
   dispatch, and what the unit test asserts) — JSDoc corrected to 500.
2. `main`'s `calc(100vh - 71px)` was a magic constant that under-counted
   when the session bar wraps on a narrow viewport — replaced with a
   flex-column body so `main` height is computed (wrap-safe, no constant).
