### PR TITLE
feat(studio): surface a browser hint when a pinned ECS image is unresolvable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -549,7 +549,14 @@ compute-locally category for Lambda + API Gateway).
   `--from-cfn-stack`, e.g. `ContainerImage.fromEcrRepository(repo)`) is
   detected as pinned — matching `cdkl start-service --from-cfn-stack`; a
   service that cannot be classified now WARNs instead of silently going
-  unmarked. Issue #385 made this re-runnable: a Session-bar
+  unmarked. When that classify failure happens WITHOUT `--from-cfn-stack`
+  (the likely-INTRINSIC-ECR case), the service / task-def entry is also
+  marked `pinUnresolved` (the classifiers' `onUnresolved` callback ->
+  `classifyStudioTargets`), so the studio composer renders an in-UI hint
+  pointing at the Session-bar `--from-cfn-stack` remedy — the terminal WARN
+  alone never reaches a browser-only user. `pinUnresolved` is mutually
+  exclusive with `pinned` (a resolved pin gets the Dockerfile picker, not the
+  hint). Issue #385 made this re-runnable: a Session-bar
   `--from-cfn-stack` change (`PATCH /api/config`) re-runs the classification
   (`classifyStudioTargets` against a fresh clone of the un-annotated base) and
   swaps the served target list under the live socket (`RunningStudioServer.

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -714,8 +714,18 @@ export function makePinClassifier(args: {
    * flag they already passed.
    */
   stateBound?: boolean;
+  /**
+   * Called with the target id when classification THREW and `--from-cfn-stack`
+   * is NOT bound (`stateBound === false`) — the case the {@link pinClassifyStateHint}
+   * remedy addresses (a likely INTRINSIC-ECR image that only resolves against
+   * deployed state). `classifyStudioTargets` uses it to mark the entry
+   * `pinUnresolved` so the browser composer can render the same Session-bar
+   * hint the terminal WARN already prints. Not called when state IS bound (the
+   * resolver's own error names the real failure) nor on a clean classify.
+   */
+  onUnresolved?: (id: string) => void;
 }): (id: string) => boolean {
-  const { stacks, contextByStack, logger, stateBound } = args;
+  const { stacks, contextByStack, logger, stateBound, onUnresolved } = args;
   return (id: string): boolean => {
     try {
       const stack = resolveEcsServiceStack(id, stacks);
@@ -731,6 +741,9 @@ export function makePinClassifier(args: {
             err instanceof Error ? err.message : String(err)
           }`
       );
+      // Gate the browser hint on the SAME condition as the terminal remedy
+      // (state not bound) so the in-UI hint and the WARN stay in lockstep.
+      if (stateBound === false) onUnresolved?.(id);
       return false;
     }
   };
