### PR TITLE
fix(invoke): pin --platform to the Lambda architecture for ZIP functions (exec format error)

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -499,7 +499,14 @@ async function resolveZipImagePlan(
 
   const image = resolveRuntimeImage(lambda.runtime);
 
-  await pullImage(image, options.pull === false);
+  // Run the base image at the Lambda's declared architecture (emulated when the
+  // host arch differs). A `provided.*` `bootstrap` compiled for one arch fails
+  // to exec on the other ("exec format error"); even managed runtimes can carry
+  // arch-specific native deps. The IMAGE path already pins the platform — the
+  // ZIP path must too.
+  const platform = architectureToPlatform(lambda.architecture);
+
+  await pullImage(image, options.pull === false, platform);
 
   const layerPlan = await materializeLambdaLayersIncludingArns(lambda.layers, options);
 
@@ -511,6 +518,7 @@ async function resolveZipImagePlan(
 
   return {
     image,
+    platform,
     mounts: [{ hostPath: codeDir, containerPath: containerCodePath, readOnly: true }],
     extraMounts: layerPlan.mount ? [layerPlan.mount] : [],
     cmd: [lambda.handler],

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -96,6 +96,7 @@ import { resolveEnvVars, type EnvOverrideFile } from '../../local/env-resolver.j
 import {
   extractEphemeralStorageMb,
   materializeAssetCodeDir,
+  resolveLambdaArchitecture,
   resolveLambdaLayers,
   type ResolvedLambdaLayer,
 } from '../../local/lambda-resolver.js';
@@ -2176,12 +2177,12 @@ async function buildContainerSpec(args: {
         inlineTmpDirs
       );
     }
-
-    // Run the warm container at the Lambda's declared architecture (emulated
-    // when the host arch differs) — a `provided.*` `bootstrap` compiled for one
-    // arch fails to exec on the other ("exec format error"). The IMAGE branch
-    // below already pins the platform; the ZIP branch must too.
-    platform = architectureToPlatform(lambda.architecture);
+    // NOTE: the ZIP warm container's `--platform` is derived from
+    // `lambda.architecture` inside the container pool's run path
+    // (`container-pool.ts` `startOne`), so it is NOT set on `platform` here —
+    // unlike the IMAGE branch below, the ZIP `ContainerSpec` carries the
+    // resolved `lambda` (with `architecture`) rather than a pre-computed
+    // platform string.
 
     // PR 6 (#232): pre-resolve the `/opt` bind-mount source. Single-
     // layer functions reuse the layer's asset dir directly; multi-
@@ -2749,9 +2750,9 @@ export function resolveLambdaByLogicalId(
     const ephemeralStorageMb = extractEphemeralStorageMb(props, logicalId);
     // Pin the warm container's platform to the declared architecture (default
     // x86_64) so a `provided.*` `bootstrap` does not hit an "exec format error".
-    const zipArches = props['Architectures'];
-    const architecture: 'x86_64' | 'arm64' =
-      Array.isArray(zipArches) && zipArches[0] === 'arm64' ? 'arm64' : 'x86_64';
+    // Shared with `cdkl invoke`'s resolver so an unsupported value errors
+    // consistently rather than being silently coerced to x86_64.
+    const architecture = resolveLambdaArchitecture(props, logicalId);
     return {
       kind: 'zip',
       stack,

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -2177,6 +2177,12 @@ async function buildContainerSpec(args: {
       );
     }
 
+    // Run the warm container at the Lambda's declared architecture (emulated
+    // when the host arch differs) — a `provided.*` `bootstrap` compiled for one
+    // arch fails to exec on the other ("exec format error"). The IMAGE branch
+    // below already pins the platform; the ZIP branch must too.
+    platform = architectureToPlatform(lambda.architecture);
+
     // PR 6 (#232): pre-resolve the `/opt` bind-mount source. Single-
     // layer functions reuse the layer's asset dir directly; multi-
     // layer functions get a freshly-merged tmpdir (later layers
@@ -2647,6 +2653,12 @@ interface ResolvedStartApiZipLambda extends ResolvedStartApiLambdaBase {
   handler: string;
   codePath: string | null;
   inlineCode?: string;
+  /**
+   * `Architectures: [x86_64]` (default) or `[arm64]` — pins the warm
+   * container's `--platform` so a `provided.*` `bootstrap` compiled for the
+   * other arch does not fail with `exec format error`.
+   */
+  architecture: 'x86_64' | 'arm64';
 }
 
 export interface ResolvedStartApiImageLambda extends ResolvedStartApiLambdaBase {
@@ -2735,6 +2747,11 @@ export function resolveLambdaByLogicalId(
     // the box.
     const layers = resolveLambdaLayers(stack, logicalId, props);
     const ephemeralStorageMb = extractEphemeralStorageMb(props, logicalId);
+    // Pin the warm container's platform to the declared architecture (default
+    // x86_64) so a `provided.*` `bootstrap` does not hit an "exec format error".
+    const zipArches = props['Architectures'];
+    const architecture: 'x86_64' | 'arm64' =
+      Array.isArray(zipArches) && zipArches[0] === 'arm64' ? 'arm64' : 'x86_64';
     return {
       kind: 'zip',
       stack,
@@ -2746,6 +2763,7 @@ export function resolveLambdaByLogicalId(
       timeoutSec,
       codePath,
       layers,
+      architecture,
       ...(inlineCode !== undefined && { inlineCode }),
       ...(ephemeralStorageMb !== undefined && { ephemeralStorageMb }),
     };

--- a/src/local/container-pool.ts
+++ b/src/local/container-pool.ts
@@ -1,5 +1,6 @@
 import { getLogger } from '../utils/logger.js';
 import { pickFreePort, removeContainer, runDetached, streamLogs } from './docker-runner.js';
+import { architectureToPlatform } from './docker-image-builder.js';
 import type { ResolvedImageLambda, ResolvedZipLambda } from './lambda-resolver.js';
 import { waitForRieReady } from './rie-client.js';
 import { resolveRuntimeCodeMountPath, resolveRuntimeImage } from './runtime-image.js';
@@ -373,6 +374,10 @@ export function createContainerPool(
       const image = resolveRuntimeImage(spec.lambda.runtime);
       containerId = await runDetached({
         image,
+        // Run the base image at the Lambda's declared architecture (emulated
+        // when the host arch differs) so a `provided.*` `bootstrap` does not
+        // hit an "exec format error". Mirrors the IMAGE branch's `spec.platform`.
+        platform: architectureToPlatform(spec.lambda.architecture),
         mounts: [{ hostPath: spec.codeDir, containerPath: containerCodePath, readOnly: true }],
         extraMounts,
         env: spec.env,

--- a/src/local/docker-runner.ts
+++ b/src/local/docker-runner.ts
@@ -163,16 +163,25 @@ export interface DockerRunOptions {
  * via `--verbose`). Errors are always surfaced: the captured stderr is
  * folded into the thrown `DockerRunnerError` message.
  */
-export async function pullImage(image: string, skipPull: boolean): Promise<void> {
+export async function pullImage(
+  image: string,
+  skipPull: boolean,
+  platform?: string
+): Promise<void> {
   const logger = getLogger().child('docker');
   if (skipPull) {
     logger.debug(`Skipping docker pull for ${image} (--no-pull)`);
     return;
   }
+  // Pull the variant matching the Lambda's declared `Architectures`. Without
+  // `--platform` docker picks the host's native arch, so on an arm64 host a
+  // function declared `x86_64` (or vice versa) gets a mismatched base image and
+  // a compiled `provided.*` `bootstrap` fails to exec ("exec format error").
+  const platformArgs = platform ? ['--platform', platform] : [];
   if (getLogger().getLevel() === 'debug') {
-    logger.info(`Pulling ${image}...`);
+    logger.info(`Pulling ${image}${platform ? ` (${platform})` : ''}...`);
     try {
-      await runDockerForeground(['pull', image]);
+      await runDockerForeground(['pull', ...platformArgs, image]);
     } catch (err) {
       const e = err as Error;
       throw new DockerRunnerError(`docker pull ${image} failed: ${e.message}`);
@@ -187,7 +196,7 @@ export async function pullImage(image: string, skipPull: boolean): Promise<void>
   // motion during what is otherwise a multi-minute silent pull
   // against a real-world image.
   try {
-    await runDockerStreaming(['pull', image], {
+    await runDockerStreaming(['pull', ...platformArgs, image], {
       streamLive: false,
       progressLabel: `Pulling ${image}`,
     });

--- a/src/local/front-door-lambda-runner.ts
+++ b/src/local/front-door-lambda-runner.ts
@@ -156,10 +156,15 @@ async function resolveZipImagePlan(
     assetTmpDir = materialized.tmpDir;
   }
   const image = resolveRuntimeImage(lambda.runtime);
-  await pullImage(image, opts.skipPull === true);
+  // Run the base image at the Lambda's declared architecture (emulated when the
+  // host arch differs) so a `provided.*` `bootstrap` does not hit an "exec
+  // format error". Mirrors the IMAGE path's `platformOverride ?? <arch>`.
+  const platform = opts.platformOverride ?? architectureToPlatform(lambda.architecture);
+  await pullImage(image, opts.skipPull === true, platform);
   const containerCodePath = resolveRuntimeCodeMountPath(lambda.runtime);
   return {
     image,
+    platform,
     mounts: [{ hostPath: codeDir, containerPath: containerCodePath, readOnly: true }],
     cmd: [lambda.handler],
     ...(inlineTmpDir !== undefined && { inlineTmpDir }),

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -226,7 +226,7 @@ export interface ResolvedImageLambda extends ResolvedLambdaBase {
  * without it a `provided.*` `bootstrap` compiled for one arch fails with
  * `exec format error` when run at the host's native arch.
  */
-function resolveLambdaArchitecture(
+export function resolveLambdaArchitecture(
   props: Record<string, unknown>,
   logicalId: string
 ): 'x86_64' | 'arm64' {

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -177,6 +177,14 @@ export interface ResolvedZipLambda extends ResolvedLambdaBase {
    * writes this into a temp dir at the path implied by `handler`.
    */
   inlineCode?: string;
+  /**
+   * `Architectures: [x86_64]` (default) or `[arm64]`. Threaded through to
+   * `--platform linux/amd64` / `linux/arm64` on the warm container's
+   * `docker run` (and base-image pull). Without it the base image runs at the
+   * host's native arch, so a `provided.*` `bootstrap` compiled for the other
+   * arch fails with `exec format error`.
+   */
+  architecture: 'x86_64' | 'arm64';
 }
 
 export interface ResolvedImageLambda extends ResolvedLambdaBase {
@@ -209,6 +217,30 @@ export interface ResolvedImageLambda extends ResolvedLambdaBase {
    * `exec format error`.
    */
   architecture: 'x86_64' | 'arm64';
+}
+
+/**
+ * Resolve a Lambda's `Architectures` array to a single architecture, defaulting
+ * to `x86_64` (AWS's default when the property is omitted). Shared by the ZIP
+ * and IMAGE resolution paths so both pin `--platform` to the declared arch —
+ * without it a `provided.*` `bootstrap` compiled for one arch fails with
+ * `exec format error` when run at the host's native arch.
+ */
+function resolveLambdaArchitecture(
+  props: Record<string, unknown>,
+  logicalId: string
+): 'x86_64' | 'arm64' {
+  const arches = props['Architectures'];
+  if (Array.isArray(arches) && arches.length > 0) {
+    const first: unknown = arches[0];
+    if (first === 'arm64') return 'arm64';
+    if (first === 'x86_64') return 'x86_64';
+    throw new LocalInvokeResolutionError(
+      `Lambda '${logicalId}' has unsupported Architectures value '${String(first)}'. ` +
+        `${getEmbedConfig().cliName} supports x86_64 and arm64.`
+    );
+  }
+  return 'x86_64';
 }
 
 export class LocalInvokeResolutionError extends Error {
@@ -461,6 +493,7 @@ function extractLambdaProperties(
   // offending entry instead of a silently-missing `/opt/<lib>` at
   // invoke time.
   const layers = resolveLambdaLayers(stack, logicalId, props);
+  const architecture = resolveLambdaArchitecture(props, logicalId);
 
   return {
     kind: 'zip',
@@ -473,6 +506,7 @@ function extractLambdaProperties(
     timeoutSec,
     codePath,
     layers,
+    architecture,
     ...(ephemeralStorageMb !== undefined && { ephemeralStorageMb }),
     ...(inlineCode !== undefined && { inlineCode }),
   };
@@ -659,21 +693,7 @@ function extractImageLambdaProperties(args: {
     imageConfig.workingDirectory = rawImageConfig['WorkingDirectory'];
   }
 
-  // Architectures is an array (CFn). CDK never sets more than one entry.
-  // Default x86_64 matches AWS.
-  const arches = props['Architectures'];
-  let architecture: 'x86_64' | 'arm64' = 'x86_64';
-  if (Array.isArray(arches) && arches.length > 0) {
-    const first: unknown = arches[0];
-    if (first === 'arm64') architecture = 'arm64';
-    else if (first === 'x86_64') architecture = 'x86_64';
-    else {
-      throw new LocalInvokeResolutionError(
-        `Lambda '${logicalId}' has unsupported Architectures value '${String(first)}'. ` +
-          `${getEmbedConfig().cliName} supports x86_64 and arm64.`
-      );
-    }
-  }
+  const architecture = resolveLambdaArchitecture(props, logicalId);
 
   // PR 6 (#232): container Lambdas reject `Layers` at deploy time on
   // the AWS side — layers are baked into the image at build time, not

--- a/tests/unit/local/container-pool-sensitive-env.test.ts
+++ b/tests/unit/local/container-pool-sensitive-env.test.ts
@@ -35,10 +35,13 @@ vi.mock('../../../src/local/runtime-image.js', () => ({
 
 const { createContainerPool } = await import('../../../src/local/container-pool.js');
 
-function zipSpec(sensitiveEnvKeys?: ReadonlySet<string>): ContainerSpec {
+function zipSpec(
+  sensitiveEnvKeys?: ReadonlySet<string>,
+  architecture: 'x86_64' | 'arm64' = 'x86_64'
+): ContainerSpec {
   return {
     kind: 'zip',
-    lambda: { logicalId: 'Fn', runtime: 'nodejs20.x', handler: 'index.handler' },
+    lambda: { logicalId: 'Fn', runtime: 'nodejs20.x', handler: 'index.handler', architecture },
     codeDir: '/tmp/code',
     env: { API_KEY: 's3cr3t', TABLE: 't' },
     ...(sensitiveEnvKeys && { sensitiveEnvKeys }),
@@ -109,6 +112,32 @@ describe('container pool forwards spec.sensitiveEnvKeys to runDetached (issue #9
 
     expect(runDetachedMock).toHaveBeenCalledTimes(1);
     expect(runDetachedMock.mock.calls[0]![0].sensitiveEnvKeys).toBeUndefined();
+    pool.release(handle);
+    await pool.dispose();
+  });
+});
+
+describe('container pool pins --platform to the ZIP Lambda architecture', () => {
+  beforeEach(() => {
+    runDetachedMock.mockReset().mockResolvedValue('container-id');
+    pickFreePortMock.mockReset().mockResolvedValue(9001);
+    removeContainerMock.mockReset().mockResolvedValue(undefined);
+    waitForRieReadyMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  // The ZIP run path (startOne) derives --platform from spec.lambda.architecture;
+  // without it a provided.* bootstrap fails with "exec format error" on a host
+  // whose native arch differs. This is the sole link carrying it to docker run.
+  it.each([
+    ['x86_64', 'linux/amd64'],
+    ['arm64', 'linux/arm64'],
+  ] as const)('runs a %s ZIP Lambda with --platform %s', async (arch, platform) => {
+    const pool = createContainerPool(new Map([['Fn', zipSpec(undefined, arch)]]), {
+      perLambdaConcurrency: 1,
+      streamLogs: false,
+    });
+    const handle = await pool.acquire('Fn');
+    expect(runDetachedMock.mock.calls[0]![0].platform).toBe(platform);
     pool.release(handle);
     await pool.dispose();
   });

--- a/tests/unit/local/front-door-lambda-runner.test.ts
+++ b/tests/unit/local/front-door-lambda-runner.test.ts
@@ -65,6 +65,7 @@ function zipLambda(overrides: Partial<ResolvedZipLambda> = {}): ResolvedZipLambd
     runtime: 'nodejs20.x',
     handler: 'index.handler',
     codePath: codeDir,
+    architecture: 'x86_64',
     ...overrides,
   } as ResolvedZipLambda;
 }
@@ -89,10 +90,18 @@ describe('createFrontDoorLambdaRunner', () => {
     const runner = createFrontDoorLambdaRunner(zipLambda(), { containerHost: '127.0.0.1' });
     await runner.start();
 
-    expect(pullImageMock).toHaveBeenCalledWith('public.ecr.aws/lambda/nodejs:20', false);
+    // Pull + run pin the platform to the Lambda's declared architecture so a
+    // provided.* bootstrap does not hit an "exec format error" on a host whose
+    // native arch differs.
+    expect(pullImageMock).toHaveBeenCalledWith(
+      'public.ecr.aws/lambda/nodejs:20',
+      false,
+      'linux/amd64'
+    );
     expect(runDetachedMock).toHaveBeenCalledTimes(1);
     const runArgs = runDetachedMock.mock.calls[0]![0];
     expect(runArgs.image).toBe('public.ecr.aws/lambda/nodejs:20');
+    expect(runArgs.platform).toBe('linux/amd64');
     expect(runArgs.cmd).toEqual(['index.handler']);
     expect(runArgs.mounts).toEqual([
       { hostPath: codeDir, containerPath: '/var/task', readOnly: true },
@@ -100,6 +109,19 @@ describe('createFrontDoorLambdaRunner', () => {
     expect(runArgs.hostPort).toBe(54321);
     expect(runArgs.env.AWS_LAMBDA_FUNCTION_NAME).toBe('EchoFn');
     expect(waitForRieReadyMock).toHaveBeenCalledWith('127.0.0.1', 54321, 30_000);
+  });
+
+  it('pins --platform to the declared arm64 architecture for a ZIP Lambda', async () => {
+    const runner = createFrontDoorLambdaRunner(zipLambda({ architecture: 'arm64' }), {
+      containerHost: '127.0.0.1',
+    });
+    await runner.start();
+    expect(pullImageMock).toHaveBeenCalledWith(
+      'public.ecr.aws/lambda/nodejs:20',
+      false,
+      'linux/arm64'
+    );
+    expect(runDetachedMock.mock.calls[0]![0].platform).toBe('linux/arm64');
   });
 
   it('extracts a .zip-packaged asset and mounts the extracted dir, cleaning it up on stop()', async () => {
@@ -161,7 +183,7 @@ describe('createFrontDoorLambdaRunner', () => {
       skipPull: true,
     });
     await runner.start();
-    expect(pullImageMock).toHaveBeenCalledWith('public.ecr.aws/lambda/nodejs:20', true);
+    expect(pullImageMock).toHaveBeenCalledWith('public.ecr.aws/lambda/nodejs:20', true, 'linux/amd64');
   });
 
   it('invoke() POSTs the event to RIE and returns the parsed payload', async () => {

--- a/tests/unit/local/lambda-resolver-asset-code.test.ts
+++ b/tests/unit/local/lambda-resolver-asset-code.test.ts
@@ -20,12 +20,18 @@ import type { CloudFormationTemplate, TemplateResource } from '../../../src/type
 
 // Build a minimal StackInfo whose single Lambda points `aws:asset:path` at
 // `assetPath` (relative to the cdk.out dir that `assetManifestPath` lives in).
-function makeStack(cdkOutDir: string, assetPath: string, extraResources = {}): StackInfo {
+function makeStack(
+  cdkOutDir: string,
+  assetPath: string,
+  extraResources = {},
+  extraProps: Record<string, unknown> = {}
+): StackInfo {
   const lambda: TemplateResource = {
     Type: 'AWS::Lambda::Function',
     Properties: {
       Runtime: 'nodejs20.x',
       Handler: 'index.handler',
+      ...extraProps,
     },
     Metadata: { 'aws:asset:path': assetPath },
   };
@@ -156,5 +162,19 @@ describe('resolveLambdaTarget asset code path (zip vs directory)', () => {
   it('errors clearly when the asset path does not exist', () => {
     const stack = makeStack(cdkOut, 'asset.missing.zip');
     expect(() => resolveLambdaTarget('Fn', [stack])).toThrow(/does not exist/);
+  });
+
+  it('carries the declared architecture (so the container runs at the right --platform)', () => {
+    const dirName = 'asset.arch';
+    mkdirSync(join(cdkOut, dirName), { recursive: true });
+    writeFileSync(join(cdkOut, dirName, 'index.js'), 'x');
+
+    const arm = resolveLambdaTarget('Fn', [makeStack(cdkOut, dirName, {}, { Architectures: ['arm64'] })]);
+    expect(arm.kind).toBe('zip');
+    if (arm.kind === 'zip') expect(arm.architecture).toBe('arm64');
+
+    // Default (no Architectures) is x86_64, matching AWS.
+    const def = resolveLambdaTarget('Fn', [makeStack(cdkOut, dirName)]);
+    if (def.kind === 'zip') expect(def.architecture).toBe('x86_64');
   });
 });


### PR DESCRIPTION
## Summary

A ZIP Lambda's invoke/warm container ran at the **host's** native architecture because the ZIP image plan never set `--platform` — only the container-image path did. On a host whose arch differs from the function's declared `Architectures`, a `provided.*` custom-runtime `bootstrap` then failed:

```
[ERROR] (rapid) Init failed error=fork/exec /var/runtime/bootstrap: exec format error
[ERROR] (rapid) Invoke DONE failed: Runtime.InvalidEntrypoint
```

Worse, which arch actually ran depended on the cached base-image variant, so the same function worked or failed **nondeterministically**. (Reproduced deterministically on an arm64 host invoking an x86_64 `provided.al2023` function.)

## Fix

Thread the declared architecture to `--platform` in every ZIP container-run path, the same way the image path already does (`architectureToPlatform(lambda.architecture)`):

- **`cdkl invoke`** (`resolveZipImagePlan`), the **front-door Lambda runner**, and **`cdkl start-api`** (via the container pool's ZIP `startOne`) all set `--platform` on `docker run`.
- `pullImage` gains an optional `platform` arg so the base-image pull fetches the matching variant.
- `ResolvedZipLambda` / start-api's `ResolvedStartApiZipLambda` now carry `architecture`, parsed via the shared exported `resolveLambdaArchitecture` (default `x86_64`, errors on an unsupported value).

## Behavior change

`provided.*` (and any arch-specific) ZIP Lambda whose declared `Architectures` differs from the host arch now runs at its **declared** arch (emulated when the host differs), instead of failing with `exec format error` / running nondeterministically. Additive — no previously-working input changes. Host CLIs embedding `cdkl invoke` / `start-api` inherit it by bumping the cdk-local version; no host-side change required. Tracked for cdkd at go-to-k/cdkd issue 768.

## Test plan

- **unit**:
  - a ZIP Lambda resolves its declared architecture (arm64 / default x86_64).
  - the front-door runner pins `--platform` + pulls the matching variant (x86_64 and arm64).
  - the container pool's ZIP run path pins `--platform` per arch (`linux/amd64` / `linux/arm64`) — the start-api site.
- **integ** (`local-invoke-provided`): the `provided.al2023` bootstrap fixture (asset dir + `.zip`) now **deterministically** exercises this. On an arm64 host (where the cached base image is arm64) it fails with `exec format error` without the fix and passes (emulated to the declared x86_64) with it — verified end-to-end (`VERIFY_EXIT=1` before, `0` after).

## Known cost (accepted)

`start-api`'s boot-time pre-pull (`distinctImages` loop) still pulls the host-native variant (it dedupes by image name, not `image+platform`). This is benign: the pool's `docker run --platform` auto-pulls the correct variant on a host-arch miss, so the worst case is one redundant warm-up pull. Left as-is to avoid restructuring the dedup for a perf-only nuance.
