### PR TITLE
fix(start-cloudfront): expose the CloudFront-Functions-2.0 runtime built-ins (Buffer, crypto, ...) in the vm sandbox

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -209,8 +209,18 @@ AWS managed services.
   issue #363). The distribution's `AWS::CloudFront::Function`s (inline
   rewrite JS — URL rewrites, trailing-slash normalization, SPA fallback,
   header tweaks) are your own application compute and run in-process in a
-  `node:vm` sandbox (`cloudfront-js-1.0` / `2.0`, async handlers awaited);
-  the S3 origin content is the BucketDeployment source asset resolved out
+  `node:vm` sandbox (`cloudfront-js-1.0` / `2.0`, async handlers awaited).
+  The sandbox reproduces the CloudFront-Functions-2.0 runtime built-ins a
+  bare vm context lacks (issue #410): the `Buffer`, `atob` / `btoa`,
+  `TextEncoder` / `TextDecoder` globals + a `require` for the `crypto`
+  (`createHash` / `createHmac`) / `querystring` / `buffer` modules — backed
+  by the Node equivalents (a superset of the documented 2.0 subset), so a
+  function using `Buffer.from(...).toString('base64')` for a Basic-Auth check
+  runs locally instead of failing with `Buffer is not defined`. `fs` /
+  `process` / timers / network / `eval` are not provided as globals (a
+  `ReferenceError`, matching the restricted runtime); the vm is a fidelity
+  sandbox, not a security boundary (moot — the function code is the user's own).
+  The S3 origin content is the BucketDeployment source asset resolved out
   of the cloud assembly (walk the origin's bucket -> its
   `Custom::CDKBucketDeployment` -> `SourceObjectKeys` -> the staged asset
   dir), served with `DefaultRootObject` (root only — sub-paths are NOT
@@ -519,7 +529,11 @@ compute-locally category for Lambda + API Gateway).
   CloudFront Function in a `node:vm` sandbox, builds the
   viewer-request / viewer-response event from an HTTP request, and
   interprets the handler's return as continue-to-origin vs short-circuit
-  response; `stripCloudFrontImport` strips the 2.0
+  response; `cloudFrontRuntimeGlobals` merges the CloudFront-Functions-2.0
+  built-ins a bare vm context lacks — `Buffer` / `atob` / `btoa` /
+  `TextEncoder` / `TextDecoder` + a `require` for `crypto` / `querystring` /
+  `buffer`, issue #410 — into both the compile probe and the invoke sandbox;
+  `stripCloudFrontImport` strips the 2.0
   `import cf from 'cloudfront'` line at compile time so a KVS-reading
   function compiles as a plain `vm.Script`, and the resolved `cf` module is
   injected under the binding name at invoke time — issue #399),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1519,7 +1519,16 @@ its `DistributionConfig`:
   viewer-request function returning a `statusCode` short-circuits with a
   generated response (redirect / fixed body); otherwise the rewritten
   request continues to the origin. A viewer-response function then runs
-  over the origin response.
+  over the origin response. The sandbox reproduces the
+  CloudFront-Functions-2.0 runtime built-ins a bare `node:vm` lacks — the
+  `Buffer`, `atob` / `btoa`, `TextEncoder` / `TextDecoder` globals and a
+  `require` for the `crypto` / `querystring` / `buffer` modules (Node-backed)
+  — so a function that uses, e.g., `Buffer.from(...).toString('base64')` for a
+  Basic-Auth check runs locally instead of failing with `Buffer is not
+  defined`. `fs` / `process` / timers / network / `eval` are not provided as
+  globals (a `ReferenceError`, matching the restricted runtime); the vm is a
+  fidelity sandbox, not a security boundary (moot — the function is your own
+  code run locally).
 - **Lambda@Edge** — each behavior's `LambdaFunctionAssociations[]`
   (`{EventType, LambdaFunctionARN, IncludeBody}`) → the
   `AWS::Lambda::Function` behind the association's `AWS::Lambda::Version`,

--- a/src/local/cloudfront-function-runtime.ts
+++ b/src/local/cloudfront-function-runtime.ts
@@ -1,5 +1,51 @@
+import * as nodeBuffer from 'node:buffer';
+import * as nodeCrypto from 'node:crypto';
+import * as nodeQuerystring from 'node:querystring';
 import * as vm from 'node:vm';
 import { createUnboundCloudFrontModule, type CloudFrontModule } from './cloudfront-kvs.js';
+
+/**
+ * The CloudFront Functions JS 2.0 runtime exposes a set of globals + `require`
+ * modules that a bare `node:vm` context does NOT provide — code that uses any
+ * of them works in production but fails locally with a `ReferenceError`
+ * (issue #410). Reproduce them with their Node equivalents:
+ *
+ *   - globals: `Buffer`, `atob` / `btoa`, `TextEncoder` / `TextDecoder`
+ *     (the 2.0 runtime's documented globals / built-in objects);
+ *   - `require('crypto')` (`createHash` / `createHmac`, md5 / sha1 / sha256),
+ *     `require('querystring')`, and `require('buffer')` — backed by the Node
+ *     modules (a superset of the 2.0 runtime's documented subset, which is the
+ *     right trade-off for a dev tool: a function using only the documented API
+ *     behaves identically; an undocumented Node-only API would work locally but
+ *     not deployed).
+ *
+ * `console` is added by the caller. A `require` of anything other than the
+ * three modules above throws, and `fs` / `process` / timers / network / `eval`
+ * are not provided as globals — matching the deployed runtime's restricted
+ * features (a fidelity convenience, not a hard isolation guarantee; see the
+ * module docstring).
+ */
+function cloudFrontRuntimeRequire(name: string): unknown {
+  if (name === 'crypto') return nodeCrypto;
+  if (name === 'querystring') return nodeQuerystring;
+  if (name === 'buffer') return nodeBuffer;
+  throw new Error(
+    `Cannot find module '${name}'. CloudFront Functions only provides the 'crypto', ` +
+      "'querystring', and 'buffer' built-in modules."
+  );
+}
+
+/** The CloudFront-Functions-2.0 globals + `require` to merge into a sandbox. */
+function cloudFrontRuntimeGlobals(): Record<string, unknown> {
+  return {
+    Buffer,
+    atob,
+    btoa,
+    TextEncoder,
+    TextDecoder,
+    require: cloudFrontRuntimeRequire,
+  };
+}
 
 /**
  * Hard cap on a single CloudFront Function's synchronous run. The deployed
@@ -25,10 +71,17 @@ const FUNCTION_TIMEOUT_MS = 5000;
  * template (CDK always synthesizes it inline). It is compiled once and run in
  * a fresh `node:vm` context per request to obtain the `handler` function, then
  * `handler(event)` is invoked. `cloudfront-js-2.0` handlers may be `async`, so
- * a returned promise is awaited. The sandbox exposes only the standard
- * JavaScript built-ins a vm context already provides plus `console` (the 2.0
- * runtime has `console.log`); it does NOT expose `require`, `process`, timers,
- * or `fetch`.
+ * a returned promise is awaited. The sandbox exposes the standard JavaScript
+ * built-ins a vm context provides plus `console` and the CloudFront-Functions-2.0
+ * runtime built-ins a bare vm context lacks — `Buffer`, `atob` / `btoa`,
+ * `TextEncoder` / `TextDecoder`, and a `require` for the `crypto` /
+ * `querystring` / `buffer` modules (see {@link cloudFrontRuntimeGlobals}, issue
+ * #410). `process` / timers / `fetch` / `fs` are not provided as globals (a
+ * function referencing them gets a `ReferenceError`, matching CloudFront's
+ * restricted features). Note the vm is a FIDELITY sandbox, not a security
+ * boundary — injecting host objects (`console`, `Buffer`, the `cf` module)
+ * means hostile code could reach the host realm; that is moot here because the
+ * function code is the user's own CDK-app code run locally for dev.
  *
  * The 2.0 KeyValueStore API IS reproduced: a `import cf from 'cloudfront'`
  * statement is stripped from the code ({@link stripCloudFrontImport}) and the
@@ -202,7 +255,7 @@ export function compileCloudFrontFunction(
   // injected per request at invoke time).
   let hasHandler: unknown;
   try {
-    const probeGlobals: Record<string, unknown> = { console };
+    const probeGlobals: Record<string, unknown> = { console, ...cloudFrontRuntimeGlobals() };
     if (bindingName) probeGlobals[bindingName] = createUnboundCloudFrontModule(logicalId);
     const probeContext = vm.createContext(probeGlobals);
     hasHandler = new vm.Script(`${source}\n;typeof handler === 'function'`).runInContext(
@@ -239,7 +292,11 @@ export async function invokeCloudFrontFunction(
   fn: CompiledCloudFrontFunction,
   event: CfViewerRequestEvent | CfViewerResponseEvent
 ): Promise<unknown> {
-  const sandbox: Record<string, unknown> = { console, [EVENT_GLOBAL]: event };
+  const sandbox: Record<string, unknown> = {
+    console,
+    ...cloudFrontRuntimeGlobals(),
+    [EVENT_GLOBAL]: event,
+  };
   // Inject the `cloudfront` module under its import binding name. The command
   // layer sets `cloudfrontModule` once the KVS bindings resolve; when the
   // function imports `cloudfront` but no binding was resolved, an unbound module

--- a/tests/integration/local-start-cloudfront/lib/local-start-cloudfront-stack.ts
+++ b/tests/integration/local-start-cloudfront/lib/local-start-cloudfront-stack.ts
@@ -108,6 +108,32 @@ export class LocalStartCloudFrontStack extends cdk.Stack {
       ),
     });
 
+    // A Basic-Auth viewer-request function on a /secure/* behavior, using the
+    // Buffer global to build the expected Authorization header. This is the
+    // common case from issue #410 — a cloudfront-js-2.0 function that uses
+    // Buffer, which previously failed locally with "Buffer is not defined".
+    const basicAuth = new cloudfront.Function(this, 'BasicAuthFn', {
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(
+        [
+          'function handler(event) {',
+          '  var request = event.request;',
+          "  var expected = 'Basic ' + Buffer.from('user:pass').toString('base64');",
+          '  var auth = request.headers.authorization;',
+          '  if (!auth || auth.value !== expected) {',
+          '    return {',
+          "      statusCode: 401,",
+          "      statusDescription: 'Unauthorized',",
+          "      headers: { 'www-authenticate': { value: 'Basic realm=\"secure\"' } },",
+          '    };',
+          '  }',
+          "  request.uri = '/';",
+          '  return request;',
+          '}',
+        ].join('\n')
+      ),
+    });
+
     const s3Origin = origins.S3BucketOrigin.withOriginAccessControl(bucket);
 
     new cloudfront.Distribution(this, 'SiteDist', {
@@ -125,6 +151,12 @@ export class LocalStartCloudFrontStack extends cdk.Stack {
           origin: s3Origin,
           functionAssociations: [
             { function: kvsRewrite, eventType: cloudfront.FunctionEventType.VIEWER_REQUEST },
+          ],
+        },
+        '/secure/*': {
+          origin: s3Origin,
+          functionAssociations: [
+            { function: basicAuth, eventType: cloudfront.FunctionEventType.VIEWER_REQUEST },
           ],
         },
       },

--- a/tests/integration/local-start-cloudfront/verify.sh
+++ b/tests/integration/local-start-cloudfront/verify.sh
@@ -136,6 +136,27 @@ if grep -qi "no binding resolved it" "${OUT_FILE}"; then
 fi
 
 # ---------------------------------------------------------------------------
+# 2c. Buffer global in a cloudfront-js-2.0 function: the /secure/* behavior's
+#     Basic-Auth function builds the expected Authorization header with
+#     Buffer.from('user:pass').toString('base64'). Previously this failed with
+#     "Buffer is not defined" (issue #410).
+# ---------------------------------------------------------------------------
+echo "==> GET /secure/x without credentials (Basic-Auth function -> 401)"
+SEC_STATUS=$(curl -s -o /dev/null -D /tmp/cdkl-cf-sec.$$ -w '%{http_code}' "${BASE}/secure/x") || true
+[[ "${SEC_STATUS}" == "401" ]] \
+  || fail "Basic-Auth function did not return 401 without credentials (got ${SEC_STATUS}; a 5xx would mean Buffer is undefined)"
+grep -qi "www-authenticate: Basic" /tmp/cdkl-cf-sec.$$ || fail "401 missing the WWW-Authenticate header"
+rm -f /tmp/cdkl-cf-sec.$$
+echo "==> GET /secure/x with correct credentials (Buffer-built check passes -> root page)"
+SEC_BODY=$(curl -fsS -u user:pass "${BASE}/secure/x") \
+  || fail "GET /secure/x with credentials failed (a Buffer ReferenceError would 5xx)"
+echo "${SEC_BODY}" | grep -qi "root page" \
+  || fail "authorized /secure/x did not rewrite to the root page (Buffer-based auth check)"
+if grep -qi "Buffer is not defined" "${OUT_FILE}"; then
+  fail "the server logged 'Buffer is not defined' — the cloudfront-js-2.0 Buffer global is missing"
+fi
+
+# ---------------------------------------------------------------------------
 # 3. CustomErrorResponses SPA fallback: missing key -> 403 -> /404.html (200).
 # ---------------------------------------------------------------------------
 echo "==> GET /does-not-exist (403 -> /404.html (200) SPA fallback)"
@@ -209,4 +230,4 @@ CDKL_PID=""
 sleep 0.5
 if lsof -ti "tcp:${PORT}" >/dev/null 2>&1; then fail "port ${PORT} still bound after shutdown"; fi
 
-echo "PASS: cdkl start-cloudfront served the viewer-request -> S3 origin -> viewer-response pipeline, a KeyValueStore-backed rewrite (--kvs-file), the SPA fallback, ResponseHeadersPolicy CORS (preflight + actual-response), and a --watch reload."
+echo "PASS: cdkl start-cloudfront served the viewer-request -> S3 origin -> viewer-response pipeline, a KeyValueStore-backed rewrite (--kvs-file), a Buffer-using Basic-Auth function (issue #410), the SPA fallback, ResponseHeadersPolicy CORS (preflight + actual-response), and a --watch reload."

--- a/tests/unit/local/cloudfront-function-runtime.test.ts
+++ b/tests/unit/local/cloudfront-function-runtime.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { describe, expect, it } from 'vite-plus/test';
 import {
   buildViewerRequestEvent,
@@ -64,6 +65,43 @@ describe('runViewerRequest', () => {
     const out = await runViewerRequest(fn, reqEvent('/x'));
     expect(out.kind).toBe('continue');
     if (out.kind === 'continue') expect(out.request.uri).toBe('/x');
+  });
+
+  it('exposes the Buffer global to the function — Basic-Auth (issue #410)', async () => {
+    const fn = compile(
+      [
+        'function handler(event) {',
+        '  var request = event.request;',
+        "  var expected = 'Basic ' + Buffer.from('user:pass').toString('base64');",
+        '  var auth = request.headers.authorization;',
+        '  if (!auth || auth.value !== expected) {',
+        "    return { statusCode: 401, statusDescription: 'Unauthorized', headers: { 'www-authenticate': { value: 'Basic' } } };",
+        '  }',
+        '  return request;',
+        '}',
+      ].join('\n')
+    );
+    // No Authorization header -> the Buffer-built expected value mismatches -> 401.
+    const denied = await runViewerRequest(fn, reqEvent('/'));
+    expect(denied.kind).toBe('response');
+    if (denied.kind === 'response') expect(denied.response.statusCode).toBe(401);
+    // The correct Basic credentials pass.
+    const token = Buffer.from('user:pass').toString('base64');
+    const ok = await runViewerRequest(fn, reqEvent('/', { authorization: `Basic ${token}` }));
+    expect(ok.kind).toBe('continue');
+  });
+
+  it('exposes Buffer to TOP-LEVEL code (the compile-time handler probe) — issue #410', () => {
+    // A function that uses Buffer at module scope must still compile (the probe
+    // runs the top-level code to check for `handler`).
+    expect(() =>
+      compile(
+        [
+          "const SECRET = Buffer.from('user:pass').toString('base64');",
+          'function handler(event) { event.request.headers["x-secret"] = { value: SECRET }; return event.request; }',
+        ].join('\n')
+      )
+    ).not.toThrow();
   });
 
   it('awaits an async (cloudfront-js-2.0) handler', async () => {
@@ -210,5 +248,51 @@ describe('CloudFront Function KeyValueStore injection', () => {
     ].join('\n');
     // The probe must not throw on the top-level cf.kvs(id) call.
     expect(() => compile(code)).not.toThrow();
+  });
+});
+
+describe('CloudFront Functions 2.0 runtime built-ins (issue #410)', () => {
+  // Run a function whose body computes a value and returns it in a response
+  // header, so the test can read the result of the global / require under test.
+  async function evalToHeader(expr: string): Promise<string | undefined> {
+    const fn = compile(
+      `function handler(event){ var v = (${expr}); return { statusCode: 200, headers: { 'x-out': { value: String(v) } } }; }`
+    );
+    const out = await runViewerRequest(fn, reqEvent('/'));
+    return out.kind === 'response' ? out.response.headers['x-out']?.value : undefined;
+  }
+
+  it('Buffer.from(...).toString(base64)', async () => {
+    expect(await evalToHeader("Buffer.from('user:pass').toString('base64')")).toBe(
+      Buffer.from('user:pass').toString('base64')
+    );
+  });
+
+  it('atob / btoa', async () => {
+    expect(await evalToHeader("atob(btoa('hello'))")).toBe('hello');
+  });
+
+  it('TextEncoder / TextDecoder', async () => {
+    expect(await evalToHeader("new TextDecoder().decode(new TextEncoder().encode('hi'))")).toBe('hi');
+  });
+
+  it("require('crypto') HMAC sha256", async () => {
+    const expected = createHmac('sha256', 'key').update('msg').digest('hex');
+    expect(
+      await evalToHeader("require('crypto').createHmac('sha256','key').update('msg').digest('hex')")
+    ).toBe(expected);
+  });
+
+  it("require('querystring').parse", async () => {
+    expect(await evalToHeader("require('querystring').parse('a=1&b=2').b")).toBe('2');
+  });
+
+  it("require('buffer').Buffer", async () => {
+    expect(await evalToHeader("require('buffer').Buffer.from('x').toString('hex')")).toBe('78');
+  });
+
+  it('require of an unavailable module (fs) throws, matching the deployed runtime', async () => {
+    const fn = compile("function handler(event){ require('fs'); return event.request; }");
+    await expect(runViewerRequest(fn, reqEvent('/'))).rejects.toThrow(/Cannot find module 'fs'/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #410: a `cloudfront-js-2.0` CloudFront Function that uses `Buffer` (the
common Basic-Auth pattern `Buffer.from(user + ':' + pass).toString('base64')`)
failed at request time in `cdkl start-cloudfront` with `ReferenceError: Buffer
is not defined`. The deployed CloudFront Functions 2.0 runtime exposes `Buffer`
as a global, but the local `node:vm` sandbox did not.

Rather than just `Buffer`, this reproduces the **full set** of CloudFront
Functions 2.0 runtime built-ins a bare `vm` context lacks (a bare context only
has the ECMAScript built-ins), so it isn't whack-a-mole the next time a
crypto-using function fails:

- **globals**: `Buffer`, `atob` / `btoa`, `TextEncoder` / `TextDecoder`
- **`require`** for `crypto` (`createHash` / `createHmac` — md5 / sha1 / sha256),
  `querystring`, and `buffer` — backed by the Node modules (a superset of the
  documented 2.0 subset; the right trade-off for a dev tool — a function using
  the documented API behaves identically). A `require` of any other module
  throws, and `fs` / `process` / timers / network / `eval` are not provided as
  globals, matching the deployed runtime's restricted features.

Merged into BOTH the compile-time handler probe and the per-request invoke
sandbox (`cloudFrontRuntimeGlobals`), so a function using these at top level or
inside the handler works.

Closes #410.

## Note on isolation

The vm is a **fidelity** sandbox, not a security boundary — injecting host
objects (`console`, `Buffer`, the `cf` module) means the host realm is reachable
from sandboxed code. This is moot here (the function code is the user's own
CDK-app code run locally for dev, not untrusted input) and pre-existing (the
`console` / `cf` injections already did this); the docs were softened to say
these features "are not provided as globals" rather than implying isolation.

## Test plan

- **Unit** (`cloudfront-function-runtime.test.ts`): Buffer Basic-Auth at request
  time + at top level (the compile probe), `atob` / `btoa`, `TextEncoder` /
  `TextDecoder`, `require('crypto')` HMAC sha256, `require('querystring')`,
  `require('buffer')`, and a `require('fs')` rejection. 187 files / 2847 tests.
- **Integ (pure-local, no AWS / Docker)**: the `local-start-cloudfront` fixture
  gains a `/secure/*` Basic-Auth function that uses `Buffer` — `GET /secure/x`
  is `401` without credentials and serves the root page with `-u user:pass`, and
  the server logs no "Buffer is not defined". Run clean.
- **Live-test**: the integ exercises the built `dist/cli.js` against the fixture
  end to end.

## Retrospective

Memory captured (local): when reproducing a deployed runtime in a `node:vm`,
audit the deployed runtime's FULL built-in list against vm's bare ECMAScript
defaults and inject the whole set (Node-backed) into both the probe and the
invoke sandbox — don't whack-a-mole the one symbol that broke.
