### PR TITLE
fix(studio): unify serve-child logs onto stdout so the LOG panel keeps emission order

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -704,7 +704,15 @@ compute-locally category for Lambda + API Gateway).
   `Service(s) running:`), tracks the running set for `/api/running`, and
   SIGTERMs the child on `/api/stop` / studio shutdown with a generous
   grace so the serve command's OWN ECS-replica + docker-network teardown
-  completes before any SIGKILL. Under `cdkl studio --watch` it appends
+  completes before any SIGKILL. Each serve child is spawned with
+  `CDKL_LOG_STREAM=stdout` (issue #403) so the logger unifies warn / error
+  onto stdout: studio reads the child's stdout + stderr via two separate OS
+  pipes with no cross-pipe order guarantee, so without unification a stderr
+  WARN (e.g. the pinned-image boot warning) could surface in the studio LOG
+  panel AFTER a later stdout line like `Press ^C to shut down.`. The serve
+  path is safe to unify (ready-line detection greps stdout; error detection
+  is via the child `error` / `close` events, not stderr content). Under
+  `cdkl studio --watch` it appends
   `--watch` to each serve child — read off the mutable config per
   `start()`, so a Session-bar toggle applies to the next serve. Issue #355
   added env-vars to the `alb` / `ecs` serve composers: `start()`

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -418,7 +418,19 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
 
     let child: ChildProcessWithoutNullStreams;
     try {
-      child = spawnFn(nodeBin, [config.cliEntry, ...buildArgs(req, spec, envFile)], { cwd });
+      // `CDKL_LOG_STREAM=stdout` (issue #403): route the serve child's warn /
+      // error to stdout too, so its boot diagnostics do not race ahead of
+      // stdout lines across two OS pipes in the studio LOG panel (Node does not
+      // guarantee cross-pipe delivery order, so a stderr WARN could otherwise
+      // surface AFTER a later stdout banner like "Press ^C to shut down."). The
+      // serve path is safe: ready-line detection greps stdout for specific
+      // patterns and error detection is via the child `error` / `close` events,
+      // not stderr content. (NOT applied to single-shot invoke children, whose
+      // agentcore path treats whole stdout as the response.)
+      child = spawnFn(nodeBin, [config.cliEntry, ...buildArgs(req, spec, envFile)], {
+        cwd,
+        env: { ...process.env, CDKL_LOG_STREAM: 'stdout' },
+      });
     } catch (err) {
       // Spawn never happened — drop the env temp dir so it does not leak.
       if (envDir) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -102,6 +102,19 @@ export class ConsoleLogger implements Logger {
   }
 
   private emit(level: LogLevel, formatted: string): void {
+    // `cdkl studio` sets `CDKL_LOG_STREAM=stdout` on its spawned serve children
+    // (issue #403) so EVERY level routes to stdout instead of the default
+    // warn/error -> stderr split. studio captures a child's stdout and stderr
+    // via two separate OS pipes, and Node does NOT guarantee cross-pipe
+    // delivery order — a warn written just before a stdout banner can surface
+    // AFTER it in the studio LOG panel (e.g. the pinned-image WARN landing
+    // below "Press ^C to shut down."). Emitting one stream preserves emission
+    // order for that consumer. Direct CLI use never sets the var, so the
+    // warn/error -> stderr split is unchanged there.
+    if (process.env['CDKL_LOG_STREAM'] === 'stdout') {
+      console.log(formatted);
+      return;
+    }
     if (level === 'error') console.error(formatted);
     else if (level === 'warn') console.warn(formatted);
     else if (level === 'info') console.info(formatted);

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1158,6 +1158,33 @@ ALB_SERVED=$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "${ALB_FILE}" | head -1 || tr
 rm -f "${ALB_FILE}"
 echo "    OK: ALB serve started; front-door fronted by studio proxy at ${ALB_SERVED}"
 
+# Issue #403: the studio-spawned serve child runs with CDKL_LOG_STREAM=stdout
+# so its warn/error are unified onto stdout. studio reads stdout + stderr via
+# two separate OS pipes (no cross-pipe order guarantee), so without the fix the
+# pinned-image WARN (stderr) could surface in the studio LOG *after* the stdout
+# "Press ^C to shut down" banner. The fixture's backing MyService image is a
+# public-registry literal => the boot emits the pin WARN; assert it lands in the
+# captured studio LOG BEFORE the banner (single-stream => emission order kept).
+echo "==> The pinned-image WARN precedes 'Press ^C' in the studio LOG (issue #403)"
+ORDER_OK=0
+for _ in $(seq 1 30); do
+  if grep -qF 'running image is pinned' "${SSE_FILE}" && grep -qF 'Press ^C to shut down' "${SSE_FILE}"; then
+    WARN_LN=$(grep -nF 'running image is pinned' "${SSE_FILE}" | head -1 | cut -d: -f1)
+    BANNER_LN=$(grep -nF 'Press ^C to shut down' "${SSE_FILE}" | head -1 | cut -d: -f1)
+    if [[ -n "${WARN_LN}" && -n "${BANNER_LN}" && "${WARN_LN}" -lt "${BANNER_LN}" ]]; then
+      ORDER_OK=1
+      break
+    fi
+  fi
+  sleep 1
+done
+if [[ "${ORDER_OK}" != "1" ]]; then
+  echo "FAIL: pinned-image WARN did not precede 'Press ^C' in the studio LOG (issue #403)"
+  echo "----- sse capture -----"; cat "${SSE_FILE}"; echo "-----------------------"
+  exit 1
+fi
+echo "    OK: pinned-image WARN appears before 'Press ^C' in the studio LOG (single-stream order preserved)"
+
 echo "==> The ALB front-door answers through the studio proxy"
 # Retry: the front-door binds before the ECS replica registers in the target
 # group, so the first requests may be 503 until the replica is healthy.

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -153,6 +153,33 @@ describe('createStudioServeManager', () => {
     expect(serves[1].endpoints).toEqual([PROXIED]);
   });
 
+  it('spawns the serve child with CDKL_LOG_STREAM=stdout so its logs are single-stream (issue #403)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      nodeBin: '/usr/bin/node',
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', LISTENING);
+    await p;
+
+    const opts = (spawnFn.mock.calls[0] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2];
+    // The serve child's warn/error are unified onto stdout so the studio LOG
+    // panel does not race them across two OS pipes. The rest of the parent env
+    // is preserved (PATH etc.) so the child still resolves node / docker.
+    expect(opts.env['CDKL_LOG_STREAM']).toBe('stdout');
+    expect(opts.env['PATH']).toBe(process.env['PATH']);
+  });
+
   it('threads --from-cfn-stack <name> + --assume-role <arn> into the serve child argv', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -40,3 +40,54 @@ describe('resolveConfiguredLogLevel', () => {
     }
   });
 });
