### PR TITLE
refactor(env-vars): share the --env-vars overlay helper across Lambda + ECS paths

### DIFF
--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -35,6 +35,7 @@ import {
   type ResolvedEcsVolume,
 } from './ecs-task-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
+import { applyEnvOverrideMap } from './env-resolver.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1354,8 +1355,8 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
 
   const overrides = opts.envOverrides;
   if (overrides) {
-    applyOverrideMap(finalEnv, overrides['Parameters']);
-    applyOverrideMap(finalEnv, overrides[container.name]);
+    applyEnvOverrideMap(finalEnv, overrides['Parameters']);
+    applyEnvOverrideMap(finalEnv, overrides[container.name]);
   }
 
   // Resolved secret values (and any AWS credentials that landed in the
@@ -1404,19 +1405,6 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
 
   args.push(image, ...entryPointTail, ...(container.command ?? []));
   return { args, sensitiveEnv, publishedEndpoints };
-}
-
-function applyOverrideMap(
-  acc: Record<string, string>,
-  map: Record<string, string | null> | undefined
-): void {
-  if (!map) return;
-  for (const [k, v] of Object.entries(map)) {
-    if (v === null) delete acc[k];
-    else if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
-      acc[k] = String(v);
-    }
-  }
 }
 
 /**

--- a/src/local/env-resolver.ts
+++ b/src/local/env-resolver.ts
@@ -91,7 +91,7 @@ export function resolveEnvVars(
   }
 
   if (overrides) {
-    applyOverrideMap(resolved, overrides.Parameters);
+    applyEnvOverrideMap(resolved, overrides.Parameters);
     // Iterate non-Parameters keys in JSON insertion order so a
     // logical-ID + display-path collision applies later-wins (SAM-compat).
     //
@@ -107,11 +107,11 @@ export function resolveEnvVars(
       if (key === 'Parameters') continue;
       if (!val || typeof val !== 'object') continue;
       if (key === logicalId) {
-        applyOverrideMap(resolved, val);
+        applyEnvOverrideMap(resolved, val);
         continue;
       }
       if (displayPath && (displayPath === key || displayPath.startsWith(`${key}/`))) {
-        applyOverrideMap(resolved, val);
+        applyEnvOverrideMap(resolved, val);
       }
     }
   }
@@ -120,12 +120,19 @@ export function resolveEnvVars(
 }
 
 /**
- * Apply one override map to the accumulator. `null` clears a key (SAM
- * compatibility); any other value is coerced to string. Unknown shapes are
- * silently skipped — the file format is loose and we don't want to fail a
- * whole run on one bad entry.
+ * Apply one `--env-vars` override map to an env accumulator. `null` CLEARS a
+ * key (SAM compatibility) by deleting it from `acc` — the key is then absent
+ * from the resolved env entirely, never set to the string `"null"`. Any other
+ * primitive value is coerced to string. Unknown shapes are silently skipped —
+ * the file format is loose and we don't want to fail a whole run on one bad
+ * entry.
+ *
+ * Shared by `cdkl invoke`'s Lambda env resolution ({@link resolveEnvVars}) and
+ * the ECS task-container env overlay in `ecs-task-runner.ts`
+ * (`start-service` / `start-alb` / `run-task`), so the two `--env-vars`
+ * code paths apply identical SAM-shape semantics and cannot drift.
  */
-function applyOverrideMap(
+export function applyEnvOverrideMap(
   acc: Record<string, string>,
   map: Record<string, string | null> | undefined
 ): void {

--- a/tests/integration/local-run-task-env-vars/bin/app.ts
+++ b/tests/integration/local-run-task-env-vars/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalRunTaskEnvVarsStack } from '../lib/local-run-task-env-vars-stack.ts';
+
+const app = new cdk.App();
+
+new LocalRunTaskEnvVarsStack(app, 'CdkLocalRunTaskEnvVarsFixture', {
+  description: 'Fixture stack for cdkl run-task --env-vars overlay integ test',
+});

--- a/tests/integration/local-run-task-env-vars/cdk.json
+++ b/tests/integration/local-run-task-env-vars/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/app.ts"
+}

