### PR TITLE
test: deflake CI-load-sensitive tests + arm forks-worker crash diagnostics (#402)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,25 @@ jobs:
       - run: vp run test
       - run: vp run build
 
+      # Issue #402 diagnostics: if a forks worker crashed ("Worker exited
+      # unexpectedly"), Node's --report-on-fatalerror / --report-uncaught-exception
+      # (armed in vite.config.ts) wrote a report.*.json with the native + JS
+      # stack and open libuv handles. Dump any report to the log on failure so
+      # the next crash pinpoints the offending native handle. No-op on success.
+      - name: Dump Node diagnostic reports (on failure)
+        if: failure()
+        run: |
+          shopt -s nullglob
+          found=0
+          for f in report.*.json; do
+            found=1
+            echo "::group::$f"
+            cat "$f"
+            echo "::endgroup::"
+          done
+          [ "$found" = 0 ] && echo "No Node diagnostic report written (worker did not hit a fatal/uncaught crash)."
+          exit 0
+
   runtime-compat:
     runs-on: ubuntu-latest
     needs: check-build-test

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ cdk.context.json
 .pr-body*.txt
 .gh-body*.md
 .gh-body*.txt
+
+# Node diagnostic reports (issue #402, --report-on-fatalerror)
+report.*.json

--- a/tests/unit/local/ecs-service-runner-front-door.test.ts
+++ b/tests/unit/local/ecs-service-runner-front-door.test.ts
@@ -84,7 +84,11 @@ function frontDoorOptions(pool: FrontDoorEndpointPool) {
   };
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+// 15s (not 3s): under CI's parallel forks workers the worker is CPU-starved,
+// so the small async restart / re-register work can take wall-clock seconds
+// even though it is logically near-instant. The tighter 3s budget flaked on CI
+// ("waitFor timed out") despite the assertion being correct (issue #402).
+async function waitFor(predicate: () => boolean, timeoutMs = 15000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() > deadline) throw new Error('waitFor timed out');

--- a/tests/unit/local/studio-server.test.ts
+++ b/tests/unit/local/studio-server.test.ts
@@ -653,8 +653,13 @@ describe('startStudioServer', () => {
     // Re-request the SAME concrete port the first server bound; the bump
     // logic must pick a different one rather than throwing EADDRINUSE.
     const second = await boot({ port: first.port });
-    expect(second.port).not.toBe(first.port);
-    expect(second.port).toBe(first.port + 1);
+    // The bump must land on a DIFFERENT, higher free port. Assert `> first`
+    // rather than exactly `first + 1`: under CI's parallel workers another
+    // process can hold `first + 1`, so the bump legitimately skips to
+    // `first + 2` (etc.) — asserting an exact `+1` flaked (issue #402). The
+    // contract under test is "pick a free port instead of throwing
+    // EADDRINUSE", not the exact offset.
+    expect(second.port).toBeGreaterThan(first.port);
   });
 
   it('rejects when the preferred port is taken and no bumps are allowed', async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,6 +72,20 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     setupFiles: ['./tests/setup.ts'],
+    // Diagnostics for issue #402's "Worker exited unexpectedly" crash variant:
+    // a reused forks worker occasionally dies on a native handle AFTER all
+    // assertions pass. It is intermittent and not locally reproducible, so we
+    // arm Node's diagnostic report on the forks workers — a fatal C++ error or
+    // an uncaught exception writes a `report.*.json` (native + JS stack, open
+    // libuv handles) to cwd, which CI dumps to the log on failure (see
+    // `.github/workflows/ci.yml`). No overhead on a clean run — a report is
+    // written ONLY when a worker actually crashes.
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        execArgv: ['--report-on-fatalerror', '--report-uncaught-exception'],
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Investigation into #402 found the CI failures are not a single bug: under
parallel forks-worker CPU contention SEVERAL timing-sensitive tests flake,
alongside the native "Worker exited unexpectedly" crash variant. Observed
distinct failures across runs: a `waitFor` timeout, a port-bump race, a
WebSocket frame race, and the worker crash. Two earlier targeted fixes
(the SIGTERM/SIGINT guard, the undici keep-alive minimization) reduced but
did not eliminate the native crash, confirming per-test teardown tweaks
are not enough.

This PR splits the remedy: deflake the clearly-caused load-sensitive tests,
and ARM diagnostics so the next native crash in CI is actually captured.

## Deflakes

- **ecs-service-runner-front-door**: the restart re-register `waitFor` budget
  was 3000ms; a CPU-starved CI worker exceeds it even though the async work is
  logically near-instant. Bumped to 15000ms (the assertion was already correct).
- **studio-server "bumps to the next free port"**: asserted the bump lands on
  EXACTLY `first.port + 1`, but a parallel process can hold that port so the
  bump legitimately skips ahead. Now asserts `> first.port` — the real
  contract is "pick a free port instead of throwing EADDRINUSE", not the offset.

## Crash diagnostics (not locally reproducible)

- `vite.config.ts`: forks workers run with `--report-on-fatalerror`
  `--report-uncaught-exception`, so a crash writes a `report.*.json` (native +
  JS stack, open libuv handles) to cwd. No overhead on a clean run.
- `.github/workflows/ci.yml`: on failure, dump any `report.*.json` to the CI
  log so the next "Worker exited unexpectedly" pinpoints the offending handle.
- `.gitignore`: ignore `report.*.json`.

## Test plan

- Both deflaked tests pass; full suite green (202 files / 3084 tests) under the
  new forks `execArgv`; `vp run check` + `vp run build` pass.
- Verified the diagnostic report is produced on an uncaught exception
  (event=Exception, JS stack captured).
- 12x local stress = 11 clean + 1 unrelated flaky, confirming the suite is
  load-sensitive and not locally reproducible — the native crash variant
  remains tracked under (#402) pending a CI-captured report.
- A WebSocket frame-ordering flake in `agentcore-ws-client` (frameSource
  close-vs-last-ack race) is a deeper behavior question, NOT fixed here, and
  remains tracked under (#402).
- Diff touches only tests + config (`vite.config.ts` / `ci.yml` / `.gitignore`),
  so the integ and cdkd-parity gates do not apply.
