### PR TITLE
chore(work-issues): name the next session's verification before writing Session-fit: next

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1577,6 +1577,24 @@ vp run runtime:smoke
   defer criterion fires, and if you must defer it anyway, put the EVIDENCE in the
   issue body, not just the diagnosis.
 
+  **Before writing `next`, NAME the command the next session will run to
+  verify the fix.** Every deferral is a PREDICTION that a later session can
+  finish the work, and an unstated prediction is never checked: the reason
+  line decays into naming the KIND of work ("a fixture change", "a
+  different subsystem"), which is the MEANS rather than the purpose. You
+  may not write `Session-fit: next` until you can name the concrete
+  command (the fixture, not "the integ"; the assertion that goes red to
+  green, not "a test") and say a FRESH session will be able to run it. The
+  check is generative rather than a lookup, so it catches what no
+  enumerated trigger list contains: a verifier bound to this host (CPU
+  architecture, the platform of a Docker image, the daemon), to this
+  account (a `*-from-cfn-stack` integ fixture's `cdk deploy`), or one that
+  does not exist yet. On 2026-08-26 go-to-k/cdk-local#560 was deferred as "a
+  fixture / base-image change" when the real verification was two
+  `start-api` fixtures ON AN arm64 HOST, which a fresh session may not
+  have; on amd64 they never emulate, so a run there cannot see the fault.
+  `/work-issues` §5 carries the worked version, beside the filing recipe.
+
   **`Session-fit: next` is not on the menu inside a cross-repo scope.** When the
   user framed the work as "do this across the repos in one session", anything
   discovered inside that scope is `now`, and three tells force it: (a) you are

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -428,8 +428,11 @@ is a mirrored skill LESSON, and it is exactly the path where this repo's
 duplicates come from.
 
 Be honest about which problem this solves here, because the sibling repo's
-argument does not transfer. Measured 2026-08-25: cdk-local has **5 open
-issues**, **none** carrying `Session-fit: next`, and nothing umbrella-shaped.
+argument does not transfer. Measured 2026-08-26: cdk-local has **8 open
+issues**, **three** carrying `Session-fit: next` (go-to-k/cdk-local#560,
+go-to-k/cdk-local#561, go-to-k/cdk-local#564), and one umbrella
+(go-to-k/cdk-local#281, parked until after launch, with its phases filed as
+go-to-k/cdk-local#286 / go-to-k/cdk-local#287 / go-to-k/cdk-local#288).
 There is no unbounded backlog to converge. What there is, is a duplicate
 GENERATOR that §10-c already names in its own text, with two measured pairs out
 of 145 issues filed (41 of them skill-flow / cross-repo-mirror shaped):
@@ -544,6 +547,71 @@ number in the row yourself. The gate exists because this
 section's own rule — "N sites of one root cause is ONE issue and ONE PR, never
 N issues", already written and already correct — did not stop either pair above.
 Registration is not execution.
+
+**Before writing `Session-fit: next`, NAME the command the next session will run
+to verify the fix -- and say that a fresh session will be able to run it.** Of
+the four classification lines this is one of the two that carry no label, and it
+is the one that decays quietly. A deferral is a PREDICTION that a later session
+can finish the work; the prediction is almost never stated, so it is never
+checked, and the classification
+decays into naming the KIND of work ("a fixture / base-image change", "a
+different subsystem"). That describes the MEANS instead of the purpose, and it is
+the failure `.claude/CLAUDE.md` names when it says the four fields exist to make
+a deferral HONEST rather than to make one available -- arriving through the
+reason line rather than through the values. No enumerated trigger list catches
+it either, because the next miss arrives in a shape the list does not contain. So
+name it concretely: not "run the integ" but the fixture, as in
+`/run-integ local-start-api-websocket`; not "add a test" but the assertion that
+goes from red to green, as in `vp test run tests/unit/local/<file>.test.ts`.
+
+The check is GENERATIVE rather than a lookup, which is the point -- it fires on
+conditions nobody enumerated. When naming the command is hard, that difficulty IS
+the finding, and in this repo it is usually one of these:
+
+- **The verifier is bound to THIS host.** 53 of this repo's 58 integ fixtures
+  drive a real Docker daemon, measured 2026-08-26 with
+  `grep -l docker tests/integration/*/verify.sh | wc -l`. So the host's CPU
+  architecture, the platform of the image the fixture resolves, the daemon's
+  version (`probeHostGatewaySupport` in `src/local/docker-version.ts` gates
+  `host-gateway` on Docker >= 20.10) and its BuildKit behaviour are all part of
+  the verifier, and none of them travels with the issue.
+- **The verifier is bound to THIS account.** A `*-from-cfn-stack` fixture's
+  `verify.sh` calls the upstream `cdk deploy`, so it needs the `cdk` CLI on
+  `$PATH` and credentials for an account it may deploy into -- which is why
+  `/run-integ` pre-flights `which cdk` and `aws sts get-caller-identity` for
+  those fixtures.
+- **The verifier does not exist yet**, and writing it is most of the work. This
+  is the one case where `next` is genuinely right, and it is right BECAUSE you
+  could name what is missing.
+- **You cannot name it at all**, which means nobody can confirm the fix later
+  either. That is not a deferral, it is an unbounded one.
+
+Measured here on 2026-08-26. go-to-k/cdk-local#560 was filed
+`Session-fit: next (not this session)` on the reasoning "the fix is a fixture /
+base-image change, on a different axis from the log-redaction lane that surfaced
+it" -- a statement about the work's CATEGORY, which reads as a sound handoff. The
+defect is a Go RIE fault under `linux/amd64` emulation (a SIGSEGV in one
+fixture, a `sync: inconsistent mutex state` panic in the other), and the issue's
+own evidence records `uname -m` = `arm64` on the machine that filed it. So the next
+session's verification is `/run-integ local-start-api` plus
+`/run-integ local-start-api-websocket` ON AN arm64 HOST, and nothing guarantees
+a fresh session has one. What follows is worse than an inconclusive run: a
+fixture declaring no `Architectures` resolves to `x86_64` (the default in
+`src/cli/commands/local-start-api.ts`) and its warm container is launched at
+`--platform linux/amd64` (`architectureToPlatform`, called for a ZIP Lambda from
+`startOne` in `src/local/container-pool.ts`), so on an amd64 host it runs
+natively and never reaches the emulated path that
+`src/local/docker-image-builder.ts` warns about -- a run there can only be
+silent about the fault the issue describes. The misclassification was caught in
+review; nothing in this flow caught it. One sentence of naming would have
+surfaced the host.
+
+**The converse is the honest use of `next`, and it costs one line.** When you CAN
+name the verification and a fresh session will plainly have it -- an existing
+`local-*` fixture needing only Docker, a `vp test run <path>` assertion, an
+ordinary `gh` query -- the deferral is sound. Put that line in the issue body
+beside `Session-fit`, so the next session starts from the check instead of
+re-deriving it.
 
 Never edit in the main checkout (`main-tree-branch-gate.sh` blocks branch creation
 there). Per lane:


### PR DESCRIPTION
## What

`Session-fit: next` is a PREDICTION that a later session can finish the work.
The prediction is never stated, so it is never checked, and the reason line
decays into naming the KIND of work ("a fixture / base-image change", "a
different subsystem") -- the MEANS rather than the purpose. No enumerated list
of triggers can catch that, because the next miss arrives in a shape the list
does not contain.

So this adds a GENERATIVE forcing question instead of another lookup table:
**you may not write `Session-fit: next` until you can name the concrete command
the next session will run to verify the fix, and say a fresh session will be
able to run it.** Not "run the integ" but the fixture; not "add a test" but the
assertion that goes red to green. When naming it is hard, that difficulty IS the
finding -- the verifier is bound to this host, or to this account, or does not
exist yet, or cannot be named at all (which is an unbounded deferral, not a
deferral).

## Where, and why there

- `.claude/skills/work-issues/SKILL.md` -- at the END of section 5's filing
  sequence, which is where this repo actually writes classification lines (the
  `gh issue create` recipe with `Severity` / `Effort` labels sits ~40 lines
  above). It is deliberately NOT a new `### 3-x` subsection: section 3 READS a
  `Session-fit` line off a candidate's body, section 5 WRITES one. Placing it
  after "Registration is not execution." also keeps "This is not a filing
  threshold ... it changes only WHERE" adjacent to the dup-check recipe that
  paragraph is about.
- `.claude/CLAUDE.md` -- a compact form in the four-TODO-fields block. The skill
  alone would not cover it: the wrap-report rule there governs EVERY session,
  and the incident below came from a lane that was not running `/work-issues`.

## The incident (this repo's own)

https://github.com/go-to-k/cdk-local/issues/560 was filed
`Session-fit: next (not this session)` on "the fix is a fixture / base-image
change, on a different axis from the log-redaction lane that surfaced it" -- a
statement about the work's CATEGORY, which reads as a sound handoff. The defect
is a Go RIE fault under `linux/amd64` emulation and the issue's own evidence
records `uname -m` = `arm64` on the filing machine, so the real verification is
`/run-integ local-start-api` plus `/run-integ local-start-api-websocket` ON AN
arm64 HOST -- which nothing guarantees a fresh session has. On an amd64 host the
fixtures run natively and never reach the emulated path at all, so a run there
cannot see the fault. The misclassification was caught in review, not by the
flow.

## Adapted, not transplanted

The lesson was written in cdkd first. Every noun was re-resolved against THIS
repo before shipping, and the following were changed rather than copied:

- Section numbering: cdkd put it at `### 3-b` after its ranking section; this
  repo has no ranking section (its `### 3-a` is the freshness quarantine), so
  the block lands in section 5 as a bolded block, matching how this file already
  carries its other filing-time lessons.
- Examples: this repo's real fixtures and marker (`local-start-api`,
  `local-start-api-websocket`, the single `integ` gate) instead of cdkd's
  `bench-cdk-sample` / `integ-destroy` / `integ-broad`, none of which exist here.
- Attribution: cdkd cites a "classify by purpose, not means" rule from its own
  CLAUDE.md; this repo's `.claude/CLAUDE.md` has no such line, so the text
  anchors to what it DOES say ("the four fields exist to make a deferral HONEST,
  not to make one available").
- Host-boundness examples are cdk-local's: the Docker daemon (53 of 58 integ
  fixtures drive one), image platform, `probeHostGatewaySupport`'s >= 20.10 gate,
  and the `*-from-cfn-stack` account binding -- not AWS regions / bootstrapped
  accounts, which are cdkd's shape.

## Also in this PR

Section 5's backlog measurement said "5 open issues, none carrying
`Session-fit: next`, and nothing umbrella-shaped" (2026-08-25). Re-measured
2026-08-26: 8 open, three carrying `Session-fit: next`, and one umbrella. The
new block's own example is one of those three, so leaving the old line would
have made the section contradict itself.

## Verification (prose-only diff, so the CLAIMS are the artifact)

Per section 8 "Arm 2". Every path, symbol, fixture, hook, skill, command and
number in the new text was resolved against this repo, and every command the
text sends a future agent to run was RUN:

- `grep -l docker tests/integration/*/verify.sh | wc -l` -> 53, of 58 -- the
  pasted number reproduces exactly.
- `probeHostGatewaySupport` / `HOST_GATEWAY_MIN_VERSION` -- `src/local/docker-version.ts:18,89,110`.
- `architectureToPlatform` -- `src/local/docker-image-builder.ts:110`; called for
  a ZIP Lambda from `startOne` (`src/local/container-pool.ts:380`), which
  `src/cli/commands/local-start-api.ts:2180` documents explicitly.
- `x86_64` default -- `src/cli/commands/local-start-api.ts:2900`.
- All 9 `*-from-cfn-stack` fixtures invoke upstream `cdk deploy`; `/run-integ`
  pre-flights `which cdk` + `aws sts get-caller-identity` for them.
- `vp test run <path>` honours the path filter (ran it).
- `uname -m` -> `arm64` and
  `docker image inspect public.ecr.aws/lambda/nodejs:20 --format '{{.Architecture}}/{{.Os}}'`
  -> `amd64/linux` on this machine, reproducing the issue's evidence.
- Quoted fragments of issue 560 are byte-identical to its body.
- `tests/unit/skills/work-issues-skill-refs.test.ts` passes, and a mutation probe
  (rewriting the qualified ref to a bare one) FAILS it on the new block's own
  line -- so the fence discriminates here rather than passing vacuously.
- `vp run check` / `vp run build` / `vp run test` (217 files, 3239 tests) /
  `vp run test:hooks` (53) all green.
- Gate liveness: `git commit --dry-run` from the repo root returned
  `Blocked by branch-gate`, so the PreToolUse gates fire in this session.

No `src/**` or `tests/integration/**` change, so the `integ` and `cdkd-parity`
gates do not apply. Reviewed by an independent read-only agent whose only job was
to resolve every named noun; its one blocking finding (the text claimed
`Session-fit` is the only unlabelled field -- `Estimate` is unlabelled too) and
ten non-blocking findings are all addressed in the current diff.
