### PR TITLE
chore(hooks): find a gated verb in any command position, not just at line start

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1525,6 +1525,25 @@ vp run runtime:smoke
   defer criterion fires, and if you must defer it anyway, put the EVIDENCE in the
   issue body, not just the diagnosis.
 
+  **`Session-fit: next` is not on the menu inside a cross-repo scope.** When the
+  user framed the work as "do this across the repos in one session", anything
+  discovered inside that scope is `now`, and three tells force it: (a) you are
+  about to file the SAME issue body in more than one repo, which is the split
+  the framing exists to end and not triage; (b) the fix is mechanical and its
+  evidence is live right now, with the repro built, the files open, and a gate
+  cycle already running; (c) the user already said "finish it here" for the
+  surrounding task, so a discovery inside that task inherits the instruction
+  instead of getting a budget of its own. The four fields exist to make a
+  deferral HONEST, not to make one available: a defensible-looking `Effort` /
+  `Estimate` written for work this session is already positioned to do is the
+  tell that the classification has turned into an excuse. On 2026-08-20 a
+  session asked to consolidate one `/work-issues` lesson across cdkd, cdk-local
+  and cdk-real-drift found that every PreToolUse gate was inert, fixed the
+  matchers in all three, and then filed the remaining script-level gap as three
+  separate issues, reproducing exactly the per-repo split the user had asked to
+  end. Fixing it in the same PRs was the correct move, and is what happened
+  once the user objected.
+
   **One field per line — never pack two onto one**, and keep the field
   names and their order identical every time. A field with nothing to
   say gets an explicit `none`, never omission:

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -2,157 +2,208 @@
 # _command-match.sh — shared command matching for the PreToolUse gate hooks.
 # SOURCED, never executed: `. "$(dirname "${BASH_SOURCE[0]}")/_command-match.sh"`.
 #
-# WHY this exists (go-to-k/cdk-local#541): every gate used to decide whether
-# it applied with a LINE-START-anchored regex, optionally tolerating one leading
-# `cd <path> &&`. So a gated verb in any other position was invisible:
+# WHY (go-to-k/cdk-local#541): every gate used to decide whether it applied
+# with a LINE-START-anchored regex tolerating at most one leading `cd <path> &&`,
+# so a gated verb anywhere else was invisible and the command ran UNGATED —
+# `git add -A && git commit`, `cd <wt>; git commit`, `(cd <wt> && git commit)`,
+# `GIT_EDITOR=true git commit`, all measured reaching git.
 #
-#   git add -A && git commit -m "…"     <- the commonest commit spelling there is
-#   cd <wt>; git commit -m "…"          <- semicolon instead of &&
-#   (cd <wt> && git commit -m "…")      <- subshell
-#   GIT_EDITOR=true git commit -m "…"   <- leading env assignment
+# The model: a Bash tool call is a COMMAND LIST. Segment it, then ask whether any
+# SEGMENT is the gated command.
 #
-# all reached git ungated, and an ungated command looks exactly like one that
-# passed. Measured on 2026-08-20 right after go-to-k/cdk-local#540 gave every
-# gate its own single-pattern `if` — before that, all seventeen `if` clauses
-# used an unsupported ` or ` join and no gate ran at all, so the matcher bug
-# had never been reachable enough to notice.
-#
-# The model: a Bash tool call is a COMMAND LIST. Split it into segments and ask
-# whether ANY segment is the gated command. Quoted spans are blanked first, so a
-# separator or a command name inside a string cannot create a phantom segment —
-# `echo "run git commit later"` is still not a commit.
+# Quoting is handled by NEUTRALISING separators inside quoted spans rather than
+# blanking the span. The first version blanked them, which also erased the PATH in
+# `cd "<worktree>" && git commit` and `git -C "<path>" commit`, so target-dir
+# resolution silently fell back to the payload cwd and the gate passed a commit it
+# should have blocked — a regression against the pre-refactor gates, caught in
+# review of go-to-k/cdk-local#542. Segments therefore carry their original text;
+# only the separator CHARACTERS inside quotes are swapped for placeholders while
+# splitting, and swapped back afterwards. A verb inside a string still does not
+# match, because the per-verb regexes are anchored at the segment START.
 