@@ -772,8 +785,10 @@ export function makeTaskPinClassifier(args: {
   logger: ReturnType<typeof getLogger>;
   /** See {@link makePinClassifier} — gates the Session-bar remedy hint. */
   stateBound?: boolean;
+  /** See {@link makePinClassifier} — fires the browser `pinUnresolved` hint. */
+  onUnresolved?: (id: string) => void;
 }): (id: string) => boolean {
-  const { stacks, contextByStack, logger, stateBound } = args;
+  const { stacks, contextByStack, logger, stateBound, onUnresolved } = args;
   return (id: string): boolean => {
     try {
       const stack = resolveEcsServiceStack(id, stacks);
@@ -788,6 +803,7 @@ export function makeTaskPinClassifier(args: {
             stateBound
           )} ${err instanceof Error ? err.message : String(err)}`
       );
+      if (stateBound === false) onUnresolved?.(id);
       return false;
     }
   };
@@ -907,17 +923,38 @@ export async function classifyStudioTargets(args: {
   // (set --from-cfn-stack to surface the picker). Computed off the same flag
   // bag prepareEcsImageContexts consumes.
   const stateBound = isCfnFlagPresent(classifyOptions);
+  // Collect the ids the classifiers could not resolve while `--from-cfn-stack`
+  // is unbound (likely INTRINSIC-ECR images). After the annotate passes, the
+  // matching ecs / ecs-task entries are flagged `pinUnresolved` so the browser
+  // composer renders the same Session-bar remedy the terminal WARN prints — the
+  // terminal-only #484 hint never reaches a browser-only user.
+  const unresolvedPinIds = new Set<string>();
+  const onUnresolved = (id: string): void => {
+    unresolvedPinIds.add(id);
+  };
   const anyPinned = annotatePinnedEcsTargets(
     groups,
-    makePinClassifier({ stacks, contextByStack, logger, stateBound })
+    makePinClassifier({ stacks, contextByStack, logger, stateBound, onUnresolved })
   );
   // Issue #388 — classify ECS task definitions (the `ecs-task` kind) too, so a
   // pinned task-def image gets the same image-override picker. The `ecs-task`
   // composer spawns `cdkl run-task`, which accepts `--image-override`.
   const anyTaskPinned = annotateEcsTaskPinnedTargets(
     groups,
-    makeTaskPinClassifier({ stacks, contextByStack, logger, stateBound })
+    makeTaskPinClassifier({ stacks, contextByStack, logger, stateBound, onUnresolved })
   );
+  // Mark the unresolved (but not pinned) ecs / ecs-task entries so the UI can
+  // hint at `--from-cfn-stack`. A successfully-classified pin already carries
+  // the Dockerfile picker, so `pinUnresolved` is kept mutually exclusive with
+  // `pinned`.
+  if (unresolvedPinIds.size > 0) {
+    for (const g of groups) {
+      if (g.kind !== 'ecs' && g.kind !== 'ecs-task') continue;
+      for (const e of g.entries) {
+        if (!e.pinned && unresolvedPinIds.has(e.id)) e.pinUnresolved = true;
+      }
+    }
+  }
   const pinnedEcsByQualifiedId = new Map<string, string>();
   for (const g of groups) {
     if (g.kind !== 'ecs') continue;

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -37,6 +37,20 @@ export interface StudioTarget {
    */
   pinned?: boolean;
   /**
+   * Set on a servable `ecs` service OR an `ecs-task` task definition whose
+   * image-pin status could NOT be classified at boot AND `--from-cfn-stack` is
+   * not bound (issue follow-up to #354 / #484). The usual cause is an INTRINSIC
+   * ECR image (`ContainerImage.fromEcrRepository(repo)`), which is only
+   * resolvable against deployed state — so without the binding the target is
+   * neither marked `pinned` (no Dockerfile picker) nor obviously broken. The
+   * terminal boot WARN already explains this, but a browser-only studio user
+   * never sees it; this flag lets the composer render an in-UI hint to set
+   * `--from-cfn-stack` in the Session bar so the picker can appear. Mutually
+   * exclusive with `pinned` (a successfully-classified pin gets the picker, not
+   * the hint).
+   */
+  pinUnresolved?: boolean;
+  /**
    * Set on an `alb` entry: the deployed-registry-pinned ECS services this ALB
    * fronts (issue #384). `start-alb` boots the ALB's backing services, so a
    * pinned backing service has the same "local edits do not take effect"

--- a/src/local/studio-ui.ts
+++ b/src/local/studio-ui.ts
@@ -867,6 +867,26 @@ const STUDIO_SCRIPT = `
     };
   }
 
+  // Shown for an ecs / ecs-task target whose image-pin status could not be
+  // classified because --from-cfn-stack is unbound (likely an INTRINSIC-ECR
+  // image, e.g. ContainerImage.fromEcrRepository). The terminal boot WARN says
+  // the same thing, but a browser-only user never sees it, so surface the
+  // Session-bar remedy in the composer where the Dockerfile picker would be.
+  function buildPinUnresolvedHint() {
+    const sec = el('div', 'section options image-override');
+    sec.appendChild(el('h3', null, 'Image override unavailable'));
+    sec.appendChild(
+      el(
+        'div',
+        'opt-hint io-hint',
+        'This image could not be classified without deployed state. If it is pinned to a deployed ' +
+          'registry (e.g. ContainerImage.fromEcrRepository), set --from-cfn-stack in the Session bar ' +
+          'so studio can resolve it and offer a Dockerfile picker to rebuild it locally.'
+      )
+    );
+    return sec;
+  }
+
   // Per-backing-service image-override pickers for a pinned ALB (issue #384):
   // one Dockerfile select per deployed-registry-pinned service the ALB fronts.
   // collect() returns a { [serviceId]: dockerfile } map threaded as
@@ -1063,6 +1083,7 @@ const STUDIO_SCRIPT = `
                 btnSlot,
                 kind: group.kind,
                 pinned: entry.pinned === true,
+                pinUnresolved: entry.pinUnresolved === true,
                 backingPinnedServices: entry.backingPinnedServices || [],
                 agentCoreHasWs: entry.agentCoreHasWs === true,
                 agentCoreContractPath: entry.agentCoreContractPath || null,
@@ -1436,6 +1457,15 @@ const STUDIO_SCRIPT = `
         const io = buildImageOverridePicker(applied && applied.imageOverride);
         ws.appendChild(io.node);
         collectImageOverride = io.collect;
+      } else if (
+        meta &&
+        (meta.kind === 'ecs' || meta.kind === 'ecs-task') &&
+        meta.pinUnresolved
+      ) {
+        // Could not classify the image-pin status (no --from-cfn-stack); hint
+        // at the Session-bar remedy instead of a Dockerfile picker (the
+        // terminal-only #484 WARN never reaches a browser-only user).
+        ws.appendChild(buildPinUnresolvedHint());
       }
       // An ALB boots its backing ECS services (issue #384); a pinned backing
       // service has the same "local edits do not take effect" problem, so offer

