### PR TITLE
feat(studio): preserve serve composer inputs across Start -> Stop

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -566,7 +566,12 @@ compute-locally category for Lambda + API Gateway).
   summary, surfaces the failure reason (`StudioServeEvent.message`,
   threaded through `onServeEvent` -> `serveState` -> the workspace error
   banner), and offers a `Reconfigure` button, instead of silently
-  reverting to a blank composer that reads as "my inputs vanished". A served
+  reverting to a blank composer that reads as "my inputs vanished". When a
+  stopped serve's composer is shown again (a Start -> Stop, or Reconfigure on
+  a failed serve), it is re-rendered PRE-FILLED from the same `serveApplied`
+  record (issue #398 — `buildOptions(kind, applied.options, applied.rawArgs)` +
+  the image-override pickers), so the bearer token / curated option inputs /
+  raw extra args / Dockerfile picks survive a restart instead of resetting. A served
   API Gateway WebSocket API additionally gets a WebSocket console
   (`renderWsConsole` — connect / send-frame / received-frame log) wired
   straight to its ws:// endpoint, with the socket + frame log held in module

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -302,7 +302,10 @@ const STUDIO_SCRIPT = `
   // the values when the user clicks Invoke / Start.
   const OPTION_SPECS = window.__OPTION_SPECS__ || {};
 
-  function buildOptions(kind) {
+  // prefill (issue #398): the option map a stopped serve was last Started with
+  // (serveApplied.options), so the re-rendered composer comes back filled.
+  // rawPrefill is the raw-extra-args string (serveApplied.rawArgs).
+  function buildOptions(kind, prefill, rawPrefill) {
     const specs = OPTION_SPECS[kind] || [];
     // The composer always shows an "All options" section (raw extra args + the
     // auto-derived flag reference), even for kinds with no curated controls.
@@ -316,10 +319,12 @@ const STUDIO_SCRIPT = `
     const bools = {};
 
     // Shared add-row pair list (used by repeat-pair AND the env-kv KV pane).
