### PR TITLE
fix(studio): make the request-composer Send button green

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -159,7 +159,9 @@ const STUDIO_CSS = `
   .req-composer select:focus, .req-composer input:focus, .req-composer textarea:focus {
     outline: none; border-color: #4ec97a; }
   .req-composer .req-send { display: flex; align-items: center; gap: 10px; }
-  .req-composer .req-send button { margin-top: 0; padding: 4px 16px; }
+  .req-composer .req-send button { margin-top: 0; padding: 4px 16px; background: #2a7d46; color: #fff; }
+  .req-composer .req-send button:hover { background: #339152; }
+  .req-composer .req-send button:disabled { background: #333; color: #888; }
   .req-composer .req-status { margin-top: 8px; font: 12px ui-monospace, Menlo, monospace; }
   .req-composer .req-result pre { background: #0e0e0e; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }

--- a/tests/unit/local/studio-ui-send-green.test.ts
+++ b/tests/unit/local/studio-ui-send-green.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the request-composer renderer so the test can mount a real Send
+// button (issue #4 — the captured api/alb + direct ecs host-port composer both
+// use `.req-composer`, so the one rule covers all "send" buttons).
+const EXPOSE = `
+window.__t = {
+  renderRequestComposer: renderRequestComposer,
+};
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+describe('request-composer Send button styling (issue #4)', () => {
+  it('renders the Send button inside .req-send and styles it green via the stylesheet', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const sec = h.window.__t.renderRequestComposer('S/Api', 'http://localhost:9999', true);
+
+      // The Send button is the captured-request submit, inside `.req-send`.
+      const sendBtn = sec.querySelector('.req-send button');
+      expect(sendBtn).not.toBeNull();
+      expect(sendBtn.textContent).toBe('Send');
+
+      // jsdom does not resolve the full CSS cascade into computed style, so the
+      // load-bearing assertion is that the embedded stylesheet now carries the
+      // green rule for the `.req-composer .req-send button` selector (the same
+      // #2a7d46 token the `.composer button` primary submit uses). Without this
+      // rule the button falls back to the UA-default white.
+      const styleText = Array.from(h.document.querySelectorAll('style'))
+        .map((s: any) => s.textContent || '')
+        .join('\n');
+      expect(styleText).toMatch(/\.req-composer \.req-send button \{[^}]*background: #2a7d46[^}]*\}/);
+      expect(styleText).toMatch(/\.req-composer \.req-send button \{[^}]*color: #fff[^}]*\}/);
+      // Hover + disabled states mirror `.composer button` so the green button is
+      // consistent across all states.
+      expect(styleText).toMatch(/\.req-composer \.req-send button:hover \{[^}]*background: #339152[^}]*\}/);
+      expect(styleText).toMatch(/\.req-composer \.req-send button:disabled \{[^}]*background: #333[^}]*color: #888[^}]*\}/);
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

In `cdkl studio`, the request-composer "Send" button rendered with the browser-default **white** styling, while every other primary submit button (Invoke composer / Start / Re-invoke) is green. Root cause: the green `.composer button { background: #2a7d46; color: #fff }` rule is scoped to `.composer`, but the request composer's root element is `.section.req-composer` (not `.composer`) and its Send button has no class — the only matching rule (`.req-composer .req-send button`) set sizing but no background.

## What changed

Extend `.req-composer .req-send button` to set the same green tokens `.composer button` uses (`background: #2a7d46; color: #fff`), plus matching `:hover` (`#339152`) and `:disabled` (`#333` / `#888`). This covers BOTH the captured api/alb request composer and the direct ecs host-port composer, since both mount `.req-composer`.

Scope: only the white request-composer Send button. The WebSocket-console Send / Connect buttons already have color (`.ws-row button`, a darker green) and are intentionally left as-is.

## Test plan

- **unit** (`tests/unit/local/studio-ui-send-green.test.ts`): renders the request composer via the jsdom harness, asserts the Send button exists inside `.req-send`, and asserts the rendered `<style>` carries the green `background: #2a7d46` / `color: #fff` rule plus the hover / disabled rules.
- **integ** (`local-studio`): the full studio integ — which boots the server and exercises the request composer / UI — passes, confirming no regression in the embedded UI string.
