### PR TITLE
feat(studio): surface the watch + assume-role session toggles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -440,7 +440,13 @@ compute-locally category for Lambda + API Gateway).
   per-run is mutable, `GET /api/config` exposes it (with the read-only
   synth-time `profile` / `region` / `app`), and `PATCH /api/config`
   (`applyConfigPatch`) edits the bindings so the change applies to
-  subsequent runs without a restart. Issue #301 slice 4 added
+  subsequent runs without a restart. A watch / assume-role toggle is
+  otherwise silent (only a from-cfn-stack change logs, via its
+  re-classification pass), so the patch handler logs a one-line
+  confirmation on a real flip — `describeWatchToggle` /
+  `describeAssumeRoleToggle` (both change-gated: a no-op re-send logs
+  nothing) note the new binding + that it binds the NEXT run, not
+  already-running serves. Issue #301 slice 4 added
   `--stack <glob...>` (`filterStudioTargetGroups` in studio-server):
   a DISPLAY-only glob filter over the listed targets (a target id is
   `Stack/Construct`, so `dev/*` scopes to stack `dev`) — it does NOT
@@ -750,7 +756,13 @@ compute-locally category for Lambda + API Gateway).
   read-only "Started with" summary (issue #356 — `formatAppliedOptions`
   over the `serveApplied` map recorded at Start) surfaces the launch
   config the serve is running with (e.g. a chosen `--max-tasks` stays
-  visible instead of silently vanishing). A serve that FAILS — a boot
+  visible instead of silently vanishing). The session-global `--watch`
+  is appended by the serve-manager from the mutable session config (not
+  a per-run option), so `startServe` records the watch checkbox state at
+  Start into `serveApplied.watch` and `formatAppliedOptions` surfaces a
+  `--watch` line FIRST — so a serve started with watch ON shows it and
+  one started before the toggle visibly does NOT (the visibility gap that
+  made a watch-on serve look watch-off). A serve that FAILS — a boot
   failure (serve-manager emits status `error` with a message) or a crash
   AFTER it was running (status `stopped` WITH a message, vs a clean user
   stop which is `stopped` with NO message) — keeps that "Started with"

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -445,6 +445,51 @@ export function applyConfigPatch(body: unknown, target: EditableSessionBindings)
   }
 }
 
