### PR TITLE
feat(studio): exclude custom-resource / provider Lambdas from the target list by default

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -319,6 +319,14 @@ compute-locally category for Lambda + API Gateway).
   WebSocket `Upgrade` requests run through the same route + auth
   pipeline, then bridge the raw TCP socket to the picked ECS replica
   with `Upgrade` / `Sec-WebSocket-*` headers preserved),
+  studio-custom-resource-filter (issue #323 —
+  `isCustomResourceLambdaTarget` / `filterStudioCustomResources`:
+  recognizes CDK custom-resource / provider-framework Lambdas by their
+  construct path (provider-framework `framework-on*`, `LogRetention`,
+  `BucketNotificationsHandler`, `AwsCustomResource`, CDK bucket
+  deployment, the `AWS679...` singleton, etc.) so `cdkl studio` hides
+  them from the target list by default — `--include-custom-resources`
+  opts back in),
   studio-events (issue #282 — the typed in-process event bus every
   `cdkl studio` observation flows through (`invocation` / `log` /
   `serve` events); the studio HTTP server
@@ -326,7 +334,10 @@ compute-locally category for Lambda + API Gateway).
   (the localhost HTTP server behind `cdkl studio`: serves the embedded
   UI at `/`, the synthesized target list (+ the boot-discovered
   Dockerfiles + a `pinned` flag per ecs service — set by
-  `annotatePinnedEcsTargets` — for the image-override picker, issue #301)
+  `annotatePinnedEcsTargets` — for the image-override picker, issue #301;
+  CDK custom-resource / provider-framework Lambdas are excluded by
+  default via `filterStudioCustomResources`, issue #323 — pass
+  `cdkl studio --include-custom-resources` to surface them)
   at `/api/targets`, an SSE
   stream of the event bus at `/api/events`, `POST /api/run` (single-shot
   invoke / serve start), `POST /api/stop` (serve stop),

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -29,6 +29,7 @@ import {
   annotatePinnedEcsTargets,
   type RunningStudioServer,
 } from '../../local/studio-server.js';
+import { filterStudioCustomResources } from '../../local/studio-custom-resource-filter.js';
 import { createStudioDispatcher, type StudioRunRequest } from '../../local/studio-dispatch.js';
 import {
   buildPerRunArgs,
@@ -337,6 +338,11 @@ interface LocalStudioOptions {
    * hot-reload on CDK source changes. No effect on single-shot invokes.
    */
   watch?: boolean;
+  /**
+   * `--include-custom-resources`: show CDK custom-resource / provider-framework
+   * Lambdas in the target list (hidden by default).
+   */
+  includeCustomResources?: boolean;
 }
 
 /**
@@ -391,7 +397,23 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   const listing = listTargets(stacks);
   // `--stack <glob>` scopes the LISTED targets (display only — the whole app
   // was already synthesized above; the filter never touches synth).
-  const targetGroups = filterStudioTargetGroups(toStudioTargetGroups(listing), options.stack);
+  const stackFiltered = filterStudioTargetGroups(toStudioTargetGroups(listing), options.stack);
+  // Hide CDK custom-resource / provider-framework Lambdas by default so the UI
+  // shows only the user's own functions (issue #323); `--include-custom-resources`
+  // surfaces them. Applied AFTER the `--stack` display filter.
+  const lambdasBefore = stackFiltered.find((g) => g.kind === 'lambda')?.entries.length ?? 0;
+  const targetGroups = filterStudioCustomResources(stackFiltered, {
+    include: options.includeCustomResources === true,
+  });
+  if (!options.includeCustomResources) {
+    const lambdasAfter = targetGroups.find((g) => g.kind === 'lambda')?.entries.length ?? 0;
+    const hidden = lambdasBefore - lambdasAfter;
+    if (hidden > 0) {
+      logger.info(
+        `Hid ${hidden} CDK custom-resource / provider Lambda(s); pass --include-custom-resources to show them.`
+      );
+    }
+  }
   if (options.stack && options.stack.length > 0) {
     const shown = targetGroups.reduce((n, g) => n + g.entries.length, 0);
     if (shown === 0) {
@@ -691,6 +713,15 @@ export function addStudioSpecificOptions(cmd: Command): Command {
         'they re-synth + rolling-reload on CDK source changes. Toggleable from the Session bar. No ' +
         'effect on single-shot invokes (each invoke re-synths anyway); the target list is not ' +
         're-synthed (restart studio to pick up newly-added resources).'
+    )
+  );
+  cmd.addOption(
+    new Option(
+      '--include-custom-resources',
+      'Show CDK custom-resource / provider-framework Lambdas in the target list (provider ' +
+        'framework onEvent/onTimeout/isComplete handlers, log-retention, bucket-notifications, ' +
+        'AwsCustomResource, BucketDeployment, etc.). Hidden by default so the list shows only ' +
+        'your own functions.'
     )
   );
   return cmd;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -711,6 +711,11 @@ export {
   type StudioTarget,
   type StudioTargetGroup,
 } from './local/studio-server.js';
+export {
+  isCustomResourceLambdaTarget,
+  filterStudioCustomResources,
+  type FilterStudioCustomResourcesOptions,
+} from './local/studio-custom-resource-filter.js';
 export { renderStudioHtml } from './local/studio-ui.js';
 
 /**

--- a/src/local/studio-custom-resource-filter.ts
+++ b/src/local/studio-custom-resource-filter.ts
@@ -1,0 +1,93 @@
+import type { StudioTarget, StudioTargetGroup } from './studio-server.js';
+
+/**
+ * Substrings / patterns that identify a Lambda as part of CDK's custom-resource
+ * or provider-framework plumbing rather than the user's own application code.
+ *
+ * Matched case-INSENSITIVELY against a target's display path / qualified id.
+ * Each entry corresponds to a well-known CDK-generated construct:
+ *
+ * - `framework-onEvent` / `framework-onTimeout` / `framework-isComplete` —
+ *   the provider-framework (`@aws-cdk/custom-resources` `Provider`) handlers.
+ * - `/Provider/` — the `Provider` construct segment that wraps a custom
+ *   resource's lifecycle Lambdas.
+ * - `LogRetention` — the singleton log-retention custom resource CDK injects
+ *   when a construct sets `logRetention`.
+ * - `BucketNotificationsHandler` — the S3 bucket-notifications custom resource.
+ * - `AwsCustomResource` — the `aws-custom-resource` SDK-call construct.
+ * - `AWS679f53fac002430cb0da5b7982bd2287` — the singleton logical id CDK emits
+ *   for the `AwsCustomResource` provider Lambda.
+ * - `CustomResourceProvider` — the low-level `CustomResourceProvider` framework
+ *   Lambda (used by many L2 constructs).
+ * - `cdkbucketdeployment` — the `BucketDeployment` asset-copy Lambda (the
+ *   logical id is `CustomCDKBucketDeployment<hash>`, the construct path node is
+ *   `Custom::CDKBucketDeployment<hash>` — the shared substring covers both).
+ * - `CDKMetadata` — the CDK metadata resource (not a Lambda, but cheap to
+ *   exclude defensively if it ever surfaces as one).
+ */
+const CUSTOM_RESOURCE_PATTERNS: readonly string[] = [
+  'framework-onevent',
+  'framework-ontimeout',
+  'framework-iscomplete',
+  '/provider/',
+  'logretention',
+  'bucketnotificationshandler',
+  'awscustomresource',
+  'aws679f53fac002430cb0da5b7982bd2287',
+  'customresourceprovider',
+  'cdkbucketdeployment',
+  'cdkmetadata',
+];
+
+/**
+ * Classify a studio Lambda target as a CDK custom-resource / provider-framework
+ * Lambda (vs the user's own application code). Matches the target's display
+ * path / qualified id against {@link CUSTOM_RESOURCE_PATTERNS}
+ * case-insensitively.
+ *
+ * Host-side use case: a host CLI building its own studio (or `cdkl list`-style
+ * UI) reuses this to hide CDK-generated plumbing Lambdas — provider-framework
+ * onEvent/onTimeout/isComplete handlers, log-retention, bucket-notifications,
+ * AwsCustomResource, BucketDeployment — from the default target list, so the
+ * user sees only their own functions. Pure / side-effect-free.
+ */
+export function isCustomResourceLambdaTarget(entry: StudioTarget): boolean {
+  const haystack = `${entry.id} ${entry.qualifiedId}`.toLowerCase();
+  return CUSTOM_RESOURCE_PATTERNS.some((p) => haystack.includes(p));
+}
+
+/** Options for {@link filterStudioCustomResources}. */
+export interface FilterStudioCustomResourcesOptions {
+  /**
+   * When true, custom-resource / provider Lambdas are KEPT (the opt-in
+   * `--include-custom-resources` behaviour). When false / omitted they are
+   * dropped from the `lambda` group.
+   */
+  include?: boolean;
+}
+
+/**
+ * Drop CDK custom-resource / provider-framework Lambdas from the `lambda` group
+ * of `groups` (issue #323). Only the `lambda` group is touched — every other
+ * group (api / ecs / alb / agentcore) is returned unchanged — and within it
+ * only entries {@link isCustomResourceLambdaTarget} matches are removed.
+ *
+ * Pass `{ include: true }` to keep them (the `--include-custom-resources`
+ * opt-in), in which case `groups` is returned unchanged.
+ *
+ * Host-side use case: `cdkl studio` (and any host CLI embedding the studio
+ * building blocks) applies this after the `--stack` display filter so the
+ * default target list shows only the user's own Lambdas, not CDK's generated
+ * plumbing. Returns a new array (the matching group is rebuilt); inputs are not
+ * mutated.
+ */
+export function filterStudioCustomResources(
+  groups: StudioTargetGroup[],
+  opts: FilterStudioCustomResourcesOptions = {}
+): StudioTargetGroup[] {
+  if (opts.include) return groups;
+  return groups.map((g) => {
+    if (g.kind !== 'lambda') return g;
+    return { ...g, entries: g.entries.filter((e) => !isCustomResourceLambdaTarget(e)) };
+  });
+}

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -53,6 +53,18 @@ export class LocalStudioStack extends cdk.Stack {
       ),
     });
 
