### PR TITLE
feat(studio): Stop button shows a transient "Stopping..." (+ "Starting..." symmetry) (#394)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -541,7 +541,12 @@ compute-locally category for Lambda + API Gateway).
   targets (api / alb / ecs / ecs-task / cloudfront) a [Start]/[Stop] control
   with a
   `running ● :port` indicator (ecs services + ecs-task runs show
-  `running` with no port). Issue #352 lists ECS Services (the `ecs`
+  `running` with no port). The control surfaces transient in-progress states
+  (issue #394): a Stop in flight shows "Stopping..." (disabled) until the
+  `stopped` / `error` serve event settles it (tracked in a client-side
+  `stoppingIds` set, cleared in `onServeEvent`), and a still-booting serve shows
+  "Starting..." (disabled) — both inert so a double-click cannot re-fire stop /
+  cancel mid-boot. Issue #352 lists ECS Services (the `ecs`
   serve kind) and ECS Task Definitions as SEPARATE target groups,
   matching `cdkl list`; issue #366 makes the task-definitions group the
   `ecs-task` kind — a [Run] control (labeled Run, not Start) that runs

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -269,6 +269,7 @@ const STUDIO_SCRIPT = `
   const targetEls = new Map();     // targetId -> left-pane element
   const serveMeta = new Map();     // serve targetId -> { dot, btnSlot } row controls
   const serveState = new Map();    // serve targetId -> { status, endpoints }
+  const stoppingIds = new Set();   // serve targetIds with a Stop in flight — button shows "Stopping..." until the stopped/error event (issue #394)
   // serve targetId -> the launch config it was last Started with (issue #356):
   // { options, rawArgs, imageOverride }. Kept separate from serveState so the
   // SSE-driven serveState rewrites (status / endpoints) never clobber it, and
@@ -701,18 +702,30 @@ const STUDIO_SCRIPT = `
     // A task-def run (ecs-task) is labeled Run (it runs the task once), vs a
     // service/api/alb which is Started (issue #366).
     const startLabel = meta.kind === 'ecs-task' ? 'Run' : 'Start';
-    const btn = running || starting
-      ? el('button', 'stop-btn', 'Stop')
-      : el('button', 'invoke-btn', startLabel);
-    btn.onclick = (e) => {
-      e.stopPropagation();
-      if (running || starting) stopServe(id); else startServe(id);
-    };
+    // Transient in-progress states (issue #394): a Stop in flight shows
+    // "Stopping..." (disabled) until the stopped/error event clears it; a
+    // serve still booting shows "Starting..." (disabled). Both are inert so a
+    // double-click cannot re-fire stop / cancel mid-boot.
+    const stopping = stoppingIds.has(id);
+    let btn;
+    if (stopping) {
+      btn = el('button', 'stop-btn', 'Stopping…');
+      btn.disabled = true;
+    } else if (starting) {
+      btn = el('button', 'stop-btn', 'Starting…');
+      btn.disabled = true;
+    } else if (running) {
+      btn = el('button', 'stop-btn', 'Stop');
+      btn.onclick = (e) => { e.stopPropagation(); stopServe(id); };
+    } else {
+      btn = el('button', 'invoke-btn', startLabel);
+      btn.onclick = (e) => { e.stopPropagation(); startServe(id); };
+    }
     meta.btnSlot.appendChild(btn);
-    // Keep a running / starting serve's row VISIBLE even though groups are
-    // collapsed by default — otherwise its dot + curl-able studio-proxy port
-    // would be hidden inside a collapsed group.
-    if (running || starting) {
+    // Keep a running / starting / stopping serve's row VISIBLE even though
+    // groups are collapsed by default — otherwise its dot + curl-able
+    // studio-proxy port would be hidden inside a collapsed group.
+    if (running || starting || stopping) {
       const body = meta.dot.closest('.group-body');
       const grp = meta.dot.closest('.target-group');
       if (body) body.classList.remove('collapsed');
@@ -813,6 +826,9 @@ const STUDIO_SCRIPT = `
       imageOverride: imageOverride,
       imageOverrides: imageOverrides,
     });
+    // Defensive: a restart clears any stale "Stopping..." transient (issue
+    // #394) so the new run shows "Starting...", not a lingering stop state.
+    stoppingIds.delete(id);
     serveState.set(id, { status: 'starting', endpoints: [] });
     updateServeRow(id);
     try {
@@ -842,15 +858,27 @@ const STUDIO_SCRIPT = `
   }
 
   async function stopServe(id) {
+    // Already stopping — ignore a double-click (the button is disabled, but a
+    // programmatic call could still arrive).
+    if (stoppingIds.has(id)) return;
+    // Show the transient "Stopping..." affordance until the serve actually
+    // stops (the SSE 'stopped' / 'error' event clears it via onServeEvent),
+    // issue #394.
+    stoppingIds.add(id);
+    updateServeRow(id);
     try {
       await fetch('/api/stop', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ targetId: id }),
       });
