### PR TITLE
fix(hooks): a flag between the command and its verb no longer skips the gate, and the liveness probe says who runs it

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1239,8 +1239,10 @@ vp run runtime:smoke
   in GitHub Actions.
 
 - **Registration is not execution — prove the gates are ALIVE before the first
-  commit of a session**: `git commit --dry-run -m "gate liveness probe"` from the
-  repo root. `--dry-run` commits nothing regardless of the tree; a `Blocked by
+  commit of a session**: run `git commit --dry-run -m "gate liveness probe"` from
+  the repo root **as a Bash TOOL CALL**. PreToolUse hooks gate the AGENT's tool
+  calls only: the same line typed by a human into a terminal never passes through
+  them, so it proves nothing and will always look "unblocked". `--dry-run` commits nothing regardless of the tree; a `Blocked by
   branch-gate` / `Blocked by check-gate` line means the hooks fire, and git's
   ordinary output means they do not — on 2026-08-20 all seventeen were registered
   and inert (go-to-k/cdk-real-drift#1801: an `if` holding `A or B` matches

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,203 +17,203 @@
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(*git commit*)",
+            "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(*git push*)",
+            "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/main-tree-branch-gate.sh",
-            "if": "Bash(*git switch*)",
+            "if": "Bash(*git*switch*)",
             "timeout": 10,
             "statusMessage": "Checking main-tree branch-switch policy..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/main-tree-branch-gate.sh",
-            "if": "Bash(*git checkout*)",
+            "if": "Bash(*git*checkout*)",
             "timeout": 10,
             "statusMessage": "Checking main-tree branch-switch policy..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
-            "if": "Bash(*git commit*)",
+            "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit message form..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/control-char-gate.sh",
-            "if": "Bash(*git commit*)",
+            "if": "Bash(*git*commit*)",
             "timeout": 15,
             "statusMessage": "Scanning staged files for NUL / control bytes..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/gh-pr-edit-deprecation-gate.sh",
-            "if": "Bash(*gh pr edit*)",
+            "if": "Bash(*gh*pr*edit*)",
             "timeout": 10,
             "statusMessage": "Checking gh pr edit deprecation..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(*gh pr edit*)",
+            "if": "Bash(*gh*pr*edit*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
-            "if": "Bash(*gh pr edit*)",
+            "if": "Bash(*gh*pr*edit*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/post-merge-orphan-push-gate.sh",
-            "if": "Bash(*git push*)",
+            "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking for orphan-push to merged branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/closes-paren-form-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Checking PR body for Closes (#N) parens-form trap..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(*gh pr edit*)",
+            "if": "Bash(*gh*pr*edit*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(*gh issue create*)",
+            "if": "Bash(*gh*issue*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(*gh issue comment*)",
+            "if": "Bash(*gh*issue*comment*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(*gh api*)",
+            "if": "Bash(*gh*api*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/check-gate.sh",
-            "if": "Bash(*git commit*)",
+            "if": "Bash(*git*commit*)",
             "timeout": 15,
             "statusMessage": "Verifying check + docs markgate markers..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-review-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Verifying pr-review marker (sha-bound)..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Verifying verify-pr markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Verifying verify-pr markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Verifying integ markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-gate.sh",
-            "if": "Bash(*git merge*)",
+            "if": "Bash(*git*merge*)",
             "timeout": 15,
             "statusMessage": "Verifying integ markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/cdkd-parity-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Verifying cdkd-parity markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/create-integ-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Verifying create-integ markgate marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/gh-pr-merge-worktree-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Checking worktree merge policy (/merge-pr)..."
           }

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -505,6 +505,11 @@ it cannot see this. One command can:
 git commit --dry-run -m "gate liveness probe"   # from the repo root, on main
 ```
 
+Run it as YOUR OWN Bash tool call. PreToolUse hooks gate the agent's tool calls
+and nothing else — the identical line typed by a human into a terminal bypasses
+the hook system entirely, so it always looks "unblocked" and proves nothing. That
+mistake was made while writing this rule.
+
 `--dry-run` commits nothing whatever the tree looks like. Expected: `Blocked by
 branch-gate` (the root is on `main`) or `Blocked by check-gate` (markers stale).
 Git's ordinary output instead — `On branch main`, `nothing to commit` — means the

