### PR TITLE
fix(invoke): preserve the executable bit when extracting a ZIP-FILE Lambda asset

### DIFF
--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -1,4 +1,12 @@
-import { existsSync, statSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  statSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  chmodSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, normalize, resolve, sep } from 'node:path';
 import { unzipSync } from 'fflate';
@@ -811,6 +819,17 @@ export function materializeAssetCodeDir(codePath: string): MaterializedAssetCode
     const dest = resolveSafeZipEntryPath(dir, name);
     mkdirSync(dirname(dest), { recursive: true });
     writeFileSync(dest, content);
+    // Restore the executable bit. The deployed Lambda package preserves the
+    // zip's unix file modes, and a `provided.*` custom runtime's entrypoint
+    // (`bootstrap`) MUST be executable or RIE fails the invoke with
+    // `Runtime.InvalidEntrypoint` / `fork/exec ...: permission denied`. fflate's
+    // `unzipSync` returns only file CONTENTS (no per-entry unix mode), so we
+    // cannot recover the exact stored mode; granting `0o755` to every extracted
+    // file makes the bootstrap executable while keeping all files readable —
+    // safe for the user's own code in an ephemeral local container. (A
+    // directory asset bypasses this path entirely: CDK already staged it with
+    // correct modes and we bind-mount it directly.)
+    chmodSync(dest, 0o755);
   }
   return { dir, tmpDir: dir };
 }

--- a/tests/integration/local-invoke-provided/lambda/.gitignore
+++ b/tests/integration/local-invoke-provided/lambda/.gitignore
@@ -2,3 +2,6 @@
 # verify.sh's `go build` inside Docker — not checked in.
 build/
 go.sum
+# ZIP-FILE asset for BootstrapZipHandler, built from build/bootstrap by
+# verify.sh — a generated artifact, not checked in.
+bootstrap.zip

