### PR TITLE
feat(studio): add a [Run] control for ECS task definitions (run-task)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -369,12 +369,17 @@ compute-locally category for Lambda + API Gateway).
   `/api/config` immediately on a checkbox toggle / input change, issue
   #301); Lambdas + AgentCore runtimes get an
   [Invoke] composer (`INVOKE_KINDS`), serve
-  targets (api / alb / ecs) a [Start]/[Stop] control with a `running ●
-  :port` indicator (ecs services show `running` with no port — only the
-  servable ECS *services* are runnable, not the task definitions; issue
-  #352 lists ECS Services and ECS Task Definitions as SEPARATE target
-  groups, matching `cdkl list`, so the non-servable task defs no longer
-  share a group with the servable services). Once a serve is Started the
+  targets (api / alb / ecs / ecs-task) a [Start]/[Stop] control with a
+  `running ● :port` indicator (ecs services + ecs-task runs show
+  `running` with no port). Issue #352 lists ECS Services (the `ecs`
+  serve kind) and ECS Task Definitions as SEPARATE target groups,
+  matching `cdkl list`; issue #366 makes the task-definitions group the
+  `ecs-task` kind — a [Run] control (labeled Run, not Start) that runs
+  `cdkl run-task` as a long-running run (a server task def streams logs
+  until [Stop]; a batch task exits and the run flips to stopped). It
+  flips to `running` on the run-task `Task running (family=...)`
+  onReady banner (a streaming run has no listening-port line). Once a
+  serve is Started the
   composer's per-run option inputs are replaced by the running view, so a
   read-only "Started with" summary (issue #356 — `formatAppliedOptions`
   over the `serveApplied` map recorded at Start) surfaces the launch

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -298,17 +298,21 @@ async function localRunTaskCommand(
       );
     }
 
-    // Double-^C exits 130 immediately.
+    // Tear the task containers + network down on SIGINT (Ctrl-C) AND SIGTERM
+    // (issue #366 — studio's serve-manager SIGTERMs a task-def Run to stop it;
+    // without a SIGTERM handler the process would die WITHOUT cleanup, orphaning
+    // the containers + network). A second stop signal force-exits immediately.
     sigintHandler = (): void => {
       sigintCount += 1;
       if (sigintCount >= 2) {
-        process.stderr.write('Force-exit on second ^C; container cleanup skipped.\n');
+        process.stderr.write('Force-exit on second stop signal; container cleanup skipped.\n');
         process.exit(130);
       }
       logger.info('Stopping task...');
       void cleanup().then(() => process.exit(130));
     };
     process.on('SIGINT', sigintHandler);
+    process.on('SIGTERM', sigintHandler);
 
     // `--assume-task-role` branches: bare flag (boolean `true`) uses the
     // task definition's resolved `TaskRoleArn`; otherwise the
@@ -402,6 +406,17 @@ async function localRunTaskCommand(
       };
     }
 