--- a/tests/unit/hooks/gate-if-matchers.test.ts
+++ b/tests/unit/hooks/gate-if-matchers.test.ts
@@ -35,37 +35,37 @@ const SETTINGS = join(here, '..', '..', '..', '.claude', 'settings.json');
 
 /** Which command each gate must be selected for. */
 const REQUIRED: Record<string, string[]> = {
-  'branch-gate.sh': ['Bash(*git commit*)', 'Bash(*git push*)'],
-  'main-tree-branch-gate.sh': ['Bash(*git switch*)', 'Bash(*git checkout*)'],
-  'commit-msg-heredoc-gate.sh': ['Bash(*git commit*)'],
-  'control-char-gate.sh': ['Bash(*git commit*)'],
-  'gh-pr-edit-deprecation-gate.sh': ['Bash(*gh pr edit*)'],
+  'branch-gate.sh': ['Bash(*git*commit*)', 'Bash(*git*push*)'],
+  'main-tree-branch-gate.sh': ['Bash(*git*switch*)', 'Bash(*git*checkout*)'],
+  'commit-msg-heredoc-gate.sh': ['Bash(*git*commit*)'],
+  'control-char-gate.sh': ['Bash(*git*commit*)'],
+  'gh-pr-edit-deprecation-gate.sh': ['Bash(*gh*pr*edit*)'],
   'non-english-text-gate.sh': [
-    'Bash(*gh pr create*)',
-    'Bash(*gh pr edit*)',
-    'Bash(*gh pr merge*)',
+    'Bash(*gh*pr*create*)',
+    'Bash(*gh*pr*edit*)',
+    'Bash(*gh*pr*merge*)',
   ],
   'docs-inline-json-flag-gate.sh': [
-    'Bash(*gh pr create*)',
-    'Bash(*gh pr edit*)',
-    'Bash(*gh pr merge*)',
+    'Bash(*gh*pr*create*)',
+    'Bash(*gh*pr*edit*)',
+    'Bash(*gh*pr*merge*)',
   ],
-  'post-merge-orphan-push-gate.sh': ['Bash(*git push*)'],
-  'closes-paren-form-gate.sh': ['Bash(*gh pr merge*)'],
+  'post-merge-orphan-push-gate.sh': ['Bash(*git*push*)'],
+  'closes-paren-form-gate.sh': ['Bash(*gh*pr*merge*)'],
   'pr-body-item-number-gate.sh': [
-    'Bash(*gh pr create*)',
-    'Bash(*gh pr edit*)',
-    'Bash(*gh issue create*)',
-    'Bash(*gh issue comment*)',
-    'Bash(*gh api*)',
+    'Bash(*gh*pr*create*)',
+    'Bash(*gh*pr*edit*)',
+    'Bash(*gh*issue*create*)',
+    'Bash(*gh*issue*comment*)',
+    'Bash(*gh*api*)',
   ],
-  'check-gate.sh': ['Bash(*git commit*)'],
-  'pr-review-gate.sh': ['Bash(*gh pr merge*)'],
-  'verify-pr-gate.sh': ['Bash(*gh pr create*)', 'Bash(*gh pr merge*)'],
-  'integ-gate.sh': ['Bash(*gh pr merge*)', 'Bash(*git merge*)'],
-  'cdkd-parity-gate.sh': ['Bash(*gh pr create*)'],
-  'create-integ-gate.sh': ['Bash(*gh pr create*)'],
-  'gh-pr-merge-worktree-gate.sh': ['Bash(*gh pr merge*)'],
+  'check-gate.sh': ['Bash(*git*commit*)'],
+  'pr-review-gate.sh': ['Bash(*gh*pr*merge*)'],
+  'verify-pr-gate.sh': ['Bash(*gh*pr*create*)', 'Bash(*gh*pr*merge*)'],
+  'integ-gate.sh': ['Bash(*gh*pr*merge*)', 'Bash(*git*merge*)'],
+  'cdkd-parity-gate.sh': ['Bash(*gh*pr*create*)'],
+  'create-integ-gate.sh': ['Bash(*gh*pr*create*)'],
+  'gh-pr-merge-worktree-gate.sh': ['Bash(*gh*pr*merge*)'],
 };
 
 interface GateHook {
@@ -138,6 +138,39 @@ describe('PreToolUse gate matchers (go-to-k/cdk-real-drift#1801)', () => {
       expect(gaps, `${gate} is missing an entry for ${gaps.join(', ')}`).toEqual([]);
     });
   }
