### PR TITLE
fix(studio): show a "Started with" summary of a serve's launch options

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -374,7 +374,12 @@ compute-locally category for Lambda + API Gateway).
   servable ECS *services* are runnable, not the task definitions; issue
   #352 lists ECS Services and ECS Task Definitions as SEPARATE target
   groups, matching `cdkl list`, so the non-servable task defs no longer
-  share a group with the servable services); a served
+  share a group with the servable services). Once a serve is Started the
+  composer's per-run option inputs are replaced by the running view, so a
+  read-only "Started with" summary (issue #356 — `formatAppliedOptions`
+  over the `serveApplied` map recorded at Start) surfaces the launch
+  config the serve is running with (e.g. a chosen `--max-tasks` stays
+  visible instead of silently vanishing). A served
   API Gateway WebSocket API additionally gets a WebSocket console
   (`renderWsConsole` — connect / send-frame / received-frame log) wired
   straight to its ws:// endpoint, with the socket + frame log held in module

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -243,6 +243,8 @@ const STUDIO_CSS = `
   .flag-row { display: flex; gap: 8px; align-items: baseline; font-size: 11px; }
   .flag-name { color: #7bd88f; font-family: ui-monospace, Menlo, monospace; white-space: nowrap; }
   .flag-desc { color: #999; }
+  .started-list { display: flex; flex-direction: column; gap: 3px; margin-top: 4px; }
+  .started-flag { color: #7bd88f; font-family: ui-monospace, Menlo, monospace; font-size: 11px; white-space: pre-wrap; word-break: break-all; }
   .envkv-modes { display: flex; gap: 0; }
   .envkv-mode { background: #1a1a1a; color: #999; border: 1px solid #333; cursor: pointer;
     padding: 3px 12px; font: 11px ui-monospace, monospace; }
@@ -267,6 +269,11 @@ const STUDIO_SCRIPT = `
   const targetEls = new Map();     // targetId -> left-pane element
   const serveMeta = new Map();     // serve targetId -> { dot, btnSlot } row controls
   const serveState = new Map();    // serve targetId -> { status, endpoints }
+  // serve targetId -> the launch config it was last Started with (issue #356):
+  // { options, rawArgs, imageOverride }. Kept separate from serveState so the
+  // SSE-driven serveState rewrites (status / endpoints) never clobber it, and
+  // surfaced as a read-only "Started with" summary while the serve runs.
+  const serveApplied = new Map();
   let active = null;               // { id, kind, ta, btn, msg, result }
   let shownInvId = null;           // lambda invocation whose result is in the workspace
   let shownServeId = null;         // serve target whose workspace is shown
@@ -694,11 +701,53 @@ const STUDIO_SCRIPT = `
     }
   }
 
+  // Format the launch config a serve was Started with (issue #356) into a list
+  // of human-readable flag lines for the read-only "Started with" summary.
+  // applied.options is the per-run values object (flag -> value) where value is
+  // a boolean (checkbox), a string (scalar), or an array of left/right pairs
+  // (repeat-pair / env-kv). Unset / false / blank entries are omitted.
+  function formatAppliedOptions(applied) {
+    const lines = [];
+    const options = applied && applied.options;
+    if (options) {
+      Object.keys(options).forEach(function (flag) {
+        const val = options[flag];
+        if (val === true) {
+          lines.push(flag);
+        } else if (val === false || val == null) {
+          /* unset boolean / null — omit */
+        } else if (Array.isArray(val)) {
+          val.forEach(function (pair) {
+            const left = pair && pair.left != null ? String(pair.left).trim() : '';
+            const right = pair && pair.right != null ? String(pair.right).trim() : '';
+            if (left === '' && right === '') return;
+            lines.push(flag + ' ' + left + '=' + right);
+          });
+        } else {
+          const s = String(val).trim();
+          if (s !== '') lines.push(flag + ' ' + s);
+        }
+      });
+    }
+    if (applied && applied.imageOverride) {
+      lines.push('--image-override ' + applied.imageOverride);
+    }
+    if (applied && applied.rawArgs) {
+      const raw = String(applied.rawArgs).trim();
+      if (raw !== '') lines.push(raw);
+    }
+    return lines;
+  }
+
   async function startServe(id, options, rawArgs, imageOverride) {
     // The serve kind (api / alb / ecs) drives which headless command the
     // server spawns; it is recorded on the row when the target list loads.
     const meta = serveMeta.get(id);
     const kind = meta ? meta.kind : 'api';
+    // Remember what this serve was Started with so the running workspace can
+    // show a read-only "Started with" summary (issue #356) — the per-run
+    // option inputs are gone once the composer is replaced by the running view.
+    serveApplied.set(id, { options: options, rawArgs: rawArgs, imageOverride: imageOverride });
     serveState.set(id, { status: 'starting', endpoints: [] });
     updateServeRow(id);
     try {
@@ -790,6 +839,24 @@ const STUDIO_SCRIPT = `
       if (opt.node) ws.appendChild(opt.node);
       collectOpts = opt.collect;
       collectRaw = opt.collectRaw;
