### PR TITLE
feat(studio): emphasise the composer result's Request/Response headings + distinct Headers/Body sub-labels

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -202,25 +202,26 @@ const STUDIO_CSS = `
   .req-composer .req-result .req-resp { margin-top: 10px; padding: 0; border-bottom: none; }
   .req-composer .req-result pre { background: #0e0e0e; }
   /* The "Headers" / "Body" sub-labels read as labels, not content: small
-     uppercase bold in a muted slate, distinct from the monospace header lines
-     below them (which share a similar grey + size otherwise). */
+     uppercase bold in blue — a distinct hue from the grey monospace header
+     lines below them (which otherwise share a similar grey + size) and from
+     the pale-yellow section headings. */
   .req-composer .req-result .opt-label {
     margin-top: 8px; margin-bottom: 3px; font-size: 10px; font-weight: 700;
-    text-transform: uppercase; letter-spacing: 0.7px; color: #707a89;
+    text-transform: uppercase; letter-spacing: 0.7px; color: #6cb6ff;
   }
   .req-composer .req-result .req-line { color: #cdd6e0; font-weight: 600; }
   .req-composer .req-result .req-resp-headers { color: #8b8b8b; }
   .req-composer .req-result .req-resp-body { color: #d6d6d6; }
   /* Make the Request / Response headings prominent (vs the muted 11px grey
-     .section h3): larger, bold, accent-coloured, with an underline rule. The
+     .section h3): larger, bold, pale-yellow accent, with an underline rule. The
      status badge keeps its own ok/bad colour. */
   .req-composer .req-result .req-req h3,
   .req-composer .req-result .req-resp h3 {
     font-size: 13px; font-weight: 700; letter-spacing: 0.4px;
     padding-bottom: 4px; margin-bottom: 8px; border-bottom: 1px solid #2c2c2c;
   }
-  .req-composer .req-result .req-req h3 { color: #6cb6ff; }
-  .req-composer .req-result .req-resp h3 { color: #c8a2ff; }
+  .req-composer .req-result .req-req h3,
+  .req-composer .req-result .req-resp h3 { color: #e3d18a; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
   .log-clear {

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -201,10 +201,26 @@ const STUDIO_CSS = `
   .req-composer .req-result .req-req,
   .req-composer .req-result .req-resp { margin-top: 10px; padding: 0; border-bottom: none; }
   .req-composer .req-result pre { background: #0e0e0e; }
-  .req-composer .req-result .opt-label { margin-top: 6px; margin-bottom: 3px; }
+  /* The "Headers" / "Body" sub-labels read as labels, not content: small
+     uppercase bold in a muted slate, distinct from the monospace header lines
+     below them (which share a similar grey + size otherwise). */
+  .req-composer .req-result .opt-label {
+    margin-top: 8px; margin-bottom: 3px; font-size: 10px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.7px; color: #707a89;
+  }
   .req-composer .req-result .req-line { color: #cdd6e0; font-weight: 600; }
   .req-composer .req-result .req-resp-headers { color: #8b8b8b; }
   .req-composer .req-result .req-resp-body { color: #d6d6d6; }
+  /* Make the Request / Response headings prominent (vs the muted 11px grey
+     .section h3): larger, bold, accent-coloured, with an underline rule. The
+     status badge keeps its own ok/bad colour. */
+  .req-composer .req-result .req-req h3,
+  .req-composer .req-result .req-resp h3 {
+    font-size: 13px; font-weight: 700; letter-spacing: 0.4px;
+    padding-bottom: 4px; margin-bottom: 8px; border-bottom: 1px solid #2c2c2c;
+  }
+  .req-composer .req-result .req-req h3 { color: #6cb6ff; }
+  .req-composer .req-result .req-resp h3 { color: #c8a2ff; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
   .log-clear {

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -305,10 +305,10 @@ if ! grep -qF "function renderHttpExchangeSection" "${BODY_FILE}" || ! grep -qF 
   echo "FAIL: GET / did not include the Request/Response exchange renderer + JSON body pretty-printer"
   exit 1
 fi
-# The inline Request / Response headings are emphasised (accent colour) and the
-# Headers / Body sub-labels are a distinct small-caps style vs the content.
-if ! grep -qF ".req-composer .req-result .req-req h3 { color: #6cb6ff; }" "${BODY_FILE}" \
-  || ! grep -qF ".req-composer .req-result .req-resp h3 { color: #c8a2ff; }" "${BODY_FILE}"; then
+# The inline Request / Response headings are emphasised (pale-yellow accent) and
+# the Headers / Body sub-labels are a distinct blue small-caps style vs the
+# grey content.
+if ! grep -qF ".req-composer .req-result .req-resp h3 { color: #e3d18a; }" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the emphasised Request/Response heading styles"
   exit 1
 fi

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -305,6 +305,13 @@ if ! grep -qF "function renderHttpExchangeSection" "${BODY_FILE}" || ! grep -qF 
   echo "FAIL: GET / did not include the Request/Response exchange renderer + JSON body pretty-printer"
   exit 1
 fi
+# The inline Request / Response headings are emphasised (accent colour) and the
+# Headers / Body sub-labels are a distinct small-caps style vs the content.
+if ! grep -qF ".req-composer .req-result .req-req h3 { color: #6cb6ff; }" "${BODY_FILE}" \
+  || ! grep -qF ".req-composer .req-result .req-resp h3 { color: #c8a2ff; }" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the emphasised Request/Response heading styles"
+  exit 1
+fi
 # Proxy-vs-child port clarity (issue #325): the Endpoints hint names the proxy
 # URLs as the capture target and the Logs note flags the child internal port.
 if ! grep -qF "the serve child internal port" "${BODY_FILE}" \

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -209,10 +209,13 @@ describe('renderStudioHtml', () => {
     // The ecs host URL is shown in Endpoints with a note that composer requests
     // ARE captured on the timeline (the direct relay self-emits — issue #432).
     expect(html).toContain('composer requests are captured on the timeline');
-    // The inline result's Request / Response headings are emphasised (accent
-    // colour + bold) vs the muted .section h3, so the pair stands out.
-    expect(html).toContain('.req-composer .req-result .req-req h3 { color: #6cb6ff; }');
-    expect(html).toContain('.req-composer .req-result .req-resp h3 { color: #c8a2ff; }');
+    // The inline result's Request / Response headings are emphasised (pale
+    // yellow + bold) vs the muted .section h3, so the pair stands out; the
+    // Headers / Body sub-labels are blue, distinct from the grey content.
+    expect(html).toContain('.req-composer .req-result .req-req h3,');
+    expect(html).toContain('.req-composer .req-result .req-resp h3 { color: #e3d18a; }');
+    expect(html).toContain('.req-composer .req-result .opt-label {');
+    expect(html).toContain('letter-spacing: 0.7px; color: #6cb6ff;');
   });
 
   it('clarifies the curl-able proxy port vs the child internal port (issue #325)', () => {

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -209,6 +209,10 @@ describe('renderStudioHtml', () => {
     // The ecs host URL is shown in Endpoints with a note that composer requests
     // ARE captured on the timeline (the direct relay self-emits — issue #432).
     expect(html).toContain('composer requests are captured on the timeline');
+    // The inline result's Request / Response headings are emphasised (accent
+    // colour + bold) vs the muted .section h3, so the pair stands out.
+    expect(html).toContain('.req-composer .req-result .req-req h3 { color: #6cb6ff; }');
+    expect(html).toContain('.req-composer .req-result .req-resp h3 { color: #c8a2ff; }');
   });
 
   it('clarifies the curl-able proxy port vs the child internal port (issue #325)', () => {


### PR DESCRIPTION
## Summary

Follow-up polish on the `cdkl studio` composer result: the inline Send result's
Request / Response headings used the muted 11px grey `.section h3`, so the pair
did not stand out, and the "Headers" / "Body" sub-labels shared the same grey +
size as the header-key content below them (hard to tell label from content).

- The **Request / Response** headings are now 13px bold **pale-yellow**
  (#e3d18a) with an underline rule; the status badge keeps its ok/bad colour.
- The **Headers / Body** sub-labels are now a small (10px) uppercase bold
  **blue** (#6cb6ff) label style — a distinct hue from the grey monospace
  content, so they read as labels.

Scoped to `.req-composer .req-result` so other `.section h3` / `.opt-label`
uses are untouched. Pure client-side styling change (embedded UI stylesheet
only); no server / CLI surface change.

## Test plan

- **Unit** (`studio-ui.test.ts`): asserts the emphasised heading rule
  (pale-yellow, grouped selector) and the blue Headers/Body sub-label rule ship
  in the served stylesheet. Full suite green (2956 tests).
- **Live render**: drove the real `renderStudioHtml` through headless Chrome
  with a sample Request/Response result (HTML directory-listing + JSON cases)
  and visually confirmed the headings/labels/contrast.
- **Integration** (`tests/integration/local-studio/verify.sh`): greps the
  emphasised heading style in the served HTML. Ran the full local-studio integ
  against real Docker — green, 0 orphan containers / networks / images.
