### PR TITLE
feat(start-cloudfront): --cache-origin read-through cache for the deployed-S3 origin (#405 follow-up)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -228,8 +228,10 @@ AWS managed services.
   BucketDeployment source -> real-S3 under `--from-cfn-stack` ->
   `--origin <id>=<dir>` override), logged per origin, gated only by the
   existing `--from-cfn-stack` flag; an `AccessDenied` (OAC-locked bucket
-  the dev creds cannot read) warns with the `--origin` escape hatch. A
-  read-through cache of fetched objects is a possible follow-up; reads use
+  the dev creds cannot read) warns with the `--origin` escape hatch.
+  `--cache-origin` opts into an in-memory read-through cache of fetched
+  objects for the session (cleared on each `--watch` reload; off by default
+  so every request re-reads / is always current). Reads use
   the `--profile` / default credential chain. Path patterns route across
   `DefaultCacheBehavior` +
   `CacheBehaviors[]` (the existing ALB `*`/`?` glob matcher). A
@@ -365,7 +367,9 @@ compute-locally category for Lambda + API Gateway).
   read-through origin served from real S3 on demand (issue #405 —
   `resolveDeployedS3Origins` reads the bucket's physical name from state +
   builds an `S3OriginReader` per origin, boot-time only, re-annotated on
-  each `--watch` reload via `annotateDeployedS3Origins`); `--origin
+  each `--watch` reload via `annotateDeployedS3Origins`; `--cache-origin`
+  opts the reader into an in-memory read-through cache, cleared on reload);
+  `--origin
   <id>=<dir>` is the local-directory escape hatch when neither resolves;
   `--no-pull` skips the Lambda
   origin image pull; `--kvs-file <kvsLogicalId>=<file>` backs a CloudFront

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1597,7 +1597,9 @@ its `DistributionConfig`:
   bucket the dev credentials cannot read) warns once with the `--origin`
   escape hatch. Reads use the `--profile` / default credential chain; the
   S3 readers are boot-time only (re-applied to a `--watch` reload, not
-  rebuilt). A read-through cache of fetched objects is a possible follow-up.
+  rebuilt). By default every request re-reads (always current); `--cache-origin`
+  opts into an in-memory read-through cache of fetched objects for the session,
+  cleared on each `--watch` reload.
 - **Lambda Function URL origin → local invoke** — the origin's
   `DomainName` (`{Fn::Select: [2, {Fn::Split: ['/', {Fn::GetAtt: [<url>,
   FunctionUrl]}]}]}`) → the `AWS::Lambda::Url` → its `TargetFunctionArn`
@@ -1634,6 +1636,7 @@ On top of the [common flags](#common-flags):
 | `--tls-key <path>` | unset | PEM server private key matching `--tls-cert`. Implies `--tls`; must be set with `--tls-cert`. |
 | `--no-pull` | off | Skip `docker pull` for a Lambda Function URL origin's base image (use the locally cached image). No effect on a pure-S3 distribution. |
 | `--from-cfn-stack [name]` | off | Bind to a deployed CloudFormation stack (`ListStackResources`). Serves an S3 origin that has NO local BucketDeployment source from its deployed bucket, read from real S3 on demand (the front/back-split case — see the S3 origin → deployed bucket bullet above), AND resolves a Function URL origin / Lambda@Edge function's intrinsic env vars to the deployed physical IDs / exports. Bare form uses the resolved stack name; pass a value when the CFn stack name differs. Same semantics as `cdkl invoke --from-cfn-stack`. |
+| `--cache-origin` | off | For a deployed-S3 origin (served from real S3 under `--from-cfn-stack`): keep fetched objects in memory for the session as a read-through cache instead of re-`GetObject`-ing on every request — faster repeat reads / fewer S3 GETs. An out-of-band S3 content change is NOT reflected until a `--watch` reload (which clears the cache) or a restart. Off by default (every request re-reads, always current). This is the local object cache, NOT CloudFront CDN / TTL caching. |
 | `--stack-region <region>` | unset | Region of the state record to read; used with `--from-cfn-stack` as the CFn client region. |
 | `--assume-role [arn]` | off | Assume a Function URL origin Lambda's deployed execution role and forward STS temp credentials into its container. `--assume-role <arn>` (explicit); `--assume-role` (bare, auto-resolves from state — requires `--from-cfn-stack`); `--no-assume-role` (opt out). Same semantics as `cdkl invoke --assume-role`. |
 | `--watch` | off | Hot reload: re-synth + re-resolve the distribution and atomically swap the in-memory routing model when the CDK app's source changes (honors `cdk.json` `watch.include` / `watch.exclude`; `cdk.out`, `node_modules`, `.git` always excluded). The listening socket is never recreated; a synth failure keeps the previous version serving (warn-and-continue). A Function URL origin's RIE container is NOT rebuilt on reload (boot-time only). |

--- a/src/cli/commands/local-start-cloudfront.ts
+++ b/src/cli/commands/local-start-cloudfront.ts
@@ -86,6 +86,12 @@ interface LocalStartCloudFrontOptions {
   origin?: string[];
   /** Repeatable `--kvs-file <kvsLogicalId>=<file.json>` local KeyValueStore map. */
   kvsFile?: string[];
+  /**
+   * `--cache-origin` — keep a deployed-S3 origin's fetched objects in memory
+   * for the session (a read-through cache) instead of re-`GetObject`-ing on
+   * every request (issue #405 follow-up). Cleared on each `--watch` reload.
+   */
+  cacheOrigin?: boolean;
   /** Opt-in to real TLS termination. */
   tls?: boolean;
   tlsCert?: string;
@@ -503,6 +509,7 @@ export async function resolveDeployedS3Origins(
       createS3OriginReader(bucketName, {
         ...(region !== undefined && { region }),
         ...(profileCredentials !== undefined && { credentials: profileCredentials }),
+        ...(options.cacheOrigin === true && { cache: true }),
       })
     );
     buckets.set(origin.originId, bucketName);
@@ -730,6 +737,8 @@ async function localStartCloudFrontCommand(
             // re-emits the origin as s3-unresolved). Before warnUnsupported so a
             // promoted origin does not re-emit the unresolved-source WARN.
             annotateDeployedS3Origins(reloaded.distribution, deployedS3.buckets);
+            // Drop any read-through cache so the reload reflects fresh S3 content.
+            for (const reader of deployedS3.readers.values()) reader.clearCache();
             warnUnsupported(reloaded.distribution);
             await attachKvsModules(
               reloaded.distribution,
@@ -782,6 +791,8 @@ async function localStartCloudFrontCommand(
         })
       )
     );
+    // Release any deployed-S3 origin reader's S3 client socket pool.
+    await Promise.all([...deployedS3.readers.values()].map((reader) => reader.close()));
     process.exit(exitCode);
   };
   process.on('SIGINT', () => void shutdown('SIGINT', 130));
@@ -876,6 +887,15 @@ export function addStartCloudFrontSpecificOptions(cmd: Command): Command {
           "function's env vars to the deployed physical IDs / exports. Use for CDK apps deployed via the upstream " +
           'CDK CLI (`cdk deploy`). Bare form uses the resolved stack name; pass a value when the CFn stack name differs.'
       )
+    )
+    .addOption(
+      new Option(
+        '--cache-origin',
+        'For a deployed-S3 origin (served from real S3 under --from-cfn-stack): keep fetched objects in memory ' +
+          'for the session instead of re-reading on every request. Faster repeat reads / fewer S3 GETs, but an ' +
+          'out-of-band S3 content change is not reflected until a --watch reload (which clears the cache) or a ' +
+          'restart. Off by default (every request re-reads, always current). Not CloudFront CDN caching.'
+      ).default(false)
     )
     .addOption(
       new Option(

--- a/src/local/cloudfront-s3-origin.ts
+++ b/src/local/cloudfront-s3-origin.ts
@@ -57,16 +57,35 @@ export interface S3OriginReaderOptions {
   region?: string;
   /** Explicit credentials (`--profile`-resolved); when absent the SDK's default credential chain is used. */
   credentials?: S3OriginCredentials;
+  /**
+   * Read-through cache: when `true`, a fetched object's bytes are kept in
+   * memory for the session so a repeat request for the same key does NOT
+   * re-`GetObject` (issue #405 follow-up). Default `false` — every request
+   * re-reads, so an out-of-band S3 content change is always reflected. The
+   * cache is cleared on a `--watch` reload via {@link S3OriginReader.clearCache}.
+   */
+  cache?: boolean;
   /** Test seam: override the object fetcher so unit tests need no real S3. */
   fetchObject?: S3ObjectFetcher;
 }
 
 /** Serve one URI from the deployed S3 origin, honoring default-root-object + custom error responses. */
-export type S3OriginReader = (input: {
-  uri: string;
-  defaultRootObject?: string;
-  customErrorResponses?: readonly ResolvedCustomErrorResponse[];
-}) => Promise<StaticOriginResult>;
+export interface S3OriginReader {
+  (input: {
+    uri: string;
+    defaultRootObject?: string;
+    customErrorResponses?: readonly ResolvedCustomErrorResponse[];
+  }): Promise<StaticOriginResult>;
+  /**
+   * Release the underlying S3 client (destroy its socket pool). Called on
+   * server shutdown so an embedding host that restarts servers in-process
+   * does not leak connections; a no-op when no client was created (an
+   * all-cached session, or an injected test fetcher).
+   */
+  close(): Promise<void>;
+  /** Drop the read-through cache (called on a `--watch` reload). No-op when caching is off. */
+  clearCache(): void;
+}
 
 /**
  * Build a reader that serves a deployed S3 bucket on demand. The S3 client is
@@ -77,10 +96,27 @@ export function createS3OriginReader(
   bucketName: string,
   options: S3OriginReaderOptions = {}
 ): S3OriginReader {
-  const fetchObject = options.fetchObject ?? defaultFetchObject(bucketName, options);
+  const source = options.fetchObject
+    ? { fetch: options.fetchObject, close: async (): Promise<void> => undefined }
+    : defaultFetchObject(bucketName, options);
   let deniedWarned = false;
+  // Read-through cache of `found` objects (opt-in). Only successful reads are
+  // cached; a miss / denial is re-tried each request (cheap + always current).
+  const cache = options.cache ? new Map<string, Buffer>() : undefined;
 
-  return async (input) => {
+  const fetchObject: S3ObjectFetcher = async (key) => {
+    const hit = cache?.get(key);
+    if (hit) return { kind: 'found', body: hit };
+    const result = await source.fetch(key);
+    if (result.kind === 'found') cache?.set(key, result.body);
+    return result;
+  };
+
+  const reader = (async (input: {
+    uri: string;
+    defaultRootObject?: string;
+    customErrorResponses?: readonly ResolvedCustomErrorResponse[];
+  }): Promise<StaticOriginResult> => {
     const key = uriToKey(input.uri, input.defaultRootObject);
     if (key !== '') {
       const direct = await fetchObject(key);
@@ -121,6 +157,15 @@ export function createS3OriginReader(
           body: page.body,
         };
       }
+      // A denied / errored error-page read can't be served and isn't a plain
+      // miss — log it (the primary-key denial already named --origin) so it is
+      // not silently swallowed on the way to the terminal 404.
+      if (page.kind === 'denied' || page.kind === 'error') {
+        getLogger().warn(
+          `S3 could not read custom-error page '${candidate.errorKey}' from bucket '${bucketName}' ` +
+            `(${page.kind}); falling through.`
+        );
+      }
     }
 
     // No object and no usable custom-error page: a plain 404 (mirrors the
@@ -130,18 +175,28 @@ export function createS3OriginReader(
       headers: { 'content-type': 'text/plain; charset=utf-8' },
       body: Buffer.from(`Not found: ${input.uri}\n`),
     };
-  };
+  }) as unknown as S3OriginReader;
+
+  reader.close = source.close;
+  reader.clearCache = (): void => cache?.clear();
+  return reader;
 }
 
 /** A minimal structural view of the S3 client + command this module uses. */
 interface S3Access {
-  client: { send(command: unknown): Promise<unknown> };
+  client: { send(command: unknown): Promise<unknown>; destroy(): void };
   GetObjectCommand: new (input: { Bucket: string; Key: string }) => unknown;
 }
 
-/** The default fetcher: a real S3 `GetObject`, classifying the SDK error into the outcome union. */
-function defaultFetchObject(bucketName: string, options: S3OriginReaderOptions): S3ObjectFetcher {
-  // The S3 client is built once on first use and reused across reads.
+/**
+ * The default object source: a real S3 `GetObject` (classifying the SDK error
+ * into the outcome union) plus a `close` that destroys the lazily-created
+ * client's socket pool. The client is built once on first read and reused.
+ */
+function defaultFetchObject(
+  bucketName: string,
+  options: S3OriginReaderOptions
+): { fetch: S3ObjectFetcher; close: () => Promise<void> } {
   let init: Promise<S3Access> | null = null;
   const getAccess = (): Promise<S3Access> => {
     if (!init) {
@@ -168,7 +223,7 @@ function defaultFetchObject(bucketName: string, options: S3OriginReaderOptions):
     return init;
   };
 
-  return async (key) => {
+  const fetch: S3ObjectFetcher = async (key) => {
     try {
       const { client, GetObjectCommand } = await getAccess();
       const res = (await client.send(new GetObjectCommand({ Bucket: bucketName, Key: key }))) as {
@@ -181,6 +236,17 @@ function defaultFetchObject(bucketName: string, options: S3OriginReaderOptions):
       return classifyS3Error(err);
     }
   };
+
+  const close = async (): Promise<void> => {
+    if (!init) return; // client never created (e.g. an all-cached session)
+    try {
+      (await init).client.destroy();
+    } catch {
+      /* best-effort */
+    }
+  };
+
+  return { fetch, close };
 }
 
 /**

--- a/tests/integration/local-start-cloudfront-s3-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-cloudfront-s3-from-cfn-stack/verify.sh
@@ -19,7 +19,8 @@
 #      ALONE (the slow CloudFront distribution is local-synth-only)
 #   3. upload content OUT OF BAND (aws s3 cp), i.e. NO BucketDeployment
 #   4. --from-cfn-stack: GET / -> the deployed bucket's index.html (read from
-#      real S3); GET a nested asset; GET a missing route -> the SPA fallback
+#      real S3); GET a nested asset; GET a missing route -> the SPA fallback;
+#      --cache-origin -> a cached object survives an out-of-band S3 delete
 #   5. baseline (no --from-cfn-stack): the S3 origin is unresolved -> 502
 #   6. cdk destroy --force (autoDeleteObjects empties the bucket) + port sweep
 #
@@ -163,6 +164,36 @@ echo "[verify]   status=$(cat "${BODY_FILE}.code") body=$(cat "${BODY_FILE}")"
 grep -qi "deployed s3 root" "${BODY_FILE}" \
   || fail "missing route did not fall back to /index.html from real S3"
 
+echo "[verify] step 4d: --cache-origin — a cached object survives an out-of-band S3 delete"
+# Boot WITH --cache-origin and keep the server up across two requests + an S3
+# delete in between. A read caches index.html; deleting it from S3 then GETting
+# again must STILL serve it (proving the read-through cache, not a re-read).
+: > "${OUT_FILE}"
+if lsof -ti "tcp:${PORT_CFN}" >/dev/null 2>&1; then lsof -ti "tcp:${PORT_CFN}" | xargs -r kill -9 || true; fi
+${CLI} start-cloudfront "${TARGET}" --port "${PORT_CFN}" --region "${REGION}" \
+  -c withDistribution=true --from-cfn-stack --cache-origin > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+cache_booted=0
+for _ in $(seq 1 240); do
+  if grep -q "CloudFront distribution serving on" "${OUT_FILE}"; then cache_booted=1; break; fi
+  kill -0 "${CDKL_PID}" 2>/dev/null || fail "cache server exited before it was ready"
+  sleep 0.5
+done
+[ "${cache_booted}" -eq 1 ] || fail "cache server did not print its ready banner in time"
+warm="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT_CFN}/")"
+[ "${warm}" = "200" ] || fail "--cache-origin: warming GET / did not return 200"
+echo "[verify]   warmed cache (GET / = 200); deleting index.html from S3 out of band"
+aws s3 rm "s3://${BUCKET}/index.html" --region "${REGION}" >/dev/null
+cached="$(curl -s -o "${BODY_FILE}" -w '%{http_code}' "http://127.0.0.1:${PORT_CFN}/")"
+stop_server
+echo "[verify]   after-delete status=${cached} body=$(cat "${BODY_FILE}")"
+[ "${cached}" = "200" ] || fail "--cache-origin did not serve the deleted object from cache (got ${cached})"
+grep -qi "deployed s3 root" "${BODY_FILE}" \
+  || fail "--cache-origin did not serve the original cached index.html after the S3 delete"
+# Re-upload so step 5 (and any rerun) starts clean.
+echo '<h1>deployed s3 root</h1>' > "${BODY_FILE}"
+aws s3 cp "${BODY_FILE}" "s3://${BUCKET}/index.html" --content-type text/html --region "${REGION}" >/dev/null
+
 echo "[verify] step 5: baseline (no --from-cfn-stack) — the S3 origin is unresolved -> 502"
 boot_and_get "${PORT_BASE}" "/" "${BODY_FILE}"
 echo "[verify]   status=$(cat "${BODY_FILE}.code")"
@@ -171,4 +202,4 @@ echo "[verify]   status=$(cat "${BODY_FILE}.code")"
 grep -qi "no resolvable local source" "${OUT_FILE}" \
   || fail "baseline did not warn that the S3 origin had no resolvable local source"
 
-echo "[verify] PASS: start-cloudfront --from-cfn-stack resolved the deployed bucket and served its out-of-band content from real S3 on demand (root, nested asset, SPA fallback); baseline left the origin unresolved (502)."
+echo "[verify] PASS: start-cloudfront --from-cfn-stack resolved the deployed bucket and served its out-of-band content from real S3 on demand (root, nested asset, SPA fallback); --cache-origin served a deleted object from the read-through cache; baseline left the origin unresolved (502)."

--- a/tests/unit/cli/local-start-cloudfront-deployed-s3.test.ts
+++ b/tests/unit/cli/local-start-cloudfront-deployed-s3.test.ts
@@ -9,14 +9,26 @@ import type { ResolvedDistribution, ResolvedOrigin } from '../../../src/local/cl
 // reload (the pure resolver re-emits the origin as `s3-unresolved`). The state
 // provider is mocked so no real AWS is touched.
 
-const { createProviderMock, cfnPresentMock } = vi.hoisted(() => ({
+const { createProviderMock, cfnPresentMock, readerMock } = vi.hoisted(() => ({
   createProviderMock: vi.fn(),
   cfnPresentMock: vi.fn(() => true),
+  // Stub the reader so the binding test can assert the options threaded into it
+  // (cache flag, region, credentials) without building a real S3 client.
+  readerMock: vi.fn(() => {
+    const fn = (async () => ({ statusCode: 404, headers: {}, body: Buffer.alloc(0) })) as never;
+    (fn as { close: unknown }).close = async (): Promise<void> => undefined;
+    (fn as { clearCache: unknown }).clearCache = (): void => undefined;
+    return fn;
+  }),
 }));
 
 vi.mock('../../../src/cli/commands/local-state-source.js', () => ({
   createLocalStateProvider: createProviderMock,
   isCfnFlagPresent: cfnPresentMock,
+}));
+
+vi.mock('../../../src/local/cloudfront-s3-origin.js', () => ({
+  createS3OriginReader: readerMock,
 }));
 
 const { resolveDeployedS3Origins, annotateDeployedS3Origins } = await import(
@@ -104,6 +116,33 @@ describe('resolveDeployedS3Origins', () => {
 
     expect(dist.origins.get('o1')?.kind).toBe('s3');
     expect(readers.size).toBe(0);
+  });
+
+  it('threads cache: true into the reader only when --cache-origin is set', async () => {
+    createProviderMock.mockReturnValue({
+      load: vi.fn().mockResolvedValue({ resources: { Bucket123: { physicalId: 'b' } } }),
+    });
+
+    readerMock.mockClear();
+    await resolveDeployedS3Origins(
+      distribution({ kind: 's3-unresolved', originId: 'o1', bucketLogicalId: 'Bucket123' }),
+      stacks,
+      { fromCfnStack: 'Stack', cacheOrigin: true } as never,
+      undefined,
+      logger
+    );
+    expect(readerMock).toHaveBeenCalledWith('b', expect.objectContaining({ cache: true }));
+
+    readerMock.mockClear();
+    await resolveDeployedS3Origins(
+      distribution({ kind: 's3-unresolved', originId: 'o1', bucketLogicalId: 'Bucket123' }),
+      stacks,
+      { fromCfnStack: 'Stack' } as never,
+      undefined,
+      logger
+    );
+    const opts = readerMock.mock.calls[0]?.[1] as { cache?: boolean } | undefined;
+    expect(opts?.cache).toBeUndefined();
   });
 });
 

--- a/tests/unit/cli/option-surface-contracts.test.ts
+++ b/tests/unit/cli/option-surface-contracts.test.ts
@@ -297,6 +297,8 @@ describe('start-cloudfront option surface contract (addStartCloudFrontSpecificOp
     expect(flags).toEqual([
       // Issue #380 — full env/state/role parity for a Function URL origin Lambda.
       '--assume-role',
+      // Issue #405 follow-up — in-memory read-through cache for a deployed-S3 origin.
+      '--cache-origin',
       '--from-cfn-stack',
       '--host',
       // Issue #399 — back a CloudFront Function's KeyValueStore reads with a local JSON map.

--- a/tests/unit/local/cloudfront-s3-origin.test.ts
+++ b/tests/unit/local/cloudfront-s3-origin.test.ts
@@ -118,3 +118,91 @@ describe('classifyS3Error', () => {
     if (r.kind === 'error') expect(r.message).toContain('connection reset');
   });
 });
+
+describe('createS3OriginReader — read-through cache (--cache-origin)', () => {
+  it('with cache off (default), re-reads the same key on every request', async () => {
+    let calls = 0;
+    const reader = createS3OriginReader('b', {
+      fetchObject: async (key) => {
+        calls += 1;
+        return key === 'index.html'
+          ? { kind: 'found', body: Buffer.from('v') }
+          : { kind: 'not-found' };
+      },
+    });
+    await reader({ uri: '/index.html' });
+    await reader({ uri: '/index.html' });
+    expect(calls).toBe(2);
+  });
+
+  it('with cache on, serves a repeat read from memory (one fetch)', async () => {
+    let calls = 0;
+    const reader = createS3OriginReader('b', {
+      cache: true,
+      fetchObject: async (key) => {
+        calls += 1;
+        return key === 'index.html'
+          ? { kind: 'found', body: Buffer.from('v') }
+          : { kind: 'not-found' };
+      },
+    });
+    const a = await reader({ uri: '/index.html' });
+    const b = await reader({ uri: '/index.html' });
+    expect(calls).toBe(1);
+    expect(a.body.toString()).toBe('v');
+    expect(b.body.toString()).toBe('v');
+  });
+
+  it('clearCache() forces the next read to re-fetch', async () => {
+    let calls = 0;
+    const reader = createS3OriginReader('b', {
+      cache: true,
+      fetchObject: async () => {
+        calls += 1;
+        return { kind: 'found', body: Buffer.from('v') };
+      },
+    });
+    await reader({ uri: '/a.js' });
+    reader.clearCache();
+    await reader({ uri: '/a.js' });
+    expect(calls).toBe(2);
+  });
+
+  it('does not cache a miss (a later upload is picked up)', async () => {
+    const objects: Record<string, string> = {};
+    const reader = createS3OriginReader('b', {
+      cache: true,
+      fetchObject: async (key) =>
+        key in objects
+          ? { kind: 'found', body: Buffer.from(objects[key]!) }
+          : { kind: 'not-found' },
+    });
+    expect((await reader({ uri: '/late.js' })).statusCode).toBe(404);
+    objects['late.js'] = 'arrived';
+    expect((await reader({ uri: '/late.js' })).statusCode).toBe(200);
+  });
+
+  it('close() resolves and is a no-op for an injected fetcher', async () => {
+    const reader = createS3OriginReader('b', { fetchObject: mapFetcher({}) });
+    await expect(reader.close()).resolves.toBeUndefined();
+  });
+});
+
+describe('createS3OriginReader — error-page read failures are logged', () => {
+  it('warns when the custom-error page itself is denied (not silently swallowed)', async () => {
+    const warn = vi.spyOn(getLogger(), 'warn').mockImplementation(() => undefined);
+    try {
+      const reader = createS3OriginReader('b', {
+        fetchObject: async () => ({ kind: 'denied' }),
+      });
+      const r = await reader({
+        uri: '/route',
+        customErrorResponses: [{ errorCode: 403, responsePagePath: '/index.html' }],
+      });
+      expect(r.statusCode).toBe(404);
+      expect(warn.mock.calls.some((c) => String(c[0]).includes('custom-error page'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #405 (serve a CloudFront S3 origin from real S3 on demand under `--from-cfn-stack`). Three things, all scoped to the deployed-S3 read-through origin:

1. **`--cache-origin`** (default off): keep a deployed-S3 origin's fetched objects in memory for the session as a read-through cache, instead of re-`GetObject`-ing on every request. Default off preserves #405's always-current behavior; on, repeat reads are served from memory and the cache is **cleared on each `--watch` reload** (so a reload reflects fresh S3 content). Only successful reads are cached — a miss is re-tried each request, so a later upload is still picked up.
2. **Reader S3-client release** (review nit from #405): the lazily-created `S3Client` is now destroyed on shutdown via `S3OriginReader.close()`, called from the command's shutdown handler alongside the Lambda runner teardown. No-op when no client was created (all-cached session / injected test fetcher).
3. **Error-page read failures logged** (review nit from #405): a custom-error-page read that is itself `denied` / `errored` is now logged on the way to the terminal 404 instead of being silently swallowed (the primary-key denial already named `--origin`; this covers the error-page leg).

## Internal-type note (cdkd / host CLIs)

`S3OriginReader` changes from a bare function type to a **callable interface** (adds `close()` + `clearCache()`); still exported from `cdk-local/internal`. Hosts that *consume* a reader (call `createS3OriginReader` then invoke it) are unaffected; only code that *assigned a plain function* to the `S3OriginReader` type would need to add the two methods — internal surface, no semver guarantee. `--cache-origin` is registered in `addStartCloudFrontSpecificOptions` (host CLIs inherit it; the option-surface contract test is updated). Additive otherwise — no behavior change without the flag.

## Test plan

- **Unit**: cache hit (one fetch for a repeat read) / miss-not-cached (a later upload is served) / `clearCache()` forces a re-fetch / `close()` resolves; the error-page-denial log; the command threads `cache: true` into the reader **only** under `--cache-origin`.
- **Integration** (real AWS, `local-start-cloudfront-s3-from-cfn-stack`): a new `--cache-origin` step proves the cache end-to-end — warm a read, `aws s3 rm` the object out of band, then GET again still serves the cached bytes (a non-cached read would 404). All prior steps (root / nested asset / SPA fallback / baseline-502) still green; stack auto-destroyed, 0 orphans.
- Full unit suite green (2845); `vp run check` + `vp run build` clean.

Refs #405.
