### PR TITLE
test(integ): run the start-api and websocket fixture Lambdas at the host architecture

### DIFF
--- a/tests/integration/local-start-api-websocket/lib/stack.ts
+++ b/tests/integration/local-start-api-websocket/lib/stack.ts
@@ -30,9 +30,15 @@ import * as path from 'node:path';
  * host's emulation for the other's. Nothing in verify.sh asserts the
  * architecture, so this costs no coverage.
  *
+ * Caveat: `process.arch` is the architecture of the Node process running
+ * this CDK app, NOT the Docker daemon's. A Rosetta-emulated Node, or a
+ * `DOCKER_HOST` / `docker context` aimed at a foreign-arch daemon, can
+ * still declare the non-native arch. Neither is the ordinary local case,
+ * and cdk-local's emulation warning still fires when it happens.
+ *
  * Keep this on every function in this fixture: a new handler that omits
- * it silently reintroduces #560 on arm64 hosts. `tests/unit/integ-fixture-host-architecture.test.ts`
- * fences that.
+ * it silently reintroduces the arm64-only flake. The fence lives in
+ * `tests/unit/integ-fixture-host-architecture.test.ts`.
  */
 const HOST_ARCHITECTURE =
   process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;

--- a/tests/integration/local-start-api-websocket/lib/stack.ts
+++ b/tests/integration/local-start-api-websocket/lib/stack.ts
@@ -11,6 +11,33 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as path from 'node:path';
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * cdk-local pins `docker --platform` to each function's declared
+ * `Architectures` (see `pullImage` / `architectureToPlatform`), which is
+ * the correct behavior: a `provided.*` bootstrap compiled for one arch
+ * must get the matching base image. But a function that declares no
+ * `architecture` defaults to `X86_64`, so on an arm64 host every
+ * container in this fixture ran `linux/amd64` under CPU emulation --
+ * and the Go RIE inside `public.ecr.aws/lambda/nodejs:20` faults
+ * intermittently there, at a different assertion on every run
+ * (issue #560).
+ *
+ * The base image is multi-arch -- `docker manifest inspect
+ * public.ecr.aws/lambda/nodejs:20` lists both `arm64`/v8 and `amd64` --
+ * so declaring the host arch makes the container native on an Apple
+ * Silicon dev host AND on an x86_64 CI runner, rather than trading one
+ * host's emulation for the other's. Nothing in verify.sh asserts the
+ * architecture, so this costs no coverage.
+ *
+ * Keep this on every function in this fixture: a new handler that omits
+ * it silently reintroduces #560 on arm64 hosts. `tests/unit/integ-fixture-host-architecture.test.ts`
+ * fences that.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * WebSocket API fixture for the `cdkl start-api` WebSocket integ
  * test (#462). The stack synthesizes 5 Lambdas + 1 WebSocket API + 5
  * routes — `$connect`, `$disconnect`, `$default`, `sendMessage` (echo),
@@ -30,26 +57,31 @@ export class LocalStartApiWebSocketStack extends cdk.Stack {
     // container).
     const connectFn = new lambda.Function(this, 'ConnectFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(import.meta.dirname, '..', 'lambda-connect')),
     });
     const disconnectFn = new lambda.Function(this, 'DisconnectFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(import.meta.dirname, '..', 'lambda-disconnect')),
     });
     const defaultFn = new lambda.Function(this, 'DefaultFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(import.meta.dirname, '..', 'lambda-default')),
     });
     const sendFn = new lambda.Function(this, 'SendFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(import.meta.dirname, '..', 'lambda-send')),
     });
     const broadcastFn = new lambda.Function(this, 'BroadcastFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(import.meta.dirname, '..', 'lambda-broadcast')),
     });

--- a/tests/integration/local-start-api/lib/local-start-api-stack.ts
+++ b/tests/integration/local-start-api/lib/local-start-api-stack.ts
@@ -32,9 +32,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * host's emulation for the other's. Nothing in verify.sh asserts the
  * architecture, so this costs no coverage.
  *
+ * Caveat: `process.arch` is the architecture of the Node process running
+ * this CDK app, NOT the Docker daemon's. A Rosetta-emulated Node, or a
+ * `DOCKER_HOST` / `docker context` aimed at a foreign-arch daemon, can
+ * still declare the non-native arch. Neither is the ordinary local case,
+ * and cdk-local's emulation warning still fires when it happens.
+ *
  * Keep this on every function in this fixture: a new handler that omits
