### PR TITLE
feat(run-task): --image-override rebuilds a pinned task-def image from a local Dockerfile (slice A of #388)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -101,7 +101,15 @@ AWS managed services.
   named target, and an orphan validator
   (`enforceImageOverrideOrphans`) fails the boot when a per-service
   flag names a service the resolved override map does NOT cover
-  (typo / forgotten `--image-override` mapping).
+  (typo / forgotten `--image-override` mapping). Issue #388 extended
+  the SAME `--image-override` flag family to `cdkl run-task`: a pinned
+  (deployed-registry) task-definition container image is rebuilt from
+  the supplied Dockerfile and threaded into the run via
+  `imageOverrideByContainer` (a task def has ONE override target — its
+  representative essential container — so the picker / boot-prompt forms
+  map to that single target; `resolveRunTaskImageOverride` reuses the
+  shared engine primitives, and a pinned-but-uncovered image WARNs that
+  local source edits will not take effect).
   The host front-door (TLS materials, JWKS cache,
   Lambda-target RIE containers, listener sockets) is built once at
   boot and is NOT recreated on reload — only the per-service replica

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -964,6 +964,12 @@ Path matching is prefix-based: an L2 path like
 | `--platform <platform>` | inferred from `RuntimePlatform.CpuArchitecture` | `linux/amd64` or `linux/arm64`. Threaded into every container's `docker run --platform`. |
 | `--keep-running` | off | Don't `docker rm -f` user containers on task exit (network + sidecar are still torn down). Use when you want to `docker exec` into a stopped container for post-mortems. |
 | `--detach` | off | Start the containers and return without streaming logs or auto-tearing them down. Useful in CI smoke tests; caller manages container lifecycle. |
+| `--image-override <target=dockerfile or dockerfile>` | — | Rebuild the task definition's pinned (deployed-registry) container image from a local `docker build` of the supplied Dockerfile, then run that locally-built image instead of pulling the pinned one. A task definition has ONE override target (its representative essential container), so an explicit `<target>=<dockerfile>` maps to it (a bare `<dockerfile>` works too — but the bare picker form needs a TTY and is skipped under `--no-interactive-overrides` / non-interactive runs, so prefer the explicit form when scripting). Lets `--from-cfn-stack` still reach real AWS state for env / secrets while you iterate on the application container locally. A pinned-but-uncovered image WARNs that local source edits will not take effect. Same engine as `start-service` / `start-alb`. |
+| `--image-build-arg <KEY=VAL>` | — | `docker build --build-arg KEY=VAL` applied to the `--image-override` build (repeatable). |
+| `--image-build-secret <id=src>` | — | `docker build --secret id=<id>,src=<src>` applied to the `--image-override` build (repeatable); enables `RUN --mount=type=secret,id=<id>` in the Dockerfile. |
+| `--image-target <stage>` | — | `docker build --target <stage>` for the `--image-override` build (stop at an intermediate multi-stage stage). |
+| `--no-interactive-overrides` | off | Suppress the interactive boot prompt that asks for a Dockerfile when the image is pinned (use in CI / scripted runs). |
+| `--strict-overrides` | off | Fail fast when the pinned image stays uncovered after `--image-override` resolves. |
 
 Plus the [common flags](#common-flags): `-a/--app`, `--output`,
 `-c/--context`, `--profile`, `--role-arn`, `--verbose`, `-y/--yes`.

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -29,6 +29,7 @@ import {
   resolveEcsTaskTarget,
   TASK_ROLE_ACCOUNT_PLACEHOLDER,
   type EcsImageResolutionContext,
+  type ResolvedEcsTask,
 } from '../../local/ecs-task-resolver.js';
 import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import {
@@ -42,9 +43,16 @@ import {
 import { matchStacks } from '../stack-matcher.js';
 import {
   addEcsAssumeRoleOptions,
+  addImageOverrideOptions,
   ecsClusterOption,
   resolveEcsAssumeRoleOption,
 } from './ecs-service-emulator.js';
+import {
+  parseImageOverrideFlags,
+  resolveImageOverrides,
+  enforceImageOverrideOrphans,
+  runImageOverrideBuilds,
+} from '../../local/image-override-engine.js';
 import {
   createLocalStateProvider,
   resolveCfnFallbackRegion,
@@ -119,6 +127,24 @@ interface LocalRunTaskOptions {
    * for `--from-cfn-stack`.
    */
   stackRegion?: string;
+  /**
+   * Issue #388 — the `--image-override` flag family (shared with
+   * `start-service` / `start-alb`). When the task definition's
+   * representative container image is a deployed-registry pin (ECR /
+   * public), rebuild it locally from a supplied Dockerfile and thread the
+   * resulting tag into the run. `imageOverride` is `<dockerfile>` (picker /
+   * boot-prompt form, single task) or `<target>=<dockerfile>` (explicit);
+   * `imageBuildArg` / `imageBuildSecret` / `imageTarget` are build-input
+   * pass-throughs; `interactiveOverrides` is `false` under
+   * `--no-interactive-overrides`; `strictOverrides` fails fast when the
+   * pinned image stays uncovered.
+   */
+  imageOverride?: string[];
+  imageBuildArg?: string[];
+  imageBuildSecret?: string[];
+  imageTarget?: string | string[];
+  interactiveOverrides?: boolean;
+  strictOverrides?: boolean;
   /** Host-injected extra state-source flag fields. */
   [key: string]: unknown;
 }
@@ -404,6 +430,25 @@ async function localRunTaskCommand(
         containerPath: profileCredsFile.containerPath,
         profileName: profileCredsFile.profileName,
       };
+    }
+
+    // Issue #388 — `--image-override`: rebuild a pinned (deployed-registry)
+    // task-def container image from a local Dockerfile and thread the built tag
+    // into the run. A pinned-but-uncovered image WARNs (local edits won't take
+    // effect); a local CDK asset already rebuilds locally, so this is a no-op.
+    const imageOverrideResult = await resolveRunTaskImageOverride({
+      task,
+      target: resolvedTarget,
+      options,
+      cwd: process.cwd(),
+    });
+    if (imageOverrideResult.imageOverrideByContainer) {
+      runOpts.imageOverrideByContainer = imageOverrideResult.imageOverrideByContainer;
+    } else if (imageOverrideResult.pinnedUncovered) {
+      logger.warn(
+        'Task definition image is pinned to a deployed registry; local source edits will not take ' +
+          'effect. Pass --image-override <dockerfile> to rebuild it from local source.'
+      );
     }
 
     // Issue #366 — a stable "running" banner after every container is up. The
@@ -757,6 +802,115 @@ export function createLocalRunTaskCommand(opts: CreateLocalRunTaskCommandOptions
  * and folding `run-task` into the service common block would mutate the
  * surface non-trivially. Each command keeps its own helper.
  */
+/** The outcome of {@link resolveRunTaskImageOverride}. */
+export interface RunTaskImageOverrideResult {
+  /**
+   * The per-container override map to thread into `runEcsTask` as
+   * `imageOverrideByContainer` — present only when an override image was
+   * built. Keyed by the representative (essential) container's name.
+   */
+  imageOverrideByContainer?: Map<string, string>;
+  /**
+   * True when the representative image is a deployed-registry pin that NO
+   * override covered, so the caller WARNs that local source edits will not
+   * take effect (the run pulls the pinned image as before).
+   */
+  pinnedUncovered?: boolean;
+}
+
+/**
+ * Resolve + build a `--image-override` for `cdkl run-task` (issue #388).
+ *
+ * A pinned (deployed-registry) task-def container image does not pick up local
+ * source edits; this rebuilds it from a supplied Dockerfile and returns the
+ * per-container override map threaded into `runEcsTask`. Mirrors the
+ * `start-service` / `start-alb` override path — the engine primitives
+ * (`parseImageOverrideFlags` / `resolveImageOverrides` /
+ * `enforceImageOverrideOrphans` / `runImageOverrideBuilds`) are shared — but
+ * resolves against the already-resolved task instead of a service: a task
+ * definition has exactly ONE override target (its representative container),
+ * so the picker / boot-prompt forms map to that single target.
+ *
+ * The representative container is the first essential one (or the first
+ * container when none is marked essential). It is pinned when its image kind is
+ * not `cdk-asset`. A short-circuit returns early when nothing is pinned AND no
+ * override flag was passed, so the common local-asset run pays nothing. Throws
+ * (clean user error) when `--strict-overrides` is set and the pinned image
+ * stays uncovered, or when a per-service build-input flag is orphaned
+ * (`enforceImageOverrideOrphans`). Exported for unit testing.
+ */
+export async function resolveRunTaskImageOverride(args: {
+  task: ResolvedEcsTask;
+  target: string;
+  options: Pick<
+    LocalRunTaskOptions,
+    | 'imageOverride'
+    | 'imageBuildArg'
+    | 'imageBuildSecret'
+    | 'imageTarget'
+    | 'interactiveOverrides'
+    | 'strictOverrides'
+  >;
+  cwd?: string;
+}): Promise<RunTaskImageOverrideResult> {
+  const { task, target, options, cwd } = args;
+  const essential = task.containers.find((c) => c.essential) ?? task.containers[0];
+  const pinned = essential !== undefined && essential.image.kind !== 'cdk-asset';
+  const pinnedTargets = pinned ? [target] : [];
+  const pinnedLabels = new Map<string, string>();
+  if (pinned) pinnedLabels.set(target, `${task.stack.stackName}/${task.taskDefinitionLogicalId}`);
+
+  const rawFlags = parseImageOverrideFlags({
+    ...(options.imageOverride && { imageOverride: options.imageOverride }),
+    ...(options.imageBuildArg && { imageBuildArg: options.imageBuildArg }),
+    ...(options.imageBuildSecret && { imageBuildSecret: options.imageBuildSecret }),
+    ...(options.imageTarget && { imageTarget: options.imageTarget }),
+  });
+
+  // Nothing pinned to prompt about AND no override flag => no-op. Per-service
+  // build-input flags are NOT eligible for short-circuit so the orphan
+  // validator still surfaces a typo'd / forgotten `--image-override`.
+  if (
+    pinnedTargets.length === 0 &&
+    rawFlags.explicit.size === 0 &&
+    rawFlags.pickerPaths.length === 0 &&
+    rawFlags.perService.size === 0
+  ) {
+    return {};
+  }
+
+  const overrides = await resolveImageOverrides({
+    rawFlags,
+    pinnedTargets,
+    pinnedLabels,
+    interactiveBootPrompt: true,
+    noInteractive: options.interactiveOverrides === false,
+    ...(cwd !== undefined ? { cwd } : {}),
+  });
+  enforceImageOverrideOrphans(rawFlags, overrides);
+
+  const uncovered = pinnedTargets.filter((t) => !overrides.has(t));
+  if (options.strictOverrides === true && uncovered.length > 0) {
+    throw new Error(
+      '--strict-overrides set, but the task definition image is pinned to a deployed registry and ' +
+        'no --image-override covered it. Pass --image-override <dockerfile> to rebuild it from local ' +
+        'source, or drop --strict-overrides / --from-cfn-stack to run the pinned image as-is.'
+    );
+  }
+
+  if (overrides.size === 0) return { pinnedUncovered: pinned };
+
+  const tags = await runImageOverrideBuilds(overrides);
+  const tag = tags.get(target);
+  if (tag !== undefined && essential !== undefined) {
+    return { imageOverrideByContainer: new Map([[essential.name, tag]]) };
+  }
+  // Defensive: overrides built but none covered THIS target — reachable only
+  // when every resolved override is for a different (mistyped) explicit key, so
+  // the actual target stays uncovered. Report it as such so the caller WARNs.
+  return { pinnedUncovered: pinned && uncovered.length > 0 };
+}
+
 export function addRunTaskSpecificOptions(cmd: Command): Command {
   cmd
     // Issue #249 / C12 — `--cluster` default sourced from the shared
@@ -847,5 +1001,10 @@ export function addRunTaskSpecificOptions(cmd: Command): Command {
         'Region of the state record to read. Used with --from-cfn-stack as the CFn client region.'
       )
     );
+  // Issue #388 — the `--image-override` flag family (shared with
+  // `start-service` / `start-alb`). Lets a pinned (deployed-registry) task-def
+  // container image be rebuilt from a local Dockerfile while `--from-cfn-stack`
+  // still reaches real AWS state for env / secrets.
+  addImageOverrideOptions(cmd);
   return cmd;
 }

--- a/tests/integration/local-run-task/Dockerfile.override
+++ b/tests/integration/local-run-task/Dockerfile.override
@@ -1,0 +1,6 @@
+# Local image-override for the run-task integ (issue #388). The fixture's
+# NginxTask pins a public-registry image (public.ecr.aws/nginx/nginx:alpine);
+# `cdkl run-task --image-override` rebuilds it from this Dockerfile instead, so
+# the served page carries a sentinel the pinned image never would.
+FROM public.ecr.aws/nginx/nginx:alpine
+RUN echo 'run-task-image-override-sentinel-388' > /usr/share/nginx/html/index.html

--- a/tests/integration/local-run-task/verify.sh
+++ b/tests/integration/local-run-task/verify.sh
@@ -24,8 +24,18 @@ cleanup() {
   echo "==> Cleanup: stopping any leftover containers"
   docker ps --filter "name=cdkl-" --format '{{.ID}}' | xargs -r docker rm -f >/dev/null 2>&1 || true
   docker network ls --filter "name=cdkl-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
+  # Issue #388 — drop the local-only override image(s) the --image-override run
+  # built (tag prefix is the embed binary name: `cdkl-override-*:local`).
+  docker images --filter 'reference=cdkl-override-*' -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+
+# Tear down every cdkl run-task container + network between phases so the
+# fixed host port 18080 is free for the next detached run.
+teardown_runs() {
+  docker ps --filter "name=cdkl-" --format '{{.ID}}' | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
+}
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
@@ -40,10 +50,21 @@ if [[ ! -d node_modules ]]; then
 fi
 
 
-echo "==> [1/2] Starting task via --detach"
-${CDKL} run-task CdkLocalRunTaskFixture/NginxTask --detach --no-pull --container-host 127.0.0.1
+echo "==> [1/3] Starting task via --detach"
+# Capture the run output: the fixture's image is a public-registry pin, so a
+# run WITHOUT --image-override must WARN that local source edits will not take
+# effect (issue #388 — this locks the command-level pinned-uncovered WARN
+# binding end-to-end, not just the helper).
+PINNED_RUN_LOG=$(mktemp)
+${CDKL} run-task CdkLocalRunTaskFixture/NginxTask --detach --no-pull --container-host 127.0.0.1 2>&1 | tee "${PINNED_RUN_LOG}"
+if ! grep -qiF 'pinned to a deployed registry' "${PINNED_RUN_LOG}"; then
+  echo "FAIL: run-task did not WARN that the pinned task-def image will not pick up local edits"
+  rm -f "${PINNED_RUN_LOG}"; exit 1
+fi
+rm -f "${PINNED_RUN_LOG}"
+echo "    OK: pinned-image WARN surfaced (suggests --image-override)"
 
-echo "==> [2/2] Curling http://127.0.0.1:18080/"
+echo "==> [2/3] Curling http://127.0.0.1:18080/"
 # Give nginx ~5s to listen.
 sleep 5
 HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:18080/ || true)
@@ -52,6 +73,34 @@ if [[ "${HTTP_CODE}" != "200" ]]; then
   echo "FAIL: expected 200, got ${HTTP_CODE}"
   exit 1
 fi
+# The pinned image serves the stock nginx welcome page (NOT the override sentinel).
+PINNED_BODY=$(curl -s http://127.0.0.1:18080/ || true)
+if grep -qF 'run-task-image-override-sentinel-388' <<<"${PINNED_BODY}"; then
+  echo "FAIL: the pinned run already served the override sentinel (test is not discriminating)"
+  exit 1
+fi
+
+# Issue #388 — `cdkl run-task --image-override <target>=<dockerfile>` rebuilds
+# the pinned (public-registry) task-def image from a local Dockerfile. The
+# explicit <target>=<dockerfile> form is used (no TTY in CI -> the bare picker
+# form would be skipped). The override image writes a sentinel into the served
+# page, so asserting the sentinel proves the LOCAL build ran in place of the
+# pinned image.
+echo "==> Tearing down the pinned run to free host port 18080"
+teardown_runs
+
+echo "==> [3/3] run-task --image-override rebuilds the pinned task-def image from a local Dockerfile"
+${CDKL} run-task CdkLocalRunTaskFixture/NginxTask \
+  --image-override 'CdkLocalRunTaskFixture/NginxTask=Dockerfile.override' \
+  --no-interactive-overrides --detach --no-pull --container-host 127.0.0.1
+sleep 5
+OV_BODY=$(curl -s http://127.0.0.1:18080/ || true)
+if ! grep -qF 'run-task-image-override-sentinel-388' <<<"${OV_BODY}"; then
+  echo "FAIL: --image-override did not serve the local Dockerfile build (sentinel absent)"
+  echo "----- body -----"; echo "${OV_BODY}" | head -c 500; echo; echo "----------------"
+  exit 1
+fi
+echo "    OK: the pinned task-def image was rebuilt from the local Dockerfile (sentinel served)"
 
 echo ""
-echo "==> All local-run-task tests passed"
+echo "==> All local-run-task tests passed (run + image-override rebuild)"

--- a/tests/unit/cli/local-run-task-image-override.test.ts
+++ b/tests/unit/cli/local-run-task-image-override.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ResolvedEcsTask, ResolvedEcsContainer } from '../../../src/local/ecs-task-resolver.js';
+
+// Mock the image-override engine so the run-task wiring (issue #388) is tested
+// without `docker build` / a real synth — the engine itself has its own suite.
+const hoisted = vi.hoisted(() => ({
+  parseImageOverrideFlags: vi.fn(),
+  resolveImageOverrides: vi.fn(),
+  enforceImageOverrideOrphans: vi.fn(),
+  runImageOverrideBuilds: vi.fn(),
+}));
+
+vi.mock('../../../src/local/image-override-engine.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/local/image-override-engine.js')>();
+  return { ...actual, ...hoisted };
+});
+
+const { resolveRunTaskImageOverride } = await import('../../../src/cli/commands/local-run-task.js');
+
+/** A minimal RawImageOverrideFlags-shaped object (only the read fields). */
+function rawFlags(over: Partial<{ explicit: Map<string, string>; pickerPaths: string[]; perService: Map<string, unknown> }> = {}) {
+  return {
+    explicit: over.explicit ?? new Map<string, string>(),
+    pickerPaths: over.pickerPaths ?? [],
+    globals: { buildArgs: new Map(), buildSecrets: new Map() },
+    perService: over.perService ?? new Map(),
+  };
+}
+
+function container(name: string, kind: ResolvedEcsContainer['image']['kind'], essential = true): ResolvedEcsContainer {
+  const image =
+    kind === 'cdk-asset'
+      ? { kind: 'cdk-asset' as const }
+      : kind === 'ecr'
+        ? { kind: 'ecr' as const, uri: '111.dkr.ecr.us-east-1.amazonaws.com/repo:tag', account: '111', region: 'us-east-1' }
+        : { kind: 'public' as const, uri: 'public.ecr.aws/x/y:latest' };
+  return { name, image, essential } as unknown as ResolvedEcsContainer;
+}
+
+function task(containers: ResolvedEcsContainer[]): ResolvedEcsTask {
+  return {
+    stack: { stackName: 'MyStack' },
+    taskDefinitionLogicalId: 'MyTaskDef',
+    family: 'fam',
+    containers,
+  } as unknown as ResolvedEcsTask;
+}
+
+beforeEach(() => {
+  hoisted.parseImageOverrideFlags.mockReset().mockReturnValue(rawFlags());
+  hoisted.resolveImageOverrides.mockReset().mockResolvedValue(new Map());
+  hoisted.enforceImageOverrideOrphans.mockReset();
+  hoisted.runImageOverrideBuilds.mockReset().mockResolvedValue(new Map());
+});
+
+describe('resolveRunTaskImageOverride (issue #388)', () => {
+  it('short-circuits for a local CDK-asset task with no override flags', async () => {
+    const result = await resolveRunTaskImageOverride({
+      task: task([container('web', 'cdk-asset')]),
+      target: 'MyStack/MyTaskDef',
+      options: {},
+    });
+    expect(result).toEqual({});
+    expect(hoisted.resolveImageOverrides).not.toHaveBeenCalled();
+    expect(hoisted.runImageOverrideBuilds).not.toHaveBeenCalled();
+  });
+
+  it('reports pinnedUncovered when a pinned image gets no override', async () => {
+    hoisted.resolveImageOverrides.mockResolvedValue(new Map()); // nothing covered
+    const result = await resolveRunTaskImageOverride({
+      task: task([container('web', 'ecr')]),
+      target: 'MyStack/MyTaskDef',
+      options: { interactiveOverrides: false },
+    });
+    expect(result.pinnedUncovered).toBe(true);
+    expect(result.imageOverrideByContainer).toBeUndefined();
+    // The pinned target + a (no-op) resolve still ran (no short-circuit).
+    expect(hoisted.resolveImageOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({ pinnedTargets: ['MyStack/MyTaskDef'] })
+    );
+    expect(hoisted.runImageOverrideBuilds).not.toHaveBeenCalled();
+  });
+
+  it('builds + threads the override tag keyed on the essential container', async () => {
+    hoisted.parseImageOverrideFlags.mockReturnValue(
+      rawFlags({ explicit: new Map([['MyStack/MyTaskDef', './Dockerfile']]) })
+    );
+    hoisted.resolveImageOverrides.mockResolvedValue(new Map([['MyStack/MyTaskDef', {}]]));
+    hoisted.runImageOverrideBuilds.mockResolvedValue(
+      new Map([['MyStack/MyTaskDef', 'cdk-local-override-mytaskdef-abc:local']])
+    );
+    const result = await resolveRunTaskImageOverride({
+      task: task([container('sidecar', 'ecr', false), container('app', 'ecr', true)]),
+      target: 'MyStack/MyTaskDef',
+      options: { imageOverride: ['./Dockerfile'] },
+    });
+    expect(result.imageOverrideByContainer).toEqual(
+      new Map([['app', 'cdk-local-override-mytaskdef-abc:local']])
+    );
+  });
+
+  it('classifies a public-registry image as pinned (parity with the ecr pin)', async () => {
+    hoisted.resolveImageOverrides.mockResolvedValue(new Map());
+    const result = await resolveRunTaskImageOverride({
+      task: task([container('web', 'public')]),
+      target: 'MyStack/MyTaskDef',
+      options: { interactiveOverrides: false },
+    });
+    expect(result.pinnedUncovered).toBe(true);
+    expect(hoisted.resolveImageOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({ pinnedTargets: ['MyStack/MyTaskDef'] })
+    );
+  });
+
+  it('keys the override on the first container when none is marked essential', async () => {
+    hoisted.parseImageOverrideFlags.mockReturnValue(
+      rawFlags({ explicit: new Map([['MyStack/MyTaskDef', './Dockerfile']]) })
+    );
+    hoisted.resolveImageOverrides.mockResolvedValue(new Map([['MyStack/MyTaskDef', {}]]));
+    hoisted.runImageOverrideBuilds.mockResolvedValue(new Map([['MyStack/MyTaskDef', 'tag:local']]));
+    // Both containers non-essential => representative is the first (`first`).
+    const result = await resolveRunTaskImageOverride({
+      task: task([container('first', 'ecr', false), container('second', 'ecr', false)]),
+      target: 'MyStack/MyTaskDef',
+      options: { imageOverride: ['./Dockerfile'] },
+    });
+    expect(result.imageOverrideByContainer).toEqual(new Map([['first', 'tag:local']]));
+  });
+
+  it('throws under --strict-overrides when the pinned image stays uncovered', async () => {
+    hoisted.resolveImageOverrides.mockResolvedValue(new Map()); // uncovered
+    await expect(
+      resolveRunTaskImageOverride({
+        task: task([container('web', 'ecr')]),
+        target: 'MyStack/MyTaskDef',
+        options: { strictOverrides: true, interactiveOverrides: false },
+      })
+    ).rejects.toThrow(/strict-overrides/);
+  });
+
+  it('propagates an orphaned per-service build-input flag error', async () => {
+    hoisted.parseImageOverrideFlags.mockReturnValue(
+      rawFlags({ perService: new Map([['MyStack/MyTaskDef', {}]]) })
+    );
+    hoisted.enforceImageOverrideOrphans.mockImplementation(() => {
+      throw new Error('orphaned --image-build-arg');
+    });
+    await expect(
+      resolveRunTaskImageOverride({
+        task: task([container('web', 'cdk-asset')]),
+        target: 'MyStack/MyTaskDef',
+        options: { imageBuildArg: ['MyStack/MyTaskDef:K=V'] },
+      })
+    ).rejects.toThrow(/orphaned/);
+  });
+});

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -106,6 +106,8 @@ describe('run-task option surface contract (addRunTaskSpecificOptions)', () => {
     // Issue #249 / C6 — `--assume-role` is the non-breaking alias of
     // `--assume-task-role` so both forms are present.
     // Issue #249 / C8 — `--no-build` parity with `cdkl invoke`.
+    // Issue #388 — the `--image-override` flag family (shared with
+    // start-service / start-alb via addImageOverrideOptions).
     expect(flags).toEqual([
       '--assume-role',
       '--assume-task-role',
@@ -116,11 +118,17 @@ describe('run-task option surface contract (addRunTaskSpecificOptions)', () => {
       '--env-vars',
       '--from-cfn-stack',
       '--host-port',
+      '--image-build-arg',
+      '--image-build-secret',
+      '--image-override',
+      '--image-target',
       '--keep-running',
       '--no-build',
+      '--no-interactive-overrides',
       '--no-pull',
       '--platform',
       '--stack-region',
+      '--strict-overrides',
     ]);
   });
 


### PR DESCRIPTION
## Summary

`cdkl run-task` could not rebuild a pinned (deployed-registry) task definition
container image from local source — the `--image-override` flag family existed
only on `start-service` / `start-alb`. A task def whose image is
`ContainerImage.fromRegistry(...)` / an ECR pin always ran the deployed image,
and local edits never took effect.

This extends the SAME `--image-override` flag family (and the shared
`image-override-engine` primitives) to `run-task`:

- `addImageOverrideOptions(cmd)` is added inside `addRunTaskSpecificOptions`,
  so `run-task` accepts `--image-override` / `--image-build-arg` /
  `--image-build-secret` / `--image-target` / `--no-interactive-overrides` /
  `--strict-overrides`.
- `resolveRunTaskImageOverride` resolves + builds the override against the
  already-resolved task: a task definition has ONE override target (its
  representative essential container), so the picker / boot-prompt forms map to
  that single target. The built tag is threaded into `runEcsTask` via
  `imageOverrideByContainer`.
- A pinned-but-uncovered task-def image WARNs that local source edits will not
  take effect (pointing at `--image-override <dockerfile>`); a local CDK asset
  is a no-op (it already rebuilds locally).

This is slice A of (#388) — the studio `ecs-task` Dockerfile picker (which
threads `--image-override` to the spawned `run-task` child) is the follow-up
slice.

## Behavior change (additive — no host migration)

`cdkl run-task` now accepts the `--image-override` flag family and WARNs when a
pinned task-def image is run without an override. cdkd embeds
`createLocalRunTaskCommand` and inherits the new flags automatically (the flag
block comes from the shared `addImageOverrideOptions` helper cdkd already
inherits for `start-service` / `start-alb`); no host-side change is required.

## Test plan

- **Unit** (`local-run-task-image-override.test.ts`): short-circuit for a local
  CDK asset; `pinnedUncovered` for a pinned image with no override; builds +
  threads the tag keyed on the essential container (incl. essential-not-first
  and all-non-essential fallback); `public`-registry parity with the `ecr` pin;
  `--strict-overrides` throws when uncovered; an orphaned per-service flag
  propagates. `option-surface-contracts.test.ts` updated for the 6 new flags.
- **Integration** (`local-run-task`): the fixture's pinned public-registry nginx
  task (1) WARNs when run without an override, and (2) is rebuilt from a local
  `Dockerfile.override` via `--image-override <target>=<dockerfile>` and serves a
  sentinel the pinned image never would (a negative pre-check asserts the pinned
  run does NOT serve the sentinel, so the test is discriminating). Ran clean; 0
  Docker container / network / override-image orphans.
- 1-reviewer tier → code + test review; all gaps (the call-site WARN binding,
  `public`-pin parity, essential fallback) addressed in this PR.

Part of (#388) — the studio `ecs-task` picker (slice B) closes it.