--- a/tests/integration/local-studio-from-cfn-stack/verify.sh
+++ b/tests/integration/local-studio-from-cfn-stack/verify.sh
@@ -19,7 +19,10 @@
 #      entry in GET /api/targets has "pinned":true (the issue #354 fix), and
 #   2. boots `cdkl studio` WITHOUT --from-cfn-stack as a NEGATIVE CONTROL and
 #      asserts the SAME service is NOT pinned (the intrinsic URI is
-#      unresolvable without the deployed-state context).
+#      unresolvable without the deployed-state context) AND carries
+#      "pinUnresolved":true, the browser-hint flag that makes the composer
+#      surface the Session-bar --from-cfn-stack remedy a browser-only user
+#      would otherwise never see (the terminal WARN does not reach the browser).
 #
 # The service deploys with desiredCount:0 so no task ever launches and no image
 # is pushed to the repo — the deploy only needs to CREATE the ECR repository so
@@ -167,12 +170,51 @@ print("PINNED" if entry.get("pinned") is True else "NOT_PINNED")
 PY
 }
 
+# Report whether the service entry carries "pinUnresolved":true — the
+# browser-hint flag the composer renders the Session-bar --from-cfn-stack
+# remedy from. Set when the intrinsic-ECR image cannot be classified AND
+# --from-cfn-stack is unbound; absent once the service resolves + pins.
+service_pin_unresolved() {
+  python3 - "$1" "${SERVICE_ID}" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+target_id = sys.argv[2]
+def walk(obj):
+    found = []
+    if isinstance(obj, dict):
+        if obj.get("id") == target_id:
+            found.append(obj)
+        for v in obj.values():
+            found += walk(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            found += walk(v)
+    return found
+matches = walk(data)
+if not matches:
+    print("MISSING")
+    sys.exit(0)
+entry = matches[0]
+print("UNRESOLVED" if entry.get("pinUnresolved") is True else "NOT_UNRESOLVED")
+PY
+}
+
 echo "[verify] step 4: studio --from-cfn-stack — expect the service is pinned:true (issue #354 fix)"
 boot_studio_and_fetch_targets --from-cfn-stack "${STACK}"
 STATUS_CFN=$(service_is_pinned "${BODY_FILE}")
 echo "[verify]   ${SERVICE_ID} under --from-cfn-stack: ${STATUS_CFN}"
 if [ "${STATUS_CFN}" != "PINNED" ]; then
   echo "[verify] FAIL: expected ${SERVICE_ID} to be pinned:true under --from-cfn-stack, got ${STATUS_CFN}"
+  echo "[verify]   /api/targets payload:"; cat "${BODY_FILE}"
+  exit 1
+fi
+# A resolved + pinned service offers the Dockerfile picker, NOT the unresolved
+# hint, so pinUnresolved must be absent here.
+UNRES_CFN=$(service_pin_unresolved "${BODY_FILE}")
+echo "[verify]   ${SERVICE_ID} under --from-cfn-stack pinUnresolved: ${UNRES_CFN}"
+if [ "${UNRES_CFN}" = "UNRESOLVED" ]; then
+  echo "[verify] FAIL: ${SERVICE_ID} should NOT be pinUnresolved under --from-cfn-stack (it is pinned)"
   echo "[verify]   /api/targets payload:"; cat "${BODY_FILE}"
   exit 1
 fi
@@ -195,6 +237,17 @@ if [ "${STATUS_NO_CFN}" = "MISSING" ]; then
   echo "[verify]   /api/targets payload:"; cat "${BODY_FILE}"
   exit 1
 fi
+# The new browser-hint flag: an unresolvable intrinsic-ECR service WITHOUT
+# --from-cfn-stack must be marked pinUnresolved:true so the composer can render
+# the Session-bar remedy a browser-only user would otherwise never see (the
+# terminal WARN does not reach the browser).
+UNRES_NO_CFN=$(service_pin_unresolved "${BODY_FILE}")
+echo "[verify]   ${SERVICE_ID} without --from-cfn-stack pinUnresolved: ${UNRES_NO_CFN}"
+if [ "${UNRES_NO_CFN}" != "UNRESOLVED" ]; then
+  echo "[verify] FAIL: expected ${SERVICE_ID} to be pinUnresolved:true without --from-cfn-stack, got ${UNRES_NO_CFN}"
+  echo "[verify]   /api/targets payload:"; cat "${BODY_FILE}"
+  exit 1
+fi
 
 echo "[verify] step 6: cdk destroy --force (handled by the cleanup trap on exit)"
 
@@ -202,4 +255,5 @@ echo ""
 echo "[verify] All checks passed:"
 echo "[verify]   - issue #354: studio --from-cfn-stack marks the intrinsic-ECR-image ECS service pinned:true,"
 echo "[verify]     so the UI offers the image-override Dockerfile picker."
-echo "[verify]   - negative control: WITHOUT --from-cfn-stack the same service is left unmarked (unresolvable intrinsic image)."
+echo "[verify]   - negative control: WITHOUT --from-cfn-stack the same service is left unmarked (unresolvable intrinsic image)"
+echo "[verify]     AND carries pinUnresolved:true so the browser composer hints at the Session-bar --from-cfn-stack remedy."

--- a/tests/unit/cli/local-studio-pin-classifier.test.ts
+++ b/tests/unit/cli/local-studio-pin-classifier.test.ts
@@ -371,6 +371,56 @@ describe('makePinClassifier', () => {
       expect.stringContaining('set --from-cfn-stack in the Session bar')
     );
   });
