### PR TITLE
feat(studio): frame the composer result as Response + capture ecs --host-port requests on the timeline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -679,7 +679,13 @@ compute-locally category for Lambda + API Gateway).
   `studio-request-relay` so the browser composer reaches the served port
   same-origin; api / alb go through the capture proxy and land on the
   timeline, an ecs serve hits the replica host URL directly — from an explicit
-  `--host-port` or an auto-published replica port, issue #392),
+  `--host-port` or an auto-published replica port, issue #392 — and that
+  direct (un-proxied) ecs relay STILL lands on the timeline because the
+  command emits the `invocation` start/end pair itself
+  (`relayAndCaptureServeRequest`), so a Service request gets the same
+  Request/Response timeline row + read-only detail an api / alb request does;
+  an external curl straight to the host port is the one case not captured, no
+  proxy intercepting it),
   `POST /api/reinvoke` (issue #284 — re-run a past Lambda / AgentCore
   timeline row with an edited payload via `studio-reinvoke`, threading
   `reinvokeOf` so the new row links to its source; a served request is

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -47,7 +47,7 @@ import {
   type OptionValues,
 } from '../../local/studio-option-specs.js';
 import { tokenizeRawArgs } from '../../local/studio-option-catalog.js';
-import { relayServeRequest } from '../../local/studio-request-relay.js';
+import { relayServeRequest, type ServeRequestResult } from '../../local/studio-request-relay.js';
 import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
 import { isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
 import { discoverDockerfiles } from '../../local/image-override-engine.js';
@@ -234,6 +234,85 @@ const SERVE_REQUEST_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 
 export function resolveServeBaseUrl(state: StudioServeState): string | undefined {
   const http = (state.endpoints || []).find((u) => /^https?:/.test(u));
   return http ?? state.hostUrl;
+}
+
+/**
+ * Whether a relayed request to this serve is already captured on the timeline.
+ * An `api` / `alb` / `cloudfront` serve's `endpoints` are the studio
+ * capture-proxy URLs, so relaying to one emits `invocation` events from the
+ * proxy. An `ecs` serve published via `--host-port` has only a `hostUrl` (no
+ * proxy in front), so a relay to it is NOT captured — the caller emits the
+ * timeline events itself (see {@link relayAndCaptureServeRequest}).
+ */
+export function serveRelayIsCaptured(state: StudioServeState): boolean {
+  return (state.endpoints || []).some((u) => /^https?:/.test(u));
+}
+
+let serveRelayIdCounter = 0;
+
+/**
+ * Relay a composed request to an UNCAPTURED serve (an `ecs` `--host-port`
+ * replica, reached direct with no capture proxy in front) while emitting the
+ * `invocation` start/end pair onto the bus, so the request lands on the studio
+ * timeline exactly like an api / alb request the capture proxy records. The
+ * event shape mirrors {@link startStudioProxy}'s so the UI's read-only
+ * Request/Response detail + the store's history/log binding treat it
+ * identically. Exported for unit testing. `clock` / `idFactory` are injectable.
+ */
+export async function relayAndCaptureServeRequest(
+  deps: {
+    bus: StudioEventBus;
+    state: StudioServeState;
+    req: StudioServeRequestPayload;
+    baseUrl: string;
+  },
+  relay: typeof relayServeRequest = relayServeRequest,
+  clock: () => number = Date.now,
+  idFactory: () => string = () => {
+    serveRelayIdCounter += 1;
+    return `req-${Date.now()}-${serveRelayIdCounter}`;
+  }
+): Promise<ServeRequestResult> {
+  const { bus, state, req, baseUrl } = deps;
+  const id = idFactory();
+  const startedAt = clock();
+  const pathStr = req.path ?? '/';
+  const label = `${req.method} ${pathStr.split('?')[0]}`;
+  const headers = req.headers ?? {};
+  const base = { id, ts: startedAt, target: state.targetId, kind: state.kind, label };
+
+  bus.emit('invocation', { ...base, request: { method: req.method, path: pathStr, headers } });
+
+  const reqShape = { method: req.method, path: pathStr, headers, body: req.body };
+  try {
+    const result = await relay({
+      baseUrl,
+      method: req.method,
+      ...(req.path !== undefined ? { path: req.path } : {}),
+      ...(req.headers !== undefined ? { headers: req.headers } : {}),
+      ...(req.body !== undefined ? { body: req.body } : {}),
+    });
+    bus.emit('invocation', {
+      ...base,
+      request: reqShape,
+      response: { status: result.status, headers: result.headers, body: result.body },
+      status: result.status,
+      durationMs: result.durationMs,
+    });
+    return result;
+  } catch (err) {
+    // A network / timeout failure still closes the timeline row (502, the same
+    // convention startStudioProxy uses for an upstream error) rather than
+    // leaving it pending forever, then rethrows so /api/request reports the 500.
+    bus.emit('invocation', {
+      ...base,
+      request: reqShape,
+      response: `relay error: ${err instanceof Error ? err.message : String(err)}`,
+      status: 502,
+      durationMs: clock() - startedAt,
+    });
+    throw err;
+  }
 }
 
 /**
@@ -1085,14 +1164,21 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
           `'${req.targetId}' has no reachable HTTP endpoint (an ecs service needs --host-port).`
         );
       }
-      const result = await relayServeRequest({
-        baseUrl,
-        method: req.method,
-        ...(req.path !== undefined ? { path: req.path } : {}),
-        ...(req.headers !== undefined ? { headers: req.headers } : {}),
-        ...(req.body !== undefined ? { body: req.body } : {}),
-      });
-      return result;
+      // An api / alb / cloudfront relay goes through the capture proxy, which
+      // already emits the timeline events. An ecs --host-port relay is direct
+      // (no proxy), so emit the invocation pair here so it lands on the
+      // timeline too — otherwise the only record of an ecs request is the
+      // composer's inline result.
+      if (serveRelayIsCaptured(state)) {
+        return relayServeRequest({
+          baseUrl,
+          method: req.method,
+          ...(req.path !== undefined ? { path: req.path } : {}),
+          ...(req.headers !== undefined ? { headers: req.headers } : {}),
+          ...(req.body !== undefined ? { body: req.body } : {}),
+        });
+      }
+      return relayAndCaptureServeRequest({ bus, state, req, baseUrl });
     },
     // `/api/reinvoke`: re-run a past Lambda / AgentCore row with an edited
     // payload (issue #284). Resolves the source target from the store and

--- a/src/local/studio-events.ts
+++ b/src/local/studio-events.ts
@@ -94,8 +94,10 @@ export interface StudioServeEvent {
   endpoints?: string[];
   /**
    * Direct host URL for an `ecs` serve published via `--host-port` (issue
-   * #322) — no proxy in front (so a request to it is not captured). Absent for
-   * api / alb (use `endpoints`) and for an ecs serve without `--host-port`.
+   * #322) — no proxy in front. A request relayed through the studio composer
+   * still lands on the timeline (studio emits the invocation events itself); an
+   * external curl straight to the host port is not captured. Absent for api /
+   * alb (use `endpoints`) and for an ecs serve without `--host-port`.
    */
   hostUrl?: string;
   /** Child process id, present from `starting` onward. */

--- a/src/local/studio-request-relay.ts
+++ b/src/local/studio-request-relay.ts
@@ -12,7 +12,9 @@
  * For an `api` / `alb` serve the endpoint is the studio capture-proxy URL, so a
  * relayed request lands on the timeline exactly like an external curl. For an
  * `ecs` serve published via `--host-port` the endpoint is the replica's host
- * URL (no proxy in front, so it is NOT captured).
+ * URL (no proxy in front); the relay is still recorded on the timeline because
+ * the caller emits the invocation events itself (see
+ * `relayAndCaptureServeRequest` in `local-studio.ts`).
  *
  * The relay is host-agnostic — it just performs one bounded HTTP request — so
  * it is exported from `cdk-local/internal` for a host CLI embedding studio.

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -63,8 +63,10 @@ export interface StudioServeState {
    * Direct host URL for an `ecs` serve published via `--host-port` (issue
    * #322). Unlike `endpoints` (api / alb capture-proxy URLs), this is the
    * replica's own host port with NO proxy in front — so the in-workspace
-   * request composer can target it, but a request to it is NOT captured on
-   * the timeline. Absent for api / alb (use `endpoints`) and for an ecs
+   * request composer can target it. A request relayed through the composer
+   * still lands on the timeline (studio emits the invocation events itself),
+   * but an EXTERNAL curl straight to the host port is not captured (no proxy
+   * intercepts it). Absent for api / alb (use `endpoints`) and for an ecs
    * serve started without `--host-port`.
    */
   hostUrl?: string;

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -190,7 +190,7 @@ const STUDIO_CSS = `
   .req-composer .req-send button { margin-top: 0; padding: 4px 16px; background: #2a7d46; color: #fff; }
   .req-composer .req-send button:hover { background: #339152; }
   .req-composer .req-send button:disabled { background: #333; color: #888; }
-  .req-composer .req-status { margin-top: 8px; font: 12px ui-monospace, Menlo, monospace; }
+  .req-composer .req-result .req-resp { margin-top: 8px; padding: 0; border-bottom: none; }
   .req-composer .req-result pre { background: #0e0e0e; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
@@ -1224,10 +1224,13 @@ const STUDIO_SCRIPT = `
       );
     } else if (running && isEcs && st.hostUrl) {
       // An ecs service published via --host-port IS reachable on the host
-      // (issue #322); show its host URL. No proxy fronts it, so requests are
-      // not captured on the timeline.
+      // (issue #322); show its host URL. No proxy fronts it, so an EXTERNAL
+      // curl to the host port is not captured — but a request sent through the
+      // composer below IS recorded on the timeline (studio emits it itself).
       epSec.appendChild(href(st.hostUrl));
-      epSec.appendChild(el('div', 'opt-hint', '(direct host port — not captured on the timeline)'));
+      epSec.appendChild(
+        el('div', 'opt-hint', '(direct host port — composer requests are captured on the timeline)')
+      );
     } else if (running && isEcs) {
       // A pure-compute ECS service has no host endpoint — it just runs the
       // replicas (reach them container-to-container via Cloud Map).
@@ -1239,8 +1242,9 @@ const STUDIO_SCRIPT = `
 
     // In-workspace HTTP request composer for a running api / alb (or ecs with
     // --host-port) serve (issue #322): compose a request and Send it; studio
-    // relays it server-side (same-origin) so it works cross-port and, for
-    // api / alb, lands on the timeline via the capture proxy.
+    // relays it server-side (same-origin) so it works cross-port and lands on
+    // the timeline — api / alb via the capture proxy, ecs via studio emitting
+    // the invocation pair itself (the direct host-port relay has no proxy).
     const httpBase = running
       ? (st.endpoints || []).find((u) => /^https?:/.test(u)) || (isEcs ? st.hostUrl : null)
       : null;
@@ -1526,17 +1530,25 @@ const STUDIO_SCRIPT = `
           msg.textContent = 'Request failed: ' + (data.error || ('HTTP ' + res.status));
           return;
         }
-        const statusLine = el('div', 'req-status');
+        // Frame the result as a "Response" section (status badge in the
+        // heading) so a sent request reads as Request (the compose form above)
+        // -> Response, matching the timeline's read-only detail. Without the
+        // heading the status + headers + body dumped raw under Send read as an
+        // unlabeled blob — most visible for an ecs --host-port serve, which is
+        // not captured on the timeline and so has only this inline result.
+        const respSec = el('div', 'section req-resp');
+        const respHead = el('h3', null, 'Response');
         const cls = data.status >= 200 && data.status < 300 ? 'ok' : 'bad';
-        statusLine.appendChild(
-          el('span', cls, data.status + (data.durationMs != null ? ' · ' + data.durationMs + 'ms' : ''))
+        respHead.appendChild(
+          el('span', cls, '  ' + data.status + (data.durationMs != null ? ' · ' + data.durationMs + 'ms' : ''))
         );
-        result.appendChild(statusLine);
+        respSec.appendChild(respHead);
         const hdrs = Object.keys(data.headers || {})
           .map(function (k) { return k + ': ' + data.headers[k]; })
           .join('\\n');
-        if (hdrs) result.appendChild(el('pre', 'req-resp-headers', hdrs));
-        result.appendChild(el('pre', null, data.body != null ? data.body : ''));
+        if (hdrs) respSec.appendChild(el('pre', 'req-resp-headers', hdrs));
+        respSec.appendChild(el('pre', null, data.body != null ? data.body : ''));
+        result.appendChild(respSec);
       } catch (err) {
         msg.textContent = 'Request failed: ' + err;
       } finally {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1408,6 +1408,45 @@ if [[ -z "${ECS_ENV_HIT}" ]]; then
 fi
 echo "    OK: --env-vars threaded; task container '${ECS_ENV_HIT}' carries STUDIO_ECS_PROBE=${ECS_ENV_VALUE}"
 
+# In-workspace HTTP request composer against an ecs --host-port serve: unlike
+# api / alb (which relay through the capture proxy), the ecs relay goes DIRECT
+# to the replica host port (no proxy). studio emits the invocation start/end
+# pair itself (relayAndCaptureServeRequest) so the request STILL lands on the
+# timeline. Start an SSE listener, relay a composed GET /, then assert (a) the
+# relay returns the fixture's directory-listing 200 and (b) an invocation row
+# with kind=ecs + the GET / label appears on the timeline.
+echo "==> POST /api/request relays to the ecs --host-port serve AND lands on the timeline"
+ECS_SSE_FILE=$(mktemp)
+curl -sN --max-time 30 "${URL}/api/events" >"${ECS_SSE_FILE}" 2>/dev/null &
+ECS_SSE_PID=$!
+sleep 1
+ECS_REQ_FILE=$(mktemp)
+HTTP_EREQ=$(curl -s -o "${ECS_REQ_FILE}" -w '%{http_code}' --max-time 30 \
+  -X POST "${URL}/api/request" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${ECS_TARGET}\",\"method\":\"GET\",\"path\":\"/\"}" || true)
+if [[ "${HTTP_EREQ}" != "200" ]] || ! grep -qF '"status":200' "${ECS_REQ_FILE}"; then
+  echo "FAIL: POST /api/request (ecs direct) did not report the upstream 200"
+  echo "----- relay result -----"; head -c 1000 "${ECS_REQ_FILE}"; echo; echo "------------------------"
+  kill "${ECS_SSE_PID}" 2>/dev/null || true
+  rm -f "${ECS_REQ_FILE}" "${ECS_SSE_FILE}"; exit 1
+fi
+rm -f "${ECS_REQ_FILE}"
+# The emitted invocation row carries kind=ecs + the GET / label — proof the
+# direct (un-proxied) ecs relay was captured onto the timeline.
+for _ in $(seq 1 20); do
+  if grep -qF 'event: invocation' "${ECS_SSE_FILE}" && grep -qF '"label":"GET /"' "${ECS_SSE_FILE}"; then break; fi
+  sleep 0.5
+done
+if ! grep -qF '"label":"GET /"' "${ECS_SSE_FILE}" || ! grep -qF '"kind":"ecs"' "${ECS_SSE_FILE}"; then
+  echo "FAIL: the ecs --host-port request was NOT captured on the timeline (invocation row)"
+  echo "----- sse capture -----"; tail -c 2000 "${ECS_SSE_FILE}"; echo "-----------------------"
+  kill "${ECS_SSE_PID}" 2>/dev/null || true
+  rm -f "${ECS_SSE_FILE}"; exit 1
+fi
+kill "${ECS_SSE_PID}" 2>/dev/null || true
+rm -f "${ECS_SSE_FILE}"
+echo "    OK: ecs direct relay captured on the timeline (GET / invocation, kind=ecs)"
+
 echo "==> GET /api/running reflects the ECS service (no endpoint)"
 curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
 if ! grep -qF "${ECS_TARGET}" "${BODY_FILE}"; then

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -9,6 +9,8 @@ import {
   coerceServeRequest,
   coerceReinvokeRequest,
   resolveServeBaseUrl,
+  serveRelayIsCaptured,
+  relayAndCaptureServeRequest,
   createLocalStudioCommand,
   installStudioResilienceGuard,
   parseStudioPort,
@@ -18,6 +20,7 @@ import {
 } from '../../../src/cli/commands/local-studio.js';
 import type { StudioRunRequest } from '../../../src/local/studio-dispatch.js';
 import type { StudioServeState } from '../../../src/local/studio-serve-manager.js';
+import { StudioEventBus } from '../../../src/local/studio-events.js';
 
 describe('createLocalStudioCommand', () => {
   it('is named "studio"', () => {
@@ -512,6 +515,114 @@ describe('resolveServeBaseUrl (issue #322)', () => {
   it('returns undefined when there is no reachable http endpoint', () => {
     expect(resolveServeBaseUrl(state({ endpoints: ['ws://x'] }))).toBeUndefined();
     expect(resolveServeBaseUrl(state({}))).toBeUndefined();
+  });
+});
+
+describe('serveRelayIsCaptured', () => {
+  const state = (over: Partial<StudioServeState>): StudioServeState => ({
+    targetId: 'T',
+    kind: 'api',
+    status: 'running',
+    endpoints: [],
+    startedAt: 0,
+    ...over,
+  });
+
+  it('is true for an api / alb serve (http capture-proxy endpoint)', () => {
+    expect(serveRelayIsCaptured(state({ endpoints: ['http://127.0.0.1:51234'] }))).toBe(true);
+  });
+
+  it('is false for an ecs --host-port serve (direct host URL, no proxy)', () => {
+    expect(
+      serveRelayIsCaptured(state({ kind: 'ecs', hostUrl: 'http://127.0.0.1:8080' }))
+    ).toBe(false);
+  });
+
+  it('is false for a ws-only endpoint (not a captured http relay)', () => {
+    expect(serveRelayIsCaptured(state({ endpoints: ['ws://127.0.0.1:51234'] }))).toBe(false);
+  });
+});
+
+describe('relayAndCaptureServeRequest', () => {
+  const ecsState: StudioServeState = {
+    targetId: 'Stack/Svc',
+    kind: 'ecs',
+    status: 'running',
+    endpoints: [],
+    hostUrl: 'http://127.0.0.1:8080',
+    startedAt: 0,
+  };
+
+  it('emits the invocation start/end pair so the ecs request lands on the timeline', async () => {
+    const bus = new StudioEventBus();
+    const events: unknown[] = [];
+    bus.on('invocation', (ev) => events.push(ev));
+
+    const relay = vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+      body: '<html/>',
+      truncated: false,
+      durationMs: 9,
+    });
+    const result = await relayAndCaptureServeRequest(
+      {
+        bus,
+        state: ecsState,
+        req: { targetId: 'Stack/Svc', method: 'GET', path: '/orders?x=1' },
+        baseUrl: 'http://127.0.0.1:8080',
+      },
+      relay,
+      () => 1000,
+      () => 'req-fixed'
+    );
+
+    // The relay was called against the ecs host URL with the composed request.
+    expect(relay).toHaveBeenCalledWith({
+      baseUrl: 'http://127.0.0.1:8080',
+      method: 'GET',
+      path: '/orders?x=1',
+    });
+    expect(result.status).toBe(200);
+
+    // Two events, both keyed by the same id, with the label stripped of query.
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      id: 'req-fixed',
+      ts: 1000,
+      target: 'Stack/Svc',
+      kind: 'ecs',
+      label: 'GET /orders',
+      request: { method: 'GET', path: '/orders?x=1', headers: {} },
+    });
+    expect(events[0]).not.toHaveProperty('response');
+    expect(events[1]).toMatchObject({
+      id: 'req-fixed',
+      target: 'Stack/Svc',
+      status: 200,
+      durationMs: 9,
+      response: { status: 200, headers: { 'content-type': 'text/html' }, body: '<html/>' },
+    });
+  });
+
+  it('closes the timeline row with a 502 and rethrows on a relay failure', async () => {
+    const bus = new StudioEventBus();
+    const events: any[] = [];
+    bus.on('invocation', (ev) => events.push(ev));
+
+    const relay = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(
+      relayAndCaptureServeRequest(
+        { bus, state: ecsState, req: { targetId: 'Stack/Svc', method: 'POST' }, baseUrl: 'http://127.0.0.1:8080' },
+        relay,
+        () => 2000,
+        () => 'req-err'
+      )
+    ).rejects.toThrow('ECONNREFUSED');
+
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({ id: 'req-err', status: 502 });
+    expect(events[1].response).toContain('ECONNREFUSED');
   });
 });
 

--- a/tests/unit/local/studio-ui-send-response.test.ts
+++ b/tests/unit/local/studio-ui-send-response.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the request-composer renderer so the test can mount a real Send
+// button and assert the inline result frames the response as a "Response"
+// section (status badge + headers + body), shared by the captured api/alb and
+// the direct ecs --host-port composer.
+const EXPOSE = `
+window.__t = {
+  renderRequestComposer: renderRequestComposer,
+};
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+/** Flush pending microtasks / timer callbacks the async Send handler queues. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+}
+
+describe('request-composer Send result framing', () => {
+  it('renders a "Response" section (status badge + headers + body) after Send', async () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      // Stub /api/request to resolve a 200 with headers + an HTML body — the
+      // ecs directory-listing shape that prompted this (a raw blob under Send).
+      (h.window as any).fetch = () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              status: 200,
+              headers: { 'content-type': 'text/html; charset=utf-8', 'content-length': '42' },
+              body: '<html><body>Directory listing for /</body></html>',
+              durationMs: 7,
+            }),
+        });
+
+      const sec = h.window.__t.renderRequestComposer('S/Svc', 'http://127.0.0.1:8080', false);
+      h.document.body.appendChild(sec);
+
+      const sendBtn = sec.querySelector('.req-send button');
+      expect(sendBtn).not.toBeNull();
+      sendBtn.click();
+      await flush();
+
+      // The inline result frames the response as a "Response" section, not a
+      // bare status line + pre dump.
+      const respSec = sec.querySelector('.req-result .req-resp');
+      expect(respSec).not.toBeNull();
+      const heading = respSec.querySelector('h3');
+      expect(heading).not.toBeNull();
+      expect(heading.textContent).toContain('Response');
+      // The status badge rides the heading (ok class for a 2xx).
+      const badge = heading.querySelector('.ok');
+      expect(badge).not.toBeNull();
+      expect(badge.textContent).toContain('200');
+      expect(badge.textContent).toContain('7ms');
+
+      // Headers + body still render below the heading.
+      const headerPre = respSec.querySelector('pre.req-resp-headers');
+      expect(headerPre).not.toBeNull();
+      expect(headerPre.textContent).toContain('content-type: text/html');
+      const pres = respSec.querySelectorAll('pre');
+      expect(pres[pres.length - 1].textContent).toContain('Directory listing for /');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('marks a non-2xx response with the bad status class', async () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      (h.window as any).fetch = () =>
+        Promise.resolve({
+          ok: true,
+          status: 404,
+          json: () =>
+            Promise.resolve({ status: 404, headers: {}, body: 'Not found', durationMs: 3 }),
+        });
+
+      const sec = h.window.__t.renderRequestComposer('S/Svc', 'http://127.0.0.1:8080', false);
+      h.document.body.appendChild(sec);
+      sec.querySelector('.req-send button').click();
+      await flush();
+
+      const badge = sec.querySelector('.req-result .req-resp h3 .bad');
+      expect(badge).not.toBeNull();
+      expect(badge.textContent).toContain('404');
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

A request sent to a `start-service` (ecs) serve from the `cdkl studio`
request composer behaved differently than an `api` / `alb` one:

1. The inline Send result dumped the raw response headers + body under the
   button with no framing (a "Directory listing for /" HTML blob reads as
   noise), and
2. The request never landed on the timeline — the ecs `--host-port` relay is
   direct (no capture proxy in front), so only `api` / `alb` requests (which
   relay through the proxy) were recorded.

This PR makes a Service request behave like an api/alb one.

### Changes

- **studio-ui** — the composer's inline Send result is now a labeled
  **"Response"** section: status badge in the heading (ok/bad color), then
  the response headers + body. A sent request now reads as Request (the
  compose form above) -> Response, matching the timeline's read-only detail.
  Shared by the api / alb and the ecs composer.

- **local-studio** — the direct (un-proxied) ecs `--host-port` relay now emits
  the `invocation` start/end pair itself (`relayAndCaptureServeRequest`),
  mirroring the capture proxy's event shape, so a Service request lands on the
  timeline with the same `kind=ecs` Request/Response row + read-only detail an
  api / alb request gets. `api` / `alb` / `cloudfront` still relay through the
  capture proxy (which already emits the events) — `serveRelayIsCaptured`
  gates the new emit so there is no double-emit. An external curl straight to
  the host port is the one case not captured (no proxy intercepts it).

### Behavior change (for host CLIs embedding studio, e.g. cdkd)

`cdkl studio`'s `POST /api/request` now records an ecs `--host-port` serve
request on the timeline where it previously did not. cdkd embeds the studio
command whole (`createLocalStudioCommand`), so the behavior flows through
automatically — no migration required, but it is tracked at
go-to-k/cdkd#769. (If a host's own UI/tests assert that an ecs serve request
is absent from the studio timeline, update that expectation.)

## Test plan

- **Unit** — new `studio-ui-send-response.test.ts` drives the real
  `renderRequestComposer` (jsdom) and asserts the inline result renders a
  "Response" heading with a status badge (ok for 2xx, bad for non-2xx) +
  headers + body. New `local-studio.test.ts` cases cover
  `serveRelayIsCaptured` (api/alb captured, ecs/ws not) and
  `relayAndCaptureServeRequest` (start/end pair shape, label query-stripping,
  502 + rethrow on relay failure). Full suite green (2941 tests).
- **Integration** — `tests/integration/local-studio/verify.sh` now relays a
  composed `GET /` through `POST /api/request` to a running ecs `--host-port`
  serve and asserts (a) the relay returns the fixture's directory-listing 200
  and (b) a `kind=ecs` / `label=GET /` invocation row appears on the SSE
  timeline. Ran the full local-studio integ against real Docker — green, 0
  orphan containers/networks/images.
- Code review (1-reviewer): no blockers.

### Known limitation (accepted, pre-existing)

`serveRelayIsCaptured` infers "captured" from "the serve has an `http(s)://`
endpoint" rather than from "a proxy is actually in front". In the rare
degraded state where an api/alb capture proxy fails to bind and the
serve-manager falls back to the direct child URL as the endpoint, a relayed
request would be neither proxy-captured nor self-emitted. This is a
pre-existing gap (the fallback already produced an uncaptured request before
this PR) and not introduced here; the proxy-bound and ecs paths this PR
targets are both correct. A `proxyPresent` flag on `StudioServeState` would
make the discrimination exact — left as a follow-up.
