### PR TITLE
feat(studio): image-override Dockerfile picker for ECS Task Definitions (#388)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -500,7 +500,9 @@ compute-locally category for Lambda + API Gateway).
   UI at `/`, the synthesized target list (+ the boot-discovered
   Dockerfiles + a `pinned` flag per ecs service — set by
   `annotatePinnedEcsTargets` — for the image-override picker, issue #301;
-  plus `backingPinnedServices` per alb entry — set by
+  plus a `pinned` flag per `ecs-task` task definition — set by
+  `annotateEcsTaskPinnedTargets`, issue #388 — for the run-task image-override
+  picker; plus `backingPinnedServices` per alb entry — set by
   `annotateAlbPinnedBackingServices`, issue #384 — for the ALB's
   per-backing-service image-override picker;
   CDK custom-resource / provider-framework Lambdas are excluded by
@@ -575,7 +577,12 @@ compute-locally category for Lambda + API Gateway).
   studio's child has no TTY, so the bare picker form would be skipped) onto
   the serve body so `start-service` rebuilds the pinned image from local
   source; a local-asset service (which already hot-reloads under `--watch`)
-  gets no picker (issue #301). An `alb` serve gets the SAME picker for its
+  gets no picker (issue #301). A PINNED `ecs-task` task definition gets the
+  SAME single picker (issue #388): the `ecs-task` composer threads
+  `--image-override <target>=<dockerfile>` onto the run body so the spawned
+  `cdkl run-task` rebuilds the pinned task-def image from local source
+  (`makeTaskPinClassifier` + `annotateEcsTaskPinnedTargets` mark a pinned task
+  def at boot). An `alb` serve gets the SAME picker for its
   pinned BACKING services (issue #384): `start-alb` boots the ALB's backing
   ECS services, so studio resolves each ALB (`resolveAlbFrontDoor`) to its
   backing services at boot, intersects them with the pinned `ecs` set

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -27,6 +27,7 @@ import {
   toStudioTargetGroups,
   filterStudioTargetGroups,
   annotatePinnedEcsTargets,
+  annotateEcsTaskPinnedTargets,
   annotateAlbPinnedBackingServices,
   type RunningStudioServer,
   type StudioTargetGroup,
@@ -50,7 +51,11 @@ import { relayServeRequest } from '../../local/studio-request-relay.js';
 import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
 import { isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
 import { discoverDockerfiles } from '../../local/image-override-engine.js';
-import { parseEcsTarget, type EcsImageResolutionContext } from '../../local/ecs-task-resolver.js';
+import {
+  parseEcsTarget,
+  resolveEcsTaskTarget,
+  type EcsImageResolutionContext,
+} from '../../local/ecs-task-resolver.js';
 import { matchStacks } from '../stack-matcher.js';
 import {
   createLocalStateProvider,
@@ -582,6 +587,44 @@ export function makePinClassifier(args: {
 }
 
 /**
+ * Build the boot-time pin classifier {@link annotateEcsTaskPinnedTargets} calls
+ * per `ecs-task` task definition (issue #388) — the counterpart of
+ * {@link makePinClassifier} for task defs. Resolves the task via
+ * {@link resolveEcsTaskTarget} (threading the owning stack's
+ * {@link EcsImageResolutionContext} so an INTRINSIC-ECR image resolves under
+ * `--from-cfn-stack`, same as the service path) and classifies its
+ * representative container (first essential, else first) as a deployed-registry
+ * pin when the image kind is not `cdk-asset`. A task def that cannot be
+ * classified is WARN-logged (not silently swallowed) and left unmarked.
+ *
+ * Returns a `(id) => boolean` callback (true = pinned). Exported for testing.
+ */
+export function makeTaskPinClassifier(args: {
+  stacks: StackInfo[];
+  contextByStack: Map<string, EcsImageResolutionContext | undefined>;
+  logger: ReturnType<typeof getLogger>;
+}): (id: string) => boolean {
+  const { stacks, contextByStack, logger } = args;
+  return (id: string): boolean => {
+    try {
+      const stack = resolveEcsServiceStack(id, stacks);
+      const context = stack ? contextByStack.get(stack.stackName) : undefined;
+      const task = resolveEcsTaskTarget(id, stacks, context);
+      const representative = task.containers.find((c) => c.essential) ?? task.containers[0];
+      return representative !== undefined && representative.image.kind !== 'cdk-asset';
+    } catch (err) {
+      logger.warn(
+        `studio: could not classify image-pin status for ECS task definition '${id}'; leaving it ` +
+          `unmarked (the image-override picker will not be offered). ${
+            err instanceof Error ? err.message : String(err)
+          }`
+      );
+      return false;
+    }
+  };
+}
+
+/**
  * Build the boot-time resolver `annotateAlbPinnedBackingServices` calls per
  * `alb` entry (issue #384). It resolves the ALB to its backing ECS services
  * (`resolveAlbFrontDoor`, template-only) and returns the subset that is in
@@ -676,8 +719,16 @@ export async function classifyStudioTargets(args: {
   // cannot be assigned to the optional-but-non-undefined field; an undefined /
   // false value reads as "no --from-cfn-stack" via `isCfnFlagPresent`.
   const classifyOptions = { ...options, fromCfnStack } as LocalStateSourceLikeOptions;
+  // Build the deployed-state image-resolution context per owning stack for the
+  // servable ECS services AND the ECS task definitions (issue #388), so an
+  // INTRINSIC-ECR image on EITHER resolves under `--from-cfn-stack`. The
+  // contexts are keyed by stack name, so a task def sharing a stack with a
+  // service reuses the same context.
+  const taskDefIds = (baseGroups.find((g) => g.kind === 'ecs-task')?.entries ?? []).map(
+    (e) => e.id
+  );
   const contextByStack = await prepareEcsImageContexts({
-    serviceIds: [...servableEcs],
+    serviceIds: [...servableEcs, ...taskDefIds],
     stacks,
     options: classifyOptions,
     logger,
@@ -685,6 +736,13 @@ export async function classifyStudioTargets(args: {
   const anyPinned = annotatePinnedEcsTargets(
     groups,
     makePinClassifier({ stacks, contextByStack, logger })
+  );
+  // Issue #388 — classify ECS task definitions (the `ecs-task` kind) too, so a
+  // pinned task-def image gets the same image-override picker. The `ecs-task`
+  // composer spawns `cdkl run-task`, which accepts `--image-override`.
+  const anyTaskPinned = annotateEcsTaskPinnedTargets(
+    groups,
+    makeTaskPinClassifier({ stacks, contextByStack, logger })
   );
   const pinnedEcsByQualifiedId = new Map<string, string>();
   for (const g of groups) {
@@ -697,7 +755,8 @@ export async function classifyStudioTargets(args: {
     groups,
     makeAlbBackingPinnedResolver({ stacks, pinnedEcsByQualifiedId, logger })
   );
-  const dockerfiles = anyPinned || anyAlbBackingPinned ? discoverDockerfiles(process.cwd()) : [];
+  const dockerfiles =
+    anyPinned || anyTaskPinned || anyAlbBackingPinned ? discoverDockerfiles(process.cwd()) : [];
   return { groups, dockerfiles };
 }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -768,6 +768,7 @@ export {
   toStudioTargetGroups,
   filterStudioTargetGroups,
   annotatePinnedEcsTargets,
+  annotateEcsTaskPinnedTargets,
   annotateAlbPinnedBackingServices,
   type StudioServerOptions,
   type RunningStudioServer,

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -26,12 +26,13 @@ export interface StudioTarget {
    */
   servable?: boolean;
   /**
-   * Set on a servable `ecs` service whose image is a deployed-registry pin
-   * (ECR / public) rather than a local CDK asset (issue #301). Local source
-   * edits do NOT take effect for a pinned image, so the serve composer offers
-   * a Dockerfile picker that threads `--image-override` to the spawned
-   * `start-service`. A local-asset service (which already hot-reloads under
-   * `--watch`) is not marked and gets no picker.
+   * Set on a servable `ecs` service OR an `ecs-task` task definition whose
+   * image is a deployed-registry pin (ECR / public) rather than a local CDK
+   * asset (issue #301 / #388). Local source edits do NOT take effect for a
+   * pinned image, so the composer offers a Dockerfile picker that threads
+   * `--image-override` to the spawned `start-service` (ecs) / `run-task`
+   * (ecs-task). A local-asset target (which already rebuilds locally) is not
+   * marked and gets no picker.
    */
   pinned?: boolean;
   /**
@@ -122,6 +123,39 @@ export function annotatePinnedEcsTargets(
     if (group.kind !== 'ecs') continue;
     for (const entry of group.entries) {
       if (!entry.servable) continue;
+      if (classify(entry.id)) {
+        entry.pinned = true;
+        anyPinned = true;
+      }
+    }
+  }
+  return anyPinned;
+}
+
+/**
+ * Annotate the `ecs-task` task-definition entries of `groups` with
+ * `pinned: true` when `classify(targetId)` returns true (issue #388). The
+ * counterpart of {@link annotatePinnedEcsTargets} for the `ecs-task` kind: a
+ * task definition whose representative container image is a deployed-registry
+ * pin gets the same image-override Dockerfile picker (the `ecs-task` composer
+ * spawns `cdkl run-task`, which now accepts `--image-override`). `classify`
+ * decides pinned vs local CDK asset for one task-def id (studio's boot resolves
+ * the task via `resolveEcsTaskTarget` and checks the representative container's
+ * image kind). Unlike the `ecs` group there is no `servable` gate — every
+ * task-def entry is run via run-task. Mutates the entries in place and returns
+ * whether ANY task definition was pinned, so the caller can include the
+ * Dockerfile scan even when no standalone `ecs` service was pinned. Non-ecs-task
+ * groups are left untouched. Exported so a host CLI can reuse it + so the boot
+ * logic is unit-testable without a real synth.
+ */
+export function annotateEcsTaskPinnedTargets(
+  groups: StudioTargetGroup[],
+  classify: (targetId: string) => boolean
+): boolean {
+  let anyPinned = false;
+  for (const group of groups) {
+    if (group.kind !== 'ecs-task') continue;
+    for (const entry of group.entries) {
       if (classify(entry.id)) {
         entry.pinned = true;
         anyPinned = true;

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -918,11 +918,13 @@ const STUDIO_SCRIPT = `
     ws.appendChild(head);
 
     if (!running && !starting && !failed) {
-      // A pinned ECS service (deployed-registry image) does not pick up local
-      // source edits — offer an image-override Dockerfile picker so it can be
-      // rebuilt locally (issue #301). Local-asset services hot-reload under
-      // --watch and get no picker.
-      if (meta && meta.kind === 'ecs' && meta.pinned) {
+      // A pinned ECS service / task definition (deployed-registry image) does
+      // not pick up local source edits — offer an image-override Dockerfile
+      // picker so it can be rebuilt locally (issue #301 for ecs, #388 for
+      // ecs-task). The ecs composer threads --image-override to start-service;
+      // the ecs-task composer threads it to run-task. Local-asset targets
+      // rebuild locally already and get no picker.
+      if (meta && (meta.kind === 'ecs' || meta.kind === 'ecs-task') && meta.pinned) {
         const io = buildImageOverridePicker();
         ws.appendChild(io.node);
         collectImageOverride = io.collect;

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -68,6 +68,9 @@ cleanup() {
   fi
   rm -f "${LOG_FILE}" "${BODY_FILE}" "${RUN_FILE}" "${SSE_FILE}"
   rm -f "$(pwd)/.studio-ws-client.mjs"
+  # Drop the local-only image-override build(s) the ecs / alb / ecs-task picker
+  # tests produced (tag prefix is the embed binary name: `cdkl-override-*:local`).
+  docker images --filter 'reference=cdkl-override-*' -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -1092,6 +1095,24 @@ if ! grep -qF 'Dockerfile.override' "${BODY_FILE}"; then
 fi
 echo "    OK: pinned ecs service flagged + Dockerfile.override discovered"
 
+# Issue #388 — the ECS Task Definition (kind `ecs-task`) MyTask shares the same
+# public-registry-pinned image, so studio marks ITS entry `pinned` too (the
+# ecs-task pin classifier), which is what gates the run-task image-override
+# picker. Assert specifically the ecs-task group's MyTask entry is pinned.
+echo "==> /api/targets marks the pinned ecs-task task definition (issue #388)"
+if ! python3 - "${BODY_FILE}" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+g = next((x for x in d["groups"] if x["kind"] == "ecs-task"), None)
+e = next((x for x in (g or {}).get("entries", []) if x["id"].endswith("/MyTask")), None)
+sys.exit(0 if e and e.get("pinned") is True else 1)
+PY
+then
+  echo "FAIL: /api/targets did not mark the ecs-task MyTask as pinned"
+  cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: ecs-task MyTask flagged pinned (the run-task image-override picker will offer)"
+
 ALB_TARGET="LocalStudioFixture/MyAlb"
 echo "==> POST /api/run starts an ALB serve (boots the ECS service + front-door)"
 # Re-arm the SSE listener to capture the ALB request invocation.
@@ -1297,6 +1318,50 @@ curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/js
   -d "{\"targetId\":\"${ECS_TASK_TARGET}\"}" -o /dev/null || true
 sleep 3
 echo "    OK: task run stopped"
+
+# ---------------------------------------------------------------------------
+# 10a2. ecs-task image-override picker (issue #388): MyTask's image is the same
+#       public-registry pin, so the run-task composer offers the Dockerfile
+#       picker. Studio threads the picked Dockerfile as the EXPLICIT
+#       `--image-override LocalStudioFixture/MyTask=./Dockerfile.override` (no
+#       TTY in the studio child) to the spawned `cdkl run-task`, plus
+#       `--host-port 80=<port>` (via rawArgs) so the published container is
+#       reachable. The override build serves the same WORKDIR sentinel, so
+#       curling it proves the picker -> /api/run -> run-task --image-override
+#       rebuild path end-to-end (the pinned image would serve a directory
+#       listing, never the sentinel).
+# ---------------------------------------------------------------------------
+TIO_HOST_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+echo "==> POST /api/run with imageOverride rebuilds the pinned task definition from a local Dockerfile"
+TIO_FILE=$(mktemp)
+HTTP_TIO=$(curl -s -o "${TIO_FILE}" -w '%{http_code}' --max-time 300 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TASK_TARGET}\",\"kind\":\"ecs-task\",\"imageOverride\":\"./Dockerfile.override\",\"rawArgs\":\"--host-port 80=${TIO_HOST_PORT}\"}" || true)
+if [[ "${HTTP_TIO}" != "200" ]] || ! grep -qF '"status":"running"' "${TIO_FILE}"; then
+  echo "FAIL: POST /api/run (ecs-task image-override) returned HTTP ${HTTP_TIO}"
+  echo "----- response -----"; cat "${TIO_FILE}"; echo "--------------------"
+  echo "----- studio log -----"; tail -c 3000 "${LOG_FILE}"; echo "----------------------"
+  rm -f "${TIO_FILE}"; exit 1
+fi
+rm -f "${TIO_FILE}"
+TIO_BODY=""
+for _ in $(seq 1 60); do
+  TIO_BODY=$(curl -fsS --max-time 3 "http://127.0.0.1:${TIO_HOST_PORT}/" 2>/dev/null || true)
+  if echo "${TIO_BODY}" | grep -qF 'studio-image-override-301'; then break; fi
+  sleep 1
+done
+if ! echo "${TIO_BODY}" | grep -qF 'studio-image-override-301'; then
+  echo "FAIL: ecs-task image-override did not apply (sentinel absent from the published container)"
+  echo "----- served body -----"; echo "${TIO_BODY}" | head -c 1000; echo "-----------------------"
+  echo "----- studio log -----"; tail -c 3000 "${LOG_FILE}"; echo "----------------------"
+  exit 1
+fi
+echo "    OK: ecs-task image-override threaded; run-task ran the LOCAL Dockerfile build (sentinel served)"
+echo "==> POST /api/stop tears the image-override task run down"
+curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TASK_TARGET}\"}" -o /dev/null || true
+sleep 3
+echo "    OK: ecs-task image-override run stopped"
 
 # ---------------------------------------------------------------------------
 # 10b. Image-override picker (issue #301): MyService's deployed image is a

--- a/tests/unit/cli/local-studio-pin-classifier.test.ts
+++ b/tests/unit/cli/local-studio-pin-classifier.test.ts
@@ -11,12 +11,19 @@ const hoisted = vi.hoisted(() => ({
   buildEcsImageResolutionContext: vi.fn(),
   createLocalStateProvider: vi.fn(),
   discoverDockerfiles: vi.fn(),
+  resolveEcsTaskTarget: vi.fn(),
 }));
 
 vi.mock('../../../src/local/ecs-service-resolver.js', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('../../../src/local/ecs-service-resolver.js')>();
   return { ...actual, resolveEcsServiceTarget: hoisted.resolveEcsServiceTarget };
+});
+// Partial mock: local-studio.ts calls resolveEcsTaskTarget for the ecs-task pin
+// classifier (issue #388); preserve every other export (parseEcsTarget, etc.).
+vi.mock('../../../src/local/ecs-task-resolver.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/local/ecs-task-resolver.js')>();
+  return { ...actual, resolveEcsTaskTarget: hoisted.resolveEcsTaskTarget };
 });
 vi.mock('../../../src/local/image-pin-detector.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../src/local/image-pin-detector.js')>();
@@ -50,6 +57,7 @@ const {
   resolveEcsServiceStack,
   prepareEcsImageContexts,
   makePinClassifier,
+  makeTaskPinClassifier,
   classifyStudioTargets,
   reclassifyTargetsOnBindingChange,
 } = await import('../../../src/cli/commands/local-studio.js');
@@ -83,6 +91,7 @@ beforeEach(() => {
   hoisted.buildEcsImageResolutionContext.mockReset();
   hoisted.createLocalStateProvider.mockReset();
   hoisted.discoverDockerfiles.mockReset();
+  hoisted.resolveEcsTaskTarget.mockReset();
 });
 
 describe('resolveEcsServiceStack', () => {
@@ -325,6 +334,63 @@ describe('makePinClassifier', () => {
   });
 });
 
+describe('makeTaskPinClassifier (issue #388)', () => {
+  const taskWith = (kind: string, essential = true) => ({
+    containers: [{ name: 'web', essential, image: { kind } }],
+  });
+
+  it('marks a registry-pinned task definition as pinned (public / ecr)', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsTaskTarget.mockReturnValue(taskWith('public'));
+    const classify = makeTaskPinClassifier({ stacks: [stack('dev')], contextByStack: new Map(), logger });
+    expect(classify('dev/Task')).toBe(true);
+  });
+
+  it('does NOT mark a local-asset task definition', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsTaskTarget.mockReturnValue(taskWith('cdk-asset'));
+    const classify = makeTaskPinClassifier({ stacks: [stack('dev')], contextByStack: new Map(), logger });
+    expect(classify('dev/Task')).toBe(false);
+  });
+
+  it('classifies the representative (first essential) container', () => {
+    const logger = fakeLogger();
+    // First container non-essential (cdk-asset), second essential (ecr pin).
+    hoisted.resolveEcsTaskTarget.mockReturnValue({
+      containers: [
+        { name: 'sidecar', essential: false, image: { kind: 'cdk-asset' } },
+        { name: 'app', essential: true, image: { kind: 'ecr' } },
+      ],
+    });
+    const classify = makeTaskPinClassifier({ stacks: [stack('dev')], contextByStack: new Map(), logger });
+    expect(classify('dev/Task')).toBe(true);
+  });
+
+  it('threads the owning-stack image context into resolveEcsTaskTarget', () => {
+    const logger = fakeLogger();
+    const ctx: EcsImageResolutionContext = { stateResources: { Repo: { id: 'r' } } };
+    hoisted.resolveEcsTaskTarget.mockReturnValue(taskWith('ecr'));
+    const classify = makeTaskPinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map([['dev', ctx]]),
+      logger,
+    });
+    classify('dev/Task');
+    expect(hoisted.resolveEcsTaskTarget).toHaveBeenCalledWith('dev/Task', expect.any(Array), ctx);
+  });
+
+  it('WARNs (not silent) and returns false when task resolution throws', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsTaskTarget.mockImplementation(() => {
+      throw new Error('cannot resolve task image');
+    });
+    const classify = makeTaskPinClassifier({ stacks: [stack('dev')], contextByStack: new Map(), logger });
+    expect(classify('dev/Task')).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('cannot resolve task image'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('task definition'));
+  });
+});
+
 describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack toggle)', () => {
   const baseGroups = (): StudioTargetGroup[] => [
     {
@@ -382,6 +448,90 @@ describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack 
     // The base groups are never mutated — each classify clones, so a re-classify
     // under a new binding never inherits stale pins.
     expect(base[0]?.entries[0]?.pinned).toBeUndefined();
+  });
+
+  it('pins a deployed-registry ECS task definition + scans Dockerfiles (issue #388)', async () => {
+    const logger = fakeLogger();
+    hoisted.discoverDockerfiles.mockReturnValue(['./Dockerfile']);
+    hoisted.resolveEcsTaskTarget.mockReturnValue({
+      containers: [{ name: 'web', essential: true, image: { kind: 'public' } }],
+    });
+    const base: StudioTargetGroup[] = [
+      { kind: 'ecs', title: 'ECS Services', entries: [] },
+      {
+        kind: 'ecs-task',
+        title: 'ECS Task Definitions',
+        entries: [{ id: 'dev/Task', qualifiedId: 'dev:Task' }],
+      },
+    ];
+    const result = await classifyStudioTargets({
+      baseGroups: base,
+      stacks: [stack('dev')],
+      servableEcs: new Set(),
+      options: {},
+      fromCfnStack: undefined,
+      logger,
+    });
+    const taskGroup = result.groups.find((g) => g.kind === 'ecs-task');
+    expect(taskGroup?.entries[0]?.pinned).toBe(true);
+    expect(result.dockerfiles).toEqual(['./Dockerfile']);
+    // The task-def id was resolved (it was collected into prepareEcsImageContexts
+    // + classified), and the base groups stay un-annotated (fresh clone).
+    expect(hoisted.resolveEcsTaskTarget).toHaveBeenCalledWith('dev/Task', expect.any(Array), undefined);
+    expect((base[1]?.entries[0] as { pinned?: boolean }).pinned).toBeUndefined();
+  });
+
+  it('builds the deployed-state context for a task-def-only stack under --from-cfn-stack (issue #388)', async () => {
+    const logger = fakeLogger();
+    hoisted.discoverDockerfiles.mockReturnValue(['./Dockerfile']);
+    // An INTRINSIC-ECR task-def image resolves ONLY with a deployed-state
+    // context; the resolver throws when no context is threaded.
+    hoisted.resolveEcsTaskTarget.mockImplementation((_id: string, _stacks: unknown, ctx: unknown) => {
+      if (!ctx) throw new Error('intrinsic ECR URI needs --from-cfn-stack');
+      return { containers: [{ name: 'web', essential: true, image: { kind: 'ecr' } }] };
+    });
+    hoisted.createLocalStateProvider.mockReturnValue({ dispose: vi.fn() });
+    hoisted.buildEcsImageResolutionContext.mockResolvedValue({ stateResources: {} });
+
+    // NO servable services — the task-def id is the ONLY reason its stack
+    // enters the per-stack context build.
+    const base: StudioTargetGroup[] = [
+      { kind: 'ecs', title: 'ECS Services', entries: [] },
+      {
+        kind: 'ecs-task',
+        title: 'ECS Task Definitions',
+        entries: [{ id: 'dev/Task', qualifiedId: 'dev:Task' }],
+      },
+    ];
+    const stacks = [stack('dev', 'us-east-1')];
+
+    // OFF: no context built -> resolve throws -> task def stays unpinned.
+    const off = await classifyStudioTargets({
+      baseGroups: base,
+      stacks,
+      servableEcs: new Set(),
+      options: {},
+      fromCfnStack: undefined,
+      logger,
+    });
+    expect(off.groups.find((g) => g.kind === 'ecs-task')?.entries[0]?.pinned).toBeUndefined();
+
+    // ON: the TASK-DEF id alone drives the per-stack context build, so the
+    // intrinsic-ECR image resolves and the task def is pinned.
+    const on = await classifyStudioTargets({
+      baseGroups: base,
+      stacks,
+      servableEcs: new Set(),
+      options: {},
+      fromCfnStack: true,
+      logger,
+    });
+    expect(on.groups.find((g) => g.kind === 'ecs-task')?.entries[0]?.pinned).toBe(true);
+    expect(hoisted.buildEcsImageResolutionContext).toHaveBeenCalledWith(
+      expect.objectContaining({ stackName: 'dev' }),
+      expect.anything(),
+      expect.objectContaining({ fromCfnStack: true })
+    );
   });
 
   it('does not scan Dockerfiles for an all-local-asset app', async () => {

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -546,6 +546,36 @@ describe('createStudioServeManager', () => {
     expect(argv[i + 1]).toBe('Stack/MyService=./Dockerfile.local');
   });
 
+  it('threads imageOverride for an ecs-task run-task too (issue #388)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'Stack/MyTask',
+      kind: 'ecs-task',
+      imageOverride: './Dockerfile.local',
+    });
+    child.stdout.emit('data', 'Task running (family=fam)\n');
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    // The ecs-task kind spawns run-task, and the override threads kind-agnostically.
+    expect(argv).toContain('run-task');
+    const i = argv.indexOf('--image-override');
+    expect(i).toBeGreaterThan(-1);
+    expect(argv[i + 1]).toBe('Stack/MyTask=./Dockerfile.local');
+  });
+
   it('materializes --env-vars into a SAM-shape temp file and removes it on stop (issue #355)', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -6,6 +6,7 @@ import {
   toStudioTargetGroups,
   filterStudioTargetGroups,
   annotatePinnedEcsTargets,
+  annotateEcsTaskPinnedTargets,
   annotateAlbPinnedBackingServices,
   type RunningStudioServer,
   type StudioTargetGroup,
@@ -218,6 +219,43 @@ describe('annotatePinnedEcsTargets', () => {
     const g = groups();
     annotatePinnedEcsTargets(g, () => true);
     expect(g[1].entries[0].pinned).toBeUndefined();
+  });
+});
+
+describe('annotateEcsTaskPinnedTargets (issue #388)', () => {
+  const groups = (): StudioTargetGroup[] => [
+    {
+      kind: 'ecs',
+      title: 'ECS Services',
+      entries: [{ id: 'S/Svc', qualifiedId: 'S:Svc', servable: true }],
+    },
+    {
+      kind: 'ecs-task',
+      title: 'ECS Task Definitions',
+      entries: [
+        { id: 'S/PinnedTask', qualifiedId: 'S:PinnedTask' },
+        { id: 'S/AssetTask', qualifiedId: 'S:AssetTask' },
+      ],
+    },
+  ];
+
+  it('marks the ecs-task entries the classifier returns true for (no servable gate)', () => {
+    const g = groups();
+    const any = annotateEcsTaskPinnedTargets(g, (id) => id === 'S/PinnedTask');
+    expect(any).toBe(true);
+    const tasks = g[1].entries;
+    expect(tasks[0].pinned).toBe(true); // S/PinnedTask
+    expect(tasks[1].pinned).toBeUndefined(); // S/AssetTask
+  });
+
+  it('leaves the ecs (service) group untouched — that is annotatePinnedEcsTargets job', () => {
+    const g = groups();
+    annotateEcsTaskPinnedTargets(g, () => true);
+    expect(g[0].entries[0].pinned).toBeUndefined();
+  });
+
+  it('returns false when no task definition is pinned', () => {
+    expect(annotateEcsTaskPinnedTargets(groups(), () => false)).toBe(false);
   });
 });
 

--- a/tests/unit/local/studio-ui-ecs-task-image-override.test.ts
+++ b/tests/unit/local/studio-ui-ecs-task-image-override.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the serve-workspace internals + a Dockerfile-list setter (issue #388).
+const EXPOSE = `
+window.__t = {
+  serveMeta: serveMeta,
+  serveState: serveState,
+  renderServeWorkspace: renderServeWorkspace,
+  setDockerfiles: function (d) { studioDockerfiles = d; },
+};
+window.__setShown = function (id) { shownServeId = id; };
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+function ecsTaskComposer(h: Harness, pinned: boolean) {
+  const t = h.window.__t;
+  t.setDockerfiles(['Dockerfile', 'task/Dockerfile']);
+  const dot = h.document.createElement('span');
+  const btnSlot = h.document.createElement('span');
+  t.serveMeta.set('S/Task', { dot, btnSlot, kind: 'ecs-task', pinned, backingPinnedServices: [] });
+  t.serveState.set('S/Task', { status: 'stopped', endpoints: [] });
+  h.window.__setShown('S/Task');
+  t.renderServeWorkspace('S/Task');
+  return t;
+}
+
+describe('ecs-task composer image-override picker (issue #388)', () => {
+  it('renders the Dockerfile picker for a pinned task definition', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      ecsTaskComposer(h, true);
+      const selects = h.document.querySelectorAll('.image-override-select');
+      expect(selects.length).toBe(1);
+      const opts = Array.from((selects[0] as any).options).map((o: any) => o.value);
+      expect(opts).toEqual(['', 'Dockerfile', 'task/Dockerfile']);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('does NOT render the picker for a local-asset task definition', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      ecsTaskComposer(h, false);
+      expect(h.document.querySelectorAll('.image-override-select').length).toBe(0);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('threads the chosen Dockerfile as the single imageOverride into the run body', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      ecsTaskComposer(h, true);
+      const sel = h.document.querySelector('.image-override-select') as any;
+      sel.value = 'task/Dockerfile';
+
+      let captured: any = null;
+      h.window.fetch = (_url: string, opts: any) => {
+        captured = JSON.parse(opts.body);
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      };
+      // Click Run — startServe builds the body + calls fetch synchronously.
+      (h.document.querySelector('#workspace .composer button') as any).click();
+
+      expect(captured).not.toBeNull();
+      expect(captured.kind).toBe('ecs-task');
+      expect(captured.imageOverride).toBe('task/Dockerfile');
+    } finally {
+      h.close();
+    }
+  });
+});

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -64,8 +64,9 @@ describe('renderStudioHtml', () => {
     // The picker builder + its select are present.
     expect(html).toContain('function buildImageOverridePicker');
     expect(html).toContain("el('select', 'image-override-select')");
-    // Gated on the serve target being a pinned ecs service.
-    expect(html).toContain("meta.kind === 'ecs' && meta.pinned");
+    // Gated on the serve target being a pinned ecs service OR ecs-task task
+    // definition (issue #388 extended the picker to the ecs-task composer).
+    expect(html).toContain("(meta.kind === 'ecs' || meta.kind === 'ecs-task') && meta.pinned");
     // The picked Dockerfile is threaded onto the serve body.
     expect(html).toContain('body.imageOverride = imageOverride');
     // The picker is populated from the boot-scanned dockerfiles carried on the


### PR DESCRIPTION
## Summary

The `cdkl studio` image-override Dockerfile picker covered pinned `ecs` services
and `alb` backing services, but NOT the ECS Task Definitions (the `ecs-task`
kind). A task def whose image is a deployed-registry pin
(`ContainerImage.fromRegistry(...)` / ECR) offered no picker, so the user could
not rebuild it from local source. With `cdkl run-task --image-override` landed
(slice A, #390), studio can now thread the override to the spawned run-task.

### Changes

- **`studio-server.ts`**: `annotateEcsTaskPinnedTargets` marks the `ecs-task`
  group's task-def entries `pinned` (the counterpart of
  `annotatePinnedEcsTargets` for the `ecs-task` kind — no `servable` gate, since
  every task def runs via run-task).
- **`local-studio.ts`**: `makeTaskPinClassifier` resolves a task def
  (`resolveEcsTaskTarget`, threading the owning-stack image context so an
  INTRINSIC-ECR image resolves under `--from-cfn-stack`) and classifies its
  representative container (first essential, else first) as a deployed-registry
  pin. `classifyStudioTargets` collects the task-def ids into the per-stack
  context build, classifies the `ecs-task` group, and includes task-def pins in
  the Dockerfile-scan gate.
- **`studio-ui.ts`**: the picker gate fires for `ecs` OR `ecs-task` pinned
  targets; the `ecs-task` composer threads the single `imageOverride` (the
  explicit `<target>=<dockerfile>` form, since studio's child has no TTY).
- The serve-manager + `coerceRunRequest` already thread `imageOverride` for any
  kind — no change there. `annotateEcsTaskPinnedTargets` is re-exported from
  `src/internal.ts` (sibling of `annotatePinnedEcsTargets`).

## Behavior change (additive — no host migration)

`cdkl studio` now marks pinned ECS task definitions and offers the run-task
image-override picker. cdkd inherits this by embedding `createLocalStudioCommand`
+ the re-exported `annotateEcsTaskPinnedTargets`. One narrow knock-on: under an
EXPLICIT `--from-cfn-stack <name>`, a session whose task definitions introduce a
SECOND owning stack (beyond the servable services' stack) now hits the existing
`rejectExplicitCfnStackWithMultipleStacks` guard at boot — semantically correct
(an explicit CFn name cannot cover a sibling stack's logical IDs; the error
points at bare `--from-cfn-stack`), but a previously-bootable explicit-name
session in that exact shape would now be rejected.

## Test plan

- **Unit**: `annotateEcsTaskPinnedTargets` (marks ecs-task, no servable gate,
  leaves ecs untouched); `makeTaskPinClassifier` (public/ecr pinned, cdk-asset
  not, representative essential-not-first, threads context into
  `resolveEcsTaskTarget`, WARN on throw); `classifyStudioTargets` (ecs-task pin
  + Dockerfile scan, base never mutated, AND a `--from-cfn-stack` case proving a
  task-def-only stack's deployed-state context is built from the task-def id
  alone); a jsdom test that the `ecs-task` composer renders the picker only when
  pinned and threads `imageOverride`; a serve-manager test that an `ecs-task`
  run threads `--image-override <target>=<dockerfile>`.
- **Integration** (`local-studio`): `/api/targets` marks the fixture's `MyTask`
  task def pinned, and a run-task image-override via the studio picker rebuilds
  it from `Dockerfile.override` and serves the sentinel the pinned image never
  would. Ran clean; 0 Docker container / network / override-image orphans (the
  studio fixture cleanup now also drops the local `cdkl-override-*` images).
- 3-axis review (spec / code / test) clean; the test-review gap (the
  `--from-cfn-stack` task-def context-build wiring) was addressed in this PR.

Closes #388
