### PR TITLE
fix(studio): visual polish — zebra contrast, wider session inputs, LOGS clear

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -50,7 +50,7 @@ const STUDIO_CSS = `
   #session-bar .sess-bind { color: #bbb; display: inline-flex; align-items: center; gap: 4px; }
   #session-bar input[type=text] {
     background: #111; color: #ddd; border: 1px solid #333; border-radius: 3px;
-    padding: 3px 6px; font: 12px ui-monospace, Menlo, monospace; min-width: 180px;
+    padding: 3px 6px; font: 12px ui-monospace, Menlo, monospace; min-width: 240px;
   }
   #session-bar input:focus { outline: none; border-color: #4ec97a; }
   #session-bar button {
@@ -99,7 +99,10 @@ const STUDIO_CSS = `
   }
   /* Zebra-stripe rows so each target box reads as its own block (the borderless
      rows otherwise blur together); the kind label stays readable on both. */
-  .group-body .target:nth-child(2n) { background: #1b1b1b; }
+  /* Zebra: alternate rows get a clearly lighter background than the base
+     (#1a1a1a) so adjacent target boxes read as distinct — a 1-step shade was
+     imperceptible. The kind label (#8f8f8f) still reads on both shades. */
+  .group-body .target:nth-child(2n) { background: #242424; }
   .target.runnable { cursor: pointer; }
   .target.runnable:hover { background: #292929; }
   .target.sel, .group-body .target.sel:nth-child(2n) { background: #2a3550; }
@@ -160,6 +163,12 @@ const STUDIO_CSS = `
   .req-composer .req-result pre { background: #0e0e0e; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
+  .log-head { display: flex; align-items: center; justify-content: space-between; }
+  .log-clear {
+    background: #1d1d1d; color: #bbb; border: 1px solid #333; border-radius: 3px;
+    padding: 2px 10px; font-size: 11px; cursor: pointer; margin: 0;
+  }
+  .log-clear:hover { background: #262626; color: #ddd; }
   .composer .err { color: #e0707a; margin-top: 6px; min-height: 18px; }
   .section { padding: 8px 12px; border-bottom: 1px solid #222; }
   .section h3 { margin: 0 0 6px; font-size: 11px; color: #888; text-transform: uppercase; }
@@ -826,7 +835,18 @@ const STUDIO_SCRIPT = `
 
     const logs = logsById.get(id) || [];
     const logSec = el('div', 'section');
-    logSec.appendChild(el('h3', null, 'Logs'));
+    // Logs header carries a Clear button (issue #338): hammering a serve piles
+    // up log lines, so let the user empty the panel (display-only — the
+    // server-side store / history is untouched).
+    const logHead = el('div', 'log-head');
+    logHead.appendChild(el('h3', null, 'Logs'));
+    const logClear = el('button', 'log-clear', 'Clear');
+    logClear.onclick = function () {
+      logsById.set(id, []);
+      renderServeWorkspace(id);
+    };
+    logHead.appendChild(logClear);
+    logSec.appendChild(logHead);
     // A proxy-fronted serve (api / alb) streams its child start-* logs here,
     // which advertise the child internal 127.0.0.1 port — a DIFFERENT port
     // than the capture-proxy URL in Endpoints above. Flag it so the child

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -286,7 +286,15 @@ if ! grep -qF "url = '/api/reinvoke'" "${BODY_FILE}" \
   echo "FAIL: GET / did not include the re-invoke wiring (issue #284)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring"
+# Visual UX fixes: zebra shade (issue #333), wider session inputs (issue #339),
+# LOGS Clear button (issue #338).
+if ! grep -qF '.group-body .target:nth-child(2n) { background: #242424; }' "${BODY_FILE}" \
+  || ! grep -qF 'min-width: 240px;' "${BODY_FILE}" \
+  || ! grep -qF "el('button', 'log-clear', 'Clear')" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the visual UX fixes (issues #333 / #338 / #339)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -129,8 +129,23 @@ describe('renderStudioHtml', () => {
     // Collapsible groups (collapsed by default) + the toggle.
     expect(html).toContain('function toggleGroup');
     expect(html).toContain("el('div', 'group-body collapsed')");
-    // Zebra striping via the group-body nth-child rule.
-    expect(html).toContain('.group-body .target:nth-child(2n)');
+    // Zebra striping via the group-body nth-child rule, with a clearly
+    // distinct shade (issue #333 — the previous #1b1b1b was 1 step off the
+    // #1a1a1a base and imperceptible).
+    expect(html).toContain('.group-body .target:nth-child(2n) { background: #242424; }');
+  });
+
+  it('widens the Session-bar inputs so the placeholder is not truncated (issue #339)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    expect(html).toContain('#session-bar input[type=text]');
+    expect(html).toContain('min-width: 240px;');
+  });
+
+  it('renders a Clear button on the serve LOGS panel (issue #338)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    expect(html).toContain("el('button', 'log-clear', 'Clear')");
+    expect(html).toContain("logsById.set(id, []);");
+    expect(html).toContain('.log-clear');
   });
 
   it('renders an in-workspace HTTP request composer for a running serve (issue #322)', () => {


### PR DESCRIPTION
## Summary

Three small visual fixes to the `cdkl studio` web console, surfaced while
reviewing the API request-composer flow.

- **Zebra contrast (issue 333)**: the target-pane alternate-row stripe was
  `#1b1b1b` against the `#1a1a1a` base — a one-step shade that was
  imperceptible. Bumped to `#242424` so adjacent target boxes read as
  distinct (the `#8f8f8f` kind label still reads on both shades).
- **Session-bar input width (issue 339)**: widened the text inputs
  (`min-width` 180px -> 240px) so the `--from-cfn-stack` placeholder
  ("stack name (blank = auto)") is no longer truncated.
- **LOGS Clear button (issue 338)**: added a Clear button to the serve
  LOGS panel — display-only (empties the panel without touching the
  server-side store / history) — so hammering a serve does not leave an
  unbounded log wall.

## Test plan

- Unit (`studio-ui.test.ts`): asserts the served HTML carries the new
  zebra shade, the 240px input width, and the `log-clear` button.
- Integration (`local-studio`): the `GET /` UI assertion now also greps
  the served page for all three. Full local-studio integ green, 0 Docker
  orphans.

Closes #333
Closes #338
Closes #339
