### PR TITLE
chore(hooks): give every gate its own single-pattern `if` — the `or` form disabled all seventeen

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,119 +17,203 @@
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(git commit*) or Bash(git push*) or Bash(git -C * commit*) or Bash(git -C * push*) or Bash(cd * && git commit*) or Bash(cd * && git push*)",
+            "if": "Bash(*git commit*)",
+            "timeout": 10,
+            "statusMessage": "Checking current branch..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/branch-gate.sh",
+            "if": "Bash(*git push*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/main-tree-branch-gate.sh",
-            "if": "Bash(git switch*) or Bash(git checkout*) or Bash(cd * && git switch*) or Bash(cd * && git checkout*) or Bash(git -C * switch*) or Bash(git -C * checkout*)",
+            "if": "Bash(*git switch*)",
+            "timeout": 10,
+            "statusMessage": "Checking main-tree branch-switch policy..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/main-tree-branch-gate.sh",
+            "if": "Bash(*git checkout*)",
             "timeout": 10,
             "statusMessage": "Checking main-tree branch-switch policy..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)",
+            "if": "Bash(*git commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit message form..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/control-char-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)",
+            "if": "Bash(*git commit*)",
             "timeout": 15,
             "statusMessage": "Scanning staged files for NUL / control bytes..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/gh-pr-edit-deprecation-gate.sh",
-            "if": "Bash(gh pr edit*) or Bash(gh -C * pr edit*)",
+            "if": "Bash(*gh pr edit*)",
             "timeout": 10,
             "statusMessage": "Checking gh pr edit deprecation..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr edit*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*gh pr create*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR diff for non-English text..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/non-english-text-gate.sh",
+            "if": "Bash(*gh pr edit*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR diff for non-English text..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/non-english-text-gate.sh",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr edit*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*gh pr create*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
+            "if": "Bash(*gh pr edit*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/post-merge-orphan-push-gate.sh",
-            "if": "Bash(git push*) or Bash(git -C * push*) or Bash(cd * && git push*)",
+            "if": "Bash(*git push*)",
             "timeout": 10,
             "statusMessage": "Checking for orphan-push to merged branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/closes-paren-form-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 30,
             "statusMessage": "Checking PR body for Closes (#N) parens-form trap..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh issue create*) or Bash(gh issue comment*) or Bash(gh api*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * issue create*) or Bash(gh -C * issue comment*) or Bash(gh -C * api*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr edit*) or Bash(cd * && gh issue create*) or Bash(cd * && gh issue comment*) or Bash(cd * && gh api*)",
+            "if": "Bash(*gh pr create*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "if": "Bash(*gh pr edit*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "if": "Bash(*gh issue create*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "if": "Bash(*gh issue comment*)",
+            "timeout": 30,
+            "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "if": "Bash(*gh api*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/check-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)",
+            "if": "Bash(*git commit*)",
             "timeout": 15,
             "statusMessage": "Verifying check + docs markgate markers..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-review-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 30,
             "statusMessage": "Verifying pr-review marker (sha-bound)..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*gh pr create*)",
+            "timeout": 15,
+            "statusMessage": "Verifying verify-pr markgate marker..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/verify-pr-gate.sh",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 15,
             "statusMessage": "Verifying verify-pr markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*) or Bash(git merge*) or Bash(git -C * merge*) or Bash(cd * && git merge*)",
+            "if": "Bash(*gh pr merge*)",
+            "timeout": 15,
+            "statusMessage": "Verifying integ markgate marker..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/integ-gate.sh",
+            "if": "Bash(*git merge*)",
             "timeout": 15,
             "statusMessage": "Verifying integ markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/cdkd-parity-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh -C * pr create*) or Bash(cd * && gh pr create*)",
+            "if": "Bash(*gh pr create*)",
             "timeout": 15,
             "statusMessage": "Verifying cdkd-parity markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/create-integ-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh -C * pr create*) or Bash(cd * && gh pr create*)",
+            "if": "Bash(*gh pr create*)",
             "timeout": 15,
             "statusMessage": "Verifying create-integ markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/gh-pr-merge-worktree-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 15,
             "statusMessage": "Checking worktree merge policy (/merge-pr)..."
           }

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1006,6 +1006,20 @@ the run evidence behind it — or "no skill change" plus what held.
   lane's store, and a `.markgate-pr-review-sha` was written into the main
   checkout before the mistake was caught and redone from the lane. `pwd` costs
   nothing; a marker in the wrong store costs a re-diagnosis.
