### PR TITLE
feat(studio): label targets-pane rows by API surface + "ECS Service"

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -352,7 +352,7 @@ const STUDIO_CSS = `
 `;
 
 const STUDIO_SCRIPT = `
-  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore', 'agentcore-ws': 'AgentCore WS' };
+  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS Service', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore', 'agentcore-ws': 'AgentCore WS' };
   const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task', 'cloudfront', 'agentcore-ws']; // long-running serve targets (ecs-task = run-task; agentcore-ws = start-agentcore /ws bridge)
   const INVOKE_KINDS = ['lambda', 'agentcore']; // single-shot invoke targets (event composer)
   const rowsById = new Map();      // invocationId -> timeline row element
@@ -865,7 +865,14 @@ const STUDIO_SCRIPT = `
             const name = el('span', 'name', tail);
             name.title = entry.id; // full path on hover
             t.appendChild(name);
-            t.appendChild(el('span', 'kind', '(' + (KIND_LABEL[group.kind] || group.kind) + ')'));
+            // An API surface carries its own kind ('HTTP API v2' / 'REST API
+            // v1' / 'Function URL' / 'WebSocket') in entry.surface; show it so
+            // the APIs group disambiguates per row (a Function URL reads as
+            // such, not a uniform '(API)' that collides with the same backing
+            // Lambda's '(Lambda)' row). Other kinds have no surface and fall
+            // back to the group-kind label.
+            const kindLabel = entry.surface || KIND_LABEL[group.kind] || group.kind;
+            t.appendChild(el('span', 'kind', '(' + kindLabel + ')'));
             if (isInvoke) {
               const btn = el('button', 'invoke-btn', 'Invoke');
               btn.onclick = (e) => { e.stopPropagation(); selectTarget(entry.id, group.kind); };

--- a/tests/unit/local/studio-ui-target-fold.test.ts
+++ b/tests/unit/local/studio-ui-target-fold.test.ts
@@ -133,6 +133,74 @@ describe('targets pane per-stack path folding', () => {
   });
 });
 
+describe('targets pane per-row kind label', () => {
+  it('shows each API surface kind per row (not a uniform group label)', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      const apiGroup = {
+        kind: 'api',
+        title: 'APIs',
+        entries: [
+          { id: 'dev/OrdersApi', qualifiedId: 'dev:OrdersApi', surface: 'HTTP API v2' },
+          { id: 'dev/LegacyApi', qualifiedId: 'dev:LegacyApi', surface: 'REST API v1' },
+          { id: 'dev/ImageResizer', qualifiedId: 'dev:ImageResizer', surface: 'Function URL' },
+          { id: 'dev/ChatApi', qualifiedId: 'dev:ChatApi', surface: 'WebSocket' },
+        ],
+      };
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch([apiGroup]);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+
+      const kinds = Array.from(h.document.querySelectorAll('.target .kind')).map((n) => n.textContent);
+      expect(kinds).toEqual(['(HTTP API v2)', '(REST API v1)', '(Function URL)', '(WebSocket)']);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('falls back to the group-kind label for a surface-less API entry', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      const apiGroup = {
+        kind: 'api',
+        title: 'APIs',
+        entries: [{ id: 'dev/Bare', qualifiedId: 'dev:Bare' }],
+      };
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch([apiGroup]);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+
+      const kind = h.document.querySelector('.target .kind') as HTMLElement;
+      expect(kind.textContent).toBe('(API)');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('labels an ECS service row "ECS Service" (paired with the "ECS Task" group)', async () => {
+    const h = createStudioHarness({ epilogue: EPILOGUE });
+    try {
+      const groups = [
+        {
+          kind: 'ecs',
+          title: 'ECS Services',
+          entries: [{ id: 'dev/WebSvc', qualifiedId: 'dev:WebSvc', servable: true }],
+        },
+        {
+          kind: 'ecs-task',
+          title: 'ECS Task Definitions',
+          entries: [{ id: 'dev/BatchTask', qualifiedId: 'dev:BatchTask' }],
+        },
+      ];
+      (h.window as unknown as { fetch: unknown }).fetch = targetsFetch(groups);
+      await (h.window as unknown as { __loadTargets: () => Promise<void> }).__loadTargets();
+
+      const kinds = Array.from(h.document.querySelectorAll('.target .kind')).map((n) => n.textContent);
+      expect(kinds).toEqual(['(ECS Service)', '(ECS Task)']);
+    } finally {
+      h.close();
+    }
+  });
+});
+
 describe('targets pane construct-path CSS', () => {
   it('makes the path a horizontal-scroll container with overscroll containment', () => {
     const html = renderStudioHtml('TestStack', 'cdkl');


### PR DESCRIPTION
## Summary

In `cdkl studio`, the targets-pane row tag rendered `KIND_LABEL[group.kind]`
uniformly, so every entry under the **APIs** group read as a generic `(API)`.
A Lambda **Function URL** was therefore indistinguishable from a REST / HTTP
API — and from the *same backing Lambda*'s `(Lambda)` row in the **Lambda
Functions** group (a Function-URL Lambda is listed in both groups: invoke it
directly vs serve its Function URL via `start-api`). The per-entry surface
(`HTTP API v2` / `REST API v1` / `Function URL` / `WebSocket`) was already
carried on the `StudioTarget` (`studio-server` sets `t.surface`) but never
read by the view.

Two label-only changes in `src/local/studio-ui.ts`:

- **Render `entry.surface` when present** (falling back to the group-kind
  label), so the APIs group disambiguates per row — e.g. a Function URL reads
  as `(Function URL)`, making the dual listing with the Lambda Functions group
  legible.
- **Relabel the `ecs` group tag `ECS` -> `ECS Service`**, so it pairs with the
  existing `ECS Task` group. The generic `ECS` was a historical leftover from
  before the service / task-def split.

No layout change (text inside the existing `.kind` span); no server / runtime
path touched.

## Test plan

- Added 3 cases to `studio-ui-target-fold.test.ts` that drive the **real**
  embedded `loadTargets` in jsdom and assert the rendered `.kind` text:
  per-API-surface labels, the surface-less fallback to `(API)`, and
  `(ECS Service)` / `(ECS Task)` pairing.
- `vp run check` (0 errors), `vp run build`, full unit suite (198 files /
  2986 tests) all green.
- `local-studio` integ (boot + UI + serve + capture + shutdown) green;
  Docker left clean (0 containers / networks).
