### PR TITLE
feat(studio): clarify the curl-able serve port (proxy vs child internal)

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -776,6 +776,17 @@ const STUDIO_SCRIPT = `
         const link = href(url);
         epSec.appendChild(link);
       }
+      // These are the studio capture-proxy URLs — the request target. curl
+      // THESE and the request lands on the timeline. The serve child in the
+      // Logs panel below advertises a DIFFERENT internal port (issue #325);
+      // that port works too but bypasses capture, so prefer the URLs here.
+      epSec.appendChild(
+        el(
+          'div',
+          'opt-hint',
+          'curl these — captured on the timeline. (The port in the Logs below is the serve child internal port; it bypasses capture.)'
+        )
+      );
     } else if (running && isEcs && st.hostUrl) {
       // An ecs service published via --host-port IS reachable on the host
       // (issue #322); show its host URL. No proxy fronts it, so requests are
@@ -813,6 +824,19 @@ const STUDIO_SCRIPT = `
     const logs = logsById.get(id) || [];
     const logSec = el('div', 'section');
     logSec.appendChild(el('h3', null, 'Logs'));
+    // A proxy-fronted serve (api / alb) streams its child start-* logs here,
+    // which advertise the child internal 127.0.0.1 port — a DIFFERENT port
+    // than the capture-proxy URL in Endpoints above. Flag it so the child
+    // hint is not mistaken for the address to curl (issue #325).
+    if (running && st.endpoints.length) {
+      logSec.appendChild(
+        el(
+          'div',
+          'opt-hint',
+          'Note: any 127.0.0.1 port below is the serve child internal port. To reach this serve on the timeline, use the Endpoints above.'
+        )
+      );
+    }
     logSec.appendChild(el('pre', null, logs.length ? logs.join('\\n') : '(none)'));
     ws.appendChild(logSec);
   }

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -272,7 +272,14 @@ if ! grep -qF "function renderRequestComposer" "${BODY_FILE}" || ! grep -qF "fet
   echo "FAIL: GET / did not include the in-workspace HTTP request composer"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer"
+# Proxy-vs-child port clarity (issue #325): the Endpoints hint names the proxy
+# URLs as the capture target and the Logs note flags the child internal port.
+if ! grep -qF "the serve child internal port" "${BODY_FILE}" \
+  || ! grep -qF "any 127.0.0.1 port below is the serve child internal port" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the proxy-vs-child port clarity hints (issue #325)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -146,6 +146,18 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('not captured on the timeline');
   });
 
+  it('clarifies the curl-able proxy port vs the child internal port (issue #325)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The Endpoints hint names the proxy URLs as the request target and warns
+    // that the Logs port is the child internal one.
+    expect(html).toContain('curl these — captured on the timeline.');
+    expect(html).toContain('the serve child internal port');
+    // The Logs panel carries a note that its 127.0.0.1 port is internal and
+    // the Endpoints above are the address to use.
+    expect(html).toContain('any 127.0.0.1 port below is the serve child internal port');
+    expect(html).toContain('use the Endpoints above');
+  });
+
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {
     const html = renderStudioHtml('<script>alert(1)</script>', '"&<>');
     // The raw markup must never appear verbatim in the document.


### PR DESCRIPTION
## Summary

`cdkl studio` fronts each api / alb serve with a capture proxy listening
on a DIFFERENT host port than the `start-api` / `start-alb` child behind
it. The child's streamed logs advertise its own internal `127.0.0.1`
port, which the user can mistake for the address to curl — but curling
it bypasses the proxy, so the request never lands on the timeline.

This is a display-only clarity fix (the proxy is intentional — it
captures external curls on the timeline).

## What changed (studio-ui)

- The **Endpoints** section of a running api / alb serve now adds a hint
  under the proxy URLs: `curl these — captured on the timeline. (The
  port in the Logs below is the serve child internal port; it bypasses
  capture.)`
- The **Logs** panel of a proxy-fronted serve carries a note: any
  `127.0.0.1` port in the streamed child logs is the serve child
  internal port; use the Endpoints above to reach the serve on the
  timeline.

No change to the proxy, the served ports, or any other behavior.

## Test plan

- Unit (`tests/unit/local/studio-ui.test.ts`): asserts the rendered UI
  carries both the Endpoints hint and the Logs note.
- Integration (`tests/integration/local-studio`): the existing `GET /`
  UI assertion now also greps the served HTML for the two port-clarity
  strings. Full local-studio integ green, 0 Docker orphans.

Closes #325
