### PR TITLE
fix(studio): keep the Stop "Stopping..." affordance visible for a minimum window

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -682,7 +682,12 @@ compute-locally category for Lambda + API Gateway).
   `running` with no port). The control surfaces transient in-progress states
   (issue #394): a Stop in flight shows "Stopping..." (disabled) until the
   `stopped` / `error` serve event settles it (tracked in a client-side
-  `stoppingIds` set, cleared in `onServeEvent`), and a still-booting serve shows
+  `stoppingIds` set, settled in `onServeEvent` via `settleStoppingTransient`
+  with a `MIN_STOPPING_MS` floor so a near-instant teardown — a `start-api` /
+  pure-S3 `cloudfront` serve with no warmed containers tears down in tens of
+  ms — still shows the affordance instead of flipping straight back to Start;
+  the floor is a no-op for `alb` / `ecs`, whose real Docker teardown already
+  takes longer), and a still-booting serve shows
   "Starting..." (disabled) — both inert so a double-click cannot re-fire stop /
   cancel mid-boot. Issue #352 lists ECS Services (the `ecs`
   serve kind) and ECS Task Definitions as SEPARATE target groups,

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -301,6 +301,40 @@ const STUDIO_SCRIPT = `
   const serveMeta = new Map();     // serve targetId -> { dot, btnSlot } row controls
   const serveState = new Map();    // serve targetId -> { status, endpoints }
   const stoppingIds = new Set();   // serve targetIds with a Stop in flight — button shows "Stopping..." until the stopped/error event (issue #394)
+  const stoppingSince = new Map(); // serve targetId -> Date.now() when Stop was clicked (drives the min-visible "Stopping..." window)
+  const stoppingTimers = new Map();// serve targetId -> pending setTimeout handle that clears the transient after the min-visible window
+  // Keep "Stopping..." visible for at least this long. A start-api / pure-S3
+  // cloudfront serve with no warmed containers tears down in tens of ms, so
+  // without a floor the button flips straight back to Start and the user never
+  // sees the Stop was registered. alb / ecs (real Docker teardown) already
+  // take longer than this, so the floor is a no-op for them.
+  const MIN_STOPPING_MS = 450;
+  // Fully clear a Stop transient (id + start time + any pending min-window timer).
+  function clearStoppingTransient(id) {
+    stoppingIds.delete(id);
+    stoppingSince.delete(id);
+    const t = stoppingTimers.get(id);
+    if (t) { clearTimeout(t); stoppingTimers.delete(id); }
+  }
+  // Settle a Stop transient when the serve reaches a terminal state: clear it
+  // immediately once the min-visible window has elapsed, else hold "Stopping..."
+  // for the remainder before reverting the button. Only holds when a user Stop
+  // is actually in flight (a self-crash that was never "stopping" clears at once).
+  function settleStoppingTransient(id) {
+    if (!stoppingIds.has(id)) return;
+    const elapsed = Date.now() - (stoppingSince.get(id) || 0);
+    const remaining = MIN_STOPPING_MS - elapsed;
+    if (remaining <= 0) { clearStoppingTransient(id); return; }
+    const existing = stoppingTimers.get(id);
+    if (existing) clearTimeout(existing);
+    const h = setTimeout(function () {
+      stoppingTimers.delete(id);
+      stoppingIds.delete(id);
+      stoppingSince.delete(id);
+      updateServeRow(id);
+    }, remaining);
+    stoppingTimers.set(id, h);
+  }
   // serve targetId -> the launch config it was last Started with (issue #356):
   // { options, rawArgs, imageOverride }. Kept separate from serveState so the
   // SSE-driven serveState rewrites (status / endpoints) never clobber it, and
@@ -969,8 +1003,9 @@ const STUDIO_SCRIPT = `
       imageOverrides: imageOverrides,
     });
     // Defensive: a restart clears any stale "Stopping..." transient (issue
-    // #394) so the new run shows "Starting...", not a lingering stop state.
-    stoppingIds.delete(id);
+    // #394) — including a pending min-visible timer — so the new run shows
+    // "Starting...", not a lingering stop state.
+    clearStoppingTransient(id);
     serveState.set(id, { status: 'starting', endpoints: [] });
     updateServeRow(id);
     try {
@@ -1007,6 +1042,9 @@ const STUDIO_SCRIPT = `
     // stops (the SSE 'stopped' / 'error' event clears it via onServeEvent),
     // issue #394.
     stoppingIds.add(id);
+    stoppingSince.set(id, Date.now());
+    const staleTimer = stoppingTimers.get(id);
+    if (staleTimer) { clearTimeout(staleTimer); stoppingTimers.delete(id); }
     updateServeRow(id);
     try {
       await fetch('/api/stop', {
@@ -1014,12 +1052,13 @@ const STUDIO_SCRIPT = `
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ targetId: id }),
       });
-      // The serve SSE 'stopped' event clears the running state + the transient.
+      // The serve SSE 'stopped' event settles the transient (with a min-visible
+      // window) + clears the running state via onServeEvent.
     } catch (err) {
       // The stop request never reached the server — clear the transient so the
       // button reverts to Stop (the serve is still running). A later SSE event
       // or refresh otherwise reconciles state.
-      stoppingIds.delete(id);
+      clearStoppingTransient(id);
       updateServeRow(id);
     }
   }
