### PR TITLE
feat(studio): surface an ecs serve's auto-published replica host port to the request composer (#392)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -515,7 +515,8 @@ compute-locally category for Lambda + API Gateway).
   (issue #322 — relay a composed HTTP request to a running serve via
   `studio-request-relay` so the browser composer reaches the served port
   same-origin; api / alb go through the capture proxy and land on the
-  timeline, an ecs `--host-port` serve hits the replica host URL directly),
+  timeline, an ecs serve hits the replica host URL directly — from an explicit
+  `--host-port` or an auto-published replica port, issue #392),
   `POST /api/reinvoke` (issue #284 — re-run a past Lambda / AgentCore
   timeline row with an edited payload via `studio-reinvoke`, threading
   `reinvokeOf` so the new row links to its source; a served request is
@@ -680,8 +681,14 @@ compute-locally category for Lambda + API Gateway).
   `cloudfront` (`start-cloudfront`, issue #367) expose host
   HTTP endpoints each fronted by a studio-proxy so the `endpoints` handed
   to the UI are the proxy URLs (slice C2 capture), while `ecs`
-  (`start-service`) is pure compute — no host port, no capture, just the
-  running replicas + their streamed logs. Resolves running on the kind's
+  (`start-service`) is pure compute — no capture proxy, just the running
+  replicas + their streamed logs. The `ecs` serve's `hostUrl` is set from an
+  explicit `--host-port` OR (issue #392) parsed from the child's
+  `... published on <ip>:<port> ...` log line when start-service auto-publishes
+  / auto-remaps a replica port (`parsePublishedHostEndpoint`, first endpoint
+  wins, re-emitted if it arrives after the running event) — so the request
+  composer can target an auto-published replica without an explicit
+  `--host-port`. Resolves running on the kind's
   ready line (`Server listening on <url>` / `ALB front-door: <url>` /
   `CloudFront distribution serving on <url>` /
   `Service(s) running:`), tracks the running set for `/api/running`, and

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -215,6 +215,22 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
   },
 };
 
