### PR TITLE
chore(work-issues): make the next-to-now promotion a query, and warn on Stop when a lane is still unmerged

### DIFF
--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -372,14 +372,18 @@ PYEOF
 # `-lt 1` arm still catches an empty parse.
 bash_count=$(printf '%s\n' "$bash_hooks" | grep -c '\.sh$' || true)
 any_count=$(printf '%s\n' "$any_hooks" | grep -c '\.sh$' || true)
-raw_count=$(grep -o '[A-Za-z0-9_-]*\.sh' "$SETTINGS" | sort -u | grep -c . || true)
+# Scoped to the `hooks` block, not the whole file: `settings.json` also carries
+# a `permissions.allow` array whose entries are `Bash(...)` patterns, and one of
+# those naming a `.sh` reds this check with nothing wrong with the parse.
+raw_count=$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])).get("hooks", {})))' "$SETTINGS" |
+  grep -o '[A-Za-z0-9_-]*\.sh' | sort -u | grep -c . || true)
 
 if [ "${bash_count:-0}" -lt 1 ]; then
   fail=$((fail + 1))
   printf 'FAIL settings parse found no Bash hooks at all -- the fence is blind\n'
 elif [ "${any_count:-0}" -ne "${raw_count:-0}" ]; then
   fail=$((fail + 1))
-  printf 'FAIL settings parse found %s hook scripts but a raw scan of the file found %s -- the parse is losing entries\n' \
+  printf 'FAIL settings parse found %s hook scripts, a raw scan of the hooks block found %s -- the two disagree, so one of them is losing entries\n' \
     "$any_count" "$raw_count"
 else
   pass=$((pass + 1))