- * it silently reintroduces #560 on arm64 hosts. `tests/unit/integ-fixture-host-architecture.test.ts`
- * fences that.
+ * it silently reintroduces the arm64-only flake. The fence lives in
+ * `tests/unit/integ-fixture-host-architecture.test.ts`.
  */
 const HOST_ARCHITECTURE =
   process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;

--- a/tests/integration/local-start-api/lib/local-start-api-stack.ts
+++ b/tests/integration/local-start-api/lib/local-start-api-stack.ts
@@ -13,6 +13,33 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * cdk-local pins `docker --platform` to each function's declared
+ * `Architectures` (see `pullImage` / `architectureToPlatform`), which is
+ * the correct behavior: a `provided.*` bootstrap compiled for one arch
+ * must get the matching base image. But a function that declares no
+ * `architecture` defaults to `X86_64`, so on an arm64 host every
+ * container in this fixture ran `linux/amd64` under CPU emulation --
+ * and the Go RIE inside `public.ecr.aws/lambda/nodejs:20` faults
+ * intermittently there, at a different assertion on every run
+ * (issue #560).
+ *
+ * The base image is multi-arch -- `docker manifest inspect
+ * public.ecr.aws/lambda/nodejs:20` lists both `arm64`/v8 and `amd64` --
+ * so declaring the host arch makes the container native on an Apple
+ * Silicon dev host AND on an x86_64 CI runner, rather than trading one
+ * host's emulation for the other's. Nothing in verify.sh asserts the
+ * architecture, so this costs no coverage.
+ *
+ * Keep this on every function in this fixture: a new handler that omits
+ * it silently reintroduces #560 on arm64 hosts. `tests/unit/integ-fixture-host-architecture.test.ts`
+ * fences that.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl start-api` integ test.
  *
  * No AWS deploy required — the integ exercises the synthesized cdk.out
@@ -64,6 +91,7 @@ export class LocalStartApiStack extends cdk.Stack {
 
     const itemsHandler = new lambda.Function(this, 'ItemsHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-items')),
       timeout: cdk.Duration.seconds(10),
@@ -102,12 +130,14 @@ export class LocalStartApiStack extends cdk.Stack {
     // Authorizer-protected route (PR 8b) — Lambda REQUEST authorizer.
     const authorizerHandler = new lambda.Function(this, 'AuthorizerHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-authorizer')),
       timeout: cdk.Duration.seconds(10),
     });
     const protectedHandler = new lambda.Function(this, 'ProtectedHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-protected')),
       timeout: cdk.Duration.seconds(10),
@@ -137,6 +167,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // `event.stageVariables.STAGE === 'prod'`.
     const restHandler = new lambda.Function(this, 'RestHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-rest')),
       timeout: cdk.Duration.seconds(10),
@@ -197,6 +228,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // us fixture this without spinning up a separate stack.
     const crossStackAuthHandler = new lambda.Function(this, 'CrossStackAuthFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       // Reuse the existing lambda-authorizer asset — never actually
       // invoked locally because the route 501s before the authorizer
@@ -337,6 +369,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // Function URL on a separate Lambda.
     const urlHandler = new lambda.Function(this, 'UrlHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-url')),
       timeout: cdk.Duration.seconds(10),
@@ -352,6 +385,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // — the documented Node 20 streaming Lambda entrypoint.
     const streamUrlHandler = new lambda.Function(this, 'StreamUrlHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-stream-url')),
       timeout: cdk.Duration.seconds(30),
@@ -375,6 +409,7 @@ export class LocalStartApiStack extends cdk.Stack {
       'StreamUrlSetContentTypeHandler',
       {
         runtime: lambda.Runtime.NODEJS_20_X,
+        architecture: HOST_ARCHITECTURE,
         handler: 'index.handler',
         code: lambda.Code.fromAsset(
           path.join(__dirname, '../lambda-stream-url-set-content-type')
@@ -396,6 +431,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // asserts the request reaches the handler instead of being denied.
     const oacUrlHandler = new lambda.Function(this, 'OacUrlHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-url')),
       timeout: cdk.Duration.seconds(10),
@@ -418,6 +454,7 @@ export class LocalStartApiStack extends cdk.Stack {
     // foreign-credential SigV4 header.
     const iamUrlHandler = new lambda.Function(this, 'IamUrlHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-url')),
       timeout: cdk.Duration.seconds(10),

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Fence for issue #560.
+ *
+ * cdk-local pins `docker --platform` to each Lambda's declared
+ * `Architectures` (`local-start-api.ts` `architecture` -> `pullImage` /
+ * `architectureToPlatform`). A function that declares no `architecture`
+ * defaults to `x86_64`, so on an arm64 host its container runs
+ * `linux/amd64` under CPU emulation -- where the Go RIE inside
+ * `public.ecr.aws/lambda/nodejs:20` faults intermittently
+ * (`fatal error: fault`, `select on synctest channel from outside
+ * bubble`, `sync: inconsistent mutex state`), failing a DIFFERENT
+ * assertion on every run.
+ *
+ * The two fixtures below therefore declare the HOST's architecture, which
+ * is native on an Apple Silicon dev host and on an x86_64 CI runner
+ * alike. This test exists because the failure mode is silent and
+ * environment-dependent: a new handler added without `architecture` would
+ * pass on CI (amd64, where the default IS the host arch) and reintroduce
+ * a flaky arm64-only failure that costs another diagnosis cycle.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Listed as literals on purpose: deriving this from a directory scan
+ * would make the test blind to a fixture being removed from the set, and
+ * would silently widen the fence to fixtures that have not been verified
+ * on an arm64 host.
+ */
+const FIXTURE_STACKS = [
+  'tests/integration/local-start-api/lib/local-start-api-stack.ts',
+  'tests/integration/local-start-api-websocket/lib/stack.ts',
+];
+
+/**
+ * Return the source text of every `new lambda.Function(...)` call in
+ * `source`, delimited by brace/paren matching rather than a line regex so
+ * that both the single-line and the wrapped
+ * `new lambda.Function(\n  this,\n  'Id',\n  {...}\n)` spellings in these
+ * fixtures are covered.
+ */
+function lambdaFunctionCalls(source: string): string[] {
+  const calls: string[] = [];
+  const needle = 'new lambda.Function(';
+  let from = 0;
+  for (;;) {
+    const start = source.indexOf(needle, from);
+    if (start === -1) break;
+    let depth = 0;
+    let end = start + needle.length - 1;
+    for (let i = start + needle.length - 1; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === '(') depth++;
+      else if (ch === ')') {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    calls.push(source.slice(start, end + 1));
+    from = end + 1;
+  }
+  return calls;
+}
+
+describe('integ fixture Lambdas run at the host architecture (issue #560)', () => {
+  for (const relPath of FIXTURE_STACKS) {
+    describe(relPath, () => {
+      const source = readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+
+      it('derives HOST_ARCHITECTURE from process.arch, mapping arm64 -> ARM_64 and everything else -> X86_64', () => {
+        // Hardcoding either arch would just move the emulation to the other
+        // host: `ARM_64` would make CI (amd64) emulate, `X86_64` is the
+        // default that caused #560 on arm64. Only the host-derived form is
+        // native on both.
+        const normalized = source.replace(/\s+/g, ' ');
+        expect(
+          normalized,
+          `${relPath} must define HOST_ARCHITECTURE from process.arch`
+        ).toContain(
+          "const HOST_ARCHITECTURE = process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;"
+        );
+      });
+
+      it('declares architecture: HOST_ARCHITECTURE on every lambda.Function', () => {
+        const calls = lambdaFunctionCalls(source);
+        expect(calls.length, `${relPath} should declare at least one lambda.Function`).toBeGreaterThan(0);
+
+        const missing = calls
+          .filter((call) => !call.includes('architecture: HOST_ARCHITECTURE'))
+          // Name the offender by its construct id so the failure points at
+          // the function to fix rather than at a count.
+          .map((call) => /new lambda\.Function\(\s*this,\s*'([^']+)'/.exec(call)?.[1] ?? call.slice(0, 80));
+
+        expect(
+          missing,
+          `${relPath}: these lambda.Function constructs are missing ` +
+            `\`architecture: HOST_ARCHITECTURE\`, which reintroduces issue #560 ` +
+            `(amd64 emulation on arm64 hosts) for them`
+        ).toEqual([]);
+      });
+    });
+  }
+});

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -37,6 +37,23 @@ const FIXTURE_STACKS = [
   'tests/integration/local-start-api-websocket/lib/stack.ts',
 ];
 