--- a/tests/integration/local-run-task-env-vars/lib/local-run-task-env-vars-stack.ts
+++ b/tests/integration/local-run-task-env-vars/lib/local-run-task-env-vars-stack.ts
@@ -1,0 +1,44 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import { Construct } from 'constructs';
+
+/**
+ * Fixture stack for the `cdkl run-task --env-vars` overlay integ test.
+ *
+ * A single short-lived busybox container (`probe`) prints its full
+ * environment to stdout and exits. The container declares two template
+ * env vars:
+ *   - KEEP_ME=kept-value      (left untouched by the overlay)
+ *   - DROP_ME=from-template   (cleared by a `null` in the --env-vars file)
+ *
+ * verify.sh runs the task with an `--env-vars` file that sets a new key,
+ * keeps KEEP_ME, and clears DROP_ME via JSON `null`, then asserts against
+ * the `[probe]`-prefixed env dump that:
+ *   - the added + kept keys appear,
+ *   - DROP_ME is GONE entirely (not `DROP_ME=null`, not empty) — the SAM
+ *     `null`-clears-a-key semantic on the ECS task-container env path.
+ *
+ * No AWS deploy required — runs against the synthesized cdk.out only.
+ */
+export class LocalRunTaskEnvVarsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const taskDef = new ecs.TaskDefinition(this, 'EnvProbeTask', {
+      compatibility: ecs.Compatibility.EC2,
+      networkMode: ecs.NetworkMode.BRIDGE,
+    });
+
+    taskDef.addContainer('probe', {
+      image: ecs.ContainerImage.fromRegistry('public.ecr.aws/docker/library/busybox:1.36'),
+      essential: true,
+      entryPoint: ['/bin/sh', '-c'],
+      command: ['env'],
+      memoryReservationMiB: 16,
+      environment: {
+        KEEP_ME: 'kept-value',
+        DROP_ME: 'from-template',
+      },
+    });
+  }
+}

--- a/tests/integration/local-run-task-env-vars/package.json
+++ b/tests/integration/local-run-task-env-vars/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdkl-integ-local-run-task-env-vars",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkl run-task --env-vars overlay (set / add / null-clear)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "pnpm@11.5.1"
+}

--- a/tests/integration/local-run-task-env-vars/tsconfig.json
+++ b/tests/integration/local-run-task-env-vars/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/integration/local-run-task-env-vars/verify.sh
+++ b/tests/integration/local-run-task-env-vars/verify.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# verify.sh — local-run-task --env-vars overlay integ test
+#
+# Fully local: no AWS resources are deployed. A single busybox container
+# prints its environment and exits. The run passes an `--env-vars` file
+# that exercises all three overlay outcomes on the ECS task-container env
+# path (start-service / start-alb / run-task share this code):
+#   - ADD    a new key not present in the template,
+#   - KEEP   a template key the overlay does not mention,
+#   - CLEAR  a template key by setting it to JSON `null` (SAM-compat) — the
+#            key must be GONE from the container env, never `KEY=null`.
+#
+# Run via `/run-integ local-run-task-env-vars` (recommended) or directly:
+#
+#     bash tests/integration/local-run-task-env-vars/verify.sh
+#
+# Requires Docker. Pulls the sidecar + busybox images up front.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CDKL="node ../../../dist/cli.js"
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+BUSYBOX_IMAGE="public.ecr.aws/docker/library/busybox:1.36"
+
+# Set once, below. Initialized empty so the EXIT trap's `rm -f` is harmless
+# if the script dies before the temp files are created (set -u safe).
+ENV_FILE=""
+OUT_FILE=""
+cleanup() {
+  echo "==> Cleanup: stopping any leftover containers"
+  docker ps --filter "name=cdkl-" --format '{{.ID}}' | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkl-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
+  rm -f "${ENV_FILE}" "${OUT_FILE}"
+}
+# A single EXIT trap: a second `trap ... EXIT` would REPLACE this one (bash
+# keeps only the last), silently dropping the docker sweep.
+trap cleanup EXIT
+
+echo "==> Verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "==> Pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${BUSYBOX_IMAGE}"
+
+echo "==> Installing fixture deps"
+if [[ ! -d node_modules ]]; then
+  vp install --prefer-offline
+fi
+
+# SAM-shape --env-vars file (Parameters apply to every container):
+#   - ADDED_BY_FLAG : new key not in the template
+#   - DROP_ME       : null -> CLEAR the template key
+# (KEEP_ME is intentionally NOT mentioned so it survives from the template.)
+ENV_FILE=$(mktemp)
+OUT_FILE=$(mktemp)
+cat > "${ENV_FILE}" <<'JSON'
+{
+  "Parameters": {
+    "ADDED_BY_FLAG": "added-value",
+    "DROP_ME": null
+  }
+}
+JSON
+
+echo "==> Running env-probe task with --env-vars overlay"
+# Run synchronously so `cdkl run-task` waits for the essential container to
+# exit; the env dump lands on stdout with the [probe] prefix.
+${CDKL} run-task CdkLocalRunTaskEnvVarsFixture/EnvProbeTask \
+  --env-vars "${ENV_FILE}" --no-pull --container-host 127.0.0.1 \
+  > "${OUT_FILE}" 2>&1
+
+dump_and_fail() {
+  echo "FAIL: $1"
+  echo "----- run output -----"
+  cat "${OUT_FILE}"
+  echo "----------------------"
+  exit 1
+}
+
+echo "==> Asserting the overlay ADDED a new key"
+grep -q '\[probe\] ADDED_BY_FLAG=added-value' "${OUT_FILE}" \
+  || dump_and_fail "expected '[probe] ADDED_BY_FLAG=added-value' (overlay add)"
+
+echo "==> Asserting an unmentioned template key SURVIVED"
+grep -q '\[probe\] KEEP_ME=kept-value' "${OUT_FILE}" \
+  || dump_and_fail "expected '[probe] KEEP_ME=kept-value' (template key preserved)"
+
+echo "==> Asserting the null'd key is GONE (the whole point)"
+# The key must not appear at all — not its template value, not empty, and
+# crucially NOT the literal string "null".
+if grep -q '\[probe\] DROP_ME=' "${OUT_FILE}"; then
+  dump_and_fail "DROP_ME should have been cleared by null, but it is still set"
+fi
+if grep -q 'DROP_ME=null' "${OUT_FILE}"; then
+  dump_and_fail "DROP_ME was stringified to \"null\" instead of being deleted"
+fi
+
+echo ""
+echo "==> local-run-task-env-vars test passed (add / keep / null-clear)"

