### PR TITLE
fix(alb): sanitize all three raw-socket header writers, and fence control bytes repo-wide

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -41,6 +41,25 @@ The hooks split into three classes:
   Fails open when `git` / `perl` are unavailable or nothing is staged.
   No bypass marker — the fix is to remove the stray byte and re-stage.
 
+  **The gate is not the only fence, because it is a PreToolUse hook and
+  therefore only ever sees the AGENT's tool calls.** Issue
+  go-to-k/cdk-local#576 records a command shape that walks past it —
+  `git add -A && git commit ...` in one call presents the gate with the
+  tree as it was BEFORE the `git add`, so nothing is staged yet for the
+  offending file. That is not hypothetical: on 2026-08-27
+  `src/local/front-door-server.ts` was found on `main` carrying two raw
+  NUL bytes (a regex character class and its comment in
+  `sanitizeRawHeaderValue`) — functionally correct JavaScript, so no test
+  or type-check noticed, while `grep -c host` on that 49 KB file answered
+  `0` and `file` reported it as `data`. That file is on the `UP_PATHS`
+  security surface below, so every grep-based audit over `src/local/**`
+  had been silently skipping it.
+  `tests/unit/no-control-bytes.test.ts` closes it from the other side:
+  it derives its population from `git ls-files` (not a hand-kept
+  directory list) and fails in CI on any C0 control byte in any tracked
+  text file, whatever shape the command took. Spell a control character
+  in source as an escape (`\u0000`), never as a literal byte.
+
 - **`closes-paren-form-gate.sh`** blocks `gh pr merge <N>` when the
   target PR's body uses `Closes (#N)` / `Fixes (#N)` /
   `Resolves (#N)` (parens form) — GitHub's auto-close grammar

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -1226,7 +1226,12 @@ function writeRawHttpUnauthorized(socket: Duplex, realm: string, reason?: string
     'HTTP/1.1 401 Unauthorized',
     'content-type: text/plain; charset=utf-8',
     `content-length: ${Buffer.byteLength(body)}`,
-    `www-authenticate: Bearer realm="${escapeRealmQuotes(realm)}"`,
+    // Sanitize for the same reason the redirect and fixed-response raw
+    // writers do: `realm` is `guard.label`, a CFn literal validated only as a
+    // string, and it is raw-written here. `escapeRealmQuotes` handles the
+    // quote that would end the realm token; CR / LF / NUL would end the
+    // HEADER, which is a different problem and needs the sanitizer.
+    `www-authenticate: Bearer realm="${sanitizeRawHeaderValue(escapeRealmQuotes(realm))}"`,
     'connection: close',
     '',
     '',

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -1298,10 +1298,19 @@ function writeRawHttpFixedResponse(socket: Duplex, action: FixedResponseRouteAct
 
 /** Strip CR / LF / NUL from a raw HTTP header value to prevent header injection. */
 function sanitizeRawHeaderValue(value: string): string {
-  // The ` ` literal in the class is the NUL byte; CRLF + NUL are the
-  // three header-injection-relevant control bytes that bypass the header
-  // grammar when raw-written over the upgrade socket.
-  return value.replace(/[\r\n ]/g, ' ');
+  // CR / LF / NUL are the three header-injection-relevant control bytes that
+  // bypass the header grammar when raw-written over the upgrade socket.
+  //
+  // NUL is spelled `\u0000` and NOT as a literal byte (issue #576): a raw
+  // control byte in committed source makes `file` report the whole file as
+  // `data` and makes `grep` return NOTHING for it, silently, for every
+  // pattern -- and this file is on the `UP_PATHS` security surface that
+  // every grep-based audit sweeps. `tests/unit/no-control-bytes.test.ts`
+  // fences that repo-wide.
+  //
+  // Matching a control character is the entire purpose of this sanitizer.
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\r\n\u0000]/g, ' ');
 }
 
 /** Minimal HTTP/1.1 status text map for the codes the raw writers emit. */

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -1248,7 +1248,15 @@ function writeRawHttpRedirect(
   scheme: 'http' | 'https'
 ): void {
   if (socket.destroyed) return;
-  const location = buildRedirectLocation(action, req, listenerPort, scheme);
+  // Sanitize for the same reason the fixed-response writer sanitizes its
+  // `content-type` (see `writeRawHttpFixedResponse`): this value is
+  // raw-written into the response, so CR / LF / NUL inside it inject
+  // headers instead of being rejected. It is built from CFn-literal
+  // `RedirectConfig.Host` / `.Path` / `.Query` fields, and the REGULAR-HTTP
+  // counterpart gets this for free -- Node's `res.writeHead` throws
+  // `ERR_INVALID_CHAR` on such a value -- so without this the raw upgrade
+  // path was the one place a redirect could inject silently.
+  const location = sanitizeRawHeaderValue(buildRedirectLocation(action, req, listenerPort, scheme));
   const statusText = action.statusCode === 301 ? 'Moved Permanently' : 'Found';
   const lines = [
     `HTTP/1.1 ${action.statusCode} ${statusText}`,

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -1721,7 +1721,60 @@ describe('startFrontDoorServer — WebSocket Upgrade resilience', () => {
 
     expect(raw).toContain('HTTP/1.1 302');
     // The CRLF is flattened INTO the Location value, not left to start a
-    // header line of its own.
+    // header line of its own. Pin the flattened value too, not only the
+    // negative -- a negative alone would also pass if the redirect writer
+    // stopped emitting a Location at all.
+    expect(raw).toContain('location: https://example.test  x-injected: yes:80/moved');
+    expect(raw).not.toMatch(/^x-injected: yes/m);
+  });
+
+  it('sanitizes CR / LF in a 401 www-authenticate realm so it cannot inject extra headers', async () => {
+    // The third raw writer. `escapeRealmQuotes` handles the `"` that would end
+    // the realm TOKEN; CR / LF / NUL end the HEADER, which is a different
+    // problem. `realm` is `guard.label`, built from a CFn literal validated
+    // only as a string -- the same trust class as `RedirectConfig.Host`.
+    const front = await startFrontDoorServer({
+      route: () => ({
+        kind: 'redirect',
+        statusCode: 302,
+        host: 'somewhere.example.com',
+        auth: {
+          realm: 'authenticate-oidc (Issuer=https://idp.test\r\nx-injected: yes)',
+          check: async () => ({ allow: false }),
+        },
+      }),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+    });
+    cleanups.push(() => front.close());
+
+    const sock = await new Promise<import('node:net').Socket>((resolve, reject) => {
+      const s = (
+        require('node:net') as typeof import('node:net')
+      ).connect({ port: front.port, host: '127.0.0.1' }, () => resolve(s));
+      s.on('error', reject);
+    });
+    sock.write(
+      [
+        'GET / HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+        'Sec-WebSocket-Version: 13',
+        '',
+        '',
+      ].join('\r\n')
+    );
+    const raw = await new Promise<string>((resolve) => {
+      const chunks: Buffer[] = [];
+      sock.on('data', (c: Buffer) => chunks.push(c));
+      sock.on('close', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    });
+
+    expect(raw).toContain('HTTP/1.1 401');
     expect(raw).not.toMatch(/^x-injected: yes/m);
   });
 });

--- a/tests/unit/local/front-door-server.test.ts
+++ b/tests/unit/local/front-door-server.test.ts
@@ -1667,5 +1667,61 @@ describe('startFrontDoorServer — WebSocket Upgrade resilience', () => {
     expect(raw).toContain('content-type: text/plain  x-injected: yes');
     // The injection attempt MUST NOT produce a separate header line.
     expect(raw).not.toMatch(/^x-injected: yes/m);
+    // NUL as well as CR / LF -- the sanitizer strips three bytes, and the
+    // source-level assertion in `tests/unit/no-control-bytes.test.ts` only
+    // pins how NUL is SPELLED, not that it is actually stripped on the wire.
+    expect(raw).not.toContain('\u0000');
+  });
+
+  it('sanitizes CR / LF in a raw-socket redirect Location so it cannot inject extra headers', async () => {
+    // The sibling of the fixed-response case above. `writeRawHttpRedirect`
+    // raw-writes the Location into the response, and the value is built from
+    // CFn-literal `RedirectConfig.Host` / `.Path` / `.Query`. The
+    // regular-HTTP counterpart is protected for free (Node's `res.writeHead`
+    // throws `ERR_INVALID_CHAR`), so the upgrade path was the one place a
+    // redirect could inject headers silently.
+    const front = await startFrontDoorServer({
+      route: () => ({
+        kind: 'redirect',
+        statusCode: 302,
+        host: 'example.test\r\nx-injected: yes',
+        path: '/moved',
+        protocol: 'https',
+      }),
+      port: 0,
+      host: '127.0.0.1',
+      listenerPort: 80,
+      label: 'listener port 80',
+    });
+    cleanups.push(() => front.close());
+
+    const sock = await new Promise<import('node:net').Socket>((resolve, reject) => {
+      const s = (
+        require('node:net') as typeof import('node:net')
+      ).connect({ port: front.port, host: '127.0.0.1' }, () => resolve(s));
+      s.on('error', reject);
+    });
+    sock.write(
+      [
+        'GET / HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+        'Sec-WebSocket-Version: 13',
+        '',
+        '',
+      ].join('\r\n')
+    );
+    const raw = await new Promise<string>((resolve) => {
+      const chunks: Buffer[] = [];
+      sock.on('data', (c: Buffer) => chunks.push(c));
+      sock.on('close', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    });
+
+    expect(raw).toContain('HTTP/1.1 302');
+    // The CRLF is flattened INTO the Location value, not left to start a
+    // header line of its own.
+    expect(raw).not.toMatch(/^x-injected: yes/m);
   });
 });

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Fence for issue #576.
+ *
+ * `.claude/hooks/control-char-gate.sh` blocks a `git commit` whose staged
+ * blobs carry a C0 control byte, because a raw control byte in committed
+ * text is invisible in the worst possible way: `file` reports the whole
+ * file as `data`, `git diff` reports `Bin 0 -> N bytes` and hides the added
+ * lines, and -- the expensive one -- **`grep` returns NOTHING for that
+ * file**, silently, for every pattern.
+ *
+ * The gate is a PreToolUse hook, so it only ever sees the AGENT's tool
+ * calls, and issue #576 records a command shape that walks straight past
+ * it (`git add -A && git commit ...` in one call presents the gate with
+ * the tree as it was BEFORE the `git add`). Registration is not
+ * execution, and the proof is that a byte got through: on 2026-08-27,
+ * `src/local/front-door-server.ts` was found on `main` carrying two raw
+ * NUL bytes -- inside a regex character class and its comment in
+ * `sanitizeRawHeaderValue`. Functionally correct JavaScript, which is why
+ * no test or type-check noticed, while `grep -c host` on that 49 KB file
+ * answered `0`. That file is on the `UP_PATHS` security surface listed in
+ * `.claude/hooks/pr-review-gate.sh`, so every grep-based audit over
+ * `src/local/**` had been skipping it.
+ *
+ * This file is the part of that fence that runs in CI on every commit,
+ * whatever shape the command took and whoever typed it.
+ *
+ * ## Population
+ *
+ * The population is derived from `git ls-files` rather than from a list of
+ * directories, because the rule is about COMMITTED TEXT and not about any
+ * particular subtree -- a hand-kept root list is the same defect wearing a
+ * comment, and would have missed `src/local/**` just as readily as it
+ * would miss whatever directory is added next. Only extensions whose
+ * content is legitimately binary are excluded, and that exclusion is
+ * asserted to be small so it cannot quietly grow into the whole repo.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+
+/** Extensions whose bytes are legitimately non-text. */
+const BINARY_EXT =
+  /\.(png|jpe?g|gif|ico|bmp|webp|woff2?|ttf|otf|eot|zip|gz|tgz|wasm|pdf|mp4|mov|jar|class|so|dylib|dll)$/i;
+
+/**
+ * Tab (0x09), LF (0x0A) and CR (0x0D) are the control bytes that belong in
+ * text. Everything else in C0, plus DEL, is a defect.
+ */
+// eslint-disable-next-line no-control-regex
+const FORBIDDEN = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/;
+
+function trackedTextFiles(): string[] {
+  const out = execFileSync('git', ['ls-files', '-z'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return out
+    .split('\0')
+    .filter((f) => f.length > 0)
+    .filter((f) => !BINARY_EXT.test(f));
+}
+
+interface Offender {
+  file: string;
+  line: number;
+  column: number;
+  byte: string;
+}
+
+function scan(file: string): Offender[] {
+  // Read as latin1 so every byte maps to exactly one code unit: a UTF-8
+  // decode would fold a lone 0x00 into a valid code point either way, but
+  // latin1 keeps the column numbers byte-accurate for the report.
+  const text = readFileSync(path.join(REPO_ROOT, file), 'latin1');
+  const found: Offender[] = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    for (let c = 0; c < line.length; c += 1) {
+      const ch = line[c] ?? '';
+      if (FORBIDDEN.test(ch)) {
+        found.push({
+          file,
+          line: i + 1,
+          column: c + 1,
+          byte: `0x${ch.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase()}`,
+        });
+      }
+    }
+  }
+  return found;
+}
+
+describe('committed text carries no C0 control bytes', () => {
+  const files = trackedTextFiles();
+
+  it('has a non-trivial population to scan', () => {
+    // A floor, so a broken `git ls-files` or an over-eager exclusion can
+    // never pass by scanning nothing. The repo tracked 985 such files when
+    // this was written.
+    expect(files.length).toBeGreaterThan(500);
+    expect(files).toContain('src/local/front-door-server.ts');
+  });
+
+  it('scans src/, tests/, docs/ and the agent-instruction files', () => {
+    // Named because those are the trees whose content is grepped by the
+    // repo's own audits; if the population ever stops reaching one of
+    // them, this fails rather than silently narrowing.
+    for (const prefix of ['src/', 'tests/', '.claude/']) {
+      expect(files.some((f) => f.startsWith(prefix))).toBe(true);
+    }
+  });
+
+  it('finds no control byte in any tracked text file', () => {
+    const offenders = files.flatMap(scan);
+    // Report file:line:column and the byte -- the consumer of a finding is
+    // someone jumping to it, and a control byte is invisible on screen.
+    const report = offenders
+      .map((o) => `${o.file}:${o.line}:${o.column} contains ${o.byte}`)
+      .join('\n');
+    expect(report).toBe('');
+  });
+});
+
+describe('sanitizeRawHeaderValue spells NUL as an escape, not a raw byte', () => {
+  const source = readFileSync(path.join(REPO_ROOT, 'src/local/front-door-server.ts'), 'utf8');
+
+  it('still strips CR, LF and NUL from a raw header value', () => {
+    // The behaviour the escape replaced: `\0` inside a character class IS
+    // the NUL character, so the swap is byte-for-byte equivalent. Pinned
+    // here because the fix edits a security-relevant sanitizer and
+    // "equivalent" is exactly the kind of claim that should not rest on
+    // the reader agreeing with it.
+    const match = /\/\[\\r\\n\\u0000\]\/g/.exec(source);
+    expect(match, 'the escape spelling is gone from sanitizeRawHeaderValue').not.toBeNull();
+
+    const withEscape = /[\r\n\0]/g;
+    const withRawByte = new RegExp(`[\\r\\n${String.fromCharCode(0)}]`, 'g');
+    const probe = `a\rb\nc${String.fromCharCode(0)}d`;
+    expect(probe.replace(withEscape, ' ')).toBe(probe.replace(withRawByte, ' '));
+    expect(probe.replace(withEscape, ' ')).toBe('a b c d');
+  });
+});

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -120,10 +120,14 @@ describe('committed text carries no C0 control bytes', () => {
       .split('\0')
       .filter((f) => f.length > 0);
     const excluded = allTracked.filter((f) => BINARY_EXT.test(f));
+    // The actual excluded count is 3 (three `assets/*.gif`). The threshold is
+    // deliberately close to it rather than generous: at 20 the guard still
+    // admitted `yaml` (13 lockfiles), `mjs` (11) or `html` (7) one at a time,
+    // which is exactly the category-sized exclusion it exists to stop.
     expect(
       excluded.length,
       `BINARY_EXT excluded ${excluded.length} files: ${excluded.slice(0, 20).join(', ')}`
-    ).toBeLessThan(20);
+    ).toBeLessThan(10);
   });
 
   it('keeps every text extension the repo actually carries', () => {
@@ -139,7 +143,7 @@ describe('committed text carries no C0 control bytes', () => {
 
   it('has a non-trivial population to scan', () => {
     // A floor, so a broken `git ls-files` or an over-eager exclusion can
-    // never pass by scanning nothing. The repo tracked 985 such files when
+    // never pass by scanning nothing. The repo tracked 986 such files when
     // this was written.
     expect(files.length).toBeGreaterThan(500);
     expect(files).toContain('src/local/front-door-server.ts');

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -108,10 +108,17 @@ function scan(file: string): Offender[] {
 describe('committed text carries no C0 control bytes', () => {
   const files = trackedTextFiles();
 
-  it('excludes only a handful of genuinely binary files', () => {
-    // The guard the docblock promises. Without it, widening BINARY_EXT by one
-    // common text extension (`sh` costs ~92 files) silently shrinks the
-    // population while every other assertion here stays green.
+  it('excludes only the extensions that are genuinely binary', () => {
+    // The guard the docblock promises, and the fence's own soft spot: widening
+    // BINARY_EXT by one common text extension silently shrinks the population
+    // while every other assertion here stays green (`sh` alone costs ~92 files,
+    // every `.claude/hooks/*.sh` -- the tree this fence's rationale is about).
+    //
+    // Asserted as a SET rather than a count. A count has to be tuned between
+    // "loud enough to catch `yaml`" and "quiet enough to survive one more demo
+    // GIF", and at the tuned value `html` cleared by exactly one file -- drop an
+    // .html from the repo and that escape reopens silently. The set fires on the
+    // FIRST file of a newly-excluded extension and never fires on an 8th GIF.
     const allTracked = execFileSync('git', ['ls-files', '-z'], {
       cwd: REPO_ROOT,
       encoding: 'utf8',
@@ -119,15 +126,12 @@ describe('committed text carries no C0 control bytes', () => {
     })
       .split('\0')
       .filter((f) => f.length > 0);
-    const excluded = allTracked.filter((f) => BINARY_EXT.test(f));
-    // The actual excluded count is 3 (three `assets/*.gif`). The threshold is
-    // deliberately close to it rather than generous: at 20 the guard still
-    // admitted `yaml` (13 lockfiles), `mjs` (11) or `html` (7) one at a time,
-    // which is exactly the category-sized exclusion it exists to stop.
-    expect(
-      excluded.length,
-      `BINARY_EXT excluded ${excluded.length} files: ${excluded.slice(0, 20).join(', ')}`
-    ).toBeLessThan(10);
+    const excludedExts = [
+      ...new Set(
+        allTracked.filter((f) => BINARY_EXT.test(f)).map((f) => path.extname(f).toLowerCase())
+      ),
+    ].sort();
+    expect(excludedExts).toEqual(['.gif']);
   });
 
   it('keeps every text extension the repo actually carries', () => {

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -37,8 +37,15 @@ import { fileURLToPath } from 'node:url';
  * particular subtree -- a hand-kept root list is the same defect wearing a
  * comment, and would have missed `src/local/**` just as readily as it
  * would miss whatever directory is added next. Only extensions whose
- * content is legitimately binary are excluded, and that exclusion is
- * asserted to be small so it cannot quietly grow into the whole repo.
+ * content is legitimately binary are excluded.
+ *
+ * That exclusion is the fence's own soft spot, so it is asserted directly
+ * rather than described: adding `sh` to `BINARY_EXT` silently drops ~92
+ * files -- every `.claude/hooks/*.sh`, which is the tree this fence's
+ * rationale is about -- while leaving the file count and the three prefix
+ * checks comfortably satisfied. So the tests below pin BOTH how many files
+ * the exclusion removes and that each text extension the repo actually
+ * carries survives it.
  */
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -101,6 +108,35 @@ function scan(file: string): Offender[] {
 describe('committed text carries no C0 control bytes', () => {
   const files = trackedTextFiles();
 
+  it('excludes only a handful of genuinely binary files', () => {
+    // The guard the docblock promises. Without it, widening BINARY_EXT by one
+    // common text extension (`sh` costs ~92 files) silently shrinks the
+    // population while every other assertion here stays green.
+    const allTracked = execFileSync('git', ['ls-files', '-z'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    })
+      .split('\0')
+      .filter((f) => f.length > 0);
+    const excluded = allTracked.filter((f) => BINARY_EXT.test(f));
+    expect(
+      excluded.length,
+      `BINARY_EXT excluded ${excluded.length} files: ${excluded.slice(0, 20).join(', ')}`
+    ).toBeLessThan(20);
+  });
+
+  it('keeps every text extension the repo actually carries', () => {
+    // The other direction: name the extensions whose exclusion would gut the
+    // fence, so a widened BINARY_EXT fails here rather than going quiet.
+    for (const ext of ['.ts', '.sh', '.md', '.json', '.yml', '.js']) {
+      expect(
+        files.some((f) => f.endsWith(ext)),
+        `no ${ext} file survived the binary-extension filter`
+      ).toBe(true);
+    }
+  });
+
   it('has a non-trivial population to scan', () => {
     // A floor, so a broken `git ls-files` or an over-eager exclusion can
     // never pass by scanning nothing. The repo tracked 985 such files when
@@ -141,7 +177,8 @@ describe('sanitizeRawHeaderValue spells NUL as an escape, not a raw byte', () =>
     const match = /\/\[\\r\\n\\u0000\]\/g/.exec(source);
     expect(match, 'the escape spelling is gone from sanitizeRawHeaderValue').not.toBeNull();
 
-    const withEscape = /[\r\n\0]/g;
+    // eslint-disable-next-line no-control-regex
+    const withEscape = /[\r\n\u0000]/g;
     const withRawByte = new RegExp(`[\\r\\n${String.fromCharCode(0)}]`, 'g');
     const probe = `a\rb\nc${String.fromCharCode(0)}d`;
     expect(probe.replace(withEscape, ' ')).toBe(probe.replace(withRawByte, ' '));

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -43,7 +43,7 @@ import { fileURLToPath } from 'node:url';
  * rather than described: adding `sh` to `BINARY_EXT` silently drops ~92
  * files -- every `.claude/hooks/*.sh`, which is the tree this fence's
  * rationale is about -- while leaving the file count and the three prefix
- * checks comfortably satisfied. So the tests below pin BOTH how many files
+ * checks comfortably satisfied. So the tests below pin BOTH WHICH EXTENSIONS
  * the exclusion removes and that each text extension the repo actually
  * carries survives it.
  */
@@ -128,7 +128,12 @@ describe('committed text carries no C0 control bytes', () => {
       .filter((f) => f.length > 0);
     const excludedExts = [
       ...new Set(
-        allTracked.filter((f) => BINARY_EXT.test(f)).map((f) => path.extname(f).toLowerCase())
+        allTracked
+          .filter((f) => BINARY_EXT.test(f))
+          // `path.extname` is '' for a leading-dot basename ('.gif'), which
+          // would put a token naming nothing into the failure diff. Fall back
+          // to the basename so a failure always names the offender.
+          .map((f) => (path.extname(f) || path.basename(f)).toLowerCase())
       ),
     ].sort();
     expect(excludedExts).toEqual(['.gif']);


### PR DESCRIPTION
## Summary

`sanitizeRawHeaderValue` in `src/local/front-door-server.ts` wrote NUL as a
LITERAL byte, both inside its regex character class and in the comment above it.
The JavaScript was correct -- a literal NUL in a character class matches exactly
what the `\u0000` escape matches, proven in the new test -- so nothing in the
toolchain objected.

What it cost was invisible and repo-wide: `file` reported the whole 49 KB file
as `data`, and **`grep` therefore returned NOTHING for it, silently, for every
pattern**. `grep -c host` on that file answered `0`; it answers `41` now.

`src/local/front-door-server.ts` is on the `UP_PATHS` security surface in
`.claude/hooks/pr-review-gate.sh`, so every grep-based audit over `src/local/**`
-- the reviewer agents, the hunt sweeps, the four-copies consistency harness --
had been skipping it.

`control-char-gate.sh` exists to stop exactly this, and
https://github.com/go-to-k/cdk-local/issues/576 records why it did not: it is a
PreToolUse hook, so it only sees the agent's tool calls, and
`git add -A && git commit ...` in one call presents it with the tree as it was
BEFORE the `git add`. Registration is not execution. So this removes the byte AND
fences it from the other side.

## Behaviour change

**Not none** -- reading the neighbourhood the NUL sat in turned up a
pre-existing header-injection gap, and closing it changes what goes on the wire.

`front-door-server.ts` has THREE raw-socket writers that hand-assemble an HTTP
response over an upgrade socket. Only ONE of them sanitized its interpolated
value. The other two now do:

- **`writeRawHttpRedirect`** emitted `location:` unsanitized. The value is built
  from CFn-literal `RedirectConfig.Host` / `.Path` / `.Query`.
- **`writeRawHttpUnauthorized`** emitted `www-authenticate: Bearer realm="..."`
  through `escapeRealmQuotes`, which escapes `"` only -- the right guard for the
  wrong problem, since a quote ends the realm TOKEN while CR / LF / NUL end the
  HEADER. `realm` is `guard.label`, built from a CFn literal validated only as a
  string, so it is the same trust class.

Both reach the same raw upgrade socket, and both have a regular-HTTP counterpart
that is protected for free (Node's `res.writeHead` throws `ERR_INVALID_CHAR`) --
so the upgrade path was the one place either could inject response headers
silently. Same root cause as the function this PR already touches, one call each
to fix, so they are swept here rather than filed.

On the wire: a CR / LF / NUL inside those values is now flattened to a space
INTO the value, instead of terminating the header line.

## What the fence does

`tests/unit/no-control-bytes.test.ts` derives its population from `git ls-files`
rather than a hand-kept directory list -- the rule is about COMMITTED TEXT, not
about any subtree, and a root list would have missed `src/local/**` as readily
as it would miss whatever directory is added next. It fails in CI on any C0
control byte in any tracked text file (tab / LF / CR excepted), reporting
`file:line:column` and the byte, since the defect is invisible on screen.

Three things keep it from going vacuous:

- a **population floor** (`> 500` files, plus an explicit assertion that `src/`,
  `tests/` and `.claude/` are all reached);
- a **guard on the binary-extension exclusion itself**, which is the fence's own
  soft spot: adding `sh` to `BINARY_EXT` silently drops ~92 files, every
  `.claude/hooks/*.sh`, which is the tree this fence's rationale is about. The
  threshold is 10 against an actual excluded count of 3 -- deliberately close
  rather than generous, because at 20 it still admitted `yaml` (13 lockfiles),
  `mjs` (11) or `html` (7) one at a time;
- a case pinning that the escape spelling is behaviourally IDENTICAL to the raw
  byte it replaced, in the exact spelling the source ships, because "equivalent"
  is not a claim that should rest on the reader agreeing with it in a
  security-relevant sanitizer.

## Scope of the defect

An audit of all 986 tracked text files found these two bytes and nothing else,
so the blast radius was bounded to this one file:

```bash
git ls-files | grep -vE '\.(png|jpe?g|gif|ico|woff2?|ttf|zip|wasm|pdf)$' > /tmp/files.txt
LC_ALL=C perl -ne 'while(/([\x00-\x08\x0B\x0C\x0E-\x1F\x7F])/g){printf "%s line %d byte 0x%02X\n",$ARGV,$.,ord($1)}' $(cat /tmp/files.txt) | sort -u
```

`eslint`'s `no-control-regex` fires on the escape where it did not fire on the
raw byte, so it carries a scoped `eslint-disable-next-line` -- matching a control
character is the entire purpose of the function -- keeping the repo at its
pre-existing single lint warning.

## Test plan

- `vp run verify`: 224 files / 3576 tests pass, 0 errors, 1 warning
  (pre-existing, `src/local/cloudfront-edge-event.ts:391`).
- **Mutation-probed, each fence independently**: restoring the literal NUL turns
  both control-byte assertions RED naming
  `src/local/front-door-server.ts:1313:30 contains 0x00`; removing the redirect
  sanitizer turns exactly the redirect case RED; removing the realm sanitizer
  turns exactly the 401 case RED; adding `sh` to `BINARY_EXT` turns both
  exclusion guards RED.
- Both new behavioural tests drive a CRLF-bearing value through a REAL upgrade
  socket and assert the injected name never starts a header line -- and pin the
  flattened value too, since a negative alone would also pass if the writer
  stopped emitting the header at all.
- `/run-integ local-start-alb-redirect`: **PASSED**, both redirect phases, clean
  teardown, 0 orphan containers / networks. That is the fixture which directly
  exercises the newly-sanitized redirect path; it was red on `main` until
  https://github.com/go-to-k/cdk-local/pull/593, which this branch is rebased
  onto.

Refs https://github.com/go-to-k/cdk-local/issues/576 -- the GATE defect that let
this land stays open and unclaimed; this PR closes the live instance and adds the
CI fence, recorded as a checklist row on that issue.


## Reviewer enumeration, and two nits deliberately not taken

The third round's reviewer did NOT check the three writers this PR names -- it
enumerated every raw socket write in the file independently, which is the right
move given rounds 1 and 2 each claimed the neighbourhood was swept and each
missed one. Result: **five** raw socket writes, **four** response writers, and
exactly **three** that interpolate a value into a HEADER. All three are now
sanitized. The fourth (`writeRawHttpError`) interpolates only into the
length-prefixed body; status codes come from validated parsers and reason
phrases from a literal map.

Two nits are consciously left:

- **`:1150` replays inbound request headers to the replica unsanitized.**
  Pre-existing, and safe today only because llhttp rejects CR / LF / NUL in
  inbound header values -- a future `insecureHTTPParser` would make it a
  smuggling vector. Not fixed here because it is a comment-or-code change in
  `src/**`, which stales the `integ` marker and buys another full Docker cycle
  for a path that is currently unreachable. Recorded here rather than filed: it
  is a note about why a guard holds, not an outstanding defect.
- **Test-helper duplication** -- the three raw-upgrade cases repeat ~40 lines of
  socket setup, and there is a third copy of a `require('node:net')` shim in a
  file that already imports `node:net`. Worth one `readRawUpgradeResponse(front)`
  helper; not worth a re-review round on a security fix.
