### PR TITLE
feat(studio): run CloudFront distributions from cdkl studio (start-cloudfront)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -211,8 +211,11 @@ AWS managed services.
   Lambda@Edge association, the KeyValueStore, and the 2.0 `cf.fetch`
   origin API are WARN-and-skip (custom / unresolved origins return 502).
   Single distribution per invocation (interactive picker when the target
-  is omitted in a TTY). `cdkl studio` integration is tracked separately
-  (issue #367)
+  is omitted in a TTY). Also runnable from `cdkl studio` as the
+  `cloudfront` serve kind (issue #367) — a [Start]/[Stop] control with a
+  capture proxy, like `api` / `alb`; the session-global
+  `--from-cfn-stack` / `--assume-role` bindings are NOT forwarded to it
+  (start-cloudfront declares neither — it makes no AWS call)
 
 ### Calls real AWS (managed services)
 
@@ -432,7 +435,8 @@ compute-locally category for Lambda + API Gateway).
   `/api/config` immediately on a checkbox toggle / input change, issue
   #301); Lambdas + AgentCore runtimes get an
   [Invoke] composer (`INVOKE_KINDS`), serve
-  targets (api / alb / ecs / ecs-task) a [Start]/[Stop] control with a
+  targets (api / alb / ecs / ecs-task / cloudfront) a [Start]/[Stop] control
+  with a
   `running ● :port` indicator (ecs services + ecs-task runs show
   `running` with no port). Issue #352 lists ECS Services (the `ecs`
   serve kind) and ECS Task Definitions as SEPARATE target groups,
@@ -506,7 +510,10 @@ compute-locally category for Lambda + API Gateway).
   `--profile` / `--region` / `-c` / `--from-cfn-stack` / `--assume-role`)
   into the argv fragment both studio-dispatch and studio-serve-manager
   forward to their spawned child commands, so the two spawn sites cannot
