### PR TITLE
fix(hooks): an unterminated heredoc opener is not a heredoc, and never let `set -e` eat a segment

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -61,31 +61,50 @@ gate_segments_raw() {
       }
       return out
     }
+    # Is there a later line equal to `t`? A heredoc opener only blanks what
+    # follows when its delimiter is actually TERMINATED. Honouring an
+    # unterminated one swallows the rest of the command, so `cat <<EOF` + prose +
+    # a real `git commit` measured as NO MATCH — fail open (found while porting
+    # this helper to cdkd, go-to-k/cdkd#2130; the matcher cdkd already had was
+    # fixed for the same shape in go-to-k/cdkd#1455).
+    function terminated(t, from,   k, probe) {
+      for (k = from; k <= total; k++) {
+        probe = raw[k]
+        sub(/\r$/, "", probe)
+        gsub(/^[ \t]+|[ \t]+$/, "", probe)
+        if (probe == t) return 1
+      }
+      return 0
+    }
     BEGIN { tag = ""; pending = ""; q = "" }
-    {
-      line = $0
+    { raw[NR] = $0; total = NR }
+    END {
+      for (i = 1; i <= total; i++) emit(i)
+      if (pending != "") print flush_line(pending)
+    }
+    function emit(i,   line, t) {
+      line = raw[i]
       sub(/\r$/, "", line)
       if (tag != "") {                      # inside a heredoc body: data, not commands
         t = line
         gsub(/^[ \t]+|[ \t]+$/, "", t)
         if (t == tag) tag = ""
         print ""
-        next
+        return
       }
       if (pending != "") { line = pending line; pending = "" }
       if (line ~ /\\$/) {                   # `\`-continuation: join with the next line
         sub(/\\$/, "", line)
         pending = line
-        next
+        return
       }
       if (match(line, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*["'"'"']?/)) {
         t = substr(line, RSTART, RLENGTH)
         gsub(/^<<-?[ \t]*|["'"'"']/, "", t)
-        tag = t
+        if (terminated(t, i + 1)) tag = t
       }
       print flush_line(line)
     }
-    END { if (pending != "") print flush_line(pending) }
   ' SEP_AMP="$GATE_SEP_AMP" SEP_SEMI="$GATE_SEP_SEMI" SEP_PIPE="$GATE_SEP_PIPE" \
     SEP_SUBST="$GATE_SEP_SUBST" <<< "$1"
 }
@@ -122,7 +141,10 @@ gate_segments() {
     segment="${segment//"$GATE_SEP_PIPE"/|}"
     segment="${segment//"$GATE_SEP_SUBST"/$}"
     segment=$(gate_strip_prefix "$segment")
-    [ -n "$segment" ] && printf '%s\n' "$segment"
+    # An `if`, not `[ … ] && printf`: under a caller's `set -e` the trailing
+    # false test aborts the whole function, and the segments after it are never
+    # emitted — a silent fail-open that depends on which gate sources this.
+    if [ -n "$segment" ]; then printf '%s\n' "$segment"; fi
   done < <(gate_segments_raw "$1")
 }
 

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -165,5 +165,23 @@ want_dir "/w t"   "quoted -C path"   'git -C "/w t" commit -m x' /fb "$C"
 want_dir "/fb"    "-C in a NON-matched segment is ignored" \
   'git -C /elsewhere status && git commit -m x' /fb "$C"
 
+# --- heredoc termination (go-to-k/cdkd#2130, found porting this to cdkd) -------
+# An opener whose delimiter never appears again does NOT open a heredoc. Honouring
+# it swallowed the rest of the command: `cat <<EOF` + prose + a real commit was a
+# NO MATCH — fail open, and the shape a PR-body-writing session produces daily.
+want_match 0 "unterminated heredoc does not swallow the command" 'cat <<EOF
+some prose
+git commit -m x' "$C"
+want_match 1 "terminated heredoc blanks its body" 'cat <<EOF
+git commit -m x
+EOF' "$C"
+want_match 0 "command AFTER a terminated heredoc still matches" 'cat <<EOF
+prose
+EOF
+git commit -m x' "$C"
+want_match 1 "a body-only mention is not a command" 'gh pr create --body-file - <<EOF
+run git commit when done
+EOF' "$C"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Two fail-opens in the shared gate matcher, both surfaced by porting it to cdkd
(go-to-k/cdkd#2130). cdkd's own matcher had already been fixed for the first one
in go-to-k/cdkd#1455, so adopting mine verbatim there would have REGRESSED it —
which is how it was caught.

### 1. An unterminated `<<TAG` swallowed the rest of the command

A heredoc opener blanked everything after it whether or not `TAG` ever reappeared:

```
cat <<EOF
some prose
git commit -m x        <- reached git; the gate saw a heredoc body
```

Measured on merged `main` before this PR: **no match**. An opener now opens a
heredoc only when its delimiter is actually terminated later, which requires the
whole input — the awk buffers and runs two-pass.

This shape is not exotic here: a session writing a PR body with
`gh pr create --body-file - <<EOF … EOF` produces it daily, and the failure is
silent in the dangerous direction.

### 2. A caller's `set -e` silently truncated the segment list

`gate_segments` emitted with `[ -n "$segment" ] && printf …`. Under `set -e` that
trailing false test aborts the function, so every segment after the first empty
one is dropped — a fail-open whose reach depends on which gate sources the
helper. It is an `if` now.

## Test plan

- [x] `bash .claude/hooks/_command-match.test.sh` — 104 cases, 0 failed. Four new
      ones pin the heredoc contract: an unterminated opener does not swallow the
      command; a terminated one blanks its body; a command AFTER a terminated
      heredoc still matches; a body-only mention is still not a command.
- [x] Mutation probe: reverting the opener to unconditional `tag = t` fails
      exactly one of the four (52/1), so the cases discriminate.
- [x] `vp run test:hooks` — 3 harnesses, 0 failed
- [x] `vp run check` — 0 errors; `vp run build`; `vp run test` — 3165 tests

No `src/**` in the diff. The same fix shipped to the sibling in go-to-k/cdk-real-drift#1807. This repo's own `GATE_RE_*` additions (switch / checkout / merge / issue create / issue comment / api) are preserved.
