### PR TITLE
feat(studio): warm-serve AgentCore HTTP composer + list all protocols (#454 slice 3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -825,13 +825,20 @@ compute-locally category for Lambda + API Gateway).
   (`renderWsConsole` — connect / send-frame / received-frame log) wired
   straight to its ws:// endpoint, with the socket + frame log held in module
   state so a log-driven serve re-render never drops the connection (issue
-  #303); the SAME console renders for an `agentcore-ws` serve (an HTTP / AGUI
-  AgentCore runtime's `/ws` endpoint served by `cdkl start-agentcore` behind a
-  host bridge — the runtime is listed in a second "AgentCore WebSocket" group
-  alongside its single-shot invoke entry, the same dual listing as the
-  ecs / ecs-task split; only HTTP / AGUI runtimes appear there since MCP / A2A
-  have no `/ws`), because the bridge's `ws://` endpoint flows through the same
-  un-proxied `endpoints` path; every composer (invoke + serve) carries a collapsed "All options"
+  #303); the SAME console renders for an `agentcore-ws` serve when the runtime
+  exposes `/ws` (HTTP / AGUI). The `agentcore-ws` serve group (relabeled
+  "AgentCore (serve)", issue #454, since start-agentcore now serves the warm
+  HTTP contract too, not just `/ws`) lists EVERY AgentCore runtime alongside its
+  single-shot invoke entry — the same dual listing as the ecs / ecs-task split —
+  because `cdkl start-agentcore` serves all four protocols warm (slices 1-2).
+  Each serve renders the api/alb-style HTTP request composer against the warm
+  container's contract endpoint, pre-filled with the protocol's `POST` path
+  (`/invocations` for HTTP / AGUI, `/mcp` for MCP, `/` for A2A — carried on the
+  target as `agentCoreContractPath`); HTTP / AGUI runtimes (`agentCoreHasWs`)
+  ADDITIONALLY render the WebSocket console, since the bridge's `ws://` endpoint
+  flows through the same un-proxied `endpoints` path while the http:// contract
+  endpoint is fronted by the capture proxy so a relayed `/invocations` lands on
+  the timeline; every composer (invoke + serve) carries a collapsed "All options"
   `<details>` (`buildAllOptions`) with a raw extra-args input + the
   read-only auto-derived flag catalog from studio-option-catalog, so the
   curated controls handle common flags richly while every other flag the
@@ -958,9 +965,15 @@ compute-locally category for Lambda + API Gateway).
   to the UI are the proxy URLs (slice C2 capture), while `ecs`
   (`start-service`) is pure compute — no capture proxy, just the running
   replicas + their streamed logs. `agentcore-ws` (`start-agentcore`) resolves