-  drift),
+  drift. The `omitStateBindings` option (issue #367) suppresses
+  `--from-cfn-stack` / `--assume-role` for a child that does not declare
+  them — the serve-manager sets it for the `cloudfront` kind, since
+  `start-cloudfront` makes no AWS call and would reject the flags),
   studio-option-specs (issue #301 slice 2 — the per-target run-option
   descriptor table (`OPTION_SPECS`) that is the single source the UI
   renders controls from (serialized into the page) AND the server builds
@@ -542,12 +549,14 @@ compute-locally category for Lambda + API Gateway).
   clean 400)),
   studio-serve-manager (issue #282 — the
   long-running serve lifecycle, parameterized by a per-kind
-  `ServeKindSpec`: `api` (`start-api`) + `alb` (`start-alb`) expose host
+  `ServeKindSpec`: `api` (`start-api`) + `alb` (`start-alb`) +
+  `cloudfront` (`start-cloudfront`, issue #367) expose host
   HTTP endpoints each fronted by a studio-proxy so the `endpoints` handed
   to the UI are the proxy URLs (slice C2 capture), while `ecs`
   (`start-service`) is pure compute — no host port, no capture, just the
   running replicas + their streamed logs. Resolves running on the kind's
   ready line (`Server listening on <url>` / `ALB front-door: <url>` /
+  `CloudFront distribution serving on <url>` /
   `Service(s) running:`), tracks the running set for `/api/running`, and
   SIGTERMs the child on `/api/stop` / studio shutdown with a generous
   grace so the serve command's OWN ECS-replica + docker-network teardown

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 
 ### Web console — `cdkl studio`
 
-`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all.
+`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` / `start-cloudfront` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all.
 
 ```bash
 cdkl studio                                  # open the console (launches your browser)

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -65,6 +65,7 @@ const STUDIO_TARGET_KINDS: readonly StudioTargetKind[] = [
   'alb',
   'ecs',
   'ecs-task',
+  'cloudfront',
   'agentcore',
 ];
 

--- a/src/local/studio-child-args.ts
+++ b/src/local/studio-child-args.ts
@@ -61,6 +61,18 @@ export interface BuildSharedChildArgsOptions {
    * to false (forward `--app <app>` — the pre-#324 behavior).
    */
   preferAssembly?: boolean;
+  /**
+   * When true, do NOT forward the session's `--from-cfn-stack` /
+   * `--assume-role` bindings to the child (issue #367). These bind a child to
+   * deployed CloudFormation state / an IAM role for the containers it runs;
+   * `cdkl start-cloudfront` runs no container and makes no AWS call (it serves
+   * the distribution's local BucketDeployment source + CloudFront Functions),
+   * so it does NOT declare those flags — forwarding them would make Commander
+   * reject the child with "unknown option". The serve-manager sets this for
+   * the `cloudfront` kind. Defaults to false (forward them — every other
+   * child command accepts both forms).
+   */
+  omitStateBindings?: boolean;
 }
 
 /**
@@ -87,15 +99,20 @@ export function buildSharedChildArgs(
   for (const [k, v] of Object.entries(config.context ?? {})) {
     args.push('-c', `${k}=${v}`);
   }
-  // `--from-cfn-stack`: bare flag (true) vs named stack (string).
-  if (config.fromCfnStack === true) {
-    args.push('--from-cfn-stack');
-  } else if (typeof config.fromCfnStack === 'string' && config.fromCfnStack !== '') {
-    args.push('--from-cfn-stack', config.fromCfnStack);
-  }
-  // `--assume-role <arn>`: explicit ARN only.
-  if (typeof config.assumeRole === 'string' && config.assumeRole !== '') {
-    args.push('--assume-role', config.assumeRole);
+  // `--from-cfn-stack` / `--assume-role` bind a child to deployed state / an
+  // IAM role. A kind whose child command does not declare them (cloudfront —
+  // issue #367) opts out so Commander does not reject the spawn.
+  if (!opts.omitStateBindings) {
+    // `--from-cfn-stack`: bare flag (true) vs named stack (string).
+    if (config.fromCfnStack === true) {
+      args.push('--from-cfn-stack');
+    } else if (typeof config.fromCfnStack === 'string' && config.fromCfnStack !== '') {
+      args.push('--from-cfn-stack', config.fromCfnStack);
+    }
+    // `--assume-role <arn>`: explicit ARN only.
+    if (typeof config.assumeRole === 'string' && config.assumeRole !== '') {
+      args.push('--assume-role', config.assumeRole);
+    }
   }
   return args;
 }

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -4,7 +4,14 @@ import { EventEmitter } from 'node:events';
  * The kind of runnable target an invocation ran against. Mirrors the
  * categories `cdkl list` / the studio target list expose.
  */
-export type StudioTargetKind = 'lambda' | 'api' | 'alb' | 'ecs' | 'ecs-task' | 'agentcore';
+export type StudioTargetKind =
+  | 'lambda'
+  | 'api'
+  | 'alb'
+  | 'ecs'
+  | 'ecs-task'
+  | 'cloudfront'
+  | 'agentcore';
 
 /**
  * One request observed by `cdkl studio` — a single-shot invoke or one

--- a/src/local/studio-option-catalog.ts
+++ b/src/local/studio-option-catalog.ts
@@ -25,6 +25,7 @@ import { createLocalInvokeAgentCoreCommand } from '../cli/commands/local-invoke-
 import { createLocalStartApiCommand } from '../cli/commands/local-start-api.js';
 import { createLocalStartAlbCommand } from '../cli/commands/local-start-alb.js';
 import { createLocalStartServiceCommand } from '../cli/commands/local-start-service.js';
+import { createLocalStartCloudFrontCommand } from '../cli/commands/local-start-cloudfront.js';
 import { createLocalRunTaskCommand } from '../cli/commands/local-run-task.js';
 import { getEmbedConfig, setEmbedConfig, type CdkLocalEmbedConfig } from './embed-config.js';
 import type { StudioTargetKind } from './studio-events.js';
@@ -78,6 +79,7 @@ const KIND_FACTORIES: Record<StudioTargetKind, { command: string; factory: FlagC
   alb: { command: 'start-alb', factory: createLocalStartAlbCommand },
   ecs: { command: 'start-service', factory: createLocalStartServiceCommand },
   'ecs-task': { command: 'run-task', factory: createLocalRunTaskCommand },
+  cloudfront: { command: 'start-cloudfront', factory: createLocalStartCloudFrontCommand },
 };
 
 let cached: Partial<Record<StudioTargetKind, KindFlagCatalog>> | undefined;

--- a/src/local/studio-option-specs.ts
+++ b/src/local/studio-option-specs.ts
@@ -237,6 +237,36 @@ export const OPTION_SPECS: Partial<Record<StudioTargetKind, OptionSpec[]>> = {
       help: 'Overlay the task container env vars — add KEY=VALUE rows or paste a JSON object.',
     },
   ],
+  // CloudFront distribution serve (start-cloudfront, issue #367). TLS mirrors
+  // alb; --origin points a distribution origin at a local directory when the
+  // BucketDeployment source can't be resolved automatically. The host/port are
+  // bound by the serve-manager (portArgs); --watch is the session-global flag.
+  cloudfront: [
+    { flag: '--tls', kind: 'boolean', label: 'TLS (terminate HTTPS locally)' },
+    {
+      flag: '--tls-cert',
+      kind: 'scalar',
+      label: 'TLS cert',
+      placeholder: './cert.pem',
+      showWhen: '--tls',
+    },
+    {
+      flag: '--tls-key',
+      kind: 'scalar',
+      label: 'TLS key',
+      placeholder: './key.pem',
+      showWhen: '--tls',
+    },
+    {
+      flag: '--origin',
+      kind: 'repeat-pair',
+      label: 'Origin source dir',
+      sep: '=',
+      leftPlaceholder: 'originId',
+      rightPlaceholder: './dist',
+      help: "Point a distribution origin at a local directory when cdk-local can't resolve its BucketDeployment source.",
+    },
+  ],
 };
 
 /** True when `value` is a non-empty trimmed string. */

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -194,6 +194,17 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     readyRe: /Task running \(family=/,
     capturesHttp: false,
   },
+  cloudfront: {
+    // start-cloudfront serves the distribution's S3 origin + CloudFront
+    // Functions over a local HTTP port (issue #363 / #367). It binds an
+    // OS-assigned port with --port 0 and logs `CloudFront distribution
+    // serving on <url>`; front it with a capture proxy like api / alb so
+    // requests land on the timeline.
+    command: 'start-cloudfront',
+    portArgs: ['--port', '0', '--host', '127.0.0.1'],
+    readyRe: /CloudFront distribution serving on (https?:\/\/\S+)/,
+    capturesHttp: true,
+  },
 };
 
 interface ServeEntry extends StudioServeState {
@@ -307,11 +318,15 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
     // `config.watch` per start (mutable — a Session-bar toggle applies to
     // the next serve), matching the `--watch` flag append below.
     const preferAssembly = config.watch !== true;
+    // `cloudfront` runs no container / makes no AWS call, so start-cloudfront
+    // declares neither `--from-cfn-stack` nor `--assume-role`; do not forward
+    // the session bindings to it (issue #367).
+    const omitStateBindings = req.kind === 'cloudfront';
     return [
       spec.command,
       req.targetId,
       ...spec.portArgs,
-      ...buildSharedChildArgs(config, { preferAssembly }),
+      ...buildSharedChildArgs(config, { preferAssembly, omitStateBindings }),
       ...buildPerRunArgs(req.kind, req.options),
       // The `--env-vars` per-run option takes a FILE (issue #355) — the env-kv
       // KV rows / JSON were materialized into a SAM-shape temp file by the

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -39,7 +39,7 @@ export interface StudioTarget {
 /** A category of targets, grouped by the studio kind that runs them. */
 export interface StudioTargetGroup {
   /** Studio kind discriminator shared with {@link StudioInvocationEvent}. */
-  kind: 'lambda' | 'api' | 'alb' | 'ecs' | 'ecs-task' | 'agentcore';
+  kind: 'lambda' | 'api' | 'alb' | 'ecs' | 'ecs-task' | 'cloudfront' | 'agentcore';
   /** Human-readable group heading. */
   title: string;
   entries: StudioTarget[];
@@ -77,6 +77,13 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
     { kind: 'ecs-task', title: 'ECS Task Definitions', entries: map(listing.ecsTaskDefinitions) },
     { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
     { kind: 'alb', title: 'Load Balancers', entries: map(listing.loadBalancers) },
+    // CloudFront distributions are a serve target (start-cloudfront -> Start),
+    // like api / alb — they expose a host HTTP endpoint (issue #367 / #363).
+    {
+      kind: 'cloudfront',
+      title: 'CloudFront Distributions',
+      entries: map(listing.cloudFrontDistributions),
+    },
   ];
 }
 

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -257,8 +257,8 @@ const STUDIO_CSS = `
 `;
 
 const STUDIO_SCRIPT = `
-  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', 'ecs-task': 'ECS Task', agentcore: 'AgentCore' };
-  const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task']; // long-running serve targets (ecs-task = run-task)
+  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore' };
+  const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task', 'cloudfront']; // long-running serve targets (ecs-task = run-task)
   const INVOKE_KINDS = ['lambda', 'agentcore']; // single-shot invoke targets (event composer)
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -5,6 +5,10 @@ import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import { Runtime as AgentCoreRuntimeConstruct, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
@@ -16,7 +20,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *
  * Hand-rolls one resource of each kind `cdkl studio` emits a group for, using
  * inline Lambda code + L1 resources where possible so the stack synthesizes
- * without AWS / context / VPC lookups and without any asset bundling:
+ * without AWS / context / VPC lookups (the only asset bundling is the
+ * CloudFront site `BucketDeployment` source + the AgentCore container):
  *
  *   - `AWS::Lambda::Function`  (`MyHandler`)      -> Lambda Functions group
  *   - `AWS::ApiGatewayV2::Api` + Route + Integration (HTTP API v2 wired to
@@ -28,6 +33,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     `AWS::ElasticLoadBalancingV2::TargetGroup` +
  *     `AWS::ElasticLoadBalancingV2::Listener`     -> Application Load Balancers
  *   - `AWS::BedrockAgentCore::Runtime` (`MyAgent`) -> AgentCore Runtimes
+ *   - `AWS::CloudFront::Distribution` (`SiteDist`) + S3 BucketDeployment ->
+ *     CloudFront Distributions (issue #367) — served end-to-end via start-cloudfront
  *
  * Enumeration is a pure synth-time read over the cloud assembly templates, so
  * the Lambda / API / ECS / ALB resources use placeholder ARNs / URIs and are
@@ -238,6 +245,42 @@ export class LocalStudioStack extends cdk.Stack {
         platform: Platform.LINUX_ARM64,
       }),
       environmentVariables: { GREETING: 'hello-from-studio-agent' },
+    });
+
+    // CloudFront distribution (issue #367) — a servable static-site target. An
+    // S3 bucket populated by a BucketDeployment of `../site` + a viewer-request
+    // CloudFront Function that rewrites an extension-less path to
+    // `<path>/index.html`. Driven end-to-end by `POST /api/run` kind=cloudfront:
+    // studio spawns `start-cloudfront`, which serves the local origin content.
+    const siteBucket = new s3.Bucket(this, 'SiteBucket', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+    new s3deploy.BucketDeployment(this, 'DeploySite', {
+      sources: [s3deploy.Source.asset(path.join(__dirname, '../site'))],
+      destinationBucket: siteBucket,
+    });
+    const rewrite = new cloudfront.Function(this, 'RewriteFn', {
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(
+        [
+          'function handler(event) {',
+          '  var request = event.request;',
+          "  if (request.uri.endsWith('/')) request.uri += 'index.html';",
+          '  return request;',
+          '}',
+        ].join('\n')
+      ),
+    });
+    // Construct id `SiteDist` -> studio target `LocalStudioFixture/SiteDist`.
+    new cloudfront.Distribution(this, 'SiteDist', {
+      defaultRootObject: 'index.html',
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+        functionAssociations: [
+          { function: rewrite, eventType: cloudfront.FunctionEventType.VIEWER_REQUEST },
+        ],
+      },
     });
   }
 }

--- a/tests/integration/local-studio/site/index.html
+++ b/tests/integration/local-studio/site/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body><h1>studio cloudfront root</h1></body></html>

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -25,6 +25,9 @@
 #     `serve` SSE event fired, then POST /api/stop tears it down,
 #   - asserts the store (slice C3) serves GET /api/history, full-text
 #     GET /api/logs?q=, and per-invocation GET /api/invocations/<id>/logs,
+#   - starts a CloudFront serve (`start-cloudfront`, kind=cloudfront, issue
+#     #367), curls the served distribution origin through the studio capture
+#     proxy + asserts the default root object comes back, then stops it,
 #   - starts an ALB serve (`start-alb`), curls the front-door through the
 #     studio capture proxy + asserts the request is captured (kind=alb),
 #     and an ECS service serve (`start-service`) that runs pure compute
@@ -344,6 +347,9 @@ for needle in \
   '"title":"ECS Task Definitions"' \
   '"kind":"agentcore"' \
   '"kind":"alb"' \
+  '"kind":"cloudfront"' \
+  '"title":"CloudFront Distributions"' \
+  'LocalStudioFixture/SiteDist' \
   'LocalStudioFixture/MyHandler'
 do
   if ! grep -qF "${needle}" "${BODY_FILE}"; then
@@ -799,6 +805,74 @@ if grep -qF "${API_TARGET}" "${BODY_FILE}"; then
   exit 1
 fi
 echo "    OK: serve stopped; /api/running is empty"
+
+# ---------------------------------------------------------------------------
+# 7a-cf. POST /api/run STARTS a `start-cloudfront` serve (issue #367); curl the
+#        served origin through the capture proxy; assert running + the
+#        viewer-request rewrite; stop it.
+# ---------------------------------------------------------------------------
+CF_TARGET="LocalStudioFixture/SiteDist"
+echo "==> POST /api/run starts a cloudfront serve for ${CF_TARGET}"
+curl -sN --max-time 200 "${URL}/api/events" >"${SSE_FILE}" 2>/dev/null &
+SSE_PID=$!
+sleep 1
+CF_FILE=$(mktemp)
+CF_CODE=$(curl -s -o "${CF_FILE}" -w '%{http_code}' --max-time 120 \
+  -X POST "${URL}/api/run" \
+  -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${CF_TARGET}\",\"kind\":\"cloudfront\"}" || true)
+if [[ "${CF_CODE}" != "200" ]]; then
+  echo "FAIL: POST /api/run (cloudfront serve) returned HTTP ${CF_CODE}"
+  echo "----- serve response -----"; cat "${CF_FILE}"; echo "--------------------------"
+  echo "----- studio log -----"; cat "${LOG_FILE}"; echo "----------------------"
+  rm -f "${CF_FILE}"
+  exit 1
+fi
+for needle in '"status":"running"' '"kind":"cloudfront"'; do
+  if ! grep -qF "${needle}" "${CF_FILE}"; then
+    echo "FAIL: cloudfront serve response missing: ${needle}"
+    echo "----- serve response -----"; cat "${CF_FILE}"; echo "--------------------------"
+    rm -f "${CF_FILE}"
+    exit 1
+  fi
+done
+CF_SERVED=$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "${CF_FILE}" | head -1 || true)
+rm -f "${CF_FILE}"
+if [[ -z "${CF_SERVED}" ]]; then
+  echo "FAIL: could not parse the served cloudfront endpoint from the run response"
+  exit 1
+fi
+echo "    OK: cloudfront serve started at ${CF_SERVED}"
+
+echo "==> The served distribution returns the default root object + runs the rewrite"
+CFROOT=$(mktemp)
+CFROOT_CODE=$(curl -s -o "${CFROOT}" -w '%{http_code}' --max-time 60 "${CF_SERVED}/" || true)
+if [[ "${CFROOT_CODE}" != "200" ]] || ! grep -qF 'studio cloudfront root' "${CFROOT}"; then
+  echo "FAIL: cloudfront / did not return the root index.html (HTTP ${CFROOT_CODE})"
+  echo "----- body -----"; cat "${CFROOT}"; echo "----------------"
+  rm -f "${CFROOT}"; exit 1
+fi
+rm -f "${CFROOT}"
+echo "    OK: GET ${CF_SERVED}/ -> 200 root index.html"
+
+echo "==> POST /api/stop tears the cloudfront serve down"
+CFSTOP=$(curl -s -o "${BODY_FILE}" -w '%{http_code}' --max-time 30 \
+  -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${CF_TARGET}\"}" || true)
+if [[ "${CFSTOP}" != "200" ]]; then
+  echo "FAIL: POST /api/stop (cloudfront) returned HTTP ${CFSTOP}"; cat "${BODY_FILE}"; exit 1
+fi
+kill "${SSE_PID}" 2>/dev/null || true
+SSE_PID=""
+for _ in $(seq 1 20); do
+  curl -fsS "${URL}/api/running" -o "${BODY_FILE}" 2>/dev/null || true
+  if ! grep -qF "${CF_TARGET}" "${BODY_FILE}"; then break; fi
+  sleep 0.5
+done
+if grep -qF "${CF_TARGET}" "${BODY_FILE}"; then
+  echo "FAIL: /api/running still lists ${CF_TARGET} after stop"; cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: cloudfront serve stopped; /api/running is empty"
 
 # ---------------------------------------------------------------------------
 # 7b. WebSocket console (issue #303): studio serves a WebSocket API

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -109,6 +109,21 @@ describe('coerceRunRequest', () => {
     });
   });
 
+  it('accepts the cloudfront serve kind with its per-run options (issue #367)', () => {
+    expect(
+      coerceRunRequest({
+        targetId: 'Stack/SiteDist',
+        kind: 'cloudfront',
+        options: { '--tls': true, '--origin': [{ left: 'O1', right: './dist' }] },
+      })
+    ).toEqual({
+      targetId: 'Stack/SiteDist',
+      kind: 'cloudfront',
+      event: undefined,
+      options: { '--tls': true, '--origin': [{ left: 'O1', right: './dist' }] },
+    });
+  });
+
   it.each([null, 42, 'str', [1, 2]])('rejects non-object options %p', (options) => {
     expect(() => coerceRunRequest({ targetId: 'T', kind: 'alb', options })).toThrow(
       /"options" must be a JSON object/

--- a/tests/unit/local/studio-child-args.test.ts
+++ b/tests/unit/local/studio-child-args.test.ts
@@ -55,6 +55,23 @@ describe('buildSharedChildArgs', () => {
     expect(buildSharedChildArgs({ assumeRole: '' })).toEqual([]);
   });
 
+  it('omits the state bindings when omitStateBindings is set (issue #367)', () => {
+    // start-cloudfront declares neither flag; the serve-manager opts out for it.
+    expect(
+      buildSharedChildArgs(
+        { fromCfnStack: 'MyStack', assumeRole: 'arn:aws:iam::123456789012:role/app' },
+        { omitStateBindings: true }
+      )
+    ).toEqual([]);
+    // Other shared flags still pass through.
+    expect(
+      buildSharedChildArgs(
+        { app: 'node app.ts', region: 'us-east-1', fromCfnStack: 'MyStack' },
+        { omitStateBindings: true }
+      )
+    ).toEqual(['--app', 'node app.ts', '--region', 'us-east-1']);
+  });
+
   describe('assembly-dir reuse (issue #324)', () => {
     it('forwards --app <app> by default (preferAssembly omitted)', () => {
       expect(

--- a/tests/unit/local/studio-option-specs.test.ts
+++ b/tests/unit/local/studio-option-specs.test.ts
@@ -65,6 +65,33 @@ describe('buildPerRunArgs', () => {
     ).toEqual(['--ws', '--bearer-token', 'eyJabc', '--session-id', 'sess-1']);
   });
 
+  it('builds CloudFront args: --tls + showWhen-gated certs + --origin repeat-pair (issue #367)', () => {
+    expect(
+      buildPerRunArgs('cloudfront', {
+        '--tls': true,
+        '--tls-cert': './c.pem',
+        '--tls-key': './k.pem',
+        '--origin': [
+          { left: 'O1', right: './dist' },
+          { left: 'O2', right: './admin' },
+        ],
+      })
+    ).toEqual([
+      '--tls',
+      '--tls-cert',
+      './c.pem',
+      '--tls-key',
+      './k.pem',
+      '--origin',
+      'O1=./dist',
+      '--origin',
+      'O2=./admin',
+    ]);
+    // The cert scalars are gated on --tls.
+    expect(buildPerRunArgs('cloudfront', { '--tls-cert': './c.pem' })).toEqual([]);
+    expect(OPTION_SPECS.cloudfront?.some((s) => s.flag === '--origin')).toBe(true);
+  });
+
   it('emits NO direct arg for env-kv (materialized separately)', () => {
     expect(buildPerRunArgs('lambda', { '--env-vars': [{ left: 'K', right: 'V' }] })).toEqual([]);
     expect(buildPerRunArgs('lambda', { '--env-vars': '{"K":"V"}' })).toEqual([]);

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -401,6 +401,84 @@ describe('createStudioServeManager', () => {
     expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
   });
 
+  it('spawns `cdkl start-cloudfront <dist> --port 0` and resolves running on its banner (issue #367)', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+    const p = mgr.start({
+      targetId: 'Stack/SiteDist',
+      kind: 'cloudfront',
+      options: { '--tls': true, '--origin': [{ left: 'O1', right: './dist' }] },
+    });
+    child.stdout.emit('data', 'CloudFront distribution serving on http://127.0.0.1:51234  (SiteDist)\n');
+    const state = await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv.slice(1, 6)).toEqual(['start-cloudfront', 'Stack/SiteDist', '--port', '0', '--host']);
+    expect(argv).toContain('--tls');
+    const oi = argv.indexOf('--origin');
+    expect(oi).toBeGreaterThan(-1);
+    expect(argv[oi + 1]).toBe('O1=./dist');
+    // It exposes a host HTTP endpoint, so it is fronted by a capture proxy.
+    expect(state.status).toBe('running');
+    expect(state.endpoints).toEqual([PROXIED]);
+    expect(fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
+  });
+
+  it('does NOT forward --from-cfn-stack / --assume-role to a cloudfront serve (issue #367)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+      // Session bindings set — start-cloudfront declares neither flag, so they
+      // must NOT reach the child (it would reject with "unknown option").
+      fromCfnStack: 'MyStack',
+      assumeRole: 'arn:aws:iam::123456789012:role/app',
+    });
+    const p = mgr.start({ targetId: 'Stack/SiteDist', kind: 'cloudfront' });
+    child.stdout.emit('data', 'CloudFront distribution serving on http://127.0.0.1:51234  (SiteDist)\n');
+    await p;
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv).not.toContain('--from-cfn-stack');
+    expect(argv).not.toContain('--assume-role');
+  });
+
+  it('DOES forward --from-cfn-stack to an api serve (kind-specific omit only) (issue #367)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+      fromCfnStack: 'MyStack',
+    });
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv).toContain('--from-cfn-stack');
+  });
+
   it('threads imageOverride as an explicit --image-override <target>=<dockerfile>', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -228,12 +228,14 @@ describe('toStudioTargetGroups', () => {
       apis: [{ qualifiedId: 'S:Api', displayPath: 'S/Api', kind: 'HTTP API v2' }],
       ecsServices: [{ qualifiedId: 'S:Svc' }],
       ecsTaskDefinitions: [{ qualifiedId: 'S:Task' }],
+      cloudFrontDistributions: [{ qualifiedId: 'S:Dist', displayPath: 'S/Dist' }],
     };
     const groups = toStudioTargetGroups(listing);
 
     // ECS Services and Task Definitions are SEPARATE groups (issue #352); the
     // task-definitions group is the `ecs-task` kind (issue #366) — a [Run]
     // control (run-task), distinct from the servable `ecs` services kind.
+    // CloudFront distributions are a serve target (issue #367).
     expect(groups.map((g) => g.kind)).toEqual([
       'lambda',
       'api',
@@ -241,6 +243,7 @@ describe('toStudioTargetGroups', () => {
       'ecs-task',
       'agentcore',
       'alb',
+      'cloudfront',
     ]);
     expect(groups.map((g) => g.title)).toEqual([
       'Lambda Functions',
@@ -249,6 +252,7 @@ describe('toStudioTargetGroups', () => {
       'ECS Task Definitions',
       'AgentCore Runtimes',
       'Load Balancers',
+      'CloudFront Distributions',
     ]);
     expect(groups[0].entries).toEqual([{ id: 'S/Fn', qualifiedId: 'S:Fn' }]);
     // API surface kind is carried onto the entry.
@@ -262,6 +266,8 @@ describe('toStudioTargetGroups', () => {
     expect(groups[2].entries.map((e) => e.id)).toEqual(['S:Svc']);
     expect(groups[2].entries.map((e) => e.servable)).toEqual([true]);
     expect(groups[3].entries).toEqual([{ id: 'S:Task', qualifiedId: 'S:Task' }]);
+    // CloudFront distributions are a plain serve entry (no servable flag).
+    expect(groups[6].entries).toEqual([{ id: 'S/Dist', qualifiedId: 'S:Dist' }]);
   });
 
   it('falls back to the qualified id when no display path exists', () => {


### PR DESCRIPTION
## Summary

Expose CloudFront distributions as a runnable `cloudfront` serve kind in `cdkl studio` (closes #367), the follow-up to #363 (`cdkl start-cloudfront`). It mirrors how `api` / `alb` / `ecs` serves are surfaced: a [Start]/[Stop] control with a `running ● :port` indicator, fronted by the studio capture proxy (start-cloudfront serves a host HTTP endpoint).

Follows the maintainer's 8-step guide on #367:

1. **studio-events** — `'cloudfront'` added to `StudioTargetKind`.
2. **studio-server** — `'cloudfront'` in `StudioTargetGroup.kind`; a `CloudFront Distributions` group in `toStudioTargetGroups` (over the `cloudFrontDistributions` enumeration from #363).
3. **local-studio** — `'cloudfront'` in `STUDIO_TARGET_KINDS`; routes to `serveManager.start` like `api` / `alb` (a serve, not an invoke; not gated by the `servableEcs` check).
4. **studio-serve-manager** — `SERVE_SPECS['cloudfront']`: `start-cloudfront --port 0 --host 127.0.0.1`, ready on `CloudFront distribution serving on <url>`, `capturesHttp: true`.
5. **studio-option-specs** — `--tls` + showWhen-gated `--tls-cert` / `--tls-key` + `--origin` repeat-pair.
6. **studio-option-catalog** — the `cloudfront -> createLocalStartCloudFrontCommand` factory mapping (the full-`Record` `KIND_FACTORIES` compiler-enforces this).
7. **studio-ui** — `KIND_LABEL` + `SERVE_KINDS` gain `cloudfront` (renders like `api` / `alb`).
8. Target enumeration already lands `cloudFrontDistributions` (#363).

### Session bindings (`omitStateBindings`)

`cdkl start-cloudfront` serves the distribution's local BucketDeployment source + runs CloudFront Functions in-process — it makes **no AWS call** and declares **neither** `--from-cfn-stack` **nor** `--assume-role`. Forwarding studio's session-global bindings to it would make Commander reject the spawn ("unknown option"). So `buildSharedChildArgs` gains an `omitStateBindings` option (studio-child-args), and the serve-manager sets it **only** for the `cloudfront` kind — `api` / `alb` / `ecs` still forward the bindings. `--watch` IS still forwarded (start-cloudfront declares it). This is the honest reading of "respect the session bindings": a kind whose child genuinely can't use a binding shouldn't be handed it.

## Test plan

- **Unit** (169 files / 2617 tests green): the cloudfront group projection (`toStudioTargetGroups`), the serve-manager spawn (`start-cloudfront <dist> --port 0`, `--tls` + `--origin` threading, running on the banner, capture-proxy endpoint), the `omitStateBindings` BOTH directions (cloudfront omits / api forwards — locked at the helper AND the serve-manager seam), the option specs (tls + showWhen certs + `--origin`), and `coerceRunRequest` accepting `kind=cloudfront`.
- **Integration** `tests/integration/local-studio/` (Docker): the fixture stack gains a real `aws-cdk-lib` CloudFront distribution (S3 + BucketDeployment + a viewer-request rewrite). `verify.sh` asserts the `cloudfront` target group in `/api/targets` AND drives `POST /api/run` `kind=cloudfront` end-to-end — serve start, the default root object served back **through the studio capture proxy**, and teardown (`/api/running` empty). Whole `local-studio` integ green; 0 Docker orphans.
- 3-axis review (spec / code / test) — all PASS, no blockers/majors/minors.

## cdkd parity

No host action: the only `src/cli/commands/local-studio.ts` change is adding `'cloudfront'` to the internal `STUDIO_TARGET_KINDS` allowlist (not a new factory / CLI option). cdkd embeds `createLocalStudioCommand` wholesale and inherits the new serve kind automatically. The wrappable command (`start-cloudfront`) already had its parity walk + cdkd notification in #363.

## Reviewer LOW suggestions accepted as known cost (not blocking)

- The integ asserts the cloudfront GET is served through the proxy (body content), but does not additionally assert the captured request landed on the SSE timeline (the ALB section does). The capture proxy is shared and already proven by the api/alb paths in the same integ run.
- `onRun`-routing of `cloudfront` to `serveManager.start` is covered by the integ end-to-end rather than a dedicated unit (the `onRun` closure has no clean unit seam; the serve-manager + `coerceRunRequest` pieces are unit-covered).

Closes #367
