### PR TITLE
chore(work-issues): add the no-src verification tier to section 8, and check cited evidence in 10-c

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -229,8 +229,9 @@ freshness) and — critically — **live-tests the changed behavior**:
   swallows an exit code looks exactly like one that fixes the gate. Three traps,
   measured here on 2026-08-19 (#504):
   - **Repeating a CACHED `vp run <task>` re-runs nothing.** `run.cache.tasks` is on
-    in `vite.config.ts`, and a task that does not opt out with `cache: false` (the
-    `check` / `test` / `lint` / `typecheck` family does not) replays its recorded exit
+    in `vite.config.ts`, and a task that does not opt out with `cache: false` — which
+    is every task you would repeat to watch it: `check`, `test`, `lint`, `typecheck`,
+    `format:check` — replays its recorded exit
     code: `vp run check` printed `cache hit, 2.01s saved` on runs 2-5 — five identical
     greens, one execution. When the POINT is to watch the exit code repeatedly, call
     the underlying command directly (`vp check` / `vp lint` / `vp fmt --check`), which
@@ -251,8 +252,9 @@ freshness) and — critically — **live-tests the changed behavior**:
   Why BOTH directions, concretely. An exit code can lie in either direction, and the
   two repos supply one example each. **Non-zero that means nothing**:
   go-to-k/cdk-real-drift#1761 / #1765 — `vp run check` exited 134 on a clean tree
-  while finding 0 errors (a Vite+ stdout `EAGAIN` panic), deterministically, 3/3 runs
-  before and 3/3 after the fix. The fix was one line of build config, and the risk it
+  while finding 0 errors (a Vite+ stdout `EAGAIN` panic), deterministically — measured
+  3/3 in each state, 134 before the fix and 0 after. The fix was a one-line change to
+  the `check` task command, and the risk it
   carried was the opposite of a flake: a redirect that swallows the exit code turns a
   RED tree green, which is why #1765 shipped a test asserting the `exit 1` survives.
   **Zero that means nothing**: right here, `vp test run` returned rc=0,0,1,0,1 across
@@ -400,6 +402,16 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   caught them. Checking in the rule here rather than in agent memory is deliberate:
   memory is per-project-path and per-machine, so it would not load in the very repos
   this bullet sends you to.
+  **Verify the cited EVIDENCE too, not only the repo-specific nouns — open the issue
+  or PR the source names and confirm it says what the source claims it says.** The
+  nouns fail when a sentence travels between repos; the evidence can be wrong where it
+  was WRITTEN, and then travels intact. On 2026-08-19 (#504) the incoming wording —
+  quoted verbatim into the issue — said "on #1761 the `check` gate flipped rc=0/rc=1
+  across identical runs (the tsgolint budget-cascade artifact)". cdk-real-drift#1761
+  itself records a DETERMINISTIC exit 134 from a Vite+ stdout `EAGAIN` panic, measured
+  3/3 in each state (134 before the fix, 0 after), with tsgolint nowhere in it.
+  Nothing had drifted; the source sentence was already false, and a per-repo noun
+  check would have passed it through. Reading #1761 and #1765 cost one command each.
 
 ### 10-d. Ship it like any other change
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -223,12 +223,41 @@ freshness) and — critically — **live-tests the changed behavior**:
 - **A docs/tooling-only PR** (no `src/**` in the diff) is EXEMPT from the live-test
   and from the integ — but NOT from `/verify-pr` itself: `verify-pr-gate` gates every
   `gh pr create` / `gh pr merge` on the marker with no diff-scope exemption, and only
