### PR TITLE
perf(studio): reuse the boot synth for spawned children (avoid the double synth)

### DIFF
--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -1,4 +1,6 @@
 import { spawn } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { Command, Option } from 'commander';
 import {
   appOptions,
@@ -201,6 +203,42 @@ export function parseStudioPort(raw: string): number {
   return port;
 }
 
+/**
+ * Resolve the on-disk cloud-assembly directory the boot synth produced, so
+ * studio can forward `--app <assemblyDir>` to NON-watch children and skip a
+ * redundant re-synth (issue #324). Returns the absolute path when a
+ * reusable assembly directory exists, else `undefined` (children then fall
+ * back to forwarding the app command).
+ *
+ * Two cases yield a reusable dir:
+ *   1. `--app` is itself a pre-synthesized assembly directory — `synthesize`
+ *      read it in place (no `--output` write), so we reuse that very dir.
+ *   2. `--app` is a CDK app command — the synth wrote the assembly to
+ *      `--output` (default `cdk.out`), so we reuse that.
+ *
+ * The existence check is defensive: if neither path is a directory on disk
+ * (an unusual synth setup), we return `undefined` rather than hand a child
+ * a `--app` that points at nothing.
+ *
+ * Exported for unit testing.
+ */
+export function resolveBootAssemblyDir(appCmd: string, output: string): string | undefined {
+  const isDir = (p: string): boolean => {
+    try {
+      return existsSync(p) && statSync(p).isDirectory();
+    } catch {
+      return false;
+    }
+  };
+  // Case 1: --app already points at a pre-synthesized assembly directory.
+  const appPath = resolve(appCmd);
+  if (isDir(appPath)) return appPath;
+  // Case 2: a CDK app command synthed into the --output directory.
+  const outPath = resolve(output);
+  if (isDir(outPath)) return outPath;
+  return undefined;
+}
+
 interface LocalStudioOptions {
   app?: string;
   output: string;
@@ -270,6 +308,17 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     ...(Object.keys(context).length > 0 && { context }),
   };
   const { stacks } = await synthesizer.synthesize(synthOpts);
+
+  // The boot synth persisted the cloud assembly to `--output` (default
+  // `cdk.out`). Capture it so NON-watch children studio spawns
+  // (`cdkl invoke` / `start-api` / ...) read `--app <assemblyDir>` and skip
+  // a redundant re-synth (issue #324). Guard on the dir actually existing —
+  // when `--app` already pointed at a pre-synthesized assembly dir,
+  // `synthesize` reads it in place and `--output` is never written, so we
+  // reuse that same dir; otherwise (and only then) fall back to forwarding
+  // the app command, never a non-existent path. A `--watch` serve still
+  // re-synths (it forwards `--app <appCmd>` — decided per spawn).
+  const assemblyDir = resolveBootAssemblyDir(appCmd, options.output);
 
   const listing = listTargets(stacks);
   // `--stack <glob>` scopes the LISTED targets (display only — the whole app
@@ -341,6 +390,7 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     bus: StudioEventBus;
     cwd: string;
     app?: string;
+    assemblyDir?: string;
     profile?: string;
     region?: string;
     context?: Record<string, string>;
@@ -352,6 +402,7 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     bus,
     cwd: process.cwd(),
     ...(appCmd ? { app: appCmd } : {}),
+    ...(assemblyDir ? { assemblyDir } : {}),
     ...(options.profile ? { profile: options.profile } : {}),
     ...(options.region ? { region: options.region } : {}),
     ...(Object.keys(context).length > 0 ? { context } : {}),

--- a/src/local/studio-child-args.ts
+++ b/src/local/studio-child-args.ts
@@ -16,6 +16,17 @@
 export interface SharedChildConfig {
   /** `--app` value, if studio was given one. */
   app?: string;
+  /**
+   * Absolute path to the cloud-assembly directory studio synthesized ONCE
+   * at boot (the `--output` dir, default `cdk.out`), if it persisted to
+   * disk. When set and the child does NOT need to re-synth (every
+   * single-shot invoke, and a serve that is NOT spawned with `--watch`),
+   * `buildSharedChildArgs({ preferAssembly: true })` forwards
+   * `--app <assemblyDir>` instead of `--app <app>` so the child reads the
+   * pre-synthesized assembly and skips its own synth (issue #324). A
+   * `--watch` serve must re-synth on change, so it keeps `--app <app>`.
+   */
+  assemblyDir?: string;
   /** `--profile` to thread through. */
   profile?: string;
   /** `--region` to thread through. */
@@ -38,14 +49,39 @@ export interface SharedChildConfig {
   assumeRole?: string;
 }
 
+/** Per-call knobs for {@link buildSharedChildArgs}. */
+export interface BuildSharedChildArgsOptions {
+  /**
+   * When true and `config.assemblyDir` is set, forward
+   * `--app <assemblyDir>` (the once-synthesized cloud assembly) instead of
+   * `--app <app>` so the child skips its own synth (issue #324). The two
+   * spawn sites decide this per child: studio-dispatch always passes `true`
+   * (single-shot invokes never re-synth), studio-serve-manager passes
+   * `!config.watch` (a `--watch` serve must re-synth on change). Defaults
+   * to false (forward `--app <app>` — the pre-#324 behavior).
+   */
+  preferAssembly?: boolean;
+}
+
 /**
  * Build the shared `--app` / `--profile` / `--region` / `-c` /
  * `--from-cfn-stack` / `--assume-role` args for a studio child command.
  * Returns a flat argv fragment to spread after the subcommand + target.
+ *
+ * When `opts.preferAssembly` is true and `config.assemblyDir` is set, the
+ * `--app` value is the once-synthesized cloud-assembly directory so the
+ * child reads it and skips a redundant synth (issue #324); otherwise it is
+ * the app command (`config.app`).
  */
-export function buildSharedChildArgs(config: SharedChildConfig): string[] {
+export function buildSharedChildArgs(
+  config: SharedChildConfig,
+  opts: BuildSharedChildArgsOptions = {}
+): string[] {
   const args: string[] = [];
-  if (config.app) args.push('--app', config.app);
+  // `--app`: reuse the boot-synthesized assembly dir when the child does
+  // not need to re-synth (issue #324); else the app command.
+  const appValue = opts.preferAssembly && config.assemblyDir ? config.assemblyDir : config.app;
+  if (appValue) args.push('--app', appValue);
   if (config.profile) args.push('--profile', config.profile);
   if (config.region) args.push('--region', config.region);
   for (const [k, v] of Object.entries(config.context ?? {})) {

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -171,7 +171,10 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
         req.targetId,
         '--event',
         eventFile,
-        ...buildSharedChildArgs(config),
+        // Single-shot invokes never re-synth, so reuse the boot-synthesized
+        // cloud assembly when studio captured one (issue #324): the child
+        // reads `--app <assemblyDir>` and skips its own synth.
+        ...buildSharedChildArgs(config, { preferAssembly: true }),
         ...buildPerRunArgs(req.kind, req.options),
       ];
 

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -256,11 +256,17 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
   }
 
   function buildArgs(req: StudioServeRequest, spec: ServeKindSpec): string[] {
+    // A `--watch` serve MUST re-synth on source changes, so it keeps
+    // `--app <app>`; a non-watch serve reuses the boot-synthesized cloud
+    // assembly studio captured (issue #324) and skips its own synth. Read
+    // `config.watch` per start (mutable — a Session-bar toggle applies to
+    // the next serve), matching the `--watch` flag append below.
+    const preferAssembly = config.watch !== true;
     return [
       spec.command,
       req.targetId,
       ...spec.portArgs,
-      ...buildSharedChildArgs(config),
+      ...buildSharedChildArgs(config, { preferAssembly }),
       ...buildPerRunArgs(req.kind, req.options),
       // Image-override picker (issue #301): a pinned ecs service rebuilds from
       // the chosen local Dockerfile. The EXPLICIT `<target>=<dockerfile>` form

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vite-plus/test';
 import {
   applyConfigPatch,
@@ -5,6 +8,7 @@ import {
   coerceStopRequest,
   createLocalStudioCommand,
   parseStudioPort,
+  resolveBootAssemblyDir,
   type EditableSessionBindings,
 } from '../../../src/cli/commands/local-studio.js';
 
@@ -244,4 +248,39 @@ describe('coerceStopRequest', () => {
       expect(() => coerceStopRequest(body)).toThrow(/non-empty "targetId"/);
     }
   );
+});
+
+describe('resolveBootAssemblyDir (issue #324)', () => {
+  it('returns the resolved --output dir for an app-command synth that wrote it', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-studio-asm-'));
+    const out = join(dir, 'cdk.out');
+    mkdirSync(out);
+    try {
+      // app command is not a directory; the synth wrote `out`.
+      expect(resolveBootAssemblyDir('node bin/app.ts', out)).toBe(out);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the --app dir when it is already a pre-synthesized assembly directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-studio-asm-'));
+    const appDir = join(dir, 'pre-synthed');
+    mkdirSync(appDir);
+    try {
+      // --app points at an assembly dir; --output was never written.
+      expect(resolveBootAssemblyDir(appDir, join(dir, 'cdk.out'))).toBe(appDir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns undefined when neither --app nor --output is a directory on disk', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkl-studio-asm-'));
+    try {
+      expect(resolveBootAssemblyDir('node bin/app.ts', join(dir, 'missing'))).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/unit/local/studio-child-args.test.ts
+++ b/tests/unit/local/studio-child-args.test.ts
@@ -55,6 +55,43 @@ describe('buildSharedChildArgs', () => {
     expect(buildSharedChildArgs({ assumeRole: '' })).toEqual([]);
   });
 
+  describe('assembly-dir reuse (issue #324)', () => {
+    it('forwards --app <app> by default (preferAssembly omitted)', () => {
+      expect(
+        buildSharedChildArgs({ app: 'node app.ts', assemblyDir: '/abs/cdk.out' })
+      ).toEqual(['--app', 'node app.ts']);
+    });
+
+    it('forwards --app <assemblyDir> when preferAssembly is true and a dir is set', () => {
+      expect(
+        buildSharedChildArgs(
+          { app: 'node app.ts', assemblyDir: '/abs/cdk.out' },
+          { preferAssembly: true }
+        )
+      ).toEqual(['--app', '/abs/cdk.out']);
+    });
+
+    it('falls back to --app <app> when preferAssembly is true but no assemblyDir is set', () => {
+      expect(
+        buildSharedChildArgs({ app: 'node app.ts' }, { preferAssembly: true })
+      ).toEqual(['--app', 'node app.ts']);
+    });
+
+    it('forwards --app <app> when preferAssembly is false even with an assemblyDir', () => {
+      expect(
+        buildSharedChildArgs(
+          { app: 'node app.ts', assemblyDir: '/abs/cdk.out' },
+          { preferAssembly: false }
+        )
+      ).toEqual(['--app', 'node app.ts']);
+    });
+
+    it('keeps the assemblyDir off the argv when neither app nor preferAssembly applies', () => {
+      // assemblyDir alone (no preferAssembly) does not leak onto the argv.
+      expect(buildSharedChildArgs({ assemblyDir: '/abs/cdk.out' })).toEqual([]);
+    });
+  });
+
   it('composes every flag in a stable order', () => {
     expect(
       buildSharedChildArgs({

--- a/tests/unit/local/studio-dispatch.test.ts
+++ b/tests/unit/local/studio-dispatch.test.ts
@@ -198,6 +198,34 @@ describe('createStudioDispatcher', () => {
     expect(argv).toContain('env=prod');
   });
 
+  it('forwards --app <assemblyDir> (not the app command) for a single-shot invoke (issue #324)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      app: 'node bin/app.ts',
+      assemblyDir: '/abs/cdk.out',
+      idFactory: () => 'inv-asm',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stdout.emit('data', '{}');
+    child.emit('close', 0);
+    await p;
+
+    // An invoke never re-synths, so it reuses the once-synthesized assembly
+    // dir rather than re-running the app command.
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const i = argv.indexOf('--app');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(argv[i + 1]).toBe('/abs/cdk.out');
+    expect(argv).not.toContain('node bin/app.ts');
+  });
+
   it('threads --from-cfn-stack <name> + --assume-role <arn> into the child argv', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -245,6 +245,55 @@ describe('createStudioServeManager', () => {
     expect((spawnFn.mock.calls[1] as unknown as [string, string[]])[1]).toContain('--watch');
   });
 
+  it('forwards --app <assemblyDir> for a non-watch serve but --app <app> when watching (issue #324)', async () => {
+    const bus = new StudioEventBus();
+    const fp = fakeProxies();
+
+    // Mutable config the manager reads per start: same object the studio
+    // childConfig PATCH /api/config edits in place.
+    const config: {
+      cliEntry: string;
+      bus: StudioEventBus;
+      app?: string;
+      assemblyDir?: string;
+      watch?: boolean;
+    } & Record<string, unknown> = {
+      cliEntry: '/path/to/cli.js',
+      bus,
+      app: 'node app.ts',
+      assemblyDir: '/abs/cdk.out',
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    };
+    const child1 = makeFakeChild();
+    const child2 = makeFakeChild();
+    const spawnFn = vi
+      .fn()
+      .mockReturnValueOnce(child1 as never)
+      .mockReturnValueOnce(child2 as never);
+    config['spawnFn'] = spawnFn;
+    const mgr = createStudioServeManager(config as never);
+
+    // Non-watch (default): reuse the boot-synthesized assembly dir.
+    const p1 = mgr.start({ targetId: 'A', kind: 'api' });
+    child1.stdout.emit('data', LISTENING);
+    await p1;
+    const argv1 = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const i1 = argv1.indexOf('--app');
+    expect(i1).toBeGreaterThanOrEqual(0);
+    expect(argv1[i1 + 1]).toBe('/abs/cdk.out');
+
+    // Watch ON: keep the app command so the serve re-synths on change.
+    config.watch = true;
+    const p2 = mgr.start({ targetId: 'B', kind: 'api' });
+    child2.stdout.emit('data', LISTENING);
+    await p2;
+    const argv2 = (spawnFn.mock.calls[1] as unknown as [string, string[]])[1];
+    const i2 = argv2.indexOf('--app');
+    expect(i2).toBeGreaterThanOrEqual(0);
+    expect(argv2[i2 + 1]).toBe('node app.ts');
+  });
+
   it('threads per-run options (boolean + repeat-pair) into the serve child argv', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();


### PR DESCRIPTION
## Summary

`cdkl studio` synthesizes at boot to build the target list, and then every
target started from the UI spawns a child (`cdkl invoke` / `start-api` /
...) that re-synthesizes the app — a redundant double-synth on every Start
/ Invoke, slow for a big app.

This reuses the boot synth: the cloud assembly is captured once
(`resolveBootAssemblyDir` — the `--output` dir, default `cdk.out`, or the
`--app`-is-already-an-assembly-dir case), and NON-watch children are spawned
with `--app <assemblyDir>` so they read the pre-synthed assembly and skip
their own synth. A `--watch` serve keeps `--app <appCmd>` (it must re-synth
on change), decided per spawn.

## Behavior change (internal)

Transparent — a child reading the once-synthed assembly produces the same
result it would by re-synthing, just faster. A host embedding studio via
`createLocalStudioCommand` inherits this automatically; no migration. The
new helpers (`resolveBootAssemblyDir`, the `assemblyDir` / `preferAssembly`
plumbing) are studio-internal — not on the `index.ts` / `internal.ts`
library surface.

## Test plan

- `vp run check` + `vp run build` + `vp run test` (157 files, 2429 tests)
  pass; new site-level binding tests lock: the dispatcher always reuses the
  assembly; a non-watch serve spawns `--app <assemblyDir>` while a `--watch`
  serve spawns `--app <appCmd>`; `resolveBootAssemblyDir` over real temp
  dirs (output-written / pre-synthed-app-dir / neither-exists)
- `/run-integ local-studio` — green: the full studio flow (invoke /
  agentcore / api/alb/ecs serve / image-override rebuild) works end-to-end
  with children now spawning `--app <assemblyDir>` — proving they read the
  reused assembly. 0 Docker orphans

Closes #324
