### PR TITLE
fix(integ): give every AWS-deploying fixture a lane-unique name

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1378,6 +1378,29 @@ vp run runtime:smoke
   cloudformation` calls — leaving orphan resources after an integ
   run is never acceptable.
 
+- **Every account-global name an AWS-deploying fixture owns is
+  lane-unique** (issue #582). `tests/integration/_lib/stack-name.sh` is
+  the single place the suffix is derived — 8 hex of the SHA-256 of the
+  worktree root, exported as `INTEG_STACK_SUFFIX` — and
+  `tests/integration/_lib/stack-name.ts` is the only place the CDK app
+  READS it, so `cdk deploy "${STACK}"` and what `bin/app.ts` synthesizes
+  agree. A fixture builds its names through `integ_stack_name` /
+  `integ_scoped_name` (shell) or `integStackName` / `integScopedName`
+  (app); with the variable unset — a bare `cdk synth` by hand — the
+  historical un-suffixed name comes back, so nothing outside `verify.sh`
+  changes. It covers stack names, SSM parameter paths and the multi-stack
+  fixture's CloudFormation EXPORT name, all of which are unique per
+  account+region. Before this, two worktree lanes running the same
+  fixture deployed, read and destroyed THE SAME stack: the pre-flight
+  scan mistook a peer's live stack for a leftover, the cleanup trap could
+  `cdk destroy` it, and a colliding run could report GREEN having
+  asserted against a peer's resources — which then refreshed the `integ`
+  merge gate. `tests/integration/_lib/stack-name.test.sh` fences it and
+  runs in CI via `vp run test:hooks`. **Host-global names are NOT covered
+  yet** — the fixtures still hard-code TCP ports, and seven of them
+  `kill -9` whoever holds one (issue #591), so two lanes running a
+  `local-start-*` serve fixture still break each other.
+
 - **cdkd parity** (host-CLI library-surface drift):
   `cdkd-parity-gate.sh` blocks `gh pr create` when the `cdkd-parity`
   marker is stale AND the diff touches the cdk-local library surface

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -98,23 +98,47 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      EXECUTED rather than read.
 
 
-     If an orphan stack is reported, abort — do NOT proceed. Destroy **the
-     names the loop printed**, not `"${STACK}"`: that variable is assigned
-     INSIDE the loop, so after it runs it holds only the LAST base name. On the
-     two-stack fixture the scan finds the orphaned PRODUCER and `"${STACK}"` is
-     the consumer, which does not exist. Pass them to one `cdk destroy` in
-     DEPENDENCY order — consumer before producer, matching the fixture's own
-     cleanup — so the export is released before its exporter goes:
+     If an orphan stack is reported, abort — do NOT proceed.
+
+     Destroy **the names the loop printed**, not `"${STACK}"`: that variable is
+     assigned INSIDE the loop, so afterwards it holds only the LAST name the
+     loop resolved — one of the set, chosen by iteration order, not the one you
+     want.
+
+     Use `aws cloudformation delete-stack`, NOT `cdk destroy`. Two reasons, both
+     measured:
+
+     - `cdk destroy` needs app context. From the repo root it fails with
+       `--app is required either in command-line, in cdk.json or in ~/.cdk.json`
+       — the fixture runs its own destroy from the fixture directory, not here.
+     - Repaired by hand, it is worse: **`cdk destroy` exits 0, silently, on a
+       name the app never synthesized.** This block is a fresh shell with no
+       `source`, so `INTEG_STACK_SUFFIX` is unset, the app builds UN-suffixed
+       names, your suffixed arguments match nothing, and you read a clean exit
+       with both stacks still deployed. That is this recipe's own defect class,
+       arriving through the remediation instead of the scan.
+
+     `delete-stack` needs no app context and no suffix in the environment, and
+     it takes one stack at a time — so order the calls yourself, in DEPENDENCY
+     order (consumer before producer, matching the fixture's own cleanup), so
+     the export is released before its exporter goes:
 
      ```bash
-     cdk destroy <ConsumerStackName> <ProducerStackName> --force \
-       --region "${AWS_REGION:-us-east-1}"
+     for STACK in <ConsumerStackName> <ProducerStackName>; do   # dependency order
+       aws cloudformation delete-stack --stack-name "${STACK}" \
+         --region "${AWS_REGION:-us-east-1}"
+       aws cloudformation wait stack-delete-complete --stack-name "${STACK}" \
+         --region "${AWS_REGION:-us-east-1}"
+     done
      ```
- Note that a stack under THIS lane's name can also
-     be a second run of the same fixture in the SAME worktree, i.e. a LIVE peer
-     rather than a leftover: check for a running `verify.sh` before destroying
-     it. Cross-worktree lanes can no longer collide, which is the point of the
-     suffix.
+
+     **Then RE-RUN the scan.** No delete command reports "I matched nothing",
+     so the only evidence the orphan is gone is the scan saying so.
+
+     Note that a stack under THIS lane's name can also be a second run of the
+     same fixture in the SAME worktree, i.e. a LIVE peer rather than a leftover:
+     check for a running `verify.sh` before destroying it. Cross-worktree lanes
+     can no longer collide, which is the point of the suffix.
 
 5. **Run the test**: `bash tests/integration/<test-name>/verify.sh`. Propagate the script's exit code — a non-zero exit must drive this skill into the failure path so step 7's cleanup verification fires. Do NOT swallow `verify.sh` failures.
 
@@ -151,9 +175,11 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    verdict into a fresh `integ` marker.
 
 
-   If any stack remains, destroy the names the loop printed — in dependency
-   order, and NOT `"${STACK}"`, which holds only the last base name (see step 4)
-   — until clean, after the SAME live-peer check step 4 describes. A second run of this fixture
+   If any stack remains, destroy the names the loop printed with
+   `aws cloudformation delete-stack` — in dependency order, and NOT
+   `"${STACK}"`, which holds only the last name the loop resolved (see step 4
+   for why `cdk destroy` is the wrong tool here) — then RE-RUN the scan, after
+   the SAME live-peer check step 4 describes. A second run of this fixture
    in the SAME worktree shares the suffix, so the name alone does not tell you
    the stack is a leftover rather than a peer's live one.
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -25,11 +25,24 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 4. **For `*-from-cfn-stack` tests only — AWS pre-flight**:
    - Verify the upstream `cdk` CLI is on `$PATH`: `which cdk`.
    - Verify AWS credentials: `aws sts get-caller-identity`.
-   - Scan for orphan stacks from a previous interrupted run:
+   - Scan for orphan stacks from a previous interrupted run. **The stack name
+     is LANE-UNIQUE (issue go-to-k/cdk-local#582)**: every AWS-deploying fixture suffixes its
+     base name with 8 hex derived from this worktree's root path, so scanning
+     the bare `<FixtureStackName>` matches nothing and reports clean no matter
+     what is actually deployed. Resolve the name the same way the fixture does:
+
      ```bash
-     aws cloudformation describe-stacks --stack-name <FixtureStackName> 2>/dev/null && echo "ORPHAN" || echo "(no orphan stack)"
+     source tests/integration/_lib/stack-name.sh
+     STACK="$(integ_stack_name <FixtureStackBaseName>)"   # e.g. CdkLocalInvokeFromCfnStackFixture
+     aws cloudformation describe-stacks --stack-name "${STACK}" 2>/dev/null && echo "ORPHAN" || echo "(no orphan stack)"
      ```
-     If an orphan stack is reported, abort with a `cdk destroy <FixtureStackName>` recipe — do NOT proceed.
+
+     If an orphan stack is reported, abort with a `cdk destroy "${STACK}"`
+     recipe — do NOT proceed. Note that a stack under THIS lane's name can also
+     be a second run of the same fixture in the SAME worktree, i.e. a LIVE peer
+     rather than a leftover: check for a running `verify.sh` before destroying
+     it. Cross-worktree lanes can no longer collide, which is the point of the
+     suffix.
 
 5. **Run the test**: `bash tests/integration/<test-name>/verify.sh`. Propagate the script's exit code — a non-zero exit must drive this skill into the failure path so step 7's cleanup verification fires. Do NOT swallow `verify.sh` failures.
 
@@ -45,13 +58,27 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
 7. **Verify AWS cleanup** (only for `*-from-cfn-stack` tests):
 
+   Resolve the lane-unique name the same way step 4 does — the bare base name
+   matches nothing and this sweep would silently report clean:
+
    ```bash
-   aws cloudformation describe-stacks --stack-name <FixtureStackName> 2>/dev/null \
+   source tests/integration/_lib/stack-name.sh
+   STACK="$(integ_stack_name <FixtureStackBaseName>)"
+   aws cloudformation describe-stacks --stack-name "${STACK}" 2>/dev/null \
      && echo "ORPHAN STACK REMAINS" \
      || echo "AWS clean"
    ```
 
-   If the stack remains, run `cdk destroy <FixtureStackName> --force` until clean. Same rule: never end the run with orphan AWS resources.
+   If the stack remains, run `cdk destroy "${STACK}" --force` until clean. Same rule: never end the run with orphan AWS resources.
+
+   Some fixtures also own account-global names that are NOT stacks and outlive a
+   failed run — SSM parameter paths and a CloudFormation export name, all
+   suffixed by the same lane hash. Sweep those too:
+
+   ```bash
+   aws ssm describe-parameters --query "Parameters[?starts_with(Name,'/cdkl')].Name" --output text
+   aws cloudformation list-exports --query "Exports[?starts_with(Name,'cdkl')].[Name,ExportingStackId]" --output text
+   ```
 
 8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for `from-cfn-stack`: "+ AWS: 0 orphan stacks").
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -81,17 +81,49 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
    ```bash
    source tests/integration/_lib/stack-name.sh   # exports INTEG_STACK_SUFFIX
+   # Fail LOUDLY if the suffix did not resolve. The `source` path above is
+   # relative, so running this from anywhere but the repo root leaves the
+   # variable unset -- and an unset variable turns the filters below into
+   # `contains(Name,'-')`, which selects every hyphenated parameter in the
+   # ACCOUNT (`/prod/db-password` included) and hands it to you as an orphan to
+   # delete. Degrading to account-wide is far worse than the peer-listing this
+   # filter exists to fix, so it must abort instead.
+   : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
+
+   # BOTH conditions: the `cdkl` anchor keeps the blast radius bounded to this
+   # repo's resources even if the suffix logic is ever changed, and the suffix
+   # bounds it to this lane.
    aws ssm describe-parameters \
-     --query "Parameters[?contains(Name,'-${INTEG_STACK_SUFFIX}')].Name" --output text
+     --query "Parameters[?starts_with(Name,'/cdkl') && contains(Name,'-${INTEG_STACK_SUFFIX}')].Name" \
+     --output text
    aws cloudformation list-exports \
-     --query "Exports[?contains(Name,'-${INTEG_STACK_SUFFIX}')].[Name,ExportingStackId]" --output text
+     --query "Exports[?starts_with(Name,'cdkl') && contains(Name,'-${INTEG_STACK_SUFFIX}')].[Name,ExportingStackId]" \
+     --output text
+
+   # Not lane-suffixed and not a stack resource, so neither sweep above can see
+   # it: `local-invoke-agentcore-froms3` creates a bucket out of band, and its
+   # trap covers EXIT/INT/TERM but not SIGKILL.
+   aws s3 ls | grep cdkl-integ-froms3 || echo "(no orphan froms3 bucket)"
    ```
 
    `contains`, not `ends_with`: `local-invoke-from-cfn-stack-large-stack` creates
    ~105 parameters shaped `/cdkl-ls-<hash>/p000`, where the suffix is a PREFIX
-   segment rather than the tail.
+   segment rather than the tail. A peer's suffix cannot satisfy this lane's
+   filter — both are exactly 8 hex characters, so `-<ours>` inside `-<theirs>`
+   requires equality.
 
-8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for `from-cfn-stack`: "+ AWS: 0 orphan stacks").
+   The same live-peer caveat as the stack scan applies, and matters MORE here: a
+   name carrying this lane's suffix can also belong to a second run of the same
+   fixture in the SAME worktree, i.e. a live peer rather than a leftover — so
+   check for a running `verify.sh` before deleting anything. An export cannot be
+   deleted except by destroying its stack, so `ExportingStackId` in that output
+   is pointing you at a stack that may still be in use.
+
+   Pass `--region` to match the fixture's (`AWS_REGION`, default `us-east-1`) if
+   your shell's default region differs — otherwise these queries report a false
+   clean from the wrong region.
+
+8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for `from-cfn-stack`: "+ AWS: 0 orphan stacks / parameters / exports / buckets" — name each sweep you actually ran, so a clean report is not writable without running them).
 
 9. **Set the `integ` markgate marker (only on full clean success)**:
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -59,8 +59,11 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      # PLURAL. Most fixtures own one stack; `local-invoke-from-cfn-stack-multi-stack`
      # owns two, and its cleanup destroys the consumer first — so an interrupted
      # destroy orphans the PRODUCER, which is exactly the one a single-name scan
-     # would skip. Read the fixture's own `integ_stack_name` calls and list all
-     # of them.
+     # would skip. Enumerate them mechanically rather than by reading -- a
+     # hand-read list is what drifted three times in this recipe's history:
+     #
+     #   grep -oE 'integ_stack_name[[:space:]]+[A-Za-z0-9_]+' \
+     #     tests/integration/<test-name>/verify.sh | awk '{print $2}' | sort -u
      for BASE in <FixtureStackBaseName> ...; do
        STACK="$(integ_stack_name "${BASE}")"
        : "${STACK:?stack name did not resolve — the helper is undefined}"
@@ -95,8 +98,19 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      EXECUTED rather than read.
 
 
-     If an orphan stack is reported, abort with a `cdk destroy "${STACK}"`
-     recipe — do NOT proceed. Note that a stack under THIS lane's name can also
+     If an orphan stack is reported, abort — do NOT proceed. Destroy **the
+     names the loop printed**, not `"${STACK}"`: that variable is assigned
+     INSIDE the loop, so after it runs it holds only the LAST base name. On the
+     two-stack fixture the scan finds the orphaned PRODUCER and `"${STACK}"` is
+     the consumer, which does not exist. Pass them to one `cdk destroy` in
+     DEPENDENCY order — consumer before producer, matching the fixture's own
+     cleanup — so the export is released before its exporter goes:
+
+     ```bash
+     cdk destroy <ConsumerStackName> <ProducerStackName> --force \
+       --region "${AWS_REGION:-us-east-1}"
+     ```
+ Note that a stack under THIS lane's name can also
      be a second run of the same fixture in the SAME worktree, i.e. a LIVE peer
      rather than a leftover: check for a running `verify.sh` before destroying
      it. Cross-worktree lanes can no longer collide, which is the point of the
@@ -137,8 +151,9 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    verdict into a fresh `integ` marker.
 
 
-   If the stack remains, run `cdk destroy "${STACK}" --force` until clean --
-   after the SAME live-peer check step 4 describes. A second run of this fixture
+   If any stack remains, destroy the names the loop printed — in dependency
+   order, and NOT `"${STACK}"`, which holds only the last base name (see step 4)
+   — until clean, after the SAME live-peer check step 4 describes. A second run of this fixture
    in the SAME worktree shares the suffix, so the name alone does not tell you
    the stack is a leftover rather than a peer's live one.
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -105,6 +105,13 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      loop resolved — one of the set, chosen by iteration order, not the one you
      want.
 
+     **First, confirm it is not a LIVE peer.** A stack under THIS lane's name can
+     also be a second run of the same fixture in the SAME worktree, so check for
+     a running `verify.sh` before destroying anything. This guard is stated
+     BEFORE the command on purpose: an agent works top-down, and a warning
+     printed below a destructive block is read after the damage. Cross-worktree
+     lanes can no longer collide, which is the point of the suffix.
+
      Use `aws cloudformation delete-stack`, NOT `cdk destroy`. Two reasons, both
      measured:
 
@@ -124,7 +131,9 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      the export is released before its exporter goes:
 
      ```bash
-     for STACK in <ConsumerStackName> <ProducerStackName>; do   # dependency order
+     # SUFFIXED names -- the ones the scan printed, not the base names step 4
+     # takes. Pasting base names deletes nothing and reports success.
+     for STACK in <ConsumerStackName-suffix> <ProducerStackName-suffix>; do
        aws cloudformation delete-stack --stack-name "${STACK}" \
          --region "${AWS_REGION:-us-east-1}"
        aws cloudformation wait stack-delete-complete --stack-name "${STACK}" \
@@ -135,10 +144,6 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      **Then RE-RUN the scan.** No delete command reports "I matched nothing",
      so the only evidence the orphan is gone is the scan saying so.
 
