### PR TITLE
test: bind agentcore WS test servers to 127.0.0.1 to close the wildcard-bind hijack window

### DIFF
--- a/tests/unit/local/agentcore-ws-bridge.test.ts
+++ b/tests/unit/local/agentcore-ws-bridge.test.ts
@@ -38,9 +38,26 @@ interface FakeContainer {
   headersFor: () => Record<string, string | string[] | undefined>;
 }
 
+/**
+ * Every fake container binds 127.0.0.1 explicitly, never the wildcard: a
+ * wildcard (`::`) bind leaves 127.0.0.1:<port> claimable by a parallel test
+ * process (SO_REUSEADDR permits the specific-over-wildcard bind on macOS),
+ * whose HTTP server then answers this file's 127.0.0.1 clients with its own
+ * 404 on the upgrade — issue #521's "Unexpected server response: 404" flake.
+ */
+const LOOPBACK = '127.0.0.1';
+
+function boundPort(wss: WebSocketServer): number {
+  const addr = wss.address() as AddressInfo;
+  // Regression guard for the wildcard-bind flake — fails if the explicit
+  // host binding is ever dropped.
+  expect(addr.address).toBe(LOOPBACK);
+  return addr.port;
+}
+
 /** Start a fake container `/ws` server that echoes each frame as `echo:<frame>`. */
 async function startFakeContainer(): Promise<FakeContainer> {
-  const wss = new WebSocketServer({ port: 0, path: '/ws' });
+  const wss = new WebSocketServer({ port: 0, host: LOOPBACK, path: '/ws' });
   containers.push(wss);
   const received: string[] = [];
   let headers: Record<string, string | string[] | undefined> = {};
@@ -53,7 +70,7 @@ async function startFakeContainer(): Promise<FakeContainer> {
     });
   });
   await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
-  return { port: (wss.address() as AddressInfo).port, received, headersFor: () => headers };
+  return { port: boundPort(wss), received, headersFor: () => headers };
 }
 
 /** Connect a header-less browser client to the bridge URL. */
