### PR TITLE
fix(studio): guard IME Enter + add Clear button in the WebSocket console

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -205,6 +205,7 @@ const STUDIO_CSS = `
   .endpoint:hover { text-decoration: underline; }
   .ws-console .ws-status { font-size: 12px; color: #888; margin-left: 8px; font-weight: 400; }
   .ws-console .ws-status.on { color: #4ec97a; }
+  .ws-console h3 .ws-clear { float: right; font-weight: 400; }
   .ws-row { display: flex; gap: 6px; align-items: center; margin: 6px 0; }
   .ws-row .ws-input { flex: 1; min-width: 0; background: #1a1a1a; border: 1px solid #333;
     color: #ddd; border-radius: 4px; padding: 5px 7px; font: inherit; }
@@ -1650,6 +1651,12 @@ const STUDIO_SCRIPT = `
       inp.value = '';
     }
   }
+  function wsClear() {
+    // Clear only the displayed frame log; the live socket stays connected.
+    wsFrames = [];
+    const pre = wsEl('.ws-frames');
+    if (pre) pre.textContent = '';
+  }
 
   function renderWsConsole(wsUrl) {
     // A fresh target's console starts with a clean frame log; same-url
@@ -1667,7 +1674,13 @@ const STUDIO_SCRIPT = `
     const input = el('input', 'ws-input');
     input.placeholder = '{ "action": "sendMessage", "text": "hi" }';
     input.disabled = !on;
-    input.onkeydown = function (e) { if (e.key === 'Enter') wsSend(); };
+    // Guard against an IME composition Enter: while composing (e.g. confirming
+    // a Japanese / CJK conversion candidate), the Enter that COMMITS the
+    // conversion must NOT send the frame. e.isComposing is true mid-composition;
+    // keyCode 229 is the legacy signal some IMEs fire instead.
+    input.onkeydown = function (e) {
+      if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229) wsSend();
+    };
     const sendBtn = el('button', 'ws-send', 'Send');
     sendBtn.disabled = !on;
     sendBtn.onclick = wsSend;
@@ -1677,6 +1690,10 @@ const STUDIO_SCRIPT = `
     row.appendChild(input);
     row.appendChild(sendBtn);
     sec.appendChild(row);
+
+    const clearBtn = el('button', 'log-clear ws-clear', 'Clear');
+    clearBtn.onclick = wsClear;
+    h.appendChild(clearBtn);
 
     const frames = el('pre', 'ws-frames', wsFrames.join('\\n'));
     sec.appendChild(frames);

--- a/tests/unit/local/studio-ui-ws-console.test.ts
+++ b/tests/unit/local/studio-ui-ws-console.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from 'vite-plus/test';
+import { createStudioHarness, type StudioHarness } from './studio-ui-harness.js';
+
+/**
+ * jsdom execution coverage for the studio WebSocket console (renderWsConsole),
+ * shared by the served API Gateway WebSocket API (issue #303) and the
+ * `agentcore-ws` serve. Covers two UX fixes:
+ *
+ *  1. An IME composition Enter (confirming a Japanese / CJK conversion
+ *     candidate) must NOT send the frame — only a plain Enter does.
+ *  2. The console has a Clear button that empties the displayed frame log
+ *     without dropping the live socket.
+ *
+ * The harness exposes `renderWsConsole` via the epilogue hook; the console's
+ * `wsEl(...)` selectors query `#workspace .ws-console ...`, so the rendered
+ * section is appended to the page's `#workspace` before driving it. A fake
+ * `WebSocket` (readyState OPEN) stands in for the browser global so `wsSend`'s
+ * `activeWs.readyState === 1` guard passes with no real network handle.
+ */
+
+let harness: StudioHarness;
+
+afterEach(() => {
+  harness?.close();
+});
+
+interface WsHarness extends StudioHarness {
+  window: StudioHarness['window'] & { __renderWsConsole: (url: string) => HTMLElement };
+}
+
+/** Render the WS console for a url and mount it under #workspace + a fake WebSocket. */
+function mountConsole(): { node: HTMLElement; input: HTMLInputElement; pre: HTMLElement } {
+  harness = createStudioHarness({
+    epilogue: 'window.__renderWsConsole = renderWsConsole;',
+  }) as WsHarness;
+  const win = harness.window as WsHarness['window'];
+
+  class FakeWS {
+    url: string;
+    readyState = 1; // OPEN — wsSend's guard checks this directly
+    sent: string[] = [];
+    onopen: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    onmessage: ((e: unknown) => void) | null = null;
+    onerror: (() => void) | null = null;
+    constructor(url: string) {
+      this.url = url;
+    }
+    send(d: string): void {
+      this.sent.push(d);
+    }
+    close(): void {
+      this.readyState = 3;
+    }
+  }
+  (win as unknown as { WebSocket: unknown }).WebSocket = FakeWS;
+
+  const node = win.__renderWsConsole('ws://127.0.0.1:9/ws');
+  win.document.getElementById('workspace')!.appendChild(node);
+
+  // Connect so activeWs is OPEN and the input is enabled.
+  (node.querySelector('.ws-connect') as HTMLElement & { onclick: () => void }).onclick();
+
+  const input = node.querySelector('.ws-input') as HTMLInputElement;
+  const pre = node.querySelector('.ws-frames') as HTMLElement;
+  return { node, input, pre };
+}
+
+/** Invoke the input's onkeydown handler directly with an event-like literal. */
+function keydown(input: HTMLInputElement, ev: Partial<KeyboardEvent>): void {
+  (input as unknown as { onkeydown: (e: Partial<KeyboardEvent>) => void }).onkeydown(ev);
+}
+
+describe('studio WebSocket console (renderWsConsole)', () => {
+  it('an IME composition Enter (isComposing) does NOT send the frame', () => {
+    const { input, pre } = mountConsole();
+    input.value = 'hello';
+    keydown(input, { key: 'Enter', isComposing: true });
+    // Frame is untouched — the Enter only commits the IME conversion.
+    expect(input.value).toBe('hello');
+    expect(pre.textContent).not.toContain('-> hello');
+  });
+
+  it('a legacy keyCode 229 Enter (IME signal) does NOT send the frame', () => {
+    const { input } = mountConsole();
+    input.value = 'world';
+    keydown(input, { key: 'Enter', isComposing: false, keyCode: 229 });
+    expect(input.value).toBe('world');
+  });
+
+  it('a plain Enter (no composition) sends the frame and clears the input', () => {
+    const { input, pre } = mountConsole();
+    input.value = 'hello';
+    keydown(input, { key: 'Enter', isComposing: false });
+    expect(input.value).toBe('');
+    expect(pre.textContent).toContain('-> hello');
+  });
+
+  it('the Clear button empties the displayed frame log', () => {
+    const { node, input, pre } = mountConsole();
+    input.value = 'hello';
+    keydown(input, { key: 'Enter', isComposing: false });
+    expect(pre.textContent!.length).toBeGreaterThan(0);
+
+    (node.querySelector('.ws-clear') as HTMLElement & { onclick: () => void }).onclick();
+    expect(pre.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Two UX fixes to the studio WebSocket console (`renderWsConsole`), which is
shared by the served API Gateway WebSocket API and the `agentcore-ws` serve —
so both fixes apply to both consoles via the single shared function.

- **IME composition Enter no longer sends early.** Typing Japanese / CJK and
  pressing Enter to commit the conversion candidate previously sent the frame
  before the conversion was confirmed. The Enter handler now guards on
  `!e.isComposing && e.keyCode !== 229`, so only a plain (non-composition)
  Enter sends.
- **Clear button for the frame log.** The console gained a Clear button
  (reusing the Logs panel's `log-clear` styling, floated into the section
  header) that empties the displayed frame log without dropping the live
  socket.

## Changes

- `src/local/studio-ui.ts` — IME guard on the WS input `onkeydown`; a
  `wsClear()` that empties `wsFrames` + the live `<pre>`; a Clear button wired
  into the console header; one CSS rule to float it right.
- `tests/unit/local/studio-ui-ws-console.test.ts` — jsdom execution coverage
  driving the **real shipped `STUDIO_SCRIPT`**: the composition guard
  (`isComposing` + legacy `keyCode` 229), the plain-Enter send path, and the
  Clear button.

## Test plan

- `vp run check` (0 errors; 1 pre-existing unrelated warning in
  `cloudfront-edge-event.ts`) / `vp run build` green.
- `vp run test` — 194 files, 2933 tests green (4 new).
- `/run-integ local-studio` — green, 0 docker orphans (exercises the studio
  serve + `agentcore-ws` bridge + ws-console sections end-to-end).
- Inline review: additive, 126 LOC / 2 files, no security surface.