+/**
+ * One-line log surfaced when a `PATCH /api/config` flips the session `watch`
+ * binding. studio otherwise logs NOTHING for a watch toggle — unlike a
+ * `--from-cfn-stack` change, which re-classifies + logs a line — so the user
+ * pressing the Session-bar `watch` checkbox has no confirmation it took (the
+ * confusion that motivated this helper). Returns `undefined` when the value did
+ * not change (the Session bar PATCHes every binding on any field edit, so a
+ * from-cfn-stack-only / assume-role-only toggle re-sends `watch` unchanged), so
+ * the caller logs only on a real flip. The "already-running serves" note
+ * mirrors the serve-manager reading `config.watch` per `start()`: the toggle
+ * binds the NEXT serve started, never a live one.
+ */
+export function describeWatchToggle(before: boolean, after: boolean): string | undefined {
+  if (before === after) return undefined;
+  return after
+    ? 'Watch mode: ON — serves started from now on hot-reload on CDK source changes ' +
+        '(already-running serves keep their launch setting; restart them to pick it up).'
+    : 'Watch mode: OFF — serves started from now on do not hot-reload ' +
+        '(already-running serves keep their launch setting; restart them to apply).';
+}
+
+/**
+ * One-line log surfaced when a `PATCH /api/config` flips the session
+ * `assume-role` binding. Like {@link describeWatchToggle}, the toggle is
+ * otherwise silent (only a from-cfn-stack change logs, via re-classification),
+ * so the user editing the Session-bar role gets no confirmation. Returns
+ * `undefined` when the value did not change (the Session bar re-sends every
+ * binding on any field edit). The binding is forwarded to every child studio
+ * spawns, so it takes effect on the NEXT invoke / serve started — already-
+ * running serves keep the role they launched with.
+ */
+export function describeAssumeRoleToggle(
+  before: string | undefined,
+  after: string | undefined
+): string | undefined {
+  const b = before ?? '';
+  const a = after ?? '';
+  if (b === a) return undefined;
+  return a === ''
+    ? 'Assume-role binding cleared — invokes / serves started from now on use the default ' +
+        'credential chain (already-running serves keep their launch setting).'
+    : `Assume-role binding set to ${a} — applied to invokes / serves started from now on ` +
+        '(already-running serves keep their launch setting).';
+}
+
 const DEFAULT_STUDIO_PORT = 9999;
 
 /**
@@ -1195,7 +1240,18 @@ async function localStudioCommand(options: LocalStudioOptions): Promise<void> {
       // Mutates the shared childConfig the dispatcher + serve-manager read
       // per-run, so the new binding applies to subsequent invokes / serves.
       const beforeFromCfn = childConfig.fromCfnStack;
+      const beforeWatch = childConfig.watch === true;
+      const beforeAssumeRole = childConfig.assumeRole;
       applyConfigPatch(body, childConfig);
+      // A watch / assume-role toggle is otherwise silent (no re-classification,
+      // unlike a from-cfn-stack change which logs via the reclassify pass), so
+      // log a one-line confirmation on a real flip so the user knows the
+      // Session-bar edit took + that it binds the NEXT run, not already-running
+      // serves.
+      const watchLog = describeWatchToggle(beforeWatch, childConfig.watch === true);
+      if (watchLog) logger.info(watchLog);
+      const assumeRoleLog = describeAssumeRoleToggle(beforeAssumeRole, childConfig.assumeRole);
+      if (assumeRoleLog) logger.info(assumeRoleLog);
       // A `--from-cfn-stack` change re-runs the ECS image-pin classification +
       // swaps the served target list under the live socket (issue #385); other
       // edits (assume-role / watch) skip it. The post-patch `childConfig.

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -1014,6 +1014,14 @@ const STUDIO_SCRIPT = `
   // (repeat-pair / env-kv). Unset / false / blank entries are omitted.
   function formatAppliedOptions(applied) {
     const lines = [];
+    // The session-global --watch is not a per-run option (the serve-manager
+    // appends it from the mutable session config), so it would otherwise never
+    // appear in this summary. Surface it first so a serve started with watch ON
+    // shows it, and one started before the toggle visibly does NOT (the
+    // confusion that a missing --watch line here used to cause).
+    if (applied && applied.watch) {
+      lines.push('--watch');
+    }
     const options = applied && applied.options;
     if (options) {
       Object.keys(options).forEach(function (flag) {
@@ -1061,11 +1069,18 @@ const STUDIO_SCRIPT = `
     // Remember what this serve was Started with so the running workspace can
     // show a read-only "Started with" summary (issue #356) — the per-run
     // option inputs are gone once the composer is replaced by the running view.
+    // Record the session-global watch state at Start time (the serve-manager
+    // reads the SAME mutable config to decide --watch), so the "Started with"
+    // summary reflects whether THIS serve actually got --watch, regardless of
+    // any later toggle. The checkbox mirrors the server binding (applyConfig
+    // PATCHes on change), and only serve kinds reach startServe.
+    const watchEl = document.getElementById('sess-watch');
     serveApplied.set(id, {
       options: options,
       rawArgs: rawArgs,
       imageOverride: imageOverride,
       imageOverrides: imageOverrides,
+      watch: !!(watchEl && watchEl.checked),
     });
     // Defensive: a restart clears any stale "Stopping..." transient (issue
     // #394) — including a pending min-visible timer — so the new run shows

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { describe, it, expect, vi } from 'vite-plus/test';
 import {
   applyConfigPatch,
+  describeWatchToggle,
+  describeAssumeRoleToggle,
   coerceRunRequest,
   coerceStopRequest,
   coerceServeRequest,
@@ -315,6 +317,55 @@ describe('applyConfigPatch', () => {
     const cfg: EditableSessionBindings = { watch: true };
     applyConfigPatch({ assumeRole: 'arn:x' }, cfg);
     expect(cfg.watch).toBe(true);
+  });
+});
+
+describe('describeWatchToggle', () => {
+  it('returns undefined when the value did not change (no spurious log)', () => {
+    expect(describeWatchToggle(false, false)).toBeUndefined();
+    expect(describeWatchToggle(true, true)).toBeUndefined();
+  });
+
+  it('logs an ON line on a false -> true flip, noting it binds the next serve', () => {
+    const line = describeWatchToggle(false, true);
+    expect(line).toMatch(/Watch mode: ON/);
+    expect(line).toMatch(/already-running serves/);
+  });
+
+  it('logs an OFF line on a true -> false flip', () => {
+    const line = describeWatchToggle(true, false);
+    expect(line).toMatch(/Watch mode: OFF/);
+  });
+});
+
+describe('describeAssumeRoleToggle', () => {
+  it('returns undefined when the value did not change (undefined / same string)', () => {
+    expect(describeAssumeRoleToggle(undefined, undefined)).toBeUndefined();
+    expect(describeAssumeRoleToggle('arn:aws:iam::1:role/r', 'arn:aws:iam::1:role/r')).toBeUndefined();
+  });
+
+  it('treats undefined and empty-string as equivalent (no spurious log)', () => {
+    expect(describeAssumeRoleToggle(undefined, '')).toBeUndefined();
+    expect(describeAssumeRoleToggle('', undefined)).toBeUndefined();
+  });
+
+  it('logs a set line naming the ARN on an unset -> set flip', () => {
+    const line = describeAssumeRoleToggle(undefined, 'arn:aws:iam::1:role/r');
+    expect(line).toMatch(/Assume-role binding set to arn:aws:iam::1:role\/r/);
+    expect(line).toMatch(/already-running serves/);
+  });
+
+  it('logs a cleared line on a set -> unset flip', () => {
+    expect(describeAssumeRoleToggle('arn:aws:iam::1:role/r', undefined)).toMatch(
+      /Assume-role binding cleared/
+    );
+    expect(describeAssumeRoleToggle('arn:aws:iam::1:role/r', '')).toMatch(
+      /Assume-role binding cleared/
+    );
+  });
+
+  it('logs a set line on a role -> different role change', () => {
+    expect(describeAssumeRoleToggle('arn:old', 'arn:new')).toMatch(/set to arn:new/);
   });
 });
 

--- a/tests/unit/local/studio-ui-applied-opts.test.ts
+++ b/tests/unit/local/studio-ui-applied-opts.test.ts
@@ -67,6 +67,23 @@ describe('studio serve "Started with" summary (issue #356)', () => {
     }
   });
 
+  it('surfaces the session-global --watch first when the serve was Started with watch ON', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE });
+    try {
+      const t = exposed(h);
+      // watch ON -> --watch line, listed first (it is not a per-run option).
+      expect(t.formatAppliedOptions({ watch: true, options: { '--max-tasks': '2' } })).toEqual([
+        '--watch',
+        '--max-tasks 2',
+      ]);
+      // watch absent / false -> no --watch line (a serve started before the toggle).
+      expect(t.formatAppliedOptions({ options: { '--max-tasks': '2' } })).toEqual(['--max-tasks 2']);
+      expect(t.formatAppliedOptions({ watch: false, options: {} })).toEqual([]);
+    } finally {
+      h.close();
+    }
+  });
+
   it('renders the chosen options in the running serve workspace', () => {
     const h = createStudioHarness({ epilogue: EXPOSE });
     try {

--- a/tests/unit/local/studio-ui-watch-applied.test.ts
+++ b/tests/unit/local/studio-ui-watch-applied.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+/**
+ * The session-global `--watch` is appended by the serve-manager from the
+ * mutable session config, not from the per-run options, so it would never show
+ * up in the "Started with" summary on its own. `startServe` records the
+ * Session-bar watch checkbox state at Start time so the running view reflects
+ * whether THIS serve actually got `--watch` (the gap that made a watch-on serve
+ * look watch-off after the toggle order tripped a user up).
+ */
+const EXPOSE = `
+window.__t = {
+  serveMeta: serveMeta,
+  serveState: serveState,
+  serveApplied: serveApplied,
+  renderServeWorkspace: renderServeWorkspace,
+  formatAppliedOptions: formatAppliedOptions,
+};
+window.__setShown = function (id) { shownServeId = id; };
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+function composeAndStart(h: Harness, watchChecked: boolean): any {
+  const t = h.window.__t;
+  // The session-bar watch checkbox is part of the static page; set it as a
+  // PATCH-driven toggle would have.
+  h.document.getElementById('sess-watch').checked = watchChecked;
+  const dot = h.document.createElement('span');
+  const btnSlot = h.document.createElement('span');
+  t.serveMeta.set('S/Api', { dot, btnSlot, kind: 'api' });
+  t.serveState.set('S/Api', { status: 'stopped', endpoints: [] });
+  h.window.__setShown('S/Api');
+  t.renderServeWorkspace('S/Api');
+  // Click Start — startServe records serveApplied (incl. watch) synchronously
+  // before it awaits fetch (the harness fetch never resolves, which is fine).
+  (h.document.querySelector('#workspace .composer button') as any).click();
+  return t;
+}
+
+describe('studio serve watch capture in "Started with" (watch visibility)', () => {
+  it('records watch=true on the serve when the Session-bar checkbox is ON at Start', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const t = composeAndStart(h, true);
+      expect(t.serveApplied.get('S/Api').watch).toBe(true);
+      expect(t.formatAppliedOptions(t.serveApplied.get('S/Api'))).toContain('--watch');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('records watch=false when the checkbox is OFF — no --watch line', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      const t = composeAndStart(h, false);
+      expect(t.serveApplied.get('S/Api').watch).toBe(false);
+      expect(t.formatAppliedOptions(t.serveApplied.get('S/Api'))).not.toContain('--watch');
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The `cdkl studio` Session-bar `watch` and `assume-role` toggles were silent.
`PATCH /api/config` applied them but logged nothing — only a `from-cfn-stack`
change logs, via its re-classification pass — and the session-global `--watch`
never showed up in a running serve's "Started with" summary (the serve-manager
appends `--watch` from the mutable session config, not from a per-run option).

The practical fallout: a user toggling `watch` got no confirmation it took, and
a serve started *before* the toggle looked identical to one started *after* —
making a watch-on serve indistinguishable from a watch-off one without
inspecting `/api/config` or the spawned child's argv by hand.

## Changes

- `patchConfig` now logs a one-line confirmation on a real `watch` /
  `assume-role` flip — `describeWatchToggle` / `describeAssumeRoleToggle`, both
  change-gated so a no-op re-send (the Session bar PATCHes every binding on any
  field edit) logs nothing. Each line notes the binding applies to the NEXT run,
  not already-running serves (mirroring the serve-manager reading `config.watch`
  per `start()`).
- `startServe` records the watch checkbox state into `serveApplied.watch`, and
  `formatAppliedOptions` surfaces a `--watch` line first — so the running view's
  "Started with" summary shows whether THIS serve actually got `--watch`.

## Behavior change

Additive, observable output only: new change-gated log lines on a watch /
assume-role toggle, and a `--watch` line in the studio UI "Started with" panel.
No input/output contract changes; a host embedding `createLocalStudioCommand`
inherits this automatically via the factory (the studio server + embedded UI are
wrapped wholesale). cdkd tracking issue:
https://github.com/go-to-k/cdkd/issues/773

## Test plan

- Unit: `describeWatchToggle` / `describeAssumeRoleToggle` (change-gated +
  message content), the `formatAppliedOptions` `--watch` line, and the
  `startServe` checkbox capture via the embedded-UI jsdom harness.
- Live: started `cdkl studio` against the `local-studio` fixture and
  `PATCH /api/config` with `watch:true` + a role, then `watch:false` + null
  role, then a no-op re-send — confirmed the ON/OFF + set/cleared lines fire on
  real flips and the no-op logged nothing.
- Full suite: 198 files / 2983 tests pass.

## Integration test

Deferred to a clean Docker window. The `local-studio` integ's cleanup
(`tests/integration/local-studio/verify.sh`) force-removes
`reference=cdkl-override-*` images, which would disrupt a live `start-alb`
`--image-override` session that was running on the shared Docker host at PR
time. This change adds no Docker / runtime-container code path (the new code is
an HTTP-handler log line + a browser-JS string), and the real behavior was
live-tested directly. The `integ` marker is intentionally left unset so the
merge gate blocks until `/run-integ local-studio` runs in a clean window.
