### PR TITLE
fix(studio): hide custom-resource Lambdas with a generic Custom:: path

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -324,9 +324,11 @@ compute-locally category for Lambda + API Gateway).
   recognizes CDK custom-resource / provider-framework Lambdas by their
   construct path (provider-framework `framework-on*`, `LogRetention`,
   `BucketNotificationsHandler`, `AwsCustomResource`, CDK bucket
-  deployment, the `AWS679...` singleton, etc.) so `cdkl studio` hides
-  them from the target list by default — `--include-custom-resources`
-  opts back in),
+  deployment, the `AWS679...` singleton, plus a GENERIC `custom::`
+  catch-all — issue #359 — that covers any provider Lambda whose
+  `aws:cdk:path` uses a `Custom::`-prefixed node the name-specific
+  patterns miss) so `cdkl studio` hides them from the target list by
+  default — `--include-custom-resources` opts back in),
   studio-events (issue #282 — the typed in-process event bus every
   `cdkl studio` observation flows through (`invocation` / `log` /
   `serve` events); the studio HTTP server

--- a/src/local/studio-custom-resource-filter.ts
+++ b/src/local/studio-custom-resource-filter.ts
@@ -24,6 +24,14 @@ import type { StudioTarget, StudioTargetGroup } from './studio-server.js';
  *   `Custom::CDKBucketDeployment<hash>` — the shared substring covers both).
  * - `CDKMetadata` — the CDK metadata resource (not a Lambda, but cheap to
  *   exclude defensively if it ever surfaces as one).
