### PR TITLE
fix(invoke): recreate symlink entries when extracting a ZIP-FILE Lambda asset

### DIFF
--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   writeFileSync,
   chmodSync,
+  symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, normalize, resolve, sep } from 'node:path';
@@ -824,34 +825,101 @@ export function materializeAssetCodeDir(codePath: string): MaterializedAssetCode
   if (statSync(codePath).isDirectory()) {
     return { dir: codePath };
   }
+  const zipBytes = readFileSync(codePath);
   let files: Record<string, Uint8Array>;
   try {
-    files = unzipSync(readFileSync(codePath));
+    files = unzipSync(zipBytes);
   } catch (err) {
     throw new LocalInvokeResolutionError(
       `Lambda asset '${codePath}' is a file but could not be read as a ZIP archive: ` +
         `${err instanceof Error ? err.message : String(err)}. Re-synthesize the app and retry.`
     );
   }
+  // fflate's `unzipSync` returns only file CONTENTS — no per-entry unix mode,
+  // and a SYMLINK entry comes back as a regular entry whose content is the link
+  // TARGET path. A `provided.*` runtime commonly ships `bootstrap` as a symlink
+  // to the real binary (e.g. Swift's `bootstrap -> MyHandler`), so writing that
+  // content as a regular file yields an 18-byte text file that RIE fork/exec's
+  // -> `exec format error` / `Runtime.InvalidEntrypoint`. So we parse the zip's
+  // central directory ourselves for each entry's stored unix mode and recreate
+  // symlinks as symlinks + restore the executable bit. (A directory asset
+  // bypasses this path entirely — CDK staged it with correct modes and we
+  // bind-mount it directly.)
+  const modes = parseZipUnixModes(zipBytes);
+  const S_IFMT = 0o170000;
+  const S_IFLNK = 0o120000;
   const dir = mkdtempSync(join(tmpdir(), `${getEmbedConfig().resourceNamePrefix}-lambda-zip-`));
+  // Two passes: write every REGULAR file first, then create symlinks. Creating
+  // symlinks last means no regular-file `writeFileSync` can follow an
+  // already-created symlink out of the extraction dir (a symlink-then-write
+  // escape), on top of the lexical zip-slip guard on every `dest`.
+  const symlinks: Array<{ dest: string; target: string }> = [];
   for (const [name, content] of Object.entries(files)) {
     if (name.endsWith('/')) continue; // directory entry — no file content
     const dest = resolveSafeZipEntryPath(dir, name);
     mkdirSync(dirname(dest), { recursive: true });
+    const mode = modes.get(name) ?? 0;
+    if ((mode & S_IFMT) === S_IFLNK) {
+      // Symlink entry: the content IS the link target path. Defer creation to
+      // the second pass.
+      symlinks.push({ dest, target: new TextDecoder().decode(content) });
+      continue;
+    }
     writeFileSync(dest, content);
-    // Restore the executable bit. The deployed Lambda package preserves the
-    // zip's unix file modes, and a `provided.*` custom runtime's entrypoint
-    // (`bootstrap`) MUST be executable or RIE fails the invoke with
-    // `Runtime.InvalidEntrypoint` / `fork/exec ...: permission denied`. fflate's
-    // `unzipSync` returns only file CONTENTS (no per-entry unix mode), so we
-    // cannot recover the exact stored mode; granting `0o755` to every extracted
-    // file makes the bootstrap executable while keeping all files readable —
-    // safe for the user's own code in an ephemeral local container. (A
-    // directory asset bypasses this path entirely: CDK already staged it with
-    // correct modes and we bind-mount it directly.)
-    chmodSync(dest, 0o755);
+    // Preserve the stored unix permission bits when present; otherwise grant
+    // 0o755 so a `provided.*` `bootstrap` stays executable (some zips store a
+    // bare 0 mode). Keeping files readable is safe: the user's own code in an
+    // ephemeral local container.
+    const perm = mode & 0o777;
+    chmodSync(dest, perm || 0o755);
+  }
+  // A `provided.*` runtime commonly ships `bootstrap` as a symlink to the real
+  // binary (Swift: `bootstrap -> MyHandler`); recreate it as a real symlink so
+  // the bind-mounted asset resolves the same as the deployed package — the
+  // target is the user's own (relative) path, resolved inside the container.
+  for (const { dest, target } of symlinks) {
+    symlinkSync(target, dest);
   }
   return { dir, tmpDir: dir };
