### PR TITLE
fix(studio): put the WS console Connect button on its own row above the input

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -1755,11 +1755,14 @@ const STUDIO_SCRIPT = `
     sendBtn.disabled = !on;
     sendBtn.onclick = wsSend;
 
-    // Input fills the row width; Send is wrapped onto its OWN row below so on
-    // a wide pane it sits at the left (near the input) instead of being flung
-    // to the far right edge.
+    // Each control on its OWN row, stacked: Connect, then the (full-width)
+    // input, then Send. Keeps Connect / Send at the left (near the input)
+    // instead of being flung to the far right edge on a wide pane.
+    const connectRow = el('div', 'ws-row');
+    connectRow.appendChild(connectBtn);
+    sec.appendChild(connectRow);
+
     const row = el('div', 'ws-row');
-    row.appendChild(connectBtn);
     row.appendChild(input);
     sec.appendChild(row);
 

--- a/tests/unit/local/studio-ui-ws-console.test.ts
+++ b/tests/unit/local/studio-ui-ws-console.test.ts
@@ -126,4 +126,17 @@ describe('studio WebSocket console (renderWsConsole)', () => {
     // ...and BEFORE the frame log.
     expect(frames!.compareDocumentPosition(clearBtn!) & NODE.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
   });
+
+  it('the Connect button sits on its own row ABOVE the text input', () => {
+    const { node, input } = mountConsole();
+    const connectBtn = node.querySelector('.ws-connect');
+    expect(connectBtn).not.toBeNull();
+    const FOLLOWING = (
+      harness.window as unknown as { Node: { DOCUMENT_POSITION_FOLLOWING: number } }
+    ).Node.DOCUMENT_POSITION_FOLLOWING;
+    // The input comes AFTER the Connect button in the DOM.
+    expect(connectBtn!.compareDocumentPosition(input) & FOLLOWING).toBeTruthy();
+    // Connect is not a sibling of the input inside the same row.
+    expect(connectBtn!.parentElement).not.toBe(input.parentElement);
+  });
 });


### PR DESCRIPTION
## Summary

Small studio WS console layout tweak: put the Connect / Disconnect button on
its own row ABOVE the text input, so the console stacks vertically:

```
[Connect]
[text input]   (full width)
[Send]
[Clear]        (right-aligned, above the log)
[log]
```

Previously Connect shared the input's row. Stacking keeps Connect / Send at the
left near the input on a wide pane.

The WS console (`renderWsConsole`) is shared by the served API Gateway
WebSocket API and the `agentcore-ws` serve, so both consoles get the layout.

## Test plan

- `vp run check` / `vp run build` green.
- `vp run test` — 196 files, 2957 tests green (adds a jsdom assertion that the
  Connect button precedes the text input and is not its row sibling).
- `/run-integ local-studio` — green, 0 docker orphans (studio serve +
  `agentcore-ws` bridge + ws-console sections end-to-end).
- **Visual check**: rendered the real `STUDIO_CSS` + DOM at 1680px via headless
  Chrome — Connect / input / Send stack vertically, Clear right-aligned above
  the log.
- Inline review: layout-only, ~20 LOC / 2 files, no security surface.
