### PR TITLE
chore(cdkd-parity): auto-file the cdkd tracking issue + hard-enforce it for new subcommand/option

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1136,13 +1136,27 @@ vp run runtime:smoke
   internal refactors don't trigger noise). The marker is set ONLY by `/check-cdkd-parity`, which walks
   the four host-impacting categories:
   - **New subcommand factory** — exported from `src/index.ts`? cdkd
-    notified (issue / cross-link)?
+    tracking issue filed (cat 1, REQUIRED)?
   - **New CLI option** — added inside the relevant
     `add<Cmd>SpecificOptions` helper (not inline in
-    `create<Cmd>Command`)? contract test still green?
+    `create<Cmd>Command`)? contract test still green? cdkd tracking
+    issue filed (cat 2, REQUIRED)?
   - **New public helper / type in `src/local/**`** — exported from
-    `src/internal.ts`? JSDoc names the host-side use case?
-  - **Behavior change** — cdkd informed? migration note in PR body?
+    `src/internal.ts`? JSDoc names the host-side use case? cdkd
+    tracking issue filed (cat 3, "optional — cdkd decides")?
+  - **Behavior change** — cdkd tracking issue filed (cat 4, REQUIRED)?
+    migration note in PR body?
+
+  The skill AUTO-FILES the cdkd tracking issue (`gh issue create --repo
+  go-to-k/cdkd`, idempotent via the per-worktree `.cdkd-parity-issue`
+  sentinel) for every applicable category, labeling each with its host
+  action (wrap / inherit / optional-adopt / adapt) so the cdkd agent can
+  follow by working its issue queue — it no longer relies on a manual
+  "notify cdkd" step that never happened. The gate HARD-BLOCKS
+  `gh pr create` for cat 1 / cat 2 until the sentinel carries a
+  `github.com/go-to-k/cdkd/issues/` reference; cat 3 / cat 4 rely on the
+  marker. `.claude/settings.json` `permissions.allow` pre-authorizes the
+  scoped `gh issue create`.
 
   Out-of-scope diffs (internal refactors, docs, tests) pass through
   silently. `gh pr merge` is intentionally NOT gated — the parity

--- a/.claude/hooks/cdkd-parity-gate.sh
+++ b/.claude/hooks/cdkd-parity-gate.sh
@@ -127,6 +127,71 @@ if [ -z "$scope_touched" ] && [ -z "$new_local_file" ]; then
   exit 0
 fi
 
