### PR TITLE
feat(hooks): force worktree PR merges through /merge-pr via a markgate gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1206,8 +1206,14 @@ vp run runtime:smoke
   rather than branching in the main worktree (shared state across
   parallel agents).
 
-- **Squash merge only**: prefer `gh pr merge <N> --squash --delete-branch`.
-  PR #1 was squash-merged; keep the history flat.
+- **Squash merge only, via `/merge-pr`**: merge every PR with the
+  `/merge-pr <N>` skill — it squash-merges (flat history) from inside the
+  feature worktree and cleans up the worktree + local + remote branch in one
+  pass. Do NOT hand-run `gh pr merge <N> --squash --delete-branch` from a side
+  worktree: `--delete-branch` trips the `'main' is already used by worktree`
+  fatal (the remote merge lands but local cleanup fails), and `gh-pr-merge-
+  worktree-gate.sh` blocks a hand-run worktree merge unless `/merge-pr` set the
+  `merge-pr` marker. PR #1 was squash-merged; keep the history flat.
 
 - **Always add unit tests for new functionality**: don't wait to be
   asked. `tests/unit/**` mirrors `src/**`. Mock external boundaries

--- a/.claude/hooks/gh-pr-merge-worktree-gate.sh
+++ b/.claude/hooks/gh-pr-merge-worktree-gate.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# gh-pr-merge-worktree-gate.sh
+#
+# PreToolUse hook. Blocks a hand-run `gh pr merge` from inside a
+# `.claude/worktrees/<branch>/` side worktree unless the `merge-pr`
+# markgate marker is fresh — forcing every merge through the `/merge-pr`
+# skill, which is the single chokepoint that:
+#   - merges WITHOUT `--delete-branch` (so gh runs no local cleanup and
+#     never trips the `'main' is already used by worktree` fatal), and
+#   - then cleans the worktree + local branch + remote branch correctly
+#     via `git -C <main>`.
+#
+# A hand-run `gh pr merge --squash --delete-branch` from a side worktree
+# both trips that fatal AND leaves the worktree / local branch behind. By
+# routing every worktree merge through `/merge-pr`, any future step added
+# to the merge flow runs automatically — there's one path, not two.
+#
+# `/merge-pr` runs `markgate set merge-pr` (in its own step, BEFORE its
+# `gh pr merge` call) so its own merge passes this gate; a hand-run merge
+# that skipped the skill has no fresh marker and is blocked. The `merge-pr`
+# gate carries a short TTL (see .markgate.yml) so a stale marker left by a
+# crashed `/merge-pr` cannot authorize a later hand-run merge.
+#
+# Scope: ONLY side worktrees (`*/.claude/worktrees/*`). A merge from the
+# main worktree does not hit the fatal and is left alone (fail-open).
+#
+# Cwd-aware: resolves the target git tree from the payload `cwd` + a
+# leading `cd <path>` + the last `gh -C <path>` (same resolution as
+# integ-gate.sh) before consulting markgate, so the per-worktree marker
+# state dir is read correctly.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate `gh pr merge` (incl. `gh -C <path> pr merge`, `cd <path> && gh
+# pr merge`, and `--auto`). Line-start anchored so a `gh pr merge` substring
+# inside a quoted argument body does NOT false-positive.
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+target_dir="${hook_cwd:-$PWD}"
+
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Resolve the absolute working-tree root. Only side worktrees under
+# `.claude/worktrees/` are gated — the main worktree never hits the fatal.
+toplevel=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "")
+case "$toplevel" in
+  */.claude/worktrees/*) ;;            # side worktree — gate it
+  *) exit 0 ;;                          # main worktree / unknown — fail-open
+esac
+
+cd "$target_dir" 2>/dev/null || exit 0
+
+if command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+elif command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+else
+  # markgate missing — fail-open (consistent with the other gates'
+  # missing-tool handling; this gate is a convenience guardrail, not a
+  # hard dependency).
+  exit 0
+fi
+
+if "${markgate[@]}" verify merge-pr >/dev/null 2>&1; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+Blocked by gh-pr-merge-worktree-gate: do not run `gh pr merge` by hand from a
+side worktree — it trips the `'main' is already used by worktree` fatal (with
+`--delete-branch`) and/or leaves the worktree + local branch uncleaned.
+
+Required action:
+  /merge-pr <N>
+
+The `/merge-pr` skill is the single merge chokepoint: it squash-merges WITHOUT
+`--delete-branch` (no fatal), cleans the worktree + local branch + remote
+branch, and sets the `merge-pr` marker that authorizes its own `gh pr merge`.
+A hand-run merge has no fresh marker, so it is blocked here.
+
+This is intentionally the ONLY sanctioned way to merge from a worktree — never
+call `markgate set merge-pr` directly to bypass it.
+EOF
+exit 2

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -14,8 +14,8 @@ The hooks split into three classes:
 3. **Markgate-backed gates** — block `git commit` / `gh pr create` /
    `gh pr merge` when the matching markgate marker is stale, forcing
    the corresponding skill (`/check`, `/check-docs`, `/run-integ`,
-   `/review-pr`, `/verify-pr`) to be re-run before the gated action
-   can proceed.
+   `/review-pr`, `/verify-pr`, `/merge-pr`) to be re-run before the
+   gated action can proceed.
 
 ## 1. Universal-shape safety hooks
 
@@ -141,9 +141,9 @@ The hooks split into three classes:
 
 ## 3. Markgate-backed gates
 
-The six markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
-`pr-review-gate.sh`, `integ-gate.sh`, `cdkd-parity-gate.sh`, and
-`create-integ-gate.sh`) are
+The seven markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
+`pr-review-gate.sh`, `integ-gate.sh`, `cdkd-parity-gate.sh`,
+`create-integ-gate.sh`, and `gh-pr-merge-worktree-gate.sh`) are
 all **cwd-aware**. Each reads the PreToolUse payload's `cwd` field plus
 parses leading `cd <path>` and the last `git -C <path>` /
 `gh -C <path>` flag from the command, then `cd`s to that resolved
@@ -378,3 +378,41 @@ call `markgate set integ` directly from a shell.
   Fail-open: `gh` / `markgate` / `git` missing, or `origin/main`
   unresolvable -> exit 0 silently. The skill is the ONLY legitimate
   setter — never `markgate set create-integ` directly from a shell.
+
+### gh-pr-merge-worktree-gate (worktree merge)
+
+- **`gh-pr-merge-worktree-gate.sh`** blocks a hand-run `gh pr merge`
+  (incl. `gh -C <path> pr merge` / `cd <path> && gh pr merge` /
+  `--auto`) from inside a `.claude/worktrees/<branch>/` **side
+  worktree** unless the `merge-pr` markgate marker is fresh — forcing
+  every worktree merge through the `/merge-pr` skill, the single
+  chokepoint that:
+  - merges WITHOUT `--delete-branch` (so gh runs no local cleanup and
+    never trips the `'main' is already used by worktree` fatal that a
+    hand-run `gh pr merge --squash --delete-branch` hits from a side
+    worktree), and
+  - then cleans the worktree + local branch + remote branch correctly
+    via `git -C <main>`.
+
+  Routing every worktree merge through one skill means any future step
+  added to the merge flow runs automatically — there is one path, not
+  two. `/merge-pr` runs `markgate set merge-pr` in its own step BEFORE
+  its `gh pr merge` call (a PreToolUse hook evaluates the whole command
+  string before any line runs, so the set + merge must be SEPARATE Bash
+  calls — see [[markgate-set-separate-bash-call]]), so the skill's own
+  merge passes; a hand-run merge has no fresh marker and is blocked with
+  an error naming `/merge-pr <N>`.
+
+  Scope: ONLY side worktrees (`*/.claude/worktrees/*`, resolved via
+  `git rev-parse --show-toplevel` after the same cwd resolution the
+  other gates use). A merge from the main worktree does not hit the
+  fatal and is left alone (fail-open). The `merge-pr` gate is TTL-only
+  (`ttl: 30m`, see `.markgate.yml`): a merge changes no tracked files,
+  so a content digest would stay fresh forever after a set — the short
+  TTL bounds the window so a stale marker left by a crashed `/merge-pr`
+  cannot authorize a later hand-run merge.
+
+  Fail-open when `git` / `markgate` are missing or the target is not a
+  side worktree. The `/merge-pr` skill is the ONLY legitimate setter of
+  the `merge-pr` marker — never `markgate set merge-pr` directly from a
+  shell to bypass this gate.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -125,6 +125,13 @@
             "if": "Bash(gh pr create*) or Bash(gh -C * pr create*) or Bash(cd * && gh pr create*)",
             "timeout": 15,
             "statusMessage": "Verifying create-integ markgate marker..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/gh-pr-merge-worktree-gate.sh",
+            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*)",
+            "timeout": 15,
+            "statusMessage": "Checking worktree merge policy (/merge-pr)..."
           }
         ]
       }

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -61,7 +61,23 @@ up local artifacts by hand. The remote branch is auto-deleted by the repo's
    the worktree-remove in step 4 (there is nothing to detach) but still delete
    the local branch.
 
-2. **Merge, WITHOUT `--delete-branch`** (run in the worktree so the merge-time
+2. **Authorize this merge through the worktree-merge gate** — in its OWN Bash
+   call, BEFORE the merge call:
+
+   ```bash
+   mise exec -- markgate set merge-pr
+   ```
+
+   `gh-pr-merge-worktree-gate.sh` blocks a hand-run `gh pr merge` from a side
+   worktree unless this marker is fresh — that is what forces every worktree
+   merge through THIS skill. It MUST be a separate Bash invocation from the
+   merge in step 3: a PreToolUse hook evaluates the whole command string before
+   any line runs, so chaining `markgate set merge-pr && gh pr merge` would still
+   see a stale marker and block. (The `merge-pr` gate has a 30m TTL so this
+   authorization does not linger.) This is the ONLY place `markgate set
+   merge-pr` is ever called — never run it by hand to merge outside this skill.
+
+3. **Merge, WITHOUT `--delete-branch`** (run in the worktree so the merge-time
    gates fire):
 
    ```bash
@@ -73,7 +89,7 @@ up local artifacts by hand. The remote branch is auto-deleted by the repo's
    gates block this — stale `verify-pr` / `pr-review` / `integ` marker — stop and
    run the named skill; do NOT work around the block.)
 
-3. **Confirm the remote merge landed** before touching anything local:
+4. **Confirm the remote merge landed** before touching anything local:
 
    ```bash
    gh pr view "$PR" --json state,mergedAt -q '"state=\(.state) mergedAt=\(.mergedAt)"'
@@ -82,7 +98,7 @@ up local artifacts by hand. The remote branch is auto-deleted by the repo's
    Expect `state=MERGED`. If it is not MERGED, STOP — do not delete the worktree
    (the branch is your only copy of un-merged work).
 
-4. **Clean up local artifacts** from the main worktree (a worktree cannot remove
+5. **Clean up local artifacts** from the main worktree (a worktree cannot remove
    itself while you are cd'd into it):
 
    ```bash
@@ -94,7 +110,7 @@ up local artifacts by hand. The remote branch is auto-deleted by the repo's
    `branch -D` succeeds because the branch is no longer checked out in any
    worktree once the worktree is removed.
 
-5. **Confirm the remote branch is gone** (the repo's `delete_branch_on_merge`
+6. **Confirm the remote branch is gone** (the repo's `delete_branch_on_merge`
    auto-deletes it on merge). Only if it somehow survived, delete it via the API
    — NOT `git push origin --delete`, which `post-merge-orphan-push-gate.sh` may
    flag:
@@ -105,13 +121,15 @@ up local artifacts by hand. The remote branch is auto-deleted by the repo's
      || echo "remote branch already deleted"
    ```
 
-6. **Report**: PR `#<N>` merged (squash), worktree removed, local + remote branch
+7. **Report**: PR `#<N>` merged (squash), worktree removed, local + remote branch
    deleted, `git worktree list` no longer shows the feature worktree.
 
 ## Notes
 
-- The `cd` into the main worktree happens only via `git -C "$MAIN"` in step 4 —
-  the working directory of the merge command in step 2 stays inside the feature
+- The `cd` into the main worktree happens only via `git -C "$MAIN"` in step 5 —
+  the working directory of the merge command in step 3 stays inside the feature
   worktree so the gates resolve the correct per-worktree markgate state dir.
-- This skill never sets any markgate marker. It assumes the gates are already
-  satisfied; it only performs the merge + cleanup.
+- This skill sets exactly ONE markgate marker: `merge-pr` (step 2), which
+  authorizes its own `gh pr merge` past `gh-pr-merge-worktree-gate.sh`. It does
+  NOT set / re-run the `verify-pr` / `pr-review` / `integ` gates — those must
+  already be satisfied; this skill is the merge + cleanup mechanic.

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -107,3 +107,20 @@ gates:
     # later edit on the same PR doesn't re-block.
     include:
       - "src/cli/commands/**"
+
+  merge-pr:
+    # `gh-pr-merge-worktree-gate.sh` blocks a hand-run `gh pr merge` from a
+    # side worktree (`*/.claude/worktrees/*`) unless this marker is fresh —
+    # forcing every worktree merge through the `/merge-pr` skill (the single
+    # chokepoint that merges WITHOUT `--delete-branch`, so it never trips the
+    # `'main' is already used by worktree` fatal, then cleans the worktree +
+    # local + remote branch). `/merge-pr` runs `markgate set merge-pr` in its
+    # own step BEFORE its `gh pr merge` call so its own merge passes; a
+    # hand-run merge has no fresh marker and is blocked.
+    #
+    # TTL-only (no file-hash): a merge does not change tracked files, so a
+    # content digest would stay "fresh" indefinitely after `/merge-pr` set
+    # it. The short TTL bounds the window so a stale marker left by a crashed
+    # `/merge-pr` cannot authorize a later hand-run merge (re-run `/merge-pr`,
+    # which re-sets it). 30m comfortably covers a merge + cleanup pass.
+    ttl: 30m


### PR DESCRIPTION
## Summary

Mechanically enforce the merge path that committed guidance only described —
and that `.claude/CLAUDE.md` actively contradicted. A hand-run `gh pr merge`
from a side worktree trips the `'main' is already used by worktree` fatal (with
`--delete-branch`) and/or leaves the worktree + local branch uncleaned. The
`/merge-pr` skill is the correct path, but nothing enforced it: a memory note
can't guarantee it (machine-local, recalled as background context), and the
`Squash merge only` rule literally recommended the foot-gun
`gh pr merge --squash --delete-branch`.

## What this adds

- **`gh-pr-merge-worktree-gate.sh`** (new PreToolUse hook): blocks `gh pr merge`
  (incl. `gh -C` / `cd && ...` / `--auto`) from a `*/.claude/worktrees/*` side
  worktree unless the `merge-pr` markgate marker is fresh. Cwd-aware (same
  `cd` / `gh -C` / payload-cwd resolution as `integ-gate.sh`); main-worktree
  merges are left alone (fail-open). Registered in `.claude/settings.json`.
- **`merge-pr` markgate gate** (`.markgate.yml`), TTL-only (`ttl: 30m`): a merge
  changes no tracked files, so a content digest would stay fresh forever after
  a set — the short TTL bounds a stale marker left by a crashed `/merge-pr`.
- **`/merge-pr` skill**: now runs `markgate set merge-pr` in its own step BEFORE
  the merge (separate Bash call — a PreToolUse hook evaluates the whole command
  before any line runs), so the skill's own merge passes while a hand-run merge
  is blocked.
- **`.claude/CLAUDE.md`**: the `Squash merge only` rule now points at
  `/merge-pr` instead of recommending `--delete-branch`.
- **`.claude/rules/hooks.md`**: documents the gate (seven gate hooks now).

The net effect: every worktree PR merge goes through one chokepoint, so any
future step added to the merge flow runs automatically — there is one path, not
two.

## Test plan

Live-tested end-to-end with synthesized PreToolUse payloads (shell hooks have no
unit harness, so this is the correctness check):

- side worktree + `--delete-branch`, no marker -> **block (exit 2)**
- side worktree + plain `--squash`, no marker -> **block (exit 2)** (forces the
  skill even for the non-fatal form)
- side worktree, after `markgate set merge-pr` -> **pass (exit 0)** (the skill's
  own merge)
- main worktree -> **pass (fail-open)**
- `gh pr create` / a quoted `gh pr merge` substring -> **pass (unmatched)**
- `cd <worktree> && gh pr merge` from the main cwd -> **block (exit 2)** (cd
  resolution)

`vp check` clean (0 errors), unit suite green (205 files / 3109 tests). No
`src/**` touched (cdkd-parity / integ n/a).

## Retrospective

This PR is itself the rule-enforcement fix for a session miss: I hand-ran
`gh pr merge --squash --delete-branch` from a worktree (hit the fatal, cleaned
up manually) when `/merge-pr` exists. Root causes — a memory note that couldn't
guarantee behavior, a `MEMORY.md` index line that buried the `/merge-pr` pointer
behind the manual-cleanup workaround, and a `CLAUDE.md` rule that recommended
the foot-gun — are all addressed (the index line was corrected in-session; the
rule + the enforcing hook land here).
