### PR TITLE
fix(integ): restore the docker sweep in local-run-task-multi-container cleanup

### DIFF
--- a/tests/integration/local-run-task-multi-container/verify.sh
+++ b/tests/integration/local-run-task-multi-container/verify.sh
@@ -15,11 +15,17 @@ CDKL="node ../../../dist/cli.js"
 SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
 BUSYBOX_IMAGE="public.ecr.aws/docker/library/busybox:1.36"
 
+# Set below; init empty so the EXIT trap's `rm -f` is set-u-safe if the
+# script dies before the temp file is created.
+OUT_FILE=""
 cleanup() {
   echo "==> Cleanup: stopping any leftover containers"
   docker ps --filter "name=cdkl-" --format '{{.ID}}' | xargs -r docker rm -f >/dev/null 2>&1 || true
   docker network ls --filter "name=cdkl-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
+  rm -f "${OUT_FILE}"
 }
+# A single EXIT trap: a second `trap ... EXIT` would REPLACE this one (bash
+# keeps only the last), silently dropping the docker sweep above.
 trap cleanup EXIT
 
 echo "==> Verifying Docker is available"
@@ -37,7 +43,6 @@ fi
 
 # Capture the run output so we can assert on the `[app]`-prefixed line.
 OUT_FILE=$(mktemp)
-trap 'rm -f "${OUT_FILE}"' EXIT
 
 echo "==> Running multi-container task"
 # Run synchronously so `cdkl run-task` waits for the essential


### PR DESCRIPTION
## Summary

Fixes a clobbered-cleanup bug in the `local-run-task-multi-container`
integ fixture. It set `trap cleanup EXIT` (the docker container/network
sweep) at the top, then later re-set `trap 'rm -f "${OUT_FILE}"' EXIT`
for the temp file. Bash keeps only the LAST `EXIT` trap, so the second
silently REPLACED the first — the docker sweep never ran on exit.

The run is synchronous (busybox containers self-exit) and `/run-integ`
has its own post-run orphan sweep, so it passed green, but the fixture's
own cleanup contract was broken.

## Fix

Fold the temp-file removal into `cleanup()` and keep a single
`trap cleanup EXIT`. `OUT_FILE` is initialized empty so the trap's
`rm -f` is `set -u`-safe if the script dies before the temp file is
created.

## How it was found + scope

A reviewer flagged the same double-trap pattern in a new fixture (the
copied template carried it). I then audited all ~21 multi-`trap`
fixtures; this is the ONLY genuinely-broken one:

- `local-start-alb*` / `local-run-task-awsvpc` / `local-ecs-service-connect`
  use a `'...; cleanup'` superset trap (benign — cleanup still runs).
- `local-list`'s `cleanup()` is temp-file-only (no docker sweep to drop).
- `local-invoke*` use progressive temp-file-only traps (no docker
  `cleanup()` to clobber).

## Test plan

- `vp run check` / `vp run build` — green.
- `vp run test` — 2972 passed (197 files).
- `/run-integ local-run-task-multi-container` — green, asserts
  `[app] hello from app`, and the restored `cleanup()` sweep now fires on
  exit (verified: 0 orphan containers / networks afterward).
