### PR TITLE
feat(docker): reach the host via host.docker.internal on invoke/run-task/ECS runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The same overlay can redirect the AWS SDK itself. Set the SDK's standard per-ser
 
 DynamoDB and S3 calls resolve to the local endpoint; Secrets Manager, SSM Parameter Store, and everything else have no override, so they hit real AWS through your `--assume-role` / `--from-cfn-stack` credentials. The suffix is the service name uppercased (`DYNAMODB`, `S3`, `SECRETS_MANAGER`, ...); the bare `AWS_ENDPOINT_URL` (no suffix) redirects every service at once, so the per-service form is what makes the split selective. cdk-local only injects these variables — it does not run the endpoint for you; start the local server separately and point the URL at it.
 
-On Docker Desktop (macOS / Windows), `host.docker.internal` reaches a server on the host out of the box. On Linux native dockerd, the `cdkl invoke` / `run-task` / ECS serve paths do not add the `host-gateway` alias, so use the Docker bridge address (e.g. `http://172.17.0.1:8000`) or put the local server on the same Docker network.
+`host.docker.internal` resolves to the host from inside the container — Docker Desktop (macOS / Windows) provides it natively, and on Linux native dockerd `cdkl` adds the `host-gateway` alias for you on the `invoke` / `run-task` / `start-service` / `start-alb` container runs (Docker 20.10+). On an older daemon the alias is skipped; use the Docker bridge address (e.g. `http://172.17.0.1:8000`) or put the local server on the same Docker network.
 
 ## Hot reload — `--watch`
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -16,6 +16,7 @@ import { singleFlight } from '../../utils/single-flight.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp, resolveWatchConfig } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
+import { resolveHostGatewayExtraHosts } from '../../local/docker-version.js';
 import { createFileWatcher, type FileWatcher } from '../../local/file-watcher.js';
 import { resolveProfileCredentials, createWatchPredicates } from './local-start-api.js';
 import { buildStsClientConfig } from '../../utils/profile-resolver.js';
@@ -1824,6 +1825,12 @@ async function resolveServiceAndRunnerOpts(
       profileName: profileCredsFile.profileName,
     };
   }
+  // Let each replica's containers reach a server on the host (an
+  // `AWS_ENDPOINT_URL_*` local endpoint / tunneled VPC resource) via
+  // `host.docker.internal`. Memoized — one `docker version` probe per
+  // process regardless of service / replica count.
+  const hostGatewayExtraHosts = await resolveHostGatewayExtraHosts();
+  if (hostGatewayExtraHosts.length > 0) taskOpts.hostGatewayExtraHosts = hostGatewayExtraHosts;
 
   // Issue #238 — when an --image-override resolved a local Dockerfile
   // build for this service target, inject the pre-built local tag

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -62,6 +62,7 @@ import {
   runDetached,
   streamLogs,
 } from '../../local/docker-runner.js';
+import { resolveHostGatewayExtraHosts } from '../../local/docker-version.js';
 import { architectureToPlatform, buildContainerImage } from '../../local/docker-image-builder.js';
 import { pullEcrImage, parseEcrUri } from '../../local/ecr-puller.js';
 import { invokeRie, waitForRieReady } from '../../local/rie-client.js';
@@ -402,6 +403,10 @@ async function localInvokeCommand(
           },
         ]
       : imagePlan.extraMounts;