+- **A hook's `if` takes ONE pattern — ` or ` matches nothing and disables the
+  gate outright.** On 2026-08-20 (go-to-k/cdk-real-drift#1801) all seventeen gates
+  here were written as
+  `"if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)"`
+  and every one was INERT: `git commit` on `main` with no markers reached git,
+  while running `branch-gate.sh` by hand on the same payload blocked with exit 2.
+  Three throwaway hooks separated the causes — an `if`-less hook fired,
+  `if: "Bash(git status*)"` fired, the ` or ` one never did. A gate guarding two
+  verbs gets two ENTRIES, and the pattern is written UNANCHORED
+  (`Bash(*git commit*)`) so a compound command still selects it; the script
+  re-matches precisely anyway. `tests/unit/hooks/gate-if-matchers.test.ts` pins
+  all three properties. **The general shape: a gate you have never watched go RED
+  is not a gate** — the failure here was invisible for as long as nobody typed a
+  command that should have been blocked and noticed that it was not.
 - **A gated command must be the ONLY thing in its Bash call.** A PreToolUse hook
   denial aborts the WHOLE command string BEFORE any line runs — including
   preamble side effects you assumed happened. On 2026-08-19 a

--- a/tests/unit/hooks/gate-if-matchers.test.ts
+++ b/tests/unit/hooks/gate-if-matchers.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+/**
+ * Every PreToolUse gate must actually BE SELECTED for the commands it guards.
+ *
+ * On 2026-08-20 (go-to-k/cdk-real-drift#1801) none of them were. Each gate's `if`
+ * joined its command spellings with ` or `:
+ *
+ *   "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)"
+ *
+ * and that is not a supported expression — an `if` holding `A or B` matches
+ * NOTHING, so the hook is never chosen and the gate is inert. It was proved with
+ * three throwaway hooks in the sibling repo: an `if`-less hook fired, one with
+ * `if: "Bash(git status*)"` fired, and one with `if: "Bash(git commit*) or
+ * Bash(git status*)"` never did — while `git commit` on `main` with no markers
+ * reached git in two different clients. All seventeen gates here were in that
+ * shape, including `check-gate`, `branch-gate`, `verify-pr-gate`, `pr-review-gate`
+ * and `integ-gate`.
+ *
+ * So: an `if` carries exactly ONE pattern, and a gate guarding two verbs gets two
+ * ENTRIES. The pattern is deliberately UNANCHORED (`*git commit*`) because the
+ * matcher's only job is to hand the script every candidate — each gate script
+ * already re-derives its own target directory and re-matches the command
+ * precisely, and an anchored matcher cannot see `git add -A && git commit`, the
+ * commonest spelling there is. cdkd, whose gates have always fired, wires its
+ * hooks with no `if` at all for the same reason.
+ */
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const SETTINGS = join(here, '..', '..', '..', '.claude', 'settings.json');
+
+/** Which command each gate must be selected for. */
+const REQUIRED: Record<string, string[]> = {
+  'branch-gate.sh': ['Bash(*git commit*)', 'Bash(*git push*)'],
+  'main-tree-branch-gate.sh': ['Bash(*git switch*)', 'Bash(*git checkout*)'],
+  'commit-msg-heredoc-gate.sh': ['Bash(*git commit*)'],
+  'control-char-gate.sh': ['Bash(*git commit*)'],
+  'gh-pr-edit-deprecation-gate.sh': ['Bash(*gh pr edit*)'],
+  'non-english-text-gate.sh': [
+    'Bash(*gh pr create*)',
+    'Bash(*gh pr edit*)',
+    'Bash(*gh pr merge*)',
+  ],
+  'docs-inline-json-flag-gate.sh': [
+    'Bash(*gh pr create*)',
+    'Bash(*gh pr edit*)',
+    'Bash(*gh pr merge*)',
+  ],
+  'post-merge-orphan-push-gate.sh': ['Bash(*git push*)'],
+  'closes-paren-form-gate.sh': ['Bash(*gh pr merge*)'],
+  'pr-body-item-number-gate.sh': [
+    'Bash(*gh pr create*)',
+    'Bash(*gh pr edit*)',
+    'Bash(*gh issue create*)',
+    'Bash(*gh issue comment*)',
+    'Bash(*gh api*)',
+  ],
+  'check-gate.sh': ['Bash(*git commit*)'],
+  'pr-review-gate.sh': ['Bash(*gh pr merge*)'],
+  'verify-pr-gate.sh': ['Bash(*gh pr create*)', 'Bash(*gh pr merge*)'],
+  'integ-gate.sh': ['Bash(*gh pr merge*)', 'Bash(*git merge*)'],
+  'cdkd-parity-gate.sh': ['Bash(*gh pr create*)'],
+  'create-integ-gate.sh': ['Bash(*gh pr create*)'],
+  'gh-pr-merge-worktree-gate.sh': ['Bash(*gh pr merge*)'],
+};
+
+interface GateHook {
+  name: string;
+  condition: string;
+}
+
+function gateHooks(): GateHook[] {
+  const settings = JSON.parse(readFileSync(SETTINGS, 'utf8')) as {
+    hooks?: {
+      PreToolUse?: { matcher?: string; if?: string; hooks?: { command?: string; if?: string }[] }[];
+    };
+  };
+  const out: GateHook[] = [];
+  for (const matcher of settings.hooks?.PreToolUse ?? []) {
+    for (const hook of matcher.hooks ?? []) {
+      const command = hook.command ?? '';
+      if (!command.includes('.claude/hooks/')) continue;
+      out.push({
+        name: basename(command.split(/\s+/)[0] ?? command),
+        condition: hook.if ?? matcher.if ?? '',
+      });
+    }
+  }
+  return out;
+}
+
+describe('PreToolUse gate matchers (go-to-k/cdk-real-drift#1801)', () => {
+  const hooks = gateHooks();
+  const patternsOf = (gate: string) =>
+    hooks.filter((h) => h.name === gate && h.condition).map((h) => h.condition);
+
+  it('finds the gate hooks', () => {
+    const names = new Set(hooks.map((h) => h.name));
+    expect(names.has('check-gate.sh')).toBe(true);
+    expect(names.has('verify-pr-gate.sh')).toBe(true);
+    expect(hooks.length).toBeGreaterThanOrEqual(17);
+  });
+
+  // THE regression case: this exact join disabled every gate in the repo.
+  it('no `if` joins patterns with `or` — that matches nothing and disables the hook', () => {
+    const joined = hooks
+      .filter((h) => / or /.test(h.condition))
+      .map((h) => `${h.name}: ${h.condition}`);
+    expect(
+      joined,
+      'an `if` takes ONE pattern; give the gate another ENTRY instead of joining'
+    ).toEqual([]);
+  });
+
+  it('every `if` holds a single well-formed Bash(...) pattern', () => {
+    const malformed = hooks
+      .filter((h) => h.condition)
+      .filter((h) => !/^Bash\([^()]*\)$/.test(h.condition))
+      .map((h) => `${h.name}: ${h.condition}`);
+    expect(malformed).toEqual([]);
+  });
+
+  it('every gate in settings.json is accounted for in the required table', () => {
+    const undeclared = [...new Set(hooks.map((h) => h.name))].filter((n) => !(n in REQUIRED));
+    expect(undeclared, 'a new gate must declare which commands select it').toEqual([]);
+    const missing = Object.keys(REQUIRED).filter((n) => patternsOf(n).length === 0);
+    expect(missing, 'REQUIRED names a gate settings.json no longer wires').toEqual([]);
+  });
+
+  for (const [gate, patterns] of Object.entries(REQUIRED)) {
+    it(`${gate} is selected for every command it guards`, () => {
+      const present = patternsOf(gate);
+      const gaps = patterns.filter((p) => !present.includes(p));
+      expect(gaps, `${gate} is missing an entry for ${gaps.join(', ')}`).toEqual([]);
+    });
+  }
+
+  it('the patterns are unanchored, so a compound command still selects the gate', () => {
+    const anchored = hooks
+      .filter((h) => /^Bash\((git|gh)\b/.test(h.condition))
+      .map((h) => `${h.name}: ${h.condition}`);
+    expect(
+      anchored,
+      'write Bash(*git commit*), not Bash(git commit*) — the latter misses ' +
+        '`git add -A && git commit` and `cd <wt> && git commit`'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Every PreToolUse gate in this repo was inert. Each one's `if` joined its command
spellings with ` or `:

```
"if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)"
```

and that is not a supported expression — the pattern matches NOTHING, so the hook
is never selected. All seventeen gates were in that shape, `check-gate`,
`branch-gate`, `verify-pr-gate`, `pr-review-gate` and `integ-gate` included.

## Evidence

Diagnosed in go-to-k/cdk-real-drift#1801, whose settings carried the same form.
Three throwaway hooks registered side by side, each only logging that it ran:

| probe | `if` | fired |
| --- | --- | --- |
| `no-if` | *(none)* | yes |
| `single-if` | `Bash(git status*)` | yes |
| `or-if` | `Bash(git commit*) or Bash(git status*)` | **no** |

Consistent with the symptom: `git commit` on `main` with no markers reached git in
two different clients, while the same payload piped into `branch-gate.sh` by hand
blocked with exit 2. Registering the real `check-gate.sh` behind ONE unanchored
pattern then blocked the commit end to end.

cdkd corroborates the shape from the other side: its gates have always fired, and
it wires all 34 of its PreToolUse hooks with **no `if` at all**.

## What changed

- `.claude/settings.json` — one ENTRY per guarded command (17 gates → 29 entries),
  each `if` a single pattern.
- The patterns are **unanchored** (`Bash(*git commit*)`). The matcher's only job is
  to hand the script every candidate; each gate script already re-derives its own
  target directory and re-matches the command precisely. An anchored pattern cannot
  see `git add -A && git commit`, the commonest spelling there is.
- `tests/unit/hooks/gate-if-matchers.test.ts` — pins three properties: no ` or ` in
  any `if`, one well-formed `Bash(...)` pattern per entry, and an entry per guarded
  command for every gate, with a completeness case so a new gate cannot be added
  without declaring what selects it.
- `.claude/skills/work-issues/SKILL.md` — the lesson, in §5's gotcha list.

## Known residual (not this PR)

The matcher now hands the script `git add -A && git commit`, but the gate scripts'
own regexes are line-start anchored, so such a command still exits 0 and runs
ungated. That is a pre-existing gap in the SCRIPTS; measured after this fix and
tracked in go-to-k/cdk-real-drift#1801's follow-up.

## Test plan

- [x] `vp run check` — 0 errors
- [x] `vp run test` — 3165 tests
- [x] `vp run test:hooks` — pass 48 / fail 0
- [x] `vp run build`
- [x] probes: re-introducing an `or`, re-anchoring a pattern, and deleting a gate
      each turn the new test RED
