### PR TITLE
feat(studio): re-classify targets when --from-cfn-stack changes in the Session bar (#385)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -356,8 +356,15 @@ compute-locally category for Lambda + API Gateway).
   `--from-cfn-stack`, e.g. `ContainerImage.fromEcrRepository(repo)`) is
   detected as pinned — matching `cdkl start-service --from-cfn-stack`; a
   service that cannot be classified now WARNs instead of silently going
-  unmarked. Boot-time only: a runtime Session-bar `--from-cfn-stack` change
-  does NOT re-classify (restart studio to re-detect).
+  unmarked. Issue #385 made this re-runnable: a Session-bar
+  `--from-cfn-stack` change (`PATCH /api/config`) re-runs the classification
+  (`classifyStudioTargets` against a fresh clone of the un-annotated base) and
+  swaps the served target list under the live socket (`RunningStudioServer.
+  setTargets`), so the image-override pickers appear / disappear under the new
+  binding WITHOUT restarting studio (latest-wins on rapid patches; the UI
+  re-fetches `/api/targets` after the binding change). The pin classification
+  re-runs ONLY when `--from-cfn-stack` actually changes (a watch / assume-role
+  toggle does not).
 - `src/synthesis/` — thin wrapper over `@aws-cdk/toolkit-lib`
   (`Toolkit.fromCdkApp()` + context store threading) that returns
   `StackInfo[]` for downstream consumers.
@@ -476,7 +483,7 @@ compute-locally category for Lambda + API Gateway).
   Dockerfiles + a `pinned` flag per ecs service — set by
   `annotatePinnedEcsTargets` — for the image-override picker, issue #301;
   plus `backingPinnedServices` per alb entry — set by
-  `annotateAlbPinnedBackingServices`, issue #382 — for the ALB's
+  `annotateAlbPinnedBackingServices`, issue #384 — for the ALB's
   per-backing-service image-override picker;
   CDK custom-resource / provider-framework Lambdas are excluded by
   default via `filterStudioCustomResources`, issue #323 — pass
