### PR TITLE
chore(workflow): /create-integ skill + gate, and pin packageManager in every integ fixture

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1021,6 +1021,21 @@ vp run runtime:smoke
   gate it so it cannot ship enabled — but still integ-test the real
   code path it adds, e.g. via the gated entrypoint.)
 
+- **Creating a NEW integ fixture**: use `/create-integ <name>`. It
+  scaffolds the fixture (`package.json` pinned with `packageManager` so
+  `vp install` is a no-op — never re-dirties on the first run, `bin` /
+  `lib` / `cdk.json` / `tsconfig` / a `verify.sh` harness), has you fill
+  in the stack + assertions, RUNS it via `/run-integ`, and sets the
+  `create-integ` marker on a clean green run. A NEW command factory
+  (a new `src/cli/commands/local-<verb>.ts` declaring a
+  `createLocal*Command`) is brand-new behavior with no existing fixture,
+  so `create-integ-gate.sh` blocks `gh pr create` until that marker is
+  fresh. It fires only on a new factory file — NOT on a new non-factory
+  helper module under `src/cli/commands/`, and NOT on a new flag on an
+  EXISTING command (extend that command's fixture instead). Details:
+  [.claude/skills/create-integ/SKILL.md](.claude/skills/create-integ/SKILL.md),
+  [.claude/rules/hooks.md](.claude/rules/hooks.md).
+
 - **When running integration tests**: use `/run-integ <test-name>`
   (e.g., `/run-integ local-invoke`). Never bypass by shelling into
   the fixture's `verify.sh` directly — the skill encodes Docker

--- a/.claude/hooks/create-integ-gate.sh
+++ b/.claude/hooks/create-integ-gate.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# create-integ-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr create` (and the
+# `cd <path> && gh pr create` / `gh -C <path> pr create` worktree forms)
+# when ALL of the following hold:
+#   1. The PR's diff vs origin/main ADDS a new command factory — a NEW
+#      `src/cli/commands/local-<verb>.ts` file (`--diff-filter=A`) that
+#      declares an `export function createLocal<Verb>Command(...)`. The
+#      content check matters: `src/cli/commands/local-*.ts` also holds
+#      non-factory helper modules (local-state-source.ts,
+#      local-profile-credentials-file.ts), which must NOT trigger the
+#      gate. A new subcommand factory is brand-new top-level user-facing
+#      behavior with NO existing integ fixture, so it MUST ship its own
+#      (the "every feature carries its integ" rule, mechanically
+#      enforced for the one case where the need is unambiguous — a new
+#      command always needs a new fixture).
+#   2. The `create-integ` markgate marker is stale (digest differs /
+#      never set).
+#
+# When either is false (no new factory, or marker fresh), exit 0 and
+# `gh pr create` proceeds. EDITS to existing command files (`M` / `D`)
+# never fire this gate — adding a flag to an existing command reuses
+# that command's existing fixture, which integ-gate already covers.
+#
+# Pre-create-only, like cdkd-parity-gate: "a fixture was created for the
+# new command" is a create-time judgment; re-blocking on a later
+# same-PR edit would be friction without value. (integ-gate still
+# enforces marker freshness at pre-merge time for any src / fixture
+# touch.)
+#
+# cwd-aware (mirrors check-gate.sh / integ-gate.sh / cdkd-parity-gate.sh):
+# resolves the target working tree from the payload `cwd` + leading
+# `cd <path>` + the last `gh -C <path>` flag, so markgate's per-worktree
+# marker store is consulted correctly.
+#
+# Fail-open: `gh` / `markgate` / `git` missing, or `origin/main`
+# unresolvable -> exit 0 silently. A safety net, not a hard dependency.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate `gh pr create`. Line-start anchored so a `gh pr create`
+# substring inside a quoted argument body does NOT false-positive.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+target_dir="${hook_cwd:-$PWD}"
+
+# `cd <path>` at the start of the command shifts the target dir.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# `gh -C <path>` beats any earlier cd; pick the LAST occurrence.
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  exit 0
+fi
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+cd "$target_dir" 2>/dev/null || exit 0
+
+if ! command -v gh >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Fire ONLY on a NEW command FACTORY file. `src/cli/commands/local-*.ts`
+# also holds non-factory helper modules (e.g. local-state-source.ts,
+# local-profile-credentials-file.ts), so a filename match alone would
+# false-positive on a new helper. Confirm each newly-ADDED file actually
+# declares an `export function createLocal<Verb>Command(...)` before
+# gating. An edit to an EXISTING command (a new flag, a behavior tweak)
+# reuses that command's existing fixture and never fires here.
+new_command=""
+while IFS= read -r added; do
+  [ -n "$added" ] || continue
+  if grep -qE 'export[[:space:]]+(async[[:space:]]+)?function[[:space:]]+createLocal[A-Za-z]*Command' "$added" 2>/dev/null; then
+    new_command="$added"
+    break
+  fi
+done < <(git diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
+  | grep -E '^src/cli/commands/local-[^/]+\.ts$')
+if [ -z "$new_command" ]; then
+  exit 0
+fi
+
+# Prefer the `mise`-managed markgate; fall back to PATH; fail open.
+if command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+elif command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+else
+  exit 0
+fi
+
+"${markgate[@]}" verify create-integ >/dev/null 2>&1
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+fi
+
+reason=$("${markgate[@]}" status create-integ 2>/dev/null \
+  | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
+
+if [ -n "$reason" ]; then
+  printf "Blocked by create-integ-gate: this PR adds a new command factory (%s) and the \`create-integ\` marker is stale %s.\n\n" "$new_command" "$reason" >&2
+else
+  printf "Blocked by create-integ-gate: this PR adds a new command factory (%s) and\nthe \`create-integ\` marker is stale.\n\n" "$new_command" >&2
+fi
+
+cat >&2 <<'EOF'
+A new subcommand is brand-new user-facing behavior with no existing
+integ fixture — it MUST ship its own. Required action:
+  /create-integ <fixture-name>
+
+The skill scaffolds a fixture (package.json pinned with `packageManager`
+so `vp install` is a no-op, bin / lib / cdk.json / tsconfig / a verify.sh
+harness), has you fill in the stack + assertions for the new command,
+RUNS it via /run-integ, and sets this marker on a clean green run.
+
+Only the skill sets `create-integ`. Calling `markgate set create-integ`
+directly from a shell to bypass this hook defeats the point — a new
+command without an exercised end-to-end fixture can ship a latent bug
+behind a green unit suite.
+EOF
+exit 2

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -141,8 +141,9 @@ The hooks split into three classes:
 
 ## 3. Markgate-backed gates
 
-The five markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
-`pr-review-gate.sh`, `integ-gate.sh`, and `cdkd-parity-gate.sh`) are
+The six markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
+`pr-review-gate.sh`, `integ-gate.sh`, `cdkd-parity-gate.sh`, and
+`create-integ-gate.sh`) are
 all **cwd-aware**. Each reads the PreToolUse payload's `cwd` field plus
 parses leading `cd <path>` and the last `git -C <path>` /
 `gh -C <path>` flag from the command, then `cd`s to that resolved
