### PR TITLE
feat(studio): auto-render editable controls for every flag in "All options"

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -888,10 +888,19 @@ compute-locally category for Lambda + API Gateway).
   flows through the same un-proxied `endpoints` path while the http:// contract
   endpoint is fronted by the capture proxy so a relayed `/invocations` lands on
   the timeline; every composer (invoke + serve) carries a collapsed "All options"
-  `<details>` (`buildAllOptions`) with a raw extra-args input + the
-  read-only auto-derived flag catalog from studio-option-catalog, so the
-  curated controls handle common flags richly while every other flag the
-  underlying command accepts stays reachable (issue #301); a PINNED ecs
+  `<details>` (`buildAllOptions`) that AUTO-RENDERS a real control (checkbox for
+  a boolean / negate flag, text input for a value flag, `<select>` for a
+  `.choices()` flag) for every RENDERABLE catalog flag — i.e. every flag the
+  underlying command accepts that is NEITHER curated (a rich control already
+  exists in OPTION_SPECS) NOR studio-managed (`CATALOG_MANAGED_FLAGS`:
+  `--event` / `--response-file` / `--host` / `--port` / `--watch` / the
+  `--image-*` override family, injected by studio itself), plus a raw
+  extra-args input as the final escape hatch; the collected values
+  (`collectCatalog` -> the `catalogArgs` map keyed by long flag) are built into
+  argv by `buildCatalogArgs` and appended after the curated per-run args (before
+  the raw args). So the curated controls handle common flags richly AND a user
+  no longer has to hand-type `--flag value` for the long tail of simple flags
+  (issue #301 + the all-options-controls slice); a PINNED ecs
   service (deployed-registry image, marked `pinned` in the target list)
   additionally gets an image-override Dockerfile picker
   (`buildImageOverridePicker`) populated from the boot-scanned Dockerfiles,
@@ -991,21 +1000,33 @@ compute-locally category for Lambda + API Gateway).
   that backs the composer's collapsed "All options" section.
   `buildFlagCatalog` introspects each runnable kind's Commander command
   factory (`createLocalInvoke*` / `createLocalStart*`) and emits every
-  flag (name + description), minus the session-global flags
-  (`CATALOG_EXCLUDED_FLAGS`: `--from-cfn-stack` / `--assume-role` /
-  `--app` / `--profile` / `--region` / `-c`, handled by the Session bar)
-  and the auto-added `--help` / `--version`; the curated OPTION_SPECS is a
-  rich-control subset, this is the complete reference so the UI is never
-  strictly less capable than the headless CLI. Memoized; each factory is
+  flag — its `flags` string + `description` PLUS the derived control
+  metadata (`long` / `takesValue` / `negate` / `variadic` / `placeholder`
+  parsed from the value token / `choices`) and a `renderable` flag — minus
+  the session-global flags (`CATALOG_EXCLUDED_FLAGS`: `--from-cfn-stack` /
+  `--assume-role` / `--app` / `--profile` / `--region` / `-c`, handled by
+  the Session bar) and the auto-added `--help` / `--version`. A flag is
+  `renderable` (the UI auto-renders an editable control for it) when it is
+  NEITHER curated (in OPTION_SPECS — a rich control already exists) NOR
+  studio-managed (`CATALOG_MANAGED_FLAGS`: `--event` / `--response-file` /
+  `--host` / `--port` / `--watch` / the `--image-*` override family, which
+  studio injects itself). `buildCatalogArgs(kind, catalogArgs)` is the
+  counterpart of OPTION_SPECS' `buildPerRunArgs`: it validates the UI-posted
+  `CatalogValues` (a `{ long-flag -> boolean|string }` map) against the
+  kind's renderable catalog flags and builds the argv fragment (bare flag for
+  a checked boolean, `flag value` otherwise) appended after the curated args
+  by both studio-dispatch and studio-serve-manager — so the UI is never
+  strictly less capable than the headless CLI AND the long-tail flags are
+  click/type-able, not raw-string-only. Memoized; each factory is
   re-handed the active embed config so host branding survives + the
   derived descriptions reflect it. `tokenizeRawArgs` is the quote-aware
   splitter for the section's raw extra-args input — the tokens are
