### PR TITLE
feat(studio): image-override Dockerfile picker for pinned ECS services

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -250,7 +250,13 @@ compute-locally category for Lambda + API Gateway).
   `PATCH /api/config`, applying to subsequently-started serves) and a
   no-op for single-shot invokes (each invoke re-synths anyway). The
   target list itself is not re-synthed (restart studio to pick up
-  newly-added resources).
+  newly-added resources). Issue #301 also classifies each servable ECS
+  service at boot (`resolveEcsServiceTarget` + `isLocalCdkAssetImage`):
+  a deployed-registry-pinned service is marked `pinned` so the UI offers
+  an image-override Dockerfile picker, and the app dir is scanned once
+  (`discoverDockerfiles`, only when something is pinned) for the picker's
+  options. The picker threads `--image-override <target>=<dockerfile>`
+  through `coerceRunRequest` (validated) + the serve manager.
 - `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
   (`Toolkit.fromCdkApp()` + context store threading) that returns
   `StackInfo[]` for downstream consumers.
@@ -318,7 +324,10 @@ compute-locally category for Lambda + API Gateway).
   `serve` events); the studio HTTP server
   subscribes and forwards to the browser over SSE), studio-server
   (the localhost HTTP server behind `cdkl studio`: serves the embedded
-  UI at `/`, the synthesized target list at `/api/targets`, an SSE
+  UI at `/`, the synthesized target list (+ the boot-discovered
+  Dockerfiles + a `pinned` flag per ecs service — set by
+  `annotatePinnedEcsTargets` — for the image-override picker, issue #301)
+  at `/api/targets`, an SSE
   stream of the event bus at `/api/events`, `POST /api/run` (single-shot
   invoke / serve start), `POST /api/stop` (serve stop),
   `GET /api/running` (running serve snapshot), the slice-C3 store
@@ -342,7 +351,15 @@ compute-locally category for Lambda + API Gateway).
   `<details>` (`buildAllOptions`) with a raw extra-args input + the
   read-only auto-derived flag catalog from studio-option-catalog, so the
   curated controls handle common flags richly while every other flag the
-  underlying command accepts stays reachable (issue #301); the
+  underlying command accepts stays reachable (issue #301); a PINNED ecs
+  service (deployed-registry image, marked `pinned` in the target list)
+  additionally gets an image-override Dockerfile picker
+  (`buildImageOverridePicker`) populated from the boot-scanned Dockerfiles,
+  threading `--image-override <target>=<dockerfile>` (the explicit form —
+  studio's child has no TTY, so the bare picker form would be skipped) onto
+  the serve body so `start-service` rebuilds the pinned image from local
+  source; a local-asset service (which already hot-reloads under `--watch`)
+  gets no picker (issue #301); the
   timeline carries both Lambda invocations and captured serve requests,
   the latter opening a read-only Request/Response detail; a log search box
   queries the store and a captured request's detail shows its bound logs),

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ cdkl studio --stack 'dev/*'                  # scope the displayed target list (
 
 `--from-cfn-stack` / `--assume-role` / `--watch` are session-global and also editable live from the Session bar — they apply to every invoke / serve you start from the UI. The standard synth flags (`--app` / `--profile` / `--region` / `-c`) work here too.
 
-Each target's composer surfaces its per-run options as controls — a Lambda's `--env-vars` as KEY/VALUE or JSON, ALB `--tls` / `--lb-port`, ECS `--max-tasks` / `--host-port`, an AgentCore runtime's `--ws` / `--sigv4` / `--bearer-token` — plus an **All options** panel listing the underlying command's full flag set with a raw extra-args input for anything not surfaced as a control.
+Each target's composer surfaces its per-run options as controls — a Lambda's `--env-vars` as KEY/VALUE or JSON, ALB `--tls` / `--lb-port`, ECS `--max-tasks` / `--host-port`, an AgentCore runtime's `--ws` / `--sigv4` / `--bearer-token` — plus an **All options** panel listing the underlying command's full flag set with a raw extra-args input for anything not surfaced as a control. An ECS service whose image is pinned to a deployed registry (local edits don't take effect) also gets a Dockerfile picker that rebuilds it from local source.
 
 ### Deployed stack binding — `--from-cfn-stack`
 

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -24,6 +24,7 @@ import {
   startStudioServer,
   toStudioTargetGroups,
   filterStudioTargetGroups,
+  annotatePinnedEcsTargets,
   type RunningStudioServer,
 } from '../../local/studio-server.js';
 import { createStudioDispatcher, type StudioRunRequest } from '../../local/studio-dispatch.js';
@@ -33,6 +34,9 @@ import {
   type OptionValues,
 } from '../../local/studio-option-specs.js';
 import { tokenizeRawArgs } from '../../local/studio-option-catalog.js';
+import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
+import { isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
+import { discoverDockerfiles } from '../../local/image-override-engine.js';
 import {
   createStudioServeManager,
   type StudioServeManager,
@@ -57,7 +61,10 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
   if (typeof body !== 'object' || body === null) {
     throw new Error('Request body must be a JSON object.');
   }
-  const { targetId, kind, event, options, rawArgs } = body as Record<string, unknown>;
+  const { targetId, kind, event, options, rawArgs, imageOverride } = body as Record<
+    string,
+    unknown
+  >;
   if (typeof targetId !== 'string' || targetId.trim() === '') {
     throw new Error('Request body must include a non-empty "targetId" string.');
   }
@@ -86,12 +93,20 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     tokenizeRawArgs(rawArgs);
     runRawArgs = rawArgs;
   }
+  let runImageOverride: string | undefined;
+  if (imageOverride !== undefined) {
+    if (typeof imageOverride !== 'string') {
+      throw new Error('Request body "imageOverride" must be a string.');
+    }
+    if (imageOverride.trim() !== '') runImageOverride = imageOverride;
+  }
   return {
     targetId,
     kind: kind as StudioTargetKind,
     event,
     ...(runOptions !== undefined ? { options: runOptions } : {}),
     ...(runRawArgs !== undefined ? { rawArgs: runRawArgs } : {}),
+    ...(runImageOverride !== undefined ? { imageOverride: runImageOverride } : {}),
   };
 }
 
@@ -282,6 +297,33 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
       .flatMap((g) => g.entries.filter((e) => e.servable).map((e) => e.id))
   );
 
+  // Mark servable ECS services whose image is a deployed-registry pin (ECR /
+  // public) rather than a local CDK asset (issue #301). A pinned image does
+  // NOT pick up local source edits, so the UI offers an image-override
+  // Dockerfile picker for those services; a local-asset service already
+  // hot-reloads under `--watch` and gets no picker.
+  //
+  // Classification is BEST-EFFORT and deliberately STATE-FREE: it reads the
+  // synthed template only (no deployed-state fetch, no AWS calls at boot), so
+  // it is cheap, but under `--from-cfn-stack` an ECR image expressed as an
+  // unresolved intrinsic could be hinted differently than the actual
+  // start-service verdict. The hint only governs whether the UI surfaces the
+  // picker; a mis-hinted service can still be overridden via the "All options"
+  // raw-args `--image-override`. Per-target resolution failures are non-fatal
+  // (the service stays unmarked). Dockerfiles are scanned once, only when at
+  // least one service is pinned, so an all-local app pays nothing.
+  const anyPinned = annotatePinnedEcsTargets(targetGroups, (id) => {
+    try {
+      return !isLocalCdkAssetImage(resolveEcsServiceTarget(id, stacks));
+    } catch (err) {
+      logger.debug(
+        `studio: could not classify pin status for '${id}': ${err instanceof Error ? err.message : String(err)}`
+      );
+      return false;
+    }
+  });
+  const dockerfiles = anyPinned ? discoverDockerfiles(process.cwd()) : [];
+
   const bus = new StudioEventBus();
   // `process.argv[1]` is the running CLI entry (`dist/cli.js` / the `cdkl`
   // bin); both the invoke dispatcher and the serve manager spawn it again
@@ -335,6 +377,7 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     port,
     bus,
     targetGroups,
+    dockerfiles,
     appLabel,
     cliName: getEmbedConfig().cliName,
     store,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -705,6 +705,7 @@ export {
   startStudioServer,
   toStudioTargetGroups,
   filterStudioTargetGroups,
+  annotatePinnedEcsTargets,
   type StudioServerOptions,
   type RunningStudioServer,
   type StudioTarget,

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -38,6 +38,12 @@ export interface StudioRunRequest {
    * args, so a flag the curated controls don't expose can still be passed.
    */
   rawArgs?: string;
+  /**
+   * Dockerfile path for a pinned `ecs` serve target's image-override picker
+   * (issue #301). Serve-only — the single-shot invoke kinds ignore it; it
+   * rides on the shared coerced request so the serve manager can read it.
+   */
+  imageOverride?: string;
 }
 
 /** The outcome of a single-shot run, returned from `/api/run`. */

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -23,6 +23,13 @@ export interface StudioServeRequest {
    * controls don't expose can still be passed.
    */
   rawArgs?: string;
+  /**
+   * Dockerfile path picked for a pinned `ecs` service (issue #301) — appended
+   * as `--image-override <path>` so `start-service` rebuilds the
+   * deployed-registry-pinned image from local source. Bare (picker) form: the
+   * single booted service is the override target. Ignored when blank.
+   */
+  imageOverride?: string;
 }
 
 /** A request to stop a running served target. */
@@ -255,6 +262,15 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       ...spec.portArgs,
       ...buildSharedChildArgs(config),
       ...buildPerRunArgs(req.kind, req.options),
+      // Image-override picker (issue #301): a pinned ecs service rebuilds from
+      // the chosen local Dockerfile. The EXPLICIT `<target>=<dockerfile>` form
+      // is used (not the bare picker form) because studio spawns the child
+      // WITHOUT a TTY — the engine skips bare picker-form paths when
+      // non-interactive, but the explicit form maps deterministically. The
+      // target key is the same id passed as the start-service target arg.
+      ...(req.imageOverride && req.imageOverride.trim() !== ''
+        ? ['--image-override', req.targetId + '=' + req.imageOverride.trim()]
+        : []),
       // `cdkl studio --watch` (issue #301): every serve kind (start-api /
       // start-alb / start-service) implements `--watch` rolling reload, so
       // forwarding the bare flag makes a UI-started serve hot-reload on source

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -25,6 +25,15 @@ export interface StudioTarget {
    * serve target): only services carry `servable: true`.
    */
   servable?: boolean;
+  /**
+   * Set on a servable `ecs` service whose image is a deployed-registry pin
+   * (ECR / public) rather than a local CDK asset (issue #301). Local source
+   * edits do NOT take effect for a pinned image, so the serve composer offers
+   * a Dockerfile picker that threads `--image-override` to the spawned
+   * `start-service`. A local-asset service (which already hot-reloads under
+   * `--watch`) is not marked and gets no picker.
+   */
+  pinned?: boolean;
 }
 
 /** A category of targets, grouped by the studio kind that runs them. */
@@ -72,6 +81,37 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
   ];
 }
 
+/**
+ * Annotate the servable `ecs` service entries of `groups` with `pinned: true`
+ * when `classify(targetId)` returns true (issue #301). `classify` decides
+ * pinned (deployed-registry image) vs local CDK asset for one service id; the
+ * caller supplies it (studio's boot does `resolveEcsServiceTarget` +
+ * `isLocalCdkAssetImage`, swallowing resolution failures as "not pinned").
+ * Mutates the entries in place and returns whether ANY service was pinned, so
+ * the caller can skip the (otherwise pointless) Dockerfile scan for an
+ * all-local-asset app. Non-ecs groups and non-servable entries (task defs) are
+ * left untouched. Exported so a host CLI building its own studio can reuse the
+ * same pinned-target annotation, and so the boot logic is unit-testable
+ * without a real synth.
+ */
+export function annotatePinnedEcsTargets(
+  groups: StudioTargetGroup[],
+  classify: (targetId: string) => boolean
+): boolean {
+  let anyPinned = false;
+  for (const group of groups) {
+    if (group.kind !== 'ecs') continue;
+    for (const entry of group.entries) {
+      if (!entry.servable) continue;
+      if (classify(entry.id)) {
+        entry.pinned = true;
+        anyPinned = true;
+      }
+    }
+  }
+  return anyPinned;
+}
+
 /** Compile a `*` / `?` glob to an anchored RegExp matched against a target id. */
 function globToRegExp(glob: string): RegExp {
   const escaped = glob
@@ -112,6 +152,13 @@ export interface StudioServerOptions {
   bus: StudioEventBus;
   /** Target groups to serve at `GET /api/targets`. */
   targetGroups: StudioTargetGroup[];
+  /**
+   * Dockerfiles discovered under the app directory at boot (issue #301),
+   * served alongside the target groups at `GET /api/targets`. The serve
+   * composer of a pinned `ecs` service offers them in an image-override
+   * picker. Empty / omitted => no picker options.
+   */
+  dockerfiles?: string[];
   /** Header label for the running app / stack context. */
   appLabel: string;
   /** CLI brand name (`cdkl`, or a host rebrand). */
@@ -189,7 +236,10 @@ export async function startStudioServer(
   const host = options.host ?? '127.0.0.1';
   const maxBump = options.maxPortBump ?? 20;
   const html = renderStudioHtml(options.appLabel, options.cliName);
-  const targetsJson = JSON.stringify({ groups: options.targetGroups });
+  const targetsJson = JSON.stringify({
+    groups: options.targetGroups,
+    dockerfiles: options.dockerfiles ?? [],
+  });
 
   const server = createServer((req, res) =>
     handleRequest(req, res, options.bus, html, targetsJson, options)

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -178,6 +178,9 @@ const STUDIO_CSS = `
   .pair-add { align-self: flex-start; background: #1d1d1d; color: #7bd88f; border: 1px solid #2f4030;
     border-radius: 3px; cursor: pointer; padding: 3px 9px; font: 12px ui-monospace, monospace; }
   .pair-add:hover { background: #243024; }
+  .options select { flex: 1; background: #111; color: #ddd; border: 1px solid #333; border-radius: 3px;
+    padding: 4px 6px; font: 12px ui-monospace, Menlo, monospace; min-width: 0; }
+  .options select:focus { outline: none; border-color: #4ec97a; }
   details.all-options { margin: 8px 0; border-top: 1px solid #2a2a2a; padding-top: 6px; }
   details.all-options > summary { color: #8a8a8a; font-size: 12px; cursor: pointer; user-select: none; }
   details.all-options > summary:hover { color: #bbb; }
@@ -217,6 +220,7 @@ const STUDIO_SCRIPT = `
   let shownInvId = null;           // lambda invocation whose result is in the workspace
   let shownServeId = null;         // serve target whose workspace is shown
   let shownDetailId = null;        // captured request whose read-only detail is shown
+  let studioDockerfiles = [];      // Dockerfiles scanned at boot (pinned-ecs image-override picker)
 
   function el(tag, cls, text) {
     const e = document.createElement(tag);
@@ -416,11 +420,48 @@ const STUDIO_SCRIPT = `
     };
   }
 
+  // Image-override picker for a pinned ECS service (issue #301): a select of
+  // the Dockerfiles discovered at boot. Picking one threads an
+  // --image-override flag to start-service so the deployed-registry-pinned
+  // image is rebuilt from local source. Default "(keep pinned image)" => no
+  // override.
+  function buildImageOverridePicker() {
+    const sec = el('div', 'section options');
+    sec.appendChild(el('h3', null, 'Image override'));
+    const row = el('div', 'opt-row');
+    row.appendChild(el('span', 'opt-label', 'Local Dockerfile'));
+    const sel = el('select', 'image-override-select');
+    const none = el('option', null, '(keep pinned image)');
+    none.value = '';
+    sel.appendChild(none);
+    studioDockerfiles.forEach(function (df) {
+      const o = el('option', null, df);
+      o.value = df;
+      sel.appendChild(o);
+    });
+    row.appendChild(sel);
+    sec.appendChild(row);
+    const hint = studioDockerfiles.length
+      ? 'This image is pinned to a deployed registry — local edits do not take effect. Pick a Dockerfile to rebuild it locally.'
+      : 'This image is pinned to a deployed registry, but no Dockerfile was found under the app directory.';
+    sec.appendChild(el('div', 'opt-hint', hint));
+    return {
+      node: sec,
+      collect: function () {
+        const v = sel.value.trim();
+        return v === '' ? undefined : v;
+      },
+    };
+  }
+
   async function loadTargets() {
     const pane = document.getElementById('targets');
     try {
       const res = await fetch('/api/targets');
       const data = await res.json();
+      // Dockerfiles discovered at boot — offered in a pinned ecs service's
+      // image-override picker (issue #301).
+      studioDockerfiles = Array.isArray(data.dockerfiles) ? data.dockerfiles : [];
       pane.querySelectorAll('.group-title,.target,.empty').forEach((n) => n.remove());
       let total = 0;
       for (const group of data.groups) {
@@ -454,7 +495,7 @@ const STUDIO_SCRIPT = `
             t.appendChild(btnSlot);
             t.onclick = () => selectTarget(entry.id, group.kind);
             targetEls.set(entry.id, t);
-            serveMeta.set(entry.id, { dot, btnSlot, kind: group.kind });
+            serveMeta.set(entry.id, { dot, btnSlot, kind: group.kind, pinned: entry.pinned === true });
             updateServeRow(entry.id);
           }
           pane.appendChild(t);
@@ -537,7 +578,7 @@ const STUDIO_SCRIPT = `
     }
   }
 
-  async function startServe(id, options, rawArgs) {
+  async function startServe(id, options, rawArgs, imageOverride) {
     // The serve kind (api / alb / ecs) drives which headless command the
     // server spawns; it is recorded on the row when the target list loads.
     const meta = serveMeta.get(id);
@@ -548,6 +589,7 @@ const STUDIO_SCRIPT = `
       const body = { targetId: id, kind };
       if (options) body.options = options;
       if (rawArgs) body.rawArgs = rawArgs;
+      if (imageOverride) body.imageOverride = imageOverride;
       const res = await fetch('/api/run', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -605,7 +647,8 @@ const STUDIO_SCRIPT = `
     // Per-run options are only set before a start; collected on the Start click.
     let collectOpts = function () { return undefined; };
     let collectRaw = function () { return undefined; };
-    btn.onclick = () => { if (running || starting) stopServe(id); else startServe(id, collectOpts(), collectRaw()); };
+    let collectImageOverride = function () { return undefined; };
+    btn.onclick = () => { if (running || starting) stopServe(id); else startServe(id, collectOpts(), collectRaw(), collectImageOverride()); };
     head.appendChild(btn);
     if (errMsg) {
       const m = el('div', 'err', errMsg);
@@ -614,6 +657,15 @@ const STUDIO_SCRIPT = `
     ws.appendChild(head);
 
     if (!running && !starting) {
+      // A pinned ECS service (deployed-registry image) does not pick up local
+      // source edits — offer an image-override Dockerfile picker so it can be
+      // rebuilt locally (issue #301). Local-asset services hot-reload under
+      // --watch and get no picker.
+      if (meta && meta.kind === 'ecs' && meta.pinned) {
+        const io = buildImageOverridePicker();
+        ws.appendChild(io.node);
+        collectImageOverride = io.collect;
+      }
       const opt = buildOptions(kind);
       if (opt.node) ws.appendChild(opt.node);
       collectOpts = opt.collect;

--- a/tests/integration/local-studio/Dockerfile.override
+++ b/tests/integration/local-studio/Dockerfile.override
@@ -1,0 +1,15 @@
+# Image-override fixture for the studio pinned-service Dockerfile picker
+# (issue #301). MyService's deployed image is a public-registry pin
+# (`public.ecr.aws/docker/library/python:3.12-alpine`) — local source edits do
+# NOT take effect for it. Picking THIS Dockerfile in the studio composer
+# threads `--image-override LocalStudioFixture/MyService=./Dockerfile.override`
+# to the spawned `start-service`, which rebuilds the service from here.
+#
+# The task definition's command (`python -m http.server 80`) serves the image
+# WORKDIR, so dropping a sentinel index.html in a WORKDIR distinguishes a local
+# override build (serves the sentinel) from the pinned image (serves the root
+# directory listing). The verify.sh curls for the sentinel to prove the
+# override applied end-to-end.
+FROM public.ecr.aws/docker/library/python:3.12-alpine
+RUN mkdir -p /srv && printf 'studio-image-override-301\n' > /srv/index.html
+WORKDIR /srv

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -225,7 +225,12 @@ if ! grep -qF "buildAllOptions" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the All options / raw extra-args builder"
   exit 1
 fi
-echo "    OK: UI HTML served with the stack label + All options catalog"
+# The pinned-service image-override Dockerfile picker (issue #301).
+if ! grep -qF "buildImageOverridePicker" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the image-override Dockerfile picker"
+  exit 1
+fi
+echo "    OK: UI HTML served with the stack label + All options catalog + image-override picker"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.
@@ -750,6 +755,21 @@ if ! grep -qF '"MyService"' "${BODY_FILE}" && ! grep -qF 'MyService' "${BODY_FIL
 fi
 echo "    OK: ecs service is listed (servable), task definition listed (not servable)"
 
+# Image-override discoverability (issue #301): MyService's image is a
+# public-registry pin (not a local CDK asset), so studio marks it
+# `"pinned":true` and exposes the boot-discovered Dockerfiles (including the
+# fixture's ./Dockerfile.override) so the composer can offer the picker.
+echo "==> /api/targets marks the pinned ecs service + lists discovered Dockerfiles"
+if ! grep -qF '"pinned":true' "${BODY_FILE}"; then
+  echo "FAIL: /api/targets did not mark the public-image ECS service as pinned"
+  cat "${BODY_FILE}"; exit 1
+fi
+if ! grep -qF 'Dockerfile.override' "${BODY_FILE}"; then
+  echo "FAIL: /api/targets did not surface the discovered ./Dockerfile.override"
+  cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: pinned ecs service flagged + Dockerfile.override discovered"
+
 ALB_TARGET="LocalStudioFixture/MyAlb"
 echo "==> POST /api/run starts an ALB serve (boots the ECS service + front-door)"
 # Re-arm the SSE listener to capture the ALB request invocation.
@@ -870,6 +890,54 @@ sleep 3
 echo "    OK: ECS service stopped"
 
 # ---------------------------------------------------------------------------
+# 10b. Image-override picker (issue #301): MyService's deployed image is a
+#      public-registry pin, so local source edits do not take effect. Studio
+#      threads the picked Dockerfile as
+#      `--image-override LocalStudioFixture/MyService=./Dockerfile.override`
+#      (the EXPLICIT form — studio's child has no TTY, so the bare picker form
+#      would be skipped). The override Dockerfile builds an image whose WORKDIR
+#      holds a sentinel index.html; the task-def command `python -m http.server
+#      80` then serves the sentinel. Curling it proves the override BUILT +
+#      RAN locally (the pinned image would serve a root directory listing,
+#      never this sentinel) — the picker -> /api/run -> --image-override ->
+#      start-service rebuild path end-to-end.
+# ---------------------------------------------------------------------------
+IO_HOST_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+echo "==> POST /api/run with imageOverride rebuilds the pinned service from a local Dockerfile"
+IO_FILE=$(mktemp)
+HTTP_IO=$(curl -s -o "${IO_FILE}" -w '%{http_code}' --max-time 300 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TARGET}\",\"kind\":\"ecs\",\"imageOverride\":\"./Dockerfile.override\",\"options\":{\"--max-tasks\":\"1\",\"--host-port\":[{\"left\":\"80\",\"right\":\"${IO_HOST_PORT}\"}]}}" || true)
+if [[ "${HTTP_IO}" != "200" ]] || ! grep -qF '"status":"running"' "${IO_FILE}"; then
+  echo "FAIL: POST /api/run (image-override) returned HTTP ${HTTP_IO}"
+  echo "----- response -----"; cat "${IO_FILE}"; echo "--------------------"
+  echo "----- studio log -----"; tail -c 3000 "${LOG_FILE}"; echo "----------------------"
+  rm -f "${IO_FILE}"; exit 1
+fi
+rm -f "${IO_FILE}"
+# The override build + boot can take a while (docker build of one extra layer
+# on top of the already-pulled base, then the replica boots). Retry the curl.
+IO_BODY=""
+for _ in $(seq 1 60); do
+  IO_BODY=$(curl -fsS --max-time 3 "http://127.0.0.1:${IO_HOST_PORT}/" 2>/dev/null || true)
+  if echo "${IO_BODY}" | grep -qF 'studio-image-override-301'; then break; fi
+  sleep 1
+done
+if ! echo "${IO_BODY}" | grep -qF 'studio-image-override-301'; then
+  echo "FAIL: image-override did not apply (sentinel absent from the served replica)"
+  echo "----- served body -----"; echo "${IO_BODY}" | head -c 1000; echo "-----------------------"
+  echo "----- studio log -----"; tail -c 3000 "${LOG_FILE}"; echo "----------------------"
+  exit 1
+fi
+echo "    OK: image-override threaded; the pinned service ran the LOCAL Dockerfile build (sentinel served)"
+
+echo "==> POST /api/stop tears the image-override service down"
+curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TARGET}\"}" -o /dev/null || true
+sleep 3
+echo "    OK: image-override service stopped"
+
+# ---------------------------------------------------------------------------
 # 11. Clean shutdown on SIGTERM.
 # ---------------------------------------------------------------------------
 echo "==> Stopping studio (SIGTERM) and asserting clean exit"
@@ -960,4 +1028,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + all-options-catalog + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -127,6 +127,31 @@ describe('coerceRunRequest', () => {
     ).toThrow(/unterminated/i);
   });
 
+  it('threads a well-formed imageOverride string through', () => {
+    expect(
+      coerceRunRequest({ targetId: 'Stack/Svc', kind: 'ecs', imageOverride: './Dockerfile' })
+    ).toEqual({
+      targetId: 'Stack/Svc',
+      kind: 'ecs',
+      event: undefined,
+      imageOverride: './Dockerfile',
+    });
+  });
+
+  it('omits a blank imageOverride', () => {
+    expect(coerceRunRequest({ targetId: 'Stack/Svc', kind: 'ecs', imageOverride: '   ' })).toEqual({
+      targetId: 'Stack/Svc',
+      kind: 'ecs',
+      event: undefined,
+    });
+  });
+
+  it('rejects a non-string imageOverride', () => {
+    expect(() =>
+      coerceRunRequest({ targetId: 'Stack/Svc', kind: 'ecs', imageOverride: 42 })
+    ).toThrow(/"imageOverride" must be a string/);
+  });
+
   it('accepts an agentcore request with its per-run options', () => {
     expect(
       coerceRunRequest({

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -274,6 +274,58 @@ describe('createStudioServeManager', () => {
     expect(argv[i + 1]).toBe('443=8443');
   });
 
+  it('threads imageOverride as an explicit --image-override <target>=<dockerfile>', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'Stack/MyService',
+      kind: 'ecs',
+      imageOverride: './Dockerfile.local',
+    });
+    child.stdout.emit('data', 'Service(s) running:\n');
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const i = argv.indexOf('--image-override');
+    expect(i).toBeGreaterThan(-1);
+    // Explicit form keyed by the SAME target id passed as the start-service
+    // target arg (the bare picker form would be skipped non-interactively).
+    expect(argv[i + 1]).toBe('Stack/MyService=./Dockerfile.local');
+  });
+
+  it('omits --image-override when imageOverride is blank', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'Stack/MyService', kind: 'ecs', imageOverride: '   ' });
+    child.stdout.emit('data', 'Service(s) running:\n');
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv).not.toContain('--image-override');
+  });
+
   it('tokenizes raw extra args and appends them to the spawned serve argv', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -5,6 +5,7 @@ import {
   startStudioServer,
   toStudioTargetGroups,
   filterStudioTargetGroups,
+  annotatePinnedEcsTargets,
   type RunningStudioServer,
   type StudioTargetGroup,
 } from '../../../src/local/studio-server.js';
@@ -173,6 +174,51 @@ const emptyListing = (): TargetListing => ({
   loadBalancers: [],
 });
 
+describe('annotatePinnedEcsTargets', () => {
+  const groups = (): StudioTargetGroup[] => [
+    {
+      kind: 'ecs',
+      title: 'ECS Services / Tasks',
+      entries: [
+        { id: 'S/Pinned', qualifiedId: 'S:Pinned', servable: true },
+        { id: 'S/Asset', qualifiedId: 'S:Asset', servable: true },
+        { id: 'S/Task', qualifiedId: 'S:Task', servable: false },
+      ],
+    },
+    { kind: 'lambda', title: 'Lambda', entries: [{ id: 'S/Fn', qualifiedId: 'S:Fn' }] },
+  ];
+
+  it('marks only the servable ecs services the classifier returns true for', () => {
+    const g = groups();
+    const anyPinned = annotatePinnedEcsTargets(g, (id) => id === 'S/Pinned');
+    expect(anyPinned).toBe(true);
+    const ecs = g[0].entries;
+    expect(ecs[0].pinned).toBe(true); // S/Pinned
+    expect(ecs[1].pinned).toBeUndefined(); // S/Asset (classifier false)
+    expect(ecs[2].pinned).toBeUndefined(); // S/Task (not servable — never classified)
+  });
+
+  it('never classifies a non-servable entry (task definition)', () => {
+    const seen: string[] = [];
+    annotatePinnedEcsTargets(groups(), (id) => {
+      seen.push(id);
+      return false;
+    });
+    // The non-servable task def + the lambda are never passed to classify.
+    expect(seen).toEqual(['S/Pinned', 'S/Asset']);
+  });
+
+  it('returns false (skip the Dockerfile scan) when nothing is pinned', () => {
+    expect(annotatePinnedEcsTargets(groups(), () => false)).toBe(false);
+  });
+
+  it('leaves non-ecs groups untouched', () => {
+    const g = groups();
+    annotatePinnedEcsTargets(g, () => true);
+    expect(g[1].entries[0].pinned).toBeUndefined();
+  });
+});
+
 describe('toStudioTargetGroups', () => {
   it('projects a TargetListing into the five studio groups', () => {
     const listing: TargetListing = {
@@ -285,6 +331,36 @@ describe('startStudioServer', () => {
     const data = (await res.json()) as { groups: { kind: string; entries: unknown[] }[] };
     const lambda = data.groups.find((g) => g.kind === 'lambda');
     expect(lambda?.entries).toEqual([{ id: 'MyStack/Handler', qualifiedId: 'MyStack:Handler' }]);
+  });
+
+  it('serves the discovered dockerfiles alongside the target groups (issue #301)', async () => {
+    const server = await boot({ dockerfiles: ['./Dockerfile', './svc/Dockerfile.dev'] });
+    const res = await http(`${server.url}/api/targets`);
+    const data = (await res.json()) as { groups: unknown[]; dockerfiles: string[] };
+    expect(data.dockerfiles).toEqual(['./Dockerfile', './svc/Dockerfile.dev']);
+  });
+
+  it('defaults dockerfiles to an empty array when none were discovered', async () => {
+    const server = await boot();
+    const res = await http(`${server.url}/api/targets`);
+    const data = (await res.json()) as { dockerfiles: string[] };
+    expect(data.dockerfiles).toEqual([]);
+  });
+
+  it('passes a pinned ecs service flag through the target list', async () => {
+    const server = await boot({
+      targetGroups: [
+        {
+          kind: 'ecs',
+          title: 'ECS Services / Tasks',
+          entries: [{ id: 'S/Svc', qualifiedId: 'S:Svc', servable: true, pinned: true }],
+        },
+      ],
+    });
+    const res = await http(`${server.url}/api/targets`);
+    const data = (await res.json()) as { groups: { kind: string; entries: { pinned?: boolean }[] }[] };
+    const ecs = data.groups.find((g) => g.kind === 'ecs');
+    expect(ecs?.entries[0].pinned).toBe(true);
   });
 
   it('404s an unknown path', async () => {

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -59,6 +59,20 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('Object.keys(out).length ? out : undefined');
   });
 
+  it('renders an image-override Dockerfile picker for a pinned ecs service (issue #301)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The picker builder + its select are present.
+    expect(html).toContain('function buildImageOverridePicker');
+    expect(html).toContain("el('select', 'image-override-select')");
+    // Gated on the serve target being a pinned ecs service.
+    expect(html).toContain("meta.kind === 'ecs' && meta.pinned");
+    // The picked Dockerfile is threaded onto the serve body.
+    expect(html).toContain('body.imageOverride = imageOverride');
+    // The picker is populated from the boot-scanned dockerfiles carried on the
+    // target list payload.
+    expect(html).toContain('studioDockerfiles = Array.isArray(data.dockerfiles)');
+  });
+
   it('makes AgentCore a single-shot invoke target with its own options (issue #303)', () => {
     const html = renderStudioHtml('MyStack', 'cdkl');
     // AgentCore is wired as an invoke kind (event composer), alongside lambda.


### PR DESCRIPTION
## Summary

Add an image-override **Dockerfile picker** to `cdkl studio` for ECS
services whose image is pinned to a deployed registry. Such a service
does NOT pick up local source edits, so studio now surfaces the
`--image-override` flow for it without leaving the UI. Part of issue
#301. Decided pinned-only (a local-asset service already hot-reloads
under `--watch`, so a picker there would be redundant + confusing).

## Implementation

- **Boot classification** (`annotatePinnedEcsTargets`, extracted +
  unit-tested): each servable ECS service is classified pinned vs local
  CDK asset (`resolveEcsServiceTarget` + `isLocalCdkAssetImage`); a
  pinned service is marked `pinned` in the target list. The app dir is
  scanned once (`discoverDockerfiles`, only when something is pinned).
  Both `pinned` and the `dockerfiles` list are served at
  `GET /api/targets`.
- **UI**: a pinned ecs serve composer gets a Dockerfile `<select>`
  (`buildImageOverridePicker`); a local-asset service gets no picker.
- **Threading**: the pick goes out as
  `--image-override <target>=<dockerfile>` — the **explicit** form, NOT
  the bare picker form, because studio spawns the child WITHOUT a TTY and
  the engine skips bare picker-form paths when non-interactive (it would
  silently not apply). The target key equals the same id passed as the
  start-service target arg. Validated at the `/api/run` boundary
  (`coerceRunRequest`).

## Behavior / design notes

- **Classification is best-effort + state-free** (template-only, no AWS
  calls at boot). Under `--from-cfn-stack`, an ECR image expressed as an
  unresolved intrinsic could be hinted differently than the actual
  start-service verdict. The hint only governs whether the UI surfaces
  the picker; a mis-hinted service can still be overridden via the "All
  options" raw-args `--image-override`.

## cdkd parity

- New exported helper `annotatePinnedEcsTargets` (re-exported from
  `src/internal.ts`) so a host building its own studio can reuse the
  same pinned-target annotation. Additive type fields `imageOverride`
  (`StudioRunRequest` / `StudioServeRequest`), `dockerfiles`
  (`StudioServerOptions`), `pinned` (`StudioTarget`) on already
  host-exported interfaces — a host embedding studio inherits the
  behavior; no migration.

## Test plan

- `vp run check` + `vp run build` + `vp run test` — 156 files, 2417
  tests pass; new `annotatePinnedEcsTargets` unit suite covers the
  classifier-true/false, non-servable-skip, non-ecs-skip, and
  any-pinned-return branches; serve-manager + coerceRunRequest +
  studio-server + studio-ui suites cover the threading / validation /
  serialization / picker-render
- `/run-integ local-studio` — green: `/api/targets` marks MyService
  (a public-registry pin) `pinned` + lists `./Dockerfile.override`; a
  `POST /api/run` with `imageOverride` rebuilds the pinned service from
  the local Dockerfile, and curling the replica returns a sentinel that
  can ONLY come from the local override build (the pinned image serves a
  root directory listing). 0 Docker orphans
