### PR TITLE
chore(work-issues): stop section 9 sending a run to delete a peer's live worktree

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -236,9 +236,15 @@ Take it all the way to merged — do not leave a green PR hanging:
    fatal) and cleans the worktree + local + remote branch in one pass. Do NOT
    hand-run `gh pr merge --squash --delete-branch` from a side worktree — it's
    gate-blocked (`gh-pr-merge-worktree-gate.sh`).
-2. **Confirm the worktree is gone** — `/merge-pr` removes it; a left-behind worktree
-   is the silent residue of this flow. `git worktree list` should show only the main
-   checkout; `git worktree prune` if anything lingers.
+2. **Confirm the worktree YOU added is gone** — `/merge-pr` removes it; a
+   left-behind worktree is the silent residue of this flow. Check `git worktree
+   list` for yours specifically, NOT for a list with only the main checkout in it:
+   it cannot tell a finished lane from a session working right now (an
+   already-on-`main` branch tip included), so a worktree you did not add may be a
+   live peer lane. Confirm it is finished (`git log --oneline -1 <branch>`, then
+   `gh pr list --state all --head <branch>` for an OPEN PR) before removing it, and
+   leave it alone when in doubt. `git worktree prune` drops entries whose directory
+   is already gone.
 
 ### 9. Record what you learned
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -329,10 +329,21 @@ Confirm the TRUE diff and rebase:
 
 ```bash
 git diff --stat $(git merge-base origin/main <branch>)..<branch>   # the real change
-git -C .claude/worktrees/<name> rebase origin/main                 # clean if disjoint
+git -C .claude/worktrees/<name> rebase origin/main                 # only SHARED LINES conflict
 ```
 
 Re-run gates, `git push --force-with-lease`.