-      // The serve SSE 'stopped' event clears the running state.
+      // The serve SSE 'stopped' event clears the running state + the transient.
     } catch (err) {
-      /* the stop SSE event (or a later refresh) reconciles state */
+      // The stop request never reached the server — clear the transient so the
+      // button reverts to Stop (the serve is still running). A later SSE event
+      // or refresh otherwise reconciles state.
+      stoppingIds.delete(id);
+      updateServeRow(id);
     }
   }
 
@@ -889,9 +917,23 @@ const STUDIO_SCRIPT = `
     const startLabel = isTaskRun ? 'Run' : 'Start';
     const head = el('div', 'composer');
     head.appendChild(el('div', 'target-name', (isTaskRun ? 'Run ' : 'Serve ') + id));
-    const btn = running || starting
-      ? el('button', null, 'Stop')
-      : el('button', null, failed ? 'Reconfigure' : startLabel);
+    // Transient in-progress button states (issue #394): a Stop in flight shows
+    // "Stopping..." (disabled) until the stopped/error event; a still-booting
+    // serve shows "Starting..." (disabled). Both inert so a double-click cannot
+    // re-fire. Otherwise: running -> Stop, failed -> Reconfigure, else Start/Run.
+    const stopping = stoppingIds.has(id);
+    let btn;
+    if (stopping) {
+      btn = el('button', null, 'Stopping…');
+      btn.disabled = true;
+    } else if (starting) {
+      btn = el('button', null, 'Starting…');
+      btn.disabled = true;
+    } else if (running) {
+      btn = el('button', null, 'Stop');
+    } else {
+      btn = el('button', null, failed ? 'Reconfigure' : startLabel);
+    }
     // Per-run options are only set before a start; collected on the Start click.
     let collectOpts = function () { return undefined; };
     let collectRaw = function () { return undefined; };
@@ -1832,6 +1874,12 @@ const STUDIO_SCRIPT = `
     // message (renderServeWorkspace uses message presence to tell them apart).
     if (ev.status === 'stopped' || ev.status === 'error') {
       serveState.set(ev.target, { status: ev.status, endpoints: [], message: ev.message });
+      // A terminal event settles any in-flight Stop transient (issue #394): the
+      // serve reached a final state, so clear "Stopping..." and let the button
+      // revert to Start (or Reconfigure on a failure). Cleared ONLY here — a
+      // late running re-emit (e.g. a hostUrl arriving after run, issue #392)
+      // must NOT cancel the in-progress stop indicator.
+      stoppingIds.delete(ev.target);
     } else {
       serveState.set(ev.target, { status: ev.status, endpoints: ev.endpoints || [], hostUrl: ev.hostUrl });
     }

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -335,7 +335,16 @@ if ! grep -qF 'let lastHeaderMode' "${BODY_FILE}" \
   echo "FAIL: GET / did not include the remembered Headers editor mode (issue #345)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor + session-bar symmetry + remembered-header-mode"
