### PR TITLE
feat(studio): add an "All options" section (auto-derived flag catalog + raw extra args)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -338,7 +338,11 @@ compute-locally category for Lambda + API Gateway).
   (`renderWsConsole` — connect / send-frame / received-frame log) wired
   straight to its ws:// endpoint, with the socket + frame log held in module
   state so a log-driven serve re-render never drops the connection (issue
-  #303); the
+  #303); every composer (invoke + serve) carries a collapsed "All options"
+  `<details>` (`buildAllOptions`) with a raw extra-args input + the
+  read-only auto-derived flag catalog from studio-option-catalog, so the
+  curated controls handle common flags richly while every other flag the
+  underlying command accepts stays reachable (issue #301); the
   timeline carries both Lambda invocations and captured serve requests,
   the latter opening a read-only Request/Response detail; a log search box
   queries the store and a captured request's detail shows its bound logs),
@@ -377,6 +381,25 @@ compute-locally category for Lambda + API Gateway).
   invoke / serve, vs the session-global flags in studio-child-args; the
   `agentcore` kind (issue #303) declares `--ws` / `--sigv4` (boolean),
   `--bearer-token` / `--session-id` (scalar), and `--env-vars` (env-kv)),
+  studio-option-catalog (issue #301 — the AUTO-DERIVED full flag catalog
+  that backs the composer's collapsed "All options" section.
+  `buildFlagCatalog` introspects each runnable kind's Commander command
+  factory (`createLocalInvoke*` / `createLocalStart*`) and emits every
+  flag (name + description), minus the session-global flags
+  (`CATALOG_EXCLUDED_FLAGS`: `--from-cfn-stack` / `--assume-role` /
+  `--app` / `--profile` / `--region` / `-c`, handled by the Session bar)
+  and the auto-added `--help` / `--version`; the curated OPTION_SPECS is a
+  rich-control subset, this is the complete reference so the UI is never
+  strictly less capable than the headless CLI. Memoized; each factory is
+  re-handed the active embed config so host branding survives + the
+  derived descriptions reflect it. `tokenizeRawArgs` is the quote-aware
+  splitter for the section's raw extra-args input — the tokens are
+  appended verbatim (LAST, so they can override a curated flag) to the
+  spawned child argv by both studio-dispatch and studio-serve-manager;
+  studio spawns children WITHOUT a shell, so there is no injection
+  surface. `coerceRunRequest` validates the `rawArgs` string at the
+  `/api/run` boundary (tokenized eagerly so an unterminated quote is a
+  clean 400)),
   studio-serve-manager (issue #282 — the
   long-running serve lifecycle, parameterized by a per-kind
   `ServeKindSpec`: `api` (`start-api`) + `alb` (`start-alb`) expose host

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -32,6 +32,7 @@ import {
   resolveEnvVars,
   type OptionValues,
 } from '../../local/studio-option-specs.js';
+import { tokenizeRawArgs } from '../../local/studio-option-catalog.js';
 import {
   createStudioServeManager,
   type StudioServeManager,
@@ -56,7 +57,7 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
   if (typeof body !== 'object' || body === null) {
     throw new Error('Request body must be a JSON object.');
   }
-  const { targetId, kind, event, options } = body as Record<string, unknown>;
+  const { targetId, kind, event, options, rawArgs } = body as Record<string, unknown>;
   if (typeof targetId !== 'string' || targetId.trim() === '') {
     throw new Error('Request body must include a non-empty "targetId" string.');
   }
@@ -75,11 +76,22 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     buildPerRunArgs(kind as StudioTargetKind, runOptions);
     resolveEnvVars(kind as StudioTargetKind, runOptions);
   }
+  let runRawArgs: string | undefined;
+  if (rawArgs !== undefined) {
+    if (typeof rawArgs !== 'string') {
+      throw new Error('Request body "rawArgs" must be a string.');
+    }
+    // Tokenize NOW so an unterminated quote fails as a clean 400 at the
+    // boundary rather than mid-spawn.
+    tokenizeRawArgs(rawArgs);
+    runRawArgs = rawArgs;
+  }
   return {
     targetId,
     kind: kind as StudioTargetKind,
     event,
     ...(runOptions !== undefined ? { options: runOptions } : {}),
+    ...(runRawArgs !== undefined ? { rawArgs: runRawArgs } : {}),
   };
 }
 

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { StudioEventBus, type StudioTargetKind } from './studio-events.js';
 import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
 import { buildPerRunArgs, resolveEnvVars, type OptionValues } from './studio-option-specs.js';
+import { tokenizeRawArgs } from './studio-option-catalog.js';
 
 /**
  * The single-shot invoke kinds this dispatcher drives, mapped to the `cdkl`
@@ -31,6 +32,12 @@ export interface StudioRunRequest {
   event: unknown;
   /** Per-run option values (issue #301 slice 2), keyed by option flag. */
   options?: OptionValues;
+  /**
+   * Raw extra args from the "All options" section — tokenized (quote-aware)
+   * and appended verbatim to the spawned child, after the curated per-run
+   * args, so a flag the curated controls don't expose can still be passed.
+   */
+  rawArgs?: string;
 }
 
 /** The outcome of a single-shot run, returned from `/api/run`. */
@@ -171,6 +178,10 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
         writeFileSync(envFile, JSON.stringify(envVars));
         args.push('--env-vars', envFile);
       }