@@ -397,9 +401,29 @@ for gate in "$HOOK_DIR"/*.sh; do
     continue
   fi
 
+  # The exemption is not unconditional, and this is the SECOND direction of the
+  # same invariant. Above: a hook wired to Bash must source the matcher. Here: a
+  # hook that SOURCES the matcher must be wired to Bash -- sourcing it is
+  # evidence the hook parses commands, so being on a non-Bash matcher means it
+  # never receives one and is INERT, the exact class this file exists for.
+  #
+  # Without this arm the Bash population had no bound at all once the old
+  # literal `-lt 10` floor was replaced (the cross-check above compares the
+  # ANY-event parse, not this one). Measured by a review round: moving 22 of the
+  # 33 entries into a second `PreToolUse` group with `matcher: "Edit|Write"` --
+  # the routine "new group, wrong matcher" slip -- silently exempted eleven live
+  # gates including `branch-gate.sh` and left the suite at 218/0. A count-based
+  # bound would also have been brittle, since a legitimate Edit-only hook is a
+  # normal thing to add; that hook simply does not source the matcher, so this
+  # arm passes it.
   if ! printf '%s\n' "$bash_hooks" | grep -qxF -- "$base"; then
-    pass=$((pass + 1))
-    printf 'OK   %s receives no Bash command, so it needs no matcher\n' "$base"
+    if grep -q '_command-match.sh' "$gate"; then
+      fail=$((fail + 1))
+      printf 'FAIL %s sources the command matcher but is not registered under a Bash matcher -- it parses commands it never receives\n' "$base"
+    else
+      pass=$((pass + 1))
+      printf 'OK   %s receives no Bash command and does not parse one\n' "$base"
+    fi
     continue
   fi
 

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -303,50 +303,101 @@ SETTINGS="$HOOK_DIR/../settings.json"
 # every hook wired to anything at all.
 bash_hooks=$(python3 - "$SETTINGS" <<'PYEOF'
 import json, sys, os
+
+# A group receives Bash commands when it is a TOOL event AND its matcher either
+# names Bash or matches everything. The first revision asked only whether the
+# string 'Bash' appears in the matcher, which handed a free pass to exactly the
+# shape that receives the MOST -- a `PreToolUse` group with the matcher omitted,
+# empty, `*` or `.*`, which fires on every tool. Measured: registering a
+# non-sourcing hook under `matcher: '*'` left this suite at 229/0. It is also
+# the shape this repo just added (the `Stop` group carries no matcher), so the
+# next gate copied from it would have dodged the fence silently.
+TOOL_EVENTS = ('PreToolUse', 'PostToolUse')
+
+def bashy(m):
+    return m is None or m.strip() in ('', '*', '.*') or 'Bash' in m
+
+def name(h):
+    parts = (h.get('command') or '').split()
+    for tok in reversed(parts):
+        if tok.endswith('.sh'):
+            return os.path.basename(tok)
+    return os.path.basename(parts[0]) if parts else ''
+
 s = json.load(open(sys.argv[1]))
 out = set()
 for event, groups in s.get('hooks', {}).items():
+    if event not in TOOL_EVENTS:
+        continue
     for g in groups:
-        if 'Bash' not in (g.get('matcher') or ''):
+        if not bashy(g.get('matcher')):
             continue
         for h in g.get('hooks', []):
-            out.add(os.path.basename(h.get('command', '').split()[0]))
+            n = name(h)
+            if n:
+                out.add(n)
 print('\n'.join(sorted(out)))
 PYEOF
 )
 any_hooks=$(python3 - "$SETTINGS" <<'PYEOF'
 import json, sys, os
+
+def name(h):
+    parts = (h.get('command') or '').split()
+    for tok in reversed(parts):
+        if tok.endswith('.sh'):
+            return os.path.basename(tok)
+    return os.path.basename(parts[0]) if parts else ''
+
 s = json.load(open(sys.argv[1]))
 out = set()
 for event, groups in s.get('hooks', {}).items():
     for g in groups:
         for h in g.get('hooks', []):
-            out.add(os.path.basename(h.get('command', '').split()[0]))
+            n = name(h)
+            if n:
+                out.add(n)
 print('\n'.join(sorted(out)))
 PYEOF
 )
 
 # A parser floor: "found nothing" must not read as "everything is fine".
+#
+# The floor has to be INDEPENDENT of the parse it is checking. A first attempt
+# derived it as `dir_count - non_bash`, where `non_bash` was itself "not in
+# $bash_hooks" -- so the bound equalled `bash_count` by construction and the
+# check could not fail for any input. The bound now comes from a SECOND method
+# over the same file: a raw grep for distinct hook script names. If the python
+# silently loses entries, the two disagree; if the grep is what breaks, the
+# `-lt 1` arm still catches an empty parse.
 bash_count=$(printf '%s\n' "$bash_hooks" | grep -c '\.sh$' || true)
-if [ "${bash_count:-0}" -lt 10 ]; then
+any_count=$(printf '%s\n' "$any_hooks" | grep -c '\.sh$' || true)
+raw_count=$(grep -o '[A-Za-z0-9_-]*\.sh' "$SETTINGS" | sort -u | grep -c . || true)
+
+if [ "${bash_count:-0}" -lt 1 ]; then
   fail=$((fail + 1))
-  printf 'FAIL settings parse found only %s Bash hooks -- the fence is blind\n' "$bash_count"
+  printf 'FAIL settings parse found no Bash hooks at all -- the fence is blind\n'
+elif [ "${any_count:-0}" -ne "${raw_count:-0}" ]; then
+  fail=$((fail + 1))
+  printf 'FAIL settings parse found %s hook scripts but a raw scan of the file found %s -- the parse is losing entries\n' \
+    "$any_count" "$raw_count"
 else
   pass=$((pass + 1))
-  printf 'OK   settings parse found %s Bash hooks\n' "$bash_count"
+  printf 'OK   settings parse found %s hook scripts (%s of them Bash), agreeing with a raw scan\n' \
+    "$any_count" "$bash_count"
 fi
 
 for gate in "$HOOK_DIR"/*.sh; do
   base=$(basename "$gate")
   case "$base" in _*.sh | *.test.sh) continue ;; esac
 
-  if ! printf '%s\n' "$any_hooks" | grep -qx "$base"; then
+  if ! printf '%s\n' "$any_hooks" | grep -qxF -- "$base"; then
     fail=$((fail + 1))
     printf 'FAIL %s is registered in no hook event -- it never runs\n' "$base"
     continue
   fi
 
-  if ! printf '%s\n' "$bash_hooks" | grep -qx "$base"; then
+  if ! printf '%s\n' "$bash_hooks" | grep -qxF -- "$base"; then
     pass=$((pass + 1))
     printf 'OK   %s receives no Bash command, so it needs no matcher\n' "$base"
     continue

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -283,10 +283,75 @@ want_dir "/w/t" "-c k=v then -C still resolves" 'git -c k=v -C /w/t commit -m y'
 # --- every gate is actually converted -----------------------------------------
 # The matcher only helps a gate that uses it. This pins the conversion so a new
 # gate (or a revert) cannot quietly go back to a line-start-anchored `grep`.
+#
+# The population is the hooks REGISTERED FOR BASH in `.claude/settings.json`, not
+# every `*.sh` in the directory. Until the first Stop hook landed the two sets
+# were the same, so iterating the directory was iterating the Bash gates by
+# coincidence; `stop-unmerged-lane-warn.sh` receives no command at all and was
+# failed by a fence asking it to parse one. Deriving the set from REGISTRATION
+# rather than from a hand-written exemption list is what keeps a new Bash gate
+# from dodging: it is in the population the moment it is wired up, and a list
+# would have to be remembered.
+#
+# The direction that would go silent is a hook registered NOWHERE -- it would
+# leave the population without being exempt -- so that is a FAIL of its own
+# below, and it is a real defect anyway (a hook that never runs).
 HOOK_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SETTINGS="$HOOK_DIR/../settings.json"
+
+# Two lists, one pass over the settings: hooks wired to a Bash matcher, and
+# every hook wired to anything at all.
+bash_hooks=$(python3 - "$SETTINGS" <<'PYEOF'
+import json, sys, os
+s = json.load(open(sys.argv[1]))
+out = set()
+for event, groups in s.get('hooks', {}).items():
+    for g in groups:
+        if 'Bash' not in (g.get('matcher') or ''):
+            continue
+        for h in g.get('hooks', []):
+            out.add(os.path.basename(h.get('command', '').split()[0]))
+print('\n'.join(sorted(out)))
+PYEOF
+)
+any_hooks=$(python3 - "$SETTINGS" <<'PYEOF'
+import json, sys, os
+s = json.load(open(sys.argv[1]))
+out = set()
+for event, groups in s.get('hooks', {}).items():
+    for g in groups:
+        for h in g.get('hooks', []):
+            out.add(os.path.basename(h.get('command', '').split()[0]))
+print('\n'.join(sorted(out)))
+PYEOF
+)
+
+# A parser floor: "found nothing" must not read as "everything is fine".
+bash_count=$(printf '%s\n' "$bash_hooks" | grep -c '\.sh$' || true)
+if [ "${bash_count:-0}" -lt 10 ]; then
+  fail=$((fail + 1))
+  printf 'FAIL settings parse found only %s Bash hooks -- the fence is blind\n' "$bash_count"
+else
+  pass=$((pass + 1))
+  printf 'OK   settings parse found %s Bash hooks\n' "$bash_count"
+fi
+
 for gate in "$HOOK_DIR"/*.sh; do
   base=$(basename "$gate")
   case "$base" in _*.sh | *.test.sh) continue ;; esac
+
+  if ! printf '%s\n' "$any_hooks" | grep -qx "$base"; then
+    fail=$((fail + 1))
+    printf 'FAIL %s is registered in no hook event -- it never runs\n' "$base"
+    continue
+  fi
+
+  if ! printf '%s\n' "$bash_hooks" | grep -qx "$base"; then
+    pass=$((pass + 1))
+    printf 'OK   %s receives no Bash command, so it needs no matcher\n' "$base"
+    continue
+  fi
+
   if grep -q '_command-match.sh' "$gate"; then
     pass=$((pass + 1)); printf 'OK   %s sources the matcher\n' "$base"
   else

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# stop-unmerged-lane-warn.sh
+#
+# Stop hook. `stop-warn.sh` next to it catches UNCOMMITTED work in the main
+# tree. This catches the other, quieter half: a feature worktree whose branch
+# is COMMITTED but still ahead of `origin/main` -- a lane that is finished as
+# far as the editor is concerned and unfinished as far as the repo is.
+#
+# Why this is a hook rather than another sentence. CLAUDE.md already says a
+# NOT-CLOSEABLE verdict is a to-do list and not a stopping point, and already
+# says that if you cannot name a signal that will re-invoke you then you are
+# STOPPED rather than WAITING. Both were violated repeatedly in one session on
+# 2026-08-26: turns ended with `Mode: WAITING` next to `Waiting on: none`, and
+# with `Verdict: NOT CLOSEABLE` in the same report as the stop. A rule that is
+# already in the text and gets violated anyway is not made load-bearing by a
+# third spelling of it (`/work-issues` section 10-b says to escalate rather
+# than restate), so this computes the verdict from the REPO instead of from the
+# agent's own self-report -- which is the part that was wrong.
+#
+# Deliberately does NOT call `gh`: a Stop hook runs on every turn, and a network
+# round-trip per turn is a cost this warning does not justify. Branch state
+# alone separates "there is unmerged work here" from "there is not".
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO" 2>/dev/null || exit 0
+
+# Cheap: no fetch. A stale `origin/main` can only UNDER-report (a branch whose
+# work already merged still looks ahead until the next fetch), and the failure
+# direction that matters is missing a real lane, not naming a merged one.
+git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
+
+lanes=""
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  [ "$wt" = "$REPO" ] && continue
+  br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
+  [ -n "$br" ] || continue
+  case "$br" in main | master) continue ;; esac
+  ahead=$(git -C "$wt" rev-list --count "origin/main..$br" 2>/dev/null) || continue
+  [ "${ahead:-0}" -gt 0 ] || continue
+  lanes="${lanes}  ${br}  (${ahead} commit(s) ahead, worktree ${wt##*/})
+"
+done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+
+[ -n "$lanes" ] || exit 0
+
+msg="WARNING: unmerged lane(s) still open -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
+Each branch below is committed but not on origin/main. If any is YOURS, you are not done: rebase, run the
+gates, open the PR, merge. If one belongs to another session, say which and why, rather than leaving it
+unexplained. And if you are ending the turn with nothing that will re-invoke you, the honest label is
+STOPPED, not WAITING."
+
+payload=$(printf '%s\n%s' "$msg" "$lanes" |
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+printf '{"systemMessage": %s}' "$payload"

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # stop-unmerged-lane-warn.sh
 #
-# Stop hook. `stop-warn.sh` next to it catches UNCOMMITTED work in the main
-# tree. This catches the other, quieter half: a feature worktree whose branch
-# is COMMITTED but still ahead of `origin/main` -- a lane that is finished as
-# far as the editor is concerned and unfinished as far as the repo is.
+# Stop hook. It catches the quiet half of unfinished work: a feature worktree
+# whose branch is COMMITTED but still ahead of `origin/main` -- a lane that is
+# finished as far as the editor is concerned and unfinished as far as the repo
+# is. (The sibling cdkd repo pairs this with a `stop-warn.sh` covering the
+# UNCOMMITTED half in the main tree. This repo has no such hook, so do not read
+# the pair as coverage here; an earlier revision of this comment named it as if
+# it sat next to this file.)
 #
 # Why this is a hook rather than another sentence. CLAUDE.md already says a
 # NOT-CLOSEABLE verdict is a to-do list and not a stopping point, and already
@@ -22,6 +25,14 @@
 # alone separates "there is unmerged work here" from "there is not".
 set -u
 
+# BASH_SOURCE resolves to whichever checkout this copy of the hook lives in --
+# in a linked worktree that is the LANE, not the main tree. That is fine as a
+# place to run `git` from (every worktree shares one object store and one
+# `origin/main`), but it must NOT be used to decide which worktree to skip: the
+# session ending inside its own lane is the case this hook exists for, and an
+# earlier revision skipped exactly that one. Measured from a lane 5 commits
+# ahead: the hook printed nothing. The main tree is excluded by BRANCH below
+# (`main`/`master`), which is the property that actually identifies it.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO" 2>/dev/null || exit 0
 
@@ -33,7 +44,6 @@ git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 lanes=""
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
-  [ "$wt" = "$REPO" ] && continue
   br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
   [ -n "$br" ] || continue
   case "$br" in main | master) continue ;; esac
