### PR TITLE
feat(cloudfront): serve a CloudFront distribution locally (start-cloudfront)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -185,6 +185,34 @@ AWS managed services.
   `POST /` paths logs a one-line WARN and proceeds single-shot
 - API Gateway authorizers — Lambda authorizers, Cognito User Pool JWT
   verification, IAM SigV4 verification
+- CloudFront distributions — the `viewer-request` -> S3 origin ->
+  `viewer-response` pipeline served locally (`cdkl start-cloudfront`,
+  issue #363). The distribution's `AWS::CloudFront::Function`s (inline
+  rewrite JS — URL rewrites, trailing-slash normalization, SPA fallback,
+  header tweaks) are your own application compute and run in-process in a
+  `node:vm` sandbox (`cloudfront-js-1.0` / `2.0`, async handlers awaited);
+  the S3 origin content is the BucketDeployment source asset resolved out
+  of the cloud assembly (walk the origin's bucket -> its
+  `Custom::CDKBucketDeployment` -> `SourceObjectKeys` -> the staged asset
+  dir), served with `DefaultRootObject` (root only — sub-paths are NOT
+  auto-indexed, matching CloudFront) and `CustomErrorResponses` (the SPA
+  fallback). Path patterns route across `DefaultCacheBehavior` +
+  `CacheBehaviors[]` (the existing ALB `*`/`?` glob matcher). A
+  viewer-request function returning a `statusCode` short-circuits with a
+  generated response (redirect / fixed body); otherwise the rewritten
+  request continues to the origin, then the viewer-response function runs
+  over the origin response. `--watch` re-synths + atomically swaps the
+  in-memory routing model under the live socket (no Docker, so a reload
+  is just re-synth + re-resolve). `--tls` terminates real HTTPS (reusing
+  the ALB front-door's self-signed cert path); `--origin <id>=<dir>`
+  points an origin at a local directory when BucketDeployment resolution
+  cannot (content uploaded out of band, non-CDK bucket). S3 origins
+  ONLY: a custom (non-S3) origin, a `LambdaFunctionAssociations`
+  Lambda@Edge association, the KeyValueStore, and the 2.0 `cf.fetch`
+  origin API are WARN-and-skip (custom / unresolved origins return 502).
+  Single distribution per invocation (interactive picker when the target
+  is omitted in a TTY). `cdkl studio` integration is tracked separately
+  (issue #367)
 
 ### Calls real AWS (managed services)
 
@@ -212,9 +240,17 @@ compute-locally category for Lambda + API Gateway).
 - `src/cli/` — Commander command factories (`createLocalInvokeCommand`,
   `createLocalInvokeAgentCoreCommand`, `createLocalStartApiCommand`,
   `createLocalRunTaskCommand`, `createLocalStartServiceCommand`,
-  `createLocalStartAlbCommand`, `createLocalListCommand`,
+  `createLocalStartAlbCommand`, `createLocalStartCloudFrontCommand`,
+  `createLocalListCommand`,
   `createLocalStudioCommand`) + shared option
-  helpers. `start-service` and `start-alb` share one neutral orchestration
+  helpers. `createLocalStartCloudFrontCommand` (`cdkl start-cloudfront`,
+  issue #363) is a thin, lean command (NOT through the ECS/Docker
+  `runEcsServiceEmulator` — no containers / Cloud Map): it synths,
+  resolves one `AWS::CloudFront::Distribution` to an in-memory routing
+  model, and serves its viewer-request -> S3 origin -> viewer-response
+  pipeline in-process. `--watch` re-synths + swaps the routing model
+  under the live socket; `--tls` reuses `front-door-tls`; `--origin
+  <id>=<dir>` is the BucketDeployment-source escape hatch. `start-service` and `start-alb` share one neutral orchestration
   in `commands/ecs-service-emulator.ts` (synth + shared docker network +
   Cloud Map + restart watcher + optional front-door); each command is a
   thin strategy over it (service targets vs ALB targets).
@@ -319,6 +355,23 @@ compute-locally category for Lambda + API Gateway).
   WebSocket `Upgrade` requests run through the same route + auth
   pipeline, then bridge the raw TCP socket to the picked ECS replica
   with `Upgrade` / `Sec-WebSocket-*` headers preserved),
