### PR TITLE
fix(start-service): print the pinned-image WARN before the endpoints banner + "Press ^C"

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -771,21 +771,6 @@ export async function runEcsServiceEmulator(
         `Service(s) running: ${frontDoorLambdaRunners.length} Lambda target(s) behind the ALB front-door.`
       );
     }
-    // Surface the consolidated endpoint URLs at the END of the boot stream so
-    // the access URL doesn't get buried between streamed `docker pull` output
-    // and the per-replica boot logs. Two sources:
-    //   - per-service static host-port publishes recorded in
-    //     `state.publishedEndpoints` by the runner (single-replica start-service);
-    //   - per-listener ALB front-door servers (start-alb), echoed here so they
-    //     end up at the bottom too — the buildFrontDoor `ALB front-door: ...`
-    //     line is emitted earlier (and is the load-bearing marker integ tests
-    //     grep for), but it streams BEFORE the docker-pull noise and ends up
-    //     buried, exactly the same problem this banner solves for start-service.
-    // Empty when neither source has anything to show (e.g. multi-replica
-    // start-service with no front-door).
-    logEndpointsBanner(perTarget, frontDoorServers, logger);
-    logger.info('Press ^C to shut down.');
-
     // Issue #234 (broadened by #238) — warn per booted target whose
     // representative container image is NOT a local CDK docker-image
     // asset AND was NOT covered by `--image-override`. Such targets
@@ -839,6 +824,27 @@ export async function runEcsServiceEmulator(
     // Boot WARN already fired above for the same set; this throws on
     // top of it so the user sees both diagnostics before exiting.
     enforceStrictOverrides(options.strictOverrides === true, uncoveredPinnedTargets);
+
+    // Surface the consolidated endpoint URLs at the very END of the boot
+    // stream — AFTER the pinned-image WARN above — so two things hold at once:
+    // the access URL is the LAST thing printed (not buried between streamed
+    // `docker pull` output and the per-replica boot logs), AND the up-front
+    // pin WARN lands BEFORE the "Press ^C to shut down" banner rather than
+    // after it (where it read as an afterthought the user only sees once
+    // they've already spent time). Two sources:
+    //   - per-service static host-port publishes recorded in
+    //     `state.publishedEndpoints` by the runner (single-replica start-service);
+    //   - per-listener ALB front-door servers (start-alb), echoed here so they
+    //     end up at the bottom too — the buildFrontDoor `ALB front-door: ...`
+    //     line is emitted earlier (and is the load-bearing marker integ tests
+    //     grep for), but it streams BEFORE the docker-pull noise and ends up
+    //     buried, exactly the same problem this banner solves for start-service.
+    // Empty when neither source has anything to show (e.g. multi-replica
+    // start-service with no front-door). Placed after enforceStrictOverrides
+    // so a `--strict-overrides` failure throws BEFORE the misleading
+    // "Press ^C to shut down" is printed.
+    logEndpointsBanner(perTarget, frontDoorServers, logger);
+    logger.info('Press ^C to shut down.');
 
     // Phase 1 + Phase 2 + Phase 3 of issue #214 — `cdkl start-service --watch`
     // (Phases 1-2) and `cdkl start-alb --watch` (Phase 3) source-tree

--- a/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts
@@ -171,4 +171,31 @@ describe('ecs-service-emulator image-pin detector binding (issue #234)', () => {
     expect(rollIdx).toBeGreaterThan(-1);
     expect(skipIdx).toBeLessThan(rollIdx);
   });
+
+  it('prints the pinned-image WARN BEFORE the endpoints banner + "Press ^C" (so the hint is not buried after the ready line)', () => {
+    const source = readFileSync(EMULATOR_SOURCE, 'utf-8');
+    // The pin WARN's whole purpose (issue #234) is to tell the user that
+    // local source edits will not take effect BEFORE they spend time saving
+    // files. Emitting it AFTER `logEndpointsBanner` + "Press ^C to shut down"
+    // buries it below the ready line, where the user only notices it once
+    // they've already started iterating. The boot-time WARN loop must come
+    // first; the endpoints banner + "Press ^C" land at the very bottom.
+    const warnUpFrontIdx = source.indexOf('Warn UP-FRONT');
+    const bannerIdx = source.indexOf('logEndpointsBanner(perTarget, frontDoorServers, logger);');
+    const pressCtrlCIdx = source.indexOf("logger.info('Press ^C to shut down.');");
+    expect(warnUpFrontIdx).toBeGreaterThan(-1);
+    expect(bannerIdx).toBeGreaterThan(-1);
+    expect(pressCtrlCIdx).toBeGreaterThan(-1);
+    // WARN region comes first; banner + "Press ^C" come after.
+    expect(warnUpFrontIdx).toBeLessThan(bannerIdx);
+    expect(warnUpFrontIdx).toBeLessThan(pressCtrlCIdx);
+    // The banner also lands AFTER the strict-overrides guard, so a
+    // `--strict-overrides` failure throws before the misleading "Press ^C".
+    const strictIdx = source.indexOf('enforceStrictOverrides(', warnUpFrontIdx);
+    expect(strictIdx).toBeGreaterThan(-1);
+    expect(strictIdx).toBeLessThan(bannerIdx);
+    // There is exactly one boot-stream banner call (it was MOVED, not copied).
+    const bannerCount = source.split('logEndpointsBanner(perTarget, frontDoorServers, logger);').length - 1;
+    expect(bannerCount).toBe(1);
+  });
 });