-     Note that a stack under THIS lane's name can also be a second run of the
-     same fixture in the SAME worktree, i.e. a LIVE peer rather than a leftover:
-     check for a running `verify.sh` before destroying it. Cross-worktree lanes
-     can no longer collide, which is the point of the suffix.
 
 5. **Run the test**: `bash tests/integration/<test-name>/verify.sh`. Propagate the script's exit code — a non-zero exit must drive this skill into the failure path so step 7's cleanup verification fires. Do NOT swallow `verify.sh` failures.
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -28,11 +28,21 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    `local-invoke-assume-role`, which deploys a stack containing an IAM role):
 
    ```bash
-   # The 12 that own a lane-suffixed stack, by construction -- they are exactly
-   # the fixtures that source the lane library.
-   grep -ln 'stack-name.sh' tests/integration/*/verify.sh
-   # Plus one that owns a real S3 bucket without deploying a stack:
-   #   local-invoke-agentcore-froms3
+   # ONE predicate, no hand-maintained exception: a fixture owns a real AWS
+   # resource iff it deploys a stack or creates a bucket out of band. Carrying
+   # the second as a prose footnote is the hand-maintained-list shape that
+   # produced three earlier misses.
+   #
+   # rc-checked like every other query here -- `grep -l` with no match exits 1
+   # with EMPTY stdout and no message, which reads as "this fixture is not
+   # AWS-owning" and skips steps 4 and 7 ENTIRELY. That is a wider blast radius
+   # than any single false clean.
+   if owners=$(grep -lE '(^|[^[:alnum:]_])(cdk[^;&|]*[[:space:]]deploy|aws[[:space:]]+s3api[[:space:]]+create-bucket)([[:space:]]|$)' \
+                 tests/integration/*/verify.sh) && [ -n "${owners}" ]; then
+     printf '%s\n' "${owners}"
+   else
+     echo "FAILED to derive the AWS-owning fixture set -- NOT a clean verdict" >&2
+   fi
    ```
 
    - Verify the upstream `cdk` CLI is on `$PATH`: `which cdk`.
@@ -53,18 +63,23 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      # fresh `integ` marker over a live orphan stack.
      : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
      STACK="$(integ_stack_name <FixtureStackBaseName>)"   # e.g. CdkLocalInvokeFromCfnStackFixture
-     # Do NOT write `2>/dev/null && ... || echo clean`. Every failure mode --
-     # expired token, AccessDenied, throttling, an undefined helper leaving
-     # `STACK` empty -- then lands in the `||` branch and prints a CLEAN verdict.
-     # Measured: invalid credentials exit 254 with `InvalidClientTokenId`, and
-     # the naive form reports "no orphan stack". Only "does not exist" is clean.
-     if err=$(aws cloudformation describe-stacks --stack-name "${STACK}" \
-                --region "${AWS_REGION:-us-east-1}" 2>&1 >/dev/null); then
-       echo "ORPHAN"
-     elif printf '%s' "${err}" | grep -q 'does not exist'; then
-       echo "(no orphan stack)"
+     # Ask with `list-stacks --query`, NOT `describe-stacks --stack-name`.
+     # `describe-stacks` ERRORS when the stack is absent, so the clean case and
+     # the could-not-look case both arrive as a non-zero exit and have to be
+     # told apart by matching stderr -- and that phrase match has already been
+     # wrong: `grep -q 'does not exist'` also matches botocore's
+     # `The source_profile "x" ... does not exist`, an InvalidConfigError raised
+     # BEFORE any network call, so a broken SSO or role-chaining profile printed
+     # a CLEAN verdict. `list-stacks` exits 0 whether or not the stack is there,
+     # so rc alone separates "looked, found nothing" from "could not look".
+     if names=$(aws cloudformation list-stacks \
+                  --region "${AWS_REGION:-us-east-1}" \
+                  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_IN_PROGRESS CREATE_FAILED DELETE_FAILED \
+                  --query "StackSummaries[?StackName=='${STACK}'].StackName" \
+                  --output text); then
+       [ -n "${names}" ] && echo "ORPHAN" || echo "(no orphan stack)"
      else
-       echo "FAILED to query -- this is NOT a clean verdict: ${err}" >&2
+       echo "FAILED to query -- this is NOT a clean verdict" >&2
      fi
      ```
 
@@ -103,17 +118,21 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    # Same shape as step 4, and for the same reason -- this one matters more, as
    # it runs after a long test where a session token can expire, and step 9
    # converts its verdict into a fresh `integ` marker.
-   if err=$(aws cloudformation describe-stacks --stack-name "${STACK}" \
-              --region "${AWS_REGION:-us-east-1}" 2>&1 >/dev/null); then
-     echo "ORPHAN STACK REMAINS"
-   elif printf '%s' "${err}" | grep -q 'does not exist'; then
-     echo "AWS clean"
+   if names=$(aws cloudformation list-stacks \
+                --region "${AWS_REGION:-us-east-1}" \
+                --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_IN_PROGRESS CREATE_FAILED DELETE_FAILED \
+                --query "StackSummaries[?StackName=='${STACK}'].StackName" \
+                --output text); then
+     [ -n "${names}" ] && echo "ORPHAN STACK REMAINS" || echo "AWS clean"
    else
-     echo "FAILED to query -- this is NOT a clean verdict: ${err}" >&2
+     echo "FAILED to query -- this is NOT a clean verdict" >&2
    fi
    ```
 
-   If the stack remains, run `cdk destroy "${STACK}" --force` until clean. Same rule: never end the run with orphan AWS resources.
+   If the stack remains, run `cdk destroy "${STACK}" --force` until clean --
+   after the SAME live-peer check step 4 describes. A second run of this fixture
+   in the SAME worktree shares the suffix, so the name alone does not tell you
+   the stack is a leftover rather than a peer's live one.
 
    Some fixtures also own account-global names that are NOT stacks and outlive a
    failed run — SSM parameter paths and a CloudFormation export name, all

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-integ
-description: Run an integration test (Docker-based, optionally AWS-deploy-backed for `*-from-cfn-stack` tests) and refresh the `integ` markgate marker on a clean run.
+description: Run an integration test (Docker-based, optionally AWS-deploy-backed for the fixtures that own real AWS resources) and refresh the `integ` markgate marker on a clean run.
 argument-hint: "<test-name>"
 ---
 
@@ -8,7 +8,7 @@ argument-hint: "<test-name>"
 
 Run an integration test against real Docker (and, for `*-from-cfn-stack` tests, a real CloudFormation stack deployed via the upstream `cdk` CLI).
 
-cdk-local is a local-execution CLI — it does NOT deploy resources itself. The only AWS-side activity in any integ test is when a fixture's `verify.sh` invokes the upstream `cdk deploy` to create a target stack for `--from-cfn-stack` to point at. Cleanup is always done by the fixture's own `verify.sh`.
+cdk-local is a local-execution CLI — it does NOT deploy resources itself. The only AWS-side activity in any integ test is when a fixture's `verify.sh` invokes the upstream `cdk deploy` (or, for `local-invoke-agentcore-froms3`, `aws s3api create-bucket`) to create a target stack for `--from-cfn-stack` to point at. Cleanup is always done by the fixture's own `verify.sh`.
 
 ## Arguments
 
@@ -22,11 +22,19 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
 3. **Pre-flight Docker sweep**: `docker ps --filter name=cdkl- -q | wc -l` and `docker network ls --filter name=cdkl-task- -q | wc -l` should both return `0`. If either is non-zero, abort and ask the user to run `/cleanup` first — running on top of orphans causes name collisions and confusing failures.
 
-4. **For AWS-deploying tests — AWS pre-flight**. That is every fixture matching
-   `*-from-cfn*`, PLUS `local-invoke-agentcore-froms3`, which creates a real S3
-   bucket without deploying a stack. Scoping this to `*-from-cfn-stack` (the
-   original wording) silently skipped three fixtures that own real AWS
-   resources:
+4. **For AWS-resource-owning tests — AWS pre-flight**. That is the fixtures that own real AWS resources. **Derive that set, do not glob it** —
+   a glob has now silently excluded a resource-owning fixture twice
+   (`*-from-cfn-stack` missed three, and the widened `*-from-cfn*` still missed
+   `local-invoke-assume-role`, which deploys a stack containing an IAM role):
+
+   ```bash
+   # The 12 that own a lane-suffixed stack, by construction -- they are exactly
+   # the fixtures that source the lane library.
+   grep -ln 'stack-name.sh' tests/integration/*/verify.sh
+   # Plus one that owns a real S3 bucket without deploying a stack:
+   #   local-invoke-agentcore-froms3
+   ```
+
    - Verify the upstream `cdk` CLI is on `$PATH`: `which cdk`.
    - Verify AWS credentials: `aws sts get-caller-identity`.
    - Scan for orphan stacks from a previous interrupted run. **The stack name
@@ -45,8 +53,19 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      # fresh `integ` marker over a live orphan stack.
      : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
      STACK="$(integ_stack_name <FixtureStackBaseName>)"   # e.g. CdkLocalInvokeFromCfnStackFixture
-     aws cloudformation describe-stacks --stack-name "${STACK}" \
-       --region "${AWS_REGION:-us-east-1}" 2>/dev/null && echo "ORPHAN" || echo "(no orphan stack)"
+     # Do NOT write `2>/dev/null && ... || echo clean`. Every failure mode --
+     # expired token, AccessDenied, throttling, an undefined helper leaving
+     # `STACK` empty -- then lands in the `||` branch and prints a CLEAN verdict.
+     # Measured: invalid credentials exit 254 with `InvalidClientTokenId`, and
+     # the naive form reports "no orphan stack". Only "does not exist" is clean.
+     if err=$(aws cloudformation describe-stacks --stack-name "${STACK}" \
+                --region "${AWS_REGION:-us-east-1}" 2>&1 >/dev/null); then
+       echo "ORPHAN"
+     elif printf '%s' "${err}" | grep -q 'does not exist'; then
+       echo "(no orphan stack)"
+     else
+       echo "FAILED to query -- this is NOT a clean verdict: ${err}" >&2
+     fi
      ```
 
      If an orphan stack is reported, abort with a `cdk destroy "${STACK}"`
@@ -68,8 +87,7 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
    If any are non-zero, dispatch `/cleanup` (no `--detect-only`) and re-run the checks. Never end the run with orphan Docker resources still present.
 
-7. **Verify AWS cleanup** (same fixture set as step 4 — `*-from-cfn*` plus
-   `local-invoke-agentcore-froms3`):
+7. **Verify AWS cleanup** (the same DERIVED fixture set as step 4):
 
    Resolve the lane-unique name the same way step 4 does — the bare base name
    matches nothing and this sweep would silently report clean:
@@ -82,10 +100,17 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    # PRIMARY resource, which step 9 turns into a fresh `integ` marker.
    : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
    STACK="$(integ_stack_name <FixtureStackBaseName>)"
-   aws cloudformation describe-stacks --stack-name "${STACK}" \
-     --region "${AWS_REGION:-us-east-1}" 2>/dev/null \
-     && echo "ORPHAN STACK REMAINS" \
-     || echo "AWS clean"
+   # Same shape as step 4, and for the same reason -- this one matters more, as
+   # it runs after a long test where a session token can expire, and step 9
+   # converts its verdict into a fresh `integ` marker.
+   if err=$(aws cloudformation describe-stacks --stack-name "${STACK}" \
+              --region "${AWS_REGION:-us-east-1}" 2>&1 >/dev/null); then
+     echo "ORPHAN STACK REMAINS"
+   elif printf '%s' "${err}" | grep -q 'does not exist'; then
+     echo "AWS clean"
+   else
+     echo "FAILED to query -- this is NOT a clean verdict: ${err}" >&2
+   fi
    ```
 
    If the stack remains, run `cdk destroy "${STACK}" --force` until clean. Same rule: never end the run with orphan AWS resources.
@@ -112,12 +137,15 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    # BOTH conditions: the `cdkl` anchor keeps the blast radius bounded to this
    # repo's resources even if the suffix logic is ever changed, and the suffix
    # bounds it to this lane.
+   # rc-checked for the same reason: on a credential failure these exit non-zero
+   # with EMPTY stdout, which reads as "0 parameters" rather than "I could not
+   # look".
    aws ssm describe-parameters --region "${AWS_REGION:-us-east-1}" \
      --query "Parameters[?starts_with(Name,'/cdkl') && contains(Name,'-${INTEG_STACK_SUFFIX}')].Name" \
-     --output text
+     --output text || echo "FAILED to query SSM -- NOT a clean verdict" >&2
    aws cloudformation list-exports --region "${AWS_REGION:-us-east-1}" \
      --query "Exports[?starts_with(Name,'cdkl') && contains(Name,'-${INTEG_STACK_SUFFIX}')].[Name,ExportingStackId]" \
-     --output text
+     --output text || echo "FAILED to query exports -- NOT a clean verdict" >&2
 
    # Not lane-suffixed and not a stack resource, so neither sweep above can see
    # it: `local-invoke-agentcore-froms3` creates a bucket out of band, and its
@@ -152,7 +180,7 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    deleted except by destroying its stack, so `ExportingStackId` in that output
    is pointing you at a stack that may still be in use.
 
-8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for `from-cfn-stack`: "+ AWS: 0 orphan stacks / parameters / exports / buckets" — name each sweep you actually ran, so a clean report is not writable without running them).
+8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for an AWS-resource-owning fixture: "+ AWS: 0 orphan stacks / parameters / exports / buckets" — name each sweep you actually ran, so a clean report is not writable without running them).
 
 9. **Set the `integ` markgate marker (only on full clean success)**:
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -73,12 +73,23 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
    Some fixtures also own account-global names that are NOT stacks and outlive a
    failed run — SSM parameter paths and a CloudFormation export name, all
-   suffixed by the same lane hash. Sweep those too:
+   suffixed by the same lane hash. Sweep those too, and **filter by THIS lane's
+   suffix**: a bare `/cdkl` prefix lists every lane's parameters, and step 7's
+   framing is "never end the run with orphan AWS resources", so an unfiltered
+   sweep hands you a peer's LIVE resources to delete — the exact cross-lane harm
+   the lane-unique naming exists to end.
 
    ```bash
-   aws ssm describe-parameters --query "Parameters[?starts_with(Name,'/cdkl')].Name" --output text
-   aws cloudformation list-exports --query "Exports[?starts_with(Name,'cdkl')].[Name,ExportingStackId]" --output text
+   source tests/integration/_lib/stack-name.sh   # exports INTEG_STACK_SUFFIX
+   aws ssm describe-parameters \
+     --query "Parameters[?contains(Name,'-${INTEG_STACK_SUFFIX}')].Name" --output text
+   aws cloudformation list-exports \
+     --query "Exports[?contains(Name,'-${INTEG_STACK_SUFFIX}')].[Name,ExportingStackId]" --output text
    ```
+
+   `contains`, not `ends_with`: `local-invoke-from-cfn-stack-large-stack` creates
+   ~105 parameters shaped `/cdkl-ls-<hash>/p000`, where the suffix is a PREFIX
+   segment rather than the tail.
 
 8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for `from-cfn-stack`: "+ AWS: 0 orphan stacks").
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -55,33 +55,29 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
      ```bash
      source tests/integration/_lib/stack-name.sh
-     # Abort if the suffix did not resolve. The `source` path is RELATIVE, so
-     # running this from anywhere but the repo root leaves the helper undefined
-     # -- and then `STACK` is empty, `describe-stacks` errors, `2>/dev/null`
-     # swallows the error, and the `||` branch prints "(no orphan stack)". A
-     # false CLEAN on the primary resource, which step 9 then converts into a
-     # fresh `integ` marker over a live orphan stack.
      : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
      STACK="$(integ_stack_name <FixtureStackBaseName>)"   # e.g. CdkLocalInvokeFromCfnStackFixture
-     # Ask with `list-stacks --query`, NOT `describe-stacks --stack-name`.
-     # `describe-stacks` ERRORS when the stack is absent, so the clean case and
-     # the could-not-look case both arrive as a non-zero exit and have to be
-     # told apart by matching stderr -- and that phrase match has already been
-     # wrong: `grep -q 'does not exist'` also matches botocore's
-     # `The source_profile "x" ... does not exist`, an InvalidConfigError raised
-     # BEFORE any network call, so a broken SSO or role-chaining profile printed
-     # a CLEAN verdict. `list-stacks` exits 0 whether or not the stack is there,
-     # so rc alone separates "looked, found nothing" from "could not look".
-     if names=$(aws cloudformation list-stacks \
-                  --region "${AWS_REGION:-us-east-1}" \
-                  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_IN_PROGRESS CREATE_FAILED DELETE_FAILED \
-                  --query "StackSummaries[?StackName=='${STACK}'].StackName" \
-                  --output text); then
-       [ -n "${names}" ] && echo "ORPHAN" || echo "(no orphan stack)"
-     else
-       echo "FAILED to query -- this is NOT a clean verdict" >&2
-     fi
+     : "${STACK:?stack name did not resolve — the helper is undefined}"
+
+     aws cloudformation describe-stacks --stack-name "${STACK}" \
+       --region "${AWS_REGION:-us-east-1}"
      ```
+
+     **Read that output yourself; the recipe deliberately does not classify it.**
+     A `ValidationError ... does not exist` is the clean case. ANY other failure
+     means you did not look — do not proceed, and do not treat it as clean.
+
+     That is not squeamishness. Every attempt in this recipe's history to EMIT a
+     verdict produced a false one: a name that could never match, a scope that
+     listed every lane, a filter that degraded to the whole account, a stderr
+     phrase match that also matched a broken `source_profile`, and a status
+     filter that hid `DELETE_IN_PROGRESS` — an interrupted `cdk destroy`, which
+     is this sweep's own scenario. `describe-stacks --stack-name` surfaces a
+     stack in every status but `DELETE_COMPLETE`, and a command that claims
+     nothing cannot claim something false.
+     go-to-k/cdk-local#601 replaces this with a script whose failure paths can be
+     EXECUTED rather than read.
+
 
      If an orphan stack is reported, abort with a `cdk destroy "${STACK}"`
      recipe — do NOT proceed. Note that a stack under THIS lane's name can also
