### PR TITLE
fix(invoke-agentcore): don't install deps for CodeConfiguration builds; warn to vendor

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -166,8 +166,13 @@ AWS managed services.
   contract, invoked once locally (`cdkl invoke-agentcore`); covers both the
   container artifact and the CodeConfiguration managed-runtime artifact
   (`fromCodeAsset` AND `fromS3` — Python 3.10-3.14 / Node 22, built from source:
-  a generated Dockerfile installs the bundle's deps and runs the EntryPoint,
-  which self-serves the contract; a `fromS3` bundle's ZIP is downloaded from S3
+  a generated Dockerfile runs the EntryPoint AS-IS — no dependency install,
+  matching the managed runtime, which resolves deps vendored into the bundle at
+  deploy time, NOT a runtime `pip install` — so a bundle that forgot to vendor
+  its deps fails locally the same way it fails deployed; a dependency manifest
+  (`requirements.txt` / `pyproject.toml`) present without vendored deps WARNs
+  with the `uv pip install --target` vendoring recipe), which self-serves the
+  contract; a `fromS3` bundle's ZIP is downloaded from S3
   and extracted first — `Code.S3.Bucket` may be a literal or, under
   `--from-cfn-stack`, a `Ref` / `Fn::ImportValue` / `Fn::GetStackOutput`
   intrinsic resolved against state) on the HTTP and MCP protocols. HTTP runs the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -486,10 +486,20 @@ self-serves the same HTTP (or MCP) contract (typically via the
 `bedrock-agentcore` SDK). cdk-local replicates that with a **local from-source
 build**: it gets the bundle source, generates a Dockerfile for the runtime's
 base image (`PYTHON_3_10`-`PYTHON_3_14` → `python:3.x-slim`, `NODE_22` →
-`node:22-slim`), installs the bundle's dependencies (`requirements.txt` /
-`pyproject.toml` for Python, `package.json` for Node — when present), runs the
-`EntryPoint`, then drives the started container with the same protocol client
-as a container artifact.
+`node:22-slim`), runs the `EntryPoint` **as-is**, then drives the started
+container with the same protocol client as a container artifact.
+
+The build does **not** install dependencies, because the AWS managed runtime
+does not either: dependencies must be **vendored into the bundle** at deploy
+time (e.g. `uv pip install --python-platform aarch64-manylinux2014 --target
+<bundle>`), and the runtime resolves them from the bundle's search path.
+Running the bundle as-is keeps local behavior faithful to deployed — a bundle
+that forgot to vendor its deps fails locally (`ModuleNotFoundError`) the same
+way it fails on AWS, instead of passing locally only because a local install
+papered over it. When a bundle declares a dependency manifest
+(`requirements.txt` / `pyproject.toml` for Python, `package.json` for Node)
+without vendored dependencies present, cdk-local logs a warning with the
+vendoring recipe.
 
 Both bundle shapes are supported:
 

--- a/src/local/agentcore-code-build.ts
+++ b/src/local/agentcore-code-build.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runDockerStreaming } from '../utils/docker-cmd.js';
@@ -16,10 +16,18 @@ import { getEmbedConfig } from './embed-config.js';
  * artifact is just source + an `EntryPoint` + a `Runtime`; AWS's managed
  * runtime runs the entrypoint, which self-serves the AgentCore HTTP contract
  * (`POST /invocations` + `GET /ping` on 8080) — typically via the