--- a/tests/unit/local/ecs-task-runner-env-overrides.test.ts
+++ b/tests/unit/local/ecs-task-runner-env-overrides.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { buildDockerRunArgs } from '../../../src/local/ecs-task-runner.js';
+import type { ResolvedEcsContainer, ResolvedEcsTask } from '../../../src/local/ecs-task-resolver.js';
+
+// buildDockerRunArgs reads only a bounded subset of the container/task
+// shapes (name/environment/image + the iterated collections), so a cast
+// partial keeps the fixture small.
+function minimalContainer(environment: Record<string, string>): ResolvedEcsContainer {
+  return {
+    name: 'app',
+    image: { kind: 'public', uri: 'public.ecr.aws/docker/library/busybox:latest' },
+    environment,
+    sensitiveEnvKeys: [],
+    secrets: [],
+    portMappings: [],
+    mountPoints: [],
+    dependsOn: [],
+    links: [],
+    essential: true,
+    ulimits: [],
+    warnings: [],
+  } as unknown as ResolvedEcsContainer;
+}
+
+const task = { family: 'fam' } as unknown as ResolvedEcsTask;
+
+function buildWithOverrides(
+  environment: Record<string, string>,
+  envOverrides: Record<string, Record<string, string | null> | undefined> | undefined
+): string[] {
+  const { args } = buildDockerRunArgs({
+    task,
+    container: minimalContainer(environment),
+    image: 'public.ecr.aws/docker/library/busybox:latest',
+    network: 'net',
+    volumeByName: new Map(),
+    secrets: [],
+    envOverrides,
+    containerHost: '127.0.0.1',
+    roleArn: undefined,
+    platformOverride: undefined,
+    region: undefined,
+  });
+  return args;
+}
+
+// Returns the inline `-e KEY=VALUE` arg for a key, or undefined when the key
+// was not passed to docker at all. (Non-sensitive env always lands as the
+// single `KEY=VALUE` element; the bare-key `-e KEY` form is sensitive-only.)
+function envFlagFor(args: string[], key: string): string | undefined {
+  return args.find((a) => a.startsWith(`${key}=`));
+}
+
+describe('buildDockerRunArgs --env-vars overlay (ECS: start-service / start-alb / run-task)', () => {
+  it('a null value in Parameters CLEARS a template env key (not "null", not empty)', () => {
+    const args = buildWithOverrides(
+      { LOG_LEVEL: 'info', FEATURE_FLAG: 'on' },
+      { Parameters: { FEATURE_FLAG: null } }
+    );
+
+    // The cleared key is absent from docker's argv entirely — no `-e
+    // FEATURE_FLAG=...` of any value, and crucially never the string "null".
+    expect(envFlagFor(args, 'FEATURE_FLAG')).toBeUndefined();
+    expect(args).not.toContain('FEATURE_FLAG=null');
+    expect(args).not.toContain('FEATURE_FLAG=');
+    expect(args.some((a) => a.startsWith('FEATURE_FLAG'))).toBe(false);
+
+    // Untouched keys still pass through inline.
+    expect(args).toContain('LOG_LEVEL=info');
+  });
+
+  it('a null value in a container-specific entry clears a template env key', () => {
+    const args = buildWithOverrides(
+      { LOG_LEVEL: 'info', SECRET_TOGGLE: 'on' },
+      { app: { SECRET_TOGGLE: null } }
+    );
+
+    expect(envFlagFor(args, 'SECRET_TOGGLE')).toBeUndefined();
+    expect(args).not.toContain('SECRET_TOGGLE=null');
+    expect(args).toContain('LOG_LEVEL=info');
+  });
+
+  it('a non-null override value is applied (string-coerced), not cleared', () => {
+    const args = buildWithOverrides(
+      { LOG_LEVEL: 'info' },
+      { Parameters: { LOG_LEVEL: 'debug', EXTRA: 'added' } }
+    );
+
+    expect(args).toContain('LOG_LEVEL=debug');
+    expect(args).toContain('EXTRA=added');
+  });
+
+  it('the JSON string "null" is a literal value, NOT a clear directive', () => {
+    // Only a real JSON null clears; the four-character string "null" is a
+    // legitimate value a user might want, so it must survive verbatim.
+    const args = buildWithOverrides({ MODE: 'real' }, { Parameters: { MODE: 'null' } });
+
+    expect(args).toContain('MODE=null');
+  });
+});


