### PR TITLE
feat(start-alb,studio): #380 env/state/role parity for ALB Lambda targets + studio cloudfront bindings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -144,11 +144,16 @@ AWS managed services.
   event -> RIE -> response), so a forward can mix ECS and Lambda
   targets. Each Lambda target's container gets the SAME env as a direct
   `cdkl invoke` (issue #380): its declared `Environment.Variables`,
-  `--from-cfn-stack` intrinsic substitution, and `--assume-role` /
-  `--profile` creds are injected via the shared `resolveLambdaContainerEnv`
-  (resolved once per unique backing Lambda at boot — boot-time only, like the
-  rest of the front-door). `--env-vars` overlays the same SAM-shape
-  `Parameters` it overlays onto the ECS task containers
+  `--from-cfn-stack` intrinsic substitution, and `--assume-role` STS /
+  `--profile`-resolved creds are injected via the shared
+  `resolveLambdaContainerEnv` (resolved once per unique backing Lambda at boot
+  — boot-time only, like the rest of the front-door). As with
+  start-cloudfront's front-door Lambda path, the resolved creds ride the
+  container env overlay (so the standard SDK credential chain resolves them);
+  the named-profile credentials-FILE mount `cdkl invoke` adds is not
+  reproduced, so a handler reading creds via an explicit `fromIni({ profile })`
+  is the one `--profile` case not covered. `--env-vars` overlays the same
+  SAM-shape `Parameters` it overlays onto the ECS task containers
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -142,7 +142,13 @@ AWS managed services.
   itself). A `TargetType: lambda` target group is served by invoking
   the backing Lambda locally (HTTP request -> `requestContext.elb`
   event -> RIE -> response), so a forward can mix ECS and Lambda