+/**
+ * Parse an auto-published replica host endpoint from an `ecs` serve child's
+ * stdout (issue #392). `start-service` publishes each replica's declared
+ * container port on the host — auto-remapping a privileged port (< 1024) to a
+ * free high port (issue #357) — and logs a line like
+ * `... container port 80 published on 127.0.0.1:54321. Reach it at ...`. studio
+ * surfaces the FIRST such endpoint as the serve's `hostUrl` so the in-workspace
+ * request composer can target it even when the user passed no explicit
+ * `--host-port`. Returns `http://<ip>:<port>` or `undefined` when the line does
+ * not carry a published endpoint. Exported for unit testing.
+ */
+export function parsePublishedHostEndpoint(line: string): string | undefined {
+  const m = /published on (\d{1,3}(?:\.\d{1,3}){3}:\d+)/.exec(line);
+  return m ? `http://${m[1]}` : undefined;
+}
+
 interface ServeEntry extends StudioServeState {
   child: ChildProcessWithoutNullStreams;
   /** Capture proxies fronting this serve's HTTP endpoints (slice C2). */
@@ -513,6 +529,17 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         // m[1] is the endpoint URL for api / alb; undefined for ecs (no
         // capture group) — a ready line with no host endpoint.
         if (m) void onReady(m[1]);
+        // An `ecs` serve auto-publishes its replica host port(s) (issue #392);
+        // surface the FIRST one as `hostUrl` so the request composer fires —
+        // unless an explicit `--host-port` already set it. The publish line can
+        // arrive after the ready line, so re-emit when the serve is running.
+        if (req.kind === 'ecs' && entry.hostUrl === undefined) {
+          const endpoint = parsePublishedHostEndpoint(line);
+          if (endpoint) {
+            entry.hostUrl = endpoint;
+            if (entry.status === 'running') emitServe(entry);
+          }
+        }
         emitLog(config.bus, clock, req.targetId, line, 'stdout');
       });
       streamLines(child.stderr, (line) => {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1285,6 +1285,69 @@ sleep 3
 echo "    OK: ECS service stopped"
 
 # ---------------------------------------------------------------------------
+# 10a-autopub. ECS service serve WITHOUT --host-port (issue #392): start-service
+#   auto-publishes the privileged container port 80 to a free high host port
+#   (#357). studio now PARSES that published-port line from the child log to set
+#   the serve's hostUrl — so the request composer fires WITHOUT an explicit
+#   --host-port. Assert /api/running carries a hostUrl (which, since no
+#   --host-port was passed, can ONLY have come from the auto-publish parse), and
+#   POST /api/request relays to the auto-published replica.
+# ---------------------------------------------------------------------------
+echo "==> ecs serve WITHOUT --host-port surfaces an auto-published hostUrl (#392)"
+AP_FILE=$(mktemp)
+HTTP_AP=$(curl -s -o "${AP_FILE}" -w '%{http_code}' --max-time 180 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TARGET}\",\"kind\":\"ecs\",\"options\":{\"--max-tasks\":\"1\"}}" || true)
+if [[ "${HTTP_AP}" != "200" ]] || ! grep -qF '"status":"running"' "${AP_FILE}"; then
+  echo "FAIL: POST /api/run (ecs auto-publish) returned HTTP ${HTTP_AP}"
+  cat "${AP_FILE}"; echo "----- studio log -----"; tail -c 2000 "${LOG_FILE}"; rm -f "${AP_FILE}"; exit 1
+fi
+rm -f "${AP_FILE}"
+# The auto-published hostUrl lands on /api/running (parsed from the child log,
+# possibly slightly after the running event). Retry while the replica boots.
+AP_HOSTURL=""
+for _ in $(seq 1 40); do
+  curl -fsS "${URL}/api/running" -o "${BODY_FILE}" 2>/dev/null || true
+  AP_HOSTURL=$(python3 - "${BODY_FILE}" "${ECS_TARGET}" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+e = next((x for x in d.get("running", []) if x.get("targetId") == sys.argv[2]), None)
+print((e or {}).get("hostUrl", "") or "")
+PY
+)
+  if [[ -n "${AP_HOSTURL}" ]]; then break; fi
+  sleep 1
+done
+if [[ -z "${AP_HOSTURL}" ]]; then
+  echo "FAIL: ecs serve without --host-port did not surface an auto-published hostUrl"
+  echo "----- /api/running -----"; cat "${BODY_FILE}"
+  echo "----- studio log -----"; tail -c 2000 "${LOG_FILE}"; exit 1
+fi
+echo "    OK: auto-published hostUrl surfaced (${AP_HOSTURL}) with NO --host-port"
+# POST /api/request relays a composed GET / to the auto-published replica; the
+# fixture container's `python -m http.server 80` answers 200. Retry while it boots.
+AP_REQ=$(mktemp)
+AP_OK=""
+for _ in $(seq 1 30); do
+  AP_CODE=$(curl -s -o "${AP_REQ}" -w '%{http_code}' --max-time 10 \
+    -X POST "${URL}/api/request" -H 'content-type: application/json' \
+    -d "{\"targetId\":\"${ECS_TARGET}\",\"method\":\"GET\",\"path\":\"/\"}" || true)
+  if [[ "${AP_CODE}" == "200" ]] && grep -qF '"status":200' "${AP_REQ}"; then AP_OK="yes"; break; fi
+  sleep 1
+done
+if [[ -z "${AP_OK}" ]]; then
+  echo "FAIL: POST /api/request did not relay to the auto-published replica"
+  head -c 1000 "${AP_REQ}"; echo; rm -f "${AP_REQ}"; exit 1
+fi
+rm -f "${AP_REQ}"
+echo "    OK: request relayed through studio to the auto-published replica (upstream 200)"
+echo "==> POST /api/stop tears the auto-publish ecs serve down"
+curl -s --max-time 60 -X POST "${URL}/api/stop" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TARGET}\"}" -o /dev/null || true
+sleep 3
+echo "    OK: auto-publish ecs serve stopped"
+
+# ---------------------------------------------------------------------------
 # 10a2. ECS TASK DEFINITION run (issue #366): a task definition is the
 #       `ecs-task` kind — a [Run] control that runs `cdkl run-task` as a
 #       long-running run (server task defs stream logs until stopped). POST

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -6,7 +6,10 @@ import {
   type StudioLogEvent,
   type StudioServeEvent,
 } from '../../../src/local/studio-events.js';
