### PR TITLE
fix(studio): tint the folded stack sub-header blue so it never reads as a row

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -125,14 +125,15 @@ const STUDIO_CSS = `
   }
   .target .name::-webkit-scrollbar { display: none; }
   /* The folded common stack prefix shared by the rows beneath it — a quiet
-     section-divider bar: a brighter label on a faint background bar (distinct
-     from both the #1a1a1a / #242424 row shades) with a hairline bottom border,
-     so the prefix reads clearly on the dark pane instead of disappearing as
-     dim grey-on-black. */
+     section-divider bar tinted in the BLUE family of the group-title accent
+     (#6aa9ff), so its hue (not just its lightness) sets it apart from the
+     neutral-grey zebra rows (#1a1a1a / #242424) and it can never be mistaken
+     for a target row. A blue-grey label on a dark-navy bar with a faint blue
+     bottom border. */
   .stack-sub {
-    padding: 4px 12px 3px; color: #b5b5b5; font-size: 10px;
-    font-family: ui-monospace, Menlo, monospace;
-    background: #202020; border-bottom: 1px solid #2c2c2c;
+    padding: 4px 12px 3px; color: #9fb2d4; font-size: 10px;
+    font-family: ui-monospace, Menlo, monospace; letter-spacing: 0.02em;
+    background: #18223a; border-bottom: 1px solid #2b3c5e;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .target .kind { color: #8f8f8f; font-size: 11px; }

--- a/tests/unit/local/studio-ui-target-fold.test.ts
+++ b/tests/unit/local/studio-ui-target-fold.test.ts
@@ -141,11 +141,11 @@ describe('targets pane construct-path CSS', () => {
     expect(html).toContain('.stack-sub {');
   });
 
-  it('renders the stack sub-header as a legible divider bar (brighter label + faint bar)', () => {
+  it('renders the stack sub-header as a blue-tinted divider bar (distinct hue from the grey rows)', () => {
     const html = renderStudioHtml('TestStack', 'cdkl');
-    // A brighter label on a faint background bar, so the folded prefix reads on
-    // the dark pane instead of disappearing as dim grey-on-black.
-    expect(html).toContain('color: #b5b5b5');
-    expect(html).toContain('background: #202020; border-bottom: 1px solid #2c2c2c;');
+    // A blue-tinted bar (group-title accent family) so its HUE sets it apart
+    // from the neutral-grey zebra rows — it can never read as a target row.
+    expect(html).toContain('color: #9fb2d4');
+    expect(html).toContain('background: #18223a; border-bottom: 1px solid #2b3c5e;');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #418 / #425. The previous contrast fix gave the folded
`<stack>/` sub-header (`.stack-sub`) a neutral `#202020` background, which
sat between the two grey zebra-row shades (`#1a1a1a` / `#242424`) and so
read as a target row rather than a divider header.

Tint it in the blue family of the group-title accent (`#6aa9ff`) instead:
- blue-grey `#9fb2d4` label
- dark-navy `#18223a` background bar
- faint `#2b3c5e` bottom border

The distinct **hue** (not just lightness) sets the sub-header apart from the
neutral-grey rows, so it can never be mistaken for a row.

## Test plan

- Unit (`studio-ui-target-fold.test.ts`): updated the CSS assertion to the
  blue-tinted bar values.
- Integ (`local-studio`): served-UI assertions green (Docker, 0 orphans).
- Visual confirmation in the browser post-publish.
