### PR TITLE
feat(studio): show the composer result as a Request/Response pair with split headers/body + JSON pretty-print

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -198,8 +198,13 @@ const STUDIO_CSS = `
   .req-composer .req-send button { margin-top: 0; padding: 4px 16px; background: #2a7d46; color: #fff; }
   .req-composer .req-send button:hover { background: #339152; }
   .req-composer .req-send button:disabled { background: #333; color: #888; }
-  .req-composer .req-result .req-resp { margin-top: 8px; padding: 0; border-bottom: none; }
+  .req-composer .req-result .req-req,
+  .req-composer .req-result .req-resp { margin-top: 10px; padding: 0; border-bottom: none; }
   .req-composer .req-result pre { background: #0e0e0e; }
+  .req-composer .req-result .opt-label { margin-top: 6px; margin-bottom: 3px; }
+  .req-composer .req-result .req-line { color: #cdd6e0; font-weight: 600; }
+  .req-composer .req-result .req-resp-headers { color: #8b8b8b; }
+  .req-composer .req-result .req-resp-body { color: #d6d6d6; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
   .log-clear {
@@ -1446,6 +1451,50 @@ const STUDIO_SCRIPT = `
     };
   }
 
+  // Pretty-print a body when it parses as JSON (object / array); otherwise
+  // return it untouched (HTML / plain text / XML stay verbatim — e.g. a
+  // python http.server directory listing is text/html, not JSON). Guarded on a
+  // leading { or [ so a bare number / quoted-string body is not reformatted.
+  function prettyBody(s) {
+    if (typeof s !== 'string') return s == null ? '' : String(s);
+    const t = s.trim();
+    if (t === '' || (t.charAt(0) !== '{' && t.charAt(0) !== '[')) return s;
+    try {
+      return JSON.stringify(JSON.parse(t), null, 2);
+    } catch (e) {
+      return s;
+    }
+  }
+
+  // Render one side of an HTTP exchange (Request or Response) as a section
+  // with a heading (a status badge for the response), the request-line (for
+  // the request), and Headers / Body split into a dimmed header block + a
+  // (JSON-pretty-printed) body block. Shared by the composer's inline result
+  // so the sent request and the response read as a labeled pair.
+  function renderHttpExchangeSection(title, status, headers, body, requestLine, durationMs) {
+    const sec = el('div', 'section ' + (title === 'Request' ? 'req-req' : 'req-resp'));
+    const head = el('h3', null, title);
+    if (status != null) {
+      const cls = status >= 200 && status < 300 ? 'ok' : 'bad';
+      head.appendChild(
+        el('span', cls, '  ' + status + (durationMs != null ? ' · ' + durationMs + 'ms' : ''))
+      );
+    }
+    sec.appendChild(head);
+    if (requestLine) sec.appendChild(el('pre', 'req-line', requestLine));
+    const hdrKeys = Object.keys(headers || {});
+    if (hdrKeys.length) {
+      sec.appendChild(el('div', 'opt-label', 'Headers'));
+      const hdrText = hdrKeys.map(function (k) { return k + ': ' + headers[k]; }).join('\\n');
+      sec.appendChild(el('pre', 'req-resp-headers', hdrText));
+    }
+    if (body != null && body !== '') {
+      sec.appendChild(el('div', 'opt-label', 'Body'));
+      sec.appendChild(el('pre', 'req-resp-body', prettyBody(body)));
+    }
+    return sec;
+  }
+
   function renderRequestComposer(id, baseUrl, captured) {
     const sec = el('div', 'section req-composer');
     sec.appendChild(el('h3', null, 'Request'));
@@ -1549,25 +1598,19 @@ const STUDIO_SCRIPT = `
           msg.textContent = 'Request failed: ' + (data.error || ('HTTP ' + res.status));
           return;
         }
-        // Frame the result as a "Response" section (status badge in the
-        // heading) so a sent request reads as Request (the compose form above)
-        // -> Response, matching the timeline's read-only detail. Without the
-        // heading the status + headers + body dumped raw under Send read as an
-        // unlabeled blob — most visible for an ecs --host-port serve, which is
-        // not captured on the timeline and so has only this inline result.
-        const respSec = el('div', 'section req-resp');
-        const respHead = el('h3', null, 'Response');
-        const cls = data.status >= 200 && data.status < 300 ? 'ok' : 'bad';
-        respHead.appendChild(
-          el('span', cls, '  ' + data.status + (data.durationMs != null ? ' · ' + data.durationMs + 'ms' : ''))
+        // Render the result as a Request -> Response PAIR (matching the
+        // timeline's read-only detail): the sent request echoed above the
+        // response, each with its status / request-line heading and Headers /
+        // Body split into separate dimmed-header + body blocks. Without this the
+        // status + headers + body dump raw under Send as one unlabeled blob —
+        // most visible for an ecs --host-port serve, whose only result surface
+        // is this inline pane.
+        result.appendChild(
+          renderHttpExchangeSection('Request', null, payload.headers, payload.body, method.value + ' ' + payload.path)
         );
-        respSec.appendChild(respHead);
-        const hdrs = Object.keys(data.headers || {})
-          .map(function (k) { return k + ': ' + data.headers[k]; })
-          .join('\\n');
-        if (hdrs) respSec.appendChild(el('pre', 'req-resp-headers', hdrs));
-        respSec.appendChild(el('pre', null, data.body != null ? data.body : ''));
-        result.appendChild(respSec);
+        result.appendChild(
+          renderHttpExchangeSection('Response', data.status, data.headers, data.body, null, data.durationMs)
+        );
       } catch (err) {
         msg.textContent = 'Request failed: ' + err;
       } finally {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -293,9 +293,16 @@ if ! grep -qF "function applyConfig" "${BODY_FILE}" || grep -qF 'id="sess-save"'
   echo "FAIL: GET / Session bar is not apply-on-change (Save button still present?)"
   exit 1
 fi
-# In-workspace HTTP request composer (issue #322).
+# In-workspace HTTP request composer (issue #322). The composer's inline result
+# renders the sent request + response as a labeled Request/Response pair with a
+# JSON-pretty-printed body (renderHttpExchangeSection + prettyBody must ship in
+# the embedded script).
 if ! grep -qF "function renderRequestComposer" "${BODY_FILE}" || ! grep -qF "fetch('/api/request'" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the in-workspace HTTP request composer"
+  exit 1
+fi
+if ! grep -qF "function renderHttpExchangeSection" "${BODY_FILE}" || ! grep -qF "function prettyBody" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the Request/Response exchange renderer + JSON body pretty-printer"
   exit 1
 fi
 # Proxy-vs-child port clarity (issue #325): the Endpoints hint names the proxy

--- a/tests/unit/local/studio-ui-send-response.test.ts
+++ b/tests/unit/local/studio-ui-send-response.test.ts
@@ -96,4 +96,73 @@ describe('request-composer Send result framing', () => {
       h.close();
     }
   });
+
+  it('echoes the sent Request (method/path + headers + body) above the Response', async () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      (h.window as any).fetch = () =>
+        Promise.resolve({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve({ status: 201, headers: {}, body: 'ok', durationMs: 2 }),
+        });
+
+      const sec = h.window.__t.renderRequestComposer('S/Svc', 'http://127.0.0.1:8080', false);
+      h.document.body.appendChild(sec);
+      // Compose a POST /orders with a body so the echo has all three parts.
+      sec.querySelector('.req-method').value = 'POST';
+      sec.querySelector('.req-path').value = '/orders';
+      sec.querySelector('.req-body').value = '{"item":"x"}';
+      sec.querySelector('.req-send button').click();
+      await flush();
+
+      // A "Request" section echoes the sent request as a counterpart to Response.
+      const reqSec = sec.querySelector('.req-result .req-req');
+      expect(reqSec).not.toBeNull();
+      expect(reqSec.querySelector('h3').textContent).toContain('Request');
+      // The request-line carries method + path.
+      const reqLine = reqSec.querySelector('pre.req-line');
+      expect(reqLine).not.toBeNull();
+      expect(reqLine.textContent).toBe('POST /orders');
+      // The request body is echoed (and pretty-printed, being JSON).
+      const reqBodyPre = reqSec.querySelector('pre.req-resp-body');
+      expect(reqBodyPre).not.toBeNull();
+      expect(reqBodyPre.textContent).toContain('"item": "x"');
+      // The Response section is still present below it.
+      expect(sec.querySelector('.req-result .req-resp h3').textContent).toContain('Response');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('pretty-prints a JSON response body but leaves HTML/text verbatim', async () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      (h.window as any).fetch = () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+              body: '{"a":1,"b":[2,3]}',
+              durationMs: 5,
+            }),
+        });
+
+      const sec = h.window.__t.renderRequestComposer('S/Api', 'http://127.0.0.1:8080', true);
+      h.document.body.appendChild(sec);
+      sec.querySelector('.req-send button').click();
+      await flush();
+
+      const bodyPre = sec.querySelector('.req-result .req-resp pre.req-resp-body');
+      expect(bodyPre).not.toBeNull();
+      // JSON.stringify(parsed, null, 2): newlines + 2-space indentation.
+      expect(bodyPre.textContent).toContain('\n  "a": 1');
+      expect(bodyPre.textContent).toContain('\n  "b": [');
+    } finally {
+      h.close();
+    }
+  });
 });

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -205,8 +205,9 @@ describe('renderStudioHtml', () => {
     // ecs --host-port host URL).
     expect(html).toContain('renderRequestComposer(id, httpBase, captured)');
     expect(html).toContain('isEcs ? st.hostUrl');
-    // The ecs host URL is shown in Endpoints with an "not captured" note.
-    expect(html).toContain('not captured on the timeline');
+    // The ecs host URL is shown in Endpoints with a note that composer requests
+    // ARE captured on the timeline (the direct relay self-emits — issue #432).
+    expect(html).toContain('composer requests are captured on the timeline');
   });
 
   it('clarifies the curl-able proxy port vs the child internal port (issue #325)', () => {


### PR DESCRIPTION
## Summary

Follow-up to the studio composer work: a request sent to a Service (ecs)
serve showed its response as one undivided block — the headers and an HTML
body (e.g. a `python -m http.server` directory listing) run together with no
labels, and no echo of the request that produced it.

The composer's inline Send result now renders the sent **Request** and the
**Response** as a labeled pair (mirroring the timeline's read-only detail),
and each side splits cleanly:

- a request-line (`POST /orders`) / status-badge (`200 · 7ms`) heading,
- a dimmed **Headers** block, and
- a **Body** block that is **JSON-pretty-printed** when the body parses as
  JSON. HTML / plain text / XML are left verbatim — a directory-listing
  response is `text/html`, so it stays as-is (that output is the container's
  actual response, not a bug).

`renderHttpExchangeSection` + `prettyBody` are the shared renderers (the
embedded `STUDIO_SCRIPT` — no backticks introduced).

## Test plan

- **Unit** (jsdom, `studio-ui-send-response.test.ts`): the Response section
  (status badge + headers + body) still renders; the Request echo carries the
  method/path request-line + headers + body; a JSON body is indented; an HTML
  body is left verbatim; a non-2xx gets the `bad` status class. Full suite
  green (2956 tests).
- Fixed a brittle assertion in `studio-ui.test.ts` that matched the ecs
  endpoint note against a source **comment** string (stale since the request
  now self-captures); it now asserts the user-visible hint text.
- **Integration** (`tests/integration/local-studio/verify.sh`): added a static
  assertion that `renderHttpExchangeSection` + `prettyBody` ship in the served
  embedded script. Ran the full local-studio integ against real Docker — green,
  0 orphan containers / networks / images.

Pure client-side rendering change (embedded UI script only); no server / CLI
surface change.
