### PR TITLE
feat(invoke/run-task): warn when a Lambda/ECS container runs under CPU emulation

### DIFF
--- a/src/local/docker-image-builder.ts
+++ b/src/local/docker-image-builder.ts
@@ -3,7 +3,7 @@ import { buildDockerImage } from '../assets/docker-build.js';
 import type { DockerImageAssetSource } from '../types/assets.js';
 import { runDockerStreaming } from '../utils/docker-cmd.js';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
-import { getLogger } from '../utils/logger.js';
+import { getLogger, type Logger } from '../utils/logger.js';
 import { isImageInLocalCache } from './ecr-puller.js';
 import { getEmbedConfig } from './embed-config.js';
 
@@ -109,6 +109,67 @@ export async function buildContainerImage(
  */
 export function architectureToPlatform(architecture: 'x86_64' | 'arm64'): string {
   return architecture === 'arm64' ? 'linux/arm64' : 'linux/amd64';
+}
+
+/**
+ * The Docker `--platform` value matching the host CPU arch.
+ *
+ * `process.arch` is `arm64` on Apple Silicon and `x64` on Intel/amd64
+ * hosts; everything else is treated as amd64 for the purpose of the
+ * emulation comparison (the only two `--platform` values cdk-local emits
+ * are `linux/arm64` / `linux/amd64`).
+ */
+function hostPlatform(): string {
+  return process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64';
+}
+
+/** Process-global dedupe so a warm pool / per-request boot warns once per arch. */
+const warnedEmulatedPlatforms = new Set<string>();
+
+/**
+ * Warn once per process when a container is about to run at a `--platform`
+ * whose CPU arch differs from the host's — i.e. it will run under CPU
+ * emulation.
+ *
+ * The arch is chosen automatically from the function's declared
+ * `Architectures`, so the user gets no signal that emulation is in play
+ * until a container dies. Emulated containers usually run fine, but some
+ * compiled custom-runtime binaries (notably a Swift `provided.*`
+ * bootstrap) crash under emulation with `exec format error` or
+ * `illegal instruction`, which is opaque without this hint. Surface the
+ * two real fixes: enable Rosetta for x86/amd64 emulation in the Docker
+ * engine settings, or build the function for the host arch.
+ *
+ * Deduped by target platform so a warm pool / per-request boot doesn't
+ * spam. `platform` is the resolved `--platform` value (`undefined` =>
+ * docker picks the host arch, so there is nothing to warn about).
+ */
+export function warnIfEmulatedPlatform(
+  platform: string | undefined,
+  opts: { label?: string; logger?: Logger } = {}
+): void {
+  if (!platform) return;
+  const host = hostPlatform();
+  if (platform === host) return;
+  if (warnedEmulatedPlatforms.has(platform)) return;
+  warnedEmulatedPlatforms.add(platform);
+  const logger = opts.logger ?? getLogger();
+  const what = opts.label ? `'${opts.label}' ` : '';
+  logger.warn(
+    `Running ${what}under ${platform} emulation on a ${host} host. ` +
+      'Emulated containers can crash some compiled custom-runtime binaries ' +
+      "(e.g. a Swift 'provided.*' bootstrap) with 'exec format error' or " +
+      "'illegal instruction'. If you hit that, enable Rosetta for x86/amd64 " +
+      `emulation in your Docker engine settings, or build the function for ${host}.`
+  );
+}
+
+/**
+ * Test-only: reset the process-global emulation-warning dedupe set so a
+ * unit test can re-assert the once-per-arch behavior across cases.
+ */
+export function resetEmulationWarningsForTesting(): void {
+  warnedEmulatedPlatforms.clear();
 }
 
 /**

--- a/src/local/docker-runner.ts
+++ b/src/local/docker-runner.ts
@@ -3,6 +3,7 @@ import { createServer } from 'node:net';
 import { promisify } from 'node:util';
 import { getDockerCmd, runDockerForeground, runDockerStreaming } from '../utils/docker-cmd.js';
 import { getLogger } from '../utils/logger.js';
+import { warnIfEmulatedPlatform } from './docker-image-builder.js';
 import { getEmbedConfig } from './embed-config.js';
 
 const execFileAsync = promisify(execFile);
@@ -241,6 +242,10 @@ export async function runDetached(opts: DockerRunOptions): Promise<string> {
   }
   if (opts.platform) {
     args.push('--platform', opts.platform);
+    // Surface CPU emulation (declared arch != host arch) before the
+    // container boots — an emulated compiled custom runtime can die with
+    // an opaque `exec format error` / `illegal instruction` otherwise.
+    warnIfEmulatedPlatform(opts.platform, opts.name ? { label: opts.name } : {});
   }
   if (opts.extraHosts) {
     for (const entry of opts.extraHosts) {

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -15,6 +15,7 @@ import {
   SENSITIVE_ENV_KEYS,
 } from './docker-runner.js';
 import { attachContainerLogStreamer } from './container-log-streamer.js';
+import { warnIfEmulatedPlatform } from './docker-image-builder.js';
 import { buildDockerImage } from '../assets/docker-build.js';
 import { isImageInLocalCache, pullEcrImage } from './ecr-puller.js';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
@@ -1211,13 +1212,20 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
     for (const f of opts.addHostFlags) args.push(f);
   }
 
+  let resolvedPlatform: string | undefined;
   if (opts.platformOverride) {
-    args.push('--platform', opts.platformOverride);
+    resolvedPlatform = opts.platformOverride;
   } else if (task.runtimePlatform) {
-    args.push(
-      '--platform',
-      task.runtimePlatform.cpuArchitecture === 'ARM64' ? 'linux/arm64' : 'linux/amd64'
-    );
+    resolvedPlatform =
+      task.runtimePlatform.cpuArchitecture === 'ARM64' ? 'linux/arm64' : 'linux/amd64';
+  }
+  if (resolvedPlatform) {
+    args.push('--platform', resolvedPlatform);
+    // An ECS task container threads `--platform` too (RuntimePlatform /
+    // override), but runs via execFileAsync rather than runDetached — so
+    // surface CPU emulation here as well: a Swift/Rust ECS task can die
+    // under emulation with the same opaque `exec format error`.
+    warnIfEmulatedPlatform(resolvedPlatform, { label: `${task.family}/${container.name}` });
   }
 
   // Issue #585 — multi-replica services skip the host-port publish.

--- a/tests/unit/local/docker-image-builder.test.ts
+++ b/tests/unit/local/docker-image-builder.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 // Mock the docker-cmd helpers used by buildDockerImage / isImageInLocalCache.
 // `vi.mock` is hoisted ABOVE top-level `const`s, so the stub functions must
@@ -40,7 +40,10 @@ vi.mock('../../../src/utils/docker-cmd.js', async () => {
 import {
   architectureToPlatform,
   buildContainerImage,
+  resetEmulationWarningsForTesting,
+  warnIfEmulatedPlatform,
 } from '../../../src/local/docker-image-builder.js';
+import type { Logger } from '../../../src/utils/logger.js';
 import { LocalInvokeBuildError } from '../../../src/utils/error-handler.js';
 
 beforeEach(() => {
@@ -61,6 +64,73 @@ describe('architectureToPlatform', () => {
   });
   it('maps arm64 to linux/arm64', () => {
     expect(architectureToPlatform('arm64')).toBe('linux/arm64');
+  });
+});
+
+describe('warnIfEmulatedPlatform', () => {
+  const realArch = process.arch;
+  const setArch = (arch: string) => {
+    Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+  };
+  const fakeLogger = () => {
+    const warn = vi.fn();
+    return { logger: { warn } as unknown as Logger, warn };
+  };
+
+  beforeEach(() => {
+    resetEmulationWarningsForTesting();
+  });
+  afterEach(() => {
+    Object.defineProperty(process, 'arch', { value: realArch, configurable: true });
+  });
+
+  it('warns when the target platform arch differs from the host (amd64 on arm64 host)', () => {
+    setArch('arm64');
+    const { logger, warn } = fakeLogger();
+    warnIfEmulatedPlatform('linux/amd64', { logger });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0][0] as string;
+    expect(msg).toContain('linux/amd64');
+    expect(msg).toContain('linux/arm64');
+    expect(msg).toContain('emulation');
+    expect(msg).toContain('Rosetta');
+  });
+
+  it('warns the other direction too (arm64 target on an amd64 host)', () => {
+    setArch('x64');
+    const { logger, warn } = fakeLogger();
+    warnIfEmulatedPlatform('linux/arm64', { logger });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('linux/arm64');
+  });
+
+  it('does not warn when the target platform matches the host arch', () => {
+    setArch('arm64');
+    const { logger, warn } = fakeLogger();
+    warnIfEmulatedPlatform('linux/arm64', { logger });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when no platform is resolved (docker picks the host arch)', () => {
+    setArch('arm64');
+    const { logger, warn } = fakeLogger();
+    warnIfEmulatedPlatform(undefined, { logger });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('dedupes by platform so a warm pool / per-request boot warns once', () => {
+    setArch('arm64');
+    const { logger, warn } = fakeLogger();
+    warnIfEmulatedPlatform('linux/amd64', { logger });
+    warnIfEmulatedPlatform('linux/amd64', { logger, label: 'cdkl-fn-2' });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes the label in the message when provided', () => {
+    setArch('arm64');
+    const { logger, warn } = fakeLogger();
+    warnIfEmulatedPlatform('linux/amd64', { logger, label: 'cdkl-MyFn-abc' });
+    expect(warn.mock.calls[0][0]).toContain('cdkl-MyFn-abc');
   });
 });
 

--- a/tests/unit/local/docker-runner-rundetached-env.test.ts
+++ b/tests/unit/local/docker-runner-rundetached-env.test.ts
@@ -20,6 +20,10 @@ vi.mock('node:child_process', () => ({
 }));
 
 const { runDetached } = await import('../../../src/local/docker-runner.js');
+const { getLogger } = await import('../../../src/utils/logger.js');
+const { resetEmulationWarningsForTesting } = await import(
+  '../../../src/local/docker-image-builder.js'
+);
 
 describe('runDetached sensitive-env wiring', () => {
   beforeEach(() => execFileMock.mockReset());
@@ -87,6 +91,56 @@ describe('runDetached sensitive-env wiring', () => {
     // Non-sensitive config still inline; value carried via process env.
     expect(args).toContain('TABLE_NAME=my-table');
     expect(options.env!['API_KEY']).toBe('s3cr3t-ssm-value');
+  });
+
+  it('threads --platform and warns once when the declared arch is emulated', async () => {
+    const realArch = process.arch;
+    Object.defineProperty(process, 'arch', { value: 'arm64', configurable: true });
+    resetEmulationWarningsForTesting();
+    const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    try {
+      await runDetached({
+        image: 'public.ecr.aws/lambda/provided:al2023',
+        mounts: [],
+        env: {},
+        cmd: ['bootstrap'],
+        hostPort: 9101,
+        platform: 'linux/amd64',
+        name: 'cdkl-MyFn-abc',
+      });
+      const [, args] = execFileMock.mock.calls[0] as [string, string[]];
+      // The platform is threaded to docker run.
+      expect(args).toContain('--platform');
+      expect(args).toContain('linux/amd64');
+      // And the emulation mismatch (amd64 target on arm64 host) is surfaced.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('emulation');
+    } finally {
+      warnSpy.mockRestore();
+      Object.defineProperty(process, 'arch', { value: realArch, configurable: true });
+    }
+  });
+
+  it('does not warn when the declared arch matches the host', async () => {
+    const realArch = process.arch;
+    Object.defineProperty(process, 'arch', { value: 'arm64', configurable: true });
+    resetEmulationWarningsForTesting();
+    const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    try {
+      await runDetached({
+        image: 'public.ecr.aws/lambda/provided:al2023',
+        mounts: [],
+        env: {},
+        cmd: ['bootstrap'],
+        hostPort: 9102,
+        platform: 'linux/arm64',
+        name: 'cdkl-MyFn-arm',
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      Object.defineProperty(process, 'arch', { value: realArch, configurable: true });
+    }
   });
 
   it('uses no env option when the container has no sensitive env', async () => {

--- a/tests/unit/local/ecs-task-runner-privileged-port.test.ts
+++ b/tests/unit/local/ecs-task-runner-privileged-port.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vite-plus/test';
 import {
   buildDockerRunArgs,
   resolvePrivilegedHostPortRemaps,
 } from '../../../src/local/ecs-task-runner.js';
+import { resetEmulationWarningsForTesting } from '../../../src/local/docker-image-builder.js';
+import { getLogger } from '../../../src/utils/logger.js';
 import type { ResolvedEcsContainer, ResolvedEcsTask } from '../../../src/local/ecs-task-resolver.js';
 
 // buildDockerRunArgs / resolvePrivilegedHostPortRemaps read only a bounded
@@ -129,5 +131,59 @@ describe('buildDockerRunArgs privileged-port auto-remap publish (issue #357)', (
     const ep = publishedEndpoints.find((e) => e.containerPort === 80);
     expect(ep?.hostPort).toBe(50000);
     expect(ep?.overridden).toBe(true);
+  });
+});
+
+describe('buildDockerRunArgs emulation warning', () => {
+  const realArch = process.arch;
+  const baseOpts = () => ({
+    task: taskWith([]),
+    container: container('web', [{ containerPort: 80, protocol: 'tcp' }]),
+    image: 'public.ecr.aws/docker/library/busybox:latest',
+    network: 'net',
+    volumeByName: new Map(),
+    secrets: [],
+    envOverrides: undefined,
+    containerHost: '127.0.0.1',
+    roleArn: undefined,
+    region: undefined,
+    hostPortOverrides: {},
+    autoRemappedContainerPorts: new Set<number>(),
+  });
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'arch', { value: 'arm64', configurable: true });
+    resetEmulationWarningsForTesting();
+  });
+  afterEach(() => {
+    Object.defineProperty(process, 'arch', { value: realArch, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('warns when a platformOverride emulates the host arch', () => {
+    const warn = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const { args } = buildDockerRunArgs({ ...baseOpts(), platformOverride: 'linux/amd64' });
+    expect(args).toContain('--platform');
+    expect(args).toContain('linux/amd64');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('emulation');
+  });
+
+  it('warns when a RuntimePlatform-derived arch emulates the host', () => {
+    const warn = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    const task = {
+      family: 'fam',
+      containers: [],
+      runtimePlatform: { cpuArchitecture: 'X86_64' },
+    } as unknown as ResolvedEcsTask;
+    const { args } = buildDockerRunArgs({ ...baseOpts(), task, platformOverride: undefined });
+    expect(args).toContain('linux/amd64');
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when the platform matches the host arch', () => {
+    const warn = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+    buildDockerRunArgs({ ...baseOpts(), platformOverride: 'linux/arm64' });
+    expect(warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

A Lambda / ECS container's `--platform` is chosen automatically from its declared `Architectures` / `RuntimePlatform`, so on a host whose arch differs (e.g. an x86_64 function on an arm64 Mac) the container runs under **CPU emulation** with no signal to the user. Emulated containers usually run, but some compiled custom-runtime binaries — notably a Swift `provided.*` bootstrap, or a Rust/Swift ECS task — crash under emulation with an opaque `exec format error` / `illegal instruction`. The user has no way to tell emulation is even in play.

This adds a one-time WARN, fired just before the container boots, when the resolved `--platform` arch differs from the host arch — naming the two real fixes: enable Rosetta for x86/amd64 emulation in the Docker engine settings, or build the function for the host arch.

## Change

- New `warnIfEmulatedPlatform(platform, { label?, logger? })` in `src/local/docker-image-builder.ts` (co-located with `architectureToPlatform`): compares the resolved `--platform` arch against `process.arch`, deduped by platform via a process-global Set so a warm pool / per-request boot warns once per arch.
- Wired into **both** `docker run --platform` chokepoints:
  - `runDetached` (`docker-runner.ts`) — covers `cdkl invoke`, `start-api`'s container pool, and the front-door Lambda runner.
  - `buildDockerRunArgs` (`ecs-task-runner.ts`) — covers `cdkl run-task` / `start-service` / `start-alb` ECS containers, which run via `execFileAsync` and never pass through `runDetached`.

## Behavior change

Additive: no previously-working input changes — an emulated container still runs exactly as before, now with an upfront stderr WARN when it might fail. Host CLIs embedding these commands inherit it by bumping the cdk-local version; no host-side change required (the diff is internal to the runtime layer — no new flag, command, or library export).

## Known cost (accepted)

The dedupe key is the resolved platform string, not the function name — so a multi-function app that emulates several functions at the same arch warns once and names only the *first* function. This is intentional (one WARN per arch, not per function), at the cost of the message naming a single representative target. Acceptable for an advisory hint.

## Test plan

- **unit**: `warnIfEmulatedPlatform` — both emulation directions (amd64-on-arm64, arm64-on-amd64), the match / `undefined` / dedupe / label cases; site-level bindings asserting both `runDetached` and `buildDockerRunArgs` thread `--platform` AND fire the warn once on a mismatch (and stay silent on a match).
- **integ** (`local-invoke-provided`): the x86_64 `provided.al2023` bootstrap fixture booted on an arm64 host exercises the emulated-container path end-to-end (5/5 green).
- **live-test**: ran `node dist/cli.js invoke .../BootstrapHandler --no-pull` directly with stderr visible on an arm64 host — confirmed the line fires: `Running under linux/amd64 emulation on a linux/arm64 host. ... enable Rosetta for x86/amd64 emulation in your Docker engine settings, or build the function for linux/arm64.` — and the invoke still succeeds.