+}
+
+/**
+ * Parse a ZIP archive's central directory into a map of entry name -> stored
+ * unix mode (the high 16 bits of the central-directory external file
+ * attributes). fflate's `unzipSync` discards this, but we need it to tell a
+ * symlink entry from a regular file and to restore the executable bit. Returns
+ * an empty map (callers fall back to a default mode) for a non-standard /
+ * unparseable archive — best-effort, never throws.
+ */
+function parseZipUnixModes(bytes: Uint8Array): Map<string, number> {
+  const modes = new Map<string, number>();
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const EOCD_SIG = 0x06054b50; // End Of Central Directory record
+  const CDH_SIG = 0x02014b50; // Central Directory file Header
+  // The EOCD is at the end, after an optional <=65535-byte comment; scan back.
+  let eocd = -1;
+  for (let i = bytes.length - 22; i >= 0; i--) {
+    if (dv.getUint32(i, true) === EOCD_SIG) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) return modes;
+  const count = dv.getUint16(eocd + 10, true);
+  let p = dv.getUint32(eocd + 16, true); // offset of central directory start
+  const decoder = new TextDecoder();
+  for (let n = 0; n < count; n++) {
+    if (p + 46 > bytes.length || dv.getUint32(p, true) !== CDH_SIG) break;
+    const nameLen = dv.getUint16(p + 28, true);
+    const extraLen = dv.getUint16(p + 30, true);
+    const commentLen = dv.getUint16(p + 32, true);
+    const externalAttrs = dv.getUint32(p + 38, true);
+    const unixMode = externalAttrs >>> 16; // high 16 bits = unix st_mode
+    const name = decoder.decode(bytes.subarray(p + 46, p + 46 + nameLen));
+    if (unixMode !== 0) modes.set(name, unixMode);
+    p += 46 + nameLen + extraLen + commentLen;
+  }
+  return modes;
 }
 
 /**

--- a/tests/integration/local-invoke-provided/lambda/.gitignore
+++ b/tests/integration/local-invoke-provided/lambda/.gitignore
@@ -2,6 +2,7 @@
 # verify.sh's `go build` inside Docker — not checked in.
 build/
 go.sum
-# ZIP-FILE asset for BootstrapZipHandler, built from build/bootstrap by
-# verify.sh — a generated artifact, not checked in.
+# ZIP-FILE asset for BootstrapZipHandler (+ its staging dir), built from
+# build/bootstrap by verify.sh — generated artifacts, not checked in.
 bootstrap.zip
+.ziptmp/

--- a/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
+++ b/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
@@ -18,12 +18,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     container; the OS-only Lambda runtime invokes it via the Lambda
  *     Runtime API. Architecture pinned to `x86_64` so the linux/amd64
  *     bootstrap built in CI matches the base image's default platform.
- *   - `BootstrapZipHandler` — same compiled `bootstrap`, but `Code.fromAsset`
- *     points at a `.zip` FILE (built by verify.sh) instead of the unzipped
- *     directory. CDK keeps it zipped (`aws:asset:path` -> `asset.<hash>.zip`),
- *     so cdkl must extract it AND preserve the bootstrap's executable bit —
- *     otherwise RIE fails with `Runtime.InvalidEntrypoint` /
- *     `fork/exec ...bootstrap: permission denied`.
+ *   - `BootstrapZipHandler` — same compiled handler, but `Code.fromAsset`
+ *     points at a `.zip` FILE (built by verify.sh) whose `bootstrap` is a
+ *     SYMLINK to the real binary (`bootstrap -> SwiftMathAlgorithm`), exactly
+ *     how Swift / many `provided.*` runtimes ship it. CDK keeps it zipped
+ *     (`aws:asset:path` -> `asset.<hash>.zip`), so cdkl must (a) recreate the
+ *     symlink (not write the link-target path as a text file) and (b) preserve
+ *     the real binary's executable bit — otherwise RIE fork/exec's a
+ *     non-executable and fails with `Runtime.InvalidEntrypoint` /
+ *     `exec format error` (or `permission denied`).
  *   - `ProvidedAl2023InlineHandler` — `CfnFunction` with `Code: { ZipFile }`
  *     and `runtime: provided.al2023`. cdk-local's local invoke must reject
  *     with the "use Code.fromAsset" message — `provided.*` runtimes ship
@@ -59,11 +62,11 @@ export class LocalInvokeProvidedStack extends cdk.Stack {
       memorySize: 256,
     });
 
-    // Same `bootstrap` binary, but `Code.fromAsset` points at a `.zip` FILE
-    // (built by verify.sh) instead of the unzipped directory. CDK stages it as
-    // `asset.<hash>.zip` and `aws:asset:path` points at the zip; cdkl must
-    // extract it AND preserve the bootstrap's executable bit, or RIE fails with
-    // `Runtime.InvalidEntrypoint` / `fork/exec ...bootstrap: permission denied`.
+    // Same handler, but `Code.fromAsset` points at a `.zip` FILE (built by
+    // verify.sh) whose `bootstrap` is a SYMLINK to the real binary — how Swift
+    // / many `provided.*` runtimes ship it. CDK stages it as `asset.<hash>.zip`;
+    // cdkl must recreate the symlink + preserve the binary's exec bit, or RIE
+    // fork/exec's a non-executable and fails with `exec format error`.
     new lambda.Function(this, 'BootstrapZipHandler', {
       runtime: lambda.Runtime.PROVIDED_AL2023,
       architecture: lambda.Architecture.X86_64,

--- a/tests/integration/local-invoke-provided/verify.sh
+++ b/tests/integration/local-invoke-provided/verify.sh
@@ -57,13 +57,22 @@ test -x lambda/build/bootstrap || {
   exit 1
 }
 
-# Build a ZIP-FILE asset from the same (executable) bootstrap for
-# BootstrapZipHandler. `zip` stores the unix exec mode; `Code.fromAsset` of a
-# `.zip` keeps it zipped (aws:asset:path -> asset.<hash>.zip), so cdkl must
-# extract it AND preserve the exec bit at invoke time. Built here (gitignored).
-echo "==> Building lambda/bootstrap.zip (ZIP-FILE asset for BootstrapZipHandler)"
+# Build a ZIP-FILE asset for BootstrapZipHandler with `bootstrap` as a SYMLINK
+# to the real binary — exactly how Swift and many other `provided.*` runtimes
+# ship it (`bootstrap -> MyHandler`). `zip -y` stores the symlink AS a symlink
+# (unix mode S_IFLNK). cdkl must (a) recreate the symlink instead of writing the
+# link-target path as a text file, and (b) preserve the real binary's exec bit,
+# or RIE fork/exec's a non-executable and fails with `exec format error`. Built
+# here (gitignored). The staging dir keeps the directory-asset BootstrapHandler
+# (Test 1/2) using a plain `bootstrap`.
+echo "==> Building lambda/bootstrap.zip (symlinked bootstrap ZIP-FILE asset)"
 rm -f lambda/bootstrap.zip
-( cd lambda/build && zip -q -X ../bootstrap.zip bootstrap )
+ZIPSTAGE="lambda/.ziptmp"
+rm -rf "${ZIPSTAGE}"
+mkdir -p "${ZIPSTAGE}"
+cp lambda/build/bootstrap "${ZIPSTAGE}/SwiftMathAlgorithm"
+( cd "${ZIPSTAGE}" && ln -sf SwiftMathAlgorithm bootstrap && zip -q -y -X ../bootstrap.zip bootstrap SwiftMathAlgorithm )
+rm -rf "${ZIPSTAGE}"
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/unit/local/lambda-resolver-asset-code.test.ts
+++ b/tests/unit/local/lambda-resolver-asset-code.test.ts
@@ -7,6 +7,8 @@ import {
   readFileSync,
   existsSync,
   statSync,
+  lstatSync,
+  readlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -121,6 +123,47 @@ describe('materializeAssetCodeDir', () => {
     // Callers whose own resolver does not validate existence (e.g. start-api's
     // local resolveAssetCodePath) rely on this guard for a friendly message.
     expect(() => materializeAssetCodeDir(join(root, 'nope.zip'))).toThrow(/does not exist/);
+  });
+
+  it('recreates a symlink entry as a symlink (not the link-target as a text file)', () => {
+    // A provided.* runtime commonly ships `bootstrap` as a symlink to the real
+    // binary (Swift: `bootstrap -> MyHandler`). fflate returns the symlink's
+    // content = the target path, so writing it as a regular file yields a tiny
+    // text file that RIE fork/exec's -> exec format error. The zip's central-dir
+    // unix mode (S_IFLNK = 0o120000) lets us recreate it as a real symlink.
+    const S_IFLNK = 0o120000;
+    const zipPath = join(root, 'asset.symlink.zip');
+    writeFileSync(
+      zipPath,
+      zipSync({
+        bootstrap: [strToU8('SwiftHandler'), { attrs: ((S_IFLNK | 0o755) << 16) >>> 0, os: 3 }],
+        SwiftHandler: [strToU8('#!/bin/sh\necho hi\n'), { attrs: (0o100755 << 16) >>> 0, os: 3 }],
+      })
+    );
+
+    const out = materializeAssetCodeDir(zipPath);
+    made.push(out.dir);
+    const bs = lstatSync(join(out.dir, 'bootstrap'));
+    expect(bs.isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(out.dir, 'bootstrap'))).toBe('SwiftHandler');
+    // The real binary keeps its stored executable mode; the symlink resolves to it.
+    expect(statSync(join(out.dir, 'bootstrap')).mode & 0o111).not.toBe(0);
+    expect(readFileSync(join(out.dir, 'bootstrap'), 'utf-8')).toContain('echo hi');
+  });
+
+  it('preserves the stored unix permission bits for a regular file', () => {
+    const zipPath = join(root, 'asset.perm.zip');
+    writeFileSync(
+      zipPath,
+      zipSync({
+        run: [strToU8('x'), { attrs: (0o100755 << 16) >>> 0, os: 3 }],
+        'data.txt': [strToU8('y'), { attrs: (0o100644 << 16) >>> 0, os: 3 }],
+      })
+    );
+    const out = materializeAssetCodeDir(zipPath);
+    made.push(out.dir);
+    expect(statSync(join(out.dir, 'run')).mode & 0o777).toBe(0o755);
+    expect(statSync(join(out.dir, 'data.txt')).mode & 0o777).toBe(0o644);
   });
 });
 


### PR DESCRIPTION
## Summary

`provided.*` custom runtimes commonly ship their entrypoint as a **symlink** to the real binary — Swift's CDK construct, for example, packages `bootstrap -> MyHandler`. fflate's `unzipSync` returns a symlink entry's content as the **link target path**, so the ZIP-FILE asset extraction (the `Code.fromAsset('bundle.zip')` path) wrote `bootstrap` as a ~18-byte regular text file containing the target name. RIE then fork/exec'd that non-executable text:

```
[ERROR] (rapid) Init failed error=fork/exec /var/runtime/bootstrap: exec format error
[ERROR] (rapid) Invoke DONE failed: Runtime.InvalidEntrypoint
```

So the function booted (asset resolved) but could not run. (This presents identically to an arch mismatch — `exec format error` — but the binary arch was correct; the "binary" was a text file.)

## Fix

fflate exposes no per-entry unix mode, so parse the zip's **central directory** ourselves (`parseZipUnixModes`) for each entry's stored mode (the high 16 bits of the external file attributes), then in `materializeAssetCodeDir`:

- recreate a symlink entry (`S_IFLNK`) as a **real symlink** (target = the entry content) — in a second pass after all regular files, so no regular-file write can follow an already-created symlink out of the extraction dir (on top of the existing lexical zip-slip guard on every destination);
- preserve the stored permission bits for regular files (0o755 fallback so a `bootstrap` stored with a bare-0 mode stays executable).

A directory asset is unaffected — CDK staged it with correct modes/symlinks and we bind-mount it directly.

## Test plan

- **unit** (`tests/unit/local/lambda-resolver-asset-code.test.ts`): a zip with a symlink entry extracts as a symlink resolving to the executable target (not a text file); regular-file unix perms are preserved.
- **integ** (`local-invoke-provided`): the `BootstrapZipHandler` zip now ships `bootstrap` as a **symlink** to the real Go binary (built by `verify.sh` with `zip -y`), so the invoke fork/exec's through the symlink end-to-end against real Docker. Verified: `exec format error` (empty-binary text file) before the fix → `{"echoed":{"from":"zip"},"greeting":"hello-from-zip"}` after. All 5 provided.* steps pass.

## Behavior change

A `provided.*` ZIP-FILE asset whose `bootstrap` is a symlink (the Swift / common layout) now runs locally instead of failing at invoke. Additive — no previously-working input changes. (Host CLIs embedding `cdkl invoke` inherit it by bumping the version; the change is internal to the asset-extraction helper, no CLI-surface change.)