-  running on `Server listening on (ws://...)`; its `ws://` endpoint is NOT
-  proxied (the capture-proxy gate is `/^https?:/`), so the browser connects
-  straight to the bridge and the UI renders the WebSocket console. The `ecs` serve's `hostUrl` is set from an
+  running on `Server listening on (<url>)` (`ws://` for HTTP / AGUI, `http://`
+  for MCP / A2A) and has `capturesHttp: true`: a `ws://` endpoint passes
+  straight through (the capture-proxy gate is `/^https?:/`) so the browser
+  connects directly to the bridge for the WebSocket console, while an `http://`
+  endpoint is fronted by the capture proxy so warm-contract requests land on the
+  timeline (issue #454). For HTTP / AGUI the `http://` contract endpoint arrives
+  on a SECOND ready line (`HTTP contract served on http://...`) captured by the
+  spec's `extraEndpointRe`, alongside the `ws://` listen line; MCP / A2A emit
+  only the `http://` listen line. The `ecs` serve's `hostUrl` is set from an
   explicit `--host-port` OR (issue #392) parsed from the child's
   `... published on <ip>:<port> ...` log line when start-service auto-publishes
   / auto-remaps a replica port (`parsePublishedHostEndpoint`, first endpoint

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 
 ### Web console — `cdkl studio`
 
-`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` / `start-cloudfront` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all. A served API Gateway WebSocket API — and an HTTP / AGUI AgentCore runtime's `/ws` endpoint (the `start-agentcore` serve, listed under "AgentCore WebSocket") — get an interactive in-browser WebSocket console (connect / send / receive frames).
+`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` / `start-cloudfront` / `start-agentcore` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all. A `start-agentcore` warm serve (listed under "AgentCore (serve)") gets an in-browser HTTP request composer against the warm container's contract; an HTTP / AGUI runtime's `/ws` endpoint — and a served API Gateway WebSocket API — additionally get an interactive in-browser WebSocket console (connect / send / receive frames).
 
 ```bash
 cdkl studio                                  # open the console (launches your browser)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -880,8 +880,9 @@ cdkl start-agentcore MyStack/Agent --from-cfn-stack
 
 `--watch` (reload on CDK source changes) is a planned follow-up; for now,
 restart the command to pick up local edits. `start-agentcore` is also runnable
-from `cdkl studio` (the `agentcore-ws` serve kind) with an in-browser WebSocket
-console.
+from `cdkl studio` (the `agentcore-ws` serve kind, listed as "AgentCore
+(serve)") with an in-browser HTTP request composer against the warm contract
+plus, for HTTP / AGUI runtimes, an interactive WebSocket console.
 
 ## `cdkl start-api` (long-running local API server)
 
@@ -1830,14 +1831,17 @@ The console is a three-pane layout:
   serve targets get a `[Start]` / `[Stop]` control with a `running ● :port`
   indicator (an ECS service shows `running` with no port — it is pure
   compute with no host endpoint; only servable ECS *services* are runnable,
-  not task definitions). An HTTP / AGUI AgentCore runtime additionally
-  appears in an **AgentCore WebSocket** group (the `agentcore-ws` serve kind):
-  a `[Start]` / `[Stop]` control that runs `cdkl start-agentcore` and, once
-  running, renders an interactive WebSocket console wired to the served `/ws`
-  bridge — the same console a served API Gateway WebSocket API gets. The dual
-  listing (invoke once vs hold a live session) mirrors the ECS service /
-  task-definition split; MCP / A2A runtimes have no `/ws` and are not listed
-  there.
+  not task definitions). Every AgentCore runtime additionally appears in an
+  **AgentCore (serve)** group (the `agentcore-ws` serve kind): a `[Start]` /
+  `[Stop]` control that runs `cdkl start-agentcore`, which keeps the container
+  warm and serves its native protocol contract. Once running, the serve renders
+  an HTTP request composer against the warm container's contract, pre-filled
+  with the protocol's `POST` path (`/invocations` for HTTP / AGUI, `/mcp` for
+  MCP, `/` for A2A); an HTTP / AGUI runtime ADDITIONALLY renders an interactive
+  WebSocket console wired to the served `/ws` bridge — the same console a served
+  API Gateway WebSocket API gets (MCP / A2A have no `/ws`, so no console). The
+  dual listing (invoke once vs hold a warm session) mirrors the ECS service /
+  task-definition split.
 - **Workspace** — the composer for the selected target (event JSON for a
   Lambda or AgentCore invoke; start / stop for a serve). An **Options**
   section exposes the per-target run options as controls — a checkbox per

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -159,6 +159,16 @@ interface ServeKindSpec {
   readyRe: RegExp;
   /** Front each HTTP endpoint with a capture proxy (api / alb yes, ecs no). */
   capturesHttp: boolean;
+  /**
+   * An ADDITIONAL endpoint line (capture group 1 = URL) emitted alongside the
+   * `readyRe` line. Used by the `agentcore-ws` serve, which prints both `Server
+   * listening on ws://...` (the readiness signal + WebSocket-console endpoint)
+   * AND `HTTP contract served on http://...` (the warm container's HTTP
+   * contract): the ws:// endpoint passes straight through for the console while
+   * the http:// endpoint is fronted by the capture proxy so `/invocations`
+   * requests land on the timeline. Optional — only `agentcore-ws` sets it.
+   */
+  extraEndpointRe?: RegExp;
 }
 
 /**
@@ -216,18 +226,22 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     capturesHttp: true,
   },
   'agentcore-ws': {
-    // start-agentcore boots an AgentCore Runtime container and serves its
-    // bidirectional /ws endpoint behind a host bridge (issue start-agentcore).
-    // It binds an OS-assigned bridge port with --port 0 and logs `Server
-    // listening on ws://...`. The endpoint is ws:// so it is NOT proxied
-    // (the capture-proxy gate is /^https?:/); the browser connects directly
-    // to the bridge, which renders the same WebSocket console an API Gateway
-    // WebSocket API gets. readyRe anchors on the ws:// scheme so a stray boot
-    // log line cannot flip the serve to running.
+    // start-agentcore boots an AgentCore Runtime container ONCE, keeps it warm,
+    // and serves its native protocol contract on one host port (issue #454). It
+    // binds an OS-assigned port with --port 0 and prints `Server listening on
+    // <url>` — `ws://...` for HTTP / AGUI (which ALSO serve the /ws bridge),
+    // `http://...` for MCP / A2A. readyRe captures whichever scheme so all four
+    // protocols flip to running. capturesHttp is TRUE: a ws:// endpoint passes
+    // straight through (the capture-proxy gate is /^https?:/) for the WebSocket
+    // console, while an http:// endpoint is fronted by the capture proxy so
+    // contract requests land on the timeline. For HTTP / AGUI the listen line
+    // is ws://, so the http:// contract endpoint arrives on a SECOND line
+    // (`HTTP contract served on http://...`) — extraEndpointRe captures it.
     command: 'start-agentcore',
     portArgs: ['--port', '0', '--host', '127.0.0.1'],
-    readyRe: /Server listening on (ws:\/\/\S+)/,
-    capturesHttp: false,
+    readyRe: /Server listening on (\S+)/,
+    capturesHttp: true,
+    extraEndpointRe: /HTTP contract served on (https?:\/\/\S+)/,
   },
 };
 
@@ -557,6 +571,14 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         // m[1] is the endpoint URL for api / alb; undefined for ecs (no
         // capture group) — a ready line with no host endpoint.
         if (m) void onReady(m[1]);
+        // An additional endpoint line (agentcore-ws: the http:// contract
+        // alongside the ws:// listen line). It does NOT flip the serve to
+        // running on its own (the readyRe line already did, or will) — onReady
+        // appends + re-emits the endpoint, fronting it with the capture proxy.
+        if (spec.extraEndpointRe) {
+          const me = spec.extraEndpointRe.exec(line);
+          if (me) void onReady(me[1]);
+        }
         // An `ecs` serve auto-publishes its replica host port(s) (issue #392);
         // surface the FIRST one as `hostUrl` so the request composer fires —
         // unless an explicit `--host-port` already set it. The publish line can

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -49,6 +49,20 @@ export interface StudioTarget {
    * empty when the ALB fronts no pinned service.
    */
   backingPinnedServices?: { id: string; label: string }[];
+  /**
+   * Set on an `agentcore-ws` serve entry: whether the runtime exposes a `/ws`
+   * WebSocket endpoint (HTTP / AGUI yes; MCP / A2A no). `cdkl start-agentcore`
+   * serves all four protocols (issue #454), so the serve group lists every
+   * runtime — this flag decides only whether the serve workspace ALSO renders
+   * the interactive WebSocket console.
+   */
+  agentCoreHasWs?: boolean;
+  /**
+   * Set on an `agentcore-ws` serve entry: the POST path the runtime's protocol
+   * contract is served on (`/invocations` / `/mcp` / `/`). Seeds the serve's
+   * HTTP request composer so a one-click invoke hits the right endpoint.
+   */
+  agentCoreContractPath?: string;
 }
 
 /** A category of targets, grouped by the studio kind that runs them. */
@@ -91,16 +105,24 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
     { kind: 'ecs', title: 'ECS Services', entries: map(listing.ecsServices, { servable: true }) },
     { kind: 'ecs-task', title: 'ECS Task Definitions', entries: map(listing.ecsTaskDefinitions) },
     { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
-    // The same runtimes that have a /ws endpoint (HTTP / AGUI — MCP / A2A
-    // don't) ALSO appear as an `agentcore-ws` serve group: a [Start]/[Stop]
-    // control that runs `cdkl start-agentcore` and renders an interactive
-    // WebSocket console (like the API Gateway WebSocket console). The dual
-    // listing mirrors the ecs / ecs-task split — invoke once vs hold a live
-    // session are genuinely different operations.
+    // Every AgentCore runtime ALSO appears as an `agentcore-ws` serve group: a
+    // [Start]/[Stop] control that runs `cdkl start-agentcore`, which keeps the
+    // container warm and serves its native protocol contract (issue #454) — all
+    // four protocols (HTTP/AGUI POST /invocations, MCP POST /mcp, A2A POST /),
+    // not just /ws. The serve workspace renders an HTTP request composer for the
+    // contract; HTTP / AGUI runtimes ALSO get the interactive WebSocket console
+    // (`agentCoreHasWs`). The dual listing (invoke vs serve) mirrors the ecs /
+    // ecs-task split — invoke once vs hold a warm session are different ops.
     {
       kind: 'agentcore-ws',
-      title: 'AgentCore WebSocket',
-      entries: map(listing.agentCoreRuntimes.filter((e) => e.agentCoreHasWs)),
+      title: 'AgentCore (serve)',
+      entries: map(listing.agentCoreRuntimes).map((t, i) => {
+        const src = listing.agentCoreRuntimes[i];
+        if (src?.agentCoreHasWs !== undefined) t.agentCoreHasWs = src.agentCoreHasWs;
+        if (src?.agentCoreContractPath !== undefined)
+          t.agentCoreContractPath = src.agentCoreContractPath;
+        return t;
+      }),
     },
     { kind: 'alb', title: 'Application Load Balancers', entries: map(listing.loadBalancers) },
     // CloudFront distributions are a serve target (start-cloudfront -> Start),

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -1343,10 +1343,15 @@ const STUDIO_SCRIPT = `
       ws.appendChild(renderRequestComposer(id, httpBase, captured, composerDefaults));
     }
 
-    // A served WebSocket API exposes a ws:// endpoint — attach a WebSocket
-    // console so the browser can connect + exchange frames (issue #303).
+    // A served WebSocket endpoint (an API Gateway WebSocket API, or an HTTP /
+    // AGUI AgentCore runtime's /ws bridge) gets a WebSocket console so the
+    // browser can connect + exchange frames (issue #303). For an agentcore
+    // serve the console is gated on agentCoreHasWs (HTTP / AGUI expose /ws;
+    // MCP / A2A do not — issue #454); the ws:// endpoint the serve advertises
+    // already encodes that, so this guard is belt-and-suspenders with the spec.
     const wsEndpoint = running ? (st.endpoints || []).find((u) => /^wss?:/.test(u)) : null;
-    if (wsEndpoint) {
+    const wsServable = !meta || meta.kind !== 'agentcore-ws' || meta.agentCoreHasWs === true;
+    if (wsEndpoint && wsServable) {
       ws.appendChild(renderWsConsole(wsEndpoint));
     }
 

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -352,8 +352,8 @@ const STUDIO_CSS = `
 `;
 
 const STUDIO_SCRIPT = `
-  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS Service', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore', 'agentcore-ws': 'AgentCore WS' };
-  const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task', 'cloudfront', 'agentcore-ws']; // long-running serve targets (ecs-task = run-task; agentcore-ws = start-agentcore /ws bridge)
+  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS Service', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore', 'agentcore-ws': 'AgentCore serve' };
+  const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task', 'cloudfront', 'agentcore-ws']; // long-running serve targets (ecs-task = run-task; agentcore-ws = start-agentcore warm serve)
   const INVOKE_KINDS = ['lambda', 'agentcore']; // single-shot invoke targets (event composer)
   const rowsById = new Map();      // invocationId -> timeline row element
   const invById = new Map();       // invocationId -> latest invocation event
