### PR TITLE
test(integ): convert the last six fixtures, taking the #569 backlog to zero (batch 4 of 4)

### DIFF
--- a/tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts
+++ b/tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts
@@ -8,6 +8,25 @@ import { Construct } from 'constructs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture for `cdkl start-alb` -> Lambda target groups (#123 Lambda-target
  * slice).
  *
@@ -41,6 +60,7 @@ export class LocalStartAlbLambdaStack extends cdk.Stack {
 
     const echoFn = new lambda.Function(this, 'EchoFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code,
       environment: { GREETING: 'hello' },
@@ -48,6 +68,7 @@ export class LocalStartAlbLambdaStack extends cdk.Stack {
     });
     const apiFn = new lambda.Function(this, 'ApiFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code,
       environment: { GREETING: 'api-hello' },

--- a/tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts
+++ b/tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts
@@ -62,6 +62,25 @@ const WS_BOOT = [
   `exec python -c "${WS_ECHO_SERVER.replace(/"/g, '\\"')}"`,
 ].join('\n');
 
+/**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
 export class LocalStartAlbWebSocketStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
@@ -126,6 +145,7 @@ export class LocalStartAlbWebSocketStack extends cdk.Stack {
 
     const plainFn = new lambda.Function(this, 'PlainFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambdaCode,
       timeout: cdk.Duration.seconds(10),

--- a/tests/integration/local-start-cloudfront-edge/lib/local-start-cloudfront-edge-stack.ts
+++ b/tests/integration/local-start-cloudfront-edge/lib/local-start-cloudfront-edge-stack.ts
@@ -11,6 +11,23 @@ import type { Construct } from 'constructs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and the container runs
+ * under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently (issue #560; extended to the remaining
+ * fixtures by issue #569).
+ *
+ * See the note on `EdgeFn` below: this fixture's Lambda is a Lambda@Edge
+ * function, which real AWS restricts to x86_64, so declaring the host arch
+ * here is a deliberate, measured deviation rather than the routine change it
+ * is everywhere else.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Lambda@Edge fixture for `cdkl start-cloudfront` (#400). The distribution's
  * default behavior wires ONE Lambda function to BOTH the `viewer-request` and
  * `viewer-response` event types (a single warm RIE container is booted). The
@@ -38,8 +55,38 @@ export class LocalStartCloudFrontEdgeStack extends cdk.Stack {
       destinationBucket: bucket,
     });
 
+    // Declares the HOST architecture, and this fixture is the one place in
+    // the repo where that is a JUDGEMENT CALL rather than the obvious move.
+    //
+    // Real AWS restricts Lambda@Edge to x86_64: a function attached to a
+    // distribution through `edgeLambdas` cannot be arm64. So on paper this
+    // fixture should pin x86_64, and CDK would not stop it either way -- it
+    // does NOT reject arm64 here at synth.
+    //
+    // It declares the host arch anyway, because the pin was measured and it
+    // is not free. Ten runs on an arm64 host, five per arm:
+    //
+    //   pinned x86_64        4/5 passed, 1 emulation warning
+    //   host architecture    5/5 passed, 0 emulation warnings
+    //
+    // and a sixth pinned run failed with the Go RIE dying mid-request --
+    // `fatal error: found pointer to free object`, then `GET /go` returning
+    // 500 instead of the edge function's 302. That is issue #560 exactly, in
+    // the last fixture of the issue that exists to remove it.
+    //
+    // What decides it: this fixture NEVER DEPLOYS. `verify.sh` runs
+    // `cdkl start-cloudfront` against the synthesized assembly, so the
+    // `Architectures` value is read by cdk-local alone and AWS never sees the
+    // template. Trading a reproducible local fault for fidelity to a
+    // constraint nothing here enforces is the wrong way round.
+    //
+    // If this fixture ever grows a `cdk deploy`, this decision reverses:
+    // pin x86_64 and accept the emulation, because then the constraint is
+    // real. **A production Lambda@Edge stack must pin x86_64** -- do not copy
+    // the line below into one.
     const edgeFn = new lambda.Function(this, 'EdgeFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromInline(
         [

--- a/tests/integration/local-start-cloudfront-edge/lib/local-start-cloudfront-edge-stack.ts
+++ b/tests/integration/local-start-cloudfront-edge/lib/local-start-cloudfront-edge-stack.ts
@@ -69,7 +69,8 @@ export class LocalStartCloudFrontEdgeStack extends cdk.Stack {
     //   pinned x86_64        4/5 passed, 1 emulation warning
     //   host architecture    5/5 passed, 0 emulation warnings
     //
-    // and a sixth pinned run failed with the Go RIE dying mid-request --
+    // and a further pinned run, in the batch sweep that preceded this A/B,
+    // failed outright with the Go RIE dying mid-request --
     // `fatal error: found pointer to free object`, then `GET /go` returning
     // 500 instead of the edge function's 302. That is issue #560 exactly, in
     // the last fixture of the issue that exists to remove it.

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts
@@ -10,6 +10,25 @@ import type { Construct } from 'constructs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl start-cloudfront --from-cfn-stack` on a Lambda
  * Function URL origin (issue #380).
  *
@@ -39,6 +58,7 @@ export class LocalStartCloudFrontLambdaUrlFromCfnStackStack extends cdk.Stack {
 
     const fn = new lambda.Function(this, 'OriginFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '..', 'lambda')),
       environment: {

--- a/tests/integration/local-start-cloudfront-lambda-url/lib/local-start-cloudfront-lambda-url-stack.ts
+++ b/tests/integration/local-start-cloudfront-lambda-url/lib/local-start-cloudfront-lambda-url-stack.ts
@@ -5,6 +5,25 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import type { Construct } from 'constructs';
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * CloudFront distribution fronting a Lambda Function URL origin, for the
  * `cdkl start-cloudfront` Lambda-origin integ test (#376):
  *
@@ -23,6 +42,7 @@ export class LocalStartCloudFrontLambdaUrlStack extends cdk.Stack {
 
     const fn = new lambda.Function(this, 'OriginFn', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromInline(
         [

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -16,6 +16,25 @@ import { Construct } from 'constructs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Run this fixture's Lambdas at the HOST's CPU architecture.
+ *
+ * A function that declares no `architecture` defaults to `X86_64`, so on an
+ * arm64 host cdk-local pins `--platform linux/amd64` and every container here
+ * runs under CPU emulation -- where the Go RIE in the `public.ecr.aws/lambda/*`
+ * base images faults intermittently, at a different assertion on every run
+ * (issue #560; extended to the remaining fixtures by issue #569).
+ *
+ * Declaring the HOST arch -- rather than hardcoding either value -- is what
+ * makes the container native on an Apple Silicon dev host AND on an x86_64 CI
+ * runner, instead of trading one host's emulation for the other's. Keep it on
+ * every function here: a new handler that omits it silently reintroduces the
+ * arm64-only flake. The full rationale, the carve-outs, and the fence that
+ * enforces this live in `tests/unit/integ-fixture-host-architecture.test.ts`.
+ */
+const HOST_ARCHITECTURE =
+  process.arch === 'arm64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64;
+
+/**
  * Fixture stack for `cdkl studio` target enumeration integ test.
  *
  * Hand-rolls one resource of each kind `cdkl studio` emits a group for, using
@@ -49,14 +68,14 @@ export class LocalStudioStack extends cdk.Stack {
     super(scope, id, props);
 
     // Lambda function — inline code so synth has no asset / bundling step.
-    // arm64 so the RIE container runs NATIVELY on an Apple Silicon dev host
-    // (where this Docker integ runs) instead of under QEMU x86 emulation, which
-    // is slow + unstable (the RIE Go binary can panic / the 30s invoke timeout
-    // can trip). The integ exercises studio orchestration, not arch fidelity,
-    // so native arm64 is the right default for this fixture.
+    // Runs at the HOST architecture so the RIE container is native. This was
+    // hardcoded `ARM_64` with the reasoning below, which was right about the
+    // problem and wrong about the fix: hardcoding arm64 is native on an Apple
+    // Silicon dev host but makes an amd64 CI runner emulate instead, trading
+    // one host's emulation for the other's rather than removing it.
     const fn = new lambda.Function(this, 'MyHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
-      architecture: lambda.Architecture.ARM_64,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       // Echoes the STUDIO_ENV_PROBE env var into the body so the per-target
       // `--env-vars` option (issue #301 slice 2) is observable end-to-end;
@@ -83,6 +102,7 @@ export class LocalStudioStack extends cdk.Stack {
     const crProvider = new Construct(this, 'MyCustomResourceProvider');
     new lambda.Function(crProvider, 'framework-onEvent', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromInline('exports.handler = async () => ({});'),
     });
@@ -97,6 +117,7 @@ export class LocalStudioStack extends cdk.Stack {
     const genericCr = new Construct(this, 'Custom::AcmeWidgetProvider');
     new lambda.Function(genericCr, 'Handler', {
       runtime: lambda.Runtime.NODEJS_20_X,
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromInline('exports.handler = async () => ({});'),
     });
@@ -130,8 +151,8 @@ export class LocalStudioStack extends cdk.Stack {
     // The body-action selection expression routes every message to `$default`.
     const wsFn = new lambda.Function(this, 'WsEchoHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
-      // arm64 for native execution on the Apple Silicon dev host (see MyHandler).
-      architecture: lambda.Architecture.ARM_64,
+      // Host architecture, for native execution on either host (see MyHandler).
+      architecture: HOST_ARCHITECTURE,
       handler: 'index.handler',
       code: lambda.Code.fromInline(
         [

--- a/tests/integration/local-studio/lib/local-studio-stack.ts
+++ b/tests/integration/local-studio/lib/local-studio-stack.ts
@@ -69,10 +69,11 @@ export class LocalStudioStack extends cdk.Stack {
 
     // Lambda function — inline code so synth has no asset / bundling step.
     // Runs at the HOST architecture so the RIE container is native. This was
-    // hardcoded `ARM_64` with the reasoning below, which was right about the
-    // problem and wrong about the fix: hardcoding arm64 is native on an Apple
-    // Silicon dev host but makes an amd64 CI runner emulate instead, trading
-    // one host's emulation for the other's rather than removing it.
+    // hardcoded `ARM_64`, on the reasoning that arm64 is native on the Apple
+    // Silicon dev host where this Docker integ runs. That was right about the
+    // problem and wrong about the fix: hardcoding arm64 makes an amd64 CI
+    // runner emulate instead, trading one host's emulation for the other's
+    // rather than removing it.
     const fn = new lambda.Function(this, 'MyHandler', {
       runtime: lambda.Runtime.NODEJS_20_X,
       architecture: HOST_ARCHITECTURE,

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -535,7 +535,12 @@ function constructId(call: string): string {
   // (`new lambda.Function(crProvider, 'framework-onEvent', ...)`), and a
   // `this`-only pattern would fall back to an 80-character source slice for
   // exactly the constructs whose names are least guessable.
-  return /new\s+[\w$.]*\(\s*[\w$.]+\s*,\s*'([^']+)'/.exec(call)?.[1] ?? call.slice(0, 80).trim();
+  // Anchored at the start of the call: unanchored, a construct whose id is
+  // not single-quoted (a template literal, or double quotes) would fall
+  // through to the first NESTED `new ...(scope, 'X')` -- e.g. an
+  // `iam.Role(fnScope, 'FnRole')` inside the props -- and the failure would
+  // name FnRole instead of the Lambda.
+  return /^new\s+[\w$.]*\(\s*[\w$.]+\s*,\s*'([^']+)'/.exec(call)?.[1] ?? call.slice(0, 80).trim();
 }
 
 const read = (relPath: string): string =>
@@ -768,6 +773,23 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
       expect(
         missingFor(`new lambda.CfnFunction(this, 'A', { architectures: ['x86_64'] })`, 'architectures', req)
       ).toBe('WRONG_VALUE');
+    });
+
+    it('names a construct scoped to a VARIABLE, not just to `this`', () => {
+      // Fences the scope-argument widening. With a `this,`-only pattern this
+      // is the case that breaks, and no other test covers it: constructId is
+      // only reached on a FAILING fixture, so reverting the widening left the
+      // whole suite green -- an assertion that could not fail, guarding a
+      // change nothing else observed.
+      const call = `new lambda.Function(crProvider, 'framework-onEvent', { runtime: R })`;
+      expect(constructId(call)).toBe('framework-onEvent');
+    });
+
+    it('names the construct itself, not a nested one, when the id is not single-quoted', () => {
+      // An unanchored pattern skips the double-quoted id and matches the
+      // NESTED role instead, blaming the wrong construct.
+      const call = 'new lambda.Function(this, "Quoted", { role: new iam.Role(scope, \'FnRole\') })';
+      expect(constructId(call)).not.toBe('FnRole');
     });
 
     it('is not fooled by a template-literal construct id', () => {
@@ -1144,9 +1166,11 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
     });
 
     it('lists only genuinely unconverted sources while it is non-empty', () => {
-      // Inert today. Kept because the bucket must stay honest if it is ever
-      // repopulated: a converted fixture parked here would dodge every
-      // per-construct assertion above.
+      // Inert today, and it cannot run without the test above being edited
+      // first -- repopulating the bucket trips that one too. Kept so the
+      // bucket stays honest if it IS ever deliberately reopened: a converted
+      // fixture parked here would otherwise dodge every per-construct
+      // assertion above.
       const wrong = NOT_YET_CONVERTED.filter((relPath) => read(relPath).includes('HOST_ARCHITECTURE'));
       expect(
         wrong,

--- a/tests/unit/integ-fixture-host-architecture.test.ts
+++ b/tests/unit/integ-fixture-host-architecture.test.ts
@@ -140,6 +140,12 @@ const HOST_ARCHITECTURE_STACKS = [
   'tests/integration/local-start-api-from-cfn-stack/lib/local-start-api-from-cfn-stack-stack.ts',
   'tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts',
   'tests/integration/local-start-api-watch/lib/watch-stack.ts',
+  'tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts',
+  'tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts',
+  'tests/integration/local-start-cloudfront-lambda-url/lib/local-start-cloudfront-lambda-url-stack.ts',
+  'tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts',
+  'tests/integration/local-studio/lib/local-studio-stack.ts',
+  'tests/integration/local-start-cloudfront-edge/lib/local-start-cloudfront-edge-stack.ts',
 ];
 
 /**
@@ -197,14 +203,7 @@ const PINNED_STACKS = [
  * between two literal arrays, and so a fixture cannot join this bucket
  * silently.
  */
-const NOT_YET_CONVERTED = [
-  'tests/integration/local-start-alb-lambda/lib/local-start-alb-lambda-stack.ts',
-  'tests/integration/local-start-alb-websocket/lib/local-start-alb-websocket-stack.ts',
-  'tests/integration/local-start-cloudfront-edge/lib/local-start-cloudfront-edge-stack.ts',
-  'tests/integration/local-start-cloudfront-lambda-url/lib/local-start-cloudfront-lambda-url-stack.ts',
-  'tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts',
-  'tests/integration/local-studio/lib/local-studio-stack.ts',
-];
+const NOT_YET_CONVERTED: string[] = [];
 
 /**
  * Fixture sources that match `*Function(` but construct NO Lambda at all
@@ -531,7 +530,12 @@ function normalizeValue(value: string): string {
 
 /** Name a call by its construct id, so a failure points at the function to fix. */
 function constructId(call: string): string {
-  return /new\s+[\w$.]*\(\s*this,\s*'([^']+)'/.exec(call)?.[1] ?? call.slice(0, 80).trim();
+  // The scope argument is not always `this`: local-studio nests its
+  // custom-resource handlers under a Construct variable
+  // (`new lambda.Function(crProvider, 'framework-onEvent', ...)`), and a
+  // `this`-only pattern would fall back to an 80-character source slice for
+  // exactly the constructs whose names are least guessable.
+  return /new\s+[\w$.]*\(\s*[\w$.]+\s*,\s*'([^']+)'/.exec(call)?.[1] ?? call.slice(0, 80).trim();
 }
 
 const read = (relPath: string): string =>
