### PR TITLE
feat(invoke): add --response-file so studio reads the raw response (not stdout)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -394,10 +394,14 @@ compute-locally category for Lambda + API Gateway).
   `agentcore` (`INVOKE_VERBS`) — studio being a control plane over the
   CLI — streaming its stdout/stderr to the event bus and returning the
   response. `extractResponse` recovers the response per kind: a Lambda's
-  is the LAST JSON-parseable stdout line (container logs interleave on
-  stdout); an AgentCore agent streams its WHOLE output to stdout (HTTP
-  SSE / MCP-A2A JSON-RPC / `--ws` frames), so the entire stdout IS the
-  response. The child is spawned with `CDKL_LOG_LEVEL=warn` so
+  is read from the `--response-file` the dispatcher passes to `cdkl
+  invoke` (issue #291 — `cdkl invoke` writes ONLY the raw RIE response
+  payload there, so a handler's own trailing `console.log(JSON)` can
+  no longer be mistaken for the response), falling back to the LAST
+  JSON-parseable stdout line when the file is absent (older `cdkl
+  invoke` / a crash before the write); an AgentCore agent streams
+  its WHOLE output to stdout (HTTP SSE / MCP-A2A JSON-RPC / `--ws`
+  frames), so the entire stdout IS the response. The child is spawned with `CDKL_LOG_LEVEL=warn` so
   cdk-local's OWN synth / orchestration progress (toolkit "Successfully
   synthesized to ...", asset-bundling, info-level status — honored by
   `resolveConfiguredLogLevel` in `utils/logger.ts` + `CdklIoHost`) is

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -134,6 +134,14 @@ interface LocalInvokeOptions {
    * when `--from-cfn-stack` is set.
    */
   stackRegion?: string;
+  /**
+   * Issue #291: machine-readable response channel. When set, the raw RIE
+   * response payload is written to this file (in addition to stdout) so a
+   * programmatic caller (e.g. `cdkl studio`'s dispatcher) recovers the
+   * response from the file instead of parsing it out of stdout, where it
+   * interleaves with synth progress + streamed container logs.
+   */
+  responseFile?: string;
   /** Host-injected extra state-source flag fields. */
   [key: string]: unknown;
 }
@@ -595,6 +603,13 @@ async function localInvokeCommand(
     // Settle a few hundred ms so logs fully flush before we tear down.
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
     process.stdout.write(`${result.raw}\n`);
+    // Issue #291: also write the raw response to the machine-readable channel
+    // so a programmatic caller reads it from the file instead of guessing the
+    // last JSON-parseable stdout line (where a handler's own trailing
+    // `console.log(JSON)` could be mistaken for the response).
+    if (options.responseFile) {
+      writeFileSync(options.responseFile, result.raw);
+    }
   } finally {
     if (sigintHandler) process.off('SIGINT', sigintHandler);
     await cleanup();
@@ -1257,6 +1272,14 @@ export function addInvokeSpecificOptions(cmd: Command): Command {
       new Option(
         '--stack-region <region>',
         'Region of the state record to read. Used with --from-cfn-stack as the CFn client region.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--response-file <path>',
+        'Also write the raw Lambda response payload to this file. Lets a programmatic ' +
+          'caller recover the response without parsing it out of stdout (where it interleaves ' +
+          'with synth progress + streamed container logs). stdout output is unchanged.'
       )
     );
 }

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -1,5 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { StudioEventBus, type StudioTargetKind } from './studio-events.js';
@@ -166,6 +166,13 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
       const eventFile = join(dir, 'event.json');
       writeFileSync(eventFile, JSON.stringify(req.event ?? {}));
 
