### PR TITLE
test(invoke-agentcore): integ-cover the no-install + unvendored-deps warning

### DIFF
--- a/tests/integration/local-invoke-agentcore/code-agent-unvendored/app.py
+++ b/tests/integration/local-invoke-agentcore/code-agent-unvendored/app.py
@@ -1,0 +1,32 @@
+# Unvendored-dependency AgentCore CodeConfiguration agent for the cdkl
+# invoke-agentcore integ test. It declares a third-party dependency
+# (requirements.txt: requests) but does NOT vendor it into the bundle.
+#
+# The AgentCore managed runtime does not install requirements.txt at runtime —
+# dependencies must be vendored into the bundle at deploy time. So cdkl builds
+# and runs this bundle AS-IS (no install): the top-level import below fails
+# with ModuleNotFoundError exactly as it would on a real deploy, and cdkl warns
+# up-front with the vendoring recipe. This is the regression guard for the
+# false-green where the from-source build used to pip-install requirements.txt
+# locally (issue #455) — making a non-vendored bundle pass locally but fail
+# deployed.
+import requests  # noqa: F401  (intentionally unvendored — must fail at runtime)
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+# Never reached: the import above raises ModuleNotFoundError before the server
+# can start. Kept so the bundle is a well-formed agent absent the missing dep.
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    print("unvendored code agent listening on 0.0.0.0:8080", file=sys.stderr, flush=True)
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()

--- a/tests/integration/local-invoke-agentcore/code-agent-unvendored/requirements.txt
+++ b/tests/integration/local-invoke-agentcore/code-agent-unvendored/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
+++ b/tests/integration/local-invoke-agentcore/lib/local-invoke-agentcore-stack.ts
@@ -107,6 +107,21 @@ export class LocalInvokeAgentCoreStack extends cdk.Stack {
       environmentVariables: { GREETING: 'hello-from-code' },
     });
 
+    // A CodeConfiguration bundle that DECLARES a third-party dependency
+    // (requirements.txt: requests) but does NOT vendor it. The AgentCore
+    // managed runtime does not install deps at runtime, so cdkl builds + runs
+    // it AS-IS: the top-level import fails (ModuleNotFoundError) exactly as it
+    // would on deploy, and cdkl warns up-front with the vendoring recipe.
+    // Regression guard for the false-green where the from-source build used to
+    // pip-install requirements.txt locally (issue #455).
+    new Runtime(this, 'UnvendoredCodeAgent', {
+      agentRuntimeArtifact: AgentRuntimeArtifact.fromCodeAsset({
+        path: path.join(__dirname, '../code-agent-unvendored'),
+        runtime: AgentCoreRuntime.PYTHON_3_12,
+        entrypoint: ['app.py'],
+      }),
+    });
+
     // An A2A-protocol runtime (ProtocolConfiguration = A2A). The container
     // serves the Agent2Agent JSON-RPC 2.0 contract on 9000 at POST / (no
     // /ping). `cdkl invoke-agentcore` POSTs one JSON-RPC request — defaults

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -37,6 +37,7 @@ PROTECTED="CdkLocalInvokeAgentCoreFixture/ProtectedAgent"
 PROTECTED_CLAIMS="CdkLocalInvokeAgentCoreFixture/ProtectedAgentClaims"
 MCP="CdkLocalInvokeAgentCoreFixture/McpAgent"
 CODE="CdkLocalInvokeAgentCoreFixture/CodeAgent"
+UNVENDORED="CdkLocalInvokeAgentCoreFixture/UnvendoredCodeAgent"
 A2A="CdkLocalInvokeAgentCoreFixture/A2aAgent"
 AGUI="CdkLocalInvokeAgentCoreFixture/AguiAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
@@ -55,7 +56,7 @@ if [[ ! -d node_modules ]]; then
 fi
 
 # Test 1 — default empty event: env injection + auto session id.
-echo "==> [1/19] Invoking EchoAgent with default empty event"
+echo "==> [1/20] Invoking EchoAgent with default empty event"
 RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -69,7 +70,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 }
 
 # Test 2 — event payload via --event echoes through /invocations.