@@ -304,3 +305,38 @@ call `markgate set integ` directly from a shell.
 
   The skill is the ONLY legitimate setter of this marker — never
   call `markgate set cdkd-parity` directly from a shell.
+
+### create-integ-gate (pre-create)
+
+- **`create-integ-gate.sh`** blocks `gh pr create` (incl.
+  `gh -C <path> pr create` / `cd <path> && gh pr create`) on PRs whose
+  diff vs `origin/main` ADDS a new command factory — a NEW
+  `src/cli/commands/local-<verb>.ts` file (`--diff-filter=A`) that
+  declares an `export function createLocal<Verb>Command(...)` — when
+  the `create-integ` marker is stale. The content check matters:
+  `src/cli/commands/local-*.ts` also holds non-factory helper modules
+  (`local-state-source.ts`, `local-profile-credentials-file.ts`), which
+  must NOT fire the gate, so a filename match alone is not enough.
+
+  A new subcommand factory is brand-new top-level user-facing behavior
+  with NO existing integ fixture, so it MUST ship its own. This is the
+  one case where "needs a new fixture" is unambiguous (a new command
+  always does), so the gate is scoped to exactly that signal — EDITS to
+  existing command files (`M` / `D`, e.g. adding a flag) never fire it,
+  since they reuse that command's existing fixture (which `integ-gate`
+  already covers at pre-merge time).
+
+  The marker is set ONLY by `/create-integ`, which scaffolds a fixture
+  (`package.json` pinned with `packageManager` so `vp install` is a
+  no-op, `bin` / `lib` / `cdk.json` / `tsconfig` / a `verify.sh`
+  harness), has you fill in the stack + assertions, **RUNS it via
+  `/run-integ`**, and records the marker only on a clean green run.
+
+  Pre-create only — `gh pr merge` is intentionally NOT gated. "A fixture
+  was created for the new command" is a create-time judgment; the
+  `integ` gate still enforces marker freshness at pre-merge for any
+  `src/**` / `tests/integration/**` touch.
+
+  Fail-open: `gh` / `markgate` / `git` missing, or `origin/main`
+  unresolvable -> exit 0 silently. The skill is the ONLY legitimate
+  setter — never `markgate set create-integ` directly from a shell.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -108,6 +108,13 @@
             "if": "Bash(gh pr create*) or Bash(gh -C * pr create*) or Bash(cd * && gh pr create*)",
             "timeout": 15,
             "statusMessage": "Verifying cdkd-parity markgate marker..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/create-integ-gate.sh",