+    // Issue #366 — a stable "running" banner after every container is up. The
+    // studio serve-manager keys on it to flip a task-def Run to `running`
+    // (a streaming run has no other ready line). Non-detach only.
+    if (!options.detach) {
+      runOpts.onReady = (): void => {
+        logger.info(
+          `Task running (family=${task.family}); streaming container logs. Stop with Ctrl-C.`
+        );
+      };
+    }
+
     const result = await runEcsTask(task, runOpts, state);
 
     if (options.detach) {
@@ -426,7 +441,10 @@ async function localRunTaskCommand(
       process.exitCode = result.exitCode;
     }
   } finally {
-    if (sigintHandler) process.off('SIGINT', sigintHandler);
+    if (sigintHandler) {
+      process.off('SIGINT', sigintHandler);
+      process.off('SIGTERM', sigintHandler);
+    }
     if (stateProvider) stateProvider.dispose();
     if (!options.detach) await cleanup();
   }

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -54,6 +54,7 @@ const STUDIO_TARGET_KINDS: readonly StudioTargetKind[] = [
   'api',
   'alb',
   'ecs',
+  'ecs-task',
   'agentcore',
 ];
 

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -152,6 +152,14 @@ export interface RunEcsTaskOptions {
   keepRunning: boolean;
   /** Start the containers and return without streaming logs. */
   detach: boolean;
+  /**
+   * Issue #366 — called ONCE after every container has started (and log
+   * streamers are attached) but BEFORE the runner blocks waiting for the
+   * essential container to exit. Non-detach only. `cdkl run-task` uses it to
+   * print a stable "Task running" banner that the studio serve-manager keys on
+   * to flip the run to `running`.
+   */
+  onReady?: () => void;
   /** AWS region for secret resolution + metadata sidecar. */
   region?: string;
   /**
@@ -557,6 +565,11 @@ export async function runEcsTask(
   if (options.detach) {
     return { exitCode: 0, state };
   }
+
+  // Issue #366 — every container is up + log streamers attached; signal ready
+  // BEFORE blocking on the essential container's exit so a caller (the studio
+  // serve-manager) can flip the run to `running`.
+  options.onReady?.();
 
   // Wait for the essential container to exit. AWS-side ECS treats the
   // first `essential: true` container as the task-driving one; cdk-local

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'node:events';
  * The kind of runnable target an invocation ran against. Mirrors the
  * categories `cdkl list` / the studio target list expose.
  */
-export type StudioTargetKind = 'lambda' | 'api' | 'alb' | 'ecs' | 'agentcore';
+export type StudioTargetKind = 'lambda' | 'api' | 'alb' | 'ecs' | 'ecs-task' | 'agentcore';
 
 /**
  * One request observed by `cdkl studio` — a single-shot invoke or one

--- a/src/local/studio-option-catalog.ts
+++ b/src/local/studio-option-catalog.ts
@@ -25,6 +25,7 @@ import { createLocalInvokeAgentCoreCommand } from '../cli/commands/local-invoke-
 import { createLocalStartApiCommand } from '../cli/commands/local-start-api.js';
 import { createLocalStartAlbCommand } from '../cli/commands/local-start-alb.js';
 import { createLocalStartServiceCommand } from '../cli/commands/local-start-service.js';
+import { createLocalRunTaskCommand } from '../cli/commands/local-run-task.js';
 import { getEmbedConfig, setEmbedConfig, type CdkLocalEmbedConfig } from './embed-config.js';
 import type { StudioTargetKind } from './studio-events.js';
 import type { Command } from 'commander';
@@ -76,6 +77,7 @@ const KIND_FACTORIES: Record<StudioTargetKind, { command: string; factory: FlagC
   api: { command: 'start-api', factory: createLocalStartApiCommand },
   alb: { command: 'start-alb', factory: createLocalStartAlbCommand },
   ecs: { command: 'start-service', factory: createLocalStartServiceCommand },
+  'ecs-task': { command: 'run-task', factory: createLocalRunTaskCommand },
 };
 
 let cached: Partial<Record<StudioTargetKind, KindFlagCatalog>> | undefined;

--- a/src/local/studio-option-specs.ts
+++ b/src/local/studio-option-specs.ts
@@ -215,6 +215,28 @@ export const OPTION_SPECS: Partial<Record<StudioTargetKind, OptionSpec[]>> = {
       help: 'Overlay the task container env vars — add KEY=VALUE rows or paste a JSON object.',
     },
   ],
+  // Task definitions run single-shot via `run-task` (issue #366). No
+  // --max-tasks (one task), but the declared container ports can be published
+  // and the container env overlaid, same as a service.
+  'ecs-task': [
+    {
+      flag: '--host-port',
+      kind: 'repeat-pair',
+      label: 'Container port publish',
+      sep: '=',
+      leftPlaceholder: 'containerPort',
+      rightPlaceholder: 'hostPort',
+    },
+    {
+      flag: '--env-vars',
+      kind: 'env-kv',
+      label: 'Env vars',
+      sep: '=',
+      leftPlaceholder: 'KEY',
+      rightPlaceholder: 'value',
+      help: 'Overlay the task container env vars — add KEY=VALUE rows or paste a JSON object.',
+    },
+  ],
 };
 
 /** True when `value` is a non-empty trimmed string. */

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -183,6 +183,17 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     readyRe: /Service\(s\) running:/,
     capturesHttp: false,
   },