+
+  // `git -C <path> commit` and `gh -R <owner/repo> pr create` put a FLAG between
+  // the command and its verb, so a pattern demanding them adjacent
+  // (`Bash(*git commit*)`) never selects those spellings — while the flow's own
+  // guidance tells an agent to use `git -C` in multi-repo sessions, steering
+  // straight into the gap (found 2026-08-21, the same class as
+  // go-to-k/cdk-real-drift#1801). Simulate the glob to keep it closed.
+  it('a flag between the command and its verb still selects the gate', () => {
+    const globToRe = (pattern: string) =>
+      new RegExp(
+        `^${pattern
+          .replace(/^Bash\(/, '')
+          .replace(/\)$/, '')
+          .split('*')
+          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('.*')}$`
+      );
+    const selects = (gate: string, spelling: string) =>
+      hooks.filter((h) => h.name === gate).some((h) => globToRe(h.condition).test(spelling));
+    for (const spelling of [
+      'git commit -m x',
+      'git -C /w/t commit -m x',
+      'git -c user.name=t commit -m x',
+      'git add -A && git commit -m x',
+    ]) {
+      expect(selects('check-gate.sh', spelling), `check-gate misses: ${spelling}`).toBe(true);
+    }
+    for (const spelling of ['gh pr create --fill', 'gh -R go-to-k/x pr create --fill']) {
+      expect(selects('verify-pr-gate.sh', spelling), `verify-pr-gate misses: ${spelling}`).toBe(
+        true
+      );
+    }
+  });
 
   it('the patterns are unanchored, so a compound command still selects the gate', () => {
     const anchored = hooks


### PR DESCRIPTION
## Summary

Two defects, both surfaced by actually running the liveness probe the last merge
added — which is the point of that rule.

## 1. Fail open: a flag between the command and its verb skipped the gate

`Bash(*git commit*)` needs `git commit` as a **contiguous** string, so these were
never selected and the gate simply did not run:

```
git -C <path> commit …
git -c user.name=t commit …
gh -R <owner/repo> pr create …
```

Measured A/B in one session, one cwd:

| command | result |
| --- | --- |
| `git commit --dry-run -m …` | `Blocked by check-gate` |
| `git -C <path> commit --dry-run -m …` | **passed** — git's ordinary output |

Same class as go-to-k/cdk-real-drift#1801, and worse than a plain gap: the shared guidance tells an agent to prefer `git -C <path>` in multi-repo sessions, so
the guidance steered straight into the hole. Most commits in the session that
wrote these gates went through ungated for exactly that reason.

Every verb pattern is now `Bash(*git*commit*)`-shaped, tolerating anything between
the command and its verb. The gate scripts already re-match precisely, so the
matcher's only job is to hand them every candidate.

## 2. The liveness rule did not say WHO runs the probe

A human typed it into a terminal, saw `nothing to commit, working tree clean`, and
reasonably read that as "the gates are dead". But a PreToolUse hook gates the
**agent's tool calls** only — a line typed into a shell never enters the hook
system, always looks unblocked, and proves nothing. `CLAUDE.md` and `/work-issues`
section 6 now say it is the agent's own Bash tool call and name that failure mode.

## Test plan

- [x] `vp test run tests/unit/hooks/gate-if-matchers.test.ts` — 23 cases, 0 failed. The
      new one simulates the glob against the real spellings (`git -C … commit`,
      `git -c k=v commit`, `git add -A && git commit`, `gh -R … pr create`);
      reverting to the adjacent-only pattern fails **4** of its cases.
- [x] `vp run check` — 0 errors; `vp run build`; `vp run test` — 3166 tests
- [x] `vp run test:hooks` — 3 harnesses, 0 failed

No `src/**` in the diff. Siblings: go-to-k/cdk-real-drift#1812 (same two fixes) and
go-to-k/cdkd#2140 (wording only — cdkd wires its hooks with no `if`, so the
matcher hole cannot occur there).
