### PR TITLE
fix(studio): keep the serve composer alive across streamed log events

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -260,6 +260,8 @@ const STUDIO_SCRIPT = `
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event
   const logsById = new Map();      // invocationId / serve targetId -> [log lines]
+  let serveLogId = null;           // serve target whose LOGS <pre> is live (issue #334)
+  let serveLogPre = null;          // the live serve LOGS <pre>, updated surgically on log events
   const targetEls = new Map();     // targetId -> left-pane element
   const serveMeta = new Map();     // serve targetId -> { dot, btnSlot } row controls
   const serveState = new Map();    // serve targetId -> { status, endpoints }
@@ -674,6 +676,10 @@ const STUDIO_SCRIPT = `
     // navigation drops it — see renderWsConsole).
     closeActiveWs();
     highlightTarget(id);
+    // Navigating to a composer leaves no timeline row "selected" — a stale
+    // row.sel from a previously-clicked event is confusing once the middle
+    // pane has moved on (issue #336).
+    document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'));
     shownDetailId = null;
     if (SERVE_KINDS.includes(kind)) {
       shownServeId = id;
@@ -734,6 +740,10 @@ const STUDIO_SCRIPT = `
   function renderServeWorkspace(id, errMsg) {
     const ws = document.getElementById('workspace');
     ws.innerHTML = '';
+    // Drop the live LOGS <pre> ref — it is re-established below if this render
+    // produces one, so a stale detached node never receives surgical updates.
+    serveLogId = null;
+    serveLogPre = null;
     const st = serveState.get(id) || { status: 'stopped', endpoints: [] };
     const running = st.status === 'running';
     const starting = st.status === 'starting';
@@ -842,8 +852,10 @@ const STUDIO_SCRIPT = `
     logHead.appendChild(el('h3', null, 'Logs'));
     const logClear = el('button', 'log-clear', 'Clear');
     logClear.onclick = function () {
+      // Surgical clear (issue #334): empty the buffer + the live <pre> without
+      // a full re-render that would wipe the request composer's fields.
       logsById.set(id, []);
-      renderServeWorkspace(id);
+      if (serveLogPre) serveLogPre.textContent = '(none)';
     };
     logHead.appendChild(logClear);
     logSec.appendChild(logHead);
@@ -860,8 +872,13 @@ const STUDIO_SCRIPT = `
         )
       );
     }
-    logSec.appendChild(el('pre', null, logs.length ? logs.join('\\n') : '(none)'));
+    const logPre = el('pre', null, logs.length ? logs.join('\\n') : '(none)');
+    logSec.appendChild(logPre);
     ws.appendChild(logSec);
+    // Register the live LOGS <pre> so streamed log events update it surgically
+    // (issue #334) instead of re-rendering the whole serve workspace.
+    serveLogId = id;
+    serveLogPre = logPre;
   }
 
   // In-workspace HTTP request composer for a running serve (issue #322):
@@ -958,6 +975,9 @@ const STUDIO_SCRIPT = `
       btn.disabled = true;
       btn.textContent = 'Sending…';
       result.innerHTML = '';
+      // Sending a fresh request leaves no prior timeline row "selected" — the
+      // new request becomes the current focus (issue #336).
+      document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'));
       try {
         const payload = {
           targetId: id,
@@ -1383,6 +1403,14 @@ const STUDIO_SCRIPT = `
       reBtn.title = 'Start the serve to re-invoke this request.';
     }
     head.appendChild(reBtn);
+    // Back to the serve's request composer for a FRESH request (issue #335) —
+    // so the user does not have to re-select the target in the left pane after
+    // inspecting a timeline detail.
+    const newReqBtn = el('button', 'reinvoke-btn', 'New request');
+    newReqBtn.onclick = function () {
+      selectTarget(ev.target, ev.kind);
+    };
+    head.appendChild(newReqBtn);
     ws.appendChild(head);
 
     const reqSec = el('div', 'section');
@@ -1492,7 +1520,13 @@ const STUDIO_SCRIPT = `
       arr.push(ev.line);
       logsById.set(ev.containerId, arr);
       if (shownInvId === ev.containerId) renderResult(ev.containerId);
-      if (shownServeId === ev.containerId) renderServeWorkspace(ev.containerId);
+      // A serve's log lines stream continuously; a FULL re-render per line
+      // would wipe the in-progress request composer (its typed-in fields + the
+      // last response). Update only the live LOGS <pre> surgically instead
+      // (issue #334). A status change still re-renders via onServeEvent.
+      if (shownServeId === ev.containerId && serveLogId === ev.containerId && serveLogPre) {
+        serveLogPre.textContent = arr.join('\\n');
+      }
     });
   }
 

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -294,7 +294,15 @@ if ! grep -qF '.group-body .target:nth-child(2n) { background: #242424; }' "${BO
   echo "FAIL: GET / did not include the visual UX fixes (issues #333 / #338 / #339)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes"
