### PR TITLE
chore(work-issues): resolve an issue's premise against the tree before writing anything that depends on it

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -246,6 +246,38 @@ choosing.
   UNDER-counts, because most of the backlog predates the labels, so the label is a
   mirror of the body line and never a second source — confirm a surprising one
   against the body before acting on it.
+- **An issue's premise may not be TRUE YET — resolve the body against the tree
+  before you write anything that depends on it.** A body written from an unmerged
+  branch describes the state of THAT branch: a lane routinely files a follow-up
+  for a file its own allow-list excluded, minutes before the PR that creates the
+  thing the follow-up talks about. The issue is then accurate about a tree that
+  does not exist on `main` yet, and stays that way until its sibling merges.
+
+  What that costs is specific, because the fix you write NAMES the premise. On
+  2026-08-26 go-to-k/cdkd#2246 asked for a doc note pointing at
+  `nestedStackChildRegionFromLocalArn` as the reader that parses a region segment
+  back; `grep -rn nestedStackChildRegionFromLocalArn src/` at claim time returned
+  **nothing** — it landed sixteen minutes later in go-to-k/cdkd#2266. Writing the
+  note on the issue's word would have shipped a comment naming a function that was
+  not there.
+
+  Two moves, and the second is the one that is easy to skip. **(1)** grep for every
+  symbol, file and behaviour the body asserts already exists, before the first
+  edit. **(2)** When a grep comes back empty, find out WHICH way:
+  `gh pr list --state all --search <symbol>` separates "the premise is wrong" from
+  "the premise is on an unmerged branch", and those need opposite responses — the
+  first is a correction to post on the issue, the second is
+  `git fetch && git rebase origin/main` and carry on. Do not read an empty grep as
+  "the issue is wrong".
+
+  **Verify the parts you are NOT changing, too.** That same issue also stated the
+  sibling producer's DOC already recorded the rationale; only its parameter NAME
+  had changed, and the doc still covered something else. That half was never going
+  to fail a build — it would have shipped as a pointer at a paragraph that does not
+  say what it was cited for. A body's claims about SURROUNDING code get no compiler
+  and no test, so they are the ones to check by hand. Say what you found in the PR
+  body: the next reader needs to know the issue and the tree disagreed, and which
+  one won.
 - Same file, related class → **bundle** into a single lane/PR (e.g. two
   `front-door-server.ts` routing fixes → one PR).
 - Different files → separate parallel lanes.


### PR DESCRIPTION
chore(work-issues): an issue's premise may not be true YET, so resolve the body against the tree before writing anything that depends on it

Triage already carries the mirror of this: "a MIRROR issue may already be DONE --
resolve it against the repo before you claim it." This is the other direction,
and in this repo it is the commoner one.

A body written from an unmerged branch describes the state of THAT branch. Lanes
here routinely file a follow-up for a file their own allow-list excluded, minutes
before the PR that CREATES the thing the follow-up talks about merges. The issue
is then accurate about a tree that does not exist on `main`, and stays that way
until its sibling lands.

What that costs is specific, because the fix you write NAMES the premise.
Measured 2026-08-26: https://github.com/go-to-k/cdkd/issues/2246 asked for a doc note pointing at
`nestedStackChildRegionFromLocalArn` as the reader that parses a nested-stack
ARN's region segment back. At claim time
`grep -rn nestedStackChildRegionFromLocalArn src/` returned NOTHING -- it landed
sixteen minutes later in https://github.com/go-to-k/cdkd/pull/2266. Writing the note on the issue's word
would have shipped a comment naming a function that was not in the tree.

Two moves, and the second is the one that is easy to skip:

1. grep for every symbol, file and behaviour the body asserts already exists,
   before the first edit -- the same one command the mirror check costs.
2. When a grep comes back EMPTY, find out WHICH way.
   `gh pr list --state all --search <symbol>` separates "the premise is wrong"
   from "the premise is on an unmerged branch", and those need opposite
   responses: the first is a correction to post on the issue, the second is
   `git fetch && git rebase origin/main` and carry on. Reading an empty grep as
   "the issue is wrong" would have produced a confident, wrong correction here.

And the half that has no compiler behind it: VERIFY THE PARTS YOU ARE NOT
CHANGING. The same issue also stated that the sibling producer's DOC already
recorded the rationale. Only its parameter NAME had changed; the doc still
covered something else entirely. That claim was never going to fail a build --
it would have shipped as a pointer at a paragraph that does not say what it was
cited for. A body's assertions about SURROUNDING code get no test, so they are
the ones to check by hand, and what you find belongs in the PR body: the next
reader needs to know the issue and the tree disagreed, and which one won.
