### PR TITLE
chore(work-issues): mirror Severity / Effort onto issue labels, and let the PR inherit them

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1540,7 +1540,10 @@ vp run runtime:smoke
   issue's labels do not carry. **The PR inherits them automatically** —
   `.github/workflows/pr-inherit-issue-labels.yml` copies every label of
   the issues a PR closes onto the PR itself (add-only, minus the
-  release-management family), so never hand-add them to a PR.
+  release-management family), so never hand-add them to a PR. The copy
+  runs when the PR is opened, reopened, or its body edited, reading the
+  labels the issue carries AT THAT MOMENT — which is why the label
+  belongs on the issue at CLAIM time, before the lane's PR exists.
 
   **Scales.** `Severity`: `high` = a wrong result, data loss, a security
   surface, or something a user hits in normal operation; `medium` = a

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1516,6 +1516,32 @@ vp run runtime:smoke
   duration and keeping the letter is exactly the failure this split
   exists to end.
 
+  **`Severity` and `Effort` are ALSO LABELS on a filed issue.** The two
+  lines stay exactly as written — nothing about the report or the body
+  changes — and the same two values are mirrored onto the issue as
+  `severity:high` / `severity:medium` / `severity:low` and
+  `effort:small` / `effort:medium` / `effort:large`. Prose is invisible
+  to every query the backlog is actually triaged with, so ranking by
+  `Severity` costs one `gh issue view` per candidate while
+  `gh issue list --label severity:high` is one call. Set them at filing
+  time (`gh issue create ... --label severity:high --label effort:large`)
+  and again when a claim rewrites an old packed body into the four-line
+  shape (`gh issue edit <n> --add-label ...`), which is where `Severity`
+  first exists for most of the backlog. **Only these two get labels**:
+  `Session-fit` is re-decided at claim time and a label silently
+  disagreeing with the body is worse than none, and `Estimate` is a
+  free-form duration whose informative half — what actually eats the
+  time — is exactly what a label cannot hold. The prefixed full words
+  are the "no bare tokens" rule applied to a label: the two scales share
+  the token `medium`, and their initials collide in the dangerous
+  direction. Enforced by
+  `.claude/hooks/issue-classification-label-gate.sh`, which refuses a
+  `gh issue create` / `gh issue edit` whose body states a value the
+  issue's labels do not carry. **The PR inherits them automatically** —
+  `.github/workflows/pr-inherit-issue-labels.yml` copies every label of
+  the issues a PR closes onto the PR itself (add-only, minus the
+  release-management family), so never hand-add them to a PR.
+
   **Scales.** `Severity`: `high` = a wrong result, data loss, a security
   surface, or something a user hits in normal operation; `medium` = a
   capability is missing but there is a workaround, or it only shows up

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -317,6 +317,12 @@ GATE_RE_GIT_SWITCH="^git${GATE_FLAGS}[[:space:]]+switch([[:space:]]|$)"
 GATE_RE_GIT_CHECKOUT="^git${GATE_FLAGS}[[:space:]]+checkout([[:space:]]|$)"
 GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
 GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
+# issue-classification-label-gate: the CLAIM site. `/work-issues` says most open
+# bodies are still in the old packed shape and are upgraded to the four-line
+# shape when the issue is claimed, so `edit` -- not `create` -- is where
+# `Severity` first exists for the bulk of the backlog. `comment` stays absent:
+# a comment is not the issue's classification.
+GATE_RE_GH_ISSUE_EDIT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+edit([[:space:]]|$)"
 GATE_RE_GH_ISSUE_COMMENT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)"
 GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 # The REST issue COLLECTION path, for issue-dup-check-gate. This matches the

