### PR TITLE
fix(local): route every STS error relay at warn through one policy, so a wire-derived message cannot forge a log line

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -572,7 +572,17 @@ compute-locally category for Lambda + API Gateway).
   websocket-server, ecs-task-runner, ecs-service-runner, ecs-network,
   cloud-map-registry, lambda-resolver, ecs-task-resolver,
   route-discovery, authorizer-resolver, lambda-authorizer, cognito-jwt,
-  sigv4-verify, rie-client, intrinsic-image, runtime-image, target-lister
+  sigv4-verify, credential-error (issues #564 / #570 — how an AWS SDK
+  failure is rendered into a DEFAULT-level log line: `describeAwsFailureForWarn`
+  keeps a modeled service exception's message, since that message is the
+  diagnosis, flattened to one line and length-capped, and withholds every
+  other error — credential-chain failures above all, which can carry a
+  `credential_process` command line — to a clamped class name plus a
+  character count, emitting the full text at `debug`;
+  `describeCredentialLoadFailure` is the unconditional-withhold form for a
+  `catch` around credential resolution alone, which is what `sigv4-verify`
+  uses. Both are re-exported from `src/internal.ts`),
+  rie-client, intrinsic-image, runtime-image, target-lister
   (`cdkl list` target enumeration), target-picker (interactive arrow-key
   target selection via `@clack/prompts` when a target is omitted in a TTY),
   agentcore-resolver (`AWS::BedrockAgentCore::Runtime` target resolution +

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -581,7 +581,12 @@ compute-locally category for Lambda + API Gateway).
   character count, emitting the full text at `debug`;
   `describeCredentialLoadFailure` is the unconditional-withhold form for a
   `catch` around credential resolution alone, which is what `sigv4-verify`
-  uses. Both are re-exported from `src/internal.ts`),
+  uses. Both are re-exported from `src/internal.ts`. SCOPE: it governs
+  `sigv4-verify` plus the nine STS relays in `src/cli/commands/**`; the
+  remaining AWS SDK error relays elsewhere under `src/local/**` — notably
+  `formatAwsErrorForWarn` in `cfn-local-state-provider` and `formatSsmError`
+  in `ssm-parameter-resolver`, which still print an UNCLAMPED wire-derived
+  `err.name` — are enumerated in issue #579),
   rie-client, intrinsic-image, runtime-image, target-lister
   (`cdkl list` target enumeration), target-picker (interactive arrow-key
   target selection via `@clack/prompts` when a target is omitted in a TTY),

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -927,7 +927,8 @@ Outcomes:
   that one may be the federated signer you need told about.
 
   When the failure is that **no local credentials resolved at all**, the warn
-  names the failure's class and the length of the credential chain's message
+  names the failure's class (plus a system-error code such as `ENOTFOUND` when
+  the failure carries one) and the length of the credential chain's message,
   but not the message itself. The full text is printed at debug level -- run
   with `--verbose` (or set `CDKL_LOG_LEVEL=debug`) to see it. The reason for holding it back is that the
   chain's error text is not cdk-local's to vouch for: the AWS SDK's

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -942,8 +942,8 @@ Outcomes:
 
   The STS calls behind `${AWS::AccountId}` resolution and `--assume-role` are
   governed by the same policy, with one difference: those wrap a call
-  cdk-local made, so when STS itself answers (`ExpiredToken`, `AccessDenied`)
-  the message is the diagnosis and keeps printing. See
+  cdk-local made, so when STS itself answers (`ExpiredTokenException`,
+  `AccessDenied`) the message is the diagnosis and keeps printing. See
   [Troubleshooting](./troubleshooting.md#an-sts-warn-says-the-message-was-withheld).
   Here there is no such call — the failure is always the local chain's — so
   the message is withheld unconditionally.

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -930,7 +930,9 @@ Outcomes:
   names the failure's class (plus a system-error code such as `ENOTFOUND` when
   the failure carries one) and the length of the credential chain's message,
   but not the message itself. The full text is printed at debug level -- run
-  with `--verbose` (or set `CDKL_LOG_LEVEL=debug`) to see it. The reason for holding it back is that the
+  with `--verbose` (or set `CDKL_LOG_LEVEL=debug`) to see it, folded onto a
+  single line (a line break in a message cdk-local does not control would
+  otherwise forge a log line in the panel `cdkl studio` serves). The reason for holding it back is that the
   chain's error text is not cdk-local's to vouch for: the AWS SDK's
   `credential_process` provider copies Node's `Command failed: <command
   line>` into the error it raises, and a `credential_process` command line is

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -940,6 +940,14 @@ Outcomes:
   serves over HTTP is the wrong place to relay an error string cdk-local does
   not control, and `--verbose` costs you nothing.
 
+  The STS calls behind `${AWS::AccountId}` resolution and `--assume-role` are
+  governed by the same policy, with one difference: those wrap a call
+  cdk-local made, so when STS itself answers (`ExpiredToken`, `AccessDenied`)
+  the message is the diagnosis and keeps printing. See
+  [Troubleshooting](./troubleshooting.md#an-sts-warn-says-the-message-was-withheld).
+  Here there is no such call — the failure is always the local chain's — so
+  the message is withheld unconditionally.
+
 #### OAC-fronted Function URLs (auto-relaxed)
 
 A Function URL declared with `AuthType: 'AWS_IAM'` is, in the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -104,6 +104,14 @@ The flag reads CloudFormation Outputs and resolves resource ARNs into env vars o
 - Confirm your IAM credentials have `cloudformation:ListStackResources`, `cloudformation:DescribeStacks`, and `cloudformation:ListExports`.
 - Confirm the stack has the Outputs / resources your CDK code expects (the local synth's expectations must match the deployed state).
 
+### An STS warn says the message was withheld
+
+A warn line ending in `N-character message withheld, logged at debug level under --verbose` means the STS call (`GetCallerIdentity` for `${AWS::AccountId}`, `AssumeRole` for `--assume-role`) failed **before the request reached AWS** — the local credential chain could not produce credentials. Re-run with `--verbose` (or `CDKL_LOG_LEVEL=debug`) to see the chain's full message; the usual causes are an expired SSO session (`aws sso login`), a `--profile` that does not exist, or no credentials configured at all.
+
+The message is withheld from the default-level line rather than printed there because it is the AWS SDK's text, not cdk-local's: the SDK's `credential_process` provider copies the failed command's own command line into the error it raises, and a `credential_process` command line is an ordinary place to keep a passphrase. Since `cdkl studio` mirrors these lines into a log ring it serves over HTTP, a default-level line is the wrong place to relay a string cdk-local does not control. The character count is kept because it is what tells you whether your `credential_process` ran at all.
+
+When STS itself answers — `ExpiredToken`, `AccessDenied`, `InvalidClientTokenId` — the message **is** printed in full at warn level, because that message is the diagnosis and it never went near your credential command. Such a message is flattened onto one line and capped at 512 characters.
+
 ### `--env-vars <file>` not applying overrides
 
 - **Wrong key format** — the file is a JSON object keyed by Lambda **logical ID** (the synthesized CloudFormation ID like `MyFn1234ABCD`). CDK display path keys are tracked as a future enhancement in [issue #27](https://github.com/go-to-k/cdk-local/issues/27).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -106,11 +106,15 @@ The flag reads CloudFormation Outputs and resolves resource ARNs into env vars o
 
 ### An STS warn says the message was withheld
 
-A warn line ending in `N-character message withheld, logged at debug level under --verbose` means the STS call (`GetCallerIdentity` for `${AWS::AccountId}`, `AssumeRole` for `--assume-role`) failed **before the request reached AWS** — the local credential chain could not produce credentials. Re-run with `--verbose` (or `CDKL_LOG_LEVEL=debug`) to see the chain's full message; the usual causes are an expired SSO session (`aws sso login`), a `--profile` that does not exist, or no credentials configured at all.
+A warn line ending in `N-character message withheld, logged at debug level under --verbose` means the STS call (`GetCallerIdentity` for `${AWS::AccountId}`, `AssumeRole` for `--assume-role`) failed **before the request reached AWS** — the local credential chain could not produce credentials. Re-run with `--verbose` (or `CDKL_LOG_LEVEL=debug`) to see the full message; the usual causes are an expired SSO session (`aws sso login`), a `--profile` that does not exist, no credentials configured at all, or no region resolved (`--region`, `AWS_REGION`, or `env.region` on the stack).
+
+The class name in front of the count is the discriminator. When the failure carries a system-error code the line names it too — `Error ENOTFOUND; ...` is an unreachable STS endpoint, `Error ETIMEDOUT; ...` a blocked one, `CredentialsProviderError; ...` a chain that found nothing.
 
 The message is withheld from the default-level line rather than printed there because it is the AWS SDK's text, not cdk-local's: the SDK's `credential_process` provider copies the failed command's own command line into the error it raises, and a `credential_process` command line is an ordinary place to keep a passphrase. Since `cdkl studio` mirrors these lines into a log ring it serves over HTTP, a default-level line is the wrong place to relay a string cdk-local does not control. The character count is kept because it is what tells you whether your `credential_process` ran at all.
 
-When STS itself answers — `ExpiredToken`, `AccessDenied`, `InvalidClientTokenId` — the message **is** printed in full at warn level, because that message is the diagnosis and it never went near your credential command. Such a message is flattened onto one line and capped at 512 characters.
+When STS itself answers — `ExpiredTokenException`, `AccessDenied` — the message **is** printed in full at warn level, because that message is the diagnosis and it never went near your credential command. Such a message is flattened onto one line and capped at 512 characters.
+
+**One caveat if you use `cdkl studio`.** The debug line goes to the same stdout studio mirrors into the log panel it serves over HTTP, so running a studio-spawned child with `--verbose` (or `CDKL_LOG_LEVEL=debug` in studio's environment) puts the withheld text into that panel. Prefer `--verbose` on a direct `cdkl invoke` / `cdkl start-api` run when the message might carry anything you would not put on a shared screen.
 
 ### `--env-vars <file>` not applying overrides
 

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -8,6 +8,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
+import { describeAwsFailureForWarn } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, LocalStartServiceError } from '../../utils/error-handler.js';
 import { resolveMultiTarget } from '../../local/target-picker.js';
@@ -2442,8 +2443,12 @@ export async function buildEcsImageResolutionContext(
     try {
       accountId = await resolveCallerAccountId(region, options.profile);
     } catch (err) {
+      // Issue #570: never interpolate the SDK error's `message` into this
+      // default-level line -- see `describeAwsFailureForWarn` in
+      // `src/local/credential-error.ts` for which half of it prints here and
+      // which is withheld to `debug`.
       logger.warn(
-        `Resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${err instanceof Error ? err.message : String(err)}. ` +
+        `Resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${describeAwsFailureForWarn(err, 'STS GetCallerIdentity')}. ` +
           'Substitution will be skipped; affected env / secret entries will be dropped with per-key warnings.'
       );
     }

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -12,6 +12,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
+import { describeAwsFailureForWarn } from '../../local/credential-error.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { getDockerCmd } from '../../utils/docker-cmd.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
@@ -864,8 +865,13 @@ export async function buildSigV4HeadersIfRequested(
  *
  * Throws a {@link CdkLocalError} when none are available — `--sigv4` cannot
  * proceed without credentials, unlike the unsigned path.
+ *
+ * Exported so the issue #570 site-level test can drive the STS failure
+ * branch with a mocked STS client -- the same reason
+ * `applyAgentCoreCredentialEnv` below is exported. A helper being correct
+ * says nothing about whether a given site actually routes through it.
  */
-async function resolveHostCredentialsForSigV4(
+export async function resolveHostCredentialsForSigV4(
   options: LocalInvokeAgentCoreOptions,
   resolved: ResolvedAgentCoreRuntime,
   loaded: LocalStateRecord | undefined,
@@ -878,9 +884,13 @@ async function resolveHostCredentialsForSigV4(
     try {
       return await assumeAgentCoreExecutionRole(assumeRoleArn, region, options.profile);
     } catch (err) {
+      // Issue #570: not on the issue's list of six, but the same class --
+      // see `describeAwsFailureForWarn` in `src/local/credential-error.ts`.
+      // `assumeRoleArn` keeps printing for the reason recorded at the
+      // `applyAgentCoreCredentialEnv` site below.
       logger.warn(
         `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for --sigv4 signing: ` +
-          `${err instanceof Error ? err.message : String(err)}. ` +
+          `${describeAwsFailureForWarn(err, 'STS AssumeRole (--sigv4 signing)')}. ` +
           `Falling back to ${options.profile ? `--profile ${options.profile}` : 'shell credentials'}.`
       );
     }
@@ -1067,8 +1077,13 @@ async function resolveAgentCoreCodeImage(
  * or resolved from `--from-cfn-stack` state for the bare form) yields STS temp
  * creds for the download; otherwise `--profile` / the default chain is used.
  * The region is `--region` / `--stack-region` / env / the stack's region.
+ *
+ * Exported so the issue #570 site-level test can drive the STS failure
+ * branch with a mocked STS client -- the same reason
+ * `applyAgentCoreCredentialEnv` below is exported. A helper being correct
+ * says nothing about whether a given site actually routes through it.
  */
-async function resolveAgentCoreCodeImageFromS3(
+export async function resolveAgentCoreCodeImageFromS3(
   resolved: ResolvedAgentCoreRuntime,
   code: AgentCoreCodeArtifact,
   s3Source: NonNullable<AgentCoreCodeArtifact['s3Source']>,
@@ -1108,9 +1123,13 @@ async function resolveAgentCoreCodeImageFromS3(
     try {
       credentials = await assumeAgentCoreExecutionRole(assumeRoleArn, region, options.profile);
     } catch (err) {
+      // Issue #570: not on the issue's list of six, but the same class --
+      // see `describeAwsFailureForWarn` in `src/local/credential-error.ts`.
+      // `assumeRoleArn` keeps printing for the reason recorded at the
+      // `applyAgentCoreCredentialEnv` site below.
       logger.warn(
         `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for the fromS3 bundle download: ` +
-          `${err instanceof Error ? err.message : String(err)}. ` +
+          `${describeAwsFailureForWarn(err, 'STS AssumeRole (fromS3 bundle download)')}. ` +
           `Falling back to ${options.profile ? `--profile ${options.profile}` : 'the default credentials'}.`
       );
     }
@@ -1334,8 +1353,12 @@ export async function buildAgentCoreImageContext(
   try {
     accountId = await resolveCallerAccountId(region, options.profile);
   } catch (err) {
+    // Issue #570: never interpolate the SDK error's `message` into this
+    // default-level line -- see `describeAwsFailureForWarn` in
+    // `src/local/credential-error.ts` for which half of it prints here and
+    // which is withheld to `debug`.
     logger.warn(
-      `--from-cfn-stack: STS GetCallerIdentity failed: ${err instanceof Error ? err.message : String(err)}. ` +
+      `--from-cfn-stack: STS GetCallerIdentity failed: ${describeAwsFailureForWarn(err, 'STS GetCallerIdentity')}. ` +
         'A same-stack ECR image URI referencing ${AWS::AccountId} may not resolve.'
     );
   }
@@ -1413,8 +1436,20 @@ export async function applyAgentCoreCredentialEnv(
       if (stsRegion) dockerEnv['AWS_REGION'] = stsRegion;
       assumeSucceeded = true;
     } catch (err) {
+      // Issue #570: never interpolate the SDK error's `message` into this
+      // default-level line -- see `describeAwsFailureForWarn` in
+      // `src/local/credential-error.ts` for which half of it prints here and
+      // which is withheld to `debug`.
+      //
+      // `args.assumeRoleArn` KEEPS printing. It is the developer's own
+      // `--assume-role` value or an ARN read from their own deployed stack
+      // state, and an ARN is a public identifier -- the same call issue #555
+      // made for the access-key-id it left quoted. It is also load-bearing
+      // for `tests/integration/local-studio/verify.sh`, which proves
+      // `--assume-role` threaded from the CLI to the spawned child by
+      // finding the ARN in the studio log ring.
       logger.warn(
-        `--assume-role: STS AssumeRole(${args.assumeRoleArn}) failed: ${err instanceof Error ? err.message : String(err)}. ` +
+        `--assume-role: STS AssumeRole(${args.assumeRoleArn}) failed: ${describeAwsFailureForWarn(err, 'STS AssumeRole')}. ` +
           "Falling back to the developer's shell credentials."
       );
     }

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -1494,7 +1494,9 @@ export async function resolveAssumeRoleArn(
   if (loaded) {
     const fromState = resolveExecutionRoleArnFromState(loaded, resolved.logicalId, 'RoleArn');
     if (fromState) {
-      getLogger().debug(`--assume-role: resolved RoleArn from state: ${fromState}`);
+      getLogger().debug(
+        `--assume-role: resolved RoleArn from state: ${flattenToOneLine(fromState)}`
+      );
       return fromState;
     }
     // Issue #187 fallback: state-only lookup misses for sibling-stack
@@ -1505,8 +1507,12 @@ export async function resolveAssumeRoleArn(
     if (stateProvider?.resolveAgentCoreRuntimeRoleArn && runtimePhysicalId) {
       const liveArn = await stateProvider.resolveAgentCoreRuntimeRoleArn(runtimePhysicalId);
       if (liveArn) {
+        // Issue #570: FLATTENED. `liveArn` is the deployed `roleArn` off a
+        // `GetAgentRuntime` response with only a `startsWith('arn:')` check, and
+        // `info` is a default level studio mirrors into an HTTP-served ring.
+        // This is the SUCCESS path, so it is more reachable than the warn.
         getLogger().info(
-          `--assume-role: auto-resolved execution role from GetAgentRuntime: ${liveArn}`
+          `--assume-role: auto-resolved execution role from GetAgentRuntime: ${flattenToOneLine(liveArn)}`
         );
         return liveArn;
       }

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -12,7 +12,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
-import { describeAwsFailureForWarn } from '../../local/credential-error.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { getDockerCmd } from '../../utils/docker-cmd.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
@@ -889,7 +889,7 @@ export async function resolveHostCredentialsForSigV4(
       // `assumeRoleArn` keeps printing for the reason recorded at the
       // `applyAgentCoreCredentialEnv` site below.
       logger.warn(
-        `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for --sigv4 signing: ` +
+        `--assume-role: STS AssumeRole(${flattenToOneLine(assumeRoleArn)}) failed for --sigv4 signing: ` +
           `${describeAwsFailureForWarn(err, 'STS AssumeRole (--sigv4 signing)')}. ` +
           `Falling back to ${options.profile ? `--profile ${options.profile}` : 'shell credentials'}.`
       );
@@ -1128,7 +1128,7 @@ export async function resolveAgentCoreCodeImageFromS3(
       // `assumeRoleArn` keeps printing for the reason recorded at the
       // `applyAgentCoreCredentialEnv` site below.
       logger.warn(
-        `--assume-role: STS AssumeRole(${assumeRoleArn}) failed for the fromS3 bundle download: ` +
+        `--assume-role: STS AssumeRole(${flattenToOneLine(assumeRoleArn)}) failed for the fromS3 bundle download: ` +
           `${describeAwsFailureForWarn(err, 'STS AssumeRole (fromS3 bundle download)')}. ` +
           `Falling back to ${options.profile ? `--profile ${options.profile}` : 'the default credentials'}.`
       );
@@ -1448,8 +1448,13 @@ export async function applyAgentCoreCredentialEnv(
       // for `tests/integration/local-studio/verify.sh`, which proves
       // `--assume-role` threaded from the CLI to the spawned child by
       // finding the ARN in the studio log ring.
+      //
+      // It is FLATTENED all the same: the bare `--assume-role` form resolves
+      // the ARN from a live `GetAgentRuntime` response, so it is wire-derived
+      // text on the line the helper beside it just made forge-proof. On a real
+      // ARN the call is a no-op, so the integ grep is unaffected.
       logger.warn(
-        `--assume-role: STS AssumeRole(${args.assumeRoleArn}) failed: ${describeAwsFailureForWarn(err, 'STS AssumeRole')}. ` +
+        `--assume-role: STS AssumeRole(${flattenToOneLine(args.assumeRoleArn)}) failed: ${describeAwsFailureForWarn(err, 'STS AssumeRole')}. ` +
           "Falling back to the developer's shell credentials."
       );
     }

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -13,7 +13,7 @@ import {
 import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { resolveContainerFallbackRegion } from './local-start-api.js';
 import { getLogger } from '../../utils/logger.js';
-import { describeAwsFailureForWarn } from '../../local/credential-error.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -1063,9 +1063,15 @@ export async function resolveLambdaContainerEnv(
       // for `tests/integration/local-studio/verify.sh`, which proves
       // `--assume-role` threaded from the CLI to the spawned child by
       // finding the ARN in the studio log ring.
+      //
+      // It is FLATTENED all the same. The bare `--assume-role` form resolves
+      // the ARN from a live `GetFunctionConfiguration` response, so under this
+      // file's own hijacked-endpoint model it is wire-derived text sitting on
+      // the very line the helper beside it just made forge-proof. On a real
+      // ARN the call is a no-op, so the integ grep is unaffected.
       const reason = describeAwsFailureForWarn(err, 'STS AssumeRole');
       logger.warn(
-        `--assume-role: STS AssumeRole(${resolvedAssumeRoleArn}) failed: ${reason}. ` +
+        `--assume-role: STS AssumeRole(${flattenToOneLine(resolvedAssumeRoleArn)}) failed: ${reason}. ` +
           "Falling back to the developer's shell credentials."
       );
     }

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -1164,7 +1164,9 @@ export async function resolveAssumeRoleArnForLambda(
   }
   const fromState = resolveExecutionRoleArnFromState(stateForRoleHint, lambdaLogicalId);
   if (fromState) {
-    logger.info(`--assume-role: auto-resolved execution role from state: ${fromState}`);
+    logger.info(
+      `--assume-role: auto-resolved execution role from state: ${flattenToOneLine(fromState)}`
+    );
     return fromState;
   }
   const fnPhysicalId = stateForRoleHint.resources[lambdaLogicalId]?.physicalId;
@@ -1175,8 +1177,18 @@ export async function resolveAssumeRoleArnForLambda(
     // carries the full ARN.
     const liveArn = await stateProvider.resolveLambdaExecutionRoleArn(fnPhysicalId);
     if (liveArn) {
+      // Issue #570: FLATTENED, and this site is the reason the failure warns
+      // below are not enough on their own. `liveArn` is the deployed
+      // `Configuration.Role` straight off a `GetFunctionConfiguration` response,
+      // validated only by `startsWith('arn:')`, and `info` is a DEFAULT level
+      // that `cdkl studio` mirrors into an HTTP-served log ring. This fires on
+      // SUCCESS, so it is strictly more reachable than the failure path.
+      //
+      // Deliberately not LENGTH-capped here: unlike a service message, an ARN
+      // has a shape, so the bound belongs at the `startsWith('arn:')`
+      // resolution point rather than at the log line. Recorded in issue #579.
       logger.info(
-        `--assume-role: auto-resolved execution role from GetFunctionConfiguration: ${liveArn}`
+        `--assume-role: auto-resolved execution role from GetFunctionConfiguration: ${flattenToOneLine(liveArn)}`
       );
       return liveArn;
     }

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -13,6 +13,7 @@ import {
 import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { resolveContainerFallbackRegion } from './local-start-api.js';
 import { getLogger } from '../../utils/logger.js';
+import { describeAwsFailureForWarn } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -693,7 +694,16 @@ export function envHasCrossStackIntrinsic(
   return false;
 }
 
-async function resolvePseudoParametersForInvoke(
+/**
+ * Build the AWS pseudo-parameter bag (`${AWS::AccountId}` / `${AWS::Region}` /
+ * partition / URL suffix) that `cdkl invoke`'s env-var substitution consumes.
+ *
+ * Exported so the issue #570 site-level test can drive the STS failure branch
+ * with a mocked STS client -- the same reason `resolveLambdaContainerEnv`
+ * below is exported. A helper being correct says nothing about whether a
+ * given site actually routes through it.
+ */
+export async function resolvePseudoParametersForInvoke(
   stackRegion: string | undefined,
   options: { region?: string; profile?: string }
 ): Promise<
@@ -721,8 +731,12 @@ async function resolvePseudoParametersForInvoke(
       sts.destroy();
     }
   } catch (err) {
+    // Issue #570: never interpolate the SDK error's `message` into this
+    // default-level line -- see `describeAwsFailureForWarn` in
+    // `src/local/credential-error.ts` for which half of it prints here and
+    // which is withheld to `debug`.
     logger.warn(
-      `Resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${err instanceof Error ? err.message : String(err)}. ` +
+      `Resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${describeAwsFailureForWarn(err, 'STS GetCallerIdentity')}. ` +
         'Substitution will be skipped; affected env entries will be dropped with per-key warnings.'
     );
   }
@@ -1037,7 +1051,19 @@ export async function resolveLambdaContainerEnv(
       if (stsRegion) dockerEnv['AWS_REGION'] = stsRegion;
       assumeSucceeded = true;
     } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
+      // Issue #570: not on the issue's list of six, but the same class --
+      // `assumeRoleCredentials` resolves the credential chain and then calls
+      // STS, so both populations land here. See `describeAwsFailureForWarn`
+      // in `src/local/credential-error.ts`.
+      //
+      // `resolvedAssumeRoleArn` KEEPS printing. It is the developer's own
+      // `--assume-role` value or an ARN read from their own deployed stack
+      // state, and an ARN is a public identifier -- the same call issue #555
+      // made for the access-key-id it left quoted. It is also load-bearing
+      // for `tests/integration/local-studio/verify.sh`, which proves
+      // `--assume-role` threaded from the CLI to the spawned child by
+      // finding the ARN in the studio log ring.
+      const reason = describeAwsFailureForWarn(err, 'STS AssumeRole');
       logger.warn(
         `--assume-role: STS AssumeRole(${resolvedAssumeRoleArn}) failed: ${reason}. ` +
           "Falling back to the developer's shell credentials."

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -1110,12 +1110,25 @@ function materializeInlineCode(handler: string, source: string, fileExtension: s
   return dir;
 }
 
-function suggestAssumeRoleFromState(state: StackState, logicalId: string): void {
+/**
+ * Suggest `--assume-role` when the deployed function's execution role is
+ * known and the user did not ask for it.
+ *
+ * Exported for the issue #570 ARN-flatten test. This is the MOST reachable of
+ * the sites that print a wire-derived ARN: its caller is guarded on
+ * `options.assumeRole === undefined`, so it fires on a plain
+ * `cdkl invoke --from-cfn-stack <fn>` with no role flag at all. The ARN comes
+ * from the same `resolveExecutionRoleArnFromState` whose other readers are
+ * flattened, `info` is a default level, and `cdkl studio` splits an invoke
+ * child's stdout on `\n` and emits every line as its own ring entry -- so an
+ * unflattened newline here is two entries, the second entirely attacker-chosen.
+ */
+export function suggestAssumeRoleFromState(state: StackState, logicalId: string): void {
   const logger = getLogger();
   const roleArn = resolveExecutionRoleArnFromState(state, logicalId);
   if (roleArn) {
     logger.info(
-      `Hint: the deployed function uses execution role ${roleArn}. ` +
+      `Hint: the deployed function uses execution role ${flattenToOneLine(roleArn)}. ` +
         `Re-run with --assume-role to invoke under the deployed function's narrow permissions.`
     );
   }
