### PR TITLE
chore(work-issues): mirror the both-directions list audit + existing-harness check into SKILL.md section 5

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1162,6 +1162,9 @@ vp run test
 vp run test:watch
 vp run test:coverage
 
+# Hook smoke tests (bash, run in CI alongside the unit suite)
+vp run test:hooks
+
 # verify = check + test + build
 vp run verify
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -188,13 +188,15 @@ go-to-k/cdkd#1972 reported one dead path in a security-surface path list; auditi
 the whole list found a second dead path (stale since an unrelated directory rename)
 plus four live authn / credential / exec surfaces that had never been added, so the
 list under-protected considerably more than it over-claimed. The same shape exists
-here: `/review-pr`'s up-bias path list is written out three times
+here: `/review-pr`'s up-bias path list is written out FOUR times
 (`UP_PATH_REGEX` in `.claude/hooks/pr-review-gate.sh`,
-`.claude/skills/review-pr/SKILL.md`, `.claude/rules/hooks.md`), so an audit checks
-every copy, not just the one the issue quotes. Then ask what makes the recurrence
-mechanical: if a list must stay in sync with the repo, that is a test asserting
-every entry resolves and that the copies agree, not a sentence asking the next
-reader to remember.
+`.claude/skills/review-pr/SKILL.md`, `.claude/rules/hooks.md`, and
+`.claude/agents/pr-code-reviewer.md`), so an audit checks every copy, not just the
+one the issue quotes — the first draft of THIS paragraph said "three times" and
+missed the reviewer-agent copy, which is also the one already out of sync.
+Then ask what makes the recurrence mechanical: if a list must stay in sync with
+the repo, that is a test asserting every entry resolves and that the copies agree,
+not a sentence asking the next reader to remember.
 
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -168,10 +168,33 @@ git worktree add .claude/worktrees/<name> -b <branch> origin/main
 ```
 
 Do the fix in the worktree (match the existing module/pattern exactly; ESM relative
-imports need the `.js` extension even in TS source). **Always add a unit test that
-fails without the fix and passes with it** — `tests/unit/**` mirrors `src/**`; mock
-the external boundaries (toolkit-lib, docker CLI, AWS SDK) with `vi.mock` /
-`vi.hoisted`.
+imports need the `.js` extension even in TS source). **Always add a test that fails
+without the fix and passes with it** — usually a unit test, where `tests/unit/**`
+mirrors `src/**` and the external boundaries (toolkit-lib, docker CLI, AWS SDK) are
+mocked with `vi.mock` / `vi.hoisted`. **Check first whether the artifact already has
+its own harness**, because it will not be under `tests/unit/**` and that is the only
+place you would think to look: a `.claude/hooks/**` fix is covered by a bash smoke
+test beside the hook — this repo carries one such suite,
+`.claude/hooks/pr-review-gate.test.sh`, run by `vp run test:hooks` and wired into CI
+— so look for a sibling `*.test.sh` before writing a new harness from scratch.
+
+**When the issue reports a stale ENTRY in an enumerated list, audit the whole list,
+in both directions, before fixing the named entry.** The defect class is "this list
+drifted from the repo", and drift almost never produces exactly the one instance
+someone happened to notice. Check both that every entry still resolves to something
+real AND that everything that belongs is present — the second half is the one that
+gets skipped, because the issue only names the first. On 2026-08-19,
+go-to-k/cdkd#1972 reported one dead path in a security-surface path list; auditing
+the whole list found a second dead path (stale since an unrelated directory rename)
+plus four live authn / credential / exec surfaces that had never been added, so the
+list under-protected considerably more than it over-claimed. The same shape exists
+here: `/review-pr`'s up-bias path list is written out three times
+(`UP_PATH_REGEX` in `.claude/hooks/pr-review-gate.sh`,
+`.claude/skills/review-pr/SKILL.md`, `.claude/rules/hooks.md`), so an audit checks
+every copy, not just the one the issue quotes. Then ask what makes the recurrence
+mechanical: if a list must stay in sync with the repo, that is a test asserting
+every entry resolves and that the copies agree, not a sentence asking the next
+reader to remember.
 
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an


### PR DESCRIPTION
## Summary

Mirrors two `/work-issues` retrospective lessons from go-to-k/cdkd#1972 into this
repo's `.claude/skills/work-issues/SKILL.md` §5 — the step where each fires.

1. **When an issue reports a stale ENTRY in an enumerated list, audit the whole
   list in both directions before fixing the named entry.** Drift rarely produces
   only the instance someone noticed, and the backward half (is everything that
   belongs still present?) is the half that gets skipped, because the issue only
   names the first.
2. **Check whether the artifact already has its own test harness before writing a
   new one.** It will not be under `tests/unit/**`, which is the only place you
   would think to look.

Lesson 1 is folded into the existing "always add a unit test" sentence rather than
added beside it, per §10-c's amend-don't-append rule.

## Claims re-measured against this checkout, not copied

- The harness here is a **single** bash smoke suite,
  `.claude/hooks/pr-review-gate.test.sh`, run by `vp run test:hooks`
  (`vite.config.ts:230`) and wired into CI (`.github/workflows/ci.yml:23`). cdkd
  has ~30 per-hook suites behind a `run-tests.sh` runner and its own `hooks.yml`
  workflow; this repo has neither, so the wording is "check for a harness", not an
  assertion that one exists per hook.
- cdkd's gate names and ship steps were **not** copied — §9 here is
  "merge -> pull -> cleanup (all via `/merge-pr`)".
- Also documents `vp run test:hooks` in `.claude/CLAUDE.md`'s build-and-test
  command block, where it was missing despite existing in `vite.config.ts` and CI.
  The new §5 text points readers at that command.

## The rule caught itself

Applying lesson 1 to this repo's own instance found two things:

- **Forward direction clean, backward direction not.** All 7 entries of
  `/review-pr`'s up-bias path list resolve, but 7 live authn / credential /
  code-exec surfaces are missing from it. Filed as a follow-up (#506) rather than
  fixed here, since editing the tier heuristic needs its own hook-test cycle.
- **The first draft of the new paragraph itself under-audited.** It said the list
  is copied "three times"; a wider grep found a fourth copy,
  `.claude/agents/pr-code-reviewer.md:24`, which carries 6 of the 7 entries
  (missing `src/utils/role-arn.ts`) and is therefore the copy already out of sync.
  Corrected in e63ee75, and recorded inline in the paragraph as its own example.
  (#506) was updated with the fourth copy and the drift.

## Test plan

No `src/**` in the diff, so this is docs/tooling-only: exempt from the live test
and from the integ gate per §8, but not from `/verify-pr` itself.

- `vp run check` — rc=0 (0 errors; the one `no-base-to-string` warning is
  pre-existing on `main` in `src/local/cloudfront-edge-event.ts`)
- `vp run test` — 208 files, 3126 tests, 0 failures
- `vp run test:hooks` — 9 pass, 0 fail (also the live check that the command the
  new §5 text names actually works)
- `vp run build` — rc=0
- Every path, task name and CI reference asserted by the new text was resolved
  against this checkout before shipping.

## Review tier

`inline` — 2 files, ~30 LOC, no security-surface paths. Per #501 `.claude/**` no
longer down-biases, so the whole diff was read at that tier rather than treated as
a low-risk text change; that read is what produced the copy-count correction above.

Closes #505