@@ -109,25 +105,19 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
    ```bash
    source tests/integration/_lib/stack-name.sh
-   # Same guard as step 4, and for the same reason: without it an unresolved
-   # helper makes `STACK` empty, `describe-stacks` error, `2>/dev/null` swallow
-   # the error, and the `||` branch print `AWS clean` -- a false clean on the
-   # PRIMARY resource, which step 9 turns into a fresh `integ` marker.
    : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
    STACK="$(integ_stack_name <FixtureStackBaseName>)"
-   # Same shape as step 4, and for the same reason -- this one matters more, as
-   # it runs after a long test where a session token can expire, and step 9
-   # converts its verdict into a fresh `integ` marker.
-   if names=$(aws cloudformation list-stacks \
-                --region "${AWS_REGION:-us-east-1}" \
-                --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_IN_PROGRESS CREATE_FAILED DELETE_FAILED \
-                --query "StackSummaries[?StackName=='${STACK}'].StackName" \
-                --output text); then
-     [ -n "${names}" ] && echo "ORPHAN STACK REMAINS" || echo "AWS clean"
-   else
-     echo "FAILED to query -- this is NOT a clean verdict" >&2
-   fi
+   : "${STACK:?stack name did not resolve — the helper is undefined}"
+
+   aws cloudformation describe-stacks --stack-name "${STACK}" \
+     --region "${AWS_REGION:-us-east-1}"
    ```
+
+   Same rule as step 4: read it, do not let the recipe classify it. Only
+   `ValidationError ... does not exist` is clean. This one matters more — it runs
+   after a long test where a session token can expire, and step 9 turns its
+   verdict into a fresh `integ` marker.
+
 
    If the stack remains, run `cdk destroy "${STACK}" --force` until clean --
    after the SAME live-peer check step 4 describes. A second run of this fixture

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -22,7 +22,11 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
 3. **Pre-flight Docker sweep**: `docker ps --filter name=cdkl- -q | wc -l` and `docker network ls --filter name=cdkl-task- -q | wc -l` should both return `0`. If either is non-zero, abort and ask the user to run `/cleanup` first — running on top of orphans causes name collisions and confusing failures.
 
-4. **For `*-from-cfn-stack` tests only — AWS pre-flight**:
+4. **For AWS-deploying tests — AWS pre-flight**. That is every fixture matching
+   `*-from-cfn*`, PLUS `local-invoke-agentcore-froms3`, which creates a real S3
+   bucket without deploying a stack. Scoping this to `*-from-cfn-stack` (the
+   original wording) silently skipped three fixtures that own real AWS
+   resources:
    - Verify the upstream `cdk` CLI is on `$PATH`: `which cdk`.
    - Verify AWS credentials: `aws sts get-caller-identity`.
    - Scan for orphan stacks from a previous interrupted run. **The stack name
@@ -33,8 +37,16 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
      ```bash
      source tests/integration/_lib/stack-name.sh
+     # Abort if the suffix did not resolve. The `source` path is RELATIVE, so
+     # running this from anywhere but the repo root leaves the helper undefined
+     # -- and then `STACK` is empty, `describe-stacks` errors, `2>/dev/null`
+     # swallows the error, and the `||` branch prints "(no orphan stack)". A
+     # false CLEAN on the primary resource, which step 9 then converts into a
+     # fresh `integ` marker over a live orphan stack.
+     : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
      STACK="$(integ_stack_name <FixtureStackBaseName>)"   # e.g. CdkLocalInvokeFromCfnStackFixture
-     aws cloudformation describe-stacks --stack-name "${STACK}" 2>/dev/null && echo "ORPHAN" || echo "(no orphan stack)"
+     aws cloudformation describe-stacks --stack-name "${STACK}" \
+       --region "${AWS_REGION:-us-east-1}" 2>/dev/null && echo "ORPHAN" || echo "(no orphan stack)"
      ```
 
      If an orphan stack is reported, abort with a `cdk destroy "${STACK}"`
@@ -56,15 +68,22 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
 
    If any are non-zero, dispatch `/cleanup` (no `--detect-only`) and re-run the checks. Never end the run with orphan Docker resources still present.
 
-7. **Verify AWS cleanup** (only for `*-from-cfn-stack` tests):
+7. **Verify AWS cleanup** (same fixture set as step 4 — `*-from-cfn*` plus
+   `local-invoke-agentcore-froms3`):
 
    Resolve the lane-unique name the same way step 4 does — the bare base name
    matches nothing and this sweep would silently report clean:
 
    ```bash
    source tests/integration/_lib/stack-name.sh
+   # Same guard as step 4, and for the same reason: without it an unresolved
+   # helper makes `STACK` empty, `describe-stacks` error, `2>/dev/null` swallow
+   # the error, and the `||` branch print `AWS clean` -- a false clean on the
+   # PRIMARY resource, which step 9 turns into a fresh `integ` marker.
+   : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
    STACK="$(integ_stack_name <FixtureStackBaseName>)"
-   aws cloudformation describe-stacks --stack-name "${STACK}" 2>/dev/null \
+   aws cloudformation describe-stacks --stack-name "${STACK}" \
+     --region "${AWS_REGION:-us-east-1}" 2>/dev/null \
      && echo "ORPHAN STACK REMAINS" \
      || echo "AWS clean"
    ```
@@ -93,17 +112,31 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    # BOTH conditions: the `cdkl` anchor keeps the blast radius bounded to this
    # repo's resources even if the suffix logic is ever changed, and the suffix
    # bounds it to this lane.
-   aws ssm describe-parameters \
+   aws ssm describe-parameters --region "${AWS_REGION:-us-east-1}" \
      --query "Parameters[?starts_with(Name,'/cdkl') && contains(Name,'-${INTEG_STACK_SUFFIX}')].Name" \
      --output text
-   aws cloudformation list-exports \
+   aws cloudformation list-exports --region "${AWS_REGION:-us-east-1}" \
      --query "Exports[?starts_with(Name,'cdkl') && contains(Name,'-${INTEG_STACK_SUFFIX}')].[Name,ExportingStackId]" \
      --output text
 
    # Not lane-suffixed and not a stack resource, so neither sweep above can see
    # it: `local-invoke-agentcore-froms3` creates a bucket out of band, and its
    # trap covers EXIT/INT/TERM but not SIGKILL.
-   aws s3 ls | grep cdkl-integ-froms3 || echo "(no orphan froms3 bucket)"
+   #
+   # `aws s3 ls` is checked SEPARATELY from the grep. Piping straight into grep
+   # makes a credential / permission / region failure produce no match, which the
+   # `||` branch then reports as "no orphan" -- the same falsely-clean shape as
+   # the stack scan above.
+   #
+   # This one carries NO lane suffix, so it lists EVERY worktree's froms3
+   # buckets, a concurrently running peer's live bucket included. Treat a match
+   # as "someone's", not "mine": confirm no `verify.sh` is running before
+   # deleting.
+   if buckets=$(aws s3 ls); then
+     printf '%s\n' "${buckets}" | grep cdkl-integ-froms3 || echo "(no orphan froms3 bucket)"
+   else
+     echo "FAILED to list buckets — this is NOT a clean verdict" >&2
+   fi
    ```
 
    `contains`, not `ends_with`: `local-invoke-from-cfn-stack-large-stack` creates
@@ -118,10 +151,6 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    check for a running `verify.sh` before deleting anything. An export cannot be
    deleted except by destroying its stack, so `ExportingStackId` in that output
    is pointing you at a stack that may still be in use.
-
-   Pass `--region` to match the fixture's (`AWS_REGION`, default `us-east-1`) if
-   your shell's default region differs — otherwise these queries report a false
-   clean from the wrong region.
 
 8. **Report results**: Show pass/fail for the test, plus a one-line cleanup summary ("docker: 0 orphans, network: 0 orphans" / for `from-cfn-stack`: "+ AWS: 0 orphan stacks / parameters / exports / buckets" — name each sweep you actually ran, so a clean report is not writable without running them).
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -56,16 +56,32 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
      ```bash
      source tests/integration/_lib/stack-name.sh
      : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
-     STACK="$(integ_stack_name <FixtureStackBaseName>)"   # e.g. CdkLocalInvokeFromCfnStackFixture
-     : "${STACK:?stack name did not resolve — the helper is undefined}"
-
-     aws cloudformation describe-stacks --stack-name "${STACK}" \
-       --region "${AWS_REGION:-us-east-1}"
+     # PLURAL. Most fixtures own one stack; `local-invoke-from-cfn-stack-multi-stack`
+     # owns two, and its cleanup destroys the consumer first — so an interrupted
+     # destroy orphans the PRODUCER, which is exactly the one a single-name scan
+     # would skip. Read the fixture's own `integ_stack_name` calls and list all
+     # of them.
+     for BASE in <FixtureStackBaseName> ...; do
+       STACK="$(integ_stack_name "${BASE}")"
+       : "${STACK:?stack name did not resolve — the helper is undefined}"
+       echo "== ${STACK}"
+       # No `2>/dev/null`: it was the original defect's mechanism. It sends the
+       # clean case and the could-not-look case into the same silence, and the
+       # whole point here is that you can tell them apart.
+       aws cloudformation describe-stacks --stack-name "${STACK}" \
+         --region "${AWS_REGION:-us-east-1}"
+     done
      ```
 
      **Read that output yourself; the recipe deliberately does not classify it.**
-     A `ValidationError ... does not exist` is the clean case. ANY other failure
-     means you did not look — do not proceed, and do not treat it as clean.
+     Both outcomes, because reading only the error is how the inversion happens:
+
+     - `ValidationError ... does not exist` — CLEAN, no such stack.
+     - **exit 0 with a JSON `Stacks` array — ORPHAN.** `describe-stacks`
+       succeeds when the stack is there, so "no error" is the ORPHAN case, not
+       the passing one.
+     - anything else — you did not look. Do not proceed, and do not treat it as
+       clean.
 
      That is not squeamishness. Every attempt in this recipe's history to EMIT a
      verdict produced a false one: a name that could never match, a scope that
@@ -106,15 +122,17 @@ cdk-local is a local-execution CLI — it does NOT deploy resources itself. The 
    ```bash
    source tests/integration/_lib/stack-name.sh
    : "${INTEG_STACK_SUFFIX:?lane suffix unresolved — run this from the repo root}"
-   STACK="$(integ_stack_name <FixtureStackBaseName>)"
-   : "${STACK:?stack name did not resolve — the helper is undefined}"
-
-   aws cloudformation describe-stacks --stack-name "${STACK}" \
-     --region "${AWS_REGION:-us-east-1}"
+   for BASE in <FixtureStackBaseName> ...; do          # PLURAL, see step 4
+     STACK="$(integ_stack_name "${BASE}")"
+     : "${STACK:?stack name did not resolve — the helper is undefined}"
+     echo "== ${STACK}"
+     aws cloudformation describe-stacks --stack-name "${STACK}" \
+       --region "${AWS_REGION:-us-east-1}"
+   done
    ```
 
-   Same rule as step 4: read it, do not let the recipe classify it. Only
-   `ValidationError ... does not exist` is clean. This one matters more — it runs
+   Same rule as step 4, including that exit 0 with a `Stacks` array is the ORPHAN
+   case. Only `ValidationError ... does not exist` is clean. This one matters more — it runs
    after a long test where a session token can expire, and step 9 turns its
    verdict into a fresh `integ` marker.
 

--- a/tests/integration/_lib/stack-name.sh
+++ b/tests/integration/_lib/stack-name.sh
@@ -74,8 +74,11 @@ _integ_lane_hash() {
   elif command -v sha256sum >/dev/null 2>&1; then
     digest="$(printf '%s' "${input}" | sha256sum | cut -d' ' -f1)"
   elif command -v cksum >/dev/null 2>&1; then
-    # Last resort: not a cryptographic hash, but it only has to separate a
-    # handful of worktree paths on one machine.
+    # Last resort, and NOT a hash: `cksum` prints a CRC32 checksum, so this
+    # branch yields CRC32 rather than SHA-256. That is acceptable only
+    # because the value is a SEPARATOR for a handful of worktree paths on
+    # one machine, never a digest anything trusts -- CRC32 is trivially
+    # collidable on demand and must not be read as one.
     digest="$(printf '%s' "${input}" | cksum | awk '{printf "%08x", $1}')"
   else
     echo "[integ-lib] FATAL: no shasum / sha256sum / cksum on PATH to derive a lane suffix" >&2
@@ -85,7 +88,23 @@ _integ_lane_hash() {
 }
 
 if [ -z "${INTEG_STACK_SUFFIX:-}" ]; then
-  INTEG_STACK_SUFFIX="$(_integ_lane_hash "$(_integ_lane_root)")"
+  # A command substitution DISCARDS the exit status of what ran inside it,
+  # so `INTEG_STACK_SUFFIX="$(_integ_lane_hash ...)"` would swallow the
+  # no-hasher `return 1` and leave the suffix EMPTY -- which is exactly the
+  # one-shared-un-suffixed-name defect issue #582 closes, silently restored.
+  # (It survived only because every caller happens to run under `set -e`.)
+  # So: capture, CHECK, and refuse to continue rather than export an empty
+  # suffix.
+  _integ_suffix="$(_integ_lane_hash "$(_integ_lane_root)")" || _integ_suffix=""
+  if [ -z "${_integ_suffix}" ]; then
+    unset _integ_suffix
+    echo "[integ-lib] FATAL: could not derive a lane suffix; refusing to fall back to a shared, un-suffixed name (issue #582)" >&2
+    # Sourced (the only supported use): return non-zero from the `source`.
+    # Executed directly: `return` is an error, so fall through to `exit`.
+    return 1 2>/dev/null || exit 1
+  fi
+  INTEG_STACK_SUFFIX="${_integ_suffix}"
+  unset _integ_suffix
 fi
 export INTEG_STACK_SUFFIX
 

--- a/tests/integration/_lib/stack-name.sh
+++ b/tests/integration/_lib/stack-name.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Lane-unique naming for integration fixtures that create real AWS
+# resources (issue #582).
+#
+# `.claude/CLAUDE.md` mandates parallel work in git worktrees under
+# `.claude/worktrees/<branch>/`, and markgate markers are per-worktree so
+# lanes verify concurrently. Every AWS-deploying fixture used to hard-code
+# ONE CloudFormation stack name, so two lanes deployed, read and destroyed
+# THE SAME stack in THE SAME account. All three failure modes were silent:
+# the pre-flight orphan scan mistook a peer's live stack for a leftover,
+# the cleanup trap could `cdk destroy` a peer's stack, and a colliding run
+# could report GREEN having asserted against a peer's resources.
+#
+# The fix is a per-worktree suffix appended to every account-global name a
+# fixture owns. It is derived from the worktree ROOT PATH rather than the
+# branch name: a branch name may contain `/` and other characters that are
+# not legal in a CloudFormation stack name, while the root path is stable
+# for the life of the worktree and unique across worktrees of the same
+# repo.
+#
+# Usage from a fixture's `verify.sh` (before the first name is built):
+#
+#     source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+#     STACK="$(integ_stack_name CdkLocalInvokeAssumeRoleFixture)"
+#
+# The suffix is EXPORTED as `INTEG_STACK_SUFFIX` so the fixture's CDK
+# app (`bin/app.ts`) builds the same names: the app appends it to the stack
+# construct id, so `cdk deploy "${STACK}"`, `cdkl ... "${STACK}/Handler"`
+# and the deployed stack name all agree. An app run WITHOUT the variable
+# set (a bare `cdk synth` by hand) keeps the historical un-suffixed name.
+#
+# The variable name deliberately does NOT start with `CDK`. The aws-cdk CLI
+# is yargs-based with `.env('CDK')`, so it maps EVERY environment variable
+# whose name begins with `CDK` onto a CLI option: an earlier spelling,
+# `CDKL_INTEG_STACK_SUFFIX`, made every `cdk deploy` / `cdk destroy` in
+# every fixture print `Unknown option(s): --lIntegStackSuffix. These will be
+# ignored.` Verified directly -- `CDKL_PROVE_IT=1 cdk doctor` prints
+# `Unknown option(s): --lProveIt`. Here it was only noise, because no real
+# option has that name; a variable whose camelCased tail COLLIDES with a
+# real cdk option would instead change deploy behaviour silently. Keep the
+# `CDK` prefix off any variable a fixture exports into a `cdk` invocation.
+#
+# Pre-setting `INTEG_STACK_SUFFIX` in the environment overrides the
+# derivation — useful for CI, where every job has its own account or its
+# own checkout path, and for this library's own test.
+
+# Absolute directory of THIS file (BASH_SOURCE[0] inside a function is the
+# file the function was DEFINED in, not the caller), resolved once.
+_integ_lib_dir() {
+  ( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd )
+}
+
+# The lane's identity: the git worktree root containing this library.
+# Falls back to the repo root two levels above `tests/integration/_lib`
+# when git is unavailable, which keeps the derivation total.
+_integ_lane_root() {
+  local lib_dir root
+  lib_dir="$(_integ_lib_dir)"
+  if root="$(git -C "${lib_dir}" rev-parse --show-toplevel 2>/dev/null)" && [ -n "${root}" ]; then
+    printf '%s' "${root}"
+    return 0
+  fi
+  ( cd "${lib_dir}/../../.." && pwd )
+}
+
+# 8 lowercase hex characters of the SHA-256 of the lane root. Short on
+# purpose: it is appended to names that have their own length ceilings
+# (a CloudFormation stack name is capped at 128 characters).
+_integ_lane_hash() {
+  local input="$1" digest=""
+  if command -v shasum >/dev/null 2>&1; then
+    digest="$(printf '%s' "${input}" | shasum -a 256 | cut -d' ' -f1)"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest="$(printf '%s' "${input}" | sha256sum | cut -d' ' -f1)"
+  elif command -v cksum >/dev/null 2>&1; then
+    # Last resort: not a cryptographic hash, but it only has to separate a
+    # handful of worktree paths on one machine.
+    digest="$(printf '%s' "${input}" | cksum | awk '{printf "%08x", $1}')"
+  else
+    echo "[integ-lib] FATAL: no shasum / sha256sum / cksum on PATH to derive a lane suffix" >&2
+    return 1
+  fi
+  printf '%s' "${digest}" | cut -c1-8
+}
+
+if [ -z "${INTEG_STACK_SUFFIX:-}" ]; then
+  INTEG_STACK_SUFFIX="$(_integ_lane_hash "$(_integ_lane_root)")"
+fi
+export INTEG_STACK_SUFFIX
+
+# integ_stack_name <base>
+#
+# Appends the lane suffix to a fixture's base stack name. The result stays
+# within CloudFormation's `[A-Za-z][A-Za-z0-9-]*`, max 128 characters: the
+# base already satisfies it and the suffix adds 9 hyphen-plus-hex
+# characters, none of which is the leading character.
+integ_stack_name() {
+  printf '%s-%s' "$1" "${INTEG_STACK_SUFFIX}"
+}
+
+# integ_scoped_name <base>
+#
+# The same suffixing for a non-stack name that is also account-global and
+# therefore also collides between lanes: an SSM parameter path, a
+# CloudFormation export name. Kept separate from `integ_stack_name` so the
+# call site says which kind of name it is building.
+integ_scoped_name() {
+  printf '%s-%s' "$1" "${INTEG_STACK_SUFFIX}"
+}

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -440,14 +440,45 @@ if [ -f "${SKILL}" ]; then
   # of which the recipe itself uses elsewhere.
   code=$(grep -vE '^[[:space:]]*#' "${SKILL}")
 