-  `/verify-pr` sets it.
+  `/verify-pr` sets it. What the exemption drops is the LIVE test, not the verifying.
+  With no runtime path to drive, **the verification IS the broken command itself**:
+  run it BEFORE and AFTER, and drive the FAILURE direction too — a change that
+  swallows an exit code looks exactly like one that fixes the gate. Three traps,
+  measured here on 2026-08-19 (#504):
+  - **Repeating a `vp run <task>` re-runs nothing.** `run.cache.tasks` is on in
+    `vite.config.ts`, so `vp run check` replayed a cached rc=0 on runs 2-5
+    (`cache hit, 2.01s saved`) — five identical greens, one execution. Call the
+    underlying command directly (`vp check` / `vp lint` / `vp fmt --check`) when the
+    POINT is to watch the exit code repeatedly; that path is uncached (5x rc=0,
+    ~420ms each).
+  - **Inject the failure into `src/**`, never into `tests/**`.** `lint.ignorePatterns`
+    / `fmt.ignorePatterns` are source-only (`['**/*', '!src', '!src/**']`): an unused
+    variable in a `src` file fails `vp check` rc=1 (`eslint(no-unused-vars)` +
+    `typescript(TS6133)`), while the same injection under `tests/unit/**` returns
+    rc=0 with the file count unmoved. A probe that lands in `tests/` proves nothing
+    and reads as "the gate is broken".
+  - **Then guard the SHAPE of the fix**, because nothing else re-checks a config or
+    hook line. For a `.claude/hooks/**` fix the repo's own mechanism is a bash smoke
+    test beside the hook — `.claude/hooks/pr-review-gate.test.sh`, run by
+    `vp run test:hooks` and wired into CI — added for #501 precisely because a
+    heuristic edit has no other regression net.
 
-After any Docker-backed run, SWEEP for orphans (`docker ps --filter name=cdkl-`,
-`docker network ls --filter name=cdkl-task-` / `cdkl-svc-`) and clean up via
-`/cleanup`; for a `*-from-cfn-stack` test, also confirm no orphan CloudFormation
-stacks remain (`cdk destroy` / `aws cloudformation`). Leaving orphan resources
+  Why repeatedly, concretely: go-to-k/cdk-real-drift#1761 / #1765 had `vp run check`
+  flapping rc=0/rc=1 across identical runs, so one green would have "proved" either
+  verdict. The same shape is live HERE, on a different task — `vp test run` returned
+  rc=0,0,1,0,1 across five identical runs on a clean branch (2026-08-19) with all
+  3126 tests passing every time: the #402 forks-worker exit, which kills a reused
+  worker AFTER its assertions pass. So on this repo one run proves neither that a
+  command is broken nor that it is fixed. (`vp check` itself was stable, 5x rc=0 —
+  the flap is task-specific, which is exactly why you measure rather than assume.)
+
+After a Docker-backed run, sweep for orphans and clean up via `/cleanup` (the
+container / network filters and the `*-from-cfn-stack` stack check are in
+`.claude/CLAUDE.md` -> "After running integration tests"). Leaving orphan resources
 after a run is never acceptable.
 
 `/verify-pr` sets the `check` + `docs` + `verify-pr` markers, which unblock

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -228,32 +228,39 @@ freshness) and — critically — **live-tests the changed behavior**:
   run it BEFORE and AFTER, and drive the FAILURE direction too — a change that
   swallows an exit code looks exactly like one that fixes the gate. Three traps,
   measured here on 2026-08-19 (#504):
-  - **Repeating a `vp run <task>` re-runs nothing.** `run.cache.tasks` is on in
-    `vite.config.ts`, so `vp run check` replayed a cached rc=0 on runs 2-5
-    (`cache hit, 2.01s saved`) — five identical greens, one execution. Call the
-    underlying command directly (`vp check` / `vp lint` / `vp fmt --check`) when the
-    POINT is to watch the exit code repeatedly; that path is uncached (5x rc=0,
-    ~420ms each).
+  - **Repeating a CACHED `vp run <task>` re-runs nothing.** `run.cache.tasks` is on
+    in `vite.config.ts`, and a task that does not opt out with `cache: false` (the
+    `check` / `test` / `lint` / `typecheck` family does not) replays its recorded exit
+    code: `vp run check` printed `cache hit, 2.01s saved` on runs 2-5 — five identical
+    greens, one execution. When the POINT is to watch the exit code repeatedly, call
+    the underlying command directly (`vp check` / `vp lint` / `vp fmt --check`), which
+    is never cached.
   - **Inject the failure into `src/**`, never into `tests/**`.** `lint.ignorePatterns`
-    / `fmt.ignorePatterns` are source-only (`['**/*', '!src', '!src/**']`): an unused
-    variable in a `src` file fails `vp check` rc=1 (`eslint(no-unused-vars)` +
-    `typescript(TS6133)`), while the same injection under `tests/unit/**` returns
-    rc=0 with the file count unmoved. A probe that lands in `tests/` proves nothing
-    and reads as "the gate is broken".
+    / `fmt.ignorePatterns` are source-only (`['**/*', '!src', '!src/**']`): a
+    non-`_`-prefixed unused variable in a `src` file fails `vp check` rc=1
+    (`eslint(no-unused-vars)` + `typescript(TS6133)`), while the same injection under
+    `tests/unit/**` returns rc=0 with the linted file count unmoved. A probe that
+    lands in `tests/` — or that a `varsIgnorePattern: '^_'` name exempts — proves
+    nothing and reads as "the gate is broken".
   - **Then guard the SHAPE of the fix**, because nothing else re-checks a config or
     hook line. For a `.claude/hooks/**` fix the repo's own mechanism is a bash smoke
     test beside the hook — `.claude/hooks/pr-review-gate.test.sh`, run by
     `vp run test:hooks` and wired into CI — added for #501 precisely because a
     heuristic edit has no other regression net.
 
-  Why repeatedly, concretely: go-to-k/cdk-real-drift#1761 / #1765 had `vp run check`
-  flapping rc=0/rc=1 across identical runs, so one green would have "proved" either
-  verdict. The same shape is live HERE, on a different task — `vp test run` returned
-  rc=0,0,1,0,1 across five identical runs on a clean branch (2026-08-19) with all
-  3126 tests passing every time: the #402 forks-worker exit, which kills a reused
-  worker AFTER its assertions pass. So on this repo one run proves neither that a
-  command is broken nor that it is fixed. (`vp check` itself was stable, 5x rc=0 —
-  the flap is task-specific, which is exactly why you measure rather than assume.)
+  Why BOTH directions, concretely. An exit code can lie in either direction, and the
+  two repos supply one example each. **Non-zero that means nothing**:
+  go-to-k/cdk-real-drift#1761 / #1765 — `vp run check` exited 134 on a clean tree
+  while finding 0 errors (a Vite+ stdout `EAGAIN` panic), deterministically, 3/3 runs
+  before and 3/3 after the fix. The fix was one line of build config, and the risk it
+  carried was the opposite of a flake: a redirect that swallows the exit code turns a
+  RED tree green, which is why #1765 shipped a test asserting the `exit 1` survives.
+  **Zero that means nothing**: right here, `vp test run` returned rc=0,0,1,0,1 across
+  five identical runs on a clean branch (2026-08-19) with all 3126 tests passing every
+  time — the #402 forks-worker exit, which kills a reused worker AFTER its assertions
+  pass. So one green proves neither that a command is broken nor that it is fixed.
+  Note the flap is task-specific (`vp check` was stable, 5x rc=0), which is the point:
+  measure the command you actually changed rather than assuming its behavior.
 
 After a Docker-backed run, sweep for orphans and clean up via `/cleanup` (the
 container / network filters and the `*-from-cfn-stack` stack check are in


### PR DESCRIPTION
## Summary

Adds the missing verification tier for a fix with **no `src/**` in the diff** to
`/work-issues` section 8, and records in section 10-c the check that would have caught
the one false claim this mirror carried.

Section 8 previously listed only the live-test tiers, so a toolchain / CI / agent-skill
fix fell through: "exempt from the live test" reads as "nothing to verify". It is an
exemption from the LIVE test, not from verifying — with no runtime path to drive, the
verification IS the broken command itself, run before and after, with the FAILURE
direction driven too.

## Per-claim verification against this repo

The issue's own "Why it is not a copy-paste" note requires every inherited claim to be
re-measured here before the wording ships. Three of the four changed, and the fourth
was wrong at its source:

| inherited claim | measured here | outcome |
| --- | --- | --- |
| `verify-pr-gate` exempts a no-`src/**` diff, so `/verify-pr` is not required | `.claude/hooks/verify-pr-gate.sh` has no diff-scope logic at all — it gates every `gh pr create` / `gh pr merge` | **false here**; section 8 already said so, the new text extends that bullet |
| run the command 3-5x | `vp run check` printed `cache hit, 2.01s saved` on runs 2-5 — five identical greens, one execution (`run.cache.tasks` in `vite.config.ts`) | **needs the direct call**: `vp check` / `vp lint` / `vp fmt --check`, uncached |
| inject an unused variable for a `no-unused-vars` gate | rc=1 in `src/**` (`eslint(no-unused-vars)` + `typescript(TS6133)`); rc=0 for the same injection in `tests/unit/**`, linted file count unmoved | **`src/**` only** — lint/fmt `ignorePatterns` are source-only; `varsIgnorePattern: '^_'` also exempts |
| guard the shape with a unit test on the config object | this repo's native form is a bash smoke test beside the hook: `.claude/hooks/pr-review-gate.test.sh`, `vp run test:hooks`, wired into CI at `.github/workflows/ci.yml` | **adapted** |

## The evidence itself was wrong at the source

The inherited bullet cited `go-to-k/cdk-real-drift` as an rc flap caused by a tsgolint
budget-cascade artifact. Reading the actual records
(https://github.com/go-to-k/cdk-real-drift/issues/1761,
https://github.com/go-to-k/cdk-real-drift/pull/1765) shows a **deterministic** exit 134
from a Vite+ stdout `EAGAIN` panic while finding 0 errors — measured 3/3 in each state,
and tsgolint mentioned nowhere. That is the "non-zero exit that means nothing"
direction, not nondeterminism.

The rewritten paragraph states it that way, and pairs it with a real flap **measured
here**: `vp test run` returned rc=0,0,1,0,1 across five identical runs on a clean
branch with all 3126 tests passing every time — this repo's known forks-worker exit,
which kills a reused worker after its assertions pass. It reproduced again mid-review
during this PR's own gate runs.

Section 10-c is amended accordingly: verify the cited EVIDENCE, not only the
repo-specific nouns. The nouns break when a sentence travels between repos; wrong
evidence is wrong where it was written and travels intact, so a per-repo noun check
passes it straight through.

Also swaps the duplicated orphan-sweep paragraph for a pointer to `.claude/CLAUDE.md`,
per section 10-c's "do not restate a rule that already lives in CLAUDE.md — point at
it instead".

## Test plan

No `src/**` in the diff, so there is no live-test tier and no integ — which makes this
PR its own first application of the rule it adds. The verification was the measurement
table above, driven in both directions:

- `vp run check` x5 vs `vp check` x5 — cached replay vs real execution, exit codes recorded
- unused-variable injection in `src/**` (rc=1) and in `tests/unit/**` (rc=0), both probes removed
- `vp run test:hooks` — 9 pass / 0 fail
- `vp test run` x5 for the flap measurement, then re-run to a clean green for the gate
- `vp check` / `vp run build` / `vp test run` all green at HEAD

Reviewed by a read-only agent whose only job was to check each claim against this
repo's files and the two sibling records. It found one blocker (the misdescribed
`cdk-real-drift` incident) and four nits (over-broad cache claim, `varsIgnorePattern`
exemption, an unverifiable timing figure, and a "3/3 before and after" phrasing that
implied the same exit code in both states); all five are fixed in this PR, none
deferred.

## Follow-ups filed

Section 10-c requires a flow lesson to land in all three repos. The other two are
filed rather than shipped here, since each needs its own worktree, gate cycle and
per-claim verification pass:

- https://github.com/go-to-k/cdk-real-drift/issues/1768 — its section 8 bullet
  contradicts the incident it cites
- https://github.com/go-to-k/cdkd/issues/1980 — still missing the no-src tier entirely

Closes #504