+
+**A clean rebase — and a clean merge — is NOT evidence that §3's one-lane-per-file
+rule held.** Git conflicts only where the two sides touched the same LINES, so two
+lanes editing disjoint SECTIONS of one file both land intact and §3 fails
+*silently*, without the loud signal this step otherwise gives you. Measured in
+cdk-real-drift on 2026-08-19 (go-to-k/cdk-real-drift#1775): PRs
+go-to-k/cdk-real-drift#1772 and go-to-k/cdk-real-drift#1773 both rewrote
+`.claude/skills/work-issues/SKILL.md` and merged NINE SECONDS apart (04:30:51Z and
+04:31:00Z); both survived by luck, not by design. When your PR lands into a file
+another PR touched in the same window, the absent conflict proves nothing — confirm
+it after the pull in §9.
 
 ## 8. Verify before merge (`/verify-pr`)
 
@@ -455,18 +466,34 @@ already used by worktree` fatal a hand-run merge hits from a side worktree), the
 cleans the worktree + local branch + remote branch in one pass. A hand-run worktree
 merge is blocked by `gh-pr-merge-worktree-gate.sh` unless `/merge-pr` set the
 `merge-pr` marker. If a later PR is behind, GitHub still merges it when the files
-are disjoint.
+are disjoint — which is also why a clean merge says nothing about whether a
+collision happened (§7).
 
 ```bash
 git checkout main && git pull origin main    # bring the merges local
 ```
 
-`/merge-pr` already removes the worktree it merged; confirm nothing lingers:
+So when your PR landed into a file another PR touched in the same window, grep the
+pulled `main` for a marker string from EACH side before believing both survived —
+one side silently overwriting the other looks exactly like a clean merge.
+
+`/merge-pr` already removes the worktree it merged; the check is that **every
+worktree THIS run added is gone** — never that only the main checkout remains:
 
 ```bash
-git worktree list                            # only the main checkout should remain
-git worktree prune
+git worktree list      # yours gone; one you did NOT add may be a LIVE peer lane
+git worktree prune     # drops entries whose directory a peer already removed
 ```
+
+`git worktree list` cannot tell you whose a worktree is: a finished lane and a
+session working right now look identical, an already-on-`main` branch tip included
+— a peer lane merges its own PR and keeps working. Before removing one you did not
+add, confirm it is finished (`git log --oneline -1 <branch>`, then `gh pr list
+--state all --head <branch>` for an OPEN PR), and when in doubt leave it and say so
+in the wrap. In cdk-real-drift on 2026-08-19 (go-to-k/cdk-real-drift#1775) a run
+read a peer's worktree as residue of the previous run — the reading the old wording
+invites — and that lane merged go-to-k/cdk-real-drift#1773 while the reading lane
+was still open.
 
 Finally, comment the outcome on each issue if it was not auto-closed. Do NOT stop
 here: what the run taught you is still only in this session's context, so go on to
@@ -624,11 +651,12 @@ pnpm install                  # worktrees have no node_modules
   treating a small text diff as low risk. A wrong rule in this file propagates into
   every future session.
 - **Merge it (via `/merge-pr`) before the wrap report**, which also removes the
-  worktree — §9 ends with "only the main checkout should remain", and §10 must not
-  undo that. This is `Session-fit: now` on the criterion that deferring leaves main
-  self-inconsistent: the skill would keep telling the next run to do the thing this
-  run just proved it gets wrong. Its evidence also dies with this session's context.
-  Leaving the PR open is an open PR (NOT CLOSEABLE) as well.
+  worktree — §9's closing check is "every worktree THIS run added is gone", and
+  §10 must not undo that. This is `Session-fit: now` on the criterion that
+  deferring leaves main self-inconsistent: the skill would keep telling the next
+  run to do the thing this run just proved it gets wrong. Its evidence also dies
+  with this session's context. Leaving the PR open is an open PR (NOT CLOSEABLE)
+  as well.
 
 Then report the outcome in one line of the wrap: what changed, in which step, and
 the run evidence behind it — or "no skill change" plus what held.
@@ -648,7 +676,13 @@ the run evidence behind it — or "no skill change" plus what held.
   fix needs a value that lives in a helper another agent owns, prefer a small
   SELF-CONTAINED change in YOUR file over editing theirs.
 - **Stale-base phantom diff** (§7) — never "restore" the peer's lines a stale
-  `git diff origin/main` appears to have removed; rebase instead.
+  `git diff origin/main` appears to have removed; rebase instead. And the converse:
+  a rebase / merge with no conflict is not proof the lanes were disjoint — same
+  file, different sections lands silently (§7, confirmed in §9).
+- **A worktree you did not add may be a LIVE peer** (§9) — `git worktree list`
+  cannot tell a finished lane from a session working right now, already-merged
+  branch tip included. The closing check is "mine are gone", not "only main
+  remains".
 - **`/merge-pr`, not a hand-run merge** — a hand-run `gh pr merge --delete-branch`
   from a side worktree trips the `'main' is already used by worktree` fatal (the
   remote merge lands but local cleanup fails) and is gate-blocked besides.


### PR DESCRIPTION
## Summary

Fixes two wordings in `/work-issues` that make a run misbehave when another
session is running, plus the one cross-reference and the one sibling-skill copy
that repeat them. Both hazards were measured in `cdk-real-drift` on 2026-08-19
(go-to-k/cdk-real-drift#1775); this is the `cdk-local` mirror required by §10-c.

**1. §9 told the run to remove a peer's LIVE worktree.** The closing check was
`git worktree list  # only the main checkout should remain`. `git worktree list`
cannot say whose a worktree is — a finished lane and a session working right now
look identical, an already-on-`main` branch tip included, because a peer lane
merges its own PR and keeps working. The check is now "every worktree THIS run
added is gone", with a two-command confirmation
(`git log --oneline -1 <branch>`, then `gh pr list --state all --head <branch>`)
before removing one you did not add, and leave-it-and-say-so-in-the-wrap when in
doubt.

**2. §7 treated a clean rebase/merge as proof of no collision.** Git conflicts
only where both sides touched the same LINES, so two lanes editing disjoint
SECTIONS of one file both land intact and §3's one-lane-per-file rule fails
*silently*. §7 now says so; §9 adds the marker grep on the pulled `main` that is
the only way to see it, and amends the adjacent "GitHub still merges it when the
files are disjoint" sentence that reinforced the false comfort.

Also updated, because they carry the same claim:

- §10-d cross-referenced §9's old phrase verbatim (`.claude/skills/work-issues/SKILL.md`)
- `/hunt-bugs` step 8 said `git worktree list` "should show only the main checkout"
- two Gotchas bullets, pointer-style, for the two traps

## Verification

No `src/**` in the diff, so this is §8's arm-2 (prose-only) tier: no live-test
and no integ, but every claim and command in the new text was resolved against
this repo and RUN.

- Commands the new text sends the next agent to run, exercised in BOTH
  directions: `gh pr list --state all --head <branch>` returned the merged PR for
  `chore/review-pr-up-bias-path-audit` (#513) and an empty list for a live peer
  branch with no PR yet; `git log --oneline -1 <branch>` resolved that peer's
  tip; `git worktree prune` dropped an entry whose directory a peer had already
  removed (observed live at 04:49Z this run).
- Repo-specific nouns re-derived here rather than copied: the
  `.claude/worktrees/` path convention, `gh-pr-merge-worktree-gate.sh`,
  `/merge-pr`. No claim about a `verify-pr` diff-shape carve-out was carried over
  — this repo has none.
- Cited evidence read, not just resolved: go-to-k/cdk-real-drift#1775 records
  both hazards; go-to-k/cdk-real-drift#1772 and go-to-k/cdk-real-drift#1773 both
  rewrote `work-issues/SKILL.md` and merged nine seconds apart (04:30:51Z /
  04:31:00Z), which is the measured number now in §7 (the source said "minutes").
- Dogfooded: PR #516 merged into the same file mid-lane. The rebase was clean —
  which under the new §7 proves nothing — so a marker string from each side was
  grepped on the rebased tree and both survived. The same check will be re-run on
  `main` after this merges.
- `vp check` 0 errors / 1 pre-existing warning · `vp run build` pass ·
  `vp test run` 3126 tests: rc=0 then rc=1 on an identical re-run, the
  `ecs-service-emulator-image-override-binding` flake already filed as #515
  (that file re-run twice on its own: 20/20 pass, 2/2 runs). Unrelated to this
  diff, which touches no code.

Per §10-c "pay for what you add": the three sentences that were wrong are
amended in place rather than appended beside.

## Not done, deliberately

A hook was considered for §10-b's "mechanically detectable" preference — block
`git worktree remove` of a worktree this session did not add. `git worktree
remove` already refuses a worktree with uncommitted changes unless `--force`, so
git itself covers the data-loss case; the residue is a recoverable annoyance, not
worth a gate.

Closes #512
