### PR TITLE
fix(start-alb): auto-remap privileged listener ports instead of crashing

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -2031,16 +2031,41 @@ export async function buildFrontDoor(
       // user whose request missed on (say) the Host header sees every rule's
       // condition + action target, not just the request path (issue #228).
       const rulesSummary: FrontDoorRuleSummary[] = listener.rules.map(buildRuleSummary);
-      const server = await startFrontDoorServer({
+      const fdBase = {
         route,
-        port: listener.hostPort,
         host: containerHost,
         listenerPort: listener.listenerPort,
         label: `listener port ${listener.listenerPort}`,
         forwardedProto,
         rulesSummary,
         ...(tls ? { tls } : {}),
-      });
+      };
+      let server: StartedFrontDoorServer;
+      try {
+        server = await startFrontDoorServer({ ...fdBase, port: listener.hostPort });
+      } catch (bindErr) {
+        // A privileged listener port (< 1024, e.g. 80 / 443) cannot be bound
+        // without root. Rather than crash the whole front-door, fall back to an
+        // OS-assigned high host port and log the remap so the serve still comes
+        // up (issue #351). An explicit `--lb-port` override still wins (its
+        // remapped hostPort is what we tried first). Without this, every ALB on
+        // 80 / 443 was un-startable from `cdkl studio`, which surfaced only a
+        // cryptic "Server exited before listening (code 1)".
+        const code =
+          bindErr && typeof bindErr === 'object' && 'code' in bindErr
+            ? (bindErr as { code?: unknown }).code
+            : undefined;
+        if (code === 'EACCES' && listener.hostPort < 1024) {
+          server = await startFrontDoorServer({ ...fdBase, port: 0 });
+          logger.warn(
+            `  WARN: listener port ${listener.listenerPort} is privileged (< 1024) and cannot be ` +
+              `bound without root; serving it on host port ${server.port} instead. Pass ` +
+              `--lb-port ${listener.listenerPort}=<hostPort> to pin a fixed port.`
+          );
+        } else {
+          throw bindErr;
+        }
+      }
       servers.push(server);
 
       logger.info(

--- a/tests/integration/local-start-alb/verify.sh
+++ b/tests/integration/local-start-alb/verify.sh
@@ -54,7 +54,55 @@ if [[ ! -d node_modules ]]; then
 fi
 
 OUT_FILE=$(mktemp)
-trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+NOLB_OUT=$(mktemp)
+trap 'rm -f "${OUT_FILE}" "${NOLB_OUT}"; cleanup' EXIT
+
+# ---------------------------------------------------------------------------
+# Issue #351: start-alb WITHOUT --lb-port. The ALB's deployed listeners are on
+# 80 / 443 (privileged); rather than crash with EACCES, the front-door must
+# auto-remap each to an OS-assigned high host port + log a WARN, and still
+# serve. (Without this fix, an ALB on 80/443 was un-startable — which is what
+# broke `cdkl studio` Start on an ALB.)
+# ---------------------------------------------------------------------------
+echo "==> start-alb WITHOUT --lb-port: privileged 80/443 auto-remap to high host ports (issue #351)"
+${CDKL} start-alb CdkLocalStartAlbFixture:WebLB --container-host 127.0.0.1 > "${NOLB_OUT}" 2>&1 &
+NOLB_PID=$!
+NOLB_OK=0
+for _ in $(seq 1 90); do
+  if grep -q "Service(s) running:" "${NOLB_OUT}" 2>/dev/null && grep -q "ALB front-door:" "${NOLB_OUT}" 2>/dev/null; then
+    NOLB_OK=1; break
+  fi
+  if ! kill -0 "${NOLB_PID}" 2>/dev/null; then
+    echo "FAIL: start-alb without --lb-port exited (EACCES fallback should keep it running)"
+    echo "----- output -----"; cat "${NOLB_OUT}"; echo "------------------"; exit 1
+  fi
+  sleep 1
+done
+if [[ "${NOLB_OK}" -ne 1 ]]; then
+  echo "FAIL: start-alb without --lb-port did not come up within 90s"; cat "${NOLB_OUT}"; exit 1
+fi
+# The privileged-port auto-remap WARN must fire for listener 80.
+if ! grep -qE "listener port 80 is privileged .* serving it on host port [0-9]+ instead" "${NOLB_OUT}"; then
+  echo "FAIL: no privileged-port auto-remap WARN for listener 80 (issue #351)"; cat "${NOLB_OUT}"; exit 1
+fi
+# Parse the auto-assigned host port for listener 80 from its front-door banner + curl it.
+NOLB_PORT=$(grep -E "ALB front-door: http://127.0.0.1:[0-9]+ \(listener port 80\)" "${NOLB_OUT}" \
+  | grep -oE "127.0.0.1:[0-9]+" | grep -oE "[0-9]+$" | head -1)
+if [[ -z "${NOLB_PORT}" ]]; then
+  echo "FAIL: could not parse the auto-remapped host port for listener 80"; cat "${NOLB_OUT}"; exit 1
+fi
+NOLB_READY=0
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:${NOLB_PORT}/" >/dev/null 2>&1; then NOLB_READY=1; break; fi
+  kill -0 "${NOLB_PID}" 2>/dev/null || break
+  sleep 1
+done
+if [[ "${NOLB_READY}" -ne 1 ]]; then
+  echo "FAIL: auto-remapped front-door (port ${NOLB_PORT}) never served 200"; cat "${NOLB_OUT}"; exit 1
+fi
+echo "    OK: privileged 80 auto-remapped to ${NOLB_PORT} + serving (no --lb-port needed)"
+kill -INT "${NOLB_PID}" 2>/dev/null; wait "${NOLB_PID}" 2>/dev/null || true
+cleanup
 
 echo "==> start-alb: naming the ALB (DesiredCount=2 backing service); HTTP:80 -> :${LB_HOST_PORT}, HTTPS:443 -> :${LB_HOST_PORT_HTTPS}"
 # Remap both privileged listener ports (80 / 443) to non-privileged host ports


### PR DESCRIPTION
fix(start-alb): auto-remap privileged listener ports instead of crashing

start-alb binds the ALB's DEPLOYED listener ports directly. Most ALBs
listen on 80 / 443 (privileged, < 1024), which a non-root process cannot
bind, so the front-door crashed with `listen EACCES`. From `cdkl studio`
this surfaced only as a cryptic "Server exited before listening (code 1)",
making nearly every real ALB un-startable from the UI.

On EACCES binding a privileged listener port, fall back to an OS-assigned
high host port + log a WARN (instead of crashing). An explicit --lb-port
override still wins. studio's capture proxy fronts whatever port the
front-door reports, so the UI keeps working transparently.

## Behavior change

`cdkl start-alb` no longer errors when an ALB listens on a privileged port
without a --lb-port remap — it auto-remaps to a high host port and logs
the chosen port. This is additive robustness (the previous behavior was a
hard crash); a host CLI embedding the serve path inherits it.

## Test plan

- Integration (local-start-alb): a new case boots start-alb WITHOUT
  --lb-port (privileged 80/443), asserts the auto-remap WARN fires for
  listener 80, parses the auto-assigned host port from the front-door
  banner, and curls it for a 200. The existing --lb-port + round-robin +
  HTTPS-degradation case still passes. Full integ green, 0 Docker orphans.

Closes #351