@@ -1123,20 +1127,33 @@ describe('integ fixture Lambdas run at the host architecture (issues #560, #569)
     }
   });
 
-  describe('fixtures not yet converted (#569 is complete when this list is empty)', () => {
-    for (const relPath of NOT_YET_CONVERTED) {
-      it(`${relPath} is genuinely unconverted, so it is parked here honestly`, () => {
-        // Stops the bucket being used as a dumping ground: a fixture that
-        // HAS been converted cannot be parked here to dodge the per-file
-        // assertions above, and a converted fixture that regressed cannot
-        // be "fixed" by moving its path down here.
-        expect(
-          read(relPath).includes('HOST_ARCHITECTURE'),
-          `${relPath} defines HOST_ARCHITECTURE, so it belongs in HOST_ARCHITECTURE_STACKS ` +
-            'where the per-construct assertions apply -- move it up rather than leaving it here'
-        ).toBe(false);
-      });
-    }
+  describe('the #569 backlog', () => {
+    // Written as fixed tests rather than one-per-path, because the list is
+    // now EMPTY and a `for` loop over it would generate no tests at all --
+    // leaving Vitest's "No test found in suite" as the only signal, which is
+    // not an assertion about anything and names nothing.
+    it('is empty, so every fixture Lambda declares the host architecture (#569 complete)', () => {
+      expect(
+        NOT_YET_CONVERTED,
+        'NOT_YET_CONVERTED is the #569 backlog and it reached zero. A path appearing here ' +
+          'again means a fixture Lambda went back to defaulting to x86_64, which emulates ' +
+          'on arm64 hosts. A NEW fixture declares the host architecture from the start ' +
+          '(see .claude/skills/create-integ/SKILL.md) and belongs in ' +
+          'HOST_ARCHITECTURE_STACKS -- do not park it here to make a failure go away'
+      ).toEqual([]);
+    });
+
+    it('lists only genuinely unconverted sources while it is non-empty', () => {
+      // Inert today. Kept because the bucket must stay honest if it is ever
+      // repopulated: a converted fixture parked here would dodge every
+      // per-construct assertion above.
+      const wrong = NOT_YET_CONVERTED.filter((relPath) => read(relPath).includes('HOST_ARCHITECTURE'));
+      expect(
+        wrong,
+        'these define HOST_ARCHITECTURE, so they belong in HOST_ARCHITECTURE_STACKS where ' +
+          'the per-construct assertions apply -- move them up rather than leaving them here'
+      ).toEqual([]);
+    });
   });
 
   describe('fixtures whose only *Function( constructs are not Lambdas', () => {


### PR DESCRIPTION
Batch 4 of 4. **`NOT_YET_CONVERTED` goes 6 -> 0**, which is (#569)'s completion
condition: every Lambda constructed in a fixture's `lib/` or `bin/` now declares the host
CPU architecture. Closes #569.

Final buckets, partitioning all 31 discovered fixture sources:

| Bucket | Count |
| --- | --- |
| `HOST_ARCHITECTURE_STACKS` | 28 |
| `PINNED_STACKS` | 1 (`local-invoke-provided`) |
| `NOT_YET_CONVERTED` | **0** |
| `NON_LAMBDA_ONLY` | 2 |

## What changed, per fixture — including what was deliberately skipped

| Fixture | In scope | Deliberately skipped |
| --- | --- | --- |
| `local-start-alb-lambda` | 2x `lambda.Function` | -- |
| `local-start-alb-websocket` | 1x `lambda.Function` | -- |
| `local-start-cloudfront-lambda-url` | 1x `lambda.Function` (`OriginFn`) | 1x `cloudfront.Function` (`StampFn`) |
| `local-start-cloudfront-lambda-url-from-cfn-stack` | 1x `lambda.Function` (`OriginFn`) | 1x `cloudfront.Function` (`StampFn`) |
| `local-start-cloudfront-edge` | 1x `lambda.Function` (`EdgeFn`) | -- |
| `local-studio` | 4x `lambda.Function` | 1x `cloudfront.Function` (`RewriteFn`) |

`cloudfront.Function` is a CloudFront Function -- a different service that runs at the
edge, not in a container, and has no `architecture` at all. None was touched. The two
fixtures whose ONLY `*Function(` constructs are CloudFront Functions
(`local-start-cloudfront`, `local-start-cloudfront-kvs-from-cfn-stack`) stay in
`NON_LAMBDA_ONLY`.

`local-studio` had **four** Lambdas, not the two the issue implies: `MyHandler` and
`WsEchoHandler` hardcoded `ARM_64`, and two custom-resource handlers
(`framework-onEvent`, `Handler`) declared nothing.

## `local-studio` was the mirror-image defect

Hardcoding `ARM_64` is not the same bug as omitting `architecture` -- it is native on an
Apple Silicon dev host and makes an **amd64 CI runner emulate instead**. Measured on the
amd64 synth:

```
pre  (x64 synth): ['arm64'], None, None, ['arm64'], None, None
post (x64 synth): ['x86_64'], ['x86_64'], ['x86_64'], ['x86_64'], None, None
post (arm synth): ['arm64'],  ['arm64'],  ['arm64'],  ['arm64'],  None, None
```

So unlike every other fixture in this issue, **CI behaviour here changes on purpose**: two
functions stop being forced to arm64 on an amd64 runner. The two trailing `None`s are
Lambdas an L3 construct synthesizes (`BucketDeployment`), outside this fence's scope as
its header now states.

## `local-start-cloudfront-edge`: the one judgement call, and it reversed

AWS restricts **Lambda@Edge to x86_64** -- a function attached through `edgeLambdas`
cannot be arm64 -- and CDK does NOT reject arm64 here at synth. So the obvious move is to
pin it, and it WAS pinned first.

Then it was measured. Five runs per arm on an arm64 host:

```
pinned x86_64        4/5 passed, 1 emulation warning,  0 RIE faults
host architecture    5/5 passed, 0 emulation warnings, 0 RIE faults
```

and a sixth pinned run, in the batch sweep, failed outright:

```
WARN: Running 'cdkl-...-EdgeFn...' under linux/amd64 emulation on a linux/arm64 host
fatal error: found pointer to free object
FAIL: GET /go did not get the edge 302 (got 500)
```

That is (#560) verbatim, in the last fixture of the issue that exists to remove it.

**What decides it: this fixture never deploys.** `verify.sh` runs `cdkl start-cloudfront`
against the synthesized assembly, so `Architectures` is read by cdk-local alone and AWS
never sees the template. Trading a reproducible local fault for fidelity to a constraint
nothing here enforces is the wrong way round.

The constraint, the measurement, the reversal condition (if the fixture ever gains a
`cdk deploy`, pin it again and accept the emulation) and a warning not to copy the line
into a production Lambda@Edge stack are all recorded on the construct. After conversion:
**5/5 green, 0 emulation warnings.**

## Runs on the arm64 host

```
local-start-alb-lambda                            PASS  11s / 11s / 11s        docker clean
local-start-cloudfront-lambda-url                 PASS   5s /  5s /  5s        docker clean
local-start-cloudfront-edge (converted)           PASS   6s / 10s / 5s / 5s / 5s   docker clean
local-start-cloudfront-lambda-url-from-cfn-stack  PASS 433s /440s /434s        docker clean, stack gone
local-studio                                      PASS 212s /203s /211s        docker clean
local-start-alb-websocket                         FAIL  -- see below
```

Sample size for the AWS-backed fixture is 3, same rule as batches 2-3: any failure
escalates to a 9-run A/B rather than a re-run. It did not fail. The edge fixture got 5
because it was the arm being decided.

**AWS sweep:** `CdkLocalStartCfFnUrlFromCfnFixture` absent after its three runs. Docker
swept with `docker ps -a` after every individual attempt, including the studio runs.

## `local-start-alb-websocket` does not pass, and it is not this change

A/B, 3 runs per arm:

| Arm | Passes | Emulation warnings |
| --- | --- | --- |
| `main` unmodified | 0 / 3 | 1 per run |
| with the architecture declared | 0 / 3 | 0 per run |

The conversion did its job -- the emulation warning is gone -- and the failure is
identical either way. It fails at the **ECS WebSocket echo round-trip** (`socket hang
up`), which runs in ECS task containers, not in the fixture's Lambda. Deterministic, 6
consecutive failures across both versions. Filed as (#589) with the A/B, and with the
first hypothesis worth testing: that fixture pins
`amazon/amazon-ecs-local-container-endpoints:latest-amd64`, an amd64-only sidecar that
emulates on an arm64 host no matter what (#569) does.

Converting it is still correct and is kept; it is one of the six that had to move for the
backlog to reach zero.

## CI (amd64)

```
local-start-alb-lambda                            +2 Architectures:["x86_64"]                      (arm64 emits 2)
local-start-alb-websocket                         +1 Architectures:["x86_64"]                      (arm64 emits 1)
local-start-cloudfront-lambda-url                 +1 Architectures:["x86_64"]                      (arm64 emits 1)
local-start-cloudfront-lambda-url-from-cfn-stack  +1 Architectures:["x86_64"]                      (arm64 emits 1)
local-start-cloudfront-edge                       +1 Architectures:["x86_64"] + 3 version ids rehashed  (arm64 emits 1)
local-studio                                      +2 Architectures:["x86_64"] + 2 hardcoded arm64 REMOVED (arm64 emits 4)
```

Two delta classes beyond `Architectures`, both named rather than filtered:

- **Lambda version ids rehashed** (edge). A `currentVersion` logical id embeds a hash of
  the function's configuration, so making an already-effective architecture explicit
  renames it. Same value, new id; nothing deploys this fixture.
- **Hardcoded arm64 removed** (studio). Described above -- the intended CI change.

To be clear about where that check lives: the amd64 parity comparison is a **session-local
script**, not a repo artifact -- it is not in this diff and there is nothing to look for in
the tree. It reverts each fixture to its `HEAD` version, synthesizes both with
`process.arch` forced, and diffs the templates. The two classes above were added to it so
its output names them rather than reporting an unexplained delta; that benefit is confined
to this session's verification, and the numbers it produced are reproduced above so they
can be checked without it.

## Fence

The empty-backlog case required restructuring. A `for` loop over an empty array generates
NO tests, so the only signal would have been Vitest's "No test found in suite" -- which
asserts nothing and names nothing. The backlog is now two fixed tests: one asserting it is
empty, whose message says a NEW fixture belongs in `HOST_ARCHITECTURE_STACKS` rather than
parked in the backlog, and one that stays honest if it is ever repopulated.

`constructId` now accepts a scope argument other than `this`. `local-studio` nests its
custom-resource handlers under a Construct variable
(`new lambda.Function(crProvider, 'framework-onEvent', ...)`), and the old `this`-only
pattern fell back to an 80-character source slice for exactly the constructs whose names
are hardest to guess.

## Issue (#569) is complete

28 fixture sources declare the host architecture, 1 keeps a measured pin, 2 construct no
Lambda, 0 remain. The fence asserts that partition against a fresh walk of the tree on
every run, so the claim is checked rather than asserted.

## Review

Two reviewers (spec / code), **no blockers**, and both verified rather than read.

The spec review independently walked `tests/integration/*/{lib,bin}/**` -- 118 `.ts`
files, **31** containing a Lambda constructor -- and confirmed the four buckets are
exactly that set, with per-file declaration counts matching constructor counts everywhere.
The code review synthesized all six fixtures on an arm64 host and confirmed **all 10 new
declarations emit `Architectures: ["arm64"]`**, then ran 20 probes (delete + relocate, for
each of the 10): **20/20 red**, including the Construct-variable-scoped
`framework-onEvent` naming itself correctly in the NESTED message.

Both also sized the scope caveat honestly: roughly 12 Lambdas across the fixtures are
synthesized by L3 constructs (`BucketDeployment`, `AutoDeleteObjects`) and declare
nothing. None is invoked by any `verify.sh`, and the fence header states the exclusion.

Findings, all fixed here:

- **The `constructId` widening was unfenced.** It was widened to accept a scope argument
  other than `this` so local-studio's Construct-variable-scoped handlers get named --
  and reverting it left **205/205 green**, because `constructId` is only reached on a
  FAILING fixture and every helper test scoped to `this`. Another assertion that could not
  fail. Two tests now cover it, and reverting the widening fails the first by name.
- **The same regex was unanchored**, so a call whose id is not single-quoted would skip
  past and take a NESTED constructor's id (`new iam.Role(scope, 'FnRole')` in the props
  reported `FnRole`). Message-only and absent from the repo, now anchored with a test.
- **Three comments pointed at nothing**: local-studio referenced "the reasoning below" in
  the same hunk that deleted it; the edge note said "ten runs, five per arm" then
  described "a sixth" (the extra observation came from the batch sweep before the A/B);
  and the backlog's second test called itself inert without noting it cannot run unless
  the first test is edited too.
- A PR-body overclaim: this description had said "the parity checker gained both classes"
  as though it were a repo artifact. It is a session-local script, not in this diff, and
  the text now says so.