@@ -551,7 +558,7 @@ compute-locally category for Lambda + API Gateway).
   the serve body so `start-service` rebuilds the pinned image from local
   source; a local-asset service (which already hot-reloads under `--watch`)
   gets no picker (issue #301). An `alb` serve gets the SAME picker for its
-  pinned BACKING services (issue #382): `start-alb` boots the ALB's backing
+  pinned BACKING services (issue #384): `start-alb` boots the ALB's backing
   ECS services, so studio resolves each ALB (`resolveAlbFrontDoor`) to its
   backing services at boot, intersects them with the pinned `ecs` set
   (`annotateAlbPinnedBackingServices` + `makeAlbBackingPinnedResolver`), and

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -29,6 +29,7 @@ import {
   annotatePinnedEcsTargets,
   annotateAlbPinnedBackingServices,
   type RunningStudioServer,
+  type StudioTargetGroup,
 } from '../../local/studio-server.js';
 import { resolveAlbFrontDoor } from '../../local/elb-front-door-resolver.js';
 import { resolveAlbTarget } from './local-start-alb.js';
@@ -125,7 +126,7 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     }
     if (imageOverride.trim() !== '') runImageOverride = imageOverride;
   }
-  // Per-backing-service image overrides for an `alb` serve (issue #382): a map
+  // Per-backing-service image overrides for an `alb` serve (issue #384): a map
   // of `Stack:LogicalId` -> Dockerfile path. Validate at the boundary so a
   // malformed map fails as a clean 400; drop blank values (the "(keep pinned
   // image)" picker choice).
@@ -547,9 +548,10 @@ export async function prepareEcsImageContexts(args: {
  * the pin resolves, and surfaces a WARN (not a silent DEBUG swallow) when a
  * service still cannot be classified.
  *
- * NOTE: the target list + these pinned flags are computed ONCE at boot. A
- * run-time Session-bar `--from-cfn-stack` change (`PATCH /api/config`) does
- * NOT re-classify — restart studio to re-detect pins under a new binding.
+ * The classifier is re-run whenever the Session-bar `--from-cfn-stack` binding
+ * changes (`PATCH /api/config`), so the pickers appear / disappear under the
+ * new binding without restarting studio (issue #385) — `classifyTargets`
+ * re-invokes this against a fresh clone of the un-annotated target groups.
  *
  * Returns a `(id) => boolean` callback (true = pinned). Exported for testing.
  */
@@ -581,7 +583,7 @@ export function makePinClassifier(args: {
 
 /**
  * Build the boot-time resolver `annotateAlbPinnedBackingServices` calls per
- * `alb` entry (issue #382). It resolves the ALB to its backing ECS services
+ * `alb` entry (issue #384). It resolves the ALB to its backing ECS services
  * (`resolveAlbFrontDoor`, template-only) and returns the subset that is in
  * `pinnedEcsByQualifiedId` — the `ecs` services already classified as a
  * deployed-registry pin by {@link makePinClassifier}. Each returned `id` is the
@@ -637,6 +639,112 @@ export function makeAlbBackingPinnedResolver(args: {
       return [];
     }
   };
+}
+
+/**
+ * Classify the studio target list for a given `--from-cfn-stack` binding
+ * (issue #385): annotate a FRESH clone of the un-annotated base groups with the
+ * `pinned` (ecs services) + `backingPinnedServices` (alb entries) image-override
+ * hints, and scan the app dir for Dockerfiles when at least one target is
+ * pinned. Returns the annotated groups + dockerfiles; the un-annotated
+ * `baseGroups` argument is left untouched so it can be re-classified under a
+ * different binding (the Session-bar `--from-cfn-stack` change path —
+ * `PATCH /api/config` — re-runs this and swaps the served target list, so the
+ * pickers appear without restarting studio). Runs once at boot and again per
+ * binding change.
+ *
+ * The clone means a re-classify never inherits stale pins; the `fromCfnStack`
+ * override is threaded into the state-source options so the pin classifier
+ * resolves INTRINSIC-ECR images against the right (or no) deployed stack
+ * (issue #354). Exported for unit testing.
+ */
+export async function classifyStudioTargets(args: {
+  baseGroups: StudioTargetGroup[];
+  stacks: StackInfo[];
+  servableEcs: ReadonlySet<string>;
+  options: LocalStateSourceLikeOptions;
+  fromCfnStack: string | boolean | undefined;
+  logger: ReturnType<typeof getLogger>;
+}): Promise<{ groups: StudioTargetGroup[]; dockerfiles: string[] }> {
+  const { baseGroups, stacks, servableEcs, options, fromCfnStack, logger } = args;
+  const groups = structuredClone(baseGroups) as StudioTargetGroup[];
+  // Re-bind the state-source options to the CURRENT `--from-cfn-stack` so the
+  // pin classifier resolves intrinsic-ECR images against the right (or no)
+  // deployed stack. `createLocalStateProvider` reads `fromCfnStack` / `profile`
+  // / region off this bag. `as` (not an annotation): with
+  // exactOptionalPropertyTypes a literal whose `fromCfnStack` may be `undefined`
+  // cannot be assigned to the optional-but-non-undefined field; an undefined /
+  // false value reads as "no --from-cfn-stack" via `isCfnFlagPresent`.
+  const classifyOptions = { ...options, fromCfnStack } as LocalStateSourceLikeOptions;
+  const contextByStack = await prepareEcsImageContexts({
+    serviceIds: [...servableEcs],
+    stacks,
+    options: classifyOptions,
+    logger,
+  });
+  const anyPinned = annotatePinnedEcsTargets(
+    groups,
+    makePinClassifier({ stacks, contextByStack, logger })
+  );
+  const pinnedEcsByQualifiedId = new Map<string, string>();
+  for (const g of groups) {
+    if (g.kind !== 'ecs') continue;
+    for (const e of g.entries) {
+      if (e.pinned) pinnedEcsByQualifiedId.set(e.qualifiedId, e.id);
+    }
+  }
+  const anyAlbBackingPinned = annotateAlbPinnedBackingServices(
+    groups,
+    makeAlbBackingPinnedResolver({ stacks, pinnedEcsByQualifiedId, logger })
+  );
+  const dockerfiles = anyPinned || anyAlbBackingPinned ? discoverDockerfiles(process.cwd()) : [];
+  return { groups, dockerfiles };
+}
+
+/**
+ * Re-classify the studio target list when the Session-bar `--from-cfn-stack`
+ * binding changes (issue #385), and swap the served list via `applyTargets`.
+ * The orchestration the `PATCH /api/config` handler runs, extracted so its
+ * branches are unit-testable without booting the studio server:
+ *
+ *  - **change gate**: returns immediately when `after === before` (a watch /
+ *    assume-role toggle does not change the pin classification);
+ *  - **latest-wins**: bumps `tokenRef.current` before the async `classify` and
+ *    applies the result ONLY if its token is still current — so a slow earlier
+ *    re-classify cannot clobber a newer binding's result when patches arrive in
+ *    quick succession;
+ *  - **fail-soft**: a `classify` rejection is WARN-logged and the previous
+ *    target list is kept (never throws — the PATCH still returns the config).
+ *
+ * `after` (the post-patch binding) is threaded into `classify`, never the boot
+ * value, so the pin classifier resolves against the new stack. Exported for
+ * unit testing.
+ */
+export async function reclassifyTargetsOnBindingChange(args: {
+  before: string | boolean | undefined;
+  after: string | boolean | undefined;
+  classify: (
+    fromCfnStack: string | boolean | undefined
+  ) => Promise<{ groups: StudioTargetGroup[]; dockerfiles: string[] }>;
+  applyTargets: (groups: StudioTargetGroup[], dockerfiles: string[]) => void;
+  tokenRef: { current: number };
+  logger: ReturnType<typeof getLogger>;
+}): Promise<void> {
+  const { before, after, classify, applyTargets, tokenRef, logger } = args;
+  if (after === before) return;
+  logger.info('--from-cfn-stack binding changed; re-classifying targets...');
+  const myToken = ++tokenRef.current;
+  try {
+    const { groups, dockerfiles } = await classify(after);
+    if (myToken === tokenRef.current) applyTargets(groups, dockerfiles);
+  } catch (err) {
+    logger.warn(
+      'studio: could not re-classify targets after a --from-cfn-stack change; the target ' +
+        `list keeps its previous pins (restart studio to retry). ${
+          err instanceof Error ? err.message : String(err)
+        }`
+    );
+  }
 }
 
 interface LocalStudioOptions {
@@ -774,68 +882,51 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
       .flatMap((g) => g.entries.filter((e) => e.servable).map((e) => e.id))
   );
 
-  // Mark servable ECS services whose image is a deployed-registry pin (ECR /
-  // public) rather than a local CDK asset (issue #301). A pinned image does
-  // NOT pick up local source edits, so the UI offers an image-override
-  // Dockerfile picker for those services; a local-asset service already
-  // hot-reloads under `--watch` and gets no picker.
+  // Mark servable ECS services / ALB-backing services whose image is a
+  // deployed-registry pin (ECR / public) rather than a local CDK asset
+  // (issue #301 / #384). A pinned image does NOT pick up local source edits,
+  // so the UI offers an image-override Dockerfile picker for those targets; a
+  // local-asset service already hot-reloads under `--watch` and gets no picker.
   //
   // Classification reads the synthed template by default. Under
-  // `--from-cfn-stack` (set at boot via the CLI flag), an ECR image expressed
-  // as an INTRINSIC URI (e.g. `ContainerImage.fromEcrRepository(repo)`) is
-  // ONLY resolvable with the deployed-state image-resolution context — the
-  // same context `cdkl run-task` / `start-service --from-cfn-stack` build. So
-  // we build a `LocalStateProvider` once at boot and thread each service's
-  // owning-stack `EcsImageResolutionContext` into the resolver; without it the
-  // service would silently stay unmarked even though start-service detects the
-  // pin (issue #354). The hint only governs whether the UI surfaces the
-  // picker; a mis-hinted service can still be overridden via the "All options"
-  // raw-args `--image-override`. A service that still cannot be classified is
-  // WARN-logged (not silently swallowed). Dockerfiles are scanned once, only
-  // when at least one service is pinned, so an all-local app pays nothing.
+  // `--from-cfn-stack`, an ECR image expressed as an INTRINSIC URI (e.g.
+  // `ContainerImage.fromEcrRepository(repo)`) is ONLY resolvable with the
+  // deployed-state image-resolution context — the same context `cdkl run-task`
+  // / `start-service --from-cfn-stack` build. So we build a `LocalStateProvider`
+  // and thread each service's owning-stack `EcsImageResolutionContext` into the
+  // resolver; without it the service would silently stay unmarked even though
+  // start-service detects the pin (issue #354). The hint only governs whether
+  // the UI surfaces the picker; a mis-hinted service can still be overridden via
+  // the "All options" raw-args `--image-override`. A service that still cannot
+  // be classified is WARN-logged (not silently swallowed). Dockerfiles are
+  // scanned once per classify, only when at least one target is pinned, so an
+  // all-local app pays nothing.
   //
-  // NOTE: the target list + pinned flags are boot-time only. A run-time
-  // Session-bar `--from-cfn-stack` change (`PATCH /api/config`) does NOT
-  // re-classify — restart studio to re-detect pins under a new binding.
-  // Pre-build each owning stack's deployed-state image-resolution context
-  // (only under `--from-cfn-stack`; each per-stack state provider is created
-  // + disposed inside the helper), then classify every servable service with
-  // its stack's context threaded into the resolver.
-  const contextByStack = await prepareEcsImageContexts({
-    serviceIds: [...servableEcs],
-    stacks,
-    options,
-    logger,
-  });
-  const anyPinned = annotatePinnedEcsTargets(
-    targetGroups,
-    makePinClassifier({ stacks, contextByStack, logger })
-  );
+  // Factored into `classifyTargets(fromCfnStack)` so the SAME path runs at boot
+  // AND on a Session-bar `--from-cfn-stack` change (`PATCH /api/config`, issue
+  // #385): the classify annotations (`pinned` / `backingPinnedServices`) are
+  // added to a FRESH clone of the un-annotated base each call, so a re-classify
+  // under a new binding never inherits stale pins from the prior one. The ALB
+  // picker (issue #384) intersects each ALB's backing ECS services with the
+  // pinned `ecs` set classified above; its key is `start-alb`'s own
+  // `Stack:LogicalId` service-boot target.
+  const baseTargetGroups = targetGroups;
+  const classifyTargets = (
+    fromCfnStack: string | boolean | undefined
+  ): Promise<{ groups: StudioTargetGroup[]; dockerfiles: string[] }> =>
+    classifyStudioTargets({
+      baseGroups: baseTargetGroups,
+      stacks,
+      servableEcs,
+      options,
+      fromCfnStack,
+      logger,
+    });
 
-  // Issue #382 — offer the image-override Dockerfile picker on the ALB
-  // composer too, not only on a standalone `ecs` service. `start-alb` boots
-  // the ALB's backing ECS services, so a pinned (deployed-registry) backing
-  // service has the same "local source edits do not take effect" problem a
-  // standalone pinned service does. Resolve each ALB to its backing ECS
-  // services and intersect with the pinned `ecs` set classified above; a
-  // pinned backing service becomes a per-service picker on the alb composer
-  // that threads `--image-override <Stack:LogicalId>=<dockerfile>` to the
-  // spawned `start-alb` (the `Stack:LogicalId` key is start-alb's own
-  // service-boot target). ALB resolution is template-only, but the pinned set
-  // it intersects is empty without `--from-cfn-stack` for INTRINSIC-ECR
-  // services — same boot-time-only caveat as the ecs picker.
-  const pinnedEcsByQualifiedId = new Map<string, string>();
-  for (const g of targetGroups) {
-    if (g.kind !== 'ecs') continue;
-    for (const e of g.entries) {
-      if (e.pinned) pinnedEcsByQualifiedId.set(e.qualifiedId, e.id);
-    }
-  }
-  const anyAlbBackingPinned = annotateAlbPinnedBackingServices(
-    targetGroups,
-    makeAlbBackingPinnedResolver({ stacks, pinnedEcsByQualifiedId, logger })
+  // Boot-time classification under the CLI `--from-cfn-stack` value.
+  const { groups: initialGroups, dockerfiles: initialDockerfiles } = await classifyTargets(
+    options.fromCfnStack
   );
-  const dockerfiles = anyPinned || anyAlbBackingPinned ? discoverDockerfiles(process.cwd()) : [];
 
   const bus = new StudioEventBus();
   // `process.argv[1]` is the running CLI entry (`dist/cli.js` / the `cdkl`
@@ -888,11 +979,23 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
   // logs at CloudWatch granularity (slice C3).
   const store = createStudioStore(bus);
 
+  // The running server, captured AFTER `startStudioServer` resolves so the
+  // `patchConfig` handler (defined inline below) can call `setTargets` on it
+  // to swap the target list under the live socket when `--from-cfn-stack`
+  // changes (issue #385). The handler only fires at run-time, by which point
+  // this is assigned. A monotonic token makes re-classification latest-wins so
+  // a slow earlier classify cannot clobber a newer binding's result.
+  let serverRef: RunningStudioServer | undefined;
+  // Monotonic re-classification token (latest-wins). Held in a ref object so
+  // {@link reclassifyTargetsOnBindingChange} can bump + compare it across
+  // overlapping PATCHes without recreating the closure.
+  const reclassifyToken = { current: 0 };
+
   const server = await startStudioServer({
     port,
     bus,
-    targetGroups,
-    dockerfiles,
+    targetGroups: initialGroups,
+    dockerfiles: initialDockerfiles,
     appLabel,
     cliName: getEmbedConfig().cliName,
     store,
@@ -942,13 +1045,27 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
     },
     getRunning: () => ({ running: serveManager.list() }),
     getConfig: () => sessionConfigSnapshot(),
-    patchConfig: (body) => {
+    patchConfig: async (body) => {
       // Mutates the shared childConfig the dispatcher + serve-manager read
       // per-run, so the new binding applies to subsequent invokes / serves.
+      const beforeFromCfn = childConfig.fromCfnStack;
       applyConfigPatch(body, childConfig);
-      return Promise.resolve(sessionConfigSnapshot());
+      // A `--from-cfn-stack` change re-runs the ECS image-pin classification +
+      // swaps the served target list under the live socket (issue #385); other
+      // edits (assume-role / watch) skip it. The post-patch `childConfig.
+      // fromCfnStack` is the new binding to classify against.
+      await reclassifyTargetsOnBindingChange({
+        before: beforeFromCfn,
+        after: childConfig.fromCfnStack,
+        classify: classifyTargets,
+        applyTargets: (groups, dockerfiles) => serverRef?.setTargets(groups, dockerfiles),
+        tokenRef: reclassifyToken,
+        logger,
+      });
+      return sessionConfigSnapshot();
     },
   });
+  serverRef = server;
 
   const cliName = getEmbedConfig().cliName;
   logger.info(`${cliName} studio is running at ${server.url}`);

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -46,7 +46,7 @@ export interface StudioRunRequest {
   imageOverride?: string;
   /**
    * Per-backing-service Dockerfile paths for an `alb` serve target's
-   * image-override pickers (issue #382), keyed by the service's
+   * image-override pickers (issue #384), keyed by the service's
    * `Stack:LogicalId` (the `--image-override` key `start-alb` matches). An ALB
    * boots multiple backing ECS services, so unlike the single `imageOverride`
    * this is a map — one `--image-override <service>=<dockerfile>` is threaded

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -34,7 +34,7 @@ export interface StudioServeRequest {
    */
   imageOverride?: string;
   /**
-   * Per-backing-service Dockerfile paths for an `alb` serve (issue #382), keyed
+   * Per-backing-service Dockerfile paths for an `alb` serve (issue #384), keyed
    * by the backing service's `Stack:LogicalId` (the `--image-override` key
    * `start-alb` matches against its own service-boot target). One
    * `--image-override <service>=<dockerfile>` is appended per entry so the
@@ -350,7 +350,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       ...(req.imageOverride && req.imageOverride.trim() !== ''
         ? ['--image-override', req.targetId + '=' + req.imageOverride.trim()]
         : []),
-      // Per-backing-service image-override for an `alb` serve (issue #382): an
+      // Per-backing-service image-override for an `alb` serve (issue #384): an
       // ALB boots multiple backing ECS services, so the alb composer's per-
       // service pickers thread one explicit `--image-override <service>=<df>`
       // each. The service key is the backing service's `Stack:LogicalId` —

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -36,7 +36,7 @@ export interface StudioTarget {
   pinned?: boolean;
   /**
    * Set on an `alb` entry: the deployed-registry-pinned ECS services this ALB
-   * fronts (issue #382). `start-alb` boots the ALB's backing services, so a
+   * fronts (issue #384). `start-alb` boots the ALB's backing services, so a
    * pinned backing service has the same "local edits do not take effect"
    * problem a standalone pinned `ecs` service does — the alb composer offers a
    * per-service Dockerfile picker that threads
@@ -133,7 +133,7 @@ export function annotatePinnedEcsTargets(
 
 /**
  * Annotate each `alb` entry of `groups` with the deployed-registry-pinned ECS
- * services that ALB fronts (issue #382), so the alb composer can offer a
+ * services that ALB fronts (issue #384), so the alb composer can offer a
  * per-service image-override Dockerfile picker. `resolveBackingPinned` maps one
  * ALB entry to its pinned backing services (`{ id, label }`, where `id` is the
  * `--image-override` key — `start-alb`'s `Stack:LogicalId` service-boot
@@ -285,6 +285,14 @@ export interface RunningStudioServer {
   port: number;
   /** Stop the server and release the port. */
   close: () => Promise<void>;
+  /**
+   * Replace the target list served at `GET /api/targets` under the live socket
+   * (issue #385). studio calls this when the Session-bar `--from-cfn-stack`
+   * binding changes and the ECS image-pin classification is re-run, so the
+   * image-override pickers appear without restarting studio. The next
+   * `GET /api/targets` returns the new groups + dockerfiles.
+   */
+  setTargets: (groups: StudioTargetGroup[], dockerfiles?: string[]) => void;
 }
 
 const SSE_HEARTBEAT_MS = 15_000;
@@ -301,13 +309,18 @@ export async function startStudioServer(
   const host = options.host ?? '127.0.0.1';
   const maxBump = options.maxPortBump ?? 20;
   const html = renderStudioHtml(options.appLabel, options.cliName);
-  const targetsJson = JSON.stringify({
+  // The served target list is mutable (issue #385): a Session-bar
+  // `--from-cfn-stack` change re-runs the ECS pin classification and pushes a
+  // fresh groups + dockerfiles set in via `setTargets`. Held as a
+  // pre-stringified cell read per `GET /api/targets`, so the swap is atomic
+  // (one assignment) and a request reads either the old or the new JSON whole.
+  let targetsJson = JSON.stringify({
     groups: options.targetGroups,
     dockerfiles: options.dockerfiles ?? [],
   });
 
   const server = createServer((req, res) =>
-    handleRequest(req, res, options.bus, html, targetsJson, options)
+    handleRequest(req, res, options.bus, html, () => targetsJson, options)
   );
 
   const boundPort = await listenWithBump(server, host, options.port, maxBump);
@@ -322,6 +335,9 @@ export async function startStudioServer(
         // so without this `close()` would hang on live EventSource clients.
         server.closeAllConnections?.();
       }),
+    setTargets: (groups, dockerfiles) => {
+      targetsJson = JSON.stringify({ groups, dockerfiles: dockerfiles ?? [] });
+    },
   };
 }
 
@@ -330,7 +346,7 @@ function handleRequest(
   res: ServerResponse,
   bus: StudioEventBus,
   html: string,
-  targetsJson: string,
+  getTargetsJson: () => string,
   options: StudioServerOptions
 ): void {
   const url = req.url ?? '/';
@@ -343,7 +359,7 @@ function handleRequest(
   }
   if (req.method === 'GET' && path === '/api/targets') {
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
-    res.end(targetsJson);
+    res.end(getTargetsJson());
     return;
   }
   if (req.method === 'GET' && path === '/api/running') {

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -280,6 +280,7 @@ const STUDIO_SCRIPT = `
   let shownDetailId = null;        // captured request whose read-only detail is shown
   let pendingReqPrefill = null;    // {method,path,headers,body} to seed the next serve request composer (re-invoke)
   let studioDockerfiles = [];      // Dockerfiles scanned at boot (pinned-ecs image-override picker)
+  let lastAppliedCfn = null;       // last-applied --from-cfn-stack (null | true | name) — a change re-loads targets (issue #385)
 
   function el(tag, cls, text) {
     const e = document.createElement(tag);
@@ -526,7 +527,7 @@ const STUDIO_SCRIPT = `
     };
   }
 
-  // Per-backing-service image-override pickers for a pinned ALB (issue #382):
+  // Per-backing-service image-override pickers for a pinned ALB (issue #384):
   // one Dockerfile select per deployed-registry-pinned service the ALB fronts.
   // collect() returns a { [serviceId]: dockerfile } map threaded as
   // imageOverrides (one --image-override service=df per entry).
@@ -784,7 +785,7 @@ const STUDIO_SCRIPT = `
       lines.push('--image-override ' + applied.imageOverride);
     }
     // An alb serve threads a per-backing-service imageOverrides map (issue
-    // #382); surface one --image-override line each so the picks do not
+    // #384); surface one --image-override line each so the picks do not
     // silently vanish from the running view (the issue #356 contract).
     if (applied && applied.imageOverrides) {
       Object.keys(applied.imageOverrides).forEach(function (svc) {
@@ -926,7 +927,7 @@ const STUDIO_SCRIPT = `
         ws.appendChild(io.node);
         collectImageOverride = io.collect;
       }
-      // An ALB boots its backing ECS services (issue #382); a pinned backing
+      // An ALB boots its backing ECS services (issue #384); a pinned backing
       // service has the same "local edits do not take effect" problem, so offer
       // a per-service Dockerfile picker that threads
       // --image-override service=dockerfile to start-alb.
@@ -1879,6 +1880,9 @@ const STUDIO_SCRIPT = `
       cfn.checked = on;
       cfnName.value = typeof c.fromCfnStack === 'string' ? c.fromCfnStack : '';
       cfnName.style.display = on ? '' : 'none';
+      // Seed the last-applied from-cfn-stack signature so the first Session-bar
+      // edit only re-loads targets if it actually changes the binding (#385).
+      lastAppliedCfn = on ? (typeof c.fromCfnStack === 'string' && c.fromCfnStack ? c.fromCfnStack : true) : null;
       // assume-role is now checkbox-gated, symmetric with from-cfn-stack
       // (issue #343): the ARN input appears only when the box is checked.
       const roleOn = document.getElementById('sess-role-on');
@@ -1907,8 +1911,9 @@ const STUDIO_SCRIPT = `
     const role = document.getElementById('sess-role');
     const roleOn = document.getElementById('sess-role-on');
     const msg = document.getElementById('sess-msg');
+    const nextCfn = cfn.checked ? cfnName.value.trim() || true : null;
     const body = {
-      fromCfnStack: cfn.checked ? cfnName.value.trim() || true : null,
+      fromCfnStack: nextCfn,
       // assume-role is explicit-ARN-only: checked + empty is simply not bound.
       assumeRole: roleOn.checked ? role.value.trim() || null : null,
       watch: document.getElementById('sess-watch').checked,
@@ -1926,16 +1931,31 @@ const STUDIO_SCRIPT = `
       }
       msg.textContent = '✓ applied';
       setTimeout(function () { msg.textContent = ''; }, 1200);
-      // Do NOT re-load from the server here (issue #349): the UI already shows
-      // exactly what was just PATCHed, and re-loading CLOBBERS the controls.
-      // assume-role has no bare server form, so a checked-but-empty assume-role
-      // PATCHes null; re-loading would read that back and immediately UN-check
-      // the box + hide the ARN input — so clicking the checkbox appeared to do
-      // nothing. loadConfig() runs once on init.
+      // Do NOT re-load the SESSION CONTROLS from the server here (issue #349):
+      // the UI already shows exactly what was just PATCHed, and re-loading
+      // CLOBBERS the controls. assume-role has no bare server form, so a
+      // checked-but-empty assume-role PATCHes null; re-loading would read that
+      // back and immediately UN-check the box. loadConfig() runs once on init.
+      //
+      // But a --from-cfn-stack change DID re-classify the targets server-side
+      // (issue #385) — the PATCH response already reflects the new binding, and
+      // the server swapped its target list. Re-fetch /api/targets so the
+      // image-override pickers appear / disappear without restarting studio.
+      // Only when the binding actually changed, so a watch / role toggle does
+      // not needlessly rebuild the target pane. Running-serve rows are
+      // preserved on re-render (serveState + updateServeRow drive them).
+      if (!sameCfn(nextCfn, lastAppliedCfn)) {
+        lastAppliedCfn = nextCfn;
+        await loadTargets();
+      }
     } catch (err) {
       msg.textContent = 'Failed: ' + err;
     }
   }
+
+  // Two --from-cfn-stack values are the same binding when both clear (null),
+  // both bare (true), or the same stack name.
+  function sameCfn(a, b) { return a === b; }
 
   function wireSession() {
     const cfn = document.getElementById('sess-cfn');

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -591,6 +591,47 @@ curl -s -X PATCH "${URL}/api/config" -H 'content-type: application/json' \
   -d '{"fromCfnStack":null}' -o /dev/null || true
 
 # ---------------------------------------------------------------------------
+# 6c2. Re-classify on --from-cfn-stack change (issue #385): a PATCH that CHANGES
+#      the binding re-runs the ECS image-pin classification + swaps the served
+#      target list under the live socket, so the image-override pickers refresh
+#      WITHOUT restarting studio. The PATCH handler AWAITS the re-classification
+#      before responding. Two end-to-end signals:
+#       (a) the studio log emits the re-classify banner (info-level, fired ONLY
+#           on a from-cfn-stack change — absent at boot), and
+#       (b) GET /api/targets still re-serves the full target list (the swap path
+#           did not break serving).
+#      The fixture's ECS service image is a public-registry literal (pinned
+#      regardless of --from-cfn-stack), so the VISIBLE pin does not flip here;
+#      the unit suite covers the pinned-flip + swap-re-serve cases.
+echo "==> PATCH /api/config --from-cfn-stack re-classifies the target list (issue #385)"
+# Snapshot the studio log line count so we inspect only lines THIS patch emits.
+LOG_OFFSET=$(wc -l < "${LOG_FILE}")
+RECLASS_PATCH=$(mktemp)
+HTTP_RC=$(curl -s -o "${RECLASS_PATCH}" -w '%{http_code}' -X PATCH "${URL}/api/config" \
+  -H 'content-type: application/json' -d '{"fromCfnStack":"BOGUSRECLASS385"}' || true)
+if [[ "${HTTP_RC}" != "200" ]]; then
+  echo "FAIL: re-classify PATCH returned HTTP ${HTTP_RC}"; cat "${RECLASS_PATCH}"; rm -f "${RECLASS_PATCH}"; exit 1
+fi
+rm -f "${RECLASS_PATCH}"
+tail -n +"$((LOG_OFFSET + 1))" "${LOG_FILE}" > "${BODY_FILE}" || true
+if ! grep -qF 're-classifying targets' "${BODY_FILE}"; then
+  echo "FAIL: a --from-cfn-stack change did not re-run the target classification"
+  echo "----- studio log tail -----"; cat "${BODY_FILE}"; echo "---------------------------"
+  exit 1
+fi
+echo "    OK: the --from-cfn-stack change re-ran classification (banner observed)"
+# The swapped target list still serves the full set under the live socket.
+curl -fsS "${URL}/api/targets" -o "${BODY_FILE}"
+if ! grep -qF '"kind":"ecs"' "${BODY_FILE}" || ! grep -qF 'LocalStudioFixture/MyHandler' "${BODY_FILE}"; then
+  echo "FAIL: GET /api/targets did not re-serve the target list after the re-classify swap"
+  cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: GET /api/targets re-served the swapped target list"
+# Reset the binding so later sections are unaffected.
+curl -s -X PATCH "${URL}/api/config" -H 'content-type: application/json' \
+  -d '{"fromCfnStack":null}' -o /dev/null || true
+
+# ---------------------------------------------------------------------------
 # 6d. POST /api/run invokes an AgentCore runtime (issue #303): the studio
 #     dispatch spawns `cdkl invoke-agentcore LocalStudioFixture/MyAgent`, which
 #     `docker build`s the `agent/` container (linux/arm64) and runs the HTTP
@@ -1306,7 +1347,7 @@ sleep 3
 echo "    OK: image-override service stopped"
 
 # ---------------------------------------------------------------------------
-# 10d. ALB image-override picker (issue #382): MyAlb fronts the pinned
+# 10d. ALB image-override picker (issue #384): MyAlb fronts the pinned
 #      MyService. Studio resolves the ALB's backing ECS services + offers a
 #      per-service Dockerfile picker on the ALB composer, threading
 #      `--image-override <Stack:LogicalId>=./Dockerfile.override` to start-alb.
@@ -1318,7 +1359,7 @@ echo "    OK: image-override service stopped"
 #      BEHIND the ALB (the picker -> /api/run -> imageOverrides ->
 #      --image-override -> start-alb rebuild path end-to-end).
 # ---------------------------------------------------------------------------
-echo "==> ALB image-override: /api/targets exposes the ALB's pinned backing services (issue #382)"
+echo "==> ALB image-override: /api/targets exposes the ALB's pinned backing services (issue #384)"
 curl -fsS "${URL}/api/targets" -o "${BODY_FILE}"
 ALB_SVC_KEY=$(python3 -c '
 import json, sys

--- a/tests/unit/cli/local-studio-alb-resolver.test.ts
+++ b/tests/unit/cli/local-studio-alb-resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 
 // Mock the two resolver functions makeAlbBackingPinnedResolver calls so we can
-// drive its branch logic (issue #382) without a real synth. local-studio.ts
+// drive its branch logic (issue #384) without a real synth. local-studio.ts
 // imports ONLY `resolveAlbTarget` from local-start-alb and `resolveAlbFrontDoor`
 // from elb-front-door-resolver, so the partial mocks cover its imports.
 const h = vi.hoisted(() => ({ resolveAlbTarget: vi.fn(), resolveAlbFrontDoor: vi.fn() }));
@@ -34,7 +34,7 @@ const ecsFwd = (...ids: string[]) => ({
 });
 const albEntry = { id: 'S/Alb', qualifiedId: 'S:Alb' };
 
-describe('makeAlbBackingPinnedResolver (issue #382)', () => {
+describe('makeAlbBackingPinnedResolver (issue #384)', () => {
   beforeEach(() => {
     h.resolveAlbTarget.mockClear();
     h.resolveAlbFrontDoor.mockClear();

--- a/tests/unit/cli/local-studio-pin-classifier.test.ts
+++ b/tests/unit/cli/local-studio-pin-classifier.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { EcsImageResolutionContext } from '../../../src/local/ecs-task-resolver.js';
+import type { StudioTargetGroup } from '../../../src/local/studio-server.js';
 
 // Mock every external boundary the boot-time pin classifier touches so the
-// tests exercise the wiring (issue #354) without synth / Docker / AWS.
+// tests exercise the wiring (issue #354 / #385) without synth / Docker / AWS.
 const hoisted = vi.hoisted(() => ({
   resolveEcsServiceTarget: vi.fn(),
   isLocalCdkAssetImage: vi.fn(),
   buildEcsImageResolutionContext: vi.fn(),
   createLocalStateProvider: vi.fn(),
+  discoverDockerfiles: vi.fn(),
 }));
 
 vi.mock('../../../src/local/ecs-service-resolver.js', async (importOriginal) => {
@@ -36,11 +38,20 @@ vi.mock('../../../src/cli/commands/local-state-source.js', async (importOriginal
     await importOriginal<typeof import('../../../src/cli/commands/local-state-source.js')>();
   return { ...actual, createLocalStateProvider: hoisted.createLocalStateProvider };
 });
+// Stub the Dockerfile scan so `classifyStudioTargets` does not walk the real
+// cwd (which has fixture Dockerfiles); the tests assert it is called only when
+// a target is pinned, and returns a deterministic list.
+vi.mock('../../../src/local/image-override-engine.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/local/image-override-engine.js')>();
+  return { ...actual, discoverDockerfiles: hoisted.discoverDockerfiles };
+});
 
 const {
   resolveEcsServiceStack,
   prepareEcsImageContexts,
   makePinClassifier,
+  classifyStudioTargets,
+  reclassifyTargetsOnBindingChange,
 } = await import('../../../src/cli/commands/local-studio.js');
 
 function stack(name: string, region?: string): StackInfo {
@@ -71,6 +82,7 @@ beforeEach(() => {
   hoisted.isLocalCdkAssetImage.mockReset();
   hoisted.buildEcsImageResolutionContext.mockReset();
   hoisted.createLocalStateProvider.mockReset();
+  hoisted.discoverDockerfiles.mockReset();
 });
 
 describe('resolveEcsServiceStack', () => {
@@ -310,5 +322,203 @@ describe('makePinClassifier', () => {
     expect(classify('dev/Svc')).toBe(false);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('cannot resolve image'));
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("'dev/Svc'"));
+  });
+});
+
+describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack toggle)', () => {
+  const baseGroups = (): StudioTargetGroup[] => [
+    {
+      kind: 'ecs',
+      title: 'ECS Services',
+      entries: [{ id: 'dev/Svc', qualifiedId: 'dev:Svc', servable: true }],
+    },
+  ];
+
+  it('pins an intrinsic-ECR service ONLY under --from-cfn-stack, re-classifying cleanly on toggle', async () => {
+    const logger = fakeLogger();
+    hoisted.discoverDockerfiles.mockReturnValue(['./Dockerfile']);
+    // An INTRINSIC-ECR image resolves ONLY with a deployed-state context; the
+    // resolver throws when no context is threaded (no --from-cfn-stack).
+    hoisted.resolveEcsServiceTarget.mockImplementation(
+      (_id: string, _stacks: unknown, ctx: unknown) => {
+        if (!ctx) throw new Error('intrinsic ECR URI needs --from-cfn-stack');
+        return { id: 'resolved' };
+      }
+    );
+    hoisted.isLocalCdkAssetImage.mockReturnValue(false); // registry pin
+    hoisted.createLocalStateProvider.mockReturnValue({ dispose: vi.fn() });
+    hoisted.buildEcsImageResolutionContext.mockResolvedValue({ stateResources: {} });
+
+    const base = baseGroups();
+    const stacks = [stack('dev', 'us-east-1')];
+    const servableEcs = new Set(['dev/Svc']);
+
+    // OFF: no context built -> resolve throws -> service stays unpinned, no scan.
+    const off = await classifyStudioTargets({
+      baseGroups: base,
+      stacks,
+      servableEcs,
+      options: {},
+      fromCfnStack: undefined,
+      logger,
+    });
+    expect(off.groups[0]?.entries[0]?.pinned).toBeUndefined();
+    expect(off.dockerfiles).toEqual([]);
+    expect(hoisted.discoverDockerfiles).not.toHaveBeenCalled();
+
+    // ON: context built -> resolve returns -> service is pinned + Dockerfiles scanned.
+    const on = await classifyStudioTargets({
+      baseGroups: base,
+      stacks,
+      servableEcs,
+      options: {},
+      fromCfnStack: true,
+      logger,
+    });
+    expect(on.groups[0]?.entries[0]?.pinned).toBe(true);
+    expect(on.dockerfiles).toEqual(['./Dockerfile']);
+    expect(hoisted.discoverDockerfiles).toHaveBeenCalledTimes(1);
+
+    // The base groups are never mutated — each classify clones, so a re-classify
+    // under a new binding never inherits stale pins.
+    expect(base[0]?.entries[0]?.pinned).toBeUndefined();
+  });
+
+  it('does not scan Dockerfiles for an all-local-asset app', async () => {
+    const logger = fakeLogger();
+    hoisted.discoverDockerfiles.mockReturnValue(['./Dockerfile']);
+    hoisted.resolveEcsServiceTarget.mockReturnValue({ id: 'resolved' });
+    hoisted.isLocalCdkAssetImage.mockReturnValue(true); // local asset => not pinned
+
+    const result = await classifyStudioTargets({
+      baseGroups: baseGroups(),
+      stacks: [stack('dev')],
+      servableEcs: new Set(['dev/Svc']),
+      options: {},
+      fromCfnStack: undefined,
+      logger,
+    });
+    expect(result.groups[0]?.entries[0]?.pinned).toBeUndefined();
+    expect(result.dockerfiles).toEqual([]);
+    expect(hoisted.discoverDockerfiles).not.toHaveBeenCalled();
+  });
+});
+
+describe('reclassifyTargetsOnBindingChange (issue #385 — PATCH /api/config orchestration)', () => {
+  const result = (dockerfiles: string[] = []) => ({
+    groups: [{ kind: 'ecs' as const, title: 'ECS Services', entries: [] }],
+    dockerfiles,
+  });
+
+  it('skips re-classification when the binding is unchanged (a watch / role toggle)', async () => {
+    const logger = fakeLogger();
+    const classify = vi.fn();
+    const applyTargets = vi.fn();
+    await reclassifyTargetsOnBindingChange({
+      before: 'dev',
+      after: 'dev',
+      classify,
+      applyTargets,
+      tokenRef: { current: 0 },
+      logger,
+    });
+    expect(classify).not.toHaveBeenCalled();
+    expect(applyTargets).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('re-classifies + swaps the target list with the POST-PATCH binding', async () => {
+    const logger = fakeLogger();
+    const classify = vi.fn().mockResolvedValue(result(['./Dockerfile']));
+    const applyTargets = vi.fn();
+    await reclassifyTargetsOnBindingChange({
+      before: undefined,
+      after: 'NewStack',
+      classify,
+      applyTargets,
+      tokenRef: { current: 0 },
+      logger,
+    });
+    // The NEW binding (not the old one) is threaded into classify.
+    expect(classify).toHaveBeenCalledWith('NewStack');
+    expect(applyTargets).toHaveBeenCalledWith(
+      [{ kind: 'ecs', title: 'ECS Services', entries: [] }],
+      ['./Dockerfile']
+    );
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('re-classifying targets'));
+  });
+
+  it('treats clearing the binding (string -> undefined) as a change', async () => {
+    const logger = fakeLogger();
+    const classify = vi.fn().mockResolvedValue(result());
+    const applyTargets = vi.fn();
+    await reclassifyTargetsOnBindingChange({
+      before: 'dev',
+      after: undefined,
+      classify,
+      applyTargets,
+      tokenRef: { current: 0 },
+      logger,
+    });
+    expect(classify).toHaveBeenCalledWith(undefined);
+    expect(applyTargets).toHaveBeenCalledTimes(1);
+  });
+
+  it('latest-wins: a superseded earlier re-classify does NOT swap the list', async () => {
+    const logger = fakeLogger();
+    const tokenRef = { current: 0 };
+    const applyTargets = vi.fn();
+    // First classify is slow (resolves last); second is fast.
+    let releaseSlow!: () => void;
+    const slow = new Promise<{ groups: never[]; dockerfiles: string[] }>((res) => {
+      releaseSlow = () => res({ groups: [], dockerfiles: ['./slow'] });
+    });
+    const classify = vi
+      .fn()
+      .mockReturnValueOnce(slow)
+      .mockResolvedValueOnce({ groups: [], dockerfiles: ['./fast'] });
+
+    const p1 = reclassifyTargetsOnBindingChange({
+      before: undefined,
+      after: 'A',
+      classify,
+      applyTargets,
+      tokenRef,
+      logger,
+    });
+    const p2 = reclassifyTargetsOnBindingChange({
+      before: 'A',
+      after: 'B',
+      classify,
+      applyTargets,
+      tokenRef,
+      logger,
+    });
+    await p2; // the newer patch applies its result first
+    releaseSlow();
+    await p1; // the older patch resolves but is superseded
+
+    // Only the LATEST binding's result was applied.
+    expect(applyTargets).toHaveBeenCalledTimes(1);
+    expect(applyTargets).toHaveBeenCalledWith([], ['./fast']);
+  });
+
+  it('fails soft: a classify rejection WARNs and keeps the previous list (no throw)', async () => {
+    const logger = fakeLogger();
+    const classify = vi.fn().mockRejectedValue(new Error('state load failed'));
+    const applyTargets = vi.fn();
+    await expect(
+      reclassifyTargetsOnBindingChange({
+        before: undefined,
+        after: 'BadStack',
+        classify,
+        applyTargets,
+        tokenRef: { current: 0 },
+        logger,
+      })
+    ).resolves.toBeUndefined();
+    expect(applyTargets).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('state load failed'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('could not re-classify'));
   });
 });

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -132,7 +132,7 @@ describe('coerceRunRequest', () => {
     );
   });
 
-  it('accepts an alb imageOverrides map + drops blank values (issue #382)', () => {
+  it('accepts an alb imageOverrides map + drops blank values (issue #384)', () => {
     expect(
       coerceRunRequest({
         targetId: 'S/Alb',

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -179,7 +179,7 @@ describe('createStudioServeManager', () => {
     expect(argv[j + 1]).toBe('arn:aws:iam::123456789012:role/svc');
   });
 
-  it('threads one --image-override <service>=<dockerfile> per backing service for an alb serve (issue #382)', async () => {
+  it('threads one --image-override <service>=<dockerfile> per backing service for an alb serve (issue #384)', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();
     const spawnFn = vi.fn(() => child as never);

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -430,6 +430,55 @@ describe('startStudioServer', () => {
     expect(ecs?.entries[0].pinned).toBe(true);
   });
 
+  it('setTargets swaps the served target list under the live socket (issue #385)', async () => {
+    const server = await boot({
+      targetGroups: [
+        {
+          kind: 'ecs',
+          title: 'ECS Services',
+          entries: [{ id: 'S/Svc', qualifiedId: 'S:Svc', servable: true }],
+        },
+      ],
+      dockerfiles: [],
+    });
+    // Before: not pinned, no dockerfiles.
+    const before = (await (await http(`${server.url}/api/targets`)).json()) as {
+      groups: { kind: string; entries: { pinned?: boolean }[] }[];
+      dockerfiles: string[];
+    };
+    expect(before.groups.find((g) => g.kind === 'ecs')?.entries[0].pinned).toBeUndefined();
+    expect(before.dockerfiles).toEqual([]);
+
+    // Re-classification (e.g. after a Session-bar --from-cfn-stack change) marks
+    // the service pinned and surfaces a Dockerfile for the override picker.
+    server.setTargets(
+      [
+        {
+          kind: 'ecs',
+          title: 'ECS Services',
+          entries: [{ id: 'S/Svc', qualifiedId: 'S:Svc', servable: true, pinned: true }],
+        },
+      ],
+      ['./Dockerfile']
+    );
+
+    const after = (await (await http(`${server.url}/api/targets`)).json()) as {
+      groups: { kind: string; entries: { pinned?: boolean }[] }[];
+      dockerfiles: string[];
+    };
+    expect(after.groups.find((g) => g.kind === 'ecs')?.entries[0].pinned).toBe(true);
+    expect(after.dockerfiles).toEqual(['./Dockerfile']);
+  });
+
+  it('setTargets defaults dockerfiles to an empty array when omitted', async () => {
+    const server = await boot();
+    server.setTargets([{ kind: 'lambda', title: 'Lambda Functions', entries: [] }]);
+    const data = (await (await http(`${server.url}/api/targets`)).json()) as {
+      dockerfiles: string[];
+    };
+    expect(data.dockerfiles).toEqual([]);
+  });
+
   it('404s an unknown path', async () => {
     const server = await boot();
     const res = await http(`${server.url}/nope`);

--- a/tests/unit/local/studio-ui-alb-image-override.test.ts
+++ b/tests/unit/local/studio-ui-alb-image-override.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { createStudioHarness } from './studio-ui-harness.js';
 
-// Expose the serve-workspace internals + a Dockerfile-list setter (issue #382).
+// Expose the serve-workspace internals + a Dockerfile-list setter (issue #384).
 const EXPOSE = `
 window.__t = {
   serveMeta: serveMeta,
@@ -31,7 +31,7 @@ function albComposer(h: Harness, backingPinnedServices: { id: string; label: str
   return t;
 }
 
-describe('alb composer image-override picker (issue #382)', () => {
+describe('alb composer image-override picker (issue #384)', () => {
   it('renders one Dockerfile <select> per pinned backing service, labeled by service', () => {
     const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
     try {

--- a/tests/unit/local/studio-ui-reclassify.test.ts
+++ b/tests/unit/local/studio-ui-reclassify.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+/**
+ * Session-bar re-classify coverage (issue #385). When the `--from-cfn-stack`
+ * binding changes, `applyConfig` re-fetches `/api/targets` so the image-override
+ * pickers (which depend on the server-side pin classification) appear / vanish
+ * without restarting studio. A watch / role toggle — which does NOT change the
+ * pin classification — must NOT needlessly rebuild the target pane.
+ *
+ * Drives the real embedded `applyConfig` in jsdom with a RESOLVING `fetch` that
+ * records every call, so the post-PATCH path runs end to end. The init
+ * `loadConfig` parks on the harness's never-resolving default fetch, so
+ * `lastAppliedCfn` starts at its `null` default (no binding).
+ */
+interface FetchCall {
+  method: string;
+  url: string;
+}
+
+function recordingFetch(calls: FetchCall[]) {
+  return (url: string, init?: { method?: string }) => {
+    calls.push({ method: (init && init.method) || 'GET', url });
+    if (url === '/api/targets') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ groups: [], dockerfiles: [] }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  };
+}
+
+const tick = (ms = 20): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('Session bar re-classify on --from-cfn-stack change (issue #385)', () => {
+  it('re-fetches /api/targets after the from-cfn-stack binding changes', async () => {
+    const h = createStudioHarness();
+    try {
+      const calls: FetchCall[] = [];
+      (h.window as unknown as { fetch: unknown }).fetch = recordingFetch(calls);
+
+      const cfn = h.document.getElementById('sess-cfn') as HTMLInputElement;
+      cfn.checked = true;
+      cfn.dispatchEvent(new h.window.Event('change'));
+      await tick();
+
+      // The binding was PATCHed AND the target list re-fetched so the pickers
+      // refresh under the new --from-cfn-stack.
+      expect(calls.some((c) => c.method === 'PATCH' && c.url === '/api/config')).toBe(true);
+      expect(calls.some((c) => c.url === '/api/targets')).toBe(true);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('does NOT re-fetch /api/targets when only the watch toggle changes', async () => {
+    const h = createStudioHarness();
+    try {
+      const calls: FetchCall[] = [];
+      (h.window as unknown as { fetch: unknown }).fetch = recordingFetch(calls);
+
+      // Toggle watch (the from-cfn-stack control stays unchecked => unchanged).
+      const watch = h.document.getElementById('sess-watch') as HTMLInputElement;
+      watch.checked = true;
+      watch.dispatchEvent(new h.window.Event('change'));
+      await tick();
+
+      expect(calls.some((c) => c.method === 'PATCH' && c.url === '/api/config')).toBe(true);
+      // No binding change => no target-pane rebuild.
+      expect(calls.some((c) => c.url === '/api/targets')).toBe(false);
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl studio`'s ECS image-pin classification — which decides whether a service
/ ALB-backing-service is a deployed-registry pin and therefore gets an
image-override Dockerfile picker — previously ran **only at boot**. For an
INTRINSIC-ECR image (e.g. `ContainerImage.fromEcrRepository(repo)`) the pin is
only resolvable WITH `--from-cfn-stack`, so setting it in the Session bar after
boot updated the run-time binding but never re-ran the classification — the
pickers never appeared without restarting studio.

Now a Session-bar `--from-cfn-stack` change (`PATCH /api/config`) re-runs the
classification and swaps the served target list under the live socket, so the
image-override pickers appear / disappear under the new binding **without
restarting studio**.

### Changes

- **`studio-server.ts`**: `RunningStudioServer.setTargets(groups, dockerfiles?)`
  swaps the served `/api/targets` JSON atomically (single pre-stringified cell,
  read per request via a getter).
- **`local-studio.ts`**: extracted `classifyStudioTargets()` (annotates a FRESH
  clone of the un-annotated base each call, so a re-classify never inherits
  stale pins) and `reclassifyTargetsOnBindingChange()` (change-gate +
  latest-wins token + fail-soft warn) from the boot classification. The
  `PATCH /api/config` handler re-classifies + swaps **only** when
  `--from-cfn-stack` actually changes (a watch / assume-role toggle does not),
  threading the post-patch binding.
- **`studio-ui.ts`**: `applyConfig` re-fetches `/api/targets` after a successful
  PATCH only when the from-cfn-stack binding changed; running-serve rows are
  preserved across the re-render (driven by `serveState` + `updateServeRow`).
- **`#382` → `#384` rename**: the studio image-override-on-ALB feature
  referenced `#382` (an unrelated merged cloudfront PR) in source comments /
  tests / docs; corrected to the dedicated tracking issue #384.

## Behavior change (additive — no host migration)

cdkd embeds `createLocalStudioCommand` and inherits the re-classify
automatically. `RunningStudioServer.setTargets` is a new additive method on the
handle already re-exported from `src/internal.ts`; a host building a custom
studio server can call it but is not required to.

## Test plan

- **Unit**: `classifyStudioTargets` (pinned flips on `--from-cfn-stack` toggle
  against a fake state, no Dockerfile scan for an all-local app, base groups
  never mutated); `reclassifyTargetsOnBindingChange` (change-gate skips a
  no-op / watch toggle, latest-wins drops a superseded earlier classify,
  fail-soft warns + keeps the prior list, threads the post-patch binding);
  `setTargets` re-serve; a jsdom test that `applyConfig` re-fetches
  `/api/targets` only on a binding change.
- **Integration** (`local-studio`): a new section asserts a `--from-cfn-stack`
  PATCH re-runs classification (the studio log banner) + `/api/targets`
  re-serves the full target list under the live socket. Ran clean against the
  real `cdkl studio` binary; 0 Docker orphans.
- 3-axis review (spec / code / test) clean; the test-review gap (the PATCH
  orchestration was inline + untested) was addressed by extracting
  `reclassifyTargetsOnBindingChange` and unit-testing its branches.

Closes #385
