### PR TITLE
test(integ): declare the host CPU architecture on the container and from-cfn-stack fixtures (batch 2 of 4)

### DIFF
--- a/tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts
+++ b/tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts
@@ -7,6 +7,34 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ *
+ * This fixture's Lambda is a `DockerImageFunction`, so the declared
+ * architecture drives the image BUILD as well as the run: cdk-local passes
+ * the same `--platform` to `docker build` (see `buildContainerImage`). The
+ * Dockerfile starts `FROM public.ecr.aws/lambda/nodejs:20`, which is
+ * multi-arch, and nothing in the image is a prebuilt arch-specific binary,
+ * so building at the host arch is safe. A fixture whose Dockerfile pulled
+ * an amd64-only base, or COPYied in a cross-compiled executable, would NOT
+ * be safe to convert -- it would belong with `local-invoke-provided`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for the comprehensive BuildKit-Dockerfile regression integ.
  *
  * `BuildkitHandler` is built from a Dockerfile that exercises EVERY
@@ -43,6 +71,7 @@ export class LocalInvokeBuildkitStack extends cdk.Stack {
           mysecret: cdk.DockerBuildSecret.fromSrc('secret.txt'),
         },
       }),
+      architecture: HOST_ARCHITECTURE,
       environment: {
         GREETING: 'hello-buildkit',
       },

--- a/tests/integration/local-invoke-container/lib/local-invoke-container-stack.ts
+++ b/tests/integration/local-invoke-container/lib/local-invoke-container-stack.ts
@@ -7,6 +7,34 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ *
+ * This fixture's Lambda is a `DockerImageFunction`, so the declared
+ * architecture drives the image BUILD as well as the run: cdk-local passes
+ * the same `--platform` to `docker build` (see `buildContainerImage`). The
+ * Dockerfile starts `FROM public.ecr.aws/lambda/nodejs:20`, which is
+ * multi-arch, and nothing in the image is a prebuilt arch-specific binary,
+ * so building at the host arch is safe. A fixture whose Dockerfile pulled
+ * an amd64-only base, or COPYied in a cross-compiled executable, would NOT
+ * be safe to convert -- it would belong with `local-invoke-provided`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl invoke` container-Lambda integ test (PR 5).
  *
  * Single Lambda — `EchoHandler` — built from a local Dockerfile in
@@ -27,6 +55,7 @@ export class LocalInvokeContainerStack extends cdk.Stack {
 
     new lambda.DockerImageFunction(this, 'EchoHandler', {
       code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, '../docker')),
+      architecture: HOST_ARCHITECTURE,
       environment: {
         GREETING: 'hello',
       },

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts
@@ -37,6 +37,25 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  */
 const PARAM_COUNT = 105;
 
+/**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
 export class LocalInvokeFromCfnStackLargeStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
@@ -63,6 +82,7 @@ export class LocalInvokeFromCfnStackLargeStack extends cdk.Stack {
 
     new lambda.Function(this, 'CountParamsHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
       environment,

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/consumer-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/consumer-stack.ts
@@ -15,6 +15,25 @@ export interface ConsumerStackProps extends cdk.StackProps {
 }
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Consumer stack for the 2-stack `Fn::ImportValue` integ (issue #611).
  *
  * One Lambda whose `SHARED_VALUE` env var is `Fn::ImportValue:
