### PR TITLE
fix(studio): drop bold on the kind-group header label

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -92,10 +92,10 @@ const STUDIO_CSS = `
      below it; the translucency keeps it a light wash rather than a heavy block.
      The label is a warm gold (a blue label would clash on the amber); caret +
      count stay neutral grey, which still reads over the tint. The header is the
-     LARGEST + bold (14px) so the section header outranks the target rows (13px)
-     below it; the stack-sub fold divider sits between at 12px. */
+     LARGEST (14px, not bold) so the section header outranks the target rows
+     (13px) below it; the stack-sub fold divider sits between at 12px. */
   .group-title {
-    padding: 7px 12px; color: #e7cd86; font-size: 14px; font-weight: 700;
+    padding: 7px 12px; color: #e7cd86; font-size: 14px;
     cursor: pointer; user-select: none;
     display: flex; align-items: center; gap: 6px; background: rgba(227, 194, 114, 0.12);
     border-bottom: 1px solid rgba(227, 194, 114, 0.3);

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -162,9 +162,9 @@ describe('renderStudioHtml', () => {
     expect(html).toContain('background: rgba(227, 194, 114, 0.12);');
     expect(html).toContain('color: #e7cd86;');
     expect(html).toContain('.group-title .count { color: #8a8a8a; }');
-    // Size hierarchy: the section header is the largest + bold (14px) so it
+    // Size hierarchy: the section header is the largest (14px, not bold) so it
     // outranks the target rows (13px); the stack-sub fold divider sits at 12px.
-    expect(html).toContain('font-size: 14px; font-weight: 700;');
+    expect(html).toContain('color: #e7cd86; font-size: 14px;');
     expect(html).toContain('color: #9fb2d4; font-size: 12px;');
   });
 


### PR DESCRIPTION
## Summary

Follow-up polish to the `cdkl studio` kind-group header. The header
(Lambda Functions / APIs / ECS Services / ...) was 14px + bold; the bold read
a touch heavy. Keep it the largest (14px — still outranks the 13px target
rows) but render the gold label in the regular weight.

Everything else is unchanged: the translucent amber bar
(`rgba(227, 194, 114, 0.12)` + gold `#e7cd86`) and the 12px `.stack-sub`
fold divider.

## Test plan

- Unit (`studio-ui.test.ts`): CSS assertion updated (group-title is
  `font-size: 14px;` with no `font-weight: 700`).
- Integ (`local-studio`): served-UI assertions green (Docker, 0 orphans).
- Non-bold look approved from a live screenshot before merge.
