### PR TITLE
fix(studio): translucent amber kind-group header + size hierarchy

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -85,18 +85,22 @@ const STUDIO_CSS = `
     font: 11px ui-monospace, Menlo, monospace;
   }
   .pane-head #target-search:focus { outline: none; border-color: #4ec97a; }
-  /* Kind-group header (Lambda Functions etc.): a single uniform dark-amber
-     bar with a hairline bottom border. Warm yellow by hue, so it stands apart
-     from both the neutral-grey rows (#1a1a1a / #242424) and the blue-navy
-     stack-sub divider below it. The label is a warm gold (a blue label would
-     clash on the amber bar); the caret + count stay neutral grey, which still
-     reads on the dark warm bar. */
+  /* Kind-group header (Lambda Functions etc.): a single uniform TRANSLUCENT
+     amber bar (a warm tint the dark pane shows through) with a hairline
+     translucent bottom border. The warm hue stands apart from both the
+     neutral-grey rows (#1a1a1a / #242424) and the blue-navy stack-sub divider
+     below it; the translucency keeps it a light wash rather than a heavy block.
+     The label is a warm gold (a blue label would clash on the amber); caret +
+     count stay neutral grey, which still reads over the tint. The header is the
+     LARGEST + bold (14px) so the section header outranks the target rows (13px)
+     below it; the stack-sub fold divider sits between at 12px. */
   .group-title {
-    padding: 7px 12px; color: #e3c272; font-size: 11px; cursor: pointer; user-select: none;
-    display: flex; align-items: center; gap: 6px; background: #302b18;
-    border-bottom: 1px solid #46411f;
+    padding: 7px 12px; color: #e7cd86; font-size: 14px; font-weight: 700;
+    cursor: pointer; user-select: none;
+    display: flex; align-items: center; gap: 6px; background: rgba(227, 194, 114, 0.12);
+    border-bottom: 1px solid rgba(227, 194, 114, 0.3);
   }
-  .group-title:hover { background: #3a341d; }
+  .group-title:hover { background: rgba(227, 194, 114, 0.18); }
   .group-title .caret { color: #9a9a9a; font-size: 9px; width: 9px; display: inline-block; transition: transform .1s; }
   .group-title.open .caret { transform: rotate(90deg); }
   .group-title .count { color: #8a8a8a; }
@@ -138,7 +142,7 @@ const STUDIO_CSS = `
      for a target row. A blue-grey label on a dark-navy bar with a faint blue
      bottom border. */
   .stack-sub {
-    padding: 4px 12px 3px; color: #9fb2d4; font-size: 10px;
+    padding: 4px 12px 3px; color: #9fb2d4; font-size: 12px;
     font-family: ui-monospace, Menlo, monospace; letter-spacing: 0.02em;
     background: #18223a; border-bottom: 1px solid #2b3c5e;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -156,12 +156,16 @@ describe('renderStudioHtml', () => {
     // a clearly distinct shade (issue #333 — the previous #1b1b1b was 1 step off
     // the #1a1a1a base and imperceptible).
     expect(html).toContain('.group-body .target.alt { background: #242424; }');
-    // Kind-group header: a uniform dark-amber bar with a warm-gold label —
-    // a warm hue that stands apart from both the neutral-grey rows and the
-    // blue-navy stack sub-header below it.
-    expect(html).toContain('background: #302b18;');
-    expect(html).toContain('color: #e3c272;');
+    // Kind-group header: a uniform TRANSLUCENT amber bar (warm tint the dark
+    // pane shows through) with a warm-gold label — a warm hue that stands apart
+    // from both the neutral-grey rows and the blue-navy stack sub-header below.
+    expect(html).toContain('background: rgba(227, 194, 114, 0.12);');
+    expect(html).toContain('color: #e7cd86;');
     expect(html).toContain('.group-title .count { color: #8a8a8a; }');
+    // Size hierarchy: the section header is the largest + bold (14px) so it
+    // outranks the target rows (13px); the stack-sub fold divider sits at 12px.
+    expect(html).toContain('font-size: 14px; font-weight: 700;');
+    expect(html).toContain('color: #9fb2d4; font-size: 12px;');
   });
 
   it('widens the Session-bar inputs so the placeholder is not truncated (issue #339)', () => {


### PR DESCRIPTION
## Summary

Two `cdkl studio` targets-pane polish tweaks, uniform across all kinds (not
per-service):

**Translucent header tint.** The kind-group header bar (Lambda Functions /
APIs / ECS Services / ...) goes from an opaque dark-amber fill to a
translucent amber tint the dark pane shows through:
- bg `rgba(227, 194, 114, 0.12)`, border `rgba(227, 194, 114, 0.3)`, gold
  label `#e7cd86`

It reads as a light warm wash rather than a heavy block, and the warm hue
still stands apart from the neutral-grey rows and the blue-navy stack-sub
divider.

**Size hierarchy fix.** The header was 11px while the target rows are 13px,
so the section header looked *smaller* than its own rows. Now:
- header: 14px + bold (the largest — clearly outranks the rows)
- `.stack-sub` per-stack fold divider: 10px -> 12px (legible between header
  and rows)

## Test plan

- Unit (`studio-ui.test.ts`): CSS assertions updated to the translucent bg /
  gold label / 14px-bold header / 12px fold.
- Integ (`local-studio`): served-UI assertions green (Docker, 0 orphans).
- Final look approved from a live-rendered HTML snapshot before merge.
