### PR TITLE
feat(studio): make the "Started with" summary collapsible (open by default)

### DIFF
--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -252,6 +252,12 @@ const STUDIO_CSS = `
   .section.req-composer > h3,
   .section.options h3,
   .req-composer > .opt-label { color: #6cb6ff; }
+  /* The "Started with" section is a collapsible <details> (open by default):
+     the <summary> carries the blue h3 heading + the disclosure toggle. The
+     h3's own bottom margin only applies while open, so collapse it onto the
+     summary line. */
+  .section.started-with > summary { cursor: pointer; user-select: none; list-style-position: inside; }
+  .section.started-with > summary > h3 { display: inline; margin: 0; }
   /* Image override is the single most consequential ECS knob — a pinned image
      silently ignores local source edits — so its block gets a boxed amber
      accent to stand out from the ordinary blue option headings (the same amber
@@ -1462,8 +1468,15 @@ const STUDIO_SCRIPT = `
       // visible instead of silently vanishing after Start). A FAILED serve
       // keeps this too, so a crash does not read as "my inputs disappeared".
       const lines = formatAppliedOptions(serveApplied.get(id));
-      const startedSec = el('div', 'section started-with');
-      startedSec.appendChild(el('h3', null, 'Started with'));
+      // Collapsible (a long launch config can crowd out the Endpoints / Logs
+      // below), open by default so the config stays visible at a glance. The
+      // h3 lives inside the <summary> so it keeps its blue section-heading
+      // styling while the summary provides the disclosure toggle.
+      const startedSec = el('details', 'section started-with');
+      startedSec.open = true;
+      const startedSum = el('summary');
+      startedSum.appendChild(el('h3', null, 'Started with'));
+      startedSec.appendChild(startedSum);
       if (lines.length) {
         const list = el('div', 'started-list');
         lines.forEach(function (ln) { list.appendChild(el('code', 'started-flag', ln)); });

--- a/tests/unit/local/studio-ui-applied-opts.test.ts
+++ b/tests/unit/local/studio-ui-applied-opts.test.ts
@@ -109,6 +109,28 @@ describe('studio serve "Started with" summary (issue #356)', () => {
     }
   });
 
+  it('renders "Started with" as a collapsible <details>, open by default', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE });
+    try {
+      const t = exposed(h);
+      t.serveMeta.set('Stk/Svc', { kind: 'ecs' });
+      t.serveApplied.set('Stk/Svc', { options: { '--max-tasks': '3' } });
+      t.serveState.set('Stk/Svc', { status: 'running', endpoints: [] });
+      t.renderServeWorkspace('Stk/Svc');
+
+      const sec = h.document.querySelector('.started-with') as any;
+      expect(sec).toBeTruthy();
+      // Collapsible so a long launch config can be hidden, but open by default
+      // so it stays visible at a glance.
+      expect(sec.tagName.toLowerCase()).toBe('details');
+      expect(sec.open).toBe(true);
+      // The heading lives inside the <summary> (the disclosure toggle).
+      expect(sec.querySelector('summary > h3')?.textContent).toBe('Started with');
+    } finally {
+      h.close();
+    }
+  });
+
   it('shows a "(defaults)" hint when a serve was started with no options', () => {
     const h = createStudioHarness({ epilogue: EXPOSE });
     try {


### PR DESCRIPTION
## Summary

The running serve workspace in `cdkl studio` shows a read-only "Started with"
summary of the launch config a serve was started with (issue #356). When that
config is long, it crowds out the Endpoints / Logs sections below it.

This makes the "Started with" section a collapsible `<details>` element, **open
by default** so the config stays visible at a glance but can be folded away when
it gets noisy. The `h3` heading lives inside the `<summary>` so it keeps its blue
section-heading styling while gaining a disclosure toggle.

Class names (`started-with` / `started-list` / `started-flag`) are unchanged, so
existing selectors, unit assertions, and the `local-studio` verify.sh structural
checks keep matching.

## Test plan

- New unit test in `studio-ui-applied-opts.test.ts` drives `renderServeWorkspace`
  in real jsdom and asserts the section is a `<details>`, `open === true`, with
  the heading under `summary > h3`.
- Full unit suite green (205 files / 3110 tests).
- `local-studio` integration test green (Docker, 0 orphans) — exercises the
  served studio UI HTML + serve-workspace rendering end-to-end.
