### PR TITLE
test(studio): SSE-capture + onRun-routing coverage for the cloudfront serve kind

### DIFF
--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -30,7 +30,11 @@ import {
   type RunningStudioServer,
 } from '../../local/studio-server.js';
 import { filterStudioCustomResources } from '../../local/studio-custom-resource-filter.js';
-import { createStudioDispatcher, type StudioRunRequest } from '../../local/studio-dispatch.js';
+import {
+  createStudioDispatcher,
+  type StudioDispatcher,
+  type StudioRunRequest,
+} from '../../local/studio-dispatch.js';
 import { reinvoke } from '../../local/studio-reinvoke.js';
 import {
   buildPerRunArgs,
@@ -142,6 +146,38 @@ export function coerceStopRequest(body: unknown): StudioStopRequest {
     throw new Error('Request body must include a non-empty "targetId" string.');
   }
   return { targetId };
+}
+
+/** Dependencies {@link routeStudioRun} dispatches a `POST /api/run` against. */
+export interface StudioRunRouterDeps {
+  /** The single-shot invoke dispatcher (lambda / agentcore). */
+  dispatcher: Pick<StudioDispatcher, 'run'>;
+  /** The long-running serve lifecycle (api / alb / ecs / ecs-task / cloudfront). */
+  serveManager: Pick<StudioServeManager, 'start'>;
+  /** Target ids of the servable ECS *services* (task defs are not servable as `ecs`). */
+  servableEcs: ReadonlySet<string>;
+}
+
+/**
+ * Route a validated `POST /api/run` request to the right runner: the
+ * single-shot dispatcher for the invoke kinds (`lambda` / `agentcore`), or the
+ * serve manager for every serve kind (`api` / `alb` / `ecs` / `ecs-task` /
+ * `cloudfront`). An `ecs` target that is NOT a servable service (a raw curl
+ * could POST a task-def id with `kind: 'ecs'`) is rejected at the boundary with
+ * a clear message rather than spawning a doomed `start-service`. Extracted from
+ * the `onRun` closure so the kind→runner routing is unit-testable without
+ * booting the studio server.
+ */
+export function routeStudioRun(req: StudioRunRequest, deps: StudioRunRouterDeps): Promise<unknown> {
+  if (req.kind === 'lambda' || req.kind === 'agentcore') return deps.dispatcher.run(req);
+  if (req.kind === 'ecs' && !deps.servableEcs.has(req.targetId)) {
+    return Promise.reject(
+      new Error(
+        `'${req.targetId}' is not a servable ECS service (an ECS task definition runs via run-task, not start-service).`
+      )
+    );
+  }
+  return deps.serveManager.start(req);
 }
 
 /** A composed HTTP request to a running serve, as the studio UI posts it. */
@@ -751,20 +787,10 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     cliName: getEmbedConfig().cliName,
     store,
     // `/api/run`: a Lambda or an AgentCore runtime is a single-shot invoke;
