### PR TITLE
feat(studio): colour-code the serve workspace headings (yellow output sections, blue structural labels)

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -216,16 +216,30 @@ const STUDIO_CSS = `
   .req-composer .req-result .req-line { color: #cdd6e0; font-weight: 600; }
   .req-composer .req-result .req-resp-headers { color: #8b8b8b; }
   .req-composer .req-result .req-resp-body { color: #d6d6d6; }
-  /* Make the Request / Response headings prominent (vs the muted 11px grey
-     .section h3): larger, bold, pale-yellow accent, with an underline rule. The
-     status badge keeps its own ok/bad colour. */
+  /* Make the major output-section headings (the result REQUEST / RESPONSE pair
+     + the serve LOGS) prominent (vs the muted 11px grey .section h3): larger,
+     bold, pale-yellow accent, with an underline rule. The status badge keeps
+     its own ok/bad colour. The .section.NAME form lifts specificity to
+     (0,2,1) so these win over a plain .section h3 (0,1,1) regardless of source
+     order (.section h3 is declared later in this stylesheet). */
   .req-composer .req-result .req-req h3,
-  .req-composer .req-result .req-resp h3 {
+  .req-composer .req-result .req-resp h3,
+  .section.serve-logs h3 {
     font-size: 13px; font-weight: 700; letter-spacing: 0.4px;
     padding-bottom: 4px; margin-bottom: 8px; border-bottom: 1px solid #2c2c2c;
   }
   .req-composer .req-result .req-req h3,
-  .req-composer .req-result .req-resp h3 { color: #e3d18a; }
+  .req-composer .req-result .req-resp h3,
+  .section.serve-logs h3 { color: #e3d18a; }
+  /* The serve workspace's structural labels (Started with / Endpoints, and the
+     request-composer form's Request / Headers / Body) are blue — matching the
+     result's blue Headers / Body sub-labels, distinct from the yellow output
+     headings. Shared by every serve kind (renderServeWorkspace). Same (0,2,1)
+     specificity lift so they beat a plain .section h3 / global .opt-label. */
+  .section.started-with h3,
+  .section.endpoints h3,
+  .section.req-composer > h3,
+  .req-composer > .opt-label { color: #6cb6ff; }
   .composer button:disabled { background: #333; color: #888; cursor: default; }
   .composer .reinvoke-btn { margin-top: 6px; padding: 4px 14px; }
   .log-clear {
@@ -1240,7 +1254,7 @@ const STUDIO_SCRIPT = `
     // Both an ecs service and an ecs-task run are pure compute: no host
     // endpoint unless a --host-port was published (issue #366).
     const isEcs = meta && (meta.kind === 'ecs' || meta.kind === 'ecs-task');
