### PR TITLE
fix(studio): split ECS Services and Task Definitions into separate target groups

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -369,7 +369,10 @@ compute-locally category for Lambda + API Gateway).
   [Invoke] composer (`INVOKE_KINDS`), serve
   targets (api / alb / ecs) a [Start]/[Stop] control with a `running ●
   :port` indicator (ecs services show `running` with no port — only the
-  servable ECS *services* are runnable, not the task definitions); a served
+  servable ECS *services* are runnable, not the task definitions; issue
+  #352 lists ECS Services and ECS Task Definitions as SEPARATE target
+  groups, matching `cdkl list`, so the non-servable task defs no longer
+  share a group with the servable services); a served
   API Gateway WebSocket API additionally gets a WebSocket console
   (`renderWsConsole` — connect / send-frame / received-frame log) wired
   straight to its ws:// endpoint, with the socket + frame log held in module

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -66,15 +66,18 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
   return [
     { kind: 'lambda', title: 'Lambda Functions', entries: map(listing.lambdas) },
     { kind: 'api', title: 'APIs', entries: map(listing.apis) },
+    // ECS services and task definitions are SEPARATE groups (issue #352),
+    // matching `cdkl list`: services are servable (`start-service` -> Start),
+    // task definitions are single-shot (`run-task`). They were previously
+    // lumped into one "ECS Services / Tasks" group, which obscured that task
+    // definitions are not a serve target. The services group stays FIRST so
+    // `annotatePinnedEcsTargets` (which finds the first `ecs`-kind group)
+    // annotates the servable services.
+    { kind: 'ecs', title: 'ECS Services', entries: map(listing.ecsServices, { servable: true }) },
     {
       kind: 'ecs',
-      title: 'ECS Services / Tasks',
-      // ECS services are servable (`start-service`); task definitions are
-      // run-task (single-shot), not a serve target.
-      entries: [
-        ...map(listing.ecsServices, { servable: true }),
-        ...map(listing.ecsTaskDefinitions, { servable: false }),
-      ],
+      title: 'ECS Task Definitions',
+      entries: map(listing.ecsTaskDefinitions, { servable: false }),
     },
     { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
     { kind: 'alb', title: 'Load Balancers', entries: map(listing.loadBalancers) },

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -334,6 +334,8 @@ for needle in \
   '"kind":"lambda"' \
   '"kind":"api"' \
   '"kind":"ecs"' \
+  '"title":"ECS Services"' \
+  '"title":"ECS Task Definitions"' \
   '"kind":"agentcore"' \
   '"kind":"alb"' \
   'LocalStudioFixture/MyHandler'

--- a/tests/unit/local/studio-custom-resource-filter.test.ts
+++ b/tests/unit/local/studio-custom-resource-filter.test.ts
@@ -71,7 +71,7 @@ const groups = (): StudioTargetGroup[] => [
   },
   {
     kind: 'ecs',
-    title: 'ECS Services / Tasks',
+    title: 'ECS Services',
     entries: [lambda('MyStack/Service')],
   },
   {

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -178,7 +178,7 @@ describe('annotatePinnedEcsTargets', () => {
   const groups = (): StudioTargetGroup[] => [
     {
       kind: 'ecs',
-      title: 'ECS Services / Tasks',
+      title: 'ECS Services',
       entries: [
         { id: 'S/Pinned', qualifiedId: 'S:Pinned', servable: true },
         { id: 'S/Asset', qualifiedId: 'S:Asset', servable: true },
@@ -220,7 +220,7 @@ describe('annotatePinnedEcsTargets', () => {
 });
 
 describe('toStudioTargetGroups', () => {
-  it('projects a TargetListing into the five studio groups', () => {
+  it('projects a TargetListing into the studio groups', () => {
     const listing: TargetListing = {
       ...emptyListing(),
       lambdas: [{ qualifiedId: 'S:Fn', displayPath: 'S/Fn' }],
@@ -230,7 +230,17 @@ describe('toStudioTargetGroups', () => {
     };
     const groups = toStudioTargetGroups(listing);
 
-    expect(groups.map((g) => g.kind)).toEqual(['lambda', 'api', 'ecs', 'agentcore', 'alb']);
+    // ECS Services and Task Definitions are SEPARATE groups (issue #352), so
+    // there are now two `ecs`-kind groups (services first, then task defs).
+    expect(groups.map((g) => g.kind)).toEqual(['lambda', 'api', 'ecs', 'ecs', 'agentcore', 'alb']);
+    expect(groups.map((g) => g.title)).toEqual([
+      'Lambda Functions',
+      'APIs',
+      'ECS Services',
+      'ECS Task Definitions',
+      'AgentCore Runtimes',
+      'Load Balancers',
+    ]);
     expect(groups[0].entries).toEqual([{ id: 'S/Fn', qualifiedId: 'S:Fn' }]);
     // API surface kind is carried onto the entry.
     expect(groups[1].entries[0]).toEqual({
@@ -238,10 +248,12 @@ describe('toStudioTargetGroups', () => {
       qualifiedId: 'S:Api',
       surface: 'HTTP API v2',
     });
-    // ECS services and task definitions fold into the one `ecs` group, but
-    // only the SERVICE is servable (start-service); the task def is not.
-    expect(groups[2].entries.map((e) => e.id)).toEqual(['S:Svc', 'S:Task']);
-    expect(groups[2].entries.map((e) => e.servable)).toEqual([true, false]);
+    // The services group holds only the servable service; the task-definitions
+    // group holds only the non-servable task def.
+    expect(groups[2].entries.map((e) => e.id)).toEqual(['S:Svc']);
+    expect(groups[2].entries.map((e) => e.servable)).toEqual([true]);
+    expect(groups[3].entries.map((e) => e.id)).toEqual(['S:Task']);
+    expect(groups[3].entries.map((e) => e.servable)).toEqual([false]);
   });
 
   it('falls back to the qualified id when no display path exists', () => {
@@ -352,7 +364,7 @@ describe('startStudioServer', () => {
       targetGroups: [
         {
           kind: 'ecs',
-          title: 'ECS Services / Tasks',
+          title: 'ECS Services',
           entries: [{ id: 'S/Svc', qualifiedId: 'S:Svc', servable: true, pinned: true }],
         },
       ],


### PR DESCRIPTION
## Summary

The `cdkl studio` left-pane target list lumped ECS **services** and ECS
**task definitions** into a single "ECS Services / Tasks" group. That
obscured the core distinction: a service is a serve target (Start ->
`start-service`), a task definition is not. Users reported the
task-definition rows looking clickable/startable when they are not.

This splits `toStudioTargetGroups` into two `ecs`-kind groups — **ECS
Services** (servable) and **ECS Task Definitions** (non-servable) —
matching the `cdkl list` enumeration.

## Details

- The services group is listed FIRST so `annotatePinnedEcsTargets`
  (which annotates the servable services across every `ecs`-kind group)
  is unaffected.
- The UI already skips empty groups, so an app with only one of the two
  kinds shows no empty section.
- No behavior change to `start-service` / image-override / pinned
  flagging — purely a display grouping change.

## Test plan

- Unit: `toStudioTargetGroups` now asserts six groups with the two
  separate ECS titles + per-group servable flags; the
  `annotatePinnedEcsTargets` and custom-resource-filter fixtures
  updated to the new title.
- Integ (`local-studio`, real Docker): `/api/targets` now asserts both
  `"title":"ECS Services"` and `"title":"ECS Task Definitions"` are
  present; full suite green, 0 Docker orphans.

Closes #352