-    function pairList(spec) {
+    // initialRows (issue #398) pre-populates one row per { left, right } so a
+    // stopped serve's composer comes back filled with what it was Started with.
+    function pairList(spec, initialRows) {
       const list = el('div', 'pair-rows');
       const pairs = [];
-      const addRow = function () {
+      const addRow = function (initial) {
         const r = el('div', 'pair-row');
         const lv = el('input');
         lv.placeholder = spec.leftPlaceholder;
@@ -327,6 +332,10 @@ const STUDIO_SCRIPT = `
         const rv = el('input');
         rv.placeholder = spec.rightPlaceholder;
         rv.className = 'pair-in';
+        if (initial) {
+          if (initial.left != null) lv.value = String(initial.left);
+          if (initial.right != null) rv.value = String(initial.right);
+        }
         const pair = { l: lv, r: rv };
         const x = el('button', 'pair-x', 'x');
         x.type = 'button';
@@ -344,7 +353,12 @@ const STUDIO_SCRIPT = `
       };
       const add = el('button', 'pair-add', '+ add');
       add.type = 'button';
-      add.onclick = addRow;
+      // Wrap so the click event is not passed as the initial-row arg to addRow.
+      add.onclick = function () { addRow(); };
+      // Pre-populate from initialRows (issue #398) — one filled row each.
+      if (Array.isArray(initialRows)) {
+        initialRows.forEach(function (ir) { addRow(ir); });
+      }
       const wrap = el('div', 'pair-wrap');
       wrap.appendChild(list);
       wrap.appendChild(add);
@@ -356,11 +370,15 @@ const STUDIO_SCRIPT = `
       };
     }
 
+    // The recorded value for a flag (issue #398) — undefined when no prefill.
+    const pre = function (flag) { return prefill ? prefill[flag] : undefined; };
+
     specs.forEach(function (spec) {
       const row = el('div', 'opt-row');
       if (spec.kind === 'boolean') {
         const cb = el('input');
         cb.type = 'checkbox';
+        if (pre(spec.flag) === true) cb.checked = true;
         const lab = el('label', 'opt-bool');
         lab.appendChild(cb);
         lab.appendChild(document.createTextNode(' ' + spec.label));
@@ -372,6 +390,8 @@ const STUDIO_SCRIPT = `
         const inp = el('input');
         inp.type = spec.inputType === 'number' ? 'number' : 'text';
         if (spec.placeholder) inp.placeholder = spec.placeholder;
+        const pv = pre(spec.flag);
+        if (pv != null && pv !== '') inp.value = String(pv);
         row.appendChild(inp);
         if (spec.showWhen) {
           const gate = bools[spec.showWhen];
@@ -393,7 +413,11 @@ const STUDIO_SCRIPT = `
         modes.appendChild(kvBtn);
         modes.appendChild(jsonBtn);
         row.appendChild(modes);
-        const pl = pairList(spec);
+        // Prefill (issue #398): collect() returns an array in KV mode and a
+        // string in JSON mode, so an array prefill restores KV rows and a
+        // string prefill restores the JSON textarea + that mode.
+        const pv = pre(spec.flag);
+        const pl = pairList(spec, Array.isArray(pv) ? pv : undefined);
         row.appendChild(pl.node);
         const ta = el('textarea', 'envkv-ta');
         ta.placeholder = '{ "KEY": "value" }';
@@ -415,19 +439,24 @@ const STUDIO_SCRIPT = `
           ta.style.display = '';
           pl.node.style.display = 'none';
         };
+        if (typeof pv === 'string') {
+          ta.value = pv;
+          jsonBtn.onclick();
+        }
         getters.push(function () {
           return mode === 'json' ? [spec.flag, ta.value] : [spec.flag, pl.rows()];
         });
       } else {
         // repeat-pair: an add-row list of left<sep>right inputs.
         row.appendChild(el('span', 'opt-label', spec.label));
-        const pl = pairList(spec);
+        const pvp = pre(spec.flag);
+        const pl = pairList(spec, Array.isArray(pvp) ? pvp : undefined);
         row.appendChild(pl.node);
         getters.push(function () { return [spec.flag, pl.rows()]; });
       }
       sec.appendChild(row);
     });
-    const allOpts = buildAllOptions(kind);
+    const allOpts = buildAllOptions(kind, rawPrefill);
     wrap.appendChild(allOpts.node);
     return {
       node: wrap,
@@ -450,7 +479,7 @@ const STUDIO_SCRIPT = `
   // UI is never strictly less capable than the headless CLI (issue #301).
   const FLAG_CATALOG = window.__FLAG_CATALOG__ || {};
 
-  function buildAllOptions(kind) {
+  function buildAllOptions(kind, rawPrefill) {
     const cat = FLAG_CATALOG[kind] || { command: '', flags: [] };
     const det = el('details', 'all-options');
     det.appendChild(el('summary', null, 'All options'));
@@ -459,6 +488,11 @@ const STUDIO_SCRIPT = `
     rawRow.appendChild(el('span', 'opt-label', 'Raw extra args'));
     const rawIn = el('input', 'raw-args');
     rawIn.placeholder = '--flag value --other "with spaces"';
+    // Prefill the raw extra args a stopped serve was Started with (issue #398).
+    if (rawPrefill != null && rawPrefill !== '') {
+      rawIn.value = String(rawPrefill);
+      det.open = true;
+    }
     rawRow.appendChild(rawIn);
     const hint = cat.command
       ? 'Appended verbatim to the spawned ' + cat.command + ' command. Quote values with spaces.'
@@ -495,7 +529,7 @@ const STUDIO_SCRIPT = `
   // One labeled Dockerfile <select> row (the discovered Dockerfiles + a
   // "(keep pinned image)" default). Shared by the ecs single picker and the
   // alb per-backing-service pickers.
-  function buildImageOverrideRow(labelText) {
+  function buildImageOverrideRow(labelText, initialValue) {
     // Vertical layout (issue #396): the construct-path label on its own line,
     // the Dockerfile select directly below it (left-aligned) — a long service
     // path no longer pushes the select to the far right. The label uses the
@@ -511,6 +545,11 @@ const STUDIO_SCRIPT = `
       o.value = df;
       sel.appendChild(o);
     });