--- a/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
+++ b/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
@@ -11,13 +11,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * Fixture stack for `cdkl invoke` provided.* + go1.x integ test
  * (issue #248, final sub-PR).
  *
- * Four Lambdas:
+ * Five Lambdas:
  *   - `BootstrapHandler` — asset-backed `provided.al2023` function. The
  *     asset directory contains a statically-linked `bootstrap` binary
  *     compiled from `lambda/main.go` inside a Docker Go toolchain
  *     container; the OS-only Lambda runtime invokes it via the Lambda
  *     Runtime API. Architecture pinned to `x86_64` so the linux/amd64
  *     bootstrap built in CI matches the base image's default platform.
+ *   - `BootstrapZipHandler` — same compiled `bootstrap`, but `Code.fromAsset`
+ *     points at a `.zip` FILE (built by verify.sh) instead of the unzipped
+ *     directory. CDK keeps it zipped (`aws:asset:path` -> `asset.<hash>.zip`),
+ *     so cdkl must extract it AND preserve the bootstrap's executable bit —
+ *     otherwise RIE fails with `Runtime.InvalidEntrypoint` /
+ *     `fork/exec ...bootstrap: permission denied`.
  *   - `ProvidedAl2023InlineHandler` — `CfnFunction` with `Code: { ZipFile }`
  *     and `runtime: provided.al2023`. cdk-local's local invoke must reject
  *     with the "use Code.fromAsset" message — `provided.*` runtimes ship
@@ -48,6 +54,23 @@ export class LocalInvokeProvidedStack extends cdk.Stack {
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/build')),
       environment: {
         GREETING: 'hello',
+      },
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 256,
+    });
+
+    // Same `bootstrap` binary, but `Code.fromAsset` points at a `.zip` FILE
+    // (built by verify.sh) instead of the unzipped directory. CDK stages it as
+    // `asset.<hash>.zip` and `aws:asset:path` points at the zip; cdkl must
+    // extract it AND preserve the bootstrap's executable bit, or RIE fails with
+    // `Runtime.InvalidEntrypoint` / `fork/exec ...bootstrap: permission denied`.
+    new lambda.Function(this, 'BootstrapZipHandler', {
+      runtime: lambda.Runtime.PROVIDED_AL2023,
+      architecture: lambda.Architecture.X86_64,
+      handler: 'bootstrap',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/bootstrap.zip')),
+      environment: {
+        GREETING: 'hello-from-zip',
       },
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,

--- a/tests/integration/local-invoke-provided/verify.sh
+++ b/tests/integration/local-invoke-provided/verify.sh
@@ -57,6 +57,14 @@ test -x lambda/build/bootstrap || {
   exit 1
 }
 
+# Build a ZIP-FILE asset from the same (executable) bootstrap for
+# BootstrapZipHandler. `zip` stores the unix exec mode; `Code.fromAsset` of a
+# `.zip` keeps it zipped (aws:asset:path -> asset.<hash>.zip), so cdkl must
+# extract it AND preserve the exec bit at invoke time. Built here (gitignored).
+echo "==> Building lambda/bootstrap.zip (ZIP-FILE asset for BootstrapZipHandler)"
+rm -f lambda/bootstrap.zip
+( cd lambda/build && zip -q -X ../bootstrap.zip bootstrap )
+
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then
   vp install --prefer-offline
@@ -67,7 +75,7 @@ fi
 # On Apple Silicon hosts, `Architecture: x86_64` triggers Docker's
 # linux/amd64 emulation. The first invocation pays a one-time emulator
 # warm-up tax (~5s); the function's 30s timeout absorbs it comfortably.
-echo "==> [1/4] Invoking BootstrapHandler with default empty event"
+echo "==> [1/5] Invoking BootstrapHandler with default empty event"
 RESULT_1=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"Greeting": *"hello"|"greeting": *"hello"' || {
@@ -76,7 +84,7 @@ echo "${RESULT_1}" | grep -Eq '"Greeting": *"hello"|"greeting": *"hello"' || {
 }
 
 # Test 2 — asset-backed bootstrap with --event payload round-trip
-echo "==> [2/4] Invoking BootstrapHandler with --event payload"
+echo "==> [2/5] Invoking BootstrapHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
@@ -87,8 +95,26 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   exit 1
 }
 
-# Test 3 — inline Code.ZipFile rejection for provided.al2023.
-echo "==> [3/4] Invoking ProvidedAl2023InlineHandler — expecting inline Code.ZipFile rejection"
+# Test 3 — ZIP-FILE asset provided.al2023 bootstrap (regression: the extracted
+# bootstrap must keep its executable bit, else RIE -> Runtime.InvalidEntrypoint).
+echo "==> [3/5] Invoking BootstrapZipHandler (Code.fromAsset of a .zip with an executable bootstrap)"
+ZIP_EVENT=$(mktemp)
+trap 'rm -f "${EVENT_FILE}" "${ZIP_EVENT}"' EXIT
+echo '{"from":"zip"}' > "${ZIP_EVENT}"
+RESULT_ZIP=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapZipHandler --event "${ZIP_EVENT}" --no-pull 2>/dev/null | tail -1)
+echo "    response: ${RESULT_ZIP}"
+echo "${RESULT_ZIP}" | grep -Eq '"Greeting": *"hello-from-zip"|"greeting": *"hello-from-zip"' || {
+  echo "FAIL: expected greeting=hello-from-zip from the extracted zip bootstrap, got: ${RESULT_ZIP}"
+  exit 1
+}
+echo "${RESULT_ZIP}" | grep -Eq '"from": *"zip"' || {
+  echo "FAIL: expected echoed from=zip, got: ${RESULT_ZIP}"
+  exit 1
+}
+echo "    zip bootstrap executed ✓"
+
+# Test 4 — inline Code.ZipFile rejection for provided.al2023.
+echo "==> [4/5] Invoking ProvidedAl2023InlineHandler — expecting inline Code.ZipFile rejection"
 RESULT_3=""
 if RESULT_3=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/ProvidedAl2023InlineHandler --no-pull 2>&1); then
   echo "FAIL: expected non-zero exit on inline provided.al2023, got success: ${RESULT_3}"
@@ -106,8 +132,8 @@ echo "${RESULT_3}" | grep -q "Code.fromAsset" || {
 }
 echo "    rejection ✓"
 
-# Test 4 — go1.x deprecation rejection.
-echo "==> [4/4] Invoking Go1xHandler — expecting go1.x deprecation message"
+# Test 5 — go1.x deprecation rejection.
+echo "==> [5/5] Invoking Go1xHandler — expecting go1.x deprecation message"
 RESULT_4=""
 if RESULT_4=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/Go1xHandler --no-pull 2>&1); then
   echo "FAIL: expected non-zero exit on go1.x, got success: ${RESULT_4}"
