### PR TITLE
feat(start-cloudfront): accept a construct path / bare id for --kvs-file key

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -368,8 +368,10 @@ AWS managed services.
   the `AWS::CloudFront::KeyValueStore` ARN from state — the physical id is the
   store NAME, looked up to its ARN via the control-plane `ListKeyValueStores` —
   and reads it through the real `cloudfront-keyvaluestore` `GetKey` data-plane
-  API, SigV4A-signed) or a local JSON map (`--kvs-file <kvsLogicalId>=<file>`,
-  the AWS-free escape hatch symmetric with `--origin`). A KVS read with no
+  API, SigV4A-signed) or a local JSON map (`--kvs-file <key>=<file>`, the
+  AWS-free escape hatch symmetric with `--origin`; the `<key>` is a
+  KeyValueStore handle — its resource logical id, construct path, or bare
+  construct id, normalized to the logical id, issue #465). A KVS read with no
   binding fails with an actionable error naming both flags; `cf.kvs().meta()` /
   `count()` and KVS writes are not reproduced. A behavior's
   **Lambda@Edge** functions (`LambdaFunctionAssociations`) ARE run (issue
@@ -451,9 +453,11 @@ compute-locally category for Lambda + API Gateway).
   `--origin
   <id>=<dir>` is the local-directory escape hatch when neither resolves;
   `--no-pull` skips the Lambda
-  origin image pull; `--kvs-file <kvsLogicalId>=<file>` backs a CloudFront
+  origin image pull; `--kvs-file <key>=<file>` backs a CloudFront
   Function's KeyValueStore reads with a local JSON map (issue #399; the
-  deployed-store alternative is `--from-cfn-stack`).
+  `<key>` accepts the KeyValueStore logical id, construct path, or bare
+  construct id — `normalizeKvsFileKeys` resolves it to the logical id, issue
+  #465; the deployed-store alternative is `--from-cfn-stack`).
   `start-service` and `start-alb` share one neutral orchestration
   in `commands/ecs-service-emulator.ts` (synth + shared docker network +
   Cloud Map + restart watcher + optional front-door); each command is a

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1683,11 +1683,14 @@ its `DistributionConfig`:
     control-plane `ListKeyValueStores`), and the read hits the real
     `cloudfront-keyvaluestore` `GetKey` data-plane API. The deployed store's
     data is read live — exactly like a Lambda reaching a real managed service.
-  - **`--kvs-file <kvsLogicalId>=<file.json>`** — a local
+  - **`--kvs-file <key>=<file.json>`** — a local
     `{ "key": "value" }` map backs the reads with no AWS (the AWS-free escape
-    hatch, symmetric with `--origin`). The key is the
-    `AWS::CloudFront::KeyValueStore` resource logical id (named in the boot
-    warning when a read is unbound).
+    hatch, symmetric with `--origin`). The key is a KeyValueStore handle — its
+    `AWS::CloudFront::KeyValueStore` resource logical id, its construct path
+    (e.g. `MyStack/RoutesKvs`), or its bare construct id (e.g. `RoutesKvs`) —
+    so you don't have to synth + grep for the hash-suffixed logical id. An
+    unrecognized key fails fast listing the distribution's KeyValueStore
+    candidates.
 
   A read with neither binding fails with an actionable error naming both
   flags. `cf.kvs().meta()` / `count()` and KVS writes are not reproduced.
