### PR TITLE
chore(hooks): a piped markgate verify reports the PIPE exit code, so a STALE gate reads as a pass

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1261,7 +1261,7 @@ vp run runtime:smoke
   a newer `.markgate.yml` for every gate at once, and the hook hides the
   parse error behind a misleading "run /check first".
 
-- **Never pipe `markgate verify` / `markgate set`** — read its verdict
+- **Never pipe `markgate verify` / `set` / `run`** — read its verdict
   with a command substitution, where `$?` is markgate's own status:
 
   ```bash

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1261,6 +1261,25 @@ vp run runtime:smoke
   a newer `.markgate.yml` for every gate at once, and the hook hides the
   parse error behind a misleading "run /check first".
 
+- **Never pipe `markgate verify` / `markgate set`** — read its verdict
+  with a command substitution, where `$?` is markgate's own status:
+
+  ```bash
+  out=$(mise exec -- markgate verify <gate> 2>&1 >/dev/null); rc=$?
+  ```
+
+  `$?` after a pipeline is the LAST STAGE's, and markgate prints
+  NOTHING when a marker is fresh — so `markgate verify integ | tail -5`
+  reports "no output, rc=0" for a STALE marker, which is exactly what a
+  fresh one looks like. The verification the gate was demanding then
+  gets skipped on a false pass; observed live on the `integ` gate
+  (go-to-k/cdk-local#571). `markgate-pipe-gate.sh` refuses the piped
+  spelling.
+  `markgate status | awk …`, `markgate verify … || echo …` and
+  `… && …` all pass through: stdout is `status`'s answer, and `||` /
+  `&&` READ the exit status instead of discarding it.
+  Details: [.claude/rules/hooks.md](.claude/rules/hooks.md).
+
 - **Before opening or merging any PR**: `verify-pr-gate.sh` blocks
   `gh pr create` / `gh pr merge` unless the `verify-pr` marker
   (declared `requires: [check, docs]`) is fresh. The marker is set

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -27,10 +27,23 @@ GATE_SEP_SEMI=$'\002'
 GATE_SEP_PIPE=$'\003'
 GATE_SEP_SUBST=$'\004'
 
+# Appended to a segment that is the LEFT side of a real `|` pipeline, and ONLY
+# when a caller asks for it (`gate_segments_raw <cmd> "$GATE_PIPE_MARK"`). The
+# ordinary separator pass collapses `&&`, `;` and `|` to the same newline, so no
+# gate could tell "its exit status is the caller's" from "the shell threw its
+# exit status away in favour of the last stage" (go-to-k/cdk-local#571). Default
+# empty, so every existing caller gets byte-identical segments.
+GATE_PIPE_MARK=$'\005'
+
+# gate_segments_raw <cmd> [<pipe-mark>]
+#
 # One awk pass: join `\`-continuations, blank heredoc BODIES, neutralise
 # separators inside quotes, and turn every real separator into a newline. Command
 # substitutions (`$(...)` and backticks) become separators too — the text inside
 # one RUNS, so `echo "$(git commit -m x)"` is a commit.
+#
+# <pipe-mark>, when non-empty, is appended to each segment that feeds a `|`
+# pipeline, so a caller can ask which segments had their exit status discarded.
 gate_segments_raw() {
   awk '
     # `q` (the open quote character) is GLOBAL: a quoted span survives a newline,
@@ -48,6 +61,28 @@ gate_segments_raw() {
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
         if (q == "") {
+          # Closing a `$(…)` / backtick substitution that was opened from INSIDE
+          # a double-quoted span (see the sub_open branch below). Until then the
+          # body was left quoted, so `echo "$(gh pr merge 1 --squash)"` matched
+          # NOTHING and ran ungated through every gate here -- the same class of
+          # false accept as go-to-k/cdk-local#571, found by its test suite.
+          #
+          # The close RE-EMITS the enclosing quote character before the rest of
+          # the span. Ending the body needs a newline, and that newline turns
+          # the PROSE that follows the substitution into a fresh segment -- so
+          # `--body "see $(date) then gh pr merge 1"` started a segment at
+          # `then gh pr merge 1`, which `gate_strip_prefix` reduced to a live
+          # verb. That is the go-to-k/cdkd#2130 prose-in-a-body regression,
+          # re-entering through the other end. A leading quote character cannot
+          # be stripped and no verb regex can match past it, so the trailing
+          # prose is inert again while the body stays visible.
+          if (sdepth > 0 && stype[sdepth] == "(" && c == "(") { sparen[sdepth]++; out = out c; continue }
+          if (sdepth > 0 && stype[sdepth] == "(" && c == ")") {
+            sparen[sdepth]--
+            if (sparen[sdepth] <= 0) { out = out "\n" squote[sdepth]; q = squote[sdepth]; sdepth--; continue }
+            out = out c; continue
+          }
+          if (sdepth > 0 && stype[sdepth] == "`" && c == "`") { out = out "\n" squote[sdepth]; q = squote[sdepth]; sdepth--; continue }
           # An escaped character outside quotes is LITERAL: `echo a\; git commit`
           # is ONE echo, and splitting on that `;` blocked it (go-to-k/cdkd#2130
           # test review).
@@ -57,12 +92,41 @@ gate_segments_raw() {
           # Process substitution runs its body too: `diff <(git commit) …`.
           if ((c == "<" || c == ">") && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
           if (c == "`") { out = out "\n"; continue }
-          if (c == "&" || c == ";" || c == "|") { out = out "\n"; continue }
+          # `||` is a logical OR, not a pipe: there the left exit status is
+          # what DECIDES whether the right side runs, so it is never lost. Only
+          # a single `|` (and `|&`) discards it. Consuming both characters also
+          # drops the empty segment `||` used to produce, which `gate_segments`
+          # was filtering out anyway. NOTE no apostrophes in this awk body --
+          # it is a single-quoted shell string.
+          if (c == "|" && substr(line, i + 1, 1) == "|") { out = out "\n"; i++; continue }
+          if (c == "|") { out = out PIPE_MARK "\n"; continue }
+          # `&` is a separator only when it is not part of a REDIRECTION.
+          # `2>&1` used to split here, which cost the anchored verb regexes
+          # nothing (the split lands after the verb) but put the pipe mark on
+          # the wrong segment: `markgate verify integ 2>&1 | tail` marked the
+          # `1` and reported the markgate segment as unpiped -- i.e. the exact
+          # command from go-to-k/cdk-local#571 walked past its own gate.
+          if (c == "&" && substr(line, i + 1, 1) == "&") { out = out "\n"; i++; continue }
+          if (c == "&" && (substr(out, length(out), 1) == ">" || substr(out, length(out), 1) == "<")) { out = out c; continue }
+          if (c == "&" && substr(line, i + 1, 1) == ">") { out = out c; continue }
+          if (c == "&" || c == ";") { out = out "\n"; continue }
           out = out c
           continue
         }
         if (c == "\\" && q == "\"") { out = out c substr(line, i + 1, 1); i++; continue }
         if (c == q) { q = ""; out = out c; continue }
+        # A command substitution inside a DOUBLE-quoted span RUNS. Leaving it
+        # quoted is what let the bypass above through. Inside a SINGLE-quoted
+        # span it is literal, so nothing changes there -- that asymmetry is the
+        # whole point, and it is why this branch tests q rather than assuming.
+        if (q == "\"" && c == "$" && substr(line, i + 1, 1) == "(") {
+          sdepth++; squote[sdepth] = q; stype[sdepth] = "("; sparen[sdepth] = 1
+          q = ""; out = out "\n"; i++; continue
+        }
+        if (q == "\"" && c == "`") {
+          sdepth++; squote[sdepth] = q; stype[sdepth] = "`"; sparen[sdepth] = 0
+          q = ""; out = out "\n"; continue
+        }
         if (c == "&") { out = out SEP_AMP; continue }
         if (c == ";") { out = out SEP_SEMI; continue }
         if (c == "|") { out = out SEP_PIPE; continue }
@@ -141,7 +205,7 @@ gate_segments_raw() {
       open_span = q
     }
     function run_pass(   i) {
-      q = ""; tag = ""; pending = ""; outn = 0; open_span = ""
+      q = ""; tag = ""; pending = ""; outn = 0; open_span = ""; sdepth = 0
       for (i = 1; i <= total; i++) emit(i)
       if (pending != "") outbuf[++outn] = flush_line(pending)
     }
@@ -153,7 +217,7 @@ gate_segments_raw() {
       for (i = 1; i <= outn; i++) print outbuf[i]
     }
   ' SEP_AMP="$GATE_SEP_AMP" SEP_SEMI="$GATE_SEP_SEMI" SEP_PIPE="$GATE_SEP_PIPE" \
-    SEP_SUBST="$GATE_SEP_SUBST" <<< "$1"
+    SEP_SUBST="$GATE_SEP_SUBST" PIPE_MARK="${2:-}" <<< "$1"
 }
 
 # Leading words that introduce a command without being one: env assignments,
@@ -200,9 +264,15 @@ gate_unquote_span() {
   printf '%s' "$v"
 }
 
-# Print one command segment per line, in the ORIGINAL text (placeholders restored).
+# gate_segments <cmd> [<pipe-mark>]
+#
+# Print one command segment per line, in the ORIGINAL text (placeholders
+# restored). <pipe-mark> is threaded straight through to `gate_segments_raw`,
+# INCLUDING into the `bash -c` recursion below — a pipe inside `bash -c "…"` is
+# a pipe, and dropping the argument there would have made the recursion the one
+# blind spot of the piped-segment scan.
 gate_segments() {
-  local segment
+  local segment mark="${2:-}"
   while IFS= read -r segment; do
     # NOT `${segment//"$GATE_SEP_AMP"/&}`: since bash 5.2 an `&` in the
     # replacement means the MATCHED TEXT, so the placeholder survived and a
@@ -221,14 +291,40 @@ gate_segments() {
     # (go-to-k/cdkd#2130 test review). Recurse ONLY here — re-segmenting every
     # segment would split a quoted `--body` whose prose contains `&&`.
     if [[ "$segment" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+(.*)$ ]]; then
-      gate_segments "$(gate_unquote_span "${BASH_REMATCH[2]}")"
+      gate_segments "$(gate_unquote_span "${BASH_REMATCH[2]}")" "$mark"
       continue
     fi
     # An `if`, not `[ … ] && printf`: under a caller's `set -e` the trailing
     # false test aborts the whole function, and the segments after it are never
     # emitted — a silent fail-open that depends on which gate sources this.
     if [ -n "$segment" ]; then printf '%s\n' "$segment"; fi
-  done < <(gate_segments_raw "$1")
+  done < <(gate_segments_raw "$1" "$mark")
+}
+
+# gate_piped_segments <cmd>
+#
+# Print only the segments whose exit status the shell THROWS AWAY because they
+# feed a `|` pipeline — the mark is stripped, so what comes out is ordinary
+# segment text. A segment that is the LAST stage of a pipeline is NOT printed:
+# there `$?` really is that command's own status.
+gate_piped_segments() {
+  local segment
+  while IFS= read -r segment; do
+    case "$segment" in
+      *"$GATE_PIPE_MARK"*) printf '%s\n' "${segment//"$GATE_PIPE_MARK"/}" ;;
+    esac
+  done < <(gate_segments "$1" "$GATE_PIPE_MARK")
+}
+
+# gate_matches_piped <cmd> <extended-regex>
+# 0 when any segment that FEEDS a pipe matches. The piped twin of
+# `gate_matches`, same anchoring and same segment model.
+gate_matches_piped() {
+  local cmd="$1" re="$2" segment
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] && return 0
+  done < <(gate_piped_segments "$cmd")
+  return 1
 }
 
 # gate_matches <cmd> <extended-regex>
@@ -325,6 +421,23 @@ GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:s
 GATE_RE_GH_ISSUE_EDIT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+edit([[:space:]]|$)"
 GATE_RE_GH_ISSUE_COMMENT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)"
 GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
+
+# markgate-pipe-gate: the two markgate verbs whose whole answer is an EXIT CODE.
+# `verify` prints NOTHING on the fresh path, so "no output, rc=0" is exactly
+# what a healthy run looks like -- and exactly what `markgate verify integ
+# 2>&1 | tail -5` reports for a STALE marker, because `$?` after a pipeline is
+# the LAST stage. `markgate status` is deliberately ABSENT: its answer is on
+# stdout, so piping it into `awk` is the correct use and every gate here does
+# it (go-to-k/cdk-local#571).
+#
+# The launcher prefix absorbs the `mise exec -- markgate …` spelling every
+# skill in this repo uses, plus `mise x`, an interposed tool pin
+# (`mise exec markgate@0.4 -- markgate verify check`), and a path-qualified
+# binary. It is anchored at the segment START like every other verb here, so a
+# mention inside `echo`/`printf` is not a match -- the launcher is the ONLY
+# thing allowed to precede `markgate`.
+GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+[^[:space:]]+)*[[:space:]]+)?"
+GATE_RE_MARKGATE_VERDICT="^${GATE_MARKGATE_LAUNCH}([^[:space:]]*/)?markgate[[:space:]]+(verify|set)([[:space:]]|$)"
 # The REST issue COLLECTION path, for issue-dup-check-gate. This matches the
 # PATH ONLY -- it says nothing about the HTTP method, and the collection is also
 # the READ endpoint (`gh api repos/<o>/<r>/issues` lists issues). An earlier

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -492,7 +492,13 @@ GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 # `git -C "/a b" commit` -- so `mise exec --cd "/w t" -- markgate ...` parses.
 GATE_MARKGATE_VALUE_FLAG="(-C|--cd|-E|--env|-j|--jobs|-c|--command)"
 GATE_MARKGATE_FLAG_VALUE="(\"[^\"]*\"|'[^']*'|[^-][^[:space:]]*)"
-GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+(--|${GATE_MARKGATE_VALUE_FLAG}[[:space:]]+${GATE_MARKGATE_FLAG_VALUE}|--?[A-Za-z][^[:space:]]*|[^[:space:]]+@[^[:space:]]+))*[[:space:]]+)?"
+#
+# The GLOBAL flag run before the subcommand (`mise -C /w exec -- markgate ...`)
+# reuses the same alternation minus `--` and the pin, neither of which can
+# precede a subcommand. Without it that spelling was under-matched, i.e. the
+# gate simply did not fire -- the original defect, one flag position away.
+GATE_MARKGATE_GLOBAL="([[:space:]]+(${GATE_MARKGATE_VALUE_FLAG}[[:space:]]+${GATE_MARKGATE_FLAG_VALUE}|--?[A-Za-z][^[:space:]]*))*"
+GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)${GATE_MARKGATE_GLOBAL}[[:space:]]+(exec|x)([[:space:]]+(--|${GATE_MARKGATE_VALUE_FLAG}[[:space:]]+${GATE_MARKGATE_FLAG_VALUE}|--?[A-Za-z][^[:space:]]*|[^[:space:]]+@[^[:space:]]+))*[[:space:]]+)?"
 GATE_RE_MARKGATE_VERDICT="^${GATE_MARKGATE_LAUNCH}([^[:space:]]*/)?markgate[[:space:]]+(verify|set|run)([[:space:]]|$)"
 # The REST issue COLLECTION path, for issue-dup-check-gate. This matches the
 # PATH ONLY -- it says nothing about the HTTP method, and the collection is also

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -280,7 +280,7 @@ gate_unquote_span() {
 # a pipe, and dropping the argument there would have made the recursion the one
 # blind spot of the piped-segment scan.
 gate_segments() {
-  local segment mark="${2:-}" piped
+  local segment mark="${2:-}" piped inner
   while IFS= read -r segment; do
     # NOT `${segment//"$GATE_SEP_AMP"/&}`: since bash 5.2 an `&` in the
     # replacement means the MATCHED TEXT, so the placeholder survived and a
@@ -310,7 +310,15 @@ gate_segments() {
     # (go-to-k/cdkd#2130 test review). Recurse ONLY here — re-segmenting every
     # segment would split a quoted `--body` whose prose contains `&&`.
     if [[ "$segment" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+(.*)$ ]]; then
-      gate_segments "$(gate_unquote_span "${BASH_REMATCH[2]}")" "$mark"
+      # `$piped` is re-attached to every segment the recursion yields, because
+      # the pipe belongs to the OUTER command: in `bash -c 'markgate verify a'
+      # | tail` it is the whole `bash -c` whose exit status the shell discards,
+      # and the recursion had been dropping that fact on the floor, so
+      # `gate_piped_segments` emitted NOTHING and the gate passed. Note it is
+      # `$piped` and not `$GATE_PIPE_MARK`: marking unconditionally would mark
+      # the inner segments of an UN-piped `bash -c` too.
+      while IFS= read -r inner; do printf '%s\n' "$inner$piped"; done \
+        < <(gate_segments "$(gate_unquote_span "${BASH_REMATCH[2]}")" "$mark")
       continue
     fi
     # An `if`, not `[ … ] && printf`: under a caller's `set -e` the trailing
@@ -461,7 +469,13 @@ GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 # `[^[:space:]]+` run instead made `mise exec -- rg markgate verify .claude |
 # head` a FALSE BLOCK, which is a command someone auditing this very gate would
 # type.
-GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+(--|-[^[:space:]]*|[^[:space:]]+@[^[:space:]]+))*[[:space:]]+)?"
+# `--` is its OWN no-value alternative and must come first: letting it take an
+# optional value re-opens the `rg` false block, because `-- rg` would absorb.
+# The flag alternative carries an optional value so the real value-taking
+# launcher flags (`-C <dir>`, `--cd`, `-E/--env`, `-j/--jobs`) still reach the
+# verb -- an earlier revision of this constant tightened them out, which turned
+# `mise exec -C /w -- markgate verify x | tail` from BLOCK into pass.
+GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+(--|--?[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?|[^[:space:]]+@[^[:space:]]+))*[[:space:]]+)?"
 GATE_RE_MARKGATE_VERDICT="^${GATE_MARKGATE_LAUNCH}([^[:space:]]*/)?markgate[[:space:]]+(verify|set|run)([[:space:]]|$)"
 # The REST issue COLLECTION path, for issue-dup-check-gate. This matches the
 # PATH ONLY -- it says nothing about the HTTP method, and the collection is also

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -88,9 +88,17 @@ gate_segments_raw() {
           # test review).
           if (c == "\\") { out = out c substr(line, i + 1, 1); i++; continue }
           if ((c == "\"" || c == "'"'"'") && c != ignore_q) { q = c; out = out c; continue }
-          if (c == "$" && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
+          # These three consume their `(` with `i++`, so it never reaches the
+          # generic paren counter above. A NESTED substitution therefore closed
+          # the OUTER one a paren early, which broke both ways:
+          # `--body "ver $(echo $(date)) then git commit -m z"` re-emitted the
+          # quote too soon and every git/gh gate then REFUSED it, while
+          # `echo "$(echo $(date); gh pr merge 1 --squash)"` still matched
+          # nothing. Count it here instead. The `stype` test matters: a backtick
+          # substitution carries `sparen = 0` and must not be paren-tracked.
+          if (c == "$" && substr(line, i + 1, 1) == "(") { if (sdepth > 0 && stype[sdepth] == "(") sparen[sdepth]++; out = out "\n"; i++; continue }
           # Process substitution runs its body too: `diff <(git commit) …`.
-          if ((c == "<" || c == ">") && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
+          if ((c == "<" || c == ">") && substr(line, i + 1, 1) == "(") { if (sdepth > 0 && stype[sdepth] == "(") sparen[sdepth]++; out = out "\n"; i++; continue }
           if (c == "`") { out = out "\n"; continue }
           # `||` is a logical OR, not a pipe: there the left exit status is
           # what DECIDES whether the right side runs, so it is never lost. Only
@@ -272,7 +280,7 @@ gate_unquote_span() {
 # a pipe, and dropping the argument there would have made the recursion the one
 # blind spot of the piped-segment scan.
 gate_segments() {
-  local segment mark="${2:-}"
+  local segment mark="${2:-}" piped
   while IFS= read -r segment; do
     # NOT `${segment//"$GATE_SEP_AMP"/&}`: since bash 5.2 an `&` in the
     # replacement means the MATCHED TEXT, so the placeholder survived and a
@@ -285,6 +293,17 @@ gate_segments() {
     segment="${segment//"$GATE_SEP_SEMI"/;}"
     segment="${segment//"$GATE_SEP_PIPE"/|}"
     segment="${segment//"$GATE_SEP_SUBST"/$}"
+    # Detach the pipe mark BEFORE `gate_strip_prefix` and re-attach after.
+    # Left in place it is the segment's last character, so the trailing-space
+    # and trailing-`)` trims both no-op: `markgate verify a | tail` came out as
+    # `"markgate verify a "` and `(markgate verify a) | tail` as
+    # `"markgate verify a)"`. Harmless for the start-anchored regexes in use
+    # today, silently fatal for the first `$`-anchored one anybody writes.
+    piped=""
+    if [ -n "$mark" ] && [[ "$segment" == *"$mark"* ]]; then
+      piped="$mark"
+      segment="${segment//"$mark"/}"
+    fi
     segment=$(gate_strip_prefix "$segment")
     # `bash -c "<cmd>"` RUNS its argument, and that argument is a command LIST:
     # matching it as ONE segment missed `bash -c "cd /w && git commit"`
@@ -297,7 +316,7 @@ gate_segments() {
     # An `if`, not `[ … ] && printf`: under a caller's `set -e` the trailing
     # false test aborts the whole function, and the segments after it are never
     # emitted — a silent fail-open that depends on which gate sources this.
-    if [ -n "$segment" ]; then printf '%s\n' "$segment"; fi
+    if [ -n "$segment" ]; then printf '%s\n' "$segment$piped"; fi
   done < <(gate_segments_raw "$1" "$mark")
 }
 
@@ -422,7 +441,8 @@ GATE_RE_GH_ISSUE_EDIT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+edit([[:space
 GATE_RE_GH_ISSUE_COMMENT="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+comment([[:space:]]|$)"
 GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 
-# markgate-pipe-gate: the two markgate verbs whose whole answer is an EXIT CODE.
+# markgate-pipe-gate: the markgate verbs whose whole answer is an EXIT CODE.
+# `run` is `verify || (cmd && set)` sugar, so it has the identical property.
 # `verify` prints NOTHING on the fresh path, so "no output, rc=0" is exactly
 # what a healthy run looks like -- and exactly what `markgate verify integ
 # 2>&1 | tail -5` reports for a STALE marker, because `$?` after a pipeline is
@@ -436,8 +456,13 @@ GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 # binary. It is anchored at the segment START like every other verb here, so a
 # mention inside `echo`/`printf` is not a match -- the launcher is the ONLY
 # thing allowed to precede `markgate`.
-GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+[^[:space:]]+)*[[:space:]]+)?"
-GATE_RE_MARKGATE_VERDICT="^${GATE_MARKGATE_LAUNCH}([^[:space:]]*/)?markgate[[:space:]]+(verify|set)([[:space:]]|$)"
+# The interposed run is restricted to things that can only be launcher
+# arguments -- `--`, a flag, or a `tool@version` pin. An unrestricted
+# `[^[:space:]]+` run instead made `mise exec -- rg markgate verify .claude |
+# head` a FALSE BLOCK, which is a command someone auditing this very gate would
+# type.
+GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+(--|-[^[:space:]]*|[^[:space:]]+@[^[:space:]]+))*[[:space:]]+)?"
+GATE_RE_MARKGATE_VERDICT="^${GATE_MARKGATE_LAUNCH}([^[:space:]]*/)?markgate[[:space:]]+(verify|set|run)([[:space:]]|$)"
 # The REST issue COLLECTION path, for issue-dup-check-gate. This matches the
 # PATH ONLY -- it says nothing about the HTTP method, and the collection is also
 # the READ endpoint (`gh api repos/<o>/<r>/issues` lists issues). An earlier

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -490,7 +490,11 @@ GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 # glued spellings because the token swallows them whole. The value alternation
 # accepts a QUOTED value -- the same fix `GATE_FLAGS` needed for
 # `git -C "/a b" commit` -- so `mise exec --cd "/w t" -- markgate ...` parses.
-GATE_MARKGATE_VALUE_FLAG="(-C|--cd|-E|--env|-j|--jobs|-c|--command)"
+# An enumeration inherits the "too narrow" failure above, so it is taken from
+# `mise exec --help` rather than from memory: these are ALL of its value-taking
+# flags. The `--allow-*` sandbox four were missed on the first pass and were
+# false negatives (the gate simply did not fire).
+GATE_MARKGATE_VALUE_FLAG="(-C|--cd|-E|--env|-j|--jobs|-c|--command|--allow-env|--allow-net|--allow-read|--allow-write)"
 GATE_MARKGATE_FLAG_VALUE="(\"[^\"]*\"|'[^']*'|[^-][^[:space:]]*)"
 #
 # The GLOBAL flag run before the subcommand (`mise -C /w exec -- markgate ...`)

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -469,13 +469,30 @@ GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 # `[^[:space:]]+` run instead made `mise exec -- rg markgate verify .claude |
 # head` a FALSE BLOCK, which is a command someone auditing this very gate would
 # type.
-# `--` is its OWN no-value alternative and must come first: letting it take an
-# optional value re-opens the `rg` false block, because `-- rg` would absorb.
-# The flag alternative carries an optional value so the real value-taking
-# launcher flags (`-C <dir>`, `--cd`, `-E/--env`, `-j/--jobs`) still reach the
-# verb -- an earlier revision of this constant tightened them out, which turned
-# `mise exec -C /w -- markgate verify x | tail` from BLOCK into pass.
-GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+(--|--?[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?|[^[:space:]]+@[^[:space:]]+))*[[:space:]]+)?"
+# Which flags TAKE A VALUE is enumerated rather than guessed, and this constant
+# has now been wrong in all three possible directions, which is why:
+#
+#   too wide   an unrestricted `[^[:space:]]+` run absorbed the command word,
+#              so `mise exec -- rg markgate verify .claude | head` -- the very
+#              command someone auditing this gate types -- was a FALSE BLOCK.
+#   too narrow allowing only `--` / a bare flag / a pin dropped every flag that
+#              takes a value, so `mise exec -C /w -- markgate verify x | tail`
+#              stopped blocking.
+#   generic    giving EVERY flag an optional value made a BOOLEAN flag swallow
+#              the command word instead, re-opening the false block one
+#              keystroke away: `mise exec --raw rg markgate verify . | head`.
+#              mise has many boolean flags (`--raw`, `-q`, `-v`, `-y`,
+#              `--silent`, `--deny-all`, `--no-deps`, `--locked`).
+#
+# So: `--` is its own no-value alternative and comes FIRST (letting it take a
+# value re-opens the false block, since `-- rg` would absorb); the value-taking
+# flags are named; every other flag is boolean, which also covers the `=` and
+# glued spellings because the token swallows them whole. The value alternation
+# accepts a QUOTED value -- the same fix `GATE_FLAGS` needed for
+# `git -C "/a b" commit` -- so `mise exec --cd "/w t" -- markgate ...` parses.
+GATE_MARKGATE_VALUE_FLAG="(-C|--cd|-E|--env|-j|--jobs|-c|--command)"
+GATE_MARKGATE_FLAG_VALUE="(\"[^\"]*\"|'[^']*'|[^-][^[:space:]]*)"
+GATE_MARKGATE_LAUNCH="(([^[:space:]]*/)?(mise|rtx)[[:space:]]+(exec|x)([[:space:]]+(--|${GATE_MARKGATE_VALUE_FLAG}[[:space:]]+${GATE_MARKGATE_FLAG_VALUE}|--?[A-Za-z][^[:space:]]*|[^[:space:]]+@[^[:space:]]+))*[[:space:]]+)?"
 GATE_RE_MARKGATE_VERDICT="^${GATE_MARKGATE_LAUNCH}([^[:space:]]*/)?markgate[[:space:]]+(verify|set|run)([[:space:]]|$)"
 # The REST issue COLLECTION path, for issue-dup-check-gate. This matches the
 # PATH ONLY -- it says nothing about the HTTP method, and the collection is also

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -480,11 +480,11 @@ want_piped 1 "status is not a verdict verb"    'mise exec -- markgate status int
 # `2>&1` is a REDIRECTION, not a separator. Splitting on its `&` put the pipe
 # mark on the trailing `1`, so the issue's own repro walked past the gate.
 want_piped 0 "2>&1 before the pipe"            'markgate verify integ 2>&1 | tail -5' "$MG"
+want_piped 0 "&> before the pipe"              'markgate verify integ &> /dev/null | tail -5' "$MG"
 # ...while a REAL bare `&` still separates.
 want_match 0 "bare & still separates"          'sleep 0 & markgate verify check' "$MG"
 
 want_piped 0 "run is a verdict verb too"        'mise exec -- markgate run check -- vp run check | tail -5' "$MG"
-want_piped 0 "&> before the pipe"              'markgate verify integ &> /dev/null | tail -5' "$MG"
 # The launcher prefix must absorb LAUNCHER ARGUMENTS only. An unrestricted run
 # of words made this a false block -- and it is the command someone auditing
 # this very gate would type.
@@ -497,6 +497,21 @@ want_piped 0 "mise exec -C <dir> -- markgate"  'mise exec -C /w -- markgate veri
 want_piped 0 "mise exec --cd <dir> -- markgate" 'mise exec --cd /w -- markgate verify x | tail' "$MG"
 want_piped 0 "mise exec -j <n> -- markgate"    'mise exec -j 4 -- markgate set integ | tee /tmp/l' "$MG"
 want_piped 1 "mise exec -C <dir> -- rg is not markgate" 'mise exec -C /w -- rg markgate verify . | head' "$MG"
+# ...and a BOOLEAN launcher flag must NOT swallow the command word. Giving every
+# flag an optional value (the fix for the two cases above) re-opened the `rg`
+# false block one keystroke away. mise has many boolean flags: `--raw`, `-q`,
+# `-v`, `-y`, `--silent`, `--deny-all`, `--no-deps`, `--locked`.
+want_piped 1 "boolean flag then rg"            'mise exec --raw rg markgate verify . | head' "$MG"
+want_piped 1 "short boolean flag then rg"      'mise exec -q rg markgate verify . | head' "$MG"
+want_piped 1 "boolean flag then grep"          'mise exec --silent grep -rn markgate verify . | head' "$MG"
+want_piped 0 "boolean flag then -- markgate"   'mise exec --raw -- markgate verify x | tail' "$MG"
+want_piped 0 "two boolean flags then markgate" 'mise exec -q --raw -- markgate verify x | tail' "$MG"
+# A QUOTED flag value -- the same shape `GATE_FLAGS` needed for
+# `git -C "/a b" commit`. A `[^-][^[:space:]]*` value cannot span it.
+want_piped 0 "quoted launcher flag value"      'mise exec --cd "/w t" -- markgate verify x | tail' "$MG"
+# A value-taking flag whose "value" is the command word itself must still fall
+# back to the boolean parse rather than eating it.
+want_piped 0 "-C directly before markgate"     'mise exec -C markgate verify x | tail' "$MG"
 # The pipe belongs to the OUTER command, so the `bash -c` recursion has to carry
 # the mark inward: it used to drop it and `gate_piped_segments` emitted nothing.
 want_piped 0 "bash -c body, outer pipe"        "bash -c 'markgate verify a' | tail" "$MG"

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -509,6 +509,10 @@ want_piped 0 "two boolean flags then markgate" 'mise exec -q --raw -- markgate v
 # A QUOTED flag value -- the same shape `GATE_FLAGS` needed for
 # `git -C "/a b" commit`. A `[^-][^[:space:]]*` value cannot span it.
 want_piped 0 "quoted launcher flag value"      'mise exec --cd "/w t" -- markgate verify x | tail' "$MG"
+# The `--allow-*` sandbox flags take a value too, and were missed when the
+# enumeration was first written -- the failure mode an enumeration always has.
+want_piped 0 "--allow-net <host> before --"    'mise exec --allow-net github.com -- markgate verify integ | tail' "$MG"
+want_piped 0 "--allow-read <path> before --"   'mise exec --allow-read /w -- markgate verify integ | tail' "$MG"
 # A value-taking flag whose "value" is the command word itself must still fall
 # back to the boolean parse rather than eating it.
 want_piped 0 "-C directly before markgate"     'mise exec -C markgate verify x | tail' "$MG"
@@ -519,7 +523,15 @@ want_piped 0 "global -C <dir> before exec"     'mise -C /w exec -- markgate veri
 want_piped 0 "global --cd <dir> before exec"   'mise --cd /w exec -- markgate set integ | tee /tmp/l' "$MG"
 want_piped 0 "global boolean flag before exec" 'mise -q exec -- markgate verify x | tail' "$MG"
 want_piped 1 "global flag, then rg not markgate" 'mise -C /w exec -- rg markgate verify . | head' "$MG"
-want_piped 1 "mise --version is not a launcher" 'mise --version | head' "$MG"
+# ...and a NON-FLAG word is not a global flag. This replaces a
+# `mise --version | head` case that was VACUOUS: that segment holds no
+# `markgate` substring at all, so no spelling of these constants could ever
+# match it -- it was a proof, not a probe. This one is the too-wide direction
+# the whole chain fights: with the global run unrestricted, `ls` is absorbed,
+# the later `exec` satisfies the subcommand, and an ordinary `mise ls` becomes
+# a FALSE BLOCK.
+want_piped 1 "a non-flag word is not a global flag" 'mise ls exec -- markgate verify x | tail' "$MG"
+want_piped 1 "two non-flag words before exec"  'mise settings set x exec -- markgate verify a | tail' "$MG"
 # The pipe belongs to the OUTER command, so the `bash -c` recursion has to carry
 # the mark inward: it used to drop it and `gate_piped_segments` emitted nothing.
 want_piped 0 "bash -c body, outer pipe"        "bash -c 'markgate verify a' | tail" "$MG"

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -512,6 +512,14 @@ want_piped 0 "quoted launcher flag value"      'mise exec --cd "/w t" -- markgat
 # A value-taking flag whose "value" is the command word itself must still fall
 # back to the boolean parse rather than eating it.
 want_piped 0 "-C directly before markgate"     'mise exec -C markgate verify x | tail' "$MG"
+# A GLOBAL flag sits BEFORE the subcommand. Without its own absorber this was
+# under-matched -- the gate simply did not fire, which is the original defect
+# one flag position away.
+want_piped 0 "global -C <dir> before exec"     'mise -C /w exec -- markgate verify x | tail' "$MG"
+want_piped 0 "global --cd <dir> before exec"   'mise --cd /w exec -- markgate set integ | tee /tmp/l' "$MG"
+want_piped 0 "global boolean flag before exec" 'mise -q exec -- markgate verify x | tail' "$MG"
+want_piped 1 "global flag, then rg not markgate" 'mise -C /w exec -- rg markgate verify . | head' "$MG"
+want_piped 1 "mise --version is not a launcher" 'mise --version | head' "$MG"
 # The pipe belongs to the OUTER command, so the `bash -c` recursion has to carry
 # the mark inward: it used to drop it and `gate_piped_segments` emitted nothing.
 want_piped 0 "bash -c body, outer pipe"        "bash -c 'markgate verify a' | tail" "$MG"

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -420,5 +420,69 @@ want_match 1 "an ordinary task run"              'vp run test' "$C"
 # separator INSIDE the quotes, which is the only shape that can distinguish it.
 want_match 1 "separator inside a quoted body" 'gh issue create --body "run vp check && git commit -m x"' "$C"
 
+# --- go-to-k/cdk-local#571: a command substitution inside a DOUBLE-quoted span
+# RUNS, so its body is commands. Leaving it quoted made every gate here blind to
+# it: measured on origin/main, all three of these matched NOTHING.
+want_match 0 "quoted substitution runs"           'echo "$(git commit -m x)"' "$C"
+want_match 0 "quoted backtick substitution runs"  'echo "`git commit -m x`"' "$C"
+want_match 0 "nested quoted substitution"         'X="$(echo "$(git commit -m x)")"' "$C"
+want_match 0 "quoted substitution, gh verb"       'echo "$(gh pr merge 1 --squash)"' "$M"
+# ...and the asymmetry that makes the fix safe rather than a blanket unquoting:
+# inside a SINGLE-quoted span a substitution is literal text, so it must stay
+# invisible. Without this pair the fix could have been "stop honouring quotes".
+want_match 1 "single-quoted substitution is literal" "echo '\$(git commit -m x)'" "$C"
+want_match 1 "single-quoted backticks are literal"   "echo '\`git commit -m x\`'" "$C"
+# The go-to-k/cdkd#2130 regression this could have reintroduced: a `--body`
+# whose PROSE follows a closed substitution is still prose, because `q` returns
+# to the double quote when the substitution ends.
+want_match 1 "prose after a closed substitution" 'gh pr create --body "see $(date) then git commit -m x"' "$C"
+
+# --- go-to-k/cdk-local#571: `gate_piped_segments` / `gate_matches_piped` ------
+# The distinction the ordinary segmenter cannot make, because it collapses `&&`,
+# `;` and `|` to the same newline: whose exit status does the shell REPORT?
+MG="$GATE_RE_MARKGATE_VERDICT"
+
+# want_piped <expect 0|1> <label> <command> <regex>
+want_piped() {
+  local want="$1" label="$2" cmd="$3" re="$4" got
+  if gate_matches_piped "$cmd" "$re"; then got=0; else got=1; fi
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s got %s) :: %s\n' "$label" "$want" "$got" "$cmd"
+  fi
+}
+
+want_piped 0 "verdict feeds a pipe"            'mise exec -- markgate verify integ 2>&1 | tail -5' "$MG"
+want_piped 0 "bare markgate feeds a pipe"      'markgate verify check | grep state' "$MG"
+want_piped 0 "set feeds a pipe"                'mise exec -- markgate set integ | tee /tmp/l' "$MG"
+want_piped 0 "|& feeds a pipe"                 'markgate set integ |& tee /tmp/l' "$MG"
+want_piped 1 "|| is a status TEST, not a pipe" 'mise exec -- markgate set integ || echo NOPE' "$MG"
+want_piped 1 "&& is a status TEST, not a pipe" 'markgate verify check && gh pr merge 1' "$MG"
+want_piped 1 "un-piped verdict"                'mise exec -- markgate verify integ >/dev/null 2>&1; rc=$?' "$MG"
+want_piped 1 "last stage of a pipeline"        'echo x | markgate verify check' "$MG"
+want_piped 1 "status is not a verdict verb"    'mise exec -- markgate status integ | awk "/state/"' "$MG"
+# `2>&1` is a REDIRECTION, not a separator. Splitting on its `&` put the pipe
+# mark on the trailing `1`, so the issue's own repro walked past the gate.
+want_piped 0 "2>&1 before the pipe"            'markgate verify integ 2>&1 | tail -5' "$MG"
+want_piped 0 "&> before the pipe"              'markgate verify integ &> /dev/null | tail -5' "$MG"
+# ...while a REAL bare `&` still separates.
+want_match 0 "bare & still separates"          'sleep 0 & markgate verify check' "$MG"
+
+# `gate_piped_segments` must print the piped segments and ONLY those, with the
+# marker stripped -- a caller reading them as ordinary text is the contract.
+got=$(gate_piped_segments 'markgate verify a | tail; markgate verify b' | tr '\n' '/')
+if [ "$got" = "markgate verify a /" ]; then
+  pass=$((pass + 1)); printf 'OK   gate_piped_segments prints only the piped segment\n'
+else
+  fail=$((fail + 1)); printf 'FAIL gate_piped_segments printed: %s\n' "$got"
+fi
+# The mark must never leak into ORDINARY segments, or every gate would see it.
+if gate_segments 'markgate verify a | tail' | grep -q "$GATE_PIPE_MARK"; then
+  fail=$((fail + 1)); printf 'FAIL the pipe mark leaked into gate_segments output\n'
+else
+  pass=$((pass + 1)); printf 'OK   gate_segments is unchanged by the pipe mark\n'
+fi
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -480,7 +480,6 @@ want_piped 1 "status is not a verdict verb"    'mise exec -- markgate status int
 # `2>&1` is a REDIRECTION, not a separator. Splitting on its `&` put the pipe
 # mark on the trailing `1`, so the issue's own repro walked past the gate.
 want_piped 0 "2>&1 before the pipe"            'markgate verify integ 2>&1 | tail -5' "$MG"
-want_piped 0 "&> before the pipe"              'markgate verify integ &> /dev/null | tail -5' "$MG"
 # ...while a REAL bare `&` still separates.
 want_match 0 "bare & still separates"          'sleep 0 & markgate verify check' "$MG"
 
@@ -490,6 +489,19 @@ want_piped 0 "&> before the pipe"              'markgate verify integ &> /dev/nu
 # of words made this a false block -- and it is the command someone auditing
 # this very gate would type.
 want_piped 1 "mise exec -- rg <pattern> is not markgate" 'mise exec -- rg markgate verify .claude | head' "$MG"
+# A launcher flag that TAKES A VALUE must still reach the verb. Tightening the
+# interposed run to close the `rg` false block above dropped these, turning
+# BLOCK into pass -- so the two cases are pinned as a PAIR, since either fix
+# alone re-breaks the other.
+want_piped 0 "mise exec -C <dir> -- markgate"  'mise exec -C /w -- markgate verify x | tail' "$MG"
+want_piped 0 "mise exec --cd <dir> -- markgate" 'mise exec --cd /w -- markgate verify x | tail' "$MG"
+want_piped 0 "mise exec -j <n> -- markgate"    'mise exec -j 4 -- markgate set integ | tee /tmp/l' "$MG"
+want_piped 1 "mise exec -C <dir> -- rg is not markgate" 'mise exec -C /w -- rg markgate verify . | head' "$MG"
+# The pipe belongs to the OUTER command, so the `bash -c` recursion has to carry
+# the mark inward: it used to drop it and `gate_piped_segments` emitted nothing.
+want_piped 0 "bash -c body, outer pipe"        "bash -c 'markgate verify a' | tail" "$MG"
+want_piped 0 "bash -c double-quoted body"      'bash -c "mise exec -- markgate verify a" | tail' "$MG"
+want_piped 1 "bash -c body, NOT piped"         "bash -c 'markgate verify a'" "$MG"
 want_piped 0 "mise exec with a tool pin"       'mise exec markgate@0.4 -- markgate verify integ | cat' "$MG"
 # Multi-line: the pipe is on a later line than the verb, and on the SAME line as
 # a different one. A segmenter that only ever saw line 1 passed both.

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -437,6 +437,21 @@ want_match 1 "single-quoted backticks are literal"   "echo '\`git commit -m x\`'
 # to the double quote when the substitution ends.
 want_match 1 "prose after a closed substitution" 'gh pr create --body "see $(date) then git commit -m x"' "$C"
 
+# NESTED substitutions. The `$(` / `<(` / `>(` branches consume their `(`
+# without counting it, so the outer substitution used to close a paren early.
+# That broke BOTH ways, and only the second half is the bypass -- the first is a
+# new FALSE BLOCK, which is why both directions are pinned here.
+want_match 1 "nested substitution in a body stays prose" \
+  'gh pr create --body "ver $(echo $(date)) then git commit -m z"' "$C"
+want_match 0 "nested substitution really runs"       'echo "$(echo $(date); gh pr merge 1 --squash)"' "$M"
+want_match 0 "process substitution inside a quoted one" 'echo "$(cat <(git commit -m x))"' "$C"
+# `<(` needs the same paren count as `$(`, and only the FALSE-BLOCK direction
+# discriminates: with the count removed the line above still matches (the verb
+# is inside the substitution either way), while this one flips from no-match to
+# MATCH and every git/gh gate starts refusing an ordinary `gh pr create`.
+want_match 1 "process substitution in a body stays prose" \
+  'gh pr create --body "ver $(cat <(date)) then git commit -m z"' "$C"
+
 # --- go-to-k/cdk-local#571: `gate_piped_segments` / `gate_matches_piped` ------
 # The distinction the ordinary segmenter cannot make, because it collapses `&&`,
 # `;` and `|` to the same newline: whose exit status does the shell REPORT?
@@ -469,13 +484,35 @@ want_piped 0 "&> before the pipe"              'markgate verify integ &> /dev/nu
 # ...while a REAL bare `&` still separates.
 want_match 0 "bare & still separates"          'sleep 0 & markgate verify check' "$MG"
 
+want_piped 0 "run is a verdict verb too"        'mise exec -- markgate run check -- vp run check | tail -5' "$MG"
+want_piped 0 "&> before the pipe"              'markgate verify integ &> /dev/null | tail -5' "$MG"
+# The launcher prefix must absorb LAUNCHER ARGUMENTS only. An unrestricted run
+# of words made this a false block -- and it is the command someone auditing
+# this very gate would type.
+want_piped 1 "mise exec -- rg <pattern> is not markgate" 'mise exec -- rg markgate verify .claude | head' "$MG"
+want_piped 0 "mise exec with a tool pin"       'mise exec markgate@0.4 -- markgate verify integ | cat' "$MG"
+# Multi-line: the pipe is on a later line than the verb, and on the SAME line as
+# a different one. A segmenter that only ever saw line 1 passed both.
+want_piped 0 "multi-line, pipe on line two"    'cd /w/t
+markgate verify integ | tail -5' "$MG"
+want_piped 0 "backslash continuation"          'markgate verify integ \
+  | tail -5' "$MG"
+want_piped 1 "multi-line, un-piped"            'cd /w/t
+markgate verify integ >/dev/null 2>&1; rc=$?' "$MG"
+
 # `gate_piped_segments` must print the piped segments and ONLY those, with the
 # marker stripped -- a caller reading them as ordinary text is the contract.
 got=$(gate_piped_segments 'markgate verify a | tail; markgate verify b' | tr '\n' '/')
-if [ "$got" = "markgate verify a /" ]; then
+if [ "$got" = "markgate verify a/" ]; then
   pass=$((pass + 1)); printf 'OK   gate_piped_segments prints only the piped segment\n'
 else
   fail=$((fail + 1)); printf 'FAIL gate_piped_segments printed: %s\n' "$got"
+fi
+got=$(gate_piped_segments '(markgate verify a) | tail')
+if [ "$got" = "markgate verify a" ]; then
+  pass=$((pass + 1)); printf 'OK   gate_piped_segments emits ordinary segment text\n'
+else
+  fail=$((fail + 1)); printf 'FAIL gate_piped_segments emitted: [%s]\n' "$got"
 fi
 # The mark must never leak into ORDINARY segments, or every gate would see it.
 if gate_segments 'markgate verify a | tail' | grep -q "$GATE_PIPE_MARK"; then

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -126,6 +126,25 @@ run_case "branch-gate: status on main"        0 branch-gate.sh 'git status'
 git -C "$repo" checkout -q feature
 run_case "branch-gate: commit on a feature branch" 0 branch-gate.sh 'git commit -m x'
 
+# markgate-pipe-gate guards the two markgate VERDICT verbs, and only when their
+# exit status feeds a pipe (go-to-k/cdk-local#571). Driven through the real hook
+# here, in addition to markgate-pipe-gate.test.sh, for the cross-gate property
+# this file exists for: a gate that sources the matcher and then asks the WRONG
+# question. Note this gate NEVER runs markgate -- MARKGATE_RC is irrelevant to
+# it, which is itself the reason a piped verdict is un-catchable at runtime and
+# has to be caught statically.
+run_case "markgate-pipe: verify piped to tail"  2 markgate-pipe-gate.sh 'mise exec -- markgate verify integ 2>&1 | tail -5'
+run_case "markgate-pipe: set piped to tee"      2 markgate-pipe-gate.sh 'mise exec -- markgate set integ | tee /tmp/l'
+run_case "markgate-pipe: un-piped verify"       0 markgate-pipe-gate.sh 'mise exec -- markgate verify integ >/dev/null 2>&1; rc=$?'
+run_case "markgate-pipe: || is not a pipe"      0 markgate-pipe-gate.sh 'mise exec -- markgate set integ || echo NOPE'
+run_case "markgate-pipe: status may be piped"   0 markgate-pipe-gate.sh 'mise exec -- markgate status integ | awk /state/'
+run_case "markgate-pipe: unrelated pipe"        0 markgate-pipe-gate.sh 'git status --short | head'
+run_case "markgate-pipe: quoted mention"        0 markgate-pipe-gate.sh 'echo \"markgate verify integ | tail\"'
+# ...and the other direction: a piped markgate is not any OTHER gate's business.
+# Without this, moving the check into (say) check-gate would look identical.
+run_case "check-gate: piped markgate is not its verb"  0 check-gate.sh 'mise exec -- markgate verify integ | tail -5'
+run_case "verify-pr-gate: piped markgate is not its verb" 0 verify-pr-gate.sh 'mise exec -- markgate verify integ | tail -5'
+
 # --- a repo/dir FLAG must not change any gate's verdict ----------------------
 # `gh -R <owner/repo> pr merge 1 --squash` matched NOTHING until 2026-08-25,
 # because GATE_GH_C absorbed `-C <path>` only, so it MERGED PAST verify-pr-gate

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -140,6 +140,8 @@ run_case "markgate-pipe: || is not a pipe"      0 markgate-pipe-gate.sh 'mise ex
 run_case "markgate-pipe: status may be piped"   0 markgate-pipe-gate.sh 'mise exec -- markgate status integ | awk /state/'
 run_case "markgate-pipe: unrelated pipe"        0 markgate-pipe-gate.sh 'git status --short | head'
 run_case "markgate-pipe: quoted mention"        0 markgate-pipe-gate.sh 'echo \"markgate verify integ | tail\"'
+run_case "markgate-pipe: run is a verdict verb"  2 markgate-pipe-gate.sh 'mise exec -- markgate run check -- vp run check | tail -5'
+run_case "markgate-pipe: grepping for the form" 0 markgate-pipe-gate.sh 'mise exec -- rg markgate verify .claude | head'
 # ...and the other direction: a piped markgate is not any OTHER gate's business.
 # Without this, moving the check into (say) check-gate would look identical.
 run_case "check-gate: piped markgate is not its verb"  0 check-gate.sh 'mise exec -- markgate verify integ | tail -5'

--- a/.claude/hooks/markgate-pipe-gate.sh
+++ b/.claude/hooks/markgate-pipe-gate.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # markgate-pipe-gate.sh
 #
-# PreToolUse hook. Blocks a Bash call in which `markgate verify <gate>` or
-# `markgate set <gate>` feeds a `|` pipeline, because there `$?` is the LAST
-# STAGE's exit status and markgate's verdict is thrown away.
+# PreToolUse hook. Blocks a Bash call in which `markgate verify <gate>`,
+# `markgate set <gate>` or `markgate run <gate> -- <cmd>` feeds a `|` pipeline,
+# because there `$?` is the LAST STAGE's exit status and markgate's verdict is
+# thrown away. (`run` is `verify || (cmd && set)` sugar, so it carries the same
+# property.)
 #
 # WHY THIS IS A GATE AND NOT A NOTE (go-to-k/cdk-local#571). markgate answers
 # with an exit code and prints NOTHING on the fresh path, so a healthy run looks
@@ -35,6 +37,12 @@
 #   markgate verify <gate> && …      same -- `&&` is a status test.
 #   echo x | markgate verify <gate>  the LAST stage of a pipeline; `$?` there
 #                                    really is markgate's own.
+#
+# `set -o pipefail; markgate verify <gate> | tail` IS refused, and that is a
+# deliberate conservative call rather than an oversight: pipefail does
+# propagate the status, but this gate reads one command's TEXT and cannot know
+# whether pipefail is still in effect when the pipeline actually runs, and the
+# non-piped rewrite costs nothing. Pinned by a case in the test file.
 #   vp run <task> | tail             same pipeline trap, but `vp` PRINTS its
 #                                    failure, so the output still carries the
 #                                    verdict. Silence on failure is what makes
@@ -75,7 +83,7 @@ cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 gate_matches_piped "$cmd" "$GATE_RE_MARKGATE_VERDICT" || exit 0
 
 cat >&2 <<'EOF'
-Blocked by markgate-pipe-gate: `markgate verify` / `markgate set` is feeding a
+Blocked by markgate-pipe-gate: `markgate verify` / `set` / `run` is feeding a
 pipe, so the exit status you would read is the LAST STAGE's, not markgate's.
 
 markgate prints NOTHING when a marker is fresh, so a piped STALE marker is

--- a/.claude/hooks/markgate-pipe-gate.sh
+++ b/.claude/hooks/markgate-pipe-gate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# markgate-pipe-gate.sh
+#
+# PreToolUse hook. Blocks a Bash call in which `markgate verify <gate>` or
+# `markgate set <gate>` feeds a `|` pipeline, because there `$?` is the LAST
+# STAGE's exit status and markgate's verdict is thrown away.
+#
+# WHY THIS IS A GATE AND NOT A NOTE (go-to-k/cdk-local#571). markgate answers
+# with an exit code and prints NOTHING on the fresh path, so a healthy run looks
+# like "no output, rc=0" -- and so does a STALE one once it is piped:
+#
+#   mise exec -- markgate verify integ 2>&1 | tail -5; echo "rc=$?"
+#   # prints nothing, rc=0    -> read as "marker fresh"
+#   mise exec -- markgate verify integ > /tmp/out 2>&1; rc=$?
+#   # rc=1                    -> the marker was STALE
+#
+# A stale marker is indistinguishable from a fresh one, and the natural next
+# step is to skip the verification the gate was demanding. Observed live while
+# working #564 / #561 on the `integ` gate, where it would have meant opening a
+# PR whose Docker path had never been exercised against the final code. A gate
+# that cannot fail is worse than no gate, because it is trusted.
+#
+# `.claude/skills/verify-pr/SKILL.md` step 1 already warned about `$?` after a
+# pipeline. It was read, and the trap was hit anyway -- on a sibling command the
+# wording did not name. That is the standard case for moving an instruction out
+# of documentation and into enforcement.
+#
+# WHAT IS DELIBERATELY NOT BLOCKED, because a merge gate that over-tightens
+# blocks everyone:
+#
+#   markgate status <gate> | awk …   its answer is on STDOUT; piping it is the
+#                                    correct use, and every gate here does it.
+#   markgate verify <gate> || echo   `||` reads the exit status rather than
+#                                    discarding it; that is the point of it.
+#   markgate verify <gate> && …      same -- `&&` is a status test.
+#   echo x | markgate verify <gate>  the LAST stage of a pipeline; `$?` there
+#                                    really is markgate's own.
+#   vp run <task> | tail             same pipeline trap, but `vp` PRINTS its
+#                                    failure, so the output still carries the
+#                                    verdict. Silence on failure is what makes
+#                                    markgate un-catchable, and it is the line
+#                                    this gate draws.
+#
+# The non-piped rewrite this gate steers to is the one cdkd's `check-gate.sh`
+# uses, where `$?` IS the command's own status:
+#
+#   out=$(mise exec -- markgate verify <gate> 2>&1 >/dev/null); rc=$?
+
+set -u
+
+# Shared, segment-aware command matching (go-to-k/cdk-local#541).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. The `declare -F` check
+# catches a partial source, where `.` succeeds but the function is missing --
+# and here it also catches an OLDER copy of the library that predates
+# `gate_matches_piped`, which would otherwise be an unbound-command no-op that
+# exits 0 on every command.
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
+. "$_gate_lib"
+if ! declare -F gate_matches_piped >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches_piped is undefined (older or truncated file?)." >&2
+  exit 2
+fi
+
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# Only a markgate VERDICT verb that FEEDS a pipe. Everything else -- including
+# the same verb un-piped, `markgate status` piped, and a mention inside a quoted
+# string or a heredoc body -- passes through.
+gate_matches_piped "$cmd" "$GATE_RE_MARKGATE_VERDICT" || exit 0
+
+cat >&2 <<'EOF'
+Blocked by markgate-pipe-gate: `markgate verify` / `markgate set` is feeding a
+pipe, so the exit status you would read is the LAST STAGE's, not markgate's.
+
+markgate prints NOTHING when a marker is fresh, so a piped STALE marker is
+byte-identical to a fresh one: no output, rc=0. The gate silently reports a
+pass and the verification it was demanding gets skipped.
+
+Rewrite with a command substitution, where `$?` IS markgate's own status:
+
+  out=$(mise exec -- markgate verify <gate> 2>&1 >/dev/null); rc=$?
+  echo "[markgate verify <gate> rc=$rc] $out"
+
+  # rc=0 fresh | rc=1 stale or no marker | rc>=2 markgate could not evaluate
+  # (e.g. an unparseable .markgate.yml, or an unresolvable `base` ref for the
+  # `integ` gate -- fix with a bare `git fetch origin`).
+
+Or redirect to a file instead of piping:
+
+  mise exec -- markgate verify <gate> > /tmp/markgate.log 2>&1; rc=$?
+
+These pass through and need no rewrite:
+
+  markgate status <gate> | awk …    stdout IS the answer there
+  markgate verify <gate> || echo …  `||` reads the status, it does not drop it
+  echo x | markgate verify <gate>   last stage: `$?` is markgate's
+
+If you are genuinely only reading `markgate status` text, use `status` -- this
+gate does not touch it.
+EOF
+exit 2

--- a/.claude/hooks/markgate-pipe-gate.test.sh
+++ b/.claude/hooks/markgate-pipe-gate.test.sh
@@ -90,6 +90,7 @@ run_case "boolean flag then -- markgate"              2 'mise exec --raw -- mark
 # --arg`, so a literal `"` needs no escaping). A backslash-escaped `\"` would be
 # a literal quote character to the segmenter and would test the wrong thing.
 run_case "quoted launcher flag value"                2 'mise exec --cd "/w t" -- markgate verify integ | tail -5'
+run_case "global flag before the subcommand"          2 'mise -C /w/t exec -- markgate verify integ | tail -5'
 run_case "inside a command substitution"              2 'echo "$(mise exec -- markgate verify integ | tail -1)"'
 run_case "mise x spelling"                            2 'mise x -- markgate verify integ | cat'
 run_case "mise exec with a tool pin"                  2 'mise exec markgate@0.4 -- markgate verify integ | cat'
@@ -152,6 +153,7 @@ run_case "grepping with the form quoted"              0 'mise exec -- grep -rn "
 run_case "grepping through a -C launcher flag"        0 'mise exec -C /w/t -- rg markgate verify . | head'
 run_case "grepping behind a boolean launcher flag"    0 'mise exec --raw rg markgate verify . | head'
 run_case "grepping behind a short boolean flag"      0 'mise exec -q rg markgate verify . | head'
+run_case "grepping behind a global flag"              0 'mise -C /w/t exec -- rg markgate verify . | head'
 run_case "bash -c body, nothing piped"                0 'bash -c "mise exec -- markgate verify integ"'
 # Multi-line ACCEPT, so the multi-line REFUSE cases above cannot be satisfied by
 # a mutation that simply refuses everything spanning a newline.

--- a/.claude/hooks/markgate-pipe-gate.test.sh
+++ b/.claude/hooks/markgate-pipe-gate.test.sh
@@ -39,6 +39,14 @@ if ! PATH=/usr/bin:/bin command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+# `python3` is used by the second `fail_closed` case. Its absence fails LOUDLY
+# rather than vacuously, but it is a dependency of this file either way, so it
+# is declared here next to `jq` instead of being an undocumented assumption.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "FATAL: python3 is required by the fail_closed cases below." >&2
+  exit 1
+fi
+
 pass=0; fail=0
 
 # run_case <name> <expect_exit> <command>
@@ -78,6 +86,30 @@ run_case "absolute markgate path"                     2 '/opt/homebrew/bin/markg
 run_case "second stage of a longer pipeline"          2 'mise exec -- markgate verify integ | grep -v x | wc -l'
 run_case "leading env assignment"                     2 'FOO=1 mise exec -- markgate verify integ | cat'
 run_case "not the first segment of the list"          2 'vp run check && markgate verify check | tail -1'
+# MULTI-LINE. Every other case here is single-line, and that was a real hole:
+# mutating the segmenter to see only the FIRST line left this suite 38/38 and
+# gate-command-recognition 121/121 green while both spellings below ACCEPTed.
+# Multi-line bash is what agents write most.
+run_case "multi-line: pipe on the second line"        2 'cd /w/t
+mise exec -- markgate verify integ | tail -5
+echo done'
+run_case "backslash continuation before the pipe"     2 'mise exec -- markgate verify integ \
+  | tail -5'
+run_case "multi-line: pipe on the third line"         2 'set -u
+echo starting
+mise exec -- markgate set integ 2>&1 | tee /tmp/l'
+# `markgate run` is `verify || (cmd && set)` sugar, so it has the identical
+# property: the answer is an exit code and the fresh path is silent.
+run_case "run piped (verify||set sugar, same defect)" 2 'mise exec -- markgate run check -- vp run check | tail -5'
+# `&>` is the sibling of the `2>&1` repro at the top of this block. Deleting its
+# guard in the segmenter used to leave this whole suite green.
+run_case "&> before the pipe"                         2 'mise exec -- markgate verify integ &> /dev/null | tail -5'
+# `set -o pipefail` DOES propagate the rc, so this refusal is a deliberate
+# conservative call rather than an oversight -- pinned so the decision is
+# visible if anyone revisits it. The gate reads one command text and cannot
+# know whether pipefail is still in effect when the pipeline runs, and the
+# non-piped rewrite is free.
+run_case "pipefail still refused (by design)"         2 'set -o pipefail; mise exec -- markgate verify check | tail -5'
 
 echo
 echo "== ACCEPT: the exit status is still markgate's =============================="
@@ -102,6 +134,15 @@ run_case "an unrelated pipe"                          0 'git status --short | he
 run_case "an unrelated pipe naming markgate as data"  0 'grep -rn markgate .claude/hooks | head'
 run_case "markgate install is not a verdict verb"     0 'mise exec -- markgate install | tail'
 run_case "empty command"                              0 ''
+# The false block the launcher prefix used to cause: auditing THIS gate is the
+# most likely reason anyone types `markgate verify` as grep input.
+run_case "grepping for the piped form"                0 'mise exec -- rg markgate verify .claude | head'
+run_case "grepping with the form quoted"              0 'mise exec -- grep -rn "markgate verify" .claude | head'
+# Multi-line ACCEPT, so the multi-line REFUSE cases above cannot be satisfied by
+# a mutation that simply refuses everything spanning a newline.
+run_case "multi-line, un-piped verdict"               0 'cd /w/t
+mise exec -- markgate verify integ >/dev/null 2>&1; rc=$?
+echo "[rc=$rc]"'
 
 echo
 echo "== the harness itself ======================================================="

--- a/.claude/hooks/markgate-pipe-gate.test.sh
+++ b/.claude/hooks/markgate-pipe-gate.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Behavioral test for markgate-pipe-gate.sh, driven through the REAL hook with
+# real PreToolUse payloads. Run from the repo root:
+#   bash .claude/hooks/markgate-pipe-gate.test.sh
+#
+# The gate is a false-ACCEPT fix (go-to-k/cdk-local#571), so the REFUSE cases
+# are what prove it works. They are not enough on their own: a refuse-only
+# fence cannot see an over-tightening, and over-tightening this gate would
+# block every legitimate `markgate status | awk` and `markgate set … || echo`
+# in the repo. Both directions are therefore driven, and the ACCEPT block below
+# is as long as the REFUSE block on purpose.
+#
+# HERMETICITY. Each axis is either pinned or measured-and-recorded:
+#   git history  not read -- the gate never shells out to git. Measured: the
+#                payload cwd below is a bare mktemp dir with no repo at all,
+#                and every case still produces its expected verdict.
+#   cwd          pinned to that same throwaway dir via the payload's `cwd`.
+#   env          pinned with `env -i`; only PATH and the payload reach the hook.
+#   PATH         pinned to /usr/bin:/bin (the hook needs `jq` and `bash` only).
+#                No stub is needed because the gate NEVER RUNS markgate -- it
+#                is a static read of the command text. That is also why there
+#                is no MARKGATE_RC here, unlike gate-command-recognition.test.sh.
+#   $HOME        pinned to the throwaway dir, so no user dotfile is sourced.
+#   clock        not read -- no TTL, no timestamp, no marker store.
+#
+# `jq` must exist on PATH for the hook to parse the payload. If it does not,
+# the hook reads an EMPTY command and every case would pass VACUOUSLY, so the
+# harness refuses to run rather than reporting a green suite over nothing.
+
+set -u
+
+HOOKS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$HOOKS/markgate-pipe-gate.sh"
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+if ! PATH=/usr/bin:/bin command -v jq >/dev/null 2>&1; then
+  echo "FATAL: jq is not on the pinned PATH, so every case would pass vacuously." >&2
+  exit 1
+fi
+
+pass=0; fail=0
+
+# run_case <name> <expect_exit> <command>
+# 2 = refused, 0 = allowed through.
+run_case() {
+  local name="$1" want="$2" cmd="$3" got out payload
+  payload=$(jq -nc --arg c "$cmd" --arg d "$SANDBOX" \
+    '{tool_name:"Bash", cwd:$d, tool_input:{command:$c}}')
+  out=$(printf '%s' "$payload" | env -i PATH=/usr/bin:/bin HOME="$SANDBOX" \
+    bash "$GATE" 2>&1); got=$?
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-58s %s\n' "$name" "(exit $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s, got %s)\n  cmd: %s\n  out: %s\n' \
+      "$name" "$want" "$got" "$cmd" "$out"
+  fi
+}
+
+echo "== REFUSE: markgate's verdict feeds a pipe =================================="
+# The literal command from the issue, `2>&1` included. That redirection is not
+# decoration: the segmenter used to split on the `&` inside `2>&1`, which put
+# the pipe mark on the trailing `1` and let THIS EXACT COMMAND through.
+run_case "issue repro: verify integ 2>&1 | tail -5"   2 'mise exec -- markgate verify integ 2>&1 | tail -5'
+run_case "verify piped to tee"                        2 'mise exec -- markgate verify integ 2>&1 | tee /tmp/o'
+run_case "verify piped to grep"                       2 'mise exec -- markgate verify check | grep state'
+run_case "bare markgate (no mise) piped"              2 'markgate verify check | head -3'
+run_case "set piped"                                  2 'mise exec -- markgate set integ | tee /tmp/l'
+run_case "|& (stderr pipe)"                           2 'mise exec -- markgate set integ |& tee /tmp/l'
+run_case "after a cd &&"                              2 'cd /w/t && mise exec -- markgate verify integ | tail -1'
+run_case "after a semicolon"                          2 'cd /w/t; mise exec -- markgate verify integ | tail -1'
+run_case "inside a subshell"                          2 '(cd /w/t && mise exec -- markgate verify integ | tail -1)'
+run_case "inside bash -c"                             2 'bash -c "mise exec -- markgate verify integ | tail"'
+run_case "inside a command substitution"              2 'echo "$(mise exec -- markgate verify integ | tail -1)"'
+run_case "mise x spelling"                            2 'mise x -- markgate verify integ | cat'
+run_case "mise exec with a tool pin"                  2 'mise exec markgate@0.4 -- markgate verify integ | cat'
+run_case "absolute markgate path"                     2 '/opt/homebrew/bin/markgate verify integ | cat'
+run_case "second stage of a longer pipeline"          2 'mise exec -- markgate verify integ | grep -v x | wc -l'
+run_case "leading env assignment"                     2 'FOO=1 mise exec -- markgate verify integ | cat'
+run_case "not the first segment of the list"          2 'vp run check && markgate verify check | tail -1'
+
+echo
+echo "== ACCEPT: the exit status is still markgate's =============================="
+run_case "redirect to a file, then \$?"               0 'mise exec -- markgate verify integ > /tmp/o 2>&1; rc=$?'
+run_case "command substitution, then \$?"             0 'out=$(mise exec -- markgate verify integ 2>&1 >/dev/null); rc=$?'
+run_case "discarded output, then \$?"                 0 'mise exec -- markgate verify integ >/dev/null 2>&1; rc=$?'
+run_case "|| reads the status"                        0 'mise exec -- markgate set integ || echo "MARKER NOT RECORDED"'
+run_case "&& reads the status"                        0 'mise exec -- markgate verify check && gh pr merge 1 --squash'
+run_case "|| and && together"                         0 'markgate verify check && echo fresh || echo stale'
+run_case "bare verify, nothing after it"              0 'mise exec -- markgate verify integ'
+run_case "bare set, nothing after it"                 0 'mise exec -- markgate set check'
+run_case "status piped to awk (the hooks' own idiom)" 0 'mise exec -- markgate status integ | awk "/^state:/"'
+run_case "status piped to grep"                       0 'markgate status check | grep state'
+run_case "last stage of a pipeline"                   0 'echo x | markgate verify check'
+run_case "quoted mention of the piped form"           0 'echo "mise exec -- markgate verify integ | tail"'
+run_case "single-quoted mention"                      0 "echo 'markgate verify integ | tail'"
+run_case "heredoc body mentioning the piped form"     0 'cat <<EOF
+mise exec -- markgate verify integ | tail -5
+EOF'
+run_case "a comment mentioning the piped form"        0 'echo hi   # markgate verify integ | tail'
+run_case "an unrelated pipe"                          0 'git status --short | head'
+run_case "an unrelated pipe naming markgate as data"  0 'grep -rn markgate .claude/hooks | head'
+run_case "markgate install is not a verdict verb"     0 'mise exec -- markgate install | tail'
+run_case "empty command"                              0 ''
+
+echo
+echo "== the harness itself ======================================================="
+# The gate must FAIL CLOSED when the shared library is unusable, rather than
+# waving every command through. Two shapes: absent, and present-but-older (a
+# copy that predates `gate_matches_piped`, where the call would be an unbound
+# command and `|| exit 0` would exit 0 on EVERYTHING).
+# fail_closed <name> <expected message fragment> <mutation>
+#
+# The fragment is load-bearing, not decoration. Deleting the library trips BOTH
+# guards -- the readability test AND the `declare -F` test after the failed
+# source -- so asserting only "exit 2 mentioning _command-match.sh" is satisfied
+# twice over, and a mutation probe confirmed it: removing the readability guard
+# entirely left this case GREEN. Naming which guard must speak makes each case
+# fence its own guard.
+fail_closed() {
+  local name="$1" want="$2" mutate="$3" tmp out rc
+  tmp="$SANDBOX/lib-$RANDOM"; mkdir -p "$tmp"
+  cp "$HOOKS/markgate-pipe-gate.sh" "$tmp/"
+  cp "$HOOKS/_command-match.sh" "$tmp/"
+  eval "$mutate"
+  out=$(jq -nc --arg d "$SANDBOX" '{tool_name:"Bash",cwd:$d,tool_input:{command:"markgate verify check | tail"}}' \
+    | env -i PATH=/usr/bin:/bin HOME="$SANDBOX" bash "$tmp/markgate-pipe-gate.sh" 2>&1); rc=$?
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "$want"; then
+    pass=$((pass + 1)); printf 'OK   %-58s %s\n' "$name" "(exit $rc)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s must exit 2 saying "%s" (got %s)\n  out: %s\n' "$name" "$want" "$rc" "$out"
+  fi
+}
+fail_closed "library absent" "is missing or unreadable" 'rm -f "$tmp/_command-match.sh"'
+fail_closed "library predates gate_matches_piped" "gate_matches_piped is undefined" \
+  'python3 - "$tmp/_command-match.sh" <<STRIP
+import io,sys
+p=sys.argv[1]; s=io.open(p,encoding="utf-8").read()
+a=s.index("gate_matches_piped() {")
+b=s.index("\nreturn 1\n}", a) if False else s.index("\n}\n", a)+3
+io.open(p,"w",encoding="utf-8").write(s[:a]+s[b:])
+STRIP'
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/markgate-pipe-gate.test.sh
+++ b/.claude/hooks/markgate-pipe-gate.test.sh
@@ -85,6 +85,11 @@ run_case "bash -c body with the pipe OUTSIDE"         2 'bash -c "mise exec -- m
 # Launcher flags that take a value must still reach the verb.
 run_case "mise exec -C <dir> -- markgate"             2 'mise exec -C /w/t -- markgate verify integ | tail -5'
 run_case "mise exec --cd <dir> -- markgate"           2 'mise exec --cd /w/t -- markgate set integ | tee /tmp/l'
+run_case "boolean flag then -- markgate"              2 'mise exec --raw -- markgate verify integ | tail -5'
+# The value is REALLY quoted here (this suite builds its payload with `jq
+# --arg`, so a literal `"` needs no escaping). A backslash-escaped `\"` would be
+# a literal quote character to the segmenter and would test the wrong thing.
+run_case "quoted launcher flag value"                2 'mise exec --cd "/w t" -- markgate verify integ | tail -5'
 run_case "inside a command substitution"              2 'echo "$(mise exec -- markgate verify integ | tail -1)"'
 run_case "mise x spelling"                            2 'mise x -- markgate verify integ | cat'
 run_case "mise exec with a tool pin"                  2 'mise exec markgate@0.4 -- markgate verify integ | cat'
@@ -145,6 +150,8 @@ run_case "empty command"                              0 ''
 run_case "grepping for the piped form"                0 'mise exec -- rg markgate verify .claude | head'
 run_case "grepping with the form quoted"              0 'mise exec -- grep -rn "markgate verify" .claude | head'
 run_case "grepping through a -C launcher flag"        0 'mise exec -C /w/t -- rg markgate verify . | head'
+run_case "grepping behind a boolean launcher flag"    0 'mise exec --raw rg markgate verify . | head'
+run_case "grepping behind a short boolean flag"      0 'mise exec -q rg markgate verify . | head'
 run_case "bash -c body, nothing piped"                0 'bash -c "mise exec -- markgate verify integ"'
 # Multi-line ACCEPT, so the multi-line REFUSE cases above cannot be satisfied by
 # a mutation that simply refuses everything spanning a newline.

--- a/.claude/hooks/markgate-pipe-gate.test.sh
+++ b/.claude/hooks/markgate-pipe-gate.test.sh
@@ -79,6 +79,12 @@ run_case "after a cd &&"                              2 'cd /w/t && mise exec --
 run_case "after a semicolon"                          2 'cd /w/t; mise exec -- markgate verify integ | tail -1'
 run_case "inside a subshell"                          2 '(cd /w/t && mise exec -- markgate verify integ | tail -1)'
 run_case "inside bash -c"                             2 'bash -c "mise exec -- markgate verify integ | tail"'
+# The pipe OUTSIDE `bash -c`: the recursion used to drop the outer mark, so
+# `gate_piped_segments` emitted nothing and the gate passed.
+run_case "bash -c body with the pipe OUTSIDE"         2 'bash -c "mise exec -- markgate verify integ" | tail -5'
+# Launcher flags that take a value must still reach the verb.
+run_case "mise exec -C <dir> -- markgate"             2 'mise exec -C /w/t -- markgate verify integ | tail -5'
+run_case "mise exec --cd <dir> -- markgate"           2 'mise exec --cd /w/t -- markgate set integ | tee /tmp/l'
 run_case "inside a command substitution"              2 'echo "$(mise exec -- markgate verify integ | tail -1)"'
 run_case "mise x spelling"                            2 'mise x -- markgate verify integ | cat'
 run_case "mise exec with a tool pin"                  2 'mise exec markgate@0.4 -- markgate verify integ | cat'
@@ -138,6 +144,8 @@ run_case "empty command"                              0 ''
 # most likely reason anyone types `markgate verify` as grep input.
 run_case "grepping for the piped form"                0 'mise exec -- rg markgate verify .claude | head'
 run_case "grepping with the form quoted"              0 'mise exec -- grep -rn "markgate verify" .claude | head'
+run_case "grepping through a -C launcher flag"        0 'mise exec -C /w/t -- rg markgate verify . | head'
+run_case "bash -c body, nothing piped"                0 'bash -c "mise exec -- markgate verify integ"'
 # Multi-line ACCEPT, so the multi-line REFUSE cases above cannot be satisfied by
 # a mutation that simply refuses everything spanning a newline.
 run_case "multi-line, un-piped verdict"               0 'cd /w/t

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -226,9 +226,11 @@ The hooks split into three classes:
   unauthenticated.
 
 - **`markgate-pipe-gate.sh`** blocks a Bash call in which
-  `markgate verify <gate>` or `markgate set <gate>` feeds a `|`
-  pipeline, because there `$?` is the LAST STAGE's status and
-  markgate's verdict is discarded. It is the one gate here selected on
+  `markgate verify <gate>`, `markgate set <gate>` or `markgate run
+  <gate> -- <cmd>` feeds a `|` pipeline, because there `$?` is the LAST
+  STAGE's status and markgate's verdict is discarded. (`run` is
+  `verify || (cmd && set)` sugar, so it has the identical property; it
+  is unused in this repo today but it is in `markgate --help`.) It is the one gate here selected on
   a command word that is neither `git` nor `gh` (`Bash(*markgate*)`),
   and the only one that never runs the tool it is named after — the
   check is a static read of the command text.
@@ -269,6 +271,11 @@ The hooks split into three classes:
   `markgate verify <gate> || echo …` and `&& …` (`||` / `&&` READ the
   status rather than dropping it); and `… | markgate verify <gate>`
   (the last stage of a pipeline, where `$?` really is markgate's).
+  `set -o pipefail; markgate verify <gate> | tail` IS refused even
+  though pipefail propagates the status — the gate reads one command's
+  TEXT and cannot know pipefail is still in effect when the pipeline
+  runs, and the non-piped rewrite is free. That call is conservative by
+  choice and pinned by its own case.
 
   Implemented on `gate_matches_piped` / `gate_piped_segments` in
   `_command-match.sh`, which needed the separator pass to stop

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -225,6 +225,75 @@ The hooks split into three classes:
   / etc. pass through). Fails open when `gh` is missing or
   unauthenticated.
 
+- **`markgate-pipe-gate.sh`** blocks a Bash call in which
+  `markgate verify <gate>` or `markgate set <gate>` feeds a `|`
+  pipeline, because there `$?` is the LAST STAGE's status and
+  markgate's verdict is discarded. It is the one gate here selected on
+  a command word that is neither `git` nor `gh` (`Bash(*markgate*)`),
+  and the only one that never runs the tool it is named after — the
+  check is a static read of the command text.
+
+  **Why a gate and not another sentence in a skill**
+  (go-to-k/cdk-local#571). markgate prints NOTHING when a marker is
+  fresh, so "no output, rc=0" is what a healthy run looks like — and
+  exactly what a STALE marker reports once piped:
+
+  ```bash
+  mise exec -- markgate verify integ 2>&1 | tail -5; echo "rc=$?"
+  # prints nothing, rc=0    -> read as "marker fresh"
+  mise exec -- markgate verify integ > /tmp/out 2>&1; rc=$?
+  # rc=1                    -> the marker was STALE
+  ```
+
+  A stale marker becomes indistinguishable from a fresh one, and the
+  natural next step is to skip the verification the gate was demanding.
+  Observed live on the `integ` gate, where it would have meant opening
+  a PR whose Docker path was never exercised against the final code.
+  A gate that cannot fail is worse than no gate, because it is trusted.
+  `/verify-pr` step 1 already warned that `$?` after a pipeline is the
+  last stage's; it was read, and the trap was hit anyway — on a sibling
+  command the wording did not name. `vp run <task>` has the same
+  property but PRINTS its failure, so the output still carries the
+  verdict; silence on failure is what makes markgate un-catchable and
+  is the line this gate draws.
+
+  **Rewrite it names**, the same one cdkd's `check-gate.sh` uses:
+
+  ```bash
+  out=$(mise exec -- markgate verify <gate> 2>&1 >/dev/null); rc=$?
+  ```
+
+  **Deliberately NOT blocked**, because over-tightening this would
+  break the repo's own idioms: `markgate status <gate> | awk …` (its
+  answer is on stdout — every gate hook here pipes it that way);
+  `markgate verify <gate> || echo …` and `&& …` (`||` / `&&` READ the
+  status rather than dropping it); and `… | markgate verify <gate>`
+  (the last stage of a pipeline, where `$?` really is markgate's).
+
+  Implemented on `gate_matches_piped` / `gate_piped_segments` in
+  `_command-match.sh`, which needed the separator pass to stop
+  collapsing `&&`, `;` and `|` into the same newline. Two consequences
+  of that work are shared by EVERY gate, not just this one:
+
+  - **`2>&1` is a redirection, not a separator.** The `&` inside it
+    used to split a segment. That cost the anchored verb regexes
+    nothing (the split lands after the verb) but it put the pipe mark
+    on the trailing `1`, so the issue's own repro walked past its own
+    gate.
+  - **A command substitution inside a DOUBLE-quoted span RUNS**, so its
+    body is commands. It used to stay quoted, which meant
+    `echo "$(gh pr merge 1 --squash)"` and ``echo "`git commit -m x`"``
+    matched NOTHING and ran ungated through every gate in this file —
+    a pre-existing live bypass, found by
+    go-to-k/cdk-local#571's test suite and fixed
+    with it. Inside a SINGLE-quoted span a substitution is literal, so
+    that stays invisible; the asymmetry is the point. Closing the
+    substitution re-emits the enclosing quote character, so PROSE
+    following it (`--body "see $(date) then gh pr merge 1"`) stays
+    inert — without that, ending the body would have started a fresh
+    segment mid-prose and reintroduced the go-to-k/cdkd#2130
+    body-text regression from the other end.
+
 ## 2. Branch / push safety
 
 - **`branch-gate.sh`** blocks `git commit` and `git push` when the
@@ -256,7 +325,9 @@ The hooks split into three classes:
 The seven markgate gate hooks (`check-gate.sh`, `verify-pr-gate.sh`,
 `pr-review-gate.sh`, `integ-gate.sh`, `cdkd-parity-gate.sh`,
 `create-integ-gate.sh`, and `gh-pr-merge-worktree-gate.sh`) are
-all **cwd-aware**. Each reads the PreToolUse payload's `cwd` field, then hands
+all **cwd-aware**. (`markgate-pipe-gate.sh` is named after markgate but
+is NOT one of them: it never runs markgate, never reads a marker, and
+so has no target directory to resolve — it lives in class 1 above.) Each reads the PreToolUse payload's `cwd` field, then hands
 the command to `gate_target_dir` in `.claude/hooks/_command-match.sh`, which
 resolves the tree in this order: a `git -C <path>` / `gh -C <path>` inside the
 MATCHED segment, else the LAST `cd <path>` segment before it, else the payload

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -184,6 +184,13 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/markgate-pipe-gate.sh",
+            "if": "Bash(*markgate*)",
+            "timeout": 10,
+            "statusMessage": "Checking markgate is not piped..."
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/check-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 15,

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -65,7 +65,7 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    record the gate so subsequent `gh pr merge` calls are unblocked:
 
    ```bash
-   mise exec -- markgate set integ || echo "MARKER NOT RECORDED — read the error above"
+   mise exec -- markgate set integ || echo "MARKER NOT RECORDED (rc=$?) — read the error above"
    ```
 
    **Check the exit code; do not assume the set succeeded.** Under `hash: files` this command could not fail, so it was safe to fire and forget. Under `hash: diff` it CAN fail, and it reports the reason on stderr — an unchecked call looks silent and successful while nothing was recorded. The failure modes and their fixes:

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -22,6 +22,7 @@ Run each check and report pass/fail:
    - `vp run check` passes (unified typecheck + lint + format)
    - `vp run build` succeeds (produces `dist/cli.js` + `dist/index.js`)
    - When piping any of the above to `tail` / `head` / `grep`, **check the actual output content** for `Error` / `Command failed` markers — `$?` after a pipeline reflects the LAST stage (usually 0), NOT the build tool's exit. When in doubt, capture without piping: `vp run X > /tmp/out 2>&1; rc=$?; tail -3 /tmp/out; echo "[rc=$rc]"`.
+   - **The same trap applies to `markgate verify` / `markgate set`, and there it is worse**: markgate answers with an EXIT CODE and prints nothing on the fresh path, so a piped STALE marker is byte-identical to a fresh one (no output, rc=0) and there is no output content left to check. `.claude/hooks/markgate-pipe-gate.sh` now refuses a piped `markgate verify` / `markgate set` outright (go-to-k/cdk-local#571) — this bullet is why. `markgate status` is unaffected: its answer is on stdout, so piping it to `awk` is correct.
 
 2. **Tests**
    - `vp run test` — all unit tests pass
@@ -51,11 +52,17 @@ Run each check and report pass/fail:
    # Only check when the PR diff actually touches the gate scope.
    if git diff origin/main...HEAD --name-only \
        | grep -qE '^src/cli/commands/|^src/internal\.ts$|^src/index\.ts$'; then
-     mise exec -- markgate verify cdkd-parity
+     out=$(mise exec -- markgate verify cdkd-parity 2>&1 >/dev/null); rc=$?
+     echo "[markgate verify cdkd-parity rc=$rc] $out"
    fi
    ```
 
-   If this exits non-zero (digest differs OR marker never set), run `/check-cdkd-parity` to walk the four host-impacting categories — new subcommand factory / new CLI option / new public helper / behavior change — and set the marker. See `.claude/skills/check-cdkd-parity/SKILL.md` and `.claude/rules/hooks.md` "cdkd-parity-gate (pre-create)".
+   The command substitution is not a style choice: `$?` there IS markgate's own
+   status, whereas `markgate verify … | tail` reports the PIPE's and a stale
+   marker reads as a pass. `markgate-pipe-gate.sh` blocks the piped spelling.
+
+   If `rc` is non-zero (1 = digest differs OR marker never set; >= 2 = markgate
+   could not evaluate at all), run `/check-cdkd-parity` to walk the four host-impacting categories — new subcommand factory / new CLI option / new public helper / behavior change — and set the marker. See `.claude/skills/check-cdkd-parity/SKILL.md` and `.claude/rules/hooks.md` "cdkd-parity-gate (pre-create)".
 
 7. **Docker + integ verification** (for src/** or tests/integration/** touches)
 
@@ -64,11 +71,14 @@ Run each check and report pass/fail:
    ```bash
    # Only check when the PR diff actually touches the gate scope.
    if git diff origin/main...HEAD --name-only | grep -qE '^src/|^tests/integration/'; then
-     mise exec -- markgate verify integ
+     out=$(mise exec -- markgate verify integ 2>&1 >/dev/null); rc=$?
+     echo "[markgate verify integ rc=$rc] $out"
    fi
    ```
 
-   If this exits non-zero (digest differs OR expired by 14d TTL), run `/run-integ <test>` against a test that exercises the changed surface — `local-start-api` for HTTP-server / route-discovery / authorizer / container-pool changes, `local-invoke` for Lambda-runtime / ZIP-asset changes, `local-run-task` for ECS task changes, `local-invoke-container` for container-Lambda changes, `local-invoke-layers` for Lambda Layers changes, `local-invoke-from-cfn-stack` for `--from-cfn-stack` AWS-binding changes. The `/run-integ` skill calls `markgate set integ` itself when the Docker-side check passes (0 orphan containers / networks; for `*-from-cfn-stack` tests, also 0 orphan CloudFormation stacks). CI is necessary but not sufficient — it does not exercise Docker-based local execution.
+   If `rc` is non-zero (1 = digest differs OR expired by 14d TTL; >= 2 = markgate
+   could not evaluate — for this gate most often an unresolvable `base` ref,
+   fixed with a bare `git fetch origin`), run `/run-integ <test>` against a test that exercises the changed surface — `local-start-api` for HTTP-server / route-discovery / authorizer / container-pool changes, `local-invoke` for Lambda-runtime / ZIP-asset changes, `local-run-task` for ECS task changes, `local-invoke-container` for container-Lambda changes, `local-invoke-layers` for Lambda Layers changes, `local-invoke-from-cfn-stack` for `--from-cfn-stack` AWS-binding changes. The `/run-integ` skill calls `markgate set integ` itself when the Docker-side check passes (0 orphan containers / networks; for `*-from-cfn-stack` tests, also 0 orphan CloudFormation stacks). CI is necessary but not sufficient — it does not exercise Docker-based local execution.
 
    For `*-from-cfn-stack` integ tests only: verify no orphan CloudFormation stack remains (`aws cloudformation describe-stacks --stack-name <FixtureStackName>` should return `Stack does not exist`).
 

--- a/tests/unit/hooks/gate-if-matchers.test.ts
+++ b/tests/unit/hooks/gate-if-matchers.test.ts
@@ -68,6 +68,10 @@ const REQUIRED: Record<string, string[]> = {
   'cdkd-parity-gate.sh': ['Bash(*gh*pr*create*)'],
   'create-integ-gate.sh': ['Bash(*gh*pr*create*)'],
   'gh-pr-merge-worktree-gate.sh': ['Bash(*gh*pr*merge*)'],
+  // The only gate selected on a non-`git`/`gh` command word
+  // (go-to-k/cdk-local#571): a piped `markgate verify` reports the PIPE's
+  // exit code, so a STALE gate reads as a pass.
+  'markgate-pipe-gate.sh': ['Bash(*markgate*)'],
 };
 
 interface GateHook {
@@ -171,6 +175,19 @@ describe('PreToolUse gate matchers (go-to-k/cdk-real-drift#1801)', () => {
       expect(selects('verify-pr-gate.sh', spelling), `verify-pr-gate misses: ${spelling}`).toBe(
         true
       );
+    }
+    // markgate-pipe-gate is selected on the LAUNCHER-prefixed spelling every
+    // skill in this repo writes, not on a bare `markgate …` — an anchored
+    // `Bash(markgate*)` would miss all of these and the gate would be inert.
+    for (const spelling of [
+      'markgate verify check | tail -5',
+      'mise exec -- markgate verify integ 2>&1 | tail -5',
+      'cd /w/t && mise exec -- markgate set integ | tee /tmp/l',
+    ]) {
+      expect(
+        selects('markgate-pipe-gate.sh', spelling),
+        `markgate-pipe-gate misses: ${spelling}`
+      ).toBe(true);
     }
   });
 


### PR DESCRIPTION
## Summary

Closes #571.

`markgate` answers with an EXIT CODE and prints **nothing** when a marker is
fresh, so "no output, rc=0" is what a healthy run looks like -- and it is also
what a **stale** marker reports once piped, because `$?` after a pipeline is the
last stage's. Measured in this worktree while writing the fix:

```console
$ mise exec -- markgate verify check 2>&1 | tail -5; echo "rc=$?"
rc=0                                          # read as "marker fresh"

$ out=$(mise exec -- markgate verify check 2>&1 >/dev/null); rc=$?
NON-PIPED: rc=1  err=[]                       # the marker was STALE
```

A stale marker becomes indistinguishable from a fresh one, and the natural next
step is to skip the verification the gate was demanding. The reporter hit this
on the `integ` gate, where it would have meant opening a PR whose Docker path was
never exercised against the final code. A gate that cannot fail is worse than no
gate, because it is trusted.

## Audit first: where the defect actually lives

Every in-repo markgate **call site was already correct**. All seven gate hooks
use `"${markgate[@]}" verify <gate> >/dev/null 2>&1` on its own line followed by
`$?`, and the only piped markgate anywhere is `markgate status` into `awk`, where
stdout is the payload and the rc is deliberately unused. Nothing needed to change
there.

The defect lives on the **agent-instruction** side: the SKILL.md snippets hand an
agent a bare `mise exec -- markgate verify <gate>` and leave reading the verdict
to it, which is the step that got piped. `/verify-pr` step 1 already warned that
`$?` after a pipeline is the last stage's -- it was read, and the trap was hit
anyway, on a sibling command the wording did not name. That is the standard case
for moving an instruction out of documentation and into enforcement.

## What this ships

- **`.claude/hooks/markgate-pipe-gate.sh` (new)** -- refuses a Bash call in which
  `markgate verify` / `markgate set` / `markgate run` feeds a `|` (`run` is
  `verify || (cmd && set)` sugar, so it has the identical property). It is the only gate selected on
  a command word that is neither `git` nor `gh` (`Bash(*markgate*)`), and the only
  one that never runs the tool it is named after: the check is a static read of
  the command text, which is the whole point, since the failure is invisible at
  runtime. The message names the rewrite (`out=$(... 2>&1 >/dev/null); rc=$?`).
- **`_command-match.sh`: `gate_piped_segments` / `gate_matches_piped`** -- the
  separator pass collapsed `&&`, `;` and `|` into the same newline, so no gate
  could tell "its exit status is the caller's" from "the shell threw it away".
  A `GATE_PIPE_MARK` is now appended to segments feeding a pipe, and **only when
  a caller asks for it**, so every existing gate reads byte-identical segments.
- **`_command-match.sh`: `2>&1` is a redirection, not a separator.** The `&`
  inside it used to split a segment. That cost the anchored verb regexes nothing
  (the split lands after the verb) but it put the pipe mark on the trailing `1` --
  so the issue's own repro walked past its own gate until this was fixed.
- **`_command-match.sh`: a command substitution inside a DOUBLE-quoted span RUNS**,
  so its body is commands. It used to stay quoted, which means on `origin/main`
  today `echo "$(gh pr merge 1 --squash)"` and ``echo "`git commit -m x`"`` match
  **nothing** and run ungated through **every** gate in this repo. That is a
  pre-existing live bypass of the same class as the issue above, found by its own test
  suite and fixed with it. A single-quoted span stays literal (the asymmetry is
  the point), and closing the substitution re-emits the enclosing quote character
  so PROSE after it (`--body "see $(date) then gh pr merge 1"`) stays inert --
  without that, ending the body would start a fresh segment mid-prose and
  reintroduce the the cdkd 2130 body-text regression from the other end.
- **`verify-pr` / `run-integ` SKILL.md** -- the snippets now read the verdict for
  the agent (`out=$(...); rc=$?; echo "[... rc=$rc] $out"`) instead of leaving `$?`
  to it, and step 1's pipeline warning now names markgate as the worse case.
- **`.claude/CLAUDE.md` / `.claude/rules/hooks.md`** -- the rule and the per-hook
  reference.

## Deliberately NOT blocked

Over-tightening a merge gate blocks everyone, so the accept side is pinned as
hard as the refuse side:

| Spelling | Why it passes |
| --- | --- |
| `markgate status <gate> \| awk ...` | its answer is on stdout; every gate hook here pipes it that way |
| `markgate verify <gate> \|\| echo ...` | `\|\|` READS the status rather than discarding it |
| `markgate verify <gate> && ...` | same -- `&&` is a status test |
| `echo x \| markgate verify <gate>` | last stage of a pipeline: `$?` really is markgate's |
| `vp run <task> \| tail` | same pipeline trap, but `vp` PRINTS its failure, so the output still carries the verdict |

The last row is the issue's "worth considering in the same pass" suggestion, and
it is a **won't-do**, recorded in the hook header and in `.claude/rules/hooks.md`.
Silence on failure is what makes markgate un-catchable; `vp` is loud, and blocking
`vp run build 2>&1 | tail -20` would break a very common workflow to fence a case
the existing prose warning already covers.

## Test plan

Hook tests ARE the deliverable here, and CI does run them: `.github/workflows/ci.yml`
runs `vp run test:hooks`, which **globs** `.claude/hooks/*.test.sh`, so the new
suite is picked up with no wiring (that glob exists because a suite was once added
and never run -- the cdk-local 542 review).

| Suite | Result |
| --- | --- |
| `.claude/hooks/markgate-pipe-gate.test.sh` (new) | 58 pass, 0 fail |
| `.claude/hooks/_command-match.test.sh` (+55 cases) | 283 pass, 0 fail |
| `.claude/hooks/gate-command-recognition.test.sh` (+11 cases) | 123 pass, 0 fail |
| `.claude/hooks/issue-classification-label-gate.test.sh` | 39 pass, 0 fail |
| `.claude/hooks/issue-dup-check-gate.test.sh` | 83 pass, 0 fail |
| `.claude/hooks/pr-review-gate.test.sh` | 53 pass, 0 fail |
| `vp run check` | pass (0 errors, 1 pre-existing warning) |
| `vp run build` | pass |
| `vp run test` | 219 files, 3264 tests, 0 fail |

**Both directions are driven.** The bug is a false ACCEPT, so the 30 REFUSE cases
prove the fix -- but a refuse-only fence cannot see an over-tightening, so the
ACCEPT block is as long as the REFUSE block on purpose (28 cases).

**Mutation probes: 33 mutations, 33 killed.** Each mutation was applied to the
real files with a pre/post sha comparison and an in-progress flag written *before*
the mutation so a killed harness restores at startup rather than leaving the tree
mutated. Every probe named below was confirmed to make at least one suite RED:

```text
KILLED  gate asks gate_matches (ignores the pipe)
KILLED  gate never refuses (bare exit 0)
KILLED  gate fails OPEN on an old library
KILLED  gate fails OPEN on a missing library
KILLED  || treated as a pipe
KILLED  2>&1 splits again (& always a separator)
KILLED  pipe mark never emitted
KILLED  every separator marked as a pipe
KILLED  mark leaks into ordinary gate_segments
KILLED  status counted as a verdict verb
KILLED  mise launcher not recognised at all
KILLED  quoted $( substitution left quoted
KILLED  quoted backtick substitution left quoted
KILLED  single-quoted substitution now runs too
KILLED  enclosing quote not re-emitted on close
KILLED  bash -c recursion drops the pipe mark
KILLED  gate unregistered from settings.json
KILLED  registration if: joined with or
KILLED  nested $( does not count its paren
KILLED  nested <( does not count its paren
KILLED  segmenter sees only the FIRST line
KILLED  launcher absorbs arbitrary words again
KILLED  run dropped from the verdict verbs
KILLED  mark left on before gate_strip_prefix
KILLED  bash -c recursion drops the OUTER mark
KILLED  recursion marks an UNPIPED bash -c too
KILLED  launcher: too narrow (drops -C /w)
KILLED  launcher: too wide (any word absorbed)
KILLED  launcher: generic value (boolean eats cmd)
KILLED  launcher: -- given a value (reopens rg)
KILLED  launcher: no global-flag absorber
KILLED  launcher: global run absorbs any word
KILLED  launcher: --allow-* dropped from the list
KILLED  launcher: flag value cannot be quoted
final sha check: tree restored, shas identical
```

The fourth probe found a real defect rather than confirming one: "gate fails OPEN
on a missing library" originally SURVIVED, because deleting `_command-match.sh`
trips both guards and the case only asserted "exit 2 mentioning `_command-match.sh`".
It now asserts *which* guard speaks, so each case fences its own guard.

**Live test**, end-to-end through the real hook with synthesized PreToolUse
payloads -- inside a throwaway git repo with `origin/main` simulated, and again
with no git repo at all under `env -i` with a foreign `$HOME`:

```text
--- inside a throwaway git repo (origin/main simulated) ---
rc=2  <- mise exec -- markgate verify integ 2>&1 | tail -5
rc=0  <- mise exec -- markgate verify integ >/dev/null 2>&1; rc=$?
rc=0  <- echo hello | wc -l
--- no git repo at all, pinned env, foreign HOME ---
rc=2  <- mise exec -- markgate verify integ 2>&1 | tail -5
rc=0  <- mise exec -- markgate verify integ >/dev/null 2>&1; rc=$?
```

**Hermeticity** of the new suite: git history is not read (measured -- the payload
cwd is a bare `mktemp -d` with no repo and every case still produces its expected
verdict); cwd, `$HOME` and PATH are pinned; env is pinned with `env -i`; the clock
is not read (no TTL, no marker store). The suite refuses to run at all if `jq` is
missing from the pinned PATH, since the hook would then read an empty command and
every case would pass vacuously.

## Retrospective (verify-pr step 11)

Three things surprised me while building this; each is already reflected in an
artifact in this PR rather than left as a note.

1. **The new gate initially let its own issue's repro through.** The segmenter
   split on the `&` inside `2>&1`, so the pipe mark landed on the trailing `1`.
   A matcher change can be defeated by an unrelated pre-existing tokenizer quirk,
   and the only reason it was caught is that the very first REFUSE case is the
   literal command from the issue rather than a tidied-up version of it.
   *Reflected as*: the issue's literal command is the first case of the new suite, and a
   mutation probe (`2>&1 splits again`) kills it.

2. **A comment can assert a capability the code does not have.** The header of
   `gate_segments_raw` has always said "Command substitutions become separators
   too -- the text inside one RUNS, so `echo "$(git commit -m x)"` is a commit."
   That sentence was FALSE for the quoted form, and had been for as long as the
   comment existed, so every gate in the repo could be walked past with one pair
   of quotes. *Reflected as*: that exact example is now a pinned test case, so
   the comment and the code cannot drift apart again silently.

3. **A fail-closed case was refused twice over.** The "library absent" case
   asserted only "exit 2 mentioning `_command-match.sh`", which the *second*
   guard satisfies after the failed source, so deleting the readability guard
   left it green. A mutation probe caught it. *Reflected as*: `fail_closed` now
   takes the message fragment its case must produce, so each case fences its own
   guard.

No new rule/hook/skill proposals beyond what ships here: (1) and (3) are
test-shape lessons already encoded in the suite, and (2) is fixed at the source.

## Review round (3-axis: spec / code / test)

Tier is `3-axis` by the repo's own heuristic (11 files >= 10), and the surface --
the segmenter every gate in the repo sources -- argues for the ceiling anyway.
All three reviewers ran against the branch, probed their own claims, and
independently re-ran the suites. **Two blockers, both fixed here**; every
remaining item is dispositioned below.

**Blocker 1 (code review) -- nested `$(...)` inside a double-quoted span closed
the outer substitution one paren early.** The `$(` / `<(` / `>(` branches consume
their `(` with `i++`, so it never reached the paren counter. This broke in BOTH
directions, and only the second is the bypass:

- a NEW false block versus `origin/main`:
  `gh pr create --body "ver $(echo $(date)) then git commit -m z"` matched
  `GATE_RE_GIT_COMMIT` on the branch and nothing on `origin/main`, so every
  git/gh gate would have refused an ordinary `gh pr create`;
- a residual fail-open: `echo "$(echo $(date); gh pr merge 1 --squash)"` still
  matched nothing -- the very class this PR set out to close.

Fixed by counting the paren in those three branches, gated on
`stype[sdepth] == "("` so a backtick frame (which carries `sparen = 0`) is not
paren-tracked. Both directions are now pinned, and for `<(` **only the
false-block direction discriminates** -- with the count removed,
`echo "$(cat <(git commit -m x))"` still matches either way, so that case would
have been vacuous on its own.

**Blocker 2 (test review) -- multi-line commands were unpinned.** Every case in
the new suite was single-line. Mutating the segmenter to see only the first line
left the new suite **38/38 green** and `gate-command-recognition` **121/121
green** while both multi-line spellings of this very defect ACCEPTed. Multi-line
bash is what agents write most. Three multi-line REFUSE cases and one multi-line
ACCEPT case added, plus a `segmenter sees only the FIRST line` mutation probe.

**Fixed here, non-blocking:**

- **`markgate run` was not a verdict verb.** It is `verify || (cmd && set)` --
  exit-code-is-the-answer, silent on the fresh path, i.e. the identical defect.
  Unused in this repo, but it is in `markgate --help`. Added to the alternation,
  plus a case and a probe.
- **`mise exec -- rg markgate verify .claude | head` was a FALSE BLOCK.** The
  launcher prefix absorbed an unrestricted run of words. Restricted to `--`, a
  flag, or a `tool@version` pin -- which keeps all five real spellings. This is
  the command someone auditing this very gate would type.
- **`gate_piped_segments` did not emit ordinary segment text.** The mark was the
  last character, so `gate_strip_prefix`'s trailing-space and trailing-`)` trims
  both no-op'd: `markgate verify a | tail` came out `"markgate verify a "` and
  `(markgate verify a) | tail` came out `"markgate verify a)"`. Harmless for
  today's start-anchored regexes, silently fatal for the first `$`-anchored one.
  The mark is now detached before the strip and re-attached after.
- **`&>` had no end-to-end case**, and **`set -o pipefail` had no case pinning
  the decision either way**. Both added; pipefail is refused deliberately (the
  gate reads one command's TEXT and cannot know pipefail is still in effect when
  the pipeline runs, and the non-piped rewrite is free) and that call is now
  written down in the hook header and in `.claude/rules/hooks.md`.
- **`python3` was an undeclared dependency of the suite's `fail_closed` cases.**
  Added to the FATAL preflight next to `jq`.

**Won't-do, with reasons:**

- **Missing `jq` fails OPEN** (raised by two reviewers). Identical to
  `check-gate.sh` / `integ-gate.sh` and every sibling, so it is a repo-wide
  idiom rather than new drift; changing it in this one gate would make the
  behaviour inconsistent for no gain. The suite refuses to run without `jq`
  precisely so the tests can never pass vacuously on that path.
- **`nice markgate verify x | tail` passes.** `nice` is not a leader
  `gate_strip_prefix` strips, so this is pre-existing for every gate here, not
  new. Both reviewers judged it not worth fixing (`nice` is prescribed by no
  skill or workflow in this repo), and widening the shared leader list is a
  change to a function two reviewers just cleared.
- **`{ markgate verify check; } | tail`, `mise exec -- bash -c "... | tail"`,
  `npx markgate` / `pnpm exec markgate`.** Under-matched, all pre-existing
  segmenter shapes or launchers this mise-pinned repo does not use. Plain
  `bash -c "... | tail"` IS covered.
- **`--body "$(...)"` truncates the matched segment**, so
  `issue-dup-check-gate`'s inline-body scan can no longer see a `Dup-check:`
  marker placed after a substitution. Direction is **fail-closed** (the gate
  refuses rather than waving through), and a substitution in an issue body is
  not a shape this flow produces.
- **Backtick-frame paren counting.** A probe removing the `stype[sdepth] == "("`
  guard SURVIVED -- but it is a genuine no-op, not a coverage gap: nothing reads
  `sparen` unless `stype` is `(`, so bumping it inside a backtick frame cannot
  change any output. Recorded rather than papered over with a vacuous test.

## Second review round (fix-back re-review)

The fix-back was re-reviewed rather than assumed correct, and that was the right
call: **it had introduced a regression of its own.** Two more blockers, both
fixed in `09a986d`.

**Blocker 3 -- the `bash -c` recursion threw the OUTER pipe mark away.**
`bash -c 'markgate verify a' | tail` produced NO piped segments at all, so the
gate passed. The pipe belongs to the outer command: it is the whole `bash -c`
whose exit status the shell discards. Every segment the recursion yields now
carries `$piped` -- deliberately `$piped` and not `$GATE_PIPE_MARK`, since
marking unconditionally would mark the inner segments of an UNPIPED `bash -c`
too. Both mutations are probed, so neither direction is free.

**Blocker 4 -- closing the `rg` false block dropped every launcher flag that
takes a VALUE.** Tightening the interposed run to `--`, a bare flag, or a
`tool@version` pin meant `mise exec -C /w -- markgate verify x | tail` blocked
before that commit and passed after it; `--cd`, `-E/--env` and `-j/--jobs` are
the same shape. The flag alternative now carries an optional value, while `--`
stays its own no-value alternative and is listed FIRST -- giving `--` an
optional value re-opens the `rg` false block, because `-- rg` absorbs. **The two
are pinned as a PAIR**, since either fix alone re-breaks the other, and both
directions have their own mutation probe.

This is the second time this one constant was changed to repair the consequences
of the previous change to it, which is exactly why the pair is pinned rather
than the current spelling.

## Third and fourth review rounds

Each fix-back was re-reviewed rather than assumed correct, and each of the first
three found something -- so the reviews continued until one came back clean
rather than stopping at a fixed count.

**Blocker 5 -- a BOOLEAN launcher flag swallowed the command word.** Giving
every flag an optional value (the fix for blocker 4) re-opened the `rg` false
block one keystroke away: `mise exec --raw rg markgate verify . | head`, and the
same for `-q`, `-v`, `-y`, `--silent`, `--deny-all`, `--no-deps`, `--locked`.

That is the **third distinct direction** this one constant has been wrong in:

| direction | symptom |
| --- | --- |
| too wide (unrestricted word run) | `mise exec -- rg markgate verify .claude \| head` FALSE BLOCK |
| too narrow (`--` / bare flag / pin only) | `mise exec -C /w -- markgate verify x \| tail` stopped blocking |
| generic optional value on every flag | `mise exec --raw rg markgate verify . \| head` FALSE BLOCK again |

So it stopped guessing. The value-taking flags are now **named**
(`-C/--cd`, `-E/--env`, `-j/--jobs`, `-c/--command`); every other flag is
boolean, which also covers the `=` and glued spellings because the token
swallows them whole; `--` stays its own no-value alternative listed first. The
value alternation also accepts a **quoted** value -- the same fix `GATE_FLAGS`
needed for `git -C "/a b" commit` -- which `mise exec --cd "/w t" -- markgate
verify x | tail` had regressed on. **Six mutation probes now cover this one
constant, one per wrong spelling**, so no single-direction fix can pass again.

**Blocker 6 -- global flags before the subcommand were under-matched.**
`mise -C /w exec -- markgate verify x | tail` did not fire the gate at all --
the original defect, one flag position away. A global run in front of `exec|x`
reuses the same alternation minus `--` and the pin, neither of which can precede
a subcommand, and both directions are pinned (`mise -C /w exec -- rg markgate
verify . | head` and `mise --version | head` must still pass).

## Fifth review round -- clean, and it corrected two of my own calls

The chain terminated: no further direction of wrongness in the constant, no bad
interaction between the global and post-`exec` runs (the literal `exec|x`
separates them, and POSIX `regexec` reports a match if ANY parse exists --
verified in both backtracking directions), no ReDoS (20 ambiguous repeated flags
stayed flat at 6 ms), and `gate_segments` / `gate_matches` output byte-identical
for 37 git/gh commands across all 14 `GATE_RE_*` constants, so the other ~20
gates are untouched. It did find three things, all fixed in `781427e`:

- **I dropped a probe on a claim that was wrong.** I had argued that restricting
  the GLOBAL run to flag-shaped tokens is not observable, since the run is
  bounded by the required `exec|x`. It is observable: an unrestricted word run
  can simply contain an `exec` later on, and with the restriction removed
  `mise ls exec -- markgate verify x | tail` and
  `mise settings set x exec -- markgate verify a | tail` become FALSE BLOCKS --
  the too-wide direction this whole chain fights. Probe restored, two cases
  added. (The backtick-frame no-op above was re-checked and does still hold.)
- **One case was vacuous**: `mise --version | head` holds no `markgate`
  substring, so no spelling of any of the four launcher constants could ever
  match it -- a proof, not a probe. It survived every mutation of all four.
  Replaced by the non-vacuous case above, which fences the same constant.
- **The value-flag enumeration was incomplete**, which is the failure mode an
  enumeration always has: `mise exec --help` also lists `--allow-env`,
  `--allow-net`, `--allow-read` and `--allow-write` as value-taking, and all
  four were FALSE NEGATIVES. The list is now taken from that help output rather
  than from memory, with its own probe.

## Remaining work

**TODO [issue 585](https://github.com/go-to-k/cdk-local/issues/585)** -- the shared `bash -c` recursion does not see
through `mise exec -c "<cmd>"`, so that spelling is invisible to this gate *and*
to the other ~20. `Severity: low` (no skill or workflow here writes it -- they
all write `mise exec -- <cmd>`, which IS covered), `Effort: medium (M)`,
`Estimate: ~1 h`. Deliberately not fixed here: the change is in the shared
recursion every gate traverses, not in this gate's constant, and bundling a
repo-wide segmentation change into a PR that has already revised its own
launcher constant four times would make the diff unreviewable. The issue carries
the measured repro, the root cause, and the obvious-but-wrong one-line fix. The
final review round found a second spelling with the same root cause --
`mise exec -- bash -c 'markgate verify integ' | tail`, where a launcher prefix
hides the segment-start-anchored `bash -c` trigger -- and it is recorded on the
same issue rather than a second one, because both want the same edit. Plain
`bash -c "... | tail"` IS covered, in both directions.

Nothing else remains: every reviewer finding across five rounds is either fixed
above, recorded as a won't-do with its reason, or on that one issue.