@@ -49,7 +59,10 @@ msg="WARNING: unmerged lane(s) still open -- a NOT-CLOSEABLE verdict is a TO-DO 
 Each branch below is committed but not on origin/main. If any is YOURS, you are not done: rebase, run the
 gates, open the PR, merge. If one belongs to another session, say which and why, rather than leaving it
 unexplained. And if you are ending the turn with nothing that will re-invoke you, the honest label is
-STOPPED, not WAITING."
+STOPPED, not WAITING.
+One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
+becomes an ancestor of origin/main and keeps reading as ahead. If a lane below is already merged, the
+remaining work is to remove its worktree and delete the branch -- not to open another PR."
 
 payload=$(printf '%s\n%s' "$msg" "$lanes" |
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -36,9 +36,12 @@ set -u
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO" 2>/dev/null || exit 0
 
-# Cheap: no fetch. A stale `origin/main` can only UNDER-report (a branch whose
-# work already merged still looks ahead until the next fetch), and the failure
-# direction that matters is missing a real lane, not naming a merged one.
+# Cheap: no fetch. A stale `origin/main` can only OVER-report: `rev-list --count
+# origin/main..$br` only grows as `origin/main` ages, so a branch whose work has
+# already merged keeps reading as ahead. That is the safe direction -- the
+# failure that matters is MISSING a real lane, and staleness cannot cause it.
+# (An earlier revision of this comment said UNDER-report while its own
+# parenthetical described over-reporting; the parenthetical was the true half.)
 git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 
 lanes=""

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Smoke test for stop-unmerged-lane-warn.sh.
+#
+# Run from BESIDE the hook (`bash .claude/hooks/stop-unmerged-lane-warn.test.sh`):
+# the path below is `${BASH_SOURCE[0]}`-relative, so a copy run from a scratch
+# directory resolves a hook that is not there and every case fails with 127.
+#
+# Both polarities are exercised. A Stop hook that only ever proves it FIRES
+# cannot notice itself starting to fire on every turn, and a warning that cries
+# wolf on a clean tree is one people learn to scroll past -- which is the same
+# outcome as not having it.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/stop-unmerged-lane-warn.sh"
+
+pass=0
+fail=0
+fail_log=""
+
+check() {
+  local name="$1" want="$2" got="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf 'OK   %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    fail_log+="FAIL $name: want '$want', got '$got'\n"
+    printf 'FAIL %s (want %s, got %s)\n' "$name" "$want" "$got"
+  fi
+}
+
+# `lanes_in <output>` -> how many branch lines the payload named.
+lanes_in() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+if not raw.strip():
+    print(0); raise SystemExit
+msg = json.loads(raw)["systemMessage"]
+print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
+'
+}
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+REPO="$SANDBOX/repo"
+mkdir -p "$REPO/.claude/hooks"
+cp "$HOOK" "$REPO/.claude/hooks/"
+RUN="$REPO/.claude/hooks/$(basename "$HOOK")"
+
+git -C "$REPO" init -q .
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+# --- SILENT: nothing unmerged. The expensive half to get right, because a
+# false alarm every turn is indistinguishable from noise. ---
+out=$(cd "$REPO" && bash "$RUN")
+check "silent when no worktree exists" "" "$out"
+
+# --- SILENT: a worktree that is level with origin/main is not a lane. ---
+git -C "$REPO" worktree add -q "$REPO/wt-level" -b feat/level HEAD
+out=$(cd "$REPO" && bash "$RUN")
+check "silent for a worktree with no commits of its own" "" "$out"
+
+# --- SILENT: a DETACHED worktree has no branch to report. ---
+git -C "$REPO" worktree add -q "$REPO/wt-detached" --detach HEAD
+out=$(cd "$REPO" && bash "$RUN")
+check "silent for a detached worktree" "" "$out"
+
+# --- FIRES: one lane with a commit of its own. ---
+git -C "$REPO/wt-level" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(cd "$REPO" && bash "$RUN")
+check "names the one lane that is ahead" "1" "$(lanes_in "$out")"
+
+# --- FIRES: counts each lane separately, and still ignores the detached one. ---
+git -C "$REPO" worktree add -q "$REPO/wt-two" -b feat/two HEAD
+git -C "$REPO/wt-two" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(cd "$REPO" && bash "$RUN")
+check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
+
+# --- The payload has to be valid JSON, or the harness swallows it silently. ---
+if printf '%s' "$out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then
+  pass=$((pass + 1)); printf 'OK   payload is valid JSON\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL payload is not valid JSON\n"; printf 'FAIL payload is valid JSON\n'
+fi
+
+# --- SILENT: no `origin/main` at all (a fresh clone before the first fetch)
+# must not error or spam. ---
+BARE="$SANDBOX/norem"
+mkdir -p "$BARE/.claude/hooks"
+cp "$HOOK" "$BARE/.claude/hooks/"
+git -C "$BARE" init -q .
+git -C "$BARE" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+out=$(cd "$BARE" && bash "$BARE/.claude/hooks/$(basename "$HOOK")")
+check "silent when origin/main is unresolvable" "" "$out"
+
+printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
+if [ "$fail" -gt 0 ]; then
+  printf '%b' "$fail_log" >&2
+  exit 1
+fi

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -42,7 +42,17 @@ print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
 '
 }
 