+/** The one Lambda constructor spelling both fixtures are required to use. */
+const CANONICAL_CTOR = 'new lambda.Function(';
+
+/**
+ * Every `new <Something>Function(` constructor call, in any spelling.
+ *
+ * `lambdaFunctionCalls` below keys off the single canonical spelling, so on
+ * its own it would report a clean pass for a handler added as
+ * `NodejsFunction` / `lambda.DockerImageFunction` / a named-import
+ * `new Function(` / even `new lambda.Function (` with a space -- i.e. it
+ * would be blind to exactly the "someone adds a handler" case this file
+ * exists to catch. Matching the broad shape and then requiring every hit to
+ * be the canonical spelling turns an unrecognized spelling into a loud
+ * failure instead of a silent pass.
+ */
+const ANY_FUNCTION_CTOR = /new\s+(?:[A-Za-z_$][\w$]*\s*\.\s*)?[\w$]*Function\s*\(/g;
+
 /**
  * Return the source text of every `new lambda.Function(...)` call in
  * `source`, delimited by brace/paren matching rather than a line regex so
@@ -46,7 +63,7 @@ const FIXTURE_STACKS = [
  */
 function lambdaFunctionCalls(source: string): string[] {
   const calls: string[] = [];
-  const needle = 'new lambda.Function(';
+  const needle = CANONICAL_CTOR;
   let from = 0;
   for (;;) {
     const start = source.indexOf(needle, from);
@@ -73,9 +90,13 @@ function lambdaFunctionCalls(source: string): string[] {
 describe('integ fixture Lambdas run at the host architecture (issue #560)', () => {
   for (const relPath of FIXTURE_STACKS) {
     describe(relPath, () => {
-      const source = readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+      // Read inside each test rather than at collection time, so a renamed or
+      // deleted fixture fails as a named test rather than as a suite-level
+      // ENOENT that names no expectation.
+      const read = (): string => readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
 
       it('derives HOST_ARCHITECTURE from process.arch, mapping arm64 -> ARM_64 and everything else -> X86_64', () => {
+        const source = read();
         // Hardcoding either arch would just move the emulation to the other
         // host: `ARM_64` would make CI (amd64) emulate, `X86_64` is the
         // default that caused #560 on arm64. Only the host-derived form is
@@ -89,8 +110,32 @@ describe('integ fixture Lambdas run at the host architecture (issue #560)', () =
         );
       });
 
+      it('defines its Lambdas only via the canonical `new lambda.Function(` spelling', () => {
+        // Guards the assumption the next test depends on. Without this, a
+        // handler added as `NodejsFunction` / `lambda.DockerImageFunction` /
+        // `new Function(` would not be found at all, and "every construct
+        // declares the architecture" would be vacuously true of it.
+        const source = read();
+        const found = [...source.matchAll(ANY_FUNCTION_CTOR)].map((m) => m[0]);
+        const nonCanonical = found.filter((spelling) => spelling !== CANONICAL_CTOR);
+
+        expect(
+          nonCanonical,
+          `${relPath}: found Lambda constructor spelling(s) this fence does not ` +
+            `understand. Either use \`${CANONICAL_CTOR}\` or teach ` +
+            `lambdaFunctionCalls() the new spelling -- otherwise the ` +
+            `architecture check silently skips those constructs`
+        ).toEqual([]);
+        expect(found.length, `${relPath} should declare at least one Lambda`).toBeGreaterThan(0);
+      });
+
       it('declares architecture: HOST_ARCHITECTURE on every lambda.Function', () => {
+        const source = read();
         const calls = lambdaFunctionCalls(source);
+        // The two counts must agree, or the brace matcher mis-delimited a call.
+        expect(calls.length, `${relPath}: brace matcher and regex disagree on the Lambda count`).toBe(
+          [...source.matchAll(ANY_FUNCTION_CTOR)].length
+        );
         expect(calls.length, `${relPath} should declare at least one lambda.Function`).toBeGreaterThan(0);
 
         const missing = calls


### PR DESCRIPTION
## Summary

The `local-start-api` and `local-start-api-websocket` fixtures could not produce a clean run on an Apple Silicon host. Both now declare the **host's** CPU architecture on their Lambdas, so their containers run natively on an arm64 dev host and on the x86_64 CI runner alike.

Closes #560

## Root cause, and which layer owns it

cdk-local pins `docker --platform` to each Lambda's declared `Architectures` (`pullImage` in `src/local/docker-runner.ts`, `architectureToPlatform` in `src/local/docker-image-builder.ts`; `src/cli/commands/local-start-api.ts` defaults an absent `Architectures` to `x86_64`). That behavior is **correct** and is not changed here -- a `provided.*` `bootstrap` compiled for one arch must get the matching base image.

The defect was in the fixtures: neither declared an `architecture`, so CDK defaulted all 15 of their Lambdas to `X86_64`. On an arm64 host that resolves to `--platform linux/amd64`, i.e. CPU emulation, where the Go RIE inside `public.ecr.aws/lambda/nodejs:20` corrupts its own runtime state and aborts.

The tell that this was environmental rather than a logic bug is that **the failure point moves**: the same commit fails a different assertion on each run.

| fixture | arm that failed | Go fault |
| --- | --- | --- |
| `local-start-api-websocket` | `stage_basic` buffered-message dispatch | `fatal error: select on synctest channel from outside bubble` |
| `local-start-api` | `POST /protected-sqs` with a valid Bearer returned 401 | `fatal error: fault` |

Both differ from the arms recorded when the problem was first reported, which is the same signature.

## Why declare the host arch rather than the alternatives

`public.ecr.aws/lambda/nodejs:20` is multi-arch -- `docker manifest inspect` returns a manifest list carrying both:

```
"platform": { "architecture": "arm64", "os": "linux", "variant": "v8" }
"platform": { "architecture": "amd64", "os": "linux" }
```

So the arm64 variant exists and no emulation is necessary on either host.

- **Hardcoding `ARM_64`** would just move the emulation onto the amd64 CI runner. The added unit test rejects that spelling explicitly.
- **Skipping the fixtures on arm64** would lose the coverage outright: CI (`.github/workflows/ci.yml`) runs `check` / `build` / `test` only and does **not** execute any integ fixture, so no other runner exercises these paths.

## Effect on an amd64 host: none

Forcing `process.arch` to `x64` and synthesizing shows the only change to the template is an explicit `Architectures: ["x86_64"]` on each function -- which is exactly the value cdk-local already resolves when the key is absent. Same resolved platform, same containers.

## Verification on an arm64 host

`uname -m` = `arm64`, Docker server `arm64/linux`. Each fixture was run three times after the change, because the fault being fixed is intermittent and a single green run would not be evidence.

| run | `local-start-api-websocket` | `local-start-api` |
| --- | --- | --- |
| before the change | exit 1 | exit 1 |
| after, run 1 | exit 0 | exit 0 |
| after, run 2 | exit 0 | exit 0 |
| after, run 3 (final content) | exit 0 | exit 0 |

Across the six post-change runs: 0 emulation warnings, 0 Go faults, 0 `FAIL` lines, and the post-run `docker ps -a --filter name=cdkl-` / network sweeps were empty every time. The emulation warning itself is retained -- it is what made this diagnosable.

## Regression fence

`tests/unit/integ-fixture-host-architecture.test.ts` asserts that both fixture stacks derive the architecture from `process.arch`, that they define Lambdas only via the canonical `new lambda.Function(` spelling, and that **every** such construct declares the architecture. The failure mode is silent and host-dependent, so a new handler added without it would pass on CI and reintroduce an arm64-only flake.

Mutation-probed, each probe restoring the file and re-checking its sha afterwards:

| probe | result |
| --- | --- |
| drop the prop from one websocket handler | fails, naming `ConnectFn` |
| drop it from the wrapped multi-line handler | fails, naming `StreamUrlSetContentTypeHandler` |
| hardcode `ARM_64` instead of deriving it | fails on the `process.arch` assertion |
| drop it from all 10 `local-start-api` handlers | fails, listing all 10 |
| swap one handler to `NodejsFunction` | fails, naming the unrecognized spelling |
| swap one to `lambda.DockerImageFunction` | fails, naming the unrecognized spelling |
| `new lambda.Function (` with a space | fails, naming the unrecognized spelling |
| named-import `new Function(` | fails, naming the unrecognized spelling |

The last four exist because keying only off the canonical spelling would have made the architecture check *vacuously* true for a handler added in any other spelling -- the exact case the fence is for.

## Reviewed and deliberately not changed

- **The brace matcher is not string/comment aware.** A stray paren inside a string within a call would mis-delimit it. It fails safe (a false FAIL, never a false PASS, which would need an unbalanced `(` plus a compensating `)`), and the canonical-spelling assertion above makes it moot. Neither fixture has parens in strings or comments inside a constructor call.
- **The explanatory JSDoc is duplicated across the two fixtures.** They are separate pnpm projects with their own `tsconfig` and `node_modules`, so a shared import would break the self-contained property every fixture in this repo has.

## Test plan

- `vp run check` -- pass
- `vp run build` -- pass
- `vp run test` -- 218 files, 3245 tests, no type errors
- `local-start-api` and `local-start-api-websocket` -- 3 clean runs each on this arm64 host, 0 Docker orphans

No release is expected: this is a `test(...)` commit, and `package.json` `files` is `["dist","README.md","LICENSE"]`, so nothing under `tests/` ships to npm.
