### PR TITLE
feat(studio): fold per-stack construct-path prefix in the targets pane

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -659,6 +659,19 @@ compute-locally category for Lambda + API Gateway).
   list does not push the APIs below the fold; a running serve auto-expands
   its group so its `:port` stays visible), zebra-stripes the rows, and has
   a full-text filter box (`applyTargetFilter`) beside the TARGETS heading.
+  Within a kind group, each stack's shared `<stack>/` construct-path prefix
+  is folded into a `.stack-sub` header (PER STACK — `stackSections` splits a
+  group's already-stack-sorted entries on a stack-key change, so rows from
+  different stacks never share a fold) and the row shows only the
+  distinguishing tail; this keeps a deep construct path legible in a narrow
+  pane where the shared prefix used to eat the width. The tail is a
+  horizontal-scroll container (a two-finger trackpad swipe reveals the rest
+  and scrolls back; `overscroll-behavior-x: contain` stops the swipe from
+  triggering browser back-navigation, a right-edge mask is the "more ->"
+  cue) instead of a hard ellipsis. The full id stays on the row `title`
+  (hover tooltip) + `data-tid` (the filter key). Zebra is a JS-applied
+  `.alt` class (continuous across sections) rather than `:nth-child`, which
+  the interleaved sub-headers would offset.
   The Session bar applies on change (no Save button — `applyConfig` PATCHes
   `/api/config` immediately on a checkbox toggle / input change, issue
   #301); Lambdas + AgentCore runtimes get an

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -102,11 +102,34 @@ const STUDIO_CSS = `
   /* Zebra: alternate rows get a clearly lighter background than the base
      (#1a1a1a) so adjacent target boxes read as distinct — a 1-step shade was
      imperceptible. The kind label (#8f8f8f) still reads on both shades. */
-  .group-body .target:nth-child(2n) { background: #242424; }
+  /* Zebra is driven by a JS-applied .alt class (not :nth-child) because the
+     stack sub-headers interleaved among the rows would otherwise throw the
+     positional count off. */
+  .group-body .target.alt { background: #242424; }
   .target.runnable { cursor: pointer; }
   .target.runnable:hover { background: #292929; }
-  .target.sel, .group-body .target.sel:nth-child(2n) { background: #2a3550; }
-  .target .name { color: #ddd; flex: 1; overflow: hidden; text-overflow: ellipsis; }
+  .target.sel, .group-body .target.sel.alt { background: #2a3550; }
+  /* The construct path. The common stack prefix is folded into the .stack-sub
+     header above, so the row shows only the distinguishing tail. The tail can
+     still overflow a narrow pane, so it is a horizontal-scroll container (a
+     two-finger trackpad swipe reveals the rest and scrolls back to the head)
+     rather than a hard ellipsis: overscroll-behavior-x stops the swipe from
+     triggering the browser's back-navigation, and the right-edge mask is the
+     "there is more ->" cue that replaces the hidden scrollbar. */
+  .target .name {
+    color: #ddd; flex: 1; min-width: 0;
+    white-space: nowrap; overflow-x: auto; overflow-y: hidden;
+    overscroll-behavior-x: contain; scrollbar-width: none;
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 14px), transparent);
+            mask-image: linear-gradient(to right, #000 calc(100% - 14px), transparent);
+  }
+  .target .name::-webkit-scrollbar { display: none; }
+  /* The folded common stack prefix shared by the rows beneath it. */
+  .stack-sub {
+    padding: 4px 12px 2px; color: #6f6f6f; font-size: 10px;
+    font-family: ui-monospace, Menlo, monospace;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
   .target .kind { color: #8f8f8f; font-size: 11px; }
   .target .invoke-btn {
     padding: 2px 10px; font: 11px ui-monospace, Menlo, monospace; font-weight: 700;
@@ -624,10 +647,17 @@ const STUDIO_SCRIPT = `
       const title = grp.querySelector('.group-title');
       const body = grp.querySelector('.group-body');
       let matches = 0;
-      body.querySelectorAll('.target').forEach(function (row) {
-        const hit = q === '' || (row.getAttribute('data-tid') || '').includes(q);
-        row.style.display = hit ? '' : 'none';
-        if (hit) matches += 1;
+      // Walk per-stack sections so a section whose rows all filter out (and its
+      // sub-header) is hidden too, not left as an orphan header.
+      body.querySelectorAll('.stack-section').forEach(function (sec) {
+        let secMatches = 0;
+        sec.querySelectorAll('.target').forEach(function (row) {
+          const hit = q === '' || (row.getAttribute('data-tid') || '').includes(q);
+          row.style.display = hit ? '' : 'none';
+          if (hit) secMatches += 1;
+        });
+        sec.style.display = q === '' || secMatches ? '' : 'none';
+        matches += secMatches;
       });
       if (q === '') {
         grp.style.display = '';
@@ -639,6 +669,45 @@ const STUDIO_SCRIPT = `
         title.classList.toggle('open', matches > 0);
       }
     });
+  }
+
+  // The stack a target id belongs to: the first '/'-delimited segment (the
+  // synthesized construct path is '<stack>/<construct>/...'). An id with no
+  // '/' (the '<stack>:<logicalId>' fallback for a resource with no cdk path)
+  // has no foldable construct path, so its stack key is the part before ':'.
+  function targetStackKey(id) {
+    const s = String(id);
+    const slash = s.indexOf('/');
+    if (slash !== -1) return s.slice(0, slash);
+    const colon = s.indexOf(':');
+    return colon !== -1 ? s.slice(0, colon) : s;
+  }
+
+  // The prefix folded into a stack sub-header: the leading '<stack>/' segment
+  // when the id carries a construct path, else '' (the colon-fallback form has
+  // nothing to fold). Folding is PER STACK only, so rows from different stacks
+  // never share a fold.
+  function stackFoldPrefix(id) {
+    const s = String(id);
+    const slash = s.indexOf('/');
+    return slash === -1 ? '' : s.slice(0, slash + 1);
+  }
+
+  // Partition a group's entries into contiguous per-stack sections. The
+  // entries arrive already sorted by stack then logical id (the target lister),
+  // so a section break is just a change of stack key.
+  function stackSections(entries) {
+    const sections = [];
+    let cur = null;
+    for (const entry of entries) {
+      const key = targetStackKey(entry.id);
+      if (!cur || cur.key !== key) {
+        cur = { key: key, prefix: stackFoldPrefix(entry.id), entries: [] };
+        sections.push(cur);
+      }
+      cur.entries.push(entry);
+    }
+    return sections;
   }
 
   async function loadTargets() {
@@ -662,45 +731,67 @@ const STUDIO_SCRIPT = `
         title.onclick = () => toggleGroup(title, body);
         grp.appendChild(title);
         grp.appendChild(body);
-        for (const entry of group.entries) {
-          total += 1;
-          // Lambda + AgentCore targets are single-shot invokes; api / alb / ecs
-          // are long-running serves. Other kinds list but are not yet runnable.
-          // Within ecs, only services are servable (task defs are run-task).
-          const isServe = SERVE_KINDS.includes(group.kind) && (group.kind !== 'ecs' || entry.servable === true);
-          const isInvoke = INVOKE_KINDS.includes(group.kind);
-          const runnable = isInvoke || isServe;
-          const t = el('div', runnable ? 'target runnable' : 'target');
-          t.setAttribute('data-tid', String(entry.id).toLowerCase()); // for the filter
-          const name = el('span', 'name', entry.id);
-          name.title = entry.id; // full path on hover even when truncated
-          t.appendChild(name);
-          t.appendChild(el('span', 'kind', '(' + (KIND_LABEL[group.kind] || group.kind) + ')'));
-          if (isInvoke) {
-            const btn = el('button', 'invoke-btn', 'Invoke');
-            btn.onclick = (e) => { e.stopPropagation(); selectTarget(entry.id, group.kind); };
-            t.appendChild(btn);
-            t.onclick = () => selectTarget(entry.id, group.kind);
-            targetEls.set(entry.id, t);
-          } else if (isServe) {
-            // A serve target: a running-state dot + a Start/Stop button
-            // slot, both refreshed by updateServeRow on serve events.
-            const dot = el('span', 'run-dot');
-            const btnSlot = el('span', 'btn-slot');
-            t.appendChild(dot);
-            t.appendChild(btnSlot);
-            t.onclick = () => selectTarget(entry.id, group.kind);
-            targetEls.set(entry.id, t);
-            serveMeta.set(entry.id, {
-              dot,
-              btnSlot,
-              kind: group.kind,
-              pinned: entry.pinned === true,
-              backingPinnedServices: entry.backingPinnedServices || [],
-            });
-            updateServeRow(entry.id);
+        // Within a kind group, fold each stack's shared '<stack>/' prefix into
+        // a sub-header and show only the distinguishing tail per row. Zebra is
+        // a running .alt class (continuous across sections) since the sub-header
+        // rows would throw a positional :nth-child count off.
+        let rowIdx = 0;
+        for (const section of stackSections(group.entries)) {
+          const sec = el('div', 'stack-section');
+          if (section.prefix) {
+            const sub = el('div', 'stack-sub', section.prefix);
+            sub.title = section.prefix;
+            sec.appendChild(sub);
           }
-          body.appendChild(t);
+          for (const entry of section.entries) {
+            total += 1;
+            // Lambda + AgentCore targets are single-shot invokes; api / alb / ecs
+            // are long-running serves. Other kinds list but are not yet runnable.
+            // Within ecs, only services are servable (task defs are run-task).
+            const isServe = SERVE_KINDS.includes(group.kind) && (group.kind !== 'ecs' || entry.servable === true);
+            const isInvoke = INVOKE_KINDS.includes(group.kind);
+            const runnable = isInvoke || isServe;
+            const t = el('div', runnable ? 'target runnable' : 'target');
+            if (rowIdx % 2 === 1) t.classList.add('alt');
+            rowIdx += 1;
+            t.setAttribute('data-tid', String(entry.id).toLowerCase()); // for the filter (full id)
+            // The folded tail; fall back to the full id if the prefix somehow
+            // does not match (defensive — sorting guarantees it does).
+            const full = String(entry.id);
+            const tail = (section.prefix && full.indexOf(section.prefix) === 0)
+              ? full.slice(section.prefix.length) || full
+              : full;
+            const name = el('span', 'name', tail);
+            name.title = entry.id; // full path on hover
+            t.appendChild(name);
+            t.appendChild(el('span', 'kind', '(' + (KIND_LABEL[group.kind] || group.kind) + ')'));
+            if (isInvoke) {
+              const btn = el('button', 'invoke-btn', 'Invoke');
+              btn.onclick = (e) => { e.stopPropagation(); selectTarget(entry.id, group.kind); };
+              t.appendChild(btn);
+              t.onclick = () => selectTarget(entry.id, group.kind);
+              targetEls.set(entry.id, t);
+            } else if (isServe) {
+              // A serve target: a running-state dot + a Start/Stop button
+              // slot, both refreshed by updateServeRow on serve events.
+              const dot = el('span', 'run-dot');
+              const btnSlot = el('span', 'btn-slot');
+              t.appendChild(dot);
+              t.appendChild(btnSlot);
+              t.onclick = () => selectTarget(entry.id, group.kind);
+              targetEls.set(entry.id, t);
+              serveMeta.set(entry.id, {
+                dot,
+                btnSlot,
+                kind: group.kind,
+                pinned: entry.pinned === true,
+                backingPinnedServices: entry.backingPinnedServices || [],
+              });
+              updateServeRow(entry.id);
+            }
+            sec.appendChild(t);
+          }
+          body.appendChild(sec);
         }
         pane.appendChild(grp);
       }

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -312,14 +312,26 @@ if ! grep -qF "url = '/api/reinvoke'" "${BODY_FILE}" \
   echo "FAIL: GET / did not include the re-invoke wiring (issue #284)"
   exit 1
 fi
-# Visual UX fixes: zebra shade (issue #333), wider session inputs (issue #339),
-# LOGS Clear button (issue #338).
-if ! grep -qF '.group-body .target:nth-child(2n) { background: #242424; }' "${BODY_FILE}" \
+# Visual UX fixes: zebra shade (issue #333 — now a JS-applied .alt class, not
+# :nth-child, since the per-stack sub-headers interleave among the rows), wider
+# session inputs (issue #339), LOGS Clear button (issue #338).
+if ! grep -qF '.group-body .target.alt { background: #242424; }' "${BODY_FILE}" \
   || ! grep -qF 'min-width: 240px;' "${BODY_FILE}" \
   || ! grep -qF "el('button', 'log-clear', 'Clear')" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the visual UX fixes (issues #333 / #338 / #339)"
   exit 1
 fi
+# Per-stack construct-path folding in the targets pane: each stack's '<stack>/'
+# prefix folds into a .stack-sub header and the row shows only the tail, with
+# the tail a horizontal-scroll container (overscroll-behavior-x stops the swipe
+# from triggering browser back-navigation) instead of a hard ellipsis.
+if ! grep -qF 'function stackSections' "${BODY_FILE}" \
+  || ! grep -qF '.stack-sub {' "${BODY_FILE}" \
+  || ! grep -qF 'overscroll-behavior-x: contain' "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the per-stack construct-path folding"
+  exit 1
+fi
+echo "    OK: targets pane folds the per-stack construct-path prefix + scrollable path tail"
 # Composer send-flow (issues #334 / #335 / #336): surgical serve-log update,
 # timeline deselect, and the New request back affordance.
 if ! grep -qF 'serveLogPre.textContent = arr.join(' "${BODY_FILE}" \

--- a/tests/unit/local/studio-ui-target-fold.test.ts
+++ b/tests/unit/local/studio-ui-target-fold.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { renderStudioHtml } from '../../../src/local/studio-ui.js';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+/**
+ * Per-stack construct-path folding in the targets pane. Target ids are the
+ * synthesized construct path (`<stack>/<construct>/...`); in a narrow pane the
+ * shared `<stack>/` prefix ate the width and a hard right-ellipsis cut off the
+ * distinguishing tail. The pane now folds each stack's `<stack>/` prefix into a
+ * `.stack-sub` header (PER STACK, so different stacks never share a fold) and
+ * shows only the tail per row, with the tail as a horizontal-scroll container
+ * (a two-finger swipe reveals the rest) instead of an ellipsis.
+ *
+ * Drives the real embedded `loadTargets` in jsdom via a resolving `fetch`, then
+ * asserts the rendered DOM. `loadTargets` / `applyTargetFilter` are stashed on
+ * `window` by a capture epilogue (the harness's fixed return object exposes
+ * only the composer builders).
+ */
+
+const EPILOGUE =
+  'window.__loadTargets = loadTargets; window.__applyTargetFilter = applyTargetFilter;';
+
+function targetsFetch(groups: unknown) {
+  return (url: string) => {
+    if (url === '/api/targets') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ groups, dockerfiles: [] }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  };
+}
+
+const LAMBDA_GROUP = {
+  kind: 'lambda',
+  title: 'Lambda Functions',
+  // Already sorted by stack then logical id (as the target lister emits).
+  entries: [
+    { id: 'dev-AiApi/GptLambda/GptStream', qualifiedId: 'dev-AiApi:GptStream' },
+    { id: 'dev-AiApi/SttLambda/EikenFn/Default', qualifiedId: 'dev-AiApi:EikenFn' },
+    { id: 'dev-AiApi/SttLambda/WordFn/Default', qualifiedId: 'dev-AiApi:WordFn' },
+    { id: 'prod-AiApi/GptLambda/GptStream', qualifiedId: 'prod-AiApi:GptStream' },
+  ],
+};
+
+describe('targets pane per-stack path folding', () => {
+  it('folds each stack prefix into a sub-header and shows the tail per row', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch([LAMBDA_GROUP]);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+
+      const subs = Array.from(h.document.querySelectorAll('.stack-sub')).map((n) => n.textContent);
+      // One sub-header per stack, carrying the folded '<stack>/' prefix.
+      expect(subs).toEqual(['dev-AiApi/', 'prod-AiApi/']);
+
+      const names = Array.from(h.document.querySelectorAll('.target .name')).map((n) => n.textContent);
+      // Rows show only the tail after their stack prefix.
+      expect(names).toEqual([
+        'GptLambda/GptStream',
+        'SttLambda/EikenFn/Default',
+        'SttLambda/WordFn/Default',
+        'GptLambda/GptStream',
+      ]);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('keeps the full id on the row title + data-tid (folding is display-only)', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch([LAMBDA_GROUP]);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+
+      const first = h.document.querySelector('.target') as HTMLElement;
+      const name = first.querySelector('.name') as HTMLElement;
+      // Hover tooltip is the full path even though the row text is the tail.
+      expect(name.getAttribute('title')).toBe('dev-AiApi/GptLambda/GptStream');
+      // The filter key stays the full lowercased id.
+      expect(first.getAttribute('data-tid')).toBe('dev-aiapi/gptlambda/gptstream');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('zebra-stripes alternate rows continuously across stack sections', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch([LAMBDA_GROUP]);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+
+      const rows = Array.from(h.document.querySelectorAll('.target'));
+      // Continuous .alt across the section boundary: rows 0,2 plain; 1,3 alt.
+      expect(rows.map((r) => r.classList.contains('alt'))).toEqual([false, true, false, true]);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('does not fold a colon-fallback id with no construct path', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      const group = {
+        kind: 'lambda',
+        title: 'Lambda Functions',
+        entries: [{ id: 'dev-AiApi:BareLogicalId', qualifiedId: 'dev-AiApi:BareLogicalId' }],
+      };
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch([group]);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+
+      // No '/' => nothing to fold => no sub-header, full id shown.
+      expect(h.document.querySelector('.stack-sub')).toBeNull();
+      const name = h.document.querySelector('.target .name') as HTMLElement;
+      expect(name.textContent).toBe('dev-AiApi:BareLogicalId');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('hides a stack section whose rows all filter out, keeps the matching one', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch([LAMBDA_GROUP]);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+      (h.window as unknown as { __applyTargetFilter: (q: string) => void }).__applyTargetFilter('eiken');
+
+      const sections = Array.from(h.document.querySelectorAll('.stack-section'));
+      // dev-AiApi section matches (EikenFn), prod-AiApi section is hidden.
+      expect((sections[0] as HTMLElement).style.display).toBe('');
+      expect((sections[1] as HTMLElement).style.display).toBe('none');
+    } finally {
+      h.close();
+    }
+  });
+});
+
+describe('targets pane construct-path CSS', () => {
+  it('makes the path a horizontal-scroll container with overscroll containment', () => {
+    const html = renderStudioHtml('TestStack', 'cdkl');
+    expect(html).toContain('overscroll-behavior-x: contain');
+    expect(html).toContain('.target .name::-webkit-scrollbar { display: none; }');
+    expect(html).toContain('.stack-sub {');
+  });
+});

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -140,10 +140,11 @@ describe('renderStudioHtml', () => {
     // Collapsible groups (collapsed by default) + the toggle.
     expect(html).toContain('function toggleGroup');
     expect(html).toContain("el('div', 'group-body collapsed')");
-    // Zebra striping via the group-body nth-child rule, with a clearly
-    // distinct shade (issue #333 — the previous #1b1b1b was 1 step off the
-    // #1a1a1a base and imperceptible).
-    expect(html).toContain('.group-body .target:nth-child(2n) { background: #242424; }');
+    // Zebra striping via the JS-applied .alt class (no longer :nth-child, since
+    // the interleaved stack sub-headers would offset a positional count), with
+    // a clearly distinct shade (issue #333 — the previous #1b1b1b was 1 step off
+    // the #1a1a1a base and imperceptible).
+    expect(html).toContain('.group-body .target.alt { background: #242424; }');
   });
 
   it('widens the Session-bar inputs so the placeholder is not truncated (issue #339)', () => {


### PR DESCRIPTION
## Summary

In `cdkl studio`, the targets pane (left) lists each target by its synthesized
construct path (`<stack>/<construct>/...`). When siblings share a long parent
prefix, a narrow pane showed only the head and a hard right-ellipsis cut off
the **distinguishing tail** — so e.g. `SttLambda/EikenFn/Default`,
`SttLambda/SentenceFn/Default`, `SttLambda/WordFn/Default` were
indistinguishable without dragging the pane wider.

This folds the shared **per-stack** `<stack>/` prefix into a `.stack-sub`
sub-header and shows only the tail per row, and makes the tail
horizontally scrollable instead of hard-ellipsised.

### Before / after (real app, narrow pane)

```
# before (ellipsis cuts the end — the distinguishing part):
dev-goto-tokyo-AiApi/SttLamb...
dev-goto-tokyo-AiApi/SttLamb...   <- Eiken / Sentence / Word all identical
dev-goto-tokyo-AiApi/SttLamb...

# after (per-stack fold; tail visible):
-- dev-goto-tokyo-AiApi/
     SttLambda/EikenFn/Default
     SttLambda/SentenceFn/Default
     SttLambda/WordFn/Default
```

### Details

- Folding is **per stack** (`stackSections` splits a group's already
  stack-sorted entries on a stack-key change), so rows from different stacks
  never share a fold. An id with no construct path (the `<stack>:<logicalId>`
  fallback) is shown in full, unfolded.
- The tail is a horizontal-scroll container: a two-finger trackpad swipe
  reveals the rest and scrolls back to the head. `overscroll-behavior-x:
  contain` stops the swipe from triggering the browser's back-navigation; a
  right-edge mask is the "more ->" cue that replaces the hidden scrollbar.
- Folding is **display-only**: the full id stays on the row `title` (hover
  tooltip) and `data-tid` (the filter key is unchanged).
- Zebra striping moves from a `:nth-child` rule to a JS-applied `.alt` class
  (continuous across sections), which the interleaved sub-headers would
  otherwise offset.

## Test plan

- Unit (`tests/unit/local/studio-ui-target-fold.test.ts`, new): drives the
  real embedded `loadTargets` in jsdom and asserts per-stack sub-headers,
  folded tails, full-id `title` + `data-tid` preservation, continuous zebra,
  the colon-fallback (unfolded) case, and that the filter hides a section whose
  rows all filter out. Plus a CSS assertion for the horizontal-scroll path.
- Integ (`tests/integration/local-studio`): asserts the served UI HTML carries
  the folding (`stackSections` / `.stack-sub` / `overscroll-behavior-x`) and
  the updated zebra CSS. Ran green (Docker, 0 orphans).
- Verified the rendered output against a real multi-stack CDK app's target ids.
