### PR TITLE
chore(work-issues): source same-file markers from merged text, grep -cF, life-only probes, and branch cleanup

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -571,19 +571,52 @@ git checkout main && git pull origin main    # bring the merges local
 ```
 
 So when your PR landed into a file another PR touched in the same window, grep the
-pulled `main` for a marker string from EACH side before believing both survived —
-one side silently overwriting the other looks exactly like a clean merge. Take each
-marker from that PR's own DIFF (`gh pr diff <n>`), never from its title: on
-2026-08-19 a marker lifted from go-to-k/cdk-local#518's title ("uncommitted-work probe") was absent
-from `main` while its actual text — `status --porcelain`, "dirty tree" — was
-present, i.e. the check reported a lost merge that had not happened.
+merged `main` for a marker string from EACH side before believing both survived —
+one side silently overwriting the other looks exactly like a clean merge. Grep the
+MERGED text, not a working copy:
+`git show origin/main:<file> | grep -cF "<marker>"`. Run from a lane worktree, a
+grep of `<file>` reads YOUR branch and passes while main is missing the very lines
+being checked (cdkd's copy of this check was vacuous for a while in exactly that
+shape, go-to-k/cdkd#2009); after the checkout+pull above the main checkout's file
+IS the merged text, but the `git show` form is correct from anywhere. `-F` is
+load-bearing — prose markers are full of regex metacharacters (`.`, `[`, `*`),
+and without it a marker silently fails to match, producing exactly the false
+lost-content alarm this check exists to prevent (it is the double quotes, not
+`-F`, that handle apostrophes). And `grep -c` exits 1 on zero matches — the very
+case being hunted — so never chain the two greps with `&&`. Pick a phrase that
+sits on ONE LINE of the merged file: this file's prose is hard-wrapped, grep is
+line-based, and a marker spanning the wrap returns a false 0 (measured while
+writing this paragraph — a phrase from go-to-k/cdk-local#530's own merged text
+scored 0 until it was re-picked within one line). Source each marker
+from MERGED text, never from a title or a draft you read earlier: take THEIRS
+from their merge commit
+(`git show "$(gh pr view <n> --json mergeCommit -q .mergeCommit.oid):<file>"`).
+On 2026-08-19 a marker lifted from go-to-k/cdk-local#518's title
+("uncommitted-work probe") was absent from `main` while its actual text —
+`status --porcelain`, "dirty tree" — was present, and in cdkd a draft-sourced
+marker against go-to-k/cdkd#2000 came back 0 after the lane reworded the sentence
+between the draft and the merge — both false lost-merge alarms. Read the two
+counts asymmetrically: whichever lane merged LAST has its marker read back out of
+what is now the tip, so that arm is tautological — two `1`s are one real
+confirmation plus one tautology, never two independent ones. Settle a 0 from your
+lane worktree with `diff <(git show origin/main:<file>) <file>` — the lines your
+commit removed should be exactly the ones you meant to replace.
 
-`/merge-pr` already removes the worktree it merged; the check is that **every
-worktree THIS run added is gone** — never that only the main checkout remains:
+`/merge-pr` already removes the worktree it merged AND deletes the local branch —
+its step 5 runs `git branch -D`, and `-D` is load-bearing because this repo
+squash-merges: a merged tip is never an ancestor of `main`, so `-d` refuses it as
+"not fully merged". Read that refusal as the expected squash artifact, not as
+unmerged work — but only after confirming the PR is MERGED. The closing check is
+that **every worktree AND every local branch THIS run added is gone** — never that
+only the main checkout remains. `git worktree remove` on its own never deletes a
+branch, so a crashed or interrupted `/merge-pr` leaves the local ref behind
+(cdkd's section 9 claimed otherwise and accumulated a dozen stale merged
+branches before go-to-k/cdkd#2015 corrected it):
 
 ```bash
 git worktree list      # yours gone; one you did NOT add may be a LIVE peer lane
 git worktree prune     # drops entries whose directory a peer already removed
+git branch --list      # local branches THIS run created are gone too
 ```
 
 `git worktree list` cannot tell you whose a worktree is: a finished lane and a
@@ -591,7 +624,14 @@ session working right now look identical, an already-on-`main` branch tip includ
 — a peer lane merges its own PR and keeps working. Before removing one you did not
 add, confirm it is finished (`git log --oneline -1 <branch>`, then `gh pr list
 --state all --head <branch>` for an OPEN PR), and when in doubt leave it and say so
-in the wrap. In cdk-real-drift on 2026-08-19 (go-to-k/cdk-real-drift#1775) a run
+in the wrap. Read every such probe — the §4 claim comment, §2's dirty-tree check,
+the log, the PR state — as evidence of LIFE only; none can establish absence. An
+absent claim comment is NO signal, never "unowned" (the §4 comment is this repo's
+only ownership record, written once at claim time — so its timestamp is CLAIM
+time, not last activity, and an old stamp is equally what a long-running live
+session looks like), and a MERGED PR is not proof of death — its owner may still
+be inside §9 or §10. Run the probes to find a reason to LEAVE a worktree, never
+as a licence to remove one. In cdk-real-drift on 2026-08-19 (go-to-k/cdk-real-drift#1775) a run
 read a peer's worktree as residue of the previous run — the reading the old wording
 invites — and that lane merged go-to-k/cdk-real-drift#1773 while the reading lane
 was still open.


### PR DESCRIPTION
## Summary

Mirrors the four `/work-issues` lessons from cdkd's 2026-08-19 run
(go-to-k/cdkd#2009 + go-to-k/cdkd#2015; the cdk-real-drift mirror is
go-to-k/cdk-real-drift#1790) into this repo's section 9, verified claim by
claim against THIS repo per section 10-c. Issues (#528) and (#531) were filed
9 minutes apart from the two sibling-repo mirrors and carry the same lesson
set, so one lane ships both.

### Same-file marker check (section 9)

- Grep the MERGED text (`git show origin/main:<file> | grep -cF "<marker>"`),
  not a working copy — run from a lane worktree, a grep of `<file>` reads
  YOUR branch and is vacuous (the shape cdkd's copy had).
- `grep -cF`: `-F` is load-bearing for regex metacharacters in prose markers,
  and `grep -c` exits 1 on zero matches so the two greps must never be
  chained. Measured on this machine (whose `grep` is ugrep: the un-escaped
  `[` is a hard rc=2 error — same false-alarm direction, louder).
- NEW trap found while live-testing this very wording: the marker phrase must
  sit on ONE LINE of the merged file. A phrase from PR (#530)'s own merged
  text scored a false 0 because it spanned the hard-wrap; re-picked within
  one line it scored 1. The paragraph now says so.
- Source THEIR marker from THEIR merge commit (`gh pr view <n> --json
  mergeCommit -q .mergeCommit.oid`), never a title or a draft (this repo's
  existing PR-title evidence kept, cdkd's draft-reword evidence
  go-to-k/cdkd#2000 added); the last-merged arm is tautological; a genuine 0
  settles with `diff <(git show origin/main:<file>) <file>`.

### Life-only probes (section 9)

Adapted to this repo's actual ownership signals (no owner sentinel here —
the section 4 claim comment, the section 2 dirty-tree probe, the log and the
PR state): all are evidence of LIFE only, none establishes absence; an
absent claim is NO signal; a MERGED PR is not death; a claim timestamp is
claim time. Probes are run to find a reason to LEAVE a worktree, never as a
licence to remove one.

### Branch cleanup (section 9 closing check)

This repo's `/merge-pr` already deletes the local branch (step 5,
`git branch -D` — `-D` load-bearing because the repo squash-merges, so `-d`
refuses the merged tip as "not fully merged"; confirmed against
`.claude/skills/merge-pr/SKILL.md` before carrying the reasoning over). The
residual gap: `git worktree remove` never deletes a branch, so a crashed
`/merge-pr` leaves the local ref — the closing check now lists branches as
well as worktrees (cdkd accumulated a dozen stale merged branches before
go-to-k/cdkd#2015 corrected the equivalent sentence).

## Verification

- `vp run verify` green; full suite 210 files / 3139 tests pass; the
  fully-qualified-refs scanner green over the edited file.
- Every command the new text prescribes was RUN live: the `git show
  origin/main` grep, the mergeCommit sourcing (against this session's own
  merged PRs (#529) and (#530)), the `-F` / rc measurements, and the
  settle-a-0 diff form.
- Cited evidence opened and read: go-to-k/cdkd#2009, go-to-k/cdkd#2015,
  go-to-k/cdkd#2000, go-to-k/cdk-real-drift#1790.

Closes #528
Closes #531