@@ -894,6 +894,8 @@ const STUDIO_SCRIPT = `
                 kind: group.kind,
                 pinned: entry.pinned === true,
                 backingPinnedServices: entry.backingPinnedServices || [],
+                agentCoreHasWs: entry.agentCoreHasWs === true,
+                agentCoreContractPath: entry.agentCoreContractPath || null,
               });
               updateServeRow(entry.id);
             }
@@ -1331,7 +1333,14 @@ const STUDIO_SCRIPT = `
       : null;
     if (httpBase) {
       const captured = (st.endpoints || []).indexOf(httpBase) >= 0;
-      ws.appendChild(renderRequestComposer(id, httpBase, captured));
+      // An agentcore serve's contract is POST-only on a fixed path
+      // (/invocations | /mcp | /), so seed the composer with that method + path
+      // instead of the generic GET / (issue #454). Other serves default to GET /.
+      const composerDefaults =
+        meta && meta.kind === 'agentcore-ws'
+          ? { method: 'POST', path: meta.agentCoreContractPath || '/invocations' }
+          : null;
+      ws.appendChild(renderRequestComposer(id, httpBase, captured, composerDefaults));
     }
 
     // A served WebSocket API exposes a ws:// endpoint — attach a WebSocket
@@ -1552,7 +1561,7 @@ const STUDIO_SCRIPT = `
     return sec;
   }
 
-  function renderRequestComposer(id, baseUrl, captured) {
+  function renderRequestComposer(id, baseUrl, captured, defaults) {
     const sec = el('div', 'section req-composer');
     sec.appendChild(el('h3', null, 'Request'));
     const row = el('div', 'req-row');
@@ -1562,9 +1571,12 @@ const STUDIO_SCRIPT = `
       o.value = m;
       method.appendChild(o);
     });
+    // Per-kind defaults (issue #454): an agentcore serve seeds POST + the
+    // protocol contract path; otherwise GET / (the generic default).
+    if (defaults && defaults.method) method.value = defaults.method;
     row.appendChild(method);
     const path = el('input', 'req-path');
-    path.value = '/';
+    path.value = defaults && defaults.path ? defaults.path : '/';
     path.placeholder = '/path?query';
     row.appendChild(path);
     sec.appendChild(row);

