### PR TITLE
fix(studio): surface a serve crash instead of silently reverting to a blank composer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -451,7 +451,14 @@ compute-locally category for Lambda + API Gateway).
   read-only "Started with" summary (issue #356 — `formatAppliedOptions`
   over the `serveApplied` map recorded at Start) surfaces the launch
   config the serve is running with (e.g. a chosen `--max-tasks` stays
-  visible instead of silently vanishing). A served
+  visible instead of silently vanishing). A serve that FAILS — a boot
+  failure (serve-manager emits status `error` with a message) or a crash
+  AFTER it was running (status `stopped` WITH a message, vs a clean user
+  stop which is `stopped` with NO message) — keeps that "Started with"
+  summary, surfaces the failure reason (`StudioServeEvent.message`,
+  threaded through `onServeEvent` -> `serveState` -> the workspace error
+  banner), and offers a `Reconfigure` button, instead of silently
+  reverting to a blank composer that reads as "my inputs vanished". A served
   API Gateway WebSocket API additionally gets a WebSocket console
   (`renderWsConsole` — connect / send-frame / received-frame log) wired
   straight to its ws:// endpoint, with the socket + frame log held in module

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -801,6 +801,15 @@ const STUDIO_SCRIPT = `
     const st = serveState.get(id) || { status: 'stopped', endpoints: [] };
     const running = st.status === 'running';
     const starting = st.status === 'starting';
+    // A serve that exited with a failure reason is FAILED, distinct from a
+    // clean user stop. A boot failure arrives as status 'error'; a crash AFTER
+    // the serve was running arrives as status 'stopped' WITH a message (a clean
+    // user stop is 'stopped' with NO message). A failed serve keeps its
+    // "Started with" context + surfaces the reason + offers a Reconfigure
+    // button instead of silently dropping to a blank composer (which reads as
+    // "my inputs vanished" when the serve actually crashed).
+    const failed = st.status === 'error' || (st.status === 'stopped' && !!st.message);
+    const effErr = errMsg || (failed ? st.message : undefined);
     // A NON-running render (serve stopped / starting) tears down any open
     // WebSocket-console socket: its endpoint is gone, and leaving it open would
     // show "● connected" against a dead serve if the same target is restarted.
@@ -819,20 +828,32 @@ const STUDIO_SCRIPT = `
     head.appendChild(el('div', 'target-name', (isTaskRun ? 'Run ' : 'Serve ') + id));
     const btn = running || starting
       ? el('button', null, 'Stop')
-      : el('button', null, starting ? 'Starting…' : startLabel);
+      : el('button', null, failed ? 'Reconfigure' : startLabel);
     // Per-run options are only set before a start; collected on the Start click.
     let collectOpts = function () { return undefined; };
     let collectRaw = function () { return undefined; };
     let collectImageOverride = function () { return undefined; };
-    btn.onclick = () => { if (running || starting) stopServe(id); else startServe(id, collectOpts(), collectRaw(), collectImageOverride()); };
+    btn.onclick = () => {
+      if (running || starting) {
+        stopServe(id);
+      } else if (failed) {
+        // Clear the failed state so the composer comes back (the user adjusts
+        // options + restarts) — NOT a blind default restart that would drop
+        // the env-vars / other options the crashed serve was started with.
+        serveState.set(id, { status: 'stopped', endpoints: [] });
+        renderServeWorkspace(id);
+      } else {
+        startServe(id, collectOpts(), collectRaw(), collectImageOverride());
+      }
+    };
     head.appendChild(btn);
