### PR TITLE
fix(integ): compare the redirect Location VALUE, not the header line

### DIFF
--- a/tests/integration/local-start-alb-redirect/verify.sh
+++ b/tests/integration/local-start-alb-redirect/verify.sh
@@ -121,7 +121,14 @@ for _ in $(seq 1 30); do
   RAW=$(curl -sS -o /dev/null -D- --max-time 5 \
     "http://127.0.0.1:${LB_HOST_PORT}/foo/bar" 2>&1 || true)
   LAST_STATUS=$(echo "${RAW}" | head -1 | tr -d '\r')
-  LAST_LOC=$(echo "${RAW}" | grep -i '^Location:' | head -1 | tr -d '\r')
+  # Capture the VALUE, not the whole header line. HTTP header names are
+  # case-insensitive (RFC 9110 5.1) and this server emits `location`
+  # lowercase, so comparing the name is comparing something the protocol
+  # does not promise -- which is exactly how this fixture came to be red on
+  # main (issue #592): the `-i` here said the case was not guaranteed, and
+  # the comparison below then required a capital `L`.
+  LAST_LOC=$(echo "${RAW}" | grep -i '^Location:' | head -1 | tr -d '\r' \
+    | sed -E 's/^[Ll]ocation:[[:space:]]*//')
   if [[ "${LAST_STATUS}" == HTTP/*\ 302* ]]; then
     READY=1
     break
@@ -141,9 +148,9 @@ if [[ "${READY}" -ne 1 ]]; then
 fi
 echo "    status=${LAST_STATUS}"
 echo "    ${LAST_LOC}"
-EXPECTED_LOC="Location: https://redirected.cdklocal.test/relocated/foo/bar"
+EXPECTED_LOC="https://redirected.cdklocal.test/relocated/foo/bar"
 if [[ "${LAST_LOC}" != "${EXPECTED_LOC}" ]]; then
-  echo "FAIL: Location header mismatch"
+  echo "FAIL: Location URL mismatch"
   echo "  expected: '${EXPECTED_LOC}'"
   echo "  got:      '${LAST_LOC}'"
   exit 1
@@ -155,7 +162,8 @@ echo "==> Phase 2: GET /baz -> 302 + Location (per-request #{path})"
 RAW=$(curl -sS -o /dev/null -D- --max-time 5 \
   "http://127.0.0.1:${LB_HOST_PORT}/baz" 2>&1 || true)
 PHASE2_STATUS=$(echo "${RAW}" | head -1 | tr -d '\r')
-PHASE2_LOC=$(echo "${RAW}" | grep -i '^Location:' | head -1 | tr -d '\r')
+PHASE2_LOC=$(echo "${RAW}" | grep -i '^Location:' | head -1 | tr -d '\r' \
+  | sed -E 's/^[Ll]ocation:[[:space:]]*//')
 echo "    status=${PHASE2_STATUS}"
 echo "    ${PHASE2_LOC}"
 if [[ "${PHASE2_STATUS}" != HTTP/*\ 302* ]]; then
@@ -163,9 +171,9 @@ if [[ "${PHASE2_STATUS}" != HTTP/*\ 302* ]]; then
   cat "${OUT_FILE}"
   exit 1
 fi
-EXPECTED_LOC2="Location: https://redirected.cdklocal.test/relocated/baz"
+EXPECTED_LOC2="https://redirected.cdklocal.test/relocated/baz"
 if [[ "${PHASE2_LOC}" != "${EXPECTED_LOC2}" ]]; then
-  echo "FAIL: Location header mismatch"
+  echo "FAIL: Location URL mismatch"
   echo "  expected: '${EXPECTED_LOC2}'"
   echo "  got:      '${PHASE2_LOC}'"
   exit 1


### PR DESCRIPTION
## Summary

`local-start-alb-redirect` failed on `main` at its first assertion, every run,
deterministically. The URL was correct; only the header NAME's case differed:

```text
    location: https://redirected.cdklocal.test/relocated/foo/bar
  FAIL: Location header mismatch
    expected: 'Location: https://redirected.cdklocal.test/relocated/foo/bar'
    got:      'location: https://redirected.cdklocal.test/relocated/foo/bar'
```

HTTP header names are case-insensitive (RFC 9110 5.1), so cdk-local's behaviour
is right and the assertion was the defect.

The fixture was case-INSENSITIVE on the way in and case-SENSITIVE on the way
out: it captured with `grep -i '^Location:'` -- the `-i` recording that the case
was not guaranteed -- then compared the WHOLE captured line, header name
included, against a literal starting with a capital `L`. Both phases had the
same pair. Now both strip the header name and compare the VALUE.

The consequence was worse than one red fixture: `src/local/front-door-server.ts`
has emitted the header lowercase since the redirect action landed, so this
fixture has never actually compared a URL. The assertion it exists to make --
that the ALB `#{path}` placeholder expands per request -- could not run, because
the line never matched for a reason unrelated to the URL.

## Test plan

- Reproduced at `origin/main` (`bc03f47`) in a clean detached worktree with a
  fresh `pnpm install` + `vp run build`, to establish the failure was
  pre-existing rather than introduced by a branch in flight: identical failure,
  identical two lines.
- `/run-integ local-start-alb-redirect` after the fix: **PASSED**, both phases
  asserting the redirect URL, clean teardown, 0 orphan containers / networks.
- Mutation-probed: pointing `EXPECTED_LOC` at a different host turns it RED with
  `FAIL: Location URL mismatch`, so the repaired assertion discriminates rather
  than having been made vacuous.
- Audited the sibling fixtures for the same capture-loose / compare-strict shape
  (`grep -rn "grep -i '^[A-Za-z-]*:'" tests/integration/*/verify.sh`): this
  fixture is the only one, on both of its phases.
- `vp run verify`: 223 files / 3568 tests pass, 0 errors.

## Retrospective (verify-pr step 11)

**Integ fixtures are not run by CI, so a fixture can be red on `main`
indefinitely and nothing reports it.** This one was red since the PR that added
it and was found only because an unrelated lane happened to pick it to satisfy
the `integ` gate -- after paying for the Docker run. The `integ` gate does not
care WHICH fixture ran, so the cost of a rotted fixture lands as a mid-lane
surprise on whoever draws it.

That is a pattern rather than a one-off, and it is mechanically detectable
(a periodic run of the Docker-only fixtures, or a recorded last-green ledger per
fixture). Filed as a follow-up rather than fixed here, since the fix is CI
infrastructure and this PR is a two-line assertion repair:
https://github.com/go-to-k/cdk-local/issues/594.

Closes #592