-    // api / alb / ecs are long-running serve starts (the serve manager rejects
-    // any other kind).
-    onRun: (body) => {
-      const req = coerceRunRequest(body);
-      if (req.kind === 'lambda' || req.kind === 'agentcore') return dispatcher.run(req);
-      if (req.kind === 'ecs' && !servableEcs.has(req.targetId)) {
-        return Promise.reject(
-          new Error(
-            `'${req.targetId}' is not a servable ECS service (an ECS task definition runs via run-task, not start-service).`
-          )
-        );
-      }
-      return serveManager.start(req);
-    },
+    // api / alb / ecs / ecs-task / cloudfront are long-running serve starts.
+    // The kind→runner routing lives in `routeStudioRun` (unit-tested).
+    onRun: (body) =>
+      routeStudioRun(coerceRunRequest(body), { dispatcher, serveManager, servableEcs }),
     onStop: async (body) => {
       const req = coerceStopRequest(body);
       await serveManager.stop(req);

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -27,7 +27,8 @@
 #     GET /api/logs?q=, and per-invocation GET /api/invocations/<id>/logs,
 #   - starts a CloudFront serve (`start-cloudfront`, kind=cloudfront, issue
 #     #367), curls the served distribution origin through the studio capture
-#     proxy + asserts the default root object comes back, then stops it,
+#     proxy + asserts the default root object comes back AND that the request
+#     was captured on the timeline (issue #372), then stops it,
 #   - starts an ALB serve (`start-alb`), curls the front-door through the
 #     studio capture proxy + asserts the request is captured (kind=alb),
 #     and an ECS service serve (`start-service`) that runs pure compute
@@ -854,6 +855,24 @@ if [[ "${CFROOT_CODE}" != "200" ]] || ! grep -qF 'studio cloudfront root' "${CFR
 fi
 rm -f "${CFROOT}"
 echo "    OK: GET ${CF_SERVED}/ -> 200 root index.html"
+
+# The cloudfront serve is fronted by the studio capture proxy (capturesHttp),
+# so the GET / we just made must surface on the timeline as an `invocation`
+# row with the GET / label + the 200 status — proving the capture-proxy
+# plumbing works for the cloudfront kind, not just for api / alb (#372).
+echo "==> The cloudfront request was captured on the timeline (SSE)"
+for _ in $(seq 1 20); do
+  if grep -qF 'event: invocation' "${SSE_FILE}" && grep -qF '"label":"GET /"' "${SSE_FILE}"; then
+    break
+  fi
+  sleep 0.5
+done
+if ! grep -qF '"label":"GET /"' "${SSE_FILE}" || ! grep -qF '"status":200' "${SSE_FILE}"; then
+  echo "FAIL: SSE stream did not carry the captured cloudfront GET / (status 200)"
+  echo "----- sse capture -----"; cat "${SSE_FILE}"; echo "-----------------------"
+  exit 1
+fi
+echo "    OK: GET / captured on the timeline with status 200"
 
 echo "==> POST /api/stop tears the cloudfront serve down"
 CFSTOP=$(curl -s -o "${BODY_FILE}" -w '%{http_code}' --max-time 30 \

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -13,8 +13,10 @@ import {
   installStudioResilienceGuard,
   parseStudioPort,
   resolveBootAssemblyDir,
+  routeStudioRun,
   type EditableSessionBindings,
 } from '../../../src/cli/commands/local-studio.js';
+import type { StudioRunRequest } from '../../../src/local/studio-dispatch.js';
 import type { StudioServeState } from '../../../src/local/studio-serve-manager.js';
 
 describe('createLocalStudioCommand', () => {
@@ -459,5 +461,57 @@ describe('resolveServeBaseUrl (issue #322)', () => {
   it('returns undefined when there is no reachable http endpoint', () => {
     expect(resolveServeBaseUrl(state({ endpoints: ['ws://x'] }))).toBeUndefined();
     expect(resolveServeBaseUrl(state({}))).toBeUndefined();
+  });
+});
+
+describe('routeStudioRun (issue #372 — POST /api/run kind -> runner)', () => {
+  const req = (kind: StudioRunRequest['kind'], targetId = 'T'): StudioRunRequest =>
+    ({ targetId, kind }) as StudioRunRequest;
+
+  const deps = () => {
+    const run = vi.fn(async () => 'invoked');
+    const start = vi.fn(async () => 'served');
+    return {
+      run,
+      start,
+      build: (servable: string[] = []) => ({
+        dispatcher: { run },
+        serveManager: { start },
+        servableEcs: new Set(servable),
+      }),
+    };
+  };
+
+  it('routes the invoke kinds to the dispatcher', async () => {
+    for (const kind of ['lambda', 'agentcore'] as const) {
+      const d = deps();
+      await routeStudioRun(req(kind), d.build());
+      expect(d.run).toHaveBeenCalledOnce();
+      expect(d.start).not.toHaveBeenCalled();
+    }
+  });
+
+  it('routes the serve kinds (incl. cloudfront) to the serve manager', async () => {
+    for (const kind of ['api', 'alb', 'ecs-task', 'cloudfront'] as const) {
+      const d = deps();
+      await routeStudioRun(req(kind), d.build());
+      expect(d.start).toHaveBeenCalledOnce();
+      expect(d.run).not.toHaveBeenCalled();
+    }
+  });
+
+  it('routes a servable ecs service to the serve manager', async () => {
+    const d = deps();
+    await routeStudioRun(req('ecs', 'Stack/Svc'), d.build(['Stack/Svc']));
+    expect(d.start).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an ecs target that is not a servable service (a task def) without spawning', async () => {
+    const d = deps();
+    await expect(routeStudioRun(req('ecs', 'Stack/TaskDef'), d.build([]))).rejects.toThrow(
+      /not a servable ECS service/
+    );
+    expect(d.start).not.toHaveBeenCalled();
+    expect(d.run).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes the two LOW test-coverage follow-ups from the PR #371 review (issue #372). No behaviour change — test hardening + a behaviour-identical refactor.

1. **Integ SSE-capture assertion.** The `local-studio` cloudfront serve section now asserts the captured `GET /` lands on the SSE timeline (an `invocation` row with the `GET /` label + a `200` status), mirroring the ALB section. This pins the studio capture-proxy plumbing for the `cloudfront` kind directly, instead of inferring it from the shared code path the api/alb kinds exercise.

2. **`onRun` routing unit.** The `POST /api/run` kind→runner routing was a closure inside `localStudioCommand`, so it was only covered end-to-end by the integ. Extracted it into a pure, exported `routeStudioRun(req, { dispatcher, serveManager, servableEcs })` and unit-tested it directly:
   - invoke kinds (`lambda` / `agentcore`) → `dispatcher.run`
   - serve kinds (`api` / `alb` / `ecs-task` / `cloudfront`) → `serveManager.start`
   - a servable `ecs` service → `serveManager.start`
   - a non-servable `ecs` target (a task-def id POSTed with `kind: 'ecs'`) → rejected at the boundary, without spawning

   `onRun` now just calls the helper; the logic + error message are byte-identical.

## Test plan

- Unit (169 files / 2621 tests green): the new `routeStudioRun` describe block (all kinds + the non-servable-ecs rejection).
- Integration: the whole `local-studio` integ re-run green (Docker), including the new cloudfront SSE-capture assertion (`GET / captured on the timeline with status 200`); 0 Docker orphans.
- Inline code review: the refactor is behaviour-identical (same routing + same error string), confirmed end-to-end by the integ.

Closes #372