### PR DESCRIPTION
## Problem

The boot-time pinned-image WARN (issue #234 / #238 — *"running image is
pinned to a deployed registry ... local source edits will not take effect"*)
was printed **after** `logEndpointsBanner` + `"Press ^C to shut down."`, so
it landed below the ready line. Its entire purpose is to warn the user
**up-front** — before they spend time saving files expecting a hot-reload
that will never fire — yet they only saw it once they had already scrolled
past "Press ^C". The block's own comment even says *"Warn UP-FRONT ... before
they spend time saving files."*

## Fix

Move the endpoints banner + `"Press ^C to shut down."` to **after** the
pinned-image WARN loop and the `enforceStrictOverrides` guard. The boot
stream now reads:

```
Service(s) running: <svc> (N replica(s)).
'<svc>': running image is pinned to a deployed registry (...).   <- WARN, up-front
Service endpoints:
  <svc> ... http://127.0.0.1:<port>
Press ^C to shut down.                                            <- now last
```

Two invariants preserved:

- The access URL still ends up at the very bottom of the boot stream (the
  banner's original goal — not burying the URL under streamed `docker pull`
  output — is intact; the WARN simply sits just above it).
- A `--strict-overrides` failure now `throw`s **before** the misleading
  `"Press ^C to shut down."` is printed, instead of after it.

Affects both `cdkl start-service` and `cdkl start-alb` (shared
`runEcsServiceEmulator`). Pure log-ordering change — no content, marker, or
exit-code change. The load-bearing ready markers a host/studio greps for
(`ALB front-door: <url>`, `Service(s) running:`) are unchanged and unmoved,
so studio readiness detection and integ greps are unaffected (cdkd-parity:
no host-facing surface change).

## Test plan

- Source-order assertion in the existing image-pin binding test
  (`tests/unit/cli/ecs-service-emulator-image-pin-binding.test.ts`): the WARN
  region precedes the banner + `Press ^C`; the banner is after
  `enforceStrictOverrides`; exactly one boot-stream banner call (moved, not
  copied).
- `vp run check` + `vp run build` green; full unit suite green (2645 tests).
- `/run-integ local-start-service` green (real Docker, 2 replicas, clean
  teardown), 0 orphans.
- Live-verified against the local-studio fixture's public-registry-pinned
  `MyService`: the WARN now prints on the line *before* `Service endpoints:` /
  `Press ^C to shut down.`
