### PR TITLE
test: minimize undici keep-alive to kill the forks-worker crash variant (#402)

### DIFF
--- a/tests/setup-helpers.ts
+++ b/tests/setup-helpers.ts
@@ -105,3 +105,54 @@ export function pruneForeignSignalListeners(
     }
   }
 }
+
+/**
+ * Node stores the global `fetch` (undici) dispatcher on this well-known global
+ * symbol — the same slot the public `undici` package reads/writes — so it can
+ * be read/replaced WITHOUT adding undici as a dependency.
+ */
+export const UNDICI_GLOBAL_DISPATCHER = Symbol.for('undici.globalDispatcher.1');
+
+/**
+ * Keep-alive-minimizing undici `Agent` options (issue #402, crash variant).
+ *
+ * A tiny `keepAliveTimeout` closes an idle socket almost immediately after its
+ * response instead of pooling it for reuse. The crash variant ("Worker exited
+ * unexpectedly", all tests passing) happens because a test `fetch`es a real
+ * server, undici pools a keep-alive socket, the test's `afterEach` closes the
+ * SERVER but not the client socket, and that now-dangling pooled socket's
+ * native handle later crashes the reused forks worker. Closing the socket right
+ * after each response removes the dangling-socket window entirely.
+ * `pipelining: 0` disables request pipelining on the connection.
+ */
+export const LOW_KEEPALIVE_DISPATCHER_OPTS = {
+  keepAliveTimeout: 1,
+  keepAliveMaxTimeout: 1,
+  pipelining: 0,
+} as const;
+
+interface UndiciDispatcherLike {
+  destroy(): Promise<void>;
+  constructor: new (opts?: unknown) => UndiciDispatcherLike;
+}
+
+/**
+ * Destroy the current undici global dispatcher and reinstall a fresh one with
+ * keep-alive minimized ({@link LOW_KEEPALIVE_DISPATCHER_OPTS}).
+ *
+ * Returns `false` (no-op) when no dispatcher exists yet — the slot is undefined
+ * until the worker issues its first `fetch`. Reuses the existing dispatcher's
+ * constructor (an undici `Agent`) so undici need not be imported (it is a
+ * transitive dependency only, not importable as `'undici'`).
+ */
+export async function reinstallLowKeepAliveDispatcher(
+  slot: Record<symbol, unknown>
+): Promise<boolean> {
+  const dispatcher = slot[UNDICI_GLOBAL_DISPATCHER] as UndiciDispatcherLike | undefined;
+  if (!dispatcher || typeof dispatcher.destroy !== 'function') {
+    return false;
+  }
+  await dispatcher.destroy();
+  slot[UNDICI_GLOBAL_DISPATCHER] = new dispatcher.constructor(LOW_KEEPALIVE_DISPATCHER_OPTS);
+  return true;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,10 +1,12 @@
 /// <reference types="node" />
 
-import { afterAll, vi } from 'vite-plus/test';
+import { afterAll, beforeAll, vi } from 'vite-plus/test';
 import {
   installTerminateGuard,
   pruneForeignSignalListeners,
+  reinstallLowKeepAliveDispatcher,
   resolveRealExit,
+  UNDICI_GLOBAL_DISPATCHER,
 } from './setup-helpers.js';
 
 /**
@@ -123,43 +125,63 @@ const realProcessExit = resolveRealExit(workerGlobals, process);
 const fastTerminate = installTerminateGuard(workerGlobals, process, realProcessExit);
 
 /**
- * Per-file teardown: destroy the undici (Node global `fetch`) keep-alive pool
- * so no pooled socket survives into the forked worker's teardown.
+ * Undici (Node global `fetch`) keep-alive defense against the "Worker exited
+ * unexpectedly" crash variant (issue #402).
  *
- * Background (issue #402):
+ *   A forked vitest worker is reused across several test files. A test that
+ *   `fetch`es a real HTTP server leaves an idle keep-alive socket pooled in
+ *   undici's global dispatcher after the response — even when the body is fully
+ *   read. The test's `afterEach` closes the SERVER but not that client socket,
+ *   so a now-dangling pooled socket lingers. On CI (slower, contended) its
+ *   native handle can crash the reused worker ("Worker exited unexpectedly")
+ *   AFTER every assertion has already passed — vitest then propagates the crash
+ *   as a non-zero exit even though the suite is green. It is intermittent and
+ *   not locally reproducible.
  *
- *   A forked vitest worker is reused across several test files. Tests that
- *   drive a real HTTP server with the global `fetch` leave an idle keep-alive
- *   socket pooled in undici's global dispatcher after the request finishes.
- *   When the worker process is later told to exit, that pooled socket's
- *   native handle can crash the worker ("Worker exited unexpectedly") AFTER
- *   every assertion has already passed — vitest then propagates the crash as
- *   a non-zero exit even though the suite is green. The crash is intermittent
- *   (timing-dependent)
- *   and not locally reproducible, so the only robust defense is to guarantee
- *   the pool is empty at every file boundary.
+ *   Two layers, both via the helper that reuses the dispatcher's own
+ *   constructor (so undici need not be imported — it is a transitive dep only):
  *
- *   Node stores the global dispatcher on a well-known global symbol
- *   (`Symbol.for('undici.globalDispatcher.1')`) — the same slot the public
- *   `undici` package reads/writes — so we can clear it WITHOUT adding undici
- *   as a dependency. We `destroy()` the current dispatcher (forcibly aborting
- *   any leftover/idle socket) and install a fresh `Agent` of the same
- *   constructor so subsequent files in the same worker get a clean pool. The
- *   symbol slot is non-configurable but writable, so reassignment is allowed;
- *   reusing the existing dispatcher's constructor avoids importing `Agent`.
+ *     1. `beforeAll` bootstrap, ONCE per worker: install a keep-alive-minimized
+ *        global dispatcher BEFORE the worker's first real test `fetch`, so no
+ *        socket is ever pooled long enough to dangle past an `afterEach`
+ *        server-close. The dispatcher is created lazily on first `fetch`, so a
+ *        throwaway `fetch` to a closed port forces it into existence first.
+ *     2. `afterAll` per file: re-destroy + reinstall the low-keep-alive
+ *        dispatcher, so any churn during the file leaves a clean slot for the
+ *        next file in the reused worker.
  *
- *   This is a per-FILE hook (`afterAll`), not per-test, so within-file
- *   connection reuse is unchanged — only the file boundary resets the pool.
  *   Tests that drive raw `node:http` sockets (their own `agent: false` /
  *   `req.destroy()` teardown) are unaffected: they do not use the undici
  *   global dispatcher.
  */
-const UNDICI_GLOBAL_DISPATCHER = Symbol.for('undici.globalDispatcher.1');
+const UNDICI_LOW_KEEPALIVE_KEY = '__cdk_local_test_undici_low_keepalive__';
 
-interface UndiciDispatcher {
-  destroy(): Promise<void>;
-  constructor: new () => UndiciDispatcher;
-}
+beforeAll(async () => {
+  if (workerGlobals[UNDICI_LOW_KEEPALIVE_KEY]) {
+    return;
+  }
+  workerGlobals[UNDICI_LOW_KEEPALIVE_KEY] = true;
+  const slot = globalThis as Record<symbol, unknown>;
+  // The global dispatcher is created lazily on the first `fetch`. Force it into
+  // existence with a throwaway request to a closed port (fails fast with
+  // ECONNREFUSED, pools nothing) so the constructor is available to reuse.
+  if (slot[UNDICI_GLOBAL_DISPATCHER] === undefined) {
+    const controller = new AbortController();
+    const guard = setTimeout(() => controller.abort(), 250);
+    try {
+      await fetch('http://127.0.0.1:1/', { signal: controller.signal });
+    } catch {
+      // Expected — the connection is refused / aborted; no socket is pooled.
+    } finally {
+      clearTimeout(guard);
+    }
+  }
+  try {
+    await reinstallLowKeepAliveDispatcher(slot);
+  } catch {
+    // Best-effort — never fail a green suite over dispatcher setup.
+  }
+});
 
 afterAll(async () => {
   // Prune any SIGTERM / SIGINT handlers a CLI command action registered while
@@ -169,16 +191,11 @@ afterAll(async () => {
   // our prepended fast-terminate guard is preserved.
   pruneForeignSignalListeners(process, fastTerminate);
 
-  const slot = globalThis as Record<symbol, unknown>;
-  const dispatcher = slot[UNDICI_GLOBAL_DISPATCHER] as UndiciDispatcher | undefined;
-  // Undefined until the worker issues its first `fetch`; nothing to clear.
-  if (!dispatcher || typeof dispatcher.destroy !== 'function') {
-    return;
-  }
-
+  // Destroy + reinstall the low-keep-alive dispatcher so no pooled socket
+  // survives into the next file / the worker's teardown. No-op until the
+  // worker has issued its first `fetch`.
   try {
-    await dispatcher.destroy();
-    slot[UNDICI_GLOBAL_DISPATCHER] = new dispatcher.constructor();
+    await reinstallLowKeepAliveDispatcher(globalThis as Record<symbol, unknown>);
   } catch {
     // Best-effort teardown — never fail a green suite over pool cleanup.
   }

--- a/tests/unit/setup-helpers.test.ts
+++ b/tests/unit/setup-helpers.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi } from 'vite-plus/test';
 import {
   FAST_TERMINATE_KEY,
+  LOW_KEEPALIVE_DISPATCHER_OPTS,
   REAL_EXIT_KEY,
   TERMINATE_SIGNALS,
+  UNDICI_GLOBAL_DISPATCHER,
   installTerminateGuard,
   pruneForeignSignalListeners,
+  reinstallLowKeepAliveDispatcher,
   resolveRealExit,
   type SignalProcessLike,
 } from '../setup-helpers.js';
@@ -139,5 +142,56 @@ describe('pruneForeignSignalListeners', () => {
     for (const signal of TERMINATE_SIGNALS) {
       expect(proc.listeners(signal)).toEqual([guard]);
     }
+  });
+});
+
+/** Records the options its constructor was last handed + whether destroy ran. */
+class FakeDispatcher {
+  static lastOpts: unknown;
+  destroyed = false;
+  constructor(opts?: unknown) {
+    FakeDispatcher.lastOpts = opts;
+  }
+  async destroy(): Promise<void> {
+    this.destroyed = true;
+  }
+}
+
+describe('reinstallLowKeepAliveDispatcher', () => {
+  it('destroys the current dispatcher and reinstalls one with low-keepalive opts', async () => {
+    FakeDispatcher.lastOpts = undefined;
+    const slot: Record<symbol, unknown> = {};
+    const original = new FakeDispatcher();
+    slot[UNDICI_GLOBAL_DISPATCHER] = original;
+
+    const installed = await reinstallLowKeepAliveDispatcher(slot);
+
+    expect(installed).toBe(true);
+    expect(original.destroyed).toBe(true);
+    const replacement = slot[UNDICI_GLOBAL_DISPATCHER];
+    expect(replacement).toBeInstanceOf(FakeDispatcher);
+    expect(replacement).not.toBe(original);
+    // The replacement was constructed with the keep-alive-minimizing options.
+    expect(FakeDispatcher.lastOpts).toEqual(LOW_KEEPALIVE_DISPATCHER_OPTS);
+  });
+
+  it('returns false (no-op) when no dispatcher exists yet (no fetch issued)', async () => {
+    const slot: Record<symbol, unknown> = {};
+    expect(await reinstallLowKeepAliveDispatcher(slot)).toBe(false);
+  });
+
+  it('returns false when the slot holds a non-dispatcher (no destroy method)', async () => {
+    const slot: Record<symbol, unknown> = { [UNDICI_GLOBAL_DISPATCHER]: {} };
+    expect(await reinstallLowKeepAliveDispatcher(slot)).toBe(false);
+    // The bogus value is left untouched.
+    expect(slot[UNDICI_GLOBAL_DISPATCHER]).toEqual({});
+  });
+
+  it('low-keepalive opts close idle sockets immediately (keepAliveTimeout minimal)', () => {
+    // Lock the intent: a tiny keepAliveTimeout + no pipelining is what removes
+    // the dangling-pooled-socket window the crash variant depends on.
+    expect(LOW_KEEPALIVE_DISPATCHER_OPTS.keepAliveTimeout).toBeLessThanOrEqual(1);
+    expect(LOW_KEEPALIVE_DISPATCHER_OPTS.keepAliveMaxTimeout).toBeLessThanOrEqual(1);
+    expect(LOW_KEEPALIVE_DISPATCHER_OPTS.pipelining).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Targets the **crash variant** of the flaky CI worker failure (#402):
"Worker exited unexpectedly" with all tests passing, intermittent, CI-only.
This is distinct from the **hang variant** ("Timeout terminating forks worker")
fixed by the earlier SIGTERM/SIGINT fast-terminate guard — proven distinct
because a code-free docs PR branched off that fix still reproduced the crash.

Root cause: any test that `fetch`es a real `.listen()` server leaves an
undici keep-alive socket pooled in the global dispatcher (even when the body
is fully read). The test's `afterEach` closes the SERVER but not that client
socket, so a dangling pooled socket lingers; on CI its native handle later
crashes the reused forks worker AFTER assertions pass. It is NOT
streaming-specific — streaming-read tests use a mocked `fetch`.

## Fix

In `tests/setup.ts`, via a pure helper in `tests/setup-helpers.ts` that reuses
the global dispatcher's own constructor (undici is a transitive dep only, not
importable as `'undici'`):

- `reinstallLowKeepAliveDispatcher(slot)` — destroy the current undici global
  dispatcher and reinstall one with keep-alive minimized
  (`keepAliveTimeout`/`keepAliveMaxTimeout: 1`, `pipelining: 0`), so a socket
  closes right after its response instead of lingering past an `afterEach`
  server-close.
- `beforeAll` bootstrap (once per worker): a throwaway `fetch` to a closed
  port force-creates the lazily-built dispatcher, then the low-keepalive one is
  installed BEFORE the worker's first real test `fetch`.
- `afterAll` (per file): re-destroy + reinstall, replacing the prior
  default-dispatcher recreate.

Deliberately does NOT swallow `unhandledRejection` — vitest already surfaces
those, and swallowing would mask real test failures.

## Test plan

- New unit tests for the helper (low-keepalive reinstall via a fake dispatcher;
  no-op when no dispatcher / non-dispatcher; opts intent lock).
- Full suite green under the REAL bootstrap+reinstall path (the `beforeAll` /
  `afterAll` run for real in every worker; real-server `fetch` tests pass under
  the low-keepalive dispatcher): 202 files / 3084 tests.
- `vp run check` (0 errors) + `vp run build` pass; diff is tests-only
  (`tests/setup*.ts` + the unit test), so the integ and cdkd-parity gates do
  not apply.
- The crash is intermittent and not locally reproducible (5x local stress runs
  were clean before and after), so elimination is confirmed over repeated CI
  runs rather than a single green check. (#402) is left OPEN until that holds.
