### PR TITLE
fix(studio): tie the UI live/disconnected indicator to its originating server

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -672,7 +672,10 @@ compute-locally category for Lambda + API Gateway).
   default via `filterStudioCustomResources`, issue #323 — pass
   `cdkl studio --include-custom-resources` to surface them)
   at `/api/targets`, an SSE
-  stream of the event bus at `/api/events`, `POST /api/run` (single-shot
+  stream of the event bus at `/api/events` (which opens with a `hello`
+  event carrying a per-boot `instanceId` and beats a JS-visible `ping`
+  event every `SSE_HEARTBEAT_MS` so the UI can detect a dead / swapped
+  server — see studio-ui's liveness watchdog), `POST /api/run` (single-shot
   invoke / serve start), `POST /api/stop` (serve stop),
   `GET /api/running` (running serve snapshot), `POST /api/request`
   (issue #322 — relay a composed HTTP request to a running serve via
@@ -799,7 +802,14 @@ compute-locally category for Lambda + API Gateway).
   Request/Response detail whose [Re-invoke] reuses that serve's request
   composer (pre-filled), and a re-invoked row is visually linked to its
   source; a log search box queries the store and a captured request's
-  detail shows its bound logs),
+  detail shows its bound logs. The header `● live` / `● disconnected`
+  indicator is driven by `connect()`'s liveness logic: it binds to the
+  FIRST `/api/events` `hello` instanceId, flips to disconnected (latched,
+  socket closed) when a reconnect lands on a DIFFERENT instanceId (a second
+  `cdkl studio` that reused this port after the originating process exited),
+  and a heartbeat watchdog flips to disconnected when no `ping` / event
+  arrives within the liveness window — so a dead server is detected even
+  when the dropped socket never surfaces an EventSource `error`),
   studio-reinvoke (issue #284 — `reinvoke({invocationId, payload}, {store,
   dispatcher})`: resolves the source target from the recorded invocation
   and re-fires the edited payload through the SAME single-shot dispatcher

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { randomUUID } from 'node:crypto';
 import {
   StudioEventBus,
   type StudioInvocationEvent,
@@ -354,6 +355,14 @@ export async function startStudioServer(
   const host = options.host ?? '127.0.0.1';
   const maxBump = options.maxPortBump ?? 20;
   const html = renderStudioHtml(options.appLabel, options.cliName);
+  // A per-boot identity so the browser can tell THIS server instance apart
+  // from any other studio process. The SSE stream announces it in a `hello`
+  // event on connect; the UI flips to "disconnected" if a reconnect ever
+  // lands on a DIFFERENT instance (e.g. a second `cdkl studio` that reused
+  // this port after the originating process exited). Without it, liveness
+  // tracked only the TCP socket + port, so the UI could read as "live"
+  // against the wrong server.
+  const instanceId = randomUUID();
   // The served target list is mutable (issue #385): a Session-bar
   // `--from-cfn-stack` change re-runs the ECS pin classification and pushes a
   // fresh groups + dockerfiles set in via `setTargets`. Held as a
@@ -365,7 +374,7 @@ export async function startStudioServer(
   });
 
   const server = createServer((req, res) =>
-    handleRequest(req, res, options.bus, html, () => targetsJson, options)
+    handleRequest(req, res, options.bus, html, () => targetsJson, options, instanceId)
   );
 
   const boundPort = await listenWithBump(server, host, options.port, maxBump);
@@ -392,7 +401,8 @@ function handleRequest(
   bus: StudioEventBus,
   html: string,
   getTargetsJson: () => string,
-  options: StudioServerOptions
+  options: StudioServerOptions,
+  instanceId: string
 ): void {
   const url = req.url ?? '/';
   const path = url.split('?')[0];
@@ -453,7 +463,7 @@ function handleRequest(
     return;
   }
   if (req.method === 'GET' && path === '/api/events') {
-    serveSse(req, res, bus);
+    serveSse(req, res, bus, instanceId);
     return;
   }
   if (req.method === 'POST' && path === '/api/run') {
@@ -558,7 +568,12 @@ function readJsonBody(req: IncomingMessage): Promise<unknown> {
   });
 }
 
-function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus): void {
+function serveSse(
+  req: IncomingMessage,
+  res: ServerResponse,
+  bus: StudioEventBus,
+  instanceId: string
+): void {
   res.writeHead(200, {
     'content-type': 'text/event-stream; charset=utf-8',
     'cache-control': 'no-cache, no-transform',
@@ -566,7 +581,12 @@ function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus
   });
 
   let closed = false;
-  const heartbeat = setInterval(() => safeWrite(':hb\n\n'), SSE_HEARTBEAT_MS);
+  // A JS-VISIBLE heartbeat (a named `ping` event, not an SSE `:comment`):
+  // the browser EventSource layer cannot observe comments, so the UI runs a
+  // client-side watchdog that flips to "disconnected" when these stop
+  // arriving — catching a dead server even when the TCP close is never
+  // surfaced as an `error` event (a backgrounded tab / a missed FIN).
+  const heartbeat = setInterval(() => safeWrite(`event: ping\ndata: {}\n\n`), SSE_HEARTBEAT_MS);
   heartbeat.unref?.();
 
   const onInvocation = (ev: StudioInvocationEvent): void => {
@@ -616,8 +636,12 @@ function serveSse(req: IncomingMessage, res: ServerResponse, bus: StudioEventBus
   res.on('close', cleanup);
   res.on('error', cleanup);
 
-  // Open the stream so EventSource fires `open` immediately.
-  safeWrite(':ok\n\n');
+  // Open the stream so EventSource fires `open` immediately, and announce
+  // this server's per-boot instance id as the first event. The UI records
+  // the first `hello` it sees and treats a later, DIFFERENT id (a reconnect
+  // that landed on another studio process reusing this port) as a
+  // disconnect from the originating server.
+  safeWrite(`event: hello\ndata: ${JSON.stringify({ instanceId })}\n\n`);
 }
 
 /**

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -2048,14 +2048,47 @@ const STUDIO_SCRIPT = `
     }
   }
 