--- a/src/local/target-lister.ts
+++ b/src/local/target-lister.ts
@@ -44,11 +44,20 @@ export interface TargetEntry {
   /**
    * For `agentCoreRuntimes` entries only: whether the runtime exposes a
    * bidirectional `/ws` WebSocket endpoint (HTTP / AGUI protocols do; MCP /
-   * A2A do not). Drives the studio `agentcore-ws` serve group, which only
-   * lists runtimes `cdkl start-agentcore` can serve. Omitted for non-agentcore
-   * targets.
+   * A2A do not). `cdkl start-agentcore` serves ALL four protocols (issue #454),
+   * so the studio serve group lists every runtime — this marker decides only
+   * whether to ALSO render the interactive WebSocket console (HTTP / AGUI yes;
+   * MCP / A2A no). Omitted for non-agentcore targets.
    */
   agentCoreHasWs?: boolean;
+  /**
+   * For `agentCoreRuntimes` entries only: the POST path the runtime's protocol
+   * contract is served on (`/invocations` for HTTP / AGUI, `/mcp` for MCP, `/`
+   * for A2A — matching `resolveAgentCoreServePlan`). The studio serve's HTTP
+   * request composer pre-fills `POST <this>` so a one-click invoke hits the
+   * right endpoint. Omitted for non-agentcore targets.
+   */
+  agentCoreContractPath?: string;
 }
 
 /**
@@ -123,10 +132,14 @@ function scanByType(stacks: readonly StackInfo[], type: string): TargetEntry[] {
 /**
  * Enumerate `AWS::BedrockAgentCore::Runtime` targets, marking each with
  * {@link TargetEntry.agentCoreHasWs} — true for HTTP / AGUI runtimes (which
- * expose a `/ws` WebSocket endpoint), false for MCP / A2A (which do not). The
- * marker lets the studio `agentcore-ws` serve group list only the runtimes
- * `cdkl start-agentcore` can serve. The protocol is read the same way the
- * resolver reads it (`Properties.ProtocolConfiguration`, default HTTP).
+ * expose a `/ws` WebSocket endpoint), false for MCP / A2A (which do not) — and
+ * {@link TargetEntry.agentCoreContractPath}, the POST path the runtime's
+ * protocol contract is served on (`/invocations` / `/mcp` / `/`). `cdkl
+ * start-agentcore` serves every protocol (issue #454), so the studio serve
+ * group lists every runtime; the `hasWs` marker decides only whether to render
+ * the WebSocket console too, and the contract path seeds the HTTP composer. The
+ * protocol is read the same way the resolver reads it
+ * (`Properties.ProtocolConfiguration`, default HTTP).
  */
 function scanAgentCoreRuntimes(stacks: readonly StackInfo[]): TargetEntry[] {
   const entries: TargetEntry[] = [];
@@ -140,6 +153,14 @@ function scanAgentCoreRuntimes(stacks: readonly StackInfo[]): TargetEntry[] {
       ];
       entry.agentCoreHasWs =
         protocol !== AGENTCORE_MCP_PROTOCOL && protocol !== AGENTCORE_A2A_PROTOCOL;
+      // The contract POST path, matching `resolveAgentCoreServePlan`: MCP -> /mcp,
+      // A2A -> /, everything else (HTTP / AGUI) -> /invocations.
+      entry.agentCoreContractPath =
+        protocol === AGENTCORE_MCP_PROTOCOL
+          ? '/mcp'
+          : protocol === AGENTCORE_A2A_PROTOCOL
+            ? '/'
+            : '/invocations';
       entries.push(entry);
     }
   }

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -1092,6 +1092,37 @@ curl -fsS "${URL}/api/running" -o "${BODY_FILE}"
 if ! grep -qF "${ACWS_URL}" "${BODY_FILE}"; then
   echo "FAIL: /api/running did not list the agentcore-ws ws:// endpoint"; cat "${BODY_FILE}"; exit 1
 fi
+
+# Issue #454: start-agentcore now keeps the container WARM and serves its HTTP
+# contract (POST /invocations) too, not just /ws — and studio fronts that
+# http:// endpoint with a capture proxy (alongside the un-proxied ws://). Assert
+# the http:// endpoint is exposed and that a relayed POST /invocations hits the
+# warm container through the proxy (so it lands on the timeline). The agent
+# echoes the request body; the bridge injects a session id.
+ACWS_HTTP_EP=$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "${BODY_FILE}" | head -1 || true)
+if [[ -z "${ACWS_HTTP_EP}" ]]; then
+  echo "FAIL: /api/running did not list the agentcore-ws http:// contract endpoint"; cat "${BODY_FILE}"; exit 1
+fi
+echo "    OK: agentcore-ws http:// contract endpoint exposed at ${ACWS_HTTP_EP}"
+ACWS_REQ_FILE=$(mktemp)
+ACWS_REQ_HTTP=$(curl -s -o "${ACWS_REQ_FILE}" -w '%{http_code}' --max-time 60 \
+  -X POST "${URL}/api/request" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"${AC_WS_TARGET}\",\"method\":\"POST\",\"path\":\"/invocations\",\"body\":\"{\\\"marker\\\":\\\"studio-454-http\\\"}\"}" || true)
+if [[ "${ACWS_REQ_HTTP}" != "200" ]]; then
+  echo "FAIL: /api/request to /invocations returned HTTP ${ACWS_REQ_HTTP}"; cat "${ACWS_REQ_FILE}"; rm -f "${ACWS_REQ_FILE}"; exit 1
+fi
+# The relay response carries the agent's echo of the body + the injected session id.
+if ! grep -qF 'studio-454-http' "${ACWS_REQ_FILE}"; then
+  echo "FAIL: warm /invocations response did not echo the request body"; cat "${ACWS_REQ_FILE}"; rm -f "${ACWS_REQ_FILE}"; exit 1
+fi
+rm -f "${ACWS_REQ_FILE}"
+echo "    OK: warm POST /invocations through the studio capture proxy echoed the body"
+# It landed on the timeline (the capture proxy emitted invocation events).
+curl -fsS "${URL}/api/history" -o "${BODY_FILE}"
+if ! grep -qF '/invocations' "${BODY_FILE}"; then
+  echo "FAIL: the relayed /invocations request did not land on the timeline"; head -c 2000 "${BODY_FILE}"; exit 1
+fi
+echo "    OK: warm /invocations request captured on the timeline"
 # Header-less client (the browser path) drives the agent's /ws REPL through the
 # bridge; asserts the bridge-injected session-id + a frame round-trip.
 cat > "$(pwd)/.studio-agentcore-ws-client.mjs" <<'NODE'