-  # No `||`-verdict attached to a STACK query. Scoped to lines carrying the
-  # query itself: the SSM / exports / bucket sweeps legitimately end in
-  # `|| echo "... NOT a clean verdict"`, and an earlier draft of this assertion
-  # flagged those -- an over-broad fence is its own kind of wrong answer.
-  case "$(printf '%s\n' "${code}" | grep -E 'aws[[:space:]]+cloudformation' | grep -cE '\|\||&&')" in
+  # JOIN CONTINUATIONS FIRST. The previous two versions of this check grepped
+  # LINES, and both stack scans are backslash continuations -- so a verdict
+  # appended to the continuation line sits on a line with no `aws cloudformation`
+  # and scored zero. Measured: appending `2>/dev/null || echo "(no orphan stack)"`
+  # to the continuation, and restoring an `if/then/else` form with no `||` at
+  # all, were BOTH green against the line-based check.
+  joined=$(printf '%s\n' "${code}" | sed -e :a -e '/\\$/N; s/\\\n//; ta')
+
+  # 1. The scans must EXIST. Round 7 asserted this and the retreat dropped it:
+  #    deleting both blocks outright, leaving the guards and prose, was green --
+  #    a recipe with no scan at all is the purest "clean without looking".
+  scans=$(printf '%s\n' "${joined}" | grep -cE 'aws[[:space:]]+cloudformation[[:space:]]+describe-stacks')
+  if [ "${scans}" -ge 2 ]; then
+    check "run-integ still HAS both stack scans (${scans})" 0
+  else
+    check "run-integ still HAS both stack scans" 1 "found ${scans}, want >= 2 (pre-flight and post-run)"
+  fi
+
+  # 2. No verdict attached to a stack query, on the JOINED command.
+  verdicts=$(printf '%s\n' "${joined}" \
+    | grep -E 'aws[[:space:]]+cloudformation[[:space:]]+describe-stacks' \
+    | grep -cE '\|\||&&')
+  case "${verdicts}" in
     0) check "run-integ's stack scans emit no clean verdict of their own" 0 ;;
     *) check "run-integ's stack scans emit no clean verdict of their own" 1 \
-         "a '|| echo clean' form is back -- that is what produced eight false verdicts" ;;
+         "${verdicts} stack query/queries carry a ||/&& verdict -- that is what produced eight false ones" ;;
+  esac
+
+  # 3. No `2>/dev/null` on a stack query: it sends the clean case and the
+  #    could-not-look case into the same silence, which was instance one's
+  #    mechanism. Unfenced until now, and its rationale comment was deleted
+  #    along with the machinery it described.
+  silenced=$(printf '%s\n' "${joined}" \
+    | grep -E 'aws[[:space:]]+cloudformation[[:space:]]+describe-stacks' \
+    | grep -cE '2>[[:space:]]*/dev/null')
+  case "${silenced}" in
+    0) check "run-integ's stack scans do not silence stderr" 0 ;;
+    *) check "run-integ's stack scans do not silence stderr" 1 \
+         "${silenced} stack query/queries discard stderr, which is how the clean and could-not-look cases became indistinguishable" ;;
   esac
 
   # No stderr phrase-matching, in either quote style.

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -417,7 +417,7 @@ if [ -f "${SKILL}" ]; then
   # missed `local-invoke-assume-role`, which deploys a stack holding an IAM
   # role. Pin that the skill DERIVES the set rather than globbing it, and that
   # the fixture both globs missed is reachable by the derivation.
-  case "$(grep -c "grep -ln 'stack-name.sh' tests/integration/\*/verify.sh" "${SKILL}")" in
+  case "$(grep -c 'owners=\$(grep -lE' "${SKILL}")" in
     0) check "run-integ derives the AWS fixture set instead of globbing it" 1 "no derivation command in the skill" ;;
     *) check "run-integ derives the AWS fixture set instead of globbing it" 0 ;;
   esac
@@ -428,16 +428,35 @@ if [ -f "${SKILL}" ]; then
       "it no longer sources the lane library, so the derived set would skip it"
   fi
 
-  # Every failure mode of `describe-stacks` -- expired token, AccessDenied,
-  # throttling, an empty STACK -- lands in the `||` branch of
-  # `2>/dev/null && ... || echo clean`, printing a CLEAN verdict. Measured: bad
-  # credentials exit 254 and the naive form reports no orphan. Step 9 turns that
-  # into a fresh `integ` marker.
-  case "$(grep -c '2>/dev/null && echo' "${SKILL}")" in
-    0) check "run-integ's stack scans do not map every failure to clean" 0 ;;
-    *) check "run-integ's stack scans do not map every failure to clean" 1 \
-         "a bare 2>/dev/null && ... || echo-clean form is back" ;;
+  # BIJECTION, not literal spellings. The previous version grepped for one
+  # exact bad form, and three equivalent spellings of the defect scored zero
+  # while restoring it (`>/dev/null 2>&1 && echo ... || echo clean` -- which is
+  # what this repo's own fixtures use -- `2> /dev/null && ...`, and a line-split
+  # `&&`). Adding a FOURTH unguarded query was green too.
+  #
+  # So assert the property instead: every CloudFormation query in the skill
+  # must sit inside an `if <var>=$(...)` capture, whose else-branch is the loud
+  # non-verdict. Counting both sides makes an unguarded addition fail.
+  cfn_queries=$(grep -cE 'aws cloudformation (list-stacks|describe-stacks)' "${SKILL}")
+  guarded=$(grep -cE '^[[:space:]]*if [a-z_]+=\$\(aws cloudformation (list-stacks|describe-stacks)' "${SKILL}")
+  if [ "${cfn_queries}" -gt 0 ] && [ "${cfn_queries}" -eq "${guarded}" ]; then
+    check "every CloudFormation query in run-integ is rc-guarded (${guarded}/${cfn_queries})" 0
+  else
+    check "every CloudFormation query in run-integ is rc-guarded" 1 \
+      "${guarded} guarded of ${cfn_queries} present -- an unguarded query can report a false clean"
+  fi
+
+  # And the phrase-match must not come back: `grep -q 'does not exist'` also
+  # matches botocore's `The source_profile "x" ... does not exist`, an
+  # InvalidConfigError raised BEFORE any network call -- so a broken SSO or
+  # role-chaining profile printed a CLEAN verdict. Measured against awscli
+  # 2.36.19. rc alone is strictly stronger than classifying stderr.
+  case "$(grep -vE '^[[:space:]]*#' "${SKILL}" | grep -cE "grep -[a-zA-Z]* *[\"']does not exist")" in
+    0) check "run-integ does not classify a stack scan by matching stderr" 0 ;;
+    *) check "run-integ does not classify a stack scan by matching stderr" 1 \
+         "a 'does not exist' phrase match is back; it fires on credential-config errors too" ;;
   esac
+
 else
   check "run-integ SKILL.md is present to check" 1 "not found at ${SKILL}"
 fi

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -1,18 +1,41 @@
 #!/usr/bin/env bash
-# Smoke test for tests/integration/_lib/stack-name.sh (issue #582).
+# Smoke test for tests/integration/_lib/stack-name.sh and stack-name.ts
+# (issue #582).
 #
 # What it pins, in the order the failure would hurt:
 #
-#   1. Every fixture that runs `cdk deploy` SOURCES the library and builds
-#      its stack name through it. A new AWS-deploying fixture that
-#      hard-codes a name reintroduces the exact defect this closes, and
-#      nothing else in the repo would notice.
-#   2. The base name in a fixture's `verify.sh` matches the base name in
-#      its `bin/app.ts`. They are two copies of one string: if they drift,
-#      `cdk deploy "${STACK}"` asks for a stack the app never synthesized.
-#   3. The suffix is stable within one worktree, differs between
-#      worktrees, and every name it produces is still a legal
-#      CloudFormation stack name (`[A-Za-z][A-Za-z0-9-]*`, max 128).
+#   1. Every fixture that DEPLOYS to AWS sources the library and builds its
+#      stack name through it. A new AWS-deploying fixture that hard-codes a
+#      name reintroduces the exact defect this closes, and nothing else in
+#      the repo would notice.
+#   2. The base name in a fixture's `verify.sh` matches the base name in its
+#      `bin/app.ts`, and the SCOPED names (SSM parameter paths,
+#      CloudFormation export names) match between `verify.sh` and
+#      `bin/*.ts` + `lib/*.ts`. Each pair is two copies of one string: if
+#      they drift, `cdk deploy "${STACK}"` asks for a stack the app never
+#      synthesized, or the fixture reads a parameter nothing created.
+#   3. No deploying fixture leaves an account-global `cdkl` name as a BARE
+#      literal -- that is the cross-lane collision itself, not a drift
+#      between two spellings of it.
+#   4. The suffix is stable within one worktree, differs between worktrees,
+#      and every name it produces is still a legal CloudFormation stack name
+#      (`[A-Za-z][A-Za-z0-9-]*`, max 128).
+#   5. The TypeScript half is EXECUTED, not merely grepped, and the shell
+#      half refuses to hand back an empty suffix when no hasher exists.
+#
+# Two properties of this file are load-bearing and easy to lose:
+#
+#   * The fixture-derived cases must not be able to go VACUOUS. The list is
+#     derived by grepping for a deploy command, so a predicate that stops
+#     matching silently deletes most of the suite while it still prints
+#     `fail: 0`. Hence the population floor and the non-empty guards below.
+#   * A grep-only agreement check cannot see a wrong IMPLEMENTATION. Both
+#     function bodies of `stack-name.ts` were once replaceable with
+#     `return base;` -- restoring the one-shared-stack defect for every
+#     fixture -- with the suite still fully green. Hence section 5.
+#
+# Must stay green under macOS system bash 3.2 as well as modern bash: no
+# `${var,,}`, no associative arrays.
 #
 # Run: bash tests/integration/_lib/stack-name.test.sh
 set -u
@@ -20,6 +43,7 @@ set -u
 LIB_DIR=$(cd "$(dirname "$0")" && pwd)
 INTEG_DIR=$(cd "${LIB_DIR}/.." && pwd)
 LIB="${LIB_DIR}/stack-name.sh"
+TS="${LIB_DIR}/stack-name.ts"
 pass=0
 fail=0
 
@@ -43,20 +67,52 @@ trap 'rm -rf "$TMP"' EXIT INT TERM
 # ---------------------------------------------------------------- 1 + 2
 # Structural: the fixtures and the library agree.
 
-deploying=$(grep -l 'cdk deploy' "${INTEG_DIR}"/*/verify.sh)
-for f in ${deploying}; do
-  name=$(basename "$(dirname "$f")")
+# Which fixtures deploy to AWS. The predicate must survive an intervening
+# flag: a fixture running `cdk --app "npx tsx bin/app.ts" deploy ...` is
+# every bit as much a deployer as one running the bare `cdk deploy`, and a
+# literal `'cdk deploy'` grep generates NO cases for it -- so the exact
+# regression this file exists to catch would walk straight past it while
+# the suite still reported `fail: 0`.
+#
+# `cdk` is matched as a WORD: without the leading boundary, `[^;&|]*`
+# lets `cdkl` in a header comment such as
+# `# verify.sh -- cdkl start-alb ... (no AWS deploy)` run all the way to
+# the word `deploy` and pull five non-deploying fixtures in.
+DEPLOY_RE='(^|[^[:alnum:]_])(cdk[^;&|]*[[:space:]]deploy|aws[[:space:]]+cloudformation[[:space:]]+(deploy|create-stack))([[:space:]]|$)'
+# The floor is the count as of issue #582. It may only ever be RAISED: a
+# drop means the predicate stopped matching, not that fixtures vanished.
+DEPLOYING_FLOOR=12
+
+deploying=$(grep -lE "${DEPLOY_RE}" "${INTEG_DIR}"/*/verify.sh)
+deploying_count=$(printf '%s\n' "${deploying}" | grep -c '.')
+
+if [ "${deploying_count}" -ge "${DEPLOYING_FLOOR}" ]; then
+  check "the deploying-fixture population is intact (${deploying_count} >= ${DEPLOYING_FLOOR})" 0
+else
+  check "the deploying-fixture population is intact" 1 \
+    "matched ${deploying_count} verify.sh, expected >= ${DEPLOYING_FLOOR}; the detection predicate has gone stale and most of this suite is no longer generated"
+fi
+
+# `while read` rather than `for f in ${deploying}`: an unquoted expansion
+# word-splits a worktree path containing a space.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  dir=$(dirname "$f")
+  name=$(basename "${dir}")
+
   if grep -q '_lib/stack-name.sh' "$f"; then
     check "${name}: verify.sh sources the shared library" 0
   else
     check "${name}: verify.sh sources the shared library" 1 "no source line"
   fi
 