@@ -2026,11 +2065,13 @@ const STUDIO_SCRIPT = `
     if (ev.status === 'stopped' || ev.status === 'error') {
       serveState.set(ev.target, { status: ev.status, endpoints: [], message: ev.message });
       // A terminal event settles any in-flight Stop transient (issue #394): the
-      // serve reached a final state, so clear "Stopping..." and let the button
-      // revert to Start (or Reconfigure on a failure). Cleared ONLY here — a
-      // late running re-emit (e.g. a hostUrl arriving after run, issue #392)
-      // must NOT cancel the in-progress stop indicator.
-      stoppingIds.delete(ev.target);
+      // serve reached a final state, so let the button revert to Start (or
+      // Reconfigure on a failure) — but keep "Stopping..." up for at least the
+      // min-visible window so a near-instant teardown (start-api / pure-S3
+      // cloudfront with no warmed containers) still shows the affordance.
+      // Settled ONLY here — a late running re-emit (e.g. a hostUrl arriving
+      // after run, issue #392) must NOT cancel the in-progress stop indicator.
+      settleStoppingTransient(ev.target);
     } else {
       serveState.set(ev.target, { status: ev.status, endpoints: ev.endpoints || [], hostUrl: ev.hostUrl });
     }

--- a/tests/unit/local/studio-ui-stopping-state.test.ts
+++ b/tests/unit/local/studio-ui-stopping-state.test.ts
@@ -7,6 +7,7 @@ const EXPOSE = `
 window.__t = {
   serveMeta: serveMeta,
   serveState: serveState,
+  stoppingSince: stoppingSince,
   renderServeWorkspace: renderServeWorkspace,
   updateServeRow: updateServeRow,
   onServeEvent: onServeEvent,
@@ -56,7 +57,7 @@ describe('Stop button "Stopping..." / "Starting..." transients (issue #394)', ()
     }
   });
 
-  it('a stopped serve event clears "Stopping..." and reverts the button to Start', () => {
+  it('a stopped serve event AFTER the min-visible window reverts the button to Start', () => {
     const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
     try {
       (h.window as any).fetch = () => new Promise(() => {});
@@ -64,9 +65,36 @@ describe('Stop button "Stopping..." / "Starting..." transients (issue #394)', ()
       headBtn(h).click();
       expect(headBtn(h).textContent).toBe('Stopping…');
 
+      // Pretend the Stop has been in flight longer than the min-visible window,
+      // so the terminal event settles immediately (no lingering "Stopping...").
+      t.stoppingSince.set('S/Svc', Date.now() - 100000);
       // The SSE 'stopped' event arrives (clean user stop — no message).
       t.onServeEvent({ target: 'S/Svc', status: 'stopped' });
 
+      expect(headBtn(h).textContent).toBe('Start');
+      expect(rowBtn(t).textContent).toBe('Start');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('a near-instant stop keeps "Stopping..." up for the min-visible window, then reverts', async () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      (h.window as any).fetch = () => new Promise(() => {});
+      const t = setup(h, 'running');
+      headBtn(h).click();
+      expect(headBtn(h).textContent).toBe('Stopping…');
+
+      // A start-api / pure-S3 cloudfront serve tears down in tens of ms — the
+      // 'stopped' event arrives almost immediately. The button must NOT flip
+      // straight to Start (that is the bug: the Stop looked like it did nothing).
+      t.onServeEvent({ target: 'S/Svc', status: 'stopped' });
+      expect(headBtn(h).textContent).toBe('Stopping…');
+      expect(headBtn(h).disabled).toBe(true);
+
+      // After the min-visible window the pending timer clears it and reverts.
+      await new Promise((r) => setTimeout(r, 700));
       expect(headBtn(h).textContent).toBe('Start');
       expect(rowBtn(t).textContent).toBe('Start');
     } finally {


### PR DESCRIPTION
## Summary

In `cdkl studio`, clicking **Stop** on a `start-api` serve flipped the button straight back to **Start** — the "Stopping..." affordance was never visible, so the Stop looked like it did nothing (the only sign was a `Received SIGTERM, shutting down...` log line afterwards).

Root cause (not a bug in the stopping logic itself): `start-api` does **not** pre-warm Lambda containers — `createContainerPool(...)` is called without `prewarm: true`, so containers boot lazily on the first request. If you Start a serve and Stop it **without sending a request**, there are no warm containers to tear down, so the child exits in tens of ms (measured: ~41ms). The "Stopping..." transient is rendered, but the `stopped` event arrives so fast it's imperceptible — it looks instant. `alb` / `ecs` serves do real Docker teardown (seconds), so the transient was always visible there; `start-api` (and a pure-S3 `cloudfront` serve) just tear down too fast to see.

## Fix

Add a **minimum-visible window** for the "Stopping..." transient in the studio UI (client-side only). When the terminal (`stopped` / `error`) event arrives, `onServeEvent` now settles the transient via `settleStoppingTransient`: if less than `MIN_STOPPING_MS` (450ms) has elapsed since the user clicked Stop, "Stopping..." is held for the remainder before the button reverts. A near-instant teardown still shows the affordance; `alb` / `ecs` (already slower than the floor) are unaffected. A restart (`startServe`) or a failed `/api/stop` fetch fully clears the transient (including any pending timer).

## Test plan

- **unit** (`tests/unit/local/studio-ui-stopping-state.test.ts`):
  - a near-instant `stopped` event keeps "Stopping..." up (does NOT flip to Start immediately), then reverts after the window — the direct regression guard.
  - a `stopped` event after the window reverts immediately.
  - the existing "click Stop -> Stopping...", "late running re-emit does not cancel", and "Starting..." cases still pass.
- **integ** (`local-studio`): the full studio integ (boots the server + exercises api / alb / ecs serve start/stop) passes — no regression in the embedded UI string.
- **measured**: `start-api` against `tests/integration/local-start-api` with no request → 0 warm containers → SIGTERM->exit in ~41ms, confirming the lazy-pool root cause.