+# --- cdkd tracking-issue enforcement (cat 1 / cat 2) ------------------------
+# The marker proves the skill WALKED the categories; it does not prove a cdkd
+# tracking issue was actually filed. For the two mechanically-unambiguous
+# host-MUST-act categories we additionally require a cdkd issue reference in
+# the per-worktree sentinel `.cdkd-parity-issue` (written by
+# `/check-cdkd-parity` when it auto-files the issue):
+#   cat 1 — a NEW command factory: a `src/cli/commands/local-*.ts` file added
+#           (`--diff-filter=A`) whose added content declares
+#           `export function createLocal<Verb>Command`. Mirrors
+#           create-integ-gate.sh's factory-content check so a new non-factory
+#           helper module does NOT fire it.
+#   cat 2 — a NEW CLI option: a `+...addOption(new Option(...)` line added to
+#           any `src/cli/commands/*.ts`.
+# cat 3 (new src/local export) and cat 4 (behavior change) are NOT hard-blocked
+# here — cat 3 is noisy and cat 4 is a judgment call; both rely on the marker
+# (the skill walked + auto-filed). This keeps the hard block on the cases where
+# cdkd unambiguously must wrap/inherit, without over-firing on internal
+# refactors.
+cat1_new_factory=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if git diff origin/main...HEAD --diff-filter=A -- "$f" 2>/dev/null \
+    | grep -qE '^\+[[:space:]]*export[[:space:]]+function[[:space:]]+createLocal[A-Z][A-Za-z]*Command'; then
+    cat1_new_factory="$f"
+    break
+  fi
+done < <(git diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
+  | grep -E '^src/cli/commands/local-[^/]+\.ts$')
+
+cat2_new_option=""
+# Same permissive pattern the skill's own detection uses (an added line that
+# carries `addOption(...new Option`), so chained `.addOption(new Option(` /
+# `cmd.addOption(new Option(` forms all match regardless of leading context.
+if git diff origin/main...HEAD -- 'src/cli/commands/*.ts' 2>/dev/null \
+  | grep -qE '^\+.*addOption.*new Option'; then
+  cat2_new_option="yes"
+fi
+
+if [ -n "$cat1_new_factory" ] || [ -n "$cat2_new_option" ]; then
+  sentinel="$target_dir/.cdkd-parity-issue"
+  if [ ! -f "$sentinel" ] || ! grep -q 'github\.com/go-to-k/cdkd/issues/' "$sentinel" 2>/dev/null; then
+    if [ -n "$cat1_new_factory" ]; then
+      cat_desc="a NEW subcommand factory ($cat1_new_factory)"
+    else
+      cat_desc="a NEW CLI option (addOption in src/cli/commands/**)"
+    fi
+    printf "Blocked by cdkd-parity-gate: this PR adds %s, which cdkd must inherit, but no cdkd tracking issue was filed.\n\n" "$cat_desc" >&2
+    cat >&2 <<'EOF'
+Required action — no exceptions:
+  /check-cdkd-parity
+
+For a new subcommand / new CLI option the skill files a tracking issue on
+go-to-k/cdkd (so the cdkd agent inherits it by working its issue queue) and
+records the issue URL in the per-worktree sentinel `.cdkd-parity-issue`. This
+gate requires that sentinel to carry a `github.com/go-to-k/cdkd/issues/`
+reference before `gh pr create` can proceed.
+
+Do NOT hand-write the sentinel to bypass this — run the skill so the issue is
+actually created.
+EOF
+    exit 2
+  fi
+fi
+# ---------------------------------------------------------------------------
+
 # Prefer the `mise`-managed markgate via `mise exec --` so the repo's
 # canonical version wins; fall back to PATH; fail open if neither.
 if command -v mise >/dev/null 2>&1; then

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -298,13 +298,40 @@ call `markgate set integ` directly from a shell.
   not touching the gate's paths, docs, tests, infra) pass through
   silently.
 
+  **Tracking-issue enforcement (cat 1 / cat 2).** The marker proves the
+  skill *walked* the categories — not that a cdkd tracking issue was
+  actually filed. So for the two mechanically-unambiguous host-MUST-act
+  categories the gate ALSO requires a cdkd issue reference, on top of the
+  marker:
+
+  - **cat 1** — a NEW `src/cli/commands/local-*.ts` file (`--diff-filter=A`)
+    whose added content declares `export function createLocal<Verb>Command`
+    (the same factory-content check as `create-integ-gate.sh`, so a new
+    non-factory helper module does NOT fire it), OR
+  - **cat 2** — a `+...addOption(new Option(...)` line added to any
+    `src/cli/commands/*.ts`.
+
+  When either fires, the gate requires the per-worktree sentinel
+  `.cdkd-parity-issue` to exist AND contain a
+  `github.com/go-to-k/cdkd/issues/` reference (written by
+  `/check-cdkd-parity` when it auto-files the issue), blocking
+  `gh pr create` until it does. cat 3 (new `src/local/**` export — noisy)
+  and cat 4 (behavior change — a judgment call) are NOT hard-blocked; they
+  rely on the marker (the skill walked + auto-filed for them too). This
+  puts the hard floor on the cases where cdkd unambiguously must
+  wrap / inherit, without over-firing on internal refactors.
+
   Fail-open behavior: when `gh` / `markgate` are missing, or
   `origin/main` is not resolvable, the hook exits 0 silently. The
   gate is a safety net for the four categories above, not a hard
   dependency.
 
   The skill is the ONLY legitimate setter of this marker — never
