### PR TITLE
feat(start-agentcore): --watch reloads the warm container in place (#454 slice 4b)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -252,8 +252,17 @@ AWS managed services.
   (kept verbatim for studio's agentcore-ws serve) plus an `HTTP contract
   served on http://...` line; MCP / A2A print a `Server listening on
   http://...` line plus a `<PROTOCOL> contract served on http://...<path>`
-  line. Runs until `^C` (`--watch` is a follow-up). The `cdkl
-  invoke-agentcore` terminal path (interactive over stdin in a TTY) is
+  line. Runs until `^C`. `--watch` (issue #454, slice 4b) re-synths + reloads
+  the warm container IN PLACE on a CDK source change, keeping the HOST serve
+  UP — only the container rotates (like start-service: the front-door stays,
+  the replicas roll). A per-firing classifier (shared with
+  invoke-agentcore `--ws --watch` + the ECS serves) picks rebuild (SIGTERM the
+  old container, boot a fresh one on a NEW port, re-point the serve via
+  `server.setContainerPort` — the proxy reads the port live per request, the
+  `/ws` bridge per upgrade) vs soft-reload (`docker cp` + `docker restart` the
+  SAME container, port preserved); the forever-promise main loop is serve-level
+  so a per-container teardown during reload never tears the serve down. The
+  `cdkl invoke-agentcore` terminal path (interactive over stdin in a TTY) is
   unchanged
 - API Gateway authorizers — Lambda authorizers, Cognito User Pool JWT
   verification, IAM SigV4 verification
@@ -578,7 +587,11 @@ compute-locally category for Lambda + API Gateway).
   401 / 403 on deny, forwarding the verified Authorization on pass) + a
   per-request `signRequest` (buffers the POST body, signs it SigV4, injects the
   `Authorization` / `X-Amz-*` headers; drops the inbound chunked
-  `transfer-encoding` since the body is now fixed-length)) + agentcore-serve-auth
+  `transfer-encoding` since the body is now fixed-length). Slice 4b added
+  `setContainerPort(port)` to the handle: the proxy reads `config.containerPort`
+  live per request and the `/ws` bridge per upgrade (its `containerPort` is now a
+  `number | (() => number)` getter), so a `--watch` rebuild re-points the serve
+  at a new warm container without rebinding the listener) + agentcore-serve-auth
   (slice 4a — `buildAgentCoreServeAuthCheck`: the per-request inbound-JWT gate
   for the warm serve, the serve counterpart of `front-door-auth`'s ALB
   `AuthCheck`; reuses `cognito-jwt`'s `verifyJwtViaDiscovery` to verify the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -890,12 +890,19 @@ cdkl start-agentcore MyStack/Agent --from-cfn-stack
 | `--container-host <ip>` | `127.0.0.1` | Host IP used to bind the agent container port. |
 | `--timeout <ms>` | `120000` | Container-ready probe timeout (`GET /ping` for HTTP / AGUI; an HTTP-response probe to the protocol path for MCP / A2A). |
 | `--assume-role [arn]` | — | Assume the runtime's execution role and forward STS credentials to the container. |
+| `--watch` | (off) | Re-synth + reload the warm container in place on a CDK source change, keeping the serve up. A per-firing classifier picks rebuild (boot a fresh container on a new port, re-point the serve) vs soft-reload (`docker cp` + `docker restart` the same container) — the same machinery as `start-service` / `invoke-agentcore --ws --watch`. |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR. |
 | `--from-cfn-stack [name]` | — | Resolve intrinsic env values / ECR image URIs against a deployed stack. |
 | `--stack-region <region>` | — | Region of the state record (with `--from-cfn-stack`). |
 
-`--watch` (reload on CDK source changes) is a planned follow-up; for now,
-restart the command to pick up local edits. `start-agentcore` is also runnable
+**`--watch`.** On a CDK source change the serve re-synths and reloads the warm
+container **in place** — the host serve stays up, only the container rotates
+(like `start-service`, where the front-door stays and the replicas roll). An
+interpreted-language source-only edit (no Dockerfile / dependency-manifest /
+compiled-source change) `docker cp`s the freshly-synthed source into the running
+container and restarts it (soft-reload, port preserved); a Dockerfile /
+dependency / ambiguous edit boots a fresh container on a new port and re-points
+the serve. `start-agentcore` is also runnable
 from `cdkl studio` (the `agentcore-ws` serve kind, listed as "AgentCore
 (serve)") with an in-browser HTTP request composer against the warm contract
 plus, for HTTP / AGUI runtimes, an interactive WebSocket console.

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -2253,7 +2253,13 @@ export async function loadAgentCoreAssetContext(args: {
  * the classifier treats `undefined` as "force rebuild", which is the
  * conservative default.
  */
-async function deriveOldAssetHash(args: {
+/**
+ * Resolve the CURRENT (pre-reload) asset hash for the runtime, so the per-firing
+ * classifier can compare it against the freshly-synthed hash. Exported so the
+ * `cdkl start-agentcore --watch` reload watcher (issue #454, slice 4b) reuses
+ * the SAME classification inputs as `invoke-agentcore --ws --watch`.
+ */
+export async function deriveOldAssetHash(args: {
   resolvedTarget: string;
   resolved: ResolvedAgentCoreRuntime;
   stacks: StackInfo[];

--- a/src/cli/commands/local-start-agentcore.ts
+++ b/src/cli/commands/local-start-agentcore.ts
@@ -12,6 +12,7 @@ import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
 import { resolveSingleTarget } from '../../local/target-picker.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import { resolveApp } from '../config-loader.js';
 import {
   createLocalStateProvider,
@@ -41,6 +42,9 @@ import {
 } from '../../local/agentcore-http-server.js';
 import { selectServeInboundAuth } from '../../local/agentcore-serve-auth.js';
 import { signAgentCoreInvocation } from '../../local/agentcore-sigv4-sign.js';
+import { createFileWatcher, type FileWatcher } from '../../local/file-watcher.js';
+import { classifySourceChange, type ReloadVerdict } from '../../local/source-change-classifier.js';
+import { AssetManifestLoader } from '../../assets/asset-manifest-loader.js';
 import {
   ensureDockerAvailable,
   pickFreePort,
@@ -48,7 +52,8 @@ import {
   runDetached,
   streamLogs,
 } from '../../local/docker-runner.js';
-import { resolveProfileCredentials } from './local-start-api.js';
+import { createWatchPredicates, resolveProfileCredentials } from './local-start-api.js';
+import { resolveWatchConfig } from '../config-loader.js';
 import {
   writeProfileCredentialsFile,
   type ProfileCredentialsFile,
@@ -56,10 +61,13 @@ import {
 import {
   buildAgentCoreImageContext,
   buildContainerEnv,
+  deriveOldAssetHash,
+  loadAgentCoreAssetContext,
   parseTimeoutMs,
   resolveAgentCoreImage,
   resolveAgentCoreSigV4Context,
   resolveFromS3BucketIntrinsic,
+  softReloadAgentContainer,
   type LocalInvokeAgentCoreOptions,
 } from './local-invoke-agentcore.js';
 
@@ -189,12 +197,20 @@ async function localStartAgentCoreCommand(
   let server: RunningAgentCoreHttpServer | undefined;
   let profileCredsFile: ProfileCredentialsFile | undefined;
   let stateProvider: LocalStateProvider | undefined;
+  let watcher: FileWatcher | undefined;
   let shuttingDown = false;
   let tornDown = false;
 
   const teardown = async (): Promise<void> => {
     if (tornDown) return;
     tornDown = true;
+    if (watcher) {
+      try {
+        await watcher.close();
+      } catch (err) {
+        logger.debug(`watcher close failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
     if (server) {
       try {
         await server.close();
@@ -339,7 +355,9 @@ async function localStartAgentCoreCommand(
     imageContext
   );
 
-  const containerHostPort = await pickFreePort();
+  // Mutable: a `--watch` rebuild rotates the warm container to a NEW host port
+  // (the signRequest closure + the reload watcher read this live).
+  let containerHostPort = await pickFreePort();
   const containerHost = options.containerHost;
   // Stable `cdkl-`-prefixed name so the orphan sweep (`docker ps --filter
   // name=cdkl-`) used by `/cleanup` + `/run-integ` finds this long-lived
@@ -461,7 +479,208 @@ async function localStartAgentCoreCommand(
   }
   logger.info('Press ^C to shut down.');
 
-  // Block forever — signal handlers exit the process.
+  // --watch (issue #454, slice 4b). Re-synth + reload the warm container in
+  // place on a CDK source change, keeping the HOST serve UP — only the
+  // container rotates (like start-service: the front-door stays, the replicas
+  // roll). A per-firing classifier (shared with invoke-agentcore --ws --watch
+  // + the ECS serves) picks rebuild vs soft-reload; a rebuild boots a fresh
+  // container on a NEW port and re-points the serve via `server.setContainerPort`
+  // (the proxy reads the port live per request, the /ws bridge per upgrade), a
+  // soft-reload `docker cp` + `docker restart`s the SAME container (port
+  // preserved). The forever-promise below is serve-level, so a per-container
+  // teardown during reload never unblocks it.
+  if (options.watch) {
+    const cdkOutDir = options.output;
+    const assetLoader = new AssetManifestLoader();
+    // The CURRENTLY-RUNNING container's asset hash, captured at boot BEFORE any
+    // reload re-synths over cdk.out. The classifier compares it against the
+    // freshly-synthed hash to pick soft-reload (hash flipped: a real source
+    // edit) vs rebuild (unchanged: a CDK construct / unrelated edit). It must be
+    // captured here — deriving it at reload time would read the post-re-synth
+    // manifest and always match the new hash (no flip ever detected). Updated
+    // after each successful reload.
+    let currentAssetHash = await deriveOldAssetHash({
+      resolvedTarget,
+      resolved,
+      stacks,
+      cdkOutDir,
+      assetLoader,
+    });
+    let reloadChain: Promise<unknown> = Promise.resolve();
+
+    const waitReady = async (port: number): Promise<void> => {
+      if (plan.readyPath === undefined) {
+        await waitForAgentCorePing(containerHost, port, options.timeout);
+      } else {
+        await waitForAgentCoreHttpReady(containerHost, port, plan.readyPath, options.timeout);
+      }
+    };
+
+    const watchRoot = process.cwd();
+    const { ignored, shouldTrigger, excludePatterns } = createWatchPredicates({
+      watchRoot,
+      output: options.output,
+      watchConfig: resolveWatchConfig(),
+    });
+    logger.info(
+      `Watching ${watchRoot} for source changes (excluding ${excludePatterns.join(', ')}). ` +
+        `The warm container reloads in place; the serve stays up.`
+    );
+    watcher = createFileWatcher({
+      paths: [watchRoot],
+      ignored,
+      shouldTrigger,
+      onChange: (changedPaths) => {
+        reloadChain = reloadChain.then(async () => {
+          // Re-synth + re-resolve the runtime FRESH (so the asset context reads
+          // the NEW hash — the boot `resolved`'s containerUri / codeAssetHash is
+          // stale after an edit, and with >1 docker asset the single-asset
+          // fallback cannot save it). Then classify rebuild vs soft-reload by
+          // comparing the running (currentResolved/currentStacks) hash against
+          // the fresh one. A synth / classify failure skips this change — a
+          // reload cannot proceed without a fresh synth.
+          let freshStacks: StackInfo[];
+          let freshResolved: ReturnType<typeof resolveAgentCoreTarget>;
+          let freshLoaded: Awaited<ReturnType<typeof buildAgentCoreImageContext>>['loaded'];
+          let freshImageContext: Awaited<ReturnType<typeof buildAgentCoreImageContext>>['context'];
+          let verdict: ReloadVerdict;
+          // The freshly-synthed asset hash (carried out of the try so the
+          // post-reload bookkeeping can advance `currentAssetHash`).
+          let nextAssetHash = currentAssetHash;
+          try {
+            const synthRes = await synthesizer.synthesize(synthOpts);
+            freshStacks = synthRes.stacks;
+            const freshCandidate = pickAgentCoreCandidateStack(resolvedTarget, freshStacks);
+            const ctx =
+              stateProvider && freshCandidate
+                ? await buildAgentCoreImageContext(freshCandidate, stateProvider, options)
+                : { context: undefined, loaded: undefined };
+            freshImageContext = ctx.context;
+            freshLoaded = ctx.loaded;
+            freshResolved = resolveAgentCoreTarget(resolvedTarget, freshStacks, freshImageContext);
+            await resolveFromS3BucketIntrinsic(
+              freshResolved,
+              stateProvider,
+              freshLoaded,
+              freshImageContext
+            );
+            const assetCtx = await loadAgentCoreAssetContext({
+              resolvedTarget,
+              resolved: freshResolved,
+              stacks: freshStacks,
+              cdkOutDir,
+              assetLoader,
+              oldAssetHash: currentAssetHash,
+            });
+            if (assetCtx?.newAssetHash !== undefined) nextAssetHash = assetCtx.newAssetHash;
+            verdict = classifySourceChange(changedPaths, assetCtx);
+            logger.info(
+              `Detected source change (${changedPaths.length} path(s)); verdict=${verdict.kind} (${verdict.reason}).`
+            );
+          } catch (err) {
+            logger.error(
+              `Reload: re-synth / classify failed ` +
+                `(${err instanceof Error ? err.message : String(err)}); skipping this change. ` +
+                `The serve stays up against the current container.`
+            );
+            return;
+          }
+
+          try {
+            if (verdict.kind === 'soft-reload') {
+              if (!containerId) {
+                throw new CdkLocalError(
+                  'Reload: no live container to docker cp / docker restart into.',
+                  'LOCAL_START_AGENTCORE_WATCH_NO_CONTAINER'
+                );
+              }
+              await softReloadAgentContainer(containerId, verdict.newAssetSourceDir);
+              await waitReady(containerHostPort);
+              logger.info(
+                `Reload: soft-reloaded the agent container (docker cp + docker restart; ` +
+                  `container ID + host port preserved).`
+              );
+            } else {
+              // Rebuild: tear down the OLD container, build + run a fresh one on
+              // a NEW port (reusing the fresh resolution above — inbound auth is
+              // NOT re-resolved; the bearer / discovery URL / sigv4 context is
+              // stable across a source edit), and re-point the still-listening
+              // serve at it.
+              if (stopLogs) {
+                try {
+                  stopLogs();
+                } catch {
+                  /* best-effort */
+                }
+                stopLogs = undefined;
+              }
+              if (containerId) {
+                await removeContainer(containerId);
+                containerId = undefined;
+              }
+              const newImage = await resolveAgentCoreImage(
+                freshResolved,
+                options,
+                freshLoaded,
+                stateProvider
+              );
+              const { env: newEnv, sensitiveEnvKeys: newSensitive } = await buildContainerEnv(
+                freshResolved,
+                options,
+                profileCredentials,
+                profileCredsFile,
+                stateProvider,
+                freshLoaded,
+                freshImageContext
+              );
+              const newPort = await pickFreePort();
+              const newName = `${getEmbedConfig().resourceNamePrefix}-agentcore-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+              logger.info(
+                `Reload: starting agent container (image=${newImage}, port=${newPort} -> ${plan.containerPortLabel})...`
+              );
+              containerId = await runDetached({
+                image: newImage,
+                mounts: [],
+                env: newEnv,
+                cmd: [],
+                hostPort: newPort,
+                host: containerHost,
+                platform: options.platform,
+                name: newName,
+                ...(plan.containerPort !== undefined && { containerPort: plan.containerPort }),
+                ...(newSensitive.size > 0 && { sensitiveEnvKeys: newSensitive }),
+              });
+              stopLogs = streamLogs(containerId);
+              containerHostPort = newPort;
+              await waitReady(newPort);
+              // Re-point the live serve at the new container (proxy + /ws bridge
+              // read the port live); the OLD container is already gone.
+              server?.setContainerPort(newPort);
+              logger.info(
+                `Reload: rebuilt the agent container; serve re-pointed to port ${newPort}.`
+              );
+            }
+            // The freshly-synthed asset is now the live one — the next edit
+            // compares against its hash.
+            currentAssetHash = nextAssetHash;
+            logger.info('Reload complete.');
+          } catch (err) {
+            // A reload failure keeps the serve up against whatever container is
+            // currently live (a soft-reload leaves the old one; a rebuild that
+            // failed mid-flight may have torn it down — the next edit retries).
+            logger.error(
+              `Reload failed: ${err instanceof Error ? err.message : String(err)}. ` +
+                `The serve stays up; edit + save again to retry.`
+            );
+          }
+        });
+      },
+    });
+  }
+
+  // Block forever — signal handlers exit the process. Serve-level (NOT tied to
+  // any per-container controller), so a reload's container teardown never
+  // unblocks it and tears the serve down.
   await new Promise<never>(() => undefined);
 }
 
@@ -577,6 +796,15 @@ export function addStartAgentCoreSpecificOptions(cmd: Command): Command {
       )
         .choices(['linux/amd64', 'linux/arm64'])
         .default('linux/arm64')
+    )
+    .addOption(
+      new Option(
+        '--watch',
+        'Re-synth + reload the warm container in place on a CDK source change, keeping the serve up. ' +
+          'A per-firing classifier picks rebuild (boot a fresh container, re-point the serve) vs ' +
+          'soft-reload (docker cp + docker restart the same container) — the same pattern as ' +
+          'start-service / invoke-agentcore --ws --watch.'
+      )
     )
     .addOption(
       new Option(

--- a/src/cli/commands/local-start-agentcore.ts
+++ b/src/cli/commands/local-start-agentcore.ts
@@ -198,6 +198,10 @@ async function localStartAgentCoreCommand(
   let profileCredsFile: ProfileCredentialsFile | undefined;
   let stateProvider: LocalStateProvider | undefined;
   let watcher: FileWatcher | undefined;
+  // Serializes --watch reload firings; teardown awaits it so an in-flight
+  // reload finishes (and its container becomes the one teardown removes) instead
+  // of racing teardown to leave an orphan container behind.
+  let reloadChain: Promise<unknown> = Promise.resolve();
   let shuttingDown = false;
   let tornDown = false;
 
@@ -210,6 +214,14 @@ async function localStartAgentCoreCommand(
       } catch (err) {
         logger.debug(`watcher close failed: ${err instanceof Error ? err.message : String(err)}`);
       }
+    }
+    // Let any reload already queued before tornDown finish its current docker
+    // op (its internal tornDown checks stop it proceeding to a fresh
+    // container), so `containerId` points at the live container teardown removes.
+    try {
+      await reloadChain;
+    } catch {
+      /* a failed reload already logged + left the serve on the prior container */
     }
     if (server) {
       try {
@@ -506,7 +518,6 @@ async function localStartAgentCoreCommand(
       cdkOutDir,
       assetLoader,
     });
-    let reloadChain: Promise<unknown> = Promise.resolve();
 
     const waitReady = async (port: number): Promise<void> => {
       if (plan.readyPath === undefined) {
@@ -532,13 +543,17 @@ async function localStartAgentCoreCommand(
       shouldTrigger,
       onChange: (changedPaths) => {
         reloadChain = reloadChain.then(async () => {
+          // A reload firing queued before shutdown must not start fresh Docker
+          // work — teardown awaits this chain, so bailing here keeps it from
+          // booting an orphan container the shutdown can't see.
+          if (tornDown || shuttingDown) return;
           // Re-synth + re-resolve the runtime FRESH (so the asset context reads
           // the NEW hash — the boot `resolved`'s containerUri / codeAssetHash is
           // stale after an edit, and with >1 docker asset the single-asset
           // fallback cannot save it). Then classify rebuild vs soft-reload by
-          // comparing the running (currentResolved/currentStacks) hash against
-          // the fresh one. A synth / classify failure skips this change — a
-          // reload cannot proceed without a fresh synth.
+          // comparing the boot/last-reloaded hash against the fresh one. A synth
+          // / classify failure skips this change — a reload cannot proceed
+          // without a fresh synth.
           let freshStacks: StackInfo[];
           let freshResolved: ReturnType<typeof resolveAgentCoreTarget>;
           let freshLoaded: Awaited<ReturnType<typeof buildAgentCoreImageContext>>['loaded'];
@@ -585,6 +600,10 @@ async function localStartAgentCoreCommand(
             );
             return;
           }
+
+          // Shutdown may have raced the (slow) synth above — bail before any
+          // container mutation so teardown's container removal is the last word.
+          if (tornDown || shuttingDown) return;
 
           try {
             if (verdict.kind === 'soft-reload') {

--- a/src/local/agentcore-http-server.ts
+++ b/src/local/agentcore-http-server.ts
@@ -132,6 +132,14 @@ export interface RunningAgentCoreHttpServer {
   wsUrl?: string;
   /** The bound host port. */
   port: number;
+  /**
+   * Re-point the serve at a NEW warm container's host port without rebinding
+   * the listener (issue #454, slice 4b — `--watch` rebuild). The host serve
+   * stays up; the proxy reads the port live per request and the `/ws` bridge
+   * reads it live per upgrade, so subsequent requests / upgrades hit the new
+   * container. A soft-reload preserves the port and never calls this.
+   */
+  setContainerPort(port: number): void;
   /** Close the server, the `/ws` bridge (if any), and every live connection. */
   close(): Promise<void>;
 }
@@ -319,10 +327,13 @@ export function startAgentCoreHttpServer(
   });
 
   // MCP / A2A have no `/ws` — the bridge is attached for HTTP / AGUI only.
+  // The bridge reads the container port LIVE per upgrade (a getter), so a
+  // `--watch` rebuild that calls setContainerPort re-points new /ws upgrades
+  // too (issue #454, slice 4b).
   const bridge = attachWs
     ? attachAgentCoreWsBridge(httpServer, {
         containerHost: config.containerHost,
-        containerPort: config.containerPort,
+        containerPort: () => config.containerPort,
         ...(config.sessionId && { sessionId: config.sessionId }),
         ...(config.authorization && { authorization: config.authorization }),
       })
@@ -343,6 +354,12 @@ export function startAgentCoreHttpServer(
         httpUrl: `http://${host}:${port}`,
         ...(bridge && { wsUrl: `ws://${host}:${port}${bridge.path}` }),
         port,
+        // The proxy reads `config.containerPort` live per request, so mutating
+        // it re-points subsequent requests (+ the bridge's getter) at the new
+        // warm container — the listener socket is untouched.
+        setContainerPort: (newPort: number) => {
+          config.containerPort = newPort;
+        },
         close: () =>
           new Promise<void>((res) => {
             if (bridge) {

--- a/src/local/agentcore-ws-bridge.ts
+++ b/src/local/agentcore-ws-bridge.ts
@@ -27,8 +27,14 @@ const DEFAULT_PATH = '/ws';
 export interface AgentCoreWsBridgeServerConfig {
   /** Host the container `/ws` is reachable on (the published-port host). */
   containerHost: string;
-  /** Host port the container's `/ws` is published on. */
-  containerPort: number;
+  /**
+   * Host port the container's `/ws` is published on. A getter resolves the port
+   * LIVE per inbound connection — used by the HTTP serve under `--watch`, where
+   * a rebuild rotates the container to a new port without re-attaching the
+   * bridge (issue #454, slice 4b). A bare number pins it (the standalone
+   * bridge).
+   */
+  containerPort: number | (() => number);
   /** Bind host for the bridge server. Defaults to `127.0.0.1`. */
   host?: string;
   /** Bind port for the bridge server. Defaults to `0` (OS-assigned). */
@@ -99,7 +105,11 @@ export function attachAgentCoreWsBridge(
 
   wss.on('connection', (browser: WebSocket) => {
     const sessionId = config.sessionId ?? randomUUID();
-    const handle = bridgeAgentCoreWs(config.containerHost, config.containerPort, {
+    // Resolve the container port LIVE so a --watch rebuild (which mutates the
+    // getter's source) routes a new inbound connection to the new container.
+    const containerPort =
+      typeof config.containerPort === 'function' ? config.containerPort() : config.containerPort;
+    const handle = bridgeAgentCoreWs(config.containerHost, containerPort, {
       sessionId,
       ...(config.authorization && { authorization: config.authorization }),
       ...(config.webSocketImpl && { webSocketImpl: config.webSocketImpl }),

--- a/tests/integration/local-start-agentcore/verify.sh
+++ b/tests/integration/local-start-agentcore/verify.sh
@@ -53,6 +53,10 @@ JWT_AUD="cdkl-agentcore-aud"
 CDKL_PID=""
 SIDECAR_PID=""
 OUT_FILE="$(mktemp)"
+# Set by the --watch step (step 11): the agent source it edits + its backup, so
+# cleanup always restores the committed fixture even if the test aborts.
+AGENT_SRC=""
+AGENT_SRC_BACKUP=""
 
 stop_server() {
   if [ -n "${CDKL_PID}" ] && kill -0 "${CDKL_PID}" 2>/dev/null; then
@@ -72,10 +76,19 @@ stop_sidecar() {
   SIDECAR_PID=""
 }
 
+restore_source() {
+  if [ -n "${AGENT_SRC_BACKUP}" ] && [ -f "${AGENT_SRC_BACKUP}" ]; then
+    cp "${AGENT_SRC_BACKUP}" "${AGENT_SRC}" 2>/dev/null || true
+    rm -f "${AGENT_SRC_BACKUP}"
+  fi
+  AGENT_SRC_BACKUP=""
+}
+
 cleanup() {
   rc=$?
   stop_server
   stop_sidecar
+  restore_source
   rm -f "${OUT_FILE}"
   exit "${rc}"
 }
@@ -291,4 +304,49 @@ echo "[verify]   --sigv4 OK: forwarded request carried an AWS4-HMAC-SHA256 Autho
 stop_server
 assert_no_orphans "sigv4 serve shutdown"
 
-echo "[verify] PASS: start-agentcore served HTTP (POST /invocations + SSE + GET /ping + /ws bridge), MCP (POST /mcp), A2A (POST /), the per-request JWT gate (401/403/200), and --sigv4 signing — each against one warm container — and cleaned up"
+echo "[verify] step 11: --watch reloads the warm container in place on a source edit (#454 slice 4b)"
+AGENT_SRC="${TEST_DIR}/agent/server.js"
+AGENT_SRC_BACKUP="$(mktemp)"
+cp "${AGENT_SRC}" "${AGENT_SRC_BACKUP}"
+
+# Boot the HTTP serve with --watch (watches the fixture cwd for source edits).
+: > "${OUT_FILE}"
+${CLI} start-agentcore "${TARGET}" --host 127.0.0.1 --port 0 --watch > "${OUT_FILE}" 2>&1 &
+CDKL_PID=$!
+WATCH_HTTP_URL="$(wait_for_ready 'HTTP contract served on http://[^ ]+' || true)"
+WATCH_HTTP_URL="${WATCH_HTTP_URL#HTTP contract served on }"
+[ -n "${WATCH_HTTP_URL}" ] || fail "--watch serve did not print its HTTP contract URL"
+echo "[verify]   watch http: ${WATCH_HTTP_URL}"
+# Confirm the watcher started.
+grep -q 'Watching .* for source changes' "${OUT_FILE}" || fail "--watch did not start the file watcher"
+
+# Pre-edit: the response does NOT carry the watch marker.
+R_PRE="$(curl -s -X POST "${WATCH_HTTP_URL}/invocations" -d '{"q":"pre-reload"}')"
+echo "${R_PRE}" | grep -q 'WATCH-V2' && fail "watchVersion present before the edit: ${R_PRE}"
+
+# Edit the agent source (interpreted-language handler, no Dockerfile change) so
+# the classifier picks soft-reload: inject a watchVersion field into the
+# /invocations response.
+node -e "const f='${AGENT_SRC}';const fs=require('fs');let s=fs.readFileSync(f,'utf8');s=s.replace(/greeting: process.env.GREETING \?\? 'unset',/g, \"greeting: process.env.GREETING ?? 'unset', watchVersion: 'WATCH-V2',\");fs.writeFileSync(f,s);"
+
+# Wait for the reload to complete (re-synth + classify + soft-reload + ready).
+RELOADED=0
+for _ in $(seq 1 240); do
+  if grep -q 'Reload complete.' "${OUT_FILE}"; then RELOADED=1; break; fi
+  kill -0 "${CDKL_PID}" 2>/dev/null || fail "--watch serve exited during reload"
+  sleep 0.5
+done
+[ "${RELOADED}" = "1" ] || fail "--watch did not complete a reload within 120s"
+grep -q 'verdict=soft-reload' "${OUT_FILE}" || fail "expected verdict=soft-reload for a source-only edit"
+echo "[verify]   reload OK: verdict=soft-reload + Reload complete."
+
+# Post-edit: the SAME warm serve now serves the new code.
+R_POST="$(curl -s -X POST "${WATCH_HTTP_URL}/invocations" -d '{"q":"post-reload"}')"
+echo "${R_POST}" | grep -q 'WATCH-V2' || fail "reloaded serve did not serve the new code: ${R_POST}"
+echo "[verify]   --watch OK: source edit -> soft-reload -> new code served on the SAME serve port"
+
+stop_server
+restore_source
+assert_no_orphans "--watch serve shutdown"
+
+echo "[verify] PASS: start-agentcore served HTTP (POST /invocations + SSE + GET /ping + /ws bridge), MCP (POST /mcp), A2A (POST /), the per-request JWT gate (401/403/200), --sigv4 signing, and --watch reload (soft-reload in place) — each against one warm container — and cleaned up"

--- a/tests/integration/local-start-agentcore/verify.sh
+++ b/tests/integration/local-start-agentcore/verify.sh
@@ -53,10 +53,12 @@ JWT_AUD="cdkl-agentcore-aud"
 CDKL_PID=""
 SIDECAR_PID=""
 OUT_FILE="$(mktemp)"
-# Set by the --watch step (step 11): the agent source it edits + its backup, so
-# cleanup always restores the committed fixture even if the test aborts.
+# Set by the --watch step (step 11): the agent source + Dockerfile it edits +
+# their backups, so cleanup always restores the committed fixture even on abort.
 AGENT_SRC=""
 AGENT_SRC_BACKUP=""
+AGENT_DOCKERFILE=""
+AGENT_DOCKERFILE_BACKUP=""
 
 stop_server() {
   if [ -n "${CDKL_PID}" ] && kill -0 "${CDKL_PID}" 2>/dev/null; then
@@ -82,6 +84,11 @@ restore_source() {
     rm -f "${AGENT_SRC_BACKUP}"
   fi
   AGENT_SRC_BACKUP=""
+  if [ -n "${AGENT_DOCKERFILE_BACKUP}" ] && [ -f "${AGENT_DOCKERFILE_BACKUP}" ]; then
+    cp "${AGENT_DOCKERFILE_BACKUP}" "${AGENT_DOCKERFILE}" 2>/dev/null || true
+    rm -f "${AGENT_DOCKERFILE_BACKUP}"
+  fi
+  AGENT_DOCKERFILE_BACKUP=""
 }
 
 cleanup() {
@@ -329,24 +336,55 @@ echo "${R_PRE}" | grep -q 'WATCH-V2' && fail "watchVersion present before the ed
 # /invocations response.
 node -e "const f='${AGENT_SRC}';const fs=require('fs');let s=fs.readFileSync(f,'utf8');s=s.replace(/greeting: process.env.GREETING \?\? 'unset',/g, \"greeting: process.env.GREETING ?? 'unset', watchVersion: 'WATCH-V2',\");fs.writeFileSync(f,s);"
 
-# Wait for the reload to complete (re-synth + classify + soft-reload + ready).
-RELOADED=0
-for _ in $(seq 1 240); do
-  if grep -q 'Reload complete.' "${OUT_FILE}"; then RELOADED=1; break; fi
-  kill -0 "${CDKL_PID}" 2>/dev/null || fail "--watch serve exited during reload"
-  sleep 0.5
-done
-[ "${RELOADED}" = "1" ] || fail "--watch did not complete a reload within 120s"
-grep -q 'verdict=soft-reload' "${OUT_FILE}" || fail "expected verdict=soft-reload for a source-only edit"
-echo "[verify]   reload OK: verdict=soft-reload + Reload complete."
+# Wait until the Nth "Reload complete." line appears (re-synth + classify +
+# reload + ready). Fails if the serve exits or the count never reaches N.
+wait_reload_count() {
+  local want="$1"
+  for _ in $(seq 1 300); do
+    [ "$(grep -c 'Reload complete.' "${OUT_FILE}" 2>/dev/null || echo 0)" -ge "${want}" ] && return 0
+    kill -0 "${CDKL_PID}" 2>/dev/null || fail "--watch serve exited during reload"
+    sleep 0.5
+  done
+  return 1
+}
 
-# Post-edit: the SAME warm serve now serves the new code.
-R_POST="$(curl -s -X POST "${WATCH_HTTP_URL}/invocations" -d '{"q":"post-reload"}')"
+# Reload 1 (soft-reload): the source-only edit flips the asset hash.
+wait_reload_count 1 || fail "--watch did not complete the first reload within 150s"
+[ "$(grep -c 'verdict=soft-reload' "${OUT_FILE}")" -ge 1 ] \
+  || fail "expected verdict=soft-reload for a source-only edit"
+R_POST="$(curl -s -X POST "${WATCH_HTTP_URL}/invocations" -d '{"q":"post-reload-1"}')"
 echo "${R_POST}" | grep -q 'WATCH-V2' || fail "reloaded serve did not serve the new code: ${R_POST}"
-echo "[verify]   --watch OK: source edit -> soft-reload -> new code served on the SAME serve port"
+echo "[verify]   reload 1 OK: verdict=soft-reload -> WATCH-V2 served on the SAME serve port"
+
+# Reload 2 (soft-reload again) — proves the asset hash ADVANCES per reload: the
+# old hash is now WATCH-V2's, so a WATCH-V2 -> WATCH-V3 edit still flips it. If
+# the old hash had not advanced (stuck at boot), this would misclassify.
+node -e "const f='${AGENT_SRC}';const fs=require('fs');let s=fs.readFileSync(f,'utf8');s=s.replace(/WATCH-V2/g,'WATCH-V3');fs.writeFileSync(f,s);"
+wait_reload_count 2 || fail "--watch did not complete the second reload within 150s"
+[ "$(grep -c 'verdict=soft-reload' "${OUT_FILE}")" -ge 2 ] \
+  || fail "expected a SECOND verdict=soft-reload (asset hash did not advance)"
+R_POST2="$(curl -s -X POST "${WATCH_HTTP_URL}/invocations" -d '{"q":"post-reload-2"}')"
+echo "${R_POST2}" | grep -q 'WATCH-V3' || fail "second reload did not serve WATCH-V3: ${R_POST2}"
+echo "[verify]   reload 2 OK: hash advanced -> second soft-reload -> WATCH-V3 served"
+
+# Reload 3 (REBUILD): a Dockerfile edit forces the rebuild path (the classifier
+# routes a Dockerfile change to rebuild). The rebuild boots a fresh container on
+# a NEW port with the CURRENT source (WATCH-V3) and re-points the live serve.
+AGENT_DOCKERFILE="${TEST_DIR}/agent/Dockerfile"
+AGENT_DOCKERFILE_BACKUP="$(mktemp)"
+cp "${AGENT_DOCKERFILE}" "${AGENT_DOCKERFILE_BACKUP}"
+printf '\n# cdkl --watch rebuild marker\n' >> "${AGENT_DOCKERFILE}"
+wait_reload_count 3 || fail "--watch did not complete the third (rebuild) reload within 150s"
+grep -q 'verdict=rebuild' "${OUT_FILE}" || fail "expected verdict=rebuild for a Dockerfile edit"
+grep -q 'rebuilt the agent container; serve re-pointed' "${OUT_FILE}" \
+  || fail "rebuild did not re-point the serve to the new container"
+R_POST3="$(curl -s -X POST "${WATCH_HTTP_URL}/invocations" -d '{"q":"post-rebuild"}')"
+echo "${R_POST3}" | grep -q 'WATCH-V3' \
+  || fail "rebuild did not serve the current code on the re-pointed serve: ${R_POST3}"
+echo "[verify]   reload 3 OK: verdict=rebuild -> serve re-pointed to a new container -> WATCH-V3 served"
 
 stop_server
 restore_source
 assert_no_orphans "--watch serve shutdown"
 
-echo "[verify] PASS: start-agentcore served HTTP (POST /invocations + SSE + GET /ping + /ws bridge), MCP (POST /mcp), A2A (POST /), the per-request JWT gate (401/403/200), --sigv4 signing, and --watch reload (soft-reload in place) — each against one warm container — and cleaned up"
+echo "[verify] PASS: start-agentcore served HTTP (POST /invocations + SSE + GET /ping + /ws bridge), MCP (POST /mcp), A2A (POST /), the per-request JWT gate (401/403/200), --sigv4 signing, and --watch reload (soft-reload x2 with hash-advance + rebuild re-point) — each against one warm container — and cleaned up"

--- a/tests/unit/cli/local-start-agentcore.test.ts
+++ b/tests/unit/cli/local-start-agentcore.test.ts
@@ -38,6 +38,7 @@ describe('createLocalStartAgentCoreCommand', () => {
       '--bearer-token',
       '--no-verify-auth',
       '--sigv4',
+      '--watch',
       '--env-vars',
       '--platform',
       '--no-pull',

--- a/tests/unit/local/agentcore-http-server.test.ts
+++ b/tests/unit/local/agentcore-http-server.test.ts
@@ -132,6 +132,35 @@ describe('startAgentCoreHttpServer', () => {
     expect(fake!.invocations[0]?.authorization).toBe('Bearer test-token');
   });
 
+  it('setContainerPort re-points the proxy at a new warm container without rebinding (issue #454, slice 4b)', async () => {
+    const s = await boot();
+    const r1 = await httpReq(
+      { host: '127.0.0.1', port: s.port, path: '/invocations', method: 'POST' },
+      '{"to":"first"}'
+    );
+    expect(JSON.parse(r1.body).echo).toBe('{"to":"first"}');
+    expect(fake!.invocations).toHaveLength(1);
+
+    // Stand up a SECOND fake container (a rebuild's replacement) and re-point.
+    const second = await startFakeContainer();
+    try {
+      const portBefore = s.port;
+      s.setContainerPort(second.port);
+      const r2 = await httpReq(
+        { host: '127.0.0.1', port: s.port, path: '/invocations', method: 'POST' },
+        '{"to":"second"}'
+      );
+      // The listener port is unchanged; the request now lands on the NEW container.
+      expect(s.port).toBe(portBefore);
+      expect(JSON.parse(r2.body).echo).toBe('{"to":"second"}');
+      expect(second.invocations).toHaveLength(1);
+      // The original container saw no further traffic.
+      expect(fake!.invocations).toHaveLength(1);
+    } finally {
+      await new Promise<void>((res) => second.server.close(() => res()));
+    }
+  });
+
   it('proxies GET /ping', async () => {
     const s = await boot();
     const r = await httpReq({ host: '127.0.0.1', port: s.port, path: '/ping', method: 'GET' });

--- a/tests/unit/local/agentcore-ws-bridge.test.ts
+++ b/tests/unit/local/agentcore-ws-bridge.test.ts
@@ -88,6 +88,38 @@ describe('startAgentCoreWsBridge', () => {
     expect(sid).toMatch(/^[0-9a-f-]{36}$/);
   });
 
+  it('resolves a containerPort GETTER live per connection (issue #454, slice 4b --watch rebuild)', async () => {
+    // A --watch rebuild rotates the warm container to a new port without
+    // re-attaching the bridge; the bridge reads the port live via the getter.
+    const a = await startFakeContainer();
+    const b = await startFakeContainer();
+    let livePort = a.port;
+    const bridge = await startAgentCoreWsBridge({
+      containerHost: '127.0.0.1',
+      containerPort: () => livePort,
+    });
+    bridges.push(bridge);
+
+    const echoVia = (label: string): Promise<string> =>
+      new Promise<string>((resolve, reject) => {
+        const browser = connectBrowser(bridge.url);
+        browser.on('open', () => browser.send(label));
+        browser.on('message', (d) => resolve(d.toString()));
+        browser.on('error', reject);
+      });
+
+    // First connection routes to container A.
+    expect(await echoVia('to-a')).toBe('echo:to-a');
+    expect(a.received).toEqual(['to-a']);
+
+    // Flip the getter's source (the rebuild) — a NEW connection routes to B.
+    livePort = b.port;
+    expect(await echoVia('to-b')).toBe('echo:to-b');
+    expect(b.received).toEqual(['to-b']);
+    // A saw no further traffic.
+    expect(a.received).toEqual(['to-a']);
+  });
+
   it('pins the configured session-id and injects the Authorization header', async () => {
     const container = await startFakeContainer();
     const bridge = await startAgentCoreWsBridge({


### PR DESCRIPTION
## Summary

Slice 4b of #454 (the final piece). `cdkl start-agentcore --watch` re-synths +
reloads the warm AgentCore container on a CDK source change, keeping the **host
serve UP** — only the container rotates (like `start-service`: the front-door
stays, the replicas roll).

- The forever-promise main loop is **serve-level** (a reload's per-container
  teardown never unblocks it and tears the serve down). A file watcher drives
  reloads in a serialized chain.
- A per-firing classifier (the SAME `classifySourceChange` shared with
  `start-service` / `invoke-agentcore --ws --watch`) picks:
  - **soft-reload** (interpreted-language source-only edit): `docker cp` the
    fresh source + `docker restart` the SAME container — port preserved,
    near-instant.
  - **rebuild** (Dockerfile / dependency / ambiguous edit): SIGTERM the old
    container, boot a fresh one on a NEW port, and re-point the live serve via
    the new `RunningAgentCoreHttpServer.setContainerPort(port)`. The proxy reads
    `config.containerPort` live per request; the `/ws` bridge's `containerPort`
    is now a `number | (() => number)` getter so it re-points per upgrade too.
- The classifier asset context is built correctly across re-synths: the OLD
  asset hash is captured at **boot** (before any reload overwrites `cdk.out`)
  and advanced after each reload, and the NEW hash is looked up with a
  **freshly-resolved** runtime — deriving the old hash at reload time would read
  the post-re-synth manifest and never detect a flip (every edit would
  misclassify as rebuild — caught by the multi-runtime integ fixture).

## Behavior change (cdkd parity — cat 4)

- **Old:** `start-agentcore` ran until `^C` with no reload.
- **New:** with `--watch` it reloads the warm container on a source change (host
  serve stays up). No library-signature change — the factory inherits it. cdkd
  tracking issue: go-to-k/cdkd#778.

## Tests

- Unit: `setContainerPort` re-points the proxy at a new fake container without
  rebinding (listener port unchanged, traffic lands on the new container); the
  `/ws` bridge resolves a `containerPort` getter live per connection (routes
  connection 1 → container A, flips the getter, routes connection 2 → B); the
  contract test gains `--watch`.
- Integ: `local-start-agentcore` extended — boot `--watch`, then **three**
  reloads against the SAME live serve: (1) source edit → `verdict=soft-reload` →
  new code served; (2) a second source edit → a SECOND soft-reload serving the
  newer marker (**proves the boot-captured hash advances per reload**); (3) a
  Dockerfile edit → `verdict=rebuild` → the serve re-pointed to a fresh
  container still serving the current code. The fixture source + Dockerfile are
  backed up + restored by the cleanup trap.

## Reviewer notes (3-axis review)

- **Spec:** clean — all points verified.
- **Code:** the BLOCKER (a reload queued before SIGTERM could boot an orphan
  container — teardown didn't await the in-flight reload chain) is fixed: the
  reload body bails on `tornDown`/`shuttingDown` at entry and before any
  container mutation, and `teardown` awaits `reloadChain` before removing the
  container. **Accepted as known cost:** the rebuild path removes the old
  container before the (slow) `docker build`, so the rebuild path has a brief
  unavailable window (soft-reload, the common case, is near-instant); a
  shadow-boot-before-swap primitive is start-service's domain and not warranted
  for a single warm container.
- **Tests:** the HIGH-severity gap (the rebuild branch + the hash-advance were
  only soft-reload-integ'd) is addressed end-to-end by the 3-reload integ above
  (real Docker — stronger than a mocked unit of the same orchestration). The
  remaining catch-arm gaps (synth-failure-skip, reload-failure-keeps-serve-up)
  are simple defensive logs and accepted as known cost.

## Test plan

- `vp run check` / `vp run build` / `vp run test` (3038 tests) green.
- `/run-integ local-start-agentcore` green (HTTP / MCP / A2A / `/ws` warm-serve +
  JWT gate + `--sigv4` + the 3-reload `--watch` scenario; 0 docker orphans).

Closes #454.
