### PR TITLE
fix(synth): drop the leaked toolkit "Supply a stack id" multi-stack hint

### DIFF
--- a/src/synthesis/cdkl-io-host.ts
+++ b/src/synthesis/cdkl-io-host.ts
@@ -39,6 +39,16 @@ import { resolveConfiguredLogLevel } from '../utils/logger.js';
  * synthesized to ..." / asset-bundling noise; real synth failures still
  * surface (toolkit raises `AssemblyError` on non-zero subprocess exit, and
  * `warn` / `error` messages still pass through).
+ *
+ * It also DROPS the "Supply a stack id (...) to display its template."
+ * line `Toolkit.synth()` emits when an assembly has more than one stack.
+ * That hint is CDK CLI advice for picking a single stack to print a
+ * template for — irrelevant to cdk-local, which synthesizes the whole app
+ * and never prints templates. toolkit-lib emits it via
+ * `ioHelper.defaults.info(...)` with NO message `code`, so it can only be
+ * matched on its text; left unfiltered it pollutes the output of every
+ * multi-stack `start-alb` / `start-service` / `studio` synth (it surfaced
+ * in the studio ALB-serve LOGS panel).
  */
 export class CdklIoHost extends NonInteractiveIoHost {
   private readonly suppressNonWarnings = (() => {
@@ -47,6 +57,10 @@ export class CdklIoHost extends NonInteractiveIoHost {
   })();
 
   async notify(msg: IoMessage<unknown>): Promise<void> {
+    if (isStackIdTemplateHint(msg)) {
+      return;
+    }
+
     const reclassified =
       msg.code === 'CDK_ASSEMBLY_E1002' ||
       msg.code === 'CDK_TOOLKIT_I1901' ||
@@ -63,4 +77,19 @@ export class CdklIoHost extends NonInteractiveIoHost {
     }
     return super.notify(reclassified);
   }
+}
+
+/**
+ * Detects the multi-stack "Supply a stack id (...) to display its template."
+ * hint `Toolkit.synth()` emits with no message `code`. The stack ids inside
+ * the parens may carry chalk colour codes, but the literal prefix and suffix
+ * are plain text, so a prefix+suffix text match is robust to colour.
+ */
+function isStackIdTemplateHint(msg: IoMessage<unknown>): boolean {
+  return (
+    msg.code === undefined &&
+    typeof msg.message === 'string' &&
+    msg.message.startsWith('Supply a stack id ') &&
+    msg.message.includes('to display its template')
+  );
 }

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -23,6 +23,8 @@
 #   3. cdk deploy (producer + consumer, in that order — cdk handles the
 #      ordering automatically from `addDependency`)
 #   4. read the producer's exported value via list-exports
+#   4b. assert the multi-stack "Supply a stack id ... to display its
+#      template." toolkit hint is suppressed (synth-only `cdkl list`)
 #   5. baseline: cdkl invoke (no --from-cfn-stack) — assert
 #      SHARED_VALUE comes through as "unset" (warn-and-drop on
 #      intrinsics)
@@ -156,6 +158,22 @@ invoke_with_retry() {
   ${CLI} invoke "${args[@]}" 2>&1 | tail -10 >&2
   return 1
 }
+
+echo "[verify] step 4b: assert the multi-stack 'Supply a stack id' toolkit hint is suppressed"
+# `@aws-cdk/toolkit-lib`'s Toolkit.synth() prints a CDK-CLI hint
+# ("Supply a stack id (<stack>, <stack>, ...) to display its template.")
+# whenever the assembly has 2+ stacks. cdk-local synthesizes the whole
+# app and never prints templates, so CdklIoHost drops that codeless info
+# line. This fixture is the only committed multi-stack app, so it is the
+# only place the suppression can be exercised end-to-end. `cdkl list` is
+# synth-only (no Docker) and runs the same Toolkit.synth() path as invoke.
+SYNTH_OUT=$(${CLI} list 2>&1 || true)
+if echo "${SYNTH_OUT}" | grep -q "Supply a stack id"; then
+  echo "[verify] FAIL: leaked toolkit 'Supply a stack id' hint present in multi-stack synth output:"
+  echo "${SYNTH_OUT}" | grep "Supply a stack id"
+  exit 1
+fi
+echo "[verify]   ok: no 'Supply a stack id' hint in multi-stack synth output"
 
 echo "[verify] step 5: cdkl invoke (no --from-cfn-stack) — expect SHARED_VALUE=unset"
 RESULT_BASELINE=$(invoke_with_retry "${CONSUMER_STACK}/EchoSharedHandler" --no-pull)

--- a/tests/unit/synthesis/cdkl-io-host.test.ts
+++ b/tests/unit/synthesis/cdkl-io-host.test.ts
@@ -54,6 +54,51 @@ describe('CdklIoHost', () => {
     stderrSpy.mockRestore();
   });
 
+  describe('multi-stack "Supply a stack id" hint', () => {
+    it('drops the codeless "Supply a stack id (...) to display its template." line', async () => {
+      const host = new CdklIoHost({ isCI: false });
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      // toolkit-lib's Toolkit.synth() emits this via ioHelper.defaults.info,
+      // so it carries NO message code and can only be matched on its text.
+      await host.notify({
+        time: new Date(),
+        level: 'info',
+        action: 'synth',
+        code: undefined,
+        message: 'Supply a stack id (StackA, StackB) to display its template.',
+        data: undefined,
+      } as never);
+
+      const written =
+        stderrSpy.mock.calls.map((c) => String(c[0])).join('') +
+        stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(written).not.toContain('Supply a stack id');
+      expect(written).not.toContain('to display its template');
+      stderrSpy.mockRestore();
+      stdoutSpy.mockRestore();
+    });
+
+    it('does NOT drop an unrelated codeless info message', async () => {
+      const host = new CdklIoHost({ isCI: false });
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      await host.notify({
+        time: new Date(),
+        level: 'info',
+        action: 'synth',
+        code: undefined,
+        message: 'Some other informational line',
+        data: undefined,
+      } as never);
+
+      const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(written).toContain('Some other informational line');
+      stderrSpy.mockRestore();
+    });
+  });
+
   describe('CDKL_LOG_LEVEL=warn suppression (studio child)', () => {
     const prev = process.env['CDKL_LOG_LEVEL'];
     afterEach(() => {


### PR DESCRIPTION
## Summary

`@aws-cdk/toolkit-lib`'s `Toolkit.synth()` prints a CDK-CLI hint —
`Supply a stack id (<stack>, <stack>, ...) to display its template.` —
whenever the synthesized assembly has **2+ stacks**. cdk-local synthesizes
the whole app and never prints templates, so the line is pure noise. It
polluted the output of every multi-stack `start-alb` / `start-service` /
`studio` synth (it surfaced in the studio ALB-serve LOGS panel alongside the
real logs).

toolkit-lib emits it via `ioHelper.defaults.info(...)` with **no message
`code`**, so `CdklIoHost` cannot match it by code (the way it does for
`CDK_ASSEMBLY_E1002` / `CDK_TOOLKIT_I190x`). It now drops the line by a
chalk-robust prefix+suffix text match (`isStackIdTemplateHint`) — placed
ahead of the existing reclassification, so the line never reaches any
stream, in every mode.

## Why a text match

The stack ids inside the parens may carry chalk colour codes, but the literal
prefix (`Supply a stack id `) and suffix (`to display its template`) are plain
text, so matching both ends is robust to colour and specific enough that no
other toolkit message collides.

## Behaviour change

For any caller of cdk-local's synth path, a multi-stack synth no longer emits
the `Supply a stack id ...` line. This is additive cleanup (a noise line
removed); no other output changes. `CdklIoHost` is internal to
`src/synthesis/`, so this is not a library-surface change.

## Test plan

- **Unit** (`tests/unit/synthesis/cdkl-io-host.test.ts`): drops the codeless
  hint; does **not** drop an unrelated codeless info line (no over-filtering).
- **Integ** (`local-invoke-from-cfn-stack-multi-stack`, the only committed
  multi-stack fixture): a new synth-only `cdkl list` assertion (step 4b)
  proves the hint is absent. Verified end-to-end against a real 2-stack
  deploy; the same assertion was confirmed to **catch the regression** on the
  pre-fix CLI (count 1) and pass on the fixed CLI (count 0).
- **Live-test**: built CLI run of `cdkl list` against a 2-stack app, before
  vs after — `Supply a stack id` count went 1 -> 0 with the rest of the output
  byte-identical.