+    // Let the Lambda container reach a server on the host (an
+    // `AWS_ENDPOINT_URL_*` local endpoint / tunneled VPC resource) via
+    // `host.docker.internal`.
+    const hostGatewayExtraHosts = await resolveHostGatewayExtraHosts();
     containerId = await runDetached({
       image: imagePlan.image,
       mounts: imagePlan.mounts,
@@ -410,6 +415,7 @@ async function localInvokeCommand(
       ...(containerEnv.sensitiveEnvKeys.length > 0 && {
         sensitiveEnvKeys: new Set(containerEnv.sensitiveEnvKeys),
       }),
+      ...(hostGatewayExtraHosts.length > 0 && { extraHosts: hostGatewayExtraHosts }),
       cmd: imagePlan.cmd,
       hostPort,
       host: containerHost,

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -15,6 +15,7 @@ import { resolveSingleTarget } from '../../local/target-picker.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
+import { resolveHostGatewayExtraHosts } from '../../local/docker-version.js';
 import { resolveProfileCredentials } from './local-start-api.js';
 import { buildStsClientConfig } from '../../utils/profile-resolver.js';
 import {
@@ -461,6 +462,11 @@ async function localRunTaskCommand(
         );
       };
     }
+
+    // Let task containers reach a server on the host (an `AWS_ENDPOINT_URL_*`
+    // local endpoint / tunneled VPC resource) via `host.docker.internal`.
+    const hostGatewayExtraHosts = await resolveHostGatewayExtraHosts();
+    if (hostGatewayExtraHosts.length > 0) runOpts.hostGatewayExtraHosts = hostGatewayExtraHosts;
 
     const result = await runEcsTask(task, runOpts, state);
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -173,8 +173,18 @@ export { bufferToBody } from './local/websocket-body.js';
  * `--add-host=...:host-gateway` mapping WebSocket Lambda containers need to
  * reach the host server on Linux native dockerd. Exposed only as the
  * consuming host's `import` statements require them.
+ *
+ * `resolveHostGatewayExtraHosts` is the memoized, never-throwing resolver a
+ * host CLI wrapping the `invoke` / `run-task` / ECS-serve container runs
+ * reuses to inject `host.docker.internal` reachability (best-effort: `[]`
+ * on a pre-20.10 / unavailable daemon).
  */
-export { HOST_GATEWAY_MIN_VERSION, probeHostGatewaySupport } from './local/docker-version.js';
+export {
+  HOST_GATEWAY_MIN_VERSION,
+  probeHostGatewaySupport,
+  resolveHostGatewayExtraHosts,
+  HOST_DOCKER_INTERNAL_GATEWAY,
+} from './local/docker-version.js';
 
 /**
  * `start-api` API-server grouping — splits a flat discovered-route list into

--- a/src/local/docker-version.ts
+++ b/src/local/docker-version.ts
@@ -110,3 +110,53 @@ export async function probeHostGatewaySupport(): Promise<HostGatewayProbeResult>
   const supported = parsed === null || compareDockerVersions(parsed, HOST_GATEWAY_MIN_VERSION) >= 0;
   return { rawVersion, parsed, supported };
 }
+
+/**
+ * The `host.docker.internal:host-gateway` extra-host mapping that lets a
+ * container reach a server bound on the host loopback. Docker Desktop
+ * (macOS / Windows) resolves `host.docker.internal` natively, but Linux
+ * native dockerd needs this explicit `--add-host` (since Docker 20.10).
+ */
+export const HOST_DOCKER_INTERNAL_GATEWAY: { host: string; ip: string } = {
+  host: 'host.docker.internal',
+  ip: 'host-gateway',
+};
+
+let hostGatewayExtraHostsCache: Promise<{ host: string; ip: string }[]> | undefined;
+
+/**
+ * Resolve the `extraHosts` entries to inject so a launched container can
+ * reach a server on the host via `host.docker.internal` — the
+ * load-bearing primitive behind pointing a Lambda / ECS container at a
+ * local endpoint (e.g. `AWS_ENDPOINT_URL_*` to a local server, or a
+ * tunneled VPC resource).
+ *
+ * Returns `[{@link HOST_DOCKER_INTERNAL_GATEWAY}]` when the Docker daemon
+ * supports the `host-gateway` alias (>= 20.10, or an unparseable
+ * podman / finch version per {@link probeHostGatewaySupport}), else `[]`
+ * — passing `--add-host ...:host-gateway` to a pre-20.10 daemon would
+ * fail the `docker run`, so an old / unknown-failed daemon silently
+ * degrades to "no mapping" (Docker Desktop still resolves the name
+ * natively; Linux native dockerd loses host reachability, matching the
+ * pre-fix behavior). A probe error (daemon down, binary missing)
+ * resolves to `[]` rather than throwing — reachability is best-effort
+ * convenience here, NOT a hard requirement like the start-api WebSocket
+ * path. Memoized per process: the probe (`docker version`) fires at most
+ * once regardless of how many containers / replicas are launched.
+ */
+export async function resolveHostGatewayExtraHosts(): Promise<{ host: string; ip: string }[]> {
+  if (hostGatewayExtraHostsCache === undefined) {
+    hostGatewayExtraHostsCache = probeHostGatewaySupport()
+      .then((probe) => (probe.supported ? [{ ...HOST_DOCKER_INTERNAL_GATEWAY }] : []))
+      .catch(() => []);
+  }
+  return hostGatewayExtraHostsCache;
+}
+
+/**
+ * Test-only: reset the {@link resolveHostGatewayExtraHosts} memo so each
+ * test controls the underlying probe mock.
+ */
+export function resetHostGatewayExtraHostsCache(): void {
+  hostGatewayExtraHostsCache = undefined;
+}

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -206,6 +206,18 @@ export interface RunEcsTaskOptions {
    */
   addHostFlags?: ReadonlyArray<string>;
   /**
+   * `host.docker.internal` extra-host mapping(s) to add so this container
+   * can reach a server bound on the host (e.g. an `AWS_ENDPOINT_URL_*`
+   * local endpoint, or a tunneled VPC resource). Resolved ONCE at command
+   * boot via `resolveHostGatewayExtraHosts()` and threaded down here —
+   * merged into the verbatim `--add-host` flag list alongside
+   * {@link addHostFlags}. Empty / undefined → no mapping (Docker Desktop
+   * resolves `host.docker.internal` natively; Linux native dockerd needs
+   * this). Distinct from {@link addHostFlags}, which carries the Cloud Map
+   * peer-discovery entries.
+   */
+  hostGatewayExtraHosts?: ReadonlyArray<{ host: string; ip: string }>;
+  /**
    * Pre-existing docker network + sidecar to reuse instead of letting
    * the runner create a fresh per-task one. Set by the
    * `cdkl start-service` CLI which creates ONE shared network at
@@ -391,6 +403,26 @@ export async function cleanupEcsRun(
 }
 
 /**
+ * Merge the Cloud Map peer-discovery `--add-host` flag pairs
+ * ({@link RunEcsTaskOptions.addHostFlags}) with the boot-resolved
+ * `host.docker.internal` host-gateway mapping(s)
+ * ({@link RunEcsTaskOptions.hostGatewayExtraHosts}) into one verbatim
+ * `['--add-host', 'name:ip', ...]` list for `docker run`. The host-gateway
+ * entry uses a distinct name, so its position relative to the peer entries
+ * is irrelevant (docker's resolver matches by name). Pure — exported for
+ * the site-level merge test.
+ */
+export function mergeHostGatewayAddHostFlags(
+  addHostFlags: ReadonlyArray<string> | undefined,
+  hostGatewayExtraHosts: ReadonlyArray<{ host: string; ip: string }> | undefined
+): string[] {
+  return [
+    ...(addHostFlags ?? []),
+    ...(hostGatewayExtraHosts ?? []).flatMap((h) => ['--add-host', `${h.host}:${h.ip}`]),
+  ];
+}
+
+/**
  * Top-level entry point. Mutates `state` as it makes progress so the
  * caller's `cleanup(state)` can roll back partial side effects on any
  * thrown error.
@@ -485,6 +517,17 @@ export async function runEcsTask(
     }
   }
 
+  // Merge the Cloud Map peer-discovery `--add-host` flags with the
+  // boot-resolved `host.docker.internal:host-gateway` mapping so every
+  // container can also reach a server on the host (an `AWS_ENDPOINT_URL_*`
+  // local endpoint / tunneled VPC resource). Both are verbatim
+  // `['--add-host', 'name:ip', ...]` pairs; the host-gateway entry uses a
+  // distinct name so order vs the peer entries is irrelevant.
+  const mergedAddHostFlags = mergeHostGatewayAddHostFlags(
+    options.addHostFlags,
+    options.hostGatewayExtraHosts
+  );
+
   // Pre-compute every container's CMD args so the start loop only does
   // docker calls.
   const dockerCmds = new Map<string, { args: string[]; sensitiveEnv: Record<string, string> }>();
@@ -515,9 +558,7 @@ export async function runEcsTask(
       options.ephemeralPublishContainerPorts.length > 0
         ? { ephemeralPublishContainerPorts: options.ephemeralPublishContainerPorts }
         : {}),
-      ...(options.addHostFlags && options.addHostFlags.length > 0
-        ? { addHostFlags: options.addHostFlags }
-        : {}),
+      ...(mergedAddHostFlags.length > 0 ? { addHostFlags: mergedAddHostFlags } : {}),
       ...((options.networkAliasesByContainer?.get(container.name)?.length ?? 0) > 0
         ? { networkAliases: options.networkAliasesByContainer!.get(container.name)! }
         : {}),

--- a/tests/unit/cli/host-gateway-extra-hosts-binding.test.ts
+++ b/tests/unit/cli/host-gateway-extra-hosts-binding.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vite-plus/test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const COMMANDS_DIR = path.join(__dirname, '../../../src/cli/commands');
+const read = (file: string): string => readFileSync(path.join(COMMANDS_DIR, file), 'utf-8');
+
+/**
+ * Site-level binding test (per `feedback_site_level_binding_test.md`).
+ *
+ * `resolveHostGatewayExtraHosts()` (memoized in `docker-version.ts`) gives a
+ * container `host.docker.internal` reachability so it can hit a server on the
+ * host (an `AWS_ENDPOINT_URL_*` local endpoint / tunneled VPC resource) on
+ * Linux native dockerd — where the alias is not auto-resolved. Three command
+ * run sites must each resolve it AND thread the result into the docker run:
+ * `cdkl invoke` (Lambda RIE container -> `runDetached`'s `extraHosts`),
+ * `cdkl run-task` (-> `runOpts.hostGatewayExtraHosts`), and the ECS service
+ * emulator behind `start-service` / `start-alb` (-> `taskOpts.hostGatewayExtraHosts`).
+ *
+ * The reachability only differs on Linux, so the integ suite (run on Docker
+ * Desktop, which resolves the name natively regardless) cannot distinguish a
+ * dropped wiring. This source-level binding pins each call site so a refactor
+ * that silently drops the resolve / thread is caught.
+ */
+describe('host.docker.internal reachability wired at every container run site', () => {
+  it('cdkl invoke resolves the mapping and passes it to runDetached as extraHosts', () => {
+    const src = read('local-invoke.ts');
+    expect(src).toMatch(/resolveHostGatewayExtraHosts\(\)/);
+    expect(src).toMatch(/extraHosts:\s*hostGatewayExtraHosts/);
+  });
+
+  it('cdkl run-task resolves the mapping and sets it on the runEcsTask options', () => {
+    const src = read('local-run-task.ts');
+    expect(src).toMatch(/resolveHostGatewayExtraHosts\(\)/);
+    expect(src).toMatch(/runOpts\.hostGatewayExtraHosts\s*=/);
+    // ...and the option is threaded into the run, not resolved-then-dropped.
+    expect(src).toMatch(/runEcsTask\(/);
+  });
+
+  it('the ECS service emulator (start-service / start-alb) resolves and sets it on taskOpts', () => {
+    const src = read('ecs-service-emulator.ts');
+    expect(src).toMatch(/resolveHostGatewayExtraHosts\(\)/);
+    expect(src).toMatch(/taskOpts\.hostGatewayExtraHosts\s*=/);
+  });
+});

--- a/tests/unit/local/docker-version.test.ts
+++ b/tests/unit/local/docker-version.test.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, expect, it, vi } from 'vite-plus/test';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   compareDockerVersions,
+  HOST_DOCKER_INTERNAL_GATEWAY,
   HOST_GATEWAY_MIN_VERSION,
   parseDockerVersion,
   probeHostGatewaySupport,
+  resetHostGatewayExtraHostsCache,
+  resolveHostGatewayExtraHosts,
 } from '../../../src/local/docker-version.js';
 
 describe('parseDockerVersion', () => {
@@ -117,5 +120,48 @@ describe('probeHostGatewaySupport', () => {
     const fakeErr = new Error('Failed to find and execute \'docker\'');
     dockerCmd.runDockerStreaming.mockRejectedValueOnce(fakeErr);
     await expect(probeHostGatewaySupport()).rejects.toThrow(/Failed to find and execute/);
+  });
+});
+
+describe('resolveHostGatewayExtraHosts', () => {
+  beforeEach(() => {
+    resetHostGatewayExtraHostsCache();
+    dockerCmd.runDockerStreaming.mockReset();
+  });
+
+  it('returns the host.docker.internal:host-gateway mapping on a supported daemon (>= 20.10)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValue({ stdout: '24.0.7\n', stderr: '' });
+    await expect(resolveHostGatewayExtraHosts()).resolves.toEqual([HOST_DOCKER_INTERNAL_GATEWAY]);
+    expect(HOST_DOCKER_INTERNAL_GATEWAY).toEqual({ host: 'host.docker.internal', ip: 'host-gateway' });
+  });
+
+  it('returns [] on a pre-20.10 daemon (passing --add-host host-gateway would fail the run)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValue({ stdout: '19.03.15\n', stderr: '' });
+    await expect(resolveHostGatewayExtraHosts()).resolves.toEqual([]);
+  });
+
+  it('returns [] when the probe throws (daemon down / binary missing) rather than rejecting', async () => {
+    dockerCmd.runDockerStreaming.mockRejectedValue(new Error('docker daemon not running'));
+    await expect(resolveHostGatewayExtraHosts()).resolves.toEqual([]);
+  });
+
+  it('returns [] on empty probe output (daemon unreachable / stripped)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValue({ stdout: '', stderr: '' });
+    await expect(resolveHostGatewayExtraHosts()).resolves.toEqual([]);
+  });
+
+  it('memoizes — the docker version probe fires at most once per process', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValue({ stdout: '24.0.7\n', stderr: '' });
+    const first = await resolveHostGatewayExtraHosts();
+    const second = await resolveHostGatewayExtraHosts();
+    expect(second).toEqual(first);
+    expect(dockerCmd.runDockerStreaming).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a fresh array copy so a caller cannot mutate the shared constant', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValue({ stdout: '24.0.7\n', stderr: '' });
+    const hosts = await resolveHostGatewayExtraHosts();
+    expect(hosts[0]).not.toBe(HOST_DOCKER_INTERNAL_GATEWAY);
+    expect(hosts[0]).toEqual(HOST_DOCKER_INTERNAL_GATEWAY);
   });
 });

