### PR TITLE
fix(ecs): auto-remap a privileged declared host port to a free high port

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ cdkl invoke MyStack/Fn --from-cfn-stack --assume-role   # ...and run as its depl
 ```
 
 - **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`.
-- **`run-task`** / single-replica **`start-service`** publish declared container ports on the host (`--host-port <container>=<host>` remaps; handy for privileged ports on macOS). **`start-service`** / **`start-alb`** also list each host URL in a `Service endpoints:` banner after boot so the access URL stays visible.
+- **`run-task`** / single-replica **`start-service`** publish declared container ports on the host (a privileged port like 80 auto-remaps to a free high host port with a WARN; `--host-port <container>=<host>` pins a specific one). **`start-service`** / **`start-alb`** also list each host URL in a `Service endpoints:` banner after boot so the access URL stays visible.
 - **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement), and WebSocket `Upgrade` proxying to ECS targets ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
 - **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, all four runtime protocols (HTTP and AGUI on 8080, MCP on 8000, A2A on 9000; SSE and WebSocket are HTTP wire-shape variants on the same 8080 container), with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
 - **`studio`** opens a local web console over the same synthesized targets — a point-and-click front over the same CLI runners. Takes no target (it lists them all). Flags + in-UI controls: [Web console — `cdkl studio`](#web-console--cdkl-studio).
@@ -200,7 +200,7 @@ Most CDK ECS apps boot multiple replicas behind an ALB. cdk-local exposes each l
 **Why the extra flags on the simple case?** The template's `DesiredCount` (typically 3 in production) is honored locally by default, but N replicas can't all bind the same host port — so `start-service` skips host publishing for multi-replica runs and the app is reachable only from inside the `cdkl-svc-` docker network. To get the simple `curl http://127.0.0.1:...` access path:
 
 - `--max-tasks 1` clamps the local replica count to 1 without touching your CDK code.
-- `--host-port <containerPort>=<hostPort>` remaps the container port to a non-privileged host port (macOS Docker Desktop needs `sudo` for ports < 1024).
+- A privileged declared host port (`< 1024`, e.g. 80) is auto-remapped to a free high host port — with a WARN naming the remap — because macOS Docker Desktop refuses to publish privileged ports and a `< 1024` host port needs root. `--host-port <containerPort>=<hostPort>` pins a specific host port instead.
 
 `start-alb` uses the symmetric `--lb-port <listenerPort>=<hostPort>` for privileged listener ports like 80 / 443, and `--tls` (or `--tls-cert` / `--tls-key`) to terminate TLS locally instead of serving the HTTPS listener over plain HTTP (the default). Full resolution model: [docs/cli-reference.md](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally).
 

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -11,6 +11,7 @@ import {
   removeContainer,
   appendEnvFlags,
   execEnvForSecrets,
+  pickFreePort,
   SENSITIVE_ENV_KEYS,
 } from './docker-runner.js';
 import { attachContainerLogStreamer } from './container-log-streamer.js';
@@ -100,6 +101,16 @@ export interface RunEcsTaskOptions {
    * publish flags emitted.
    */
   ephemeralPublishContainerPorts?: number[];
+  /**
+   * Issue #357 — free-host-port allocator used to auto-remap a privileged
+   * declared host port (`< 1024`, e.g. 80) that the user did NOT pin via
+   * `--host-port`, so `docker run` never tries to publish e.g.
+   * `127.0.0.1:80:80` (macOS Docker Desktop rejects privileged-port
+   * publishing through the `com.docker.vmnetd` helper, and a `< 1024` host
+   * port needs root on Linux too). Defaults to {@link pickFreePort};
+   * injected by tests for deterministic ports.
+   */
+  allocateHostPort?: () => Promise<number>;
   /** Optional STS-issued temp credentials to expose via the metadata sidecar (`--assume-task-role`). */
   taskCredentials?: {
     accessKeyId: string;
@@ -443,6 +454,27 @@ export async function runEcsTask(
   // pin v1 to per-task semantics).
   const volumeByName = await realizeDockerVolumes(task.volumes, state);
 
+  // Issue #357 — auto-remap privileged declared host ports (< 1024) the user
+  // did NOT pin via `--host-port` to free high ports, so `docker run` never
+  // tries to publish e.g. `127.0.0.1:80:80` (macOS Docker Desktop rejects
+  // privileged-port publishing; a < 1024 host port needs root). Skipped when
+  // host-port publishing is suppressed (multi-replica — nothing is published).
+  let effectiveHostPortOverrides = options.hostPortOverrides;
+  let autoRemappedContainerPorts: ReadonlySet<number> | undefined;
+  if (!options.skipHostPortPublish) {
+    const remaps = await resolvePrivilegedHostPortRemaps({
+      task,
+      userOverrides: options.hostPortOverrides,
+      ephemeralPorts: new Set(options.ephemeralPublishContainerPorts ?? []),
+      allocate: options.allocateHostPort ?? pickFreePort,
+    });
+    const remapKeys = Object.keys(remaps);
+    if (remapKeys.length > 0) {
+      effectiveHostPortOverrides = { ...options.hostPortOverrides, ...remaps };
+      autoRemappedContainerPorts = new Set(remapKeys.map(Number));
+    }
+  }
+
   // Pre-compute every container's CMD args so the start loop only does
   // docker calls.
   const dockerCmds = new Map<string, { args: string[]; sensitiveEnv: Record<string, string> }>();
@@ -467,7 +499,8 @@ export async function runEcsTask(
       region: options.region,
       sidecarIp: state.network.sidecarIp,
       ...(options.skipHostPortPublish ? { skipHostPortPublish: true } : {}),
-      ...(options.hostPortOverrides ? { hostPortOverrides: options.hostPortOverrides } : {}),
+      ...(effectiveHostPortOverrides ? { hostPortOverrides: effectiveHostPortOverrides } : {}),
+      ...(autoRemappedContainerPorts ? { autoRemappedContainerPorts } : {}),
       ...(options.ephemeralPublishContainerPorts &&
       options.ephemeralPublishContainerPorts.length > 0
         ? { ephemeralPublishContainerPorts: options.ephemeralPublishContainerPorts }
@@ -967,9 +1000,17 @@ interface BuildDockerRunArgs {
   skipHostPortPublish?: boolean;
   /**
    * `--host-port` overrides (`containerPort -> hostPort`); see the
-   * matching field on {@link RunEcsTaskOptions}.
+   * matching field on {@link RunEcsTaskOptions}. Includes the privileged-port
+   * auto-remaps (issue #357) merged over the user's pins by the caller.
    */
   hostPortOverrides?: Record<number, number>;
+  /**
+   * Issue #357 — container ports whose `hostPortOverrides` entry is an
+   * automatic privileged-port remap (not a user `--host-port` pin), so the
+   * publish log labels them "(privileged-port auto-remap)" rather than
+   * "(--host-port override)".
+   */
+  autoRemappedContainerPorts?: ReadonlySet<number>;
   /**
    * Issue #86 v1 — container ports to publish on EPHEMERAL host ports, used by
    * the local ALB front-door. A port is published (as
@@ -1050,6 +1091,66 @@ export function parseHostPortOverrides(values: string[] | undefined): Record<num
 }
 
 /**
+ * Issue #357 — auto-remap privileged declared host ports to free high host
+ * ports so `docker run` never tries to publish e.g. `127.0.0.1:80:80`.
+ *
+ * For each container port whose DECLARED host port (`hostPort ?? containerPort`)
+ * is privileged (`< 1024`), is NOT already pinned by a user `--host-port`
+ * override, and is NOT an ephemeral front-door port, a free high host port is
+ * allocated and recorded as an additional override. A loud WARN names the remap
+ * and the `--host-port` escape hatch so the change is never silent. The
+ * returned map is keyed by containerPort and meant to be merged OVER the user
+ * overrides (which always win).
+ *
+ * Why: macOS Docker Desktop rejects publishing a privileged host port through
+ * the `com.docker.vmnetd` helper, and a `< 1024` host port needs root on Linux
+ * — so a single-replica `start-service` / `run-task` / `start-alb` publish of a
+ * task definition that declares container port 80 used to fail at `docker run`.
+ * Remapping makes it work out of the box; the user can still pin a specific
+ * (even privileged) port with `--host-port`.
+ *
+ * Pure except for the injected `allocate` (a free-host-port finder). Callers
+ * skip this entirely when host-port publishing is suppressed (multi-replica).
+ * One remap per containerPort (the override map is flat / keyed by container
+ * port), matching the existing `--host-port` semantics.
+ *
+ * Applied automatically by `runEcsTask`; exported (no leading underscore) so the
+ * unit tests can assert the remap decisions directly with an injected allocator.
+ */
+export async function resolvePrivilegedHostPortRemaps(opts: {
+  task: ResolvedEcsTask;
+  userOverrides: Record<number, number> | undefined;
+  ephemeralPorts: ReadonlySet<number>;
+  allocate: () => Promise<number>;
+}): Promise<Record<number, number>> {
+  const { task, userOverrides, ephemeralPorts, allocate } = opts;
+  const remaps: Record<number, number> = {};
+  const seen = new Set<number>();
+  for (const container of task.containers) {
+    for (const pm of container.portMappings) {
+      const cp = pm.containerPort;
+      if (seen.has(cp)) continue; // one remap per container port (flat override map)
+      if (ephemeralPorts.has(cp)) continue; // front-door ephemeral publish, not a fixed bind
+      if (userOverrides && userOverrides[cp] !== undefined) continue; // user pinned it explicitly
+      const declaredHostPort = pm.hostPort ?? cp;
+      if (declaredHostPort >= 1024) continue; // not privileged — leave it
+      seen.add(cp);
+      const freePort = await allocate();
+      remaps[cp] = freePort;
+      getLogger()
+        .child('ecs')
+        .warn(
+          `Container '${container.name}' container port ${cp} declares a privileged host port ` +
+            `${declaredHostPort}, which cannot be published locally (macOS Docker Desktop rejects ` +
+            `privileged-port publishing; a host port < 1024 needs root). Auto-remapped to host port ` +
+            `${freePort}. Pass --host-port ${cp}=<hostPort> to pin a specific host port.`
+        );
+    }
+  }
+  return remaps;
+}
+
+/**
  * Build the full `docker run -d` argument list for one container.
  * Exported (no-leading-underscore) so the unit tests can assert against
  * the shape directly without spawning a process.
@@ -1125,7 +1226,12 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
       const declaredHostPort = pm.hostPort ?? pm.containerPort;
       const hostPort = opts.hostPortOverrides?.[pm.containerPort] ?? declaredHostPort;
       const overridden = hostPort !== declaredHostPort;
-      const overrideNote = overridden ? ' (--host-port override)' : '';
+      const autoRemapped = opts.autoRemappedContainerPorts?.has(pm.containerPort) ?? false;
+      const overrideNote = autoRemapped
+        ? ' (privileged-port auto-remap)'
+        : overridden
+          ? ' (--host-port override)'
+          : '';
       getLogger()
         .child('ecs')
         .info(

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1193,6 +1193,51 @@ STUDIO_PID=""
 echo "    OK: studio stopped cleanly"
 
 # ---------------------------------------------------------------------------
+# 11b. Privileged host-port auto-remap (issue #357): a single-replica
+#      start-service whose task container declares a privileged port (80) and
+#      is NOT pinned with --host-port auto-remaps the host publish to a free
+#      high port + WARNs, instead of failing at `docker run` (macOS Docker
+#      Desktop rejects publishing 127.0.0.1:80 via the privileged vmnetd
+#      helper; a < 1024 host port needs root). The fixture's MyService runs
+#      `python -m http.server 80`, so the auto-assigned host port is reachable.
+#      Driven as a DIRECT start-service (studio is already stopped above).
+# ---------------------------------------------------------------------------
+echo "==> start-service auto-remaps a privileged container port to a high host port (#357)"
+PP_LOG=$(mktemp)
+${CDKL} start-service LocalStudioFixture/MyService --max-tasks 1 --no-pull --container-host 127.0.0.1 \
+  >"${PP_LOG}" 2>&1 &
+PP_PID=$!
+PP_PORT=""
+for _ in $(seq 1 90); do
+  if grep -qF 'Auto-remapped to host port' "${PP_LOG}"; then
+    PP_PORT=$(grep -oE 'published on 127\.0\.0\.1:[0-9]+' "${PP_LOG}" | head -1 | grep -oE '[0-9]+$' || true)
+    [ -n "${PP_PORT}" ] && break
+  fi
+  kill -0 "${PP_PID}" 2>/dev/null || break
+  sleep 1
+done
+if [ -z "${PP_PORT}" ]; then
+  echo "FAIL: start-service did not auto-remap the privileged port (no WARN + published-port line)"
+  cat "${PP_LOG}"; kill -TERM "${PP_PID}" 2>/dev/null || true; wait "${PP_PID}" 2>/dev/null || true; rm -f "${PP_LOG}"; exit 1
+fi
+if [ "${PP_PORT}" -lt 1024 ]; then
+  echo "FAIL: auto-remapped to a still-privileged host port ${PP_PORT}"
+  cat "${PP_LOG}"; kill -TERM "${PP_PID}" 2>/dev/null || true; wait "${PP_PID}" 2>/dev/null || true; rm -f "${PP_LOG}"; exit 1
+fi
+PP_REACH=""
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 3 "http://127.0.0.1:${PP_PORT}/" -o /dev/null 2>/dev/null; then PP_REACH=yes; break; fi
+  sleep 1
+done
+kill -TERM "${PP_PID}" 2>/dev/null || true
+wait "${PP_PID}" 2>/dev/null || true
+rm -f "${PP_LOG}"
+if [ -z "${PP_REACH}" ]; then
+  echo "FAIL: container not reachable on the auto-remapped host port ${PP_PORT}"; exit 1
+fi
+echo "    OK: privileged port 80 auto-remapped to high host port ${PP_PORT}; reachable + WARN logged"
+
+# ---------------------------------------------------------------------------
 # 12. Session-global flag threading (issue #301 slice 1): `cdkl studio
 #     --from-cfn-stack <name> --assume-role <arn>` forwards both flags to the
 #     child commands it spawns. Boot studio bound to a BOGUS stack + role (no

--- a/tests/unit/local/ecs-task-runner-privileged-port.test.ts
+++ b/tests/unit/local/ecs-task-runner-privileged-port.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  buildDockerRunArgs,
+  resolvePrivilegedHostPortRemaps,
+} from '../../../src/local/ecs-task-runner.js';
+import type { ResolvedEcsContainer, ResolvedEcsTask } from '../../../src/local/ecs-task-resolver.js';
+
+// buildDockerRunArgs / resolvePrivilegedHostPortRemaps read only a bounded
+// subset of the container/task shapes, so a cast partial keeps fixtures small.
+function container(
+  name: string,
+  portMappings: Array<{ containerPort: number; hostPort?: number; protocol: string }>
+): ResolvedEcsContainer {
+  return {
+    name,
+    image: { kind: 'public', uri: 'public.ecr.aws/docker/library/busybox:latest' },
+    environment: {},
+    sensitiveEnvKeys: [],
+    secrets: [],
+    portMappings,
+    mountPoints: [],
+    dependsOn: [],
+    links: [],
+    essential: true,
+    ulimits: [],
+    warnings: [],
+  } as unknown as ResolvedEcsContainer;
+}
+
+const taskWith = (containers: ResolvedEcsContainer[]): ResolvedEcsTask =>
+  ({ family: 'fam', containers }) as unknown as ResolvedEcsTask;
+
+/** A deterministic free-port allocator: hands out 50000, 50001, ... */
+function fakeAllocator(): () => Promise<number> {
+  let next = 50000;
+  return () => Promise.resolve(next++);
+}
+
+describe('resolvePrivilegedHostPortRemaps (issue #357)', () => {
+  it('remaps a privileged declared host port the user did not pin', async () => {
+    const remaps = await resolvePrivilegedHostPortRemaps({
+      task: taskWith([container('web', [{ containerPort: 80, protocol: 'tcp' }])]),
+      userOverrides: undefined,
+      ephemeralPorts: new Set(),
+      allocate: fakeAllocator(),
+    });
+    expect(remaps).toEqual({ 80: 50000 });
+  });
+
+  it('uses the DECLARED host port (hostPort ?? containerPort) for the privileged check', async () => {
+    // containerPort is high (8080) but the declared hostPort is privileged (80).
+    const remaps = await resolvePrivilegedHostPortRemaps({
+      task: taskWith([container('web', [{ containerPort: 8080, hostPort: 80, protocol: 'tcp' }])]),
+      userOverrides: undefined,
+      ephemeralPorts: new Set(),
+      allocate: fakeAllocator(),
+    });
+    expect(remaps).toEqual({ 8080: 50000 });
+  });
+
+  it('does NOT remap a non-privileged port', async () => {
+    const remaps = await resolvePrivilegedHostPortRemaps({
+      task: taskWith([container('web', [{ containerPort: 8080, protocol: 'tcp' }])]),
+      userOverrides: undefined,
+      ephemeralPorts: new Set(),
+      allocate: fakeAllocator(),
+    });
+    expect(remaps).toEqual({});
+  });
+
+  it('does NOT remap a port the user pinned via --host-port', async () => {
+    const remaps = await resolvePrivilegedHostPortRemaps({
+      task: taskWith([container('web', [{ containerPort: 80, protocol: 'tcp' }])]),
+      userOverrides: { 80: 8080 },
+      ephemeralPorts: new Set(),
+      allocate: fakeAllocator(),
+    });
+    expect(remaps).toEqual({});
+  });
+
+  it('does NOT remap an ephemeral front-door port', async () => {
+    const remaps = await resolvePrivilegedHostPortRemaps({
+      task: taskWith([container('web', [{ containerPort: 80, protocol: 'tcp' }])]),
+      userOverrides: undefined,
+      ephemeralPorts: new Set([80]),
+      allocate: fakeAllocator(),
+    });
+    expect(remaps).toEqual({});
+  });
+
+  it('remaps each distinct privileged container port across containers', async () => {
+    const remaps = await resolvePrivilegedHostPortRemaps({
+      task: taskWith([
+        container('web', [{ containerPort: 80, protocol: 'tcp' }]),
+        container('admin', [{ containerPort: 443, protocol: 'tcp' }]),
+      ]),
+      userOverrides: undefined,
+      ephemeralPorts: new Set(),
+      allocate: fakeAllocator(),
+    });
+    expect(remaps).toEqual({ 80: 50000, 443: 50001 });
+  });
+});
+
+describe('buildDockerRunArgs privileged-port auto-remap publish (issue #357)', () => {
+  it('publishes the remapped host port for an auto-remapped container port', () => {
+    const { args, publishedEndpoints } = buildDockerRunArgs({
+      task: taskWith([]),
+      container: container('web', [{ containerPort: 80, protocol: 'tcp' }]),
+      image: 'public.ecr.aws/docker/library/busybox:latest',
+      network: 'net',
+      volumeByName: new Map(),
+      secrets: [],
+      envOverrides: undefined,
+      containerHost: '127.0.0.1',
+      roleArn: undefined,
+      platformOverride: undefined,
+      region: undefined,
+      hostPortOverrides: { 80: 50000 },
+      autoRemappedContainerPorts: new Set([80]),
+    });
+
+    // The publish binds the remapped HIGH host port, never the privileged 80.
+    const i = args.indexOf('-p');
+    expect(i).toBeGreaterThan(-1);
+    expect(args).toContain('127.0.0.1:50000:80/tcp');
+    expect(args.some((a) => a === '127.0.0.1:80:80/tcp')).toBe(false);
+
+    const ep = publishedEndpoints.find((e) => e.containerPort === 80);
+    expect(ep?.hostPort).toBe(50000);
+    expect(ep?.overridden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

A single-replica `start-service` / `run-task` / `start-alb` publishes the task
definition's declared container ports on the host. When a declared host port is
privileged (`< 1024`, e.g. an awsvpc Fargate task exposing port 80) and the user
did NOT pin it with `--host-port`, `docker run -p 127.0.0.1:80:80` fails — macOS
Docker Desktop rejects privileged-port publishing through the `com.docker.vmnetd`
helper, and a `< 1024` host port needs root on Linux:

```
ports are not available: exposing port TCP 127.0.0.1:80 -> 127.0.0.1:0:
connecting to /var/run/com.docker.vmnetd.sock: ... no such file or directory
```

The service never boots, with that cryptic error.

## Fix

`runEcsTask` now auto-remaps a privileged declared host port the user did not
pin to a free high host port (via `pickFreePort`), with a loud WARN naming the
remap and the `--host-port <containerPort>=<hostPort>` escape hatch to pin a
specific (even privileged) port. The publish log labels the binding
"(privileged-port auto-remap)".

- Skipped when host-port publishing is suppressed (multi-replica — nothing is
  published) and for ephemeral front-door ports.
- A user `--host-port` pin always wins (no auto-remap for that port).
- One remap per container port (the override map is flat), matching existing
  `--host-port` semantics.

## Test plan

- Unit (`ecs-task-runner-privileged-port`): `resolvePrivilegedHostPortRemaps`
  remaps a privileged declared port, uses `hostPort ?? containerPort` for the
  check, and does NOT remap a non-privileged port / a user-pinned port / an
  ephemeral port; `buildDockerRunArgs` publishes the remapped high port (never
  `127.0.0.1:80:80`) for an auto-remapped container port.
- Integ (`local-studio`, real Docker): a direct single-replica
  `start-service` (no `--host-port`) against a task that declares container port
  80 auto-remaps to a high host port (52591 in the run), the WARN is logged, and
  the container is reachable on the auto-assigned port — proving the fix on real
  macOS Docker where publishing 80 would fail. Full suite green, 0 orphans.

Closes #357