+
+  it('fires onUnresolved with the id when classify throws AND state is NOT bound', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockImplementation(() => {
+      throw new Error('cannot resolve image');
+    });
+    const onUnresolved = vi.fn();
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: false,
+      onUnresolved,
+    });
+    classify('dev/Svc');
+    expect(onUnresolved).toHaveBeenCalledWith('dev/Svc');
+  });
+
+  it('does NOT fire onUnresolved when state IS bound (the resolver error explains it)', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockImplementation(() => {
+      throw new Error('cannot resolve image');
+    });
+    const onUnresolved = vi.fn();
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: true,
+      onUnresolved,
+    });
+    classify('dev/Svc');
+    expect(onUnresolved).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire onUnresolved on a clean classify', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsServiceTarget.mockReturnValue({});
+    hoisted.isLocalCdkAssetImage.mockReturnValue(false);
+    const onUnresolved = vi.fn();
+    const classify = makePinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: false,
+      onUnresolved,
+    });
+    expect(classify('dev/Svc')).toBe(true);
+    expect(onUnresolved).not.toHaveBeenCalled();
+  });
 });
 
 describe('makeTaskPinClassifier (issue #388)', () => {
@@ -445,6 +495,40 @@ describe('makeTaskPinClassifier (issue #388)', () => {
       expect.stringContaining('set --from-cfn-stack in the Session bar')
     );
   });
+
+  it('fires onUnresolved with the id when classify throws AND state is NOT bound', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsTaskTarget.mockImplementation(() => {
+      throw new Error('cannot resolve task image');
+    });
+    const onUnresolved = vi.fn();
+    const classify = makeTaskPinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: false,
+      onUnresolved,
+    });
+    classify('dev/Task');
+    expect(onUnresolved).toHaveBeenCalledWith('dev/Task');
+  });
+
+  it('does NOT fire onUnresolved when state IS bound', () => {
+    const logger = fakeLogger();
+    hoisted.resolveEcsTaskTarget.mockImplementation(() => {
+      throw new Error('cannot resolve task image');
+    });
+    const onUnresolved = vi.fn();
+    const classify = makeTaskPinClassifier({
+      stacks: [stack('dev')],
+      contextByStack: new Map(),
+      logger,
+      stateBound: true,
+      onUnresolved,
+    });
+    classify('dev/Task');
+    expect(onUnresolved).not.toHaveBeenCalled();
+  });
 });
 
 describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack toggle)', () => {
