### PR TITLE
chore(work-issues): add the uncommitted-work probe to the section 2 collision map

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -84,12 +84,29 @@ For each active worktree, find what it ACTUALLY edits (not the stale-base noise)
 
 ```bash
 git -C .claude/worktrees/<w> log --oneline -1     # its own commit subject → the issue it owns
-git -C .claude/worktrees/<w> show --stat HEAD     # the files that commit touches
+git -C .claude/worktrees/<w> show --stat HEAD     # the files that commit HAS FINISHED
+git -C .claude/worktrees/<w> status --porcelain   # what it is editing RIGHT NOW
 ```
 
-Read any "working on this" comments already on candidate issues. **A file another
-agent is editing is OFF-LIMITS.** In practice the contested files are the SHARED,
-cross-cutting runtime modules that many fixes route through:
+**A file another agent is editing is OFF-LIMITS** — and the third probe is the one
+that catches a live lane, so do not stop at the first two. A lane's committed diff is
+what it has finished; its dirty tree is what it is holding. Read the "working on this"
+comments on candidate issues too, but treat the dirty tree, not the comment, as the
+authority on what a lane currently owns: a claim is written once at the start and goes
+stale as the lane's scope grows. On 2026-08-19 the #506 lane (PR #513) was editing
+THIS file's §4 and §8 while its claim comment on #506 named five other files and not
+this one — the comment said free, and only `status --porcelain` (plus an mtime seconds
+old) said otherwise.
+
+When the contested file is one you cannot avoid because the issue names it, the choice
+is not just wait-or-collide: shape your edit to rebase cleanly over theirs. Leave the
+anchors their hunks sit on — list indentation, heading levels, surrounding blank lines
+— untouched, so no line belongs to both diffs. #516 restructured §8 into two arms
+while #513 was inserting a bullet into §8's trap list; keeping the trap bullets at
+their original indentation is why that rebase applied with no conflict.
+
+In practice the contested files are the SHARED, cross-cutting runtime modules that
+many fixes route through:
 
 - `src/cli/commands/ecs-service-emulator.ts` — shared `start-service` /
   `start-alb` orchestration (synth + docker network + Cloud Map + reload watcher).


### PR DESCRIPTION
## Summary

§2's job is to find what other lanes are editing, but both probes it listed read
COMMITTED state (`log --oneline -1`, `show --stat HEAD`), so a live lane's
uncommitted work was invisible to the step whose whole purpose is to surface it. The
step then leaned on the issue's "working on this" comment — which is written once at
the start and goes stale as a lane's scope grows.

This is the §10 retrospective for the #511 run (#516).

## Evidence from that run

The #506 lane (PR #513) was editing **this file's §4 and §8** while its claim comment
on #506 named five other files and not this one. Both §2 probes and the claim comment
reported the file free. Only `git status --porcelain` in that worktree — plus a file
mtime one second old — showed the collision, on the exact file the next lane was about
to edit.

## Changes

- Adds `git -C <w> status --porcelain` as a third probe, labelled as the one that
  catches a live lane, with the committed-vs-dirty distinction spelled out and the
  dirty tree named as the authority over the claim comment.
- Adds the case §2 had no answer for: when the contested file is one you cannot avoid
  because the issue names it, the choice is not just wait-or-collide — shape the edit
  to rebase cleanly. Leave the anchors the other lane's hunks sit on (list
  indentation, heading levels, surrounding blank lines) untouched so no line belongs
  to both diffs. #516 restructured §8 into two arms while #513 was inserting a bullet
  into §8's trap list, and that is why the rebase applied with no conflict.
- Folds the pre-existing "read any working on this comments" sentence into the new
  paragraph instead of leaving it beside it, so the step keeps one account of how to
  judge ownership (per §10-c, amend rather than append).

## Mirroring

Filed as go-to-k/cdkd#1996 and go-to-k/cdk-real-drift#1779 rather than shipped in all
three here: each needs its own worktree + gate cycle and a per-claim verification pass
against its own gate names and path conventions.

## Test plan

Prose-only diff (no `src/**`, no `tests/**`), so Arm 2 of the tier this run just added
applies: the claims are the artifact.

- All three probes run against a real worktree and produce the documented output; the
  new probe is what actually surfaced the live #506 lane during the #511 run, before
  this text was written.
- Every issue reference (#506, #513, #516) resolves in this repo; no cross-repo bare
  refs introduced (the rule added in #516).
- `vp check` 0 errors, `vp build` pass, `vp run test:hooks` 48/48,
  `vp test run` 208 files / 3126 tests pass.
- `integ` / `cdkd-parity` out of scope for this diff.

Review tier: inline (25 LOC, 1 file; `.claude/**` takes no down-bias per #501).
