### PR TITLE
fix(studio): survive stray errors + remember the Headers editor mode

### DIFF
--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -629,7 +629,47 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     openBrowser(server.url);
   }
 
-  await blockUntilShutdown(server, serveManager, store, cliName);
+  // Keep the control plane alive across a stray error (issue #346): a single
+  // unhandled rejection / exception anywhere in the long-running studio process
+  // would otherwise crash it, after which the browser sees "Failed to fetch"
+  // and Stop / teardown stop responding. Log loudly and continue. Installed
+  // only now that the server is listening, so genuine startup / bind errors
+  // still propagate; removed on shutdown so it never leaks (e.g. for a host
+  // CLI embedding studio).
+  const uninstallGuard = installStudioResilienceGuard(logger);
+  try {
+    await blockUntilShutdown(server, serveManager, store, cliName);
+  } finally {
+    uninstallGuard();
+  }
+}
+
+/**
+ * Install process-level `uncaughtException` / `unhandledRejection` handlers
+ * that LOG and continue (instead of crashing the studio process), returning an
+ * uninstaller. studio is a long-running local dev control plane — a stray error
+ * from one bad request must not take down the whole console (issue #346). This
+ * also backstops the Ctrl-C SSE-socket-destroy race the streaming handler works
+ * around. Genuine fatal conditions are still visible in the log. Exported for
+ * unit testing; not a host-facing library API (not re-exported from
+ * `src/index.ts` / `src/internal.ts`).
+ */
+export function installStudioResilienceGuard(logger: ReturnType<typeof getLogger>): () => void {
+  const describe = (e: unknown): string => (e instanceof Error ? e.stack || e.message : String(e));
+  const onUncaught = (err: unknown): void => {
+    logger.warn(`studio caught an unexpected error and is continuing: ${describe(err)}`);
+  };
+  const onRejection = (reason: unknown): void => {
+    logger.warn(
+      `studio caught an unhandled promise rejection and is continuing: ${describe(reason)}`
+    );
+  };
+  process.on('uncaughtException', onUncaught);
+  process.on('unhandledRejection', onRejection);
+  return (): void => {
+    process.off('uncaughtException', onUncaught);
+    process.off('unhandledRejection', onRejection);
+  };
 }
 
 /** Best-effort cross-platform browser open. Failures are non-fatal. */

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -261,6 +261,7 @@ const STUDIO_SCRIPT = `
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event
   const logsById = new Map();      // invocationId / serve targetId -> [log lines]
+  let lastHeaderMode = 'kv';       // remember the request-composer Headers editor mode (issue #345)
   let serveLogId = null;           // serve target whose LOGS <pre> is live (issue #334)
   let serveLogPre = null;          // the live serve LOGS <pre>, updated surgically on log events
   const targetEls = new Map();     // targetId -> left-pane element
@@ -946,20 +947,27 @@ const STUDIO_SCRIPT = `
     wrap.appendChild(ta);
 
     let mode = 'kv';
