### PR TITLE
fix(local): withhold the credential chain's error text from the SigV4 warn, and bound the foreign-id dedup set

### DIFF
--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -916,8 +916,28 @@ Outcomes:
   placeholder principalId keeps identity-based handler authz from trusting a
   forged caller, and the deployed API Gateway still does the real
   verification + IAM evaluation. Pass `--strict-sigv4` to **deny** unverifiable
-  requests instead (fail-closed). The warn fires at most once per foreign
-  access-key-id per server lifecycle.
+  requests instead (fail-closed).
+
+  The warn is deduplicated per foreign access-key-id, best-effort: the server
+  remembers the 256 most recently warned ids, so a client cycling through
+  more than that draws a repeat warning for one it has already seen. The
+  bound is deliberately placed so it can only ever make cdk-local NOISIER --
+  it never goes quiet on an access-key-id it has not warned about yet, since
+  that one may be the federated signer you need told about.
+
+  When the failure is that **no local credentials resolved at all**, the warn
+  names the failure's class and the length of the credential chain's message
+  but not the message itself. The full text is printed at debug level -- run
+  with `--verbose` to see it. The reason for holding it back is that the
+  chain's error text is not cdk-local's to vouch for: the AWS SDK's
+  `credential_process` provider copies Node's `Command failed: <command
+  line>` into the error it raises, and a `credential_process` command line is
+  an ordinary place to keep a passphrase. That text does not reach the log on
+  today's SDK versions, which discard it in favour of a generic message -- so
+  this is a precaution rather than a fix for something you can observe -- but
+  a default-level line that `cdkl studio` also mirrors into the log ring it
+  serves over HTTP is the wrong place to relay an error string cdk-local does
+  not control, and `--verbose` costs you nothing.
 
 #### OAC-fronted Function URLs (auto-relaxed)
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -919,8 +919,9 @@ Outcomes:
   requests instead (fail-closed).
 
   The warn is deduplicated per foreign access-key-id, best-effort: the server
-  remembers the 256 most recently warned ids, so a client cycling through
-  more than that draws a repeat warning for one it has already seen. The
+  remembers the 256 most recently FIRST-warned ids (a repeat hit does not
+  refresh an id's place in the queue), so a client cycling through more than
+  that draws a repeat warning for one it has already seen. The
   bound is deliberately placed so it can only ever make cdk-local NOISIER --
   it never goes quiet on an access-key-id it has not warned about yet, since
   that one may be the federated signer you need told about.
@@ -928,7 +929,7 @@ Outcomes:
   When the failure is that **no local credentials resolved at all**, the warn
   names the failure's class and the length of the credential chain's message
   but not the message itself. The full text is printed at debug level -- run
-  with `--verbose` to see it. The reason for holding it back is that the
+  with `--verbose` (or set `CDKL_LOG_LEVEL=debug`) to see it. The reason for holding it back is that the
   chain's error text is not cdk-local's to vouch for: the AWS SDK's
   `credential_process` provider copies Node's `Command failed: <command
   line>` into the error it raises, and a `credential_process` command line is

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -307,18 +307,74 @@ export async function verifySigV4(
     // cdk-local cannot fully emulate. `--strict-sigv4` flips this to
     // fail-closed. OAC-fronted routes always pass (no client signature
     // exists to verify in production).
-    // NOTE (issue #564): `reason` is the credential CHAIN's own error text,
-    // relayed unbounded into the `warn` lines below. With a
-    // `credential_process` profile the SDK runs the configured command
-    // through `child_process.exec` and rethrows Node's
-    // `Command failed: <command line>\n<stderr>`, so a passphrase on that
-    // command line reaches a default-level log. Issue #555's sweep covered
-    // caller-supplied `Authorization` material and did not reach this,
-    // which points the other way — the developer's own machine config.
-    // Left here so a later sweep finds the pointer rather than re-deriving
-    // it; the fix belongs in #564 with its own judgement about how much of
-    // a credential-loader failure may print.
-    const reason = err instanceof Error ? err.message : String(err);
+    // Issue #564: `reason` used to be the credential CHAIN's own error text,
+    // relayed verbatim into every `warn` spelling below. It is withheld now,
+    // and the chain's message moved to the `debug` line just below.
+    //
+    // Issue #555's criterion was PROVENANCE — material cdk-local resolved
+    // out of a secret or parameter store is redacted, the developer's own
+    // payload is not — and on provenance alone this value stays: it is the
+    // developer's own machine configuration, not something cdk-local went
+    // and fetched. Provenance did not settle #555's own sigv4-verify cases
+    // either, and it does not settle this one. Two further axes decide it,
+    // and both point the other way:
+    //
+    //   LEVEL — these are `warn`, so they print on a plain `cdkl start-api`
+    //   run rather than only under `--verbose`, and `cdkl studio` mirrors a
+    //   serve child's output into a log ring it serves over HTTP. The
+    //   population that sees a `warn` is everyone; the population that sees
+    //   a `debug` line asked for it.
+    //
+    //   RECONSTRUCTION — what can reach this string is not a hint about a
+    //   secret, it is the secret. `@aws-sdk/credential-provider-process`
+    //   builds its failure as `new CredentialsProviderError(error.message)`
+    //   where `error` is the rejection from `promisify(child_process.exec)`
+    //   — Node's `Command failed: <command line>\n<stderr>`. A passphrase
+    //   written on a `credential_process` command line is therefore already
+    //   inside a credential-chain error object. That is unlike the values
+    //   #555 left quoted: an access-key-id is a public identifier, and a
+    //   SigV4 signature is an HMAC that is worthless without the key.
+    //
+    //   MEASURED — and this CORRECTS issue #564's own premise, which said
+    //   the process provider's error propagates verbatim because it carries
+    //   no `tryNextLink`. It carries none, and that is exactly why it does
+    //   NOT propagate: `CredentialsProviderError` defaults `tryNextLink` to
+    //   TRUE, so `internalCreateChain` continues past it, and the node
+    //   chain's last link unconditionally throws the generic `Could not load
+    //   credentials from any providers` with `tryNextLink: false`. Repro on
+    //   the versions this repo resolves (@aws-sdk/credential-provider-node
+    //   3.972.44, credential-provider-process 3.972.43): a profile whose
+    //   `credential_process` exits non-zero, proven to have RUN by a marker
+    //   file it touches, yields exactly that 45-character generic message
+    //   and no command line.
+    //
+    //   So this is defense in depth, not a live disclosure — worth having
+    //   anyway, because all that separates the command line from a
+    //   default-level log line is one defaulted `tryNextLink` inside a
+    //   vendored dependency that deliberately copies the exec message into
+    //   the error it throws. cdk-local neither owns that line nor would
+    //   notice it changing. What actually reaches `reason` today is that
+    //   generic message and a handful of profile-naming chain errors, none
+    //   of them secret; the cost of withholding them is zero, since
+    //   `--verbose` still prints every one in full.
+    //
+    // Two axes of three say withhold, so the `warn` carries an
+    // input-INDEPENDENT discriminator only — `err.name` plus a length, the
+    // shape `ecs-secrets-resolver.ts` already uses for the parse failure it
+    // must not echo. `err.name` is set by the throwing class, never from the
+    // loader's input, which is the property that makes it safe.
+    //
+    // Deliberately NOT done: stripping the `Command failed:` first line and
+    // keeping the rest. That enumerates one known-bad shape and loses the
+    // race — the stderr on the second line is exactly as able to carry a
+    // passphrase prompt or a token, and the next loader to grow its own
+    // format would not be covered at all. Define the safe state positively
+    // instead, which is what "input-independent" is.
+    logger.debug(
+      `AWS_IAM authorizer: the AWS credential chain's own failure message was: ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    const reason = describeCredentialLoadFailure(err);
     const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();
     if (opts.strict && !opts.oacFronted) {
       logger.warn(
@@ -367,7 +423,23 @@ export async function verifySigV4(
     // (AKIDFOREIGN, akidforeign, AkIdFOREIGN) would trigger a fresh
     // warn line per case. Case-insensitive compare → case-insensitive
     // dedup. (PR #484 review MINOR.)
-    const dedupKey = parsed.credentialAccessKeyId.toLowerCase();
+    //
+    // Issue #561: the id is HASHED before it becomes a key, and the set it
+    // goes into is bounded (see {@link rememberWarnedForeignId}). Nothing
+    // validates `credentialAccessKeyId` before it arrives here — it is
+    // whatever occupied the first '/'-separated segment of `Credential=`, so
+    // a caller controls its content AND its length, up to Node's
+    // `http.maxHeaderSize` (16384, read off `require('node:http')` on the
+    // Node 24.15 this repo pins). Storing it raw would make an entry-count
+    // cap a weak bound — cap times sixteen kilobytes — while a fixed 64-hex
+    // digest makes it a real one, and it collides no more often than the raw
+    // value does. Truncating the id instead would be the wrong shape: two
+    // distinct long ids sharing a prefix would collapse onto one key and the
+    // second signer's warning would be SUPPRESSED, which is the one outcome
+    // this dedup must never produce.
+    const dedupKey = createHash('sha256')
+      .update(parsed.credentialAccessKeyId.toLowerCase())
+      .digest('hex');
     const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();
     if (opts.strict && !opts.oacFronted) {
       if (!warned || !warned.has(dedupKey)) {
@@ -386,7 +458,7 @@ export async function verifySigV4(
                 `cdk-local denies it; remove ${optFlag} to warn-and-pass (the default), or sign the ` +
                 `request with the same credentials cdk-local resolves locally.`
         );
-        warned?.add(dedupKey);
+        rememberWarnedForeignId(warned, dedupKey);
       }
       return { allow: false, identityHash: undefined };
     }
@@ -411,7 +483,7 @@ export async function verifySigV4(
               `pass ${optFlag} to deny instead. Do NOT trust ` +
               `event.requestContext.authorizer.principalId in handler code.`
       );
-      warned?.add(dedupKey);
+      rememberWarnedForeignId(warned, dedupKey);
     }
     return {
       allow: true,
@@ -576,6 +648,97 @@ export function redactSignature(signature: string): string {
     return `<withheld: ${signature.length} characters that are not a signature>`;
   }
   return signature;
+}
+
+/**
+ * Describe a credential-chain failure for a default-level log line WITHOUT
+ * relaying the chain's own message (issue #564).
+ *
+ * The message is withheld because of what a credential-chain error CAN
+ * carry: `@aws-sdk/credential-provider-process` copies the rejection of
+ * `promisify(child_process.exec)` — Node's
+ * `Command failed: <command line>\n<stderr>` — into the error it throws, so
+ * a passphrase on a `credential_process` command line is already inside a
+ * chain error object. On the SDK versions this repo resolves today that
+ * object does not actually reach the caller (the chain swallows it and ends
+ * on a generic message), which makes this defense in depth rather than a
+ * live disclosure. The measurement, and the full reasoning for withholding
+ * at `warn` while keeping the text at `debug`, are at the call site in
+ * {@link verifySigV4}.
+ *
+ * What is reported instead is input-INDEPENDENT: `err.name` is set by the
+ * throwing class rather than derived from anything the loader read, which is
+ * the property that makes quoting it safe, and is the same discriminator
+ * `ecs-secrets-resolver.ts` reports for the JSON parse failure it must not
+ * echo. `'unknown'` rather than a guessed class name for a non-`Error`
+ * throw, so the field never names a class the throw was not.
+ *
+ * The LENGTH is reported, unlike in `ecs-secrets-resolver.ts`, and the
+ * difference is deliberate: there the user already knows which secret it is
+ * and can read the value at its source, so a character count would be
+ * disclosure buying nothing. Here the user cannot see the withheld message
+ * at all, and the count is what separates a one-line
+ * `Could not load credentials from any providers` from a multi-hundred-
+ * character `Command failed:` dump — which is what tells them whether their
+ * `credential_process` even ran. It is the same choice
+ * {@link redactAuthorizationSegment} makes when it withholds.
+ */
+export function describeCredentialLoadFailure(err: unknown): string {
+  const kind = err instanceof Error ? err.name : 'unknown';
+  const length = err instanceof Error ? err.message.length : String(err).length;
+  return `${kind}; ${length}-character message withheld, logged at debug level under --verbose`;
+}
+
+/**
+ * How many distinct foreign access-key-ids {@link verifySigV4}'s warn-dedup
+ * set retains (issue #561).
+ *
+ * The legitimate population is tiny — a session sees one federated / Cognito
+ * Identity Pool / cross-account signer, occasionally a handful — so 256
+ * leaves two orders of magnitude of headroom over any real use while holding
+ * the set at 256 entries of exactly 64 hex characters whatever a caller
+ * sends, because {@link verifySigV4} hashes the id before it becomes a key.
+ *
+ * `docs/local-emulation.md` states this number to users ("the 256 most
+ * recently warned ids"); change both together.
+ */
+const FOREIGN_ID_DEDUP_MAX = 256;
+
+/**
+ * Record that the foreign-access-key-id warning has been emitted for
+ * `dedupKey`, evicting oldest-first so the set cannot grow without bound
+ * (issue #561).
+ *
+ * # Why eviction, and not "stop warning past the cap"
+ *
+ * The set's only power is SUPPRESSION — an entry present means the warning
+ * is skipped — so the two candidate policies differ in the DIRECTION they
+ * fail. Evicting an entry can only ever cause a REPEAT warning, which is
+ * precisely the un-deduped behaviour this code had before the dedup existed:
+ * noisier, never quieter. Capping by refusing to warn once the set is full
+ * would instead silence the (cap+1)-th distinct signer, and that signer is
+ * every bit as likely to be the real federated identity the developer needs
+ * told about as it is to be a prober's next value. A warning that never
+ * arrives is a worse failure than a set that grows, so the bound is put
+ * where it cannot suppress anything.
+ *
+ * `Set` iterates in insertion order, so `values().next()` is the oldest
+ * entry and this is FIFO. It is a loop rather than a single `delete` so a
+ * set handed in already over the cap is brought back under it.
+ *
+ * What this does NOT fix: a client looping over DISTINCT ids still draws one
+ * warn line per probe. Distinct ids defeat the dedup whether or not the set
+ * is bounded, and closing that half would need suppression — the direction
+ * ruled out above. The bound here is on memory only.
+ */
+function rememberWarnedForeignId(warned: Set<string> | undefined, dedupKey: string): void {
+  if (!warned) return;
+  while (warned.size >= FOREIGN_ID_DEDUP_MAX) {
+    const oldest = warned.values().next();
+    if (oldest.done === true) break;
+    warned.delete(oldest.value);
+  }
+  warned.add(dedupKey);
 }
 
 /**

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -342,8 +342,15 @@ export async function verifySigV4(
     //   TRUE, so `internalCreateChain` continues past it, and the node
     //   chain's last link unconditionally throws the generic `Could not load
     //   credentials from any providers` with `tryNextLink: false`. Repro on
-    //   the versions this repo resolves (@aws-sdk/credential-provider-node
-    //   3.972.44, credential-provider-process 3.972.43): a profile whose
+    //   the versions this repo RESOLVES -- and note there are TWO
+    //   resolutions of the process provider, so a single version number here
+    //   is wrong whichever one you pick: from `@aws-sdk/client-sts`,
+    //   credential-provider-node 3.972.44 reaches
+    //   credential-provider-process 3.972.39 directly, while
+    //   credential-provider-ini 3.972.43 reaches 3.972.43 -- and INI is what
+    //   actually handles a `credential_process` profile, so 3.972.43 is what
+    //   the repro exercised. The two dist bundles are byte-identical, so
+    //   nothing behavioural turns on the pairing. Repro: a profile whose
     //   `credential_process` exits non-zero, proven to have RUN by a marker
     //   file it touches, yields exactly that 45-character generic message
     //   and no command line.
@@ -358,11 +365,14 @@ export async function verifySigV4(
     //   of them secret; the cost of withholding them is zero, since
     //   `--verbose` still prints every one in full.
     //
-    // Two axes of three say withhold, so the `warn` carries an
-    // input-INDEPENDENT discriminator only — `err.name` plus a length, the
-    // shape `ecs-secrets-resolver.ts` already uses for the parse failure it
-    // must not echo. `err.name` is set by the throwing class, never from the
-    // loader's input, which is the property that makes it safe.
+    // Two axes of three say withhold, so the `warn` carries a clamped class
+    // name plus a length -- the shape `ecs-secrets-resolver.ts` already uses
+    // for the parse failure it must not echo. The class name is made
+    // input-independent by the clamp in
+    // {@link describeCredentialLoadFailure} (it is NOT independent on its
+    // own -- see the note there). The LENGTH is the one input-derived field
+    // that is kept, deliberately, and its cost is weighed in that same
+    // JSDoc.
     //
     // Deliberately NOT done: stripping the `Command failed:` first line and
     // keeping the rest. That enumerates one known-bad shape and loses the
@@ -372,7 +382,7 @@ export async function verifySigV4(
     // instead, which is what "input-independent" is.
     logger.debug(
       `AWS_IAM authorizer: the AWS credential chain's own failure message was: ` +
-        `${err instanceof Error ? err.message : String(err)}`
+        `${stringifyCredentialLoadFailure(err)}`
     );
     const reason = describeCredentialLoadFailure(err);
     const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();
@@ -671,7 +681,9 @@ export function redactSignature(signature: string): string {
  * the property that makes quoting it safe, and is the same discriminator
  * `ecs-secrets-resolver.ts` reports for the JSON parse failure it must not
  * echo. `'unknown'` rather than a guessed class name for a non-`Error`
- * throw, so the field never names a class the throw was not.
+ * throw, so the field never names a class the throw was not -- and the same
+ * `'unknown'` for a `name` that is not a bare identifier, so the guarantee
+ * does not rest on every provider following the convention.
  *
  * The LENGTH is reported, unlike in `ecs-secrets-resolver.ts`, and the
  * difference is deliberate: there the user already knows which secret it is
@@ -682,10 +694,52 @@ export function redactSignature(signature: string): string {
  * character `Command failed:` dump — which is what tells them whether their
  * `credential_process` even ran. It is the same choice
  * {@link redactAuthorizationSegment} makes when it withholds.
+ *
+ * The count is a side channel, and a narrow one: against a KNOWN
+ * `credential_process` template the number is `constant + len(passphrase)`,
+ * so it yields the passphrase's LENGTH. That is accepted rather than
+ * overlooked. It buys the one thing the user cannot otherwise see, the
+ * `Command failed:` dump is not reachable today anyway (see the call site),
+ * and bucketing the number would blur exactly the boilerplate-vs-dump
+ * distinction the field exists for.
  */
+export function stringifyCredentialLoadFailure(err: unknown): string {
+  // `String(err)` is not total: a `Symbol` throw, or an object with a null
+  // prototype, raises `TypeError` on conversion. That throw would escape the
+  // `catch` in {@link verifySigV4} and reject the whole authorizer pass -- a
+  // 500 in place of the warn-and-pass the branch exists to produce. One
+  // helper rather than two expressions, so the length reported in the `warn`
+  // and the text printed at `debug` can never describe different strings.
+  try {
+    return err instanceof Error ? String(err.message) : String(err);
+  } catch {
+    return '[unstringifiable throw]';
+  }
+}
+
 export function describeCredentialLoadFailure(err: unknown): string {
-  const kind = err instanceof Error ? err.name : 'unknown';
-  const length = err instanceof Error ? err.message.length : String(err).length;
+  const rawKind = err instanceof Error ? err.name : 'unknown';
+  // `err.name` comes off the same third-party object whose `message` this
+  // function exists to withhold, and it is NOT always set by the throwing
+  // class: for an AWS service exception it is WIRE-DERIVED. `@aws-sdk/core`
+  // builds it from the `x-amzn-errortype` header / the body's `code` /
+  // `__type`, through `sanitizeErrorCode`, which splits on ',' ':' and '#'
+  // and does nothing else -- no length cap, no newline stripping (read at
+  // `@aws-sdk/core@3.974.13` protocols/index.js:324). Such an exception can
+  // reach this catch, because `credential-provider-ini` calls the STS
+  // `roleAssumer` unwrapped. So a hostile or hijacked credential endpoint
+  // (`AWS_CONTAINER_CREDENTIALS_FULL_URI`, a redirected IMDS) answering with
+  // `x-amzn-errortype: Foo\nWARN: signature verified` could FORGE log lines
+  // into the very `warn` stream -- and into the studio ring served over HTTP
+  // -- that this change exists to keep clean.
+  //
+  // The clamp is therefore not hypothetical hardening: a bare identifier of
+  // at most 64 characters is what every real class name is and what no
+  // injected value can be. Anything else degrades to `unknown`. Note the
+  // wrong fix: `err.name.slice(0, 64)` keeps the newline, so the forgery
+  // survives truncation.
+  const kind = /^[A-Za-z0-9_.-]{1,64}$/.test(rawKind) ? rawKind : 'unknown';
+  const length = stringifyCredentialLoadFailure(err).length;
   return `${kind}; ${length}-character message withheld, logged at debug level under --verbose`;
 }
 
@@ -733,6 +787,17 @@ const FOREIGN_ID_DEDUP_MAX = 256;
  */
 function rememberWarnedForeignId(warned: Set<string> | undefined, dedupKey: string): void {
   if (!warned) return;
+  // Eviction happens before the add, so calling this for a key already
+  // present would drop one UNRELATED entry per repeat. Both of today's call
+  // sites sit inside `if (!warned || !warned.has(dedupKey))`, which is why
+  // that cannot happen now -- this line states the precondition positively
+  // so a third call site cannot quietly break it.
+  //
+  // Note what this is NOT: a `delete` + re-`add` to refresh recency. That
+  // would turn the FIFO into an LRU, and an LRU lets a high-rate prober keep
+  // its own ids resident and push the real federated signer out -- the exact
+  // outcome the policy above says must never happen.
+  if (warned.has(dedupKey)) return;
   while (warned.size >= FOREIGN_ID_DEDUP_MAX) {
     const oldest = warned.values().next();
     if (oldest.done === true) break;

--- a/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
+++ b/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
@@ -5,6 +5,7 @@ import {
   type SigV4VerifyRequest,
   type ResolvedCredentials,
 } from '../../../src/local/sigv4-verify.js';
+import { createHash } from 'node:crypto';
 import { getLogger } from '../../../src/utils/logger.js';
 import { setEmbedConfig, resetEmbedConfig } from '../../../src/local/embed-config.js';
 
@@ -69,6 +70,12 @@ const CHAIN_MESSAGE_LENGTH = 125;
 
 class CredentialsProviderError extends Error {
   override name = 'CredentialsProviderError';
+}
+
+function namedError(name: string, message: string): Error {
+  const e = new Error(message);
+  Object.defineProperty(e, 'name', { value: name });
+  return e;
 }
 
 const loadThrowsChainError = async (): Promise<ResolvedCredentials> => {
@@ -200,6 +207,77 @@ describe('#564 — the credential chain error text never reaches a warn', () => 
     );
   });
 
+  it('does not print at default level -- the debug route is really gated', async () => {
+    // The whole fix rests on `debug` reaching a smaller population than
+    // `warn`. Assert it end-to-end through the REAL logger at its default
+    // level rather than trusting the level table: spy on the console sinks
+    // `ConsoleLogger.emit` writes to, and require that nothing the process
+    // actually printed carries the chain message.
+    const logger = getLogger();
+    const before = logger.getLevel();
+    logger.setLevel('info');
+    const sinks = (['log', 'info', 'warn', 'error', 'debug'] as const).map((m) =>
+      vi.spyOn(console, m).mockImplementation(() => {})
+    );
+    try {
+      await verifySigV4(makeRequest('AKIAFOREIGN'), loadThrowsChainError, { now: () => NOW });
+      const printed = sinks
+        .flatMap((sp) => sp.mock.calls.map((c) => String(c[0])))
+        .join('\n');
+      // It DID print something -- otherwise this passes for the wrong reason.
+      expect(printed).toContain('could not resolve local AWS credentials');
+      expect(printed).not.toContain(CHAIN_MESSAGE);
+      expect(printed).not.toContain(PASSPHRASE);
+    } finally {
+      for (const sp of sinks) sp.mockRestore();
+      logger.setLevel(before);
+    }
+  });
+
+  it('clamps a name that is not a bare identifier, rather than quoting it', () => {
+    // `err.name` is third-party data from the same object whose `message` is
+    // withheld; a provider that derived it from input would otherwise
+    // reopen #564 through the field left quoted.
+    const hostile = new Error('short');
+    Object.defineProperty(hostile, 'name', {
+      value: `Command failed: /opt/bin/get-creds --vault-passphrase ${PASSPHRASE}`,
+    });
+    const out = describeCredentialLoadFailure(hostile);
+    expect(out).not.toContain(PASSPHRASE);
+    expect(out).toBe('unknown; 5-character message withheld, logged at debug level under --verbose');
+
+    // A 64-character bare identifier is still quoted; 65 is not.
+    expect(describeCredentialLoadFailure(namedError('A'.repeat(64), 'x'))).toContain(
+      `${'A'.repeat(64)}; 1-character`
+    );
+    expect(describeCredentialLoadFailure(namedError('A'.repeat(65), 'x'))).toContain(
+      'unknown; 1-character'
+    );
+    // An ordinary class name is unaffected.
+    expect(describeCredentialLoadFailure(namedError('CredentialsProviderError', 'x'))).toContain(
+      'CredentialsProviderError; 1-character'
+    );
+  });
+
+  it('survives a throw that cannot be stringified, instead of turning it into a 500', async () => {
+    // `String(Object.create(null))` raises TypeError. Before the shared
+    // helper, that throw escaped this catch and rejected the whole
+    // authorizer pass -- a 500 in place of the warn-and-pass the branch
+    // exists to produce.
+    const warn = spy('warn');
+    const result = await verifySigV4(
+      makeRequest('AKIAFOREIGN'),
+      async () => {
+        throw Object.create(null);
+      },
+      { now: () => NOW }
+    );
+    expect(result.allow).toBe(true);
+    expect(result.principalId).toBe('unverified-no-creds');
+    expect(warn.calls()).toContain('(unknown; 23-character message withheld,');
+    warn.restore();
+  });
+
   it("reports 'unknown' for a non-Error throw rather than guessing a class", () => {
     expect(describeCredentialLoadFailure('plain string throw')).toBe(
       'unknown; 18-character message withheld, logged at debug level under --verbose'
@@ -255,12 +333,22 @@ describe('#561 — the foreign-access-key-id warn-dedup set is bounded', () => {
     ['warn-and-pass site', {}],
     ['strict deny site', { strict: true }],
   ] as Array<[string, { strict?: boolean }]>) {
-    it(`caps the set at ${CAP} entries from the ${label}`, async () => {
+    it(`caps the set at ${CAP} entries from the ${label}, without going quiet`, async () => {
       const warned = new Set<string>();
-      for (let i = 0; i < CAP + 44; i++) {
-        await warnFor(`AKIAFOREIGN${i}`, warned, opts);
+      const total = CAP + 44;
+      let warnCount = 0;
+      for (let i = 0; i < total; i++) {
+        if ((await warnFor(`AKIAFOREIGN${i}`, warned, opts)) !== '') warnCount++;
       }
       expect(warned.size).toBe(CAP);
+      // Asserting the SIZE alone does not fence the policy this bound was
+      // chosen for. Writing `&& warned.size < CAP` into this site's
+      // `!warned.has(dedupKey)` guard -- i.e. going quiet once full instead
+      // of evicting -- also lands the size on exactly CAP, so a size-only
+      // test passes on it. A mutation probe of that variant on the
+      // strict-deny site was GREEN against the size-only version of this
+      // test. Every id here is distinct, so every one must warn.
+      expect(warnCount).toBe(total);
     });
   }
 
@@ -284,7 +372,13 @@ describe('#561 — the foreign-access-key-id warn-dedup set is bounded', () => {
     for (const entry of warned) {
       expect(entry).toMatch(/^[0-9a-f]{64}$/);
     }
-    expect([...warned].join('')).not.toContain('AAAA');
+    // Lowercased, because the id is lowercased before hashing -- an
+    // uppercase needle here could never appear even if the raw id WERE
+    // stored, which would make this assertion vacuous.
+    expect([...warned].join('')).not.toContain('aaaaaaaa');
+    // Pin the digest identity, so "it is 64 hex characters" cannot be
+    // satisfied by some other 64-hex derivation.
+    expect(warned.has(createHash('sha256').update('akiaforeign').digest('hex'))).toBe(true);
   });
 
   it('evicts oldest-first, so eviction repeats a warning and never suppresses one', async () => {

--- a/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
+++ b/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+import {
+  verifySigV4,
+  describeCredentialLoadFailure,
+  type SigV4VerifyRequest,
+  type ResolvedCredentials,
+} from '../../../src/local/sigv4-verify.js';
+import { getLogger } from '../../../src/utils/logger.js';
+import { setEmbedConfig, resetEmbedConfig } from '../../../src/local/embed-config.js';
+
+/**
+ * Issue #564 — the credential chain's own error text must not reach a `warn`.
+ * Issue #561 — the foreign-access-key-id warn-dedup set must be bounded.
+ *
+ * Both live in `verifySigV4`, and both are asserted through `verifySigV4`
+ * rather than against the helpers alone: the helpers being correct says
+ * nothing about whether every message branch actually routes through them,
+ * and the credential-load failure has FIVE warn spellings.
+ */
+
+const NOW = new Date('2026-01-01T00:00:00Z');
+
+function makeRequest(accessKeyId: string): SigV4VerifyRequest {
+  const credential = `${accessKeyId}/20260101/ap-northeast-1/cloudfront/aws4_request`;
+  return {
+    method: 'POST',
+    rawUrl: '/',
+    headers: {
+      host: '127.0.0.1:65483',
+      'x-amz-date': '20260101T000000Z',
+      authorization:
+        `AWS4-HMAC-SHA256 Credential=${credential}, ` +
+        `SignedHeaders=host;x-amz-date, Signature=abcdef0123456789`,
+    },
+    body: Buffer.alloc(0),
+  };
+}
+
+const LOCAL_CREDS: ResolvedCredentials = {
+  accessKeyId: 'AKIALOCALEXAMPLE',
+  secretAccessKey: 'secret',
+};
+const loadLocal = async (): Promise<ResolvedCredentials> => LOCAL_CREDS;
+
+/**
+ * The shape this test exists for. `@aws-sdk/credential-provider-process`
+ * copies the rejection of `promisify(child_process.exec)` —
+ * `Command failed: <command line>\n<stderr>` — into the error it throws, and
+ * BOTH of those lines can carry a passphrase, which is why the fix withholds
+ * the whole message rather than stripping the first one.
+ *
+ * The fixture builds that error DIRECTLY rather than through the real chain,
+ * and deliberately so: measured against the SDK versions this repo resolves,
+ * the node provider chain swallows the process provider's error and ends on
+ * a generic message, so a chain-driven fixture would carry no secret and
+ * could not discriminate the fix from its absence. What is under test is the
+ * policy — an uncontrolled third-party error string must not reach a
+ * default-level log line — so the fixture supplies the worst string that
+ * policy has to hold for. See the call site in `sigv4-verify.ts` for the
+ * measurement and for why the guard is kept anyway.
+ */
+const PASSPHRASE = 'hunter2-do-not-log';
+const CHAIN_MESSAGE =
+  `Command failed: /opt/bin/get-creds --vault-passphrase ${PASSPHRASE}\n` +
+  `  vault: unlocked with passphrase ${PASSPHRASE}`;
+
+/** Measured, not assumed: see the length assertions below. */
+const CHAIN_MESSAGE_LENGTH = 125;
+
+class CredentialsProviderError extends Error {
+  override name = 'CredentialsProviderError';
+}
+
+const loadThrowsChainError = async (): Promise<ResolvedCredentials> => {
+  throw new CredentialsProviderError(CHAIN_MESSAGE);
+};
+
+function spy(level: 'warn' | 'debug'): { calls: () => string; restore: () => void } {
+  const s = vi.spyOn(getLogger(), level).mockImplementation(() => {});
+  return {
+    calls: () => s.mock.calls.map((c) => String(c[0])).join('\n'),
+    restore: () => s.mockRestore(),
+  };
+}
+
+describe('#564 — the credential chain error text never reaches a warn', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetEmbedConfig();
+  });
+
+  // The five warn spellings the no-creds branch can take. Each is listed
+  // explicitly rather than derived from the source: a branch DELETED from
+  // the implementation must still be a case here that then fails, which a
+  // table generated off the implementation could never notice.
+  const branches: Array<{
+    name: string;
+    strictByDefault: boolean;
+    opts: { strict?: boolean; oacFronted?: boolean };
+    expectAllow: boolean;
+    /** A literal unique to THIS spelling, proving the fixture reached it. */
+    reached: string;
+  }> = [
+    {
+      name: 'strict deny, cdk-local opt-IN polarity',
+      strictByDefault: false,
+      opts: { strict: true },
+      expectAllow: false,
+      reached: '--strict-sigv4 is set, so cdk-local denies unverifiable IAM requests',
+    },
+    {
+      name: 'strict deny, host opt-OUT polarity',
+      strictByDefault: true,
+      opts: { strict: true },
+      expectAllow: false,
+      reached: 'cdk-local denies unverifiable IAM requests by default',
+    },
+    {
+      name: 'warn-and-pass, cdk-local opt-IN polarity',
+      strictByDefault: false,
+      opts: {},
+      expectAllow: true,
+      reached: "cdk-local's default for unverifiable IAM requests",
+    },
+    {
+      name: 'warn-and-pass, host opt-OUT polarity',
+      strictByDefault: true,
+      opts: {},
+      expectAllow: true,
+      reached: '--allow-unverified-sigv4 is set; passing through',
+    },
+    {
+      name: 'warn-and-pass, CloudFront OAC wording',
+      strictByDefault: false,
+      opts: { strict: true, oacFronted: true },
+      expectAllow: true,
+      reached: 'Function URL is fronted by CloudFront OAC',
+    },
+  ];
+
+  for (const branch of branches) {
+    it(`withholds the chain message in the ${branch.name} spelling`, async () => {
+      if (branch.strictByDefault) {
+        setEmbedConfig({ sigV4StrictByDefault: true, sigV4OptFlag: '--allow-unverified-sigv4' });
+      }
+      const warn = spy('warn');
+      const result = await verifySigV4(makeRequest('AKIAFOREIGN'), loadThrowsChainError, {
+        ...branch.opts,
+        now: () => NOW,
+      });
+      expect(result.allow).toBe(branch.expectAllow);
+      const warns = warn.calls();
+
+      // The branch really was the one intended — otherwise a fixture that
+      // silently took a different path would "pass" while fencing nothing.
+      expect(warns).toContain(branch.reached);
+
+      // The secret, and the command line carrying it, are absent.
+      expect(warns).not.toContain(PASSPHRASE);
+      expect(warns).not.toContain('Command failed');
+      expect(warns).not.toContain('/opt/bin/get-creds');
+
+      // And the discriminator IS present, anchored on the full literal:
+      // a bare '125-character message withheld' would also be a substring
+      // of '1125-character message withheld', so the '; ' delimiter and the
+      // class name are part of the needle.
+      expect(warns).toContain(
+        `(CredentialsProviderError; ${CHAIN_MESSAGE_LENGTH}-character message withheld, ` +
+          `logged at debug level under --verbose)`
+      );
+      warn.restore();
+    });
+  }
+
+  it('routes the full chain message to debug, which --verbose is what enables', async () => {
+    const debug = spy('debug');
+    const warn = spy('warn');
+    await verifySigV4(makeRequest('AKIAFOREIGN'), loadThrowsChainError, { now: () => NOW });
+    // The actionable detail is not destroyed, only moved to the population
+    // that asked for it (`local-start-api.ts` maps `--verbose` to
+    // `logger.setLevel('debug')`).
+    expect(debug.calls()).toContain(CHAIN_MESSAGE);
+    expect(debug.calls()).toContain(PASSPHRASE);
+    expect(warn.calls()).not.toContain(PASSPHRASE);
+    debug.restore();
+    warn.restore();
+  });
+
+  it('measures the length it reports, and names the throwing class', () => {
+    // A hard-coded pair, so the assertion cannot drift with the fixture.
+    expect(describeCredentialLoadFailure(new CredentialsProviderError('abcdefghij0123456789'))).toBe(
+      'CredentialsProviderError; 20-character message withheld, logged at debug level under --verbose'
+    );
+    // The fixture's own measured length, cross-checked against the constant
+    // the branch cases assert with.
+    expect(CHAIN_MESSAGE.length).toBe(CHAIN_MESSAGE_LENGTH);
+    expect(describeCredentialLoadFailure(new CredentialsProviderError(CHAIN_MESSAGE))).toBe(
+      `CredentialsProviderError; ${CHAIN_MESSAGE_LENGTH}-character message withheld, ` +
+        `logged at debug level under --verbose`
+    );
+  });
+
+  it("reports 'unknown' for a non-Error throw rather than guessing a class", () => {
+    expect(describeCredentialLoadFailure('plain string throw')).toBe(
+      'unknown; 18-character message withheld, logged at debug level under --verbose'
+    );
+    expect('plain string throw'.length).toBe(18);
+  });
+
+  it('withholds a non-Error throw at warn too', async () => {
+    const warn = spy('warn');
+    await verifySigV4(
+      makeRequest('AKIAFOREIGN'),
+      async () => {
+        throw `boom ${PASSPHRASE}`;
+      },
+      { now: () => NOW }
+    );
+    const warns = warn.calls();
+    expect(warns).not.toContain(PASSPHRASE);
+    expect(warns).toContain('(unknown; 23-character message withheld,');
+    warn.restore();
+  });
+});
+
+describe('#561 — the foreign-access-key-id warn-dedup set is bounded', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetEmbedConfig();
+  });
+
+  /** Matches FOREIGN_ID_DEDUP_MAX in the implementation. */
+  const CAP = 256;
+
+  async function warnFor(
+    id: string,
+    warned: Set<string>,
+    opts: { strict?: boolean } = {}
+  ): Promise<string> {
+    const warn = spy('warn');
+    await verifySigV4(makeRequest(id), loadLocal, {
+      warnedForeignIds: warned,
+      now: () => NOW,
+      ...opts,
+    });
+    const out = warn.calls();
+    warn.restore();
+    return out;
+  }
+
+  // Both `rememberWarnedForeignId` call sites are exercised separately. They
+  // are textually identical, so a probe of only one answers "is EITHER site
+  // bounded", not "is EACH".
+  for (const [label, opts] of [
+    ['warn-and-pass site', {}],
+    ['strict deny site', { strict: true }],
+  ] as Array<[string, { strict?: boolean }]>) {
+    it(`caps the set at ${CAP} entries from the ${label}`, async () => {
+      const warned = new Set<string>();
+      for (let i = 0; i < CAP + 44; i++) {
+        await warnFor(`AKIAFOREIGN${i}`, warned, opts);
+      }
+      expect(warned.size).toBe(CAP);
+    });
+  }
+
+  it('still deduplicates a repeated id, and still ignores its case', async () => {
+    const warned = new Set<string>();
+    expect(await warnFor('AKIAFOREIGN', warned)).toContain('AKIAFOREIGN');
+    expect(await warnFor('AKIAFOREIGN', warned)).toBe('');
+    expect(await warnFor('akiaforeign', warned)).toBe('');
+    expect(warned.size).toBe(1);
+  });
+
+  it('stores a fixed-size digest, never the caller-supplied id', async () => {
+    // The id is unvalidated caller text of caller-chosen length, so an
+    // entry-count cap alone would not bound the memory. Every entry is a
+    // 64-character sha256 hex digest whatever arrives.
+    const warned = new Set<string>();
+    const huge = 'A'.repeat(4000);
+    await warnFor(huge, warned);
+    await warnFor('AKIAFOREIGN', warned);
+    expect(warned.size).toBe(2);
+    for (const entry of warned) {
+      expect(entry).toMatch(/^[0-9a-f]{64}$/);
+    }
+    expect([...warned].join('')).not.toContain('AAAA');
+  });
+
+  it('evicts oldest-first, so eviction repeats a warning and never suppresses one', async () => {
+    // The safety property of the chosen policy: the bound can only ever make
+    // the code NOISIER (an evicted id warns a second time), never quieter.
+    // A "stop warning once full" cap would fail the other way, silencing the
+    // (cap+1)-th distinct signer — which may be the real federated identity.
+    const warned = new Set<string>();
+    await warnFor('AKIAFIRST', warned);
+    const firstDigest = [...warned][0];
+
+    // Fill past the cap so the very first id is evicted.
+    for (let i = 0; i < CAP; i++) {
+      await warnFor(`AKIAFILLER${i}`, warned);
+    }
+    expect(warned.has(firstDigest as string)).toBe(false);
+
+    // The evicted id warns AGAIN — the un-deduped default, not silence.
+    expect(await warnFor('AKIAFIRST', warned)).toContain('AKIAFIRST');
+
+    // And a brand-new id past the cap is still warned about.
+    expect(await warnFor('AKIANEVERSEEN', warned)).toContain('AKIANEVERSEEN');
+    expect(warned.size).toBe(CAP);
+  });
+
+  it('brings an over-cap set handed in from outside back under the cap', async () => {
+    const warned = new Set<string>(Array.from({ length: CAP + 10 }, (_, i) => `preexisting-${i}`));
+    await warnFor('AKIAFOREIGN', warned);
+    expect(warned.size).toBe(CAP);
+  });
+});


### PR DESCRIPTION
## Summary

Two issues in `src/local/sigv4-verify.ts`, taken in one lane because they live in the same function.

### Closes #564 -- the credential chain's error text is no longer relayed at `warn`

`verifySigV4`'s credential-load-failure branch interpolated the AWS credential chain's own `err.message` into all five of its `warn` spellings.

Issue 555's criterion was PROVENANCE -- library-resolved secret material is redacted, the developer's own payload is not -- and on provenance alone this value stays, since it is the developer's own machine configuration. Provenance did not settle issue 555's own `sigv4-verify` cases either. Two further axes decide it:

- **LEVEL.** These are `warn`, so they print on a plain `cdkl start-api` run rather than only under `--verbose`, and `cdkl studio` mirrors a serve child's output into a log ring it serves over HTTP. The population that sees a `warn` is everyone.
- **RECONSTRUCTION.** `@aws-sdk/credential-provider-process` copies Node's `Command failed: <command line>\n<stderr>` into the error it throws, so a `credential_process` passphrase is already inside a chain error object -- unlike the values issue 555 left quoted (an access-key-id is a public identifier; a signature is an HMAC worthless without the key).

Two axes of three say withhold. The `warn` now carries a clamped class name plus a length; the full message moves to `debug`, which `--verbose` (or `CDKL_LOG_LEVEL=debug`) still prints in full.

The `Command failed:` first line is deliberately NOT stripped-and-kept: the stderr on the second line carries a passphrase prompt just as readily, so that enumerates one bad shape instead of defining the safe one.

**This corrects the issue's own premise, measured while fixing it.** The issue says the process provider's error propagates verbatim "because it carries no `tryNextLink`". It carries none, and that is exactly why it does NOT propagate: `CredentialsProviderError` defaults `tryNextLink` to TRUE, so `internalCreateChain` continues past it, and the node chain's last link unconditionally throws the generic `Could not load credentials from any providers` with `tryNextLink: false`. A repro whose `credential_process` was proven to have RUN by a marker file it touches yields that 45-character generic message and no command line. So this is **defense in depth, not a live disclosure** -- corrected Severity: low. It is kept because all that separates the command line from a default-level log line is one defaulted `tryNextLink` in a vendored dependency, and because `--verbose` makes the cost zero. Posted to the issue as a comment.

### Closes #561 -- the foreign-access-key-id dedup set is bounded

The `Set<string>` only ever grew, keyed on unvalidated caller text of caller-chosen length (whatever occupied the first `/`-separated segment of `Credential=`, up to `http.maxHeaderSize`, measured at 16384 on the pinned Node 24.15).

- Entries are now sha256 hex digests, so an entry-count cap is a real memory bound rather than `cap x 16 KB`. Truncating the id instead would be wrong: two long ids sharing a prefix would collapse onto one key and the second signer's warning would be **suppressed**.
- The set evicts **oldest-first at 256**.

**Why eviction and not "stop warning once full".** The set's only power is suppression, so the two policies differ in the direction they fail. Evicting can only ever cause a REPEAT warning -- the un-deduped behaviour this code had before the dedup existed. Going quiet when full would instead silence the 257th distinct signer, who is as likely to be the real federated identity the developer needs told about as a prober's next value. The bound is put where it cannot suppress anything.

Not fixed, and stated so it is not mistaken for an oversight: a client looping over DISTINCT ids still draws one warn per probe. Distinct ids defeat the dedup whether or not the set is bounded, and closing that half needs suppression -- the direction ruled out above. The bound here is on memory only.

## Review round

Three reviewers (code / security / test adequacy) ran against the diff. Two findings were load-bearing:

1. **`err.name` is NOT input-independent**, which the first pass asserted in two comments and rested the design on. For an AWS service exception it is WIRE-DERIVED: `@aws-sdk/core@3.974.13` builds it from `x-amzn-errortype` / the body `code` / `__type` through `sanitizeErrorCode` (`protocols/index.js:324`), which splits on `,` `:` `#` and does nothing else -- no length cap, no newline stripping -- and `credential-provider-ini` calls the STS `roleAssumer` unwrapped, so such an exception reaches this catch. A hijacked credential endpoint (`AWS_CONTAINER_CREDENTIALS_FULL_URI`, a redirected IMDS) answering `x-amzn-errortype: Foo\nWARN: signature verified` could FORGE lines into the very warn stream and studio ring this change exists to keep clean. Now clamped to a bare identifier of at most 64 characters. `slice(0, 64)` is the wrong fix -- it keeps the newline.

2. **The cap tests asserted set SIZE only, which does not fence the policy the bound was chosen for.** Writing `&& warned.size < CAP` into a call site's guard -- going quiet when full instead of evicting -- also lands the size on exactly CAP. A mutation probe of that variant on the strict-deny site was **GREEN against the first version of the tests**. The tests now assert the warn COUNT, and probes of the variant at each site independently go RED.

Also from the round: `String(err)` is not total (a `Symbol` throw or a null-prototype object raises `TypeError`, which escaped the catch and turned a warn-and-pass into a 500), the helper's evict-before-membership precondition is now stated positively, and several claims were corrected -- see the second commit.

## Test plan

- `vp run verify` -- 218 files / 3257 tests, typecheck + lint + format + build all green.
- 18 new cases in `tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts`. Each of the five `warn` spellings is asserted separately with a literal unique to that spelling, so a fixture that silently took another branch cannot pass.
- **Every assertion mutation-probed, and each occurrence probed separately.** 16 probes, 15 RED. Both dedup call sites were probed independently -- a whole-symbol probe answers "is ANY of this fenced", not "is EACH", and that is precisely how the suppress-past-cap variant was found unfenced at one of the two sites.
- The one GREEN probe is disclosed rather than papered over: removing the `if (warned.has(dedupKey)) return;` precondition from `rememberWarnedForeignId` changes nothing, because both call sites already pre-check. It is unreachable-by-construction defensive code, and the guaranteeing invariant (the `!warned.has(dedupKey)` guard directly above each of the two call sites) runs BEFORE it.
- **Integ**: `local-start-api` re-run against the final code, exit 0, 0 orphan containers / networks. The fixture exercises the AWS_IAM foreign-signature, `--strict-sigv4` deny, and OAC pass-through paths.
- **Live-test of the changed behaviour**, against the real built `dist/cli.js` and a profile whose `credential_process` fails:
  - default run: `... could not resolve local AWS credentials (CredentialsProviderError; 45-character message withheld, logged at debug level under --verbose) ...`, with 0 occurrences of the passphrase and 0 of `Command failed` anywhere in the log.
  - `--verbose` run: the debug line carries the full message, confirming the detail is moved rather than destroyed.
  - dedup: the same id sent 3 times (2 exact + 1 case-variant) produced exactly 1 warn; a different id produced a 2nd.

## Won't-do (decided and recorded)

- **The reported LENGTH is a narrow side channel** -- against a known `credential_process` template the count is `constant + len(passphrase)`. Accepted rather than overlooked: it buys the one thing the user cannot otherwise see, the `Command failed:` dump is not reachable today anyway, and bucketing the number would blur exactly the boilerplate-vs-dump distinction the field exists for. Recorded in `describeCredentialLoadFailure`'s JSDoc.

## Follow-ups filed

- Follow-up (#570) -- six other AWS SDK error relays at `warn` share the policy this PR sets, in four CLI command files. Deliberately not folded in: each needs its own call on how much of an STS error is actionable, and bundling them would make this PR's one-root-cause claim false -- the same reason issue 564 was split out of issue 555.
- Follow-up (#571) -- a retrospective finding: a piped `markgate verify` reports the PIPE's exit code, so a STALE gate reads as an apparent pass. Hit during this session on the `integ` gate, where it would have meant opening a PR whose Docker path had not been exercised against the final code. The prose warning for this already exists in `/verify-pr` step 1 but is scoped to `vp run`; proposal is to make it mechanical.
