### PR TITLE
fix(invoke): correct the emulation warn message (drop the misattributed Swift/illegal-instruction example)

### DIFF
--- a/src/local/docker-image-builder.ts
+++ b/src/local/docker-image-builder.ts
@@ -132,13 +132,18 @@ const warnedEmulatedPlatforms = new Set<string>();
  * emulation.
  *
  * The arch is chosen automatically from the function's declared
- * `Architectures`, so the user gets no signal that emulation is in play
- * until a container dies. Emulated containers usually run fine, but some
- * compiled custom-runtime binaries (notably a Swift `provided.*`
- * bootstrap) crash under emulation with `exec format error` or
- * `illegal instruction`, which is opaque without this hint. Surface the
- * two real fixes: enable Rosetta for x86/amd64 emulation in the Docker
- * engine settings, or build the function for the host arch.
+ * `Architectures`, so the user gets no signal that emulation is in play.
+ * Emulated containers are slower and some compiled binaries can fail
+ * under emulation (an unsupported CPU instruction surfaces as a crash),
+ * which is opaque without this hint. Surface the two real fixes: enable
+ * Rosetta for x86/amd64 emulation in the Docker engine settings, or build
+ * the function for the host arch.
+ *
+ * The message stays generic about failure symptoms on purpose: an
+ * emulated container that crashes may be a genuine emulation limit, but
+ * the same symptom (e.g. `illegal instruction`) can also come from the
+ * program's own trap on an unrelated runtime error — so the warning flags
+ * that emulation is in play without claiming it is the cause.
  *
  * Deduped by target platform so a warm pool / per-request boot doesn't
  * spam. `platform` is the resolved `--platform` value (`undefined` =>
@@ -156,11 +161,11 @@ export function warnIfEmulatedPlatform(
   const logger = opts.logger ?? getLogger();
   const what = opts.label ? `'${opts.label}' ` : '';
   logger.warn(
-    `Running ${what}under ${platform} emulation on a ${host} host. ` +
-      'Emulated containers can crash some compiled custom-runtime binaries ' +
-      "(e.g. a Swift 'provided.*' bootstrap) with 'exec format error' or " +
-      "'illegal instruction'. If you hit that, enable Rosetta for x86/amd64 " +
-      `emulation in your Docker engine settings, or build the function for ${host}.`
+    `Running ${what}under ${platform} emulation on a ${host} host ` +
+      '(the declared architecture differs from the host). Emulation is slower ' +
+      'and some compiled binaries can fail under it. If the container does not ' +
+      'run correctly, enable Rosetta for x86/amd64 emulation in your Docker ' +
+      `engine settings, or build the function for ${host}.`
   );
 }
 


### PR DESCRIPTION
## Summary

The emulation WARN shipped in the previous change used "a Swift `provided.*` bootstrap ... `illegal instruction`" as its example failure. That was a misattribution, and this corrects the message.

A `swift-aws-lambda-runtime` function crashing under the local Lambda RIE is the runtime's own `fatalError` on a **missing `Lambda-Runtime-Trace-Id` header** — not a failure of the emulation. Verified against the real `provided:al2023` RIE: the `/next` response carries only `Lambda-Runtime-Aws-Request-Id` / `Lambda-Runtime-Deadline-Ms` / `Lambda-Runtime-Invoked-Function-Arn`, with no `Lambda-Runtime-Trace-Id` — and that holds whether or not an `X-Amzn-Trace-Id` header is sent on the invoke or an `_X_AMZN_TRACE_ID` env is set on the container. Swift's `fatalError` traps with an illegal instruction, so the symptom appears under emulation (`signal: illegal instruction`) but is not caused by it: the binary itself runs fine emulated (init succeeds, the invoke starts). Rosetta or an arm64 build would not fix that crash.

## Change

Generalize the WARN message and its JSDoc: it states that the container runs under emulation (declared arch differs from host), that emulation is slower and some binaries can fail under it, and the two real fixes (enable Rosetta, or build for the host arch) — **without** naming `illegal instruction` / `exec format error` / a Swift example, since those symptoms overlap with non-emulation causes. The warn still flags that emulation is in play; it no longer claims to diagnose a specific crash.

## Behavior change

Message wording only — no logic change. The warn fires under exactly the same condition (resolved `--platform` arch != host arch), deduped per arch, from the same two chokepoints (`runDetached` + `buildDockerRunArgs`).

## Test plan

- **unit**: the existing `warnIfEmulatedPlatform` tests across all three call sites stay green — they assert the message contains `emulation` / `Rosetta` + both platform strings, none of which changed; no test asserted a removed substring.
- **live-test**: ran `cdkl invoke .../BootstrapHandler --no-pull` on an arm64 host — confirmed the new line: `Running under linux/amd64 emulation on a linux/arm64 host (the declared architecture differs from the host). Emulation is slower and some compiled binaries can fail under it. If the container does not run correctly, enable Rosetta for x86/amd64 emulation in your Docker engine settings, or build the function for linux/arm64.`
- **integ**: `local-invoke-provided` 5/5 green.