@@ -1772,7 +1775,7 @@ On top of the [common flags](#common-flags):
 | `--port <port>` | `0` (auto-allocate) | Host port for the local server. |
 | `--host <host>` | `127.0.0.1` | Bind address. |
 | `--origin <originId=dir>` | — | Point a distribution origin at a local directory (repeatable). Use when cdk-local cannot resolve the origin's BucketDeployment source automatically AND you do not want the deployed-S3 read-through (content uploaded out of band, or a non-CDK bucket). Wins over both the BucketDeployment source and the `--from-cfn-stack` deployed-S3 path. |
-| `--kvs-file <kvsLogicalId=file.json>` | — | Back a CloudFront Function's KeyValueStore reads (`cf.kvs().get()`) with a local JSON map (repeatable). The key is the `AWS::CloudFront::KeyValueStore` resource logical id; the file is a flat `{ "key": "value" }` object path. The AWS-free alternative to `--from-cfn-stack`, which instead reads the deployed store via `GetKey`. |
+| `--kvs-file <key=file.json>` | — | Back a CloudFront Function's KeyValueStore reads (`cf.kvs().get()`) with a local JSON map (repeatable). The key is a KeyValueStore handle — its `AWS::CloudFront::KeyValueStore` resource logical id, its construct path (`MyStack/RoutesKvs`), or its bare construct id (`RoutesKvs`); the file is a flat `{ "key": "value" }` object path. The AWS-free alternative to `--from-cfn-stack`, which instead reads the deployed store via `GetKey`. |
 | `--tls` | off | Terminate real HTTPS. Uses `--tls-cert` / `--tls-key` when supplied, else an auto-generated self-signed cert (cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`; requires `openssl` on PATH). Implied by `--tls-cert` / `--tls-key`. |
 | `--tls-cert <path>` | unset | PEM server certificate. Implies `--tls`; must be set with `--tls-key`. |
 | `--tls-key <path>` | unset | PEM server private key matching `--tls-cert`. Implies `--tls`; must be set with `--tls-cert`. |

--- a/src/cli/commands/local-start-cloudfront.ts
+++ b/src/cli/commands/local-start-cloudfront.ts
@@ -47,7 +47,7 @@ import {
 import { parseEcsTarget } from '../../local/ecs-task-resolver.js';
 import { listTargets } from '../../local/target-lister.js';
 import { resolveSingleTarget } from '../../local/target-picker.js';
-import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cdk-path.js';
+import { buildCdkPathIndex, readCdkPath, resolveCdkPathToLogicalIds } from '../cdk-path.js';
 import { matchStacks } from '../stack-matcher.js';
 import { resolveApp, resolveWatchConfig } from '../config-loader.js';
 import {
@@ -62,6 +62,7 @@ import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { getLogger } from '../../utils/logger.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import type { StackInfo } from '../../synthesis/assembly-reader.js';
+import type { CloudFormationTemplate } from '../../types/resource.js';
 import { CLOUDFRONT_DISTRIBUTION_TYPE } from '../../local/cloudfront-resolver.js';
 import { createWatchPredicates } from './local-start-api.js';
 
@@ -155,12 +156,13 @@ export function parseOriginOverrides(values: string[] | undefined): Map<string, 
 }
 
 /**
- * Parse the repeatable `--kvs-file <kvsLogicalId>=<file.json>` overrides into a
+ * Parse the repeatable `--kvs-file <key>=<file.json>` overrides into a
  * map. Each entry backs a CloudFront Function's `cf.kvs()` reads with a local
  * JSON map instead of the deployed store — the AWS-free escape hatch for KVS,
- * symmetric with `--origin <id>=<dir>`. The key is the
- * `AWS::CloudFront::KeyValueStore` resource logical id (surfaced in the
- * unbound-KVS boot warning when missing).
+ * symmetric with `--origin <id>=<dir>`. The key is a KeyValueStore handle —
+ * its `AWS::CloudFront::KeyValueStore` resource logical id, its construct path,
+ * or its bare construct id — resolved to a logical id by
+ * {@link normalizeKvsFileKeys} once the template is known.
  */
 export function parseKvsFileOverrides(values: string[] | undefined): Map<string, string> {
   const out = new Map<string, string>();
@@ -168,10 +170,93 @@ export function parseKvsFileOverrides(values: string[] | undefined): Map<string,
     const eq = raw.indexOf('=');
     if (eq <= 0 || eq === raw.length - 1) {
       throw new LocalStartCloudFrontError(
-        `Invalid --kvs-file '${raw}'. Expected <kvsLogicalId>=<file.json> (e.g. MyKvsStore=./kvs.json).`
+        `Invalid --kvs-file '${raw}'. Expected <key>=<file.json> (e.g. RoutesKvs=./kvs.json).`
       );
     }
     out.set(raw.slice(0, eq).trim(), raw.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+/** A KeyValueStore resource identity, indexed for `--kvs-file` key matching. */
+interface KvsStoreIdentity {
+  logicalId: string;
+  /** The L1 `aws:cdk:path`, e.g. `App/RoutesKvs/Resource` (absent if unsynthed). */
+  cdkPath?: string;
+  /** The construct path the user thinks in, e.g. `App/RoutesKvs` (no `/Resource`). */
+  constructPath?: string;
+  /** The bare construct id, the last `constructPath` segment, e.g. `RoutesKvs`. */
+  constructId?: string;
+}
+
+/** Index every `AWS::CloudFront::KeyValueStore` in a template for key matching. */
+function collectKvsStoreIdentities(template: CloudFormationTemplate): KvsStoreIdentity[] {
+  const out: KvsStoreIdentity[] = [];
+  for (const [logicalId, resource] of Object.entries(template.Resources ?? {})) {
+    if (resource.Type !== 'AWS::CloudFront::KeyValueStore') continue;
+    const cdkPath = readCdkPath(resource) || undefined;
+    // CDK synthesizes the L1 path as `<...>/<construct>/Resource`; strip the
+    // trailing `/Resource` so the construct path is what the user wrote in CDK.
+    const constructPath = cdkPath?.endsWith('/Resource')
+      ? cdkPath.slice(0, -'/Resource'.length)
+      : cdkPath;
+    const constructId = constructPath?.split('/').pop();
+    out.push({
+      logicalId,
+      ...(cdkPath !== undefined && { cdkPath }),
+      ...(constructPath !== undefined && { constructPath }),
+      ...(constructId !== undefined && constructId !== '' && { constructId }),
+    });
+  }
+  return out;
+}
+
+/**
+ * Resolve the `--kvs-file` keys (a logical id, a construct path, or a bare
+ * construct id) to `AWS::CloudFront::KeyValueStore` resource logical ids, so the
+ * binding layer — which matches strictly by logical id — finds them. Mirrors the
+ * construct-path ergonomics the `start-cloudfront` target argument already has,
+ * removing the need to synth + grep the template for the hash-suffixed logical
+ * id (issue #465).
+ *
+ * Match priority per key: exact logical id, then exact construct path (the
+ * `aws:cdk:path` with or without the synthesized `/Resource` leaf), then bare
+ * construct id. A key matching no store, or a bare id matching more than one,
+ * throws a {@link LocalStartCloudFrontError} listing the candidates.
+ */
+export function normalizeKvsFileKeys(
+  kvsFiles: Map<string, string>,
+  template: CloudFormationTemplate
+): Map<string, string> {
+  if (kvsFiles.size === 0) return kvsFiles;
+  const stores = collectKvsStoreIdentities(template);
+  const candidates = (): string =>
+    stores
+      .map((s) => (s.constructPath ? `${s.logicalId} (${s.constructPath})` : s.logicalId))
+      .join(', ') || '(none in this distribution)';
+
+  const out = new Map<string, string>();
+  for (const [key, filePath] of kvsFiles) {
+    // Priority order: exact logical id -> exact construct path -> bare id.
+    const tiers: KvsStoreIdentity[][] = [
+      stores.filter((s) => s.logicalId === key),
+      stores.filter((s) => s.constructPath === key || s.cdkPath === key),
+      stores.filter((s) => s.constructId === key),
+    ];
+    const matched = tiers.find((t) => t.length > 0) ?? [];
+    if (matched.length === 0) {
+      throw new LocalStartCloudFrontError(
+        `--kvs-file key '${key}' matched no AWS::CloudFront::KeyValueStore in the distribution. ` +
+          `Pass a store's logical id, construct path, or bare construct id. Candidates: ${candidates()}.`
+      );
+    }
+    if (matched.length > 1) {
+      throw new LocalStartCloudFrontError(
+        `--kvs-file key '${key}' is ambiguous — it matched ${matched.length} KeyValueStores ` +
+          `(${matched.map((s) => s.logicalId).join(', ')}). Use the logical id or full construct path.`
+      );
+    }
+    out.set(matched[0]!.logicalId, filePath);
   }
   return out;
 }
