### PR TITLE
feat(start-cloudfront): resolve an external / non-CDK S3 origin bucket (DomainName parse + GetDistributionConfig) (#405 follow-up)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -229,12 +229,17 @@ AWS managed services.
   front/back-split case where the CDK repo defines the distribution +
   bucket but the static files are uploaded out of band by a separate
   frontend repo / pipeline — `--from-cfn-stack` resolves the deployed
-  bucket's physical name from state (`ListStackResources`) and serves it
-  by reading from **real S3 on demand** (issue #405): a request-time
-  `GetObject` per touched key (no pre-sync, so a CDN bucket with
-  100k objects is fine — a test touches a handful), reusing the same
-  URI->key / `DefaultRootObject` / `CustomErrorResponses` resolution
-  (`cloudfront-s3-origin`). The choice is automatic per origin (local
+  bucket NAME and serves it by reading from **real S3 on demand** (issue
+  #405): a request-time `GetObject` per touched key (no pre-sync, so a CDN
+  bucket with 100k objects is fine — a test touches a handful), reusing the
+  same URI->key / `DefaultRootObject` / `CustomErrorResponses` resolution
+  (`cloudfront-s3-origin`). The bucket name is resolved in priority order
+  (issue #405 + follow-up): a same-stack CDK bucket's physical id from
+  `ListStackResources`; else a literal bucket name parsed from the origin's
+  `DomainName` (an external / imported-by-name bucket); else — when the name
+  is a pure intrinsic (a `Ref` parameter / cross-stack import) — from the
+  deployed distribution via `cloudfront:GetDistributionConfig`
+  (`cloudfront-distribution-config`). The choice is automatic per origin (local
   BucketDeployment source -> real-S3 under `--from-cfn-stack` ->
   `--origin <id>=<dir>` override), logged per origin, gated only by the
   existing `--from-cfn-stack` flag; an `AccessDenied` (OAC-locked bucket
@@ -375,7 +380,8 @@ compute-locally category for Lambda + API Gateway).
   reuses `front-door-tls`; `--from-cfn-stack` additionally promotes an S3
   origin with no local BucketDeployment source to a deployed-S3
   read-through origin served from real S3 on demand (issue #405 —
-  `resolveDeployedS3Origins` reads the bucket's physical name from state +
+  `resolveDeployedS3Origins` resolves the bucket name (state physical id /
+  literal `DomainName` / `GetDistributionConfig`) +
   builds an `S3OriginReader` per origin, boot-time only, re-annotated on
   each `--watch` reload via `annotateDeployedS3Origins`; `--cache-origin`
   opts the reader into an in-memory read-through cache, cleared on reload);
@@ -520,7 +526,11 @@ compute-locally category for Lambda + API Gateway).
   origins (S3 origin -> local
   BucketDeployment source dir via the asset manifest, else an
   `s3-unresolved` origin the command promotes to `s3-deployed` real-S3
-  read-through under `--from-cfn-stack`, issue #405; a Lambda Function
+  read-through under `--from-cfn-stack`, issue #405 — `describeS3OriginDomain`
+  also detects an external/imported-bucket origin from its `DomainName`
+  (`<bucket>.s3[.-]...amazonaws.com`, literal / `Fn::Sub` / `Fn::Join`) and
+  parses the literal bucket name, marking a pure-intrinsic name
+  `deployedConfigOnly`; a Lambda Function
   URL origin -> backing `AWS::Lambda::Function` via the
   `Fn::Select/Split/GetAtt` `DomainName` + `AWS::Lambda::Url`
   `TargetFunctionArn`, issue #376; custom / unresolved origins flagged),
@@ -565,6 +575,13 @@ compute-locally category for Lambda + API Gateway).
   resolution; `classifyS3Error` maps a miss to the SPA fallback and an
   `AccessDenied` to an actionable `--origin` warning; the command promotes
   an `s3-unresolved` origin to `s3-deployed` under `--from-cfn-stack`),
+  cloudfront-distribution-config (issue #405 follow-up — the
+  `GetDistributionConfig` boundary: `resolveDeployedOriginBucket` reads the
+  DEPLOYED distribution's origin `DomainName` and parses the bucket name from
+  it, the fallback for a deployed-S3 origin whose bucket name is a pure
+  intrinsic (a `Ref` parameter / cross-stack import) not derivable from the
+  local template or stack state; never throws — a read failure resolves to
+  undefined so the command falls back to the `--origin` guidance),
   cloudfront-lambda-origin (issue #376 — serves a Lambda Function URL
   origin: builds a Function URL payload-v2.0 event from the request
   (reusing `buildHttpApiV2Event` with a synthetic `$default` route),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1593,9 +1593,15 @@ its `DistributionConfig`:
   fallback for a missing key.
 - **S3 origin → deployed bucket (real S3)** — when the above finds NO
   local BucketDeployment source (the front/back-split case: files uploaded
-  out of band), `--from-cfn-stack` resolves the origin's bucket physical
-  NAME from `ListStackResources` and the origin is served by reading the
-  **deployed bucket from real S3 on demand** (a request-time `GetObject`
+  out of band), `--from-cfn-stack` resolves the origin's bucket NAME and the
+  origin is served by reading the **deployed bucket from real S3 on demand**.
+  The bucket name is resolved in priority order: a same-stack CDK bucket's
+  physical id from `ListStackResources`; else a literal bucket name parsed
+  from the origin's `DomainName` (an external / imported-by-name bucket whose
+  domain is `<bucket>.s3...amazonaws.com`); else — when the name is a pure
+  intrinsic (a `Ref` parameter / cross-stack import) — from the deployed
+  distribution via `cloudfront:GetDistributionConfig`. The read itself is a
+  request-time `GetObject`
   per touched key — no pre-sync, so a CDN bucket with 100k objects is fine;
   the fetched bytes live only in memory for that one request). The same
   URI→key / `DefaultRootObject` / `CustomErrorResponses` resolution applies

--- a/src/cli/commands/local-start-cloudfront.ts
+++ b/src/cli/commands/local-start-cloudfront.ts
@@ -14,6 +14,7 @@ import {
   type LambdaUrlInvokerMap,
 } from '../../local/cloudfront-server.js';
 import { createS3OriginReader, type S3OriginReader } from '../../local/cloudfront-s3-origin.js';
+import { resolveDeployedOriginBucket } from '../../local/cloudfront-distribution-config.js';
 import {
   createFrontDoorLambdaRunner,
   type FrontDoorLambdaRunner,
@@ -498,12 +499,38 @@ export async function resolveDeployedS3Origins(
     synthRegion
   );
   const record = provider ? await provider.load(distribution.stackName, synthRegion) : undefined;
+  // The deployed distribution's physical id (for the GetDistributionConfig
+  // fallback) — `ListStackResources` records it under the distribution's
+  // logical id.
+  const distributionId = record?.resources[distribution.logicalId]?.physicalId;
 
   for (const origin of [...distribution.origins.values()]) {
-    if (origin.kind !== 's3-unresolved' || origin.bucketLogicalId === undefined) continue;
-    // `ListStackResources` returns the bucket's NAME as its physical id.
-    const bucketName = record?.resources[origin.bucketLogicalId]?.physicalId;
-    if (!bucketName) continue; // not in state -> leave unresolved (warnUnsupported handles it)
+    if (origin.kind !== 's3-unresolved') continue;
+
+    // Resolve the bucket NAME in priority order (issue #405 + follow-up):
+    let bucketName: string | undefined;
+    let via: string;
+    if (origin.bucketLogicalId !== undefined) {
+      // Same-stack CDK bucket: ListStackResources records the NAME as its physical id.
+      bucketName = record?.resources[origin.bucketLogicalId]?.physicalId;
+      via = 'deployed state';
+    } else if (origin.bucketName !== undefined) {
+      // External / imported bucket whose name is literal in the DomainName.
+      bucketName = origin.bucketName;
+      via = "the origin's DomainName";
+    } else if (origin.deployedConfigOnly && distributionId) {
+      // Bucket name is a pure intrinsic -> read the deployed distribution config.
+      bucketName = await resolveDeployedOriginBucket({
+        distributionId,
+        originId: origin.originId,
+        ...(profileCredentials !== undefined && { credentials: profileCredentials }),
+      });
+      via = 'GetDistributionConfig';
+    } else {
+      continue; // nothing to resolve from
+    }
+    if (!bucketName) continue; // unresolved -> leave as-is (warnUnsupported handles it)
+
     readers.set(
       origin.originId,
       createS3OriginReader(bucketName, {
@@ -520,7 +547,7 @@ export async function resolveDeployedS3Origins(
     });
     logger.info(
       `Origin '${origin.originId}': no local BucketDeployment source; serving from deployed S3 ` +
-        `(bucket=${bucketName}) on demand under --from-cfn-stack.`
+        `(bucket=${bucketName}, resolved via ${via}) on demand under --from-cfn-stack.`
     );
   }
   return { readers, buckets };

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -702,6 +702,7 @@ export {
   pickFunctionUrlLogicalIdFromOrigin,
   pickTargetFunctionLogicalId,
   pickLambdaEdgeFunctionLogicalId,
+  describeS3OriginDomain,
   extractKvsAssociations,
   pickKvsLogicalIdFromArn,
   CLOUDFRONT_DISTRIBUTION_TYPE,
@@ -795,6 +796,18 @@ export {
   type S3ObjectFetcher,
   type S3FetchResult,
 } from './local/cloudfront-s3-origin.js';
+/**
+ * Deployed-distribution bucket resolution for `start-cloudfront` (issue #405
+ * follow-up): `cloudfront:GetDistributionConfig` -> the origin's deployed
+ * `DomainName` -> bucket name, for a deployed-S3 origin whose bucket name is a
+ * pure intrinsic (not resolvable from the local template or stack state). A
+ * host CLI wrapping `start-cloudfront` reuses `resolveDeployedOriginBucket`.
+ */
+export {
+  resolveDeployedOriginBucket,
+  type ResolveDeployedOriginBucketOptions,
+  type CloudFrontClientCredentials,
+} from './local/cloudfront-distribution-config.js';
 export {
   serveLambdaUrlOrigin,
   type LambdaUrlOriginRequest,

--- a/src/local/cloudfront-distribution-config.ts
+++ b/src/local/cloudfront-distribution-config.ts
@@ -1,0 +1,88 @@
+import { describeS3OriginDomain } from './cloudfront-resolver.js';
+
+/**
+ * Resolve a deployed S3 origin's bucket NAME via `cloudfront:GetDistributionConfig`
+ * (issue #405 follow-up). The fallback for a deployed-S3 origin whose bucket
+ * name is a pure intrinsic in the local template (a `Ref` to a parameter, a
+ * cross-stack import) — not a same-stack `Fn::GetAtt` (resolved from
+ * `ListStackResources` state) and not a literal in the `DomainName` (parsed
+ * locally). The DEPLOYED distribution config carries the origin's concrete
+ * `DomainName`, from which the bucket name is parsed the same way the local
+ * resolver parses a literal S3 domain.
+ *
+ * Used by `cdkl start-cloudfront --from-cfn-stack` (the command resolves the
+ * distribution's physical id from state, then calls this); a host CLI wrapping
+ * the command reaches it via `cdk-local/internal`. CloudFront is a global
+ * service, so the client signs against `us-east-1` regardless of the bucket's
+ * region (the bucket region is the S3 client's concern, not this call's).
+ */
+
+/** Static / STS-issued credentials for the CloudFront control-plane read. */
+export interface CloudFrontClientCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+export interface ResolveDeployedOriginBucketOptions {
+  /** The deployed `AWS::CloudFront::Distribution` physical id (e.g. `E123ABC`). */
+  distributionId: string;
+  /** The origin's `Id` within the distribution config. */
+  originId: string;
+  /** Explicit credentials; when absent the SDK's default credential chain is used. */
+  credentials?: CloudFrontClientCredentials;
+  /**
+   * Test seam: override the GetDistributionConfig call so unit tests need no
+   * real CloudFront. Receives the distribution id, returns the origins list.
+   */
+  getOrigins?: (distributionId: string) => Promise<Array<{ Id?: string; DomainName?: string }>>;
+}
+
+/**
+ * Returns the resolved bucket name, or `undefined` when the distribution /
+ * origin cannot be read or its `DomainName` is not an S3 domain. Never throws —
+ * a failure (no permission, wrong id, throttle) resolves to `undefined` so the
+ * caller can fall back to its actionable `--origin` guidance.
+ */
+export async function resolveDeployedOriginBucket(
+  options: ResolveDeployedOriginBucketOptions
+): Promise<string | undefined> {
+  try {
+    const origins = await (options.getOrigins
+      ? options.getOrigins(options.distributionId)
+      : defaultGetOrigins(options));
+    const origin = origins.find((o) => o.Id === options.originId);
+    if (!origin || typeof origin.DomainName !== 'string') return undefined;
+    return describeS3OriginDomain(origin.DomainName).bucketName;
+  } catch {
+    return undefined;
+  }
+}
+
+async function defaultGetOrigins(
+  options: ResolveDeployedOriginBucketOptions
+): Promise<Array<{ Id?: string; DomainName?: string }>> {
+  const { CloudFrontClient, GetDistributionConfigCommand } =
+    await import('@aws-sdk/client-cloudfront');
+  const client = new CloudFrontClient({
+    region: 'us-east-1', // CloudFront is global; the control plane lives in us-east-1.
+    ...(options.credentials && {
+      credentials: {
+        accessKeyId: options.credentials.accessKeyId,
+        secretAccessKey: options.credentials.secretAccessKey,
+        ...(options.credentials.sessionToken && {
+          sessionToken: options.credentials.sessionToken,
+        }),
+      },
+    }),
+  });
+  try {
+    const res = await client.send(new GetDistributionConfigCommand({ Id: options.distributionId }));
+    return (res.DistributionConfig?.Origins?.Items ?? []) as Array<{
+      Id?: string;
+      DomainName?: string;
+    }>;
+  } finally {
+    client.destroy();
+  }
+}

--- a/src/local/cloudfront-resolver.ts
+++ b/src/local/cloudfront-resolver.ts
@@ -87,7 +87,24 @@ export interface ResolvedBehavior {
 /** A resolved origin: an S3 origin, a Lambda Function URL origin, or a custom origin. */
 export type ResolvedOrigin =
   | { kind: 's3'; originId: string; localDirs: string[] }
-  | { kind: 's3-unresolved'; originId: string; bucketLogicalId?: string }
+  | {
+      /**
+       * An S3 origin with no local BucketDeployment source. The command
+       * promotes it to `s3-deployed` under `--from-cfn-stack` by resolving the
+       * bucket name from (in priority order): `bucketLogicalId` -> deployed
+       * state physical id (same-stack CDK bucket, issue #405); `bucketName` ->
+       * used directly (an external / imported-by-name bucket whose name is
+       * literal in the origin's `DomainName`, issue #405 follow-up); else
+       * `deployedConfigOnly` -> the bucket name is a pure intrinsic resolvable
+       * only in the deployed distribution, so the command reads the bucket
+       * name via `cloudfront:GetDistributionConfig`.
+       */
+      kind: 's3-unresolved';
+      originId: string;
+      bucketLogicalId?: string;
+      bucketName?: string;
+      deployedConfigOnly?: boolean;
+    }
   | {
       /**
        * An S3 origin with no local BucketDeployment source, served by reading
@@ -440,7 +457,13 @@ function resolveOrigins(
     }
 
     const bucketLogicalId = pickBucketLogicalIdFromOrigin(origin, template);
-    const isS3 = origin['S3OriginConfig'] !== undefined || bucketLogicalId !== undefined;
+    // An external / imported bucket origin carries its bucket name in the
+    // DomainName (`<bucket>.s3[.-]...amazonaws.com`), not via a same-stack
+    // Fn::GetAtt. Detect that shape so it is served as S3 (issue #405
+    // follow-up) instead of being mis-classified as a generic custom origin.
+    const s3Domain = describeS3OriginDomain(origin['DomainName']);
+    const isS3 =
+      origin['S3OriginConfig'] !== undefined || bucketLogicalId !== undefined || s3Domain.isS3;
     if (!isS3) {
       // A Lambda Function URL custom origin (origins.FunctionUrlOrigin) is the
       // one custom origin cdk-local serves: the backing Lambda is the user's
@@ -465,14 +488,76 @@ function resolveOrigins(
     if (localDirs.length > 0) {
       out.set(originId, { kind: 's3', originId, localDirs });
     } else {
+      // No local source -> command resolves the deployed bucket. Carry the
+      // best resolution hint: a same-stack logical id (physical id from state),
+      // a literal bucket name parsed from the DomainName, else the
+      // deployed-config-only signal (bucket name is a pure intrinsic).
+      const literalBucket = bucketLogicalId === undefined ? s3Domain.bucketName : undefined;
       out.set(originId, {
         kind: 's3-unresolved',
         originId,
         ...(bucketLogicalId !== undefined && { bucketLogicalId }),
+        ...(literalBucket !== undefined && { bucketName: literalBucket }),
+        ...(bucketLogicalId === undefined && literalBucket === undefined && s3Domain.isS3
+          ? { deployedConfigOnly: true }
+          : {}),
       });
     }
   }
   return out;
+}
+
+/**
+ * Describe an S3 origin's `DomainName`: whether it is an S3-bucket domain and,
+ * if so, the literal bucket name when it is statically derivable from the
+ * template (issue #405 follow-up). Handles a literal string, an `Fn::Sub`
+ * template, and an `Fn::Join('', [...])`. The bucket label is the part before
+ * `.s3` / `.s3-website`; when that label is a pure intrinsic (`${Ref}`), the
+ * name is left undefined (the command resolves it via GetDistributionConfig).
+ * The region segment (`${AWS::Region}` etc.) does NOT affect the bucket name,
+ * so it is normalized away just to validate the S3 shape.
+ */
+export function describeS3OriginDomain(value: unknown): {
+  isS3: boolean;
+  bucketName?: string;
+} {
+  const flat = flattenDomainTemplate(value);
+  if (flat === undefined) return { isS3: false };
+  // Normalize the pseudo-AWS vars (region / url-suffix / partition) so the S3
+  // shape validates; a remaining `${...}` marks a non-literal segment.
+  const normalized = flat
+    .replace(/\$\{AWS::Region\}/g, 'region')
+    .replace(/\$\{AWS::URLSuffix\}/g, 'amazonaws.com')
+    .replace(/\$\{AWS::Partition\}/g, 'aws');
+  // `<label>.s3` then any number of `.<seg>` / `-<seg>` then `.amazonaws.com`.
+  const match = /^(.+?)\.s3(?:[.-][A-Za-z0-9$.{}_-]+)*\.amazonaws\.com$/.exec(normalized);
+  if (!match) return { isS3: false };
+  const label = match[1]!;
+  // A literal bucket label has no unresolved intrinsic marker.
+  if (label.includes('${') || label.includes('{Fn')) return { isS3: true };
+  return { isS3: true, bucketName: label };
+}
+
+/**
+ * Flatten an origin `DomainName` to a single string for S3-shape matching:
+ * a literal string verbatim; an `Fn::Sub` template's string; an
+ * `Fn::Join('', parts)` with literal parts verbatim and intrinsic parts as a
+ * `${...}` marker. Returns `undefined` for any other shape.
+ */
+function flattenDomainTemplate(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return undefined;
+  const obj = value as Record<string, unknown>;
+  const sub = obj['Fn::Sub'];
+  if (typeof sub === 'string') return sub;
+  if (Array.isArray(sub) && typeof sub[0] === 'string') return sub[0];
+  const join = obj['Fn::Join'];
+  if (Array.isArray(join) && join[0] === '' && Array.isArray(join[1])) {
+    return (join[1] as unknown[])
+      .map((part) => (typeof part === 'string' ? part : '${x}'))
+      .join('');
+  }
+  return undefined;
 }
 
 /**

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartCloudFrontExtBucketFromCfnStackStack } from '../lib/local-start-cloudfront-extbucket-from-cfn-stack-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartCloudFrontExtBucketFromCfnStackStack(app, 'CdkLocalStartCfExtBucketFromCfnFixture', {
+  description:
+    'Fixture for cdkl start-cloudfront --from-cfn-stack (GetDistributionConfig external-bucket resolution) integ test',
+});

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/cdk.json
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/lib/local-start-cloudfront-extbucket-from-cfn-stack-stack.ts
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/lib/local-start-cloudfront-extbucket-from-cfn-stack-stack.ts
@@ -1,0 +1,62 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import type { Construct } from 'constructs';
+
+/**
+ * Real-AWS fixture for `cdkl start-cloudfront --from-cfn-stack` resolving a
+ * deployed S3 origin whose bucket name is a PURE INTRINSIC in the template, via
+ * `cloudfront:GetDistributionConfig` (issue #405 follow-up).
+ *
+ * The distribution is an L1 `CfnDistribution` whose S3 origin `DomainName` is an
+ * `Fn::Sub` referencing the bucket name as a Sub variable
+ * (`${BN}.s3.${AWS::Region}.amazonaws.com`). Locally cdk-local cannot derive the
+ * bucket name from that (the label is `${BN}`, not a literal and not a same-stack
+ * `Fn::GetAtt`), so it falls back to `GetDistributionConfig` on the DEPLOYED
+ * distribution — whose origin `DomainName` is the concrete
+ * `<bucket>.s3.<region>.amazonaws.com` — and parses the bucket name from there.
+ *
+ * Unlike the #405 fixture (bucket-only deploy), this MUST deploy the
+ * distribution so `GetDistributionConfig` has something to read. The
+ * distribution is never served through (cdk-local reads the bucket directly with
+ * the dev credentials), so the legacy public-S3 origin config is fine — it just
+ * needs to exist. No `BucketDeployment`: content is uploaded out of band.
+ */
+export class LocalStartCloudFrontExtBucketFromCfnStackStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const bucket = new s3.Bucket(this, 'SiteBucket', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+    new cdk.CfnOutput(this, 'BucketName', { value: bucket.bucketName });
+
+    new cloudfront.CfnDistribution(this, 'Dist', {
+      distributionConfig: {
+        enabled: true,
+        defaultRootObject: 'index.html',
+        origins: [
+          {
+            id: 'o1',
+            // Pure-intrinsic S3 origin domain: the bucket name is a Sub variable,
+            // not a literal or a same-stack Fn::GetAtt -> forces the
+            // GetDistributionConfig fallback locally.
+            domainName: cdk.Fn.sub('${BN}.s3.${AWS::Region}.amazonaws.com', {
+              BN: bucket.bucketName,
+            }),
+            s3OriginConfig: { originAccessIdentity: '' },
+          },
+        ],
+        defaultCacheBehavior: {
+          targetOriginId: 'o1',
+          viewerProtocolPolicy: 'allow-all',
+          forwardedValues: { queryString: false },
+        },
+        customErrorResponses: [
+          { errorCode: 403, responseCode: 200, responsePagePath: '/index.html' },
+        ],
+      },
+    });
+  }
+}

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/package.json
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkl-integ-local-start-cloudfront-extbucket-from-cfn-stack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-cloudfront --from-cfn-stack (GetDistributionConfig external-bucket resolution, #405 follow-up)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/tsconfig.json
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/verify.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Real-AWS validation for `cdkl start-cloudfront --from-cfn-stack` resolving a
+# deployed S3 origin whose bucket name is a PURE INTRINSIC, via
+# `cloudfront:GetDistributionConfig` (issue #405 follow-up).
+#
+# The fixture's distribution origin DomainName is `Fn::Sub
+# '${BN}.s3.${AWS::Region}.amazonaws.com'` (BN = the bucket name) — locally
+# cdk-local cannot derive the bucket name (the label is the Sub var `${BN}`, not
+# a literal and not a same-stack Fn::GetAtt), so it reads the DEPLOYED
+# distribution config and parses the bucket name from the resolved origin
+# DomainName. Exercising that requires a real deployed CloudFront distribution.
+#
+# NOTE: this deploys + destroys a CloudFront distribution, so it is SLOW
+# (create + the disable-then-delete teardown can take 15-30 min total). The
+# distribution is never served through — cdk-local reads the bucket directly
+# with the dev credentials; the distribution only needs to exist for
+# GetDistributionConfig.
+#
+# Steps:
+#   1. install + build cdk-local + fixture deps
+#   2. pre-flight orphan scan, then cdk deploy (bucket + CloudFront distribution)
+#   3. upload content OUT OF BAND (aws s3 cp), i.e. NO BucketDeployment
+#   4. --from-cfn-stack: GET / + a missing-route SPA fallback served from real S3
+#      with the bucket resolved via GetDistributionConfig
+#   5. baseline (no --from-cfn-stack): the origin is unresolved -> 502
+#   6. cdk destroy --force (autoDeleteObjects empties the bucket) + port sweep
+#
+# Run via `/run-integ local-start-cloudfront-extbucket-from-cfn-stack`. Requires
+# AWS credentials with CloudFront + S3 deploy permissions +
+# `cloudfront:GetDistributionConfig` + `s3:GetObject` / `s3:PutObject`, and the
+# global `cdk` (aws-cdk) CLI on $PATH.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkLocalStartCfExtBucketFromCfnFixture"
+TARGET="${STACK}/Dist"
+PORT_CFN=18396
+PORT_BASE=18397
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+CDKL_PID=""
+WE_CREATED_STACK=0
+BUCKET=""
+OUT_FILE="$(mktemp)"
+BODY_FILE="$(mktemp)"
+
+stop_server() {
+  if [ -n "${CDKL_PID}" ] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      kill -0 "${CDKL_PID}" 2>/dev/null || break
+      sleep 0.25
+    done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  CDKL_PID=""
+}
+
+cleanup() {
+  rc=$?
+  stop_server
+  if [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    echo "[verify] teardown: cdk destroy ${STACK} (CloudFront delete is slow)"
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  rm -f "${OUT_FILE}" "${BODY_FILE}" "${BODY_FILE}.code"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  echo "[verify] FAIL: $*" >&2
+  echo "----- server output -----" >&2
+  cat "${OUT_FILE}" >&2 || true
+  exit 1
+}
+
+# boot_and_get <port> <uri> <body-out> [extra cdkl flags...]
+boot_and_get() {
+  local port="$1" uri="$2" body_out="$3"
+  shift 3
+  : > "${OUT_FILE}"
+  if lsof -ti "tcp:${port}" >/dev/null 2>&1; then
+    lsof -ti "tcp:${port}" | xargs -r kill -9 || true
+  fi
+  ${CLI} start-cloudfront "${TARGET}" --port "${port}" --region "${REGION}" "$@" \
+    > "${OUT_FILE}" 2>&1 &
+  CDKL_PID=$!
+  local booted=0
+  for _ in $(seq 1 240); do
+    if grep -q "CloudFront distribution serving on" "${OUT_FILE}"; then booted=1; break; fi
+    kill -0 "${CDKL_PID}" 2>/dev/null || fail "server exited before it was ready"
+    sleep 0.5
+  done
+  [ "${booted}" -eq 1 ] || fail "server did not print its ready banner in time"
+  curl -s -o "${body_out}" -w '%{http_code}' "http://127.0.0.1:${port}${uri}" > "${body_out}.code" || true
+  stop_server
+}
+
+echo "[verify] region=${REGION} stack=${STACK}"
+
+echo "[verify] step 1: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+
+cd "${TEST_DIR}"
+echo "[verify] step 1b: install fixture deps"
+[ -d node_modules ] || vp install --prefer-offline
+
+echo "[verify] step 2: pre-flight orphan scan"
+if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: ${STACK} already exists in CloudFormation — clean up first:"
+  echo "          cdk destroy ${STACK} --force --region ${REGION}"
+  exit 1
+fi
+
+echo "[verify] step 2b: cdk deploy (bucket + CloudFront distribution) — SLOW"
+WE_CREATED_STACK=1
+cdk deploy "${STACK}" \
+  --require-approval never \
+  --no-version-reporting \
+  --no-asset-metadata \
+  --no-path-metadata \
+  --region "${REGION}"
+echo "[verify] step 2b ok: cdk deploy completed"
+
+echo "[verify] step 2c: resolve the deployed bucket name"
+BUCKET="$(aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" \
+  --query "Stacks[0].Outputs[?OutputKey=='BucketName'].OutputValue" --output text)"
+[ -n "${BUCKET}" ] && [ "${BUCKET}" != "None" ] || fail "could not resolve the deployed bucket name"
+echo "[verify]   bucket=${BUCKET}"
+
+echo "[verify] step 3: upload content OUT OF BAND (no BucketDeployment)"
+echo '<h1>ext bucket via GetDistributionConfig</h1>' > "${BODY_FILE}"
+aws s3 cp "${BODY_FILE}" "s3://${BUCKET}/index.html" --content-type text/html --region "${REGION}"
+
+echo "[verify] step 4a: --from-cfn-stack — GET / resolves the bucket via GetDistributionConfig"
+boot_and_get "${PORT_CFN}" "/" "${BODY_FILE}" --from-cfn-stack
+echo "[verify]   status=$(cat "${BODY_FILE}.code") body=$(cat "${BODY_FILE}")"
+[ "$(cat "${BODY_FILE}.code")" = "200" ] || fail "GET / did not return 200 from the deployed S3 origin"
+grep -qi "ext bucket via GetDistributionConfig" "${BODY_FILE}" \
+  || fail "GET / did not serve the out-of-band-uploaded index.html"
+grep -qi "resolved via GetDistributionConfig" "${OUT_FILE}" \
+  || fail "boot did not log resolution via GetDistributionConfig"
+
+echo "[verify] step 4b: --from-cfn-stack — a missing route falls back to the SPA index"
+boot_and_get "${PORT_CFN}" "/does/not/exist" "${BODY_FILE}" --from-cfn-stack
+echo "[verify]   status=$(cat "${BODY_FILE}.code")"
+[ "$(cat "${BODY_FILE}.code")" = "200" ] || fail "missing route did not return the 200 SPA fallback"
+grep -qi "ext bucket via GetDistributionConfig" "${BODY_FILE}" \
+  || fail "missing route did not fall back to /index.html"
+
+echo "[verify] step 5: baseline (no --from-cfn-stack) — the origin is unresolved -> 502"
+boot_and_get "${PORT_BASE}" "/" "${BODY_FILE}"
+echo "[verify]   status=$(cat "${BODY_FILE}.code")"
+[ "$(cat "${BODY_FILE}.code")" = "502" ] \
+  || fail "baseline (no --from-cfn-stack) should 502 on the unresolved origin"
+
+echo "[verify] PASS: start-cloudfront --from-cfn-stack resolved the deployed bucket via GetDistributionConfig (pure-intrinsic origin domain) and served its out-of-band content from real S3 (root + SPA fallback); baseline left the origin unresolved (502)."

--- a/tests/unit/cli/local-start-cloudfront-deployed-s3.test.ts
+++ b/tests/unit/cli/local-start-cloudfront-deployed-s3.test.ts
@@ -9,7 +9,7 @@ import type { ResolvedDistribution, ResolvedOrigin } from '../../../src/local/cl
 // reload (the pure resolver re-emits the origin as `s3-unresolved`). The state
 // provider is mocked so no real AWS is touched.
 
-const { createProviderMock, cfnPresentMock, readerMock } = vi.hoisted(() => ({
+const { createProviderMock, cfnPresentMock, readerMock, bucketResolverMock } = vi.hoisted(() => ({
   createProviderMock: vi.fn(),
   cfnPresentMock: vi.fn(() => true),
   // Stub the reader so the binding test can assert the options threaded into it
@@ -20,6 +20,8 @@ const { createProviderMock, cfnPresentMock, readerMock } = vi.hoisted(() => ({
     (fn as { clearCache: unknown }).clearCache = (): void => undefined;
     return fn;
   }),
+  // Stub the GetDistributionConfig fallback (no real CloudFront call).
+  bucketResolverMock: vi.fn(async () => undefined as string | undefined),
 }));
 
 vi.mock('../../../src/cli/commands/local-state-source.js', () => ({
@@ -29,6 +31,10 @@ vi.mock('../../../src/cli/commands/local-state-source.js', () => ({
 
 vi.mock('../../../src/local/cloudfront-s3-origin.js', () => ({
   createS3OriginReader: readerMock,
+}));
+
+vi.mock('../../../src/local/cloudfront-distribution-config.js', () => ({
+  resolveDeployedOriginBucket: bucketResolverMock,
 }));
 
 const { resolveDeployedS3Origins, annotateDeployedS3Origins } = await import(
@@ -115,6 +121,70 @@ describe('resolveDeployedS3Origins', () => {
     );
 
     expect(dist.origins.get('o1')?.kind).toBe('s3');
+    expect(readers.size).toBe(0);
+  });
+
+  it('uses a literal bucketName from the DomainName directly (external/imported bucket)', async () => {
+    createProviderMock.mockReturnValue({ load: vi.fn().mockResolvedValue({ resources: {} }) });
+    readerMock.mockClear();
+    const dist = distribution({ kind: 's3-unresolved', originId: 'o1', bucketName: 'ext-bucket' });
+
+    const { readers, buckets } = await resolveDeployedS3Origins(
+      dist,
+      stacks,
+      { fromCfnStack: 'Stack' } as never,
+      undefined,
+      logger
+    );
+
+    expect(buckets.get('o1')).toBe('ext-bucket');
+    expect(readers.has('o1')).toBe(true);
+    expect(readerMock).toHaveBeenCalledWith('ext-bucket', expect.anything());
+    expect(dist.origins.get('o1')).toMatchObject({ kind: 's3-deployed', bucketName: 'ext-bucket' });
+  });
+
+  it('falls back to GetDistributionConfig for a deployedConfigOnly origin (pure intrinsic)', async () => {
+    createProviderMock.mockReturnValue({
+      load: vi.fn().mockResolvedValue({ resources: { Dist: { physicalId: 'E123ABC' } } }),
+    });
+    bucketResolverMock.mockResolvedValueOnce('resolved-from-config');
+    readerMock.mockClear();
+    const dist = distribution({ kind: 's3-unresolved', originId: 'o1', deployedConfigOnly: true });
+
+    const { buckets } = await resolveDeployedS3Origins(
+      dist,
+      stacks,
+      { fromCfnStack: 'Stack' } as never,
+      undefined,
+      logger
+    );
+
+    expect(bucketResolverMock).toHaveBeenCalledWith(
+      expect.objectContaining({ distributionId: 'E123ABC', originId: 'o1' })
+    );
+    expect(buckets.get('o1')).toBe('resolved-from-config');
+    expect(dist.origins.get('o1')).toMatchObject({
+      kind: 's3-deployed',
+      bucketName: 'resolved-from-config',
+    });
+  });
+
+  it('leaves a deployedConfigOnly origin unresolved when GetDistributionConfig cannot resolve it', async () => {
+    createProviderMock.mockReturnValue({
+      load: vi.fn().mockResolvedValue({ resources: { Dist: { physicalId: 'E123ABC' } } }),
+    });
+    bucketResolverMock.mockResolvedValueOnce(undefined);
+    const dist = distribution({ kind: 's3-unresolved', originId: 'o1', deployedConfigOnly: true });
+
+    const { readers } = await resolveDeployedS3Origins(
+      dist,
+      stacks,
+      { fromCfnStack: 'Stack' } as never,
+      undefined,
+      logger
+    );
+
+    expect(dist.origins.get('o1')?.kind).toBe('s3-unresolved');
     expect(readers.size).toBe(0);
   });
 

--- a/tests/unit/local/cloudfront-distribution-config.test.ts
+++ b/tests/unit/local/cloudfront-distribution-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { resolveDeployedOriginBucket } from '../../../src/local/cloudfront-distribution-config.js';
+
+describe('resolveDeployedOriginBucket', () => {
+  it('parses the bucket name from the matching origin DomainName in the deployed config', async () => {
+    const bucket = await resolveDeployedOriginBucket({
+      distributionId: 'E123',
+      originId: 'o1',
+      getOrigins: async () => [
+        { Id: 'other', DomainName: 'wrong.s3.us-east-1.amazonaws.com' },
+        { Id: 'o1', DomainName: 'deployed-bucket.s3.us-west-2.amazonaws.com' },
+      ],
+    });
+    expect(bucket).toBe('deployed-bucket');
+  });
+
+  it('returns undefined when the origin id is not in the config', async () => {
+    const bucket = await resolveDeployedOriginBucket({
+      distributionId: 'E123',
+      originId: 'missing',
+      getOrigins: async () => [{ Id: 'o1', DomainName: 'b.s3.us-east-1.amazonaws.com' }],
+    });
+    expect(bucket).toBeUndefined();
+  });
+
+  it('returns undefined when the matched origin DomainName is not an S3 domain', async () => {
+    const bucket = await resolveDeployedOriginBucket({
+      distributionId: 'E123',
+      originId: 'o1',
+      getOrigins: async () => [{ Id: 'o1', DomainName: 'example.execute-api.us-east-1.amazonaws.com' }],
+    });
+    expect(bucket).toBeUndefined();
+  });
+
+  it('never throws — a GetDistributionConfig failure resolves to undefined', async () => {
+    const bucket = await resolveDeployedOriginBucket({
+      distributionId: 'E123',
+      originId: 'o1',
+      getOrigins: async () => {
+        throw new Error('AccessDenied');
+      },
+    });
+    expect(bucket).toBeUndefined();
+  });
+});

--- a/tests/unit/local/cloudfront-resolver.test.ts
+++ b/tests/unit/local/cloudfront-resolver.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 import {
+  describeS3OriginDomain,
   extractKvsAssociations,
   pickBucketLogicalIdFromOrigin,
   pickFunctionLogicalIdFromArn,
@@ -548,5 +549,96 @@ describe('resolveCloudFrontDistribution KVS associations', () => {
     expect(vr?.kvsAssociations).toEqual([
       { arnValue: { 'Fn::GetAtt': ['Kvs', 'Arn'] }, kvsLogicalId: 'Kvs' },
     ]);
+  });
+});
+
+describe('describeS3OriginDomain (issue #405 follow-up — external bucket detection)', () => {
+  it('parses a literal regional S3 domain', () => {
+    expect(describeS3OriginDomain('my-bucket.s3.us-east-1.amazonaws.com')).toEqual({
+      isS3: true,
+      bucketName: 'my-bucket',
+    });
+  });
+
+  it('parses the legacy global S3 domain', () => {
+    expect(describeS3OriginDomain('my-bucket.s3.amazonaws.com')).toEqual({
+      isS3: true,
+      bucketName: 'my-bucket',
+    });
+  });
+
+  it('parses an S3 website endpoint', () => {
+    expect(describeS3OriginDomain('my-bucket.s3-website-us-east-1.amazonaws.com')).toEqual({
+      isS3: true,
+      bucketName: 'my-bucket',
+    });
+  });
+
+  it('keeps dots in the bucket name (label before .s3)', () => {
+    expect(describeS3OriginDomain('my.dotted.bucket.s3.eu-west-1.amazonaws.com')).toEqual({
+      isS3: true,
+      bucketName: 'my.dotted.bucket',
+    });
+  });
+
+  it('resolves an Fn::Sub with ${AWS::Region} (literal bucket label)', () => {
+    expect(
+      describeS3OriginDomain({ 'Fn::Sub': 'my-bucket.s3.${AWS::Region}.${AWS::URLSuffix}' })
+    ).toEqual({ isS3: true, bucketName: 'my-bucket' });
+  });
+
+  it('flags an Fn::Sub whose bucket label is a Ref as S3 but deployed-only (no literal name)', () => {
+    expect(
+      describeS3OriginDomain({ 'Fn::Sub': '${BucketNameParam}.s3.${AWS::Region}.amazonaws.com' })
+    ).toEqual({ isS3: true });
+  });
+
+  it('handles Fn::Join with a literal bucket and intrinsic region', () => {
+    const r = describeS3OriginDomain({
+      'Fn::Join': ['', ['my-bucket.s3.', { Ref: 'AWS::Region' }, '.amazonaws.com']],
+    });
+    expect(r.isS3).toBe(true);
+    expect(r.bucketName).toBe('my-bucket');
+  });
+
+  it('is not S3 for an API Gateway / non-S3 domain', () => {
+    expect(describeS3OriginDomain('abc.execute-api.us-east-1.amazonaws.com').isS3).toBe(false);
+    expect(describeS3OriginDomain('example.com').isS3).toBe(false);
+  });
+
+  it('is not S3 for an unrecognized intrinsic shape', () => {
+    expect(describeS3OriginDomain({ 'Fn::GetAtt': ['X', 'DomainName'] }).isS3).toBe(false);
+  });
+});
+
+describe('resolveCloudFrontDistribution — external/imported S3 origin (issue #405 follow-up)', () => {
+  function distWithOriginDomain(domainName: unknown): CloudFormationTemplate {
+    return {
+      Resources: {
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [{ Id: 'ext', DomainName: domainName, S3OriginConfig: { OriginAccessIdentity: '' } }],
+              DefaultCacheBehavior: { TargetOriginId: 'ext' },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it('classifies a literal external-bucket domain as s3-unresolved with the parsed bucketName', () => {
+    const stack = buildStack(distWithOriginDomain('ext-bucket.s3.us-east-1.amazonaws.com'));
+    const origin = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' }).origins.get('ext');
+    expect(origin).toEqual({ kind: 's3-unresolved', originId: 'ext', bucketName: 'ext-bucket' });
+  });
+
+  it('marks a pure-intrinsic bucket name as deployedConfigOnly (GetDistributionConfig fallback)', () => {
+    const stack = buildStack(
+      distWithOriginDomain({ 'Fn::Sub': '${BucketParam}.s3.${AWS::Region}.amazonaws.com' })
+    );
+    const origin = resolveCloudFrontDistribution({ stack, logicalId: 'Dist' }).origins.get('ext');
+    expect(origin).toEqual({ kind: 's3-unresolved', originId: 'ext', deployedConfigOnly: true });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #405. #405 served a CloudFront S3 origin from real S3 on demand under `--from-cfn-stack`, but only resolved a **same-stack CDK bucket** (its physical id from `ListStackResources`). This resolves an S3 origin whose bucket is **not a same-stack CDK resource** — the external / imported-by-name / cross-stack case — so `--from-cfn-stack` serves it too.

The bucket name is now resolved in priority order:

1. **Same-stack CDK bucket** → physical id from `ListStackResources` (#405, unchanged).
2. **Literal `DomainName` parse** (no AWS call) → the resolver detects an S3-bucket origin from its `DomainName` shape (`<bucket>.s3[.-]...amazonaws.com` — literal, `Fn::Sub`, or `Fn::Join`) even with no same-stack `Fn::GetAtt`, and parses the literal bucket name. Covers an imported-by-name bucket.
3. **`cloudfront:GetDistributionConfig` fallback** → when the bucket name is a pure intrinsic (a `Ref` parameter / cross-stack import) not derivable from the local template, the command reads the deployed distribution's concrete origin `DomainName` and parses the bucket name from there.

The **serving path is unchanged from #405** — the same `S3OriginReader`, URI→key, `DefaultRootObject`, and `CustomErrorResponses`. Only the bucket-name *source* is extended (`resolveDeployedS3Origins` tries the three in order). `GetDistributionConfig` never throws — a read failure leaves the origin unresolved and falls back to the `--origin <id>=<dir>` escape hatch.

## Behavior change (additive)

An external / intrinsic-named S3 origin that previously warned + 502'd is now served under `--from-cfn-stack`. No change without the flag. **Internal-type note** (cdkd / host CLIs): the `s3-unresolved` `ResolvedOrigin` variant gains optional `bucketName?` / `deployedConfigOnly?` fields, and `describeS3OriginDomain` + `resolveDeployedOriginBucket` are exported from `cdk-local/internal` — internal surface, no semver. Refs #405.

## Test plan

- **Unit**: `describeS3OriginDomain` across literal / `Fn::Sub` (region-substituted) / `Fn::Join` / website-endpoint / dotted-bucket / pure-intrinsic / non-S3 shapes; `resolveCloudFrontDistribution` classifying an external literal origin (→ `bucketName`) vs a pure-intrinsic origin (→ `deployedConfigOnly`); the `GetDistributionConfig` client (found / missing-origin / non-S3-domain / throws→undefined); the command's literal-`bucketName` path and `GetDistributionConfig`-fallback path (incl. unresolved-stays-502).
- **Integration** (real AWS, `local-start-cloudfront-extbucket-from-cfn-stack`): deploys a CloudFront **distribution** whose S3 origin `DomainName` is a pure-intrinsic `Fn::Sub` (`${BN}.s3.${AWS::Region}.amazonaws.com`) — forcing the `GetDistributionConfig` path locally — plus a bucket. Content uploaded **out of band** is served from real S3 (root + SPA fallback), the boot log shows `resolved via GetDistributionConfig`, and the no-flag baseline 502s. This fixture deploys + destroys a real CloudFront distribution, so it is slow (CloudFront teardown).
- Full unit suite green; `vp run check` + `vp run build` clean.

## Note on the literal-DomainName path's integ coverage

The literal-`DomainName`-parse path (item 2) shares the #405 serving path verbatim and its `describeS3OriginDomain` parsing is exercised end-to-end by this fixture too (the deployed origin's resolved `DomainName` is parsed by the same helper). Its template-side parsing is unit-locked. The new AWS-touching code (`GetDistributionConfig`) is what the integ proves.

## Reviewer nits (accepted as known cost)

3-axis review (spec / code / test) returned no blockers. Accepted minor items:
- `describeS3OriginDomain`'s `label.includes('{Fn')` guard is belt-and-suspenders (the `Fn::Join` path already normalizes intrinsic parts to `${x}`, caught by the `${` check) — harmless.
- An exotic non-bucket S3-family host (e.g. `*.s3-control.*.amazonaws.com`) would be classified as a bucket — not reachable as a CloudFront origin in practice.
- `defaultGetOrigins` (the real CloudFront SDK client construction + `us-east-1` pin + `client.destroy()`) is exercised by the integ end-to-end rather than a unit test — the SDK boundary is mocked via the `getOrigins` seam in unit tests.