- * `bedrock-agentcore` SDK. We replicate that locally: generate a Dockerfile
- * for the runtime's base image, install the bundle's dependencies, and run the
- * entrypoint. The resulting container speaks the same 8080 contract, so the
- * existing HTTP client drives it unchanged.
+ * `bedrock-agentcore` SDK. Crucially, the managed runtime does NOT install
+ * dependencies at runtime: deps are vendored INTO the bundle at deploy time
+ * (e.g. `uv pip install --target`), and the runtime resolves them from the
+ * bundle's dependency search path. We replicate that locally faithfully:
+ * generate a Dockerfile for the runtime's base image that copies the bundle
+ * and runs the entrypoint AS-IS (no install). So a bundle that forgot to
+ * vendor its deps fails locally the same way it fails deployed
+ * (`ModuleNotFoundError`) instead of passing locally only because we installed
+ * them — `buildAgentCoreCodeImage` warns up-front with the vendoring recipe
+ * when a dependency manifest is present without vendored deps. The resulting
+ * container speaks the same 8080 contract, so the existing HTTP client drives
+ * it unchanged.
  */
 
 /** AgentCore CodeConfiguration `Runtime` enum → local Docker base image. */
@@ -66,6 +74,7 @@ export async function buildAgentCoreCodeImage(
   }
 
   const isNode = options.runtime.startsWith('NODE');