+    // A custom-resource / provider-framework Lambda (issue #323). Its CDK path
+    // contains `Provider/framework-onEvent`, which studio's custom-resource
+    // filter recognizes as infra plumbing and EXCLUDES from the target list by
+    // default (shown only under `--include-custom-resources`). Inline code, no
+    // bundling — synthesizes without AWS / assets like the other fixtures.
+    const crProvider = new Construct(this, 'MyCustomResourceProvider');
+    new lambda.Function(crProvider, 'framework-onEvent', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline('exports.handler = async () => ({});'),
+    });
+
     // HTTP API v2 + a single Lambda-backed route.
     const httpApi = new apigwv2.CfnApi(this, 'MyHttpApi', {
       name: 'cdkl-studio-fixture-http-api',

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -114,6 +114,33 @@ rm -f "${FLT_LOG}"
 echo "    OK: --stack scoped the list to the matching target only"
 
 # ---------------------------------------------------------------------------
+# 1b2. Custom-resource opt-in (issue #323): `cdkl studio --include-custom-resources`
+#      shows the provider-framework Lambda that is hidden by default. Boot a
+#      short-lived studio WITH the flag and assert /api/targets now includes it.
+# ---------------------------------------------------------------------------
+echo "==> --include-custom-resources surfaces the hidden provider Lambda"
+INC_LOG=$(mktemp)
+${CDKL} studio --no-open --studio-port "${PORT}" --include-custom-resources >"${INC_LOG}" 2>&1 &
+INC_PID=$!
+INC_URL=""
+for _ in $(seq 1 60); do
+  if ! kill -0 "${INC_PID}" 2>/dev/null; then
+    echo "FAIL: --include-custom-resources studio exited during boot"; cat "${INC_LOG}"; rm -f "${INC_LOG}"; exit 1
+  fi
+  INC_URL=$(grep -oE "http://${HOST}:[0-9]+" "${INC_LOG}" | head -1 || true)
+  if [[ -n "${INC_URL}" ]] && curl -fsS "${INC_URL}/api/targets" -o /dev/null 2>/dev/null; then break; fi
+  sleep 0.5
+done
+curl -fsS "${INC_URL}/api/targets" -o "${BODY_FILE}"
+if ! grep -qF 'framework-onEvent' "${BODY_FILE}"; then
+  echo "FAIL: --include-custom-resources did NOT surface the provider Lambda"; cat "${BODY_FILE}"
+  kill "${INC_PID}" 2>/dev/null || true; rm -f "${INC_LOG}"; exit 1
+fi
+kill "${INC_PID}" 2>/dev/null || true; wait "${INC_PID}" 2>/dev/null || true
+rm -f "${INC_LOG}"
+echo "    OK: --include-custom-resources surfaced the provider Lambda"
+
+# ---------------------------------------------------------------------------
 # 1c. Watch mode (issue #301): `cdkl studio --watch` spawns serves started from
 #     the UI with `--watch`, so they hot-reload on source changes. Boot a
 #     short-lived studio WITH --watch, assert the boot log + GET /api/config
@@ -267,6 +294,15 @@ do
   fi
   echo "    OK: ${needle}"
 done
+
+# Custom-resource exclusion (issue #323): the fixture's provider-framework
+# Lambda (path `.../MyCustomResourceProvider/framework-onEvent`) is infra
+# plumbing, so the DEFAULT target list must NOT include it.
+if grep -qF 'framework-onEvent' "${BODY_FILE}"; then
+  echo "FAIL: /api/targets included the custom-resource provider Lambda by default"
+  cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: custom-resource provider Lambda excluded from the default target list"
 
 # ---------------------------------------------------------------------------
 # 5. GET /api/events opens a Server-Sent-Events stream.
@@ -1087,4 +1123,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + custom-resource-exclusion + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -28,6 +28,15 @@ describe('createLocalStudioCommand', () => {
     const portOpt = cmd.options.find((o) => o.long === '--studio-port');
     expect(portOpt?.defaultValue).toBe('9999');
   });
+
+  it('exposes --include-custom-resources (boolean, default false)', () => {
+    const cmd = createLocalStudioCommand();
+    const longs = cmd.options.map((o) => o.long);
+    expect(longs).toContain('--include-custom-resources');
+    const opt = cmd.options.find((o) => o.long === '--include-custom-resources');
+    // A bare boolean flag has no default value set => undefined (falsy).
+    expect(opt?.defaultValue).toBeUndefined();
+  });
 });
 
 describe('parseStudioPort', () => {

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -138,6 +138,7 @@ describe('studio option surface contract (addStudioSpecificOptions)', () => {
     expect(flags).toEqual([
       '--assume-role',
       '--from-cfn-stack',
+      '--include-custom-resources',
       '--no-open',
       '--stack',
       '--studio-port',

--- a/tests/unit/local/studio-custom-resource-filter.test.ts
+++ b/tests/unit/local/studio-custom-resource-filter.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isCustomResourceLambdaTarget,
+  filterStudioCustomResources,
+} from '../../../src/local/studio-custom-resource-filter.js';
+import type { StudioTarget, StudioTargetGroup } from '../../../src/local/studio-server.js';
+
+const lambda = (id: string, qualifiedId = `Stack:${id.replace(/\//g, '')}`): StudioTarget => ({
+  id,
+  qualifiedId,
+});
+
+describe('isCustomResourceLambdaTarget', () => {
+  // Each well-known CDK-generated construct must be classified as a
+  // custom-resource Lambda (matched against id / qualifiedId, case-insensitive).
+  it.each([
+    'MyStack/Provider/framework-onEvent',
+    'MyStack/Provider/framework-onTimeout',
+    'MyStack/Provider/framework-isComplete',
+    'MyStack/MyResource/Provider/Handler',
+    'MyStack/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a',
+    'MyStack/BucketNotificationsHandler050a0587b7544547bf325f094a3db834',
+    'MyStack/AwsCustomResource',
+    'MyStack/CustomResourceProvider',
+    'MyStack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C',
+  ])('matches %s', (id) => {
+    expect(isCustomResourceLambdaTarget(lambda(id))).toBe(true);
+  });
+
+  it('matches the singleton AwsCustomResource provider logical id via qualifiedId', () => {
+    expect(
+      isCustomResourceLambdaTarget({
+        id: 'MyStack/AWS679f53fac002430cb0da5b7982bd2287',
+        qualifiedId: 'MyStack:AWS679f53fac002430cb0da5b7982bd2287',
+      })
+    ).toBe(true);
+  });
+
+  it('matches CDKMetadata', () => {
+    expect(isCustomResourceLambdaTarget(lambda('MyStack/CDKMetadata'))).toBe(true);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(isCustomResourceLambdaTarget(lambda('MyStack/Provider/FRAMEWORK-ONEVENT'))).toBe(true);
+  });
+
+  it('does NOT match a normal app Lambda', () => {
+    expect(isCustomResourceLambdaTarget(lambda('MyStack/EchoHandler'))).toBe(false);
+  });
+
+  it('does NOT match another normal app Lambda whose name resembles nothing', () => {
+    expect(isCustomResourceLambdaTarget(lambda('OrdersStack/CreateOrderFn'))).toBe(false);
+  });
+});
+
+const groups = (): StudioTargetGroup[] => [
+  {
+    kind: 'lambda',
+    title: 'Lambda Functions',
+    entries: [
+      lambda('MyStack/EchoHandler'),
+      lambda('MyStack/Provider/framework-onEvent'),
+      lambda('MyStack/LogRetentionaae0aa3c'),
+      lambda('MyStack/CreateOrderFn'),
+    ],
+  },
+  {
+    kind: 'api',
+    title: 'APIs',
+    entries: [lambda('MyStack/Api')],
+  },
+  {
+    kind: 'ecs',
+    title: 'ECS Services / Tasks',
+    entries: [lambda('MyStack/Service')],
+  },
+  {
+    kind: 'alb',
+    title: 'Load Balancers',
+    entries: [lambda('MyStack/Alb')],
+  },
+  {
+    kind: 'agentcore',
+    title: 'AgentCore Runtimes',
+    entries: [lambda('MyStack/Agent')],
+  },
+];
+
+describe('filterStudioCustomResources', () => {
+  it('drops custom-resource / provider Lambdas from the lambda group by default', () => {
+    const result = filterStudioCustomResources(groups());
+    const lambdaGroup = result.find((g) => g.kind === 'lambda');
+    expect(lambdaGroup?.entries.map((e) => e.id)).toEqual([
+      'MyStack/EchoHandler',
+      'MyStack/CreateOrderFn',
+    ]);
+  });
+
+  it('keeps custom-resource Lambdas when include:true', () => {
+    const result = filterStudioCustomResources(groups(), { include: true });
+    const lambdaGroup = result.find((g) => g.kind === 'lambda');
+    expect(lambdaGroup?.entries).toHaveLength(4);
+  });
+
+  it('returns the same array reference when include:true (no-op)', () => {
+    const input = groups();
+    expect(filterStudioCustomResources(input, { include: true })).toBe(input);
+  });
+
+  it('leaves non-lambda groups (api / ecs / alb / agentcore) untouched', () => {
+    const result = filterStudioCustomResources(groups());
+    for (const kind of ['api', 'ecs', 'alb', 'agentcore'] as const) {
+      const before = groups().find((g) => g.kind === kind)?.entries;
+      const after = result.find((g) => g.kind === kind)?.entries;
+      expect(after).toEqual(before);
+    }
+  });
+
+  it('does not mutate the input groups', () => {
+    const input = groups();
+    filterStudioCustomResources(input);
+    expect(input.find((g) => g.kind === 'lambda')?.entries).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl studio` now hides CDK custom-resource / provider-framework Lambdas
from the target list by default, so the UI shows only the user's own
functions. A new `--include-custom-resources` flag opts back in.

CDK injects plumbing Lambdas for many constructs (provider-framework
`framework-onEvent` / `onTimeout` / `isComplete` handlers, log-retention,
S3 bucket-notifications, `AwsCustomResource`, `BucketDeployment`, the
`AWS679...` singleton, etc.). These are infrastructure, not application
code the user wants to invoke locally, and they crowded out the user's
own functions in the studio Lambda list.

## What changed

- New `src/local/studio-custom-resource-filter.ts`:
  `isCustomResourceLambdaTarget` classifies a studio Lambda target by its
  construct path / qualified id against a list of well-known CDK-generated
  patterns; `filterStudioCustomResources` drops the matches from the
  `lambda` group only (every other group is returned unchanged). Pure /
  side-effect-free; exported from `src/internal.ts` for host CLIs.
- New `--include-custom-resources` flag in `addStudioSpecificOptions`
  (the host-inheritable helper). Applied AFTER the `--stack` display
  filter; logs a one-line `Hid N CDK custom-resource / provider Lambda(s)`
  note when something is hidden.

## Behavior change

`cdkl studio` (and any host CLI embedding the studio building blocks) now
shows fewer Lambdas by default — custom-resource / provider plumbing is
excluded unless `--include-custom-resources` is passed. This is a
display-only change; synth and every other target group are untouched.

## Test plan

- 17 unit tests for `isCustomResourceLambdaTarget` /
  `filterStudioCustomResources` (each pattern + the include passthrough +
  non-lambda groups untouched).
- Unit test for the `--include-custom-resources` flag wiring.
- Integration (`tests/integration/local-studio`): the fixture now declares
  a provider-framework Lambda
  (`MyCustomResourceProvider/framework-onEvent`); `verify.sh` asserts
  `GET /api/targets` excludes it by default and that booting with
  `--include-custom-resources` surfaces it. Full local-studio integ green,
  0 Docker orphans.

Closes #323
