### PR TITLE
fix(studio): symmetric AgentCore (invoke)/(serve) group names + drop dead invoke row button

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -869,9 +869,11 @@ compute-locally category for Lambda + API Gateway).
   straight to its ws:// endpoint, with the socket + frame log held in module
   state so a log-driven serve re-render never drops the connection (issue
   #303); the SAME console renders for an `agentcore-ws` serve when the runtime
-  exposes `/ws` (HTTP / AGUI). The `agentcore-ws` serve group (relabeled
-  "AgentCore (serve)", issue #454, since start-agentcore now serves the warm
-  HTTP contract too, not just `/ws`) lists EVERY AgentCore runtime alongside its
+  exposes `/ws` (HTTP / AGUI). The two AgentCore groups are titled
+  "AgentCore Runtimes (invoke)" (the `agentcore` invoke kind) and
+  "AgentCore Runtimes (serve)" (the `agentcore-ws` serve kind, issue #454 —
+  start-agentcore serves the warm HTTP contract now, not just `/ws`); the serve
+  group lists EVERY AgentCore runtime alongside its
   single-shot invoke entry — the same dual listing as the ecs / ecs-task split —
   because `cdkl start-agentcore` serves all four protocols warm (slices 1-2).
   Each serve renders the api/alb-style HTTP request composer against the warm

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Full flags, precedence, and `--from-cfn-stack` resolution: [docs/cli-reference.m
 
 ### Web console — `cdkl studio`
 
-`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` / `start-cloudfront` / `start-agentcore` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all. A `start-agentcore` warm serve (listed under "AgentCore (serve)") gets an in-browser HTTP request composer against the warm container's contract; an HTTP / AGUI runtime's `/ws` endpoint — and a served API Gateway WebSocket API — additionally get an interactive in-browser WebSocket console (connect / send / receive frames).
+`cdkl studio` is a point-and-click front over the same runners: pick a Lambda or AgentCore runtime and invoke it, start / stop a `start-api` / `start-alb` / `start-service` / `start-cloudfront` / `start-agentcore` serve, and watch invocations + captured serve requests stream onto a live timeline with their bound logs. It takes no target — it lists them all. A `start-agentcore` warm serve (listed under "AgentCore Runtimes (serve)") gets an in-browser HTTP request composer against the warm container's contract; an HTTP / AGUI runtime's `/ws` endpoint — and a served API Gateway WebSocket API — additionally get an interactive in-browser WebSocket console (connect / send / receive frames).
 
 ```bash
 cdkl studio                                  # open the console (launches your browser)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1854,8 +1854,9 @@ The console is a three-pane layout:
   serve targets get a `[Start]` / `[Stop]` control with a `running ● :port`
   indicator (an ECS service shows `running` with no port — it is pure
   compute with no host endpoint; only servable ECS *services* are runnable,
-  not task definitions). Every AgentCore runtime additionally appears in an
-  **AgentCore (serve)** group (the `agentcore-ws` serve kind): a `[Start]` /
+  not task definitions). Every AgentCore runtime is listed in two groups —
+  **AgentCore Runtimes (invoke)** (the single-shot `[Invoke]` composer) and
+  **AgentCore Runtimes (serve)** (the `agentcore-ws` serve kind): a `[Start]` /
   `[Stop]` control that runs `cdkl start-agentcore`, which keeps the container
   warm and serves its native protocol contract. Once running, the serve renders
   an HTTP request composer against the warm container's contract, pre-filled

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -104,7 +104,11 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
     // `ecs`-kind group) annotates the servable services and NOT the task defs.
     { kind: 'ecs', title: 'ECS Services', entries: map(listing.ecsServices, { servable: true }) },
     { kind: 'ecs-task', title: 'ECS Task Definitions', entries: map(listing.ecsTaskDefinitions) },
-    { kind: 'agentcore', title: 'AgentCore Runtimes', entries: map(listing.agentCoreRuntimes) },
+    {
+      kind: 'agentcore',
+      title: 'AgentCore Runtimes (invoke)',
+      entries: map(listing.agentCoreRuntimes),
+    },
     // Every AgentCore runtime ALSO appears as an `agentcore-ws` serve group: a
     // [Start]/[Stop] control that runs `cdkl start-agentcore`, which keeps the
     // container warm and serves its native protocol contract (issue #454) — all
@@ -115,7 +119,7 @@ export function toStudioTargetGroups(listing: TargetListing): StudioTargetGroup[
     // ecs-task split — invoke once vs hold a warm session are different ops.
     {
       kind: 'agentcore-ws',
-      title: 'AgentCore (serve)',
+      title: 'AgentCore Runtimes (serve)',
       entries: map(listing.agentCoreRuntimes).map((t, i) => {
         const src = listing.agentCoreRuntimes[i];
         if (src?.agentCoreHasWs !== undefined) t.agentCoreHasWs = src.agentCoreHasWs;

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -5,8 +5,9 @@
  * the studio HTTP server (`startStudioServer`) at `GET /`.
  *
  * 3-pane shell (decision D6), framework-free vanilla JS (decision D7):
- *   - left   = target list (from `GET /api/targets`); each Lambda or
- *     AgentCore runtime has an [Invoke] button, each API a [Start] / [Stop]
+ *   - left   = target list (from `GET /api/targets`); a Lambda or AgentCore
+ *     runtime row opens its [Invoke] composer on click (no row button -- an
+ *     invoke needs a composed payload), each API a [Start] / [Stop]
  *     serve control with a `running ● :port` indicator (slice C1), plus a
  *     selected-highlight.
  *   - center = the WORKSPACE for the selected target: for a Lambda or an
@@ -874,9 +875,12 @@ const STUDIO_SCRIPT = `
             const kindLabel = entry.surface || KIND_LABEL[group.kind] || group.kind;
             t.appendChild(el('span', 'kind', '(' + kindLabel + ')'));
             if (isInvoke) {
-              const btn = el('button', 'invoke-btn', 'Invoke');
-              btn.onclick = (e) => { e.stopPropagation(); selectTarget(entry.id, group.kind); };
-              t.appendChild(btn);
+              // No row-level action button: an invoke needs a composed payload,
+              // so the row just opens the composer (clicking anywhere on the
+              // .runnable row selects it -- cursor + hover signal it). A button
+              // labeled "Invoke" that only opened the composer (never invoked)
+              // read as broken. Serve rows DO get a Start/Stop button below
+              // because a serve start is parameterless and acts immediately.
               t.onclick = () => selectTarget(entry.id, group.kind);
               targetEls.set(entry.id, t);
             } else if (isServe) {

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -330,8 +330,8 @@ describe('toStudioTargetGroups', () => {
       'APIs',
       'ECS Services',
       'ECS Task Definitions',
-      'AgentCore Runtimes',
-      'AgentCore (serve)',
+      'AgentCore Runtimes (invoke)',
+      'AgentCore Runtimes (serve)',
       'Application Load Balancers',
       'CloudFront Distributions',
     ]);

--- a/tests/unit/local/studio-ui-agentcore-serve.test.ts
+++ b/tests/unit/local/studio-ui-agentcore-serve.test.ts
@@ -141,7 +141,7 @@ describe('studio agentcore-ws serve workspace (issue #454)', () => {
               groups: [
                 {
                   kind: 'agentcore-ws',
-                  title: 'AgentCore (serve)',
+                  title: 'AgentCore Runtimes (serve)',
                   entries: [
                     {
                       id: 'S/Http',
@@ -173,5 +173,50 @@ describe('studio agentcore-ws serve workspace (issue #454)', () => {
     expect(http?.agentCoreContractPath).toBe('/invocations');
     expect(mcp?.agentCoreHasWs).toBe(false);
     expect(mcp?.agentCoreContractPath).toBe('/mcp');
+  });
+
+  it('invoke rows carry no action button (click-to-open); serve rows keep Start', async () => {
+    // An invoke needs a composed payload, so the row has no button — it opens
+    // the composer on click (the .runnable class supplies cursor + hover). A
+    // serve start is parameterless, so the serve row keeps an acting button.
+    harness = createStudioHarness({ epilogue: EXPOSE }) as AcHarness;
+    const win = harness.window as AcHarness['window'];
+    (win as unknown as { fetch: unknown }).fetch = (url: string) => {
+      if (url === '/api/targets') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              groups: [
+                {
+                  kind: 'agentcore',
+                  title: 'AgentCore Runtimes (invoke)',
+                  entries: [{ id: 'S/Inv', qualifiedId: 'S:Inv' }],
+                },
+                {
+                  kind: 'agentcore-ws',
+                  title: 'AgentCore Runtimes (serve)',
+                  entries: [{ id: 'S/Srv', qualifiedId: 'S:Srv', agentCoreContractPath: '/mcp' }],
+                },
+              ],
+              dockerfiles: [],
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    };
+
+    await win.__t.loadTargets();
+
+    const doc = win.document;
+    const invokeRow = doc.querySelector('.target[data-tid="s/inv"]') as HTMLElement;
+    const serveRow = doc.querySelector('.target[data-tid="s/srv"]') as HTMLElement;
+    expect(invokeRow).toBeTruthy();
+    expect(serveRow).toBeTruthy();
+    // Invoke row: runnable + clickable, but NO action button.
+    expect(invokeRow.classList.contains('runnable')).toBe(true);
+    expect(invokeRow.querySelector('button')).toBeNull();
+    // Serve row: keeps an acting Start button.
+    expect(serveRow.querySelector('button')?.textContent).toBe('Start');
   });
 });


### PR DESCRIPTION
## Summary

Two studio-UI fixes surfaced while live-testing the warm-serve AgentCore work
(#454) in `cdkl studio`:

1. **AgentCore group names are now symmetric.** The two AgentCore target groups
   were titled "AgentCore Runtimes" (invoke) and "AgentCore (serve)" — asymmetric,
   and the second read as if only the serve entries were Runtimes (they are all
   Runtimes; invoke vs serve is the *action*). They are now
   **"AgentCore Runtimes (invoke)"** and **"AgentCore Runtimes (serve)"**.

2. **The dead row-level "Invoke" button is gone.** Invoke-kind rows (Lambda +
   AgentCore) rendered an "Invoke" button that only ever opened the composer —
   identical to clicking the row — and never actually invoked, because an invoke
   needs a composed payload. A button labeled "Invoke" that does not invoke reads
   as broken. The row now just opens the composer on click (the `.runnable` class
   already supplies the cursor + hover affordance). Serve rows are unchanged —
   they keep their `Start` / `Stop` button because a serve start is parameterless
   and acts immediately.

## Changes

- `src/local/studio-server.ts` — group titles → `(invoke)` / `(serve)`.
- `src/local/studio-ui.ts` — drop the `isInvoke` row button (keep the row
  `onclick` + selection); JSDoc updated.
- tests — title assertions updated + a new jsdom test locking the asymmetry:
  an invoke row has no action button (click-to-open), a serve row keeps `Start`.
- docs — README / `docs/cli-reference.md` / `.claude/CLAUDE.md` group-name
  references updated.

No library-surface change (studio internals only; edits to existing
`src/local/**` files, no new export) — cdkd parity is out of scope.

## Test plan

- `vp run check` / `vp run build` / `vp test run` (201 files, 3039 tests) — green.
- `/run-integ local-studio` — green against the worktree build; 0 Docker orphans.
- Live: rendered the targets pane — invoke rows open the composer on click with
  no button, serve rows keep `Start`, both AgentCore groups read
  `AgentCore Runtimes (invoke)` / `AgentCore Runtimes (serve)`.
