### PR TITLE
feat(studio): KV / JSON toggle for the request composer's Headers

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -155,6 +155,7 @@ const STUDIO_CSS = `
     background: #111; color: #ddd; border: 1px solid #333; border-radius: 3px; padding: 5px;
     font: 12px/1.5 ui-monospace, Menlo, monospace; margin-bottom: 6px; }
   .req-composer .req-body { min-height: 70px; }
+  .req-composer .hdr-editor { margin-bottom: 8px; }
   .req-composer select:focus, .req-composer input:focus, .req-composer textarea:focus {
     outline: none; border-color: #4ec97a; }
   .req-composer .req-send { display: flex; align-items: center; gap: 10px; }
@@ -888,15 +889,116 @@ const STUDIO_SCRIPT = `
   // proxy and lands on the timeline.
   const REQ_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
 
-  function parseHeaderLines(text) {
-    const out = {};
-    String(text || '').split('\\n').forEach(function (line) {
-      const i = line.indexOf(':');
-      if (i <= 0) return;
-      const k = line.slice(0, i).trim();
-      if (k) out[k] = line.slice(i + 1).trim();
-    });
-    return out;
+  // Headers editor with a KV / JSON toggle (issue #337), mirroring the Lambda
+  // env-vars control. Returns { node, collect, prefill, jsonError }. KV mode is
+  // add-row Name/value pairs; JSON mode is a raw JSON object of string values.
+  // collect() yields a flat { Name: value } object; an invalid JSON object
+  // surfaces via jsonError() so the Send handler can refuse rather than silently
+  // drop the headers.
+  function buildHeaderEditor() {
+    const wrap = el('div', 'hdr-editor');
+    const modes = el('div', 'envkv-modes');
+    const kvBtn = el('button', 'envkv-mode active', 'KV');
+    kvBtn.type = 'button';
+    const jsonBtn = el('button', 'envkv-mode', 'JSON');
+    jsonBtn.type = 'button';
+    modes.appendChild(kvBtn);
+    modes.appendChild(jsonBtn);
+    wrap.appendChild(modes);
+
+    const list = el('div', 'pair-rows');
+    const pairs = [];
+    function addRow(name, value) {
+      const r = el('div', 'pair-row');
+      const lv = el('input', 'pair-in');
+      lv.placeholder = 'Header';
+      lv.value = name || '';
+      const rv = el('input', 'pair-in');
+      rv.placeholder = 'value';
+      rv.value = value || '';
+      const pair = { l: lv, r: rv };
+      const x = el('button', 'pair-x', 'x');
+      x.type = 'button';
+      x.onclick = function () {
+        list.removeChild(r);
+        const i = pairs.indexOf(pair);
+        if (i >= 0) pairs.splice(i, 1);
+      };
+      r.appendChild(lv);
+      r.appendChild(el('span', 'pair-sep', ':'));
+      r.appendChild(rv);
+      r.appendChild(x);
+      list.appendChild(r);
+      pairs.push(pair);
+    }
+    const add = el('button', 'pair-add', '+ add');
+    add.type = 'button';
+    add.onclick = function () { addRow(); };
+    const kvPane = el('div', 'pair-wrap');
+    kvPane.appendChild(list);
+    kvPane.appendChild(add);
+    wrap.appendChild(kvPane);
+
+    const ta = el('textarea', 'envkv-ta');
+    ta.placeholder = '{ "Authorization": "Bearer demo" }';
+    ta.spellcheck = false;
+    ta.style.display = 'none';
+    wrap.appendChild(ta);
+
+    let mode = 'kv';
+    kvBtn.onclick = function () {
+      mode = 'kv';
+      kvBtn.className = 'envkv-mode active';
+      jsonBtn.className = 'envkv-mode';
+      kvPane.style.display = '';
+      ta.style.display = 'none';
+    };
+    jsonBtn.onclick = function () {
+      mode = 'json';
+      jsonBtn.className = 'envkv-mode active';
+      kvBtn.className = 'envkv-mode';
+      ta.style.display = '';
+      kvPane.style.display = 'none';
+    };
+
+    function parseJson() {
+      const t = ta.value.trim();
+      if (t === '') return { ok: true, value: {} };
+      try {
+        const o = JSON.parse(t);
+        if (!o || typeof o !== 'object' || Array.isArray(o)) {
+          return { ok: false, error: 'Headers JSON must be an object of string values.' };
+        }
+        const out = {};
+        Object.keys(o).forEach(function (k) { out[k] = String(o[k]); });
+        return { ok: true, value: out };
+      } catch (e) {
+        return { ok: false, error: 'Invalid headers JSON: ' + e.message };
+      }
+    }
+
+    return {
+      node: wrap,
+      collect: function () {
+        if (mode === 'json') {
+          const p = parseJson();
+          return p.ok ? p.value : {};
+        }
+        const out = {};
+        pairs.forEach(function (p) {
+          const k = p.l.value.trim();
+          if (k) out[k] = p.r.value;
+        });
+        return out;
+      },
+      jsonError: function () {
+        return mode === 'json' ? (parseJson().ok ? null : parseJson().error) : null;
+      },
+      prefill: function (headersObj) {
+        if (!headersObj || typeof headersObj !== 'object') return;
+        Object.keys(headersObj).forEach(function (k) { addRow(k, String(headersObj[k])); });
+      },
+    };
   }
 
   function renderRequestComposer(id, baseUrl, captured) {
@@ -916,11 +1018,9 @@ const STUDIO_SCRIPT = `
     row.appendChild(path);
     sec.appendChild(row);
 
-    sec.appendChild(el('div', 'opt-label', 'Headers (one per line: Name: value)'));
-    const headers = el('textarea', 'req-headers');
-    headers.placeholder = 'Authorization: Bearer demo';
-    headers.spellcheck = false;
-    sec.appendChild(headers);
+    sec.appendChild(el('div', 'opt-label', 'Headers'));
+    const headerEditor = buildHeaderEditor();
+    sec.appendChild(headerEditor.node);
 
     sec.appendChild(el('div', 'opt-label', 'Body'));
     const bodyTa = el('textarea', 'req-body');
@@ -945,10 +1045,11 @@ const STUDIO_SCRIPT = `
           // (host / content-length / etc.) — they are noise in the editor and
           // the relay sets them itself.
           const SKIP = ['host', 'connection', 'content-length', 'transfer-encoding', 'accept-encoding'];
-          headers.value = Object.keys(pf.headers)
-            .filter(function (k) { return SKIP.indexOf(k.toLowerCase()) === -1; })
-            .map(function (k) { return k + ': ' + pf.headers[k]; })
-            .join('\\n');
+          const seed = {};
+          Object.keys(pf.headers).forEach(function (k) {
+            if (SKIP.indexOf(k.toLowerCase()) === -1) seed[k] = pf.headers[k];
+          });
+          headerEditor.prefill(seed);
         }
         if (pf.body != null) {
           bodyTa.value = typeof pf.body === 'string' ? pf.body : JSON.stringify(pf.body);
@@ -972,6 +1073,13 @@ const STUDIO_SCRIPT = `
 
     btn.onclick = async function () {
       msg.textContent = '';
+      // Refuse a send on a malformed Headers JSON rather than silently dropping
+      // the headers (issue #337).
+      const hdrErr = headerEditor.jsonError();
+      if (hdrErr) {
+        msg.textContent = hdrErr;
+        return;
+      }
       btn.disabled = true;
       btn.textContent = 'Sending…';
       result.innerHTML = '';
@@ -983,7 +1091,7 @@ const STUDIO_SCRIPT = `
           targetId: id,
           method: method.value,
           path: path.value || '/',
-          headers: parseHeaderLines(headers.value),
+          headers: headerEditor.collect(),
         };
         if (bodyTa.value !== '') payload.body = bodyTa.value;
         const res = await fetch('/api/request', {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -302,7 +302,14 @@ if ! grep -qF 'serveLogPre.textContent = arr.join(' "${BODY_FILE}" \
   echo "FAIL: GET / did not include the composer send-flow fixes (issues #334 / #335 / #336)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes"
+# Headers KV / JSON editor (issue #337): the request composer's Headers field
+# is the KV/JSON editor, not a one-per-line textarea.
+if ! grep -qF 'function buildHeaderEditor()' "${BODY_FILE}" \
+  || ! grep -qF 'headers: headerEditor.collect()' "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the headers KV/JSON editor (issue #337)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -210,6 +210,17 @@ describe('renderStudioHtml', () => {
     expect(html).toContain("el('button', 'reinvoke-btn', 'Re-invoke')");
   });
 
+  it('renders a KV / JSON headers editor in the request composer (issue #337)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The editor builder + its KV/JSON modes + the collect/jsonError wiring.
+    expect(html).toContain('function buildHeaderEditor()');
+    expect(html).toContain('const headerEditor = buildHeaderEditor()');
+    expect(html).toContain('headers: headerEditor.collect()');
+    expect(html).toContain('headerEditor.jsonError()');
+    // The old one-per-line textarea label is gone.
+    expect(html).not.toContain('Headers (one per line: Name: value)');
+  });
+
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {
     const html = renderStudioHtml('<script>alert(1)</script>', '"&<>');
     // The raw markup must never appear verbatim in the document.


### PR DESCRIPTION
## Summary

The serve request composer's Headers field was a plain one-per-line
textarea. Replace it with the same KV / JSON editor the Lambda env-vars
control uses (issue 337).

## What changed (studio-ui)

- New `buildHeaderEditor()`: a KV / JSON mode toggle. KV mode is add-row
  Name/value pairs; JSON mode is a raw object of string values, toggled in
  place. `collect()` yields a flat `{ Name: value }` object.
- A malformed Headers JSON now refuses the Send with an inline error
  (`jsonError()`) instead of silently dropping the headers.
- The issue 284 re-invoke prefill seeds the KV rows (still filtering the
  hop-by-hop / transport headers the proxy captured verbatim).

## Test plan

- Unit (`studio-ui.test.ts`): asserts the served HTML carries the
  `buildHeaderEditor` builder, the `collect()` / `jsonError()` wiring, and
  that the old one-per-line label is gone.
- Integration (`local-studio`): the `GET /` UI assertion greps the served
  page for the editor; the existing request-relay assertion still sends a
  real request through the composer (default empty headers). Full
  local-studio integ green, 0 Docker orphans.

Closes #337
