### PR TITLE
fix(local): stop echoing a prefix of the parsed input in two JSON-parse failure messages

### DIFF
--- a/src/local/rie-client.ts
+++ b/src/local/rie-client.ts
@@ -466,7 +466,9 @@ export async function invokeRieStreaming(
       // is the only one suppressed here. V8 embeds a ~10-character prefix of
       // the PARSED INPUT in `SyntaxError.message` (quoting a short input in
       // FULL), and those bytes are NOT guaranteed to be protocol framing: the
-      // split above scans the WHOLE response for an 8-NUL run, and the
+      // split above scans the response for an 8-NUL run (up to
+      // `STREAM_PRELUDE_MAX_BYTES`, 1 MiB, past which it gives up with its
+      // own error rather than reaching here), and the
       // unframed-response block ABOVE records that the commonest handler
       // shape in the wild -- `streamifyResponse` plus `setContentType` /
       // `write`, never calling `HttpResponseStream.from` -- emits no framing

--- a/src/local/rie-client.ts
+++ b/src/local/rie-client.ts
@@ -462,8 +462,40 @@ export async function invokeRieStreaming(
     } catch (err) {
       clearTimeout(timer);
       reader.cancel().catch(() => undefined);
+      // Only the `JSON.parse` failure carries the bytes it was given, and it
+      // is the only one suppressed here. V8 embeds a ~10-character prefix of
+      // the PARSED INPUT in `SyntaxError.message` (quoting a short input in
+      // FULL), and those bytes are NOT guaranteed to be protocol framing: the
+      // split above scans the WHOLE response for an 8-NUL run, and the
+      // unframed-response block ABOVE records that the commonest handler
+      // shape in the wild -- `streamifyResponse` plus `setContentType` /
+      // `write`, never calling `HttpResponseStream.from` -- emits no framing
+      // at all, so what is scanned is raw function OUTPUT. An 8-NUL run
+      // inside binary output therefore matches by COINCIDENCE and makes
+      // `preludeBytes` a slice of application data. Reproduced on Node 24.15
+      // with a tar stream, whose 512-byte member header NUL-pads everything
+      // after the name field: the first run sits immediately after the file
+      // name, and the parser answers
+      // `Unexpected token 'c', "customer-d"... is not valid JSON`. Reported
+      // against the cdkd host as go-to-k/cdkd#2203.
+      //
+      // `parseStreamingPrelude`'s OTHER three throws -- `empty prelude`,
+      // `prelude is not a JSON object`, and `statusCode must be a number (got
+      // <typeof>)` -- are input-INDEPENDENT. Suppressing them would buy no
+      // privacy at all while telling a correctly-framed handler that its
+      // valid JSON is "not valid JSON", so they stay legible.
+      if (err instanceof SyntaxError) {
+        throw new Error(
+          `RIE streaming response prelude is not valid JSON (SyntaxError; ${preludeBytes.length} bytes before the 8-NUL separator). ` +
+            'The 8-NUL run in this response was taken as the prelude/body separator, and the bytes before it as the prelude. ' +
+            'A handler that does not call awslambda.HttpResponseStream.from(stream, metadata) sends no framing at all, so such a ' +
+            'run can occur by coincidence inside binary output and those bytes are then raw function output -- which is why the ' +
+            'parser detail is withheld here instead of echoed. ' +
+            'Check the container logs; calling HttpResponseStream.from(...) frames the response explicitly and rules the misread out.'
+        );
+      }
       throw new Error(
-        `RIE streaming response prelude is not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+        `RIE streaming response prelude is invalid: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -158,7 +158,18 @@ export function buildDefaultUtil(): VtlUtil {
     }
     // Object / array — JSON-stringify to avoid the `[object Object]` trap.
     try {
-      return JSON.stringify(v);
+      // `?? ''` is load-bearing, not defensive: `JSON.stringify` RETURNS
+      // `undefined` (it does not throw) for a function, a symbol, or an
+      // object whose `toJSON` yields undefined, and TypeScript hides that
+      // because `JSON.stringify(unknown)` selects the `any` overload. All
+      // three are reachable from a template -- `$input.json` / `$input.path`
+      // / `$input.params` are own-property FUNCTIONS on the object
+      // `buildVtlInput` returns, so `$util.parseJson($input.params)` (the
+      // call parens forgotten) hands one straight in. Without the coalesce
+      // this returns `undefined` and every `.length` / `.replace` on the
+      // result throws a TypeError, escaping as something other than the
+      // `VtlEvaluationError` a host is documented to be able to `instanceof`.
+      return JSON.stringify(v) ?? '';
     } catch {
       return '';
     }
@@ -214,10 +225,13 @@ export function buildDefaultUtil(): VtlUtil {
         // `err.name` is input-independent and safe as a discriminator, and
         // the argument's LENGTH is reported because it is the one property of
         // the input a developer can act on without being shown it. Note the
-        // length is that of the COERCED string: `coerce` answers `''` for a
-        // value `JSON.stringify` refuses (a circular object), so a reported
-        // length of 0 means "nothing was there to parse" and NOT necessarily
-        // "the caller sent an empty body".
+        // length is that of the COERCED string, and `coerce` answers `''` for
+        // two different kinds of value: one `JSON.stringify` THROWS on (a
+        // circular object) and one it RETURNS `undefined` for (a function, a
+        // symbol, a `toJSON` yielding undefined). So a reported length of 0
+        // means "nothing was there to parse" and NOT necessarily "the caller
+        // sent an empty body". The count is in UTF-16 code units, unlike the
+        // sibling message in `rie-client.ts`, which counts BYTES.
         //
         // `'unknown'` rather than `'SyntaxError'` on the non-Error arm: that
         // arm is unreachable today (this `JSON.parse` takes no reviver, so V8
@@ -936,7 +950,9 @@ function safeStringify(v: unknown): string {
   if (typeof v === 'string') return v;
   if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint') return String(v);
   try {
-    return JSON.stringify(v);
+    // See `coerce` above: `JSON.stringify` RETURNS `undefined` for a
+    // function / symbol / `toJSON`-returning-undefined rather than throwing.
+    return JSON.stringify(v) ?? '';
   } catch {
     return '';
   }

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -198,8 +198,36 @@ export function buildDefaultUtil(): VtlUtil {
       try {
         return JSON.parse(s);
       } catch (err) {
+        // NEVER interpolate the parser's own message here. V8 embeds a
+        // ~10-character prefix of the PARSED INPUT in `SyntaxError.message`
+        // (`Unexpected token 'h', "hunter2-my"... is not valid JSON`), and it
+        // appends `...` only past that window -- so a SHORT input is quoted
+        // in FULL rather than truncated. Under `start-api` the argument of
+        // `$util.parseJson(...)` is routinely `$input.body`, the incoming
+        // HTTP REQUEST BODY, which on a login endpoint carries the caller's
+        // password. The echo does not stop at the terminal either:
+        // `vtlFailure` in `rest-v1-integrations.ts` copies this message into
+        // the 502 RESPONSE BODY, sending the prefix back over the wire to
+        // whoever sent the request. Reported against the cdkd host as
+        // go-to-k/cdkd#2203.
+        //
+        // `err.name` is input-independent and safe as a discriminator, and
+        // the argument's LENGTH is reported because it is the one property of
+        // the input a developer can act on without being shown it. Note the
+        // length is that of the COERCED string: `coerce` answers `''` for a
+        // value `JSON.stringify` refuses (a circular object), so a reported
+        // length of 0 means "nothing was there to parse" and NOT necessarily
+        // "the caller sent an empty body".
+        //
+        // `'unknown'` rather than `'SyntaxError'` on the non-Error arm: that
+        // arm is unreachable today (this `JSON.parse` takes no reviver, so V8
+        // throws only a SyntaxError), and naming a class the throw was not
+        // would become a lie the moment it turns reachable.
+        const kind = err instanceof Error ? err.name : 'unknown';
         throw new VtlEvaluationError(
-          `$util.parseJson: invalid JSON input: ${err instanceof Error ? err.message : String(err)}`
+          `$util.parseJson: the argument is not valid JSON (${kind}; argument length ${s.length}). ` +
+            'The parser detail is withheld because it would echo a prefix of the parsed input, ' +
+            'which for a start-api request template can be the incoming HTTP request body.'
         );
       }
     },

--- a/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
@@ -75,6 +75,41 @@ export class LocalStartApiRestV1NonProxyStack extends cdk.Stack {
       }
     );
 
+    // MOCK parse-json-header — the request template runs `$util.parseJson`
+    // over a REQUEST HEADER, the vector the cdkd host reproduced the leak
+    // with (go-to-k/cdkd#2203). A header is the only request-carried value a
+    // MOCK template can see: `dispatchMockIntegration` builds its VTL context
+    // with a hardcoded EMPTY body, so `$input.body` is always `''` here --
+    // measured, after a first cut of this fixture used the body and the
+    // premise check below caught it answering 502 with `argument length 0`.
+    //
+    // A VALID JSON header renders `{"statusCode": 200}` and answers 200; a
+    // NON-JSON one throws `VtlEvaluationError`, which the REST v1 dispatcher
+    // turns into a 502 whose body carries the reason. verify.sh asserts BOTH
+    // directions, so an edit that stops the route reaching `$util.parseJson`
+    // fails loudly instead of silently disarming the redaction assertion.
+    const parseJsonHeader = api.root.addResource('parse-json-header');
+    parseJsonHeader.addMethod(
+      'POST',
+      new apigw.MockIntegration({
+        requestTemplates: {
+          'application/json':
+            "#set($parsed = $util.parseJson($input.params('xpayload')))\n{\"statusCode\": 200}",
+        },
+        integrationResponses: [
+          {
+            statusCode: '200',
+            responseTemplates: {
+              'application/json': '{"source":"mock","parsed":true}',
+            },
+          },
+        ],
+      }),
+      {
+        methodResponses: [{ statusCode: '200' }],
+      }
+    );
+
     // MOCK 404 — request template selects statusCode 404.
     const mock404 = api.root.addResource('mock-404');
     mock404.addMethod(
@@ -126,6 +161,38 @@ export class LocalStartApiRestV1NonProxyStack extends cdk.Stack {
         requestTemplates: {
           'application/json':
             '{"action": "$input.path(\'$.action\')", "name": "$input.path(\'$.name\')"}',
+        },
+        integrationResponses: [
+          {
+            statusCode: '200',
+            responseTemplates: {
+              'application/json': '{"data": $input.json("$.greeting")}',
+            },
+          },
+        ],
+      }),
+      {
+        methodResponses: [{ statusCode: '200' }],
+      }
+    );
+
+    // AWS Lambda non-proxy parse-json-body — the BODY vector of
+    // go-to-k/cdkd#2203. Unlike MOCK, `dispatchAwsLambdaIntegration` hands
+    // the real request body to the VTL context, so `$util.parseJson(
+    // $input.body)` here parses what the caller actually POSTed -- the
+    // login-endpoint shape the issue describes.
+    //
+    // The request template is evaluated BEFORE the Lambda is invoked, so the
+    // failing case costs no container round trip; the valid case does invoke
+    // it, which is what proves the route is wired rather than merely present.
+    const parseJsonBody = api.root.addResource('parse-json-body');
+    parseJsonBody.addMethod(
+      'POST',
+      new apigw.LambdaIntegration(handler, {
+        proxy: false,
+        requestTemplates: {
+          'application/json':
+            '#set($parsed = $util.parseJson($input.body))\n{"action": "greet", "name": "$parsed.name"}',
         },
         integrationResponses: [
           {

--- a/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
@@ -36,6 +36,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *     request body, invoke the Lambda, and shape the response via VTL
  *     into `{"data": "Hello, <name>"}`. The integ asserts that the
  *     request-side AND response-side VTL both fired.
+ *
+ *   - `POST /parse-json-header` — MOCK whose request template runs
+ *     `$util.parseJson` over a request HEADER, and
+ *     `POST /parse-json-body` — AWS (Lambda non-proxy) whose request
+ *     template runs it over the request BODY. Both cover
+ *     go-to-k/cdkd#2203: the failure message must not echo a prefix of
+ *     what it parsed, and `vtlFailure` copies that message into the 502
+ *     response body, so the assertion has to be made over HTTP. The two
+ *     vectors are separate because a MOCK template is handed a hardcoded
+ *     EMPTY body and can only see a header.
  */
 export class LocalStartApiRestV1NonProxyStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {

--- a/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
@@ -13,6 +13,12 @@
 #                       isolation — accepts 200 OR 502).
 #   - POST /aws-lambda -> AWS Lambda non-proxy integration with
 #                         request-side AND response-side VTL.
+#   - POST /parse-json-header -> MOCK whose request template runs
+#                         `$util.parseJson` over a request HEADER.
+#   - POST /parse-json-body   -> AWS Lambda non-proxy whose request template
+#                         runs `$util.parseJson` over the request BODY.
+#     Both assert the failure message does NOT echo the parsed input
+#     (go-to-k/cdkd#2203).
 #
 # Run via `/run-integ local-start-api-rest-v1-non-proxy` (recommended)
 # or directly:
@@ -225,17 +231,24 @@ assert_redacted() {
   fi
 
   # THE NEGATIVE: no byte of the caller's payload may appear anywhere in the
-  # response, nor in the server log -- the other reader of this message.
+  # response. This is THE assertion -- `vtlFailure` returns the reason in the
+  # 502 body, which is the channel the defect travelled on.
   if echo "${body}" | grep -q "${NEEDLE}"; then
     echo "FAIL: ${label}: the 502 body ECHOES the caller payload (${NEEDLE}) -- go-to-k/cdkd#2203 regressed."
     echo "      body was: ${body}"
     exit 1
   fi
+  # The server-log grep is a FORWARD fence, not a second proof: on today's
+  # code `vtlFailure` RETURNS the outcome and nothing on that path logs the
+  # reason, so this passes with the fix reverted. It is kept so that routing
+  # the reason to a log later cannot reintroduce the leak unnoticed -- stated
+  # rather than implied, because an assertion that cannot currently fail
+  # otherwise reads as evidence it is not.
   if grep -q "${NEEDLE}" "${LOG_FILE}"; then
     echo "FAIL: ${label}: the server log ECHOES the caller payload (${NEEDLE}) -- go-to-k/cdkd#2203 regressed."
     exit 1
   fi
-  echo "    ${label}: needle absent from BOTH the 502 body and the server log"
+  echo "    ${label}: needle absent from the 502 body (and from the server log, which does not carry it today)"
 }
 
 echo "==> HEADER vector premise: POST ${BASE_URL}/parse-json-header with a VALID JSON header"

--- a/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
@@ -176,4 +176,120 @@ if ! echo "${BODY}" | grep -q '"data"'; then
   exit 1
 fi
 
+# --- go-to-k/cdkd#2203: the VTL parse failure must not echo the input ----
+#
+# `$util.parseJson(<something the caller sent>)` is the shape that put a
+# prefix of the payload into the error message, and `vtlFailure` copies that
+# message into the 502 RESPONSE BODY -- so the leak crossed the HTTP
+# boundary, not just the terminal. Both request-carried vectors are covered:
+# a HEADER (MOCK; its VTL context is built with a hardcoded empty body) and
+# the BODY (AWS Lambda non-proxy, which gets the real body).
+#
+# Each vector proves its PREMISE in its own step first. Without that, a route
+# that stopped reaching `$util.parseJson` would make the redaction assertion
+# pass while fencing nothing -- which is exactly what the first cut of this
+# fixture did, answering 502 with `argument length 0` because MOCK zeroes
+# the body.
+#
+# The needle is 9 characters: V8 appends `...` only past its ~10-char
+# window, so a SHORT input is quoted in FULL. That is the shape a whole
+# password was recovered with.
+NEEDLE='hunter2pw'
+
+assert_redacted() {
+  local label="$1" body_file="$2" arg_len="$3"
+  local body
+  body="$(cat "${body_file}")"
+  echo "    body=${body}"
+
+  # POSITIVES first: "the needle is absent" alone is a confluence point that
+  # any unrelated failure -- including one that never ran the template --
+  # also satisfies.
+  if ! echo "${body}" | grep -q 'VTL request-template evaluation failed'; then
+    echo "FAIL: ${label}: 502 body is not the VTL failure envelope; body was: ${body}"
+    exit 1
+  fi
+  if ! echo "${body}" | grep -q 'util.parseJson: the argument is not valid JSON'; then
+    echo "FAIL: ${label}: 502 reason does not name the redacted parse failure; body was: ${body}"
+    exit 1
+  fi
+  if ! echo "${body}" | grep -q 'SyntaxError'; then
+    echo "FAIL: ${label}: 502 reason lost the input-independent discriminator; body was: ${body}"
+    exit 1
+  fi
+  # Anchored with the trailing `)`: a bare `argument length 9` is a substring
+  # of `argument length 90`, so an inflated count would slip through.
+  if ! echo "${body}" | grep -q "argument length ${arg_len})"; then
+    echo "FAIL: ${label}: 502 reason lost the argument-length detail; body was: ${body}"
+    exit 1
+  fi
+
+  # THE NEGATIVE: no byte of the caller's payload may appear anywhere in the
+  # response, nor in the server log -- the other reader of this message.
+  if echo "${body}" | grep -q "${NEEDLE}"; then
+    echo "FAIL: ${label}: the 502 body ECHOES the caller payload (${NEEDLE}) -- go-to-k/cdkd#2203 regressed."
+    echo "      body was: ${body}"
+    exit 1
+  fi
+  if grep -q "${NEEDLE}" "${LOG_FILE}"; then
+    echo "FAIL: ${label}: the server log ECHOES the caller payload (${NEEDLE}) -- go-to-k/cdkd#2203 regressed."
+    exit 1
+  fi
+  echo "    ${label}: needle absent from BOTH the 502 body and the server log"
+}
+
+echo "==> HEADER vector premise: POST ${BASE_URL}/parse-json-header with a VALID JSON header"
+STATUS="$(curl -sS -o /tmp/resp.body -w '%{http_code}' -X POST \
+  -H 'Content-Type: application/json' -H 'xpayload: {"any":"json"}' \
+  -d '{}' "${BASE_URL}/parse-json-header")"
+echo "    status=${STATUS}"
+if [[ "${STATUS}" != "200" ]]; then
+  echo "FAIL: /parse-json-header must answer 200 for a valid JSON header, got ${STATUS}."
+  echo "      The redaction assertion below would be INERT: the route is not reaching util.parseJson."
+  cat /tmp/resp.body
+  exit 1
+fi
+if ! grep -q '"parsed":true' /tmp/resp.body; then
+  echo "FAIL: /parse-json-header valid case did not render the response template; body was: $(cat /tmp/resp.body)"
+  exit 1
+fi
+
+echo "==> HEADER vector: POST ${BASE_URL}/parse-json-header with a NON-JSON header"
+STATUS="$(curl -sS -o /tmp/resp.body -w '%{http_code}' -X POST \
+  -H 'Content-Type: application/json' -H "xpayload: ${NEEDLE}" \
+  -d '{}' "${BASE_URL}/parse-json-header")"
+echo "    status=${STATUS}"
+if [[ "${STATUS}" != "502" ]]; then
+  echo "FAIL: expected 502 from /parse-json-header for a non-JSON header, got ${STATUS}"
+  cat /tmp/resp.body
+  exit 1
+fi
+assert_redacted "header vector" /tmp/resp.body "${#NEEDLE}"
+
+echo "==> BODY vector premise: POST ${BASE_URL}/parse-json-body with a VALID JSON body"
+OUT="$(assert_status "${BASE_URL}/parse-json-body" POST '{"name":"Alice"}')"
+STATUS="$(echo "${OUT}" | sed -n '1p')"
+echo "    status=${STATUS}"
+if [[ "${STATUS}" != "200" ]]; then
+  echo "FAIL: /parse-json-body must answer 200 for a valid JSON body, got ${STATUS}."
+  echo "      The redaction assertion below would be INERT: the route is not reaching util.parseJson."
+  cat /tmp/resp.body
+  exit 1
+fi
+if ! grep -q 'Hello, Alice' /tmp/resp.body; then
+  echo "FAIL: /parse-json-body valid case did not round-trip through the Lambda; body was: $(cat /tmp/resp.body)"
+  exit 1
+fi
+
+echo "==> BODY vector: POST ${BASE_URL}/parse-json-body with a NON-JSON body"
+OUT="$(assert_status "${BASE_URL}/parse-json-body" POST "${NEEDLE}")"
+STATUS="$(echo "${OUT}" | sed -n '1p')"
+echo "    status=${STATUS}"
+if [[ "${STATUS}" != "502" ]]; then
+  echo "FAIL: expected 502 from /parse-json-body for a non-JSON body, got ${STATUS}"
+  cat /tmp/resp.body
+  exit 1
+fi
+assert_redacted "body vector" /tmp/resp.body "${#NEEDLE}"
+
 echo "==> All REST v1 non-AWS_PROXY integration assertions passed (#457)"

--- a/tests/unit/local/rie-client-prelude-redaction.test.ts
+++ b/tests/unit/local/rie-client-prelude-redaction.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The RIE streaming prelude parse must not echo the bytes it parsed, because
+ * those bytes are not guaranteed to be protocol framing. `invokeRieStreaming`
+ * scans the WHOLE response for an 8-NUL run, and the commonest handler shape
+ * in the wild (`streamifyResponse` plus `setContentType` / `write`, never
+ * calling `HttpResponseStream.from`) sends no framing at all -- so an 8-NUL
+ * run inside binary output matches by coincidence and the "prelude" is a
+ * slice of raw function OUTPUT. Reported against the cdkd host as
+ * go-to-k/cdkd#2203.
+ *
+ * These exercise `invokeRieStreaming` end-to-end against a tiny local HTTP
+ * server rather than `parseStreamingPrelude` directly: the suppression lives
+ * at the CALLER, so a direct-parser test cannot see it.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { invokeRieStreaming } from '../../../src/local/rie-client.js';
+
+const SEPARATOR = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
+
+let server: Server;
+let port: number;
+type StreamHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void> | void;
+let nextStreamResponse: StreamHandler | undefined;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const handler = nextStreamResponse;
+    if (!handler) {
+      res.statusCode = 200;
+      res.end('{}');
+      return;
+    }
+    Promise.resolve()
+      .then(() => handler(req, res))
+      .catch(() => {
+        if (!res.headersSent) res.statusCode = 500;
+        if (!res.writableEnded) res.end();
+      });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('no port');
+  port = addr.port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+});
+
+/** Send `payload` as the whole response and return the rejection message. */
+async function rejectionMessage(payload: Buffer): Promise<string> {
+  nextStreamResponse = (_req, res) => {
+    res.writeHead(200);
+    res.end(payload);
+  };
+  try {
+    await invokeRieStreaming('127.0.0.1', port, {}, 5000);
+  } catch (err) {
+    return (err as Error).message;
+  }
+  return expect.fail('invokeRieStreaming should have rejected on an unparseable prelude');
+}
+
+describe('invokeRieStreaming prelude failure message (go-to-k/cdkd#2203)', () => {
+  it('withholds the ~10-character prefix V8 quotes from a spurious NUL match in binary output', async () => {
+    // A tar stream is the sharpest instance: its 512-byte member header
+    // NUL-pads everything after the 100-byte name field, so the FIRST 8-NUL
+    // run sits immediately after the file name. `preludeBytes` becomes that
+    // name, and on Node 24.15 the parser answers
+    // `Unexpected token 'c', "customer-d"... is not valid JSON`.
+    const name = 'customer-database-dump.sql';
+    const tarHeader = Buffer.alloc(512);
+    tarHeader.write(name, 0, 'utf8');
+    const message = await rejectionMessage(
+      Buffer.concat([tarHeader, Buffer.from('...archive payload...')])
+    );
+
+    // The needle is the PREFIX, not the whole name: `not.toContain(name)`
+    // would pass WITHOUT the fix, since V8 never emits past its window.
+    expect(message).not.toContain('customer-d');
+
+    expect(message).toContain('prelude is not valid JSON');
+    expect(message).toContain('SyntaxError');
+    // Anchored on both sides: a bare `26 bytes before` is a substring of
+    // `126 bytes before`, so an inflated count would pass unnoticed.
+    expect(message).toContain(`; ${name.length} bytes before the 8-NUL separator`);
+    // Anchored to the whole remediation clause: the diagnosis sentence above
+    // it also names `HttpResponseStream.from`, so a bare symbol match stays
+    // green with the remediation deleted.
+    expect(message).toContain('calling HttpResponseStream.from(...) frames the response explicitly');
+  });
+
+  it('withholds a SHORT prelude, which V8 quotes in FULL rather than truncating', async () => {
+    // Second leak shape: V8 appends `...` only past its prefix window, so
+    // `JSON.parse('not-json{')` quotes the whole string.
+    const bogus = 'not-json{';
+    const message = await rejectionMessage(
+      Buffer.concat([Buffer.from(bogus), SEPARATOR, Buffer.from('body')])
+    );
+
+    expect(message).not.toContain(bogus);
+
+    expect(message).toContain('prelude is not valid JSON');
+    expect(message).toContain('SyntaxError');
+    expect(message).toContain(`; ${bogus.length} bytes before the 8-NUL separator`);
+  });
+
+  // --- the three input-INDEPENDENT throws must stay legible -------------
+  //
+  // `parseStreamingPrelude` throws four ways and only the `JSON.parse` one
+  // carries the parsed bytes. Suppressing the other three buys no privacy
+  // and ships a FALSE diagnosis -- a correctly-framed handler being told its
+  // valid JSON is "not valid JSON", with advice to call a function it already
+  // called. These fence the `err instanceof SyntaxError` gate.
+
+  it('keeps the non-object-prelude diagnosis verbatim (valid JSON, wrong shape)', async () => {
+    const message = await rejectionMessage(
+      Buffer.concat([Buffer.from('"a string"'), SEPARATOR, Buffer.from('body')])
+    );
+
+    expect(message).toContain('prelude is not a JSON object');
+    // The false diagnosis this gate exists to prevent.
+    expect(message).not.toContain('is not valid JSON');
+    expect(message).not.toContain('HttpResponseStream.from');
+  });
+
+  it('keeps the statusCode diagnosis verbatim (valid JSON object, bad statusCode)', async () => {
+    const message = await rejectionMessage(
+      Buffer.concat([Buffer.from('{"foo":1}'), SEPARATOR, Buffer.from('body')])
+    );
+
+    expect(message).toContain('statusCode must be a number');
+    expect(message).toContain('got undefined');
+    expect(message).not.toContain('is not valid JSON');
+    expect(message).not.toContain('HttpResponseStream.from');
+  });
+
+  it('keeps the empty-prelude diagnosis verbatim', async () => {
+    // Whitespace-only bytes before the separator: non-empty, so the
+    // synthesized-prelude path is not taken, but `trim()` empties it.
+    const message = await rejectionMessage(
+      Buffer.concat([Buffer.from('   '), SEPARATOR, Buffer.from('body')])
+    );
+
+    expect(message).toContain('empty prelude');
+    expect(message).not.toContain('is not valid JSON');
+    expect(message).not.toContain('HttpResponseStream.from');
+  });
+});

--- a/tests/unit/local/rie-client-prelude-redaction.test.ts
+++ b/tests/unit/local/rie-client-prelude-redaction.test.ts
@@ -109,6 +109,25 @@ describe('invokeRieStreaming prelude failure message (go-to-k/cdkd#2203)', () =>
     expect(message).toContain(`; ${bogus.length} bytes before the 8-NUL separator`);
   });
 
+  it('counts BYTES, not UTF-16 code units, in the reported prelude size', () => {
+    // Both other fixtures are pure ASCII, where the two counts coincide -- so
+    // a mutation to `preludeBytes.toString('utf8').length` would survive them.
+    // Four 3-byte characters are 12 bytes and 4 code units.
+    const multibyte = '\u3042\u3044\u3046\u3048'; // 4 chars, 12 bytes in UTF-8
+    const preludeBuf = Buffer.from(multibyte, 'utf8');
+    expect(preludeBuf.length).toBe(12);
+    expect(multibyte.length).toBe(4);
+
+    return rejectionMessage(
+      Buffer.concat([preludeBuf, SEPARATOR, Buffer.from('body')])
+    ).then((message) => {
+      expect(message).toContain('; 12 bytes before the 8-NUL separator');
+      expect(message).not.toContain('; 4 bytes before the 8-NUL separator');
+      expect(message).not.toContain(multibyte);
+      expect(message).not.toContain('Unexpected token');
+    });
+  });
+
   // --- the three input-INDEPENDENT throws must stay legible -------------
   //
   // `parseStreamingPrelude` throws four ways and only the `JSON.parse` one

--- a/tests/unit/local/vtl-engine-parse-json-redaction.test.ts
+++ b/tests/unit/local/vtl-engine-parse-json-redaction.test.ts
@@ -58,6 +58,10 @@ describe('$util.parseJson failure message (go-to-k/cdkd#2203)', () => {
     const message = parseJsonFailure(body);
 
     expect(message).not.toContain('hunter2-my');
+    // Also fence the parser's PHRASING, not just the quoted segment: a
+    // message that kept `Unexpected token 'h', is not valid JSON` with only
+    // the quote stripped still leaks the first character and the offset.
+    expect(message).not.toContain('Unexpected token');
 
     expect(message).toContain('$util.parseJson');
     expect(message).toContain('SyntaxError');
@@ -75,29 +79,54 @@ describe('$util.parseJson failure message (go-to-k/cdkd#2203)', () => {
     const message = parseJsonFailure(body);
 
     expect(message).not.toContain(body);
+    expect(message).not.toContain('Unexpected token');
 
     expect(message).toContain('$util.parseJson');
     expect(message).toContain('SyntaxError');
     expect(message).toContain('argument length 4)');
   });
 
-  it('reports the COERCED length, so a circular argument is not called an empty body', () => {
-    // `coerce` answers `''` for a value `JSON.stringify` refuses, so the
-    // reported length is 0 for a non-empty argument. The message therefore
-    // says "argument length 0" and deliberately does NOT claim the caller
-    // sent an empty body.
+  it('reports the COERCED length for every value that coerces to the empty string', () => {
+    // `coerce` answers `''` two different ways, and only one of them was
+    // covered before: `JSON.stringify` THROWS on a circular object, and
+    // RETURNS `undefined` for a function / symbol / `toJSON`-yielding-
+    // undefined. The second kind used to make `s.length` throw a TypeError,
+    // so the caller got something OTHER than a `VtlEvaluationError` -- the
+    // class hosts are documented to be able to `instanceof`.
     const circular: Record<string, unknown> = {};
     circular['self'] = circular;
-    const util = buildDefaultUtil();
+    const toJsonUndefined = { toJSON: () => undefined };
 
-    let message = '';
-    try {
-      util.parseJson(circular);
-    } catch (err) {
-      message = (err as Error).message;
+    for (const [label, value] of [
+      ['circular (stringify throws)', circular],
+      ['function (stringify returns undefined)', () => 'x'],
+      ['symbol (stringify returns undefined)', Symbol('s')],
+      ['toJSON -> undefined', toJsonUndefined],
+    ] as const) {
+      let caught: unknown;
+      try {
+        buildDefaultUtil().parseJson(value);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught, label).toBeInstanceOf(VtlEvaluationError);
+      expect((caught as Error).message, label).toContain('argument length 0)');
     }
+  });
 
-    expect(message).toContain('argument length 0)');
-    expect(message).not.toContain('empty body');
+  it('reaches the empty-coercion path from a TEMPLATE, not just a direct call', () => {
+    // `$input.json` / `$input.path` / `$input.params` are own-property
+    // FUNCTIONS on the object `buildVtlInput` returns, so forgetting the call
+    // parens hands one straight to `$util.parseJson`. This is the reachable
+    // spelling of the case above.
+    const ctx = contextWithBody('{"a":1}');
+    let caught: unknown;
+    try {
+      evaluateVtl('$util.parseJson($input.params)', ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(VtlEvaluationError);
+    expect((caught as Error).message).toContain('argument length 0)');
   });
 });

--- a/tests/unit/local/vtl-engine-parse-json-redaction.test.ts
+++ b/tests/unit/local/vtl-engine-parse-json-redaction.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `$util.parseJson` must not echo a prefix of the argument it failed to
+ * parse. Under `start-api` that argument is routinely `$input.body` -- the
+ * incoming HTTP request body, which on a login endpoint carries the caller's
+ * password -- and V8 embeds a prefix of the PARSED INPUT in
+ * `SyntaxError.message`. The echo also reaches the wire, because
+ * `vtlFailure` in `rest-v1-integrations.ts` copies the reason into the 502
+ * response body. Reported against the cdkd host as go-to-k/cdkd#2203.
+ *
+ * Each case pairs the negative with POSITIVES: "the needle is absent" on its
+ * own is a confluence point that any unrelated rejection also satisfies, so
+ * the discriminators that must SURVIVE are asserted too.
+ */
+
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildDefaultUtil,
+  buildVtlInput,
+  buildVtlRequestContext,
+  evaluateVtl,
+  VtlEvaluationError,
+  type VtlContext,
+} from '../../../src/local/vtl-engine.js';
+
+function contextWithBody(body: string): VtlContext {
+  return {
+    input: buildVtlInput(body, {}, {}, {}),
+    context: buildVtlRequestContext({
+      requestId: 'req-1',
+      httpMethod: 'POST',
+      resourcePath: '/login',
+      stage: 'prod',
+      sourceIp: '1.2.3.4',
+      userAgent: 'test-agent',
+    }),
+    util: buildDefaultUtil(),
+  };
+}
+
+/** Render `$util.parseJson($input.body)` and return the failure message. */
+function parseJsonFailure(body: string): string {
+  try {
+    evaluateVtl('$util.parseJson($input.body)', contextWithBody(body));
+  } catch (err) {
+    expect(err).toBeInstanceOf(VtlEvaluationError);
+    return (err as Error).message;
+  }
+  return expect.fail('$util.parseJson should have thrown on a non-JSON body');
+}
+
+describe('$util.parseJson failure message (go-to-k/cdkd#2203)', () => {
+  it('withholds the ~10-character prefix V8 quotes from a long body', () => {
+    // `JSON.parse('hunter2-my-db-password')` answers
+    // `Unexpected token 'h', "hunter2-my"... is not valid JSON` on Node 24.15.
+    // The needle is the PREFIX, not the whole body: `not.toContain(body)`
+    // would pass WITHOUT the fix, since V8 never emits past its window.
+    const body = 'hunter2-my-db-password';
+    const message = parseJsonFailure(body);
+
+    expect(message).not.toContain('hunter2-my');
+
+    expect(message).toContain('$util.parseJson');
+    expect(message).toContain('SyntaxError');
+    // Anchored with the trailing `)`: a bare `argument length 22` is a
+    // substring of `argument length 220`, so an inflated count would pass.
+    expect(message).toContain(`argument length ${body.length})`);
+  });
+
+  it('withholds a SHORT body, which V8 quotes in FULL rather than truncating', () => {
+    // A distinct leak shape: V8 appends `...` only past its prefix window, so
+    // `JSON.parse('pw42')` quotes the whole string. A guard written only
+    // against the truncated shape misses this one entirely, and this is the
+    // shape the cdkd host reproduced over HTTP with a real header value.
+    const body = 'pw42';
+    const message = parseJsonFailure(body);
+
+    expect(message).not.toContain(body);
+
+    expect(message).toContain('$util.parseJson');
+    expect(message).toContain('SyntaxError');
+    expect(message).toContain('argument length 4)');
+  });
+
+  it('reports the COERCED length, so a circular argument is not called an empty body', () => {
+    // `coerce` answers `''` for a value `JSON.stringify` refuses, so the
+    // reported length is 0 for a non-empty argument. The message therefore
+    // says "argument length 0" and deliberately does NOT claim the caller
+    // sent an empty body.
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    const util = buildDefaultUtil();
+
+    let message = '';
+    try {
+      util.parseJson(circular);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+
+    expect(message).toContain('argument length 0)');
+    expect(message).not.toContain('empty body');
+  });
+});

--- a/tests/unit/local/vtl-engine-parse-json-redaction.test.ts
+++ b/tests/unit/local/vtl-engine-parse-json-redaction.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, it } from 'vite-plus/test';
+import { dispatchMockIntegration } from '../../../src/local/rest-v1-integrations.js';
 import {
   buildDefaultUtil,
   buildVtlInput,
@@ -128,5 +129,57 @@ describe('$util.parseJson failure message (go-to-k/cdkd#2203)', () => {
     }
     expect(caught).toBeInstanceOf(VtlEvaluationError);
     expect((caught as Error).message).toContain('argument length 0)');
+  });
+});
+
+describe('the 502 RESPONSE BODY must not carry the parsed input (go-to-k/cdkd#2203)', () => {
+  // The reason reaches the WIRE, not just a terminal: `vtlFailure` copies the
+  // VTL failure message into the 502 body. That channel had only Docker-gated
+  // coverage (the `local-start-api-rest-v1-non-proxy` integ arm); this case
+  // fences it with no container, so a regression INSIDE `vtlFailure` -- say
+  // attaching the raw `err`, or dropping the template truncation -- reds in
+  // the ordinary unit run.
+  //
+  // A MOCK integration is the cheapest reachable spelling: its VTL context is
+  // built with a hardcoded EMPTY body, so the caller-supplied value has to be
+  // a header, which is also the vector the leak was reproduced with.
+  function mockRequestWithHeader(value: string) {
+    return {
+      method: 'POST',
+      matchedPath: '/login',
+      pathParameters: {},
+      querystring: {},
+      headers: { xpayload: value },
+      body: Buffer.alloc(0),
+      sourceIp: '1.2.3.4',
+      userAgent: 'test-agent',
+      stage: 'prod',
+      resourcePath: '/login',
+      requestId: 'req-1',
+    };
+  }
+
+  it('returns 502 without the header value the template failed to parse', () => {
+    const needle = 'hunter2pw';
+    const outcome = dispatchMockIntegration(
+      {
+        kind: 'mock',
+        requestTemplate: '#set($p = $util.parseJson($input.params(\'xpayload\')))\n{"statusCode": 200}',
+        responses: [{ StatusCode: '200', ResponseTemplates: { 'application/json': '{"ok":true}' } }],
+      },
+      mockRequestWithHeader(needle)
+    );
+
+    expect(outcome.statusCode).toBe(502);
+    const body = outcome.body.toString();
+
+    // Positives first -- absence alone is satisfied by any unrelated failure.
+    expect(body).toContain('VTL request-template evaluation failed');
+    expect(body).toContain('$util.parseJson');
+    expect(body).toContain('SyntaxError');
+    expect(body).toContain(`argument length ${needle.length})`);
+
+    expect(body).not.toContain(needle);
+    expect(body).not.toContain('Unexpected token');
   });
 });


### PR DESCRIPTION
Reported against the cdkd host as [go-to-k/cdkd#2203](https://github.com/go-to-k/cdkd/issues/2203). cdkd first fixed its own forked copies of these files, then found the fork is not on the shipped path -- cdkd`s `src/local/http-server.ts` re-exports `startApiServer` from `cdk-local/internal`, so `cdkd local start-api` runs THIS code. This PR is the fix that actually reaches users.

## The defect

Two sites interpolated a parser`s own message into their error. V8 embeds a prefix of the PARSED INPUT in `SyntaxError.message`, and appends `...` only past its ~10-character window -- so a SHORT input is quoted in FULL:

```
JSON.parse("hunter2-my-db-password")  ->  Unexpected token h, "hunter2-my"... is not valid JSON
JSON.parse("hunter2pw")               ->  Unexpected token h, "hunter2pw" is not valid JSON
```

**`src/local/vtl-engine.ts`** -- under `start-api` the argument of `$util.parseJson(...)` is routinely a value the caller sent (`$input.body`, or a header via `$input.params(...)`). The echo does not stop at the terminal: `vtlFailure` in `rest-v1-integrations.ts` copies the reason into the **502 RESPONSE BODY**, sending it back over the wire to whoever sent the request. Reproduced live against this branch: a 9-character non-JSON header came back whole.

**`src/local/rie-client.ts`** -- the prelude bytes are NOT guaranteed to be protocol framing. `invokeRieStreaming` scans the response for an 8-NUL run, and the unframed-response block above it records that the commonest handler shape in the wild (`streamifyResponse` plus `setContentType` / `write`, never calling `HttpResponseStream.from`) sends no framing at all -- so what is scanned is raw function OUTPUT. An 8-NUL run inside binary output matches by coincidence and the "prelude" becomes application data. Reproduced with a tar stream, whose 512-byte member header NUL-pads everything after the name field: the first run sits immediately after the file name, and the parser answers `Unexpected token c, "customer-d"... is not valid JSON`.

## What changed

Both messages carry `err.name` plus a fixed discriminator and state outright that the parser detail is withheld, so a later contributor does not helpfully restore it.

**Only the `JSON.parse` failure is suppressed.** `parseStreamingPrelude` throws four ways; the other three (`empty prelude`, `prelude is not a JSON object`, `statusCode must be a number (got <typeof>)`) are input-INDEPENDENT. Suppressing them would buy no privacy while telling a correctly-framed handler that its valid JSON is "not valid JSON", with advice to call a function it already called -- so the throw is gated on `err instanceof SyntaxError` and the rest stay verbatim.

Each message keeps a detail the prefix never gave: the argument LENGTH, and the byte count before the separator. `rie-client` leads with the MISREAD rather than blaming the handler, because the unframed shape is one this code deliberately supports -- framing is offered as a way to rule the misread out, not as the diagnosis.

## A blocker this PR introduced and then fixed

Reading `s.length` in the new message exposed a latent hole: `coerce` is typed `=> string` but returned `undefined`, because `JSON.stringify` RETURNS `undefined` (it does not throw) for a function, a symbol, or an object whose `toJSON` yields undefined -- TypeScript hides it because `JSON.stringify(unknown)` selects the `any` overload. Reachable from an ordinary template, since `$input.json` / `$input.path` / `$input.params` are own-property FUNCTIONS on the object `buildVtlInput` returns: `$util.parseJson($input.params)`, the call parens forgotten, threw a `TypeError` instead of the diagnosis -- so what escaped `evaluateVtl` was no longer the `VtlEvaluationError` that `src/internal.ts` documents a host being able to `instanceof`. Fixed with `?? ""`, in `coerce` and in `safeStringify`, which carried the same hole.

## Verification

- `vp run verify` green: 213 test files, 3178 tests, 0 errors.
- **Live integ arm** added to `local-start-api-rest-v1-non-proxy`, covering both request-carried vectors -- a HEADER (MOCK, whose VTL context is built with a hardcoded empty body) and the BODY (AWS Lambda non-proxy). Each proves its PREMISE in its own step first, because a route that stopped reaching `$util.parseJson` would make "the needle is absent" pass while fencing nothing -- which is exactly what the first cut did, answering 502 with `argument length 0`.
- **Live-arm mutation probe**: reverting the interpolation, rebuilding `dist/`, and re-running the fixture reds it, with the pre-fix 502 body carrying `Unexpected token h, "hunter2pw" is not valid JSON` verbatim. Docker sweep empty on every run.
- **13 unit mutation probes**, all red: the two anchor probes (length x10, byte count +100), the gate probe (widening `instanceof SyntaxError` to `instanceof Error` reds all three legibility cases), the `?? ""` probe, and the byte-vs-char probe.
- Count needles are anchored on their delimiters, since `argument length 4` is a substring of `argument length 40` and `26 bytes before` of `126 bytes before`.
- The 502 channel also has Docker-free coverage via a `dispatchMockIntegration` case, so a regression inside `vtlFailure` reds without a container.

## Review

Three reviewers (code / test / security). One blocker (the `coerce` hole above) plus six findings, all dispositioned: fixed here, or filed as #554 / #555.

Two vacuous assertions were DELETED rather than kept -- a whole-input negative that held with the fix reverted (V8 never emits past its window), and a `not.toContain("empty body")` on a string no version of the message contains. An assertion that cannot fail reads as protection that is not there.

## Follow-ups filed

- **#554** -- the SAME parser-message echo over the SECRET population, in `ecs-secrets-resolver.ts`. This is the defect the cdkd host fixed as go-to-k/cdkd#2189; it was never ported here, and `cdkl run-task` reaches it. Two sibling sites in `cloudfront-kvs.ts`. **Severity high** -- worth looking at next.
- **#555** -- four debug/info log sites echoing caller-supplied request data.