### PR TITLE
fix(start-service): emit the same-stack-ECR boot WARN once, not twice

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -2423,7 +2423,8 @@ export async function buildEcsImageResolutionContext(
   target: string,
   stacks: StackInfo[],
   options: EcsServiceEmulatorOptions,
-  stateProvider: LocalStateProvider | undefined
+  stateProvider: LocalStateProvider | undefined,
+  opts: { suppressStateWarning?: boolean } = {}
 ): Promise<EcsImageResolutionContext | undefined> {
   const logger = getLogger();
   const parsed = parseEcsTarget(target);
@@ -2495,15 +2496,24 @@ export async function buildEcsImageResolutionContext(
       }
     }
   } else if (!stateProvider && needs.needsStateResources) {
-    logger.warn(
-      'Container Image references a same-stack AWS::ECR::Repository. Pass a state-source flag ' +
-        '(e.g. --from-cfn-stack or a host-provided extension) to substitute the deployed repository URI.'
-    );
+    // `suppressStateWarning` is set by the pre-boot pin-classification peek
+    // (`resolveAndBuildImageOverrides`), which calls this builder purely to
+    // classify each target's image kind and handles its OWN resolution errors
+    // as DEBUG. Without the guard the peek + the real boot both emit this WARN
+    // for the same target, so the user sees it twice (once per call site).
+    if (!opts.suppressStateWarning) {
+      logger.warn(
+        'Container Image references a same-stack AWS::ECR::Repository. Pass a state-source flag ' +
+          '(e.g. --from-cfn-stack or a host-provided extension) to substitute the deployed repository URI.'
+      );
+    }
   } else if (!stateProvider && needs.needsEnvOrSecretSubstitution) {
-    logger.warn(
-      'Container Environment / Secrets entries contain CloudFormation intrinsics. ' +
-        'Pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to substitute them against the deployed state.'
-    );
+    if (!opts.suppressStateWarning) {
+      logger.warn(
+        'Container Environment / Secrets entries contain CloudFormation intrinsics. ' +
+          'Pass a state-source flag (e.g. --from-cfn-stack or a host-provided extension) to substitute them against the deployed state.'
+      );
+    }
   }
 
   return ctx;
