### PR TITLE
feat(start-agentcore): serve an AgentCore /ws endpoint via a host WebSocket bridge

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -201,7 +201,24 @@ AWS managed services.
   container handoff) so the next session connects to the rebuilt
   container — the honest local-dev semantic. `--watch` on the
   single-shot HTTP `POST /invocations`, MCP `POST /mcp`, and A2A
-  `POST /` paths logs a one-line WARN and proceeds single-shot
+  `POST /` paths logs a one-line WARN and proceeds single-shot.
+  `cdkl start-agentcore` is the long-running serve counterpart of the
+  single-shot `invoke-agentcore --ws`: it boots the agent
+  container once (same image / env / `--from-cfn-stack` / `--assume-role`
+  / `--bearer-token` resolution as `invoke-agentcore`) and serves the
+  bidirectional `/ws` endpoint behind a host WebSocket BRIDGE so a
+  header-less client — a browser `WebSocket`, which cannot set the
+  `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` (or `Authorization`)
+  upgrade header — can hold an interactive multi-frame session. The
+  bridge accepts the header-less client on its own `--port` (default 0)
+  and opens a `ws` connection to the container `/ws` with those headers
+  injected (a fresh session-id UUID per inbound connection, unless
+  `--session-id` pins one), piping frames both ways. HTTP / AGUI
+  protocols only — MCP / A2A runtimes have no `/ws` (hard-rejected at
+  resolution). It prints a `Server listening on ws://...` ready line and
+  runs until `^C` (`--watch` is a follow-up). The `cdkl invoke-agentcore`
+  terminal path (interactive over stdin in a TTY) is unchanged; the
+  bridge exists for clients that cannot drive a terminal
 - API Gateway authorizers — Lambda authorizers, Cognito User Pool JWT
   verification, IAM SigV4 verification
 - CloudFront distributions — the `viewer-request` -> S3 origin ->
@@ -359,6 +376,7 @@ compute-locally category for Lambda + API Gateway).
   `createLocalInvokeAgentCoreCommand`, `createLocalStartApiCommand`,
   `createLocalRunTaskCommand`, `createLocalStartServiceCommand`,
   `createLocalStartAlbCommand`, `createLocalStartCloudFrontCommand`,
+  `createLocalStartAgentCoreCommand`,
   `createLocalListCommand`,
   `createLocalStudioCommand`) + shared option
   helpers. `createLocalStartCloudFrontCommand` (`cdkl start-cloudfront`,
@@ -395,6 +413,18 @@ compute-locally category for Lambda + API Gateway).
   in `commands/ecs-service-emulator.ts` (synth + shared docker network +
   Cloud Map + restart watcher + optional front-door); each command is a
   thin strategy over it (service targets vs ALB targets).