@@ -1186,7 +1199,8 @@ export async function resolveAssumeRoleArnForLambda(
       //
       // Deliberately not LENGTH-capped here: unlike a service message, an ARN
       // has a shape, so the bound belongs at the `startsWith('arn:')`
-      // resolution point rather than at the log line. Recorded in issue #579.
+      // resolution point rather than at the log line. Recorded in issue #579
+      // (which carries the ARN-bound paragraph as well as the relay list).
       logger.info(
         `--assume-role: auto-resolved execution role from GetFunctionConfiguration: ${flattenToOneLine(liveArn)}`
       );

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -8,6 +8,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
+import { describeAwsFailureForWarn } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -584,8 +585,12 @@ export async function buildEcsImageResolutionContext(
     try {
       accountId = await resolveCallerAccountId(region, options.profile);
     } catch (err) {
+      // Issue #570: never interpolate the SDK error's `message` into this
+      // default-level line -- see `describeAwsFailureForWarn` in
+      // `src/local/credential-error.ts` for which half of it prints here and
+      // which is withheld to `debug`.
       logger.warn(
-        `Resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${err instanceof Error ? err.message : String(err)}. ` +
+        `Resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${describeAwsFailureForWarn(err, 'STS GetCallerIdentity')}. ` +
           'Substitution will be skipped; affected env / secret entries will be dropped with per-key warnings.'
       );
     }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -3665,9 +3665,9 @@ export async function loadStateForRoutedStacks(
  * the state record's region (returned by the active `LocalStateProvider`).
  *
  * Exported so the issue #570 site-level test can drive the STS failure
- * branch with a mocked STS client -- the same reason
- * `applyAgentCoreCredentialEnv` below is exported. A helper being correct
- * says nothing about whether a given site actually routes through it.
+ * branch with a mocked STS client. A helper being correct says nothing about
+ * whether a given site actually routes through it, so each of the nine
+ * converted sites is driven separately.
  */
 export async function resolvePseudoParametersForStartApi(
   stateRegion: string,

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -15,6 +15,7 @@ import {
 } from '../options.js';
 import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { getLogger } from '../../utils/logger.js';
+import { describeAwsFailureForWarn } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -3662,8 +3663,13 @@ export async function loadStateForRoutedStacks(
  *
  * Region precedence: `--region` > `AWS_REGION` > `AWS_DEFAULT_REGION` >
  * the state record's region (returned by the active `LocalStateProvider`).
+ *
+ * Exported so the issue #570 site-level test can drive the STS failure
+ * branch with a mocked STS client -- the same reason
+ * `applyAgentCoreCredentialEnv` below is exported. A helper being correct
+ * says nothing about whether a given site actually routes through it.
  */
-async function resolvePseudoParametersForStartApi(
+export async function resolvePseudoParametersForStartApi(
   stateRegion: string,
   options: LocalStartApiOptions
 ): Promise<PseudoParameters | undefined> {
@@ -3683,8 +3689,12 @@ async function resolvePseudoParametersForStartApi(
       sts.destroy();
     }
   } catch (err) {
+    // Issue #570: never interpolate the SDK error's `message` into this
+    // default-level line -- see `describeAwsFailureForWarn` in
+    // `src/local/credential-error.ts` for which half of it prints here and
+    // which is withheld to `debug`.
     logger.warn(
-      `--from-state: resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${err instanceof Error ? err.message : String(err)}. ` +
+      `--from-state: resolver needs \${AWS::AccountId} but STS GetCallerIdentity failed: ${describeAwsFailureForWarn(err, 'STS GetCallerIdentity')}. ` +
         'Substitution will be skipped for AWS::AccountId; affected env entries will be dropped with per-key warnings.'
     );
   }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -15,7 +15,7 @@ import {
 } from '../options.js';
 import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { getLogger } from '../../utils/logger.js';
-import { describeAwsFailureForWarn } from '../../local/credential-error.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -1994,8 +1994,13 @@ export function resolveStartApiAssumeRoleArn(args: {
   if (stateBundle) {
     const fromState = resolveExecutionRoleArnFromState(stateBundle.state, logicalId);
     if (fromState) {
+      // Issue #570: FLATTENED. Under `--from-cfn-stack` the state record is
+      // built from CloudFormation responses, so this ARN is wire-derived and
+      // `info` is a default level studio mirrors into an HTTP-served ring.
       getLogger().info(
-        `--assume-role: auto-resolved execution role for '${logicalId}' from state: ${fromState}`
+        `--assume-role: auto-resolved execution role for '${logicalId}' from state: ${flattenToOneLine(
+          fromState
+        )}`
       );
       return fromState;
     }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -289,6 +289,36 @@ export {
 export { defaultCredentialsLoader, type CredentialsLoader } from './local/sigv4-verify.js';
 
 /**
+ * Rendering an AWS SDK failure into a DEFAULT-level log line (issues #564,
+ * #570).
+ *
+ * Host-side use case: a host CLI that wraps these command factories prints
+ * into the same stream cdk-local does, and a host that mirrors that stream
+ * anywhere a third party can read it (a served log panel, a captured build
+ * log) inherits the same question cdk-local answered here — an AWS SDK
+ * error's `message` is not the CLI's to vouch for. Reuse these rather than
+ * arriving at a second spelling of the policy:
+ *
+ * - `describeAwsFailureForWarn(err, operation)` for a `catch` around an SDK
+ *   CALL, where a modeled service exception's message is the diagnosis and
+ *   must survive: it keeps that message (flattened to one line and length-
+ *   capped) and withholds everything else to a clamped class name plus a
+ *   character count, emitting the full text at `debug` itself.
+ * - `describeCredentialLoadFailure(err)` for a `catch` around credential
+ *   RESOLUTION only, where nothing actionable is lost by withholding all of
+ *   it; the caller emits its own `debug` line.
+ *
+ * The primitives underneath (the name clamp, the service-exception test, the
+ * message sanitizer) are deliberately NOT exported: a host reusing the policy
+ * wants the decision, and a host reassembling it from parts would be free to
+ * reassemble it wrongly.
+ */
+export {
+  describeAwsFailureForWarn,
+  describeCredentialLoadFailure,
+} from './local/credential-error.js';
+
+/**
  * `start-service` Cloud Map service-discovery index — parses the
  * `AWS::ServiceDiscovery::PrivateDnsNamespace` / `::Service` resources in a
  * synthesized stack into the namespace / service lookup maps the local ECS

--- a/src/local/credential-error.ts
+++ b/src/local/credential-error.ts
@@ -13,7 +13,8 @@
  * SCOPE, stated so a later sweep finds a decision rather than an oversight:
  * this module governs those nine plus sigv4-verify's one. It does NOT yet
  * govern the AWS SDK error relays elsewhere under `src/local/**` — notably
- * `formatAwsErrorForWarn` (`cfn-local-state-provider.ts`, seven warn sites)
+ * `formatAwsErrorForWarn` (`cfn-local-state-provider.ts`, six warn sites and
+ * one non-warn caller)
  * and `formatSsmError` (`ssm-parameter-resolver.ts`), which still print an
  * UNCLAMPED wire-derived `err.name`. Those are enumerated and tracked in
  * issue #579; they were left out here so a cross-cutting refactor of eight
@@ -172,8 +173,20 @@ export function stringifyThrown(err: unknown): string {
  * forgery survives truncation.
  */
 export function clampErrorName(err: unknown): string {
-  const rawKind = err instanceof Error ? err.name : 'unknown';
-  return /^[A-Za-z0-9_.-]{1,64}$/.test(rawKind) ? rawKind : 'unknown';
+  // The READ is guarded, not just the value. `err` is a third-party object and
+  // `name` can be an accessor that throws (or a Proxy trap that does), and such
+  // a throw would escape the `catch` this is called from -- the same hazard
+  // {@link stringifyThrown} exists to close, arriving through a different
+  // property.
+  let rawKind: unknown;
+  try {
+    rawKind = err instanceof Error ? err.name : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+  return typeof rawKind === 'string' && /^[A-Za-z0-9_.-]{1,64}$/.test(rawKind)
+    ? rawKind
+    : 'unknown';
 }
 
 /**
@@ -187,10 +200,16 @@ export function clampErrorName(err: unknown): string {
  * cannot tell a misconfiguration from an unreachable endpoint.
  *
  * Node sets `code` on its system errors (`ENOTFOUND`, `ETIMEDOUT`,
- * `ECONNREFUSED`) and it is a fixed enum of bare identifiers chosen by the
- * runtime, not read off a response — the same property that makes a clamped
- * `name` safe to quote. It is clamped anyway, by the same rule, so nothing
- * rests on that argument holding for a value some library sets by hand.
+ * `ECONNREFUSED`) and there it is a fixed enum chosen by the runtime. It is
+ * NOT input-independent in general, though, and the earlier draft of this note
+ * claimed it was: `@smithy/core`'s `decorateServiceException`
+ * (`dist-cjs/submodules/client/index.js:795-802`) copies every key of the
+ * PARSED RESPONSE BODY onto the exception, so an unmodeled error from a
+ * hostile endpoint can carry a `code` of its choosing. The clamp is therefore
+ * load-bearing rather than belt-and-braces, exactly as it is for
+ * {@link clampErrorName}: what survives is at most 64 characters matching
+ * `[A-Za-z0-9_.-]`, which cannot forge a line, and which is the same residue
+ * the class name already accepts.
  *
  * `undefined` rather than `'unknown'` when there is none, so the caller can
  * omit the field entirely instead of printing a placeholder that says less
@@ -198,7 +217,12 @@ export function clampErrorName(err: unknown): string {
  */
 export function clampErrorCode(err: unknown): string | undefined {
   if (!err || typeof err !== 'object') return undefined;
-  const raw = (err as { code?: unknown }).code;
+  let raw: unknown;
+  try {
+    raw = (err as { code?: unknown }).code;
+  } catch {
+    return undefined;
+  }
   if (typeof raw !== 'string') return undefined;
   return /^[A-Za-z0-9_.-]{1,64}$/.test(raw) ? raw : undefined;
 }
@@ -224,9 +248,17 @@ export function clampErrorCode(err: unknown): string | undefined {
 export function isAwsServiceException(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const candidate = err as { $fault?: unknown; $metadata?: unknown };
-  return (
-    Boolean(candidate.$metadata) && (candidate.$fault === 'client' || candidate.$fault === 'server')
-  );
+  try {
+    return (
+      Boolean(candidate.$metadata) &&
+      (candidate.$fault === 'client' || candidate.$fault === 'server')
+    );
+  } catch {
+    // A throwing accessor means the shape cannot be established, and an
+    // unestablished shape is the withheld bucket -- the same direction every
+    // other unknown takes.
+    return false;
+  }
 }
 
 /**
@@ -364,10 +396,12 @@ export function describeCredentialLoadFailure(err: unknown): string {
  * see. Note that this puts the full text into that ring for a
  * `--verbose` studio run; see `docs/troubleshooting.md`.
  *
- * ORDERING: the `debug` line is emitted while the `warn`'s template is being
- * evaluated, so under `--verbose` it prints immediately ABOVE the `warn` that
- * refers to it. Left as is — restructuring every call site to log afterwards
- * would buy an ordering nobody reads top-down anyway.
+ * ORDERING: the `debug` line is emitted when THIS function runs, which is
+ * before the `warn` at every site — inline in the `warn`'s template at eight of
+ * them, and a couple of statements earlier at the one that hoists the result
+ * into a `const reason`. Either way it prints immediately ABOVE the `warn` that
+ * refers to it under `--verbose`. Left as is: restructuring every call site to
+ * log afterwards would buy an ordering nobody reads top-down anyway.
  */
 export function describeAwsFailureForWarn(err: unknown, operation: string): string {
   if (isAwsServiceException(err)) {

--- a/src/local/credential-error.ts
+++ b/src/local/credential-error.ts
@@ -6,9 +6,18 @@
  *
  * Issue #564 settled the policy for one site — the credential-chain failure
  * in {@link file://./sigv4-verify.ts} — and #570 found the same shape at nine
- * more, spread across four `src/cli/commands/*.ts` files. Every one of them
+ * more, spread across five `src/cli/commands/*.ts` files. Every one of them
  * relays a third-party error's `message` into a `logger.warn`, so they share
  * one question and must not grow nine answers to it.
+ *
+ * SCOPE, stated so a later sweep finds a decision rather than an oversight:
+ * this module governs those nine plus sigv4-verify's one. It does NOT yet
+ * govern the AWS SDK error relays elsewhere under `src/local/**` — notably
+ * `formatAwsErrorForWarn` (`cfn-local-state-provider.ts`, seven warn sites)
+ * and `formatSsmError` (`ssm-parameter-resolver.ts`), which still print an
+ * UNCLAMPED wire-derived `err.name`. Those are enumerated and tracked in
+ * issue #579; they were left out here so a cross-cutting refactor of eight
+ * more files would not share a review with the policy that justifies it.
  *
  * # The two axes that decide it
  *
@@ -43,15 +52,18 @@
  *
  *   1. the credential chain failed before the request went out, which is
  *      #564's population exactly, and
- *   2. STS answered with a modeled service exception — `ExpiredToken`,
- *      `AccessDenied`, `InvalidClientTokenId` — whose message IS the
- *      diagnosis the user needs, and which never went near
- *      `credential_process`.
+ *   2. STS answered with a modeled service exception — `ExpiredTokenException`,
+ *      `AccessDenied` — whose message IS the diagnosis the user needs, and
+ *      which never went near `credential_process`. (Spelled as the SDK
+ *      spells them: `@aws-sdk/client-sts` models `ExpiredTokenException`
+ *      (`dist-cjs/models/errors.js:6`), while `AccessDenied` is unmodeled and
+ *      arrives as the wire code verbatim — which is exactly why the name is
+ *      clamped rather than trusted.)
  *
  * Blanket-withholding would turn the single commonest failure of these
- * commands (`ExpiredToken: The security token included in the request is
- * expired`) into a class name and a character count. So the split is by
- * population, via {@link describeAwsFailureForWarn}.
+ * commands (`ExpiredTokenException: The security token included in the
+ * request is expired`) into a class name and a character count. So the split
+ * is by population, via {@link describeAwsFailureForWarn}.
  *
  * # The safe state is defined POSITIVELY
  *
@@ -60,10 +72,27 @@
  * race here. It is the SDK's own structural test for "this came off the wire
  * as a modeled service error" ({@link isAwsServiceException}). Anything that
  * does not match — a chain failure, a socket error, a bare `throw 'x'` — is
- * withheld. An unrecognised shape therefore fails toward withholding, and so
- * does a hostile endpoint that forges `x-amzn-errortype:
- * CredentialsProviderError` to dodge the branch: it lands in the withheld
- * bucket, which discloses strictly less.
+ * withheld. An unrecognised shape therefore fails toward withholding.
+ *
+ * A hostile endpoint cannot steer the discriminator into disclosing MORE.
+ * `$fault` / `$metadata` are set by the SDK from the HTTP response, not from
+ * anything the body names, so forging `x-amzn-errortype:
+ * CredentialsProviderError` only changes `err.name` — the response is still a
+ * service response, so the error stays on the KEPT branch and its message is
+ * still the sanitized, capped one the endpoint could have sent under any
+ * other name. What the endpoint cannot do is move a `credential_process`
+ * command line onto that branch: that text originates locally, inside a
+ * `CredentialsProviderError` that never acquires `$fault`.
+ *
+ * # What this does NOT close
+ *
+ * A single-LINE forged string still reaches readers other than a human.
+ * `cdkl studio` matches every serve-child stdout line against an unanchored
+ * ready-line regex and proxies to the URL it captures, so a message
+ * containing `Server listening on http://...` can redirect the studio proxy.
+ * That is not fixed here — the sanitizer bounds the line, it does not stop a
+ * machine from reading it — and it predates this change (an ordinary handler
+ * log line trips the same matcher). Tracked in issue #578.
  */
 import { getLogger } from '../utils/logger.js';
 
@@ -148,6 +177,33 @@ export function clampErrorName(err: unknown): string {
 }
 
 /**
+ * The thrown value's `code`, when it is a bare identifier, else `undefined`.
+ *
+ * This exists because withholding by class name alone is not discriminating
+ * enough for the population that actually reaches the withheld branch most
+ * often. `Region is missing`, `getaddrinfo ENOTFOUND sts.<region>.amazonaws.com`
+ * and `connect ETIMEDOUT 169.254.169.254:80` all arrive as a plain `Error`, so
+ * all three render as `Error; N-character message withheld` and the reader
+ * cannot tell a misconfiguration from an unreachable endpoint.
+ *
+ * Node sets `code` on its system errors (`ENOTFOUND`, `ETIMEDOUT`,
+ * `ECONNREFUSED`) and it is a fixed enum of bare identifiers chosen by the
+ * runtime, not read off a response — the same property that makes a clamped
+ * `name` safe to quote. It is clamped anyway, by the same rule, so nothing
+ * rests on that argument holding for a value some library sets by hand.
+ *
+ * `undefined` rather than `'unknown'` when there is none, so the caller can
+ * omit the field entirely instead of printing a placeholder that says less
+ * than nothing.
+ */
+export function clampErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const raw = (err as { code?: unknown }).code;
+  if (typeof raw !== 'string') return undefined;
+  return /^[A-Za-z0-9_.-]{1,64}$/.test(raw) ? raw : undefined;
+}
+
+/**
  * Is `err` a modeled AWS service exception — i.e. did the SDK parse it out of
  * a service RESPONSE, rather than raise it while assembling the request?
  *
@@ -174,25 +230,67 @@ export function isAwsServiceException(err: unknown): boolean {
 }
 
 /**
+ * Replace every character that could make one emitted line render as more than
+ * one line, or render in an order it was not written in, with a space.
+ *
+ * Four Unicode categories, each measured rather than assumed (see the fixture
+ * in `tests/unit/local/credential-error.test.ts`):
+ *
+ *   - `Cc` — the C0/C1 controls, which is `\n` / `\r` (a forged extra line in
+ *     the studio ring) and `\x1b` (an ANSI escape in a terminal). U+0085 NEL
+ *     lives here too.
+ *   - `Cf` — the format characters, which is U+202E RIGHT-TO-LEFT OVERRIDE and
+ *     friends: they forge how the REST of the line reads. The cost is that a
+ *     ZWJ inside an emoji or an Indic cluster is replaced too; an AWS error
+ *     message is ASCII, so that is a trade with no observed downside.
+ *   - `Zl` / `Zp` — U+2028 and U+2029. Neither is in `Cc` or `Cf`, and both are
+ *     forced line breaks in the studio UI's `<pre>`, so leaving them out would
+ *     have left the forged-line case open in HTML while closing it in a
+ *     terminal.
+ *   - `Cs` — a LONE surrogate, which is not a character at all and breaks JSON
+ *     encoding of the log event. With the `u` flag a well-formed pair is one
+ *     code point and does NOT match, so emoji survive.
+ *
+ * Used by both branches of {@link describeAwsFailureForWarn}: the kept
+ * message, and the `debug` line carrying the withheld one — because the
+ * `debug` stream is the SAME studio ring under `--verbose`, so a text that is
+ * unsafe to put on a line at `warn` is unsafe to put on a line at `debug`.
+ */
+export function flattenToOneLine(message: string): string {
+  return message.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}\p{Cs}]/gu, ' ');
+}
+
+/**
  * Render a wire-derived service message safe to put on one log line.
  *
  * Two properties, and both are about the LINE rather than about secrecy — the
  * message itself is already judged safe to print by the time this is called:
  *
- *   - No control or format characters. A newline forges a whole log line into
- *     the studio ring; a bidi override (U+202E) forges how the rest of the
- *     line READS in the studio UI. Both become a space, so the text stays
- *     legible and the count of lines cdk-local emitted stays honest.
+ *   - No line breaks and no rendering-direction control, via
+ *     {@link flattenToOneLine}.
  *   - Bounded length, with the true length named when it is exceeded. The
  *     suffix names the character count of the SANITIZED message rather than
  *     of the raw one, because the sanitized string is what the truncated
  *     prefix is a prefix OF; quoting the raw length would describe a string
  *     the reader can never see.
+ *
+ * The cut is made on CODE POINTS rather than UTF-16 units, so a truncation
+ * landing inside an astral character cannot emit half of a surrogate pair. The
+ * count in the suffix is the code-point count for the same reason: the prefix
+ * and the number must describe the same string.
  */
 export function sanitizeServiceExceptionMessage(message: string): string {
-  const flattened = message.replace(/[\p{Cc}\p{Cf}]/gu, ' ');
-  if (flattened.length <= SERVICE_MESSAGE_MAX) return flattened;
-  return `${flattened.slice(0, SERVICE_MESSAGE_MAX)}[... truncated; ${flattened.length}-character message]`;
+  // Code points are exactly the unit wanted here. `no-misused-spread`'s concern
+  // is that spreading a string splits grapheme CLUSTERS (a ZWJ emoji sequence, a
+  // combining mark), and that is accepted: the input is an AWS error message,
+  // and the property being bought is that the cut cannot land inside a surrogate
+  // PAIR and emit half of one. `Intl.Segmenter` would preserve clusters and is
+  // what the rule suggests, but it makes the cap locale-dependent, which a
+  // log-line bound must not be.
+  // oxlint-disable-next-line typescript/no-misused-spread
+  const points = [...flattenToOneLine(message)];
+  if (points.length <= SERVICE_MESSAGE_MAX) return points.join('');
+  return `${points.slice(0, SERVICE_MESSAGE_MAX).join('')}[... truncated; ${points.length}-character message]`;
 }
 
 /**
@@ -202,7 +300,16 @@ export function sanitizeServiceExceptionMessage(message: string): string {
  * What is reported instead is input-INDEPENDENT: the clamped class name (see
  * {@link clampErrorName}), which is the same discriminator
  * `ecs-secrets-resolver.ts` reports for the JSON parse failure it must not
- * echo.
+ * echo, plus the clamped {@link clampErrorCode} when the throw carries one.
+ *
+ * Withholding is NOT free, and the cost lands on cdk-local's own text as well
+ * as on the SDK's: `role-arn.ts`'s
+ * `AssumeRole(<arn>) returned no usable credentials.` is a plain `Error` with
+ * no `$fault`, so it is withheld like any other. That is a real diagnostic
+ * loss, accepted because the alternative — an allow-list of messages that may
+ * print — is the deny-list this design rejects, wearing the other sign. The
+ * fix is to make cdk-local's own throws identifiable rather than to guess at
+ * their text; it is not done here, and is noted in issue #579.
  *
  * The LENGTH is reported, unlike in `ecs-secrets-resolver.ts`, and the
  * difference is deliberate: there the user already knows which secret it is
@@ -223,7 +330,9 @@ export function sanitizeServiceExceptionMessage(message: string): string {
  * exists for.
  */
 export function describeCredentialLoadFailure(err: unknown): string {
-  return `${clampErrorName(err)}; ${stringifyThrown(err).length}-character message withheld, logged at debug level under --verbose`;
+  const code = clampErrorCode(err);
+  const kind = code === undefined ? clampErrorName(err) : `${clampErrorName(err)} ${code}`;
+  return `${kind}; ${stringifyThrown(err).length}-character message withheld, logged at debug level under --verbose`;
 }
 
 /**
@@ -245,11 +354,27 @@ export function describeCredentialLoadFailure(err: unknown): string {
  * The `debug` line fires ONLY on the withheld branch. On the service-exception
  * branch the `warn` already carries the message, and repeating it verbatim one
  * level down would say nothing the reader did not just read.
+ *
+ * It is FLATTENED (not capped). Flattened because the `debug` stream is not a
+ * private channel: it is the same stdout `cdkl studio` mirrors into the log
+ * ring it serves over HTTP, so a `\n` in the withheld text would forge a line
+ * there exactly as it would at `warn`. Not capped, because being able to read
+ * the whole withheld message is the entire reason the line exists — the
+ * `warn`'s character count is what tells the reader how much they are about to
+ * see. Note that this puts the full text into that ring for a
+ * `--verbose` studio run; see `docs/troubleshooting.md`.
+ *
+ * ORDERING: the `debug` line is emitted while the `warn`'s template is being
+ * evaluated, so under `--verbose` it prints immediately ABOVE the `warn` that
+ * refers to it. Left as is — restructuring every call site to log afterwards
+ * would buy an ordering nobody reads top-down anyway.
  */
 export function describeAwsFailureForWarn(err: unknown, operation: string): string {
   if (isAwsServiceException(err)) {
     return `${clampErrorName(err)}: ${sanitizeServiceExceptionMessage(stringifyThrown(err))}`;
   }
-  getLogger().debug(`${operation}: the AWS SDK's own failure message was: ${stringifyThrown(err)}`);
+  getLogger().debug(
+    `${operation}: the AWS SDK's own failure message was: ${flattenToOneLine(stringifyThrown(err))}`
+  );
   return describeCredentialLoadFailure(err);
 }

--- a/src/local/credential-error.ts
+++ b/src/local/credential-error.ts
@@ -11,8 +11,11 @@
  * one question and must not grow nine answers to it.
  *
  * SCOPE, stated so a later sweep finds a decision rather than an oversight:
- * this module governs those nine plus sigv4-verify's one. It does NOT yet
- * govern the AWS SDK error relays elsewhere under `src/local/**` — notably
+ * this module governs those nine plus sigv4-verify's one, and its
+ * {@link flattenToOneLine} additionally covers every other wire-derived value
+ * printed on those lines (the role ARN, on the failure AND success paths). It
+ * does NOT yet govern the AWS SDK error relays elsewhere under
+ * `src/local/**` — notably
  * `formatAwsErrorForWarn` (`cfn-local-state-provider.ts`, six warn sites and
  * one non-warn caller)
  * and `formatSsmError` (`ssm-parameter-resolver.ts`), which still print an
@@ -283,10 +286,15 @@ export function isAwsServiceException(err: unknown): boolean {
  *     encoding of the log event. With the `u` flag a well-formed pair is one
  *     code point and does NOT match, so emoji survive.
  *
- * Used by both branches of {@link describeAwsFailureForWarn}: the kept
- * message, and the `debug` line carrying the withheld one — because the
- * `debug` stream is the SAME studio ring under `--verbose`, so a text that is
- * unsafe to put on a line at `warn` is unsafe to put on a line at `debug`.
+ * Used by both branches of {@link describeAwsFailureForWarn} — the kept
+ * message, and the `debug` line carrying the withheld one, because the `debug`
+ * stream is the SAME studio ring under `--verbose`, so a text unsafe to put on
+ * a line at `warn` is unsafe at `debug` — and, since issue #570's review
+ * rounds, by every OTHER wire-derived value that lands on one of these lines:
+ * `sigv4-verify`'s own `debug` line, and the role ARN at the four warn sites
+ * plus the five `info` / `debug` sites that print an ARN resolved from a live
+ * `GetFunctionConfiguration` / `GetAgentRuntime` response. The last group is
+ * the more reachable one — it fires on SUCCESS.
  */
 export function flattenToOneLine(message: string): string {
   return message.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}\p{Cs}]/gu, ' ');

--- a/src/local/credential-error.ts
+++ b/src/local/credential-error.ts
@@ -1,0 +1,255 @@
+/**
+ * Rendering an AWS SDK failure into a log line cdk-local is willing to print
+ * at DEFAULT level (issues #564, #570).
+ *
+ * # Why a shared module
+ *
+ * Issue #564 settled the policy for one site — the credential-chain failure
+ * in {@link file://./sigv4-verify.ts} — and #570 found the same shape at nine
+ * more, spread across four `src/cli/commands/*.ts` files. Every one of them
+ * relays a third-party error's `message` into a `logger.warn`, so they share
+ * one question and must not grow nine answers to it.
+ *
+ * # The two axes that decide it
+ *
+ * PROVENANCE alone says relay: a credential-chain error is about the
+ * developer's own machine configuration, not something cdk-local fetched out
+ * of a secret store (issue #555's criterion). Two further axes overrule it:
+ *
+ *   LEVEL — these are `warn`, so they print on a plain `cdkl start-api` /
+ *   `cdkl invoke` run rather than only under `--verbose`, and `cdkl studio`
+ *   mirrors a serve child's output into a log ring it serves over HTTP.
+ *   Everybody sees a `warn`; only someone who asked sees a `debug`.
+ *
+ *   RECONSTRUCTION — what can reach the string is not a hint about a secret,
+ *   it is the secret. `@aws-sdk/credential-provider-process` builds its
+ *   failure as `new CredentialsProviderError(error.message)` where `error` is
+ *   the rejection of `promisify(child_process.exec)`, i.e. Node's
+ *   `Command failed: <command line>\n<stderr>`, and a passphrase written on a
+ *   `credential_process` command line is an ordinary thing to have. (Verified
+ *   at `@aws-sdk/credential-provider-process@3.972.{39,41,43}`
+ *   `dist-cjs/index.js:56` in this repo's tree.)
+ *
+ * # Where these sites DIFFER from sigv4-verify's, and why the answer differs
+ *
+ * {@link file://./sigv4-verify.ts}'s `catch` wraps `client.config.credentials()`
+ * and nothing else: credential-chain resolution, with no AWS operation
+ * cdk-local asked for. Nothing actionable is lost by withholding all of it,
+ * so that site withholds unconditionally and keeps the text at `debug`.
+ *
+ * The #570 sites wrap an SDK call cdk-local DID make — STS
+ * `GetCallerIdentity` or `AssumeRole` — so two unrelated error populations
+ * land in one `catch`:
+ *
+ *   1. the credential chain failed before the request went out, which is
+ *      #564's population exactly, and
+ *   2. STS answered with a modeled service exception — `ExpiredToken`,
+ *      `AccessDenied`, `InvalidClientTokenId` — whose message IS the
+ *      diagnosis the user needs, and which never went near
+ *      `credential_process`.
+ *
+ * Blanket-withholding would turn the single commonest failure of these
+ * commands (`ExpiredToken: The security token included in the request is
+ * expired`) into a class name and a character count. So the split is by
+ * population, via {@link describeAwsFailureForWarn}.
+ *
+ * # The safe state is defined POSITIVELY
+ *
+ * The discriminator is not a deny-list of bad error shapes — #564 rejected
+ * that reasoning for the `Command failed:` first line, and it loses the same
+ * race here. It is the SDK's own structural test for "this came off the wire
+ * as a modeled service error" ({@link isAwsServiceException}). Anything that
+ * does not match — a chain failure, a socket error, a bare `throw 'x'` — is
+ * withheld. An unrecognised shape therefore fails toward withholding, and so
+ * does a hostile endpoint that forges `x-amzn-errortype:
+ * CredentialsProviderError` to dodge the branch: it lands in the withheld
+ * bucket, which discloses strictly less.
+ */
+import { getLogger } from '../utils/logger.js';
+
+/**
+ * Longest service-exception message relayed into a `warn` line, in
+ * characters.
+ *
+ * A modeled STS error's message is WIRE-DERIVED — the SDK reads it out of the
+ * response body — so its length is not cdk-local's to assume. Real ones run
+ * to roughly 150 characters (`AccessDenied: User: arn:... is not authorized to
+ * perform: sts:AssumeRole on resource: arn:...`), and the policy-quoting ones
+ * are the longest, so the cap is set well above that: it exists to stop an
+ * unbounded body from becoming an unbounded log line, not to trim ordinary
+ * AWS text, which must survive intact or the branch buys nothing.
+ *
+ * Truncation is announced with the true length (see
+ * {@link sanitizeServiceExceptionMessage}) so a capped line is never mistaken
+ * for a complete one.
+ */
+const SERVICE_MESSAGE_MAX = 512;
+
+/**
+ * Total stringification of a thrown value's message.
+ *
+ * `String(err)` is NOT total. That throw would escape the `catch` it is
+ * called from and turn a warn-and-continue branch into a hard failure — a 500
+ * from the SigV4 authorizer in #564's testing, and a dead `cdkl invoke` here.
+ * One helper rather than an expression repeated per site, so the length
+ * reported in a `warn` and the text printed at `debug` can never describe
+ * different strings.
+ *
+ * CORRECTION to #564, measured on this repo's Node 24: `String(aSymbol)`
+ * does NOT throw — it returns `'Symbol(x)'`, and it is template
+ * INTERPOLATION (`` `${aSymbol}` ``) that raises
+ * `TypeError: Cannot convert a Symbol value to a string`. Since both the old
+ * code and this helper call `String()` explicitly, a `Symbol` throw was never
+ * one of the reachable cases. The two that ARE reachable, both verified:
+ * an object with a null prototype (`TypeError: Cannot convert object to
+ * primitive value`, because it has no `toString`), and any value whose
+ * `toString` / `Symbol.toPrimitive` throws — which a hostile or merely buggy
+ * third-party error object is free to do.
+ *
+ * Named for what it does rather than for one caller: #564 shipped it as
+ * `stringifyCredentialLoadFailure`, and #570 gave it a second population
+ * (service exceptions) for which that name was simply wrong.
+ */
+export function stringifyThrown(err: unknown): string {
+  try {
+    return err instanceof Error ? String(err.message) : String(err);
+  } catch {
+    return '[unstringifiable throw]';
+  }
+}
+
+/**
+ * The throwing class's name, clamped to something no input can forge.
+ *
+ * `err.name` is NOT input-independent, which is the whole reason this is a
+ * function and not an interpolation. For an AWS service exception it is
+ * WIRE-DERIVED: `@aws-sdk/core` builds it from the `x-amzn-errortype` header
+ * / the body's `code` / `__type` through `sanitizeErrorCode`, which splits on
+ * ',' ':' and '#' and does nothing else — no length cap, no newline stripping
+ * (read at `@aws-sdk/core@3.974.13` `protocols/index.js:324`). Such an
+ * exception reaches these call sites, because `credential-provider-ini` calls
+ * the STS `roleAssumer` unwrapped and because the #570 sites invoke STS
+ * directly. So a hostile or hijacked credential endpoint
+ * (`AWS_CONTAINER_CREDENTIALS_FULL_URI`, a redirected IMDS) answering
+ * `x-amzn-errortype: Foo\nWARN: signature verified` could FORGE log lines
+ * into the `warn` stream — and into the studio ring served over HTTP.
+ *
+ * A bare identifier of at most 64 characters is what every real class name is
+ * and what no injected value can be; anything else degrades to `'unknown'`,
+ * which also covers a non-`Error` throw, so the field never names a class the
+ * throw was not.
+ *
+ * Note the WRONG fix: `err.name.slice(0, 64)` keeps the newline, so the
+ * forgery survives truncation.
+ */
+export function clampErrorName(err: unknown): string {
+  const rawKind = err instanceof Error ? err.name : 'unknown';
+  return /^[A-Za-z0-9_.-]{1,64}$/.test(rawKind) ? rawKind : 'unknown';
+}
+
+/**
+ * Is `err` a modeled AWS service exception — i.e. did the SDK parse it out of
+ * a service RESPONSE, rather than raise it while assembling the request?
+ *
+ * This is `ServiceException.isInstance`'s own structural test, reproduced
+ * rather than imported: cdk-local loads `@aws-sdk/client-sts` lazily at every
+ * one of these call sites (a dynamic `import()` inside the `try`), so taking
+ * a static dependency on `@smithy/core` purely to type-test an error would
+ * pull the SDK into the CLI's startup path. The structural form also keeps
+ * working across the several `@smithy/core` copies pnpm resolves in this
+ * tree, where an `instanceof` against one copy's class fails for an error
+ * minted by another.
+ *
+ * The test is deliberately the SDK's and not a name list: a name list would
+ * have to be extended for every new STS error code, and a missing entry would
+ * fail toward DISCLOSING less, which is safe, but also toward hiding the
+ * actionable message, which is the regression this split exists to avoid.
+ */
+export function isAwsServiceException(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const candidate = err as { $fault?: unknown; $metadata?: unknown };
+  return (
+    Boolean(candidate.$metadata) && (candidate.$fault === 'client' || candidate.$fault === 'server')
+  );
+}
+
+/**
+ * Render a wire-derived service message safe to put on one log line.
+ *
+ * Two properties, and both are about the LINE rather than about secrecy — the
+ * message itself is already judged safe to print by the time this is called:
+ *
+ *   - No control or format characters. A newline forges a whole log line into
+ *     the studio ring; a bidi override (U+202E) forges how the rest of the
+ *     line READS in the studio UI. Both become a space, so the text stays
+ *     legible and the count of lines cdk-local emitted stays honest.
+ *   - Bounded length, with the true length named when it is exceeded. The
+ *     suffix names the character count of the SANITIZED message rather than
+ *     of the raw one, because the sanitized string is what the truncated
+ *     prefix is a prefix OF; quoting the raw length would describe a string
+ *     the reader can never see.
+ */
+export function sanitizeServiceExceptionMessage(message: string): string {
+  const flattened = message.replace(/[\p{Cc}\p{Cf}]/gu, ' ');
+  if (flattened.length <= SERVICE_MESSAGE_MAX) return flattened;
+  return `${flattened.slice(0, SERVICE_MESSAGE_MAX)}[... truncated; ${flattened.length}-character message]`;
+}
+
+/**
+ * Describe a credential-chain failure for a default-level log line WITHOUT
+ * relaying the chain's own message (issue #564).
+ *
+ * What is reported instead is input-INDEPENDENT: the clamped class name (see
+ * {@link clampErrorName}), which is the same discriminator
+ * `ecs-secrets-resolver.ts` reports for the JSON parse failure it must not
+ * echo.
+ *
+ * The LENGTH is reported, unlike in `ecs-secrets-resolver.ts`, and the
+ * difference is deliberate: there the user already knows which secret it is
+ * and can read the value at its source, so a character count would be
+ * disclosure buying nothing. Here the user cannot see the withheld message at
+ * all, and the count is what separates a one-line
+ * `Could not load credentials from any providers` (45 characters, measured
+ * against `@aws-sdk/credential-provider-node@3.972.44` `dist-cjs/index.js:144`)
+ * from a multi-hundred-character `Command failed:` dump — which is what tells
+ * them whether their `credential_process` even ran.
+ *
+ * The count is a side channel, and a narrow one: against a KNOWN
+ * `credential_process` template the number is `constant + len(passphrase)`, so
+ * it yields the passphrase's LENGTH. That is accepted rather than overlooked.
+ * It buys the one thing the user cannot otherwise see, the `Command failed:`
+ * dump is not reachable on today's SDK versions anyway, and bucketing the
+ * number would blur exactly the boilerplate-vs-dump distinction the field
+ * exists for.
+ */
+export function describeCredentialLoadFailure(err: unknown): string {
+  return `${clampErrorName(err)}; ${stringifyThrown(err).length}-character message withheld, logged at debug level under --verbose`;
+}
+
+/**
+ * Render an AWS SDK call failure for a `logger.warn` line, and emit the
+ * withheld text at `debug` when it is withheld (issue #570).
+ *
+ * `operation` names the call for the `debug` line — e.g.
+ * `'STS GetCallerIdentity'`. It is cdk-local's own literal at every call
+ * site, never anything read off an error or a response.
+ *
+ * # Why this emits the `debug` line itself
+ *
+ * Because the alternative is nine call sites each free to withhold a message
+ * and forget to print it anywhere. The pairing is the invariant — "withheld
+ * at `warn`" is only acceptable while "in full at `debug`" holds — so it
+ * lives in one function rather than in a convention nine sites must keep. A
+ * tenth site gets it for free.
+ *
+ * The `debug` line fires ONLY on the withheld branch. On the service-exception
+ * branch the `warn` already carries the message, and repeating it verbatim one
+ * level down would say nothing the reader did not just read.
+ */
+export function describeAwsFailureForWarn(err: unknown, operation: string): string {
+  if (isAwsServiceException(err)) {
+    return `${clampErrorName(err)}: ${sanitizeServiceExceptionMessage(stringifyThrown(err))}`;
+  }
+  getLogger().debug(`${operation}: the AWS SDK's own failure message was: ${stringifyThrown(err)}`);
+  return describeCredentialLoadFailure(err);
+}

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -72,7 +72,11 @@
 
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import { getLogger } from '../utils/logger.js';
-import { describeCredentialLoadFailure, stringifyThrown } from './credential-error.js';
+import {
+  describeCredentialLoadFailure,
+  flattenToOneLine,
+  stringifyThrown,
+} from './credential-error.js';
 import { buildIdentityHash } from './authorizer-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
 import type { CachedAuthorizerResult } from './authorizer-cache.js';
@@ -380,7 +384,7 @@ export async function verifySigV4(
     // wraps: this one wraps `loadCredentials()` and nothing else, so every
     // error reaching it is a credential-chain error with no diagnosis
     // cdk-local asked for. Those wrap an STS call cdk-local made, where a
-    // modeled service exception -- `ExpiredToken`, `AccessDenied` -- is the
+    // modeled service exception -- `ExpiredTokenException`, `AccessDenied` -- is the
     // answer the user needs. See {@link file://./credential-error.ts}.
     //
     // Deliberately NOT done: stripping the `Command failed:` first line and
@@ -389,9 +393,15 @@ export async function verifySigV4(
     // passphrase prompt or a token, and the next loader to grow its own
     // format would not be covered at all. Define the safe state positively
     // instead, which is what "input-independent" is.
+    // FLATTENED, for the reason `describeAwsFailureForWarn` gives at its own
+    // debug line: this stream is not a private channel. It is the same stdout
+    // `cdkl studio` mirrors into the log ring it serves over HTTP, so a `\n` in
+    // the chain's message forges a line there under `--verbose` exactly as it
+    // would at `warn`. Not capped -- reading the withheld message whole is why
+    // the line exists.
     logger.debug(
       `AWS_IAM authorizer: the AWS credential chain's own failure message was: ` +
-        `${stringifyThrown(err)}`
+        `${flattenToOneLine(stringifyThrown(err))}`
     );
     const reason = describeCredentialLoadFailure(err);
     const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -72,6 +72,7 @@
 
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import { getLogger } from '../utils/logger.js';
+import { describeCredentialLoadFailure, stringifyThrown } from './credential-error.js';
 import { buildIdentityHash } from './authorizer-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
 import type { CachedAuthorizerResult } from './authorizer-cache.js';
@@ -368,11 +369,19 @@ export async function verifySigV4(
     // Two axes of three say withhold, so the `warn` carries a clamped class
     // name plus a length -- the shape `ecs-secrets-resolver.ts` already uses
     // for the parse failure it must not echo. The class name is made
-    // input-independent by the clamp in
-    // {@link describeCredentialLoadFailure} (it is NOT independent on its
-    // own -- see the note there). The LENGTH is the one input-derived field
-    // that is kept, deliberately, and its cost is weighed in that same
-    // JSDoc.
+    // input-independent by `clampErrorName` in
+    // {@link file://./credential-error.ts} (it is NOT independent on its
+    // own -- see the note there). The LENGTH is the one
+    // input-derived field that is kept, deliberately, and its cost is
+    // weighed in {@link describeCredentialLoadFailure}'s JSDoc.
+    //
+    // This site withholds UNCONDITIONALLY, and the nine #570 sites in
+    // `src/cli/commands/` do not. The difference is what each `catch`
+    // wraps: this one wraps `loadCredentials()` and nothing else, so every
+    // error reaching it is a credential-chain error with no diagnosis
+    // cdk-local asked for. Those wrap an STS call cdk-local made, where a
+    // modeled service exception -- `ExpiredToken`, `AccessDenied` -- is the
+    // answer the user needs. See {@link file://./credential-error.ts}.
     //
     // Deliberately NOT done: stripping the `Command failed:` first line and
     // keeping the rest. That enumerates one known-bad shape and loses the
@@ -382,7 +391,7 @@ export async function verifySigV4(
     // instead, which is what "input-independent" is.
     logger.debug(
       `AWS_IAM authorizer: the AWS credential chain's own failure message was: ` +
-        `${stringifyCredentialLoadFailure(err)}`
+        `${stringifyThrown(err)}`
     );
     const reason = describeCredentialLoadFailure(err);
     const { sigV4StrictByDefault, sigV4OptFlag: optFlag } = getEmbedConfig();
@@ -658,89 +667,6 @@ export function redactSignature(signature: string): string {
     return `<withheld: ${signature.length} characters that are not a signature>`;
   }
   return signature;
-}
-
-/**
- * Describe a credential-chain failure for a default-level log line WITHOUT
- * relaying the chain's own message (issue #564).
- *
- * The message is withheld because of what a credential-chain error CAN
- * carry: `@aws-sdk/credential-provider-process` copies the rejection of
- * `promisify(child_process.exec)` — Node's
- * `Command failed: <command line>\n<stderr>` — into the error it throws, so
- * a passphrase on a `credential_process` command line is already inside a
- * chain error object. On the SDK versions this repo resolves today that
- * object does not actually reach the caller (the chain swallows it and ends
- * on a generic message), which makes this defense in depth rather than a
- * live disclosure. The measurement, and the full reasoning for withholding
- * at `warn` while keeping the text at `debug`, are at the call site in
- * {@link verifySigV4}.
- *
- * What is reported instead is input-INDEPENDENT: `err.name` is set by the
- * throwing class rather than derived from anything the loader read, which is
- * the property that makes quoting it safe, and is the same discriminator
- * `ecs-secrets-resolver.ts` reports for the JSON parse failure it must not
- * echo. `'unknown'` rather than a guessed class name for a non-`Error`
- * throw, so the field never names a class the throw was not -- and the same
- * `'unknown'` for a `name` that is not a bare identifier, so the guarantee
- * does not rest on every provider following the convention.
- *
- * The LENGTH is reported, unlike in `ecs-secrets-resolver.ts`, and the
- * difference is deliberate: there the user already knows which secret it is
- * and can read the value at its source, so a character count would be
- * disclosure buying nothing. Here the user cannot see the withheld message
- * at all, and the count is what separates a one-line
- * `Could not load credentials from any providers` from a multi-hundred-
- * character `Command failed:` dump — which is what tells them whether their
- * `credential_process` even ran. It is the same choice
- * {@link redactAuthorizationSegment} makes when it withholds.
- *
- * The count is a side channel, and a narrow one: against a KNOWN
- * `credential_process` template the number is `constant + len(passphrase)`,
- * so it yields the passphrase's LENGTH. That is accepted rather than
- * overlooked. It buys the one thing the user cannot otherwise see, the
- * `Command failed:` dump is not reachable today anyway (see the call site),
- * and bucketing the number would blur exactly the boilerplate-vs-dump
- * distinction the field exists for.
- */
-export function stringifyCredentialLoadFailure(err: unknown): string {
-  // `String(err)` is not total: a `Symbol` throw, or an object with a null
-  // prototype, raises `TypeError` on conversion. That throw would escape the
-  // `catch` in {@link verifySigV4} and reject the whole authorizer pass -- a
-  // 500 in place of the warn-and-pass the branch exists to produce. One
-  // helper rather than two expressions, so the length reported in the `warn`
-  // and the text printed at `debug` can never describe different strings.
-  try {
-    return err instanceof Error ? String(err.message) : String(err);
-  } catch {
-    return '[unstringifiable throw]';
-  }
-}
-
-export function describeCredentialLoadFailure(err: unknown): string {
-  const rawKind = err instanceof Error ? err.name : 'unknown';
-  // `err.name` comes off the same third-party object whose `message` this
-  // function exists to withhold, and it is NOT always set by the throwing
-  // class: for an AWS service exception it is WIRE-DERIVED. `@aws-sdk/core`
-  // builds it from the `x-amzn-errortype` header / the body's `code` /
-  // `__type`, through `sanitizeErrorCode`, which splits on ',' ':' and '#'
-  // and does nothing else -- no length cap, no newline stripping (read at
-  // `@aws-sdk/core@3.974.13` protocols/index.js:324). Such an exception can
-  // reach this catch, because `credential-provider-ini` calls the STS
-  // `roleAssumer` unwrapped. So a hostile or hijacked credential endpoint
-  // (`AWS_CONTAINER_CREDENTIALS_FULL_URI`, a redirected IMDS) answering with
-  // `x-amzn-errortype: Foo\nWARN: signature verified` could FORGE log lines
-  // into the very `warn` stream -- and into the studio ring served over HTTP
-  // -- that this change exists to keep clean.
-  //
-  // The clamp is therefore not hypothetical hardening: a bare identifier of
-  // at most 64 characters is what every real class name is and what no
-  // injected value can be. Anything else degrades to `unknown`. Note the
-  // wrong fix: `err.name.slice(0, 64)` keeps the newline, so the forgery
-  // survives truncation.
-  const kind = /^[A-Za-z0-9_.-]{1,64}$/.test(rawKind) ? rawKind : 'unknown';
-  const length = stringifyCredentialLoadFailure(err).length;
-  return `${kind}; ${length}-character message withheld, logged at debug level under --verbose`;
 }
 
 /**

--- a/tests/unit/cli/assume-role-arn-log-flatten.test.ts
+++ b/tests/unit/cli/assume-role-arn-log-flatten.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { getLogger } from '../../../src/utils/logger.js';
+import type { StackState } from '../../../src/types/state.js';
+import type { LocalStateRecord } from '../../../src/local/local-state-provider.js';
+import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-resolver.js';
+import {
+  resolveAssumeRoleArnForLambda,
+  resolveExecutionRoleArnFromState,
+} from '../../../src/cli/commands/local-invoke.js';
+import { resolveAssumeRoleArn } from '../../../src/cli/commands/local-invoke-agentcore.js';
+import { resolveStartApiAssumeRoleArn } from '../../../src/cli/commands/local-start-api.js';
+
+/**
+ * Issue #570, third review round — the role ARN on the SUCCESS path.
+ *
+ * The lane started by flattening the ARN on the four `warn` lines that report
+ * an `sts:AssumeRole` FAILURE. A security pass then pointed out that the same
+ * wire-derived ARN is printed by five more lines that fire when the resolution
+ * SUCCEEDS, which makes them strictly more reachable:
+ *
+ *   - `local-invoke.ts` — from state, and from `GetFunctionConfiguration`
+ *   - `local-invoke-agentcore.ts` — from state, and from `GetAgentRuntime`
+ *   - `local-start-api.ts` — from state
+ *
+ * Where the ARN comes from is the point. Under `--from-cfn-stack` the bare
+ * `--assume-role` form reads it out of a live AWS response
+ * (`Configuration.Role`, `roleArn`) or out of a state record built from one,
+ * and the only validation anywhere on that path is `startsWith('arn:')`. Two
+ * of the five are `logger.info`, which is a DEFAULT level, and `cdkl studio`
+ * mirrors every level of a serve child's stdout into a log ring it serves over
+ * HTTP. So a hostile Lambda / AgentCore endpoint answering
+ * `arn:aws:iam::1:role/x\nWARN: ...` forges a line there.
+ *
+ * This file exists because the flatten shipped UNFENCED at both of the
+ * `local-invoke.ts` sites — mutation probes reverted each and all 119 tests
+ * stayed green. That is the third time in this lane a `flattenToOneLine` call
+ * arrived without a test, so every one of the five is driven here.
+ */
+
+/** A forged ARN: `startsWith('arn:')` passes, and the tail forges a line. */
+const FORGED = 'arn:aws:iam::123456789012:role/x\nWARN: signature verified';
+/** What must appear instead — every character, on one line. */
+const FLAT = 'arn:aws:iam::123456789012:role/x WARN: signature verified';
+
+function stateWithRole(logicalId: string, roleArn: string, roleProperty = 'Role'): StackState {
+  return {
+    version: 1,
+    stackName: 'Stack',
+    resources: {
+      [logicalId]: {
+        physicalId: `${logicalId}-physical`,
+        resourceType: 'AWS::Lambda::Function',
+        properties: { [roleProperty]: roleArn },
+        attributes: {},
+        dependencies: [],
+      },
+    },
+    outputs: {},
+    lastModified: 0,
+  } as unknown as StackState;
+}
+
+describe('#570 — a forged newline in a role ARN cannot forge a line on the SUCCESS path', () => {
+  let lines: string[];
+
+  beforeEach(() => {
+    lines = [];
+    for (const level of ['info', 'debug', 'warn'] as const) {
+      vi.spyOn(getLogger(), level).mockImplementation((m: string) => {
+        lines.push(String(m));
+      });
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** The one emitted line that mentions the forged tail. */
+  function forgedLine(): string {
+    const matches = lines.filter((l) => l.includes('signature verified'));
+    expect(matches, 'no log line carried the ARN at all — the fixture missed the site').toHaveLength(
+      1
+    );
+    return matches[0]!;
+  }
+
+  it('premise: the fixture ARN passes the only validation on the path', () => {
+    // Non-vacuity for every case below. If `startsWith('arn:')` rejected this
+    // value, each site would return early and every assertion would pass over
+    // a line that was never emitted.
+    expect(FORGED.startsWith('arn:')).toBe(true);
+    expect(FORGED).toContain('\n');
+    expect(FLAT).not.toContain('\n');
+    // And the state helper really does hand the raw value back.
+    expect(resolveExecutionRoleArnFromState(stateWithRole('Handler', FORGED), 'Handler')).toBe(
+      FORGED
+    );
+  });
+
+  it('local-invoke: from state', async () => {
+    await resolveAssumeRoleArnForLambda(true, stateWithRole('Handler', FORGED), undefined, 'Handler');
+    const line = forgedLine();
+    expect(line).toContain(`from state: ${FLAT}`);
+    expect(line).not.toContain('\n');
+  });
+
+  it('local-invoke: from GetFunctionConfiguration', async () => {
+    // State misses (no Role property), so the live fallback fires.
+    const state = stateWithRole('Handler', FORGED, 'SomethingElse');
+    await resolveAssumeRoleArnForLambda(true, state, {
+      resolveLambdaExecutionRoleArn: vi.fn().mockResolvedValue(FORGED),
+    }, 'Handler');
+    const line = forgedLine();
+    expect(line).toContain(`from GetFunctionConfiguration: ${FLAT}`);
+    expect(line).not.toContain('\n');
+  });
+
+  it('local-invoke-agentcore: from state', async () => {
+    const loaded = stateWithRole('ChatAgent', FORGED, 'RoleArn') as unknown as LocalStateRecord;
+    await resolveAssumeRoleArn(
+      { assumeRole: true } as never,
+      { logicalId: 'ChatAgent', resource: { Properties: {} } } as unknown as ResolvedAgentCoreRuntime,
+      loaded,
+      undefined
+    );
+    const line = forgedLine();
+    expect(line).toContain(`resolved RoleArn from state: ${FLAT}`);
+    expect(line).not.toContain('\n');
+  });
+
+  it('local-invoke-agentcore: from GetAgentRuntime', async () => {
+    const loaded = stateWithRole(
+      'ChatAgent',
+      FORGED,
+      'SomethingElse'
+    ) as unknown as LocalStateRecord;
+    await resolveAssumeRoleArn(
+      { assumeRole: true } as never,
+      { logicalId: 'ChatAgent', resource: { Properties: {} } } as unknown as ResolvedAgentCoreRuntime,
+      loaded,
+      { resolveAgentCoreRuntimeRoleArn: vi.fn().mockResolvedValue(FORGED) }
+    );
+    const line = forgedLine();
+    expect(line).toContain(`from GetAgentRuntime: ${FLAT}`);
+    expect(line).not.toContain('\n');
+  });
+
+  it('local-start-api: from state', () => {
+    resolveStartApiAssumeRoleArn({
+      logicalId: 'Handler',
+      assumeRole: { bareAutoResolve: true } as never,
+      lambdaResource: { Type: 'AWS::Lambda::Function', Properties: {} } as never,
+      stateBundle: { state: stateWithRole('Handler', FORGED) } as never,
+    });
+    const line = forgedLine();
+    expect(line).toContain(`from state: ${FLAT}`);
+    expect(line).not.toContain('\n');
+  });
+});

--- a/tests/unit/cli/assume-role-arn-log-flatten.test.ts
+++ b/tests/unit/cli/assume-role-arn-log-flatten.test.ts
@@ -6,6 +6,7 @@ import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-reso
 import {
   resolveAssumeRoleArnForLambda,
   resolveExecutionRoleArnFromState,
+  suggestAssumeRoleFromState,
 } from '../../../src/cli/commands/local-invoke.js';
 import { resolveAssumeRoleArn } from '../../../src/cli/commands/local-invoke-agentcore.js';
 import { resolveStartApiAssumeRoleArn } from '../../../src/cli/commands/local-start-api.js';
@@ -22,6 +23,13 @@ import { resolveStartApiAssumeRoleArn } from '../../../src/cli/commands/local-st
  *   - `local-invoke-agentcore.ts` — from state, and from `GetAgentRuntime`
  *   - `local-start-api.ts` — from state
  *
+ * A fourth round then found a SIXTH, more reachable than any of them:
+ * `suggestAssumeRoleFromState`'s `Hint:` line, whose caller is guarded on
+ * `options.assumeRole === undefined`, so it fires on a plain
+ * `cdkl invoke --from-cfn-stack <fn>` with no role flag at all. The first
+ * enumeration had walked the assume-role RESOLVERS rather than the readers of
+ * `resolveExecutionRoleArnFromState`.
+ *
  * Where the ARN comes from is the point. Under `--from-cfn-stack` the bare
  * `--assume-role` form reads it out of a live AWS response
  * (`Configuration.Role`, `roleArn`) or out of a state record built from one,
@@ -33,8 +41,9 @@ import { resolveStartApiAssumeRoleArn } from '../../../src/cli/commands/local-st
  *
  * This file exists because the flatten shipped UNFENCED at both of the
  * `local-invoke.ts` sites — mutation probes reverted each and all 119 tests
- * stayed green. That is the third time in this lane a `flattenToOneLine` call
- * arrived without a test, so every one of the five is driven here.
+ * stayed green. That was the third time in this lane a `flattenToOneLine` call
+ * arrived without a test, so all SIX are driven here, each by the exported
+ * function that owns it.
  */
 
 /** A forged ARN: `startsWith('arn:')` passes, and the tail forges a line. */
@@ -143,6 +152,14 @@ describe('#570 — a forged newline in a role ARN cannot forge a line on the SUC
     );
     const line = forgedLine();
     expect(line).toContain(`from GetAgentRuntime: ${FLAT}`);
+    expect(line).not.toContain('\n');
+  });
+
+  it('local-invoke: the no-flag `Hint:` line, the most reachable of the six', () => {
+    // Fires with NO `--assume-role`, on a plain `cdkl invoke --from-cfn-stack`.
+    suggestAssumeRoleFromState(stateWithRole('Handler', FORGED), 'Handler');
+    const line = forgedLine();
+    expect(line).toContain(`uses execution role ${FLAT}`);
     expect(line).not.toContain('\n');
   });
 

--- a/tests/unit/cli/sts-error-relay-sites.test.ts
+++ b/tests/unit/cli/sts-error-relay-sites.test.ts
@@ -1,0 +1,434 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { LocalStateProvider, LocalStateRecord } from '../../../src/local/local-state-provider.js';
+import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-resolver.js';
+import type { ResolvedLambda } from '../../../src/local/lambda-resolver.js';
+import { getLogger } from '../../../src/utils/logger.js';
+
+/**
+ * Issue #570 — the CALL SITES. Nine `logger.warn` lines across five
+ * `src/cli/commands/*.ts` files relayed an AWS SDK error's `message`
+ * verbatim; each now routes through `describeAwsFailureForWarn`.
+ *
+ * Every site is driven SEPARATELY, on purpose. Issue #564 found that
+ * replacing five interpolations at once and probing the symbol reported RED
+ * while two of the five were unfenced: a whole-symbol probe answers "is ANY
+ * of this fenced", not "is EACH". So each row below reaches exactly one
+ * `catch` and asserts against that site's own literal.
+ *
+ * The helper's own behaviour is fenced in
+ * `tests/unit/local/credential-error.test.ts`; this file asserts only that
+ * each site routes through it.
+ */
+
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+// `resolveAgentCoreCodeImageFromS3` continues into an S3 GetObject after the
+// warn under test. Stub it so the test stays hermetic (no network) and fast:
+// without this, each of that site's four cases spends ~550 ms in the SDK's
+// retry loop against a bucket that does not exist.
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class {
+    send(): never {
+      throw new Error('s3 stubbed out for the #570 relay-site test');
+    }
+    destroy(): void {}
+  },
+  GetObjectCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    send = sendMock;
+    destroy(): void {}
+  },
+  AssumeRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+  GetCallerIdentityCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+const { resolvePseudoParametersForInvoke, resolveLambdaContainerEnv } = await import(
+  '../../../src/cli/commands/local-invoke.js'
+);
+const { buildEcsImageResolutionContext: buildRunTaskContext } = await import(
+  '../../../src/cli/commands/local-run-task.js'
+);
+const { buildEcsImageResolutionContext: buildStartServiceContext } = await import(
+  '../../../src/cli/commands/local-start-service.js'
+);
+const { resolvePseudoParametersForStartApi } = await import(
+  '../../../src/cli/commands/local-start-api.js'
+);
+const {
+  applyAgentCoreCredentialEnv,
+  buildAgentCoreImageContext,
+  resolveAgentCoreCodeImageFromS3,
+  resolveHostCredentialsForSigV4,
+} = await import('../../../src/cli/commands/local-invoke-agentcore.js');
+
+// --------------------------------------------------------------------------
+// Fixtures
+// --------------------------------------------------------------------------
+
+/**
+ * The worst string a credential-chain error can carry, reused from #564's
+ * fixture: `@aws-sdk/credential-provider-process` copies the rejection of
+ * `promisify(child_process.exec)` — `Command failed: <command line>\n<stderr>`
+ * — into the error it throws, and both lines can hold a passphrase.
+ */
+const PASSPHRASE = 'hunter2-do-not-log';
+const CHAIN_MESSAGE =
+  `Command failed: /opt/bin/get-creds --vault-passphrase ${PASSPHRASE}\n` +
+  `  vault: unlocked with passphrase ${PASSPHRASE}`;
+
+/** Measured in `credential-error.test.ts`, restated so the expected line is literal. */
+const CHAIN_MESSAGE_LENGTH = 125;
+const WITHHELD = `CredentialsProviderError; ${CHAIN_MESSAGE_LENGTH}-character message withheld, logged at debug level under --verbose`;
+
+class CredentialsProviderError extends Error {
+  override name = 'CredentialsProviderError';
+}
+
+function chainError(): Error {
+  return new CredentialsProviderError(CHAIN_MESSAGE);
+}
+
+/** The service message that must KEEP printing: it is the diagnosis. */
+const SERVICE_MESSAGE = 'The security token included in the request is expired';
+
+function expiredTokenError(): Error {
+  const e = new Error(SERVICE_MESSAGE);
+  Object.defineProperty(e, 'name', { value: 'ExpiredToken' });
+  Object.assign(e, {
+    $fault: 'client',
+    $metadata: { httpStatusCode: 403, requestId: 'req-1' },
+  });
+  return e;
+}
+
+/** A service exception whose wire-derived message carries a forged log line. */
+function forgedServiceError(): Error {
+  const e = new Error('denied\nWARN: signature verified');
+  Object.defineProperty(e, 'name', { value: 'AccessDenied' });
+  Object.assign(e, {
+    $fault: 'client',
+    $metadata: { httpStatusCode: 403 },
+  });
+  return e;
+}
+
+const ROLE_ARN = 'arn:aws:iam::123456789012:role/relay-test';
+
+function ecsStack(): StackInfo {
+  return {
+    stackName: 'MyStack',
+    region: 'us-east-1',
+    template: {
+      Parameters: {
+        SsmDbHost: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/app/db-host' },
+      },
+      Resources: {
+        TaskDef: {
+          Type: 'AWS::ECS::TaskDefinition',
+          Properties: {
+            ContainerDefinitions: [
+              { Name: 'app', Environment: [{ Name: 'DB_HOST', Value: { Ref: 'SsmDbHost' } }] },
+            ],
+          },
+        },
+      },
+    },
+  } as unknown as StackInfo;
+}
+
+function ecsStateProvider(): LocalStateProvider {
+  return {
+    label: '--from-cfn-stack',
+    load: vi.fn().mockResolvedValue({ resources: {}, outputs: {}, region: 'us-east-1' }),
+    buildCrossStackResolver: vi.fn().mockResolvedValue(undefined),
+    resolveTemplateSsmParameters: vi
+      .fn()
+      .mockResolvedValue({ values: { SsmDbHost: 'db.internal' }, secureStringLogicalIds: [] }),
+    dispose: vi.fn(),
+  } as unknown as LocalStateProvider;
+}
+
+function agentRuntime(): ResolvedAgentCoreRuntime {
+  return {
+    stack: { stackName: 'App', region: 'us-east-1' } as ResolvedAgentCoreRuntime['stack'],
+    logicalId: 'ChatAgent',
+    resource: { Type: 'AWS::BedrockAgentCore::Runtime', Properties: {} },
+    containerUri: 'repo:tag',
+    environmentVariables: {},
+    protocol: 'HTTP',
+  } as unknown as ResolvedAgentCoreRuntime;
+}
+
+function agentStack(): StackInfo {
+  return { stackName: 'App', region: 'us-east-1', template: { Resources: {} } } as unknown as StackInfo;
+}
+
+function agentStateProvider(): LocalStateProvider {
+  return {
+    label: '--from-cfn-stack',
+    load: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+  } as unknown as LocalStateProvider;
+}
+
+function assumeRoleLambda(): ResolvedLambda {
+  return {
+    kind: 'zip',
+    stack: {
+      stackName: 'Stack',
+      displayName: 'Stack',
+      artifactId: 'Stack',
+      template: { Resources: {} },
+      dependencyNames: [],
+      region: 'us-east-1',
+    },
+    logicalId: 'Handler',
+    resource: {
+      Type: 'AWS::Lambda::Function',
+      Properties: { Environment: { Variables: { GREETING: 'hello' } } },
+      Metadata: { 'aws:cdk:path': 'Stack/Handler/Resource' },
+    },
+    memoryMb: 256,
+    timeoutSec: 7,
+    layers: [],
+    runtime: 'nodejs20.x',
+    handler: 'index.handler',
+    codePath: '/tmp/code',
+  } as unknown as ResolvedLambda;
+}
+
+/** Swallow whatever the site does AFTER the warn (S3 download, creds throw). */
+async function tolerate(run: () => Promise<unknown>): Promise<void> {
+  try {
+    await run();
+  } catch {
+    // The warn under test is emitted before the failure; the failure itself
+    // belongs to a code path this test deliberately does not stub.
+  }
+}
+
+// --------------------------------------------------------------------------
+// The nine sites
+// --------------------------------------------------------------------------
+
+interface Site {
+  /** `<file>:<enclosing function>` — the identity of the occurrence. */
+  name: string;
+  /**
+   * A literal unique to THIS site's warn text, proving the fixture reached
+   * the intended `catch` and not some other warn the same call emits.
+   *
+   * `local-run-task` and `local-start-service` share a byte-identical
+   * spelling, so for those two the discriminator is the MODULE each row
+   * drives, not the string — which is why every row calls exactly one
+   * command module.
+   */
+  reached: string;
+  /** Whether the site interpolates the role ARN, which must keep printing. */
+  quotesRoleArn: boolean;
+  drive: () => Promise<void>;
+}
+
+const sites: Site[] = [
+  {
+    name: 'local-invoke.ts / resolvePseudoParametersForInvoke',
+    reached:
+      'Resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
+    quotesRoleArn: false,
+    drive: async () => {
+      await tolerate(() => resolvePseudoParametersForInvoke('us-east-1', {}));
+    },
+  },
+  {
+    name: 'local-invoke.ts / resolveLambdaContainerEnv (--assume-role)',
+    reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed: `,
+    quotesRoleArn: true,
+    drive: async () => {
+      await tolerate(() =>
+        resolveLambdaContainerEnv(assumeRoleLambda(), { assumeRole: ROLE_ARN }, undefined)
+      );
+    },
+  },
+  {
+    name: 'local-run-task.ts / buildEcsImageResolutionContext',
+    reached:
+      'Resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
+    quotesRoleArn: false,
+    drive: async () => {
+      await tolerate(() => buildRunTaskContext(ecsStack(), ecsStateProvider(), {} as never));
+    },
+  },
+  {
+    name: 'ecs-service-emulator.ts / buildEcsImageResolutionContext',
+    reached:
+      'Resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
+    quotesRoleArn: false,
+    drive: async () => {
+      await tolerate(() =>
+        buildStartServiceContext(
+          'MyStack:WebService',
+          [ecsStack()],
+          {} as never,
+          ecsStateProvider()
+        )
+      );
+    },
+  },
+  {
+    name: 'local-start-api.ts / resolvePseudoParametersForStartApi',
+    reached:
+      '--from-state: resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
+    quotesRoleArn: false,
+    drive: async () => {
+      await tolerate(() => resolvePseudoParametersForStartApi('us-east-1', {} as never));
+    },
+  },
+  {
+    name: 'local-invoke-agentcore.ts / resolveHostCredentialsForSigV4',
+    reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed for --sigv4 signing: `,
+    quotesRoleArn: true,
+    drive: async () => {
+      await tolerate(() =>
+        resolveHostCredentialsForSigV4(
+          { assumeRole: ROLE_ARN } as never,
+          agentRuntime(),
+          undefined,
+          'us-east-1',
+          undefined
+        )
+      );
+    },
+  },
+  {
+    name: 'local-invoke-agentcore.ts / resolveAgentCoreCodeImageFromS3',
+    reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed for the fromS3 bundle download: `,
+    quotesRoleArn: true,
+    drive: async () => {
+      await tolerate(() =>
+        resolveAgentCoreCodeImageFromS3(
+          agentRuntime(),
+          { runtime: 'python3.12', entryPoint: ['app.py'] } as never,
+          { bucket: 'bkt', key: 'bundle.zip' } as never,
+          { assumeRole: ROLE_ARN } as never,
+          'x86_64',
+          undefined,
+          undefined
+        )
+      );
+    },
+  },
+  {
+    name: 'local-invoke-agentcore.ts / buildAgentCoreImageContext',
+    reached: '--from-cfn-stack: STS GetCallerIdentity failed: ',
+    quotesRoleArn: false,
+    drive: async () => {
+      await tolerate(() =>
+        buildAgentCoreImageContext(agentStack(), agentStateProvider(), {} as never)
+      );
+    },
+  },
+  {
+    name: 'local-invoke-agentcore.ts / applyAgentCoreCredentialEnv',
+    reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed: `,
+    quotesRoleArn: true,
+    drive: async () => {
+      await tolerate(() => applyAgentCoreCredentialEnv({}, { assumeRoleArn: ROLE_ARN }));
+    },
+  },
+];
+
+describe('#570 — no AWS SDK error message reaches a warn unfiltered', () => {
+  let warnLines: string[];
+  let debugLines: string[];
+
+  beforeEach(() => {
+    warnLines = [];
+    debugLines = [];
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'debug').mockImplementation((m: string) => {
+      debugLines.push(String(m));
+    });
+    // Not under test, and one site logs progress before it fails.
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    sendMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** The one warn line this site's fixture produced. */
+  function siteWarn(site: Site): string {
+    const matches = warnLines.filter((l) => l.includes(site.reached));
+    expect(
+      matches,
+      `no warn line at ${site.name} contained its own literal — the fixture did not reach the site`
+    ).toHaveLength(1);
+    return matches[0]!;
+  }
+
+  it('covers every relay site the sweep found, with no row silently dropped', () => {
+    // A table driven off the source could not notice a site being DELETED
+    // from it, so the count is asserted against a literal. Six sites are
+    // from issue #570's body; three more (`resolveLambdaContainerEnv`,
+    // `resolveHostCredentialsForSigV4`, `resolveAgentCoreCodeImageFromS3`)
+    // are the same class and were found while working it.
+    expect(sites).toHaveLength(9);
+    expect(new Set(sites.map((s) => s.name)).size).toBe(9);
+    expect(sites.filter((s) => s.quotesRoleArn)).toHaveLength(4);
+  });
+
+  describe.each(sites)('$name', (site) => {
+    it('withholds a credential-chain message from the warn and prints it at debug', async () => {
+      sendMock.mockRejectedValue(chainError());
+      await site.drive();
+
+      const line = siteWarn(site);
+      // The literal shape, not a substring of it: `toContain(WITHHELD)`
+      // would still pass if the raw message were appended alongside, so the
+      // absence assertions below carry the other half.
+      expect(line).toContain(`${site.reached}${WITHHELD}`);
+      expect(line).not.toContain(PASSPHRASE);
+      expect(line).not.toContain('Command failed');
+      expect(line).not.toContain('\n');
+
+      // Withheld at `warn` is only acceptable while in full at `debug`.
+      expect(debugLines.join('\n')).toContain(PASSPHRASE);
+    });
+
+    it('keeps a modeled STS service exception message, which is the diagnosis', async () => {
+      sendMock.mockRejectedValue(expiredTokenError());
+      await site.drive();
+
+      expect(siteWarn(site)).toContain(`${site.reached}ExpiredToken: ${SERVICE_MESSAGE}`);
+    });
+
+    it('flattens a forged newline inside a kept service message', async () => {
+      sendMock.mockRejectedValue(forgedServiceError());
+      await site.drive();
+
+      const line = siteWarn(site);
+      expect(line).toContain(`${site.reached}AccessDenied: denied WARN: signature verified`);
+      expect(line).not.toContain('\n');
+    });
+
+    it('keeps the role ARN when the site quotes one', async () => {
+      if (!site.quotesRoleArn) return;
+      sendMock.mockRejectedValue(chainError());
+      await site.drive();
+      expect(siteWarn(site)).toContain(ROLE_ARN);
+    });
+  });
+});

--- a/tests/unit/cli/sts-error-relay-sites.test.ts
+++ b/tests/unit/cli/sts-error-relay-sites.test.ts
@@ -103,7 +103,10 @@ const SERVICE_MESSAGE = 'The security token included in the request is expired';
 
 function expiredTokenError(): Error {
   const e = new Error(SERVICE_MESSAGE);
-  Object.defineProperty(e, 'name', { value: 'ExpiredToken' });
+  // The name the SDK actually sets: `@aws-sdk/client-sts` models this one, at
+  // `dist-cjs/models/errors.js:6`. (`AccessDenied`, used below, is NOT modeled
+  // and arrives as the wire code verbatim -- both shapes are exercised.)
+  Object.defineProperty(e, 'name', { value: 'ExpiredTokenException' });
   Object.assign(e, {
     $fault: 'client',
     $metadata: { httpStatusCode: 403, requestId: 'req-1' },
@@ -228,10 +231,13 @@ interface Site {
    * A literal unique to THIS site's warn text, proving the fixture reached
    * the intended `catch` and not some other warn the same call emits.
    *
-   * `local-run-task` and `local-start-service` share a byte-identical
-   * spelling, so for those two the discriminator is the MODULE each row
-   * drives, not the string — which is why every row calls exactly one
-   * command module.
+   * TWO pairs share a byte-identical spelling, not one: `local-run-task` /
+   * `ecs-service-emulator` (the `${AWS::AccountId}` line) and
+   * `local-invoke` / `local-invoke-agentcore` (the bare `--assume-role: STS
+   * AssumeRole(<arn>) failed: ` line). For those four rows the discriminator
+   * is the MODULE the row drives, not the string — which is why every row
+   * calls exactly one command module and no row is ever consolidated with
+   * another on the strength of its literal.
    */
   reached: string;
   /** Whether the site interpolates the role ARN, which must keep printing. */
@@ -388,6 +394,22 @@ describe('#570 — no AWS SDK error message reaches a warn unfiltered', () => {
     expect(sites).toHaveLength(9);
     expect(new Set(sites.map((s) => s.name)).size).toBe(9);
     expect(sites.filter((s) => s.quotesRoleArn)).toHaveLength(4);
+
+    // The role ARN is fenced by `reached` itself, not by a separate case: for
+    // the four quoting sites the ARN is INSIDE the literal that `siteWarn`
+    // requires to appear in a real warn line, so every one of this row's other
+    // cases already fails if the ARN stops printing. A dedicated
+    // `expect(line).toContain(ROLE_ARN)` could not fail after `siteWarn`
+    // returned, which is why there is no such case.
+    //
+    // What this asserts is the remaining half: that `quotesRoleArn` agrees
+    // with the literal, so the flag cannot drift into describing a site it no
+    // longer describes.
+    for (const s of sites) {
+      expect(s.reached.includes(ROLE_ARN), `${s.name}: quotesRoleArn disagrees with reached`).toBe(
+        s.quotesRoleArn
+      );
+    }
   });
 
   describe.each(sites)('$name', (site) => {
@@ -412,7 +434,9 @@ describe('#570 — no AWS SDK error message reaches a warn unfiltered', () => {
       sendMock.mockRejectedValue(expiredTokenError());
       await site.drive();
 
-      expect(siteWarn(site)).toContain(`${site.reached}ExpiredToken: ${SERVICE_MESSAGE}`);
+      expect(siteWarn(site)).toContain(
+        `${site.reached}ExpiredTokenException: ${SERVICE_MESSAGE}`
+      );
     });
 
     it('flattens a forged newline inside a kept service message', async () => {
@@ -424,11 +448,16 @@ describe('#570 — no AWS SDK error message reaches a warn unfiltered', () => {
       expect(line).not.toContain('\n');
     });
 
-    it('keeps the role ARN when the site quotes one', async () => {
-      if (!site.quotesRoleArn) return;
-      sendMock.mockRejectedValue(chainError());
+    it('withholds an unstringifiable throw rather than crashing the site', async () => {
+      // Reaches `stringifyThrown`'s `[unstringifiable throw]` fallback through
+      // a real call site, not just through the helper: `String()` on a
+      // null-prototype object raises TypeError, and that throw escaping the
+      // `catch` would turn warn-and-continue into a hard failure.
+      sendMock.mockRejectedValue(Object.create(null));
       await site.drive();
-      expect(siteWarn(site)).toContain(ROLE_ARN);
+      expect(siteWarn(site)).toContain(
+        `${site.reached}unknown; 23-character message withheld`
+      );
     });
   });
 });

--- a/tests/unit/cli/sts-error-relay-sites.test.ts
+++ b/tests/unit/cli/sts-error-relay-sites.test.ts
@@ -228,26 +228,37 @@ interface Site {
   /** `<file>:<enclosing function>` — the identity of the occurrence. */
   name: string;
   /**
+   * The `operation` literal the site passes to `describeAwsFailureForWarn`,
+   * which is what its `debug` line is prefixed with. Asserted because a
+   * copy-pasted wrong label is otherwise undetectable: the `warn` reads
+   * correctly and only the `debug` line names the wrong call.
+   */
+  operation: string;
+  /**
    * A literal unique to THIS site's warn text, proving the fixture reached
    * the intended `catch` and not some other warn the same call emits.
    *
-   * TWO pairs share a byte-identical spelling, not one: `local-run-task` /
-   * `ecs-service-emulator` (the `${AWS::AccountId}` line) and
-   * `local-invoke` / `local-invoke-agentcore` (the bare `--assume-role: STS
-   * AssumeRole(<arn>) failed: ` line). For those four rows the discriminator
-   * is the MODULE the row drives, not the string — which is why every row
-   * calls exactly one command module and no row is ever consolidated with
-   * another on the strength of its literal.
+   * Spellings are NOT unique, and the count has been undercounted twice while
+   * writing this file, so it is asserted below rather than described here. As
+   * of now: one TRIPLE (`local-invoke`, `local-run-task`,
+   * `ecs-service-emulator` all say `Resolver needs ${AWS::AccountId} but STS
+   * GetCallerIdentity failed: `) and one PAIR (`local-invoke` and
+   * `local-invoke-agentcore` both say the bare `--assume-role: STS
+   * AssumeRole(<arn>) failed: `). For those five rows the discriminator is the
+   * MODULE the row drives, not the string — which is why every row calls
+   * exactly one command module and no row is ever consolidated with another on
+   * the strength of its literal.
    */
   reached: string;
   /** Whether the site interpolates the role ARN, which must keep printing. */
   quotesRoleArn: boolean;
-  drive: () => Promise<void>;
+  drive: (arn?: string) => Promise<void>;
 }
 
 const sites: Site[] = [
   {
     name: 'local-invoke.ts / resolvePseudoParametersForInvoke',
+    operation: 'STS GetCallerIdentity',
     reached:
       'Resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
     quotesRoleArn: false,
@@ -257,16 +268,18 @@ const sites: Site[] = [
   },
   {
     name: 'local-invoke.ts / resolveLambdaContainerEnv (--assume-role)',
+    operation: 'STS AssumeRole',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed: `,
     quotesRoleArn: true,
-    drive: async () => {
+    drive: async (arn = ROLE_ARN) => {
       await tolerate(() =>
-        resolveLambdaContainerEnv(assumeRoleLambda(), { assumeRole: ROLE_ARN }, undefined)
+        resolveLambdaContainerEnv(assumeRoleLambda(), { assumeRole: arn }, undefined)
       );
     },
   },
   {
     name: 'local-run-task.ts / buildEcsImageResolutionContext',
+    operation: 'STS GetCallerIdentity',
     reached:
       'Resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
     quotesRoleArn: false,
@@ -276,6 +289,7 @@ const sites: Site[] = [
   },
   {
     name: 'ecs-service-emulator.ts / buildEcsImageResolutionContext',
+    operation: 'STS GetCallerIdentity',
     reached:
       'Resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
     quotesRoleArn: false,
@@ -292,6 +306,7 @@ const sites: Site[] = [
   },
   {
     name: 'local-start-api.ts / resolvePseudoParametersForStartApi',
+    operation: 'STS GetCallerIdentity',
     reached:
       '--from-state: resolver needs ${AWS::AccountId} but STS GetCallerIdentity failed: ',
     quotesRoleArn: false,
@@ -301,12 +316,13 @@ const sites: Site[] = [
   },
   {
     name: 'local-invoke-agentcore.ts / resolveHostCredentialsForSigV4',
+    operation: 'STS AssumeRole (--sigv4 signing)',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed for --sigv4 signing: `,
     quotesRoleArn: true,
-    drive: async () => {
+    drive: async (arn = ROLE_ARN) => {
       await tolerate(() =>
         resolveHostCredentialsForSigV4(
-          { assumeRole: ROLE_ARN } as never,
+          { assumeRole: arn } as never,
           agentRuntime(),
           undefined,
           'us-east-1',
@@ -317,15 +333,16 @@ const sites: Site[] = [
   },
   {
     name: 'local-invoke-agentcore.ts / resolveAgentCoreCodeImageFromS3',
+    operation: 'STS AssumeRole (fromS3 bundle download)',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed for the fromS3 bundle download: `,
     quotesRoleArn: true,
-    drive: async () => {
+    drive: async (arn = ROLE_ARN) => {
       await tolerate(() =>
         resolveAgentCoreCodeImageFromS3(
           agentRuntime(),
           { runtime: 'python3.12', entryPoint: ['app.py'] } as never,
           { bucket: 'bkt', key: 'bundle.zip' } as never,
-          { assumeRole: ROLE_ARN } as never,
+          { assumeRole: arn } as never,
           'x86_64',
           undefined,
           undefined
@@ -335,6 +352,7 @@ const sites: Site[] = [
   },
   {
     name: 'local-invoke-agentcore.ts / buildAgentCoreImageContext',
+    operation: 'STS GetCallerIdentity',
     reached: '--from-cfn-stack: STS GetCallerIdentity failed: ',
     quotesRoleArn: false,
     drive: async () => {
@@ -345,10 +363,11 @@ const sites: Site[] = [
   },
   {
     name: 'local-invoke-agentcore.ts / applyAgentCoreCredentialEnv',
+    operation: 'STS AssumeRole',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed: `,
     quotesRoleArn: true,
-    drive: async () => {
-      await tolerate(() => applyAgentCoreCredentialEnv({}, { assumeRoleArn: ROLE_ARN }));
+    drive: async (arn = ROLE_ARN) => {
+      await tolerate(() => applyAgentCoreCredentialEnv({}, { assumeRoleArn: arn }));
     },
   },
 ];
@@ -410,6 +429,14 @@ describe('#570 — no AWS SDK error message reaches a warn unfiltered', () => {
         s.quotesRoleArn
       );
     }
+
+    // Pin the literal-sharing, because prose about it has been wrong twice.
+    // Every row drives its own module, so sharing is harmless -- but a future
+    // editor must not consolidate rows on the strength of a shared string, and
+    // this is what tells them the strings are shared.
+    const byLiteral = new Map<string, string[]>();
+    for (const s of sites) byLiteral.set(s.reached, [...(byLiteral.get(s.reached) ?? []), s.name]);
+    expect([...byLiteral.values()].map((names) => names.length).sort()).toEqual([1, 1, 1, 1, 2, 3]);
   });
 
   describe.each(sites)('$name', (site) => {
@@ -426,8 +453,15 @@ describe('#570 — no AWS SDK error message reaches a warn unfiltered', () => {
       expect(line).not.toContain('Command failed');
       expect(line).not.toContain('\n');
 
-      // Withheld at `warn` is only acceptable while in full at `debug`.
-      expect(debugLines.join('\n')).toContain(PASSPHRASE);
+      // Withheld at `warn` is only acceptable while in full at `debug`, and
+      // the debug line must name THIS call -- a copy-pasted `operation` label
+      // is invisible in the `warn`.
+      const debug = debugLines.filter((l) => l.includes(PASSPHRASE));
+      expect(debug).toHaveLength(1);
+      expect(debug[0]!).toContain(`${site.operation}: the AWS SDK's own failure message was:`);
+      // Flattened: the debug stream is the same stdout studio mirrors into an
+      // HTTP-served ring, so the two-line chain message must arrive as one.
+      expect(debug[0]!).not.toContain('\n');
     });
 
     it('keeps a modeled STS service exception message, which is the diagnosis', async () => {
@@ -458,6 +492,61 @@ describe('#570 — no AWS SDK error message reaches a warn unfiltered', () => {
       expect(siteWarn(site)).toContain(
         `${site.reached}unknown; 23-character message withheld`
       );
+    });
+  });
+});
+
+/**
+ * The four sites that interpolate a role ARN keep printing it -- it is the
+ * developer's own flag value, or an ARN read from their own deployed stack, and
+ * `tests/integration/local-studio/verify.sh` greps the studio log ring for it.
+ *
+ * But the BARE `--assume-role` form resolves that ARN from a live SDK response
+ * (`GetFunctionConfiguration.Configuration.Role`, `GetAgentRuntime`), and only
+ * a `startsWith('arn:')` check stands between that response and this template.
+ * Under the same hijacked-endpoint model the rest of this file is built on, it
+ * is wire-derived text sitting on the very line the helper beside it just made
+ * forge-proof -- so it is flattened too.
+ *
+ * This block exists because the flatten shipped UNFENCED at first: a mutation
+ * probe that reverted it left all 37 cases green.
+ */
+describe('#570 — a forged newline in the role ARN cannot forge a line either', () => {
+  const FORGED_ARN = 'arn:aws:iam::123456789012:role/x\nWARN: signature verified';
+
+  let warnLines: string[];
+
+  beforeEach(() => {
+    warnLines = [];
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    sendMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const quoting = sites.filter((s) => s.quotesRoleArn);
+
+  it('covers all four ARN-quoting sites', () => {
+    expect(quoting).toHaveLength(4);
+  });
+
+  describe.each(quoting)('$name', (site) => {
+    it('flattens the ARN, keeping every character on one line', async () => {
+      sendMock.mockRejectedValue(chainError());
+      await site.drive(FORGED_ARN);
+
+      const matches = warnLines.filter((l) => l.includes('WARN: signature verified'));
+      expect(matches, 'the forged ARN never reached a warn line at all').toHaveLength(1);
+      const line = matches[0]!;
+      // Every character survives -- only the break became a space.
+      expect(line).toContain('arn:aws:iam::123456789012:role/x WARN: signature verified');
+      expect(line).not.toContain('\n');
     });
   });
 });

--- a/tests/unit/cli/sts-error-relay-source-fence.test.ts
+++ b/tests/unit/cli/sts-error-relay-source-fence.test.ts
@@ -36,8 +36,24 @@ import { dirname, join } from 'node:path';
  *   - It is wording-bound. A tenth site spelled `STS ${op} failure` or with no
  *     `STS` token at all produces no finding — though a copy-paste-shaped one
  *     trips the exact-9 count loudly.
- *   - `readdirSync` is not recursive, so a future `src/cli/commands/<subdir>/`
- *     is unscanned.
+ *   - Its directory scope is `src/cli/commands/*.ts`, non-recursively. A
+ *     relay of the same shape lives outside it today —
+ *     `src/local/layer-arn-materializer.ts:122` renders
+ *     `STS AssumeRole(${roleArn}) failed: ${errMsg(err)}` with an unflattening
+ *     `errMsg`. It THROWS rather than logging, so it is a different surface,
+ *     and it is pre-existing; it is enumerated in issue #579 with the rest.
+ *   - `stripComments` handles a leading and a trailing `//`, not a trailing
+ *     BLOCK comment: one opening with a slash-star, naming the helper, and
+ *     closing again on the same line, placed beside a destructured
+ *     `const { message } = awsErr;`, vouches for the code and evades the
+ *     raw check at once. Deliberate self-evasion, not accident.
+ *   - The announcing check needs `STS <Op>` on ONE physical line, so a template
+ *     that wraps between `STS ` and the operation is undetected. The `+`-wrap
+ *     fix covered the `failed` half of the split, not this one.
+ *   - `RAW_RELAY` is identifier-bound to `err` / `error` / `e`, so
+ *     `caught.message`, a destructured `{ message }`, `err.toString()` and
+ *     `JSON.stringify(err)` all miss. That only bites inside the adjacency
+ *     case above, where something else already vouches.
  *
  * Its scope stays narrow on purpose: only lines that name an STS operation as
  * having failed. A broader rule ("no `err.message` in any warn") would be
@@ -94,8 +110,10 @@ const LINES_AFTER = 1;
 interface Finding {
   file: string;
   line: number;
-  /** The window with `//` comments stripped, so a comment cannot vouch for code. */
+  /** The window with comments stripped — what `HELPER_CALL` is matched against. */
   code: string;
+  /** The window verbatim — what `RAW_RELAY` is matched against. See below. */
+  raw: string;
 }
 
 /**
@@ -106,9 +124,20 @@ interface Finding {
  * line of real code, which satisfied the helper check while the code beside it
  * relayed the message raw. Measured.
  *
- * The `//` strip is naive about a `//` inside a string literal. That direction
- * is fail-CLOSED here (it can only remove text, never add a helper call), so
- * the trade is accepted.
+ * The `//` strip is naive about a `//` inside a string literal — a URL in a
+ * message truncates the line. An earlier draft called that "fail-CLOSED", which
+ * was wrong and is worth spelling out, because the reasoning covered only half
+ * the file: it IS fail-closed for `HELPER_CALL` (stripping can only remove a
+ * call, never invent one), and fail-OPEN for `RAW_RELAY` (stripping can remove
+ * a raw read that sat after the URL). A reviewer demonstrated the combination —
+ * a helper call before the URL, a raw relay after it — passing both assertions.
+ *
+ * So the two checks read DIFFERENT text, which makes the claim true by
+ * construction rather than by argument: `HELPER_CALL` gets the stripped window,
+ * `RAW_RELAY` gets the verbatim one. The cost is that a COMMENT containing
+ * something like `err.message` would trip the raw check; that is the
+ * fail-closed direction, and the assertion names the line so it is a
+ * ten-second fix.
  */
 function stripComments(text: string): string {
   return text
@@ -141,7 +170,7 @@ function stsFailureRelays(file: string): Finding[] {
     const ahead = lines.slice(i, i + LINES_AFTER + 1).join('\n');
     if (!/\bSTS\s+[A-Za-z$]/.test(line) || !STS_FAILURE_LINE.test(ahead)) continue;
     const window = lines.slice(Math.max(0, i - LINES_BEFORE), i + LINES_AFTER + 1).join('\n');
-    found.push({ file, line: i + 1, code: stripComments(window) });
+    found.push({ file, line: i + 1, code: stripComments(window), raw: window });
   }
   return found;
 }
@@ -174,7 +203,7 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
   });
 
   it('leaves none of them reading the raw error message', () => {
-    const raw = all.filter((f) => RAW_RELAY.test(f.code));
+    const raw = all.filter((f) => RAW_RELAY.test(f.raw));
     expect(
       raw.map((f) => `${f.file}:${f.line}`),
       'an STS failure warn still reading err.message directly'
@@ -221,7 +250,16 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
     const trailing =
       "        `STS AssumeRole failed: ${String(err)}`, // describeAwsFailureForWarn(err, 'x')";
     expect(HELPER_CALL.test(stripComments(trailing))).toBe(false);
-    expect(RAW_RELAY.test(stripComments(trailing))).toBe(true);
+    expect(RAW_RELAY.test(trailing)).toBe(true);
+
+    // (d2) and the reverse: a `//` inside a STRING must not let the strip hide
+    // a raw read that follows it. This is why `RAW_RELAY` reads the verbatim
+    // window while `HELPER_CALL` reads the stripped one.
+    const urlInString =
+      '        `STS AssumeRole failed: ${describeAwsFailureForWarn(err, op)} (https://aws.amazon.com) raw=${err.message}`';
+    expect(HELPER_CALL.test(stripComments(urlInString))).toBe(true);
+    expect(RAW_RELAY.test(stripComments(urlInString))).toBe(false);
+    expect(RAW_RELAY.test(urlInString), 'the verbatim window must still see it').toBe(true);
 
     // (e) a template wrapping across a `+` is still DETECTED.
     const wrapped = ['      `... STS AssumeRole(${arn}) ` +', '        `failed: ${err.message}`'].join(

--- a/tests/unit/cli/sts-error-relay-source-fence.test.ts
+++ b/tests/unit/cli/sts-error-relay-source-fence.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * Issue #570 — the TENTH-site fence.
+ *
+ * `sts-error-relay-sites.test.ts` drives nine known sites and fails when any of
+ * them stops routing through `describeAwsFailureForWarn`. What it cannot see is
+ * a site that did not exist when the table was written: a new
+ * `logger.warn('... STS <Op> failed: ${err.message}')` generates no case, so it
+ * generates no failure either. That is the shape this file closes.
+ *
+ * It is a SOURCE-TEXT check, deliberately, and its scope is deliberately narrow:
+ * every `logger.warn` line in the five converted command files that names an STS
+ * operation as having failed must render the error through the shared helper.
+ * A broader rule ("no `err.message` in any warn") would be wrong — those files
+ * carry dozens of legitimate Docker / filesystem / synth relays, and a fence
+ * that has to be suppressed is a fence nobody keeps.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = join(HERE, '..', '..', '..', 'src');
+
+/**
+ * The five files whose STS relays issue #570 converted. Listed as literals
+ * rather than globbed: a glob would silently stop covering a file that was
+ * renamed, which is the direction that fails open.
+ */
+const CONVERTED_FILES = [
+  'cli/commands/local-invoke.ts',
+  'cli/commands/local-run-task.ts',
+  'cli/commands/ecs-service-emulator.ts',
+  'cli/commands/local-start-api.ts',
+  'cli/commands/local-invoke-agentcore.ts',
+];
+
+/** `STS GetCallerIdentity failed` / `STS AssumeRole(...) failed` and friends. */
+const STS_FAILURE_LINE = /STS\s+(GetCallerIdentity|AssumeRole)[^`]*?failed/;
+
+/** The raw shape the fix replaced. */
+const RAW_RELAY = /err\s+instanceof\s+Error\s*\?\s*err\.message\s*:\s*String\(err\)/;
+
+interface Finding {
+  file: string;
+  line: number;
+  text: string;
+}
+
+/**
+ * How many source lines around the announcing line count as part of the site.
+ *
+ * A warn's template is split across source lines, and the error rendering sits
+ * on EITHER side of the announcing one: inline on the same or the next line at
+ * seven sites, and hoisted into a `const reason = ...` a couple of lines ABOVE
+ * at the two that interpolate a role ARN. A one-sided window reported one of
+ * those two as unguarded, which is how these numbers were arrived at rather
+ * than guessed.
+ */
+const LINES_BEFORE = 4;
+const LINES_AFTER = 2;
+
+/** Collect every physical line that announces an STS failure, with its window. */
+function stsFailureRelays(file: string): Finding[] {
+  const lines = readFileSync(join(SRC, file), 'utf8').split('\n');
+  const found: Finding[] = [];
+  for (const [i, line] of lines.entries()) {
+    if (!STS_FAILURE_LINE.test(line)) continue;
+    // Skip prose: only a template-literal line can be relaying anything.
+    if (line.trimStart().startsWith('//') || line.trimStart().startsWith('*')) continue;
+    const window = lines.slice(Math.max(0, i - LINES_BEFORE), i + LINES_AFTER + 1).join('\n');
+    found.push({ file, line: i + 1, text: window });
+  }
+  return found;
+}
+
+describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
+  const all = CONVERTED_FILES.flatMap(stsFailureRelays);
+
+  it('finds the STS failure lines it is supposed to be guarding', () => {
+    // Non-vacuity: if the regex ever stops matching (a reworded message, a
+    // renamed file), every assertion below passes over an empty list. The
+    // count is the nine converted sites; it is asserted as a floor AND a
+    // ceiling so both a silently-lost match and an unnoticed new site show up.
+    expect(all.map((f) => `${f.file}:${f.line}`)).toHaveLength(9);
+  });
+
+  it('routes every one of them through describeAwsFailureForWarn', () => {
+    const unguarded = all.filter((f) => !f.text.includes('describeAwsFailureForWarn'));
+    expect(
+      unguarded.map((f) => `${f.file}:${f.line}`),
+      'an STS failure warn that does not render its error through the shared policy'
+    ).toEqual([]);
+  });
+
+  it('leaves none of them interpolating the raw error message', () => {
+    const raw = all.filter((f) => RAW_RELAY.test(f.text));
+    expect(
+      raw.map((f) => `${f.file}:${f.line}`),
+      'an STS failure warn still interpolating err.message verbatim'
+    ).toEqual([]);
+  });
+
+  it('proves the guard discriminates: a synthesized unguarded site is caught', () => {
+    // Without this, the three assertions above are "no bad rows in a list I
+    // built" and would pass just as well against a broken matcher. Feed the
+    // matcher a line of exactly the shape a tenth site would have and confirm
+    // it is both FOUND and REJECTED.
+    const tenth = [
+      '    } catch (err) {',
+      '      logger.warn(',
+      "        `--assume-role: STS AssumeRole(${arn}) failed: ${err instanceof Error ? err.message : String(err)}. ` +",
+      "          'Falling back.'",
+      '      );',
+    ].join('\n');
+    const announcing = tenth.split('\n')[2]!;
+    expect(STS_FAILURE_LINE.test(announcing)).toBe(true);
+    expect(tenth.includes('describeAwsFailureForWarn')).toBe(false);
+    expect(RAW_RELAY.test(tenth)).toBe(true);
+  });
+});

--- a/tests/unit/cli/sts-error-relay-source-fence.test.ts
+++ b/tests/unit/cli/sts-error-relay-source-fence.test.ts
@@ -12,24 +12,37 @@ import { dirname, join } from 'node:path';
  * `logger.warn('... STS <Op> failed: ${err.message}')` generates no case, so it
  * generates no failure either. That is the shape this file closes.
  *
- * It is a SOURCE-TEXT check, and the first draft of it was weaker than it read.
- * Three evasions were found by review and are closed here, each with the
- * assertion that closes it:
+ * It is a SOURCE-TEXT check, and every draft of it has been weaker than it
+ * read. Five evasions found by review are closed, each with the assertion that
+ * closes it:
  *
  *   - A tenth site in a SIXTH file was invisible, because the file list was
- *     hard-coded. The scan now walks every `src/cli/commands/*.ts` and the file
- *     list is asserted to be exactly what the scan finds.
- *   - The `describeAwsFailureForWarn` check matched the window text, and every
- *     site carries a COMMENT naming that helper — so a copy-pasted tenth site
- *     that kept the comment and wrote `${(err as Error).message}` passed. The
- *     check now matches a CALL, with comments stripped first.
- *   - The raw-relay check matched one exact ternary spelling. It now matches any
- *     `err.message` read.
+ *     hard-coded. The scan walks every `src/cli/commands/*.ts` now and the file
+ *     set is asserted rather than assumed.
+ *   - The helper check matched the window TEXT, and every site carries a
+ *     comment naming the helper — so a tenth site keeping the comment and
+ *     writing `${(err as Error).message}` passed. A CALL is matched now.
+ *   - Comment stripping only handled a LEADING `//`; a TRAILING one on a line
+ *     of real code still vouched for it.
+ *   - The raw-relay check matched one exact ternary spelling.
+ *   - Detection was per-line, so a template wrapping across a `+` — the house
+ *     style at four of the nine sites — was invisible.
  *
- * Its scope stays narrow on purpose: only `logger.warn` lines that name an STS
- * operation as having failed. A broader rule ("no `err.message` in any warn")
- * would be wrong — these files carry dozens of legitimate Docker / filesystem /
- * synth relays, and a fence that has to be suppressed is a fence nobody keeps.
+ * WHAT IT STILL DOES NOT CATCH, stated so nobody reads more into a green run:
+ *
+ *   - It does not match the error VALUE. A `describeAwsFailureForWarn(other, …)`
+ *     one line away vouches for an unguarded neighbour. Only per-error matching
+ *     fixes that, which needs an AST.
+ *   - It is wording-bound. A tenth site spelled `STS ${op} failure` or with no
+ *     `STS` token at all produces no finding — though a copy-paste-shaped one
+ *     trips the exact-9 count loudly.
+ *   - `readdirSync` is not recursive, so a future `src/cli/commands/<subdir>/`
+ *     is unscanned.
+ *
+ * Its scope stays narrow on purpose: only lines that name an STS operation as
+ * having failed. A broader rule ("no `err.message` in any warn") would be
+ * wrong — these files carry dozens of legitimate Docker / filesystem / synth
+ * relays, and a fence that has to be suppressed is a fence nobody keeps.
  */
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -37,15 +50,30 @@ const SRC = join(HERE, '..', '..', '..', 'src');
 const COMMANDS = join(SRC, 'cli', 'commands');
 
 /**
- * Announces an STS failure. Deliberately loose about what sits between the
- * operation and `failed` — a template literal wraps across source lines, so an
- * anchored or backtick-free pattern would silently match nothing (which is the
- * fail-open direction) rather than too much.
+ * Announces an STS failure. Matched against a JOINED window rather than one
+ * line: four of the nine existing sites wrap their template across a `+`,
+ * which is the house style, and a per-line pattern misses every one of those
+ * in the FAIL-OPEN direction (no finding, so no count trip either).
+ *
+ * `STS` is matched CASE-SENSITIVELY and on a word boundary, and both halves
+ * were paid for. A case-insensitive `/sts\s+/` matched the word `lists ` in
+ * `local-start-alb.ts`'s `--tls-cert` help text ("the cert lists DNS:localhost
+ * ... will fail the SAN check"), reporting an option definition as an
+ * unguarded relay. cdk-local writes the service as `STS` everywhere, so
+ * insisting on that spelling costs nothing and removes a whole class of prose
+ * false positives.
  */
-const STS_FAILURE_LINE = /STS\s+[A-Za-z]+.{0,120}?failed/;
+const STS_FAILURE_LINE = /\bSTS\s+[A-Za-z$][\s\S]{0,200}?fail/;
 
-/** Any read of the error's message, not one blessed ternary spelling. */
-const RAW_RELAY = /\berr(?:or)?\s*(?:as\s+Error\s*\)?)?\s*\)?\s*\.message\b|\berr(?:or)?\.message\b/;
+/**
+ * A read of anything wire-derived off the error. Deliberately broader than
+ * `.message`: `err.name` is the `x-amzn-errortype` forging vector this whole
+ * change exists to close, and `String(err)` / `err.stack` carry the message
+ * anyway. Each spelling here was added because a review probe got past the
+ * previous one.
+ */
+const RAW_RELAY =
+  /\b(?:err|error|e)\s*(?:as\s+[A-Za-z.<>\[\]]+\s*)?\)?\s*[?!]?\.\s*(?:message|name|stack)\b|\bString\s*\(\s*err/;
 
 /** A CALL to the shared helper, not a comment mentioning it. */
 const HELPER_CALL = /describeAwsFailureForWarn\s*\(/;
@@ -70,14 +98,25 @@ interface Finding {
   code: string;
 }
 
-/** Strip `//` comments so a comment naming the helper cannot satisfy the check. */
-function stripLineComments(text: string): string {
+/**
+ * Remove comment text so a comment cannot vouch for code.
+ *
+ * Both forms matter and the first draft only handled the first: a LEADING
+ * `//` line, and a TRAILING `// ... describeAwsFailureForWarn(err, op)` on a
+ * line of real code, which satisfied the helper check while the code beside it
+ * relayed the message raw. Measured.
+ *
+ * The `//` strip is naive about a `//` inside a string literal. That direction
+ * is fail-CLOSED here (it can only remove text, never add a helper call), so
+ * the trade is accepted.
+ */
+function stripComments(text: string): string {
   return text
     .split('\n')
     .map((l) => {
       const t = l.trimStart();
-      if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) return '';
-      return l;
+      if (t.startsWith('*') || t.startsWith('/*')) return '';
+      return l.replace(/\/\/.*$/, '');
     })
     .join('\n');
 }
@@ -95,9 +134,14 @@ function stsFailureRelays(file: string): Finding[] {
     const bare = line.trimStart();
     // Prose cannot relay anything.
     if (bare.startsWith('//') || bare.startsWith('*') || bare.startsWith('/*')) continue;
-    if (!STS_FAILURE_LINE.test(line)) continue;
+    // A site is announced by a line that opens a template naming STS; the
+    // `failed` half may wrap onto the next one, so the DETECTION window looks
+    // forward from here while the GUARD window also looks back (the two
+    // ARN-quoting sites hoist their render into a `const reason` above).
+    const ahead = lines.slice(i, i + LINES_AFTER + 1).join('\n');
+    if (!/\bSTS\s+[A-Za-z$]/.test(line) || !STS_FAILURE_LINE.test(ahead)) continue;
     const window = lines.slice(Math.max(0, i - LINES_BEFORE), i + LINES_AFTER + 1).join('\n');
-    found.push({ file, line: i + 1, code: stripLineComments(window) });
+    found.push({ file, line: i + 1, code: stripComments(window) });
   }
   return found;
 }
@@ -137,7 +181,7 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
     ).toEqual([]);
   });
 
-  it('proves the guard discriminates, on each of the three evasions it closes', () => {
+  it('proves the guard discriminates, on each evasion it closes', () => {
     // Without this, the assertions above are "no bad rows in a list I built"
     // and would pass just as well against a matcher that matches nothing.
 
@@ -148,24 +192,53 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
       "          'Falling back.'",
     ].join('\n');
     expect(STS_FAILURE_LINE.test(inline.split('\n')[1]!)).toBe(true);
-    expect(HELPER_CALL.test(stripLineComments(inline))).toBe(false);
-    expect(RAW_RELAY.test(stripLineComments(inline))).toBe(true);
+    expect(HELPER_CALL.test(stripComments(inline))).toBe(false);
+    expect(RAW_RELAY.test(stripComments(inline))).toBe(true);
 
     // (b) a comment naming the helper must NOT vouch for the code.
     const commentOnly = [
       '      // rendered via describeAwsFailureForWarn(err, ...)',
       "        `STS AssumeRole failed: ${(err as Error).message}`",
     ].join('\n');
-    expect(HELPER_CALL.test(stripLineComments(commentOnly))).toBe(false);
-    expect(RAW_RELAY.test(stripLineComments(commentOnly))).toBe(true);
+    expect(HELPER_CALL.test(stripComments(commentOnly))).toBe(false);
+    expect(RAW_RELAY.test(stripComments(commentOnly))).toBe(true);
 
-    // (c) a spelling the first draft's raw-relay regex missed.
-    expect(RAW_RELAY.test('`${error.message}`')).toBe(true);
+    // (c) spellings earlier drafts' raw-relay regex missed, each from a probe.
+    for (const spelling of [
+      '`${error.message}`',
+      '`${(err as any).message}`',
+      '`${err?.message}`',
+      '`${err!.message}`',
+      '`${e.message}`',
+      '`${(err as Error).name}`',
+      '`${err.stack}`',
+      '`${String(err)}`',
+    ]) {
+      expect(RAW_RELAY.test(spelling), `RAW_RELAY missed ${spelling}`).toBe(true);
+    }
+
+    // (d) a TRAILING comment naming the helper must not vouch for the code.
+    const trailing =
+      "        `STS AssumeRole failed: ${String(err)}`, // describeAwsFailureForWarn(err, 'x')";
+    expect(HELPER_CALL.test(stripComments(trailing))).toBe(false);
+    expect(RAW_RELAY.test(stripComments(trailing))).toBe(true);
+
+    // (e) a template wrapping across a `+` is still DETECTED.
+    const wrapped = ['      `... STS AssumeRole(${arn}) ` +', '        `failed: ${err.message}`'].join(
+      '\n'
+    );
+    expect(STS_FAILURE_LINE.test(wrapped)).toBe(true);
+
+    // (f) and prose must NOT be: the `/i` draft matched `lists DNS...fail` in a
+    // `--tls-cert` help string and reported an option definition as a relay.
+    expect(
+      STS_FAILURE_LINE.test('the cert lists DNS:localhost as SubjectAltName, will fail the check')
+    ).toBe(false);
 
     // And the positive control: a genuine site is accepted.
     const guarded = "        `STS GetCallerIdentity failed: ${describeAwsFailureForWarn(err, 'x')}`";
     expect(STS_FAILURE_LINE.test(guarded)).toBe(true);
-    expect(HELPER_CALL.test(stripLineComments(guarded))).toBe(true);
-    expect(RAW_RELAY.test(stripLineComments(guarded))).toBe(false);
+    expect(HELPER_CALL.test(stripComments(guarded))).toBe(true);
+    expect(RAW_RELAY.test(stripComments(guarded))).toBe(false);
   });
 });

--- a/tests/unit/cli/sts-error-relay-source-fence.test.ts
+++ b/tests/unit/cli/sts-error-relay-source-fence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -12,111 +12,160 @@ import { dirname, join } from 'node:path';
  * `logger.warn('... STS <Op> failed: ${err.message}')` generates no case, so it
  * generates no failure either. That is the shape this file closes.
  *
- * It is a SOURCE-TEXT check, deliberately, and its scope is deliberately narrow:
- * every `logger.warn` line in the five converted command files that names an STS
- * operation as having failed must render the error through the shared helper.
- * A broader rule ("no `err.message` in any warn") would be wrong — those files
- * carry dozens of legitimate Docker / filesystem / synth relays, and a fence
- * that has to be suppressed is a fence nobody keeps.
+ * It is a SOURCE-TEXT check, and the first draft of it was weaker than it read.
+ * Three evasions were found by review and are closed here, each with the
+ * assertion that closes it:
+ *
+ *   - A tenth site in a SIXTH file was invisible, because the file list was
+ *     hard-coded. The scan now walks every `src/cli/commands/*.ts` and the file
+ *     list is asserted to be exactly what the scan finds.
+ *   - The `describeAwsFailureForWarn` check matched the window text, and every
+ *     site carries a COMMENT naming that helper — so a copy-pasted tenth site
+ *     that kept the comment and wrote `${(err as Error).message}` passed. The
+ *     check now matches a CALL, with comments stripped first.
+ *   - The raw-relay check matched one exact ternary spelling. It now matches any
+ *     `err.message` read.
+ *
+ * Its scope stays narrow on purpose: only `logger.warn` lines that name an STS
+ * operation as having failed. A broader rule ("no `err.message` in any warn")
+ * would be wrong — these files carry dozens of legitimate Docker / filesystem /
+ * synth relays, and a fence that has to be suppressed is a fence nobody keeps.
  */
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SRC = join(HERE, '..', '..', '..', 'src');
+const COMMANDS = join(SRC, 'cli', 'commands');
 
 /**
- * The five files whose STS relays issue #570 converted. Listed as literals
- * rather than globbed: a glob would silently stop covering a file that was
- * renamed, which is the direction that fails open.
+ * Announces an STS failure. Deliberately loose about what sits between the
+ * operation and `failed` — a template literal wraps across source lines, so an
+ * anchored or backtick-free pattern would silently match nothing (which is the
+ * fail-open direction) rather than too much.
  */
-const CONVERTED_FILES = [
-  'cli/commands/local-invoke.ts',
-  'cli/commands/local-run-task.ts',
-  'cli/commands/ecs-service-emulator.ts',
-  'cli/commands/local-start-api.ts',
-  'cli/commands/local-invoke-agentcore.ts',
-];
+const STS_FAILURE_LINE = /STS\s+[A-Za-z]+.{0,120}?failed/;
 
-/** `STS GetCallerIdentity failed` / `STS AssumeRole(...) failed` and friends. */
-const STS_FAILURE_LINE = /STS\s+(GetCallerIdentity|AssumeRole)[^`]*?failed/;
+/** Any read of the error's message, not one blessed ternary spelling. */
+const RAW_RELAY = /\berr(?:or)?\s*(?:as\s+Error\s*\)?)?\s*\)?\s*\.message\b|\berr(?:or)?\.message\b/;
 
-/** The raw shape the fix replaced. */
-const RAW_RELAY = /err\s+instanceof\s+Error\s*\?\s*err\.message\s*:\s*String\(err\)/;
-
-interface Finding {
-  file: string;
-  line: number;
-  text: string;
-}
+/** A CALL to the shared helper, not a comment mentioning it. */
+const HELPER_CALL = /describeAwsFailureForWarn\s*\(/;
 
 /**
  * How many source lines around the announcing line count as part of the site.
  *
- * A warn's template is split across source lines, and the error rendering sits
- * on EITHER side of the announcing one: inline on the same or the next line at
- * seven sites, and hoisted into a `const reason = ...` a couple of lines ABOVE
- * at the two that interpolate a role ARN. A one-sided window reported one of
- * those two as unguarded, which is how these numbers were arrived at rather
- * than guessed.
+ * Measured, not guessed: seven sites render inline on the announcing line or
+ * the one after it, and one (`local-invoke.ts`'s `--assume-role` site) hoists
+ * the render into a `const reason = ...` two lines above. A one-sided window
+ * reported that one as unguarded. The numbers are the measured need and no
+ * more — a wider window lets one site's helper call vouch for an unguarded
+ * neighbour.
  */
-const LINES_BEFORE = 4;
-const LINES_AFTER = 2;
+const LINES_BEFORE = 2;
+const LINES_AFTER = 1;
 
-/** Collect every physical line that announces an STS failure, with its window. */
+interface Finding {
+  file: string;
+  line: number;
+  /** The window with `//` comments stripped, so a comment cannot vouch for code. */
+  code: string;
+}
+
+/** Strip `//` comments so a comment naming the helper cannot satisfy the check. */
+function stripLineComments(text: string): string {
+  return text
+    .split('\n')
+    .map((l) => {
+      const t = l.trimStart();
+      if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) return '';
+      return l;
+    })
+    .join('\n');
+}
+
+function commandFiles(): string[] {
+  return readdirSync(COMMANDS)
+    .filter((f) => f.endsWith('.ts'))
+    .sort();
+}
+
 function stsFailureRelays(file: string): Finding[] {
-  const lines = readFileSync(join(SRC, file), 'utf8').split('\n');
+  const lines = readFileSync(join(COMMANDS, file), 'utf8').split('\n');
   const found: Finding[] = [];
   for (const [i, line] of lines.entries()) {
+    const bare = line.trimStart();
+    // Prose cannot relay anything.
+    if (bare.startsWith('//') || bare.startsWith('*') || bare.startsWith('/*')) continue;
     if (!STS_FAILURE_LINE.test(line)) continue;
-    // Skip prose: only a template-literal line can be relaying anything.
-    if (line.trimStart().startsWith('//') || line.trimStart().startsWith('*')) continue;
     const window = lines.slice(Math.max(0, i - LINES_BEFORE), i + LINES_AFTER + 1).join('\n');
-    found.push({ file, line: i + 1, text: window });
+    found.push({ file, line: i + 1, code: stripLineComments(window) });
   }
   return found;
 }
 
 describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
-  const all = CONVERTED_FILES.flatMap(stsFailureRelays);
+  const all = commandFiles().flatMap(stsFailureRelays);
 
   it('finds the STS failure lines it is supposed to be guarding', () => {
     // Non-vacuity: if the regex ever stops matching (a reworded message, a
-    // renamed file), every assertion below passes over an empty list. The
-    // count is the nine converted sites; it is asserted as a floor AND a
-    // ceiling so both a silently-lost match and an unnoticed new site show up.
-    expect(all.map((f) => `${f.file}:${f.line}`)).toHaveLength(9);
+    // renamed file), every assertion below passes over an empty list. Both the
+    // count AND the identity of the files carrying them are pinned, so a new
+    // site in a file not previously carrying one fails here rather than
+    // slipping past a hard-coded list.
+    expect(all).toHaveLength(9);
+    expect([...new Set(all.map((f) => f.file))].sort()).toEqual([
+      'ecs-service-emulator.ts',
+      'local-invoke-agentcore.ts',
+      'local-invoke.ts',
+      'local-run-task.ts',
+      'local-start-api.ts',
+    ]);
   });
 
-  it('routes every one of them through describeAwsFailureForWarn', () => {
-    const unguarded = all.filter((f) => !f.text.includes('describeAwsFailureForWarn'));
+  it('routes every one of them through a describeAwsFailureForWarn CALL', () => {
+    const unguarded = all.filter((f) => !HELPER_CALL.test(f.code));
     expect(
       unguarded.map((f) => `${f.file}:${f.line}`),
       'an STS failure warn that does not render its error through the shared policy'
     ).toEqual([]);
   });
 
-  it('leaves none of them interpolating the raw error message', () => {
-    const raw = all.filter((f) => RAW_RELAY.test(f.text));
+  it('leaves none of them reading the raw error message', () => {
+    const raw = all.filter((f) => RAW_RELAY.test(f.code));
     expect(
       raw.map((f) => `${f.file}:${f.line}`),
-      'an STS failure warn still interpolating err.message verbatim'
+      'an STS failure warn still reading err.message directly'
     ).toEqual([]);
   });
 
-  it('proves the guard discriminates: a synthesized unguarded site is caught', () => {
-    // Without this, the three assertions above are "no bad rows in a list I
-    // built" and would pass just as well against a broken matcher. Feed the
-    // matcher a line of exactly the shape a tenth site would have and confirm
-    // it is both FOUND and REJECTED.
-    const tenth = [
-      '    } catch (err) {',
+  it('proves the guard discriminates, on each of the three evasions it closes', () => {
+    // Without this, the assertions above are "no bad rows in a list I built"
+    // and would pass just as well against a matcher that matches nothing.
+
+    // (a) the shape a tenth site would have, inline.
+    const inline = [
       '      logger.warn(',
       "        `--assume-role: STS AssumeRole(${arn}) failed: ${err instanceof Error ? err.message : String(err)}. ` +",
       "          'Falling back.'",
-      '      );',
     ].join('\n');
-    const announcing = tenth.split('\n')[2]!;
-    expect(STS_FAILURE_LINE.test(announcing)).toBe(true);
-    expect(tenth.includes('describeAwsFailureForWarn')).toBe(false);
-    expect(RAW_RELAY.test(tenth)).toBe(true);
+    expect(STS_FAILURE_LINE.test(inline.split('\n')[1]!)).toBe(true);
+    expect(HELPER_CALL.test(stripLineComments(inline))).toBe(false);
+    expect(RAW_RELAY.test(stripLineComments(inline))).toBe(true);
+
+    // (b) a comment naming the helper must NOT vouch for the code.
+    const commentOnly = [
+      '      // rendered via describeAwsFailureForWarn(err, ...)',
+      "        `STS AssumeRole failed: ${(err as Error).message}`",
+    ].join('\n');
+    expect(HELPER_CALL.test(stripLineComments(commentOnly))).toBe(false);
+    expect(RAW_RELAY.test(stripLineComments(commentOnly))).toBe(true);
+
+    // (c) a spelling the first draft's raw-relay regex missed.
+    expect(RAW_RELAY.test('`${error.message}`')).toBe(true);
+
+    // And the positive control: a genuine site is accepted.
+    const guarded = "        `STS GetCallerIdentity failed: ${describeAwsFailureForWarn(err, 'x')}`";
+    expect(STS_FAILURE_LINE.test(guarded)).toBe(true);
+    expect(HELPER_CALL.test(stripLineComments(guarded))).toBe(true);
+    expect(RAW_RELAY.test(stripLineComments(guarded))).toBe(false);
   });
 });

--- a/tests/unit/export-surface.test.ts
+++ b/tests/unit/export-surface.test.ts
@@ -30,6 +30,11 @@ describe('package export surface', () => {
     // Spot-check a few internal-only helpers a shim host consumes.
     expect(internal).toHaveProperty('pickRefLogicalId');
     expect(internal).toHaveProperty('resolveLambdaArnIntrinsic');
+    // Issue #570: the two credential-error policy entry points. Their JSDoc in
+    // `src/internal.ts` advertises them as a host-reuse contract, which is not
+    // a contract at all unless something fails when they disappear.
+    expect(internal).toHaveProperty('describeAwsFailureForWarn');
+    expect(internal).toHaveProperty('describeCredentialLoadFailure');
   });
 
   it('does NOT leak internal building blocks into the main entry', () => {

--- a/tests/unit/local/credential-error.test.ts
+++ b/tests/unit/local/credential-error.test.ts
@@ -118,6 +118,35 @@ describe('stringifyThrown — total, so a throw cannot escape a catch', () => {
   it('stringifies a non-Error throw', () => {
     expect(stringifyThrown('plain string throw')).toBe('plain string throw');
   });
+
+  it('survives a throwing `name` accessor, which clampErrorName has to read', () => {
+    const hostile = new Error('boom');
+    Object.defineProperty(hostile, 'name', {
+      get(): string {
+        throw new Error('nope');
+      },
+    });
+    expect(() => hostile.name).toThrow('nope');
+    expect(clampErrorName(hostile)).toBe('unknown');
+    expect(() => describeCredentialLoadFailure(hostile)).not.toThrow();
+  });
+
+  it('survives a throwing `code` accessor and a throwing `$fault` accessor', () => {
+    const codeThrows = Object.defineProperty(new Error('boom'), 'code', {
+      get(): string {
+        throw new Error('nope');
+      },
+    });
+    expect(clampErrorCode(codeThrows)).toBeUndefined();
+
+    const faultThrows = Object.defineProperty(new Error('boom'), '$fault', {
+      get(): string {
+        throw new Error('nope');
+      },
+    });
+    expect(isAwsServiceException(faultThrows)).toBe(false);
+    expect(() => describeAwsFailureForWarn(faultThrows, 'STS AssumeRole')).not.toThrow();
+  });
 });
 
 describe('clampErrorName — the wire-derived name cannot forge a log line', () => {
@@ -214,18 +243,28 @@ describe('sanitizeServiceExceptionMessage — the line stays one line', () => {
     expect(sanitizeServiceExceptionMessage('a\u{1F600}b')).toBe('a\u{1F600}b');
   });
 
-  it('flattens an ANSI escape', () => {
+  it('flattens an ANSI escape (a Cc case, listed here for the reader)', () => {
+    // Note for anyone reading this among the widening cases above: U+001B is
+    // `Cc`, so this reds on a `Cc` mutation and NOT on dropping any of the
+    // classes the fix round added. It is kept because a terminal-escape
+    // example is what a reader looks for, not because it fences Zl/Zp/Cs.
     expect(sanitizeServiceExceptionMessage('a\u001B[31mred')).toBe('a [31mred');
   });
 
   it('cuts on code points, so truncation cannot split a surrogate pair', () => {
-    const msg = '\u{1F600}'.repeat(600);
+    // The leading 'A' is load-bearing and was missing at first: with only
+    // two-UTF-16-unit emoji, `.slice(0, 512)` lands on an EXACT code-point
+    // boundary and emits no lone surrogate, so the lone-surrogate assertion
+    // passed under the very mutation it claims to catch. One BMP character in
+    // front makes the UTF-16 cut land mid-pair. Measured both ways.
+    const msg = `A${'\u{1F600}'.repeat(600)}`;
     const out = sanitizeServiceExceptionMessage(msg);
-    expect(out).toBe(`${'\u{1F600}'.repeat(512)}[... truncated; 600-character message]`);
-    // The UTF-16 length is 1200; a `.slice(0, 512)` would have cut mid-pair and
-    // emitted a lone surrogate, which this asserts did not happen.
-    expect(msg.length).toBe(1200);
+    expect(out).toBe(`A${'\u{1F600}'.repeat(511)}[... truncated; 601-character message]`);
+    expect(msg.length).toBe(1201);
     expect([...out].some((c) => /\p{Cs}/u.test(c))).toBe(false);
+    // The mutation this fences, spelled out: a UTF-16 slice of this fixture
+    // ends on the high half of the 256th emoji.
+    expect(/\p{Cs}/u.test(msg.slice(0, 512).at(-1)!)).toBe(true);
   });
 
   it('keeps a 512-character message whole', () => {

--- a/tests/unit/local/credential-error.test.ts
+++ b/tests/unit/local/credential-error.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import {
+  clampErrorName,
+  describeAwsFailureForWarn,
+  describeCredentialLoadFailure,
+  isAwsServiceException,
+  sanitizeServiceExceptionMessage,
+  stringifyThrown,
+} from '../../../src/local/credential-error.js';
+import { getLogger } from '../../../src/utils/logger.js';
+
+/**
+ * Issue #570 — the helper half. The nine CALL SITES are fenced separately in
+ * `tests/unit/cli/sts-error-relay-sites.test.ts`, because a correct helper
+ * says nothing about whether a given `logger.warn` routes through it.
+ */
+
+/**
+ * The shape this exists for, reused from the #564 fixture:
+ * `@aws-sdk/credential-provider-process` copies the rejection of
+ * `promisify(child_process.exec)` — `Command failed: <command line>\n<stderr>`
+ * — into the error it throws, and BOTH lines can carry a passphrase.
+ */
+const PASSPHRASE = 'hunter2-do-not-log';
+const CHAIN_MESSAGE =
+  `Command failed: /opt/bin/get-creds --vault-passphrase ${PASSPHRASE}\n` +
+  `  vault: unlocked with passphrase ${PASSPHRASE}`;
+
+/** Measured below, not assumed. */
+const CHAIN_MESSAGE_LENGTH = 125;
+
+class CredentialsProviderError extends Error {
+  override name = 'CredentialsProviderError';
+}
+
+function namedError(name: string, message: string): Error {
+  const e = new Error(message);
+  Object.defineProperty(e, 'name', { value: name });
+  return e;
+}
+
+/**
+ * A modeled AWS service exception, built the way the SDK builds one: the
+ * `name` comes off the wire (`x-amzn-errortype`) and `$fault` / `$metadata`
+ * are what {@link isAwsServiceException} keys on.
+ */
+function serviceException(name: string, message: string): Error {
+  const e = namedError(name, message);
+  Object.assign(e, {
+    $fault: 'client',
+    $metadata: { httpStatusCode: 403, requestId: 'req-1' },
+  });
+  return e;
+}
+
+function spy(level: 'warn' | 'debug'): { calls: () => string; restore: () => void } {
+  const s = vi.spyOn(getLogger(), level).mockImplementation(() => {});
+  return {
+    calls: () => s.mock.calls.map((c) => String(c[0])).join('\n'),
+    restore: () => s.mockRestore(),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('stringifyThrown — total, so a throw cannot escape a catch', () => {
+  it('returns an Error message', () => {
+    expect(stringifyThrown(new Error('boom'))).toBe('boom');
+  });
+
+  it('measures the chain fixture, so every length assertion below is grounded', () => {
+    expect(stringifyThrown(new CredentialsProviderError(CHAIN_MESSAGE)).length).toBe(
+      CHAIN_MESSAGE_LENGTH
+    );
+  });
+
+  it('pins the CORRECTION to #564: a Symbol throw does not break String()', () => {
+    // #564's JSDoc listed a `Symbol` throw as a `String()` failure. Measured
+    // here instead of assumed: `String(sym)` is fine, and it is template
+    // INTERPOLATION that throws. Both the old code and the helper call
+    // `String()` explicitly, so this case was never reachable — the case is
+    // kept so the corrected claim stays measured rather than remembered.
+    expect(String(Symbol('x'))).toBe('Symbol(x)');
+    expect(() => `${Symbol('x') as unknown as string}`).toThrow(TypeError);
+    expect(stringifyThrown(Symbol('x'))).toBe('Symbol(x)');
+  });
+
+  it('does not throw on a null-prototype object, which String() DOES reject', () => {
+    const hostile = Object.create(null) as object;
+    expect(() => String(hostile)).toThrow(TypeError);
+    expect(stringifyThrown(hostile)).toBe('[unstringifiable throw]');
+  });
+
+  it('does not throw when the thrown value has a toString that throws', () => {
+    const hostile = {
+      toString(): string {
+        throw new Error('nope');
+      },
+    };
+    expect(() => String(hostile)).toThrow('nope');
+    expect(stringifyThrown(hostile)).toBe('[unstringifiable throw]');
+  });
+
+  it('does not throw when an Error message getter throws', () => {
+    const hostile = new Error('placeholder');
+    Object.defineProperty(hostile, 'message', {
+      get(): string {
+        throw new Error('nope');
+      },
+    });
+    expect(stringifyThrown(hostile)).toBe('[unstringifiable throw]');
+  });
+
+  it('stringifies a non-Error throw', () => {
+    expect(stringifyThrown('plain string throw')).toBe('plain string throw');
+  });
+});
+
+describe('clampErrorName — the wire-derived name cannot forge a log line', () => {
+  it('keeps a real class name', () => {
+    expect(clampErrorName(new CredentialsProviderError('x'))).toBe('CredentialsProviderError');
+  });
+
+  it("reports 'unknown' for a non-Error throw rather than guessing a class", () => {
+    expect(clampErrorName('plain string throw')).toBe('unknown');
+  });
+
+  it('keeps a 64-character name and rejects a 65-character one', () => {
+    expect(clampErrorName(namedError('A'.repeat(64), 'x'))).toBe('A'.repeat(64));
+    expect(clampErrorName(namedError('A'.repeat(65), 'x'))).toBe('unknown');
+  });
+
+  it('rejects a newline-carrying forged name outright, not by truncating it', () => {
+    const forged = 'Foo\nWARN: signature verified';
+    // The WRONG fix the JSDoc names: slicing keeps the newline, so the second
+    // line still lands in the log. Assert that slicing would NOT have worked,
+    // so this case cannot go green under it.
+    expect(forged.slice(0, 64)).toContain('\n');
+    expect(clampErrorName(namedError(forged, 'x'))).toBe('unknown');
+  });
+
+  it('rejects a bidi-override name', () => {
+    expect(clampErrorName(namedError('Foo\u202Ebar', 'x'))).toBe('unknown');
+  });
+});
+
+describe('isAwsServiceException — the positively-defined safe state', () => {
+  it('accepts a modeled service exception', () => {
+    expect(isAwsServiceException(serviceException('AccessDenied', 'nope'))).toBe(true);
+  });
+
+  it('rejects a credential-chain error', () => {
+    expect(isAwsServiceException(new CredentialsProviderError(CHAIN_MESSAGE))).toBe(false);
+  });
+
+  it('rejects a plain Error, a string throw, null and undefined', () => {
+    expect(isAwsServiceException(new Error('x'))).toBe(false);
+    expect(isAwsServiceException('x')).toBe(false);
+    expect(isAwsServiceException(null)).toBe(false);
+    expect(isAwsServiceException(undefined)).toBe(false);
+  });
+
+  it('rejects an object carrying only ONE of the two markers', () => {
+    const faultOnly = Object.assign(new Error('x'), { $fault: 'client' });
+    const metadataOnly = Object.assign(new Error('x'), { $metadata: { httpStatusCode: 403 } });
+    expect(isAwsServiceException(faultOnly)).toBe(false);
+    expect(isAwsServiceException(metadataOnly)).toBe(false);
+  });
+
+  it('rejects a $fault that is not one of the two modeled values', () => {
+    const bogus = Object.assign(new Error('x'), {
+      $fault: 'definitely-a-service-error',
+      $metadata: { httpStatusCode: 403 },
+    });
+    expect(isAwsServiceException(bogus)).toBe(false);
+  });
+});
+
+describe('sanitizeServiceExceptionMessage — the line stays one line', () => {
+  it('leaves an ordinary AWS message untouched', () => {
+    const msg = 'The security token included in the request is expired';
+    expect(sanitizeServiceExceptionMessage(msg)).toBe(msg);
+  });
+
+  it('flattens control characters, so an injected newline cannot forge a line', () => {
+    const out = sanitizeServiceExceptionMessage('Denied\nWARN: signature verified\r\nx\tY\u0000Z');
+    expect(out).not.toContain('\n');
+    expect(out).not.toContain('\r');
+    expect(out).not.toContain('\t');
+    expect(out).not.toContain('\u0000');
+    expect(out).toBe('Denied WARN: signature verified  x Y Z');
+  });
+
+  it('flattens a bidi override, which forges how the rest of the line reads', () => {
+    expect(sanitizeServiceExceptionMessage('a\u202Eb')).toBe('a b');
+  });
+
+  it('keeps a 512-character message whole', () => {
+    const msg = 'A'.repeat(512);
+    expect(sanitizeServiceExceptionMessage(msg)).toBe(msg);
+  });
+
+  it('truncates at 513 and names the true length', () => {
+    const out = sanitizeServiceExceptionMessage('A'.repeat(513));
+    expect(out).toBe(`${'A'.repeat(512)}[... truncated; 513-character message]`);
+  });
+
+  it('names the SANITIZED length, which is the string the prefix is a prefix of', () => {
+    // 600 newlines become 600 spaces, so the counts happen to coincide; the
+    // assertion that matters is that the prefix and the count describe the
+    // SAME string — the prefix must be all spaces, not the raw newlines.
+    const out = sanitizeServiceExceptionMessage('\n'.repeat(600));
+    expect(out).toBe(`${' '.repeat(512)}[... truncated; 600-character message]`);
+    expect(out).not.toContain('\n');
+  });
+});
+
+describe('describeCredentialLoadFailure — #564 shape, unchanged by the move', () => {
+  it('reports the clamped class name and the length, never the message', () => {
+    const out = describeCredentialLoadFailure(new CredentialsProviderError(CHAIN_MESSAGE));
+    expect(out).toBe(
+      `CredentialsProviderError; ${CHAIN_MESSAGE_LENGTH}-character message withheld, ` +
+        `logged at debug level under --verbose`
+    );
+    expect(out).not.toContain(PASSPHRASE);
+    expect(out).not.toContain('Command failed');
+  });
+});
+
+describe('describeAwsFailureForWarn — the split by population', () => {
+  it('withholds a credential-chain message and prints it at debug', () => {
+    const debug = spy('debug');
+    const out = describeAwsFailureForWarn(
+      new CredentialsProviderError(CHAIN_MESSAGE),
+      'STS GetCallerIdentity'
+    );
+    expect(out).toBe(
+      `CredentialsProviderError; ${CHAIN_MESSAGE_LENGTH}-character message withheld, ` +
+        `logged at debug level under --verbose`
+    );
+    expect(out).not.toContain(PASSPHRASE);
+    expect(debug.calls()).toContain('STS GetCallerIdentity');
+    expect(debug.calls()).toContain(PASSPHRASE);
+    debug.restore();
+  });
+
+  it('keeps a modeled service exception message, which is the diagnosis', () => {
+    const out = describeAwsFailureForWarn(
+      serviceException('ExpiredToken', 'The security token included in the request is expired'),
+      'STS GetCallerIdentity'
+    );
+    expect(out).toBe('ExpiredToken: The security token included in the request is expired');
+  });
+
+  it('does NOT re-log a kept service message at debug', () => {
+    const debug = spy('debug');
+    describeAwsFailureForWarn(serviceException('AccessDenied', 'nope'), 'STS AssumeRole');
+    expect(debug.calls()).toBe('');
+    debug.restore();
+  });
+
+  it('clamps a forged wire-derived name on the kept branch too', () => {
+    const out = describeAwsFailureForWarn(
+      serviceException('Foo\nWARN: signature verified', 'body'),
+      'STS AssumeRole'
+    );
+    expect(out).toBe('unknown: body');
+    expect(out).not.toContain('\n');
+  });
+
+  it('flattens a forged newline inside a kept service MESSAGE', () => {
+    const out = describeAwsFailureForWarn(
+      serviceException('AccessDenied', 'denied\nWARN: signature verified'),
+      'STS AssumeRole'
+    );
+    expect(out).toBe('AccessDenied: denied WARN: signature verified');
+    expect(out).not.toContain('\n');
+  });
+
+  it('withholds when a hostile endpoint forges the chain class name, i.e. fails safe', () => {
+    // `x-amzn-errortype: CredentialsProviderError` would make `err.name` say
+    // "chain error" while `$fault` still says "service exception". The
+    // discriminator is `$fault` / `$metadata`, so this stays on the KEPT
+    // branch; the point of the assertion is that the forged name cannot make
+    // the helper disclose MORE than the message it already judged printable.
+    const out = describeAwsFailureForWarn(
+      serviceException('CredentialsProviderError', 'body'),
+      'STS AssumeRole'
+    );
+    expect(out).toBe('CredentialsProviderError: body');
+  });
+
+  it('withholds an unrecognised throw shape (a bare string) rather than relaying it', () => {
+    const debug = spy('debug');
+    const out = describeAwsFailureForWarn('raw throw text', 'STS AssumeRole');
+    expect(out).toBe(
+      'unknown; 14-character message withheld, logged at debug level under --verbose'
+    );
+    expect(out).not.toContain('raw throw text');
+    expect(debug.calls()).toContain('raw throw text');
+    debug.restore();
+  });
+
+  it('withholds a socket-level Error, which carries no service diagnosis', () => {
+    const out = describeAwsFailureForWarn(
+      namedError('TimeoutError', 'socket hang up'),
+      'STS GetCallerIdentity'
+    );
+    expect(out).toBe(
+      'TimeoutError; 14-character message withheld, logged at debug level under --verbose'
+    );
+  });
+
+  it('does not throw when the thrown value is unstringifiable', () => {
+    const debug = spy('debug');
+    // `'[unstringifiable throw]'` is 23 characters — the length field
+    // describes the placeholder, which is the only string that exists.
+    expect(describeAwsFailureForWarn(Object.create(null), 'STS AssumeRole')).toBe(
+      'unknown; 23-character message withheld, logged at debug level under --verbose'
+    );
+    debug.restore();
+  });
+});

--- a/tests/unit/local/credential-error.test.ts
+++ b/tests/unit/local/credential-error.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
+  clampErrorCode,
   clampErrorName,
   describeAwsFailureForWarn,
   describeCredentialLoadFailure,
+  flattenToOneLine,
   isAwsServiceException,
   sanitizeServiceExceptionMessage,
   stringifyThrown,
@@ -197,6 +199,35 @@ describe('sanitizeServiceExceptionMessage — the line stays one line', () => {
     expect(sanitizeServiceExceptionMessage('a\u202Eb')).toBe('a b');
   });
 
+  it('flattens U+2028 / U+2029, which are NOT control or format characters', () => {
+    // Measured, because the obvious class misses them: both are Zl / Zp, so a
+    // `[\\p{Cc}\\p{Cf}]` filter leaves them in -- and both are forced line
+    // breaks in the studio UI's `<pre>`, i.e. the forged-line case still open
+    // in HTML while closed in a terminal.
+    expect(/[\p{Cc}\p{Cf}]/u.test('\u2028')).toBe(false);
+    expect(/[\p{Cc}\p{Cf}]/u.test('\u2029')).toBe(false);
+    expect(sanitizeServiceExceptionMessage('a\u2028b\u2029c')).toBe('a b c');
+  });
+
+  it('flattens a LONE surrogate but leaves a well-formed pair alone', () => {
+    expect(sanitizeServiceExceptionMessage('a\uD800b')).toBe('a b');
+    expect(sanitizeServiceExceptionMessage('a\u{1F600}b')).toBe('a\u{1F600}b');
+  });
+
+  it('flattens an ANSI escape', () => {
+    expect(sanitizeServiceExceptionMessage('a\u001B[31mred')).toBe('a [31mred');
+  });
+
+  it('cuts on code points, so truncation cannot split a surrogate pair', () => {
+    const msg = '\u{1F600}'.repeat(600);
+    const out = sanitizeServiceExceptionMessage(msg);
+    expect(out).toBe(`${'\u{1F600}'.repeat(512)}[... truncated; 600-character message]`);
+    // The UTF-16 length is 1200; a `.slice(0, 512)` would have cut mid-pair and
+    // emitted a lone surrogate, which this asserts did not happen.
+    expect(msg.length).toBe(1200);
+    expect([...out].some((c) => /\p{Cs}/u.test(c))).toBe(false);
+  });
+
   it('keeps a 512-character message whole', () => {
     const msg = 'A'.repeat(512);
     expect(sanitizeServiceExceptionMessage(msg)).toBe(msg);
@@ -217,6 +248,45 @@ describe('sanitizeServiceExceptionMessage — the line stays one line', () => {
   });
 });
 
+describe('flattenToOneLine — one emitted line stays one line', () => {
+  it('is what the debug line uses, so a withheld message cannot forge one either', () => {
+    expect(flattenToOneLine('a\nb\r\nc')).toBe('a b  c');
+  });
+
+  it('does not truncate: the debug line exists to carry the whole message', () => {
+    const long = 'A'.repeat(5000);
+    expect(flattenToOneLine(long)).toBe(long);
+  });
+});
+
+describe('clampErrorCode — the field that separates ENOTFOUND from a misconfig', () => {
+  it('returns a Node system-error code', () => {
+    expect(clampErrorCode(Object.assign(new Error('getaddrinfo ENOTFOUND x'), { code: 'ENOTFOUND' }))).toBe(
+      'ENOTFOUND'
+    );
+  });
+
+  it('returns undefined when there is no code, rather than a placeholder', () => {
+    expect(clampErrorCode(new Error('Region is missing'))).toBeUndefined();
+    expect(clampErrorCode('string throw')).toBeUndefined();
+    expect(clampErrorCode(null)).toBeUndefined();
+  });
+
+  it('returns undefined for a non-string code', () => {
+    expect(clampErrorCode(Object.assign(new Error('x'), { code: 42 }))).toBeUndefined();
+  });
+
+  it('clamps by the same rule as the name, so it cannot forge a line either', () => {
+    expect(
+      clampErrorCode(Object.assign(new Error('x'), { code: 'Foo\nWARN: signature verified' }))
+    ).toBeUndefined();
+    expect(clampErrorCode(Object.assign(new Error('x'), { code: 'A'.repeat(65) }))).toBeUndefined();
+    expect(clampErrorCode(Object.assign(new Error('x'), { code: 'A'.repeat(64) }))).toBe(
+      'A'.repeat(64)
+    );
+  });
+});
+
 describe('describeCredentialLoadFailure — #564 shape, unchanged by the move', () => {
   it('reports the clamped class name and the length, never the message', () => {
     const out = describeCredentialLoadFailure(new CredentialsProviderError(CHAIN_MESSAGE));
@@ -226,6 +296,21 @@ describe('describeCredentialLoadFailure — #564 shape, unchanged by the move', 
     );
     expect(out).not.toContain(PASSPHRASE);
     expect(out).not.toContain('Command failed');
+  });
+
+  it('adds the clamped code when the throw carries one', () => {
+    const dns = Object.assign(new Error('getaddrinfo ENOTFOUND sts.us-east-1.amazonaws.com'), {
+      code: 'ENOTFOUND',
+    });
+    expect(describeCredentialLoadFailure(dns)).toBe(
+      'Error ENOTFOUND; 49-character message withheld, logged at debug level under --verbose'
+    );
+  });
+
+  it('omits the code entirely when there is none, keeping #564 output byte-identical', () => {
+    expect(describeCredentialLoadFailure(new CredentialsProviderError('abcdefghij'))).toBe(
+      'CredentialsProviderError; 10-character message withheld, logged at debug level under --verbose'
+    );
   });
 });
 
@@ -247,11 +332,18 @@ describe('describeAwsFailureForWarn — the split by population', () => {
   });
 
   it('keeps a modeled service exception message, which is the diagnosis', () => {
+    // `ExpiredTokenException` is the name `@aws-sdk/client-sts` actually sets
+    // (`dist-cjs/models/errors.js:6`), not the bare wire code.
     const out = describeAwsFailureForWarn(
-      serviceException('ExpiredToken', 'The security token included in the request is expired'),
+      serviceException(
+        'ExpiredTokenException',
+        'The security token included in the request is expired'
+      ),
       'STS GetCallerIdentity'
     );
-    expect(out).toBe('ExpiredToken: The security token included in the request is expired');
+    expect(out).toBe(
+      'ExpiredTokenException: The security token included in the request is expired'
+    );
   });
 
   it('does NOT re-log a kept service message at debug', () => {
@@ -300,6 +392,25 @@ describe('describeAwsFailureForWarn — the split by population', () => {
     );
     expect(out).not.toContain('raw throw text');
     expect(debug.calls()).toContain('raw throw text');
+    debug.restore();
+  });
+
+  it('flattens the withheld text on the DEBUG line too', () => {
+    const debug = spy('debug');
+    describeAwsFailureForWarn(new CredentialsProviderError(CHAIN_MESSAGE), 'STS AssumeRole');
+    const line = debug.calls();
+    // The chain message is two lines; the debug stream is the same stdout
+    // `cdkl studio` mirrors into an HTTP-served ring, so it must arrive as one.
+    expect(line).toContain(PASSPHRASE);
+    expect(line.split('\n')).toHaveLength(1);
+    debug.restore();
+  });
+
+  it('does NOT truncate the debug line: reading it whole is why it exists', () => {
+    const debug = spy('debug');
+    const long = 'B'.repeat(5000);
+    describeAwsFailureForWarn(new CredentialsProviderError(long), 'STS AssumeRole');
+    expect(debug.calls()).toContain(long);
     debug.restore();
   });
 

--- a/tests/unit/local/credential-error.test.ts
+++ b/tests/unit/local/credential-error.test.ts
@@ -139,13 +139,34 @@ describe('stringifyThrown — total, so a throw cannot escape a catch', () => {
     });
     expect(clampErrorCode(codeThrows)).toBeUndefined();
 
-    const faultThrows = Object.defineProperty(new Error('boom'), '$fault', {
-      get(): string {
+    // `$metadata` is load-bearing on this fixture and was missing at first:
+    // `isAwsServiceException` reads `Boolean($metadata) && ...`, so without it
+    // the `&&` short-circuits and the `$fault` getter is NEVER read -- the case
+    // passed with the guard deleted. Measured by counting getter invocations.
+    let faultReads = 0;
+    const faultThrows = Object.defineProperty(
+      Object.assign(new Error('boom'), { $metadata: { httpStatusCode: 403 } }),
+      '$fault',
+      {
+        get(): string {
+          faultReads += 1;
+          throw new Error('nope');
+        },
+      }
+    );
+    expect(isAwsServiceException(faultThrows)).toBe(false);
+    expect(faultReads, 'the $fault getter was never reached, so this case fences nothing').toBe(1);
+    expect(() => describeAwsFailureForWarn(faultThrows, 'STS AssumeRole')).not.toThrow();
+  });
+
+  it('survives a throwing `$metadata` accessor, the property read FIRST', () => {
+    const metadataThrows = Object.defineProperty(new Error('boom'), '$metadata', {
+      get(): unknown {
         throw new Error('nope');
       },
     });
-    expect(isAwsServiceException(faultThrows)).toBe(false);
-    expect(() => describeAwsFailureForWarn(faultThrows, 'STS AssumeRole')).not.toThrow();
+    expect(isAwsServiceException(metadataThrows)).toBe(false);
+    expect(() => describeAwsFailureForWarn(metadataThrows, 'STS AssumeRole')).not.toThrow();
   });
 });
 
@@ -410,7 +431,7 @@ describe('describeAwsFailureForWarn — the split by population', () => {
     expect(out).not.toContain('\n');
   });
 
-  it('withholds when a hostile endpoint forges the chain class name, i.e. fails safe', () => {
+  it('KEEPS a forged chain class name on the service branch, and cannot disclose more', () => {
     // `x-amzn-errortype: CredentialsProviderError` would make `err.name` say
     // "chain error" while `$fault` still says "service exception". The
     // discriminator is `$fault` / `$metadata`, so this stays on the KEPT

--- a/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
+++ b/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
@@ -5,7 +5,10 @@ import {
   type ResolvedCredentials,
 } from '../../../src/local/sigv4-verify.js';
 // Issue #570 lifted the two #564 helpers into their own module when it found
-// nine more sites of the same shape; the definitions moved verbatim.
+// nine more sites of the same shape. The definitions moved unchanged EXCEPT
+// for one addition, fenced at the bottom of this file: the withheld line now
+// names a clamped `err.code` when the throw carries one, which changes this
+// site's output too.
 import { describeCredentialLoadFailure } from '../../../src/local/credential-error.js';
 import { createHash } from 'node:crypto';
 import { getLogger } from '../../../src/utils/logger.js';
@@ -188,8 +191,16 @@ describe('#564 — the credential chain error text never reaches a warn', () => 
     // The actionable detail is not destroyed, only moved to the population
     // that asked for it (`local-start-api.ts` maps `--verbose` to
     // `logger.setLevel('debug')`).
-    expect(debug.calls()).toContain(CHAIN_MESSAGE);
+    //
+    // Issue #570 changed this assertion, and the change is the point: the
+    // message arrives FLATTENED, because the debug stream is the same stdout
+    // `cdkl studio` mirrors into an HTTP-served log ring, so a `\n` here would
+    // forge a line there exactly as it would at `warn`. Every character is
+    // still present -- only the line break became a space.
+    expect(debug.calls()).toContain(CHAIN_MESSAGE.replace('\n', ' '));
+    expect(debug.calls()).not.toContain(CHAIN_MESSAGE);
     expect(debug.calls()).toContain(PASSPHRASE);
+    expect(debug.calls()).toContain('vault: unlocked with passphrase');
     expect(warn.calls()).not.toContain(PASSPHRASE);
     debug.restore();
     warn.restore();
@@ -410,5 +421,42 @@ describe('#561 — the foreign-access-key-id warn-dedup set is bounded', () => {
     const warned = new Set<string>(Array.from({ length: CAP + 10 }, (_, i) => `preexisting-${i}`));
     await warnFor('AKIAFOREIGN', warned);
     expect(warned.size).toBe(CAP);
+  });
+});
+
+describe('#570 — the two changes the lift made to THIS site', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetEmbedConfig();
+  });
+
+  it('names a clamped err.code in the withheld line when the throw carries one', async () => {
+    // The lift added this field, so #564's line is NOT byte-identical for a
+    // chain error wrapping a Node system error -- and `ProviderError.from`
+    // copies `code` onto the wrapper, so that combination is reachable here.
+    const dns = Object.assign(
+      new CredentialsProviderError('getaddrinfo ENOTFOUND sts.us-east-1.amazonaws.com'),
+      { code: 'ENOTFOUND' }
+    );
+    const warn = spy('warn');
+    await verifySigV4(makeRequest('AKIAFOREIGN'), async () => {
+      throw dns;
+    }, { now: () => NOW });
+    expect(warn.calls()).toContain(
+      'CredentialsProviderError ENOTFOUND; 49-character message withheld, ' +
+        'logged at debug level under --verbose'
+    );
+    warn.restore();
+  });
+
+  it('flattens the debug line, because that stream is the studio ring too', async () => {
+    const debug = spy('debug');
+    await verifySigV4(makeRequest('AKIAFOREIGN'), loadThrowsChainError, { now: () => NOW });
+    const lines = debug.calls().split('\n');
+    // The chain fixture is two lines. One emitted call must stay one line.
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain(PASSPHRASE);
+    expect(lines[0]).toContain('vault: unlocked with passphrase');
+    debug.restore();
   });
 });

--- a/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
+++ b/tests/unit/local/sigv4-verify-credential-failure-and-dedup.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
 import {
   verifySigV4,
-  describeCredentialLoadFailure,
   type SigV4VerifyRequest,
   type ResolvedCredentials,
 } from '../../../src/local/sigv4-verify.js';
+// Issue #570 lifted the two #564 helpers into their own module when it found
+// nine more sites of the same shape; the definitions moved verbatim.
+import { describeCredentialLoadFailure } from '../../../src/local/credential-error.js';
 import { createHash } from 'node:crypto';
 import { getLogger } from '../../../src/utils/logger.js';
 import { setEmbedConfig, resetEmbedConfig } from '../../../src/local/embed-config.js';


### PR DESCRIPTION
Closes #570

Follows the policy https://github.com/go-to-k/cdk-local/issues/564 set for one site.

## What was wrong

Nine `logger.warn` lines across five `src/cli/commands/*.ts` files interpolated a
third-party error's `message` verbatim. `warn` prints on a plain run, and `cdkl studio`
mirrors a serve child's output into a log ring it serves over HTTP, so two things could
reach a reader:

- A `credential_process` command line. `@aws-sdk/credential-provider-process` builds its
  failure as `new CredentialsProviderError(error.message)` where `error` is the rejection
  of `promisify(child_process.exec)` -- Node's `Command failed: <command line>\n<stderr>`
  (verified at `@aws-sdk/credential-provider-process@3.972.{39,41,43}`
  `dist-cjs/index.js:56` in this repo's tree). A passphrase on such a command line is
  ordinary.
- Forged log lines. The message is wire-derived for a modeled service exception, and so
  is `err.name`, which `@aws-sdk/core` builds from `x-amzn-errortype` through
  `sanitizeErrorCode` -- which splits on `,` `:` `#` and does nothing else, no length cap
  and no newline stripping (`@aws-sdk/core@3.974.13` `protocols/index.js:324`).

## Nine sites, not the six the issue listed

A grep for warn-level relays of a credential-chain error across the same five files found
three more reaching the identical `catch` through `assumeRoleCredentials` /
`assumeAgentCoreExecutionRole`: `resolveLambdaContainerEnv` (`local-invoke.ts`),
`resolveHostCredentialsForSigV4` and `resolveAgentCoreCodeImageFromS3`
(`local-invoke-agentcore.ts`). Leaving those three would reproduce the split the issue
exists to end, so the lane covers all nine.

## Scope, stated so it is a decision and not an oversight

This policy governs `sigv4-verify.ts`'s one site plus those nine. It does **not** govern
the AWS SDK error relays elsewhere under `src/local/**` -- and two of those,
`formatAwsErrorForWarn` (`cfn-local-state-provider.ts`, six warn sites and one
non-warn caller) and `formatSsmError` (`ssm-parameter-resolver.ts`), print an **unclamped** wire-derived
`err.name`, which is the forging vector this module exists to close. The full audit of
that surface is https://github.com/go-to-k/cdk-local/issues/579, named from the module
header and from `.claude/CLAUDE.md` so the next sweep reads the decision rather than
re-deriving it. It was left out so a cross-cutting refactor of eight more files would not
share a review with the policy that justifies it.

## Why the answer is NOT "withhold everything"

`src/local/sigv4-verify.ts`'s `catch` wraps `client.config.credentials()` and nothing
else, so every error reaching it is a credential-chain error with no diagnosis cdk-local
asked for -- withholding all of it costs nothing. **Its withhold/keep decision is
unchanged**, but the site is not untouched: it inherits the two properties the review
rounds added to the shared helper, and both change its output. Its withheld line names a
clamped `err.code` when the throw carries one (`ProviderError.from` copies `code` onto
the wrapper, so `CredentialsProviderError ENOTFOUND; N-character ...` is reachable), and
its `debug` line is flattened. Both are fenced at the `verifySigV4` level, and
`docs/local-emulation.md` describes the code field.

These nine wrap an STS call cdk-local made, so two populations land in one `catch`: the
chain failing before the request went out, and STS answering with a modeled service
exception whose message IS the diagnosis (`ExpiredTokenException`, `AccessDenied`) and
which never went near `credential_process`.

`describeAwsFailureForWarn` splits by population, on the SDK's own structural test for
"parsed out of a service response" -- not on a deny-list of bad shapes, which
https://github.com/go-to-k/cdk-local/issues/564 already rejected for the `Command failed:`
first line and which loses the same race here:

- service exception -> the message is KEPT, flattened to one line and capped at 512
  code points, with the class name clamped by the same rule 564 uses.
- everything else -> a clamped class name, the clamped `err.code` when there is one, and
  a character count, with the full text emitted at `debug` by the helper itself so
  "withheld at warn" cannot drift apart from "in full at debug" at a tenth site.

An unrecognised shape lands in the withheld bucket. A hostile endpoint forging
`x-amzn-errortype: CredentialsProviderError` does **not**: `$fault` / `$metadata` come
from the HTTP response rather than the errortype, so it stays on the kept branch with the
sanitized message it could have sent under any name. What it cannot do is move a
`credential_process` command line onto that branch -- that text originates locally, in an
error that never acquires `$fault`.

## Per-site decisions, on the two axes

LEVEL is identical at all nine: `warn`, default-level, mirrored into the studio ring.
RECONSTRUCTION differs only in the operation, so all nine take the same split. Four of
them additionally quote a role ARN, and that is its own call:

| Site | Op | Role ARN quoted |
| --- | --- | --- |
| `local-invoke.ts` / `resolvePseudoParametersForInvoke` | GetCallerIdentity | no |
| `local-invoke.ts` / `resolveLambdaContainerEnv` | AssumeRole | yes |
| `local-run-task.ts` / `buildEcsImageResolutionContext` | GetCallerIdentity | no |
| `ecs-service-emulator.ts` / `buildEcsImageResolutionContext` | GetCallerIdentity | no |
| `local-start-api.ts` / `resolvePseudoParametersForStartApi` | GetCallerIdentity | no |
| `local-invoke-agentcore.ts` / `resolveHostCredentialsForSigV4` | AssumeRole | yes |
| `local-invoke-agentcore.ts` / `resolveAgentCoreCodeImageFromS3` | AssumeRole | yes |
| `local-invoke-agentcore.ts` / `buildAgentCoreImageContext` | GetCallerIdentity | no |
| `local-invoke-agentcore.ts` / `applyAgentCoreCredentialEnv` | AssumeRole | yes |

The ARN keeps printing. It is the developer's own `--assume-role` value or an ARN read
from their own deployed stack state, and an ARN is a public identifier -- the same call
https://github.com/go-to-k/cdk-local/issues/555 made for the access-key-id it left
quoted. It is also load-bearing: `tests/integration/local-studio/verify.sh` greps for it
as proof that `--assume-role` threaded from the CLI to the spawned child.

## Behavior change

Those nine warn lines changed their text. Old: the raw `err.message`. New: either
`<Class>: <sanitized message>` for a modeled STS service exception, or
`<Class>[ <CODE>]; N-character message withheld, logged at debug level under --verbose`
for everything else, with the full text at `debug`. Anything matching on those strings
needs updating; a matcher keyed on the role ARN is unaffected. Host tracking issue:
https://github.com/go-to-k/cdkd/issues/2300 (also carries the new `cdk-local/internal`
exports as an optional cat-3 adoption).

Four functions became exported so their sites could be driven by unit tests
(`resolvePseudoParametersForInvoke`, `resolvePseudoParametersForStartApi`,
`resolveHostCredentialsForSigV4`, `resolveAgentCoreCodeImageFromS3`) -- additive.

## Measured corrections to 564's own notes

- `String(aSymbol)` does NOT throw: it returns `'Symbol(x)'`, and it is template
  INTERPOLATION that raises `TypeError`. Since both the old code and the helper call
  `String()` explicitly, a `Symbol` throw was never a reachable case. The two that ARE
  reachable, both verified on this repo's Node 24: an object with a null prototype, and a
  value whose `toString` throws.
- `ExpiredToken` is not a name the SDK sets. `@aws-sdk/client-sts` models
  `ExpiredTokenException` (`dist-cjs/models/errors.js:6`), while `AccessDenied` is
  unmodeled and arrives as the wire code verbatim -- which is exactly why the name is
  clamped rather than trusted.

## Review round (spec / code / test / security, four agents)

Every finding is on one of three paths. Fixed here:

- The sanitizer missed `Zl` / `Zp` (U+2028 / U+2029, forced line breaks in the studio
  UI's `<pre>`, in neither `Cc` nor `Cf`) and `Cs` (a lone surrogate). The 512 cut is on
  code points now, so it cannot split a pair.
- The `debug` line carrying the withheld text is flattened too. That stream is not a
  private channel -- it is the same stdout studio mirrors into the HTTP-served ring -- so
  a newline there forges a line exactly as at `warn`. It is deliberately NOT capped, and
  `docs/troubleshooting.md` now says `--verbose` on a studio-spawned child puts the full
  text in the panel.
- The withheld branch names a clamped `err.code`. Without it `Region is missing`,
  `getaddrinfo ENOTFOUND` and `connect ETIMEDOUT` were indistinguishable.
- The wrong forged-errortype claim, the `ExpiredToken` spelling, and the "four files"
  count are corrected; the "nothing actionable is lost" claim is narrowed.
- The per-row `keeps the role ARN` test was vacuous (the ARN is inside the `reached`
  literal `siteWarn()` already required, so it could not fail). Replaced by a
  table-integrity assertion plus a new per-row case driving a null-prototype throw, so
  `[unstringifiable throw]` is reached through a real call site.
- `sts-error-relay-source-fence.test.ts` closes the tenth-site gap: a new
  `STS <Op> ... failed` warn in those five files must render through the shared helper,
  with a synthesized unguarded site proving the matcher discriminates.
- The note naming which warn spellings collide named one pair; there are two.

Filed as follow-ups, referenced above and from the code:

- https://github.com/go-to-k/cdk-local/issues/579 -- the remaining AWS SDK error relays,
  including the two unclamped-`err.name` helpers.
- https://github.com/go-to-k/cdk-local/issues/578 -- studio matches an unanchored
  ready-line regex against every serve-child stdout line and proxies to the URL it
  captures, with no loopback check. Pre-existing and reachable without any attacker (a
  handler printing `Server listening on ...` trips it), so it is not closed by
  sanitising a log line; the module header says so rather than implying otherwise.
- https://github.com/go-to-k/cdk-local/issues/577 -- a non-zero `cdkl` exit aborts
  `local-invoke-assume-role` before its own FAIL diagnostic runs (hit live in this
  session; the re-run passed).
- https://github.com/go-to-k/cdk-local/issues/576 -- `control-char-gate` scans the index,
  so staging and committing in one call slips a NUL past it (hit live in this session).

### Second review round (same four agents, against the fix round)

One blocker, fixed: `sigv4-verify.ts`'s debug line was not flattened -- the previous
commit wrote the invariant into the helper's JSDoc and applied it to one of the two
debug sites. Also fixed: the role ARN is flattened at the four sites that quote one (the
bare `--assume-role` form resolves it from a live SDK response); the `err.name` /
`err.code` / `$fault` READS are guarded, since each can be a throwing accessor; the
`clampErrorCode` JSDoc claimed `code` is not read off a response, which
`decorateServiceException` disproves; three evasions in the source fence (a sixth file,
a comment vouching for code, one raw-relay spelling); and four tests that were green for
the wrong reason -- most notably the surrogate-truncation case, which passed under the
very mutation it named because 600 two-unit emoji make a UTF-16 cut land on an exact
code-point boundary.

That last one is worth stating plainly: the fix round's own new test was vacuous, and
the probe that should have caught it did not, because the ARN flatten shipped with no
test at all and the probe list was built from the previous round's changes. Both are
fixed and both are now individually probed.

### Third review round

One blocker, fixed: the same wire-derived role ARN prints on FIVE more lines that fire
when the resolution SUCCEEDS -- two of them `logger.info`, a default level -- so they are
strictly more reachable than the four failure warns the second round fixed. All five are
flattened, and a new test file drives every one.

Also fixed: the throwing-`$fault` case added in the second round was VACUOUS (no
`$metadata`, so `isAwsServiceException`'s `&&` short-circuited and the getter was never
read -- it passed with the guard deleted); the source fence's comment stripping handled
only LEADING `//`, its detection was per-line so a template wrapping across a `+` was
invisible, and its raw-relay pattern missed `err.name` -- the `x-amzn-errortype` vector
this whole change exists to close. Matching `sts` case-insensitively turned out to be a
regression, not an improvement: it matched the word `lists ` in a `--tls-cert` help
string and reported an option definition as an unguarded relay.

The fence's docstring now states what it still does NOT catch -- it does not match the
error VALUE, so a neighbouring guarded call vouches for an unguarded site; it is
wording-bound; and `readdirSync` is not recursive.

Three times in this lane a `flattenToOneLine` call shipped with no test, each caught by a
mutation probe rather than by review. That is the honest summary of what the probe
harness bought here.

### Fourth review round

One blocker, fixed: a SIXTH unflattened role-ARN site, and the most reachable of them --
`suggestAssumeRoleFromState`'s `Hint:` line, which fires on a plain
`cdkl invoke --from-cfn-stack <fn>` with no role flag at all. Worth recording WHY it was
missed: the third round enumerated the assume-role RESOLVERS when the population that
matters is the READERS of `resolveExecutionRoleArnFromState`, and this line calls that
helper fifty lines above a site the same commit flattened.

Also fixed: the source fence documented `stripComments` as "fail-CLOSED" while reasoning
only about the helper check -- it is fail-OPEN for the raw-relay check, because a `//`
inside a string truncates the line and can take a raw read with it. The two checks read
different text now (stripped for the helper call, verbatim for the raw relay), which
makes the claim true by construction. Two residuals review found are stated in the
fence's own "what it still does not catch" list rather than implied closed, along with a
same-shaped relay that lives outside the directory it scans.

And a false citation: the code said the ARN's length bound was "recorded in issue #579"
when 579 was entirely about `err.message` relays. The paragraph is there now, and puts
the bound at the three `startsWith('arn:')` resolution points rather than at the log
line -- which also fixes the value SENT to `AssumeRoleCommand.RoleArn`, not just the one
printed.

Two flakes hit during this round and were folded into the issues that already own them
rather than filed again: the vitest worker-fork crash that fails `check-build-test` with
every test passing (https://github.com/go-to-k/cdk-local/issues/402 -- seen today on two
unrelated branches; the re-run was green and the same suite ran green three times
locally), and a `local-invoke` fixture failure that produced no diagnostic at all
(https://github.com/go-to-k/cdk-local/issues/577 -- the same `set -euo pipefail` capture
shape, now confirmed in a second fixture; the command run directly a minute later
exited 0).

Won't-do, recorded: cdk-local's own plain-`Error` throws in `role-arn.ts` are withheld
like any other. Making them identifiable is a separate change and is noted in
`describeCredentialLoadFailure`'s JSDoc and in 579. The `debug`-before-`warn` ordering is
accepted and noted in the JSDoc.

## Retrospective — two patterns worth a rule

- **A needle that is inside its own anchor fences nothing.** The `keeps the role ARN`
  case filtered the warn lines by a literal that already contained the ARN, then
  asserted the ARN was present. It was green under every mutation. The general shape:
  when a test SELECTS a line by a literal and then ASSERTS something about that line,
  the assertion is vacuous for anything the literal already implies. Judgemental rather
  than mechanically detectable, so this is a memory-level lesson, not a hook.
- **A JSDoc that states a case's outcome must be checked against the test for that
  case.** The module header said a forged `x-amzn-errortype: CredentialsProviderError`
  lands in the withheld bucket; the test for exactly that case asserted -- correctly --
  that it lands in the kept one. Both were written in the same sitting and they
  contradicted each other. Mechanically detectable in principle (a doc naming a symbol
  and an outcome, next to a test naming both), but not cheaply, so also memory-level.

The two mechanically-detectable ones became issues instead:
https://github.com/go-to-k/cdk-local/issues/576 (a PreToolUse gate that scans the index
cannot see what the same command is about to stage) and
https://github.com/go-to-k/cdk-local/issues/577 (a fixture whose failure diagnostic is
unreachable under `set -euo pipefail`).

## Verification

- **Per-occurrence mutation probe.** Each of the nine sites was reverted to the raw
  interpolation ONE AT A TIME and the site suite re-run. All nine went RED, each failing
  exactly its own four assertions and no others -- so the fences discriminate per site
  rather than per symbol. Restore was guarded on an in-progress flag written immediately
  before each mutation plus a pre/post sha comparison of all five files: `ALL-RESTORED`.
- **Helper mutation probe, eight mutations, all RED:** narrowing the character class back
  to `Cc|Cf`, a UTF-16 slice instead of code points, dropping the debug flatten, dropping
  the `err.code`, unclamping the `err.code`, `slice(0, 64)` for the name, an always-true
  service-exception test, and dropping the length cap.
- **Live against real AWS on the built `dist/cli.js`,** all three branches: a failing
  credential chain printed `... failed: Error; 17-character message withheld, logged at
  debug level under --verbose.` with `STS AssumeRole: the AWS SDK's own failure message
  was: Region is missing` at debug; a real STS refusal printed `AccessDenied: User:
  arn:aws:iam::<acct>:user/<u> is not authorized to perform: sts:AssumeRole on resource:
  arn:aws:iam::<acct>:role/<r>.` in full; an unreachable endpoint printed
  `Error ENOTFOUND; 54-character message withheld`.
- **Integs:** `local-studio` -- the fixture that proves these lines reach the
  HTTP-served ring, and that greps the bound ring for the `--assume-role` ARN -- plus
  `local-invoke`, both green on the final build. Zero Docker orphans, zero orphan
  CloudFormation stacks.
  `local-invoke-assume-role` (real deploy + destroy, all three assume-role cases) is
  green on an earlier build of this branch and was NOT re-run on the final one: another
  worktree lane was holding that fixture's hard-coded stack name at the time, and
  re-running would have collided with it. The collision is itself a finding, filed as
  https://github.com/go-to-k/cdk-local/issues/582.
- `vp run verify`: 222 files / 3351 tests green, typecheck + lint + build clean.
