### PR TITLE
docs: require a scoped Remaining-work section + Session-close verdict on wrap

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1410,6 +1410,32 @@ vp run runtime:smoke
   collisions → claim → file-disjoint lanes → `/verify-pr` → `/merge-pr`);
   `/hunt-bugs` is the companion sweep that files the issues. Skip the claim
   only for a trivial change you will PR within minutes.
+- **Every session-wrap / task-complete report MUST end with a "Remaining
+  work" section AND a "Session close" verdict — unprompted** (mirrors
+  go-to-k/cdkd#1257 and #1262; the user should never have to ask "any
+  follow-up tasks?" or "can I close this session?"). **Scope: only work
+  THIS session created or touched.** The section reports residuals of the
+  task just finished: gaps in what was shipped, polish deferred while doing
+  it, and issues filed BECAUSE of this work. It is NOT a backlog dump. Do
+  not list pre-existing open issues that merely happen to be unresolved,
+  and once the session moves on to an unrelated task, stop carrying forward
+  items from the earlier unrelated work. If the current work leaves nothing
+  behind, the answer is "Nothing remaining" even when the repo has open
+  issues elsewhere. **Remaining work** — exactly one of: **TODO (issue
+  #N)** (work that still needs doing later; the ONLY bucket meaning
+  follow-ups exist — every entry MUST have a GitHub issue number, filed
+  BEFORE reporting); **Won't-do (decided + recorded)** (things consciously
+  decided AGAINST doing, with a one-line reason and where the decision is
+  recorded — PR body, in-code comment, issue comment; no action needed);
+  **Nothing remaining** (an explicit statement after actually auditing for
+  deferred polish and reviewer nits). Same taxonomy as the `/verify-pr`
+  nit sweep. **Session close** — a one-line verdict: **CLOSEABLE** or
+  **NOT CLOSEABLE (waiting on: ...)** naming the blocker. CLOSEABLE
+  requires ALL of: working tree clean and no dangling feature branch; no
+  open PRs owned by this session; no running background tasks / integs /
+  subagents; no leftover Docker containers or networks from local runs
+  (`docker ps --filter name=cdkl-`, `docker network ls --filter
+  name=cdkl-task-`); every TODO filed as an issue.
 
 ## Positioning when communicating
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -276,3 +276,9 @@ anything non-obvious you learned in memory.
 - **Never defer integration tests to a later PR** — every slice ships its own integ
   coverage green before merge. (`.claude/CLAUDE.md` → Workflow rules.)
 - **Never download/run/install untrusted third-party content** (§0).
+- **Wrap with a Remaining-work section + Session-close verdict, scoped to the
+  issues this run actually worked.** This skill is the easiest place to get that
+  scope wrong: it starts from a backlog, so the issues you triaged but did NOT
+  pick up look like follow-ups. They are not. List only residuals of the lanes
+  you shipped (gaps, deferred polish, issues filed because of this work).
+  (`CLAUDE.md` → Workflow rules.)


### PR DESCRIPTION
## Summary

Requires every session-wrap report to end with a **Remaining work** section and
a **Session close** verdict, with the scope stated up front. Mirrors
go-to-k/cdkd#1257 (the rule) and go-to-k/cdkd#1262 (the scope clause).

The `/verify-pr` nit sweep already uses the fixed / TODO / won't-do taxonomy
(#495), but nothing required the session wrap itself to report remaining work,
so the user had to ask "any follow-up tasks?" each time. And where the rule does
exist in sibling repos, it was being filled with pre-existing open issues that
had nothing to do with the task just finished, which buries the residuals that
matter and reads as a backlog dump.

This adds the rule with the scope explicit: it reports what THIS session created
or touched (gaps in what was shipped, polish deferred while doing it, issues
filed because of this work), not unrelated open issues elsewhere in the repo.

Two adaptations for this repo:

- The Session-close checklist uses this repo's own Docker sweep
  (`docker ps --filter name=cdkl-`, `docker network ls --filter name=cdkl-task-`)
  instead of an AWS-resource cleanup check.
- The `work-issues` skill gets the same note, since it starts from a backlog and
  is therefore the easiest place to get the scope wrong.

## Test plan

Documentation only (CLAUDE.md rule plus one bullet in a skill). No source or
behavior change.