+    }
+
+    if (running || starting) {
+      // Issue #356: the per-run option inputs are gone once the composer is
+      // replaced by this running view, so surface what the serve was Started
+      // with as a read-only summary (so e.g. a chosen --max-tasks stays
+      // visible instead of silently vanishing after Start).
+      const lines = formatAppliedOptions(serveApplied.get(id));
+      const startedSec = el('div', 'section started-with');
+      startedSec.appendChild(el('h3', null, 'Started with'));
+      if (lines.length) {
+        const list = el('div', 'started-list');
+        lines.forEach(function (ln) { list.appendChild(el('code', 'started-flag', ln)); });
+        startedSec.appendChild(list);
+      } else {
+        startedSec.appendChild(el('div', 'opt-hint', '(defaults — no options set)'));
+      }
+      ws.appendChild(startedSec);
     }
 
     const isEcs = meta && meta.kind === 'ecs';

--- a/tests/unit/local/studio-ui-applied-opts.test.ts
+++ b/tests/unit/local/studio-ui-applied-opts.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+/**
+ * "Started with" applied-options summary (issue #356). After a serve is
+ * Started, the per-run option inputs are gone (the composer is replaced by the
+ * running view), so the launch config the user chose used to silently vanish —
+ * e.g. a chosen `--max-tasks` disappeared. The running workspace now renders a
+ * read-only "Started with" summary from `serveApplied` (recorded at Start).
+ *
+ * The harness evaluates the real embedded STUDIO_SCRIPT in jsdom; the epilogue
+ * exposes the inner formatter + serve maps + `renderServeWorkspace` so the
+ * formatting AND the DOM render can be driven directly.
+ */
+const EXPOSE = `
+window.__applied = {
+  formatAppliedOptions: formatAppliedOptions,
+  renderServeWorkspace: renderServeWorkspace,
+  serveMeta: serveMeta,
+  serveState: serveState,
+  serveApplied: serveApplied,
+};
+`;
+
+interface Exposed {
+  formatAppliedOptions: (applied: unknown) => string[];
+  renderServeWorkspace: (id: string, err?: string) => void;
+  serveMeta: Map<string, unknown>;
+  serveState: Map<string, unknown>;
+  serveApplied: Map<string, unknown>;
+}
+
+const exposed = (h: ReturnType<typeof createStudioHarness>): Exposed =>
+  (h.window as unknown as { __applied: Exposed }).__applied;
+
+describe('studio serve "Started with" summary (issue #356)', () => {
+  it('formats scalar / boolean / pair / env / rawArgs / imageOverride options', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE });
+    try {
+      const t = exposed(h);
+      // scalar -> "flag value"
+      expect(t.formatAppliedOptions({ options: { '--max-tasks': '2' } })).toEqual(['--max-tasks 2']);
+      // boolean true -> flag only; false -> omitted; blank scalar -> omitted
+      expect(
+        t.formatAppliedOptions({ options: { '--tls': true, '--no-verify-auth': false, '--tls-cert': '' } })
+      ).toEqual(['--tls']);
+      // repeat-pair -> one "flag left=right" per NON-empty pair
+      expect(
+        t.formatAppliedOptions({
+          options: { '--host-port': [{ left: '80', right: '8080' }, { left: '', right: '' }] },
+        })
+      ).toEqual(['--host-port 80=8080']);
+      // env-kv pairs
+      expect(t.formatAppliedOptions({ options: { '--env-vars': [{ left: 'K', right: 'V' }] } })).toEqual([
+        '--env-vars K=V',
+      ]);
+      // imageOverride + rawArgs are appended after the curated options
+      expect(t.formatAppliedOptions({ imageOverride: './Dockerfile', rawArgs: '--foo bar' })).toEqual([
+        '--image-override ./Dockerfile',
+        '--foo bar',
+      ]);
+      // nothing applied -> empty list (the UI shows a "(defaults)" hint)
+      expect(t.formatAppliedOptions(undefined)).toEqual([]);
+      expect(t.formatAppliedOptions({ options: undefined })).toEqual([]);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('renders the chosen options in the running serve workspace', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE });
+    try {
+      const t = exposed(h);
+      t.serveMeta.set('Stk/Svc', { kind: 'ecs' });
+      t.serveApplied.set('Stk/Svc', {
+        options: { '--max-tasks': '3', '--host-port': [{ left: '80', right: '8080' }] },
+      });
+      t.serveState.set('Stk/Svc', { status: 'running', endpoints: [] });
+      t.renderServeWorkspace('Stk/Svc');
+
+      expect(h.document.querySelector('.started-with')).toBeTruthy();
+      const flags = Array.from(h.document.querySelectorAll('.started-flag')).map((n) => n.textContent);
+      expect(flags).toContain('--max-tasks 3');
+      expect(flags).toContain('--host-port 80=8080');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('shows a "(defaults)" hint when a serve was started with no options', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE });
+    try {
+      const t = exposed(h);
+      t.serveMeta.set('Stk/Api', { kind: 'api' });
+      t.serveApplied.set('Stk/Api', { options: undefined });
+      t.serveState.set('Stk/Api', { status: 'running', endpoints: [] });
+      t.renderServeWorkspace('Stk/Api');
+
+      const sec = h.document.querySelector('.started-with');
+      expect(sec).toBeTruthy();
+      expect(sec?.textContent).toContain('defaults');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('does NOT render a "Started with" section before Start (composer state)', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE });
+    try {
+      const t = exposed(h);
+      t.serveMeta.set('Stk/Api2', { kind: 'api' });
+      t.serveState.set('Stk/Api2', { status: 'stopped', endpoints: [] });
+      t.renderServeWorkspace('Stk/Api2');
+      expect(h.document.querySelector('.started-with')).toBeNull();
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

In `cdkl studio`, the per-run option inputs (max replicas, port remaps,
TLS, bearer-token, env, etc.) live in the serve composer and are replaced
by the running view once the serve is Started — so the launch config the
user chose silently vanished. Setting `--max-tasks` on a start-service /
start-alb serve and clicking Start made the value disappear with no record
of what the serve was running with.

## Fix

- Record the applied options / rawArgs / imageOverride at Start time in a
  `serveApplied` map, kept SEPARATE from `serveState` so the SSE-driven
  status / endpoint rewrites never clobber it.
- Render a read-only **"Started with"** summary in the running workspace
  for every serve kind (api / alb / ecs). `formatAppliedOptions` turns the
  per-run values object into human-readable flag lines (scalar -> `flag
  value`, boolean -> `flag`, repeat-pair / env-kv -> `flag left=right` per
  non-empty pair), appending `--image-override` and any raw extra args; an
  all-defaults start shows a `(defaults)` hint.

## Test plan

- Unit (jsdom harness, drives the REAL embedded STUDIO_SCRIPT): a new
  `studio-ui-applied-opts.test.ts` exercises `formatAppliedOptions` across
  every option shape AND `renderServeWorkspace` — asserting the running
  view shows the chosen `--max-tasks` / `--host-port`, the `(defaults)`
  hint when nothing was set, and NO summary before Start.
- Integ (`local-studio`, real Docker): regression — the served page +
  api / alb / ecs serve flows stay green (the summary is browser DOM, not
  curl-visible, so it is covered by the jsdom harness). 0 Docker orphans.

Closes #356