+            "if": "Bash(gh pr create*) or Bash(gh -C * pr create*) or Bash(cd * && gh pr create*)",
+            "timeout": 15,
+            "statusMessage": "Verifying create-integ markgate marker..."
           }
         ]
       }

--- a/.claude/skills/create-integ/SKILL.md
+++ b/.claude/skills/create-integ/SKILL.md
@@ -1,0 +1,233 @@
+# Integration Test Creator
+
+Scaffold a NEW `tests/integration/<name>/` fixture, fill in its stack +
+assertions, RUN it, and record the `create-integ` marker.
+
+cdk-local's integ fixtures are the lifeline — they exercise the actual
+user-facing behavior against real Docker (and, for `*-from-cfn-stack`
+fixtures, a real deployed CloudFormation stack via the upstream `cdk` CLI).
+Every new subcommand factory (`src/cli/commands/local-<verb>.ts`) is
+brand-new behavior with no existing fixture, so it MUST ship its own —
+`create-integ-gate.sh` blocks `gh pr create` until this marker is fresh.
+
+Use this skill whenever you add a new command, or a new feature that genuinely
+needs its OWN fixture (a new runtime path that no existing fixture exercises).
+A new flag on an existing command usually reuses that command's fixture —
+extend it instead.
+
+## Arguments
+
+- `name`: the fixture directory name under `tests/integration/`, by convention
+  `local-<command>[-<scenario>]` (e.g. `local-start-foo`,
+  `local-start-foo-from-cfn-stack`). If omitted, ask which command/behavior the
+  fixture covers and derive the name.
+
+## Steps
+
+1. **Decide the shape.** Two kinds:
+   - **Docker-only** (most): the command runs containers locally; `verify.sh`
+     boots `cdkl <cmd>` against a synthesized fixture and asserts the result.
+   - **`*-from-cfn-stack`** (real AWS): the command needs a deployed stack;
+     `verify.sh` does `cdk deploy` first, runs `cdkl <cmd> --from-cfn-stack`,
+     then `cdk destroy`. Name it with the `-from-cfn-stack` suffix so
+     `/run-integ` runs the AWS orphan-stack sweep.
+
+2. **Scaffold the files** under `tests/integration/<name>/`:
+
+   - `cdk.json`:
+     ```json
+     {
+       "app": "node bin/app.ts"
+     }
+     ```
+
+   - `package.json` — **pin `packageManager`** so `vp install` is a no-op and
+     does NOT dirty the file on the first integ run (the recurring churn trap).
+     Keep the trailing newline:
+     ```json
+     {
+       "name": "cdkl-integ-<name>",
+       "version": "1.0.0",
+       "private": true,
+       "description": "Integration test fixture for <what it covers>",
+       "scripts": {
+         "build": "tsc",
+         "watch": "tsc -w"
+       },
+       "devDependencies": {
+         "@types/node": "^20.0.0",
+         "typescript": "^5.0.0"
+       },
+       "dependencies": {
+         "aws-cdk-lib": "^2.169.0",
+         "constructs": "^10.0.0"
+       },
+       "type": "module",
+       "packageManager": "pnpm@11.5.1"
+     }
+     ```
+     Match the `packageManager` version to what `vp install` would write (run
+     `vp install` once in a throwaway dir if unsure; it must match exactly, or
+     it re-churns). Copy `tsconfig.json` verbatim from an existing fixture
+     (e.g. `local-start-cloudfront-s3-from-cfn-stack/tsconfig.json`).
+
+   - `bin/app.ts`:
+     ```ts
+     #!/usr/bin/env node
+     import * as cdk from 'aws-cdk-lib';
+     import { <Stack> } from '../lib/<name>-stack.ts';
+
+     const app = new cdk.App();
+     new <Stack>(app, '<FixtureStackName>', {
+       description: 'Fixture stack for cdkl <cmd> integ test',
+     });
+     ```
+
+   - `lib/<name>-stack.ts` — the minimal CDK resources the command exercises.
+     Keep it as small as possible (a `*-from-cfn-stack` fixture that does NOT
+     need a slow resource deployed should gate it behind a `withX` context flag,
+     like the cloudfront fixtures deploy a bucket-only stack and synth the
+     distribution locally only under `-c withDistribution=true`).
+
+   - `verify.sh` (executable; `chmod +x`) — start from the harness below and
+     fill in the deploy (for `*-from-cfn-stack`) + the boot + assertions.
+
+3. **Fill in the assertions.** Read the command's actual output shape and assert
+   the real user-facing behavior (the ready-line banner, the served response, a
+   404/502 baseline). Cover the new behavior AND a baseline/negative case.
+
+4. **Make the source files tracked.** `tests/integration/.gitignore` ignores
+   `*.js` / `*.d.ts` and (for some) `pnpm-lock.yaml`. Confirm your `.ts` sources
+   are tracked (`git add -f` a handler `*.js` if your fixture ships one, or add a
+   `!subdir/*.js` negation to the fixture's own `.gitignore`). The fixture must
+   build on a fresh checkout / in CI.
+
+5. **RUN it** (NEVER skip — the whole point is to exercise the real path):
+   ```
+   /run-integ <name>
+   ```
+   `/run-integ` does the Docker pre-flight, `verify.sh`, the post-run orphan
+   sweep (+ AWS stack sweep for `*-from-cfn-stack`), and sets the `integ` marker
+   on a clean run. Fix anything it surfaces and re-run until green with 0
+   orphans.
+
+6. **Record the `create-integ` marker** — ONLY after `/run-integ` finished
+   clean (verify.sh exit 0, 0 docker orphans, 0 AWS orphan stacks):
+   ```bash
+   mise exec -- markgate set create-integ
+   ```
+   Skip this if the run was not clean — a stale marker correctly keeps
+   `gh pr create` blocked until the fixture actually passes.
+
+## verify.sh harness
+
+The repetitive shell scaffold (stop / cleanup-trap / fail / a boot-and-curl
+helper / the ready-line wait). Fill in `<CMD>`, `<STACK>`, ports, and the
+assertions. For a Docker-only fixture, drop the `cdk deploy` / `cdk destroy`
+blocks.
+
+`boot_and_get` below is the **HTTP-server shape** — it fits `start-api` /
+`start-cloudfront` (they declare `--port` and serve over HTTP). A non-serving
+command asserts differently: `start-service` / `start-alb` use listener /
+`--host-port` ports (no `--port`); `invoke` / `run-task` / `list` /
+`invoke-agentcore` are not servers — run `${CLI} <cmd> ...` to completion (or
+until a ready banner for a streaming run) and assert on its captured **stdout**
+(the response payload / the `==> ... passed` lines), not a curl. Pick the shape
+that matches your command's surface.
+
+```bash
+#!/usr/bin/env bash
+#
+# Real-Docker validation for `cdkl <CMD>` (<what it covers>).
+# Run via `/run-integ <name>`.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="<FixtureStackName>"
+TARGET="${STACK}/<Construct>"
+PORT=18500
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/<name>"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+
+CDKL_PID=""
+WE_CREATED_STACK=0          # *-from-cfn-stack only
+OUT_FILE="$(mktemp)"
+BODY_FILE="$(mktemp)"
+
+stop_server() {
+  if [ -n "${CDKL_PID}" ] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 60); do kill -0 "${CDKL_PID}" 2>/dev/null || break; sleep 0.25; done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  CDKL_PID=""
+}
+
+cleanup() {
+  rc=$?
+  stop_server
+  if [ "${WE_CREATED_STACK}" -eq 1 ]; then
+    (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
+      --no-version-reporting --no-asset-metadata --no-path-metadata) || true
+  fi
+  rm -f "${OUT_FILE}" "${BODY_FILE}" "${BODY_FILE}.code"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+fail() { echo "[verify] FAIL: $*" >&2; cat "${OUT_FILE}" >&2 || true; exit 1; }
+
+# boot_and_get <port> <uri> <body-out> [extra cdkl flags...]
+boot_and_get() {
+  local port="$1" uri="$2" body_out="$3"; shift 3
+  : > "${OUT_FILE}"
+  lsof -ti "tcp:${port}" >/dev/null 2>&1 && lsof -ti "tcp:${port}" | xargs -r kill -9 || true
+  ${CLI} <CMD> "${TARGET}" --port "${port}" "$@" > "${OUT_FILE}" 2>&1 &
+  CDKL_PID=$!
+  local booted=0
+  for _ in $(seq 1 240); do
+    if grep -q "<READY LINE>" "${OUT_FILE}"; then booted=1; break; fi
+    kill -0 "${CDKL_PID}" 2>/dev/null || fail "server exited before it was ready"
+    sleep 0.5
+  done
+  [ "${booted}" -eq 1 ] || fail "server did not print its ready banner in time"
+  curl -s -o "${body_out}" -w '%{http_code}' "http://127.0.0.1:${port}${uri}" > "${body_out}.code" || true
+  stop_server
+}
+
+echo "[verify] step 1: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+cd "${TEST_DIR}"
+[ -d node_modules ] || vp install --prefer-offline
+
+# --- *-from-cfn-stack only: deploy first ---
+# if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
+#   echo "[verify] FAIL: ${STACK} already exists — clean up first"; exit 1; fi
+# WE_CREATED_STACK=1
+# cdk deploy "${STACK}" --require-approval never --no-version-reporting \
+#   --no-asset-metadata --no-path-metadata --region "${REGION}"
+
+echo "[verify] step 2: <assert the new behavior>"
+boot_and_get "${PORT}" "/" "${BODY_FILE}"
+[ "$(cat "${BODY_FILE}.code")" = "200" ] || fail "GET / did not return 200"
+# grep -qi "<expected body>" "${BODY_FILE}" || fail "..."
+
+echo "[verify] PASS: <one-line summary of what was proven>"
+```
+
+## Important
+
+- **Always RUN the fixture (step 5) before recording the marker.** A scaffold
+  that never ran proves nothing. `create-integ` is earned by a clean
+  `/run-integ`, not by writing files.
+- **`packageManager` is pinned on purpose** — without it `vp install` adds it on
+  the first run, dirtying `package.json`, staling the `integ` marker, and
+  leaking into the PR. Pinning it makes the install a no-op.
+- **English only** for all committed artifacts (see `.claude/CLAUDE.md`).
+- This skill is the ONLY legitimate setter of `create-integ`; never
+  `markgate set create-integ` from a shell to bypass `create-integ-gate.sh`.

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -1,6 +1,6 @@
 # markgate configuration — https://github.com/go-to-k/markgate
 #
-# Six gates back the pre-commit / pre-PR / pre-merge checks for cdk-local.
+# Seven gates back the pre-commit / pre-PR / pre-merge checks for cdk-local.
 # cdk-local does NOT deploy to AWS (no destroy path, no schema migration,
 # no broad real-AWS integ matrix), so the destroy / broad / schema-migration
 # gates from cdkd are not needed.
@@ -32,6 +32,10 @@
 #                    new public helper / behavior change). Set ONLY by
 #                    /check-cdkd-parity. Scope is the public library
 #                    surface; out-of-scope diffs don't invalidate it.
+#   create-integ   — A NEW `src/cli/commands/local-<verb>.ts` factory (a
+#                    brand-new subcommand) MUST ship its own integ fixture.
+#                    Set ONLY by /create-integ, which scaffolds + RUNS the
+#                    new fixture. Pre-create only, like cdkd-parity.
 
 gates:
   check:
@@ -87,3 +91,19 @@ gates:
       - "src/cli/commands/**"
       - "src/internal.ts"
       - "src/index.ts"
+
+  create-integ:
+    hash: files
+    # A NEW `src/cli/commands/local-<verb>.ts` factory (a file declaring
+    # `createLocal<Verb>Command`) is a brand-new subcommand with NO
+    # existing integ fixture, so it MUST ship its own.
+    # `create-integ-gate.sh` (pre-create only) fires when the PR adds such
+    # a factory file; `/create-integ` scaffolds + RUNS the new fixture and
+    # sets this marker. Scope is the whole command-factory surface, which
+    # is intentionally BROADER than the gate's trigger: any
+    # `src/cli/commands/**` edit stales the marker, but the gate only
+    # BLOCKS when a new factory file is also added, so staleness without a
+    # new-file add is a no-op. Pre-create-only, like cdkd-parity, so a
+    # later edit on the same PR doesn't re-block.
+    include:
+      - "src/cli/commands/**"

--- a/tests/integration/local-ecs-service-connect/package.json
+++ b/tests/integration/local-ecs-service-connect/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-agentcore-from-cfn/package.json
+++ b/tests/integration/local-invoke-agentcore-from-cfn/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/package.json
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-agentcore-froms3/package.json
+++ b/tests/integration/local-invoke-agentcore-froms3/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-agentcore/package.json
+++ b/tests/integration/local-invoke-agentcore/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-assume-role/package.json
+++ b/tests/integration/local-invoke-assume-role/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-buildkit/package.json
+++ b/tests/integration/local-invoke-buildkit/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-container/package.json
+++ b/tests/integration/local-invoke-container/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-dotnet/package.json
+++ b/tests/integration/local-invoke-dotnet/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-from-cfn-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-java/package.json
+++ b/tests/integration/local-invoke-java/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-layers/package.json
+++ b/tests/integration/local-invoke-layers/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-provided/package.json
+++ b/tests/integration/local-invoke-provided/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-python/package.json
+++ b/tests/integration/local-invoke-python/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke-ruby/package.json
+++ b/tests/integration/local-invoke-ruby/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-invoke/package.json
+++ b/tests/integration/local-invoke/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-list/package.json
+++ b/tests/integration/local-list/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-run-task-awsvpc/package.json
+++ b/tests/integration/local-run-task-awsvpc/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-run-task-multi-container/package.json
+++ b/tests/integration/local-run-task-multi-container/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-run-task/package.json
+++ b/tests/integration/local-run-task/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-auth-jwks/package.json
+++ b/tests/integration/local-start-alb-auth-jwks/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-auth/package.json
+++ b/tests/integration/local-start-alb-auth/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-https/package.json
+++ b/tests/integration/local-start-alb-https/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-lambda/package.json
+++ b/tests/integration/local-start-alb-lambda/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-redirect/package.json
+++ b/tests/integration/local-start-alb-redirect/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-routing-conditions/package.json
+++ b/tests/integration/local-start-alb-routing-conditions/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-routing/package.json
+++ b/tests/integration/local-start-alb-routing/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-watch/package.json
+++ b/tests/integration/local-start-alb-watch/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-websocket/package.json
+++ b/tests/integration/local-start-alb-websocket/package.json
@@ -17,5 +17,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb-weighted/package.json
+++ b/tests/integration/local-start-alb-weighted/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-alb/package.json
+++ b/tests/integration/local-start-alb/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-all-stacks/package.json
+++ b/tests/integration/local-start-api-all-stacks/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-cognito-jwt/package.json
+++ b/tests/integration/local-start-api-cognito-jwt/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-container/package.json
+++ b/tests/integration/local-start-api-container/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-from-cfn-stack/package.json
+++ b/tests/integration/local-start-api-from-cfn-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-http-proxy/package.json
+++ b/tests/integration/local-start-api-http-proxy/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-rest-v1-non-proxy/package.json
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-watch/package.json
+++ b/tests/integration/local-start-api-watch/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api-websocket/package.json
+++ b/tests/integration/local-start-api-websocket/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-api/package.json
+++ b/tests/integration/local-start-api/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-cloudfront-edge/package.json
+++ b/tests/integration/local-start-cloudfront-edge/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/package.json
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-cloudfront-kvs-from-cfn-stack/package.json
+++ b/tests/integration/local-start-cloudfront-kvs-from-cfn-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/package.json
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-cloudfront-lambda-url/package.json
+++ b/tests/integration/local-start-cloudfront-lambda-url/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-cloudfront-s3-from-cfn-stack/package.json
+++ b/tests/integration/local-start-cloudfront-s3-from-cfn-stack/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-cloudfront/package.json
+++ b/tests/integration/local-start-cloudfront/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-service-image-override/package.json
+++ b/tests/integration/local-start-service-image-override/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-service-watch-fast/package.json
+++ b/tests/integration/local-start-service-watch-fast/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-service-watch-multi/package.json
+++ b/tests/integration/local-start-service-watch-multi/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-service-watch/package.json
+++ b/tests/integration/local-start-service-watch/package.json
@@ -16,5 +16,5 @@
     "constructs": "^10.0.0"
   },
   "type": "module",
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-start-service/package.json
+++ b/tests/integration/local-start-service/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }

