### PR TITLE
feat(start-cloudfront): full env-var + --from-cfn-stack + --assume-role parity for a Function URL origin Lambda (#380 slice A)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -211,9 +211,17 @@ AWS managed services.
   becomes the origin response (the viewer-response function still runs over
   it). So start-cloudfront is pure-local (no Docker) for a pure-S3
   distribution, and boots a Lambda container ONLY when the distribution has
-  a Function URL origin; the Lambda runs with the dev shell's forwarded AWS
-  creds (no `--from-cfn-stack` / `--assume-role`; AWS_IAM auth on the
-  Function URL is not enforced; response streaming is buffered). `--watch`
+  a Function URL origin. That Lambda gets the SAME container env as a direct
+  `cdkl invoke` (issue #380): its declared `Environment.Variables` are
+  injected, `--from-cfn-stack [name]` substitutes intrinsic env values
+  against a deployed stack (SSM / cross-stack / deployed-env fallback), and
+  `--assume-role [arn]` (bare auto-resolves the execution role from state)
+  injects STS creds into the container — via the shared
+  `resolveLambdaContainerEnv` the front-door Lambda boot path now calls.
+  `--profile` / `--region` shape the creds / region; without a state flag
+  the dev shell's creds are forwarded and intrinsic env values are dropped
+  (warn-per-key), matching `cdkl invoke`. AWS_IAM auth on the Function URL is
+  still not enforced; response streaming is buffered. `--watch`
   re-synths + atomically swaps the in-memory routing model under the live
   socket (the viewer functions + S3 origins reload; a Function URL origin's
   warm container is boot-time only, NOT rebuilt on reload — restart to pick
@@ -229,8 +237,10 @@ AWS managed services.
   is omitted in a TTY). Also runnable from `cdkl studio` as the
   `cloudfront` serve kind (issue #367) — a [Start]/[Stop] control with a
   capture proxy, like `api` / `alb`; the session-global
-  `--from-cfn-stack` / `--assume-role` bindings are NOT forwarded to it
-  (start-cloudfront declares neither — it makes no AWS call)
+  `--from-cfn-stack` / `--assume-role` bindings are NOT forwarded to the
+  studio cloudfront serve yet (studio still sets `omitStateBindings` for the
+  `cloudfront` kind — a #380 follow-up, since start-cloudfront now DOES
+  declare those flags for its Function URL origin Lambda)
 
 ### Calls real AWS (managed services)
 
@@ -269,7 +279,13 @@ compute-locally category for Lambda + API Gateway).
   in-process. It is pure-local (no Docker) for an S3-origin
   distribution; a Lambda Function URL origin (issue #376) boots one warm
   RIE container per backing function via `createFrontDoorLambdaRunner`
-  (stopped on shutdown, boot-time only — not rebuilt on reload). `--watch`
+  (stopped on shutdown, boot-time only — not rebuilt on reload), with the
+  container env resolved by the shared `resolveLambdaContainerEnv`
+  (extracted from `local-invoke.ts` so `cdkl invoke` and the front-door
+  Lambda path agree — issue #380): `--from-cfn-stack [name]` /
+  `--assume-role [arn]` / `--stack-region` give the Function URL Lambda the
+  same env-var + deployed-state + execution-role injection as a direct
+  `cdkl invoke`. `--watch`
   re-synths + swaps the routing model under the live socket; `--tls`
   reuses `front-door-tls`; `--origin <id>=<dir>` is the
   BucketDeployment-source escape hatch; `--no-pull` skips the Lambda
@@ -355,7 +371,10 @@ compute-locally category for Lambda + API Gateway).
   priority ordered), alb-lambda-event (HTTP <-> ALB
   `requestContext.elb` Lambda event/response translation), front-door-pool
   (round-robin pool of live replica endpoints), front-door-lambda-runner
-  (one warm RIE container per Lambda target), front-door-tls (resolves
+  (one warm RIE container per Lambda target; accepts an optional
+  pre-resolved `containerEnv` overlay + `sensitiveEnvKeys` so the caller can
+  inject a fully-resolved env via `resolveLambdaContainerEnv` — issue #380 —
+  instead of the default shell-creds-only forward), front-door-tls (resolves
   TLS materials for HTTPS listeners: `--tls-cert` / `--tls-key` pair or
   an auto-generated self-signed cert cached under XDG cache via openssl),
   front-door-auth (builds the per-action `AuthCheck` callback for
@@ -549,8 +568,10 @@ compute-locally category for Lambda + API Gateway).
   forward to their spawned child commands, so the two spawn sites cannot
   drift. The `omitStateBindings` option (issue #367) suppresses
   `--from-cfn-stack` / `--assume-role` for a child that does not declare
-  them — the serve-manager sets it for the `cloudfront` kind, since
-  `start-cloudfront` makes no AWS call and would reject the flags),
+  them — the serve-manager still sets it for the `cloudfront` kind. As of
+  issue #380 start-cloudfront DOES declare those flags (for a Function URL
+  origin Lambda), so forwarding the session bindings to the cloudfront serve
+  is a #380 follow-up; today they are still omitted),
   studio-option-specs (issue #301 slice 2 — the per-target run-option
   descriptor table (`OPTION_SPECS`) that is the single source the UI
   renders controls from (serialized into the page) AND the server builds

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1476,11 +1476,15 @@ Two origin kinds are served:
 It does NOT emulate the managed CloudFront service: other custom (non-S3,
 non-Function-URL) origins, Lambda@Edge (`LambdaFunctionAssociations`), the
 KeyValueStore, and the 2.0 `cf.fetch` origin API are out of scope
-(warn-and-skip; a request routed to one returns 502). On a Function URL
-origin the Lambda runs with the dev shell's forwarded AWS credentials —
-`start-cloudfront` takes neither `--from-cfn-stack` nor `--assume-role`;
-`AWS_IAM` auth on the Function URL is not enforced locally and response
-streaming is invoked buffered.
+(warn-and-skip; a request routed to one returns 502). A Function URL origin
+Lambda gets the **same container environment as a direct `cdkl invoke`**:
+its declared `Environment.Variables` are injected, `--from-cfn-stack [name]`
+substitutes intrinsic env values against a deployed stack, and
+`--assume-role [arn]` injects the deployed execution role's STS credentials
+(see the options table). Without a state-source flag the dev shell's
+credentials are forwarded and intrinsic env values are dropped (warn-per-key),
+matching `cdkl invoke`. `AWS_IAM` auth on the Function URL is not enforced
+locally and response streaming is invoked buffered.
 
 ### Resolution model
 
@@ -1542,6 +1546,9 @@ On top of the [common flags](#common-flags):
 | `--tls-cert <path>` | unset | PEM server certificate. Implies `--tls`; must be set with `--tls-key`. |
 | `--tls-key <path>` | unset | PEM server private key matching `--tls-cert`. Implies `--tls`; must be set with `--tls-cert`. |
 | `--no-pull` | off | Skip `docker pull` for a Lambda Function URL origin's base image (use the locally cached image). No effect on a pure-S3 distribution. |
+| `--from-cfn-stack [name]` | off | Bind a Function URL origin's backing Lambda to a deployed CloudFormation stack so its intrinsic env vars resolve to the deployed physical IDs / exports (`ListStackResources`). Bare form uses the resolved stack name; pass a value when the CFn stack name differs. No effect on a pure-S3 distribution. Same semantics as `cdkl invoke --from-cfn-stack`. |
+| `--stack-region <region>` | unset | Region of the state record to read; used with `--from-cfn-stack` as the CFn client region. |
+| `--assume-role [arn]` | off | Assume a Function URL origin Lambda's deployed execution role and forward STS temp credentials into its container. `--assume-role <arn>` (explicit); `--assume-role` (bare, auto-resolves from state — requires `--from-cfn-stack`); `--no-assume-role` (opt out). Same semantics as `cdkl invoke --assume-role`. |
 | `--watch` | off | Hot reload: re-synth + re-resolve the distribution and atomically swap the in-memory routing model when the CDK app's source changes (honors `cdk.json` `watch.include` / `watch.exclude`; `cdk.out`, `node_modules`, `.git` always excluded). The listening socket is never recreated; a synth failure keeps the previous version serving (warn-and-continue). A Function URL origin's RIE container is NOT rebuilt on reload (boot-time only). |
 
 ```bash

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -24,6 +24,7 @@ import {
   createLocalStateProvider,
   resolveCfnFallbackRegion,
   type ExtraStateProviders,
+  type LocalStateSourceOptions,
 } from './local-state-source.js';
 import type { LocalStateProvider } from '../../local/local-state-provider.js';
 import {
@@ -322,210 +323,32 @@ async function localInvokeCommand(
 
     imagePlan = await resolveImagePlan(lambda, options);
 
-    let stateAudit: StateEnvSubstitutionAudit | undefined;
-    let templateEnv = getTemplateEnv(lambda.resource);
-    let stateForRoleHint: StackState | undefined;
-    // Pick the right LocalStateProvider for the supplied flags. Returns
-    // `undefined` when no state-source flag is set.
-    const stateProvider = createLocalStateProvider(
+    // Resolve the container env (declared env vars + `--from-cfn-stack` state
+    // substitution + `--assume-role` / shell creds + region) via the shared
+    // helper that `start-cloudfront` / `start-alb`'s Lambda paths also use
+    // (issue #380), so a direct invoke and a CDN-/ALB-fronted invoke agree.
+    const containerEnv = await resolveLambdaContainerEnv(
+      lambda,
       options,
-      lambda.stack.stackName,
-      await resolveCfnFallbackRegion(options, lambda.stack.region),
+      profileCredentials,
       extraStateProviders
     );
-    if (stateProvider) {
-      try {
-        const loaded = await stateProvider.load(lambda.stack.stackName, lambda.stack.region);
-        if (loaded) {
-          // Synthetic StackState shape consumed by the legacy
-          // `--assume-role` hint path. Sufficient for
-          // `resolveExecutionRoleArnFromState`, which only touches
-          // `state.resources[...].properties.Role` /
-          // `attributes.Arn`.
-          stateForRoleHint = {
-            version: 1,
-            stackName: lambda.stack.stackName,
-            resources: loaded.resources,
-            outputs: loaded.outputs,
-            lastModified: 0,
-          };
-          const subContext: SubstitutionContext = {
-            resources: loaded.resources,
-            consumerRegion: loaded.region,
-          };
-          if (envHasIntrinsicValue(templateEnv)) {
-            const pseudo = await resolvePseudoParametersForInvoke(lambda.stack.region, options);
-            if (pseudo) subContext.pseudoParameters = pseudo;
-          }
-          // Resolve SSM-backed template parameters
-          // (`AWS::SSM::Parameter::Value<String>`) so a `Ref` to such a
-          // parameter in an env var resolves to its SSM value instead of
-          // being warn-and-dropped (issue #94). Only the CFn provider
-          // implements this; the resolved map feeds the substitution
-          // context's `parameters` field consulted by `resolveRef`.
-          if (envHasIntrinsicValue(templateEnv) && stateProvider.resolveTemplateSsmParameters) {
-            const ssmParams = await stateProvider.resolveTemplateSsmParameters(
-              lambda.stack.template
-            );
-            if (Object.keys(ssmParams.values).length > 0) subContext.parameters = ssmParams.values;
-            // Flag decrypted SecureString parameters so the consuming env
-            // keys are kept off the `docker run` argv (issue #99).
-            if (ssmParams.secureStringLogicalIds.length > 0) {
-              subContext.sensitiveParameters = new Set(ssmParams.secureStringLogicalIds);
-            }
-          }
-          if (envHasCrossStackIntrinsic(templateEnv)) {
-            const resolver = await stateProvider.buildCrossStackResolver(loaded.region);
-            if (resolver) {
-              subContext.crossStackResolver = resolver;
-            }
-          }
-          const { env, audit } = await substituteEnvVarsFromStateAsync(templateEnv, subContext);
-          templateEnv = env;
-          const label = stateProvider.label;
-          for (const key of audit.resolvedKeys) {
-            logger.debug(`${label}: substituted env var ${key}`);
-          }
-          // Deployed-env fallback: keys whose intrinsic value the static
-          // substituter could not resolve (e.g. `Fn::GetAtt <Sibling>.Arn`)
-          // are filled from the consumer function's deploy-time-resolved
-          // `Environment.Variables`. Only the CFn provider implements
-          // `resolveDeployedFunctionEnv`; the S3 provider's state already
-          // carries deploy-time attributes so its GetAtt resolves above.
-          let unresolved = audit.unresolved;
-          const resolvedKeys = [...audit.resolvedKeys];
-          if (unresolved.length > 0 && stateProvider.resolveDeployedFunctionEnv) {
-            const physicalId = loaded.resources[lambda.logicalId]?.physicalId;
-            if (physicalId) {
-              const deployedEnv = await stateProvider.resolveDeployedFunctionEnv(physicalId);
-              const fb = applyDeployedEnvFallback(templateEnv, unresolved, deployedEnv);
-              templateEnv = fb.env;
-              unresolved = fb.stillUnresolved;
-              for (const key of fb.filled) {
-                resolvedKeys.push(key);
-                logger.debug(`${label}: filled env var ${key} from deployed function config`);
-              }
-            }
-          }
-          stateAudit = { resolvedKeys, unresolved, sensitiveKeys: audit.sensitiveKeys };
-          for (const { key, reason } of unresolved) {
-            logger.warn(
-              `${label}: could not substitute env var ${key} (${reason}). ` +
-                `Override it via --env-vars or it will be dropped.`
-            );
-          }
-        }
-      } catch (err) {
-        // Ensure the provider is released if the substitution pass threw.
-        // The success path defers dispose until after the assume-role
-        // resolution below so the issue-#181 fallback can still use it.
-        stateProvider.dispose();
-        throw err;
-      }
-    }
-
-    // Resolve env vars. Intrinsic-valued template entries are warned about
-    // and dropped; the user can override them via --env-vars (SAM-shape).
-    const overrides = readEnvOverridesFile(options.envVars);
-    const lambdaCdkPath = readCdkPathOrUndefined(lambda.resource);
-    const envResult = resolveEnvVars(lambda.logicalId, lambdaCdkPath, templateEnv, overrides);
-    for (const key of envResult.unresolved) {
-      if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
-      // Prefer the L2 form (`MyStack/MyFn`) in the suggestion since that
-      // matches the README guidance and `cdkl invoke` target shape; the
-      // resolver's prefix rule accepts either form.
-      const overrideKeyExample = lambdaCdkPath?.replace(/\/Resource$/, '') ?? lambda.logicalId;
-      logger.warn(
-        `Environment variable ${key} contains a CloudFormation intrinsic and was dropped. ` +
-          `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}), or pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to recover deployed values.`
-      );
-    }
-
-    // Resolve the role ARN to assume (if any). Three forms — explicit
-    // ARN, bare (auto-resolve from state, with a #181 fallback to
-    // GetFunctionConfiguration.Role when state misses), or absent.
-    // The state provider's dispose is deferred until after this call so
-    // the issue-#181 fallback can still use it.
-    let resolvedAssumeRoleArn: string | undefined;
-    try {
-      resolvedAssumeRoleArn = await resolveAssumeRoleArnForLambda(
-        options.assumeRole,
-        stateForRoleHint,
-        stateProvider,
-        lambda.logicalId
-      );
-    } finally {
-      stateProvider?.dispose();
-    }
-    if (options.assumeRole === undefined && stateForRoleHint) {
+    const dockerEnv = containerEnv.env;
+    if (options.assumeRole === undefined && containerEnv.stateForRoleHint) {
       // Legacy hint path: surface the deployed role ARN so they can re-run
       // with `--assume-role`.
-      suggestAssumeRoleFromState(stateForRoleHint, lambda.logicalId);
+      suggestAssumeRoleFromState(containerEnv.stateForRoleHint, lambda.logicalId);
+    }
+    // Point the container's SDK chain at the bind-mounted profile credentials
+    // file (invoke-specific) so `fromIni({ profile })` inside the handler
+    // resolves to the same creds. Only when no assume-role creds were applied.
+    if (!containerEnv.assumeRoleApplied && profileCredsFile) {
+      dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
+      dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
     }
 
     // Read the event payload. Default to {} (matches SAM).
     const event = await readEvent(options);
-
-    const dockerEnv: Record<string, string> = {
-      AWS_LAMBDA_FUNCTION_NAME: lambda.logicalId,
-      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: String(lambda.memoryMb),
-      AWS_LAMBDA_FUNCTION_TIMEOUT: String(lambda.timeoutSec),
-      AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
-      AWS_LAMBDA_LOG_GROUP_NAME: `/aws/lambda/${lambda.logicalId}`,
-      AWS_LAMBDA_LOG_STREAM_NAME: 'local',
-      ...envResult.resolved,
-    };
-    let assumeSucceeded = false;
-    if (resolvedAssumeRoleArn) {
-      const stsRegion =
-        options.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'];
-      try {
-        const creds = await assumeLambdaExecutionRole(
-          resolvedAssumeRoleArn,
-          stsRegion,
-          options.profile
-        );
-        dockerEnv['AWS_ACCESS_KEY_ID'] = creds.accessKeyId;
-        dockerEnv['AWS_SECRET_ACCESS_KEY'] = creds.secretAccessKey;
-        dockerEnv['AWS_SESSION_TOKEN'] = creds.sessionToken;
-        if (stsRegion) dockerEnv['AWS_REGION'] = stsRegion;
-        assumeSucceeded = true;
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        logger.warn(
-          `--assume-role: STS AssumeRole(${resolvedAssumeRoleArn}) failed: ${reason}. ` +
-            "Falling back to the developer's shell credentials."
-        );
-      }
-    }
-    if (!assumeSucceeded) {
-      forwardAwsEnv(dockerEnv);
-      applyProfileCredentialsOverlay(dockerEnv, profileCredentials, false);
-      // Point the container's SDK chain at the bind-mounted credentials
-      // file so
-      // `fromIni({ profile })` calls inside the handler resolve to the
-      // same creds. `AWS_PROFILE` makes `fromIni()` (no explicit arg)
-      // ALSO use this profile.
-      if (profileCredsFile) {
-        dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
-        dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
-      }
-    }
-    // Seed the container's `AWS_REGION` fallback so handler ambient-region
-    // SDK calls (`new XxxClient({})`) reach the same region the deployed
-    // function would. Precedence mirrors `start-api` via
-    // `resolveContainerFallbackRegion`:
-    //   1. `--region` / `AWS_REGION` / `AWS_DEFAULT_REGION` (forwarded above)
-    //   2. the synth-derived stack region (`env.region` on the CDK stack)
-    //   3. the `--profile`'s configured region (new in #245)
-    if (!dockerEnv['AWS_REGION'] && !dockerEnv['AWS_DEFAULT_REGION']) {
-      const fallbackRegion = resolveContainerFallbackRegion({
-        stackRegionOverride: options.region,
-        synthRegion: lambda.stack.region,
-        profileRegion: profileCredentials?.region,
-      });
-      if (fallbackRegion) dockerEnv['AWS_REGION'] = fallbackRegion;
-    }
 
     let debugPort: number | undefined;
     if (options.debugPort) {
@@ -572,10 +395,9 @@ async function localInvokeCommand(
       mounts: imagePlan.mounts,
       extraMounts: extraMountsWithProfile,
       env: dockerEnv,
-      ...(stateAudit &&
-        stateAudit.sensitiveKeys.length > 0 && {
-          sensitiveEnvKeys: new Set(stateAudit.sensitiveKeys),
-        }),
+      ...(containerEnv.sensitiveEnvKeys.length > 0 && {
+        sensitiveEnvKeys: new Set(containerEnv.sensitiveEnvKeys),
+      }),
       cmd: imagePlan.cmd,
       hostPort,
       host: containerHost,
@@ -838,7 +660,7 @@ export function envHasCrossStackIntrinsic(
 
 async function resolvePseudoParametersForInvoke(
   stackRegion: string | undefined,
-  options: LocalInvokeOptions
+  options: { region?: string; profile?: string }
 ): Promise<
   { accountId?: string; region?: string; partition?: string; urlSuffix?: string } | undefined
 > {
@@ -1020,6 +842,223 @@ export function applyProfileCredentialsOverlay(
   } else {
     delete env['AWS_SESSION_TOKEN'];
   }
+}
+
+/** The `--profile`-resolved static credentials, as {@link resolveProfileCredentials} returns. */
+export interface ResolvedProfileCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  region?: string;
+}
+
+/** Options for {@link resolveLambdaContainerEnv} — the state-source + assume-role + env-vars surface. */
+export interface LambdaContainerEnvOptions extends LocalStateSourceOptions {
+  /** `--assume-role` form (true=bare, string=ARN, undefined=off). */
+  assumeRole?: string | boolean;
+  /** `--env-vars` SAM-shape override file path. */
+  envVars?: string;
+}
+
+/** The fully resolved container environment for a Lambda. */
+export interface LambdaContainerEnvResult {
+  /**
+   * The container env map: `AWS_LAMBDA_*` runtime vars + the function's
+   * resolved declared env vars + AWS credentials + a fallback `AWS_REGION`.
+   * Does NOT include the `AWS_SHARED_CREDENTIALS_FILE` / `AWS_PROFILE` pointer
+   * to a bind-mounted profile credentials file — that mount is the caller's
+   * (only `cdkl invoke` materializes it today).
+   */
+  env: Record<string, string>;
+  /**
+   * Env keys whose values are decrypted SecureStrings — the caller passes
+   * these to `runDetached`'s `sensitiveEnvKeys` so they stay off the
+   * `docker run` argv.
+   */
+  sensitiveEnvKeys: string[];
+  /**
+   * The loaded deployed state (a synthetic {@link StackState}) when a
+   * state-source flag resolved one — so the caller can surface the
+   * assume-role suggestion hint. `undefined` when no state was loaded.
+   */
+  stateForRoleHint?: StackState;
+  /** Whether an `--assume-role` STS assume succeeded (creds are in `env`). */
+  assumeRoleApplied: boolean;
+}
+
+/**
+ * Resolve the full container environment for a Lambda: its declared env vars
+ * (literal + `--env-vars` overrides + intrinsic values substituted against a
+ * `--from-cfn-stack` deployed stack — SSM / cross-stack / deployed-env
+ * fallback included), the `AWS_LAMBDA_*` runtime vars, and AWS credentials
+ * (an `--assume-role` STS assume, else the dev shell's forwarded creds + a
+ * `--profile` overlay), plus a fallback `AWS_REGION`.
+ *
+ * This is the single source of truth shared by `cdkl invoke` AND the
+ * front-door Lambda boot path (`start-cloudfront`'s Function URL origin,
+ * `start-alb`'s Lambda targets — issue #380), so a CDN- / ALB-fronted Lambda
+ * reaches the same deployed resources as a direct `cdkl invoke`. The caller
+ * layers any command-specific concerns (a `--profile` credentials-file
+ * bind-mount, `--debug-port`) on top of `env`.
+ */
+export async function resolveLambdaContainerEnv(
+  lambda: ResolvedLambda,
+  options: LambdaContainerEnvOptions,
+  profileCredentials: ResolvedProfileCredentials | undefined,
+  extraStateProviders?: ExtraStateProviders
+): Promise<LambdaContainerEnvResult> {
+  const logger = getLogger();
+  let stateAudit: StateEnvSubstitutionAudit | undefined;
+  let templateEnv = getTemplateEnv(lambda.resource);
+  let stateForRoleHint: StackState | undefined;
+  // Pick the right LocalStateProvider for the supplied flags. Returns
+  // `undefined` when no state-source flag is set.
+  const stateProvider = createLocalStateProvider(
+    options,
+    lambda.stack.stackName,
+    await resolveCfnFallbackRegion(options, lambda.stack.region),
+    extraStateProviders
+  );
+  if (stateProvider) {
+    try {
+      const loaded = await stateProvider.load(lambda.stack.stackName, lambda.stack.region);
+      if (loaded) {
+        stateForRoleHint = {
+          version: 1,
+          stackName: lambda.stack.stackName,
+          resources: loaded.resources,
+          outputs: loaded.outputs,
+          lastModified: 0,
+        };
+        const subContext: SubstitutionContext = {
+          resources: loaded.resources,
+          consumerRegion: loaded.region,
+        };
+        if (envHasIntrinsicValue(templateEnv)) {
+          const pseudo = await resolvePseudoParametersForInvoke(lambda.stack.region, options);
+          if (pseudo) subContext.pseudoParameters = pseudo;
+        }
+        if (envHasIntrinsicValue(templateEnv) && stateProvider.resolveTemplateSsmParameters) {
+          const ssmParams = await stateProvider.resolveTemplateSsmParameters(lambda.stack.template);
+          if (Object.keys(ssmParams.values).length > 0) subContext.parameters = ssmParams.values;
+          if (ssmParams.secureStringLogicalIds.length > 0) {
+            subContext.sensitiveParameters = new Set(ssmParams.secureStringLogicalIds);
+          }
+        }
+        if (envHasCrossStackIntrinsic(templateEnv)) {
+          const resolver = await stateProvider.buildCrossStackResolver(loaded.region);
+          if (resolver) subContext.crossStackResolver = resolver;
+        }
+        const { env, audit } = await substituteEnvVarsFromStateAsync(templateEnv, subContext);
+        templateEnv = env;
+        const label = stateProvider.label;
+        for (const key of audit.resolvedKeys) {
+          logger.debug(`${label}: substituted env var ${key}`);
+        }
+        let unresolved = audit.unresolved;
+        const resolvedKeys = [...audit.resolvedKeys];
+        if (unresolved.length > 0 && stateProvider.resolveDeployedFunctionEnv) {
+          const physicalId = loaded.resources[lambda.logicalId]?.physicalId;
+          if (physicalId) {
+            const deployedEnv = await stateProvider.resolveDeployedFunctionEnv(physicalId);
+            const fb = applyDeployedEnvFallback(templateEnv, unresolved, deployedEnv);
+            templateEnv = fb.env;
+            unresolved = fb.stillUnresolved;
+            for (const key of fb.filled) {
+              resolvedKeys.push(key);
+              logger.debug(`${label}: filled env var ${key} from deployed function config`);
+            }
+          }
+        }
+        stateAudit = { resolvedKeys, unresolved, sensitiveKeys: audit.sensitiveKeys };
+        for (const { key, reason } of unresolved) {
+          logger.warn(
+            `${label}: could not substitute env var ${key} (${reason}). ` +
+              `Override it via --env-vars or it will be dropped.`
+          );
+        }
+      }
+    } catch (err) {
+      stateProvider.dispose();
+      throw err;
+    }
+  }
+
+  const overrides = readEnvOverridesFile(options.envVars);
+  const lambdaCdkPath = readCdkPathOrUndefined(lambda.resource);
+  const envResult = resolveEnvVars(lambda.logicalId, lambdaCdkPath, templateEnv, overrides);
+  for (const key of envResult.unresolved) {
+    if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
+    const overrideKeyExample = lambdaCdkPath?.replace(/\/Resource$/, '') ?? lambda.logicalId;
+    logger.warn(
+      `Environment variable ${key} contains a CloudFormation intrinsic and was dropped. ` +
+        `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}), or pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to recover deployed values.`
+    );
+  }
+
+  let resolvedAssumeRoleArn: string | undefined;
+  try {
+    resolvedAssumeRoleArn = await resolveAssumeRoleArnForLambda(
+      options.assumeRole,
+      stateForRoleHint,
+      stateProvider,
+      lambda.logicalId
+    );
+  } finally {
+    stateProvider?.dispose();
+  }
+
+  const dockerEnv: Record<string, string> = {
+    AWS_LAMBDA_FUNCTION_NAME: lambda.logicalId,
+    AWS_LAMBDA_FUNCTION_MEMORY_SIZE: String(lambda.memoryMb),
+    AWS_LAMBDA_FUNCTION_TIMEOUT: String(lambda.timeoutSec),
+    AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
+    AWS_LAMBDA_LOG_GROUP_NAME: `/aws/lambda/${lambda.logicalId}`,
+    AWS_LAMBDA_LOG_STREAM_NAME: 'local',
+    ...envResult.resolved,
+  };
+  let assumeSucceeded = false;
+  if (resolvedAssumeRoleArn) {
+    const stsRegion =
+      options.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'];
+    try {
+      const creds = await assumeLambdaExecutionRole(
+        resolvedAssumeRoleArn,
+        stsRegion,
+        options.profile
+      );
+      dockerEnv['AWS_ACCESS_KEY_ID'] = creds.accessKeyId;
+      dockerEnv['AWS_SECRET_ACCESS_KEY'] = creds.secretAccessKey;
+      dockerEnv['AWS_SESSION_TOKEN'] = creds.sessionToken;
+      if (stsRegion) dockerEnv['AWS_REGION'] = stsRegion;
+      assumeSucceeded = true;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        `--assume-role: STS AssumeRole(${resolvedAssumeRoleArn}) failed: ${reason}. ` +
+          "Falling back to the developer's shell credentials."
+      );
+    }
+  }
+  if (!assumeSucceeded) {
+    forwardAwsEnv(dockerEnv);
+    applyProfileCredentialsOverlay(dockerEnv, profileCredentials, false);
+  }
+  if (!dockerEnv['AWS_REGION'] && !dockerEnv['AWS_DEFAULT_REGION']) {
+    const fallbackRegion = resolveContainerFallbackRegion({
+      stackRegionOverride: options.region,
+      synthRegion: lambda.stack.region,
+      profileRegion: profileCredentials?.region,
+    });
+    if (fallbackRegion) dockerEnv['AWS_REGION'] = fallbackRegion;
+  }
+
+  return {
+    env: dockerEnv,
+    sensitiveEnvKeys: stateAudit?.sensitiveKeys ?? [],
+    ...(stateForRoleHint !== undefined && { stateForRoleHint }),
+    assumeRoleApplied: assumeSucceeded,
+  };
 }
 
 function materializeInlineCode(handler: string, source: string, fileExtension: string): string {

--- a/src/cli/commands/local-start-cloudfront.ts
+++ b/src/cli/commands/local-start-cloudfront.ts
@@ -17,6 +17,12 @@ import {
   createFrontDoorLambdaRunner,
   type FrontDoorLambdaRunner,
 } from '../../local/front-door-lambda-runner.js';
+import {
+  resolveLambdaContainerEnv,
+  type LambdaContainerEnvOptions,
+  type ResolvedProfileCredentials,
+} from './local-invoke.js';
+import { resolveProfileCredentials } from '../../utils/profile-resolver.js';
 import { resolveLambdaTarget } from '../../local/lambda-resolver.js';
 import { createFileWatcher, type FileWatcher } from '../../local/file-watcher.js';
 import {
@@ -76,6 +82,20 @@ interface LocalStartCloudFrontOptions {
    * false, skip `docker pull` for a Lambda Function URL origin's base image.
    */
   pull?: boolean;
+  /**
+   * `--from-cfn-stack [name]` — bind a Lambda Function URL origin's backing
+   * Lambda to a deployed CloudFormation stack so its intrinsic env vars
+   * resolve to deployed physical IDs (issue #380). Off for a pure-S3
+   * distribution (no AWS call).
+   */
+  fromCfnStack?: string | boolean;
+  /** `--stack-region <region>` — CFn client region for `--from-cfn-stack`. */
+  stackRegion?: string;
+  /**
+   * `--assume-role [arn]` — assume the Function URL origin Lambda's deployed
+   * execution role and inject the STS creds into its container.
+   */
+  assumeRole?: string | boolean;
 }
 
 /** Factory options for {@link createLocalStartCloudFrontCommand}. */
@@ -192,7 +212,18 @@ function notFound(
 export async function bootLambdaUrlOrigins(
   distribution: ResolvedDistribution,
   stacks: StackInfo[],
-  opts: { containerHost: string; skipPull: boolean; region?: string }
+  opts: {
+    containerHost: string;
+    skipPull: boolean;
+    /**
+     * State-source + assume-role + profile options threaded into the shared
+     * {@link resolveLambdaContainerEnv} so a Function URL origin Lambda gets
+     * its declared env vars + `--from-cfn-stack` deployed values + an
+     * `--assume-role` execution role, exactly like `cdkl invoke` (issue #380).
+     */
+    envOptions: LambdaContainerEnvOptions;
+    profileCredentials?: ResolvedProfileCredentials;
+  }
 ): Promise<{ invokers: LambdaUrlInvokerMap; runners: FrontDoorLambdaRunner[] }> {
   const logger = getLogger();
   const invokers: LambdaUrlInvokerMap = new Map();
@@ -206,10 +237,22 @@ export async function bootLambdaUrlOrigins(
     let runner: FrontDoorLambdaRunner;
     try {
       const lambda = resolveLambdaTarget(functionLogicalId, stacks);
+      // Resolve the container env (declared env vars + --from-cfn-stack state
+      // substitution + --assume-role / shell creds) the same way `cdkl invoke`
+      // does, so the Function URL Lambda reaches its deployed resources.
+      const containerEnv = await resolveLambdaContainerEnv(
+        lambda,
+        opts.envOptions,
+        opts.profileCredentials
+      );
       runner = createFrontDoorLambdaRunner(lambda, {
         containerHost: opts.containerHost,
         skipPull: opts.skipPull,
-        ...(opts.region !== undefined && { region: opts.region }),
+        ...(opts.envOptions.region !== undefined && { region: opts.envOptions.region }),
+        containerEnv: containerEnv.env,
+        ...(containerEnv.sensitiveEnvKeys.length > 0 && {
+          sensitiveEnvKeys: new Set(containerEnv.sensitiveEnvKeys),
+        }),
       });
       logger.info(
         `Booting Lambda Function URL origin container for ${functionLogicalId} (the backing Lambda runs locally via RIE)...`
@@ -325,6 +368,23 @@ async function localStartCloudFrontCommand(
   const initial = await synthAndResolve();
   warnUnsupported(initial.distribution);
 
+  // `--profile`-resolved static credentials, forwarded into a Function URL
+  // origin Lambda's container (the front-door Lambda path has no profile
+  // credentials-file bind-mount; the env overlay carries the creds).
+  const profileCredentials = options.profile
+    ? await resolveProfileCredentials(options.profile)
+    : undefined;
+  // State-source + assume-role options threaded into the shared container-env
+  // resolver so a Function URL origin Lambda gets its env vars + deployed
+  // values + execution role, exactly like `cdkl invoke` (issue #380).
+  const envOptions: LambdaContainerEnvOptions = {
+    ...(options.fromCfnStack !== undefined && { fromCfnStack: options.fromCfnStack }),
+    ...(options.assumeRole !== undefined && { assumeRole: options.assumeRole }),
+    ...(options.region !== undefined && { region: options.region }),
+    ...(options.profile !== undefined && { profile: options.profile }),
+    ...(options.stackRegion !== undefined && { stackRegion: options.stackRegion }),
+  };
+
   // Boot a warm RIE container per Lambda Function URL origin (issue #376).
   // No Function URL origin -> empty map -> start-cloudfront stays pure-local.
   const { invokers: lambdaInvokers, runners: lambdaRunners } = await bootLambdaUrlOrigins(
@@ -333,7 +393,8 @@ async function localStartCloudFrontCommand(
     {
       containerHost: options.host,
       skipPull: options.pull === false,
-      ...(options.region !== undefined && { region: options.region }),
+      envOptions,
+      ...(profileCredentials !== undefined && { profileCredentials }),
     }
   );
 
@@ -503,6 +564,30 @@ export function addStartCloudFrontSpecificOptions(cmd: Command): Command {
       new Option(
         '--no-pull',
         "Skip 'docker pull' for a Lambda Function URL origin's base image (use the locally cached image)."
+      )
+    )
+    .addOption(
+      new Option(
+        '--from-cfn-stack [cfn-stack-name]',
+        "Bind a Lambda Function URL origin's backing Lambda to a deployed CloudFormation stack so its " +
+          'env vars resolve to the deployed physical IDs / exports (ListStackResources). Use for CDK apps ' +
+          'deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the resolved stack name; pass a value ' +
+          'when the CFn stack name differs. No effect on a pure-S3 distribution.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--stack-region <region>',
+        'Region of the state record to read. Used with --from-cfn-stack as the CFn client region.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--assume-role [arn]',
+        "Assume a Lambda Function URL origin's deployed execution role and forward STS-issued temp " +
+          'credentials into its container so the handler runs with the deployed permissions. Three forms: ' +
+          '`--assume-role <arn>` (explicit ARN); `--assume-role` (bare, auto-resolves from state — requires ' +
+          '--from-cfn-stack); `--no-assume-role` (opt out). Off by default (the dev shell credentials are forwarded).'
       )
     )
     .addOption(

--- a/src/local/front-door-lambda-runner.ts
+++ b/src/local/front-door-lambda-runner.ts
@@ -67,14 +67,16 @@ export interface FrontDoorLambdaRunnerOptions {
   /** Whether to attach `docker logs -f`. Default true. */
   streamLogs?: boolean;
   /**
-   * Pre-resolved container environment overlaid on the `AWS_LAMBDA_*` base
-   * (issue #380). The caller resolves the function's declared env vars +
-   * `--from-cfn-stack` state substitution + `--assume-role` / shell creds via
-   * the shared `resolveLambdaContainerEnv`, so a CDN-/ALB-fronted Lambda
-   * reaches the same deployed resources as a direct `cdkl invoke`. Overlaid
-   * AFTER the base so a caller-provided `AWS_*` cred / region wins, while the
-   * runner still owns the `AWS_LAMBDA_FUNCTION_*` identity vars. When absent,
-   * the runner forwards only the dev shell's AWS env (the pre-#380 behavior).
+   * Pre-resolved container environment (issue #380). The caller resolves the
+   * function's declared env vars + `--from-cfn-stack` state substitution +
+   * `--assume-role` / shell creds via the shared `resolveLambdaContainerEnv`,
+   * so a CDN-/ALB-fronted Lambda reaches the same deployed resources as a
+   * direct `cdkl invoke`. When present, this REPLACES the runner's env base
+   * entirely — `resolveLambdaContainerEnv` already emits the six
+   * `AWS_LAMBDA_FUNCTION_*` identity vars (from the same `ResolvedLambda`), so
+   * the caller owns the full env. When absent, the runner builds the
+   * `AWS_LAMBDA_*` base itself and forwards only the dev shell's AWS env (the
+   * pre-#380 behavior).
    */
   containerEnv?: Record<string, string>;
   /** Env keys carrying decrypted SecureStrings — kept off the `docker run` argv. */

--- a/src/local/front-door-lambda-runner.ts
+++ b/src/local/front-door-lambda-runner.ts
@@ -66,6 +66,19 @@ export interface FrontDoorLambdaRunnerOptions {
   region?: string;
   /** Whether to attach `docker logs -f`. Default true. */
   streamLogs?: boolean;
+  /**
+   * Pre-resolved container environment overlaid on the `AWS_LAMBDA_*` base
+   * (issue #380). The caller resolves the function's declared env vars +
+   * `--from-cfn-stack` state substitution + `--assume-role` / shell creds via
+   * the shared `resolveLambdaContainerEnv`, so a CDN-/ALB-fronted Lambda
+   * reaches the same deployed resources as a direct `cdkl invoke`. Overlaid
+   * AFTER the base so a caller-provided `AWS_*` cred / region wins, while the
+   * runner still owns the `AWS_LAMBDA_FUNCTION_*` identity vars. When absent,
+   * the runner forwards only the dev shell's AWS env (the pre-#380 behavior).
+   */
+  containerEnv?: Record<string, string>;
+  /** Env keys carrying decrypted SecureStrings — kept off the `docker run` argv. */
+  sensitiveEnvKeys?: Set<string>;
 }
 
 interface ImagePlan {
@@ -238,15 +251,23 @@ export function createFrontDoorLambdaRunner(
     const name = `${getEmbedConfig().resourceNamePrefix}-alblambda-${lambda.logicalId}-${process.pid}-${Math.floor(
       Math.random() * 1_000_000
     )}`;
-    const env: Record<string, string> = {
-      AWS_LAMBDA_FUNCTION_NAME: lambda.logicalId,
-      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: String(lambda.memoryMb),
-      AWS_LAMBDA_FUNCTION_TIMEOUT: String(lambda.timeoutSec),
-      AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
-      AWS_LAMBDA_LOG_GROUP_NAME: `/aws/lambda/${lambda.logicalId}`,
-      AWS_LAMBDA_LOG_STREAM_NAME: 'local',
-      ...forwardAwsEnv(),
-    };
+    // When the caller pre-resolved the container env (issue #380 — declared
+    // env vars + `--from-cfn-stack` state substitution + `--assume-role` /
+    // shell creds, via `resolveLambdaContainerEnv`), it already carries the
+    // `AWS_LAMBDA_*` identity vars + resolved env + credentials, so use it
+    // directly. Otherwise fall back to the pre-#380 behavior: `AWS_LAMBDA_*`
+    // + only the dev shell's forwarded AWS env.
+    const env: Record<string, string> = opts.containerEnv
+      ? { ...opts.containerEnv }
+      : {
+          AWS_LAMBDA_FUNCTION_NAME: lambda.logicalId,
+          AWS_LAMBDA_FUNCTION_MEMORY_SIZE: String(lambda.memoryMb),
+          AWS_LAMBDA_FUNCTION_TIMEOUT: String(lambda.timeoutSec),
+          AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
+          AWS_LAMBDA_LOG_GROUP_NAME: `/aws/lambda/${lambda.logicalId}`,
+          AWS_LAMBDA_LOG_STREAM_NAME: 'local',
+          ...forwardAwsEnv(),
+        };
     logger.info(
       `Starting Lambda target container for ${lambda.logicalId} (image=${plan.image}, port=${port})...`
     );
@@ -254,6 +275,8 @@ export function createFrontDoorLambdaRunner(
       image: plan.image,
       mounts: plan.mounts,
       env,
+      ...(opts.sensitiveEnvKeys &&
+        opts.sensitiveEnvKeys.size > 0 && { sensitiveEnvKeys: opts.sensitiveEnvKeys }),
       cmd: plan.cmd,
       hostPort: port,
       host: opts.containerHost,

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartCloudFrontLambdaUrlFromCfnStackStack } from '../lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartCloudFrontLambdaUrlFromCfnStackStack(app, 'CdkLocalStartCfFnUrlFromCfnFixture', {
+  description: 'Fixture stack for cdkl start-cloudfront --from-cfn-stack (Lambda Function URL origin) integ test',
+});

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/cdk.json
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lambda/index.js
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lambda/index.js
@@ -1,0 +1,14 @@
+// Lambda Function URL handler behind a CloudFront distribution. Echoes back
+// the env vars the container saw as a Function URL (payload v2.0) response.
+// The integ asserts TABLE_NAME is the deployed DynamoDB table's physical name
+// (only under --from-cfn-stack) and STATIC_VALUE is the literal.
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      tableName: process.env.TABLE_NAME ?? 'unset',
+      staticValue: process.env.STATIC_VALUE ?? 'unset',
+    }),
+  };
+};

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts
@@ -1,0 +1,77 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import type { Construct } from 'constructs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture stack for `cdkl start-cloudfront --from-cfn-stack` on a Lambda
+ * Function URL origin (issue #380).
+ *
+ * A DynamoDB table + a Lambda whose `Environment.Variables` carries
+ * `TABLE_NAME: Ref MyTable` (an intrinsic resolved from `ListStackResources`
+ * physical IDs only under `--from-cfn-stack`) plus a literal `STATIC_VALUE`.
+ * The Lambda has a Function URL (`AuthType: NONE`), and a CloudFront
+ * distribution fronts it via `origins.FunctionUrlOrigin`.
+ *
+ * `verify.sh` deploys via the upstream `cdk` CLI, then serves the
+ * distribution locally and asserts that a request through the CDN reaches the
+ * Lambda with `TABLE_NAME` resolved to the deployed table's physical name —
+ * proving the front-door Lambda path resolves env vars exactly like
+ * `cdkl invoke --from-cfn-stack`. Without the flag, `TABLE_NAME` is dropped.
+ *
+ * The table carries `removalPolicy: DESTROY` so `cdk destroy` is fully
+ * self-contained.
+ */
+export class LocalStartCloudFrontLambdaUrlFromCfnStackStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const table = new dynamodb.Table(this, 'MyTable', {
+      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const fn = new lambda.Function(this, 'OriginFn', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '..', 'lambda')),
+      environment: {
+        // Intrinsic — only resolvable under --from-cfn-stack (Ref -> the
+        // deployed table's physical name via ListStackResources).
+        TABLE_NAME: table.tableName,
+        // Literal — always present, even without a state source.
+        STATIC_VALUE: 'static-ok',
+      },
+    });
+
+    const fnUrl = fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE });
+
+    const stampHeader = new cloudfront.Function(this, 'StampFn', {
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(
+        [
+          'function handler(event) {',
+          '  var response = event.response;',
+          "  response.headers['x-cdkl-fixture'] = { value: 'lambda-url-from-cfn' };",
+          '  return response;',
+          '}',
+        ].join('\n')
+      ),
+    });
+
+    new cloudfront.Distribution(this, 'ApiDist', {
+      defaultBehavior: {
+        origin: new origins.FunctionUrlOrigin(fnUrl),
+        functionAssociations: [
+          { function: stampHeader, eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE },
+        ],
+      },
+    });
+  }
+}

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/package.json
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-cloudfront-lambda-url-from-cfn-stack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-cloudfront --from-cfn-stack (Lambda Function URL origin, #380)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/tsconfig.json
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/verify.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Real-AWS validation for `cdkl start-cloudfront --from-cfn-stack` on a Lambda
+# Function URL origin (issue #380).
+#
+# The front-door Lambda path (start-cloudfront's Function URL origin) now
+# resolves its container env through the SAME shared helper as `cdkl invoke`,
+# so a Function URL origin Lambda gets its declared env vars + --from-cfn-stack
+# intrinsic substitution + --assume-role creds. The only way to exercise the
+# state round-trip is to deploy via the upstream `cdk` CLI and serve locally.
+#
+# Steps:
+#   1. install + build cdk-local + fixture deps + docker pull
+#   2. pre-flight orphan scan, then cdk deploy (upstream CDK CLI)
+#   3. read the deployed DynamoDB table's physical name from CloudFormation
+#   4. --from-cfn-stack: serve the distribution + curl through the CDN ->
+#      assert the Lambda saw TABLE_NAME == the deployed table name (intrinsic
+#      env var resolved), STATIC_VALUE == the literal, and the viewer-response
+#      header is stamped.
+#   5. baseline (no --from-cfn-stack): assert TABLE_NAME == "unset" (the
+#      intrinsic is dropped) while STATIC_VALUE still passes through.
+#   6. cdk destroy --force + Lambda container / port sweep.
+#
+# Run via `/run-integ local-start-cloudfront-lambda-url-from-cfn-stack`.
+# Requires Docker, AWS credentials with deploy permissions, and the global
+# `cdk` (aws-cdk) CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalStartCfFnUrlFromCfnFixture"
+TARGET="${STACK}/ApiDist"
+IMAGE="public.ecr.aws/lambda/nodejs:20"
+PORT_CFN=18381
+PORT_BASE=18382
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+CDKL_PID=""
+WE_CREATED_STACK=0
+OUT_FILE="$(mktemp)"
+BODY_FILE="$(mktemp)"
+
+stop_server() {
+  if [ -n "${CDKL_PID}" ] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      kill -0 "${CDKL_PID}" 2>/dev/null || break
+      sleep 0.25
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  CDKL_PID=""
+}
+
+cleanup() {
+  rc=$?
+  stop_server
+  # Belt-and-suspenders: remove any Function URL origin Lambda container.
+  docker ps -aq --filter name=cdkl-alblambda- | xargs -r docker rm -f >/dev/null 2>&1 || true
+  if [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] teardown: cdk destroy ${STACK}"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  rm -f "${OUT_FILE}" "${BODY_FILE}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  echo "[verify] FAIL: $*" >&2
+  echo "----- server output -----" >&2
+  cat "${OUT_FILE}" >&2 || true
+  exit 1
+}
+
+# boot_and_get <port> <body-out> [extra cdkl flags...]
+# Boots `cdkl start-cloudfront` and GETs `/` through the CDN once.
+boot_and_get() {
+  local port="$1" body_out="$2"
+  shift 2
+  : > "${OUT_FILE}"
+  if lsof -ti "tcp:${port}" >/dev/null 2>&1; then
+    lsof -ti "tcp:${port}" | xargs -r kill -9 || true
+  fi
+  ${CLI} start-cloudfront "${TARGET}" --port "${port}" --no-pull "$@" > "${OUT_FILE}" 2>&1 &
+  CDKL_PID=$!
+  local booted=0
+  for _ in $(seq 1 240); do
+    if grep -q "CloudFront distribution serving on" "${OUT_FILE}"; then booted=1; break; fi
+    kill -0 "${CDKL_PID}" 2>/dev/null || fail "server exited before it was ready"
+    sleep 0.5
+  done
+  [ "${booted}" -eq 1 ] || fail "server did not print its ready banner in time"
+  curl -fsS -D "${OUT_FILE}.hdr" -o "${body_out}" "http://127.0.0.1:${port}/" || fail "GET / failed"
+  stop_server
+}
+
+echo "[verify] region=${REGION} stack=${STACK}"
+
+echo "[verify] step 1: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+echo "[verify] step 1b: docker available + pull ${IMAGE}"
+docker version --format '{{.Server.Version}}' >/dev/null
+docker pull "${IMAGE}"
+echo "[verify] step 1c: install fixture deps"
+[ -d node_modules ] || vp install --prefer-offline
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists in CloudFormation — clean up first:"
+  echo "          aws cloudformation delete-stack --stack-name ${STACK} --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 2b: cdk deploy (upstream CDK CLI)"
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 2b ok: cdk deploy completed"
+
+echo "[verify] step 3: read the deployed DynamoDB table name"
+DEPLOYED_TABLE=$(aws cloudformation describe-stack-resources \
+  --stack-name "${STACK}" \
+  --region "${REGION}" \
+  --query 'StackResources[?ResourceType==`AWS::DynamoDB::Table`].PhysicalResourceId | [0]' \
+  --output text)
+echo "[verify]   deployed table: ${DEPLOYED_TABLE}"
+[ -n "${DEPLOYED_TABLE}" ] && [ "${DEPLOYED_TABLE}" != "None" ] \
+  || fail "could not read deployed table name from CloudFormation"
+
+echo "[verify] step 4: --from-cfn-stack — serve the distribution + GET / through the CDN"
+boot_and_get "${PORT_CFN}" "${BODY_FILE}" --from-cfn-stack
+echo "[verify]   response: $(cat "${BODY_FILE}")"
+grep -q "\"tableName\":\"${DEPLOYED_TABLE}\"" "${BODY_FILE}" \
+  || fail "--from-cfn-stack did not resolve TABLE_NAME to the deployed table '${DEPLOYED_TABLE}'"
+grep -q '"staticValue":"static-ok"' "${BODY_FILE}" || fail "STATIC_VALUE literal not present"
+grep -qi "x-cdkl-fixture: lambda-url-from-cfn" "${OUT_FILE}.hdr" \
+  || fail "viewer-response header not stamped over the Lambda origin response"
+
+echo "[verify] step 5: baseline (no --from-cfn-stack) — TABLE_NAME drops"
+boot_and_get "${PORT_BASE}" "${BODY_FILE}"
+echo "[verify]   response: $(cat "${BODY_FILE}")"
+grep -q '"tableName":"unset"' "${BODY_FILE}" \
+  || fail "baseline (no --from-cfn-stack) should have dropped the intrinsic TABLE_NAME to 'unset'"
+grep -q '"staticValue":"static-ok"' "${BODY_FILE}" || fail "STATIC_VALUE literal not present in baseline"
+
+rm -f "${OUT_FILE}.hdr"
+echo "[verify] PASS: start-cloudfront --from-cfn-stack resolved the Function URL origin Lambda's intrinsic TABLE_NAME to the deployed table; baseline dropped it."

--- a/tests/unit/cli/lambda-container-env.test.ts
+++ b/tests/unit/cli/lambda-container-env.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { resolveLambdaContainerEnv } from '../../../src/cli/commands/local-invoke.js';
+import type { ResolvedLambda } from '../../../src/local/lambda-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+// Contract test for the shared container-env resolver (issue #380) on its
+// no-state path: a Lambda with literal env vars and no `--from-cfn-stack` /
+// `--assume-role` flag resolves to the AWS_LAMBDA_* base + the literal env,
+// with no AWS call. (The state-substitution + assume-role paths are exercised
+// end to end through `cdkl invoke`'s suite, which now calls this helper, and
+// by the real-AWS from-cfn-stack integ.)
+
+function zipLambda(envVars: Record<string, unknown>): ResolvedLambda {
+  const stack: StackInfo = {
+    stackName: 'Stack',
+    displayName: 'Stack',
+    artifactId: 'Stack',
+    template: { Resources: {} },
+    dependencyNames: [],
+    region: 'us-east-1',
+  };
+  return {
+    kind: 'zip',
+    stack,
+    logicalId: 'Handler',
+    resource: {
+      Type: 'AWS::Lambda::Function',
+      Properties: { Environment: { Variables: envVars } },
+      Metadata: { 'aws:cdk:path': 'Stack/Handler/Resource' },
+    },
+    memoryMb: 256,
+    timeoutSec: 7,
+    layers: [],
+    runtime: 'nodejs20.x',
+    handler: 'index.handler',
+    codePath: '/tmp/code',
+  } as unknown as ResolvedLambda;
+}
+
+describe('resolveLambdaContainerEnv — no-state path', () => {
+  it('resolves literal env vars onto the AWS_LAMBDA_* base, no assume-role', async () => {
+    const result = await resolveLambdaContainerEnv(
+      zipLambda({ GREETING: 'hello', COUNT: 3 }),
+      {},
+      undefined
+    );
+    expect(result.assumeRoleApplied).toBe(false);
+    expect(result.sensitiveEnvKeys).toEqual([]);
+    expect(result.stateForRoleHint).toBeUndefined();
+    expect(result.env['AWS_LAMBDA_FUNCTION_NAME']).toBe('Handler');
+    expect(result.env['AWS_LAMBDA_FUNCTION_MEMORY_SIZE']).toBe('256');
+    expect(result.env['AWS_LAMBDA_FUNCTION_TIMEOUT']).toBe('7');
+    // The function's literal declared env vars are present (coerced to strings).
+    expect(result.env['GREETING']).toBe('hello');
+    expect(result.env['COUNT']).toBe('3');
+    // No state source -> no fallback AWS_REGION jump beyond the synth region.
+    expect(result.env['AWS_REGION']).toBe('us-east-1');
+  });
+
+  it('drops an intrinsic-valued env var without a state source (warn-and-drop)', async () => {
+    const result = await resolveLambdaContainerEnv(
+      zipLambda({ TABLE_NAME: { Ref: 'Table' }, OK: 'literal' }),
+      {},
+      undefined
+    );
+    // The intrinsic is dropped (no --from-cfn-stack to resolve it); the literal survives.
+    expect(result.env['TABLE_NAME']).toBeUndefined();
+    expect(result.env['OK']).toBe('literal');
+  });
+});

--- a/tests/unit/cli/lambda-container-env.test.ts
+++ b/tests/unit/cli/lambda-container-env.test.ts
@@ -1,7 +1,24 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { describe, expect, it, vi } from 'vite-plus/test';
 import { resolveLambdaContainerEnv } from '../../../src/cli/commands/local-invoke.js';
 import type { ResolvedLambda } from '../../../src/local/lambda-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+// Mock STS so the explicit `--assume-role <arn>` path resolves to deterministic
+// temp credentials without a real AWS call (the helper's `assumeLambdaExecutionRole`
+// dynamically imports @aws-sdk/client-sts).
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    async send(): Promise<unknown> {
+      return {
+        Credentials: { AccessKeyId: 'AKIATEST', SecretAccessKey: 'secretTEST', SessionToken: 'tokTEST' },
+      };
+    }
+    destroy(): void {}
+  },
+  AssumeRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
 
 // Contract test for the shared container-env resolver (issue #380) on its
 // no-state path: a Lambda with literal env vars and no `--from-cfn-stack` /
@@ -66,5 +83,22 @@ describe('resolveLambdaContainerEnv — no-state path', () => {
     // The intrinsic is dropped (no --from-cfn-stack to resolve it); the literal survives.
     expect(result.env['TABLE_NAME']).toBeUndefined();
     expect(result.env['OK']).toBe('literal');
+  });
+});
+
+describe('resolveLambdaContainerEnv — explicit --assume-role', () => {
+  it('injects the assumed-role STS credentials into the container env', async () => {
+    const result = await resolveLambdaContainerEnv(
+      zipLambda({ GREETING: 'hi' }),
+      { assumeRole: 'arn:aws:iam::123456789012:role/ExecRole', region: 'us-west-2' },
+      undefined
+    );
+    expect(result.assumeRoleApplied).toBe(true);
+    expect(result.env['AWS_ACCESS_KEY_ID']).toBe('AKIATEST');
+    expect(result.env['AWS_SECRET_ACCESS_KEY']).toBe('secretTEST');
+    expect(result.env['AWS_SESSION_TOKEN']).toBe('tokTEST');
+    expect(result.env['AWS_REGION']).toBe('us-west-2');
+    // The declared env var still rides alongside the creds.
+    expect(result.env['GREETING']).toBe('hi');
   });
 });

--- a/tests/unit/cli/local-start-cloudfront-boot.test.ts
+++ b/tests/unit/cli/local-start-cloudfront-boot.test.ts
@@ -5,17 +5,30 @@ import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 // Mock the two external boundaries `bootLambdaUrlOrigins` drives: the Lambda
 // resolver and the RIE runner factory. We assert the orchestration (dedup,
 // pure-S3 short-circuit, partial-boot rollback) without any Docker.
-const { resolveLambdaTargetMock, createRunnerMock, runners } = vi.hoisted(() => ({
-  resolveLambdaTargetMock: vi.fn(),
-  createRunnerMock: vi.fn(),
-  runners: [] as Array<{ logicalId: string; start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn>; invoke: ReturnType<typeof vi.fn> }>,
-}));
+const { resolveLambdaTargetMock, createRunnerMock, resolveContainerEnvMock, runners } = vi.hoisted(
+  () => ({
+    resolveLambdaTargetMock: vi.fn(),
+    createRunnerMock: vi.fn(),
+    resolveContainerEnvMock: vi.fn(),
+    runners: [] as Array<{
+      logicalId: string;
+      start: ReturnType<typeof vi.fn>;
+      stop: ReturnType<typeof vi.fn>;
+      invoke: ReturnType<typeof vi.fn>;
+    }>,
+  })
+);
 
 vi.mock('../../../src/local/lambda-resolver.js', () => ({
   resolveLambdaTarget: resolveLambdaTargetMock,
 }));
 vi.mock('../../../src/local/front-door-lambda-runner.js', () => ({
   createFrontDoorLambdaRunner: createRunnerMock,
+}));
+// bootLambdaUrlOrigins imports ONLY `resolveLambdaContainerEnv` (a value) from
+// local-invoke.js — the rest are erased types — so a minimal module mock is safe.
+vi.mock('../../../src/cli/commands/local-invoke.js', () => ({
+  resolveLambdaContainerEnv: resolveContainerEnvMock,
 }));
 
 const { bootLambdaUrlOrigins } = await import(
@@ -35,13 +48,21 @@ function distributionWith(origins: ResolvedOrigin[]): ResolvedDistribution {
 const stacks: StackInfo[] = [
   { stackName: 'Stack', displayName: 'Stack', artifactId: 'Stack', template: {}, dependencyNames: [] },
 ];
-const bootOpts = { containerHost: '127.0.0.1', skipPull: false };
+const bootOpts = { containerHost: '127.0.0.1', skipPull: false, envOptions: {} };
 
 beforeEach(() => {
   resolveLambdaTargetMock.mockReset();
   createRunnerMock.mockReset();
+  resolveContainerEnvMock.mockReset();
   runners.length = 0;
   resolveLambdaTargetMock.mockImplementation((id: string) => ({ logicalId: id }));
+  // The shared env resolver is exercised in its own tests; here it is a stub so
+  // the orchestration (dedup / rollback) is isolated from state/STS resolution.
+  resolveContainerEnvMock.mockResolvedValue({
+    env: {},
+    sensitiveEnvKeys: [],
+    assumeRoleApplied: false,
+  });
   createRunnerMock.mockImplementation((lambda: { logicalId: string }) => {
     const runner = {
       logicalId: lambda.logicalId,
@@ -62,6 +83,39 @@ describe('bootLambdaUrlOrigins', () => {
     expect(r).toHaveLength(0);
     expect(createRunnerMock).not.toHaveBeenCalled();
     expect(resolveLambdaTargetMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves the container env per backing Lambda and threads it into the runner (issue #380)', async () => {
+    resolveContainerEnvMock.mockResolvedValue({
+      env: { TABLE_NAME: 'deployed-table', AWS_ACCESS_KEY_ID: 'AKIA' },
+      sensitiveEnvKeys: ['SECRET_VALUE'],
+      assumeRoleApplied: true,
+    });
+    const dist = distributionWith([
+      { kind: 'lambda-url', originId: 'a', functionLogicalId: 'Fn', functionUrlLogicalId: 'FnUrl' },
+    ]);
+    const envOptions = { fromCfnStack: 'MyStack', assumeRole: true as const, region: 'us-east-1' };
+    const profileCredentials = { accessKeyId: 'AK', secretAccessKey: 'SK' };
+    await bootLambdaUrlOrigins(dist, stacks, {
+      containerHost: '127.0.0.1',
+      skipPull: false,
+      envOptions,
+      profileCredentials,
+    });
+    // The shared resolver is called with the resolved Lambda + the threaded
+    // state/assume-role options + the profile credentials.
+    expect(resolveContainerEnvMock).toHaveBeenCalledWith(
+      { logicalId: 'Fn' },
+      envOptions,
+      profileCredentials
+    );
+    // The resolver's env + sensitive keys reach the runner factory.
+    const runnerOpts = createRunnerMock.mock.calls[0]![1];
+    expect(runnerOpts.containerEnv).toEqual({
+      TABLE_NAME: 'deployed-table',
+      AWS_ACCESS_KEY_ID: 'AKIA',
+    });
+    expect(runnerOpts.sensitiveEnvKeys).toEqual(new Set(['SECRET_VALUE']));
   });
 
   it('boots one runner per UNIQUE backing function (dedups shared functions)', async () => {

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -287,11 +287,15 @@ describe('start-cloudfront option surface contract (addStartCloudFrontSpecificOp
   it('addStartCloudFrontSpecificOptions registers exactly the known start-cloudfront-only flags', () => {
     const flags = longFlagsOf(addStartCloudFrontSpecificOptions(new Command()));
     expect(flags).toEqual([
+      // Issue #380 — full env/state/role parity for a Function URL origin Lambda.
+      '--assume-role',
+      '--from-cfn-stack',
       '--host',
       // Issue #376 — skip the docker pull for a Lambda Function URL origin image.
       '--no-pull',
       '--origin',
       '--port',
+      '--stack-region',
       '--tls',
       '--tls-cert',
       '--tls-key',

--- a/tests/unit/local/front-door-lambda-runner.test.ts
+++ b/tests/unit/local/front-door-lambda-runner.test.ts
@@ -87,6 +87,29 @@ describe('createFrontDoorLambdaRunner', () => {
     expect(waitForRieReadyMock).toHaveBeenCalledWith('127.0.0.1', 54321, 30_000);
   });
 
+  it('uses a caller-provided containerEnv overlay + forwards sensitiveEnvKeys (issue #380)', async () => {
+    const containerEnv = {
+      AWS_LAMBDA_FUNCTION_NAME: 'EchoFn',
+      TABLE_NAME: 'deployed-table',
+      AWS_ACCESS_KEY_ID: 'AKIA',
+      SECRET_VALUE: 'shh',
+    };
+    const runner = createFrontDoorLambdaRunner(zipLambda(), {
+      containerHost: '127.0.0.1',
+      containerEnv,
+      sensitiveEnvKeys: new Set(['SECRET_VALUE']),
+    });
+    await runner.start();
+
+    const runArgs = runDetachedMock.mock.calls[0]![0];
+    // The overlay REPLACES the runner's default base (it already carries the
+    // AWS_LAMBDA_* identity vars from resolveLambdaContainerEnv).
+    expect(runArgs.env).toEqual(containerEnv);
+    expect(runArgs.env.TABLE_NAME).toBe('deployed-table');
+    // Sensitive keys are forwarded so they stay off the docker run argv.
+    expect(runArgs.sensitiveEnvKeys).toEqual(new Set(['SECRET_VALUE']));
+  });
+
   it('is idempotent — a second start() does not boot a second container', async () => {
     const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
     await runner.start();


### PR DESCRIPTION
## Summary

A Lambda Function URL origin (`cdkl start-cloudfront`, #376) ran its backing
Lambda through the shared `front-door-lambda-runner`, which only injected
`AWS_LAMBDA_*` + the dev shell's AWS creds — **no declared env vars, no
`--from-cfn-stack` state substitution, no `--assume-role`**. A CDN-fronted
Lambda that depends on env vars or real deployed resources could not be
tested end to end.

This brings the front-door Lambda path (start-cloudfront's Function URL
origin) to the SAME container-env parity as `cdkl invoke`, via a **single
source of truth** — no second implementation to drift:

1. **Extract** the env + state-substitution + assume-role + container-env
   assembly that was inline in `local-invoke.ts` into an exported
   `resolveLambdaContainerEnv(lambda, options, profileCredentials)` and
   **rewire `cdkl invoke` onto it** (behavior-preserving — the invoke suite
   stays green). The helper resolves: declared `Environment.Variables`
   (literal + `--env-vars`), `--from-cfn-stack` intrinsic substitution (SSM
   / cross-stack / deployed-env fallback), `--assume-role` STS creds (bare
   auto-resolves the execution role from state), else forwarded shell /
   `--profile` creds, + a fallback `AWS_REGION`.
2. **`front-door-lambda-runner`** gains an optional pre-resolved
   `containerEnv` overlay + `sensitiveEnvKeys` (the runner stays dumb; the
   caller resolves — when present, the overlay REPLACES the env base, which
   the helper already populates with the `AWS_LAMBDA_*` identity vars).
3. **`start-cloudfront`** gains `--from-cfn-stack [name]` /
   `--assume-role [arn]` / `--stack-region`; `bootLambdaUrlOrigins` calls the
   shared helper per Function URL Lambda and threads the resolved env into
   the runner.

A pure-S3 distribution is unaffected (no Function URL origin → no resolve,
no Docker). `--profile` shapes the forwarded creds. `AWS_IAM` auth on the
Function URL is still not enforced; response streaming is buffered.

### Behavior change (additive)

`cdkl invoke` behavior is unchanged (the extraction is a faithful lift; its
existing tests stay green). `start-cloudfront`'s Function URL origin Lambda
now gets env / state / role injection instead of an empty env — purely
additive (a previously-dropped env var now resolves). A host CLI that wraps
`start-cloudfront` (e.g. cdkd's thin wrapper) inherits the new flags +
behavior automatically on its next `cdk-local` dependency bump; no host code
change needed. `resolveLambdaContainerEnv` / `LambdaContainerEnvOptions` are
exported from `src/cli/commands/local-invoke.ts` and consumed cross-command;
they live under `src/cli/commands/**` (not a new `src/local/**` file), so no
`src/internal.ts` re-export — a host wraps the command factories, not this
helper.

## Slice B (follow-up, NOT in this PR)

- Wire `start-alb`'s existing `--from-cfn-stack` / `--assume-role` through to
  its Lambda target groups via the same shared helper (same `front-door-lambda-runner`).
- Forward the studio session bindings to the `cloudfront` serve kind (drop
  `omitStateBindings`, now that start-cloudfront declares the flags).

## Test plan

- `vp run check` — pass (typecheck + lint + format, 129 files).
- `vp test run` — 2649 unit tests pass, incl. new direct coverage for the
  shared resolver (no-state drop + explicit `--assume-role` STS injection,
  mocked STS), the runner `containerEnv` overlay branch (overlay replaces
  base + `sensitiveEnvKeys` → `runDetached`), the boot-path threading
  (`envOptions` + `profileCredentials` reach the resolver; resolved env →
  runner), and the 3 new flags' option-surface contract. The invoke rewire
  is regression-checked by its existing suite.
- `vp run build` — green.
- **Real-AWS integ** `local-start-cloudfront-lambda-url-from-cfn-stack` —
  PASS. Deploys a DynamoDB table + a Lambda (env `TABLE_NAME` = a `Ref`
  intrinsic) behind a Function URL + CloudFront distribution via the upstream
  `cdk` CLI, serves the distribution locally, and asserts a request through
  the CDN reaches the Function URL origin Lambda with `TABLE_NAME` resolved
  to the deployed table's physical name under `--from-cfn-stack` (and dropped
  to `"unset"` in the baseline). cdk destroy clean, 0 orphan stack / 0 Docker
  orphans.

## Review

3-axis (spec / code / test). Spec: PASS (invoke rewire verified
behavior-preserving step by step). Addressed from review: the integ Lambda
handler was gitignored and uncommitted (force-added — was a blocker for a
fresh checkout); the assume-role STS branch and the runner `containerEnv`
overlay branch gained direct unit tests; the runner JSDoc was corrected
(replaces, not overlays).

Part of #380 (slice A). Implements the `start-cloudfront` half; `start-alb` +
studio follow in slice B.
