### PR TITLE
feat(logger): prefix warn/error with WARN:/ERROR: + colour studio LOGS by level

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -936,7 +936,14 @@ compute-locally category for Lambda + API Gateway).
   Request/Response detail whose [Re-invoke] reuses that serve's request
   composer (pre-filled), and a re-invoked row is visually linked to its
   source; a log search box queries the store and a captured request's
-  detail shows its bound logs. The header `● live` / `● disconnected`
+  detail shows its bound logs. The LOGS panel + log search colour each
+  line by its level (`fillLogPre` / `logLineClass`): a line whose text
+  starts `WARN:` / `ERROR:` (optionally after a `[module]` tag) is
+  rendered amber / red, so warn / error stand out even though the captured
+  child output carries no ANSI colour (serve children run colourless under
+  a pipe) — the text prefix is the only severity signal that survives, and
+  the compact logger now emits it (see logger note below). The header
+  `● live` / `● disconnected`
   indicator is driven by `connect()`'s liveness logic: it binds to the
   FIRST `/api/events` `hello` instanceId, flips to disconnected (latched,
   socket closed) when a reconnect lands on a DIFFERENT instanceId (a second
@@ -1068,7 +1075,12 @@ compute-locally category for Lambda + API Gateway).
   WARN (e.g. the pinned-image boot warning) could surface in the studio LOG
   panel AFTER a later stdout line like `Press ^C to shut down.`. The serve
   path is safe to unify (ready-line detection greps stdout; error detection
-  is via the child `error` / `close` events, not stderr content). Under
+  is via the child `error` / `close` events, not stderr content).
+  Complementing this, the compact-mode logger (`utils/logger.ts`) prefixes
+  warn / error lines with `WARN:` / `ERROR:` (info stays prefix-less) so the
+  severity is legible even when ANSI colour is stripped — a piped /
+  redirected CLI run, `NO_COLOR`, or the colourless studio child pipe; the
+  studio LOGS panel re-colours each line off that prefix. Under
   `cdkl studio --watch` it appends
   `--watch` to each serve child — read off the mutable config per
   `start()`, so a Session-bar toggle applies to the next serve. Issue #355

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -293,6 +293,12 @@ const STUDIO_CSS = `
   .log-hit .lt { color: #777; }
   .log-hit .lg { color: #6aa9ff; }
   .log-hits-meta { padding: 6px 12px; color: #888; font-size: 11px; }
+  /* Per-line log severity colour (parsed from the WARN: / ERROR: prefix the
+     compact logger emits) so warn / error stand out in the LOGS panel + search
+     even with no ANSI colour over the child pipe. */
+  .log-row { display: block; }
+  .log-warn { color: #e5b567; }
+  .log-error { color: #e0707a; }
   #conn { font-size: 11px; }
   #conn.up { color: #7bd88f; }
   #conn.down { color: #e0707a; }
@@ -430,6 +436,40 @@ const STUDIO_SCRIPT = `
     if (cls) e.className = cls;
     if (text != null) e.textContent = text;
     return e;
+  }
+
+  // Classify a streamed log line by its level prefix so warn / error stand out
+  // even though the captured child output carries no ANSI color (serve children
+  // run colorless under a pipe). cdk-local's compact logger prefixes warn /
+  // error lines with WARN: / ERROR: (utils/logger.ts) -- the one severity
+  // signal that survives the pipe. An optional leading child-logger [module]
+  // tag is tolerated. A container's own runtime logs that happen to start
+  // ERROR: / WARN: are coloured too, which is desirable. Written with string
+  // ops (no regex) because backslash escapes do not survive the STUDIO_SCRIPT
+  // template literal.
+  function logLineClass(line) {
+    let s = line == null ? '' : String(line);
+    if (s.charAt(0) === '[') {
+      const close = s.indexOf('] ');
+      if (close !== -1) s = s.slice(close + 2);
+    }
+    if (s.indexOf('ERROR: ') === 0) return 'log-error';
+    if (s.indexOf('WARN: ') === 0) return 'log-warn';
+    return null;
+  }
+  // Render lines into a <pre> as one block span each so a per-line level colour
+  // can apply (a single textContent join cannot be partially coloured).
+  function fillLogPre(pre, lines) {
+    pre.textContent = '';
+    if (!lines || !lines.length) {
+      pre.textContent = '(none)';
+      return;
+    }
+    for (let i = 0; i < lines.length; i++) {
+      const span = el('span', logLineClass(lines[i]), lines[i]);
+      span.classList.add('log-row');
+      pre.appendChild(span);
+    }
   }
 
   // Per-target run options (issue #301 slice 2). The descriptor table is