+
+      // Raw extra args go LAST so a user can override a curated flag if they
+      // really mean to (Commander takes the last value for a scalar flag).
+      args.push(...tokenizeRawArgs(req.rawArgs));
 
       const { code, stdout, stderr } = await runChild(
         spawnFn,

--- a/src/local/studio-option-catalog.ts
+++ b/src/local/studio-option-catalog.ts
@@ -1,0 +1,186 @@
+/**
+ * Auto-derived full-flag catalog for `cdkl studio` (issue #301).
+ *
+ * The per-target {@link OPTION_SPECS} in `studio-option-specs.ts` is a
+ * CURATED subset — the handful of flags worth a rich control (a checkbox, a
+ * KV editor, an add-row list). But a command like `cdkl start-api` accepts
+ * many more flags than studio renders a control for, and hiding them makes
+ * the UI strictly less capable than the headless CLI.
+ *
+ * This module closes that gap by INTROSPECTING each runnable kind's Commander
+ * command factory and emitting the complete flag list (name + description).
+ * The studio UI serializes it into the page and renders, inside a collapsed
+ * "All options" section, (a) the full catalog as a read-only reference and
+ * (b) a raw extra-args input (see {@link tokenizeRawArgs}) so any flag the
+ * curated controls don't expose can still be passed verbatim. Auto-derivation
+ * means the catalog can never drift from the command's real option set.
+ *
+ * Session-global flags (handled by the studio Session bar / `studio-child-args`)
+ * and the auto-added `--help` / `--version` are excluded — passing them per-run
+ * would conflict with the session-wide wiring.
+ */
+
+import { createLocalInvokeCommand } from '../cli/commands/local-invoke.js';
+import { createLocalInvokeAgentCoreCommand } from '../cli/commands/local-invoke-agentcore.js';
+import { createLocalStartApiCommand } from '../cli/commands/local-start-api.js';
+import { createLocalStartAlbCommand } from '../cli/commands/local-start-alb.js';
+import { createLocalStartServiceCommand } from '../cli/commands/local-start-service.js';
+import { getEmbedConfig, setEmbedConfig, type CdkLocalEmbedConfig } from './embed-config.js';
+import type { StudioTargetKind } from './studio-events.js';
+import type { Command } from 'commander';
+
+/** One flag the underlying command accepts. */
+export interface FlagInfo {
+  /** The Commander flags string, e.g. `-e, --event <file>` or `--tls`. */
+  flags: string;
+  /** The option's help description (may be empty). */
+  description: string;
+}
+
+/** The full flag catalog for one runnable kind. */
+export interface KindFlagCatalog {
+  /** The headless subcommand these flags belong to, e.g. `start-api`. */
+  command: string;
+  /** Every flag the command accepts, minus session-global + help/version. */
+  flags: FlagInfo[];
+}
+
+/**
+ * Long flag names handled by the session bar / `studio-child-args` (forwarded
+ * to every spawned child once, session-wide). Excluded from the per-target
+ * catalog so a user does not re-specify them per-run and collide with the
+ * session-wide value. Plus the Commander-managed `--help` / `--version`.
+ */
+export const CATALOG_EXCLUDED_FLAGS: ReadonlySet<string> = new Set([
+  '--app',
+  '--profile',
+  '--region',
+  '--context',
+  '--from-cfn-stack',
+  '--assume-role',
+  '--help',
+  '--version',
+]);
+
+/**
+ * The runnable kind -> command factory + headless subcommand name. Mirrors
+ * the kind->verb maps in `studio-dispatch` (`INVOKE_VERBS`) and
+ * `studio-serve-manager` (`SERVE_SPECS`); studio spawns these commands as
+ * children, so their flag sets are exactly what a per-run override may carry.
+ */
+type FlagCommandFactory = (opts?: { embedConfig?: CdkLocalEmbedConfig }) => Command;
+
+const KIND_FACTORIES: Record<StudioTargetKind, { command: string; factory: FlagCommandFactory }> = {
+  lambda: { command: 'invoke', factory: createLocalInvokeCommand },
+  agentcore: { command: 'invoke-agentcore', factory: createLocalInvokeAgentCoreCommand },
+  api: { command: 'start-api', factory: createLocalStartApiCommand },
+  alb: { command: 'start-alb', factory: createLocalStartAlbCommand },
+  ecs: { command: 'start-service', factory: createLocalStartServiceCommand },
+};
+
+let cached: Partial<Record<StudioTargetKind, KindFlagCatalog>> | undefined;
+
+/**
+ * Build (and memoize) the full per-kind flag catalog by introspecting each
+ * runnable kind's Commander command factory.
+ *
+ * Each factory calls `setEmbedConfig(opts.embedConfig)` at construction — with
+ * no opts that resets the active embed config to cdk-local defaults, which
+ * would wipe a host CLI's branding. So the active config is snapshotted and
+ * each factory is re-handed it: branding is preserved AND the derived flag
+ * descriptions reflect the host's active branding. The `finally` restore is a
+ * belt-and-suspenders against a factory that ignores the passed config.
+ * Memoized: the factories are instantiated exactly once per process, not per
+ * page render.
+ */
+export function buildFlagCatalog(): Partial<Record<StudioTargetKind, KindFlagCatalog>> {
+  if (cached) return cached;
+  const savedEmbedConfig = getEmbedConfig();
+  try {
+    const out: Partial<Record<StudioTargetKind, KindFlagCatalog>> = {};
+    for (const kind of Object.keys(KIND_FACTORIES) as StudioTargetKind[]) {
+      const { command, factory } = KIND_FACTORIES[kind];
+      const cmd = factory({ embedConfig: savedEmbedConfig });
+      const flags: FlagInfo[] = [];
+      for (const opt of cmd.options) {
+        if (opt.hidden) continue;
+        if (opt.long && CATALOG_EXCLUDED_FLAGS.has(opt.long)) continue;
+        flags.push({ flags: opt.flags, description: opt.description ?? '' });
+      }
+      out[kind] = { command, flags };
+    }
+    cached = out;
+    return out;
+  } finally {
+    // Restore branding (ResolvedEmbedConfig is a superset of the input shape).
+    setEmbedConfig(savedEmbedConfig);
+  }
+}
+
+/**
+ * Test-only: clear the memoized catalog so a test can force a fresh build
+ * (e.g. to exercise the embed-config snapshot/restore path under custom
+ * branding, which the memoized fast-path would otherwise skip). Not part of
+ * the production flow.
+ */
+export function __resetFlagCatalogCacheForTest(): void {
+  cached = undefined;
+}
+
+/**
+ * Tokenize a raw extra-args string into discrete argv elements, honoring
+ * single / double quotes and backslash escaping so values with spaces survive
+ * (`--name "two words"` -> `['--name', 'two words']`). studio spawns children
+ * WITHOUT a shell (argv array), so the tokens are appended verbatim — there is
+ * no shell-injection surface; the child command still validates each arg.
+ *
+ * Returns `[]` for an empty / whitespace-only input. Throws on an unterminated
+ * quote so a malformed raw-args string fails as a clean boundary error rather
+ * than spawning a child with a mis-split argv.
+ */
+export function tokenizeRawArgs(raw: string | undefined): string[] {
+  if (raw === undefined) return [];
+  const tokens: string[] = [];
+  let current = '';
+  let inToken = false;
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (quote) {
+      if (ch === '\\' && quote === '"' && i + 1 < raw.length) {
+        // Inside double quotes a backslash escapes the next char (shell-like).
+        current += raw[++i];
+      } else if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      inToken = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < raw.length) {
+      current += raw[++i];
+      inToken = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      if (inToken) {
+        tokens.push(current);
+        current = '';
+        inToken = false;
+      }
+      continue;
+    }
+    current += ch;
+    inToken = true;
+  }
+  if (quote) {
+    throw new Error(`Raw extra args have an unterminated ${quote} quote.`);
+  }
+  if (inToken) tokens.push(current);
+  return tokens;
+}

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -7,6 +7,7 @@ import {
 } from './studio-proxy.js';
 import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
 import { buildPerRunArgs, type OptionValues } from './studio-option-specs.js';