-  # Base names, in file order, from both copies.
-  sh_bases=$(grep -oE 'integ_stack_name [A-Za-z][A-Za-z0-9-]*' "$f" \
-    | awk '{print $2}' | sort)
-  ts_bases=$(grep -ohE "integStackName\('[A-Za-z][A-Za-z0-9-]*'\)" "$(dirname "$f")"/bin/*.ts \
-    | sed -E "s/integStackName\('([^']*)'\)/\1/" | sort)
+  # Base stack names, from both copies. The base may be written quoted or
+  # bare -- `integ_stack_name "Base"` is correct shell, and demanding the
+  # bare spelling made it fail with a misleading "none found".
+  sh_bases=$(grep -oE "integ_stack_name [\"']?[A-Za-z][A-Za-z0-9-]*" "$f" \
+    | sed -E "s/^integ_stack_name [\"']?//" | sort -u)
+  ts_bases=$(grep -ohE "integStackName\('[A-Za-z][A-Za-z0-9-]*'\)" "${dir}"/bin/*.ts \
+    | sed -E "s/integStackName\('([^']*)'\)/\1/" | sort -u)
   if [ -z "${sh_bases}" ]; then
     check "${name}: verify.sh builds its stack name via integ_stack_name" 1 "none found"
   elif [ "${sh_bases}" = "${ts_bases}" ]; then
@@ -65,7 +121,49 @@ for f in ${deploying}; do
     check "${name}: verify.sh and bin/app.ts agree on the base name(s)" 1 \
       "sh=[$(echo "${sh_bases}" | tr '\n' ' ')] ts=[$(echo "${ts_bases}" | tr '\n' ' ')]"
   fi
-done
+
+  # SCOPED names -- SSM parameter paths and CloudFormation export names.
+  # Same two-copies-of-one-string problem as the stack name, and previously
+  # unguarded in both directions. Read from bin/ AND lib/: unlike the stack
+  # name (always constructed in bin/app.ts), a scoped name is usually
+  # declared beside the construct that owns it, in lib/.
+  sh_scoped=$(grep -oE "integ_scoped_name [\"']?[/A-Za-z][A-Za-z0-9/_.-]*" "$f" \
+    | sed -E "s/^integ_scoped_name [\"']?//" | sort -u)
+  ts_scoped=$(cat "${dir}"/bin/*.ts "${dir}"/lib/*.ts 2>/dev/null \
+    | grep -oE "integScopedName\('[^']*'\)" \
+    | sed -E "s/integScopedName\('([^']*)'\)/\1/" | sort -u)
+  if [ -z "${sh_scoped}" ]; then
+    # Legitimate: a fixture whose scoped names live only in the CDK app
+    # (nothing in verify.sh names them). The bare-literal check below is
+    # what covers that case.
+    check "${name}: verify.sh names no scoped name (app-side only)" 0
+  else
+    scoped_missing=""
+    while IFS= read -r b; do
+      [ -n "$b" ] || continue
+      printf '%s\n' "${ts_scoped}" | grep -Fxq -- "$b" || scoped_missing="${scoped_missing} ${b}"
+    done <<<"${sh_scoped}"
+    if [ -z "${scoped_missing}" ]; then
+      check "${name}: verify.sh and bin|lib/*.ts agree on the scoped name(s)" 0
+    else
+      check "${name}: verify.sh and bin|lib/*.ts agree on the scoped name(s)" 1 \
+        "in verify.sh but not in the app:${scoped_missing}; app has [$(echo "${ts_scoped}" | tr '\n' ' ')]"
+    fi
+  fi
+
+  # No account-global name may be a BARE literal. Drift between two
+  # spellings is what the check above catches; this catches the collision
+  # itself -- an SSM path or export name reverted to a plain string, which
+  # every lane in the account would then create under one name.
+  bare=$(grep -rnE "'/?cdkl-[A-Za-z0-9/_.-]*'" "${dir}"/bin "${dir}"/lib 2>/dev/null \
+    | grep -v 'integScopedName(' || true)
+  if [ -z "${bare}" ]; then
+    check "${name}: no bare account-global 'cdkl-*' literal in the app" 0
+  else
+    check "${name}: no bare account-global 'cdkl-*' literal in the app" 1 \
+      "$(echo "${bare}" | tr '\n' ' ')"
+  fi
+done <<<"${deploying}"
 
 # ------------------------------------------------------------------- 3
 # The derivation itself.
@@ -110,6 +208,8 @@ eq "four distinct trees produce four distinct suffixes" "4" "${uniq_count}"
 # Pre-set value wins (CI pin / this test's own forcing).
 forced=$(INTEG_STACK_SUFFIX=deadbeef bash -c "source '${LIB}'; integ_stack_name Base")
 eq "a pre-set INTEG_STACK_SUFFIX is honored" "Base-deadbeef" "${forced}"
+forced_scoped=$(INTEG_STACK_SUFFIX=deadbeef bash -c "source '${LIB}'; integ_scoped_name /cdkl-integ/p")
+eq "a pre-set INTEG_STACK_SUFFIX is honored by integ_scoped_name" "/cdkl-integ/p-deadbeef" "${forced_scoped}"
 
 # The exported variable name must NOT start with `CDK`. The aws-cdk CLI is
 # yargs-based with `.env('CDK')`, so it maps every CDK-prefixed environment
@@ -130,9 +230,122 @@ else
   check "a CDK-free environment still derives an 8-hex suffix" 1 "expected 'Base-<8hex>', got '${clean}'"
 fi
 
+# ------------------------------------------------------------------- 4
+# The hasher fallback chain, including the branch that must REFUSE.
+#
+# `INTEG_STACK_SUFFIX="$(_integ_lane_hash ...)"` discards the function's
+# exit status, so the no-hasher `return 1` used to leave the suffix EMPTY
+# and hand every lane the same un-suffixed name -- the defect itself,
+# restored by the error path. Both branches are driven with a stubbed PATH.
+
+stub_path() { # stub_path <dir> <tool>...
+  local dir="$1" t p
+  shift
+  mkdir -p "${dir}"
+  for t in "$@"; do
+    p=$(command -v "$t" 2>/dev/null) && ln -s "$p" "${dir}/$t" 2>/dev/null
+  done
+}
+# `env` and `bash` are re-execed through the stubbed PATH, so they must be
+# in it too. `shasum` / `sha256sum` are deliberately absent from both.
+STUB_BASE_TOOLS="bash env cut awk dirname basename git sed grep"
+# shellcheck disable=SC2086  # the tool list must word-split
+stub_path "${TMP}/bin-cksum" ${STUB_BASE_TOOLS} cksum
+# shellcheck disable=SC2086
+stub_path "${TMP}/bin-nohash" ${STUB_BASE_TOOLS}
+
+cksum_out=$(env -u INTEG_STACK_SUFFIX PATH="${TMP}/bin-cksum" \
+  bash -c "source '${LIB}'; integ_stack_name Base" 2>/dev/null)
+if [[ "${cksum_out}" =~ ^Base-[0-9a-f]{8}$ ]]; then
+  check "the cksum fallback still yields a non-empty 8-hex suffix" 0
+else
+  check "the cksum fallback still yields a non-empty 8-hex suffix" 1 \
+    "expected 'Base-<8hex>', got '${cksum_out}'"
+fi
+
+env -u INTEG_STACK_SUFFIX PATH="${TMP}/bin-nohash" \
+  bash -c "source '${LIB}'" >/dev/null 2>&1
+nohash_rc=$?
+if [ "${nohash_rc}" -ne 0 ]; then
+  check "with no hasher on PATH, sourcing the library FAILS" 0
+else
+  check "with no hasher on PATH, sourcing the library FAILS" 1 "source returned 0"
+fi
+
+nohash_out=$(env -u INTEG_STACK_SUFFIX PATH="${TMP}/bin-nohash" \
+  bash -c "source '${LIB}'; integ_stack_name Base" 2>/dev/null)
+if [ -z "${nohash_out}" ]; then
+  check "with no hasher on PATH, no un-suffixed name is produced" 0
+else
+  check "with no hasher on PATH, no un-suffixed name is produced" 1 \
+    "expected nothing, got '${nohash_out}' (an empty suffix is the shared-name defect)"
+fi
+
+# ------------------------------------------------------------------- 5
+# The TypeScript half, EXECUTED rather than grepped.
+
+NODE_TS_OPTS=""
+ts_supported=0
+if node --input-type=module -e "await import('file://${TS}');" >/dev/null 2>&1; then
+  ts_supported=1
+elif node --experimental-strip-types --input-type=module -e "await import('file://${TS}');" >/dev/null 2>&1; then
+  ts_supported=1
+  NODE_TS_OPTS="--experimental-strip-types"
+fi
+
+ts_eval() { # ts_eval <suffix|-> <js-expression over the module `m`>
+  # shellcheck disable=SC2086  # NODE_TS_OPTS is "" or exactly one flag
+  if [ "$1" = "-" ]; then
+    env -u INTEG_STACK_SUFFIX node ${NODE_TS_OPTS} --input-type=module -e \
+      "const m = await import('file://${TS}'); process.stdout.write(String($2));"
+  else
+    env "INTEG_STACK_SUFFIX=$1" node ${NODE_TS_OPTS} --input-type=module -e \
+      "const m = await import('file://${TS}'); process.stdout.write(String($2));"
+  fi
+}
+
+if [ "${ts_supported}" -eq 0 ]; then
+  # NOT skipped: skipping is how this half went uncovered in the first
+  # place. `.node-version` pins 24, where type stripping is native.
+  for c in \
+    "integStackName appends a pre-set suffix" \
+    "integScopedName appends a pre-set suffix" \
+    "integStackName falls back to the bare base" \
+    "integScopedName falls back to the bare base" \
+    "the TS and shell halves build the same name"; do
+    check "${c}" 1 "node cannot run ${TS}: needs Node >= 22.6 (type stripping); .node-version pins 24"
+  done
+else
+  eq "integStackName appends a pre-set suffix" \
+     "B-deadbeef" "$(ts_eval deadbeef "m.integStackName('B')")"
+  eq "integScopedName appends a pre-set suffix" \
+     "/cdkl-integ/p-deadbeef" "$(ts_eval deadbeef "m.integScopedName('/cdkl-integ/p')")"
+  # The documented un-suffixed fallback: a bare `cdk synth` by hand keeps
+  # the historical name.
+  eq "integStackName falls back to the bare base" \
+     "B" "$(ts_eval - "m.integStackName('B')")"
+  eq "integScopedName falls back to the bare base" \
+     "/cdkl-integ/p" "$(ts_eval - "m.integScopedName('/cdkl-integ/p')")"
+  # The two halves are two implementations of one rule; a fixture is
+  # correct only while they agree.
+  eq "the TS and shell halves build the same name" \
+     "$(INTEG_STACK_SUFFIX=deadbeef bash -c "source '${LIB}'; integ_stack_name Base")" \
+     "$(ts_eval deadbeef "m.integStackName('Base')")"
+fi
+
+# ------------------------------------------------------------------- 6
 # Every real fixture name stays a legal CloudFormation stack name.
-all_bases=$(grep -ohE 'integ_stack_name [A-Za-z][A-Za-z0-9-]*' "${INTEG_DIR}"/*/verify.sh \
-  | awk '{print $2}' | sort -u)
+
+all_bases=$(grep -ohE "integ_stack_name [\"']?[A-Za-z][A-Za-z0-9-]*" "${INTEG_DIR}"/*/verify.sh \
+  | sed -E "s/^integ_stack_name [\"']?//" | sort -u)
+if [ -n "${all_bases}" ]; then
+  check "the CFN-legality check has base names to check" 0
+else
+  # Without this the loop below iterates zero times and reports
+  # `longest=0` as a pass -- a vacuous green.
+  check "the CFN-legality check has base names to check" 1 \
+    "no integ_stack_name call sites found under ${INTEG_DIR}/*/verify.sh"
+fi
 bad=""
 longest=0
 while IFS= read -r base; do
@@ -142,8 +355,10 @@ while IFS= read -r base; do
   [[ "${full}" =~ ^[A-Za-z][A-Za-z0-9-]*$ ]] || bad="${bad} ${full}(charset)"
   [ "${#full}" -le 128 ] || bad="${bad} ${full}(len=${#full})"
 done <<<"${all_bases}"
-if [ -z "${bad}" ]; then
+if [ -n "${all_bases}" ] && [ -z "${bad}" ]; then
   check "every suffixed stack name is CFN-legal and <= 128 chars (longest=${longest})" 0
+elif [ -z "${all_bases}" ]; then
+  check "every suffixed stack name is CFN-legal and <= 128 chars" 1 "nothing to check"
 else
   check "every suffixed stack name is CFN-legal and <= 128 chars" 1 "${bad}"
 fi

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -363,5 +363,36 @@ else
   check "every suffixed stack name is CFN-legal and <= 128 chars" 1 "${bad}"
 fi
 
+# ---------------------------------------------------------------------------
+# 6. `/run-integ`'s orphan sweep stays lane-scoped.
+#
+# The skill tells an agent to DELETE what these queries return, under the
+# heading "never end the run with orphan AWS resources". That makes an
+# unfiltered query actively harmful rather than merely noisy, and it went wrong
+# twice while this change was being written: first a bare `/cdkl` prefix that
+# listed every LANE's parameters, then a suffix filter with no guard, which
+# degrades to `contains(Name,'-')` -- every hyphenated parameter in the ACCOUNT
+# -- the moment the relative `source` fails. Nothing else in the repo reads that
+# file, so a future edit could drop either half silently.
+SKILL="${INTEG_DIR}/../../.claude/skills/run-integ/SKILL.md"
+if [ -f "${SKILL}" ]; then
+  sweep=$(sed -n '/describe-parameters/,/list-exports/p' "${SKILL}")
+  case "${sweep}" in
+    *'INTEG_STACK_SUFFIX'*) check "run-integ's SSM sweep filters by the lane suffix" 0 ;;
+    *) check "run-integ's SSM sweep filters by the lane suffix" 1 "no INTEG_STACK_SUFFIX in the query block" ;;
+  esac
+  case "${sweep}" in
+    *"starts_with(Name,'/cdkl')"*) check "run-integ's SSM sweep keeps the cdkl anchor" 0 ;;
+    *) check "run-integ's SSM sweep keeps the cdkl anchor" 1 "no starts_with(Name,'/cdkl') anchor" ;;
+  esac
+  # The guard is what stops an unresolved suffix becoming an account-wide list.
+  case "$(grep -c 'INTEG_STACK_SUFFIX:?' "${SKILL}")" in
+    0) check "run-integ aborts when the lane suffix is unresolved" 1 "no \${INTEG_STACK_SUFFIX:?...} guard" ;;
+    *) check "run-integ aborts when the lane suffix is unresolved" 0 ;;
+  esac
+else
+  check "run-integ SKILL.md is present to check" 1 "not found at ${SKILL}"
+fi
+
 printf '\npass: %d  fail: %d\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -376,20 +376,41 @@ fi
 # file, so a future edit could drop either half silently.
 SKILL="${INTEG_DIR}/../../.claude/skills/run-integ/SKILL.md"
 if [ -f "${SKILL}" ]; then
-  sweep=$(sed -n '/describe-parameters/,/list-exports/p' "${SKILL}")
-  case "${sweep}" in
-    *'INTEG_STACK_SUFFIX'*) check "run-integ's SSM sweep filters by the lane suffix" 0 ;;
-    *) check "run-integ's SSM sweep filters by the lane suffix" 1 "no INTEG_STACK_SUFFIX in the query block" ;;
-  esac
-  case "${sweep}" in
-    *"starts_with(Name,'/cdkl')"*) check "run-integ's SSM sweep keeps the cdkl anchor" 0 ;;
-    *) check "run-integ's SSM sweep keeps the cdkl anchor" 1 "no starts_with(Name,'/cdkl') anchor" ;;
-  esac
-  # The guard is what stops an unresolved suffix becoming an account-wide list.
-  case "$(grep -c 'INTEG_STACK_SUFFIX:?' "${SKILL}")" in
-    0) check "run-integ aborts when the lane suffix is unresolved" 1 "no \${INTEG_STACK_SUFFIX:?...} guard" ;;
-    *) check "run-integ aborts when the lane suffix is unresolved" 0 ;;
-  esac
+  # Assert per QUERY LINE, not over a sed range. The first version of this
+  # fence extracted `/describe-parameters/,/list-exports/p`, whose range ENDS
+  # on the `list-exports \` line -- before its own `--query`. Deleting the
+  # exports filter (restoring the cross-lane defect, on the output whose prose
+  # says it matters MORE) left the suite at 73/0.
+  ssm_q=$(grep -F "Parameters[?starts_with(Name,'/cdkl')" "${SKILL}")
+  exp_q=$(grep -F "Exports[?starts_with(Name,'cdkl')" "${SKILL}")
+
+  for pair in "SSM:${ssm_q}" "exports:${exp_q}"; do
+    label="${pair%%:*}"
+    query="${pair#*:}"
+    if [ -z "${query}" ]; then
+      check "run-integ's ${label} sweep keeps the cdkl anchor" 1 "no anchored query line found"
+      check "run-integ's ${label} sweep filters by the lane suffix" 1 "no anchored query line found"
+      continue
+    fi
+    check "run-integ's ${label} sweep keeps the cdkl anchor" 0
+    case "${query}" in
+      *"contains(Name,'-\${INTEG_STACK_SUFFIX}')"*)
+        check "run-integ's ${label} sweep filters by the lane suffix" 0 ;;
+      *)
+        check "run-integ's ${label} sweep filters by the lane suffix" 1 "no suffix filter in the ${label} query" ;;
+    esac
+  done
+
+  # Structural, not token-presence: the guard must be a real `: "${VAR:?...}"`
+  # statement at the start of a line, so prose merely MENTIONING it does not
+  # satisfy the check. Both the pre-flight scan and the post-run sweep need it.
+  guards=$(grep -cE '^[[:space:]]*: "\$\{INTEG_STACK_SUFFIX:\?' "${SKILL}")
+  if [ "${guards}" -ge 3 ]; then
+    check "run-integ aborts when the lane suffix is unresolved (${guards} guards)" 0
+  else
+    check "run-integ aborts when the lane suffix is unresolved" 1 \
+      "expected >= 3 guard statements (pre-flight stack, post-run stack, sweeps), found ${guards}"
+  fi
 else
   check "run-integ SKILL.md is present to check" 1 "not found at ${SKILL}"
 fi

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -428,34 +428,73 @@ if [ -f "${SKILL}" ]; then
       "it no longer sources the lane library, so the derived set would skip it"
   fi
 
-  # BIJECTION, not literal spellings. The previous version grepped for one
-  # exact bad form, and three equivalent spellings of the defect scored zero
-  # while restoring it (`>/dev/null 2>&1 && echo ... || echo clean` -- which is
-  # what this repo's own fixtures use -- `2> /dev/null && ...`, and a line-split
-  # `&&`). Adding a FOURTH unguarded query was green too.
+  # The recipe no longer EMITS a verdict for the stack scans -- it prints the
+  # raw `describe-stacks` result and tells the reader to judge. That is the
+  # retreat after eight instances of a recipe claiming "clean" while not having
+  # looked, so what the fence pins is the ABSENCE of a claim, which is a
+  # property rather than a spelling.
   #
