### PR TITLE
fix(logger): only emit ANSI color when output is a TTY (NO_COLOR / FORCE_COLOR aware)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -44,6 +44,44 @@ function formatTimestamp(): string {
 }
 
 /**
+ * Resolve whether ANSI color should be emitted by default.
+ *
+ * Color is appropriate for an interactive terminal but is noise (literal
+ * `\x1b[31m...` escapes) when the output is a pipe — e.g. when `cdkl studio`
+ * spawns `cdkl invoke` / a serve command as a child and captures its output to
+ * render in the browser, where the raw escapes leak as visible text. So the
+ * default tracks the stdout TTY-ness, with the two standard env overrides:
+ *
+ * - `NO_COLOR` (any non-empty value) forces colors OFF (https://no-color.org).
+ * - `FORCE_COLOR` (non-empty, not `'0'` / `'false'`) forces colors ON, even
+ *   when not a TTY (the convention many CLIs honor for CI / log capture).
+ * - otherwise: on when `process.stdout.isTTY`.
+ *
+ * We gate on `process.stdout.isTTY` even though warn / error go to stderr via
+ * `console.error` / `console.warn`. In the case this fix targets — a piped
+ * child (e.g. studio) — NEITHER stdout nor stderr is a TTY, so gating on stdout
+ * still yields colorless output. Tracking stdout matches common CLI tooling and
+ * keeps a single, predictable signal; an explicit `useColors` argument (passed
+ * by child loggers) always overrides this default.
+ */
+export function resolveDefaultUseColors(): boolean {
+  const noColor = process.env['NO_COLOR'];
+  if (noColor !== undefined && noColor !== '') {
+    return false;
+  }
+  const forceColor = process.env['FORCE_COLOR'];
+  if (
+    forceColor !== undefined &&
+    forceColor !== '' &&
+    forceColor !== '0' &&
+    forceColor !== 'false'
+  ) {
+    return true;
+  }
+  return !!process.stdout.isTTY;
+}
+
+/**
  * Console logger implementation
  *
  * Supports two output modes:
@@ -54,7 +92,7 @@ export class ConsoleLogger implements Logger {
   private level: LogLevel;
   private useColors: boolean;
 
-  constructor(level: LogLevel = 'info', useColors: boolean = true) {
+  constructor(level: LogLevel = 'info', useColors: boolean = resolveDefaultUseColors()) {
     this.level = level;
     this.useColors = useColors;
   }

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect, afterEach, vi } from 'vite-plus/test';
-import { resolveConfiguredLogLevel, ConsoleLogger } from '../../../src/utils/logger.js';
+import {
+  resolveConfiguredLogLevel,
+  resolveDefaultUseColors,
+  ConsoleLogger,
+} from '../../../src/utils/logger.js';
+
+/**
+ * Set `process.stdout.isTTY` for the duration of a test, returning a restore fn.
+ * `isTTY` is a plain own property on the stream, so redefining it is enough.
+ */
+function withStdoutTTY(value: boolean | undefined): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value,
+  });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', descriptor);
+    } else {
+      delete (process.stdout as { isTTY?: boolean }).isTTY;
+    }
+  };
+}
 
 describe('resolveConfiguredLogLevel', () => {
   const prev = process.env['CDKL_LOG_LEVEL'];
@@ -88,6 +111,162 @@ describe('ConsoleLogger CDKL_LOG_STREAM=stdout unification (issue #403)', () => 
     } finally {
       infoSpy.mockRestore();
       warnSpy.mockRestore();
+    }
+  });
+});
+
+const ANSI_RED = '\x1b[31m';
+
+describe('resolveDefaultUseColors (TTY-aware default, issue #2)', () => {
+  const prevNoColor = process.env['NO_COLOR'];
+  const prevForceColor = process.env['FORCE_COLOR'];
+  let restoreTTY: (() => void) | undefined;
+
+  afterEach(() => {
+    if (prevNoColor === undefined) delete process.env['NO_COLOR'];
+    else process.env['NO_COLOR'] = prevNoColor;
+    if (prevForceColor === undefined) delete process.env['FORCE_COLOR'];
+    else process.env['FORCE_COLOR'] = prevForceColor;
+    restoreTTY?.();
+    restoreTTY = undefined;
+  });
+
+  it('NO_COLOR disables colors even on a TTY', () => {
+    delete process.env['FORCE_COLOR'];
+    process.env['NO_COLOR'] = '1';
+    restoreTTY = withStdoutTTY(true);
+    expect(resolveDefaultUseColors()).toBe(false);
+  });
+
+  it('an empty NO_COLOR does NOT disable colors (must be non-empty)', () => {
+    delete process.env['FORCE_COLOR'];
+    process.env['NO_COLOR'] = '';
+    restoreTTY = withStdoutTTY(true);
+    expect(resolveDefaultUseColors()).toBe(true);
+  });
+
+  it('FORCE_COLOR enables colors even when stdout is not a TTY', () => {
+    delete process.env['NO_COLOR'];
+    process.env['FORCE_COLOR'] = '1';
+    restoreTTY = withStdoutTTY(false);
+    expect(resolveDefaultUseColors()).toBe(true);
+  });
+
+  it.each(['0', 'false'])('FORCE_COLOR=%s is treated as off', (val) => {
+    delete process.env['NO_COLOR'];
+    process.env['FORCE_COLOR'] = val;
+    restoreTTY = withStdoutTTY(false);
+    expect(resolveDefaultUseColors()).toBe(false);
+  });
+
+  it('NO_COLOR wins over FORCE_COLOR', () => {
+    process.env['NO_COLOR'] = '1';
+    process.env['FORCE_COLOR'] = '1';
+    restoreTTY = withStdoutTTY(true);
+    expect(resolveDefaultUseColors()).toBe(false);
+  });
+
+  it('no env: follows stdout.isTTY (true)', () => {
+    delete process.env['NO_COLOR'];
+    delete process.env['FORCE_COLOR'];
+    restoreTTY = withStdoutTTY(true);
+    expect(resolveDefaultUseColors()).toBe(true);
+  });
+
+  it('no env: follows stdout.isTTY (false)', () => {
+    delete process.env['NO_COLOR'];
+    delete process.env['FORCE_COLOR'];
+    restoreTTY = withStdoutTTY(false);
+    expect(resolveDefaultUseColors()).toBe(false);
+  });
+});
+
+describe('ConsoleLogger color gating by default (issue #2)', () => {
+  const prevNoColor = process.env['NO_COLOR'];
+  const prevForceColor = process.env['FORCE_COLOR'];
+  const prevLogStream = process.env['CDKL_LOG_STREAM'];
+  let restoreTTY: (() => void) | undefined;
+
+  afterEach(() => {
+    if (prevNoColor === undefined) delete process.env['NO_COLOR'];
+    else process.env['NO_COLOR'] = prevNoColor;
+    if (prevForceColor === undefined) delete process.env['FORCE_COLOR'];
+    else process.env['FORCE_COLOR'] = prevForceColor;
+    if (prevLogStream === undefined) delete process.env['CDKL_LOG_STREAM'];
+    else process.env['CDKL_LOG_STREAM'] = prevLogStream;
+    restoreTTY?.();
+    restoreTTY = undefined;
+  });
+
+  it('non-TTY, no env: the formatted error line carries NO ANSI', () => {
+    // The studio-child case: stdout is a pipe. The default must be colorless.
+    delete process.env['NO_COLOR'];
+    delete process.env['FORCE_COLOR'];
+    delete process.env['CDKL_LOG_STREAM'];
+    restoreTTY = withStdoutTTY(false);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // Construct WITHOUT an explicit useColors so the new default applies.
+      const logger = new ConsoleLogger('info');
+      logger.error('boom');
+      const line = errSpy.mock.calls[0]?.[0] as string;
+      expect(line).toBe('boom');
+      expect(line).not.toContain(ANSI_RED);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('TTY, no env: the formatted error line carries ANSI red', () => {
+    delete process.env['NO_COLOR'];
+    delete process.env['FORCE_COLOR'];
+    delete process.env['CDKL_LOG_STREAM'];
+    restoreTTY = withStdoutTTY(true);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const logger = new ConsoleLogger('info');
+      logger.error('boom');
+      const line = errSpy.mock.calls[0]?.[0] as string;
+      expect(line).toContain(ANSI_RED);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('composes with CDKL_LOG_STREAM=stdout: piped non-TTY child stays colorless', () => {
+    // A studio serve child sets CDKL_LOG_STREAM=stdout (issue #403) AND has a
+    // piped, non-TTY stdout. The two are orthogonal: routing to stdout must not
+    // re-introduce color.
+    delete process.env['NO_COLOR'];
+    delete process.env['FORCE_COLOR'];
+    process.env['CDKL_LOG_STREAM'] = 'stdout';
+    restoreTTY = withStdoutTTY(false);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const logger = new ConsoleLogger('info');
+      logger.error('boom');
+      const line = logSpy.mock.calls[0]?.[0] as string;
+      expect(line).toBe('boom');
+      expect(line).not.toContain(ANSI_RED);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('honors an explicit useColors override regardless of TTY default', () => {
+    // Child loggers pass useColors explicitly; the explicit value wins.
+    delete process.env['NO_COLOR'];
+    delete process.env['FORCE_COLOR'];
+    delete process.env['CDKL_LOG_STREAM'];
+    restoreTTY = withStdoutTTY(false);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const logger = new ConsoleLogger('info', true);
+      logger.error('boom');
+      const line = errSpy.mock.calls[0]?.[0] as string;
+      expect(line).toContain(ANSI_RED);
+    } finally {
+      errSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

`ConsoleLogger` hard-coded `useColors = true` and `getLogger()` never checked whether the output stream was a TTY, so error / warn lines were always wrapped in raw ANSI escapes (`\x1b[31m...\x1b[0m`) — even when stdout / stderr were pipes. When `cdkl studio` spawns `cdkl invoke` / a serve command as a child and renders its captured output in the browser, the browser does not interpret ANSI, so the literal `[31m` / `[0m` leaked as visible text (and studio's own CSS colored the line red on top — double-colored garbage).

## What changed

- New `resolveDefaultUseColors()` (`src/utils/logger.ts`): colors default to `process.stdout.isTTY`, with the two standard overrides — `NO_COLOR` (any non-empty value) forces off; `FORCE_COLOR` (non-empty, not `0`/`false`) forces on.
- The `ConsoleLogger` constructor default now uses it, so `getLogger()` is TTY-aware. The explicit `useColors` argument still overrides (child loggers pass it through unchanged).
- Composes with the existing `CDKL_LOG_STREAM=stdout` studio branch: a piped non-TTY child stays colorless regardless of stream routing.

## Test plan

- **unit** (`tests/unit/utils/logger.test.ts`): `NO_COLOR` off even on a (mocked) TTY; `FORCE_COLOR` on even when `isTTY` is false; non-TTY default emits no `\x1b[31m`; TTY default does; explicit-override path; `CDKL_LOG_STREAM=stdout` composition.
- **live-test** (built `dist/cli.js`): a piped (non-TTY) error run emits 0 logger ANSI escapes; `FORCE_COLOR=1` emits the red escape — confirming the studio `[31m` leak is fixed while interactive color still works.
- **integ** (`local-invoke`): full Lambda invoke against real Docker (the logger handles all synth / orchestration output) passes, confirming no general-output regression.
