### PR TITLE
chore(work-issues): gate issue filing on an open-issue root-cause check, and close the gh -R gate bypass it surfaced

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1375,7 +1375,13 @@ vp run runtime:smoke
   `gh pr create` for cat 1 / cat 2 until the sentinel carries a
   `github.com/go-to-k/cdkd/issues/` reference; cat 3 / cat 4 rely on the
   marker. `.claude/settings.json` `permissions.allow` pre-authorizes the
-  scoped `gh issue create`.
+  scoped `gh issue create`. That auto-file runs the `/work-issues` §5
+  open-issue search against cdkd first and carries the resulting
+  `Dup-check:` line in its body — `issue-dup-check-gate.sh` refuses a
+  `gh issue create` without one, and since this is the cross-repo mirror
+  filer whose duplicate history is that gate's rationale, an unreconciled
+  template would have deadlocked the flow outright: the gate blocks the
+  filing, and the missing filing blocks `gh pr create`.
 
   Out-of-scope diffs (internal refactors, docs, tests) pass through
   silently. `gh pr merge` is intentionally NOT gated — the parity

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1477,8 +1477,15 @@ vp run runtime:smoke
   ```
 
   A report adds a fifth line, **`Notes`**, for session-specific context
-  (`none` when there is nothing); the issue body stays at four, because
-  what belongs there is only the part that outlives the session.
+  (`none` when there is nothing); the issue body carries no `Notes`,
+  because what belongs there is only the part that outlives the session.
+  Four CLASSIFICATION lines, and they stay four — a filed issue body also
+  carries a **`Dup-check:`** line recording that the OPEN issue list was
+  searched for an issue already covering this root cause
+  (`/work-issues` §5), but that is a filing-time record rather than a
+  classification field: it is written once when the issue is created and
+  never re-decided on a claim. `.claude/hooks/issue-dup-check-gate.sh`
+  refuses `gh issue create` without it.
 
   **The four answer four DIFFERENT questions and none derives from
   another**: `Session-fit` is the decision, `Severity` the cost of

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -249,13 +249,63 @@ gate_matches() {
 # both quote characters inside one bracket expression.
 GATE_PATH_TOKEN='("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+)'
 
+# A shell WORD, which may EMBED quoted spans rather than being one: `-c`'s value
+# in `git -c core.pager="less -C /evil" commit` is a single word whose middle is
+# quoted. GATE_PATH_TOKEN cannot express that -- it is "a quoted span OR a bare
+# run of non-space", so it splits `core.pager="less` at the first space and the
+# tail `-C /evil"` reads as a fresh `-C` flag. That is how a QUOTED FLAG VALUE
+# steered the target directory: `git -c core.pager="less -C /evil" commit -m y`
+# resolved to /evil, and through branch-gate with the repo on `main` that turned
+# rc=2 into rc=0. Pre-existing on origin/main, but the widened `-C` scan makes it
+# reachable in more shapes, so it is fixed here.
+GATE_EMBEDDING_TOKEN='(("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'])+)'
+
 # The regexes, kept here so every gate spells its verb the same way. Each is
 # anchored at the START of a segment; `git -C <path>` / `git -c k=v` and
 # `gh -C <path>` are absorbed — including a QUOTED path containing spaces, which
 # an earlier version could not parse, so `git -C "/a b" commit` matched nothing
 # and ran ungated (go-to-k/cdk-local#542 review).
 GATE_FLAGS='([[:space:]]+-[^[:space:]]+([[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]-][^[:space:]]*))?)*'
-GATE_GH_C='([[:space:]]+-C[[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+))?'
+# `gh`'s leading flags, absorbed with the SAME token shape `git`'s are -- this is
+# literally GATE_FLAGS, not a parallel list, and that is the point.
+#
+# Two rounds of under-approximation here, both LIVE GATE BYPASSES rather than
+# cosmetic gaps, because every `gh` verb regex below is built on this constant:
+#
+#   1. It absorbed `-C <path>` ONLY, so `gh -R <owner/repo> pr merge 1 --squash`
+#      matched NOTHING and ran ungated. Driven through the real hooks with
+#      markgate stubbed stale: verify-pr-gate answered 2 to `gh pr merge
+#      1 --squash` and 0 to the `-R` spelling, on `pr create` too, and
+#      integ-gate the same.
+#   2. Replacing it with an explicit `(-C|-R|--repo)` alternation fixed only the
+#      SPACE-separated form, because that alternation demanded `[[:space:]]+`
+#      between the flag and its value. `gh` accepts three separators, verified
+#      against a real repo -- `gh pr list --repo=go-to-k/cdkd`,
+#      `gh pr list -R=go-to-k/cdkd` and the GLUED `gh pr list -Rgo-to-k/cdkd`
+#      all return the same PR number -- so `gh --repo=<owner/repo> pr merge
+#      --squash` still walked past verify-pr-gate, one keystroke from the
+#      bypass just closed. The `-C` support had the same hole all along:
+#      `gh -C=/w/t pr merge` did not match either.
+#
+# GATE_FLAGS' token is `-[^[:space:]]+`, which swallows `--repo=X`, `-R=X` and
+# `-RX` WHOLE -- the value group is needed only for the space-separated form. So
+# all three separators fall out of the token shape instead of being enumerated,
+# which is why this is not an explicit flag list: an alternation has to spell
+# each flag times each separator, and the glued form is the one it is most
+# likely to miss. Being wider than "repo/dir flags" costs nothing, since a flag
+# regex only decides which spellings REACH the verb -- `_command-match.test.sh`
+# pins that no `gh` verb matches a DIFFERENT `gh` verb, which is the failure
+# mode a flag absorber could actually introduce.
+#
+# Like GATE_FLAGS, this contributes THREE capture groups -- the same count the
+# explicit alternation had, so no `BASH_REMATCH` index anywhere shifts.
+#
+# The equality of the plain and flagged spellings is asserted THROUGH the gates
+# in `gate-command-recognition.test.sh`, not only at the regex level: a matcher
+# test can only fail once someone already suspects the flag, which is how both
+# rounds of this survived. Same defect and same fix as go-to-k/cdkd#2027 review
+# round 4, whose GATE_GH_C is this same GATE_FLAGS.
+GATE_GH_C="$GATE_FLAGS"
 GATE_RE_GIT_COMMIT="^git${GATE_FLAGS}[[:space:]]+commit([[:space:]]|$)"
 GATE_RE_GIT_PUSH="^git${GATE_FLAGS}[[:space:]]+push([[:space:]]|$)"
 GATE_RE_GH_PR_CREATE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+create([[:space:]]|$)"
@@ -269,37 +319,22 @@ GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
 GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
 GATE_RE_GH_ISSUE_COMMENT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)"
 GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
-# `gh` flags for the ISSUE-MINT gate only: `-C <path>` AND `-R <owner/repo>` /
-# `--repo <owner/repo>`, quoted alternatives included, repeatable so
-# `gh -C /w/t -R o/r issue create` is absorbed too.
+# The REST issue COLLECTION path, for issue-dup-check-gate. This matches the
+# PATH ONLY -- it says nothing about the HTTP method, and the collection is also
+# the READ endpoint (`gh api repos/<o>/<r>/issues` lists issues). An earlier
+# comment here claimed a `title=` check the regex never performed, and the gate
+# consequently refused plain reads: `gh api repos/go-to-k/cdk-local/issues` and
+# `gh api -X GET … -f state=open` both exited 2. Deciding mint-vs-read needs the
+# method and the fields, which is logic rather than a regex, so it lives in
+# `issue-dup-check-gate.sh`'s `seg_is_api_mint` and this constant is only the
+# trigger.
 #
