### PR TITLE
test(integ): close the fence's nested-placement gap and convert the start-api family (batch 3 of 4)

### DIFF
--- a/.claude/skills/create-integ/SKILL.md
+++ b/.claude/skills/create-integ/SKILL.md
@@ -108,8 +108,15 @@ extend it instead.
      on every L1 `lambda.CfnFunction` (the L1 takes architecture NAMES, not the
      `Architecture` object). Do NOT hardcode either value: `ARM_64` makes an
      amd64 CI runner emulate, and `X86_64` is the default that caused go-to-k/cdk-local#560.
-     The only exception is a handler shipping a PREBUILT binary compiled for a
-     specific arch, which must pin to match the BINARY.
+     Two exceptions, both where an ARTIFACT dictates the architecture rather
+     than the host: a handler shipping a PREBUILT binary compiled for a
+     specific arch (pin to match the BINARY), and a `DockerImageFunction`
+     whose Dockerfile pulls an arch-specific base image or `COPY`s in a
+     cross-compiled executable (the declared architecture drives
+     `docker build` as well as `docker run`, so it cannot be built for the
+     host). A Dockerfile on a multi-arch base such as
+     `public.ecr.aws/lambda/nodejs:20`, with no prebuilt binary copied in, is
+     NOT an exception and should declare the host architecture.
 
      Then add the new file to `HOST_ARCHITECTURE_STACKS` in
      `tests/unit/integ-fixture-host-architecture.test.ts` — that fence asserts

--- a/tests/integration/local-list/lib/local-list-stack.ts
+++ b/tests/integration/local-list/lib/local-list-stack.ts
@@ -8,20 +8,26 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import { Construct } from 'constructs';
 
 /**
- * Run this fixture's Lambdas at the HOST's CPU architecture.
+ * Declare the HOST's CPU architecture on this fixture's Lambda.
  *
- * A function that declares no `architecture` defaults to `X86_64`, so on an
- * arm64 host cdk-local pins `--platform linux/amd64` and every container here
- * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
- * base images faults intermittently, at a different assertion on every run
- * (issue #560; extended to the remaining fixtures by issue #569).
+ * Unlike the other converted fixtures, **this one runs no container**:
+ * `verify.sh` exercises `cdkl list` / `cdkl ls`, which is a pure synth-time
+ * read over the cloud assembly. So this declaration fixes no observed fault
+ * here and nothing about the test's behaviour changes.
  *
- * Declaring the HOST arch -- rather than hardcoding either value -- is what
- * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
- * runner, instead of trading one host's emulation for the other's. Keep it on
- * every function here: a new handler that omits it silently reintroduces the
- * arm64-only flake. The full rationale, the carve-outs, and the fence that
- * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ * It is declared anyway for two reasons. The synthesized template is
+ * consistent with every other fixture's, so a reader comparing them does not
+ * find one Lambda silently defaulting to `x86_64`; and the fence in
+ * `tests/unit/integ-fixture-host-architecture.test.ts` accounts for EVERY
+ * fixture source that constructs a Lambda, so leaving this one out would mean
+ * carrying it in the `NOT_YET_CONVERTED` backlog forever and never reaching
+ * the empty state that marks issue #569 done.
+ *
+ * If this fixture ever grows a step that actually invokes the handler, the
+ * declaration is already correct: a function that declares no `architecture`
+ * defaults to `X86_64`, which on an arm64 host runs the container under
+ * emulation where the Go RIE faults intermittently (issue #560). Hardcoding
+ * either value would only move that emulation to the other host.
  */
 const HOST_ARCHITECTURE =
   process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;

--- a/tests/integration/local-start-api-all-stacks/lib/stack-a.ts
+++ b/tests/integration/local-start-api-all-stacks/lib/stack-a.ts
@@ -8,12 +8,32 @@ import type { Construct } from 'constructs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
 export class StackA extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const fn = new lambda.Function(this, 'PingHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(here, '..', 'lambda-a')),
     });

--- a/tests/integration/local-start-api-all-stacks/lib/stack-b.ts
+++ b/tests/integration/local-start-api-all-stacks/lib/stack-b.ts
@@ -8,12 +8,32 @@ import type { Construct } from 'constructs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
 export class StackB extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const fn = new lambda.Function(this, 'PongHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(here, '..', 'lambda-b')),
     });

--- a/tests/integration/local-start-api-cognito-jwt/lib/local-start-api-cognito-jwt-stack.ts
+++ b/tests/integration/local-start-api-cognito-jwt/lib/local-start-api-cognito-jwt-stack.ts
@@ -48,12 +48,32 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SIDECAR_ISSUER = 'http://127.0.0.1:19001';
 const SIDECAR_AUDIENCE = 'cdkl-integ-g3-aud';
 