+    // Restore the Dockerfile picked before a stop (issue #398) — only when it
+    // is still one of the discovered options, else keep the default.
+    if (initialValue && studioDockerfiles.indexOf(initialValue) >= 0) {
+      sel.value = initialValue;
+    }
     row.appendChild(sel);
     return {
       row: row,
@@ -520,10 +559,10 @@ const STUDIO_SCRIPT = `
     };
   }
 
-  function buildImageOverridePicker() {
+  function buildImageOverridePicker(prefillValue) {
     const sec = el('div', 'section options');
     sec.appendChild(el('h3', null, 'Image override'));
-    const r = buildImageOverrideRow('Local Dockerfile');
+    const r = buildImageOverrideRow('Local Dockerfile', prefillValue);
     sec.appendChild(r.row);
     const hint = studioDockerfiles.length
       ? 'This image is pinned to a deployed registry — local edits do not take effect. Pick a Dockerfile to rebuild it locally.'
@@ -542,11 +581,11 @@ const STUDIO_SCRIPT = `
   // one Dockerfile select per deployed-registry-pinned service the ALB fronts.
   // collect() returns a { [serviceId]: dockerfile } map threaded as
   // imageOverrides (one --image-override service=df per entry).
-  function buildAlbImageOverridePicker(services) {
+  function buildAlbImageOverridePicker(services, prefillMap) {
     const sec = el('div', 'section options');
     sec.appendChild(el('h3', null, 'Image override (pinned backing services)'));
     const rows = services.map(function (svc) {
-      const r = buildImageOverrideRow(svc.label);
+      const r = buildImageOverrideRow(svc.label, prefillMap ? prefillMap[svc.id] : undefined);
       sec.appendChild(r.row);
       return { id: svc.id, getValue: r.getValue };
     });
@@ -970,6 +1009,12 @@ const STUDIO_SCRIPT = `
     ws.appendChild(head);
 
     if (!running && !starting && !failed) {
+      // Prefill the composer with what this serve was last Started with (issue
+      // #398): a Start -> Stop (or Reconfigure on a failed serve) re-renders
+      // here, so thread the recorded serveApplied values back into the inputs
+      // instead of dropping them to a blank composer. Undefined on the first
+      // render (no prior start) => blank, as before.
+      const applied = serveApplied.get(id);
       // A pinned ECS service / task definition (deployed-registry image) does
       // not pick up local source edits — offer an image-override Dockerfile
       // picker so it can be rebuilt locally (issue #301 for ecs, #388 for
@@ -977,7 +1022,7 @@ const STUDIO_SCRIPT = `
       // the ecs-task composer threads it to run-task. Local-asset targets
       // rebuild locally already and get no picker.
       if (meta && (meta.kind === 'ecs' || meta.kind === 'ecs-task') && meta.pinned) {
-        const io = buildImageOverridePicker();
+        const io = buildImageOverridePicker(applied && applied.imageOverride);
         ws.appendChild(io.node);
         collectImageOverride = io.collect;
       }
@@ -986,11 +1031,14 @@ const STUDIO_SCRIPT = `
       // a per-service Dockerfile picker that threads
       // --image-override service=dockerfile to start-alb.
       if (meta && meta.kind === 'alb' && meta.backingPinnedServices && meta.backingPinnedServices.length) {
-        const io = buildAlbImageOverridePicker(meta.backingPinnedServices);
+        const io = buildAlbImageOverridePicker(
+          meta.backingPinnedServices,
+          applied && applied.imageOverrides
+        );
         ws.appendChild(io.node);
         collectImageOverrides = io.collect;
       }
-      const opt = buildOptions(kind);
+      const opt = buildOptions(kind, applied && applied.options, applied && applied.rawArgs);
       if (opt.node) ws.appendChild(opt.node);
       collectOpts = opt.collect;
       collectRaw = opt.collectRaw;

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -276,6 +276,13 @@ if ! grep -qF 'io-label' "${BODY_FILE}" || ! grep -qF 'io-hint' "${BODY_FILE}"; 
   echo "FAIL: GET / did not include the legible image-override picker classes (issue #396)"
   exit 1
 fi
+# Serve composer input preservation (issue #398): a stopped serve re-renders
+# its composer pre-filled from the recorded serveApplied values, so the
+# render path threads the applied options + rawArgs into buildOptions.
+if ! grep -qF 'buildOptions(kind, applied' "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the serve-composer input-preservation wiring (issue #398)"
+  exit 1
+fi
 # Target-pane UX (issue #301): collapsible/filterable groups + apply-on-change
 # Session bar (no Save button).
 if ! grep -qF 'id="target-search"' "${BODY_FILE}" || ! grep -qF "function applyTargetFilter" "${BODY_FILE}"; then
@@ -351,7 +358,7 @@ if ! grep -qF 'stoppingIds' "${BODY_FILE}" \
   echo "FAIL: GET / did not include the Stop/Start transient button states (issue #394)"
   exit 1
 fi
-echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor + session-bar symmetry + remembered-header-mode + stop/start transients"
+echo "    OK: UI HTML served with the All options catalog + image-override picker + target-pane UX + request composer + port-clarity hints + re-invoke wiring + visual UX fixes + send-flow fixes + headers KV/JSON editor + session-bar symmetry + remembered-header-mode + stop/start transients + serve-input preservation"
 
 # ---------------------------------------------------------------------------
 # 4. GET /api/targets lists the fixture's targets.

--- a/tests/unit/local/studio-ui-serve-input-preserve.test.ts
+++ b/tests/unit/local/studio-ui-serve-input-preserve.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the serve-workspace internals + a Dockerfile-list setter so a test
+// can drive a Start -> Stop -> re-render cycle and assert the composer comes
+// back pre-filled with what the serve was last Started with (issue #398).
+const EXPOSE = `
+window.__t = {
+  serveMeta: serveMeta,
+  serveState: serveState,
+  serveApplied: serveApplied,
+  renderServeWorkspace: renderServeWorkspace,
+};
+window.__setShown = function (id) { shownServeId = id; };
+window.__setDockerfiles = function (d) { studioDockerfiles = d; };
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+// Find the input whose row label matches `label`. A scalar/env row labels with
+// a `.opt-label` span; a boolean row labels with a `.opt-bool` <label> whose
+// text carries a leading space.
+function inputForLabel(doc: any, label: string): any {
+  const rows = Array.from(doc.querySelectorAll('#workspace .opt-row')) as any[];
+  const row = rows.find((r) => {
+    const lab = r.querySelector('.opt-label');
+    if (lab && lab.textContent === label) return true;
+    const boolLab = r.querySelector('.opt-bool');
+    return boolLab && boolLab.textContent.trim() === label;
+  });
+  if (!row) return null;
+  return row.querySelector('input, textarea, select');
+}
+
+// Boot an alb serve composer (stopped) with two pinned backing services + a
+// couple of discovered Dockerfiles, shown in the workspace.
+function albComposer(h: Harness) {
+  const t = h.window.__t;
+  h.window.__setDockerfiles(['Dockerfile', 'api/Dockerfile']);
+  const dot = h.document.createElement('span');
+  const btnSlot = h.document.createElement('span');
+  t.serveMeta.set('S/Alb', {
+    dot,
+    btnSlot,
+    kind: 'alb',
+    pinned: false,
+    backingPinnedServices: [
+      { id: 'S:SvcA', label: 'S/SvcA' },
+      { id: 'S:SvcB', label: 'S/SvcB' },
+    ],
+  });
+  t.serveState.set('S/Alb', { status: 'stopped', endpoints: [] });
+  h.window.__setShown('S/Alb');
+  t.renderServeWorkspace('S/Alb');
+  return t;
+}
+
+// Stub fetch so the Start click resolves; then drive the serve to 'stopped'
+// and re-render the composer (the real Start -> SSE 'stopped' -> re-render).
+function startThenStop(h: Harness) {
+  h.window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  (h.document.querySelector('#workspace .composer button') as any).click();
+  h.window.__t.serveState.set('S/Alb', { status: 'stopped', endpoints: [] });
+  h.window.__t.renderServeWorkspace('S/Alb');
+}
+
+describe('serve composer input preservation across Start -> Stop (issue #398)', () => {
+  it('refills the bearer-token scalar after a Start -> Stop cycle', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h);
+      inputForLabel(h.document, 'Bearer token').value = 'eyJ-test-token';
+      startThenStop(h);
+      // serveApplied recorded the value at Start...
+      expect(h.window.__t.serveApplied.get('S/Alb').options['--bearer-token']).toBe('eyJ-test-token');
+      // ...and the re-rendered composer comes back filled.
+      expect(inputForLabel(h.document, 'Bearer token').value).toBe('eyJ-test-token');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('refills a boolean + its showWhen-gated scalar (tls / tls-cert)', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h);
+      const tls = inputForLabel(h.document, 'TLS (terminate HTTPS locally)');
+      tls.checked = true;
+      // Toggling the gate reveals tls-cert (showWhen).
+      tls.dispatchEvent(new h.window.Event('change'));
+      inputForLabel(h.document, 'TLS cert').value = './c.pem';
+      startThenStop(h);
+      expect(inputForLabel(h.document, 'TLS (terminate HTTPS locally)').checked).toBe(true);
+      const cert = inputForLabel(h.document, 'TLS cert');
+      expect(cert.value).toBe('./c.pem');
+      // The gated row is visible again (not display:none) because its gate is checked.
+      expect(cert.closest('.opt-row').style.display).not.toBe('none');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('refills a repeat-pair (listener port remap) row', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h);
+      // Add one --lb-port row and fill it.
+      const rows = Array.from(h.document.querySelectorAll('#workspace .opt-row')) as any[];
+      const lbRow = rows.find((r) => {
+        const lab = r.querySelector('.opt-label');
+        return lab && lab.textContent === 'Listener port remap';
+      });
+      (lbRow.querySelector('.pair-add') as any).click();
+      const ins = lbRow.querySelectorAll('.pair-in');
+      ins[0].value = '443';
+      ins[1].value = '8443';
+      startThenStop(h);
+      const rows2 = Array.from(h.document.querySelectorAll('#workspace .opt-row')) as any[];
+      const lbRow2 = rows2.find((r) => {
+        const lab = r.querySelector('.opt-label');
+        return lab && lab.textContent === 'Listener port remap';
+      });
+      const ins2 = lbRow2.querySelectorAll('.pair-in');
+      expect(ins2.length).toBe(2);
+      expect(ins2[0].value).toBe('443');
+      expect(ins2[1].value).toBe('8443');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('refills an env-kv KV row', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h);
+      const rows = Array.from(h.document.querySelectorAll('#workspace .opt-row')) as any[];
+      const envRow = rows.find((r) => {
+        const lab = r.querySelector('.opt-label');
+        return lab && lab.textContent === 'Env vars';
+      });
+      (envRow.querySelector('.pair-add') as any).click();
+      const ins = envRow.querySelectorAll('.pair-in');
+      ins[0].value = 'API_KEY';
+      ins[1].value = 'secret';
+      startThenStop(h);
+      const rows2 = Array.from(h.document.querySelectorAll('#workspace .opt-row')) as any[];
+      const envRow2 = rows2.find((r) => {
+        const lab = r.querySelector('.opt-label');
+        return lab && lab.textContent === 'Env vars';
+      });
+      const ins2 = envRow2.querySelectorAll('.pair-in');
+      expect(ins2[0].value).toBe('API_KEY');
+      expect(ins2[1].value).toBe('secret');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('refills the raw extra args (and opens the All options section)', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h);
+      (h.document.querySelector('#workspace .raw-args') as any).value = '--no-pull';
+      startThenStop(h);
+      const raw = h.document.querySelector('#workspace .raw-args') as any;
+      expect(raw.value).toBe('--no-pull');
+      expect((raw.closest('.all-options') as any).open).toBe(true);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('refills the alb per-backing-service image-override pick', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h);
+      const selects = h.document.querySelectorAll('#workspace .image-override-select');
+      // Pick a Dockerfile for the first backing service; leave the second.
+      (selects[0] as any).value = 'api/Dockerfile';
+      startThenStop(h);
+      expect(h.window.__t.serveApplied.get('S/Alb').imageOverrides).toEqual({ 'S:SvcA': 'api/Dockerfile' });
+      const selects2 = h.document.querySelectorAll('#workspace .image-override-select');
+      expect((selects2[0] as any).value).toBe('api/Dockerfile');
+      expect((selects2[1] as any).value).toBe('');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('leaves the composer blank on the FIRST render (no prior start)', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      albComposer(h);
+      // No serveApplied record yet => every input is empty / unchecked.
+      expect(inputForLabel(h.document, 'Bearer token').value).toBe('');
+      expect(inputForLabel(h.document, 'TLS (terminate HTTPS locally)').checked).toBe(false);
+      const selects = h.document.querySelectorAll('#workspace .image-override-select');
+      Array.from(selects).forEach((s: any) => expect(s.value).toBe(''));
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

In `cdkl studio`, a serve target (e.g. an ALB) Started then Stopped re-rendered
its composer **blank** — the bearer token, curated option inputs, raw extra
args, and image-override Dockerfile picks all reset, so restarting with the same
configuration meant re-typing everything.

The launch config is already recorded client-side in `serveApplied` at Start (it
backs the read-only "Started with" summary, #356). This threads that record back
into the composer builders when re-rendering a **stopped** serve — or after
clicking **Reconfigure** on a failed serve — so the inputs come back pre-filled:

- `buildOptions(kind, applied.options, applied.rawArgs)` prefills the curated
  controls per spec kind — boolean checkbox, scalar input (incl. a
  `showWhen`-gated scalar, whose gate is restored first), `repeat-pair` rows,
  and the `env-kv` editor (an array prefill restores KV rows; a string prefill
  restores the JSON textarea + that mode) — plus the raw extra-args field (and
  auto-opens the "All options" section so the restored value is visible).
- The ecs / ecs-task single image-override picker and the alb
  per-backing-service image-override map restore the chosen Dockerfile(s) (only
  when still a discovered option).

The first render (no prior start) stays blank, exactly as before.

## Test plan

- `vp run check` / `vp run build` — pass
- `vp test run` — 181 files / 2739 tests pass, incl. a new
  `studio-ui-serve-input-preserve.test.ts` driving a Start -> Stop -> re-render
  cycle for each spec kind (bearer-token scalar, tls boolean + showWhen-gated
  tls-cert, lb-port repeat-pair, env-kv KV row, raw args, alb image-override
  map) + a first-render-blank assertion.
- `tests/integration/local-studio` — pass; the served-UI GET / assertion now
  also checks the input-preservation wiring ships in the page.

## Notes

Pure `src/local/studio-ui.ts` (embedded browser JS) change — the new
`buildOptions` / `buildAllOptions` / image-override-picker parameters are
optional, so the single-shot invoke composer (which passes none) is unchanged.
No CLI surface, no exported helper, no change to the spawned child — cdkd-parity
n/a.

Closes #398