@@ -485,6 +569,9 @@ describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack 
       logger,
     });
     expect(off.groups[0]?.entries[0]?.pinned).toBeUndefined();
+    // Unresolved without state => flagged so the browser composer can hint at
+    // the Session-bar --from-cfn-stack remedy (the terminal WARN already does).
+    expect(off.groups[0]?.entries[0]?.pinUnresolved).toBe(true);
     expect(off.dockerfiles).toEqual([]);
     expect(hoisted.discoverDockerfiles).not.toHaveBeenCalled();
     // Without --from-cfn-stack, the classify WARN tells the user how to surface
@@ -505,6 +592,8 @@ describe('classifyStudioTargets (issue #385 — re-classify on --from-cfn-stack 
       logger,
     });
     expect(on.groups[0]?.entries[0]?.pinned).toBe(true);
+    // Resolved + pinned => the picker is offered, NOT the unresolved hint.
+    expect(on.groups[0]?.entries[0]?.pinUnresolved).toBeUndefined();
     expect(on.dockerfiles).toEqual(['./Dockerfile']);
     expect(hoisted.discoverDockerfiles).toHaveBeenCalledTimes(1);
 

--- a/tests/unit/local/studio-ui-pin-unresolved-hint.test.ts
+++ b/tests/unit/local/studio-ui-pin-unresolved-hint.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createStudioHarness } from './studio-ui-harness.js';
+
+// Expose the serve-workspace internals so a test can render the composer for a
+// target whose image-pin status could not be classified (pinUnresolved).
+const EXPOSE = `
+window.__t = {
+  serveMeta: serveMeta,
+  serveState: serveState,
+  renderServeWorkspace: renderServeWorkspace,
+  setDockerfiles: function (d) { studioDockerfiles = d; },
+};
+window.__setShown = function (id) { shownServeId = id; };
+`;
+
+interface Harness {
+  window: any;
+  document: any;
+  close: () => void;
+}
+
+function composer(
+  h: Harness,
+  kind: 'ecs' | 'ecs-task',
+  meta: { pinned?: boolean; pinUnresolved?: boolean }
+) {
+  const t = h.window.__t;
+  t.setDockerfiles(['Dockerfile']);
+  const dot = h.document.createElement('span');
+  const btnSlot = h.document.createElement('span');
+  t.serveMeta.set('S/Svc', {
+    dot,
+    btnSlot,
+    kind,
+    pinned: meta.pinned === true,
+    pinUnresolved: meta.pinUnresolved === true,
+    backingPinnedServices: [],
+  });
+  t.serveState.set('S/Svc', { status: 'stopped', endpoints: [] });
+  h.window.__setShown('S/Svc');
+  t.renderServeWorkspace('S/Svc');
+  return t;
+}
+
+const HINT_TEXT = 'set --from-cfn-stack in the Session bar';
+
+describe('studio composer pin-unresolved hint', () => {
+  for (const kind of ['ecs', 'ecs-task'] as const) {
+    it(`renders the Session-bar hint (no picker) for a ${kind} target that is pinUnresolved`, () => {
+      const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+      try {
+        composer(h, kind, { pinUnresolved: true });
+        const ws = h.document.querySelector('#workspace') as any;
+        // The hint is shown...
+        expect(ws.textContent).toContain('Image override unavailable');
+        expect(ws.textContent).toContain(HINT_TEXT);
+        // ...and the Dockerfile picker is NOT (it cannot be resolved yet).
+        expect(h.document.querySelectorAll('.image-override-select').length).toBe(0);
+      } finally {
+        h.close();
+      }
+    });
+  }
+
+  it('renders the Dockerfile picker (NOT the hint) for a classified-pinned target', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      // pinned wins over pinUnresolved (they are mutually exclusive in
+      // practice, but assert the picker branch takes precedence).
+      composer(h, 'ecs', { pinned: true, pinUnresolved: true });
+      const ws = h.document.querySelector('#workspace') as any;
+      expect(h.document.querySelectorAll('.image-override-select').length).toBe(1);
+      expect(ws.textContent).not.toContain('Image override unavailable');
+    } finally {
+      h.close();
+    }
+  });
+
+  it('renders neither hint nor picker for an unmarked (local-asset) target', () => {
+    const h = createStudioHarness({ epilogue: EXPOSE }) as Harness;
+    try {
+      composer(h, 'ecs', {});
+      const ws = h.document.querySelector('#workspace') as any;
+      expect(h.document.querySelectorAll('.image-override-select').length).toBe(0);
+      expect(ws.textContent).not.toContain('Image override unavailable');
+      expect(ws.textContent).not.toContain(HINT_TEXT);
+    } finally {
+      h.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl studio` lists an ECS service / task definition with an **intrinsic-ECR
image** (e.g. `ContainerImage.fromEcrRepository(repo)`), but can only classify
it as a deployed-registry pin — and offer the image-override Dockerfile picker —
when `--from-cfn-stack` is bound. Without that binding the classify throws and
the target is left unmarked. The terminal already WARNs with the
`--from-cfn-stack` remedy (issue #484), but a **browser-only studio user never
sees the terminal**, so the picker silently never appears and there is no in-UI
reason why.

This surfaces the same remedy in the browser: the unresolved (but not pinned)
entry is marked `pinUnresolved`, and the serve composer renders an in-UI hint
pointing at the Session-bar `--from-cfn-stack` setting, where the Dockerfile
picker would otherwise be.

## Implementation

- `makePinClassifier` / `makeTaskPinClassifier` gain an optional `onUnresolved`
  callback, fired in the `catch` **only when `stateBound === false`** — the same
  gate as the existing terminal remedy (`pinClassifyStateHint`). A local-asset
  target classifies cleanly (no throw, never fires); a state-bound failure keeps
  the resolver's own error (which names the real cause), so the hint is not
  shown when `--from-cfn-stack` is already set.
- `classifyStudioTargets` collects the unresolved ids and marks matching
  `ecs` / `ecs-task` entries `pinUnresolved`, kept **mutually exclusive with
  `pinned`** (a resolved pin gets the picker, not the hint). It runs on a
  `structuredClone` of the un-annotated base, so the flag appears / disappears
  under a Session-bar `--from-cfn-stack` toggle exactly like the picker does.
- `StudioTarget` gains an optional `pinUnresolved` field (`GET /api/targets`);
  `studio-ui` renders the hint in an `else if` after the pinned-picker branch
  (pinned wins).

## Behavior change (additive, inherited automatically)

`GET /api/targets` now carries an optional `pinUnresolved` field on ecs /
ecs-task entries, and the studio composer renders a new hint. Purely additive —
the existing `pinned` flag and all other output are unchanged, and a host
embedding `createLocalStudioCommand` gets this for free on the next bump. cdkd
tracking issue: https://github.com/go-to-k/cdkd/issues/787

## Test plan

- **Unit**: classifier `onUnresolved` fires (throw + unbound) / suppresses
  (throw + bound; clean classify) for BOTH classifiers; `classifyStudioTargets`
  sets `pinUnresolved` unbound and clears it bound; `studio-ui` renders the hint
  (ecs + ecs-task), picker-wins-over-hint, and neither-for-local-asset. 3126
  unit tests pass.
- **Integ** (`local-studio-from-cfn-stack`, real AWS): asserts the
  intrinsic-ECR service is `pinUnresolved:true` WITHOUT `--from-cfn-stack` and
  absent (pinned instead) WITH it. Green, 0 Docker / CloudFormation orphans.
- **Live-test**: booted the real studio server against the intrinsic-ECR
  fixture without `--from-cfn-stack`; `GET /api/targets` reports
  `pinUnresolved:true` on both the service and the task definition.

## Review notes

`/review-pr` (1-reviewer tier) returned no blockers. Two nits, both accepted as
harmless: (1) the `if (unresolvedPinIds.size > 0)` guard around the marking loop
is a redundant micro-skip (kept for explicit intent); (2) the studio-ui test
seeds a partial `serveMeta` omitting agentcore-only fields (irrelevant for
ecs / ecs-task, matches existing harness practice).
