### PR TITLE
fix(studio): expose the image-override build-input flags as "All options" controls

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -898,9 +898,13 @@ compute-locally category for Lambda + API Gateway).
   `.choices()` flag) for every RENDERABLE catalog flag — i.e. every flag the
   underlying command accepts that is NEITHER curated (a rich control already
   exists in OPTION_SPECS) NOR studio-managed (`CATALOG_MANAGED_FLAGS`:
-  `--event` / `--response-file` / `--host` / `--port` / `--watch` / the
-  `--image-*` override family, injected by studio itself), plus a raw
-  extra-args input as the final escape hatch; the collected values
+  `--event` / `--response-file` / `--host` / `--port` / `--watch` + the
+  override-selection flags `--image-override` / `--no-interactive-overrides`
+  / `--strict-overrides`, injected by studio itself — but NOT the build-input
+  pass-throughs `--image-build-arg` / `--image-build-secret` / `--image-target`,
+  which DO auto-render since the Dockerfile picker only threads
+  `--image-override`), plus a raw extra-args input as the final escape hatch;
+  the collected values
   (`collectCatalog` -> the `catalogArgs` map keyed by long flag) are built into
   argv by `buildCatalogArgs` and appended after the curated per-run args (before
   the raw args). So the curated controls handle common flags richly AND a user
@@ -1021,8 +1025,12 @@ compute-locally category for Lambda + API Gateway).
   `renderable` (the UI auto-renders an editable control for it) when it is
   NEITHER curated (in OPTION_SPECS — a rich control already exists) NOR
   studio-managed (`CATALOG_MANAGED_FLAGS`: `--event` / `--response-file` /
-  `--host` / `--port` / `--watch` / the `--image-*` override family, which
-  studio injects itself). `buildCatalogArgs(kind, catalogArgs)` is the
+  `--host` / `--port` / `--watch` + the override-selection flags
+  `--image-override` / `--no-interactive-overrides` / `--strict-overrides`,
+  which studio injects itself; the build-input pass-throughs
+  `--image-build-arg` / `--image-build-secret` / `--image-target` are NOT
+  managed — they auto-render, since the picker only threads
+  `--image-override`). `buildCatalogArgs(kind, catalogArgs)` is the
   counterpart of OPTION_SPECS' `buildPerRunArgs`: it validates the UI-posted
   `CatalogValues` (a `{ long-flag -> boolean|string }` map) against the
   kind's renderable catalog flags and builds the argv fragment (bare flag for

