### PR TITLE
feat(studio): interactive WebSocket console for AgentCore /ws (agentcore-ws serve kind)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -714,7 +714,8 @@ compute-locally category for Lambda + API Gateway).
   `/api/config` immediately on a checkbox toggle / input change, issue
   #301); Lambdas + AgentCore runtimes get an
   [Invoke] composer (`INVOKE_KINDS`), serve
-  targets (api / alb / ecs / ecs-task / cloudfront) a [Start]/[Stop] control
+  targets (api / alb / ecs / ecs-task / cloudfront / agentcore-ws) a
+  [Start]/[Stop] control
   with a
   `running ● :port` indicator (ecs services + ecs-task runs show
   `running` with no port). The control surfaces transient in-progress states
@@ -757,7 +758,13 @@ compute-locally category for Lambda + API Gateway).
   (`renderWsConsole` — connect / send-frame / received-frame log) wired
   straight to its ws:// endpoint, with the socket + frame log held in module
   state so a log-driven serve re-render never drops the connection (issue
-  #303); every composer (invoke + serve) carries a collapsed "All options"
+  #303); the SAME console renders for an `agentcore-ws` serve (an HTTP / AGUI
+  AgentCore runtime's `/ws` endpoint served by `cdkl start-agentcore` behind a
+  host bridge — the runtime is listed in a second "AgentCore WebSocket" group
+  alongside its single-shot invoke entry, the same dual listing as the
+  ecs / ecs-task split; only HTTP / AGUI runtimes appear there since MCP / A2A
+  have no `/ws`), because the bridge's `ws://` endpoint flows through the same
+  un-proxied `endpoints` path; every composer (invoke + serve) carries a collapsed "All options"
   `<details>` (`buildAllOptions`) with a raw extra-args input + the
   read-only auto-derived flag catalog from studio-option-catalog, so the
   curated controls handle common flags richly while every other flag the
@@ -846,7 +853,10 @@ compute-locally category for Lambda + API Gateway).
   `--bearer-token` / `--session-id` (scalar), and `--env-vars` (env-kv);
   the `alb` / `ecs` serve kinds also declare `--env-vars` (env-kv, issue
   #355) so a UI-started serve can overlay the backing ECS task container
-  env)),
+  env; the `agentcore-ws` serve kind declares `--bearer-token` (scalar) /
+  `--no-verify-auth` (boolean) / `--session-id` (scalar) / `--env-vars`
+  (env-kv) — the serve-relevant subset of start-agentcore's flags, no
+  `--ws` / `--sigv4`)),
   studio-option-catalog (issue #301 — the AUTO-DERIVED full flag catalog
   that backs the composer's collapsed "All options" section.
   `buildFlagCatalog` introspects each runnable kind's Commander command
@@ -873,14 +883,18 @@ compute-locally category for Lambda + API Gateway).
   HTTP endpoints each fronted by a studio-proxy so the `endpoints` handed
   to the UI are the proxy URLs (slice C2 capture), while `ecs`
   (`start-service`) is pure compute — no capture proxy, just the running