+ * - `custom::` — the GENERIC catch-all (issue #359). `Custom::` is
+ *   CloudFormation's reserved prefix for custom-resource provider construct
+ *   ids, and CDK threads it into the `aws:cdk:path` of provider Lambdas it
+ *   generates (e.g. `Stack/Custom::FooProvider/Handler`). The name-specific
+ *   entries above are a whack-a-mole list that misses any provider whose node
+ *   name is not one of them; this substring covers the whole family. A user's
+ *   own application Lambda never carries `Custom::` in its construct path, so
+ *   the match is safe (and still opt-out via `--include-custom-resources`).
  */
 const CUSTOM_RESOURCE_PATTERNS: readonly string[] = [
   'framework-onevent',
@@ -37,6 +45,7 @@ const CUSTOM_RESOURCE_PATTERNS: readonly string[] = [
   'customresourceprovider',
   'cdkbucketdeployment',
   'cdkmetadata',
+  'custom::',
 ];
 
 /**

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -74,6 +74,20 @@ export class LocalStudioStack extends cdk.Stack {
       code: lambda.Code.fromInline('exports.handler = async () => ({});'),
     });
 
+    // A SECOND custom-resource Lambda whose CDK path uses a `Custom::`-prefixed
+    // provider node (issue #359). Its path is
+    // `.../Custom::AcmeWidgetProvider/Handler` — NOT matched by any
+    // name-specific pattern (`framework-*`, `/provider/`,
+    // `customresourceprovider`, ...), so it exercises the GENERIC `custom::`
+    // catch-all. Excluded by default, surfaced only under
+    // `--include-custom-resources`.
+    const genericCr = new Construct(this, 'Custom::AcmeWidgetProvider');
+    new lambda.Function(genericCr, 'Handler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline('exports.handler = async () => ({});'),
+    });
+
     // HTTP API v2 + a single Lambda-backed route.
     const httpApi = new apigwv2.CfnApi(this, 'MyHttpApi', {
       name: 'cdkl-studio-fixture-http-api',

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -136,9 +136,14 @@ if ! grep -qF 'framework-onEvent' "${BODY_FILE}"; then
   echo "FAIL: --include-custom-resources did NOT surface the provider Lambda"; cat "${BODY_FILE}"
   kill "${INC_PID}" 2>/dev/null || true; rm -f "${INC_LOG}"; exit 1
 fi
+# Issue #359: the generic `Custom::`-path provider Lambda is also surfaced.
+if ! grep -qF 'Custom::AcmeWidgetProvider' "${BODY_FILE}"; then
+  echo "FAIL: --include-custom-resources did NOT surface the generic Custom:: provider Lambda"; cat "${BODY_FILE}"
+  kill "${INC_PID}" 2>/dev/null || true; rm -f "${INC_LOG}"; exit 1
+fi
 kill "${INC_PID}" 2>/dev/null || true; wait "${INC_PID}" 2>/dev/null || true
 rm -f "${INC_LOG}"
-echo "    OK: --include-custom-resources surfaced the provider Lambda"
+echo "    OK: --include-custom-resources surfaced the provider Lambdas (framework-onEvent + generic Custom::)"
 
 # ---------------------------------------------------------------------------
 # 1c. Watch mode (issue #301): `cdkl studio --watch` spawns serves started from
@@ -355,7 +360,14 @@ if grep -qF 'framework-onEvent' "${BODY_FILE}"; then
   echo "FAIL: /api/targets included the custom-resource provider Lambda by default"
   cat "${BODY_FILE}"; exit 1
 fi
-echo "    OK: custom-resource provider Lambda excluded from the default target list"
+# Issue #359: the generic `Custom::`-path provider Lambda
+# (`.../Custom::AcmeWidgetProvider/Handler`, matched only by the `custom::`
+# catch-all) is likewise excluded by default.
+if grep -qF 'Custom::AcmeWidgetProvider' "${BODY_FILE}"; then
+  echo "FAIL: /api/targets included the generic Custom:: provider Lambda by default"
+  cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: custom-resource provider Lambdas (framework-onEvent + generic Custom::) excluded from the default target list"
 
 # ---------------------------------------------------------------------------
 # 5. GET /api/events opens a Server-Sent-Events stream.

--- a/tests/unit/local/studio-custom-resource-filter.test.ts
+++ b/tests/unit/local/studio-custom-resource-filter.test.ts
@@ -44,6 +44,19 @@ describe('isCustomResourceLambdaTarget', () => {
     expect(isCustomResourceLambdaTarget(lambda('MyStack/Provider/FRAMEWORK-ONEVENT'))).toBe(true);
   });
 
+  // Issue #359: the generic `Custom::` catch-all covers any provider Lambda
+  // whose construct path uses a `Custom::`-prefixed node that is NOT one of the
+  // name-specific patterns above. None of `framework-*`, `/provider/`,
+  // `logretention`, `customresourceprovider`, etc. is a substring of this id —
+  // only `custom::` matches it.
+  it.each([
+    'MyStack/Custom::MyWidget/Resource',
+    'MyStack/Custom::AcmeNotifier/Handler',
+    'MyStack/Custom::VpcRestrictDefaultSG/Resource',
+  ])('matches a generic Custom:: provider node: %s', (id) => {
+    expect(isCustomResourceLambdaTarget(lambda(id))).toBe(true);
+  });
+
   it('does NOT match a normal app Lambda', () => {
     expect(isCustomResourceLambdaTarget(lambda('MyStack/EchoHandler'))).toBe(false);
   });


### PR DESCRIPTION
## Summary

`cdkl studio` still surfaced some CDK custom-resource / provider-framework
Lambdas in the left-pane **TARGETS** list, shown with a `Custom::...`
construct path. `filterStudioCustomResources` (issue #323) matched a fixed
list of construct-name substrings, but that is a whack-a-mole list: any
provider Lambda whose `aws:cdk:path` uses a `Custom::`-prefixed node that is
NOT one of those exact names slipped through.

`target-lister` enumerates only `AWS::Lambda::Function` resources, so these
rows are genuinely backing Lambdas of a custom resource — not the user's own
application code — and should be hidden by default.

## Fix

Add a generic `custom::` substring to the custom-resource pattern list.
`Custom::` is CloudFormation's reserved prefix for custom-resource provider
construct ids, and CDK threads it into the `aws:cdk:path` of the provider
Lambdas it generates, so this one rule covers the whole family. A user's own
application Lambda never carries `Custom::` in its construct path, so the
match is safe (and still opt-out via `--include-custom-resources`).

## Test plan

- Unit: a new `it.each` proves a generic `Custom::FooProvider/Handler` path
  (matched by NO name-specific pattern) is classified as a custom resource,
  alongside the existing named cases + the negative app-Lambda cases.
- Integ (`local-studio`, real Docker): the fixture gains a second CR Lambda
  under a `Custom::AcmeWidgetProvider` construct; `/api/targets` asserts it is
  excluded by default AND surfaced under `--include-custom-resources`. Full
  suite green, 0 Docker orphans.

Closes #359