-  function connect() {
+  function setConn(live) {
     const conn = document.getElementById('conn');
+    if (!conn) return;
+    conn.textContent = live ? '● live' : '● disconnected';
+    conn.className = live ? 'up' : 'down';
+  }
+  // Liveness watchdog window: the SSE stream emits a ping event every ~15s
+  // (plus real events). If nothing arrives for longer than this, the
+  // originating server is gone even when the dropped socket never surfaced an
+  // error event. Kept a generous multiple of the server heartbeat so a slow
+  // tick can never false-trip.
+  const LIVENESS_TIMEOUT_MS = 45000;
+  function connect() {
     const es = new EventSource('/api/events');
-    es.addEventListener('open', () => { conn.textContent = '● live'; conn.className = 'up'; });
-    es.addEventListener('error', () => { conn.textContent = '● disconnected'; conn.className = 'down'; });
-    es.addEventListener('invocation', (e) => addInvocation(JSON.parse(e.data)));
-    es.addEventListener('serve', (e) => onServeEvent(JSON.parse(e.data)));
+    let seenInstance = null;     // instanceId of the server we first connected to
+    let lastBeat = 0;            // ms timestamp of the last received message
+    let dead = false;            // latched once this server is judged gone
+    const beat = () => { lastBeat = Date.now(); if (!dead) setConn(true); };
+    es.addEventListener('open', () => beat());
+    es.addEventListener('error', () => { if (!dead) setConn(false); });
+    es.addEventListener('ping', () => beat());
+    es.addEventListener('hello', (e) => {
+      let id = null;
+      try { id = JSON.parse(e.data).instanceId; } catch (_) { id = null; }
+      if (seenInstance === null) { seenInstance = id; beat(); return; }
+      if (id && id !== seenInstance) {
+        // The reconnect landed on a DIFFERENT studio process that reused this
+        // port after the originating server exited. It is not our server, so
+        // stay disconnected and stop listening (a page reload re-binds to the
+        // new server cleanly).
+        dead = true;
+        setConn(false);
+        es.close();
+        return;
+      }
+      beat();
+    });
+    es.addEventListener('invocation', (e) => { beat(); addInvocation(JSON.parse(e.data)); });
+    es.addEventListener('serve', (e) => { beat(); onServeEvent(JSON.parse(e.data)); });
     es.addEventListener('log', (e) => {
+      beat();
       const ev = JSON.parse(e.data);
       const arr = logsById.get(ev.containerId) || [];
       arr.push(ev.line);
@@ -2069,6 +2102,10 @@ const STUDIO_SCRIPT = `
         serveLogPre.textContent = arr.join('\\n');
       }
     });
+    setInterval(() => {
+      if (dead) return;
+      if (lastBeat && Date.now() - lastBeat > LIVENESS_TIMEOUT_MS) setConn(false);
+    }, 5000);
   }
 
   function onServeEvent(ev) {

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -553,7 +553,7 @@ describe('startStudioServer', () => {
     const reader = res.body!.getReader();
     const decoder = new TextDecoder();
 
-    // The server writes an opening `:ok` comment; read it so we know the
+    // The server writes an opening `hello` event; read it so we know the
     // subscription is live before emitting.
     await reader.read();
     bus.emit('invocation', {
@@ -875,7 +875,7 @@ describe('startStudioServer', () => {
     const res = await resP;
     const reader = res.body!.getReader();
     const decoder = new TextDecoder();
-    await reader.read(); // opening `:ok`
+    await reader.read(); // opening `hello`
 
     bus.emit('serve', {
       ts: 1,

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -577,6 +577,49 @@ describe('startStudioServer', () => {
     expect(buf).toContain('"id":"sse1"');
   });
 
+  it('opens the SSE stream with a hello event carrying a per-boot instanceId', async () => {
+    const server = await boot();
+    const { res: resP, abort } = openSse(`${server.url}/api/events`);
+    const res = await resP;
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    let buf = '';
+    while (!buf.includes('event: hello')) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+    }
+    abort();
+
+    expect(buf).toContain('event: hello');
+    const m = /event: hello\ndata: (\{.*\})/.exec(buf);
+    expect(m).not.toBeNull();
+    const payload = JSON.parse(m![1]);
+    expect(typeof payload.instanceId).toBe('string');
+    expect(payload.instanceId.length).toBeGreaterThan(0);
+  });
+
+  it('gives a distinct instanceId to each studio server boot', async () => {
+    async function helloId(server: RunningStudioServer): Promise<string> {
+      const { res: resP, abort } = openSse(`${server.url}/api/events`);
+      const res = await resP;
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      while (!buf.includes('event: hello')) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+      }
+      abort();
+      return JSON.parse(/data: (\{.*\})/.exec(buf)![1]).instanceId;
+    }
+    const a = await boot();
+    const b = await boot();
+    expect(await helloId(a)).not.toBe(await helloId(b));
+  });
+
   it('bumps to the next free port when the preferred port is taken', async () => {
     const first = await boot({ port: 0 });
     // Re-request the SAME concrete port the first server bound; the bump

--- a/tests/unit/local/studio-ui-liveness.test.ts
+++ b/tests/unit/local/studio-ui-liveness.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from 'vite-plus/test';
+import { createStudioHarness, type StudioHarness } from './studio-ui-harness.js';
+
+/**
+ * Execution coverage for the studio UI connection-liveness logic (the `● live`
+ * / `● disconnected` indicator). The embedded `connect()` must:
+ *
+ *   - bind to the FIRST server `hello` instanceId it sees, and
+ *   - flip to disconnected (and stay there) when a reconnect lands on a
+ *     DIFFERENT studio process that reused the port — so a second
+ *     `cdkl studio` cannot keep an orphaned UI reading "live", and
+ *   - flip to disconnected via a heartbeat watchdog when the originating
+ *     server simply dies and no events arrive, even if the dropped socket
+ *     never surfaces an `error` event.
+ *
+ * The harness exposes `connect` via an epilogue and the test drives a
+ * controllable in-memory `EventSource`, so no real network / timers are used
+ * for the event-driven cases.
+ */
+
+let harness: StudioHarness;
+
+afterEach(() => {
+  harness?.close();
+});
+
+/** A controllable in-memory EventSource: records listeners + lets a test fire events. */
+class FakeES {
+  static last: FakeES | undefined;
+  listeners: Record<string, Array<(e: { data?: string }) => void>> = {};
+  closed = false;
+  constructor(public url: string) {
+    FakeES.last = this;
+  }
+  addEventListener(type: string, fn: (e: { data?: string }) => void): void {
+    (this.listeners[type] ||= []).push(fn);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  emit(type: string, data?: string): void {
+    (this.listeners[type] || []).forEach((fn) => fn({ data }));
+  }
+}
+
+function bootHarness(): { connect: () => void; win: Record<string, unknown> } {
+  harness = createStudioHarness({ epilogue: 'window.__connect = connect;' });
+  const win = harness.window as unknown as Record<string, unknown>;
+  FakeES.last = undefined;
+  win.EventSource = FakeES;
+  return { connect: win.__connect as () => void, win };
+}
+
+function connText(): string {
+  return harness.document.getElementById('conn')!.textContent ?? '';
+}
+
+describe('studio UI connection liveness', () => {
+  it('goes live on the first hello and stays live on a same-instance ping', () => {
+    const { connect } = bootHarness();
+    connect();
+    const es = FakeES.last!;
+    es.emit('hello', JSON.stringify({ instanceId: 'A' }));
+    expect(connText()).toBe('● live');
+    es.emit('error');
+    expect(connText()).toBe('● disconnected');
+    es.emit('ping');
+    expect(connText()).toBe('● live');
+  });
+
+  it('disconnects (latched) when a reconnect lands on a DIFFERENT instance', () => {
+    const { connect } = bootHarness();
+    connect();
+    const es = FakeES.last!;
+    es.emit('hello', JSON.stringify({ instanceId: 'A' }));
+    expect(connText()).toBe('● live');
+
+    // A second studio process reused the port; the stream now announces a
+    // different instanceId. The UI must drop to disconnected and stop listening.
+    es.emit('hello', JSON.stringify({ instanceId: 'B' }));
+    expect(connText()).toBe('● disconnected');
+    expect(es.closed).toBe(true);
+
+    // Latched: a stray later event from the wrong server cannot revive it.
+    es.emit('ping');
+    expect(connText()).toBe('● disconnected');
+  });
+
+  it('disconnects via the watchdog when heartbeats stop arriving', () => {
+    const captured: Array<() => void> = [];
+    harness = createStudioHarness({ epilogue: 'window.__connect = connect;' });
+    const win = harness.window as unknown as Record<string, unknown>;
+    FakeES.last = undefined;
+    win.EventSource = FakeES;
+    // Capture the watchdog interval callback instead of relying on real time.
+    win.setInterval = ((fn: () => void) => {
+      captured.push(fn);
+      return captured.length;
+    }) as unknown as typeof setInterval;
+
+    (win.__connect as () => void)();
+    const es = FakeES.last!;
+    es.emit('hello', JSON.stringify({ instanceId: 'A' }));
+    expect(connText()).toBe('● live');
+
+    const realNow = (win.Date as DateConstructor).now;
+    try {
+      // Advance the clock past the liveness window; the watchdog must fire.
+      (win.Date as unknown as { now: () => number }).now = () => realNow() + 46_000;
+      captured.forEach((fn) => fn());
+    } finally {
+      (win.Date as unknown as { now: () => number }).now = realNow;
+    }
+    expect(connText()).toBe('● disconnected');
+  });
+});


### PR DESCRIPTION
## Summary

The `cdkl studio` web UI's header `● live` / `● disconnected` indicator was
tied only to the EventSource TCP connection to `/api/events` staying open,
with the listen port as the server's only identity. The SSE heartbeat was an
SSE `:comment`, invisible to the browser EventSource JS layer, so the UI had
no application-level liveness signal and no way to tell one studio process
from another.

Two user-visible consequences:

1. When the originating `cdkl studio` process exited, a missed / delayed
   socket FIN could leave the EventSource in `OPEN` state, so the UI kept
   reading `● live` indefinitely.
2. With a second `cdkl studio` running (another CDK project), the first
   project's UI could not distinguish its own server from the other instance,
   so it stayed `live` even though its originating process was gone.

## What changed

- **studio-server**: stamp a per-boot `instanceId` (`randomUUID`) and announce
  it in a `hello` event when the SSE stream opens. Emit the heartbeat as a
  JS-visible `ping` event instead of an SSE `:comment`.
- **studio-ui** (`connect()`):
  - binds to the FIRST `hello` `instanceId` it sees;
  - latches to `disconnected` (and closes the socket) if a reconnect lands on
    a DIFFERENT `instanceId` — i.e. a second studio that reused this port
    after the originating process exited;
  - runs a heartbeat **watchdog** that flips to `disconnected` when no `ping`
    / event arrives within the liveness window — detecting a dead server even
    when the dropped socket never surfaces an EventSource `error`.

So an orphaned UI now correctly shows `disconnected` when its originating
`cdkl studio` dies, regardless of whether another studio process is alive.

## Test plan

- Unit: server emits a `hello` event carrying a per-boot `instanceId`, and
  distinct ids across boots; UI goes live on first hello, stays live on a
  same-instance ping, disconnects (latched, socket closed) on a different
  instanceId, and disconnects via the watchdog when heartbeats stop.
- Live: booted two real servers from the built `dist/internal.js` and
  confirmed distinct `hello` instanceIds; confirmed the `ping` heartbeat
  arrives over the wire.
- Integration: `local-studio` (Docker) green end-to-end, 0 orphan
  containers / networks / images.