+  `createLocalStartAgentCoreCommand` (`cdkl start-agentcore`)
+  is the long-running serve counterpart of the single-shot
+  `createLocalInvokeAgentCoreCommand`: it reuses that command's exported
+  boot helpers (`resolveAgentCoreImage` / `buildContainerEnv` /
+  `resolveInboundAuthorization` / `buildAgentCoreImageContext`) to boot the
+  agent container once, then runs `startAgentCoreWsBridge` (a host
+  WebSocket server) in front of the container `/ws` so a header-less
+  browser client can hold an interactive session. HTTP / AGUI only
+  (`assertAgentCoreWsServable` hard-rejects MCP / A2A). New CLI options
+  live in `addStartAgentCoreSpecificOptions` (`--port` / `--host` /
+  `--session-id` / `--bearer-token` / `--no-verify-auth` / `--env-vars` /
+  `--platform` / `--from-cfn-stack` / `--assume-role` / ...).
   `createLocalStudioCommand` (`cdkl studio`, issue #282) is the
   interactive web console over the same target enumeration — a control
   plane that spawns the SAME `invoke` / `start-api` / `start-alb` /
@@ -464,7 +494,15 @@ compute-locally category for Lambda + API Gateway).
   agentcore-resolver (`AWS::BedrockAgentCore::Runtime` target resolution +
   container-URI extraction) + agentcore-client (the `/ping` + `/invocations`
   HTTP-contract client for `cdkl invoke-agentcore`) + agentcore-ws-client (the
-  bidirectional `/ws` WebSocket client for `--ws`) + agentcore-s3-bundle
+  bidirectional `/ws` WebSocket client for `--ws` (`invokeAgentCoreWs`), plus
+  the caller-driven relay primitive `bridgeAgentCoreWs` — which
+  opens the container `/ws` with the session-id / Authorization headers
+  injected and sends NO initial frame, so a caller drives every frame) +
+  agentcore-ws-bridge (`startAgentCoreWsBridge`: the host
+  WebSocket server behind `cdkl start-agentcore`; accepts a header-less client
+  (a browser, which cannot set the upgrade headers) and bridges each
+  connection to the container `/ws` via `bridgeAgentCoreWs`, injecting a
+  per-connection session-id UUID + optional Authorization) + agentcore-s3-bundle
   (downloads + extracts a fromS3 CodeConfiguration bundle for the from-source
   build), embed-config
   (embed-time branding overrides for host CLIs), ssm-parameter-resolver

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The locally executable resources are listed under [Supported resources](#support
 
 Run every `cdkl` command from your CDK project root (the directory containing `cdk.json`).
 
-Run any command with no target for an arrow-key picker (`invoke` / `invoke-agentcore` / `run-task` / `start-cloudfront` pick one; `start-service` / `start-alb` / `start-api` multi-select). Or name a target — the CDK display path (recommended) or a stack-qualified logical ID (`MyStack:Fn1234ABCD`, the SAM-compatible form); single-stack apps may drop the stack prefix.
+Run any command with no target for an arrow-key picker (`invoke` / `invoke-agentcore` / `start-agentcore` / `run-task` / `start-cloudfront` pick one; `start-service` / `start-alb` / `start-api` multi-select). Or name a target — the CDK display path (recommended) or a stack-qualified logical ID (`MyStack:Fn1234ABCD`, the SAM-compatible form); single-stack apps may drop the stack prefix.
 
 ```bash
 cdkl invoke MyStack/Fn --event ./event.json   # Lambda (ZIP or container image)
@@ -65,6 +65,7 @@ cdkl start-alb MyStack/WebAlb                  # ECS behind an ALB (front-door p
 cdkl start-api MyStack/Api                     # API Gateway REST v1 / HTTP v2 / WebSocket + Function URLs
 cdkl start-cloudfront MyStack/SiteDist         # CloudFront: S3 / Lambda Function URL origins + Functions (static site / SPA / SSR)
 cdkl invoke-agentcore MyStack/Agent            # Bedrock AgentCore Runtime (HTTP / MCP / A2A / AGUI)
+cdkl start-agentcore MyStack/Agent             # serve an AgentCore /ws endpoint for an interactive WebSocket session
 cdkl list                                      # every runnable target, grouped by command (alias: ls)
 cdkl studio                                    # interactive web console over every target
 ```
@@ -85,6 +86,7 @@ cdkl invoke MyStack/Fn --from-cfn-stack --assume-role   # ...and run as its depl
 - **`start-alb`** stands up the ECS service(s) behind an ALB plus a host-side front-door on each listener port, honoring all six listener-rule conditions, weighted forwards, redirect / fixed-response actions, mixed ECS + Lambda targets, `authenticate-cognito` / `authenticate-oidc` actions (local Bearer-JWT enforcement), and WebSocket `Upgrade` proxying to ECS targets ([details](docs/cli-reference.md#cdkl-start-alb-run-an-alb-fronted-service-locally)).
 - **`start-cloudfront`** serves a CloudFront distribution's `viewer-request` -> origin -> `viewer-response` pipeline locally — CloudFront Functions in-process (incl. **KeyValueStore** reads via the deployed store with `--from-cfn-stack` or a local map with `--kvs-file`) and **Lambda@Edge** functions in a real RIE container (all four event types — viewer / origin request / response) over an **S3 origin** (BucketDeployment source, or — when there's no local source, e.g. files uploaded out of band by a separate frontend repo — the deployed bucket read from **real S3 on demand** with `--from-cfn-stack`) or a **Lambda Function URL origin** (the backing Lambda run locally), with the behavior's **`ResponseHeadersPolicy` CORS** (preflight + response headers) reproduced at the edge, so a routing / rewrite / auth / SPA-fallback / CDN-fronted-Lambda / CORS change is verifiable in seconds. `--origin`, `--tls`, `--watch` ([details](docs/cli-reference.md#cdkl-start-cloudfront-serve-a-cloudfront-distribution-locally)).
 - **`invoke-agentcore`** invokes a Bedrock AgentCore Runtime agent locally — container or `fromCodeAsset` / `fromS3` managed runtime, all four runtime protocols (HTTP and AGUI on 8080, MCP on 8000, A2A on 9000; SSE and WebSocket are HTTP wire-shape variants on the same 8080 container), with `customJwtAuthorizer` and `--sigv4` enforcement ([details](docs/cli-reference.md#cdkl-invoke-agentcore-run-bedrock-agentcore-runtime-agents-locally)).
+- **`start-agentcore`** serves an HTTP / AGUI AgentCore Runtime's bidirectional `/ws` endpoint as a long-running local session — it boots the agent container (same env / credential / `--bearer-token` resolution as `invoke-agentcore`) behind a host WebSocket bridge that injects the AgentCore session-id (and `Authorization` under a `customJwtAuthorizer`) on the container upgrade, so a header-less client — a browser `WebSocket`, which can't set those headers — can hold an interactive multi-frame session ([details](docs/cli-reference.md#cdkl-start-agentcore-serve-an-agentcore-ws-endpoint-locally)).
 - **`studio`** opens a local web console over the same synthesized targets — a point-and-click front over the same CLI runners. Takes no target (it lists them all). Flags + in-UI controls: [Web console — `cdkl studio`](#web-console--cdkl-studio).
 - Non-TTY (CI / pipes): every command except a bare `start-api` needs an explicit target.
 
@@ -217,7 +219,7 @@ Most CDK ECS apps boot multiple replicas behind an ALB. cdk-local exposes each l
 | Cloud Map / Service Connect registry | service discovery between local replicas |
 | ALB-fronted ECS / Lambda services | `start-alb` — HTTP / HTTPS listeners, all six listener-rule conditions, weighted forwards, redirect / fixed-response, mixed ECS + Lambda targets, authenticate-cognito / authenticate-oidc (local Bearer-JWT enforcement), WebSocket Upgrade |
 | CloudFront distributions (S3 + Lambda Function URL origins + CloudFront Functions + Lambda@Edge) | `start-cloudfront` — viewer-request / viewer-response Functions over S3 origin routing (default root object, custom error responses / SPA fallback; the deployed bucket read from real S3 on demand via `--from-cfn-stack` when there's no local BucketDeployment source) and Lambda Function URL origins (backing Lambda run locally), **Lambda@Edge** functions in a real RIE container (all four event types), CloudFront Function **KeyValueStore** reads (deployed store via `--from-cfn-stack` or a local map via `--kvs-file`), `ResponseHeadersPolicy` CORS (preflight + response headers), `--tls`, `--watch` |
-| Bedrock AgentCore Runtime agents | `invoke-agentcore` — container + `fromCodeAsset` / `fromS3` artifacts, HTTP / MCP / A2A / AGUI |
+| Bedrock AgentCore Runtime agents | `invoke-agentcore` — container + `fromCodeAsset` / `fromS3` artifacts, HTTP / MCP / A2A / AGUI; `start-agentcore` — long-running serve of an HTTP / AGUI `/ws` endpoint behind a header-injecting WebSocket bridge (browser-client sessions) |
 
 Lambda runs on every current AWS Lambda runtime — Node.js (18/20/22/24), Python (3.11–3.14), Ruby (3.2/3.3), Java (8.al2/11/17/21), .NET (6/8), and the OS-only `provided.al2` / `provided.al2023`. The retired `go1.x` runtime is rejected with a pointer to migrate to `provided.al2023`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,6 +18,7 @@ cdk-local has eight subcommands, all under the `cdkl` binary:
 | `cdkl run-task <target>` | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
 | `cdkl start-service <targets...>` | Long-running ECS `Service` emulator (replicas only, no load balancer) | `run-task` machinery per replica + shared docker network + restart-on-exit watcher |
 | `cdkl start-alb <targets...>` | ECS service(s) behind an ALB + a local front-door on each listener port | `start-service` machinery + host-side `node:http` reverse proxy round-robining the replicas |
+| `cdkl start-agentcore <target>` | Long-running serve of an HTTP / AGUI AgentCore Runtime's `/ws` WebSocket endpoint | Agent container + a host WebSocket bridge (`node:http` + `ws`) that injects the session-id / `Authorization` upgrade headers a browser can't set |
 | `cdkl studio` | Interactive web console over every runnable target — invoke / serve from the browser, watch a live activity timeline | `node:http` server hosting the embedded UI; spawns the same `invoke` / `start-api` / `start-alb` / `start-service` runners as child processes |
 
 The run commands (`invoke` / `invoke-agentcore` / `start-api` / `run-task` /
@@ -779,6 +780,67 @@ and non-integer values pre-container.
   `error` (MCP), OR a cdk-local-side error: Docker not installed, image
   build / pull failed, target not found, the agent never became ready within
   the readiness window, or the container exited before responding.
+
+## `cdkl start-agentcore` (serve an AgentCore `/ws` endpoint locally)
+
+`cdkl start-agentcore <target>` is the long-running serve counterpart of the
+single-shot `cdkl invoke-agentcore`. It boots an `AWS::BedrockAgentCore::Runtime`
+agent container once — using the **same** image / env-var / `--from-cfn-stack`
+/ `--assume-role` / `--bearer-token` resolution as `invoke-agentcore` — and
+then serves the agent's bidirectional `/ws` WebSocket endpoint behind a host
+**bridge** so a client can hold an interactive multi-frame session. It prints a
+`Server listening on ws://127.0.0.1:<port>/ws` ready line and runs until `^C`.
+
+**Why a bridge.** The AgentCore `/ws` upgrade requires the
+`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header (and `Authorization:
+Bearer <jwt>` when the runtime declares a `customJwtAuthorizer`). A browser
+`WebSocket` cannot set custom request headers, so it can't connect to the
+container directly. The bridge accepts a header-less client on its own
+`--port` and opens a connection to the container `/ws` with those headers
+injected — a fresh session-id UUID per inbound connection (so each client /
+browser tab is its own AgentCore session), unless `--session-id` pins one.
+
+**Protocols.** HTTP and AGUI runtimes only — they expose `/ws` on 8080. MCP
+(`POST /mcp`) and A2A (`POST /`) are single-shot request/response contracts
+with no `/ws`, and are rejected up front with an actionable error (use
+`cdkl invoke-agentcore` for those).
+
+```bash
+# Pick an AgentCore Runtime interactively (TTY), serve its /ws on a free port
+cdkl start-agentcore
+
+# Serve a named runtime's /ws on a fixed bridge port
+cdkl start-agentcore MyStack/Agent --port 8080
+
+# Forward a bearer token (verified against the runtime's OIDC discovery URL)
+# on every bridged container upgrade
+cdkl start-agentcore MyStack/Agent --bearer-token "$JWT"
+
+# Bind to a deployed stack so intrinsic env values / ECR image URIs resolve
+cdkl start-agentcore MyStack/Agent --from-cfn-stack
+```
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--port <n>` | `0` | Bridge-server bind port the client connects to (0 = OS-assigned). |
+| `--host <ip>` | `127.0.0.1` | Bridge-server bind host. |
+| `--session-id <id>` | random UUID per connection | Pin one AgentCore session-id header value for every connection. |
+| `--bearer-token <jwt>` | — | Bearer JWT for a `customJwtAuthorizer`; verified against the runtime's OIDC discovery URL, then injected as `Authorization: Bearer <jwt>` on every container `/ws` upgrade. |
+| `--no-verify-auth` | (verify on) | Skip inbound JWT verification (local-dev escape hatch); a `--bearer-token`, if given, is still forwarded. |
+| `--env-vars <file>` | — | SAM-shape JSON env-var overrides for the agent container. |
+| `--platform <platform>` | `linux/arm64` | `docker --platform` for the agent container. |
+| `--no-pull` / `--no-build` | (on) | Skip the image pull / local build. |
+| `--container-host <ip>` | `127.0.0.1` | Host IP used to bind the agent container port. |
+| `--timeout <ms>` | `120000` | `GET /ping` container-ready probe timeout. |
+| `--assume-role [arn]` | — | Assume the runtime's execution role and forward STS credentials to the container. |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR. |
+| `--from-cfn-stack [name]` | — | Resolve intrinsic env values / ECR image URIs against a deployed stack. |
+| `--stack-region <region>` | — | Region of the state record (with `--from-cfn-stack`). |
+
+`--watch` (reload on CDK source changes) is a planned follow-up; for now,
+restart the command to pick up local edits. `start-agentcore` is also runnable
+from `cdkl studio` (the `agentcore-ws` serve kind) with an in-browser WebSocket
+console.
 
 ## `cdkl start-api` (long-running local API server)
 

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -112,7 +112,7 @@ import {
   type ProfileCredentialsFile,
 } from './local-profile-credentials-file.js';
 
-interface LocalInvokeAgentCoreOptions {
+export interface LocalInvokeAgentCoreOptions {
   app?: string;
   output: string;
   verbose: boolean;

--- a/src/cli/commands/local-start-agentcore.ts
+++ b/src/cli/commands/local-start-agentcore.ts
@@ -1,0 +1,485 @@
+import { Command, Option } from 'commander';
+import {
+  appOptions,
+  commonOptions,
+  contextOptions,
+  regionOption,
+  parseContextOptions,
+} from '../options.js';
+import { getLogger } from '../../utils/logger.js';
+import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
+import { listTargets } from '../../local/target-lister.js';
+import { resolveSingleTarget } from '../../local/target-picker.js';
+import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import { resolveApp } from '../config-loader.js';
+import {
+  createLocalStateProvider,
+  resolveCfnFallbackRegion,
+  type ExtraStateProviders,
+} from './local-state-source.js';
+import type { LocalStateProvider } from '../../local/local-state-provider.js';
+import {
+  getEmbedConfig,
+  setEmbedConfig,
+  type CdkLocalEmbedConfig,
+} from '../../local/embed-config.js';
+import {
+  AGENTCORE_A2A_PROTOCOL,
+  AGENTCORE_MCP_PROTOCOL,
+  pickAgentCoreCandidateStack,
+  resolveAgentCoreTarget,
+  type ResolvedAgentCoreRuntime,
+} from '../../local/agentcore-resolver.js';
+import { waitForAgentCorePing } from '../../local/agentcore-client.js';
+import {
+  startAgentCoreWsBridge,
+  type RunningAgentCoreWsBridge,
+} from '../../local/agentcore-ws-bridge.js';
+import {
+  ensureDockerAvailable,
+  pickFreePort,
+  removeContainer,
+  runDetached,
+  streamLogs,
+} from '../../local/docker-runner.js';
+import { resolveProfileCredentials } from './local-start-api.js';
+import {
+  writeProfileCredentialsFile,
+  type ProfileCredentialsFile,
+} from './local-profile-credentials-file.js';
+import {
+  buildAgentCoreImageContext,
+  buildContainerEnv,
+  parseTimeoutMs,
+  resolveAgentCoreImage,
+  resolveFromS3BucketIntrinsic,
+  resolveInboundAuthorization,
+  type LocalInvokeAgentCoreOptions,
+} from './local-invoke-agentcore.js';
+
+/**
+ * Options for `cdkl start-agentcore`. A superset of the single-shot
+ * `invoke-agentcore` options (so the shared boot / env / auth / image helpers
+ * can be reused verbatim) plus the bridge-server bind controls. The
+ * invoke-only fields (`--ws` / `--sigv4` / `--event` / `--event-stdin`) are
+ * absent — this command never single-shots; it serves the `/ws` endpoint.
+ */
+interface LocalStartAgentCoreOptions extends LocalInvokeAgentCoreOptions {
+  /** Bridge-server bind port (`--port`, default 0 = OS-assigned). */
+  port: number;
+  /** Bridge-server bind host (`--host`, default 127.0.0.1). */
+  host: string;
+}
+
+/**
+ * Parser for `--port <n>`. Accepts 0 (OS-assigned) through 65535.
+ */
+function parsePort(raw: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+    throw new CdkLocalError(`--port must be an integer 0-65535, got '${raw}'.`, 'INVALID_PORT');
+  }
+  return n;
+}
+
+/**
+ * Reject MCP / A2A runtimes: the `/ws` WebSocket endpoint this command serves
+ * exists only on the HTTP / AGUI protocols. MCP (`POST /mcp`) and A2A
+ * (`POST /`) are single-shot request/response contracts with no bidirectional
+ * socket. Exported so a unit test can drive the gate without the Docker
+ * pipeline.
+ */
+export function assertAgentCoreWsServable(
+  resolved: Pick<ResolvedAgentCoreRuntime, 'protocol' | 'logicalId'>
+): void {
+  if (
+    resolved.protocol === AGENTCORE_MCP_PROTOCOL ||
+    resolved.protocol === AGENTCORE_A2A_PROTOCOL
+  ) {
+    throw new CdkLocalError(
+      `${getEmbedConfig().cliName} start-agentcore serves the HTTP / AGUI /ws WebSocket endpoint, but ` +
+        `'${resolved.logicalId}' is a ${resolved.protocol} runtime, which has no /ws. ` +
+        `Use \`${getEmbedConfig().cliName} invoke-agentcore\` for ${resolved.protocol} runtimes.`,
+      'LOCAL_START_AGENTCORE_PROTOCOL_UNSUPPORTED'
+    );
+  }
+}
+
+/**
+ * `cdkl start-agentcore <target>` — boot a Bedrock AgentCore Runtime container
+ * locally and serve its bidirectional `/ws` WebSocket endpoint behind a
+ * long-running host bridge, so a browser (or any WebSocket client) can hold an
+ * interactive multi-frame session against it.
+ *
+ * Why a bridge rather than the published container port directly: the
+ * AgentCore `/ws` upgrade requires the session-id (and, under a
+ * `customJwtAuthorizer`, `Authorization`) header, which a browser `WebSocket`
+ * cannot set. The bridge accepts a header-less client and injects those
+ * headers on the container leg. HTTP / AGUI protocols only — MCP / A2A
+ * runtimes have no `/ws`.
+ *
+ * The container is booted once via the SAME image / env / auth resolution as
+ * `cdkl invoke-agentcore`; the process then blocks until SIGINT / SIGTERM,
+ * tearing down the bridge and the container.
+ */
+async function localStartAgentCoreCommand(
+  target: string | undefined,
+  options: LocalStartAgentCoreOptions,
+  extraStateProviders: ExtraStateProviders | undefined
+): Promise<void> {
+  const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
+
+  let containerId: string | undefined;
+  let stopLogs: (() => void) | undefined;
+  let bridge: RunningAgentCoreWsBridge | undefined;
+  let profileCredsFile: ProfileCredentialsFile | undefined;
+  let stateProvider: LocalStateProvider | undefined;
+  let shuttingDown = false;
+  let tornDown = false;
+
+  const teardown = async (): Promise<void> => {
+    if (tornDown) return;
+    tornDown = true;
+    if (bridge) {
+      try {
+        await bridge.close();
+      } catch (err) {
+        logger.debug(`bridge close failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (stopLogs) {
+      try {
+        stopLogs();
+      } catch (err) {
+        logger.debug(`streamLogs stop failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (containerId) {
+      try {
+        await removeContainer(containerId);
+      } catch (err) {
+        logger.debug(
+          `removeContainer(${containerId}) failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+    if (stateProvider) {
+      try {
+        stateProvider.dispose();
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (profileCredsFile) {
+      try {
+        await profileCredsFile.dispose();
+      } catch {
+        /* best-effort */
+      }
+    }
+  };
+
+  await applyRoleArnIfSet({
+    roleArn: options.roleArn,
+    region: options.region,
+    profile: options.profile,
+  });
+  await ensureDockerAvailable();
+
+  const profileCredentials = options.profile
+    ? await resolveProfileCredentials(options.profile)
+    : undefined;
+  if (options.profile && profileCredentials) {
+    profileCredsFile = await writeProfileCredentialsFile(options.profile, profileCredentials);
+  }
+
+  const appCmd = resolveApp(options.app);
+  if (!appCmd) {
+    throw new Error(
+      `No CDK app specified. Pass --app, set ${getEmbedConfig().envPrefix}_APP, or add "app" to cdk.json.`
+    );
+  }
+
+  logger.info('Synthesizing CDK app...');
+  const synthesizer = new Synthesizer();
+  const context = parseContextOptions(options.context);
+  const synthOpts: SynthesisOptions = {
+    app: appCmd,
+    output: options.output,
+    ...(options.region && { region: options.region }),
+    ...(options.profile && { profile: options.profile }),
+    ...(Object.keys(context).length > 0 && { context }),
+  };
+  const { stacks } = await synthesizer.synthesize(synthOpts);
+
+  const resolvedTarget = await resolveSingleTarget(target, {
+    entries: listTargets(stacks).agentCoreRuntimes,
+    message: 'Select an AgentCore Runtime to serve',
+    noun: 'AgentCore Runtimes',
+    onMissing: () =>
+      new CdkLocalError(
+        `${getEmbedConfig().cliName} start-agentcore requires a <target> (an AgentCore Runtime display path or logical ID). ` +
+          `Run \`${getEmbedConfig().cliName} list\` to see them, or run it in a TTY to pick interactively.`,
+        'LOCAL_START_AGENTCORE_TARGET_REQUIRED'
+      ),
+  });
+
+  const candidate = pickAgentCoreCandidateStack(resolvedTarget, stacks);
+  stateProvider = createLocalStateProvider(
+    options,
+    candidate?.stackName ?? '',
+    await resolveCfnFallbackRegion(options, candidate?.region),
+    extraStateProviders
+  );
+  const { context: imageContext, loaded: loadedState } =
+    stateProvider && candidate
+      ? await buildAgentCoreImageContext(candidate, stateProvider, options)
+      : { context: undefined, loaded: undefined };
+
+  const resolved = resolveAgentCoreTarget(resolvedTarget, stacks, imageContext);
+  logger.info(`Target: ${resolved.stack.stackName}/${resolved.logicalId} (${resolved.protocol})`);
+
+  // The /ws WebSocket endpoint exists only on the HTTP / AGUI protocols.
+  assertAgentCoreWsServable(resolved);
+
+  // Inbound JWT auth: when the runtime declares a customJwtAuthorizer, verify
+  // the supplied --bearer-token against its OIDC discovery URL BEFORE any
+  // Docker work and resolve the Authorization header the bridge injects on the
+  // container leg (the bridge speaks to the same authorizer the cloud would).
+  const authorization = await resolveInboundAuthorization(resolved, options);
+
+  // Resolve a fromS3 bundle's intrinsic bucket before the image step.
+  await resolveFromS3BucketIntrinsic(resolved, stateProvider, loadedState, imageContext);
+
+  const image = await resolveAgentCoreImage(resolved, options, loadedState, stateProvider);
+  const { env: dockerEnv, sensitiveEnvKeys } = await buildContainerEnv(
+    resolved,
+    options,
+    profileCredentials,
+    profileCredsFile,
+    stateProvider,
+    loadedState,
+    imageContext
+  );
+
+  const containerHostPort = await pickFreePort();
+  const containerHost = options.containerHost;
+  // Stable `cdkl-`-prefixed name so the orphan sweep (`docker ps --filter
+  // name=cdkl-`) used by `/cleanup` + `/run-integ` finds this long-lived
+  // container if the process is killed before teardown.
+  const containerName = `${getEmbedConfig().resourceNamePrefix}-agentcore-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  logger.info(`Starting agent container (image=${image}, port=${containerHostPort} -> 8080)...`);
+  containerId = await runDetached({
+    image,
+    mounts: [],
+    env: dockerEnv,
+    cmd: [],
+    hostPort: containerHostPort,
+    host: containerHost,
+    platform: options.platform,
+    name: containerName,
+    ...(sensitiveEnvKeys.size > 0 && { sensitiveEnvKeys }),
+  });
+  stopLogs = streamLogs(containerId);
+
+  // Wire the shutdown handlers NOW — immediately after the container is booted,
+  // BEFORE the (potentially slow) /ping wait + bridge bind — so a SIGINT /
+  // SIGTERM arriving during boot still tears the container down instead of
+  // orphaning it. `teardown` is null-safe (the bridge may not exist yet) and
+  // idempotent, so the boot-error catch below and a racing signal cannot
+  // double-tear-down.
+  const shutdown = async (signal: string, exitCode: number): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info(`Received ${signal}, shutting down...`);
+    await teardown();
+    process.exit(exitCode);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT', 130));
+  process.on('SIGTERM', () => void shutdown('SIGTERM', 0));
+
+  // A failure in the post-boot setup (/ping wait or bridge bind) must stop the
+  // booted container before rethrowing.
+  try {
+    await waitForAgentCorePing(containerHost, containerHostPort, options.timeout);
+    bridge = await startAgentCoreWsBridge({
+      containerHost,
+      containerPort: containerHostPort,
+      host: options.host,
+      port: options.port,
+      ...(authorization && { authorization }),
+      ...(options.sessionId && { sessionId: options.sessionId }),
+    });
+  } catch (err) {
+    await teardown();
+    throw err;
+  }
+
+  // start-api shares the "Server listening on <url>" prefix so studio's
+  // serve-manager readyRe captures the ws:// endpoint and renders its
+  // WebSocket console.
+  logger.info(`Server listening on ${bridge.url}  (${resolved.logicalId} (AgentCore WebSocket))`);
+  logger.info('Press ^C to shut down.');
+
+  // Block forever — signal handlers exit the process.
+  await new Promise<never>(() => undefined);
+}
+
+export interface CreateLocalStartAgentCoreCommandOptions {
+  extraStateProviders?: ExtraStateProviders;
+  /** Embed-time branding overrides for a host wrapping this factory. */
+  embedConfig?: CdkLocalEmbedConfig;
+}
+
+/**
+ * `cdkl start-agentcore <target>` — long-running serve for a Bedrock AgentCore
+ * Runtime's `/ws` WebSocket endpoint, fronted by a host bridge that injects the
+ * session-id / Authorization upgrade headers a browser `WebSocket` cannot set.
+ * The serve counterpart of the single-shot `cdkl invoke-agentcore`; the studio
+ * `agentcore-ws` serve kind spawns this command.
+ */
+export function createLocalStartAgentCoreCommand(
+  opts: CreateLocalStartAgentCoreCommandOptions = {}
+): Command {
+  setEmbedConfig(opts.embedConfig);
+  const cmd = new Command('start-agentcore')
+    .description(
+      "Serve a Bedrock AgentCore Runtime's bidirectional /ws WebSocket endpoint locally for an " +
+        'interactive multi-frame session. Boots the AWS::BedrockAgentCore::Runtime container (same ' +
+        'image / env / credential resolution as invoke-agentcore), then runs a host WebSocket bridge ' +
+        'that injects the AgentCore session-id (and Authorization under a customJwtAuthorizer) on the ' +
+        'container upgrade so a header-less client (e.g. a browser) can connect. HTTP / AGUI protocols ' +
+        'only (MCP / A2A runtimes have no /ws). Target accepts a CDK display path (MyStack/MyAgent) or ' +
+        'stack-qualified logical ID; single-stack apps may omit the prefix. Omit <target> in a TTY to ' +
+        'pick from a list. Runs until ^C.'
+    )
+    .argument(
+      '[target]',
+      'CDK display path or stack-qualified logical ID of the AgentCore Runtime to serve (omit to pick interactively in a TTY)'
+    )
+    .action(
+      withErrorHandling(async (target: string | undefined, options: LocalStartAgentCoreOptions) => {
+        await localStartAgentCoreCommand(target, options, opts.extraStateProviders);
+      })
+    );
+
+  addStartAgentCoreSpecificOptions(cmd);
+  [...commonOptions(), ...appOptions(), ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  cmd.addOption(regionOption);
+  return cmd;
+}
+
+/**
+ * Register the option block `cdkl start-agentcore` adds on top of the shared
+ * common / app / context helpers. Shared with any host CLI (e.g. cdkd's
+ * `local start-agentcore`) wrapping this factory, so adding or renaming a
+ * `start-agentcore`-only flag here propagates without duplicate
+ * `.addOption(...)` blocks. Chainable: returns `cmd`.
+ */
+export function addStartAgentCoreSpecificOptions(cmd: Command): Command {
+  return cmd
+    .addOption(
+      new Option(
+        '--port <n>',
+        'Bridge-server bind port the client (browser) connects to. Default 0 (OS-assigned).'
+      )
+        .default(0)
+        .argParser(parsePort)
+    )
+    .addOption(
+      new Option('--host <ip>', 'Bridge-server bind host. Default 127.0.0.1.').default('127.0.0.1')
+    )
+    .addOption(
+      new Option(
+        '--session-id <id>',
+        'Pin one AgentCore runtime session id header value for every connection ' +
+          '(default: a fresh random UUID per connection, so each client is its own session).'
+      )
+    )
+    .addOption(
+      new Option(
+        '--bearer-token <jwt>',
+        'Bearer JWT to present when the runtime declares a customJwtAuthorizer. Verified against ' +
+          "the runtime's OIDC discovery URL before the container starts, then injected as " +
+          'Authorization: Bearer <jwt> on the container /ws upgrade for every bridged connection.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--no-verify-auth',
+        'Skip inbound JWT verification even when the runtime declares a customJwtAuthorizer ' +
+          '(local-dev escape hatch). A --bearer-token, if given, is still forwarded.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--env-vars <file>',
+        'JSON env-var overrides (SAM-compatible: {"LogicalId":{"KEY":"VALUE"}, "Parameters": {...}})'
+      )
+    )
+    .addOption(
+      new Option(
+        '--platform <platform>',
+        'docker --platform for the agent container (linux/amd64 or linux/arm64). ' +
+          'Defaults to linux/arm64 because the cloud AgentCore Runtime requires arm64.'
+      )
+        .choices(['linux/amd64', 'linux/arm64'])
+        .default('linux/arm64')
+    )
+    .addOption(
+      new Option(
+        '--no-pull',
+        'Skip docker pull (use cached image) — no-op for the local-build path'
+      )
+    )
+    .addOption(
+      new Option(
+        '--no-build',
+        'Skip docker build on the local-asset path (use the previously-built tag). No-op for the ECR / registry pull paths.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--container-host <host>',
+        'Host IP used to bind the agent container port. Must be a numeric IP. Defaults to 127.0.0.1.'
+      ).default('127.0.0.1')
+    )
+    .addOption(
+      new Option(
+        '--timeout <ms>',
+        'Maximum time in milliseconds to wait for the container to become ready (the GET /ping readiness deadline). Default 120000.'
+      )
+        .default(120000)
+        .argParser(parseTimeoutMs)
+    )
+    .addOption(
+      new Option(
+        '--assume-role [arn]',
+        "Assume the runtime's execution role and forward STS-issued temp credentials to the container. " +
+          '(1) `--assume-role <arn>` assumes the explicit ARN; ' +
+          "(2) `--assume-role` (bare) uses the runtime's literal RoleArn; " +
+          '(3) `--no-assume-role` opts out. Off by default.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--ecr-role-arn <arn>',
+        'Role ARN to assume before authenticating against ECR for cross-account / centralized registries.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--from-cfn-stack [cfn-stack-name]',
+        'Read a deployed CloudFormation stack and substitute Ref / Fn::ImportValue in env vars / image ' +
+          'URIs with the deployed physical IDs / exports. Bare form uses the resolved stack name.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--stack-region <region>',
+        'Region of the state record to read. Used with --from-cfn-stack as the CFn client region.'
+      )
+    );
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { createLocalRunTaskCommand } from './commands/local-run-task.js';
 import { createLocalStartServiceCommand } from './commands/local-start-service.js';
 import { createLocalStartAlbCommand } from './commands/local-start-alb.js';
 import { createLocalStartCloudFrontCommand } from './commands/local-start-cloudfront.js';
+import { createLocalStartAgentCoreCommand } from './commands/local-start-agentcore.js';
 import { createLocalListCommand } from './commands/local-list.js';
 import { createLocalStudioCommand } from './commands/local-studio.js';
 
@@ -26,6 +27,7 @@ program.addCommand(createLocalRunTaskCommand());
 program.addCommand(createLocalStartServiceCommand());
 program.addCommand(createLocalStartAlbCommand());
 program.addCommand(createLocalStartCloudFrontCommand());
+program.addCommand(createLocalStartAgentCoreCommand());
 program.addCommand(createLocalListCommand());
 program.addCommand(createLocalStudioCommand());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ export {
   type CreateLocalStartCloudFrontCommandOptions,
 } from './cli/commands/local-start-cloudfront.js';
 export {
+  createLocalStartAgentCoreCommand,
+  type CreateLocalStartAgentCoreCommandOptions,
+} from './cli/commands/local-start-agentcore.js';
+export {
   createLocalListCommand,
   formatTargetListing,
   type CreateLocalListCommandOptions,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -345,9 +345,17 @@ export {
 } from './local/agentcore-mcp-client.js';
 export {
   invokeAgentCoreWs,
+  bridgeAgentCoreWs,
   type InvokeAgentCoreWsOptions,
   type AgentCoreWsResult,
+  type BridgeAgentCoreWsOptions,
+  type AgentCoreWsBridgeHandle,
 } from './local/agentcore-ws-client.js';
+export {
+  startAgentCoreWsBridge,
+  type AgentCoreWsBridgeServerConfig,
+  type RunningAgentCoreWsBridge,
+} from './local/agentcore-ws-bridge.js';
 export {
   a2aInvokeOnce,
   A2A_CONTAINER_PORT,
@@ -663,6 +671,7 @@ export { addListSpecificOptions } from './cli/commands/local-list.js';
 export { addRunTaskSpecificOptions } from './cli/commands/local-run-task.js';
 export { addInvokeSpecificOptions } from './cli/commands/local-invoke.js';
 export { addInvokeAgentCoreSpecificOptions } from './cli/commands/local-invoke-agentcore.js';
+export { addStartAgentCoreSpecificOptions } from './cli/commands/local-start-agentcore.js';
 export { addStartApiSpecificOptions } from './cli/commands/local-start-api.js';
 export {
   addStartServiceSpecificOptions,

--- a/src/local/agentcore-ws-bridge.ts
+++ b/src/local/agentcore-ws-bridge.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { WebSocketServer, type WebSocket, type RawData } from 'ws';
+import { bridgeAgentCoreWs } from './agentcore-ws-client.js';
+import { getLogger } from '../utils/logger.js';
+
+/**
+ * Host-side WebSocket bridge in front of an AgentCore runtime's container
+ * `/ws` endpoint, the serving primitive behind `cdkl start-agentcore`.
+ *
+ * Why a bridge instead of pointing a client straight at the published
+ * container port: the AgentCore `/ws` upgrade requires the
+ * `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header (and `Authorization`
+ * under a `customJwtAuthorizer`), but a browser `WebSocket` cannot set custom
+ * request headers. So a browser console connects to THIS header-less bridge,
+ * and the bridge opens a `ws` connection to the container with the headers
+ * injected (via {@link bridgeAgentCoreWs}), piping frames both ways.
+ *
+ * One container connection per inbound client connection; each inbound client
+ * gets its own AgentCore session id (a fresh UUID, unless one is pinned) so a
+ * browser tab is its own session — the way the cloud front door scopes them.
+ */
+
+const DEFAULT_PATH = '/ws';
+
+export interface AgentCoreWsBridgeServerConfig {
+  /** Host the container `/ws` is reachable on (the published-port host). */
+  containerHost: string;
+  /** Host port the container's `/ws` is published on. */
+  containerPort: number;
+  /** Bind host for the bridge server. Defaults to `127.0.0.1`. */
+  host?: string;
+  /** Bind port for the bridge server. Defaults to `0` (OS-assigned). */
+  port?: number;
+  /**
+   * Pin a single AgentCore session id for every inbound connection. When
+   * omitted, each inbound connection gets a fresh `randomUUID()` so each
+   * browser tab is its own session.
+   */
+  sessionId?: string;
+  /** `Authorization: Bearer <jwt>` injected on every container upgrade. */
+  authorization?: string;
+  /** URL path the bridge accepts upgrades on. Defaults to `/ws`. */
+  path?: string;
+  /** Injected WebSocket implementation for tests, threaded to the container leg. */
+  webSocketImpl?: typeof WebSocket;
+}
+
+export interface RunningAgentCoreWsBridge {
+  /** `ws://host:port/path` a client (browser) connects to. */
+  url: string;
+  /** The bound bridge port. */
+  port: number;
+  /** Close the bridge server + every live bridged connection. */
+  close(): Promise<void>;
+}
+
+function decodeBrowserFrame(data: RawData, isBinary: boolean): string {
+  if (typeof data === 'string') return data;
+  const buf = Buffer.isBuffer(data)
+    ? data
+    : Array.isArray(data)
+      ? Buffer.concat(data)
+      : Buffer.from(data);
+  // A text frame arrives as bytes too; decode either way (the wire framing over
+  // /ws is agent-defined, so we treat everything as UTF-8 text like the client).
+  void isBinary;
+  return buf.toString('utf-8');
+}
+
+/**
+ * Start the bridge server. Resolves once it is listening; the returned handle
+ * carries the connectable `url` and a `close()` that tears down the server and
+ * every live bridged connection.
+ */
+export function startAgentCoreWsBridge(
+  config: AgentCoreWsBridgeServerConfig
+): Promise<RunningAgentCoreWsBridge> {
+  const host = config.host ?? '127.0.0.1';
+  const path = config.path ?? DEFAULT_PATH;
+  const httpServer: Server = createServer((_req, res) => {
+    // The bridge speaks WebSocket only; a plain HTTP hit gets a hint.
+    res.writeHead(426, { 'Content-Type': 'text/plain' });
+    res.end('Upgrade required: connect over WebSocket.\n');
+  });
+  const wss = new WebSocketServer({ server: httpServer, path });
+  const liveCloses = new Set<() => void>();
+
+  wss.on('connection', (browser: WebSocket) => {
+    const sessionId = config.sessionId ?? randomUUID();
+    const handle = bridgeAgentCoreWs(config.containerHost, config.containerPort, {
+      sessionId,
+      ...(config.authorization && { authorization: config.authorization }),
+      ...(config.webSocketImpl && { webSocketImpl: config.webSocketImpl }),
+      onMessage: (text) => {
+        if (browser.readyState === browser.OPEN) browser.send(text);
+      },
+      onClose: () => {
+        try {
+          browser.close();
+        } catch {
+          /* already closing */
+        }
+      },
+      onError: (err) => {
+        // Surface the failure to the console, then drop the connection.
+        if (browser.readyState === browser.OPEN) {
+          try {
+            browser.send(`[bridge error] ${err.message}`);
+          } catch {
+            /* best effort */
+          }
+        }
+        try {
+          browser.close();
+        } catch {
+          /* already closing */
+        }
+      },
+    });
+    liveCloses.add(handle.close);
+
+    browser.on('message', (data: RawData, isBinary: boolean) => {
+      handle.send(decodeBrowserFrame(data, isBinary));
+    });
+    browser.on('close', () => {
+      liveCloses.delete(handle.close);
+      handle.close();
+    });
+    browser.on('error', () => {
+      liveCloses.delete(handle.close);
+      handle.close();
+    });
+  });
+
+  return new Promise<RunningAgentCoreWsBridge>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(config.port ?? 0, host, () => {
+      httpServer.removeListener('error', reject);
+      // A post-listen server error (rare socket-level failure) on this
+      // long-running server must not become an uncaught exception that crashes
+      // the process — log it instead. The serve command's signal handlers own
+      // teardown; a transient server error does not tear the bridge down.
+      httpServer.on('error', (err) =>
+        getLogger().debug(`agentcore-ws bridge server error: ${err.message}`)
+      );
+      const port = (httpServer.address() as AddressInfo).port;
+      resolve({
+        url: `ws://${host}:${port}${path}`,
+        port,
+        close: () =>
+          new Promise<void>((res) => {
+            for (const closeLeg of liveCloses) closeLeg();
+            liveCloses.clear();
+            wss.close(() => httpServer.close(() => res()));
+          }),
+      });
+    });
+  });
+}

--- a/src/local/agentcore-ws-client.ts
+++ b/src/local/agentcore-ws-client.ts
@@ -65,6 +65,155 @@ export interface AgentCoreWsResult {
 }
 
 /**
+ * Decode a `ws` {@link RawData} frame to UTF-8 text. `ws` delivers a Buffer by
+ * default (binaryType 'nodebuffer'); handle the fragments / ArrayBuffer shapes
+ * too so a frame is always decoded the same way regardless of source.
+ */
+function decodeWsFrame(data: RawData): string {
+  const buf = Buffer.isBuffer(data)
+    ? data
+    : Array.isArray(data)
+      ? Buffer.concat(data)
+      : Buffer.from(data);
+  return buf.toString('utf-8');
+}
+
+export interface BridgeAgentCoreWsOptions {
+  /** Value for the {@link AGENTCORE_SESSION_ID_HEADER} upgrade header. */
+  sessionId: string;
+  /**
+   * `Authorization: Bearer <jwt>` to send on the upgrade when the runtime
+   * declares a `customJwtAuthorizer`, forwarded the way the HTTP path forwards
+   * it to `/invocations`.
+   */
+  authorization?: string;
+  /** Sink for each received text frame, in arrival order (container -> caller). */
+  onMessage: (text: string) => void;
+  /** Fired once the upgrade completes and buffered frames have been flushed. */
+  onOpen?: () => void;
+  /** Fired when the container `/ws` socket closes (carries the close code). */
+  onClose?: (code?: number) => void;
+  /** Fired on a connection / send error. */
+  onError?: (err: Error) => void;
+  /** Optional `AbortSignal`; firing it closes the WS cleanly. */
+  abortSignal?: AbortSignal;
+  /** Injected WebSocket implementation for tests. Defaults to `ws`. */
+  webSocketImpl?: typeof WebSocket;
+}
+
+/**
+ * A live, caller-driven bridge to the container `/ws` endpoint. Unlike {@link
+ * invokeAgentCoreWs} (a fire-and-await-close promise that sends the `--event`
+ * as the first frame), this opens the socket and sends NOTHING on its own — the
+ * caller drives every frame via {@link AgentCoreWsBridgeHandle.send}. It is the
+ * relay primitive behind `cdkl start-agentcore`: a browser (which cannot set
+ * the session-id / Authorization upgrade headers) connects to a host bridge
+ * server, and the bridge forwards its frames here with the headers injected.
+ */
+export interface AgentCoreWsBridgeHandle {
+  /**
+   * Forward a text frame to the container. Frames sent before the upgrade
+   * completes are buffered and flushed in order on `open`.
+   */
+  send: (text: string) => void;
+  /** Close the container `/ws` socket. Idempotent. */
+  close: () => void;
+}
+
+/**
+ * Open `ws://host:port/ws` with the AgentCore session-id (+ optional
+ * `Authorization`) upgrade header and return a handle for bidirectional
+ * frame relay. Sends NO initial frame — the caller drives every frame. Each
+ * received frame is decoded to UTF-8 and passed to {@link
+ * BridgeAgentCoreWsOptions.onMessage}.
+ */
+export function bridgeAgentCoreWs(
+  host: string,
+  port: number,
+  options: BridgeAgentCoreWsOptions
+): AgentCoreWsBridgeHandle {
+  const Impl = options.webSocketImpl ?? WebSocket;
+  const url = `ws://${host}:${port}${WS_PATH}`;
+  const ws = new Impl(url, {
+    headers: {
+      [AGENTCORE_SESSION_ID_HEADER]: options.sessionId,
+      ...(options.authorization && { Authorization: options.authorization }),
+    },
+  });
+
+  let open = false;
+  let closed = false;
+  const pending: string[] = [];
+
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    options.abortSignal?.removeEventListener('abort', close);
+    try {
+      ws.close();
+    } catch {
+      /* already closing */
+    }
+  };
+
+  if (options.abortSignal) {
+    if (options.abortSignal.aborted) {
+      close();
+    } else {
+      options.abortSignal.addEventListener('abort', close, { once: true });
+    }
+  }
+
+  const sendFrame = (text: string): void => {
+    try {
+      ws.send(text);
+    } catch (err) {
+      options.onError?.(err instanceof Error ? err : new Error(String(err)));
+    }
+  };
+
+  ws.on('open', () => {
+    open = true;
+    // A close() that raced the upgrade: honor it now that the socket is open.
+    if (closed) {
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+      return;
+    }
+    options.onOpen?.();
+    for (const frame of pending.splice(0)) sendFrame(frame);
+  });
+  ws.on('message', (data: RawData) => options.onMessage(decodeWsFrame(data)));
+  ws.on('close', (code?: number) => {
+    closed = true;
+    // The container closing first (the common case — the agent ends the
+    // stream) must also detach the abort listener so a long-lived signal
+    // (e.g. a future --watch reload controller) does not retain this handle.
+    options.abortSignal?.removeEventListener('abort', close);
+    options.onClose?.(code);
+  });
+  ws.on('error', (err: Error) => options.onError?.(err));
+
+  return {
+    send: (text: string): void => {
+      // Post-close sends are intentionally dropped silently: the bridge
+      // server's browser `message` can fire between the container `close` and
+      // the browser-close propagation, and those frames have nowhere to go.
+      if (closed) return;
+      if (!open) {
+        pending.push(text);
+        return;
+      }
+      sendFrame(text);
+    },
+    close,
+  };
+}
+
+/**
  * Open `/ws`, send the event as the first frame, stream received frames to
  * `onMessage`, and resolve when the server closes. Rejects on a connection
  * error or when `timeoutMs` elapses before the server closes.

--- a/tests/integration/local-start-agentcore/.gitignore
+++ b/tests/integration/local-start-agentcore/.gitignore
@@ -1,0 +1,9 @@
+# The integ runner installs deps fresh via `vp install`, so the lockfile
+# is a build artifact, not a committed source (matches local-invoke-agentcore).
+pnpm-lock.yaml
+
+# Override the parent integ .gitignore so the agent container's source files
+# are tracked. The Dockerfile builds against /app/server.js in a node base
+# image: the AgentCore HTTP + /ws contract on 8080.
+!agent/*.js
+!agent/Dockerfile

--- a/tests/integration/local-start-agentcore/agent/Dockerfile
+++ b/tests/integration/local-start-agentcore/agent/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/docker/library/node:20-slim
+
+WORKDIR /app
+COPY server.js /app/server.js
+
+EXPOSE 8080
+CMD ["node", "/app/server.js"]

--- a/tests/integration/local-start-agentcore/agent/server.js
+++ b/tests/integration/local-start-agentcore/agent/server.js
@@ -1,0 +1,219 @@
+// Minimal Bedrock AgentCore Runtime agent for the cdkl invoke-agentcore integ
+// test. Serves the AgentCore HTTP contract on 0.0.0.0:8080:
+//   GET  /ping        -> 200 {"status":"Healthy", ...}
+//   POST /invocations -> by default echoes the request body, the received
+//                        session-id header, the received Authorization header,
+//                        and the injected GREETING env var. When the event has
+//                        {"stream": true}, instead responds with a
+//                        text/event-stream body emitting a few SSE frames with
+//                        small gaps, to exercise incremental streaming.
+//   GET  /ws (upgrade) -> bidirectional WebSocket: on the first received frame,
+//                        sends one JSON frame echoing the frame + session-id +
+//                        Authorization + GREETING, then a second text frame, then
+//                        closes — exercising `cdkl invoke-agentcore --ws`.
+//                        When the first frame's payload contains {"loop": true},
+//                        instead enters a REPL mode: echoes each subsequent text
+//                        frame as `loop-echo:<payload>` and stays open until the
+//                        client closes — exercising `--ws-interactive`.
+// The WebSocket handshake + framing is implemented over the built-in `http`
+// `upgrade` event so the container needs no npm deps.
+// Startup logs go to stderr so the host's stdout carries only the cdkl
+// result line.
+const http = require('node:http');
+const crypto = require('node:crypto');
+
+const SESSION_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+function streamSse(res) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  const tokens = ['hello', 'from', 'sse'];
+  let i = 0;
+  const timer = setInterval(() => {
+    if (i < tokens.length) {
+      res.write(`data: {"token":"${tokens[i]}"}\n\n`);
+      i += 1;
+      return;
+    }
+    res.write('data: [DONE]\n\n');
+    clearInterval(timer);
+    res.end();
+  }, 50);
+}
+
+// Encode a single unmasked text frame (server -> client). Payloads here are
+// small, so only the 7-bit and 16-bit length forms are needed.
+function encodeTextFrame(text) {
+  const payload = Buffer.from(text, 'utf-8');
+  const len = payload.length;
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x81, len]);
+  } else {
+    header = Buffer.from([0x81, 126, (len >> 8) & 0xff, len & 0xff]);
+  }
+  return Buffer.concat([header, payload]);
+}
+
+function encodeCloseFrame() {
+  // FIN + opcode 0x8 (close), zero-length payload.
+  return Buffer.from([0x88, 0x00]);
+}
+
+// Decode the FIRST complete frame in `buf`. Returns { opcode, payload,
+// frameLength } or null when the buffer does not yet hold a full frame (the
+// caller keeps accumulating until it does). `frameLength` is the number of
+// bytes the frame consumed, so the caller can advance past it. Client frames
+// are masked.
+function decodeFrame(buf) {
+  if (buf.length < 2) return null;
+  const opcode = buf[0] & 0x0f;
+  const masked = (buf[1] & 0x80) !== 0;
+  let len = buf[1] & 0x7f;
+  let offset = 2;
+  if (len === 126) {
+    if (buf.length < offset + 2) return null;
+    len = buf.readUInt16BE(offset);
+    offset += 2;
+  } else if (len === 127) {
+    if (buf.length < offset + 8) return null;
+    len = Number(buf.readBigUInt64BE(offset));
+    offset += 8;
+  }
+  let maskKey;
+  if (masked) {
+    if (buf.length < offset + 4) return null;
+    maskKey = buf.subarray(offset, offset + 4);
+    offset += 4;
+  }
+  if (buf.length < offset + len) return null;
+  const payload = Buffer.from(buf.subarray(offset, offset + len));
+  if (masked) {
+    for (let i = 0; i < payload.length; i += 1) payload[i] ^= maskKey[i % 4];
+  }
+  return { opcode, payload, frameLength: offset + len };
+}
+
+function handleUpgrade(req, socket) {
+  const key = req.headers['sec-websocket-key'];
+  if (!key) {
+    socket.destroy();
+    return;
+  }
+  const accept = crypto
+    .createHash('sha1')
+    .update(key + WS_GUID)
+    .digest('base64');
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+  );
+
+  let buf = Buffer.alloc(0);
+  let firstFrameSeen = false;
+  let loopMode = false;
+  socket.on('data', (chunk) => {
+    // A frame can span TCP reads (or several frames can share one read), so
+    // accumulate and drain complete frames as they arrive.
+    buf = Buffer.concat([buf, chunk]);
+    let frame;
+    while ((frame = decodeFrame(buf)) !== null) {
+      buf = buf.subarray(frame.frameLength);
+      if (frame.opcode === 0x8) {
+        socket.end();
+        return;
+      }
+      if (frame.opcode !== 0x1) continue; // skip ping/pong/continuation control frames
+      const payloadText = frame.payload.toString('utf-8');
+      if (!firstFrameSeen) {
+        firstFrameSeen = true;
+        let echoed;
+        try {
+          echoed = JSON.parse(payloadText || '{}');
+        } catch {
+          echoed = payloadText;
+        }
+        const reply = JSON.stringify({
+          ws: true,
+          echoed,
+          sessionId: req.headers[SESSION_HEADER] ?? null,
+          authorization: req.headers['authorization'] ?? null,
+          greeting: process.env.GREETING ?? 'unset',
+        });
+        socket.write(encodeTextFrame(reply));
+        if (echoed && typeof echoed === 'object' && echoed.loop === true) {
+          // REPL mode: echo each subsequent text frame as `loop-echo:<text>`
+          // and stay open until the client sends a close frame.
+          loopMode = true;
+          continue;
+        }
+        socket.write(encodeTextFrame('ws-frame-2'));
+        socket.write(encodeCloseFrame());
+        socket.end();
+        return;
+      }
+      if (loopMode) {
+        socket.write(encodeTextFrame(`loop-echo:${payloadText}`));
+      }
+    }
+  });
+  socket.on('error', () => socket.destroy());
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/ping') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'Healthy', time_of_last_update: Math.floor(Date.now() / 1000) }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/invocations') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      let echoed;
+      try {
+        echoed = JSON.parse(body || '{}');
+      } catch {
+        echoed = body;
+      }
+      if (echoed && typeof echoed === 'object' && echoed.stream === true) {
+        streamSse(res);
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          echoed,
+          sessionId: req.headers[SESSION_HEADER] ?? null,
+          authorization: req.headers['authorization'] ?? null,
+          greeting: process.env.GREETING ?? 'unset',
+        })
+      );
+    });
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'not found' }));
+});
+
+server.on('upgrade', (req, socket) => {
+  if (req.url === '/ws') {
+    handleUpgrade(req, socket);
+    return;
+  }
+  socket.destroy();
+});
+
+server.listen(8080, '0.0.0.0', () => {
+  console.error('agent listening on 0.0.0.0:8080');
+});

--- a/tests/integration/local-start-agentcore/bin/app.ts
+++ b/tests/integration/local-start-agentcore/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalStartAgentCoreStack } from '../lib/local-start-agentcore-stack.ts';
+
+const app = new cdk.App();
+
+new LocalStartAgentCoreStack(app, 'CdkLocalStartAgentCoreFixture', {
+  description: 'Fixture stack for cdkl start-agentcore integ test',
+});

--- a/tests/integration/local-start-agentcore/cdk.json
+++ b/tests/integration/local-start-agentcore/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-start-agentcore/lib/local-start-agentcore-stack.ts
+++ b/tests/integration/local-start-agentcore/lib/local-start-agentcore-stack.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Fixture stack for the `cdkl start-agentcore` integ test.
+ *
+ * One HTTP-protocol AgentCore `Runtime` whose container (built from the local
+ * `agent/` Dockerfile) serves GET /ping + the bidirectional /ws WebSocket on
+ * 8080. The /ws handler echoes the first frame, and when that frame carries
+ * `{"loop": true}` it enters a REPL mode that echoes each subsequent frame as
+ * `loop-echo:<text>` until the client closes.
+ *
+ * No AWS deploy required. The integ exercises the local-build serve path:
+ * `cdkl start-agentcore` builds the asset, boots the container, waits for
+ * /ping, and runs the host WebSocket bridge that injects the session-id on the
+ * container /ws upgrade — so a header-less client (the browser path) can hold
+ * an interactive multi-frame session.
+ */
+export class LocalStartAgentCoreStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    new Runtime(this, 'EchoAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromAsset(path.join(__dirname, '../agent'), {
+        platform: Platform.LINUX_ARM64,
+      }),
+      environmentVariables: { GREETING: 'hello-from-agent' },
+    });
+  }
+}

--- a/tests/integration/local-start-agentcore/package.json
+++ b/tests/integration/local-start-agentcore/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-start-agentcore",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl start-agentcore (/ws bridge serve)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.257.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
+}

--- a/tests/integration/local-start-agentcore/tsconfig.json
+++ b/tests/integration/local-start-agentcore/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-start-agentcore/verify.sh
+++ b/tests/integration/local-start-agentcore/verify.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Real-Docker validation for `cdkl start-agentcore` — the long-running serve
+# that boots a Bedrock AgentCore Runtime container and fronts its /ws
+# WebSocket endpoint with a host bridge so a header-less client (the browser
+# path) can hold an interactive multi-frame session.
+#
+# Fully local — no AWS resources are deployed. The fixture's single
+# HTTP-protocol Runtime (EchoAgent) is built from a local Dockerfile; the
+# container serves GET /ping + a /ws REPL. The probe connects with the Node
+# global WebSocket (no custom headers, exactly like a browser) and asserts:
+#   - the bridge injects a session-id on the container /ws upgrade
+#     (the header-less client never sent one)
+#   - a second frame round-trips through the bridge (loop-echo:<text>)
+# Then SIGTERM is sent and we assert no `cdkl-agentcore-*` container leaks.
+#
+# Run via `/run-integ local-start-agentcore` (recommended) or directly:
+#
+#     bash tests/integration/local-start-agentcore/verify.sh
+#
+# Requires Docker.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-start-agentcore"
+CLI="node ${REPO_ROOT}/dist/cli.js"
+STACK="CdkLocalStartAgentCoreFixture"
+TARGET="${STACK}/EchoAgent"
+BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
+
+CDKL_PID=""
+OUT_FILE="$(mktemp)"
+
+stop_server() {
+  if [ -n "${CDKL_PID}" ] && kill -0 "${CDKL_PID}" 2>/dev/null; then
+    kill -TERM "${CDKL_PID}" 2>/dev/null || true
+    for _ in $(seq 1 80); do kill -0 "${CDKL_PID}" 2>/dev/null || break; sleep 0.25; done
+    kill -KILL "${CDKL_PID}" 2>/dev/null || true
+  fi
+  CDKL_PID=""
+}
+
+cleanup() {
+  rc=$?
+  stop_server
+  rm -f "${OUT_FILE}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  echo "[verify] FAIL: $*" >&2
+  echo "----- cdkl output -----" >&2
+  cat "${OUT_FILE}" >&2 || true
+  exit 1
+}
+
+echo "[verify] step 1: install + build cdk-local"
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
+cd "${TEST_DIR}"
+[ -d node_modules ] || vp install --prefer-offline
+
+echo "[verify] step 2: Docker available + base image present"
+docker version --format '{{.Server.Version}}' >/dev/null
+docker pull --platform linux/arm64 "${BASE_IMAGE}" >/dev/null
+
+echo "[verify] step 3: boot \`cdkl start-agentcore ${TARGET}\`"
+: > "${OUT_FILE}"
+${CLI} start-agentcore "${TARGET}" --host 127.0.0.1 --port 0 > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+
+WS_URL=""
+for _ in $(seq 1 480); do
+  # Ready line: "Server listening on ws://127.0.0.1:<port>/ws  (EchoAgent (AgentCore WebSocket))"
+  line="$(grep -Eo 'Server listening on ws://[^ ]+/ws' "${OUT_FILE}" | head -1 || true)"
+  if [ -n "${line}" ]; then WS_URL="${line#Server listening on }"; break; fi
+  kill -0 "${CDKL_PID}" 2>/dev/null || fail "start-agentcore exited before it was ready"
+  sleep 0.5
+done
+[ -n "${WS_URL}" ] || fail "start-agentcore did not print its ws:// ready banner in time"
+echo "[verify]   ready: ${WS_URL}"
+
+echo "[verify] step 4: header-less WebSocket probe (browser path) round-trips through the bridge"
+if ! node ws-probe.mjs "${WS_URL}"; then
+  fail "WebSocket probe did not succeed"
+fi
+
+echo "[verify] step 5: SIGTERM tears the container down (no orphan)"
+stop_server
+# Give Docker a moment to reflect the removal.
+sleep 1
+ORPHANS="$(docker ps -a --filter name=cdkl-agentcore- --format '{{.Names}}' || true)"
+[ -z "${ORPHANS}" ] || fail "leftover agent container(s) after shutdown: ${ORPHANS}"
+
+echo "[verify] PASS: start-agentcore served /ws through the bridge (session-id injected, frame round-trip) and cleaned up its container"

--- a/tests/integration/local-start-agentcore/ws-probe.mjs
+++ b/tests/integration/local-start-agentcore/ws-probe.mjs
@@ -1,0 +1,67 @@
+// Header-less WebSocket probe for the `cdkl start-agentcore` integ test.
+//
+// Uses the Node global `WebSocket` (browser-compatible API) — which, like a
+// browser, CANNOT set custom request headers. This is the whole point: it
+// proves the host bridge injects the AgentCore session-id on the container
+// /ws upgrade so a header-less client can hold a session.
+//
+// Drives the agent's /ws REPL mode:
+//   1. send `{"loop":true}` as the first frame
+//   2. assert the reply echoes our frame AND carries a non-null sessionId
+//      (the bridge-injected UUID — we never sent one)
+//   3. send a second frame `hello-2`
+//   4. assert the agent echoes it back as `loop-echo:hello-2`
+//
+// Prints `PROBE_OK` and exits 0 on success; prints a reason and exits 1
+// otherwise (including a hard timeout).
+//
+// Usage: node ws-probe.mjs ws://127.0.0.1:<port>/ws
+
+const url = process.argv[2];
+if (!url) {
+  console.error('usage: node ws-probe.mjs <ws-url>');
+  process.exit(1);
+}
+
+const fail = (msg) => {
+  console.error(`PROBE_FAIL: ${msg}`);
+  process.exit(1);
+};
+
+const timer = setTimeout(() => fail('timed out after 15s'), 15000);
+
+const ws = new WebSocket(url);
+let stage = 0;
+
+ws.addEventListener('open', () => {
+  ws.send(JSON.stringify({ loop: true }));
+});
+
+ws.addEventListener('message', (ev) => {
+  const text = typeof ev.data === 'string' ? ev.data : Buffer.from(ev.data).toString('utf-8');
+  if (stage === 0) {
+    let reply;
+    try {
+      reply = JSON.parse(text);
+    } catch {
+      return fail(`first frame was not JSON: ${text}`);
+    }
+    if (reply.ws !== true) return fail(`first frame missing ws:true: ${text}`);
+    if (!reply.sessionId) return fail(`bridge did not inject a session id: ${text}`);
+    stage = 1;
+    ws.send('hello-2');
+    return;
+  }
+  if (stage === 1) {
+    if (text !== 'loop-echo:hello-2') return fail(`expected loop-echo:hello-2, got: ${text}`);
+    clearTimeout(timer);
+    console.log('PROBE_OK');
+    ws.close();
+    process.exit(0);
+  }
+});
+
+ws.addEventListener('error', (ev) => fail(`socket error: ${ev.message ?? ev.type ?? 'unknown'}`));
+ws.addEventListener('close', () => {
+  if (stage < 2) fail('socket closed before the probe completed');
+});

--- a/tests/unit/cli/local-start-agentcore.test.ts
+++ b/tests/unit/cli/local-start-agentcore.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import {
+  createLocalStartAgentCoreCommand,
+  addStartAgentCoreSpecificOptions,
+  assertAgentCoreWsServable,
+} from '../../../src/cli/commands/local-start-agentcore.js';
+import { Command } from 'commander';
+import { getEmbedConfig, setEmbedConfig } from '../../../src/local/embed-config.js';
+import {
+  AGENTCORE_HTTP_PROTOCOL,
+  AGENTCORE_AGUI_PROTOCOL,
+  AGENTCORE_MCP_PROTOCOL,
+  AGENTCORE_A2A_PROTOCOL,
+} from '../../../src/local/agentcore-resolver.js';
+
+// Instantiating a command factory mutates the global embed config as a side
+// effect; snapshot + restore so introspecting it here cannot wipe host branding.
+const saved = getEmbedConfig();
+afterEach(() => setEmbedConfig(saved));
+
+describe('createLocalStartAgentCoreCommand', () => {
+  it('builds a "start-agentcore" command with a [target] argument', () => {
+    const cmd = createLocalStartAgentCoreCommand();
+    expect(cmd.name()).toBe('start-agentcore');
+    expect(cmd.description()).toMatch(/AgentCore/i);
+    // [target] is optional (interactive picker in a TTY when omitted).
+    expect(cmd.registeredArguments.map((a) => a.required)).toEqual([false]);
+  });
+
+  it('registers the bridge + boot flags via addStartAgentCoreSpecificOptions', () => {
+    const cmd = new Command('start-agentcore');
+    addStartAgentCoreSpecificOptions(cmd);
+    const flags = cmd.options.map((o) => o.long);
+    for (const f of [
+      '--port',
+      '--host',
+      '--session-id',
+      '--bearer-token',
+      '--no-verify-auth',
+      '--env-vars',
+      '--platform',
+      '--no-pull',
+      '--no-build',
+      '--container-host',
+      '--timeout',
+      '--assume-role',
+      '--ecr-role-arn',
+      '--from-cfn-stack',
+      '--stack-region',
+    ]) {
+      expect(flags, `missing ${f}`).toContain(f);
+    }
+    // Invoke-only flags must NOT leak onto the serve command.
+    expect(flags).not.toContain('--ws');
+    expect(flags).not.toContain('--sigv4');
+  });
+
+  it('defaults --port to 0 and --host to 127.0.0.1', () => {
+    const cmd = new Command('start-agentcore');
+    addStartAgentCoreSpecificOptions(cmd);
+    const port = cmd.options.find((o) => o.long === '--port');
+    const host = cmd.options.find((o) => o.long === '--host');
+    expect(port?.defaultValue).toBe(0);
+    expect(host?.defaultValue).toBe('127.0.0.1');
+  });
+
+  it('defaults --timeout to 120000', () => {
+    const cmd = new Command('start-agentcore');
+    addStartAgentCoreSpecificOptions(cmd);
+    const timeout = cmd.options.find((o) => o.long === '--timeout');
+    expect(timeout?.defaultValue).toBe(120000);
+  });
+
+  it('--port parser rejects out-of-range values', () => {
+    const cmd = new Command('start-agentcore').exitOverride();
+    addStartAgentCoreSpecificOptions(cmd);
+    cmd.action(() => {});
+    expect(() => cmd.parse(['--port', '70000'], { from: 'user' })).toThrow(/0-65535/);
+  });
+});
+
+describe('assertAgentCoreWsServable', () => {
+  it('accepts HTTP and AGUI runtimes', () => {
+    expect(() =>
+      assertAgentCoreWsServable({ protocol: AGENTCORE_HTTP_PROTOCOL, logicalId: 'A' })
+    ).not.toThrow();
+    expect(() =>
+      assertAgentCoreWsServable({ protocol: AGENTCORE_AGUI_PROTOCOL, logicalId: 'A' })
+    ).not.toThrow();
+  });
+
+  it('rejects MCP and A2A runtimes with an actionable error', () => {
+    expect(() =>
+      assertAgentCoreWsServable({ protocol: AGENTCORE_MCP_PROTOCOL, logicalId: 'McpAgent' })
+    ).toThrow(/McpAgent.*no \/ws|no \/ws.*McpAgent|MCP runtime/);
+    expect(() =>
+      assertAgentCoreWsServable({ protocol: AGENTCORE_A2A_PROTOCOL, logicalId: 'A2aAgent' })
+    ).toThrow(/A2A/);
+  });
+});

--- a/tests/unit/local/agentcore-ws-bridge.test.ts
+++ b/tests/unit/local/agentcore-ws-bridge.test.ts
@@ -1,0 +1,230 @@
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { WebSocket, WebSocketServer } from 'ws';
+import { startAgentCoreWsBridge } from '../../../src/local/agentcore-ws-bridge.js';
+import { AGENTCORE_SESSION_ID_HEADER } from '../../../src/local/agentcore-client.js';
+
+/**
+ * `startAgentCoreWsBridge` is the host WebSocket server behind
+ * `cdkl start-agentcore`. It is exercised end to end: a real in-process `ws`
+ * server stands in for the AgentCore container `/ws`, and a real `ws` client
+ * (the "browser", deliberately sending NO custom headers) connects to the
+ * bridge. The bridge must inject the session-id / Authorization on the
+ * container leg and pipe frames both ways.
+ */
+
+let containers: WebSocketServer[] = [];
+let bridges: Array<{ close(): Promise<void> }> = [];
+let clients: WebSocket[] = [];
+
+afterEach(async () => {
+  for (const c of clients) {
+    try {
+      c.close();
+    } catch {
+      /* ignore */
+    }
+  }
+  clients = [];
+  await Promise.all(bridges.map((b) => b.close().catch(() => undefined)));
+  bridges = [];
+  await Promise.all(containers.map((s) => new Promise<void>((r) => s.close(() => r()))));
+  containers = [];
+});
+
+interface FakeContainer {
+  port: number;
+  received: string[];
+  headersFor: () => Record<string, string | string[] | undefined>;
+}
+
+/** Start a fake container `/ws` server that echoes each frame as `echo:<frame>`. */
+async function startFakeContainer(): Promise<FakeContainer> {
+  const wss = new WebSocketServer({ port: 0, path: '/ws' });
+  containers.push(wss);
+  const received: string[] = [];
+  let headers: Record<string, string | string[] | undefined> = {};
+  wss.on('connection', (ws, req) => {
+    headers = req.headers;
+    ws.on('message', (data) => {
+      const text = data.toString();
+      received.push(text);
+      ws.send(`echo:${text}`);
+    });
+  });
+  await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
+  return { port: (wss.address() as AddressInfo).port, received, headersFor: () => headers };
+}
+
+/** Connect a header-less browser client to the bridge URL. */
+function connectBrowser(url: string): WebSocket {
+  const ws = new WebSocket(url);
+  clients.push(ws);
+  return ws;
+}
+
+describe('startAgentCoreWsBridge', () => {
+  it('round-trips a frame browser -> bridge -> container -> bridge -> browser, injecting the session-id', async () => {
+    const container = await startFakeContainer();
+    const bridge = await startAgentCoreWsBridge({
+      containerHost: '127.0.0.1',
+      containerPort: container.port,
+    });
+    bridges.push(bridge);
+    expect(bridge.url).toMatch(/^ws:\/\/127\.0\.0\.1:\d+\/ws$/);
+
+    const browser = connectBrowser(bridge.url);
+    const echoed = await new Promise<string>((resolve, reject) => {
+      browser.on('open', () => browser.send('hello'));
+      browser.on('message', (d) => resolve(d.toString()));
+      browser.on('error', reject);
+    });
+
+    expect(echoed).toBe('echo:hello');
+    expect(container.received).toEqual(['hello']);
+    // The header-less browser never set it; the bridge injected a UUID.
+    const sid = container.headersFor()[AGENTCORE_SESSION_ID_HEADER.toLowerCase()];
+    expect(typeof sid).toBe('string');
+    expect(sid).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('pins the configured session-id and injects the Authorization header', async () => {
+    const container = await startFakeContainer();
+    const bridge = await startAgentCoreWsBridge({
+      containerHost: '127.0.0.1',
+      containerPort: container.port,
+      sessionId: 'pinned-session',
+      authorization: 'Bearer jwt-123',
+    });
+    bridges.push(bridge);
+
+    const browser = connectBrowser(bridge.url);
+    await new Promise<void>((resolve, reject) => {
+      browser.on('open', () => browser.send('ping'));
+      browser.on('message', () => resolve());
+      browser.on('error', reject);
+    });
+
+    expect(container.headersFor()[AGENTCORE_SESSION_ID_HEADER.toLowerCase()]).toBe('pinned-session');
+    expect(container.headersFor()['authorization']).toBe('Bearer jwt-123');
+  });
+
+  it('gives each browser connection its own session id', async () => {
+    const sessions: string[] = [];
+    const wss = new WebSocketServer({ port: 0, path: '/ws' });
+    containers.push(wss);
+    wss.on('connection', (ws, req) => {
+      sessions.push(String(req.headers[AGENTCORE_SESSION_ID_HEADER.toLowerCase()]));
+      ws.on('message', (d) => ws.send(d.toString()));
+    });
+    await new Promise<void>((r) => wss.on('listening', () => r()));
+    const containerPort = (wss.address() as AddressInfo).port;
+
+    const bridge = await startAgentCoreWsBridge({ containerHost: '127.0.0.1', containerPort });
+    bridges.push(bridge);
+
+    const drive = (): Promise<void> =>
+      new Promise<void>((resolve, reject) => {
+        const b = connectBrowser(bridge.url);
+        b.on('open', () => b.send('x'));
+        b.on('message', () => resolve());
+        b.on('error', reject);
+      });
+    await drive();
+    await drive();
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]).not.toBe(sessions[1]);
+  });
+
+  it('closes the browser socket when the container closes', async () => {
+    const wss = new WebSocketServer({ port: 0, path: '/ws' });
+    containers.push(wss);
+    wss.on('connection', (ws) => ws.close());
+    await new Promise<void>((r) => wss.on('listening', () => r()));
+    const containerPort = (wss.address() as AddressInfo).port;
+
+    const bridge = await startAgentCoreWsBridge({ containerHost: '127.0.0.1', containerPort });
+    bridges.push(bridge);
+
+    const browser = connectBrowser(bridge.url);
+    const closed = await new Promise<boolean>((resolve, reject) => {
+      browser.on('close', () => resolve(true));
+      browser.on('error', reject);
+    });
+    expect(closed).toBe(true);
+  });
+
+  it('notifies the browser and closes when the container leg fails', async () => {
+    // No container server on this port — the bridge's container leg errors,
+    // which must surface a `[bridge error]` frame to the browser then close it.
+    const bridge = await startAgentCoreWsBridge({
+      containerHost: '127.0.0.1',
+      containerPort: 1,
+    });
+    bridges.push(bridge);
+
+    const browser = connectBrowser(bridge.url);
+    const frames: string[] = [];
+    const closed = await new Promise<boolean>((resolve, reject) => {
+      browser.on('message', (d) => frames.push(d.toString()));
+      browser.on('close', () => resolve(true));
+      browser.on('error', reject);
+    });
+    expect(closed).toBe(true);
+    // The error notice is best-effort (may race the close), so assert only the
+    // shape if any frame arrived.
+    if (frames.length > 0) expect(frames[0]).toMatch(/^\[bridge error\]/);
+  });
+
+  it('serves on a custom path', async () => {
+    const container = await startFakeContainer();
+    const bridge = await startAgentCoreWsBridge({
+      containerHost: '127.0.0.1',
+      containerPort: container.port,
+      path: '/agent-ws',
+    });
+    bridges.push(bridge);
+    expect(bridge.url).toMatch(/\/agent-ws$/);
+
+    const browser = connectBrowser(bridge.url);
+    const echoed = await new Promise<string>((resolve, reject) => {
+      browser.on('open', () => browser.send('hi'));
+      browser.on('message', (d) => resolve(d.toString()));
+      browser.on('error', reject);
+    });
+    expect(echoed).toBe('echo:hi');
+  });
+
+  it('answers a plain HTTP request with 426 Upgrade Required', async () => {
+    const container = await startFakeContainer();
+    const bridge = await startAgentCoreWsBridge({
+      containerHost: '127.0.0.1',
+      containerPort: container.port,
+    });
+    bridges.push(bridge);
+
+    const httpUrl = bridge.url.replace(/^ws:/, 'http:');
+    const res = await fetch(httpUrl);
+    expect(res.status).toBe(426);
+    await res.text();
+  });
+
+  it('close() stops accepting new connections', async () => {
+    const container = await startFakeContainer();
+    const bridge = await startAgentCoreWsBridge({
+      containerHost: '127.0.0.1',
+      containerPort: container.port,
+    });
+    const { url } = bridge;
+    await bridge.close();
+
+    const failed = await new Promise<boolean>((resolve) => {
+      const b = new WebSocket(url);
+      clients.push(b);
+      b.on('open', () => resolve(false));
+      b.on('error', () => resolve(true));
+    });
+    expect(failed).toBe(true);
+  });
+});

--- a/tests/unit/local/agentcore-ws-client.test.ts
+++ b/tests/unit/local/agentcore-ws-client.test.ts
@@ -1,7 +1,7 @@
 import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 import { WebSocketServer, type WebSocket } from 'ws';
-import { invokeAgentCoreWs } from '../../../src/local/agentcore-ws-client.js';
+import { invokeAgentCoreWs, bridgeAgentCoreWs } from '../../../src/local/agentcore-ws-client.js';
 import { AGENTCORE_SESSION_ID_HEADER } from '../../../src/local/agentcore-client.js';
 
 /**
@@ -272,5 +272,187 @@ describe('invokeAgentCoreWs', () => {
         })
       ).rejects.toThrow(/boom from frame source/);
     });
+  });
+});
+
+/**
+ * `bridgeAgentCoreWs` is the caller-driven relay primitive behind
+ * `cdkl start-agentcore`. Unlike {@link invokeAgentCoreWs} it sends NO initial
+ * frame — every frame is driven by the caller via the handle. Tested against a
+ * real in-process `ws` server (the container stand-in) so the upgrade headers +
+ * framing are exercised end to end.
+ */
+describe('bridgeAgentCoreWs', () => {
+  let liveHandles: Array<{ close: () => void }> = [];
+  afterEach(() => {
+    for (const h of liveHandles) {
+      try {
+        h.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    liveHandles = [];
+  });
+  const track = <T extends { close: () => void }>(h: T): T => {
+    liveHandles.push(h);
+    return h;
+  };
+
+  /** Start a server that records every frame it receives + the upgrade headers. */
+  async function startRecordingServer(
+    onConn?: (ws: WebSocket) => void
+  ): Promise<{
+    port: number;
+    received: string[];
+    lastHeaders: () => Record<string, string | string[] | undefined>;
+    sendToClient: (text: string) => void;
+    closeClient: () => void;
+  }> {
+    const wss = new WebSocketServer({ port: 0, path: '/ws' });
+    servers.push(wss);
+    const received: string[] = [];
+    let headers: Record<string, string | string[] | undefined> = {};
+    let live: WebSocket | undefined;
+    wss.on('connection', (ws, req) => {
+      headers = req.headers;
+      live = ws;
+      ws.on('message', (data) => received.push(data.toString()));
+      onConn?.(ws);
+    });
+    await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
+    const port = (wss.address() as AddressInfo).port;
+    return {
+      port,
+      received,
+      lastHeaders: () => headers,
+      sendToClient: (text) => live?.send(text),
+      closeClient: () => live?.close(),
+    };
+  }
+
+  const tick = (ms = 60): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+  it('does NOT auto-send any initial frame on open', async () => {
+    const server = await startRecordingServer();
+    const opened = new Promise<void>((resolve) => {
+      track(
+        bridgeAgentCoreWs('127.0.0.1', server.port, {
+          sessionId: 's1',
+          onMessage: () => {},
+          onOpen: () => resolve(),
+        })
+      );
+    });
+    await opened;
+    await tick();
+    expect(server.received).toEqual([]);
+  });
+
+  it('sets the session-id (+ Authorization) on the upgrade and forwards a frame to the container', async () => {
+    const server = await startRecordingServer();
+    const handle = track(
+      bridgeAgentCoreWs('127.0.0.1', server.port, {
+        sessionId: 'sess-42',
+        authorization: 'Bearer tok',
+        onMessage: () => {},
+      })
+    );
+    // Sent before open — must be buffered and flushed in order on open.
+    handle.send('first');
+    handle.send('second');
+    await tick(120);
+    // Node lowercases incoming header names.
+    expect(server.lastHeaders()[AGENTCORE_SESSION_ID_HEADER.toLowerCase()]).toBe('sess-42');
+    expect(server.lastHeaders()['authorization']).toBe('Bearer tok');
+    expect(server.received).toEqual(['first', 'second']);
+    handle.close();
+  });
+
+  it('forwards each container frame to onMessage', async () => {
+    const frames: string[] = [];
+    const server = await startRecordingServer((ws) => {
+      ws.send('from-container-1');
+      ws.send('from-container-2');
+    });
+    await new Promise<void>((resolve) => {
+      let n = 0;
+      track(
+        bridgeAgentCoreWs('127.0.0.1', server.port, {
+          sessionId: 's',
+          onMessage: (t) => {
+            frames.push(t);
+            if (++n === 2) resolve();
+          },
+        })
+      );
+    });
+    expect(frames).toEqual(['from-container-1', 'from-container-2']);
+  });
+
+  it('fires onClose when the container closes the socket', async () => {
+    const server = await startRecordingServer((ws) => ws.close());
+    const closed = await new Promise<boolean>((resolve) => {
+      track(
+        bridgeAgentCoreWs('127.0.0.1', server.port, {
+          sessionId: 's',
+          onMessage: () => {},
+          onClose: () => resolve(true),
+        })
+      );
+    });
+    expect(closed).toBe(true);
+  });
+
+  it('close() tears the container socket down (onClose fires, later sends are dropped)', async () => {
+    const server = await startRecordingServer();
+    const events: string[] = [];
+    const handle = track(
+      bridgeAgentCoreWs('127.0.0.1', server.port, {
+        sessionId: 's',
+        onMessage: () => {},
+        onOpen: () => events.push('open'),
+        onClose: () => events.push('close'),
+      })
+    );
+    await tick(80);
+    handle.close();
+    await tick(80);
+    handle.send('after-close'); // dropped — must not reach the server
+    await tick(60);
+    expect(events).toEqual(['open', 'close']);
+    expect(server.received).toEqual([]);
+  });
+
+  it('fires onError when the container connection cannot be established', async () => {
+    // Point at a port with no listener — the `ws` connect fails, surfacing
+    // onError (the failure path the bridge server turns into a browser notice).
+    const err = await new Promise<Error>((resolve) => {
+      track(
+        bridgeAgentCoreWs('127.0.0.1', 1, {
+          sessionId: 's',
+          onMessage: () => {},
+          onError: (e) => resolve(e),
+        })
+      );
+    });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('closes cleanly when a pre-fired abort signal is supplied', async () => {
+    const server = await startRecordingServer();
+    const controller = new AbortController();
+    controller.abort();
+    const handle = track(
+      bridgeAgentCoreWs('127.0.0.1', server.port, {
+        sessionId: 's',
+        onMessage: () => {},
+        abortSignal: controller.signal,
+      })
+    );
+    await tick(80);
+    handle.send('never'); // closed already → dropped
+    await tick(60);
+    expect(server.received).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Adds `cdkl start-agentcore <target>` — the long-running serve counterpart of the
single-shot `cdkl invoke-agentcore`. It boots a Bedrock AgentCore Runtime
container once (reusing invoke-agentcore's image / env / `--from-cfn-stack` /
`--assume-role` / `--bearer-token` resolution) and serves the agent's
bidirectional `/ws` WebSocket endpoint behind a host WebSocket **bridge**.

**Why a bridge.** The `/ws` upgrade requires the
`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header (and `Authorization` under
a `customJwtAuthorizer`), but a browser `WebSocket` cannot set custom request
headers. The bridge accepts a header-less client and opens a `ws` connection to
the container with those headers injected (a fresh session-id UUID per inbound
connection, unless `--session-id` pins one), piping frames both ways. HTTP /
AGUI protocols only — MCP / A2A have no `/ws` and are rejected up front.

This is the CLI half of the AgentCore-`/ws`-in-`cdkl studio` work; the studio
`agentcore-ws` serve kind that spawns this command is a follow-up PR.

## Changes

- `bridgeAgentCoreWs` — new caller-driven relay primitive in
  `agentcore-ws-client.ts` (opens the container `/ws` with headers injected,
  sends **no** initial frame). `invokeAgentCoreWs` is unchanged.
- `startAgentCoreWsBridge` — new host bridge server (`agentcore-ws-bridge.ts`).
- `createLocalStartAgentCoreCommand` + `addStartAgentCoreSpecificOptions`,
  registered in the CLI, exported from `index.ts`; bridge primitives + helper
  exported from `internal.ts`.
- Unit tests (32) for the bridge primitive, bridge server, and command factory.
- New integ fixture `local-start-agentcore`: a real-Docker run that drives the
  browser path with a header-less `WebSocket` probe, asserting the bridge
  injects the session-id and round-trips a frame, then verifies no orphan
  container after SIGTERM.
- README / `.claude/CLAUDE.md` / `docs/cli-reference.md` updated.

## Test plan

- `vp run check` / `vp run build` / `vp run test` (2894 unit tests) green.
- `/run-integ local-start-agentcore` — PASS (real Docker; header-less probe
  round-trips through the bridge; 0 orphan containers / networks).
- 3-axis review (spec / code / test): spec CLEAN; code review fixes applied
  (`--timeout` now threaded to the `/ping` probe; the bridge primitive's abort
  listener is detached on natural container close); test review gaps closed
  (added `onError`-path tests for both the primitive and the server, a custom
  `path` test, and `--timeout` default assertion).

## cdkd parity

New subcommand factory (`createLocalStartAgentCoreCommand`, exported from
`index.ts`), new options (all inside `addStartAgentCoreSpecificOptions`), and new
public helpers (`startAgentCoreWsBridge` / `bridgeAgentCoreWs` /
`addStartAgentCoreSpecificOptions`, exported from `internal.ts`). A host CLI
embedding cdk-local can wrap the new subcommand and inherit the option block.
No behavior change to existing commands (the only edit to
`local-invoke-agentcore.ts` is exporting its options interface).

## Known cost

The command's boot-failure teardown branch (a `/ping` / bridge-start failure
after the container is booted -> stop the container, rethrow) is covered by the
real-Docker integ happy path and verified by code review, but not by a dedicated
unit test (it would need ~10 module mocks and fights `withErrorHandling`'s
`process.exit`). Accepted as-is for this PR.