--- a/tests/unit/local/ecs-task-runner-host-gateway.test.ts
+++ b/tests/unit/local/ecs-task-runner-host-gateway.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { mergeHostGatewayAddHostFlags } from '../../../src/local/ecs-task-runner.js';
+
+const GATEWAY = { host: 'host.docker.internal', ip: 'host-gateway' };
+
+describe('mergeHostGatewayAddHostFlags (ECS run-task / start-service / start-alb)', () => {
+  it('returns [] when neither Cloud Map peer flags nor a host-gateway entry are present', () => {
+    expect(mergeHostGatewayAddHostFlags(undefined, undefined)).toEqual([]);
+    expect(mergeHostGatewayAddHostFlags([], [])).toEqual([]);
+  });
+
+  it('passes Cloud Map peer flags through unchanged when there is no host-gateway entry', () => {
+    expect(mergeHostGatewayAddHostFlags(['--add-host', 'svc.cdkl.local:10.0.0.5'], undefined)).toEqual([
+      '--add-host',
+      'svc.cdkl.local:10.0.0.5',
+    ]);
+    expect(mergeHostGatewayAddHostFlags(['--add-host', 'svc.cdkl.local:10.0.0.5'], [])).toEqual([
+      '--add-host',
+      'svc.cdkl.local:10.0.0.5',
+    ]);
+  });
+
+  it('emits the host.docker.internal:host-gateway pair when only the gateway entry is present', () => {
+    expect(mergeHostGatewayAddHostFlags(undefined, [GATEWAY])).toEqual([
+      '--add-host',
+      'host.docker.internal:host-gateway',
+    ]);
+  });
+
+  it('merges peer flags AND the host-gateway pair (peers first; distinct names so order is irrelevant)', () => {
+    expect(
+      mergeHostGatewayAddHostFlags(['--add-host', 'svc.cdkl.local:10.0.0.5'], [GATEWAY])
+    ).toEqual([
+      '--add-host',
+      'svc.cdkl.local:10.0.0.5',
+      '--add-host',
+      'host.docker.internal:host-gateway',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the "Selective local backends" docs (PR #482). Containers
launched by `cdkl invoke`, `cdkl run-task`, `cdkl start-service`, and
`cdkl start-alb` now get `--add-host host.docker.internal:host-gateway`, so a
handler / task can reach a server bound on the host (e.g. an
`AWS_ENDPOINT_URL_*` local endpoint, or a tunneled VPC resource) on Linux
native dockerd — where the alias is not auto-resolved. Docker Desktop
(macOS / Windows) already resolved the name; previously only the `start-api`
WebSocket path injected the alias, so the documented "point a service at a
local endpoint" workflow silently failed on Linux for those commands.

`--add-host` is a Docker `docker run` flag, not a `cdkl` option — the user
can't request it; cdk-local must emit it. This PR makes it emit it at the
three container run sites the docs name.

## Behavior change

Containers from `cdkl invoke` / `run-task` / `start-service` / `start-alb`
now carry one extra `--add-host host.docker.internal:host-gateway` entry
(when the Docker daemon is >= 20.10). Additive and benign — but a caller that
asserts on the exact `docker run` argv / container `/etc/hosts` should expect
it. On a pre-20.10 / unavailable daemon the alias is silently skipped (the
resolver never throws), preserving the previous behavior. cdkd tracking issue:
https://github.com/go-to-k/cdkd/issues/784

## Design

- `resolveHostGatewayExtraHosts()` (new, in `docker-version.ts`) is memoized —
  one `docker version` probe per process regardless of container / replica
  count — and never throws (reachability is best-effort convenience here, not
  a hard requirement like the start-api WS path). Returns the mapping on a
  supporting daemon, `[]` otherwise.
- Three run sites resolve it once at boot and thread it down: `invoke` ->
  `runDetached`'s `extraHosts`; `run-task` -> `runOpts`; the ECS service
  emulator -> `taskOpts` -> `runEcsTask`, where `mergeHostGatewayAddHostFlags`
  merges it with the Cloud Map peer-discovery `--add-host` entries.
- Front-door Lambda / AgentCore / `start-api` non-WS container runs are out of
  scope (the docs caveat named exactly these four commands).

## Test plan

- Unit: `resolveHostGatewayExtraHosts` (supported / pre-20.10 / probe-error /
  empty / memoization / fresh-copy), `mergeHostGatewayAddHostFlags` (peer +
  gateway merge), and a source-level binding test pinning the resolve+thread
  at all three call sites.
- Live-tested end-to-end: `docker inspect` of a running `cdkl invoke` Lambda
  container AND a `cdkl run-task` ECS app container both show
  `ExtraHosts=["host.docker.internal:host-gateway"]`; the ECS sidecar (infra,
  not a user container) correctly does not.
- Integ green: `local-invoke` (6/6) + `local-run-task` (run + image-override),
  0 docker / network orphans.

The Linux-only benefit cannot be distinguished by the integ suite (run on
Docker Desktop, which resolves the name natively), so the structural catch is
the unit + source-binding coverage; the integs confirm no regression with the
flag present.

Updates the README "Selective local backends" Linux caveat accordingly.
