### PR TITLE
feat(studio): in-workspace HTTP request composer for served api / alb / ecs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -330,7 +330,12 @@ compute-locally category for Lambda + API Gateway).
   at `/api/targets`, an SSE
   stream of the event bus at `/api/events`, `POST /api/run` (single-shot
   invoke / serve start), `POST /api/stop` (serve stop),
-  `GET /api/running` (running serve snapshot), the slice-C3 store
+  `GET /api/running` (running serve snapshot), `POST /api/request`
+  (issue #322 — relay a composed HTTP request to a running serve via
+  `studio-request-relay` so the browser composer reaches the served port
+  same-origin; api / alb go through the capture proxy and land on the
+  timeline, an ecs `--host-port` serve hits the replica host URL directly),
+  the slice-C3 store
   endpoints `GET /api/history` / `GET /api/logs?q=` (full-text log
   search) / `GET /api/invocations/<id>/logs` (per-request log binding),
   and the slice-3 session config `GET /api/config` (read-only synth

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -36,6 +36,7 @@ import {
   type OptionValues,
 } from '../../local/studio-option-specs.js';
 import { tokenizeRawArgs } from '../../local/studio-option-catalog.js';
+import { relayServeRequest } from '../../local/studio-request-relay.js';
 import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
 import { isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
 import { discoverDockerfiles } from '../../local/image-override-engine.js';
@@ -43,6 +44,7 @@ import {
   createStudioServeManager,
   type StudioServeManager,
   type StudioStopRequest,
+  type StudioServeState,
 } from '../../local/studio-serve-manager.js';
 
 const STUDIO_TARGET_KINDS: readonly StudioTargetKind[] = [
@@ -126,6 +128,72 @@ export function coerceStopRequest(body: unknown): StudioStopRequest {
     throw new Error('Request body must include a non-empty "targetId" string.');
   }
   return { targetId };
+}
+
+/** A composed HTTP request to a running serve, as the studio UI posts it. */
+export interface StudioServeRequestPayload {
+  targetId: string;
+  method: string;
+  path?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+const SERVE_REQUEST_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']);
+
+/**
+ * Pick the HTTP base URL the request composer relays to for a running serve
+ * (issue #322): the first `http(s)://` endpoint (the api / alb capture-proxy
+ * URL — a `ws://` WebSocket-API endpoint is NOT relayable, so it is skipped),
+ * else the ecs `--host-port` host URL, else `undefined` (no reachable HTTP
+ * endpoint). Exported so the relay base-URL choice is unit-testable.
+ */
+export function resolveServeBaseUrl(state: StudioServeState): string | undefined {
+  const http = (state.endpoints || []).find((u) => /^https?:/.test(u));
+  return http ?? state.hostUrl;
+}
+
+/**
+ * Validate + narrow the untyped `POST /api/request` body (issue #322). Throws
+ * on a malformed body; the studio server surfaces a thrown handler error as a
+ * 500 (the same convention as {@link coerceRunRequest} / {@link
+ * coerceStopRequest}) so a bad UI / curl payload fails loudly rather than
+ * relaying a bogus request.
+ */
+export function coerceServeRequest(body: unknown): StudioServeRequestPayload {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('Request body must be a JSON object.');
+  }
+  const { targetId, method, path, headers, body: reqBody } = body as Record<string, unknown>;
+  if (typeof targetId !== 'string' || targetId.trim() === '') {
+    throw new Error('Request body must include a non-empty "targetId" string.');
+  }
+  if (typeof method !== 'string' || !SERVE_REQUEST_METHODS.has(method.toUpperCase())) {
+    throw new Error(
+      `Request body "method" must be one of: ${[...SERVE_REQUEST_METHODS].join(', ')}.`
+    );
+  }
+  const out: StudioServeRequestPayload = { targetId, method: method.toUpperCase() };
+  if (path !== undefined) {
+    if (typeof path !== 'string') throw new Error('Request body "path" must be a string.');
+    out.path = path;
+  }
+  if (headers !== undefined) {
+    if (typeof headers !== 'object' || headers === null || Array.isArray(headers)) {
+      throw new Error('Request body "headers" must be a JSON object of string values.');
+    }
+    const h: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) {
+      if (typeof v !== 'string') throw new Error(`Request header "${k}" must be a string.`);
+      if (k.trim() !== '') h[k] = v;
+    }
+    out.headers = h;
+  }
+  if (reqBody !== undefined) {
+    if (typeof reqBody !== 'string') throw new Error('Request body "body" must be a string.');
+    out.body = reqBody;
+  }
+  return out;
 }
 
 /** The session config served at `GET /api/config` (issue #301 slice 3). */
@@ -451,6 +519,31 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
       const req = coerceStopRequest(body);
       await serveManager.stop(req);
       return { stopped: req.targetId };
+    },
+    onServeRequest: async (body) => {
+      // Relay a composed HTTP request to a RUNNING serve, server-side (issue
+      // #322). For api / alb the base URL is the capture-proxy endpoint (so
+      // the request lands on the timeline); for an ecs serve published via
+      // --host-port it is the replica host URL (no proxy, not captured).
+      const req = coerceServeRequest(body);
+      const state = serveManager.list().find((s) => s.targetId === req.targetId);
+      if (!state || state.status !== 'running') {
+        throw new Error(`'${req.targetId}' is not a running serve target.`);
+      }
+      const baseUrl = resolveServeBaseUrl(state);
+      if (!baseUrl) {
+        throw new Error(
+          `'${req.targetId}' has no reachable HTTP endpoint (an ecs service needs --host-port).`
+        );
+      }
+      const result = await relayServeRequest({
+        baseUrl,
+        method: req.method,
+        ...(req.path !== undefined ? { path: req.path } : {}),
+        ...(req.headers !== undefined ? { headers: req.headers } : {}),
+        ...(req.body !== undefined ? { body: req.body } : {}),
+      });
+      return result;
     },
     getRunning: () => ({ running: serveManager.list() }),
     getConfig: () => sessionConfigSnapshot(),

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -728,7 +728,27 @@ export {
   type StudioRunRequest,
   type StudioRunResult,
 } from './local/studio-dispatch.js';
