### PR TITLE
fix(studio): give the kind-group headers a uniform light-grey bar background

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -85,14 +85,21 @@ const STUDIO_CSS = `
     font: 11px ui-monospace, Menlo, monospace;
   }
   .pane-head #target-search:focus { outline: none; border-color: #4ec97a; }
+  /* Kind-group header (Lambda Functions etc.): a single uniform light-grey
+     bar (lighter than the row shades #1a1a1a / #242424, so the section header
+     reads as the most prominent band) with a hairline bottom border. Neutral
+     grey by hue, so it never clashes with the blue-navy stack-sub divider
+     below it. The blue label (#6aa9ff) still reads on the lighter bar; the
+     caret + count are lifted to suit the brighter background. */
   .group-title {
     padding: 7px 12px; color: #6aa9ff; font-size: 11px; cursor: pointer; user-select: none;
-    display: flex; align-items: center; gap: 6px; background: #131313;
+    display: flex; align-items: center; gap: 6px; background: #2e2e2e;
+    border-bottom: 1px solid #3a3a3a;
   }
-  .group-title:hover { background: #1a1a1a; }
-  .group-title .caret { color: #777; font-size: 9px; width: 9px; display: inline-block; transition: transform .1s; }
+  .group-title:hover { background: #363636; }
+  .group-title .caret { color: #9a9a9a; font-size: 9px; width: 9px; display: inline-block; transition: transform .1s; }
   .group-title.open .caret { transform: rotate(90deg); }
-  .group-title .count { color: #666; }
+  .group-title .count { color: #8a8a8a; }
   .group-body.collapsed { display: none; }
   .target {
     padding: 6px 12px; display: flex; align-items: center; gap: 8px;

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -156,6 +156,11 @@ describe('renderStudioHtml', () => {
     // a clearly distinct shade (issue #333 — the previous #1b1b1b was 1 step off
     // the #1a1a1a base and imperceptible).
     expect(html).toContain('.group-body .target.alt { background: #242424; }');
+    // Kind-group header: a uniform light-grey bar (lighter than the row shades)
+    // with a bottom border — neutral hue so it never clashes with the blue-navy
+    // stack sub-header below it.
+    expect(html).toContain('background: #2e2e2e;');
+    expect(html).toContain('.group-title .count { color: #8a8a8a; }');
   });
 
   it('widens the Session-bar inputs so the placeholder is not truncated (issue #339)', () => {


### PR DESCRIPTION
## Summary

The kind-group headers in the `cdkl studio` targets pane (Lambda Functions /
APIs / ECS Services / ...) used a near-black `#131313` background that barely
separated from the dark pane.

Give them a single **uniform** light-grey bar (not per-service):
- `#2e2e2e` background — lighter than the row shades (`#1a1a1a` / `#242424`)
  so the section header reads as the most prominent band
- hairline `#3a3a3a` bottom border for definition
- neutral grey by **hue**, so it never clashes with the blue-navy stack
  sub-header below it
- the blue label (`#6aa9ff`) still reads on the lighter bar; the caret + count
  are lifted to `#9a9a9a` / `#8a8a8a` to suit the brighter background

## Test plan

- Unit (`studio-ui.test.ts`): added CSS assertions for the new bar background
  and the lifted count colour.
- Integ (`local-studio`): served-UI assertions green (Docker, 0 orphans).
- Visual confirmation in the browser post-publish.
