### PR TITLE
chore(hooks): scope branch gates to opted-in repos

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -85,6 +85,18 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Repo opt-in scope (cdkd#1259): this gate protects repos that follow
+# the feature-branch + PR + markgate convention. A session rooted in
+# such a repo can still run git against OTHER repos (a personal blog, a
+# scratch clone) where committing straight to main is the normal
+# workflow; the gate must not fire there. Opt-in signal: a
+# `.markgate.yml` at the resolved target repo's top level. Repos
+# without it pass through untouched.
+target_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "")
+if [[ -z "$target_top" || ! -f "$target_top/.markgate.yml" ]]; then
+  exit 0
+fi
+
 # Read the branch from the resolved target dir. `-C` lets git operate
 # on a directory that isn't our cwd; if the dir doesn't exist or isn't
 # inside a git repo, symbolic-ref returns empty and we fall through to

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -103,6 +103,15 @@ if [[ -z "$main_tree" ]]; then
   exit 0
 fi
 
+# Repo opt-in scope (cdkd#1259): only repos following the worktree +
+# markgate convention get main-tree branch protection. Unrelated repos
+# (a personal blog, a scratch clone) have no parallel-agent contention
+# on their main tree. Opt-in signal: a `.markgate.yml` at the main
+# worktree root.
+if [[ ! -f "$main_tree/.markgate.yml" ]]; then
+  exit 0
+fi
+
 # Canonicalize both sides before compare. macOS resolves
 # `/tmp` → `/private/tmp` and `/var` → `/private/var` via symlinks;
 # `git worktree list --porcelain` always emits the real path, while


### PR DESCRIPTION
## Summary
- Port of go-to-k/cdkd#1259 (fixed in cdkd by go-to-k/cdkd#1264): branch-gate.sh and main-tree-branch-gate.sh resolved their target repo from the tool call and fired in ANY git repository a session touched, including unrelated personal repos whose normal workflow is committing straight to main.
- Both hooks now early-exit unless the resolved target repo carries a `.markgate.yml` at its root (the opt-in signal). cdk-local behavior is unchanged.

## Test plan
- [x] Live-tested: patched branch-gate and main-tree-branch-gate pass (exit 0) against a repo without `.markgate.yml` on main, and still block (exit 2) against the cdk-local main tree