+  await warnIfDependenciesNotVendored(options.sourceDir, options.runtime, isNode, logger);
   const dockerfile = renderCodeDockerfile(base, options.entryPoint, isNode);
   const tag = computeCodeImageTag(
     options.sourceDir,
@@ -113,26 +122,74 @@ export async function buildAgentCoreCodeImage(
 }
 
 /**
- * Render the generated Dockerfile. Dependencies are installed conditionally
- * (a bundle may vendor them or ship none), and the EntryPoint is mapped to a
- * CMD: a bare script (`app.py` / `server.js`) is run by the interpreter, while
- * an explicit launcher (e.g. `opentelemetry-instrument`) is run verbatim.
+ * Render the generated Dockerfile. Dependencies are NOT installed: the
+ * AgentCore managed runtime resolves deps from the bundle (vendored at deploy
+ * time), so we copy the bundle and run the EntryPoint as-is to match deployed
+ * behavior. The EntryPoint is mapped to a CMD: a bare script (`app.py` /
+ * `server.js`) is run by the interpreter, while an explicit launcher (e.g.
+ * `opentelemetry-instrument`) is run verbatim.
  */
 export function renderCodeDockerfile(base: string, entryPoint: string[], isNode: boolean): string {
-  const installStep = isNode
-    ? 'RUN if [ -f package.json ]; then npm install --omit=dev; fi'
-    : 'RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; ' +
-      'elif [ -f pyproject.toml ]; then pip install --no-cache-dir .; fi';
   return (
     [
       `FROM ${base}`,
       'WORKDIR /app',
       'COPY . /app',
-      installStep,
       'EXPOSE 8080',
       `CMD ${JSON.stringify(toCmdArgv(entryPoint, isNode))}`,
     ].join('\n') + '\n'
   );
+}
+
+/**
+ * Warn when a code bundle declares a dependency manifest but does not appear to
+ * vendor its dependencies. The AgentCore managed runtime does NOT install deps
+ * at runtime, so an unvendored bundle that "works" only because something
+ * installed deps for it would fail on deploy with `ModuleNotFoundError`. We run
+ * the bundle as-is locally (matching deploy); this surfaces the likely cause
+ * up-front with the vendoring recipe. Heuristic: a Python bundle is considered
+ * vendored if it contains any `*.dist-info` dir (what `pip install --target`
+ * leaves); a Node bundle if it has a `node_modules` dir.
+ */
+async function warnIfDependenciesNotVendored(
+  sourceDir: string,
+  runtime: string,
+  isNode: boolean,
+  logger: ReturnType<typeof getLogger>
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(sourceDir);
+  } catch {
+    return;
+  }
+  const has = (name: string): boolean => entries.includes(name);
+
+  if (isNode) {
+    if (has('package.json') && !has('node_modules')) {
+      logger.warn(
+        `AgentCore code bundle '${sourceDir}' declares package.json but does not vendor node_modules. ` +
+          'The AgentCore managed runtime does NOT install dependencies at runtime, so the deployed agent ' +
+          "will fail to resolve them. Vendor dependencies into the bundle (e.g. 'npm install --omit=dev' " +
+          'in the bundle dir) so the deploy artifact is self-contained. cdk-local runs the bundle as-is to ' +
+          'match the deployed runtime.'
+      );
+    }
+    return;
+  }
+
+  const manifest = await pythonManifestDeclaringDeps(sourceDir, entries);
+  const vendored = entries.some((e) => e.endsWith('.dist-info'));
+  if (manifest && !vendored) {
+    const pyVersion = runtime.replace('PYTHON_', '').replace('_', '.');
+    logger.warn(
+      `AgentCore code bundle '${sourceDir}' declares ${manifest} but does not vendor its dependencies. ` +
+        'The AgentCore managed runtime does NOT install dependencies at runtime, so the deployed agent will ' +
+        'fail with ModuleNotFoundError. Vendor arm64 wheels into the bundle, e.g.:\n' +
+        `  uv pip install --python-platform aarch64-manylinux2014 --python-version ${pyVersion} --target <bundle-dir> -r requirements.txt\n` +
+        'cdk-local runs the bundle as-is to match the deployed runtime.'
+    );
+  }
 }
 
 /**
@@ -146,6 +203,35 @@ export function toCmdArgv(entryPoint: string[], isNode: boolean): string[] {
   const isScript = isNode ? /\.[cm]?js$/.test(first) : /\.py$/.test(first);
   if (!isScript) return entryPoint;
   return [isNode ? 'node' : 'python', ...entryPoint];
+}
+
+/**
+ * Return the Python dependency manifest filename that declares at least one
+ * real dependency, or undefined. A `requirements.txt` that is empty or only
+ * comments/pip-options (the stdlib-only-agent case) declares nothing, so it
+ * must not trigger the unvendored-deps warning.
+ */
+async function pythonManifestDeclaringDeps(
+  sourceDir: string,
+  entries: string[]
+): Promise<string | undefined> {
+  if (entries.includes('requirements.txt')) {
+    const content = await readFile(join(sourceDir, 'requirements.txt'), 'utf-8').catch(() => '');
+    const declares = content.split(/\r?\n/).some((line) => {
+      const t = line.trim();
+      return t.length > 0 && !t.startsWith('#') && !t.startsWith('-');
+    });
+    if (declares) return 'requirements.txt';
+  }
+  if (entries.includes('pyproject.toml')) {
+    const content = await readFile(join(sourceDir, 'pyproject.toml'), 'utf-8').catch(() => '');
+    // PEP 621 `dependencies = ["..."]` with an entry, or a poetry deps table.
+    const declares =
+      /dependencies\s*=\s*\[\s*["']/.test(content) ||
+      content.includes('[tool.poetry.dependencies]');
+    if (declares) return 'pyproject.toml';
+  }
+  return undefined;
 }
 
 /** Deterministic local tag, stable for identical source + runtime + entrypoint. */

--- a/tests/integration/local-invoke-agentcore-froms3/code-agent/app.py
+++ b/tests/integration/local-invoke-agentcore-froms3/code-agent/app.py
@@ -2,8 +2,9 @@
 # for the cdkl invoke-agentcore fromS3 integ test. Authored as plain source
 # (no Dockerfile) and shipped as a ZIP uploaded to S3 (the fromS3 shape): cdkl
 # downloads + extracts the bundle, builds it from source for the declared
-# runtime (installs requirements.txt), and runs this entrypoint, which
-# self-serves the AgentCore HTTP contract on 0.0.0.0:8080:
+# runtime and runs this entrypoint AS-IS (no dependency install — matching the
+# managed runtime; this agent is stdlib-only), which self-serves the AgentCore
+# HTTP contract on 0.0.0.0:8080:
 #   GET  /ping        -> 200 {"status":"Healthy"}
 #   POST /invocations -> echoes the request body + the injected GREETING env var
 # Uses only the Python stdlib. Startup logs go to stderr so the host's stdout

--- a/tests/integration/local-invoke-agentcore-froms3/code-agent/requirements.txt
+++ b/tests/integration/local-invoke-agentcore-froms3/code-agent/requirements.txt
@@ -1,2 +1,5 @@
 # No third-party dependencies — this agent uses only the Python stdlib.
-# Kept so `cdkl invoke-agentcore` exercises the from-source pip-install build step.
+# Kept (comment-only, declares no deps) so the from-source build exercises the
+# code path WITHOUT triggering the unvendored-deps warning: the AgentCore
+# managed runtime does not install requirements.txt at runtime, so cdkl runs
+# the bundle as-is and only warns when real (unvendored) deps are declared.

--- a/tests/integration/local-invoke-agentcore-froms3/lib/local-invoke-agentcore-froms3-stack.ts
+++ b/tests/integration/local-invoke-agentcore-froms3/lib/local-invoke-agentcore-froms3-stack.ts
@@ -24,8 +24,8 @@ export interface LocalInvokeAgentCoreFromS3StackProps extends cdk.StackProps {
  *
  * No CloudFormation deploy: `cdkl invoke-agentcore` downloads the bundle from
  * S3, extracts it, runs the same from-source build the fromCodeAsset path uses
- * (pip install + run the entrypoint), and the entrypoint self-serves the 8080
- * HTTP contract.
+ * (run the entrypoint as-is, no install), and the entrypoint self-serves the
+ * 8080 HTTP contract.
  */
 export class LocalInvokeAgentCoreFromS3Stack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: LocalInvokeAgentCoreFromS3StackProps) {

--- a/tests/integration/local-invoke-agentcore-froms3/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3/verify.sh
@@ -10,7 +10,7 @@
 #   - zip the local `code-agent/` source and upload it as the bundle object,
 #   - synth a stack whose `fromS3(...)` points at that literal bucket + key,
 #   - `cdkl invoke-agentcore` downloads + extracts the bundle, builds it from
-#     source (pip install + run the entrypoint), runs it on 8080, and POSTs the
+#     source (run the entrypoint as-is, no install), runs it on 8080, and POSTs the
 #     event to /invocations,
 #   - assert the response (runtime marker + injected GREETING + echoed event),
 #   - delete the object + bucket.

--- a/tests/integration/local-invoke-agentcore/code-agent/app.py
+++ b/tests/integration/local-invoke-agentcore/code-agent/app.py
@@ -1,7 +1,8 @@
 # Minimal Bedrock AgentCore Runtime CodeConfiguration (managed-runtime) agent
 # for the cdkl invoke-agentcore integ test. Authored as plain source (no
-# Dockerfile): cdkl builds it from source for the declared runtime, installs
-# requirements.txt, and runs this entrypoint, which self-serves the AgentCore
+# Dockerfile): cdkl builds it from source for the declared runtime and runs
+# this entrypoint AS-IS (no dependency install — matching the managed runtime;
+# this agent is stdlib-only), which self-serves the AgentCore
 # HTTP contract on 0.0.0.0:8080:
 #   GET  /ping        -> 200 {"status":"Healthy"}
 #   POST /invocations -> echoes the request body + the injected GREETING env var

--- a/tests/integration/local-invoke-agentcore/code-agent/requirements.txt
+++ b/tests/integration/local-invoke-agentcore/code-agent/requirements.txt
@@ -1,2 +1,5 @@
 # No third-party dependencies — this agent uses only the Python stdlib.
-# Kept so `cdkl invoke-agentcore` exercises the from-source pip-install build step.
+# Kept (comment-only, declares no deps) so the from-source build exercises the
+# code path WITHOUT triggering the unvendored-deps warning: the AgentCore
+# managed runtime does not install requirements.txt at runtime, so cdkl runs
+# the bundle as-is and only warns when real (unvendored) deps are declared.

--- a/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
+++ b/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
@@ -96,8 +96,8 @@ export class LocalInvokeAgentCoreStack extends cdk.Stack {
 
     // A CodeConfiguration (managed-runtime) runtime authored as plain source
     // (no Dockerfile) via fromCodeAsset. `cdkl invoke-agentcore` builds it from
-    // source for the declared runtime (pip install + run the entrypoint), which
-    // self-serves the same 8080 HTTP contract.
+    // source for the declared runtime (run the entrypoint as-is, no install),
+    // which self-serves the same 8080 HTTP contract.
     new Runtime(this, 'CodeAgent', {
       agentRuntimeArtifact: AgentRuntimeArtifact.fromCodeAsset({
         path: path.join(__dirname, '../code-agent'),

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -189,8 +189,8 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 }
 
 # Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
-# source (no Dockerfile): cdkl builds it from source (pip install + run the
-# entrypoint) and the entrypoint self-serves the 8080 HTTP contract.
+# source (no Dockerfile): cdkl builds it from source (run the entrypoint as-is,
+# no install) and the entrypoint self-serves the 8080 HTTP contract.
 echo "==> [11/19] CodeAgent (fromCodeAsset) builds from source + responds"
 RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_11}"

--- a/tests/unit/local/agentcore-code-build.test.ts
+++ b/tests/unit/local/agentcore-code-build.test.ts
@@ -1,8 +1,12 @@
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
-const { runDockerStreamingMock, isImageInLocalCacheMock } = vi.hoisted(() => ({
+const { runDockerStreamingMock, isImageInLocalCacheMock, warnMock } = vi.hoisted(() => ({
   runDockerStreamingMock: vi.fn(),
   isImageInLocalCacheMock: vi.fn(),
+  warnMock: vi.fn(),
 }));
 
 vi.mock('../../../src/utils/docker-cmd.js', async (importActual) => ({
@@ -12,6 +16,15 @@ vi.mock('../../../src/utils/docker-cmd.js', async (importActual) => ({
 vi.mock('../../../src/local/ecr-puller.js', async (importActual) => ({
   ...(await importActual<object>()),
   isImageInLocalCache: isImageInLocalCacheMock,
+}));
+vi.mock('../../../src/utils/logger.js', async (importActual) => ({
+  ...(await importActual<object>()),
+  getLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+  }),
 }));
 
 const {
@@ -44,21 +57,25 @@ describe('toCmdArgv', () => {
 });
 
 describe('renderCodeDockerfile', () => {
-  it('generates a Python Dockerfile with conditional pip install + interpreter CMD', () => {
+  it('generates a Python Dockerfile that runs the bundle as-is (NO install)', () => {
     const df = renderCodeDockerfile('python:3.12-slim', ['app.py'], false);
     expect(df).toContain('FROM python:3.12-slim');
     expect(df).toContain('COPY . /app');
-    expect(df).toContain('pip install --no-cache-dir -r requirements.txt');
-    expect(df).toContain('pyproject.toml');
     expect(df).toContain('EXPOSE 8080');
     expect(df).toContain('CMD ["python","app.py"]');
+    // The managed runtime resolves vendored deps; we must NOT pip-install
+    // (doing so would mask a missing-vendored-deps bundle — local pass /
+    // deployed fail).
+    expect(df).not.toContain('pip install');
+    expect(df).not.toMatch(/\bRUN\b/);
   });
 
-  it('generates a Node Dockerfile with npm install + node CMD', () => {
+  it('generates a Node Dockerfile that runs the bundle as-is (NO install)', () => {
     const df = renderCodeDockerfile('node:22-slim', ['server.js'], true);
     expect(df).toContain('FROM node:22-slim');
-    expect(df).toContain('npm install --omit=dev');
     expect(df).toContain('CMD ["node","server.js"]');
+    expect(df).not.toContain('npm install');
+    expect(df).not.toMatch(/\bRUN\b/);
   });
 });
 
@@ -123,7 +140,7 @@ describe('buildAgentCoreCodeImage', () => {
   });
 
   it('wraps a docker build failure with the captured stderr', async () => {
-    const err = Object.assign(new Error('exit 1'), { stderr: 'pip: not found' });
+    const err = Object.assign(new Error('exit 1'), { stderr: 'build error' });
     runDockerStreamingMock.mockRejectedValue(err);
     await expect(
       buildAgentCoreCodeImage({
@@ -132,7 +149,7 @@ describe('buildAgentCoreCodeImage', () => {
         entryPoint: ['app.py'],
         architecture: 'arm64',
       })
-    ).rejects.toThrow(/docker build failed.*pip: not found/);
+    ).rejects.toThrow(/docker build failed.*build error/);
   });
 
   it('with noBuild verifies the cached tag instead of building', async () => {
@@ -159,5 +176,91 @@ describe('buildAgentCoreCodeImage', () => {
         noBuild: true,
       })
     ).rejects.toThrow(/not in local registry/);
+  });
+});
+
+describe('warnIfDependenciesNotVendored (via buildAgentCoreCodeImage)', () => {
+  let dir: string;
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('warns when a Python bundle declares requirements.txt without vendored deps', async () => {
+    runDockerStreamingMock.mockResolvedValue({ stdout: '', stderr: '' });
+    dir = await mkdtemp(join(tmpdir(), 'cdkl-codebuild-test-'));
+    await writeFile(join(dir, 'main.py'), 'print(1)');
+    await writeFile(join(dir, 'requirements.txt'), 'bedrock-agentcore');
+    await buildAgentCoreCodeImage({
+      sourceDir: dir,
+      runtime: 'PYTHON_3_12',
+      entryPoint: ['main.py'],
+      architecture: 'arm64',
+    });
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    const msg = warnMock.mock.calls[0]?.[0] as string;
+    expect(msg).toMatch(/does not vendor/);
+    expect(msg).toMatch(/ModuleNotFoundError/);
+    expect(msg).toMatch(/uv pip install .*--target/);
+    expect(msg).toContain('3.12'); // python-version derived from the runtime
+  });
+
+  it('does NOT warn when the Python bundle vendors its deps (a *.dist-info dir)', async () => {
+    runDockerStreamingMock.mockResolvedValue({ stdout: '', stderr: '' });
+    dir = await mkdtemp(join(tmpdir(), 'cdkl-codebuild-test-'));
+    await writeFile(join(dir, 'main.py'), 'print(1)');
+    await writeFile(join(dir, 'requirements.txt'), 'bedrock-agentcore');
+    await mkdir(join(dir, 'bedrock_agentcore-1.0.0.dist-info'));
+    await buildAgentCoreCodeImage({
+      sourceDir: dir,
+      runtime: 'PYTHON_3_12',
+      entryPoint: ['main.py'],
+      architecture: 'arm64',
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn when a Python bundle ships no dependency manifest', async () => {
+    runDockerStreamingMock.mockResolvedValue({ stdout: '', stderr: '' });
+    dir = await mkdtemp(join(tmpdir(), 'cdkl-codebuild-test-'));
+    await writeFile(join(dir, 'main.py'), 'print(1)'); // stdlib-only, no requirements.txt
+    await buildAgentCoreCodeImage({
+      sourceDir: dir,
+      runtime: 'PYTHON_3_12',
+      entryPoint: ['main.py'],
+      architecture: 'arm64',
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn for a comment-only requirements.txt (stdlib-only agent)', async () => {
+    runDockerStreamingMock.mockResolvedValue({ stdout: '', stderr: '' });
+    dir = await mkdtemp(join(tmpdir(), 'cdkl-codebuild-test-'));
+    await writeFile(join(dir, 'main.py'), 'print(1)');
+    await writeFile(
+      join(dir, 'requirements.txt'),
+      '# No third-party dependencies — stdlib only.\n# kept for documentation\n'
+    );
+    await buildAgentCoreCodeImage({
+      sourceDir: dir,
+      runtime: 'PYTHON_3_12',
+      entryPoint: ['main.py'],
+      architecture: 'arm64',
+    });
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('warns when a Node bundle declares package.json without node_modules', async () => {
+    runDockerStreamingMock.mockResolvedValue({ stdout: '', stderr: '' });
+    dir = await mkdtemp(join(tmpdir(), 'cdkl-codebuild-test-'));
+    await writeFile(join(dir, 'server.js'), 'console.log(1)');
+    await writeFile(join(dir, 'package.json'), '{}');
+    await buildAgentCoreCodeImage({
+      sourceDir: dir,
+      runtime: 'NODE_22',
+      entryPoint: ['server.js'],
+      architecture: 'arm64',
+    });
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0]?.[0] as string).toMatch(/node_modules/);
   });
 });


### PR DESCRIPTION
## Summary

The AgentCore `fromCodeAsset` / `fromS3` (CodeConfiguration) from-source build
used to `pip install requirements.txt` (and `npm install`) into the generated
image. But the **real AgentCore managed runtime does NOT install dependencies
at runtime** — deps must be vendored into the bundle at deploy time (arm64
wheels, e.g. `uv pip install --python-platform aarch64-manylinux2014 --target`).
So a bundle shipping only `main.py` + `requirements.txt` (no vendored deps)
**passed locally under cdk-local but failed on deploy with
`ModuleNotFoundError`** — a silent local-passes / deployed-fails (false-green),
the exact gap cdk-local exists to prevent.

This was verified end-to-end: deploying a real `fromCodeAsset` AgentCore
Runtime and invoking it with the identical bundle gave cdkl-local = pass /
real-AWS = `ModuleNotFoundError`. AWS docs confirm the contract (deps vendored
into the zip; runtime resolves from the bundle search path).

## Behavior change

- **Old:** the generated Dockerfile pip-installed `requirements.txt` /
  `pyproject.toml` (Python) or `npm install`ed `package.json` (Node).
- **New:** the Dockerfile runs the bundle **as-is** (no install), matching the
  managed runtime. A non-vendored bundle now fails locally the same way it
  fails deployed instead of passing locally only because of the local install.
  When a bundle declares a dependency manifest **without** vendored deps, cdk-local
  logs an actionable warning naming the `uv pip install --target` vendoring
  recipe. A comment-only / dependency-free manifest does not warn (the
  stdlib-only-agent case).
- Container artifacts (`fromAsset` / `fromEcrRepository`) are unaffected.

Fidelity-first (option A) was chosen over a warn-but-still-install option,
because the latter keeps the false-green a warning can be missed past. cdkd
(host CLI) inherits this transitively; tracking issue:
https://github.com/go-to-k/cdkd/issues/774

## Changes

- `src/local/agentcore-code-build.ts` — `renderCodeDockerfile` drops the
  install step; new `warnIfDependenciesNotVendored` + `pythonManifestDeclaringDeps`
  (the latter ignores comment-only / option-only manifests so stdlib agents
  don't false-warn); corrected the misleading header JSDoc.
- Unit tests — 18 cases covering no-install Dockerfile output + the warn
  (real dep / vendored / comment-only / no-manifest / Node) branches.
- Docs — `.claude/CLAUDE.md` + `docs/cli-reference.md` updated to the
  run-as-is + vendor contract.
- Integ fixtures — `local-invoke-agentcore` / `*-froms3` agents are stdlib-only
  (comment-only `requirements.txt`); stale "pip install" comments corrected.

## Test plan

- `vp run check` / `vp run build` / `vp run test` (198 files, 2991 tests) — green.
- `tests/integration/local-invoke-agentcore` real-Docker integ — **19/19**,
  including the fromCodeAsset CodeAgent (tests 11/12) that exercise the changed
  build path; 0 Docker orphans.
- Live-tested the warning through the built `dist/internal.js`: a real
  unvendored dep warns with the recipe; a comment-only manifest and a vendored
  (`*.dist-info`) bundle do not.

Closes #455