+
+describe('ConsoleLogger CDKL_LOG_STREAM=stdout unification (issue #403)', () => {
+  const prev = process.env['CDKL_LOG_STREAM'];
+  afterEach(() => {
+    if (prev === undefined) delete process.env['CDKL_LOG_STREAM'];
+    else process.env['CDKL_LOG_STREAM'] = prev;
+  });
+
+  it('routes warn AND error to stdout (console.log) instead of stderr when set', () => {
+    process.env['CDKL_LOG_STREAM'] = 'stdout';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const logger = new ConsoleLogger('info', false);
+      logger.info('an info line');
+      logger.warn('a warning');
+      logger.error('an error');
+      // All three landed on stdout, in emission order, so a consumer that
+      // reads only one stream sees them ordered.
+      expect(logSpy.mock.calls.map((c) => c[0])).toEqual([
+        'an info line',
+        'a warning',
+        'an error',
+      ]);
+      // None went to the stderr-backed channels.
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('keeps the default warn->stderr split when the env var is unset', () => {
+    delete process.env['CDKL_LOG_STREAM'];
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const logger = new ConsoleLogger('info', false);
+      logger.info('info to stdout');
+      logger.warn('warn to stderr');
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

In `cdkl studio`, a serve's LOG panel could show a child's **stderr** warning
*after* a **stdout** line the child actually printed later — most visibly the
pinned-image boot WARN landing below `Press ^C to shut down.` when starting an
ALB whose backing service image is pinned to a deployed registry.

This is **not** a source-ordering bug: running `cdkl start-alb` directly in a
terminal already prints the WARN before the banner (that order was fixed for the
shared emulator in #381). The reorder is specific to studio — it captures the
child's stdout and stderr via **two separate OS pipes**, and Node does not
guarantee cross-pipe delivery order, so stderr lines can batch ahead of / behind
stdout lines. A minimal repro (child writes `ERR0 OUT0 ERR1 OUT1 ...`) shows the
parent receiving `ERR0 ERR1 ... OUT0 OUT1 ...`.

## Fix

Studio spawns each serve child with `CDKL_LOG_STREAM=stdout`, and the logger
honors it by routing warn / error to stdout too (instead of the default
warn/error -> stderr split). The child's output is then a single stream, so
studio's stdout reader emits the lines to the bus in emission order and the LOG
panel preserves it.

Safe for the serve path: ready-line detection greps stdout for specific
patterns, and error detection is via the child `error` / `close` events (not
stderr content); the studio UI ignores the per-line stream tag, so unification
is lossless. Single-shot **invoke** (dispatch) children are intentionally NOT
changed — the agentcore path treats whole stdout as the response, so warns must
stay off stdout there. Direct CLI behavior is unchanged (the env var is only set
by studio).

## Test plan

- `vp run check` / `vp run build` — pass
- `vp test run` — 181 files / 2742 tests pass, incl.
  - logger: `CDKL_LOG_STREAM=stdout` routes warn+error to stdout in emission
    order; the default warn->stderr split holds when unset.
  - serve-manager: the serve child is spawned with `env.CDKL_LOG_STREAM=stdout`
    (parent env otherwise preserved).
- `tests/integration/local-studio` — pass; the studio-started ALB serve's
  captured LOG now asserts the pinned-image WARN appears BEFORE
  `Press ^C to shut down.` (single-stream order preserved end-to-end).
- Live test: spawned `cdkl start-alb` with `CDKL_LOG_STREAM=stdout` under a
  studio-style separate stdout/stderr capture — the pin WARN and the banner both
  land on stdout, in order.

## Notes

Edits to `src/utils/logger.ts` + `src/local/studio-serve-manager.ts` (existing
files) only — no CLI surface, no exported helper, no new `src/local` file. The
logger change is gated entirely by the env var (unset everywhere except studio
serve children), so no existing caller's behavior changes. cdkd-parity n/a.

Closes #403
