### PR TITLE
chore(work-issues): prefer measured Severity over the title-prefix proxy when picking issues

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -221,6 +221,31 @@ choosing.
   rather than from a list here, which would be a fifth copy to keep in sync. A
   security fix landing outside those paths gets no automatic bump, so raise the
   tier by hand and say why.
+- **Then higher `Severity` first**, when BOTH candidates carry it — `high` >
+  `medium` > `low`. It is the same axis the security rule above approximates: how
+  much the defect costs while it sits. The difference is that `Severity` was
+  MEASURED by the session that held the evidence, where a title prefix or a hunch
+  about the area is only a proxy for it, and **a proxy does not outrank the
+  measurement it stands in for**. The "BOTH carry it" precondition is what makes
+  that safe — most of the backlog carries no `Severity` at all, and for those this
+  preference simply does not fire, so an unclassified `fix:` never loses its place
+  to a `chore:` that happens to claim `high`.
+
+  `Severity` is a LABEL as well as a body line, so this is answerable from the
+  LISTING rather than one `gh issue view` per candidate:
+
+  ```bash
+  gh issue list --state open --limit 200 --json number,title,labels \
+    --jq '.[] | [.number,
+                 ([.labels[].name | select(startswith("severity:"))] | first // "severity:?"),
+                 ([.labels[].name | select(startswith("effort:"))]   | first // "effort:?"),
+                 .title] | @tsv'
+  ```
+
+  `severity:?` means UNLABELLED, which is **not** `low`. A label-only query
+  UNDER-counts, because most of the backlog predates the labels, so the label is a
+  mirror of the body line and never a second source — confirm a surprising one
+  against the body before acting on it.
 - Same file, related class → **bundle** into a single lane/PR (e.g. two
   `front-door-server.ts` routing fixes → one PR).
 - Different files → separate parallel lanes.


### PR DESCRIPTION
chore(work-issues): prefer measured Severity over the title-prefix proxy when picking issues

`Severity` is written by the session that reproduced the defect and held the
evidence. A conventional-commit prefix is a guess at the same question -- how
much does this cost while it sits -- made by whoever typed the title. The two
were ordered with the guess on top.

A proxy should not outrank the measurement it stands in for, so the Severity
preference now applies BEFORE the prefix, immediately after the security rule.

The old ordering had a real reason, and it is worth being precise about why it
no longer applies: most of the backlog carries no `Severity` at all (32 of 120
open issues in go-to-k/cdkd carry the line; the other 88 are the old packed
shape, whose `Effort:` holds a duration and which state no `Severity`). The fear
was that an unclassified `fix:` would lose its place to a `chore:` claiming
`high`. But that is already prevented by the preference's own precondition --
it fires only when BOTH candidates carry a value -- so an unclassified issue
falls straight through to the prefix rule exactly as before. The precondition
was doing the work the ordering was credited with.

What made the promotion practical rather than merely correct: `Severity` is now
a LABEL as well as a body line, so the comparison is answerable from the ISSUE
LISTING instead of one `gh issue view` per candidate. The recipe is included and
was run against the live repo.

Stated where it would otherwise be re-derived: `severity:?` in that listing means
UNLABELLED, which is NOT `low` -- the rule does not fire for such an issue. A
label-only query UNDER-counts for the same reason, so the label stays a mirror of
the body line and never a second source.

This repo's triage list is a set of PREFERENCES rather than a numbered table, so
the change is one new bullet placed directly after the security rule -- there are
no rank numbers here to renumber. Ported from go-to-k/cdkd, where the same rule
moved from position 4 to position 3.
