### PR TITLE
docs(demo-gif): document the studio GIF recorder + fix its result selector

### DIFF
--- a/assets/demo-gif/README.md
+++ b/assets/demo-gif/README.md
@@ -1,11 +1,16 @@
 # cdk-local demo GIFs
 
-Source files for the demo GIFs shown in the project README. Two flows are recorded today:
+Source files for the demo GIFs shown in the project README. Three flows are recorded today:
 
-| File | Source tape | Source orchestrator | Linked from |
+| File | Source | Source orchestrator | Linked from |
 |---|---|---|---|
-| `assets/cdkl-start-api.gif` | `cdkl-start-api.tape` | `run-start-api.sh` | top of README |
-| `assets/cdkl-invoke.gif` | `cdkl-invoke.tape` | `run.sh` | inside `#### Lambda — invoke` section |
+| `assets/cdkl-start-api.gif` | `cdkl-start-api.tape` (vhs) | `run-start-api.sh` | top of README |
+| `assets/cdkl-invoke.gif` | `cdkl-invoke.tape` (vhs) | `run.sh` | inside `#### Lambda — invoke` section |
+| `assets/cdkl-studio.gif` | `record-studio.mjs` (Playwright) | `record-studio.mjs` (self-contained) | `### cdkl studio` section |
+
+The two CLI GIFs are recorded with [`vhs`](https://github.com/charmbracelet/vhs)
+(terminal screencast). The studio GIF is a **browser** screencast — `vhs` can't
+record a web UI — so it uses a separate Playwright harness (`record-studio.mjs`).
 
 ## What gets recorded
 
@@ -27,6 +32,31 @@ A single terminal pane running:
 3. `cdkl invoke CdklDemo/EchoHandler --event event.json` — run the Lambda locally in Docker via RIE and print the returned JSON
 
 Roughly 3-5 seconds of recorded time. The final JSON includes `"message": "Hello from cdk-local!"` — the punchline.
+
+### `cdkl-studio.gif` (inside `### cdkl studio`)
+
+A **browser** screencast of the `cdkl studio` web console, driven end to end by
+Playwright (headless Chromium). The captured flow:
+
+1. Expand the **APIs** group in the targets pane and pick the HTTP API.
+2. **Start** the serve from the workspace — the per-target request composer
+   appears once the backing RIE container is up.
+3. Compose a `POST /echo` request: set the method, type the path, add an
+   `X-Demo: studio` header, and a JSON body.
+4. **Send** — the response renders inline as a Request -> Response pair, and the
+   request lands on the timeline.
+5. Scroll the workspace to reveal the streamed container logs, then click the
+   captured row on the timeline to open its read-only detail.
+
+The harness injects a green cursor dot (Playwright's headless Chromium renders no
+OS cursor) so clicks read on the recording. It boots the real `cdkl studio`
+against `sample-app` as a child process, drives the UI, then converts the
+captured `.webm` to `../cdkl-studio.gif` with ffmpeg (two-pass palette).
+
+This is the GIF most coupled to the UI: the harness uses CSS selectors
+(`.req-composer`, `.req-result .req-resp`, `.group-title`, ...) that move when
+the studio UI is redesigned. Re-run it after any studio UI change and fix up the
+selectors if the flow stalls.
 
 ## Reproducing
 
@@ -57,6 +87,29 @@ bash run.sh --dry-run              # plans the single-pane tmux invocation
 
 That prints the planned `tmux` invocations so the scaffold can be sanity-checked on a CI runner or a fresh laptop.
 
+### Recording the studio GIF
+
+The studio GIF uses Playwright instead of `vhs`. Playwright is a maintainer-only
+recorder dependency, NOT a committed `devDependency` (it would bloat every
+contributor's install for a demo tool), so install it on demand first:
+
+```bash
+# from the repo root
+vp run build                              # so dist/cli.js is current
+pnpm add -D playwright                    # maintainer-only, do not commit
+npx playwright install chromium           # one-time browser download
+
+node assets/demo-gif/record-studio.mjs    # generates assets/cdkl-studio.gif
+```
+
+Docker must be running (Start boots a RIE container behind the API) and `ffmpeg`
+must be on PATH (webm -> gif conversion). The harness boots `cdkl studio` on a
+fixed port against `sample-app`, drives the UI, and SIGTERMs it when done.
+
+After recording, verify the result by opening it in Chrome
+(`open -a "Google Chrome" assets/cdkl-studio.gif`) — macOS Preview / Safari shows
+a GIF as a filmstrip rather than animating it.
+
 ## Files
 
 | File | Role |
@@ -65,6 +118,7 @@ That prints the planned `tmux` invocations so the scaffold can be sanity-checked
 | `run-start-api.sh` | tmux split-pane orchestrator: pre-warms `pnpm install` + `cdk synth` outside the recorded session, then runs `cdkl start-api` (left) + `sleep 6 && curl` (right) |
 | `cdkl-invoke.tape` | vhs script for the single-pane invoke demo (1400x720, 22pt JetBrainsMono Nerd Font) |
 | `run.sh` | single-pane orchestrator for the invoke demo |
+| `record-studio.mjs` | self-contained Playwright recorder for the studio web-UI GIF: boots `cdkl studio` against `sample-app`, drives the API request-composer flow in headless Chromium, and converts the capture to `../cdkl-studio.gif` via ffmpeg |
 | `tmux-clean.conf` | strips the tmux status bar so the recording looks polished (shared) |
 | `sample-app/` | minimal CDK app both demos drive |
 | `sample-app/lib/cdkl-demo-stack.ts` | one `AWS::Lambda::Function` (Node.js 20) + one `AWS::ApiGatewayV2::Api` (HTTP API with GET `/hello`) |

--- a/assets/demo-gif/record-studio.mjs
+++ b/assets/demo-gif/record-studio.mjs
@@ -157,7 +157,9 @@ async function main() {
 
   // Send — the response renders inline AND lands on the timeline.
   await click(page.locator('.req-send button', { hasText: 'Send' }));
-  await page.locator('.req-result .req-status').first().waitFor({ timeout: 30000 });
+  // The result renders as a Request -> Response PAIR (#438 / #444); wait for the
+  // Response section to appear (the old single .req-status span was retired).
+  await page.locator('.req-result .req-resp').first().waitFor({ timeout: 30000 });
   // Hold on the inline response (status + reflected body) so it reads clearly.
   await wait(2600);
 


### PR DESCRIPTION
## Summary

Document the studio (web UI) GIF recorder in `assets/demo-gif/README.md`,
which until now only covered the two vhs-based CLI GIFs. The studio GIF is
recorded by a separate Playwright harness (`record-studio.mjs`) — a browser
screencast, since `vhs` can only capture a terminal — and that harness had
no doc coverage.

- Add `cdkl-studio.gif` to the flows table, noting CLI = vhs vs studio = Playwright.
- New studio subsection under "What gets recorded" describing the captured
  flow (start an API, compose `POST /echo`, Send, scroll logs, open the
  timeline detail) and flagging that the harness is UI-coupled.
- New "Recording the studio GIF" steps under "Reproducing" (on-demand
  Playwright install, Docker + ffmpeg prereqs, Chrome sign-off).
- Add `record-studio.mjs` to the Files table.

Also fix the recorder's post-Send wait selector. The inline composer result
was reworked into a Request -> Response pair, retiring the single
`.req-status` span the harness waited on — so the recorder stalled after
Send. It now waits on `.req-result .req-resp`.

## Notes

- Docs + maintainer-tooling only — no `src/**`, no top-level `README.md`,
  no `package.json`. No cdkd-parity or integ surface touched.
- The GIF asset itself is intentionally NOT re-recorded here: the studio UI
  is mid-redesign, so the re-record is deferred until the UI settles (it
  will land with the finalized selectors in a follow-up).

## Test plan

- `vp run check` / `vp run build` / `vp test run` green (2968 tests).
- Live-tested the selector fix: ran `node assets/demo-gif/record-studio.mjs`
  end to end against the current built UI — the flow no longer stalls after
  Send and produces `assets/cdkl-studio.gif`.