-# A SEPARATE constant rather than a widening of GATE_GH_C, because GATE_GH_C is
-# the flag absorber for every other gh verb regex in this file --
-# GATE_RE_GH_PR_CREATE / _EDIT / _MERGE, GATE_RE_GH_ISSUE_CREATE,
-# GATE_RE_GH_ISSUE_COMMENT and GATE_RE_GH_API -- which between them decide the
-# trigger surface of verify-pr-gate, pr-review-gate, integ-gate,
-# closes-paren-form-gate, gh-pr-merge-worktree-gate, non-english-text-gate,
-# docs-inline-json-flag-gate, cdkd-parity-gate, create-integ-gate and
-# pr-body-item-number-gate. Those surfaces must not change here.
-#
-# Why the issue mint needs the wider absorber and the others (for now) do not:
-# `gh -R go-to-k/<target> issue create` is the CROSS-REPO MIRROR flow's own
-# spelling -- `/work-issues` section 10-c runs it from one repo's worktree into
-# a sibling -- and that flow is the documented duplicate GENERATOR that
-# issue-dup-check-gate exists to fence (go-to-k/cdk-local#528 /
-# go-to-k/cdk-local#531). A gate whose stated reason for existing is the mirror
-# path but which does not match the mirror path's command is close to inert.
-GATE_GH_CR='([[:space:]]+(-C|-R|--repo)[[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+))*'
-# The REST spelling of MINTING an issue, for issue-dup-check-gate. `gh api
-# repos/<o>/<r>/issues` with a `title=` field creates an issue, so the gate that
-# refuses `gh issue create` has to refuse this too or the trigger is
-# under-approximated. The path must NOT continue past `issues`, which is what
-# separates a mint from `/issues/<n>/comments` (a comment) and `/issues/<n>`
-# (an edit) -- neither of which mints anything, and both of which are the
-# CHEAP path this gate exists to steer toward. The trailing `\"` alternative
-# catches a fully quoted path argument. Built on GATE_GH_CR: this constant is
-# NEW, so it has no existing consumer whose surface could change.
-GATE_RE_GH_API_ISSUE_CREATE="^gh${GATE_GH_CR}[[:space:]]+api([[:space:]]|$).*repos/[^[:space:]/]+/[^[:space:]/]+/issues([[:space:]]|$|\")"
+# The path must NOT continue past `issues`: that is what separates the
+# collection from `/issues/<n>/comments` (a comment) and `/issues/<n>` (an
+# edit), neither of which mints anything, and both of which are the CHEAP path
+# the gate exists to steer toward. The trailing `\"` alternative catches a fully
+# quoted path argument.
+GATE_RE_GH_API_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$).*repos/[^[:space:]/]+/[^[:space:]/]+/issues([[:space:]]|$|\")"
 
 # Strip one layer of surrounding quotes from a path token.
 gate_unquote() {
@@ -307,6 +342,152 @@ gate_unquote() {
   p="${p%\"}"; p="${p#\"}"
   p="${p%\'}"; p="${p#\'}"
   printf '%s' "$p"
+}
+
+# gate_pr_selector <command> <verb-ere>
+#
+# Print the PR number the guarded command targets, or NOTHING when it carries no
+# positional (gh's "the PR for the current branch" semantics). The caller
+# decides what "nothing" means; this function never guesses one.
+#
+# WHY THIS IS SHARED, and why a local prefix strip is not good enough.
+# Four gates each rolled their own extraction, and all four broke the moment
+# GATE_GH_C learned to absorb `-R <owner/repo>`. Widening the absorber makes the
+# flagged command REACH the gate; it does nothing about the gate then parsing it.
+# Measured 2026-08-25 against `gh -R go-to-k/cdk-local pr merge 552 --squash`:
+#
+#   closes-paren-form-gate   `args="${cmd##*gh pr merge}"` does not strip, the
+#                            number regex finds nothing, exit 0 -- gh never
+#                            called. The plain form exits 2. Fully bypassed.
+#   non-english-text-gate    a hard-coded `-C`-only PR-number regex misses, so it
+#   docs-inline-json-flag    falls back to `gh pr view --json number`, the
+#                            CURRENT BRANCH's PR: `pr diff 999` instead of 552.
+#                            The verdict is about someone else's diff.
+#   pr-review-gate           same failed strip, then its arg loop scans the WHOLE
+#                            command for the first bare integer, so
+#                            `sleep 30 && gh -R o/r pr merge 552` resolves to 30.
+#                            The wrong PR's size decides the review tier.
+#
+# So the extraction is derived from the SAME constant that decides the trigger:
+# the verb ERE is anchored at the segment start and already absorbs every flag
+# spelling, so `BASH_REMATCH[0]` is exactly the part to remove, whatever flags it
+# swallowed. A gate can no longer match one way and parse another.
+gate_pr_selector() {
+  local cmd="$1" re="$2" segment args tok
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] || continue
+    # Everything after the matched verb -- flags included, because the verb ERE
+    # consumed them. Scanning starts here rather than at the segment start, which
+    # is what stops a leading `sleep 30 &&` from being read as the PR number.
+    args="${segment#"${BASH_REMATCH[0]}"}"
+    # Walk with GATE_EMBEDDING_TOKEN, not `set -- $args`. Word-splitting breaks a
+    # QUOTED flag value at its first space, so `gh pr merge --subject "chore: x"
+    # 2195` split into `"chore:` and `x"`, the flag consumed only the first half,
+    # and the second half -- a non-numeric positional -- ended the walk empty.
+    # Embedding tokens keep the value whole. It also removes the globbing hazard
+    # entirely (an unquoted `$args` let a literal `*` expand against the CWD:
+    # measured with files `77` and `aaa` present, `gh pr merge --some-flag * 552`
+    # resolved to 77) -- nothing is ever expanded now, so no `set -f` is needed.
+    while [[ "$args" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
+      tok="${BASH_REMATCH[1]}"
+      args="${BASH_REMATCH[3]}"
+      [ -n "$tok" ] || break
+      case "$tok" in
+        --*=*) continue ;;
+        # Enumerate the VALUELESS flags; treat every other `-...` as consuming
+        # the next token.
+        #
+        # THE DIRECTION OF STALENESS IS THE WHOLE ARGUMENT, and it is asymmetric.
+        # This file briefly had the opposite polarity -- value-takers enumerated
+        # -- and that is strictly worse:
+        #
+        #   enumerate value-takers -> an unlisted VALUE-TAKING flag leaves its
+        #     value in the walk -> a plausible integer becomes the selector ->
+        #     the gate judges a DIFFERENT PR. Measured: `gh pr merge -t 42 552`
+        #     resolved to 42.
+        #   enumerate valueless    -> an unlisted VALUELESS flag eats the number
+        #     -> the selector is EMPTY -> the caller falls back to gh's
+        #     current-branch semantics, or declines.
+        #
+        # Wrong-PR is severe; no-PR is not. Note this also covers the flags the
+        # verb ERE does NOT absorb: it only swallows what precedes the verb, so
+        # `gh pr merge -R <slug> 552` puts `-R` into THIS walk.
+        #
+        # The short spellings are gh pr merge's own valueless flags (`-d`
+        # delete-branch, `-s` squash, `-m` merge, `-r` rebase); they are listed
+        # because omitting them costs the number for the commonest hand-typed
+        # form. `--match-head-commit`, `--body`, `-b`, `--body-file`, `-F`, `-t`,
+        # `--subject`, `-R`, `--repo` are all deliberately ABSENT: they take
+        # values, and being unlisted is now the SAFE side.
+        --squash|--merge|--rebase|--auto|--disable-auto|--admin|--delete-branch|-d|-s|-m|-r)
+          continue ;;
+        -*)
+          # consume this flag's value
+          if [[ "$args" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; then
+            args="${BASH_REMATCH[3]}"
+          fi
+          continue ;;
+        *)
+          # THE FINAL NUMERIC GUARD. Every caller wants a PR NUMBER, so a
+          # non-numeric positional -- a branch name, a URL, or a repo slug that
+          # an unlisted flag left behind -- must yield EMPTY rather than be
+          # handed on. Stop rather than walk on: continuing would find a digit
+          # further along that belongs to something else entirely.
+          if [[ "$tok" =~ ^[0-9]+$ ]]; then printf '%s' "$tok"; fi
+          return 0 ;;
+      esac
+    done
+    return 0
+  done < <(gate_segments "$cmd")
+  return 0
+}
+
+# gate_cmd_repo <command> <verb-ere>
+#
+# Print the `-R <owner/repo>` / `--repo <owner/repo>` the guarded command names,
+# or nothing when it names none. All three of gh's separators are handled, and
+# tokens embed quoted spans (see GATE_EMBEDDING_TOKEN), so a repo slug inside a
+# quoted flag value is not mistaken for the flag.
+#
+# WHY: a gate resolves the PR NUMBER and then asks `gh pr view <N>` from the
+# resolved directory, WITHOUT the repo flag -- so `gh -R go-to-k/OTHER pr merge
+# 552` made every gate judge the LOCAL repo's PR 552. Right number, wrong repo,
+# and no assertion anywhere could see it because the exit code and the number
+# are both indistinguishable from the correct case. The gates pass this through
+# to their own gh calls so the question they ask matches the command they guard.
+gate_cmd_repo() {
+  local cmd="$1" re="$2" segment remaining tok found=""
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] || continue
+    # The WHOLE segment, not just the verb run: gh accepts the repo flag on
+    # either side of the verb, and `gh pr merge -R <slug> 552` writes it after.
+    # A segment is one command, so any repo flag in it belongs to this
+    # invocation.
+    remaining="$segment"
+    while [[ "$remaining" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
+      tok="${BASH_REMATCH[1]}"
+      remaining="${BASH_REMATCH[3]}"
+      [ -n "$tok" ] || break
+      case "$tok" in
+        --repo=*) found="${tok#--repo=}" ;;
+        -R=*)     found="${tok#-R=}" ;;
+        -R|--repo)
+          if [[ "$remaining" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; then
+            found="${BASH_REMATCH[1]}"; remaining="${BASH_REMATCH[3]}"
+          fi ;;
+        -R*) found="${tok#-R}" ;;
+        *) ;;
+      esac
+    done
+    break
+  done < <(gate_segments "$cmd")
+  found=$(gate_unquote "$found")
+  # An unexpanded value is not a repo; better to ask about the local one than
+  # about a literal `$VAR`.
+  case "$found" in *'$'*|*'`'*) found="" ;; esac
+  # Must look like owner/repo, or it is some other flag's value.
+  [[ "$found" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || found=""
+  printf '%s' "$found"
 }
 
 # gate_target_dir <cmd> <fallback> <extended-regex>
@@ -317,7 +498,7 @@ gate_unquote() {
 # Quoted paths survive: segments carry their original text (see the header).
 gate_target_dir() {
   local cmd="$1" fallback="$2" re="$3"
-  local target="$fallback" segment cd_target c_target remaining
+  local target="$fallback" segment cd_target c_target remaining verb_run tok
   while IFS= read -r segment; do
     if [[ "$segment" =~ ^cd[[:space:]]+$GATE_PATH_TOKEN ]]; then
       cd_target=$(gate_unquote "${BASH_REMATCH[1]}")
@@ -333,14 +514,56 @@ gate_target_dir() {
       continue
     fi
     [[ "$segment" =~ $re ]] || continue
-    # Last `-C <path>` in this segment wins over any earlier cd.
-    if [[ "$segment" =~ (git|gh)[[:space:]]+-C[[:space:]]+$GATE_PATH_TOKEN ]]; then
-      c_target=""
-      remaining="$segment"
-      while [[ "$remaining" =~ (git|gh)[[:space:]]+-C[[:space:]]+$GATE_PATH_TOKEN ]]; do
-        c_target="${BASH_REMATCH[2]}"
-        remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-      done
+    # A `-C <path>` in the MATCHED VERB'S OWN FLAG RUN wins over any earlier cd.
+    #
+    # Scanned out of `BASH_REMATCH[0]` -- the text the verb ERE just consumed,
+    # i.e. `gh <every leading flag> pr merge` -- rather than by anchoring on
+    # `(git|gh)[[:space:]]+-C`. That anchor required `-C` to sit IMMEDIATELY
+    # after the command word, so FLAG ORDER silently decided the verdict:
+    #
+    #   gh -C /w/t -R o/r pr merge 1   -> /w/t        (resolved)
+    #   gh -R o/r -C /w/t pr merge 1   -> payload cwd (NOT resolved)
+    #
+    # and the second is a live bypass, not a cosmetic asymmetry. Driven through
+    # verify-pr-gate with the `-C` target's marker STALE and the payload cwd's
+    # marker FRESH, the `-R`-first spellings returned rc=0 -- the merge was
+    # judged against a DIFFERENT worktree's marker and allowed. This is the same
+    # class as the two bypasses already closed on this branch: GATE_GH_C admits
+    # the flagged command to the verb, and a downstream reader still assumes the
+    # old adjacent-flag layout. Sourcing the scan from the ERE's own match is
+    # what makes the two agree by construction instead of by maintenance.
+    #
+    # `(^|[[:space:]])` rather than a command word, so `-C` is found wherever it
+    # sits in the run; the separator is optional and may be `=`, matching
+    # GATE_GH_C's token (`-C /w/t`, `-C=/w/t`, `-C/w/t`, quoted paths). NOTE the
+    # path is BASH_REMATCH[3]: both the leading boundary and the optional
+    # separator are groups. Lowercase `git -c k=v` does not match -- `[[ =~ ]]`
+    # is case-sensitive unless nocasematch is set, which nothing here sets.
+    verb_run="${BASH_REMATCH[0]}"
+    # Walk the flag run TOKEN BY TOKEN, with tokens that embed quoted spans, so
+    # a `-C` inside a quoted flag VALUE is part of that value and never a flag
+    # of its own (see GATE_EMBEDDING_TOKEN). A regex scan over the whole run
+    # cannot make that distinction: it has no notion of where a word begins.
+    c_target=""
+    remaining="$verb_run"
+    while [[ "$remaining" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
+      tok="${BASH_REMATCH[1]}"
+      remaining="${BASH_REMATCH[3]}"
+      [ -n "$tok" ] || break
+      case "$tok" in
+        -C=*) c_target="${tok#-C=}" ;;
+        -C)
+          # value is the NEXT token
+          if [[ "$remaining" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; then
+            c_target="${BASH_REMATCH[1]}"
+            remaining="${BASH_REMATCH[3]}"
+          fi
+          ;;
+        -C*) c_target="${tok#-C}" ;;
+        *) ;;
+      esac
+    done
+    if [ -n "$c_target" ]; then
       c_target=$(gate_unquote "$c_target")
       case "$c_target" in *'$'*|*'`'*) c_target="" ;; esac
       if [ -n "$c_target" ]; then

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -269,6 +269,37 @@ GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
 GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
 GATE_RE_GH_ISSUE_COMMENT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)"
 GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
+# `gh` flags for the ISSUE-MINT gate only: `-C <path>` AND `-R <owner/repo>` /
+# `--repo <owner/repo>`, quoted alternatives included, repeatable so
+# `gh -C /w/t -R o/r issue create` is absorbed too.
+#
+# A SEPARATE constant rather than a widening of GATE_GH_C, because GATE_GH_C is
+# the flag absorber for every other gh verb regex in this file --
+# GATE_RE_GH_PR_CREATE / _EDIT / _MERGE, GATE_RE_GH_ISSUE_CREATE,
+# GATE_RE_GH_ISSUE_COMMENT and GATE_RE_GH_API -- which between them decide the
+# trigger surface of verify-pr-gate, pr-review-gate, integ-gate,
+# closes-paren-form-gate, gh-pr-merge-worktree-gate, non-english-text-gate,
+# docs-inline-json-flag-gate, cdkd-parity-gate, create-integ-gate and
+# pr-body-item-number-gate. Those surfaces must not change here.
+#
+# Why the issue mint needs the wider absorber and the others (for now) do not:
+# `gh -R go-to-k/<target> issue create` is the CROSS-REPO MIRROR flow's own
+# spelling -- `/work-issues` section 10-c runs it from one repo's worktree into
+# a sibling -- and that flow is the documented duplicate GENERATOR that
+# issue-dup-check-gate exists to fence (go-to-k/cdk-local#528 /
+# go-to-k/cdk-local#531). A gate whose stated reason for existing is the mirror
+# path but which does not match the mirror path's command is close to inert.
+GATE_GH_CR='([[:space:]]+(-C|-R|--repo)[[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+))*'
+# The REST spelling of MINTING an issue, for issue-dup-check-gate. `gh api
+# repos/<o>/<r>/issues` with a `title=` field creates an issue, so the gate that
+# refuses `gh issue create` has to refuse this too or the trigger is
+# under-approximated. The path must NOT continue past `issues`, which is what
+# separates a mint from `/issues/<n>/comments` (a comment) and `/issues/<n>`
+# (an edit) -- neither of which mints anything, and both of which are the
+# CHEAP path this gate exists to steer toward. The trailing `\"` alternative
+# catches a fully quoted path argument. Built on GATE_GH_CR: this constant is
+# NEW, so it has no existing consumer whose surface could change.
+GATE_RE_GH_API_ISSUE_CREATE="^gh${GATE_GH_CR}[[:space:]]+api([[:space:]]|$).*repos/[^[:space:]/]+/[^[:space:]/]+/issues([[:space:]]|$|\")"
 
 # Strip one layer of surrounding quotes from a path token.
 gate_unquote() {

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -97,31 +97,60 @@ want_match 0 "gh api after a cd"              'cd /w/t && gh api -X PATCH repos/
 want_match 1 "api inside a string"            'echo "next: gh api repos/o/r"' "$API"
 want_match 1 "gh pr create is not gh api"     'gh pr create --fill' "$API"
 
-# --- GATE_GH_CR: `-R <owner/repo>` absorbed, for the ISSUE-MINT gate only -----
-# `gh -R go-to-k/<target> issue create` is the cross-repo mirror flow's own
-# spelling and the reason issue-dup-check-gate exists, so its verb regex is
-# built on GATE_GH_CR rather than the `-C`-only GATE_GH_C.
-MINT="^gh${GATE_GH_CR}[[:space:]]+issue[[:space:]]+create([[:space:]]|\$)"
-want_match 0 "mint: plain"                    'gh issue create -t x' "$MINT"
-want_match 0 "mint: -R <repo>"                'gh -R go-to-k/cdk-local issue create -t x' "$MINT"
-want_match 0 "mint: --repo <repo>"            'gh --repo go-to-k/cdkd issue create -t x' "$MINT"
-want_match 0 "mint: -C <path>"                'gh -C /w/t issue create -t x' "$MINT"
-want_match 0 "mint: -C and -R together"       'gh -C /w/t -R go-to-k/cdkd issue create -t x' "$MINT"
-want_match 0 "mint: quoted -C path"           'gh -C "/a b" issue create -t x' "$MINT"
-want_match 0 "mint: -R after a cd, chained"   'cd /w/t && gh -R go-to-k/cdkd issue create -t x' "$MINT"
-want_match 1 "mint: -R issue comment"         'gh -R go-to-k/cdk-local issue comment 7 --body x' "$MINT"
-want_match 1 "mint: -R pr create"             'gh -R go-to-k/cdk-local pr create --fill' "$MINT"
-want_match 1 "mint: inside a string"          'echo "gh -R o/r issue create"' "$MINT"
-
-# The SHARED constant is deliberately NOT widened: pr-body-item-number-gate.sh
-# consumes it, and the other gh verb regexes share GATE_GH_C, so its surface
-# must stay exactly as it was. These pin that surface in both directions -- the
-# `-R` miss is a KNOWN gap in those gates, reported separately, not something
-# this lane changed.
-want_match 0 "shared IC: plain still matches"  'gh issue create -t x' "$IC"
-want_match 0 "shared IC: -C still matches"     'gh -C /w/t issue create -t x' "$IC"
-want_match 1 "shared IC: -R unchanged (known gap)" 'gh -R go-to-k/cdk-local issue create -t x' "$IC"
-want_match 1 "shared PR create: -R unchanged (known gap)" 'gh -R go-to-k/cdk-local pr create --fill' "$GATE_RE_GH_PR_CREATE"
+# --- GATE_GH_C absorbs `-C` / `-R` / `--repo` for EVERY gh verb --------------
+# It absorbed `-C <path>` only until 2026-08-25, which was a live gate bypass:
+# `gh -R o/r pr merge 1 --squash` matched nothing and walked past verify-pr-gate
+# and integ-gate. These pin the widened surface on every gh verb regex, since
+# they all share the absorber.
+want_match 0 "IC: -R <repo>"                  'gh -R go-to-k/cdk-local issue create -t x' "$IC"
+want_match 0 "IC: --repo <repo>"              'gh --repo go-to-k/cdkd issue create -t x' "$IC"
+want_match 0 "IC: -C and -R together"         'gh -C /w/t -R go-to-k/cdkd issue create -t x' "$IC"
+want_match 0 "IC: quoted -C path"             'gh -C "/a b" issue create -t x' "$IC"
+want_match 0 "IC: -R after a cd, chained"     'cd /w/t && gh -R go-to-k/cdkd issue create -t x' "$IC"
+# THE bypass cases. Before the widening these matched NOTHING.
+want_match 0 "pr merge: -R <repo>"            'gh -R go-to-k/cdk-local pr merge 1 --squash' "$M"
+want_match 0 "pr merge: --repo <repo>"        'gh --repo go-to-k/cdk-local pr merge 1 --squash' "$M"
+want_match 0 "pr create: -R <repo>"           'gh -R go-to-k/cdk-local pr create --fill' "$GATE_RE_GH_PR_CREATE"
+want_match 0 "pr edit: -R <repo>"             'gh -R go-to-k/cdk-local pr edit 1 --body x' "$GATE_RE_GH_PR_EDIT"
+want_match 0 "issue comment: -R <repo>"       'gh -R go-to-k/cdk-local issue comment 7 --body x' "$ICM"
+want_match 0 "gh api: -R <repo>"              'gh -R go-to-k/cdk-local api repos/o/r/pulls/1' "$API"
+# ALL THREE separators `gh` accepts, not just the space form. Verified against a
+# real repo: `gh pr list --repo=go-to-k/cdkd`, `-R=go-to-k/cdkd` and the GLUED
+# `-Rgo-to-k/cdkd` all return the same PR number. An explicit flag alternation
+# fixed only the space form, so `gh --repo=o/r pr merge --squash` was still a
+# bypass; GATE_FLAGS' `-[^[:space:]]+` token swallows all three whole.
+want_match 0 "pr merge: --repo=<repo>"       'gh --repo=go-to-k/cdk-local pr merge 1 --squash' "$M"
+want_match 0 "pr merge: -R=<repo>"           'gh -R=go-to-k/cdk-local pr merge 1 --squash' "$M"
+want_match 0 "pr merge: -R<repo> glued"      'gh -Rgo-to-k/cdk-local pr merge 1 --squash' "$M"
+want_match 0 "pr merge: -C=<path>"           'gh -C=/w/t pr merge 1 --squash' "$M"
+want_match 0 "pr create: --repo=<repo>"      'gh --repo=go-to-k/cdk-local pr create --fill' "$GATE_RE_GH_PR_CREATE"
+want_match 0 "IC: --repo=<repo>"             'gh --repo=go-to-k/cdk-local issue create -t x' "$IC"
+want_match 0 "IC: -R=<repo>"                 'gh -R=go-to-k/cdk-local issue create -t x' "$IC"
+want_match 0 "IC: -R<repo> glued"            'gh -Rgo-to-k/cdk-local issue create -t x' "$IC"
+want_match 0 "IC: two flags, mixed seps"     'gh -C /w/t --repo=go-to-k/cdkd issue create -t x' "$IC"
+want_match 0 "api mint: --repo=<repo>"       'gh --repo=go-to-k/cdkd api repos/go-to-k/cdkd/issues -f title=t' "$GATE_RE_GH_API_ISSUE_CREATE"
+# The wider token must still not let one gh verb match a DIFFERENT one, and the
+# `=`/glued forms are where a too-greedy absorber would show it first.
+want_match 1 "glued -R: pr view is not create" 'gh -Rgo-to-k/cdk-local pr view 42' "$GATE_RE_GH_PR_CREATE"
+want_match 1 "glued -R: pr create is not merge" 'gh -Rgo-to-k/cdk-local pr create --fill' "$M"
+want_match 1 "--repo=: issue comment is not create" 'gh --repo=go-to-k/cdk-local issue comment 7 --body x' "$IC"
+# A flag VALUE must not swallow the verb: GATE_FLAGS' optional value group could
+# consume `pr`, and only backtracking saves it. Pin both directions.
+want_match 0 "flag with no value, then verb"  'gh --draft pr create --fill' "$GATE_RE_GH_PR_CREATE"
+want_match 0 "boolean flag before merge"      'gh --yes pr merge 1 --squash' "$M"
+# The plain and `-C` spellings must keep the verdicts they already had --
+# widening an absorber must not change what a verb regex means.
+want_match 0 "IC: plain unchanged"            'gh issue create -t x' "$IC"
+want_match 0 "IC: -C unchanged"               'gh -C /w/t issue create -t x' "$IC"
+want_match 0 "pr merge: plain unchanged"      'gh pr merge 1 --squash' "$M"
+want_match 0 "pr merge: -C unchanged"         'gh -C /w/t pr merge 1 --squash' "$M"
+# ...and the absorber must not let one gh verb match a DIFFERENT gh verb, which
+# is the failure mode a greedy flag run would introduce.
+want_match 1 "pr merge: -R pr create is not merge" 'gh -R go-to-k/cdk-local pr create --fill' "$M"
+want_match 1 "IC: -R issue comment is not create"  'gh -R go-to-k/cdk-local issue comment 7 --body x' "$IC"
+want_match 1 "IC: -R pr create is not issue create" 'gh -R go-to-k/cdk-local pr create --fill' "$IC"
+want_match 1 "pr create: -R pr view is not create"  'gh -R go-to-k/cdk-local pr view 42' "$GATE_RE_GH_PR_CREATE"
+want_match 1 "IC: -R inside a string"              'echo "gh -R o/r issue create"' "$IC"
 
 # --- the REST mint (issue-dup-check-gate) -------------------------------------
 # `gh api repos/<o>/<r>/issues` creates an issue; the path must NOT continue
@@ -147,6 +176,109 @@ want_dir "/fallback/rel" "relative cd"         'cd rel && git commit -m x' /fall
 want_dir "/w/t"       "git -C beats cd"        'cd /other && git -C /w/t commit -m x' /fallback "$C"
 want_dir "/w/t"       "gh -C on a merge"       'gh -C /w/t pr merge 1 --squash' /fallback "$M"
 want_dir "/fallback"  "cd AFTER the verb does not count" 'git commit -m x && cd /w/t' /fallback "$C"
+
+# --- gate_target_dir: `-C` is ORDER-INDEPENDENT within the flag run ----------
+# The scan used to anchor on `(git|gh)[[:space:]]+-C`, so `-C` had to sit
+# IMMEDIATELY after the command word and FLAG ORDER decided the verdict:
+# `gh -C /w/t -R o/r pr merge` resolved, `gh -R o/r -C /w/t pr merge` fell back
+# to the payload cwd. That is a live bypass -- driven through verify-pr-gate
+# with the `-C` target's marker STALE and the payload cwd's FRESH, the
+# `-R`-first spellings returned rc=0 and the merge was judged against a
+# different worktree's marker. Until this block there was NO want_dir case for
+# the `=` / multi-flag resolution at all.
+want_dir "/w/t" "-C first, then -R"        'gh -C /w/t -R o/r pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "-R first, then -C"        'gh -R o/r -C /w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "--repo= first, then -C"   'gh --repo=o/r -C /w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "-R first, then -C="       'gh -R o/r -C=/w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "glued -R, glued -C"       'gh -Ro/r -C/w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "-C= alone"                'gh -C=/w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "-C glued alone"           'gh -C/w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/w t" "-R first, quoted -C path" 'gh -R o/r -C "/w t" pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "last -C wins, after -R"   'gh -R o/r -C /a -C /w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/w/t" "-C after -R on issue create" 'gh -R o/r -C /w/t issue create -t x' /fallback "$IC"
+# A `-C` AFTER the verb is an argument, not a flag of the verb run, so it must
+# NOT steer the lookup -- the scan reads only the text the verb ERE consumed.
+want_dir "/fallback" "-C after the verb is ignored" 'gh pr merge 1 --squash -C /w/t' /fallback "$M"
+# Lowercase `git -c k=v` is not `-C` (the match is case-sensitive).
+want_dir "/w/t" "git -c config before -C" 'git -c user.name=t -C /w/t commit -m x' /fallback "$C"
+want_dir "/fallback" "git -c alone is not -C" 'git -c user.name=t commit -m x' /fallback "$C"
+want_dir "/base" "-C= with an unexpanded variable falls back" 'gh -R o/r -C="$WT" pr merge 1' /base "$M"
+
+# --- gate_pr_selector: DIRECT cases -----------------------------------------
+# It was fenced only indirectly, through the gates in
+# gate-command-recognition.test.sh. A helper four gates depend on for the PR
+# they judge deserves cases at its own level.
+want_sel() {
+  local want="$1" label="$2" cmd="$3" re="$4" got
+  got=$(gate_pr_selector "$cmd" "$re")
+  [ -z "$got" ] && got="(none)"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s\n  want: %s\n  got:  %s\n' "$label" "$want" "$got"
+  fi
+}
+want_sel "552"    "plain positional"            'gh pr merge 552 --squash' "$M"
+want_sel "552"    "-R before the verb"          'gh -R go-to-k/x pr merge 552 --squash' "$M"
+want_sel "552"    "--repo= before the verb"     'gh --repo=go-to-k/x pr merge 552 --squash' "$M"
+want_sel "552"    "glued -R before the verb"    'gh -Rgo-to-k/x pr merge 552 --squash' "$M"
+want_sel "552"    "flags before the number"     'gh pr merge --squash --auto 552' "$M"
+want_sel "552"    "short boolean before number" 'gh pr merge -d 552' "$M"
+want_sel "552"    "--flag=value before number"  'gh pr merge --body=x 552' "$M"
+want_sel "552"    "numeric token BEFORE the verb is not the selector" \
+  'sleep 30 && gh -R go-to-k/x pr merge 552 --squash' "$M"
+want_sel "552"    "an earlier merge mention does not win" \
+  'echo "gh pr merge 11" && gh pr merge 552 --squash' "$M"
+want_sel "(none)" "no positional means current branch" 'gh pr merge --squash' "$M"
+want_sel "(none)" "a branch name is not a number"      'gh pr merge my-branch --squash' "$M"
+want_sel "(none)" "a URL positional is not a number"   'gh pr merge https://github.com/o/r/pull/552' "$M"
+want_sel "(none)" "verb not present"                   'gh pr view 552' "$M"
+want_sel "552"    "pr edit selector"                   'gh -R go-to-k/x pr edit 552 --body x' "$GATE_RE_GH_PR_EDIT"
+# THE POLARITY of the flag enumeration, pinned in both directions. VALUELESS
+# flags are enumerated; every other `-...` consumes its next token. The opposite
+# polarity -- enumerating value-takers -- was tried and is strictly worse,
+# because the two failure modes are not symmetric:
+#
+#   unlisted VALUE-TAKER   -> its value stays in the walk -> a plausible integer
+#                             becomes the selector -> a DIFFERENT PR is judged.
+#                             Measured: `gh pr merge -t 42 552` resolved to 42.
+#   unlisted VALUELESS     -> it eats the number -> selector EMPTY -> the caller
+#                             falls back to current-branch semantics.
+#
+# Wrong-PR is severe, no-PR is not, so the empty results below are the DESIRED
+# outcome, not a gap.
+want_sel "552"    "--disable-auto is valueless"    'gh pr merge --disable-auto 552' "$M"
+want_sel "552"    "--admin is valueless"           'gh pr merge --admin 552' "$M"
+want_sel "552"    "-d short boolean"               'gh pr merge -d 552' "$M"
+want_sel "2195"   "--delete-branch --squash"       'gh pr merge --delete-branch --squash 2195' "$M"
+want_sel "(none)" "an unknown future flag yields EMPTY, not a wrong PR" \
+  'gh pr merge --some-new-flag 552' "$M"
+# The verb ERE absorbs only what PRECEDES the verb, so a repo flag written AFTER
+# it lands in this walk. Unlisted => value-taking => the slug is consumed and the
+# real number is found. Under the value-taker polarity `-R` was treated as
+# valueless and the SLUG became the selector.
+want_sel "552"    "-R <slug> after the verb"       'gh pr merge -R go-to-k/cdk-local 552 --squash' "$M"
+want_sel "552"    "--repo <slug> after the verb"   'gh pr merge --repo go-to-k/cdk-local 552' "$M"
+want_sel "552"    "-t <title> after the verb"      'gh pr merge -t 42 552' "$M"
+want_sel "552"    "--body-file value is skipped"   'gh pr merge --body-file /tmp/b.md 552' "$M"
+want_sel "552"    "--match-head-commit is skipped" 'gh pr merge --match-head-commit abc123 552' "$M"
+want_sel "552"    "-b value is skipped"            'gh pr merge -b text 552' "$M"
+# The FINAL NUMERIC GUARD: every caller wants a PR number, so a non-numeric
+# positional must yield empty rather than be handed on.
+want_sel "(none)" "a repo slug alone is not a PR number" 'gh pr merge go-to-k/cdk-local' "$M"
+
+# --- gate_target_dir must not read inside a quoted flag VALUE ---------------
+# `GATE_PATH_TOKEN` is "a quoted span OR a bare run of non-space", so it split
+# `core.pager="less` at the first space and read the tail `-C /evil"` as a fresh
+# `-C` flag: a quoted flag value STEERED the target directory, and through
+# branch-gate on `main` that turns rc=2 into rc=0. Tokens now EMBED quoted spans.
+want_dir "/fallback" "-C inside a quoted flag value is not a flag" \
+  'git -c core.pager="less -C /evil" commit -m y' /fallback "$C"
+want_dir "/fallback" "-C inside a single-quoted value is not a flag" \
+  "git -c core.pager='less -C /evil' commit -m y" /fallback "$C"
+want_dir "/w/t" "a real -C still wins after a quoted value" \
+  'git -c a.b="x -C /evil" -C /w/t commit -m y' /fallback "$C"
+want_dir "/w/t" "-c k=v then -C still resolves" 'git -c k=v -C /w/t commit -m y' /fallback "$C"
 
 # --- every gate is actually converted -----------------------------------------
 # The matcher only helps a gate that uses it. This pins the conversion so a new

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -97,6 +97,44 @@ want_match 0 "gh api after a cd"              'cd /w/t && gh api -X PATCH repos/
 want_match 1 "api inside a string"            'echo "next: gh api repos/o/r"' "$API"
 want_match 1 "gh pr create is not gh api"     'gh pr create --fill' "$API"
 
+# --- GATE_GH_CR: `-R <owner/repo>` absorbed, for the ISSUE-MINT gate only -----
+# `gh -R go-to-k/<target> issue create` is the cross-repo mirror flow's own
+# spelling and the reason issue-dup-check-gate exists, so its verb regex is
+# built on GATE_GH_CR rather than the `-C`-only GATE_GH_C.
+MINT="^gh${GATE_GH_CR}[[:space:]]+issue[[:space:]]+create([[:space:]]|\$)"
+want_match 0 "mint: plain"                    'gh issue create -t x' "$MINT"
+want_match 0 "mint: -R <repo>"                'gh -R go-to-k/cdk-local issue create -t x' "$MINT"
+want_match 0 "mint: --repo <repo>"            'gh --repo go-to-k/cdkd issue create -t x' "$MINT"
+want_match 0 "mint: -C <path>"                'gh -C /w/t issue create -t x' "$MINT"
+want_match 0 "mint: -C and -R together"       'gh -C /w/t -R go-to-k/cdkd issue create -t x' "$MINT"
+want_match 0 "mint: quoted -C path"           'gh -C "/a b" issue create -t x' "$MINT"
+want_match 0 "mint: -R after a cd, chained"   'cd /w/t && gh -R go-to-k/cdkd issue create -t x' "$MINT"
+want_match 1 "mint: -R issue comment"         'gh -R go-to-k/cdk-local issue comment 7 --body x' "$MINT"
+want_match 1 "mint: -R pr create"             'gh -R go-to-k/cdk-local pr create --fill' "$MINT"
+want_match 1 "mint: inside a string"          'echo "gh -R o/r issue create"' "$MINT"
+
+# The SHARED constant is deliberately NOT widened: pr-body-item-number-gate.sh
+# consumes it, and the other gh verb regexes share GATE_GH_C, so its surface
+# must stay exactly as it was. These pin that surface in both directions -- the
+# `-R` miss is a KNOWN gap in those gates, reported separately, not something
+# this lane changed.
+want_match 0 "shared IC: plain still matches"  'gh issue create -t x' "$IC"
+want_match 0 "shared IC: -C still matches"     'gh -C /w/t issue create -t x' "$IC"
+want_match 1 "shared IC: -R unchanged (known gap)" 'gh -R go-to-k/cdk-local issue create -t x' "$IC"
+want_match 1 "shared PR create: -R unchanged (known gap)" 'gh -R go-to-k/cdk-local pr create --fill' "$GATE_RE_GH_PR_CREATE"
+
+# --- the REST mint (issue-dup-check-gate) -------------------------------------
+# `gh api repos/<o>/<r>/issues` creates an issue; the path must NOT continue
+# past `issues`, which is what separates a mint from a comment or an edit.
+APIIC="$GATE_RE_GH_API_ISSUE_CREATE"
+want_match 0 "gh api issues POST"             'gh api repos/go-to-k/cdk-local/issues -f title=t' "$APIIC"
+want_match 0 "gh api issues POST after a cd"  'cd /w/t && gh api repos/go-to-k/cdkd/issues -f title=t' "$APIIC"
+want_match 0 "gh api issues POST with -R"     'gh -R go-to-k/cdkd api repos/go-to-k/cdkd/issues -f title=t' "$APIIC"
+want_match 1 "gh api issue comments"          'gh api repos/go-to-k/cdk-local/issues/5/comments -f body=x' "$APIIC"
+want_match 1 "gh api issue PATCH"             'gh api -X PATCH repos/go-to-k/cdk-local/issues/5 -f body=x' "$APIIC"
+want_match 1 "gh api pulls is not issues"     'gh api repos/go-to-k/cdk-local/pulls -f title=t' "$APIIC"
+want_match 1 "gh issue create is not gh api"  'gh issue create --fill' "$APIIC"
+
 want_dir "/w/t" "gh -C on an issue comment"   'gh -C /w/t issue comment 7 --body x' /fallback "$ICM"
 want_dir "/w/t" "cd before a git switch"      'cd /w/t && git switch main' /fallback "$SW"
 

--- a/.claude/hooks/closes-paren-form-gate.sh
+++ b/.claude/hooks/closes-paren-form-gate.sh
@@ -31,6 +31,12 @@ if ! declare -F gate_matches >/dev/null 2>&1; then
   echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
   exit 2
 fi
+# `gate_pr_selector` too: without it the selector silently comes back EMPTY and
+# the gate judges the wrong PR (or none) instead of refusing.
+if ! declare -F gate_pr_selector >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_pr_selector is undefined (predates the shared PR-selector extractor?)." >&2
+  exit 2
+fi
 
 
 input_json=$(cat)
@@ -48,13 +54,19 @@ command=$(jq -r '.tool_input.command // empty' <<<"$input_json" 2>/dev/null || t
 # this used to run could not tell those apart).
 gate_matches "$command" "$GATE_RE_GH_PR_MERGE" || exit 0
 
-# Extract the LAST `gh pr merge ... N` occurrence so an earlier mention in the
-# same command line does not confuse the positional parser.
-trimmed="${command}"
-
-# Extract PR number (positional integer after `gh pr merge`)
-args="${trimmed##*gh pr merge}"
-pr_num=$(echo "$args" | grep -oE '^[[:space:]]*[0-9]+' | head -1 | tr -d '[:space:]' || true)
+# Extract the PR number through the SHARED extractor, which strips the matched
+# verb -- flags and all -- rather than a literal `gh pr merge` prefix.
+# `args="${command##*gh pr merge}"` was the old shape and it did not strip under
+# a repo flag, so the number regex found nothing and this gate exited 0:
+# `gh -R <owner/repo> pr merge 552 --squash` was FULLY bypassed while the plain
+# form was refused (measured 2026-08-25 with a gh shim returning a body carrying
+# `Closes (#12)`: plain rc=2, every flagged spelling rc=0 with gh never called).
+pr_num=$(gate_pr_selector "$command" "$GATE_RE_GH_PR_MERGE")
+# The repo the command NAMES, passed through to this gate's own gh calls. Without
+# it `gh -R go-to-k/OTHER pr merge 552` made the gate ask the LOCAL repo about
+# its PR 552 -- right number, wrong repo, and indistinguishable from the correct
+# case by both exit code and PR number.
+cmd_repo=$(gate_cmd_repo "$command" "$GATE_RE_GH_PR_MERGE")
 [[ -n "$pr_num" ]] || exit 0
 [[ "$pr_num" =~ ^[0-9]+$ ]] || exit 0
 
@@ -69,7 +81,7 @@ pr_num=$(echo "$args" | grep -oE '^[[:space:]]*[0-9]+' | head -1 | tr -d '[:spac
 #       grep below handles empty input cleanly; no warning needed.
 gh_stderr=$(mktemp)
 trap 'rm -f "$gh_stderr"' EXIT
-if ! body=$(gh pr view "$pr_num" --json body -q .body 2>"$gh_stderr"); then
+if ! body=$(gh pr view "$pr_num" ${cmd_repo:+--repo "$cmd_repo"} --json body -q .body 2>"$gh_stderr"); then
   {
     echo "WARN: closes-paren-form-gate could not fetch PR #$pr_num body"
     echo "    (\`gh pr view\` exited non-zero — likely network / auth /"

--- a/.claude/hooks/docs-inline-json-flag-gate.sh
+++ b/.claude/hooks/docs-inline-json-flag-gate.sh
@@ -70,6 +70,12 @@ if ! declare -F gate_matches >/dev/null 2>&1; then
   echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
   exit 2
 fi
+# `gate_pr_selector` too: without it the selector silently comes back EMPTY and
+# the gate judges the wrong PR (or none) instead of refusing.
+if ! declare -F gate_pr_selector >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_pr_selector is undefined (predates the shared PR-selector extractor?)." >&2
+  exit 2
+fi
 
 
 input=$(cat 2>/dev/null || true)
@@ -118,13 +124,23 @@ fi
 #
 #   `gh pr merge <N>` / `gh pr edit <N>` — N is the explicit arg.
 #   `gh pr create` / `gh pr merge` (no arg) — current branch's PR.
-pr_number=""
-if [[ "$cmd" =~ gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(merge|edit)[[:space:]]+([0-9]+) ]]; then
-  pr_number="${BASH_REMATCH[3]}"
-fi
+# Through the SHARED extractor, which strips whatever flags the verb regex
+# absorbed. The hard-coded `-C`-only pattern this replaces did not match under a
+# repo flag, so resolution fell through to `gh pr view --json number` -- the
+# CURRENT BRANCH's PR. Measured 2026-08-25: `gh -R go-to-k/cdk-local pr merge
+# 552 --squash` produced `gh pr diff 999 --name-only`, i.e. the gate's verdict
+# was about a different PR's diff entirely.
+pr_number=$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_MERGE")
+[[ -n "$pr_number" ]] || pr_number=$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_EDIT")
+# The repo the command NAMES, passed through to this gate's own gh calls. Without
+# it `gh -R go-to-k/OTHER pr merge 552` made the gate ask the LOCAL repo about
+# its PR 552 -- right number, wrong repo, and indistinguishable from the correct
+# case by both exit code and PR number.
+cmd_repo=$(gate_cmd_repo "$cmd" "$GATE_RE_GH_PR_MERGE")
+[[ -n "$cmd_repo" ]] || cmd_repo=$(gate_cmd_repo "$cmd" "$GATE_RE_GH_PR_EDIT")
 
 if [[ -z "$pr_number" ]]; then
-  pr_number=$( (cd "$target_dir" && "$GH" pr view --json number -q .number) 2>/dev/null || true)
+  pr_number=$( (cd "$target_dir" && "$GH" pr view ${cmd_repo:+--repo "$cmd_repo"} --json number -q .number) 2>/dev/null || true)
 fi
 
 # No PR yet (typical `gh pr create` on a fresh branch) — fall back to
@@ -145,7 +161,7 @@ if [[ "$use_local_diff" -eq 1 ]]; then
   fi
   changed_files=$(git -C "$target_dir" diff "$merge_base..HEAD" --name-only --diff-filter=AM 2>/dev/null || true)
 else
-  changed_files=$( (cd "$target_dir" && "$GH" pr diff "$pr_number" --name-only) 2>/dev/null || true)
+  changed_files=$( (cd "$target_dir" && "$GH" pr diff "$pr_number" ${cmd_repo:+--repo "$cmd_repo"} --name-only) 2>/dev/null || true)
 fi
 
 if [[ -z "$changed_files" ]]; then
@@ -169,7 +185,7 @@ MAX_REPORT=20
 
 pr_head_sha=""
 if [[ "$use_local_diff" -eq 0 ]]; then
-  pr_head_sha=$( (cd "$target_dir" && "$GH" pr view "$pr_number" --json headRefOid -q .headRefOid) 2>/dev/null || true)
+  pr_head_sha=$( (cd "$target_dir" && "$GH" pr view "$pr_number" ${cmd_repo:+--repo "$cmd_repo"} --json headRefOid -q .headRefOid) 2>/dev/null || true)
 fi
 
 read_file_content() {

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -25,21 +25,63 @@ git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 : > "$repo/.markgate.yml"   # opt in to the markgate convention
 
 SHIM="$TMPDIR/bin"; mkdir -p "$SHIM"
+# Both stubs LOG THEIR $PWD when asked to. A gate `cd`s into the directory it
+# resolved before asking markgate, so that log is a direct read of
+# gate_target_dir's answer through the real hook -- which is the only way to
+# fence target-dir resolution for gates whose exit code is the same either way.
+# Both stubs log their $PWD AND THEIR ARGV. Logging only $PWD was a blind spot
+# of its own: nothing asserted WHICH GATE NAME a hook verifies, so swapping
+# `markgate verify verify-pr` for `markgate verify check` in verify-pr-gate --
+# a LIVE BYPASS, since the PR then merges whenever `/check` alone is fresh and
+# the `/verify-pr` checklist never ran -- left the whole suite green. The `gh`
+# shim had had argv logging since the selector round; markgate had not.
 cat > "$SHIM/mise" <<'MISE'
 #!/usr/bin/env bash
+[ -n "${PWD_LOG:-}" ] && printf '%s\n' "$PWD" >> "$PWD_LOG"
+[ -n "${MG_LOG:-}" ] && printf '%s\n' "$*" >> "$MG_LOG"
 exit "${MARKGATE_RC:-1}"
 MISE
 cat > "$SHIM/markgate" <<'MG'
 #!/usr/bin/env bash
+[ -n "${PWD_LOG:-}" ] && printf '%s\n' "$PWD" >> "$PWD_LOG"
+[ -n "${MG_LOG:-}" ] && printf '%s\n' "$*" >> "$MG_LOG"
 exit "${MARKGATE_RC:-1}"
 MG
-chmod +x "$SHIM/mise" "$SHIM/markgate"
+# A `git` shim that logs argv. cdkd-parity-gate / create-integ-gate expose the
+# directory they resolved on their FIRST `git -C "$target_dir" rev-parse
+# --git-dir`, long before markgate -- so their resolution IS observable, and an
+# earlier revision of this file wrongly recorded "(never asked)" and called them
+# uncoverable. Delegates to the real git so the gates still function.
+cat > "$SHIM/git" <<'GIT'
+#!/usr/bin/env bash
+[ -n "${GIT_LOG:-}" ] && printf '%s\n' "$*" >> "$GIT_LOG"
+exec /usr/bin/git "$@"
+GIT
+# A `gh` shim that LOGS its argv. Without it the gh-calling gates fail open and
+# every pair below is satisfied vacuously at 0 -- which is exactly how three live
+# bypasses were certified green (see run_sel).
+cat > "$SHIM/gh" <<'GH'
+#!/usr/bin/env bash
+[ -n "${GH_LOG:-}" ] && printf '%s\n' "$*" >> "$GH_LOG"
+case "$*" in
+  "auth status"*) exit 0 ;;
+  *"pr view --json number"*) echo 999 ;;   # the CURRENT BRANCH's PR, never the target
+  *"pr view"*"body"*) echo 'Closes (#12)' ;;
+  *"pr view"*) echo '{"additions":50,"deletions":10,"changedFiles":2,"files":[],"headRefOid":"abc","headRefName":"f"}' ;;
+  *"pr diff"*) echo 'README.md' ;;
+esac
+exit 0
+GH
+chmod +x "$SHIM/mise" "$SHIM/markgate" "$SHIM/gh" "$SHIM/git"
 
 pass=0; fail=0
 # run_case <name> <expect_exit> <hook> <command>
 run_case() {
   local name="$1" want="$2" hook="$3" cmd="$4" got out payload
-  payload=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd")
+  # `tool_name` is REQUIRED, not decoration: closes-paren-form-gate reads it and
+  # exits before ever looking at the command when it is absent, so a payload
+  # without it reported "both exit 0" over a fully bypassed gate.
+  payload=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd")
   out=$(printf '%s' "$payload" | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 \
     "$HOOKS/$hook" 2>&1); got=$?
   if [ "$got" = "$want" ]; then
@@ -83,6 +125,296 @@ run_case "branch-gate: chained commit"        2 branch-gate.sh 'vp run check && 
 run_case "branch-gate: status on main"        0 branch-gate.sh 'git status'
 git -C "$repo" checkout -q feature
 run_case "branch-gate: commit on a feature branch" 0 branch-gate.sh 'git commit -m x'
+
+# --- a repo/dir FLAG must not change any gate's verdict ----------------------
+# `gh -R <owner/repo> pr merge 1 --squash` matched NOTHING until 2026-08-25,
+# because GATE_GH_C absorbed `-C <path>` only, so it MERGED PAST verify-pr-gate
+# and integ-gate while the identical command without the flag was refused
+# (verify-pr-gate 2 -> 0 on both `pr merge` and `pr create`; integ-gate 2 -> 0).
+#
+# The regex-level cases in `_command-match.test.sh` pin the absorber, but they
+# can only fail once someone already suspects the flag. THIS is the assertion
+# that would have caught it cold: drive the gate with the plain and the flagged
+# spelling of the same command and demand the SAME exit code. It needs no
+# knowledge of which flags exist — only that adding one must not change a
+# verdict.
+#
+# run_pair <name> <hook> <plain-cmd> <flagged-cmd> [<expected-plain-rc>]
+#
+# The 5th argument is a GUARD ON THE GUARD. Several gates shell out to `gh` and
+# fail OPEN when it errors, so under this harness they answer 0 to both
+# spellings and the equality holds VACUOUSLY. Passing the expected plain rc
+# forces the pair to be discriminating: if the gate stops refusing the plain
+# command, the case fails instead of quietly proving nothing.
+run_pair() {
+  local name="$1" hook="$2" plain="$3" flagged="$4" want_plain="${5:-}"
+  local a b pa pb
+  pa=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$plain")
+  pb=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$flagged")
+  printf '%s' "$pa" | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 "$HOOKS/$hook" >/dev/null 2>&1; a=$?
+  printf '%s' "$pb" | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 "$HOOKS/$hook" >/dev/null 2>&1; b=$?
+  if [ -n "$want_plain" ] && [ "$a" != "$want_plain" ]; then
+    fail=$((fail + 1))
+    printf 'FAIL %s (plain rc %s, expected %s -- the pair no longer discriminates)\n' "$name" "$a" "$want_plain"
+    return
+  fi
+  if [ "$a" = "$b" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(both exit $a)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (plain %s, flagged %s -- the flag bypasses the gate)\n' "$name" "$a" "$b"
+  fi
+}
+
+R=go-to-k/cdk-local
+# The three pairs that actually discriminate under this harness, each pinned to
+# the refusing rc so they cannot go vacuous.
+run_pair "verify-pr-gate: -R pr merge"  verify-pr-gate.sh "gh pr merge 1 --squash" "gh -R $R pr merge 1 --squash" 2
+run_pair "verify-pr-gate: -R pr create" verify-pr-gate.sh "gh pr create --fill"    "gh -R $R pr create --fill"    2
+run_pair "integ-gate: -R pr merge"      integ-gate.sh     "gh pr merge 1 --squash" "gh -R $R pr merge 1 --squash" 2
+run_pair "issue-dup-gate: -R issue create" issue-dup-check-gate.sh \
+  "gh issue create -t x --body-file /nope.md" "gh -R $R issue create -t x --body-file /nope.md" 2
+run_pair "verify-pr-gate: --repo pr merge" verify-pr-gate.sh "gh pr merge 1 --squash" "gh --repo $R pr merge 1 --squash" 2
+run_pair "verify-pr-gate: -C then -R"      verify-pr-gate.sh "gh pr merge 1 --squash" "gh -C $repo -R $R pr merge 1 --squash" 2
+# ...and the REVERSED order, which is the one that broke: the `-C` scan required
+# `-C` immediately after `gh`, so `gh -R o/r -C <dir> …` resolved to the payload
+# cwd instead of <dir>. With a STALE marker in the -C target that returned rc=0
+# -- the merge judged against a different worktree's marker. Only the working
+# order was tested here before.
+run_pair "verify-pr-gate: -R then -C"      verify-pr-gate.sh "gh pr merge 1 --squash" "gh -R $R -C $repo pr merge 1 --squash" 2
+run_pair "verify-pr-gate: --repo= then -C" verify-pr-gate.sh "gh pr merge 1 --squash" "gh --repo=$R -C $repo pr merge 1 --squash" 2
+run_pair "verify-pr-gate: -R then -C="     verify-pr-gate.sh "gh pr merge 1 --squash" "gh -R $R -C=$repo pr merge 1 --squash" 2
+run_pair "integ-gate: -R then -C"          integ-gate.sh     "gh pr merge 1 --squash" "gh -R $R -C $repo pr merge 1 --squash" 2
+# ALL THREE separators `gh` accepts. The `=` and GLUED forms are not exotic:
+# `gh pr list --repo=<o/r>`, `-R=<o/r>` and `-R<o/r>` all work against a real
+# repo. An explicit flag alternation absorbed only the space form, so these were
+# still merging past verify-pr-gate one keystroke after the space form was
+# fixed -- and the glued form is the one a hand-written alternation misses,
+# since it has no separator at all.
+run_pair "verify-pr-gate: --repo=<repo>"   verify-pr-gate.sh "gh pr merge 1 --squash" "gh --repo=$R pr merge 1 --squash" 2
+run_pair "verify-pr-gate: -R=<repo>"       verify-pr-gate.sh "gh pr merge 1 --squash" "gh -R=$R pr merge 1 --squash" 2
+run_pair "verify-pr-gate: -R<repo> glued"  verify-pr-gate.sh "gh pr merge 1 --squash" "gh -R$R pr merge 1 --squash" 2
+run_pair "verify-pr-gate: -C=<path>"       verify-pr-gate.sh "gh pr merge 1 --squash" "gh -C=$repo pr merge 1 --squash" 2
+run_pair "integ-gate: -R<repo> glued"      integ-gate.sh     "gh pr merge 1 --squash" "gh -R$R pr merge 1 --squash" 2
+run_pair "integ-gate: --repo=<repo>"       integ-gate.sh     "gh pr merge 1 --squash" "gh --repo=$R pr merge 1 --squash" 2
+run_pair "issue-dup-gate: -R<repo> glued"  issue-dup-check-gate.sh \
+  "gh issue create -t x --body-file /nope.md" "gh -R$R issue create -t x --body-file /nope.md" 2
+run_pair "issue-dup-gate: --repo=<repo>"   issue-dup-check-gate.sh \
+  "gh issue create -t x --body-file /nope.md" "gh --repo=$R issue create -t x --body-file /nope.md" 2
+# The remaining gh gates fail open under the stubbed `gh`, so these pairs are
+# equal at 0 and are kept as REGRESSION cases only -- deliberately WITHOUT a
+# discriminating rc, because there is none to assert here. They still catch a
+# widening that makes one spelling throw where the other does not.
+run_pair "pr-review-gate: -R pr merge"     pr-review-gate.sh     "gh pr merge 1 --squash" "gh -R $R pr merge 1 --squash"
+run_pair "closes-paren-gate: -R pr merge"  closes-paren-form-gate.sh "gh pr merge 1 --squash" "gh -R $R pr merge 1 --squash"
+# CONTROLS, not fences -- say so rather than let the count imply coverage. Both
+# gates answer 0 to either spelling under the stubbed `gh`, so the equality is
+# satisfied trivially and proves only that the flag introduces no new error.
+# Unlike verify-pr-gate / integ-gate they have no rc that discriminates here, so
+# they get no expected-plain-rc argument; what DOES fence their target-dir
+# resolution is run_dir below, which asserts the directory they consult.
+run_pair "cdkd-parity-gate: -R pr create (control)"  cdkd-parity-gate.sh   "gh pr create --fill" "gh -R $R pr create --fill"
+run_pair "create-integ-gate: -R pr create (control)" create-integ-gate.sh  "gh pr create --fill" "gh -R $R pr create --fill"
+
+# --- the DIRECTORY a gate consults, for the gates whose rc cannot show it ----
+# `markgate` is asked from inside the resolved target dir, so logging its $PWD
+# is a direct read of gate_target_dir's answer through the real hook. This is
+# what covers cdkd-parity-gate / create-integ-gate, whose exit codes are equal
+# either way, and it is the assertion that would have caught the `-C` order bug
+# for them.
+run_dir() {
+  local name="$1" hook="$2" cmd="$3" want="$4" got
+  : > "$TMPDIR/pwd.log"
+  printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd" \
+    | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 PWD_LOG="$TMPDIR/pwd.log" \
+      "$HOOKS/$hook" >/dev/null 2>&1
+  got=$(head -1 "$TMPDIR/pwd.log")
+  [ -z "$got" ] && got="(never asked)"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(consulted $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (consulted %s, expected %s)\n' "$name" "$got" "$want"
+  fi
+}
+
+other="$TMPDIR/other"; mkdir -p "$other"; git -C "$other" init -q 2>/dev/null; : > "$other/.markgate.yml"
+verb="pr merge 1 --squash"
+run_dir "verify-pr-gate: no -C uses the payload cwd" verify-pr-gate.sh "gh $verb"                     "$repo"
+run_dir "verify-pr-gate: -C only"                    verify-pr-gate.sh "gh -C $other $verb"           "$other"
+run_dir "verify-pr-gate: -C then -R"                 verify-pr-gate.sh "gh -C $other -R $R $verb"     "$other"
+run_dir "verify-pr-gate: -R then -C"                 verify-pr-gate.sh "gh -R $R -C $other $verb"     "$other"
+run_dir "verify-pr-gate: --repo= then -C"            verify-pr-gate.sh "gh --repo=$R -C $other $verb" "$other"
+run_dir "verify-pr-gate: -R then -C="                verify-pr-gate.sh "gh -R $R -C=$other $verb"     "$other"
+run_dir "verify-pr-gate: -C after the verb is ignored" verify-pr-gate.sh "gh $verb -C $other"         "$repo"
+
+# cdkd-parity-gate / create-integ-gate DO expose the directory they resolved --
+# on their first `git -C "$target_dir" rev-parse --git-dir`, long before
+# markgate. An earlier revision of this file recorded "(never asked)" for them
+# and called the coverage impossible; that was wrong, and the comment saying so
+# is exactly what would have stopped the next person from adding this. Read the
+# `git -C` argument instead.
+#
+# run_git_dir <name> <hook> <cmd> <expected -C argument>
+run_git_dir() {
+  local name="$1" hook="$2" cmd="$3" want="$4" got
+  : > "$TMPDIR/git.log"
+  printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd" \
+    | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 GIT_LOG="$TMPDIR/git.log" \
+      "$HOOKS/$hook" >/dev/null 2>&1
+  got=$(grep -oE '^-C [^ ]+' "$TMPDIR/git.log" | head -1 | awk '{print $2}')
+  [ -z "$got" ] && got="(never asked)"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(git -C $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (git -C %s, expected %s)\n' "$name" "$got" "$want"
+  fi
+}
+
+for g in cdkd-parity-gate.sh create-integ-gate.sh; do
+  run_git_dir "$g: no -C uses the payload cwd" "$g" "gh pr create --fill"                     "$repo"
+  run_git_dir "$g: -C only"                    "$g" "gh -C $other pr create --fill"           "$other"
+  run_git_dir "$g: -C then -R"                 "$g" "gh -C $other -R $R pr create --fill"     "$other"
+  run_git_dir "$g: -R then -C"                 "$g" "gh -R $R -C $other pr create --fill"     "$other"
+  run_git_dir "$g: --repo= then -C"            "$g" "gh --repo=$R -C $other pr create --fill" "$other"
+  run_git_dir "$g: -R then -C="                "$g" "gh -R $R -C=$other pr create --fill"     "$other"
+done
+
+# --- WHICH MARKER a gate verifies -------------------------------------------
+# The same lens as run_sel, turned on markgate instead of gh. Swapping
+# verify-pr-gate's `verify verify-pr` for `verify check` is a LIVE BYPASS -- the
+# PR merges whenever `/check` alone is fresh -- and it left the suite green.
+#
+# run_marker <name> <hook> <cmd> <expected gate name>
+run_marker() {
+  local name="$1" hook="$2" cmd="$3" want="$4" got
+  : > "$TMPDIR/mg.log"
+  printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd" \
+    | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 MG_LOG="$TMPDIR/mg.log" \
+      "$HOOKS/$hook" >/dev/null 2>&1
+  got=$(grep -oE '(^|[[:space:]])verify [A-Za-z0-9-]+' "$TMPDIR/mg.log" | head -1 | awk '{print $NF}')
+  [ -z "$got" ] && got="(never asked)"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(asked: verify $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (asked: verify %s, expected verify %s)\n' "$name" "$got" "$want"
+  fi
+}
+
+run_marker "verify-pr-gate verifies verify-pr" verify-pr-gate.sh "gh pr merge 1 --squash"   verify-pr
+run_marker "verify-pr-gate on pr create"       verify-pr-gate.sh "gh pr create --fill"      verify-pr
+run_marker "integ-gate verifies integ"         integ-gate.sh     "gh pr merge 1 --squash"   integ
+run_marker "check-gate verifies check"         check-gate.sh     "git commit -m x"          check
+
+# --- the RESOLVED SELECTOR, not just the exit code --------------------------
+# Equal exit codes cannot tell "resolved the same PR" from "both failed
+# differently", and that gap is where three live bypasses lived: widening
+# GATE_GH_C made the flagged commands REACH these gates, but each then extracted
+# its PR number with the same `-C`-only shape the absorber had outgrown.
+# Measured before the fix, against `gh -R go-to-k/cdk-local pr merge 552`:
+#
+#   closes-paren-form-gate   gh never called at all (plain form: `pr view 552`)
+#   non-english-text-gate    `pr diff 999` -- the CURRENT BRANCH's PR
+#   docs-inline-json-flag    `pr diff 999` -- likewise
+#   pr-review-gate           `pr view 30` from `sleep 30 && gh -R … merge 552`
+#
+# So assert what the gate ASKED GITHUB ABOUT. The shim answers 999 to
+# `pr view --json number`, so a fall-through to current-branch resolution shows
+# up as a wrong number rather than as silence.
+#
+# run_sel <name> <hook> <cmd> <expected-pr-number>
+run_sel() {
+  local name="$1" hook="$2" cmd="$3" want="$4" log got
+  log="$TMPDIR/gh.log"; : > "$log"
+  printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd" \
+    | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 GH_LOG="$log" "$HOOKS/$hook" >/dev/null 2>&1
+  got=$(grep -oE 'pr (view|diff) [0-9]+' "$log" | head -1 | grep -oE '[0-9]+$')
+  [ -z "$got" ] && got="none"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(resolved PR $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (resolved PR %s, expected %s)\n' "$name" "$got" "$want"
+  fi
+}
+
+# Every spelling must resolve the SAME PR the plain form does. The plain arm of
+# each group is the control: if it stops resolving 552 the group is broken
+# rather than passing vacuously.
+for gate in closes-paren-form-gate.sh non-english-text-gate.sh \
+            docs-inline-json-flag-gate.sh pr-review-gate.sh; do
+  run_sel "$gate: plain"        "$gate" "gh pr merge 552 --squash"          552
+  run_sel "$gate: -R <repo>"    "$gate" "gh -R $R pr merge 552 --squash"    552
+  run_sel "$gate: --repo=<repo>" "$gate" "gh --repo=$R pr merge 552 --squash" 552
+  run_sel "$gate: -R<repo> glued" "$gate" "gh -R$R pr merge 552 --squash"   552
+  # A leading numeric token must not be read as the selector.
+  run_sel "$gate: numeric token before the verb" "$gate" \
+    "sleep 30 && gh -R $R pr merge 552 --squash" 552
+  # Flag VALUES must not be read as the selector either.
+  run_sel "$gate: -d before the number" "$gate" "gh -R $R pr merge -d 552" 552
+done
+
+# --- WHICH REPO the gate asks about -----------------------------------------
+# The fourth blind spot, and the one no existing helper could see: `run_sel`
+# greps the NUMBER out of the gh log and ignores `-R`, so
+# `gh -R go-to-k/OTHER pr merge 552` looked identical to the correct case in
+# both exit code and selector while every gate asked the LOCAL repo about ITS
+# PR 552. Right number, wrong repo. Assert the repo the gate names.
+#
+# run_repo <name> <hook> <cmd> <expected --repo value, or "(local)">
+run_repo() {
+  local name="$1" hook="$2" cmd="$3" want="$4" log got
+  log="$TMPDIR/gh.log"; : > "$log"
+  printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd" \
+    | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 GH_LOG="$log" "$HOOKS/$hook" >/dev/null 2>&1
+  got=$(grep -oE '\-\-repo [^ ]+' "$log" | head -1 | awk '{print $2}')
+  [ -z "$got" ] && got="(local)"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(asked $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (asked %s, expected %s)\n' "$name" "$got" "$want"
+  fi
+}
+
+for gate in closes-paren-form-gate.sh non-english-text-gate.sh \
+            docs-inline-json-flag-gate.sh pr-review-gate.sh; do
+  run_repo "$gate: no -R asks the local repo" "$gate" "gh pr merge 552 --squash"            "(local)"
+  run_repo "$gate: -R is passed through"      "$gate" "gh -R go-to-k/OTHER pr merge 552"    "go-to-k/OTHER"
+  run_repo "$gate: --repo= is passed through" "$gate" "gh --repo=go-to-k/OTHER pr merge 552" "go-to-k/OTHER"
+  run_repo "$gate: -R after the verb"         "$gate" "gh pr merge -R go-to-k/OTHER 552"    "go-to-k/OTHER"
+done
+
+# --- the `gate_pr_selector` fail-closed arms --------------------------------
+# Four gates refuse when the shared library predates the shared PR-selector
+# extractor, because an undefined function returns an EMPTY selector and the
+# gate would silently judge the wrong PR (or none) instead of declining. That
+# guard had zero cases: flipping all four to `exit 0` was green, so the commit
+# asserted it rather than measuring it.
+#
+# The library here defines `gate_matches` and the GATE_RE_* constants but NOT
+# `gate_pr_selector`, which is exactly the "older library" shape.
+selector_guard() {
+  local hook="$1" tmp out rc
+  tmp=$(mktemp -d)
+  cp "$HOOKS"/*.sh "$tmp/" 2>/dev/null
+  # strip the helper, keeping everything else loadable
+  python3 - "$tmp/_command-match.sh" <<'STRIP'
+import io,sys,re
+p=sys.argv[1]; s=io.open(p,encoding='utf-8').read()
+a=s.index('gate_pr_selector() {')
+b=s.index('\n}\n', a)+3
+io.open(p,'w',encoding='utf-8').write(s[:a]+s[b:])
+STRIP
+  out=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"gh pr merge 1 --squash"}}' "$repo" \
+    | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 "$tmp/$hook" 2>&1); rc=$?
+  rm -rf "$tmp"
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "gate_pr_selector"; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$hook: fails closed without gate_pr_selector" "(exit $rc)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s must exit 2 naming gate_pr_selector (got %s)\n' "$hook" "$rc"
+  fi
+}
+for g in closes-paren-form-gate.sh non-english-text-gate.sh \
+         docs-inline-json-flag-gate.sh pr-review-gate.sh; do
+  selector_guard "$g"
+done
 
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -63,6 +63,18 @@ run_case "verify-pr-gate: push && pr create"  2 verify-pr-gate.sh 'git push && g
 run_case "verify-pr-gate: pr merge"           2 verify-pr-gate.sh 'gh pr merge 42 --squash'
 run_case "verify-pr-gate: pr view passes"     0 verify-pr-gate.sh 'gh pr view 42'
 
+# issue-dup-check-gate guards the two verbs that MINT an issue, and only those.
+# Driven through the real hook so a gate that sources the helper and then asks
+# the WRONG question is still caught (the reason this file exists).
+run_case "issue-dup: issue create"            2 issue-dup-check-gate.sh 'gh issue create --title t --body-file /nope.md'
+run_case "issue-dup: gh -R issue create"      2 issue-dup-check-gate.sh 'gh -R go-to-k/cdkd issue create --title t --body-file /nope.md'
+run_case "issue-dup: chained issue create"    2 issue-dup-check-gate.sh 'git push && gh issue create --title t --body-file /nope.md'
+run_case "issue-dup: gh api issues POST"      2 issue-dup-check-gate.sh 'gh api repos/go-to-k/cdk-local/issues -f title=t -f body=x'
+run_case "issue-dup: issue comment passes"    0 issue-dup-check-gate.sh 'gh issue comment 7 --body-file /nope.md'
+run_case "issue-dup: issue edit passes"       0 issue-dup-check-gate.sh 'gh issue edit 7 --body-file /nope.md'
+run_case "issue-dup: pr create passes"        0 issue-dup-check-gate.sh 'gh pr create --fill'
+run_case "issue-dup: quoted mention passes"   0 issue-dup-check-gate.sh 'echo \"then gh issue create -t x\"'
+
 # branch-gate guards commit AND push, and only on a protected branch.
 git -C "$repo" checkout -q -b main
 run_case "branch-gate: commit on main"        2 branch-gate.sh 'git commit -m x'

--- a/.claude/hooks/issue-dup-check-gate.sh
+++ b/.claude/hooks/issue-dup-check-gate.sh
@@ -26,13 +26,14 @@
 #   go-to-k/cdk-local#531  2026-08-19T06:46:00Z  "... marker-sourcing, grep -cF,
 #                                                 and life-only-probe lessons"
 #
-#     NINE MINUTES apart. #531's three lessons are a strict SUBSET of #528's
-#     four -- same three sections, same evidence, different wording. Both were
-#     then closed by one PR, go-to-k/cdk-local#532. #528's body shows the near
-#     miss precisely: it checked the merged FILE and the open PRs
-#     (go-to-k/cdk-local#523, go-to-k/cdk-local#526) and reported them as
-#     carrying different lesson sets -- and never checked the open ISSUE list,
-#     where its own duplicate landed nine minutes later.
+#     EIGHT MINUTES apart (8 m 14 s). #531's three lessons are a strict SUBSET
+#     of #528's four -- same three sections, same evidence, different wording.
+#     Both were then closed by one PR, go-to-k/cdk-local#532. #528's body shows
+#     the near miss precisely: it records a FILE check against the merged
+#     SKILL.md and a scan of the open PRs (go-to-k/cdk-local#523,
+#     go-to-k/cdk-local#526), reporting them as carrying different lesson sets
+#     -- and no check of the open ISSUE list, where its own duplicate landed
+#     eight minutes later.
 #
 #   go-to-k/cdk-local#504  2026-08-19T03:14:05Z  "mirror the no-src verification
 #                                                 tier into `/work-issues` section 8"
@@ -45,9 +46,11 @@
 # So the failure mode this gate fences is not "the backlog grows without
 # bound"; it is "two hops of one lesson file the same issue, because the window
 # nobody searches is the OPEN ISSUE list". Section 10-c already carries a
-# three-window check -- merged file, then open PRs, then open issues -- and
-# both pairs above show the first two windows being searched while the third is
-# not. Registration is not execution; this is the execution half.
+# three-window check -- merged file, then open PRs, then open issues. What the
+# four bodies actually record is thinner than that check: #528 records the file
+# and open-PR windows, #531 records the file window only, and #504 / #511 record
+# no window at all. NONE of the four records an open-ISSUE search, which is the
+# one window that would have caught each pair. Registration is not execution; this is the execution half.
 #
 # WHAT IS AND IS NOT GATED
 #
@@ -104,25 +107,13 @@ fi
 if ! declare -F gate_matches >/dev/null 2>&1 \
   || ! declare -F gate_segments >/dev/null 2>&1 \
   || ! declare -F gate_target_dir >/dev/null 2>&1 \
-  || [ -z "${GATE_GH_CR:-}" ] \
+  || [ -z "${GATE_RE_GH_ISSUE_CREATE:-}" ] \
   || [ -z "${GATE_RE_GH_API_ISSUE_CREATE:-}" ]; then
   echo "Blocked: .claude/hooks/_command-match.sh loaded but is truncated or" >&2
-  echo "predates GATE_GH_CR / GATE_RE_GH_API_ISSUE_CREATE, so" >&2
-  echo "issue-dup-check-gate cannot evaluate the command. Restore the file; do" >&2
-  echo "not work around the gate." >&2
+  echo "predates GATE_RE_GH_API_ISSUE_CREATE, so issue-dup-check-gate cannot" >&2
+  echo "evaluate the command. Restore the file; do not work around the gate." >&2
   exit 2
 fi
-
-# The issue-create verb, built HERE on the shared GATE_GH_CR rather than reusing
-# the shared GATE_RE_GH_ISSUE_CREATE. The shared one absorbs `-C <path>` only
-# (GATE_GH_C), so it does not match `gh -R go-to-k/<target> issue create` -- and
-# that is the CROSS-REPO MIRROR flow's own spelling, which is this gate's whole
-# reason for existing (see the header). Widening GATE_GH_C itself would change
-# the trigger surface of pr-body-item-number-gate.sh, which consumes
-# GATE_RE_GH_ISSUE_CREATE, plus every other gh verb regex in this repo; that is
-# a separate change. So the shared constant is left exactly as it is and the
-# wider absorber is applied only here, where the new surface is wanted.
-GATE_RE_ISSUE_MINT="^gh${GATE_GH_CR}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
 
 input=$(cat 2>/dev/null || true)
 # An ABSENT `tool_name` is treated as Bash rather than as "not Bash": the
@@ -137,7 +128,10 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Command-position matching, so a body or comment that merely QUOTES
 # `gh issue create` does not arm the gate (.claude/rules/hooks.md).
-gate_matches "$cmd" "$GATE_RE_ISSUE_MINT" \
+# Over-approximate the TRIGGER, be strict on RESOLUTION: the `gh api` arm here
+# matches the issue COLLECTION path, reads included, and `seg_is_api_mint` below
+# is what separates a POST from a GET. Arming on a read costs one no-op pass.
+gate_matches "$cmd" "$GATE_RE_GH_ISSUE_CREATE" \
   || gate_matches "$cmd" "$GATE_RE_GH_API_ISSUE_CREATE" || exit 0
 
 # --- 0. resolve the target directory ONCE -----------------------------------
@@ -150,10 +144,10 @@ gate_matches "$cmd" "$GATE_RE_ISSUE_MINT" \
 # `gh issue list --search x && cd <repo> && gh issue create ...`, the
 # search-then-file chain this gate's own message prescribes, would never see the
 # `cd`, the opt-in would resolve against the payload cwd, and the gate would
-# exit 0. Deriving it from the two mint regexes also keeps GATE_GH_CR's quoted
+# exit 0. Deriving it from the two mint regexes also keeps GATE_GH_C's quoted
 # alternative, without which `gh -C "/a b" issue create` matches no verb (the
 # go-to-k/cdk-local#542 class .claude/rules/hooks.md records).
-VERB_ERE="^((${GATE_RE_ISSUE_MINT#^})|(${GATE_RE_GH_API_ISSUE_CREATE#^}))"
+VERB_ERE="^((${GATE_RE_GH_ISSUE_CREATE#^})|(${GATE_RE_GH_API_ISSUE_CREATE#^}))"
 target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$VERB_ERE" 2>/dev/null || true)
 [ -n "$target_dir" ] || target_dir="${hook_cwd:-$PWD}"
 
@@ -228,13 +222,73 @@ MARKER_RE_LOOSE='dup-check:'
 #
 # Every matching segment must carry the marker: a command opening two issues
 # must record the search for both.
-seg_has_marker() {
-  local seg="$1" f
-
-  # inline `--body '...'`: the marker is in the segment text itself.
-  if printf '%s' "$seg" | grep -qiE "$MARKER_RE_LOOSE"; then
-    return 0
+# Is this `gh api ... /issues` segment a MINT, or a READ? The path constant
+# matches the collection, and the collection is also the LIST endpoint --
+# `gh api repos/<o>/<r>/issues` and `gh api -X GET ... -f state=open` are reads,
+# and refusing them (which this gate did) is pure friction with no duplicate
+# anywhere in sight. gh sends GET unless told otherwise or unless fields are
+# supplied, so:
+#   explicit POST                      -> mint
+#   any other explicit method          -> read (GET / PATCH / DELETE ...)
+#   no method, but a `title=` field    -> mint (gh implies POST from fields)
+#   otherwise                          -> read
+seg_is_api_mint() {
+  local seg="$1" method
+  if [[ "$seg" =~ (-X|--method)[[:space:]=]+([A-Za-z]+) ]]; then
+    method=$(printf '%s' "${BASH_REMATCH[2]}" | tr '[:lower:]' '[:upper:]')
+    [ "$method" = "POST" ] && return 0
+    return 1
   fi
+  printf '%s' "$seg" | grep -qE '(^|[[:space:]])(-f|-F|--field|--raw-field)[[:space:]=]+.?title=' && return 0
+  # `--input <file>` (and `--input -`) also implies POST -- confirmed live:
+  # `GH_DEBUG=api gh api rate_limit --input f.json` logs `> POST`. Without this
+  # arm `gh api repos/<o>/<r>/issues --input body.json` mints an issue and the
+  # gate waves it through, which is the same fail-open the `title=` arm exists
+  # to close.
+  printf '%s' "$seg" | grep -qE '(^|[[:space:]])--input([[:space:]=]|$)' && return 0
+  return 1
+}
+
+# The inline body values a segment carries, one per line. The loose scan runs
+# over THESE rather than over the whole segment, because the segment also holds
+# the TITLE: `gh issue create --title 'Dup-check: yes' --body '<no marker>'`
+# satisfied the gate with a marker-free body (verified rc=0). A title is not a
+# record of having searched anything.
+seg_inline_bodies() {
+  printf '%s' "$1" | perl -0777 -ne '
+      my $Q = "\x27";
+      # --body <v> / --body=<v>, quoted either way or bare. `--body-file` does
+      # NOT match: `[=\s]` after `--body` cannot consume the `-` of `-file`.
+      while (/--body[=\s]+("([^"]*)"|${Q}([^${Q}]*)${Q}|([^\s]+))/g) {
+        print((defined($2) ? $2 : defined($3) ? $3 : $4), "\n");
+      }
+      while (/(?:^|\s)-b[=\s]+("([^"]*)"|${Q}([^${Q}]*)${Q}|([^\s]+))/g) {
+        print((defined($2) ? $2 : defined($3) ? $3 : $4), "\n");
+      }
+      # `-f body=<v>` / `--field body=<v>` and friends. The QUOTED forms come
+      # first and may contain spaces -- a single-quoted `body=x Dup-check: none` is one
+      # value, and a bare-token-only pattern truncated it at the first space and
+      # lost the marker. `body=@file` is excluded: that is a body FILE, and the
+      # file scan below owns it.
+      while (/(?:--field|--raw-field|-f|-F)[=\s]+${Q}body=([^${Q}]*)${Q}/g) { print "$1\n"; }
+      while (/(?:--field|--raw-field|-f|-F)[=\s]+"body=([^"]*)"/g)    { print "$1\n"; }
+      while (/(?:--field|--raw-field|-f|-F)[=\s]+body=([^"${Q}\s@][^"${Q}\s]*)/g) { print "$1\n"; }
+    ' 2>/dev/null
+}
+
+seg_has_marker() {
+  local seg="$1" f body
+
+  # inline `--body '...'`: the marker is in the body VALUE, not anywhere in the
+  # segment. `--body-file` values are excluded by construction (`--body-file`
+  # does not match `--body[=\s]`), so a PATH that happens to contain the word
+  # cannot satisfy this either.
+  while IFS= read -r body; do
+    [ -n "$body" ] || continue
+    if printf '%s' "$body" | grep -qiE "$MARKER_RE_LOOSE"; then
+      return 0
+    fi
+  done < <(seg_inline_bodies "$seg")
 
   while IFS= read -r f; do
     [ -n "$f" ] || continue
@@ -267,6 +321,16 @@ seg_has_marker() {
       # is the one place a cross-segment read is allowed, and its window is
       # narrow by construction -- it opens only when the named body file cannot
       # be read at all.
+      #
+      # KNOWN ASYMMETRY, accepted rather than fixed. The fallback is ANCHORED, so
+      # a heredoc (whose body has real line structure) PASSES while the
+      # equivalent `printf 'Dup-check: ...\n' > f.md && gh issue create
+      # --body-file f.md` BLOCKS -- in the printf form the marker sits mid-line,
+      # after `printf '`. Both directions were verified. This is the
+      # fail-CLOSED direction and it is trivially clearable (write the body with
+      # a heredoc, pass `--body` inline, or create the file in an earlier
+      # command), whereas un-anchoring the fallback would let any passing
+      # mention anywhere in the command satisfy the gate.
       if printf '%s' "$cmd" | grep -qiE "$MARKER_RE_LINE"; then
         return 0
       fi
@@ -297,7 +361,14 @@ found_body_file=0
 unresolvable_path=""
 offending=""
 while IFS= read -r seg; do
-  [[ "$seg" =~ $GATE_RE_ISSUE_MINT ]] || [[ "$seg" =~ $GATE_RE_GH_API_ISSUE_CREATE ]] || continue
+  if [[ "$seg" =~ $GATE_RE_GH_ISSUE_CREATE ]]; then
+    :
+  elif [[ "$seg" =~ $GATE_RE_GH_API_ISSUE_CREATE ]]; then
+    # The path alone does not say mint; the collection is the LIST endpoint too.
+    seg_is_api_mint "$seg" || continue
+  else
+    continue
+  fi
   if ! seg_has_marker "$seg"; then
     offending="$seg"
     break
@@ -335,10 +406,10 @@ fi
   fi
   echo ""
   echo "Run the search first -- search the CONCEPT, not this instance's spelling."
-  echo "go-to-k/cdk-local#531 duplicated go-to-k/cdk-local#528 nine minutes later"
+  echo "go-to-k/cdk-local#531 duplicated go-to-k/cdk-local#528 eight minutes later"
   echo "with a strict subset of its lessons, and go-to-k/cdk-local#511 duplicated"
-  echo "go-to-k/cdk-local#504 after 75 minutes, because each hop searched the"
-  echo "merged file and the open PRs but never the open ISSUE list:"
+  echo "go-to-k/cdk-local#504 after 75 minutes. Not one of those four bodies"
+  echo "records an open-ISSUE search:"
   echo ""
   echo "  gh issue list --state open --limit 200 --search '<root-cause concept>' \\"
   echo "    --json number,title"

--- a/.claude/hooks/issue-dup-check-gate.sh
+++ b/.claude/hooks/issue-dup-check-gate.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# issue-dup-check-gate.sh -- block `gh issue create` unless the body carries a
+# `Dup-check:` line recording that the OPEN issue list was searched for an issue
+# already covering this root cause.
+#
+# WHY, FOR THIS REPO (measured 2026-08-25, go-to-k/cdk-local):
+#
+#   open issues                                        5
+#   open issues carrying `Session-fit: next`           0
+#   issues ever filed                                145
+#   of those, skill-flow / cross-repo-mirror shaped   41
+#
+# cdk-local does NOT have the backlog-convergence problem its sibling cdkd
+# has. Five open issues, none deferred, nothing umbrella-shaped: the argument
+# from an unbounded open count is simply false here, and reproducing it would
+# be a fabricated justification for a gate that is wanted for a different and
+# verifiable reason.
+#
+# The reason here is the MIRROR PATH, which `/work-issues` section 10-c already
+# names as a duplicate GENERATOR in its own text. Two measured pairs, both
+# filed by this flow, both confirmed by reading the issue bodies:
+#
+#   go-to-k/cdk-local#528  2026-08-19T06:37:46Z  "... marker-sourcing, grep -cF,
+#                                                 life-only-probe and
+#                                                 branch-cleanup lessons ..."
+#   go-to-k/cdk-local#531  2026-08-19T06:46:00Z  "... marker-sourcing, grep -cF,
+#                                                 and life-only-probe lessons"
+#
+#     NINE MINUTES apart. #531's three lessons are a strict SUBSET of #528's
+#     four -- same three sections, same evidence, different wording. Both were
+#     then closed by one PR, go-to-k/cdk-local#532. #528's body shows the near
+#     miss precisely: it checked the merged FILE and the open PRs
+#     (go-to-k/cdk-local#523, go-to-k/cdk-local#526) and reported them as
+#     carrying different lesson sets -- and never checked the open ISSUE list,
+#     where its own duplicate landed nine minutes later.
+#
+#   go-to-k/cdk-local#504  2026-08-19T03:14:05Z  "mirror the no-src verification
+#                                                 tier into `/work-issues` section 8"
+#   go-to-k/cdk-local#511  2026-08-19T04:29:26Z  "mirror the no-src verification
+#                                                 tier into section 8, split by
+#                                                 command-change vs prose-only"
+#
+#     SEVENTY-FIVE MINUTES apart, same target section, same upstream lesson.
+#
+# So the failure mode this gate fences is not "the backlog grows without
+# bound"; it is "two hops of one lesson file the same issue, because the window
+# nobody searches is the OPEN ISSUE list". Section 10-c already carries a
+# three-window check -- merged file, then open PRs, then open issues -- and
+# both pairs above show the first two windows being searched while the third is
+# not. Registration is not execution; this is the execution half.
+#
+# WHAT IS AND IS NOT GATED
+#
+#   gated:      gh issue create                       -- MINTS an issue
+#               gh api repos/<o>/<r>/issues           -- the same mint, REST verb
+#   not gated:  gh issue edit / gh issue comment      -- folding a finding into an
+#                                                       issue that already exists is
+#                                                       the outcome this gate steers
+#                                                       toward; taxing it would
+#                                                       penalise the cheap path and
+#                                                       leave the costly one free
+#
+# THIS GATE DOES NOT SUPPRESS FINDINGS, AND MUST NEVER BE USED TO.
+# `/work-issues` section 10-0 is explicit that `filed <= closed` is not a target
+# and that an unfiled finding is strictly worse than a filed one, because it
+# removes the defect from the record while leaving it in the product. Nothing
+# here changes the threshold for writing a defect down. It changes only WHERE it
+# gets written: into the open issue that already names its root cause, as a
+# checklist row, rather than into a new issue number.
+#
+# If the search genuinely finds nothing, say so on the line and file: that is a
+# PASS, and it is the expected outcome for a real new root cause.
+#
+# ACCEPTED FORMS (any line in the body starting with `Dup-check:`)
+#
+#   Dup-check: searched open issues for `no-src verification tier` -- none covers
+#     this root cause
+#   Dup-check: searched open issues for `marker sourcing` --
+#     go-to-k/cdk-local#528 is the same AREA but a different root cause
+#
+# No bypass marker, matching non-english-text-gate.sh and
+# closes-paren-form-gate.sh: running the search and writing one line is the
+# entire ask, and a bypass would defeat the gate.
+
+set -u
+
+# Shared, segment-aware command matching (go-to-k/cdk-local#541).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r ... ] || exit 0` was the
+# first shape in this hooks dir and it silently disabled the gate whenever the
+# library was unreadable or truncated (go-to-k/cdkd#2130 review). The
+# `declare -F` checks catch a partial source, where `.` succeeds but the
+# function is missing, and the GATE_RE_* checks catch a library that predates
+# this gate's constants.
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so" >&2
+  echo "issue-dup-check-gate cannot evaluate the command. Restore the file; do" >&2
+  echo "not work around the gate." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
+. "$_gate_lib" 2>/dev/null
+if ! declare -F gate_matches >/dev/null 2>&1 \
+  || ! declare -F gate_segments >/dev/null 2>&1 \
+  || ! declare -F gate_target_dir >/dev/null 2>&1 \
+  || [ -z "${GATE_GH_CR:-}" ] \
+  || [ -z "${GATE_RE_GH_API_ISSUE_CREATE:-}" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but is truncated or" >&2
+  echo "predates GATE_GH_CR / GATE_RE_GH_API_ISSUE_CREATE, so" >&2
+  echo "issue-dup-check-gate cannot evaluate the command. Restore the file; do" >&2
+  echo "not work around the gate." >&2
+  exit 2
+fi
+
+# The issue-create verb, built HERE on the shared GATE_GH_CR rather than reusing
+# the shared GATE_RE_GH_ISSUE_CREATE. The shared one absorbs `-C <path>` only
+# (GATE_GH_C), so it does not match `gh -R go-to-k/<target> issue create` -- and
+# that is the CROSS-REPO MIRROR flow's own spelling, which is this gate's whole
+# reason for existing (see the header). Widening GATE_GH_C itself would change
+# the trigger surface of pr-body-item-number-gate.sh, which consumes
+# GATE_RE_GH_ISSUE_CREATE, plus every other gh verb regex in this repo; that is
+# a separate change. So the shared constant is left exactly as it is and the
+# wider absorber is applied only here, where the new surface is wanted.
+GATE_RE_ISSUE_MINT="^gh${GATE_GH_CR}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
+
+input=$(cat 2>/dev/null || true)
+# An ABSENT `tool_name` is treated as Bash rather than as "not Bash": the
+# payloads this hooks dir's own suites build carry only `cwd` + `tool_input`
+# (see gate-command-recognition.test.sh), and defaulting the other way would
+# make the gate exit 0 for every one of them -- inert while looking green.
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // "Bash"' 2>/dev/null || echo "Bash")
+[ "$tool_name" = "Bash" ] || exit 0
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$cmd" ] || exit 0
+
+# Command-position matching, so a body or comment that merely QUOTES
+# `gh issue create` does not arm the gate (.claude/rules/hooks.md).
+gate_matches "$cmd" "$GATE_RE_ISSUE_MINT" \
+  || gate_matches "$cmd" "$GATE_RE_GH_API_ISSUE_CREATE" || exit 0
+
+# --- 0. resolve the target directory ONCE -----------------------------------
+# Both the opt-in check below and the relative `--body-file` resolution later
+# need the same directory, and they must agree.
+#
+# The verb ERE is the ALTERNATION of the two MINT constants, never a bare `gh`.
+# `gate_target_dir` stops at the first segment matching the ERE it is given, so
+# a bare `gh` makes it stop at the first gh segment of any kind --
+# `gh issue list --search x && cd <repo> && gh issue create ...`, the
+# search-then-file chain this gate's own message prescribes, would never see the
+# `cd`, the opt-in would resolve against the payload cwd, and the gate would
+# exit 0. Deriving it from the two mint regexes also keeps GATE_GH_CR's quoted
+# alternative, without which `gh -C "/a b" issue create` matches no verb (the
+# go-to-k/cdk-local#542 class .claude/rules/hooks.md records).
+VERB_ERE="^((${GATE_RE_ISSUE_MINT#^})|(${GATE_RE_GH_API_ISSUE_CREATE#^}))"
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$VERB_ERE" 2>/dev/null || true)
+[ -n "$target_dir" ] || target_dir="${hook_cwd:-$PWD}"
+
+# NOTE ON `cd "$VAR"`, which differs from cdkd's `cmd_last_cd_target` in shape
+# but not in outcome: `gate_target_dir` SKIPS a cd whose path is unexpanded and
+# keeps the previous target (ultimately the payload cwd). For THIS gate that is
+# the safe direction and needs no special arm. Two cases, both fine:
+#   - the opt-in check then asks about the payload cwd instead of the real
+#     target. Worst case the gate declines to fire in a repo it would have
+#     gated, or fires in one it would not -- and the second is bounded by the
+#     opt-in itself, which still requires a `.markgate.yml`.
+#   - a RELATIVE `--body-file` then resolves against the wrong directory, the
+#     file is unreadable, and the unreadable-file arm below falls back to
+#     scanning the whole command with the ANCHORED marker. A body with no
+#     `Dup-check:` line still BLOCKS. That is fail-closed.
+# The `$VAR` case that genuinely needs its own refusal is an unexpanded
+# `--body-file "$BODY"`, which is handled explicitly further down: there the
+# gate would otherwise have to guess at the CONTENT it is supposed to check.
+
+# --- 0b. repo opt-in ---------------------------------------------------------
+# Same scoping every markgate-backed gate in this dir uses (branch-gate.sh,
+# check-gate.sh, main-tree-branch-gate.sh): fire only in a repo that opts into
+# this convention by carrying `.markgate.yml` at its root. A session working in
+# cdk-local regularly files issues in unrelated personal repos, where this
+# repo's root-cause-unit discipline is not the local convention and a refusal is
+# pure friction.
+#
+# The CWD's repo decides, not any `-R <owner/repo>` in the command, and that is
+# deliberate: `-R` names where the issue LANDS, while the cwd names which
+# project's policy the session is operating under. Section 10-c's cross-repo
+# mirror flow is exactly the case that makes the difference matter -- it runs
+# `gh -R go-to-k/<sibling> issue create` from a cdk-local worktree, and those
+# filings are precisely the ones this repo wants checked, since that flow is the
+# documented duplicate generator in the header above.
+#
+# Unresolvable cwd, or a cwd outside any repo, means NOT gated. This is a
+# discipline aid, not a safety boundary, so a rare miss costs less than a
+# refusal in a context that never opted in.
+optin_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$optin_top" ] || exit 0
+[ -f "$optin_top/.markgate.yml" ] || exit 0
+
+# TWO spellings of the same marker, and the difference is not cosmetic.
+#
+# In a body FILE the line structure is real, so the marker is anchored at the
+# start of a line (optionally as a list item) -- which keeps a passing mention
+# inside a sentence from satisfying the gate.
+#
+# In the raw COMMAND there is no such structure: an inline
+# `--body 'Bug. Dup-check: ...'` is one line, so the same anchor never matches
+# and the gate would refuse a body that carries exactly what it asks for. The
+# command scan is therefore unanchored. The threat model is FORGETTING to run
+# the search, not defeating the gate: someone who types the line without
+# searching has already decided to, and no regex reaches that.
+# `-i` on the greps rather than a `[Dd]` class, so `Dup-Check:` is accepted:
+# refusing a capitalisation variant teaches people the gate is capricious, and
+# nothing is gained by the strictness.
+MARKER_RE_LINE='^[[:space:]]*([-*+>][[:space:]]+)?dup-check:'
+MARKER_RE_LOOSE='dup-check:'
+
+# BOTH scans are scoped to the SEGMENT that is the mint, never to the whole
+# command, and that scoping is load-bearing rather than tidy.
+#
+# Unscoped, the gate has a demonstrated FAIL-OPEN in the shape this repo writes
+# most: `git commit -F <msg> && gh issue create --body-file <no-marker>` passes,
+# because `-F` is `git commit`'s flag as well as gh's short `--body-file`, so the
+# extraction reads the COMMIT MESSAGE and finds the marker there -- and
+# commit-msg-heredoc-gate.sh MANDATES `git commit -F <file>` in this repo, so
+# that shape is the norm rather than an exotic one. Commit messages quote the
+# lines they describe. The loose inline scan has the same hole for the same
+# reason, in either command order.
+#
+# Every matching segment must carry the marker: a command opening two issues
+# must record the search for both.
+seg_has_marker() {
+  local seg="$1" f
+
+  # inline `--body '...'`: the marker is in the segment text itself.
+  if printf '%s' "$seg" | grep -qiE "$MARKER_RE_LOOSE"; then
+    return 0
+  fi
+
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    # An unexpanded `$VAR` or a substitution cannot be resolved from command
+    # TEXT. Refuse, but through the dedicated message arm below: a bare "check
+    # the path" is unclearable when the file does carry the line.
+    case "$f" in
+      *'$'*|*'`'*) unresolvable_path="$f"; return 1 ;;
+    esac
+    # A literal `~` in the command string is text, not something to expand -- a
+    # real tilde would already have been expanded by the shell before gh ran.
+    # shellcheck disable=SC2088
+    case "$f" in
+      /*) ;;
+      "~/"*) f="${HOME:-/nonexistent}/${f#\~/}" ;;
+      *) f="$target_dir/$f" ;;
+    esac
+    if [ ! -f "$f" ]; then
+      # The file may not exist YET. `heredoc -> file -> --body-file` in ONE
+      # command is a legitimate and common publishing shape here (this repo's
+      # gh-pr-edit-deprecation-gate.sh prescribes `-F body=@<file>`, and
+      # commit-msg-heredoc-gate.sh pushes bodies into files generally), and at
+      # PreToolUse time the heredoc has not run. After the segment scoping,
+      # treating that as a miss would be a false BLOCK on a shape the flow
+      # itself prescribes, which is the worse direction.
+      #
+      # So fall back to the WHOLE command, with the ANCHORED marker: a heredoc
+      # body carries real line structure, so the same line-start rule applies
+      # and a passing mention inside a sentence still does not satisfy it. This
+      # is the one place a cross-segment read is allowed, and its window is
+      # narrow by construction -- it opens only when the named body file cannot
+      # be read at all.
+      if printf '%s' "$cmd" | grep -qiE "$MARKER_RE_LINE"; then
+        return 0
+      fi
+      continue
+    fi
+    found_body_file=1
+    if grep -qiE "$MARKER_RE_LINE" "$f"; then
+      return 0
+    fi
+  # This extraction is a near-copy of pr-body-item-number-gate.sh's
+  # `extract_files`, deliberately not shared, and it has already DIVERGED in
+  # three ways: it runs on ONE SEGMENT rather than the whole command, it adds
+  # the bare `-F <file>` arm (gh's short `--body-file`), and its caller treats
+  # an unreadable path as a BLOCK where that hook simply skips the file. The
+  # third is a deliberate opposite -- that gate objects to content it FINDS, so
+  # a missed read costs one warning, while a missed read here costs the gate.
+  # Stated rather than left to be discovered: if you fix a path-extraction bug
+  # in either, check the other.
+  done < <(printf '%s' "$seg" | perl -0777 -ne '
+      while (/--body-file[=\s]+(["\x27]?)([^"\x27\s]+)\1/g) { print "$2\n"; }
+      while (/(?:--field|--raw-field|-F)[=\s]+(["\x27]?)body=\@([^"\x27\s]+)\1/g) { print "$2\n"; }
+      while (/(?:^|\s)-F[=\s]+(["\x27]?)([^"\x27\s=]+)\1(?=\s|$)/g) { print "$2\n"; }
+    ' 2>/dev/null)
+  return 1
+}
+
+found_body_file=0
+unresolvable_path=""
+offending=""
+while IFS= read -r seg; do
+  [[ "$seg" =~ $GATE_RE_ISSUE_MINT ]] || [[ "$seg" =~ $GATE_RE_GH_API_ISSUE_CREATE ]] || continue
+  if ! seg_has_marker "$seg"; then
+    offending="$seg"
+    break
+  fi
+done < <(gate_segments "$cmd")
+
+[ -n "$offending" ] || exit 0
+
+if [ -n "$unresolvable_path" ]; then
+  {
+    echo "Blocked by issue-dup-check-gate: the --body-file path \`$unresolvable_path\`"
+    echo "carries an unexpanded variable or substitution, and this gate reads the"
+    echo "command TEXT rather than the shell's expansion of it, so it cannot open"
+    echo "the file to look for the \`Dup-check:\` line."
+    echo ""
+    echo "This refuses rather than guessing, per the fail-closed convention in"
+    echo ".claude/rules/hooks.md. Two ways to clear it, both of which leave the"
+    echo "gate doing its job:"
+    echo ""
+    echo "  - pass the path literally:  gh issue create --body-file /abs/path.md"
+    echo "  - or carry the line inline: gh issue create --body \"...Dup-check: ...\""
+  } >&2
+  exit 2
+fi
+
+{
+  echo "Blocked by issue-dup-check-gate: this \`gh issue create\` body carries no"
+  echo "\`Dup-check:\` line, so nothing records that the OPEN issue list was"
+  echo "searched for an issue already covering this root cause."
+  if [ "$found_body_file" = "0" ]; then
+    echo ""
+    echo "(No readable --body-file was found in the command either. If you passed"
+    echo " one, check the path: an unreadable body file is treated as a miss, not"
+    echo " as a pass.)"
+  fi
+  echo ""
+  echo "Run the search first -- search the CONCEPT, not this instance's spelling."
+  echo "go-to-k/cdk-local#531 duplicated go-to-k/cdk-local#528 nine minutes later"
+  echo "with a strict subset of its lessons, and go-to-k/cdk-local#511 duplicated"
+  echo "go-to-k/cdk-local#504 after 75 minutes, because each hop searched the"
+  echo "merged file and the open PRs but never the open ISSUE list:"
+  echo ""
+  echo "  gh issue list --state open --limit 200 --search '<root-cause concept>' \\"
+  echo "    --json number,title"
+  echo "  gh issue list --state open --limit 200 --json number,title,body \\"
+  echo "    --jq '.[] | select((.body // \"\") | test(\"<shared symbol / call / assumption>\";\"i\"))"
+  echo "          | \"\\(.number)\\t\\(.title)\"'"
+  echo ""
+  echo "  \`(.body // \"\")\`, not \`.body\`: an issue filed with no body makes"
+  echo "  \`test\` abort the whole jq program, so one body-less issue silently"
+  echo "  costs you the entire window."
+  echo ""
+  echo "On a HIT, do not create -- fold the finding into that issue as a"
+  echo "checklist row, which keeps the defect on the record while the open count"
+  echo "stays one-per-root-cause:"
+  echo ""
+  echo "  U=\$(mktemp)   # NOT a fixed /tmp path: parallel lanes share the scratchpad"
+  echo "  gh issue view <hit> --json body -q .body > \"\$U\" \\"
+  echo "    && [ -s \"\$U\" ] \\"
+  echo "    && printf -- '- [ ] <site>: <one line, plus where the evidence is>\\n' >> \"\$U\" \\"
+  echo "    && gh issue edit <hit> --body-file \"\$U\""
+  echo ""
+  echo "  The chaining and the -s test are load-bearing, not style: the redirect"
+  echo "  truncates \$U before gh runs, so an unchained recipe whose \`view\` fails"
+  echo "  (wrong number, transient error) replaces the umbrella's WHOLE body with"
+  echo "  the single new row -- destroying every previously folded finding through"
+  echo "  the very procedure meant to preserve them."
+  echo ""
+  echo "On a MISS, that is a real new root cause -- file it, and record the"
+  echo "search in the body:"
+  echo ""
+  echo "  Dup-check: searched open issues for <terms> -- none covers this root cause"
+  echo ""
+  echo "This gate never asks you to drop a finding. /work-issues section 10-0 is"
+  echo "explicit that \`filed <= closed\` is not a target and that an unfiled"
+  echo "finding is worse than a filed one. It changes only WHERE the finding is"
+  echo "written, so an open issue counts one unresolved root cause rather than"
+  echo "one unfixed site."
+  echo ""
+  echo "Rule: .claude/skills/work-issues/SKILL.md section 5 (\"N sites of one root"
+  echo "cause is ONE issue and ONE PR, never N issues\")."
+} >&2
+exit 2

--- a/.claude/hooks/issue-dup-check-gate.test.sh
+++ b/.claude/hooks/issue-dup-check-gate.test.sh
@@ -17,9 +17,11 @@
 #   - PASS  for a command that merely QUOTES the trigger
 #   - PASS  in a repo that never opted in (no `.markgate.yml`)
 #
-# Measured rather than asserted (2026-08-25, bash 5.3): an always-`exit 0` stub
-# fails 34 of these and an always-`exit 2` stub fails 36, so neither direction
-# can pass vacuously.
+# Measured rather than asserted (2026-08-25, bash 5.3, re-measured against the
+# final case list): an always-`exit 0` stub fails 41 of these and an
+# always-`exit 2` stub fails 45, so neither direction can pass vacuously. Keep
+# these numbers current when cases are added -- a stale count in a comment that
+# exists to prove non-vacuity is itself the thing it warns about.
 
 set -u
 
@@ -56,6 +58,24 @@ run_msg() {
   else
     echo "FAIL: $name (exit $rc, expected $expect carrying '$needle')"
     printf '%s\n' "$out" | sed 's/^/      /' | head -4
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# run_nomsg <name> <command> <cwd> <expected-exit> <substring the stderr must NOT carry>
+# The complement of run_msg. A conditional block in an error message needs BOTH
+# directions pinned; only asserting its presence lets the condition be deleted.
+run_nomsg() {
+  local name="$1" command="$2" cwd="$3" expect="$4" needle="$5"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ] && ! printf '%s' "$out" | grep -qF "$needle"; then
+    echo "PASS: $name (exit $rc, message correctly omits it)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $rc, expected $expect WITHOUT '$needle')"
     FAIL=$((FAIL + 1))
   fi
 }
@@ -112,6 +132,7 @@ PLUSLIST="$TMPROOT/plus.md"
 COMMITMSG="$TMPBASE/commit-msg.txt"
 printf 'Some defect.\n\nDup-check: searched open issues for `route discovery` -- none covers this root cause\n' > "$WITH"
 printf 'Some defect.\n\nSession-fit: next (not this session) -- needs a new fixture\n' > "$WITHOUT"
+printf 'Some defect, no marker at all.\n' > "$TMPROOT/dup-check-notes.md"
 printf 'Some defect.\n\n- Dup-check: searched open issues for `authorizer cache` -- none covers this\n' > "$LIST"
 printf 'Some defect.\n\ndup-check: searched open issues -- none covers this root cause\n' > "$LOWER"
 # The marker only mid-sentence. This is what fences MARKER_RE_LINE's ANCHOR:
@@ -163,19 +184,26 @@ run "chained after && blocks"            "git push && gh issue create --body-fil
 run "chained after ; blocks"             "echo done; gh issue create --body-file $WITHOUT"  "$TMPROOT" 2
 # `gh -R <owner/repo> issue create` is the CROSS-REPO MIRROR flow's own
 # spelling, and that flow is this gate's whole reason for existing -- so this
-# pair is the headline case, not an edge one. The shared
-# `GATE_RE_GH_ISSUE_CREATE` absorbs `-C <path>` only and does NOT match these;
-# the gate builds its verb on `GATE_GH_CR` instead, leaving the shared
-# constant's surface (pr-body-item-number-gate.sh consumes it) untouched.
+# pair is the headline case, not an edge one. `GATE_GH_C` absorbed `-C <path>`
+# only until 2026-08-25, so `GATE_RE_GH_ISSUE_CREATE` did not match these at all
+# -- the same gap that let `gh -R o/r pr merge` walk past verify-pr-gate and
+# integ-gate. Widening the shared absorber fixed all of them at once.
 run "gh -R <repo> issue create blocks"   "gh -R go-to-k/cdk-local issue create --body-file $WITHOUT" "$TMPROOT" 2
 run "gh -R <repo> with marker passes"    "gh -R go-to-k/cdk-local issue create --body-file $WITH"    "$TMPROOT" 0
 run "gh --repo <repo> blocks"            "gh --repo go-to-k/cdkd issue create --body-file $WITHOUT"  "$TMPROOT" 2
 run "gh --repo <repo> with marker passes" "gh --repo go-to-k/cdkd issue create --body-file $WITH"    "$TMPROOT" 0
-# The `-C` and plain forms must keep the verdicts they had before GATE_GH_CR.
+# The `-C` and plain forms must keep the verdicts they had before the widening.
 run "gh -C <dir> issue create blocks"    "gh -C $TMPROOT issue create --body-file $WITHOUT" "$TMPROOT" 2
 run "gh -C <dir> with marker passes"     "gh -C $TMPROOT issue create --body-file $WITH"    "$TMPROOT" 0
 run "gh -C and -R together blocks"       "gh -C $TMPROOT -R go-to-k/cdkd issue create --body-file $WITHOUT" "$TMPROOT" 2
 run "gh -R on a comment still passes"    "gh -R go-to-k/cdkd issue comment 7 --body-file $WITHOUT"  "$TMPROOT" 0
+# All three separators `gh` accepts. The GLUED form has no separator at all and
+# is the one a hand-written flag alternation misses.
+run "gh --repo=<repo> blocks"            "gh --repo=go-to-k/cdkd issue create --body-file $WITHOUT" "$TMPROOT" 2
+run "gh -R=<repo> blocks"                "gh -R=go-to-k/cdkd issue create --body-file $WITHOUT"     "$TMPROOT" 2
+run "gh -R<repo> glued blocks"           "gh -Rgo-to-k/cdkd issue create --body-file $WITHOUT"      "$TMPROOT" 2
+run "gh -R<repo> glued with marker"      "gh -Rgo-to-k/cdkd issue create --body-file $WITH"         "$TMPROOT" 0
+run "gh api mint with --repo= blocks"    "gh --repo=go-to-k/cdkd api repos/go-to-k/cdkd/issues -f title=t" "$TMPROOT" 2
 run "subshell blocks"                    "(gh issue create --body-file $WITHOUT)"           "$TMPROOT" 2
 run "command substitution blocks"        "URL=\$(gh issue create --body-file $WITHOUT)"     "$TMPROOT" 2
 
@@ -216,6 +244,39 @@ run "gh api issues POST, no marker" "gh api repos/go-to-k/cdk-local/issues -f ti
 run "gh api issues POST, marker"    "gh api repos/go-to-k/cdk-local/issues -f title=t -f 'body=x Dup-check: none'" "$TMPROOT" 0
 run "gh api comments is not a mint" "gh api repos/go-to-k/cdk-local/issues/5/comments -f body=x"                   "$TMPROOT" 0
 run "gh api issue edit is not a mint" "gh api -X PATCH repos/go-to-k/cdk-local/issues/5 -f body=x"                 "$TMPROOT" 0
+# The issue COLLECTION path is also the LIST endpoint. `gh api .../issues` and
+# `-X GET` are READS and must pass -- refusing them (which this gate did) is
+# pure friction with no duplicate in sight. gh sends GET unless told otherwise
+# or unless fields are supplied, so a `title=` field means mint.
+run "gh api issues GET is a read"    "gh api repos/go-to-k/cdk-local/issues"                         "$TMPROOT" 0
+run "gh api issues -X GET is a read" "gh api -X GET repos/go-to-k/cdk-local/issues -f state=open"    "$TMPROOT" 0
+run "gh api issues -X DELETE"        "gh api -X DELETE repos/go-to-k/cdk-local/issues"               "$TMPROOT" 0
+run "gh api issues -X POST blocks"   "gh api -X POST repos/go-to-k/cdk-local/issues -f title=t -f body=x" "$TMPROOT" 2
+run "gh api quoted body= with marker" "gh api repos/go-to-k/cdk-local/issues -f title=t -f 'body=x Dup-check: none'" "$TMPROOT" 0
+# `--input <file>` / `--input -` implies POST too (confirmed live: `GH_DEBUG=api
+# gh api rate_limit --input f.json` logs `> POST`), so it mints an issue and must
+# be gated like `-f title=`.
+run "gh api --input mints"           "gh api repos/go-to-k/cdk-local/issues --input body.json"  "$TMPROOT" 2
+run "gh api --input - mints"         "gh api repos/go-to-k/cdk-local/issues --input -"          "$TMPROOT" 2
+run "gh api --input on a comment"    "gh api repos/go-to-k/cdk-local/issues/5/comments --input body.json" "$TMPROOT" 0
+
+# The loose inline scan reads the BODY VALUE, not the whole segment. A TITLE is
+# not a record of having searched anything, and `--title 'Dup-check: yes'`
+# satisfied the gate with a marker-free body until this was scoped.
+run "marker in --title does not count" "gh issue create --title 'Dup-check: yes' --body 'no marker here'" "$TMPROOT" 2
+run "marker in --body still counts"    "gh issue create --title 'Dup-check: yes' --body 'x Dup-check: none'" "$TMPROOT" 0
+run "-b short body flag"               "gh issue create -b 'Dup-check: searched, none'"                "$TMPROOT" 0
+run "--body=<v> equals form"           "gh issue create --body=\"Dup-check: none\""                    "$TMPROOT" 0
+# A --body-file PATH containing the word must not satisfy the loose scan: the
+# body flag extractor cannot see `--body-file` (the `-` of `-file` is not `=` or
+# space), so this falls through to the FILE scan and blocks on a marker-free file.
+run "dup-check in the body-file PATH" "gh issue create --body-file $TMPROOT/dup-check-notes.md"       "$TMPROOT" 2
+# ...and the COLON in MARKER_RE_LOOSE needs its own discriminator. The case
+# above is a control: it blocks for the unrelated reason that the FILE carries
+# no marker, so dropping the colon from the pattern is caught by nothing. This
+# one puts `dup-check` WITHOUT a colon in the BODY, where the loose scan reads,
+# so it is the case that fails if the colon goes.
+run "dup-check without a colon in --body" "gh issue create --body 'see the dup-check notes file'" "$TMPROOT" 2
 
 # --- more body-file spellings ----------------------------------------------
 run "--body-file=<p> form"          "gh issue create --body-file=$WITH"        "$TMPROOT" 0
@@ -227,6 +288,10 @@ run "--raw-field body=@ with"       "gh issue create --raw-field body=@$WITH"  "
 # --- both refusal arms carry their own message ------------------------------
 run_msg "missing-marker message"    "gh issue create --body-file $WITHOUT" "$TMPROOT" 2 "carries no"
 run_msg "unreadable-path message"   "gh issue create --body-file $TMPROOT/nope.md" "$TMPROOT" 2 "No readable --body-file"
+# ...and the hint must be SUPPRESSED when a body file WAS read, or `found_body_file`
+# is inert: both needles above appear in the readable-file branch too, so pinning
+# `found_body_file=0` left the suite fully green. This is the missing direction.
+run_nomsg "readable body file omits the path hint" "gh issue create --body-file $WITHOUT" "$TMPROOT" 2 "No readable --body-file"
 # An unexpanded variable is refused through its OWN arm: a bare "check the path"
 # is unclearable when the file does carry the line.
 run_msg "unexpanded \$VAR message"  "gh issue create --body-file \"\$BODY\"" "$TMPROOT" 2 "unexpanded variable"
@@ -241,7 +306,7 @@ lib_fail_closed() {
   out=$(jq -n '{tool_name:"Bash", tool_input:{command:"gh issue create --body-file /nope.md"}, cwd:"/"}' \
         | "$tmp/gate.sh" 2>&1) && rc=0 || rc=$?
   rm -rf "$tmp"
-  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "_command-match.sh"; then
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "is missing or unreadable"; then
     echo "PASS: unloadable library fails CLOSED (exit $rc)"; PASS=$((PASS + 1))
   else
     echo "FAIL: unloadable library should exit 2 naming the library (got $rc)"; FAIL=$((FAIL + 1))
@@ -260,10 +325,13 @@ lib_truncated_fails_closed() {
   out=$(jq -n '{tool_name:"Bash", tool_input:{command:"gh issue create --body-file /nope.md"}, cwd:"/"}' \
         | "$tmp/gate.sh" 2>&1) && rc=0 || rc=$?
   rm -rf "$tmp"
-  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "_command-match.sh"; then
+  # `_command-match.sh` alone appears in BOTH load-failure messages, so it
+  # cannot tell the truncated arm from the missing arm. Pin the wording unique
+  # to arm 2.
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "loaded but is truncated"; then
     echo "PASS: library missing the constant fails CLOSED (exit $rc)"; PASS=$((PASS + 1))
   else
-    echo "FAIL: truncated library should exit 2 naming the library (got $rc)"; FAIL=$((FAIL + 1))
+    echo "FAIL: truncated library should exit 2 naming the TRUNCATED arm (got $rc)"; FAIL=$((FAIL + 1))
   fi
 }
 lib_truncated_fails_closed

--- a/.claude/hooks/issue-dup-check-gate.test.sh
+++ b/.claude/hooks/issue-dup-check-gate.test.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Smoke tests for issue-dup-check-gate.sh
+#
+# Run from anywhere:  bash .claude/hooks/issue-dup-check-gate.test.sh
+# `vp run test:hooks` globs `.claude/hooks/*.test.sh`, so this file is picked up
+# with no registration step.
+#
+# The gate blocks `gh issue create` (and the `gh api repos/<o>/<r>/issues` REST
+# mint) unless the body carries a `Dup-check:` line. Asserts, in both
+# directions:
+#   - PASS  when a --body-file / -F body=@ / inline --body carries the marker
+#   - BLOCK when it does not, including when the named body file is unreadable
+#   - PASS  for the verbs deliberately NOT gated (edit / comment), which is the
+#           whole point: folding into an existing issue must stay untaxed
+#   - BLOCK for chained and `-R` / `cd` spellings, which is where the
+#           line-start-anchored ancestors of this gate family leaked
+#   - PASS  for a command that merely QUOTES the trigger
+#   - PASS  in a repo that never opted in (no `.markgate.yml`)
+#
+# Measured rather than asserted (2026-08-25, bash 5.3): an always-`exit 0` stub
+# fails 34 of these and an always-`exit 2` stub fails 36, so neither direction
+# can pass vacuously.
+
+set -u
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/issue-dup-check-gate.sh"
+PASS=0
+FAIL=0
+# Two fixture trees, because the gate is repo-opt-in:
+#   $TMPROOT  -- a git repo carrying `.markgate.yml`, so the gate fires
+#   $NOOPTIN  -- a git repo without it, so the gate must stay silent
+# Real repos rather than mocks: the opt-in decision is exactly what
+# `git rev-parse --show-toplevel` reports, so mocking it would test nothing.
+TMPBASE=$(mktemp -d)
+trap 'rm -rf "$TMPBASE"' EXIT
+TMPROOT="$TMPBASE/optin"
+NOOPTIN="$TMPBASE/no-optin"
+for d in "$TMPROOT" "$NOOPTIN"; do
+  mkdir -p "$d"
+  git -C "$d" init -q 2>/dev/null
+done
+printf 'gates: {}\n' > "$TMPROOT/.markgate.yml"
+
+# run_msg <name> <command> <cwd> <expected-exit> <substring the stderr must carry>
+# Both refusal arms exit 2, so the exit code alone cannot tell them apart --
+# deleting one arm's message would otherwise leave the suite green.
+run_msg() {
+  local name="$1" command="$2" cwd="$3" expect="$4" needle="$5"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ] && printf '%s' "$out" | grep -qF "$needle"; then
+    echo "PASS: $name (exit $rc, message matched)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $rc, expected $expect carrying '$needle')"
+    printf '%s\n' "$out" | sed 's/^/      /' | head -4
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# run <name> <command> <cwd> <expected-exit>
+run() {
+  local name="$1" command="$2" cwd="$3" expect="$4"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ]; then
+    echo "PASS: $name (exit $rc)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $rc, expected $expect)"
+    echo "$out" | sed 's/^/      /' | head -5
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# The payload shape this hooks dir's OTHER suites build carries no `tool_name`
+# (gate-command-recognition.test.sh). Defaulting an absent one to "not Bash"
+# would make the gate inert for every such payload while looking green, so the
+# default is pinned here in both directions.
+run_no_tool_name() {
+  local name="$1" command="$2" cwd="$3" expect="$4"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ]; then
+    echo "PASS: $name (exit $rc)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $rc, expected $expect)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# run_nonbash <name> <expected-exit>
+run_nonbash() {
+  local payload out rc
+  payload=$(jq -n '{tool_name:"Edit", tool_input:{file_path:"/tmp/x"}}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$2" ]; then echo "PASS: $1 (exit $rc)"; PASS=$((PASS + 1))
+  else echo "FAIL: $1 (exit $rc, expected $2)"; FAIL=$((FAIL + 1)); fi
+}
+
+WITH="$TMPROOT/with.md"
+WITHOUT="$TMPROOT/without.md"
+LIST="$TMPROOT/list.md"
+LOWER="$TMPROOT/lower.md"
+MIDLINE="$TMPROOT/midline.md"
+PLUSLIST="$TMPROOT/plus.md"
+COMMITMSG="$TMPBASE/commit-msg.txt"
+printf 'Some defect.\n\nDup-check: searched open issues for `route discovery` -- none covers this root cause\n' > "$WITH"
+printf 'Some defect.\n\nSession-fit: next (not this session) -- needs a new fixture\n' > "$WITHOUT"
+printf 'Some defect.\n\n- Dup-check: searched open issues for `authorizer cache` -- none covers this\n' > "$LIST"
+printf 'Some defect.\n\ndup-check: searched open issues -- none covers this root cause\n' > "$LOWER"
+# The marker only mid-sentence. This is what fences MARKER_RE_LINE's ANCHOR:
+# without a case whose ONLY occurrence is mid-line, the anchor could be swapped
+# for the loose form and the suite would stay green -- the split the gate's
+# header calls load-bearing would have no discriminating case at all.
+printf 'Some defect.\n\nWe ran a dup-check: nothing turned up, honest.\n' > "$MIDLINE"
+printf 'Some defect.\n\n+ Dup-Check: searched open issues -- none covers this\n' > "$PLUSLIST"
+# A commit message that QUOTES the marker at LINE START, which is the realistic
+# shape -- a commit message quoting the line it requires, and this repo's
+# commit-msg-heredoc-gate mandates `git commit -F <file>` so the shape is the
+# norm. Mid-sentence would make this fixture pass for the WRONG reason:
+# MARKER_RE_LINE's anchor rejects it regardless of scoping, so the case would
+# stay green with the segment scoping removed and fence nothing.
+printf 'chore: add the gate\n\nThe body must carry a line of this form:\n\nDup-check: searched open issues -- none covers this root cause\n' > "$COMMITMSG"
+
+# --- the two directions, file-borne -----------------------------------------
+run "body-file carries Dup-check"        "gh issue create --title t --body-file $WITH"    "$TMPROOT" 0
+run "body-file lacks Dup-check"          "gh issue create --title t --body-file $WITHOUT" "$TMPROOT" 2
+run "marker as a list item"              "gh issue create --title t --body-file $LIST"    "$TMPROOT" 0
+run "marker lowercased"                  "gh issue create --title t --body-file $LOWER"   "$TMPROOT" 0
+run "-F body=@ form carries marker"      "gh issue create -F body=@$WITH"                 "$TMPROOT" 0
+run "-F body=@ form lacks marker"        "gh issue create -F body=@$WITHOUT"              "$TMPROOT" 2
+run "bare -F <file> carries marker"      "gh issue create -F $WITH"                       "$TMPROOT" 0
+
+# An unreadable body file must BLOCK, not pass. "Cannot read" being treated as
+# "nothing to object to" is the fail-open that made twelve sibling gates inert
+# (go-to-k/cdkd#2027).
+run "body-file path does not exist"      "gh issue create --body-file $TMPROOT/nope.md"   "$TMPROOT" 2
+
+# Relative --body-file resolves against the payload cwd, and against a `cd` in
+# command position before the verb.
+run "relative body-file via payload cwd" "gh issue create --body-file with.md"                     "$TMPROOT" 0
+run "relative body-file via leading cd"  "cd $TMPROOT && gh issue create --body-file with.md"      "/"        0
+run "relative body-file, cd, no marker"  "cd $TMPROOT && gh issue create --body-file without.md"   "/"        2
+
+# --- the two directions, inline ---------------------------------------------
+run "inline --body carries marker"       "gh issue create --title t --body 'Bug. Dup-check: searched open issues -- none covers this'" "$TMPROOT" 0
+run "inline --body lacks marker"         "gh issue create --title t --body 'Bug. Nothing else.'"                                       "$TMPROOT" 2
+
+# --- verbs deliberately NOT gated -------------------------------------------
+run "gh issue edit passes"               "gh issue edit 12 --body-file $WITHOUT"          "$TMPROOT" 0
+run "gh issue comment passes"            "gh issue comment 12 --body-file $WITHOUT"       "$TMPROOT" 0
+run "gh pr create passes"                "gh pr create --body-file $WITHOUT"              "$TMPROOT" 0
+run "gh issue list passes"               "gh issue list --state open --search foo"        "$TMPROOT" 0
+
+# --- spellings the line-start-anchored ancestors leaked ---------------------
+run "chained after && blocks"            "git push && gh issue create --body-file $WITHOUT" "$TMPROOT" 2
+run "chained after ; blocks"             "echo done; gh issue create --body-file $WITHOUT"  "$TMPROOT" 2
+# `gh -R <owner/repo> issue create` is the CROSS-REPO MIRROR flow's own
+# spelling, and that flow is this gate's whole reason for existing -- so this
+# pair is the headline case, not an edge one. The shared
+# `GATE_RE_GH_ISSUE_CREATE` absorbs `-C <path>` only and does NOT match these;
+# the gate builds its verb on `GATE_GH_CR` instead, leaving the shared
+# constant's surface (pr-body-item-number-gate.sh consumes it) untouched.
+run "gh -R <repo> issue create blocks"   "gh -R go-to-k/cdk-local issue create --body-file $WITHOUT" "$TMPROOT" 2
+run "gh -R <repo> with marker passes"    "gh -R go-to-k/cdk-local issue create --body-file $WITH"    "$TMPROOT" 0
+run "gh --repo <repo> blocks"            "gh --repo go-to-k/cdkd issue create --body-file $WITHOUT"  "$TMPROOT" 2
+run "gh --repo <repo> with marker passes" "gh --repo go-to-k/cdkd issue create --body-file $WITH"    "$TMPROOT" 0
+# The `-C` and plain forms must keep the verdicts they had before GATE_GH_CR.
+run "gh -C <dir> issue create blocks"    "gh -C $TMPROOT issue create --body-file $WITHOUT" "$TMPROOT" 2
+run "gh -C <dir> with marker passes"     "gh -C $TMPROOT issue create --body-file $WITH"    "$TMPROOT" 0
+run "gh -C and -R together blocks"       "gh -C $TMPROOT -R go-to-k/cdkd issue create --body-file $WITHOUT" "$TMPROOT" 2
+run "gh -R on a comment still passes"    "gh -R go-to-k/cdkd issue comment 7 --body-file $WITHOUT"  "$TMPROOT" 0
+run "subshell blocks"                    "(gh issue create --body-file $WITHOUT)"           "$TMPROOT" 2
+run "command substitution blocks"        "URL=\$(gh issue create --body-file $WITHOUT)"     "$TMPROOT" 2
+
+# --- quoted-body false-positive cases ---------------------------------------
+# A command that merely NAMES the trigger must not fire the gate.
+run "quoted mention in commit message"   "git commit -m 'docs: explain gh issue create --body-file flow'" "$TMPROOT" 0
+run "quoted mention in echo"             "echo 'run: gh issue create --body-file x.md'"                   "$TMPROOT" 0
+
+# --- repo opt-in scope -------------------------------------------------------
+# A repo that never opted in must not inherit this repo's filing discipline.
+# The control directly below it is what keeps these from passing merely because
+# the gate is broken.
+run "no .markgate.yml: not gated"        "gh issue create --body-file $NOOPTIN/x.md"       "$NOOPTIN" 0
+run "outside any git repo: not gated"    "gh issue create --body-file $TMPBASE/x.md"       "$TMPBASE" 0
+run "-R sibling from an opted-in cwd"    "gh -R go-to-k/cdkd issue create --body-file $WITHOUT" "$TMPROOT" 2
+
+# --- the marker must be a LINE in a body file, not a passing mention --------
+run "body-file marker only mid-sentence" "gh issue create --body-file $MIDLINE"  "$TMPROOT" 2
+run "+ list prefix and odd caps accepted" "gh issue create --body-file $PLUSLIST" "$TMPROOT" 0
+
+# --- the scans are scoped to the mint SEGMENT -------------------------------
+# `-F` is `git commit`'s flag as well as gh's short `--body-file`, so an
+# unscoped extraction reads the COMMIT MESSAGE and finds the marker there. Both
+# orderings, because scoping only "after the verb" fixes just one of them.
+run "commit -F before, gh after"  "git commit -F $COMMITMSG && gh issue create --body-file $WITHOUT" "$TMPROOT" 2
+run "gh before, commit -F after"  "gh issue create --body-file $WITHOUT && git commit -F $COMMITMSG" "$TMPROOT" 2
+run "grep -F pattern is not a body" "grep -F dup-check: $COMMITMSG && gh issue create --body-file $WITHOUT" "$TMPROOT" 2
+
+# --- the opt-in `cd` must survive an EARLIER gh ----------------------------
+# `gate_target_dir` stops at the first segment matching the ERE it is given, so
+# a bare `gh` verb ERE makes it stop at the first gh segment and miss the `cd`.
+# That is exactly the search-then-file chain this gate's own message prescribes.
+run "search, cd, then file (no marker)" "gh issue list --state open --search x && cd $TMPROOT && gh issue create --body-file without.md" "$TMPBASE" 2
+run "search, cd, then file (marker)"    "gh issue list --state open --search x && cd $TMPROOT && gh issue create --body-file with.md"    "$TMPBASE" 0
+
+# --- the REST mint --------------------------------------------------------
+run "gh api issues POST, no marker" "gh api repos/go-to-k/cdk-local/issues -f title=t -f body=x"                  "$TMPROOT" 2
+run "gh api issues POST, marker"    "gh api repos/go-to-k/cdk-local/issues -f title=t -f 'body=x Dup-check: none'" "$TMPROOT" 0
+run "gh api comments is not a mint" "gh api repos/go-to-k/cdk-local/issues/5/comments -f body=x"                   "$TMPROOT" 0
+run "gh api issue edit is not a mint" "gh api -X PATCH repos/go-to-k/cdk-local/issues/5 -f body=x"                 "$TMPROOT" 0
+
+# --- more body-file spellings ----------------------------------------------
+run "--body-file=<p> form"          "gh issue create --body-file=$WITH"        "$TMPROOT" 0
+run "--body-file=<p> without"       "gh issue create --body-file=$WITHOUT"     "$TMPROOT" 2
+run "quoted --body-file path"       "gh issue create --body-file \"$WITHOUT\"" "$TMPROOT" 2
+run "--field body=@ without"        "gh issue create --field body=@$WITHOUT"   "$TMPROOT" 2
+run "--raw-field body=@ with"       "gh issue create --raw-field body=@$WITH"  "$TMPROOT" 0
+
+# --- both refusal arms carry their own message ------------------------------
+run_msg "missing-marker message"    "gh issue create --body-file $WITHOUT" "$TMPROOT" 2 "carries no"
+run_msg "unreadable-path message"   "gh issue create --body-file $TMPROOT/nope.md" "$TMPROOT" 2 "No readable --body-file"
+# An unexpanded variable is refused through its OWN arm: a bare "check the path"
+# is unclearable when the file does carry the line.
+run_msg "unexpanded \$VAR message"  "gh issue create --body-file \"\$BODY\"" "$TMPROOT" 2 "unexpanded variable"
+
+# --- the library-load guard must FAIL CLOSED -------------------------------
+# Swapping the whole guard for `. lib || exit 0` leaves every other case green.
+lib_fail_closed() {
+  local tmp out rc
+  tmp=$(mktemp -d)
+  cp "$HOOK" "$tmp/gate.sh"          # no _command-match.sh beside it
+  chmod +x "$tmp/gate.sh"
+  out=$(jq -n '{tool_name:"Bash", tool_input:{command:"gh issue create --body-file /nope.md"}, cwd:"/"}' \
+        | "$tmp/gate.sh" 2>&1) && rc=0 || rc=$?
+  rm -rf "$tmp"
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "_command-match.sh"; then
+    echo "PASS: unloadable library fails CLOSED (exit $rc)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: unloadable library should exit 2 naming the library (got $rc)"; FAIL=$((FAIL + 1))
+  fi
+}
+lib_fail_closed
+
+# A library present but TRUNCATED past this gate's constants: `.` succeeds and
+# `gate_matches` exists, so only the GATE_RE_* checks catch it.
+lib_truncated_fails_closed() {
+  local tmp out rc
+  tmp=$(mktemp -d)
+  cp "$HOOK" "$tmp/gate.sh"
+  chmod +x "$tmp/gate.sh"
+  sed '/^GATE_RE_GH_API_ISSUE_CREATE=/d' "$(dirname "$HOOK")/_command-match.sh" > "$tmp/_command-match.sh"
+  out=$(jq -n '{tool_name:"Bash", tool_input:{command:"gh issue create --body-file /nope.md"}, cwd:"/"}' \
+        | "$tmp/gate.sh" 2>&1) && rc=0 || rc=$?
+  rm -rf "$tmp"
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "_command-match.sh"; then
+    echo "PASS: library missing the constant fails CLOSED (exit $rc)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: truncated library should exit 2 naming the library (got $rc)"; FAIL=$((FAIL + 1))
+  fi
+}
+lib_truncated_fails_closed
+
+# --- the hook is actually REGISTERED ---------------------------------------
+# The suite invokes the hook directly, so it would not otherwise notice the
+# hook being dropped from .claude/settings.json. The `if:` matchers themselves
+# are asserted by tests/unit/hooks/gate-if-matchers.test.ts.
+registration_check() {
+  local settings
+  settings="$(cd "$(dirname "$0")/../.." && pwd)/.claude/settings.json"
+  if [ -f "$settings" ] && grep -q 'issue-dup-check-gate.sh' "$settings"; then
+    echo "PASS: registered in .claude/settings.json"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: not registered in .claude/settings.json"; FAIL=$((FAIL + 1))
+  fi
+}
+registration_check
+
+# --- heredoc -> file -> --body-file in ONE command --------------------------
+# The file does not exist at PreToolUse time. It must PASS when the heredoc body
+# carries the marker at line start -- and still BLOCK when it does not.
+HD_OK="cat > $TMPROOT/hd.md <<'EOF'
+Some defect.
+
+Dup-check: searched open issues -- none covers this root cause
+EOF
+gh issue create --body-file $TMPROOT/hd.md"
+HD_NO="cat > $TMPROOT/hd2.md <<'EOF'
+Some defect, nothing else.
+EOF
+gh issue create --body-file $TMPROOT/hd2.md"
+run "heredoc body carries the marker" "$HD_OK" "$TMPROOT" 0
+run "heredoc body lacks the marker"   "$HD_NO" "$TMPROOT" 2
+# The fallback uses the ANCHORED marker, so a passing mention does not satisfy it.
+HD_MID="cat > $TMPROOT/hd3.md <<'EOF'
+We ran a dup-check: nothing turned up.
+EOF
+gh issue create --body-file $TMPROOT/hd3.md"
+run "heredoc body mentions it mid-line" "$HD_MID" "$TMPROOT" 2
+
+run "empty command passes" "" "$TMPROOT" 0
+run_no_tool_name "absent tool_name is treated as Bash (blocks)" "gh issue create --body-file $WITHOUT" "$TMPROOT" 2
+run_no_tool_name "absent tool_name is treated as Bash (passes)" "gh issue create --body-file $WITH"    "$TMPROOT" 0
+run_nonbash "non-Bash tool passes" 0
+
+echo ""
+echo "Pass: $PASS  Fail: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -82,6 +82,12 @@ if ! declare -F gate_matches >/dev/null 2>&1; then
   echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
   exit 2
 fi
+# `gate_pr_selector` too: without it the selector silently comes back EMPTY and
+# the gate judges the wrong PR (or none) instead of refusing.
+if ! declare -F gate_pr_selector >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_pr_selector is undefined (predates the shared PR-selector extractor?)." >&2
+  exit 2
+fi
 
 
 input=$(cat 2>/dev/null || true)
@@ -131,13 +137,23 @@ fi
 #
 #   `gh pr merge <N>` / `gh pr edit <N>` — N is the explicit arg.
 #   `gh pr create` / `gh pr merge` (no arg) — current branch's PR.
-pr_number=""
-if [[ "$cmd" =~ gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(merge|edit)[[:space:]]+([0-9]+) ]]; then
-  pr_number="${BASH_REMATCH[3]}"
-fi
+# Through the SHARED extractor, which strips whatever flags the verb regex
+# absorbed. The hard-coded `-C`-only pattern this replaces did not match under a
+# repo flag, so resolution fell through to `gh pr view --json number` -- the
+# CURRENT BRANCH's PR. Measured 2026-08-25: `gh -R go-to-k/cdk-local pr merge
+# 552 --squash` produced `gh pr diff 999 --name-only`, i.e. the gate's verdict
+# was about a different PR's diff entirely.
+pr_number=$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_MERGE")
+[[ -n "$pr_number" ]] || pr_number=$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_EDIT")
+# The repo the command NAMES, passed through to this gate's own gh calls. Without
+# it `gh -R go-to-k/OTHER pr merge 552` made the gate ask the LOCAL repo about
+# its PR 552 -- right number, wrong repo, and indistinguishable from the correct
+# case by both exit code and PR number.
+cmd_repo=$(gate_cmd_repo "$cmd" "$GATE_RE_GH_PR_MERGE")
+[[ -n "$cmd_repo" ]] || cmd_repo=$(gate_cmd_repo "$cmd" "$GATE_RE_GH_PR_EDIT")
 
 if [[ -z "$pr_number" ]]; then
-  pr_number=$( (cd "$target_dir" && "$GH" pr view --json number -q .number) 2>/dev/null || true)
+  pr_number=$( (cd "$target_dir" && "$GH" pr view ${cmd_repo:+--repo "$cmd_repo"} --json number -q .number) 2>/dev/null || true)
 fi
 
 # No PR yet (typical `gh pr create` on a fresh branch) — fall back to
@@ -158,7 +174,7 @@ if [[ "$use_local_diff" -eq 1 ]]; then
   fi
   changed_files=$(git -C "$target_dir" diff "$merge_base..HEAD" --name-only --diff-filter=AM 2>/dev/null || true)
 else
-  changed_files=$( (cd "$target_dir" && "$GH" pr diff "$pr_number" --name-only) 2>/dev/null || true)
+  changed_files=$( (cd "$target_dir" && "$GH" pr diff "$pr_number" ${cmd_repo:+--repo "$cmd_repo"} --name-only) 2>/dev/null || true)
 fi
 
 if [[ -z "$changed_files" ]]; then
@@ -192,7 +208,7 @@ MAX_REPORT=20
 # sha once.
 pr_head_sha=""
 if [[ "$use_local_diff" -eq 0 ]]; then
-  pr_head_sha=$( (cd "$target_dir" && "$GH" pr view "$pr_number" --json headRefOid -q .headRefOid) 2>/dev/null || true)
+  pr_head_sha=$( (cd "$target_dir" && "$GH" pr view "$pr_number" ${cmd_repo:+--repo "$cmd_repo"} --json headRefOid -q .headRefOid) 2>/dev/null || true)
 fi
 
 read_file_content() {

--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -40,6 +40,12 @@ if ! declare -F gate_matches >/dev/null 2>&1; then
   echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
   exit 2
 fi
+# `gate_pr_selector` too: without it the selector silently comes back EMPTY and
+# the gate judges the wrong PR (or none) instead of refusing.
+if ! declare -F gate_pr_selector >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_pr_selector is undefined (predates the shared PR-selector extractor?)." >&2
+  exit 2
+fi
 
 
 # Read the PreToolUse payload (command + cwd) once — separate jq
@@ -83,44 +89,31 @@ cd "$target_dir" 2>/dev/null || exit 0
 #   gh pr merge --squash --auto 123
 #   gh pr merge --auto    (no number; merges PR for current branch)
 #
-# Take the first bare numeric token after `merge`, ignoring flag
-# values. If no numeric token is found, we fall back to gh's "PR for
-# current branch" semantics by passing no positional arg.
-pr_number=""
-# Strip everything up to and including the LAST `gh pr merge` so we only
-# scan its args. Greedy `##*PATTERN` (not the shortest `#*PATTERN`) so a
-# Bash comment containing the bare word "merge" earlier in the command
-# (e.g. `# Wait + merge\ngh pr merge 21`) doesn't cause us to read the
-# wrong token as the PR number.
-args="${cmd##*gh pr merge}"
-# shellcheck disable=SC2086
-set -- $args
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --*=*) shift; continue ;;
-    --auto|--admin|--delete-branch|--squash|--merge|--rebase)
-      shift; continue ;;
-    -*)
-      # Flag that may take a value; skip the next token defensively.
-      shift
-      [ $# -gt 0 ] && shift
-      continue
-      ;;
-    *)
-      if printf '%s' "$1" | grep -qE '^[0-9]+$'; then
-        pr_number="$1"
-        break
-      fi
-      shift
-      ;;
-  esac
-done
+# No numeric token means gh's "PR for the current branch" semantics, which the
+# call below reproduces by passing no positional arg.
+# Through the SHARED extractor. Two defects were folded into the old local one,
+# and the second only became reachable once GATE_GH_C learned `-R`:
+#   - `args="${cmd##*gh pr merge}"` does not strip under a repo flag, so...
+#   - ...the arg loop scanned the WHOLE command for the first bare integer.
+#     `sleep 30 && gh -R go-to-k/cdk-local pr merge 552 --squash` resolved to
+#     `gh pr view 30` (measured 2026-08-25). The WRONG PR's additions, deletions
+#     and file count then chose the review tier -- and if that PR is `inline`,
+#     the real merge passes with no reviewer at all.
+# The shared extractor scans only what follows the matched verb, so a leading
+# numeric token cannot be read as the selector.
+pr_number=$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_MERGE")
+# The repo the command NAMES, passed through to this gate's own gh calls. Without
+# it `gh -R go-to-k/OTHER pr merge 552` made the gate ask the LOCAL repo about
+# its PR 552 -- right number, wrong repo, and indistinguishable from the correct
+# case by both exit code and PR number.
+cmd_repo=$(gate_cmd_repo "$cmd" "$GATE_RE_GH_PR_MERGE")
 
 # --- Fetch PR stats via gh. --------------------------------------------
 # Pass-through on any gh error so an unrelated infra outage doesn't
 # block merges (fail-open posture, mirroring check-gate.sh).
 if [ -n "$pr_number" ]; then
-  pr_json=$(gh pr view "$pr_number" \
+  # shellcheck disable=SC2086
+  pr_json=$(gh pr view "$pr_number" ${cmd_repo:+--repo "$cmd_repo"} \
     --json additions,deletions,changedFiles,files,headRefOid,headRefName 2>/dev/null) || {
     printf 'pr-review-gate: gh pr view %s failed; allowing merge (infra fail-open)\n' "$pr_number" >&2
     exit 0
@@ -284,8 +277,14 @@ fi
 # commits on the PR branch whose message starts with `fix:` / `fix(`.
 branch=$(printf '%s' "$pr_json" | jq -r '.headRefName // ""' 2>/dev/null || echo "")
 if [ -n "$branch" ] && git rev-parse --verify --quiet "origin/$branch" >/dev/null 2>&1; then
+  # `$(… || echo 0)` is WRONG here: `grep -c` already prints `0` before exiting
+  # 1 on no match, so the fallback APPENDS and the substitution is `0\n0` --
+  # which makes the test below print `[: 0\n0: integer expression expected` on
+  # every gated merge. The outcome happened to be correct (non-numeric is not
+  # `-gt 1`), which is exactly why it survived: a real parse failure would look
+  # identical. Assign, then default on the assignment's own exit status.
   fix_count=$(git log "origin/main..origin/$branch" --oneline 2>/dev/null \
-    | grep -cE '^[a-f0-9]+ fix(\(|:)' || echo 0)
+    | grep -cE '^[a-f0-9]+ fix(\(|:)') || fix_count=0
   if [ "${fix_count:-0}" -gt 1 ]; then
     up_bias=1
   fi

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -80,9 +80,12 @@ The hooks split into three classes:
   `review-fix #N` / `step #N` / plain `#N` in prose are blocked with
   line-numbered offender output.
 
-- **`issue-dup-check-gate.sh`** blocks `gh issue create` — and
-  `gh api repos/<owner>/<repo>/issues`, the same mint through the REST
-  verb — when the issue body carries no `Dup-check:` line recording
+- **`issue-dup-check-gate.sh`** blocks `gh issue create` — and a
+  `gh api repos/<owner>/<repo>/issues` that is actually a MINT (an
+  explicit `POST`, or a `title=` field with no explicit method, since gh
+  infers POST from fields); the collection path is also the LIST
+  endpoint, so plain reads and `-X GET` pass — when the issue body
+  carries no `Dup-check:` line recording
   that the OPEN issue list was searched for an issue already covering
   this root cause. `gh issue edit` / `gh issue comment` are
   deliberately NOT gated: folding a finding into an issue that already
@@ -96,20 +99,24 @@ The hooks split into three classes:
   `Session-fit: next`, nothing umbrella-shaped): the target is the
   cross-repo MIRROR path, which `/work-issues` §10-c already names as
   a duplicate generator in its own text. go-to-k/cdk-local#531 was
-  filed nine minutes after go-to-k/cdk-local#528 with a strict SUBSET
+  filed eight minutes after go-to-k/cdk-local#528 with a strict SUBSET
   of its lessons, and go-to-k/cdk-local#511 duplicated
-  go-to-k/cdk-local#504 after 75 minutes. go-to-k/cdk-local#528's body
-  shows the near
-  miss exactly — it checked the merged file and the open PRs and
-  reported them clear, and never checked the open ISSUE list.
+  go-to-k/cdk-local#504 after 75 minutes.
+  go-to-k/cdk-local#528's body shows the near miss exactly — it records
+  a file check and an open-PR scan, and no check of the open ISSUE
+  list. Not one of the four bodies records an open-issue search, which
+  is the window that would have caught either pair.
 
   Two marker spellings, and the split is load-bearing. In a body FILE
   the marker is ANCHORED at line start (optional `-*+>` list prefix,
   case-insensitive), so a passing mention inside a sentence does not
   satisfy it. In the raw COMMAND there is no line structure — an
   inline `--body 'Bug. Dup-check: ...'` is one line — so that scan is
-  unanchored. The threat model is FORGETTING to run the search, not
-  defeating the gate.
+  unanchored, and it reads the BODY VALUES only (`--body` / `-b` /
+  `body=`), never the whole segment: `--title 'Dup-check: yes'` used to
+  satisfy the gate with a marker-free body, and a title is not a record
+  of having searched anything. The threat model is FORGETTING to run the
+  search, not defeating the gate.
 
   Both scans are scoped to the `gh issue create` / `gh api ... issues`
   SEGMENT, never the whole command, and that scoping is load-bearing:
@@ -132,14 +139,15 @@ The hooks split into three classes:
   `check-gate.sh`, so filing an issue in an unrelated personal repo is
   not refused; the CWD's repo decides, not any `-R <owner/repo>` in
   the command, because `-R` names where the issue LANDS while the cwd
-  names whose policy the session is under. Its verb regexes are built on
-  `GATE_GH_CR` rather than the shared `GATE_RE_GH_ISSUE_CREATE`, so
+  names whose policy the session is under.
   `gh -R go-to-k/<target> issue create` — the cross-repo mirror flow's
-  own spelling, and this gate's headline case — is matched without
-  changing any other gate's trigger surface (see §3's note on
-  `GATE_GH_C`). No bypass marker — running
+  own spelling, and this gate's headline case — is matched because
+  `GATE_GH_C` absorbs `-R` in all three of `gh`'s separator forms —
+  space, `=`, and glued (see §3; it did not until 2026-08-25, which is
+  the same bypass that let `gh -R … pr merge` past `verify-pr-gate`).
+  No bypass marker — running
   the search and writing one line is the entire ask. Covered by
-  `.claude/hooks/issue-dup-check-gate.test.sh` (63 cases) plus
+  `.claude/hooks/issue-dup-check-gate.test.sh` (83 cases) plus
   recognition cases in `gate-command-recognition.test.sh`.
 
 - **`docs-inline-json-flag-gate.sh`** blocks `gh pr create` /
@@ -212,26 +220,144 @@ resolves the tree in this order: a `git -C <path>` / `gh -C <path>` inside the
 MATCHED segment, else the LAST `cd <path>` segment before it, else the payload
 cwd. (Before go-to-k/cdk-local#542 each gate parsed only a LEADING `cd` and any
 `-C` anywhere in the command.) The verb regexes in that file absorb the
-LEADING FLAGS between the command and its verb: `GATE_FLAGS` for `git`, and for
-`gh` **`GATE_GH_C`, which absorbs `-C <path>` ONLY**. That is a known
-under-approximation — measured 2026-08-25 with the real constants,
-`gh -R go-to-k/cdk-local pr create`,
-`gh --repo go-to-k/cdk-local pr merge 1 --squash` and
-`gh -R go-to-k/cdk-local issue create` match NOTHING, so every gate keyed on a
-`gh` verb regex (`verify-pr-gate`, `pr-review-gate`, `integ-gate`,
-`closes-paren-form-gate`, `gh-pr-merge-worktree-gate`, `non-english-text-gate`,
-`docs-inline-json-flag-gate`, `cdkd-parity-gate`, `create-integ-gate`,
-`pr-body-item-number-gate`) passes an `-R`-carrying command through while
-refusing the identical command without the flag — and the `-R` form is what
-this repo's own `.claude/settings.json` permission allow-list writes for
-cross-repo filing. Widening `GATE_GH_C` would change all ten trigger surfaces at
-once, so it is tracked as its own change rather than done in passing; the
-sibling shipped that fix as go-to-k/cdkd#2027 review round 4. In the meantime
-`GATE_GH_CR` sits beside it, absorbing `-C` / `-R` / `--repo`, and is used ONLY
-by `issue-dup-check-gate.sh`'s verb regexes — the one gate whose stated reason
-for existing IS the `-R` spelling. `_command-match.test.sh` pins both: the
-`GATE_GH_CR` forms match, and `GATE_RE_GH_ISSUE_CREATE` /
-`GATE_RE_GH_PR_CREATE` keep their existing surface, `-R` gap included.
+LEADING FLAGS between the command and its verb: `GATE_FLAGS` for `git`, and
+**`GATE_GH_C`, which is literally `GATE_FLAGS`** — the same token shape — for
+`gh`.
+
+It has been wrong twice, and both were **live gate bypasses** rather than
+cosmetic gaps, because every `gh` verb regex is built on it:
+
+1. It absorbed `-C <path>` ONLY, so `gh -R <owner/repo> pr merge 1 --squash`
+   matched nothing and ran ungated.
+2. Replacing it with an explicit `(-C|-R|--repo)` alternation fixed only the
+   SPACE-separated form, because the alternation demanded `[[:space:]]+` between
+   flag and value. `gh` accepts three separators — verified against a real repo,
+   `gh pr list --repo=go-to-k/cdkd`, `-R=go-to-k/cdkd` and the GLUED
+   `-Rgo-to-k/cdkd` all return the same PR number — so `gh --repo=<owner/repo>
+   pr merge --squash` was still a bypass, one keystroke from the one just
+   closed. `-C` had the same hole all along: `gh -C=/w/t pr merge` never matched.
+
+Measured by driving the real hooks with markgate stubbed stale:
+
+| gate | plain | `-R <o/r>` (round 1) | `--repo=<o/r>` / `-R<o/r>` (round 2) |
+|---|---|---|---|
+| `verify-pr-gate` (`pr merge`) | 2 | **0** | **0** |
+| `verify-pr-gate` (`pr create`) | 2 | **0** | **0** |
+| `integ-gate` (`pr merge`) | 2 | **0** | **0** |
+
+So `/verify-pr` and the Docker integ gate were both skippable by adding a flag
+the flow itself tells you to use in multi-repo sessions, and which this repo's
+own `.claude/settings.json` permission allow-list already writes for cross-repo
+filing. (The other `gh` gates shell out to `gh` and fail OPEN when it errors, so
+under a stubbed `gh` they answer 0 to both spellings — a harness limit, not
+evidence they were unaffected; they share the same absorber.)
+
+`GATE_FLAGS`' token is `-[^[:space:]]+`, which swallows `--repo=X`, `-R=X` and
+`-RX` WHOLE, with the value group needed only for the space form. All three
+separators fall out of the token shape instead of being enumerated — which is
+why this is not a curated flag list: an alternation must spell each flag times
+each separator, and the glued form, having no separator at all, is the one it
+misses. Being wider than "repo/dir flags" costs nothing, since a flag regex only
+decides which spellings REACH the verb. Same defect and same fix as
+go-to-k/cdkd#2027 review round 4, whose `GATE_GH_C` is this same `GATE_FLAGS`.
+
+**Widening the absorber is necessary and NOT sufficient**, and this is the part
+that bit hardest. Making the flagged commands REACH a gate does nothing about
+the gate then parsing them, and four gates each rolled their own PR-selector
+extraction with the same `-C`-only shape the absorber had just outgrown.
+Measured against `gh -R go-to-k/cdk-local pr merge 552 --squash`:
+
+| gate | plain resolves | flagged resolved (before) |
+|---|---|---|
+| `closes-paren-form-gate` | `pr view 552` | **`gh` never called — fully bypassed** |
+| `non-english-text-gate` | `pr diff 552` | **`pr diff 999`** (the current branch's PR) |
+| `docs-inline-json-flag-gate` | `pr diff 552` | **`pr diff 999`** |
+| `pr-review-gate` | `pr view 552` | **`pr view 30`** from `sleep 30 && gh -R … merge 552` |
+
+The last one is the worst: the wrong PR's additions / deletions / file count
+chose the review tier, so if that PR is `inline` the real merge passes with no
+reviewer at all. All four now call **`gate_pr_selector`** in
+`_command-match.sh`, which strips `BASH_REMATCH[0]` of the SAME verb ERE that
+armed the gate — whatever flags it absorbed — and scans only what follows. A
+gate can no longer match one way and parse another. Each of the four also
+fails CLOSED if the library predates the helper.
+
+`gate_target_dir`'s `-C` recognition was widened alongside, for the same reason:
+the absorber now admits `gh -C=/w/t pr merge 1`, which previously resolved to the
+payload cwd, so a **different worktree's markgate marker** decided the verdict.
+
+Two further instances of the same shape, both found by review rather than by the
+suite, and both fixed here:
+
+- **The flag enumeration had the wrong polarity.** `gate_pr_selector` skipped an
+  enumerated list of VALUE-TAKERS, so any unlisted value-taking flag left its
+  value in the walk — `gh pr merge -t 42 552` resolved to **42**. The list is now
+  of VALUELESS flags, and every other `-…` consumes its next token. The direction
+  of staleness is the argument: an unlisted value-taker judges a DIFFERENT PR,
+  while an unlisted valueless flag merely empties the selector and the caller
+  falls back to current-branch semantics. A final numeric guard makes a branch
+  name, URL or repo slug yield empty rather than be handed on.
+- **The `-C` scan read inside quoted flag VALUES.**
+  `git -c core.pager="less -C /evil" commit -m y` resolved to `/evil`, and through
+  `branch-gate` on `main` that turns rc=2 into rc=0. The cause was tokenisation,
+  not the scan: `GATE_PATH_TOKEN` is "a quoted span OR a bare run of non-space",
+  so it split `core.pager="less` at the first space and read the tail as a fresh
+  `-C`. `GATE_EMBEDDING_TOKEN` lets a token EMBED quoted spans, and the flag run
+  is now walked token-by-token. Pre-existing on `origin/main`; the widened `-C`
+  scan made it reachable in more shapes.
+
+**Which REPO the gate asks about** was a fourth blind spot with no helper at all:
+a gate resolved the PR number and then ran `gh pr view <N>` from the resolved
+directory WITHOUT the repo flag, so `gh -R go-to-k/OTHER pr merge 552` made every
+gate judge the LOCAL repo's PR 552 — right number, wrong repo, and identical to
+the correct case in both exit code and selector. `gate_cmd_repo` extracts the
+named repo (all three separators, quoted spans embedded, either side of the verb)
+and the four gates pass it through to their own gh calls. Fenced by `run_repo`.
+
+The regression cases live in TWO places on purpose. `_command-match.test.sh`
+pins the absorber at the regex level, in every direction — all three separator
+forms match, the plain / `-C` forms keep the verdicts they already had, no `gh`
+verb matches a DIFFERENT `gh` verb, and a flag VALUE does not swallow the verb
+(`gh --draft pr create` still matches `pr create`, which only backtracking
+saves). But a matcher test can only fail once someone
+already suspects the flag, so `gate-command-recognition.test.sh` adds the
+assertion that would have caught this cold: drive a gate with the plain and the
+flagged spelling of the SAME command and demand the same exit code. Those pairs
+carry an expected plain rc as a guard-the-guard, because a gate that fails open
+under the stub would otherwise satisfy the equality vacuously at 0.
+
+**Equal exit codes are still not enough**, which is how the four selector bugs
+above were certified green. Two harness defects had to be fixed before any of
+them was visible: the payloads carried no `tool_name`, so `closes-paren-form-gate`
+exited at its `tool_name` check before ever reading the command and its pair
+reported "both exit 0" over a live bypass; and nothing asserted **what the gate
+asked GitHub about**. `run_sel` now does exactly that — a `gh` shim logs its argv
+and answers `999` to `pr view --json number`, so a fall-through to
+current-branch resolution shows up as a wrong PR number rather than as silence.
+Every spelling must resolve the SAME PR the plain form does, with the plain arm
+as the control.
+
+**And the same lens has to be turned on every verifier a gate consults, not just
+on `gh`.** Three further blind spots, each of which left a live bypass green:
+
+- **WHICH MARKER a gate verifies.** The markgate stub logged `$PWD` and
+  discarded `$*`, so swapping `verify-pr-gate`'s `markgate verify verify-pr` for
+  `verify check` was fully green — a mutant that merges any PR whose `/check`
+  alone is fresh, i.e. whose `/verify-pr` checklist never ran. The stub now logs
+  argv and `run_marker` asserts the gate name.
+- **WHICH REPO a gate asks about** — see `gate_cmd_repo` above, fenced by
+  `run_repo`.
+- **The directory `cdkd-parity-gate` / `create-integ-gate` resolve.** An earlier
+  revision recorded "(never asked)" for these and called them uncoverable
+  controls. That was FALSE: both expose the resolved directory on their first
+  `git -C "$target_dir" rev-parse --git-dir`, long before markgate. A `git` shim
+  logging argv reads it, and `run_git_dir` asserts it. A comment claiming
+  coverage is impossible is worse than no comment — it is what stops the next
+  person from adding it.
+
+The rule these three share: **assert what the gate ASKS ITS VERIFIER, not only
+what it answers.** An exit code cannot distinguish "asked the right question and
+got no" from "asked the wrong question and got no".
 
 The hook then `cd`s to that resolved target dir
 before invoking `markgate verify`. This preserves

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -80,6 +80,68 @@ The hooks split into three classes:
   `review-fix #N` / `step #N` / plain `#N` in prose are blocked with
   line-numbered offender output.
 
+- **`issue-dup-check-gate.sh`** blocks `gh issue create` — and
+  `gh api repos/<owner>/<repo>/issues`, the same mint through the REST
+  verb — when the issue body carries no `Dup-check:` line recording
+  that the OPEN issue list was searched for an issue already covering
+  this root cause. `gh issue edit` / `gh issue comment` are
+  deliberately NOT gated: folding a finding into an issue that already
+  exists is the outcome the gate steers toward, so taxing it would
+  penalise the cheap path and leave the costly one free. It is NOT a
+  filing threshold — `/work-issues` §10-0 forbids using it as one; it
+  changes WHERE a finding is written, never whether.
+
+  Why here, since cdk-local does not have its sibling's backlog
+  problem (measured 2026-08-25: 5 open issues, none carrying
+  `Session-fit: next`, nothing umbrella-shaped): the target is the
+  cross-repo MIRROR path, which `/work-issues` §10-c already names as
+  a duplicate generator in its own text. go-to-k/cdk-local#531 was
+  filed nine minutes after go-to-k/cdk-local#528 with a strict SUBSET
+  of its lessons, and go-to-k/cdk-local#511 duplicated
+  go-to-k/cdk-local#504 after 75 minutes. go-to-k/cdk-local#528's body
+  shows the near
+  miss exactly — it checked the merged file and the open PRs and
+  reported them clear, and never checked the open ISSUE list.
+
+  Two marker spellings, and the split is load-bearing. In a body FILE
+  the marker is ANCHORED at line start (optional `-*+>` list prefix,
+  case-insensitive), so a passing mention inside a sentence does not
+  satisfy it. In the raw COMMAND there is no line structure — an
+  inline `--body 'Bug. Dup-check: ...'` is one line — so that scan is
+  unanchored. The threat model is FORGETTING to run the search, not
+  defeating the gate.
+
+  Both scans are scoped to the `gh issue create` / `gh api ... issues`
+  SEGMENT, never the whole command, and that scoping is load-bearing:
+  `-F` is `git commit`'s flag as well as gh's short `--body-file`, and
+  `commit-msg-heredoc-gate.sh` MANDATES `git commit -F <file>` here,
+  so an unscoped extraction reads the COMMIT MESSAGE — which quotes
+  the very lines it describes — and finds the marker there. Fenced in
+  both command orders.
+
+  An unreadable `--body-file` BLOCKS rather than passes ("cannot read"
+  treated as "nothing to object to" is the fail-open shape of
+  go-to-k/cdkd#2027), with ONE deliberate exception: `heredoc -> file
+  -> --body-file` in one command is a legitimate publishing shape and
+  the file does not exist yet at PreToolUse time, so an unreadable
+  path falls back to scanning the WHOLE command with the ANCHORED
+  marker. A `--body-file "$VAR"` whose path is unexpanded gets its own
+  refusal message, because a bare "check the path" is unclearable when
+  the file does carry the line. Repo opt-in via `.markgate.yml` at the
+  resolved cwd's repo root, same as `branch-gate.sh` /
+  `check-gate.sh`, so filing an issue in an unrelated personal repo is
+  not refused; the CWD's repo decides, not any `-R <owner/repo>` in
+  the command, because `-R` names where the issue LANDS while the cwd
+  names whose policy the session is under. Its verb regexes are built on
+  `GATE_GH_CR` rather than the shared `GATE_RE_GH_ISSUE_CREATE`, so
+  `gh -R go-to-k/<target> issue create` — the cross-repo mirror flow's
+  own spelling, and this gate's headline case — is matched without
+  changing any other gate's trigger surface (see §3's note on
+  `GATE_GH_C`). No bypass marker — running
+  the search and writing one line is the entire ask. Covered by
+  `.claude/hooks/issue-dup-check-gate.test.sh` (63 cases) plus
+  recognition cases in `gate-command-recognition.test.sh`.
+
 - **`docs-inline-json-flag-gate.sh`** blocks `gh pr create` /
   `gh pr edit` / `gh pr merge` (and their `gh -C <path>` / `cd <path>
   && ...` forms) when a Markdown file in the resolved PR diff (or
@@ -149,7 +211,29 @@ the command to `gate_target_dir` in `.claude/hooks/_command-match.sh`, which
 resolves the tree in this order: a `git -C <path>` / `gh -C <path>` inside the
 MATCHED segment, else the LAST `cd <path>` segment before it, else the payload
 cwd. (Before go-to-k/cdk-local#542 each gate parsed only a LEADING `cd` and any
-`-C` anywhere in the command.) The hook then `cd`s to that resolved target dir
+`-C` anywhere in the command.) The verb regexes in that file absorb the
+LEADING FLAGS between the command and its verb: `GATE_FLAGS` for `git`, and for
+`gh` **`GATE_GH_C`, which absorbs `-C <path>` ONLY**. That is a known
+under-approximation — measured 2026-08-25 with the real constants,
+`gh -R go-to-k/cdk-local pr create`,
+`gh --repo go-to-k/cdk-local pr merge 1 --squash` and
+`gh -R go-to-k/cdk-local issue create` match NOTHING, so every gate keyed on a
+`gh` verb regex (`verify-pr-gate`, `pr-review-gate`, `integ-gate`,
+`closes-paren-form-gate`, `gh-pr-merge-worktree-gate`, `non-english-text-gate`,
+`docs-inline-json-flag-gate`, `cdkd-parity-gate`, `create-integ-gate`,
+`pr-body-item-number-gate`) passes an `-R`-carrying command through while
+refusing the identical command without the flag — and the `-R` form is what
+this repo's own `.claude/settings.json` permission allow-list writes for
+cross-repo filing. Widening `GATE_GH_C` would change all ten trigger surfaces at
+once, so it is tracked as its own change rather than done in passing; the
+sibling shipped that fix as go-to-k/cdkd#2027 review round 4. In the meantime
+`GATE_GH_CR` sits beside it, absorbing `-C` / `-R` / `--repo`, and is used ONLY
+by `issue-dup-check-gate.sh`'s verb regexes — the one gate whose stated reason
+for existing IS the `-R` spelling. `_command-match.test.sh` pins both: the
+`GATE_GH_CR` forms match, and `GATE_RE_GH_ISSUE_CREATE` /
+`GATE_RE_GH_PR_CREATE` keep their existing surface, `-R` gap included.
+
+The hook then `cd`s to that resolved target dir
 before invoking `markgate verify`. This preserves
 markgate's per-worktree marker isolation — each parallel agent's
 worktree has its own markgate state dir

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -121,6 +121,20 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/issue-dup-check-gate.sh",
+            "if": "Bash(*gh*issue*create*)",
+            "timeout": 10,
+            "statusMessage": "Checking the issue body for a Dup-check line..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/issue-dup-check-gate.sh",
+            "if": "Bash(*gh*api*)",
+            "timeout": 10,
+            "statusMessage": "Checking the issue body for a Dup-check line..."
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 30,

--- a/.claude/skills/check-cdkd-parity/SKILL.md
+++ b/.claude/skills/check-cdkd-parity/SKILL.md
@@ -222,7 +222,39 @@ else
   #   cat 2 -> "inherit the new option (add<Cmd>SpecificOptions) — REQUIRED"
   #   cat 3 -> "new internal primitive available — OPTIONAL: adopt if useful, cdkd decides"
   #   cat 4 -> "behavior change — adapt — REQUIRED" (name old vs new + migration)
-  cat > /tmp/cdkd-parity-body.md <<'BODY'
+  # SEARCH FIRST. `issue-dup-check-gate.sh` refuses a `gh issue create` whose
+  # body carries no `Dup-check:` line, and this auto-file is THE cross-repo
+  # mirror filer whose duplicate history is that gate's stated rationale
+  # (`/work-issues` §5) -- so it is the last place to skip the search. Search
+  # cdkd's OPEN issues for the SURFACE this change touches (the subcommand, the
+  # option, the helper name), not for this PR's wording:
+  #
+  #   gh issue list --repo go-to-k/cdkd --state open --limit 200 \
+  #     --search 'Follow cdk-local <surface>' --json number,title
+  #   gh issue list --repo go-to-k/cdkd --state open --limit 200 \
+  #     --json number,title,body \
+  #     --jq '.[] | select((.body // "") | test("<subcommand / option / helper>";"i"))
+  #           | "\(.number)\t\(.title)"'
+  #
+  # On a HIT, do NOT file: add this change as a checklist row on that issue and
+  # write its URL to the sentinel, which satisfies the gate the same way --
+  #
+  #   U=$(mktemp)
+  #   gh issue view <hit> --repo go-to-k/cdkd --json body -q .body > "$U" \
+  #     && [ -s "$U" ] \
+  #     && printf -- '- [ ] <surface>: <one line> (%s)\n' "<cdk-local PR URL>" >> "$U" \
+  #     && gh issue edit <hit> --repo go-to-k/cdkd --body-file "$U"
+  #   printf '%s\n' "<hit URL>" > "$SENTINEL"   # only after the edit SUCCEEDS
+  #
+  # On a MISS, file, and RECORD THE TERMS YOU ACTUALLY SEARCHED on the
+  # `Dup-check:` line below -- replace the placeholder, do not ship it verbatim.
+  # NOT a fixed /tmp path. `issue-dup-check-gate` falls back to scanning the
+  # command when the body file cannot be read, but a fixed path that ALREADY
+  # EXISTS on this machine is readable -- so a marker-free heredoc writing it
+  # passes the gate against a STALE on-disk file. The gate's own message
+  # mandates `mktemp` for the fold recipe; the same applies here.
+  BODY_FILE=$(mktemp)
+  cat > "$BODY_FILE" <<'BODY'
 ## Follow cdk-local: <one-line summary>
 
 cdk-local changed its host-facing surface. All changes are additive unless a
@@ -230,12 +262,21 @@ category-4 item below says otherwise. cdk-local PR:
 https://github.com/go-to-k/cdk-local/pull/<N>  (or the branch URL pre-merge)
 
 <one bullet per applicable category, each with the host-action label above>
+
+Dup-check: searched go-to-k/cdkd open issues for <the surface terms you used>
+-- none covers this root cause
 BODY
   url=$(gh issue create --repo go-to-k/cdkd \
     --title "Follow cdk-local: <one-line summary>" \
-    --body-file /tmp/cdkd-parity-body.md)
-  printf '%s\n' "$url" > "$SENTINEL"
-  echo "Filed cdkd tracking issue: $url"
+    --body-file "$BODY_FILE") \
+    && [ -n "$url" ] \
+    && printf '%s\n' "$url" > "$SENTINEL" \
+    && echo "Filed cdkd tracking issue: $url"
+  # CHAINED, and the `-n` test is load-bearing: an unchained `> "$SENTINEL"`
+  # runs even when `gh issue create` failed, writing an empty file that
+  # `cdkd-parity-gate` then reads -- satisfying the gate with no issue behind
+  # it. The MISS path below fails closed by contrast; this one must too.
+  rm -f "$BODY_FILE"
 fi
 ```
 

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -192,6 +192,23 @@ Effort: small (S) | medium (M) | large (L) - <which verification cycle it drags>
 Estimate: <duration, e.g. ~1-3 h -- never a bare letter> - <what eats the time>
 ```
 
+Four CLASSIFICATION lines, and they stay four. Alongside them the body carries a
+**`Dup-check:`** line -- a filing-time record, not a fifth classification field:
+
+```text
+Dup-check: searched open issues for <terms> -- none covers this root cause
+```
+
+`.claude/hooks/issue-dup-check-gate.sh` refuses `gh issue create` (and the
+`gh api repos/<o>/<r>/issues` REST mint) without it, so a hunt that skips the
+search is physically blocked from filing. This hunt is the highest-volume filer
+in the repo, so it is where the line matters most: search the CONCEPT the bug
+turns on rather than this instance's spelling, and on a HIT fold the finding into
+that issue as a checklist row via `gh issue edit` instead of minting a new number
+(`/work-issues` §5 carries the full window and the fold recipe). That is not a
+filing threshold -- an unfiled finding is strictly worse than a filed one; what
+changes is WHERE the finding is written, never whether.
+
 A hunt is the single best moment to write them: you have just reproduced the bug,
 so `Severity` is measured rather than guessed, and you already know which fixture
 the fix will drag. Deferring them to whoever picks the issue up throws that

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -367,6 +367,108 @@ Two boundaries, so this does not become a licence for unbounded lanes:
   are two issues; one wrong assumption at five call sites is one. The test is
   whether a single sentence describes the fix at every site.
 
+**And whatever you do file, resolve it against the issues ALREADY OPEN first.**
+The sweep above looks for sibling sites in the CODE. This looks for a sibling
+ISSUE, and it is a different search with a different answer: the issue that
+already covers your finding was written from a DIFFERENT angle, by a different
+hop, and names a different section. §10-c already runs a rigorous version of
+this check — the merged file, then open PRs, then open issues — but its subject
+is a mirrored skill LESSON, and it is exactly the path where this repo's
+duplicates come from.
+
+Be honest about which problem this solves here, because the sibling repo's
+argument does not transfer. Measured 2026-08-25: cdk-local has **5 open
+issues**, **none** carrying `Session-fit: next`, and nothing umbrella-shaped.
+There is no unbounded backlog to converge. What there is, is a duplicate
+GENERATOR that §10-c already names in its own text, with two measured pairs out
+of 145 issues filed (41 of them skill-flow / cross-repo-mirror shaped):
+
+- go-to-k/cdk-local#528 (2026-08-19T06:37:46Z) and go-to-k/cdk-local#531
+  (06:46:00Z) — **nine minutes apart**, and go-to-k/cdk-local#531's three lessons
+  (marker-sourcing, `grep -cF`, life-only-probe) are a strict SUBSET of
+  go-to-k/cdk-local#528's four. Both were then closed by one PR, go-to-k/cdk-local#532.
+  go-to-k/cdk-local#528's own body shows the near miss precisely: it checked the merged FILE and the open PRs
+  (go-to-k/cdk-local#523, go-to-k/cdk-local#526) and reported them as carrying
+  different lesson sets — and never checked the open ISSUE list, where its own
+  duplicate landed nine minutes later.
+- go-to-k/cdk-local#504 (03:14:05Z) and go-to-k/cdk-local#511 (04:29:26Z) —
+  **75 minutes apart**, same target section (`/work-issues` §8's no-src
+  verification tier), same upstream lesson.
+
+Two of the three windows were searched both times. The third was not.
+
+```bash
+# Search the CONCEPT, not this instance's spelling — the same reason the code
+# sweep above greps for a SHAPE rather than a name.
+gh issue list --state open --limit 200 --search '<root-cause concept>' \
+  --json number,title
+# Then the body window, which the search index misses: an issue names the
+# section or symbol it targets in the body, not always in the title.
+gh issue list --state open --limit 200 --json number,title,body \
+  --jq '.[] | select((.body // "") | test("<shared symbol / call / assumption>";"i"))
+        | "\(.number)\t\(.title)"'
+# `(.body // "")`, not `.body`: an issue filed with no body makes `test` abort
+# the whole jq program with "null (null) cannot be matched", so one body-less
+# issue silently costs you the entire window.
+```
+
+On a HIT, the finding becomes a CHECKLIST ROW in that issue rather than a new
+issue number:
+
+```bash
+U=$(mktemp)   # NOT a fixed /tmp path — parallel lanes share the scratchpad
+gh issue view <hit> --json body -q .body > "$U" \
+  && [ -s "$U" ] \
+  && printf -- '- [ ] <site>: <one line, plus where the evidence is>\n' >> "$U" \
+  && gh issue edit <hit> --body-file "$U"
+```
+
+**The chaining and the `-s` test are load-bearing, not style.** The redirect
+truncates `$U` before `gh` runs, so an unchained recipe whose `view` fails —
+wrong number, a non-repo cwd, a transient error — leaves an empty file that the
+`printf` fills with the single new row, and the `edit` then replaces the target
+issue's WHOLE body with it. Every previously folded finding would be destroyed
+by the very procedure that exists to preserve them, which is the one outcome
+§10-0 says must never happen. `mktemp` rather than a fixed path for the same
+reason at a different scale: parallel lanes share the scratchpad, and a
+read-modify-write with no concurrency control loses a row when two folds
+overlap — so do not run two folds against the same issue concurrently.
+
+On a MISS — the expected outcome for a genuinely new root cause — file it, and
+record the search in the body so the next hop can see the window was checked:
+
+```text
+Dup-check: searched open issues for <terms> -- none covers this root cause
+```
+
+**This is not a filing threshold, and it must never be used as one.** §10-0
+below is explicit that `filed <= closed` is not a target and that an unfiled
+finding is strictly worse than a filed one. Nothing here changes WHETHER a
+defect gets written down; it changes only WHERE.
+
+Enforced by `.claude/hooks/issue-dup-check-gate.sh`, which refuses
+`gh issue create` without the `Dup-check:` line, and the same refusal covers
+`gh api repos/<o>/<r>/issues`, which mints an issue through the REST verb.
+`gh issue edit` and `gh issue comment` are deliberately NOT gated — folding
+into an existing issue is the outcome this steers toward, so taxing it would
+penalise the cheap path and leave the costly one free.
+
+Be precise about what that buys, because the obvious claim is false: folding is
+not CHEAPER than minting. After the same search, minting is one command and
+folding is three (`view`, `printf`, `edit`). What the gate does is make minting
+non-free while leaving folding untaxed — it removes minting's advantage rather
+than creating one for folding. Two consequences worth stating rather than
+discovering: a folded row carries no `Session-fit` / `Severity`, so §3's ranking
+cannot see it (write the severity into the row's text), and `gh issue edit` is
+NOT one of the verbs `pr-body-item-number-gate.sh` selects — checked against its
+verb list and its `if:` entries, which cover `gh issue create` and
+`gh issue comment` but not `edit` — so a folded row is the ONE issue-body path
+with no `#N` auto-link check in front of it. Write `go-to-k/<repo>#N` or a bare
+number in the row yourself. The gate exists because this
+section's own rule — "N sites of one root cause is ONE issue and ONE PR, never
+N issues", already written and already correct — did not stop either pair above.
+Registration is not execution.
+
 Never edit in the main checkout (`main-tree-branch-gate.sh` blocks branch creation
 there). Per lane:
 
@@ -940,9 +1042,30 @@ subject and a wider scope, and neither is covered by that one:
 ### 10-0. Measure the run's net effect on the backlog
 
 Before anything else in this step, count what the run did to the issue list and put
-both numbers in the wrap report — `closed N / filed M` — and **when M > N, give the
-reason in one more line**. It is almost always one of three, and only the first is
-healthy:
+both numbers in the wrap report. Then split the filed count by what §5's
+open-issue window did with each finding, because the aggregate cannot tell the two
+apart and they mean opposite things:
+
+```bash
+# Folded INTO an existing issue rather than filed as a new one. `updatedAt`
+# alone does NOT answer this: §4 makes every lane post a CLAIM comment on the
+# issue it takes, so a bare updatedAt sweep counts this run's own claims and can
+# never read 0. Count the issues whose BODY gained a checklist row instead.
+gh issue list --state open --limit 200 --json number,updatedAt \
+  --jq '.[] | select(.updatedAt > "<this run start ISO>") | .number' \
+| while read -r n; do
+    gh issue view "$n" --json body -q '.body' \
+      | grep -qE '^[[:space:]]*- \[ \]' && echo "$n"
+  done
+```
+
+Report it as one line — `closed N / filed M (new K / folded J)` — and **when
+M > N, give the reason in one more line**. `J` is the number §5's window exists to
+move, and it is the only one of the three below that can be improved without
+either missing a defect or leaving one unfixed; a run reporting `J = 0` over
+several findings in one area is the signal that the window was searched by this
+instance's spelling rather than by the concept. The reason is almost always one of
+three, and only the first is healthy:
 
 - **the code really does have that many independent defects** — the run walked into
   an untested area. Fine; say which area, so the next hunt aims there.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -384,18 +384,23 @@ GENERATOR that §10-c already names in its own text, with two measured pairs out
 of 145 issues filed (41 of them skill-flow / cross-repo-mirror shaped):
 
 - go-to-k/cdk-local#528 (2026-08-19T06:37:46Z) and go-to-k/cdk-local#531
-  (06:46:00Z) — **nine minutes apart**, and go-to-k/cdk-local#531's three lessons
+  (06:46:00Z) — **eight minutes apart** (8 m 14 s), and go-to-k/cdk-local#531's three lessons
   (marker-sourcing, `grep -cF`, life-only-probe) are a strict SUBSET of
   go-to-k/cdk-local#528's four. Both were then closed by one PR, go-to-k/cdk-local#532.
-  go-to-k/cdk-local#528's own body shows the near miss precisely: it checked the merged FILE and the open PRs
-  (go-to-k/cdk-local#523, go-to-k/cdk-local#526) and reported them as carrying
-  different lesson sets — and never checked the open ISSUE list, where its own
-  duplicate landed nine minutes later.
+  go-to-k/cdk-local#528's own body shows the near miss precisely: it records a
+  FILE check against the merged SKILL.md and a scan of the open PRs
+  (go-to-k/cdk-local#523, go-to-k/cdk-local#526), reporting them as carrying
+  different lesson sets — and no check of the open ISSUE list, where its own
+  duplicate landed eight minutes later.
 - go-to-k/cdk-local#504 (03:14:05Z) and go-to-k/cdk-local#511 (04:29:26Z) —
   **75 minutes apart**, same target section (`/work-issues` §8's no-src
   verification tier), same upstream lesson.
 
-Two of the three windows were searched both times. The third was not.
+What the four bodies record is thinner than §10-c's three-window check:
+go-to-k/cdk-local#528 records the file and open-PR windows,
+go-to-k/cdk-local#531 the file window only, and go-to-k/cdk-local#504 /
+go-to-k/cdk-local#511 none at all. **Not one of them records an open-ISSUE
+search** — the single window that would have caught either pair.
 
 ```bash
 # Search the CONCEPT, not this instance's spelling — the same reason the code

--- a/tests/unit/hooks/gate-if-matchers.test.ts
+++ b/tests/unit/hooks/gate-if-matchers.test.ts
@@ -52,6 +52,7 @@ const REQUIRED: Record<string, string[]> = {
   ],
   'post-merge-orphan-push-gate.sh': ['Bash(*git*push*)'],
   'closes-paren-form-gate.sh': ['Bash(*gh*pr*merge*)'],
+  'issue-dup-check-gate.sh': ['Bash(*gh*issue*create*)', 'Bash(*gh*api*)'],
   'pr-body-item-number-gate.sh': [
     'Bash(*gh*pr*create*)',
     'Bash(*gh*pr*edit*)',
@@ -102,7 +103,7 @@ describe('PreToolUse gate matchers (go-to-k/cdk-real-drift#1801)', () => {
     const names = new Set(hooks.map((h) => h.name));
     expect(names.has('check-gate.sh')).toBe(true);
     expect(names.has('verify-pr-gate.sh')).toBe(true);
-    expect(hooks.length).toBeGreaterThanOrEqual(17);
+    expect(hooks.length).toBeGreaterThanOrEqual(19);
   });
 
   // THE regression case: this exact join disabled every gate in the repo.


### PR DESCRIPTION
Two commits, ported from go-to-k/cdkd but **adapted** — and the second one is a
live gate bypass this port surfaced in cdk-local, unrelated to the feature.

## 1. `chore(work-issues)`: gate issue filing on an open-issue root-cause check

`.claude/hooks/issue-dup-check-gate.sh` refuses `gh issue create` — and
`gh api repos/<o>/<r>/issues`, which mints one through the REST verb — whose body
carries no `Dup-check:` line recording that the OPEN issue list was searched for
an issue already naming this root cause. `gh issue edit` / `gh issue comment` are
deliberately **not** gated: folding a finding into the issue that already covers
its root cause is the outcome this steers toward.

**cdkd's rationale does not apply here and was NOT copied.** cdkd's case is that
its backlog does not converge (115 open, 94 carrying `Session-fit: next`, its
four oldest all umbrella-shaped). Measured 2026-08-25, cdk-local has **5 open
issues and none carries `Session-fit: next`**. That argument is simply false
here, and reproducing it would have been a fabricated justification.

The true, verified case for cdk-local is the **mirror path**, which
`/work-issues` §10-c already documents as a duplicate GENERATOR:

| Issue | Created (UTC) | |
|---|---|---|
| `go-to-k/cdk-local` 528 | 2026-08-19T06:37:46Z | `...marker-sourcing, grep -cF, life-only-probe and branch-cleanup lessons` |
| `go-to-k/cdk-local` 531 | 2026-08-19T06:46:00Z | `...marker-sourcing, grep -cF, and life-only-probe lessons` |

**Nine minutes apart**, https://github.com/go-to-k/cdk-local/issues/531's three lessons a strict subset of https://github.com/go-to-k/cdk-local/issues/528's four. Both
were closed by one PR (https://github.com/go-to-k/cdk-local/issues/532) whose own body says they "carry the
same lesson set, so one lane ships both". And https://github.com/go-to-k/cdk-local/issues/528's body shows the near miss: it
checked the merged file and the open PRs and reported them as different — and
never checked the open **issue** list, where its own duplicate landed nine minutes
later. Two of §10-c's three windows searched; the third not.

https://github.com/go-to-k/cdk-local/issues/504 and https://github.com/go-to-k/cdk-local/issues/511 are a second pair, 75 minutes
apart, same target section.

**This is not a filing threshold.** §10-0 already forbids using it as one: an
unfiled finding is strictly worse than a filed one, because it removes the defect
from the record while leaving it in the product. What changes is WHERE a finding
is written, never whether.

## 2. `chore(hooks)`: close the `gh -R <owner/repo>` bypass in every gh-verb gate

**This is the part to read closely.** While porting, the shared absorber
`GATE_GH_C` turned out to accept only `-C <path>` — so every gate keyed on a
`gh` verb missed every repo-flag spelling. Measured by driving the real hooks:

| Gate | Verb | plain | `-R <o/r>` before | after |
|---|---|---|---|---|
| `verify-pr-gate` | `pr merge` | 2 | **0 — bypass** | 2 |
| `verify-pr-gate` | `pr create` | 2 | **0 — bypass** | 2 |
| `integ-gate` | `pr merge` | 2 | **0 — bypass** | 2 |

So `gh -R go-to-k/cdk-local pr merge 1 --squash` merged past `/verify-pr` today.
cdkd is not exposed — its `GATE_GH_C` is the full `GATE_FLAGS`.

The first fix covered only the space-separated form. `gh` accepts more, verified
against a real repo (each returned a PR number): `--repo=X`, `-R=X`, and the
**glued** `-RX` with no separator at all. `GATE_GH_C` is now `GATE_FLAGS`, whose
token `-[^[:space:]]+` swallows all three whole — the separators fall out of the
token shape instead of being enumerated, which is what a curated
`(-C|-R|--repo)` alternation kept missing. A pre-existing hole in `-C` support
(`-C=/w/t`) closes with them.

The two failure modes a wider token could introduce are pinned in both
directions: no `gh` verb matches a **different** `gh` verb (7 negatives, `=` and
glued included), and a flag **value** does not swallow the verb
(`gh --draft pr create` must not read as `pr merge`).

**The assertion left behind** is `run_pair` in
`gate-command-recognition.test.sh`: drive a gate with the plain and the flagged
spelling of the same command and demand the same exit code. It needs no
knowledge of which flags exist — only that adding one must not change a verdict —
which is why it catches this cold where a matcher test cannot. Each pair carries
the expected plain rc as a guard-the-guard, without which the gates that fail
open under a stubbed `gh` satisfy the equality vacuously at 0.

## Open question for the maintainer

Registered with `if:` matching all 29 siblings. cdkd **removed every `if:`**
after measuring that project-settings `if:` never fires
(https://github.com/go-to-k/cdkd/issues/1476 / https://github.com/go-to-k/cdkd/issues/1455). If that holds here, this gate does not
fire — and neither do the other 29. Not attempted here: it is a separate, larger
change. **Liveness is explicitly not claimed**: the session that wrote this ran
cdkd's hooks, so nothing here passed through cdk-local's `settings.json`. What is
proved is that the scripts work, driven directly with JSON payloads on stdin.

Second, smaller: `commit-prefix-scope-gate` requires `chore:` for a
`.claude/**`-only diff, so a security-relevant bypass fix ships under
`chore(hooks):` and will not surface in the changelog.

## Test plan

- Hook suites under `bash` 5.3.9 **and** `/bin/bash` 3.2.57, identical:
  `_command-match` 181, `gate-command-recognition` 41, `issue-dup-check-gate` 68,
  `pr-review-gate` 53 — `vp run test:hooks` **343 / 0**.
- `vp check` 0 errors (one pre-existing `src/local/cloudfront-edge-event.ts`
  warning, untouched, confirmed uncached), `vp run build` clean, `vp run test`
  **3167 / 3167**, no type errors.
- End-to-end bypass probe: **11 gate/verb pairs, 0 bypassed**.
- **Mutation probes, with an unmutated control run first.** Reverting to the
  original `-C`-only absorber fails **46** cases; reverting to the intermediate
  space-only alternation fails **24**, and its `gate-command-recognition`
  failures are exactly the `=` and glued pairs with no collateral. Plain and
  space-separated `-C` cases stay green under both, which is what shows the
  widening moved only the spellings it meant to.
- The control earned its place: the first probe copied only `.claude/hooks/`,
  while `pr-review-gate.test.sh` reads `src/**`, so 4 cases failed in the control
  *and* in both reverts. Those 4 would have been reported as evidence. The
  harness now copies the full tree; the numbers above are the corrected ones.

## One more gap this PR does not close

Writing this body surfaced it: `pr-body-item-number-gate.sh` here has no
allow-list arm for the fully-qualified `owner/repo#N` reference, so it blocks
the very citation form `/work-issues` section 10-c **mandates** for mirrored
files — the hook and the skill in direct contradiction. cdkd added that arm in
its issue 1992; this repo's copy predates it. Every reference above is therefore
written as a full URL, which both repos allow.

Not fixed here: it is a third concern in a PR that already carries two, and it
is a five-line change to an unrelated hook. Recorded rather than filed, so the
maintainer can take it in whichever direction they prefer — port the arm, or
keep URLs and drop the section 10-c requirement.

Worth knowing while you evaluate the rest: **which repo's copy of a hook runs is
decided by the session cwd**, because the registrations are relative paths. The
same `gh pr create` was judged by cdkd's copy from one directory and cdk-local's
from another, with different verdicts. That is the mechanism behind the
"a block in a sibling repo is expected behaviour" note in cdkd's CLAUDE.md, and
it cuts both ways: a sibling's OLDER hook can be stricter than cdkd's.