-  call `markgate set cdkd-parity` directly from a shell.
+  call `markgate set cdkd-parity` directly from a shell. Likewise, do
+  NOT hand-write `.cdkd-parity-issue` to satisfy the cat-1/2 check — run
+  `/check-cdkd-parity` so the issue is actually created on go-to-k/cdkd
+  (the skill auto-creates it; `.claude/settings.json` `permissions.allow`
+  pre-authorizes the scoped `gh issue create`).
 
 ### create-integ-gate (pre-create)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,14 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh issue create --repo go-to-k/cdkd*)",
+      "Bash(gh -C * issue create --repo go-to-k/cdkd*)",
+      "Bash(cd * && gh issue create --repo go-to-k/cdkd*)",
+      "Bash(gh issue comment * --repo go-to-k/cdkd*)",
+      "Bash(gh -C * issue comment * --repo go-to-k/cdkd*)",
+      "Bash(cd * && gh issue comment * --repo go-to-k/cdkd*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/check-cdkd-parity/SKILL.md
+++ b/.claude/skills/check-cdkd-parity/SKILL.md
@@ -80,11 +80,12 @@ For each new factory file:
       The new factory name must appear in the export list. If it
       doesn't, add the export before setting the marker.
 
-- [ ] **cdkd notified?** — this is a manual step. Either file an issue
-      on the cdkd repo describing the new subcommand and the wrap point
-      (`createLocal<Verb>Command` factory + suggested host-side options
-      block), OR cross-link this PR in an existing tracking issue. Note
-      which path you took in the PR body.
+- [ ] **cdkd tracking issue filed?** — REQUIRED for a new subcommand. File
+      (or reuse) the cdkd issue per "File the cdkd tracking issue" below,
+      labeling this as cat 1 "wrap the new subcommand
+      (`createLocal<Verb>Command`) — REQUIRED". The `cdkd-parity-gate.sh`
+      hook hard-blocks `gh pr create` until `.cdkd-parity-issue` carries the
+      issue URL.
 
 ## Category 2: New CLI option on an existing command?
 
@@ -157,6 +158,14 @@ For each new export in `src/local/**`:
       by cdkd's `<command>` provider to ..."). Pure-implementation
       docstrings ("returns a Foo") are not sufficient.
 
+- [ ] **cdkd tracking issue filed?** — file (or reuse) the cdkd issue per
+      "File the cdkd tracking issue" below, labeling this as cat 3 "new
+      internal primitive available — OPTIONAL: adopt if useful, cdkd
+      decides". Additive, so cdkd's build won't break by not adopting —
+      but filing surfaces it so cdkd makes the adoption call, instead of
+      cdk-local silently deciding for it. (The hook does NOT hard-block
+      cat 3; the marker covers it.)
+
 ## Category 4: Behavior change in an existing command?
 
 Behavior changes — changed defaults, new validation, changed output
@@ -171,25 +180,79 @@ change for an existing input?".
 
 For each behavior change:
 
-- [ ] **cdkd informed?** — file an issue on the cdkd repo OR cross-link
-      this PR in an existing tracking issue. The issue must name the
-      old behavior, the new behavior, and the migration cdkd needs to
-      apply (if any). Without this, cdkd's next release silently ships
-      the changed behavior with no host-side adjustment.
+- [ ] **cdkd tracking issue filed?** — REQUIRED for a behavior change. File
+      (or reuse) the cdkd issue per "File the cdkd tracking issue" below,
+      labeling this as cat 4 "behavior change — adapt — REQUIRED" and naming
+      the old behavior, the new behavior, and the migration cdkd needs to
+      apply. (The hook does NOT mechanically detect cat 4; the marker covers
+      it — so filing here is on your honor, but it is REQUIRED.)
 
-- [ ] **Migration note in PR body?** — the PR body must call out the
+- [ ] **Migration note in PR body?** — the PR body must ALSO call out the
       behavior change in a section labeled `Behavior change` (or
       `Breaking change` when appropriate), so anyone bumping the
       `cdk-local` version in cdkd reads it without digging through the
       diff.
 