-  appended verbatim (LAST, so they can override a curated flag) to the
-  spawned child argv by both studio-dispatch and studio-serve-manager;
-  studio spawns children WITHOUT a shell, so there is no injection
-  surface. `coerceRunRequest` validates the `rawArgs` string at the
-  `/api/run` boundary (tokenized eagerly so an unterminated quote is a
-  clean 400)),
+  appended verbatim (LAST, so they can override an earlier flag) to the
+  spawned child argv; studio spawns children WITHOUT a shell, so there is no
+  injection surface. `coerceRunRequest` validates BOTH the `catalogArgs` map
+  (via `buildCatalogArgs`) and the `rawArgs` string (tokenized eagerly) at the
+  `/api/run` boundary so an unknown / non-overridable flag or an unterminated
+  quote is a clean 400)),
   studio-serve-manager (issue #282 — the
   long-running serve lifecycle, parameterized by a per-kind
   `ServeKindSpec`: `api` (`start-api`) + `alb` (`start-alb`) +

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cdkl studio --stack 'dev/*'                  # scope the displayed target list (
 Each target's composer surfaces its per-run options as controls:
 
 - curated controls per kind — a Lambda's `--env-vars` as KEY/VALUE or JSON, ALB `--tls` / `--lb-port`, ECS `--max-tasks` / `--host-port`, an AgentCore runtime's `--ws` / `--sigv4` / `--bearer-token`;
-- an **All options** panel with the underlying command's full flag set plus a raw extra-args input for anything not surfaced as a control;
+- an **All options** panel that renders an editable control (checkbox / input / dropdown) for every other flag the underlying command accepts, with a raw extra-args input as the final escape hatch;
 - a Dockerfile picker for an ECS service pinned to a deployed registry (where local edits otherwise don't take effect), rebuilding it from local source.
 
 ## Deployed stack binding — `--from-cfn-stack`

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -46,7 +46,11 @@ import {
   resolveEnvVars,
   type OptionValues,
 } from '../../local/studio-option-specs.js';
-import { tokenizeRawArgs } from '../../local/studio-option-catalog.js';
+import {
+  buildCatalogArgs,
+  tokenizeRawArgs,
+  type CatalogValues,
+} from '../../local/studio-option-catalog.js';
 import { relayServeRequest, type ServeRequestResult } from '../../local/studio-request-relay.js';
 import { resolveEcsServiceTarget } from '../../local/ecs-service-resolver.js';
 import { isLocalCdkAssetImage } from '../../local/image-pin-detector.js';
@@ -93,10 +97,8 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
   if (typeof body !== 'object' || body === null) {
     throw new Error('Request body must be a JSON object.');
   }
-  const { targetId, kind, event, options, rawArgs, imageOverride, imageOverrides } = body as Record<
-    string,
-    unknown
-  >;
+  const { targetId, kind, event, options, catalogArgs, rawArgs, imageOverride, imageOverrides } =
+    body as Record<string, unknown>;
   if (typeof targetId !== 'string' || targetId.trim() === '') {
     throw new Error('Request body must include a non-empty "targetId" string.');
   }
@@ -114,6 +116,17 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     // resolveEnvVars both throw on malformed input).
     buildPerRunArgs(kind as StudioTargetKind, runOptions);
     resolveEnvVars(kind as StudioTargetKind, runOptions);
+  }
+  let runCatalogArgs: CatalogValues | undefined;
+  if (catalogArgs !== undefined) {
+    if (typeof catalogArgs !== 'object' || catalogArgs === null || Array.isArray(catalogArgs)) {
+      throw new Error('Request body "catalogArgs" must be a JSON object keyed by flag.');
+    }
+    runCatalogArgs = catalogArgs as CatalogValues;
+    // Validate the values against the kind's flag catalog NOW so an unknown /
+    // non-overridable flag or a type mismatch fails as a clean 400 at the
+    // boundary, not mid-spawn (buildCatalogArgs throws on either).
+    buildCatalogArgs(kind as StudioTargetKind, runCatalogArgs);
   }
   let runRawArgs: string | undefined;
   if (rawArgs !== undefined) {
@@ -159,6 +172,7 @@ export function coerceRunRequest(body: unknown): StudioRunRequest {
     kind: kind as StudioTargetKind,
     event,
     ...(runOptions !== undefined ? { options: runOptions } : {}),
+    ...(runCatalogArgs !== undefined ? { catalogArgs: runCatalogArgs } : {}),
     ...(runRawArgs !== undefined ? { rawArgs: runRawArgs } : {}),
     ...(runImageOverride !== undefined ? { imageOverride: runImageOverride } : {}),
     ...(runImageOverrides !== undefined ? { imageOverrides: runImageOverrides } : {}),

--- a/src/local/studio-dispatch.ts
+++ b/src/local/studio-dispatch.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { StudioEventBus, type StudioTargetKind } from './studio-events.js';
 import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
 import { buildPerRunArgs, resolveEnvVars, type OptionValues } from './studio-option-specs.js';
-import { tokenizeRawArgs } from './studio-option-catalog.js';
+import { buildCatalogArgs, tokenizeRawArgs, type CatalogValues } from './studio-option-catalog.js';
 
 /**
  * The single-shot invoke kinds this dispatcher drives, mapped to the `cdkl`
@@ -32,6 +32,14 @@ export interface StudioRunRequest {
   event: unknown;
   /** Per-run option values (issue #301 slice 2), keyed by option flag. */
   options?: OptionValues;
+  /**
+   * Auto-rendered "All options" control values, keyed by long flag (e.g.
+   * `{ '--no-pull': true, '--platform': 'linux/amd64' }`). Built into argv by
+   * {@link buildCatalogArgs} and appended after the curated per-run args (but
+   * before {@link rawArgs}), so every non-curated command flag is reachable
+   * through a real control instead of only the raw extra-args input.
+   */
+  catalogArgs?: CatalogValues;
   /**
    * Raw extra args from the "All options" section — tokenized (quote-aware)
    * and appended verbatim to the spawned child, after the curated per-run
@@ -200,6 +208,7 @@ export function createStudioDispatcher(config: StudioDispatchConfig): StudioDisp
         // reads `--app <assemblyDir>` and skips its own synth.
         ...buildSharedChildArgs(config, { preferAssembly: true }),
         ...buildPerRunArgs(req.kind, req.options),
+        ...buildCatalogArgs(req.kind, req.catalogArgs),
         ...(responseFilePath ? ['--response-file', responseFilePath] : []),
       ];
 

--- a/src/local/studio-option-catalog.ts
+++ b/src/local/studio-option-catalog.ts
@@ -29,6 +29,7 @@ import { createLocalStartCloudFrontCommand } from '../cli/commands/local-start-c
 import { createLocalStartAgentCoreCommand } from '../cli/commands/local-start-agentcore.js';
 import { createLocalRunTaskCommand } from '../cli/commands/local-run-task.js';
 import { getEmbedConfig, setEmbedConfig, type CdkLocalEmbedConfig } from './embed-config.js';
+import { OPTION_SPECS } from './studio-option-specs.js';
 import type { StudioTargetKind } from './studio-events.js';
 import type { Command } from 'commander';
 
@@ -38,6 +39,26 @@ export interface FlagInfo {
   flags: string;
   /** The option's help description (may be empty). */
   description: string;
+  /** The long flag name, e.g. `--tls` / `--no-pull` (the control's value key). */
+  long: string;
+  /** True when the flag takes a value (`<x>` / `[x]`) — render an input/select. */
+  takesValue: boolean;
+  /** True for a `--no-xxx` negate flag (a boolean that emits the bare flag). */
+  negate: boolean;
+  /** True for a variadic value flag (`<x...>`). */
+  variadic: boolean;
+  /** The placeholder parsed from the flags' value token (`<file>` -> `file`). */
+  placeholder?: string;
+  /** The allowed values when the option declares `.choices(...)`. */
+  choices?: string[];
+  /**
+   * True when the studio UI should auto-render an input control for this flag
+   * in the "All options" section: it is NEITHER curated (a rich control already
+   * exists in {@link OPTION_SPECS}) NOR studio-managed (injected by studio
+   * itself — see {@link CATALOG_MANAGED_FLAGS}). A non-renderable flag stays in
+   * the catalog (so the count / reference is complete) but the UI skips it.
+   */
+  renderable: boolean;
 }
 
 /** The full flag catalog for one runnable kind. */
@@ -66,6 +87,37 @@ export const CATALOG_EXCLUDED_FLAGS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Long flags studio INJECTS or binds itself per run, so the "All options"
+ * section must NOT auto-render an editable control for them (a user-set value
+ * would collide with — or break — studio's own wiring). They still appear in
+ * the catalog (so it stays a complete reference), just `renderable: false`; a
+ * power user can still force one via the raw extra-args input, which is
+ * appended last.
+ *
+ * - `--event` / `--response-file`: studio writes the composed event /
+ *   response-capture file and passes these itself (the invoke kinds).
+ * - `--host` / `--port`: the serve-manager binds the listen host/port and the
+ *   capture proxy fronts it; a user override would desync the proxy URL.
+ * - `--watch`: the session-global Session-bar toggle (appended by the
+ *   serve-manager from the mutable config), not a per-run flag.
+ * - the `--image-*` override family: handled by the dedicated Dockerfile
+ *   picker (a partial control here would produce a half-wired override).
+ */
+export const CATALOG_MANAGED_FLAGS: ReadonlySet<string> = new Set([
+  '--event',
+  '--response-file',
+  '--host',
+  '--port',
+  '--watch',
+  '--image-override',
+  '--image-build-arg',
+  '--image-build-secret',
+  '--image-target',
+  '--no-interactive-overrides',
+  '--strict-overrides',
+]);
+
+/**
  * The runnable kind -> command factory + headless subcommand name. Mirrors
  * the kind->verb maps in `studio-dispatch` (`INVOKE_VERBS`) and
  * `studio-serve-manager` (`SERVE_SPECS`); studio spawns these commands as
@@ -85,6 +137,20 @@ const KIND_FACTORIES: Record<StudioTargetKind, { command: string; factory: FlagC
 };
 
 let cached: Partial<Record<StudioTargetKind, KindFlagCatalog>> | undefined;
+
+/**
+ * Parse the value-token placeholder out of a Commander flags string for a
+ * value-taking option: `-e, --event <file>` -> `file`,
+ * `--platform <platform>` -> `platform`, `--lb-port <listener=host>` ->
+ * `listener=host`. The trailing `...` of a variadic token is dropped. Returns
+ * undefined for a boolean flag (no `<...>` / `[...]` token), so the input
+ * placeholder falls back to a generic hint.
+ */
+export function parseFlagPlaceholder(flags: string): string | undefined {
+  const m = /[<[]([^>\]]+)[>\]]/.exec(flags);
+  if (!m || m[1] === undefined) return undefined;
+  return m[1].replace(/\.\.\.$/, '').trim() || undefined;
+}
 
 /**
  * Build (and memoize) the full per-kind flag catalog by introspecting each
@@ -107,11 +173,36 @@ export function buildFlagCatalog(): Partial<Record<StudioTargetKind, KindFlagCat
     for (const kind of Object.keys(KIND_FACTORIES) as StudioTargetKind[]) {
       const { command, factory } = KIND_FACTORIES[kind];
       const cmd = factory({ embedConfig: savedEmbedConfig });
+      // The flags this kind already renders a rich curated control for — they
+      // must NOT also get an auto-rendered control in the "All options"
+      // section. A `showWhen`-gated curated scalar (e.g. `--tls-cert`) is in
+      // OPTION_SPECS too, so it is covered by the same set.
+      const curated = new Set((OPTION_SPECS[kind] ?? []).map((s) => s.flag));
       const flags: FlagInfo[] = [];
       for (const opt of cmd.options) {
         if (opt.hidden) continue;
         if (opt.long && CATALOG_EXCLUDED_FLAGS.has(opt.long)) continue;
-        flags.push({ flags: opt.flags, description: opt.description ?? '' });
+        const long = opt.long ?? '';
+        // Commander marks a value-taking option via `.required` (`<x>`) or
+        // `.optional` (`[x]`); a bare / negate flag is a boolean.
+        const takesValue = Boolean(opt.required || opt.optional);
+        const negate = Boolean(opt.negate);
+        const variadic = Boolean(opt.variadic);
+        const choices = Array.isArray(opt.argChoices) ? [...opt.argChoices] : undefined;
+        const placeholder = parseFlagPlaceholder(opt.flags);
+        const renderable = long !== '' && !curated.has(long) && !CATALOG_MANAGED_FLAGS.has(long);
+        const info: FlagInfo = {
+          flags: opt.flags,
+          description: opt.description ?? '',
+          long,
+          takesValue,
+          negate,
+          variadic,
+          renderable,
+        };
+        if (placeholder !== undefined) info.placeholder = placeholder;
+        if (choices) info.choices = choices;
+        flags.push(info);
       }
       out[kind] = { command, flags };
     }
@@ -189,4 +280,61 @@ export function tokenizeRawArgs(raw: string | undefined): string[] {
   }
   if (inToken) tokens.push(current);
   return tokens;
+}
+
+/**
+ * Per-run values for the auto-rendered "All options" controls, keyed by the
+ * long flag (e.g. `{ '--no-pull': true, '--platform': 'linux/amd64' }`). A
+ * boolean value drives a checkbox flag; a string value drives an input / select
+ * flag. This is the catalog counterpart of `OPTION_SPECS`' {@link OptionValues}
+ * — kept separate because these flags carry NO curated control / validation
+ * spec; they are validated structurally against the flag catalog instead.
+ */
+export type CatalogValues = Record<string, boolean | string>;
+
+/**
+ * Build the argv fragment for the auto-rendered "All options" controls from the
+ * UI-posted {@link CatalogValues}, validating each key against the kind's flag
+ * catalog. Emits `--flag` for a checked boolean (bare/negate) flag and
+ * `--flag <value>` for a non-empty value flag. Blank / false values are
+ * omitted.
+ *
+ * Throws (→ a clean 400 at the `/api/run` boundary) on a key that is not a
+ * RENDERABLE catalog flag for the kind — an unknown flag, a session-global /
+ * studio-managed flag, or a curated flag (which belongs to the `options` path,
+ * not here). The studio UI only ever posts renderable flags; the validation
+ * guards a hand-rolled curl body. studio spawns children WITHOUT a shell, so
+ * each emitted token is a discrete argv element with no injection surface.
+ */
+export function buildCatalogArgs(
+  kind: StudioTargetKind,
+  values: CatalogValues | undefined
+): string[] {
+  if (values === undefined) return [];
+  const catalog = buildFlagCatalog()[kind];
+  const byFlag = new Map(
+    (catalog?.flags ?? []).filter((f) => f.renderable).map((f) => [f.long, f])
+  );
+
+  const args: string[] = [];
+  for (const [flag, value] of Object.entries(values)) {
+    const info = byFlag.get(flag);
+    if (!info) {
+      throw new Error(`Unknown / non-overridable option '${flag}' for target kind '${kind}'.`);
+    }
+    if (info.takesValue) {
+      if (typeof value !== 'string') {
+        throw new Error(`Option '${flag}' must be a string value.`);
+      }
+      const trimmed = value.trim();
+      if (trimmed !== '') args.push(flag, trimmed);
+    } else {
+      // Boolean (bare / negate) flag — emit the bare flag only when checked.
+      if (typeof value !== 'boolean') {
+        throw new Error(`Option '${flag}' must be a boolean.`);
+      }
+      if (value) args.push(flag);
+    }
+  }
+  return args;
 }

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -10,7 +10,7 @@ import {
 } from './studio-proxy.js';
 import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
 import { buildPerRunArgs, resolveEnvVars, type OptionValues } from './studio-option-specs.js';
-import { tokenizeRawArgs } from './studio-option-catalog.js';
+import { buildCatalogArgs, tokenizeRawArgs, type CatalogValues } from './studio-option-catalog.js';
 
 /** A request to start serving a target, as the studio UI posts it. */
 export interface StudioServeRequest {
@@ -20,6 +20,13 @@ export interface StudioServeRequest {
   kind: StudioTargetKind;
   /** Per-run option values (issue #301 slice 2), keyed by option flag. */
   options?: OptionValues;
+  /**
+   * Auto-rendered "All options" control values, keyed by long flag. Built into
+   * argv by {@link buildCatalogArgs} and appended after the curated per-run
+   * args (before {@link rawArgs}), so every non-curated serve flag is reachable
+   * through a real control instead of only the raw extra-args input.
+   */
+  catalogArgs?: CatalogValues;
   /**
    * Raw extra args from the "All options" section — tokenized (quote-aware)
    * and appended verbatim to the spawned serve child, so a flag the curated
@@ -384,6 +391,9 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       ...spec.portArgs,
       ...buildSharedChildArgs(config, { preferAssembly }),
       ...buildPerRunArgs(req.kind, req.options),
+      // Auto-rendered "All options" controls: every non-curated, non-managed
+      // command flag, built into argv and validated against the flag catalog.
+      ...buildCatalogArgs(req.kind, req.catalogArgs),
       // The `--env-vars` per-run option takes a FILE (issue #355) — the env-kv
       // KV rows / JSON were materialized into a SAM-shape temp file by the
       // caller; point start-service / start-alb at it so the override applies

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -335,10 +335,18 @@ const STUDIO_CSS = `
      read — kept small as it is secondary. */
   .io-label { color: #d7dde5; font-weight: 500; overflow-wrap: anywhere; min-width: 0; }
   .io-hint { color: #e3b34a; font-size: 11px; }
-  .flag-catalog { margin-top: 8px; display: flex; flex-direction: column; gap: 2px; }
-  .flag-row { display: flex; gap: 8px; align-items: baseline; font-size: 11px; }
-  .flag-name { color: #7bd88f; font-family: ui-monospace, Menlo, monospace; white-space: nowrap; }
-  .flag-desc { color: #999; }
+  /* Auto-rendered controls for the residual (non-curated) command flags in the
+     "All options" section: one stacked row per flag (label + input/select +
+     description hint), styled to match the curated .options controls. */
+  .flag-controls { display: flex; flex-direction: column; gap: 6px; margin-bottom: 8px; }
+  .all-options input.flag-control, .all-options select.flag-control {
+    width: 100%; box-sizing: border-box; background: #111; color: #ddd; border: 1px solid #333;
+    border-radius: 3px; padding: 4px 6px; font: 12px ui-monospace, Menlo, monospace;
+  }
+  .all-options input.flag-control:focus, .all-options select.flag-control:focus {
+    outline: none; border-color: #4ec97a;
+  }
+  .all-options .opt-label { color: #9aa4ad; }
   .started-list { display: flex; flex-direction: column; gap: 3px; margin-top: 4px; }
   .started-flag { color: #7bd88f; font-family: ui-monospace, Menlo, monospace; font-size: 11px; white-space: pre-wrap; word-break: break-all; }
   .envkv-modes { display: flex; gap: 0; }
@@ -433,7 +441,7 @@ const STUDIO_SCRIPT = `
   // prefill (issue #398): the option map a stopped serve was last Started with
   // (serveApplied.options), so the re-rendered composer comes back filled.
   // rawPrefill is the raw-extra-args string (serveApplied.rawArgs).
-  function buildOptions(kind, prefill, rawPrefill) {
+  function buildOptions(kind, prefill, rawPrefill, catalogPrefill) {
     const specs = OPTION_SPECS[kind] || [];
     // The composer always shows an "All options" section (raw extra args + the
     // auto-derived flag reference), even for kinds with no curated controls.
@@ -584,7 +592,7 @@ const STUDIO_SCRIPT = `
       }
       sec.appendChild(row);
     });
-    const allOpts = buildAllOptions(kind, rawPrefill);
+    const allOpts = buildAllOptions(kind, rawPrefill, catalogPrefill);
     wrap.appendChild(allOpts.node);
     return {
       node: wrap,
@@ -596,21 +604,96 @@ const STUDIO_SCRIPT = `
         // body identical to before this section existed.
         return Object.keys(out).length ? out : undefined;
       },
+      collectCatalog: allOpts.collectCatalog,
       collectRaw: allOpts.collectRaw,
     };
   }
 
-  // The collapsed "All options" section: a raw extra-args input (appended
-  // verbatim to the spawned child) + the auto-derived, read-only catalog of
-  // every flag the underlying command accepts. The curated controls above
-  // cover the common flags with rich UI; this exposes the rest so the studio
-  // UI is never strictly less capable than the headless CLI (issue #301).
+  // The collapsed "All options" section. The curated controls above cover the
+  // common flags with rich UI; this section auto-renders a real control
+  // (checkbox / input / select) for EVERY other flag the underlying command
+  // accepts (the catalog's renderable flags), so the studio UI is never
+  // strictly less capable than the headless CLI AND a user does not have to
+  // hand-type "--flag value" for the long tail of simple flags. A raw
+  // extra-args input remains as the final escape hatch for anything the
+  // auto-render cannot express (issue #301 + the all-options-controls slice).
   const FLAG_CATALOG = window.__FLAG_CATALOG__ || {};
 
-  function buildAllOptions(kind, rawPrefill) {
+  function buildAllOptions(kind, rawPrefill, catalogPrefill) {
     const cat = FLAG_CATALOG[kind] || { command: '', flags: [] };
     const det = el('details', 'all-options');
     det.appendChild(el('summary', null, 'All options'));
+
+    // Auto-rendered controls for every renderable (non-curated, non-managed)
+    // flag. The collected value map is keyed by the long flag.
+    const catGetters = [];
+    const renderable = (cat.flags || []).filter(function (f) {
+      return f.renderable;
+    });
+    const preCat = function (flag) {
+      return catalogPrefill ? catalogPrefill[flag] : undefined;
+    };
+    if (renderable.length) {
+      const grid = el('div', 'flag-controls');
+      renderable.forEach(function (f) {
+        const row = el('div', 'opt-row opt-col');
+        if (!f.takesValue) {
+          // Boolean (bare / negate) flag -> checkbox; emits the bare flag.
+          const cb = el('input');
+          cb.type = 'checkbox';
+          if (preCat(f.long) === true) {
+            cb.checked = true;
+            det.open = true;
+          }
+          const lab = el('label', 'opt-bool');
+          lab.appendChild(cb);
+          lab.appendChild(document.createTextNode(' ' + f.long));
+          row.appendChild(lab);
+          catGetters.push(function () {
+            return [f.long, cb.checked];
+          });
+        } else if (f.choices && f.choices.length) {
+          // Value flag with a fixed choice set -> select (blank = unset).
+          row.appendChild(el('span', 'opt-label', f.long));
+          const sel = el('select', 'flag-control');
+          const none = el('option', null, '(default)');
+          none.value = '';
+          sel.appendChild(none);
+          f.choices.forEach(function (c) {
+            const o = el('option', null, c);
+            o.value = c;
+            sel.appendChild(o);
+          });
+          const pv = preCat(f.long);
+          if (pv != null && pv !== '') {
+            sel.value = String(pv);
+            det.open = true;
+          }
+          row.appendChild(sel);
+          catGetters.push(function () {
+            return [f.long, sel.value];
+          });
+        } else {
+          // Value flag -> text input. The placeholder is the flag's own value
+          // token (e.g. file, from the flags' angle-bracket token).
+          row.appendChild(el('span', 'opt-label', f.long));
+          const inp = el('input', 'flag-control');
+          inp.placeholder = f.placeholder || 'value';
+          const pv = preCat(f.long);
+          if (pv != null && pv !== '') {
+            inp.value = String(pv);
+            det.open = true;
+          }
+          row.appendChild(inp);
+          catGetters.push(function () {
+            return [f.long, inp.value];
+          });
+        }
+        if (f.description) row.appendChild(el('div', 'opt-hint', f.description));
+        grid.appendChild(row);
+      });
+      det.appendChild(grid);
+    }
 
     const rawRow = el('div', 'opt-row opt-col');
     rawRow.appendChild(el('span', 'opt-label', 'Raw extra args'));
@@ -628,20 +711,25 @@ const STUDIO_SCRIPT = `
     rawRow.appendChild(el('div', 'opt-hint', hint));
     det.appendChild(rawRow);
 
-    if (cat.flags.length) {
-      const ref = el('div', 'flag-catalog');
-      ref.appendChild(el('div', 'opt-label', 'Available flags'));
-      cat.flags.forEach(function (f) {
-        const row = el('div', 'flag-row');
-        row.appendChild(el('code', 'flag-name', f.flags));
-        if (f.description) row.appendChild(el('span', 'flag-desc', f.description));
-        ref.appendChild(row);
-      });
-      det.appendChild(ref);
-    }
-
     return {
       node: det,
+      // Collect the auto-rendered control values, omitting unset ones (an
+      // unchecked checkbox / a blank input or select) so the posted map carries
+      // only flags the user actually set. Returns undefined when nothing is set.
+      collectCatalog: function () {
+        const out = {};
+        catGetters.forEach(function (g) {
+          const kv = g();
+          const flag = kv[0];
+          const val = kv[1];
+          if (typeof val === 'boolean') {
+            if (val) out[flag] = true;
+          } else if (typeof val === 'string' && val.trim() !== '') {
+            out[flag] = val.trim();
+          }
+        });
+        return Object.keys(out).length ? out : undefined;
+      },
       collectRaw: function () {
         const v = rawIn.value.trim();
         return v === '' ? undefined : v;
@@ -1060,6 +1148,16 @@ const STUDIO_SCRIPT = `
         }
       });
     }
+    // Auto-rendered "All options" controls (the catalog flags). Surface each
+    // set flag so the running view does not look like the picks vanished (the
+    // issue #356 contract): the bare flag for a checked boolean, flag + value
+    // otherwise.
+    if (applied && applied.catalogArgs) {
+      Object.keys(applied.catalogArgs).forEach(function (flag) {
+        const v = applied.catalogArgs[flag];
+        lines.push(v === true ? flag : flag + ' ' + v);
+      });
+    }
     if (applied && applied.imageOverride) {
       lines.push('--image-override ' + applied.imageOverride);
     }
@@ -1078,7 +1176,7 @@ const STUDIO_SCRIPT = `
     return lines;
   }
 
-  async function startServe(id, options, rawArgs, imageOverride, imageOverrides) {
+  async function startServe(id, options, catalogArgs, rawArgs, imageOverride, imageOverrides) {
     // The serve kind (api / alb / ecs) drives which headless command the
     // server spawns; it is recorded on the row when the target list loads.
     const meta = serveMeta.get(id);
@@ -1094,6 +1192,7 @@ const STUDIO_SCRIPT = `
     const watchEl = document.getElementById('sess-watch');
     serveApplied.set(id, {
       options: options,
+      catalogArgs: catalogArgs,
       rawArgs: rawArgs,
       imageOverride: imageOverride,
       imageOverrides: imageOverrides,
@@ -1108,6 +1207,7 @@ const STUDIO_SCRIPT = `
     try {
       const body = { targetId: id, kind };
       if (options) body.options = options;
+      if (catalogArgs) body.catalogArgs = catalogArgs;
       if (rawArgs) body.rawArgs = rawArgs;
       if (imageOverride) body.imageOverride = imageOverride;
       if (imageOverrides) body.imageOverrides = imageOverrides;
@@ -1214,6 +1314,7 @@ const STUDIO_SCRIPT = `
     }
     // Per-run options are only set before a start; collected on the Start click.
     let collectOpts = function () { return undefined; };
+    let collectCatalog = function () { return undefined; };
     let collectRaw = function () { return undefined; };
     let collectImageOverride = function () { return undefined; };
     let collectImageOverrides = function () { return undefined; };
@@ -1227,7 +1328,14 @@ const STUDIO_SCRIPT = `
         serveState.set(id, { status: 'stopped', endpoints: [] });
         renderServeWorkspace(id);
       } else {
-        startServe(id, collectOpts(), collectRaw(), collectImageOverride(), collectImageOverrides());
+        startServe(
+          id,
+          collectOpts(),
+          collectCatalog(),
+          collectRaw(),
+          collectImageOverride(),
+          collectImageOverrides()
+        );
       }
     };
     head.appendChild(btn);
@@ -1267,9 +1375,15 @@ const STUDIO_SCRIPT = `
         ws.appendChild(io.node);
         collectImageOverrides = io.collect;
       }
-      const opt = buildOptions(kind, applied && applied.options, applied && applied.rawArgs);
+      const opt = buildOptions(
+        kind,
+        applied && applied.options,
+        applied && applied.rawArgs,
+        applied && applied.catalogArgs
+      );
       if (opt.node) ws.appendChild(opt.node);
       collectOpts = opt.collect;
+      collectCatalog = opt.collectCatalog;
       collectRaw = opt.collectRaw;
     }
 
@@ -1888,7 +2002,7 @@ const STUDIO_SCRIPT = `
     // target; per-run options are not carried over, so the options section is
     // omitted (the payload is the thing being tweaked). A fresh invoke keeps
     // the per-run options (e.g. env vars) below the event, above Invoke.
-    let opt = { collect: undefined, collectRaw: undefined };
+    let opt = { collect: undefined, collectCatalog: undefined, collectRaw: undefined };
     if (reinvokeOf) {
       composer.appendChild(
         el('div', 'opt-hint', 'Re-invoke runs the edited event through the same target (per-run options use defaults).')
@@ -1916,6 +2030,7 @@ const STUDIO_SCRIPT = `
       msg,
       result,
       collectOpts: opt.collect,
+      collectCatalog: opt.collectCatalog,
       collectRaw: opt.collectRaw,
       reinvokeOf: reinvokeOf || null,
     };
@@ -1954,6 +2069,8 @@ const STUDIO_SCRIPT = `
         body = { targetId: id, kind, event };
         const options = active.collectOpts ? active.collectOpts() : undefined;
         if (options) body.options = options;
+        const catalogArgs = active.collectCatalog ? active.collectCatalog() : undefined;
+        if (catalogArgs) body.catalogArgs = catalogArgs;
         const rawArgs = active.collectRaw ? active.collectRaw() : undefined;
         if (rawArgs) body.rawArgs = rawArgs;
       }

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -264,6 +264,13 @@ if ! grep -qF "buildAllOptions" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the All options / raw extra-args builder"
   exit 1
 fi
+# The "All options" panel auto-renders a real control for every renderable
+# (non-curated, non-managed) flag (all-options-controls slice): the controls
+# container class + the collector are in the page.
+if ! grep -qF "flag-controls" "${BODY_FILE}" || ! grep -qF "collectCatalog" "${BODY_FILE}"; then
+  echo "FAIL: GET / did not include the auto-rendered All options controls"
+  exit 1
+fi
 # The pinned-service image-override Dockerfile picker (issue #301).
 if ! grep -qF "buildImageOverridePicker" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the image-override Dockerfile picker"
@@ -278,8 +285,9 @@ if ! grep -qF 'io-label' "${BODY_FILE}" || ! grep -qF 'io-hint' "${BODY_FILE}"; 
 fi
 # Serve composer input preservation (issue #398): a stopped serve re-renders
 # its composer pre-filled from the recorded serveApplied values, so the
-# render path threads the applied options + rawArgs into buildOptions.
-if ! grep -qF 'buildOptions(kind, applied' "${BODY_FILE}"; then
+# render path threads the applied options + rawArgs (+ catalogArgs) into
+# buildOptions.
+if ! grep -qF 'applied && applied.options' "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the serve-composer input-preservation wiring (issue #398)"
   exit 1
 fi
@@ -601,6 +609,49 @@ if ! grep -qF "${RAW_STACK}" "${BODY_FILE}"; then
   exit 1
 fi
 echo "    OK: rawArgs string tokenized + threaded to the child invoke argv"
+
+# ---------------------------------------------------------------------------
+# 6b2b. "All options" auto-rendered controls (all-options-controls slice):
+#       POST /api/run with a `catalogArgs` map (the auto-rendered control values
+#       keyed by long flag). The server validates it against the kind's flag
+#       catalog (buildCatalogArgs) and appends the built args to the child argv.
+#       Pass `--debug-port` (a renderable lambda flag) a NON-NUMERIC value: the
+#       child `cdkl invoke` rejects it and NAMES the value in the error, proving
+#       the control's value reached the child argv (UI control -> catalogArgs ->
+#       /api/run -> buildCatalogArgs -> child argv). Creds-free + deterministic.
+# ---------------------------------------------------------------------------
+echo "==> POST /api/run threads an 'All options' catalog control value into the invoke argv"
+CAT_TOKEN="CATALOGARGSBOGUS301"
+CAT_RUN=$(mktemp)
+curl -s -o "${CAT_RUN}" --max-time 180 -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"LocalStudioFixture/MyHandler\",\"kind\":\"lambda\",\"event\":{},\"catalogArgs\":{\"--debug-port\":\"${CAT_TOKEN}\"}}" >/dev/null || true
+# The rejected value is surfaced in the run result's error AND the bound logs;
+# the run-response body is the deterministic, binding-independent check.
+if ! grep -qF "${CAT_TOKEN}" "${CAT_RUN}"; then
+  echo "FAIL: the catalogArgs --debug-port value did not reach the child (token absent from run result)"
+  echo "----- run response -----"; head -c 2000 "${CAT_RUN}"; echo; echo "------------------------"
+  rm -f "${CAT_RUN}"; exit 1
+fi
+rm -f "${CAT_RUN}"
+echo "    OK: catalogArgs control value threaded to the child invoke argv"
+
+# ---------------------------------------------------------------------------
+# 6b2c. catalogArgs boundary validation: a non-overridable flag (a
+#       studio-managed flag like --event, which studio injects itself) is
+#       rejected at the /api/run boundary (buildCatalogArgs throws -> non-200),
+#       NOT silently appended. Proves the renderable-flag guard runs server-side.
+# ---------------------------------------------------------------------------
+echo "==> POST /api/run rejects a non-overridable catalogArgs flag at the boundary"
+NEG_RUN=$(mktemp)
+HTTP_NEG=$(curl -s -o "${NEG_RUN}" -w '%{http_code}' --max-time 60 \
+  -X POST "${URL}/api/run" -H 'content-type: application/json' \
+  -d "{\"targetId\":\"LocalStudioFixture/MyHandler\",\"kind\":\"lambda\",\"event\":{},\"catalogArgs\":{\"--event\":\"x\"}}" || true)
+if [[ "${HTTP_NEG}" == "200" ]]; then
+  echo "FAIL: a non-overridable catalogArgs flag (--event) was not rejected at the boundary (HTTP ${HTTP_NEG})"
+  cat "${NEG_RUN}"; rm -f "${NEG_RUN}"; exit 1
+fi
+rm -f "${NEG_RUN}"
+echo "    OK: non-overridable catalogArgs flag rejected at the /api/run boundary (HTTP ${HTTP_NEG})"
 
 # ---------------------------------------------------------------------------
 # 6c. Editable Session config (issue #301 slice 3): GET /api/config exposes

--- a/tests/unit/cli/local-studio.test.ts
+++ b/tests/unit/cli/local-studio.test.ts
@@ -204,6 +204,34 @@ describe('coerceRunRequest', () => {
     ).toThrow(/unterminated/i);
   });
 
+  it('threads well-formed catalogArgs (auto-rendered All-options controls) through', () => {
+    expect(
+      coerceRunRequest({
+        targetId: 'Stack/SiteDist',
+        kind: 'cloudfront',
+        catalogArgs: { '--no-pull': true, '--stack-region': 'us-west-2' },
+      })
+    ).toEqual({
+      targetId: 'Stack/SiteDist',
+      kind: 'cloudfront',
+      event: undefined,
+      catalogArgs: { '--no-pull': true, '--stack-region': 'us-west-2' },
+    });
+  });
+
+  it.each([null, 42, 'str', [1, 2]])('rejects a non-object catalogArgs %p', (catalogArgs) => {
+    expect(() => coerceRunRequest({ targetId: 'T', kind: 'cloudfront', catalogArgs })).toThrow(
+      /"catalogArgs" must be a JSON object/
+    );
+  });
+
+  it('rejects a non-overridable / unknown catalogArgs flag at the boundary', () => {
+    // --event is studio-managed — not reachable via the catalog path.
+    expect(() =>
+      coerceRunRequest({ targetId: 'T', kind: 'lambda', catalogArgs: { '--event': 'x' } })
+    ).toThrow(/non-overridable|Unknown/i);
+  });
+
   it('threads a well-formed imageOverride string through', () => {
     expect(
       coerceRunRequest({ targetId: 'Stack/Svc', kind: 'ecs', imageOverride: './Dockerfile' })

--- a/tests/unit/local/studio-dispatch.test.ts
+++ b/tests/unit/local/studio-dispatch.test.ts
@@ -75,6 +75,35 @@ describe('createStudioDispatcher', () => {
     expect(result.invocationId).toBe('inv-1');
   });
 
+  it('builds the auto-rendered "All options" catalog controls into the invoke argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+
+    const dispatcher = createStudioDispatcher({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      nodeBin: '/usr/bin/node',
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      idFactory: () => 'inv-cat',
+    });
+
+    const p = dispatcher.run({
+      targetId: 'Stack/Fn',
+      kind: 'lambda',
+      event: {},
+      // --no-pull is a renderable boolean catalog flag for `cdkl invoke`.
+      catalogArgs: { '--no-pull': true },
+    });
+    child.stdout.emit('data', '"ok"');
+    child.emit('close', 0);
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv).toContain('--no-pull');
+  });
+
   it('emits an invocation start then end event keyed by the same id', async () => {
     const bus = new StudioEventBus();
     const { invocations } = collect(bus);

--- a/tests/unit/local/studio-option-catalog.test.ts
+++ b/tests/unit/local/studio-option-catalog.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vite-plus/test';
 import {
   buildFlagCatalog,
+  buildCatalogArgs,
+  parseFlagPlaceholder,
   tokenizeRawArgs,
   CATALOG_EXCLUDED_FLAGS,
+  CATALOG_MANAGED_FLAGS,
   __resetFlagCatalogCacheForTest,
 } from '../../../src/local/studio-option-catalog.js';
+import { OPTION_SPECS } from '../../../src/local/studio-option-specs.js';
 import { getEmbedConfig, setEmbedConfig, resetEmbedConfig } from '../../../src/local/embed-config.js';
 
 describe('buildFlagCatalog', () => {
@@ -56,6 +60,44 @@ describe('buildFlagCatalog', () => {
 
   it('is memoized — repeated calls return the same object', () => {
     expect(buildFlagCatalog()).toBe(buildFlagCatalog());
+  });
+
+  it('classifies each flag value type (boolean vs value, negate, variadic, placeholder)', () => {
+    const cat = buildFlagCatalog();
+    // --no-pull is a bare boolean (negate form): takes no value.
+    const noPull = (cat.lambda?.flags ?? []).find((f) => f.long === '--no-pull');
+    expect(noPull).toBeDefined();
+    expect(noPull?.takesValue).toBe(false);
+    expect(noPull?.negate).toBe(true);
+    // --event <file> takes a value; its placeholder is parsed from <file>.
+    const event = (cat.lambda?.flags ?? []).find((f) => f.long === '--event');
+    expect(event?.takesValue).toBe(true);
+    expect(event?.placeholder).toBe('file');
+  });
+
+  it('marks renderable=false for curated and studio-managed flags', () => {
+    const cat = buildFlagCatalog();
+    // --event is studio-managed (injected per run) — not auto-rendered.
+    const event = (cat.lambda?.flags ?? []).find((f) => f.long === '--event');
+    expect(event?.renderable).toBe(false);
+    // A curated flag (in OPTION_SPECS) is not auto-rendered either: --tls is a
+    // curated alb control.
+    const albCurated = new Set((OPTION_SPECS.alb ?? []).map((s) => s.flag));
+    expect(albCurated.has('--tls')).toBe(true);
+    const tls = (cat.alb?.flags ?? []).find((f) => f.long === '--tls');
+    expect(tls?.renderable).toBe(false);
+    // No renderable flag is ever a managed flag.
+    for (const kind of Object.keys(cat) as (keyof typeof cat)[]) {
+      for (const f of cat[kind]?.flags ?? []) {
+        if (f.renderable) expect(CATALOG_MANAGED_FLAGS.has(f.long)).toBe(false);
+      }
+    }
+  });
+
+  it('exposes at least one renderable residual flag (e.g. cloudfront --no-pull)', () => {
+    const cat = buildFlagCatalog();
+    const renderable = (cat.cloudfront?.flags ?? []).filter((f) => f.renderable).map((f) => f.long);
+    expect(renderable).toContain('--no-pull');
   });
 
   it('does not wipe the active embed config and reflects host branding in descriptions', () => {
@@ -141,5 +183,61 @@ describe('tokenizeRawArgs', () => {
   it('throws on an unterminated quote', () => {
     expect(() => tokenizeRawArgs('--name "unterminated')).toThrow(/unterminated/i);
     expect(() => tokenizeRawArgs("--x 'oops")).toThrow(/unterminated/i);
+  });
+});
+
+describe('parseFlagPlaceholder', () => {
+  it('extracts the value token from a flags string', () => {
+    expect(parseFlagPlaceholder('-e, --event <file>')).toBe('file');
+    expect(parseFlagPlaceholder('--platform <platform>')).toBe('platform');
+    expect(parseFlagPlaceholder('--max-tasks [count]')).toBe('count');
+  });
+
+  it('drops a trailing variadic ellipsis', () => {
+    expect(parseFlagPlaceholder('--stack <glob...>')).toBe('glob');
+  });
+
+  it('returns undefined for a boolean flag with no value token', () => {
+    expect(parseFlagPlaceholder('--tls')).toBeUndefined();
+    expect(parseFlagPlaceholder('--no-pull')).toBeUndefined();
+  });
+});
+
+describe('buildCatalogArgs', () => {
+  beforeEach(() => __resetFlagCatalogCacheForTest());
+
+  it('returns [] for undefined values', () => {
+    expect(buildCatalogArgs('lambda', undefined)).toEqual([]);
+  });
+
+  it('emits a bare flag for a checked boolean and flag+value for a string', () => {
+    // cloudfront has renderable --no-pull (boolean) and --stack-region (value).
+    const args = buildCatalogArgs('cloudfront', {
+      '--no-pull': true,
+      '--stack-region': 'us-west-2',
+    });
+    expect(args).toContain('--no-pull');
+    expect(args.join(' ')).toContain('--stack-region us-west-2');
+  });
+
+  it('omits a false boolean and a blank value', () => {
+    expect(buildCatalogArgs('cloudfront', { '--no-pull': false })).toEqual([]);
+    expect(buildCatalogArgs('cloudfront', { '--stack-region': '   ' })).toEqual([]);
+  });
+
+  it('throws on an unknown / non-renderable flag (curated or managed)', () => {
+    // --event is studio-managed; passing it through the catalog path is rejected.
+    expect(() => buildCatalogArgs('lambda', { '--event': 'x' })).toThrow(/non-overridable|Unknown/i);
+    // A made-up flag is rejected too.
+    expect(() => buildCatalogArgs('lambda', { '--nope': 'x' })).toThrow(/Unknown/i);
+  });
+
+  it('throws on a type mismatch', () => {
+    expect(() => buildCatalogArgs('cloudfront', { '--no-pull': 'yes' as never })).toThrow(
+      /must be a boolean/i
+    );
+    expect(() => buildCatalogArgs('cloudfront', { '--stack-region': true as never })).toThrow(
+      /must be a string/i
+    );
   });
 });

--- a/tests/unit/local/studio-option-catalog.test.ts
+++ b/tests/unit/local/studio-option-catalog.test.ts
@@ -100,6 +100,26 @@ describe('buildFlagCatalog', () => {
     expect(renderable).toContain('--no-pull');
   });
 
+  it('derives the choices set for a `.choices()` flag (drives the UI <select>)', () => {
+    const cat = buildFlagCatalog();
+    // agentcore (invoke-agentcore) --platform is a renderable choices flag.
+    const platform = (cat.agentcore?.flags ?? []).find((f) => f.long === '--platform');
+    expect(platform).toBeDefined();
+    expect(platform?.takesValue).toBe(true);
+    expect(platform?.renderable).toBe(true);
+    expect(platform?.choices).toEqual(['linux/amd64', 'linux/arm64']);
+  });
+
+  it('derives the variadic flag (`<x...>`) from the command', () => {
+    const cat = buildFlagCatalog();
+    // ecs --host-port is a repeatable (variadic) value flag.
+    const hostPort = (cat.ecs?.flags ?? []).find((f) => f.long === '--host-port');
+    expect(hostPort?.variadic).toBe(true);
+    // A plain scalar flag is not variadic.
+    const stackRegion = (cat.cloudfront?.flags ?? []).find((f) => f.long === '--stack-region');
+    expect(stackRegion?.variadic).toBe(false);
+  });
+
   it('does not wipe the active embed config and reflects host branding in descriptions', () => {
     // A host CLI installs custom branding; building the catalog instantiates
     // the command factories (each calls setEmbedConfig at construction, which

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -797,6 +797,35 @@ describe('createStudioServeManager', () => {
     expect(argv[i + 1]).toBe('my host');
   });
 
+  it('builds the auto-rendered "All options" catalog controls into the serve argv', async () => {
+    const bus = new StudioEventBus();
+    const child = makeFakeChild();
+    const spawnFn = vi.fn(() => child as never);
+    const fp = fakeProxies();
+
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus,
+      spawnFn: spawnFn as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+
+    const p = mgr.start({
+      targetId: 'Stack/SiteDist',
+      kind: 'cloudfront',
+      catalogArgs: { '--no-pull': true, '--stack-region': 'us-west-2' },
+    });
+    child.stdout.emit('data', 'CloudFront distribution serving on http://127.0.0.1:51999\n');
+    await p;
+
+    const argv = (spawnFn.mock.calls[0] as unknown as [string, string[]])[1];
+    expect(argv).toContain('--no-pull');
+    const i = argv.indexOf('--stack-region');
+    expect(i).toBeGreaterThan(-1);
+    expect(argv[i + 1]).toBe('us-west-2');
+  });
+
   it('streams child stdout AND stderr lines onto the bus as log events keyed by the target', async () => {
     const bus = new StudioEventBus();
     const { logs } = collect(bus);

--- a/tests/unit/local/studio-ui-applied-opts.test.ts
+++ b/tests/unit/local/studio-ui-applied-opts.test.ts
@@ -59,6 +59,11 @@ describe('studio serve "Started with" summary (issue #356)', () => {
         '--image-override ./Dockerfile',
         '--foo bar',
       ]);
+      // catalogArgs (auto-rendered "All options" controls): bare flag for a
+      // checked boolean, "flag value" otherwise (all-options-controls slice).
+      expect(
+        t.formatAppliedOptions({ catalogArgs: { '--no-pull': true, '--stack-region': 'us-west-2' } })
+      ).toEqual(['--no-pull', '--stack-region us-west-2']);
       // nothing applied -> empty list (the UI shows a "(defaults)" hint)
       expect(t.formatAppliedOptions(undefined)).toEqual([]);
       expect(t.formatAppliedOptions({ options: undefined })).toEqual([]);

--- a/tests/unit/local/studio-ui-exec.test.ts
+++ b/tests/unit/local/studio-ui-exec.test.ts
@@ -338,3 +338,95 @@ describe('studio UI buildHeaderEditor (issue #305)', () => {
     expect(second.collect()).toEqual({ A: 'b' });
   });
 });
+
+describe('studio UI "All options" auto-rendered controls (all-options-controls slice)', () => {
+  // buildOptions(...) returns collectCatalog alongside collect/collectRaw; the
+  // shared harness type predates it, so read it through a widened shape.
+  type WithCatalog = ReturnType<StudioHarness['buildOptions']> & {
+    collectCatalog: () => Record<string, boolean | string> | undefined;
+  };
+
+  it('auto-renders a checkbox for a boolean flag and an input for a value flag, then collects them (cloudfront)', () => {
+    harness = createStudioHarness();
+    const opts = harness.buildOptions('cloudfront') as WithCatalog;
+    const node = opts.node;
+    // The controls live inside the collapsed "All options" <details>, under
+    // the .flag-controls container.
+    const controls = node.querySelector('details.all-options .flag-controls');
+    expect(controls).toBeTruthy();
+
+    // --no-pull is a renderable boolean -> checkbox labeled with the bare flag.
+    const noPullRow = [...controls!.querySelectorAll('.opt-row')].find((r) =>
+      (r.textContent || '').includes('--no-pull'),
+    )!;
+    const noPull = noPullRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(noPull).toBeTruthy();
+    noPull.checked = true;
+
+    // --stack-region is a renderable value flag -> text input.
+    const regionRow = [...controls!.querySelectorAll('.opt-row')].find((r) =>
+      (r.textContent || '').includes('--stack-region'),
+    )!;
+    const regionInput = regionRow.querySelector('input.flag-control') as HTMLInputElement;
+    expect(regionInput).toBeTruthy();
+    regionInput.value = 'us-west-2';
+
+    const collected = opts.collectCatalog()!;
+    expect(collected['--no-pull']).toBe(true);
+    expect(collected['--stack-region']).toBe('us-west-2');
+    // A curated flag (none for cloudfront beyond --tls/--origin) / managed flag
+    // is NOT rendered here — only renderable residual flags.
+    expect(collected['--watch']).toBeUndefined();
+  });
+
+  it('omits unset controls (unchecked box / blank input) from the collected map', () => {
+    harness = createStudioHarness();
+    const opts = harness.buildOptions('cloudfront') as WithCatalog;
+    // Nothing touched -> no catalog args posted (keeps the run body minimal).
+    expect(opts.collectCatalog()).toBeUndefined();
+  });
+
+  it('auto-renders a <select> for a .choices() flag and collects the picked value (agentcore --platform)', () => {
+    harness = createStudioHarness();
+    const opts = harness.buildOptions('agentcore') as WithCatalog;
+    const controls = opts.node.querySelector('details.all-options .flag-controls')!;
+
+    const platformRow = [...controls.querySelectorAll('.opt-row')].find((r) =>
+      (r.textContent || '').includes('--platform'),
+    )!;
+    const select = platformRow.querySelector('select.flag-control') as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    // The options are the (default) sentinel + the two declared choices.
+    const optionValues = [...select.options].map((o) => o.value);
+    expect(optionValues).toEqual(['', 'linux/amd64', 'linux/arm64']);
+
+    // Blank (default) selection -> omitted.
+    expect(opts.collectCatalog()).toBeUndefined();
+    // Pick a choice -> collected.
+    select.value = 'linux/arm64';
+    expect(opts.collectCatalog()!['--platform']).toBe('linux/arm64');
+  });
+
+  it('prefills the controls from a recorded catalogArgs map and opens the panel', () => {
+    harness = createStudioHarness();
+    // buildOptions(kind, prefill, rawPrefill, catalogPrefill) — the harness type
+    // only declares the kind arg, so call through a widened signature.
+    const build = harness.buildOptions as unknown as (
+      kind: string,
+      prefill?: unknown,
+      rawPrefill?: unknown,
+      catalogPrefill?: Record<string, boolean | string>,
+    ) => WithCatalog;
+    const opts = build('cloudfront', undefined, undefined, {
+      '--no-pull': true,
+      '--stack-region': 'eu-west-1',
+    });
+    const details = opts.node.querySelector('details.all-options') as HTMLDetailsElement;
+    // A prefilled value auto-expands the collapsed panel.
+    expect(details.open).toBe(true);
+    // The recorded values round-trip back out of the re-rendered controls.
+    const collected = opts.collectCatalog()!;
+    expect(collected['--no-pull']).toBe(true);
+    expect(collected['--stack-region']).toBe('eu-west-1');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl studio`'s composer "All options" panel previously showed a read-only
flag list plus a single raw `--flag value` text box, so a user had to
hand-type any flag not surfaced as a curated control. This makes the panel
auto-render a real editable control for every command flag instead.

For each RENDERABLE catalog flag:

- boolean / `--no-xxx` negate flag -> checkbox (emits the bare flag)
- value flag -> text input (placeholder parsed from the flag's value token)
- `.choices()` flag -> `<select>`

A flag is renderable when it is NEITHER curated (a rich control already exists
in `OPTION_SPECS`) NOR studio-managed (`CATALOG_MANAGED_FLAGS`: `--event` /
`--response-file` / `--host` / `--port` / `--watch` / the `--image-*` override
family, which studio injects itself). The raw extra-args input stays as the
final escape hatch.

## Implementation

- `studio-option-catalog`: `buildFlagCatalog` now emits per-flag control
  metadata (`long` / `takesValue` / `negate` / `variadic` / `placeholder` /
  `choices` / `renderable`); new `buildCatalogArgs(kind, values)` validates the
  UI-posted `{ flag -> boolean|string }` map and builds the argv fragment.
- `studio-dispatch` / `studio-serve-manager`: append the catalog args after the
  curated per-run args, before the raw args (no-op when absent).
- `coerceRunRequest`: validates `catalogArgs` at the `/api/run` boundary
  (unknown / non-overridable flag -> clean error).
- `studio-ui`: `buildAllOptions` auto-renders + collects the controls; threaded
  through the invoke + serve flows, the `serveApplied` prefill, and the
  "Started with" summary.

The new helpers stay studio-internal (not exported from `src/internal.ts` /
`src/index.ts`), matching the un-exported sibling `buildPerRunArgs` /
`buildFlagCatalog`.

## Test plan

- Unit: flag-type derivation (boolean / value / negate / variadic / choices /
  placeholder / renderable), `buildCatalogArgs` happy + error paths,
  `coerceRunRequest` boundary validation, dispatch + serve-manager argv
  threading, and jsdom coverage driving the real embedded script —
  `buildAllOptions` renders checkbox / input / `<select>`, `collectCatalog`
  round-trips set controls + omits unset ones + prefills from a recorded map,
  and `formatAppliedOptions` surfaces a `catalogArgs` entry.
- Integration (`local-studio`, real Docker, green): the served HTML embeds the
  auto-rendered controls; a `catalogArgs` control value (`--debug-port`
  non-numeric) reaches the child argv (proven by the child naming the rejected
  value); a non-overridable flag (`--event`) is rejected at the `/api/run`
  boundary.
- Manual: booted `cdkl studio` and confirmed the controls render with
  descriptions for both an invoke (lambda) and a serve (cloudfront) composer.