@@ -2769,7 +2779,12 @@ async function resolveAndBuildImageOverrides(args: {
     let imageContext: EcsImageResolutionContext | undefined;
     let service: ResolvedEcsService | undefined;
     try {
-      imageContext = await buildEcsImageResolutionContext(target, stacks, options, stateProvider);
+      // Suppress the "needs deployed state" WARN here: this is the pre-boot
+      // classification peek (its own errors are DEBUG, line below), and the
+      // real boot path emits the WARN once. Without this the user sees it twice.
+      imageContext = await buildEcsImageResolutionContext(target, stacks, options, stateProvider, {
+        suppressStateWarning: true,
+      });
       service = resolveEcsServiceTarget(target, stacks, imageContext, {
         suppressLoadBalancerWarning: true,
       });

--- a/tests/unit/cli/ecs-service-emulator-state-warning-dedup.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-state-warning-dedup.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+/**
+ * `cdkl start-service` / `cdkl start-alb` resolve every target's image TWICE
+ * during boot: once in the pre-boot pin-classification peek
+ * (`resolveAndBuildImageOverrides`, to decide which targets are pinned) and
+ * once in the real service boot (`resolveServiceAndRunnerOpts`). Both go
+ * through `buildEcsImageResolutionContext`, which WARNs when a same-stack ECR
+ * image needs deployed state and none is bound — so WITHOUT a guard the user
+ * saw the "references a same-stack AWS::ECR::Repository. Pass a state-source
+ * flag ..." WARN twice for the same service (the duplicate the studio LOGS
+ * panel surfaced for a spawned `start-alb` child).
+ *
+ * The peek now passes `{ suppressStateWarning: true }` so the message fires
+ * exactly once (from the real boot path). This covers both the builder's
+ * suppression behaviour and the peek's binding (source-grep, since booting the
+ * full emulator end-to-end needs Docker + a real ECS template).
+ */
+
+const { stsSendMock } = vi.hoisted(() => ({ stsSendMock: vi.fn() }));
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    send = stsSendMock;
+    destroy(): void {}
+  },
+  GetCallerIdentityCommand: class {},
+}));
+
+const { buildEcsImageResolutionContext } = await import(
+  '../../../src/cli/commands/local-start-service.js'
+);
+
+function ecrImageStack(): StackInfo {
+  // A TaskDef whose container image references a same-stack
+  // AWS::ECR::Repository via `Fn::GetAtt` / `Ref` — triggers
+  // `needsStateResources`, so with no stateProvider the builder reaches the
+  // "needs deployed state" WARN branch.
+  return {
+    stackName: 'MyStack',
+    region: 'us-east-1',
+    template: {
+      Resources: {
+        Repo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TaskDef: {
+          Type: 'AWS::ECS::TaskDefinition',
+          Properties: {
+            ContainerDefinitions: [
+              {
+                Name: 'app',
+                Image: {
+                  'Fn::Join': [
+                    '',
+                    [
+                      { 'Fn::Select': [4, { 'Fn::Split': [':', { 'Fn::GetAtt': ['Repo', 'Arn'] }] }] },
+                      '.dkr.ecr.',
+                      { 'Fn::Select': [3, { 'Fn::Split': [':', { 'Fn::GetAtt': ['Repo', 'Arn'] }] }] },
+                      '.',
+                      { Ref: 'AWS::URLSuffix' },
+                      '/',
+                      { Ref: 'Repo' },
+                      ':latest',
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
+const ECR_WARN = 'references a same-stack AWS::ECR::Repository';
+
+describe('buildEcsImageResolutionContext state-warning suppression', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stsSendMock.mockReset();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  function warnedAboutEcr(): boolean {
+    return warnSpy.mock.calls.some((args) => args.some((a) => String(a).includes(ECR_WARN)));
+  }
+
+  it('WARNs about the same-stack ECR image when no state is bound (default)', async () => {
+    await buildEcsImageResolutionContext('MyStack:TaskDef', [ecrImageStack()], {} as never, undefined);
+    expect(warnedAboutEcr()).toBe(true);
+  });
+
+  it('stays silent when suppressStateWarning is set (the pre-boot peek path)', async () => {
+    await buildEcsImageResolutionContext('MyStack:TaskDef', [ecrImageStack()], {} as never, undefined, {
+      suppressStateWarning: true,
+    });
+    expect(warnedAboutEcr()).toBe(false);
+  });
+});
+
+describe('resolveAndBuildImageOverrides peek binding (state-warning dedup)', () => {
+  const SOURCE = readFileSync(
+    path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../../src/cli/commands/ecs-service-emulator.ts'
+    ),
+    'utf-8'
+  );
+
+  it('threads suppressStateWarning into the peek call so the WARN is not duplicated', () => {
+    // The peek (`resolveAndBuildImageOverrides`) classifies each target's image
+    // and handles its own resolution errors as DEBUG; it must NOT also emit the
+    // user-facing state WARN, which the real boot path emits once. Lock that the
+    // peek's buildEcsImageResolutionContext call passes the suppress flag.
+    const peekStart = SOURCE.indexOf('async function resolveAndBuildImageOverrides');
+    expect(peekStart).toBeGreaterThan(-1);
+    const peekBody = SOURCE.slice(peekStart, peekStart + 3000);
+    expect(peekBody).toContain('buildEcsImageResolutionContext');
+    expect(peekBody).toContain('suppressStateWarning: true');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl start-service` / `cdkl start-alb` printed the same-stack-ECR boot WARN
**twice** for the same service. This makes it fire once.

At boot the command resolves each target's image twice — once in the pre-boot
pin-classification peek (`resolveAndBuildImageOverrides`, deciding which
targets are deployed-registry pins) and once in the real service boot
(`resolveServiceAndRunnerOpts`). Both go through
`buildEcsImageResolutionContext`, which WARNs when a same-stack ECR image needs
deployed state and none is bound. So for a `ContainerImage.fromEcrRepository(repo)`
service run without `--from-cfn-stack`, the WARN

```
WARN: Container Image references a same-stack AWS::ECR::Repository. Pass a state-source flag ...
```

appeared twice (most visibly in the `cdkl studio` ALB-serve LOGS panel, which
captures the spawned start-alb child's output), immediately before the
actionable `EcsTaskResolutionError`.

### Fix

The peek is a classification pass — it already swallows its own resolution
errors as DEBUG — so it should not emit user-facing WARNs.
`buildEcsImageResolutionContext` now takes an optional
`opts: { suppressStateWarning?: boolean }` (additive, backward-compatible), and
the peek passes `suppressStateWarning: true`. The real boot path keeps the
WARN, so it fires exactly once. The WARN text and the subsequent
`EcsTaskResolutionError` are unchanged.

### Behavior change (non-breaking)

A duplicate boot WARN in `start-service` / `start-alb` is now emitted once
instead of twice. `buildEcsImageResolutionContext` (exported via
`cdk-local/internal`) gained an optional 5th param — an existing 4-arg call is
unaffected. cdkd tracking issue filed (additive; no host action likely needed).

## Test plan

- Unit: `buildEcsImageResolutionContext` WARNs by default and stays silent with
  `suppressStateWarning: true`; a source-grep binding test locks that the peek
  threads the flag. 206 files / 3112 tests pass.
- Integ: `local-start-service` (real Docker) green — 2 replicas boot + clean
  teardown; 0 container/network orphans.
- Live: ran the built `start-service` against an intrinsic-ECR fixture
  (`local-studio-from-cfn-stack`'s `AppService`) WITHOUT `--from-cfn-stack` and
  confirmed the WARN now appears exactly once (`grep -c` = 1, was 2), with the
  actionable `EcsTaskResolutionError` still following.