+/**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
 export class LocalStartApiCognitoJwtStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const protectedHandler = new lambda.Function(this, 'ProtectedHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-protected')),
       timeout: cdk.Duration.seconds(10),

--- a/tests/integration/local-start-api-container/lib/local-start-api-container-stack.ts
+++ b/tests/integration/local-start-api-container/lib/local-start-api-container-stack.ts
@@ -9,6 +9,32 @@ import * as apigwv2int from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ *
+ * This fixture's Lambda is a `DockerImageFunction`, so the declared
+ * architecture drives the image BUILD as well as the run: cdk-local passes
+ * the same `--platform` to `docker build` (see `buildContainerImage`). The
+ * Dockerfile starts `FROM public.ecr.aws/lambda/nodejs:20`, which is
+ * multi-arch, and copies in no prebuilt arch-specific binary, so building at
+ * the host arch is safe.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for the `cdkl start-api` container-Lambda integ
  * test (closes #453).
  *
@@ -25,7 +51,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *      backing container Lambda.
  *   2. The container-pool's IMAGE branch (PR closing #453) runs
  *      `docker build` against the asset entry, NO bind-mount at
- *      /var/task, `--platform linux/amd64` threaded through.
+ *      /var/task, and `--platform` threaded through. That platform is
+ *      whatever the function's `Architectures` declares -- since issue
+ *      #569 that is the HOST arch, so it is `linux/arm64` on an Apple
+ *      Silicon dev host and `linux/amd64` on an x86_64 CI runner. It was
+ *      hardcoded as `linux/amd64` in this comment when the fixture
+ *      declared no architecture and always defaulted to x86_64.
  *   3. A `curl http://127.0.0.1:<port>/` against the HTTP server
  *      reaches the container Lambda via RIE and the JSON response
  *      includes the `fromContainer: true` marker the app.js emits.
@@ -36,6 +67,7 @@ export class LocalStartApiContainerStack extends cdk.Stack {
 
     const fn = new lambda.DockerImageFunction(this, 'EchoHandler', {
       code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, '../docker')),
+      architecture: HOST_ARCHITECTURE,
       environment: {
         GREETING: 'hello',
       },

--- a/tests/integration/local-start-api-from-cfn-stack/lib/local-start-api-from-cfn-stack-stack.ts
+++ b/tests/integration/local-start-api-from-cfn-stack/lib/local-start-api-from-cfn-stack-stack.ts
@@ -8,6 +8,25 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl start-api --from-cfn-stack`.
  *
  * The originally-reported bug was on `start-api`: an env var set to
@@ -42,6 +61,7 @@ export class LocalStartApiFromCfnStackStack extends cdk.Stack {
     // deployed ARN to resolve to.
     const sibling = new lambda.Function(this, 'SiblingHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
       timeout: cdk.Duration.seconds(10),
@@ -49,6 +69,7 @@ export class LocalStartApiFromCfnStackStack extends cdk.Stack {
 
     const echo = new lambda.Function(this, 'EchoHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
       environment: {

--- a/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts
@@ -8,6 +8,25 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl start-api` REST v1 non-AWS_PROXY
  * integrations (#457).
  *
@@ -53,6 +72,7 @@ export class LocalStartApiRestV1NonProxyStack extends cdk.Stack {
 
     const handler = new lambda.Function(this, 'NonProxyHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-non-proxy')),
       timeout: cdk.Duration.seconds(10),

--- a/tests/integration/local-start-api-watch/lib/watch-stack.ts
+++ b/tests/integration/local-start-api-watch/lib/watch-stack.ts
@@ -7,6 +7,25 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl start-api --watch` integ test.
  *
  * No AWS deploy required — the integ exercises the synthesized cdk.out
@@ -26,6 +45,7 @@ export class LocalStartApiWatchStack extends cdk.Stack {
 
     const pingHandler = new lambda.Function(this, 'PingHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda-ping')),
       timeout: cdk.Duration.seconds(10),

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -122,11 +122,37 @@ const HOST_ARCHITECTURE_STACKS = [
   'tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts',
   'tests/integration/local-invoke-from-cfn-stack-multi-stack/lib/consumer-stack.ts',
   'tests/integration/local-list/lib/local-list-stack.ts',
+  'tests/integration/local-start-api-all-stacks/lib/stack-a.ts',
+  'tests/integration/local-start-api-all-stacks/lib/stack-b.ts',
+  'tests/integration/local-start-api-cognito-jwt/lib/local-start-api-cognito-jwt-stack.ts',
+  'tests/integration/local-start-api-container/lib/local-start-api-container-stack.ts',
+  'tests/integration/local-start-api-from-cfn-stack/lib/local-start-api-from-cfn-stack-stack.ts',
+  'tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts',
+  'tests/integration/local-start-api-watch/lib/watch-stack.ts',
 ];
 
 /**
  * Fixture sources whose architecture is pinned to a PREBUILT ARTIFACT and
  * must NOT be converted to the host architecture.
+ *
+ * Two shapes qualify, and both are about the ARTIFACT dictating the
+ * architecture rather than the host:
+ *
+ *  - **A prebuilt executable.** `local-invoke-provided` is the live case:
+ *    its `verify.sh` cross-compiles `bootstrap` with `GOARCH=amd64`, so the
+ *    declared architecture must match that binary. Handing an arm64 base
+ *    image an amd64 executable fails at RIE fork/exec with
+ *    `exec format error`.
+ *  - **A container image that cannot be built for the host.** For a
+ *    `DockerImageFunction` the declared architecture drives `docker build`
+ *    as well as `docker run` (cdk-local passes the same `--platform` to
+ *    both, see `buildContainerImage`), so a fixture whose Dockerfile pulls
+ *    an arch-specific base, or `COPY`s in a cross-compiled binary, cannot
+ *    be converted either. No fixture is in this shape today: the three
+ *    container fixtures all build `FROM public.ecr.aws/lambda/nodejs:20`,
+ *    which is multi-arch, and none copies in a prebuilt executable -- which
+ *    is why they ARE converted. Recorded here because the fixtures point at
+ *    this file for the carve-outs, so the list has to actually contain them.
  */
 const PINNED_STACKS = [
   {
@@ -163,13 +189,6 @@ const PINNED_STACKS = [
 const NOT_YET_CONVERTED = [
   'tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts',
   'tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts',
-  'tests/integration/local-start-api-all-stacks/lib/stack-a.ts',
-  'tests/integration/local-start-api-all-stacks/lib/stack-b.ts',
-  'tests/integration/local-start-api-cognito-jwt/lib/local-start-api-cognito-jwt-stack.ts',
-  'tests/integration/local-start-api-container/lib/local-start-api-container-stack.ts',
-  'tests/integration/local-start-api-from-cfn-stack/lib/local-start-api-from-cfn-stack-stack.ts',
-  'tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts',
-  'tests/integration/local-start-api-watch/lib/watch-stack.ts',
   'tests/integration/local-start-cloudfront-edge/lib/local-start-cloudfront-edge-stack.ts',
   'tests/integration/local-start-cloudfront-lambda-url/lib/local-start-cloudfront-lambda-url-stack.ts',
   'tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts',
@@ -296,6 +315,58 @@ function constructorCalls(source: string, needle: string): string[] {
     from = end + 1;
   }
   return calls;
+}
+
+/**
+ * The text of a constructor call's OWN property object, with everything
+ * nested inside it removed.
+ *
+ * `constructorCalls` returns the whole call, `fromImageAsset(...)` options
+ * and all, so a plain `call.includes('architecture: HOST_ARCHITECTURE')`
+ * matches a property that sits ONE LEVEL IN and does nothing. That is not
+ * hypothetical: moving the declaration into
+ * `DockerImageCode.fromImageAsset(dir, { ... })` keeps the whole suite
+ * green while the synthesized template loses `Architectures` entirely.
+ * TypeScript's excess-property check would normally reject it, but the
+ * fixtures run through `node bin/app.ts` type stripping, so nothing ever
+ * type-checks that object.
+ *
+ * Returning only depth-1 characters means a nested property is invisible
+ * here, and the caller can tell "absent" from "present but nested" and say
+ * which.
+ *
+ * Limitation: brace/paren counting is not string-aware, so a `{` inside a
+ * string literal in a fixture's props would skew it. Sources are
+ * comment-stripped first, no fixture does that today, and the count
+ * cross-check above would surface the resulting mis-delimitation.
+ */
+function ownPropsText(call: string): string {
+  let depth = 0;
+  let start = -1;
+  for (let i = call.indexOf('('); i < call.length; i++) {
+    const c = call[i];
+    if (c === '(') depth++;
+    else if (c === ')') depth--;
+    else if (c === '{' && depth === 1) {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) return '';
+  let out = '';
+  let d = 0;
+  for (let i = start; i < call.length; i++) {
+    const c = call[i];
+    if (c === '{' || c === '(' || c === '[') {
+      d++;
+      if (d === 1) continue;
+    } else if (c === '}' || c === ')' || c === ']') {
+      d--;
+      if (d === 0) break;
+    }
+    if (d === 1) out += c;
+  }
+  return out;
 }
 
 /** Name a call by its construct id, so a failure points at the function to fix. */
@@ -535,11 +606,23 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
           const missing: string[] = [];
 
           for (const [ctor, requiredProp] of LAMBDA_CTORS) {
+            const key = requiredProp.slice(0, requiredProp.indexOf(':'));
+            // `architecture` is a prefix of `architectures`, so the colon is
+            // load-bearing: it keeps the L2 key from matching the L1 one.
+            const keyAtTopLevel = new RegExp(`(^|[^\\w$])${key}\\s*:`);
             for (const call of constructorCalls(source, ctor)) {
               seen.push(call);
-              // `source` is comment-stripped, so a commented-out
-              // `// architecture: HOST_ARCHITECTURE` cannot satisfy this.
-              if (!call.includes(requiredProp)) {
+              // Two different failures, reported differently, because the
+              // fix differs. `source` is comment-stripped, so a
+              // commented-out declaration counts as absent.
+              if (!keyAtTopLevel.test(ownPropsText(call))) {
+                missing.push(
+                  call.includes(requiredProp)
+                    ? `${constructId(call)} (has \`${key}\`, but NESTED inside another ` +
+                        `object or call rather than on the construct's own props -- move it out)`
+                    : `${constructId(call)} (needs \`${requiredProp}\`)`
+                );
+              } else if (!call.includes(requiredProp)) {
                 missing.push(`${constructId(call)} (needs \`${requiredProp}\`)`);
               }
             }

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -38,7 +38,18 @@ import { fileURLToPath } from 'node:url';
  * `discovers every fixture that constructs a *Function(` closes it from
  * the other side. It walks `tests/integration/<fixture>/{lib,bin}` for
  * real (non-comment) `*Function(` constructor calls and asserts the
- * discovered set EQUALS the union of the four buckets. A deletion, an
+ * discovered set EQUALS the union of the four buckets.
+ *
+ * Scope, stated precisely because the phrase "every fixture Lambda" would
+ * overclaim: this covers every Lambda CONSTRUCTED DIRECTLY in a fixture's
+ * `lib/` or `bin/`. It does not cover Lambdas an L3 construct synthesizes
+ * on your behalf -- `s3deploy.BucketDeployment` emits an
+ * `AWS::Lambda::Function` with no `Architectures` in several fixtures --
+ * nor a Lambda built in some other directory and imported. Neither is a
+ * fixture handler anyone invokes, and neither is reachable from source
+ * text; closing them means reading synthesized templates, which CI cannot
+ * do (fixtures are not workspace members, so their node_modules never
+ * exist there). A deletion, an
  * addition, a renamed file, and a SECOND stack file inside an
  * already-listed fixture (`local-start-api-all-stacks/lib/stack-a.ts`
  * and `stack-b.ts` are exactly that shape) all become loud.
@@ -226,8 +237,9 @@ const ANY_FUNCTION_CTOR = /new\s+(?:[A-Za-z_$][\w$]*\s*\.\s*)*[\w$]*Function\s*\
  * (`const F = lambda.Function`), a parenthesized callee
  * (`new (lambda.Function)(`), and generics. All require going out of the
  * way, none appears in this repo, and closing them means parsing rather
- * than matching. The discovery assertion still accounts for the FILE, so
- * the damage is bounded to a construct inside an already-listed fixture.
+ * than matching. The discovery assertion bounds the damage to a construct
+ * inside an already-listed fixture -- EXCEPT where a fixture's only Lambda
+ * uses such a spelling, in which case the file is never discovered at all.
  */
 
 /**
@@ -318,8 +330,8 @@ function constructorCalls(source: string, needle: string): string[] {
 }
 
 /**
- * The text of a constructor call's OWN property object, with everything
- * nested inside it removed.
+ * Scan a constructor call's OWN property object, returning the depth-1
+ * characters plus, for each, its index in the original call.
  *
  * `constructorCalls` returns the whole call, `fromImageAsset(...)` options
  * and all, so a plain `call.includes('architecture: HOST_ARCHITECTURE')`
@@ -331,20 +343,34 @@ function constructorCalls(source: string, needle: string): string[] {
  * fixtures run through `node bin/app.ts` type stripping, so nothing ever
  * type-checks that object.
  *
- * Returning only depth-1 characters means a nested property is invisible
- * here, and the caller can tell "absent" from "present but nested" and say
- * which.
+ * Quote-aware, because it is not only nesting that skews brace counting: a
+ * construct id written as a template literal (`` `${prefix}Handler` ``)
+ * puts a `${` before the real props brace, and a naive scanner takes that
+ * as the object -- reporting "NESTED, move it out" about a fixture that is
+ * perfectly correct. Wrong-diagnosis failures cost more than no failure.
  *
- * Limitation: brace/paren counting is not string-aware, so a `{` inside a
- * string literal in a fixture's props would skew it. Sources are
- * comment-stripped first, no fixture does that today, and the count
- * cross-check above would surface the resulting mis-delimitation.
+ * The index map is what lets `ownPropValue` recover a property's VALUE from
+ * the original text after finding its key at depth 1.
  */
-function ownPropsText(call: string): string {
+function scanOwnProps(call: string): { text: string; index: number[] } {
+  const text: string[] = [];
+  const index: number[] = [];
+  let quote: string | null = null;
   let depth = 0;
   let start = -1;
+
+  // Find the props object: the first `{` at paren-depth 1, ignoring quotes.
   for (let i = call.indexOf('('); i < call.length; i++) {
     const c = call[i];
+    if (quote) {
+      if (c === '\\') i++;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      quote = c;
+      continue;
+    }
     if (c === '(') depth++;
     else if (c === ')') depth--;
     else if (c === '{' && depth === 1) {
@@ -352,11 +378,32 @@ function ownPropsText(call: string): string {
       break;
     }
   }
-  if (start === -1) return '';
-  let out = '';
+  if (start === -1) return { text: '', index: [] };
+
   let d = 0;
+  quote = null;
   for (let i = start; i < call.length; i++) {
     const c = call[i];
+    if (quote) {
+      if (c === '\\') {
+        i++;
+        continue;
+      }
+      if (c === quote) quote = null;
+      if (d === 1) {
+        text.push(c);
+        index.push(i);
+      }
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      quote = c;
+      if (d === 1) {
+        text.push(c);
+        index.push(i);
+      }
+      continue;
+    }
     if (c === '{' || c === '(' || c === '[') {
       d++;
       if (d === 1) continue;
@@ -364,9 +411,75 @@ function ownPropsText(call: string): string {
       d--;
       if (d === 0) break;
     }
-    if (d === 1) out += c;
+    if (d === 1) {
+      text.push(c);
+      index.push(i);
+    }
   }
-  return out;
+  return { text: text.join(''), index };
+}
+
+/** The depth-1 characters of a call's own props object. */
+function ownPropsText(call: string): string {
+  return scanOwnProps(call).text;
+}
+
+/**
+ * The SOURCE TEXT of the value assigned to `key` on the construct's own
+ * props, or `undefined` when the key is not there at depth 1.
+ *
+ * Pinning only the key is not enough, and the gap is not theoretical:
+ *
+ * ```ts
+ * new lambda.DockerImageFunction(this, 'F', {
+ *   architecture: undefined,                       // key at depth 1
+ *   code: DockerImageCode.fromImageAsset(dir, {
+ *     architecture: HOST_ARCHITECTURE,             // the real one, nested
+ *   }),
+ * });
+ * ```
+ *
+ * The key is present, the required text appears somewhere in the call, and
+ * CDK emits `Architectures: ["x86_64"]` -- issue #560 verbatim.
+ *
+ * The value is read from the ORIGINAL call rather than from the depth-1
+ * text, because the depth-1 view drops bracket contents and the L1 spelling
+ * `architectures: [HOST_ARCHITECTURE.name]` lives entirely inside them.
+ */
+function ownPropValue(call: string, key: string): string | undefined {
+  const { text, index } = scanOwnProps(call);
+  const m = new RegExp(`(^|[^\\w$])${key}\\s*:`).exec(text);
+  if (!m) return undefined;
+  const colonInText = m.index + m[0].length - 1;
+  let i = index[colonInText] + 1;
+
+  let depth = 0;
+  let quote: string | null = null;
+  let out = '';
+  for (; i < call.length; i++) {
+    const c = call[i];
+    if (quote) {
+      out += c;
+      if (c === '\\') {
+        out += call[++i] ?? '';
+        continue;
+      }
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      quote = c;
+      out += c;
+      continue;
+    }
+    if (c === '{' || c === '(' || c === '[') depth++;
+    else if (c === '}' || c === ')' || c === ']') {
+      if (depth === 0) break;
+      depth--;
+    } else if (c === ',' && depth === 0) break;
+    out += c;
+  }
+  return out.trim();
 }
 
 /** Name a call by its construct id, so a failure points at the function to fix. */
@@ -522,6 +635,132 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
       expect(call.includes('architecture: HOST_ARCHITECTURE')).toBe(false);
     });
 
+    // The BRANCH SELECTION is the part that had no committed coverage: the
+    // helper tests exercise the scanner, but nothing pinned "absent says
+    // needs, nested says NESTED, wrong value says wrong value". Those three
+    // messages send a reader to three different fixes.
+    const missingFor = (call: string, key: string, required: string): string => {
+      const actual = ownPropValue(call, key);
+      const nested = call.includes(required);
+      const want = required.slice(required.indexOf(':') + 1).trim();
+      if (actual === undefined) return nested ? 'NESTED' : 'MISSING';
+      return actual.replace(/\s+/g, ' ') === want ? 'OK' : 'WRONG_VALUE';
+    };
+    const L2 = 'architecture: HOST_ARCHITECTURE';
+
+    it('classifies a correct declaration as OK', () => {
+      expect(
+        missingFor(`new lambda.Function(this, 'A', { runtime: R, ${L2}, timeout: T })`, 'architecture', L2)
+      ).toBe('OK');
+    });
+
+    it('classifies a genuinely absent declaration as MISSING, not NESTED', () => {
+      expect(missingFor(`new lambda.Function(this, 'A', { runtime: R })`, 'architecture', L2)).toBe(
+        'MISSING'
+      );
+    });
+
+    it('classifies a RELOCATED declaration as NESTED', () => {
+      const call = `new lambda.DockerImageFunction(this, 'A', {
+        code: DockerImageCode.fromImageAsset(d, { ${L2} }),
+      })`;
+      expect(missingFor(call, 'architecture', L2)).toBe('NESTED');
+    });
+
+    it('rejects a depth-1 key whose VALUE is wrong even when the right text is nested', () => {
+      // The shape that passed a key-only check: the key IS on the construct's
+      // own props, the required text IS somewhere in the call, and CDK still
+      // emits x86_64.
+      const call = `new lambda.DockerImageFunction(this, 'A', {
+        architecture: undefined,
+        code: DockerImageCode.fromImageAsset(d, { ${L2} }),
+      })`;
+      expect(missingFor(call, 'architecture', L2)).toBe('WRONG_VALUE');
+    });
+
+    it('rejects a depth-1 key holding an indirect value', () => {
+      expect(
+        missingFor(`new lambda.Function(this, 'A', { architecture: props.arch })`, 'architecture', L2)
+      ).toBe('WRONG_VALUE');
+    });
+
+    it('accepts the L1 array value and rejects a wrong one', () => {
+      const req = 'architectures: [HOST_ARCHITECTURE.name]';
+      expect(
+        missingFor(`new lambda.CfnFunction(this, 'A', { runtime: 'r', ${req} })`, 'architectures', req)
+      ).toBe('OK');
+      expect(
+        missingFor(`new lambda.CfnFunction(this, 'A', { architectures: ['x86_64'] })`, 'architectures', req)
+      ).toBe('WRONG_VALUE');
+    });
+
+    it('is not fooled by a template-literal construct id', () => {
+      // `${` is a brace at paren depth 1; a scanner that is not quote-aware
+      // takes it as the props object and reports NESTED about a correct
+      // fixture -- a wrong diagnosis, which costs more than no diagnosis.
+      const call = 'new lambda.Function(this, `${id}Fn`, { runtime: R, ' + L2 + ' })';
+      expect(missingFor(call, 'architecture', L2)).toBe('OK');
+    });
+
+    it('is not fooled by a brace inside a string-valued property', () => {
+      const call = `new lambda.Function(this, 'A', { description: '{oops}', ${L2} })`;
+      expect(missingFor(call, 'architecture', L2)).toBe('OK');
+    });
+
+    it('ownPropsText returns only the construct\'s OWN properties, not nested ones', () => {
+      const call = `new lambda.DockerImageFunction(this, 'A', {
+        code: lambda.DockerImageCode.fromImageAsset(dir, {
+          architecture: HOST_ARCHITECTURE,
+          target: 'final',
+        }),
+        timeout: T,
+      })`;
+      const own = ownPropsText(call);
+      expect(own).toContain('code:');
+      expect(own).toContain('timeout:');
+      // The whole point: a property one level in must NOT appear.
+      expect(own).not.toContain('architecture:');
+      expect(own).not.toContain('target:');
+    });
+
+    it('ownPropsText finds the props object of a WRAPPED call', () => {
+      const call = `new lambda.Function(
+        this,
+        'Wrapped',
+        {
+          runtime: R,
+          architecture: HOST_ARCHITECTURE,
+        }
+      )`;
+      expect(ownPropsText(call)).toContain('architecture:');
+    });
+
+    it('ownPropsText keeps an array-valued own property visible by key', () => {
+      // The L1 spelling is `architectures: [HOST_ARCHITECTURE.name]`. The
+      // bracket contents are nested and therefore dropped, so the fence
+      // matches the KEY here and the full value against the whole call.
+      const call = `new lambda.CfnFunction(this, 'A', {
+        runtime: 'ruby3.3',
+        architectures: [HOST_ARCHITECTURE.name],
+      })`;
+      const own = ownPropsText(call);
+      expect(own).toMatch(/(^|[^\w$])architectures\s*:/);
+      expect(own).not.toContain('HOST_ARCHITECTURE.name');
+    });
+
+    it('ownPropsText does not confuse the L1 and L2 keys', () => {
+      const l2 = ownPropsText(`new lambda.Function(this, 'A', { architecture: X })`);
+      const l1 = ownPropsText(`new lambda.CfnFunction(this, 'A', { architectures: [X] })`);
+      expect(l2).toMatch(/(^|[^\w$])architecture\s*:/);
+      // `architectures:` must not satisfy a search for `architecture:`.
+      expect(l1).not.toMatch(/(^|[^\w$])architecture\s*:/);
+      expect(l1).toMatch(/(^|[^\w$])architectures\s*:/);
+    });
+
+    it('ownPropsText returns empty for a call with no props object', () => {
+      expect(ownPropsText(`new lambda.Function(this, 'A')`)).toBe('');
+    });
+
     it('keeps a `//` inside a string literal', () => {
       expect(stripComments(`const u = 'https://example.com/x';`)).toContain('https://example.com/x');
     });
@@ -606,24 +845,43 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
           const missing: string[] = [];
 
           for (const [ctor, requiredProp] of LAMBDA_CTORS) {
-            const key = requiredProp.slice(0, requiredProp.indexOf(':'));
-            // `architecture` is a prefix of `architectures`, so the colon is
-            // load-bearing: it keeps the L2 key from matching the L1 one.
-            const keyAtTopLevel = new RegExp(`(^|[^\\w$])${key}\\s*:`);
+            const colon = requiredProp.indexOf(':');
+            // A LAMBDA_CTORS value without a colon would silently yield a
+            // truncated key and weaken every check below, so refuse instead.
+            expect(colon, `LAMBDA_CTORS value ${requiredProp} must be "key: value"`).toBeGreaterThan(0);
+            const key = requiredProp.slice(0, colon);
+            const wantValue = requiredProp.slice(colon + 1).trim();
+
             for (const call of constructorCalls(source, ctor)) {
               seen.push(call);
-              // Two different failures, reported differently, because the
-              // fix differs. `source` is comment-stripped, so a
-              // commented-out declaration counts as absent.
-              if (!keyAtTopLevel.test(ownPropsText(call))) {
+              const actual = ownPropValue(call, key);
+              const nestedSomewhere = call.includes(requiredProp);
+
+              if (actual === undefined) {
+                // Absent from the construct's own props. Two different
+                // fixes, so two different messages -- a fence that cries
+                // "NESTED" at a simply-missing property sends the reader
+                // hunting for a nesting problem that is not there.
                 missing.push(
-                  call.includes(requiredProp)
+                  nestedSomewhere
                     ? `${constructId(call)} (has \`${key}\`, but NESTED inside another ` +
                         `object or call rather than on the construct's own props -- move it out)`
                     : `${constructId(call)} (needs \`${requiredProp}\`)`
                 );
-              } else if (!call.includes(requiredProp)) {
-                missing.push(`${constructId(call)} (needs \`${requiredProp}\`)`);
+              } else if (actual.replace(/\s+/g, ' ') !== wantValue) {
+                // The key IS at depth 1 but carries the wrong value. The
+                // dangerous shape is `architecture: undefined` at depth 1
+                // with the real declaration nested: key present, required
+                // text present in the call, and the template still defaults
+                // to x86_64.
+                missing.push(
+                  `${constructId(call)} (declares \`${key}: ${actual}\` on its own props, ` +
+                    `but needs \`${requiredProp}\`` +
+                    (nestedSomewhere
+                      ? ` -- the correct declaration is NESTED one level in and CDK never sees it`
+                      : '') +
+                    `)`
+                );
               }
             }
           }
@@ -672,19 +930,53 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
         });
 
         it('does not set Architectures through an escape hatch the fence cannot read', () => {
-          // `addPropertyOverride('Architectures', ...)` after construction
-          // would override the declared value while leaving the
-          // constructor call looking correct -- green fence, emulated
-          // container.
-          const source = read(relPath);
-          const overrides = source
-            .split('\n')
-            .filter((line) => /add(?:Property)?Override\s*\(/.test(line))
-            .filter((line) => /architectures?/i.test(line));
+          // A post-construction mutation overrides the declared value while
+          // leaving the constructor call looking correct: green fence,
+          // emulated container. Matched against whitespace-collapsed source
+          // rather than line by line, because a formatter splits
+          // `addPropertyOverride(\n  'Architectures',\n  ...)` across lines and
+          // a per-line conjunction then matches neither half.
+          const flat = read(relPath).replace(/\s+/g, ' ');
+          const escapes = [
+            /add(?:Property)?Override\s*\(\s*['"`]Architectures/i,
+            /addPropertyDeletionOverride\s*\(\s*['"`]Architectures/i,
+            /addDeletionOverride\s*\(\s*['"`]Architectures/i,
+            /\.architectures\s*=/i,
+          ]
+            .filter((re) => re.test(flat))
+            .map((re) => re.source);
+
           expect(
-            overrides,
-            `${relPath}: an Architectures override bypasses the declared architecture. ` +
-              'Set it on the constructor instead'
+            escapes,
+            `${relPath}: an Architectures override or direct assignment bypasses the ` +
+              'declared architecture. Set it on the constructor instead'
+          ).toEqual([]);
+        });
+
+        it('does not pin a foreign platform in its Dockerfile', () => {
+          // The PINNED_STACKS note says a Dockerfile pulling an
+          // arch-specific base disqualifies a fixture from conversion --
+          // but nothing READ a Dockerfile, so that carve-out was a claim
+          // rather than a check. `FROM --platform=linux/amd64` restores
+          // emulation on an arm64 host with every other assertion green.
+          const fixtureDir = path.join(REPO_ROOT, relPath.split('/').slice(0, 3).join('/'));
+          let dockerfiles: string[] = [];
+          try {
+            dockerfiles = (readdirSync(fixtureDir, { recursive: true }) as string[]).filter((f) =>
+              path.basename(f).startsWith('Dockerfile')
+            );
+          } catch {
+            dockerfiles = [];
+          }
+          const pinned = dockerfiles.filter((f) =>
+            /^\s*FROM\s+--platform=/im.test(readFileSync(path.join(fixtureDir, f), 'utf8'))
+          );
+          expect(
+            pinned,
+            `${relPath}: these Dockerfiles pin a --platform, which overrides the host ` +
+              'architecture this fixture declares and puts the container back under ' +
+              'emulation. Either drop the pin, or move the fixture to PINNED_STACKS ' +
+              'because its image genuinely cannot be built for the host'
           ).toEqual([]);
         });
       });
@@ -716,6 +1008,27 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
             .filter((call) => !call.includes(pin))
             .map((call) => constructId(call));
           expect(unpinned, `${relPath}: these constructs lost \`${pin}\`: ${why}`).toEqual([]);
+        });
+
+        it('leaves its L1 CfnFunctions undeclared so they default to the pinned arch', () => {
+          // The per-call check above covers `new lambda.Function(` only. This
+          // fixture also has three `CfnFunction`s; they declare no
+          // `architectures` and so default to x86_64, which is correct for an
+          // amd64 bootstrap. Asserted rather than assumed, so a future edit
+          // that gives one of them arm64 -- silently contradicting the pin --
+          // is caught.
+          const source = read(relPath);
+          const wrong = constructorCalls(source, 'new lambda.CfnFunction(')
+            .filter((call) => {
+              const v = ownPropValue(call, 'architectures');
+              return v !== undefined && !v.includes('x86_64');
+            })
+            .map(constructId);
+          expect(
+            wrong,
+            `${relPath}: these L1 constructs declare a non-x86_64 architecture, which ` +
+              `contradicts the fixture's pin: ${why}`
+          ).toEqual([]);
         });
 
         it('is not converted to HOST_ARCHITECTURE', () => {

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -482,6 +482,53 @@ function ownPropValue(call: string, key: string): string | undefined {
   return out.trim();
 }
 
+/**
+ * Known parsing limitations, recorded rather than chased.
+ *
+ * All of them FAIL LOUDLY -- they end in `MISSING`, `NESTED` or
+ * `WRONG_VALUE` on code that is actually correct, never in a silent pass on
+ * code that is wrong. That asymmetry is why they are acceptable: the cost is
+ * a confusing failure someone must read, not an emulated container nobody
+ * notices. None occurs anywhere in the repo today.
+ *
+ *  - A depth-1 STRING that contains the key (`description: 'architecture: x'`)
+ *    hijacks the first regex match; every construction tried yields
+ *    `WRONG_VALUE`.
+ *  - A regex literal containing an unbalanced quote desynchronises the quote
+ *    state and reports `NESTED`. This is inherited: `stripComments` is
+ *    likewise regex-blind, so `/'/` already confuses the whole file.
+ *  - A quoted or computed key (`'architecture':` / `[key]:`) reports
+ *    `MISSING`, because the key regex expects a bare identifier.
+ *  - `constructorCalls` is not quote-aware, so a `)` inside a string can
+ *    truncate a call early; the truncated text then reports `MISSING`.
+ *
+ * The paren/regex COUNT CROSS-CHECK does not catch any of these -- it
+ * compares two views that share the same blindness. It catches a
+ * mis-delimited constructor NAME, which is a different failure.
+ */
+
+/**
+ * Compare property values without depending on how they are laid out.
+ *
+ * Whitespace is removed entirely rather than collapsed, and a trailing comma
+ * before a closing bracket or brace is dropped, so a hand-wrapped L1 array
+ *
+ * ```ts
+ * architectures: [
+ *   HOST_ARCHITECTURE.name,
+ * ],
+ * ```
+ *
+ * still equals `[HOST_ARCHITECTURE.name]`. Collapsing to single spaces was
+ * not enough: it yields `[ HOST_ARCHITECTURE.name, ]`, so a CORRECT fixture
+ * would be reported as having the wrong value. oxfmt would not produce that
+ * shape at `printWidth: 100`, but a person editing the L1 spelling by hand
+ * would, and the L1 spelling is the one that gets hand-edited.
+ */
+function normalizeValue(value: string): string {
+  return value.replace(/\s+/g, '').replace(/,+(?=[\]}])/g, '');
+}
+
 /** Name a call by its construct id, so a failure points at the function to fix. */
 function constructId(call: string): string {
   return /new\s+[\w$.]*\(\s*this,\s*'([^']+)'/.exec(call)?.[1] ?? call.slice(0, 80).trim();
@@ -644,7 +691,7 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
       const nested = call.includes(required);
       const want = required.slice(required.indexOf(':') + 1).trim();
       if (actual === undefined) return nested ? 'NESTED' : 'MISSING';
-      return actual.replace(/\s+/g, ' ') === want ? 'OK' : 'WRONG_VALUE';
+      return normalizeValue(actual) === normalizeValue(want) ? 'OK' : 'WRONG_VALUE';
     };
     const L2 = 'architecture: HOST_ARCHITECTURE';
 
@@ -684,6 +731,31 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
       ).toBe('WRONG_VALUE');
     });
 
+    it('accepts a hand-wrapped L1 array with a trailing comma', () => {
+      // The layout a person produces when editing the L1 spelling by hand.
+      // A whitespace-COLLAPSING comparison reports WRONG_VALUE here, i.e. it
+      // fails a correct fixture.
+      const req = 'architectures: [HOST_ARCHITECTURE.name]';
+      const call = `new lambda.CfnFunction(this, 'A', {
+        runtime: 'ruby3.3',
+        architectures: [
+          HOST_ARCHITECTURE.name,
+        ],
+      })`;
+      expect(missingFor(call, 'architectures', req)).toBe('OK');
+    });
+
+    it('accepts a reformatted L2 value and still rejects a different one', () => {
+      const call = `new lambda.Function(this, 'A', {
+        architecture:
+          HOST_ARCHITECTURE,
+      })`;
+      expect(missingFor(call, 'architecture', L2)).toBe('OK');
+      expect(
+        missingFor(`new lambda.Function(this, 'A', { architecture: OTHER })`, 'architecture', L2)
+      ).toBe('WRONG_VALUE');
+    });
+
     it('accepts the L1 array value and rejects a wrong one', () => {
       const req = 'architectures: [HOST_ARCHITECTURE.name]';
       expect(
@@ -702,8 +774,18 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
       expect(missingFor(call, 'architecture', L2)).toBe('OK');
     });
 
-    it('is not fooled by a brace inside a string-valued property', () => {
-      const call = `new lambda.Function(this, 'A', { description: '{oops}', ${L2} })`;
+    it('is not fooled by an UNBALANCED brace inside a string-valued property', () => {
+      // The brace must be unbalanced to discriminate. An earlier version used
+      // '{oops}', whose `{` and `}` cancel out, so the depth counter ends up
+      // in the same place with or without quote awareness and the test passed
+      // against a non-quote-aware scanner -- a fence assertion that could not
+      // fail, which is the exact class this file exists to catch.
+      const call = `new lambda.Function(this, 'A', { description: '{', ${L2} })`;
+      expect(missingFor(call, 'architecture', L2)).toBe('OK');
+    });
+
+    it('is not fooled by an unbalanced paren inside a string-valued property', () => {
+      const call = `new lambda.Function(this, 'A', { description: '(', ${L2} })`;
       expect(missingFor(call, 'architecture', L2)).toBe('OK');
     });
 
@@ -868,7 +950,7 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
                         `object or call rather than on the construct's own props -- move it out)`
                     : `${constructId(call)} (needs \`${requiredProp}\`)`
                 );
-              } else if (actual.replace(/\s+/g, ' ') !== wantValue) {
+              } else if (normalizeValue(actual) !== normalizeValue(wantValue)) {
                 // The key IS at depth 1 but carries the wrong value. The
                 // dangerous shape is `architecture: undefined` at depth 1
                 // with the real declaration nested: key present, required


### PR DESCRIPTION
Batch 3 of 4 for (#569), plus the fence fix a batch-2 review turned up. One batch
remains, so (#569) stays open.

Backlog counter: `NOT_YET_CONVERTED` **13 -> 6**.

## The fence could not see WHERE a property sat

`constructorCalls` returns the whole constructor call, nested arguments and all, so
`call.includes('architecture: HOST_ARCHITECTURE')` matched a declaration one level in.
Moving it into `DockerImageCode.fromImageAsset(dir, { ... })` kept the suite **104/104
green while the synthesized template lost `Architectures` entirely**. I reproduced that
before fixing it. TypeScript's excess-property check would normally reject that object,
but fixtures run under `node bin/app.ts` type stripping, so nothing ever type-checks it.

**Why it survived two review rounds:** every probe so far DELETED or altered the
property. None RELOCATED it. A deletion and a relocation look identical to a substring
check and completely different to CDK.

The check now extracts the constructor's OWN props object -- depth-1 characters only --
and requires the key there, so a nested declaration reads as absent. The two failures are
reported differently, because the fixes differ:

```
needs `architecture: HOST_ARCHITECTURE`
has `architecture`, but NESTED inside another object or call rather than on the
  construct's own props -- move it out
```

`local-start-api-container` is the same `DockerImageFunction` shape that exposed the gap,
so this batch would have walked straight back into it. Probed on that exact fixture: it
now fails with the NESTED message.

### Why not assert against the synthesized template

That was the stronger suggestion and would close the whole class rather than one shape.
It is not adopted here, but **my first rationale for that was wrong and the spec review
caught it**, so the corrected version:

- *What I claimed:* CI never installs fixture `node_modules`, so a synth-based unit test
  would pass locally and fail in CI.
- *What is actually true:* the premises hold (there is no `pnpm-workspace.yaml`, and
  `ci.yml` installs only the root) but the conclusion does not follow. `aws-cdk-lib` and
  `constructs` are ROOT dependencies, so the root install satisfies them and a synth
  resolves fine in CI. The reviewer ran exactly that to produce independent S6 evidence.
- *The real obstacle is the mirror image:* **locally**, a fixture's own `node_modules`
  shadows the root copy, and the two CDK instances collide -- `scope.node._scopes is not
  iterable` in 4 of 8 fixtures. A test that fails on the maintainer's machine and passes
  in CI is worse than one that does neither.

So the depth check stays, on its own merits: it closes the same class, runs everywhere,
and costs no subprocess synths in the unit suite. Recording the correction rather than
the original reasoning, so nobody re-derives the wrong premise.

### Probes

```
[x] T0 CONTROL: unmutated                                     control passes
[x] T1 RELOCATED into fromImageAsset options (the gap)        named "NESTED"
[x] T2 RELOCATED into the environment object (plain Function) named "NESTED"
[x] T3 RELOCATED into the L1 code object (CfnFunction)        named "NESTED"
[x] T4 simply absent still says "needs ..." not "NESTED"      distinguishes the two
[x] T5 L1 key not satisfied by the L2 key                     named "InlineHandler"
[x] relocation probed on local-start-api-container itself     named "NESTED"
[x] restore verified: sha256 unchanged for every touched file
```

T4 matters as much as T1: a fence that reports every failure as "NESTED" would send
someone hunting for a nesting problem that is not there.

## What changed

| Fixture | Declarations | Class | Notes |
| --- | --- | --- | --- |
| `local-start-api-all-stacks` | 2 (`stack-a.ts`, `stack-b.ts`) | A | two sources in one fixture |
| `local-start-api-cognito-jwt` | 1 | A | |
| `local-start-api-container` | 1 | **C (image)** | same shape as the gap |
| `local-start-api-from-cfn-stack` | 2 | A | real CloudFormation stack |
| `local-start-api-rest-v1-non-proxy` | 1 | A | |
| `local-start-api-watch` | 1 | A | |

Buckets still partition all 31 discovered sources: 22 / 1 / 6 / 2.

## Three comments that said things the code does not do

- **`local-list`** claimed "every container here runs under CPU emulation" while its own
  `verify.sh` says "No Docker required -- pure synth-time read". It runs `cdkl list` /
  `cdkl ls` and boots nothing. The comment now says the declaration is for template
  consistency and fence completeness, and that no observed fault is being fixed there.
  The batch-2 PR body had the honest wording; the code did not, which is the worse place
  for the discrepancy to live.
- **The container fixtures** pointed at the fence for "the carve-outs" and then stated a
  NEW one (an arch-specific base image, or a `COPY`ied cross-compiled binary) that
  appeared neither in the fence nor in `create-integ`'s scaffold. Both now carry it, so
  the pointer is true.
- **`local-start-api-container`**'s own doc said `--platform linux/amd64` was threaded
  through, which was only true while the fixture defaulted to x86_64.

## CI (amd64) is unchanged

```
local-start-api-all-stacks / A     +1 Architectures:["x86_64"]                       (arm64 emits 1 "arm64")
local-start-api-all-stacks / B     +1 Architectures:["x86_64"]                       (arm64 emits 1 "arm64")
local-start-api-cognito-jwt        +1 Architectures:["x86_64"]                       (arm64 emits 1 "arm64")
local-start-api-container          +1 Architectures:["x86_64"] + 1 container-asset tag (arm64 emits 1 "arm64")
local-start-api-from-cfn-stack     +2 Architectures:["x86_64"]                       (arm64 emits 2 "arm64")
local-start-api-rest-v1-non-proxy  +1 Architectures:["x86_64"]                       (arm64 emits 1 "arm64")
local-start-api-watch              +1 Architectures:["x86_64"]                       (arm64 emits 1 "arm64")
```

8 additions for 8 declarations. The container fixture carries the same second delta batch
2 documented -- CDK folds the architecture into the `DockerImageAsset` platform, changing
the asset hash. Nothing deploys it.

`local-start-api-all-stacks` is the two-source fixture whose shape broke the parity
checker in batch 2 (it reverted only the first `lib/*.ts`, compared a file against
itself, and scored the empty diff as a pass). With that fixed, each stack reports its own
`+1` -- the case the fix was for, now exercised.

## Runs on the arm64 host

```
local-start-api-cognito-jwt        PASS  9s /  7s / 14s    docker clean
local-start-api-rest-v1-non-proxy  PASS  8s /  8s /  7s    docker clean
local-start-api-watch              PASS 13s / 14s / 13s    docker clean
local-start-api-container          PASS  5s /  5s /  6s    docker clean
local-start-api-all-stacks         PASS 10s / 10s / 15s    docker clean
local-start-api-from-cfn-stack     PASS 109s / 99s / 102s  docker clean, stack gone
```

18 runs, all green. Sample size for the AWS-backed fixture is 3, with the same rule as
batch 2: any failure escalates to a 9-run A/B rather than a re-run. None failed.

Direct evidence for the `start-api` container path, which is a different code path from
batch 2's `invoke` -- server booted with `--verbose`, one real request driven through it:

```
response: {"fromContainer":true,"greeting":"hello","rawPath":"/","method":"GET"}
--platform passed to docker: linux/arm64
emulation warnings: 0
docker after: []
```

**AWS sweep:** `CdkLocalStartApiFromCfnStackFixture` absent after the three runs. Docker
swept with `docker ps -a` after every individual attempt.

## Second review round

Three reviewers (code / test / spec) at the `3-axis` tier. The spec review verified all
seven requirements and independently re-walked the fixture tree, finding **31** sources
byte-identical to the four buckets with zero miscategorised paths. Two findings were
blocking and are fixed here:

- **The value was never pinned at depth 1.** The check required the KEY on the
  construct's own props and the required TEXT anywhere in the call. So
  `architecture: undefined` at depth 1, with the real declaration nested, passed: key
  present, text present, and CDK emits `Architectures: ["x86_64"]` -- issue (#560)
  verbatim. I reproduced it (**137/137 green**) before fixing. The check now extracts the
  depth-1 property's VALUE from the original source -- including bracket contents, so the
  L1 `architectures: [HOST_ARCHITECTURE.name]` still compares correctly -- and reports a
  third distinct message naming what it found.
- **`ownPropsText` had no committed test**, so mutating it to `return call;` (the exact
  pre-PR behaviour this PR exists to remove) left the suite green. It now has self-tests,
  and so does the BRANCH SELECTION: absent says "needs", relocated says "NESTED", wrong
  value says what it found. Three messages, three different fixes.

Non-blocking findings, also fixed:

- The scanner was not quote-aware, so a template-literal construct id
  (`` `${id}Fn` ``) put a `${` before the real props brace and reported "NESTED, move it
  out" about a **correct** fixture. A wrong diagnosis is worse than none. Same for a brace
  inside a string-valued prop. Both now have tests.
- The override detector matched per line, so a formatter-wrapped
  `addPropertyOverride(\n 'Architectures',\n ...)` slipped through, as did
  `addPropertyDeletionOverride` and a direct `.architectures =` assignment. Now matched
  against whitespace-collapsed source with all four spellings.
- The `PINNED_STACKS` note claimed an arch-specific base image disqualifies a fixture, but
  nothing read a Dockerfile -- `FROM --platform=linux/amd64` restored emulation with every
  assertion green. Now checked.
- The completion-signal wording overclaimed. The walk covers Lambdas constructed directly
  in a fixture's `lib/`/`bin/`; it does not cover Lambdas an L3 construct synthesizes
  (`s3deploy.BucketDeployment` emits one in several fixtures). Reworded to say so.
- The pinned fixture's three L1 `CfnFunction`s were unchecked. They correctly declare
  nothing and default to x86_64, matching the amd64 bootstrap -- now asserted, so a future
  edit giving one of them arm64 is caught.

All five probe suites (P/Q/R/S/T, 41 mutations) were re-run after the helper rewrite: no
regressions, every restore sha256-verified.

## Third review round

Re-review of the rewritten helpers: **no blockers**, both round-2 blockers confirmed
closed empirically -- all 22 converted fixtures `OK` with exact index alignment, all 6
`NOT_YET_CONVERTED` parsing cleanly, and every mutant killed. Two non-blocking findings,
both fixed, and both the same class this file keeps catching:

- **A vacuous test.** The quote-awareness case used a string containing `'{oops}'` -- a
  BALANCED pair, so the depth counter lands identically with or without quote handling
  and the test passed against a non-quote-aware scanner. Mutation-proven: neutering every
  quote-entry site killed exactly ONE test, the template-literal one. The string is now a
  single unbalanced `'{'`, with a second case for `'('`. The same mutation now kills
  three tests. Quote-awareness was fenced by one assertion; it is fenced by three.
- **A claim the code did not honour.** The value comparison collapsed whitespace to
  single spaces, so a hand-wrapped `architectures: [\n  HOST_ARCHITECTURE.name,\n]`
  became `[ HOST_ARCHITECTURE.name, ]` and a CORRECT fixture reported `WRONG_VALUE` --
  contradicting this file's own reformat-tolerance claim. Not reachable through oxfmt at
  `printWidth: 100`, but reachable by hand, and the L1 spelling is the one that gets
  hand-edited. Whitespace is now stripped entirely and a trailing comma before `]`/`}`
  dropped. Mutation-verified: restoring the old normalizer kills the new test.

Remaining parsing limitations are now recorded in the file with the reason they are
acceptable: a depth-1 string containing the key, a regex literal with an unbalanced quote
(inherited -- `stripComments` is regex-blind too), a quoted or computed key, and a `)`
inside a string truncating a call. Every one fails LOUDLY on correct code rather than
passing silently on wrong code, and none occurs in the repo. The paren/regex count
cross-check catches none of them, because it compares two views sharing the same
blindness -- stated explicitly so nobody mistakes it for a backstop it is not.