-  targets
+  targets. Each Lambda target's container gets the SAME env as a direct
+  `cdkl invoke` (issue #380): its declared `Environment.Variables`,
+  `--from-cfn-stack` intrinsic substitution, and `--assume-role` /
+  `--profile` creds are injected via the shared `resolveLambdaContainerEnv`
+  (resolved once per unique backing Lambda at boot — boot-time only, like the
+  rest of the front-door). `--env-vars` overlays the same SAM-shape
+  `Parameters` it overlays onto the ECS task containers
 - Bedrock AgentCore Runtime agents — the agent served over its protocol
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
@@ -253,10 +259,9 @@ AWS managed services.
   is omitted in a TTY). Also runnable from `cdkl studio` as the
   `cloudfront` serve kind (issue #367) — a [Start]/[Stop] control with a
   capture proxy, like `api` / `alb`; the session-global
-  `--from-cfn-stack` / `--assume-role` bindings are NOT forwarded to the
-  studio cloudfront serve yet (studio still sets `omitStateBindings` for the
-  `cloudfront` kind — a #380 follow-up, since start-cloudfront now DOES
-  declare those flags for its Function URL origin Lambda)
+  `--from-cfn-stack` / `--assume-role` bindings ARE forwarded to the studio
+  cloudfront serve (issue #380, since start-cloudfront declares those flags
+  for its Function URL origin Lambda), same as every other serve kind
 
 ### Calls real AWS (managed services)
 
@@ -604,10 +609,11 @@ compute-locally category for Lambda + API Gateway).
   forward to their spawned child commands, so the two spawn sites cannot
   drift. The `omitStateBindings` option (issue #367) suppresses
   `--from-cfn-stack` / `--assume-role` for a child that does not declare
-  them — the serve-manager still sets it for the `cloudfront` kind. As of
-  issue #380 start-cloudfront DOES declare those flags (for a Function URL
-  origin Lambda), so forwarding the session bindings to the cloudfront serve
-  is a #380 follow-up; today they are still omitted),
+  them; as of issue #380 EVERY serve kind (incl. `cloudfront`, for its
+  Function URL origin Lambda) declares those flags, so the serve-manager no
+  longer sets `omitStateBindings` for any kind — the bindings are forwarded
+  to all serves. The guard stays available for a future pure-local serve
+  kind),
   studio-option-specs (issue #301 slice 2 — the per-target run-option
   descriptor table (`OPTION_SPECS`) that is the single source the UI
   renders controls from (serialized into the page) AND the server builds

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -100,6 +100,11 @@ import {
   createFrontDoorLambdaRunner,
   type FrontDoorLambdaRunner,
 } from '../../local/front-door-lambda-runner.js';
+import {
+  resolveLambdaContainerEnv,
+  type LambdaContainerEnvOptions,
+  type LambdaContainerEnvResult,
+} from './local-invoke.js';
 import type { FrontDoorAuthGuard } from '../../local/elb-front-door-resolver.js';
 import { buildAuthCheck } from '../../local/front-door-auth.js';
 import { createJwksCache, type WarnedAt } from '../../local/cognito-jwt.js';
@@ -695,7 +700,7 @@ export async function runEcsServiceEmulator(
     // bind failure should surface before any docker budget is spent. No-op when
     // the strategy returned no plan (start-service / pure compute).
     if (frontDoor && frontDoor.listeners.length > 0) {
-      const built = await buildFrontDoor(frontDoor, options, logger);
+      const built = await buildFrontDoor(frontDoor, options, logger, extraStateProviders);
       frontDoorServers = built.servers;
       frontDoorByService = built.frontDoorByService;
       frontDoorLambdaRunners = built.lambdaRunners;
@@ -1865,6 +1870,71 @@ async function resolveServiceAndRunnerOpts(
 }
 
 /**
+ * Collect the unique backing Lambdas across every forward action in the plan
+ * (default actions + listener rules), keyed by logical id. start-service plans
+ * have no Lambda targets so this is empty.
+ */
+function collectAlbLambdaTargets(plan: FrontDoorPlan): Map<string, ResolvedLambda> {
+  const out = new Map<string, ResolvedLambda>();
+  const fromAction = (action: PlannedAction | undefined): void => {
+    if (!action || action.kind !== 'forward') return;
+    for (const t of action.targets) {
+      if (t.kind === 'lambda' && !out.has(t.lambda.logicalId)) {
+        out.set(t.lambda.logicalId, t.lambda);
+      }
+    }
+  };
+  for (const listener of plan.listeners) {
+    fromAction(listener.defaultAction);
+    for (const rule of listener.rules) fromAction(rule.action);
+  }
+  return out;
+}
+
+/**
+ * Issue #380 — resolve the container env for every ALB `TargetType: lambda`
+ * target group's backing Lambda, the SAME way `cdkl invoke` /
+ * `cdkl start-cloudfront` do, via the shared {@link resolveLambdaContainerEnv}.
+ * Returns a `logicalId -> LambdaContainerEnvResult` map the front-door threads
+ * into each Lambda runner so the function's declared `Environment.Variables` +
+ * `--from-cfn-stack` intrinsic substitution + `--assume-role` / `--profile`
+ * creds all reach the locally-invoked Lambda. `--assume-role` collapses the
+ * legacy `--assume-task-role` alias via {@link resolveEcsAssumeRoleOption}, and
+ * `--env-vars` overlays the same SAM-shape `Parameters` it overlays onto the
+ * ECS task containers. Empty when the plan carries no Lambda targets.
+ */
+async function resolveAlbLambdaTargetEnv(
+  plan: FrontDoorPlan,
+  options: EcsServiceEmulatorOptions,
+  extraStateProviders: ExtraStateProviders | undefined
+): Promise<Map<string, LambdaContainerEnvResult>> {
+  const lambdas = collectAlbLambdaTargets(plan);
+  const out = new Map<string, LambdaContainerEnvResult>();
+  if (lambdas.size === 0) return out;
+
+  const effectiveAssumeRole = resolveEcsAssumeRoleOption(options);
+  const envOptions: LambdaContainerEnvOptions = {
+    ...(options.fromCfnStack !== undefined && { fromCfnStack: options.fromCfnStack }),
+    ...(effectiveAssumeRole !== undefined && { assumeRole: effectiveAssumeRole }),
+    ...(options.region !== undefined && { region: options.region }),
+    ...(options.profile !== undefined && { profile: options.profile }),
+    ...(options.stackRegion !== undefined && { stackRegion: options.stackRegion }),
+    ...(options.envVars !== undefined && { envVars: options.envVars }),
+  };
+  const profileCredentials = options.profile
+    ? await resolveProfileCredentials(options.profile)
+    : undefined;
+
+  for (const [logicalId, lambda] of lambdas) {
+    out.set(
+      logicalId,
+      await resolveLambdaContainerEnv(lambda, envOptions, profileCredentials, extraStateProviders)
+    );
+  }
+  return out;
+}
+
+/**
  * Stand up one host-side reverse-proxy server PER LISTENER PORT from the
  * resolved {@link FrontDoorPlan}, path-routing each request across the services
  * the listener fronts, and return the started servers (for teardown) plus a
@@ -1883,7 +1953,13 @@ async function resolveServiceAndRunnerOpts(
 export async function buildFrontDoor(
   plan: FrontDoorPlan,
   options: EcsServiceEmulatorOptions,
-  logger: ReturnType<typeof getLogger>
+  logger: ReturnType<typeof getLogger>,
+  // State providers for resolving ALB Lambda-target container env under
+  // `--from-cfn-stack` (issue #380). The production caller passes the
+  // emulator's providers; it defaults so ECS-routing unit tests (which carry
+  // no Lambda targets) can omit it — with no Lambda targets the resolution is
+  // never invoked, so the omission never masks a missing-state bug.
+  extraStateProviders?: ExtraStateProviders
 ): Promise<{
   servers: StartedFrontDoorServer[];
   frontDoorByService: Map<string, FrontDoorServicePools>;
@@ -1900,16 +1976,32 @@ export async function buildFrontDoor(
   // Lambda logicalId -> one warm runner, reused across listeners / rules.
   const lambdaRegistry = new Map<string, FrontDoorLambdaRunner>();
 
+  // Issue #380 — resolve each ALB Lambda target group's container env the
+  // SAME way `cdkl invoke` does, so a `TargetType: lambda` target reaches its
+  // deployed resources: declared `Environment.Variables` + `--from-cfn-stack`
+  // intrinsic substitution + `--assume-role` STS creds (else forwarded shell /
+  // `--profile` creds). Pre-resolved once per unique backing Lambda (boot-time
+  // only — the front-door is not rebuilt on `--watch` reload), then threaded
+  // into each runner below. start-service plans carry no Lambda targets, so
+  // this is a no-op there.
+  const lambdaEnvByLogicalId = await resolveAlbLambdaTargetEnv(plan, options, extraStateProviders);
+
   const dispatchFor = (t: PlannedForwardTarget): FrontDoorDispatchTarget => {
     if (t.kind === 'lambda') {
       let runner = lambdaRegistry.get(t.lambda.logicalId);
       if (!runner) {
+        const containerEnv = lambdaEnvByLogicalId.get(t.lambda.logicalId);
         runner = createFrontDoorLambdaRunner(t.lambda, {
           containerHost,
           skipPull: options.pull === false,
           ...(options.platform !== undefined && { platformOverride: options.platform }),
           ...(options.ecrRoleArn !== undefined && { ecrRoleArn: options.ecrRoleArn }),
           ...(options.region !== undefined && { region: options.region }),
+          ...(containerEnv !== undefined && { containerEnv: containerEnv.env }),
+          ...(containerEnv !== undefined &&
+            containerEnv.sensitiveEnvKeys.length > 0 && {
+              sensitiveEnvKeys: new Set(containerEnv.sensitiveEnvKeys),
+            }),
         });
         lambdaRegistry.set(t.lambda.logicalId, runner);
       }

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -326,15 +326,17 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
     // `config.watch` per start (mutable — a Session-bar toggle applies to
     // the next serve), matching the `--watch` flag append below.
     const preferAssembly = config.watch !== true;
-    // `cloudfront` runs no container / makes no AWS call, so start-cloudfront
-    // declares neither `--from-cfn-stack` nor `--assume-role`; do not forward
-    // the session bindings to it (issue #367).
-    const omitStateBindings = req.kind === 'cloudfront';
+    // Every serve kind now declares `--from-cfn-stack` / `--assume-role`:
+    // start-cloudfront gained them in issue #380 (a Function URL origin Lambda
+    // gets the same env / deployed-state / execution-role injection as
+    // `cdkl invoke`), so the session bindings are forwarded to ALL kinds. The
+    // `omitStateBindings` guard in buildSharedChildArgs stays available for a
+    // future pure-local serve kind that declares neither flag.
     return [
       spec.command,
       req.targetId,
       ...spec.portArgs,
-      ...buildSharedChildArgs(config, { preferAssembly, omitStateBindings }),
+      ...buildSharedChildArgs(config, { preferAssembly }),
       ...buildPerRunArgs(req.kind, req.options),
       // The `--env-vars` per-run option takes a FILE (issue #355) — the env-kv
       // KV rows / JSON were materialized into a SAM-shape temp file by the

--- a/tests/integration/local-start-alb-lambda/verify.sh
+++ b/tests/integration/local-start-alb-lambda/verify.sh
@@ -12,6 +12,10 @@
 #     event (requestContext.elb present, httpMethod=GET, path=/, query a=1).
 #   - GET /api/ping?x=1&x=2 -> path-routed to ApiFn, which sees the multi-value
 #     query variant (multiValueQueryStringParameters present).
+#   - Each Lambda target receives its declared Environment.Variables (GREETING),
+#     proving issue #380's container-env wiring (resolveLambdaContainerEnv) for
+#     ALB Lambda targets — before it, the runner injected only AWS_LAMBDA_* +
+#     shell creds and GREETING echoed "unset".
 #   - SIGTERM tears every container + network + front-door socket down.
 #
 #     bash tests/integration/local-start-alb-lambda/verify.sh
@@ -149,7 +153,15 @@ if ! echo "${ROOT_RESP}" | grep -q '"a":"1"'; then
   echo "FAIL: the Lambda event did not carry queryStringParameters {a:1}"
   exit 1
 fi
-echo "    OK: echo Lambda saw the ALB Lambda-target event (elb context + method + path + query)"
+# Issue #380 — the ALB Lambda target's declared Environment.Variables now reach
+# the container (via the shared resolveLambdaContainerEnv). Before this wiring
+# the front-door runner injected only AWS_LAMBDA_* + shell creds, so GREETING
+# would echo "unset"; assert the declared value flows through.
+if ! echo "${ROOT_RESP}" | grep -q '"greeting":"hello"'; then
+  echo "FAIL: EchoFn did not receive its declared env var GREETING=hello (got: ${ROOT_RESP})"
+  exit 1
+fi
+echo "    OK: echo Lambda saw the ALB Lambda-target event (elb context + method + path + query + declared env)"
 
 echo "==> Asserting the response headers were translated back to HTTP"
 HEADERS=$(curl -fsS -D - -o /dev/null "http://127.0.0.1:${LB_HOST_PORT}/?a=1" 2>/dev/null || true)
@@ -177,7 +189,13 @@ if ! echo "${API_RESP}" | grep -q '"multiValueQueryStringParameters":{"x":\["1",
   echo "FAIL: ApiFn did not receive the multi-value query variant for the multi-value-headers TG"
   exit 1
 fi
-echo "    OK: /api/ping path-routed to ApiFn with the multi-value query event variant"
+# Issue #380 — ApiFn's distinct declared env var reaches its container too (a
+# per-target env, not a shared one), proving the resolve-per-Lambda wiring.
+if ! echo "${API_RESP}" | grep -q '"greeting":"api-hello"'; then
+  echo "FAIL: ApiFn did not receive its declared env var GREETING=api-hello (got: ${API_RESP})"
+  exit 1
+fi
+echo "    OK: /api/ping path-routed to ApiFn with the multi-value query event variant + declared env"
 
 echo "==> Sending SIGTERM to cdk-local (${CDKL_PID})"
 kill -TERM "${CDKL_PID}"
@@ -219,4 +237,4 @@ if curl -fsS --max-time 2 "http://127.0.0.1:${LB_HOST_PORT}/" >/dev/null 2>&1; t
 fi
 
 echo ""
-echo "==> local-start-alb-lambda test passed (default -> EchoFn, /api/* -> ApiFn multi-value, clean teardown)"
+echo "==> local-start-alb-lambda test passed (default -> EchoFn, /api/* -> ApiFn multi-value, declared env injected, clean teardown)"

--- a/tests/unit/cli/start-alb-lambda-target-env.test.ts
+++ b/tests/unit/cli/start-alb-lambda-target-env.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { FrontDoorPlan } from '../../../src/cli/commands/ecs-service-emulator.js';
+import type { ResolvedLambda } from '../../../src/local/lambda-resolver.js';
+
+// Issue #380 — lock the binding that threads each ALB `TargetType: lambda`
+// target group's container env (resolved the same way `cdkl invoke` does)
+// into its front-door RIE runner. Mock the two boundaries `buildFrontDoor`
+// drives for a Lambda target — the shared env resolver and the runner factory
+// — and assert the env options + resolved env reach them. The front-door HTTP
+// server still binds a real ephemeral socket (closed in the test).
+const { resolveContainerEnvMock, createRunnerMock } = vi.hoisted(() => ({
+  resolveContainerEnvMock: vi.fn(),
+  createRunnerMock: vi.fn(),
+}));
+
+vi.mock('../../../src/cli/commands/local-invoke.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../src/cli/commands/local-invoke.js')>();
+  return { ...actual, resolveLambdaContainerEnv: resolveContainerEnvMock };
+});
+vi.mock('../../../src/local/front-door-lambda-runner.js', async (importActual) => {
+  const actual =
+    await importActual<typeof import('../../../src/local/front-door-lambda-runner.js')>();
+  return { ...actual, createFrontDoorLambdaRunner: createRunnerMock };
+});
+
+const { buildFrontDoor } = await import('../../../src/cli/commands/ecs-service-emulator.js');
+
+const lambda = { logicalId: 'EchoFn', functionName: 'echo' } as unknown as ResolvedLambda;
+
+/** A one-listener plan whose default action forwards to a single Lambda target. */
+function lambdaPlan(): FrontDoorPlan {
+  return {
+    listeners: [
+      {
+        listenerPort: 80,
+        hostPort: 0, // ephemeral — no privileged bind in the unit test
+        protocol: 'HTTP',
+        defaultAction: {
+          kind: 'forward',
+          targets: [
+            {
+              kind: 'lambda',
+              lambda,
+              targetGroupArn: 'AlbStack:WebTargetGroup',
+              multiValueHeaders: false,
+              weight: 1,
+            },
+          ],
+        },
+        rules: [],
+      },
+    ],
+  };
+}
+
+const logger = { info: () => {}, warn: () => {} } as never;
+const extraStateProviders = { marker: 'providers' } as never;
+
+beforeEach(() => {
+  resolveContainerEnvMock.mockReset();
+  createRunnerMock.mockReset();
+  resolveContainerEnvMock.mockResolvedValue({
+    env: { TABLE_NAME: 'deployed-table', AWS_LAMBDA_FUNCTION_NAME: 'EchoFn' },
+    sensitiveEnvKeys: ['DB_SECRET'],
+    assumeRoleApplied: true,
+  });
+  createRunnerMock.mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+    invoke: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('buildFrontDoor — ALB Lambda-target container env (issue #380)', () => {
+  it('resolves each Lambda target env via the shared resolver and threads it into the runner', async () => {
+    const options = {
+      containerHost: '127.0.0.1',
+      pull: true,
+      fromCfnStack: 'MyStack',
+      assumeRole: true,
+      region: 'us-east-1',
+      stackRegion: 'us-west-2',
+      envVars: '/tmp/env.json',
+    } as never;
+
+    const { servers, lambdaRunners } = await buildFrontDoor(
+      lambdaPlan(),
+      options,
+      logger,
+      extraStateProviders
+    );
+    try {
+      // The shared resolver was called once for the backing Lambda, with the
+      // state-source + assume-role + env-vars options collapsed from the ALB
+      // flags, plus the emulator's state providers.
+      expect(resolveContainerEnvMock).toHaveBeenCalledTimes(1);
+      const [passedLambda, envOptions, profileCreds, passedProviders] =
+        resolveContainerEnvMock.mock.calls[0]!;
+      expect((passedLambda as ResolvedLambda).logicalId).toBe('EchoFn');
+      expect(envOptions).toEqual({
+        fromCfnStack: 'MyStack',
+        assumeRole: true,
+        region: 'us-east-1',
+        stackRegion: 'us-west-2',
+        envVars: '/tmp/env.json',
+      });
+      expect(profileCreds).toBeUndefined(); // no --profile -> shell creds
+      expect(passedProviders).toBe(extraStateProviders);
+
+      // The resolved env + sensitive keys reached the runner factory.
+      expect(createRunnerMock).toHaveBeenCalledTimes(1);
+      const runnerOpts = createRunnerMock.mock.calls[0]![1] as {
+        containerEnv?: Record<string, string>;
+        sensitiveEnvKeys?: Set<string>;
+      };
+      expect(runnerOpts.containerEnv).toEqual({
+        TABLE_NAME: 'deployed-table',
+        AWS_LAMBDA_FUNCTION_NAME: 'EchoFn',
+      });
+      expect(runnerOpts.sensitiveEnvKeys).toEqual(new Set(['DB_SECRET']));
+      expect(lambdaRunners).toHaveLength(1);
+    } finally {
+      await Promise.all(servers.map((s) => s.close()));
+    }
+  });
+
+  it('resolves env ONCE per unique backing Lambda across multiple rules', async () => {
+    const plan = lambdaPlan();
+    // A second rule forwarding to the SAME Lambda must not re-resolve its env.
+    plan.listeners[0]!.rules.push({
+      priority: 10,
+      pathPatterns: ['/api/*'],
+      hostPatterns: [],
+      httpHeaderConditions: [],
+      httpRequestMethods: [],
+      queryStringConditions: [],
+      sourceIpCidrs: [],
+      action: {
+        kind: 'forward',
+        targets: [
+          {
+            kind: 'lambda',
+            lambda,
+            targetGroupArn: 'AlbStack:WebTargetGroup',
+            multiValueHeaders: false,
+            weight: 1,
+          },
+        ],
+      },
+    });
+
+    const { servers } = await buildFrontDoor(
+      plan,
+      { containerHost: '127.0.0.1', pull: true } as never,
+      logger,
+      undefined
+    );
+    try {
+      expect(resolveContainerEnvMock).toHaveBeenCalledTimes(1);
+      expect(createRunnerMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await Promise.all(servers.map((s) => s.close()));
+    }
+  });
+
+  it('does not resolve any Lambda env for an ECS-only plan (start-service path)', async () => {
+    const plan: FrontDoorPlan = {
+      listeners: [
+        {
+          listenerPort: 80,
+          hostPort: 0,
+          protocol: 'HTTP',
+          defaultAction: {
+            kind: 'forward',
+            targets: [
+              {
+                kind: 'ecs',
+                serviceTarget: 'S:Web',
+                targetContainerName: 'web',
+                targetContainerPort: 80,
+                weight: 1,
+              },
+            ],
+          },
+          rules: [],
+        },
+      ],
+    };
+    const { servers } = await buildFrontDoor(
+      plan,
+      { containerHost: '127.0.0.1', pull: true } as never,
+      logger,
+      undefined
+    );
+    try {
+      expect(resolveContainerEnvMock).not.toHaveBeenCalled();
+      expect(createRunnerMock).not.toHaveBeenCalled();
+    } finally {
+      await Promise.all(servers.map((s) => s.close()));
+    }
+  });
+});

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -467,7 +467,7 @@ describe('createStudioServeManager', () => {
     expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
   });
 
-  it('does NOT forward --from-cfn-stack / --assume-role to a cloudfront serve (issue #367)', async () => {
+  it('DOES forward --from-cfn-stack / --assume-role to a cloudfront serve (issue #380)', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();
     const spawnFn = vi.fn(() => child as never);
@@ -478,8 +478,9 @@ describe('createStudioServeManager', () => {
       spawnFn: spawnFn as never,
       clock: fixedClock(),
       proxyFactory: fp.factory,
-      // Session bindings set — start-cloudfront declares neither flag, so they
-      // must NOT reach the child (it would reject with "unknown option").
+      // Session bindings set — start-cloudfront declares both flags as of #380
+      // (a Function URL origin Lambda gets `cdkl invoke`-parity env / state /
+      // role), so they MUST reach the child.
       fromCfnStack: 'MyStack',
       assumeRole: 'arn:aws:iam::123456789012:role/app',
     });
@@ -487,11 +488,15 @@ describe('createStudioServeManager', () => {
     child.stdout.emit('data', 'CloudFront distribution serving on http://127.0.0.1:51234  (SiteDist)\n');
     await p;
     const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
-    expect(argv).not.toContain('--from-cfn-stack');
-    expect(argv).not.toContain('--assume-role');
+    const fi = argv.indexOf('--from-cfn-stack');
+    expect(fi).toBeGreaterThan(-1);
+    expect(argv[fi + 1]).toBe('MyStack');
+    const ai = argv.indexOf('--assume-role');
+    expect(ai).toBeGreaterThan(-1);
+    expect(argv[ai + 1]).toBe('arn:aws:iam::123456789012:role/app');
   });
 
-  it('DOES forward --from-cfn-stack to an api serve (kind-specific omit only) (issue #367)', async () => {
+  it('DOES forward --from-cfn-stack to an api serve (issue #367)', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();
     const spawnFn = vi.fn(() => child as never);


### PR DESCRIPTION
## Summary

Completes issue #380's `cdkl invoke`-parity container-env injection across the
remaining serve surfaces (slice A, #382, did start-cloudfront's Function URL
origin Lambda). Two related follow-ups:

### 1. start-alb Lambda target groups get their container env

An ALB `TargetType: lambda` target group's backing Lambda ran through the
front-door runner with only `AWS_LAMBDA_*` + the dev shell's AWS creds — its
declared `Environment.Variables` were **dropped**, and start-alb's existing
`--from-cfn-stack` / `--assume-role` flags (already wired for the ECS targets)
never reached it.

`buildFrontDoor` now pre-resolves each unique backing Lambda's container env via
the shared `resolveLambdaContainerEnv` (the same helper `cdkl invoke` /
`start-cloudfront` use) and threads the resolved `containerEnv` +
`sensitiveEnvKeys` into each runner: declared env vars + `--from-cfn-stack`
intrinsic substitution + `--assume-role` STS creds (collapsing the legacy
`--assume-task-role` alias via `resolveEcsAssumeRoleOption`) + `--profile`
creds + `--env-vars` overlay. Resolved once per unique Lambda at boot (boot-time
only, like the rest of the front-door). `start-service` plans carry no Lambda
targets, so it is a no-op there.

### 2. studio forwards the session bindings to the cloudfront serve

start-cloudfront declares `--from-cfn-stack` / `--assume-role` as of #380, so
the studio serve-manager no longer sets `omitStateBindings` for the `cloudfront`
kind — the session-global bindings now forward to **every** serve kind. The
`omitStateBindings` guard stays available for a future pure-local serve kind.

### Behavior change (additive)

ALB Lambda targets now receive their declared env / deployed-state / role
(previously an empty env), and the studio cloudfront serve now inherits the
session bindings. Both additive — a host CLI wrapping `start-alb` / `cdkl studio`
inherits the behavior on its next `cdk-local` dependency bump, no host code
change. No new CLI flags, no new `src/internal.ts` / `src/index.ts` surface
(the new helpers are internal to `ecs-service-emulator.ts`), so cdkd parity is a
documented additive behavior change only.

### Known limitation (`--profile`)

As with start-cloudfront's front-door Lambda path, the `--profile`-resolved
creds ride the container env overlay (the standard SDK credential chain resolves
them), but the named-profile credentials-FILE mount `cdkl invoke` adds is not
reproduced — so a handler reading creds via an explicit `fromIni({ profile })`
is the one `--profile` case not covered. Documented in `.claude/CLAUDE.md`.

## Test plan

- `vp run check` + `vp run build` — pass.
- `vp test run` — 2689 unit tests pass, incl. a new site-level binding test
  (`tests/unit/cli/start-alb-lambda-target-env.test.ts`): the ALB flags reach
  the shared resolver as `envOptions`, the resolved env + sensitiveEnvKeys reach
  the runner, env is resolved once per unique Lambda across multiple rules, and
  an ECS-only plan resolves nothing (no profile-cred fetch). The studio
  cloudfront forward test is flipped to assert the bindings now reach the child.
- **Integ** `local-start-alb-lambda` (pure-local, Docker, no AWS) — extended
  with GREETING assertions: each ALB Lambda target now receives its declared
  `Environment.Variables` (`hello` / `api-hello` per target) where it echoed
  `"unset"` before this wiring. PASS, 0 Docker orphans. The `--from-cfn-stack`
  intrinsic-resolution path is covered end-to-end for the shared helper by the
  existing `local-start-cloudfront-lambda-url-from-cfn-stack` real-AWS integ.

## Review

1-reviewer (size tier). 0 blockers. One minor finding — the `--profile`
named-profile-file-mount gap — accepted as a documented known limitation
(consistent with start-cloudfront's front-door Lambda path) and the
`.claude/CLAUDE.md` claim narrowed accordingly.

Part of #380 (slice B). Slice A (#382) shipped the start-cloudfront half.
