### PR TITLE
fix(studio): bind AgentCore invocation logs strictly by container id

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -443,9 +443,10 @@ compute-locally category for Lambda + API Gateway).
   store: subscribes to the bus and retains a bounded, newest-wins window
   of invocations + log lines so the server can answer history on
   (re)connect, full-text log search across the session, and
-  per-invocation log binding at CloudWatch granularity (decision D5 — a
-  Lambda binds strictly by container id; a captured serve request binds
-  best-effort by target + time window). alb / ecs serve kinds still to
+  per-invocation log binding at CloudWatch granularity (decision D5 — the
+  single-shot invoke kinds (lambda + agentcore, issue #309) bind strictly
+  by container id; a captured serve request binds best-effort by target +
+  time window). alb / ecs serve kinds still to
   come), etc.
 - `src/assets/` — asset manifest loader + docker-build for container Lambdas.
 - `src/types/` — shared interfaces (`StackState`, `ResourceState`,

--- a/src/local/studio-store.ts
+++ b/src/local/studio-store.ts
@@ -123,12 +123,14 @@ export function createStudioStore(
     logsForInvocation: (id): StudioLogEvent[] => {
       const inv = invocations.get(id);
       if (!inv) return [];
-      // Bind by KIND, not by "did the strict filter match anything". A
-      // Lambda's lines are keyed to the invocation id, so bind STRICTLY by
-      // container id — even when the invocation emitted none (an empty
-      // result is correct; falling back to a time window would surface a
-      // DIFFERENT invocation's logs of the same function).
-      if (inv.kind === 'lambda') {
+      // Bind by KIND, not by "did the strict filter match anything". The
+      // single-shot invoke kinds (lambda + agentcore, issue #303) key every
+      // log line to the invocation id (the dispatcher's runChild emits each
+      // with `containerId: invocationId`), so bind STRICTLY by container id —
+      // even when the invocation emitted none (an empty result is correct;
+      // falling back to a time window would surface a DIFFERENT invocation's
+      // logs of the same target, e.g. two sequential invokes of one agent).
+      if (inv.kind === 'lambda' || inv.kind === 'agentcore') {
         return logs.filter((l) => l.containerId === id);
       }
       // A captured serve request's logs are keyed to the long-running serve

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -446,7 +446,27 @@ for needle in '"ok":true' '"status":200' '"echoed"' '"hello":"studio"' 'hello-fr
   fi
   echo "    OK: AgentCore run response has ${needle}"
 done
+# Per-invocation log binding for the AgentCore invoke (issue #309): an
+# agentcore invocation keys its logs to the invocation id (like a Lambda), so
+# GET /api/invocations/<id>/logs must bind STRICTLY by container id, not the
+# loose time-window fallback. Assert the endpoint returns this invocation's
+# bound logs (a JSON array) — exercising the agentcore branch of
+# logsForInvocation end-to-end.
+AC_INV=$(grep -oE '"invocationId":"[^"]+"' "${AC_FILE}" | head -1 | sed 's/.*"invocationId":"//;s/"//')
 rm -f "${AC_FILE}"
+if [[ -z "${AC_INV}" ]]; then echo "FAIL: no invocationId from the AgentCore invoke"; exit 1; fi
+AC_LOGS=$(curl -fsS "${URL}/api/invocations/${AC_INV}/logs" || true)
+# The endpoint returns { "logs": [ { containerId, target, line, ... } ] }. With
+# strict container-id binding the bound lines carry THIS invocation's id as
+# their containerId — assert the agent's own log lines (keyed to AC_INV) are
+# present, proving the agentcore branch bound by container id, not a loose
+# time window.
+if ! echo "${AC_LOGS}" | grep -qF "\"containerId\":\"${AC_INV}\""; then
+  echo "FAIL: GET /api/invocations/<agentcore-id>/logs did not bind this invocation's container-id logs"
+  echo "----- body -----"; echo "${AC_LOGS}" | head -c 500; echo; echo "----------------"
+  exit 1
+fi
+echo "    OK: the AgentCore invocation's logs bind by container id (issue #309)"
 
 # ---------------------------------------------------------------------------
 # 6e. POST /api/run with the AgentCore `--ws` per-run option (issue #303):

--- a/tests/unit/local/studio-store.test.ts
+++ b/tests/unit/local/studio-store.test.ts
@@ -138,6 +138,22 @@ describe('createStudioStore', () => {
       expect(store.logsForInvocation('inv-1').map((l) => l.line)).toEqual(['mine']);
     });
 
+    it('binds an AgentCore invocation STRICTLY by container id (issue #309)', () => {
+      const bus = new StudioEventBus();
+      const store = createStudioStore(bus);
+      // Two sequential invokes of the SAME agent at the SAME timestamp — a
+      // time-window bind would cross-surface them, so strict container-id
+      // binding is required (the dispatcher keys agentcore logs by invocation
+      // id, exactly like a Lambda).
+      bus.emit('invocation', inv({ id: 'ac-1', kind: 'agentcore', target: 'Stack/Agent', ts: 100 }));
+      bus.emit('invocation', inv({ id: 'ac-2', kind: 'agentcore', target: 'Stack/Agent', ts: 100 }));
+      bus.emit('log', log({ line: 'first', containerId: 'ac-1', target: 'Stack/Agent', ts: 100 }));
+      bus.emit('log', log({ line: 'second', containerId: 'ac-2', target: 'Stack/Agent', ts: 100 }));
+
+      expect(store.logsForInvocation('ac-1').map((l) => l.line)).toEqual(['first']);
+      expect(store.logsForInvocation('ac-2').map((l) => l.line)).toEqual(['second']);
+    });
+
     it('binds a captured serve request best-effort by target + time window', () => {
       const bus = new StudioEventBus();
       const store = createStudioStore(bus, { bindGraceMs: 50 });


### PR DESCRIPTION
## Summary

`studio-store`'s `logsForInvocation` bound an invocation's logs strictly
by container id only for `kind === 'lambda'`; every other kind fell to
the best-effort time-window binding (target + the request's time window),
which is right for a captured long-running serve request but loose for a
single-shot invoke.

Since #303 made AgentCore runtimes a first-class single-shot invoke whose
logs are keyed to the invocation id exactly like a Lambda's (the
dispatcher's `runChild` emits each log with `containerId: invocationId`),
an `agentcore` invocation now binds **strictly by container id** too —
otherwise two sequential invokes of the same agent could cross-surface
each other's logs via the time-window fallback.

One-line predicate change (`lambda` -> `lambda || agentcore`); the
time-window binding stays for captured serve requests.

## Test plan

- Unit (`studio-store.test.ts`): a new test invokes two agentcore
  invocations at the SAME timestamp and asserts each binds only its own
  container-id logs (a time-window bind would cross-surface them)
- Integ (`local-studio`): the AgentCore HTTP invoke now also asserts
  `GET /api/invocations/<id>/logs` binds this invocation's container-id
  logs (the agent's `listening on ...` line keyed to the invocation id) —
  exercising the agentcore branch end-to-end. 0 Docker orphans
- `vp run check` + `vp run test` (156 files, 2418 tests) pass

Closes #309