+import { tokenizeRawArgs } from './studio-option-catalog.js';
 
 /** A request to start serving a target, as the studio UI posts it. */
 export interface StudioServeRequest {
@@ -16,6 +17,12 @@ export interface StudioServeRequest {
   kind: StudioTargetKind;
   /** Per-run option values (issue #301 slice 2), keyed by option flag. */
   options?: OptionValues;
+  /**
+   * Raw extra args from the "All options" section — tokenized (quote-aware)
+   * and appended verbatim to the spawned serve child, so a flag the curated
+   * controls don't expose can still be passed.
+   */
+  rawArgs?: string;
 }
 
 /** A request to stop a running served target. */
@@ -254,6 +261,9 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       // changes. Read off the (mutable) config per start so a Session-bar
       // toggle applies to the next serve.
       ...(config.watch === true ? ['--watch'] : []),
+      // Raw extra args go LAST so a user can override an earlier flag if they
+      // mean to (Commander takes the last value for a scalar flag).
+      ...tokenizeRawArgs(req.rawArgs),
     ];
   }
 

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -26,6 +26,7 @@
  * the primary surface — the timeline is secondary history.
  */
 
+import { buildFlagCatalog } from './studio-option-catalog.js';
 import { OPTION_SPECS } from './studio-option-specs.js';
 
 const STUDIO_CSS = `
@@ -177,6 +178,20 @@ const STUDIO_CSS = `
   .pair-add { align-self: flex-start; background: #1d1d1d; color: #7bd88f; border: 1px solid #2f4030;
     border-radius: 3px; cursor: pointer; padding: 3px 9px; font: 12px ui-monospace, monospace; }
   .pair-add:hover { background: #243024; }
+  details.all-options { margin: 8px 0; border-top: 1px solid #2a2a2a; padding-top: 6px; }
+  details.all-options > summary { color: #8a8a8a; font-size: 12px; cursor: pointer; user-select: none; }
+  details.all-options > summary:hover { color: #bbb; }
+  .all-options .opt-row { display: flex; flex-direction: column; align-items: stretch; gap: 4px; margin: 6px 0; }
+  .all-options input.raw-args {
+    width: 100%; box-sizing: border-box; background: #111; color: #ddd; border: 1px solid #333;
+    border-radius: 3px; padding: 4px 6px; font: 12px ui-monospace, Menlo, monospace;
+  }
+  .all-options input.raw-args:focus { outline: none; border-color: #4ec97a; }
+  .opt-hint { color: #777; font-size: 11px; }
+  .flag-catalog { margin-top: 8px; display: flex; flex-direction: column; gap: 2px; }
+  .flag-row { display: flex; gap: 8px; align-items: baseline; font-size: 11px; }
+  .flag-name { color: #7bd88f; font-family: ui-monospace, Menlo, monospace; white-space: nowrap; }
+  .flag-desc { color: #999; }
   .envkv-modes { display: flex; gap: 0; }
   .envkv-mode { background: #1a1a1a; color: #999; border: 1px solid #333; cursor: pointer;
     padding: 3px 12px; font: 11px ui-monospace, monospace; }
@@ -218,9 +233,14 @@ const STUDIO_SCRIPT = `
 
   function buildOptions(kind) {
     const specs = OPTION_SPECS[kind] || [];
-    if (!specs.length) return { node: null, collect: function () { return undefined; } };
+    // The composer always shows an "All options" section (raw extra args + the
+    // auto-derived flag reference), even for kinds with no curated controls.
+    const wrap = el('div', 'options-wrap');
     const sec = el('div', 'section options');
-    sec.appendChild(el('h3', null, 'Options'));
+    if (specs.length) {
+      sec.appendChild(el('h3', null, 'Options'));
+      wrap.appendChild(sec);
+    }
     const getters = [];
     const bools = {};
 
@@ -336,12 +356,62 @@ const STUDIO_SCRIPT = `
       }
       sec.appendChild(row);
     });
+    const allOpts = buildAllOptions(kind);
+    wrap.appendChild(allOpts.node);
     return {
-      node: sec,
+      node: wrap,
       collect: function () {
         const out = {};
         getters.forEach(function (g) { const kv = g(); out[kv[0]] = kv[1]; });
-        return out;
+        // Omit-when-empty: a kind with no curated controls (e.g. api) collects
+        // nothing, so return undefined rather than {} to keep the run/serve
+        // body identical to before this section existed.
+        return Object.keys(out).length ? out : undefined;
+      },
+      collectRaw: allOpts.collectRaw,
+    };
+  }
+
+  // The collapsed "All options" section: a raw extra-args input (appended
+  // verbatim to the spawned child) + the auto-derived, read-only catalog of
+  // every flag the underlying command accepts. The curated controls above
+  // cover the common flags with rich UI; this exposes the rest so the studio
+  // UI is never strictly less capable than the headless CLI (issue #301).
+  const FLAG_CATALOG = window.__FLAG_CATALOG__ || {};
+
+  function buildAllOptions(kind) {
+    const cat = FLAG_CATALOG[kind] || { command: '', flags: [] };
+    const det = el('details', 'all-options');
+    det.appendChild(el('summary', null, 'All options'));
+
+    const rawRow = el('div', 'opt-row opt-col');
+    rawRow.appendChild(el('span', 'opt-label', 'Raw extra args'));
+    const rawIn = el('input', 'raw-args');
+    rawIn.placeholder = '--flag value --other "with spaces"';
+    rawRow.appendChild(rawIn);
+    const hint = cat.command
+      ? 'Appended verbatim to the spawned ' + cat.command + ' command. Quote values with spaces.'
+      : 'Appended verbatim to the spawned command. Quote values with spaces.';
+    rawRow.appendChild(el('div', 'opt-hint', hint));
+    det.appendChild(rawRow);
+
+    if (cat.flags.length) {
+      const ref = el('div', 'flag-catalog');
+      ref.appendChild(el('div', 'opt-label', 'Available flags'));
+      cat.flags.forEach(function (f) {
+        const row = el('div', 'flag-row');
+        row.appendChild(el('code', 'flag-name', f.flags));
+        if (f.description) row.appendChild(el('span', 'flag-desc', f.description));
+        ref.appendChild(row);
+      });
+      det.appendChild(ref);
+    }
+
+    return {
+      node: det,
+      collectRaw: function () {
+        const v = rawIn.value.trim();
+        return v === '' ? undefined : v;
       },
     };
   }
@@ -467,7 +537,7 @@ const STUDIO_SCRIPT = `
     }
   }
 
-  async function startServe(id, options) {
+  async function startServe(id, options, rawArgs) {
     // The serve kind (api / alb / ecs) drives which headless command the
     // server spawns; it is recorded on the row when the target list loads.
     const meta = serveMeta.get(id);
@@ -477,6 +547,7 @@ const STUDIO_SCRIPT = `
     try {
       const body = { targetId: id, kind };
       if (options) body.options = options;
+      if (rawArgs) body.rawArgs = rawArgs;
       const res = await fetch('/api/run', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -533,7 +604,8 @@ const STUDIO_SCRIPT = `
       : el('button', null, starting ? 'Starting…' : 'Start');
     // Per-run options are only set before a start; collected on the Start click.
     let collectOpts = function () { return undefined; };
-    btn.onclick = () => { if (running || starting) stopServe(id); else startServe(id, collectOpts()); };
+    let collectRaw = function () { return undefined; };
+    btn.onclick = () => { if (running || starting) stopServe(id); else startServe(id, collectOpts(), collectRaw()); };
     head.appendChild(btn);
     if (errMsg) {
       const m = el('div', 'err', errMsg);
@@ -545,6 +617,7 @@ const STUDIO_SCRIPT = `
       const opt = buildOptions(kind);
       if (opt.node) ws.appendChild(opt.node);
       collectOpts = opt.collect;
+      collectRaw = opt.collectRaw;
     }
 
     const isEcs = meta && meta.kind === 'ecs';
@@ -744,7 +817,7 @@ const STUDIO_SCRIPT = `
     ws.appendChild(composer);
     ws.appendChild(result);
 
-    active = { id, kind, ta, btn, msg, result, collectOpts: opt.collect };
+    active = { id, kind, ta, btn, msg, result, collectOpts: opt.collect, collectRaw: opt.collectRaw };
     btn.onclick = () => runInvoke();
     shownInvId = null;
     shownDetailId = null;
@@ -769,6 +842,8 @@ const STUDIO_SCRIPT = `
       const body = { targetId: id, kind, event };
       const options = active.collectOpts ? active.collectOpts() : undefined;
       if (options) body.options = options;
+      const rawArgs = active.collectRaw ? active.collectRaw() : undefined;
+      if (rawArgs) body.rawArgs = rawArgs;
       const res = await fetch('/api/run', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -1138,6 +1213,9 @@ export function renderStudioHtml(appLabel: string, cliName: string): string {
   // render controls from. `<` is escaped so a value can never close the
   // surrounding <script> tag.
   const optionSpecsJson = JSON.stringify(OPTION_SPECS).replace(/</g, '\\u003c');
+  // The auto-derived full flag catalog per runnable kind — the "All options"
+  // section renders it as a read-only reference beside the raw extra-args input.
+  const flagCatalogJson = JSON.stringify(buildFlagCatalog()).replace(/</g, '\\u003c');
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -1175,6 +1253,7 @@ export function renderStudioHtml(appLabel: string, cliName: string): string {
   </section>
 </main>
 <script>window.__OPTION_SPECS__ = ${optionSpecsJson};</script>
+<script>window.__FLAG_CATALOG__ = ${flagCatalogJson};</script>
 <script>${STUDIO_SCRIPT}</script>
 </body>
 </html>`;

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -215,7 +215,17 @@ if ! grep -qF "LocalStudioFixture" "${BODY_FILE}"; then
   cat "${BODY_FILE}"
   exit 1
 fi
-echo "    OK: UI HTML served with the stack label"
+# The "All options" section (issue #301): the auto-derived flag catalog is
+# serialized into the page, and the raw extra-args builder is present.
+if ! grep -qF "window.__FLAG_CATALOG__" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not embed the auto-derived flag catalog (All options)"
+  exit 1
+fi
+if ! grep -qF "buildAllOptions" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the All options / raw extra-args builder"
+  exit 1
+fi
+echo "    OK: UI HTML served with the stack label + All options catalog"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.
@@ -333,6 +343,31 @@ if ! grep -qF "${PROBE}" "${OPT_FILE}"; then
 fi
 rm -f "${OPT_FILE}"
 echo "    OK: --env-vars KEY/VALUE option threaded through to the Lambda container"
+
+# ---------------------------------------------------------------------------
+# 6b2. "All options" raw extra args (issue #301): POST /api/run with a
+#      `rawArgs` string. The server tokenizes it (quote-aware) and appends the
+#      tokens verbatim to the spawned `cdkl invoke` argv. Pass a BOGUS
+#      `--from-cfn-stack` (no deploy, creds-light): the child attempts to bind
+#      it, fails gracefully, and names the bogus stack in its logs — proof the
+#      raw string reached the child argv (UI raw-args -> /api/run -> tokenize ->
+#      child argv -> graceful fallback log).
+# ---------------------------------------------------------------------------
+echo "==> POST /api/run threads a rawArgs string into the invoke argv"
+RAW_STACK="RAWARGSBOGUS301"
+RAW_RUN=$(mktemp)
+curl -s -o "${RAW_RUN}" --max-time 180 -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"LocalStudioFixture/MyHandler\",\"kind\":\"lambda\",\"event\":{},\"rawArgs\":\"--from-cfn-stack ${RAW_STACK}\"}" >/dev/null || true
+RAW_INV=$(grep -oE '"invocationId":"[^"]+"' "${RAW_RUN}" | head -1 | sed 's/.*"invocationId":"//;s/"//')
+rm -f "${RAW_RUN}"
+if [[ -z "${RAW_INV}" ]]; then echo "FAIL: no invocationId after a rawArgs invoke"; exit 1; fi
+curl -fsS "${URL}/api/invocations/${RAW_INV}/logs" -o "${BODY_FILE}"
+if ! grep -qF "${RAW_STACK}" "${BODY_FILE}"; then
+  echo "FAIL: the rawArgs --from-cfn-stack did not reach the child (stack absent from logs)"
+  echo "----- bound logs -----"; head -c 2000 "${BODY_FILE}"; echo; echo "----------------------"
+  exit 1
+fi
+echo "    OK: rawArgs string tokenized + threaded to the child invoke argv"
 
 # ---------------------------------------------------------------------------
 # 6c. Editable Session config (issue #301 slice 3): GET /api/config exposes
@@ -925,4 +960,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + ws-console + request capture + history/log-search + per-target-options + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + all-options-catalog + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -109,6 +109,24 @@ describe('coerceRunRequest', () => {
     ).toThrow(/not valid JSON/);
   });
 
+  it('threads a well-formed rawArgs string through', () => {
+    expect(
+      coerceRunRequest({ targetId: 'T', kind: 'api', rawArgs: '--warm --port 9000' })
+    ).toEqual({ targetId: 'T', kind: 'api', event: undefined, rawArgs: '--warm --port 9000' });
+  });
+
+  it('rejects a non-string rawArgs', () => {
+    expect(() =>
+      coerceRunRequest({ targetId: 'T', kind: 'api', rawArgs: ['--warm'] })
+    ).toThrow(/"rawArgs" must be a string/);
+  });
+
+  it('rejects rawArgs with an unterminated quote at the boundary', () => {
+    expect(() =>
+      coerceRunRequest({ targetId: 'T', kind: 'api', rawArgs: '--name "oops' })
+    ).toThrow(/unterminated/i);
+  });
+
   it('accepts an agentcore request with its per-run options', () => {
     expect(
       coerceRunRequest({

--- a/tests/unit/local/studio-dispatch.test.ts
+++ b/tests/unit/local/studio-dispatch.test.ts
@@ -516,6 +516,38 @@ describe('createStudioDispatcher', () => {
     expect(result.status).toBe(500);
     expect(result.error).toContain('agent container exited early');
   });
+
+  it('tokenizes raw extra args and appends them LAST to the spawned argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      idFactory: () => 'inv-raw',
+    });
+
+    const p = dispatcher.run({
+      targetId: 'Stack/Fn',
+      kind: 'lambda',
+      event: {},
+      rawArgs: '--timeout 30 --memory "512 mb"',
+    });
+    child.stdout.emit('data', '{"ok":true}');
+    child.emit('close', 0);
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    // Quote-aware tokenization: "512 mb" stays one argv element.
+    expect(argv).toContain('--timeout');
+    expect(argv).toContain('30');
+    expect(argv).toContain('--memory');
+    expect(argv).toContain('512 mb');
+    // Raw args land at the very end of the argv (override semantics).
+    expect(argv.slice(-4)).toEqual(['--timeout', '30', '--memory', '512 mb']);
+  });
 });
 
 /** Count leftover `cdkl-studio-run-*` temp dirs (for cleanup assertions). */

--- a/tests/unit/local/studio-option-catalog.test.ts
+++ b/tests/unit/local/studio-option-catalog.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import {
+  buildFlagCatalog,
+  tokenizeRawArgs,
+  CATALOG_EXCLUDED_FLAGS,
+  __resetFlagCatalogCacheForTest,
+} from '../../../src/local/studio-option-catalog.js';
+import { getEmbedConfig, setEmbedConfig, resetEmbedConfig } from '../../../src/local/embed-config.js';
+
+describe('buildFlagCatalog', () => {
+  // Clear the memo before each test so a build actually instantiates the
+  // factories — otherwise the embed-config snapshot/restore path (and the
+  // branding-reflecting descriptions) would never run after the first call.
+  beforeEach(() => __resetFlagCatalogCacheForTest());
+
+  it('emits a catalog for every runnable kind, mapped to its headless command', () => {
+    const cat = buildFlagCatalog();
+    expect(cat.lambda?.command).toBe('invoke');
+    expect(cat.agentcore?.command).toBe('invoke-agentcore');
+    expect(cat.api?.command).toBe('start-api');
+    expect(cat.alb?.command).toBe('start-alb');
+    expect(cat.ecs?.command).toBe('start-service');
+  });
+
+  it('derives real flags from each command (name + description)', () => {
+    const cat = buildFlagCatalog();
+    const lambdaFlags = (cat.lambda?.flags ?? []).map((f) => f.flags);
+    // `--event` is a real `cdkl invoke` flag with a description.
+    expect(lambdaFlags.some((f) => f.includes('--event'))).toBe(true);
+    const event = (cat.lambda?.flags ?? []).find((f) => f.flags.includes('--event <file>'));
+    expect(event?.description).toBeTruthy();
+    // start-alb exposes --tls.
+    expect((cat.alb?.flags ?? []).some((f) => f.flags.includes('--tls'))).toBe(true);
+  });
+
+  it('excludes session-global flags and help/version from every kind (exact, not substring)', () => {
+    const cat = buildFlagCatalog();
+    for (const kind of Object.keys(cat) as (keyof typeof cat)[]) {
+      // Tokenize each flags string ("-e, --event <file>") into discrete flag
+      // tokens so the exclusion is matched EXACTLY — `--assume-role-auto` is a
+      // distinct flag that must NOT be dropped by the `--assume-role` exclusion.
+      const tokens = (cat[kind]?.flags ?? []).flatMap((f) => f.flags.split(/[\s,]+/));
+      for (const excluded of CATALOG_EXCLUDED_FLAGS) {
+        expect(tokens).not.toContain(excluded);
+      }
+    }
+  });
+
+  it('keeps a near-name flag that only shares a prefix with an excluded one', () => {
+    // `--assume-role` is session-global (excluded), but `--assume-role-auto` is
+    // a per-run start-api flag that must survive.
+    const cat = buildFlagCatalog();
+    const apiTokens = (cat.api?.flags ?? []).flatMap((f) => f.flags.split(/[\s,]+/));
+    expect(apiTokens).toContain('--assume-role-auto');
+  });
+
+  it('is memoized — repeated calls return the same object', () => {
+    expect(buildFlagCatalog()).toBe(buildFlagCatalog());
+  });
+
+  it('does not wipe the active embed config and reflects host branding in descriptions', () => {
+    // A host CLI installs custom branding; building the catalog instantiates
+    // the command factories (each calls setEmbedConfig at construction, which
+    // with no opts would reset to cdk-local defaults). The cache is cleared by
+    // beforeEach, so this build genuinely runs the factories under the custom
+    // config — exercising the snapshot/restore path, not a memoized result.
+    try {
+      setEmbedConfig({ cliName: 'cdkd local', binaryName: 'cdkd', envPrefix: 'CDKD' });
+      const before = getEmbedConfig();
+      const cat = buildFlagCatalog();
+      const after = getEmbedConfig();
+      // (a) The active branding survived the introspection.
+      expect(after.cliName).toBe(before.cliName);
+      expect(after.binaryName).toBe(before.binaryName);
+      expect(after.envPrefix).toBe('CDKD');
+      // (b) The derived descriptions reflect the host branding — `--role-arn`'s
+      // help interpolates `${envPrefix}_ROLE_ARN`, so under CDKD it must read
+      // CDKD_ROLE_ARN (not the cdk-local default CDKL_ROLE_ARN).
+      const roleArn = (cat.lambda?.flags ?? []).find((f) => f.flags.includes('--role-arn'));
+      expect(roleArn?.description).toContain('CDKD_ROLE_ARN');
+      expect(roleArn?.description).not.toContain('CDKL_ROLE_ARN');
+    } finally {
+      resetEmbedConfig();
+      __resetFlagCatalogCacheForTest();
+    }
+  });
+});
+
+describe('tokenizeRawArgs', () => {
+  it('returns [] for undefined / empty / whitespace', () => {
+    expect(tokenizeRawArgs(undefined)).toEqual([]);
+    expect(tokenizeRawArgs('')).toEqual([]);
+    expect(tokenizeRawArgs('   \t\n ')).toEqual([]);
+  });
+
+  it('splits on whitespace into discrete argv elements', () => {
+    expect(tokenizeRawArgs('--port 8080 --host 127.0.0.1')).toEqual([
+      '--port',
+      '8080',
+      '--host',
+      '127.0.0.1',
+    ]);
+  });
+
+  it('keeps double-quoted values with spaces as one token', () => {
+    expect(tokenizeRawArgs('--name "two words" --x 1')).toEqual([
+      '--name',
+      'two words',
+      '--x',
+      '1',
+    ]);
+  });
+
+  it('keeps single-quoted values as one token (no escaping inside)', () => {
+    expect(tokenizeRawArgs("--json '{\"a\": 1}'")).toEqual(['--json', '{"a": 1}']);
+  });
+
+  it('honors a backslash escape inside double quotes', () => {
+    expect(tokenizeRawArgs('--q "a\\"b"')).toEqual(['--q', 'a"b']);
+  });
+
+  it('honors a bare backslash escape outside quotes', () => {
+    expect(tokenizeRawArgs('a\\ b')).toEqual(['a b']);
+  });
+
+  it('preserves an explicit empty-string quoted arg', () => {
+    expect(tokenizeRawArgs('--x ""')).toEqual(['--x', '']);
+    expect(tokenizeRawArgs("--x ''")).toEqual(['--x', '']);
+  });
+
+  it('swallows a backslash escaping an ordinary char inside double quotes', () => {
+    // Inside double quotes a backslash escapes the next char (shell-like), so
+    // the backslash is dropped and the char kept literally.
+    expect(tokenizeRawArgs('"a\\nb"')).toEqual(['anb']);
+  });
+
+  it('keeps a trailing backslash with nothing to escape as a literal', () => {
+    expect(tokenizeRawArgs('a\\')).toEqual(['a\\']);
+  });
+
+  it('throws on an unterminated quote', () => {
+    expect(() => tokenizeRawArgs('--name "unterminated')).toThrow(/unterminated/i);
+    expect(() => tokenizeRawArgs("--x 'oops")).toThrow(/unterminated/i);
+  });
+});

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -274,6 +274,35 @@ describe('createStudioServeManager', () => {
     expect(argv[i + 1]).toBe('443=8443');
   });
 
+  it('tokenizes raw extra args and appends them to the spawned serve argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'MyApi',
+      kind: 'api',
+      rawArgs: '--warm --container-host "my host"',
+    });
+    child.stdout.emit('data', 'Server listening on http://127.0.0.1:51999\n');
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv).toContain('--warm');
+    const i = argv.indexOf('--container-host');
+    expect(i).toBeGreaterThan(-1);
+    expect(argv[i + 1]).toBe('my host');
+  });
+
   it('streams child stdout AND stderr lines onto the bus as log events keyed by the target', async () => {
     const bus = new StudioEventBus();
     const { logs } = collect(bus);

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -29,6 +29,36 @@ describe('renderStudioHtml', () => {
     expect(html).not.toMatch(/__OPTION_SPECS__ = [^;]*<\//);
   });
 
+  it('embeds the auto-derived full flag catalog for the "All options" section (issue #301)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The full per-kind catalog is serialized for the UI.
+    expect(html).toContain('window.__FLAG_CATALOG__ =');
+    // It carries each runnable kind's headless command + real flags.
+    expect(html).toContain('"command":"start-api"');
+    expect(html).toContain('"command":"invoke-agentcore"');
+    // Session-global flags are excluded from the per-target catalog.
+    expect(html).not.toMatch(/__FLAG_CATALOG__ =[^;]*"--from-cfn-stack"/);
+    // `<` is escaped so a flag description can never close the <script>.
+    expect(html).not.toMatch(/__FLAG_CATALOG__ = [^;]*<\//);
+  });
+
+  it('renders the collapsed "All options" section with a raw extra-args input', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The builder + the collapsed <details>, the raw-args input, and the
+    // read-only catalog reference are all present in the embedded script.
+    expect(html).toContain('function buildAllOptions');
+    expect(html).toContain("el('details', 'all-options')");
+    expect(html).toContain("el('input', 'raw-args')");
+    expect(html).toContain('FLAG_CATALOG = window.__FLAG_CATALOG__');
+    // Raw args are collected and threaded onto the run/serve body.
+    expect(html).toContain('body.rawArgs = rawArgs');
+    expect(html).toContain('collectRaw');
+    // A no-curated-control kind (api) collects nothing, so the option values
+    // are omitted (undefined), keeping the run/serve body byte-identical to
+    // before this section existed.
+    expect(html).toContain('Object.keys(out).length ? out : undefined');
+  });
+
   it('makes AgentCore a single-shot invoke target with its own options (issue #303)', () => {
     const html = renderStudioHtml('MyStack', 'cdkl');
     // AgentCore is wired as an invoke kind (event composer), alongside lambda.


### PR DESCRIPTION
## Summary

Add a collapsed **"All options"** section to every `cdkl studio` composer
(invoke + serve) so the web UI is never strictly less capable than the
headless CLI. Part of issue #301.

Inside the section:

- **Raw extra args** — a free-text input. The string is tokenized
  (quote-aware, backslash-escape) and appended verbatim to the spawned
  child argv, **last** so it can override a curated flag. studio spawns
  children WITHOUT a shell (argv array), so the tokens are discrete argv
  elements with no injection surface; the child still validates each arg.
- **Auto-derived flag reference** — a read-only list of every flag the
  underlying command accepts (name + description). `buildFlagCatalog`
  introspects each runnable kind's Commander command factory, so the
  reference can never drift from the real option set. Session-global
  flags (handled by the Session bar) and `--help` / `--version` are
  excluded.

The curated `OPTION_SPECS` stays the rich-control subset for the common
flags; this exposes the rest.

## Implementation

- New module `src/local/studio-option-catalog.ts`: `buildFlagCatalog`
  (memoized; snapshots + re-hands the active embed config to each factory
  so host branding survives AND derived descriptions reflect it) and
  `tokenizeRawArgs` (quote-aware splitter).
- `rawArgs` threads through `coerceRunRequest` (validated at the
  `/api/run` boundary — an unterminated quote is a clean 400),
  `studio-dispatch`, and `studio-serve-manager`.
- studio-ui: every composer always renders the collapsed `<details>`,
  even for kinds with no curated controls (e.g. `api`).

## cdkd parity

- The new helpers are **internal-only**: a host embedding studio gets the
  All options catalog + raw-args behavior for free through the already
  host-exported entry points (`renderStudioHtml` -> `buildFlagCatalog`;
  `createStudioDispatcher` / `createStudioServeManager` / `coerceRunRequest`
  -> `tokenizeRawArgs`). No new `internal.ts` export needed.
- Additive behavior change: `coerceRunRequest` and the
  `StudioRunRequest` / `StudioServeRequest` types gained an optional
  `rawArgs` field. Backward-compatible — a host wiring `coerceRunRequest`
  now also accepts `rawArgs` from its UI; no migration.
- Known host nuance: the catalog reflects cdk-local's command factories
  (the shared option blocks a host inherits via `add*SpecificOptions`),
  not host-only flags. The raw-args input still works for any flag (it is
  appended to the host's child argv). An exact host catalog (pluggable
  factories) is a possible future enhancement.

## Test plan

- `vp run check` + `vp run build` — pass
- `vp run test` — 156 files, 2404 tests pass; new `studio-option-catalog`
  suite covers tokenizer edge cases (quotes / escapes / empty-quote /
  unterminated / trailing backslash), session-global exclusion (exact,
  not substring — `--assume-role` vs `--assume-role-auto`), and
  embed-config preservation + branding-reflecting descriptions (cache
  reset so the real factory-instantiating path runs, not a memoized one)
- `/run-integ local-studio` — green: the served HTML embeds the
  auto-derived catalog + the All options builder, and a `rawArgs` string
  POSTed to `/api/run` is tokenized and reaches the child argv (proven by
  the child naming a bogus `--from-cfn-stack` in its bound logs). 0 Docker
  orphans
- Live-checked the rendered UI: collapsed "All options", raw-args input +
  hint, and the green-flag/grey-description reference list

## Review

3-axis review (spec clean; code + test findings all addressed in this PR):
the no-spec-kind `collect()` omit-when-empty contract restored, the
vacuous (memoized) embed-config test made real, and the missing tokenizer
edge cases covered.