+## File the cdkd tracking issue (REQUIRED when any category applies)
+
+When ANY of categories 1-4 above applies, you MUST file a tracking issue on
+the `go-to-k/cdkd` repo so the cdkd agent can inherit the change by working
+its own issue queue — without having to actively watch cdk-local. cdk-local's
+job is to SURFACE the change; cdkd decides whether/how to follow.
+
+This is no longer optional or a PR-body note. The `cdkd-parity-gate.sh` hook
+hard-blocks `gh pr create` for category 1 (new subcommand) and category 2 (new
+option) until the per-worktree sentinel `.cdkd-parity-issue` carries a
+`github.com/go-to-k/cdkd/issues/` reference. Categories 3 and 4 are filed too
+(the gate relies on the marker for those, but you still file).
+
+**Idempotent — reuse the sentinel; never open a duplicate on a re-run:**
+
+```bash
+SENTINEL=".cdkd-parity-issue"   # per-worktree, gitignored (like .markgate-pr-review-sha)
+if [ -f "$SENTINEL" ] && grep -q 'github.com/go-to-k/cdkd/issues/' "$SENTINEL"; then
+  echo "Reusing existing cdkd issue: $(cat "$SENTINEL")"
+  # If the applicable categories changed since it was filed, append an update
+  # with: gh issue comment "$(cat "$SENTINEL")" --repo go-to-k/cdkd --body-file <file>
+else
+  # Build the body in a file (NEVER inline bare #N — the cross-repo auto-link
+  # trap; reference the cdk-local PR/branch as a FULL GitHub URL). Label EACH
+  # applicable category with its host action:
+  #   cat 1 -> "wrap the new subcommand (createLocal<Verb>Command) — REQUIRED"
+  #   cat 2 -> "inherit the new option (add<Cmd>SpecificOptions) — REQUIRED"
+  #   cat 3 -> "new internal primitive available — OPTIONAL: adopt if useful, cdkd decides"
+  #   cat 4 -> "behavior change — adapt — REQUIRED" (name old vs new + migration)
+  cat > /tmp/cdkd-parity-body.md <<'BODY'
+## Follow cdk-local: <one-line summary>
+
+cdk-local changed its host-facing surface. All changes are additive unless a
+category-4 item below says otherwise. cdk-local PR:
+https://github.com/go-to-k/cdk-local/pull/<N>  (or the branch URL pre-merge)
+
+<one bullet per applicable category, each with the host-action label above>
+BODY
+  url=$(gh issue create --repo go-to-k/cdkd \
+    --title "Follow cdk-local: <one-line summary>" \
+    --body-file /tmp/cdkd-parity-body.md)
+  printf '%s\n' "$url" > "$SENTINEL"
+  echo "Filed cdkd tracking issue: $url"
+fi
+```
+
+If `gh issue create` is denied (permission / offline), say so explicitly and
+STOP — do NOT hand-write the sentinel to satisfy the gate. The whole point is
+that the issue actually exists. (The committed `permissions.allow` in
+`.claude/settings.json` pre-authorizes `gh issue create --repo go-to-k/cdkd`,
+so this should not normally prompt.)
+
 ## Final step: set the marker
 
 Only call `mise exec -- markgate set cdkd-parity` when EVERY check