@@ -39,6 +58,7 @@ export class ConsumerStack extends cdk.Stack {
 
     const fn = new lambda.Function(this, 'EchoSharedHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
       timeout: cdk.Duration.seconds(10),

--- a/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
@@ -29,6 +29,25 @@ const SSM_DB_HOST_PARAM = '/cdkl-integ/invoke-from-cfn-stack/db-host';
 const SSM_API_KEY_PARAM = '/cdkl-integ/invoke-from-cfn-stack/api-key';
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl invoke --from-cfn-stack` (issue #606).
  *
  * One echo Lambda + one DynamoDB table + one sibling Lambda. The echo
@@ -67,6 +86,7 @@ export class LocalInvokeFromCfnStackStack extends cdk.Stack {
     // deployed ARN to resolve to.
     const sibling = new lambda.Function(this, 'SiblingHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
       timeout: cdk.Duration.seconds(10),
@@ -74,6 +94,7 @@ export class LocalInvokeFromCfnStackStack extends cdk.Stack {
 
     new lambda.Function(this, 'EchoTableHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
       environment: {

--- a/tests/integration/local-list/lib/local-list-stack.ts
+++ b/tests/integration/local-list/lib/local-list-stack.ts
@@ -8,6 +8,25 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import { Construct } from 'constructs';
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl list` target enumeration integ test.
  *
  * Hand-rolls one resource of each kind `cdkl list` emits a group for, using
@@ -38,6 +57,7 @@ export class LocalListStack extends cdk.Stack {
     // Lambda function — inline code so synth has no asset / bundling step.
     const fn = new lambda.Function(this, 'MyHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromInline(
         "exports.handler = async () => ({ statusCode: 200, body: 'ok' });"

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -116,6 +116,12 @@ const HOST_ARCHITECTURE_STACKS = [
   'tests/integration/local-invoke-ruby/lib/local-invoke-ruby-stack.ts',
   'tests/integration/local-invoke-java/lib/local-invoke-java-stack.ts',
   'tests/integration/local-invoke-dotnet/lib/local-invoke-dotnet-stack.ts',
+  'tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts',
+  'tests/integration/local-invoke-container/lib/local-invoke-container-stack.ts',
+  'tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts',
+  'tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts',
+  'tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/consumer-stack.ts',
+  'tests/integration/local-list/lib/local-list-stack.ts',
 ];
 
 /**
@@ -155,12 +161,6 @@ const PINNED_STACKS = [
  * silently.
  */
 const NOT_YET_CONVERTED = [
-  'tests/integration/local-invoke-buildkit/lib/local-invoke-buildkit-stack.ts',
-  'tests/integration/local-invoke-container/lib/local-invoke-container-stack.ts',
-  'tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts',
-  'tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts',
-  'tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/consumer-stack.ts',
-  'tests/integration/local-list/lib/local-list-stack.ts',
   'tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts',
   'tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts',
   'tests/integration/local-start-api-all-stacks/lib/stack-a.ts',


### PR DESCRIPTION
Batch 2 of 4 for (#569). Converts the container-Lambda pair, the three
`*-from-cfn-stack` invoke fixtures, and `local-list`. Two of the four batches remain,
so (#569) stays open.

Backlog counter: `NOT_YET_CONVERTED` **19 -> 13**.

## What changed

6 fixture sources, 7 declarations.

| Fixture | Constructs | Class | Runs a container? |
| --- | --- | --- | --- |
| `local-invoke-container` | 1x `lambda.DockerImageFunction` | **C (image)** | yes |
| `local-invoke-buildkit` | 1x `lambda.DockerImageFunction` | **C (image)** | yes |
| `local-invoke-from-cfn-stack` | 2x `lambda.Function` | A | yes (real CFn stack) |
| `local-invoke-from-cfn-stack-large-stack` | 1x `lambda.Function` | A | yes (real CFn stack) |
| `local-invoke-from-cfn-stack-multi-stack` | 1x `lambda.Function` (`consumer-stack.ts`) | A | yes (two real CFn stacks) |
| `local-list` | 1x `lambda.Function` | A | **no** |

`local-list` only runs `cdkl list` / `cdkl ls`, so its declaration never reaches a
container. It is converted for template consistency and so the fence can account for
every fixture source, not because it fixes an observed fault there. Said plainly rather
than folded into the pass list.

`producer-stack.ts` in the multi-stack fixture constructs no Lambda, so it is correctly
absent from every bucket -- the fence lists only sources that construct a `*Function(`.

### The container class is not the same mechanism

For a `DockerImageFunction` the declared architecture drives the image **build**, not
just the run: cdk-local passes the same `--platform` to `docker build`
(`buildContainerImage`). That is safe here because both Dockerfiles start
`FROM public.ecr.aws/lambda/nodejs:20` (multi-arch) and neither copies in a prebuilt
arch-specific executable. A fixture that pulled an amd64-only base, or `COPY`ied a
cross-compiled binary, would NOT be convertible and would belong with
`local-invoke-provided`. That reasoning is now recorded in both fixtures.

## CI (amd64): one delta class beyond `Architectures`, and it is real

Pre/post synth with `process.arch` forced to `x64`, templates diffed:

```
local-invoke-buildkit      +1 Architectures:["x86_64"] + 1 container-asset tag  (arm64 synth emits 1 "arm64")
local-invoke-container     +1 Architectures:["x86_64"] + 1 container-asset tag  (arm64 synth emits 1 "arm64")
local-invoke-from-cfn-stack           +2 Architectures:["x86_64"]               (arm64 emits 2 "arm64")
local-invoke-from-cfn-stack-large     +1 Architectures:["x86_64"]               (arm64 emits 1 "arm64")
multi-stack / Consumer                +1 Architectures:["x86_64"]               (arm64 emits 1 "arm64")
multi-stack / Producer                +0 (constructs no Lambda)                 (arm64 emits 0)
local-list                            +1 Architectures:["x86_64"]               (arm64 emits 1 "arm64")
```

7 additions for 7 declarations.

**The two container fixtures also change their ECR asset tag, and that is not cosmetic.**
CDK folds the Lambda's `architecture` into the `DockerImageAsset`'s `platform`, which is
part of the asset hash:

```
pre:  platform <unset>       tag d7aaadba…
post: platform linux/amd64   tag 6fdff399…   (x64 synth)
post: platform linux/arm64   tag 6a168e8a…   (arm64 synth)
```

On an amd64 runner the built image is the same architecture as before -- docker's default
was already the host -- but the platform is now EXPLICIT, so the hash differs. Nothing
deploys these fixtures (both are local-only, no `cdk deploy`), so no ECR push changes.
Stating it because "the only delta is `Architectures`" is true for the L2 class and NOT
true for the container class, and a reviewer checking that claim would find a second
delta.

## Runs on the arm64 host

Local-only, 3 each:

```
local-invoke-container  PASS 23s / 19s / 13s    docker clean
local-invoke-buildkit   PASS 28s / 21s / 34s    docker clean
local-list              PASS  7s /  6s /  6s    docker clean
```

Direct platform evidence with stderr visible (the fixtures discard it):

```
local-invoke-container  EchoHandler     -> platform=linux/arm64  emulation-warnings=0
local-invoke-buildkit   BuildkitHandler -> platform=linux/arm64  emulation-warnings=0
```

AWS-backed, 3 each. Every run is a full `cdk deploy` + invokes + `cdk destroy`:

```
local-invoke-from-cfn-stack              PASS 115s / 116s / 109s   docker clean, stacks gone
local-invoke-from-cfn-stack-large-stack  PASS 160s / 155s / 155s   docker clean, stacks gone
local-invoke-from-cfn-stack-multi-stack  PASS 115s / 111s / 117s   docker clean, both stacks gone
```

**Sample size, chosen deliberately.** 3 runs per AWS fixture, with the rule that ANY
failure escalates to a 9-run A/B against unmodified `main` rather than a re-run. An AWS
cycle costs ~2 minutes against ~20 seconds for a local one, so 3 is the affordable
default -- but three passes on a genuinely 50%-flaky fixture happens about 12% of the
time, which is why the escalation trigger is a failure, not a hunch. No batch-2 fixture
failed, so no escalation fired. (That rule exists because
`local-invoke-assume-role` in batch 1 went 3/3 green and then 3/3 red; the 18-run A/B
that followed is filed as (#583).)

**Per-fixture AWS sweep, after each fixture's 3 runs:** all four stack names absent
(`CdkLocalInvokeFromCfnStackFixture`, `CdkLocalInvokeFromCfnStackLargeFixture`,
`CdkLocalInvokeMultiStackProducer`, `CdkLocalInvokeMultiStackConsumer`). A final
account-wide sweep for anything named `CdkLocal` found no CloudFormation stacks in any
non-deleted status, no Lambda functions, no DynamoDB tables and no SSM parameters. Docker
containers and networks were swept with `docker ps -a` after every individual attempt.

## Fence

Six paths moved from `NOT_YET_CONVERTED` into `HOST_ARCHITECTURE_STACKS`; buckets still
partition all 31 discovered sources (15 / 1 / 13 / 2).

### Probes: the container spelling had never actually been exercised

Batch 1 registered `new lambda.DockerImageFunction(` in the constructor table, but no
converted fixture used one, so none of the per-construct rules had ever run against it.
Assuming the regex generalised is exactly the assumption worth testing:

```
[x] S0 CONTROL: unmutated                                        control passes
[x] S1 DockerImageFunction, architecture removed (wrapped code:) named "BuildkitHandler"
[x] S2 DockerImageFunction, architecture removed (inline code:)  named "EchoHandler"
[x] S3 DockerImageFunction, hardcoded ARM_64                     named "hardcoded architecture"
[x] S4 DockerImageFunction, architecture COMMENTED OUT           named "BuildkitHandler"
[x] S5 DockerImageFunction with a deep namespace                 named "does not understand"
[x] S6 second Lambda in a *-from-cfn-stack fixture left bare     named "EchoTableHandler"
[x] restore verified: sha256 unchanged for all touched files
```

S1 vs S2 matter separately: buildkit's `code:` spans multiple lines with nested parens
and braces, container's is a single line. The property-insertion anchor and the paren
matcher had only ever met the single-line shape.

## A defect in my own verification tooling

The batch-2 parity run initially reported `multi-stack / Consumer: +0 Architectures and
nothing else` -- a **pass**. It was wrong twice over:

1. The script reverted `find lib -name '*.ts' | head -1`, which for this fixture is
   `producer-stack.ts`. The modified `consumer-stack.ts` was never reverted, so "PRE"
   and "POST" were the same file and the diff was empty.
2. An empty diff was reported as a pass, so a comparison that exercised nothing was
   indistinguishable from a correct one.

Both are fixed: every `lib/**/*.ts` is reverted, and an empty diff is now a FAILURE
whenever the arm64 control shows the constant is live. Verified by fabricating that exact
shape (PRE == POST while the arm64 synth still emits `"arm64"`) and confirming the guard
fires. After the fix the same fixture reports `+1`, matching its one declaration.

This mattered beyond one row: `local-start-api-all-stacks` in batch 3 has the same
two-stack-files shape and would have been mis-verified the same way.
