### PR TITLE
feat(studio): make the image-override Dockerfile picker more legible

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -239,6 +239,12 @@ const STUDIO_CSS = `
   }
   .all-options input.raw-args:focus { outline: none; border-color: #4ec97a; }
   .opt-hint { color: #777; font-size: 11px; }
+  /* Image-override picker legibility (issue #396): the construct-path label is
+     a readable light color (long paths wrap cleanly), and the caveat hint is an
+     attention amber so the "local edits do not take effect" note is actually
+     read — kept small as it is secondary. */
+  .io-label { color: #d7dde5; font-weight: 500; overflow-wrap: anywhere; min-width: 0; }
+  .io-hint { color: #e3b34a; font-size: 11px; }
   .flag-catalog { margin-top: 8px; display: flex; flex-direction: column; gap: 2px; }
   .flag-row { display: flex; gap: 8px; align-items: baseline; font-size: 11px; }
   .flag-name { color: #7bd88f; font-family: ui-monospace, Menlo, monospace; white-space: nowrap; }
@@ -490,8 +496,12 @@ const STUDIO_SCRIPT = `
   // "(keep pinned image)" default). Shared by the ecs single picker and the
   // alb per-backing-service pickers.
   function buildImageOverrideRow(labelText) {
-    const row = el('div', 'opt-row');
-    row.appendChild(el('span', 'opt-label', labelText));
+    // Vertical layout (issue #396): the construct-path label on its own line,
+    // the Dockerfile select directly below it (left-aligned) — a long service
+    // path no longer pushes the select to the far right. The label uses the
+    // readable io-label color (light) instead of the faint grey opt-label.
+    const row = el('div', 'opt-row opt-col');
+    row.appendChild(el('span', 'opt-label io-label', labelText));
     const sel = el('select', 'image-override-select');
     const none = el('option', null, '(keep pinned image)');
     none.value = '';
@@ -518,7 +528,7 @@ const STUDIO_SCRIPT = `
     const hint = studioDockerfiles.length
       ? 'This image is pinned to a deployed registry — local edits do not take effect. Pick a Dockerfile to rebuild it locally.'
       : 'This image is pinned to a deployed registry, but no Dockerfile was found under the app directory.';
-    sec.appendChild(el('div', 'opt-hint', hint));
+    sec.appendChild(el('div', 'opt-hint io-hint', hint));
     return {
       node: sec,
       collect: function () {
@@ -543,7 +553,7 @@ const STUDIO_SCRIPT = `
     const hint = studioDockerfiles.length
       ? 'These services behind the ALB are pinned to a deployed registry — local edits do not take effect. Pick a Dockerfile to rebuild one from local source.'
       : 'These services behind the ALB are pinned to a deployed registry, but no Dockerfile was found under the app directory.';
-    sec.appendChild(el('div', 'opt-hint', hint));
+    sec.appendChild(el('div', 'opt-hint io-hint', hint));
     return {
       node: sec,
       collect: function () {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -269,6 +269,13 @@ if ! grep -qF "buildImageOverridePicker" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the image-override Dockerfile picker"
   exit 1
 fi
+# Image-override picker legibility (issue #396): the readable construct-path
+# label class (io-label, unique to the picker row) + the attention caveat hint
+# class (io-hint). Both the CSS rule and the JS that applies it are in the page.
+if ! grep -qF 'io-label' "${BODY_FILE}" || ! grep -qF 'io-hint' "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the legible image-override picker classes (issue #396)"
+  exit 1
+fi
 # Target-pane UX (issue #301): collapsible/filterable groups + apply-on-change
 # Session bar (no Save button).
 if ! grep -qF 'id="target-search"' "${BODY_FILE}" || ! grep -qF "function applyTargetFilter" "${BODY_FILE}"; then

--- a/tests/unit/local/studio-ui-alb-image-override.test.ts
+++ b/tests/unit/local/studio-ui-alb-image-override.test.ts
@@ -54,6 +54,29 @@ describe('alb composer image-override picker (issue #384)', () => {
     }
   });
 
+  it('lays each picker row out vertically with a legible label + amber hint (issue #396)', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h, [{ id: 'S:SvcA', label: 'My-App/Backend/Api/Fargate/Service/Resource/Service' }]);
+      // The select sits BELOW its label (vertical opt-col row), not pushed to
+      // the far right of a long construct path.
+      const sel = h.document.querySelector('.image-override-select');
+      const row = sel.closest('.opt-row');
+      expect(row.classList.contains('opt-col')).toBe(true);
+      // The construct-path label uses the readable io-label class (not the faint
+      // grey opt-label alone).
+      const label = row.querySelector('.io-label');
+      expect(label).toBeTruthy();
+      expect(label.textContent).toBe('My-App/Backend/Api/Fargate/Service/Resource/Service');
+      // The caveat hint uses the attention io-hint class.
+      const hint = h.document.querySelector('.io-hint');
+      expect(hint).toBeTruthy();
+      expect(hint.textContent).toContain('local edits do not take effect');
+    } finally {
+      h.close();
+    }
+  });
+
   it('threads only the chosen services into the POST body imageOverrides map', () => {
     const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
     try {


### PR DESCRIPTION
## Summary

The studio image-override Dockerfile picker (the `ecs` single picker and the
`alb` per-backing-service pickers) was easy to miss: the `<select>` sat at the
far right of a long construct path, the construct-path label was a faint grey,
and the "local edits do not take effect" caveat hint was small grey and went
unread. This makes the picker legible without making it loud.

- **Vertical layout** — the picker row is now `opt-row opt-col`, so the
  construct-path label sits on its own line with the Dockerfile `<select>`
  directly below it (left-aligned). A long service path no longer pushes the
  select off to the right.
- **Readable label** — the construct-path label gains an `.io-label` class
  (light `#d7dde5`, `overflow-wrap: anywhere`, `min-width: 0`) so it reads
  clearly and long paths wrap cleanly instead of forcing the old `120px`
  min-width.
- **Attention hint** — the pinned-image caveat hint gains an `.io-hint` class
  (amber `#e3b34a`) so the "local edits do not take effect" note is actually
  read. Kept small (11px) as it is secondary information.

Closes #396

## Test plan

- `vp run check` (typecheck + lint + format) — pass
- `vp run build` — pass
- `vp test run` — 180 files / 2732 tests pass, incl. a new
  `studio-ui-alb-image-override.test.ts` case asserting the picker row is
  `opt-col`, the label carries `.io-label`, and the hint carries `.io-hint`.
- `tests/integration/local-studio/verify.sh` — pass; the served UI HTML
  assertion now also greps for `io-label` + `io-hint`.

## Notes

Purely a studio-ui CSS / layout change (`src/local/studio-ui.ts`); no CLI
surface, no exported helper, no behavior change — cdkd-parity n/a.
