### PR TITLE
fix(studio): symmetric "(AgentCore)" row label across invoke/serve groups

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -353,7 +353,7 @@ const STUDIO_CSS = `
 `;
 
 const STUDIO_SCRIPT = `
-  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS Service', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore', 'agentcore-ws': 'AgentCore serve' };
+  const KIND_LABEL = { lambda: 'Lambda', api: 'API', alb: 'ALB', ecs: 'ECS Service', 'ecs-task': 'ECS Task', cloudfront: 'CloudFront', agentcore: 'AgentCore', 'agentcore-ws': 'AgentCore' };
   const SERVE_KINDS = ['api', 'alb', 'ecs', 'ecs-task', 'cloudfront', 'agentcore-ws']; // long-running serve targets (ecs-task = run-task; agentcore-ws = start-agentcore warm serve)
   const INVOKE_KINDS = ['lambda', 'agentcore']; // single-shot invoke targets (event composer)
   const rowsById = new Map();      // invocationId -> timeline row element

--- a/tests/unit/local/studio-ui-agentcore-serve.test.ts
+++ b/tests/unit/local/studio-ui-agentcore-serve.test.ts
@@ -218,5 +218,11 @@ describe('studio agentcore-ws serve workspace (issue #454)', () => {
     expect(invokeRow.querySelector('button')).toBeNull();
     // Serve row: keeps an acting Start button.
     expect(serveRow.querySelector('button')?.textContent).toBe('Start');
+    // Both groups' row kind labels read the same resource type "(AgentCore)" —
+    // the action (invoke vs serve) is conveyed by the group title, so the
+    // per-row parenthetical stays symmetric (not "(AgentCore)" vs
+    // "(AgentCore serve)").
+    expect(invokeRow.querySelector('.kind')?.textContent).toBe('(AgentCore)');
+    expect(serveRow.querySelector('.kind')?.textContent).toBe('(AgentCore)');
   });
 });

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -29,14 +29,16 @@ describe('renderStudioHtml', () => {
     expect(html).not.toMatch(/__OPTION_SPECS__ = [^;]*<\//);
   });
 
-  it('treats agentcore-ws as a serve kind with the AgentCore serve label', () => {
+  it('treats agentcore-ws as a serve kind with the AgentCore row label', () => {
     const html = renderStudioHtml('MyStack', 'cdkl');
     // agentcore-ws is a serve kind (Start/Stop + HTTP composer + WebSocket
     // console for HTTP/AGUI), distinct from the single-shot agentcore invoke
-    // kind. The label is "AgentCore serve" since start-agentcore now serves the
-    // warm HTTP contract too, not just /ws (issue #454).
+    // kind. The per-row label is just "AgentCore" (same as the invoke kind) —
+    // the action (invoke vs serve) is conveyed by the group title
+    // "AgentCore Runtimes (invoke)" / "(serve)", so the row parenthetical stays
+    // symmetric instead of "(AgentCore)" vs "(AgentCore serve)".
     expect(html).toContain("'agentcore-ws'");
-    expect(html).toContain("'agentcore-ws': 'AgentCore serve'");
+    expect(html).toContain("'agentcore-ws': 'AgentCore'");
     // Its per-run serve options are serialized too.
     expect(html).toContain('"--no-verify-auth"');
   });


### PR DESCRIPTION
## Summary

Follow-up to #463. After the AgentCore groups were renamed to
"AgentCore Runtimes (invoke)" / "AgentCore Runtimes (serve)", the **per-row kind
label** (the parenthetical to the right of each target name) was still
asymmetric: `(AgentCore)` in the invoke group but `(AgentCore serve)` in the
serve group. Since the group title already conveys the action (invoke vs serve)
and both rows are the same underlying runtime, the per-row label now reads
`(AgentCore)` in both groups.

## Changes

- `src/local/studio-ui.ts` — `KIND_LABEL['agentcore-ws']`:
  `'AgentCore serve'` → `'AgentCore'`.
- tests — update the label assertion in `studio-ui.test.ts` and extend the
  jsdom row test in `studio-ui-agentcore-serve.test.ts` to lock BOTH groups'
  row labels to `(AgentCore)`.

No docs change (the group titles documented in #463 are unchanged; the per-row
label is not documented). studio internals only — cdkd parity out of scope.

## Test plan

- `vp run check` / `vp run build` / `vp test run` (201 files, 3039 tests) — green.
- `/run-integ local-studio` — green; 0 Docker orphans.
- Live (jsdom): rendered the targets pane — invoke and serve AgentCore rows both
  show `(AgentCore)`.
