### PR TITLE
fix(studio): add env-vars to the start-alb / start-service serve composers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -449,7 +449,10 @@ compute-locally category for Lambda + API Gateway).
   temp file passed as `--env-vars <file>`. Per-target options vary per
   invoke / serve, vs the session-global flags in studio-child-args; the
   `agentcore` kind (issue #303) declares `--ws` / `--sigv4` (boolean),
-  `--bearer-token` / `--session-id` (scalar), and `--env-vars` (env-kv)),
+  `--bearer-token` / `--session-id` (scalar), and `--env-vars` (env-kv);
+  the `alb` / `ecs` serve kinds also declare `--env-vars` (env-kv, issue
+  #355) so a UI-started serve can overlay the backing ECS task container
+  env)),
   studio-option-catalog (issue #301 — the AUTO-DERIVED full flag catalog
   that backs the composer's collapsed "All options" section.
   `buildFlagCatalog` introspects each runnable kind's Commander command
@@ -482,7 +485,14 @@ compute-locally category for Lambda + API Gateway).
   grace so the serve command's OWN ECS-replica + docker-network teardown
   completes before any SIGKILL. Under `cdkl studio --watch` it appends
   `--watch` to each serve child — read off the mutable config per
-  `start()`, so a Session-bar toggle applies to the next serve),
+  `start()`, so a Session-bar toggle applies to the next serve. Issue #355
+  added env-vars to the `alb` / `ecs` serve composers: `start()`
+  materializes the env-kv option via `resolveEnvVars` into a SAM-shape
+  temp file and appends `--env-vars <file>` so the override reaches the
+  backing ECS task containers (`start-service` / `start-alb` overlay the
+  `Parameters` map onto every container). The temp dir outlives the child
+  (a `--watch` serve re-reads it on reload) and is removed on teardown via
+  `closeProxies`),
   studio-proxy
   (issue #282, slice C2 — a capturing reverse proxy in front of each
   HTTP serve endpoint: forwards every request verbatim to the upstream

--- a/src/local/studio-option-specs.ts
+++ b/src/local/studio-option-specs.ts
@@ -142,6 +142,15 @@ export const OPTION_SPECS: Partial<Record<StudioTargetKind, OptionSpec[]>> = {
       help: 'Default JWT injected for authenticate-cognito / authenticate-oidc actions.',
     },
     { flag: '--no-verify-auth', kind: 'boolean', label: 'Disable auth guard' },
+    {
+      flag: '--env-vars',
+      kind: 'env-kv',
+      label: 'Env vars',
+      sep: '=',
+      leftPlaceholder: 'KEY',
+      rightPlaceholder: 'value',
+      help: 'Overlay the backing ECS task container env vars — add KEY=VALUE rows or paste a JSON object.',
+    },
   ],
   agentcore: [
     {
@@ -195,6 +204,15 @@ export const OPTION_SPECS: Partial<Record<StudioTargetKind, OptionSpec[]>> = {
       sep: '=',
       leftPlaceholder: 'containerPort',
       rightPlaceholder: 'hostPort',
+    },
+    {
+      flag: '--env-vars',
+      kind: 'env-kv',
+      label: 'Env vars',
+      sep: '=',
+      leftPlaceholder: 'KEY',
+      rightPlaceholder: 'value',
+      help: 'Overlay the task container env vars — add KEY=VALUE rows or paste a JSON object.',
     },
   ],
 };

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -1,4 +1,7 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { StudioEventBus, type StudioServeEvent, type StudioTargetKind } from './studio-events.js';
 import {
   startStudioProxy,
@@ -6,7 +9,7 @@ import {
   type StudioProxyConfig,
 } from './studio-proxy.js';
 import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
-import { buildPerRunArgs, type OptionValues } from './studio-option-specs.js';
+import { buildPerRunArgs, resolveEnvVars, type OptionValues } from './studio-option-specs.js';
 import { tokenizeRawArgs } from './studio-option-catalog.js';
 
 /** A request to start serving a target, as the studio UI posts it. */
@@ -187,6 +190,13 @@ interface ServeEntry extends StudioServeState {
   /** Capture proxies fronting this serve's HTTP endpoints (slice C2). */
   proxies: RunningStudioProxy[];
   /**
+   * Temp dir holding the `--env-vars` SAM-shape file (issue #355), when the
+   * serve was started with env-var overrides. Removed on teardown (the file
+   * must outlive a `--watch` serve's reloads, which re-read it, so it is
+   * cleaned up only when the serve stops — not after spawn).
+   */
+  envDir?: string;
+  /**
    * Set by `stop()` when it tears the child down WHILE it is still
    * `starting` (the ready promise has not settled). The child's `close`
    * handler reads it so a user-initiated stop is not misreported as a
@@ -233,10 +243,23 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
 
   const entries = new Map<string, ServeEntry>();
 
-  /** Close every capture proxy fronting `e` (best-effort; idempotent). */
+  /**
+   * Release every per-serve resource fronting `e` (best-effort; idempotent):
+   * its capture proxies (slice C2) and the `--env-vars` temp dir (issue #355).
+   * Called at every teardown path so neither a proxy socket nor the env file
+   * leaks when a serve stops / errors / times out.
+   */
   async function closeProxies(e: ServeEntry): Promise<void> {
     const proxies = e.proxies.splice(0);
     await Promise.all(proxies.map((p) => p.close().catch(() => undefined)));
+    if (e.envDir) {
+      try {
+        rmSync(e.envDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort temp cleanup — a leftover temp dir is harmless */
+      }
+      delete e.envDir;
+    }
   }
 
   function publicState(e: ServeEntry): StudioServeState {
@@ -266,7 +289,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
     config.bus.emit('serve', ev);
   }
 
-  function buildArgs(req: StudioServeRequest, spec: ServeKindSpec): string[] {
+  function buildArgs(req: StudioServeRequest, spec: ServeKindSpec, envFile?: string): string[] {
     // A `--watch` serve MUST re-synth on source changes, so it keeps
     // `--app <app>`; a non-watch serve reuses the boot-synthesized cloud
     // assembly studio captured (issue #324) and skips its own synth. Read
@@ -279,6 +302,11 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       ...spec.portArgs,
       ...buildSharedChildArgs(config, { preferAssembly }),
       ...buildPerRunArgs(req.kind, req.options),
+      // The `--env-vars` per-run option takes a FILE (issue #355) — the env-kv
+      // KV rows / JSON were materialized into a SAM-shape temp file by the
+      // caller; point start-service / start-alb at it so the override applies
+      // to the backing ECS task containers.
+      ...(envFile ? ['--env-vars', envFile] : []),
       // Image-override picker (issue #301): a pinned ecs service rebuilds from
       // the chosen local Dockerfile. The EXPLICIT `<target>=<dockerfile>` form
       // is used (not the bare picker form) because studio spawns the child
@@ -313,10 +341,32 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
     }
 
     const startedAt = clock();
+
+    // Materialize the `--env-vars` env-kv option (issue #355) into a SAM-shape
+    // temp file the serve child reads. Computed BEFORE spawn so a malformed
+    // JSON value throws as a clean /api/run boundary error rather than after a
+    // child is already running. The dir outlives the child (a `--watch` serve
+    // re-reads the file on reload) and is removed on teardown via closeProxies.
+    let envDir: string | undefined;
+    const envVars = resolveEnvVars(req.kind, req.options);
+    if (envVars) {
+      envDir = mkdtempSync(join(tmpdir(), 'cdkl-studio-env-'));
+      writeFileSync(join(envDir, 'env-vars.json'), JSON.stringify(envVars));
+    }
+    const envFile = envDir ? join(envDir, 'env-vars.json') : undefined;
+
     let child: ChildProcessWithoutNullStreams;
     try {
-      child = spawnFn(nodeBin, [config.cliEntry, ...buildArgs(req, spec)], { cwd });
+      child = spawnFn(nodeBin, [config.cliEntry, ...buildArgs(req, spec, envFile)], { cwd });
     } catch (err) {
+      // Spawn never happened — drop the env temp dir so it does not leak.
+      if (envDir) {
+        try {
+          rmSync(envDir, { recursive: true, force: true });
+        } catch {
+          /* best-effort */
+        }
+      }
       throw err instanceof Error ? err : new Error(String(err));
     }
 
@@ -330,6 +380,8 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       proxies: [],
     };
     if (child.pid !== undefined) entry.pid = child.pid;
+    // Bind the env temp dir to the entry so closeProxies removes it on teardown.
+    if (envDir) entry.envDir = envDir;
     // An ecs serve published via `--host-port` is reachable on the host (issue
     // #322); surface its host URL so the in-workspace request composer can
     // target it (the first mapping's host port). No proxy fronts it, so a

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1053,12 +1053,17 @@ ECS_TARGET="LocalStudioFixture/MyService"
 # `python -m http.server 80`, so a REACHABLE host port proves both options
 # threaded CLI -> child end-to-end (not a tautology — without the options the
 # port would never be published, and studio's ecs kind exposes no endpoint).
+# ALSO thread `--env-vars` (issue #355): the env-kv option is materialized into
+# a SAM-shape `{Parameters:{...}}` temp file the serve child reads, and
+# start-service overlays Parameters onto every task container — proven below
+# by `docker inspect`-ing the replica's env for the overridden value.
 ECS_HOST_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
-echo "==> POST /api/run starts an ECS service serve with --max-tasks + --host-port options"
+ECS_ENV_VALUE="studio-ecs-env-355"
+echo "==> POST /api/run starts an ECS service serve with --max-tasks + --host-port + --env-vars options"
 ECS_FILE=$(mktemp)
 HTTP_CODE=$(curl -s -o "${ECS_FILE}" -w '%{http_code}' --max-time 180 \
   -X POST "${URL}/api/run" -H 'content-type: application/json' \
-  -d "{\"targetId\":\"${ECS_TARGET}\",\"kind\":\"ecs\",\"options\":{\"--max-tasks\":\"1\",\"--host-port\":[{\"left\":\"80\",\"right\":\"${ECS_HOST_PORT}\"}]}}" || true)
+  -d "{\"targetId\":\"${ECS_TARGET}\",\"kind\":\"ecs\",\"options\":{\"--max-tasks\":\"1\",\"--host-port\":[{\"left\":\"80\",\"right\":\"${ECS_HOST_PORT}\"}],\"--env-vars\":[{\"left\":\"STUDIO_ECS_PROBE\",\"right\":\"${ECS_ENV_VALUE}\"}]}}" || true)
 if [[ "${HTTP_CODE}" != "200" ]] || ! grep -qF '"status":"running"' "${ECS_FILE}"; then
   echo "FAIL: POST /api/run (ecs) returned HTTP ${HTTP_CODE}"
   echo "----- ecs response -----"; cat "${ECS_FILE}"; echo "------------------------"
@@ -1086,6 +1091,29 @@ if [[ -z "${ECS_REACH}" ]]; then
   exit 1
 fi
 echo "    OK: --max-tasks + --host-port threaded; replica :80 reachable on host :${ECS_HOST_PORT}"
+
+# Issue #355: the --env-vars override reached the replica TASK container's env.
+# The studio env-kv -> {Parameters:{STUDIO_ECS_PROBE:...}} temp file ->
+# start-service Parameters overlay -> docker container env chain end-to-end.
+# The task container is named `<prefix>-<family>-<containerName>-<rand>`; the
+# `cdkl-svc-<rand>-metadata` sidecar (the ECS task-metadata endpoint) is a
+# DIFFERENT container with its own env, so iterate every NON-metadata cdkl-
+# container and assert at least one task container carries the override.
+ECS_ENV_HIT=""
+for c in $(docker ps --filter 'name=cdkl-' --format '{{.Names}}' | grep -v -- '-metadata'); do
+  if docker inspect --format '{{json .Config.Env}}' "$c" 2>/dev/null | grep -qF "STUDIO_ECS_PROBE=${ECS_ENV_VALUE}"; then
+    ECS_ENV_HIT="$c"; break
+  fi
+done
+if [[ -z "${ECS_ENV_HIT}" ]]; then
+  echo "FAIL: --env-vars override did NOT reach any replica task container env"
+  for c in $(docker ps --filter 'name=cdkl-' --format '{{.Names}}'); do
+    echo "----- ${c} Config.Env -----"; docker inspect --format '{{json .Config.Env}}' "$c" 2>/dev/null
+  done
+  echo "----- studio log -----"; tail -c 2000 "${LOG_FILE}"; echo "----------------------"
+  exit 1
+fi
+echo "    OK: --env-vars threaded; task container '${ECS_ENV_HIT}' carries STUDIO_ECS_PROBE=${ECS_ENV_VALUE}"
 
 echo "==> GET /api/running reflects the ECS service (no endpoint)"
 curl -fsS "${URL}/api/running" -o "${BODY_FILE}"

--- a/tests/unit/local/studio-option-specs.test.ts
+++ b/tests/unit/local/studio-option-specs.test.ts
@@ -68,6 +68,10 @@ describe('buildPerRunArgs', () => {
   it('emits NO direct arg for env-kv (materialized separately)', () => {
     expect(buildPerRunArgs('lambda', { '--env-vars': [{ left: 'K', right: 'V' }] })).toEqual([]);
     expect(buildPerRunArgs('lambda', { '--env-vars': '{"K":"V"}' })).toEqual([]);
+    // The alb / ecs serve kinds now declare --env-vars too (issue #355); it is
+    // likewise materialized into a file, not emitted as a direct arg.
+    expect(buildPerRunArgs('alb', { '--env-vars': [{ left: 'K', right: 'V' }] })).toEqual([]);
+    expect(buildPerRunArgs('ecs', { '--env-vars': [{ left: 'K', right: 'V' }] })).toEqual([]);
   });
 });
 
@@ -88,6 +92,22 @@ describe('resolveEnvVars', () => {
         ],
       })
     ).toEqual({ Parameters: { LOG_LEVEL: 'debug', TABLE: 'my-table' } });
