### PR TITLE
feat(start-api): accept a WebSocket API as an explicit target (#311)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -833,7 +833,18 @@ to serve every API (bare in a non-TTY) or to open the multi-select picker
 4. **CDK Construct path prefix** — `MyStack/MyHttpApi`.
 
 For Function URLs, the path forms reference the **backing Lambda's**
-`aws:cdk:path`, not the auto-generated URL resource.
+`aws:cdk:path`, not the auto-generated URL resource. A **WebSocket API**
+is targetable by the same id forms (the `AWS::ApiGatewayV2::Api`
+resource's logical id / stack-qualified id / construct path), so
+`cdkl start-api MyStack/MyWsApi` serves exactly that WebSocket API.
+
+The target filter applies to **WebSocket APIs too**: an explicit target
+serves only the named APIs (REST / HTTP / Function URL / WebSocket
+alike), and bare `start-api` (no target) serves every API including all
+WebSocket APIs. (Previously WebSocket APIs were always served as a group
+regardless of the target — so targeting an HTTP API also booted unrelated
+WebSocket APIs, and a WebSocket-API target errored with "did not match any
+discovered API". Both are fixed.)
 
 When several targets are passed and they span **different stacks**, the
 single-stack synth optimization is skipped and every stack is

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -62,6 +62,8 @@ import type { DockerImageAssetSource } from '../../types/assets.js';
 import { discoverRoutes, type DiscoveredRoute } from '../../local/route-discovery.js';
 import {
   discoverWebSocketApis,
+  filterWebSocketApisByIdentifiers,
+  availableWebSocketApiIdentifiers,
   type DiscoveredWebSocketApi,
 } from '../../local/websocket-route-discovery.js';
 import {
@@ -587,7 +589,9 @@ async function localStartApiCommand(
         logger.warn(`WebSocket discovery: ${e}`);
       }
     }
-    const webSocketApis = wsDiscovery.apis;
+    // `let` so the target-subset filter (issue #311) can narrow it to the
+    // WS APIs the explicit `<target...>` named.
+    let webSocketApis = wsDiscovery.apis;
     if (routes.length === 0 && webSocketApis.length === 0) {
       throw new Error(
         `No supported API routes were discovered. ${getEmbedConfig().cliName} start-api supports AWS::ApiGateway::* (REST v1), AWS::ApiGatewayV2::* (HTTP + WebSocket), and AWS::Lambda::Url (Function URL) with AWS_PROXY integrations only.`
@@ -637,19 +641,24 @@ async function localStartApiCommand(
     // plus the identifiers that matched nothing. Available identifiers are
     // computed once inside it (not per-id) for the O(N·M) bound.
     if (apiFilters.length > 0) {
-      const { filtered, unmatched } = resolveApiTargetSubset(
+      const { filtered, filteredWebSocketApis, unmatched } = resolveApiTargetSubset(
         routesWithAuth,
         apiFilters,
-        targetStacks.map((s) => s.stackName)
+        targetStacks.map((s) => s.stackName),
+        webSocketApis
       );
       // Surface any individual identifier that matched nothing (the union
-      // still has routes from its siblings, so the run continues) — a
-      // single typo in a multi-target list otherwise silently serves a
+      // still has routes / WS APIs from its siblings, so the run continues) —
+      // a single typo in a multi-target list otherwise silently serves a
       // smaller set than the user asked for. Gated one-shot per identifier
       // (`unmatchedTargetWarned`) so a `--watch` hot reload doesn't re-warn
       // the same typo on every file change.
       if (unmatched.length > 0) {
-        const available = availableApiIdentifiers(routesWithAuth).join(', ') || '(none)';
+        const available =
+          [
+            ...availableApiIdentifiers(routesWithAuth),
+            ...availableWebSocketApiIdentifiers(webSocketApis),
+          ].join(', ') || '(none)';
         for (const id of unmatched) {
           if (unmatchedTargetWarned.has(id)) continue;
           unmatchedTargetWarned.add(id);
@@ -659,6 +668,9 @@ async function localStartApiCommand(
         }
       }
       routesWithAuth = filtered;
+      // Issue #311: narrow the served WS APIs to the target subset too (they
+      // were previously served in full regardless of the target).
+      webSocketApis = filteredWebSocketApis;
     }
 
     // PR 8c: per-API CORS config. HTTP API v2's `CorsConfiguration` +
@@ -1499,9 +1511,16 @@ export function allStacksConflicts(
  * once per typo without re-running the per-id filter).
  */
 export interface ApiTargetSubset {
-  /** The UNION of routes matching any supplied identifier. Non-empty. */
+  /** The UNION of routes matching any supplied identifier. */
   readonly filtered: RouteWithAuth[];
-  /** Identifiers that matched zero routes — order preserved from input. */
+  /**
+   * The UNION of WebSocket APIs matching any supplied identifier (issue
+   * #311). Empty when no WS API was passed / matched. At least one of
+   * `filtered` / `filteredWebSocketApis` is non-empty (else the resolver
+   * throws "did not match any discovered API").
+   */
+  readonly filteredWebSocketApis: DiscoveredWebSocketApi[];
+  /** Identifiers that matched zero routes AND zero WS APIs — input order. */
   readonly unmatched: string[];
 }
 
@@ -1532,7 +1551,8 @@ export interface ApiTargetSubset {
 export function resolveApiTargetSubset(
   routes: readonly RouteWithAuth[],
   identifiers: readonly string[],
-  stackNames: readonly string[]
+  stackNames: readonly string[],
+  webSocketApis: readonly DiscoveredWebSocketApi[] = []
 ): ApiTargetSubset {
   // Strict multi-stack rejection for the bare-logical-id form (no `:`,
   // no `/`). A bare id in a multi-stack app is ambiguous, because two
@@ -1554,23 +1574,33 @@ export function resolveApiTargetSubset(
   }
 
   const filtered = filterRoutesByApiIdentifiers(routes, identifiers);
-  if (filtered.length === 0) {
-    const available = availableApiIdentifiers(routes).join(', ') || '(none)';
+  // Issue #311: WebSocket APIs are filtered by the SAME identifiers as routes
+  // (previously they were always served as a group, so an explicit target
+  // that named a WS API matched no route and threw). A WS-only target now
+  // resolves to its API, and an HTTP / REST target no longer drags unrelated
+  // WS APIs along.
+  const filteredWebSocketApis = filterWebSocketApisByIdentifiers(webSocketApis, identifiers);
+  if (filtered.length === 0 && filteredWebSocketApis.length === 0) {
+    const available =
+      [...availableApiIdentifiers(routes), ...availableWebSocketApiIdentifiers(webSocketApis)].join(
+        ', '
+      ) || '(none)';
     throw new Error(
       `Target(s) [${identifiers.join(', ')}] did not match any discovered API. Available identifiers: ${available}.`
     );
   }
 
-  // Surface any individual identifier that matched nothing (the union
-  // still has routes from its siblings, so the run continues) — a single
-  // typo in a multi-target list otherwise silently serves a smaller set
-  // than the user asked for. `availableApiIdentifiers(routes)` is hoisted
-  // out of this loop (computed once below) for the caller's warning.
+  // Surface any individual identifier that matched nothing — neither a route
+  // NOR a WS API (the union still has the matched siblings, so the run
+  // continues) — a single typo in a multi-target list otherwise silently
+  // serves a smaller set than the user asked for.
   const unmatched = identifiers.filter(
-    (id) => filterRoutesByApiIdentifiers(routes, [id]).length === 0
+    (id) =>
+      filterRoutesByApiIdentifiers(routes, [id]).length === 0 &&
+      filterWebSocketApisByIdentifiers(webSocketApis, [id]).length === 0
   );
 
-  return { filtered, unmatched };
+  return { filtered, filteredWebSocketApis, unmatched };
 }
 
 /**

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -57,6 +57,13 @@ export {
   discoverWebSocketApis,
   discoverWebSocketApisOrThrow,
   parseSelectionExpressionPath,
+  // Consumed by cdkd / `cdkl studio` to serve a SINGLE WebSocket API:
+  // `start-api`'s target subset resolver filters WebSocket APIs by the same
+  // id forms it accepts for routes, so a host can pass a WS API's construct
+  // path as an explicit target (issue #311).
+  webSocketApiMatchesIdentifier,
+  filterWebSocketApisByIdentifiers,
+  availableWebSocketApiIdentifiers,
   type DiscoveredWebSocketApi,
   type WebSocketRouteEntry,
 } from './local/websocket-route-discovery.js';

--- a/src/local/websocket-route-discovery.ts
+++ b/src/local/websocket-route-discovery.ts
@@ -469,3 +469,64 @@ function readApiCdkPath(logicalId: string, template: CloudFormationTemplate): st
   const path = readCdkPath(resource);
   return path === '' ? undefined : path;
 }
+
+/**
+ * Match a single user-supplied identifier against a discovered WebSocket
+ * API, mirroring `routeMatchesIdentifier` in `api-server-grouping.ts` so the
+ * `cdkl start-api <target>` selector accepts the SAME id forms for a
+ * WebSocket API it accepts for a route-based one:
+ *   - the bare logical id of the `AWS::ApiGatewayV2::Api` resource,
+ *   - the stack-qualified `<StackName>:<LogicalId>` form,
+ *   - the CDK Construct path (exact, or as a `<path>/...` prefix so a
+ *     parent-construct id selects the API beneath it).
+ *
+ * Consumed by `resolveApiTargetSubset` (and `cdkl studio`, which serves a
+ * single WebSocket API by passing its construct-path target to `start-api`).
+ */
+export function webSocketApiMatchesIdentifier(
+  api: DiscoveredWebSocketApi,
+  identifier: string
+): boolean {
+  if (api.apiLogicalId === identifier) return true;
+  if (api.apiStackName && identifier === `${api.apiStackName}:${api.apiLogicalId}`) return true;
+  if (api.apiCdkPath) {
+    if (identifier === api.apiCdkPath) return true;
+    if (api.apiCdkPath.startsWith(`${identifier}/`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Filter the WebSocket API list to the UNION of the supplied identifiers
+ * (the variadic `cdkl start-api <target...>` shape). An empty `identifiers`
+ * list returns every API unchanged — the "serve all" default. Mirrors
+ * `filterRoutesByApiIdentifiers` for the route surface.
+ */
+export function filterWebSocketApisByIdentifiers(
+  apis: readonly DiscoveredWebSocketApi[],
+  identifiers: readonly string[]
+): DiscoveredWebSocketApi[] {
+  if (identifiers.length === 0) return [...apis];
+  return apis.filter((api) => identifiers.some((id) => webSocketApiMatchesIdentifier(api, id)));
+}
+
+/**
+ * Enumerate every distinct WebSocket API identifier, in discovery order,
+ * in its PRIMARY form (CDK Construct path when available, else bare logical
+ * id) — folded into the "available identifiers" hint when a `start-api`
+ * target matches nothing. Mirrors `availableApiIdentifiers` for routes.
+ */
+export function availableWebSocketApiIdentifiers(
+  apis: readonly DiscoveredWebSocketApi[]
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const api of apis) {
+    const primary = api.apiCdkPath ?? api.apiLogicalId;
+    if (!seen.has(primary)) {
+      seen.add(primary);
+      out.push(primary);
+    }
+  }
+  return out;
+}

--- a/tests/integration/local-start-api-websocket/verify.sh
+++ b/tests/integration/local-start-api-websocket/verify.sh
@@ -74,8 +74,70 @@ cleanup() {
   fi
   rm -f "${LOG_FILE}"
   rm -f "$(pwd)/.ws-client.mjs"
+  rm -f "$(pwd)/.et-client.mjs"
 }
 trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Explicit WebSocket-API target (issue #311): `cdkl start-api <WsApi target>`
+# serves ONLY that WebSocket API. Pre-PR this threw "did not match any
+# discovered API" because the target-subset filter ignored WebSocket APIs
+# (they were always served as a group, never selectable). Boot the explicit
+# target on a separate port, assert it serves + a client round-trips, then
+# tear it down before the main no-target suite.
+# ---------------------------------------------------------------------------
+ET_TARGET="CdkLocalStartApiWebSocket/WsApi"
+ET_PORT=$(( PORT + 1 ))
+ET_LOG="$(mktemp)"
+echo "==> Explicit WS target: cdkl start-api '${ET_TARGET}' on port ${ET_PORT}"
+${CDKL} start-api "${ET_TARGET}" \
+  --port "${ET_PORT}" \
+  --container-host "${CONTAINER_HOST}" \
+  --no-pull \
+  >"${ET_LOG}" 2>&1 &
+ET_PID=$!
+ET_READY=0
+for _ in $(seq 1 60); do
+  if grep -q "Server listening on ws" "${ET_LOG}" 2>/dev/null; then ET_READY=1; break; fi
+  if grep -qi "did not match any discovered API" "${ET_LOG}" 2>/dev/null; then
+    echo "FAIL: explicit WS target '${ET_TARGET}' was rejected (the #311 regression)"
+    cat "${ET_LOG}"; kill "${ET_PID}" 2>/dev/null || true; rm -f "${ET_LOG}"; exit 1
+  fi
+  if ! kill -0 "${ET_PID}" 2>/dev/null; then
+    echo "FAIL: explicit WS-target server exited during boot"; cat "${ET_LOG}"; rm -f "${ET_LOG}"; exit 1
+  fi
+  sleep 0.5
+done
+if [[ "${ET_READY}" -ne 1 ]]; then
+  echo "FAIL: explicit WS-target serve did not come up within 30s"; cat "${ET_LOG}"
+  kill "${ET_PID}" 2>/dev/null || true; rm -f "${ET_LOG}"; exit 1
+fi
+ET_WS_URL=$(grep -E "^Server listening on ws" "${ET_LOG}" | head -1 | sed -E 's/^Server listening on (ws[s]?:\/\/[^[:space:]]+).*/\1/')
+echo "    OK: explicit WS target serves at ${ET_WS_URL}"
+# One client round-trip through the explicitly-targeted serve (the `sendMessage`
+# route echoes the frame's `text` back via PostToConnection).
+cat > "$(pwd)/.et-client.mjs" <<'NODE'
+import { WebSocket } from 'ws';
+const ws = new WebSocket(process.argv[2]);
+let got = '';
+const done = (code, msg) => { if (msg) console.error(msg); process.exit(code); };
+ws.on('open', () => ws.send(JSON.stringify({ action: 'sendMessage', text: 'hi-explicit-311' })));
+ws.on('message', (d) => { got = d.toString(); ws.close(); });
+ws.on('error', (e) => done(1, 'client error: ' + e.message));
+ws.on('close', () => got.includes('hi-explicit-311') ? (console.log('PASS:', got), done(0)) : done(1, 'no echo: ' + got));
+setTimeout(() => done(1, 'timeout waiting for echo'), 30000);
+NODE
+if ! node "$(pwd)/.et-client.mjs" "${ET_WS_URL}"; then
+  echo "FAIL: explicit WS-target client round-trip"; cat "${ET_LOG}"
+  kill "${ET_PID}" 2>/dev/null || true; rm -f "${ET_LOG}" "$(pwd)/.et-client.mjs"; exit 1
+fi
+rm -f "$(pwd)/.et-client.mjs"
+kill -TERM "${ET_PID}" 2>/dev/null || true
+for _ in $(seq 1 20); do kill -0 "${ET_PID}" 2>/dev/null || break; sleep 0.5; done
+kill -KILL "${ET_PID}" 2>/dev/null || true; wait "${ET_PID}" 2>/dev/null || true
+docker ps --filter "name=cdkl-" -q | xargs -r docker rm -f >/dev/null 2>&1 || true
+rm -f "${ET_LOG}"
+echo "    OK: explicit WS-target client round-trip echoed 'hi-explicit-311'"
 
 echo "==> Starting cdkl start-api on port ${PORT}"
 ${CDKL} start-api \

--- a/tests/unit/cli/local-start-api-target-subset.test.ts
+++ b/tests/unit/cli/local-start-api-target-subset.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import type { RouteWithAuth } from '../../../src/local/authorizer-resolver.js';
 import type { DiscoveredRoute } from '../../../src/local/route-discovery.js';
+import type { DiscoveredWebSocketApi } from '../../../src/local/websocket-route-discovery.js';
 import { resolveApiTargetSubset } from '../../../src/cli/commands/local-start-api.js';
 
 // Mirror of `tests/unit/local/api-server-grouping.test.ts`'s `makeRoute`:
@@ -20,6 +21,20 @@ function makeRoute(partial: Partial<DiscoveredRoute>): RouteWithAuth {
     ...(partial.apiCdkPath !== undefined && { apiCdkPath: partial.apiCdkPath }),
   };
   return { route, authorizer: undefined };
+}
+
+// Minimal `DiscoveredWebSocketApi` — the subset resolver only reads the
+// identity fields (apiLogicalId / apiStackName / apiCdkPath) for matching.
+function makeWsApi(partial: Partial<DiscoveredWebSocketApi>): DiscoveredWebSocketApi {
+  return {
+    apiLogicalId: partial.apiLogicalId ?? 'WsApi',
+    apiStackName: partial.apiStackName ?? 'Stack',
+    declaredAt: partial.declaredAt ?? `${partial.apiStackName ?? 'Stack'}/${partial.apiLogicalId ?? 'WsApi'}`,
+    routeSelectionExpression: partial.routeSelectionExpression ?? '$request.body.action',
+    stage: partial.stage ?? 'prod',
+    routes: partial.routes ?? [],
+    ...(partial.apiCdkPath !== undefined && { apiCdkPath: partial.apiCdkPath }),
+  };
 }
 
 describe('resolveApiTargetSubset (variadic start-api subset resolution)', () => {
@@ -100,5 +115,45 @@ describe('resolveApiTargetSubset (variadic start-api subset resolution)', () => 
     const slash = resolveApiTargetSubset(routes, ['WebStack/MyApi'], ['WebStack', 'AdminStack']);
     expect(slash.filtered).toHaveLength(1);
     expect(slash.unmatched).toEqual([]);
+  });
+
+  // --- WebSocket APIs as explicit targets (issue #311) ---
+
+  it('resolves a WebSocket-API-only target (no route match) without throwing', () => {
+    const ws = makeWsApi({ apiLogicalId: 'WsApi', apiCdkPath: 'Stack/WsApi' });
+    const routes = [makeRoute({ source: 'http-api', apiLogicalId: 'MyHttpApi' })];
+    const r = resolveApiTargetSubset(routes, ['Stack/WsApi'], ['Stack'], [ws]);
+    expect(r.filtered).toHaveLength(0); // no route matched
+    expect(r.filteredWebSocketApis).toEqual([ws]); // the WS API matched
+    expect(r.unmatched).toEqual([]);
+  });
+
+  it('narrows WebSocket APIs to the target subset (an HTTP target drops WS APIs)', () => {
+    const ws = makeWsApi({ apiLogicalId: 'WsApi', apiCdkPath: 'Stack/WsApi' });
+    const routes = [makeRoute({ source: 'http-api', apiLogicalId: 'MyHttpApi' })];
+    const r = resolveApiTargetSubset(routes, ['MyHttpApi'], ['Stack'], [ws]);
+    expect(r.filtered).toHaveLength(1);
+    expect(r.filteredWebSocketApis).toEqual([]); // WS API NOT dragged along
+  });
+
+  it('lists WebSocket API identifiers in the empty-union error', () => {
+    const ws = makeWsApi({ apiLogicalId: 'WsApi', apiCdkPath: 'Stack/WsApi' });
+    const routes = [makeRoute({ source: 'http-api', apiLogicalId: 'MyHttpApi' })];
+    expect(() => resolveApiTargetSubset(routes, ['Nope'], ['Stack'], [ws])).toThrow(/Stack\/WsApi/);
+  });
+
+  it('treats a matched WebSocket id as matched in the unmatched scan', () => {
+    const ws = makeWsApi({ apiLogicalId: 'WsApi', apiCdkPath: 'Stack/WsApi' });
+    const routes = [makeRoute({ source: 'http-api', apiLogicalId: 'MyHttpApi' })];
+    // 'MyHttpApi' matches a route, 'Stack/WsApi' matches the WS API, 'Typo' neither.
+    const r = resolveApiTargetSubset(
+      routes,
+      ['MyHttpApi', 'Stack/WsApi', 'Typo'],
+      ['Stack'],
+      [ws]
+    );
+    expect(r.unmatched).toEqual(['Typo']);
+    expect(r.filtered).toHaveLength(1);
+    expect(r.filteredWebSocketApis).toEqual([ws]);
   });
 });

--- a/tests/unit/local/websocket-route-discovery.test.ts
+++ b/tests/unit/local/websocket-route-discovery.test.ts
@@ -3,6 +3,10 @@ import {
   discoverWebSocketApis,
   discoverWebSocketApisOrThrow,
   parseSelectionExpressionPath,
+  webSocketApiMatchesIdentifier,
+  filterWebSocketApisByIdentifiers,
+  availableWebSocketApiIdentifiers,
+  type DiscoveredWebSocketApi,
 } from '../../../src/local/websocket-route-discovery.js';
 import { RouteDiscoveryError } from '../../../src/utils/error-handler.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
@@ -623,5 +627,41 @@ describe('discoverWebSocketApis B2 authorizer admission guard', () => {
     });
     const { apis } = discoverWebSocketApis([stack]);
     expect(apis[0]!.unsupported).toBeUndefined();
+  });
+});
+
+describe('WebSocket API target matchers (issue #311)', () => {
+  const mk = (over: Partial<DiscoveredWebSocketApi>): DiscoveredWebSocketApi => ({
+    apiLogicalId: over.apiLogicalId ?? 'WsApi',
+    apiStackName: over.apiStackName ?? 'Stack',
+    declaredAt: `${over.apiStackName ?? 'Stack'}/${over.apiLogicalId ?? 'WsApi'}`,
+    routeSelectionExpression: '$request.body.action',
+    stage: 'prod',
+    routes: [],
+    ...(over.apiCdkPath !== undefined && { apiCdkPath: over.apiCdkPath }),
+  });
+
+  it('matches by bare logical id, stack-qualified id, and cdk path (exact + prefix)', () => {
+    const api = mk({ apiLogicalId: 'WsApi', apiStackName: 'Stack', apiCdkPath: 'Stack/WsApi' });
+    expect(webSocketApiMatchesIdentifier(api, 'WsApi')).toBe(true);
+    expect(webSocketApiMatchesIdentifier(api, 'Stack:WsApi')).toBe(true);
+    expect(webSocketApiMatchesIdentifier(api, 'Stack/WsApi')).toBe(true);
+    expect(webSocketApiMatchesIdentifier(api, 'Stack')).toBe(true); // prefix of the cdk path
+    expect(webSocketApiMatchesIdentifier(api, 'Other')).toBe(false);
+  });
+
+  it('filters to the union of identifiers; empty identifiers returns all', () => {
+    const a = mk({ apiLogicalId: 'A', apiCdkPath: 'Stack/A' });
+    const b = mk({ apiLogicalId: 'B', apiCdkPath: 'Stack/B' });
+    expect(filterWebSocketApisByIdentifiers([a, b], ['Stack/A'])).toEqual([a]);
+    expect(filterWebSocketApisByIdentifiers([a, b], ['A', 'B'])).toEqual([a, b]);
+    expect(filterWebSocketApisByIdentifiers([a, b], [])).toEqual([a, b]);
+    expect(filterWebSocketApisByIdentifiers([a, b], ['Nope'])).toEqual([]);
+  });
+
+  it('enumerates the primary form (cdk path when present, else logical id), de-duped', () => {
+    const a = mk({ apiLogicalId: 'A', apiCdkPath: 'Stack/A' });
+    const b = mk({ apiLogicalId: 'B' }); // no cdk path -> bare id
+    expect(availableWebSocketApiIdentifiers([a, b, a])).toEqual(['Stack/A', 'B']);
   });
 });


### PR DESCRIPTION
## Summary

`cdkl start-api <target>` now accepts a **WebSocket API** as an explicit
target — it filters WebSocket APIs by the supplied identifier(s) the same
way it already filters REST / HTTP / Function URL routes.

Previously WebSocket APIs were discovered separately and **always served as
a group**, ignored by the target filter. So:
- targeting a WebSocket API errored — `Target(s) [Stack/MyWsApi] did not
  match any discovered API` (the route filter found nothing and threw);
- targeting an HTTP / REST API also booted **every unrelated WebSocket
  API**.

Both are fixed. This is the prerequisite for the `cdkl studio` WebSocket
console (#303 / #311) — studio serves one target by spawning
`cdkl start-api <target>`, so it could not serve a WS API at all.

- **`src/local/websocket-route-discovery.ts`** — `webSocketApiMatchesIdentifier`
  (mirrors `routeMatchesIdentifier`), `filterWebSocketApisByIdentifiers`,
  `availableWebSocketApiIdentifiers`. Re-exported from `cdk-local/internal`
  (host parity — cdkd / studio).
- **`src/cli/commands/local-start-api.ts`** — `resolveApiTargetSubset` takes
  the discovered WebSocket APIs, returns `filteredWebSocketApis`, throws
  only when BOTH routes and WS APIs are empty, and folds WS ids into the
  "available identifiers" hint + the per-id unmatched scan. The serve path
  narrows the served WS APIs to the subset.

## Behavior change

An explicit `start-api` target now scopes WebSocket APIs:
- a WebSocket-API target serves **only** that API (was: hard error);
- an HTTP / REST / Function URL target **no longer** drags unrelated
  WebSocket APIs along.

Bare `start-api` (no target) is **unchanged** — it serves every API
including all WebSocket APIs. The change is additive for the bare path and a
bugfix for the targeted path. Tracked in #311; cdkd inherits it via the
`start-api` factory + the new `cdk-local/internal` matchers.

## Test plan

- `vp run verify` green (155 files / 2380 tests). New unit tests:
  `resolveApiTargetSubset` with WS APIs (WS-only target resolves without
  throwing; an HTTP target drops WS APIs; WS ids appear in the empty-union
  error; the unmatched scan spans routes + WS); the three matchers
  (bare/qualified/cdk-path exact+prefix, union filter, primary-form
  enumeration).
- Integ (`local-start-api-websocket`, real Docker): a new pre-section boots
  `cdkl start-api 'CdkLocalStartApiWebSocket/WsApi'` (explicit WS target) on
  its own port, asserts it serves (`Server listening on ws://...`) instead
  of the old "did not match" error, and round-trips a `ws` client through
  the explicitly-targeted serve (`sendMessage` echo). The existing no-target
  suite (all WS routes / multi-client / deny / drain / sigterm) still runs.
- Live-tested: `cdkl start-api CdkLocalStartApiWebSocket/WsApi` against the
  fixture serves `ws://127.0.0.1:PORT/prod (WsApi (WebSocket API))`.

Part 1 of the studio WebSocket console (#311). Part 2 (the browser console)
follows.
