### PR TITLE
feat(studio): image-override Dockerfile picker for an ALB's pinned backing services

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -433,6 +433,9 @@ compute-locally category for Lambda + API Gateway).
   UI at `/`, the synthesized target list (+ the boot-discovered
   Dockerfiles + a `pinned` flag per ecs service — set by
   `annotatePinnedEcsTargets` — for the image-override picker, issue #301;
+  plus `backingPinnedServices` per alb entry — set by
+  `annotateAlbPinnedBackingServices`, issue #382 — for the ALB's
+  per-backing-service image-override picker;
   CDK custom-resource / provider-framework Lambdas are excluded by
   default via `filterStudioCustomResources`, issue #323 — pass
   `cdkl studio --include-custom-resources` to surface them)
@@ -505,7 +508,17 @@ compute-locally category for Lambda + API Gateway).
   studio's child has no TTY, so the bare picker form would be skipped) onto
   the serve body so `start-service` rebuilds the pinned image from local
   source; a local-asset service (which already hot-reloads under `--watch`)
-  gets no picker (issue #301); the
+  gets no picker (issue #301). An `alb` serve gets the SAME picker for its
+  pinned BACKING services (issue #382): `start-alb` boots the ALB's backing
+  ECS services, so studio resolves each ALB (`resolveAlbFrontDoor`) to its
+  backing services at boot, intersects them with the pinned `ecs` set
+  (`annotateAlbPinnedBackingServices` + `makeAlbBackingPinnedResolver`), and
+  the alb composer offers ONE Dockerfile picker per pinned backing service
+  (`buildAlbImageOverridePicker`) — threading a per-service
+  `imageOverrides` map (`{ Stack:LogicalId -> dockerfile }`, one
+  `--image-override <service>=<dockerfile>` each, the service key being
+  start-alb's own service-boot target) so a pinned service rebuilds from
+  local source while running behind the ALB; the
   timeline carries both Lambda invocations and captured serve requests;
   clicking a past Lambda / AgentCore row reloads it into the composer
   pre-filled + wired to re-invoke (issue #284, the [Re-invoke] button ->

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -27,8 +27,11 @@ import {
   toStudioTargetGroups,
   filterStudioTargetGroups,
   annotatePinnedEcsTargets,
+  annotateAlbPinnedBackingServices,
   type RunningStudioServer,
 } from '../../local/studio-server.js';
+import { resolveAlbFrontDoor } from '../../local/elb-front-door-resolver.js';
+import { resolveAlbTarget } from './local-start-alb.js';
 import { filterStudioCustomResources } from '../../local/studio-custom-resource-filter.js';
 import {
   createStudioDispatcher,
@@ -83,7 +86,7 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
   if (typeof body !== 'object' || body === null) {
     throw new Error('Request body must be a JSON object.');
   }
-  const { targetId, kind, event, options, rawArgs, imageOverride } = body as Record<
+  const { targetId, kind, event, options, rawArgs, imageOverride, imageOverrides } = body as Record<
     string,
     unknown
   >;
@@ -122,6 +125,28 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     }
     if (imageOverride.trim() !== '') runImageOverride = imageOverride;
   }
+  // Per-backing-service image overrides for an `alb` serve (issue #382): a map
+  // of `Stack:LogicalId` -> Dockerfile path. Validate at the boundary so a
+  // malformed map fails as a clean 400; drop blank values (the "(keep pinned
+  // image)" picker choice).
+  let runImageOverrides: Record<string, string> | undefined;
+  if (imageOverrides !== undefined) {
+    if (
+      typeof imageOverrides !== 'object' ||
+      imageOverrides === null ||
+      Array.isArray(imageOverrides)
+    ) {
+      throw new Error('Request body "imageOverrides" must be a JSON object keyed by service id.');
+    }
+    const collected: Record<string, string> = {};
+    for (const [svc, df] of Object.entries(imageOverrides as Record<string, unknown>)) {
+      if (typeof df !== 'string') {
+        throw new Error(`Request body "imageOverrides.${svc}" must be a string.`);
+      }
+      if (df.trim() !== '') collected[svc] = df.trim();
+    }
+    if (Object.keys(collected).length > 0) runImageOverrides = collected;
+  }
   return {
     targetId,
     kind: kind as StudioTargetKind,
@@ -129,6 +154,7 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     ...(runOptions !== undefined ? { options: runOptions } : {}),
     ...(runRawArgs !== undefined ? { rawArgs: runRawArgs } : {}),
     ...(runImageOverride !== undefined ? { imageOverride: runImageOverride } : {}),
+    ...(runImageOverrides !== undefined ? { imageOverrides: runImageOverrides } : {}),
   };
 }
 
@@ -553,6 +579,66 @@ export function makePinClassifier(args: {
   };
 }
 
+/**
+ * Build the boot-time resolver `annotateAlbPinnedBackingServices` calls per
+ * `alb` entry (issue #382). It resolves the ALB to its backing ECS services
+ * (`resolveAlbFrontDoor`, template-only) and returns the subset that is in
+ * `pinnedEcsByQualifiedId` — the `ecs` services already classified as a
+ * deployed-registry pin by {@link makePinClassifier}. Each returned `id` is the
+ * service's `Stack:LogicalId` (the `--image-override` key `start-alb` matches
+ * against its own service-boot target); `label` is the pinned service's display
+ * id. An ALB that cannot be resolved is WARN-logged + contributes no pickers
+ * (the start-alb run still works; only the picker is absent). Exported for
+ * testing.
+ */
+export function makeAlbBackingPinnedResolver(args: {
+  stacks: StackInfo[];
+  pinnedEcsByQualifiedId: Map<string, string>;
+  logger: ReturnType<typeof getLogger>;
+}): (albEntry: { id: string; qualifiedId: string }) => { id: string; label: string }[] {
+  const { stacks, pinnedEcsByQualifiedId, logger } = args;
+  return (albEntry) => {
+    // No pinned ecs services => nothing an ALB picker could rebuild.
+    if (pinnedEcsByQualifiedId.size === 0) return [];
+    try {
+      const { stack, albLogicalId } = resolveAlbTarget(albEntry.id, stacks);
+      const resolution = resolveAlbFrontDoor(stack, albLogicalId);
+      // Collect the distinct ECS-service targets the ALB forwards to (default
+      // action + every rule action; redirect / fixed-response / lambda targets
+      // carry no backing ECS service).
+      const serviceQualifiedIds = new Set<string>();
+      for (const listener of resolution.listeners) {
+        const actions = [
+          ...(listener.defaultAction ? [listener.defaultAction] : []),
+          ...listener.rules.map((r) => r.action),
+        ];
+        for (const action of actions) {
+          if (action.kind !== 'forward') continue;
+          for (const t of action.targets) {
+            if (t.kind === 'ecs') {
+              serviceQualifiedIds.add(`${stack.stackName}:${t.serviceLogicalId}`);
+            }
+          }
+        }
+      }
+      const out: { id: string; label: string }[] = [];
+      for (const qid of serviceQualifiedIds) {
+        const label = pinnedEcsByQualifiedId.get(qid);
+        if (label !== undefined) out.push({ id: qid, label });
+      }
+      return out;
+    } catch (err) {
+      logger.warn(
+        `studio: could not resolve ALB '${albEntry.id}' backing services for the image-override ` +
+          `picker; the alb composer will not offer one. ${
+            err instanceof Error ? err.message : String(err)
+          }`
+      );
+      return [];
+    }
+  };
+}
+
 interface LocalStudioOptions {
   app?: string;
   output: string;
@@ -725,7 +811,31 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     targetGroups,
     makePinClassifier({ stacks, contextByStack, logger })
   );
-  const dockerfiles = anyPinned ? discoverDockerfiles(process.cwd()) : [];
+
+  // Issue #382 — offer the image-override Dockerfile picker on the ALB
+  // composer too, not only on a standalone `ecs` service. `start-alb` boots
+  // the ALB's backing ECS services, so a pinned (deployed-registry) backing
+  // service has the same "local source edits do not take effect" problem a
+  // standalone pinned service does. Resolve each ALB to its backing ECS
+  // services and intersect with the pinned `ecs` set classified above; a
+  // pinned backing service becomes a per-service picker on the alb composer
+  // that threads `--image-override <Stack:LogicalId>=<dockerfile>` to the
+  // spawned `start-alb` (the `Stack:LogicalId` key is start-alb's own
+  // service-boot target). ALB resolution is template-only, but the pinned set
+  // it intersects is empty without `--from-cfn-stack` for INTRINSIC-ECR
+  // services — same boot-time-only caveat as the ecs picker.
+  const pinnedEcsByQualifiedId = new Map<string, string>();
+  for (const g of targetGroups) {
+    if (g.kind !== 'ecs') continue;
+    for (const e of g.entries) {
+      if (e.pinned) pinnedEcsByQualifiedId.set(e.qualifiedId, e.id);
+    }
+  }
+  const anyAlbBackingPinned = annotateAlbPinnedBackingServices(
+    targetGroups,
+    makeAlbBackingPinnedResolver({ stacks, pinnedEcsByQualifiedId, logger })
+  );
+  const dockerfiles = anyPinned || anyAlbBackingPinned ? discoverDockerfiles(process.cwd()) : [];
 
   const bus = new StudioEventBus();
   // `process.argv[1]` is the running CLI entry (`dist/cli.js` / the `cdkl`

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -768,6 +768,7 @@ export {
   toStudioTargetGroups,
   filterStudioTargetGroups,
   annotatePinnedEcsTargets,
+  annotateAlbPinnedBackingServices,
   type StudioServerOptions,
   type RunningStudioServer,
   type StudioTarget,

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -45,6 +45,15 @@ export interface StudioRunRequest {
    */
   imageOverride?: string;
   /**
+   * Per-backing-service Dockerfile paths for an `alb` serve target's
+   * image-override pickers (issue #382), keyed by the service's
+   * `Stack:LogicalId` (the `--image-override` key `start-alb` matches). An ALB
+   * boots multiple backing ECS services, so unlike the single `imageOverride`
+   * this is a map — one `--image-override <service>=<dockerfile>` is threaded
+   * per entry. Serve-only.
+   */
+  imageOverrides?: Record<string, string>;
+  /**
    * Issue #284: when this run is a re-invoke of a past timeline row, the
    * source invocation id. Threaded verbatim into the emitted `invocation`
    * start + end events as `reinvokeOf` so the UI links the new row to its

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -33,6 +33,14 @@ export interface StudioServeRequest {
    * single booted service is the override target. Ignored when blank.
    */
   imageOverride?: string;
+  /**
+   * Per-backing-service Dockerfile paths for an `alb` serve (issue #382), keyed
+   * by the backing service's `Stack:LogicalId` (the `--image-override` key
+   * `start-alb` matches against its own service-boot target). One
+   * `--image-override <service>=<dockerfile>` is appended per entry so the
+   * ALB's pinned backing services rebuild from local source. Ignored when empty.
+   */
+  imageOverrides?: Record<string, string>;
 }
 
 /** A request to stop a running served target. */
@@ -342,6 +350,15 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       ...(req.imageOverride && req.imageOverride.trim() !== ''
         ? ['--image-override', req.targetId + '=' + req.imageOverride.trim()]
         : []),
+      // Per-backing-service image-override for an `alb` serve (issue #382): an
+      // ALB boots multiple backing ECS services, so the alb composer's per-
+      // service pickers thread one explicit `--image-override <service>=<df>`
+      // each. The service key is the backing service's `Stack:LogicalId` —
+      // exactly start-alb's own service-boot target — so the override engine
+      // matches it without an orphan-flag failure.
+      ...Object.entries(req.imageOverrides ?? {}).flatMap(([svc, df]) =>
+        df && df.trim() !== '' ? ['--image-override', svc + '=' + df.trim()] : []
+      ),
       // `cdkl studio --watch` (issue #301): every serve kind (start-api /
       // start-alb / start-service) implements `--watch` rolling reload, so
       // forwarding the bare flag makes a UI-started serve hot-reload on source

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -34,6 +34,19 @@ export interface StudioTarget {
    * `--watch`) is not marked and gets no picker.
    */
   pinned?: boolean;
+  /**
+   * Set on an `alb` entry: the deployed-registry-pinned ECS services this ALB
+   * fronts (issue #382). `start-alb` boots the ALB's backing services, so a
+   * pinned backing service has the same "local edits do not take effect"
+   * problem a standalone pinned `ecs` service does — the alb composer offers a
+   * per-service Dockerfile picker that threads
+   * `--image-override <service-qualified-id>=<dockerfile>` to the spawned
+   * `start-alb` (the `<service-qualified-id>` is `start-alb`'s own
+   * `Stack:LogicalId` service-boot target). Each entry's `id` is that
+   * `--image-override` key; `label` is a human-readable service name. Absent /
+   * empty when the ALB fronts no pinned service.
+   */
+  backingPinnedServices?: { id: string; label: string }[];
 }
 
 /** A category of targets, grouped by the studio kind that runs them. */
@@ -116,6 +129,38 @@ export function annotatePinnedEcsTargets(
     }
   }
   return anyPinned;
+}
+
+/**
+ * Annotate each `alb` entry of `groups` with the deployed-registry-pinned ECS
+ * services that ALB fronts (issue #382), so the alb composer can offer a
+ * per-service image-override Dockerfile picker. `resolveBackingPinned` maps one
+ * ALB entry to its pinned backing services (`{ id, label }`, where `id` is the
+ * `--image-override` key — `start-alb`'s `Stack:LogicalId` service-boot
+ * target); the caller supplies it (studio's boot resolves the ALB via
+ * `resolveAlbFrontDoor` and intersects the backing services with the already-
+ * classified pinned `ecs` set). Mutates the entries in place and returns whether
+ * ANY ALB fronts a pinned service, so the caller can include the Dockerfile
+ * scan even when no standalone `ecs` service was pinned. Non-alb groups are
+ * left untouched. Exported so a host CLI can reuse it + so the boot logic is
+ * unit-testable without a real synth.
+ */
+export function annotateAlbPinnedBackingServices(
+  groups: StudioTargetGroup[],
+  resolveBackingPinned: (albEntry: StudioTarget) => { id: string; label: string }[]
+): boolean {
+  let any = false;
+  for (const group of groups) {
+    if (group.kind !== 'alb') continue;
+    for (const entry of group.entries) {
+      const pinned = resolveBackingPinned(entry);
+      if (pinned.length > 0) {
+        entry.backingPinnedServices = pinned;
+        any = true;
+      }
+    }
+  }
+  return any;
 }
 
 /** Compile a `*` / `?` glob to an anchored RegExp matched against a target id. */

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -783,6 +783,14 @@ const STUDIO_SCRIPT = `
     if (applied && applied.imageOverride) {
       lines.push('--image-override ' + applied.imageOverride);
     }
+    // An alb serve threads a per-backing-service imageOverrides map (issue
+    // #382); surface one --image-override line each so the picks do not
+    // silently vanish from the running view (the issue #356 contract).
+    if (applied && applied.imageOverrides) {
+      Object.keys(applied.imageOverrides).forEach(function (svc) {
+        lines.push('--image-override ' + svc + '=' + applied.imageOverrides[svc]);
+      });
+    }
     if (applied && applied.rawArgs) {
       const raw = String(applied.rawArgs).trim();
       if (raw !== '') lines.push(raw);

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -484,11 +484,12 @@ const STUDIO_SCRIPT = `
   // --image-override flag to start-service so the deployed-registry-pinned
   // image is rebuilt from local source. Default "(keep pinned image)" => no
   // override.
-  function buildImageOverridePicker() {
-    const sec = el('div', 'section options');
-    sec.appendChild(el('h3', null, 'Image override'));
+  // One labeled Dockerfile <select> row (the discovered Dockerfiles + a
+  // "(keep pinned image)" default). Shared by the ecs single picker and the
+  // alb per-backing-service pickers.
+  function buildImageOverrideRow(labelText) {
     const row = el('div', 'opt-row');
-    row.appendChild(el('span', 'opt-label', 'Local Dockerfile'));
+    row.appendChild(el('span', 'opt-label', labelText));
     const sel = el('select', 'image-override-select');
     const none = el('option', null, '(keep pinned image)');
     none.value = '';
@@ -499,7 +500,19 @@ const STUDIO_SCRIPT = `
       sel.appendChild(o);
     });
     row.appendChild(sel);
-    sec.appendChild(row);
+    return {
+      row: row,
+      getValue: function () {
+        return sel.value.trim();
+      },
+    };
+  }
+
+  function buildImageOverridePicker() {
+    const sec = el('div', 'section options');
+    sec.appendChild(el('h3', null, 'Image override'));
+    const r = buildImageOverrideRow('Local Dockerfile');
+    sec.appendChild(r.row);
     const hint = studioDockerfiles.length
       ? 'This image is pinned to a deployed registry — local edits do not take effect. Pick a Dockerfile to rebuild it locally.'
       : 'This image is pinned to a deployed registry, but no Dockerfile was found under the app directory.';
@@ -507,8 +520,37 @@ const STUDIO_SCRIPT = `
     return {
       node: sec,
       collect: function () {
-        const v = sel.value.trim();
+        const v = r.getValue();
         return v === '' ? undefined : v;
+      },
+    };
+  }
+
+  // Per-backing-service image-override pickers for a pinned ALB (issue #382):
+  // one Dockerfile select per deployed-registry-pinned service the ALB fronts.
+  // collect() returns a { [serviceId]: dockerfile } map threaded as
+  // imageOverrides (one --image-override service=df per entry).
+  function buildAlbImageOverridePicker(services) {
+    const sec = el('div', 'section options');
+    sec.appendChild(el('h3', null, 'Image override (pinned backing services)'));
+    const rows = services.map(function (svc) {
+      const r = buildImageOverrideRow(svc.label);
+      sec.appendChild(r.row);
+      return { id: svc.id, getValue: r.getValue };
+    });
+    const hint = studioDockerfiles.length
+      ? 'These services behind the ALB are pinned to a deployed registry — local edits do not take effect. Pick a Dockerfile to rebuild one from local source.'
+      : 'These services behind the ALB are pinned to a deployed registry, but no Dockerfile was found under the app directory.';
+    sec.appendChild(el('div', 'opt-hint', hint));
+    return {
+      node: sec,
+      collect: function () {
+        const map = {};
+        rows.forEach(function (r) {
+          const v = r.getValue();
+          if (v !== '') map[r.id] = v;
+        });
+        return Object.keys(map).length ? map : undefined;
       },
     };
   }
@@ -598,7 +640,13 @@ const STUDIO_SCRIPT = `
             t.appendChild(btnSlot);
             t.onclick = () => selectTarget(entry.id, group.kind);
             targetEls.set(entry.id, t);
-            serveMeta.set(entry.id, { dot, btnSlot, kind: group.kind, pinned: entry.pinned === true });
+            serveMeta.set(entry.id, {
+              dot,
+              btnSlot,
+              kind: group.kind,
+              pinned: entry.pinned === true,
+              backingPinnedServices: entry.backingPinnedServices || [],
+            });
             updateServeRow(entry.id);
           }
           body.appendChild(t);
@@ -742,7 +790,7 @@ const STUDIO_SCRIPT = `
     return lines;
   }
 
-  async function startServe(id, options, rawArgs, imageOverride) {
+  async function startServe(id, options, rawArgs, imageOverride, imageOverrides) {
     // The serve kind (api / alb / ecs) drives which headless command the
     // server spawns; it is recorded on the row when the target list loads.
     const meta = serveMeta.get(id);
@@ -750,7 +798,12 @@ const STUDIO_SCRIPT = `
     // Remember what this serve was Started with so the running workspace can
     // show a read-only "Started with" summary (issue #356) — the per-run
     // option inputs are gone once the composer is replaced by the running view.
-    serveApplied.set(id, { options: options, rawArgs: rawArgs, imageOverride: imageOverride });
+    serveApplied.set(id, {
+      options: options,
+      rawArgs: rawArgs,
+      imageOverride: imageOverride,
+      imageOverrides: imageOverrides,
+    });
     serveState.set(id, { status: 'starting', endpoints: [] });
     updateServeRow(id);
     try {
@@ -758,6 +811,7 @@ const STUDIO_SCRIPT = `
       if (options) body.options = options;
       if (rawArgs) body.rawArgs = rawArgs;
       if (imageOverride) body.imageOverride = imageOverride;
+      if (imageOverrides) body.imageOverrides = imageOverrides;
       const res = await fetch('/api/run', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -833,6 +887,7 @@ const STUDIO_SCRIPT = `
     let collectOpts = function () { return undefined; };
     let collectRaw = function () { return undefined; };
     let collectImageOverride = function () { return undefined; };
+    let collectImageOverrides = function () { return undefined; };
     btn.onclick = () => {
       if (running || starting) {
         stopServe(id);
@@ -843,7 +898,7 @@ const STUDIO_SCRIPT = `
         serveState.set(id, { status: 'stopped', endpoints: [] });
         renderServeWorkspace(id);
       } else {
-        startServe(id, collectOpts(), collectRaw(), collectImageOverride());
+        startServe(id, collectOpts(), collectRaw(), collectImageOverride(), collectImageOverrides());
       }
     };
     head.appendChild(btn);
@@ -862,6 +917,15 @@ const STUDIO_SCRIPT = `
         const io = buildImageOverridePicker();
         ws.appendChild(io.node);
         collectImageOverride = io.collect;
+      }
+      // An ALB boots its backing ECS services (issue #382); a pinned backing
+      // service has the same "local edits do not take effect" problem, so offer
+      // a per-service Dockerfile picker that threads
+      // --image-override service=dockerfile to start-alb.
+      if (meta && meta.kind === 'alb' && meta.backingPinnedServices && meta.backingPinnedServices.length) {
+        const io = buildAlbImageOverridePicker(meta.backingPinnedServices);
+        ws.appendChild(io.node);
+        collectImageOverrides = io.collect;
       }
       const opt = buildOptions(kind);
       if (opt.node) ws.appendChild(opt.node);

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1306,6 +1306,74 @@ sleep 3
 echo "    OK: image-override service stopped"
 
 # ---------------------------------------------------------------------------
+# 10d. ALB image-override picker (issue #382): MyAlb fronts the pinned
+#      MyService. Studio resolves the ALB's backing ECS services + offers a
+#      per-service Dockerfile picker on the ALB composer, threading
+#      `--image-override <Stack:LogicalId>=./Dockerfile.override` to start-alb.
+#      The override key is read back from /api/targets (the alb entry's
+#      backingPinnedServices[].id — start-alb's own service-boot target), which
+#      also proves the boot resolver populated it. Then the ALB is started with
+#      that imageOverrides map + the front-door is curled: the sentinel proves
+#      the backing pinned service was REBUILT from local source while running
+#      BEHIND the ALB (the picker -> /api/run -> imageOverrides ->
+#      --image-override -> start-alb rebuild path end-to-end).
+# ---------------------------------------------------------------------------
+echo "==> ALB image-override: /api/targets exposes the ALB's pinned backing services (issue #382)"
+curl -fsS "${URL}/api/targets" -o "${BODY_FILE}"
+ALB_SVC_KEY=$(python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1])); tgt = sys.argv[2]
+for g in d["groups"]:
+    if g["kind"] != "alb":
+        continue
+    for e in g["entries"]:
+        if e["id"] == tgt:
+            bs = e.get("backingPinnedServices") or []
+            if bs:
+                print(bs[0]["id"])
+' "${BODY_FILE}" "${ALB_TARGET}")
+if [[ -z "${ALB_SVC_KEY}" ]]; then
+  echo "FAIL: /api/targets did not expose backingPinnedServices for ${ALB_TARGET}"
+  echo "----- targets -----"; cat "${BODY_FILE}"; echo "-------------------"
+  exit 1
+fi
+echo "    OK: ${ALB_TARGET} backing pinned service resolved = ${ALB_SVC_KEY}"
+
+echo "==> POST /api/run starts the ALB with imageOverrides; the backing service rebuilds from a local Dockerfile"
+AIO_FILE=$(mktemp)
+HTTP_AIO=$(curl -s -o "${AIO_FILE}" -w '%{http_code}' --max-time 300 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ALB_TARGET}\",\"kind\":\"alb\",\"imageOverrides\":{\"${ALB_SVC_KEY}\":\"./Dockerfile.override\"}}" || true)
+if [[ "${HTTP_AIO}" != "200" ]] || ! grep -qF '"status":"running"' "${AIO_FILE}"; then
+  echo "FAIL: POST /api/run (alb image-override) returned HTTP ${HTTP_AIO}"
+  echo "----- response -----"; cat "${AIO_FILE}"; echo "--------------------"
+  echo "----- studio log -----"; tail -c 3000 "${LOG_FILE}"; echo "----------------------"
+  rm -f "${AIO_FILE}"; exit 1
+fi
+AIO_SERVED=$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "${AIO_FILE}" | head -1 || true)
+rm -f "${AIO_FILE}"
+# The override build + ALB boot + replica registration can take a while; retry.
+AIO_BODY=""
+for _ in $(seq 1 90); do
+  AIO_BODY=$(curl -fsS --max-time 3 "${AIO_SERVED}/" 2>/dev/null || true)
+  if echo "${AIO_BODY}" | grep -qF 'studio-image-override-301'; then break; fi
+  sleep 1
+done
+if ! echo "${AIO_BODY}" | grep -qF 'studio-image-override-301'; then
+  echo "FAIL: alb image-override did not apply (sentinel absent behind the ALB front-door)"
+  echo "----- served body -----"; echo "${AIO_BODY}" | head -c 1000; echo "-----------------------"
+  echo "----- studio log -----"; tail -c 3000 "${LOG_FILE}"; echo "----------------------"
+  exit 1
+fi
+echo "    OK: alb imageOverrides threaded; the backing pinned service rebuilt from the LOCAL Dockerfile + serves the sentinel behind the ALB"
+
+echo "==> POST /api/stop tears the ALB image-override serve down"
+curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ALB_TARGET}\"}" -o /dev/null || true
+sleep 3
+echo "    OK: ALB image-override serve stopped"
+
+# ---------------------------------------------------------------------------
 # 11. Clean shutdown on SIGTERM.
 # ---------------------------------------------------------------------------
 echo "==> Stopping studio (SIGTERM) and asserting clean exit"
@@ -1441,4 +1509,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + custom-resource-exclusion + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + reinvoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + custom-resource-exclusion + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + reinvoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + alb-image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"

--- a/tests/unit/cli/local-studio-alb-resolver.test.ts
+++ b/tests/unit/cli/local-studio-alb-resolver.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Mock the two resolver functions makeAlbBackingPinnedResolver calls so we can
+// drive its branch logic (issue #382) without a real synth. local-studio.ts
+// imports ONLY `resolveAlbTarget` from local-start-alb and `resolveAlbFrontDoor`
+// from elb-front-door-resolver, so the partial mocks cover its imports.
+const h = vi.hoisted(() => ({ resolveAlbTarget: vi.fn(), resolveAlbFrontDoor: vi.fn() }));
+vi.mock('../../../src/cli/commands/local-start-alb.js', async (importActual) => ({
+  ...((await importActual()) as object),
+  resolveAlbTarget: h.resolveAlbTarget,
+}));
+vi.mock('../../../src/local/elb-front-door-resolver.js', async (importActual) => ({
+  ...((await importActual()) as object),
+  resolveAlbFrontDoor: h.resolveAlbFrontDoor,
+}));
+
+import { makeAlbBackingPinnedResolver } from '../../../src/cli/commands/local-studio.js';
+
+const stack = { stackName: 'S' };
+const warn = vi.fn();
+const logger = { warn, info: vi.fn(), debug: vi.fn(), error: vi.fn(), trace: vi.fn() } as never;
+
+function build(pinned: Record<string, string>) {
+  h.resolveAlbTarget.mockReturnValue({ stack, albLogicalId: 'Alb' });
+  return makeAlbBackingPinnedResolver({
+    stacks: [stack] as never,
+    pinnedEcsByQualifiedId: new Map(Object.entries(pinned)),
+    logger,
+  });
+}
+const ecsFwd = (...ids: string[]) => ({
+  kind: 'forward',
+  targets: ids.map((id) => ({ kind: 'ecs', serviceLogicalId: id })),
+});
+const albEntry = { id: 'S/Alb', qualifiedId: 'S:Alb' };
+
+describe('makeAlbBackingPinnedResolver (issue #382)', () => {
+  beforeEach(() => {
+    h.resolveAlbTarget.mockClear();
+    h.resolveAlbFrontDoor.mockClear();
+    warn.mockClear();
+  });
+
+  it('returns the pinned backing services the ALB forwards to, deduped across listeners/rules', () => {
+    h.resolveAlbFrontDoor.mockReturnValue({
+      warnings: [],
+      listeners: [
+        {
+          defaultAction: { kind: 'fixed-response' },
+          rules: [{ action: ecsFwd('SvcA') }, { action: ecsFwd('SvcA', 'SvcB') }],
+        },
+      ],
+    });
+    const r = build({ 'S:SvcA': 'S/SvcA', 'S:SvcB': 'S/SvcB', 'S:Unpinned': 'x' });
+    const out = r(albEntry);
+    // SvcA + SvcB are pinned + forwarded; SvcA is deduped; Unpinned is not forwarded.
+    expect(out).toHaveLength(2);
+    expect(out).toContainEqual({ id: 'S:SvcA', label: 'S/SvcA' });
+    expect(out).toContainEqual({ id: 'S:SvcB', label: 'S/SvcB' });
+  });
+
+  it('drops a forwarded service that is NOT in the pinned set', () => {
+    h.resolveAlbFrontDoor.mockReturnValue({
+      warnings: [],
+      listeners: [{ defaultAction: ecsFwd('SvcA', 'SvcLocalAsset'), rules: [] }],
+    });
+    // Only SvcA is pinned; SvcLocalAsset (a local-asset service) is excluded.
+    expect(build({ 'S:SvcA': 'S/SvcA' })(albEntry)).toEqual([{ id: 'S:SvcA', label: 'S/SvcA' }]);
+  });
+
+  it('skips non-forward actions and non-ecs (lambda) forward targets', () => {
+    h.resolveAlbFrontDoor.mockReturnValue({
+      warnings: [],
+      listeners: [
+        {
+          defaultAction: { kind: 'redirect' },
+          rules: [
+            { action: { kind: 'fixed-response' } },
+            { action: { kind: 'forward', targets: [{ kind: 'lambda', lambdaLogicalId: 'Fn' }] } },
+          ],
+        },
+      ],
+    });
+    expect(build({ 'S:SvcA': 'S/SvcA' })(albEntry)).toEqual([]);
+  });
+
+  it('short-circuits (does not resolve the ALB) when nothing is pinned', () => {
+    const r = build({});
+    expect(r(albEntry)).toEqual([]);
+    expect(h.resolveAlbFrontDoor).not.toHaveBeenCalled();
+  });
+
+  it('WARN-logs + returns [] when the ALB cannot be resolved', () => {
+    warn.mockClear();
+    h.resolveAlbFrontDoor.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(build({ 'S:SvcA': 'S/SvcA' })(albEntry)).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('could not resolve ALB'));
+  });
+});

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -132,6 +132,43 @@ describe('coerceRunRequest', () => {
     );
   });
 
+  it('accepts an alb imageOverrides map + drops blank values (issue #382)', () => {
+    expect(
+      coerceRunRequest({
+        targetId: 'S/Alb',
+        kind: 'alb',
+        imageOverrides: { 'S:SvcA': ' /app/a/Dockerfile ', 'S:SvcB': '' },
+      })
+    ).toEqual({
+      targetId: 'S/Alb',
+      kind: 'alb',
+      event: undefined,
+      // blank-valued service dropped; the kept value is trimmed.
+      imageOverrides: { 'S:SvcA': '/app/a/Dockerfile' },
+    });
+  });
+
+  it('omits imageOverrides entirely when every value is blank', () => {
+    const r = coerceRunRequest({
+      targetId: 'S/Alb',
+      kind: 'alb',
+      imageOverrides: { 'S:SvcA': '', 'S:SvcB': '   ' },
+    });
+    expect('imageOverrides' in r).toBe(false);
+  });
+
+  it.each([null, 42, 'str', [1, 2]])('rejects a non-object imageOverrides %p', (imageOverrides) => {
+    expect(() => coerceRunRequest({ targetId: 'S/Alb', kind: 'alb', imageOverrides })).toThrow(
+      /"imageOverrides" must be a JSON object/
+    );
+  });
+
+  it('rejects a non-string imageOverrides value', () => {
+    expect(() =>
+      coerceRunRequest({ targetId: 'S/Alb', kind: 'alb', imageOverrides: { 'S:Svc': 42 } })
+    ).toThrow(/"imageOverrides.S:Svc" must be a string/);
+  });
+
   it('rejects an unknown option flag for the kind (clean 400 at the boundary)', () => {
     expect(() =>
       coerceRunRequest({ targetId: 'T', kind: 'ecs', options: { '--tls': true } })

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -179,6 +179,38 @@ describe('createStudioServeManager', () => {
     expect(argv[j + 1]).toBe('arn:aws:iam::123456789012:role/svc');
   });
 
+  it('threads one --image-override <service>=<dockerfile> per backing service for an alb serve (issue #382)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'S/Alb',
+      kind: 'alb',
+      imageOverrides: { 'S:SvcA': '/app/a/Dockerfile', 'S:SvcB': '/app/b/Dockerfile' },
+    });
+    child.stdout.emit('data', 'ALB front-door: http://127.0.0.1:51234\n');
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    const pairs = argv.reduce<string[]>((acc, a, idx) => {
+      if (a === '--image-override') acc.push(argv[idx + 1]);
+      return acc;
+    }, []);
+    expect(pairs).toContain('S:SvcA=/app/a/Dockerfile');
+    expect(pairs).toContain('S:SvcB=/app/b/Dockerfile');
+    expect(pairs).toHaveLength(2);
+  });
+
   it('appends --watch to the serve child argv only when config.watch is set', async () => {
     const bus = new StudioEventBus();
     const fp = fakeProxies();

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -6,6 +6,7 @@ import {
   toStudioTargetGroups,
   filterStudioTargetGroups,
   annotatePinnedEcsTargets,
+  annotateAlbPinnedBackingServices,
   type RunningStudioServer,
   type StudioTargetGroup,
 } from '../../../src/local/studio-server.js';
@@ -217,6 +218,46 @@ describe('annotatePinnedEcsTargets', () => {
     const g = groups();
     annotatePinnedEcsTargets(g, () => true);
     expect(g[1].entries[0].pinned).toBeUndefined();
+  });
+});
+
+describe('annotateAlbPinnedBackingServices', () => {
+  const groups = (): StudioTargetGroup[] => [
+    {
+      kind: 'ecs',
+      title: 'ECS Services',
+      entries: [{ id: 'S/Svc', qualifiedId: 'S:Svc', servable: true, pinned: true }],
+    },
+    {
+      kind: 'alb',
+      title: 'Load Balancers',
+      entries: [
+        { id: 'S/Alb1', qualifiedId: 'S:Alb1' },
+        { id: 'S/Alb2', qualifiedId: 'S:Alb2' },
+      ],
+    },
+  ];
+
+  it('sets backingPinnedServices on the alb entries the resolver returns pinned services for', () => {
+    const g = groups();
+    const any = annotateAlbPinnedBackingServices(g, (e) =>
+      e.id === 'S/Alb1' ? [{ id: 'S:Svc', label: 'S/Svc' }] : []
+    );
+    expect(any).toBe(true);
+    expect(g[1].entries[0].backingPinnedServices).toEqual([{ id: 'S:Svc', label: 'S/Svc' }]);
+    expect(g[1].entries[1].backingPinnedServices).toBeUndefined();
+  });
+
+  it('returns false + annotates nothing when no ALB fronts a pinned service', () => {
+    const g = groups();
+    expect(annotateAlbPinnedBackingServices(g, () => [])).toBe(false);
+    expect(g[1].entries[0].backingPinnedServices).toBeUndefined();
+  });
+
+  it('only touches alb groups (ecs entries are left alone)', () => {
+    const g = groups();
+    annotateAlbPinnedBackingServices(g, () => [{ id: 'X', label: 'X' }]);
+    expect(g[0].entries[0].backingPinnedServices).toBeUndefined();
   });
 });
 

--- a/tests/unit/local/studio-ui-alb-image-override.test.ts
+++ b/tests/unit/local/studio-ui-alb-image-override.test.ts
@@ -7,6 +7,7 @@ window.__t = {
   serveMeta: serveMeta,
   serveState: serveState,
   renderServeWorkspace: renderServeWorkspace,
+  formatAppliedOptions: formatAppliedOptions,
   setDockerfiles: function (d) { studioDockerfiles = d; },
 };
 window.__setShown = function (id) { shownServeId = id; };
@@ -85,6 +86,19 @@ describe('alb composer image-override picker (issue #382)', () => {
     try {
       albComposer(h, []);
       expect(h.document.querySelectorAll('.image-override-select').length).toBe(0);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('surfaces the imageOverrides picks in the "Started with" summary (issue #356 contract)', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const lines = h.window.__t.formatAppliedOptions({
+        imageOverrides: { 'S:SvcA': 'api/Dockerfile', 'S:SvcB': 'web/Dockerfile' },
+      });
+      expect(lines).toContain('--image-override S:SvcA=api/Dockerfile');
+      expect(lines).toContain('--image-override S:SvcB=web/Dockerfile');
     } finally {
       h.close();
     }

--- a/tests/unit/local/studio-ui-alb-image-override.test.ts
+++ b/tests/unit/local/studio-ui-alb-image-override.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the serve-workspace internals + a Dockerfile-list setter (issue #382).
+const EXPOSE = `
+window.__t = {
+  serveMeta: serveMeta,
+  serveState: serveState,
+  renderServeWorkspace: renderServeWorkspace,
+  setDockerfiles: function (d) { studioDockerfiles = d; },
+};
+window.__setShown = function (id) { shownServeId = id; };
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+function albComposer(h: Harness, backingPinnedServices: { id: string; label: string }[]) {
+  const t = h.window.__t;
+  t.setDockerfiles(['Dockerfile', 'api/Dockerfile']);
+  const dot = h.document.createElement('span');
+  const btnSlot = h.document.createElement('span');
+  t.serveMeta.set('S/Alb', { dot, btnSlot, kind: 'alb', pinned: false, backingPinnedServices });
+  t.serveState.set('S/Alb', { status: 'stopped', endpoints: [] });
+  h.window.__setShown('S/Alb');
+  t.renderServeWorkspace('S/Alb');
+  return t;
+}
+
+describe('alb composer image-override picker (issue #382)', () => {
+  it('renders one Dockerfile <select> per pinned backing service, labeled by service', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h, [
+        { id: 'S:SvcA', label: 'S/SvcA' },
+        { id: 'S:SvcB', label: 'S/SvcB' },
+      ]);
+      const selects = h.document.querySelectorAll('.image-override-select');
+      expect(selects.length).toBe(2);
+      const labels = Array.from(h.document.querySelectorAll('.opt-label')).map(
+        (n: any) => n.textContent
+      );
+      expect(labels).toContain('S/SvcA');
+      expect(labels).toContain('S/SvcB');
+      // The discovered Dockerfiles are options (+ the "(keep pinned image)" default).
+      const opts = Array.from((selects[0] as any).options).map((o: any) => o.value);
+      expect(opts).toEqual(['', 'Dockerfile', 'api/Dockerfile']);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('threads only the chosen services into the POST body imageOverrides map', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h, [
+        { id: 'S:SvcA', label: 'S/SvcA' },
+        { id: 'S:SvcB', label: 'S/SvcB' },
+      ]);
+      const selects = h.document.querySelectorAll('.image-override-select');
+      // Pick a Dockerfile for SvcA; leave SvcB on "(keep pinned image)".
+      (selects[0] as any).value = 'api/Dockerfile';
+
+      let captured: any = null;
+      h.window.fetch = (_url: string, opts: any) => {
+        captured = JSON.parse(opts.body);
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      };
+      // Click Start — startServe builds the body + calls fetch synchronously.
+      (h.document.querySelector('#workspace .composer button') as any).click();
+
+      expect(captured).not.toBeNull();
+      expect(captured.kind).toBe('alb');
+      expect(captured.imageOverrides).toEqual({ 'S:SvcA': 'api/Dockerfile' });
+    } finally {
+      h.close();
+    }
+  });
+
+  it('does NOT render the picker for an ALB with no pinned backing services', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h, []);
+      expect(h.document.querySelectorAll('.image-override-select').length).toBe(0);
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The image-override Dockerfile picker — which lets a pinned (deployed-registry)
ECS service rebuild from a local Dockerfile instead of running the unchangeable
deployed image — only existed for the standalone `ecs` serve kind (issue #301).
But `start-alb` boots the ALB's backing ECS services, and a service run BEHIND
an ALB had the same "local source edits do not take effect" problem with **no
picker**. A user iterating on an ALB-fronted service (the realistic topology)
was stuck: run the service standalone (losing the ALB host-header / path
routing) just to get the picker, or not iterate locally at all.

## Fix

Offer the same picker on the `alb` composer, one per pinned backing service.

- **Boot** — `makeAlbBackingPinnedResolver` resolves each ALB to its backing
  ECS services (`resolveAlbFrontDoor`, template-only) and intersects them with
  the pinned `ecs` set already classified by `makePinClassifier`.
  `annotateAlbPinnedBackingServices` records the result on the alb target entry
  as `backingPinnedServices` (`{ id: Stack:LogicalId, label }`).
- **UI** — `buildAlbImageOverridePicker` renders one Dockerfile `<select>` per
  pinned backing service; `collect()` returns an `imageOverrides` map. The
  running-view "Started with" summary lists the picks (issue #356 contract).
- **Threading** — `coerceRunRequest` validates the map at the `/api/run`
  boundary; the serve manager appends one `--image-override <service>=<df>` per
  entry. The service key is **`start-alb`'s own `Stack:LogicalId` service-boot
  target** (`local-start-alb.ts` builds the identical
  `${stackName}:${serviceLogicalId}`), so the override engine matches it with no
  `enforceImageOverrideOrphans` false-fire.

The pinned-classification caveat is unchanged: an INTRINSIC-ECR backing service
is only resolvable under `--from-cfn-stack` at boot (a public-registry pin is
classified without it), so the alb picker appears for it only when studio was
booted with `--from-cfn-stack` (a follow-up will re-classify on a Session-bar
change).

## cdkd parity

Additive only. `annotateAlbPinnedBackingServices` is re-exported from
`cdk-local/internal` alongside `annotatePinnedEcsTargets`. `imageOverrides` is a
new OPTIONAL field on `StudioRunRequest` / `StudioServeRequest`; no changed
default / exit code / error for any existing input, so a host inherits it for
free.

## Test plan

- Unit: `annotateAlbPinnedBackingServices` (studio-server),
  `makeAlbBackingPinnedResolver` branch logic (empty-pin short-circuit, dedup,
  unpinned-drop, non-forward / lambda-target skip, resolve-failure WARN),
  serve-manager per-service `--image-override` argv threading,
  `coerceRunRequest` `imageOverrides` validation, and a jsdom test of the alb
  composer (per-service render + select -> POST body + "Started with" summary).
- `vp run check` + `vp run build` green; full unit suite green (2665 tests).
- Integ (`/run-integ local-studio`): `GET /api/targets` exposes
  `MyAlb.backingPinnedServices = LocalStudioFixture:MyService`, then starting
  the ALB with `imageOverrides` rebuilds the backing pinned `MyService` from a
  local Dockerfile and serves the `studio-image-override-301` sentinel **behind
  the ALB front-door**. 0 docker orphans.
