### PR TITLE
fix(studio): give --assume-role a checkbox so the Session bar is symmetric

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -1693,7 +1693,13 @@ const STUDIO_SCRIPT = `
       cfn.checked = on;
       cfnName.value = typeof c.fromCfnStack === 'string' ? c.fromCfnStack : '';
       cfnName.style.display = on ? '' : 'none';
+      // assume-role is now checkbox-gated, symmetric with from-cfn-stack
+      // (issue #343): the ARN input appears only when the box is checked.
+      const roleOn = document.getElementById('sess-role-on');
+      const roleBound = !!c.assumeRole;
+      roleOn.checked = roleBound;
       role.value = c.assumeRole || '';
+      role.style.display = roleBound ? '' : 'none';
       document.getElementById('sess-watch').checked = c.watch === true;
       const s = c.synth || {};
       const parts = [];
@@ -1713,10 +1719,12 @@ const STUDIO_SCRIPT = `
     const cfn = document.getElementById('sess-cfn');
     const cfnName = document.getElementById('sess-cfn-name');
     const role = document.getElementById('sess-role');
+    const roleOn = document.getElementById('sess-role-on');
     const msg = document.getElementById('sess-msg');
     const body = {
       fromCfnStack: cfn.checked ? cfnName.value.trim() || true : null,
-      assumeRole: role.value.trim() || null,
+      // assume-role is explicit-ARN-only: checked + empty is simply not bound.
+      assumeRole: roleOn.checked ? role.value.trim() || null : null,
       watch: document.getElementById('sess-watch').checked,
     };
     try {
@@ -1748,9 +1756,17 @@ const STUDIO_SCRIPT = `
       if (cfn.checked) cfnName.focus();
       applyConfig();
     });
+    // assume-role toggle: show/hide the ARN input AND apply immediately
+    // (issue #343), mirroring the from-cfn-stack toggle above.
+    const roleOn = document.getElementById('sess-role-on');
+    roleOn.addEventListener('change', function () {
+      role.style.display = roleOn.checked ? '' : 'none';
+      if (roleOn.checked) role.focus();
+      applyConfig();
+    });
     // Text inputs apply on change (blur / Enter), not on every keystroke.
     cfnName.addEventListener('change', function () { if (cfn.checked) applyConfig(); });
-    role.addEventListener('change', applyConfig);
+    role.addEventListener('change', function () { if (roleOn.checked) applyConfig(); });
     document.getElementById('sess-watch').addEventListener('change', applyConfig);
   }
 
@@ -1805,8 +1821,8 @@ export function renderStudioHtml(appLabel: string, cliName: string): string {
   <label class="sess-bind"><input type="checkbox" id="sess-watch" /> watch</label>
   <label class="sess-bind"><input type="checkbox" id="sess-cfn" /> from-cfn-stack</label>
   <input id="sess-cfn-name" type="text" placeholder="stack name (blank = auto)" style="display:none" />
-  <label class="sess-bind" for="sess-role">assume-role</label>
-  <input id="sess-role" type="text" placeholder="arn:aws:iam::…:role/…" />
+  <label class="sess-bind"><input type="checkbox" id="sess-role-on" /> assume-role</label>
+  <input id="sess-role" type="text" placeholder="arn:aws:iam::…:role/…" style="display:none" />
   <span id="sess-msg"></span>
   <span id="sess-synth" class="sess-synth"></span>
 </div>

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -309,7 +309,14 @@ if ! grep -qF 'function buildHeaderEditor()' "${BODY_FILE}" \
   echo "FAIL: GET / did not include the headers KV/JSON editor (issue #337)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor"
+# Session-bar symmetry (issue #343): assume-role is checkbox-gated like
+# from-cfn-stack.
+if ! grep -qF 'id="sess-role-on"' "${BODY_FILE}" \
+  || ! grep -qF 'assumeRole: roleOn.checked ?' "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the assume-role checkbox (issue #343)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor + session-bar symmetry"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -117,8 +117,18 @@ describe('renderStudioHtml', () => {
     expect(html).not.toContain('id="sess-save"');
     expect(html).toContain('function applyConfig');
     // The controls wire their change events to apply immediately.
-    expect(html).toContain("role.addEventListener('change', applyConfig)");
     expect(html).toContain("document.getElementById('sess-watch').addEventListener('change', applyConfig)");
+  });
+
+  it('gives --assume-role a checkbox so the Session bar bindings are symmetric (issue #343)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // assume-role is now checkbox-gated like from-cfn-stack.
+    expect(html).toContain('id="sess-role-on"');
+    // Its ARN input is hidden until the box is checked.
+    expect(html).toContain('id="sess-role" type="text" placeholder="arn:aws:iam::…:role/…" style="display:none"');
+    // The binding reads the checkbox + reveals/hides the input on toggle.
+    expect(html).toContain('assumeRole: roleOn.checked ? role.value.trim() || null : null');
+    expect(html).toContain("role.style.display = roleOn.checked ? '' : 'none'");
   });
 
   it('renders the collapsible / zebra / filterable target pane (issue #301)', () => {


### PR DESCRIPTION
## Summary

The Session bar's two run-time bindings behaved differently:
`--from-cfn-stack` had a checkbox and hid its text box until checked,
while `--assume-role` had no checkbox and always showed its input. At
boot the from-cfn-stack field was invisible while assume-role was not — a
confusing asymmetry (issue 343).

## What changed (studio-ui)

- `--assume-role` gains a checkbox (`sess-role-on`); its ARN input appears
  only when the box is checked, mirroring `--from-cfn-stack`.
- `--assume-role` in studio is explicit-ARN-only (no bare/auto form), so a
  checked-but-empty assume-role is simply not bound. The server
  `applyConfigPatch` contract is unchanged (`assumeRole` stays
  `string | null`).

## Test plan

- Unit (`studio-ui.test.ts`): asserts the served HTML carries the
  `sess-role-on` checkbox, the hidden ARN input, and the checkbox-gated
  read + show/hide wiring.
- Integration (`local-studio`): the `GET /` UI assertion greps the served
  page for the checkbox + the gated read. Full local-studio integ green,
  0 Docker orphans.

Closes #343
