### PR TITLE
fix(local): per-site judgement on the start-api log echoes, and resolveSsm coverage

### DIFF
--- a/src/local/rest-v1-integrations.ts
+++ b/src/local/rest-v1-integrations.ts
@@ -724,6 +724,18 @@ function pickRequestTemplate(
  */
 function extractStatusCodeFromRendered(rendered: string): number | undefined {
   const logFallback = (reason: string): undefined => {
+    // Issue #555, reviewed and DELIBERATELY LEFT — do not re-raise this as
+    // an echo of caller request data. `rendered` is the MOCK request
+    // template's output, so it can carry `$input.params(...)` /
+    // `$input.body` material from the incoming request, and `reason` can
+    // carry a `statusCode` value out of the same render. But this is
+    // `debug`: it prints only under `--verbose`, on a server the developer
+    // started, for a request they sent to their own machine — nothing here
+    // was resolved by cdk-local out of a secret or parameter store, which
+    // is the line the sibling redactions in `ecs-secrets-resolver.ts`
+    // (#554) and `sigv4-verify.ts` (#555) draw. Showing what the selection
+    // driver actually saw IS the diagnostic; withholding it would leave
+    // `--verbose` reporting only that a fallback happened.
     const truncated = rendered.length > 200 ? rendered.slice(0, 200) + '...' : rendered;
     getLogger()
       .child('start-api')

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -246,15 +246,15 @@ export async function verifySigV4(
   if (parsed.algorithm !== 'AWS4-HMAC-SHA256') {
     logger.info(
       `AWS_IAM authorizer: rejecting request — unsupported Authorization algorithm ` +
-        `'${parsed.algorithm}'. Expected 'AWS4-HMAC-SHA256'.`
+        `'${redactAuthorizationSegment(parsed.algorithm)}'. Expected 'AWS4-HMAC-SHA256'.`
     );
     return { allow: false, identityHash: undefined };
   }
   if (parsed.credentialTerminator !== 'aws4_request') {
     logger.info(
       `AWS_IAM authorizer: rejecting request — invalid credential-scope terminator ` +
-        `'${parsed.credentialTerminator}'. Expected 'aws4_request' (the last '/' segment ` +
-        `of the Credential= value).`
+        `'${redactAuthorizationSegment(parsed.credentialTerminator)}'. Expected 'aws4_request' ` +
+        `(the last '/' segment of the Credential= value).`
     );
     return { allow: false, identityHash: undefined };
   }
@@ -413,6 +413,16 @@ export async function verifySigV4(
   // key, recompute the signature, compare.
   const recomputed = computeSignature(req, parsed, local.secretAccessKey, amzDate);
   if (!constantTimeEqual(recomputed, parsed.signature)) {
+    // Deliberately NOT routed through `redactAuthorizationSegment` (issue
+    // #555). This echo is a different population from the sweep-in ones it
+    // guards: the value is a PARSED `Signature=` field rather than whatever
+    // a mis-delimited split swept into a segment, it is a per-request HMAC
+    // rather than a durable credential, and this branch is reachable only
+    // after the request's access-key id matched the credentials cdk-local
+    // resolved locally — so it is provably the developer's own signature,
+    // not a third party's. Printing it beside the recomputed one IS the
+    // diagnostic (issue #246): a mismatch is only actionable when both
+    // sides are visible. Leave it.
     logger.info(
       `AWS_IAM authorizer: rejecting request — Signature= mismatch (recomputed ` +
         `'${recomputed}', got '${parsed.signature}'). The request was signed with the ` +
@@ -427,6 +437,48 @@ export async function verifySigV4(
     principalId: parsed.credentialAccessKeyId,
     identityHash: buildIdentityHash([parsed.signature]),
   };
+}
+
+/**
+ * Upper bound on how much of an `Authorization`-header segment a rejection
+ * message may quote. Every segment those messages legitimately name is a
+ * short token — `AWS4-HMAC-SHA256` (16 characters), `aws4_request` (12), a
+ * `YYYYMMDD` date (8) — so this leaves each actionable case quoted whole.
+ */
+const AUTH_SEGMENT_QUOTE_MAX = 32;
+
+/**
+ * Quote one caller-supplied `Authorization`-header segment for a rejection
+ * message, or withhold it when it cannot be a segment.
+ *
+ * Issue #555. These messages are `info`, not `debug`, so they print on a
+ * plain `cdkl start-api` run rather than only under `--verbose` — a
+ * different population from a verbose-gated diagnostic, and the reason the
+ * auth-header sites were the ones worth changing. What each names is a
+ * POSITION in the header, and a position holds only its own short token
+ * while the header's delimiters sit where the parser expects them. When
+ * they do not — `Credential=AKID/20260101/us-east-1/execute-api/aws4_request
+ * SignedHeaders=host Signature=<hex>`, a hand-written header using spaces
+ * where AWS wants commas — the split sweeps the REST of the header into the
+ * final segment, and the terminator message prints the `Signature=`
+ * component at default level.
+ *
+ * So a quote is allowed only for input that could still BE one segment: no
+ * whitespace, no `=`, no longer than {@link AUTH_SEGMENT_QUOTE_MAX}. Any of
+ * those failing means the parse boundary was elsewhere and the value is
+ * unrelated header material of unknown extent, reported by shape instead.
+ * Every genuine typo (`aws3_request`, `AWS4-HMAC-SHA512`) stays quoted in
+ * full — the actionability issue #246 added these messages for — while the
+ * sweep-in case degrades to a character count.
+ *
+ * Not every echo in this file goes through here, deliberately: see the
+ * `Signature=` mismatch message in {@link verifySigV4}.
+ */
+export function redactAuthorizationSegment(segment: string): string {
+  if (segment.length > AUTH_SEGMENT_QUOTE_MAX || /[\s=]/.test(segment)) {
+    return `<withheld: ${segment.length} characters of unparsed header material>`;
+  }
+  return segment;
 }
 
 /**
@@ -446,9 +498,18 @@ export function parseAuthorizationHeader(value: string): ParsedAuthorization {
   // is permitted by the AWS spec.
   const parts = rest.split(',').map((s) => s.trim());
   const fields: Record<string, string> = {};
-  for (const part of parts) {
+  for (const [i, part] of parts.entries()) {
     const eq = part.indexOf('=');
-    if (eq < 0) throw new Error(`malformed parameter '${part}'`);
+    // Report the POSITION, never the content. A part reaching here holds no
+    // `=`, so quoting it says nothing about the fault the message already
+    // names -- while an `Authorization: Basic <base64>` sent to an AWS_IAM
+    // route arrives as exactly one such part, and quoting it would print
+    // that credential at `info` (issue #555). The developer reading the
+    // message is holding the header they sent; an index locates the part
+    // for them without cdk-local repeating any of it.
+    if (eq < 0) {
+      throw new Error(`malformed parameter ${i + 1} of ${parts.length} (no '=' in it)`);
+    }
     const key = part.slice(0, eq).trim();
     const val = part.slice(eq + 1).trim();
     fields[key] = val;
@@ -464,7 +525,15 @@ export function parseAuthorizationHeader(value: string): ParsedAuthorization {
   // Credential format: AKID/YYYYMMDD/region/service/aws4_request
   const credParts = credential.split('/');
   if (credParts.length !== 5) {
-    throw new Error(`malformed Credential '${credential}' (expected 5 slash-separated segments)`);
+    // Count, not content: the whole Credential= value is the one segment
+    // that can never be safely quoted. It is unbounded, it is the position
+    // a hand-written (space- rather than comma-delimited) header sweeps the
+    // REST of the Authorization value into -- `Signature=<hex>` included --
+    // and the count is what makes the fault actionable anyway (issue #555).
+    throw new Error(
+      `malformed Credential: expected 5 slash-separated segments ` +
+        `'<AKID>/<YYYYMMDD>/<region>/<service>/aws4_request', got ${credParts.length}`
+    );
   }
   const [accessKeyId, date, region, service, terminator] = credParts as [
     string,
@@ -475,7 +544,9 @@ export function parseAuthorizationHeader(value: string): ParsedAuthorization {
   ];
 
   if (!/^[0-9]{8}$/.test(date)) {
-    throw new Error(`malformed credential date '${date}' (expected YYYYMMDD)`);
+    throw new Error(
+      `malformed credential date '${redactAuthorizationSegment(date)}' (expected YYYYMMDD)`
+    );
   }
 
   return {

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -272,26 +272,9 @@ export async function verifySigV4(
     return { allow: false, identityHash: undefined };
   }
   if (!validateAmzDateMatchesCredentialDate(amzDate, parsed.credentialDate)) {
-    // The `x-amz-date` / `date` value is quoted RAW here and in the
-    // clock-skew message below. Issue #555 reviewed this and DELIBERATELY
-    // LEFT it — do not route it through `redactAuthorizationSegment`.
-    //
-    // It is not an `Authorization` segment: `pickHeader` reads the whole
-    // header, so no delimiter mistake can sweep the developer's own
-    // `Signature=` into it. What lands here is whatever the CALLER put in
-    // their own timestamp header, echoed back to the terminal of the
-    // developer they sent it to — the same population as the debug-gated
-    // sites in `websocket-server.ts`, differing only in level.
-    //
-    // And a shape-based bound would cost the actual diagnostic. The value
-    // reaching THIS branch is often a perfectly valid timestamp that simply
-    // disagrees with the credential scope, and its legal spellings carry
-    // spaces and run long: RFC 1123 `Mon, 02 Jan 2006 15:04:05 GMT` is 29
-    // characters, and `new Date().toString()` — which a naive client may
-    // send — is 75. A whitespace or short-length rule withholds exactly the
-    // case the user needs to read.
     logger.info(
-      `AWS_IAM authorizer: rejecting request — x-amz-date '${amzDate}' does not match ` +
+      `AWS_IAM authorizer: rejecting request — x-amz-date / date ` +
+        `'${boundTimestampHeader(amzDate)}' does not match ` +
         `credential-scope date '${parsed.credentialDate}'. The 'YYYYMMDD' prefix of ` +
         `x-amz-date must equal the date segment of Credential=<AKID>/<YYYYMMDD>/...`
     );
@@ -304,7 +287,8 @@ export async function verifySigV4(
   const now = (opts.now ?? ((): Date => new Date()))();
   if (amzDateOutsideSkew(amzDate, now)) {
     logger.info(
-      `AWS_IAM authorizer: rejecting request — x-amz-date '${amzDate}' is outside the ` +
+      `AWS_IAM authorizer: rejecting request — x-amz-date / date ` +
+        `'${boundTimestampHeader(amzDate)}' is outside the ` +
         `15-minute clock-skew window (local now=${now.toISOString()}). Re-sign the ` +
         `request with the current time or sync the local clock.`
     );
@@ -323,6 +307,17 @@ export async function verifySigV4(
     // cdk-local cannot fully emulate. `--strict-sigv4` flips this to
     // fail-closed. OAC-fronted routes always pass (no client signature
     // exists to verify in production).
+    // NOTE (issue #564): `reason` is the credential CHAIN's own error text,
+    // relayed unbounded into the `warn` lines below. With a
+    // `credential_process` profile the SDK runs the configured command
+    // through `child_process.exec` and rethrows Node's
+    // `Command failed: <command line>\n<stderr>`, so a passphrase on that
+    // command line reaches a default-level log. Issue #555's sweep covered
+    // caller-supplied `Authorization` material and did not reach this,
+    // which points the other way — the developer's own machine config.
+    // Left here so a later sweep finds the pointer rather than re-deriving
+    // it; the fix belongs in #564 with its own judgement about how much of
+    // a credential-loader failure may print.
     const reason = err instanceof Error ? err.message : String(err);
     const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();
     if (opts.strict && !opts.oacFronted) {
@@ -472,13 +467,14 @@ export async function verifySigV4(
  * Upper bound on how much of an `Authorization`-header segment a rejection
  * message may quote.
  *
- * 32 is the smallest bound that still quotes every value these messages
- * legitimately name: `AWS4-HMAC-SHA256` (16 characters) plus the longer
- * legacy `AWS4-HMAC-SHA256-...` spellings this parser deliberately rejects,
- * `aws4_request` (12), a `YYYYMMDD` date (8), and a real 20-character
- * access-key id. It also sits below the 40 characters of an AWS SECRET
- * access key, so the one way a developer's own secret enters this header —
- * pasting it into `AWS_ACCESS_KEY_ID` — is withheld rather than quoted.
+ * 32 clears every value these messages legitimately name, with room to
+ * spare: `AWS4-HMAC-SHA256` is 16 characters, the longest real algorithm
+ * spelling this parser rejects (`AWS4-ECDSA-P256-SHA256-PAYLOAD`) is 30,
+ * `aws4_request` is 12, a `YYYYMMDD` date is 8, and an access-key id is 20.
+ * The ceiling is what fixes it at 32 rather than higher: an AWS SECRET
+ * access key is 40 characters, and pasting one into `AWS_ACCESS_KEY_ID` is
+ * the one way a developer's own secret reaches this header — so the bound
+ * has to sit below 40 for that paste to be withheld rather than quoted.
  */
 const AUTH_SEGMENT_QUOTE_MAX = 32;
 
@@ -521,15 +517,56 @@ export function redactAuthorizationSegment(segment: string): string {
 }
 
 /**
+ * Bound on the `x-amz-date` / `date` echo. Every legal spelling is far
+ * below it. Measured on Node 24: RFC 1123 `Mon, 02 Jan 2006 15:04:05 GMT`
+ * is 29 characters; `new Date().toString()` runs 45 to 76 depending on the
+ * zone name (55 on the machine this was written on, 76 for
+ * `Australia/Eucla`) across all 418 zones `Intl.supportedValuesOf` lists;
+ * and the longest spelling `Date` was observed to PARSE,
+ * `Wednesday, December 31, 2025 00:00:00 GMT+0000 (Coordinated Universal
+ * Time)`, is 75. So nothing actionable is ever withheld.
+ */
+const TIMESTAMP_HEADER_QUOTE_MAX = 200;
+
+/**
+ * Bound the `x-amz-date` / `date` echo by LENGTH ONLY.
+ *
+ * Issue #555 reviewed this site and deliberately did NOT route it through
+ * {@link redactAuthorizationSegment}. It is not an `Authorization` segment:
+ * `pickHeader` reads the whole header, so no delimiter mistake can sweep a
+ * `Signature=` component into it, and what lands here is whatever the
+ * CALLER put in their own timestamp header. More to the point, a SHAPE
+ * bound would withhold exactly the case the message exists for — the value
+ * reaching the mismatch branch is usually a perfectly valid timestamp that
+ * simply disagrees with the credential scope, and the legal spellings carry
+ * spaces and run long (see {@link TIMESTAMP_HEADER_QUOTE_MAX}). A
+ * whitespace clause or a 32-character cap withholds all of them.
+ *
+ * "No shape bound" is not "no bound", though. The value is unbounded caller
+ * input printed at `info`, and `cdkl studio` mirrors these lines into a log
+ * ring it serves over HTTP, so a length cap costs nothing and ends the
+ * flood. Do not tighten it into a shape check.
+ */
+export function boundTimestampHeader(value: string): string {
+  if (value.length > TIMESTAMP_HEADER_QUOTE_MAX) {
+    return `<withheld: ${value.length} characters, too long to be a timestamp>`;
+  }
+  return value;
+}
+
+/**
  * Quote the caller's OFFERED `Signature=` value, or withhold it when that
  * field swept in material which is not a signature.
  *
  * `Signature=` is the LAST parameter of the header, which makes it a sweep
  * position exactly like the credential-scope terminator: a header ending
  * `..., Signature=<hex> X-Anything=foo` parses to a `signature` of
- * `<hex> x-anything=foo`. A real SigV4 signature is lowercase hex, at most
- * 64 characters, so requiring precisely that quotes every legitimate value
- * — the one issue #246 needs the user to compare — and withholds the rest.
+ * `<hex> x-anything=foo`. A real SigV4 signature is lowercase hex and
+ * EXACTLY 64 characters; the predicate accepts 1 to 64 rather than exactly
+ * 64 only so that a short but otherwise plausible value still shows (a
+ * truncated paste is worth seeing). Either way it quotes every legitimate
+ * value — the one issue #246 needs the user to compare — and withholds
+ * anything a mis-delimited split swept in.
  *
  * This covers the OFFERED signature only. The RECOMPUTED one is never
  * printed; the mismatch message in {@link verifySigV4} says why.

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -272,6 +272,24 @@ export async function verifySigV4(
     return { allow: false, identityHash: undefined };
   }
   if (!validateAmzDateMatchesCredentialDate(amzDate, parsed.credentialDate)) {
+    // The `x-amz-date` / `date` value is quoted RAW here and in the
+    // clock-skew message below. Issue #555 reviewed this and DELIBERATELY
+    // LEFT it — do not route it through `redactAuthorizationSegment`.
+    //
+    // It is not an `Authorization` segment: `pickHeader` reads the whole
+    // header, so no delimiter mistake can sweep the developer's own
+    // `Signature=` into it. What lands here is whatever the CALLER put in
+    // their own timestamp header, echoed back to the terminal of the
+    // developer they sent it to — the same population as the debug-gated
+    // sites in `websocket-server.ts`, differing only in level.
+    //
+    // And a shape-based bound would cost the actual diagnostic. The value
+    // reaching THIS branch is often a perfectly valid timestamp that simply
+    // disagrees with the credential scope, and its legal spellings carry
+    // spaces and run long: RFC 1123 `Mon, 02 Jan 2006 15:04:05 GMT` is 29
+    // characters, and `new Date().toString()` — which a naive client may
+    // send — is 75. A whitespace or short-length rule withholds exactly the
+    // case the user needs to read.
     logger.info(
       `AWS_IAM authorizer: rejecting request — x-amz-date '${amzDate}' does not match ` +
         `credential-scope date '${parsed.credentialDate}'. The 'YYYYMMDD' prefix of ` +
@@ -360,13 +378,13 @@ export async function verifySigV4(
       if (!warned || !warned.has(dedupKey)) {
         logger.warn(
           sigV4StrictByDefault
-            ? `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+            ? `AWS_IAM authorizer: request signed with access-key-id '${redactAuthorizationSegment(parsed.credentialAccessKeyId)}', ` +
                 `which differs from the AWS credentials cdk-local resolved locally — SigV4 (HMAC / ` +
                 `shared-secret) can only be verified with the signer's own credentials, never a ` +
                 `federated / Cognito Identity Pool / cross-account signer's. cdk-local denies it by ` +
                 `default; pass ${optFlag} to warn-and-pass, or sign the request with the same ` +
                 `credentials cdk-local resolves locally.`
-            : `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+            : `AWS_IAM authorizer: request signed with access-key-id '${redactAuthorizationSegment(parsed.credentialAccessKeyId)}', ` +
                 `which differs from the AWS credentials cdk-local resolved locally — SigV4 (HMAC / ` +
                 `shared-secret) can only be verified with the signer's own credentials, never a ` +
                 `federated / Cognito Identity Pool / cross-account signer's. ${optFlag} is set, so ` +
@@ -380,17 +398,17 @@ export async function verifySigV4(
     if (!warned || !warned.has(dedupKey)) {
       logger.warn(
         opts.oacFronted
-          ? `AWS_IAM authorizer: Function URL is fronted by CloudFront OAC — in production CloudFront re-signs the origin request, so the local client's signature (access-key-id '${parsed.credentialAccessKeyId}') cannot be verified. ` +
+          ? `AWS_IAM authorizer: Function URL is fronted by CloudFront OAC — in production CloudFront re-signs the origin request, so the local client's signature (access-key-id '${redactAuthorizationSegment(parsed.credentialAccessKeyId)}') cannot be verified. ` +
               `Passing through with unverified principalId 'unverified-foreign-identity'. ` +
               `Do NOT trust event.requestContext.authorizer.principalId in handler code.`
           : sigV4StrictByDefault
-            ? `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+            ? `AWS_IAM authorizer: request signed with access-key-id '${redactAuthorizationSegment(parsed.credentialAccessKeyId)}', ` +
               `a federated / Cognito Identity Pool / cross-account signer cdk-local cannot verify ` +
               `locally (SigV4 is an HMAC shared-secret signature; the deployed API Gateway verifies ` +
               `it because AWS holds the secret). ${optFlag} is set; passing through with unverified ` +
               `principalId 'unverified-foreign-identity'. Do NOT trust ` +
               `event.requestContext.authorizer.principalId in handler code.`
-            : `AWS_IAM authorizer: request signed with access-key-id '${parsed.credentialAccessKeyId}', ` +
+            : `AWS_IAM authorizer: request signed with access-key-id '${redactAuthorizationSegment(parsed.credentialAccessKeyId)}', ` +
               `a federated / Cognito Identity Pool / cross-account signer cdk-local cannot verify ` +
               `locally (SigV4 is an HMAC shared-secret signature; the deployed API Gateway verifies ` +
               `it because AWS holds the secret). Passing through with unverified principalId ` +
@@ -413,21 +431,32 @@ export async function verifySigV4(
   // key, recompute the signature, compare.
   const recomputed = computeSignature(req, parsed, local.secretAccessKey, amzDate);
   if (!constantTimeEqual(recomputed, parsed.signature)) {
-    // Deliberately NOT routed through `redactAuthorizationSegment` (issue
-    // #555). This echo is a different population from the sweep-in ones it
-    // guards: the value is a PARSED `Signature=` field rather than whatever
-    // a mis-delimited split swept into a segment, it is a per-request HMAC
-    // rather than a durable credential, and this branch is reachable only
-    // after the request's access-key id matched the credentials cdk-local
-    // resolved locally — so it is provably the developer's own signature,
-    // not a third party's. Printing it beside the recomputed one IS the
-    // diagnostic (issue #246): a mismatch is only actionable when both
-    // sides are visible. Leave it.
+    // The RECOMPUTED signature is deliberately NOT printed (issue #555).
+    // It is `HMAC(signing key derived from the developer's real secret
+    // access key, string-to-sign)`, and every input to that string-to-sign
+    // is chosen by the caller: the credential scope's region and service,
+    // the date, the signed-header list and their values, the URI, the query
+    // string, and the payload hash. Reaching this branch needs only an
+    // access-key id equal to the local one, and an access-key id is an
+    // identifier rather than a secret. So echoing the result would make
+    // `cdkl start-api` a signing oracle: send a request canonically
+    // identical to some AWS API call, then read a VALID signature for that
+    // call, under the developer's own credentials, straight off the log.
+    // This site is `info`, so no `--verbose` is needed, and `cdkl studio`
+    // mirrors these lines into a log ring it serves over HTTP.
+    //
+    // The OFFERED signature IS printed. The caller supplied it, so echoing
+    // it back to a local terminal tells them nothing they did not send, and
+    // it is what makes the mismatch actionable (issue #246). The recomputed
+    // hex only restated the inequality the message already names — the
+    // fault itself always lies in the canonical request.
     logger.info(
-      `AWS_IAM authorizer: rejecting request — Signature= mismatch (recomputed ` +
-        `'${recomputed}', got '${parsed.signature}'). The request was signed with the ` +
-        `expected access-key-id but the HMAC does not verify — check the SignedHeaders ` +
-        `list, request body, and canonical-request normalization on the signer side.`
+      `AWS_IAM authorizer: rejecting request — Signature= mismatch (got ` +
+        `'${redactSignature(parsed.signature)}'; the recomputed signature is withheld, ` +
+        `because it is a valid signature for this request under your local credentials). ` +
+        `The request was signed with the expected access-key-id but the HMAC does not ` +
+        `verify — check the SignedHeaders list, request body, and canonical-request ` +
+        `normalization on the signer side.`
     );
     return { allow: false, identityHash: undefined };
   }
@@ -441,9 +470,15 @@ export async function verifySigV4(
 
 /**
  * Upper bound on how much of an `Authorization`-header segment a rejection
- * message may quote. Every segment those messages legitimately name is a
- * short token — `AWS4-HMAC-SHA256` (16 characters), `aws4_request` (12), a
- * `YYYYMMDD` date (8) — so this leaves each actionable case quoted whole.
+ * message may quote.
+ *
+ * 32 is the smallest bound that still quotes every value these messages
+ * legitimately name: `AWS4-HMAC-SHA256` (16 characters) plus the longer
+ * legacy `AWS4-HMAC-SHA256-...` spellings this parser deliberately rejects,
+ * `aws4_request` (12), a `YYYYMMDD` date (8), and a real 20-character
+ * access-key id. It also sits below the 40 characters of an AWS SECRET
+ * access key, so the one way a developer's own secret enters this header —
+ * pasting it into `AWS_ACCESS_KEY_ID` — is withheld rather than quoted.
  */
 const AUTH_SEGMENT_QUOTE_MAX = 32;
 
@@ -451,17 +486,20 @@ const AUTH_SEGMENT_QUOTE_MAX = 32;
  * Quote one caller-supplied `Authorization`-header segment for a rejection
  * message, or withhold it when it cannot be a segment.
  *
- * Issue #555. These messages are `info`, not `debug`, so they print on a
- * plain `cdkl start-api` run rather than only under `--verbose` — a
- * different population from a verbose-gated diagnostic, and the reason the
- * auth-header sites were the ones worth changing. What each names is a
+ * Issue #555. These messages are `info` and `warn`, not `debug`, so they
+ * print on a plain `cdkl start-api` run rather than only under `--verbose`
+ * — a different population from a verbose-gated diagnostic, and the reason
+ * the auth-header sites were the ones worth changing. What each names is a
  * POSITION in the header, and a position holds only its own short token
- * while the header's delimiters sit where the parser expects them. When
- * they do not — `Credential=AKID/20260101/us-east-1/execute-api/aws4_request
- * SignedHeaders=host Signature=<hex>`, a hand-written header using spaces
- * where AWS wants commas — the split sweeps the REST of the header into the
- * final segment, and the terminator message prints the `Signature=`
- * component at default level.
+ * while the header's delimiters sit where the parser expects them. Drop a
+ * single comma —
+ * `Credential=AKID/20260101/us-east-1/execute-api/aws4_request Signature=<hex>, SignedHeaders=host, Signature=abcd`
+ * — and `Credential=`'s value absorbs the parameter that should have
+ * followed it, so the credential-scope split hands its LAST segment the
+ * `Signature=` component and the terminator message prints it at default
+ * level. (A header delimited by spaces throughout never reaches that
+ * message: it yields a single parameter, so the parse throws `missing
+ * SignedHeaders` first.)
  *
  * So a quote is allowed only for input that could still BE one segment: no
  * whitespace, no `=`, no longer than {@link AUTH_SEGMENT_QUOTE_MAX}. Any of
@@ -471,14 +509,36 @@ const AUTH_SEGMENT_QUOTE_MAX = 32;
  * full — the actionability issue #246 added these messages for — while the
  * sweep-in case degrades to a character count.
  *
- * Not every echo in this file goes through here, deliberately: see the
- * `Signature=` mismatch message in {@link verifySigV4}.
+ * The offered `Signature=` value has its own predicate,
+ * {@link redactSignature}: a real signature is 64 characters, so this bound
+ * would withhold every legitimate one.
  */
 export function redactAuthorizationSegment(segment: string): string {
   if (segment.length > AUTH_SEGMENT_QUOTE_MAX || /[\s=]/.test(segment)) {
     return `<withheld: ${segment.length} characters of unparsed header material>`;
   }
   return segment;
+}
+
+/**
+ * Quote the caller's OFFERED `Signature=` value, or withhold it when that
+ * field swept in material which is not a signature.
+ *
+ * `Signature=` is the LAST parameter of the header, which makes it a sweep
+ * position exactly like the credential-scope terminator: a header ending
+ * `..., Signature=<hex> X-Anything=foo` parses to a `signature` of
+ * `<hex> x-anything=foo`. A real SigV4 signature is lowercase hex, at most
+ * 64 characters, so requiring precisely that quotes every legitimate value
+ * — the one issue #246 needs the user to compare — and withholds the rest.
+ *
+ * This covers the OFFERED signature only. The RECOMPUTED one is never
+ * printed; the mismatch message in {@link verifySigV4} says why.
+ */
+export function redactSignature(signature: string): string {
+  if (!/^[0-9a-f]{1,64}$/.test(signature)) {
+    return `<withheld: ${signature.length} characters that are not a signature>`;
+  }
+  return signature;
 }
 
 /**
@@ -508,7 +568,9 @@ export function parseAuthorizationHeader(value: string): ParsedAuthorization {
     // message is holding the header they sent; an index locates the part
     // for them without cdk-local repeating any of it.
     if (eq < 0) {
-      throw new Error(`malformed parameter ${i + 1} of ${parts.length} (no '=' in it)`);
+      const detail =
+        part.length === 0 ? 'empty, stray comma?' : `${part.length} characters, no '='`;
+      throw new Error(`malformed parameter ${i + 1} of ${parts.length} (${detail})`);
     }
     const key = part.slice(0, eq).trim();
     const val = part.slice(eq + 1).trim();
@@ -530,9 +592,10 @@ export function parseAuthorizationHeader(value: string): ParsedAuthorization {
     // a hand-written (space- rather than comma-delimited) header sweeps the
     // REST of the Authorization value into -- `Signature=<hex>` included --
     // and the count is what makes the fault actionable anyway (issue #555).
+    // The caller's own catch already prints the full expected shape, so
+    // naming it again here would state it twice in one line.
     throw new Error(
-      `malformed Credential: expected 5 slash-separated segments ` +
-        `'<AKID>/<YYYYMMDD>/<region>/<service>/aws4_request', got ${credParts.length}`
+      `malformed Credential: expected 5 slash-separated segments, got ${credParts.length}`
     );
   }
   const [accessKeyId, date, region, service, terminator] = credParts as [

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -1095,6 +1095,26 @@ export function buildVtlInput(
  * Minimal JSONPath evaluator. Supports `$`, `$.field`, `$.field.sub`,
  * `$.array[index]`. Unsupported syntax throws so the user sees a clear
  * pointer to the gap.
+ *
+ * The five throws below quote the offending expression, and `vtlFailure` in
+ * `rest-v1-integrations.ts` copies that message into the 502 response body.
+ * Issue #555 reviewed that and DELIBERATELY LEFT it — do not re-raise it as
+ * an echo of caller request data. Two reasons, and the second is the one
+ * that settles it:
+ *
+ *   1. `expr` is normally the developer's own template text — the literal
+ *      inside `$input.json('$.foo')`. It becomes caller-controllable only
+ *      when a template deliberately routes a request value into the
+ *      expression, e.g. `$input.json($input.params('p'))`.
+ *   2. Even then the 502 goes back to the caller who supplied that value,
+ *      and the SAME body already carries 200 characters of the rendered
+ *      template verbatim (see `vtlFailure`). Withholding the expression
+ *      would remove nothing from the response while destroying the only
+ *      pointer the developer has to the unsupported syntax.
+ *
+ * Unlike `$util.parseJson`'s catch above, nothing here was resolved by
+ * cdk-local out of a secret or parameter store, and no third party reads
+ * the message.
  */
 export function applyJsonPath(root: unknown, expr: string): unknown {
   const trimmed = expr.trim();

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -1106,11 +1106,14 @@ export function buildVtlInput(
  *      inside `$input.json('$.foo')`. It becomes caller-controllable only
  *      when a template deliberately routes a request value into the
  *      expression, e.g. `$input.json($input.params('p'))`.
- *   2. Even then the 502 goes back to the caller who supplied that value,
- *      and the SAME body already carries 200 characters of the rendered
- *      template verbatim (see `vtlFailure`). Withholding the expression
- *      would remove nothing from the response while destroying the only
- *      pointer the developer has to the unsupported syntax.
+ *   2. Even then, the 502 goes back to the CALLER WHO SUPPLIED that value,
+ *      so it discloses nothing that caller did not already send. (Note the
+ *      `template` field `vtlFailure` puts beside `reason` is the template
+ *      SOURCE, not its render — so in that case this message is the one
+ *      place the value appears, and the argument has to rest on the
+ *      recipient rather than on the value being present anyway.)
+ *      Withholding it would cost the developer the only pointer they have
+ *      to the unsupported syntax.
  *
  * Unlike `$util.parseJson`'s catch above, nothing here was resolved by
  * cdk-local out of a secret or parameter store, and no third party reads

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -1115,9 +1115,12 @@ export function buildVtlInput(
  *      Withholding it would cost the developer the only pointer they have
  *      to the unsupported syntax.
  *
- * Unlike `$util.parseJson`'s catch above, nothing here was resolved by
- * cdk-local out of a secret or parameter store, and no third party reads
- * the message.
+ * The difference from `$util.parseJson`'s catch above is the SIZE of what
+ * would be echoed, not its provenance: there the withheld material is the
+ * whole request body, which on a login endpoint is the caller's password,
+ * while here it is one path expression out of the developer's template.
+ * Both are the caller's own data returned to the caller; only one of them
+ * is worth withholding.
  */
 export function applyJsonPath(root: unknown, expr: string): unknown {
   const trimmed = expr.trim();

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -354,11 +354,13 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     ws.on('message', (raw, isBinary) => {
       const { body, isBase64Encoded } = websocketBody.bufferToBody(raw, isBinary);
       // Issue #555, reviewed and DELIBERATELY LEFT — do not re-raise this
-      // as an echo of caller request data. The first 200 CHARACTERS of the
-      // frame (base64 for a binary frame, so up to 800 bytes of multi-byte
-      // UTF-8) are the payload the developer's own client just sent to the
-      // local server, and this is `debug`, so it prints only under
-      // `--verbose`.
+      // as an echo of caller request data. The slice is 200 UTF-16 CODE
+      // UNITS, not bytes. For a text frame that is at most 600 UTF-8 bytes
+      // (measured: 600 for 3-byte BMP characters, 400 for astral pairs);
+      // for a binary frame the body is already base64, which is ASCII, so
+      // 200 characters is 150 bytes of the original payload. Either way it
+      // is what the developer's own client just sent to the local server,
+      // and this is `debug`, so it prints only under `--verbose`.
       // No part of it was resolved by cdk-local out of a secret or
       // parameter store, which is the line the redactions in
       // `ecs-secrets-resolver.ts` (#554) and `sigv4-verify.ts` (#555) draw.

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -353,6 +353,15 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     // AWS-deployed semantics.
     ws.on('message', (raw, isBinary) => {
       const { body, isBase64Encoded } = websocketBody.bufferToBody(raw, isBinary);
+      // Issue #555, reviewed and DELIBERATELY LEFT — do not re-raise this
+      // as an echo of caller request data. The first 200 bytes of the frame
+      // are the payload the developer's own client just sent to the local
+      // server, and this is `debug`, so it prints only under `--verbose`.
+      // No part of it was resolved by cdk-local out of a secret or
+      // parameter store, which is the line the redactions in
+      // `ecs-secrets-resolver.ts` (#554) and `sigv4-verify.ts` (#555) draw.
+      // Seeing the frame that produced a routing decision is the reason
+      // `--verbose` exists on `start-api`.
       logger.debug(
         `WebSocket message received for connection ${connectionId}: ${body.slice(0, 200)}`
       );
@@ -475,6 +484,12 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
   ): Promise<void> => {
     const entry = registry.unregister(connectionId);
     if (!entry) return;
+    // Issue #555, reviewed and DELIBERATELY LEFT — same call as the frame
+    // body above. The close reason is client-supplied, but it is the
+    // developer's own client, it is `debug`-gated, and it is already handed
+    // to the `$disconnect` handler as `disconnectReason` on the event just
+    // below, so withholding it from the log would hide a value the request
+    // path passes on regardless.
     logger.debug(
       `WebSocket disconnected: ${connectionId} (code=${code}, reason=${reason || '<none>'})`
     );

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -354,9 +354,11 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     ws.on('message', (raw, isBinary) => {
       const { body, isBase64Encoded } = websocketBody.bufferToBody(raw, isBinary);
       // Issue #555, reviewed and DELIBERATELY LEFT — do not re-raise this
-      // as an echo of caller request data. The first 200 bytes of the frame
-      // are the payload the developer's own client just sent to the local
-      // server, and this is `debug`, so it prints only under `--verbose`.
+      // as an echo of caller request data. The first 200 CHARACTERS of the
+      // frame (base64 for a binary frame, so up to 800 bytes of multi-byte
+      // UTF-8) are the payload the developer's own client just sent to the
+      // local server, and this is `debug`, so it prints only under
+      // `--verbose`.
       // No part of it was resolved by cdk-local out of a secret or
       // parameter store, which is the line the redactions in
       // `ecs-secrets-resolver.ts` (#554) and `sigv4-verify.ts` (#555) draw.
@@ -486,10 +488,11 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     if (!entry) return;
     // Issue #555, reviewed and DELIBERATELY LEFT — same call as the frame
     // body above. The close reason is client-supplied, but it is the
-    // developer's own client, it is `debug`-gated, and it is already handed
-    // to the `$disconnect` handler as `disconnectReason` on the event just
-    // below, so withholding it from the log would hide a value the request
-    // path passes on regardless.
+    // developer's own client and this is `debug`-gated. When the API
+    // declares a `$disconnect` route the value is handed to that handler as
+    // `disconnectReason` a few lines below, so for those APIs the log adds
+    // no reach at all; when it does not, this line is the only place a
+    // developer can see why the client hung up.
     logger.debug(
       `WebSocket disconnected: ${connectionId} (code=${code}, reason=${reason || '<none>'})`
     );

--- a/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
@@ -20,6 +20,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { SSMClient } from '@aws-sdk/client-ssm';
+import type { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 
 const { smSend, ssmSend, smCtors, ssmCtors, smDestroy, ssmDestroy } = vi.hoisted(() => ({
   smSend: vi.fn(),
@@ -294,6 +295,20 @@ describe('resolveEcsSecrets — SSM and Secrets Manager entries in one batch (is
     // The Secrets Manager client was still constructed by the resolver, so
     // that one IS closed -- the two are tracked independently.
     expect(smDestroy).toHaveBeenCalledTimes(1);
+
+    // The mirror case. Fencing only the SSM direction cannot tell "destroys
+    // because it owns" from "destroys unconditionally" on the other half:
+    // `ownsSecretsClient = true` and an unconditional `secretsClient
+    // .destroy()` both survive a test that never borrows a SM client.
+    smDestroy.mockReset();
+    ssmDestroy.mockReset();
+    smSend.mockResolvedValue({ SecretString: 'sm-value' });
+    const borrowedSm = { send: smSend, destroy: smDestroy };
+    await resolveEcsSecrets([entry(SM_ARN, 'API_TOKEN')], {
+      secretsManagerClient: borrowedSm as unknown as SecretsManagerClient,
+    });
+    expect(smDestroy).not.toHaveBeenCalled();
+    expect(ssmDestroy).toHaveBeenCalledTimes(1);
   });
 
   it('constructs no SDK client at all for an empty batch', async () => {

--- a/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Issue #557 — `resolveSsm`, the SSM Parameter Store half of the ECS
+ * `Secrets[].ValueFrom` resolver, had no unit coverage repo-wide. Both test
+ * files that mock this resolver's SDK boundary create an `ssmSend` and then
+ * never give it a resolved value, so every case there drives the Secrets
+ * Manager branch.
+ *
+ * Nothing here is a leak: the SSM branch never parses the resolved value, it
+ * returns `Parameter.Value` verbatim, so it carries none of #554's echo.
+ * What is unfenced is ordinary behavior whose regression is SILENT —
+ * `WithDecryption: true` dropped hands the container a SecureString's
+ * ciphertext instead of failing, and only a real deploy would show it.
+ *
+ * The command RETAINS its input here. A `class {}` that discards it (the
+ * shape the sibling files use, which is why they could not have caught this)
+ * cannot tell a correct call from a wrong-argument one: `send` resolving for
+ * any argument hides a dropped `WithDecryption`, a `Name` still carrying the
+ * whole ARN, and a lost leading slash alike.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { smSend, ssmSend } = vi.hoisted(() => ({
+  smSend: vi.fn(),
+  ssmSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: class {
+    send = smSend;
+    destroy(): void {}
+  },
+  GetSecretValueCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock('@aws-sdk/client-ssm', () => ({
+  SSMClient: class {
+    send = ssmSend;
+    destroy(): void {}
+  },
+  GetParameterCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+const { resolveEcsSecrets, EcsSecretsResolutionError } = await import(
+  '../../../src/local/ecs-secrets-resolver.js'
+);
+
+/** An SSM Parameter ARN whose name is a NESTED path, so a lost slash shows. */
+const SSM_ARN = 'arn:aws:ssm:us-east-1:123456789012:parameter/app/db/password';
+/** The name `classifySecretArn` extracts from it — leading slash included. */
+const SSM_NAME = '/app/db/password';
+
+const SM_ARN = 'arn:aws:secretsmanager:us-east-1:123456789012:secret:app-token';
+
+function entry(
+  valueFrom: string,
+  name = 'DB_PASSWORD'
+): { containerName: string; name: string; valueFrom: string } {
+  return { containerName: 'ApiContainer', name, valueFrom };
+}
+
+/** The input of the single `GetParameterCommand` the resolver sent. */
+function sentParameterInput(): unknown {
+  expect(ssmSend).toHaveBeenCalledTimes(1);
+  return (ssmSend.mock.calls[0]![0] as { input: unknown }).input;
+}
+
+/**
+ * Resolve one SSM entry and return the failure message. Fails the test if
+ * the resolve SUCCEEDS — otherwise a mock that stopped rejecting would make
+ * every negative below pass while fencing nothing.
+ */
+async function ssmFailure(): Promise<string> {
+  try {
+    await resolveEcsSecrets([entry(SSM_ARN)]);
+  } catch (err) {
+    expect(err).toBeInstanceOf(EcsSecretsResolutionError);
+    return (err as Error).message;
+  }
+  return expect.fail('resolveEcsSecrets should have thrown for this SSM response');
+}
+
+describe('resolveSsm — the GetParameter call (issue #557)', () => {
+  beforeEach(() => {
+    smSend.mockReset();
+    ssmSend.mockReset();
+  });
+
+  it('requests decryption — a dropped WithDecryption yields ciphertext, silently', async () => {
+    ssmSend.mockResolvedValue({ Parameter: { Value: 'plaintext' } });
+    await resolveEcsSecrets([entry(SSM_ARN)]);
+    // Asserted on its own, not only inside the whole-input compare below, so
+    // the failure names the field a regression would have dropped. A
+    // SecureString resolved WITHOUT this comes back as a base64 KMS blob
+    // that the container accepts as its password.
+    expect((sentParameterInput() as { WithDecryption?: unknown }).WithDecryption).toBe(true);
+  });
+
+  it('sends exactly the parameter NAME classifySecretArn extracted, not the ARN', async () => {
+    ssmSend.mockResolvedValue({ Parameter: { Value: 'plaintext' } });
+    await resolveEcsSecrets([entry(SSM_ARN)]);
+    // Whole-input compare: an EXTRA field is as wrong as a missing one, and
+    // `Name` must keep the leading slash `parameter/app/db/password` implies.
+    expect(sentParameterInput()).toEqual({ Name: SSM_NAME, WithDecryption: true });
+  });
+
+  it('returns Parameter.Value verbatim — no parsing, no json-key extraction', async () => {
+    // A JSON-shaped value is the sharp case: the Secrets Manager branch
+    // would parse this, the SSM branch must not. `:<json-key>::` is a
+    // Secrets Manager convention and has no SSM counterpart.
+    const stored = '{"password":"hunter2"}';
+    ssmSend.mockResolvedValue({ Parameter: { Value: stored } });
+    const out = await resolveEcsSecrets([entry(SSM_ARN)]);
+    expect(out).toEqual([
+      {
+        containerName: 'ApiContainer',
+        name: 'DB_PASSWORD',
+        valueFrom: SSM_ARN,
+        value: stored,
+      },
+    ]);
+  });
+
+  it('keeps an empty-string parameter value rather than treating it as missing', async () => {
+    // `Parameter.Value === ''` is a real, resolvable value; only `undefined`
+    // is the missing case. A truthiness check here would turn a legitimate
+    // empty parameter into a hard failure.
+    ssmSend.mockResolvedValue({ Parameter: { Value: '' } });
+    const out = await resolveEcsSecrets([entry(SSM_ARN)]);
+    expect(out[0]!.value).toBe('');
+  });
+});
+
+describe('resolveSsm — the failure shapes (issue #557)', () => {
+  beforeEach(() => {
+    smSend.mockReset();
+    ssmSend.mockReset();
+  });
+
+  it('throws when the response carries a Parameter with no Value', async () => {
+    ssmSend.mockResolvedValue({ Parameter: { Name: SSM_NAME } });
+    const message = await ssmFailure();
+    expect(message).toContain(`SSM parameter '${SSM_NAME}' returned no Value`);
+    expect(message).toContain("container 'ApiContainer'");
+    expect(message).toContain("env 'DB_PASSWORD'");
+    // The `err instanceof EcsSecretsResolutionError` re-throw guard: this
+    // throw is raised INSIDE the try, so without the guard the catch would
+    // re-wrap it as a transport failure and report a resolvable parameter as
+    // an AWS / credentials problem.
+    expect(message).not.toContain('Failed to resolve SSM parameter');
+  });
+
+  it('throws the same way when the response carries no Parameter at all', async () => {
+    ssmSend.mockResolvedValue({});
+    const message = await ssmFailure();
+    expect(message).toContain(`SSM parameter '${SSM_NAME}' returned no Value`);
+    expect(message).not.toContain('Failed to resolve SSM parameter');
+  });
+
+  it('wraps an SDK rejection with the container, env, parameter name and cause', async () => {
+    // The shape `ssm:GetParameter` answers with for a name that does not
+    // exist, or for one the profile's credentials may not read.
+    const sdkError = Object.assign(new Error('Parameter /app/db/password not found.'), {
+      name: 'ParameterNotFound',
+    });
+    ssmSend.mockRejectedValue(sdkError);
+    const message = await ssmFailure();
+    expect(message).toContain(
+      "Failed to resolve SSM parameter for container 'ApiContainer' / env 'DB_PASSWORD'"
+    );
+    expect(message).toContain(`(${SSM_NAME})`);
+    expect(message).toContain('Parameter /app/db/password not found.');
+  });
+
+  it('wraps an InvalidParameters-style rejection the same way', async () => {
+    const sdkError = Object.assign(new Error('InvalidParameters: /app/db/password'), {
+      name: 'InvalidParameters',
+    });
+    ssmSend.mockRejectedValue(sdkError);
+    const message = await ssmFailure();
+    expect(message).toContain('Failed to resolve SSM parameter');
+    expect(message).toContain('InvalidParameters: /app/db/password');
+  });
+
+  it('stringifies a non-Error rejection instead of reporting undefined', async () => {
+    ssmSend.mockRejectedValue('socket hang up');
+    const message = await ssmFailure();
+    expect(message).toContain('Failed to resolve SSM parameter');
+    expect(message).toContain('socket hang up');
+  });
+});
+
+describe('resolveEcsSecrets — SSM and Secrets Manager entries in one batch (issue #557)', () => {
+  beforeEach(() => {
+    smSend.mockReset();
+    ssmSend.mockReset();
+  });
+
+  it('routes each ValueFrom shape to its own client and keeps entry order', async () => {
+    smSend.mockResolvedValue({ SecretString: 'sm-value' });
+    ssmSend.mockResolvedValue({ Parameter: { Value: 'ssm-value' } });
+
+    const out = await resolveEcsSecrets([
+      entry(SM_ARN, 'API_TOKEN'),
+      entry(SSM_ARN, 'DB_PASSWORD'),
+    ]);
+
+    expect(out.map((r) => [r.name, r.value])).toEqual([
+      ['API_TOKEN', 'sm-value'],
+      ['DB_PASSWORD', 'ssm-value'],
+    ]);
+    // One call each: a shape routed to the wrong client would show up as two
+    // on one and zero on the other.
+    expect(smSend).toHaveBeenCalledTimes(1);
+    expect(ssmSend).toHaveBeenCalledTimes(1);
+    expect((smSend.mock.calls[0]![0] as { input: unknown }).input).toEqual({ SecretId: SM_ARN });
+    expect(sentParameterInput()).toEqual({ Name: SSM_NAME, WithDecryption: true });
+  });
+
+  it('fails the whole batch when only the SSM half fails', async () => {
+    // Resolution is all-or-nothing by design: a partially-resolved batch
+    // would boot a container with one secret as a literal empty string.
+    smSend.mockResolvedValue({ SecretString: 'sm-value' });
+    ssmSend.mockRejectedValue(new Error('AccessDeniedException'));
+    await expect(
+      resolveEcsSecrets([entry(SM_ARN, 'API_TOKEN'), entry(SSM_ARN, 'DB_PASSWORD')])
+    ).rejects.toBeInstanceOf(EcsSecretsResolutionError);
+  });
+});

--- a/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
@@ -19,16 +19,24 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { SSMClient } from '@aws-sdk/client-ssm';
 
-const { smSend, ssmSend } = vi.hoisted(() => ({
+const { smSend, ssmSend, smCtors, ssmCtors, smDestroy, ssmDestroy } = vi.hoisted(() => ({
   smSend: vi.fn(),
   ssmSend: vi.fn(),
+  smCtors: { count: 0 },
+  ssmCtors: { count: 0 },
+  smDestroy: vi.fn(),
+  ssmDestroy: vi.fn(),
 }));
 
 vi.mock('@aws-sdk/client-secrets-manager', () => ({
   SecretsManagerClient: class {
+    constructor() {
+      smCtors.count += 1;
+    }
     send = smSend;
-    destroy(): void {}
+    destroy = smDestroy;
   },
   GetSecretValueCommand: class {
     constructor(public input: unknown) {}
@@ -37,8 +45,11 @@ vi.mock('@aws-sdk/client-secrets-manager', () => ({
 
 vi.mock('@aws-sdk/client-ssm', () => ({
   SSMClient: class {
+    constructor() {
+      ssmCtors.count += 1;
+    }
     send = ssmSend;
-    destroy(): void {}
+    destroy = ssmDestroy;
   },
   GetParameterCommand: class {
     constructor(public input: unknown) {}
@@ -88,6 +99,10 @@ describe('resolveSsm — the GetParameter call (issue #557)', () => {
   beforeEach(() => {
     smSend.mockReset();
     ssmSend.mockReset();
+    smDestroy.mockReset();
+    ssmDestroy.mockReset();
+    smCtors.count = 0;
+    ssmCtors.count = 0;
   });
 
   it('requests decryption — a dropped WithDecryption yields ciphertext, silently', async () => {
@@ -139,6 +154,10 @@ describe('resolveSsm — the failure shapes (issue #557)', () => {
   beforeEach(() => {
     smSend.mockReset();
     ssmSend.mockReset();
+    smDestroy.mockReset();
+    ssmDestroy.mockReset();
+    smCtors.count = 0;
+    ssmCtors.count = 0;
   });
 
   it('throws when the response carries a Parameter with no Value', async () => {
@@ -198,6 +217,10 @@ describe('resolveEcsSecrets — SSM and Secrets Manager entries in one batch (is
   beforeEach(() => {
     smSend.mockReset();
     ssmSend.mockReset();
+    smDestroy.mockReset();
+    ssmDestroy.mockReset();
+    smCtors.count = 0;
+    ssmCtors.count = 0;
   });
 
   it('routes each ValueFrom shape to its own client and keeps entry order', async () => {
@@ -250,6 +273,33 @@ describe('resolveEcsSecrets — SSM and Secrets Manager entries in one batch (is
     ).rejects.toThrow(/unsupported ValueFrom shape/);
     expect(ssmSend).not.toHaveBeenCalled();
     expect(smSend).not.toHaveBeenCalled();
+  });
+
+  it('destroys the clients it constructed, and never one the caller supplied', async () => {
+    // The mocked `destroy` used to be a no-op METHOD, so dropping the
+    // `finally` block that calls it survived every case here -- the real
+    // cost being leaked sockets on a long-lived `cdkl start-service`.
+    ssmSend.mockResolvedValue({ Parameter: { Value: 'ssm-value' } });
+    await resolveEcsSecrets([entry(SSM_ARN)]);
+    expect(ssmDestroy).toHaveBeenCalledTimes(1);
+    expect(smDestroy).toHaveBeenCalledTimes(1);
+
+    smDestroy.mockReset();
+    ssmDestroy.mockReset();
+    // A caller-supplied client is the caller's to close: destroying it here
+    // would break a host that reuses one across several resolves.
+    const borrowed = { send: ssmSend, destroy: ssmDestroy };
+    await resolveEcsSecrets([entry(SSM_ARN)], { ssmClient: borrowed as unknown as SSMClient });
+    expect(ssmDestroy).not.toHaveBeenCalled();
+    // The Secrets Manager client was still constructed by the resolver, so
+    // that one IS closed -- the two are tracked independently.
+    expect(smDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('constructs no SDK client at all for an empty batch', async () => {
+    await expect(resolveEcsSecrets([])).resolves.toEqual([]);
+    expect(ssmCtors.count).toBe(0);
+    expect(smCtors.count).toBe(0);
   });
 
   it('fails the whole batch when only the SSM half fails', async () => {

--- a/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
@@ -221,6 +221,37 @@ describe('resolveEcsSecrets — SSM and Secrets Manager entries in one batch (is
     expect(sentParameterInput()).toEqual({ Name: SSM_NAME, WithDecryption: true });
   });
 
+  it('keeps two SSM entries correlated to their own parameters', async () => {
+    // Every other case sends ONE SSM entry, so a cross-entry mix-up --
+    // `Promise.all` writing entry A's value onto entry B -- would be
+    // invisible. Distinct values per Name make the correlation observable.
+    const OTHER_ARN = 'arn:aws:ssm:us-east-1:123456789012:parameter/app/api/key';
+    ssmSend.mockImplementation((cmd: { input: { Name: string } }) =>
+      Promise.resolve({ Parameter: { Value: `value-for${cmd.input.Name}` } })
+    );
+
+    const out = await resolveEcsSecrets([
+      entry(SSM_ARN, 'DB_PASSWORD'),
+      entry(OTHER_ARN, 'API_KEY'),
+    ]);
+
+    expect(out.map((r) => [r.name, r.value])).toEqual([
+      ['DB_PASSWORD', 'value-for/app/db/password'],
+      ['API_KEY', 'value-for/app/api/key'],
+    ]);
+  });
+
+  it('rejects a ValueFrom that is neither shape, without calling either client', async () => {
+    // `classifySecretArn` answers `unknown` and `resolveOne` throws before
+    // any SDK call -- so a future shape added to the classifier but not to
+    // the switch would surface here rather than as a silent empty env var.
+    await expect(
+      resolveEcsSecrets([entry('arn:aws:s3:::my-bucket/secret.txt', 'DB_PASSWORD')])
+    ).rejects.toThrow(/unsupported ValueFrom shape/);
+    expect(ssmSend).not.toHaveBeenCalled();
+    expect(smSend).not.toHaveBeenCalled();
+  });
+
   it('fails the whole batch when only the SSM half fails', async () => {
     // Resolution is all-or-nothing by design: a partially-resolved batch
     // would boot a container with one secret as a literal empty string.

--- a/tests/unit/local/sigv4-verify-auth-segment-redaction.test.ts
+++ b/tests/unit/local/sigv4-verify-auth-segment-redaction.test.ts
@@ -24,10 +24,12 @@ import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
 import {
   verifySigV4,
   redactAuthorizationSegment,
+  redactSignature,
   type SigV4VerifyRequest,
   type ResolvedCredentials,
 } from '../../../src/local/sigv4-verify.js';
 import { getLogger } from '../../../src/utils/logger.js';
+import { setEmbedConfig, resetEmbedConfig } from '../../../src/local/embed-config.js';
 
 const NOW = new Date('2026-01-01T00:00:00Z');
 
@@ -75,6 +77,38 @@ async function infoOnReject(authorization: string): Promise<string> {
   return joined;
 }
 
+/**
+ * Drive one `Authorization` header through `verifySigV4` and return every
+ * `warn` line it produced. Fails the test if the request is DENIED — the
+ * foreign-access-key-id path warn-and-PASSES by default, so a denial means
+ * the case tripped some earlier guard instead.
+ */
+async function warnOnForeignId(
+  authorization: string,
+  opts: { strict?: boolean; oacFronted?: boolean } = {}
+): Promise<string> {
+  const spy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+  const req: SigV4VerifyRequest = {
+    method: 'POST',
+    rawUrl: '/',
+    headers: {
+      host: '127.0.0.1:65483',
+      'x-amz-date': '20260101T000000Z',
+      authorization,
+    },
+    body: Buffer.alloc(0),
+  };
+  const result = await verifySigV4(req, loadLocal, { now: () => NOW, ...opts });
+  // Only `--strict-sigv4` on a non-OAC route denies; the other two
+  // warn-and-PASS. Asserting the expected outcome keeps a case that tripped
+  // some earlier guard from looking like a clean run of this branch.
+  expect(result.allow).toBe(!(opts.strict === true && opts.oacFronted !== true));
+  const joined = spy.mock.calls.map((c) => String(c[0])).join('\n');
+  spy.mockRestore();
+  expect(joined).toContain('access-key-id');
+  return joined;
+}
+
 describe('redactAuthorizationSegment — the quote/withhold boundary (issue #555)', () => {
   it('quotes a short single-token segment verbatim', () => {
     expect(redactAuthorizationSegment('aws3_request')).toBe('aws3_request');
@@ -99,6 +133,40 @@ describe('redactAuthorizationSegment — the quote/withhold boundary (issue #555
     expect(redactAuthorizationSegment('Signature=abcd')).toBe(
       '<withheld: 14 characters of unparsed header material>'
     );
+  });
+
+  it('withholds on whitespace ALONE — short, and with no \'=\' to fall back on', () => {
+    // Fences the whitespace half of the `/[\s=]/` disjunction on its own.
+    // Every other case here also trips the length bound or the `=` clause,
+    // so rewriting the predicate to `/=/` would leave them all green.
+    expect(redactAuthorizationSegment('aws4_request foo')).toBe(
+      '<withheld: 16 characters of unparsed header material>'
+    );
+  });
+});
+
+describe('redactSignature — the offered Signature= value (issue #555)', () => {
+  it('quotes a real 64-character lowercase-hex signature verbatim', () => {
+    const real = 'f00dfeed'.repeat(8);
+    expect(real).toHaveLength(64);
+    expect(redactSignature(real)).toBe(real);
+  });
+
+  it('withholds anything past 64 characters, or not lowercase hex, or empty', () => {
+    expect(redactSignature('a'.repeat(65))).toBe(
+      '<withheld: 65 characters that are not a signature>'
+    );
+    // The parser lowercases before this runs, so uppercase is unreachable
+    // in production; the predicate states the requirement explicitly.
+    expect(redactSignature('DEADBEEF')).toBe('<withheld: 8 characters that are not a signature>');
+    expect(redactSignature('')).toBe('<withheld: 0 characters that are not a signature>');
+  });
+
+  it('withholds the sweep-in shape a trailing parameter produces', () => {
+    const swept = `${SIGNATURE} x-anything=foo`;
+    const out = redactSignature(swept);
+    expect(out).not.toContain(SIGNATURE);
+    expect(out).toBe(`<withheld: ${swept.length} characters that are not a signature>`);
   });
 });
 
@@ -132,8 +200,11 @@ describe('verifySigV4 — no unparsed Authorization material at info (issue #555
         `SignedHeaders=host, Signature=${SIGNATURE}`
     );
     expect(infos).toContain('malformed Authorization header');
-    expect(infos).toContain('expected 5 slash-separated segments');
-    expect(infos).toContain('got 2');
+    // Anchored through to the count: `expected 5 slash-separated segments`
+    // on its own is a SUBSTRING of the message this replaces
+    // (`malformed Credential '<value>' (expected 5 slash-separated
+    // segments)`), so it would pass on exactly the form it rejects.
+    expect(infos).toContain('expected 5 slash-separated segments, got 2');
     expect(infos).not.toContain(SIGNATURE);
   });
 
@@ -175,6 +246,52 @@ describe('verifySigV4 — no unparsed Authorization material at info (issue #555
     expect(infos).not.toContain(SIGNATURE);
     expect(infos).toContain('expected YYYYMMDD');
   });
+
+  it('withholds an access-key-id segment that swallowed the signature (warn level)', async () => {
+    // `warn` is LESS gated than the `info` sites above, so scoping the fix
+    // to `info` would have inverted its own visibility argument. The
+    // foreign-identity path warn-and-passes by default, so this line prints
+    // on a request that is then SERVED.
+    const header =
+      `AWS4-HMAC-SHA256 Credential=AKIALOCAL Signature=${SIGNATURE}/20260101/us-east-1/execute-api/aws4_request, ` +
+      'SignedHeaders=host, Signature=abcd';
+    // FIVE separate interpolations produce this warn, and a single case
+    // leaves four of them unfenced. Two axes multiply: the route mode
+    // (default warn-and-pass / `--strict-sigv4` deny / CloudFront-OAC pass)
+    // and the host's `sigV4StrictByDefault`, which selects a different
+    // wording of the same line. A per-occurrence mutation probe found the
+    // two `sigV4StrictByDefault: true` spellings still green when only the
+    // three route modes were covered.
+    for (const strictByDefault of [false, true]) {
+      setEmbedConfig(
+        strictByDefault
+          ? { sigV4StrictByDefault: true, sigV4OptFlag: '--allow-unverified-sigv4' }
+          : {}
+      );
+      try {
+        for (const opts of [{}, { strict: true }, { oacFronted: true, strict: true }]) {
+          const warns = await warnOnForeignId(header, opts);
+          expect(warns).toMatch(WITHHELD);
+          expect(warns).not.toContain(SIGNATURE);
+        }
+      } finally {
+        resetEmbedConfig();
+      }
+    }
+  });
+
+  it('withholds an offered Signature= that swallowed a trailing parameter', async () => {
+    // The access-key id matches the local credentials, so this reaches the
+    // mismatch message — where `Signature=` is the LAST parameter and
+    // therefore a sweep position of its own.
+    const infos = await infoOnReject(
+      `AWS4-HMAC-SHA256 Credential=${LOCAL_CREDS.accessKeyId}/20260101/us-east-1/execute-api/aws4_request, ` +
+        `SignedHeaders=host;x-amz-date, Signature=${SIGNATURE} X-Anything=foo`
+    );
+    expect(infos).toContain('Signature= mismatch');
+    expect(infos).toContain('characters that are not a signature');
+    expect(infos).not.toContain(SIGNATURE);
+  });
 });
 
 describe('verifySigV4 — the diagnostics issue #246 added are NOT over-redacted', () => {
@@ -198,11 +315,43 @@ describe('verifySigV4 — the diagnostics issue #246 added are NOT over-redacted
     expect(alg).toContain("algorithm 'AWS4-HMAC-SHA512'.");
   });
 
-  it('still prints BOTH signatures on a Signature= mismatch (deliberate, see the in-code note)', async () => {
-    // Reached only when the request's access-key id matches the credentials
-    // cdk-local resolved locally, so the signature is provably the
-    // developer's own. Printing it beside the recomputed one IS the
-    // diagnostic; this case is what stops a later sweep from "fixing" it.
+  it('still quotes an RFC 1123 x-amz-date in full (deliberately not redacted)', async () => {
+    // `x-amz-date` is left raw on purpose (see the note at the site): no
+    // delimiter mistake can sweep an `Authorization` segment into it, and
+    // its legal spellings carry spaces and run long, so any shape-based
+    // bound would withhold the valid-but-mismatched timestamp this message
+    // exists to show. This case is what stops a later sweep from applying
+    // `redactAuthorizationSegment` here by analogy.
+    const rfcDate = 'Mon, 02 Jan 2006 15:04:05 GMT';
+    const spy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: {
+        host: '127.0.0.1:65483',
+        'x-amz-date': rfcDate,
+        authorization:
+          'AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws4_request, ' +
+          'SignedHeaders=host, Signature=abcd',
+      },
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = spy.mock.calls.map((c) => String(c[0])).join('\n');
+    spy.mockRestore();
+    expect(infos).toContain(`x-amz-date '${rfcDate}'`);
+    expect(infos).not.toMatch(WITHHELD);
+  });
+
+  it('prints the OFFERED signature and withholds the RECOMPUTED one', async () => {
+    // The offered value is the caller's own, so echoing it back to a local
+    // terminal discloses nothing they did not send, and it is what makes
+    // the mismatch actionable (issue #246). The recomputed value is an HMAC
+    // under the developer's real secret access key over a string-to-sign
+    // the CALLER chose, and this branch needs only a matching access-key id
+    // — an identifier, not a secret — so printing it would hand out valid
+    // signatures for arbitrary AWS calls.
     const offered = '0'.repeat(64);
     const infos = await infoOnReject(
       `AWS4-HMAC-SHA256 Credential=${LOCAL_CREDS.accessKeyId}/20260101/us-east-1/execute-api/aws4_request, ` +
@@ -210,7 +359,13 @@ describe('verifySigV4 — the diagnostics issue #246 added are NOT over-redacted
     );
     expect(infos).toContain('Signature= mismatch');
     expect(infos).toContain(`got '${offered}'`);
-    expect(infos).toMatch(/recomputed '[0-9a-f]{64}'/);
-    expect(infos).not.toMatch(WITHHELD);
+    expect(infos).toContain('the recomputed signature is withheld');
+    // The positive half of the negative: exactly ONE 64-hex run in the
+    // whole output, and it is the one the caller supplied. A bare
+    // `not.toContain(<recomputed>)` would need the recomputed value, which
+    // the test cannot see — and "no hex at all" would also pass if the
+    // message lost the offered signature too.
+    const hexRuns = infos.match(/[0-9a-f]{64}/g) ?? [];
+    expect(hexRuns).toEqual([offered]);
   });
 });

--- a/tests/unit/local/sigv4-verify-auth-segment-redaction.test.ts
+++ b/tests/unit/local/sigv4-verify-auth-segment-redaction.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Issue #555 site 3 — the SigV4 rejection messages log at `info`, so they
+ * print on a plain `cdkl start-api` run rather than only under `--verbose`.
+ * Each names a POSITION in the `Authorization` header, and a position holds
+ * only its own short token while the header's delimiters sit where the
+ * parser expects them. When they do not — a hand-written header using
+ * spaces where AWS wants commas — the split sweeps the REST of the header
+ * into the final segment, and the message prints the `Signature=` component
+ * at default level.
+ *
+ * Every case here pairs the negative ("the swept-in material is absent")
+ * with a POSITIVE marker. "The signature did not appear" on its own is a
+ * confluence point: a request rejected earlier, a mock that never ran, or a
+ * message that lost the diagnostic entirely all satisfy it while fencing
+ * nothing. So each case also asserts the withheld-marker / count that only
+ * the intended branch produces.
+ *
+ * The last two cases fence the OTHER direction — over-redaction. Issue #246
+ * added these messages so a developer can fix their request without
+ * re-reading the SigV4 spec, and a blanket redaction would take that back.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+import {
+  verifySigV4,
+  redactAuthorizationSegment,
+  type SigV4VerifyRequest,
+  type ResolvedCredentials,
+} from '../../../src/local/sigv4-verify.js';
+import { getLogger } from '../../../src/utils/logger.js';
+
+const NOW = new Date('2026-01-01T00:00:00Z');
+
+const LOCAL_CREDS: ResolvedCredentials = {
+  accessKeyId: 'AKIALOCALEXAMPLE',
+  secretAccessKey: 'secret',
+};
+
+const loadLocal = async (): Promise<ResolvedCredentials> => LOCAL_CREDS;
+
+/**
+ * A distinctive stand-in for the `Signature=` component. Long enough to be
+ * a real SigV4 signature (64 hex characters) and unique enough that a
+ * `not.toContain` on it cannot be satisfied by coincidence.
+ */
+const SIGNATURE = 'f00dfeed'.repeat(8);
+
+/** The `<withheld: N characters ...>` shape `redactAuthorizationSegment` emits. */
+const WITHHELD = /<withheld: \d+ characters of unparsed header material>/;
+
+/**
+ * Drive one `Authorization` header through `verifySigV4` and return every
+ * `info` line it produced, joined. Fails the test if the request is
+ * ALLOWED — otherwise a change that stopped rejecting would make every
+ * absence assertion below pass while fencing nothing.
+ */
+async function infoOnReject(authorization: string): Promise<string> {
+  const spy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+  const req: SigV4VerifyRequest = {
+    method: 'POST',
+    rawUrl: '/',
+    headers: {
+      host: '127.0.0.1:65483',
+      'x-amz-date': '20260101T000000Z',
+      authorization,
+    },
+    body: Buffer.alloc(0),
+  };
+  const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+  expect(result.allow).toBe(false);
+  const joined = spy.mock.calls.map((c) => String(c[0])).join('\n');
+  spy.mockRestore();
+  // A rejection that logged nothing would also satisfy every `not.toContain`.
+  expect(joined).toContain('AWS_IAM authorizer: rejecting request');
+  return joined;
+}
+
+describe('redactAuthorizationSegment — the quote/withhold boundary (issue #555)', () => {
+  it('quotes a short single-token segment verbatim', () => {
+    expect(redactAuthorizationSegment('aws3_request')).toBe('aws3_request');
+    expect(redactAuthorizationSegment('AWS4-HMAC-SHA512')).toBe('AWS4-HMAC-SHA512');
+  });
+
+  it('quotes at exactly 32 characters and withholds at 33', () => {
+    expect(redactAuthorizationSegment('a'.repeat(32))).toBe('a'.repeat(32));
+    expect(redactAuthorizationSegment('a'.repeat(33))).toBe(
+      '<withheld: 33 characters of unparsed header material>'
+    );
+  });
+
+  it('withholds a segment carrying whitespace (the comma-vs-space sweep-in)', () => {
+    const swept = `aws4_request SignedHeaders=host Signature=${SIGNATURE}`;
+    const out = redactAuthorizationSegment(swept);
+    expect(out).not.toContain(SIGNATURE);
+    expect(out).toBe(`<withheld: ${swept.length} characters of unparsed header material>`);
+  });
+
+  it("withholds a segment carrying '=' even when it is short", () => {
+    expect(redactAuthorizationSegment('Signature=abcd')).toBe(
+      '<withheld: 14 characters of unparsed header material>'
+    );
+  });
+});
+
+describe('verifySigV4 — no unparsed Authorization material at info (issue #555)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('withholds the terminator when a space-delimited header sweeps the signature into it', async () => {
+    // One comma missing — the shape a hand-written `curl -H` header takes.
+    // `Credential=`'s value absorbs the `Signature=` parameter that should
+    // have followed it, so the 5th slash-separated segment (the terminator)
+    // becomes `aws4_request Signature=<hex>` while the header still parses
+    // far enough to reach the terminator check.
+    const infos = await infoOnReject(
+      `AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws4_request ` +
+        `Signature=${SIGNATURE}, SignedHeaders=host, Signature=abcd`
+    );
+    expect(infos).toContain('invalid credential-scope terminator');
+    expect(infos).toMatch(WITHHELD);
+    expect(infos).not.toContain(SIGNATURE);
+    // The remedy the message points at must survive the withholding.
+    expect(infos).toContain("Expected 'aws4_request'");
+  });
+
+  it('reports the Credential segment COUNT instead of the value', async () => {
+    // Two slash-separated segments, the second of which has swallowed the
+    // `Signature=` component.
+    const infos = await infoOnReject(
+      `AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/x Signature=${SIGNATURE}, ` +
+        `SignedHeaders=host, Signature=${SIGNATURE}`
+    );
+    expect(infos).toContain('malformed Authorization header');
+    expect(infos).toContain('expected 5 slash-separated segments');
+    expect(infos).toContain('got 2');
+    expect(infos).not.toContain(SIGNATURE);
+  });
+
+  it('reports the POSITION of a parameter with no \'=\', never its content', async () => {
+    // `Authorization: Basic <base64>` sent to an AWS_IAM route arrives as
+    // exactly one such part; so does a trailing paste. Quoting it would put
+    // the credential on the terminal at default level.
+    const basic = 'dXNlcjpodW50ZXIy';
+    const infos = await infoOnReject(
+      'AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws4_request, ' +
+        `SignedHeaders=host, ${basic}`
+    );
+    expect(infos).toContain('malformed Authorization header');
+    expect(infos).toContain('malformed parameter 3 of 3');
+    expect(infos).not.toContain(basic);
+  });
+
+  it('withholds an algorithm token too long to be a scheme name', async () => {
+    // The algorithm is `value.slice(0, indexOf(' '))` — whatever precedes
+    // the first space. A pasted opaque token followed by anything the
+    // parameter parser accepts therefore lands in the algorithm position.
+    const infos = await infoOnReject(
+      `${SIGNATURE}xyz Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws4_request, ` +
+        'SignedHeaders=host, Signature=abcd'
+    );
+    expect(infos).toContain('unsupported Authorization algorithm');
+    expect(infos).toMatch(WITHHELD);
+    expect(infos).not.toContain(SIGNATURE);
+  });
+
+  it('withholds a credential-date segment that swallowed the signature', async () => {
+    // Five segments, so the length check passes; the 2nd one is not a date.
+    const infos = await infoOnReject(
+      `AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/x Signature=${SIGNATURE}/us-east-1/execute-api/aws4_request, ` +
+        'SignedHeaders=host, Signature=abcd'
+    );
+    expect(infos).toContain('malformed credential date');
+    expect(infos).toMatch(WITHHELD);
+    expect(infos).not.toContain(SIGNATURE);
+    expect(infos).toContain('expected YYYYMMDD');
+  });
+});
+
+describe('verifySigV4 — the diagnostics issue #246 added are NOT over-redacted', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('still quotes a short terminator and a short algorithm verbatim', async () => {
+    const term = await infoOnReject(
+      'AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws3_request, ' +
+        'SignedHeaders=host, Signature=abcd'
+    );
+    // Delimiter-anchored: `'aws3_request'` alone is also a substring of
+    // `'aws3_request '` + anything a future sweep-in might append.
+    expect(term).toContain("terminator 'aws3_request'.");
+
+    const alg = await infoOnReject(
+      'AWS4-HMAC-SHA512 Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws4_request, ' +
+        'SignedHeaders=host, Signature=abcd'
+    );
+    expect(alg).toContain("algorithm 'AWS4-HMAC-SHA512'.");
+  });
+
+  it('still prints BOTH signatures on a Signature= mismatch (deliberate, see the in-code note)', async () => {
+    // Reached only when the request's access-key id matches the credentials
+    // cdk-local resolved locally, so the signature is provably the
+    // developer's own. Printing it beside the recomputed one IS the
+    // diagnostic; this case is what stops a later sweep from "fixing" it.
+    const offered = '0'.repeat(64);
+    const infos = await infoOnReject(
+      `AWS4-HMAC-SHA256 Credential=${LOCAL_CREDS.accessKeyId}/20260101/us-east-1/execute-api/aws4_request, ` +
+        `SignedHeaders=host;x-amz-date, Signature=${offered}`
+    );
+    expect(infos).toContain('Signature= mismatch');
+    expect(infos).toContain(`got '${offered}'`);
+    expect(infos).toMatch(/recomputed '[0-9a-f]{64}'/);
+    expect(infos).not.toMatch(WITHHELD);
+  });
+});

--- a/tests/unit/local/sigv4-verify-auth-segment-redaction.test.ts
+++ b/tests/unit/local/sigv4-verify-auth-segment-redaction.test.ts
@@ -25,6 +25,7 @@ import {
   verifySigV4,
   redactAuthorizationSegment,
   redactSignature,
+  boundTimestampHeader,
   type SigV4VerifyRequest,
   type ResolvedCredentials,
 } from '../../../src/local/sigv4-verify.js';
@@ -145,6 +146,26 @@ describe('redactAuthorizationSegment — the quote/withhold boundary (issue #555
   });
 });
 
+describe('boundTimestampHeader — length only, never shape (issue #555)', () => {
+  it('quotes every legal timestamp spelling verbatim, spaces and all', () => {
+    for (const legal of [
+      '20260101T000000Z',
+      'Mon, 02 Jan 2006 15:04:05 GMT',
+      new Date().toString(),
+      'Wednesday, December 31, 2025 00:00:00 GMT+0000 (Coordinated Universal Time)',
+    ]) {
+      expect(boundTimestampHeader(legal)).toBe(legal);
+    }
+  });
+
+  it('withholds only a value too long to be any of them', () => {
+    expect(boundTimestampHeader('a'.repeat(200))).toBe('a'.repeat(200));
+    expect(boundTimestampHeader('a'.repeat(201))).toBe(
+      '<withheld: 201 characters, too long to be a timestamp>'
+    );
+  });
+});
+
 describe('redactSignature — the offered Signature= value (issue #555)', () => {
   it('quotes a real 64-character lowercase-hex signature verbatim', () => {
     const real = 'f00dfeed'.repeat(8);
@@ -218,8 +239,20 @@ describe('verifySigV4 — no unparsed Authorization material at info (issue #555
         `SignedHeaders=host, ${basic}`
     );
     expect(infos).toContain('malformed Authorization header');
-    expect(infos).toContain('malformed parameter 3 of 3');
+    // The detail is asserted too, not only the position: both arms of it
+    // were unfenced, so deleting it entirely left the suite green.
+    expect(infos).toContain(`malformed parameter 3 of 3 (${basic.length} characters, no '=')`);
     expect(infos).not.toContain(basic);
+  });
+
+  it('names a stray trailing comma as an EMPTY parameter, not a missing \'=\'', async () => {
+    // The other arm of the same detail. "no '=' in it" is true of an empty
+    // part but points at the wrong fault, which is the extra comma.
+    const infos = await infoOnReject(
+      'AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws4_request, ' +
+        'SignedHeaders=host, Signature=abcd,'
+    );
+    expect(infos).toContain('malformed parameter 4 of 4 (empty, stray comma?)');
   });
 
   it('withholds an algorithm token too long to be a scheme name', async () => {
@@ -245,6 +278,33 @@ describe('verifySigV4 — no unparsed Authorization material at info (issue #555
     expect(infos).toMatch(WITHHELD);
     expect(infos).not.toContain(SIGNATURE);
     expect(infos).toContain('expected YYYYMMDD');
+  });
+
+  it('withholds an over-long x-amz-date rather than flooding the log with it', async () => {
+    // `info`, and `cdkl studio` mirrors these lines into a log ring it
+    // serves over HTTP, so the echo has to be bounded even though its shape
+    // must not be constrained.
+    const flood = `2026-01-01T00:00:00Z ${'x'.repeat(400)}`;
+    const spy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    const req: SigV4VerifyRequest = {
+      method: 'POST',
+      rawUrl: '/',
+      headers: {
+        host: '127.0.0.1:65483',
+        'x-amz-date': flood,
+        authorization:
+          'AWS4-HMAC-SHA256 Credential=AKIALOCALEXAMPLE/20260101/us-east-1/execute-api/aws4_request, ' +
+          'SignedHeaders=host, Signature=abcd',
+      },
+      body: Buffer.alloc(0),
+    };
+    const result = await verifySigV4(req, loadLocal, { now: () => NOW });
+    expect(result.allow).toBe(false);
+    const infos = spy.mock.calls.map((c) => String(c[0])).join('\n');
+    spy.mockRestore();
+    expect(infos).toContain('does not match');
+    expect(infos).toContain('too long to be a timestamp');
+    expect(infos).not.toContain('x'.repeat(400));
   });
 
   it('withholds an access-key-id segment that swallowed the signature (warn level)', async () => {
@@ -315,13 +375,14 @@ describe('verifySigV4 — the diagnostics issue #246 added are NOT over-redacted
     expect(alg).toContain("algorithm 'AWS4-HMAC-SHA512'.");
   });
 
-  it('still quotes an RFC 1123 x-amz-date in full (deliberately not redacted)', async () => {
-    // `x-amz-date` is left raw on purpose (see the note at the site): no
-    // delimiter mistake can sweep an `Authorization` segment into it, and
-    // its legal spellings carry spaces and run long, so any shape-based
-    // bound would withhold the valid-but-mismatched timestamp this message
-    // exists to show. This case is what stops a later sweep from applying
-    // `redactAuthorizationSegment` here by analogy.
+  it('still quotes an RFC 1123 x-amz-date in full (length-bounded, never shape-bounded)', async () => {
+    // The timestamp header is bounded by LENGTH ONLY (see the note on
+    // `boundTimestampHeader`): no delimiter mistake can sweep an
+    // `Authorization` segment into it, and its legal spellings carry spaces
+    // and run long, so any SHAPE bound would withhold the
+    // valid-but-mismatched timestamp this message exists to show. This case
+    // is what stops a later sweep from applying `redactAuthorizationSegment`
+    // here by analogy.
     const rfcDate = 'Mon, 02 Jan 2006 15:04:05 GMT';
     const spy = vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
     const req: SigV4VerifyRequest = {
@@ -340,7 +401,7 @@ describe('verifySigV4 — the diagnostics issue #246 added are NOT over-redacted
     expect(result.allow).toBe(false);
     const infos = spy.mock.calls.map((c) => String(c[0])).join('\n');
     spy.mockRestore();
-    expect(infos).toContain(`x-amz-date '${rfcDate}'`);
+    expect(infos).toContain(`x-amz-date / date '${rfcDate}'`);
     expect(infos).not.toMatch(WITHHELD);
   });
 

--- a/tests/unit/local/sigv4-verify-rejection-paths-info.test.ts
+++ b/tests/unit/local/sigv4-verify-rejection-paths-info.test.ts
@@ -218,7 +218,7 @@ describe('verifySigV4 — 7 rejection paths surface at info (issue #246)', () =>
     // key over a string-to-sign the caller chose, so echoing it would hand
     // out valid signatures. That withholding is fenced in
     // `sigv4-verify-auth-segment-redaction.test.ts`.
-    expect(infos).toMatch(/recomputed/);
+    expect(infos).toContain('the recomputed signature is withheld');
     expect(infos).toMatch(/0{64}/);
     info.restore();
   });

--- a/tests/unit/local/sigv4-verify-rejection-paths-info.test.ts
+++ b/tests/unit/local/sigv4-verify-rejection-paths-info.test.ts
@@ -212,8 +212,12 @@ describe('verifySigV4 — 7 rejection paths surface at info (issue #246)', () =>
     expect(result.allow).toBe(false);
     const infos = info.calls().join('\n');
     expect(infos).toMatch(/Signature= mismatch/);
-    // Both the recomputed and the offered signatures should appear so the
-    // user can spot the divergence at a glance.
+    // The OFFERED signature appears, so the user can compare it with what
+    // their signer produced. The RECOMPUTED one is named but withheld
+    // (issue #555): it is an HMAC under the developer's real secret access
+    // key over a string-to-sign the caller chose, so echoing it would hand
+    // out valid signatures. That withholding is fenced in
+    // `sigv4-verify-auth-segment-redaction.test.ts`.
     expect(infos).toMatch(/recomputed/);
     expect(infos).toMatch(/0{64}/);
     info.restore();


### PR DESCRIPTION
## Summary

Two issues in one lane.

**Issue 555** asked for a per-site JUDGEMENT on four log sites that echo caller-supplied request data, not a blanket redaction. Every site is either fixed, or left with an in-code note saying why — an uncommented "deliberately left" site is indistinguishable from an oversight.

Two different arguments decide the four, and it is worth naming both, because only one of them is the criterion the sibling redaction work used:

- **Provenance** — does the value come from material cdk-local resolved out of a secret or parameter store, or is it the developer's own payload on their own machine? This is what settles the three `debug`-gated sites, and it is why they stay.
- **Level plus delimiter sweep** — what settles `sigv4-verify.ts`. Its material is caller-supplied too, so provenance alone would have left it. What makes it different is that it prints WITHOUT `--verbose`, and that a mis-delimited header makes the message print something other than the field it names.

**Issue 557** asked for unit coverage of `resolveSsm`, the SSM half of the ECS secrets resolver, which had none repo-wide.

## Issue 555 — the four sites, and what happened to each

| Site | Level | Decision |
|---|---|---|
| `src/local/sigv4-verify.ts` — the `Authorization` segments | `info` / `warn` | **FIXED** |
| `src/local/rest-v1-integrations.ts` — the MOCK render + `statusCode` reason | `debug` | **LEFT**, with a note |
| `src/local/websocket-server.ts` — the frame body and the close reason | `debug` | **LEFT**, with a note |
| `src/local/vtl-engine.ts` — the JSONPath expression, which reaches the 502 body | n/a (throw) | **LEFT**, with a note |

**Why sigv4-verify is the one that changed.** Each of its messages names a POSITION in the header, and a position holds only its own short token while the delimiters sit where the parser expects. Drop ONE comma:

```
Credential=AKID/20260101/us-east-1/execute-api/aws4_request Signature=<hex>, SignedHeaders=host, Signature=abcd
```

and `Credential=`'s value absorbs the parameter that should have followed it, so the credential-scope split hands its last segment the `Signature=` component — printed at default level. (A header delimited by spaces THROUGHOUT does not reach that message: it yields one parameter, so the parse throws `missing SignedHeaders` first.)

New `redactAuthorizationSegment` quotes a segment only when it could still BE one — no whitespace, no `=`, at most 32 characters. 32 clears every value these messages legitimately name with room to spare (`AWS4-HMAC-SHA256` is 16, the longest real algorithm spelling the parser rejects is 30, `aws4_request` is 12, a `YYYYMMDD` date is 8, an access-key id is 20); what fixes it AT 32 rather than higher is the ceiling — an AWS secret access key is 40 characters, and pasting one into `AWS_ACCESS_KEY_ID` is the one way a developer's own secret reaches this header, so the bound has to sit below 40.

Two sites report shape rather than value, because neither can be quoted safely: the `Credential=` value reports its segment COUNT, and a parameter with no `=` reports its POSITION (an `Authorization: Basic <base64>` sent to an AWS_IAM route arrives as exactly one such parameter).

**The recomputed signature is now withheld.** This was a blocker found by the security reviewer on the first commit. `recomputed` is `HMAC(signing key derived from the developer's real secret access key, string-to-sign)`, and every input to that string-to-sign is caller-chosen: the credential scope's region and service, the date, the signed headers and their values, the URI, the query, the payload hash. Reaching the branch needs only an access-key id equal to the local one, and an access-key id is an identifier rather than a secret. So the message was a signing oracle: send a request canonically identical to some AWS API call, read a valid signature for it under the developer's own credentials off the log — at `info`, with `cdkl studio` mirroring the line into a log ring it serves over HTTP. The OFFERED signature is still printed, through a hex-only predicate, because `Signature=` is the LAST parameter and therefore a sweep position of its own.

The five access-key-id echoes at `warn` are redacted too: `warn` is LESS gated than `info`, so scoping the fix to `info` would have inverted its own visibility argument.

**`x-amz-date` / `date` is bounded by LENGTH ONLY**, never by shape, and the note at the site says why. Nothing can be swept into it (`pickHeader` reads the whole header), and its legal spellings carry spaces and run long — measured on Node 24, RFC 1123 is 29 characters and `new Date().toString()` runs 45 to 76 across all 418 zones `Intl.supportedValuesOf` lists — so a whitespace clause or a 32-character cap would withhold exactly the valid-but-mismatched timestamp the message exists to show. But "no shape bound" is not "no bound": the value is unbounded caller input at `info`, so it is capped at 200 characters, which is above every spelling above. Tests pin both directions.

## Issue 557 — resolveSsm coverage

`tests/unit/local/ecs-secrets-resolver-ssm.test.ts` fences: `WithDecryption: true` (asserted standalone, so the failure names the field a regression drops — without it every SecureString silently resolves to ciphertext), the leading-slash `Name` that `classifySecretArn` extracts from a nested path, the verbatim value including a JSON-shaped one, an empty-string value, the no-`Value` throw in both response shapes, the `err instanceof EcsSecretsResolutionError` re-throw guard, `ParameterNotFound` / `InvalidParameters` / non-`Error` rejections, a mixed Secrets Manager + SSM batch, two SSM entries correlated to their own parameters, the unsupported-`ValueFrom` branch, client lifecycle (built ones closed, borrowed ones not), and the empty-batch short circuit.

The command RETAINS its input here, unlike the two sibling files whose `GetParameterCommand: class {}` discards it — which is why they could not have caught any of this.

## Test plan

- `vp run check` — 0 errors (the 1 warning is pre-existing, in an untouched file).
- `vp run build`, `vp run test` — 216 files / 3221 tests, 0 type errors. `vp run test:hooks` — 53 pass / 0 fail.
- **30 mutation probes, every one RED at the final state.** Each restores through an in-progress-flag guard and re-checks the file's sha. Per-OCCURRENCE probing mattered: replacing all five access-key-id interpolations at once reported RED while two of the five spellings (the `sigV4StrictByDefault` variants) were in fact unfenced, so that axis is covered now.
- **Live test against the built CLI**, not just unit tests: `node dist/cli.js start-api` over the `local-start-api` fixture, three arms curled at the AWS_IAM Function URL — the one-missing-comma sweep, an `Authorization: Basic <base64>`, and a matching-access-key-id request with a wrong signature. The same script run against a detached `origin/main` worktree FAILS all three assertions (the signature, the base64 credential and a second 64-hex value all appear in the log), so the arms discriminate rather than passing vacuously.
- Integ: `local-start-api-rest-v1-non-proxy` passes clean with 0 Docker orphans, exercising the `rest-v1-integrations.ts` + `vtl-engine.ts` paths this PR annotates. `local-start-api` and `local-start-api-websocket` fail on this machine on BOTH this branch and `origin/main`, in the Go RIE under `linux/amd64` emulation on an `arm64` host — cdk-local's own warning predicts it. Evidence and candidate fixes are in (#560); this PR changes none of the code those arms cover.

## Reviewer findings and their disposition

Two rounds of four reviewers each — 3-axis plus a security pass, the tier being `1-reviewer` by size and biased up by `src/local/sigv4-verify.ts`. Round 2 confirmed the round-1 blocker closed (`recomputed` has exactly one read, `constantTimeEqual`, and never reaches `buildIdentityHash`, the response body, or a cache) and blocked on nothing.

Fixed here: the recomputed-signature oracle; the access-key-id echoes at `warn`; the offered signature's own sweep position; the unbounded `x-amz-date` echo; `vtl-engine.ts` claiming `vtlFailure` puts the RENDERED template in the 502 body when it puts the SOURCE, and separately drawing a provenance distinction from `$util.parseJson` that does not exist (the real difference is size — a whole request body versus one path expression); a cited example header that throws `missing SignedHeaders` before reaching the message it illustrates; "provably the developer's own signature" overstating what an access-key-id match proves; `200 bytes` where the slice is 200 UTF-16 code units (at most 600 UTF-8 bytes for a text frame, 150 payload bytes for an already-base64 binary one); the close reason described as always reaching the `$disconnect` handler when the route may not exist; `new Date().toString()` given as 75 characters when it is 45-76 by zone; "32 is the smallest bound" when it is merely comfortably above the values it must quote; `redactSignature` documented as "at most 64" against a signature that is exactly 64; the empty-parameter case reporting the wrong fault; the `Credential=` message repeating a shape its own caller prints; `expected 5 slash-separated segments` being a substring of the message it replaces; the unfenced whitespace half of the segment predicate; a `toMatch(/recomputed/)` that now matched the withholding sentence instead of a value; two SSM entries in one batch; the unsupported-`ValueFrom` branch; client lifecycle and the empty-batch path. Round 2's own per-occurrence sweep found two more survivors, both now fenced: both arms of the `malformed parameter` detail (deleting it entirely left the suite green), and the Secrets Manager half of the client-ownership split, which a test that never borrows one cannot tell from an unconditional destroy.

TODO, filed: the credential chain's own error text relayed at `warn`, which a `credential_process` command line can carry a passphrase into (#564) — a pointer comment sits at the site so a later sweep finds it rather than re-deriving it. The foreign-access-key-id warn dedup Set grows without bound (#561). The arm64 emulation fixture failures (#560).

Won't-do, decided and recorded here:

- **Tests pinning that the three LEFT sites still print their diagnostic.** Issue 555's own Effort line says "the four decisions and their tests", so this is a real omission rather than an oversight: the in-code note is the durable artifact and the issue's stated hard requirement, while a test asserting a `debug` line's text would pin log wording without pinning any property the decision rests on. The one LEFT decision that DID get tests is `x-amz-date`, because there the decision is a predicate (length yes, shape no) and a predicate can be fenced.
- **`expected YYYYMMDD` also being a substring of the message it replaces.** That case's discriminating assertions are its siblings (the withheld marker and the signature's absence), and the mutation probe for that site is RED.
- **The `cdkl studio` log ring as an additional reader.** Real — studio streams a serve child's stdout onto a bus it serves at `GET /api/logs` — but the server binds `127.0.0.1` and sets no CORS headers, so a browser blocks cross-origin reads. The two echoes where the reader mattered, the recomputed signature and the unbounded timestamp, are bounded here rather than argued about.

## Retrospective — patterns worth a rule, surfaced rather than written

Not committed here, because they change agent-instruction files and that propagates to every future session:

1. **A "deliberately left" note must enumerate EVERY value interpolated on the line it defends.** The first commit's note argued about the offered signature while the same line also printed the recomputed one, which is derived from the developer's secret. A rationale that names one of several interpolations silently covers the rest.
2. **Probe each occurrence separately when a fix touches N textually identical sites.** Replacing all five at once reported RED and hid that two were unfenced. A whole-symbol probe answers "is ANY of this fenced", not "is EACH".
3. **Before applying a redaction predicate to a new field, enumerate that field's legal vocabulary and check the predicate accepts all of it** — and if the shape bound is wrong, remember that a LENGTH bound may still be right. Ruling out one kind of bound is not ruling out all of them.
4. **A number quoted from a reviewer is a claim you are publishing.** Two length figures reached a comment and this body before being measured; both were wrong.

Closes #555
Closes #557