--- a/.claude/hooks/issue-classification-label-gate.sh
+++ b/.claude/hooks/issue-classification-label-gate.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# issue-classification-label-gate.sh — block `gh issue create` / `gh issue edit`
+# when the issue BODY states a `Severity:` / `Effort:` value that the issue's
+# LABELS do not carry.
+#
+# WHY
+#
+# CLAUDE.md's four classification fields (`Session-fit` / `Severity` / `Effort`
+# / `Estimate`) live in the issue BODY as prose lines. That is the right place
+# for the one-line reason each of them carries, and nothing here changes how
+# they are written or displayed. But prose is invisible to every query the
+# backlog is actually triaged with: `/work-issues` section 3's ranking rule 4
+# ("higher `Severity` first, when BOTH candidates carry the line") can only be
+# applied by opening each body, which is why it sits below a title-prefix
+# heuristic rather than above it. `gh issue list --label severity:high` answers
+# the same question in one call.
+#
+# So the two values that have a CLOSED set of tokens are mirrored onto labels:
+#
+#   Severity: high | medium | low   ->  severity:high | severity:medium | severity:low
+#   Effort:   small | medium | large ->  effort:small  | effort:medium  | effort:large
+#
+# ONLY those two. `Session-fit` is re-decided when an issue is claimed (section
+# 3 requires the claim comment to say why a recorded classification no longer
+# applies), and a label that silently disagrees with the body is worse than no
+# label at all. `Estimate` is a free-form duration with no closed value set --
+# CLAUDE.md's own rule that it "must name what actually eats the time" is
+# exactly what a label cannot hold.
+#
+# The prefixed full words are deliberate, and they are CLAUDE.md's own "no bare
+# tokens" rule applied to a label: `Severity` and `Effort` share the token
+# `medium`, and their initials collide in the dangerous direction (`L` is
+# severity *low*, the least urgent thing there is, and effort *large*, the
+# biggest). `severity:medium` / `effort:medium` cannot be confused; `M` can.
+#
+# WHAT IS AND IS NOT GATED
+#
+#   gated:      gh issue create   -- the filing site, where the four lines are
+#                                    first written
+#               gh issue edit     -- the CLAIM site: section 3 says most open
+#                                    bodies are still in the old packed shape
+#                                    and are upgraded to the four-line shape
+#                                    when claimed, which is the moment
+#                                    `Severity` first exists for them
+#   not gated:  gh issue comment  -- a comment is not the issue's classification
+#
+# On `gh issue edit` the gate asks gh what labels the issue ALREADY carries, so
+# re-editing an issue that is already labelled is not taxed; only a body whose
+# stated value has no matching label is refused, and one `--add-label` clears
+# it. That is also how the pre-existing backlog gets labelled: on touch, by the
+# lane that is already holding the evidence, rather than by a bulk sweep that
+# would manufacture guesses (section 3 forbids that sweep for the same reason).
+#
+# NO BYPASS MARKER, matching issue-dup-check-gate.sh: copying a value that is
+# already written one line above onto a flag is the entire ask.
+
+set -u
+
+__hook_dir="${BASH_SOURCE[0]%/*}"
+# `%/*` leaves the string unchanged when the path has no slash (invoked as
+# `bash issue-classification-label-gate.sh` from inside the hooks dir).
+[ "$__hook_dir" = "${BASH_SOURCE[0]}" ] && __hook_dir="."
+
+# The shared matcher lives at `lib/command-match.sh` in cdkd and at
+# `_command-match.sh` in the sibling repos this hook is mirrored into. Try both
+# rather than forking the file: the two spellings are the ONLY difference
+# between the three copies, and a fork is how they drift.
+# shellcheck source=lib/command-match.sh
+if ! . "$__hook_dir/lib/command-match.sh" 2>/dev/null \
+  && ! . "$__hook_dir/_command-match.sh" 2>/dev/null; then
+  echo "Blocked: the shared command matcher (lib/command-match.sh or" >&2
+  echo "_command-match.sh) is missing or unloadable, so" >&2
+  echo "issue-classification-label-gate cannot evaluate the command." >&2
+  echo "Restore the file; do not work around the gate." >&2
+  exit 2
+fi
+# FAIL CLOSED on a matcher that loaded but predates the constants this gate
+# needs -- `|| exit 0` here is what silently disabled ten sibling gates
+# (go-to-k/cdkd#2130 review).
+if ! declare -F gate_matches >/dev/null \
+  || ! declare -F gate_segments >/dev/null \
+  || [ -z "${GATE_RE_GH_ISSUE_CREATE:-}" ] \
+  || [ -z "${GATE_RE_GH_ISSUE_EDIT:-}" ]; then
+  echo "Blocked: the shared command matcher loaded but is missing gate_matches," >&2
+  echo "gate_segments, GATE_RE_GH_ISSUE_CREATE or GATE_RE_GH_ISSUE_EDIT, so" >&2
+  echo "issue-classification-label-gate cannot evaluate the command." >&2
+  exit 2
+fi
+
+input=$(cat 2>/dev/null || true)
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+[ "$tool_name" = "Bash" ] || exit 0
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$cmd" ] || exit 0
+
+# Command-position matching, so a body or comment that merely QUOTES
+# `gh issue create` does not arm the gate (.claude/rules/hooks.md).
+gate_matches "$cmd" "$GATE_RE_GH_ISSUE_CREATE" \
+  || gate_matches "$cmd" "$GATE_RE_GH_ISSUE_EDIT" || exit 0
+
+target_dir="${hook_cwd:-$PWD}"
+
+# --- repo opt-in (issue #1259's scoping) ------------------------------------
+# A session in one of these repos regularly files issues in unrelated personal
+# repos, where this classification discipline is not the local convention and a
+# refusal is pure friction. So the gate fires only in a repo that opts in by
+# carrying `.markgate.yml` at its root. The CWD's repo decides, not any
+# `-R <owner/repo>` in the command: `-R` names where the issue LANDS, while the
+# cwd names whose policy the session is operating under -- and the cross-repo
+# mirror flow (/work-issues section 10-c) files into a sibling from here,
+# which is exactly a filing this repo wants classified.
+optin_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$optin_top" ] || exit 0
+[ -f "$optin_top/.markgate.yml" ] || exit 0
+
+# --- value extraction -------------------------------------------------------
+# The key must be followed by at least one SPACE, and that is load-bearing
+# rather than incidental: the label spelling is `severity:high` with no space,
+# so this scan reads the BODY's `Severity: high` and never the `--label`
+# argument sitting in the same command string. Without the space rule a
+# `--label severity:low` would satisfy its own requirement.
+classification_value() {
+  local text="$1" key="$2" allowed="$3"
+  printf '%s' "$text" \
+    | grep -oiE "${key}:[[:space:]]+(${allowed})([^[:alnum:]]|\$)" \
+    | head -1 \
+    | grep -oiE "(${allowed})" \
+    | head -1 \
+    | tr '[:upper:]' '[:lower:]'
+}
+
+# Every `--label` / `--add-label` value in one segment, comma-split. The
+# extraction is the same one gh-label-validity-gate.sh uses: the unquoted value
+# is terminated by whitespace or a shell metacharacter, so a chained
+# `--label X; other-cmd` captures `X`, not `X;`.
+segment_labels() {
+  printf '%s' "$1" \
+    | grep -oE -- '--(add-)?label[= ]("[^"]+"|'\''[^'\'']+'\''|[^ ;&|()<>"'\'']+)' \
+    | sed -E -e 's/^--(add-)?label[= ]//' -e 's/^["'\'']//' -e 's/["'\'']$//' \
+    | tr ',' '\n' \
+    | sed 's/^ *//;s/ *$//' \
+    | grep -v '^$' || true
+}
+
+# The text a segment's body amounts to: the segment itself (covering an inline
+# `--body '...'`), plus the contents of any readable `--body-file`, plus -- when
+# a named body file cannot be read -- the WHOLE command. That last fallback is
+# this repo's mandated `heredoc -> file -> --body-file` publishing shape, whose
+# file does not exist yet at PreToolUse time; issue-dup-check-gate.sh documents
+# the same window.
+segment_body_text() {
+  local seg="$1" f out
+  out="$seg"
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    case "$f" in
+      *'$'*|*'`'*) out="$out
+$cmd"; continue ;;
+    esac
+    # shellcheck disable=SC2088
+    case "$f" in
+      /*) ;;
+      "~/"*) f="${HOME:-/nonexistent}/${f#\~/}" ;;
+      *) f="$target_dir/$f" ;;
+    esac
+    if [ -r "$f" ]; then
+      out="$out
+$(cat "$f" 2>/dev/null || true)"
+    else
+      out="$out
+$cmd"
+    fi
+  done < <(printf '%s' "$seg" | perl -0777 -ne '
+      while (/--body-file[=\s]+(["\x27]?)([^"\x27\s]+)\1/g) { print "$2\n"; }
+      while (/(?:--field|--raw-field|-F)[=\s]+(["\x27]?)body=\@([^"\x27\s]+)\1/g) { print "$2\n"; }
+    ' 2>/dev/null)
+  printf '%s' "$out"
+}
+
+# The labels an EXISTING issue already carries, for the `gh issue edit` arm.
+# Fails OPEN (prints nothing and lets the caller treat it as "unknown, do not
+# block") on any gh error: this is a discipline aid, not a safety boundary, and
+# a transient gh failure must not stop a body edit.
+existing_labels() {
+  local seg="$1" num repo_args
+  num=$(printf '%s' "$seg" | sed -nE 's#.*/issues/([0-9]+).*#\1#p' | head -1)
+  if [ -z "$num" ]; then
+    num=$(printf '%s' "$seg" \
+      | sed -nE 's/.*issue[[:space:]]+edit[[:space:]]+["'\'']?#?([0-9]+).*/\1/p' | head -1)
+  fi
+  [ -n "$num" ] || return 1
+  repo_args=$(printf '%s' "$seg" \
+    | sed -nE 's/.*[[:space:]](-R|--repo)[= ]["'\'']?([^ "'\'']+).*/\2/p' | head -1)
+  if [ -n "$repo_args" ]; then
+    gh issue view "$num" -R "$repo_args" --json labels -q '.labels[].name' 2>/dev/null
+  else
+    (cd "$target_dir" 2>/dev/null && gh issue view "$num" --json labels -q '.labels[].name' 2>/dev/null)
+  fi
+}
+
+has_label() {
+  printf '%s\n' "$2" | grep -qFx -- "$1"
+}
+
+offending_seg=""
+missing=""
+while IFS= read -r seg; do
+  is_edit=0
+  if gate_matches "$seg" "$GATE_RE_GH_ISSUE_EDIT"; then
+    is_edit=1
+  elif ! gate_matches "$seg" "$GATE_RE_GH_ISSUE_CREATE"; then
+    continue
+  fi
+
+  body_text=$(segment_body_text "$seg")
+  sev=$(classification_value "$body_text" 'severity' 'high|medium|low')
+  eff=$(classification_value "$body_text" 'effort' 'small|medium|large')
+  # An old packed body writes `Effort: ~1-3 h`, which is a DURATION rather than
+  # one of the three verification-cycle kinds (/work-issues section 3). No token
+  # matches, so no label is demanded -- reading that field as the new `Effort`
+  # is the misreading section 3 warns about, and this gate must not force it.
+  [ -n "$sev" ] || [ -n "$eff" ] || continue
+
+  known=$(segment_labels "$seg")
+  if [ "$is_edit" = "1" ]; then
+    prior=$(existing_labels "$seg" || true)
+    if [ -n "$prior" ]; then
+      known="$known
+$prior"
+    elif [ -z "$known" ]; then
+      # Unknown issue number, or gh could not answer: fail OPEN rather than
+      # refuse a body edit over a label we cannot see.
+      continue
+    fi
+  fi
+
+  seg_missing=""
+  if [ -n "$sev" ] && ! has_label "severity:$sev" "$known"; then
+    seg_missing="${seg_missing}  - severity:${sev}   (body says \`Severity: ${sev}\`)"$'\n'
+  fi
+  if [ -n "$eff" ] && ! has_label "effort:$eff" "$known"; then
+    seg_missing="${seg_missing}  - effort:${eff}   (body says \`Effort: ${eff}\`)"$'\n'
+  fi
+  if [ -n "$seg_missing" ]; then
+    offending_seg="$seg"
+    missing="$seg_missing"
+    is_edit_offending="$is_edit"
+    break
+  fi
+done < <(gate_segments "$cmd")
+
+[ -n "$offending_seg" ] || exit 0
+
+if [ "${is_edit_offending:-0}" = "1" ]; then
+  flag="--add-label"
+  verb="gh issue edit"
+else
+  flag="--label"
+  verb="gh issue create"
+fi
+
+{
+  echo "Blocked by issue-classification-label-gate: this \`${verb}\` states a"
+  echo "classification in the body that the issue's labels do not carry."
+  echo ""
+  echo "Missing label(s):"
+  printf '%s' "$missing"
+  echo ""
+  echo "Add them to the same command -- the body text stays exactly as written,"
+  echo "the labels are a second copy of the SAME two values:"
+  echo ""
+  echo "  ${verb} ... ${flag} severity:<high|medium|low> ${flag} effort:<small|medium|large>"
+  echo ""
+  echo "Why: the four classification fields live in the body as prose, which no"
+  echo "\`gh issue list\` query can read. /work-issues section 3's ranking rule 4"
+  echo "(\"higher Severity first\") therefore costs one \`gh issue view\` per"
+  echo "candidate, while \`gh issue list --label severity:high\` is one call."
+  echo "Only Severity and Effort are mirrored: Session-fit is re-decided at claim"
+  echo "time and a stale label would be worse than none, and Estimate is a"
+  echo "free-form duration with no closed value set."
+  echo ""
+  echo "If the label does not exist yet in this repo, create it once:"
+  echo "  gh label create 'severity:high' --description '...' --color 'b60205'"
+  echo ""
+  echo "Rule: CLAUDE.md -> the four TODO classification fields."
+} >&2
+exit 2

--- a/.claude/hooks/issue-classification-label-gate.sh
+++ b/.claude/hooks/issue-classification-label-gate.sh
@@ -37,6 +37,8 @@
 #
 #   gated:      gh issue create   -- the filing site, where the four lines are
 #                                    first written
+#               gh api repos/<o>/<r>/issues -- the same mint through the REST
+#                                    verb, when the matcher exposes the constant
 #               gh issue edit     -- the CLAIM site: section 3 says most open
 #                                    bodies are still in the old packed shape
 #                                    and are upgraded to the four-line shape
@@ -96,10 +98,32 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Command-position matching, so a body or comment that merely QUOTES
 # `gh issue create` does not arm the gate (.claude/rules/hooks.md).
+# The REST mint is the same act as `gh issue create` through another verb:
+# `gh api repos/<o>/<r>/issues` with a `title=` field creates an issue. Sibling
+# issue-dup-check-gate.sh already covers it, and omitting it here would leave
+# the trigger under-approximated against the "over-approximate the TRIGGER, be
+# strict on RESOLUTION" rule in .claude/rules/hooks.md.
+GATE_RE_API_MINT="${GATE_RE_GH_API_ISSUE_CREATE:-}"
 gate_matches "$cmd" "$GATE_RE_GH_ISSUE_CREATE" \
-  || gate_matches "$cmd" "$GATE_RE_GH_ISSUE_EDIT" || exit 0
+  || gate_matches "$cmd" "$GATE_RE_GH_ISSUE_EDIT" \
+  || { [ -n "$GATE_RE_API_MINT" ] && gate_matches "$cmd" "$GATE_RE_API_MINT"; } || exit 0
 
 target_dir="${hook_cwd:-$PWD}"
+# A leading `cd <repo>` steers BOTH the opt-in check and the relative
+# `--body-file` resolution, and the two must agree. The search-then-`cd`-then-
+# file chain is a documented shape here, and without this the opt-in resolved
+# against the payload cwd -- the same fail-open issue-dup-check-gate.sh closed.
+# Guarded by `declare -F`: the sibling repos this hook is mirrored into carry an
+# older matcher with no `cmd_last_cd_target`, where the gate degrades to the
+# payload cwd rather than failing to load.
+if declare -F cmd_last_cd_target >/dev/null 2>&1; then
+  # The verb ERE is DERIVED from the shared constants rather than hand-rolled:
+  # a local copy drops GATE_FLAGS' quoted alternative, so `gh -C "/a b" issue
+  # create` matches no verb and a TRAILING `cd` steers the lookup instead.
+  _cd_target=$(cmd_last_cd_target "$cmd" "$target_dir" \
+    "(${GATE_RE_GH_ISSUE_CREATE#^})|(${GATE_RE_GH_ISSUE_EDIT#^})" 2>/dev/null || true)
+  [ -n "$_cd_target" ] && target_dir="$_cd_target"
+fi
 
 # --- repo opt-in (issue #1259's scoping) ------------------------------------
 # A session in one of these repos regularly files issues in unrelated personal
@@ -134,26 +158,41 @@ classification_value() {
 # extraction is the same one gh-label-validity-gate.sh uses: the unquoted value
 # is terminated by whitespace or a shell metacharacter, so a chained
 # `--label X; other-cmd` captures `X`, not `X;`.
+# `-l` IS matched here, unlike gh-label-validity-gate.sh which excludes it.
+# There the scan spans `gh issue|pr create|edit` where `-l` is also short for
+# `--limit`; here every segment is a `gh issue create` or `gh issue edit`, where
+# `-l` can only be `--label`. The cost directions differ too: missing a label
+# there costs a skipped check, while missing one HERE costs a false BLOCK on a
+# command that already carries what the gate asks for, and there is no bypass.
 segment_labels() {
   printf '%s' "$1" \
-    | grep -oE -- '--(add-)?label[= ]("[^"]+"|'\''[^'\'']+'\''|[^ ;&|()<>"'\'']+)' \
-    | sed -E -e 's/^--(add-)?label[= ]//' -e 's/^["'\'']//' -e 's/["'\'']$//' \
+    | grep -oE -- '(--(add-)?label|(^|[[:space:]])-l)[= ]("[^"]+"|'\''[^'\'']+'\''|[^ ;&|()<>"'\'']+)' \
+    | sed -E -e 's/^[[:space:]]*//' -e 's/^(--(add-)?label|-l)[= ]//' -e 's/^["'\'']//' -e 's/["'\'']$//' \
     | tr ',' '\n' \
     | sed 's/^ *//;s/ *$//' \
     | grep -v '^$' || true
 }
 
-# The text a segment's body amounts to: the segment itself (covering an inline
-# `--body '...'`), plus the contents of any readable `--body-file`, plus -- when
-# a named body file cannot be read -- the WHOLE command. That last fallback is
-# this repo's mandated `heredoc -> file -> --body-file` publishing shape, whose
-# file does not exist yet at PreToolUse time; issue-dup-check-gate.sh documents
-# the same window.
+# The BODY text of a segment, in descending order of specificity. Precedence is
+# load-bearing rather than tidy: `classification_value` takes the FIRST match,
+# so concatenating the whole segment in front of the body let an unrelated
+# mention outrank the real line. Measured: `--title \'Severity: high pages
+# fail\'` with a body stating `Severity: low` and a correct `--label
+# severity:low` was REFUSED, quoting a value the body never states.
+#
+#   1. the contents of a readable `--body-file` / `-F <path>` / `-F body=@path`
+#   2. the WHOLE command, when such a path was named but cannot be read -- the
+#      `heredoc -> file -> --body-file` publishing shape this repo mandates,
+#      whose file does not exist yet at PreToolUse time (issue-dup-check-gate.sh
+#      documents the same window)
+#   3. the inline `--body` value, quote-aware so a multi-word body is one token
+#   4. the whole segment, as a last resort
 segment_body_text() {
-  local seg="$1" f out
-  out="$seg"
+  local seg="$1" f out=""
   while IFS= read -r f; do
     [ -n "$f" ] || continue
+    # An unexpanded `$VAR` or a substitution cannot be resolved from command
+    # TEXT; treat it like an unreadable path and fall back to the whole command.
     case "$f" in
       *'$'*|*'`'*) out="$out
 $cmd"; continue ;;
@@ -171,11 +210,34 @@ $(cat "$f" 2>/dev/null || true)"
       out="$out
 $cmd"
     fi
+  # The bare `-F <path>` arm is NOT optional: `-F` is gh's short `--body-file`,
+  # so without it `gh issue create -F body.md` was never scanned and the gate
+  # exited 0 on a body stating `Severity: high` with no label. Sibling
+  # issue-dup-check-gate.sh already carries the same three arms. `body=@` is
+  # matched FIRST so an `-F body=@path` is not also read as a bare `-F path`.
   done < <(printf '%s' "$seg" | perl -0777 -ne '
-      while (/--body-file[=\s]+(["\x27]?)([^"\x27\s]+)\1/g) { print "$2\n"; }
       while (/(?:--field|--raw-field|-F)[=\s]+(["\x27]?)body=\@([^"\x27\s]+)\1/g) { print "$2\n"; }
+      while (/--body-file[=\s]+(["\x27]?)([^"\x27\s]+)\1/g) { print "$2\n"; }
+      while (/(?:^|\s)-F[=\s]+(["\x27]?)([^"\x27\s=]+)\1(?=\s|$)/g) { print "$2\n"; }
     ' 2>/dev/null)
-  printf '%s' "$out"
+
+  if [ -n "$out" ]; then
+    printf '%s' "$out"
+    return 0
+  fi
+
+  out=$(printf '%s' "$seg" | perl -0777 -ne '
+    while (/(?:^|\s)--body[=\s]+("(?:[^"\\]|\\.)*"|\x27[^\x27]*\x27|\S+)/g) {
+      my $v = $1;
+      $v =~ s/^["\x27]//; $v =~ s/["\x27]$//;
+      print "$v\n";
+    }' 2>/dev/null)
+  if [ -n "$out" ]; then
+    printf '%s' "$out"
+    return 0
+  fi
+
+  printf '%s' "$seg"
 }
 
 # The labels an EXISTING issue already carries, for the `gh issue edit` arm.
@@ -184,14 +246,27 @@ $cmd"
 # a transient gh failure must not stop a body edit.
 existing_labels() {
   local seg="$1" num repo_args
-  num=$(printf '%s' "$seg" | sed -nE 's#.*/issues/([0-9]+).*#\1#p' | head -1)
-  if [ -z "$num" ]; then
-    num=$(printf '%s' "$seg" \
-      | sed -nE 's/.*issue[[:space:]]+edit[[:space:]]+["'\'']?#?([0-9]+).*/\1/p' | head -1)
-  fi
+  # The number must come from the `issue edit` ARGUMENT, not from any
+  # `/issues/N` URL in the command. An unanchored URL scan reads a link the
+  # body happens to contain -- routine here -- and a greedy `.*` takes the
+  # LAST one, so `gh issue edit 42 --body "see .../other/repo/issues/999 ...
+  # Severity: high"` looked up 999's labels and let an unlabelled 42 through.
+  # perl rather than sed: this needs a LEFTMOST match anchored to the verb, and
+  # ERE has no non-greedy quantifier.
+  num=$(printf '%s' "$seg" | perl -0777 -ne '
+    if (/\bissue\s+edit\s+(?:["\x27])?\#?(?:https:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/)?(\d+)/) {
+      print $1;
+    }' 2>/dev/null)
   [ -n "$num" ] || return 1
-  repo_args=$(printf '%s' "$seg" \
-    | sed -nE 's/.*[[:space:]](-R|--repo)[= ]["'\'']?([^ "'\'']+).*/\2/p' | head -1)
+  # Anchored to the verb for the same reason as `num` above: a greedy `.*` over
+  # the segment takes the LAST `-R` in it, including one quoted inside a body,
+  # which sends the lookup to another repo. Leftmost match after `issue edit`,
+  # and a value starting with `-` is rejected rather than passed to gh as a
+  # stray flag.
+  repo_args=$(printf '%s' "$seg" | perl -0777 -ne '
+    if (/\bissue\s+edit\b.{0,400}?\s(?:-R|--repo)[=\s]+(["\x27]?)([^\s"\x27]+)\1/s) {
+      print $2 unless $2 =~ /^-/;
+    }' 2>/dev/null)
   if [ -n "$repo_args" ]; then
     gh issue view "$num" -R "$repo_args" --json labels -q '.labels[].name' 2>/dev/null
   else
@@ -210,7 +285,9 @@ while IFS= read -r seg; do
   if gate_matches "$seg" "$GATE_RE_GH_ISSUE_EDIT"; then
     is_edit=1
   elif ! gate_matches "$seg" "$GATE_RE_GH_ISSUE_CREATE"; then
-    continue
+    if [ -z "$GATE_RE_API_MINT" ] || ! gate_matches "$seg" "$GATE_RE_API_MINT"; then
+      continue
+    fi
   fi
 
   body_text=$(segment_body_text "$seg")
@@ -224,15 +301,20 @@ while IFS= read -r seg; do
 
   known=$(segment_labels "$seg")
   if [ "$is_edit" = "1" ]; then
-    prior=$(existing_labels "$seg" || true)
-    if [ -n "$prior" ]; then
-      known="$known
-$prior"
-    elif [ -z "$known" ]; then
-      # Unknown issue number, or gh could not answer: fail OPEN rather than
-      # refuse a body edit over a label we cannot see.
+    # FAIL OPEN on the LOOKUP FAILING, not on it returning nothing. Those are
+    # different states and conflating them broke the contract in both
+    # directions: an issue that genuinely carries no labels (rc 0, empty
+    # output) must still be refused, while a gh error or an unresolvable issue
+    # number must pass through EVEN IF the command supplies some labels --
+    # otherwise a half-labelled command was refused over a label the gate could
+    # not see.
+    prior_rc=0
+    prior=$(existing_labels "$seg") || prior_rc=$?
+    if [ "$prior_rc" != "0" ]; then
       continue
     fi
+    known="$known
+$prior"
   fi
 
   seg_missing=""

--- a/.claude/hooks/issue-classification-label-gate.test.sh
+++ b/.claude/hooks/issue-classification-label-gate.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Smoke tests for issue-classification-label-gate.sh
+#
+# The gate blocks `gh issue create` / `gh issue edit` when the BODY states a
+# `Severity:` / `Effort:` value that the issue's labels do not carry. Asserts,
+# in both directions:
+#   - PASS  when the command carries the matching `--label` / `--add-label`
+#   - BLOCK when it carries none, or carries a DIFFERENT value (a label that
+#           disagrees with the body is the failure mode this exists to stop)
+#   - PASS  when the body states no classification at all, and when the old
+#           packed shape writes `Effort: ~1-3 h` -- a DURATION, which
+#           /work-issues section 3 says must NOT be read as the new `Effort`
+#   - PASS  when the LABEL SPELLING appears in the command but no body line
+#           does. The label form has no space after the colon and the body form
+#           does, and that separation is the whole gate: relaxing the scan's
+#           `[[:space:]]+` to `*` makes a `--label` satisfy its own requirement
+#           and makes a passing mention of `severity:high` in a TITLE demand a
+#           label. Both of those are fenced below
+#   - edit: PASS when gh reports the label is ALREADY on the issue, BLOCK when
+#           it reports none, PASS when gh cannot answer (fail open -- a
+#           transient gh failure must not stop a body edit)
+#   - PASS  for verbs deliberately not gated (`gh issue comment`), for a command
+#           that merely QUOTES the trigger, and in a repo that never opted in
+#
+# Measured rather than asserted (2026-08-26): an always-`exit 0` stub fails 7 of
+# these and an always-`exit 2` stub fails all 25, so neither direction can pass
+# vacuously. A targeted mutant -- the scan's `[[:space:]]+` relaxed to `*` --
+# fails 2, both named in the list above.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/issue-classification-label-gate.sh"
+PASS=0
+FAIL=0
+
+# Two fixture trees, because the gate is repo-opt-in:
+#   $TMPROOT  -- a git repo carrying `.markgate.yml`, so the gate fires
+#   $NOOPTIN  -- a git repo without it, so the gate must stay silent
+TMPBASE=$(mktemp -d)
+trap 'rm -rf "$TMPBASE"' EXIT
+TMPROOT="$TMPBASE/optin"
+NOOPTIN="$TMPBASE/no-optin"
+for d in "$TMPROOT" "$NOOPTIN"; do
+  mkdir -p "$d"
+  git -C "$d" init -q 2>/dev/null
+done
+printf 'gates: {}\n' > "$TMPROOT/.markgate.yml"
+
+# A PATH-stubbed `gh`, because the edit arm asks the real service what labels an
+# issue already carries. The stub answers from GH_STUB_LABELS and fails when
+# GH_STUB_FAIL is set, which is the only way to exercise the fail-open arm.
+STUBDIR="$TMPBASE/bin"
+mkdir -p "$STUBDIR"
+cat > "$STUBDIR/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "${GH_STUB_FAIL:-}" ]; then exit 1; fi
+printf '%s\n' ${GH_STUB_LABELS:-}
+STUB
+chmod +x "$STUBDIR/gh"
+PATH="$STUBDIR:$PATH"
+export PATH
+
+# run <name> <command> <cwd> <expected-exit>
+run() {
+  local name="$1" command="$2" cwd="$3" expect="$4"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ]; then
+    echo "PASS: $name (exit $rc)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $rc, expected $expect)"
+    printf '%s\n' "$out" | sed 's/^/      /' | head -6
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# run_msg <name> <command> <cwd> <expected-exit> <substring the stderr must carry>
+# The refusal names WHICH label is missing; asserting the exit code alone let an
+# earlier draft report `effort:` for a missing `severity:` and stay green.
+run_msg() {
+  local name="$1" command="$2" cwd="$3" expect="$4" needle="$5"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ] && printf '%s' "$out" | grep -qF "$needle"; then
+    echo "PASS: $name (exit $rc, message matched)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $rc, expected $expect carrying '$needle')"
+    printf '%s\n' "$out" | sed 's/^/      /' | head -6
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+BODY_BOTH="$TMPROOT/both.md"
+cat > "$BODY_BOTH" <<'B'
+The provider drops the field.
+
+Dup-check: searched open issues -- none covers this root cause
+Session-fit: next (not this session) -- needs a new fixture
+Severity: high -- deploy silently ships a resource missing the property
+Effort: large (L) -- a new integ fixture has to be written
+Estimate: ~3 h+ -- the fixture deploys a NAT gateway
+B
+
+BODY_PACKED="$TMPROOT/packed.md"
+cat > "$BODY_PACKED" <<'B'
+The old packed shape, from before the five-field split.
+
+Session-fit: next (not this session) -- Effort: ~1-3 h
+Severity: medium -- one provider is missing a property
+B
+
+BODY_NONE="$TMPROOT/none.md"
+printf 'Just a feature request, no classification lines.\n' > "$BODY_NONE"
+
+# --- create -----------------------------------------------------------------
+run "create: both labels present" \
+  "gh issue create -t x --body-file $BODY_BOTH --label severity:high --label effort:large" \
+  "$TMPROOT" 0
+run_msg "create: no labels at all" \
+  "gh issue create -t x --body-file $BODY_BOTH" \
+  "$TMPROOT" 2 "severity:high"
+run_msg "create: severity labelled, effort missing" \
+  "gh issue create -t x --body-file $BODY_BOTH --label severity:high" \
+  "$TMPROOT" 2 "effort:large"
+run_msg "create: label DISAGREES with the body" \
+  "gh issue create -t x --body-file $BODY_BOTH --label severity:low --label effort:large" \
+  "$TMPROOT" 2 "severity:high"
+run "create: comma-separated labels" \
+  "gh issue create -t x --body-file $BODY_BOTH --label severity:high,effort:large" \
+  "$TMPROOT" 0
+run "create: old packed body demands only severity" \
+  "gh issue create -t x --body-file $BODY_PACKED --label severity:medium" \
+  "$TMPROOT" 0
+run "create: body with no classification lines" \
+  "gh issue create -t x --body-file $BODY_NONE" \
+  "$TMPROOT" 0
+# The separation the whole gate rests on: a label carries no space after the
+# colon, a body line does. Without it this command would demand the label its
+# own `--label` names and every command would pass vacuously.
+run "create: a bare --label does not satisfy itself" \
+  "gh issue create -t x --body-file $BODY_NONE --label severity:high" \
+  "$TMPROOT" 0
+# The other half of the same separation: a label SPELLING quoted in a title is
+# not a classification. Relaxing the space rule turns this into a refusal.
+run "create: the label spelling in a TITLE is not a classification" \
+  "gh issue create -t 'add a severity:high label to the tracker' --body-file $BODY_NONE" \
+  "$TMPROOT" 0
+run "create: inline --body carrying the lines" \
+  "gh issue create -t x --body 'Broken. Severity: medium -- workaround exists. Effort: small (S) -- unit tests only.' --label severity:medium --label effort:small" \
+  "$TMPROOT" 0
+run_msg "create: inline --body, labels absent" \
+  "gh issue create -t x --body 'Broken. Severity: medium -- workaround exists.'" \
+  "$TMPROOT" 2 "severity:medium"
+run "create: chained after another command" \
+  "git status && gh issue create -t x --body-file $BODY_BOTH --label severity:high --label effort:large" \
+  "$TMPROOT" 0
+run_msg "create: chained, labels absent" \
+  "git status && gh issue create -t x --body-file $BODY_BOTH" \
+  "$TMPROOT" 2 "severity:high"
+
+# --- heredoc -> file -> --body-file in ONE command --------------------------
+# The file does not exist at PreToolUse time, so the scan falls back to the
+# whole command. This is the repo's mandated publishing shape.
+HD_NO="cat > $TMPROOT/hd.md <<'EOF'
+Severity: high -- users hit it in normal operation
+EOF
+gh issue create -t x --body-file $TMPROOT/hd.md"
+HD_OK="cat > $TMPROOT/hd2.md <<'EOF'
+Severity: high -- users hit it in normal operation
+EOF
+gh issue create -t x --body-file $TMPROOT/hd2.md --label severity:high"
+run_msg "heredoc body, label absent" "$HD_NO" "$TMPROOT" 2 "severity:high"
+run "heredoc body, label present"    "$HD_OK" "$TMPROOT" 0
+
+# --- edit -------------------------------------------------------------------
+GH_STUB_LABELS="bug severity:high" \
+  run "edit: issue already carries the label" \
+  "gh issue edit 42 --body-file $BODY_BOTH --add-label effort:large" \
+  "$TMPROOT" 0
+GH_STUB_LABELS="bug" \
+  run_msg "edit: issue carries neither" \
+  "gh issue edit 42 --body-file $BODY_BOTH" \
+  "$TMPROOT" 2 "severity:high"
+GH_STUB_LABELS="bug" \
+  run "edit: both supplied on the command" \
+  "gh issue edit 42 --body-file $BODY_BOTH --add-label severity:high --add-label effort:large" \
+  "$TMPROOT" 0
+GH_STUB_FAIL=1 \
+  run "edit: gh cannot answer -- fail open" \
+  "gh issue edit 42 --body-file $BODY_BOTH" \
+  "$TMPROOT" 0
+GH_STUB_LABELS="bug" \
+  run "edit: issue number unresolvable -- fail open" \
+  "gh issue edit --body-file $BODY_BOTH" \
+  "$TMPROOT" 0
+
+# --- not gated / not armed --------------------------------------------------
+run "gh issue comment is not gated" \
+  "gh issue comment 42 --body-file $BODY_BOTH" \
+  "$TMPROOT" 0
+run "a command that merely QUOTES the trigger" \
+  "echo 'gh issue create -t x --body \"Severity: high\"'" \
+  "$TMPROOT" 0
+run "repo that never opted in" \
+  "gh issue create -t x --body-file $BODY_BOTH" \
+  "$NOOPTIN" 0
+run "empty command passes" "" "$TMPROOT" 0
+
+payload=$(jq -n '{tool_name:"Edit", tool_input:{file_path:"/tmp/x"}}')
+out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+if [ "${rc:-0}" -eq 0 ]; then echo "PASS: non-Bash tool passes (exit 0)"; PASS=$((PASS + 1))
+else echo "FAIL: non-Bash tool passes (exit ${rc:-0})"; FAIL=$((FAIL + 1)); fi
+
+echo ""
+echo "Pass: $PASS  Fail: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/issue-classification-label-gate.test.sh
+++ b/.claude/hooks/issue-classification-label-gate.test.sh
@@ -12,20 +12,28 @@
 #           /work-issues section 3 says must NOT be read as the new `Effort`
 #   - PASS  when the LABEL SPELLING appears in the command but no body line
 #           does. The label form has no space after the colon and the body form
-#           does, and that separation is the whole gate: relaxing the scan's
-#           `[[:space:]]+` to `*` makes a `--label` satisfy its own requirement
-#           and makes a passing mention of `severity:high` in a TITLE demand a
-#           label. Both of those are fenced below
+#           does. Precedence does most of the work -- the body FILE outranks the
+#           segment text, so a `--title 'Severity: high ...'` cannot outrank the
+#           body's own line -- and the space rule guards the LAST-RESORT segment
+#           scan, the only path where the two spellings still meet
+#   - PASS  for `-F <path>` and `-l`, gh's short `--body-file` and `--label`.
+#           Missing the first meant the body was never scanned at all; missing
+#           the second was a false BLOCK on a command already carrying the label
+#   - edit: the lookup must use the `issue edit` ARGUMENT, not a `/issues/N`
+#           URL the body happens to cite, and it must reach the `-R` repo. The
+#           stub records its argv so a case can pin WHICH issue was asked about
 #   - edit: PASS when gh reports the label is ALREADY on the issue, BLOCK when
 #           it reports none, PASS when gh cannot answer (fail open -- a
 #           transient gh failure must not stop a body edit)
 #   - PASS  for verbs deliberately not gated (`gh issue comment`), for a command
 #           that merely QUOTES the trigger, and in a repo that never opted in
 #
-# Measured rather than asserted (2026-08-26): an always-`exit 0` stub fails 7 of
-# these and an always-`exit 2` stub fails all 25, so neither direction can pass
-# vacuously. A targeted mutant -- the scan's `[[:space:]]+` relaxed to `*` --
-# fails 2, both named in the list above.
+# Measured rather than asserted (2026-08-26), and re-measured after each fix:
+# an always-`exit 0` stub fails 14 of these and an always-`exit 2` stub fails 39
+# of 40, so neither direction can pass vacuously. Targeted mutants: the scan's
+# `[[:space:]]+` relaxed to `*` fails exactly 1 (the no-body space-rule case);
+# reverting the body-file precedence fails exactly 2 (both `--title` cases);
+# dropping the bare `-F <path>` arm fails exactly 1.
 
 set -u
 
@@ -53,7 +61,23 @@ STUBDIR="$TMPBASE/bin"
 mkdir -p "$STUBDIR"
 cat > "$STUBDIR/gh" <<'STUB'
 #!/usr/bin/env bash
+# The stub RECORDS its argv and answers PER ISSUE NUMBER. Both matter: a stub
+# that ignores the invocation cannot tell a lookup of the right issue from a
+# lookup of the wrong one, so rewriting `existing_labels` to `gh issue view 1`
+# -- dropping the number AND the `-R` -- left the suite fully green while real
+# gh would answer about a different issue.
+[ -n "${GH_CALL_LOG:-}" ] && printf '%s\n' "$*" >> "$GH_CALL_LOG"
 if [ -n "${GH_STUB_FAIL:-}" ]; then exit 1; fi
+if [ "$1 $2" = "issue view" ]; then
+  n="$3"
+  case "$n" in ''|*[!0-9]*) n="" ;; esac
+  if [ -n "$n" ]; then
+    # `${VAR-...}` without the colon, so `ISSUE_42=""` means "the issue exists
+    # and carries NO labels" -- a distinct state from "gh could not answer".
+    v=$(eval "printf '%s' \"\${ISSUE_$n-__UNSET__}\"")
+    if [ "$v" != "__UNSET__" ]; then printf '%s\n' $v; exit 0; fi
+  fi
+fi
 printf '%s\n' ${GH_STUB_LABELS:-}
 STUB
 chmod +x "$STUBDIR/gh"
@@ -86,7 +110,10 @@ run_msg() {
   payload=$(jq -n --arg c "$command" --arg d "$cwd" \
     '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
   out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
-  if [ "$rc" -eq "$expect" ] && printf '%s' "$out" | grep -qF "$needle"; then
+  # `grep -qF -- "$needle"`: without the `--`, a needle that starts with a dash
+  # (`--add-label`) is parsed as grep's own option and the case fails on a
+  # message that carries exactly what it asked for.
+  if [ "$rc" -eq "$expect" ] && printf '%s' "$out" | grep -qF -- "$needle"; then
     echo "PASS: $name (exit $rc, message matched)"
     PASS=$((PASS + 1))
   else
@@ -151,6 +178,13 @@ run "create: a bare --label does not satisfy itself" \
 run "create: the label spelling in a TITLE is not a classification" \
   "gh issue create -t 'add a severity:high label to the tracker' --body-file $BODY_NONE" \
   "$TMPROOT" 0
+# The same, with NO body at all, so the scan falls through to the whole segment
+# -- the ONLY path on which the space rule can still be observed once the body
+# file takes precedence over the segment text. Relaxing `[[:space:]]+` to `*`
+# makes this a refusal, and it is the sole case that catches that mutation.
+run "create: (space rule) a label spelling with no body is not a classification" \
+  "gh issue create -t 'add a severity:high label to the tracker' --label bug" \
+  "$TMPROOT" 0
 run "create: inline --body carrying the lines" \
   "gh issue create -t x --body 'Broken. Severity: medium -- workaround exists. Effort: small (S) -- unit tests only.' --label severity:medium --label effort:small" \
   "$TMPROOT" 0
@@ -199,6 +233,89 @@ GH_STUB_LABELS="bug" \
   run "edit: issue number unresolvable -- fail open" \
   "gh issue edit --body-file $BODY_BOTH" \
   "$TMPROOT" 0
+# The number must come from the `issue edit` ARGUMENT. An unanchored
+# `/issues/N` scan reads a link the BODY happens to contain -- routine here --
+# and a greedy `.*` takes the LAST one, so this looked up 999's labels and let
+# an unlabelled 42 through. The stub answers for whatever number is asked, so
+# the two arms below separate them: 42 carries only `bug` (BLOCK), 999 has both.
+ISSUE_42="bug" ISSUE_999="severity:high effort:large" \
+  run_msg "edit: a /issues/N URL in the body does not hijack the lookup" \
+  "gh issue edit 42 --body-file $BODY_BOTH --body 'see https://github.com/other/repo/issues/999'" \
+  "$TMPROOT" 2 "severity:high"
+# Exit code alone cannot separate "asked about 42 and found nothing" from
+# "asked about 999 and the answer was discarded", so assert the ARGV.
+: > "$TMPBASE/calls.log"
+GH_CALL_LOG="$TMPBASE/calls.log" ISSUE_42="bug" ISSUE_999="severity:high effort:large" \
+  run "edit: (argv probe) the lookup runs at all" \
+  "gh issue edit 42 -R go-to-k/cdkd --body-file $BODY_BOTH --body 'see https://github.com/other/repo/issues/999'" \
+  "$TMPROOT" 2
+if grep -q '^issue view 42 ' "$TMPBASE/calls.log" \
+  && grep -q -- '-R go-to-k/cdkd' "$TMPBASE/calls.log" \
+  && ! grep -q '^issue view 999' "$TMPBASE/calls.log"; then
+  echo "PASS: edit: gh was asked about issue 42 in the -R repo, not the body's 999"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: edit: wrong gh invocation"
+  sed 's/^/      /' "$TMPBASE/calls.log"
+  FAIL=$((FAIL + 1))
+fi
+# ...and the URL form of the ARGUMENT itself still resolves.
+ISSUE_42="severity:high effort:large" \
+  run "edit: the issue URL as the argument resolves" \
+  "gh issue edit https://github.com/go-to-k/cdkd/issues/42 --body-file $BODY_BOTH" \
+  "$TMPROOT" 0
+
+# --- flag spellings and precedence ------------------------------------------
+# `-F <path>` is gh's short `--body-file`. Missing it meant the body was never
+# scanned and the gate exited 0 on a body stating `Severity: high`.
+run_msg "create: bare -F <path> is read as the body" \
+  "gh issue create -t x -F $BODY_BOTH" \
+  "$TMPROOT" 2 "severity:high"
+run "create: bare -F <path> with the labels" \
+  "gh issue create -t x -F $BODY_BOTH --label severity:high --label effort:large" \
+  "$TMPROOT" 0
+run "create: --body-file= equals form" \
+  "gh issue create -t x --body-file=$BODY_BOTH --label severity:high --label effort:large" \
+  "$TMPROOT" 0
+# `-l` is gh's short `--label`, and on `gh issue create|edit` it is unambiguous.
+# Missing it was a false BLOCK on a command already carrying what is asked for.
+run "create: -l is accepted as --label" \
+  "gh issue create -t x --body-file $BODY_BOTH -l severity:high -l effort:large" \
+  "$TMPROOT" 0
+# The body FILE outranks the segment text. Without that precedence a spaced
+# mention in an unrelated flag was quoted back as though the body said it.
+run "create: a --title mention does not outrank the body's own line" \
+  "gh issue create -t 'Severity: high pages fail on retry' --body-file $BODY_PACKED --label severity:medium" \
+  "$TMPROOT" 0
+# ...and the same for an inline --body, which outranks the rest of the segment.
+run "create: a --title mention does not outrank an inline --body" \
+  "gh issue create -t 'Severity: high pages fail' --body 'Severity: low -- tidiness only' --label severity:low" \
+  "$TMPROOT" 0
+# The opt-in must follow a leading `cd`, or a chain that starts outside the repo
+# files into it ungated. Degrades to the payload cwd on a matcher with no
+# `cmd_last_cd_target`, so this case is skipped there rather than failing.
+if grep -q 'cmd_last_cd_target' "$(dirname "$HOOK")/lib/command-match.sh" 2>/dev/null; then
+  run_msg "create: a leading cd into the opted-in repo arms the gate" \
+    "cd $TMPROOT && gh issue create -t x --body-file $BODY_BOTH" \
+    "$NOOPTIN" 2 "severity:high"
+fi
+# The edit arm's remediation must name --add-label, not --label: an `edit`
+# caller told to use `--label` reads it as "re-file the issue".
+ISSUE_42="bug" \
+  run_msg "edit: the refusal names --add-label" \
+  "gh issue edit 42 --body-file $BODY_BOTH" \
+  "$TMPROOT" 2 "--add-label"
+# Fail-open is about the LOOKUP FAILING, not about it returning nothing, so it
+# must hold even when the command supplies some of the labels.
+GH_STUB_FAIL=1 \
+  run "edit: gh fails while the command supplies one label -- still open" \
+  "gh issue edit 42 --body-file $BODY_BOTH --add-label severity:high" \
+  "$TMPROOT" 0
+# ...while an issue that genuinely carries NO labels is still refused.
+ISSUE_42="" \
+  run_msg "edit: an issue with no labels at all is refused" \
+  "gh issue edit 42 --body-file $BODY_BOTH" \
+  "$TMPROOT" 2 "severity:high"
 
 # --- not gated / not armed --------------------------------------------------
 run "gh issue comment is not gated" \

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -150,6 +150,36 @@ The hooks split into three classes:
   `.claude/hooks/issue-dup-check-gate.test.sh` (83 cases) plus
   recognition cases in `gate-command-recognition.test.sh`.
 
+- **`issue-classification-label-gate.sh`** blocks `gh issue create` /
+  `gh issue edit` when the body being published states a `Severity:` or
+  `Effort:` value that the issue's LABELS do not carry. The four
+  classification fields live in the body as prose lines, which is where
+  their one-line reasons belong — and nothing about how they are written
+  changes. But prose is invisible to every query the backlog is triaged
+  with: ranking by `Severity` costs one `gh issue view` per candidate,
+  while `gh issue list --label severity:high` is one call. So the two
+  fields with a CLOSED token set are mirrored onto labels:
+  `severity:high|medium|low` and `effort:small|medium|large`. Only those
+  two — `Session-fit` is re-decided at claim time and a label silently
+  disagreeing with the body is worse than none, and `Estimate` is a
+  free-form duration whose informative half a label cannot hold.
+  `gh issue edit` IS gated here and `gh issue comment` is not, which is
+  the opposite split from `issue-dup-check-gate.sh` and is deliberate:
+  that gate steers toward folding into an existing issue, while `edit`
+  is the CLAIM site where an old packed body is rewritten into the
+  four-line shape, so it is where `Severity` first exists for the bulk
+  of the backlog. On `edit` the gate asks gh what labels the issue
+  already carries, so a re-edit of an already-labelled issue is untaxed;
+  an unresolvable issue number or a gh failure FAILS OPEN. The scan
+  requires at least one SPACE after the key, and that separation is the
+  whole gate: the label spelling is `severity:high` with no space, the
+  body form is `Severity: high`, and without it a `--label` would
+  satisfy its own requirement. Covered by
+  `.claude/hooks/issue-classification-label-gate.test.sh` (25 cases,
+  green under bash 5.x and macOS system bash 3.2; mutation-probed
+  2026-08-26 — an always-`exit 0` stub fails 7, an always-`exit 2` stub
+  fails all 25, and relaxing the space rule fails exactly 2).
+
 - **`docs-inline-json-flag-gate.sh`** blocks `gh pr create` /
   `gh pr edit` / `gh pr merge` (and their `gh -C <path>` / `cd <path>
   && ...` forms) when a Markdown file in the resolved PR diff (or

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -157,7 +157,10 @@ The hooks split into three classes:
   their one-line reasons belong — and nothing about how they are written
   changes. But prose is invisible to every query the backlog is triaged
   with: ranking by `Severity` costs one `gh issue view` per candidate,
-  while `gh issue list --label severity:high` is one call. So the two
+  while `gh issue list --label severity:high` is one call. The label
+  changes the PRICE of asking, not the coverage — an issue carrying the
+  line but not the label predates the labels, so a label-only query
+  under-counts and the body stays the authority. So the two
   fields with a CLOSED token set are mirrored onto labels:
   `severity:high|medium|low` and `effort:small|medium|large`. Only those
   two — `Session-fit` is re-decided at claim time and a label silently
@@ -170,15 +173,24 @@ The hooks split into three classes:
   four-line shape, so it is where `Severity` first exists for the bulk
   of the backlog. On `edit` the gate asks gh what labels the issue
   already carries, so a re-edit of an already-labelled issue is untaxed;
-  an unresolvable issue number or a gh failure FAILS OPEN. The scan
-  requires at least one SPACE after the key, and that separation is the
-  whole gate: the label spelling is `severity:high` with no space, the
-  body form is `Severity: high`, and without it a `--label` would
+  an unresolvable issue number or a gh failure FAILS OPEN. The `gh api
+  repos/<o>/<r>/issues` REST mint is gated on the same footing as
+  `gh issue create`. Body text is read in descending order of
+  specificity — a readable `--body-file` / `-F <path>`, else the WHOLE
+  command when such a path is named but does not exist yet (the
+  `heredoc -> file -> --body-file` shape), else an inline `--body`, else
+  the whole segment — and on that last path the scan requires at least
+  one SPACE after the key, so `severity:high` in a `--label` cannot
   satisfy its own requirement. Covered by
-  `.claude/hooks/issue-classification-label-gate.test.sh` (25 cases,
-  green under bash 5.x and macOS system bash 3.2; mutation-probed
-  2026-08-26 — an always-`exit 0` stub fails 7, an always-`exit 2` stub
-  fails all 25, and relaxing the space rule fails exactly 2).
+  `.claude/hooks/issue-classification-label-gate.test.sh` (40 cases; 39
+  run here, since the leading-`cd` opt-in case needs a
+  `cmd_last_cd_target` this repo's matcher does not carry, and the gate
+  degrades to the payload cwd there). Green under bash 5.x and macOS
+  system bash 3.2; mutation-probed in cdkd 2026-08-26 against the
+  byte-identical script — an always-`exit 0` stub fails 14, an
+  always-`exit 2` stub 39 of 40, relaxing the space rule exactly 1,
+  reverting the body-file precedence exactly 2, dropping the bare
+  `-F <path>` arm exactly 1.
 
 - **`docs-inline-json-flag-gate.sh`** blocks `gh pr create` /
   `gh pr edit` / `gh pr merge` (and their `gh -C <path>` / `cd <path>

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -128,6 +128,20 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/issue-classification-label-gate.sh",
+            "if": "Bash(*gh*issue*create*)",
+            "timeout": 15,
+            "statusMessage": "Checking the issue's Severity / Effort labels match its body..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/issue-classification-label-gate.sh",
+            "if": "Bash(*gh*issue*edit*)",
+            "timeout": 15,
+            "statusMessage": "Checking the issue's Severity / Effort labels match its body..."
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/issue-dup-check-gate.sh",
             "if": "Bash(*gh*api*)",
             "timeout": 10,

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -192,6 +192,16 @@ Effort: small (S) | medium (M) | large (L) - <which verification cycle it drags>
 Estimate: <duration, e.g. ~1-3 h -- never a bare letter> - <what eats the time>
 ```
 
+**Two of the four are ALSO LABELS on the filed issue** -- the body lines stay
+exactly as written, and the same values ride the command as
+`--label severity:<high|medium|low> --label effort:<small|medium|large>`. Prose
+is invisible to `gh issue list`, so ranking by `Severity` costs one
+`gh issue view` per candidate without them. `Session-fit` and `Estimate` get no
+label (the first is re-decided at claim time, the second is a free-form
+duration). Enforced by `.claude/hooks/issue-classification-label-gate.sh`; the
+fix PR inherits the issue's labels via
+`.github/workflows/pr-inherit-issue-labels.yml`, so never hand-add them there.
+
 Four CLASSIFICATION lines, and they stay four. Alongside them the body carries a
 **`Dup-check:`** line -- a filing-time record, not a fifth classification field:
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -446,6 +446,26 @@ record the search in the body so the next hop can see the window was checked:
 Dup-check: searched open issues for <terms> -- none covers this root cause
 ```
 
+**File it with its `Severity` / `Effort` values ALSO as labels** -- the body
+lines stay exactly as written, and the same two values ride the command as
+`--label severity:<high|medium|low> --label effort:<small|medium|large>`:
+
+```bash
+gh issue create -t 'fix(local): ...' --body-file "$B" \
+  --label severity:high --label effort:large
+```
+
+Prose is invisible to `gh issue list`, so ranking by `Severity` costs one
+`gh issue view` per candidate without the labels. Only these two get labels:
+`Session-fit` is re-decided when the issue is claimed and a stale label would be
+worse than none, and `Estimate` is a free-form duration with no closed value set.
+The same applies at the CLAIM, which is where an old packed body is rewritten
+into the four-line shape and therefore where `Severity` first exists for most of
+the backlog -- carry `--add-label` on that `gh issue edit`. Enforced by
+`.claude/hooks/issue-classification-label-gate.sh`. The lane's PR inherits the
+labels from the issue it closes via
+`.github/workflows/pr-inherit-issue-labels.yml`, so never hand-add them to a PR.
+
 **This is not a filing threshold, and it must never be used as one.** §10-0
 below is explicit that `filed <= closed` is not a target and that an unfiled
 finding is strictly worse than a filed one. Nothing here changes WHETHER a

--- a/.github/workflows/pr-inherit-issue-labels.yml
+++ b/.github/workflows/pr-inherit-issue-labels.yml
@@ -1,0 +1,118 @@
+name: PR inherit issue labels
+
+# Copy the labels of every issue a PR CLOSES onto the PR itself.
+#
+# WHY: the classification labels `severity:*` / `effort:*` (CLAUDE.md -> the
+# four TODO classification fields) live on the ISSUE, so a PR list shows no
+# indication of how severe the defect being fixed was or what verification it
+# drags. Copying them makes `gh pr list --label severity:high` answer the same
+# question the issue query does, and a reviewer sees the classification without
+# opening the linked issue.
+#
+# `pull_request_target`, NOT `pull_request`, and NOTHING from the head is
+# checked out or executed. A fork PR's `pull_request` token is read-only, so the
+# copy would silently no-op on exactly the PRs a maintainer did not open -- a
+# workflow that works only for the trusted case is the shape that reads as
+# working while doing nothing. `pull_request_target` runs the workflow
+# definition from the BASE branch with a write token, which is safe here only
+# because the sole PR-controlled input is the body TEXT: it is fetched
+# server-side with `gh pr view` rather than interpolated from the event payload,
+# and it is scanned for `#<digits>` and never handed to a shell.
+#
+# ADD-ONLY. Labels already on the PR are never removed: a human may have
+# curated them, and this workflow re-runs on every `edited`.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: pr-inherit-issue-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  inherit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy linked issues' labels onto the PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Release-management labels are applied AFTER the fix ships. Copying
+          # one onto a PR that has not merged yet states the opposite of the
+          # truth, so they are the one family excluded. `duplicate` / `wontfix`
+          # / `invalid` are triage verdicts on the ISSUE and say nothing about
+          # the PR that fixes it.
+          DENY='^(released|released on @experimental|duplicate|wontfix|invalid)$'
+
+          body=$(gh pr view "$PR_NUMBER" -R "$REPO" --json title,body \
+            -q '"\(.title)\n\(.body // "")"')
+
+          # GitHub's auto-close grammar: a closing keyword, then a parens-FREE
+          # `#N` or a full issue URL in THIS repo. The `Closes (#N)` paren form
+          # is deliberately NOT matched -- it does not auto-close either, and
+          # `.claude/hooks/closes-paren-form-gate.sh` refuses a merge that uses
+          # it, so matching it here would paper over that gate.
+          #
+          # `|| true` on both greps: `set -o pipefail` plus a no-match grep
+          # makes the whole substitution fail, and "this PR closes no issue" is
+          # the ordinary case, not an error.
+          numbers=$( { printf '%s\n' "$body" \
+            | grep -oiE "\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\b[[:space:]]*:?[[:space:]]+(https://github\\.com/$REPO/issues/|#)[0-9]+" \
+            | grep -oE '[0-9]+$' \
+            | sort -u; } || true)
+
+          if [ -z "$numbers" ]; then
+            echo "No closing reference in the title or body -- nothing to copy."
+            exit 0
+          fi
+
+          want=""
+          for n in $numbers; do
+            # `gh issue view` on a PULL REQUEST number fails, which is exactly
+            # the filter wanted: a PR saying "Closes #<another PR>" must not
+            # inherit that PR's labels.
+            labels=$(gh issue view "$n" -R "$REPO" --json labels \
+              -q '.labels[].name' 2>/dev/null) || {
+              echo "#$n is not an issue in $REPO -- skipped."
+              continue
+            }
+            [ -n "$labels" ] || continue
+            echo "#$n carries: $(printf '%s' "$labels" | tr '\n' ' ')"
+            # `printf` rather than an embedded newline in the assignment: a
+            # literal line break inside this `run: |` block would have to start
+            # at column 0 to be a bare continuation, which ends the block scalar
+            # and makes the YAML unparseable.
+            want=$(printf '%s\n%s' "$want" "$labels")
+          done
+
+          want=$( { printf '%s\n' "$want" | grep -v '^$' | grep -viE "$DENY" | sort -u; } || true)
+          if [ -z "$want" ]; then
+            echo "Nothing left to copy after the deny list."
+            exit 0
+          fi
+
+          have=$(gh pr view "$PR_NUMBER" -R "$REPO" --json labels -q '.labels[].name' || true)
+          add=$( { printf '%s\n' "$want" \
+            | grep -vxF -f <(printf '%s\n' "$have"); } || true)
+          if [ -z "$add" ]; then
+            echo "The PR already carries every label -- nothing to add."
+            exit 0
+          fi
+
+          echo "Adding: $(printf '%s' "$add" | tr '\n' ' ')"
+          # A JSON payload rather than repeated `-f labels[]=...`: label names
+          # contain spaces in this repo (`good first issue`, `help wanted`), and
+          # word-splitting a built-up argument string drops them mid-name.
+          printf '%s\n' "$add" \
+            | jq -R -s '{labels: (split("\n") | map(select(length > 0)))}' \
+            | gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" --input - --silent

--- a/.github/workflows/pr-inherit-issue-labels.yml
+++ b/.github/workflows/pr-inherit-issue-labels.yml
@@ -52,7 +52,10 @@ jobs:
           # truth, so they are the one family excluded. `duplicate` / `wontfix`
           # / `invalid` are triage verdicts on the ISSUE and say nothing about
           # the PR that fixes it.
-          DENY='^(released|released on @experimental|duplicate|wontfix|invalid)$'
+          # `released on @experimental` is not a fixed string: semantic-release
+          # emits `released on @<channel>` per release channel, so enumerating
+          # today's channels defeats the exclusion the moment one is added.
+          DENY='^(released( on @.+)?|duplicate|wontfix|invalid)[[:space:]]*$'
 
           body=$(gh pr view "$PR_NUMBER" -R "$REPO" --json title,body \
             -q '"\(.title)\n\(.body // "")"')
@@ -76,16 +79,39 @@ jobs:
             exit 0
           fi
 
+          # A CAP, stated out loud rather than applied silently. A PR body is
+          # capped at 65536 bytes, which fits ~5000 `Closes #N` references, and
+          # each one costs a `gh issue view` against a GITHUB_TOKEN budget of
+          # ~1000 requests/hour SHARED with every other workflow in the repo. A
+          # fork PR can therefore starve CI. 20 is far above any real PR.
+          found=$(printf '%s\n' "$numbers" | grep -c .)
+          if [ "$found" -gt 20 ]; then
+            echo "::warning::$found closing references found; following only the first 20."
+            numbers=$(printf '%s\n' "$numbers" | head -20)
+          fi
+
           want=""
           for n in $numbers; do
             # `gh issue view` on a PULL REQUEST number fails, which is exactly
             # the filter wanted: a PR saying "Closes #<another PR>" must not
             # inherit that PR's labels.
+            err=$(mktemp)
             labels=$(gh issue view "$n" -R "$REPO" --json labels \
-              -q '.labels[].name' 2>/dev/null) || {
+              -q '.labels[].name' 2>"$err") || {
+              # "not an issue" and "gh could not reach GitHub" are different
+              # states, and mapping both to `continue` made a rate-limit 403
+              # look like a clean skip: the loop would burn the rest of the
+              # budget and report success while copying nothing.
+              if grep -qiE 'rate limit|API rate|HTTP 40[13]|HTTP 5[0-9][0-9]|timeout' "$err"; then
+                echo "::error::gh failed on #$n (transport or rate limit), not a missing issue:"
+                cat "$err"
+                exit 1
+              fi
               echo "#$n is not an issue in $REPO -- skipped."
+              rm -f "$err"
               continue
             }
+            rm -f "$err"
             [ -n "$labels" ] || continue
             echo "#$n carries: $(printf '%s' "$labels" | tr '\n' ' ')"
             # `printf` rather than an embedded newline in the assignment: a

--- a/tests/unit/hooks/gate-if-matchers.test.ts
+++ b/tests/unit/hooks/gate-if-matchers.test.ts
@@ -53,6 +53,7 @@ const REQUIRED: Record<string, string[]> = {
   'post-merge-orphan-push-gate.sh': ['Bash(*git*push*)'],
   'closes-paren-form-gate.sh': ['Bash(*gh*pr*merge*)'],
   'issue-dup-check-gate.sh': ['Bash(*gh*issue*create*)', 'Bash(*gh*api*)'],
+  'issue-classification-label-gate.sh': ['Bash(*gh*issue*create*)', 'Bash(*gh*issue*edit*)'],
   'pr-body-item-number-gate.sh': [
     'Bash(*gh*pr*create*)',
     'Bash(*gh*pr*edit*)',

--- a/tests/unit/hooks/pr-inherit-issue-labels.test.ts
+++ b/tests/unit/hooks/pr-inherit-issue-labels.test.ts
@@ -33,6 +33,17 @@ import { dirname, join } from 'node:path';
  *     view` failing on it rather than by a second API call
  *   - a full issue URL in THIS repo (matched) vs one in another repo (not),
  *     because the other repo's label may not exist here
+ *   - the WRITE target, not just the label set: re-pointing the POST at another
+ *     repo left every earlier case green
+ *   - dedup across two issues sharing a label neither is already on the PR --
+ *     the earlier overlap case confounded `sort -u` with the `have` filter
+ *   - each deny-list entry individually, including the per-channel
+ *     `released on @<channel>` form semantic-release actually emits
+ *
+ * Mutation-probed 2026-08-26: removing the deny list fails 7 of 17; dropping
+ * `sort -u`, re-pointing the POST, accepting the `Closes (#N)` paren form, and
+ * narrowing the deny list back to a fixed `released on @experimental` each fail
+ * exactly 1.
  */
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const WORKFLOW = join(repoRoot, '.github', 'workflows', 'pr-inherit-issue-labels.yml');
@@ -41,8 +52,12 @@ const WORKFLOW = join(repoRoot, '.github', 'workflows', 'pr-inherit-issue-labels
 function extractRunBlock(): string {
   const yml = readFileSync(WORKFLOW, 'utf8');
   const marker = '        run: |\n';
+  // UNIQUENESS is asserted, not assumed. The slice runs to EOF, so a second
+  // step appended after this one would be spliced into the script and executed
+  // as bash by every case below -- or, if it came first, would be the thing
+  // tested while the real block went unexercised.
+  expect(yml.split(marker).length, 'the workflow must carry exactly one `run: |` block').toBe(2);
   const at = yml.indexOf(marker);
-  expect(at, 'the workflow must carry exactly one `run: |` block at this indent').toBeGreaterThan(-1);
   return yml
     .slice(at + marker.length)
     .split('\n')
@@ -73,7 +88,10 @@ beforeAll(() => {
     '    [ "$v" = "__MISSING__" ] && exit 1',
     '    printf %s "$v" | tr "|" "\\n" ;;',
     '  "api "*|"api")',
-    '    echo "API-PAYLOAD:"; cat ;;',
+    // The one WRITE had an unasserted target: re-pointing the POST at another
+    // repo's `pulls/1/labels` left every case green. The argv is echoed so a
+    // case can pin WHERE the labels land, not just which ones.
+    '    echo "API-ARGV: $*"; echo "API-PAYLOAD:"; cat ;;',
     '  *) echo "unexpected gh $*" >&2; exit 1 ;;',
     'esac',
     '',
@@ -87,7 +105,7 @@ afterAll(() => {
 });
 
 /** Runs the extracted block and returns the labels it would POST, sorted. */
-function run(env: Record<string, string>): { out: string; posted: string[] } {
+function run(env: Record<string, string>): { out: string; posted: string[]; target: string } {
   const out = execFileSync('bash', [join(dir, 'script.sh')], {
     encoding: 'utf8',
     env: {
@@ -100,9 +118,10 @@ function run(env: Record<string, string>): { out: string; posted: string[] } {
     },
   });
   const at = out.indexOf('API-PAYLOAD:');
-  if (at === -1) return { out, posted: [] };
+  if (at === -1) return { out, posted: [], target: '' };
+  const header = out.slice(0, at).split('\n').filter((l) => l.startsWith('API-ARGV:')).pop() ?? '';
   const payload = JSON.parse(out.slice(at + 'API-PAYLOAD:'.length));
-  return { out, posted: [...payload.labels].sort() };
+  return { out, posted: [...payload.labels].sort(), target: header.replace('API-ARGV:', '').trim() };
 }
 
 describe('pr-inherit-issue-labels workflow', () => {
@@ -162,6 +181,55 @@ describe('pr-inherit-issue-labels workflow', () => {
       ISSUE_12: 'bug',
     });
     expect(theirs.posted).toEqual([]);
+  });
+
+  it('posts to THIS PR\'s labels endpoint, not somewhere else', () => {
+    const { target } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes #12',
+      ISSUE_12: 'severity:high',
+    });
+    expect(target).toContain('repos/go-to-k/cdk-local/issues/99/labels');
+    expect(target).toContain('--method POST');
+  });
+
+  it('deduplicates a label two closed issues share', () => {
+    // Without `sort -u` this posts the same label twice. The earlier cases
+    // could not see it: their overlap was also already on the PR, so the
+    // `have` filter removed the duplicate for an unrelated reason.
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes #7 and closes #8',
+      ISSUE_7: 'severity:high|bug',
+      ISSUE_8: 'severity:high|effort:small',
+    });
+    expect(posted).toEqual(['bug', 'effort:small', 'severity:high']);
+  });
+
+  it.each([
+    ['released', 'released'],
+    ['duplicate', 'duplicate'],
+    ['wontfix', 'wontfix'],
+    ['invalid', 'invalid'],
+    // Not a fixed string: semantic-release emits one per release channel, so a
+    // hardcoded `released on @experimental` breaks the moment a channel is added.
+    ['a per-channel released label', 'released on @next'],
+  ])('drops %s', (_name, label) => {
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes #12',
+      ISSUE_12: `${label}|severity:high`,
+    });
+    expect(posted).toEqual(['severity:high']);
+  });
+
+  it('finds a closing keyword that appears only in the title', () => {
+    const { posted } = run({
+      PR_TITLE: 'fix(local): drop the phantom flag, fixes #12',
+      PR_BODY: 'No reference in the body at all.',
+      ISSUE_12: 'severity:medium',
+    });
+    expect(posted).toEqual(['severity:medium']);
   });
 
   it('posts nothing when every label is already on the PR', () => {

--- a/tests/unit/hooks/pr-inherit-issue-labels.test.ts
+++ b/tests/unit/hooks/pr-inherit-issue-labels.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * `.github/workflows/pr-inherit-issue-labels.yml` copies a closed issue's
+ * labels onto the PR that closes it. Its whole body is an inline `run:` block,
+ * and it CANNOT be extracted to a script file: the workflow runs on
+ * `pull_request_target` with nothing checked out, so there is no repo file for
+ * it to call. An inline block is otherwise unreachable by any test -- it only
+ * ever executes on GitHub, on a real PR, where a mistake shows up as labels
+ * silently not appearing.
+ *
+ * So this suite EXTRACTS the block and runs it against a PATH-stubbed `gh`.
+ * The stub answers the three reads (`gh pr view --json title,body`,
+ * `gh issue view --json labels`, `gh pr view --json labels`) and echoes the
+ * payload of the one write, so every case asserts the exact label set the
+ * workflow would POST.
+ *
+ * WHAT EACH CASE FENCES -- these are the ways the copy goes wrong quietly:
+ *   - the deny list, so a `released` label (applied by semantic-release AFTER
+ *     the fix ships) never lands on a PR that has not merged
+ *   - label names CONTAINING SPACES (`good first issue`), which a built-up
+ *     `-f labels[]=...` argument string splits mid-name -- the reason the
+ *     payload is JSON
+ *   - `Closes (#N)`, the paren form, which does NOT auto-close and which
+ *     `.claude/hooks/closes-paren-form-gate.sh` refuses at merge. Matching it
+ *     here would paper over that gate
+ *   - a closing reference to a PULL REQUEST number, filtered by `gh issue
+ *     view` failing on it rather than by a second API call
+ *   - a full issue URL in THIS repo (matched) vs one in another repo (not),
+ *     because the other repo's label may not exist here
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const WORKFLOW = join(repoRoot, '.github', 'workflows', 'pr-inherit-issue-labels.yml');
+
+/** The `run: |` block, dedented by its own indentation. */
+function extractRunBlock(): string {
+  const yml = readFileSync(WORKFLOW, 'utf8');
+  const marker = '        run: |\n';
+  const at = yml.indexOf(marker);
+  expect(at, 'the workflow must carry exactly one `run: |` block at this indent').toBeGreaterThan(-1);
+  return yml
+    .slice(at + marker.length)
+    .split('\n')
+    .map((l) => (l.startsWith(' '.repeat(10)) ? l.slice(10) : l))
+    .join('\n');
+}
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'pr-inherit-labels-'));
+  writeFileSync(join(dir, 'script.sh'), extractRunBlock());
+  // Labels are `|`-separated in the fixture env and split to ONE PER LINE here,
+  // because that is what `gh --json labels -q '.labels[].name'` emits. An
+  // earlier stub emitted them space-separated and reported `good first issue`
+  // as three labels -- a stub artefact that would have read as a real defect.
+  const stub = [
+    '#!/usr/bin/env bash',
+    'case "$1 $2" in',
+    '  "pr view")',
+    '    if printf %s "$*" | grep -q "title,body"; then',
+    '      printf "%s\\n" "$PR_TITLE"; printf "%s\\n" "$PR_BODY"',
+    '    else',
+    '      [ -n "${PR_LABELS:-}" ] && printf %s "$PR_LABELS" | tr "|" "\\n"',
+    '    fi ;;',
+    '  "issue view")',
+    '    v=$(eval "printf %s \\"\\${ISSUE_$3:-__MISSING__}\\"")',
+    '    [ "$v" = "__MISSING__" ] && exit 1',
+    '    printf %s "$v" | tr "|" "\\n" ;;',
+    '  "api "*|"api")',
+    '    echo "API-PAYLOAD:"; cat ;;',
+    '  *) echo "unexpected gh $*" >&2; exit 1 ;;',
+    'esac',
+    '',
+  ].join('\n');
+  writeFileSync(join(dir, 'gh'), stub);
+  chmodSync(join(dir, 'gh'), 0o755);
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Runs the extracted block and returns the labels it would POST, sorted. */
+function run(env: Record<string, string>): { out: string; posted: string[] } {
+  const out = execFileSync('bash', [join(dir, 'script.sh')], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH}`,
+      REPO: 'go-to-k/cdk-local',
+      PR_NUMBER: '99',
+      PR_LABELS: '',
+      ...env,
+    },
+  });
+  const at = out.indexOf('API-PAYLOAD:');
+  if (at === -1) return { out, posted: [] };
+  const payload = JSON.parse(out.slice(at + 'API-PAYLOAD:'.length));
+  return { out, posted: [...payload.labels].sort() };
+}
+
+describe('pr-inherit-issue-labels workflow', () => {
+  it('copies the issue labels and drops the release-management ones', () => {
+    const { posted } = run({
+      PR_TITLE: 'fix(local): drop the phantom flag',
+      PR_BODY: 'Closes #12',
+      ISSUE_12: 'bug|severity:high|effort:large|released',
+    });
+    expect(posted).toEqual(['bug', 'effort:large', 'severity:high']);
+  });
+
+  it('keeps a label name that contains spaces intact', () => {
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Fixes #7 and resolves #8',
+      ISSUE_7: 'good first issue|severity:low',
+      ISSUE_8: 'severity:low|effort:small',
+      PR_LABELS: 'severity:low',
+    });
+    // `severity:low` is already on the PR, so only the two new ones are posted.
+    expect(posted).toEqual(['effort:small', 'good first issue']);
+  });
+
+  it('does not match the `Closes (#N)` paren form', () => {
+    const { out, posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes (#12)',
+      ISSUE_12: 'bug|severity:high',
+    });
+    expect(posted).toEqual([]);
+    expect(out).toContain('No closing reference');
+  });
+
+  it('ignores a reference that is not a closing keyword', () => {
+    const { posted } = run({ PR_TITLE: 'chore: tidy', PR_BODY: 'Refs #12', ISSUE_12: 'bug' });
+    expect(posted).toEqual([]);
+  });
+
+  it('skips a closing reference that names a pull request, not an issue', () => {
+    const { out, posted } = run({ PR_TITLE: 'fix: x', PR_BODY: 'Closes #500' });
+    expect(posted).toEqual([]);
+    expect(out).toContain('#500 is not an issue');
+  });
+
+  it('matches a full issue URL in THIS repo but not in another', () => {
+    const mine = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Resolves https://github.com/go-to-k/cdk-local/issues/33',
+      ISSUE_33: 'severity:medium',
+    });
+    expect(mine.posted).toEqual(['severity:medium']);
+
+    const theirs = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes https://github.com/other/repo/issues/12',
+      ISSUE_12: 'bug',
+    });
+    expect(theirs.posted).toEqual([]);
+  });
+
+  it('posts nothing when every label is already on the PR', () => {
+    const { out, posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes #12',
+      ISSUE_12: 'bug|severity:high',
+      PR_LABELS: 'bug|severity:high',
+    });
+    expect(posted).toEqual([]);
+    expect(out).toContain('already carries every label');
+  });
+
+  it('posts nothing when the issue carries only denied labels', () => {
+    const { out, posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes #12',
+      ISSUE_12: 'released|wontfix',
+    });
+    expect(posted).toEqual([]);
+    expect(out).toContain('after the deny list');
+  });
+
+  it('finds a lower-case keyword on its own line in a multi-line body', () => {
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Some text\ncloses #12\n\nmore',
+      ISSUE_12: 'severity:high|effort:small',
+    });
+    expect(posted).toEqual(['effort:small', 'severity:high']);
+  });
+});


### PR DESCRIPTION
## What

`Severity` and `Effort` — two of the four classification fields every filed issue carries — are now ALSO labels on the issue, and a PR inherits the labels of the issues it closes.

The body text and the wrap-report format are unchanged. This adds a second, queryable copy of two values that were already being written.

## Why

The four fields (`Session-fit` / `Severity` / `Effort` / `Estimate`) live in the body as prose, which is the right place for the one-line reason each carries. But prose is invisible to every query the backlog is actually triaged with. `/work-issues` section 3's ranking rule 4 — "higher `Severity` first, when BOTH candidates carry the line" — costs one `gh issue view` per candidate, which is why it sits BELOW a title-prefix heuristic rather than above it. `gh issue list --label severity:high` is one call.

## Which fields, and why not the other two

| field | label |
| --- | --- |
| `Severity: high \| medium \| low` | `severity:high` / `severity:medium` / `severity:low` |
| `Effort: small \| medium \| large` | `effort:small` / `effort:medium` / `effort:large` |

- `Session-fit` gets none: it is re-decided when an issue is claimed, and a label silently disagreeing with the body is worse than no label.
- `Estimate` gets none: it is a free-form duration, and its informative half — what actually eats the time — is exactly what a label cannot hold.

The prefixed full words are CLAUDE.md's "no bare tokens" rule applied to a label. The two scales share the token `medium`, and their initials collide in the dangerous direction: `L` is severity *low*, the least urgent thing there is, and effort *large*, the biggest.

## What lands

1. **`.claude/hooks/issue-classification-label-gate.sh`** — refuses a `gh issue create` / `gh issue edit` whose body states a value the issue's labels do not carry.
   - `gh issue edit` IS gated and `gh issue comment` is not. That is the opposite split from `issue-dup-check-gate.sh`, and deliberate: that gate steers toward folding into an existing issue, while `edit` here is the CLAIM site, where section 3 says an old packed body is rewritten into the four-line shape — so it is where `Severity` first exists for the bulk of the backlog. This is also how the existing backlog gets labelled on touch, by the lane already holding the evidence, rather than by the bulk sweep section 3 forbids.
   - On `edit` the gate asks gh what the issue already carries, so a re-edit of an already-labelled issue is untaxed. An unresolvable issue number or a gh failure FAILS OPEN — a transient gh error must not stop a body edit.
   - **The scan requires at least one SPACE after the key, and that separation is the whole gate.** The label spelling is `severity:high` with no space; the body form is `Severity: high`. Without it a `--label` would satisfy its own requirement, making the gate a no-op that always passes, and a passing mention of the label name in a TITLE would demand a label.
   - An old packed body writing `Effort: ~1-3 h` matches no token, so no `effort:` label is demanded — reading that field as the new `Effort` is exactly the misreading section 3 warns about.
2. **`GATE_RE_GH_ISSUE_EDIT`** in the shared matcher, so the verb is spelled once.
3. **`.github/workflows/pr-inherit-issue-labels.yml`** — copies every label of the issues a PR closes onto the PR itself. Add-only, minus the release-management family (`released` is applied AFTER the fix ships, so copying it onto an unmerged PR states the opposite of the truth). `pull_request_target` with NOTHING checked out: a fork PR's `pull_request` token is read-only, so the copy would silently no-op on exactly the PRs a maintainer did not open, and the only PR-controlled input is the body text, fetched server-side and scanned for `#<digits>` rather than interpolated into a shell.
4. **`tests/unit/hooks/pr-inherit-issue-labels.test.ts`** — extracts that inline `run:` block and runs it against a PATH-stubbed `gh`. The block cannot move to a script file (nothing is checked out), so it would otherwise only ever execute on a real PR, where a mistake shows up as labels silently not appearing.

## Verification

Every fence was mutation-probed rather than asserted; the numbers are in the table below.

Existing open issues were back-filled from the values their own bodies already state — 32 in `go-to-k/cdkd`, 2 in `go-to-k/cdk-local`, 0 in `go-to-k/cdk-real-drift` (it has no open issues). The 88 cdkd issues left unlabelled are the old packed shape: they carry no `Severity:` line at all and their `Effort:` holds a DURATION, so `/work-issues` section 3's ban on manufacturing guesses applies and the gate demands nothing for them either.

Green under bash 5.x and macOS system bash 3.2. Full hook suite (`bash .claude/hooks/run-tests.sh`) green.

The six labels are created in this repo and in `go-to-k/cdkd` / `go-to-k/cdk-real-drift`, which get the same mechanism in their own PRs.

## Review fixes (second commit)

A 4-axis review (spec / code / test / security) found six defects, two of them BLOCKERs — cases where the gate silently did not fire, or consulted the wrong issue. All are fixed and fenced; see the second commit's message for the full list. In brief:

- `-F <path>` (gh's short `--body-file`) was never read, so a body stating `Severity: high` with no label exited 0.
- The `edit` arm took its issue number from any `/issues/N` URL in the command, greedily — so a link inside a `--body` sent the label lookup to a different issue. The `-R` capture had the identical shape. Both are now leftmost-anchored to the `issue edit` verb.
- A `--title 'Severity: high ...'` outranked the body's own line. Body text is now read in descending order of specificity, and the space-after-key rule guards only the last-resort segment path.
- `-l` was not recognised as `--label` (a false block); a leading `cd <repo>` did not steer the opt-in check (the fail-open the sibling gate already fixed); the `edit` fail-open keyed on the lookup returning nothing rather than on it FAILING; and the `gh api repos/<o>/<r>/issues` REST mint was ungated.
- Workflow: an unbounded `Closes #N` fan-out could exhaust the repo's shared `GITHUB_TOKEN` budget from a fork PR (now capped at 20 with a `::warning::` naming what was dropped); a rate-limit 403 was mapped to "not an issue — skipped", so the job reported success while copying nothing; and the deny list hardcoded `released on @experimental` while semantic-release emits `released on @<channel>` per channel.

Tests grew 25 → 40 (gate) and 9 → 17 (workflow). The `gh` stub now records its argv and answers per issue NUMBER: rewriting `existing_labels` to `gh issue view 1` — dropping the number AND the `-R` — previously left the suite fully green.

| suite | cases | always-`exit 0` | always-`exit 2` | targeted mutants |
| --- | --- | --- | --- | --- |
| `issue-classification-label-gate.test.sh` | 40 | fails 14 | fails 39 | space rule `+`→`*`: 1 · body-file precedence reverted: 2 · bare `-F` arm dropped: 1 |
| `pr-inherit-issue-labels.test.ts` | 17 | — | — | deny list removed: 7 · `sort -u` dropped: 1 · POST re-pointed: 1 · paren form accepted: 1 · deny narrowed to a fixed string: 1 |

**Won't-do, recorded here:** the workflow does not trigger on `issues: [labeled]`. It reads the issue's labels when the PR is opened, reopened, or its body edited, which covers the prescribed order (`/work-issues` labels the issue at CLAIM time, before the lane's PR exists). Adding a second privileged `issues`-triggered job to cover the out-of-order case was judged not worth the extra write-token surface; the docs now state the ordering instead of promising immediate propagation.