-above passed or was explicitly marked N/A. If any item is unresolved,
-skip the marker, list the unresolved items, and stop — the
-`cdkd-parity-gate.sh` hook will then correctly block `gh pr create`
-until the walk-through is repeated.
+above passed or was explicitly marked N/A, AND — when any category applied —
+the cdkd tracking issue has been filed and `.cdkd-parity-issue` carries its
+URL. If any item is unresolved, skip the marker, list the unresolved items,
+and stop — the `cdkd-parity-gate.sh` hook will then correctly block
+`gh pr create` until the walk-through is repeated.
 
 ```bash
 mise exec -- markgate set cdkd-parity
@@ -207,6 +270,11 @@ the per-worktree marker convention.
   — the dependency direction is `cdkd -> cdk-local`. The skill talks
   about "notify cdkd" / "host CLI", not about cdkd's deploy or
   provider system.
-- The "notify cdkd" steps are manual — this skill does NOT file the
-  issue / send the message itself; it prompts the user to do so and
-  records the decision in the PR body.
+- Filing the cdkd tracking issue is done BY this skill (auto `gh issue
+  create --repo go-to-k/cdkd`, idempotent via the `.cdkd-parity-issue`
+  sentinel), not left as a manual prompt — that is the change that makes
+  cdkd follow-up actually happen (it never did under the old manual /
+  PR-body-note path). cat 1 / cat 2 are hard-blocked by the gate until the
+  sentinel carries the issue URL; cat 3 / cat 4 are filed on the marker's
+  honor. The committed `permissions.allow` in `.claude/settings.json`
+  pre-authorizes the scoped `gh issue create` / `gh issue comment`.

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ cdk.context.json
 # markgate pr-review sentinel
 .markgate-pr-review-sha
 
+# cdkd-parity tracking-issue sentinel (per-worktree; written by /check-cdkd-parity)
+.cdkd-parity-issue
+
 # Worktree-local scratch files for git commit -F / gh --body-file payloads
 .commit-msg*.txt
 .commit-msg*.md


### PR DESCRIPTION
## Summary

Makes the `check-cdkd-parity` flow **actually file a cdkd tracking issue** when
cdk-local changes its host-facing surface, and **hard-enforces** it for the
unambiguous cases — so the cdkd agent can follow cdk-local by just working its
issue queue.

**Problem:** the skill's "notify cdkd" step was manual and optional (file an
issue OR cross-link OR note in the PR body), and the `cdkd-parity` marker is set
merely by *walking* the four categories — not by verifying an issue was filed.
A markgate marker attests "the checklist ran," not "the side-effect happened,"
so agents took the lightest path and a cdkd tracking issue was never actually
created.

## Changes

- **`check-cdkd-parity` SKILL.md** — when any category applies, the skill now
  AUTO-CREATES (or reuses, idempotently via the per-worktree `.cdkd-parity-issue`
  sentinel) a tracking issue on `go-to-k/cdkd`, labeling each applicable
  category with its host action: cat 1 = wrap (required), cat 2 = inherit
  (required), cat 3 = optional-adopt (cdkd decides), cat 4 = adapt (required).
  The cdk-local PR is referenced by full GitHub URL (never bare `#N`). The
  marker is set only after the issue exists.
- **`cdkd-parity-gate.sh`** — on top of the marker, HARD-BLOCK `gh pr create`
  for the two mechanically-unambiguous host-MUST-act categories — cat 1 (a new
  `local-*.ts` factory file declaring `createLocal*Command`) and cat 2 (a new
  `addOption(new Option` line) — until `.cdkd-parity-issue` carries a
  `github.com/go-to-k/cdkd/issues/` reference. cat 3 (noisy) / cat 4 (judgment)
  are not hard-blocked; they rely on the marker.
- **`.claude/settings.json`** — a scoped `permissions.allow` pre-authorizes
  `gh issue create` / `gh issue comment --repo go-to-k/cdkd` so the auto-create
  is frictionless.
- **`.gitignore`** — ignore the per-worktree `.cdkd-parity-issue` sentinel.
- **Docs** — `.claude/rules/hooks.md` + `.claude/CLAUDE.md`.

## Why cat 3 is filed-but-not-hard-blocked

A new internal export is additive — cdkd's build won't break by not adopting
it. But cdk-local can't know whether cdkd *wants* it, so we still file (labeled
"optional — cdkd decides") rather than let cdk-local silently decide for the
host. The hard block stays on cat 1/2 (host must wrap/inherit) to avoid
over-firing the gate on every internal refactor.

## Test plan

- `vp run check` / `vp run build` / `vp run test` (2929) green (no `src/`
  touched).
- **Hook live-tested end-to-end** against a throwaway repo (`git update-ref`
  origin/main): cat-1 (new factory) and cat-2 (new `addOption`) without a
  sentinel ref → exit 2 with the issue-required message; with the
  `github.com/go-to-k/cdkd/issues/` ref → pass; an out-of-scope (docs-only)
  diff → exit 0; a new NON-factory `local-*.ts` helper → not blocked (the
  factory-content check excludes it).
- Inline review (233 LOC, all `.claude/` infra).

This is the follow-up to the AgentCore `/ws` studio work that surfaced the gap
(cdkd issue go-to-k/cdkd#765 was the first one ever filed, by hand).
