### PR TITLE
chore(deps): bump pnpm to v11.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/go-to-k/cdk-local/issues"
   },
   "type": "module",
-  "packageManager": "pnpm@11.1.0",
+  "packageManager": "pnpm@11.15.0",
   "keywords": [
     "aws",
     "cdk",


### PR DESCRIPTION
## Summary

Bumps the pinned package manager from pnpm 11.1.0 to **pnpm 11.15.0** (current `latest`). Mirrors go-to-k/cdk-real-drift#1672, adapted to this repo:

- cdk-local was already on pnpm 11, so this is the minor pin refresh only.
- No package.json `pnpm` field exists here, so the settings migration to `pnpm-workspace.yaml` that cdk-real-drift needed does not apply — no new file.

## Verification

- `pnpm-lock.yaml` is **untouched** by this PR: a full pnpm 11.15.0 install reproduces the identical lockfile — no conflict surface with other open PRs.
- `vp install --frozen-lockfile` honors the `packageManager` pin and runs **pnpm v11.15.0** locally — CI takes the same path.
- `vp run check` (0 errors) / `vp run build` + `node dist/cli.js --version` smoke / `vp test run` (208 files / 3126 tests) — all pass under the pnpm 11.15.0 install.
