### PR TITLE
fix(studio): make the folded stack sub-header legible on the dark pane

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -124,10 +124,15 @@ const STUDIO_CSS = `
             mask-image: linear-gradient(to right, #000 calc(100% - 14px), transparent);
   }
   .target .name::-webkit-scrollbar { display: none; }
-  /* The folded common stack prefix shared by the rows beneath it. */
+  /* The folded common stack prefix shared by the rows beneath it — a quiet
+     section-divider bar: a brighter label on a faint background bar (distinct
+     from both the #1a1a1a / #242424 row shades) with a hairline bottom border,
+     so the prefix reads clearly on the dark pane instead of disappearing as
+     dim grey-on-black. */
   .stack-sub {
-    padding: 4px 12px 2px; color: #6f6f6f; font-size: 10px;
+    padding: 4px 12px 3px; color: #b5b5b5; font-size: 10px;
     font-family: ui-monospace, Menlo, monospace;
+    background: #202020; border-bottom: 1px solid #2c2c2c;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .target .kind { color: #8f8f8f; font-size: 11px; }

--- a/tests/unit/local/studio-ui-target-fold.test.ts
+++ b/tests/unit/local/studio-ui-target-fold.test.ts
@@ -140,4 +140,12 @@ describe('targets pane construct-path CSS', () => {
     expect(html).toContain('.target .name::-webkit-scrollbar { display: none; }');
     expect(html).toContain('.stack-sub {');
   });
+
+  it('renders the stack sub-header as a legible divider bar (brighter label + faint bar)', () => {
+    const html = renderStudioHtml('TestStack', 'cdkl');
+    // A brighter label on a faint background bar, so the folded prefix reads on
+    // the dark pane instead of disappearing as dim grey-on-black.
+    expect(html).toContain('color: #b5b5b5');
+    expect(html).toContain('background: #202020; border-bottom: 1px solid #2c2c2c;');
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the per-stack construct-path folding (#418): the folded
`<stack>/` sub-header (`.stack-sub`) rendered as dim `#6f6f6f` grey with no
background, so it disappeared against the dark targets pane.

Render it as a quiet section-divider bar instead:
- brighter `#b5b5b5` label (reads on the dark pane, still below the `#ddd`
  row names so the hierarchy holds)
- faint `#202020` background bar, distinct from both row shades
  (`#1a1a1a` / `#242424`)
- hairline `#2c2c2c` bottom border to delineate the bar

## Test plan

- Unit (`studio-ui-target-fold.test.ts`): added a CSS assertion locking the
  brighter label + bar treatment.
- Integ (`local-studio`): served-UI assertions still green (Docker, 0 orphans).
- Visual confirmation deferred to post-publish eyeball (the embedded UI's
  colors render in the browser).
