### PR TITLE
refactor: extract the four duplicated STS AssumeRole copies into role-arn.ts

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -8,7 +8,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
-import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, LocalStartServiceError } from '../../utils/error-handler.js';
 import { resolveMultiTarget } from '../../local/target-picker.js';
 import type { TargetEntry } from '../../local/target-lister.js';
@@ -2388,30 +2388,13 @@ async function assumeTaskRole(
   region: string | undefined,
   profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
-  const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  // Thread `--profile` so AssumeRole is signed with the profile's
-  // credentials, not the default env-shadowed chain (issue #245).
-  const sts = new STSClient(buildStsClientConfig({ region, profile }));
-  try {
-    const response = await sts.send(
-      new AssumeRoleCommand({
-        RoleArn: roleArn,
-        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-start-service-${Date.now()}`,
-        DurationSeconds: 3600,
-      })
-    );
-    const creds = response.Credentials;
-    if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-      throw new LocalStartServiceError(`AssumeRole(${roleArn}) returned no usable credentials.`);
-    }
-    return {
-      accessKeyId: creds.AccessKeyId,
-      secretAccessKey: creds.SecretAccessKey,
-      sessionToken: creds.SessionToken,
-    };
-  } finally {
-    sts.destroy();
-  }
+  return assumeRoleCredentials({
+    roleArn,
+    region,
+    profile,
+    sessionNameSuffix: 'start-service',
+    makeError: (message) => new LocalStartServiceError(message),
+  });
 }
 
 /**

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -13,7 +13,7 @@ import {
 import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { resolveContainerFallbackRegion } from './local-start-api.js';
 import { getLogger } from '../../utils/logger.js';
-import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
 import { resolveSingleTarget } from '../../local/target-picker.js';
@@ -817,38 +817,6 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString('utf-8');
 }
 
-async function assumeLambdaExecutionRole(
-  roleArn: string,
-  region: string | undefined,
-  profile: string | undefined
-): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
-  const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  // Thread `--profile` so the AssumeRole call is signed with the profile's
-  // credentials (matching `aws sts assume-role --profile <p>`), not the
-  // default env-shadowed chain (issue #245).
-  const sts = new STSClient(buildStsClientConfig({ region, profile }));
-  try {
-    const response = await sts.send(
-      new AssumeRoleCommand({
-        RoleArn: roleArn,
-        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-invoke-${Date.now()}`,
-        DurationSeconds: 3600,
-      })
-    );
-    const creds = response.Credentials;
-    if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-      throw new Error(`AssumeRole(${roleArn}) returned no usable credentials.`);
-    }
-    return {
-      accessKeyId: creds.AccessKeyId,
-      secretAccessKey: creds.SecretAccessKey,
-      sessionToken: creds.SessionToken,
-    };
-  } finally {
-    sts.destroy();
-  }
-}
-
 function forwardAwsEnv(env: Record<string, string>): void {
   const passThrough = [
     'AWS_ACCESS_KEY_ID',
@@ -1057,11 +1025,12 @@ export async function resolveLambdaContainerEnv(
     const stsRegion =
       options.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'];
     try {
-      const creds = await assumeLambdaExecutionRole(
-        resolvedAssumeRoleArn,
-        stsRegion,
-        options.profile
-      );
+      const creds = await assumeRoleCredentials({
+        roleArn: resolvedAssumeRoleArn,
+        region: stsRegion,
+        profile: options.profile,
+        sessionNameSuffix: 'invoke',
+      });
       dockerEnv['AWS_ACCESS_KEY_ID'] = creds.accessKeyId;
       dockerEnv['AWS_SECRET_ACCESS_KEY'] = creds.secretAccessKey;
       dockerEnv['AWS_SESSION_TOKEN'] = creds.sessionToken;

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -8,7 +8,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
-import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
 import { resolveSingleTarget } from '../../local/target-picker.js';
@@ -540,30 +540,7 @@ async function assumeTaskRole(
   region: string | undefined,
   profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
-  const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  // Thread `--profile` so AssumeRole is signed with the profile's
-  // credentials, not the default env-shadowed chain (issue #245).
-  const sts = new STSClient(buildStsClientConfig({ region, profile }));
-  try {
-    const response = await sts.send(
-      new AssumeRoleCommand({
-        RoleArn: roleArn,
-        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-run-task-${Date.now()}`,
-        DurationSeconds: 3600,
-      })
-    );
-    const creds = response.Credentials;
-    if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-      throw new Error(`AssumeRole(${roleArn}) returned no usable credentials.`);
-    }
-    return {
-      accessKeyId: creds.AccessKeyId,
-      secretAccessKey: creds.SecretAccessKey,
-      sessionToken: creds.SessionToken,
-    };
-  } finally {
-    sts.destroy();
-  }
+  return assumeRoleCredentials({ roleArn, region, profile, sessionNameSuffix: 'run-task' });
 }
 
 /**

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -15,7 +15,7 @@ import {
 } from '../options.js';
 import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { getLogger } from '../../utils/logger.js';
-import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
 import { isInteractive, pickManyTargets } from '../../local/target-picker.js';
@@ -3143,39 +3143,17 @@ export function resolveContainerFallbackRegion(args: {
 }
 
 /**
- * Issue an STS AssumeRole and return temporary credentials. Mirrors
- * `cdkl invoke`'s helper byte-for-byte; lifted here so the
- * start-api command stays self-contained.
+ * Issue an STS AssumeRole and return temporary credentials, via the
+ * shared `assumeRoleCredentials` helper in `utils/role-arn.ts`
+ * (issue #509 — previously a byte-for-byte copy of `cdkl invoke`'s
+ * inline helper).
  */
 async function assumeLambdaExecutionRole(
   roleArn: string,
   region: string | undefined,
   profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
-  const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
-  // Thread `--profile` so AssumeRole is signed with the profile's
-  // credentials, not the default env-shadowed chain (issue #245).
-  const sts = new STSClient(buildStsClientConfig({ region, profile }));
-  try {
-    const response = await sts.send(
-      new AssumeRoleCommand({
-        RoleArn: roleArn,
-        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-start-api-${Date.now()}`,
-        DurationSeconds: 3600,
-      })
-    );
-    const creds = response.Credentials;
-    if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-      throw new Error(`AssumeRole(${roleArn}) returned no usable credentials.`);
-    }
-    return {
-      accessKeyId: creds.AccessKeyId,
-      secretAccessKey: creds.SecretAccessKey,
-      sessionToken: creds.SessionToken,
-    };
-  } finally {
-    sts.destroy();
-  }
+  return assumeRoleCredentials({ roleArn, region, profile, sessionNameSuffix: 'start-api' });
 }
 
 /**

--- a/src/utils/role-arn.ts
+++ b/src/utils/role-arn.ts
@@ -3,6 +3,65 @@ import { getLogger } from './logger.js';
 import { getEmbedConfig } from '../local/embed-config.js';
 import { buildStsClientConfig } from './profile-resolver.js';
 
+/** Temporary credentials minted by {@link assumeRoleCredentials}. */
+export interface AssumedRoleCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+}
+
+/**
+ * Issue an STS AssumeRole for `roleArn` and return the temporary
+ * credentials (issue #509).
+ *
+ * This is the single shared implementation behind every command's
+ * `--assume-role` / `--assume-task-role` path (`cdkl invoke`,
+ * `start-api`, `run-task`, and the `start-service` / `start-alb`
+ * emulator) — each previously carried its own near-identical copy,
+ * which kept credential-minting logic OFF this module (the one
+ * `/review-pr`'s up-bias security surface lists) and duplicated the
+ * issue #245 `--profile` threading fix four times.
+ *
+ * `sessionNameSuffix` distinguishes the callers in CloudTrail
+ * (`<resourceNamePrefix>-<suffix>-<epochMs>`). `makeError` lets a
+ * caller surface the no-usable-credentials failure as its own error
+ * class (the ECS emulator throws `LocalStartServiceError`); STS
+ * transport errors always propagate unwrapped.
+ */
+export async function assumeRoleCredentials(opts: {
+  roleArn: string;
+  region: string | undefined;
+  profile: string | undefined;
+  sessionNameSuffix: string;
+  makeError?: (message: string) => Error;
+}): Promise<AssumedRoleCredentials> {
+  // Thread `--profile` so the AssumeRole call is signed with the
+  // profile's credentials (matching `aws sts assume-role --profile
+  // <p>`), not the default env-shadowed chain (issue #245).
+  const sts = new STSClient(buildStsClientConfig({ region: opts.region, profile: opts.profile }));
+  try {
+    const response = await sts.send(
+      new AssumeRoleCommand({
+        RoleArn: opts.roleArn,
+        RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-${opts.sessionNameSuffix}-${Date.now()}`,
+        DurationSeconds: 3600,
+      })
+    );
+    const creds = response.Credentials;
+    if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
+      const message = `AssumeRole(${opts.roleArn}) returned no usable credentials.`;
+      throw opts.makeError ? opts.makeError(message) : new Error(message);
+    }
+    return {
+      accessKeyId: creds.AccessKeyId,
+      secretAccessKey: creds.SecretAccessKey,
+      sessionToken: creds.SessionToken,
+    };
+  } finally {
+    sts.destroy();
+  }
+}
+
 /**
  * Resolve the role-arn argument (CLI flag or `CDKL_ROLE_ARN` env var) and,
  * when set, assume the role and write the resulting temporary credentials

--- a/tests/unit/cli/lambda-container-env.test.ts
+++ b/tests/unit/cli/lambda-container-env.test.ts
@@ -4,8 +4,8 @@ import type { ResolvedLambda } from '../../../src/local/lambda-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
 // Mock STS so the explicit `--assume-role <arn>` path resolves to deterministic
-// temp credentials without a real AWS call (the helper's `assumeLambdaExecutionRole`
-// dynamically imports @aws-sdk/client-sts).
+// temp credentials without a real AWS call (the shared `assumeRoleCredentials`
+// helper in utils/role-arn.ts imports @aws-sdk/client-sts).
 vi.mock('@aws-sdk/client-sts', () => ({
   STSClient: class {
     async send(): Promise<unknown> {

--- a/tests/unit/utils/role-arn.test.ts
+++ b/tests/unit/utils/role-arn.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// Capture every STSClient construction + AssumeRoleCommand input so the
+// tests can assert the shared helper's wire behavior without a real AWS
+// call (issue #509 — the single implementation behind every command's
+// `--assume-role` / `--assume-task-role` path).
+const { sent, clientConfigs, destroyed, sendImpl } = vi.hoisted(() => ({
+  sent: [] as unknown[],
+  clientConfigs: [] as unknown[],
+  destroyed: { count: 0 },
+  sendImpl: {
+    fn: async (): Promise<unknown> => ({
+      Credentials: {
+        AccessKeyId: 'AKIATEST',
+        SecretAccessKey: 'secretTEST',
+        SessionToken: 'tokTEST',
+      },
+    }),
+  },
+}));
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    constructor(config: unknown) {
+      clientConfigs.push(config);
+    }
+    async send(command: unknown): Promise<unknown> {
+      sent.push(command);
+      return sendImpl.fn();
+    }
+    destroy(): void {
+      destroyed.count += 1;
+    }
+  },
+  AssumeRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+import { assumeRoleCredentials } from '../../../src/utils/role-arn.js';
+
+const ROLE_ARN = 'arn:aws:iam::111111111111:role/AppRole';
+
+describe('assumeRoleCredentials (issue #509 shared helper)', () => {
+  beforeEach(() => {
+    sent.length = 0;
+    clientConfigs.length = 0;
+    destroyed.count = 0;
+    sendImpl.fn = async () => ({
+      Credentials: {
+        AccessKeyId: 'AKIATEST',
+        SecretAccessKey: 'secretTEST',
+        SessionToken: 'tokTEST',
+      },
+    });
+  });
+
+  it('returns the minted credentials and destroys the client', async () => {
+    const creds = await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: 'us-east-1',
+      profile: undefined,
+      sessionNameSuffix: 'invoke',
+    });
+    expect(creds).toEqual({
+      accessKeyId: 'AKIATEST',
+      secretAccessKey: 'secretTEST',
+      sessionToken: 'tokTEST',
+    });
+    expect(destroyed.count).toBe(1);
+  });
+
+  it('builds the RoleSessionName from the embed prefix + caller suffix, 1h duration', async () => {
+    await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-service',
+    });
+    const input = (sent[0] as { input: Record<string, unknown> }).input;
+    expect(input['RoleArn']).toBe(ROLE_ARN);
+    expect(input['RoleSessionName']).toMatch(/^cdkl-start-service-\d+$/);
+    expect(input['DurationSeconds']).toBe(3600);
+  });
+
+  it('threads --profile and --region into the STS client config (issue #245)', async () => {
+    await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: 'eu-west-1',
+      profile: 'dev',
+      sessionNameSuffix: 'run-task',
+    });
+    expect(clientConfigs[0]).toMatchObject({ region: 'eu-west-1', profile: 'dev' });
+  });
+
+  it('throws a plain Error when the response has no usable credentials', async () => {
+    sendImpl.fn = async () => ({ Credentials: { AccessKeyId: 'AKIATEST' } });
+    await expect(
+      assumeRoleCredentials({
+        roleArn: ROLE_ARN,
+        region: undefined,
+        profile: undefined,
+        sessionNameSuffix: 'invoke',
+      })
+    ).rejects.toThrow(`AssumeRole(${ROLE_ARN}) returned no usable credentials.`);
+    expect(destroyed.count).toBe(1);
+  });
+
+  it("surfaces the no-credentials failure through the caller's makeError class", async () => {
+    class CallerError extends Error {}
+    sendImpl.fn = async () => ({});
+    await expect(
+      assumeRoleCredentials({
+        roleArn: ROLE_ARN,
+        region: undefined,
+        profile: undefined,
+        sessionNameSuffix: 'start-service',
+        makeError: (message) => new CallerError(message),
+      })
+    ).rejects.toBeInstanceOf(CallerError);
+  });
+
+  it('propagates an STS transport error unwrapped even when makeError is set', async () => {
+    class CallerError extends Error {}
+    const transport = new Error('connect ETIMEDOUT');
+    sendImpl.fn = async () => {
+      throw transport;
+    };
+    const failure = await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-api',
+      makeError: (message) => new CallerError(message),
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    expect(failure).toBe(transport);
+    expect(destroyed.count).toBe(1);
+  });
+});
+
+// Site-level binding lock (same pattern as sts-client-profile-audit): the
+// four command call sites delegate to the shared helper through thin,
+// non-exported wrappers, so a dropped `sessionNameSuffix` / `makeError`
+// would not fail any behavioral test — grep the source instead.
+describe('assumeRoleCredentials call-site bindings', () => {
+  const here = fileURLToPath(new URL('.', import.meta.url));
+  const commandsDir = join(here, '..', '..', '..', 'src', 'cli', 'commands');
+  const read = (file: string): string => readFileSync(join(commandsDir, file), 'utf-8');
+
+  it.each([
+    ['local-invoke.ts', 'invoke'],
+    ['local-start-api.ts', 'start-api'],
+    ['local-run-task.ts', 'run-task'],
+    ['ecs-service-emulator.ts', 'start-service'],
+  ])('%s mints via the shared helper with suffix %s', (file, suffix) => {
+    const source = read(file);
+    expect(source).toContain(`sessionNameSuffix: '${suffix}'`);
+    expect(source).toMatch(/assumeRoleCredentials\(\{/);
+    // No residual inline AssumeRole implementation may survive in the
+    // command file (issue #509 — the duplication this helper replaced).
+    expect(source).not.toMatch(/new AssumeRoleCommand\(/);
+  });
+
+  it('the emulator preserves LocalStartServiceError via makeError', () => {
+    const source = read('ecs-service-emulator.ts');
+    expect(source).toMatch(/makeError:\s*\(message\)\s*=>\s*new LocalStartServiceError\(message\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #509, option 1 (extract, don't list): `cdkl invoke`, `start-api`, `run-task`, and the `start-service` / `start-alb` emulator each carried a near-identical inline STS `AssumeRoleCommand` implementation, keeping credential-minting logic off `src/utils/role-arn.ts` — the module the review up-bias security surface lists — so a PR changing how STS credentials are minted was reviewed at whatever tier its size gave.

The whole-class audit found the duplication is FOUR copies, not the two the issue names: `local-run-task.ts` and `local-start-api.ts` carried the same helper (the latter's JSDoc said "mirrors `cdkl invoke`'s helper byte-for-byte"). All four call sites now route through one shared `assumeRoleCredentials(...)` in `src/utils/role-arn.ts`:

- the per-command `RoleSessionName` segment is preserved via `sessionNameSuffix` (`invoke` / `start-service` / `run-task` / `start-api`);
- the emulator's `LocalStartServiceError` on the no-usable-credentials check is preserved via the optional `makeError` factory; STS transport errors always propagate unwrapped;
- the issue #245 `--profile` threading (`buildStsClientConfig`) now lives in one place, on a module already covered by the `sts-client-profile-audit` test and the review up-bias.

No behavior change: session-name wire format, error classes, flags, and credential handling are identical. The old copies' lazy `await import('@aws-sdk/client-sts')` bought nothing — each command file already statically imports `role-arn.js`, which statically imports the STS client — so the shared static import is load-order equivalent.

Won't-do (recorded here): `assumeRoleCredentials` is NOT re-exported from `src/internal.ts` — hosts reach this behavior through the command factories; widening the internal surface was considered and skipped.

## Test plan

- New `tests/unit/utils/role-arn.test.ts`: 6 behavioral tests (minted-credentials shape + client destroy, session-name format, `--profile` / `--region` threading, plain-Error and `makeError`-wrapped no-credentials failures, unwrapped transport-error propagation) plus 5 site-level binding locks (each command file calls the shared helper with its exact `sessionNameSuffix`, carries no residual inline `AssumeRoleCommand`, and the emulator passes the `LocalStartServiceError` `makeError`).
- Full suite: 209 files / 3137 tests pass; `vp run check` + build green.
- Live-tested against real AWS via the `local-invoke-assume-role` integ fixture (deploy → invoke → destroy, run twice, all clean): baseline shows no implicit credential injection; explicit and bare `--assume-role` both returned the deployed role's `assumed-role/<RoleName>/cdkl-invoke-<ts>` STS identity minted by the shared helper.

## Review (3-axis)

Base tier 1-reviewer (376 LOC / 7 files) up-biased to 3-axis by the `src/utils/role-arn.ts` security surface. Spec reviewer: clean, all five spec points verified with citations. Code reviewer: one nit (the insertion orphaned `applyRoleArnIfSet`'s JSDoc from its function) — fixed by reattaching the block. Test reviewer: three low-severity call-site gaps — closed by the site-level binding tests above. Won't-do (informational nits, recorded here): the `makeError` test asserts the error class but not the message text, and the partial-credentials guard is exercised via two of its variants rather than all enumerations — both sit behind the same `||` chain the happy-path test locks.

Closes #509 (merged before this body fix landed, so the issue is closed manually with a pointer).