-  # So assert the property instead: every CloudFormation query in the skill
-  # must sit inside an `if <var>=$(...)` capture, whose else-branch is the loud
-  # non-verdict. Counting both sides makes an unguarded addition fail.
-  cfn_queries=$(grep -cE 'aws cloudformation (list-stacks|describe-stacks)' "${SKILL}")
-  guarded=$(grep -cE '^[[:space:]]*if [a-z_]+=\$\(aws cloudformation (list-stacks|describe-stacks)' "${SKILL}")
-  if [ "${cfn_queries}" -gt 0 ] && [ "${cfn_queries}" -eq "${guarded}" ]; then
-    check "every CloudFormation query in run-integ is rc-guarded (${guarded}/${cfn_queries})" 0
-  else
-    check "every CloudFormation query in run-integ is rc-guarded" 1 \
-      "${guarded} guarded of ${cfn_queries} present -- an unguarded query can report a false clean"
-  fi
+  # Counted with `grep -c` on occurrences, over non-comment lines, with
+  # `[[:space:]]+` between words -- the previous line-grep version was defeated
+  # by a two-space `aws  cloudformation` and by a backslash continuation, both
+  # of which the recipe itself uses elsewhere.
+  code=$(grep -vE '^[[:space:]]*#' "${SKILL}")
 
-  # And the phrase-match must not come back: `grep -q 'does not exist'` also
-  # matches botocore's `The source_profile "x" ... does not exist`, an
-  # InvalidConfigError raised BEFORE any network call -- so a broken SSO or
-  # role-chaining profile printed a CLEAN verdict. Measured against awscli
-  # 2.36.19. rc alone is strictly stronger than classifying stderr.
-  case "$(grep -vE '^[[:space:]]*#' "${SKILL}" | grep -cE "grep -[a-zA-Z]* *[\"']does not exist")" in
+  # No `||`-verdict attached to a STACK query. Scoped to lines carrying the
+  # query itself: the SSM / exports / bucket sweeps legitimately end in
+  # `|| echo "... NOT a clean verdict"`, and an earlier draft of this assertion
+  # flagged those -- an over-broad fence is its own kind of wrong answer.
+  case "$(printf '%s\n' "${code}" | grep -E 'aws[[:space:]]+cloudformation' | grep -cE '\|\||&&')" in
+    0) check "run-integ's stack scans emit no clean verdict of their own" 0 ;;
+    *) check "run-integ's stack scans emit no clean verdict of their own" 1 \
+         "a '|| echo clean' form is back -- that is what produced eight false verdicts" ;;
+  esac
+
+  # No stderr phrase-matching, in either quote style.
+  case "$(printf '%s\n' "${code}" | grep -cE "grep -[a-zA-Z]* *[\"']does not exist")" in
     0) check "run-integ does not classify a stack scan by matching stderr" 0 ;;
     *) check "run-integ does not classify a stack scan by matching stderr" 1 \
          "a 'does not exist' phrase match is back; it fires on credential-config errors too" ;;
   esac
+
+  # No `--stack-status-filter`: it hid 16 of 23 statuses, `DELETE_IN_PROGRESS`
+  # -- an interrupted `cdk destroy`, this sweep's own scenario -- among them.
+  case "$(printf '%s\n' "${code}" | grep -c 'stack-status-filter')" in
+    0) check "run-integ's stack scans do not filter by status" 0 ;;
+    *) check "run-integ's stack scans do not filter by status" 1 \
+         "a --stack-status-filter is back; it hides an orphan in any unlisted status" ;;
+  esac
+
+  # Both the suffix AND the resolved name are guarded. The suffix guard alone is
+  # a PROXY: `stack-name.sh` documents pre-setting it in the environment, so it
+  # can be satisfied while `integ_stack_name` is undefined and `STACK` empty.
+  suffix_guards=$(printf '%s\n' "${code}" | grep -cE '^[[:space:]]*: "\$\{INTEG_STACK_SUFFIX:\?')
+  stack_guards=$(printf '%s\n' "${code}" | grep -cE '^[[:space:]]*: "\$\{STACK:\?')
+  if [ "${suffix_guards}" -ge 3 ] && [ "${stack_guards}" -ge 2 ]; then
+    check "run-integ guards the suffix (${suffix_guards}) and the resolved name (${stack_guards})" 0
+  else
+    check "run-integ guards the suffix and the resolved name" 1 \
+      "suffix=${suffix_guards} (want >= 3), stack=${stack_guards} (want >= 2)"
+  fi
+
+  # EXECUTE the derivation predicate rather than asserting its text. The old
+  # check asserted the fixture sources `stack-name.sh`, which is the criterion
+  # the predicate REPLACED -- so gutting the predicate stayed green.
+  pred=$(printf '%s\n' "${code}" | grep -oE "grep -lE '[^']+'" | head -1 | sed "s/^grep -lE '//;s/'\$//")
+  if [ -z "${pred}" ]; then
+    check "run-integ's derivation predicate is extractable and covers every AWS-owning fixture" 1 \
+      "no 'grep -lE' predicate found in the skill"
+  else
+    derived=$(cd "${INTEG_DIR}/.." && grep -lE "${pred}" integration/*/verify.sh 2>/dev/null | sed 's#integration/##;s#/verify.sh##' | sort)
+    want=$( { grep -l 'stack-name.sh' "${INTEG_DIR}"/*/verify.sh; grep -lE 'aws[[:space:]]+s3api[[:space:]]+create-bucket' "${INTEG_DIR}"/*/verify.sh; } \
+            | sed "s#${INTEG_DIR}/##;s#/verify.sh##" | sort -u)
+    missing=$(comm -23 <(printf '%s\n' "${want}") <(printf '%s\n' "${derived}") | tr '\n' ' ')
+    if [ -z "${missing}" ]; then
+      check "run-integ's derivation predicate covers every AWS-owning fixture ($(printf '%s\n' "${derived}" | grep -c .))" 0
+    else
+      check "run-integ's derivation predicate covers every AWS-owning fixture" 1 "misses:${missing}"
+    fi
+  fi
 
 else
   check "run-integ SKILL.md is present to check" 1 "not found at ${SKILL}"

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -448,24 +448,32 @@ if [ -f "${SKILL}" ]; then
   # all, were BOTH green against the line-based check.
   joined=$(printf '%s\n' "${code}" | sed -e :a -e '/\\$/N; s/\\\n//; ta')
 
-  # 1. The scans must EXIST. Round 7 asserted this and the retreat dropped it:
-  #    deleting both blocks outright, leaving the guards and prose, was green --
-  #    a recipe with no scan at all is the purest "clean without looking".
-  scans=$(printf '%s\n' "${joined}" | grep -cE 'aws[[:space:]]+cloudformation[[:space:]]+describe-stacks')
-  if [ "${scans}" -ge 2 ]; then
-    check "run-integ still HAS both stack scans (${scans})" 0
+  # 1. The scans must EXIST -- anchored to a real command at line start, and
+  #    counted PER STEP. Counting the bare token over the whole file was green
+  #    with both scan commands deleted and two PROSE mentions added, and green
+  #    with the post-run scan deleted and the pre-flight one duplicated.
+  scan_re='^[[:space:]]*aws[[:space:]]+cloudformation[[:space:]]+describe-stacks'
+  pre=$(printf '%s\n' "${joined}" | sed -n '1,/^7\. \*\*Verify AWS cleanup/p' | grep -cE "${scan_re}")
+  post=$(printf '%s\n' "${joined}" | sed -n '/^7\. \*\*Verify AWS cleanup/,$p' | grep -cE "${scan_re}")
+  if [ "${pre}" -ge 1 ] && [ "${post}" -ge 1 ]; then
+    check "run-integ has a real stack scan in BOTH steps (pre=${pre} post=${post})" 0
   else
-    check "run-integ still HAS both stack scans" 1 "found ${scans}, want >= 2 (pre-flight and post-run)"
+    check "run-integ has a real stack scan in BOTH steps" 1 \
+      "pre-flight=${pre}, post-run=${post}; each needs >= 1 actual command, not a prose mention"
   fi
 
-  # 2. No verdict attached to a stack query, on the JOINED command.
+  # 2. No verdict attached to a stack query. `||`/`&&` on the joined command,
+  #    AND the `if <query>; then ... else <verdict>` form -- round 7 used that
+  #    one and it carries no `||` at all, so joining continuations closed only
+  #    half of that instance. A previous version of this PR's body claimed both
+  #    were covered; they were not.
   verdicts=$(printf '%s\n' "${joined}" \
     | grep -E 'aws[[:space:]]+cloudformation[[:space:]]+describe-stacks' \
-    | grep -cE '\|\||&&')
+    | grep -cE '\|\||&&|^[[:space:]]*if[[:space:]]')
   case "${verdicts}" in
     0) check "run-integ's stack scans emit no clean verdict of their own" 0 ;;
     *) check "run-integ's stack scans emit no clean verdict of their own" 1 \
-         "${verdicts} stack query/queries carry a ||/&& verdict -- that is what produced eight false ones" ;;
+         "${verdicts} stack query/queries carry a ||/&&/if verdict -- that is what produced nine false ones" ;;
   esac
 
   # 3. No `2>/dev/null` on a stack query: it sends the clean case and the
@@ -507,6 +515,15 @@ if [ -f "${SKILL}" ]; then
     check "run-integ guards the suffix and the resolved name" 1 \
       "suffix=${suffix_guards} (want >= 3), stack=${stack_guards} (want >= 2)"
   fi
+
+  # BOUNDARY, recorded rather than papered over. Checks 2 and 3 read the stack
+  # QUERY's own joined command. A verdict placed further away still escapes:
+  # `[ $? -ne 0 ] && echo clean` on the next line, a blanket echo after `done`,
+  # `case "$out" in *"does not exist"*)`, or the query assembled into a variable
+  # first. Those were each measured green. Fencing them needs a shell parser,
+  # not greps -- which is the argument FOR go-to-k/cdk-local#601 (a real script,
+  # whose failure paths are executed) rather than a reason to grow this file.
+  # What is pinned here is the shape the nine live instances actually took.
 
   # EXECUTE the derivation predicate rather than asserting its text. The old
   # check asserted the fixture sources `stack-name.sh`, which is the criterion

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -516,6 +516,27 @@ if [ -f "${SKILL}" ]; then
       "suffix=${suffix_guards} (want >= 3), stack=${stack_guards} (want >= 2)"
   fi
 
+  # 4. The REMEDIATION shape, not just the scan. Five of the eleven instances
+  #    arrived through the previous fix, and the last one was in the remediation
+  #    -- `cdk destroy` needs app context the recipe's own cwd does not provide,
+  #    and repaired by hand it exits 0 SILENTLY on names the app never
+  #    synthesized. Measured: restoring that line verbatim left this suite at
+  #    84/0, so the fence pinned the scan and nothing else. That was the one
+  #    recurrence channel still open.
+  destroys=$(printf '%s\n' "${joined}" | grep -cE '^[[:space:]]*cdk[[:space:]]+destroy')
+  case "${destroys}" in
+    0) check "run-integ's remediation does not use cdk destroy" 0 ;;
+    *) check "run-integ's remediation does not use cdk destroy" 1 \
+         "${destroys} cdk destroy command(s) -- it needs --app from this cwd, and exits 0 on unmatched names" ;;
+  esac
+  del_pre=$(printf '%s\n' "${joined}" | sed -n '1,/^7\. \*\*Verify AWS cleanup/p' \
+    | grep -cE '^[[:space:]]*aws[[:space:]]+cloudformation[[:space:]]+delete-stack')
+  if [ "${del_pre}" -ge 1 ]; then
+    check "run-integ remediates with delete-stack (${del_pre} in the pre-flight step)" 0
+  else
+    check "run-integ remediates with delete-stack" 1 "no delete-stack command found in step 4"
+  fi
+
   # BOUNDARY, recorded rather than papered over. Checks 2 and 3 read the stack
   # QUERY's own joined command. A verdict placed further away still escapes:
   # `[ $? -ne 0 ] && echo clean` on the next line, a blanket echo after `done`,

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -411,6 +411,33 @@ if [ -f "${SKILL}" ]; then
     check "run-integ aborts when the lane suffix is unresolved" 1 \
       "expected >= 3 guard statements (pre-flight stack, post-run stack, sweeps), found ${guards}"
   fi
+
+  # The gate on steps 4 and 7 has silently excluded a resource-owning fixture
+  # TWICE: `*-from-cfn-stack` missed three, and the widened `*-from-cfn*` still
+  # missed `local-invoke-assume-role`, which deploys a stack holding an IAM
+  # role. Pin that the skill DERIVES the set rather than globbing it, and that
+  # the fixture both globs missed is reachable by the derivation.
+  case "$(grep -c "grep -ln 'stack-name.sh' tests/integration/\*/verify.sh" "${SKILL}")" in
+    0) check "run-integ derives the AWS fixture set instead of globbing it" 1 "no derivation command in the skill" ;;
+    *) check "run-integ derives the AWS fixture set instead of globbing it" 0 ;;
+  esac
+  if grep -lq 'stack-name.sh' "${INTEG_DIR}/local-invoke-assume-role/verify.sh" 2>/dev/null; then
+    check "the derivation reaches local-invoke-assume-role (both globs missed it)" 0
+  else
+    check "the derivation reaches local-invoke-assume-role (both globs missed it)" 1 \
+      "it no longer sources the lane library, so the derived set would skip it"
+  fi
+
+  # Every failure mode of `describe-stacks` -- expired token, AccessDenied,
+  # throttling, an empty STACK -- lands in the `||` branch of
+  # `2>/dev/null && ... || echo clean`, printing a CLEAN verdict. Measured: bad
+  # credentials exit 254 and the naive form reports no orphan. Step 9 turns that
+  # into a fresh `integ` marker.
+  case "$(grep -c '2>/dev/null && echo' "${SKILL}")" in
+    0) check "run-integ's stack scans do not map every failure to clean" 0 ;;
+    *) check "run-integ's stack scans do not map every failure to clean" 1 \
+         "a bare 2>/dev/null && ... || echo-clean form is back" ;;
+  esac
 else
   check "run-integ SKILL.md is present to check" 1 "not found at ${SKILL}"
 fi