-echo "==> [2/19] Invoking EchoAgent with --event payload"
+echo "==> [2/20] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
@@ -81,7 +82,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 }
 
 # Test 3 — --env-vars override wins over the template env.
-echo "==> [3/19] Invoking EchoAgent with --env-vars override"
+echo "==> [3/20] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
@@ -93,7 +94,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 }
 
 # Test 4 — explicit --session-id reaches the container's session header.
-echo "==> [4/19] Invoking EchoAgent with explicit --session-id"
+echo "==> [4/20] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
 RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
@@ -104,7 +105,7 @@ echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
 
 # Test 5 — a JWT-protected runtime invoked WITHOUT a token is rejected
 # BEFORE any container starts (AgentCore returns 401 in the cloud).
-echo "==> [5/19] ProtectedAgent without --bearer-token must be rejected pre-container"
+echo "==> [5/20] ProtectedAgent without --bearer-token must be rejected pre-container"
 set +e
 OUT_5=$(${CDKL} invoke-agentcore "${PROTECTED}" 2>&1)
 RC_5=$?
@@ -125,7 +126,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 }
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
-echo "==> [6/19] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
+echo "==> [6/20] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
 RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -135,7 +136,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 
 # Test 7 — a --bearer-token (discovery URL unreachable -> pass-through accept)
 # is verified and forwarded to /invocations as the Authorization header.
-echo "==> [7/19] ProtectedAgent with --bearer-token forwards the Authorization header"
+echo "==> [7/20] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
 RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_7}"
@@ -148,7 +149,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # The agent emits SSE frames when the event carries {"stream": true}; we assert
 # every streamed frame reached stdout (the full body, not a single buffered
 # line — so we capture all output, not just tail -1).
-echo "==> [8/19] EchoAgent streams a text/event-stream response to stdout"
+echo "==> [8/20] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
@@ -168,7 +169,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # Test 9 — an MCP-protocol runtime, no --event: the session handshake runs and
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
-echo "==> [9/19] McpAgent (no --event) runs the handshake + tools/list"
+echo "==> [9/20] McpAgent (no --event) runs the handshake + tools/list"
 RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
@@ -177,7 +178,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 }
 
 # Test 10 — an MCP tools/call via --event returns the tool result.
-echo "==> [10/19] McpAgent with --event runs tools/call"
+echo "==> [10/20] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
@@ -191,7 +192,7 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 # Test 11 — a CodeConfiguration (managed-runtime) runtime authored as plain
 # source (no Dockerfile): cdkl builds it from source (run the entrypoint as-is,
 # no install) and the entrypoint self-serves the 8080 HTTP contract.
-echo "==> [11/19] CodeAgent (fromCodeAsset) builds from source + responds"
+echo "==> [11/20] CodeAgent (fromCodeAsset) builds from source + responds"
 RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_11}"
 echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
@@ -204,7 +205,7 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 }
 
 # Test 12 — a --event payload echoes through the from-source agent.
-echo "==> [12/19] CodeAgent with --event echoes the payload"
+echo "==> [12/20] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
@@ -219,7 +220,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # the first frame and streams every received frame to stdout until the agent
 # closes. The fixture agent replies with one JSON frame (echo + session id +
 # Authorization + GREETING) then a second text frame, then closes.