--- a/src/local/studio-option-catalog.ts
+++ b/src/local/studio-option-catalog.ts
@@ -100,8 +100,20 @@ export const CATALOG_EXCLUDED_FLAGS: ReadonlySet<string> = new Set([
  *   capture proxy fronts it; a user override would desync the proxy URL.
  * - `--watch`: the session-global Session-bar toggle (appended by the
  *   serve-manager from the mutable config), not a per-run flag.
- * - the `--image-*` override family: handled by the dedicated Dockerfile
- *   picker (a partial control here would produce a half-wired override).
+ * - `--image-override` / `--no-interactive-overrides` / `--strict-overrides`:
+ *   the OVERRIDE-SELECTION flags. `--image-override` is threaded by the
+ *   dedicated Dockerfile picker (a generic control would produce a half-wired
+ *   override); the other two govern the picker's TTY prompt / strictness,
+ *   which studio drives itself (the child is non-interactive).
+ *
+ * Deliberately NOT managed (so they auto-render as controls): the build-input
+ * pass-throughs `--image-build-arg` / `--image-build-secret` / `--image-target`.
+ * The Dockerfile picker only threads `--image-override`, so excluding these
+ * would leave them reachable ONLY via the raw extra-args box — the exact UX
+ * gap the auto-rendered controls exist to close. A user rebuilding a pinned
+ * image from a local Dockerfile legitimately needs to pass build args /
+ * secrets / a target stage, so they get a control (variadic → one value per
+ * control; the raw-args box remains for multiple).
  */
 export const CATALOG_MANAGED_FLAGS: ReadonlySet<string> = new Set([
   '--event',
@@ -110,9 +122,6 @@ export const CATALOG_MANAGED_FLAGS: ReadonlySet<string> = new Set([
   '--port',
   '--watch',
   '--image-override',
-  '--image-build-arg',
-  '--image-build-secret',
-  '--image-target',
   '--no-interactive-overrides',
   '--strict-overrides',
 ]);

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -356,8 +356,10 @@ if ! grep -qF 'function stackSections' "${BODY_FILE}" \
 fi
 echo "    OK: targets pane folds the per-stack construct-path prefix + scrollable path tail"
 # Composer send-flow (issues #334 / #335 / #336): surgical serve-log update,
-# timeline deselect, and the New request back affordance.
-if ! grep -qF 'serveLogPre.textContent = arr.join(' "${BODY_FILE}" \
+# timeline deselect, and the New request back affordance. The surgical update
+# now goes through fillLogPre (the colour-by-level helper, #478) instead of a
+# raw `serveLogPre.textContent = arr.join(...)` assignment.
+if ! grep -qF 'fillLogPre(serveLogPre, arr)' "${BODY_FILE}" \
   || ! grep -qF "el('button', 'reinvoke-btn', 'New request')" "${BODY_FILE}" \
   || ! grep -qF "document.querySelectorAll('.row.sel').forEach((n) => n.classList.remove('sel'))" "${BODY_FILE}"; then
   echo "FAIL: GET / did not include the composer send-flow fixes (issues #334 / #335 / #336)"

--- a/tests/unit/local/studio-option-catalog.test.ts
+++ b/tests/unit/local/studio-option-catalog.test.ts
@@ -100,6 +100,20 @@ describe('buildFlagCatalog', () => {
     expect(renderable).toContain('--no-pull');
   });
 
+  it('renders the image-override BUILD-INPUT pass-throughs but not the override-selection flags (alb)', () => {
+    const cat = buildFlagCatalog();
+    const renderable = new Set((cat.alb?.flags ?? []).filter((f) => f.renderable).map((f) => f.long));
+    // The build inputs are reachable as controls (the picker only threads
+    // --image-override, so excluding these would strand them in raw-args).
+    expect(renderable.has('--image-build-secret')).toBe(true);
+    expect(renderable.has('--image-build-arg')).toBe(true);
+    expect(renderable.has('--image-target')).toBe(true);
+    // The override-selection flags stay managed (handled by the picker / TTY).
+    expect(renderable.has('--image-override')).toBe(false);
+    expect(renderable.has('--no-interactive-overrides')).toBe(false);
+    expect(renderable.has('--strict-overrides')).toBe(false);
+  });
+
   it('derives the choices set for a `.choices()` flag (drives the UI <select>)', () => {
     const cat = buildFlagCatalog();
     // agentcore (invoke-agentcore) --platform is a renderable choices flag.

--- a/tests/unit/local/studio-ui-exec.test.ts
+++ b/tests/unit/local/studio-ui-exec.test.ts
@@ -429,4 +429,25 @@ describe('studio UI "All options" auto-rendered controls (all-options-controls s
     expect(collected['--no-pull']).toBe(true);
     expect(collected['--stack-region']).toBe('eu-west-1');
   });
+
+  it('renders the image-override build-input flags as controls (alb --image-build-secret)', () => {
+    harness = createStudioHarness();
+    const opts = harness.buildOptions('alb') as WithCatalog;
+    const controls = opts.node.querySelector('details.all-options .flag-controls')!;
+    // The Dockerfile picker only threads --image-override, so the build-input
+    // pass-throughs must auto-render here (else they'd be raw-args-only).
+    const secretRow = [...controls.querySelectorAll('.opt-row')].find((r) =>
+      (r.textContent || '').includes('--image-build-secret'),
+    )!;
+    expect(secretRow).toBeTruthy();
+    const secretInput = secretRow.querySelector('input.flag-control') as HTMLInputElement;
+    expect(secretInput).toBeTruthy();
+    secretInput.value = 'npmrc=./.npmrc';
+    expect(opts.collectCatalog()!['--image-build-secret']).toBe('npmrc=./.npmrc');
+    // The override-selection flag --image-override is NOT auto-rendered (picker).
+    // Match on the control LABEL, not textContent — the build-input descriptions
+    // mention "--image-override", which would falsely match a substring search.
+    const labels = [...controls.querySelectorAll('.opt-label')].map((l) => (l.textContent || '').trim());
+    expect(labels).not.toContain('--image-override');
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the studio "All options" auto-rendered controls: the
image-override BUILD-INPUT flags (`--image-build-arg` / `--image-build-secret`
/ `--image-target`) were being hidden from the composer.

The previous slice put the entire `--image-*` family in
`CATALOG_MANAGED_FLAGS`, reasoning "handled by the Dockerfile picker". But the
picker only threads `--image-override` — the build-input pass-throughs are NOT,
so excluding them left them reachable ONLY via the raw extra-args box, the exact
UX gap the auto-rendered controls exist to close. `--image-build-secret`
especially matters: it is how a pinned-image local rebuild passes a
private-registry secret (`--image-build-secret npmrc=./.npmrc`).

This drops the three build-input flags from the managed set so they auto-render
as controls. The override-SELECTION flags (`--image-override` +
`--no-interactive-overrides` / `--strict-overrides`) stay managed — the
Dockerfile picker / TTY handle those.

## Also fixes a latent integ breakage

`tests/integration/local-studio/verify.sh` still grepped the old surgical
serve-log form `serveLogPre.textContent = arr.join(`; that was refactored to
`fillLogPre(serveLogPre, arr)` when the log colour-by-level helper landed
(#478), so the `local-studio` integ was latently red on `GET /`. Updated to the
current form.

## Test plan

- Unit: `buildFlagCatalog` marks `--image-build-arg` / `--image-build-secret` /
  `--image-target` renderable and the override-selection flags non-renderable
  (alb); jsdom drives the real script and asserts the alb composer renders an
  `--image-build-secret` input that `collectCatalog` round-trips, and does NOT
  render an `--image-override` control.
- Integration (`local-studio`, real Docker): green (102 OK / 0 FAIL) after the
  verify.sh fix.
- Manual: booted `cdkl studio`, opened the ALB composer's All options, confirmed
  `--image-build-arg` / `--image-build-secret` / `--image-target` render as
  inputs with their help text, alongside the separate Dockerfile picker.
