### PR TITLE
docs(readme): document selective local backends via AWS_ENDPOINT_URL_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,23 @@ Each top-level JSON key picks which target to overlay:
 
 When pointing a container at a tunneled VPC resource (e.g. an Aurora cluster reached via a local port forward), use `host.docker.internal` instead of `127.0.0.1` — `127.0.0.1` inside the container is the container itself, not the host where the tunnel listens.
 
+### Selective local backends
+
+The same overlay can redirect the AWS SDK itself. Set the SDK's standard per-service endpoint variables to point individual services at a local AWS-compatible endpoint you run yourself, while every other service stays on real AWS:
+
+```json
+{
+  "Parameters": {
+    "AWS_ENDPOINT_URL_DYNAMODB": "http://host.docker.internal:8000",
+    "AWS_ENDPOINT_URL_S3": "http://host.docker.internal:9000"
+  }
+}
+```
+
+DynamoDB and S3 calls resolve to the local endpoint; Secrets Manager, SSM Parameter Store, and everything else have no override, so they hit real AWS through your `--assume-role` / `--from-cfn-stack` credentials. The suffix is the service name uppercased (`DYNAMODB`, `S3`, `SECRETS_MANAGER`, ...); the bare `AWS_ENDPOINT_URL` (no suffix) redirects every service at once, so the per-service form is what makes the split selective. cdk-local only injects these variables — it does not run the endpoint for you; start the local server separately and point the URL at it.
+
+On Docker Desktop (macOS / Windows), `host.docker.internal` reaches a server on the host out of the box. On Linux native dockerd, the `cdkl invoke` / `run-task` / ECS serve paths do not add the `host-gateway` alias, so use the Docker bridge address (e.g. `http://172.17.0.1:8000`) or put the local server on the same Docker network.
+
 ## Hot reload — `--watch`
 
 ```bash


### PR DESCRIPTION
## Summary

Documents the "emulate some managed services locally, keep others on real
AWS" workflow under the existing `--env-vars` section — a question that
already has an answer (the overlay passes arbitrary keys to the container
env verbatim), it just wasn't written down.

The new **Selective local backends** subsection shows pointing individual
services at a local endpoint via the AWS SDK's standard per-service
`AWS_ENDPOINT_URL_<SERVICE>` variables (e.g. DynamoDB + S3 to a local
server) while every unset service still resolves to real AWS through the
`--assume-role` / `--from-cfn-stack` credentials. Stays within scope: no
third-party product is named — the local endpoint is one the user runs
themselves; cdk-local only injects the env.

It also records the host-reachability caveat: `host.docker.internal` works
out of the box on Docker Desktop, but the `invoke` / `run-task` / ECS serve
paths don't inject the `host-gateway` alias on Linux native dockerd, so use
the Docker bridge address there.

## Verification

- The overlay reaching the container env verbatim (incl. an unknown
  `AWS_ENDPOINT_URL_*` key — no allowlist in `appendEnvFlags`) and
  `host.docker.internal` reachability were live-tested against the
  `local-invoke` fixture + a plain `docker run` before writing the docs.
- Docs-only change (README.md). `vp run check` (0 errors), `vp run build`,
  and the unit suite (203 files / 3093 tests) all green.

## Follow-up (separate PR)

The Linux `host.docker.internal` gap is fixable in-mechanism — emit
`--add-host host.docker.internal:host-gateway` (already wired for the
start-api WebSocket path) on the `invoke` / `run-task` / `start-service`
container runs too, guarded on Docker 20.10+. That is a src behavior
change (integ + parity), so it is intentionally left out of this docs PR;
once it lands the Linux caveat above can be removed.