-export { coerceRunRequest, coerceStopRequest } from './cli/commands/local-studio.js';
+export {
+  coerceRunRequest,
+  coerceStopRequest,
+  coerceServeRequest,
+  resolveServeBaseUrl,
+  type StudioServeRequestPayload,
+} from './cli/commands/local-studio.js';
+
+/**
+ * `cdkl studio` request relay (issue #322). A host CLI embedding studio wires
+ * `relayServeRequest` as the `startStudioServer` `onServeRequest` handler so
+ * the browser's in-workspace HTTP composer can exercise a running serve via a
+ * same-origin `POST /api/request` (avoiding a cross-origin fetch to the served
+ * port). For api / alb the base URL is the capture-proxy endpoint (captured on
+ * the timeline); for ecs published via `--host-port` it is the replica host URL.
+ */
+export {
+  relayServeRequest,
+  type ServeRequestInput,
+  type ServeRequestResult,
+} from './local/studio-request-relay.js';
 
 /**
  * `cdkl studio` serve manager (issue #282, slice C1). A host CLI

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -84,6 +84,12 @@ export interface StudioServeEvent {
    * several (multiple APIs / WebSocket listeners), so this is a list.
    */
   endpoints?: string[];
+  /**
+   * Direct host URL for an `ecs` serve published via `--host-port` (issue
+   * #322) — no proxy in front (so a request to it is not captured). Absent for
+   * api / alb (use `endpoints`) and for an ecs serve without `--host-port`.
+   */
+  hostUrl?: string;
   /** Child process id, present from `starting` onward. */
   pid?: number;
   /** Status / error detail (e.g. the failure reason on `error`). */