--- a/tests/integration/local-studio/package.json
+++ b/tests/integration/local-studio/package.json
@@ -15,5 +15,6 @@
     "aws-cdk-lib": "^2.169.0",
     "constructs": "^10.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
 }


### PR DESCRIPTION
## Summary

Kills the recurring "`vp install` dirties the fixture `package.json`" trap at the source, standardizes new-fixture creation, and adds a gate so a new subcommand can't ship without its own integ fixture. Workflow-infra only — no `src/` / runtime change.

### 1. `/create-integ` skill

`.claude/skills/create-integ/SKILL.md` scaffolds a new `tests/integration/<name>/` fixture:
- `package.json` **pinned** with `packageManager: pnpm@11.5.1` so `vp install` is a verified no-op (it never re-dirties the file on the first run).
- `bin` / `lib` / `cdk.json` / `tsconfig` + a `verify.sh` harness (stop / cleanup-trap / fail / boot-and-curl / ready-line wait).
- You fill in the stack + assertions, the skill **RUNS it via `/run-integ`**, and sets the `create-integ` marker only on a clean green run.

### 2. `create-integ` gate

`create-integ-gate.sh` + the `create-integ` markgate gate block `gh pr create` when the diff **ADDS** a new `src/cli/commands/local-<verb>.ts` factory (`--diff-filter=A`) and the marker is stale. A new subcommand is brand-new behavior with no existing fixture, so it MUST ship its own — the one case where "needs a new fixture" is unambiguous. **EDITS** to existing commands (a new flag) never fire it (they reuse that command's fixture, which `integ-gate` already covers). Pre-create only, cwd-aware + fail-open, mirroring `cdkd-parity-gate`. Registered in `settings.json`; documented in `.claude/rules/hooks.md` + `.claude/CLAUDE.md`.

### 3. `packageManager` pin sweep

Every existing fixture was inconsistent (8× `11.4.0`, 4× `11.5.0`, 2× `11.5.1`, ~42 with none), so a fresh-worktree `vp install` re-added / version-bumped the field and dirtied the tree (the trap that bit ~3× recently). Normalizing all 56 to the version `vp install` writes (`11.5.1`) makes the install a repo-wide no-op.

## Why a skill + gate instead of a hook that strips the field

`vp install` adds `packageManager` whenever it's absent or version-mismatched (an `.npmrc manage-package-manager-versions=false` does NOT stop `vp install` — verified). The root-cause fix is to make the file already-correct, not to fight the field on every run. Committing the pin makes the install a no-op; the skill bakes it into new fixtures so the trap never returns; the gate ensures the skill is actually used for new commands.

## Test plan

- The gate hook was **exercised end-to-end** with synthesized PreToolUse payloads in a throwaway repo: blocks a new factory with a stale marker (exit 2, correct message), passes once the marker is set, ignores `gh pr merge`, and ignores an edit-to-an-existing-command even with a stale marker (proves it's the new-FILE signal that gates, not marker freshness).
- The pin is a verified `vp install` no-op (committing `pnpm@11.5.1` → `vp install` leaves the file byte-identical).
- One Docker integ (`local-invoke`) re-run green (0 orphans) to refresh the `integ` marker for the `tests/integration/**` touch — and it dogfoods the pin (its `vp install` no longer churns the fixture `package.json`).
- `vp run check` + `vp run build` + full unit suite green.
