### PR TITLE
test(integ): run the local-studio fixture Lambdas on arm64 (kill the emulation flake)

### DIFF
--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -49,8 +49,14 @@ export class LocalStudioStack extends cdk.Stack {
     super(scope, id, props);
 
     // Lambda function — inline code so synth has no asset / bundling step.
+    // arm64 so the RIE container runs NATIVELY on an Apple Silicon dev host
+    // (where this Docker integ runs) instead of under QEMU x86 emulation, which
+    // is slow + unstable (the RIE Go binary can panic / the 30s invoke timeout
+    // can trip). The integ exercises studio orchestration, not arch fidelity,
+    // so native arm64 is the right default for this fixture.
     const fn = new lambda.Function(this, 'MyHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: lambda.Architecture.ARM_64,
       handler: 'index.handler',
       // Echoes the STUDIO_ENV_PROBE env var into the body so the per-target
       // `--env-vars` option (issue #301 slice 2) is observable end-to-end;
@@ -124,6 +130,8 @@ export class LocalStudioStack extends cdk.Stack {
     // The body-action selection expression routes every message to `$default`.
     const wsFn = new lambda.Function(this, 'WsEchoHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      // arm64 for native execution on the Apple Silicon dev host (see MyHandler).
+      architecture: lambda.Architecture.ARM_64,
       handler: 'index.handler',
       code: lambda.Code.fromInline(
         [


### PR DESCRIPTION
## Summary

The `local-studio` integ intermittently failed on the Lambda invoke steps with
QEMU-emulation symptoms (the 30s RIE invoke timeout tripping, or the RIE Go
binary panicking mid-invoke, or the WS-console echo round-trip returning empty).

Root cause: the fixture's `MyHandler` / `WsEchoHandler` Lambdas declared no
architecture, so CDK defaulted them to **x86_64**. On an Apple Silicon dev host
(where this Docker integ runs) cdk-local pulls the x86 base image and runs the
RIE container under **QEMU emulation** — slow and unstable.

This declares `architecture: lambda.Architecture.ARM_64` on the two
RIE-invoked Lambdas so they run **natively** on the dev host — no QEMU, no
flake. The ECS task (multi-arch `python:3.12-alpine`) and the AgentCore
container (already `Platform.LINUX_ARM64`) were already native, so the Lambdas
were the only emulated compute. The integ exercises studio orchestration, not
architecture fidelity, so native arm64 is the right default for this fixture.

## Test plan

- `local-studio` integ (real Docker): green on the first try — 102 OK / 0 FAIL,
  with **zero** `emulation on a linux/arm64 host` warnings (vs the previous runs
  that flaked on the emulated x86 Lambda invokes).