@@ -143,14 +160,14 @@ describe('startAgentCoreWsBridge', () => {
 
   it('gives each browser connection its own session id', async () => {
     const sessions: string[] = [];
-    const wss = new WebSocketServer({ port: 0, path: '/ws' });
+    const wss = new WebSocketServer({ port: 0, host: LOOPBACK, path: '/ws' });
     containers.push(wss);
     wss.on('connection', (ws, req) => {
       sessions.push(String(req.headers[AGENTCORE_SESSION_ID_HEADER.toLowerCase()]));
       ws.on('message', (d) => ws.send(d.toString()));
     });
     await new Promise<void>((r) => wss.on('listening', () => r()));
-    const containerPort = (wss.address() as AddressInfo).port;
+    const containerPort = boundPort(wss);
 
     const bridge = await startAgentCoreWsBridge({ containerHost: '127.0.0.1', containerPort });
     bridges.push(bridge);
@@ -170,11 +187,11 @@ describe('startAgentCoreWsBridge', () => {
   });
 
   it('closes the browser socket when the container closes', async () => {
-    const wss = new WebSocketServer({ port: 0, path: '/ws' });
+    const wss = new WebSocketServer({ port: 0, host: LOOPBACK, path: '/ws' });
     containers.push(wss);
     wss.on('connection', (ws) => ws.close());
     await new Promise<void>((r) => wss.on('listening', () => r()));
-    const containerPort = (wss.address() as AddressInfo).port;
+    const containerPort = boundPort(wss);
 
     const bridge = await startAgentCoreWsBridge({ containerHost: '127.0.0.1', containerPort });
     bridges.push(bridge);

--- a/tests/unit/local/agentcore-ws-client.test.ts
+++ b/tests/unit/local/agentcore-ws-client.test.ts
@@ -25,11 +25,28 @@ interface StartedServer {
   lastHeaders: () => Record<string, string | string[] | undefined>;
 }
 
+/**
+ * Every server here binds 127.0.0.1 explicitly, never the wildcard: a
+ * wildcard (`::`) bind leaves 127.0.0.1:<port> claimable by a parallel test
+ * process (SO_REUSEADDR permits the specific-over-wildcard bind on macOS),
+ * whose HTTP server then answers this file's 127.0.0.1 clients with its own
+ * 404 on the upgrade — issue #521's "Unexpected server response: 404" flake.
+ */
+const LOOPBACK = '127.0.0.1';
+
+function boundPort(wss: WebSocketServer): number {
+  const addr = wss.address() as AddressInfo;
+  // Regression guard for the wildcard-bind flake — fails if the explicit
+  // host binding is ever dropped.
+  expect(addr.address).toBe(LOOPBACK);
+  return addr.port;
+}
+
 /** Start a `/ws` server; `onConn` decides how the server replies/closes. */
 async function startServer(
   onConn: (ws: WebSocket, firstFrame: string) => void
 ): Promise<StartedServer> {
-  const wss = new WebSocketServer({ port: 0, path: '/ws' });
+  const wss = new WebSocketServer({ port: 0, host: LOOPBACK, path: '/ws' });
   servers.push(wss);
   let headers: Record<string, string | string[] | undefined> = {};
   wss.on('connection', (ws, req) => {
@@ -37,8 +54,7 @@ async function startServer(
     ws.once('message', (data) => onConn(ws, data.toString()));
   });
   await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
-  const port = (wss.address() as AddressInfo).port;
-  return { port, lastHeaders: () => headers };
+  return { port: boundPort(wss), lastHeaders: () => headers };
 }
 
 /**
@@ -49,7 +65,7 @@ async function startServer(
 async function startMultiFrameServer(
   onFrame: (ws: WebSocket, frame: string, index: number) => void
 ): Promise<StartedServer> {
-  const wss = new WebSocketServer({ port: 0, path: '/ws' });
+  const wss = new WebSocketServer({ port: 0, host: LOOPBACK, path: '/ws' });
   servers.push(wss);
   let headers: Record<string, string | string[] | undefined> = {};
   wss.on('connection', (ws, req) => {
@@ -61,8 +77,7 @@ async function startMultiFrameServer(
     });
   });
   await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
-  const port = (wss.address() as AddressInfo).port;
-  return { port, lastHeaders: () => headers };
+  return { port: boundPort(wss), lastHeaders: () => headers };
 }
 
 async function* fromArray<T>(items: T[]): AsyncIterable<T> {
@@ -309,7 +324,7 @@ describe('bridgeAgentCoreWs', () => {
     sendToClient: (text: string) => void;
     closeClient: () => void;
   }> {
-    const wss = new WebSocketServer({ port: 0, path: '/ws' });
+    const wss = new WebSocketServer({ port: 0, host: LOOPBACK, path: '/ws' });
     servers.push(wss);
     const received: string[] = [];
     let headers: Record<string, string | string[] | undefined> = {};
@@ -321,7 +336,7 @@ describe('bridgeAgentCoreWs', () => {
       onConn?.(ws);
     });
     await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
-    const port = (wss.address() as AddressInfo).port;
+    const port = boundPort(wss);
     return {
       port,
       received,


### PR DESCRIPTION
## Summary

Fixes the load-dependent `Unexpected server response: 404` flake on the WS
upgrade in `tests/unit/local/agentcore-ws-client.test.ts` (observed 1 run in
13 during the issue (#515) flake measurement), and the identical latent shape
in `tests/unit/local/agentcore-ws-bridge.test.ts`.

## Root cause (reproduced deterministically)

`new WebSocketServer({ port: 0 })` binds the wildcard address (`::`). On
macOS, SO_REUSEADDR permits another process to bind `127.0.0.1:<same port>`
specifically OVER the live wildcard bind — and the OS routes connections to
the most specific binding. Under parallel full-suite load, another vitest
fork worker's ephemeral server can land on `127.0.0.1:<port>`, and this
file's `127.0.0.1` client then reaches THAT process's HTTP server, whose 404
answer to the upgrade request is exactly the observed error.

Demonstration (scratchpad script, run on this machine):

```text
[wss] bound to address=:: port=59206
[intruder] BOUND 127.0.0.1:59206 over the live wildcard bind (SO_REUSEADDR)
[client] upgrade result: Unexpected server response: 404
[wss-fixed] bound to address=127.0.0.1 port=59208
[intruder2] bind failed: EADDRINUSE — specific bind closes the hijack window
```

## Fix

Bind every test WS server to `127.0.0.1` explicitly (`host: LOOPBACK`), the
same address the clients connect to. With the specific bind, an intruding
bind on the same port fails `EADDRINUSE` instead of silently shadowing the
server. A shared `boundPort` helper asserts the bound address in both files,
so dropping the explicit host binding fails loudly (verified: removing it
fails 15 cases with `expected '::' to be '127.0.0.1'`).

This is the setup-race class of fix the issue asked for — no timeout was
raised.

## Test plan

- `vp run verify` green; full suite 210 files / 3139 tests pass.
- Failure direction driven: host binding removed -> 15 assertion failures;
  restored -> 26/26 pass across both files.
- No `src/**` change (tests only), so no integ run is required by the integ
  gate's scope.

Closes #521