+  'ecs-task': {
+    // run-task runs a task definition's containers once (issue #366). For a
+    // server task def the containers stream logs until stopped (the serve
+    // lifecycle); a batch task exits and the run flips to stopped. No host
+    // port, no capture. `Task running (family=...)` (the run-task onReady
+    // banner) is its stable ready marker.
+    command: 'run-task',
+    portArgs: [],
+    readyRe: /Task running \(family=/,
+    capturesHttp: false,
+  },
 };
 
 interface ServeEntry extends StudioServeState {

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -39,7 +39,7 @@ export interface StudioTarget {
 /** A category of targets, grouped by the studio kind that runs them. */
 export interface StudioTargetGroup {
   /** Studio kind discriminator shared with {@link StudioInvocationEvent}. */
-  kind: 'lambda' | 'api' | 'alb' | 'ecs' | 'agentcore';
+  kind: 'lambda' | 'api' | 'alb' | 'ecs' | 'ecs-task' | 'agentcore';
   /** Human-readable group heading. */
   title: string;
   entries: StudioTarget[];
@@ -67,18 +67,14 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
     { kind: 'lambda', title: 'Lambda Functions', entries: map(listing.lambdas) },
     { kind: 'api', title: 'APIs', entries: map(listing.apis) },
     // ECS services and task definitions are SEPARATE groups (issue #352),
-    // matching `cdkl list`: services are servable (`start-service` -> Start),
-    // task definitions are single-shot (`run-task`). They were previously
-    // lumped into one "ECS Services / Tasks" group, which obscured that task
-    // definitions are not a serve target. The services group stays FIRST so
-    // `annotatePinnedEcsTargets` (which finds the first `ecs`-kind group)
-    // annotates the servable services.
+    // matching `cdkl list`. Services are the `ecs` serve kind (start-service ->
+    // Start). Task definitions are the `ecs-task` kind (issue #366): a [Run]
+    // control that runs `cdkl run-task` as a long-running run (server task
+    // defs stream logs until stopped; batch tasks exit). The `ecs` services
+    // group stays FIRST so `annotatePinnedEcsTargets` (which finds the first
+    // `ecs`-kind group) annotates the servable services and NOT the task defs.
     { kind: 'ecs', title: 'ECS Services', entries: map(listing.ecsServices, { servable: true }) },
-    {
-      kind: 'ecs',
-      title: 'ECS Task Definitions',
-      entries: map(listing.ecsTaskDefinitions, { servable: false }),
-    },
+    { kind: 'ecs-task', title: 'ECS Task Definitions', entries: map(listing.ecsTaskDefinitions) },
     { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
     { kind: 'alb', title: 'Load Balancers', entries: map(listing.loadBalancers) },
   ];

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -257,8 +257,8 @@ const STUDIO_CSS = `
 `;
 
 const STUDIO_SCRIPT = `
-  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', agentcore: 'AgentCore' };
-  const SERVE_KINDS = ['api', 'alb', 'ecs']; // long-running serve targets
+  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', 'ecs-task': 'ECS Task', agentcore: 'AgentCore' };
+  const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task']; // long-running serve targets (ecs-task = run-task)
   const INVOKE_KINDS = ['lambda', 'agentcore']; // single-shot invoke targets (event composer)
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event
@@ -649,9 +649,12 @@ const STUDIO_SCRIPT = `
     meta.dot.textContent = running ? (port ? '● ' + port : '● running') : starting ? '○ starting' : '';
     meta.dot.className = 'run-dot' + (starting ? ' starting' : '');
     meta.btnSlot.innerHTML = '';
+    // A task-def run (ecs-task) is labeled Run (it runs the task once), vs a
+    // service/api/alb which is Started (issue #366).
+    const startLabel = meta.kind === 'ecs-task' ? 'Run' : 'Start';
     const btn = running || starting
       ? el('button', 'stop-btn', 'Stop')
-      : el('button', 'invoke-btn', 'Start');
+      : el('button', 'invoke-btn', startLabel);
     btn.onclick = (e) => {
       e.stopPropagation();
       if (running || starting) stopServe(id); else startServe(id);
@@ -808,11 +811,15 @@ const STUDIO_SCRIPT = `
     const meta = serveMeta.get(id);
     const kind = meta ? meta.kind : 'api';
 
+    // A task-def run (ecs-task) is labeled Run, vs a service/api/alb Serve/Start
+    // (issue #366).
+    const isTaskRun = kind === 'ecs-task';
+    const startLabel = isTaskRun ? 'Run' : 'Start';
     const head = el('div', 'composer');
-    head.appendChild(el('div', 'target-name', 'Serve ' + id));
+    head.appendChild(el('div', 'target-name', (isTaskRun ? 'Run ' : 'Serve ') + id));
     const btn = running || starting
       ? el('button', null, 'Stop')
-      : el('button', null, starting ? 'Starting…' : 'Start');
+      : el('button', null, starting ? 'Starting…' : startLabel);
     // Per-run options are only set before a start; collected on the Start click.
     let collectOpts = function () { return undefined; };
     let collectRaw = function () { return undefined; };
@@ -859,7 +866,9 @@ const STUDIO_SCRIPT = `
       ws.appendChild(startedSec);
     }
 
-    const isEcs = meta && meta.kind === 'ecs';
+    // Both an ecs service and an ecs-task run are pure compute: no host
+    // endpoint unless a --host-port was published (issue #366).
+    const isEcs = meta && (meta.kind === 'ecs' || meta.kind === 'ecs-task');
     const epSec = el('div', 'section');
     epSec.appendChild(el('h3', null, 'Endpoints'));
     if (running && st.endpoints.length) {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -339,6 +339,7 @@ for needle in \
   '"kind":"lambda"' \
   '"kind":"api"' \
   '"kind":"ecs"' \
+  '"kind":"ecs-task"' \
   '"title":"ECS Services"' \
   '"title":"ECS Task Definitions"' \
   '"kind":"agentcore"' \
@@ -1127,6 +1128,41 @@ curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/js
   -d "{\"targetId\":\"${ECS_TARGET}\"}" -o /dev/null || true
 sleep 3
 echo "    OK: ECS service stopped"
+
+# ---------------------------------------------------------------------------
+# 10a2. ECS TASK DEFINITION run (issue #366): a task definition is the
+#       `ecs-task` kind — a [Run] control that runs `cdkl run-task` as a
+#       long-running run (server task defs stream logs until stopped). POST
+#       /api/run with kind=ecs-task boots the fixture's MyTask container and the
+#       serve flips to running ONLY once the run-task `Task running (family=...)`
+#       onReady banner matched the serve-manager readyRe — proving the
+#       run-task dispatch + ready detection end-to-end. POST /api/stop tears the
+#       container down.
+# ---------------------------------------------------------------------------
+ECS_TASK_TARGET="LocalStudioFixture/MyTask"
+echo "==> POST /api/run runs an ECS task definition (kind=ecs-task -> run-task)"
+TASK_FILE=$(mktemp)
+HTTP_TASK=$(curl -s -o "${TASK_FILE}" -w '%{http_code}' --max-time 180 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TASK_TARGET}\",\"kind\":\"ecs-task\"}" || true)
+if [[ "${HTTP_TASK}" != "200" ]] || ! grep -qF '"status":"running"' "${TASK_FILE}"; then
+  echo "FAIL: POST /api/run (ecs-task) returned HTTP ${HTTP_TASK}"
+  echo "----- response -----"; cat "${TASK_FILE}"; echo "--------------------"
+  echo "----- studio log -----"; tail -c 2000 "${LOG_FILE}"; echo "----------------------"
+  rm -f "${TASK_FILE}"; exit 1
+fi
+rm -f "${TASK_FILE}"
+# /api/running reflects the task run.
+curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
+if ! grep -qF "${ECS_TASK_TARGET}" "${BODY_FILE}"; then
+  echo "FAIL: /api/running did not list the running task"; cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: task definition running via run-task (Task running banner matched)"
+echo "==> POST /api/stop tears the task run down"
+curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TASK_TARGET}\"}" -o /dev/null || true
+sleep 3
+echo "    OK: task run stopped"
 
 # ---------------------------------------------------------------------------
 # 10b. Image-override picker (issue #301): MyService's deployed image is a

--- a/tests/unit/local/studio-option-specs.test.ts
+++ b/tests/unit/local/studio-option-specs.test.ts
@@ -108,6 +108,10 @@ describe('resolveEnvVars', () => {
     expect(resolveEnvVars('ecs', { '--env-vars': '{ "Parameters": { "X": "1" } }' })).toEqual({
       Parameters: { X: '1' },
     });
+    // Task definitions (run-task) likewise materialize env-kv (issue #366).
+    expect(resolveEnvVars('ecs-task', { '--env-vars': [{ left: 'STAGE', right: 'local' }] })).toEqual({
+      Parameters: { STAGE: 'local' },
+    });
   });
 
   it('wraps a flat JSON object in Parameters', () => {
@@ -153,6 +157,9 @@ describe('OPTION_SPECS table', () => {
     // alb + ecs gained an --env-vars env-kv option (issue #355).
     expect(OPTION_SPECS.alb?.map((s) => s.flag)).toContain('--env-vars');
     expect(OPTION_SPECS.ecs?.map((s) => s.flag)).toEqual(['--max-tasks', '--host-port', '--env-vars']);
+    // Task definitions run via run-task (issue #366): --host-port + --env-vars,
+    // no --max-tasks (a single task, not replicas).
+    expect(OPTION_SPECS['ecs-task']?.map((s) => s.flag)).toEqual(['--host-port', '--env-vars']);
     expect(OPTION_SPECS.agentcore?.map((s) => s.flag)).toEqual([
       '--ws',
       '--sigv4',

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -370,6 +370,37 @@ describe('createStudioServeManager', () => {
     expect(mgr.list()[0].hostUrl).toBeUndefined();
   });
 
+  it('spawns `cdkl run-task <taskdef>` and resolves running on the Task running banner (issue #366)', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+    const p = mgr.start({ targetId: 'Stack/MyTask', kind: 'ecs-task' });
+    // run-task's onReady banner is the ready marker (a streaming run has no
+    // listening-port line).
+    child.stdout.emit(
+      'data',
+      'Task running (family=cdkl-fixture-task); streaming container logs. Stop with Ctrl-C.\n'
+    );
+    const state = await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv.slice(1, 3)).toEqual(['run-task', 'Stack/MyTask']);
+    expect(state.status).toBe('running');
+    // Pure compute — no host endpoint, no capture proxy.
+    expect(state.endpoints).toEqual([]);
+    expect(fp.upstreams).toEqual([]);
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
+  });
+
   it('threads imageOverride as an explicit --image-override <target>=<dockerfile>', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -230,9 +230,17 @@ describe('toStudioTargetGroups', () => {
     };
     const groups = toStudioTargetGroups(listing);
 
-    // ECS Services and Task Definitions are SEPARATE groups (issue #352), so
-    // there are now two `ecs`-kind groups (services first, then task defs).
-    expect(groups.map((g) => g.kind)).toEqual(['lambda', 'api', 'ecs', 'ecs', 'agentcore', 'alb']);
+    // ECS Services and Task Definitions are SEPARATE groups (issue #352); the
+    // task-definitions group is the `ecs-task` kind (issue #366) — a [Run]
+    // control (run-task), distinct from the servable `ecs` services kind.
+    expect(groups.map((g) => g.kind)).toEqual([
+      'lambda',
+      'api',
+      'ecs',
+      'ecs-task',
+      'agentcore',
+      'alb',
+    ]);
     expect(groups.map((g) => g.title)).toEqual([
       'Lambda Functions',
       'APIs',
@@ -248,12 +256,11 @@ describe('toStudioTargetGroups', () => {
       qualifiedId: 'S:Api',
       surface: 'HTTP API v2',
     });
-    // The services group holds only the servable service; the task-definitions
-    // group holds only the non-servable task def.
+    // The `ecs` services group holds the servable service; the `ecs-task` group
+    // holds the task def (plain entry — no servable flag, the kind IS the run).
     expect(groups[2].entries.map((e) => e.id)).toEqual(['S:Svc']);
     expect(groups[2].entries.map((e) => e.servable)).toEqual([true]);
-    expect(groups[3].entries.map((e) => e.id)).toEqual(['S:Task']);
-    expect(groups[3].entries.map((e) => e.servable)).toEqual([false]);
+    expect(groups[3].entries).toEqual([{ id: 'S:Task', qualifiedId: 'S:Task' }]);
   });
 
   it('falls back to the qualified id when no display path exists', () => {


### PR DESCRIPTION
## Summary

In `cdkl studio`, ECS task definitions were listed (the "ECS Task Definitions"
group, issue #352) but had no action button — only ECS services got a [Start].
A task definition is now the **`ecs-task`** kind (issue #366): a **[Run]**
control that runs `cdkl run-task <taskdef>` as a long-running run.

A server task definition's container runs until stopped, so this uses the
serve-manager lifecycle (long-running child + [Stop] + streamed logs), NOT the
single-shot invoke dispatcher (which awaits child completion and would block on
a server task). A batch task that exits flips the run to `stopped`.

## How it works

- `studio-events` — `StudioTargetKind` gains `ecs-task`.
- `studio-server` — `toStudioTargetGroups` emits the task-definitions group as
  the `ecs-task` kind; `annotatePinnedEcsTargets` (first `ecs`-kind group) still
  only annotates the servable services.
- `studio-serve-manager` — `SERVE_SPECS['ecs-task']` spawns `run-task`,
  resolving running on the run-task `Task running (family=...)` banner.
- `ecs-task-runner` + `run-task` — a new `onReady` callback fires after every
  container is up (before the runner blocks on the essential container's exit);
  the CLI prints the banner so the serve-manager can flip to running (a
  streaming run has no listening-port line).
- `studio-option-specs` (`--host-port` + `--env-vars`) / `studio-option-catalog`
  (`ecs-task` -> `run-task`) / `coerceRunRequest` (`STUDIO_TARGET_KINDS`).
- `studio-ui` — a [Run]/[Stop] control (labeled Run) + pure-compute rendering.

## Behavior notes (host-facing)

- **`run-task` now tears down on SIGTERM** (not just SIGINT / Ctrl-C). The
  serve-manager SIGTERMs to stop a task run; without this the containers +
  network orphaned. Strictly better — any process manager stopping `run-task`
  now gets a clean teardown.
- **studio gains the `ecs-task` kind / group.** A host CLI embedding studio's
  target list picks it up automatically via `toStudioTargetGroups`; no host-side
  change needed beyond bumping the `cdk-local` version.

## Test plan

- Unit: `toStudioTargetGroups` (the task-def group is `ecs-task`),
  `studio-serve-manager` (spawns `run-task <taskdef>`, resolves running on the
  `Task running` banner, no host endpoint), `studio-option-specs` (the
  `ecs-task` option set + env-kv resolution).
- Integ (`local-studio`, real Docker): `/api/targets` lists the `ecs-task`
  group; POST `/api/run` `kind=ecs-task` boots the fixture's task definition via
  run-task, the serve flips to running (banner matched), `/api/running` reflects
  it, and POST `/api/stop` tears it down cleanly. Full suite green, **0 Docker
  orphans** (the SIGTERM-cleanup fix verified end-to-end).

Closes #366