--- a/src/local/studio-request-relay.ts
+++ b/src/local/studio-request-relay.ts
@@ -1,0 +1,100 @@
+/**
+ * Server-side HTTP relay for the `cdkl studio` in-workspace request composer
+ * (issue #322).
+ *
+ * The composer lives in the browser, but the served target runs on a DIFFERENT
+ * host port than the studio page — a direct browser fetch to it would be a
+ * cross-origin request the served app does not allow (CORS). So studio relays
+ * the composed request through its OWN server (same-origin from the browser):
+ * `POST /api/request` -> this module -> the serve's endpoint -> the response is
+ * returned to the browser.
+ *
+ * For an `api` / `alb` serve the endpoint is the studio capture-proxy URL, so a
+ * relayed request lands on the timeline exactly like an external curl. For an
+ * `ecs` serve published via `--host-port` the endpoint is the replica's host
+ * URL (no proxy in front, so it is NOT captured).
+ *
+ * The relay is host-agnostic — it just performs one bounded HTTP request — so
+ * it is exported from `cdk-local/internal` for a host CLI embedding studio.
+ */
+
+/** A composed request as the studio UI posts it (validated by the caller). */
+export interface ServeRequestInput {
+  /** Absolute base URL of the running serve (proxy URL or ecs host URL). */
+  baseUrl: string;
+  /** HTTP method (GET / POST / PUT / PATCH / DELETE / HEAD / OPTIONS). */
+  method: string;
+  /** Request path (joined onto `baseUrl`); defaults to `/`. */
+  path?: string;
+  /** Request headers. */
+  headers?: Record<string, string>;
+  /** Request body (string); omitted for body-less methods. */
+  body?: string;
+  /** Abort the request after this many ms (default 30s). */
+  timeoutMs?: number;
+  /** Cap the captured response body at this many chars (UTF-16 code units) (default 512 KiB). */
+  maxBodyChars?: number;
+}
+
+/** The relayed response handed back to the studio UI. */
+export interface ServeRequestResult {
+  status: number;
+  headers: Record<string, string>;
+  /** Response body, truncated to `maxBodyChars` code units (a marker is appended if cut). */
+  body: string;
+  /** True when the body was truncated at the cap. */
+  truncated: boolean;
+  /** Wall-clock duration in ms. */
+  durationMs: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BODY = 512 * 1024;
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/** Join a base URL and a path without doubling or dropping the `/`. */
+function joinUrl(baseUrl: string, path: string | undefined): string {
+  const base = baseUrl.replace(/\/+$/, '');
+  if (!path || path === '') return base + '/';
+  return base + (path.startsWith('/') ? path : '/' + path);
+}
+
+/**
+ * Perform one HTTP request against a running serve and return a bounded
+ * response. `fetchFn` is injectable for tests (defaults to the global `fetch`).
+ * Throws on a network / timeout error (the caller maps it to a 502/500); an
+ * HTTP error status is a NORMAL result (returned, not thrown).
+ */
+export async function relayServeRequest(
+  input: ServeRequestInput,
+  fetchFn: typeof fetch = fetch,
+  clock: () => number = Date.now
+): Promise<ServeRequestResult> {
+  const method = input.method.toUpperCase();
+  const url = joinUrl(input.baseUrl, input.path);
+  const maxBody = input.maxBodyChars ?? DEFAULT_MAX_BODY;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const startedAt = clock();
+  try {
+    const res = await fetchFn(url, {
+      method,
+      headers: input.headers ?? {},
+      // Only attach a body for methods that take one — fetch rejects a body on
+      // GET / HEAD.
+      ...(BODY_METHODS.has(method) && input.body !== undefined ? { body: input.body } : {}),
+      signal: controller.signal,
+      redirect: 'manual',
+    });
+    const headers: Record<string, string> = {};
+    res.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    const full = await res.text();
+    const truncated = full.length > maxBody;
+    const body = truncated ? full.slice(0, maxBody) + '\n…[truncated]' : full;
+    return { status: res.status, headers, body, truncated, durationMs: clock() - startedAt };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -48,6 +48,15 @@ export interface StudioServeState {
   status: 'starting' | 'running' | 'stopped' | 'error';
   /** Served endpoint URLs, populated once running. */
   endpoints: string[];
+  /**
+   * Direct host URL for an `ecs` serve published via `--host-port` (issue
+   * #322). Unlike `endpoints` (api / alb capture-proxy URLs), this is the
+   * replica's own host port with NO proxy in front — so the in-workspace
+   * request composer can target it, but a request to it is NOT captured on
+   * the timeline. Absent for api / alb (use `endpoints`) and for an ecs
+   * serve started without `--host-port`.
+   */
+  hostUrl?: string;
   /** Child process id. */
   pid?: number;
   /** Wall-clock epoch ms when the serve started. */
@@ -239,6 +248,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       startedAt: e.startedAt,
     };
     if (e.pid !== undefined) s.pid = e.pid;
+    if (e.hostUrl !== undefined) s.hostUrl = e.hostUrl;
     return s;
   }
 
@@ -251,6 +261,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       endpoints: [...e.endpoints],
     };
     if (e.pid !== undefined) ev.pid = e.pid;
+    if (e.hostUrl !== undefined) ev.hostUrl = e.hostUrl;
     if (message !== undefined) ev.message = message;
     config.bus.emit('serve', ev);
   }
@@ -319,6 +330,19 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       proxies: [],
     };
     if (child.pid !== undefined) entry.pid = child.pid;