+# Composer send-flow (issues #334 / #335 / #336): surgical serve-log update,
+# timeline deselect, and the New request back affordance.
+if ! grep -qF 'serveLogPre.textContent = arr.join(' "${BODY_FILE}" \
+  || ! grep -qF "el('button', 'reinvoke-btn', 'New request')" "${BODY_FILE}" \
+  || ! grep -qF "document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'))" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the composer send-flow fixes (issues #334 / #335 / #336)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -148,6 +148,26 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('.log-clear');
   });
 
+  it('preserves the serve composer across streamed log events (issue #334)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // A live LOGS <pre> ref is held and updated surgically on log events,
+    // instead of re-rendering the whole serve workspace (which wiped the
+    // composer inputs + the last response).
+    expect(html).toContain('serveLogPre');
+    expect(html).toContain('serveLogId');
+    expect(html).toContain('serveLogPre.textContent = arr.join(');
+    // The log handler no longer full-re-renders a shown serve.
+    expect(html).not.toContain('if (shownServeId === ev.containerId) renderServeWorkspace(ev.containerId)');
+  });
+
+  it('deselects the timeline and offers a back-to-composer affordance (issues #335 / #336)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // selectTarget + a fresh Send clear any stale `.row.sel`.
+    expect(html).toContain("document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'))");
+    // The captured-request detail offers a New request button back to the composer.
+    expect(html).toContain("el('button', 'reinvoke-btn', 'New request')");
+  });
+
   it('renders an in-workspace HTTP request composer for a running serve (issue #322)', () => {
     const html = renderStudioHtml('MyStack', 'cdkl');
     // The composer builder + its Send wiring to the same-origin relay.


### PR DESCRIPTION
## Summary

The middle-pane request composer for a running serve was rebuilt on every
streamed log line: a `log` SSE event called `renderServeWorkspace`, which
re-rendered the whole workspace and discarded the composer's typed-in
fields AND the last response shown inline. Hammering a served API made it
impossible to keep a request in the box or read its response.

## What changed (studio-ui)

- **Preserve the composer (issue 334)**: hold a reference to the live LOGS
  `<pre>` and update it SURGICALLY on log events instead of re-rendering
  the serve workspace. A status change still re-renders via `onServeEvent`.
  The Clear button is likewise surgical now. The composer fields + the
  inline response survive a stream of log lines.
- **Deselect stale timeline rows (issue 336)**: sending a request (and
  navigating to any composer) clears a stale `.row.sel`, so the
  highlighted timeline row always matches what the middle pane shows.
- **Back-to-composer affordance (issue 335)**: a captured serve-request
  detail gains a "New request" button that returns to that serve's
  composer without re-selecting the target in the left pane.

## Test plan

- Unit (`studio-ui.test.ts`): asserts the live-pre surgical-update wiring
  (and that the log handler no longer full-re-renders a shown serve), the
  `.row.sel` deselect, and the New request button.
- Integration (`local-studio`): the `GET /` UI assertion now greps the
  served page for all three. Full local-studio integ green, 0 Docker
  orphans.

Closes #334
Closes #335
Closes #336
