### PR TITLE
fix(studio): detect a --from-cfn-stack-pinned ECS service at boot (image-override picker)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -256,7 +256,17 @@ compute-locally category for Lambda + API Gateway).
   an image-override Dockerfile picker, and the app dir is scanned once
   (`discoverDockerfiles`, only when something is pinned) for the picker's
   options. The picker threads `--image-override <target>=<dockerfile>`
-  through `coerceRunRequest` (validated) + the serve manager.
+  through `coerceRunRequest` (validated) + the serve manager. Issue #354:
+  when studio is booted with `--from-cfn-stack`, the boot pin
+  classification threads the deployed-state image-resolution context per
+  owning stack (`prepareEcsImageContexts` -> `buildEcsImageResolutionContext`
+  -> `makePinClassifier` -> `resolveEcsServiceTarget(id, stacks, ctx)`), so a
+  service pinned to an INTRINSIC ECR URI (only resolvable under
+  `--from-cfn-stack`, e.g. `ContainerImage.fromEcrRepository(repo)`) is
+  detected as pinned — matching `cdkl start-service --from-cfn-stack`; a
+  service that cannot be classified now WARNs instead of silently going
+  unmarked. Boot-time only: a runtime Session-bar `--from-cfn-stack` change
+  does NOT re-classify (restart studio to re-detect).
 - `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
   (`Toolkit.fromCdkApp()` + context store threading) that returns
   `StackInfo[]` for downstream consumers.

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -42,6 +42,16 @@ import { relayServeRequest } from '../../local/studio-request-relay.js';
 import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
 import { isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
 import { discoverDockerfiles } from '../../local/image-override-engine.js';
+import { parseEcsTarget, type EcsImageResolutionContext } from '../../local/ecs-task-resolver.js';
+import { matchStacks } from '../stack-matcher.js';
+import {
+  createLocalStateProvider,
+  resolveCfnFallbackRegion,
+  isCfnFlagPresent,
+  rejectExplicitCfnStackWithMultipleStacks,
+} from './local-state-source.js';
+import { buildEcsImageResolutionContext } from './local-run-task.js';
+import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import {
   createStudioServeManager,
   type StudioServeManager,
@@ -339,6 +349,173 @@ export function resolveBootAssemblyDir(appCmd: string, output: string): string |
   return undefined;
 }
 
+/**
+ * Resolve the {@link StackInfo} an ECS-service target id belongs to.
+ *
+ * A studio ECS target id is a CDK display path (`Stack/Construct/...`) or a
+ * `Stack:LogicalId` form (the same shapes {@link resolveEcsServiceTarget}
+ * accepts). We only need the owning stack so we can build that stack's
+ * {@link EcsImageResolutionContext}. Returns `undefined` when the id has no
+ * stack segment (single-stack app uses the lone stack) or the segment matches
+ * no / multiple stacks — the caller then resolves without an image context,
+ * which is exactly the no-`--from-cfn-stack` behavior.
+ *
+ * Exported for unit testing.
+ */
+export function resolveEcsServiceStack(
+  targetId: string,
+  stacks: StackInfo[]
+): StackInfo | undefined {
+  const parsed = parseEcsTarget(targetId);
+  if (parsed.stackPattern === null) {
+    return stacks.length === 1 ? stacks[0] : undefined;
+  }
+  const matched = matchStacks(stacks, [parsed.stackPattern]);
+  return matched.length === 1 ? matched[0] : undefined;
+}
+
+/** The subset of studio options the pin classifier forwards to the state-source helpers. */
+export type LocalStateSourceLikeOptions = {
+  fromCfnStack?: string | boolean;
+  region?: string;
+  profile?: string;
+  stackRegion?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Pre-build the per-stack {@link EcsImageResolutionContext} map the boot-time
+ * pin classifier needs (issue #354). `buildEcsImageResolutionContext` is
+ * async (it may load deployed state / call STS), but the classify callback
+ * `annotatePinnedEcsTargets` invokes is synchronous, so the contexts must be
+ * materialized BEFORE classification.
+ *
+ * When `--from-cfn-stack` is NOT set, returns an empty map and the classifier
+ * resolves against the synthed template only (the historical behavior). When
+ * it IS set, for every distinct stack that owns a servable ECS service id this
+ * builds a `LocalStateProvider` bound to THAT stack (so a multi-stack app with
+ * bare `--from-cfn-stack` reads each stack's own CFn counterpart — the CFn
+ * provider is stack-bound at construction, `load()` ignores its stack-name
+ * argument), then builds + caches that stack's image-resolution context once.
+ * Each per-stack provider is disposed before returning.
+ *
+ * A per-stack build failure is logged as a WARN and that stack maps to
+ * `undefined` (resolve without an image context) rather than aborting boot.
+ *
+ * Exported for unit testing.
+ */
+export async function prepareEcsImageContexts(args: {
+  serviceIds: string[];
+  stacks: StackInfo[];
+  options: LocalStateSourceLikeOptions;
+  logger: ReturnType<typeof getLogger>;
+}): Promise<Map<string, EcsImageResolutionContext | undefined>> {
+  const { serviceIds, stacks, options, logger } = args;
+  const contextByStack = new Map<string, EcsImageResolutionContext | undefined>();
+  if (!isCfnFlagPresent(options)) return contextByStack;
+
+  // The distinct owning stacks of the servable services, each built at most
+  // once. An explicit `--from-cfn-stack <name>` binds the SINGLE named CFn
+  // stack, so reject it up front when more than one stack owns a service (it
+  // would silently mis-map logical IDs across siblings — same guard the
+  // multi-stack serve commands apply); bare `--from-cfn-stack` is fine.
+  const owningStacks: StackInfo[] = [];
+  const seen = new Set<string>();
+  for (const id of serviceIds) {
+    // A malformed service id must NOT abort studio boot — skip it (the
+    // classifier WARNs + leaves it unmarked too). In practice servable ids are
+    // well-formed CDK display paths, so this is a defensive guard.
+    let stack: StackInfo | undefined;
+    try {
+      stack = resolveEcsServiceStack(id, stacks);
+    } catch {
+      continue;
+    }
+    if (stack && !seen.has(stack.stackName)) {
+      seen.add(stack.stackName);
+      owningStacks.push(stack);
+    }
+  }
+  rejectExplicitCfnStackWithMultipleStacks(options, owningStacks.length);
+
+  for (const stack of owningStacks) {
+    const stateProvider = createLocalStateProvider(
+      options,
+      stack.stackName,
+      await resolveCfnFallbackRegion(options, stack.region)
+    );
+    try {
+      // buildEcsImageResolutionContext reads `region` / `profile` off the bag
+      // for the pseudo-parameter / state-load resolution; the studio options
+      // carry both. The cast bridges to run-task's wider options shape (the
+      // extra required fields like `cluster` are not read by this code path).
+      const ctx = await buildEcsImageResolutionContext(
+        stack,
+        stateProvider,
+        options as unknown as Parameters<typeof buildEcsImageResolutionContext>[2]
+      );
+      contextByStack.set(stack.stackName, ctx);
+    } catch (err) {
+      logger.warn(
+        `studio: could not build deployed-state image context for stack '${stack.stackName}'; ` +
+          `ECS services in it resolve against the synthed template only. ${
+            err instanceof Error ? err.message : String(err)
+          }`
+      );
+      contextByStack.set(stack.stackName, undefined);
+    } finally {
+      stateProvider?.dispose();
+    }
+  }
+  return contextByStack;
+}
+
+/**
+ * Build the boot-time ECS pin classifier `annotatePinnedEcsTargets` calls per
+ * servable service (issue #354). When `--from-cfn-stack` is set, a service
+ * whose container image is an INTRINSIC ECR URI (e.g.
+ * `ContainerImage.fromEcrRepository(repo)`) is only resolvable WITH the
+ * deployed-state image-resolution context — without it the resolver throws
+ * and the service was silently left unmarked, so the UI never offered the
+ * image-override picker even though `cdkl start-service --from-cfn-stack`
+ * detects the very same pin. This threads each service's owning-stack
+ * {@link EcsImageResolutionContext} (pre-built by
+ * {@link prepareEcsImageContexts}) into {@link resolveEcsServiceTarget} so
+ * the pin resolves, and surfaces a WARN (not a silent DEBUG swallow) when a
+ * service still cannot be classified.
+ *
+ * NOTE: the target list + these pinned flags are computed ONCE at boot. A
+ * run-time Session-bar `--from-cfn-stack` change (`PATCH /api/config`) does
+ * NOT re-classify — restart studio to re-detect pins under a new binding.
+ *
+ * Returns a `(id) => boolean` callback (true = pinned). Exported for testing.
+ */
+export function makePinClassifier(args: {
+  stacks: StackInfo[];
+  contextByStack: Map<string, EcsImageResolutionContext | undefined>;
+  logger: ReturnType<typeof getLogger>;
+}): (id: string) => boolean {
+  const { stacks, contextByStack, logger } = args;
+  return (id: string): boolean => {
+    try {
+      const stack = resolveEcsServiceStack(id, stacks);
+      const context = stack ? contextByStack.get(stack.stackName) : undefined;
+      return !isLocalCdkAssetImage(resolveEcsServiceTarget(id, stacks, context));
+    } catch (err) {
+      // Replaces the prior silent DEBUG swallow (issue #354): a service that
+      // cannot be pin-classified is surfaced, not invisibly left unmarked, so
+      // a misconfigured / unresolvable image is visible at boot.
+      logger.warn(
+        `studio: could not classify image-pin status for ECS service '${id}'; leaving it unmarked ` +
+          `(the image-override picker will not be offered). ${
+            err instanceof Error ? err.message : String(err)
+          }`
+      );
+      return false;
+    }
+  };
+}
+
 interface LocalStudioOptions {
   app?: string;
   output: string;
@@ -374,6 +551,13 @@ interface LocalStudioOptions {
    * Lambdas in the target list (hidden by default).
    */
   includeCustomResources?: boolean;
+  /**
+   * Host-injected extra state-source flag fields (parity with `run-task`'s
+   * options bag) — read by {@link createLocalStateProvider} /
+   * {@link prepareEcsImageContexts} for the boot-time ECS pin classification
+   * under `--from-cfn-stack` (issue #354).
+   */
+  [key: string]: unknown;
 }
 
 /**
@@ -473,25 +657,37 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   // Dockerfile picker for those services; a local-asset service already
   // hot-reloads under `--watch` and gets no picker.
   //
-  // Classification is BEST-EFFORT and deliberately STATE-FREE: it reads the
-  // synthed template only (no deployed-state fetch, no AWS calls at boot), so
-  // it is cheap, but under `--from-cfn-stack` an ECR image expressed as an
-  // unresolved intrinsic could be hinted differently than the actual
-  // start-service verdict. The hint only governs whether the UI surfaces the
+  // Classification reads the synthed template by default. Under
+  // `--from-cfn-stack` (set at boot via the CLI flag), an ECR image expressed
+  // as an INTRINSIC URI (e.g. `ContainerImage.fromEcrRepository(repo)`) is
+  // ONLY resolvable with the deployed-state image-resolution context — the
+  // same context `cdkl run-task` / `start-service --from-cfn-stack` build. So
+  // we build a `LocalStateProvider` once at boot and thread each service's
+  // owning-stack `EcsImageResolutionContext` into the resolver; without it the
+  // service would silently stay unmarked even though start-service detects the
+  // pin (issue #354). The hint only governs whether the UI surfaces the
   // picker; a mis-hinted service can still be overridden via the "All options"
-  // raw-args `--image-override`. Per-target resolution failures are non-fatal
-  // (the service stays unmarked). Dockerfiles are scanned once, only when at
-  // least one service is pinned, so an all-local app pays nothing.
-  const anyPinned = annotatePinnedEcsTargets(targetGroups, (id) => {
-    try {
-      return !isLocalCdkAssetImage(resolveEcsServiceTarget(id, stacks));
-    } catch (err) {
-      logger.debug(
-        `studio: could not classify pin status for '${id}': ${err instanceof Error ? err.message : String(err)}`
-      );
-      return false;
-    }
+  // raw-args `--image-override`. A service that still cannot be classified is
+  // WARN-logged (not silently swallowed). Dockerfiles are scanned once, only
+  // when at least one service is pinned, so an all-local app pays nothing.
+  //
+  // NOTE: the target list + pinned flags are boot-time only. A run-time
+  // Session-bar `--from-cfn-stack` change (`PATCH /api/config`) does NOT
+  // re-classify — restart studio to re-detect pins under a new binding.
+  // Pre-build each owning stack's deployed-state image-resolution context
+  // (only under `--from-cfn-stack`; each per-stack state provider is created
+  // + disposed inside the helper), then classify every servable service with
+  // its stack's context threaded into the resolver.
+  const contextByStack = await prepareEcsImageContexts({
+    serviceIds: [...servableEcs],
+    stacks,
+    options,
+    logger,
   });
+  const anyPinned = annotatePinnedEcsTargets(
+    targetGroups,
+    makePinClassifier({ stacks, contextByStack, logger })
+  );
   const dockerfiles = anyPinned ? discoverDockerfiles(process.cwd()) : [];
 
   const bus = new StudioEventBus();

--- a/tests/integration/local-studio-from-cfn-stack/.scenarios.json
+++ b/tests/integration/local-studio-from-cfn-stack/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-studio-pin-from-cfn-stack"
+  ]
+}

--- a/tests/integration/local-studio-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-studio-from-cfn-stack/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStudioFromCfnStackStack } from '../lib/local-studio-from-cfn-stack-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStudioFromCfnStackStack(app, 'CdkLocalStudioFromCfnStackFixture', {
+  description: 'Fixture stack for cdkl studio --from-cfn-stack ECS pin classification (issue #354)',
+});

--- a/tests/integration/local-studio-from-cfn-stack/cdk.json
+++ b/tests/integration/local-studio-from-cfn-stack/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-studio-from-cfn-stack/lib/local-studio-from-cfn-stack-stack.ts
+++ b/tests/integration/local-studio-from-cfn-stack/lib/local-studio-from-cfn-stack-stack.ts
@@ -1,0 +1,83 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+
+/**
+ * Fixture stack for `cdkl studio --from-cfn-stack` ECS pin classification
+ * (issue #354).
+ *
+ * The point: an ECS Service whose container image is an INTRINSIC ECR URI
+ * (`ContainerImage.fromEcrRepository(repo)` — a `Fn::Sub` / `Fn::Join`
+ * referencing the repo's `RepositoryUri` plus `AWS::AccountId` /
+ * `AWS::Region` pseudo parameters) is ONLY resolvable with the deployed-state
+ * image-resolution context. `cdkl studio` builds that context at boot ONLY
+ * when `--from-cfn-stack` is passed, so:
+ *
+ *   - WITHOUT `--from-cfn-stack`: the intrinsic image cannot be resolved, the
+ *     pin classifier leaves the service UNMARKED (no `pinned` flag).
+ *   - WITH `--from-cfn-stack <DeployedStackName>`: the boot classifier
+ *     resolves the repo's deployed URI, sees it is a deployed-registry pin
+ *     (not a local CDK asset), and marks the service `pinned: true` so the UI
+ *     offers the image-override Dockerfile picker — matching what
+ *     `cdkl start-service --from-cfn-stack` detects ("Detected pinned image").
+ *
+ * Deploy notes:
+ *   - `desiredCount: 0` so the service deploys WITHOUT waiting for any task to
+ *     reach steady state. No image is ever pushed to the repo; the deploy only
+ *     needs to CREATE the ECR repository so its physical id / URI is returned
+ *     by `ListStackResources` and resolves under `--from-cfn-stack`.
+ *   - `RemovalPolicy.DESTROY` + `emptyOnDelete` on the repo and a minimal
+ *     NAT-less VPC so `cdk destroy` is fully self-contained (no orphan repo /
+ *     NAT gateway left behind).
+ */
+export class LocalStudioFromCfnStackStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // The ECR repository whose intrinsic image URI the service pins to. Its
+    // presence in the deployed stack is the whole point: under
+    // `--from-cfn-stack`, ListStackResources returns it and the intrinsic
+    // image URI resolves, so studio's boot pin classifier marks the service.
+    const repo = new ecr.Repository(this, 'AppRepo', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      emptyOnDelete: true,
+    });
+
+    // Minimal NAT-less VPC — desiredCount:0 means no task ever launches, so no
+    // egress is needed; this keeps the deploy cheap + fast and the teardown
+    // clean (no NAT gateway to orphan).
+    const vpc = new ec2.Vpc(this, 'AppVpc', {
+      maxAzs: 2,
+      natGateways: 0,
+      subnetConfiguration: [
+        { name: 'public', subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+      ],
+    });
+
+    const cluster = new ecs.Cluster(this, 'AppCluster', { vpc });
+
+    const taskDef = new ecs.FargateTaskDefinition(this, 'AppTask', {
+      cpu: 256,
+      memoryLimitMiB: 512,
+    });
+
+    // The container image is an INTRINSIC ECR URI — this is the resource the
+    // classifier can only resolve under `--from-cfn-stack`.
+    taskDef.addContainer('AppContainer', {
+      image: ecs.ContainerImage.fromEcrRepository(repo),
+      logging: ecs.LogDrivers.awsLogs({ streamPrefix: 'app' }),
+    });
+
+    new ecs.FargateService(this, 'AppService', {
+      cluster,
+      taskDefinition: taskDef,
+      // Deploy WITHOUT waiting for a task to stabilize — no image is pushed to
+      // the repo, so a non-zero count would never reach steady state.
+      desiredCount: 0,
+      assignPublicIp: true,
+      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+    });
+  }
+}

--- a/tests/integration/local-studio-from-cfn-stack/package.json
+++ b/tests/integration/local-studio-from-cfn-stack/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-studio-from-cfn-stack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl studio --from-cfn-stack ECS pin classification (issue #354)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
+}

--- a/tests/integration/local-studio-from-cfn-stack/tsconfig.json
+++ b/tests/integration/local-studio-from-cfn-stack/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-studio-from-cfn-stack/verify.sh
+++ b/tests/integration/local-studio-from-cfn-stack/verify.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkl studio --from-cfn-stack` ECS pin
+# classification (issue #354).
+#
+# Why this exists: `cdkl studio` computes each servable ECS service's `pinned`
+# flag ONCE at boot. A service whose container image is an INTRINSIC ECR URI
+# (e.g. `ContainerImage.fromEcrRepository(repo)`) is only resolvable with the
+# deployed-state image-resolution context — which studio builds ONLY when
+# `--from-cfn-stack` is passed at boot. Before issue #354 the classify callback
+# resolved WITHOUT that context and swallowed the failure silently, so the
+# service was left UNMARKED and the UI never offered the image-override picker,
+# even though `cdkl start-service --from-cfn-stack` detects the same pin.
+#
+# This test deploys a fixture stack carrying an ECR repo + an ECS Fargate
+# service pinned to that repo's intrinsic image URI, then:
+#
+#   1. boots `cdkl studio --from-cfn-stack <stack>` and asserts the service
+#      entry in GET /api/targets has "pinned":true (the issue #354 fix), and
+#   2. boots `cdkl studio` WITHOUT --from-cfn-stack as a NEGATIVE CONTROL and
+#      asserts the SAME service is NOT pinned (the intrinsic URI is
+#      unresolvable without the deployed-state context).
+#
+# The service deploys with desiredCount:0 so no task ever launches and no image
+# is pushed to the repo — the deploy only needs to CREATE the ECR repository so
+# its physical id / URI resolves under --from-cfn-stack.
+#
+# Run via `/run-integ local-studio-from-cfn-stack` (recommended) or directly:
+#
+#     bash tests/integration/local-studio-from-cfn-stack/verify.sh
+#
+# Requires Docker (studio boot pre-flights it) AND AWS credentials with deploy
+# permissions. Also requires the global `cdk` (aws-cdk) CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalStudioFromCfnStackFixture"
+# The servable ECS service target id is the CDK display path. The L2
+# FargateService nests its AWS::ECS::Service under a `Service` node, so the
+# listed id is `<Stack>/AppService/Service` (confirm with `cdkl list`).
+SERVICE_ID="${STACK}/AppService/Service"
+HOST="127.0.0.1"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-studio-from-cfn-stack"
+CDKL="node ${REPO_ROOT}/dist/cli.js"
+
+echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed)"
+
+echo "[verify] step 1a: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+
+echo "[verify] step 1b: install fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+echo "[verify] step 1c: verifying Docker is available (studio boot pre-flights it)"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+# State the studio process(es) + temp files clean up on every exit. The stack
+# teardown is gated on a "we created it" sentinel so the pre-flight orphan
+# scan's `exit 1` (a same-named stack pre-exists) never destroys user
+# resources.
+WE_CREATED_STACK=0
+STUDIO_PID=""
+LOG_FILE=$(mktemp)
+BODY_FILE=$(mktemp)
+cleanup() {
+  rc=$?
+  if [[ -n "${STUDIO_PID}" ]] && kill -0 "${STUDIO_PID}" 2>/dev/null; then
+    kill "${STUDIO_PID}" 2>/dev/null || true
+    wait "${STUDIO_PID}" 2>/dev/null || true
+  fi
+  if [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] tearing down: cdk destroy ${STACK}"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  rm -f "${LOG_FILE}" "${BODY_FILE}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists in CloudFormation — clean up first via:"
+  echo "          aws cloudformation delete-stack --stack-name ${STACK} --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 3: cdk deploy (upstream CDK CLI; desiredCount:0 => no task wait)"
+# Set the sentinel BEFORE deploy: pre-flight verified the namespace is clean,
+# so once we issue the deploy we OWN the namespace (cdk destroy is a no-op on
+# a stack that never reached AWS, so this is safe on early-failure paths).
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 3 ok: cdk deploy completed"
+
+# Boot a short-lived studio, wait for /api/targets to answer, dump it to
+# BODY_FILE, and tear the studio down. Args after the function name are passed
+# verbatim to `cdkl studio`. Port 0 => OS-assigned; the bound URL is parsed
+# from the boot log. Generous retries for a cold boot.
+boot_studio_and_fetch_targets() {
+  : >"${LOG_FILE}"
+  ${CDKL} studio --no-open --studio-port 0 "$@" >"${LOG_FILE}" 2>&1 &
+  STUDIO_PID=$!
+  local url=""
+  for _ in $(seq 1 120); do
+    if ! kill -0 "${STUDIO_PID}" 2>/dev/null; then
+      echo "[verify] FAIL: studio exited during boot (args: $*)"; cat "${LOG_FILE}"; return 1
+    fi
+    url=$(grep -oE "http://${HOST}:[0-9]+" "${LOG_FILE}" | head -1 || true)
+    if [[ -n "${url}" ]] && curl -fsS "${url}/api/targets" -o "${BODY_FILE}" 2>/dev/null; then
+      break
+    fi
+    sleep 0.5
+  done
+  if [[ -z "${url}" ]]; then
+    echo "[verify] FAIL: studio never printed a bound URL (args: $*)"; cat "${LOG_FILE}"; return 1
+  fi
+  # Final authoritative fetch.
+  curl -fsS "${url}/api/targets" -o "${BODY_FILE}"
+  kill "${STUDIO_PID}" 2>/dev/null || true
+  wait "${STUDIO_PID}" 2>/dev/null || true
+  STUDIO_PID=""
+}
+
+# Assert (or refute) that the service entry in BODY_FILE carries "pinned":true.
+# The /api/targets payload is `{ "groups": [ { "entries": [ { "id", "pinned",
+# ... } ] } ] }`. We recurse the whole parsed object to find the entry by id
+# and check the pinned flag. python3 keeps the parse robust against key-order /
+# whitespace.
+service_is_pinned() {
+  python3 - "$1" "${SERVICE_ID}" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+target_id = sys.argv[2]
+def walk(obj):
+    found = []
+    if isinstance(obj, dict):
+        if obj.get("id") == target_id:
+            found.append(obj)
+        for v in obj.values():
+            found += walk(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            found += walk(v)
+    return found
+matches = walk(data)
+if not matches:
+    print("MISSING")
+    sys.exit(0)
+entry = matches[0]
+print("PINNED" if entry.get("pinned") is True else "NOT_PINNED")
+PY
+}
+
+echo "[verify] step 4: studio --from-cfn-stack — expect the service is pinned:true (issue #354 fix)"
+boot_studio_and_fetch_targets --from-cfn-stack "${STACK}"
+STATUS_CFN=$(service_is_pinned "${BODY_FILE}")
+echo "[verify]   ${SERVICE_ID} under --from-cfn-stack: ${STATUS_CFN}"
+if [ "${STATUS_CFN}" != "PINNED" ]; then
+  echo "[verify] FAIL: expected ${SERVICE_ID} to be pinned:true under --from-cfn-stack, got ${STATUS_CFN}"
+  echo "[verify]   /api/targets payload:"; cat "${BODY_FILE}"
+  exit 1
+fi
+
+echo "[verify] step 5: studio WITHOUT --from-cfn-stack (negative control) — expect NOT pinned"
+boot_studio_and_fetch_targets
+STATUS_NO_CFN=$(service_is_pinned "${BODY_FILE}")
+echo "[verify]   ${SERVICE_ID} without --from-cfn-stack: ${STATUS_NO_CFN}"
+# Without the deployed-state context the intrinsic ECR URI is unresolvable, so
+# the classifier leaves the service unmarked. Accept NOT_PINNED (the expected
+# control outcome); MISSING would mean the service is not even listed (a synth
+# regression), which is also a failure.
+if [ "${STATUS_NO_CFN}" = "PINNED" ]; then
+  echo "[verify] FAIL: ${SERVICE_ID} should NOT be pinned without --from-cfn-stack (negative control), got ${STATUS_NO_CFN}"
+  echo "[verify]   /api/targets payload:"; cat "${BODY_FILE}"
+  exit 1
+fi
+if [ "${STATUS_NO_CFN}" = "MISSING" ]; then
+  echo "[verify] FAIL: ${SERVICE_ID} not listed at all without --from-cfn-stack (synth/list regression)"
+  echo "[verify]   /api/targets payload:"; cat "${BODY_FILE}"
+  exit 1
+fi
+
+echo "[verify] step 6: cdk destroy --force (handled by the cleanup trap on exit)"
+
+echo ""
+echo "[verify] All checks passed:"
+echo "[verify]   - issue #354: studio --from-cfn-stack marks the intrinsic-ECR-image ECS service pinned:true,"
+echo "[verify]     so the UI offers the image-override Dockerfile picker."
+echo "[verify]   - negative control: WITHOUT --from-cfn-stack the same service is left unmarked (unresolvable intrinsic image)."

--- a/tests/unit/cli/local-studio-pin-classifier.test.ts
+++ b/tests/unit/cli/local-studio-pin-classifier.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { EcsImageResolutionContext } from '../../../src/local/ecs-task-resolver.js';
+
+// Mock every external boundary the boot-time pin classifier touches so the
+// tests exercise the wiring (issue #354) without synth / Docker / AWS.
+const hoisted = vi.hoisted(() => ({
+  resolveEcsServiceTarget: vi.fn(),
+  isLocalCdkAssetImage: vi.fn(),
+  buildEcsImageResolutionContext: vi.fn(),
+  createLocalStateProvider: vi.fn(),
+}));
+
+vi.mock('../../../src/local/ecs-service-resolver.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../src/local/ecs-service-resolver.js')>();
+  return { ...actual, resolveEcsServiceTarget: hoisted.resolveEcsServiceTarget };
+});
+vi.mock('../../../src/local/image-pin-detector.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/local/image-pin-detector.js')>();
+  return { ...actual, isLocalCdkAssetImage: hoisted.isLocalCdkAssetImage };
+});
+// Partial mock: local-studio.ts only calls buildEcsImageResolutionContext, but
+// studio-option-catalog (transitively imported) needs the real
+// createLocalRunTaskCommand factory, so preserve every other export.
+vi.mock('../../../src/cli/commands/local-run-task.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/cli/commands/local-run-task.js')>();
+  return { ...actual, buildEcsImageResolutionContext: hoisted.buildEcsImageResolutionContext };
+});
+// Stub the per-stack state-provider factory so the test asserts the wiring
+// (provider built under --from-cfn-stack, disposed) without an AWS / CFn call.
+// resolveCfnFallbackRegion + rejectExplicitCfnStackWithMultipleStacks keep
+// their real (pure) behavior.
+vi.mock('../../../src/cli/commands/local-state-source.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../src/cli/commands/local-state-source.js')>();
+  return { ...actual, createLocalStateProvider: hoisted.createLocalStateProvider };
+});
+
+const {
+  resolveEcsServiceStack,
+  prepareEcsImageContexts,
+  makePinClassifier,
+} = await import('../../../src/cli/commands/local-studio.js');
+
+function stack(name: string, region?: string): StackInfo {
+  return {
+    stackName: name,
+    displayName: name,
+    artifactId: name,
+    template: { Resources: {} },
+    dependencyNames: [],
+    ...(region !== undefined ? { region } : {}),
+  } as StackInfo;
+}
+
+function fakeLogger() {
+  return {
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    setLevel: vi.fn(),
+  } as unknown as ReturnType<
+    typeof import('../../../src/utils/logger.js').getLogger
+  >;
+}
+
+beforeEach(() => {
+  hoisted.resolveEcsServiceTarget.mockReset();
+  hoisted.isLocalCdkAssetImage.mockReset();
+  hoisted.buildEcsImageResolutionContext.mockReset();
+  hoisted.createLocalStateProvider.mockReset();
+});
+
+describe('resolveEcsServiceStack', () => {
+  it('returns the lone stack for an id with no stack segment', () => {
+    const s = stack('OnlyStack');
+    expect(resolveEcsServiceStack('Svc', [s])).toBe(s);
+  });
+
+  it('returns undefined for an unprefixed id when multiple stacks exist', () => {
+    expect(resolveEcsServiceStack('Svc', [stack('A'), stack('B')])).toBeUndefined();
+  });
+
+  it('matches a path-form id by its stack segment', () => {
+    const dev = stack('dev');
+    const prod = stack('prod');
+    expect(resolveEcsServiceStack('dev/Svc/Service', [dev, prod])).toBe(dev);
+  });
+
+  it('matches a stack:logicalId id by its stack segment', () => {
+    const dev = stack('dev');
+    const prod = stack('prod');
+    expect(resolveEcsServiceStack('prod:SvcABC123', [dev, prod])).toBe(prod);
+  });
+});
+
+describe('prepareEcsImageContexts', () => {
+  it('returns an empty map and builds NO state provider when --from-cfn-stack is not set', async () => {
+    const logger = fakeLogger();
+    const map = await prepareEcsImageContexts({
+      serviceIds: ['dev/Svc'],
+      stacks: [stack('dev')],
+      options: {},
+      logger,
+    });
+    expect(map.size).toBe(0);
+    expect(hoisted.createLocalStateProvider).not.toHaveBeenCalled();
+    expect(hoisted.buildEcsImageResolutionContext).not.toHaveBeenCalled();
+  });
+
+  it('builds ONE state provider + context per owning stack under --from-cfn-stack, then disposes it', async () => {
+    const logger = fakeLogger();
+    const ctx: EcsImageResolutionContext = { stateResources: {} };
+    const dispose = vi.fn();
+    hoisted.createLocalStateProvider.mockReturnValue({ dispose });
+    hoisted.buildEcsImageResolutionContext.mockResolvedValue(ctx);
+
+    const map = await prepareEcsImageContexts({
+      // Two services in the SAME stack => one provider + one context build.
+      serviceIds: ['dev/SvcA', 'dev/SvcB'],
+      stacks: [stack('dev', 'us-east-1')],
+      options: { fromCfnStack: true },
+      logger,
+    });
+
+    expect(hoisted.createLocalStateProvider).toHaveBeenCalledTimes(1);
+    expect(hoisted.buildEcsImageResolutionContext).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(map.get('dev')).toBe(ctx);
+  });
+
+  it('builds a SEPARATE provider + context per DISTINCT owning stack (bare --from-cfn-stack)', async () => {
+    const logger = fakeLogger();
+    const ctx: EcsImageResolutionContext = { stateResources: {} };
+    hoisted.createLocalStateProvider.mockReturnValue({ dispose: vi.fn() });
+    hoisted.buildEcsImageResolutionContext.mockResolvedValue(ctx);
+
+    const map = await prepareEcsImageContexts({
+      serviceIds: ['dev/Svc', 'prod/Svc'],
+      stacks: [stack('dev', 'us-east-1'), stack('prod', 'us-west-2')],
+      options: { fromCfnStack: true },
+      logger,
+    });
+
+    // One provider + one context build PER distinct owning stack.
+    expect(hoisted.createLocalStateProvider).toHaveBeenCalledTimes(2);
+    expect(hoisted.buildEcsImageResolutionContext).toHaveBeenCalledTimes(2);
+    expect(map.get('dev')).toBe(ctx);
+    expect(map.get('prod')).toBe(ctx);
+  });
+
+  it('rejects an EXPLICIT --from-cfn-stack <name> when services span multiple stacks', async () => {
+    const logger = fakeLogger();
+    hoisted.createLocalStateProvider.mockReturnValue({ dispose: vi.fn() });
+    hoisted.buildEcsImageResolutionContext.mockResolvedValue(undefined);
+
+    // An explicit stack name binds ONE CFn stack; >1 owning stack is ambiguous
+    // and must fail fast (the real `rejectExplicitCfnStackWithMultipleStacks`).
+    await expect(
+      prepareEcsImageContexts({
+        serviceIds: ['dev/Svc', 'prod/Svc'],
+        stacks: [stack('dev', 'us-east-1'), stack('prod', 'us-west-2')],
+        options: { fromCfnStack: 'MyDeployedStack' },
+        logger,
+      })
+    ).rejects.toThrow();
+    // No provider is built once the guard rejects.
+    expect(hoisted.createLocalStateProvider).not.toHaveBeenCalled();
+  });
+
+  it('skips a malformed service id instead of aborting boot', async () => {
+    const logger = fakeLogger();
+    const ctx: EcsImageResolutionContext = { stateResources: {} };
+    hoisted.createLocalStateProvider.mockReturnValue({ dispose: vi.fn() });
+    hoisted.buildEcsImageResolutionContext.mockResolvedValue(ctx);
+
+    // '' is malformed (resolveEcsServiceStack -> parseEcsTarget throws); the
+    // well-formed id is still classified. The call must NOT reject.
+    const map = await prepareEcsImageContexts({
+      serviceIds: ['', 'dev/Svc'],
+      stacks: [stack('dev', 'us-east-1')],
+      options: { fromCfnStack: true },
+      logger,
+    });
+    expect(map.get('dev')).toBe(ctx);
+  });
+
+  it('passes the deployed-state context to buildEcsImageResolutionContext (the issue #354 thread)', async () => {
+    const logger = fakeLogger();
+    const provider = { dispose: vi.fn() };
+    hoisted.createLocalStateProvider.mockReturnValue(provider);
+    hoisted.buildEcsImageResolutionContext.mockResolvedValue(undefined);
+
+    await prepareEcsImageContexts({
+      serviceIds: ['dev/Svc'],
+      stacks: [stack('dev', 'us-east-1')],
+      options: { fromCfnStack: true },
+      logger,
+    });
+
+    expect(hoisted.buildEcsImageResolutionContext).toHaveBeenCalledWith(
+      expect.objectContaining({ stackName: 'dev' }),
+      provider,
+      expect.objectContaining({ fromCfnStack: true })
+    );
+  });
+
+  it('maps a stack to undefined and WARNs when its context build throws', async () => {
+    const logger = fakeLogger();
+    const dispose = vi.fn();
+    hoisted.createLocalStateProvider.mockReturnValue({ dispose });
+    hoisted.buildEcsImageResolutionContext.mockRejectedValue(new Error('state load failed'));
+
+    const map = await prepareEcsImageContexts({
+      serviceIds: ['dev/Svc'],
+      stacks: [stack('dev', 'us-east-1')],
+      options: { fromCfnStack: true },
+      logger,
+    });
+
+    expect(map.get('dev')).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('state load failed'));
+    // Provider is still disposed on the failure path.
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('makePinClassifier', () => {
+  it('marks a registry-pinned service as pinned (true)', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockReturnValue({ id: 'resolved' });
+    hoisted.isLocalCdkAssetImage.mockReturnValue(false); // not a local asset => pinned
+
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+    });
+
+    expect(classify('dev/Svc')).toBe(true);
+  });
+
+  it('does NOT mark a local-asset service (false)', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockReturnValue({ id: 'resolved' });
+    hoisted.isLocalCdkAssetImage.mockReturnValue(true); // local asset => not pinned
+
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+    });
+
+    expect(classify('dev/Svc')).toBe(false);
+  });
+
+  it('threads the owning-stack image context into resolveEcsServiceTarget', () => {
+    const logger = fakeLogger();
+    const ctx: EcsImageResolutionContext = { stateResources: { Repo: { id: 'r' } } };
+    hoisted.resolveEcsServiceTarget.mockReturnValue({ id: 'resolved' });
+    hoisted.isLocalCdkAssetImage.mockReturnValue(false);
+
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map([['dev', ctx]]),
+      logger,
+    });
+
+    classify('dev/Svc');
+    expect(hoisted.resolveEcsServiceTarget).toHaveBeenCalledWith(
+      'dev/Svc',
+      expect.any(Array),
+      ctx
+    );
+  });
+
+  it('resolves with NO context when no --from-cfn-stack context was built', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockReturnValue({ id: 'resolved' });
+    hoisted.isLocalCdkAssetImage.mockReturnValue(true);
+
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(), // empty => no context
+      logger,
+    });
+
+    classify('dev/Svc');
+    expect(hoisted.resolveEcsServiceTarget).toHaveBeenCalledWith(
+      'dev/Svc',
+      expect.any(Array),
+      undefined
+    );
+  });
+
+  it('WARNs (not silent) and returns false when classification throws', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockImplementation(() => {
+      throw new Error('cannot resolve image');
+    });
+
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+    });
+
+    expect(classify('dev/Svc')).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('cannot resolve image'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("'dev/Svc'"));
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl studio` computes each ECS service's `pinned` flag ONCE at boot to decide
whether to offer the image-override Dockerfile picker. The classifier resolved
the service image against the synthesized template only — it did NOT thread the
session `--from-cfn-stack` deployed-state context — and swallowed resolution
failures silently. So a service pinned to an INTRINSIC ECR URI (only resolvable
under `--from-cfn-stack`, e.g. `ContainerImage.fromEcrRepository(repo)`) was left
unmarked: no picker, even though `cdkl start-service --from-cfn-stack` detects it.

## Fix

When studio is booted with `--from-cfn-stack`, the boot pin classification builds
the deployed-state image-resolution context PER owning stack
(`prepareEcsImageContexts` -> `buildEcsImageResolutionContext`, each
`LocalStateProvider` disposed) and threads it into
`resolveEcsServiceTarget(id, stacks, ctx)` via `makePinClassifier`, so the
intrinsic ECR image resolves to its deployed registry URI and the service is
marked pinned — matching `cdkl start-service --from-cfn-stack`. A service that
cannot be classified now WARNs instead of silently going unmarked.

Boot-time only: the target list + pinned flags are computed once at boot, so a
runtime Session-bar `--from-cfn-stack` change does not re-classify (restart
studio to re-detect) — documented in the code + CLAUDE.md.

## Behavior note (host-facing)

Studio's boot pin classification now makes deployed-state (CFn `ListStackResources`)
calls when `--from-cfn-stack` is set at boot. A host CLI embedding studio inherits
this transparently; no host-side change beyond bumping the `cdk-local` version.

## Test plan

- Unit (`local-studio-pin-classifier`): 13 tests mocking `resolveEcsServiceTarget`
  / `isLocalCdkAssetImage` / `buildEcsImageResolutionContext` /
  `createLocalStateProvider` — the context is threaded under `--from-cfn-stack`,
  no provider is built without it, providers are disposed on success + failure, a
  registry pin -> `pinned` / local asset -> not pinned, and a classification
  failure WARNs (not silent).
- Integ (`local-studio-from-cfn-stack`, **real AWS**, ran clean): a new fixture
  deploys a stack with an ECR repo + a Fargate service (`desiredCount: 0`) imaged
  via `fromEcrRepository(repo)` (intrinsic URI), then `cdkl studio
  --from-cfn-stack` asserts the service is `pinned:true` AND a studio WITHOUT the
  flag asserts it is NOT pinned (negative control). `cdk destroy` in a cleanup
  trap — verified 0 orphan stacks + 0 Docker orphans after the run.

Closes #354