-    kvBtn.onclick = function () {
-      mode = 'kv';
-      kvBtn.className = 'envkv-mode active';
-      jsonBtn.className = 'envkv-mode';
-      kvPane.style.display = '';
-      ta.style.display = 'none';
-    };
-    jsonBtn.onclick = function () {
-      mode = 'json';
-      jsonBtn.className = 'envkv-mode active';
-      kvBtn.className = 'envkv-mode';
-      ta.style.display = '';
-      kvPane.style.display = 'none';
-    };
+    // Switch mode + remember it session-wide so a later composer (incl.
+    // re-invoke) opens in the SAME mode instead of snapping back to KV
+    // (issue #345).
+    function setMode(m) {
+      mode = m;
+      lastHeaderMode = m;
+      if (m === 'json') {
+        jsonBtn.className = 'envkv-mode active';
+        kvBtn.className = 'envkv-mode';
+        ta.style.display = '';
+        kvPane.style.display = 'none';
+      } else {
+        kvBtn.className = 'envkv-mode active';
+        jsonBtn.className = 'envkv-mode';
+        kvPane.style.display = '';
+        ta.style.display = 'none';
+      }
+    }
+    kvBtn.onclick = function () { setMode('kv'); };
+    jsonBtn.onclick = function () { setMode('json'); };
+    setMode(lastHeaderMode);
 
     function parseJson() {
       const t = ta.value.trim();
@@ -997,6 +1005,9 @@ const STUDIO_SCRIPT = `
       prefill: function (headersObj) {
         if (!headersObj || typeof headersObj !== 'object') return;
         Object.keys(headersObj).forEach(function (k) { addRow(k, String(headersObj[k])); });
+        // Seed the JSON pane too so the data shows in whichever mode is active
+        // (issue #345) — a re-invoke opens in the user's last-used mode.
+        ta.value = JSON.stringify(headersObj, null, 2);
       },
     };
   }

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -316,7 +316,14 @@ if ! grep -qF 'id="sess-role-on"' "${BODY_FILE}" \
   echo "FAIL: GET / did not include the assume-role checkbox (issue #343)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor + session-bar symmetry"
+# Headers editor remembers its mode (issue #345): the editor opens in the
+# last-used mode and the re-invoke prefill seeds the JSON pane too.
+if ! grep -qF 'let lastHeaderMode' "${BODY_FILE}" \
+  || ! grep -qF 'setMode(lastHeaderMode)' "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the remembered Headers editor mode (issue #345)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor + session-bar symmetry + remembered-header-mode"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, vi } from 'vite-plus/test';
 import {
   applyConfigPatch,
   coerceRunRequest,
@@ -10,6 +10,7 @@ import {
   coerceReinvokeRequest,
   resolveServeBaseUrl,
   createLocalStudioCommand,
+  installStudioResilienceGuard,
   parseStudioPort,
   resolveBootAssemblyDir,
   type EditableSessionBindings,
@@ -376,6 +377,38 @@ describe('coerceReinvokeRequest (issue #284)', () => {
 
   it('rejects when the payload key is absent (vs an explicit null)', () => {
     expect(() => coerceReinvokeRequest({ invocationId: 'src-1' })).toThrow(/must include a "payload"/);
+  });
+});
+
+describe('installStudioResilienceGuard (issue #346)', () => {
+  const fakeLogger = (): { warn: ReturnType<typeof vi.fn> } => ({ warn: vi.fn() });
+
+  it('installs + removes uncaughtException / unhandledRejection listeners', () => {
+    const before = {
+      ue: process.listenerCount('uncaughtException'),
+      ur: process.listenerCount('unhandledRejection'),
+    };
+    const uninstall = installStudioResilienceGuard(fakeLogger() as never);
+    expect(process.listenerCount('uncaughtException')).toBe(before.ue + 1);
+    expect(process.listenerCount('unhandledRejection')).toBe(before.ur + 1);
+    uninstall();
+    expect(process.listenerCount('uncaughtException')).toBe(before.ue);
+    expect(process.listenerCount('unhandledRejection')).toBe(before.ur);
+  });
+
+  it('logs (and does not rethrow) when its listener handles an error', () => {
+    const logger = fakeLogger();
+    const uninstall = installStudioResilienceGuard(logger as never);
+    try {
+      // Invoke the just-installed listener DIRECTLY (not via process.emit, which
+      // could disturb the test runner) with an Error.
+      const listener = process.listeners('uncaughtException').at(-1) as (e: unknown) => void;
+      expect(() => listener(new Error('boom'))).not.toThrow();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn.mock.calls[0][0]).toMatch(/studio caught an unexpected error.*boom/s);
+    } finally {
+      uninstall();
+    }
   });
 });
 

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -231,6 +231,16 @@ describe('renderStudioHtml', () => {
     expect(html).not.toContain('Headers (one per line: Name: value)');
   });
 
+  it('remembers the last-used Headers editor mode across composers (issue #345)', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // The editor opens in the remembered mode + records the mode on toggle.
+    expect(html).toContain('let lastHeaderMode');
+    expect(html).toContain('lastHeaderMode = m;');
+    expect(html).toContain('setMode(lastHeaderMode)');
+    // Re-invoke prefill seeds the JSON pane too, so the data shows in either mode.
+    expect(html).toContain('ta.value = JSON.stringify(headersObj');
+  });
+
   it('HTML-escapes the interpolated app label and CLI name (no injection)', () => {
     const html = renderStudioHtml('<script>alert(1)</script>', '"&<>');
     // The raw markup must never appear verbatim in the document.


### PR DESCRIPTION
## Summary

Two fixes surfaced while testing the API request composer.

## Resilience guard (issue 346)

`cdkl studio` had no top-level `uncaughtException` / `unhandledRejection`
handler, so a single stray rejection anywhere in the long-running process
crashed the whole control plane — after which the browser saw "Failed to
fetch" and Stop / teardown stopped responding.

Install process-level handlers while the server is running that LOG at
WARN and continue (removed on shutdown so they never leak; installed only
once listening so genuine bind errors still propagate). This also
backstops the Ctrl-C SSE-socket-destroy race the streaming handler works
around.

## Remember the Headers editor mode (issue 345)

The request composer's Headers KV/JSON toggle defaulted to KV on every
render, so re-invoking a request entered in JSON mode snapped back to KV
(values preserved, but a confusing mode switch). Remember the last-used
mode session-wide and open new composers (incl. re-invoke) in that mode;
the re-invoke prefill seeds the JSON pane too so the data shows in either
mode.

## cdkd parity

`installStudioResilienceGuard` is exported from `local-studio.ts` for
unit testing only — NOT a host-facing library API (not re-exported from
`src/index.ts` / `src/internal.ts`). The behavior change (studio no
longer crashes on a stray error) is additive robustness.

## Test plan

- Unit: the guard installs + removes its process listeners and its
  listener logs (and does not rethrow); the Headers editor opens in the
  remembered mode + seeds the JSON pane on prefill.
- Live: confirmed an unhandledRejection handler keeps the Node process
  alive (the mechanism the guard relies on).
- Integration (`local-studio`): the `GET /` UI assertion greps the served
  page for the remembered-mode wiring. Full local-studio integ green, 0
  Docker orphans.

Closes #345
Closes #346
