### PR TITLE
chore(hooks): probe that the gates are ALIVE before the session's first commit

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1238,6 +1238,14 @@ vp run runtime:smoke
   This is what CI runs; failing locally is faster feedback than failing
   in GitHub Actions.
 
+- **Registration is not execution — prove the gates are ALIVE before the first
+  commit of a session**: `git commit --dry-run -m "gate liveness probe"` from the
+  repo root. `--dry-run` commits nothing regardless of the tree; a `Blocked by
+  branch-gate` / `Blocked by check-gate` line means the hooks fire, and git's
+  ordinary output means they do not — on 2026-08-20 all seventeen were registered
+  and inert (go-to-k/cdk-real-drift#1801: an `if` holding `A or B` matches
+  nothing), which `/hooks` cannot show because it lists registration, not firing.
+
 - **Before every commit**: `check-gate.sh` blocks `git commit` unless
   both the `check` and `docs` markgate markers are fresh. Run
   `/check` and/or `/check-docs` proactively based on what your diff

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -494,6 +494,24 @@ enforce quality yourself; you (the orchestrator) still gate the MERGE via
 
 ## 6. Gates + PR (per lane)
 
+**Before the session's FIRST commit, prove the gates are ALIVE.** Registration is
+not execution: on 2026-08-20 all seventeen PreToolUse gates here were registered
+and INERT (go-to-k/cdk-real-drift#1801 — an `if` holding `A or B` matches
+nothing), and the failure is silent in the worst direction, since an ungated
+commit looks exactly like one that passed. `/hooks` lists what is REGISTERED, so
+it cannot see this. One command can:
+
+```bash
+git commit --dry-run -m "gate liveness probe"   # from the repo root, on main
+```
+
+`--dry-run` commits nothing whatever the tree looks like. Expected: `Blocked by
+branch-gate` (the root is on `main`) or `Blocked by check-gate` (markers stale).
+Git's ordinary output instead — `On branch main`, `nothing to commit` — means the
+gates are not firing at all, and every gate step below is then self-enforced: run
+each check by hand and say so in the report, because nothing else will.
+
+
 From inside the worktree, run the full check that CI runs:
 
 ```bash


### PR DESCRIPTION
## Summary

Registration is not execution, and nothing in this repo could tell the difference.
On 2026-08-20 all seventeen PreToolUse gates here were registered and **inert for a day**
(go-to-k/cdk-real-drift#1801: an `if` holding `A or B` matches nothing). The
failure is silent in the worst direction — an ungated commit looks exactly like
one that passed — and none of the existing fences can see it:

- `/hooks` lists what is REGISTERED, not what fires.
- The hook harnesses run the scripts DIRECTLY, so they pass either way.
- `tests/unit/hooks/gate-if-matchers.test.ts` reads `settings.json`, so it checks
  the configuration, not the client's use of it.

Only a real tool call routed through the client exercises the wiring. So the flow
takes one, once per session, before the first commit:

```bash
git commit --dry-run -m "gate liveness probe"
```

`--dry-run` commits nothing whatever the tree looks like. `Blocked by
branch-gate` / `Blocked by check-gate` means the hooks fire. **Git's ordinary
output means they do not**, and every gate is then self-enforced: run each check
by hand and say so in the report, because nothing else will.

Recorded in `.claude/CLAUDE.md` beside the commit-gate rule, and in `/work-issues` section 6
where a lane's first commit happens.

## Test plan

- [x] The probe itself, run in this repo: `Blocked by check-gate: run /check
      first …` — the expected output when markers are stale, which is the state a
      fresh worktree starts in
- [x] `vp run check` — 0 errors; `vp run build`; `vp run test` — 3165 tests
- [x] `vp run test:hooks` — 3 harnesses, 0 failed

No `src/**` in the diff. Same rule in go-to-k/cdk-real-drift#1811 and go-to-k/cdkd#2131.
