### PR TITLE
fix(studio): rename the targets-pane ALB group to "Application Load Balancers"

### DIFF
--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -102,7 +102,7 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
       title: 'AgentCore WebSocket',
       entries: map(listing.agentCoreRuntimes.filter((e) => e.agentCoreHasWs)),
     },
-    { kind: 'alb', title: 'Load Balancers', entries: map(listing.loadBalancers) },
+    { kind: 'alb', title: 'Application Load Balancers', entries: map(listing.loadBalancers) },
     // CloudFront distributions are a serve target (start-cloudfront -> Start),
     // like api / alb — they expose a host HTTP endpoint (issue #367 / #363).
     {

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -103,7 +103,15 @@ const STUDIO_CSS = `
   .group-title:hover { background: rgba(227, 194, 114, 0.18); }
   .group-title .caret { color: #9a9a9a; font-size: 9px; width: 9px; display: inline-block; transition: transform .1s; }
   .group-title.open .caret { transform: rotate(90deg); }
-  .group-title .count { color: #8a8a8a; }
+  /* A long group label (e.g. "Application Load Balancers") would wrap onto a
+     second line in the 280px pane and shove the count off to the right; keep
+     the label on one line and ellipsis the overflow (full text on hover via
+     the title attr) so the row height + count placement stay uniform. */
+  .group-title .group-name {
+    flex: 0 1 auto; min-width: 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .group-title .count { color: #8a8a8a; flex: none; }
   .group-body.collapsed { display: none; }
   .target {
     padding: 6px 12px; display: flex; align-items: center; gap: 8px;
@@ -816,6 +824,7 @@ const STUDIO_SCRIPT = `
         if (!group.entries.length) continue;
         const grp = el('div', 'target-group');
         const title = el('div', 'group-title');
+        title.title = group.title; // full label on hover (the name ellipsises when long)
         title.appendChild(el('span', 'caret', '▶'));
         title.appendChild(el('span', 'group-name', group.title));
         title.appendChild(el('span', 'count', '(' + group.entries.length + ')'));

--- a/tests/unit/local/studio-custom-resource-filter.test.ts
+++ b/tests/unit/local/studio-custom-resource-filter.test.ts
@@ -89,7 +89,7 @@ const groups = (): StudioTargetGroup[] => [
   },
   {
     kind: 'alb',
-    title: 'Load Balancers',
+    title: 'Application Load Balancers',
     entries: [lambda('MyStack/Alb')],
   },
   {

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -268,7 +268,7 @@ describe('annotateAlbPinnedBackingServices', () => {
     },
     {
       kind: 'alb',
-      title: 'Load Balancers',
+      title: 'Application Load Balancers',
       entries: [
         { id: 'S/Alb1', qualifiedId: 'S:Alb1' },
         { id: 'S/Alb2', qualifiedId: 'S:Alb2' },
@@ -332,7 +332,7 @@ describe('toStudioTargetGroups', () => {
       'ECS Task Definitions',
       'AgentCore Runtimes',
       'AgentCore WebSocket',
-      'Load Balancers',
+      'Application Load Balancers',
       'CloudFront Distributions',
     ]);
     expect(groups[0].entries).toEqual([{ id: 'S/Fn', qualifiedId: 'S:Fn' }]);

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -161,7 +161,11 @@ describe('renderStudioHtml', () => {
     // from both the neutral-grey rows and the blue-navy stack sub-header below.
     expect(html).toContain('background: rgba(227, 194, 114, 0.12);');
     expect(html).toContain('color: #e7cd86;');
-    expect(html).toContain('.group-title .count { color: #8a8a8a; }');
+    expect(html).toContain('.group-title .count { color: #8a8a8a; flex: none; }');
+    // A long group label (e.g. "Application Load Balancers") ellipsises on one
+    // line instead of wrapping + shoving the count off (issue: ALB label fit).
+    expect(html).toContain('.group-title .group-name {');
+    expect(html).toContain('white-space: nowrap; overflow: hidden; text-overflow: ellipsis;');
     // Size hierarchy: the section header is the largest (14px, not bold) so it
     // outranks the target rows (13px); the stack-sub fold divider sits at 12px.
     expect(html).toContain('color: #e7cd86; font-size: 14px;');


### PR DESCRIPTION
## Summary

The `cdkl studio` targets pane (left column) labelled the ALB group
"Load Balancers", but that group only ever lists **Application Load
Balancers** — `start-alb` fronts ALBs only. Renamed it to "Application
Load Balancers" to match `cdkl list`'s own label and avoid implying the
group covers NLBs / GWLBs.

The longer label wrapped onto a second line in the fixed 280px targets
pane and shoved the per-group count off to the right. Fixed the group
header layout so any long label stays on one line:

- `.group-title .group-name` now `flex: 0 1 auto; min-width: 0` with
  `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` — the
  label ellipsises instead of wrapping.
- `.group-title .count` pinned with `flex: none` so the count keeps its
  place next to the (possibly-truncated) label.
- The group header carries a `title` attr so the full label shows on
  hover when truncated.

## Test plan

- Unit: updated the studio-server / studio-ui / custom-resource-filter
  tests for the new label + CSS (196 files, 2968 tests pass).
- Live: rendered the real `STUDIO_CSS` in headless Chrome at the 280px
  pane width — the label fits on one line ("Application Load Balanc…")
  with the count aligned like every other group.
- Integ: `local-studio` (real Docker) green — `/api/targets` still lists
  the `kind=alb` group; 0 orphan containers / networks.
