### PR TITLE
fix(studio): switch the kind-group header bar to a warm amber tint

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -85,18 +85,18 @@ const STUDIO_CSS = `
     font: 11px ui-monospace, Menlo, monospace;
   }
   .pane-head #target-search:focus { outline: none; border-color: #4ec97a; }
-  /* Kind-group header (Lambda Functions etc.): a single uniform light-grey
-     bar (lighter than the row shades #1a1a1a / #242424, so the section header
-     reads as the most prominent band) with a hairline bottom border. Neutral
-     grey by hue, so it never clashes with the blue-navy stack-sub divider
-     below it. The blue label (#6aa9ff) still reads on the lighter bar; the
-     caret + count are lifted to suit the brighter background. */
+  /* Kind-group header (Lambda Functions etc.): a single uniform dark-amber
+     bar with a hairline bottom border. Warm yellow by hue, so it stands apart
+     from both the neutral-grey rows (#1a1a1a / #242424) and the blue-navy
+     stack-sub divider below it. The label is a warm gold (a blue label would
+     clash on the amber bar); the caret + count stay neutral grey, which still
+     reads on the dark warm bar. */
   .group-title {
-    padding: 7px 12px; color: #6aa9ff; font-size: 11px; cursor: pointer; user-select: none;
-    display: flex; align-items: center; gap: 6px; background: #2e2e2e;
-    border-bottom: 1px solid #3a3a3a;
+    padding: 7px 12px; color: #e3c272; font-size: 11px; cursor: pointer; user-select: none;
+    display: flex; align-items: center; gap: 6px; background: #302b18;
+    border-bottom: 1px solid #46411f;
   }
-  .group-title:hover { background: #363636; }
+  .group-title:hover { background: #3a341d; }
   .group-title .caret { color: #9a9a9a; font-size: 9px; width: 9px; display: inline-block; transition: transform .1s; }
   .group-title.open .caret { transform: rotate(90deg); }
   .group-title .count { color: #8a8a8a; }

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -156,10 +156,11 @@ describe('renderStudioHtml', () => {
     // a clearly distinct shade (issue #333 — the previous #1b1b1b was 1 step off
     // the #1a1a1a base and imperceptible).
     expect(html).toContain('.group-body .target.alt { background: #242424; }');
-    // Kind-group header: a uniform light-grey bar (lighter than the row shades)
-    // with a bottom border — neutral hue so it never clashes with the blue-navy
-    // stack sub-header below it.
-    expect(html).toContain('background: #2e2e2e;');
+    // Kind-group header: a uniform dark-amber bar with a warm-gold label —
+    // a warm hue that stands apart from both the neutral-grey rows and the
+    // blue-navy stack sub-header below it.
+    expect(html).toContain('background: #302b18;');
+    expect(html).toContain('color: #e3c272;');
     expect(html).toContain('.group-title .count { color: #8a8a8a; }');
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #435. Switch the uniform kind-group header bar (Lambda Functions
/ APIs / ECS Services / ...) from neutral grey to a warm amber tint:
- background `#302b18` (dark amber) + `#46411f` bottom border
- label `#e3c272` (warm gold) — a blue label would clash on the amber bar
- caret + count stay neutral grey (still read on the dark warm bar)

The warm hue stands apart from both the neutral-grey rows (`#1a1a1a` /
`#242424`) and the blue-navy stack sub-header below it. Uniform across all
kinds (not per-service).

## Test plan

- Unit (`studio-ui.test.ts`): CSS assertions updated to the amber bar + gold label.
- Integ (`local-studio`): served-UI assertions green (Docker, 0 orphans). Two
  earlier runs failed on environmental load crashes (a WS-echo timeout and a Go
  RIE runtime panic) under heavy concurrent load — unrelated to this CSS-only
  change; passed cleanly once the machine was quiet.
- Visual confirmation in the browser post-publish.