@@ -1506,7 +1546,8 @@ const STUDIO_SCRIPT = `
     };
     logClearRow.appendChild(logClear);
     logSec.appendChild(logClearRow);
-    const logPre = el('pre', null, logs.length ? logs.join('\\n') : '(none)');
+    const logPre = el('pre', null);
+    fillLogPre(logPre, logs);
     logSec.appendChild(logPre);
     ws.appendChild(logSec);
     // Register the live LOGS <pre> so streamed log events update it surgically
@@ -2126,7 +2167,9 @@ const STUDIO_SCRIPT = `
     const logs = logsById.get(invId) || [];
     const logSec = el('div', 'section');
     logSec.appendChild(el('h3', null, 'Logs'));
-    logSec.appendChild(el('pre', null, logs.length ? logs.join('\\n') : '(none)'));
+    const invLogPre = el('pre', null);
+    fillLogPre(invLogPre, logs);
+    logSec.appendChild(invLogPre);
     result.appendChild(logSec);
   }
 
@@ -2275,7 +2318,7 @@ const STUDIO_SCRIPT = `
       const res = await fetch('/api/invocations/' + encodeURIComponent(id) + '/logs');
       const data = await res.json();
       const lines = (data.logs || []).map((l) => l.line);
-      if (shownDetailId === id) pre.textContent = lines.length ? lines.join('\\n') : '(none)';
+      if (shownDetailId === id) fillLogPre(pre, lines);
     } catch (err) {
       if (shownDetailId === id) pre.textContent = '(failed to load logs)';
     }
@@ -2313,7 +2356,7 @@ const STUDIO_SCRIPT = `
         const row = el('div', 'log-hit');
         row.appendChild(el('span', 'lt', new Date(h.ts).toLocaleTimeString() + '  '));
         row.appendChild(el('span', 'lg', (h.target || '') + '  '));