+      // Issue #291: `cdkl invoke` writes the raw Lambda response to this file,
+      // so we recover it authoritatively instead of guessing the last
+      // JSON-parseable stdout line (a handler's own trailing `console.log(JSON)`
+      // could otherwise be mistaken for the response). Only `cdkl invoke`
+      // (lambda) accepts `--response-file`; agentcore streams its whole stdout.
+      const responseFilePath = req.kind === 'lambda' ? join(dir, 'response.json') : undefined;
+
       const args = [
         verb,
         req.targetId,
@@ -176,6 +183,7 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
         // reads `--app <assemblyDir>` and skips its own synth.
         ...buildSharedChildArgs(config, { preferAssembly: true }),
         ...buildPerRunArgs(req.kind, req.options),
+        ...(responseFilePath ? ['--response-file', responseFilePath] : []),
       ];
 
       // The `--env-vars` per-run option takes a FILE — materialize the UI's
@@ -207,7 +215,26 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
       const ok = code === 0;
       const failure = stderr.trim() || `cdkl ${verb} exited ${code}`;
 
-      const { response, raw, stdoutLogLines } = extractResponse(req.kind, stdout, ok, failure);
+      // Issue #291: read the machine-readable response file the child wrote.
+      // Absent / empty (older `cdkl invoke`, or a crash before the write) falls
+      // back to the last-JSON-line stdout heuristic inside extractResponse.
+      let fileResponse: string | undefined;
+      if (responseFilePath) {
+        try {
+          const content = readFileSync(responseFilePath, 'utf8');
+          if (content.length > 0) fileResponse = content;
+        } catch {
+          // No file — fall back to stdout parsing.
+        }
+      }
+
+      const { response, raw, stdoutLogLines } = extractResponse(
+        req.kind,
+        stdout,
+        ok,
+        failure,
+        fileResponse
+      );
 
       // Surface the stdout lines that are NOT the response as log events
       // (Lambda container logs; AgentCore has none — its whole stdout is the
@@ -364,7 +391,8 @@ function extractResponse(
   kind: StudioTargetKind,
   stdout: string,
   ok: boolean,
-  failure: string
+  failure: string,
+  fileResponse?: string
 ): ExtractedResponse {
   if (kind === 'agentcore') {
     const text = stdout.trim();
@@ -381,6 +409,18 @@ function extractResponse(
 
   if (!ok) {
     return { response: failure, raw: '', stdoutLogLines: stdoutLines };
+  }
+
+  // Issue #291: when `cdkl invoke` wrote the machine-readable response file,
+  // use it as the authoritative response — no stdout guessing. The response is
+  // ALSO echoed on stdout, so drop the line equal to it from the log lines (so
+  // it is not shown twice). This eliminates the last-JSON-line heuristic's one
+  // failure mode: a handler whose own trailing `console.log` is a JSON value.
+  if (fileResponse !== undefined) {
+    const trimmed = fileResponse.trim();
+    const parsed = tryParseJson(trimmed);
+    const stdoutLogLines = stdoutLines.filter((l) => l.trim() !== trimmed);
+    return { response: parsed.ok ? parsed.value : fileResponse, raw: fileResponse, stdoutLogLines };
   }
 
   let responseIdx = -1;

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -47,9 +47,14 @@ export class LocalStudioStack extends cdk.Stack {
       handler: 'index.handler',
       // Echoes the STUDIO_ENV_PROBE env var into the body so the per-target
       // `--env-vars` option (issue #301 slice 2) is observable end-to-end;
-      // defaults to 'ok' so the other assertions are unaffected.
+      // defaults to 'ok' so the other assertions are unaffected. Also emits a
+      // trailing `console.log(JSON)` line — the exact shape that would fool
+      // studio's last-JSON-line stdout heuristic — so the invoke assertion
+      // proves studio recovers the REAL return value via --response-file and
+      // not this log line (issue #291).
       code: lambda.Code.fromInline(
-        "exports.handler = async () => ({ statusCode: 200, body: process.env.STUDIO_ENV_PROBE || 'ok' });"
+        "exports.handler = async () => { console.log(JSON.stringify({ cdklResponseTrap: 'not-the-response' })); " +
+          "return { statusCode: 200, body: process.env.STUDIO_ENV_PROBE || 'ok' }; };"
       ),
     });
 

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -358,6 +358,19 @@ for needle in '"ok":true' '"status":200' '"statusCode":200'; do
   fi
   echo "    OK: run response has ${needle}"
 done
+# Issue #291: the handler also console.logs `{"cdklResponseTrap":...}` AFTER
+# the response — the exact shape the old last-JSON-line heuristic would
+# mis-pick. studio now reads the response from the child's --response-file, so
+# the recovered response must be the real return value and must NOT contain the
+# trap marker. (The trap line still appears in the LOGS stream, just not as the
+# response.)
+RESPONSE_FIELD=$(grep -oE '"response":\{[^}]*\}' "${RUN_FILE}" | head -1 || true)
+if echo "${RESPONSE_FIELD}" | grep -qF 'cdklResponseTrap'; then
+  echo "FAIL: /api/run picked the trailing console.log(JSON) as the response (issue #291 regression)"
+  echo "----- run response -----"; cat "${RUN_FILE}"; echo "------------------------"
+  exit 1
+fi
+echo "    OK: response recovered via --response-file, not the trailing console.log(JSON) trap"
 # Capture the Lambda invocation id for the slice-C3 per-invocation log
 # binding assertion below.
 LAMBDA_INV_ID=$(grep -oE '"invocationId":"[^"]+"' "${RUN_FILE}" | head -1 | sed 's/.*"invocationId":"//;s/"//')

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -173,6 +173,7 @@ describe('invoke option surface contract (addInvokeSpecificOptions)', () => {
       '--layer-role-arn',
       '--no-build',
       '--no-pull',
+      '--response-file',
       '--stack-region',
     ]);
   });