-# Blank the CONTENT of quoted spans, preserving length so offsets and the
-# surrounding structure survive. Unterminated quotes blank to end of input, which
-# is the conservative reading (that text is not a command).
-gate_blank_quotes() {
+# Placeholders for separators that live inside quoted spans (never in real input).
+GATE_SEP_AMP=$'\001'
+GATE_SEP_SEMI=$'\002'
+GATE_SEP_PIPE=$'\003'
+GATE_SEP_SUBST=$'\004'
+
+# One awk pass: join `\`-continuations, blank heredoc BODIES, neutralise
+# separators inside quotes, and turn every real separator into a newline. Command
+# substitutions (`$(...)` and backticks) become separators too — the text inside
+# one RUNS, so `echo "$(git commit -m x)"` is a commit.
+gate_segments_raw() {
   awk '
-    {
-      line = $0; out = ""; q = ""
-      n = length(line)
+    # `q` is deliberately GLOBAL: a quoted span survives a newline, and a
+    # `--body "…multi-line…"` argument is ONE span. Resetting it per line split a
+    # PR body into segments and matched a `&& git commit` inside the prose
+    # (caught in review of go-to-k/cdk-local#542).
+    function flush_line(line,   i, n, c, out, prev) {
+      out = ""; n = length(line)
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
+        prev = (i > 1) ? substr(line, i - 1, 1) : ""
         if (q == "") {
           if (c == "\"" || c == "'"'"'") { q = c; out = out c; continue }
+          if (c == "$" && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
+          if (c == "`") { out = out "\n"; continue }
+          if (c == "&" || c == ";" || c == "|") { out = out "\n"; continue }
           out = out c
-        } else {
-          if (c == "\\" && q == "\"") { out = out "  "; i++; continue }
-          if (c == q) { q = ""; out = out c; continue }
-          out = out " "
+          continue
         }
+        # inside a quoted span
+        if (c == "\\" && q == "\"") { out = out c substr(line, i + 1, 1); i++; continue }
+        if (c == q) { q = ""; out = out c; continue }
+        if (c == "&") { out = out SEP_AMP; continue }
+        if (c == ";") { out = out SEP_SEMI; continue }
+        if (c == "|") { out = out SEP_PIPE; continue }
+        if (c == "$" && substr(line, i + 1, 1) == "(") { out = out SEP_SUBST "("; i++; continue }
+        out = out c
       }
-      print out
+      return out
     }
-  ' <<< "$1"
-}
-
-# Blank the BODY of every heredoc, keeping the line count. A heredoc body is data
-# the shell hands to a program, not a command list — and this repo's own flow
-# writes PR bodies with `gh pr create --body-file <<EOF ... git commit ... EOF`,
-# which would otherwise trip the commit gates on its own prose.
-gate_blank_heredocs() {
-  awk '
-    BEGIN { tag = "" }
+    BEGIN { tag = ""; pending = ""; q = "" }
     {
-      if (tag != "") {
-        line = $0
-        gsub(/^[ \t]+|[ \t]+$/, "", line)
-        if (line == tag) { tag = "" ; print $0 ; next }
+      line = $0
+      sub(/\r$/, "", line)
+      if (tag != "") {                      # inside a heredoc body: data, not commands
+        t = line
+        gsub(/^[ \t]+|[ \t]+$/, "", t)
+        if (t == tag) tag = ""
         print ""
         next
       }
-      if (match($0, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*["'"'"']?/)) {
-        t = substr($0, RSTART, RLENGTH)
+      if (pending != "") { line = pending line; pending = "" }
+      if (line ~ /\\$/) {                   # `\`-continuation: join with the next line
+        sub(/\\$/, "", line)
+        pending = line
+        next
+      }
+      if (match(line, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*["'"'"']?/)) {
+        t = substr(line, RSTART, RLENGTH)
         gsub(/^<<-?[ \t]*|["'"'"']/, "", t)
         tag = t
       }
-      print $0
+      print flush_line(line)
     }
-  ' <<< "$1"
+    END { if (pending != "") print flush_line(pending) }
+  ' SEP_AMP="$GATE_SEP_AMP" SEP_SEMI="$GATE_SEP_SEMI" SEP_PIPE="$GATE_SEP_PIPE" \
+    SEP_SUBST="$GATE_SEP_SUBST" <<< "$1"
 }
 
-# Print one command segment per line: split on && || ; | newline, and drop the
-# grouping punctuation ( ) { } that wraps a subshell or brace group.
-gate_segments() {
-  local blanked
-  blanked=$(gate_blank_quotes "$(gate_blank_heredocs "$1")")
-  printf '%s' "$blanked" |
-    sed -E 's/\|\||&&|;|\||\n/\n/g' |
-    sed -E 's/^[[:space:]]*[({][[:space:]]*//; s/[[:space:]]*[)}][[:space:]]*$//' |
-    sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' |
-    grep -v '^$'
-}
-
-# Strip leading `VAR=value` assignments and an `env`/`command`/`nohup` wrapper, so
-# `GIT_EDITOR=true git commit` and `env git commit` are seen as `git commit`.
+# Leading words that introduce a command without being one: env assignments,
+# wrappers, and the keywords that open a compound statement.
 gate_strip_prefix() {
-  printf '%s' "$1" | sed -E 's/^(([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup)[[:space:]]+)*//'
+  local s="$1"
+  # Trim first: a segment split off after a separator starts with a space, and
+  # every verb regex is anchored at the segment start.
+  s="${s#"${s%%[![:space:]]*}"}"
+  # `bash -c "<cmd>"` RUNS its argument, so a gated verb inside it is a gated
+  # command (go-to-k/cdk-local#542 review).
+  if [[ "$s" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+[\"\'](.*)[\"\'][[:space:]]*$ ]]; then
+    s="${BASH_REMATCH[2]}"
+  fi
+  while [[ "$s" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup|time|timeout[[:space:]]+[^[:space:]]+|exec|then|do|else|elif|\{|\()[[:space:]]+(.*)$ ]]; do
+    s="${BASH_REMATCH[2]}"
+  done
+  # Any remaining grouping punctuation at either end (nested subshells).
+  while [[ "$s" =~ ^[[:space:]]*[\(\{][[:space:]]*(.*)$ ]]; do s="${BASH_REMATCH[1]}"; done
+  while [[ "$s" =~ ^(.*[^[:space:]])[[:space:]]*[\)\}][[:space:]]*$ ]]; do s="${BASH_REMATCH[1]}"; done
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# Print one command segment per line, in the ORIGINAL text (placeholders restored).
+gate_segments() {
+  local segment
+  while IFS= read -r segment; do
+    segment="${segment//"$GATE_SEP_AMP"/&}"
+    segment="${segment//"$GATE_SEP_SEMI"/;}"
+    segment="${segment//"$GATE_SEP_PIPE"/|}"
+    segment="${segment//"$GATE_SEP_SUBST"/$}"
+    segment=$(gate_strip_prefix "$segment")
+    [ -n "$segment" ] && printf '%s\n' "$segment"
+  done < <(gate_segments_raw "$1")
 }
 
 # gate_matches <cmd> <extended-regex>
-# 0 when any segment matches the regex (anchored at the segment start, after the
-# prefix strip). The regex is the SAME per-verb shape each gate used to carry.
+# 0 when any segment matches. Bash-native `=~` rather than a `grep` per segment:
+# these hooks run on every matching Bash tool call, and the fork per segment per
+# gate was measured at ~5x the whole gate suite's latency in review of
+# go-to-k/cdk-local#542.
 gate_matches() {
   local cmd="$1" re="$2" segment
   while IFS= read -r segment; do
-    segment=$(gate_strip_prefix "$segment")
-    printf '%s' "$segment" | grep -qE "$re" && return 0
+    [[ "$segment" =~ $re ]] && return 0
   done < <(gate_segments "$cmd")
   return 1
 }
 
+# A path token: a quoted span (either quote character) or a bare run of
+# non-space. Held in a variable because a literal `[[ =~ ]]` pattern cannot carry
+# both quote characters inside one bracket expression.
+GATE_PATH_TOKEN='("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+)'
+
 # The regexes, kept here so every gate spells its verb the same way. Each is
 # anchored at the START of a segment; `git -C <path>` / `git -c k=v` and
-# `gh -C <path>` are absorbed.
-GATE_RE_GIT_COMMIT='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'
-GATE_RE_GIT_PUSH='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+push([[:space:]]|$)'
-GATE_RE_GH_PR_CREATE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'
-GATE_RE_GH_PR_EDIT='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+edit([[:space:]]|$)'
-GATE_RE_GH_PR_MERGE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'
+# `gh -C <path>` are absorbed — including a QUOTED path containing spaces, which
+# an earlier version could not parse, so `git -C "/a b" commit` matched nothing
+# and ran ungated (go-to-k/cdk-local#542 review).
+GATE_FLAGS='([[:space:]]+-[^[:space:]]+([[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]-][^[:space:]]*))?)*'
+GATE_GH_C='([[:space:]]+-C[[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+))?'
+GATE_RE_GIT_COMMIT="^git${GATE_FLAGS}[[:space:]]+commit([[:space:]]|$)"
+GATE_RE_GIT_PUSH="^git${GATE_FLAGS}[[:space:]]+push([[:space:]]|$)"
+GATE_RE_GH_PR_CREATE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+create([[:space:]]|$)"
+GATE_RE_GH_PR_EDIT="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+edit([[:space:]]|$)"
+GATE_RE_GH_PR_MERGE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)"
 
-# cdk-local also gates these verbs (cdk-real-drift, the repo this helper was
-# ported from, has no gate for them): branch switching, a local merge, and the
-# `gh issue` / `gh api` writers whose bodies pr-body-item-number-gate inspects.
-GATE_RE_GIT_SWITCH='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+switch([[:space:]]|$)'
-GATE_RE_GIT_CHECKOUT='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+checkout([[:space:]]|$)'
-GATE_RE_GIT_MERGE='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+merge([[:space:]]|$)'
-GATE_RE_GH_ISSUE_CREATE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+issue[[:space:]]+create([[:space:]]|$)'
-GATE_RE_GH_ISSUE_COMMENT='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)'
-GATE_RE_GH_API='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+api([[:space:]]|$)'
+# cdk-local gates more verbs than its siblings; same construction.
+GATE_RE_GIT_SWITCH="^git${GATE_FLAGS}[[:space:]]+switch([[:space:]]|$)"
+GATE_RE_GIT_CHECKOUT="^git${GATE_FLAGS}[[:space:]]+checkout([[:space:]]|$)"
+GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
+GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
+GATE_RE_GH_ISSUE_COMMENT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)"
+GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
+
+# Strip one layer of surrounding quotes from a path token.
+gate_unquote() {
+  local p="$1"
+  p="${p%\"}"; p="${p#\"}"
+  p="${p%\'}"; p="${p#\'}"
+  printf '%s' "$p"
+}
 
 # gate_target_dir <cmd> <fallback> <extended-regex>
 # The working tree the gated command will actually run in:
 #   1. a `-C <path>` inside the MATCHED segment wins (git -C / gh -C), else
 #   2. the last `cd <path>` segment BEFORE the matched one, else
 #   3. the fallback (the hook payload's cwd).
-# Relative paths resolve against the fallback, then against each other, which is
-# what a `cd a && cd b` chain does.
+# Quoted paths survive: segments carry their original text (see the header).
 gate_target_dir() {
   local cmd="$1" fallback="$2" re="$3"
-  local target="$fallback" segment stripped cd_target c_target remaining
+  local target="$fallback" segment cd_target c_target remaining
   while IFS= read -r segment; do
-    stripped=$(gate_strip_prefix "$segment")
-    if [[ "$stripped" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-      cd_target="${BASH_REMATCH[1]}"
-      cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-      cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+    if [[ "$segment" =~ ^cd[[:space:]]+$GATE_PATH_TOKEN ]]; then
+      cd_target=$(gate_unquote "${BASH_REMATCH[1]}")
+      [ -z "$cd_target" ] && continue
       [[ "$cd_target" != /* ]] && cd_target="$target/$cd_target"
       target="$cd_target"
       continue
     fi
-    printf '%s' "$stripped" | grep -qE "$re" || continue
+    [[ "$segment" =~ $re ]] || continue
     # Last `-C <path>` in this segment wins over any earlier cd.
-    if [[ "$stripped" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+    if [[ "$segment" =~ (git|gh)[[:space:]]+-C[[:space:]]+$GATE_PATH_TOKEN ]]; then
       c_target=""
-      remaining="$stripped"
-      while [[ "$remaining" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+      remaining="$segment"
+      while [[ "$remaining" =~ (git|gh)[[:space:]]+-C[[:space:]]+$GATE_PATH_TOKEN ]]; do
         c_target="${BASH_REMATCH[2]}"
         remaining="${remaining#*"${BASH_REMATCH[0]}"}"
       done
-      c_target="${c_target%\"}"; c_target="${c_target#\"}"
-      c_target="${c_target%\'}"; c_target="${c_target#\'}"
-      [[ "$c_target" != /* ]] && c_target="$target/$c_target"
-      target="$c_target"
+      c_target=$(gate_unquote "$c_target")
+      if [ -n "$c_target" ]; then
+        [[ "$c_target" != /* ]] && c_target="$target/$c_target"
+        target="$c_target"
+      fi
     fi
     break
   done < <(gate_segments "$cmd")

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# _command-match.sh — shared command matching for the PreToolUse gate hooks.
+# SOURCED, never executed: `. "$(dirname "${BASH_SOURCE[0]}")/_command-match.sh"`.
+#
+# WHY this exists (go-to-k/cdk-local#541): every gate used to decide whether
+# it applied with a LINE-START-anchored regex, optionally tolerating one leading
+# `cd <path> &&`. So a gated verb in any other position was invisible:
+#
+#   git add -A && git commit -m "…"     <- the commonest commit spelling there is
+#   cd <wt>; git commit -m "…"          <- semicolon instead of &&
+#   (cd <wt> && git commit -m "…")      <- subshell
+#   GIT_EDITOR=true git commit -m "…"   <- leading env assignment
+#
+# all reached git ungated, and an ungated command looks exactly like one that
+# passed. Measured on 2026-08-20 right after go-to-k/cdk-local#540 gave every
+# gate its own single-pattern `if` — before that, all seventeen `if` clauses
+# used an unsupported ` or ` join and no gate ran at all, so the matcher bug
+# had never been reachable enough to notice.
+#
+# The model: a Bash tool call is a COMMAND LIST. Split it into segments and ask
+# whether ANY segment is the gated command. Quoted spans are blanked first, so a
+# separator or a command name inside a string cannot create a phantom segment —
+# `echo "run git commit later"` is still not a commit.
+
+# Blank the CONTENT of quoted spans, preserving length so offsets and the
+# surrounding structure survive. Unterminated quotes blank to end of input, which
+# is the conservative reading (that text is not a command).
+gate_blank_quotes() {
+  awk '
+    {
+      line = $0; out = ""; q = ""
+      n = length(line)
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (q == "") {
+          if (c == "\"" || c == "'"'"'") { q = c; out = out c; continue }
+          out = out c
+        } else {
+          if (c == "\\" && q == "\"") { out = out "  "; i++; continue }
+          if (c == q) { q = ""; out = out c; continue }
+          out = out " "
+        }
+      }
+      print out
+    }
+  ' <<< "$1"
+}
+
+# Blank the BODY of every heredoc, keeping the line count. A heredoc body is data
+# the shell hands to a program, not a command list — and this repo's own flow
+# writes PR bodies with `gh pr create --body-file <<EOF ... git commit ... EOF`,
+# which would otherwise trip the commit gates on its own prose.
+gate_blank_heredocs() {
+  awk '
+    BEGIN { tag = "" }
+    {
+      if (tag != "") {
+        line = $0
+        gsub(/^[ \t]+|[ \t]+$/, "", line)
+        if (line == tag) { tag = "" ; print $0 ; next }
+        print ""
+        next
+      }
+      if (match($0, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*["'"'"']?/)) {
+        t = substr($0, RSTART, RLENGTH)
+        gsub(/^<<-?[ \t]*|["'"'"']/, "", t)
+        tag = t
+      }
+      print $0
+    }
+  ' <<< "$1"
+}
+
+# Print one command segment per line: split on && || ; | newline, and drop the
+# grouping punctuation ( ) { } that wraps a subshell or brace group.
+gate_segments() {
+  local blanked
+  blanked=$(gate_blank_quotes "$(gate_blank_heredocs "$1")")
+  printf '%s' "$blanked" |
+    sed -E 's/\|\||&&|;|\||\n/\n/g' |
+    sed -E 's/^[[:space:]]*[({][[:space:]]*//; s/[[:space:]]*[)}][[:space:]]*$//' |
+    sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' |
+    grep -v '^$'
+}
+
+# Strip leading `VAR=value` assignments and an `env`/`command`/`nohup` wrapper, so
+# `GIT_EDITOR=true git commit` and `env git commit` are seen as `git commit`.
+gate_strip_prefix() {
+  printf '%s' "$1" | sed -E 's/^(([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup)[[:space:]]+)*//'
+}
+
+# gate_matches <cmd> <extended-regex>
+# 0 when any segment matches the regex (anchored at the segment start, after the
+# prefix strip). The regex is the SAME per-verb shape each gate used to carry.
+gate_matches() {
+  local cmd="$1" re="$2" segment
+  while IFS= read -r segment; do
+    segment=$(gate_strip_prefix "$segment")
+    printf '%s' "$segment" | grep -qE "$re" && return 0
+  done < <(gate_segments "$cmd")
+  return 1
+}
+
+# The regexes, kept here so every gate spells its verb the same way. Each is
+# anchored at the START of a segment; `git -C <path>` / `git -c k=v` and
+# `gh -C <path>` are absorbed.
+GATE_RE_GIT_COMMIT='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'
+GATE_RE_GIT_PUSH='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+push([[:space:]]|$)'
+GATE_RE_GH_PR_CREATE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'
+GATE_RE_GH_PR_EDIT='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+edit([[:space:]]|$)'
+GATE_RE_GH_PR_MERGE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'
+
+# cdk-local also gates these verbs (cdk-real-drift, the repo this helper was
+# ported from, has no gate for them): branch switching, a local merge, and the
+# `gh issue` / `gh api` writers whose bodies pr-body-item-number-gate inspects.
+GATE_RE_GIT_SWITCH='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+switch([[:space:]]|$)'
+GATE_RE_GIT_CHECKOUT='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+checkout([[:space:]]|$)'
+GATE_RE_GIT_MERGE='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+merge([[:space:]]|$)'
+GATE_RE_GH_ISSUE_CREATE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+issue[[:space:]]+create([[:space:]]|$)'
+GATE_RE_GH_ISSUE_COMMENT='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)'
+GATE_RE_GH_API='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+api([[:space:]]|$)'
+
+# gate_target_dir <cmd> <fallback> <extended-regex>
+# The working tree the gated command will actually run in:
+#   1. a `-C <path>` inside the MATCHED segment wins (git -C / gh -C), else
+#   2. the last `cd <path>` segment BEFORE the matched one, else
+#   3. the fallback (the hook payload's cwd).
+# Relative paths resolve against the fallback, then against each other, which is
+# what a `cd a && cd b` chain does.
+gate_target_dir() {
+  local cmd="$1" fallback="$2" re="$3"
+  local target="$fallback" segment stripped cd_target c_target remaining
+  while IFS= read -r segment; do
+    stripped=$(gate_strip_prefix "$segment")
+    if [[ "$stripped" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+      cd_target="${BASH_REMATCH[1]}"
+      cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+      cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+      [[ "$cd_target" != /* ]] && cd_target="$target/$cd_target"
+      target="$cd_target"
+      continue
+    fi
+    printf '%s' "$stripped" | grep -qE "$re" || continue
+    # Last `-C <path>` in this segment wins over any earlier cd.
+    if [[ "$stripped" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+      c_target=""
+      remaining="$stripped"
+      while [[ "$remaining" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+        c_target="${BASH_REMATCH[2]}"
+        remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+      done
+      c_target="${c_target%\"}"; c_target="${c_target#\"}"
+      c_target="${c_target%\'}"; c_target="${c_target#\'}"
+      [[ "$c_target" != /* ]] && c_target="$target/$c_target"
+      target="$c_target"
+    fi
+    break
+  done < <(gate_segments "$cmd")
+  printf '%s' "$target"
+}

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Smoke test for _command-match.sh, the shared segment matcher every gate uses.
+# Run from the repo root: `bash .claude/hooks/_command-match.test.sh`
+#
+# The cases are the spellings go-to-k/cdk-local#541 measured running UNGATED
+# against the old line-start-anchored regexes, plus the negatives that must stay
+# out (a verb inside a string, a different verb, a lookalike).
+
+set -u
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
+pass=0; fail=0
+
+# want_match <expect 0|1> <label> <command> <regex>
+want_match() {
+  local want="$1" label="$2" cmd="$3" re="$4" got
+  if gate_matches "$cmd" "$re"; then got=0; else got=1; fi
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s got %s) :: %s\n' "$label" "$want" "$got" "$cmd"
+  fi
+}
+
+# want_dir <expected> <label> <command> <fallback> <regex>
+want_dir() {
+  local want="$1" label="$2" cmd="$3" fallback="$4" re="$5" got
+  got=$(gate_target_dir "$cmd" "$fallback" "$re")
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s\n  want: %s\n  got:  %s\n' "$label" "$want" "$got"
+  fi
+}
+
+C="$GATE_RE_GIT_COMMIT"
+P="$GATE_RE_GIT_PUSH"
+M="$GATE_RE_GH_PR_MERGE"
+
+# --- the spellings that used to bypass ---------------------------------------
+want_match 0 "bare git commit"              'git commit -m x' "$C"
+want_match 0 "git add -A && git commit"     'git add -A && git commit -m x' "$C"
+want_match 0 "cd && git commit"             'cd /w/t && git commit -m x' "$C"
+want_match 0 "cd ; git commit"              'cd /w/t; git commit -m x' "$C"
+want_match 0 "no spaces around &&"          'cd /w/t&&git commit -m x' "$C"
+want_match 0 "subshell"                     '(cd /w/t && git commit -m x)' "$C"
+want_match 0 "leading env assignment"       'GIT_EDITOR=true git commit -m x' "$C"
+want_match 0 "env wrapper"                  'env git commit -m x' "$C"
+want_match 0 "git -C <path> commit"         'git -C /w/t commit -m x' "$C"
+want_match 0 "git -c k=v commit"            'git -c user.name=t commit -m x' "$C"
+want_match 0 "three-segment chain"          'vp run check && git add -A && git commit -m x' "$C"
+want_match 0 "pipe into another command"    'git commit -m x | tee log' "$C"
+want_match 0 "gh pr merge after a push"     'git push && gh pr merge 1 --squash' "$M"
+want_match 0 "git push in second position"  'echo go && git push origin HEAD' "$P"
+
+# --- negatives ----------------------------------------------------------------
+want_match 1 "verb inside a double-quoted string" 'echo "next: git commit -m x"' "$C"
+want_match 1 "verb inside a single-quoted string" "echo 'run git commit later'" "$C"
+want_match 1 "heredoc body mentioning the verb"   'cat <<EOF
+git commit -m x
+EOF' "$C"
+want_match 1 "different verb"                     'git status --short' "$C"
+want_match 1 "commit as an argument, not a verb"  'git log --grep commit' "$C"
+want_match 1 "push is not commit"                 'git push origin HEAD' "$C"
+want_match 1 "gh pr create is not merge"          'gh pr create --fill' "$M"
+
+# --- the verbs cdk-local adds --------------------------------------------------
+SW="$GATE_RE_GIT_SWITCH"
+CO="$GATE_RE_GIT_CHECKOUT"
+GM="$GATE_RE_GIT_MERGE"
+IC="$GATE_RE_GH_ISSUE_CREATE"
+ICM="$GATE_RE_GH_ISSUE_COMMENT"
+API="$GATE_RE_GH_API"
+
+want_match 0 "git switch after a cd"          'cd /w/t && git switch -c feat/x' "$SW"
+want_match 1 "switch inside a string"         'echo "then git switch main"' "$SW"
+want_match 1 "switch is not checkout"         'git switch main' "$CO"
+
+want_match 0 "git checkout in second position" 'git fetch origin && git checkout main' "$CO"
+want_match 1 "checkout inside a string"        "echo 'git checkout main next'" "$CO"
+
+want_match 0 "git merge after a fetch"        'git fetch && git merge --ff-only origin/main' "$GM"
+want_match 1 "merge-base is not merge"        'git merge-base origin/main HEAD' "$GM"
+want_match 1 "gh pr merge is not git merge"   'gh pr merge 1 --squash' "$GM"
+
+want_match 0 "gh issue create after a write"  'cat > /tmp/b.md <<EOF
+body
+EOF
+gh issue create --body-file /tmp/b.md' "$IC"
+want_match 1 "issue create inside a string"   'echo "run gh issue create later"' "$IC"
+
+want_match 0 "gh issue comment in a chain"    'git push && gh issue comment 7 --body-file /tmp/b.md' "$ICM"
+want_match 1 "issue create is not comment"    'gh issue create --fill' "$ICM"
+
+want_match 0 "gh api after a cd"              'cd /w/t && gh api -X PATCH repos/o/r/pulls/1 -F body=@/tmp/b.md' "$API"
+want_match 1 "api inside a string"            'echo "next: gh api repos/o/r"' "$API"
+want_match 1 "gh pr create is not gh api"     'gh pr create --fill' "$API"
+
+want_dir "/w/t" "gh -C on an issue comment"   'gh -C /w/t issue comment 7 --body x' /fallback "$ICM"
+want_dir "/w/t" "cd before a git switch"      'cd /w/t && git switch main' /fallback "$SW"
+
+# --- target directory ---------------------------------------------------------
+want_dir "/fallback"  "no cd, no -C"           'git commit -m x' /fallback "$C"
+want_dir "/w/t"       "leading cd"             'cd /w/t && git commit -m x' /fallback "$C"
+want_dir "/w/t"       "cd in an earlier segment" 'cd /w/t && git add -A && git commit -m x' /fallback "$C"
+want_dir "/w/b"       "chained cd"             'cd /w && cd /w/b && git commit -m x' /fallback "$C"
+want_dir "/fallback/rel" "relative cd"         'cd rel && git commit -m x' /fallback "$C"
+want_dir "/w/t"       "git -C beats cd"        'cd /other && git -C /w/t commit -m x' /fallback "$C"
+want_dir "/w/t"       "gh -C on a merge"       'gh -C /w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/fallback"  "cd AFTER the verb does not count" 'git commit -m x && cd /w/t' /fallback "$C"
+
+# --- every gate is actually converted -----------------------------------------
+# The matcher only helps a gate that uses it. This pins the conversion so a new
+# gate (or a revert) cannot quietly go back to a line-start-anchored `grep`.
+HOOK_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+for gate in "$HOOK_DIR"/*.sh; do
+  base=$(basename "$gate")
+  case "$base" in _*.sh | *.test.sh) continue ;; esac
+  if grep -q '_command-match.sh' "$gate"; then
+    pass=$((pass + 1)); printf 'OK   %s sources the matcher\n' "$base"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s does not source _command-match.sh\n' "$base"
+  fi
+  if grep -q "grep -qE '\^\[\[:space:\]\]\*(cd\[" "$gate"; then
+    fail=$((fail + 1)); printf 'FAIL %s still has a line-start-anchored matcher\n' "$base"
+  else
+    pass=$((pass + 1)); printf 'OK   %s has no line-start-anchored matcher\n' "$base"
+  fi
+done
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -129,5 +129,41 @@ for gate in "$HOOK_DIR"/*.sh; do
   fi
 done
 
+# --- the review findings from go-to-k/cdk-local#542 --------------------------
+# Every one of these was measured WRONG in the first version of this helper.
+want_match 0 "bare & separator"              'sleep 0 & git commit -m x' "$C"
+want_match 0 "command substitution"          'echo $(git commit -m x)' "$C"
+want_match 0 "substitution into a variable"  'SHA=$(git commit -m x)' "$C"
+want_match 0 "backtick substitution"         'echo `git commit -m x`' "$C"
+want_match 0 "bash -c wrapper"               'bash -c "git commit -m x"' "$C"
+want_match 0 "if/then compound"              'if true; then git commit -m x; fi' "$C"
+want_match 0 "for/do compound"               'for f in a; do git commit -m x; done' "$C"
+want_match 0 "timeout wrapper"               'timeout 60 git commit -m x' "$C"
+want_match 0 "time wrapper"                  'time git commit -m x' "$C"
+want_match 0 "nested subshells"              '( ( git commit -m x ) )' "$C"
+want_match 0 "backslash continuation"        'git \
+  commit -m x' "$C"
+want_match 0 "quoted -C path with a space"   'git -C "/w t" commit -m x' "$C"
+
+# The quote machinery only earns its keep on a separator INSIDE a string: without
+# it these match, and the gates start blocking ordinary `echo`s.
+want_match 1 "&& inside a quoted string"     'echo "step && git commit -m x"' "$C"
+want_match 1 "; inside a quoted string"      "echo 'step ; git commit -m x'" "$C"
+want_match 1 "| inside a quoted string"      'echo "step | git commit -m x"' "$C"
+# A quoted span survives a NEWLINE: a `--body "…"` argument is one span, and this
+# repo writes PR bodies that quote shell examples.
+want_match 1 "multi-line quoted body" 'gh pr create --body "line one
+line two && git commit -m x
+line three"' "$C"
+want_match 1 "CRLF heredoc terminator" 'cat <<EOF
+body
+EOF
+echo done' "$C"
+
+want_dir "/w t"   "quoted cd path"   'cd "/w t" && git commit -m x' /fb "$C"
+want_dir "/w t"   "quoted -C path"   'git -C "/w t" commit -m x' /fb "$C"
+want_dir "/fb"    "-C in a NON-matched segment is ignored" \
+  'git -C /elsewhere status && git commit -m x' /fb "$C"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -25,7 +25,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Read the entire stdin payload once; we need both .tool_input.command
 # and .cwd from it. Reading via two separate jq invocations would

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -14,12 +14,18 @@
 # the commit landed on the parent worktree's `main`.
 #
 # Resolution order for "where will the git command actually run":
-#   1. Explicit `git -C <path> commit/push` — last `-C` wins.
-#   2. Leading `cd <path> && ...` — the cd target.
+#   1. Explicit `git -C <path> commit/push` in the matched segment —
+#      last `-C` wins.
+#   2. The last `cd <path>` segment BEFORE the matched one.
 #   3. The hook input's `cwd` field (the Bash tool's persisted cwd).
 #   4. The hook process's own $PWD (fallback, almost never reached).
 
 set -u
+
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
 # Read the entire stdin payload once; we need both .tool_input.command
 # and .cwd from it. Reading via two separate jq invocations would
@@ -29,61 +35,25 @@ input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate git commit / git push — any other command passes through.
-# The regex matches `git` + optional global flags (e.g. `-C <path>`,
-# `-c <key>=<value>`, `--no-pager`, `--git-dir=<path>`) + the literal
-# subcommand `commit` or `push`, anchored so that `commit` / `push`
-# must appear in the GIT SUBCOMMAND POSITION — not as a substring of
-# a refspec (`<sha>^{commit}`), a pathspec (`-- '*push*.md'`), or a
-# `--grep=push` query.
-#
-# Line-start anchored so `git commit` / `git push` substrings inside
-# quoted argument bodies (`gh issue create --body "git commit later"`)
-# do NOT false-positive into a hard block. The optional leading
-# `cd <path> &&` prefix preserves the worktree-aware
-# `cd <side> && git commit` chain shape.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(commit|push)([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
-
-# Start from the Bash session's persisted cwd; fall back to the hook
-# process's own cwd if the payload did not include a `cwd` field.
-target_dir="${hook_cwd:-$PWD}"
-
-# `cd <path>` at the start of the command shifts the target dir. We
-# look at the FIRST `cd` and stop — chained `cd` patterns are rare
-# enough that handling only the leading one covers the realistic
-# foot-gun (the "cd into parent for tooling" case) without parsing
-# arbitrary shell.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  # Strip surrounding single or double quotes if present.
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  # Resolve relative paths against the inherited cwd.
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
+# Only gate `git commit` / `git push`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored. `gate_re` keeps whichever verb matched so the target-dir
+# resolution below reads the right segment.
+gate_re=""
+for gate_candidate in "$GATE_RE_GIT_COMMIT" "$GATE_RE_GIT_PUSH"; do
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
   fi
-  target_dir="$cd_target"
-fi
+done
+[ -n "$gate_re" ] || exit 0
 
-# `git -C <path>` is git's own "run as if from <path>" flag and beats
-# any earlier cd. Find the LAST occurrence so a chained
-# `git -C /a foo && git -C /b commit` resolves to /b.
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_re")
 
 # Repo opt-in scope (cdkd#1259): this gate protects repos that follow
 # the feature-branch + PR + markgate convention. A session rooted in

--- a/.claude/hooks/cdkd-parity-gate.sh
+++ b/.claude/hooks/cdkd-parity-gate.sh
@@ -37,48 +37,27 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `gh pr create`. `gh pr merge` is intentionally NOT gated — the
-# parity question is a pre-create judgment; once the marker has been set,
-# subsequent re-merges shouldn't re-block on a stale marker for a small
-# follow-up. Line-start anchored so `gh pr create` substrings inside quoted
-# argument bodies do NOT false-positive.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+# Only gate `gh pr create`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GH_PR_CREATE" || exit 0
 
-target_dir="${hook_cwd:-$PWD}"
-
-# `cd <path>` at the start of the command shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# `gh -C <path>` beats any earlier cd; pick the LAST occurrence.
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GH_PR_CREATE")
 
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see.

--- a/.claude/hooks/cdkd-parity-gate.sh
+++ b/.claude/hooks/cdkd-parity-gate.sh
@@ -40,7 +40,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/cdkd-parity-gate.sh
+++ b/.claude/hooks/cdkd-parity-gate.sh
@@ -83,7 +83,12 @@ fi
 
 # Fail-open if origin/main is not resolvable (fresh clone with no fetch
 # yet, weird remote setup, etc.).
-if ! git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+# Read git state from the RESOLVED TARGET DIR, not the hook's own cwd: the hook
+# process runs wherever the client launched it, so a scope decision taken here
+# was about the wrong tree — empty diff in a clean main checkout (gate fires
+# needlessly), or an unrelated tree's diff (gate skips wrongly). Same class as
+# go-to-k/cdk-real-drift#1805.
+if ! git -C "$target_dir" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
   exit 0
 fi
 
@@ -100,10 +105,10 @@ fi
 #     `/check-cdkd-parity`'s category 3 walk-through is meant to catch.
 #     Edits to EXISTING `src/local/**` files (`M` / `D`) are excluded
 #     so internal refactors don't fire the gate.
-scope_touched=$(git diff origin/main...HEAD --name-only 2>/dev/null \
+scope_touched=$(git -C "$target_dir" diff origin/main...HEAD --name-only 2>/dev/null \
   | grep -E '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$' \
   | head -1)
-new_local_file=$(git diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
+new_local_file=$(git -C "$target_dir" diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
   | grep -E '^src/local/.+\.ts$' \
   | head -1)
 if [ -z "$scope_touched" ] && [ -z "$new_local_file" ]; then
@@ -131,19 +136,19 @@ fi
 cat1_new_factory=""
 while IFS= read -r f; do
   [ -n "$f" ] || continue
-  if git diff origin/main...HEAD --diff-filter=A -- "$f" 2>/dev/null \
+  if git -C "$target_dir" diff origin/main...HEAD --diff-filter=A -- "$f" 2>/dev/null \
     | grep -qE '^\+[[:space:]]*export[[:space:]]+function[[:space:]]+createLocal[A-Z][A-Za-z]*Command'; then
     cat1_new_factory="$f"
     break
   fi
-done < <(git diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
+done < <(git -C "$target_dir" diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
   | grep -E '^src/cli/commands/local-[^/]+\.ts$')
 
 cat2_new_option=""
 # Same permissive pattern the skill's own detection uses (an added line that
 # carries `addOption(...new Option`), so chained `.addOption(new Option(` /
 # `cmd.addOption(new Option(` forms all match regardless of leading context.
-if git diff origin/main...HEAD -- 'src/cli/commands/*.ts' 2>/dev/null \
+if git -C "$target_dir" diff origin/main...HEAD -- 'src/cli/commands/*.ts' 2>/dev/null \
   | grep -qE '^\+.*addOption.*new Option'; then
   cat2_new_option="yes"
 fi

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -20,7 +20,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Read the entire stdin payload once; we need both .tool_input.command
 # and .cwd from it. Reading via two separate jq invocations would
@@ -44,6 +48,17 @@ target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_COMMIT")
 
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see.
+# Repo opt-in scope, mirroring branch-gate (go-to-k/cdkd#1259): this gate belongs
+# to repos that follow the markgate convention. A session rooted in one of them
+# still runs git against OTHER repos — a dotfiles checkout, a scratch clone —
+# where committing to main is normal and no marker exists to be fresh. Without
+# this the gate blocked those commits with a message naming skills that repo does
+# not have (hit on 2026-08-20 from a sibling-repo session).
+target_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -z "$target_top" ] || [ ! -f "$target_top/.markgate.yml" ]; then
+  exit 0
+fi
+
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -11,11 +11,16 @@
 # `git worktree`, and markgate stores marker state per-worktree at
 # `<git rev-parse --absolute-git-dir>/markgate/`. We resolve the
 # target working tree from the PreToolUse payload's `cwd` field +
-# leading `cd <path>` + last `git -C <path>` flag, exactly mirroring
-# branch-gate.sh, so the markgate verify runs against the worktree the
-# commit will actually land in.
+# `cd <path>` segments + the matched segment's `git -C <path>` flag
+# (all via the shared `gate_target_dir`), so the markgate verify runs
+# against the worktree the commit will actually land in.
 
 set -u
+
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
 # Read the entire stdin payload once; we need both .tool_input.command
 # and .cwd from it. Reading via two separate jq invocations would
@@ -25,56 +30,20 @@ input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate git commit -- any other command passes through. The
-# matcher tolerates `git -C <path> commit` / `git -c <key>=<val> commit`
-# / `git --no-pager commit` / etc. by allowing zero or more flag tokens
-# between `git` and the `commit` subcommand. Line-start anchored so
-# `git commit` substrings inside quoted argument bodies
-# (`gh issue create --body "we should run git commit later"`) do
-# NOT false-positive into a hard block. The optional leading
-# `cd <path> &&` prefix preserves the worktree-aware
-# `cd <side> && git commit` chain shape. Trailing class
-# `([[:space:]]|$|[|;&\`)])` ensures `commit` appears in the GIT
-# SUBCOMMAND POSITION — not as the prefix of `commit-tree` /
-# `commit-graph`.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+commit([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+# Only gate `git commit`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GIT_COMMIT" || exit 0
 
-# Resolve where the git command will actually run (cwd-aware; mirrors
-# branch-gate.sh — keep these in sync if either gains new resolution
-# shapes).
-target_dir="${hook_cwd:-$PWD}"
-
-# `cd <path>` at the start of the command shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# `git -C <path>` beats any earlier cd; pick the LAST occurrence.
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_COMMIT")
 
 # If the resolved target dir is not a git repo, silently pass — we
-# can't audit what we can't see (mirrors branch-gate.sh).
+# can't audit what we can't see.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/closes-paren-form-gate.sh
+++ b/.claude/hooks/closes-paren-form-gate.sh
@@ -11,6 +11,11 @@
 
 set -euo pipefail
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
+# spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input_json=$(cat)
 
 tool_name=$(jq -r '.tool_name // empty' <<<"$input_json" 2>/dev/null || true)
@@ -19,14 +24,16 @@ tool_name=$(jq -r '.tool_name // empty' <<<"$input_json" 2>/dev/null || true)
 command=$(jq -r '.tool_input.command // empty' <<<"$input_json" 2>/dev/null || true)
 [[ -n "$command" ]] || exit 0
 
-# Match `gh pr merge <N>` (allowing `gh -R repo` / `gh -C path` prefixes
-# and any flag order). Extract the LAST `gh pr merge ... N` occurrence
-# so a `# Wait + merge` Bash comment doesn't confuse the parser.
+# Only gate `gh pr merge`; anything else passes through. `gate_matches` splits
+# the command into segments, so the verb is caught in ANY position — after a
+# `git push &&`, after a `cd <wt>;`, inside a subshell — while a mention inside
+# a quoted string or a heredoc body is still ignored (the plain substring test
+# this used to run could not tell those apart).
+gate_matches "$command" "$GATE_RE_GH_PR_MERGE" || exit 0
+
+# Extract the LAST `gh pr merge ... N` occurrence so an earlier mention in the
+# same command line does not confuse the positional parser.
 trimmed="${command}"
-case "$trimmed" in
-  *"gh pr merge"*) ;;
-  *) exit 0 ;;
-esac
 
 # Extract PR number (positional integer after `gh pr merge`)
 args="${trimmed##*gh pr merge}"

--- a/.claude/hooks/closes-paren-form-gate.sh
+++ b/.claude/hooks/closes-paren-form-gate.sh
@@ -14,7 +14,11 @@ set -euo pipefail
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
 # spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input_json=$(cat)
 

--- a/.claude/hooks/commit-msg-heredoc-gate.sh
+++ b/.claude/hooks/commit-msg-heredoc-gate.sh
@@ -26,7 +26,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
 # spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 

--- a/.claude/hooks/commit-msg-heredoc-gate.sh
+++ b/.claude/hooks/commit-msg-heredoc-gate.sh
@@ -23,12 +23,19 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
+# spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
-# Only gate git commit invocations.
-if ! printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+commit\b'; then
-  exit 0
-fi
+# Only gate `git commit`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GIT_COMMIT" || exit 0
 
 # Block only when `git commit ... (-m|--message) ... <<` appears in
 # the same pipeline segment (no `;` / `&&` / `||` / `|` between them).

--- a/.claude/hooks/control-char-gate.sh
+++ b/.claude/hooks/control-char-gate.sh
@@ -30,7 +30,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/control-char-gate.sh
+++ b/.claude/hooks/control-char-gate.sh
@@ -18,58 +18,40 @@
 # about. Files with binary/asset extensions (images, fonts, archives, etc.)
 # legitimately contain control bytes and are skipped.
 #
-# Cwd-aware, mirroring branch-gate.sh: resolves the working tree the commit
-# will actually act on from `git -C <path>` > leading `cd <path>` > the hook
-# payload's `cwd` > the hook process's own $PWD.
+# Cwd-aware via the shared `gate_target_dir`: resolves the working tree the
+# commit will actually act on from the matched segment's `git -C <path>` > the
+# last preceding `cd <path>` > the hook payload's `cwd` > its own $PWD.
 #
 # Fails open (exit 0) when git / perl are unavailable or nothing is staged —
 # a safety net must never wedge an otherwise-valid commit.
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `git commit` (with optional global flags + the leading
-# `cd <path> &&` / `git -C <path>` worktree forms). Anchored so `commit`
-# must be in the subcommand position, not a substring of a refspec /
-# pathspec / quoted argument body.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+commit([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+# Only gate `git commit`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GIT_COMMIT" || exit 0
 
 # Need both git and perl to scan; without them, fail open.
 command -v git >/dev/null 2>&1 || exit 0
 command -v perl >/dev/null 2>&1 || exit 0
 
-# Resolve the target working tree (same precedence as branch-gate.sh).
-target_dir="${hook_cwd:-$PWD}"
-
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_COMMIT")
 
 # Staged added/modified files (NUL-delimited, so paths with spaces / newlines
 # are handled). Renames/copies/deletes are excluded — D has no content, and

--- a/.claude/hooks/create-integ-gate.sh
+++ b/.claude/hooks/create-integ-gate.sh
@@ -39,45 +39,27 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `gh pr create`. Line-start anchored so a `gh pr create`
-# substring inside a quoted argument body does NOT false-positive.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+# Only gate `gh pr create`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GH_PR_CREATE" || exit 0
 
-target_dir="${hook_cwd:-$PWD}"
-
-# `cd <path>` at the start of the command shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# `gh -C <path>` beats any earlier cd; pick the LAST occurrence.
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GH_PR_CREATE")
 
 if ! command -v git >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/create-integ-gate.sh
+++ b/.claude/hooks/create-integ-gate.sh
@@ -42,7 +42,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/create-integ-gate.sh
+++ b/.claude/hooks/create-integ-gate.sh
@@ -78,7 +78,12 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 0
 fi
 
-if ! git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+# Read git state from the RESOLVED TARGET DIR, not the hook's own cwd: the hook
+# process runs wherever the client launched it, so a scope decision taken here
+# was about the wrong tree — empty diff in a clean main checkout (gate fires
+# needlessly), or an unrelated tree's diff (gate skips wrongly). Same class as
+# go-to-k/cdk-real-drift#1805.
+if ! git -C "$target_dir" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
   exit 0
 fi
 
@@ -96,7 +101,7 @@ while IFS= read -r added; do
     new_command="$added"
     break
   fi
-done < <(git diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
+done < <(git -C "$target_dir" diff origin/main...HEAD --diff-filter=A --name-only 2>/dev/null \
   | grep -E '^src/cli/commands/local-[^/]+\.ts$')
 if [ -z "$new_command" ]; then
   exit 0

--- a/.claude/hooks/docs-inline-json-flag-gate.sh
+++ b/.claude/hooks/docs-inline-json-flag-gate.sh
@@ -50,44 +50,35 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate gh pr create / edit / merge — anything else passes through.
-if ! printf '%s' "$cmd" | grep -qE '\bgh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|edit|merge)\b'; then
-  exit 0
-fi
-
-target_dir="${hook_cwd:-$PWD}"
-
-# Leading `cd <path> && ...` shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
+# Only gate `gh pr create` / `edit` / `merge`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored. `gate_re` keeps whichever verb matched so the target-dir
+# resolution below reads the right segment.
+gate_re=""
+for gate_candidate in "$GATE_RE_GH_PR_CREATE" "$GATE_RE_GH_PR_EDIT" "$GATE_RE_GH_PR_MERGE"; do
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
   fi
-  target_dir="$cd_target"
-fi
+done
+[ -n "$gate_re" ] || exit 0
 
-# Last `gh -C <path>` wins.
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_re")
 
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/docs-inline-json-flag-gate.sh
+++ b/.claude/hooks/docs-inline-json-flag-gate.sh
@@ -53,7 +53,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Behavioral smoke test for the gates' COMMAND RECOGNITION, driven through the
+# real hooks with real payloads. Run from the repo root:
+#   bash .claude/hooks/gate-command-recognition.test.sh
+#
+# Why this exists (go-to-k/cdk-local#542 review): the helper's own harness tests
+# `gate_matches`, and a structural case asserts each gate sources the helper —
+# but neither can see a gate that sources it and then asks the WRONG question.
+# Two mutations proved it: pointing `check-gate` at `GATE_RE_GIT_PUSH`, and
+# replacing its `gate_matches … || exit 0` with a bare `exit 0`, both left the
+# suite green. These cases kill both.
+#
+# markgate is stubbed so marker state is controlled; the gates' own verdict logic
+# is out of scope here — what is under test is WHICH commands reach it.
+
+set -u
+
+HOOKS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+repo="$TMPDIR/repo"
+git init -q -b feature "$repo"
+git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+: > "$repo/.markgate.yml"   # opt in to the markgate convention
+
+SHIM="$TMPDIR/bin"; mkdir -p "$SHIM"
+cat > "$SHIM/mise" <<'MISE'
+#!/usr/bin/env bash
+exit "${MARKGATE_RC:-1}"
+MISE
+cat > "$SHIM/markgate" <<'MG'
+#!/usr/bin/env bash
+exit "${MARKGATE_RC:-1}"
+MG
+chmod +x "$SHIM/mise" "$SHIM/markgate"
+
+pass=0; fail=0
+# run_case <name> <expect_exit> <hook> <command>
+run_case() {
+  local name="$1" want="$2" hook="$3" cmd="$4" got out payload
+  payload=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd")
+  out=$(printf '%s' "$payload" | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 \
+    "$HOOKS/$hook" 2>&1); got=$?
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(exit $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s, got %s)\n  out: %s\n' "$name" "$want" "$got" "$out"
+  fi
+}
+
+# check-gate guards `git commit` — and ONLY that verb.
+run_case "check-gate: bare commit"            2 check-gate.sh 'git commit -m x'
+run_case "check-gate: add -A && commit"       2 check-gate.sh 'git add -A && git commit -m x'
+run_case "check-gate: subshell commit"        2 check-gate.sh '(cd . && git commit -m x)'
+run_case "check-gate: push is not its verb"   0 check-gate.sh 'git push origin HEAD'
+run_case "check-gate: status passes"          0 check-gate.sh 'git status --short'
+run_case "check-gate: quoted mention passes"  0 check-gate.sh 'echo \"then git commit -m x\"'
+
+# verify-pr-gate guards `gh pr create` / `gh pr merge`, not `gh pr view`.
+run_case "verify-pr-gate: pr create"          2 verify-pr-gate.sh 'gh pr create --fill'
+run_case "verify-pr-gate: push && pr create"  2 verify-pr-gate.sh 'git push && gh pr create --fill'
+run_case "verify-pr-gate: pr merge"           2 verify-pr-gate.sh 'gh pr merge 42 --squash'
+run_case "verify-pr-gate: pr view passes"     0 verify-pr-gate.sh 'gh pr view 42'
+
+# branch-gate guards commit AND push, and only on a protected branch.
+git -C "$repo" checkout -q -b main
+run_case "branch-gate: commit on main"        2 branch-gate.sh 'git commit -m x'
+run_case "branch-gate: push on main"          2 branch-gate.sh 'git push origin HEAD'
+run_case "branch-gate: chained commit"        2 branch-gate.sh 'vp run check && git commit -m x'
+run_case "branch-gate: status on main"        0 branch-gate.sh 'git status'
+git -C "$repo" checkout -q feature
+run_case "branch-gate: commit on a feature branch" 0 branch-gate.sh 'git commit -m x'
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/gh-pr-edit-deprecation-gate.sh
+++ b/.claude/hooks/gh-pr-edit-deprecation-gate.sh
@@ -25,7 +25,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
 # spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 

--- a/.claude/hooks/gh-pr-edit-deprecation-gate.sh
+++ b/.claude/hooks/gh-pr-edit-deprecation-gate.sh
@@ -22,12 +22,19 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
+# spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
-# Only gate `gh pr edit` invocations.
-if ! printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+edit\b'; then
-  exit 0
-fi
+# Only gate `gh pr edit`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GH_PR_EDIT" || exit 0
 
 # Only block if the invocation actually sets --title or --body.
 if ! printf '%s' "$cmd" | grep -qE '(--title|--body|--body-file)\b'; then

--- a/.claude/hooks/gh-pr-merge-worktree-gate.sh
+++ b/.claude/hooks/gh-pr-merge-worktree-gate.sh
@@ -34,7 +34,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/gh-pr-merge-worktree-gate.sh
+++ b/.claude/hooks/gh-pr-merge-worktree-gate.sh
@@ -25,50 +25,33 @@
 # main worktree does not hit the fatal and is left alone (fail-open).
 #
 # Cwd-aware: resolves the target git tree from the payload `cwd` + a
-# leading `cd <path>` + the last `gh -C <path>` (same resolution as
+# preceding `cd <path>` segments + the last `gh -C <path>` (same resolution as
 # integ-gate.sh) before consulting markgate, so the per-worktree marker
 # state dir is read correctly.
 
 set -u
+
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `gh pr merge` (incl. `gh -C <path> pr merge`, `cd <path> && gh
-# pr merge`, and `--auto`). Line-start anchored so a `gh pr merge` substring
-# inside a quoted argument body does NOT false-positive.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+# Only gate `gh pr merge`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GH_PR_MERGE" || exit 0
 
-target_dir="${hook_cwd:-$PWD}"
-
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GH_PR_MERGE")
 
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/integ-gate.sh
+++ b/.claude/hooks/integ-gate.sh
@@ -32,7 +32,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/integ-gate.sh
+++ b/.claude/hooks/integ-gate.sh
@@ -23,67 +23,41 @@
 #
 # WHY cwd-aware resolution: this repo is regularly worked in via
 # `git worktree`. We read the actual git working tree the command
-# will run against (via `git -C` or leading `cd <path>`) before
+# will run against (via `git -C` or a preceding `cd <path>`) before
 # consulting markgate. Convention: set markers from the worktree you
 # intend to merge from.
 
 set -u
+
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `gh pr merge` and `git merge`. `gh pr create` is
-# intentionally NOT gated — opening a PR for review should be allowed
-# even when the integ marker is stale; the gate only fires at merge
-# time. Line-start anchored so `gh pr merge` / `git merge` substrings
-# inside quoted argument bodies do NOT false-positive.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$|[|;&`)])|^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git[^|;&]*[[:space:]]merge([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
-
-target_dir="${hook_cwd:-$PWD}"
-
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
+# Only gate `gh pr merge` and `git merge`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored. `gate_re` keeps whichever verb matched so the target-dir
+# resolution below reads the right segment.
+gate_re=""
+for gate_candidate in "$GATE_RE_GH_PR_MERGE" "$GATE_RE_GIT_MERGE"; do
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
   fi
-  target_dir="$cd_target"
-fi
+done
+[ -n "$gate_re" ] || exit 0
 
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
-
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_re")
 
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/integ-gate.sh
+++ b/.claude/hooks/integ-gate.sh
@@ -86,8 +86,13 @@ cd "$target_dir" 2>/dev/null || exit 0
 # message and re-running `/run-integ` CANNOT clear it (its own
 # `markgate set integ` fails the same way). The fix is `git fetch
 # origin`. Still conservative — it blocks rather than passes.
-if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
-  if ! git diff origin/main...HEAD --name-only 2>/dev/null \
+# Read git state from the RESOLVED TARGET DIR, not the hook's own cwd: the hook
+# process runs wherever the client launched it, so a scope decision taken here
+# was about the wrong tree — empty diff in a clean main checkout (gate fires
+# needlessly), or an unrelated tree's diff (gate skips wrongly). Same class as
+# go-to-k/cdk-real-drift#1805.
+if git -C "$target_dir" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  if ! git -C "$target_dir" diff origin/main...HEAD --name-only 2>/dev/null \
       | grep -qE '^(src/|tests/integration/)'; then
     exit 0
   fi

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -16,8 +16,8 @@
 # contention doesn't exist.
 #
 # Resolution order for "where is the git command running":
-#   1. `git -C <path>` — last `-C` wins.
-#   2. Leading `cd <path> && ...` — the cd target.
+#   1. `git -C <path>` in the matched segment — last `-C` wins.
+#   2. The last `cd <path>` segment BEFORE the matched one.
 #   3. The hook's `cwd` field.
 #   4. $PWD.
 #
@@ -38,53 +38,35 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Match `git switch` / `git checkout` in the subcommand position.
-# Line-start anchored so `git switch` / `git checkout` substrings
-# inside quoted argument bodies (`gh issue create --body
-# "remember to git switch back"`) do NOT false-positive into a hard
-# block. The optional leading `cd <path> &&` prefix preserves the
-# worktree-aware `cd <main> && git switch <feat>` chain shape.
-# Reuses the branch-gate flag-token grammar so `git -C <path> switch`
-# / `git -c <key>=<val> switch` / etc. all qualify.
-#
-# We deliberately do NOT match `git worktree` — `git worktree add`
-# is the sanctioned escape and must always pass.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(switch|checkout)([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
-
-# Resolve the target dir the same way branch-gate.sh does.
-target_dir="${hook_cwd:-$PWD}"
-
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
+# Only gate `git switch` / `git checkout`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored. `gate_re` keeps whichever verb matched so the target-dir
+# resolution below reads the right segment.
+gate_re=""
+for gate_candidate in "$GATE_RE_GIT_SWITCH" "$GATE_RE_GIT_CHECKOUT"; do
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
   fi
-  target_dir="$cd_target"
-fi
+done
+[ -n "$gate_re" ] || exit 0
 
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_re")
 
 # Is the target dir the main worktree (= the top-level of the
 # shared .git directory)? `git rev-parse --show-toplevel` returns

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -41,7 +41,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -62,44 +62,35 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate gh pr create / edit / merge — anything else passes through.
-if ! printf '%s' "$cmd" | grep -qE '\bgh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|edit|merge)\b'; then
-  exit 0
-fi
-
-target_dir="${hook_cwd:-$PWD}"
-
-# Leading `cd <path> && ...` shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
+# Only gate `gh pr create` / `edit` / `merge`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored. `gate_re` keeps whichever verb matched so the target-dir
+# resolution below reads the right segment.
+gate_re=""
+for gate_candidate in "$GATE_RE_GH_PR_CREATE" "$GATE_RE_GH_PR_EDIT" "$GATE_RE_GH_PR_MERGE"; do
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
   fi
-  target_dir="$cd_target"
-fi
+done
+[ -n "$gate_re" ] || exit 0
 
-# Last `gh -C <path>` wins.
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_re")
 
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -65,7 +65,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -34,7 +34,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Read the entire stdin payload once; we need both .tool_input.command
 # and .cwd. Reading via two separate jq invocations would consume stdin

--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -31,6 +31,11 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 # Read the entire stdin payload once; we need both .tool_input.command
 # and .cwd. Reading via two separate jq invocations would consume stdin
 # twice and the second read would see nothing.
@@ -39,50 +44,17 @@ input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `git push` — any other command passes through. Line-start
-# anchored so `git push` substrings inside quoted argument bodies
-# (`gh issue create --body "remember to git push"`) do NOT
-# false-positive into a hard block. The optional leading
-# `cd <path> &&` prefix preserves the worktree-aware
-# `cd <side> && git push` chain shape. `[^|;&]*` matches any flag/value
-# pairs between `git` and the subcommand without crossing pipeline
-# separators. We intentionally do NOT match `git push origin :branch`
-# (delete push) — see explicit deletion check below.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git[^|;&]*[[:space:]]push([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+# Only gate `git push`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GIT_PUSH" || exit 0
 
-# Resolve where the git command will actually run (cwd-aware, copied
-# from branch-gate.sh — keep the two in sync if either gains new
-# resolution shapes).
-target_dir="${hook_cwd:-$PWD}"
-
-# `cd <path>` at the start of the command shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# `git -C <path>` beats any earlier cd; pick the LAST occurrence.
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_PUSH")
 
 # Parse `git push [...] <remote> <branch>` out of the command. We strip
 # the `git ... push` prefix (incl. any `-C <path>` between `git` and

--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -42,7 +42,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
 # spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 

--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -39,13 +39,29 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches` and the GATE_RE_* verb regexes every gate now
+# spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
-# Only gate gh invocations that pass a body file. Cheap pre-filter
-# before the more expensive extraction.
-if ! printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+(pr[[:space:]]+(create|edit)|issue[[:space:]]+(create|comment)|api)\b'; then
-  exit 0
-fi
+# Only gate the `gh` writers that take a body; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored. This gate acts on the body FILE, not on a working tree, so
+# the matched regex is only used to decide whether to keep going.
+gate_re=""
+for gate_candidate in "$GATE_RE_GH_PR_CREATE" "$GATE_RE_GH_PR_EDIT" \
+  "$GATE_RE_GH_ISSUE_CREATE" "$GATE_RE_GH_ISSUE_COMMENT" "$GATE_RE_GH_API"; do
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
+  fi
+done
+[ -n "$gate_re" ] || exit 0
+
 if ! printf '%s' "$cmd" | grep -qE '(--body-file|body=@)'; then
   exit 0
 fi

--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -23,7 +23,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Read the PreToolUse payload (command + cwd) once — separate jq
 # invocations would consume stdin twice.

--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -20,24 +20,24 @@
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 # Read the PreToolUse payload (command + cwd) once — separate jq
 # invocations would consume stdin twice.
 input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `gh pr merge` (incl. --auto). Anything else passes through.
-# Tolerate an optional `gh -C <path>` between `gh` and `pr`. Line-start
-# anchored so `gh pr merge` substrings inside quoted argument bodies
-# (`echo "remember to gh pr merge later"`) do NOT false-positive into a
-# hard block. The optional leading `cd <path> &&` prefix preserves the
-# worktree-aware `cd <side> && gh pr merge` chain shape.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+# Only gate `gh pr merge`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored.
+gate_matches "$cmd" "$GATE_RE_GH_PR_MERGE" || exit 0
 
-# Resolve where the gh command will actually run (cwd-aware).
-#
 # `gh pr merge` is a working-tree-agnostic remote operation, but
 # markgate's marker is stored per-worktree at
 # `<git rev-parse --absolute-git-dir>/markgate/`. The marker lands in
@@ -47,32 +47,10 @@ fi
 # `.markgate-pr-review-sha` is already per-worktree (each worktree has
 # its own root), so concurrent agents on different PRs in different
 # worktrees no longer clobber each other's sentinels.
-target_dir="${hook_cwd:-$PWD}"
-
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GH_PR_MERGE")
 
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/pr-review-gate.test.sh
+++ b/.claude/hooks/pr-review-gate.test.sh
@@ -126,6 +126,45 @@ else
   printf 'FAIL gh pr create should pass through\n'; fail=$((fail + 1))
 fi
 
+
+# ---------------------------------------------------------------------------
+# Compound command shapes (issue #541).
+#
+# The gate used to decide whether it applied with a LINE-START-anchored regex,
+# so `gh pr merge` in any position but the first ran UNGATED. These cases pin
+# the segment matcher: the verb blocks wherever it sits in the command list,
+# and a mention inside a quoted string still does not.
+# ---------------------------------------------------------------------------
+
+# run_cmd_case <name> <expected-exit> <command>
+# Uses the 500-loc, six-file skills-only diff -- the same shape as the
+# `skills-only keeps its tier` case above, i.e. a diff that MUST block once the
+# gate recognises the command. Anything that fails to recognise it exits 0, so
+# a `want 2` case can only pass by way of the matcher.
+run_cmd_case() {
+  local name="$1" want="$2" command="$3" got payload
+  GH_FIXTURE=$(fixture 500 "${SIX_SKILLS[@]}")
+  export GH_FIXTURE
+  payload=$(jq -nc --arg c "$command" --arg d "$REPO" \
+    '{tool_input:{command:$c},cwd:$d}')
+  ( cd "$REPO" && export PATH="$TMP/bin:$PATH" \
+    && printf '%s' "$payload" | bash "$HOOK" >/dev/null 2>&1 )
+  got=$?
+  if [ "$got" -eq "$want" ]; then
+    printf 'ok   %s (exit %s)\n' "$name" "$got"; pass=$((pass + 1))
+  else
+    printf 'FAIL %s: want exit %s, got %s\n' "$name" "$want" "$got"; fail=$((fail + 1))
+  fi
+}
+
+run_cmd_case "git add -A && gh pr merge blocks"   2 'git add -A && gh pr merge 42 --squash'
+run_cmd_case "echo x && gh pr merge blocks"       2 'echo x && gh pr merge 42 --squash'
+run_cmd_case "semicolon-separated merge blocks"   2 'echo x; gh pr merge 42 --squash'
+run_cmd_case "quoted mention passes through"      0 'echo "next: gh pr merge 42 --squash"'
+run_cmd_case "heredoc body mention passes through" 0 'cat <<EOF
+gh pr merge 42 --squash
+EOF'
+
 # ---------------------------------------------------------------------------
 # Up-bias security surface (issue #506).
 #

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -20,59 +20,42 @@
 # `git worktree`, and markgate stores marker state per-worktree at
 # `<git rev-parse --absolute-git-dir>/markgate/`. We resolve the
 # target working tree from the PreToolUse payload's `cwd` field +
-# leading `cd <path>` + last `gh -C <path>` flag, so the markgate
+# preceding `cd <path>` segments + the last `gh -C <path>` flag, so the markgate
 # verify runs against the worktree the PR will actually open / merge
 # from. Convention: set markers from the worktree you intend to open
 # the PR (and merge it) from.
 
 set -u
 
+# Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
+# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
+# regexes every gate now spells the same way.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Only gate `gh pr create` and `gh pr merge`. Match both `gh pr merge`
-# and `gh pr merge --auto`. Tolerate an optional `gh -C <path>` between
-# `gh` and `pr`. Line-start anchored so `gh pr create` / `gh pr merge`
-# substrings inside quoted argument bodies
-# (`echo "next step: gh pr create"`) do NOT false-positive into a hard
-# block. The optional leading `cd <path> &&` prefix preserves the
-# worktree-aware `cd <side> && gh pr create` chain shape.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
-
-# Resolve where the gh command will actually run (cwd-aware; mirrors
-# non-english-text-gate.sh / pr-review-gate.sh).
-target_dir="${hook_cwd:-$PWD}"
-
-# `cd <path>` at the start of the command shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
+# Only gate `gh pr create` and `gh pr merge`; anything else passes through.
+# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
+# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
+# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
+# is still ignored. `gate_re` keeps whichever verb matched so the target-dir
+# resolution below reads the right segment.
+gate_re=""
+for gate_candidate in "$GATE_RE_GH_PR_CREATE" "$GATE_RE_GH_PR_MERGE"; do
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
   fi
-  target_dir="$cd_target"
-fi
+done
+[ -n "$gate_re" ] || exit 0
 
-# Last `gh -C <path>` wins.
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Where the gated command will actually run: a `-C <path>` inside the MATCHED
+# segment wins, else the last `cd <path>` segment before it, else the hook
+# payload's cwd (see gate_target_dir in _command-match.sh).
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_re")
 
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see.

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -30,7 +30,11 @@ set -u
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
 # gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
 # regexes every gate now spells the same way.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 input=$(cat 2>/dev/null || true)
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -144,10 +144,13 @@ The hooks split into three classes:
 The seven markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
 `pr-review-gate.sh`, `integ-gate.sh`, `cdkd-parity-gate.sh`,
 `create-integ-gate.sh`, and `gh-pr-merge-worktree-gate.sh`) are
-all **cwd-aware**. Each reads the PreToolUse payload's `cwd` field plus
-parses leading `cd <path>` and the last `git -C <path>` /
-`gh -C <path>` flag from the command, then `cd`s to that resolved
-target dir before invoking `markgate verify`. This preserves
+all **cwd-aware**. Each reads the PreToolUse payload's `cwd` field, then hands
+the command to `gate_target_dir` in `.claude/hooks/_command-match.sh`, which
+resolves the tree in this order: a `git -C <path>` / `gh -C <path>` inside the
+MATCHED segment, else the LAST `cd <path>` segment before it, else the payload
+cwd. (Before go-to-k/cdk-local#542 each gate parsed only a LEADING `cd` and any
+`-C` anywhere in the command.) The hook then `cd`s to that resolved target dir
+before invoking `markgate verify`. This preserves
 markgate's per-worktree marker isolation — each parallel agent's
 worktree has its own markgate state dir
 (`<worktree>/.git/worktrees/<name>/markgate/` for side worktrees,

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -906,8 +906,9 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   found every PreToolUse gate inert, fixed the matcher in all three, then filed
   the remaining script-level gap as three separate issues — the per-repo split
   the user had asked it to end, rebuilt one classification line at a time. The
-  fix rode the same three PRs after the user objected, which is where it should
-  have gone in the first place.
+  fix landed in the same SESSION only after the user objected, as a follow-up PR
+  per repo — same session is the bar, same PR only when the work is small enough
+  to review together.
   **Verify the copy against the TARGET repo, claim by claim, before shipping it.**
   Their gates, hooks and ship steps differ, so a sentence that is true here reads as
   authoritative there while being false, and nothing lints instruction prose — the

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -890,6 +890,24 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   so re-filing the lesson you RECEIVED into the other two only manufactures a second
   and third copy of it. What IS new is whatever your ADAPTATION taught you, and that
   is subject to the same rule in turn: all three repos, this session.
+  **Inside this scope, `Session-fit: next` is not an available answer.** A run
+  the user framed as "one session across the repos" cannot classify its own
+  discoveries out of that session, and three tells make the call for you: you
+  are about to file the SAME issue body into more than one repo (that is the
+  split §10 exists to end, not triage); the fix is mechanical and its evidence
+  is live in this run, with the repro built, the files open and a gate cycle
+  already turning; or the user has already said "finish it here" for the
+  surrounding task, which a discovery inside that task inherits rather than
+  re-litigates. The four classification lines of §4 make a deferral HONEST;
+  they do not make one available, and an `Effort` / `Estimate` pair that reads
+  defensibly for work this run is already positioned to do is the tell that the
+  fields are being used as an excuse. Watched here on 2026-08-20: the session
+  carrying one `/work-issues` lesson into cdkd, cdk-local and cdk-real-drift
+  found every PreToolUse gate inert, fixed the matcher in all three, then filed
+  the remaining script-level gap as three separate issues — the per-repo split
+  the user had asked it to end, rebuilt one classification line at a time. The
+  fix rode the same three PRs after the user objected, which is where it should
+  have gone in the first place.
   **Verify the copy against the TARGET repo, claim by claim, before shipping it.**
   Their gates, hooks and ship steps differ, so a sentence that is true here reads as
   authoritative there while being false, and nothing lints instruction prose — the

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -228,8 +228,10 @@ export default defineConfig({
         command: 'vp run check && vp run test && vp run build',
       },
       'test:hooks': {
+        // Glob, not a hardcoded list: a new `.claude/hooks/*.test.sh` used to be
+        // added and then never run by anything (go-to-k/cdk-local#542 review).
         command:
-          'bash .claude/hooks/_command-match.test.sh && bash .claude/hooks/pr-review-gate.test.sh',
+          'for t in .claude/hooks/*.test.sh; do echo "== $t"; bash "$t" || exit 1; done',
         // Spawns throwaway git repos and a PATH-stubbed `gh`, so the result
         // depends on the hook script rather than on a tracked input set the
         // task runner can digest -- no caching.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -228,7 +228,8 @@ export default defineConfig({
         command: 'vp run check && vp run test && vp run build',
       },
       'test:hooks': {
-        command: 'bash .claude/hooks/pr-review-gate.test.sh',
+        command:
+          'bash .claude/hooks/_command-match.test.sh && bash .claude/hooks/pr-review-gate.test.sh',
         // Spawns throwaway git repos and a PATH-stubbed `gh`, so the result
         // depends on the hook script rather than on a tracked input set the
         // task runner can digest -- no caching.


### PR DESCRIPTION
## The bug

Every PreToolUse gate decided whether it applied with a LINE-START-anchored
regex that tolerated at most one leading `cd <path> &&`. A gated verb in any
other position was invisible, so the command ran **ungated** -- and an ungated
command looks exactly like one that passed.

Shapes that bypassed every gate:

| spelling | why it bypassed |
| --- | --- |
| `git add -A && git commit -m "..."` | verb not in first position (the commonest commit spelling there is) |
| `cd <wt>; git commit -m "..."` | separator is `;`, not `&&` |
| `cd <wt>&&git commit -m "..."` | no spaces around `&&` |
| `(cd <wt> && git commit -m "...")` | subshell parenthesis before `cd` |
| `GIT_EDITOR=true git commit -m "..."` | leading env assignment |

## Evidence

Measured on 2026-08-20, right after #540 gave every gate its own single-pattern
`if`. Before that, all seventeen `if` clauses used an unsupported ` or ` join
and **no gate ran at all**, so this matcher bug had never been reachable enough
to notice. The same defect was found and fixed in the sibling repos in the same
session (cdk-real-drift, cdkd).

## What changed

- **New `.claude/hooks/_command-match.sh`** (ported verbatim from
  cdk-real-drift, the reference implementation). It models a Bash tool call as
  a COMMAND LIST: split on `&&` / `||` / `;` / `|` / newline, unwrap subshell
  and brace grouping, and ask whether ANY segment is the gated verb. Quoted
  spans and heredoc bodies are blanked FIRST, so `echo "run git commit later"`
  and a `gh pr create --body-file <<EOF ... git commit ... EOF` body are still
  not commits. Leading `VAR=value` / `env` / `command` / `nohup` prefixes are
  stripped before matching.
- **`gate_target_dir`** replaces each gate's own ~35-line copy of the
  resolution: a `-C <path>` inside the MATCHED segment wins, else the last
  `cd <path>` segment BEFORE the matched one, else the hook payload's cwd.
  Relative paths resolve against the fallback and then against each other,
  which is what a `cd a && cd b` chain does.
- **`GATE_RE_*` constants** so every gate spells its verb once. cdk-local needs
  six the reference lacks: `GIT_SWITCH`, `GIT_CHECKOUT`, `GIT_MERGE`,
  `GH_ISSUE_CREATE`, `GH_ISSUE_COMMENT`, `GH_API`.
- **All 17 gates converted**: branch, cdkd-parity, check, closes-paren-form,
  commit-msg-heredoc, control-char, create-integ, docs-inline-json-flag,
  gh-pr-edit-deprecation, gh-pr-merge-worktree, integ, main-tree-branch,
  non-english-text, post-merge-orphan-push, pr-body-item-number, pr-review,
  verify-pr.

**What a gate blocks ON is unchanged.** Only recognition and directory
resolution moved. Fail-open paths, error text, exit codes and every
command-specific parse (`--admin`, `--auto`, PR-number extraction, body-file
extraction, the `git push origin :branch` deletion check) are preserved. Two
deliberate consequences of the shared matcher, both narrowings in the safe
direction:

1. `commit-msg-heredoc-gate`, `gh-pr-edit-deprecation-gate`,
   `pr-body-item-number-gate`, `docs-inline-json-flag-gate`,
   `non-english-text-gate` and `closes-paren-form-gate` used an UNANCHORED
   substring test, so a verb inside a quoted string used to trip them. It no
   longer does.
2. `integ-gate` used to apply both a `git -C` and a `gh -C` sweep over the whole
   command; it now takes the `-C` of the segment that actually matched.

Also amends one rule in `.claude/CLAUDE.md` and `.claude/skills/work-issues/SKILL.md`
(each in its own voice): `Session-fit: next` is not available for work
discovered inside a scope the user framed as "do this across the repos in one
session", with the 2026-08-20 incident carried inline as the evidence.

## Test plan

- `bash .claude/hooks/_command-match.test.sh` -- **80 pass / 0 fail**. Every
  bypassing spelling above matches; a verb in a double-quoted string, in a
  single-quoted string, in a heredoc body, a different verb, and a lookalike
  (`git log --grep commit`, `git merge-base`) do not; the target-dir precedence
  cases hold (`-C` beats `cd`, chained `cd`, relative `cd`, a `cd` AFTER the
  verb does not count). The six cdk-local verbs each get a compound positive and
  a negative. A final section asserts every gate sources the helper and carries
  no line-start-anchored matcher, so a revert cannot pass quietly.
- `bash .claude/hooks/pr-review-gate.test.sh` -- **53 pass / 0 fail**, its 48
  existing cases plus five end-to-end ones: `git add -A && gh pr merge`,
  `echo x && gh pr merge` and `echo x; gh pr merge` all BLOCK on a diff that
  must block, while a quoted mention and a heredoc-body mention pass through.
- `vp run test:hooks` now runs both harnesses.
- `vp run check` (0 errors, 1 pre-existing warning in `src/local/cloudfront-edge-event.ts`),
  `vp run build`, `vp run test` (211 files / 3165 tests) all green.
- Manual smoke against a throwaway repo on `main`: `git add -A && git commit`
  and `GIT_EDITOR=true git commit` block on branch-gate, `echo "later: git
  commit"` and `git status` pass; `echo hi && git commit -m "$(cat <<EOF ...)"`
  blocks on commit-msg-heredoc-gate while the `cat > file <<EOF ... git commit
  -F file` form still passes; `echo x && gh pr edit 1 --title y` blocks while
  the quoted mention passes.

Closes #541
