### PR TITLE
chore(work-issues): ship-order for flake-fix lanes, and two single-call gotchas

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -514,6 +514,19 @@ merge is blocked by `gh-pr-merge-worktree-gate.sh` unless `/merge-pr` set the
 are disjoint — which is also why a clean merge says nothing about whether a
 collision happened (§7).
 
+**When one lane fixes a full-suite flake, merge THAT lane first** — every other
+lane's `/check` and `/verify-pr` runs the same suite, so until the fix is on
+`main` each of them rolls the same dice. On 2026-08-19 the go-to-k/cdk-local#509
+lane's suite runs hit the go-to-k/cdk-local#515 timeout twice (2/2 in that
+worktree) while the fix sat unmerged in a sibling lane; merging the fix
+(go-to-k/cdk-local#522) and rebasing made the very next run green. The rebase is
+what delivers the fix — a lane branched before the merge keeps flaking on its
+own stale base. Corollary for a PR's CI: it runs on the MERGE ref (branch +
+current `main`), so a red check can be caused by a PEER's just-merged content
+your local green never saw — go-to-k/cdk-local#524's new reference harness
+failed CI on a line go-to-k/cdk-local#520 had merged in parallel; the fix was
+fetch + rebase + re-run, not distrusting the harness.
+
 ```bash
 git checkout main && git pull origin main    # bring the merges local
 ```
@@ -742,6 +755,26 @@ the run evidence behind it — or "no skill change" plus what held.
   cannot tell a finished lane from a session working right now, already-merged
   branch tip included. The closing check is "mine are gone", not "only main
   remains".
+- **Start every marker / gate command with an explicit `cd <worktree> &&`** — the
+  shell cwd does not reliably persist across tool calls, and a `markgate set` /
+  sha-sentinel write that lands in the WRONG worktree surfaces later as a
+  mystifying `no marker` (each worktree has its own markgate store). On
+  2026-08-19 this fired twice in one run: a `markgate status check` diagnosed
+  "no marker" because it ran in the main checkout while the marker sat in the
+  lane's store, and a `.markgate-pr-review-sha` was written into the main
+  checkout before the mistake was caught and redone from the lane. `pwd` costs
+  nothing; a marker in the wrong store costs a re-diagnosis.
+- **A gated command must be the ONLY thing in its Bash call.** A PreToolUse hook
+  denial aborts the WHOLE command string BEFORE any line runs — including
+  preamble side effects you assumed happened. On 2026-08-19 a
+  `cat > body.md <<EOF ... && gh pr create --body-file body.md` was blocked by
+  `verify-pr-gate`, so the body file was never written; a later `cat >>` append
+  then CREATED the file as a fragment, and PR go-to-k/cdk-local#525 opened with
+  only its review section — no summary and no `Closes` line, which silently
+  cost the issue's auto-close at merge. Same mechanism as the documented
+  markgate-set rule (`.claude/rules/hooks.md`, gh-pr-merge-worktree-gate): write
+  files and set markers in their own calls, then run `git commit` /
+  `gh pr create` / `gh pr merge` alone.
 - **`/merge-pr`, not a hand-run merge** — a hand-run `gh pr merge --delete-branch`
   from a side worktree trips the `'main' is already used by worktree` fatal (the
   remote merge lands but local cleanup fails) and is gate-blocked besides.


### PR DESCRIPTION
## Summary

Section 10 retrospective of the 2026-08-19 `/work-issues` run (issues #509 / #515 / #514). Three lessons, each with in-run evidence carried inline per the skill's own style:

1. **Section 9 — flake-fix lanes merge first.** Every lane's `/check` and `/verify-pr` runs the same suite, so a known-flake fix sitting unmerged in a sibling lane keeps every other lane rolling the dice: the issue #509 lane hit the issue #515 timeout 2/2 in its worktree until PR #522 merged, and its very next post-rebase run was green. The corollary is that a PR's CI runs on the MERGE ref, so a red check can be caused by a peer's just-merged content local green never saw — PR #524's new reference harness failed CI on a line PR #520 merged in parallel; the fix was fetch + rebase + re-run.
2. **Gotchas — explicit `cd` on every marker / gate command.** The shell cwd does not reliably persist across tool calls, and each worktree has its own markgate store, so a marker set in the wrong one surfaces later as a mystifying `no marker`. Fired twice this run (a misdiagnosed `markgate status check`, and a `.markgate-pr-review-sha` written into the main checkout and redone).
3. **Gotchas — a gated command must be the only thing in its Bash call.** A PreToolUse denial aborts the whole command string including preamble side effects; a retry built on `>>` then produces a fragment. That is exactly how PR #525 opened with only its review section and no `Closes` line (costing the issue's auto-close). Generalizes the markgate-set-separate-call rule already documented in `.claude/rules/hooks.md`.

No line was cut in exchange: the run proved no existing sentence stale, and none of the three lessons restates one (the third points at the existing hooks.md rule rather than duplicating it).

## Test plan

- `tests/unit/skills/work-issues-skill-refs.test.ts` green on the edited file (all new issue refs fully qualified).
- Full suite 209 files / 3128 tests, `vp run check` + build green.
- Prose-only diff (`.claude/**`): claims verified against this repo — the cited PRs/issues are this session's own, and the referenced `.claude/rules/hooks.md` section exists.