+  });
+
+  it('resolves env-kv for the alb / ecs serve kinds too (issue #355)', () => {
+    // start-alb / start-service accept --env-vars (overlay the backing ECS
+    // task container env); the serve kinds gained the env-kv spec, so the same
+    // Parameters-form materialization applies — start-service / start-alb then
+    // overlay Parameters onto every container.
+    expect(resolveEnvVars('alb', { '--env-vars': [{ left: 'API_KEY', right: 'abc' }] })).toEqual({
+      Parameters: { API_KEY: 'abc' },
+    });
+    expect(resolveEnvVars('ecs', { '--env-vars': [{ left: 'STAGE', right: 'local' }] })).toEqual({
+      Parameters: { STAGE: 'local' },
+    });
+    expect(resolveEnvVars('ecs', { '--env-vars': '{ "Parameters": { "X": "1" } }' })).toEqual({
+      Parameters: { X: '1' },
+    });
   });
 
   it('wraps a flat JSON object in Parameters', () => {
@@ -130,7 +150,9 @@ describe('OPTION_SPECS table', () => {
   it('declares per-target options for the runnable kinds', () => {
     expect(OPTION_SPECS.lambda?.map((s) => s.flag)).toEqual(['--env-vars']);
     expect(OPTION_SPECS.alb?.map((s) => s.flag)).toContain('--tls');
-    expect(OPTION_SPECS.ecs?.map((s) => s.flag)).toEqual(['--max-tasks', '--host-port']);
+    // alb + ecs gained an --env-vars env-kv option (issue #355).
+    expect(OPTION_SPECS.alb?.map((s) => s.flag)).toContain('--env-vars');
+    expect(OPTION_SPECS.ecs?.map((s) => s.flag)).toEqual(['--max-tasks', '--host-port', '--env-vars']);
     expect(OPTION_SPECS.agentcore?.map((s) => s.flag)).toEqual([
       '--ws',
       '--sigv4',

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { existsSync, readFileSync } from 'node:fs';
 import { describe, it, expect, vi } from 'vite-plus/test';
 import {
   StudioEventBus,
@@ -397,6 +398,67 @@ describe('createStudioServeManager', () => {
     // Explicit form keyed by the SAME target id passed as the start-service
     // target arg (the bare picker form would be skipped non-interactively).
     expect(argv[i + 1]).toBe('Stack/MyService=./Dockerfile.local');
+  });
+
+  it('materializes --env-vars into a SAM-shape temp file and removes it on stop (issue #355)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'Stack/MyService',
+      kind: 'ecs',
+      options: {
+        '--env-vars': [
+          { left: 'STAGE', right: 'local' },
+          { left: 'DEBUG', right: '1' },
+        ],
+      },
+    });
+    child.stdout.emit('data', 'Service(s) running:\n');
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const ei = argv.indexOf('--env-vars');
+    expect(ei).toBeGreaterThan(-1);
+    const envFile = argv[ei + 1];
+    expect(existsSync(envFile)).toBe(true);
+    expect(JSON.parse(readFileSync(envFile, 'utf8'))).toEqual({
+      Parameters: { STAGE: 'local', DEBUG: '1' },
+    });
+
+    // Stop tears the serve down -> the env temp dir is removed (no leak). The
+    // fake child must emit `close` so stopChild's grace wait resolves.
+    const stopP = mgr.stop({ targetId: 'Stack/MyService' });
+    child.emit('close', 0, null);
+    await stopP;
+    expect(existsSync(envFile)).toBe(false);
+  });
+
+  it('passes NO --env-vars when the ecs serve has no env values', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+    const p = mgr.start({ targetId: 'Stack/MyService', kind: 'ecs', options: { '--max-tasks': '2' } });
+    child.stdout.emit('data', 'Service(s) running:\n');
+    await p;
+    expect((spawnFn.mock.calls[0] as unknown as [string, string[]])[1]).not.toContain('--env-vars');
   });
 
   it('omits --image-override when imageOverride is blank', async () => {


### PR DESCRIPTION
## Summary

The `cdkl studio` ALB / ECS serve composers had **no env-vars input** even
though `start-alb` / `start-service` both accept `--env-vars` (which overlays
the backing ECS task container env). Only the lambda / api / agentcore invoke
composers exposed it, so a user could not set container env overrides for an
ECS-backed serve from the UI.

## Fix

Two gaps were closed:

1. The `alb` / `ecs` `OPTION_SPECS` gained an `--env-vars` env-kv option, so
   the UI renders the KV / JSON editor and `resolveEnvVars` materializes it.
2. The serve manager did NOT call `resolveEnvVars` (only the single-shot
   invoke dispatcher did). `start()` now materializes the env-kv option into a
   SAM-shape `{ Parameters: {...} }` temp file and appends `--env-vars <file>`
   so start-service / start-alb overlay the Parameters map onto every task
   container. The temp dir outlives the child (a `--watch` serve re-reads it
   on reload) and is removed on teardown via `closeProxies` (the shared
   release path for every stop / error / timeout).

## Test plan

- Unit (`studio-option-specs`): `resolveEnvVars` / `buildPerRunArgs` now cover
  the `alb` / `ecs` env-kv (KV rows + JSON wrap into `{ Parameters }`; env-kv
  emits no direct arg); the OPTION_SPECS table test asserts the new flags.
- Unit (`studio-serve-manager`): `start()` writes the SAM-shape temp file,
  appends `--env-vars <file>` to the child argv, and removes the temp dir on
  `stop()`; a no-env serve passes no `--env-vars`.
- Integ (`local-studio`, real Docker): the ECS serve now also threads
  `--env-vars`, and `docker inspect` asserts the **task** container (not the
  `-metadata` sidecar) carries the overridden `STUDIO_ECS_PROBE` — the studio
  env-kv -> temp file -> start-service Parameters overlay -> container env
  chain end-to-end. Full suite green, 0 Docker orphans.

Closes #355
