### PR TITLE
docs(readme): make the coverage tagline open-ended instead of an exhaustive list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: Apache-2.0](https://img.shields.io/npm/l/cdk-local.svg)](./LICENSE)
 
 **Run your CDK-built app locally, no deploy needed — standalone, or kept local while it reaches the real AWS resources and data it depends on, with no `.env` or local copies to maintain.**
-A CDK-native alternative to `sam local`, covering Lambda, API Gateway, ECS, ALB-fronted services, and Bedrock AgentCore.
+A CDK-native alternative to `sam local`, covering Lambda, API Gateway, ECS, ALB, CloudFront, and more of your CDK app's compute.
 
 ![cdkl start-api serving a local CDK app's HTTP API; curl in the right pane reaches the local Lambda](assets/cdkl-start-api.gif)
 


### PR DESCRIPTION
## Summary

Make the README coverage tagline open-ended so it stops going stale on
every new runtime.

- Was: `covering Lambda, API Gateway, ECS, ALB-fronted services, and
  Bedrock AgentCore` — an exhaustive list that omitted CloudFront (the
  most recently added runtime) and needs an edit on every addition.
- Now: `covering Lambda, API Gateway, ECS, ALB, CloudFront, and more of
  your CDK app's compute` — names representative targets and ends open.

The authoritative, complete coverage list still lives in the Coverage
table further down the README, so nothing is lost.

No behavior change; docs only.

## Test plan

- `vp run check` passes (format + lint + typecheck, 128 files).
- Build / unit tests unaffected (no `src/**` or `tests/**` changes).