+    // An ecs serve published via `--host-port` is reachable on the host (issue
+    // #322); surface its host URL so the in-workspace request composer can
+    // target it (the first mapping's host port). No proxy fronts it, so a
+    // request to it is not captured on the timeline.
+    if (req.kind === 'ecs') {
+      const hp = req.options?.['--host-port'];
+      if (Array.isArray(hp)) {
+        const first = hp.find(
+          (r) => r && typeof r === 'object' && typeof r.right === 'string' && r.right.trim() !== ''
+        );
+        if (first) entry.hostUrl = 'http://127.0.0.1:' + first.right.trim();
+      }
+    }
     entries.set(req.targetId, entry);
     emitServe(entry);
 

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -184,6 +184,13 @@ export interface StudioServerOptions {
    */
   onStop?: (body: unknown) => Promise<unknown>;
   /**
+   * Handler for `POST /api/request` (issue #322) — relay a composed HTTP
+   * request to a RUNNING serve target's endpoint, server-side, and return the
+   * response. The browser composer posts here (same-origin) so it never hits
+   * the served port cross-origin. When omitted, `/api/request` answers 501.
+   */
+  onServeRequest?: (body: unknown) => Promise<unknown>;
+  /**
    * Snapshot of the currently-running serve targets, served at
    * `GET /api/running`. When omitted, the endpoint returns an empty
    * list (the observe-only shell never runs anything).
@@ -332,6 +339,10 @@ function handleRequest(
   }
   if (req.method === 'POST' && path === '/api/run') {
     void handleDispatch(req, res, options.onRun);
+    return;
+  }
+  if (req.method === 'POST' && path === '/api/request') {
+    void handleDispatch(req, res, options.onServeRequest);
     return;
   }
   if (req.method === 'POST' && path === '/api/stop') {

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -142,6 +142,21 @@ const STUDIO_CSS = `
     border: 0; border-radius: 3px; cursor: pointer; font: inherit; font-weight: 700;
   }
   .composer button:hover { background: #339152; }
+  .req-composer .req-row { display: flex; gap: 6px; margin-bottom: 6px; }
+  .req-composer .req-method { background: #111; color: #ddd; border: 1px solid #333; border-radius: 3px;
+    padding: 4px 6px; font: 12px ui-monospace, Menlo, monospace; }
+  .req-composer .req-path { flex: 1; min-width: 0; background: #111; color: #ddd; border: 1px solid #333;
+    border-radius: 3px; padding: 4px 6px; font: 12px ui-monospace, Menlo, monospace; }
+  .req-composer textarea { width: 100%; box-sizing: border-box; min-height: 48px; resize: vertical;
+    background: #111; color: #ddd; border: 1px solid #333; border-radius: 3px; padding: 5px;
+    font: 12px/1.5 ui-monospace, Menlo, monospace; margin-bottom: 6px; }
+  .req-composer .req-body { min-height: 70px; }
+  .req-composer select:focus, .req-composer input:focus, .req-composer textarea:focus {
+    outline: none; border-color: #4ec97a; }
+  .req-composer .req-send { display: flex; align-items: center; gap: 10px; }
+  .req-composer .req-send button { margin-top: 0; padding: 4px 16px; }
+  .req-composer .req-status { margin-top: 8px; font: 12px ui-monospace, Menlo, monospace; }
+  .req-composer .req-result pre { background: #0e0e0e; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .err { color: #e0707a; margin-top: 6px; min-height: 18px; }
   .section { padding: 8px 12px; border-bottom: 1px solid #222; }
@@ -761,6 +776,12 @@ const STUDIO_SCRIPT = `
         const link = href(url);
         epSec.appendChild(link);
       }
+    } else if (running && isEcs && st.hostUrl) {
+      // An ecs service published via --host-port IS reachable on the host
+      // (issue #322); show its host URL. No proxy fronts it, so requests are
+      // not captured on the timeline.
+      epSec.appendChild(href(st.hostUrl));
+      epSec.appendChild(el('div', 'opt-hint', '(direct host port — not captured on the timeline)'));
     } else if (running && isEcs) {
       // A pure-compute ECS service has no host endpoint — it just runs the
       // replicas (reach them container-to-container via Cloud Map).
@@ -769,6 +790,18 @@ const STUDIO_SCRIPT = `
       epSec.appendChild(el('pre', null, starting ? '(starting…)' : '(not running)'));
     }
     ws.appendChild(epSec);
+
+    // In-workspace HTTP request composer for a running api / alb (or ecs with
+    // --host-port) serve (issue #322): compose a request and Send it; studio
+    // relays it server-side (same-origin) so it works cross-port and, for
+    // api / alb, lands on the timeline via the capture proxy.
+    const httpBase = running
+      ? (st.endpoints || []).find((u) => /^https?:/.test(u)) || (isEcs ? st.hostUrl : null)
+      : null;
+    if (httpBase) {
+      const captured = (st.endpoints || []).indexOf(httpBase) >= 0;
+      ws.appendChild(renderRequestComposer(id, httpBase, captured));
+    }
 
     // A served WebSocket API exposes a ws:// endpoint — attach a WebSocket
     // console so the browser can connect + exchange frames (issue #303).
@@ -782,6 +815,111 @@ const STUDIO_SCRIPT = `
     logSec.appendChild(el('h3', null, 'Logs'));
     logSec.appendChild(el('pre', null, logs.length ? logs.join('\\n') : '(none)'));
     ws.appendChild(logSec);
+  }
+
+  // In-workspace HTTP request composer for a running serve (issue #322):
+  // Method + Path + Headers + Body -> Send. The request is relayed by studio's
+  // OWN server (POST /api/request) so it reaches the served port without a
+  // cross-origin fetch; for an api / alb serve it flows through the capture
+  // proxy and lands on the timeline.
+  const REQ_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+
+  function parseHeaderLines(text) {
+    const out = {};
+    String(text || '').split('\\n').forEach(function (line) {
+      const i = line.indexOf(':');
+      if (i <= 0) return;
+      const k = line.slice(0, i).trim();
+      if (k) out[k] = line.slice(i + 1).trim();
+    });
+    return out;
+  }
+
+  function renderRequestComposer(id, baseUrl, captured) {
+    const sec = el('div', 'section req-composer');
+    sec.appendChild(el('h3', null, 'Request'));
+    const row = el('div', 'req-row');
+    const method = el('select', 'req-method');
+    REQ_METHODS.forEach(function (m) {
+      const o = el('option', null, m);
+      o.value = m;
+      method.appendChild(o);
+    });
+    row.appendChild(method);
+    const path = el('input', 'req-path');
+    path.value = '/';
+    path.placeholder = '/path?query';
+    row.appendChild(path);
+    sec.appendChild(row);
+
+    sec.appendChild(el('div', 'opt-label', 'Headers (one per line: Name: value)'));
+    const headers = el('textarea', 'req-headers');
+    headers.placeholder = 'Authorization: Bearer demo';
+    headers.spellcheck = false;
+    sec.appendChild(headers);
+
+    sec.appendChild(el('div', 'opt-label', 'Body'));
+    const bodyTa = el('textarea', 'req-body');
+    bodyTa.placeholder = '{ }';
+    bodyTa.spellcheck = false;
+    sec.appendChild(bodyTa);
+
+    const sendRow = el('div', 'req-send');
+    const btn = el('button', null, 'Send');
+    sendRow.appendChild(btn);
+    sendRow.appendChild(
+      el('span', 'opt-hint', captured
+        ? 'Relayed via studio to ' + baseUrl + ' — captured on the timeline.'
+        : 'Relayed direct to ' + baseUrl + ' (ecs host port) — not captured.')
+    );
+    sec.appendChild(sendRow);
+    const msg = el('div', 'err');
+    sec.appendChild(msg);
+    const result = el('div', 'req-result');
+    sec.appendChild(result);
+
+    btn.onclick = async function () {
+      msg.textContent = '';
+      btn.disabled = true;
+      btn.textContent = 'Sending…';
+      result.innerHTML = '';
+      try {
+        const payload = {
+          targetId: id,
+          method: method.value,
+          path: path.value || '/',
+          headers: parseHeaderLines(headers.value),
+        };
+        if (bodyTa.value !== '') payload.body = bodyTa.value;
+        const res = await fetch('/api/request', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          msg.textContent = 'Request failed: ' + (data.error || ('HTTP ' + res.status));
+          return;
+        }
+        const statusLine = el('div', 'req-status');
+        const cls = data.status >= 200 && data.status < 300 ? 'ok' : 'bad';
+        statusLine.appendChild(
+          el('span', cls, data.status + (data.durationMs != null ? ' · ' + data.durationMs + 'ms' : ''))
+        );
+        result.appendChild(statusLine);
+        const hdrs = Object.keys(data.headers || {})
+          .map(function (k) { return k + ': ' + data.headers[k]; })
+          .join('\\n');
+        if (hdrs) result.appendChild(el('pre', 'req-resp-headers', hdrs));
+        result.appendChild(el('pre', null, data.body != null ? data.body : ''));
+      } catch (err) {
+        msg.textContent = 'Request failed: ' + err;
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Send';
+      }
+    };
+    return sec;
   }
 
   // Build an <a> that opens an http(s) endpoint in a new tab; ws:// URLs
@@ -1219,7 +1357,7 @@ const STUDIO_SCRIPT = `
     if (ev.status === 'stopped' || ev.status === 'error') {
       serveState.set(ev.target, { status: ev.status, endpoints: [] });
     } else {
-      serveState.set(ev.target, { status: ev.status, endpoints: ev.endpoints || [] });
+      serveState.set(ev.target, { status: ev.status, endpoints: ev.endpoints || [], hostUrl: ev.hostUrl });
     }
     updateServeRow(ev.target);
   }

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -240,7 +240,12 @@ if ! grep -qF "function applyConfig" "${BODY_FILE}" || grep -qF 'id="sess-save"'
   echo "FAIL: GET / Session bar is not apply-on-change (Save button still present?)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX"
+# In-workspace HTTP request composer (issue #322).
+if ! grep -qF "function renderRequestComposer" "${BODY_FILE}" || ! grep -qF "fetch('/api/request'" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the in-workspace HTTP request composer"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.
@@ -855,6 +860,30 @@ fi
 echo "    OK: the ALB request was captured (GET / invocation, kind=alb) on the timeline"
 kill "${SSE_PID}" 2>/dev/null || true; SSE_PID=""
 
+# In-workspace HTTP request composer (issue #322): POST /api/request relays a
+# composed GET / through studio's OWN server to the running ALB serve's
+# capture-proxy endpoint, and returns the upstream response. A 200 with the
+# fixture's body proves the relay path (browser composer -> /api/request ->
+# studio server -> proxy -> ECS replica -> response) end-to-end.
+echo "==> POST /api/request relays a composed request to the running ALB serve"
+REQ_FILE=$(mktemp)
+HTTP_REQ=$(curl -s -o "${REQ_FILE}" -w '%{http_code}' --max-time 30 \
+  -X POST "${URL}/api/request" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ALB_TARGET}\",\"method\":\"GET\",\"path\":\"/\"}" || true)
+if [[ "${HTTP_REQ}" != "200" ]]; then
+  echo "FAIL: POST /api/request returned HTTP ${HTTP_REQ}"
+  cat "${REQ_FILE}"; rm -f "${REQ_FILE}"; exit 1
+fi
+# The relay result is { status, headers, body, ... }; the upstream GET / is a
+# 200 from the fixture replica.
+if ! grep -qF '"status":200' "${REQ_FILE}"; then
+  echo "FAIL: the relayed request did not report the upstream 200"
+  echo "----- relay result -----"; head -c 1000 "${REQ_FILE}"; echo; echo "------------------------"
+  rm -f "${REQ_FILE}"; exit 1
+fi
+rm -f "${REQ_FILE}"
+echo "    OK: composed request relayed through studio to the ALB serve (upstream 200)"
+
 echo "==> POST /api/stop tears the ALB serve down"
 curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
   -d "{\"targetId\":\"${ALB_TARGET}\"}" -o /dev/null || true
@@ -1058,4 +1087,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -6,11 +6,14 @@ import {
   applyConfigPatch,
   coerceRunRequest,
   coerceStopRequest,
+  coerceServeRequest,
+  resolveServeBaseUrl,
   createLocalStudioCommand,
   parseStudioPort,
   resolveBootAssemblyDir,
   type EditableSessionBindings,
 } from '../../../src/cli/commands/local-studio.js';
+import type { StudioServeState } from '../../../src/local/studio-serve-manager.js';
 
 describe('createLocalStudioCommand', () => {
   it('is named "studio"', () => {
@@ -282,5 +285,90 @@ describe('resolveBootAssemblyDir (issue #324)', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('coerceServeRequest (issue #322)', () => {
+  it('accepts a well-formed request and upper-cases the method', () => {
+    expect(
+      coerceServeRequest({
+        targetId: 'Stack/Api',
+        method: 'post',
+        path: '/items?q=1',
+        headers: { 'content-type': 'application/json', '': 'dropped' },
+        body: '{"a":1}',
+      })
+    ).toEqual({
+      targetId: 'Stack/Api',
+      method: 'POST',
+      path: '/items?q=1',
+      headers: { 'content-type': 'application/json' }, // blank-name header dropped
+      body: '{"a":1}',
+    });
+  });
+
+  it('accepts a minimal request (method + targetId only)', () => {
+    expect(coerceServeRequest({ targetId: 'T', method: 'GET' })).toEqual({
+      targetId: 'T',
+      method: 'GET',
+    });
+  });
+
+  it.each([{}, { targetId: '', method: 'GET' }])('rejects a missing targetId %p', (body) => {
+    expect(() => coerceServeRequest(body)).toThrow(/non-empty "targetId"/);
+  });
+
+  it.each([{ targetId: 'T' }, { targetId: 'T', method: 'FETCH' }])(
+    'rejects a missing/invalid method %p',
+    (body) => {
+      expect(() => coerceServeRequest(body)).toThrow(/"method" must be one of/);
+    }
+  );
+
+  it('rejects a non-string path / body / header value', () => {
+    expect(() => coerceServeRequest({ targetId: 'T', method: 'GET', path: 1 })).toThrow(
+      /"path" must be a string/
+    );
+    expect(() => coerceServeRequest({ targetId: 'T', method: 'GET', body: {} })).toThrow(
+      /"body" must be a string/
+    );
+    expect(() =>
+      coerceServeRequest({ targetId: 'T', method: 'GET', headers: { x: 1 } })
+    ).toThrow(/header "x" must be a string/);
+  });
+});
+
+describe('resolveServeBaseUrl (issue #322)', () => {
+  const state = (over: Partial<StudioServeState>): StudioServeState => ({
+    targetId: 'T',
+    kind: 'api',
+    status: 'running',
+    endpoints: [],
+    startedAt: 0,
+    ...over,
+  });
+
+  it('picks the first http(s) endpoint (the api / alb capture-proxy URL)', () => {
+    expect(resolveServeBaseUrl(state({ endpoints: ['http://127.0.0.1:51234'] }))).toBe(
+      'http://127.0.0.1:51234'
+    );
+  });
+
+  it('skips a ws:// endpoint and falls back to the host URL', () => {
+    // A WebSocket-API serve exposes a ws:// endpoint that is NOT relayable.
+    expect(
+      resolveServeBaseUrl(state({ endpoints: ['ws://127.0.0.1:51234'], hostUrl: 'http://h:8080' }))
+    ).toBe('http://h:8080');
+  });
+
+  it('uses the ecs host URL when there is no http endpoint', () => {
+    expect(resolveServeBaseUrl(state({ kind: 'ecs', hostUrl: 'http://127.0.0.1:8080' }))).toBe(
+      'http://127.0.0.1:8080'
+    );
+  });
+
+  it('returns undefined when there is no reachable http endpoint', () => {
+    expect(resolveServeBaseUrl(state({ endpoints: ['ws://x'] }))).toBeUndefined();
+    expect(resolveServeBaseUrl(state({}))).toBeUndefined();
   });
 });

--- a/tests/unit/local/studio-request-relay.test.ts
+++ b/tests/unit/local/studio-request-relay.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { relayServeRequest } from '../../../src/local/studio-request-relay.js';
+
+/** A minimal Response stand-in for the injected fetchFn. */
+function fakeResponse(
+  status: number,
+  body: string,
+  headers: Record<string, string> = {}
+): Response {
+  return {
+    status,
+    text: () => Promise.resolve(body),
+    headers: {
+      forEach: (cb: (value: string, key: string) => void) => {
+        for (const [k, v] of Object.entries(headers)) cb(v, k);
+      },
+    },
+  } as unknown as Response;
+}
+
+describe('relayServeRequest', () => {
+  it('joins base + path, forwards method / headers / body, returns the response', async () => {
+    const fetchFn = vi.fn(() => Promise.resolve(fakeResponse(201, 'created', { etag: 'abc' })));
+    const clock = (() => {
+      let t = 1000;
+      return () => (t += 5);
+    })();
+    const result = await relayServeRequest(
+      {
+        baseUrl: 'http://127.0.0.1:51234/',
+        method: 'post',
+        path: 'items',
+        headers: { 'content-type': 'application/json' },
+        body: '{"a":1}',
+      },
+      fetchFn as unknown as typeof fetch,
+      clock
+    );
+
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('http://127.0.0.1:51234/items'); // no doubled / dropped slash
+    expect(init.method).toBe('POST'); // upper-cased
+    expect(init.headers).toEqual({ 'content-type': 'application/json' });
+    expect(init.body).toBe('{"a":1}');
+    expect(result).toEqual({
+      status: 201,
+      headers: { etag: 'abc' },
+      body: 'created',
+      truncated: false,
+      durationMs: 5,
+    });
+  });
+
+  it('defaults the path to / and omits a body on GET', async () => {
+    const fetchFn = vi.fn(() => Promise.resolve(fakeResponse(200, 'ok')));
+    await relayServeRequest(
+      { baseUrl: 'http://127.0.0.1:9/', method: 'GET', body: 'ignored' },
+      fetchFn as unknown as typeof fetch
+    );
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('http://127.0.0.1:9/');
+    expect('body' in init).toBe(false); // GET never carries the body
+  });
+
+  it('returns an HTTP error status as a NORMAL result (does not throw)', async () => {
+    const fetchFn = vi.fn(() => Promise.resolve(fakeResponse(503, 'down')));
+    const result = await relayServeRequest(
+      { baseUrl: 'http://x/', method: 'GET' },
+      fetchFn as unknown as typeof fetch
+    );
+    expect(result.status).toBe(503);
+    expect(result.body).toBe('down');
+  });
+
+  it('truncates an over-cap response body and flags it', async () => {
+    const big = 'x'.repeat(100);
+    const fetchFn = vi.fn(() => Promise.resolve(fakeResponse(200, big)));
+    const result = await relayServeRequest(
+      { baseUrl: 'http://x/', method: 'GET', maxBodyChars: 10 },
+      fetchFn as unknown as typeof fetch
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.body).toBe('xxxxxxxxxx\n…[truncated]');
+  });
+
+  it('propagates a network / abort error from the fetch', async () => {
+    const fetchFn = vi.fn(() => Promise.reject(new Error('ECONNREFUSED')));
+    await expect(
+      relayServeRequest({ baseUrl: 'http://x/', method: 'GET' }, fetchFn as unknown as typeof fetch)
+    ).rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  it('aborts via the timeout signal when the upstream hangs', async () => {
+    // A fetchFn that never resolves until its abort signal fires — exercises
+    // the setTimeout -> controller.abort() -> reject path (and clearTimeout in
+    // the finally).
+    const fetchFn = vi.fn((_url: string, init: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    });
+    await expect(
+      relayServeRequest(
+        { baseUrl: 'http://x/', method: 'GET', timeoutMs: 1 },
+        fetchFn as unknown as typeof fetch
+      )
+    ).rejects.toThrow(/aborted/);
+  });
+});

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -323,6 +323,52 @@ describe('createStudioServeManager', () => {
     expect(argv[i + 1]).toBe('443=8443');
   });
 
+  it('surfaces a hostUrl for an ecs serve published via --host-port (issue #322)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'Stack/MyService',
+      kind: 'ecs',
+      options: { '--host-port': [{ left: '80', right: '8080' }] },
+    });
+    child.stdout.emit('data', 'Service(s) running:\n');
+    await p;
+
+    // ecs has no capture-proxy endpoint, but the published host port is the
+    // composer's reachable target.
+    expect(mgr.list()[0].endpoints).toEqual([]);
+    expect(mgr.list()[0].hostUrl).toBe('http://127.0.0.1:8080');
+  });
+
+  it('does not set hostUrl for an ecs serve without --host-port', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+    const p = mgr.start({ targetId: 'Stack/MyService', kind: 'ecs' });
+    child.stdout.emit('data', 'Service(s) running:\n');
+    await p;
+    expect(mgr.list()[0].hostUrl).toBeUndefined();
+  });
+
   it('threads imageOverride as an explicit --image-override <target>=<dockerfile>', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -133,6 +133,19 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('.group-body .target:nth-child(2n)');
   });
 