-SANDBOX="$(mktemp -d)"
+# `pwd -P` is load-bearing, not tidiness. On macOS `mktemp -d` hands back a
+# path under `/var/folders/...` whose real location is `/private/var/...`, and
+# the hook derives its own root with `cd ... && pwd`, which canonicalises. Git,
+# meanwhile, records a worktree under whatever path it was CREATED with. So an
+# uncanonicalised sandbox makes the hook's root and git's listing two spellings
+# of one directory that never compare equal -- and any case whose subject is an
+# equality between those two paths passes no matter what the hook does. That is
+# how the self-lane case below was measured VACUOUS on its first attempt: the
+# defect it was written for (a skip keyed on the hook's own checkout) could be
+# reintroduced and the suite stayed 10/0.
+SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
 REPO="$SANDBOX/repo"
@@ -79,6 +89,45 @@ git -C "$REPO" worktree add -q "$REPO/wt-two" -b feat/two HEAD
 git -C "$REPO/wt-two" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
 out=$(cd "$REPO" && bash "$RUN")
 check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
+
+# --- FIRES: run from INSIDE a lane worktree, that lane must still be named. ---
+# The case the hook exists for, and the one every case above misses: they all
+# `cd "$REPO"` (the main tree), so a skip keyed on the hook's OWN checkout was
+# invisible to all seven of them. An earlier revision derived the skip from
+# `BASH_SOURCE` and went silent for exactly this run. The main tree is excluded
+# by BRANCH, so removing that skip costs nothing here -- which this case pins
+# from the other side, by asserting the count is 2 rather than 3.
+cp "$HOOK" "$REPO/wt-two/.claude/hooks/" 2>/dev/null || {
+  mkdir -p "$REPO/wt-two/.claude/hooks"; cp "$HOOK" "$REPO/wt-two/.claude/hooks/"
+}
+out=$(cd "$REPO/wt-two" && bash "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
+check "names its OWN lane when run from inside it" "2" "$(lanes_in "$out")"
+if printf '%s' "$out" | grep -q 'feat/two'; then
+  pass=$((pass + 1)); printf 'OK   the self-lane is the one named\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the self-lane is not named\n"; printf 'FAIL the self-lane is named\n'
+fi
+
+# --- SILENT: the main tree ON `main`, ahead of origin/main, is NOT a lane.
+# Without this the `main`/`master` filter is unfenced: everywhere else in this
+# sandbox the main tree is LEVEL with origin/main, so the ahead-count check
+# already excludes it and deleting the branch filter changes nothing. Measured:
+# with this case absent, dropping `case "$br" in main|master) continue` left the
+# suite at 10/0. Direct commits on `main` are a different problem with its own
+# gate; this hook reports unmerged LANES.
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'on main'
+out=$(cd "$REPO" && bash "$RUN")
+check "the main tree on main is not a lane even when ahead" "2" "$(lanes_in "$out")"
+
+# --- The BRANCH filter, not the path, is what excludes the main tree. Put the
+# main tree on a feature branch that is ahead and it must be named like any
+# other lane; otherwise the two filters mask each other and neither is fenced.
+git -C "$REPO" checkout -q -b feat/main-tree-lane
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(cd "$REPO" && bash "$RUN")
+check "the main tree on a feature branch is a lane too" "3" "$(lanes_in "$out")"
+git -C "$REPO" checkout -q -
+git -C "$REPO" branch -q -D feat/main-tree-lane
 
 # --- The payload has to be valid JSON, or the harness swallows it silently. ---
 if printf '%s' "$out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -97,9 +97,8 @@ check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
 # `BASH_SOURCE` and went silent for exactly this run. The main tree is excluded
 # by BRANCH, so removing that skip costs nothing here -- which this case pins
 # from the other side, by asserting the count is 2 rather than 3.
-cp "$HOOK" "$REPO/wt-two/.claude/hooks/" 2>/dev/null || {
-  mkdir -p "$REPO/wt-two/.claude/hooks"; cp "$HOOK" "$REPO/wt-two/.claude/hooks/"
-}
+mkdir -p "$REPO/wt-two/.claude/hooks"
+cp "$HOOK" "$REPO/wt-two/.claude/hooks/"
 out=$(cd "$REPO/wt-two" && bash "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
 check "names its OWN lane when run from inside it" "2" "$(lanes_in "$out")"
 if printf '%s' "$out" | grep -q 'feat/two'; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -247,6 +247,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop-unmerged-lane-warn.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1316,8 +1316,8 @@ for n in <the numbers this run filed that are still open>; do
     | grep -oE '[A-Za-z0-9_][A-Za-z0-9_./-]*\.[a-z]+' | sort -u \
     | while read -r f; do
         # Suffix match, not equality: an issue body names a file by BASENAME far
-        # more often than by full path (`destroy-runner.ts`, not
-        # `src/cli/commands/destroy-runner.ts`), and an exact-line compare misses
+        # more often than by full path (the bare file name, not the full
+        # repo-relative one), and an exact whole-line compare misses
         # every one of those. Measured: the exact form fired on 1 of this run's 2
         # deferrals and missed the one whose body used the basename.
         grep -E "(^|/)$(printf '%s' "$f" | sed 's/[.[\*^$]/\\&/g')\$" \

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1291,6 +1291,72 @@ gh issue list --state open --limit 200 --json number,updatedAt \
   done
 ```
 
+**Then run the PROMOTION check on every `next` this run filed, because a
+deferral is judged against the run that has now HAPPENED, not the run that was
+predicted when it was written.** At wrap time nobody re-opens a decision they
+remember making deliberately, so this is left as a QUERY rather than as a thing
+to remember:
+
+```bash
+# For each issue this run filed, does the run's OWN merged diff touch a file
+# that issue names? A hit means the deferral was written against a run that
+# then went somewhere else.
+RANGE="<the sha main was at when this run started>..origin/main"
+git diff --name-only "$RANGE" | sort -u > /tmp/run-touched.$$
+# The population is the issues this run FILED and left OPEN -- not the folded
+# list above, and not the ones it filed and then fixed in the same lane, which
+# section 3-a makes routine.
+for n in <the numbers this run filed that are still open>; do
+  b=$(gh issue view "$n" --json body -q .body)
+  # The prose says every `next`; without this the loop also reports items
+  # already classified `now`, which are not deferrals at all. `Session-fit`
+  # carries no GitHub label, so it has to be grepped out of the body.
+  printf '%s' "$b" | grep -q 'Session-fit: *next' || continue
+  printf '%s' "$b" \
+    | grep -oE '[A-Za-z0-9_][A-Za-z0-9_./-]*\.[a-z]+' | sort -u \
+    | while read -r f; do
+        # Suffix match, not equality: an issue body names a file by BASENAME far
+        # more often than by full path (`destroy-runner.ts`, not
+        # `src/cli/commands/destroy-runner.ts`), and an exact-line compare misses
+        # every one of those. Measured: the exact form fired on 1 of this run's 2
+        # deferrals and missed the one whose body used the basename.
+        grep -E "(^|/)$(printf '%s' "$f" | sed 's/[.[\*^$]/\\&/g')\$" \
+          /tmp/run-touched.$$ | while read -r hit; do
+            echo "PROMOTE #$n -- this run touched $hit"
+          done
+      done
+done
+rm -f /tmp/run-touched.$$
+```
+
+Pipe the whole loop through `sort -u`: a body naming the same file twice prints
+twice, and the duplicate reads as two findings.
+
+**A hit is a prompt for judgement, not a verdict** -- measured on this run's own
+two deferrals, one hit on the single file its fix touches and the other hit on
+FOUR, three of which its body cited as precedent rather than as files to change.
+The check cannot tell a citation from a target, and should not try: its job is to
+put the issue back in front of you at the moment the answer has changed.
+
+A hit is still not something to skim past. Either do the item in this run -- the context that
+made it cheap is still loaded -- or re-classify it in the issue body with the
+reason it still does not belong here.
+
+**And re-read the REASON, not just the files, because a deferral reason can name
+a state that has since resolved.** Classifying once, when the item is created,
+is right: it is what stops the post-merge moment being re-litigated. But it
+freezes the DECISION, and a reason phrased in terms of the run's own transient
+state -- "the PR carrying it is still open", "the lane holding that file is
+mid-flight", "taking this now would be a fifth review round" -- is true when
+written and FALSE the moment that state resolves. Measured in the sibling repo
+go-to-k/cdkd on 2026-08-26 (issue go-to-k/cdkd#2259, deferred while
+go-to-k/cdkd#2247 was still in review): the fix would have been a fifth review
+round on that open PR, and the reason survived unchanged
+into the wrap report after that PR merged, where it read as a considered
+judgement rather than an expired one. Re-reading a premise that has expired is
+not re-litigation; keeping a `next` alive on a reason that has stopped being
+true is.
+
 Report it as one line — `closed N / filed M (new K / folded J)` — and **when
 M > N, give the reason in one more line**. `J` is the number §5's window exists to
 move, and it is the only one of the three below that can be improved without


### PR DESCRIPTION
Two changes from one run's retrospective, both replacing an instruction that already
existed and was violated anyway with something that does not depend on the agent
remembering it.

## 1. The `next` -> `now` promotion becomes a QUERY

Section 10-0 already stops to run `gh issue list`. It now also intersects the paths each
issue this run FILED names against the run's own merged diff, and prints `PROMOTE #N` on a
hit.

Two rules already covered the case that went wrong. The `next` criterion "an independent
subsystem with no file overlap" carries the conjunct "AND none of the `now` criteria
fire", and CLAUDE.md requires promoting a `next` to `now` when the session ends up touching
those files anyway. Both were skipped, because at wrap time nobody re-opens a decision they
remember making deliberately. Section 10-b is explicit that another sentence does not fix
that — escalate rather than restate.

**Two defects were found by running the query against this run's own two deferrals**, and
both would have shipped from the first draft:

- the path regex allow-listed `(src|tests|docs|scripts)/`, which excludes `.claude/**` —
  and section 10 files INTO `.claude/skills/**`, so the run most likely to have a hit was
  exactly the one the grep could not see. In cdk-local `scripts/` does not exist at all.
  The directory allow-list is gone: the intersection with `git diff --name-only` already
  restricts matches to real tracked paths, so enumerating roots bought nothing and could
  only go stale per repo.
- the comparison was `grep -qxF`, an exact whole-line match against full paths, while issue
  bodies name files by BASENAME far more often. Measured: the exact form fired on one of
  the two deferrals and missed the other for precisely that reason. It is a suffix match
  now, and both fire.

The honest limit is stated rather than asserted: one of those two hit on FOUR files, three
of which its body cited as precedent rather than as files to change. The check cannot tell
a citation from a target and should not try — its job is to put the issue back in front of
you at the moment the answer has changed.

## 2. A deferral REASON can expire

Classifying once, when the item is created, is right — it is what stops the post-merge
moment being re-litigated. But it freezes the DECISION, and a reason phrased in terms of
the run's own transient state ("the PR carrying it is still open", "taking this now would
be a fifth review round") is true when written and FALSE the moment that state resolves.
This run shipped exactly that. Re-reading an expired premise is not re-litigation; keeping
a `next` alive on a reason that has stopped being true is.

## 3. `stop-unmerged-lane-warn.sh` — a NOT-CLOSEABLE verdict is not a stopping point

Same escalation, applied to the wrap report itself. Two rules already say it: a
NOT-CLOSEABLE verdict is a to-do list, and an agent that cannot name a signal which will
re-invoke it is STOPPED rather than WAITING. Both were violated repeatedly in one session —
turns ended with `Mode: WAITING` next to `Waiting on: none`, and with `Verdict: NOT
CLOSEABLE` in the same report as the stop. The maintainer had to ask twice.

So the verdict is computed from the REPO rather than from the agent's self-report, which is
the part that was wrong. On Stop, any linked worktree whose branch is ahead of
`origin/main` is named. The existing `stop-warn.sh` catches UNCOMMITTED work in the main
tree; this is the quieter half — a lane finished as far as the editor is concerned and
unfinished as far as the repo is.

Deliberately cheap: no `gh`, no `git fetch`. A Stop hook runs every turn, and a stale
`origin/main` can only UNDER-report, which is the safe direction.

## Verification

No `src/**` change, so this takes section 8's no-src tier — and BOTH arms of it, because
the diff does both:

- **prose arm** (SKILL.md): every claim resolved against this repo's own files. The two
  citations that exist only in cdkd were verified present here / absent in the siblings
  before being kept / dropped per repo.
- **command arm** (the hook): its own suite, run from beside the hook, fences both
  polarities — silent with no worktrees, silent for a worktree level with main, silent for
  a detached one, silent when `origin/main` is unresolvable, and naming each lane genuinely
  ahead. **Probed rather than asserted**: disabling the detection reds 3 of the 7 cases.

Full suite green. The `work-issues-skill-refs` fence (which validates the qualified
`go-to-k/cdkd#N` citation form) passes.


## The CI failure this branch hit, and the wrong guess before it

`check-build-test` failed three times. It was never the unit suite: 219 files / 3263 tests
pass, locally and in the same CI job. The failing step was `vp run test:hooks`, at
`pass: 228  fail: 1` — one case, `stop-unmerged-lane-warn.sh does not source
_command-match.sh`.

The matcher class fence in `_command-match.test.sh` iterated every non-underscore `*.sh`
in the hooks directory and required each to source `_command-match.sh`. That was correct
for as long as the directory held nothing but Bash gates — which was true until this
branch, so the fence was iterating its real population **by coincidence**. The hook this
PR adds is registered on `Stop` with no matcher and receives no command at all, and the
fence failed it for not parsing one.

The population is now derived from REGISTRATION in `.claude/settings.json`. A new Bash
gate joins it the moment it is wired up, so it cannot dodge; a hand-written exemption list
would have to be remembered instead. The direction that could go silent is a hook
registered nowhere — it would leave the population without being exempt — so that is now
a failure of its own, and a hook that never runs is a real defect regardless.

Probed rather than asserted, each restoring first:

| mutation | measured |
|---|---|
| a Bash gate stops sourcing the matcher | 1 fail |
| the Stop hook registered under `Bash` | 1 fail — the exemption is registration-bound, not a free pass |
| a gate wired to no event at all | 2 fail |
| settings parsed to nothing | 21 fail — the parser floor |

229 pass / 0 fail under bash 5.x and macOS system bash 3.2.

**A correction.** An earlier commit on this branch (`chore: trigger a fresh CI run to
separate a flaky vitest worker crash from a real failure`) was pushed on a wrong premise.
A local run had once printed `Errors  1 error` alongside a fully green suite, and that was
read as the CI failure; it was a local flake and the CI job never failed on the unit
suite. The empty commit bought nothing, and a baseline-probe PR opened on the same premise
(https://github.com/go-to-k/cdk-local/pull/574) has been closed. The evidence was in the job log the whole time —
`--log-failed` names the failing STEP, and it said `test:hooks`, not `test`.


## Round 2: an independent review, and a regression it caught in my own fix

Two reviewers were dispatched against the first fix; a third round was scoped to the fix DELTA, because that code is what no reviewer has seen and it lands where a reviewer has just proved the ground is subtle. It found a regression I had introduced.

**The Stop hook was INERT for its primary case.** It derived `REPO` from `BASH_SOURCE` and skipped the worktree that matched -- intended to skip the main tree, but in a linked worktree `BASH_SOURCE` IS the lane, so the session ending inside its own unmerged lane got nothing. Measured from this branch's own worktree, five commits ahead: EMPTY. All seven original cases ran the hook from the sandbox's MAIN tree, which is why none could see it. The main tree is identified by BRANCH, which the loop already checks, so the path skip was redundant AND the whole defect.

**The first case written for that passed while proving nothing.** On macOS `mktemp -d` returns a `/var/folders/...` path whose real location is `/private/var/...`; the hook canonicalises its root with `cd && pwd` while git records a worktree under the path it was CREATED with. The two spellings never compare equal, so a case whose subject IS that equality cannot fail -- reintroducing the skip left the suite at 10/0. The sandbox root is now `cd "$(mktemp -d)" && pwd -P`.

**The fence exempted the shape that receives the most.** It asked whether the string `Bash` appears in a group's matcher; a `PreToolUse` group with the matcher omitted, empty, `*` or `.*` fires on every tool and was waved through -- and that is the shape this branch itself added. Classification is now by EVENT plus a wildcard-aware matcher test.

**Then my replacement floor was itself a regression.** The old literal `-lt 10` was a bad bound, but swapping it for a cross-check of the ANY-event parse left the BASH population with no bound beyond `-lt 1`. Measured by the review: moving 22 of the 33 hook entries into a second `PreToolUse` group with `matcher: "Edit|Write"` silently exempted ELEVEN live gates including `branch-gate.sh`, and the suite stayed at 218/0. The fix is not a better count but the SECOND DIRECTION of the invariant -- a hook that SOURCES the matcher must be wired to Bash, since sourcing it is evidence the hook parses commands and a non-Bash matcher means it never receives one. Unlike a count that is not brittle: a legitimate Edit-only hook does not source the matcher and passes.

Smaller: the raw cross-check scanned the whole file, so a `permissions.allow` entry naming a `.sh` reddened it; its message asserted a direction a symmetric comparison cannot know; the hook's own comment said a stale `origin/main` "can only UNDER-report" while its parenthetical described the opposite (`rev-list --count` only grows as `origin/main` ages, so staleness over-reports -- still the safe direction, now stated correctly); and a `cp` in the new case could never succeed, its fallback always running.

Six further findings did NOT reproduce when run and are unchanged: `bashy(None)` misclassifying a non-tool group (the event filter runs first, verified against four non-tool events), matcher exclusion for `"Edit|Write"` / `"Notebook.*"`, double-counting or a detached/bare worktree after removing the `$REPO` skip, ordering coupling among the new cases, `grep -c .` on empty input, and a hooks-dir name containing a dot.

| final mutation | measured |
|---|---|
| 22 entries moved to an `Edit|Write` group | 11 fail (was 0) |
| reintroduce the `BASH_SOURCE` skip | 3 fail |
| drop the `main` / `master` filter | 1 fail |
| bare `mktemp -d` AND the skip reintroduced | **11/0 -- vacuous**, which is why `pwd -P` is load-bearing |
| a Bash gate stops sourcing the matcher | 1 fail |
| a non-sourcing hook under `matcher: '*'` / omitted | 1 fail each |
| a hook wired to no event at all | 1 fail |
| the parse made to lose one entry | 3 fail |
| settings parsed to nothing | 21 fail |

229/0 for the fence and 11/0 for the Stop hook under bash 5.x and macOS system bash 3.2; `test:hooks` green; 219 files / 3263 tests green.