### PR DESCRIPTION
## Summary

Deduplicates the `--env-vars` SAM-shape overlay helper and adds the
previously-missing coverage for the ECS task-container env path.

The overlay logic (apply a value, or CLEAR a key when its value is JSON
`null`) was duplicated byte-for-byte:

- a private `applyOverrideMap` in `src/local/env-resolver.ts` — the
  `cdkl invoke` Lambda env path,
- an identical private copy in `src/local/ecs-task-runner.ts` — the
  `start-service` / `start-alb` / `run-task` ECS task-container env path.

The ECS copy had **no test**, so the two could silently drift. This PR
collapses them into one exported `applyEnvOverrideMap` in `env-resolver.ts`
that `ecs-task-runner.ts` imports, so both paths apply identical semantics.

**No behavior change** — pure dedup. The semantics (now locked by tests on
both paths):

- a JSON `null` value DELETES the key from the container env — it is absent,
  never the string `"null"`, never empty,
- a non-null value is string-coerced,
- the literal string `"null"` stays a value.

## Changes

- `src/local/env-resolver.ts` — export `applyEnvOverrideMap` (was the
  private `applyOverrideMap`); JSDoc names both consuming paths.
- `src/local/ecs-task-runner.ts` — drop the duplicate helper, import the
  shared one. No import cycle (`env-resolver.ts` has no imports).
- `tests/unit/local/ecs-task-runner-env-overrides.test.ts` (new) — drives
  the real `buildDockerRunArgs` and asserts add / keep / null-clear, incl.
  that a null'd key never becomes `KEY=null` or `KEY=`, and that the literal
  string `"null"` survives as a value.
- `tests/integration/local-run-task-env-vars/` (new fixture) — a busybox
  task dumps its env; the run passes an `--env-vars` file that adds a key,
  keeps a template key, and clears one via `null`, then asserts the cleared
  key is gone end-to-end through real Docker.

## Test plan

- `vp run check` / `vp run build` — green.
- `vp run test` — 2972 passed (197 files), including the new ECS unit test.
- `/run-integ local-run-task-env-vars` — green, 0 orphan containers /
  networks. Confirms the null-clear end-to-end on the real ECS run-task
  Docker path.

## Notes

- The new fixture's `verify.sh` uses a single `cleanup()` + one
  `trap ... EXIT` (a second `trap ... EXIT` would silently REPLACE the
  first and drop the docker sweep — a latent pattern in several existing
  fixtures, left for a separate audit).