+  cloudfront-resolver (issue #363 — resolves an
+  `AWS::CloudFront::Distribution` to a `ResolvedDistribution`: behaviors
+  (default + `CacheBehaviors[]`) -> path pattern + viewer-request /
+  viewer-response CloudFront Functions, origins (S3 origin -> local
+  BucketDeployment source dir via the asset manifest, custom / unresolved
+  origins flagged), and custom error responses; the `start-cloudfront`
+  entry), cloudfront-function-runtime (compiles + runs an inline
+  CloudFront Function in a `node:vm` sandbox, builds the
+  viewer-request / viewer-response event from an HTTP request, and
+  interprets the handler's return as continue-to-origin vs short-circuit
+  response), cloudfront-static-origin (serves a URI from the resolved S3
+  origin dir(s): default-root-object at `/`, path-traversal guard, MIME
+  by extension, `CustomErrorResponses` SPA fallback), cloudfront-server
+  (the local HTTP/HTTPS server behind `start-cloudfront`: per-request
+  behavior match -> viewer-request fn -> S3 static origin ->
+  viewer-response fn, with a mutable distribution cell so `--watch`
+  swaps the routing model under the live socket),
   studio-custom-resource-filter (issue #323 —
   `isCustomResourceLambdaTarget` / `filterStudioCustomResources`:
   recognizes CDK custom-resource / provider-framework Lambdas by their
@@ -717,7 +770,7 @@ vp run runtime:smoke
 - `cdk-local` is the **npm package** name (what users import / install).
 - When referring to the project in prose, use "cdk-local".
 - When referring to the CLI command in code blocks / examples, use
-  `cdkl invoke / invoke-agentcore / start-api / run-task / start-service / start-alb / list`.
+  `cdkl invoke / invoke-agentcore / start-api / run-task / start-service / start-alb / start-cloudfront / list`.
 - Do NOT name, recommend, or compare against any third-party product
   in committed artifacts (README, docs, JSDoc, CONTRIBUTING). No
   comparison tables, no "pair with" / "use alongside" recommendations,

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The locally executable resources are listed under [Supported resources](#support
 
 Run every `cdkl` command from your CDK project root (the directory containing `cdk.json`).
 
-Run any command with no target for an arrow-key picker (`invoke` / `invoke-agentcore` / `run-task` pick one; `start-service` / `start-alb` / `start-api` multi-select). Or name a target — the CDK display path (recommended) or a stack-qualified logical ID (`MyStack:Fn1234ABCD`, the SAM-compatible form); single-stack apps may drop the stack prefix.
+Run any command with no target for an arrow-key picker (`invoke` / `invoke-agentcore` / `run-task` / `start-cloudfront` pick one; `start-service` / `start-alb` / `start-api` multi-select). Or name a target — the CDK display path (recommended) or a stack-qualified logical ID (`MyStack:Fn1234ABCD`, the SAM-compatible form); single-stack apps may drop the stack prefix.
 
 ```bash
 cdkl invoke MyStack/Fn --event ./event.json   # Lambda (ZIP or container image)
@@ -63,6 +63,7 @@ cdkl run-task MyStack/Task                     # ECS task, run once
 cdkl start-service MyStack/Worker              # ECS service replicas (no load balancer)
 cdkl start-alb MyStack/WebAlb                  # ECS behind an ALB (front-door per listener)
 cdkl start-api MyStack/Api                     # API Gateway REST v1 / HTTP v2 / WebSocket + Function URLs
+cdkl start-cloudfront MyStack/SiteDist         # CloudFront Functions + S3 origin routing (static site / SPA)
 cdkl invoke-agentcore MyStack/Agent            # Bedrock AgentCore Runtime (HTTP / MCP / A2A / AGUI)
 cdkl list                                      # every runnable target, grouped by command (alias: ls)
 cdkl studio                                    # interactive web console over every target
@@ -82,6 +83,7 @@ cdkl invoke MyStack/Fn --from-cfn-stack --assume-role   # ...and run as its depl
 - **`start-api`** serves one HTTP server per API; a bare `start-api` in a multi-stack app needs `--all-stacks` or `--stack <name>`.
 - **`run-task`** / single-replica **`start-service`** publish declared container ports on the host (a privileged port like 80 auto-remaps to a free high host port with a WARN; `--host-port <container>=<host>` pins a specific one). **`start-service`** / **`start-alb`** also list each host URL in a `Service endpoints:` banner after boot so the access URL stays visible.
 - **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement), and WebSocket `Upgrade` proxying to ECS targets ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
+- **`start-cloudfront`** serves a CloudFront distribution's `viewer-request` -> S3 origin -> `viewer-response` pipeline locally: it runs the distribution's CloudFront Functions (the same inline rewrite JS, in-process) over the S3 origin content resolved from the BucketDeployment source in the cloud assembly, so a URL-rewrite / routing / SPA-fallback change is verifiable in seconds instead of a deploy. Serves S3 origins only; custom origins and Lambda@Edge are not run (warn-and-skip). `--origin <id>=<dir>` points an origin at a local directory when the source can't be resolved automatically; `--tls` terminates real HTTPS; `--watch` re-synths + swaps the routing model on save.
 - **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, all four runtime protocols (HTTP and AGUI on 8080, MCP on 8000, A2A on 9000; SSE and WebSocket are HTTP wire-shape variants on the same 8080 container), with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
 - **`studio`** opens a local web console over the same synthesized targets — a point-and-click front over the same CLI runners. Takes no target (it lists them all). Flags + in-UI controls: [Web console — `cdkl studio`](#web-console--cdkl-studio).
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
@@ -214,6 +216,7 @@ Most CDK ECS apps boot multiple replicas behind an ALB. cdk-local exposes each l
 | ECS services | `start-service` |
 | Cloud Map / Service Connect registry | service discovery between local replicas |
 | ALB-fronted ECS / Lambda services | `start-alb` — HTTP / HTTPS listeners, all six listener-rule conditions, weighted forwards, redirect / fixed-response, mixed ECS + Lambda targets, authenticate-cognito / authenticate-oidc (local Bearer-JWT enforcement), WebSocket Upgrade |
+| CloudFront distributions (S3 origin + CloudFront Functions) | `start-cloudfront` — viewer-request / viewer-response Functions over S3 origin routing, default root object, custom error responses (SPA fallback), `--tls`, `--watch` |
 | Bedrock AgentCore Runtime agents | `invoke-agentcore` — container + `fromCodeAsset` / `fromS3` artifacts, HTTP / MCP / A2A / AGUI |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1450,6 +1450,96 @@ remote, or use a permissive loopback CIDR for local smoke tests.
   frontable ECS service behind it, port bind failure) OR uncaught exception.
 - `130` — exited via SIGINT (`^C`).
 
+## `cdkl start-cloudfront` (serve a CloudFront distribution locally)
+
+`cdkl start-cloudfront <target>` reproduces a CloudFront distribution's
+**viewer-request → S3 origin → viewer-response** pipeline on a local HTTP
+(or HTTPS) server, so a URL-rewrite / routing / SPA-fallback change is
+verifiable in seconds instead of a deploy. A CloudFront Function is your
+own application compute — a few lines of rewrite JS — and this command
+runs it wired to the actual S3 origin content (default root object, the
+real keys, index / error-page fallback), which is exactly the end-to-end
+connection a unit test of the function alone cannot exercise. No Docker is
+needed: the functions run in-process and the origin is served from local
+files.
+
+This serves the static-site / SPA shape — an **S3 origin** plus
+CloudFront Functions. It does NOT emulate the managed CloudFront service:
+custom (non-S3) origins, Lambda@Edge (`LambdaFunctionAssociations`), the
+KeyValueStore, and the 2.0 `cf.fetch` origin API are out of scope
+(warn-and-skip).
+
+### Resolution model
+
+`start-cloudfront` resolves the distribution you name →
+its `DistributionConfig`:
+
+- **Behaviors** — `DefaultCacheBehavior` + each `CacheBehaviors[]` entry.
+  A request is matched against the `CacheBehaviors[]` path patterns (the
+  ALB `*` / `?` glob) in declared order, falling back to the default
+  behavior.
+- **CloudFront Functions** — each behavior's `FunctionAssociations[]`
+  (`{Fn::GetAtt: [<fn>, FunctionARN]}`) → the `AWS::CloudFront::Function`'s
+  inline `FunctionCode`, compiled once and run per request in a `node:vm`
+  sandbox (`cloudfront-js-1.0` / `2.0`; async handlers awaited). A
+  viewer-request function returning a `statusCode` short-circuits with a
+  generated response (redirect / fixed body); otherwise the rewritten
+  request continues to the origin. A viewer-response function then runs
+  over the origin response.
+- **S3 origin → local content** — the behavior's `TargetOriginId` → the
+  origin's bucket (`{Fn::GetAtt: [<bucket>, RegionalDomainName]}`) → the
+  `Custom::CDKBucketDeployment` custom resource whose
+  `DestinationBucketName` is that bucket → its `SourceObjectKeys` → the
+  staged asset directory in the cloud assembly (the same files that would
+  be uploaded). `DefaultRootObject` is applied at `/` only — CloudFront
+  does NOT auto-index sub-paths (that is what a rewrite function does).
+  `CustomErrorResponses` (e.g. `403 → /index.html`) provide the SPA
+  fallback for a missing key.
+
+### Target resolution
+
+- `Stack/Dist` (display path), an ancestor prefix, or `Stack:LogicalId`;
+  single-stack apps may omit the stack prefix. Omit `<target>` in a TTY to
+  pick interactively.
+- The target MUST resolve to an `AWS::CloudFront::Distribution`. One
+  distribution per invocation.
+
+### Options
+
+On top of the [common flags](#common-flags):
+
+| Flag | Default | Behavior |
+| --- | --- | --- |
+| `--port <port>` | `0` (auto-allocate) | Host port for the local server. |
+| `--host <host>` | `127.0.0.1` | Bind address. |
+| `--origin <originId=dir>` | — | Point a distribution origin at a local directory (repeatable). Use when cdk-local cannot resolve the origin's BucketDeployment source automatically (content uploaded out of band, or a non-CDK bucket). |
+| `--tls` | off | Terminate real HTTPS. Uses `--tls-cert` / `--tls-key` when supplied, else an auto-generated self-signed cert (cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`; requires `openssl` on PATH). Implied by `--tls-cert` / `--tls-key`. |
+| `--tls-cert <path>` | unset | PEM server certificate. Implies `--tls`; must be set with `--tls-key`. |
+| `--tls-key <path>` | unset | PEM server private key matching `--tls-cert`. Implies `--tls`; must be set with `--tls-cert`. |
+| `--watch` | off | Hot reload: re-synth + re-resolve the distribution and atomically swap the in-memory routing model when the CDK app's source changes (honors `cdk.json` `watch.include` / `watch.exclude`; `cdk.out`, `node_modules`, `.git` always excluded). The listening socket is never recreated; a synth failure keeps the previous version serving (warn-and-continue). |
+
+```bash
+# Serve a static-site distribution; pick interactively in a TTY
+cdkl start-cloudfront
+# or name it:
+cdkl start-cloudfront MyStack/SiteDist --port 8080
+# then: curl http://127.0.0.1:8080/        (default root object)
+#       curl http://127.0.0.1:8080/foo/    (viewer-request rewrites -> /foo/index.html)
+
+# Iterate on the rewrite function with hot reload
+cdkl start-cloudfront MyStack/SiteDist --port 8080 --watch
+
+# Point an origin at a local build dir when the source can't be resolved
+cdkl start-cloudfront MyStack/SiteDist --origin SiteOrigin=./dist
+```
+
+### `cdkl start-cloudfront` exit codes
+
+- `0` — server started cleanly and shut down on SIGTERM.
+- `1` — startup failure (target not a distribution, port bind failure,
+  TLS material error) OR uncaught exception.
+- `130` — exited via SIGINT (`^C`).
+
 ## `cdkl studio` (interactive web console)
 
 `cdkl studio` is the interactive counterpart to the headless `invoke` /

--- a/src/cli/commands/local-list.ts
+++ b/src/cli/commands/local-list.ts
@@ -106,7 +106,7 @@ export function formatTargetListing(
   options: FormatTargetListingOptions = {}
 ): string {
   if (countTargets(listing) === 0) {
-    return `No runnable targets (Lambda functions, APIs, ECS services / tasks, AgentCore Runtimes, load balancers) found in this CDK app.`;
+    return `No runnable targets (Lambda functions, APIs, ECS services / tasks, AgentCore Runtimes, load balancers, CloudFront distributions) found in this CDK app.`;
   }
 
   const long = options.long ?? false;
@@ -135,6 +135,12 @@ export function formatTargetListing(
       'Application Load Balancers',
       `${cliName} start-alb <target...>`,
       listing.loadBalancers,
+      long
+    ),
+    formatSection(
+      'CloudFront Distributions',
+      `${cliName} start-cloudfront <target>`,
+      listing.cloudFrontDistributions,
       long
     ),
   ];
@@ -182,7 +188,8 @@ export function createLocalListCommand(opts: CreateLocalListCommandOptions = {})
       'List the runnable targets in the synthesized CDK app, grouped by the command that runs them: ' +
         'Lambda functions (invoke), API Gateway REST v1 / HTTP v2 / Function URL / WebSocket surfaces ' +
         '(start-api), ECS services (start-service), ECS task definitions (run-task), AgentCore ' +
-        'Runtimes (invoke-agentcore), and Application Load Balancers (start-alb). Each target is ' +
+        'Runtimes (invoke-agentcore), Application Load Balancers (start-alb), and CloudFront ' +
+        'distributions (start-cloudfront). Each target is ' +
         'shown by its CDK display path; pass -l to also print the stack-qualified logical ID. Tip: you ' +
         'usually do not need to copy these — just run the command (e.g. `invoke`) with no target in a ' +
         'terminal and pick from the list.'

--- a/src/cli/commands/local-start-cloudfront.ts
+++ b/src/cli/commands/local-start-cloudfront.ts
@@ -1,0 +1,413 @@
+import { Command, Option } from 'commander';
+import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
+import {
+  resolveCloudFrontDistribution,
+  type ResolvedDistribution,
+} from '../../local/cloudfront-resolver.js';
+import {
+  startCloudFrontServer,
+  type StartedCloudFrontServer,
+} from '../../local/cloudfront-server.js';
+import { createFileWatcher, type FileWatcher } from '../../local/file-watcher.js';
+import {
+  resolveFrontDoorTlsMaterials,
+  type FrontDoorTlsMaterials,
+} from '../../local/front-door-tls.js';
+import { parseEcsTarget } from '../../local/ecs-task-resolver.js';
+import { listTargets } from '../../local/target-lister.js';
+import { resolveSingleTarget } from '../../local/target-picker.js';
+import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cdk-path.js';
+import { matchStacks } from '../stack-matcher.js';
+import { resolveApp, resolveWatchConfig } from '../config-loader.js';
+import {
+  appOptions,
+  commonOptions,
+  contextOptions,
+  parseContextOptions,
+  regionOption,
+} from '../options.js';
+import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
+import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { getLogger } from '../../utils/logger.js';
+import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import type { StackInfo } from '../../synthesis/assembly-reader.js';
+import { CLOUDFRONT_DISTRIBUTION_TYPE } from '../../local/cloudfront-resolver.js';
+import { createWatchPredicates } from './local-start-api.js';
+
+/** Error thrown by `cdkl start-cloudfront` for target / option problems. */
+export class LocalStartCloudFrontError extends CdkLocalError {
+  constructor(message: string, cause?: Error) {
+    super(message, 'LOCAL_START_CLOUDFRONT_ERROR', cause);
+  }
+}
+
+interface LocalStartCloudFrontOptions {
+  app?: string;
+  output: string;
+  verbose: boolean;
+  region?: string;
+  profile?: string;
+  roleArn?: string;
+  context?: string[];
+  /** Bind port (default 0 = auto-allocate). */
+  port: string;
+  /** Bind host (default 127.0.0.1). */
+  host: string;
+  /** Repeatable `--origin <id>=<dir>` override. */
+  origin?: string[];
+  /** Opt-in to real TLS termination. */
+  tls?: boolean;
+  tlsCert?: string;
+  tlsKey?: string;
+  /** Hot-reload on CDK source changes. */
+  watch: boolean;
+}
+
+/** Factory options for {@link createLocalStartCloudFrontCommand}. */
+export interface CreateLocalStartCloudFrontCommandOptions {
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
+}
+
+/**
+ * Parse the repeatable `--origin <originId>=<dir>` overrides into a map. Each
+ * value points one of the distribution's origins at a local directory — the
+ * escape hatch for when cdk-local cannot resolve the BucketDeployment source
+ * automatically (content uploaded out of band, or a non-CDK bucket).
+ */
+export function parseOriginOverrides(values: string[] | undefined): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const raw of values ?? []) {
+    const eq = raw.indexOf('=');
+    if (eq <= 0 || eq === raw.length - 1) {
+      throw new LocalStartCloudFrontError(
+        `Invalid --origin '${raw}'. Expected <originId>=<dir> (e.g. MyOrigin=./site).`
+      );
+    }
+    out.set(raw.slice(0, eq).trim(), raw.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+/**
+ * Resolve a CloudFront target string (`Stack/Path` display path or
+ * `Stack:LogicalId`) to its stack + `AWS::CloudFront::Distribution` logical id.
+ * Mirrors the ALB / ECS resolver target grammar.
+ */
+export function resolveCloudFrontTarget(
+  target: string,
+  stacks: StackInfo[]
+): { stack: StackInfo; logicalId: string } {
+  if (stacks.length === 0) {
+    throw new LocalStartCloudFrontError('No stacks found in the synthesized assembly.');
+  }
+  const parsed = parseEcsTarget(target);
+  const stack = pickStack(parsed.stackPattern, stacks, target);
+  const resources = stack.template.Resources ?? {};
+
+  if (parsed.isPath) {
+    const index = buildCdkPathIndex(stack.template);
+    const resolved = resolveCdkPathToLogicalIds(parsed.pathOrId, index);
+    const dists = resolved.filter(({ logicalId }) => {
+      const r = resources[logicalId];
+      return r !== undefined && r.Type === CLOUDFRONT_DISTRIBUTION_TYPE;
+    });
+    if (dists.length === 0) throw notFound(target, stack, resources);
+    if (dists.length > 1) {
+      throw new LocalStartCloudFrontError(
+        `Target '${target}' matches ${dists.length} distributions in ${stack.stackName}: ` +
+          `${dists.map((d) => d.logicalId).join(', ')}. Refine the path or use the stack:LogicalId form.`
+      );
+    }
+    return { stack, logicalId: dists[0]!.logicalId };
+  }
+
+  const res = resources[parsed.pathOrId];
+  if (!res || res.Type !== CLOUDFRONT_DISTRIBUTION_TYPE) throw notFound(target, stack, resources);
+  return { stack, logicalId: parsed.pathOrId };
+}
+
+function pickStack(stackPattern: string | null, stacks: StackInfo[], target: string): StackInfo {
+  if (stackPattern === null) {
+    if (stacks.length === 1) return stacks[0]!;
+    throw new LocalStartCloudFrontError(
+      `Target '${target}' has no stack prefix, and the assembly contains ${stacks.length} stacks: ` +
+        `${stacks.map((s) => s.stackName).join(', ')}. Pass it as 'Stack/Path' or 'Stack:LogicalId'.`
+    );
+  }
+  const matched = matchStacks(stacks, [stackPattern]);
+  if (matched.length === 0) {
+    throw new LocalStartCloudFrontError(
+      `No stack matches '${stackPattern}'. Available stacks: ${stacks.map((s) => s.stackName).join(', ')}.`
+    );
+  }
+  if (matched.length > 1) {
+    throw new LocalStartCloudFrontError(
+      `Multiple stacks match '${stackPattern}': ${matched.map((s) => s.stackName).join(', ')}. Refine the pattern.`
+    );
+  }
+  return matched[0]!;
+}
+
+function notFound(
+  target: string,
+  stack: StackInfo,
+  resources: Record<string, { Type: string }>
+): LocalStartCloudFrontError {
+  const dists = Object.entries(resources)
+    .filter(([, r]) => r.Type === CLOUDFRONT_DISTRIBUTION_TYPE)
+    .map(([logicalId]) => logicalId);
+  const available =
+    dists.length > 0
+      ? ` Available distributions in ${stack.stackName}: ${dists.join(', ')}.`
+      : ` ${stack.stackName} declares no ${CLOUDFRONT_DISTRIBUTION_TYPE} resources.`;
+  return new LocalStartCloudFrontError(
+    `Target '${target}' did not match a CloudFront distribution in ${stack.stackName}.${available}`
+  );
+}
+
+/** Emit boot-time WARNs for parts of the distribution cdk-local does not serve. */
+function warnUnsupported(distribution: ResolvedDistribution): void {
+  const logger = getLogger();
+  for (const origin of distribution.origins.values()) {
+    if (origin.kind === 'custom') {
+      logger.warn(
+        `Origin '${origin.originId}' is a custom (non-S3) origin (${origin.domainName}); cdkl start-cloudfront serves S3 origins only. Requests routed to it return 502.`
+      );
+    } else if (origin.kind === 's3-unresolved') {
+      logger.warn(
+        `Origin '${origin.originId}' is an S3 origin with no resolvable local source (no BucketDeployment found, or its source could not be located in the cloud assembly). ` +
+          `Point it at a directory with --origin ${origin.originId}=<dir>. Requests routed to it return 502.`
+      );
+    }
+  }
+  if (distribution.behaviors.some((b) => b.hasLambdaEdge)) {
+    logger.warn(
+      'One or more cache behaviors carry a Lambda@Edge association; cdk-local does not run Lambda@Edge functions — only CloudFront Functions + the S3 origin are served.'
+    );
+  }
+}
+
+async function localStartCloudFrontCommand(
+  target: string | undefined,
+  options: LocalStartCloudFrontOptions
+): Promise<void> {
+  const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
+
+  const originOverrides = parseOriginOverrides(options.origin);
+  const tlsRequested =
+    options.tls === true || options.tlsCert !== undefined || options.tlsKey !== undefined;
+
+  await applyRoleArnIfSet({
+    roleArn: options.roleArn,
+    region: options.region,
+    profile: options.profile,
+  });
+
+  const appCmd = resolveApp(options.app);
+  if (!appCmd) {
+    throw new LocalStartCloudFrontError(
+      `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+    );
+  }
+
+  const basePort = parseInt(options.port, 10);
+  if (!Number.isFinite(basePort) || basePort < 0 || basePort > 65535) {
+    throw new LocalStartCloudFrontError(`--port must be 0..65535 (got ${options.port}).`);
+  }
+
+  // One synth + resolve pass; reused on the initial boot and every reload.
+  const synthAndResolve = async (): Promise<ResolvedDistribution> => {
+    logger.info('Synthesizing CDK app...');
+    const synthesizer = new Synthesizer();
+    const context = parseContextOptions(options.context);
+    const synthOpts: SynthesisOptions = {
+      app: appCmd,
+      output: options.output,
+      ...(options.region && { region: options.region }),
+      ...(options.profile && { profile: options.profile }),
+      ...(Object.keys(context).length > 0 && { context }),
+    };
+    const { stacks } = await synthesizer.synthesize(synthOpts);
+
+    const chosen = await resolveSingleTarget(target, {
+      entries: listTargets(stacks).cloudFrontDistributions,
+      message: 'Select a CloudFront distribution to serve',
+      noun: 'CloudFront distributions',
+      onMissing: () =>
+        new LocalStartCloudFrontError(
+          `${getEmbedConfig().cliName} start-cloudfront requires a <target>. ` +
+            "Pass a distribution path like 'Stack/MyDist', or run it in a TTY to pick interactively."
+        ),
+    });
+    // Pin the resolved target so reloads don't re-prompt.
+    target = chosen;
+
+    const { stack, logicalId } = resolveCloudFrontTarget(chosen, stacks);
+    return resolveCloudFrontDistribution({ stack, logicalId, originOverrides });
+  };
+
+  const initial = await synthAndResolve();
+  warnUnsupported(initial);
+
+  // TLS resolution (real termination opt-in). Resolved once at boot.
+  let tls: FrontDoorTlsMaterials | undefined;
+  if (tlsRequested) {
+    tls = await resolveFrontDoorTlsMaterials({
+      certPath: options.tlsCert,
+      keyPath: options.tlsKey,
+    });
+  }
+
+  const server: StartedCloudFrontServer = await startCloudFrontServer({
+    distribution: initial,
+    host: options.host,
+    port: basePort,
+    ...(tls && { tls }),
+  });
+
+  // D8.4-style load-bearing banner: verify.sh greps for this exact prefix.
+  process.stdout.write(
+    `CloudFront distribution serving on ${server.url}  (${initial.logicalId})\n`
+  );
+  process.stdout.write('^C to stop.\n');
+
+  // `--watch`: re-synth + swap the in-memory routing model on source change.
+  // No Docker / containers here, so a reload is just re-synth + re-resolve +
+  // `server.update()` — the listening socket is never recreated.
+  let watcher: FileWatcher | undefined;
+  let reloadChain: Promise<unknown> = Promise.resolve();
+  if (options.watch) {
+    const watchRoot = process.cwd();
+    const { ignored, shouldTrigger, excludePatterns } = createWatchPredicates({
+      watchRoot,
+      output: options.output,
+      watchConfig: resolveWatchConfig(),
+    });
+    watcher = createFileWatcher({
+      paths: [watchRoot],
+      ignored,
+      shouldTrigger,
+      onChange: () => {
+        logger.info('Detected source change; reloading...');
+        const next = reloadChain.then(async () => {
+          try {
+            const reloaded = await synthAndResolve();
+            warnUnsupported(reloaded);
+            server.update(reloaded);
+            logger.info('Reload complete.');
+          } catch (err) {
+            logger.warn(
+              `Reload failed; keeping the previous version serving: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        });
+        reloadChain = next.catch(() => undefined);
+      },
+    });
+    logger.info(
+      `Watching ${watchRoot} for source changes (excluding ${excludePatterns.join(', ')}).`
+    );
+  }
+
+  // Graceful shutdown.
+  let shuttingDown = false;
+  const shutdown = async (signal: string, exitCode: number): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info(`Received ${signal}, shutting down...`);
+    if (watcher) {
+      try {
+        await watcher.close();
+      } catch {
+        /* best-effort */
+      }
+    }
+    try {
+      await server.close();
+    } catch {
+      /* best-effort */
+    }
+    process.exit(exitCode);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT', 130));
+  process.on('SIGTERM', () => void shutdown('SIGTERM', 0));
+
+  // Block forever — signal handlers exit the process.
+  await new Promise<never>(() => undefined);
+}
+
+export function createLocalStartCloudFrontCommand(
+  opts: CreateLocalStartCloudFrontCommandOptions = {}
+): Command {
+  setEmbedConfig(opts.embedConfig);
+  const cmd = new Command('start-cloudfront')
+    .description(
+      'Run a long-running local server that serves a CloudFront distribution: its S3 origin content (resolved ' +
+        'from the BucketDeployment source in the cloud assembly) plus its viewer-request / viewer-response ' +
+        'CloudFront Functions, reproducing the distribution routing locally so a rewrite / routing change is ' +
+        'verifiable in seconds. Serves S3 origins only; custom origins and Lambda@Edge are not run (warn-and-skip). ' +
+        'Tip: omit the target in a terminal to pick interactively.'
+    )
+    .argument(
+      '[target]',
+      "CloudFront distribution to serve. Accepts the CDK Construct path ('MyStack/MyDist'), an ancestor prefix, " +
+        "or the stack-qualified logical id ('MyStack:MyDist'). When omitted in a TTY, an interactive picker opens."
+    )
+    .action(
+      withErrorHandling(
+        async (target: string | undefined, options: LocalStartCloudFrontOptions) => {
+          await localStartCloudFrontCommand(target, options);
+        }
+      )
+    );
+
+  addStartCloudFrontSpecificOptions(cmd);
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(regionOption);
+  return cmd;
+}
+
+/**
+ * Register the `cdkl start-cloudfront`-only option block on top of the shared
+ * common / app / context helpers. Shared between `cdkl start-cloudfront` and
+ * any host CLI (e.g. cdkd) that wraps the distribution-serving command, so
+ * adding or renaming a `start-cloudfront` flag here propagates to every
+ * embedder without duplicate `.addOption(...)` blocks. Chainable: returns
+ * `cmd`.
+ */
+export function addStartCloudFrontSpecificOptions(cmd: Command): Command {
+  return cmd
+    .addOption(
+      new Option('--port <port>', 'HTTP server port (default: auto-allocate)').default('0')
+    )
+    .addOption(new Option('--host <host>', 'Bind address').default('127.0.0.1'))
+    .addOption(
+      new Option(
+        '--origin <originId=dir>',
+        'Point a distribution origin at a local directory (repeatable). Use when cdk-local cannot resolve the ' +
+          "origin's BucketDeployment source automatically (content uploaded out of band, or a non-CDK bucket)."
+      ).argParser((value: string, prev: string[] | undefined) => [...(prev ?? []), value])
+    )
+    .addOption(
+      new Option(
+        '--tls',
+        'Terminate real TLS (HTTPS). Uses --tls-cert / --tls-key when supplied, else an auto-generated self-signed cert.'
+      ).default(false)
+    )
+    .addOption(new Option('--tls-cert <path>', 'PEM server certificate for --tls (implies --tls).'))
+    .addOption(new Option('--tls-key <path>', 'PEM server private key for --tls (implies --tls).'))
+    .addOption(
+      new Option(
+        '--watch',
+        "Hot-reload: re-synth + re-resolve the distribution when the CDK app's source changes (honors cdk.json " +
+          'watch.include/exclude; cdk.out, node_modules, .git are always excluded). The server keeps the previous ' +
+          'version serving when synth fails mid-reload.'
+      ).default(false)
+    );
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { createLocalStartApiCommand } from './commands/local-start-api.js';
 import { createLocalRunTaskCommand } from './commands/local-run-task.js';
 import { createLocalStartServiceCommand } from './commands/local-start-service.js';
 import { createLocalStartAlbCommand } from './commands/local-start-alb.js';
+import { createLocalStartCloudFrontCommand } from './commands/local-start-cloudfront.js';
 import { createLocalListCommand } from './commands/local-list.js';
 import { createLocalStudioCommand } from './commands/local-studio.js';
 
@@ -24,6 +25,7 @@ program.addCommand(createLocalStartApiCommand());
 program.addCommand(createLocalRunTaskCommand());
 program.addCommand(createLocalStartServiceCommand());
 program.addCommand(createLocalStartAlbCommand());
+program.addCommand(createLocalStartCloudFrontCommand());
 program.addCommand(createLocalListCommand());
 program.addCommand(createLocalStudioCommand());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,10 @@ export {
   type CreateLocalStartAlbCommandOptions,
 } from './cli/commands/local-start-alb.js';
 export {
+  createLocalStartCloudFrontCommand,
+  type CreateLocalStartCloudFrontCommandOptions,
+} from './cli/commands/local-start-cloudfront.js';
+export {
   createLocalListCommand,
   formatTargetListing,
   type CreateLocalListCommandOptions,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -670,6 +670,58 @@ export {
 } from './cli/commands/local-start-service.js';
 
 /**
+ * `start-cloudfront` (issue #363) command surface: the per-command option
+ * block (`--port` / `--host` / `--origin` / `--tls` / `--tls-cert` /
+ * `--tls-key` / `--watch`), the distribution target resolver, and the
+ * `--origin` override parser. A host CLI (e.g. cdkd's `local
+ * start-cloudfront`) composes `addStartCloudFrontSpecificOptions(cmd)` on top
+ * of the shared common / app / context block and calls `resolveCloudFrontTarget`
+ * to map a target string to its distribution logical id.
+ */
+export {
+  addStartCloudFrontSpecificOptions,
+  resolveCloudFrontTarget,
+  parseOriginOverrides,
+  LocalStartCloudFrontError,
+} from './cli/commands/local-start-cloudfront.js';
+
+/**
+ * `start-cloudfront` runtime layer (issue #363): the distribution resolver
+ * (synthesized `AWS::CloudFront::Distribution` -> behaviors / CloudFront
+ * Functions / S3 origins / custom error responses), the in-process CloudFront
+ * Function `node:vm` runtime, the S3 static-origin server, and the local
+ * HTTP/HTTPS distribution server. Exposed for host CLIs that drive the same
+ * local-CloudFront serving without re-importing the command factory.
+ */
+export {
+  resolveCloudFrontDistribution,
+  isCloudFrontDistribution,
+  CLOUDFRONT_DISTRIBUTION_TYPE,
+  type ResolvedDistribution,
+  type ResolvedBehavior,
+  type ResolvedOrigin,
+  type ResolvedCloudFrontFunction,
+} from './local/cloudfront-resolver.js';
+export {
+  compileCloudFrontFunction,
+  runViewerRequest,
+  runViewerResponse,
+  type CompiledCloudFrontFunction,
+  type CfRequest,
+  type CfResponse,
+} from './local/cloudfront-function-runtime.js';
+export {
+  serveFromStaticOrigin,
+  type StaticOriginResult,
+  type ResolvedCustomErrorResponse,
+} from './local/cloudfront-static-origin.js';
+export {
+  startCloudFrontServer,
+  matchBehavior,
+  type StartedCloudFrontServer,
+} from './local/cloudfront-server.js';
+
+/**
  * Shared `--profile` plumbing helpers (issue #245). Every STS-touching
  * call site across `cdkl` commands now goes through these two helpers
  * so a host CLI (e.g. cdkd) wrapping the same factories inherits the

--- a/src/local/cloudfront-function-runtime.ts
+++ b/src/local/cloudfront-function-runtime.ts
@@ -1,0 +1,401 @@
+import * as vm from 'node:vm';
+
+/**
+ * Run a synthesized `AWS::CloudFront::Function`'s inline JavaScript locally
+ * (issue #363). A CloudFront Function is the user's own application compute —
+ * a small `viewer-request` / `viewer-response` handler doing URL rewrites,
+ * header tweaks, redirects, or SPA fallback — and `cdkl start-cloudfront`
+ * runs it in-process over the distribution's routing the same way `start-api`
+ * runs a Lambda handler. This is NOT an emulation of the managed CloudFront
+ * service: only the function-code contract is reproduced.
+ *
+ * The function body is the literal `Properties.FunctionCode` string from the
+ * template (CDK always synthesizes it inline). It is compiled once and run in
+ * a fresh `node:vm` context per request to obtain the `handler` function, then
+ * `handler(event)` is invoked. `cloudfront-js-2.0` handlers may be `async`, so
+ * a returned promise is awaited. The sandbox exposes only the standard
+ * JavaScript built-ins a vm context already provides plus `console` (the 2.0
+ * runtime has `console.log`); it does NOT expose `require`, `process`, timers,
+ * or `fetch`, so a function reaching for the real CloudFront KeyValueStore /
+ * `cf.fetch` runtime APIs fails locally with a clear error rather than
+ * silently diverging.
+ *
+ * Out of scope: the CloudFront KeyValueStore (`cloudfront.kvs()`), the 2.0
+ * `cf.fetch` origin-request API, and crypto helpers — these have no local
+ * analogue and are documented as unsupported.
+ */
+
+/** The CloudFront-Functions header / cookie / query-value object shape. */
+export interface CfValue {
+  value: string;
+  /** Present for multi-valued headers / query params. */
+  multiValue?: Array<{ value: string }>;
+}
+
+/** A CloudFront Functions `event.request` object. */
+export interface CfRequest {
+  method: string;
+  uri: string;
+  querystring: Record<string, CfValue>;
+  headers: Record<string, CfValue>;
+  cookies: Record<string, CfValue>;
+}
+
+/** A CloudFront Functions `event.response` object. */
+export interface CfResponse {
+  statusCode: number;
+  statusDescription?: string;
+  headers: Record<string, CfValue>;
+  cookies?: Record<string, CfValue>;
+  body?: string | { encoding?: 'text' | 'base64'; data?: string };
+}
+
+/** The event passed to a `viewer-request` handler. */
+export interface CfViewerRequestEvent {
+  version: '1.0';
+  context: {
+    distributionDomainName: string;
+    distributionId: string;
+    eventType: string;
+    requestId: string;
+  };
+  viewer: { ip: string };
+  request: CfRequest;
+}
+
+/** The event passed to a `viewer-response` handler. */
+export interface CfViewerResponseEvent extends CfViewerRequestEvent {
+  response: CfResponse;
+}
+
+/** A compiled CloudFront Function — reused across requests. */
+export interface CompiledCloudFrontFunction {
+  /** The `AWS::CloudFront::Function` logical id (for diagnostics). */
+  logicalId: string;
+  /** Declared runtime (`cloudfront-js-1.0` / `cloudfront-js-2.0`). */
+  runtime: string;
+  /** Compiled script that, when run, evaluates to the `handler` function. */
+  script: vm.Script;
+}
+
+/**
+ * Compile a CloudFront Function's inline code once. Throws a clear error when
+ * the code has a syntax error or declares no `handler` (surfaced at boot so a
+ * malformed function never silently no-ops at request time).
+ */
+export function compileCloudFrontFunction(
+  logicalId: string,
+  code: string,
+  runtime: string
+): CompiledCloudFrontFunction {
+  let script: vm.Script;
+  try {
+    // The trailing `handler` expression makes the script evaluate to the
+    // declared handler function (a `function handler(){}` declaration is
+    // hoisted; a `var handler = ...` assignment is also in scope).
+    script = new vm.Script(`${code}\n;typeof handler === 'function' ? handler : undefined`, {
+      filename: `cloudfront-function-${logicalId}.js`,
+    });
+  } catch (err) {
+    throw new Error(
+      `CloudFront Function '${logicalId}' failed to compile: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  // Probe once that a `handler` is actually defined.
+  const probe = script.runInContext(vm.createContext({ console }));
+  if (typeof probe !== 'function') {
+    throw new Error(
+      `CloudFront Function '${logicalId}' does not declare a 'handler' function. ` +
+        'A CloudFront Function must export `function handler(event) { ... }`.'
+    );
+  }
+  return { logicalId, runtime, script };
+}
+
+/**
+ * Invoke a compiled function's `handler(event)` in a fresh sandbox and return
+ * its result. A `cloudfront-js-2.0` async handler's promise is awaited. Any
+ * error thrown by the handler is wrapped with the function's logical id.
+ */
+export async function invokeCloudFrontFunction(
+  fn: CompiledCloudFrontFunction,
+  event: CfViewerRequestEvent | CfViewerResponseEvent
+): Promise<unknown> {
+  const context = vm.createContext({ console });
+  let handler: unknown;
+  try {
+    handler = fn.script.runInContext(context);
+  } catch (err) {
+    throw new Error(
+      `CloudFront Function '${fn.logicalId}' failed while loading: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (typeof handler !== 'function') {
+    throw new Error(`CloudFront Function '${fn.logicalId}' has no callable 'handler'.`);
+  }
+  try {
+    const result = (handler as (e: unknown) => unknown)(event);
+    return result instanceof Promise ? await result : result;
+  } catch (err) {
+    throw new Error(
+      `CloudFront Function '${fn.logicalId}' threw at request time: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+/**
+ * The outcome of running a `viewer-request` function: either CONTINUE to the
+ * origin with the (possibly rewritten) request, or short-circuit with a
+ * RESPONSE the function generated (a redirect / fixed body). CloudFront treats
+ * a returned object carrying a `statusCode` as a response; otherwise it is the
+ * forwarded request.
+ */
+export type ViewerRequestOutcome =
+  | { kind: 'continue'; request: CfRequest }
+  | { kind: 'response'; response: CfResponse };
+
+/**
+ * Run a `viewer-request` function and classify its return value. A non-object
+ * return (or `undefined`) is treated as "continue unchanged" — a defensive
+ * default matching CloudFront's tolerance of a function that just inspects the
+ * request.
+ */
+export async function runViewerRequest(
+  fn: CompiledCloudFrontFunction,
+  event: CfViewerRequestEvent
+): Promise<ViewerRequestOutcome> {
+  const result = await invokeCloudFrontFunction(fn, event);
+  if (result && typeof result === 'object') {
+    const obj = result as Record<string, unknown>;
+    if ('statusCode' in obj) {
+      return { kind: 'response', response: coerceResponse(obj) };
+    }
+    return { kind: 'continue', request: coerceRequest(obj, event.request) };
+  }
+  return { kind: 'continue', request: event.request };
+}
+
+/**
+ * Run a `viewer-response` function and return the (possibly mutated) response.
+ * A non-object return falls back to the unmodified origin response.
+ */
+export async function runViewerResponse(
+  fn: CompiledCloudFrontFunction,
+  event: CfViewerResponseEvent
+): Promise<CfResponse> {
+  const result = await invokeCloudFrontFunction(fn, event);
+  if (result && typeof result === 'object') {
+    return coerceResponse(result as Record<string, unknown>, event.response);
+  }
+  return event.response;
+}
+
+/** Normalize a function's returned request object back into a {@link CfRequest}. */
+function coerceRequest(obj: Record<string, unknown>, fallback: CfRequest): CfRequest {
+  return {
+    method: typeof obj['method'] === 'string' ? (obj['method'] as string) : fallback.method,
+    uri: typeof obj['uri'] === 'string' ? (obj['uri'] as string) : fallback.uri,
+    querystring: coerceValueMap(obj['querystring']) ?? fallback.querystring,
+    headers: coerceValueMap(obj['headers']) ?? fallback.headers,
+    cookies: coerceValueMap(obj['cookies']) ?? fallback.cookies,
+  };
+}
+
+/** Normalize a function's returned response object into a {@link CfResponse}. */
+function coerceResponse(obj: Record<string, unknown>, fallback?: CfResponse): CfResponse {
+  const statusCode =
+    typeof obj['statusCode'] === 'number'
+      ? (obj['statusCode'] as number)
+      : (fallback?.statusCode ?? 200);
+  const res: CfResponse = {
+    statusCode,
+    headers: coerceValueMap(obj['headers']) ?? fallback?.headers ?? {},
+  };
+  const desc = obj['statusDescription'] ?? fallback?.statusDescription;
+  if (typeof desc === 'string') res.statusDescription = desc;
+  const cookies = coerceValueMap(obj['cookies']);
+  if (cookies) res.cookies = cookies;
+  const body = obj['body'];
+  if (typeof body === 'string' || (body && typeof body === 'object')) {
+    res.body = body as NonNullable<CfResponse['body']>;
+  } else if (fallback?.body !== undefined) {
+    res.body = fallback.body;
+  }
+  return res;
+}
+
+/**
+ * Coerce a header / cookie / querystring map back into the `{ value }` shape,
+ * tolerating a function that wrote a bare string value (`headers.location =
+ * 'https://...'` instead of `{ value: '...' }`). Returns `undefined` when the
+ * field is absent so the caller keeps the prior value.
+ */
+function coerceValueMap(value: unknown): Record<string, CfValue> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const out: Record<string, CfValue> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (v && typeof v === 'object' && 'value' in (v as Record<string, unknown>)) {
+      const cv = v as { value: unknown; multiValue?: unknown };
+      const entry: CfValue = { value: scalarToString(cv.value) };
+      if (Array.isArray(cv.multiValue)) {
+        entry.multiValue = cv.multiValue
+          .filter((m): m is { value: unknown } => Boolean(m) && typeof m === 'object')
+          .map((m) => ({ value: scalarToString((m as { value: unknown }).value) }));
+      }
+      out[k] = entry;
+    } else if (typeof v === 'string') {
+      out[k] = { value: v };
+    }
+  }
+  return out;
+}
+
+/**
+ * Coerce a CloudFront function's header / cookie / query value to a string. CF
+ * values are strings, but a function may hand back a number / boolean; anything
+ * non-scalar (or absent) collapses to the empty string.
+ */
+function scalarToString(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return '';
+}
+
+/**
+ * Build a `viewer-request` event from an incoming HTTP request. Header keys
+ * are lower-cased (CloudFront's contract); a multi-valued header is carried in
+ * `multiValue` with `value` set to the first entry.
+ */
+export function buildViewerRequestEvent(input: {
+  method: string;
+  uri: string;
+  querystring: string;
+  headers: NodeJS.Dict<string | string[]>;
+  ip: string;
+  distributionId: string;
+  domainName: string;
+  requestId: string;
+}): CfViewerRequestEvent {
+  return {
+    version: '1.0',
+    context: {
+      distributionDomainName: input.domainName,
+      distributionId: input.distributionId,
+      eventType: 'viewer-request',
+      requestId: input.requestId,
+    },
+    viewer: { ip: input.ip },
+    request: {
+      method: input.method.toUpperCase(),
+      uri: input.uri,
+      querystring: parseQueryStringToCf(input.querystring),
+      headers: headersToCf(input.headers),
+      cookies: cookiesFromHeaders(input.headers),
+    },
+  };
+}
+
+/** Extend a request event into a `viewer-response` event with the origin response. */
+export function buildViewerResponseEvent(
+  requestEvent: CfViewerRequestEvent,
+  response: {
+    statusCode: number;
+    statusDescription?: string;
+    headers: NodeJS.Dict<string | string[]>;
+  }
+): CfViewerResponseEvent {
+  return {
+    ...requestEvent,
+    context: { ...requestEvent.context, eventType: 'viewer-response' },
+    response: {
+      statusCode: response.statusCode,
+      ...(response.statusDescription !== undefined && {
+        statusDescription: response.statusDescription,
+      }),
+      headers: headersToCf(response.headers),
+    },
+  };
+}
+
+/** Serialize a CloudFront request's `querystring` object back to a raw string. */
+export function serializeCfQueryString(qs: Record<string, CfValue>): string {
+  const parts: string[] = [];
+  for (const [key, val] of Object.entries(qs)) {
+    const values =
+      val.multiValue && val.multiValue.length > 0 ? val.multiValue : [{ value: val.value }];
+    for (const v of values) {
+      parts.push(
+        v.value === ''
+          ? encodeURIComponent(key)
+          : `${encodeURIComponent(key)}=${encodeURIComponent(v.value)}`
+      );
+    }
+  }
+  return parts.join('&');
+}
+
+function parseQueryStringToCf(raw: string): Record<string, CfValue> {
+  const out: Record<string, CfValue> = {};
+  if (!raw) return out;
+  for (const pair of raw.split('&')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    const key = decodePart(eq === -1 ? pair : pair.slice(0, eq));
+    const value = eq === -1 ? '' : decodePart(pair.slice(eq + 1));
+    addCfValue(out, key, value);
+  }
+  return out;
+}
+
+function headersToCf(headers: NodeJS.Dict<string | string[]>): Record<string, CfValue> {
+  const out: Record<string, CfValue> = {};
+  for (const [name, raw] of Object.entries(headers)) {
+    if (raw === undefined) continue;
+    // `cookie` is surfaced via `request.cookies`, not `request.headers`, to
+    // match CloudFront — but it is harmless to also keep it as a header.
+    const lower = name.toLowerCase();
+    if (Array.isArray(raw)) {
+      for (const v of raw) addCfValue(out, lower, v);
+    } else {
+      addCfValue(out, lower, raw);
+    }
+  }
+  return out;
+}
+
+function cookiesFromHeaders(headers: NodeJS.Dict<string | string[]>): Record<string, CfValue> {
+  const out: Record<string, CfValue> = {};
+  const raw = headers['cookie'] ?? headers['Cookie'];
+  const list = raw === undefined ? [] : Array.isArray(raw) ? raw : [raw];
+  for (const header of list) {
+    for (const pair of header.split(';')) {
+      const trimmed = pair.trim();
+      if (!trimmed) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq === -1) continue;
+      const name = trimmed.slice(0, eq).trim();
+      const value = trimmed.slice(eq + 1).trim();
+      addCfValue(out, name, value);
+    }
+  }
+  return out;
+}
+
+/** Append a value under `key`, promoting to `multiValue` on the second hit. */
+function addCfValue(map: Record<string, CfValue>, key: string, value: string): void {
+  const existing = map[key];
+  if (existing === undefined) {
+    map[key] = { value };
+    return;
+  }
+  if (!existing.multiValue) existing.multiValue = [{ value: existing.value }];
+  existing.multiValue.push({ value });
+}
+
+function decodePart(s: string): string {
+  try {
+    return decodeURIComponent(s.replace(/\+/g, ' '));
+  } catch {
+    return s;
+  }
+}

--- a/src/local/cloudfront-function-runtime.ts
+++ b/src/local/cloudfront-function-runtime.ts
@@ -1,6 +1,17 @@
 import * as vm from 'node:vm';
 
 /**
+ * Hard cap on a single CloudFront Function's synchronous run. The deployed
+ * runtime caps CPU at ~1ms; locally we are generous but still bound it so a
+ * runaway `while (true) {}` in a function fails that one request with a clear
+ * error instead of wedging the single-threaded local server for every
+ * subsequent request. `vm`'s timeout only interrupts synchronous code — an
+ * `await`-based hang in a 2.0 async handler is not caught (it has no local
+ * analogue), which is acceptable for a dev tool.
+ */
+const FUNCTION_TIMEOUT_MS = 5000;
+
+/**
  * Run a synthesized `AWS::CloudFront::Function`'s inline JavaScript locally
  * (issue #363). A CloudFront Function is the user's own application compute —
  * a small `viewer-request` / `viewer-response` handler doing URL rewrites,
@@ -74,9 +85,16 @@ export interface CompiledCloudFrontFunction {
   logicalId: string;
   /** Declared runtime (`cloudfront-js-1.0` / `cloudfront-js-2.0`). */
   runtime: string;
-  /** Compiled script that, when run, evaluates to the `handler` function. */
+  /**
+   * Compiled script that runs the user's code (defining `handler`) and then
+   * invokes `handler(__cfEvent)`, returning its result. Running the INVOCATION
+   * inside the vm — not just the handler extraction — is what lets the
+   * {@link FUNCTION_TIMEOUT_MS} bound a runaway synchronous handler.
+   */
   script: vm.Script;
 }
+
+const EVENT_GLOBAL = '__cfEvent';
 
 /**
  * Compile a CloudFront Function's inline code once. Throws a clear error when
@@ -90,10 +108,11 @@ export function compileCloudFrontFunction(
 ): CompiledCloudFrontFunction {
   let script: vm.Script;
   try {
-    // The trailing `handler` expression makes the script evaluate to the
-    // declared handler function (a `function handler(){}` declaration is
-    // hoisted; a `var handler = ...` assignment is also in scope).
-    script = new vm.Script(`${code}\n;typeof handler === 'function' ? handler : undefined`, {
+    // The user code defines `handler`; the trailing call invokes it with the
+    // per-request event injected as a context global. Compiling the call into
+    // the same script means `runInContext`'s `timeout` covers the handler's
+    // synchronous execution, not just its definition.
+    script = new vm.Script(`${code}\n;handler(${EVENT_GLOBAL})`, {
       filename: `cloudfront-function-${logicalId}.js`,
     });
   } catch (err) {
@@ -101,9 +120,21 @@ export function compileCloudFrontFunction(
       `CloudFront Function '${logicalId}' failed to compile: ${err instanceof Error ? err.message : String(err)}`
     );
   }
-  // Probe once that a `handler` is actually defined.
-  const probe = script.runInContext(vm.createContext({ console }));
-  if (typeof probe !== 'function') {
+  // Probe once that a `handler` is actually defined, surfacing a
+  // missing-handler error at boot rather than a silent no-op per request.
+  let hasHandler: unknown;
+  try {
+    const probeContext = vm.createContext({ console });
+    hasHandler = new vm.Script(`${code}\n;typeof handler === 'function'`).runInContext(
+      probeContext,
+      { timeout: FUNCTION_TIMEOUT_MS }
+    );
+  } catch (err) {
+    throw new Error(
+      `CloudFront Function '${logicalId}' failed to compile: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (hasHandler !== true) {
     throw new Error(
       `CloudFront Function '${logicalId}' does not declare a 'handler' function. ` +
         'A CloudFront Function must export `function handler(event) { ... }`.'
@@ -114,27 +145,25 @@ export function compileCloudFrontFunction(
 
 /**
  * Invoke a compiled function's `handler(event)` in a fresh sandbox and return
- * its result. A `cloudfront-js-2.0` async handler's promise is awaited. Any
- * error thrown by the handler is wrapped with the function's logical id.
+ * its result. The synchronous portion is bounded by {@link FUNCTION_TIMEOUT_MS}
+ * (a runaway `while (true) {}` fails this one request instead of wedging the
+ * server); a `cloudfront-js-2.0` async handler's promise is awaited. Any error
+ * thrown by the handler is wrapped with the function's logical id.
  */
 export async function invokeCloudFrontFunction(
   fn: CompiledCloudFrontFunction,
   event: CfViewerRequestEvent | CfViewerResponseEvent
 ): Promise<unknown> {
-  const context = vm.createContext({ console });
-  let handler: unknown;
+  const context = vm.createContext({ console, [EVENT_GLOBAL]: event });
+  let result: unknown;
   try {
-    handler = fn.script.runInContext(context);
+    result = fn.script.runInContext(context, { timeout: FUNCTION_TIMEOUT_MS });
   } catch (err) {
     throw new Error(
-      `CloudFront Function '${fn.logicalId}' failed while loading: ${err instanceof Error ? err.message : String(err)}`
+      `CloudFront Function '${fn.logicalId}' threw at request time: ${err instanceof Error ? err.message : String(err)}`
     );
   }
-  if (typeof handler !== 'function') {
-    throw new Error(`CloudFront Function '${fn.logicalId}' has no callable 'handler'.`);
-  }
   try {
-    const result = (handler as (e: unknown) => unknown)(event);
     return result instanceof Promise ? await result : result;
   } catch (err) {
     throw new Error(

--- a/src/local/cloudfront-resolver.ts
+++ b/src/local/cloudfront-resolver.ts
@@ -1,0 +1,412 @@
+import { readFileSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import type { StackInfo } from '../synthesis/assembly-reader.js';
+import type { AssetManifest, FileAsset } from '../types/assets.js';
+import type { CloudFormationTemplate, TemplateResource } from '../types/resource.js';
+import { getLogger } from '../utils/logger.js';
+import {
+  compileCloudFrontFunction,
+  type CompiledCloudFrontFunction,
+} from './cloudfront-function-runtime.js';
+import type { ResolvedCustomErrorResponse } from './cloudfront-static-origin.js';
+
+/**
+ * Resolve a synthesized `AWS::CloudFront::Distribution` into the in-memory
+ * routing model `cdkl start-cloudfront` serves (issue #363): each cache
+ * behavior's path pattern + viewer-request / viewer-response CloudFront
+ * Functions, the origin each behavior targets, and the distribution's custom
+ * error responses. This is the static-site / SPA shape — an S3 origin whose
+ * content is resolved from the BucketDeployment source asset in the cloud
+ * assembly + CloudFront Functions doing the routing.
+ *
+ * Scope (v1, issue #363): S3 origins only. A custom (non-S3) origin and a
+ * Lambda@Edge `LambdaFunctionAssociations` association are recorded but
+ * WARN-and-skip at request time — cdk-local does not emulate them. The origin's
+ * local content is resolved by walking the distribution's S3 origins back to
+ * their `Custom::CDKBucketDeployment` source asset; an origin with no
+ * resolvable local source is surfaced as `s3-unresolved` so the boot path can
+ * WARN and the user can point it at a directory with `--origin <id>=<dir>`.
+ */
+
+/** A CloudFront Function wired to a cache behavior, compiled and ready to run. */
+export interface ResolvedCloudFrontFunction extends CompiledCloudFrontFunction {}
+
+/** One resolved cache behavior (the default behavior, or a `CacheBehaviors[]` entry). */
+export interface ResolvedBehavior {
+  /**
+   * The behavior's `PathPattern` (`*` / `?` glob). `undefined` for the default
+   * cache behavior — the catch-all evaluated when no other behavior matches.
+   */
+  pathPattern?: string;
+  /** The `TargetOriginId` this behavior forwards to. */
+  targetOriginId: string;
+  /** `ViewerProtocolPolicy` (informational locally; see start-cloudfront docs). */
+  viewerProtocolPolicy?: string;
+  /** Compiled `viewer-request` function, if associated. */
+  viewerRequest?: ResolvedCloudFrontFunction;
+  /** Compiled `viewer-response` function, if associated. */
+  viewerResponse?: ResolvedCloudFrontFunction;
+  /**
+   * True when the behavior carries a `LambdaFunctionAssociations` (Lambda@Edge)
+   * — recorded so the boot path WARNs that it is not run locally.
+   */
+  hasLambdaEdge: boolean;
+}
+
+/** A resolved origin: an S3 origin with (or without) a local source directory. */
+export type ResolvedOrigin =
+  | { kind: 's3'; originId: string; localDirs: string[] }
+  | { kind: 's3-unresolved'; originId: string; bucketLogicalId?: string }
+  | { kind: 'custom'; originId: string; domainName: string };
+
+/** The fully resolved distribution `cdkl start-cloudfront` serves. */
+export interface ResolvedDistribution {
+  /** The distribution's CloudFormation logical id. */
+  logicalId: string;
+  /** The stack the distribution lives in. */
+  stackName: string;
+  /** `DefaultRootObject` (e.g. `index.html`), if set. */
+  defaultRootObject?: string;
+  /** Default behavior first, then `CacheBehaviors[]` in declared order. */
+  behaviors: ResolvedBehavior[];
+  /** Origins keyed by `Id`. */
+  origins: Map<string, ResolvedOrigin>;
+  /** `CustomErrorResponses[]`, resolved to plain numbers / paths. */
+  customErrorResponses: ResolvedCustomErrorResponse[];
+}
+
+export const CLOUDFRONT_DISTRIBUTION_TYPE = 'AWS::CloudFront::Distribution';
+const CLOUDFRONT_FUNCTION_TYPE = 'AWS::CloudFront::Function';
+const S3_BUCKET_TYPE = 'AWS::S3::Bucket';
+
+/**
+ * Resolve a distribution logical id within a stack into its routing model.
+ * `originOverrides` maps an origin id to a local directory (the `--origin`
+ * escape hatch); a covered origin is served from that directory regardless of
+ * BucketDeployment resolution.
+ */
+export function resolveCloudFrontDistribution(args: {
+  stack: StackInfo;
+  logicalId: string;
+  originOverrides?: Map<string, string>;
+}): ResolvedDistribution {
+  const { stack, logicalId } = args;
+  const template = stack.template;
+  const resource = (template.Resources ?? {})[logicalId];
+  if (!resource || resource.Type !== CLOUDFRONT_DISTRIBUTION_TYPE) {
+    throw new Error(
+      `Resource '${logicalId}' in stack ${stack.stackName} is not an ${CLOUDFRONT_DISTRIBUTION_TYPE}.`
+    );
+  }
+  const distConfig = (resource.Properties ?? {})['DistributionConfig'];
+  if (!distConfig || typeof distConfig !== 'object') {
+    throw new Error(`Distribution '${logicalId}' has no DistributionConfig.`);
+  }
+  const dc = distConfig as Record<string, unknown>;
+
+  const functionsByLogicalId = compileDistributionFunctions(template);
+  const behaviors = resolveBehaviors(dc, functionsByLogicalId, logicalId);
+  const origins = resolveOrigins(dc, template, stack, args.originOverrides ?? new Map());
+  const customErrorResponses = resolveCustomErrorResponses(dc);
+
+  const result: ResolvedDistribution = {
+    logicalId,
+    stackName: stack.stackName,
+    behaviors,
+    origins,
+    customErrorResponses,
+  };
+  if (typeof dc['DefaultRootObject'] === 'string' && dc['DefaultRootObject'] !== '') {
+    result.defaultRootObject = dc['DefaultRootObject'];
+  }
+  return result;
+}
+
+/** Compile every `AWS::CloudFront::Function` in the template, keyed by logical id. */
+function compileDistributionFunctions(
+  template: CloudFormationTemplate
+): Map<string, CompiledCloudFrontFunction> {
+  const out = new Map<string, CompiledCloudFrontFunction>();
+  for (const [logicalId, resource] of Object.entries(template.Resources ?? {})) {
+    if (resource.Type !== CLOUDFRONT_FUNCTION_TYPE) continue;
+    const props = resource.Properties ?? {};
+    const code = props['FunctionCode'];
+    if (typeof code !== 'string') {
+      getLogger().warn(
+        `CloudFront Function '${logicalId}' has a non-inline FunctionCode; cdk-local can only run inline function code. Skipping.`
+      );
+      continue;
+    }
+    const config = props['FunctionConfig'];
+    const runtime =
+      config &&
+      typeof config === 'object' &&
+      typeof (config as Record<string, unknown>)['Runtime'] === 'string'
+        ? ((config as Record<string, unknown>)['Runtime'] as string)
+        : 'cloudfront-js-1.0';
+    out.set(logicalId, compileCloudFrontFunction(logicalId, code, runtime));
+  }
+  return out;
+}
+
+function resolveBehaviors(
+  dc: Record<string, unknown>,
+  functions: Map<string, CompiledCloudFrontFunction>,
+  distLogicalId: string
+): ResolvedBehavior[] {
+  const behaviors: ResolvedBehavior[] = [];
+  const def = dc['DefaultCacheBehavior'];
+  if (def && typeof def === 'object') {
+    behaviors.push(
+      resolveBehavior(def as Record<string, unknown>, undefined, functions, distLogicalId)
+    );
+  }
+  const extra = Array.isArray(dc['CacheBehaviors']) ? (dc['CacheBehaviors'] as unknown[]) : [];
+  for (const b of extra) {
+    if (!b || typeof b !== 'object') continue;
+    const behavior = b as Record<string, unknown>;
+    const pattern =
+      typeof behavior['PathPattern'] === 'string' ? (behavior['PathPattern'] as string) : '*';
+    behaviors.push(resolveBehavior(behavior, pattern, functions, distLogicalId));
+  }
+  return behaviors;
+}
+
+function resolveBehavior(
+  behavior: Record<string, unknown>,
+  pathPattern: string | undefined,
+  functions: Map<string, CompiledCloudFrontFunction>,
+  distLogicalId: string
+): ResolvedBehavior {
+  const resolved: ResolvedBehavior = {
+    targetOriginId:
+      typeof behavior['TargetOriginId'] === 'string' ? (behavior['TargetOriginId'] as string) : '',
+    hasLambdaEdge: Array.isArray(behavior['LambdaFunctionAssociations'])
+      ? (behavior['LambdaFunctionAssociations'] as unknown[]).length > 0
+      : false,
+  };
+  if (pathPattern !== undefined) resolved.pathPattern = pathPattern;
+  if (typeof behavior['ViewerProtocolPolicy'] === 'string') {
+    resolved.viewerProtocolPolicy = behavior['ViewerProtocolPolicy'] as string;
+  }
+  const assocs = Array.isArray(behavior['FunctionAssociations'])
+    ? (behavior['FunctionAssociations'] as unknown[])
+    : [];
+  for (const a of assocs) {
+    if (!a || typeof a !== 'object') continue;
+    const assoc = a as Record<string, unknown>;
+    const eventType = assoc['EventType'];
+    const fnLogicalId = pickFunctionLogicalIdFromArn(assoc['FunctionARN'] ?? assoc['FunctionArn']);
+    if (!fnLogicalId) {
+      getLogger().warn(
+        `Distribution '${distLogicalId}': a FunctionAssociation references a function ARN cdk-local could not resolve to a local AWS::CloudFront::Function; it will not run.`
+      );
+      continue;
+    }
+    const fn = functions.get(fnLogicalId);
+    if (!fn) continue;
+    if (eventType === 'viewer-request') resolved.viewerRequest = fn;
+    else if (eventType === 'viewer-response') resolved.viewerResponse = fn;
+  }
+  return resolved;
+}
+
+/**
+ * Unwrap a `FunctionAssociations[].FunctionARN` intrinsic to the
+ * `AWS::CloudFront::Function` logical id. CDK synthesizes it as
+ * `{Fn::GetAtt: [<logicalId>, "FunctionARN"]}`.
+ */
+export function pickFunctionLogicalIdFromArn(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const getAtt = (value as Record<string, unknown>)['Fn::GetAtt'];
+  if (Array.isArray(getAtt) && getAtt.length === 2 && typeof getAtt[0] === 'string') {
+    return getAtt[0];
+  }
+  return undefined;
+}
+
+function resolveOrigins(
+  dc: Record<string, unknown>,
+  template: CloudFormationTemplate,
+  stack: StackInfo,
+  overrides: Map<string, string>
+): Map<string, ResolvedOrigin> {
+  const out = new Map<string, ResolvedOrigin>();
+  const origins = Array.isArray(dc['Origins']) ? (dc['Origins'] as unknown[]) : [];
+  // Resolve the manifest once (shared across origins).
+  const manifest = loadStackManifest(stack);
+  for (const o of origins) {
+    if (!o || typeof o !== 'object') continue;
+    const origin = o as Record<string, unknown>;
+    const originId = typeof origin['Id'] === 'string' ? (origin['Id'] as string) : undefined;
+    if (!originId) continue;
+
+    const overrideDir = overrides.get(originId);
+    if (overrideDir) {
+      out.set(originId, { kind: 's3', originId, localDirs: [resolveDir(overrideDir)] });
+      continue;
+    }
+
+    const bucketLogicalId = pickBucketLogicalIdFromOrigin(origin, template);
+    const isS3 = origin['S3OriginConfig'] !== undefined || bucketLogicalId !== undefined;
+    if (!isS3) {
+      out.set(originId, {
+        kind: 'custom',
+        originId,
+        domainName: describeDomainName(origin['DomainName']),
+      });
+      continue;
+    }
+
+    const localDirs =
+      bucketLogicalId && manifest
+        ? resolveBucketDeploymentDirs(template, manifest, stack, bucketLogicalId)
+        : [];
+    if (localDirs.length > 0) {
+      out.set(originId, { kind: 's3', originId, localDirs });
+    } else {
+      out.set(originId, {
+        kind: 's3-unresolved',
+        originId,
+        ...(bucketLogicalId !== undefined && { bucketLogicalId }),
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Read a stack's asset manifest, or `undefined` when it ships no assets / is
+ * unreadable. We already hold the absolute manifest path on {@link StackInfo},
+ * so we read + parse it directly rather than going through the by-stack-name
+ * loader.
+ */
+function loadStackManifest(stack: StackInfo): AssetManifest | undefined {
+  if (!stack.assetManifestPath) return undefined;
+  try {
+    return JSON.parse(readFileSync(stack.assetManifestPath, 'utf-8')) as AssetManifest;
+  } catch (err) {
+    getLogger().warn(
+      `Could not read asset manifest at ${stack.assetManifestPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Walk a bucket's `Custom::CDKBucketDeployment*` custom resources back to the
+ * local source-asset directories that were staged for it. Returns the resolved
+ * local directories (one per matching BucketDeployment source) — empty when the
+ * bucket has no BucketDeployment (content uploaded out of band) or the source
+ * object key cannot be matched to a manifest file asset.
+ */
+export function resolveBucketDeploymentDirs(
+  template: CloudFormationTemplate,
+  manifest: AssetManifest,
+  stack: StackInfo,
+  bucketLogicalId: string
+): string[] {
+  const manifestDir = stack.assetManifestPath ? dirname(stack.assetManifestPath) : undefined;
+  if (!manifestDir) return [];
+  const dirs: string[] = [];
+  for (const resource of Object.values(template.Resources ?? {})) {
+    if (!String(resource.Type).startsWith('Custom::CDKBucketDeployment')) continue;
+    const props = resource.Properties ?? {};
+    if (refLogicalId(props['DestinationBucketName']) !== bucketLogicalId) continue;
+    const keys = Array.isArray(props['SourceObjectKeys']) ? props['SourceObjectKeys'] : [];
+    for (const key of keys) {
+      if (typeof key !== 'string') continue; // non-literal (intrinsic) -> unresolved
+      const asset = findFileAssetByObjectKey(manifest, key);
+      if (!asset) continue;
+      dirs.push(resolve(manifestDir, asset.source.path));
+    }
+  }
+  return dirs;
+}
+
+/**
+ * Find the file asset whose published object key equals `objectKey`. The
+ * BucketDeployment `SourceObjectKeys` carries the published key
+ * (`<hash>.zip`); matching on the destination object key is more robust than
+ * guessing how the hash maps to the manifest key.
+ */
+function findFileAssetByObjectKey(
+  manifest: AssetManifest,
+  objectKey: string
+): FileAsset | undefined {
+  for (const asset of Object.values(manifest.files ?? {})) {
+    for (const dest of Object.values(asset.destinations ?? {})) {
+      if (dest.objectKey === objectKey) return asset;
+    }
+  }
+  // Fallback: the key is `<hash>.zip`; match the manifest entry by hash.
+  const hash = objectKey.replace(/\.zip$/, '');
+  return manifest.files?.[hash];
+}
+
+/**
+ * Extract the S3 bucket logical id an origin's `DomainName` points at. CDK
+ * synthesizes an S3 origin's `DomainName` as
+ * `{Fn::GetAtt: [<bucket>, "RegionalDomainName"]}` (or `DomainName` /
+ * `WebsiteURL`). Returns the logical id only when it resolves to an
+ * `AWS::S3::Bucket` in the template.
+ */
+export function pickBucketLogicalIdFromOrigin(
+  origin: Record<string, unknown>,
+  template: CloudFormationTemplate
+): string | undefined {
+  const candidate = getAttLogicalId(origin['DomainName']);
+  if (!candidate) return undefined;
+  const resource = (template.Resources ?? {})[candidate];
+  if (resource && resource.Type === S3_BUCKET_TYPE) return candidate;
+  return undefined;
+}
+
+function getAttLogicalId(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const getAtt = (value as Record<string, unknown>)['Fn::GetAtt'];
+  if (Array.isArray(getAtt) && getAtt.length === 2 && typeof getAtt[0] === 'string') {
+    return getAtt[0];
+  }
+  return undefined;
+}
+
+function refLogicalId(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const ref = (value as Record<string, unknown>)['Ref'];
+  return typeof ref === 'string' ? ref : undefined;
+}
+
+function resolveCustomErrorResponses(dc: Record<string, unknown>): ResolvedCustomErrorResponse[] {
+  const raw = Array.isArray(dc['CustomErrorResponses'])
+    ? (dc['CustomErrorResponses'] as unknown[])
+    : [];
+  const out: ResolvedCustomErrorResponse[] = [];
+  for (const e of raw) {
+    if (!e || typeof e !== 'object') continue;
+    const entry = e as Record<string, unknown>;
+    if (typeof entry['ErrorCode'] !== 'number') continue;
+    const resolved: ResolvedCustomErrorResponse = { errorCode: entry['ErrorCode'] as number };
+    if (typeof entry['ResponsePagePath'] === 'string')
+      resolved.responsePagePath = entry['ResponsePagePath'];
+    if (typeof entry['ResponseCode'] === 'number')
+      resolved.responseCode = entry['ResponseCode'] as number;
+    out.push(resolved);
+  }
+  return out;
+}
+
+function describeDomainName(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object') return JSON.stringify(value);
+  return '<unknown>';
+}
+
+function resolveDir(dir: string): string {
+  return isAbsolute(dir) ? dir : resolve(process.cwd(), dir);
+}
+
+/** True when a template resource is an `AWS::CloudFront::Distribution`. */
+export function isCloudFrontDistribution(resource: TemplateResource): boolean {
+  return resource.Type === CLOUDFRONT_DISTRIBUTION_TYPE;
+}

--- a/src/local/cloudfront-resolver.ts
+++ b/src/local/cloudfront-resolver.ts
@@ -165,9 +165,17 @@ function resolveBehaviors(
   for (const b of extra) {
     if (!b || typeof b !== 'object') continue;
     const behavior = b as Record<string, unknown>;
-    const pattern =
-      typeof behavior['PathPattern'] === 'string' ? (behavior['PathPattern'] as string) : '*';
-    behaviors.push(resolveBehavior(behavior, pattern, functions, distLogicalId));
+    // CFn requires a literal `PathPattern` on every non-default behavior. A
+    // missing / non-literal (intrinsic) value is malformed: defaulting it to a
+    // catch-all `*` would silently shadow the default behavior for ALL
+    // requests, so skip it with a WARN instead.
+    if (typeof behavior['PathPattern'] !== 'string') {
+      getLogger().warn(
+        `Distribution '${distLogicalId}': a cache behavior has no literal PathPattern; cdk-local cannot route it and is skipping it.`
+      );
+      continue;
+    }
+    behaviors.push(resolveBehavior(behavior, behavior['PathPattern'], functions, distLogicalId));
   }
   return behaviors;
 }

--- a/src/local/cloudfront-server.ts
+++ b/src/local/cloudfront-server.ts
@@ -1,0 +1,289 @@
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
+import { getLogger } from '../utils/logger.js';
+import { albPathPatternMatches } from './alb-path-matcher.js';
+import {
+  buildViewerRequestEvent,
+  buildViewerResponseEvent,
+  runViewerRequest,
+  runViewerResponse,
+  type CfResponse,
+  type CfValue,
+} from './cloudfront-function-runtime.js';
+import type {
+  ResolvedBehavior,
+  ResolvedDistribution,
+  ResolvedOrigin,
+} from './cloudfront-resolver.js';
+import { serveFromStaticOrigin } from './cloudfront-static-origin.js';
+import type { FrontDoorTlsMaterials } from './front-door-tls.js';
+
+/**
+ * Local HTTP / HTTPS server that serves an `AWS::CloudFront::Distribution`'s
+ * viewer-request -> S3 origin -> viewer-response pipeline (issue #363). Per
+ * request it picks the matching cache behavior, runs the behavior's
+ * viewer-request CloudFront Function (short-circuiting on a generated
+ * response), serves the (possibly rewritten) URI from the behavior's resolved
+ * S3 origin directory, then runs the viewer-response function — exactly the
+ * routing the deployed distribution would, reproduced locally so a rewrite /
+ * routing change is verifiable in seconds.
+ *
+ * The resolved distribution is held behind a mutable cell so `--watch` can
+ * atomically swap it via {@link StartedCloudFrontServer.update}; the listening
+ * socket is never recreated.
+ */
+
+/** A running local CloudFront server. */
+export interface StartedCloudFrontServer {
+  /** The base URL the server is listening on (e.g. `http://127.0.0.1:8080`). */
+  url: string;
+  /** The bound port. */
+  port: number;
+  /** `http` or `https`. */
+  scheme: 'http' | 'https';
+  /** Swap the served distribution (a `--watch` reload). */
+  update(distribution: ResolvedDistribution): void;
+  /** Stop listening. */
+  close(): Promise<void>;
+}
+
+export interface StartCloudFrontServerOptions {
+  distribution: ResolvedDistribution;
+  host: string;
+  port: number;
+  /** TLS materials for an HTTPS listener; plain HTTP when absent. */
+  tls?: FrontDoorTlsMaterials;
+}
+
+/** Start the local CloudFront server and resolve once it is listening. */
+export async function startCloudFrontServer(
+  options: StartCloudFrontServerOptions
+): Promise<StartedCloudFrontServer> {
+  const logger = getLogger().child('cloudfront');
+  // Mutable cell so `--watch` can swap the routing model under the live socket.
+  const state: { distribution: ResolvedDistribution } = { distribution: options.distribution };
+
+  const handler = (req: IncomingMessage, res: ServerResponse): void => {
+    void handleRequest(req, res, state, logger).catch((err) => {
+      logger.warn(`Request handling failed: ${err instanceof Error ? err.message : String(err)}`);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader('content-type', 'text/plain; charset=utf-8');
+      }
+      if (!res.writableEnded) res.end('Internal error in cdkl start-cloudfront.\n');
+    });
+  };
+
+  const scheme: 'http' | 'https' = options.tls ? 'https' : 'http';
+  const server: Server = options.tls
+    ? createHttpsServer({ cert: options.tls.certPem, key: options.tls.keyPem }, handler)
+    : createHttpServer(handler);
+
+  const port = await listen(server, options.host, options.port);
+  const url = `${scheme}://${options.host}:${port}`;
+  return {
+    url,
+    port,
+    scheme,
+    update(distribution: ResolvedDistribution): void {
+      state.distribution = distribution;
+    },
+    close(): Promise<void> {
+      return new Promise<void>((resolveClose) => {
+        server.close(() => resolveClose());
+      });
+    },
+  };
+}
+
+/** The per-request pipeline: behavior match -> viewer-request -> origin -> viewer-response. */
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  state: { distribution: ResolvedDistribution },
+  logger: ReturnType<typeof getLogger>
+): Promise<void> {
+  const distribution = state.distribution;
+  const rawUrl = req.url ?? '/';
+  const queryIdx = rawUrl.indexOf('?');
+  const uri = queryIdx === -1 ? rawUrl : rawUrl.slice(0, queryIdx);
+  const querystring = queryIdx === -1 ? '' : rawUrl.slice(queryIdx + 1);
+
+  const behavior = matchBehavior(distribution.behaviors, uri);
+  if (!behavior) {
+    writePlain(res, 404, 'No cache behavior matched.\n');
+    return;
+  }
+
+  // Build the viewer-request event and run the viewer-request function.
+  let requestEvent = buildViewerRequestEvent({
+    method: req.method ?? 'GET',
+    uri,
+    querystring,
+    headers: req.headers,
+    ip: req.socket.remoteAddress ?? '127.0.0.1',
+    distributionId: distribution.logicalId,
+    domainName: req.headers.host ?? 'localhost',
+    requestId: `cdkl-${Date.now().toString(36)}-${Math.floor(performance.now()).toString(36)}`,
+  });
+
+  let effectiveUri = uri;
+  if (behavior.viewerRequest) {
+    const outcome = await runViewerRequest(behavior.viewerRequest, requestEvent);
+    if (outcome.kind === 'response') {
+      writeCfResponse(res, outcome.response);
+      return;
+    }
+    effectiveUri = outcome.request.uri;
+    requestEvent = {
+      ...requestEvent,
+      request: outcome.request,
+    };
+  }
+
+  // Resolve + serve from the behavior's origin.
+  const origin = distribution.origins.get(behavior.targetOriginId);
+  const originResult = serveFromOrigin(origin, behavior, effectiveUri, distribution, logger);
+  if (!originResult) return writePlain(res, 502, originUnavailableMessage(origin, behavior));
+
+  // Run the viewer-response function over the origin response.
+  let finalStatus = originResult.statusCode;
+  let finalHeaders = originResult.headers;
+  if (behavior.viewerResponse) {
+    const responseEvent = buildViewerResponseEvent(requestEvent, {
+      statusCode: originResult.statusCode,
+      headers: originResult.headers,
+    });
+    const mutated = await runViewerResponse(behavior.viewerResponse, responseEvent);
+    finalStatus = mutated.statusCode;
+    finalHeaders = cfHeadersToPlain(mutated.headers, originResult.headers);
+  }
+
+  res.statusCode = finalStatus;
+  for (const [name, value] of Object.entries(finalHeaders)) res.setHeader(name, value);
+  res.end(originResult.body);
+}
+
+/** The origin-serve result before viewer-response runs. */
+interface OriginResult {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+function serveFromOrigin(
+  origin: ResolvedOrigin | undefined,
+  behavior: ResolvedBehavior,
+  uri: string,
+  distribution: ResolvedDistribution,
+  logger: ReturnType<typeof getLogger>
+): OriginResult | undefined {
+  if (behavior.hasLambdaEdge) {
+    logger.warn(
+      `Behavior ${behavior.pathPattern ?? '(default)'} carries a Lambda@Edge association; cdk-local does not run Lambda@Edge — serving the S3 origin only.`
+    );
+  }
+  if (!origin || origin.kind !== 's3') return undefined;
+  const result = serveFromStaticOrigin({
+    localDirs: origin.localDirs,
+    uri,
+    ...(distribution.defaultRootObject !== undefined && {
+      defaultRootObject: distribution.defaultRootObject,
+    }),
+    customErrorResponses: distribution.customErrorResponses,
+  });
+  return { statusCode: result.statusCode, headers: result.headers, body: result.body };
+}
+
+function originUnavailableMessage(
+  origin: ResolvedOrigin | undefined,
+  behavior: ResolvedBehavior
+): string {
+  if (!origin)
+    return `Behavior ${behavior.pathPattern ?? '(default)'} targets unknown origin '${behavior.targetOriginId}'.\n`;
+  if (origin.kind === 'custom') {
+    return (
+      `Origin '${origin.originId}' is a custom (non-S3) origin (${origin.domainName}). ` +
+      'cdkl start-cloudfront serves S3 origins only.\n'
+    );
+  }
+  return (
+    `Origin '${origin.originId}' is an S3 origin with no resolvable local source. ` +
+    `Point it at a directory with --origin ${origin.originId}=<dir>.\n`
+  );
+}
+
+/**
+ * Pick the cache behavior for a URI: the first `CacheBehaviors[]` entry (in
+ * declared order) whose path pattern matches, else the default behavior. The
+ * default behavior is the entry with no `pathPattern`.
+ */
+export function matchBehavior(
+  behaviors: readonly ResolvedBehavior[],
+  uri: string
+): ResolvedBehavior | undefined {
+  let fallback: ResolvedBehavior | undefined;
+  for (const behavior of behaviors) {
+    if (behavior.pathPattern === undefined) {
+      fallback = behavior;
+      continue;
+    }
+    if (albPathPatternMatches(behavior.pathPattern, uri)) return behavior;
+  }
+  return fallback;
+}
+
+function writeCfResponse(res: ServerResponse, response: CfResponse): void {
+  res.statusCode = response.statusCode;
+  for (const [name, value] of Object.entries(cfHeadersToPlain(response.headers, {}))) {
+    res.setHeader(name, value);
+  }
+  const body = cfResponseBody(response);
+  res.end(body);
+}
+
+function cfResponseBody(response: CfResponse): Buffer {
+  if (response.body === undefined) return Buffer.alloc(0);
+  if (typeof response.body === 'string') return Buffer.from(response.body);
+  const data = response.body.data ?? '';
+  return response.body.encoding === 'base64' ? Buffer.from(data, 'base64') : Buffer.from(data);
+}
+
+/** Flatten a CloudFront header map (`{ name: { value } }`) to `{ name: value }`. */
+function cfHeadersToPlain(
+  cf: Record<string, CfValue>,
+  base: Record<string, string>
+): Record<string, string> {
+  const out: Record<string, string> = { ...base };
+  for (const [name, val] of Object.entries(cf)) {
+    if (val.multiValue && val.multiValue.length > 0) {
+      out[name] = val.multiValue.map((m) => m.value).join(', ');
+    } else {
+      out[name] = val.value;
+    }
+  }
+  return out;
+}
+
+function writePlain(res: ServerResponse, status: number, body: string): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'text/plain; charset=utf-8');
+  res.end(body);
+}
+
+function listen(server: Server, host: string, port: number): Promise<number> {
+  return new Promise<number>((resolvePort, rejectPort) => {
+    server.once('error', rejectPort);
+    server.listen(port, host, () => {
+      const addr = server.address();
+      const bound = typeof addr === 'object' && addr ? addr.port : port;
+      server.removeListener('error', rejectPort);
+      resolvePort(bound);
+    });
+  });
+}

--- a/src/local/cloudfront-server.ts
+++ b/src/local/cloudfront-server.ts
@@ -136,7 +136,7 @@ async function handleRequest(
   if (behavior.viewerRequest) {
     const outcome = await runViewerRequest(behavior.viewerRequest, requestEvent);
     if (outcome.kind === 'response') {
-      writeCfResponse(res, outcome.response);
+      writeCfResponse(res, outcome.response, logger);
       return;
     }
     effectiveUri = outcome.request.uri;
@@ -165,8 +165,31 @@ async function handleRequest(
   }
 
   res.statusCode = finalStatus;
-  for (const [name, value] of Object.entries(finalHeaders)) res.setHeader(name, value);
+  setHeadersSafely(res, finalHeaders, logger);
   res.end(originResult.body);
+}
+
+/**
+ * Set response headers, skipping any whose name / value Node rejects (invalid
+ * HTTP token, CR/LF injection) rather than throwing an opaque 500. A CloudFront
+ * Function can return an arbitrary header map; a malformed entry should fail
+ * loudly on that one header, not the whole response. CR/LF is stripped from
+ * values defensively before the set.
+ */
+function setHeadersSafely(
+  res: ServerResponse,
+  headers: Record<string, string>,
+  logger: ReturnType<typeof getLogger>
+): void {
+  for (const [name, value] of Object.entries(headers)) {
+    try {
+      res.setHeader(name, value.replace(/[\r\n]/g, ''));
+    } catch (err) {
+      logger.warn(
+        `Skipping invalid response header '${name}': ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
 }
 
 /** The origin-serve result before viewer-response runs. */
@@ -238,11 +261,13 @@ export function matchBehavior(
   return fallback;
 }
 
-function writeCfResponse(res: ServerResponse, response: CfResponse): void {
+function writeCfResponse(
+  res: ServerResponse,
+  response: CfResponse,
+  logger: ReturnType<typeof getLogger>
+): void {
   res.statusCode = response.statusCode;
-  for (const [name, value] of Object.entries(cfHeadersToPlain(response.headers, {}))) {
-    res.setHeader(name, value);
-  }
+  setHeadersSafely(res, cfHeadersToPlain(response.headers, {}), logger);
   const body = cfResponseBody(response);
   res.end(body);
 }

--- a/src/local/cloudfront-static-origin.ts
+++ b/src/local/cloudfront-static-origin.ts
@@ -1,0 +1,184 @@
+import { readFileSync, statSync } from 'node:fs';
+import { join, normalize, sep } from 'node:path';
+
+/**
+ * Serve a request URI from a local directory standing in for a distribution's
+ * S3 origin (issue #363). The local directory is the BucketDeployment source
+ * asset cdk-local resolves out of the cloud assembly — the same files that
+ * would be uploaded to the bucket — so a routing change can be checked against
+ * the ACTUAL keys, default-root-object, and custom-error fallback the deployed
+ * distribution would resolve, without a deploy.
+ *
+ * Origin semantics reproduced (NOT the managed S3 service):
+ *   - `DefaultRootObject` is appended ONLY at the root path `/` — CloudFront
+ *     does NOT auto-append `index.html` to sub-paths (that is exactly what a
+ *     viewer-request rewrite function does, which is why this command runs the
+ *     function in front of the origin).
+ *   - A missing key returns a 403/404 the way an OAC-fronted private bucket
+ *     does (S3 returns 403 AccessDenied for a missing key when ListBucket is
+ *     not granted — the common static-site setup); the distribution's
+ *     `CustomErrorResponses` then map that to a response page (the SPA
+ *     fallback).
+ */
+
+/** A distribution `CustomErrorResponses[]` entry, resolved to plain values. */
+export interface ResolvedCustomErrorResponse {
+  errorCode: number;
+  responsePagePath?: string;
+  responseCode?: number;
+}
+
+/** The result of resolving a URI against the static origin. */
+export interface StaticOriginResult {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+/**
+ * Resolve a URI against one or more local origin directories, honoring the
+ * default root object and the distribution's custom error responses. The
+ * directories are searched in order (a BucketDeployment can layer multiple
+ * sources onto one bucket; later sources overlay earlier ones in the cloud, so
+ * the first directory that has the key wins here).
+ */
+export function serveFromStaticOrigin(input: {
+  localDirs: readonly string[];
+  uri: string;
+  defaultRootObject?: string;
+  customErrorResponses?: readonly ResolvedCustomErrorResponse[];
+}): StaticOriginResult {
+  const key = uriToKey(input.uri, input.defaultRootObject);
+  const direct = readKey(input.localDirs, key);
+  if (direct) {
+    return { statusCode: 200, headers: { 'content-type': contentTypeForKey(key) }, body: direct };
+  }
+
+  // Missing key -> the origin would 403 (private/OAC bucket) or 404. Mirror
+  // CloudFront: try the matching CustomErrorResponses entry. We classify a
+  // missing key as 403 to match the OAC-fronted private-bucket default, which
+  // is what static-site CDK apps overwhelmingly use; an app that mapped 404
+  // instead is also honored because we try BOTH codes' error responses.
+  const errorResponses = input.customErrorResponses ?? [];
+  for (const code of [403, 404]) {
+    const match = errorResponses.find((e) => e.errorCode === code);
+    if (!match || !match.responsePagePath) continue;
+    const errorKey = stripLeadingSlash(match.responsePagePath);
+    const body = readKey(input.localDirs, errorKey);
+    if (body) {
+      return {
+        statusCode: match.responseCode ?? code,
+        headers: { 'content-type': contentTypeForKey(errorKey) },
+        body,
+      };
+    }
+  }
+
+  // No custom-error page (or its file is missing too): a plain 404.
+  return {
+    statusCode: 404,
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    body: Buffer.from(`Not found: ${input.uri}\n`),
+  };
+}
+
+/**
+ * Map a request URI to an S3 object key. The query string / fragment is
+ * dropped, the leading slash is removed, and the root path (`/` or empty)
+ * resolves to the default root object. A URI ending in `/` is NOT auto-indexed
+ * (CloudFront does not), so it falls through to a missing key unless a function
+ * rewrote it.
+ */
+export function uriToKey(uri: string, defaultRootObject?: string): string {
+  let path = uri;
+  const q = path.indexOf('?');
+  if (q !== -1) path = path.slice(0, q);
+  const h = path.indexOf('#');
+  if (h !== -1) path = path.slice(0, h);
+  path = decodeURIComponentSafe(path);
+  const stripped = stripLeadingSlash(path);
+  if (stripped === '') return defaultRootObject ? stripLeadingSlash(defaultRootObject) : '';
+  return stripped;
+}
+
+/**
+ * Read a key from the first directory that contains it as a regular file.
+ * Path-traversal safe: the resolved absolute path must stay within the origin
+ * directory (a `../` in the key, or a symlink escaping the root, yields no
+ * read). Returns `undefined` when no directory has the key.
+ */
+function readKey(localDirs: readonly string[], key: string): Buffer | undefined {
+  if (key === '') return undefined;
+  for (const dir of localDirs) {
+    const resolved = safeJoin(dir, key);
+    if (!resolved) continue;
+    try {
+      const st = statSync(resolved);
+      if (st.isFile()) return readFileSync(resolved);
+    } catch {
+      // Missing in this dir — try the next.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Join `key` onto `dir`, rejecting any result that escapes `dir` (Zip-Slip /
+ * path-traversal guard). Returns `undefined` when the key would escape.
+ */
+export function safeJoin(dir: string, key: string): string | undefined {
+  const candidate = normalize(join(dir, key));
+  const root = normalize(dir);
+  const rootWithSep = root.endsWith(sep) ? root : root + sep;
+  if (candidate !== root && !candidate.startsWith(rootWithSep)) return undefined;
+  return candidate;
+}
+
+function stripLeadingSlash(s: string): string {
+  return s.startsWith('/') ? s.replace(/^\/+/, '') : s;
+}
+
+function decodeURIComponentSafe(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+/** Minimal extension -> MIME map for the common static-site asset types. */
+const MIME_BY_EXT: Record<string, string> = {
+  html: 'text/html; charset=utf-8',
+  htm: 'text/html; charset=utf-8',
+  css: 'text/css; charset=utf-8',
+  js: 'text/javascript; charset=utf-8',
+  mjs: 'text/javascript; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+  map: 'application/json; charset=utf-8',
+  xml: 'application/xml; charset=utf-8',
+  txt: 'text/plain; charset=utf-8',
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  eot: 'application/vnd.ms-fontobject',
+  pdf: 'application/pdf',
+  wasm: 'application/wasm',
+  webmanifest: 'application/manifest+json',
+};
+
+/** Resolve a Content-Type for an object key by extension. */
+export function contentTypeForKey(key: string): string {
+  const dot = key.lastIndexOf('.');
+  if (dot === -1 || dot === key.length - 1) return 'application/octet-stream';
+  const ext = key.slice(dot + 1).toLowerCase();
+  return MIME_BY_EXT[ext] ?? 'application/octet-stream';
+}

--- a/src/local/target-lister.ts
+++ b/src/local/target-lister.ts
@@ -60,6 +60,8 @@ export interface TargetListing {
   agentCoreRuntimes: TargetEntry[];
   /** Application `AWS::ElasticLoadBalancingV2::LoadBalancer` — `cdkl start-alb`. */
   loadBalancers: TargetEntry[];
+  /** `AWS::CloudFront::Distribution` — `cdkl start-cloudfront`. */
+  cloudFrontDistributions: TargetEntry[];
 }
 
 function makeEntry(
@@ -197,6 +199,7 @@ export function listTargets(stacks: readonly StackInfo[]): TargetListing {
     ecsTaskDefinitions: sortEntries(scanByType(stacks, 'AWS::ECS::TaskDefinition')),
     agentCoreRuntimes: sortEntries(scanByType(stacks, AGENTCORE_RUNTIME_TYPE)),
     loadBalancers: sortEntries(scanApplicationLoadBalancers(stacks)),
+    cloudFrontDistributions: sortEntries(scanByType(stacks, 'AWS::CloudFront::Distribution')),
   };
 }
 
@@ -234,6 +237,7 @@ export function countTargets(listing: TargetListing): number {
     listing.ecsServices.length +
     listing.ecsTaskDefinitions.length +
     listing.agentCoreRuntimes.length +
-    listing.loadBalancers.length
+    listing.loadBalancers.length +
+    listing.cloudFrontDistributions.length
   );
 }

--- a/tests/integration/local-list/lib/local-list-stack.ts
+++ b/tests/integration/local-list/lib/local-list-stack.ts
@@ -4,6 +4,7 @@ import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import { Construct } from 'constructs';
 
 /**
@@ -23,6 +24,7 @@ import { Construct } from 'constructs';
  *     `AWS::ElasticLoadBalancingV2::TargetGroup` +
  *     `AWS::ElasticLoadBalancingV2::Listener`     -> Application Load Balancers
  *   - `AWS::BedrockAgentCore::Runtime` (`MyAgent`) -> AgentCore Runtimes
+ *   - `AWS::CloudFront::Distribution` (`MyDistribution`) -> CloudFront Distributions
  *
  * The test never executes any of these — `cdkl list` is a pure synth-time
  * read over the cloud assembly templates, so placeholder ARNs / URIs are
@@ -121,6 +123,28 @@ export class LocalListStack extends cdk.Stack {
         containerConfiguration: {
           containerUri:
             '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdkl-list-fixture-agent:latest',
+        },
+      },
+    });
+
+    // CloudFront distribution — L1 only so no bucket/asset resolution is
+    // needed. `cdkl list` reads the resource type + path metadata only, so a
+    // placeholder origin is fine; it surfaces under the
+    // `CloudFront Distributions -> cdkl start-cloudfront` group (issue #363).
+    new cloudfront.CfnDistribution(this, 'MyDistribution', {
+      distributionConfig: {
+        enabled: true,
+        defaultRootObject: 'index.html',
+        origins: [
+          {
+            id: 'placeholder-s3',
+            domainName: 'placeholder.s3.us-east-1.amazonaws.com',
+            s3OriginConfig: { originAccessIdentity: '' },
+          },
+        ],
+        defaultCacheBehavior: {
+          targetOriginId: 'placeholder-s3',
+          viewerProtocolPolicy: 'allow-all',
         },
       },
     });

--- a/tests/integration/local-list/verify.sh
+++ b/tests/integration/local-list/verify.sh
@@ -14,6 +14,7 @@
 #   - ECS Task Definitions -> cdkl run-task <target>         (MyTask)
 #   - AgentCore Runtimes ->  cdkl invoke-agentcore <target>  (MyAgent)
 #   - Application Load Balancers -> cdkl start-alb <target...> (MyAlb)
+#   - CloudFront Distributions -> cdkl start-cloudfront <target> (MyDistribution)
 #
 # Also locks down:
 #   - `cdkl ls` (alias) produces the same output as `cdkl list`.
@@ -50,7 +51,8 @@ for header in \
   'ECS Services  ->  cdkl start-service <target...>' \
   'ECS Task Definitions  ->  cdkl run-task <target>' \
   'AgentCore Runtimes  ->  cdkl invoke-agentcore <target>' \
-  'Application Load Balancers  ->  cdkl start-alb <target...>'
+  'Application Load Balancers  ->  cdkl start-alb <target...>' \
+  'CloudFront Distributions  ->  cdkl start-cloudfront <target>'
 do
   if ! grep -qF "${header}" "${OUT_FILE}"; then
     echo "FAIL: missing group header: ${header}"
@@ -72,7 +74,8 @@ for line in \
   '  LocalListFixture/MyService' \
   '  LocalListFixture/MyTask' \
   '  LocalListFixture/MyAgent' \
-  '  LocalListFixture/MyAlb'
+  '  LocalListFixture/MyAlb' \
+  '  LocalListFixture/MyDistribution'
 do
   if ! grep -qF "${line}" "${OUT_FILE}"; then
     echo "FAIL: missing target line: '${line}'"

--- a/tests/integration/local-start-cloudfront/.scenarios.json
+++ b/tests/integration/local-start-cloudfront/.scenarios.json
@@ -1,0 +1,5 @@
+{
+  "scenarios": [
+    "local-start-cloudfront"
+  ]
+}

--- a/tests/integration/local-start-cloudfront/bin/app.ts
+++ b/tests/integration/local-start-cloudfront/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartCloudFrontStack } from '../lib/local-start-cloudfront-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartCloudFrontStack(app, 'CdkLocalStartCloudFrontFixture', {
+  description: 'Fixture stack for cdkl start-cloudfront integ test (#363)',
+});

--- a/tests/integration/local-start-cloudfront/cdk.json
+++ b/tests/integration/local-start-cloudfront/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-cloudfront/lib/local-start-cloudfront-stack.ts
+++ b/tests/integration/local-start-cloudfront/lib/local-start-cloudfront-stack.ts
@@ -1,0 +1,86 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
+import type { Construct } from 'constructs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static-site distribution fixture for `cdkl start-cloudfront` (#363):
+ *
+ *   - An S3 bucket populated by a `BucketDeployment` of `../site`
+ *     (`index.html`, `foo/index.html`, `404.html`) — the local source
+ *     cdk-local resolves to serve the origin.
+ *   - A `viewer-request` CloudFront Function that rewrites an extension-less
+ *     path to `<path>/index.html` (e.g. `/foo` -> `/foo/index.html`) and a
+ *     trailing-slash path to `<path>index.html`.
+ *   - A `viewer-response` CloudFront Function that stamps an `x-cdkl-fixture`
+ *     header so the integ can assert the response function ran.
+ *   - `DefaultRootObject: index.html` and a `403 -> /404.html (200)` custom
+ *     error response (the SPA fallback for a missing key behind an
+ *     OAC-fronted private bucket).
+ */
+export class LocalStartCloudFrontStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const bucket = new s3.Bucket(this, 'SiteBucket', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    new s3deploy.BucketDeployment(this, 'DeploySite', {
+      sources: [s3deploy.Source.asset(path.join(__dirname, '..', 'site'))],
+      destinationBucket: bucket,
+    });
+
+    const rewrite = new cloudfront.Function(this, 'RewriteFn', {
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(
+        [
+          'function handler(event) {',
+          '  var request = event.request;',
+          '  var uri = request.uri;',
+          "  if (uri.endsWith('/')) {",
+          "    request.uri = uri + 'index.html';",
+          "  } else if (!uri.split('/').pop().includes('.')) {",
+          "    request.uri = uri + '/index.html';",
+          '  }',
+          '  return request;',
+          '}',
+        ].join('\n')
+      ),
+    });
+
+    const stampHeader = new cloudfront.Function(this, 'StampFn', {
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(
+        [
+          'function handler(event) {',
+          '  var response = event.response;',
+          "  response.headers['x-cdkl-fixture'] = { value: 'start-cloudfront' };",
+          '  return response;',
+          '}',
+        ].join('\n')
+      ),
+    });
+
+    new cloudfront.Distribution(this, 'SiteDist', {
+      defaultRootObject: 'index.html',
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(bucket),
+        functionAssociations: [
+          { function: rewrite, eventType: cloudfront.FunctionEventType.VIEWER_REQUEST },
+          { function: stampHeader, eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE },
+        ],
+      },
+      errorResponses: [
+        { httpStatus: 403, responseHttpStatus: 200, responsePagePath: '/404.html' },
+      ],
+    });
+  }
+}

--- a/tests/integration/local-start-cloudfront/package.json
+++ b/tests/integration/local-start-cloudfront/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-cloudfront",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-cloudfront (#363)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-cloudfront/site/404.html
+++ b/tests/integration/local-start-cloudfront/site/404.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body><h1>spa fallback</h1></body></html>

--- a/tests/integration/local-start-cloudfront/site/foo/index.html
+++ b/tests/integration/local-start-cloudfront/site/foo/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body><h1>foo page</h1></body></html>

--- a/tests/integration/local-start-cloudfront/site/index.html
+++ b/tests/integration/local-start-cloudfront/site/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body><h1>root page</h1></body></html>

--- a/tests/integration/local-start-cloudfront/tsconfig.json
+++ b/tests/integration/local-start-cloudfront/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-cloudfront/verify.sh
+++ b/tests/integration/local-start-cloudfront/verify.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# verify.sh — cdkl start-cloudfront integ test (#363, no AWS, no Docker)
+#
+# Serves a static-site CloudFront distribution locally: an S3 origin whose
+# content is the BucketDeployment source asset resolved out of the cloud
+# assembly + two CloudFront Functions (a viewer-request rewrite and a
+# viewer-response header stamp). Asserts the full pipeline end to end:
+#   - GET /        -> 200, default root object (index.html), and the
+#                     viewer-response function's x-cdkl-fixture header.
+#   - GET /foo     -> the viewer-request function rewrites it to
+#                     /foo/index.html and the S3 origin serves that key.
+#   - GET /missing -> the 403 -> /404.html (200) CustomErrorResponse fires
+#                     (the SPA fallback for a missing key).
+#   - --watch      -> editing the site source re-synths + swaps the routing
+#                     model under the live socket; the new content is served.
+#   - SIGTERM frees the listening port.
+#
+#     bash tests/integration/local-start-cloudfront/verify.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+PORT=18363
+BASE="http://127.0.0.1:${PORT}"
+TARGET="CdkLocalStartCloudFrontFixture/SiteDist"
+
+CDKL_PID=""
+OUT_FILE=$(mktemp)
+
+cleanup() {
+  echo "==> Cleanup: stopping the server"
+  if [[ -n "${CDKL_PID}" ]] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 40); do
+      if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+      sleep 0.25
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  # Restore any file the --watch scenario edited.
+  if [[ -f site/index.html.bak ]]; then
+    mv -f site/index.html.bak site/index.html
+  fi
+  rm -f "${OUT_FILE}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  echo "----- server output -----" >&2
+  cat "${OUT_FILE}" >&2 || true
+  exit 1
+}
+
+echo "==> Pre-test port sweep (${PORT})"
+if lsof -ti "tcp:${PORT}" >/dev/null 2>&1; then
+  lsof -ti "tcp:${PORT}" | xargs -r kill -9 || true
+fi
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+echo "==> Booting: cdkl start-cloudfront ${TARGET} --port ${PORT} --watch"
+${CDKL} start-cloudfront "${TARGET}" --port "${PORT}" --watch > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+echo "==> Waiting for the server banner"
+BOOTED=0
+for _ in $(seq 1 120); do
+  if grep -q "CloudFront distribution serving on" "${OUT_FILE}"; then BOOTED=1; break; fi
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then fail "server exited before it was ready"; fi
+  sleep 0.5
+done
+[[ "${BOOTED}" -eq 1 ]] || fail "server did not print its ready banner in time"
+
+# ---------------------------------------------------------------------------
+# 1. Default root object + viewer-response header.
+# ---------------------------------------------------------------------------
+echo "==> GET / (default root object + viewer-response header)"
+ROOT_HEADERS=$(curl -fsS -D - -o /tmp/cdkl-cf-root.$$ "${BASE}/") || fail "GET / failed"
+grep -qi "root page" /tmp/cdkl-cf-root.$$ || fail "GET / did not serve the root index.html"
+echo "${ROOT_HEADERS}" | grep -qi "x-cdkl-fixture: start-cloudfront" \
+  || fail "viewer-response function header x-cdkl-fixture not present on GET /"
+rm -f /tmp/cdkl-cf-root.$$
+
+# ---------------------------------------------------------------------------
+# 2. viewer-request rewrite: /foo -> /foo/index.html.
+# ---------------------------------------------------------------------------
+echo "==> GET /foo (viewer-request rewrite -> /foo/index.html)"
+FOO_BODY=$(curl -fsS "${BASE}/foo") || fail "GET /foo failed"
+echo "${FOO_BODY}" | grep -qi "foo page" \
+  || fail "viewer-request rewrite did not resolve /foo to /foo/index.html"
+
+# ---------------------------------------------------------------------------
+# 3. CustomErrorResponses SPA fallback: missing key -> 403 -> /404.html (200).
+# ---------------------------------------------------------------------------
+echo "==> GET /does-not-exist (403 -> /404.html (200) SPA fallback)"
+MISS_STATUS=$(curl -s -o /tmp/cdkl-cf-miss.$$ -w '%{http_code}' "${BASE}/does-not-exist") || true
+[[ "${MISS_STATUS}" == "200" ]] || fail "missing key did not return the custom-error 200 (got ${MISS_STATUS})"
+grep -qi "spa fallback" /tmp/cdkl-cf-miss.$$ || fail "missing key did not serve the /404.html custom-error page"
+rm -f /tmp/cdkl-cf-miss.$$
+
+# ---------------------------------------------------------------------------
+# 4. --watch: edit the site source, expect the new content served after reload.
+# ---------------------------------------------------------------------------
+echo "==> --watch: edit site/index.html and expect the reload to serve it"
+cp site/index.html site/index.html.bak
+printf '<!doctype html><html><body><h1>reloaded root</h1></body></html>\n' > site/index.html
+RELOADED=0
+for _ in $(seq 1 120); do
+  if curl -fsS "${BASE}/" 2>/dev/null | grep -qi "reloaded root"; then RELOADED=1; break; fi
+  sleep 0.5
+done
+mv -f site/index.html.bak site/index.html
+[[ "${RELOADED}" -eq 1 ]] || fail "--watch did not serve the edited site content after a reload"
+
+# ---------------------------------------------------------------------------
+# 5. Teardown frees the port.
+# ---------------------------------------------------------------------------
+echo "==> SIGTERM and verify the port is freed"
+kill -TERM "${CDKL_PID}" 2>/dev/null || true
+for _ in $(seq 1 40); do
+  if ! kill -0 "${CDKL_PID}" 2>/dev/null; then break; fi
+  sleep 0.25
+done
+kill -0 "${CDKL_PID}" 2>/dev/null && fail "server did not exit on SIGTERM"
+CDKL_PID=""
+sleep 0.5
+if lsof -ti "tcp:${PORT}" >/dev/null 2>&1; then fail "port ${PORT} still bound after shutdown"; fi
+
+echo "PASS: cdkl start-cloudfront served the viewer-request -> S3 origin -> viewer-response pipeline, the SPA fallback, and a --watch reload."

--- a/tests/unit/cli/local-list.test.ts
+++ b/tests/unit/cli/local-list.test.ts
@@ -16,6 +16,7 @@ const empty: TargetListing = {
   ecsTaskDefinitions: [],
   agentCoreRuntimes: [],
   loadBalancers: [],
+  cloudFrontDistributions: [],
 };
 
 describe('formatTargetListing', () => {
@@ -31,6 +32,7 @@ describe('formatTargetListing', () => {
       ecsTaskDefinitions: [entry('App/TaskDef', 'App:TaskDef')],
       agentCoreRuntimes: [entry('App/ChatAgent', 'App:ChatAgent')],
       loadBalancers: [entry('App/WebLB', 'App:WebLB')],
+      cloudFrontDistributions: [entry('App/SiteDist', 'App:SiteDist')],
     };
     const out = formatTargetListing(listing, 'cdkl');
     expect(out).toContain('Lambda Functions  ->  cdkl invoke <target>');
@@ -39,6 +41,7 @@ describe('formatTargetListing', () => {
     expect(out).toContain('ECS Task Definitions  ->  cdkl run-task <target>');
     expect(out).toContain('AgentCore Runtimes  ->  cdkl invoke-agentcore <target>');
     expect(out).toContain('Application Load Balancers  ->  cdkl start-alb <target...>');
+    expect(out).toContain('CloudFront Distributions  ->  cdkl start-cloudfront <target>');
   });
 
   it('appends the API surface kind to each API line', () => {

--- a/tests/unit/cli/local-start-cloudfront.test.ts
+++ b/tests/unit/cli/local-start-cloudfront.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  parseOriginOverrides,
+  resolveCloudFrontTarget,
+} from '../../../src/cli/commands/local-start-cloudfront.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+
+function stack(name: string, template: CloudFormationTemplate): StackInfo {
+  return {
+    stackName: name,
+    displayName: name,
+    artifactId: name,
+    template,
+    dependencyNames: [],
+  };
+}
+
+const distTemplate: CloudFormationTemplate = {
+  Resources: {
+    SiteDist: {
+      Type: 'AWS::CloudFront::Distribution',
+      Properties: {},
+      Metadata: { 'aws:cdk:path': 'App/SiteDist/Resource' },
+    },
+    NotADist: { Type: 'AWS::S3::Bucket', Properties: {} },
+  },
+};
+
+describe('resolveCloudFrontTarget', () => {
+  it('resolves a CDK display path to the distribution logical id', () => {
+    const { logicalId } = resolveCloudFrontTarget('App/SiteDist', [stack('App', distTemplate)]);
+    expect(logicalId).toBe('SiteDist');
+  });
+
+  it('resolves a stack-qualified logical id', () => {
+    const { logicalId } = resolveCloudFrontTarget('App:SiteDist', [stack('App', distTemplate)]);
+    expect(logicalId).toBe('SiteDist');
+  });
+
+  it('throws a helpful error when the target is not a distribution', () => {
+    expect(() => resolveCloudFrontTarget('App:NotADist', [stack('App', distTemplate)])).toThrow(
+      /did not match a CloudFront distribution/
+    );
+  });
+
+  it('requires a stack prefix in a multi-stack app', () => {
+    expect(() =>
+      resolveCloudFrontTarget('SiteDist', [
+        stack('App', distTemplate),
+        stack('Other', { Resources: {} }),
+      ])
+    ).toThrow(/has no stack prefix/);
+  });
+});
+
+describe('parseOriginOverrides', () => {
+  it('parses <id>=<dir> pairs', () => {
+    const map = parseOriginOverrides(['origin1=./site', 'origin2=/abs/path']);
+    expect(map.get('origin1')).toBe('./site');
+    expect(map.get('origin2')).toBe('/abs/path');
+  });
+
+  it('returns an empty map for undefined', () => {
+    expect(parseOriginOverrides(undefined).size).toBe(0);
+  });
+
+  it('rejects a malformed value', () => {
+    expect(() => parseOriginOverrides(['nope'])).toThrow(/Expected <originId>=<dir>/);
+    expect(() => parseOriginOverrides(['=dir'])).toThrow(/Expected <originId>=<dir>/);
+  });
+});

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -30,6 +30,10 @@ import {
   addStudioSpecificOptions,
   createLocalStudioCommand,
 } from '../../../src/cli/commands/local-studio.js';
+import {
+  addStartCloudFrontSpecificOptions,
+  createLocalStartCloudFrontCommand,
+} from '../../../src/cli/commands/local-start-cloudfront.js';
 
 /**
  * Return the sorted long-flag set for a Commander command. Mirrors the
@@ -273,6 +277,32 @@ describe('start-api option surface contract (addStartApiSpecificOptions)', () =>
       new Set([
         ...commonAppContextRegionFlags(),
         ...longFlagsOf(addStartApiSpecificOptions(new Command())),
+      ])
+    ).sort();
+    expect(full).toEqual(expected);
+  });
+});
+
+describe('start-cloudfront option surface contract (addStartCloudFrontSpecificOptions)', () => {
+  it('addStartCloudFrontSpecificOptions registers exactly the known start-cloudfront-only flags', () => {
+    const flags = longFlagsOf(addStartCloudFrontSpecificOptions(new Command()));
+    expect(flags).toEqual([
+      '--host',
+      '--origin',
+      '--port',
+      '--tls',
+      '--tls-cert',
+      '--tls-key',
+      '--watch',
+    ]);
+  });
+
+  it('createLocalStartCloudFrontCommand surface equals common + start-cloudfront-specific (no inline drift)', () => {
+    const full = longFlagsOf(createLocalStartCloudFrontCommand());
+    const expected = Array.from(
+      new Set([
+        ...commonAppContextRegionFlags(),
+        ...longFlagsOf(addStartCloudFrontSpecificOptions(new Command())),
       ])
     ).sort();
     expect(full).toEqual(expected);

--- a/tests/unit/local/cloudfront-function-runtime.test.ts
+++ b/tests/unit/local/cloudfront-function-runtime.test.ts
@@ -77,6 +77,22 @@ describe('runViewerRequest', () => {
     const fn = compile("function handler(event){ throw new Error('boom'); }");
     await expect(runViewerRequest(fn, reqEvent('/'))).rejects.toThrow(/CloudFront Function 'Fn'.*boom/);
   });
+
+  it('tolerates a handler that writes a bare-string header value', async () => {
+    const fn = compile(
+      "function handler(event){ var r=event.request; r.headers['x-test']='bare'; return r; }"
+    );
+    const out = await runViewerRequest(fn, reqEvent('/'));
+    expect(out.kind).toBe('continue');
+    if (out.kind === 'continue') expect(out.request.headers['x-test']?.value).toBe('bare');
+  });
+
+  it('aborts a runaway synchronous handler via the vm timeout', async () => {
+    const fn = compile('function handler(event){ while (true) {} }');
+    await expect(runViewerRequest(fn, reqEvent('/'))).rejects.toThrow(
+      /CloudFront Function 'Fn'/
+    );
+  }, 15000);
 });
 
 describe('runViewerResponse', () => {

--- a/tests/unit/local/cloudfront-function-runtime.test.ts
+++ b/tests/unit/local/cloudfront-function-runtime.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildViewerRequestEvent,
+  buildViewerResponseEvent,
+  compileCloudFrontFunction,
+  runViewerRequest,
+  runViewerResponse,
+  serializeCfQueryString,
+} from '../../../src/local/cloudfront-function-runtime.js';
+
+function compile(code: string, runtime = 'cloudfront-js-2.0') {
+  return compileCloudFrontFunction('Fn', code, runtime);
+}
+
+function reqEvent(uri: string, headers: Record<string, string | string[]> = {}) {
+  return buildViewerRequestEvent({
+    method: 'GET',
+    uri,
+    querystring: '',
+    headers,
+    ip: '203.0.113.1',
+    distributionId: 'Dist',
+    domainName: 'localhost',
+    requestId: 'req-1',
+  });
+}
+
+describe('compileCloudFrontFunction', () => {
+  it('throws on a syntax error', () => {
+    expect(() => compile('function handler(event) { return ')).toThrow(/failed to compile/);
+  });
+
+  it('throws when no handler is declared', () => {
+    expect(() => compile('var notHandler = 1;')).toThrow(/does not declare a 'handler'/);
+  });
+});
+
+describe('runViewerRequest', () => {
+  it('rewrites the uri and continues to the origin', async () => {
+    const fn = compile(
+      "function handler(event){var r=event.request; if(r.uri.endsWith('/')) r.uri+='index.html'; return r;}"
+    );
+    const out = await runViewerRequest(fn, reqEvent('/foo/'));
+    expect(out.kind).toBe('continue');
+    if (out.kind === 'continue') expect(out.request.uri).toBe('/foo/index.html');
+  });
+
+  it('short-circuits with a generated response when the handler returns a statusCode', async () => {
+    const fn = compile(
+      "function handler(event){return {statusCode:301, statusDescription:'Moved', headers:{location:{value:'https://example.com/'}}};}"
+    );
+    const out = await runViewerRequest(fn, reqEvent('/old'));
+    expect(out.kind).toBe('response');
+    if (out.kind === 'response') {
+      expect(out.response.statusCode).toBe(301);
+      expect(out.response.headers['location']?.value).toBe('https://example.com/');
+    }
+  });
+
+  it('continues unchanged when the handler returns a non-object', async () => {
+    const fn = compile('function handler(event){ return undefined; }');
+    const out = await runViewerRequest(fn, reqEvent('/x'));
+    expect(out.kind).toBe('continue');
+    if (out.kind === 'continue') expect(out.request.uri).toBe('/x');
+  });
+
+  it('awaits an async (cloudfront-js-2.0) handler', async () => {
+    const fn = compile(
+      "async function handler(event){ var r = event.request; r.uri = '/async.html'; return r; }"
+    );
+    const out = await runViewerRequest(fn, reqEvent('/'));
+    expect(out.kind).toBe('continue');
+    if (out.kind === 'continue') expect(out.request.uri).toBe('/async.html');
+  });
+
+  it('wraps a handler that throws with the function logical id', async () => {
+    const fn = compile("function handler(event){ throw new Error('boom'); }");
+    await expect(runViewerRequest(fn, reqEvent('/'))).rejects.toThrow(/CloudFront Function 'Fn'.*boom/);
+  });
+});
+
+describe('runViewerResponse', () => {
+  it('mutates a response header', async () => {
+    const fn = compile(
+      "function handler(event){var r=event.response; r.headers['x-frame-options']={value:'DENY'}; return r;}"
+    );
+    const reqEv = reqEvent('/');
+    const respEv = buildViewerResponseEvent(reqEv, {
+      statusCode: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+    const out = await runViewerResponse(fn, respEv);
+    expect(out.statusCode).toBe(200);
+    expect(out.headers['x-frame-options']?.value).toBe('DENY');
+    // The origin header is preserved.
+    expect(out.headers['content-type']?.value).toBe('text/html');
+  });
+});
+
+describe('buildViewerRequestEvent', () => {
+  it('lower-cases header names and splits cookies out', () => {
+    const ev = reqEvent('/p', { Host: 'localhost', Cookie: 'a=1; b=2' });
+    expect(ev.request.headers['host']?.value).toBe('localhost');
+    expect(ev.request.cookies['a']?.value).toBe('1');
+    expect(ev.request.cookies['b']?.value).toBe('2');
+    expect(ev.context.eventType).toBe('viewer-request');
+  });
+
+  it('promotes a repeated query parameter to multiValue', () => {
+    const ev = buildViewerRequestEvent({
+      method: 'GET',
+      uri: '/p',
+      querystring: 'a=1&a=2&b=3',
+      headers: {},
+      ip: '203.0.113.1',
+      distributionId: 'D',
+      domainName: 'localhost',
+      requestId: 'r',
+    });
+    expect(ev.request.querystring['a']?.multiValue?.map((m) => m.value)).toEqual(['1', '2']);
+    expect(ev.request.querystring['b']?.value).toBe('3');
+  });
+});
+
+describe('serializeCfQueryString', () => {
+  it('round-trips single and multi values', () => {
+    expect(serializeCfQueryString({ a: { value: '1' }, b: { value: 'x', multiValue: [{ value: 'x' }, { value: 'y' }] } })).toBe(
+      'a=1&b=x&b=y'
+    );
+  });
+});

--- a/tests/unit/local/cloudfront-resolver.test.ts
+++ b/tests/unit/local/cloudfront-resolver.test.ts
@@ -1,0 +1,219 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import {
+  pickBucketLogicalIdFromOrigin,
+  pickFunctionLogicalIdFromArn,
+  resolveCloudFrontDistribution,
+} from '../../../src/local/cloudfront-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = mkdtempSync(join(tmpdir(), 'cdkl-cf-resolver-'));
+});
+afterEach(() => {
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+/** Build a StackInfo backed by an on-disk asset manifest + staged asset dir. */
+function buildStack(template: CloudFormationTemplate, assetHash?: string): StackInfo {
+  const assetManifestPath = join(outDir, 'Stack.assets.json');
+  const files: Record<string, unknown> = {};
+  if (assetHash) {
+    const assetPath = `asset.${assetHash}`;
+    mkdirSync(join(outDir, assetPath), { recursive: true });
+    writeFileSync(join(outDir, assetPath, 'index.html'), '<h1>root</h1>');
+    files[assetHash] = {
+      displayName: 'Site',
+      source: { path: assetPath, packaging: 'zip' },
+      destinations: { current: { bucketName: 'b', objectKey: `${assetHash}.zip` } },
+    };
+  }
+  writeFileSync(assetManifestPath, JSON.stringify({ version: '1', files, dockerImages: {} }));
+  return {
+    stackName: 'Stack',
+    displayName: 'Stack',
+    artifactId: 'Stack',
+    template,
+    assetManifestPath,
+    dependencyNames: [],
+  };
+}
+
+const HASH = 'a'.repeat(64);
+
+function s3DistributionTemplate(): CloudFormationTemplate {
+  return {
+    Resources: {
+      SiteBucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+      RewriteFn: {
+        Type: 'AWS::CloudFront::Function',
+        Properties: {
+          FunctionCode:
+            "function handler(event){var r=event.request; if(r.uri.endsWith('/')) r.uri+='index.html'; return r;}",
+          FunctionConfig: { Runtime: 'cloudfront-js-2.0', Comment: 'c' },
+        },
+      },
+      Deploy: {
+        Type: 'Custom::CDKBucketDeployment',
+        Properties: {
+          DestinationBucketName: { Ref: 'SiteBucket' },
+          SourceObjectKeys: [`${HASH}.zip`],
+        },
+      },
+      Dist: {
+        Type: 'AWS::CloudFront::Distribution',
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: 'index.html',
+            Origins: [
+              {
+                Id: 'origin1',
+                DomainName: { 'Fn::GetAtt': ['SiteBucket', 'RegionalDomainName'] },
+                S3OriginConfig: { OriginAccessIdentity: '' },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: 'origin1',
+              ViewerProtocolPolicy: 'redirect-to-https',
+              FunctionAssociations: [
+                { EventType: 'viewer-request', FunctionARN: { 'Fn::GetAtt': ['RewriteFn', 'FunctionARN'] } },
+              ],
+            },
+            CustomErrorResponses: [{ ErrorCode: 403, ResponseCode: 200, ResponsePagePath: '/index.html' }],
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('resolveCloudFrontDistribution — S3 origin happy path', () => {
+  it('resolves behaviors, the viewer-request function, the S3 origin dir, and custom errors', () => {
+    const stack = buildStack(s3DistributionTemplate(), HASH);
+    const resolved = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' });
+
+    expect(resolved.defaultRootObject).toBe('index.html');
+    expect(resolved.behaviors).toHaveLength(1);
+    const def = resolved.behaviors[0]!;
+    expect(def.pathPattern).toBeUndefined();
+    expect(def.targetOriginId).toBe('origin1');
+    expect(def.viewerProtocolPolicy).toBe('redirect-to-https');
+    expect(def.viewerRequest?.logicalId).toBe('RewriteFn');
+    expect(def.viewerResponse).toBeUndefined();
+    expect(def.hasLambdaEdge).toBe(false);
+
+    const origin = resolved.origins.get('origin1');
+    expect(origin?.kind).toBe('s3');
+    if (origin?.kind === 's3') {
+      expect(origin.localDirs).toHaveLength(1);
+      expect(origin.localDirs[0]).toContain(`asset.${HASH}`);
+    }
+
+    expect(resolved.customErrorResponses).toEqual([
+      { errorCode: 403, responseCode: 200, responsePagePath: '/index.html' },
+    ]);
+  });
+});
+
+describe('resolveCloudFrontDistribution — unresolved + custom origins', () => {
+  it('marks an S3 origin with no BucketDeployment as s3-unresolved', () => {
+    const template = s3DistributionTemplate();
+    delete (template.Resources as Record<string, unknown>)['Deploy'];
+    const stack = buildStack(template, HASH);
+    const resolved = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' });
+    const origin = resolved.origins.get('origin1');
+    expect(origin?.kind).toBe('s3-unresolved');
+  });
+
+  it('honors an --origin override even when resolution would succeed', () => {
+    const stack = buildStack(s3DistributionTemplate(), HASH);
+    const overrideDir = mkdtempSync(join(tmpdir(), 'cdkl-cf-override-'));
+    try {
+      const resolved = resolveCloudFrontDistribution({
+        stack,
+        logicalId: 'Dist',
+        originOverrides: new Map([['origin1', overrideDir]]),
+      });
+      const origin = resolved.origins.get('origin1');
+      expect(origin?.kind).toBe('s3');
+      if (origin?.kind === 's3') expect(origin.localDirs[0]).toBe(overrideDir);
+    } finally {
+      rmSync(overrideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('classifies a non-S3 origin as custom', () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [
+                {
+                  Id: 'api',
+                  DomainName: 'api.example.com',
+                  CustomOriginConfig: { OriginProtocolPolicy: 'https-only' },
+                },
+              ],
+              DefaultCacheBehavior: { TargetOriginId: 'api' },
+            },
+          },
+        },
+      },
+    };
+    const stack = buildStack(template);
+    const resolved = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' });
+    const origin = resolved.origins.get('api');
+    expect(origin?.kind).toBe('custom');
+    if (origin?.kind === 'custom') expect(origin.domainName).toBe('api.example.com');
+  });
+
+  it('records a Lambda@Edge association as hasLambdaEdge', () => {
+    const template = s3DistributionTemplate();
+    const dc = (template.Resources!['Dist']!.Properties as Record<string, Record<string, unknown>>)[
+      'DistributionConfig'
+    ]!;
+    (dc['DefaultCacheBehavior'] as Record<string, unknown>)['LambdaFunctionAssociations'] = [
+      { EventType: 'origin-request', LambdaFunctionArn: 'arn:aws:lambda:...' },
+    ];
+    const stack = buildStack(template, HASH);
+    const resolved = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' });
+    expect(resolved.behaviors[0]!.hasLambdaEdge).toBe(true);
+  });
+
+  it('resolves CacheBehaviors[] in declared order after the default', () => {
+    const template = s3DistributionTemplate();
+    const dc = (template.Resources!['Dist']!.Properties as Record<string, Record<string, unknown>>)[
+      'DistributionConfig'
+    ]!;
+    dc['CacheBehaviors'] = [{ PathPattern: '/api/*', TargetOriginId: 'origin1' }];
+    const stack = buildStack(template, HASH);
+    const resolved = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' });
+    expect(resolved.behaviors.map((b) => b.pathPattern)).toEqual([undefined, '/api/*']);
+  });
+});
+
+describe('intrinsic helpers', () => {
+  it('pickFunctionLogicalIdFromArn unwraps Fn::GetAtt', () => {
+    expect(pickFunctionLogicalIdFromArn({ 'Fn::GetAtt': ['Fn', 'FunctionARN'] })).toBe('Fn');
+    expect(pickFunctionLogicalIdFromArn('literal')).toBeUndefined();
+  });
+
+  it('pickBucketLogicalIdFromOrigin only resolves to an S3 bucket', () => {
+    const template: CloudFormationTemplate = {
+      Resources: { B: { Type: 'AWS::S3::Bucket', Properties: {} } },
+    };
+    expect(
+      pickBucketLogicalIdFromOrigin({ DomainName: { 'Fn::GetAtt': ['B', 'RegionalDomainName'] } }, template)
+    ).toBe('B');
+    expect(
+      pickBucketLogicalIdFromOrigin({ DomainName: { 'Fn::GetAtt': ['X', 'RegionalDomainName'] } }, template)
+    ).toBeUndefined();
+  });
+});

--- a/tests/unit/local/cloudfront-resolver.test.ts
+++ b/tests/unit/local/cloudfront-resolver.test.ts
@@ -197,6 +197,29 @@ describe('resolveCloudFrontDistribution — unresolved + custom origins', () => 
     const resolved = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' });
     expect(resolved.behaviors.map((b) => b.pathPattern)).toEqual([undefined, '/api/*']);
   });
+
+  it('skips a CacheBehaviors[] entry with a non-literal PathPattern (no silent catch-all)', () => {
+    const template = s3DistributionTemplate();
+    const dc = (template.Resources!['Dist']!.Properties as Record<string, Record<string, unknown>>)[
+      'DistributionConfig'
+    ]!;
+    // An intrinsic / missing PathPattern would default to '*' and shadow the
+    // default behavior; it must be skipped instead.
+    dc['CacheBehaviors'] = [{ PathPattern: { Ref: 'Something' }, TargetOriginId: 'origin1' }];
+    const stack = buildStack(template, HASH);
+    const resolved = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' });
+    expect(resolved.behaviors.map((b) => b.pathPattern)).toEqual([undefined]);
+  });
+
+  it('throws on a distribution with no DistributionConfig', () => {
+    const template: CloudFormationTemplate = {
+      Resources: { Dist: { Type: 'AWS::CloudFront::Distribution', Properties: {} } },
+    };
+    const stack = buildStack(template);
+    expect(() => resolveCloudFrontDistribution({ stack, logicalId: 'Dist' })).toThrow(
+      /has no DistributionConfig/
+    );
+  });
 });
 
 describe('intrinsic helpers', () => {

--- a/tests/unit/local/cloudfront-server.test.ts
+++ b/tests/unit/local/cloudfront-server.test.ts
@@ -104,6 +104,28 @@ describe('startCloudFrontServer — pipeline', () => {
       server.update(distribution());
     }
   });
+
+  it('skips an invalid function-returned header instead of 500-ing the response', async () => {
+    const badHeaderFn = compileCloudFrontFunction(
+      'BadHeaderFn',
+      "function handler(event){ var r=event.response; r.headers['x-bad'] = { value: 'a\\r\\nInjected: 1' }; r.headers['x-good'] = { value: 'ok' }; return r; }",
+      'cloudfront-js-2.0'
+    );
+    const withBad = distribution();
+    withBad.behaviors = [
+      { targetOriginId: 'o1', hasLambdaEdge: false, viewerResponse: badHeaderFn },
+    ];
+    server.update(withBad);
+    try {
+      const res = await fetch(`${server.url}/`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('x-good')).toBe('ok');
+      // The CRLF in the bad value is stripped, never reflected as a real header.
+      expect(res.headers.get('injected')).toBeNull();
+    } finally {
+      server.update(distribution());
+    }
+  });
 });
 
 describe('matchBehavior', () => {

--- a/tests/unit/local/cloudfront-server.test.ts
+++ b/tests/unit/local/cloudfront-server.test.ts
@@ -1,0 +1,122 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { compileCloudFrontFunction } from '../../../src/local/cloudfront-function-runtime.js';
+import type {
+  ResolvedBehavior,
+  ResolvedDistribution,
+} from '../../../src/local/cloudfront-resolver.js';
+import {
+  matchBehavior,
+  startCloudFrontServer,
+  type StartedCloudFrontServer,
+} from '../../../src/local/cloudfront-server.js';
+
+let dir: string;
+let server: StartedCloudFrontServer;
+
+const rewriteFn = compileCloudFrontFunction(
+  'RewriteFn',
+  "function handler(event){var r=event.request; if(r.uri.endsWith('/')) r.uri+='index.html'; return r;}",
+  'cloudfront-js-2.0'
+);
+const headerFn = compileCloudFrontFunction(
+  'HeaderFn',
+  "function handler(event){var r=event.response; r.headers['x-cdkl']={value:'1'}; return r;}",
+  'cloudfront-js-2.0'
+);
+
+function distribution(): ResolvedDistribution {
+  const def: ResolvedBehavior = {
+    targetOriginId: 'o1',
+    hasLambdaEdge: false,
+    viewerRequest: rewriteFn,
+    viewerResponse: headerFn,
+  };
+  return {
+    logicalId: 'Dist',
+    stackName: 'Stack',
+    defaultRootObject: 'index.html',
+    behaviors: [def],
+    origins: new Map([['o1', { kind: 's3', originId: 'o1', localDirs: [dir] }]]),
+    customErrorResponses: [{ errorCode: 403, responseCode: 200, responsePagePath: '/index.html' }],
+  };
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'cdkl-cf-server-'));
+  writeFileSync(join(dir, 'index.html'), '<h1>root</h1>');
+  mkdirSync(join(dir, 'foo'), { recursive: true });
+  writeFileSync(join(dir, 'foo', 'index.html'), '<h1>foo</h1>');
+  server = await startCloudFrontServer({ distribution: distribution(), host: '127.0.0.1', port: 0 });
+});
+
+afterAll(async () => {
+  await server.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('startCloudFrontServer — pipeline', () => {
+  it('serves the default root object at / with the viewer-response header applied', async () => {
+    const res = await fetch(`${server.url}/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('root');
+    expect(res.headers.get('x-cdkl')).toBe('1');
+  });
+
+  it('runs the viewer-request rewrite (/foo/ -> /foo/index.html)', async () => {
+    const res = await fetch(`${server.url}/foo/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('foo');
+  });
+
+  it('applies the custom-error SPA fallback for a missing key', async () => {
+    const res = await fetch(`${server.url}/missing-key`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('root');
+  });
+
+  it('update() swaps the served distribution (a --watch reload)', async () => {
+    const second = mkdtempSync(join(tmpdir(), 'cdkl-cf-server2-'));
+    writeFileSync(join(second, 'index.html'), '<h1>reloaded</h1>');
+    try {
+      const next = distribution();
+      next.origins = new Map([['o1', { kind: 's3', originId: 'o1', localDirs: [second] }]]);
+      server.update(next);
+      const res = await fetch(`${server.url}/`);
+      expect(await res.text()).toContain('reloaded');
+    } finally {
+      // Restore for sibling test isolation, then remove.
+      server.update(distribution());
+      rmSync(second, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 502 for an unresolved S3 origin', async () => {
+    const unresolved = distribution();
+    unresolved.origins = new Map([['o1', { kind: 's3-unresolved', originId: 'o1' }]]);
+    server.update(unresolved);
+    try {
+      const res = await fetch(`${server.url}/`);
+      expect(res.status).toBe(502);
+    } finally {
+      server.update(distribution());
+    }
+  });
+});
+
+describe('matchBehavior', () => {
+  const def: ResolvedBehavior = { targetOriginId: 'o', hasLambdaEdge: false };
+  const api: ResolvedBehavior = { pathPattern: '/api/*', targetOriginId: 'o', hasLambdaEdge: false };
+
+  it('prefers a matching path pattern over the default', () => {
+    expect(matchBehavior([def, api], '/api/x')).toBe(api);
+  });
+  it('falls back to the default behavior when no pattern matches', () => {
+    expect(matchBehavior([def, api], '/other')).toBe(def);
+  });
+  it('returns undefined when there is no default and nothing matches', () => {
+    expect(matchBehavior([api], '/other')).toBeUndefined();
+  });
+});

--- a/tests/unit/local/cloudfront-static-origin.test.ts
+++ b/tests/unit/local/cloudfront-static-origin.test.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import {
+  contentTypeForKey,
+  safeJoin,
+  serveFromStaticOrigin,
+  uriToKey,
+} from '../../../src/local/cloudfront-static-origin.js';
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'cdkl-cf-origin-'));
+  writeFileSync(join(dir, 'index.html'), '<h1>root</h1>');
+  mkdirSync(join(dir, 'foo'), { recursive: true });
+  writeFileSync(join(dir, 'foo', 'index.html'), '<h1>foo</h1>');
+  writeFileSync(join(dir, 'app.js'), 'console.log(1)');
+  writeFileSync(join(dir, 'error.html'), '<h1>spa</h1>');
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('serveFromStaticOrigin', () => {
+  it('serves the default root object at /', () => {
+    const r = serveFromStaticOrigin({ localDirs: [dir], uri: '/', defaultRootObject: 'index.html' });
+    expect(r.statusCode).toBe(200);
+    expect(r.body.toString()).toContain('root');
+    expect(r.headers['content-type']).toContain('text/html');
+  });
+
+  it('serves an exact key with the right content type', () => {
+    const r = serveFromStaticOrigin({ localDirs: [dir], uri: '/app.js' });
+    expect(r.statusCode).toBe(200);
+    expect(r.headers['content-type']).toContain('javascript');
+  });
+
+  it('serves a key the viewer-request function rewrote (/foo/index.html)', () => {
+    const r = serveFromStaticOrigin({ localDirs: [dir], uri: '/foo/index.html' });
+    expect(r.statusCode).toBe(200);
+    expect(r.body.toString()).toContain('foo');
+  });
+
+  it('does NOT auto-index a sub-path (/foo) — CloudFront leaves that to a function', () => {
+    const r = serveFromStaticOrigin({ localDirs: [dir], uri: '/foo' });
+    expect(r.statusCode).toBe(404);
+  });
+
+  it('applies a 403 CustomErrorResponses page (SPA fallback) for a missing key', () => {
+    const r = serveFromStaticOrigin({
+      localDirs: [dir],
+      uri: '/does-not-exist',
+      customErrorResponses: [{ errorCode: 403, responseCode: 200, responsePagePath: '/error.html' }],
+    });
+    expect(r.statusCode).toBe(200);
+    expect(r.body.toString()).toContain('spa');
+  });
+
+  it('returns a plain 404 with no matching custom-error page', () => {
+    const r = serveFromStaticOrigin({ localDirs: [dir], uri: '/missing' });
+    expect(r.statusCode).toBe(404);
+    expect(r.headers['content-type']).toContain('text/plain');
+  });
+
+  it('searches multiple dirs in order (first hit wins)', () => {
+    const second = mkdtempSync(join(tmpdir(), 'cdkl-cf-origin2-'));
+    writeFileSync(join(second, 'only-in-second.txt'), 'second');
+    try {
+      const r = serveFromStaticOrigin({ localDirs: [dir, second], uri: '/only-in-second.txt' });
+      expect(r.statusCode).toBe(200);
+      expect(r.body.toString()).toBe('second');
+    } finally {
+      rmSync(second, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a path-traversal key', () => {
+    const r = serveFromStaticOrigin({ localDirs: [dir], uri: '/../../etc/passwd' });
+    expect(r.statusCode).toBe(404);
+  });
+});
+
+describe('uriToKey', () => {
+  it('drops query and fragment, strips leading slash', () => {
+    expect(uriToKey('/a/b.html?x=1#frag')).toBe('a/b.html');
+  });
+  it('maps root to the default root object', () => {
+    expect(uriToKey('/', 'index.html')).toBe('index.html');
+  });
+});
+
+describe('safeJoin', () => {
+  it('rejects escapes', () => {
+    expect(safeJoin('/srv/site', '../secret')).toBeUndefined();
+  });
+  it('accepts an in-tree key', () => {
+    expect(safeJoin('/srv/site', 'a/b.html')).toBe('/srv/site/a/b.html');
+  });
+});
+
+describe('contentTypeForKey', () => {
+  it('maps known extensions', () => {
+    expect(contentTypeForKey('x.css')).toContain('text/css');
+    expect(contentTypeForKey('x.svg')).toBe('image/svg+xml');
+  });
+  it('falls back to octet-stream', () => {
+    expect(contentTypeForKey('x.unknownext')).toBe('application/octet-stream');
+    expect(contentTypeForKey('noext')).toBe('application/octet-stream');
+  });
+});

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -172,6 +172,7 @@ const emptyListing = (): TargetListing => ({
   ecsTaskDefinitions: [],
   agentCoreRuntimes: [],
   loadBalancers: [],
+  cloudFrontDistributions: [],
 });
 
 describe('annotatePinnedEcsTargets', () => {

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -319,9 +319,10 @@ describe('countTargets', () => {
       Svc: { Type: 'AWS::ECS::Service', Properties: {} },
       Td: { Type: 'AWS::ECS::TaskDefinition', Properties: {} },
       Agent: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      Dist: { Type: 'AWS::CloudFront::Distribution', Properties: {} },
     });
     const listing = listTargets([stack]);
-    expect(countTargets(listing)).toBe(4);
+    expect(countTargets(listing)).toBe(5);
   });
 
   it('returns 0 for an app with no runnable targets', () => {
@@ -337,6 +338,7 @@ describe('countTargets', () => {
       ecsTaskDefinitions: [],
       agentCoreRuntimes: [],
       loadBalancers: [],
+      cloudFrontDistributions: [],
     });
   });
 
@@ -354,5 +356,23 @@ describe('countTargets', () => {
     });
     const listing = listTargets([stack]);
     expect(listing.loadBalancers.map((e) => e.logicalId).sort()).toEqual(['DefaultLB', 'WebLB']);
+  });
+
+  it('enumerates CloudFront distributions (start-cloudfront)', () => {
+    const stack = buildStack('App', {
+      SiteDist: withPath(
+        { Type: 'AWS::CloudFront::Distribution', Properties: {} },
+        'App/SiteDist/Resource'
+      ),
+    });
+    const listing = listTargets([stack]);
+    expect(listing.cloudFrontDistributions).toEqual([
+      {
+        logicalId: 'SiteDist',
+        stackName: 'App',
+        qualifiedId: 'App:SiteDist',
+        displayPath: 'App/SiteDist',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds `cdkl start-cloudfront <distribution>` (closes #363): a long-running local server that reproduces a CloudFront distribution's **viewer-request -> S3 origin -> viewer-response** pipeline, so a URL-rewrite / routing / SPA-fallback change is verifiable in seconds instead of a deploy. A CloudFront Function is the user's own application compute, and the distribution routing is reproduced locally the same way `start-api` reproduces API Gateway routing -- not an emulation of the managed CloudFront service.

```bash
cdkl start-cloudfront                       # pick interactively in a TTY
cdkl start-cloudfront MyStack/SiteDist --port 8080
#  curl /        -> default root object (index.html)
#  curl /foo     -> viewer-request rewrites to /foo/index.html, S3 origin serves it
#  curl /missing -> 403 -> /index.html (200) CustomErrorResponse (SPA fallback)
cdkl start-cloudfront MyStack/SiteDist --watch          # re-synth + swap routing on save
cdkl start-cloudfront MyStack/SiteDist --origin SiteOrigin=./dist   # local-dir escape hatch
```

### How it works

- **cloudfront-function-runtime** -- compiles + runs an inline CloudFront Function in a `node:vm` sandbox (cloudfront-js-1.0 / 2.0, async handlers awaited); the synchronous run is bounded by a 5s vm timeout (a runaway `while(true){}` fails that one request instead of wedging the server). Builds the viewer-request / viewer-response event from an HTTP request and interprets the return as continue-to-origin (rewritten request) vs short-circuit response (when it returns a `statusCode`).
- **cloudfront-static-origin** -- serves a URI from the resolved S3 origin dir(s): `DefaultRootObject` at `/` only (CloudFront does NOT auto-index sub-paths -- that's what a rewrite function does), path-traversal guard, MIME by extension, `CustomErrorResponses` SPA fallback.
- **cloudfront-resolver** -- resolves `AWS::CloudFront::Distribution` -> behaviors (default + `CacheBehaviors[]`), viewer-request / viewer-response Functions (linked via `FunctionAssociations[].FunctionARN`), S3 origin -> local BucketDeployment source dir (bucket from the `DomainName` GetAtt -> its `Custom::CDKBucketDeployment` -> `SourceObjectKeys` -> the staged asset dir in the cloud assembly), and `CustomErrorResponses`.
- **cloudfront-server** -- the per-request pipeline (behavior match via the ALB `*`/`?` glob matcher, `CacheBehaviors[]` order then default-behavior fallback), with a mutable distribution cell so `--watch` swaps the routing model under the live socket. `--tls` reuses the ALB front-door's self-signed-cert path.
- Distributions are enumerated in `cdkl list` + the interactive picker; the factory is exported from `src/index.ts` and the runtime helpers from `src/internal.ts`.

### Scope

S3 origins only. Custom (non-S3) origins, Lambda@Edge (`LambdaFunctionAssociations`), the KeyValueStore, and the 2.0 `cf.fetch` API are out of scope -- custom / unresolved origins return 502 with an actionable message, and the boot path WARNs. Single distribution per invocation. **`cdkl studio` integration is tracked separately in #367** (the studio layer is under concurrent work).

### cdkd parity

- New subcommand factory `createLocalStartCloudFrontCommand` -- exported from `src/index.ts`; a host CLI wraps it via `addStartCloudFrontSpecificOptions` (the option block) + `resolveCloudFrontTarget`. cdkd should inherit the new subcommand when it next bumps `cdk-local`.
- New `src/local/**` helpers (resolver / function-runtime / static-origin / server) re-exported from `src/internal.ts` with host-use-case JSDoc.
- Additive surface: `TargetListing` gains a `cloudFrontDistributions` field and `cdkl list` gains a `CloudFront Distributions` group. Hosts that call `listTargets()` get the field for free; a host hand-constructing a `TargetListing` literal must add the field.

## Test plan

- **Unit** (168 files / 2594 tests green): function runtime (rewrite, short-circuit, async, error wrap, vm-timeout abort, bare-string header coercion), static origin (root-object-at-root-only, traversal guard, custom-error fallback, MIME, multi-dir), resolver (S3-dir resolution chain, custom / unresolved origin, Lambda@Edge flag, non-literal PathPattern skip, no-DistributionConfig throw, override), server (behavior match, full in-process pipeline via `fetch`, `update()` swap, 502 paths, invalid-header skip), command target resolver + `--origin` parser, the option-surface contract, and `cdkl list` / picker enumeration.
- **Integration** `tests/integration/local-start-cloudfront/` (no AWS / no Docker): a real `aws-cdk-lib` static-site fixture (S3 + BucketDeployment + a viewer-request rewrite + a viewer-response header stamp + a 403 SPA fallback). `verify.sh` exercises `/`, `/foo` rewrite, missing-key SPA fallback, a real `--watch` reload, and the SIGTERM port-free teardown. The `local-list` fixture gains a distribution + its group assertion. Both green; 0 Docker / port orphans.

## Reviewer nits accepted as known cost (not blocking)

- `ResolvedBehavior.viewerProtocolPolicy` is resolved + exported but not enforced locally (a cloud `redirect-to-https` behavior is served over plain HTTP unless `--tls`). Documented as informational; kept on the exported model for host use.
- The static origin follows a symlink that lives inside the origin dir (the path-string guard, not a realpath check). BucketDeployment assets contain no symlinks, so the risk is nil for the supported source.
- `tlsRequested` derivation + `--port` bounds are not unit-tested directly (trivial OR + a one-line range check; the cert path reuses the already-tested `front-door-tls`).

Closes #363