-import { createStudioServeManager } from '../../../src/local/studio-serve-manager.js';
+import {
+  createStudioServeManager,
+  parsePublishedHostEndpoint,
+} from '../../../src/local/studio-serve-manager.js';
 
 /** A minimal stand-in for a long-running spawned serve child. */
 function makeFakeChild(pid = 4242): EventEmitter & {
@@ -1156,5 +1159,101 @@ describe('createStudioServeManager', () => {
     expect(mgr.list()).toEqual([]);
     expect(children[0].kill).toHaveBeenCalledWith('SIGTERM');
     expect(children[1].kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  // Issue #392 — an ecs serve auto-publishes its replica host port; studio
+  // surfaces it as hostUrl so the request composer fires.
+  const ECS_READY = 'Service(s) running: 1 replica.\n';
+  const PUBLISH_LINE =
+    "Container 'web' container port 80 published on 127.0.0.1:54321. Reach it at 127.0.0.1:54321.\n";
+
+  it('sets hostUrl from an auto-published port that arrives before the ready line (#392)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'Stack/Svc', kind: 'ecs' });
+    child.stdout.emit('data', PUBLISH_LINE);
+    child.stdout.emit('data', ECS_READY);
+    const state = await p;
+    expect(state.hostUrl).toBe('http://127.0.0.1:54321');
+  });
+
+  it('sets hostUrl + re-emits when the published port arrives AFTER running (#392)', async () => {
+    const bus = new StudioEventBus();
+    const evs = collect(bus);
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'Stack/Svc', kind: 'ecs' });
+    child.stdout.emit('data', ECS_READY);
+    const state = await p;
+    expect(state.hostUrl).toBeUndefined(); // not known yet at ready time
+    // The publish line lands later -> hostUrl is set + a fresh serve event fires.
+    child.stdout.emit('data', PUBLISH_LINE);
+    const last = evs.serves.at(-1);
+    expect(last?.status).toBe('running');
+    expect(last?.hostUrl).toBe('http://127.0.0.1:54321');
+    expect(mgr.list()[0]?.hostUrl).toBe('http://127.0.0.1:54321');
+  });
+
+  it('does NOT override an explicit --host-port with the auto-published port (#392)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: 'cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'Stack/Svc',
+      kind: 'ecs',
+      options: { '--host-port': [{ left: '80', right: '9000' }] },
+    });
+    // Runner publishes on a DIFFERENT (auto-remapped) port — must NOT win over
+    // the explicit --host-port value.
+    child.stdout.emit('data', PUBLISH_LINE);
+    child.stdout.emit('data', ECS_READY);
+    const state = await p;
+    expect(state.hostUrl).toBe('http://127.0.0.1:9000');
+  });
+});
+
+describe('parsePublishedHostEndpoint (issue #392)', () => {
+  it('extracts http://<ip>:<port> from a publish line', () => {
+    expect(
+      parsePublishedHostEndpoint(
+        "Container 'web' container port 80 published on 127.0.0.1:54321. Reach it at 127.0.0.1:54321."
+      )
+    ).toBe('http://127.0.0.1:54321');
+  });
+
+  it('handles a non-loopback container-host IP', () => {
+    expect(parsePublishedHostEndpoint('published on 192.168.0.5:8080')).toBe(
+      'http://192.168.0.5:8080'
+    );
+  });
+
+  it('returns undefined for a line with no published endpoint', () => {
+    expect(parsePublishedHostEndpoint('Service(s) running: 1 replica.')).toBeUndefined();
+    expect(parsePublishedHostEndpoint('Starting container web')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

`cdkl studio` set an `ecs` serve's `hostUrl` (which gates the in-workspace HTTP
request composer) ONLY from the explicit `--host-port <cp>=<hp>` option. But
`start-service` also publishes the task definition's declared container ports on
the host — auto-remapping a privileged port (< 1024) to a free high port (issue
#357). Studio never surfaced that, so an auto-publishing service showed
"(running — pure compute service, no host endpoint)" and offered no request
composer, even though the replica WAS reachable on the host.

Now the serve-manager parses the `... published on <ip>:<port> ...` line from
the `ecs` child's stdout (`parsePublishedHostEndpoint`) and sets the serve's
`hostUrl` from the FIRST published endpoint — unless an explicit `--host-port`
already set one. The publish line can arrive after the ready line, so a late
parse re-emits the serve event. The existing request-composer gate
(`isEcs && st.hostUrl`) then fires, so the user can compose + send requests to
the auto-published replica.

This is serve-manager-only — the UI already gated the composer on `hostUrl`,
and `coerceRunRequest` / `/api/request` already relay to it.

## Test plan

- **Unit** (`studio-serve-manager.test.ts`): `parsePublishedHostEndpoint`
  (extracts `http://<ip>:<port>`, handles a non-loopback IP, returns undefined
  for a non-matching line); the streamed-line wiring (hostUrl set when the
  publish line arrives BEFORE the ready line; set + re-emitted when it arrives
  AFTER running; an explicit `--host-port` is NOT overridden by the
  auto-published port).
- **Integration** (`local-studio`): an ecs serve started WITHOUT `--host-port`
  (only `--max-tasks 1`) surfaces a `hostUrl` on `/api/running` — which, since
  no `--host-port` was passed, can ONLY have come from the auto-publish parse —
  and `POST /api/request` relays a composed GET / to the auto-published replica
  (upstream 200). Ran clean; 0 Docker orphans.
- Inline-tier review (4 files / ~200 LOC, no security paths); change is
  serve-manager-only and gated to the `ecs` kind.

Closes #392
