### PR TITLE
test: hoist the emulator dynamic import out of strict-overrides case bodies

### DIFF
--- a/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts
@@ -9,6 +9,18 @@ const EMULATOR_SOURCE = path.join(
   '../../../src/cli/commands/ecs-service-emulator.ts'
 );
 
+// Issue #515 — the emulator module is one of the largest in the repo, and
+// importing it INSIDE an it() body charged the whole module load against
+// that single case's 5s testTimeout (observed at 2312ms on a passing run,
+// and over 5s on a loaded worker). Pay the load ONCE at module scope —
+// outside any per-case budget — matching the top-level `await import`
+// pattern the sibling emulator test files use. This file has no vi.mock,
+// so the import order is unconstrained.
+const { enforceStrictOverrides } = await import(
+  '../../../src/cli/commands/ecs-service-emulator.js'
+);
+const { LocalStartServiceError } = await import('../../../src/utils/error-handler.js');
+
 /**
  * Issue #238 site-level binding test (mirrors the
  * `feedback_site_level_binding_test.md` pattern used by
@@ -272,11 +284,7 @@ describe('enforceStrictOverrides (issue #238 strict-overrides guard, behavioral)
   // entire emulator (synth + resolvers + docker) just to exercise the
   // one if-statement. The boot path's call site is locked via the
   // source-grep test below.
-  it('throws LocalStartServiceError naming every uncovered target when strict=true', async () => {
-    const { enforceStrictOverrides } = await import(
-      '../../../src/cli/commands/ecs-service-emulator.js'
-    );
-    const { LocalStartServiceError } = await import('../../../src/utils/error-handler.js');
+  it('throws LocalStartServiceError naming every uncovered target when strict=true', () => {
     expect(() => enforceStrictOverrides(true, ['AppService', 'AuthService'])).toThrow(
       LocalStartServiceError
     );
@@ -293,17 +301,11 @@ describe('enforceStrictOverrides (issue #238 strict-overrides guard, behavioral)
     }
   });
 
-  it('is a no-op when strict=false (even with uncovered targets)', async () => {
-    const { enforceStrictOverrides } = await import(
-      '../../../src/cli/commands/ecs-service-emulator.js'
-    );
+  it('is a no-op when strict=false (even with uncovered targets)', () => {
     expect(() => enforceStrictOverrides(false, ['AppService'])).not.toThrow();
   });
 
-  it('is a no-op when strict=true but no targets are uncovered', async () => {
-    const { enforceStrictOverrides } = await import(
-      '../../../src/cli/commands/ecs-service-emulator.js'
-    );
+  it('is a no-op when strict=true but no targets are uncovered', () => {
     expect(() => enforceStrictOverrides(true, [])).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

Fixes the intermittent 5s timeout of the `enforceStrictOverrides` strict-overrides case in `tests/unit/cli/ecs-service-emulator-image-override-binding.test.ts`.

The case body opened with `await import('.../ecs-service-emulator.js')` — one of the largest modules in the repo — so the module load was charged against the single case's 5s `testTimeout` (observed at 2312ms on a passing run; timing out under parallel-worker load, 4 failing runs out of 7 measured on `main` on 2026-08-19). This PR hoists the import to module scope (the top-level `await import` pattern the sibling emulator test files already use; the file has no `vi.mock`, so import order is unconstrained), paying the load once at collection time outside any per-case budget. The three cases drop `async` since no `await` remains.

## Audit (fix direction 3 of the issue)

All other `tests/unit/**` importers of `ecs-service-emulator.js` were audited for the same in-case-import shape. No other load-bearing instance exists: the remaining in-case imports (`ecs-service-emulator-shadow-ready-timeout.test.ts`, `cli-consistency-249.test.ts`) sit in files that also statically import the module at top level, so they are module-registry cache hits with no load cost. Won't-do: hoisting those is churn with no flake-risk reduction (recorded here).

## Test plan

- Single file in isolation: 3 runs before + 3 after, all green (20 tests).
- Full suite (`vp test run`, sequential, uncached): 3 runs before + 10 runs after — the named case never failed or timed out in any of the 13 runs. The only non-zero exits were the known issue #402 worker-teardown shape (exit 1 with all 3126 tests passing) and one unrelated `agentcore-ws-client` flake, filed as issue #521.

Closes #515
