### PR TITLE
chore(work-issues): rank security issues first, and require a per-repo claim check when mirroring

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -125,8 +125,11 @@ choosing.
   `src/local/docker-image-builder.ts`, `src/local/ecr-puller.ts`), command
   injection, or anything tied to a GHSA advisory. When in doubt, treat it as
   security — ranking a normal bug first costs one position in a queue. Urgency
-  changes ORDER only: a security lane still takes the review tier its size gives
-  PLUS the security reviewer, and the same verification depth as any other lane.
+  changes ORDER only: a security lane takes the tier its size gives, moved UP one
+  step by `/review-pr`'s security up-bias, and the same verification depth as any
+  other lane. Note that up-bias is PATH-keyed (the files listed above), so a
+  security fix landing outside them gets no automatic bump — raise the tier by hand
+  and say why.
 - Same file, related class → **bundle** into a single lane/PR (e.g. two
   `front-door-server.ts` routing fixes → one PR).
 - Different files → separate parallel lanes.
@@ -390,11 +393,10 @@ pnpm install                  # worktrees have no node_modules
   `src/**` change means no integ and no live-test.
 - Merge it with `/merge-pr <n>` like every other lane — a hand-run `gh pr merge`
   from a side worktree is gate-blocked.
-- `/review-pr` DOWN-biases `.claude/**` here, so the tier it emits for a skill-only
-  PR is a FLOOR, not a verdict: read the whole diff yourself regardless. A wrong
-  rule in this file propagates into every future session, which is the opposite of
-  the low risk that down-bias assumes (cdkd removed agent-instruction paths from its
-  own down-bias set for exactly that reason).
+- `/review-pr` no longer down-biases `.claude/**` (issue #501), so a skill-only PR
+  keeps the tier its size gives — read the whole diff at that tier rather than
+  treating a small text diff as low risk. A wrong rule in this file propagates into
+  every future session.
 - **Merge it (via `/merge-pr`) before the wrap report**, which also removes the
   worktree — §9 ends with "only the main checkout should remain", and §10 must not
   undo that. This is `Session-fit: now` on the criterion that deferring leaves main

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -336,6 +336,18 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   session when it can pay for two more gate runs; otherwise file one issue per repo
   carrying the `Session-fit` line. What is not an option is landing the fix in one
   of the three — that is how the three drift apart.
+  **Verify the copy against the TARGET repo, claim by claim, before shipping it.**
+  Their gates, hooks and ship steps differ, so a sentence that is true here reads as
+  authoritative there while being false, and nothing lints instruction prose — the
+  next agent simply acts on it. On 2026-08-18 the first mirror of this section
+  carried four such claims: a `verify-pr` gate that exempts a non-`src/**` diff, a
+  review heuristic that still down-biases `.claude/**`, a `CLAUDE.md` rule the
+  sibling does not carry, and a hook it does not ship. A read-only reviewer per
+  target repo — its only job being to check each gate name, hook behavior, skill
+  name, path convention and cross-reference against that repo's own files — is what
+  caught them. Checking in the rule here rather than in agent memory is deliberate:
+  memory is per-project-path and per-machine, so it would not load in the very repos
+  this bullet sends you to.
 
 ### 10-d. Ship it like any other change
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -114,6 +114,19 @@ one. **At most one lane per shared cross-cutting module.** Map each candidate to
 its target file (grep the relevant symbol; read the issue's "Fix direction") before
 choosing.
 
+- **Security issues come FIRST**, ahead of every other preference on this list. A
+  security defect is the one class whose cost grows while it waits: the vulnerable
+  behavior is already shipped and running, and the report may be public. It counts
+  as security when the issue reports credential / secret handling, redaction or
+  masking, a sensitive value persisted or logged, auth / token verification
+  (`src/local/cognito-jwt.ts`, `src/local/lambda-authorizer.ts`,
+  `src/local/sigv4-verify.ts`), role assumption, container or image handling that
+  executes untrusted input (`src/local/docker-runner.ts`,
+  `src/local/docker-image-builder.ts`, `src/local/ecr-puller.ts`), command
+  injection, or anything tied to a GHSA advisory. When in doubt, treat it as
+  security — ranking a normal bug first costs one position in a queue. Urgency
+  changes ORDER only: a security lane still takes the review tier its size gives
+  PLUS the security reviewer, and the same verification depth as any other lane.
 - Same file, related class → **bundle** into a single lane/PR (e.g. two
   `front-door-server.ts` routing fixes → one PR).
 - Different files → separate parallel lanes.


### PR DESCRIPTION
## Summary

The section-10 mirror bullet told the next agent to "adapt the wording per repo",
which reads as an editing note. What actually happened when this section was first
mirrored across the three repos is stronger than that: four claims travelled as
authoritative statements that are FALSE in the target repo —

- a `verify-pr` gate that exempts a diff with no `src/**` path (true in one repo, not the others),
- a review-tier heuristic that still down-biases `.claude/**`,
- a `CLAUDE.md` rule the sibling repo does not carry (a dangling pointer),
- a hook named as the reason for a step that the sibling does not ship.

Nothing type-checks instruction prose and the markdown lints clean, so the failure
is silent: the next agent reads the claim and acts on it.

## What changes

One clause in 10-c's mirror bullet: verify the copy against the TARGET repo claim
by claim before shipping it, with the check that actually caught these — a
read-only reviewer per target repo whose only job is to walk each gate name, hook
behavior, skill name, path convention and cross-reference against that repo's own
files.

It also records WHY the rule is checked in rather than kept in agent memory: memory
is per-project-path and per-machine, so a note written in one repo's memory does not
load in the repos this bullet sends you to. Git is the only carrier that crosses
both.

## Test plan

- Tooling-only change, no `src/**`.
- Local quality checks green in the worktree.
- Review: inline read (1 file, 12 added lines).

Landing the same clause in all three repos (cdkd, cdk-local, cdk-real-drift), per
the bullet it amends.


## Also in this PR: security issues rank first

The pick step ordered candidates by how much value a fix adds (type, then area,
then file isolation, then age). A security defect does not sit on that axis — the
vulnerable behavior is already shipped and running in users' accounts and the
report may be public, so its cost grows while it waits instead of staying flat. It
now sorts ahead of every other rule, with its own detection list (credential /
secret handling, redaction or masking, a sensitive value persisted or logged, IAM /
role-assumption scope, auth or token verification, command injection, GHSA-tied
reports, plus the paths the security reviewer covers) and an instruction to treat
ambiguous cases as security.

Two interactions are spelled out because they read the other way otherwise: a
security issue that is ALSO an umbrella gets split and started, not deferred by the
umbrella-last rule; and urgency never buys a shortcut — the lane keeps the review
tier its size gives, adds the security reviewer, and runs the same verification as
any other lane.

The same change lands in all three repos' copies of this skill.
