### PR TITLE
chore(work-issues): mirror the scanner-calibration lesson and the test-vs-content collision shape

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -34,7 +34,7 @@ If any fail, show the error output and STOP — do not write the commit-gate mar
 
 After all three checks pass, record a marker so the `check` gate is fresh. The marker is managed by [markgate](https://github.com/go-to-k/markgate) and captures the current working tree state; any subsequent edits invalidate it and require re-running `/check`.
 
-Run this from the repo root (cdk-local pins markgate via mise, so use `mise exec` to avoid PATH issues when shims aren't active):
+Run this from the WORKTREE you will commit from — not the main checkout (each worktree has its own markgate marker store, so a marker set elsewhere surfaces later as a mystifying "no marker"; see the convention in `.claude/rules/hooks.md`). cdk-local pins markgate via mise, so use `mise exec` to avoid PATH issues when shims aren't active:
 
 ```bash
 mise exec -- markgate set check

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -344,6 +344,25 @@ surface is wide: go-to-k/cdk-local#506 named 7 missing paths, and an independent
 found ~18 more (the authorizer ENFORCEMENT points, not just the verifiers), which
 is what actually shipped.
 
+**When the fix mechanizes a rule as a repo-wide SCANNER test, calibrate the
+detection rule against the PRE-FIX broken tree — do not implement the issue's
+signature literally.** An issue describes the signature as its author noticed ONE
+instance, not as a rule with a measured false-positive rate. Run the candidate
+rule over the unrepaired tree and read every hit before committing to it: in
+go-to-k/cdk-real-drift#1771 -> go-to-k/cdk-real-drift#1782 (2026-08-19) the
+issue's proposed "code span
+immediately followed by an alphanumeric" flagged ~30 spots, mostly idiomatic
+prose; measuring on the broken tree split the hits by side (before-side 5/5
+genuine; after-side 13 with 6 ordinary plural suffixes), yielding a rule with
+zero false positives that still caught all 12 real hits. One markdown-specific
+trap: a code span may WRAP a line break, so decide explicitly whether your
+scanner handles that — either tokenize per PARAGRAPH, or scan per line and
+ENFORCE the single-line-span convention as part of the test, the way this repo's
+`tests/unit/skills/work-issues-skill-refs.test.ts` deliberately does (a per-line
+scan that has not decided pairs one span's closing backtick with the next one's
+opening backtick and invents findings). And report the HIT's own line number,
+not the paragraph start — the consumer of a finding is someone jumping to it.
+
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an
 explicit "do NOT touch <the other lanes' / other agents' files>; STOP and report
@@ -389,6 +408,24 @@ go-to-k/cdk-real-drift#1772 and go-to-k/cdk-real-drift#1773 both rewrote
 04:31:00Z); both survived by luck, not by design. When your PR lands into a file
 another PR touched in the same window, the absent conflict proves nothing — confirm
 it after the pull in §9.
+
+The same silence covers a second shape: a peer PR that adds a **repo-wide check**
+— a test globbing the tree (`git ls-files`, a `readdirSync` over a directory) or a
+new lint rule — gains jurisdiction over CONTENT in files it never touched, so
+file-disjointness says nothing and neither PR's CI exercised the pair (yours ran
+before their check existed, theirs before your content did). `main` can go red on
+a merge where both sides were green. This repo has measured both halves: its own
+§9 CI corollary records go-to-k/cdk-local#524's reference harness failing on a
+line go-to-k/cdk-local#520 merged in parallel, and in cdk-real-drift
+(2026-08-19) go-to-k/cdk-real-drift#1782 merged a `git ls-files "*.md"` scanner
+while go-to-k/cdk-real-drift#1783 was adding ~100 lines of markdown it never
+touched — the rebase was clean, and running the scanner over the new prose (21/21)
+cost one command. So when a peer merges mid-lane, look at **what** it added, not
+only which files it touched: rebase, then RUN any repo-wide check the peer
+introduced over your own diff before merging. This repo is especially exposed —
+it already ships repo-wide consistency tests (the four-copies harness
+`.claude/hooks/pr-review-gate.test.sh`, the reference scanner
+`tests/unit/skills/work-issues-skill-refs.test.ts`).
 
 ## 8. Verify before merge (`/verify-pr`)
 
@@ -512,7 +549,9 @@ cleans the worktree + local branch + remote branch in one pass. A hand-run workt
 merge is blocked by `gh-pr-merge-worktree-gate.sh` unless `/merge-pr` set the
 `merge-pr` marker. If a later PR is behind, GitHub still merges it when the files
 are disjoint — which is also why a clean merge says nothing about whether a
-collision happened (§7).
+collision happened (§7), in either shape: content-vs-content, or a peer's
+repo-wide check judging your content (run the peer's new check over your diff
+after the rebase, per §7).
 
 **When one lane fixes a full-suite flake, merge THAT lane first** — every other
 lane's `/check` and `/verify-pr` runs the same suite, so until the fix is on


### PR DESCRIPTION
## Summary

Mirrors two `/work-issues` flow lessons from sibling repos, verified claim by
claim against THIS repo before shipping the wording (the section 10-c rule),
in one lane because both issues edit the same file.

### Issue (#523) — cdk-real-drift's markgate + scanner lessons

- Lessons 1 (a `markgate set` must be its own Bash call — a PreToolUse gate
  judges the whole command string before any line runs) and 2 (set markers
  from the worktree) are ALREADY on `main` here via the two gotchas merged in
  PR (#527). Verified rather than re-added; the one residual wrong sentence
  was `.claude/skills/check/SKILL.md`'s "Run this from the repo root", which
  in the mandated worktree flow points at the WRONG marker store — amended to
  "run from the worktree you will commit from". Measured live in this repo:
  markers are PER-WORKTREE stores (unlike cdk-real-drift's shared store) — a
  `markgate set check` in the lane worktree left the main checkout reporting
  `no marker`.
- Lesson 3 is the residual delta: a new section 5 paragraph — calibrate a
  repo-wide scanner test against the PRE-FIX broken tree instead of
  implementing the issue's signature literally. The evidence citation was
  itself corrected during verification: issue (#523) attributed the
  measurement to go-to-k/cdk-real-drift#1783, but the numbers are recorded
  in go-to-k/cdk-real-drift#1771 -> go-to-k/cdk-real-drift#1782 (confirmed
  by reading both). The span-wrapping trap is stated both ways because this
  repo's own scanner (`tests/unit/skills/work-issues-skill-refs.test.ts`)
  deliberately chose per-line scanning + an enforced single-line-span
  convention over per-paragraph tokenization.

### Issue (#526) — a peer's repo-wide check collides with your content

- Section 7: extended the "a clean rebase / merge is NOT evidence" paragraph
  with the test-vs-content shape — a peer PR adding a repo-wide check gains
  jurisdiction over content in files it never touched; rebase and RUN the
  peer's new check over your own diff before merging. Anchored to this repo's
  own measured instance (PR (#524)'s harness failing CI on a line PR (#520)
  merged in parallel) plus the cdk-real-drift measurement
  (go-to-k/cdk-real-drift#1782 vs go-to-k/cdk-real-drift#1783).
- Section 9: the "GitHub still merges it when the files are disjoint"
  sentence now carries the test-vs-content caveat and points at section 7.

## Verification

- `vp run verify` green; full suite 210 files / 3139 tests pass.
- `tests/unit/skills/work-issues-skill-refs.test.ts` green over the edited
  SKILL.md (all new issue references fully qualified).
- `vp run test:hooks` green (48 pass) — no hook touched, run as a guard.
- Every artifact the new prose names resolves in this repo
  (`.claude/hooks/pr-review-gate.test.sh`, the refs test, the hooks.md
  worktree convention); the cited sibling-repo evidence was opened and read.

Closes #523
Closes #526
