### PR TITLE
fix(studio): cap WS console width + move Clear below the log, enlarge it

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -194,12 +194,15 @@ const STUDIO_CSS = `
   .req-composer .req-result pre { background: #0e0e0e; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
-  .log-head { display: flex; align-items: center; justify-content: space-between; }
   .log-clear {
-    background: #1d1d1d; color: #bbb; border: 1px solid #333; border-radius: 3px;
-    padding: 2px 10px; font-size: 11px; cursor: pointer; margin: 0;
+    background: #1d1d1d; color: #ccc; border: 1px solid #3a3a3a; border-radius: 4px;
+    padding: 5px 16px; font-size: 12px; cursor: pointer; margin: 0;
   }
-  .log-clear:hover { background: #262626; color: #ddd; }
+  .log-clear:hover { background: #2a2a2a; color: #fff; border-color: #4a4a4a; }
+  /* A Clear action sits BELOW the log it clears, right-aligned within the
+     same capped content column so it lands near the log, not at the far
+     right edge of a wide pane. */
+  .clear-row { display: flex; justify-content: flex-end; max-width: 760px; margin-top: 6px; }
   .composer .err { color: #e0707a; margin-top: 6px; min-height: 18px; }
   .section { padding: 8px 12px; border-bottom: 1px solid #222; }
   .section h3 { margin: 0 0 6px; font-size: 11px; color: #888; text-transform: uppercase; }
@@ -210,8 +213,12 @@ const STUDIO_CSS = `
   .endpoint:hover { text-decoration: underline; }
   .ws-console .ws-status { font-size: 12px; color: #888; margin-left: 8px; font-weight: 400; }
   .ws-console .ws-status.on { color: #4ec97a; }
-  .ws-console h3 .ws-clear { float: right; font-weight: 400; }
-  .ws-row { display: flex; gap: 6px; align-items: center; margin: 6px 0; }
+  /* Cap the interactive content to a readable column so on a wide center
+     pane the input does not stretch edge-to-edge and fling Send far to the
+     right. Send then sits right after the input; the log + Clear share the
+     same column. The cap is a no-op on a narrow pane (content uses what is
+     available). */
+  .ws-row { display: flex; gap: 6px; align-items: center; margin: 6px 0; max-width: 760px; }
   .ws-row .ws-input { flex: 1; min-width: 0; background: #1a1a1a; border: 1px solid #333;
     color: #ddd; border-radius: 4px; padding: 5px 7px; font: inherit; }
   .ws-row .ws-input:focus { outline: none; border-color: #4ec97a; }
@@ -219,7 +226,10 @@ const STUDIO_CSS = `
     padding: 5px 12px; cursor: pointer; }
   .ws-row button:disabled { background: #2a2a2a; color: #666; cursor: default; }
   .ws-frames { max-height: 180px; overflow: auto; background: #141414; border: 1px solid #262626;
-    border-radius: 4px; padding: 6px 8px; margin-top: 4px; min-height: 22px; }
+    border-radius: 4px; padding: 6px 8px; margin-top: 4px; min-height: 22px; max-width: 760px; }
+  /* The serve LOGS <pre> shares the capped column so its Clear (below it,
+     right-aligned via .clear-row) lands at the column edge, near the log. */
+  .serve-log { max-width: 760px; }
   .searchbar { padding: 6px 10px; border-bottom: 1px solid #2a2a2a; background: #151515;
     position: sticky; top: 28px; z-index: 1; }
   .searchbar input {
@@ -1258,20 +1268,7 @@ const STUDIO_SCRIPT = `
 
     const logs = logsById.get(id) || [];
     const logSec = el('div', 'section');
-    // Logs header carries a Clear button (issue #338): hammering a serve piles
-    // up log lines, so let the user empty the panel (display-only — the
-    // server-side store / history is untouched).
-    const logHead = el('div', 'log-head');
-    logHead.appendChild(el('h3', null, 'Logs'));
-    const logClear = el('button', 'log-clear', 'Clear');
-    logClear.onclick = function () {
-      // Surgical clear (issue #334): empty the buffer + the live <pre> without
-      // a full re-render that would wipe the request composer's fields.
-      logsById.set(id, []);
-      if (serveLogPre) serveLogPre.textContent = '(none)';
-    };
-    logHead.appendChild(logClear);
-    logSec.appendChild(logHead);
+    logSec.appendChild(el('h3', null, 'Logs'));
     // A proxy-fronted serve (api / alb) streams its child start-* logs here,
     // which advertise the child internal 127.0.0.1 port — a DIFFERENT port
     // than the capture-proxy URL in Endpoints above. Flag it so the child
@@ -1285,8 +1282,22 @@ const STUDIO_SCRIPT = `
         )
       );
     }
-    const logPre = el('pre', null, logs.length ? logs.join('\\n') : '(none)');
+    const logPre = el('pre', 'serve-log', logs.length ? logs.join('\\n') : '(none)');
     logSec.appendChild(logPre);
+    // Clear sits below the log (issue #338): hammering a serve piles up log
+    // lines, so let the user empty the panel (display-only — the server-side
+    // store / history is untouched). Below the log + right-aligned so it lands
+    // near the content it clears, not in the section header above.
+    const logClearRow = el('div', 'clear-row');
+    const logClear = el('button', 'log-clear', 'Clear');
+    logClear.onclick = function () {
+      // Surgical clear (issue #334): empty the buffer + the live <pre> without
+      // a full re-render that would wipe the request composer's fields.
+      logsById.set(id, []);
+      if (serveLogPre) serveLogPre.textContent = '(none)';
+    };
+    logClearRow.appendChild(logClear);
+    logSec.appendChild(logClearRow);
     ws.appendChild(logSec);
     // Register the live LOGS <pre> so streamed log events update it surgically
     // (issue #334) instead of re-rendering the whole serve workspace.
@@ -1696,12 +1707,16 @@ const STUDIO_SCRIPT = `
     row.appendChild(sendBtn);
     sec.appendChild(row);
 
-    const clearBtn = el('button', 'log-clear ws-clear', 'Clear');
-    clearBtn.onclick = wsClear;
-    h.appendChild(clearBtn);
-
     const frames = el('pre', 'ws-frames', wsFrames.join('\\n'));
     sec.appendChild(frames);
+
+    // Clear sits BELOW the log it clears (the log streams downward), right-
+    // aligned within the capped column so it stays near the content.
+    const clearRow = el('div', 'clear-row');
+    const clearBtn = el('button', 'log-clear ws-clear', 'Clear');
+    clearBtn.onclick = wsClear;
+    clearRow.appendChild(clearBtn);
+    sec.appendChild(clearRow);
     return sec;
   }
 

--- a/tests/unit/local/studio-ui-ws-console.test.ts
+++ b/tests/unit/local/studio-ui-ws-console.test.ts
@@ -105,4 +105,18 @@ describe('studio WebSocket console (renderWsConsole)', () => {
     (node.querySelector('.ws-clear') as HTMLElement & { onclick: () => void }).onclick();
     expect(pre.textContent).toBe('');
   });
+
+  it('the Clear button sits BELOW the frame log (in a .clear-row), not in the header', () => {
+    const { node } = mountConsole();
+    // Not in the section header anymore.
+    expect(node.querySelector('h3 .ws-clear')).toBeNull();
+    // Inside a .clear-row, and that row comes AFTER the frame log in the DOM.
+    const clearBtn = node.querySelector('.clear-row .ws-clear');
+    const frames = node.querySelector('.ws-frames');
+    expect(clearBtn).not.toBeNull();
+    expect(frames).not.toBeNull();
+    const FOLLOWING = (harness.window as unknown as { Node: { DOCUMENT_POSITION_FOLLOWING: number } })
+      .Node.DOCUMENT_POSITION_FOLLOWING;
+    expect(frames!.compareDocumentPosition(clearBtn!) & FOLLOWING).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Layout fixes to the studio WebSocket console + Logs panel, surfaced on a
wide center pane.

- **Send no longer flies far from the input.** `.ws-input { flex: 1 }` let
  the input stretch edge-to-edge on a wide pane, pushing Send to the far
  right. The interactive content is now capped to a readable ~760px column
  (`.ws-row` / `.ws-frames` / `.serve-log` / `.clear-row` max-width), so Send
  sits right after the input. The cap is a no-op on a narrow pane.
- **Clear moved below the log it clears.** Both the WS console and Logs panel
  Clear buttons were in the section header (above the log) and floated to the
  far right. They now sit BELOW the log, right-aligned within the capped
  column via a shared `.clear-row`, so Clear lands near the content.
- **Clear enlarged.** `.log-clear` padding 2px 10px / 11px -> 5px 16px / 12px
  (lighter border) so it is no longer easy to miss.

The WS console (`renderWsConsole`) is shared by the served API Gateway
WebSocket API and the `agentcore-ws` serve, so both consoles get the fix.

## Test plan

- `vp run check` (0 errors; 1 pre-existing unrelated warning) / `vp run build`
  green.
- `vp run test` — 195 files, 2944 tests green (extends the WS console jsdom
  test to lock the new Clear position: in a `.clear-row` that follows the
  frame log in the DOM, not the header).
- `/run-integ local-studio` — green, 0 docker orphans (studio serve +
  `agentcore-ws` bridge + ws-console sections end-to-end).
- **Visual check**: rendered the real `STUDIO_CSS` + DOM structure at 1680px
  via headless Chrome — Send sits right after the input, Clear sits below the
  log right-aligned at the column edge, both Clear buttons larger.
- Inline review: 83 LOC / 2 files, no security surface.
