### PR TITLE
fix(start-alb): emit listener warnings once, not "WARN:   WARN:" + repair the alb-https integ fixture

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -2163,7 +2163,7 @@ export async function buildFrontDoor(
         if (code === 'EACCES' && listener.hostPort < 1024) {
           server = await startFrontDoorServer({ ...fdBase, port: 0 });
           logger.warn(
-            `  WARN: listener port ${listener.listenerPort} is privileged (< 1024) and cannot be ` +
+            `listener port ${listener.listenerPort} is privileged (< 1024) and cannot be ` +
               `bound without root; serving it on host port ${server.port} instead. Pass ` +
               `--lb-port ${listener.listenerPort}=<hostPort> to pin a fixed port.`
           );
@@ -2178,7 +2178,7 @@ export async function buildFrontDoor(
       );
       if (degradedHttps) {
         logger.warn(
-          `  WARN: listener port ${listener.listenerPort} is HTTPS in the cloud but serving HTTP ` +
+          `listener port ${listener.listenerPort} is HTTPS in the cloud but serving HTTP ` +
             'locally (X-Forwarded-Proto: https preserved). Pass --tls to terminate TLS locally ' +
             'with a self-signed or user-supplied cert.'
         );

--- a/tests/integration/local-start-alb-https/verify.sh
+++ b/tests/integration/local-start-alb-https/verify.sh
@@ -73,8 +73,13 @@ trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
 echo "==> start-alb: HTTP on ${LB_HTTP_PORT}, HTTPS on ${LB_HTTPS_PORT}"
 # Listener ports 80 and 443 are both privileged; remap each to a
 # non-privileged host port so the front-door binds without root.
+# `--tls` opts the HTTPS:443 listener into real local TLS termination with an
+# auto-generated self-signed cert (the path this fixture asserts) — without it
+# a cloud-HTTPS listener is served over plain HTTP locally by default, so the
+# HTTPS front-door banner never appears.
 ${CDKL} start-alb CdkLocalStartAlbHttpsFixture:WebLB \
   --container-host 127.0.0.1 \
+  --tls \
   --lb-port "80=${LB_HTTP_PORT}" \
   --lb-port "443=${LB_HTTPS_PORT}" \
   > "${OUT_FILE}" 2>&1 &

--- a/tests/unit/cli/ecs-service-emulator-warn-prefix.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-warn-prefix.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vite-plus/test';
+
+/**
+ * Regression for the doubled `WARN:   WARN:` log prefix.
+ *
+ * The compact-mode logger (`src/utils/logger.ts`) prefixes warn lines with
+ * `WARN: ` (and error lines with `ERROR: `) so the severity survives a
+ * colourless pipe (the studio child / `NO_COLOR`). A message string that ALSO
+ * begins with a literal `WARN:` therefore double-prefixes to
+ * `WARN:   WARN: ...`. Two listener warnings in `ecs-service-emulator.ts` (the
+ * privileged-port remap + the degraded-HTTPS notice) carried a stale `  WARN:`
+ * from before the logger added the prefix — surfaced in the `cdkl studio`
+ * ALB-serve LOGS panel as `WARN:   WARN: listener port 443 ...`.
+ *
+ * Source-grep (the front-door boot path can't be exercised end-to-end without
+ * Docker + an EACCES privileged bind): no logged message in this file may
+ * start with a literal `WARN:` / `ERROR:` — the logger owns that prefix.
+ */
+const SOURCE = readFileSync(
+  path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../../src/cli/commands/ecs-service-emulator.ts'
+  ),
+  'utf-8'
+);
+
+describe('ecs-service-emulator listener WARN prefix', () => {
+  it('embeds no literal WARN:/ERROR: prefix in a logged message (the logger adds it)', () => {
+    // A backtick template literal that opens with (optional spaces then)
+    // `WARN:` / `ERROR:` is the double-prefix shape.
+    expect(/`\s*(WARN|ERROR):/.test(SOURCE)).toBe(false);
+  });
+
+  it('still emits the privileged-port + degraded-HTTPS listener warnings', () => {
+    expect(SOURCE).toContain('is privileged (< 1024) and cannot be');
+    expect(SOURCE).toContain('is HTTPS in the cloud but serving HTTP');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl start-alb` / `cdkl start-service` printed two listener warnings with a
**doubled** `WARN:   WARN:` prefix.

Two warnings in the front-door boot — the privileged-port remap notice and the
cloud-HTTPS-served-over-HTTP-locally notice — carried a stale literal `  WARN:`
inside the message string. The compact-mode logger (`utils/logger.ts`, issue
#403) already prefixes warn lines with `WARN: `, so they rendered as:

```
WARN:   WARN: listener port 443 is privileged (< 1024) ...
WARN:   WARN: listener port 443 is HTTPS in the cloud but serving HTTP ...
```

(most visibly in the `cdkl studio` ALB-serve LOGS panel, which captures the
spawned start-alb child's output). The literal prefix is removed from both
messages — the logger owns it — so each renders with a single `WARN: `.

## Behavior change (non-breaking)

A doubled `WARN:   WARN:` start-alb listener warning now renders as a single
`WARN: `. The message wording and severity are otherwise unchanged. cdkd
tracking issue filed (additive log-string fix; no host action likely needed).

## Also: repair the local-start-alb-https integ fixture

While live-testing, the `local-start-alb-https` integ surfaced a pre-existing
break unrelated to this change: its `verify.sh` ran `start-alb` **without
`--tls`**, so the HTTPS:443 listener was served over plain HTTP locally (the
documented default — `--tls` opts into local TLS termination), and the asserted
HTTPS front-door banner never appeared. The fixture failed on current
behavior. Added the missing `--tls` so the listener terminates TLS with an
auto-generated self-signed cert — the path the fixture is named for. (Docker
integs are not run in CI, so this sat broken on `main` undetected.)

## Test plan

- Unit: a source-grep regression test asserts no logged message in
  `ecs-service-emulator.ts` embeds a literal `WARN:` / `ERROR:` prefix (the
  logger adds it). 207 files / 3115 tests pass.
- Integ: `local-start-alb-https` (real Docker) now **green with the `--tls`
  fix** — both HTTP + HTTPS banners present, HTTPS front-door serves 200 and
  load-balances across 2 replicas, clean teardown; 0 orphans. `local-start-alb`
  also green.
- Live: ran the built `start-alb` against the 443/HTTPS fixture WITHOUT
  `--tls`/`--lb-port` (to trigger both warnings) and confirmed all three
  listener warnings now render with a single `WARN: ` prefix
  (`grep -c 'WARN:   WARN:'` = 0, was non-zero).
