### PR TITLE
docs(readme): emphasize the no-seeding payoff in Why cdk-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cdkl studio                                # open the web console (no target nee
 - **Iterate against your real deployed stack — including its data.** `--from-cfn-stack` reads the deployed CloudFormation stack and injects its real ARNs and Secret values into the container — **no `.env` file to maintain, no manual ARN copy-paste** — so you stay on the real DynamoDB rows, S3 objects, Cognito users, and Secret values your IAM credentials reach. An offline emulator can fake the API surface, but **you'd still own the cost of seeding it**:
   - dumping real data into a local DB
   - mirroring Secret values into a local secret store
-  - anonymizing fixtures across schema changes
+  - re-anonymizing that test data every time the schema changes
   - scripting realistic Cognito test users
 
 ## What runs locally

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ cdkl studio                                # open the web console (no target nee
   - pure handler logic — validation, transforms, branching
   - Lambda authorizers, running in real local containers
   - API Gateway routing and request shaping
-- **Iterate against your real deployed stack — including its data.** `--from-cfn-stack` reads the deployed CloudFormation stack and injects its real ARNs and Secret values into the container — no `.env` file to maintain, no manual ARN copy-paste — so you stay on the real DynamoDB rows, S3 objects, Cognito users, and Secret values your IAM credentials reach. An offline emulator can fake the API surface, but you'd still own the cost of seeding it:
-  - dumping production data into a local DB
-  - mirroring Secret values into local Secrets Manager
+- **Iterate against your real deployed stack — including its data.** `--from-cfn-stack` reads the deployed CloudFormation stack and injects its real ARNs and Secret values into the container — **no `.env` file to maintain, no manual ARN copy-paste** — so you stay on the real DynamoDB rows, S3 objects, Cognito users, and Secret values your IAM credentials reach. An offline emulator can fake the API surface, but **you'd still own the cost of seeding it**:
+  - dumping real data into a local DB
+  - mirroring Secret values into a local secret store
   - anonymizing fixtures across schema changes
   - scripting realistic Cognito test users
 


### PR DESCRIPTION
## Summary

Polish the "Iterate against your real deployed stack" bullet in
**Why cdk-local** (README only):

- Bold the two payoff phrases so the real-data-vs-seeding contrast is
  scannable: **no `.env` file to maintain, no manual ARN copy-paste** and
  **you'd still own the cost of seeding it**.
- "production data" -> "real data" (matches the section's real-data
  framing).
- "local Secrets Manager" -> "a local secret store" (the proper-noun
  service name read oddly with "local").
- "anonymizing fixtures across schema changes" ->
  "re-anonymizing that test data every time the schema changes" (the
  original was too compressed to parse; it refers to the data copied into
  the local DB).

## Test plan

- `vp run check` / `vp check --fix` — pass.
- Docs-only change (README.md only); no `src/**` / `tests/**` delta, so
  unit / integ / cdkd-parity are not impacted.