-  replicas + their streamed logs. The `ecs` serve's `hostUrl` is set from an
+  replicas + their streamed logs. `agentcore-ws` (`start-agentcore`) resolves
+  running on `Server listening on (ws://...)`; its `ws://` endpoint is NOT
+  proxied (the capture-proxy gate is `/^https?:/`), so the browser connects
+  straight to the bridge and the UI renders the WebSocket console. The `ecs` serve's `hostUrl` is set from an
   explicit `--host-port` OR (issue #392) parsed from the child's
   `... published on <ip>:<port> ...` log line when start-service auto-publishes
   / auto-remaps a replica port (`parsePublishedHostEndpoint`, first endpoint
   wins, re-emitted if it arrives after the running event) — so the request
   composer can target an auto-published replica without an explicit
   `--host-port`. Resolves running on the kind's
-  ready line (`Server listening on <url>` / `ALB front-door: <url>` /
+  ready line (`Server listening on <url>` (shared by start-api and
+  start-agentcore — the latter's is a `ws://` URL) / `ALB front-door: <url>` /
   `CloudFront distribution serving on <url>` /
   `Service(s) running:`), tracks the running set for `/api/running`, and
   SIGTERMs the child on `/api/stop` / studio shutdown with a generous

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 
 ### Web console — `cdkl studio`
 
-`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` / `start-cloudfront` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all.
+`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` / `start-cloudfront` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all. A served API Gateway WebSocket API — and an HTTP / AGUI AgentCore runtime's `/ws` endpoint (the `start-agentcore` serve, listed under "AgentCore WebSocket") — get an interactive in-browser WebSocket console (connect / send / receive frames).
 
 ```bash
 cdkl studio                                  # open the console (launches your browser)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1789,7 +1789,14 @@ The console is a three-pane layout:
   serve targets get a `[Start]` / `[Stop]` control with a `running ● :port`
   indicator (an ECS service shows `running` with no port — it is pure
   compute with no host endpoint; only servable ECS *services* are runnable,
-  not task definitions).
+  not task definitions). An HTTP / AGUI AgentCore runtime additionally
+  appears in an **AgentCore WebSocket** group (the `agentcore-ws` serve kind):
+  a `[Start]` / `[Stop]` control that runs `cdkl start-agentcore` and, once
+  running, renders an interactive WebSocket console wired to the served `/ws`
+  bridge — the same console a served API Gateway WebSocket API gets. The dual
+  listing (invoke once vs hold a live session) mirrors the ECS service /
+  task-definition split; MCP / A2A runtimes have no `/ws` and are not listed
+  there.
 - **Workspace** — the composer for the selected target (event JSON for a
   Lambda or AgentCore invoke; start / stop for a serve). An **Options**
   section exposes the per-target run options as controls — a checkbox per

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -80,6 +80,7 @@ const STUDIO_TARGET_KINDS: readonly StudioTargetKind[] = [
   'ecs-task',
   'cloudfront',
   'agentcore',
+  'agentcore-ws',
 ];
 
 /**

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -11,7 +11,8 @@ export type StudioTargetKind =
   | 'ecs'
   | 'ecs-task'
   | 'cloudfront'
-  | 'agentcore';
+  | 'agentcore'
+  | 'agentcore-ws';
 
 /**
  * One request observed by `cdkl studio` — a single-shot invoke or one

--- a/src/local/studio-option-catalog.ts
+++ b/src/local/studio-option-catalog.ts
@@ -26,6 +26,7 @@ import { createLocalStartApiCommand } from '../cli/commands/local-start-api.js';
 import { createLocalStartAlbCommand } from '../cli/commands/local-start-alb.js';
 import { createLocalStartServiceCommand } from '../cli/commands/local-start-service.js';
 import { createLocalStartCloudFrontCommand } from '../cli/commands/local-start-cloudfront.js';
+import { createLocalStartAgentCoreCommand } from '../cli/commands/local-start-agentcore.js';
 import { createLocalRunTaskCommand } from '../cli/commands/local-run-task.js';
 import { getEmbedConfig, setEmbedConfig, type CdkLocalEmbedConfig } from './embed-config.js';
 import type { StudioTargetKind } from './studio-events.js';
@@ -80,6 +81,7 @@ const KIND_FACTORIES: Record<StudioTargetKind, { command: string; factory: FlagC
   ecs: { command: 'start-service', factory: createLocalStartServiceCommand },
   'ecs-task': { command: 'run-task', factory: createLocalRunTaskCommand },
   cloudfront: { command: 'start-cloudfront', factory: createLocalStartCloudFrontCommand },
+  'agentcore-ws': { command: 'start-agentcore', factory: createLocalStartAgentCoreCommand },
 };
 
 let cached: Partial<Record<StudioTargetKind, KindFlagCatalog>> | undefined;

--- a/src/local/studio-option-specs.ts
+++ b/src/local/studio-option-specs.ts
@@ -189,6 +189,37 @@ export const OPTION_SPECS: Partial<Record<StudioTargetKind, OptionSpec[]>> = {
       help: 'Overlay container env vars — add KEY=VALUE rows or paste a JSON object.',
     },
   ],
+  'agentcore-ws': [
+    {
+      flag: '--bearer-token',
+      kind: 'scalar',
+      label: 'Bearer token',
+      placeholder: 'eyJ...',
+      help: "Bearer JWT to present when the runtime declares a customJwtAuthorizer (verified against the runtime's OIDC discovery URL, then injected on every container /ws upgrade).",
+    },
+    {
+      flag: '--no-verify-auth',
+      kind: 'boolean',
+      label: 'Skip JWT verification',
+      help: 'Skip inbound JWT verification even when the runtime declares a customJwtAuthorizer (local-dev escape hatch). A bearer token, if given, is still forwarded.',
+    },
+    {
+      flag: '--session-id',
+      kind: 'scalar',
+      label: 'Session id',
+      placeholder: 'auto (random UUID per connection)',
+      help: 'Pin one AgentCore session id for every connection. Defaults to a fresh random UUID per connection when blank.',
+    },
+    {
+      flag: '--env-vars',
+      kind: 'env-kv',
+      label: 'Env vars',
+      sep: '=',
+      leftPlaceholder: 'KEY',
+      rightPlaceholder: 'value',
+      help: 'Overlay container env vars — add KEY=VALUE rows or paste a JSON object.',
+    },
+  ],
   ecs: [
     {
       flag: '--max-tasks',

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -213,6 +213,20 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     readyRe: /CloudFront distribution serving on (https?:\/\/\S+)/,
     capturesHttp: true,
   },
+  'agentcore-ws': {
+    // start-agentcore boots an AgentCore Runtime container and serves its
+    // bidirectional /ws endpoint behind a host bridge (issue start-agentcore).
+    // It binds an OS-assigned bridge port with --port 0 and logs `Server
+    // listening on ws://...`. The endpoint is ws:// so it is NOT proxied
+    // (the capture-proxy gate is /^https?:/); the browser connects directly
+    // to the bridge, which renders the same WebSocket console an API Gateway
+    // WebSocket API gets. readyRe anchors on the ws:// scheme so a stray boot
+    // log line cannot flip the serve to running.
+    command: 'start-agentcore',
+    portArgs: ['--port', '0', '--host', '127.0.0.1'],
+    readyRe: /Server listening on (ws:\/\/\S+)/,
+    capturesHttp: false,
+  },
 };
 
 /**

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -53,7 +53,7 @@ export interface StudioTarget {
 /** A category of targets, grouped by the studio kind that runs them. */
 export interface StudioTargetGroup {
   /** Studio kind discriminator shared with {@link StudioInvocationEvent}. */
-  kind: 'lambda' | 'api' | 'alb' | 'ecs' | 'ecs-task' | 'cloudfront' | 'agentcore';
+  kind: 'lambda' | 'api' | 'alb' | 'ecs' | 'ecs-task' | 'cloudfront' | 'agentcore' | 'agentcore-ws';
   /** Human-readable group heading. */
   title: string;
   entries: StudioTarget[];
@@ -90,6 +90,17 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
     { kind: 'ecs', title: 'ECS Services', entries: map(listing.ecsServices, { servable: true }) },
     { kind: 'ecs-task', title: 'ECS Task Definitions', entries: map(listing.ecsTaskDefinitions) },
     { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
+    // The same runtimes that have a /ws endpoint (HTTP / AGUI — MCP / A2A
+    // don't) ALSO appear as an `agentcore-ws` serve group: a [Start]/[Stop]
+    // control that runs `cdkl start-agentcore` and renders an interactive
+    // WebSocket console (like the API Gateway WebSocket console). The dual
+    // listing mirrors the ecs / ecs-task split — invoke once vs hold a live
+    // session are genuinely different operations.
+    {
+      kind: 'agentcore-ws',
+      title: 'AgentCore WebSocket',
+      entries: map(listing.agentCoreRuntimes.filter((e) => e.agentCoreHasWs)),
+    },
     { kind: 'alb', title: 'Load Balancers', entries: map(listing.loadBalancers) },
     // CloudFront distributions are a serve target (start-cloudfront -> Start),
     // like api / alb — they expose a host HTTP endpoint (issue #367 / #363).

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -288,8 +288,8 @@ const STUDIO_CSS = `
 `;
 
 const STUDIO_SCRIPT = `
-  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore' };
-  const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task', 'cloudfront']; // long-running serve targets (ecs-task = run-task)
+  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore', 'agentcore-ws': 'AgentCore WS' };
+  const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task', 'cloudfront', 'agentcore-ws']; // long-running serve targets (ecs-task = run-task; agentcore-ws = start-agentcore /ws bridge)
   const INVOKE_KINDS = ['lambda', 'agentcore']; // single-shot invoke targets (event composer)
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event

--- a/src/local/target-lister.ts
+++ b/src/local/target-lister.ts
@@ -1,7 +1,11 @@
 import { readCdkPathOrUndefined } from '../cli/cdk-path.js';
 import type { StackInfo } from '../synthesis/assembly-reader.js';
 import { getLogger } from '../utils/logger.js';
-import { AGENTCORE_RUNTIME_TYPE } from './agentcore-resolver.js';
+import {
+  AGENTCORE_RUNTIME_TYPE,
+  AGENTCORE_MCP_PROTOCOL,
+  AGENTCORE_A2A_PROTOCOL,
+} from './agentcore-resolver.js';
 import { discoverRoutes } from './route-discovery.js';
 import { discoverWebSocketApis } from './websocket-route-discovery.js';
 
@@ -37,6 +41,14 @@ export interface TargetEntry {
    * targets apart. Omitted for Lambda / ECS targets.
    */
   kind?: string;
+  /**
+   * For `agentCoreRuntimes` entries only: whether the runtime exposes a
+   * bidirectional `/ws` WebSocket endpoint (HTTP / AGUI protocols do; MCP /
+   * A2A do not). Drives the studio `agentcore-ws` serve group, which only
+   * lists runtimes `cdkl start-agentcore` can serve. Omitted for non-agentcore
+   * targets.
+   */
+  agentCoreHasWs?: boolean;
 }
 
 /**
@@ -103,6 +115,32 @@ function scanByType(stacks: readonly StackInfo[], type: string): TargetEntry[] {
     for (const [logicalId, resource] of Object.entries(resources)) {
       if (resource.Type !== type) continue;
       entries.push(makeEntry(stack.stackName, logicalId, readCdkPathOrUndefined(resource)));
+    }
+  }
+  return entries;
+}
+
+/**
+ * Enumerate `AWS::BedrockAgentCore::Runtime` targets, marking each with
+ * {@link TargetEntry.agentCoreHasWs} — true for HTTP / AGUI runtimes (which
+ * expose a `/ws` WebSocket endpoint), false for MCP / A2A (which do not). The
+ * marker lets the studio `agentcore-ws` serve group list only the runtimes
+ * `cdkl start-agentcore` can serve. The protocol is read the same way the
+ * resolver reads it (`Properties.ProtocolConfiguration`, default HTTP).
+ */
+function scanAgentCoreRuntimes(stacks: readonly StackInfo[]): TargetEntry[] {
+  const entries: TargetEntry[] = [];
+  for (const stack of stacks) {
+    const resources = stack.template.Resources ?? {};
+    for (const [logicalId, resource] of Object.entries(resources)) {
+      if (resource.Type !== AGENTCORE_RUNTIME_TYPE) continue;
+      const entry = makeEntry(stack.stackName, logicalId, readCdkPathOrUndefined(resource));
+      const protocol = (resource.Properties as Record<string, unknown> | undefined)?.[
+        'ProtocolConfiguration'
+      ];
+      entry.agentCoreHasWs =
+        protocol !== AGENTCORE_MCP_PROTOCOL && protocol !== AGENTCORE_A2A_PROTOCOL;
+      entries.push(entry);
     }
   }
   return entries;
@@ -197,7 +235,7 @@ export function listTargets(stacks: readonly StackInfo[]): TargetListing {
     apis: sortApiEntries(listApiSurfaces(stacks)),
     ecsServices: sortEntries(scanByType(stacks, 'AWS::ECS::Service')),
     ecsTaskDefinitions: sortEntries(scanByType(stacks, 'AWS::ECS::TaskDefinition')),
-    agentCoreRuntimes: sortEntries(scanByType(stacks, AGENTCORE_RUNTIME_TYPE)),
+    agentCoreRuntimes: sortEntries(scanAgentCoreRuntimes(stacks)),
     loadBalancers: sortEntries(scanApplicationLoadBalancers(stacks)),
     cloudFrontDistributions: sortEntries(scanByType(stacks, 'AWS::CloudFront::Distribution')),
   };

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -67,7 +67,7 @@ cleanup() {
     wait "${STUDIO_PID}" 2>/dev/null || true
   fi
   rm -f "${LOG_FILE}" "${BODY_FILE}" "${RUN_FILE}" "${SSE_FILE}"
-  rm -f "$(pwd)/.studio-ws-client.mjs"
+  rm -f "$(pwd)/.studio-ws-client.mjs" "$(pwd)/.studio-agentcore-ws-client.mjs"
   # Drop the local-only image-override build(s) the ecs / alb / ecs-task picker
   # tests produced (tag prefix is the embed binary name: `cdkl-override-*:local`).
   docker images --filter 'reference=cdkl-override-*' -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
@@ -1038,6 +1038,81 @@ for _ in $(seq 1 20); do
   sleep 0.5
 done
 echo "    OK: WebSocket-API serve stopped"
+
+# ---------------------------------------------------------------------------
+# 7c. AgentCore WebSocket console (start-agentcore): studio serves an
+#     HTTP-protocol AgentCore runtime's /ws endpoint as the `agentcore-ws`
+#     serve kind (`start-agentcore LocalStudioFixture/MyAgent`), exposing the
+#     host bridge's ws:// endpoint un-proxied. A header-less client (the
+#     browser path — the global WebSocket cannot set the session-id header)
+#     connects through the bridge, and the bridge injects the session-id on the
+#     container /ws upgrade. Drive the agent's /ws REPL: send {"loop":true},
+#     assert the reply carries a bridge-injected sessionId, then a second frame
+#     round-trips as loop-echo:<text>. Proves studio -> start-agentcore ->
+#     bridge -> browser-reachable ws:// session end-to-end.
+# ---------------------------------------------------------------------------
+AC_WS_TARGET="LocalStudioFixture/MyAgent"
+echo "==> GET /api/targets lists ${AC_WS_TARGET} under the agentcore-ws serve group"
+curl -fsS "${URL}/api/targets" -o "${BODY_FILE}"
+if ! grep -qF '"kind":"agentcore-ws"' "${BODY_FILE}"; then
+  echo "FAIL: /api/targets has no agentcore-ws group"; head -c 2000 "${BODY_FILE}"; exit 1
+fi
+echo "    OK: agentcore-ws group present"
+
+echo "==> POST /api/run starts an agentcore-ws serve for ${AC_WS_TARGET}"
+ACWS_FILE=$(mktemp)
+ACWS_HTTP=$(curl -s -o "${ACWS_FILE}" -w '%{http_code}' --max-time 300 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${AC_WS_TARGET}\",\"kind\":\"agentcore-ws\"}" || true)
+if [[ "${ACWS_HTTP}" != "200" ]]; then
+  echo "FAIL: agentcore-ws serve start returned HTTP ${ACWS_HTTP}"; cat "${ACWS_FILE}"; rm -f "${ACWS_FILE}"; exit 1
+fi
+ACWS_URL=$(grep -oE 'ws://127\.0\.0\.1:[0-9]+/ws' "${ACWS_FILE}" | head -1 || true)
+rm -f "${ACWS_FILE}"
+if [[ -z "${ACWS_URL}" ]]; then
+  echo "FAIL: studio did not expose a ws:// endpoint for the agentcore-ws serve"; exit 1
+fi
+echo "    OK: agentcore-ws serve running at ${ACWS_URL}"
+curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
+if ! grep -qF "${ACWS_URL}" "${BODY_FILE}"; then
+  echo "FAIL: /api/running did not list the agentcore-ws ws:// endpoint"; cat "${BODY_FILE}"; exit 1
+fi
+# Header-less client (the browser path) drives the agent's /ws REPL through the
+# bridge; asserts the bridge-injected session-id + a frame round-trip.
+cat > "$(pwd)/.studio-agentcore-ws-client.mjs" <<'NODE'
+const url = process.argv[2];
+const ws = new WebSocket(url);
+let stage = 0;
+const done = (code, msg) => { if (msg) console.error(msg); process.exit(code); };
+ws.addEventListener('open', () => ws.send(JSON.stringify({ loop: true })));
+ws.addEventListener('message', async (e) => {
+  const text = typeof e.data === 'string' ? e.data : (e.data && typeof e.data.text === 'function' ? await e.data.text() : '');
+  if (stage === 0) {
+    let reply; try { reply = JSON.parse(text); } catch { return done(1, 'first frame not JSON: ' + text); }
+    if (reply.ws !== true) return done(1, 'first frame missing ws:true: ' + text);
+    if (!reply.sessionId) return done(1, 'bridge did not inject a session id: ' + text);
+    stage = 1; ws.send('studio-acws-415'); return;
+  }
+  if (text !== 'loop-echo:studio-acws-415') return done(1, 'expected loop-echo, got: ' + text);
+  console.log('PASS:', text); ws.close(); done(0);
+});
+ws.addEventListener('error', () => done(1, 'client socket error'));
+setTimeout(() => done(1, 'timeout waiting for agentcore /ws round-trip'), 30000);
+NODE
+if ! node "$(pwd)/.studio-agentcore-ws-client.mjs" "${ACWS_URL}"; then
+  echo "FAIL: AgentCore WebSocket console round-trip through the studio-served bridge"
+  curl -fsS "${URL}/api/stop" -H 'content-type: application/json' -d "{\"targetId\":\"${AC_WS_TARGET}\"}" -o /dev/null 2>/dev/null || true
+  rm -f "$(pwd)/.studio-agentcore-ws-client.mjs"; exit 1
+fi
+rm -f "$(pwd)/.studio-agentcore-ws-client.mjs"
+echo "    OK: AgentCore WebSocket console round-trip (session-id injected + loop-echo) through ${ACWS_URL}"
+curl -fsS "${URL}/api/stop" -H 'content-type: application/json' -d "{\"targetId\":\"${AC_WS_TARGET}\"}" -o /dev/null 2>/dev/null || true
+for _ in $(seq 1 40); do
+  curl -fsS "${URL}/api/running" -o "${BODY_FILE}" 2>/dev/null || true
+  if ! grep -qF "${AC_WS_TARGET}" "${BODY_FILE}"; then break; fi
+  sleep 0.5
+done
+echo "    OK: agentcore-ws serve stopped"
 
 # ---------------------------------------------------------------------------
 # 8. The store (slice C3): history + full-text log search + per-invocation

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -239,6 +239,20 @@ describe('coerceRunRequest', () => {
       options: { '--ws': true, '--bearer-token': 'eyJ' },
     });
   });
+
+  it('accepts the agentcore-ws serve kind with its per-run options', () => {
+    expect(
+      coerceRunRequest({
+        targetId: 'Stack/Agent',
+        kind: 'agentcore-ws',
+        options: { '--bearer-token': 'eyJ', '--no-verify-auth': true },
+      })
+    ).toEqual({
+      targetId: 'Stack/Agent',
+      kind: 'agentcore-ws',
+      options: { '--bearer-token': 'eyJ', '--no-verify-auth': true },
+    });
+  });
 });
 
 describe('applyConfigPatch', () => {
@@ -528,8 +542,8 @@ describe('routeStudioRun (issue #372 — POST /api/run kind -> runner)', () => {
     }
   });
 
-  it('routes the serve kinds (incl. cloudfront) to the serve manager', async () => {
-    for (const kind of ['api', 'alb', 'ecs-task', 'cloudfront'] as const) {
+  it('routes the serve kinds (incl. cloudfront + agentcore-ws) to the serve manager', async () => {
+    for (const kind of ['api', 'alb', 'ecs-task', 'cloudfront', 'agentcore-ws'] as const) {
       const d = deps();
       await routeStudioRun(req(kind), d.build());
       expect(d.start).toHaveBeenCalledOnce();

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -153,6 +153,40 @@ describe('createStudioServeManager', () => {
     expect(serves[1].endpoints).toEqual([PROXIED]);
   });
 
+  it('spawns `cdkl start-agentcore <target> --port 0` and surfaces the ws:// endpoint un-proxied', async () => {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      nodeBin: '/usr/bin/node',
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'MyAgent', kind: 'agentcore-ws' });
+    child.stdout.emit(
+      'data',
+      'Server listening on ws://127.0.0.1:49160/ws  (MyAgent (AgentCore WebSocket))\n'
+    );
+    const state = await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv.slice(1, 6)).toEqual(['start-agentcore', 'MyAgent', '--port', '0', '--host']);
+
+    expect(state.status).toBe('running');
+    // ws:// endpoints are NOT proxied (the capture-proxy gate is /^https?:/),
+    // so the browser connects straight to the bridge.
+    expect(state.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+    expect(fp.upstreams).toEqual([]);
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
+  });
+
   it('spawns the serve child with CDKL_LOG_STREAM=stdout so its logs are single-stream (issue #403)', async () => {
     const bus = new StudioEventBus();
     const child = makeFakeChild();

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -321,6 +321,7 @@ describe('toStudioTargetGroups', () => {
       'ecs',
       'ecs-task',
       'agentcore',
+      'agentcore-ws',
       'alb',
       'cloudfront',
     ]);
@@ -330,6 +331,7 @@ describe('toStudioTargetGroups', () => {
       'ECS Services',
       'ECS Task Definitions',
       'AgentCore Runtimes',
+      'AgentCore WebSocket',
       'Load Balancers',
       'CloudFront Distributions',
     ]);
@@ -346,7 +348,24 @@ describe('toStudioTargetGroups', () => {
     expect(groups[2].entries.map((e) => e.servable)).toEqual([true]);
     expect(groups[3].entries).toEqual([{ id: 'S:Task', qualifiedId: 'S:Task' }]);
     // CloudFront distributions are a plain serve entry (no servable flag).
-    expect(groups[6].entries).toEqual([{ id: 'S/Dist', qualifiedId: 'S:Dist' }]);
+    expect(groups[7].entries).toEqual([{ id: 'S/Dist', qualifiedId: 'S:Dist' }]);
+  });
+
+  it('lists only WS-capable runtimes in the agentcore-ws serve group', () => {
+    const listing: TargetListing = {
+      ...emptyListing(),
+      agentCoreRuntimes: [
+        { qualifiedId: 'S:Http', displayPath: 'S/Http', agentCoreHasWs: true },
+        { qualifiedId: 'S:Mcp', displayPath: 'S/Mcp', agentCoreHasWs: false },
+      ],
+    };
+    const groups = toStudioTargetGroups(listing);
+    const invoke = groups.find((g) => g.kind === 'agentcore');
+    const wsServe = groups.find((g) => g.kind === 'agentcore-ws');
+    // Both runtimes are invoke-able...
+    expect(invoke?.entries.map((e) => e.id)).toEqual(['S/Http', 'S/Mcp']);
+    // ...but only the HTTP runtime (agentCoreHasWs) is WS-servable.
+    expect(wsServe?.entries.map((e) => e.id)).toEqual(['S/Http']);
   });
 
   it('falls back to the qualified id when no display path exists', () => {

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -29,6 +29,16 @@ describe('renderStudioHtml', () => {
     expect(html).not.toMatch(/__OPTION_SPECS__ = [^;]*<\//);
   });
 
+  it('treats agentcore-ws as a serve kind with the AgentCore WS label', () => {
+    const html = renderStudioHtml('MyStack', 'cdkl');
+    // agentcore-ws is a serve kind (Start/Stop + WebSocket console), distinct
+    // from the single-shot agentcore invoke kind.
+    expect(html).toContain("'agentcore-ws'");
+    expect(html).toContain("'agentcore-ws': 'AgentCore WS'");
+    // Its per-run serve options are serialized too.
+    expect(html).toContain('"--no-verify-auth"');
+  });
+
   it('embeds the auto-derived full flag catalog for the "All options" section (issue #301)', () => {
     const html = renderStudioHtml('MyStack', 'cdkl');
     // The full per-kind catalog is serialized for the UI.
@@ -36,6 +46,7 @@ describe('renderStudioHtml', () => {
     // It carries each runnable kind's headless command + real flags.
     expect(html).toContain('"command":"start-api"');
     expect(html).toContain('"command":"invoke-agentcore"');
+    expect(html).toContain('"command":"start-agentcore"');
     // Session-global flags are excluded from the per-target catalog.
     expect(html).not.toMatch(/__FLAG_CATALOG__ =[^;]*"--from-cfn-stack"/);
     // `<` is escaped so a flag description can never close the <script>.

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -154,8 +154,32 @@ describe('listTargets — AgentCore Runtimes', () => {
         stackName: 'App',
         qualifiedId: 'App:ChatAgent',
         displayPath: 'App/ChatAgent',
+        // No ProtocolConfiguration -> defaults to HTTP -> has a /ws endpoint.
+        agentCoreHasWs: true,
       },
     ]);
+  });
+
+  it('marks agentCoreHasWs per protocol (HTTP/AGUI true, MCP/A2A false)', () => {
+    const stack = buildStack('App', {
+      HttpAgent: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+      AguiAgent: {
+        Type: 'AWS::BedrockAgentCore::Runtime',
+        Properties: { ProtocolConfiguration: 'AGUI' },
+      },
+      McpAgent: {
+        Type: 'AWS::BedrockAgentCore::Runtime',
+        Properties: { ProtocolConfiguration: 'MCP' },
+      },
+      A2aAgent: {
+        Type: 'AWS::BedrockAgentCore::Runtime',
+        Properties: { ProtocolConfiguration: 'A2A' },
+      },
+    });
+    const byId = Object.fromEntries(
+      listTargets([stack]).agentCoreRuntimes.map((e) => [e.logicalId, e.agentCoreHasWs])
+    );
+    expect(byId).toEqual({ HttpAgent: true, AguiAgent: true, McpAgent: false, A2aAgent: false });
   });
 });
 


### PR DESCRIPTION
## Summary

Make an HTTP / AGUI Bedrock AgentCore runtime's bidirectional `/ws` endpoint
servable from `cdkl studio` with an interactive in-browser WebSocket console —
the same console a served API Gateway WebSocket API already gets.

Adds an `agentcore-ws` serve kind. The studio serve-manager spawns
`cdkl start-agentcore <target>` (the host `/ws` bridge command merged in the
previous PR), captures its `ws://` ready endpoint un-proxied, and the existing
`renderWsConsole` attaches to it. HTTP / AGUI runtimes are listed in a second
**AgentCore WebSocket** target group alongside their single-shot invoke entry —
the same dual listing as the ECS service / task-definition split; MCP / A2A
runtimes have no `/ws` and are excluded.

Builds on the merged `cdkl start-agentcore` command
(https://github.com/go-to-k/cdk-local/pull/420).

## Changes

- `StudioTargetKind` / `STUDIO_TARGET_KINDS` / `StudioTargetGroup.kind` gain
  `agentcore-ws`; `routeStudioRun` routes it to the serve manager.
- `studio-serve-manager` SERVE_SPECS: `agentcore-ws` -> `start-agentcore`,
  `readyRe` anchored on `ws://`, `capturesHttp` false (the browser connects
  straight to the bridge — `ws://` flows through un-proxied).
- `target-lister` marks each AgentCore entry `agentCoreHasWs` (HTTP / AGUI
  true, MCP / A2A false); `toStudioTargetGroups` builds the `agentcore-ws`
  group from that subset.
- `studio-option-specs` + `studio-option-catalog` declare the serve-relevant
  flags (`--bearer-token` / `--no-verify-auth` / `--session-id` / `--env-vars`);
  `studio-ui` adds `agentcore-ws` to `SERVE_KINDS` + the "AgentCore WS" label.
- Unit tests across every layer; `local-studio` integ section 7c drives the
  full path with a header-less WebSocket client (the browser path), asserting
  the bridge-injected session-id + a `loop-echo` round-trip.
- README / `.claude/CLAUDE.md` / `docs/cli-reference.md` updated.

## Test plan

- `vp run check` / `vp run build` / `vp run test` (2929 unit tests) green.
- `/run-integ local-studio` — PASS (real Docker; the new section 7c drives the
  studio -> start-agentcore -> bridge -> header-less browser WS round-trip; 0
  orphan containers / networks / override images).
- 3-axis review.

## cdkd parity

Additive only. The new studio serve kind surfaces automatically for a host
embedding `createLocalStudioCommand`, provided `cdkl start-agentcore` is on the
spawned CLI surface (the serve-manager spawns it). New exported type field
(`TargetEntry.agentCoreHasWs`, optional) is backward-compatible. Tracked for
cdkd in https://github.com/go-to-k/cdkd/issues/765.
