### PR TITLE
test: stop reused forks worker from hanging / crashing on teardown (#402)

### DIFF
--- a/tests/setup-helpers.ts
+++ b/tests/setup-helpers.ts
@@ -1,0 +1,107 @@
+/// <reference types="node" />
+
+/**
+ * Pure, side-effect-free helpers used by `tests/setup.ts` to make a reused
+ * vitest forks worker tear down cleanly (issue #402). Kept in their own module
+ * so they can be unit-tested with a fake process / globals bag WITHOUT
+ * signalling the real worker process (which would kill the test run) and
+ * WITHOUT re-triggering `tests/setup.ts`'s global side effects on import.
+ */
+
+/** The minimal `process`-shaped surface these helpers touch. */
+export interface SignalProcessLike {
+  exit: (code?: number) => never;
+  prependListener: (signal: string, listener: (...args: unknown[]) => void) => unknown;
+  listeners: (signal: string) => Array<(...args: unknown[]) => void>;
+  removeListener: (signal: string, listener: (...args: unknown[]) => void) => unknown;
+}
+
+/** Worker-global keys (stashed on `globalThis`, shared across files in a worker). */
+export const REAL_EXIT_KEY = '__cdk_local_test_original_exit__';
+export const FAST_TERMINATE_KEY = '__cdk_local_test_fast_terminate__';
+
+/** Signals tinypool / a Ctrl-C may use to terminate a worker. */
+export const TERMINATE_SIGNALS = ['SIGTERM', 'SIGINT'] as const;
+
+type GlobalsBag = Record<string, unknown>;
+
+/**
+ * Capture the REAL `process.exit` ONCE per worker.
+ *
+ * setupFiles re-run per test file (vitest isolates the module registry), but
+ * `process` is a true global shared across files in the reused worker — so on
+ * the 2nd+ file `process.exit` is ALREADY the no-op installed by the 1st file.
+ * Stash the genuine exit on a worker-global the first time only, and read it
+ * back everywhere so the fast-terminate guard never calls the no-op.
+ */
+export function resolveRealExit(
+  globals: GlobalsBag,
+  proc: Pick<SignalProcessLike, 'exit'>
+): (code?: number) => never {
+  if (typeof globals[REAL_EXIT_KEY] !== 'function') {
+    globals[REAL_EXIT_KEY] = proc.exit;
+  }
+  return globals[REAL_EXIT_KEY] as (code?: number) => never;
+}
+
+/**
+ * Install a fast-terminate guard, PREPENDED so it runs FIRST on SIGTERM /
+ * SIGINT and exits immediately via the supplied real (un-stubbed) exit.
+ *
+ * tinypool terminates a REUSED forks worker by sending it SIGTERM
+ * (`ProcessWorker.terminate()` -> `child.kill()`). CLI command actions
+ * exercised by unit tests register graceful-shutdown
+ * `process.on('SIGTERM' | 'SIGINT', ...)` handlers (docker / server / front-door
+ * teardown) that never resolve under mocks. A registered SIGTERM listener
+ * SUPPRESSES Node's default terminate-on-signal, so at worker teardown the
+ * leftover graceful handler runs and stalls — vitest reports "Timeout
+ * terminating forks worker" and fails an otherwise-green suite.
+ *
+ * Running first + exiting beats every leftover handler to the punch. Installed
+ * once per worker (guarded on a worker-global, since setupFiles re-run per
+ * file) and the SAME function object is reused across files so
+ * {@link pruneForeignSignalListeners} can tell it apart from foreign handlers.
+ * Returns the stable guard function.
+ */
+export function installTerminateGuard(
+  globals: GlobalsBag,
+  proc: SignalProcessLike,
+  realExit: (code?: number) => never
+): (...args: unknown[]) => void {
+  const existing = globals[FAST_TERMINATE_KEY] as ((...args: unknown[]) => void) | undefined;
+  if (existing) {
+    return existing;
+  }
+
+  const fastTerminate = (): void => {
+    realExit(0);
+  };
+  globals[FAST_TERMINATE_KEY] = fastTerminate;
+  for (const signal of TERMINATE_SIGNALS) {
+    proc.prependListener(signal, fastTerminate);
+  }
+  return fastTerminate;
+}
+
+/**
+ * Remove every SIGTERM / SIGINT listener EXCEPT the fast-terminate guard.
+ *
+ * CLI command actions register a fresh graceful-shutdown handler each time a
+ * test drives them; across many files in a reused worker these accumulate
+ * (MaxListeners noise) and retain references to servers / sockets that can
+ * contribute to the "Worker exited unexpectedly" native-handle crash. Pruning
+ * at each file boundary keeps only our guard so the worker stays lean and
+ * terminates cleanly.
+ */
+export function pruneForeignSignalListeners(
+  proc: SignalProcessLike,
+  keep: (...args: unknown[]) => void
+): void {
+  for (const signal of TERMINATE_SIGNALS) {
+    for (const listener of proc.listeners(signal)) {
+      if (listener !== keep) {
+        proc.removeListener(signal, listener);
+      }
+    }
+  }
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,11 @@
 /// <reference types="node" />
 
 import { afterAll, vi } from 'vite-plus/test';
+import {
+  installTerminateGuard,
+  pruneForeignSignalListeners,
+  resolveRealExit,
+} from './setup-helpers.js';
 
 /**
  * Global vitest setup — defenses against Node 24 + vitest 1.6.1 surfacing
@@ -95,15 +100,27 @@ vi.fn = ((implementation?: MockableImplementation) => {
   return wrapMockImplementationSetters(originalViFn(implementation as never));
 }) as typeof vi.fn;
 
-const originalExit = process.exit;
+// Capture the REAL `process.exit` ONCE per worker (stashed on a worker-global
+// keyed by REAL_EXIT_KEY). setupFiles re-run per test file, but `process` is a
+// true global shared across files in the reused worker — so on the 2nd+ file
+// `process.exit` is ALREADY the no-op installed by the 1st file. resolveRealExit
+// stores + returns the genuine exit so neither the no-op replacement below nor
+// the terminate guard ever loses the real one.
+const workerGlobals = globalThis as Record<string, unknown>;
+const realProcessExit = resolveRealExit(workerGlobals, process);
 
-// Replace `process.exit` with a no-op. See module docstring for the why.
+// Replace `process.exit` with a no-op. See module docstring for the why. The
+// real exit stays available to anything reading `globalThis[REAL_EXIT_KEY]`
+// (the previously-named `__cdk_local_test_original_exit__` global).
 (process as unknown as { exit: (code?: number) => never }).exit = ((_code?: number): never => {
   return undefined as never;
 }) as never;
 
-// Keep a reference to the real exit in case anything downstream wants it.
-(globalThis as Record<string, unknown>).__cdk_local_test_original_exit__ = originalExit;
+// Install the per-worker fast-terminate guard (issue #402, hang variant). It is
+// PREPENDED so it wins the SIGTERM / SIGINT race against any graceful-shutdown
+// handler a CLI command action registered during a test, exiting the worker
+// immediately on teardown via the real (un-stubbed) exit. See setup-helpers.ts.
+const fastTerminate = installTerminateGuard(workerGlobals, process, realProcessExit);
 
 /**
  * Per-file teardown: destroy the undici (Node global `fetch`) keep-alive pool
@@ -145,6 +162,13 @@ interface UndiciDispatcher {
 }
 
 afterAll(async () => {
+  // Prune any SIGTERM / SIGINT handlers a CLI command action registered while
+  // driving its parse during this file (issue #402). They accumulate across
+  // files in the reused worker (MaxListeners noise) and retain server / socket
+  // references that feed the "Worker exited unexpectedly" native-handle crash;
+  // our prepended fast-terminate guard is preserved.
+  pruneForeignSignalListeners(process, fastTerminate);
+
   const slot = globalThis as Record<symbol, unknown>;
   const dispatcher = slot[UNDICI_GLOBAL_DISPATCHER] as UndiciDispatcher | undefined;
   // Undefined until the worker issues its first `fetch`; nothing to clear.

--- a/tests/unit/setup-helpers.test.ts
+++ b/tests/unit/setup-helpers.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import {
+  FAST_TERMINATE_KEY,
+  REAL_EXIT_KEY,
+  TERMINATE_SIGNALS,
+  installTerminateGuard,
+  pruneForeignSignalListeners,
+  resolveRealExit,
+  type SignalProcessLike,
+} from '../setup-helpers.js';
+
+type Listener = (...args: unknown[]) => void;
+
+/** A minimal fake `process` recording prepend / remove against per-signal lists. */
+function makeFakeProcess(exit: (code?: number) => never): SignalProcessLike & {
+  store: Map<string, Listener[]>;
+} {
+  const store = new Map<string, Listener[]>();
+  return {
+    store,
+    exit,
+    prependListener(signal, listener) {
+      const list = store.get(signal) ?? [];
+      list.unshift(listener);
+      store.set(signal, list);
+      return this;
+    },
+    listeners(signal) {
+      return [...(store.get(signal) ?? [])];
+    },
+    removeListener(signal, listener) {
+      const list = store.get(signal) ?? [];
+      store.set(
+        signal,
+        list.filter((l) => l !== listener)
+      );
+      return this;
+    },
+  };
+}
+
+const noopExit = (() => undefined) as unknown as (code?: number) => never;
+
+describe('resolveRealExit', () => {
+  it('captures the real exit on first call and stashes it under REAL_EXIT_KEY', () => {
+    const globals: Record<string, unknown> = {};
+    const realExit = noopExit;
+    const resolved = resolveRealExit(globals, { exit: realExit });
+    expect(resolved).toBe(realExit);
+    expect(globals[REAL_EXIT_KEY]).toBe(realExit);
+  });
+
+  it('returns the FIRST captured exit even when a later file passes the no-op', () => {
+    const globals: Record<string, unknown> = {};
+    const realExit = (() => undefined) as unknown as (code?: number) => never;
+    resolveRealExit(globals, { exit: realExit });
+
+    // Simulate the 2nd file: process.exit has been replaced with a no-op.
+    const noop = (() => undefined) as unknown as (code?: number) => never;
+    const resolvedSecond = resolveRealExit(globals, { exit: noop });
+
+    expect(resolvedSecond).toBe(realExit);
+    expect(resolvedSecond).not.toBe(noop);
+  });
+});
+
+describe('installTerminateGuard', () => {
+  it('prepends a guard on every terminate signal that exits via the real exit', () => {
+    const globals: Record<string, unknown> = {};
+    const exitSpy = vi.fn();
+    const proc = makeFakeProcess(exitSpy as unknown as (code?: number) => never);
+
+    const guard = installTerminateGuard(
+      globals,
+      proc,
+      exitSpy as unknown as (code?: number) => never
+    );
+
+    for (const signal of TERMINATE_SIGNALS) {
+      expect(proc.listeners(signal)).toContain(guard);
+    }
+
+    guard();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('is idempotent per worker — only installs once and returns the same function', () => {
+    const globals: Record<string, unknown> = {};
+    const proc = makeFakeProcess(noopExit);
+
+    const first = installTerminateGuard(globals, proc, noopExit);
+    const second = installTerminateGuard(globals, proc, noopExit);
+
+    expect(second).toBe(first);
+    expect(globals[FAST_TERMINATE_KEY]).toBe(first);
+    // Only one listener per signal despite two install calls.
+    for (const signal of TERMINATE_SIGNALS) {
+      expect(proc.listeners(signal)).toHaveLength(1);
+    }
+  });
+
+  it('runs FIRST (prepended) ahead of a later graceful-shutdown handler', () => {
+    const globals: Record<string, unknown> = {};
+    const proc = makeFakeProcess(noopExit);
+    const guard = installTerminateGuard(globals, proc, noopExit);
+
+    // A CLI command action registers its graceful handler AFTER the guard.
+    const graceful: Listener = () => undefined;
+    proc.store.get('SIGTERM')?.push(graceful);
+
+    expect(proc.listeners('SIGTERM')[0]).toBe(guard);
+  });
+});
+
+describe('pruneForeignSignalListeners', () => {
+  it('removes foreign handlers but keeps the guard', () => {
+    const globals: Record<string, unknown> = {};
+    const proc = makeFakeProcess(noopExit);
+    const guard = installTerminateGuard(globals, proc, noopExit);
+
+    const foreignA: Listener = () => undefined;
+    const foreignB: Listener = () => undefined;
+    proc.store.get('SIGTERM')?.push(foreignA);
+    proc.store.get('SIGINT')?.push(foreignB);
+
+    pruneForeignSignalListeners(proc, guard);
+
+    expect(proc.listeners('SIGTERM')).toEqual([guard]);
+    expect(proc.listeners('SIGINT')).toEqual([guard]);
+  });
+
+  it('is a no-op when only the guard is registered', () => {
+    const globals: Record<string, unknown> = {};
+    const proc = makeFakeProcess(noopExit);
+    const guard = installTerminateGuard(globals, proc, noopExit);
+
+    pruneForeignSignalListeners(proc, guard);
+
+    for (const signal of TERMINATE_SIGNALS) {
+      expect(proc.listeners(signal)).toEqual([guard]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the intermittent CI `check-build-test` exit 1 where every test passes but
a reused vitest forks worker fails during teardown. Closes #402.

Two teardown variants, both in a reused tinypool forks worker:

- **"Timeout terminating forks worker"** (hang) — tinypool terminates a reused
  worker with `SIGTERM` (`ProcessWorker.terminate` -> `child.kill()`). A
  registered `SIGTERM` listener SUPPRESSES Node's default terminate-on-signal,
  and CLI command actions exercised by unit tests leave behind graceful-shutdown
  `SIGTERM`/`SIGINT` handlers that never resolve under mocks, so the worker hangs.
- **"Worker exited unexpectedly"** (crash) — an undici keep-alive socket's native
  handle crashes the idle reused worker (the 0.120.0 `afterAll` undici-pool
  teardown reduced but did not eliminate it).

## Fix

In `tests/setup.ts`, backed by pure helpers in `tests/setup-helpers.ts`:

1. **Prepend a per-worker fast-terminate guard** on `SIGTERM`/`SIGINT` that exits
   immediately via the real (un-stubbed) `process.exit`. It runs FIRST, beating
   any leftover graceful-shutdown handler, so worker teardown can never hang.
2. **Capture the real `process.exit` once per worker.** setupFiles re-run per
   file, but `process` is shared across files in a reused worker, so on the 2nd+
   file `process.exit` is already the no-op the 1st file installed. The old code
   re-stored that no-op as the "original" exit (latent bug); `resolveRealExit`
   stashes the genuine exit on a `globalThis` key so the guard never calls a no-op.
3. **Prune leftover foreign `SIGTERM`/`SIGINT` handlers each `afterAll`** (keeping
   only the guard) to drop retained server/socket references that feed the
   native-handle crash and to avoid MaxListeners noise.
4. **Keep the existing undici global-dispatcher teardown.**

## Test plan

- New `tests/unit/setup-helpers.test.ts` unit-tests the pure helpers: capture
  the real exit once (returns the first exit even when a later file passes the
  no-op), prepend-first ordering, idempotent install, and foreign-handler pruning.
- Full suite green under the modified `setup.ts`: 202 files / 3055 tests, `vp run
  check` 0 errors, `vp run build` ok.
- Live-tested the mechanism on the real Node runtime with a standalone script: a
  graceful `SIGTERM` handler that hangs keeps the process alive past `SIGTERM`
  (reproducing the hang), while the same process with a prepended guard exits 0
  immediately.

The crash is intermittent and not locally reproducible (issue #402 notes this),
so final confirmation relies on repeated CI runs after merge rather than a single
green check.

## Notes

- Diff is tests-only — no `src/**` or `tests/integration/**` touched, so the
  integ and cdkd-parity gates do not apply.
- Retrospective: the diagnosis (a registered signal handler suppresses Node's
  default terminate; setupFiles re-run per file while `process` is shared) is
  judgmental and not mechanically gateable, so it is recorded as a local memory
  rather than a new hook/skill.
