### PR TITLE
chore(work-issues): a relayed count is unearned, and "integ last" does not hold still across review rounds

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -367,6 +367,32 @@ Two boundaries, so this does not become a licence for unbounded lanes:
   are two issues; one wrong assumption at five call sites is one. The test is
   whether a single sentence describes the fix at every site.
 
+**A COUNT is a claim, and one RELAYED from a subagent is unearned.** A sweep that
+reports "N sites" in its commit message, its changelog entry and its PR body has
+asserted that number three times, and a reader can only re-derive it if the query
+is there — so paste the command beside the number. The harder half is the count
+you did not derive at all: in this flow the numbers that get published usually
+arrive inside a fan-out agent's summary or a reviewer's finding, already phrased
+as fact, and get copied onward without anyone re-running anything.
+
+Measured in cdkd on 2026-08-26, whose `/work-issues` run published FOUR such
+counts, every one wrong and every one relayed — "all nine sibling sites" (a grep
+found 78 across 14 files), "nine mutation probes" (fourteen), "ten unit shapes"
+(thirteen), and a "if a third copy ever appears" trigger for a predicate that
+already had nine copies. Two went into GitHub artifacts, where they outlive the
+session, and the first was the load-bearing argument for deferring that work to
+an umbrella at all — so being wrong by ~9x under-scoped the deferral it was
+justifying.
+
+The tell is grammatical rather than technical: a number arriving as a WORD
+("nine sites", "a third copy") was counted by a person or an agent, while one
+arriving as command output was counted by a machine. Before a relayed count goes
+anywhere durable — an issue body, a PR body, a changelog entry, this file — run
+the query yourself and put it in the text. It is one command. What worked on that
+run was the implementing agent deriving its next count with `awk` and catching
+its own correction mid-flight, and declining to relay a path from the
+orchestrator's message after grepping and finding no such file.
+
 **And whatever you do file, resolve it against the issues ALREADY OPEN first.**
 The sweep above looks for sibling sites in the CODE. This looks for a sibling
 ISSUE, and it is a different search with a different answer: the issue that
@@ -747,6 +773,24 @@ it already ships repo-wide consistency tests (the four-copies harness
 Run `/verify-pr`. It walks the full checklist (typecheck / lint / build / tests, CI
 status, docs consistency, Docker + integ marker, code review, PR title/body
 freshness) and — critically — **live-tests the changed behavior**:
+
+**Run the integ LAST, and note that "last" does not hold still across review
+rounds — so DECLARE the tree final, in words, to whoever is still editing it.**
+The `integ` gate is `hash: diff` against `merge-base(origin/main, HEAD)`, so it
+digests this branch's DELTA over the include set rather than the working tree's
+behaviour. That has a consequence worth stating outright: a round of review
+fixes whose change to an in-scope file is **comment-only** still stales the
+marker, and still costs a full Docker fixture run. Measured in cdkd on
+2026-08-26, where a lane paid THREE real-AWS runs of one fixture, the third for a
+round whose provider change was verified to carry zero non-comment lines. What
+ended it was telling the implementing agent, before its last pass, to batch every
+remaining finding into ONE commit and report when the tree is FINAL with no
+second pass — after which the integ ran once. Say that explicitly rather than
+assuming it: an agent handed a list of findings will otherwise fix, verify and
+hand back, which is the right instinct everywhere except in front of a gate that
+costs a Docker run. The reviewer-side corollary is the reverse — dispatch a round
+SCOPED to the delta and ask for the whole round's findings at once, rather than
+trickling them.
 
 - **A `src/**` runtime change** → drive the affected flow end-to-end against
   Docker / a fixture (invoke the Lambda, hit the served route, run the task), not


### PR DESCRIPTION
## Summary

Mirrors two `/work-issues` lessons measured in cdkd on 2026-08-26
(go-to-k/cdkd#2261). Both are about the FLOW rather than about cdkd, so section
10-c's default applies — the session that finds a lesson lands it in all three
repos.

Neither rule existed here, so these land as **new text rather than amendments**,
and every claim was re-verified against this repo instead of copied.

## 1. A relayed count is unearned (section 5)

Section 5 already tells you to sweep siblings and to keep the count honest for a
sweep **you** ran. The counts that actually get published in this flow usually
did not come from one — they arrive inside a fan-out agent's summary or a
reviewer's finding, already phrased as fact, and get copied onward without
anyone re-running anything.

That cdkd run published four such counts, every one wrong and every one relayed:

| published | actual |
|---|---|
| "all **nine** sibling sites" | **78** call sites across 14 files |
| "**nine** mutation probes" | **fourteen** |
| "**ten** unit shapes" | **thirteen** |
| "if a **third** copy ever appears" | already **nine** copies |

Two went into GitHub artifacts, where they outlive the session, and the first was
the load-bearing argument for deferring that work to an umbrella — so being wrong
by ~9x under-scoped the deferral it was justifying.

The new text names the grammatical tell (a number arriving as a WORD was counted
by a person or an agent; one arriving as command output was counted by a machine)
and records what ended it: the implementing agent derived its next count with
`awk` and caught its own correction mid-flight, and declined to relay a path from
the orchestrator's message after grepping and finding no such file.

## 2. "Integ last" does not hold still across review rounds (section 8)

Verified against **this repo's** `.markgate.yml`: the `integ` gate is `hash: diff`
over `src/**` and `tests/integration/**`. That means it digests the branch's
DELTA, not the working tree's behaviour — so a review round whose in-scope change
is **comment-only** still stales the marker and still costs a full Docker fixture
run.

The cdkd lane paid three real-AWS runs of one fixture, the third for a round
whose provider change was verified to carry zero non-comment lines. What ended it
was telling the implementing agent, before its last pass, to batch every
remaining finding into ONE commit and report when the tree is FINAL with no
second pass. The reviewer-side corollary is the reverse: dispatch a round scoped
to the delta and ask for the whole round's findings at once.

## Verification

Prose-only change to an agent-instruction file, so per this repo's own §8 "Arm 2"
the CLAIMS are the artifact — each was resolved against this repo, not the
sibling's wording:

- `integ` gate mode and include set — read from this repo's `.markgate.yml`
  (`hash: diff`, `src/**` + `tests/integration/**`), and the cost is stated as a
  Docker fixture run rather than cdkd's real-AWS one.
- `tests/unit/skills/work-issues-skill-refs.test.ts` — **6 passed** (this repo's
  reference fence; every issue reference added is `go-to-k/cdkd#N`).
- `vp check --fix` 0 · `vp run check` 0 · `build` 0 · full suite **215 files /
  3202 tests, rc=0**.
- No cdkd-only artifact is named: the text cites cdkd only as the place the
  measurement was taken, and every mechanism it asserts here (`hash: diff`,
  subagent fan-out) was confirmed present in this repo first.