@@ -1869,4 +1900,4 @@ STUDIO_PID=""
 rm -f "${LOG_FILE2}" "${RUN_FILE2}"
 
 echo ""
-echo "==> local-studio test passed (gate + stack-filter + custom-resource-exclusion + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + reinvoke + agentcore-invoke + agentcore-ws + api/alb/ecs serve + image-override-rebuild + alb-image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"
+echo "==> local-studio test passed (gate + stack-filter + custom-resource-exclusion + watch-mode + boot + UI + all-options-catalog + image-override-picker + targets + SSE + invoke + reinvoke + agentcore-invoke + agentcore-ws + agentcore-warm-http-contract + api/alb/ecs serve + image-override-rebuild + alb-image-override-rebuild + request-composer + ws-console + request capture + history/log-search + per-target-options + raw-args + session-config + flag-threading + shutdown)"

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -153,7 +153,7 @@ describe('createStudioServeManager', () => {
     expect(serves[1].endpoints).toEqual([PROXIED]);
   });
 
-  it('spawns `cdkl start-agentcore <target> --port 0` and surfaces the ws:// endpoint un-proxied', async () => {
+  it('serves an HTTP/AGUI agentcore runtime: ws:// un-proxied + http:// contract proxied (issue #454)', async () => {
     const bus = new StudioEventBus();
     const { serves } = collect(bus);
     const child = makeFakeChild();
@@ -170,21 +170,66 @@ describe('createStudioServeManager', () => {
     });
 
     const p = mgr.start({ targetId: 'MyAgent', kind: 'agentcore-ws' });
+    // start-agentcore prints BOTH lines for HTTP / AGUI: the ws:// listen line
+    // (readiness + WebSocket-console endpoint) and the http:// contract line.
     child.stdout.emit(
       'data',
       'Server listening on ws://127.0.0.1:49160/ws  (MyAgent (AgentCore WebSocket))\n'
     );
     const state = await p;
+    // The http:// contract endpoint arrives on a second line; let its async
+    // proxy startup settle before asserting endpoints.
+    child.stdout.emit(
+      'data',
+      'HTTP contract served on http://127.0.0.1:51234 — POST http://127.0.0.1:51234/invocations, GET http://127.0.0.1:51234/ping\n'
+    );
+    await new Promise((r) => setTimeout(r, 0));
 
     const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
     expect(argv.slice(1, 6)).toEqual(['start-agentcore', 'MyAgent', '--port', '0', '--host']);
 
     expect(state.status).toBe('running');
-    // ws:// endpoints are NOT proxied (the capture-proxy gate is /^https?:/),
-    // so the browser connects straight to the bridge.
-    expect(state.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
-    expect(fp.upstreams).toEqual([]);
-    expect(serves.map((s) => s.status)).toEqual(['starting', 'running']);
+    // ws:// passes straight through (the capture-proxy gate is /^https?:/) so the
+    // browser connects directly to the bridge; http:// is fronted by the capture
+    // proxy so /invocations requests land on the timeline.
+    const live = mgr.list().find((s) => s.targetId === 'MyAgent');
+    expect(live?.endpoints).toEqual(['ws://127.0.0.1:49160/ws', PROXIED]);
+    expect(fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+    expect(serves.map((s) => s.status)).toEqual(['starting', 'running', 'running']);
+  });
+
+  it('serves an MCP/A2A agentcore runtime: the http:// listen line is proxied, no ws:// (issue #454)', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({ targetId: 'McpAgent', kind: 'agentcore-ws' });
+    // MCP / A2A have no /ws: the listen line is http:// (proxied), and the
+    // protocol contract line (`MCP contract served on http://...<path>`) is NOT
+    // an extra endpoint (it carries a path — the listen line is the base).
+    child.stdout.emit('data', 'Server listening on http://127.0.0.1:51234  (McpAgent)\n');
+    child.stdout.emit(
+      'data',
+      'MCP contract served on http://127.0.0.1:51234/mcp — POST http://127.0.0.1:51234/mcp\n'
+    );
+    const state = await p;
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(state.status).toBe('running');
+    // Exactly one endpoint — the proxied http:// base. No ws://, no double-proxy
+    // from the contract-path line.
+    const live = mgr.list().find((s) => s.targetId === 'McpAgent');
+    expect(live?.endpoints).toEqual([PROXIED]);
+    expect(fp.upstreams).toEqual(['http://127.0.0.1:51234']);
   });
 
   it('spawns the serve child with CDKL_LOG_STREAM=stdout so its logs are single-stream (issue #403)', async () => {

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -331,7 +331,7 @@ describe('toStudioTargetGroups', () => {
       'ECS Services',
       'ECS Task Definitions',
       'AgentCore Runtimes',
-      'AgentCore WebSocket',
+      'AgentCore (serve)',
       'Application Load Balancers',
       'CloudFront Distributions',
     ]);
@@ -351,21 +351,49 @@ describe('toStudioTargetGroups', () => {
     expect(groups[7].entries).toEqual([{ id: 'S/Dist', qualifiedId: 'S:Dist' }]);
   });
 
-  it('lists only WS-capable runtimes in the agentcore-ws serve group', () => {
+  it('lists ALL runtimes in the agentcore serve group, carrying hasWs + contract path', () => {
+    // start-agentcore serves all four protocols warm (issue #454), so the serve
+    // group lists every runtime — not just the /ws-capable ones. The per-entry
+    // agentCoreHasWs flag (decides whether to ALSO render the WS console) and
+    // agentCoreContractPath (seeds the HTTP composer) ride along.
     const listing: TargetListing = {
       ...emptyListing(),
       agentCoreRuntimes: [
-        { qualifiedId: 'S:Http', displayPath: 'S/Http', agentCoreHasWs: true },
-        { qualifiedId: 'S:Mcp', displayPath: 'S/Mcp', agentCoreHasWs: false },
+        {
+          qualifiedId: 'S:Http',
+          displayPath: 'S/Http',
+          agentCoreHasWs: true,
+          agentCoreContractPath: '/invocations',
+        },
+        {
+          qualifiedId: 'S:Mcp',
+          displayPath: 'S/Mcp',
+          agentCoreHasWs: false,
+          agentCoreContractPath: '/mcp',
+        },
+        {
+          qualifiedId: 'S:A2a',
+          displayPath: 'S/A2a',
+          agentCoreHasWs: false,
+          agentCoreContractPath: '/',
+        },
       ],
     };
     const groups = toStudioTargetGroups(listing);
     const invoke = groups.find((g) => g.kind === 'agentcore');
-    const wsServe = groups.find((g) => g.kind === 'agentcore-ws');
-    // Both runtimes are invoke-able...
-    expect(invoke?.entries.map((e) => e.id)).toEqual(['S/Http', 'S/Mcp']);
-    // ...but only the HTTP runtime (agentCoreHasWs) is WS-servable.
-    expect(wsServe?.entries.map((e) => e.id)).toEqual(['S/Http']);
+    const serve = groups.find((g) => g.kind === 'agentcore-ws');
+    // Both invoke and serve groups list every runtime.
+    expect(invoke?.entries.map((e) => e.id)).toEqual(['S/Http', 'S/Mcp', 'S/A2a']);
+    expect(serve?.entries.map((e) => e.id)).toEqual(['S/Http', 'S/Mcp', 'S/A2a']);
+    // The serve entries carry hasWs (HTTP yes, MCP / A2A no) + the contract path.
+    expect(serve?.entries.map((e) => e.agentCoreHasWs)).toEqual([true, false, false]);
+    expect(serve?.entries.map((e) => e.agentCoreContractPath)).toEqual([
+      '/invocations',
+      '/mcp',
+      '/',
+    ]);
+    // The invoke group does NOT carry the serve-only fields.
+    expect(invoke?.entries.every((e) => e.agentCoreHasWs === undefined)).toBe(true);
   });
 
   it('falls back to the qualified id when no display path exists', () => {

--- a/tests/unit/local/studio-ui-agentcore-serve.test.ts
+++ b/tests/unit/local/studio-ui-agentcore-serve.test.ts
@@ -19,6 +19,7 @@ const EXPOSE = `
 window.__t = {
   renderServeWorkspace: renderServeWorkspace,
   renderRequestComposer: renderRequestComposer,
+  loadTargets: loadTargets,
   serveState: serveState,
   serveMeta: serveMeta,
 };
@@ -34,8 +35,9 @@ interface AcHarness extends StudioHarness {
         captured: boolean,
         defaults?: { method?: string; path?: string }
       ) => HTMLElement;
+      loadTargets: () => Promise<void>;
       serveState: Map<string, unknown>;
-      serveMeta: Map<string, unknown>;
+      serveMeta: Map<string, { agentCoreHasWs?: boolean; agentCoreContractPath?: string | null }>;
     };
   };
 }
@@ -121,5 +123,55 @@ describe('studio agentcore-ws serve workspace (issue #454)', () => {
     const sec = harness.window.__t.renderRequestComposer('S/Api', 'http://127.0.0.1:9999', true);
     expect((sec.querySelector('.req-method') as HTMLSelectElement).value).toBe('GET');
     expect((sec.querySelector('.req-path') as HTMLInputElement).value).toBe('/');
+  });
+
+  it('loadTargets copies agentCoreHasWs + agentCoreContractPath from the target JSON into serveMeta', async () => {
+    // Covers the entry -> serveMeta hop the direct-seed tests above bypass: the
+    // `/api/targets` projection carries agentCoreHasWs + agentCoreContractPath,
+    // and the targets-pane render must thread them onto serveMeta so the serve
+    // workspace can gate the WS console + seed the composer path per protocol.
+    harness = createStudioHarness({ epilogue: EXPOSE }) as AcHarness;
+    const win = harness.window as AcHarness['window'];
+    (win as unknown as { fetch: unknown }).fetch = (url: string) => {
+      if (url === '/api/targets') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              groups: [
+                {
+                  kind: 'agentcore-ws',
+                  title: 'AgentCore (serve)',
+                  entries: [
+                    {
+                      id: 'S/Http',
+                      qualifiedId: 'S:Http',
+                      agentCoreHasWs: true,
+                      agentCoreContractPath: '/invocations',
+                    },
+                    {
+                      id: 'S/Mcp',
+                      qualifiedId: 'S:Mcp',
+                      agentCoreHasWs: false,
+                      agentCoreContractPath: '/mcp',
+                    },
+                  ],
+                },
+              ],
+              dockerfiles: [],
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    };
+
+    await win.__t.loadTargets();
+
+    const http = win.__t.serveMeta.get('S/Http');
+    const mcp = win.__t.serveMeta.get('S/Mcp');
+    expect(http?.agentCoreHasWs).toBe(true);
+    expect(http?.agentCoreContractPath).toBe('/invocations');
+    expect(mcp?.agentCoreHasWs).toBe(false);
+    expect(mcp?.agentCoreContractPath).toBe('/mcp');
   });
 });

--- a/tests/unit/local/studio-ui-agentcore-serve.test.ts
+++ b/tests/unit/local/studio-ui-agentcore-serve.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach } from 'vite-plus/test';
+import { createStudioHarness, type StudioHarness } from './studio-ui-harness.js';
+
+/**
+ * jsdom coverage for the studio `agentcore-ws` serve workspace after issue #454
+ * generalized `cdkl start-agentcore` from a /ws-only bridge to a warm serve of
+ * the agent's native protocol contract. The serve workspace must now render the
+ * api/alb-style HTTP request composer for the contract (`POST /invocations` |
+ * `POST /mcp` | `POST /`), and ADDITIONALLY the WebSocket console only for
+ * HTTP / AGUI runtimes (which expose `/ws`) — MCP / A2A get the composer but no
+ * console.
+ *
+ * The serve workspace reads module-state `serveState` / `serveMeta`, so the
+ * epilogue exposes those maps (and `renderServeWorkspace`) and the test seeds a
+ * running serve before rendering into the page's `#workspace`.
+ */
+
+const EXPOSE = `
+window.__t = {
+  renderServeWorkspace: renderServeWorkspace,
+  renderRequestComposer: renderRequestComposer,
+  serveState: serveState,
+  serveMeta: serveMeta,
+};
+`;
+
+interface AcHarness extends StudioHarness {
+  window: StudioHarness['window'] & {
+    __t: {
+      renderServeWorkspace: (id: string, err?: string) => void;
+      renderRequestComposer: (
+        id: string,
+        baseUrl: string,
+        captured: boolean,
+        defaults?: { method?: string; path?: string }
+      ) => HTMLElement;
+      serveState: Map<string, unknown>;
+      serveMeta: Map<string, unknown>;
+    };
+  };
+}
+
+let harness: AcHarness;
+
+afterEach(() => {
+  harness?.close();
+});
+
+/** Seed a running agentcore-ws serve and render its workspace into #workspace. */
+function renderServe(opts: {
+  id: string;
+  endpoints: string[];
+  hasWs: boolean;
+  contractPath: string;
+}): HTMLElement {
+  harness = createStudioHarness({ epilogue: EXPOSE }) as AcHarness;
+  const t = harness.window.__t;
+  t.serveMeta.set(opts.id, {
+    dot: harness.document.createElement('span'),
+    btnSlot: harness.document.createElement('span'),
+    kind: 'agentcore-ws',
+    pinned: false,
+    backingPinnedServices: [],
+    agentCoreHasWs: opts.hasWs,
+    agentCoreContractPath: opts.contractPath,
+  });
+  t.serveState.set(opts.id, { status: 'running', endpoints: opts.endpoints });
+  t.renderServeWorkspace(opts.id);
+  return harness.document.getElementById('workspace') as HTMLElement;
+}
+
+describe('studio agentcore-ws serve workspace (issue #454)', () => {
+  it('renders the HTTP composer (POST + contract path) AND the WS console for an HTTP/AGUI runtime', () => {
+    const ws = renderServe({
+      id: 'S/HttpAgent',
+      endpoints: ['ws://127.0.0.1:49160/ws', 'http://127.0.0.1:61234'],
+      hasWs: true,
+      contractPath: '/invocations',
+    });
+
+    const composer = ws.querySelector('.req-composer');
+    expect(composer).not.toBeNull();
+    // The composer is pre-filled with the contract's POST method + path so a
+    // one-click invoke hits the warm container's /invocations endpoint.
+    expect((composer!.querySelector('.req-method') as HTMLSelectElement).value).toBe('POST');
+    expect((composer!.querySelector('.req-path') as HTMLInputElement).value).toBe('/invocations');
+
+    // HTTP / AGUI expose /ws, so the interactive WebSocket console renders too.
+    expect(ws.querySelector('.ws-console')).not.toBeNull();
+  });
+
+  it('renders the HTTP composer (POST /mcp) but NO WS console for an MCP runtime', () => {
+    const ws = renderServe({
+      id: 'S/McpAgent',
+      endpoints: ['http://127.0.0.1:61234'],
+      hasWs: false,
+      contractPath: '/mcp',
+    });
+
+    const composer = ws.querySelector('.req-composer');
+    expect(composer).not.toBeNull();
+    expect((composer!.querySelector('.req-method') as HTMLSelectElement).value).toBe('POST');
+    expect((composer!.querySelector('.req-path') as HTMLInputElement).value).toBe('/mcp');
+
+    // MCP has no /ws — the console must NOT render (no ws:// endpoint).
+    expect(ws.querySelector('.ws-console')).toBeNull();
+  });
+
+  it('renderRequestComposer seeds method + path from the defaults arg (A2A POST /)', () => {
+    harness = createStudioHarness({ epilogue: EXPOSE }) as AcHarness;
+    const sec = harness.window.__t.renderRequestComposer('S/A2a', 'http://127.0.0.1:61234', true, {
+      method: 'POST',
+      path: '/',
+    });
+    expect((sec.querySelector('.req-method') as HTMLSelectElement).value).toBe('POST');
+    expect((sec.querySelector('.req-path') as HTMLInputElement).value).toBe('/');
+  });
+
+  it('renderRequestComposer with no defaults stays GET / (other serve kinds)', () => {
+    harness = createStudioHarness({ epilogue: EXPOSE }) as AcHarness;
+    const sec = harness.window.__t.renderRequestComposer('S/Api', 'http://127.0.0.1:9999', true);
+    expect((sec.querySelector('.req-method') as HTMLSelectElement).value).toBe('GET');
+    expect((sec.querySelector('.req-path') as HTMLInputElement).value).toBe('/');
+  });
+});

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -29,12 +29,14 @@ describe('renderStudioHtml', () => {
     expect(html).not.toMatch(/__OPTION_SPECS__ = [^;]*<\//);
   });
 
-  it('treats agentcore-ws as a serve kind with the AgentCore WS label', () => {
+  it('treats agentcore-ws as a serve kind with the AgentCore serve label', () => {
     const html = renderStudioHtml('MyStack', 'cdkl');
-    // agentcore-ws is a serve kind (Start/Stop + WebSocket console), distinct
-    // from the single-shot agentcore invoke kind.
+    // agentcore-ws is a serve kind (Start/Stop + HTTP composer + WebSocket
+    // console for HTTP/AGUI), distinct from the single-shot agentcore invoke
+    // kind. The label is "AgentCore serve" since start-agentcore now serves the
+    // warm HTTP contract too, not just /ws (issue #454).
     expect(html).toContain("'agentcore-ws'");
-    expect(html).toContain("'agentcore-ws': 'AgentCore WS'");
+    expect(html).toContain("'agentcore-ws': 'AgentCore serve'");
     // Its per-run serve options are serialized too.
     expect(html).toContain('"--no-verify-auth"');
   });
@@ -212,7 +214,7 @@ describe('renderStudioHtml', () => {
     expect(html).toContain("fetch('/api/request'");
     // Gated on a running serve having an http base URL (proxy endpoint or the
     // ecs --host-port host URL).
-    expect(html).toContain('renderRequestComposer(id, httpBase, captured)');
+    expect(html).toContain('renderRequestComposer(id, httpBase, captured, composerDefaults)');
     expect(html).toContain('isEcs ? st.hostUrl');
     // The ecs host URL is shown in Endpoints with a note that composer requests
     // ARE captured on the timeline (the direct relay self-emits — issue #432).

--- a/tests/unit/local/target-lister.test.ts
+++ b/tests/unit/local/target-lister.test.ts
@@ -154,13 +154,15 @@ describe('listTargets — AgentCore Runtimes', () => {
         stackName: 'App',
         qualifiedId: 'App:ChatAgent',
         displayPath: 'App/ChatAgent',
-        // No ProtocolConfiguration -> defaults to HTTP -> has a /ws endpoint.
+        // No ProtocolConfiguration -> defaults to HTTP -> has a /ws endpoint
+        // and serves its contract on POST /invocations.
         agentCoreHasWs: true,
+        agentCoreContractPath: '/invocations',
       },
     ]);
   });
 
-  it('marks agentCoreHasWs per protocol (HTTP/AGUI true, MCP/A2A false)', () => {
+  it('marks agentCoreHasWs + contract path per protocol', () => {
     const stack = buildStack('App', {
       HttpAgent: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
       AguiAgent: {
@@ -177,9 +179,19 @@ describe('listTargets — AgentCore Runtimes', () => {
       },
     });
     const byId = Object.fromEntries(
-      listTargets([stack]).agentCoreRuntimes.map((e) => [e.logicalId, e.agentCoreHasWs])
+      listTargets([stack]).agentCoreRuntimes.map((e) => [
+        e.logicalId,
+        { hasWs: e.agentCoreHasWs, path: e.agentCoreContractPath },
+      ])
     );
-    expect(byId).toEqual({ HttpAgent: true, AguiAgent: true, McpAgent: false, A2aAgent: false });
+    expect(byId).toEqual({
+      // HTTP / AGUI: /ws + POST /invocations.
+      HttpAgent: { hasWs: true, path: '/invocations' },
+      AguiAgent: { hasWs: true, path: '/invocations' },
+      // MCP: no /ws, POST /mcp. A2A: no /ws, POST /.
+      McpAgent: { hasWs: false, path: '/mcp' },
+      A2aAgent: { hasWs: false, path: '/' },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Slice 3 of #454. After slices 1-2 (#458, #459) `cdkl start-agentcore` keeps the
AgentCore container **warm** and serves **all four protocols'** HTTP contract
(`POST /invocations` + `GET /ping` / `POST /mcp` / `POST /`) plus the `/ws`
bridge — but `cdkl studio` still treated it as a `/ws`-only bridge: it listed
only HTTP/AGUI runtimes in the serve group and rendered only a WebSocket
console. This slice catches studio up to the warm serve.

## Changes

- **List every runtime.** The `agentcore-ws` serve group (relabeled **"AgentCore
  (serve)"**) now lists ALL `agentCoreRuntimes`, not just the `/ws`-capable ones
  — start-agentcore serves MCP/A2A warm too. `agentCoreHasWs` is kept per-entry
  to decide only whether to ALSO render the WebSocket console (HTTP/AGUI yes;
  MCP/A2A no), and a new `agentCoreContractPath` (`/invocations` | `/mcp` | `/`,
  matching `resolveAgentCoreServePlan`) seeds the composer.
- **HTTP request composer.** The serve workspace renders the same api/alb-style
  HTTP request composer against the warm container's contract, pre-filled with
  the protocol's `POST` path. It POSTs via `/api/request` → capture proxy →
  timeline.
- **Capture proxy on the http:// endpoint.** `studio-serve-manager`'s
  `agentcore-ws` spec gains `capturesHttp: true` + a new `extraEndpointRe`. The
  `ws://` endpoint passes straight through (un-proxied) for the console, while
  the `http://` contract endpoint is fronted by the capture proxy so
  `/invocations` requests land on the timeline. start-agentcore prints both
  ready lines; the broadened `readyRe` (`/Server listening on (\S+)/`) matches
  the `ws://` (HTTP/AGUI) or `http://` (MCP/A2A) listen line, and
  `extraEndpointRe` (`/HTTP contract served on (https?:\/\/\S+)/`) captures the
  second `http://` contract line for HTTP/AGUI.

## Tests

- Unit: `studio-server` projects all runtimes + the new fields; `serve-manager`
  captures the dual `ws://`+proxied-`http://` endpoints for HTTP/AGUI and the
  single proxied `http://` for MCP/A2A (asserting **no double-proxy** from the
  contract-path line); `target-lister` marks the contract path per protocol; a
  new `studio-ui` jsdom test asserts the serve workspace renders the HTTP
  composer (POST + contract path), the WS console only for HTTP/AGUI, and that
  `loadTargets` threads `agentCoreHasWs` + `agentCoreContractPath` from the
  target JSON onto `serveMeta`.
- Integ: `local-studio` extended — the warm `http://` contract endpoint is
  exposed and a relayed `POST /invocations` hits the warm container through the
  capture proxy + lands on the timeline.

## cdkd parity

Studio-only — the diff touches `src/local/**` (edits, no new files) and tests /
docs, not `src/cli/commands/**` / `src/internal.ts` / `src/index.ts`. No
host-facing surface change; cdkd inherits nothing. (`/check-cdkd-parity`:
out-of-scope.)

## Reviewer notes (3-axis review)

- **Spec:** clean — all four spec points verified.
- **Code:** no blockers/majors. The "`agentCoreHasWs` carried but unused" nit is
  addressed — the WS console now gates on `meta.agentCoreHasWs` for the
  agentcore kind (a behavioral no-op, since MCP/A2A advertise no `ws://`
  endpoint, but it makes the flag spec-load-bearing).
- **Tests:** the "entry → serveMeta copy untested" gap is addressed by the new
  `loadTargets` test. **Accepted as known cost:** MCP/A2A warm-serve has no
  *studio* integ (the `local-studio` fixture has only an HTTP runtime) — the
  studio glue for MCP/A2A is the serve-manager's `http://` listen-line proxy
  (unit-tested) and `start-agentcore`'s MCP/A2A serve itself is integ'd in
  slices 1-2 (`local-start-agentcore`), so the marginal end-to-end risk is low
  and adding MCP/A2A runtimes to the studio fixture is disproportionate.

## Test plan

- `vp run check` / `vp run build` / `vp run test` (3013 tests) green.
- `/run-integ local-studio` green (0 docker orphans).

Part of #454.