@@ -126,4 +152,4 @@ echo "${RESULT_4}" | grep -q "PROVIDED_AL2023" || {
 echo "    deprecation ✓"
 
 echo ""
-echo "==> All 4 local-invoke provided.* + go1.x tests passed"
+echo "==> All 5 local-invoke provided.* + go1.x tests passed"

--- a/tests/unit/local/lambda-resolver-asset-code.test.ts
+++ b/tests/unit/local/lambda-resolver-asset-code.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  statSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { zipSync, strToU8 } from 'fflate';
@@ -72,6 +80,23 @@ describe('materializeAssetCodeDir', () => {
     expect(out.dir).not.toBe(zipPath);
     expect(readFileSync(join(out.dir, 'index.js'), 'utf-8')).toContain('ok: true');
     expect(readFileSync(join(out.dir, 'lib/util.js'), 'utf-8')).toBe('module.exports = 1;');
+  });
+
+  it('makes extracted files executable so a provided.* runtime bootstrap can be fork/exec-ed', () => {
+    // fflate's unzipSync drops unix modes, so without restoring the executable
+    // bit a `provided.*` custom runtime's `bootstrap` is written 0644 and RIE
+    // fails the invoke with `Runtime.InvalidEntrypoint` /
+    // `fork/exec /var/runtime/bootstrap: permission denied`.
+    const zipPath = join(root, 'asset.boot.zip');
+    writeFileSync(
+      zipPath,
+      zipSync({ bootstrap: strToU8('#!/bin/sh\nexec /usr/bin/true\n'), 'data.json': strToU8('{}') })
+    );
+    const out = materializeAssetCodeDir(zipPath);
+    made.push(out.dir);
+    // 0o111 = any execute bit set.
+    expect(statSync(join(out.dir, 'bootstrap')).mode & 0o111).not.toBe(0);
+    expect(statSync(join(out.dir, 'data.json')).mode & 0o111).not.toBe(0);
   });
 
   it('rejects a .zip entry that escapes the extraction root (zip-slip)', () => {


### PR DESCRIPTION
## Summary

Follow-up to the ZIP-FILE Lambda asset support (#415). That change extracts a `.zip`-packaged asset to a temp dir before bind-mounting, but wrote every extracted file with the default `0644` mode — dropping the executable bit the deployed Lambda package preserves.

A `provided.*` custom runtime's entrypoint (`bootstrap`) **must** be executable. So a function whose code is a `.zip` asset booted (the asset now resolved) but failed at invoke time with:

```
[ERROR] (rapid) Init failed error=fork/exec /var/runtime/bootstrap: permission denied
[ERROR] (rapid) Invoke DONE failed: Runtime.InvalidEntrypoint
```

(A `nodejs` / `python` zip asset was unaffected — those runtimes only read the handler file — which is why the original integ, which used a `nodejs` zip handler, did not catch it.)

## Fix

fflate's `unzipSync` returns only file **contents** (no per-entry unix mode), so the exact stored mode is unrecoverable. `materializeAssetCodeDir` now `chmodSync(dest, 0o755)` on each extracted file: the `bootstrap` becomes executable while every file stays readable — safe for the user's own code in an ephemeral local container. The chmod runs on the zip-slip-guarded destination path, after the write.

A **directory** asset is unaffected — CDK already staged it with correct modes and we bind-mount it directly.

## Test plan

- **unit** (`tests/unit/local/lambda-resolver-asset-code.test.ts`): `materializeAssetCodeDir` sets an execute bit (`mode & 0o111`) on extracted files.
- **integ** (`local-invoke-provided`): a new `BootstrapZipHandler` — `provided.al2023`, `Code.fromAsset` of a `.zip` built by `verify.sh` from the compiled Go `bootstrap` — is invoked end-to-end against real Docker. It fork/execs the extracted bootstrap and returns `{"echoed":{"from":"zip"},"greeting":"hello-from-zip"}`, which only works when the exec bit survives extraction. All 5 provided.* steps pass.

## Behavior change

A `.zip`-file asset for a `provided.*` (custom-runtime) Lambda that failed at invoke with `Runtime.InvalidEntrypoint` now runs. Additive — no previously-working input changes.
