### PR TITLE
fix(studio): point users to --from-cfn-stack when an ECS image can't be pin-classified

### DIFF
--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -703,8 +703,19 @@ export function makePinClassifier(args: {
   stacks: StackInfo[];
   contextByStack: Map<string, EcsImageResolutionContext | undefined>;
   logger: ReturnType<typeof getLogger>;
+  /**
+   * Whether `--from-cfn-stack` is currently bound for the session. An
+   * INTRINSIC-ECR image (`ContainerImage.fromEcrRepository(repo)`) is only
+   * resolvable WITH deployed state, so without the binding it cannot be
+   * classified and the picker is not offered. When `false`, the WARN appends
+   * the Session-bar remedy so a studio-from user discovers why the picker is
+   * absent; when `true` (already bound) the resolver's own error already
+   * explains the real failure, so the remedy is omitted to avoid suggesting a
+   * flag they already passed.
+   */
+  stateBound?: boolean;
 }): (id: string) => boolean {
-  const { stacks, contextByStack, logger } = args;
+  const { stacks, contextByStack, logger, stateBound } = args;
   return (id: string): boolean => {
     try {
       const stack = resolveEcsServiceStack(id, stacks);
@@ -716,13 +727,30 @@ export function makePinClassifier(args: {
       // a misconfigured / unresolvable image is visible at boot.
       logger.warn(
         `studio: could not classify image-pin status for ECS service '${id}'; leaving it unmarked ` +
-          `(the image-override picker will not be offered). ${
+          `(the image-override picker will not be offered).${pinClassifyStateHint(stateBound)} ${
             err instanceof Error ? err.message : String(err)
           }`
       );
       return false;
     }
   };
+}
+
+/**
+ * The Session-bar `--from-cfn-stack` remedy appended to a pin-classify WARN
+ * when the binding is NOT set (the common reason an INTRINSIC-ECR service
+ * cannot be classified, so the override picker is silently absent). Returns an
+ * empty string when the binding IS set — the resolver's own appended error
+ * already names the real failure, and re-suggesting a flag the user already
+ * passed is misleading. Shared by the service + task-def classifiers.
+ */
+function pinClassifyStateHint(stateBound: boolean | undefined): string {
+  if (stateBound !== false) return '';
+  return (
+    ' If this image is pinned to a deployed registry (e.g.' +
+    ' ContainerImage.fromEcrRepository), set --from-cfn-stack in the Session bar so studio can' +
+    ' resolve it and offer the image-override picker.'
+  );
 }
 
 /**
@@ -742,8 +770,10 @@ export function makeTaskPinClassifier(args: {
   stacks: StackInfo[];
   contextByStack: Map<string, EcsImageResolutionContext | undefined>;
   logger: ReturnType<typeof getLogger>;
+  /** See {@link makePinClassifier} — gates the Session-bar remedy hint. */
+  stateBound?: boolean;
 }): (id: string) => boolean {
-  const { stacks, contextByStack, logger } = args;
+  const { stacks, contextByStack, logger, stateBound } = args;
   return (id: string): boolean => {
     try {
       const stack = resolveEcsServiceStack(id, stacks);
@@ -754,9 +784,9 @@ export function makeTaskPinClassifier(args: {
     } catch (err) {
       logger.warn(
         `studio: could not classify image-pin status for ECS task definition '${id}'; leaving it ` +
-          `unmarked (the image-override picker will not be offered). ${
-            err instanceof Error ? err.message : String(err)
-          }`
+          `unmarked (the image-override picker will not be offered).${pinClassifyStateHint(
+            stateBound
+          )} ${err instanceof Error ? err.message : String(err)}`
       );
       return false;
     }
@@ -872,16 +902,21 @@ export async function classifyStudioTargets(args: {
     options: classifyOptions,
     logger,
   });
+  // When --from-cfn-stack is NOT bound, an INTRINSIC-ECR service cannot be
+  // resolved/classified, so the classifier WARN appends the Session-bar remedy
+  // (set --from-cfn-stack to surface the picker). Computed off the same flag
+  // bag prepareEcsImageContexts consumes.
+  const stateBound = isCfnFlagPresent(classifyOptions);
   const anyPinned = annotatePinnedEcsTargets(
     groups,
-    makePinClassifier({ stacks, contextByStack, logger })
+    makePinClassifier({ stacks, contextByStack, logger, stateBound })
   );
   // Issue #388 — classify ECS task definitions (the `ecs-task` kind) too, so a
   // pinned task-def image gets the same image-override picker. The `ecs-task`
   // composer spawns `cdkl run-task`, which accepts `--image-override`.
   const anyTaskPinned = annotateEcsTaskPinnedTargets(
     groups,
-    makeTaskPinClassifier({ stacks, contextByStack, logger })
+    makeTaskPinClassifier({ stacks, contextByStack, logger, stateBound })
   );
   const pinnedEcsByQualifiedId = new Map<string, string>();
   for (const g of groups) {

--- a/tests/unit/cli/local-studio-pin-classifier.test.ts
+++ b/tests/unit/cli/local-studio-pin-classifier.test.ts
@@ -332,6 +332,45 @@ describe('makePinClassifier', () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('cannot resolve image'));
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("'dev/Svc'"));
   });
+
+  it('appends the Session-bar --from-cfn-stack remedy when state is NOT bound', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockImplementation(() => {
+      throw new Error('cannot resolve image');
+    });
+
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: false,
+    });
+
+    classify('dev/Svc');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('set --from-cfn-stack in the Session bar')
+    );
+  });
+
+  it('omits the remedy when state IS bound (the resolver error already explains it)', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockImplementation(() => {
+      throw new Error('cannot resolve image');
+    });
+
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: true,
+    });
+
+    classify('dev/Svc');
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('cannot resolve image'));
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('set --from-cfn-stack in the Session bar')
+    );
+  });
 });
 
 describe('makeTaskPinClassifier (issue #388)', () => {
@@ -389,6 +428,23 @@ describe('makeTaskPinClassifier (issue #388)', () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('cannot resolve task image'));
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('task definition'));
   });
+
+  it('appends the Session-bar --from-cfn-stack remedy when state is NOT bound', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsTaskTarget.mockImplementation(() => {
+      throw new Error('cannot resolve task image');
+    });
+    const classify = makeTaskPinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: false,
+    });
+    classify('dev/Task');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('set --from-cfn-stack in the Session bar')
+    );
+  });
 });
 
 describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack toggle)', () => {
@@ -431,6 +487,13 @@ describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack 
     expect(off.groups[0]?.entries[0]?.pinned).toBeUndefined();
     expect(off.dockerfiles).toEqual([]);
     expect(hoisted.discoverDockerfiles).not.toHaveBeenCalled();
+    // Without --from-cfn-stack, the classify WARN tells the user how to surface
+    // the picker (set --from-cfn-stack in the Session bar) — the studio-from
+    // discoverability fix. End-to-end: classifyStudioTargets derives stateBound
+    // from the (absent) binding and threads it into the classifier.
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('set --from-cfn-stack in the Session bar')
+    );
 
     // ON: context built -> resolve returns -> service is pinned + Dockerfiles scanned.
     const on = await classifyStudioTargets({


### PR DESCRIPTION
## Summary

A discoverability fix for the `cdkl studio` image-override picker.

When studio boots WITHOUT `--from-cfn-stack`, an ECS service / task definition
whose container image is an intrinsic ECR reference
(`ContainerImage.fromEcrRepository(repo)`) cannot be resolved, so it is left
unmarked and the image-override Dockerfile picker never appears. The
classify-failure WARN previously said only "leaving it unmarked (the
image-override picker will not be offered)" — it never told a **studio-from**
user that the fix is to set `--from-cfn-stack` in the Session bar.

This appends the remedy to that WARN when the binding is absent:

```
studio: could not classify image-pin status for ECS service 'dev/Svc';
leaving it unmarked (the image-override picker will not be offered). If this
image is pinned to a deployed registry (e.g. ContainerImage.fromEcrRepository),
set --from-cfn-stack in the Session bar so studio can resolve it and offer the
image-override picker. <resolver error>
```

### How it works

- `makePinClassifier` / `makeTaskPinClassifier` take an optional `stateBound`
  flag, derived from `isCfnFlagPresent` in `classifyStudioTargets`.
- The remedy is appended only when `stateBound === false` (no
  `--from-cfn-stack`). When it IS bound but classification still fails, the
  resolver's own appended error already names the real failure, so the hint is
  omitted to avoid re-suggesting a flag the user already passed.
- A public-registry pin (`ContainerImage.fromRegistry(...)`) resolves fine
  without state, so it does not throw, does not WARN, and gets no hint — the
  message appears only in the genuine intrinsic-ECR-without-state case.

This complements the CLI side, which already surfaces the same remedy: the
`start-service` / `start-alb` boot WARN (`--image-override` / `fromAsset`) and
the image-resolution error (`pass --from-cfn-stack ... fromAsset ... public
image`). The gap was studio's boot classify WARN.

The classifiers are studio-internal (not exported via `internal.ts`), the
original WARN substring is preserved (additive), and there are no CLI surface
changes — no host (cdkd) contract impact.

## Test plan

- Unit: the classifier WARN appends the Session-bar remedy when `stateBound`
  is false and omits it when true (service + task-def); an end-to-end
  `classifyStudioTargets` test (no `--from-cfn-stack` -> intrinsic-ECR resolve
  throws) asserts the WARN carries the remedy. 203 files / 3096 tests pass.
- Integ: `local-studio` (real Docker) green end-to-end; 0 orphans.
- Live: booted `cdkl studio` against the local-studio fixture without
  `--from-cfn-stack` and confirmed the public-registry-pinned services
  classify cleanly with NO spurious hint WARN (the message is correctly gated
  to the throw case).