--- a/tests/unit/local/studio-dispatch.test.ts
+++ b/tests/unit/local/studio-dispatch.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { readdirSync } from 'node:fs';
+import { readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, vi } from 'vite-plus/test';
 import { StudioEventBus, type StudioInvocationEvent, type StudioLogEvent } from '../../../src/local/studio-events.js';
@@ -346,6 +346,109 @@ describe('createStudioDispatcher', () => {
       'START RequestId: abc',
       'REPORT RequestId: abc Duration: 1ms',
     ]);
+  });
+
+  it('prefers the --response-file payload over a trailing console.log(JSON) line (issue #291)', async () => {
+    const bus = new StudioEventBus();
+    const { invocations, logs } = collect(bus);
+    const child = makeFakeChild();
+
+    // Capture the --response-file path the dispatcher passes and write the
+    // authoritative response there, simulating what `cdkl invoke` does.
+    let responsePath: string | undefined;
+    const spawnFn = vi.fn((_bin: string, argv: string[]) => {
+      const i = argv.indexOf('--response-file');
+      responsePath = i >= 0 ? argv[i + 1] : undefined;
+      return child as never;
+    });
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-rf',
+    });
+
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    // The child wrote the REAL response to the file.
+    expect(responsePath).toBeDefined();
+    writeFileSync(responsePath!, '{"statusCode":200,"body":"real"}');
+    // stdout echoes the response AND ends with a handler's own console.log of a
+    // JSON value — the exact case the last-JSON-line heuristic would mis-pick.
+    child.stdout.emit(
+      'data',
+      'START RequestId: abc\n' +
+        '{"statusCode":200,"body":"real"}\n' +
+        '{"debug":"trailing handler log that is also JSON"}\n'
+    );
+    child.emit('close', 0);
+    const result = await p;
+
+    // The file payload wins — NOT the trailing JSON log line.
+    expect(result.response).toEqual({ statusCode: 200, body: 'real' });
+    expect(result.raw).toBe('{"statusCode":200,"body":"real"}');
+    expect(invocations[1].response).toEqual({ statusCode: 200, body: 'real' });
+    // The echoed response line is dropped from the logs; the trailing JSON log
+    // line is kept (it is a real log, not the response).
+    const stdoutLogs = logs.filter((l) => l.stream === 'stdout').map((l) => l.line);
+    expect(stdoutLogs).toContain('{"debug":"trailing handler log that is also JSON"}');
+    expect(stdoutLogs).not.toContain('{"statusCode":200,"body":"real"}');
+    expect(stdoutLogs).toContain('START RequestId: abc');
+  });
+
+  it('passes --response-file for a lambda invoke but not for agentcore (issue #291)', async () => {
+    const bus = new StudioEventBus();
+    const lambdaChild = makeFakeChild();
+    const lambdaSpawn = vi.fn(() => lambdaChild as never);
+    const lambdaDispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: lambdaSpawn as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-l',
+    });
+    const lp = lambdaDispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    lambdaChild.stdout.emit('data', '{"ok":true}');
+    lambdaChild.emit('close', 0);
+    await lp;
+    const lambdaArgv = (lambdaSpawn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(lambdaArgv).toContain('--response-file');
+
+    const agentChild = makeFakeChild();
+    const agentSpawn = vi.fn(() => agentChild as never);
+    const agentDispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: agentSpawn as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-a',
+    });
+    const ap = agentDispatcher.run({ targetId: 'T', kind: 'agentcore', event: {} });
+    agentChild.stdout.emit('data', '{"ok":true}');
+    agentChild.emit('close', 0);
+    await ap;
+    const agentArgv = (agentSpawn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(agentArgv).not.toContain('--response-file');
+  });
+
+  it('falls back to the stdout heuristic when the response file is absent (issue #291)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      // spawnFn does NOT write the response file — older `cdkl invoke` / a crash
+      // before the write. The dispatcher must fall back to last-JSON-line.
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-fb',
+    });
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stdout.emit('data', 'START RequestId: abc\n{"statusCode":200,"body":"fallback"}\n');
+    child.emit('close', 0);
+    const result = await p;
+    expect(result.response).toEqual({ statusCode: 200, body: 'fallback' });
   });
 
   it('rejects when spawn throws synchronously', async () => {


### PR DESCRIPTION
## Summary

`cdkl studio` recovers a Lambda's response by spawning `cdkl invoke` and
taking the LAST JSON-parseable stdout line, because synth progress +
streamed container logs + the response all interleave on stdout. That
heuristic has one narrow failure mode: a handler whose own LAST stdout
output is a `console.log` of a JSON value, flushed after the response.

This adds a machine-readable response channel so studio never guesses.

## What changed

- `cdkl invoke` gains `--response-file <path>` (in the inherited
  `addInvokeSpecificOptions` helper): it writes ONLY the raw RIE response
  payload to that file. stdout output is unchanged.
- `src/local/studio-dispatch.ts` passes `--response-file` for a `lambda`
  invoke and reads the file as the authoritative response; the echoed
  stdout line is dropped from the LOGS stream so it is not shown twice.
  When the file is absent (older `cdkl invoke`, or a crash before the
  write) it falls back to the last-JSON-line heuristic. AgentCore is
  unchanged (its whole stdout IS the response).

## cdkd parity

Additive opt-in CLI option, registered in the host-inherited
`addInvokeSpecificOptions` helper, so a host CLI embedding `cdkl invoke`
inherits it automatically. No change to existing behavior when the flag
is absent. The option-surface contract test is updated.

## Test plan

- Unit (`studio-dispatch.test.ts`): the dispatcher prefers the file
  payload over a trailing `console.log(JSON)` trap, passes
  `--response-file` for lambda but not agentcore, and falls back to the
  stdout heuristic when the file is absent. Option-surface contract
  updated.
- Integration (`local-studio`): the fixture handler now emits a trailing
  `console.log(JSON)`; `verify.sh` asserts the studio invoke recovers the
  real return value and the response does not contain the trap marker.
  Full local-studio integ green, 0 Docker orphans.

Closes #291
