### PR TITLE
chore(markgate): adopt `hash: diff` for the integ gate so an unrelated main merge stops forcing a Docker re-run

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1243,7 +1243,10 @@ vp run runtime:smoke
   scopes need neither). `/verify-pr` refreshes both in one shot.
   Per-gate scopes, error-message decoding, and other details:
   [.claude/rules/hooks.md](.claude/rules/hooks.md). Install `vp` +
-  `markgate` via `mise install` at the repo root.
+  `markgate` via `mise install` at the repo root, and re-run it after
+  any pull that changes `.mise.toml` — an older markgate binary rejects
+  a newer `.markgate.yml` for every gate at once, and the hook hides the
+  parse error behind a misleading "run /check first".
 
 - **Before opening or merging any PR**: `verify-pr-gate.sh` blocks
   `gh pr create` / `gh pr merge` unless the `verify-pr` marker

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1309,7 +1309,15 @@ vp run runtime:smoke
   Skipping any step risks setting the `integ` marker on incomplete
   verification. The `integ-gate.sh` hook blocks
   `gh pr merge` when `src/**` or `tests/integration/**` is touched
-  and the marker is stale.
+  and the marker is stale. `integ` is the one gate on markgate's
+  `hash: diff` mode (0.4+): its digest is THIS branch's delta against
+  `merge-base(origin/main, HEAD)` within that scope, so merging an
+  updated `main` that moved an in-scope file this branch did not touch
+  no longer forces a Docker re-run, while your own in-scope changes
+  (and the 14d TTL) still stale it. Set the marker from the PR's own
+  worktree on the PR branch — on a clean `main` the empty delta makes
+  markgate refuse rather than silently pass.
+  Details: [.claude/rules/hooks.md](.claude/rules/hooks.md).
 
 - **After running integration tests**: verify no leftover Docker
   containers / networks remain (`docker ps --filter name=cdkl-`,

--- a/.claude/hooks/integ-gate.sh
+++ b/.claude/hooks/integ-gate.sh
@@ -3,13 +3,20 @@
 #
 # PreToolUse hook. Blocks `gh pr merge` (including --auto) and
 # `git merge` unless the `integ` markgate marker is fresh for
-# the current content state. The gate's scope (see .markgate.yml)
-# covers `src/**` and `tests/integration/**`; editing any of them
-# invalidates the marker and forces a successful Docker-based
-# `/run-integ <test-name>` run before the PR can be merged.
+# the current branch delta. The gate's scope (see .markgate.yml)
+# covers `src/**` and `tests/integration/**`; a change THIS BRANCH
+# makes to any of them invalidates the marker and forces a successful
+# Docker-based `/run-integ <test-name>` run before the PR can be merged.
+#
+# The gate runs on markgate's `hash: diff` mode (0.4+): the digest is
+# this branch's delta against `merge-base(origin/main, HEAD)` restricted
+# to that scope, NOT the working tree's content. So a `main` merge /
+# rebase that moves an in-scope file this branch did not touch leaves
+# the marker fresh, while an overlapping `main` change still stales it.
+# See .claude/rules/hooks.md "integ-gate (pre-merge)" and issue #498.
 #
 # The `.markgate.yml` integ gate also carries a 14-day TTL on top
-# of the file-scope check, so the marker decays even when nothing
+# of the diff-scope check, so the marker decays even when nothing
 # changed in the repo — Docker base-image behavior, RIE binary, and
 # host network plumbing drift over time, so a marker more than two
 # weeks old no longer proves today's local code path works.
@@ -122,8 +129,18 @@ fi
 # Extract the parenthesized reason from `markgate status integ` so
 # the error message tells the user *why* the gate is stale. With the
 # 14d TTL configured in .markgate.yml, the stale reason is either
-# "(digest differs)" (a src/** or tests/integration/** file changed)
-# or "(expired by ttl: 14d, marker is Nd old)" (the marker aged out).
+# "(digest differs)" (this branch's src/** or tests/integration/**
+# delta changed) or "(expired by ttl: 14d, marker is Nd old)" (the
+# marker aged out). The `state:` line format is unchanged by the
+# `hash: diff` mode — it only adds `base:` / `merge base:` lines
+# above, so this awk still finds the parenthetical.
+#
+# Under `hash: diff`, `markgate status` can also exit 2 with a
+# "no delta against merge-base" error (empty branch delta, i.e. a
+# clean base branch). That writes to stderr, so `reason` comes back
+# empty and the generic message below is used. The scope
+# short-circuit above already exits 0 in that situation for any PR
+# that touches neither src/** nor tests/integration/**.
 reason=$("${markgate[@]}" status integ 2>/dev/null \
   | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
 

--- a/.claude/hooks/integ-gate.sh
+++ b/.claude/hooks/integ-gate.sh
@@ -101,8 +101,13 @@ cd "$target_dir" 2>/dev/null || exit 0
 # base used by `create-integ-gate.sh` / `cdkd-parity-gate.sh`.
 #
 # Only short-circuit when the diff is computable. If origin/main is
-# unresolvable (fresh clone, detached state), fall through to the marker
-# check — the conservative choice, never weaker than the prior behavior.
+# unresolvable (fresh clone, a worktree that never fetched), fall
+# through — but note that under `hash: diff` this is NOT a marker check
+# any more: markgate exits 2 on an unresolvable base ref for `verify`,
+# `status` and `set` alike, so the merge is blocked with the generic
+# message and re-running `/run-integ` CANNOT clear it (its own
+# `markgate set integ` fails the same way). The fix is `git fetch
+# origin`. Still conservative — it blocks rather than passes.
 if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
   if ! git diff origin/main...HEAD --name-only 2>/dev/null \
       | grep -qE '^(src/|tests/integration/)'; then
@@ -136,11 +141,13 @@ fi
 # above, so this awk still finds the parenthetical.
 #
 # Under `hash: diff`, `markgate status` can also exit 2 with a
-# "no delta against merge-base" error (empty branch delta, i.e. a
-# clean base branch). That writes to stderr, so `reason` comes back
-# empty and the generic message below is used. The scope
-# short-circuit above already exits 0 in that situation for any PR
-# that touches neither src/** nor tests/integration/**.
+# "no delta against merge-base" error (empty TOTAL branch delta, i.e.
+# a clean base branch) or a 'base ref does not resolve' error. Both
+# write to stderr, so `reason` comes back empty and the generic
+# message below is used. The empty-delta one cannot actually reach
+# here: an empty delta means an empty diff, so the scope short-circuit
+# above always exits 0 first. Note an empty IN-SCOPE delta is a
+# different thing — markgate ACCEPTS it with a warning and exit 0.
 reason=$("${markgate[@]}" status integ 2>/dev/null \
   | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -187,6 +187,15 @@ construction.
   `.markgate.yml`) need neither. The hook is a safety net, not the
   primary trigger.
 
+  **Run `mise install` after pulling a change to `.mise.toml`.** An
+  older markgate binary rejects a newer `.markgate.yml` (an unknown
+  `hash:` value fails config parsing for EVERY gate, not just the one
+  that uses it), and this hook discards markgate's stderr — so the
+  symptom is a misleading "run /check first" that re-running `/check`
+  cannot clear. The hook's preferred `mise exec -- markgate` path
+  installs the pinned version on demand; its `command -v markgate`
+  fallback, used when mise is absent, does not.
+
 ### verify-pr-gate (pre-create + pre-merge)
 
 - **`verify-pr-gate.sh`** blocks `gh pr create` and `gh pr merge`
@@ -280,19 +289,37 @@ deltas never overlap and the marker stays fresh though the combination
 is unverified. `hash: files` caught that incidentally; the 14d TTL
 still forces a periodic Docker run. See issue #498 for the measurement
 behind adopting it here and NOT for `cdkd-parity` / `create-integ`
-(both scoped to the small, hot `src/cli/commands/**` directory, where
+(both centred on the small, hot `src/cli/commands/**` directory —
+`cdkd-parity` also covers `src/internal.ts` / `src/index.ts` — where
 half the invalidations are genuine overlaps) or `check` / `docs`
 (cheap to re-run, so strictness costs nothing).
 
-One operational consequence: `hash: diff` refuses (exit 2, "no delta
-against merge-base") when run from a branch with an empty delta vs its
-base — a clean `main`, typically. That is louder than a silent pass,
-and it does not reach the gate in practice: the scope short-circuit
-below exits 0 first for any PR whose diff touches neither `src/**` nor
-`tests/integration/**`, and a PR that does touch them has a non-empty
-delta by construction. If the error ever does surface, `markgate
-status` writes it to stderr, the reason extraction yields nothing, and
-the hook falls back to its generic blocked message.
+Two operational consequences, both louder than a silent pass:
+
+- **Empty TOTAL delta is refused** (exit 2, "no delta against
+  merge-base") — typically a clean `main`. The empty check runs BEFORE
+  include/exclude filtering, so it cannot be reached through the gate: a
+  branch with no delta at all also has no diff, and the scope
+  short-circuit below exits 0 first. If the error ever does surface,
+  `markgate status` writes it to stderr, the reason extraction yields
+  nothing, and the hook falls back to its generic blocked message.
+- **Empty IN-SCOPE delta is ACCEPTED**, with a warning and exit 0:
+  `hash=diff recorded an empty in-scope delta (include: src/**,
+  tests/integration/**); this branch changes nothing the gate covers,
+  so the marker stays fresh until it does`. A docs-only branch is the
+  normal case. Do not read that warning as the refusal above — the
+  marker IS written, and `verify` returns 0.
+
+**Unresolvable `base` ref is a hard stop, and `/run-integ` cannot clear
+it.** When `origin/main` does not resolve (fresh clone, a worktree that
+has never fetched), markgate exits 2 for `verify`, `status` AND `set`
+alike: `hash=diff: base ref "origin/main" does not resolve; fetch it
+first (git fetch origin)`. The hook's short-circuit is skipped in that
+state too (it needs the same ref), so the merge is blocked with the
+generic message — and re-running `/run-integ` cannot fix it, because
+its `markgate set integ` fails identically. **The fix is `git fetch
+origin`**, after which `set` succeeds normally. Under `hash: files`
+this situation degraded to an ordinary marker check; it no longer does.
 
 **Scope short-circuit.** Before consulting the marker, the hook diffs
 the PR vs `origin/main` (`git diff origin/main...HEAD --name-only`, the
@@ -303,7 +330,9 @@ worktree (per-worktree marker isolation means a new worktree starts
 with none), so a docs / hooks / skills-only PR would be wrongly blocked
 and forced into an irrelevant Docker run. The short-circuit only fires
 when the diff is computable; if `origin/main` is unresolvable it falls
-through to the marker check (conservative — never weaker than before).
+through — but under `hash: diff` that is no longer a marker check, it
+is an unconditional block (markgate exits 2 on the unresolvable base,
+see above). Run `git fetch origin`, not `/run-integ`.
 
 The skill is the ONLY legitimate setter of this marker — never
 call `markgate set integ` directly from a shell.

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -250,11 +250,49 @@ empty. `integ-gate.sh` is installed and consults it.
 `integ-gate.sh` blocks `gh pr merge` on PRs whose
 diff touches `src/**` or `tests/integration/**` when the `integ`
 marker is stale (digest differs OR expired by the 14-day TTL).
-The 14d TTL is on top of the file-scope check — Docker base-image
+The 14d TTL is on top of the diff-scope check — Docker base-image
 behavior (`public.ecr.aws/lambda/*`, RIE binary), `dockerd`
 semantics, and chokidar / network plumbing drift even when the
 repo doesn't, so a marker more than two weeks old no longer proves
 today's local code path actually works.
+
+**`hash: diff`, not `hash: files` (markgate 0.4+).** `integ` is the
+only gate on the diff mode. Its digest is this branch's delta against
+`merge-base(origin/main, HEAD)` restricted to the include set, rather
+than the working tree's content, so it can tell a change THIS BRANCH
+made from one that arrived from `main`:
+
+| event | marker |
+|---|---|
+| `main` moves an in-scope file this branch did NOT touch | **fresh** |
+| `main` moves an in-scope file this branch ALSO touched | stale |
+| in-scope edit on this branch (committed or not) | stale |
+| out-of-scope edit | fresh |
+
+Pulling / rebasing onto an updated `main` therefore stops forcing an
+irrelevant Docker re-run — every incoming change already passed this
+same gate in its own PR. `base: origin/main` is mandatory for the mode
+(no `origin/HEAD` fallback: that ref is frequently unset in CI clones,
+which would make the gate mean different things locally and in CI).
+Accepted limitation: cross-file interaction is invisible — if this
+branch changes A and `main` changes B and a caller uses both, the
+deltas never overlap and the marker stays fresh though the combination
+is unverified. `hash: files` caught that incidentally; the 14d TTL
+still forces a periodic Docker run. See issue #498 for the measurement
+behind adopting it here and NOT for `cdkd-parity` / `create-integ`
+(both scoped to the small, hot `src/cli/commands/**` directory, where
+half the invalidations are genuine overlaps) or `check` / `docs`
+(cheap to re-run, so strictness costs nothing).
+
+One operational consequence: `hash: diff` refuses (exit 2, "no delta
+against merge-base") when run from a branch with an empty delta vs its
+base — a clean `main`, typically. That is louder than a silent pass,
+and it does not reach the gate in practice: the scope short-circuit
+below exits 0 first for any PR whose diff touches neither `src/**` nor
+`tests/integration/**`, and a PR that does touch them has a non-empty
+delta by construction. If the error ever does surface, `markgate
+status` writes it to stderr, the reason extraction yields nothing, and
+the hook falls back to its generic blocked message.
 
 **Scope short-circuit.** Before consulting the marker, the hook diffs
 the PR vs `origin/main` (`git diff origin/main...HEAD --name-only`, the

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -68,11 +68,11 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    mise exec -- markgate set integ
    ```
 
-   If any of the above failed, do NOT set the marker — that is the whole point of the gate. The `integ` gate (see `.markgate.yml`) blocks `gh pr merge` for any PR that touches `src/**` or `tests/integration/**` until this marker is fresh.
+   If any of the above failed, do NOT set the marker — that is the whole point of the gate. The `integ` gate (see `.markgate.yml`) blocks `gh pr merge` for any PR that touches `src/**` or `tests/integration/**` until this marker is fresh. Set the marker from the PR's own worktree, on the PR branch: the gate uses markgate's `hash: diff` mode, whose digest is that branch's delta against `merge-base(origin/main, HEAD)` — so a marker recorded on a clean `main` is not just wrong, it is refused (`no delta against merge-base`, exit 2).
 
 ## Important
 
 - **Never bypass this skill** by invoking the fixture's `verify.sh` directly from a shell — the cleanup verification + markgate set are part of the contract.
 - **Never call `markgate set integ` directly** to skip the verification. The marker only earns its place by completing the full sequence above.
 - Always confirm the test name is on the official list (`ls tests/integration/`) — typos lead to confusing "no verify.sh" errors.
-- The 14-day TTL on the marker (see `.markgate.yml`) accepts that Docker base-image behavior drifts over time even when the repo doesn't; re-running an integ after two weeks is the explicit revalidation.
+- The 14-day TTL on the marker (see `.markgate.yml`) accepts that Docker base-image behavior drifts over time even when the repo doesn't; re-running an integ after two weeks is the explicit revalidation. It is also what bounds `hash: diff`'s accepted blind spot — a caller broken by this branch changing A while `main` changed B produces no delta overlap, so only the TTL forces the eventual re-run.

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -65,10 +65,18 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    record the gate so subsequent `gh pr merge` calls are unblocked:
 
    ```bash
-   mise exec -- markgate set integ
+   mise exec -- markgate set integ || echo "MARKER NOT RECORDED — read the error above"
    ```
 
-   If any of the above failed, do NOT set the marker — that is the whole point of the gate. The `integ` gate (see `.markgate.yml`) blocks `gh pr merge` for any PR that touches `src/**` or `tests/integration/**` until this marker is fresh. Set the marker from the PR's own worktree, on the PR branch: the gate uses markgate's `hash: diff` mode, whose digest is that branch's delta against `merge-base(origin/main, HEAD)` — so a marker recorded on a clean `main` is not just wrong, it is refused (`no delta against merge-base`, exit 2).
+   **Check the exit code; do not assume the set succeeded.** Under `hash: files` this command could not fail, so it was safe to fire and forget. Under `hash: diff` it CAN fail, and it reports the reason on stderr — an unchecked call looks silent and successful while nothing was recorded. The failure modes and their fixes:
+
+   - `no delta against merge-base(origin/main, HEAD)` — you are on the base branch. Re-run from the PR's own worktree, on the PR branch.
+   - `base ref "origin/main" does not resolve` — run `git fetch origin`, then set again. Re-running the whole integ does NOT help; the set fails identically until the ref exists.
+   - `hash=diff recorded an empty in-scope delta` — this is a WARNING, not a failure: the marker WAS saved and the exit code is 0. It only means the branch changes nothing under `src/**` / `tests/integration/**`.
+
+   Confirm with `mise exec -- markgate status integ` (expect `state: match`) before reporting the run as complete. The expensive failure this prevents: a full Docker fixture run finishes, the marker is silently not recorded, the merge stays blocked, and the natural reaction is to run the integ AGAIN rather than fetch.
+
+   If any of the above failed, do NOT set the marker — that is the whole point of the gate. The `integ` gate (see `.markgate.yml`) blocks `gh pr merge` for any PR that touches `src/**` or `tests/integration/**` until this marker is fresh. Set the marker from the PR's own worktree, on the PR branch: the gate uses markgate's `hash: diff` mode, whose digest is that branch's delta against `merge-base(origin/main, HEAD)`.
 
 ## Important
 

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -26,7 +26,7 @@ Run each check and report pass/fail:
 2. **Tests**
    - `vp run test` — all unit tests pass
    - Report test count (files and tests)
-   - **Test coverage check**: compare `git diff main...HEAD` for `src/` changes vs `tests/` changes. If new logic was added or modified in `src/` but no corresponding test files were added or updated, flag as **fail** and add the missing tests before proceeding.
+   - **Test coverage check**: compare `git diff origin/main...HEAD` for `src/` changes vs `tests/` changes. If new logic was added or modified in `src/` but no corresponding test files were added or updated, flag as **fail** and add the missing tests before proceeding.
 
 3. **CI status**
    - If PR number is not provided as argument, auto-detect via `gh pr view --json number -q .number`
@@ -63,7 +63,7 @@ Run each check and report pass/fail:
 
    ```bash
    # Only check when the PR diff actually touches the gate scope.
-   if git diff main...HEAD --name-only | grep -qE '^src/|^tests/integration/'; then
+   if git diff origin/main...HEAD --name-only | grep -qE '^src/|^tests/integration/'; then
      mise exec -- markgate verify integ
    fi
    ```
@@ -84,7 +84,7 @@ Run each check and report pass/fail:
 
      The skill applies bias factors (security surfaces bump up; pure-infra / docs / tests-only bump down). Trust the recommendation; override only when you have a concrete reason (note the reason here).
    - Synthesize the reviewer reports (or your inline read) into a pass / issues-found verdict. Any blocker → fix-back loop before continuing.
-   - `git diff main...HEAD` — confirm the diff is what you reviewed (no last-minute commits slipped through).
+   - `git diff origin/main...HEAD` — confirm the diff is what you reviewed (no last-minute commits slipped through).
    - For each change: is it correct? complete? necessary?
    - Check for:
      - Logic errors or unhandled edge cases.
@@ -128,9 +128,9 @@ Run each check and report pass/fail:
     - **Title check**: read `gh pr view <PR> --json title -q .title` and confirm it still describes the union of commits on the branch. Update via `gh api -X PATCH repos/{owner}/{repo}/pulls/{number} -f title="..."` (NOT `gh pr edit --title`, which fails silently due to GraphQL Projects-classic deprecation — see hook `gh-pr-edit-deprecation-gate.sh`).
     - **Body freshness commands**:
       - `gh pr view <PR> --json commits -q '.commits | length'` — commit count on the PR
-      - `git log main..HEAD --oneline | wc -l` — commit count locally
+      - `git log origin/main..HEAD --oneline | wc -l` — commit count locally
       - If they match and > 1, the PR has been iterated on; the initial body is almost certainly stale.
-    - Read the current body (`gh pr view <PR> --json body -q .body`) and compare against the actual final diff (`git diff main...HEAD`). Flag any of:
+    - Read the current body (`gh pr view <PR> --json body -q .body`) and compare against the actual final diff (`git diff origin/main...HEAD`). Flag any of:
       - Bullets describing behavior that was reverted in a later commit.
       - Bullets describing checks/validations the code no longer performs.
       - File:line citations that no longer exist.

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -59,7 +59,7 @@ Run each check and report pass/fail:
 
 7. **Docker + integ verification** (for src/** or tests/integration/** touches)
 
-   The `integ` markgate gate physically blocks `gh pr merge` when its marker is stale (see `.claude/hooks/integ-gate.sh` once shipped). The merge-time gate has a known blind spot: it reads the **local working tree** digest, and when `gh pr merge` runs from a parent worktree still on pre-PR `main`, the digest matches the old content and the gate passes silently — so an unverified change can reach main via the merge-from-parent path. `/verify-pr` runs in the PR's own worktree (post-PR content), so verifying the marker here closes that gap structurally:
+   The `integ` markgate gate physically blocks `gh pr merge` when its marker is stale (see `.claude/hooks/integ-gate.sh`). The gate runs on markgate's `hash: diff` mode, so the digest is **this branch's delta** against `merge-base(origin/main, HEAD)` within `src/**` / `tests/integration/**` — a `main` change to an in-scope file this branch did not touch no longer stales it, but any in-scope change this branch made does. The merge-time gate has a known blind spot: it reads the **local** git state, and when `gh pr merge` runs from a parent worktree still on pre-PR `main`, that tree's diff vs `origin/main` is empty, the hook's scope short-circuit exits 0, and the marker is never consulted — so an unverified change can reach main via the merge-from-parent path. `/verify-pr` runs in the PR's own worktree (post-PR content), so verifying the marker here closes that gap structurally:
 
    ```bash
    # Only check when the PR diff actually touches the gate scope.

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -27,6 +27,7 @@
 #                    chokidar / network behavior, dockerd semantics drift
 #                    over time, so a marker that's been clean for two
 #                    weeks no longer proves today's local code path works.
+#                    The only gate on `hash: diff` (see its block below).
 #   cdkd-parity    — Host-CLI (cdkd) parity review for library-surface
 #                    changes (new subcommand factory / new CLI option /
 #                    new public helper / behavior change). Set ONLY by
@@ -68,8 +69,29 @@ gates:
       - ".markgate-pr-review-sha"
 
   integ:
-    hash: files
-    # Wall-clock TTL on top of the file-scope check (markgate 0.3+).
+    # `hash: diff` (markgate 0.4+) digests this branch's delta against
+    # `merge-base(origin/main, HEAD)` restricted to the include set below,
+    # NOT the working tree's content. So a `main` merge / rebase that moves
+    # an in-scope file this branch did NOT touch leaves the marker fresh —
+    # that change already passed this same gate in its own PR — while a
+    # `main` change to a file this branch ALSO changed still stales it, as
+    # does any in-scope edit on this branch (committed or not). Adopted for
+    # `integ` only: re-running it costs a Docker fixture run, so the
+    # strictness `hash: files` buys is worth trading here. The narrower
+    # `cdkd-parity` / `create-integ` gates stay on `hash: files` — both are
+    # scoped to the small, hot `src/cli/commands/**` directory where half
+    # the invalidations are genuine overlaps, so the mode would buy almost
+    # nothing; `check` / `docs` stay strict because re-running them is
+    # cheap. Measurement + accepted limitation (a caller broken by this
+    # branch changing A while `main` changes B is invisible to `hash: diff`,
+    # bounded by the TTL below): issue #498.
+    #
+    # `base` is mandatory for `hash: diff` — there is no `origin/HEAD`
+    # fallback, since that ref is frequently unset in CI clones and the gate
+    # must mean the same thing locally and in CI.
+    hash: diff
+    base: origin/main
+    # Wall-clock TTL on top of the diff-scope check (markgate 0.3+).
     # Docker base-image behavior (`public.ecr.aws/lambda/*`, RIE binary),
     # `dockerd` semantics, and chokidar / network plumbing drift even
     # when the repo doesn't. 14d matches cdkd's integ-local gate —

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -1,9 +1,15 @@
 # markgate configuration — https://github.com/go-to-k/markgate
 #
-# Seven gates back the pre-commit / pre-PR / pre-merge checks for cdk-local.
+# Eight gates back the pre-commit / pre-PR / pre-merge checks for cdk-local.
 # cdk-local does NOT deploy to AWS (no destroy path, no schema migration,
 # no broad real-AWS integ matrix), so the destroy / broad / schema-migration
 # gates from cdkd are not needed.
+#
+# After pulling a change to this file OR to `.mise.toml`, run `mise install`.
+# An older markgate binary rejects a newer config outright — an unknown
+# `hash:` value fails parsing for EVERY gate, not just the one using it —
+# and the gate hooks discard markgate's stderr, so the symptom is a
+# misleading "run /check first" that re-running `/check` cannot clear.
 #
 # Gates:
 #   check          — typecheck/lint/build/unit tests
@@ -37,6 +43,9 @@
 #                    brand-new subcommand) MUST ship its own integ fixture.
 #                    Set ONLY by /create-integ, which scaffolds + RUNS the
 #                    new fixture. Pre-create only, like cdkd-parity.
+#   merge-pr       — Forces a worktree `gh pr merge` through the /merge-pr
+#                    skill. TTL-only (30m), no file hash — see its block
+#                    below for why a content digest cannot work here.
 
 gates:
   check:
@@ -79,8 +88,9 @@ gates:
     # `integ` only: re-running it costs a Docker fixture run, so the
     # strictness `hash: files` buys is worth trading here. The narrower
     # `cdkd-parity` / `create-integ` gates stay on `hash: files` — both are
-    # scoped to the small, hot `src/cli/commands/**` directory where half
-    # the invalidations are genuine overlaps, so the mode would buy almost
+    # centred on the small, hot `src/cli/commands/**` directory (cdkd-parity
+    # also covers `src/internal.ts` / `src/index.ts`) where half the
+    # invalidations are genuine overlaps, so the mode would buy almost
     # nothing; `check` / `docs` stay strict because re-running them is
     # cheap. Measurement + accepted limitation (a caller broken by this
     # branch changing A while `main` changes B is invisible to `hash: diff`,

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"ubi:go-to-k/markgate" = "0.4.0"
+"ubi:go-to-k/markgate" = "0.4.1"
 
 [tools."http:vp"]
 version = "0.1.20"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"ubi:go-to-k/markgate" = "0.3.3"
+"ubi:go-to-k/markgate" = "0.4.0"
 
 [tools."http:vp"]
 version = "0.1.20"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ mise trust       # one-time, when you check out a fresh clone
 pnpm install     # workspace deps
 ```
 
+Re-run `mise install` whenever a pull changes `.mise.toml` — the pinned
+markgate version and `.markgate.yml` move together, and an older binary
+rejects a newer config outright rather than degrading gracefully.
+
 The shipped runtime targets **Node 20+**; CI runs the Node 20 / 22 / 24
 matrix.
 


### PR DESCRIPTION
## Summary

The `integ` gate digested working-tree **content** (`hash: files`), so it could not
tell a change this branch made from one that arrived from `main`. Pulling or
rebasing onto an updated `main` invalidated the marker and forced a Docker fixture
re-run even when every incoming change was unrelated — and each of those changes had
already passed this same gate in its own PR. Measured over the last 250 merged PRs
(58.7 days): 26 invalidations, 20 of them (77%) caused purely by another PR's
unrelated in-scope change.

markgate 0.4 adds `hash: diff`, whose digest is the branch's delta against
`merge-base(base, HEAD)` restricted to the gate's include set. This PR adopts it for
the `integ` gate and nothing else.

| event | `hash: files` (before) | `hash: diff` (now) |
|---|---|---|
| `main` moves an **unrelated** in-scope file | stale | **fresh** |
| `main` moves a file this branch **also** changed | stale | stale |
| in-scope edit on this branch (committed or not) | stale | stale |
| out-of-scope edit | fresh | fresh |

## Changes

- `.mise.toml` — `ubi:go-to-k/markgate` `0.3.3` -> `0.4.1`. Nothing in
  `.github/workflows/**` installs mise or markgate, so CI is unaffected. (`v0.4.2`
  exists but is a re-tag of the identical commit — `compare/v0.4.1...v0.4.2` reports
  `ahead_by: 0`, no commits, no files — so the pin loses nothing by naming `0.4.1`.)
- `.markgate.yml` — the `integ` gate only: `hash: diff` + `base: origin/main`.
  `ttl: 14d` and the `include` list (`src/**`, `tests/integration/**`) are byte-identical.
- Prose brought in line with the config: `.claude/rules/hooks.md` (integ-gate section),
  `.claude/CLAUDE.md` (integ workflow bullet), `.claude/skills/run-integ/SKILL.md`,
  `.claude/skills/verify-pr/SKILL.md`, and the header comments in
  `.claude/hooks/integ-gate.sh`. No hook logic changed — comments only.

## Gates deliberately NOT switched

- **`cdkd-parity` / `create-integ`** stay on `hash: files`. Both are centred on the small,
  hot `src/cli/commands/**` directory (`cdkd-parity` also covers `src/internal.ts` /
  `src/index.ts`), where half their invalidations (5 of 10 each) are
  genuine overlaps — exactly the case `hash: diff` still catches, and where it therefore
  buys almost nothing. The measurement in the issue is the record of that decision;
  re-measure before revisiting rather than assuming the narrow gates behave like the broad one.
- **`check` / `docs`** stay on `hash: files`: re-running them is cheap, `hash: files` is the
  stricter mode, and strictness should only be traded where the re-verification it forces is
  genuinely expensive.
- **`pr-review`** is already sentinel-bound, so a pull cannot invalidate it.

## Accepted limitation

Cross-file interaction is invisible: if a caller uses A and B, this branch changes A and
`main` changes B, the deltas never overlap and the marker stays fresh though the combination
is unverified. `hash: files` caught that incidentally, so strictness drops. Accepted for
`integ` — it was 6 of the 26 cases, and the 14d TTL still forces a periodic Docker run.
Recorded in `.markgate.yml` and `.claude/rules/hooks.md` so it is challengeable later.

## Test plan

Verified against the pinned binary (`mise exec -- markgate version` -> `0.4.1`, resolving to
`~/.local/share/mise/installs/ubi-go-to-k-markgate/0.4.1/markgate`; a bare `markgate` on PATH
is a stale `v0.1.0` and lies) using this PR's exact `.markgate.yml`, in a throwaway git repo
with `origin/main` simulated via `git update-ref`. Every row below was re-run end to end
against 0.4.1 after the version bump rather than inherited from the 0.4.0 run — `.mise.toml`
sits outside every gate's include scope, so swapping the binary leaves `check` / `docs` /
`verify-pr` reporting fresh while what they attest to has changed (that scope gap is filed
separately as https://github.com/go-to-k/cdkd/issues/1954 and is not something this PR relies on):

- **`main` moves an in-scope file this branch did NOT touch** (`src/b.ts` +
  `tests/integration/fixture.txt`), branch merges it -> `markgate verify integ` **exit 0**,
  `state: match (expires in 13d23h)`. This is the whole point of the change, and it holds.
- **Control, same replay with `hash: files`** -> **exit 1**, `state: mismatch (digest differs)`.
  So the FRESH result above is the new mode's doing, not an insensitive marker.
- **`main` moves a file this branch ALSO changed** (`src/a.ts`) -> **exit 1**,
  `state: mismatch (digest differs)`.
- **Uncommitted in-scope edit** -> **exit 1**. Uncommitted **out-of-scope** edit
  (`docs/readme.md`) -> exit 0, as before.
- **Run from a clean base branch** (`HEAD == origin/main`) -> **exit 2** on `verify`,
  `status` and `set` alike: `hash=diff: no delta against merge-base(origin/main, HEAD); the
  digest would be a constant that never goes stale, ...`. Not a silent pass.

Hook compatibility:

- The `state:` line format is unchanged — `markgate status` for a diff-mode gate only adds
  `base:` / `merge base:` lines above it. The `awk '/^state:/ { ... }'` reason extraction used by `check-gate.sh`,
  `verify-pr-gate.sh`, `integ-gate.sh`, `cdkd-parity-gate.sh` and `create-integ-gate.sh` still
  yields `(digest differs)` under the new mode.
- `integ-gate.sh` run end-to-end against a stale diff-mode marker renders
  "Blocked by integ-gate: this PR touches src/\*\* or tests/integration/\*\* and the `integ`
  marker is stale (digest differs)." (exit 2); against a fresh one after an unrelated `main`
  merge it exits 0; and it ignores non-matching commands (`git status`, `gh pr view 1`, and a
  string merely containing "gh pr merge") with exit 0 even while the marker is stale.
- Every markgate-backed gate hook dry-runs correctly against this worktree under the pinned binary
  (`check-gate` pass, `verify-pr-gate` correctly blocking until this run sets its marker,
  `cdkd-parity-gate` / `create-integ-gate` / `integ-gate` pass as out-of-scope,
  `pr-review-gate` fail-open on a nonexistent PR, `gh-pr-merge-worktree-gate` blocking a
  hand-run merge as designed).
  `markgate config lint` reports only the four pre-existing include-glob warnings already
  present on `main`; none concern `integ`. The `requires: [check, docs]` chain on `verify-pr`
  still resolves.
- `vp run check` 0 errors (1 pre-existing `no-base-to-string` warning in
  `src/local/cloudfront-edge-event.ts`, untouched here), `vp run build` OK,
  `vp run test` 208 files / 3126 tests passed.

No `src/**` or `tests/integration/**` file is touched, so `integ-gate.sh`'s scope
short-circuit exits 0 for this PR and no Docker integ run is required to merge it. Note that
the mode switch changes the digest, so the first `/run-integ` after this lands will be setting
a fresh diff-mode marker regardless — set it from the PR's own worktree, on the PR branch.

## Review follow-ups (second commit)

An independent read-only code review found no blockers and reproduced all four behavior
rows independently. Eight smaller items were raised and all eight are fixed in the second commit — all
documentation / skill-procedure, no gate logic changed:

1. **Unresolvable `base` ref is a hard stop, not a marker check.** `.claude/rules/hooks.md`
   and `integ-gate.sh` both still said an unresolvable `origin/main` "falls through to the
   marker check (conservative)". Under `hash: diff` markgate exits 2 for `verify`, `status`
   AND `set`, so it is an unconditional block whose prescribed remedy cannot clear it —
   `/run-integ`'s own `markgate set integ` fails identically. Both now name `git fetch origin`.
2. **`/run-integ` step 9 did not check the exit code** of `markgate set integ`. Under
   `hash: files` that call could not fail; now it can, on stderr, so an unchecked call looks
   successful while nothing is recorded — a full Docker run wasted, merge still blocked, and
   the natural reaction is to re-run the integ instead of fetching. Now asserts rc=0,
   enumerates the three outcomes, and confirms with `markgate status integ`.
3. **`integ-gate.sh` empty-delta comment** claimed the short-circuit exits 0 "for any PR
   that touches neither `src/**` nor `tests/integration/**`" — an empty delta means an empty
   diff, so it ALWAYS exits 0 and the error cannot reach that path. Aligned to `hooks.md`.
4. **Documented an undocumented 0.4 behavior**: an empty IN-SCOPE delta is *accepted* with
   a warning at rc=0, unlike an empty TOTAL delta which is refused at rc=2. Without the note
   a future reader takes the warning for the refusal.
5. **`cdkd-parity` scope** was described as `src/cli/commands/**` only; it also covers
   `src/internal.ts` / `src/index.ts`.
6. **`/verify-pr` used `git diff main...HEAD`** while the digest is pinned to `origin/main`,
   so a lagging local `main` made skill and hook disagree about what the branch touched. All
   five occurrences in that skill now use `origin/main`.
7. **`.markgate.yml` said "Seven gates"** while defining eight; `merge-pr` was missing from
   the header list.
8. **Nothing told contributors to re-run `mise install`.** With 0.3.3 the new config fails
   parsing for every gate, and `check-gate.sh` discards markgate's stderr, so the symptom is
   a misleading "run /check first" that re-running `/check` cannot clear. Noted in
   `CONTRIBUTING.md`, `.claude/CLAUDE.md` and the `.markgate.yml` header. The `mise exec`
   path auto-installs the pin; the `command -v markgate` fallback does not.

Items 1 and 4 were reproduced before being written, and again against 0.4.1:

```
# base ref deleted
markgate: hash=diff: base ref "origin/main" does not resolve; fetch it first (git fetch origin)
verify rc=2 / set rc=2 / status rc=2
# ... and after restoring the ref:
marker saved: integ        set rc=0

# docs-only branch off the base (empty in-scope delta)
markgate: integ: hash=diff recorded an empty in-scope delta (include: src/**, tests/integration/**);
this branch changes nothing the gate covers, so the marker stays fresh until it does
marker saved: integ        set rc=0        verify rc=0
```

`vp run check` / `build` / `test` re-run green after the fixes (208 files, 3126 tests), and
every markgate-backed gate re-dry-run correctly (including `check-gate` / `verify-pr-gate`
correctly going red on the stale `docs` marker, with `verify-pr` reporting
`child docs is stale`, then green again after `/check-docs`).

## Retrospective

- Encoded in this PR: `hash: diff` refuses an empty delta, so `markgate set integ` from a clean
  `main` now fails loudly instead of recording a meaningless marker. `run-integ`'s skill and
  `.claude/rules/hooks.md` now say to set it from the PR branch's own worktree.
- The review's items 1, 2 and 4 are one pattern: switching a hash mode silently added new
  *failure* modes to commands that previously could not fail, and the surrounding prose was
  rewritten for the success path only. Worth checking the failure paths of any command a
  config change newly allows to fail, not just its happy path.
- Not encoded here (harness-level, not a repo artifact): when an agent's working directory is a
  *different* repository than the one being changed, invoking a skill by name can load that other
  repo's copy of the checklist. `/check` resolved to a sibling repo's version, whose steps
  (`vp check --fix`, `vp run typecheck:test`) do not all exist here. Read the target repo's
  `.claude/skills/<name>/SKILL.md` directly when working cross-repo.

Closes #498