-    if (errMsg) {
-      const m = el('div', 'err', errMsg);
+    if (effErr) {
+      const m = el('div', 'err', effErr);
       head.appendChild(m);
     }
     ws.appendChild(head);
 
-    if (!running && !starting) {
+    if (!running && !starting && !failed) {
       // A pinned ECS service (deployed-registry image) does not pick up local
       // source edits — offer an image-override Dockerfile picker so it can be
       // rebuilt locally (issue #301). Local-asset services hot-reload under
@@ -848,11 +869,12 @@ const STUDIO_SCRIPT = `
       collectRaw = opt.collectRaw;
     }
 
-    if (running || starting) {
+    if (running || starting || failed) {
       // Issue #356: the per-run option inputs are gone once the composer is
       // replaced by this running view, so surface what the serve was Started
       // with as a read-only summary (so e.g. a chosen --max-tasks stays
-      // visible instead of silently vanishing after Start).
+      // visible instead of silently vanishing after Start). A FAILED serve
+      // keeps this too, so a crash does not read as "my inputs disappeared".
       const lines = formatAppliedOptions(serveApplied.get(id));
       const startedSec = el('div', 'section started-with');
       startedSec.appendChild(el('h3', null, 'Started with'));
@@ -1727,9 +1749,14 @@ const STUDIO_SCRIPT = `
 
   function onServeEvent(ev) {
     // A 'stopped' / 'error' transition clears the running state; otherwise
-    // record the latest status + endpoints for the row + workspace.
+    // record the latest status + endpoints for the row + workspace. Keep the
+    // failure reason (ev.message) so the workspace can surface a crash instead
+    // of silently reverting to a blank composer: a boot failure arrives as
+    // 'error' with a message, a crash AFTER the serve was running arrives as
+    // 'stopped' WITH a message, and a clean user stop is 'stopped' with NO
+    // message (renderServeWorkspace uses message presence to tell them apart).
     if (ev.status === 'stopped' || ev.status === 'error') {
-      serveState.set(ev.target, { status: ev.status, endpoints: [] });
+      serveState.set(ev.target, { status: ev.status, endpoints: [], message: ev.message });
     } else {
       serveState.set(ev.target, { status: ev.status, endpoints: ev.endpoints || [], hostUrl: ev.hostUrl });
     }

--- a/tests/unit/local/studio-ui-serve-failure.test.ts
+++ b/tests/unit/local/studio-ui-serve-failure.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the serve-workspace internals the failure-rendering tests drive.
+const EXPOSE = `
+window.__t = {
+  onServeEvent: onServeEvent,
+  serveMeta: serveMeta,
+  serveState: serveState,
+  serveApplied: serveApplied,
+  renderServeWorkspace: renderServeWorkspace,
+};
+window.__setShown = function (id) { shownServeId = id; };
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+// Boot a shown alb serve in the RUNNING state with a recorded "Started with".
+function setupRunning(h: Harness, applied?: unknown) {
+  const t = h.window.__t;
+  const dot = h.document.createElement('span');
+  const btnSlot = h.document.createElement('span');
+  t.serveMeta.set('Stk/Alb', { kind: 'alb', dot, btnSlot });
+  if (applied) t.serveApplied.set('Stk/Alb', applied);
+  t.serveState.set('Stk/Alb', { status: 'running', endpoints: ['http://127.0.0.1:8080'] });
+  h.window.__setShown('Stk/Alb');
+  t.renderServeWorkspace('Stk/Alb');
+  return t;
+}
+
+const q = (h: Harness, sel: string) => h.document.querySelector(sel);
+const flagTexts = (h: Harness) =>
+  Array.from(h.document.querySelectorAll('.started-flag')).map((n: any) => n.textContent);
+const headBtn = (h: Harness) => h.document.querySelector('#workspace .composer button');
+
+describe('serve workspace: failure vs clean-stop rendering', () => {
+  it('a post-start crash (stopped WITH a message) surfaces the reason + keeps "Started with", no composer', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const t = setupRunning(h, { options: { '--env-vars': [{ left: 'API_KEY', right: 'secret' }] } });
+      // running -> Started with shows the env-vars
+      expect(flagTexts(h)).toContain('--env-vars API_KEY=secret');
+
+      // The serve child crashes after it was running: 'stopped' WITH a message.
+      t.onServeEvent({ target: 'Stk/Alb', status: 'stopped', message: 'Server process exited (code 1).' });
+
+      // The crash reason is now visible (was silently swallowed before the fix).
+      expect((q(h, '#workspace .err') as any)?.textContent).toBe('Server process exited (code 1).');
+      // "Started with" is preserved (does not read as "my inputs vanished").
+      expect(flagTexts(h)).toContain('--env-vars API_KEY=secret');
+      // The blank composer is NOT shown; the button offers Reconfigure.
+      expect(q(h, '#workspace .options-wrap')).toBeNull();
+      expect((headBtn(h) as any).textContent).toBe('Reconfigure');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('a clean user stop (stopped with NO message) returns to the composer with no error banner', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const t = setupRunning(h, { options: { '--env-vars': [{ left: 'API_KEY', right: 'secret' }] } });
+
+      // A user Stop emits 'stopped' with NO message.
+      t.onServeEvent({ target: 'Stk/Alb', status: 'stopped' });
+
+      expect(q(h, '#workspace .err')).toBeNull();
+      expect(q(h, '#workspace .started-with')).toBeNull();
+      expect(q(h, '#workspace .options-wrap')).not.toBeNull();
+      expect((headBtn(h) as any).textContent).toBe('Start');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('a boot failure (error status WITH a message) surfaces the reason like a crash', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const t = setupRunning(h, { options: {} });
+
+      t.onServeEvent({
+        target: 'Stk/Alb',
+        status: 'error',
+        message: 'Server exited before listening (code 1).',
+      });
+
+      expect((q(h, '#workspace .err') as any)?.textContent).toBe('Server exited before listening (code 1).');
+      expect(q(h, '#workspace .options-wrap')).toBeNull();
+      expect((headBtn(h) as any).textContent).toBe('Reconfigure');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('Reconfigure clears the failed state and brings the composer back', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const t = setupRunning(h, { options: { '--env-vars': [{ left: 'API_KEY', right: 'secret' }] } });
+      t.onServeEvent({ target: 'Stk/Alb', status: 'stopped', message: 'Server process exited (code 1).' });
+
+      // Click Reconfigure.
+      (headBtn(h) as any).click();
+
+      expect(q(h, '#workspace .err')).toBeNull();
+      expect(q(h, '#workspace .started-with')).toBeNull();
+      expect(q(h, '#workspace .options-wrap')).not.toBeNull();
+      expect((headBtn(h) as any).textContent).toBe('Start');
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

In `cdkl studio`, a serve that **failed after start** was indistinguishable
from a clean stop in the UI: the workspace silently reverted to a fresh,
empty composer. To the user this reads as "my env-vars / options
disappeared" and "the Started with summary vanished" — when the serve
actually crashed.

The serve-manager already classifies the lifecycle correctly:

- a boot failure emits a `serve` event with status `error` + a message
  (`Server exited before listening (code N).`)
- a crash **after** the serve was running emits status `stopped` **WITH** a
  message (`Server process exited (code N).`)
- a clean user stop emits status `stopped` with **NO** message

But the UI's `onServeEvent` dropped `ev.message` and re-rendered the
workspace without it, so the failure reason was swallowed, the read-only
"Started with" summary (only rendered while `running || starting`)
disappeared, and the composer came back empty.

## Fix

The workspace now treats a serve carrying a failure reason as **FAILED**
(`status === 'error'`, or `status === 'stopped'` **with** a message — distinct
from a clean user stop). A failed serve:

- surfaces the failure reason in the workspace error banner
  (`StudioServeEvent.message`, threaded through `onServeEvent` into
  `serveState` so it survives every re-render, not just the immediate one)
- keeps its "Started with" summary, so a crash does not read as "my inputs
  vanished"
- offers a `Reconfigure` button (returns to the composer to adjust options +
  restart) instead of a silent blank composer

A clean user stop (`stopped`, no message) still returns straight to the
composer with no banner, exactly as before. The path is kind-agnostic, so
this applies to every serve kind (`api` / `alb` / `ecs` / `ecs-task` /
`cloudfront`).

No tracking issue — discovered interactively while reproducing a user report
that start-alb env-vars + the "Started with" summary "disappear after Start".

## Test plan

- 4 new jsdom cases over the **real embedded `STUDIO_SCRIPT`**
  (`tests/unit/local/studio-ui-serve-failure.test.ts`): post-start crash
  (`stopped` + message), clean user stop (`stopped`, no message), boot
  failure (`error` + message), and the `Reconfigure` round-trip.
- Full unit suite green (2625 tests).
- `vp run check` + `vp run build` green.
- `/run-integ local-studio` green (real Docker; alb/ecs/ecs-task serve,
  env-vars threading, image-override, request capture), 0 orphans.
- Live-verified against the local-studio fixture: a `kill -9`'d `start-alb`
  child emits `stopped` + message `Server process exited (code null).` over
  SSE — exactly the event the UI now renders as a visible failure.