+# Stop/Start transient button states (issue #394): a Stop in flight shows
+# "Stopping..." (disabled) until the stopped/error event; a booting serve shows
+# "Starting..." — both backed by the stoppingIds transient set.
+if ! grep -qF 'stoppingIds' "${BODY_FILE}" \
+  || ! grep -qF 'Stopping…' "${BODY_FILE}" \
+  || ! grep -qF 'Starting…' "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the Stop/Start transient button states (issue #394)"
+  exit 1
+fi
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor + session-bar symmetry + remembered-header-mode + stop/start transients"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/local/studio-ui-stopping-state.test.ts
+++ b/tests/unit/local/studio-ui-stopping-state.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the serve-workspace internals so tests can drive the Stop/Start
+// lifecycle and assert the transient button states (issue #394).
+const EXPOSE = `
+window.__t = {
+  serveMeta: serveMeta,
+  serveState: serveState,
+  renderServeWorkspace: renderServeWorkspace,
+  updateServeRow: updateServeRow,
+  onServeEvent: onServeEvent,
+};
+window.__setShown = function (id) { shownServeId = id; };
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+function setup(h: Harness, status: string) {
+  const t = h.window.__t;
+  const dot = h.document.createElement('span');
+  const btnSlot = h.document.createElement('span');
+  t.serveMeta.set('S/Svc', { dot, btnSlot, kind: 'ecs', pinned: false, backingPinnedServices: [] });
+  t.serveState.set('S/Svc', { status, endpoints: [] });
+  h.window.__setShown('S/Svc');
+  t.updateServeRow('S/Svc'); // populate the row button (btnSlot)
+  t.renderServeWorkspace('S/Svc');
+  return t;
+}
+
+const headBtn = (h: Harness) => h.document.querySelector('#workspace .composer button');
+const rowBtn = (t: any) => t.serveMeta.get('S/Svc').btnSlot.querySelector('button');
+
+describe('Stop button "Stopping..." / "Starting..." transients (issue #394)', () => {
+  it('clicking Stop flips the row + workspace button to "Stopping..." (disabled)', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      // A never-resolving fetch keeps the Stop in flight (the SSE event, not the
+      // fetch resolution, clears the transient).
+      (h.window as any).fetch = () => new Promise(() => {});
+      const t = setup(h, 'running');
+      expect(headBtn(h).textContent).toBe('Stop');
+
+      headBtn(h).click(); // -> stopServe -> stoppingIds.add + re-render
+
+      expect(headBtn(h).textContent).toBe('Stopping…');
+      expect(headBtn(h).disabled).toBe(true);
+      expect(rowBtn(t).textContent).toBe('Stopping…');
+      expect(rowBtn(t).disabled).toBe(true);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('a stopped serve event clears "Stopping..." and reverts the button to Start', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      (h.window as any).fetch = () => new Promise(() => {});
+      const t = setup(h, 'running');
+      headBtn(h).click();
+      expect(headBtn(h).textContent).toBe('Stopping…');
+
+      // The SSE 'stopped' event arrives (clean user stop — no message).
+      t.onServeEvent({ target: 'S/Svc', status: 'stopped' });
+
+      expect(headBtn(h).textContent).toBe('Start');
+      expect(rowBtn(t).textContent).toBe('Start');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('a late running re-emit during a Stop does NOT cancel "Stopping..."', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      (h.window as any).fetch = () => new Promise(() => {});
+      const t = setup(h, 'running');
+      headBtn(h).click();
+      expect(headBtn(h).textContent).toBe('Stopping…');
+
+      // A stray 'running' re-emit (e.g. a late hostUrl from issue #392) must not
+      // clear the in-progress stop indicator.
+      t.onServeEvent({ target: 'S/Svc', status: 'running', endpoints: [] });
+
+      expect(headBtn(h).textContent).toBe('Stopping…');
+      expect(headBtn(h).disabled).toBe(true);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('a starting serve shows "Starting..." (disabled) instead of Stop', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const t = setup(h, 'starting');
+      expect(headBtn(h).textContent).toBe('Starting…');
+      expect(headBtn(h).disabled).toBe(true);
+      expect(rowBtn(t).textContent).toBe('Starting…');
+      expect(rowBtn(t).disabled).toBe(true);
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Clicking Stop on a running serve in `cdkl studio` fired `POST /api/stop` but the
button stayed "Stop" with no feedback while the serve's teardown ran (an ECS /
ALB teardown takes a few seconds) — so the user got no signal the stop was in
progress and might click again. Symmetrically, a still-booting serve already
showed "Stop" (clickable) with no in-progress affordance.

Now:
- Clicking Stop adds the target to a client-side `stoppingIds` set; the row +
  workspace buttons render "Stopping..." (disabled) until the `stopped` /
  `error` serve event clears it (in `onServeEvent`). A failed `POST /api/stop`
  clears the transient so the button reverts to Stop.
- A `starting` serve shows "Starting..." (disabled) instead of "Stop".
- Both states are inert so a double-click cannot re-fire stop / cancel mid-boot.
  The transient is cleared ONLY on a terminal event, so a late `running` re-emit
  (e.g. a hostUrl arriving after run, issue #392) does not cancel it; a restart
  defensively clears any stale transient.

Pure UI (`studio-ui.ts`) — no server / API change.

## Test plan

- **Unit** (`studio-ui-stopping-state.test.ts`, jsdom): clicking Stop flips the
  row + workspace button to "Stopping..." (disabled); a `stopped` serve event
  reverts it to Start; a stray `running` re-emit during a Stop keeps
  "Stopping..."; a `starting` serve shows "Starting..." (disabled).
- **Integration** (`local-studio`): the served HTML carries the `stoppingIds`
  transient + the "Stopping..." / "Starting..." button states (UI-level
  assertion, alongside the existing served-HTML checks). Ran clean; 0 orphans.
- Inline-tier review (4 files / ~200 LOC, pure UI, no security paths).

Closes #394