-echo "==> [13/19] EchoAgent over the /ws WebSocket (--ws)"
+echo "==> [13/20] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
@@ -244,7 +245,7 @@ echo "${RESULT_13}" | grep -q 'ws-frame-2' || {
 
 # Test 14 — --ws is HTTP-only: against an MCP runtime it warns and is ignored,
 # falling through to the normal MCP path (tools/list still returns).
-echo "==> [14/19] McpAgent with --ws warns + still runs the MCP path"
+echo "==> [14/20] McpAgent with --ws warns + still runs the MCP path"
 set +e
 OUT_14=$(${CDKL} invoke-agentcore "${MCP}" --ws 2>/tmp/cdkl-ws-mcp-stderr; cat /tmp/cdkl-ws-mcp-stderr >&2)
 RC_14=$?
@@ -271,7 +272,7 @@ echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP / AGUI protocols' |
 # invoke succeeds even with a placeholder bearer token. (The verifier's actual
 # scope / claim checks are covered by the unit tests, which sign real RS256
 # tokens against mock JWKS.)
-echo "==> [15/19] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
+echo "==> [15/20] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
 RESULT_15=$(${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s" 2>/dev/null | tail -1)
 echo "    response: ${RESULT_15}"
 echo "${RESULT_15}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -291,7 +292,7 @@ echo "${RESULT_15}" | grep -q '"authorization":"Bearer h.p.s"' || {
 # agent never validates the signature against AWS, it just echoes the header.
 # A second --sigv4 + --bearer-token sub-check confirms the mutually-exclusive
 # gate rejects pre-container.
-echo "==> [16/19] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
+echo "==> [16/20] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
 RESULT_16=$(AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
   AWS_REGION=us-east-1 \
@@ -306,7 +307,7 @@ echo "${RESULT_16}" | grep -q '/us-east-1/bedrock-agentcore/aws4_request' || {
   exit 1
 }
 
-echo "==> [16/19] --sigv4 + --bearer-token together rejected (mutually exclusive)"
+echo "==> [16/20] --sigv4 + --bearer-token together rejected (mutually exclusive)"
 set +e
 OUT_16B=$(${CDKL} invoke-agentcore "${TARGET}" --sigv4 --bearer-token "h.p.s" 2>&1)
 RC_16B=$?
@@ -326,7 +327,7 @@ echo "${OUT_16B}" | grep -q 'mutually exclusive' || {
 # responds (the flag is parsed + threaded into the client call, not silently
 # ignored). The negative sub-check confirms the parser rejects a non-positive
 # value pre-container.
-echo "==> [17/19] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
+echo "==> [17/20] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
 RESULT_17=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 60000 2>/dev/null | tail -1)
 echo "    response: ${RESULT_17}"
 echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
@@ -334,7 +335,7 @@ echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
   exit 1
 }
 
-echo "==> [17/19] --timeout 0 rejected by the parser (positive integer required)"
+echo "==> [17/20] --timeout 0 rejected by the parser (positive integer required)"
 set +e
 OUT_17B=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 0 2>&1)
 RC_17B=$?
@@ -351,7 +352,7 @@ echo "${OUT_17B}" | grep -q 'positive integer' || {
 # Test 19 — A2A protocol runtime: the container serves the Agent2Agent
 # JSON-RPC 2.0 contract at POST / on 9000. With no --event, `cdkl
 # invoke-agentcore` defaults to `agent/getCard` (the agent discovery card).
-echo "==> [18/19] A2aAgent (no --event) runs the JSON-RPC agent/getCard request"
+echo "==> [18/20] A2aAgent (no --event) runs the JSON-RPC agent/getCard request"
 RESULT_19=$(${CDKL} invoke-agentcore "${A2A}" 2>/dev/null)
 echo "    response: ${RESULT_19}"
 echo "${RESULT_19}" | grep -q '"name": "fixture-a2a-agent"' || {
@@ -360,7 +361,7 @@ echo "${RESULT_19}" | grep -q '"name": "fixture-a2a-agent"' || {
 }
 
 # Test 19 — A2A with --event runs the tasks/send method.
-echo "==> [18/19] A2aAgent with --event runs tasks/send"
+echo "==> [18/20] A2aAgent with --event runs tasks/send"
 A2A_EVENT=$(mktemp -t cdkl-a2a-event-XXXX.json)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${A2A_EVENT}"' EXIT
 echo '{"method":"tasks/send","params":{"id":"task-1","message":{"text":"hello a2a"}}}' > "${A2A_EVENT}"
@@ -380,7 +381,7 @@ echo "${RESULT_19B}" | grep -q '"state": "completed"' || {
 # AG-UI events). `cdkl invoke-agentcore` routes through the existing HTTP path
 # and streams each event line to stdout. The agent emits three events in order
 # (RUN_STARTED, MESSAGE_CONTENT, RUN_FINISHED).
-echo "==> [19/19] AguiAgent SSE event stream surfaces RUN_STARTED + MESSAGE_CONTENT + RUN_FINISHED"
+echo "==> [19/20] AguiAgent SSE event stream surfaces RUN_STARTED + MESSAGE_CONTENT + RUN_FINISHED"
 RESULT_20=$(${CDKL} invoke-agentcore "${AGUI}" 2>/dev/null)
 echo "    response (head): $(echo "${RESULT_20}" | head -c 300)..."
 echo "${RESULT_20}" | grep -q '"type":"RUN_STARTED"' || {
@@ -396,5 +397,27 @@ echo "${RESULT_20}" | grep -q '"type":"RUN_FINISHED"' || {
   exit 1
 }
 
+# Test 21 — a CodeConfiguration bundle that DECLARES a dependency
+# (requirements.txt: requests) WITHOUT vendoring it. cdkl runs the bundle
+# as-is (the managed runtime does not install deps at runtime), so it (a) warns
+# up-front with the vendoring recipe and (b) the agent fails to import the
+# missing dep at runtime — exactly as it would on a real deploy. Regression
+# guard for the false-green where the from-source build used to pip-install
+# requirements.txt locally (issue #455), making a non-vendored bundle pass
+# locally but fail deployed.
+echo "==> [20/20] UnvendoredCodeAgent warns + does not auto-install requirements.txt"
+# The agent crashes on import, so it never serves /ping — cdkl waits out its
+# ping deadline (~30s) then errors; `|| true` keeps the assertions in control.
+RESULT_UNVENDORED=$(${CDKL} invoke-agentcore "${UNVENDORED}" 2>&1 || true)
+echo "${RESULT_UNVENDORED}" | grep -q "does not vendor its dependencies" || {
+  echo "FAIL: expected the unvendored-deps warning, got: ${RESULT_UNVENDORED}"
+  exit 1
+}
+echo "${RESULT_UNVENDORED}" | grep -Eq "ModuleNotFoundError|No module named 'requests'" || {
+  echo "FAIL: expected the agent to fail importing the unvendored dep (proving no auto-install), got: ${RESULT_UNVENDORED}"
+  exit 1
+}
+echo "    warned + import failed as on deploy (no auto-install)"
+
 echo ""
-echo "==> All 19 local-invoke-agentcore tests passed"
+echo "==> All 20 local-invoke-agentcore tests passed"


### PR DESCRIPTION
## Summary

Follow-up to #455 / #456. The merged fix made the AgentCore `fromCodeAsset` /
`fromS3` from-source build run the bundle **as-is** (no dependency install) and
warn when a dependency manifest is present without vendored deps. The merged
PR's integ (`local-invoke-agentcore`) only exercised the **stdlib-only
regression** (an agent that runs fine without an install) — it did **not**
exercise the **new behavior path**: a declared-but-unvendored dependency must
warn AND fail at runtime (no auto-install), the false-green that was fixed.

This adds that missing end-to-end coverage.

## Changes

- New fixture bundle `tests/integration/local-invoke-agentcore/code-agent-unvendored/`
  — an agent that imports `requests` (declared in `requirements.txt`) but does
  NOT vendor it.
- New `UnvendoredCodeAgent` `fromCodeAsset` Runtime in the fixture stack.
- New `verify.sh` case `[20/20]`: runs `cdkl invoke-agentcore` against it and
  asserts (a) the `does not vendor its dependencies` warning is emitted, and
  (b) the container fails with `ModuleNotFoundError` — proving cdkl did NOT
  auto-install `requirements.txt` (the old behavior would have installed
  `requests` and the agent would have started). This is exactly the deployed
  failure mode, reproduced locally.

## Test plan

- `/run-integ local-invoke-agentcore` — **20/20** green (the new `[20/20]`
  reported `warned + import failed as on deploy (no auto-install)`); 0 Docker
  orphans.
- `vp run check` / `vp run test` (198 files, 2991 tests) — green.

Refs #455
