### PR TITLE
chore(work-issues): take the section 9 collision marker from the diff, not the title

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -502,7 +502,11 @@ git checkout main && git pull origin main    # bring the merges local
 
 So when your PR landed into a file another PR touched in the same window, grep the
 pulled `main` for a marker string from EACH side before believing both survived —
-one side silently overwriting the other looks exactly like a clean merge.
+one side silently overwriting the other looks exactly like a clean merge. Take each
+marker from that PR's own DIFF (`gh pr diff <n>`), never from its title: on
+2026-08-19 a marker lifted from #518's title ("uncommitted-work probe") was absent
+from `main` while its actual text — `status --porcelain`, "dirty tree" — was
+present, i.e. the check reported a lost merge that had not happened.
 
 `/merge-pr` already removes the worktree it merged; the check is that **every
 worktree THIS run added is gone** — never that only the main checkout remains:


### PR DESCRIPTION
## Summary

#517 added a §9 check: after a merge that lands into a file another PR touched in
the same window, grep the pulled `main` for a marker string from EACH side before
believing both survived. Running it for real minutes later produced a FALSE
POSITIVE — it reported that #518's change was missing from `main` when it was
not.

The cause: the marker was taken from #518's TITLE ("uncommitted-work probe"). The
text that PR actually shipped says `status --porcelain` and "dirty tree"; the word
"uncommitted" appears nowhere in it. A check whose failure mode is "reports a lost
merge that did not happen" is worse than no check — it sends the next run hunting
an overwrite that does not exist — so §9 now names `gh pr diff <n>` as the source
of each marker.

## Verification

Prose-only (§8 arm 2), so the claims are the artifact and each was run:

- `gh pr diff 518 | grep -c 'status --porcelain'` → 2 (the marker that works)
- `gh pr view 518 --json title` → "...uncommitted-work probe..." while
  `grep -c uncommitted` on the merged file → 0 (the marker that failed)
- the real check re-run on `main` with diff-sourced markers: #517, #518 and #519
  all present, and the pre-#519 broken command string gone
- `vp check` 0 errors / 1 pre-existing warning · `vp run build` pass ·
  `vp test run` 208 files / 3126 tests pass (rc=0)

Six-line amendment to the sentence #517 added, in the step where it fires.