@@ -192,9 +277,13 @@ async function attachKvsModules(
   logger: ReturnType<typeof getLogger>,
   extraStateProviders: ExtraStateProviders | undefined
 ): Promise<void> {
-  const kvsFiles = parseKvsFileOverrides(options.kvsFile);
   const stack = stacks.find((s) => s.stackName === distribution.stackName);
   const synthRegion = stack?.region;
+  // Accept a logical id, construct path, or bare construct id for the --kvs-file
+  // key; normalize to the logical id the binding layer matches on (issue #465).
+  const kvsFiles = stack
+    ? normalizeKvsFileKeys(parseKvsFileOverrides(options.kvsFile), stack.template)
+    : parseKvsFileOverrides(options.kvsFile);
 
   const resolveDeployedKvs = isCfnFlagPresent(options)
     ? async (kvsLogicalId: string): Promise<DeployedKvsRef | undefined> => {
@@ -906,9 +995,10 @@ export function addStartCloudFrontSpecificOptions(cmd: Command): Command {
     )
     .addOption(
       new Option(
-        '--kvs-file <kvsLogicalId=file.json>',
+        '--kvs-file <key=file.json>',
         "Back a CloudFront Function's KeyValueStore reads (cf.kvs().get()) with a local JSON map " +
-          '(repeatable). The key is the AWS::CloudFront::KeyValueStore resource logical id; the file is a flat ' +
+          '(repeatable). The key is a KeyValueStore handle — its AWS::CloudFront::KeyValueStore resource ' +
+          'logical id, its construct path, or its bare construct id; the file is a flat ' +
           '{ "key": "value" } object. The AWS-free alternative to --from-cfn-stack, which instead reads the ' +
           'deployed store via the GetKey API.'
       ).argParser((value: string, prev: string[] | undefined) => [...(prev ?? []), value])

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -713,6 +713,7 @@ export {
   resolveCloudFrontTarget,
   parseOriginOverrides,
   parseKvsFileOverrides,
+  normalizeKvsFileKeys,
   LocalStartCloudFrontError,
 } from './cli/commands/local-start-cloudfront.js';
 

--- a/tests/integration/local-start-cloudfront/verify.sh
+++ b/tests/integration/local-start-cloudfront/verify.sh
@@ -68,29 +68,18 @@ if [[ ! -d node_modules ]]; then
   vp install --prefer-offline
 fi
 
-# Synth once so we can read the AWS::CloudFront::KeyValueStore logical id (the
-# --kvs-file key is the resource logical id) out of the template, rather than
-# hardcoding its hash-suffixed value (which a CDK version bump could change).
-echo "==> Synth + extract the KeyValueStore logical id"
-# CDK App auto-synths only under the CDK CLI (i.e. when CDK_OUTDIR is set);
-# set it so a standalone `node bin/app.ts` writes the assembly to cdk.out.
-CDK_OUTDIR=cdk.out node bin/app.ts >/dev/null 2>&1 || fail "standalone synth (node bin/app.ts) failed"
-KVS_ID=$(node -e '
-const fs = require("fs");
-for (const f of fs.readdirSync("cdk.out").filter((x) => x.endsWith(".template.json"))) {
-  const t = JSON.parse(fs.readFileSync("cdk.out/" + f, "utf-8"));
-  for (const [id, r] of Object.entries(t.Resources || {})) {
-    if (r.Type === "AWS::CloudFront::KeyValueStore") { console.log(id); process.exit(0); }
-  }
-}
-process.exit(1);
-') || fail "could not find an AWS::CloudFront::KeyValueStore in the synthesized template"
-echo "    KeyValueStore logical id: ${KVS_ID}"
+# The --kvs-file key is a KeyValueStore HANDLE: its logical id, its construct
+# path, or its bare construct id (issue #465). We pass the bare construct id
+# `RoutesKvs` — the stable, ergonomic form — instead of the hash-suffixed logical
+# id, so this run exercises the construct-id -> logical-id normalization
+# end-to-end (the binding still matches strictly by logical id). cdkl resolves it
+# from the synthesized template's aws:cdk:path; no standalone synth + grep needed.
+KVS_KEY="RoutesKvs"
 KVS_FILE="$(pwd)/kvs.json"
 
-echo "==> Booting: cdkl start-cloudfront ${TARGET} --port ${PORT} --watch --kvs-file ${KVS_ID}=${KVS_FILE}"
+echo "==> Booting: cdkl start-cloudfront ${TARGET} --port ${PORT} --watch --kvs-file ${KVS_KEY}=${KVS_FILE}"
 ${CDKL} start-cloudfront "${TARGET}" --port "${PORT}" --watch \
-  --kvs-file "${KVS_ID}=${KVS_FILE}" > "${OUT_FILE}" 2>&1 &
+  --kvs-file "${KVS_KEY}=${KVS_FILE}" > "${OUT_FILE}" 2>&1 &
 CDKL_PID=$!
 
 echo "==> Waiting for the server banner"
@@ -124,9 +113,11 @@ echo "${FOO_BODY}" | grep -qi "foo page" \
 # 2b. KeyValueStore-backed viewer-request rewrite (--kvs-file): the /kv/*
 #     behavior's function reads cf.kvs().get('/kv/go') -> '/foo/index.html'
 #     from the local JSON map, exercising the import-cf-from-cloudfront
-#     transform + cf.kvs() runtime path with no AWS. (issue #399)
+#     transform + cf.kvs() runtime path with no AWS (issue #399). The
+#     --kvs-file key here is the BARE CONSTRUCT ID `RoutesKvs`, so a passing
+#     rewrite proves the construct-id -> logical-id normalization too (#465).
 # ---------------------------------------------------------------------------
-echo "==> GET /kv/go (KeyValueStore rewrite -> /foo/index.html via --kvs-file)"
+echo "==> GET /kv/go (KeyValueStore rewrite -> /foo/index.html via --kvs-file RoutesKvs=...)"
 KV_BODY=$(curl -fsS "${BASE}/kv/go") || fail "GET /kv/go failed"
 echo "${KV_BODY}" | grep -qi "foo page" \
   || fail "KeyValueStore-backed rewrite did not resolve /kv/go to /foo/index.html"
@@ -230,4 +221,4 @@ CDKL_PID=""
 sleep 0.5
 if lsof -ti "tcp:${PORT}" >/dev/null 2>&1; then fail "port ${PORT} still bound after shutdown"; fi
 
-echo "PASS: cdkl start-cloudfront served the viewer-request -> S3 origin -> viewer-response pipeline, a KeyValueStore-backed rewrite (--kvs-file), a Buffer-using Basic-Auth function (issue #410), the SPA fallback, ResponseHeadersPolicy CORS (preflight + actual-response), and a --watch reload."
+echo "PASS: cdkl start-cloudfront served the viewer-request -> S3 origin -> viewer-response pipeline, a KeyValueStore-backed rewrite via a bare-construct-id --kvs-file key (issues #399 + #465), a Buffer-using Basic-Auth function (issue #410), the SPA fallback, ResponseHeadersPolicy CORS (preflight + actual-response), and a --watch reload."

--- a/tests/unit/cli/local-start-cloudfront.test.ts
+++ b/tests/unit/cli/local-start-cloudfront.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
   createLocalStartCloudFrontCommand,
+  normalizeKvsFileKeys,
   parseKvsFileOverrides,
   parseOriginOverrides,
   resolveCloudFrontTarget,
@@ -85,8 +86,98 @@ describe('parseKvsFileOverrides', () => {
   });
 
   it('rejects a malformed value', () => {
-    expect(() => parseKvsFileOverrides(['nope'])).toThrow(/Expected <kvsLogicalId>=<file.json>/);
-    expect(() => parseKvsFileOverrides(['=x.json'])).toThrow(/Expected <kvsLogicalId>=<file.json>/);
+    expect(() => parseKvsFileOverrides(['nope'])).toThrow(/Expected <key>=<file.json>/);
+    expect(() => parseKvsFileOverrides(['=x.json'])).toThrow(/Expected <key>=<file.json>/);
+  });
+});
+
+describe('normalizeKvsFileKeys', () => {
+  const kvsTemplate: CloudFormationTemplate = {
+    Resources: {
+      RoutesKvs8B16D3AA: {
+        Type: 'AWS::CloudFront::KeyValueStore',
+        Properties: {},
+        Metadata: { 'aws:cdk:path': 'App/RoutesKvs/Resource' },
+      },
+      OtherStoreABC123: {
+        Type: 'AWS::CloudFront::KeyValueStore',
+        Properties: {},
+        Metadata: { 'aws:cdk:path': 'App/Nested/OtherStore/Resource' },
+      },
+    },
+  };
+
+  it('passes a logical-id key through unchanged', () => {
+    const out = normalizeKvsFileKeys(new Map([['RoutesKvs8B16D3AA', './kvs.json']]), kvsTemplate);
+    expect(out.get('RoutesKvs8B16D3AA')).toBe('./kvs.json');
+  });
+
+  it('resolves a construct path to the logical id', () => {
+    const out = normalizeKvsFileKeys(new Map([['App/RoutesKvs', './kvs.json']]), kvsTemplate);
+    expect(out.get('RoutesKvs8B16D3AA')).toBe('./kvs.json');
+    expect(out.has('App/RoutesKvs')).toBe(false);
+  });
+
+  it('resolves the full L1 aws:cdk:path (with /Resource) to the logical id', () => {
+    const out = normalizeKvsFileKeys(new Map([['App/RoutesKvs/Resource', './kvs.json']]), kvsTemplate);
+    expect(out.get('RoutesKvs8B16D3AA')).toBe('./kvs.json');
+  });
+
+  it('resolves a bare construct id to the logical id', () => {
+    const out = normalizeKvsFileKeys(new Map([['OtherStore', './o.json']]), kvsTemplate);
+    expect(out.get('OtherStoreABC123')).toBe('./o.json');
+  });
+
+  it('returns the same empty map without scanning', () => {
+    const empty = new Map<string, string>();
+    expect(normalizeKvsFileKeys(empty, kvsTemplate)).toBe(empty);
+  });
+
+  it('throws with candidates when the key matches no store', () => {
+    expect(() => normalizeKvsFileKeys(new Map([['Nope', './x.json']]), kvsTemplate)).toThrow(
+      /matched no AWS::CloudFront::KeyValueStore.*RoutesKvs8B16D3AA \(App\/RoutesKvs\)/s
+    );
+  });
+
+  it('throws on an ambiguous bare id shared by two stores', () => {
+    const ambiguous: CloudFormationTemplate = {
+      Resources: {
+        A1: {
+          Type: 'AWS::CloudFront::KeyValueStore',
+          Properties: {},
+          Metadata: { 'aws:cdk:path': 'App/One/Store/Resource' },
+        },
+        B2: {
+          Type: 'AWS::CloudFront::KeyValueStore',
+          Properties: {},
+          Metadata: { 'aws:cdk:path': 'App/Two/Store/Resource' },
+        },
+      },
+    };
+    expect(() => normalizeKvsFileKeys(new Map([['Store', './x.json']]), ambiguous)).toThrow(
+      /ambiguous.*A1, B2/s
+    );
+  });
+
+  it('prefers an exact logical id over a colliding bare id', () => {
+    const collide: CloudFormationTemplate = {
+      Resources: {
+        // A store whose logical id equals another store's bare construct id.
+        Store: {
+          Type: 'AWS::CloudFront::KeyValueStore',
+          Properties: {},
+          Metadata: { 'aws:cdk:path': 'App/Primary/Resource' },
+        },
+        Other: {
+          Type: 'AWS::CloudFront::KeyValueStore',
+          Properties: {},
+          Metadata: { 'aws:cdk:path': 'App/Store/Resource' },
+        },
+      },
+    };
+    const out = normalizeKvsFileKeys(new Map([['Store', './x.json']]), collide);
+    expect(out.get('Store')).toBe('./x.json');
+    expect(out.has('Other')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`cdkl start-cloudfront --kvs-file <key>=<file.json>` previously required the
hash-suffixed `AWS::CloudFront::KeyValueStore` resource logical id as the key,
unlike the `start-cloudfront` target argument which accepts a construct path.
Users naturally tried the construct path / bare id and silently got an unbound
store (the `cf.kvs()` read then failed at runtime).

`--kvs-file` now accepts a KeyValueStore **handle** — its logical id, its
construct path (`MyStack/RoutesKvs`), or its bare construct id (`RoutesKvs`).
A new `normalizeKvsFileKeys` runs in the command after synth: it indexes each
`AWS::CloudFront::KeyValueStore` by logical id + `aws:cdk:path` (construct path
with/without the synthesized `/Resource` leaf) + bare construct id, then maps
each user key to a logical id (priority: logical id -> construct path -> bare
id). The binding layer still matches strictly by logical id, so it is
unchanged.

## Behavior change

- The `<key>` left-hand side of `--kvs-file` now accepts a construct path /
  bare construct id in addition to the logical id (additive).
- An **unrecognized** `--kvs-file` key (or an **ambiguous** bare id matching
  more than one store) now **fails fast** at boot with an error listing the
  distribution's KeyValueStore candidates. Previously an unknown key was
  silently ignored (the store stayed unbound and the read failed later at
  runtime). cdkd parity tracked at https://github.com/go-to-k/cdkd/issues/780
  (cdkd's `local start-cloudfront` wrapper inherits this automatically).

## Test plan

- Unit: `normalizeKvsFileKeys` matrix — logical-id passthrough (regression),
  construct path, full L1 `aws:cdk:path`, bare id, empty map, unknown-key
  candidate listing, ambiguous bare id, logical-id-over-bare-id precedence.
  Full suite: 201 files / 3047 tests green.
- Integ: `local-start-cloudfront` now boots with the bare construct id
  `--kvs-file RoutesKvs=...`, so the `/kv/go` rewrite passing proves the
  construct-id -> logical-id normalization end-to-end (no AWS, Docker).
- Live: ran the built CLI against the fixture — an unknown key fast-fails with
  the candidate list (no serve), and the full construct path
  `CdkLocalStartCloudFrontFixture/RoutesKvs` serves `/kv/go` with no unbound
  warning.

Closes #465
