### PR TITLE
fix(studio): selection highlight follows the clicked row, not its same-id twin

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -362,7 +362,11 @@ const STUDIO_SCRIPT = `
   let lastHeaderMode = 'kv';       // remember the request-composer Headers editor mode (issue #345)
   let serveLogId = null;           // serve target whose LOGS <pre> is live (issue #334)
   let serveLogPre = null;          // the live serve LOGS <pre>, updated surgically on log events
-  const targetEls = new Map();     // targetId -> left-pane element
+  const targetEls = new Map();     // kind+id -> left-pane element (a runtime
+                                   // listed in two groups — agentcore invoke +
+                                   // agentcore-ws serve — shares an id, so the
+                                   // key includes the kind to avoid collision)
+  const targetElKey = (kind, id) => kind + '|' + id;
   const serveMeta = new Map();     // serve targetId -> { dot, btnSlot } row controls
   const serveState = new Map();    // serve targetId -> { status, endpoints }
   const stoppingIds = new Set();   // serve targetIds with a Stop in flight — button shows "Stopping..." until the stopped/error event (issue #394)
@@ -882,7 +886,7 @@ const STUDIO_SCRIPT = `
               // read as broken. Serve rows DO get a Start/Stop button below
               // because a serve start is parameterless and acts immediately.
               t.onclick = () => selectTarget(entry.id, group.kind);
-              targetEls.set(entry.id, t);
+              targetEls.set(targetElKey(group.kind, entry.id), t);
             } else if (isServe) {
               // A serve target: a running-state dot + a Start/Stop button
               // slot, both refreshed by updateServeRow on serve events.
@@ -891,7 +895,7 @@ const STUDIO_SCRIPT = `
               t.appendChild(dot);
               t.appendChild(btnSlot);
               t.onclick = () => selectTarget(entry.id, group.kind);
-              targetEls.set(entry.id, t);
+              targetEls.set(targetElKey(group.kind, entry.id), t);
               serveMeta.set(entry.id, {
                 dot,
                 btnSlot,
@@ -992,9 +996,9 @@ const STUDIO_SCRIPT = `
     if (shownServeId === id) renderServeWorkspace(id);
   }
 
-  function highlightTarget(id) {
+  function highlightTarget(id, kind) {
     document.querySelectorAll('.target.sel').forEach((n) => n.classList.remove('sel'));
-    const t = targetEls.get(id);
+    const t = targetEls.get(targetElKey(kind, id));
     if (t) t.classList.add('sel');
   }
 
@@ -1003,7 +1007,7 @@ const STUDIO_SCRIPT = `
     // a previously-shown serve (a log-driven re-render keeps it, an explicit
     // navigation drops it — see renderWsConsole).
     closeActiveWs();
-    highlightTarget(id);
+    highlightTarget(id, kind);
     // Navigating to a composer leaves no timeline row "selected" — a stale
     // row.sel from a previously-clicked event is confusing once the middle
     // pane has moved on (issue #336).
@@ -2054,7 +2058,7 @@ const STUDIO_SCRIPT = `
     document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'));
     const row = rowsById.get(id);
     if (row) row.classList.add('sel');
-    highlightTarget(ev.target);
+    highlightTarget(ev.target, ev.kind);
     if (INVOKE_KINDS.includes(ev.kind)) {
       // A single-shot invocation row (Lambda or AgentCore) reloads into the
       // re-invokable composer, pre-filled with the captured event and wired to

--- a/tests/unit/local/studio-ui-agentcore-serve.test.ts
+++ b/tests/unit/local/studio-ui-agentcore-serve.test.ts
@@ -225,4 +225,57 @@ describe('studio agentcore-ws serve workspace (issue #454)', () => {
     expect(invokeRow.querySelector('.kind')?.textContent).toBe('(AgentCore)');
     expect(serveRow.querySelector('.kind')?.textContent).toBe('(AgentCore)');
   });
+
+  it('selecting the invoke row highlights it, not the serve row with the same id', async () => {
+    // The same runtime id appears in BOTH the agentcore invoke group and the
+    // agentcore-ws serve group. The selection highlight must land on the row
+    // the user clicked — keyed by (kind, id), not id alone (which collided so
+    // the later-rendered serve row always won).
+    harness = createStudioHarness({ epilogue: EXPOSE }) as AcHarness;
+    const win = harness.window as AcHarness['window'];
+    (win as unknown as { fetch: unknown }).fetch = (url: string) => {
+      if (url === '/api/targets') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              groups: [
+                {
+                  kind: 'agentcore',
+                  title: 'AgentCore Runtimes (invoke)',
+                  entries: [{ id: 'S/Agent', qualifiedId: 'S:Agent' }],
+                },
+                {
+                  kind: 'agentcore-ws',
+                  title: 'AgentCore Runtimes (serve)',
+                  entries: [
+                    { id: 'S/Agent', qualifiedId: 'S:Agent', agentCoreContractPath: '/invocations' },
+                  ],
+                },
+              ],
+              dockerfiles: [],
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    };
+
+    await win.__t.loadTargets();
+
+    const doc = win.document;
+    const rows = doc.querySelectorAll('.target[data-tid="s/agent"]');
+    expect(rows.length).toBe(2);
+    const invokeRow = rows[0] as HTMLElement; // agentcore group rendered first
+    const serveRow = rows[1] as HTMLElement;
+
+    // Click the INVOKE row -> only it is highlighted.
+    invokeRow.click();
+    expect(invokeRow.classList.contains('sel')).toBe(true);
+    expect(serveRow.classList.contains('sel')).toBe(false);
+
+    // Click the SERVE row -> highlight moves to it, off the invoke row.
+    serveRow.click();
+    expect(serveRow.classList.contains('sel')).toBe(true);
+    expect(invokeRow.classList.contains('sel')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Studio UI bug: clicking an AgentCore runtime row in the **invoke** group
("AgentCore Runtimes (invoke)") highlighted the **serve** group's row instead
(it turned blue).

The same runtime id is listed in two groups — `agentcore` (invoke) and
`agentcore-ws` (serve). `targetEls` (the id → left-pane row map used by the
selection highlight) was keyed by `entry.id` alone, so the later-rendered serve
row overwrote the invoke row in the map. `highlightTarget(id)` then always
resolved to the serve row regardless of which row was clicked.

## Fix

Key `targetEls` by a `(kind, id)` composite (`targetElKey`) and thread the kind
into `highlightTarget(id, kind)`. `selectTarget` passes its own kind; the
timeline-row path passes `ev.kind`. So the highlight lands on the row the user
actually clicked.

Only AgentCore is dual-listed, so this is the only collision; all other kinds
are unaffected (same kind used on set + get).

## Changes

- `src/local/studio-ui.ts` — `targetElKey(kind, id)` composite key at the two
  `targetEls.set` sites + `highlightTarget(id, kind)` lookup + its two callers.
- test — jsdom case with the SAME id in both groups: clicking the invoke row
  highlights it (not the serve twin), clicking the serve row moves the highlight.

studio internals only (edit to an existing `src/local/**` file) — cdkd parity
out of scope.

## Test plan

- `vp run check` / `vp run build` / `vp test run` (201 files, 3040 tests) — green;
  the new test fails without the keyed fix.
- `/run-integ local-studio` — green; 0 Docker orphans.
