### PR TITLE
feat(studio): re-invoke a past timeline row with an edited payload

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -346,6 +346,10 @@ compute-locally category for Lambda + API Gateway).
   `studio-request-relay` so the browser composer reaches the served port
   same-origin; api / alb go through the capture proxy and land on the
   timeline, an ecs `--host-port` serve hits the replica host URL directly),
+  `POST /api/reinvoke` (issue #284 — re-run a past Lambda / AgentCore
+  timeline row with an edited payload via `studio-reinvoke`, threading
+  `reinvokeOf` so the new row links to its source; a served request is
+  re-sent through the request composer instead),
   the slice-C3 store
   endpoints `GET /api/history` / `GET /api/logs?q=` (full-text log
   search) / `GET /api/invocations/<id>/logs` (per-request log binding),
@@ -383,9 +387,20 @@ compute-locally category for Lambda + API Gateway).
   the serve body so `start-service` rebuilds the pinned image from local
   source; a local-asset service (which already hot-reloads under `--watch`)
   gets no picker (issue #301); the
-  timeline carries both Lambda invocations and captured serve requests,
-  the latter opening a read-only Request/Response detail; a log search box
-  queries the store and a captured request's detail shows its bound logs),
+  timeline carries both Lambda invocations and captured serve requests;
+  clicking a past Lambda / AgentCore row reloads it into the composer
+  pre-filled + wired to re-invoke (issue #284, the [Re-invoke] button ->
+  `POST /api/reinvoke`), a captured serve request opens a read-only
+  Request/Response detail whose [Re-invoke] reuses that serve's request
+  composer (pre-filled), and a re-invoked row is visually linked to its
+  source; a log search box queries the store and a captured request's
+  detail shows its bound logs),
+  studio-reinvoke (issue #284 — `reinvoke({invocationId, payload}, {store,
+  dispatcher})`: resolves the source target from the recorded invocation
+  and re-fires the edited payload through the SAME single-shot dispatcher
+  `POST /api/run` uses, threading `reinvokeOf`. Lambda / AgentCore only; a
+  served request is re-sent client-side through the request composer so
+  the capture proxy still records it),
   studio-dispatch
   (issue #282 / #303 — the single-shot `POST /api/run` handler
   for the invoke kinds: runs a target from the studio UI by

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -31,6 +31,7 @@ import {
 } from '../../local/studio-server.js';
 import { filterStudioCustomResources } from '../../local/studio-custom-resource-filter.js';
 import { createStudioDispatcher, type StudioRunRequest } from '../../local/studio-dispatch.js';
+import { reinvoke } from '../../local/studio-reinvoke.js';
 import {
   buildPerRunArgs,
   resolveEnvVars,
@@ -195,6 +196,35 @@ export function coerceServeRequest(body: unknown): StudioServeRequestPayload {
     out.body = reqBody;
   }
   return out;
+}
+
+/** Validated `POST /api/reinvoke` body (issue #284). */
+export interface StudioReinvokePayload {
+  /** Id of the recorded invocation to re-run. */
+  invocationId: string;
+  /** The (possibly edited) payload to re-invoke with. */
+  payload: unknown;
+}
+
+/**
+ * Validate the `POST /api/reinvoke` body at the HTTP boundary (issue #284):
+ * a non-empty `invocationId` string and a `payload` (the edited event — any
+ * JSON value, including `null`, but the key must be present so an omitted
+ * payload is a clean 4xx rather than a silent re-invoke with `undefined`).
+ */
+export function coerceReinvokeRequest(body: unknown): StudioReinvokePayload {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('Request body must be a JSON object.');
+  }
+  const record = body as Record<string, unknown>;
+  const { invocationId } = record;
+  if (typeof invocationId !== 'string' || invocationId.trim() === '') {
+    throw new Error('Request body must include a non-empty "invocationId" string.');
+  }
+  if (!('payload' in record)) {
+    throw new Error('Request body must include a "payload" (the edited event).');
+  }
+  return { invocationId, payload: record['payload'] };
 }
 
 /** The session config served at `GET /api/config` (issue #301 slice 3). */
@@ -566,6 +596,15 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
         ...(req.body !== undefined ? { body: req.body } : {}),
       });
       return result;
+    },
+    // `/api/reinvoke`: re-run a past Lambda / AgentCore row with an edited
+    // payload (issue #284). Resolves the source target from the store and
+    // re-dispatches through the SAME single-shot dispatcher, threading
+    // `reinvokeOf` so the new timeline row links to its source. A served
+    // request is re-sent client-side via the request composer instead.
+    onReinvoke: (body) => {
+      const { invocationId, payload } = coerceReinvokeRequest(body);
+      return reinvoke({ invocationId, payload }, { store, dispatcher });
     },
     getRunning: () => ({ running: serveManager.list() }),
     getConfig: () => sessionConfigSnapshot(),

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -756,6 +756,15 @@ export {
 } from './local/studio-request-relay.js';
 
 /**
+ * `cdkl studio` re-invoke (issue #284). A host CLI embedding studio wires
+ * `reinvoke` as the `startStudioServer` `onReinvoke` handler so a past
+ * Lambda / AgentCore timeline row can be re-run with an edited payload —
+ * resolving the source target from the store and re-dispatching through the
+ * same single-shot dispatcher `POST /api/run` uses, threading `reinvokeOf`.
+ */
+export { reinvoke, type ReinvokeInput, type ReinvokeDeps } from './local/studio-reinvoke.js';
+
+/**
  * `cdkl studio` serve manager (issue #282, slice C1). A host CLI
  * embedding studio wires `createStudioServeManager(...)` so the browser's
  * `POST /api/run` for a long-running target (the `api` kind) starts the

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -44,6 +44,13 @@ export interface StudioRunRequest {
    * rides on the shared coerced request so the serve manager can read it.
    */
   imageOverride?: string;
+  /**
+   * Issue #284: when this run is a re-invoke of a past timeline row, the
+   * source invocation id. Threaded verbatim into the emitted `invocation`
+   * start + end events as `reinvokeOf` so the UI links the new row to its
+   * source. Absent for a fresh invoke.
+   */
+  reinvokeOf?: string;
 }
 
 /** The outcome of a single-shot run, returned from `/api/run`. */
@@ -156,6 +163,7 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
       kind: req.kind,
       label: 'invoke',
       request: req.event,
+      ...(req.reinvokeOf ? { reinvokeOf: req.reinvokeOf } : {}),
     });
 
     // `dir` is created inside the try so a `writeFileSync` / `JSON.stringify`
@@ -261,6 +269,7 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
         response,
         status,
         durationMs,
+        ...(req.reinvokeOf ? { reinvokeOf: req.reinvokeOf } : {}),
       });
 
       const result: StudioRunResult = { invocationId, ok, status, durationMs };

--- a/src/local/studio-reinvoke.ts
+++ b/src/local/studio-reinvoke.ts
@@ -1,0 +1,65 @@
+import type { StudioStore } from './studio-store.js';
+import type { StudioDispatcher, StudioRunRequest, StudioRunResult } from './studio-dispatch.js';
+
+/** Input for {@link reinvoke}: the source row + the (possibly edited) payload. */
+export interface ReinvokeInput {
+  /** Id of the recorded invocation to re-run (a past timeline row). */
+  invocationId: string;
+  /** The payload to re-invoke with — the captured event, edited by the user. */
+  payload: unknown;
+}
+
+/** Collaborators {@link reinvoke} reads the source from / dispatches through. */
+export interface ReinvokeDeps {
+  /** The event store holding the recorded invocations (the source lookup). */
+  store: StudioStore;
+  /** The single-shot dispatcher the re-invoke runs through. */
+  dispatcher: StudioDispatcher;
+}
+
+/**
+ * The target kinds a timeline row can be re-invoked through the dispatcher.
+ * Single-shot invoke kinds only — a served request (api / alb / ecs) is
+ * re-sent client-side through the request composer + the live front door
+ * (issue #322), not re-dispatched here, so the proxy still captures it.
+ */
+const REINVOKABLE_KINDS = new Set<string>(['lambda', 'agentcore']);
+
+/**
+ * Re-invoke a past timeline row with an edited payload (issue #284, studio
+ * Phase 3). Resolves the original target from the recorded invocation and
+ * re-fires the edited payload through the SAME single-shot dispatcher
+ * `POST /api/run` uses, threading `reinvokeOf` so the new row links to its
+ * source. The payload REPLACES the original event (the edit IS the point);
+ * run options are not carried over (re-invoke edits the payload, not the
+ * flags).
+ *
+ * Only `lambda` / `agentcore` rows are re-invokable here — a served request
+ * is re-sent through the request composer instead, so this throws for serve
+ * kinds (and for an id that has aged out of the bounded history window).
+ *
+ * Host-side use case: consumed by `cdkl studio`'s `POST /api/reinvoke`
+ * handler; a host CLI embedding the studio building blocks reuses it to wire
+ * the same re-invoke route over its own store + dispatcher.
+ */
+export async function reinvoke(input: ReinvokeInput, deps: ReinvokeDeps): Promise<StudioRunResult> {
+  const original = deps.store.invocation(input.invocationId);
+  if (!original) {
+    throw new Error(
+      `No recorded invocation '${input.invocationId}' to re-invoke (it may have aged out of the history window).`
+    );
+  }
+  if (!REINVOKABLE_KINDS.has(original.kind)) {
+    throw new Error(
+      `Re-invoke from the timeline is server-side only for Lambda / AgentCore targets; ` +
+        `re-send a '${original.kind}' request with the request composer instead.`
+    );
+  }
+  const req: StudioRunRequest = {
+    targetId: original.target,
+    kind: original.kind,
+    event: input.payload,
+    reinvokeOf: input.invocationId,
+  };
+  return deps.dispatcher.run(req);
+}

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -191,6 +191,13 @@ export interface StudioServerOptions {
    */
   onServeRequest?: (body: unknown) => Promise<unknown>;
   /**
+   * Handler for `POST /api/reinvoke` (issue #284) — re-run a past timeline
+   * row with an edited payload. Body `{ invocationId, payload }`; resolves the
+   * source target from the store and re-dispatches the edited payload (Lambda /
+   * AgentCore only). When omitted, `/api/reinvoke` answers 501.
+   */
+  onReinvoke?: (body: unknown) => Promise<unknown>;
+  /**
    * Snapshot of the currently-running serve targets, served at
    * `GET /api/running`. When omitted, the endpoint returns an empty
    * list (the observe-only shell never runs anything).
@@ -339,6 +346,10 @@ function handleRequest(
   }
   if (req.method === 'POST' && path === '/api/run') {
     void handleDispatch(req, res, options.onRun);
+    return;
+  }
+  if (req.method === 'POST' && path === '/api/reinvoke') {
+    void handleDispatch(req, res, options.onReinvoke);
     return;
   }
   if (req.method === 'POST' && path === '/api/request') {

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -127,6 +127,7 @@ const STUDIO_CSS = `
   .row.sel { background: #2a3550; }
   .row .ts { color: #777; }
   .row .label { color: #ddd; flex: 1; overflow: hidden; text-overflow: ellipsis; }
+  .row.reinvoke .label::before { content: '\\21A9 '; color: #6aa0ff; margin-right: 2px; }
   .row .status { color: #7bd88f; }
   .row .status.err { color: #e0707a; }
   #workspace { padding: 0 0 24px; }
@@ -158,6 +159,7 @@ const STUDIO_CSS = `
   .req-composer .req-status { margin-top: 8px; font: 12px ui-monospace, Menlo, monospace; }
   .req-composer .req-result pre { background: #0e0e0e; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
+  .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
   .composer .err { color: #e0707a; margin-top: 6px; min-height: 18px; }
   .section { padding: 8px 12px; border-bottom: 1px solid #222; }
   .section h3 { margin: 0 0 6px; font-size: 11px; color: #888; text-transform: uppercase; }
@@ -256,6 +258,7 @@ const STUDIO_SCRIPT = `
   let shownInvId = null;           // lambda invocation whose result is in the workspace
   let shownServeId = null;         // serve target whose workspace is shown
   let shownDetailId = null;        // captured request whose read-only detail is shown
+  let pendingReqPrefill = null;    // {method,path,headers,body} to seed the next serve request composer (re-invoke)
   let studioDockerfiles = [];      // Dockerfiles scanned at boot (pinned-ecs image-override picker)
 
   function el(tag, cls, text) {
@@ -888,6 +891,24 @@ const STUDIO_SCRIPT = `
     bodyTa.spellcheck = false;
     sec.appendChild(bodyTa);
 
+    // Re-invoke prefill (issue #284): seed the fields from a captured request
+    // when the user clicked [Re-invoke] on a served-request detail. Consumed
+    // once (cleared) so a later fresh open of this serve starts empty.
+    if (pendingReqPrefill) {
+      const pf = pendingReqPrefill;
+      pendingReqPrefill = null;
+      if (pf.method) method.value = String(pf.method).toUpperCase();
+      if (pf.path != null) path.value = pf.path;
+      if (pf.headers && typeof pf.headers === 'object') {
+        headers.value = Object.keys(pf.headers)
+          .map(function (k) { return k + ': ' + pf.headers[k]; })
+          .join('\\n');
+      }
+      if (pf.body != null) {
+        bodyTa.value = typeof pf.body === 'string' ? pf.body : JSON.stringify(pf.body);
+      }
+    }
+
     const sendRow = el('div', 'req-send');
     const btn = el('button', null, 'Send');
     sendRow.appendChild(btn);
@@ -1088,21 +1109,31 @@ const STUDIO_SCRIPT = `
     return sec;
   }
 
-  function renderComposer(id, kind, eventText) {
+  function renderComposer(id, kind, eventText, reinvokeOf) {
     const ws = document.getElementById('workspace');
     ws.innerHTML = '';
 
     const composer = el('div', 'composer');
-    composer.appendChild(el('div', 'target-name', 'Invoke ' + id));
+    composer.appendChild(el('div', 'target-name', (reinvokeOf ? 'Re-invoke ' : 'Invoke ') + id));
     const ta = el('textarea');
     ta.value = eventText;
     ta.spellcheck = false;
     composer.appendChild(ta);
-    // Per-run options (e.g. env vars) below the event, above Invoke.
-    const opt = buildOptions(kind);
-    if (opt.node) composer.appendChild(opt.node);
+    // A re-invoke (issue #284) re-runs the EDITED event against the same
+    // target; per-run options are not carried over, so the options section is
+    // omitted (the payload is the thing being tweaked). A fresh invoke keeps
+    // the per-run options (e.g. env vars) below the event, above Invoke.
+    let opt = { collect: undefined, collectRaw: undefined };
+    if (reinvokeOf) {
+      composer.appendChild(
+        el('div', 'opt-hint', 'Re-invoke runs the edited event through the same target (per-run options use defaults).')
+      );
+    } else {
+      opt = buildOptions(kind);
+      if (opt.node) composer.appendChild(opt.node);
+    }
     composer.appendChild(document.createElement('br'));
-    const btn = el('button', null, 'Invoke');
+    const btn = el('button', null, reinvokeOf ? 'Re-invoke' : 'Invoke');
     const msg = el('div', 'err');
     composer.appendChild(btn);
     composer.appendChild(msg);
@@ -1112,7 +1143,17 @@ const STUDIO_SCRIPT = `
     ws.appendChild(composer);
     ws.appendChild(result);
 
-    active = { id, kind, ta, btn, msg, result, collectOpts: opt.collect, collectRaw: opt.collectRaw };
+    active = {
+      id,
+      kind,
+      ta,
+      btn,
+      msg,
+      result,
+      collectOpts: opt.collect,
+      collectRaw: opt.collectRaw,
+      reinvokeOf: reinvokeOf || null,
+    };
     btn.onclick = () => runInvoke();
     shownInvId = null;
     shownDetailId = null;
@@ -1129,17 +1170,29 @@ const STUDIO_SCRIPT = `
       msg.textContent = 'Invalid JSON: ' + err.message;
       return;
     }
+    const isReinvoke = !!active.reinvokeOf;
     msg.textContent = '';
     btn.disabled = true;
-    btn.textContent = 'Invoking...';
+    btn.textContent = isReinvoke ? 'Re-invoking...' : 'Invoking...';
     result.innerHTML = '';
     try {
-      const body = { targetId: id, kind, event };
-      const options = active.collectOpts ? active.collectOpts() : undefined;
-      if (options) body.options = options;
-      const rawArgs = active.collectRaw ? active.collectRaw() : undefined;
-      if (rawArgs) body.rawArgs = rawArgs;
-      const res = await fetch('/api/run', {
+      // A re-invoke (issue #284) re-runs a recorded row by id with the edited
+      // payload through POST /api/reinvoke; a fresh invoke runs the target by
+      // POST /api/run with the composed options.
+      let url;
+      let body;
+      if (isReinvoke) {
+        url = '/api/reinvoke';
+        body = { invocationId: active.reinvokeOf, payload: event };
+      } else {
+        url = '/api/run';
+        body = { targetId: id, kind, event };
+        const options = active.collectOpts ? active.collectOpts() : undefined;
+        if (options) body.options = options;
+        const rawArgs = active.collectRaw ? active.collectRaw() : undefined;
+        if (rawArgs) body.rawArgs = rawArgs;
+      }
+      const res = await fetch(url, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
@@ -1150,13 +1203,14 @@ const STUDIO_SCRIPT = `
         renderResult(shownInvId);
       }
       if (!res.ok || data.ok === false) {
-        msg.textContent = 'Invoke failed: ' + (data.error || ('HTTP ' + res.status));
+        const verb = isReinvoke ? 'Re-invoke' : 'Invoke';
+        msg.textContent = verb + ' failed: ' + (data.error || ('HTTP ' + res.status));
       }
     } catch (err) {
       msg.textContent = 'Request failed: ' + err;
     } finally {
       btn.disabled = false;
-      btn.textContent = 'Invoke';
+      btn.textContent = isReinvoke ? 'Re-invoke' : 'Invoke';
     }
   }
 
@@ -1214,6 +1268,12 @@ const STUDIO_SCRIPT = `
     const d = new Date(merged.ts);
     row.querySelector('.ts').textContent = d.toLocaleTimeString();
     row.querySelector('.label').textContent = (merged.target || '') + '  ' + (merged.label || '');
+    // A re-invoke (issue #284) row is visually linked to its source: a CSS
+    // marker on the label + a tooltip naming the source invocation.
+    if (merged.reinvokeOf) {
+      row.classList.add('reinvoke');
+      row.title = 'Re-invoke of ' + merged.reinvokeOf;
+    }
     const statusEl = row.querySelector('.status');
     statusEl.textContent =
       merged.status != null
@@ -1236,10 +1296,11 @@ const STUDIO_SCRIPT = `
     highlightTarget(ev.target);
     if (INVOKE_KINDS.includes(ev.kind)) {
       // A single-shot invocation row (Lambda or AgentCore) reloads into the
-      // re-invokable composer.
+      // re-invokable composer, pre-filled with the captured event and wired to
+      // POST /api/reinvoke (issue #284) so the new row links to this source.
       shownDetailId = null;
       shownServeId = null;
-      renderComposer(ev.target, ev.kind, ev.request != null ? fmt(ev.request) : '{}');
+      renderComposer(ev.target, ev.kind, ev.request != null ? fmt(ev.request) : '{}', id);
       shownInvId = id;
       renderResult(id);
     } else {
@@ -1262,6 +1323,23 @@ const STUDIO_SCRIPT = `
 
     const head = el('div', 'composer');
     head.appendChild(el('div', 'target-name', (ev.label || 'request') + '  —  ' + (ev.target || '')));
+    // Re-invoke (issue #284): a captured served request is re-sent through the
+    // live front door by reusing that serve's request composer. Clicking
+    // navigates to the running serve and pre-fills it with this request; the
+    // serve must be running (restart it first if it has stopped).
+    const serveSt = serveState.get(ev.target);
+    const serveRunning = serveSt && serveSt.status === 'running';
+    const reBtn = el('button', 'reinvoke-btn', 'Re-invoke');
+    if (serveRunning) {
+      reBtn.onclick = function () {
+        pendingReqPrefill = ev.request && typeof ev.request === 'object' ? ev.request : null;
+        selectTarget(ev.target, ev.kind);
+      };
+    } else {
+      reBtn.disabled = true;
+      reBtn.title = 'Start the serve to re-invoke this request.';
+    }
+    head.appendChild(reBtn);
     ws.appendChild(head);
 
     const reqSec = el('div', 'section');

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -892,20 +892,30 @@ const STUDIO_SCRIPT = `
     sec.appendChild(bodyTa);
 
     // Re-invoke prefill (issue #284): seed the fields from a captured request
-    // when the user clicked [Re-invoke] on a served-request detail. Consumed
-    // once (cleared) so a later fresh open of this serve starts empty.
+    // when the user clicked [Re-invoke] on a served-request detail. The prefill
+    // is address-tagged with its target; consume it UNCONDITIONALLY (so a stray
+    // one from a since-stopped serve never lingers) but only APPLY it when the
+    // target matches this composer.
     if (pendingReqPrefill) {
-      const pf = pendingReqPrefill;
+      const pending = pendingReqPrefill;
       pendingReqPrefill = null;
-      if (pf.method) method.value = String(pf.method).toUpperCase();
-      if (pf.path != null) path.value = pf.path;
-      if (pf.headers && typeof pf.headers === 'object') {
-        headers.value = Object.keys(pf.headers)
-          .map(function (k) { return k + ': ' + pf.headers[k]; })
-          .join('\\n');
-      }
-      if (pf.body != null) {
-        bodyTa.value = typeof pf.body === 'string' ? pf.body : JSON.stringify(pf.body);
+      if (pending.targetId === id && pending.req && typeof pending.req === 'object') {
+        const pf = pending.req;
+        if (pf.method) method.value = String(pf.method).toUpperCase();
+        if (pf.path != null) path.value = pf.path;
+        if (pf.headers && typeof pf.headers === 'object') {
+          // Drop hop-by-hop / transport headers the proxy captured verbatim
+          // (host / content-length / etc.) — they are noise in the editor and
+          // the relay sets them itself.
+          const SKIP = ['host', 'connection', 'content-length', 'transfer-encoding', 'accept-encoding'];
+          headers.value = Object.keys(pf.headers)
+            .filter(function (k) { return SKIP.indexOf(k.toLowerCase()) === -1; })
+            .map(function (k) { return k + ': ' + pf.headers[k]; })
+            .join('\\n');
+        }
+        if (pf.body != null) {
+          bodyTa.value = typeof pf.body === 'string' ? pf.body : JSON.stringify(pf.body);
+        }
       }
     }
 
@@ -1332,7 +1342,20 @@ const STUDIO_SCRIPT = `
     const reBtn = el('button', 'reinvoke-btn', 'Re-invoke');
     if (serveRunning) {
       reBtn.onclick = function () {
-        pendingReqPrefill = ev.request && typeof ev.request === 'object' ? ev.request : null;
+        // Re-check running at CLICK time: the serve may have stopped since the
+        // detail was rendered (the button is not re-rendered on a stop). If so,
+        // do NOT seed a prefill (it would otherwise leak into the next serve
+        // composer). The prefill is address-tagged with the target so a stray
+        // one is dropped on mismatch (see renderRequestComposer).
+        const cur = serveState.get(ev.target);
+        if (!cur || cur.status !== 'running') {
+          renderCapturedDetail(id); // re-render to reflect the now-stopped state
+          return;
+        }
+        pendingReqPrefill =
+          ev.request && typeof ev.request === 'object'
+            ? { targetId: ev.target, req: ev.request }
+            : null;
         selectTarget(ev.target, ev.kind);
       };
     } else {

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -47,14 +47,18 @@ export class LocalStudioStack extends cdk.Stack {
       handler: 'index.handler',
       // Echoes the STUDIO_ENV_PROBE env var into the body so the per-target
       // `--env-vars` option (issue #301 slice 2) is observable end-to-end;
-      // defaults to 'ok' so the other assertions are unaffected. Also emits a
-      // trailing `console.log(JSON)` line — the exact shape that would fool
-      // studio's last-JSON-line stdout heuristic — so the invoke assertion
-      // proves studio recovers the REAL return value via --response-file and
-      // not this log line (issue #291).
+      // defaults to 'ok' so the other assertions are unaffected. Echoes the
+      // event's `echo` field into the response so re-invoking with an edited
+      // payload is observable end-to-end (issue #284). Also emits a trailing
+      // `console.log(JSON)` line — the exact shape that would fool studio's
+      // last-JSON-line stdout heuristic — so the invoke assertion proves
+      // studio recovers the REAL return value via --response-file and not
+      // this log line (issue #291).
       code: lambda.Code.fromInline(
-        "exports.handler = async () => { console.log(JSON.stringify({ cdklResponseTrap: 'not-the-response' })); " +
-          "return { statusCode: 200, body: process.env.STUDIO_ENV_PROBE || 'ok' }; };"
+        'exports.handler = async (event) => { ' +
+          "console.log(JSON.stringify({ cdklResponseTrap: 'not-the-response' })); " +
+          "return { statusCode: 200, body: process.env.STUDIO_ENV_PROBE || 'ok', " +
+          'echo: (event && event.echo) != null ? event.echo : null }; };'
       ),
     });
 

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -279,7 +279,14 @@ if ! grep -qF "the serve child internal port" "${BODY_FILE}" \
   echo "FAIL: GET / did not include the proxy-vs-child port clarity hints (issue #325)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints"
+# Re-invoke wiring (issue #284): the composer posts to /api/reinvoke and rows
+# get the reinvoke marker.
+if ! grep -qF "url = '/api/reinvoke'" "${BODY_FILE}" \
+  || ! grep -qF "row.classList.add('reinvoke')" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the re-invoke wiring (issue #284)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.
@@ -375,6 +382,44 @@ echo "    OK: response recovered via --response-file, not the trailing console.l
 # binding assertion below.
 LAMBDA_INV_ID=$(grep -oE '"invocationId":"[^"]+"' "${RUN_FILE}" | head -1 | sed 's/.*"invocationId":"//;s/"//')
 echo "    (lambda invocationId=${LAMBDA_INV_ID})"
+
+# ---------------------------------------------------------------------------
+# 6b. POST /api/reinvoke re-runs that recorded row with an EDITED payload
+#     (issue #284). The handler echoes the event's `echo` field into the
+#     response, so a modified `echo` proves the edited payload reached the
+#     target; the new invocation must carry `reinvokeOf` linking it to the
+#     source row (asserted via GET /api/history).
+# ---------------------------------------------------------------------------
+echo "==> POST /api/reinvoke re-runs the row with an edited payload"
+REINV_FILE=$(mktemp)
+HTTP_RI=$(curl -s -o "${REINV_FILE}" -w '%{http_code}' --max-time 180 \
+  -X POST "${URL}/api/reinvoke" \
+  -H 'content-type: application/json' \
+  -d "{\"invocationId\":\"${LAMBDA_INV_ID}\",\"payload\":{\"echo\":\"reinvoke-edited\"}}" || true)
+if [[ "${HTTP_RI}" != "200" ]]; then
+  echo "FAIL: POST /api/reinvoke returned HTTP ${HTTP_RI}"
+  echo "----- reinvoke response -----"; cat "${REINV_FILE}"; echo "-----------------------------"
+  rm -f "${REINV_FILE}"; exit 1
+fi
+# The edited payload reached the target: its response echoes the new value.
+if ! grep -qF '"echo":"reinvoke-edited"' "${REINV_FILE}"; then
+  echo "FAIL: re-invoke response did not echo the edited payload"
+  echo "----- reinvoke response -----"; cat "${REINV_FILE}"; echo "-----------------------------"
+  rm -f "${REINV_FILE}"; exit 1
+fi
+REINV_ID=$(grep -oE '"invocationId":"[^"]+"' "${REINV_FILE}" | head -1 | sed 's/.*"invocationId":"//;s/"//')
+echo "    OK: re-invoke ran the edited payload (new invocationId=${REINV_ID})"
+rm -f "${REINV_FILE}"
+# The new row links to its source: GET /api/history shows reinvokeOf = source id.
+HIST_FILE=$(mktemp)
+curl -fsS "${URL}/api/history" -o "${HIST_FILE}"
+if ! grep -qF "\"reinvokeOf\":\"${LAMBDA_INV_ID}\"" "${HIST_FILE}"; then
+  echo "FAIL: history has no invocation linking back to the source (reinvokeOf=${LAMBDA_INV_ID})"
+  echo "----- history -----"; cat "${HIST_FILE}"; echo "-------------------"
+  rm -f "${HIST_FILE}"; exit 1
+fi
+rm -f "${HIST_FILE}"
+echo "    OK: the re-invoked row links to its source via reinvokeOf"
 
 echo "==> The invocation was broadcast over SSE"
 # Give the SSE listener a moment to receive the end event, then stop it.
@@ -1143,4 +1188,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + custom-resource-exclusion + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + custom-resource-exclusion + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + reinvoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -7,6 +7,7 @@ import {
   coerceRunRequest,
   coerceStopRequest,
   coerceServeRequest,
+  coerceReinvokeRequest,
   resolveServeBaseUrl,
   createLocalStudioCommand,
   parseStudioPort,
@@ -344,6 +345,37 @@ describe('coerceServeRequest (issue #322)', () => {
     expect(() =>
       coerceServeRequest({ targetId: 'T', method: 'GET', headers: { x: 1 } })
     ).toThrow(/header "x" must be a string/);
+  });
+});
+
+describe('coerceReinvokeRequest (issue #284)', () => {
+  it('accepts a well-formed body and returns invocationId + payload', () => {
+    expect(coerceReinvokeRequest({ invocationId: 'src-1', payload: { a: 2 } })).toEqual({
+      invocationId: 'src-1',
+      payload: { a: 2 },
+    });
+  });
+
+  it('accepts a null payload (the key is present) — clearing the event', () => {
+    expect(coerceReinvokeRequest({ invocationId: 'src-1', payload: null })).toEqual({
+      invocationId: 'src-1',
+      payload: null,
+    });
+  });
+
+  it.each([null, 'x', 42])('rejects a non-object body %p', (body) => {
+    expect(() => coerceReinvokeRequest(body)).toThrow(/must be a JSON object/);
+  });
+
+  it.each([{ payload: {} }, { invocationId: '', payload: {} }, { invocationId: 42, payload: {} }])(
+    'rejects a missing/blank invocationId %p',
+    (body) => {
+      expect(() => coerceReinvokeRequest(body)).toThrow(/non-empty "invocationId"/);
+    }
+  );
+
+  it('rejects when the payload key is absent (vs an explicit null)', () => {
+    expect(() => coerceReinvokeRequest({ invocationId: 'src-1' })).toThrow(/must include a "payload"/);
   });
 });
 

--- a/tests/unit/local/studio-dispatch.test.ts
+++ b/tests/unit/local/studio-dispatch.test.ts
@@ -451,6 +451,46 @@ describe('createStudioDispatcher', () => {
     expect(result.response).toEqual({ statusCode: 200, body: 'fallback' });
   });
 
+  it('threads reinvokeOf into the emitted start + end invocation events (issue #284)', async () => {
+    const bus = new StudioEventBus();
+    const { invocations } = collect(bus);
+    const child = makeFakeChild();
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-ri',
+    });
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: { a: 2 }, reinvokeOf: 'src-1' });
+    child.stdout.emit('data', '{"ok":true}');
+    child.emit('close', 0);
+    await p;
+    // Both the start (no status) and end (status filled) events carry the link.
+    expect(invocations).toHaveLength(2);
+    expect(invocations[0].reinvokeOf).toBe('src-1');
+    expect(invocations[1].reinvokeOf).toBe('src-1');
+  });
+
+  it('omits reinvokeOf for a fresh (non-re-invoke) run', async () => {
+    const bus = new StudioEventBus();
+    const { invocations } = collect(bus);
+    const child = makeFakeChild();
+    const dispatcher = createStudioDispatcher({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-fresh',
+    });
+    const p = dispatcher.run({ targetId: 'T', kind: 'lambda', event: {} });
+    child.stdout.emit('data', '{"ok":true}');
+    child.emit('close', 0);
+    await p;
+    expect(invocations[0].reinvokeOf).toBeUndefined();
+    expect(invocations[1].reinvokeOf).toBeUndefined();
+  });
+
   it('rejects when spawn throws synchronously', async () => {
     const bus = new StudioEventBus();
     const spawnFn = vi.fn(() => {

--- a/tests/unit/local/studio-reinvoke.test.ts
+++ b/tests/unit/local/studio-reinvoke.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { reinvoke } from '../../../src/local/studio-reinvoke.js';
+import type { StudioStore } from '../../../src/local/studio-store.js';
+import type { StudioDispatcher, StudioRunRequest } from '../../../src/local/studio-dispatch.js';
+import type { StudioInvocationEvent } from '../../../src/local/studio-events.js';
+
+/** A store stub whose `invocation(id)` returns the supplied record (or none). */
+function fakeStore(record: Partial<StudioInvocationEvent> | undefined): StudioStore {
+  return {
+    history: () => ({ invocations: [], logs: [] }),
+    searchLogs: () => [],
+    logsForInvocation: () => [],
+    invocation: (id: string) =>
+      record ? ({ id, ts: 0, label: 'invoke', ...record } as StudioInvocationEvent) : undefined,
+    dispose: () => undefined,
+  };
+}
+
+/** A dispatcher stub that records the request it was handed. */
+function fakeDispatcher(): { dispatcher: StudioDispatcher; calls: StudioRunRequest[] } {
+  const calls: StudioRunRequest[] = [];
+  const dispatcher: StudioDispatcher = {
+    run: vi.fn(async (req: StudioRunRequest) => {
+      calls.push(req);
+      return { invocationId: 'new-inv', ok: true, status: 200, durationMs: 5 };
+    }),
+  };
+  return { dispatcher, calls };
+}
+
+describe('reinvoke', () => {
+  it('re-dispatches a recorded lambda row with the edited payload + reinvokeOf', async () => {
+    const store = fakeStore({ target: 'Stack/Fn', kind: 'lambda', request: { a: 1 } });
+    const { dispatcher, calls } = fakeDispatcher();
+
+    const result = await reinvoke({ invocationId: 'src-1', payload: { a: 2 } }, { store, dispatcher });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      targetId: 'Stack/Fn',
+      kind: 'lambda',
+      event: { a: 2 }, // the EDITED payload replaces the original event
+      reinvokeOf: 'src-1',
+    });
+  });
+
+  it('re-dispatches a recorded agentcore row', async () => {
+    const store = fakeStore({ target: 'Stack/Agent', kind: 'agentcore', request: { prompt: 'hi' } });
+    const { dispatcher, calls } = fakeDispatcher();
+
+    await reinvoke({ invocationId: 'src-2', payload: { prompt: 'bye' } }, { store, dispatcher });
+
+    expect(calls[0]).toMatchObject({
+      targetId: 'Stack/Agent',
+      kind: 'agentcore',
+      event: { prompt: 'bye' },
+      reinvokeOf: 'src-2',
+    });
+  });
+
+  it('throws when the source invocation has aged out of the store', async () => {
+    const store = fakeStore(undefined);
+    const { dispatcher, calls } = fakeDispatcher();
+
+    await expect(reinvoke({ invocationId: 'gone', payload: {} }, { store, dispatcher })).rejects.toThrow(
+      /No recorded invocation 'gone'/
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it('throws for a served (api / alb / ecs) source — re-sent via the composer instead', async () => {
+    const store = fakeStore({ target: 'Stack/Api', kind: 'api', request: { method: 'GET', path: '/' } });
+    const { dispatcher, calls } = fakeDispatcher();
+
+    await expect(reinvoke({ invocationId: 'src-3', payload: {} }, { store, dispatcher })).rejects.toThrow(
+      /server-side only for Lambda \/ AgentCore/
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes a null edited payload through verbatim (clearing the event)', async () => {
+    const store = fakeStore({ target: 'Stack/Fn', kind: 'lambda', request: { a: 1 } });
+    const { dispatcher, calls } = fakeDispatcher();
+
+    await reinvoke({ invocationId: 'src-4', payload: null }, { store, dispatcher });
+
+    expect(calls[0]?.event).toBeNull();
+  });
+});

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -508,6 +508,36 @@ describe('startStudioServer', () => {
     expect(data.error).toContain('dispatch blew up');
   });
 
+  it('POST /api/reinvoke dispatches to onReinvoke and returns its result as JSON (issue #284)', async () => {
+    let received: unknown;
+    const onReinvoke = (body: unknown): Promise<unknown> => {
+      received = body;
+      return Promise.resolve({ invocationId: 'new-inv', ok: true });
+    };
+    const server = await boot({ onReinvoke });
+    const res = await http(`${server.url}/api/reinvoke`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ invocationId: 'src-1', payload: { a: 2 } }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { invocationId: string; ok: boolean };
+    expect(data.ok).toBe(true);
+    expect(data.invocationId).toBe('new-inv');
+    expect(received).toEqual({ invocationId: 'src-1', payload: { a: 2 } });
+  });
+
+  it('POST /api/reinvoke answers 501 when no onReinvoke handler is wired', async () => {
+    const server = await boot(); // observe-only shell
+    const res = await http(`${server.url}/api/reinvoke`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(501);
+    await res.text();
+  });
+
   it('POST /api/stop dispatches to onStop and returns its result as JSON', async () => {
     let received: unknown;
     const onStop = (body: unknown): Promise<unknown> => {

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -158,6 +158,23 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('use the Endpoints above');
   });
 
+  it('wires the re-invoke flow into the composer + timeline (issue #284)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The composer takes a reinvoke source and posts to /api/reinvoke.
+    expect(html).toContain('function renderComposer(id, kind, eventText, reinvokeOf)');
+    expect(html).toContain("url = '/api/reinvoke'");
+    expect(html).toContain('invocationId: active.reinvokeOf, payload: event');
+    // A past invoke row reloads into the re-invokable composer with its source id.
+    expect(html).toContain('renderComposer(ev.target, ev.kind, ev.request != null ? fmt(ev.request) : ');
+    // Re-invoked rows are visually linked to the source.
+    expect(html).toContain("row.classList.add('reinvoke')");
+    expect(html).toContain('.row.reinvoke .label::before');
+    // The captured serve detail offers a Re-invoke that reuses the request
+    // composer via the prefill.
+    expect(html).toContain('pendingReqPrefill');
+    expect(html).toContain("el('button', 'reinvoke-btn', 'Re-invoke')");
+  });
+
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {
     const html = renderStudioHtml('<script>alert(1)</script>', '"&<>');
     // The raw markup must never appear verbatim in the document.


### PR DESCRIPTION
## Summary

Phase 3 of the `cdkl studio` umbrella. Click a past Lambda / AgentCore
timeline row, edit its captured payload, and re-run it — replacing the
"re-run a `curl` with one field tweaked in a second terminal" loop.

## Server-side

- New `src/local/studio-reinvoke.ts`: `reinvoke({invocationId, payload},
  {store, dispatcher})` resolves the source target from the recorded
  invocation and re-fires the edited payload through the SAME single-shot
  dispatcher `POST /api/run` uses, threading `reinvokeOf`. Lambda /
  AgentCore only; a served request is re-sent client-side via the request
  composer so the capture proxy still records it. Exported from
  `src/internal.ts`.
- `StudioRunRequest` gains `reinvokeOf`; the dispatcher threads it into the
  emitted invocation start + end events so the new row links to its source.
- `startStudioServer` gains an `onReinvoke` handler + `POST /api/reinvoke`;
  `local-studio` wires it with a `coerceReinvokeRequest` validator.

## UI

- Clicking a past Lambda / AgentCore row reloads it into the composer
  pre-filled + wired to `POST /api/reinvoke` (the button reads "Re-invoke").
- A captured serve request's read-only detail gets a [Re-invoke] that
  reuses that serve's request composer, pre-filled (when the serve is
  running).
- A re-invoked row is visually linked to its source (CSS marker + tooltip).

## cdkd parity

New public helper `studio-reinvoke` (exported from `internal.ts` with a
host-side JSDoc) + an additive `onReinvoke` server option. No CLI option,
no behavior change to existing endpoints.

## Test plan

- Unit: `studio-reinvoke` (target resolution, payload edit, serve-kind +
  aged-out rejection), dispatcher `reinvokeOf` threading, `POST
  /api/reinvoke` server contract, `coerceReinvokeRequest` validation, UI
  re-invoke wiring.
- Integration (`local-studio`): invoke once, re-invoke with an edited
  `echo` field, assert the target observed the modification and `GET
  /api/history` shows the new row's `reinvokeOf` linking to the source.
  Full local-studio integ green, 0 Docker orphans.

Closes #284