--- a/tests/integration/_lib/stack-name.test.sh
+++ b/tests/integration/_lib/stack-name.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Smoke test for tests/integration/_lib/stack-name.sh (issue #582).
+#
+# What it pins, in the order the failure would hurt:
+#
+#   1. Every fixture that runs `cdk deploy` SOURCES the library and builds
+#      its stack name through it. A new AWS-deploying fixture that
+#      hard-codes a name reintroduces the exact defect this closes, and
+#      nothing else in the repo would notice.
+#   2. The base name in a fixture's `verify.sh` matches the base name in
+#      its `bin/app.ts`. They are two copies of one string: if they drift,
+#      `cdk deploy "${STACK}"` asks for a stack the app never synthesized.
+#   3. The suffix is stable within one worktree, differs between
+#      worktrees, and every name it produces is still a legal
+#      CloudFormation stack name (`[A-Za-z][A-Za-z0-9-]*`, max 128).
+#
+# Run: bash tests/integration/_lib/stack-name.test.sh
+set -u
+
+LIB_DIR=$(cd "$(dirname "$0")" && pwd)
+INTEG_DIR=$(cd "${LIB_DIR}/.." && pwd)
+LIB="${LIB_DIR}/stack-name.sh"
+pass=0
+fail=0
+
+check() { # check <name> <ok:0|1> [detail]
+  if [ "$2" -eq 0 ]; then
+    pass=$((pass + 1))
+    printf 'ok   %s\n' "$1"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s%s\n' "$1" "${3:+ -- $3}"
+  fi
+}
+
+eq() { # eq <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then check "$1" 0; else check "$1" 1 "expected '$2', got '$3'"; fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+# ---------------------------------------------------------------- 1 + 2
+# Structural: the fixtures and the library agree.
+
+deploying=$(grep -l 'cdk deploy' "${INTEG_DIR}"/*/verify.sh)
+for f in ${deploying}; do
+  name=$(basename "$(dirname "$f")")
+  if grep -q '_lib/stack-name.sh' "$f"; then
+    check "${name}: verify.sh sources the shared library" 0
+  else
+    check "${name}: verify.sh sources the shared library" 1 "no source line"
+  fi
+
+  # Base names, in file order, from both copies.
+  sh_bases=$(grep -oE 'integ_stack_name [A-Za-z][A-Za-z0-9-]*' "$f" \
+    | awk '{print $2}' | sort)
+  ts_bases=$(grep -ohE "integStackName\('[A-Za-z][A-Za-z0-9-]*'\)" "$(dirname "$f")"/bin/*.ts \
+    | sed -E "s/integStackName\('([^']*)'\)/\1/" | sort)
+  if [ -z "${sh_bases}" ]; then
+    check "${name}: verify.sh builds its stack name via integ_stack_name" 1 "none found"
+  elif [ "${sh_bases}" = "${ts_bases}" ]; then
+    check "${name}: verify.sh and bin/app.ts agree on the base name(s)" 0
+  else
+    check "${name}: verify.sh and bin/app.ts agree on the base name(s)" 1 \
+      "sh=[$(echo "${sh_bases}" | tr '\n' ' ')] ts=[$(echo "${ts_bases}" | tr '\n' ' ')]"
+  fi
+done
+
+# ------------------------------------------------------------------- 3
+# The derivation itself.
+
+# shellcheck source=./stack-name.sh
+source "${LIB}"
+
+case "${INTEG_STACK_SUFFIX}" in
+  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+    check "suffix is 8 lowercase hex characters" 0 ;;
+  *)
+    check "suffix is 8 lowercase hex characters" 1 "got '${INTEG_STACK_SUFFIX}'" ;;
+esac
+
+eq "integ_stack_name is stable within a process" \
+   "$(integ_stack_name Base)" "$(integ_stack_name Base)"
+
+# Stable across separate processes in the same tree.
+a=$(env -u INTEG_STACK_SUFFIX bash -c "source '${LIB}'; printf '%s' \"\${INTEG_STACK_SUFFIX}\"")
+b=$(env -u INTEG_STACK_SUFFIX bash -c "source '${LIB}'; printf '%s' \"\${INTEG_STACK_SUFFIX}\"")
+eq "suffix is stable across processes in one worktree" "$a" "$b"
+
+# Distinct across worktrees: three separate trees, each with its own copy
+# of the library at the same relative path.
+declare -a suffixes=()
+for lane in lane-one lane-two lane-three; do
+  root="${TMP}/${lane}"
+  mkdir -p "${root}/tests/integration/_lib"
+  cp "${LIB}" "${root}/tests/integration/_lib/stack-name.sh"
+  git -C "${root}" init -q 2>/dev/null || true
+  s=$(env -u INTEG_STACK_SUFFIX bash -c \
+      "source '${root}/tests/integration/_lib/stack-name.sh'; printf '%s' \"\${INTEG_STACK_SUFFIX}\"")
+  suffixes+=("$s")
+  # And stable when re-derived from that same tree.
+  s2=$(env -u INTEG_STACK_SUFFIX bash -c \
+      "source '${root}/tests/integration/_lib/stack-name.sh'; printf '%s' \"\${INTEG_STACK_SUFFIX}\"")
+  eq "${lane}: suffix is stable across repeated derivations" "$s" "$s2"
+done
+uniq_count=$(printf '%s\n' "${suffixes[@]}" "${INTEG_STACK_SUFFIX}" | sort -u | wc -l | tr -d ' ')
+eq "four distinct trees produce four distinct suffixes" "4" "${uniq_count}"
+
+# Pre-set value wins (CI pin / this test's own forcing).
+forced=$(INTEG_STACK_SUFFIX=deadbeef bash -c "source '${LIB}'; integ_stack_name Base")
+eq "a pre-set INTEG_STACK_SUFFIX is honored" "Base-deadbeef" "${forced}"
+
+# The exported variable name must NOT start with `CDK`. The aws-cdk CLI is
+# yargs-based with `.env('CDK')`, so it maps every CDK-prefixed environment
+# variable onto a CLI option: the earlier `CDKL_INTEG_STACK_SUFFIX` spelling
+# made every `cdk deploy` / `cdk destroy` print
+# `Unknown option(s): --lIntegStackSuffix. These will be ignored.`
+# Noise here, but a tail that camelCases onto a REAL cdk option would change
+# deploy behaviour silently.
+exported=$(bash -c "source '${LIB}'; compgen -e | grep -c '^CDK' || true")
+eq "the library exports no CDK-prefixed variable" "0" "${exported}"
+
+# ...and the derivation still works when the caller's environment is clean of
+# CDK-prefixed variables, which is what the fixtures actually run under.
+clean=$(env -i PATH="$PATH" HOME="$HOME" bash -c "source '${LIB}'; integ_stack_name Base")
+if [[ "${clean}" =~ ^Base-[0-9a-f]{8}$ ]]; then
+  check "a CDK-free environment still derives an 8-hex suffix" 0
+else
+  check "a CDK-free environment still derives an 8-hex suffix" 1 "expected 'Base-<8hex>', got '${clean}'"
+fi
+
+# Every real fixture name stays a legal CloudFormation stack name.
+all_bases=$(grep -ohE 'integ_stack_name [A-Za-z][A-Za-z0-9-]*' "${INTEG_DIR}"/*/verify.sh \
+  | awk '{print $2}' | sort -u)
+bad=""
+longest=0
+while IFS= read -r base; do
+  [ -n "${base}" ] || continue
+  full="$(integ_stack_name "${base}")"
+  [ "${#full}" -gt "${longest}" ] && longest=${#full}
+  [[ "${full}" =~ ^[A-Za-z][A-Za-z0-9-]*$ ]] || bad="${bad} ${full}(charset)"
+  [ "${#full}" -le 128 ] || bad="${bad} ${full}(len=${#full})"
+done <<<"${all_bases}"
+if [ -z "${bad}" ]; then
+  check "every suffixed stack name is CFN-legal and <= 128 chars (longest=${longest})" 0
+else
+  check "every suffixed stack name is CFN-legal and <= 128 chars" 1 "${bad}"
+fi
+
+printf '\npass: %d  fail: %d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/integration/_lib/stack-name.ts
+++ b/tests/integration/_lib/stack-name.ts
@@ -1,0 +1,31 @@
+/**
+ * Lane-unique naming for integration fixtures (issue #582), app side.
+ *
+ * `tests/integration/_lib/stack-name.sh` derives a per-worktree suffix and
+ * exports it as `INTEG_STACK_SUFFIX` before a fixture's `verify.sh`
+ * builds any name. The CDK app inherits that variable (the toolkit spawns
+ * the app with the full parent environment), so appending it here makes the
+ * synthesized stack name match the one `verify.sh` deploys, scans for and
+ * destroys — and makes `cdkl <Stack>/<Construct>` targets line up too.
+ *
+ * With the variable unset — a bare `cdk synth` run by hand — the historical
+ * un-suffixed name is returned, so nothing outside `verify.sh` changes.
+ *
+ * The shell library is the single place the suffix is DERIVED; this is only
+ * the place it is READ.
+ */
+export function integStackName(base: string): string {
+  const lane = process.env.INTEG_STACK_SUFFIX;
+  return lane ? `${base}-${lane}` : base;
+}
+
+/**
+ * The same suffixing for a non-stack name that is also account-global and so
+ * also collides between lanes: a CloudFormation export name, an SSM
+ * parameter path. Separate from {@link integStackName} so a call site says
+ * which kind of name it is building.
+ */
+export function integScopedName(base: string): string {
+  const lane = process.env.INTEG_STACK_SUFFIX;
+  return lane ? `${base}-${lane}` : base;
+}

--- a/tests/integration/local-invoke-agentcore-from-cfn/bin/app.ts
+++ b/tests/integration/local-invoke-agentcore-from-cfn/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalInvokeAgentCoreFromCfnStack } from '../lib/local-invoke-agentcore-from-cfn-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeAgentCoreFromCfnStack(app, 'CdkLocalInvokeAgentCoreFromCfnFixture', {
+new LocalInvokeAgentCoreFromCfnStack(app, integStackName('CdkLocalInvokeAgentCoreFromCfnFixture'), {
   description: 'Fixture stack for cdkl invoke-agentcore --from-cfn-stack integ test',
 });

--- a/tests/integration/local-invoke-agentcore-from-cfn/lib/local-invoke-agentcore-from-cfn-stack.ts
+++ b/tests/integration/local-invoke-agentcore-from-cfn/lib/local-invoke-agentcore-from-cfn-stack.ts
@@ -5,6 +5,7 @@ import { Construct } from 'constructs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore';
+import { integScopedName } from '../../_lib/stack-name.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -13,7 +14,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * BEFORE `cdk deploy` (CloudFormation resolves `AWS::SSM::Parameter::Value`
  * parameters at deploy start). Kept in sync with verify.sh's GREETING_PARAM.
  */
-const SSM_GREETING_PARAM = '/cdkl-integ/invoke-agentcore-from-cfn/greeting';
+const SSM_GREETING_PARAM = integScopedName('/cdkl-integ/invoke-agentcore-from-cfn/greeting');
 
 /**
  * SSM parameter for the SecureString case. `verify.sh` creates it as a plain
@@ -24,7 +25,7 @@ const SSM_GREETING_PARAM = '/cdkl-integ/invoke-agentcore-from-cfn/greeting';
  * sees the SecureString type and must route the decrypted value off the
  * `docker run` argv. Kept in sync with verify.sh's API_KEY_PARAM.
  */
-const SSM_API_KEY_PARAM = '/cdkl-integ/invoke-agentcore-from-cfn/api-key';
+const SSM_API_KEY_PARAM = integScopedName('/cdkl-integ/invoke-agentcore-from-cfn/api-key');
 
 /**
  * Fixture stack for `cdkl invoke-agentcore --from-cfn-stack` (issue #130).

--- a/tests/integration/local-invoke-agentcore-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-from-cfn/verify.sh
@@ -26,13 +26,16 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalInvokeAgentCoreFromCfnFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalInvokeAgentCoreFromCfnFixture)"
 TARGET="${STACK}/EchoAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
 
-GREETING_PARAM="/cdkl-integ/invoke-agentcore-from-cfn/greeting"
+GREETING_PARAM="$(integ_scoped_name /cdkl-integ/invoke-agentcore-from-cfn/greeting)"
 GREETING_VALUE="hello-from-ssm-state"
-API_KEY_PARAM="/cdkl-integ/invoke-agentcore-from-cfn/api-key"
+API_KEY_PARAM="$(integ_scoped_name /cdkl-integ/invoke-agentcore-from-cfn/api-key)"
 API_KEY_PLACEHOLDER="placeholder-not-secret"
 API_KEY_VALUE="s3cr3t-agentcore-9f3a2b"
 

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/bin/app.ts
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalInvokeAgentCoreFromS3FromCfnStack } from '../lib/local-invoke-agentcore-froms3-from-cfn-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeAgentCoreFromS3FromCfnStack(app, 'CdkLocalInvokeAgentCoreFromS3FromCfnFixture', {
+new LocalInvokeAgentCoreFromS3FromCfnStack(app, integStackName('CdkLocalInvokeAgentCoreFromS3FromCfnFixture'), {
   description: 'Fixture stack for cdkl invoke-agentcore fromS3 + --from-cfn-stack integ test',
 });

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
@@ -23,7 +23,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalInvokeAgentCoreFromS3FromCfnFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalInvokeAgentCoreFromS3FromCfnFixture)"
 TARGET="${STACK}/S3Agent"
 CODE_BASE_IMAGE="public.ecr.aws/docker/library/python:3.12-slim"
 

--- a/tests/integration/local-invoke-assume-role/bin/app.ts
+++ b/tests/integration/local-invoke-assume-role/bin/app.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalInvokeAssumeRoleStack } from '../lib/local-invoke-assume-role-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeAssumeRoleStack(app, 'CdkLocalInvokeAssumeRoleFixture', {
+new LocalInvokeAssumeRoleStack(app, integStackName('CdkLocalInvokeAssumeRoleFixture'), {
   description:
     'Fixture stack for cdkl invoke --assume-role (explicit ARN + bare auto-resolve from CFn state)',
 });

--- a/tests/integration/local-invoke-assume-role/verify.sh
+++ b/tests/integration/local-invoke-assume-role/verify.sh
@@ -37,7 +37,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalInvokeAssumeRoleFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalInvokeAssumeRoleFixture)"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/bin/app.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalInvokeFromCfnStackLargeStack } from '../lib/local-invoke-from-cfn-stack-large-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeFromCfnStackLargeStack(app, 'CdkLocalInvokeFromCfnStackLargeFixture', {
+new LocalInvokeFromCfnStackLargeStack(app, integStackName('CdkLocalInvokeFromCfnStackLargeFixture'), {
   description: 'Fixture stack (>100 resources) for cdkl invoke --from-cfn-stack pagination',
 });

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/lib/local-invoke-from-cfn-stack-large-stack-stack.ts
@@ -4,8 +4,18 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { integScopedName } from '../../_lib/stack-name.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * SSM parameter-path prefix for this fixture's ~120 parameters. An SSM
+ * parameter name is ACCOUNT + REGION global, so two worktree lanes running
+ * this fixture at once would both try to create `/cdkl-ls/p000` and the
+ * second `cdk deploy` would fail. Lane-scoped for the same reason the stack
+ * name is (issue #582).
+ */
+const SSM_PARAM_PREFIX = integScopedName('/cdkl-ls');
 
 /**
  * Fixture for `cdkl invoke --from-cfn-stack` against a stack with MORE
@@ -70,7 +80,7 @@ export class LocalInvokeFromCfnStackLargeStack extends cdk.Stack {
       const suffix = String(i).padStart(3, '0');
       const param = new ssm.CfnParameter(this, `Param${suffix}`, {
         type: 'String',
-        name: `/cdkl-ls/p${suffix}`,
+        name: `${SSM_PARAM_PREFIX}/p${suffix}`,
         value: `value-${suffix}`,
       });
       // `param.ref` synthesizes to `{ Ref: Param<suffix> }`, which CFn

--- a/tests/integration/local-invoke-from-cfn-stack-large-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-large-stack/verify.sh
@@ -18,7 +18,7 @@
 #
 # Steps:
 #   1. install + build cdk-local (root) + install fixture deps + docker pull
-#   2. cdk deploy CdkLocalInvokeFromCfnStackLargeFixture (upstream CDK CLI)
+#   2. cdk deploy CdkLocalInvokeFromCfnStackLargeFixture-<lane> (upstream CDK CLI)
 #   3. baseline: cdkl invoke (no --from-cfn-stack) — assert paramCount=0
 #      (every intrinsic-valued env var dropped via warn-and-drop).
 #   4. cdkl invoke --from-cfn-stack — assert paramCount=105, i.e. ALL
@@ -38,7 +38,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalInvokeFromCfnStackLargeFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalInvokeFromCfnStackLargeFixture)"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 EXPECTED_COUNT=105
 

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/bin/app.ts
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/bin/app.ts
@@ -2,6 +2,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { ProducerStack } from '../lib/producer-stack.ts';
 import { ConsumerStack } from '../lib/consumer-stack.ts';
+import { integStackName, integScopedName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
@@ -9,14 +10,19 @@ const app = new cdk.App();
 // `Export.Name` set to this; consumer's Lambda env var pulls it via
 // `Fn::ImportValue`. The literal is intentionally distinctive so the
 // integ can grep for it.
-const EXPORT_NAME = 'cdkl-multi-stack-shared-value';
+//
+// An export name is ACCOUNT-GLOBAL, exactly like a stack name, so it is
+// lane-suffixed too (issue #582): without that, two worktree lanes would
+// fight over one export even with distinct stack names, and the second
+// producer deploy would fail with "Export ... is already exported".
+const EXPORT_NAME = integScopedName('cdkl-multi-stack-shared-value');
 
-const producer = new ProducerStack(app, 'CdkLocalInvokeMultiStackProducer', {
+const producer = new ProducerStack(app, integStackName('CdkLocalInvokeMultiStackProducer'), {
   description: 'Producer stack: emits an SSM Parameter and exports its name via Fn::ImportValue.',
   exportName: EXPORT_NAME,
 });
 
-new ConsumerStack(app, 'CdkLocalInvokeMultiStackConsumer', {
+new ConsumerStack(app, integStackName('CdkLocalInvokeMultiStackConsumer'), {
   description: 'Consumer stack: Lambda env reads producer export via Fn::ImportValue.',
   exportName: EXPORT_NAME,
 }).addDependency(producer);

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -47,9 +47,12 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-PRODUCER_STACK="CdkLocalInvokeMultiStackProducer"
-CONSUMER_STACK="CdkLocalInvokeMultiStackConsumer"
-EXPORT_NAME="cdkl-multi-stack-shared-value"
+# Lane-unique names (issue #582): both stack names AND the CloudFormation
+# export name are account-global, so all three collide between worktree lanes.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+PRODUCER_STACK="$(integ_stack_name CdkLocalInvokeMultiStackProducer)"
+CONSUMER_STACK="$(integ_stack_name CdkLocalInvokeMultiStackConsumer)"
+EXPORT_NAME="$(integ_scoped_name cdkl-multi-stack-shared-value)"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/tests/integration/local-invoke-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-invoke-from-cfn-stack/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalInvokeFromCfnStackStack } from '../lib/local-invoke-from-cfn-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalInvokeFromCfnStackStack(app, 'CdkLocalInvokeFromCfnStackFixture', {
+new LocalInvokeFromCfnStackStack(app, integStackName('CdkLocalInvokeFromCfnStackFixture'), {
   description: 'Fixture stack for cdkl invoke --from-cfn-stack integ test',
 });

--- a/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
+++ b/tests/integration/local-invoke-from-cfn-stack/lib/local-invoke-from-cfn-stack-stack.ts
@@ -5,6 +5,7 @@ import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { integScopedName } from '../../_lib/stack-name.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -14,7 +15,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * parameters at the start of a deploy, so the SSM value must already exist).
  * Kept in sync with `verify.sh`'s `SSM_PARAM_NAME`.
  */
-const SSM_DB_HOST_PARAM = '/cdkl-integ/invoke-from-cfn-stack/db-host';
+const SSM_DB_HOST_PARAM = integScopedName('/cdkl-integ/invoke-from-cfn-stack/db-host');
 
 /**
  * SSM parameter name for the issue #99 SecureString case. `verify.sh`
@@ -26,7 +27,7 @@ const SSM_DB_HOST_PARAM = '/cdkl-integ/invoke-from-cfn-stack/db-host';
  * it sees the SecureString type and routes the decrypted value off the
  * `docker run` argv. Kept in sync with `verify.sh`'s `SSM_API_KEY_PARAM`.
  */
-const SSM_API_KEY_PARAM = '/cdkl-integ/invoke-from-cfn-stack/api-key';
+const SSM_API_KEY_PARAM = integScopedName('/cdkl-integ/invoke-from-cfn-stack/api-key');
 
 /**
  * Run this fixture's Lambdas at the HOST's CPU architecture.

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -13,7 +13,7 @@
 #
 # Steps:
 #   1. install + build cdk-local (root) + install fixture deps + docker pull
-#   2. cdk deploy CdkLocalInvokeFromCfnStackFixture (upstream CDK CLI)
+#   2. cdk deploy CdkLocalInvokeFromCfnStackFixture-<lane> (upstream CDK CLI)
 #   3. baseline: cdkl invoke (no --from-cfn-stack) — assert
 #      TABLE_NAME comes through as "unset" (env var dropped because it's
 #      intrinsic-valued and the default behavior warns + drops).
@@ -34,7 +34,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalInvokeFromCfnStackFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalInvokeFromCfnStackFixture)"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
 # issue #94: the stack's DB_HOST env var is a Ref to an
@@ -44,7 +47,7 @@ IMAGE="public.ecr.aws/lambda/nodejs:20"
 # already exist — verify.sh `put-parameter`s it before deploy and deletes
 # it on exit. SSM_PARAM_NAME is kept in sync with the stack's
 # SSM_DB_HOST_PARAM constant.
-SSM_PARAM_NAME="/cdkl-integ/invoke-from-cfn-stack/db-host"
+SSM_PARAM_NAME="$(integ_scoped_name /cdkl-integ/invoke-from-cfn-stack/db-host)"
 SSM_PARAM_VALUE="db.internal.example"
 
 # issue #99: a SECOND SSM parameter that the stack Refs via API_KEY. It is
@@ -55,7 +58,7 @@ SSM_PARAM_VALUE="db.internal.example"
 # sees the SecureString type and must keep the decrypted value off the
 # `docker run` argv. The post-swap value differs from the placeholder to
 # prove cdkl reads SSM fresh (not the deploy-time-baked value).
-SSM_API_KEY_PARAM="/cdkl-integ/invoke-from-cfn-stack/api-key"
+SSM_API_KEY_PARAM="$(integ_scoped_name /cdkl-integ/invoke-from-cfn-stack/api-key)"
 SSM_API_KEY_PLACEHOLDER="placeholder-not-secret"
 SSM_API_KEY_VALUE="s3cr3t-api-key-9f3a2b"
 

--- a/tests/integration/local-start-api-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-api-from-cfn-stack/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalStartApiFromCfnStackStack } from '../lib/local-start-api-from-cfn-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalStartApiFromCfnStackStack(app, 'CdkLocalStartApiFromCfnStackFixture', {
+new LocalStartApiFromCfnStackStack(app, integStackName('CdkLocalStartApiFromCfnStackFixture'), {
   description: 'Fixture stack for cdkl start-api --from-cfn-stack integ test',
 });

--- a/tests/integration/local-start-api-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-api-from-cfn-stack/verify.sh
@@ -17,7 +17,7 @@
 #
 # Steps:
 #   1. install + build cdk-local (root) + docker pull
-#   2. cdk deploy CdkLocalStartApiFromCfnStackFixture (upstream CDK CLI)
+#   2. cdk deploy CdkLocalStartApiFromCfnStackFixture-<lane> (upstream CDK CLI)
 #   3. read deployed table name + sibling ARN from AWS
 #   4. baseline: cdkl start-api (no flag) — assert TABLE_NAME / SIBLING_ARN
 #      come through as "unset" (intrinsic-valued, default warn-and-drop).
@@ -36,7 +36,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalStartApiFromCfnStackFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalStartApiFromCfnStackFixture)"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 CONTAINER_HOST="127.0.0.1"
 

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/bin/app.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalStartCloudFrontExtBucketFromCfnStackStack } from '../lib/local-start-cloudfront-extbucket-from-cfn-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalStartCloudFrontExtBucketFromCfnStackStack(app, 'CdkLocalStartCfExtBucketFromCfnFixture', {
+new LocalStartCloudFrontExtBucketFromCfnStackStack(app, integStackName('CdkLocalStartCfExtBucketFromCfnFixture'), {
   description:
     'Fixture for cdkl start-cloudfront --from-cfn-stack (GetDistributionConfig external-bucket resolution) integ test',
 });

--- a/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-cloudfront-extbucket-from-cfn-stack/verify.sh
@@ -35,7 +35,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalStartCfExtBucketFromCfnFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalStartCfExtBucketFromCfnFixture)"
 TARGET="${STACK}/Dist"
 PORT_CFN=18396
 PORT_BASE=18397

--- a/tests/integration/local-start-cloudfront-kvs-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-cloudfront-kvs-from-cfn-stack/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalStartCloudFrontKvsFromCfnStackStack } from '../lib/local-start-cloudfront-kvs-from-cfn-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalStartCloudFrontKvsFromCfnStackStack(app, 'CdkLocalStartCfKvsFromCfnFixture', {
+new LocalStartCloudFrontKvsFromCfnStackStack(app, integStackName('CdkLocalStartCfKvsFromCfnFixture'), {
   description: 'Fixture stack for cdkl start-cloudfront --from-cfn-stack (CloudFront KeyValueStore) integ test',
 });

--- a/tests/integration/local-start-cloudfront-kvs-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-cloudfront-kvs-from-cfn-stack/verify.sh
@@ -29,7 +29,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalStartCfKvsFromCfnFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalStartCfKvsFromCfnFixture)"
 TARGET="${STACK}/SiteDist"
 PORT_CFN=18391
 PORT_BASE=18392

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalStartCloudFrontLambdaUrlFromCfnStackStack } from '../lib/local-start-cloudfront-lambda-url-from-cfn-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalStartCloudFrontLambdaUrlFromCfnStackStack(app, 'CdkLocalStartCfFnUrlFromCfnFixture', {
+new LocalStartCloudFrontLambdaUrlFromCfnStackStack(app, integStackName('CdkLocalStartCfFnUrlFromCfnFixture'), {
   description: 'Fixture stack for cdkl start-cloudfront --from-cfn-stack (Lambda Function URL origin) integ test',
 });

--- a/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-cloudfront-lambda-url-from-cfn-stack/verify.sh
@@ -29,7 +29,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalStartCfFnUrlFromCfnFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalStartCfFnUrlFromCfnFixture)"
 TARGET="${STACK}/ApiDist"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 PORT_CFN=18381

--- a/tests/integration/local-start-cloudfront-s3-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-start-cloudfront-s3-from-cfn-stack/bin/app.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalStartCloudFrontS3FromCfnStackStack } from '../lib/local-start-cloudfront-s3-from-cfn-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalStartCloudFrontS3FromCfnStackStack(app, 'CdkLocalStartCfS3FromCfnFixture', {
+new LocalStartCloudFrontS3FromCfnStackStack(app, integStackName('CdkLocalStartCfS3FromCfnFixture'), {
   description:
     'Fixture stack for cdkl start-cloudfront --from-cfn-stack (deployed-S3 read-through origin) integ test',
 });

--- a/tests/integration/local-start-cloudfront-s3-from-cfn-stack/verify.sh
+++ b/tests/integration/local-start-cloudfront-s3-from-cfn-stack/verify.sh
@@ -32,7 +32,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalStartCfS3FromCfnFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalStartCfS3FromCfnFixture)"
 TARGET="${STACK}/SiteDist"
 PORT_CFN=18394
 PORT_BASE=18395

--- a/tests/integration/local-studio-from-cfn-stack/bin/app.ts
+++ b/tests/integration/local-studio-from-cfn-stack/bin/app.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { LocalStudioFromCfnStackStack } from '../lib/local-studio-from-cfn-stack-stack.ts';
+import { integStackName } from '../../_lib/stack-name.ts';
 
 const app = new cdk.App();
 
-new LocalStudioFromCfnStackStack(app, 'CdkLocalStudioFromCfnStackFixture', {
+new LocalStudioFromCfnStackStack(app, integStackName('CdkLocalStudioFromCfnStackFixture'), {
   description: 'Fixture stack for cdkl studio --from-cfn-stack ECS pin classification (issue #354)',
 });

--- a/tests/integration/local-studio-from-cfn-stack/verify.sh
+++ b/tests/integration/local-studio-from-cfn-stack/verify.sh
@@ -39,7 +39,10 @@ set -euo pipefail
 
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
-STACK="CdkLocalStudioFromCfnStackFixture"
+# Lane-unique stack name (issue #582): every AWS-deploying fixture used to
+# hard-code ONE name, so two worktree lanes shared one CloudFormation stack.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/stack-name.sh"
+STACK="$(integ_stack_name CdkLocalStudioFromCfnStackFixture)"
 # The servable ECS service target id is the CDK display path. The L2
 # FargateService nests its AWS::ECS::Service under a `Service` node, so the
 # listed id is `<Stack>/AppService/Service` (confirm with `cdkl list`).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -230,8 +230,12 @@ export default defineConfig({
       'test:hooks': {
         // Glob, not a hardcoded list: a new `.claude/hooks/*.test.sh` used to be
         // added and then never run by anything (go-to-k/cdk-local#542 review).
+        // `tests/integration/_lib/*.test.sh` is in the same glob for the same
+        // reason: the integ fixtures' shared shell helpers (go-to-k/cdk-local#582)
+        // are bash, so they have no home under `tests/unit/**`, and a smoke test
+        // nothing runs is a smoke test that rots.
         command:
-          'for t in .claude/hooks/*.test.sh; do echo "== $t"; bash "$t" || exit 1; done',
+          'for t in .claude/hooks/*.test.sh tests/integration/_lib/*.test.sh; do echo "== $t"; bash "$t" || exit 1; done',
         // Spawns throwaway git repos and a PATH-stubbed `gh`, so the result
         // depends on the hook script rather than on a tracked input set the
         // task runner can digest -- no caching.


### PR DESCRIPTION
## Summary

Every AWS-deploying integ fixture hard-coded ONE CloudFormation stack name, while
the repo mandates parallel work in worktrees and markgate markers are per-worktree
so lanes verify concurrently. Two lanes running the same fixture therefore
deployed, read and destroyed **the same stack in the same account**, and all three
failure modes were silent:

- the pre-flight orphan scan mistook a peer's LIVE stack for a leftover;
- the cleanup trap ran `cdk destroy` gated only on `WE_CREATED_STACK`, set by THIS
  process, so a lane could destroy a peer's stack;
- worst, a colliding run could report GREEN having asserted against a peer's
  resources -- and that green refreshes the `integ` merge gate.

Observed live on 2026-08-26: seven create/delete cycles of one stack name in
twelve minutes from two interleaved lanes.

## The fix

`tests/integration/_lib/stack-name.sh` derives an 8-hex suffix from the worktree
ROOT PATH (not the branch name -- a branch name may contain `/`, which is not
legal in a stack name) and exports `INTEG_STACK_SUFFIX`.
`tests/integration/_lib/stack-name.ts` is the only place it is READ.

`verify.sh` alone could not carry this: a fixture's stack name is its CDK app's
CONSTRUCT ID, and no `cdk deploy` flag renames a stack, so suffixing only the
shell variable would ask for a stack the app never synthesized. With the variable
unset -- a bare `cdk synth` by hand -- the historical name comes back.

**Stack names were not the only account-global names these fixtures own.** Fixing
only those would have left the collision one layer down:

- `local-invoke-from-cfn-stack-multi-stack` publishes an explicit CloudFormation
  EXPORT name the consumer reads via `Fn::ImportValue`. Export names are unique
  per account+region, so the second lane's producer deploy would fail outright.
- `local-invoke-from-cfn-stack-large-stack` creates ~120 SSM parameters at fixed
  `/cdkl-ls/**` paths, and two other fixtures `put-parameter` /
  `delete-parameter` at fixed `/cdkl-integ/**` paths in their cleanup traps.

Fixtures that declare a `STACK=` they do NOT deploy are deliberately untouched
(synth-time construct ids, and `local-studio`'s deliberately-bogus
`--from-cfn-stack` arguments).

The `pgrep`-style peer check the issue suggested is deliberately NOT implemented:
with lane-unique names, a peer worktree running the same fixture is exactly the
case this makes SAFE, so a process check would refuse the concurrency the fix
enables. The remaining hazard -- two runs in ONE worktree -- is already handled by
the pre-flight scan.

## What the integ caught that no unit test could

The first spelling was `CDKL_INTEG_STACK_SUFFIX`, and every `cdk deploy` printed
`Unknown option(s): --lIntegStackSuffix`. The aws-cdk CLI is yargs-based with
`.env('CDK')`, so it maps EVERY environment variable beginning with `CDK` onto a
CLI option -- verified directly: `CDKL_PROVE_IT=1 cdk doctor` prints
`Unknown option(s): --lProveIt`. Harmless here, but a variable whose camelCased
tail collided with a real option would have changed deploy behaviour silently, in
exactly the fixtures that talk to a real account. Renamed, with a regression case.

## `/run-integ`'s orphan sweep: eleven instances of one defect class

The lane-unique rename made the skill's orphan sweep a no-op -- it scanned a bare
base name that can never match. Repairing it took **ten review rounds**, and
**five of the eleven instances were introduced by the fix for the one before**:

| # | Defect | Verdict it produced |
|---|---|---|
| 1 | scanned the un-suffixed name | clean, unconditionally |
| 2 | scoped to `/cdkl` | listed every LANE's parameters |
| 3 | suffix filter, no guard | `contains(Name,'-')` -- the whole ACCOUNT |
| 4 | STACK scans had no guard | false clean |
| 5 | widened glob still missed `local-invoke-assume-role` | fixture skipped entirely |
| 6 | every AWS failure mapped to clean | false clean on expired creds |
| 7 | `grep -q 'does not exist'` | also matches a broken `source_profile` |
| 8 | `--stack-status-filter` hid 16 of 23 statuses | missed `DELETE_IN_PROGRESS` |
| 9 | singular scan | missed the orphaned PRODUCER |
| 10 | singular REMEDIATION | destroyed the wrong stack name |
| 11 | `cdk destroy` in the remediation | exits 0 silently on unmatched names |

Every one was found by a reviewer EXECUTING something -- running the recipe,
driving a mutant, calling the AWS CLI. None by reading the diff. Twice the
knowledge was already written down (a comment describing the falsely-clean shape
three lines above code that had it; a commit message naming backslash
continuations as the fence's defeat, then fixing only half).

**So the recipe stopped claiming things.** Both scans print raw `describe-stacks`
output and the prose names BOTH outcomes -- `ValidationError ... does not exist`
is clean, and exit 0 with a `Stacks` array is the ORPHAN case, since reading "no
error" as "passed" is the natural inversion. Remediation uses
`aws cloudformation delete-stack` (no app context, no suffix in the environment)
rather than `cdk destroy`, which fails on `--app` from the repo root and,
repaired by hand, exits 0 silently on names the app never synthesized. The scan
must be re-run afterwards, because no delete command reports "I matched nothing".

## The fence

`tests/integration/_lib/stack-name.test.sh` grew 35 -> 86 cases. It pins the
lane-naming itself (the TS half is EXECUTED, not grepped -- replacing both
function bodies with `return base` used to leave the suite green) and the sweep's
properties: no verdict on a stack query, no stderr phrase match, no status
filter, stderr not silenced, both guards present, a real scan in BOTH steps, and
-- by RUNNING the extracted predicate -- coverage of all 13 AWS-owning fixtures.

It also pins the REMEDIATION shape -- no `cdk destroy`, a `delete-stack`
present -- because the confirmation review measured that restoring instance 11
verbatim left the suite green. Five of eleven instances arrived through the
previous fix, so an unfenced remediation was the one recurrence channel still
open.

Its boundary is recorded in the file rather than papered over: a verdict placed
away from the QUERY still escapes, and closing that needs a shell parser rather
than greps. That is the argument for
https://github.com/go-to-k/cdk-local/issues/601 (make the sweep a real script
whose failure paths are EXECUTED), which owns the structural replacement.

## Test plan

- **The concurrency proof the issue asks for**: two worktrees ran the SAME fixture
  three seconds apart. Both exited 0, and sampling `list-stacks` through the
  overlap showed two distinctly-named stacks coexisting, then none.
- `/run-integ local-invoke-from-cfn-stack` re-run after every round: PASSED.
- The plural scan run against `local-invoke-from-cfn-stack-multi-stack`: both
  producer and consumer checked, both clean.
- Cleanup after each: 0 docker containers, 0 networks, 0 orphan stacks, 0 `/cdkl`
  SSM parameters, 0 exports, 0 froms3 buckets.
- Fence: 84/0, green under macOS system bash 3.2 as well as 5.x, wired into
  `vp run test:hooks` which CI runs.
- Every assertion mutation-probed; each reported mutant was green before and red
  after.
- `vp run verify`: 224 files / 3576 tests, 0 errors.
- The live-peer guard now PRECEDES the destructive block. An agent works
  top-down, so a warning printed below a delete command is read after the
  damage.

## Known residuals

- Host-global names are still shared: 30 fixtures hard-code a TCP port and 7
  `kill -9` whoever holds one -- https://github.com/go-to-k/cdk-local/issues/591.
- `DEPLOY_RE` misses a backslash-continuation `cdk` invocation, and the
  bare-literal check has known false negatives (double quotes, template literals,
  same-line masking). Both are convention checks rather than soundness proofs;
  every fixture today uses the covered spelling.

Closes #582