-        row.appendChild(document.createTextNode(h.line));
+        row.appendChild(el('span', logLineClass(h.line), h.line));
         results.appendChild(row);
       }
     } catch (err) {
@@ -2390,7 +2433,7 @@ const STUDIO_SCRIPT = `
       // last response). Update only the live LOGS <pre> surgically instead
       // (issue #334). A status change still re-renders via onServeEvent.
       if (shownServeId === ev.containerId && serveLogId === ev.containerId && serveLogPre) {
-        serveLogPre.textContent = arr.join('\\n');
+        fillLogPre(serveLogPre, arr);
       }
     });
     setInterval(() => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -126,14 +126,20 @@ export class ConsoleLogger implements Logger {
       return `${timestamp} ${levelStr} ${message}${formattedArgs}`;
     }
 
-    if (this.useColors) {
-      if (level === 'error') {
-        return `${colors.red}${message}${formattedArgs}${colors.reset}`;
-      }
-      if (level === 'warn') {
-        return `${colors.yellow}${message}${formattedArgs}${colors.reset}`;
-      }
-      return `${message}${formattedArgs}`;
+    // Compact mode (info level) prefixes warn / error with an UPPERCASE level
+    // tag so the severity is legible even when ANSI color is stripped — a
+    // piped / redirected CLI run, `NO_COLOR`, or the `cdkl studio` serve child
+    // (captured over a pipe, so colorless). Color, when available, still wraps
+    // the whole line. info stays prefix-less so the common-case progress output
+    // is unchanged. The prefix is the one severity signal that survives a pipe,
+    // and studio's LOG panel re-colors off it (studio-ui).
+    if (level === 'error') {
+      const line = `ERROR: ${message}${formattedArgs}`;
+      return this.useColors ? `${colors.red}${line}${colors.reset}` : line;
+    }
+    if (level === 'warn') {
+      const line = `WARN: ${message}${formattedArgs}`;
+      return this.useColors ? `${colors.yellow}${line}${colors.reset}` : line;
     }
 
     return `${message}${formattedArgs}`;

--- a/tests/unit/local/studio-ui-log-level.test.ts
+++ b/tests/unit/local/studio-ui-log-level.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+/**
+ * The studio LOGS panel re-colours warn / error lines off the WARN: / ERROR:
+ * prefix the compact logger emits (the captured serve-child output carries no
+ * ANSI colour, so the text prefix is the only severity signal that survives the
+ * pipe). These tests drive the embedded `logLineClass` / `fillLogPre` helpers
+ * via the jsdom harness and assert the per-line span class.
+ */
+describe('studio LOGS panel level colouring', () => {
+  function withHelpers<T>(fn: (h: ReturnType<typeof createStudioHarness>) => T): T {
+    // Expose the two log helpers via a window property captured by the epilogue.
+    const harness = createStudioHarness({
+      epilogue: 'window.__logHelpers = { logLineClass: logLineClass, fillLogPre: fillLogPre };',
+    });
+    try {
+      return fn(harness);
+    } finally {
+      harness.close();
+    }
+  }
+
+  it('classifies a line by its level prefix (tolerating a [module] tag)', () => {
+    withHelpers((h) => {
+      const { logLineClass } = (h.window as unknown as {
+        __logHelpers: { logLineClass: (line: string) => string | null };
+      }).__logHelpers;
+      expect(logLineClass('ERROR: boom')).toBe('log-error');
+      expect(logLineClass('WARN: heads up')).toBe('log-warn');
+      expect(logLineClass('[docker] ERROR: boom')).toBe('log-error');
+      expect(logLineClass('just info')).toBe(null);
+      expect(logLineClass('contains ERROR: mid-line')).toBe(null);
+    });
+  });
+
+  it('fillLogPre renders one block span per line with the level class', () => {
+    withHelpers((h) => {
+      const { fillLogPre } = (h.window as unknown as {
+        __logHelpers: { fillLogPre: (pre: Element, lines: string[]) => void };
+      }).__logHelpers;
+      const pre = h.document.createElement('pre');
+      fillLogPre(pre, ['booting', 'WARN: pinned image', 'ERROR: crashed']);
+      const spans = pre.querySelectorAll('span.log-row');
+      expect(spans.length).toBe(3);
+      expect(spans[0].className).toBe('log-row');
+      expect(spans[1].className).toContain('log-warn');
+      expect(spans[2].className).toContain('log-error');
+      expect(spans[1].textContent).toBe('WARN: pinned image');
+    });
+  });
+
+  it('fillLogPre shows (none) for an empty log set', () => {
+    withHelpers((h) => {
+      const { fillLogPre } = (h.window as unknown as {
+        __logHelpers: { fillLogPre: (pre: Element, lines: string[]) => void };
+      }).__logHelpers;
+      const pre = h.document.createElement('pre');
+      fillLogPre(pre, []);
+      expect(pre.textContent).toBe('(none)');
+      expect(pre.querySelectorAll('span').length).toBe(0);
+    });
+  });
+});

--- a/tests/unit/local/studio-ui.test.ts
+++ b/tests/unit/local/studio-ui.test.ts
@@ -196,7 +196,9 @@ describe('renderStudioHtml', () => {
     // composer inputs + the last response).
     expect(html).toContain('serveLogPre');
     expect(html).toContain('serveLogId');
-    expect(html).toContain('serveLogPre.textContent = arr.join(');
+    // The live LOGS <pre> is refilled surgically per log event (one level-
+    // coloured span per line via fillLogPre, issue: warn/error legibility).
+    expect(html).toContain('fillLogPre(serveLogPre, arr)');
     // The log handler no longer full-re-renders a shown serve.
     expect(html).not.toContain('if (shownServeId === ev.containerId) renderServeWorkspace(ev.containerId)');
   });

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -3,6 +3,7 @@ import {
   resolveConfiguredLogLevel,
   resolveDefaultUseColors,
   ConsoleLogger,
+  setLogger,
 } from '../../../src/utils/logger.js';
 
 /**
@@ -85,8 +86,8 @@ describe('ConsoleLogger CDKL_LOG_STREAM=stdout unification (issue #403)', () => 
       // reads only one stream sees them ordered.
       expect(logSpy.mock.calls.map((c) => c[0])).toEqual([
         'an info line',
-        'a warning',
-        'an error',
+        'WARN: a warning',
+        'ERROR: an error',
       ]);
       // None went to the stderr-backed channels.
       expect(warnSpy).not.toHaveBeenCalled();
@@ -210,7 +211,7 @@ describe('ConsoleLogger color gating by default (issue #2)', () => {
       const logger = new ConsoleLogger('info');
       logger.error('boom');
       const line = errSpy.mock.calls[0]?.[0] as string;
-      expect(line).toBe('boom');
+      expect(line).toBe('ERROR: boom');
       expect(line).not.toContain(ANSI_RED);
     } finally {
       errSpy.mockRestore();
@@ -246,7 +247,7 @@ describe('ConsoleLogger color gating by default (issue #2)', () => {
       const logger = new ConsoleLogger('info');
       logger.error('boom');
       const line = logSpy.mock.calls[0]?.[0] as string;
-      expect(line).toBe('boom');
+      expect(line).toBe('ERROR: boom');
       expect(line).not.toContain(ANSI_RED);
     } finally {
       logSpy.mockRestore();
@@ -267,6 +268,64 @@ describe('ConsoleLogger color gating by default (issue #2)', () => {
       expect(line).toContain(ANSI_RED);
     } finally {
       errSpy.mockRestore();
+    }
+  });
+});
+
+describe('ConsoleLogger compact-mode level prefix', () => {
+  const prevLogStream = process.env['CDKL_LOG_STREAM'];
+
+  afterEach(() => {
+    if (prevLogStream === undefined) delete process.env['CDKL_LOG_STREAM'];
+    else process.env['CDKL_LOG_STREAM'] = prevLogStream;
+  });
+
+  it('prefixes warn / error so severity survives a colorless pipe; info stays bare', () => {
+    // The severity signal that crosses the studio child pipe (no ANSI there).
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const logger = new ConsoleLogger('info', false);
+      logger.info('progress');
+      logger.warn('heads up');
+      logger.error('broke');
+      expect(infoSpy.mock.calls[0]?.[0]).toBe('progress');
+      expect(warnSpy.mock.calls[0]?.[0]).toBe('WARN: heads up');
+      expect(errSpy.mock.calls[0]?.[0]).toBe('ERROR: broke');
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('keeps the prefix INSIDE the color wrap when colors are on', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const logger = new ConsoleLogger('info', true);
+      logger.error('broke');
+      const line = errSpy.mock.calls[0]?.[0] as string;
+      // red ... ERROR: broke ... reset
+      expect(line).toBe(`\x1b[31mERROR: broke\x1b[0m`);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('a child logger in compact mode also carries the prefix (no [module] tag)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // The child syncs its LEVEL from the global logger; pin it to info so the
+      // compact (not debug) branch is exercised regardless of cross-test state.
+      const parent = new ConsoleLogger('info', false);
+      setLogger(parent);
+      const child = parent.child('docker');
+      child.warn('heads up');
+      // compact mode omits the [module] tag but keeps the level prefix.
+      expect(warnSpy.mock.calls[0]?.[0]).toBe('WARN: heads up');
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

Make log severity legible whenever ANSI colour is stripped — a piped /
redirected CLI run, `NO_COLOR`, or the `cdkl studio` serve child (captured
over a pipe, so colourless). In those paths warn / error were
indistinguishable from info: no colour, no text marker.

- **logger** (`src/utils/logger.ts`): compact-mode warn / error now carry a
  `WARN:` / `ERROR:` text prefix (info stays prefix-less). Colour, when
  available, still wraps the whole line. The prefix is the one severity
  signal that survives a pipe.
- **studio UI** (`src/local/studio-ui.ts`): the LOGS panel + log search
  re-colour each line off that prefix (`fillLogPre` / `logLineClass`) ->
  amber warn / red error, rendered as one block span per line. Written with
  string ops, not a regex, because backslash escapes (`\[` / `\]`) do not
  survive the `STUDIO_SCRIPT` template literal — a regex char class would be
  silently corrupted at template-eval time.

## Test plan

- Unit: logger prefix (compact / coloured / child logger); studio
  `logLineClass` / `fillLogPre` driven against the real shipped
  `STUDIO_SCRIPT` via the jsdom harness (this caught the regex-mangling
  bug). All 3094 tests pass.
- Live (built CLI): `ERROR:` prefix over a pipe; red + `ERROR:` on a TTY.
- Integ: `local-invoke` 6/6 green, 0 Docker orphans (regression check on
  the most-trafficked path through the changed logger). Note: the
  warn/error prefix itself is verified by the direct live-CLI run, since
  integ `verify.sh` pipes invoke output through filters that suppress
  stderr lines.
