### PR TITLE
feat(studio): in-browser WebSocket console for served WebSocket APIs (#303)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -333,7 +333,12 @@ compute-locally category for Lambda + API Gateway).
   [Invoke] composer (`INVOKE_KINDS`), serve
   targets (api / alb / ecs) a [Start]/[Stop] control with a `running ●
   :port` indicator (ecs services show `running` with no port — only the
-  servable ECS *services* are runnable, not the task definitions); the
+  servable ECS *services* are runnable, not the task definitions); a served
+  API Gateway WebSocket API additionally gets a WebSocket console
+  (`renderWsConsole` — connect / send-frame / received-frame log) wired
+  straight to its ws:// endpoint, with the socket + frame log held in module
+  state so a log-driven serve re-render never drops the connection (issue
+  #303); the
   timeline carries both Lambda invocations and captured serve requests,
   the latter opening a read-only Request/Response detail; a log search box
   queries the store and a captured request's detail shows its bound logs),

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -517,6 +517,12 @@ const STUDIO_SCRIPT = `
     const st = serveState.get(id) || { status: 'stopped', endpoints: [] };
     const running = st.status === 'running';
     const starting = st.status === 'starting';
+    // A NON-running render (serve stopped / starting) tears down any open
+    // WebSocket-console socket: its endpoint is gone, and leaving it open would
+    // show "● connected" against a dead serve if the same target is restarted.
+    // A RUNNING re-render (a streamed log line) keeps the socket alive — the
+    // console re-syncs from module state, so the connection survives.
+    if (!running) closeActiveWs();
 
     const meta = serveMeta.get(id);
     const kind = meta ? meta.kind : 'api';
@@ -659,9 +665,12 @@ const STUDIO_SCRIPT = `
     wsSyncUi();
     sock.onopen = function () { if (activeWs === sock) { wsAppend('--', 'connected'); wsSyncUi(); } };
     sock.onmessage = function (e) {
+      if (activeWs !== sock) return; // ignore a late frame from a replaced socket
       // A frame arrives as a string (text) or — the local emulator's
       // PostToConnection path sends binary — a Blob / ArrayBuffer. Decode the
       // binary forms to text so the console shows the payload, not a placeholder.
+      // (A binary Blob decodes async via .text(), so two rapid binary frames
+      // could append slightly out of receive order — fine for a dev console.)
       const d = e.data;
       if (typeof d === 'string') wsAppend('<-', d);
       else if (d && typeof d.text === 'function') d.text().then(function (t) { wsAppend('<-', t); });

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -12,7 +12,10 @@
  *   - center = the WORKSPACE for the selected target: for a Lambda or an
  *     AgentCore runtime, an event composer (textarea + Invoke button) with
  *     the latest run's Request / Response / Logs shown below; for an API, a
- *     Start/Stop control with the served endpoints + streaming logs.
+ *     Start/Stop control with the served endpoints + streaming logs. A served
+ *     API Gateway WebSocket API additionally gets a WebSocket console
+ *     (connect / send frame / received-frame log) wired straight to its ws://
+ *     endpoint (issue #303).
  *   - right  = the timeline (history) of every invocation AND every
  *     captured serve request (slice C2); clicking a Lambda row reloads
  *     it into the composer, clicking a captured request row opens a
@@ -127,6 +130,17 @@ const STUDIO_CSS = `
   .section pre { margin: 0; white-space: pre-wrap; word-break: break-word; color: #cfcfcf; }
   .endpoint { display: block; color: #6aa9ff; text-decoration: none; padding: 2px 0; }
   .endpoint:hover { text-decoration: underline; }
+  .ws-console .ws-status { font-size: 12px; color: #888; margin-left: 8px; font-weight: 400; }
+  .ws-console .ws-status.on { color: #4ec97a; }
+  .ws-row { display: flex; gap: 6px; align-items: center; margin: 6px 0; }
+  .ws-row .ws-input { flex: 1; min-width: 0; background: #1a1a1a; border: 1px solid #333;
+    color: #ddd; border-radius: 4px; padding: 5px 7px; font: inherit; }
+  .ws-row .ws-input:focus { outline: none; border-color: #4ec97a; }
+  .ws-row button { background: #2a4636; color: #cfe; border: 0; border-radius: 4px;
+    padding: 5px 12px; cursor: pointer; }
+  .ws-row button:disabled { background: #2a2a2a; color: #666; cursor: default; }
+  .ws-frames { max-height: 180px; overflow: auto; background: #141414; border: 1px solid #262626;
+    border-radius: 4px; padding: 6px 8px; margin-top: 4px; min-height: 22px; }
   .searchbar { padding: 6px 10px; border-bottom: 1px solid #2a2a2a; background: #151515;
     position: sticky; top: 28px; z-index: 1; }
   .searchbar input {
@@ -437,6 +451,10 @@ const STUDIO_SCRIPT = `
   }
 
   function selectTarget(id, kind) {
+    // Navigating to any target closes a WebSocket console socket left open on
+    // a previously-shown serve (a log-driven re-render keeps it, an explicit
+    // navigation drops it — see renderWsConsole).
+    closeActiveWs();
     highlightTarget(id);
     shownDetailId = null;
     if (SERVE_KINDS.includes(kind)) {
@@ -541,6 +559,13 @@ const STUDIO_SCRIPT = `
     }
     ws.appendChild(epSec);
 
+    // A served WebSocket API exposes a ws:// endpoint — attach a WebSocket
+    // console so the browser can connect + exchange frames (issue #303).
+    const wsEndpoint = running ? (st.endpoints || []).find((u) => /^wss?:/.test(u)) : null;
+    if (wsEndpoint) {
+      ws.appendChild(renderWsConsole(wsEndpoint));
+    }
+
     const logs = logsById.get(id) || [];
     const logSec = el('div', 'section');
     logSec.appendChild(el('h3', null, 'Logs'));
@@ -549,7 +574,8 @@ const STUDIO_SCRIPT = `
   }
 
   // Build an <a> that opens an http(s) endpoint in a new tab; ws:// URLs
-  // are shown as plain text (not navigable in a browser tab).
+  // are shown as plain text (not navigable in a browser tab — the WebSocket
+  // console below connects to them instead).
   function href(url) {
     if (/^https?:/.test(url)) {
       const a = el('a', 'endpoint', url);
@@ -559,6 +585,131 @@ const STUDIO_SCRIPT = `
       return a;
     }
     return el('div', 'endpoint', url);
+  }
+
+  // --- WebSocket console (issue #303) ----------------------------------------
+  // A served API Gateway WebSocket API exposes a ws:// endpoint (handed through
+  // un-proxied by the serve manager). The console connects the BROWSER straight
+  // to it so you can send frames + watch received frames, without leaving the
+  // studio tab.
+  //
+  // The serve workspace re-renders on every streamed log line (line ~931), so
+  // the socket + the frame log live in MODULE state (not the rebuilt DOM): the
+  // socket's callbacks update the CURRENT DOM via wsEl() selectors, and
+  // renderWsConsole repopulates from wsFrames + the live socket state on each
+  // rebuild. So a log-triggered re-render never drops the connection.
+  let activeWs = null;
+  let wsFrames = [];
+  let wsConsoleUrl = null;
+
+  function wsEl(sel) {
+    return document.querySelector('#workspace .ws-console ' + sel);
+  }
+  function wsSyncUi() {
+    const on = !!activeWs && activeWs.readyState === 1;
+    const status = wsEl('.ws-status');
+    if (status) {
+      status.textContent = on ? '● connected' : '○ disconnected';
+      status.className = 'ws-status' + (on ? ' on' : '');
+    }
+    const cb = wsEl('.ws-connect');
+    if (cb) cb.textContent = activeWs ? 'Disconnect' : 'Connect';
+    const inp = wsEl('.ws-input');
+    if (inp) inp.disabled = !on;
+    const sb = wsEl('.ws-send');
+    if (sb) sb.disabled = !on;
+  }
+  function wsAppend(dir, text) {
+    wsFrames.push(dir + ' ' + text);
+    if (wsFrames.length > 200) wsFrames = wsFrames.slice(-200);
+    const pre = wsEl('.ws-frames');
+    if (pre) {
+      pre.textContent = wsFrames.join('\\n');
+      pre.scrollTop = pre.scrollHeight;
+    }
+  }
+  function closeActiveWs() {
+    if (activeWs) {
+      try {
+        activeWs.onclose = null;
+        activeWs.close();
+      } catch (e) {
+        /* already closing */
+      }
+      activeWs = null;
+    }
+  }
+  function wsConnect(wsUrl) {
+    if (activeWs) {
+      closeActiveWs();
+      wsAppend('--', 'disconnected');
+      wsSyncUi();
+      return;
+    }
+    let sock;
+    try {
+      sock = new WebSocket(wsUrl);
+    } catch (err) {
+      wsAppend('!!', 'could not open: ' + err);
+      return;
+    }
+    activeWs = sock;
+    wsConsoleUrl = wsUrl;
+    wsAppend('--', 'connecting to ' + wsUrl + ' …');
+    wsSyncUi();
+    sock.onopen = function () { if (activeWs === sock) { wsAppend('--', 'connected'); wsSyncUi(); } };
+    sock.onmessage = function (e) {
+      // A frame arrives as a string (text) or — the local emulator's
+      // PostToConnection path sends binary — a Blob / ArrayBuffer. Decode the
+      // binary forms to text so the console shows the payload, not a placeholder.
+      const d = e.data;
+      if (typeof d === 'string') wsAppend('<-', d);
+      else if (d && typeof d.text === 'function') d.text().then(function (t) { wsAppend('<-', t); });
+      else if (d && d.byteLength !== undefined) wsAppend('<-', new TextDecoder().decode(d));
+      else wsAppend('<-', '[binary frame]');
+    };
+    sock.onerror = function () { wsAppend('!!', 'socket error'); };
+    sock.onclose = function () { if (activeWs === sock) { activeWs = null; wsAppend('--', 'closed'); wsSyncUi(); } };
+  }
+  function wsSend() {
+    const inp = wsEl('.ws-input');
+    if (activeWs && activeWs.readyState === 1 && inp && inp.value) {
+      activeWs.send(inp.value);
+      wsAppend('->', inp.value);
+      inp.value = '';
+    }
+  }
+
+  function renderWsConsole(wsUrl) {
+    // A fresh target's console starts with a clean frame log; same-url
+    // re-renders (log streaming) keep it so the history survives.
+    if (wsConsoleUrl !== wsUrl) wsFrames = [];
+    const on = !!activeWs && activeWs.readyState === 1;
+
+    const sec = el('div', 'section ws-console');
+    const h = el('h3', null, 'WebSocket');
+    h.appendChild(el('span', 'ws-status' + (on ? ' on' : ''), on ? '● connected' : '○ disconnected'));
+    sec.appendChild(h);
+
+    const connectBtn = el('button', 'invoke-btn ws-connect', activeWs ? 'Disconnect' : 'Connect');
+    connectBtn.onclick = function () { wsConnect(wsUrl); };
+    const input = el('input', 'ws-input');
+    input.placeholder = '{ "action": "sendMessage", "text": "hi" }';
+    input.disabled = !on;
+    input.onkeydown = function (e) { if (e.key === 'Enter') wsSend(); };
+    const sendBtn = el('button', 'ws-send', 'Send');
+    sendBtn.disabled = !on;
+    sendBtn.onclick = wsSend;
+
+    const row = el('div', 'ws-row');
+    row.appendChild(connectBtn);
+    row.appendChild(input);
+    row.appendChild(sendBtn);
+    sec.appendChild(row);
+
+    const frames = el('pre', 'ws-frames', wsFrames.join('\\n'));
+    sec.appendChild(frames);
+    return sec;
   }
 
   function renderComposer(id, kind, eventText) {
@@ -700,6 +851,7 @@ const STUDIO_SCRIPT = `
   function loadInvocation(id) {
     const ev = invById.get(id);
     if (!ev) return;
+    closeActiveWs(); // navigating to a timeline row leaves any serve WS console
     document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'));
     const row = rowsById.get(id);
     if (row) row.classList.add('sel');

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -74,6 +74,68 @@ export class LocalStudioStack extends cdk.Stack {
     // `(Function URL)` kind, keyed by the BACKING LAMBDA's logical ID.
     fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE });
 
+    // WebSocket API (issue #303) — so studio can serve it and the browser
+    // WebSocket console can connect + exchange frames. One inline Lambda backs
+    // both routes: `$connect` admits the client; `$default` echoes the frame's
+    // `text` back over the connection via the local `@connections` management
+    // endpoint (`fetch`, no SDK — the local emulator does not require SigV4).
+    // The body-action selection expression routes every message to `$default`.
+    const wsFn = new lambda.Function(this, 'WsEchoHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(
+        [
+          'exports.handler = async (event) => {',
+          '  const rc = event.requestContext || {};',
+          "  if (rc.routeKey === '$connect' || rc.routeKey === '$disconnect') return { statusCode: 200 };",
+          '  const endpoint = process.env.AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI;',
+          '  let parsed; try { parsed = JSON.parse(event.body || "{}"); } catch { parsed = { text: event.body }; }',
+          '  await fetch(endpoint + "/@connections/" + encodeURIComponent(rc.connectionId), {',
+          '    method: "POST",',
+          '    body: JSON.stringify({ route: rc.routeKey, echo: parsed.text != null ? parsed.text : null, connectionId: rc.connectionId }),',
+          '  });',
+          '  return { statusCode: 200 };',
+          '};',
+        ].join('\n')
+      ),
+    });
+    const wsApi = new apigwv2.CfnApi(this, 'MyWsApi', {
+      name: 'cdkl-studio-fixture-ws-api',
+      protocolType: 'WEBSOCKET',
+      routeSelectionExpression: '$request.body.action',
+    });
+    const wsRegion = cdk.Stack.of(this).region;
+    const wsIntegrationUri = cdk.Fn.join('', [
+      `arn:aws:apigateway:${wsRegion}:lambda:path/2015-03-31/functions/`,
+      wsFn.functionArn,
+      '/invocations',
+    ]);
+    const wsConnectInteg = new apigwv2.CfnIntegration(this, 'MyWsConnectIntegration', {
+      apiId: wsApi.ref,
+      integrationType: 'AWS_PROXY',
+      integrationUri: wsIntegrationUri,
+    });
+    const wsDefaultInteg = new apigwv2.CfnIntegration(this, 'MyWsDefaultIntegration', {
+      apiId: wsApi.ref,
+      integrationType: 'AWS_PROXY',
+      integrationUri: wsIntegrationUri,
+    });
+    new apigwv2.CfnRoute(this, 'MyWsConnectRoute', {
+      apiId: wsApi.ref,
+      routeKey: '$connect',
+      target: cdk.Fn.join('/', ['integrations', wsConnectInteg.ref]),
+    });
+    new apigwv2.CfnRoute(this, 'MyWsDefaultRoute', {
+      apiId: wsApi.ref,
+      routeKey: '$default',
+      target: cdk.Fn.join('/', ['integrations', wsDefaultInteg.ref]),
+    });
+    new apigwv2.CfnStage(this, 'MyWsStage', {
+      apiId: wsApi.ref,
+      stageName: 'prod',
+      autoDeploy: true,
+    });
+
     // ECS cluster + bridge-mode task definition + service.
     const cluster = new ecs.CfnCluster(this, 'MyCluster', {
       clusterName: 'cdkl-studio-fixture-cluster',

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -63,6 +63,7 @@ cleanup() {
     wait "${STUDIO_PID}" 2>/dev/null || true
   fi
   rm -f "${LOG_FILE}" "${BODY_FILE}" "${RUN_FILE}" "${SSE_FILE}"
+  rm -f "$(pwd)/.studio-ws-client.mjs"
 }
 trap cleanup EXIT
 
@@ -572,6 +573,73 @@ fi
 echo "    OK: serve stopped; /api/running is empty"
 
 # ---------------------------------------------------------------------------
+# 7b. WebSocket console (issue #303): studio serves a WebSocket API
+#     (`start-api LocalStudioFixture/MyWsApi`, resolvable as an explicit
+#     target since Part 1), exposes its raw ws:// endpoint un-proxied, and the
+#     browser WebSocket console connects straight to it. Drive the same path a
+#     headless client: start the serve, read the ws:// endpoint from
+#     /api/running, connect a client, send a frame, and assert the agent
+#     echoes it (proving studio -> start-api WS serve -> browser-reachable
+#     ws:// + frame exchange end-to-end). The console UI itself is unit-tested
+#     (renderStudioHtml string assertions).
+# ---------------------------------------------------------------------------
+WS_TARGET="LocalStudioFixture/MyWsApi"
+echo "==> POST /api/run starts a WebSocket-API serve for ${WS_TARGET}"
+WSV_FILE=$(mktemp)
+WHTTP=$(curl -s -o "${WSV_FILE}" -w '%{http_code}' --max-time 120 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${WS_TARGET}\",\"kind\":\"api\"}" || true)
+if [[ "${WHTTP}" != "200" ]]; then
+  echo "FAIL: WS-API serve start returned HTTP ${WHTTP}"; cat "${WSV_FILE}"; rm -f "${WSV_FILE}"; exit 1
+fi
+WSV_URL=$(grep -oE 'ws://127\.0\.0\.1:[0-9]+/[A-Za-z0-9_]+' "${WSV_FILE}" | head -1 || true)
+rm -f "${WSV_FILE}"
+if [[ -z "${WSV_URL}" ]]; then
+  echo "FAIL: studio did not expose a ws:// endpoint for the WebSocket-API serve"; exit 1
+fi
+echo "    OK: WS-API serve running at ${WSV_URL}"
+# Confirm /api/running reports it (what the UI reads to render the console).
+curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
+if ! grep -qF "${WSV_URL}" "${BODY_FILE}"; then
+  echo "FAIL: /api/running did not list the ws:// endpoint"; cat "${BODY_FILE}"; exit 1
+fi
+# Connect a client to the studio-served ws:// endpoint (Node 24 global WebSocket)
+# and assert the $default echo round-trips — the same thing the browser console
+# does.
+cat > "$(pwd)/.studio-ws-client.mjs" <<'NODE'
+const url = process.argv[2];
+const ws = new WebSocket(url);
+let got = '';
+const done = (code, msg) => { if (msg) console.error(msg); process.exit(code); };
+ws.addEventListener('open', () => ws.send(JSON.stringify({ action: 'sendMessage', text: 'studio-ws-303' })));
+ws.addEventListener('message', async (e) => {
+  // The local emulator delivers the echo as a binary Blob; decode to text
+  // (same as the browser console does).
+  got = typeof e.data === 'string' ? e.data : (e.data && typeof e.data.text === 'function' ? await e.data.text() : '');
+  ws.close();
+});
+ws.addEventListener('error', () => done(1, 'client socket error'));
+ws.addEventListener('close', () => got.includes('studio-ws-303') ? (console.log('PASS:', got), done(0)) : done(1, 'no echo: ' + got));
+setTimeout(() => done(1, 'timeout waiting for echo'), 30000);
+NODE
+if ! node "$(pwd)/.studio-ws-client.mjs" "${WSV_URL}"; then
+  echo "FAIL: WebSocket console round-trip through the studio-served endpoint"
+  curl -fsS "${URL}/api/running" -o "${BODY_FILE}" 2>/dev/null; cat "${BODY_FILE}"
+  curl -fsS "${URL}/api/stop" -H 'content-type: application/json' -d "{\"targetId\":\"${WS_TARGET}\"}" -o /dev/null 2>/dev/null || true
+  rm -f "$(pwd)/.studio-ws-client.mjs"; exit 1
+fi
+rm -f "$(pwd)/.studio-ws-client.mjs"
+echo "    OK: WebSocket console round-trip echoed 'studio-ws-303' through ${WSV_URL}"
+# Stop the WS serve.
+curl -fsS "${URL}/api/stop" -H 'content-type: application/json' -d "{\"targetId\":\"${WS_TARGET}\"}" -o /dev/null 2>/dev/null || true
+for _ in $(seq 1 20); do
+  curl -fsS "${URL}/api/running" -o "${BODY_FILE}" 2>/dev/null || true
+  if ! grep -qF "${WS_TARGET}" "${BODY_FILE}"; then break; fi
+  sleep 0.5
+done
+echo "    OK: WebSocket-API serve stopped"
+
+# ---------------------------------------------------------------------------
 # 8. The store (slice C3): history + full-text log search + per-invocation
 #    log binding (decision D5) are served from the retained event window.
 # ---------------------------------------------------------------------------
@@ -857,4 +925,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + request capture + history/log-search + per-target-options + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + ws-console + request capture + history/log-search + per-target-options + session-config + flag-threading + shutdown)"

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -43,6 +43,22 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('INVOKE_KINDS.includes(ev.kind)');
   });
 
+  it('embeds a WebSocket console for served WebSocket APIs (issue #303)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The console renderer + its lifecycle helpers are present.
+    expect(html).toContain('function renderWsConsole');
+    expect(html).toContain('new WebSocket(wsUrl)');
+    // Wired into the serve workspace for a running serve with a ws:// endpoint.
+    expect(html).toContain("/^wss?:/.test(u)");
+    expect(html).toContain('ws.appendChild(renderWsConsole(wsEndpoint))');
+    // The socket lives in module state so a log-driven serve re-render does not
+    // drop the connection; explicit navigation closes it.
+    expect(html).toContain('function closeActiveWs');
+    // A received frame may be a binary Blob (the local emulator's
+    // PostToConnection path) — decode it to text rather than show a placeholder.
+    expect(html).toContain("typeof d.text === 'function'");
+  });
+
   it('renders the editable Session bar (issue #301 slice 3)', () => {
     const html = renderStudioHtml('MyStack', 'cdkl');
     expect(html).toContain('id="session-bar"');

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -52,8 +52,11 @@ describe('renderStudioHtml', () => {
     expect(html).toContain("/^wss?:/.test(u)");
     expect(html).toContain('ws.appendChild(renderWsConsole(wsEndpoint))');
     // The socket lives in module state so a log-driven serve re-render does not
-    // drop the connection; explicit navigation closes it.
+    // drop the connection; navigation away AND a non-running re-render (serve
+    // stopped) close it so it can't linger against a dead serve.
     expect(html).toContain('function closeActiveWs');
+    expect(html).toContain('closeActiveWs();'); // called on navigation + serve stop, not just defined
+    expect(html).toContain('if (!running) closeActiveWs();'); // stop-leak guard
     // A received frame may be a binary Blob (the local emulator's
     // PostToConnection path) — decode it to text rather than show a placeholder.
     expect(html).toContain("typeof d.text === 'function'");


### PR DESCRIPTION
## Summary

`cdkl studio` now ships an **in-browser WebSocket console** for served API
Gateway WebSocket APIs (Part 2 of #303; Part 1 — `start-api` accepting a WS
API as an explicit target — landed in #314).

When studio serves a WebSocket API, the serve manager hands the raw `ws://`
endpoint to the UI un-proxied. The serve workspace now renders a console wired
straight to it: **Connect / Disconnect**, a frame input + **Send**, a
connection-status dot, and a received-frame log — the browser connects
directly to the served endpoint, no studio round-trip.

- **`src/local/studio-ui.ts`** — `renderWsConsole` + a module-state lifecycle
  (`activeWs` / `wsFrames` / `wsConnect` / `wsSend` / `closeActiveWs`). The
  serve workspace re-renders on every streamed log line, so the socket + frame
  log live in **module state** (not the rebuilt DOM); the socket callbacks
  re-sync the *current* DOM via `wsEl()` selectors and `renderWsConsole`
  repopulates from `wsFrames` + the live socket state on each rebuild — a
  log-driven re-render never drops the connection. Explicit navigation
  (`selectTarget` / `loadInvocation`) closes it. A received frame may be a
  binary `Blob` (the local emulator's PostToConnection path) — decoded to text.

## Fixture

The `local-studio` stack gains a minimal WebSocket API (`MyWsApi`): one inline
Lambda echo (`$connect` admits; `$default` echoes the frame's `text` via the
local `@connections` endpoint with a raw `fetch`, no SDK — the local emulator
doesn't require SigV4).

## Test plan

- `vp run verify` green (155 files / 2381 tests). The studio-ui unit test
  asserts the console renderer, the wiring into the serve workspace, the
  module-state lifecycle, and the Blob -> text decode.
- Integ (`local-studio`, real Docker): studio serves `MyWsApi`, `/api/running`
  exposes the `ws://` endpoint, and a client round-trips a `sendMessage` frame
  through the studio-served endpoint (`echo` of a unique token) — the same path
  the browser console drives. Zero leftover containers.
- Live-tested: a node client (Node global `WebSocket`) connects to the
  studio-served `ws://...:PORT/prod` and the `$default` echo round-trips (the
  binary frame decoded to text).

This completes the studio interaction surface for #303 (AgentCore composer +
WebSocket console). Follow-ups (separate): an "All options" section + an
image-override Dockerfile picker.