+  it('renders an in-workspace HTTP request composer for a running serve (issue #322)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The composer builder + its Send wiring to the same-origin relay.
+    expect(html).toContain('function renderRequestComposer');
+    expect(html).toContain("fetch('/api/request'");
+    // Gated on a running serve having an http base URL (proxy endpoint or the
+    // ecs --host-port host URL).
+    expect(html).toContain('renderRequestComposer(id, httpBase, captured)');
+    expect(html).toContain('isEcs ? st.hostUrl');
+    // The ecs host URL is shown in Endpoints with an "not captured" note.
+    expect(html).toContain('not captured on the timeline');
+  });
+
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {
     const html = renderStudioHtml('<script>alert(1)</script>', '"&<>');
     // The raw markup must never appear verbatim in the document.


### PR DESCRIPTION
## Summary

A served `api` / `alb` (or an `ecs` service published via `--host-port`) now
gets an in-workspace HTTP request composer — Method / Path / Headers / Body
-> Send — so you can exercise it from studio instead of copying the URL and
curling it elsewhere. Closes #322.

## Implementation

- **`POST /api/request` + `studio-request-relay`**: studio relays the
  composed request SERVER-SIDE (so the browser reaches the served port
  same-origin, no CORS). For api / alb the base URL is the capture-proxy
  endpoint, so the relayed request lands on the timeline like an external
  curl; for an ecs `--host-port` serve it hits the replica host URL directly
  (no proxy, not captured — noted in the UI).
- The serve manager surfaces `hostUrl` for an ecs serve started with
  `--host-port` and threads it through the serve event so the UI can target
  it. The Endpoints section shows the ecs host URL with a "not captured" note.
- `coerceServeRequest` validates the request at the `/api/request` boundary.

## cdkd parity

- New host-facing helpers exported from `src/internal.ts`:
  `relayServeRequest` (+ `ServeRequestInput` / `ServeRequestResult`) and
  `coerceServeRequest` (+ `StudioServeRequestPayload`) — a host embedding
  studio wires `relayServeRequest` as the `startStudioServer`
  `onServeRequest` handler. JSDoc names the host use case.
- Additive behavior: new `/api/request` endpoint + `onServeRequest` option +
  `hostUrl` on `StudioServeState` / the serve event. A host embedding studio
  via `createLocalStudioCommand` inherits it; no migration.

## Test plan

- `vp run check` + `vp run build` + `vp run test` (157 files, 2444 tests)
  pass; new `studio-request-relay` suite (url-join, method/headers/body
  forwarding, GET-drops-body, HTTP-error-is-a-result, truncation, network
  error), `coerceServeRequest` validation, the serve-manager `hostUrl`
  surfacing, and the studio-ui composer markup are covered
- `/run-integ local-studio` — green: `POST /api/request` relays a composed
  `GET /` through studio to the running ALB serve and returns the upstream
  200 (browser composer -> /api/request -> studio -> proxy -> ECS replica).
  0 Docker orphans
