### PR TITLE
fix(local): stop echoing the secret plaintext in the ECS json-key JSON-parse failure message

### DIFF
--- a/src/local/cloudfront-kvs.ts
+++ b/src/local/cloudfront-kvs.ts
@@ -137,6 +137,22 @@ function makeHandle(source: KvsDataSource): CloudFrontKvsHandle {
         try {
           return JSON.parse(value) as unknown;
         } catch (err) {
+          // The parser message carries a prefix of the parsed input (V8 embeds
+          // one in `SyntaxError.message`, quoting a short input in FULL), and
+          // that is deliberately KEPT here. Reviewed against issue #554's
+          // criterion -- "does the throwing operation consume material the
+          // library RESOLVED from a secret / parameter store?" -- and the
+          // answer is no on both bindings this handle can be built over:
+          // `createLocalFileKvsDataSource` reads the developer's OWN
+          // `--kvs-file` JSON, and the `--from-cfn-stack` binding reads a
+          // deployed CloudFront KeyValueStore, a plaintext edge-config store
+          // rather than a secret store. Nor does the echo reach the wire the
+          // way the `$util.parseJson` one did (PR #556): a rejected
+          // `cf.kvs()` read propagates out of the function sandbox to
+          // `cloudfront-server.ts`'s top-level handler, which logs it and
+          // answers a FIXED 500 body. Echoing the parser detail is what makes
+          // a malformed stored value diagnosable, so it stays. Re-raising
+          // this site needs one of those three facts to have changed.
           throw new Error(
             `cf.kvs().get('${key}', { format: 'json' }): value is not valid JSON: ${
               err instanceof Error ? err.message : String(err)
@@ -191,6 +207,11 @@ export function createLocalFileKvsDataSource(args: {
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
+    // Parser detail KEPT, same review as the `format: 'json'` site above
+    // (issue #554). What is parsed here is a file the developer wrote and
+    // named on their own command line, not material this library resolved
+    // from a secret / parameter store, and the message names that file --
+    // so the quoted fragment is how they find the syntax error in it.
     throw new Error(
       `--kvs-file '${args.id}=${args.filePath}': not valid JSON: ${
         err instanceof Error ? err.message : String(err)

--- a/src/local/cloudfront-kvs.ts
+++ b/src/local/cloudfront-kvs.ts
@@ -142,11 +142,16 @@ function makeHandle(source: KvsDataSource): CloudFrontKvsHandle {
           // that is deliberately KEPT here. Reviewed against issue #554's
           // criterion -- "does the throwing operation consume material the
           // library RESOLVED from a secret / parameter store?" -- and the
-          // answer is no on both bindings this handle can be built over:
-          // `createLocalFileKvsDataSource` reads the developer's OWN
-          // `--kvs-file` JSON, and the `--from-cfn-stack` binding reads a
+          // answer is no on either binding cdk-local's own CLI builds this
+          // handle over: `createLocalFileKvsDataSource` reads the developer's
+          // OWN `--kvs-file` JSON, and the `--from-cfn-stack` binding reads a
           // deployed CloudFront KeyValueStore, a plaintext edge-config store
-          // rather than a secret store. Nor does the echo reach the wire the
+          // rather than a secret store. That is a statement about THIS CLI,
+          // not about every caller: `createCloudFrontModule` and
+          // `KvsDataSource` ship through the `cdk-local/internal` subpath, so
+          // an embedding host can supply a source backed by anything it
+          // likes, and such a source inherits this echo. Nor does the echo
+          // reach the wire the
           // way the `$util.parseJson` one did (PR #556): a rejected
           // `cf.kvs()` read propagates out of the function sandbox to
           // `cloudfront-server.ts`'s top-level handler, which logs it and
@@ -211,7 +216,13 @@ export function createLocalFileKvsDataSource(args: {
     // (issue #554). What is parsed here is a file the developer wrote and
     // named on their own command line, not material this library resolved
     // from a secret / parameter store, and the message names that file --
-    // so the quoted fragment is how they find the syntax error in it.
+    // so the quoted fragment is how they find the syntax error in it. The
+    // `--env-vars` file parsers (`local-invoke.ts`, `local-run-task.ts`,
+    // `local-start-api.ts`, `local-invoke-agentcore.ts`,
+    // `ecs-service-emulator.ts`) are the same class and were reviewed the
+    // same way, even though such a file routinely holds secret env values:
+    // the developer supplied the file, and naming its syntax error is the
+    // whole point of the message.
     throw new Error(
       `--kvs-file '${args.id}=${args.filePath}': not valid JSON: ${
         err instanceof Error ? err.message : String(err)

--- a/src/local/cloudfront-kvs.ts
+++ b/src/local/cloudfront-kvs.ts
@@ -146,18 +146,23 @@ function makeHandle(source: KvsDataSource): CloudFrontKvsHandle {
           // handle over: `createLocalFileKvsDataSource` reads the developer's
           // OWN `--kvs-file` JSON, and the `--from-cfn-stack` binding reads a
           // deployed CloudFront KeyValueStore, a plaintext edge-config store
-          // rather than a secret store. That is a statement about THIS CLI,
-          // not about every caller: `createCloudFrontModule` and
-          // `KvsDataSource` ship through the `cdk-local/internal` subpath, so
-          // an embedding host can supply a source backed by anything it
-          // likes, and such a source inherits this echo. Nor does the echo
-          // reach the wire the
+          // rather than a secret store. Nor does the echo reach the wire the
           // way the `$util.parseJson` one did (PR #556): a rejected
           // `cf.kvs()` read propagates out of the function sandbox to
           // `cloudfront-server.ts`'s top-level handler, which logs it and
           // answers a FIXED 500 body. Echoing the parser detail is what makes
           // a malformed stored value diagnosable, so it stays. Re-raising
-          // this site needs one of those three facts to have changed.
+          // this site needs one of those facts to have changed.
+          //
+          // BOTH of those facts are about THIS CLI, and the caveat is
+          // accepted rather than merely noted. `createCloudFrontModule` and
+          // `KvsDataSource` ship through the `cdk-local/internal` subpath, so
+          // an embedding host can back a source with anything it likes AND
+          // need not route the rejection through that fixed-500 handler --
+          // in-repo the only caller is `cloudfront-kvs-binding.ts`. Such a
+          // host owns both halves of that decision, and the unstable subpath
+          // carries no semver guarantee, so the echo is not narrowed for a
+          // caller cdk-local cannot see.
           throw new Error(
             `cf.kvs().get('${key}', { format: 'json' }): value is not valid JSON: ${
               err instanceof Error ? err.message : String(err)
@@ -217,10 +222,11 @@ export function createLocalFileKvsDataSource(args: {
     // named on their own command line, not material this library resolved
     // from a secret / parameter store, and the message names that file --
     // so the quoted fragment is how they find the syntax error in it. The
-    // `--env-vars` file parsers (`local-invoke.ts`, `local-run-task.ts`,
-    // `local-start-api.ts`, `local-invoke-agentcore.ts`,
-    // `ecs-service-emulator.ts`) are the same class and were reviewed the
-    // same way, even though such a file routinely holds secret env values:
+    // five `--env-vars` file parsers under `src/cli/commands/`
+    // (`local-invoke.ts`, `local-run-task.ts`, `local-start-api.ts`,
+    // `local-invoke-agentcore.ts`, `ecs-service-emulator.ts`) are the same
+    // class and were reviewed the same way, even though such a file
+    // routinely holds secret env values:
     // the developer supplied the file, and naming its syntax error is the
     // whole point of the message.
     throw new Error(

--- a/src/local/ecs-secrets-resolver.ts
+++ b/src/local/ecs-secrets-resolver.ts
@@ -204,20 +204,27 @@ async function resolveSecretsManager(
   try {
     parsed = JSON.parse(secretString);
   } catch (err) {
-    // NEVER interpolate the parser's own message here. V8 embeds a ~10-char
-    // prefix of the PARSED INPUT in `SyntaxError.message`
-    // (`Unexpected token 's', "supersecre"... is not valid JSON`), and appends
-    // `...` only PAST that window -- so a short secret is quoted in FULL
-    // rather than truncated. The parsed input IS the secret plaintext this
-    // resolver just fetched from Secrets Manager, so echoing it puts the
-    // secret on stderr and into any surrounding log capture (issue #554;
-    // fixed in the cdkd host as go-to-k/cdkd#2189). Reaching it needs no
-    // hostile input -- a plain-string secret plus a `:json-key::` ValueFrom
-    // is an ordinary user mistake.
+    // NEVER interpolate the parser's own message here. V8 embeds a prefix of
+    // the PARSED INPUT in `SyntaxError.message`
+    // (`Unexpected token 's', "supersecre"... is not valid JSON`), and it
+    // TRUNCATES to that ~10-character prefix only for a long input: measured
+    // on Node 24.15, an input of 20 characters or fewer is quoted in FULL,
+    // and `...` first appears at 21. So a short secret leaks whole. The
+    // parsed input IS the secret plaintext this resolver just fetched from
+    // Secrets Manager, so echoing it puts the secret on stderr and into any
+    // surrounding log capture (issue #554; reported against the cdkd host as
+    // go-to-k/cdkd#2189 and fixed there by go-to-k/cdkd#2214, whose message
+    // this one matches). Reaching it needs no hostile input -- a plain-string
+    // secret plus a `:json-key::` ValueFrom is an ordinary user mistake.
     //
     // `err.name` is input-independent and safe as a discriminator; the
     // container, env var and requested json-key already make the message
-    // actionable without showing any of the value.
+    // actionable without showing any of the value. Deliberately NOT reported:
+    // the input's LENGTH, which the sibling `$util.parseJson` message in
+    // `vtl-engine.ts` does give. There the argument is an anonymous HTTP body
+    // whose size is the only actionable property; here the user already knows
+    // WHICH secret this is and can read it at the source, so a character
+    // count would be disclosure buying nothing. Do not "harmonize" them.
     //
     // `'unknown'` rather than `'SyntaxError'` for the non-Error arm: it is
     // unreachable today (this `JSON.parse` takes no reviver, so V8 throws

--- a/src/local/ecs-secrets-resolver.ts
+++ b/src/local/ecs-secrets-resolver.ts
@@ -186,6 +186,14 @@ async function resolveSecretsManager(
     const resp = await client.send(new GetSecretValueCommand({ SecretId: shape.baseArn }));
     secretString = resp.SecretString;
   } catch (err) {
+    // Parser/transport detail KEPT, unlike the `JSON.parse` catch below.
+    // Reviewed under issue #554's criterion and excluded on the same ground
+    // as the `cloudfront-kvs.ts` echoes: this throw fires BEFORE any value
+    // exists -- `secretString` is still undefined -- so what it relays is an
+    // AWS SDK error about the ARN (AccessDenied, ResourceNotFound,
+    // throttling), which is exactly what makes a credential or IAM problem
+    // diagnosable. It is the one throw in this function the sibling-branch
+    // test block deliberately does not cover, and this is why.
     throw new EcsSecretsResolutionError(
       `Failed to resolve Secrets Manager secret for container '${entry.containerName}' / env '${entry.name}' (${shape.baseArn}): ${
         err instanceof Error ? err.message : String(err)

--- a/src/local/ecs-secrets-resolver.ts
+++ b/src/local/ecs-secrets-resolver.ts
@@ -204,10 +204,29 @@ async function resolveSecretsManager(
   try {
     parsed = JSON.parse(secretString);
   } catch (err) {
+    // NEVER interpolate the parser's own message here. V8 embeds a ~10-char
+    // prefix of the PARSED INPUT in `SyntaxError.message`
+    // (`Unexpected token 's', "supersecre"... is not valid JSON`), and appends
+    // `...` only PAST that window -- so a short secret is quoted in FULL
+    // rather than truncated. The parsed input IS the secret plaintext this
+    // resolver just fetched from Secrets Manager, so echoing it puts the
+    // secret on stderr and into any surrounding log capture (issue #554;
+    // fixed in the cdkd host as go-to-k/cdkd#2189). Reaching it needs no
+    // hostile input -- a plain-string secret plus a `:json-key::` ValueFrom
+    // is an ordinary user mistake.
+    //
+    // `err.name` is input-independent and safe as a discriminator; the
+    // container, env var and requested json-key already make the message
+    // actionable without showing any of the value.
+    //
+    // `'unknown'` rather than `'SyntaxError'` for the non-Error arm: it is
+    // unreachable today (this `JSON.parse` takes no reviver, so V8 throws
+    // only a SyntaxError), and reporting a class the throw was not would
+    // become a lie the moment it turns reachable.
+    const kind = err instanceof Error ? err.name : 'unknown';
     throw new EcsSecretsResolutionError(
-      `Container '${entry.containerName}' secret '${entry.name}' specified json-key '${shape.jsonKey}' but the secret value is not valid JSON: ${
-        err instanceof Error ? err.message : String(err)
-      }`
+      `Container '${entry.containerName}' secret '${entry.name}' specified json-key '${shape.jsonKey}' but the secret value is not valid JSON (${kind}). ` +
+        'The parser detail is withheld because it would echo the secret plaintext.'
     );
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/tests/unit/local/ecs-secrets-resolver-json-key-redaction.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-json-key-redaction.test.ts
@@ -105,9 +105,10 @@ describe('resolveEcsSecrets json-key parse failure (issue #554)', () => {
   });
 
   it('withholds a SHORT secret, which V8 quotes in FULL rather than truncating', async () => {
-    // The worst case and a distinct leak shape: V8 appends `...` only PAST its
-    // prefix window, so `JSON.parse('pw42')` quotes the whole string. A guard
-    // written only against the truncated shape misses this one entirely.
+    // The worst case and a distinct leak shape: an input of 20 characters or
+    // fewer is quoted in FULL (`...` first appears at 21), so
+    // `JSON.parse('pw42')` quotes the whole string. A guard written only
+    // against the truncated shape misses this one entirely.
     // Chosen so the needle appears nowhere else in the message -- the
     // container, env var and json-key literals do not contain it.
     const secret = 'pw42';
@@ -151,18 +152,35 @@ describe('resolveEcsSecrets json-key parse failure (issue #554)', () => {
   });
 });
 
-describe('the SIBLING json-key failure branches must stay value-free (issue #554)', () => {
-  // None of these three echoes the secret today, and the point is to keep it
-  // that way: they are the branches a later "let us be more helpful" edit
-  // would reach for, and nothing asserted their silence. Each fixture makes
-  // its OWN branch the one that fires -- a value that parses cleanly, so the
+describe('the three VALUE-consuming sibling branches must stay value-free (issue #554)', () => {
+  // The three branches of `resolveSecretsManager` that are HANDED the resolved
+  // secret and could therefore disclose it. None echoes today, and the point
+  // is to keep it that way: they are where a later "let us be more helpful"
+  // edit reaches, and nothing asserted their silence. Each fixture makes its
+  // OWN branch the one that fires -- a value that parses cleanly, so the
   // `JSON.parse` catch fixed above is NOT what threw.
+  //
+  // The FOURTH throw in this function -- the `client.send` catch at
+  // `ecs-secrets-resolver.ts:188` -- is deliberately NOT here, and the reason
+  // is recorded at that site: it fires BEFORE any value exists, and what it
+  // relays is an AWS transport error about the ARN. Naming the exclusion
+  // matters because a block titled "the sibling branches" otherwise reads as
+  // covering all four.
+  //
+  // A leak is asserted absent in every ENCODING a plausible edit would emit
+  // it in, not just as the literal string. Interpolating a `Uint8Array`
+  // yields a decimal byte list and `JSON.stringify` yields an index-keyed
+  // object -- both trivially reversible, and both FAR likelier than the
+  // hand-decode an earlier cut of this test probed. Fencing only the decoded
+  // form is the "probed the mutation nobody would write" trap.
   beforeEach(() => {
     smSend.mockReset();
     ssmSend.mockReset();
   });
 
   const PLAINTEXT = 'pw42';
+  /** A key name the fixture's secret carries and the requested json-key does not. */
+  const OTHER_KEY = 'dbUsernameField';
 
   it.each([
     [
@@ -172,7 +190,7 @@ describe('the SIBLING json-key failure branches must stay value-free (issue #554
     ],
     [
       'no such key exists in the secret JSON',
-      { SecretString: JSON.stringify({ other: PLAINTEXT }) },
+      { SecretString: JSON.stringify({ [OTHER_KEY]: PLAINTEXT }) },
       'no such key exists in the secret JSON',
     ],
   ])('%s', async (_label, response, surviving) => {
@@ -193,15 +211,23 @@ describe('the SIBLING json-key failure branches must stay value-free (issue #554
     // Positive first: this is the branch under test, not some earlier throw.
     expect(message).toContain(surviving);
     expect(message).toContain("Container 'ApiContainer'");
+    expect(message).toContain("secret 'DB_PASSWORD'");
     expect(message).toContain("json-key 'password'");
 
     expect(message).not.toContain(PLAINTEXT);
+    // The secret's STRUCTURE is disclosure too, and listing the keys it does
+    // have (`Available keys: ...`) is the canonical helpful-edit for a
+    // missing-key error. Asserted on both rows because the array fixture
+    // simply has no keys to list, so the guard costs nothing there.
+    expect(message).not.toContain(OTHER_KEY);
   });
 
-  it('binary secret: reports no SecretString without describing what came back', async () => {
-    // The `SecretString === undefined` arm. `SecretBinary` is what AWS
-    // actually returns here, and it must not be relayed either.
-    smSend.mockResolvedValue({ SecretBinary: new TextEncoder().encode(PLAINTEXT) });
+  it('binary secret: reports no string value without relaying the bytes in ANY encoding', async () => {
+    // The `SecretString === undefined` arm. AWS returns the value under
+    // `SecretBinary` here, and relaying it -- decoded, interpolated, or
+    // JSON-stringified -- discloses the same plaintext.
+    const bytes = new TextEncoder().encode(PLAINTEXT);
+    smSend.mockResolvedValue({ SecretBinary: bytes });
 
     let caught: unknown;
     try {
@@ -217,6 +243,22 @@ describe('the SIBLING json-key failure branches must stay value-free (issue #554
 
     expect(message).toContain('returned no SecretString');
     expect(message).toContain('Binary secrets are not supported');
+
+    // Decoded -- the hand-written `TextDecoder` form.
     expect(message).not.toContain(PLAINTEXT);
+    // Interpolated / `String(...)`-ed -- a typed array stringifies to its
+    // decimal bytes (`112,119,52,50`). This is what `+ String(resp.SecretBinary)`
+    // emits, and it is the likelier edit of the two.
+    expect(message).not.toContain(Array.from(bytes).join(','));
+    // `JSON.stringify(resp)` renders the array as an INDEX-KEYED object, so
+    // the byte list above does not appear in it. Built from the bytes rather
+    // than by re-stringifying a guessed response shape, so it still matches
+    // when the edit stringifies a response carrying other fields too.
+    const indexKeyed = JSON.stringify(
+      Object.fromEntries(Array.from(bytes).map((b, i) => [String(i), b]))
+    );
+    expect(message).not.toContain(indexKeyed);
+    // Base64 -- the shape a `Buffer.from(...).toString('base64')` edit emits.
+    expect(message).not.toContain(Buffer.from(bytes).toString('base64'));
   });
 });

--- a/tests/unit/local/ecs-secrets-resolver-json-key-redaction.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-json-key-redaction.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `resolveEcsSecrets` must not echo the parser's own message when a
+ * `:json-key::` `ValueFrom` points at a secret whose value is not JSON.
+ * V8 embeds a prefix of the PARSED INPUT in `SyntaxError.message`, and the
+ * parsed input here IS the secret plaintext this resolver just fetched from
+ * Secrets Manager -- so the echo puts the secret on stderr and into any
+ * surrounding log capture. `cdkl run-task` reaches it on an ordinary user
+ * mistake (issue #554; the same defect the cdkd host fixed as
+ * go-to-k/cdkd#2189).
+ *
+ * Each case pairs the negative with POSITIVES. "The secret is absent" on its
+ * own is a confluence point -- an unrelated rejection (a bad ARN, a mock that
+ * never resolved) satisfies it while fencing nothing -- so the discriminators
+ * that must SURVIVE are asserted alongside it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { smSend, ssmSend } = vi.hoisted(() => ({
+  smSend: vi.fn(),
+  ssmSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: class {
+    send = smSend;
+    destroy(): void {}
+  },
+  GetSecretValueCommand: class {},
+}));
+
+vi.mock('@aws-sdk/client-ssm', () => ({
+  SSMClient: class {
+    send = ssmSend;
+    destroy(): void {}
+  },
+  GetParameterCommand: class {},
+}));
+
+const { resolveEcsSecrets, EcsSecretsResolutionError } = await import(
+  '../../../src/local/ecs-secrets-resolver.js'
+);
+
+/** A Secrets Manager ARN carrying the `:<json-key>::` extraction suffix. */
+const ARN_WITH_JSON_KEY =
+  'arn:aws:secretsmanager:us-east-1:123456789012:secret:app-db:password::';
+
+/**
+ * Resolve one json-key entry against a secret whose stored value is `stored`,
+ * and return the failure message. Fails the test if the resolve SUCCEEDS --
+ * otherwise a mock that stopped rejecting would make every negative below
+ * pass while fencing nothing.
+ */
+async function jsonKeyFailure(stored: string): Promise<string> {
+  smSend.mockResolvedValue({ SecretString: stored });
+  try {
+    await resolveEcsSecrets([
+      { containerName: 'ApiContainer', name: 'DB_PASSWORD', valueFrom: ARN_WITH_JSON_KEY },
+    ]);
+  } catch (err) {
+    expect(err).toBeInstanceOf(EcsSecretsResolutionError);
+    return (err as Error).message;
+  }
+  return expect.fail('resolveEcsSecrets should have thrown on a non-JSON secret value');
+}
+
+/** The discriminators that must survive the redaction, in every case. */
+function expectStillActionable(message: string): void {
+  expect(message).toContain("Container 'ApiContainer'");
+  expect(message).toContain("secret 'DB_PASSWORD'");
+  expect(message).toContain("json-key 'password'");
+  expect(message).toContain('not valid JSON (SyntaxError)');
+  expect(message).toContain('withheld');
+}
+
+describe('resolveEcsSecrets json-key parse failure (issue #554)', () => {
+  beforeEach(() => {
+    smSend.mockReset();
+    ssmSend.mockReset();
+  });
+
+  it('withholds the ~10-character prefix V8 quotes from a long secret', async () => {
+    // `JSON.parse('supersecretpassword12345')` answers
+    // `Unexpected token 's', "supersecre"... is not valid JSON` on Node 24.15.
+    // The needle is the PREFIX, not the whole secret: `not.toContain(secret)`
+    // would pass WITHOUT the fix, since V8 never emits past its window -- an
+    // assertion that cannot fail reads as protection that is not there.
+    const secret = 'supersecretpassword12345';
+    const message = await jsonKeyFailure(secret);
+
+    expect(message).not.toContain('supersecre');
+    // Fence the parser's PHRASING too, not just the quoted segment: a message
+    // that kept `Unexpected token 's', is not valid JSON` with only the quote
+    // stripped still leaks the secret's first character.
+    expect(message).not.toContain('Unexpected token');
+
+    expectStillActionable(message);
+  });
+
+  it('withholds a SHORT secret, which V8 quotes in FULL rather than truncating', async () => {
+    // The worst case and a distinct leak shape: V8 appends `...` only PAST its
+    // prefix window, so `JSON.parse('pw42')` quotes the whole string. A guard
+    // written only against the truncated shape misses this one entirely.
+    // Chosen so the needle appears nowhere else in the message -- the
+    // container, env var and json-key literals do not contain it.
+    const secret = 'pw42';
+    const message = await jsonKeyFailure(secret);
+
+    expect(message).not.toContain(secret);
+    expect(message).not.toContain('Unexpected token');
+
+    expectStillActionable(message);
+  });
+
+  it('still extracts the key when the secret IS valid JSON', async () => {
+    // The premise of both cases above: this resolver reaches the json-key
+    // branch at all. Without this, a change that stopped extracting -- or
+    // stopped honouring the `:json-key::` suffix -- would leave the two
+    // negatives passing over a path that no longer parses anything.
+    smSend.mockResolvedValue({ SecretString: JSON.stringify({ password: 'pw42' }) });
+
+    const out = await resolveEcsSecrets([
+      { containerName: 'ApiContainer', name: 'DB_PASSWORD', valueFrom: ARN_WITH_JSON_KEY },
+    ]);
+
+    expect(out).toEqual([
+      {
+        containerName: 'ApiContainer',
+        name: 'DB_PASSWORD',
+        valueFrom: ARN_WITH_JSON_KEY,
+        value: 'pw42',
+      },
+    ]);
+  });
+});

--- a/tests/unit/local/ecs-secrets-resolver-json-key-redaction.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-json-key-redaction.test.ts
@@ -5,8 +5,8 @@
  * parsed input here IS the secret plaintext this resolver just fetched from
  * Secrets Manager -- so the echo puts the secret on stderr and into any
  * surrounding log capture. `cdkl run-task` reaches it on an ordinary user
- * mistake (issue #554; the same defect the cdkd host fixed as
- * go-to-k/cdkd#2189).
+ * mistake (issue #554; reported against the cdkd host as go-to-k/cdkd#2189 and
+ * fixed there by go-to-k/cdkd#2214).
  *
  * Each case pairs the negative with POSITIVES. "The secret is absent" on its
  * own is a confluence point -- an unrelated rejection (a bad ARN, a mock that
@@ -26,7 +26,14 @@ vi.mock('@aws-sdk/client-secrets-manager', () => ({
     send = smSend;
     destroy(): void {}
   },
-  GetSecretValueCommand: class {},
+  // The command RETAINS its input. A `class {}` that discards it cannot tell a
+  // correct call from a wrong-argument one, so `send` resolving for any
+  // argument would hide, for instance, the resolver passing the whole
+  // `valueFrom` (`...:secret:app-db:password::`) where the base ARN belongs --
+  // green here, `ResourceNotFound` against real AWS.
+  GetSecretValueCommand: class {
+    constructor(public input: unknown) {}
+  },
 }));
 
 vi.mock('@aws-sdk/client-ssm', () => ({
@@ -131,5 +138,85 @@ describe('resolveEcsSecrets json-key parse failure (issue #554)', () => {
         value: 'pw42',
       },
     ]);
+
+    // ...and it asked AWS for the BASE ARN, with the `:<json-key>::` suffix
+    // stripped. Secrets Manager rejects the suffixed form, so a resolver that
+    // forwarded `valueFrom` verbatim would pass every assertion above while
+    // failing against real AWS -- which is exactly the hole an input-discarding
+    // command mock leaves open.
+    expect(smSend).toHaveBeenCalledTimes(1);
+    expect((smSend.mock.calls[0]![0] as { input: unknown }).input).toEqual({
+      SecretId: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:app-db',
+    });
+  });
+});
+
+describe('the SIBLING json-key failure branches must stay value-free (issue #554)', () => {
+  // None of these three echoes the secret today, and the point is to keep it
+  // that way: they are the branches a later "let us be more helpful" edit
+  // would reach for, and nothing asserted their silence. Each fixture makes
+  // its OWN branch the one that fires -- a value that parses cleanly, so the
+  // `JSON.parse` catch fixed above is NOT what threw.
+  beforeEach(() => {
+    smSend.mockReset();
+    ssmSend.mockReset();
+  });
+
+  const PLAINTEXT = 'pw42';
+
+  it.each([
+    [
+      'the secret root is not a JSON object',
+      { SecretString: JSON.stringify([PLAINTEXT]) },
+      'the secret root is not a JSON object',
+    ],
+    [
+      'no such key exists in the secret JSON',
+      { SecretString: JSON.stringify({ other: PLAINTEXT }) },
+      'no such key exists in the secret JSON',
+    ],
+  ])('%s', async (_label, response, surviving) => {
+    smSend.mockResolvedValue(response);
+
+    let caught: unknown;
+    try {
+      await resolveEcsSecrets([
+        { containerName: 'ApiContainer', name: 'DB_PASSWORD', valueFrom: ARN_WITH_JSON_KEY },
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(EcsSecretsResolutionError);
+    const message = (caught as Error).message;
+
+    // Positive first: this is the branch under test, not some earlier throw.
+    expect(message).toContain(surviving);
+    expect(message).toContain("Container 'ApiContainer'");
+    expect(message).toContain("json-key 'password'");
+
+    expect(message).not.toContain(PLAINTEXT);
+  });
+
+  it('binary secret: reports no SecretString without describing what came back', async () => {
+    // The `SecretString === undefined` arm. `SecretBinary` is what AWS
+    // actually returns here, and it must not be relayed either.
+    smSend.mockResolvedValue({ SecretBinary: new TextEncoder().encode(PLAINTEXT) });
+
+    let caught: unknown;
+    try {
+      await resolveEcsSecrets([
+        { containerName: 'ApiContainer', name: 'DB_PASSWORD', valueFrom: ARN_WITH_JSON_KEY },
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(EcsSecretsResolutionError);
+    const message = (caught as Error).message;
+
+    expect(message).toContain('returned no SecretString');
+    expect(message).toContain('Binary secrets are not supported');
+    expect(message).not.toContain(PLAINTEXT);
   });
 });


### PR DESCRIPTION
Closes #554.

## The defect

`resolveSecretsManager` in `src/local/ecs-secrets-resolver.ts` interpolated the raw `JSON.parse` failure into its own error when a `:json-key::` `ValueFrom` points at a secret whose stored value is not JSON. V8 embeds a prefix of the PARSED INPUT in `SyntaxError.message`, and truncates to a 10-character prefix only for a LONG input -- measured on Node 24.15, an input of 20 characters or fewer is quoted in FULL and `...` first appears at 21:

```
JSON.parse("supersecretpassword12345")  ->  Unexpected token 's', "supersecre"... is not valid JSON
JSON.parse("pw42")                      ->  Unexpected token 'p', "pw42" is not valid JSON
```

The parsed input here IS the secret plaintext this resolver just fetched from Secrets Manager. `src/local/ecs-task-runner.ts:29` imports `resolveEcsSecrets`, so `cdkl run-task` reaches it on an ordinary user mistake -- a plain-string secret plus a `:json-key::` `ValueFrom` -- putting the secret on stderr and into any surrounding log capture.

This is the defect reported against the cdkd host as https://github.com/go-to-k/cdkd/issues/2189 and fixed there by https://github.com/go-to-k/cdkd/pull/2214; that fix never reached cdk-local.

## What changed

The message now carries `err.name` plus a fixed statement that the parser detail is withheld. It is **byte-identical to the host's**, so this is not a third spelling (#556 gave `vtl-engine.ts` / `rie-client.ts` the same treatment):

```
Container 'ApiContainer' secret 'DB_PASSWORD' specified json-key 'password' but the secret value is not valid JSON (SyntaxError). The parser detail is withheld because it would echo the secret plaintext.
```

The container, env var and requested json-key already make it actionable. Unlike the `$util.parseJson` message this one deliberately does NOT report the input LENGTH: there the argument is an anonymous HTTP body whose size is the only actionable property, whereas here the user already knows which secret it is and can read it at the source, so a character count would be disclosure buying nothing. The comment says so, to stop a later "harmonize the two messages" edit.

## Sweep

Population: an interpolation whose thrown-from operation consumed material this library RESOLVED from a secret / parameter store. **One site before, zero after.**

cdk-local's layout DIFFERS from the host's, where https://github.com/go-to-k/cdkd/issues/2203 records secret material entering exactly two files. Here it enters three, and each was traced from entry to every throwing operation that consumes the resolved value:

- `src/local/ecs-secrets-resolver.ts` -- the one hit, fixed here. Its other throws consume the ARN / parameter name, not the value.
- `src/local/ssm-parameter-resolver.ts` -- `GetParameters` with `WithDecryption`, so SecureString values pass through it. Its one interpolation is a FAILED-call warn whose operation consumed the parameter NAMES; the resolved values are never parsed.
- `src/local/ecr-puller.ts` -- the ECR authorization token. The password goes to `docker login` over `--password-stdin`, never argv, and the `formatDockerLoginError` path relays docker's stderr, which does not carry it.

Downstream of the resolver, `ecs-task-runner.ts` already routes every resolved secret through docker's value-from-process-env form (`-e KEY`), so no resolved value reaches an argv either.

### The two `cloudfront-kvs.ts` siblings named in the issue: kept, with the reason in-code

Both are annotated so a later sweep does not re-raise them:

- `createLocalFileKvsDataSource` parses a file the developer wrote and named on their own command line (`--kvs-file`). The quoted fragment is how they find the syntax error in it. The comment names the `--env-vars` file parsers as the same reviewed class -- such a file routinely holds secret env values, so the next sweep would otherwise re-derive that call from scratch.
- `cf.kvs().get(key, { format: 'json' })` parses a KeyValueStore VALUE, from either that same local file or -- under `--from-cfn-stack` -- a deployed CloudFront KeyValueStore, which is a plaintext edge-config store rather than a secret store. Nor does the echo reach the wire the way the `$util.parseJson` one did: a rejected `cf.kvs()` read propagates to `cloudfront-server.ts`'s top-level handler, which logs it and answers a FIXED 500 body. That is a statement about THIS CLI: `createCloudFrontModule` / `KvsDataSource` ship through `cdk-local/internal`, so an embedder-supplied source inherits the echo, and the comment says so.

## Verification

- `vp run verify` green: 214 test files, 3184 tests, 0 type errors, build clean.
- **Live test against the SHIPPED artifact, both arms.** `node dist/cli.js run-task` on a synthesized app whose container carries `ecs.Secret.fromSecretsManager(secret, 'password')`, with the real `@aws-sdk/client-secrets-manager` pointed at a local stand-in endpoint via `AWS_ENDPOINT_URL_SECRETS_MANAGER` returning the plain string `pw42` -- short enough that V8 quotes it in FULL. Nothing was created in AWS. Pre-fix (interpolation reverted, `dist/` rebuilt) the run prints `... is not valid JSON: Unexpected token 'p', "pw42" is not valid JSON` -- the whole secret. Post-fix the same run carries every discriminator and neither `pw42` nor `Unexpected token`.
- `/run-integ local-run-task` clean (rc=0) after the final commit; 0 orphan containers / networks before and after.
- **Fourteen unit mutation probes, all RED**: full revert; a half-fix stripping only V8's quoted segment while keeping `Unexpected token 'p',` (which is why the test fences the parser's PHRASING, not just the quoted span); changing the `(${kind})` discriminator; dropping the "withheld" sentence; dropping the container / env / json-key discriminators; a premise probe parsing a constant instead of the fetched secret; a `SecretId` sent as the raw suffixed `valueFrom`; the three sibling branches each made to echo the plaintext; and the four encoding / structure leaks described below. Every probe reddens exactly ONE test, which is the evidence that each fixture reaches its own branch rather than tripping an earlier throw.
- **The binary arm is fenced in every encoding a leak would use, not just the decoded one.** Two reviewers independently found the first cut of that case vacuous, one rating it a blocker: hoisting `SecretBinary` and interpolating it shipped the secret while the suite stayed 6/6 green, because a typed array renders as `112,119,52,50` and never as the plaintext. The case now asserts absence of the decoded string, the default interpolation, the `JSON.stringify` index-keyed rendering (`{"0":112,...}`, built from the bytes rather than from a guessed response shape), and base64 (`cHc0Mg==`) -- each confirmed RED by its own probe. The missing-key branch likewise fences KEY-NAME disclosure (`Available keys: ...`), which discloses the secret's structure without ever emitting a value.
- The long-secret case asserts absence of the 10-character PREFIX rather than of the whole secret on purpose: V8 never emits past its window, so `not.toContain(wholeSecret)` would pass WITHOUT the fix. Every negative is paired with positives -- absence alone is a confluence point that any unrelated rejection also satisfies.

## Review

Two rounds. Round 1: three reviewers (code / security / test) on the first commit, no blockers. Round 2: code + test re-review of the delta, which found the binary-arm vacuity described above -- rated a BLOCKER by one of the two reviewers that hit it independently, and fixed here. Every finding from both rounds is dispositioned:

- **Fixed here** -- cite the cdkd fix PR alongside its issue; replace the imprecise "appends `...` only past that ~10-character window" with the measured boundary; state why the LENGTH is omitted; scope the `cloudfront-kvs` "both bindings" claim to cdk-local's own CLI and note the `cdk-local/internal` embedder path; name the `--env-vars` family as the same reviewed class; retain the command input in the Secrets Manager mock and assert the resolver asks for the BASE ARN (a resolver forwarding the suffixed `valueFrom` was green until that assertion existed); fence the three sibling failure branches.
- **TODO (#557)** -- `resolveSsm`, the SSM half of this same resolver, has no unit coverage repo-wide. Different concern (ordinary resolution behavior, no leak), so it is not folded in here.
- **Won't-do** -- the non-Error catch arm is unreachable through the public API (`JSON.parse` without a reviver throws only `SyntaxError`), so no test can reach it; the in-code comment already records that. The `client.send` catch, the fourth throw in this function, keeps its echo: it fires BEFORE any value exists, so what it relays is an AWS error about the ARN, which is what makes a credential or IAM problem diagnosable -- now recorded at the site, because a test block titled for the sibling branches otherwise reads as covering it. And the embedder caveat on `cloudfront-kvs.ts` is accepted rather than merely noted: a host reaching `createCloudFrontModule` through the unstable `cdk-local/internal` subpath owns both the data source AND the rejection handling, so the echo is not narrowed for a caller cdk-local cannot see.

## Retrospective

Two techniques from this session worth reusing, offered as proposals rather than changes:

1. **`AWS_ENDPOINT_URL_<SERVICE>` makes a real-AWS code path live-testable with no AWS resources.** `/verify-pr` step 10 lists only fixture-driven live tests, which is why a defect on an AWS-dependent path invites "cannot live-test". Pointing the real SDK at a local stand-in exercises `dist/cli.js`, the real client, and the real resolver, and it is what produced both arms above.
2. **A reviewer sub-agent dispatched against a SHARED worktree needs to be told to copy it first.** A test reviewer's mutation probes and the parent's build / integ run write the same files. Saying so in the dispatch prompt cost one line and avoided a class of collision that is invisible afterwards -- the probe restores, so the corrupted run just looks like a flaky failure.
3. **A redaction test must fence the ENCODINGS a leak would arrive in, not the value.** The binary arm here asserted absence of `pw42` and passed while shipping `112,119,52,50`. The general rule the two reviewers converged on: when the guarded value is not a string, enumerate how a plausible edit would RENDER it -- default interpolation, `JSON.stringify`, base64 -- and assert each. Choosing the mutation to probe is the load-bearing step, and the natural pick (a hand-written decode) was the one nobody would write.