-    const epSec = el('div', 'section');
+    const epSec = el('div', 'section endpoints');
     epSec.appendChild(el('h3', null, 'Endpoints'));
     if (running && st.endpoints.length) {
       for (const url of st.endpoints) {
@@ -1297,7 +1311,7 @@ const STUDIO_SCRIPT = `
     }
 
     const logs = logsById.get(id) || [];
-    const logSec = el('div', 'section');
+    const logSec = el('div', 'section serve-logs');
     logSec.appendChild(el('h3', null, 'Logs'));
     // A proxy-fronted serve (api / alb) streams its child start-* logs here,
     // which advertise the child internal 127.0.0.1 port — a DIFFERENT port

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -305,11 +305,12 @@ if ! grep -qF "function renderHttpExchangeSection" "${BODY_FILE}" || ! grep -qF 
   echo "FAIL: GET / did not include the Request/Response exchange renderer + JSON body pretty-printer"
   exit 1
 fi
-# The inline Request / Response headings are emphasised (pale-yellow accent) and
-# the Headers / Body sub-labels are a distinct blue small-caps style vs the
-# grey content.
-if ! grep -qF ".req-composer .req-result .req-resp h3 { color: #e3d18a; }" "${BODY_FILE}"; then
-  echo "FAIL: GET / did not include the emphasised Request/Response heading styles"
+# The major output-section headings (Request / Response / serve LOGS) are
+# emphasised pale-yellow, and the serve workspace's structural labels (Started
+# with / Endpoints / form Request / Headers / Body) are blue.
+if ! grep -qF ".section.serve-logs h3 { color: #e3d18a; }" "${BODY_FILE}" \
+  || ! grep -qF ".req-composer > .opt-label { color: #6cb6ff; }" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the emphasised heading + blue structural-label styles"
   exit 1
 fi
 # Proxy-vs-child port clarity (issue #325): the Endpoints hint names the proxy

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -213,11 +213,18 @@ describe('renderStudioHtml', () => {
     // The ecs host URL is shown in Endpoints with a note that composer requests
     // ARE captured on the timeline (the direct relay self-emits — issue #432).
     expect(html).toContain('composer requests are captured on the timeline');
-    // The inline result's Request / Response headings are emphasised (pale
-    // yellow + bold) vs the muted .section h3, so the pair stands out; the
-    // Headers / Body sub-labels are blue, distinct from the grey content.
+    // The major output-section headings — the result Request / Response pair
+    // AND the serve LOGS — are emphasised pale-yellow (grouped selector),
+    // distinct from the blue structural labels.
     expect(html).toContain('.req-composer .req-result .req-req h3,');
-    expect(html).toContain('.req-composer .req-result .req-resp h3 { color: #e3d18a; }');
+    expect(html).toContain('.section.serve-logs h3 { color: #e3d18a; }');
+    // The serve workspace's structural labels (Started with / Endpoints + the
+    // request-composer form's Request / Headers / Body) are blue — the
+    // .section.NAME form lifts specificity over the later `.section h3`.
+    expect(html).toContain('.section.started-with h3,');
+    expect(html).toContain('.section.endpoints h3,');
+    expect(html).toContain('.req-composer > .opt-label { color: #6cb6ff; }');
+    // The result's Headers / Body sub-labels are blue too.
     expect(html).toContain('.req-composer .req-result .opt-label {');
     expect(html).toContain('letter-spacing: 0.7px; color: #6cb6ff;');
   });


### PR DESCRIPTION
## Summary

Colour-code the `cdkl studio` serve workspace headings so the structure is easy
to scan (api / alb / ecs / ecs-task / cloudfront / agentcore-ws — all share
`renderServeWorkspace`, so this applies to every serve kind):

- The major **output-section** headings — the inline result's **Request** /
  **Response** pair AND the serve **Logs** — are prominent pale-yellow
  (#e3d18a, 13px bold + underline), matching each other.
- The **structural labels** — **Started with**, **Endpoints**, and the
  request-composer form's **Request** / **Headers** / **Body** — are blue
  (#6cb6ff), matching the result's blue Headers / Body sub-labels. The
  response status badge keeps its ok/bad colour.

The Endpoints and serve-Logs sections gained `endpoints` / `serve-logs` classes
so the rules can target them; the `.section.NAME` selector form lifts
specificity to (0,2,1) so the new colours win over the later-declared
`.section h3` (0,1,1) regardless of source order. Scoped to the serve
workspace, so the Lambda invoke composer / timeline detail are untouched. Pure
client-side styling change (embedded stylesheet only); no server / CLI surface
change.

## Test plan

- **Unit** (`studio-ui.test.ts`): asserts the yellow output-heading rule
  (grouped Request/Response/serve-Logs), the blue structural-label rules
  (Started with / Endpoints / form Request / Headers / Body), and the blue
  result Headers/Body sub-label rule ship in the stylesheet. Full suite green
  (2968 tests).
- **Live render**: drove the real `renderServeWorkspace` for a running api
  serve through headless Chrome and visually confirmed every heading colour /
  size (Started with / Endpoints / form Request·Headers·Body blue; result
  Request / Response / Logs yellow + large).
- **Integration** (`tests/integration/local-studio/verify.sh`): greps the
  yellow serve-Logs heading + blue form-label rules in the served HTML. Ran the
  full local-studio integ against real Docker on a clean window — green, 0
  orphan containers / networks / images.
