### PR TITLE
fix(studio): bound a serve endpoint to loopback instead of trusting any stdout line

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1129,7 +1129,26 @@ compute-locally category for Lambda + API Gateway).
   bounded body) onto the bus, so every request to the served port lands
   on the timeline regardless of source — browser / curl / pad alike
   (decision D4a); `Upgrade` (WebSocket) requests are raw-bridged without
-  capture), studio-store (issue #282, slice C3 — the in-memory event
+  capture. The upstream it will front is bounded to LOOPBACK (issue #578):
+  studio learns a serve child's endpoint by regex-matching its stdout, so
+  the URL is only ever as trustworthy as the line that carried it — an
+  ordinary application log (`Server listening on http://0.0.0.0:3000` is
+  what a web framework prints) or a warn relaying a wire-derived AWS SDK
+  message could otherwise name any host, and every composer request,
+  headers and body included, would be forwarded there. Three bounds, in
+  `studio-serve-manager` and in `startStudioProxy` itself: a line carrying
+  cdk-local's own `WARN: ` / `ERROR: ` prefix is never pattern-matched at
+  all (`classifyChildLine` strips ANSI, the verbose `<ts> <LEVEL>` preamble
+  and a `[module]` tag first, so anchoring survives `--verbose`); every
+  ready pattern is anchored to the start of the line; and the resolved
+  upstream must be loopback (`normalizeLocalUpstream`) or the serve is
+  refused with a warn rather than flipped to running against a foreign
+  host. A WILDCARD bind address (`0.0.0.0` / `::`) is REWRITTEN to
+  `127.0.0.1` rather than refused — it is a bind address, not a
+  destination, and `--container-host 0.0.0.0` is an ordinary value studio
+  auto-renders. The same bound covers the `ecs` `hostUrl` that
+  `parsePublishedHostEndpoint` derives from the replica publish banner,
+  which the request composer targets DIRECTLY (un-proxied)), studio-store (issue #282, slice C3 — the in-memory event
   store: subscribes to the bus and retains a bounded, newest-wins window
   of invocations + log lines so the server can answer history on
   (re)connect, full-text log search across the session, and

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -75,6 +75,7 @@ import {
 } from '@aws-sdk/client-bedrock-agentcore-control';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { getLogger } from '../utils/logger.js';
+import { flattenToOneLine } from './credential-error.js';
 import { collectSsmParameterRefs, resolveSsmParameters } from './ssm-parameter-resolver.js';
 import type { ResolvedSsmParameters } from './ssm-parameter-resolver.js';
 import type { CloudFormationTemplate } from '../types/resource.js';
@@ -715,14 +716,23 @@ export async function fetchAllExports(client: CloudFormationClient): Promise<Map
  * S3-bucket-specific (it rewrites the synthetic `Unknown`/`UnknownError`
  * with bucket / region context), so the CFn provider extracts the
  * pieces directly here.
+ *
+ * Issue #578 — the result is FLATTENED TO ONE LINE via
+ * {@link flattenToOneLine}, the same helper `credential-error` applies to
+ * every other wire-derived value that lands on a log line, rather than a
+ * second spelling of it. Both `err.name` and `err.message` come off the wire,
+ * and this warn is relayed onto a `cdkl studio` serve child's stdout, where
+ * `studio-serve-manager` splits on `\n`: an embedded newline puts line 2 on
+ * the stream with no `WARN: ` prefix, so it clears the diagnostic bound and
+ * matches a ready pattern at `^`. One line in, one line out.
  */
 export function formatAwsErrorForWarn(err: unknown): string {
-  if (!(err instanceof Error)) return String(err);
+  if (!(err instanceof Error)) return flattenToOneLine(String(err));
   const name = err.name && err.name !== 'Error' ? err.name : undefined;
   const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
   const prefixParts: string[] = [];
   if (name !== undefined) prefixParts.push(name);
   if (status !== undefined) prefixParts.push(`HTTP ${status}`);
-  if (prefixParts.length === 0) return err.message;
-  return `${prefixParts.join(' ')}: ${err.message}`;
+  if (prefixParts.length === 0) return flattenToOneLine(err.message);
+  return flattenToOneLine(`${prefixParts.join(' ')}: ${err.message}`);
 }

--- a/src/local/credential-error.ts
+++ b/src/local/credential-error.ts
@@ -90,13 +90,15 @@
  *
  * # What this does NOT close
  *
- * A single-LINE forged string still reaches readers other than a human.
- * `cdkl studio` matches every serve-child stdout line against an unanchored
- * ready-line regex and proxies to the URL it captures, so a message
- * containing `Server listening on http://...` can redirect the studio proxy.
- * That is not fixed here — the sanitizer bounds the line, it does not stop a
- * machine from reading it — and it predates this change (an ordinary handler
- * log line trips the same matcher). Tracked in issue #578.
+ * A single-LINE forged string still reaches readers other than a human. It no
+ * longer redirects the studio capture proxy: issue #578 anchored every
+ * `cdkl studio` ready pattern to the start of the line, made the serve manager
+ * skip a line carrying cdk-local's own `WARN: ` / `ERROR: ` decoration
+ * outright, and bounded the resolved upstream to loopback — so a message
+ * containing `Server listening on http://...` is neither read as a banner nor
+ * usable as a destination. What remains is the reader this sanitizer was
+ * always aimed at: a HUMAN scanning the log, for whom a forged-looking line is
+ * still misleading text, which is why the flattening + capping stay.
  */
 import { getLogger } from '../utils/logger.js';
 

--- a/src/local/studio-proxy.ts
+++ b/src/local/studio-proxy.ts
@@ -94,30 +94,19 @@ export function isWildcardHostname(hostname: string): boolean {
 }
 
 /**
- * Resolve an upstream URL a serve child named into the URL studio may
- * actually use, or `undefined` when it must be refused (issue #578).
+ * Rewrite the HOST TOKEN of a wildcard-bound URL to `127.0.0.1`, leaving
+ * scheme, userinfo, port, path, query and fragment byte-for-byte (rather than
+ * re-serialising the `URL`, which would append a `/` the child never printed).
  *
- * A wildcard host is REWRITTEN to `127.0.0.1` (see
- * {@link isWildcardHostname}) and the rewritten URL is what gets adopted as
- * the endpoint and handed to the proxy, so the destination really is
- * loopback rather than merely tolerated. Everything else must already be
- * loopback ({@link isLoopbackHostname}); a foreign host or an unparseable URL
- * resolves to `undefined`.
- *
- * Only the host token is rewritten — scheme, userinfo, port, path, query and
- * fragment are carried through byte-for-byte (rather than re-serialising the
- * `URL`, which would append a `/` the child never printed).
+ * This is string surgery over an authority the WHATWG parser has ALREADY
+ * accepted, and the two parsers do not agree on where the authority ends —
+ * `\` terminates it for the parser and not for the `[/?#]` scan here, and any
+ * future terminator will diverge the same way. So this is deliberately NOT the
+ * decision-maker: {@link normalizeLocalUpstream} re-parses whatever comes back
+ * and refuses it unless the RESULT is loopback. Returning a wrong string here
+ * costs a refusal, never a foreign destination.
  */
-export function normalizeLocalUpstream(upstream: string): string | undefined {
-  let parsed: URL;
-  try {
-    parsed = new URL(upstream);
-  } catch {
-    return undefined;
-  }
-  if (!isWildcardHostname(parsed.hostname)) {
-    return isLoopbackHostname(parsed.hostname) ? upstream : undefined;
-  }
+function rewriteWildcardHostToken(upstream: string): string | undefined {
   const schemeEnd = upstream.indexOf('://');
   if (schemeEnd === -1) return undefined;
   const head = upstream.slice(0, schemeEnd + 3);
@@ -131,6 +120,62 @@ export function normalizeLocalUpstream(upstream: string): string | undefined {
   const portAt = hostPort.startsWith('[') ? hostPort.indexOf(']') + 1 : hostPort.indexOf(':');
   const port = portAt > 0 ? hostPort.slice(portAt) : '';
   return `${head}${userinfo}127.0.0.1${port}${tail}`;
+}
+
+/**
+ * Resolve an upstream URL a serve child named into the URL studio may
+ * actually use, or `undefined` when it must be refused (issue #578).
+ *
+ * A wildcard host is REWRITTEN to `127.0.0.1` (see
+ * {@link isWildcardHostname}) and the rewritten URL is what gets adopted as
+ * the endpoint and handed to the proxy, so the destination really is
+ * loopback rather than merely tolerated. Everything else must already be
+ * loopback; a foreign host or an unparseable URL resolves to `undefined`.
+ *
+ * # The answer is CHECKED, not asserted
+ *
+ * Whatever string this is about to return — the input verbatim, or the
+ * host-token rewrite of {@link rewriteWildcardHostToken} — is re-parsed with
+ * `new URL` and its `hostname` must satisfy {@link isLoopbackHostname}. That
+ * single post-condition is the whole guarantee, and it is stated over the
+ * VALUE HANDED BACK rather than over the value inspected on the way in, so it
+ * cannot be outrun by a spelling nobody enumerated.
+ *
+ * It has to be, because the string surgery and the URL parser disagree about
+ * where an authority ends. `http://0.0.0.0\@attacker.example/` parses to host
+ * `0.0.0.0` (WHATWG treats `\` as an authority terminator) but the `[/?#]`
+ * scan reads `0.0.0.0\@attacker.example` as one authority, so the rewrite
+ * lands on the wrong token and produces `http://0.0.0.0\@127.0.0.1/` — which
+ * re-parses to host `0.0.0.0`, NOT loopback, and is refused here. Adding `\`
+ * to the cut set would close exactly that spelling and leave the next one
+ * open; the post-condition closes the shape.
+ *
+ * Userinfo rides through byte-for-byte on the accepted path
+ * (`http://tok@0.0.0.0:51234/` -> `http://tok@127.0.0.1:51234/`) — verified,
+ * not assumed, since the post-condition now proves the destination that
+ * string actually names.
+ */
+export function normalizeLocalUpstream(upstream: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(upstream);
+  } catch {
+    return undefined;
+  }
+  const candidate = isWildcardHostname(parsed.hostname)
+    ? rewriteWildcardHostToken(upstream)
+    : upstream;
+  if (candidate === undefined) return undefined;
+  // The post-condition. A non-wildcard input re-parses to the hostname
+  // already read off `parsed`, so this is the ONLY loopback test the function
+  // needs — one check, over the returned value, on every path.
+  let confirmed: URL;
+  try {
+    confirmed = new URL(candidate);
+  } catch {
+    return undefined;
+  }
+  return isLoopbackHostname(confirmed.hostname) ? candidate : undefined;
 }
 
 /**

--- a/src/local/studio-proxy.ts
+++ b/src/local/studio-proxy.ts
@@ -70,6 +70,22 @@ export function isLoopbackHostname(hostname: string): boolean {
 }
 
 /**
+ * Drop the brackets `URL.hostname` keeps around an IPv6 literal (`[::1]`), so
+ * the host can be handed to `node:http` / `node:net`.
+ *
+ * Those two disagree with `URL` about the spelling: `http.request({ host:
+ * '[::1]' })` fails with `ENOTFOUND` (it is looked up as a NAME), while `'::1'`
+ * connects. {@link isLoopbackHostname} already tolerates the bracketed form —
+ * so `--host ::1` on a serve child yields an upstream this proxy ACCEPTS and
+ * then 502s every request through, which is the worst of the three outcomes.
+ * Bracket-stripping is safe for every other spelling: a dotted IPv4, a name
+ * and a bare hextet form carry no brackets to remove.
+ */
+function stripHostBrackets(hostname: string): string {
+  return hostname.replace(/^\[/, '').replace(/\]$/, '');
+}
+
+/**
  * True when `hostname` is the UNSPECIFIED (wildcard) address: IPv4 `0.0.0.0`,
  * IPv6 `::` (`URL` normalises `0:0:0:0:0:0:0:0` to it), or the IPv4-mapped
  * `::ffff:0.0.0.0` (which `URL.hostname` renders as `[::ffff:0:0]`).
@@ -242,7 +258,7 @@ export function startStudioProxy(config: StudioProxyConfig): Promise<RunningStud
     );
   }
   const upstreamUrl = new URL(resolvedUpstream);
-  const upstreamHost = upstreamUrl.hostname;
+  const upstreamHost = stripHostBrackets(upstreamUrl.hostname);
   const upstreamPort = Number(upstreamUrl.port) || 80;
 
   const server = createServer((clientReq, clientRes) => {

--- a/src/local/studio-proxy.ts
+++ b/src/local/studio-proxy.ts
@@ -40,6 +40,113 @@ export interface RunningStudioProxy {
 let proxyIdCounter = 0;
 
 /**
+ * True when `hostname` names this machine's loopback interface: `localhost`,
+ * an IPv4 address in `127.0.0.0/8`, IPv6 `::1`, or an IPv4-mapped loopback
+ * (`::ffff:127.0.0.1`, which `URL.hostname` renders in hex as
+ * `[::ffff:7f00:1]`). Surrounding brackets, as `URL.hostname` keeps them for
+ * an IPv6 literal, are tolerated. The match is EXACT — `localhost.example.com`
+ * and `127.0.0.1.example.com` are ordinary DNS names that resolve wherever
+ * their owner points them, and are NOT loopback.
+ *
+ * A `cdkl` serve child always listens on this machine, so this is the bound
+ * studio puts on where it will ever forward a composer request (issue #578).
+ * A destination that is not loopback did not come from a genuine serve, and
+ * forwarding to it would carry the developer's request — headers and body —
+ * off-box.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  const h = hostname.trim().replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+  if (h === 'localhost') return true;
+  if (h === '::1' || h === '0:0:0:0:0:0:0:1') return true;
+  // IPv4-mapped IPv6 in hex form (`::ffff:7f00:1`): the high hextet's top
+  // byte is the first IPv4 octet.
+  const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(h);
+  if (mapped) return parseInt(mapped[1]!, 16) >> 8 === 127;
+  const dotted = /^(?:::ffff:)?(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
+  if (!dotted) return false;
+  const octets = dotted.slice(1).map(Number);
+  if (octets.some((o) => o > 255)) return false;
+  return octets[0] === 127;
+}
+
+/**
+ * True when `hostname` is the UNSPECIFIED (wildcard) address: IPv4 `0.0.0.0`,
+ * IPv6 `::` (`URL` normalises `0:0:0:0:0:0:0:0` to it), or the IPv4-mapped
+ * `::ffff:0.0.0.0` (which `URL.hostname` renders as `[::ffff:0:0]`).
+ *
+ * A wildcard is a BIND address, not a destination — a server bound to it IS
+ * reachable on loopback, and `--container-host 0.0.0.0` is an ordinary value
+ * for `start-service` / `run-task` (default `127.0.0.1`) that `cdkl studio`
+ * auto-renders in its "All options" section. So a wildcard is normalised to
+ * loopback rather than refused; the security property is untouched, because a
+ * line naming a real foreign host still names a real foreign host, and no
+ * spelling of the wildcard reaches anywhere but this machine.
+ */
+export function isWildcardHostname(hostname: string): boolean {
+  const h = hostname.trim().replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+  return (
+    h === '0.0.0.0' ||
+    h === '::' ||
+    h === '0:0:0:0:0:0:0:0' ||
+    h === '::ffff:0.0.0.0' ||
+    h === '::ffff:0:0'
+  );
+}
+
+/**
+ * Resolve an upstream URL a serve child named into the URL studio may
+ * actually use, or `undefined` when it must be refused (issue #578).
+ *
+ * A wildcard host is REWRITTEN to `127.0.0.1` (see
+ * {@link isWildcardHostname}) and the rewritten URL is what gets adopted as
+ * the endpoint and handed to the proxy, so the destination really is
+ * loopback rather than merely tolerated. Everything else must already be
+ * loopback ({@link isLoopbackHostname}); a foreign host or an unparseable URL
+ * resolves to `undefined`.
+ *
+ * Only the host token is rewritten — scheme, userinfo, port, path, query and
+ * fragment are carried through byte-for-byte (rather than re-serialising the
+ * `URL`, which would append a `/` the child never printed).
+ */
+export function normalizeLocalUpstream(upstream: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(upstream);
+  } catch {
+    return undefined;
+  }
+  if (!isWildcardHostname(parsed.hostname)) {
+    return isLoopbackHostname(parsed.hostname) ? upstream : undefined;
+  }
+  const schemeEnd = upstream.indexOf('://');
+  if (schemeEnd === -1) return undefined;
+  const head = upstream.slice(0, schemeEnd + 3);
+  const rest = upstream.slice(schemeEnd + 3);
+  const cut = rest.search(/[/?#]/);
+  const authority = cut === -1 ? rest : rest.slice(0, cut);
+  const tail = cut === -1 ? '' : rest.slice(cut);
+  const at = authority.lastIndexOf('@');
+  const userinfo = at === -1 ? '' : authority.slice(0, at + 1);
+  const hostPort = at === -1 ? authority : authority.slice(at + 1);
+  const portAt = hostPort.startsWith('[') ? hostPort.indexOf(']') + 1 : hostPort.indexOf(':');
+  const port = portAt > 0 ? hostPort.slice(portAt) : '';
+  return `${head}${userinfo}127.0.0.1${port}${tail}`;
+}
+
+/**
+ * Render an UNTRUSTED endpoint string for a human-readable message. The
+ * string reached studio from a child's stdout, so it can carry control
+ * characters (ANSI escapes, a bare CR) that would forge extra output, and it
+ * can be arbitrarily long. Non-printable-ASCII bytes become `?` and the result
+ * is length-capped, the same shape `credential-error` applies to a relayed
+ * service message.
+ */
+export function describeEndpointForMessage(value: string): string {
+  const flat = value.replace(/[^\x20-\x7e]/g, '?');
+  return flat.length > 120 ? `${flat.slice(0, 120)}...` : flat;
+}
+
+/**
  * Start a capturing reverse proxy in front of a studio serve target
  * (decision D4a: because every request to the served port flows through
  * `cdkl studio`, the timeline observes them regardless of source —
@@ -56,6 +163,12 @@ let proxyIdCounter = 0;
  * Studio is a control plane over the CLI, so this proxy sits in front of
  * the long-running `cdkl start-api` child the serve manager spawned; it
  * does NOT re-implement any routing — it forwards verbatim.
+ *
+ * Throws SYNCHRONOUSLY (rather than rejecting) when `upstream` is unparseable
+ * or names a non-loopback host (issue #578) — a refusal to attempt the proxy
+ * at all, rather than a runtime failure of one. A wildcard bind address
+ * (`0.0.0.0` / `::`) is not a refusal: it is rewritten to `127.0.0.1` and
+ * forwarded there ({@link normalizeLocalUpstream}).
  */
 export function startStudioProxy(config: StudioProxyConfig): Promise<RunningStudioProxy> {
   const host = config.host ?? '127.0.0.1';
@@ -68,7 +181,22 @@ export function startStudioProxy(config: StudioProxyConfig): Promise<RunningStud
       return `req-${clock()}-${proxyIdCounter}`;
     });
 
-  const upstreamUrl = new URL(config.upstream);
+  // Defence in depth (issue #578). The serve manager already resolves a ready
+  // URL before it ever reaches a proxy, but this proxy is the component that
+  // actually forwards the developer's request, so it enforces the same bound
+  // itself: every caller — now and later — has to name a local upstream. A
+  // wildcard BIND address is rewritten to loopback (so the forwarded request
+  // goes to 127.0.0.1, not 0.0.0.0); anything else non-loopback is refused,
+  // which also means the guard cannot be lost by a future call site that
+  // forgets it.
+  const resolvedUpstream = normalizeLocalUpstream(config.upstream);
+  if (resolvedUpstream === undefined) {
+    throw new Error(
+      `studio proxy refuses the non-loopback upstream '${describeEndpointForMessage(config.upstream)}': ` +
+        'a serve child always listens on this machine, so a request forwarded there would leave it.'
+    );
+  }
+  const upstreamUrl = new URL(resolvedUpstream);
   const upstreamHost = upstreamUrl.hostname;
   const upstreamPort = Number(upstreamUrl.port) || 80;
 

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { StudioEventBus, type StudioServeEvent, type StudioTargetKind } from './studio-events.js';
 import {
+  describeEndpointForMessage,
+  normalizeLocalUpstream,
   startStudioProxy,
   type RunningStudioProxy,
   type StudioProxyConfig,
@@ -11,6 +13,7 @@ import {
 import { buildSharedChildArgs, type SharedChildConfig } from './studio-child-args.js';
 import { buildPerRunArgs, resolveEnvVars, type OptionValues } from './studio-option-specs.js';
 import { buildCatalogArgs, tokenizeRawArgs, type CatalogValues } from './studio-option-catalog.js';
+import { getLogger } from '../utils/logger.js';
 
 /** A request to start serving a target, as the studio UI posts it. */
 export interface StudioServeRequest {
@@ -162,6 +165,15 @@ interface ServeKindSpec {
    * The stdout line that signals readiness. Capture group 1, when present,
    * is the served endpoint URL (api / alb); a kind with no host endpoint
    * (ecs service — pure compute) matches with NO capture group.
+   *
+   * ANCHORED to the start of the line (issue #578). Every serve command emits
+   * its ready banner as a WHOLE line, so an unanchored pattern only ever
+   * ADDED matches — a phrase embedded mid-message, in cdk-local's own relayed
+   * diagnostics or in the served application's own output (`Server listening
+   * on http://0.0.0.0:3000` is an ordinary thing for a web framework in an
+   * ECS replica to print). Matched against the DECORATION-STRIPPED line
+   * ({@link classifyChildLine}), so `--verbose`'s timestamp + level preamble
+   * and a child logger's `[module]` tag do not break the anchor.
    */
   readyRe: RegExp;
   /** Front each HTTP endpoint with a capture proxy (api / alb yes, ecs no). */
@@ -174,6 +186,7 @@ interface ServeKindSpec {
    * contract): the ws:// endpoint passes straight through for the console while
    * the http:// endpoint is fronted by the capture proxy so `/invocations`
    * requests land on the timeline. Optional — only `agentcore-ws` sets it.
+   * Anchored + decoration-stripped exactly like {@link readyRe}.
    */
   extraEndpointRe?: RegExp;
 }
@@ -188,7 +201,7 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
   api: {
     command: 'start-api',
     portArgs: ['--port', '0', '--host', '127.0.0.1'],
-    readyRe: /Server listening on (\S+)/,
+    readyRe: /^Server listening on (\S+)/,
     capturesHttp: true,
   },
   alb: {
@@ -199,7 +212,7 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     // (capturing `generated`) and flip the serve to running prematurely.
     command: 'start-alb',
     portArgs: [],
-    readyRe: /ALB front-door: (https?:\/\/\S+)/,
+    readyRe: /^ALB front-door: (https?:\/\/\S+)/,
     capturesHttp: true,
   },
   ecs: {
@@ -207,7 +220,7 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     // capture. `Service(s) running:` is its stable ready marker.
     command: 'start-service',
     portArgs: [],
-    readyRe: /Service\(s\) running:/,
+    readyRe: /^Service\(s\) running:/,
     capturesHttp: false,
   },
   'ecs-task': {
@@ -218,7 +231,7 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     // banner) is its stable ready marker.
     command: 'run-task',
     portArgs: [],
-    readyRe: /Task running \(family=/,
+    readyRe: /^Task running \(family=/,
     capturesHttp: false,
   },
   cloudfront: {
@@ -229,7 +242,7 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     // requests land on the timeline.
     command: 'start-cloudfront',
     portArgs: ['--port', '0', '--host', '127.0.0.1'],
-    readyRe: /CloudFront distribution serving on (https?:\/\/\S+)/,
+    readyRe: /^CloudFront distribution serving on (https?:\/\/\S+)/,
     capturesHttp: true,
   },
   'agentcore-ws': {
@@ -246,9 +259,9 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     // (`HTTP contract served on http://...`) — extraEndpointRe captures it.
     command: 'start-agentcore',
     portArgs: ['--port', '0', '--host', '127.0.0.1'],
-    readyRe: /Server listening on (\S+)/,
+    readyRe: /^Server listening on (\S+)/,
     capturesHttp: true,
-    extraEndpointRe: /HTTP contract served on (https?:\/\/\S+)/,
+    extraEndpointRe: /^HTTP contract served on (https?:\/\/\S+)/,
   },
 };
 
@@ -256,16 +269,100 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
  * Parse an auto-published replica host endpoint from an `ecs` serve child's
  * stdout (issue #392). `start-service` publishes each replica's declared
  * container port on the host — auto-remapping a privileged port (< 1024) to a
- * free high port (issue #357) — and logs a line like
- * `... container port 80 published on 127.0.0.1:54321. Reach it at ...`. studio
- * surfaces the FIRST such endpoint as the serve's `hostUrl` so the in-workspace
- * request composer can target it even when the user passed no explicit
- * `--host-port`. Returns `http://<ip>:<port>` or `undefined` when the line does
- * not carry a published endpoint. Exported for unit testing.
+ * free high port (issue #357) — and logs the WHOLE line
+ * `Container 'web' container port 80 published on 127.0.0.1:54321. Reach it at
+ * 127.0.0.1:54321.` (`ecs-task-runner`). studio surfaces the FIRST such
+ * endpoint as the serve's `hostUrl` so the in-workspace request composer can
+ * target it even when the user passed no explicit `--host-port`. Returns
+ * `http://<ip>:<port>` or `undefined` when the line is not that banner.
+ * Exported for unit testing.
+ *
+ * ANCHORED to the whole banner (issue #578), not just the `published on`
+ * phrase: `hostUrl` is a destination the request composer posts to DIRECTLY,
+ * with no proxy in between, so a mid-message occurrence of the phrase — in a
+ * relayed error, or in a replica's own application output — must not be able
+ * to name it. Pass the decoration-stripped line ({@link classifyChildLine}).
+ * The loopback bound is applied by the CALLER (a parsed endpoint is still only
+ * adopted when {@link normalizeLocalUpstream} accepts it), so this stays a pure
+ * reader of the banner.
  */
 export function parsePublishedHostEndpoint(line: string): string | undefined {
-  const m = /published on (\d{1,3}(?:\.\d{1,3}){3}:\d+)/.exec(line);
+  const m = /^Container '[^']*' container port \d+ published on (\d{1,3}(?:\.\d{1,3}){3}:\d+)/.exec(
+    line
+  );
   return m ? `http://${m[1]}` : undefined;
+}
+
+/** ANSI SGR colour escapes, as the logger wraps a warn / error line with. */
+// eslint-disable-next-line no-control-regex -- ESC is exactly what is being stripped.
+const ANSI_SGR_RE = /\u001b\[[0-9;]*m/g;
+/** The verbose-mode preamble `<iso-timestamp> <LEVEL>  ` (`utils/logger`). */
+const VERBOSE_PREAMBLE_RE = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+(DEBUG|INFO|WARN|ERROR)\s+/;
+/** A child logger's `[module] ` tag (`utils/logger`'s `ChildLogger`). */
+const MODULE_TAG_RE = /^\[[^\]]*\]\s+/;
+/** The compact-mode level prefix `WARN: ` / `ERROR: ` (`utils/logger`). */
+const COMPACT_LEVEL_RE = /^(WARN|ERROR):\s/;
+
+/** One child stdout line, with cdk-local's own log decoration read off it. */
+export interface ClassifiedChildLine {
+  /**
+   * True when the line is one of cdk-local's OWN warn / error diagnostics.
+   * Such a line is never a ready banner, and it is the one place a
+   * wire-derived string (an AWS SDK error `message`) is relayed onto the
+   * child's stdout — so no endpoint is ever read out of it (issue #578).
+   */
+  diagnostic: boolean;
+  /**
+   * The line with ANSI colour, the verbose `<timestamp> <LEVEL>` preamble, a
+   * `[module]` child-logger tag and the compact `WARN: ` / `ERROR: ` prefix
+   * removed — so a ready pattern can be anchored to `^` regardless of which
+   * of the logger's two rendering modes the child ran in. Leading whitespace
+   * is NOT trimmed: the banners start at column 0, and trimming would let an
+   * indented line impersonate one.
+   */
+  text: string;
+}
+
+/**
+ * Read the log decoration off one child stdout line (issue #578).
+ *
+ * `cdkl studio` runs its serve children with `CDKL_LOG_STREAM=stdout` (issue
+ * #403), so cdk-local's own warn / error lines share the stream the ready
+ * banners arrive on. Those lines relay wire-derived text (an AWS SDK error's
+ * `message`), which is exactly the text that must never be able to name the
+ * endpoint studio proxies to. The compact renderer prefixes them `WARN: ` /
+ * `ERROR: ` (the same signal `studio-ui`'s `logLineClass` colours off) and the
+ * verbose renderer (`--verbose` / `CDKL_LOG_LEVEL=debug`, both reachable in a
+ * studio-spawned child) writes `<timestamp> <LEVEL>  [module] `. Both shapes
+ * are recognised here, so the caller can skip a diagnostic line AND anchor its
+ * patterns against `text` without the mode deciding whether the anchor holds.
+ */
+export function classifyChildLine(line: string): ClassifiedChildLine {
+  let text = line.replace(ANSI_SGR_RE, '');
+  let diagnostic = false;
+  const verbose = VERBOSE_PREAMBLE_RE.exec(text);
+  if (verbose) {
+    if (verbose[1] === 'WARN' || verbose[1] === 'ERROR') diagnostic = true;
+    text = text.slice(verbose[0].length);
+  }
+  // A `[module]` tag and a compact `WARN: ` prefix can both remain, in either
+  // order (the compact renderer emits `WARN: `; `studio-ui` also tolerates a
+  // leading tag before it), so strip up to two decorations.
+  for (let i = 0; i < 2; i += 1) {
+    const tag = MODULE_TAG_RE.exec(text);
+    if (tag) {
+      text = text.slice(tag[0].length);
+      continue;
+    }
+    const level = COMPACT_LEVEL_RE.exec(text);
+    if (level) {
+      diagnostic = true;
+      text = text.slice(level[0].length);
+      continue;
+    }
+    break;
+  }
+  return { diagnostic, text };
 }
 
 interface ServeEntry extends StudioServeState {
@@ -540,6 +637,24 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         resolve(publicState(entry));
       };
 
+      /**
+       * Refuse a destination a child's stdout named that is not on this
+       * machine (issue #578), and say so loudly: on the bus, so the studio
+       * LOGS panel shows it (rendered with the same `WARN: ` prefix the
+       * compact logger emits, which `studio-ui` colours), and on the studio
+       * process's own logger, for a user watching the terminal. The endpoint
+       * is untrusted text, so it is flattened + length-capped before being
+       * quoted back.
+       */
+      const refuseForeignEndpoint = (endpoint: string, what: string): void => {
+        const msg =
+          `refused a non-loopback ${what} '${describeEndpointForMessage(endpoint)}' from ` +
+          `'${req.targetId}': a serve child always listens on this machine, so studio will ` +
+          'not send requests there. No endpoint was adopted and no capture proxy was started.';
+        emitLog(config.bus, clock, req.targetId, `WARN: ${msg}`, 'stderr');
+        getLogger().warn(msg);
+      };
+
       // Handle a child ready line. `childUrl` (capture group 1) is the
       // served endpoint for api / alb — fronted with a capture proxy (slice
       // C2 / decision D4a) when `capturesHttp` so every request to it lands
@@ -547,7 +662,28 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       // through. An ecs service has NO endpoint (`childUrl` undefined): it
       // just flips to running with no endpoint + no proxy. The FIRST ready
       // line flips the serve to running; later ones append + re-emit.
-      const onReady = async (childUrl?: string): Promise<void> => {
+      const onReady = async (readyUrl?: string): Promise<void> => {
+        // Issue #578 — the bound that does not depend on getting the ready
+        // pattern exactly right: a serve child always listens on THIS machine,
+        // so an endpoint naming any other host did not come from a genuine
+        // ready banner. Refuse it outright — no proxy, no adopted endpoint, and
+        // no flip to running, since flipping would publish a foreign URL to the
+        // UI as this serve's endpoint. The serve stays `starting` and the ready
+        // timeout reports it honestly; the warn says why. A WILDCARD bind
+        // address (`--container-host 0.0.0.0`, or an `api` / `alb` bound to
+        // `::`) is a legitimate serve that IS reachable on loopback, so it is
+        // rewritten to `127.0.0.1` — and the REWRITTEN url is what is adopted
+        // as the endpoint and proxied to, so the composer targets a real
+        // destination rather than a bind address.
+        let childUrl = readyUrl;
+        if (readyUrl !== undefined) {
+          const local = normalizeLocalUpstream(readyUrl);
+          if (local === undefined) {
+            refuseForeignEndpoint(readyUrl, 'ready line');
+            return;
+          }
+          childUrl = local;
+        }
         let endpoint = childUrl;
         if (childUrl && spec.capturesHttp && captureRequests && /^https?:/i.test(childUrl)) {
           try {
@@ -577,27 +713,47 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       };
 
       streamLines(child.stdout, (line) => {
-        const m = spec.readyRe.exec(line);
-        // m[1] is the endpoint URL for api / alb; undefined for ecs (no
-        // capture group) — a ready line with no host endpoint.
-        if (m) void onReady(m[1]);
-        // An additional endpoint line (agentcore-ws: the http:// contract
-        // alongside the ws:// listen line). It does NOT flip the serve to
-        // running on its own (the readyRe line already did, or will) — onReady
-        // appends + re-emits the endpoint, fronting it with the capture proxy.
-        if (spec.extraEndpointRe) {
-          const me = spec.extraEndpointRe.exec(line);
-          if (me) void onReady(me[1]);
-        }
-        // An `ecs` serve auto-publishes its replica host port(s) (issue #392);
-        // surface the FIRST one as `hostUrl` so the request composer fires —
-        // unless an explicit `--host-port` already set it. The publish line can
-        // arrive after the ready line, so re-emit when the serve is running.
-        if (req.kind === 'ecs' && entry.hostUrl === undefined) {
-          const endpoint = parsePublishedHostEndpoint(line);
-          if (endpoint) {
-            entry.hostUrl = endpoint;
-            if (entry.status === 'running') emitServe(entry);
+        // Issue #578 — read the log decoration off the line ONCE, then match
+        // the banners against the stripped text. A WARN / ERROR line is
+        // cdk-local's own diagnostic, the one place wire-derived text (an AWS
+        // SDK error `message`) reaches this stream, so no endpoint is read out
+        // of it at all; the line is still logged verbatim below.
+        const parsed = classifyChildLine(line);
+        if (!parsed.diagnostic) {
+          const m = spec.readyRe.exec(parsed.text);
+          // m[1] is the endpoint URL for api / alb; undefined for ecs (no
+          // capture group) — a ready line with no host endpoint.
+          if (m) void onReady(m[1]);
+          // An additional endpoint line (agentcore-ws: the http:// contract
+          // alongside the ws:// listen line). It does NOT flip the serve to
+          // running on its own (the readyRe line already did, or will) —
+          // onReady appends + re-emits the endpoint, fronting it with the
+          // capture proxy.
+          if (spec.extraEndpointRe) {
+            const me = spec.extraEndpointRe.exec(parsed.text);
+            if (me) void onReady(me[1]);
+          }
+          // An `ecs` serve auto-publishes its replica host port(s) (issue
+          // #392); surface the FIRST one as `hostUrl` so the request composer
+          // fires — unless an explicit `--host-port` already set it. The
+          // publish line can arrive after the ready line, so re-emit when the
+          // serve is running. `hostUrl` is posted to DIRECTLY by the composer
+          // (no proxy in front), so it carries the same loopback bound the
+          // proxied endpoints do (issue #578).
+          if (req.kind === 'ecs' && entry.hostUrl === undefined) {
+            const endpoint = parsePublishedHostEndpoint(parsed.text);
+            if (endpoint) {
+              // Same resolution as the ready path: a wildcard `--container-host`
+              // publish is rewritten to loopback (that IS where it is
+              // reachable), anything else non-loopback is refused.
+              const local = normalizeLocalUpstream(endpoint);
+              if (local === undefined) {
+                refuseForeignEndpoint(endpoint, 'published replica endpoint');
+              } else {
+                entry.hostUrl = local;
+                if (entry.status === 'running') emitServe(entry);
+              }
+            }
           }
         }
         emitLog(config.bus, clock, req.targetId, line, 'stdout');

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -189,6 +189,25 @@ interface ServeKindSpec {
    * Anchored + decoration-stripped exactly like {@link readyRe}.
    */
   extraEndpointRe?: RegExp;
+  /**
+   * True when this kind legitimately prints its {@link readyRe} banner MORE
+   * THAN ONCE, so the post-ready stop below must NOT apply to it (issue #578).
+   *
+   * Exactly two kinds do, and both were verified at the emit site rather than
+   * assumed:
+   *
+   *   - `api` — `local-start-api` writes one banner per API GROUP and one per
+   *     WebSocket API (`process.stdout.write`, two consecutive loops).
+   *   - `alb` — `buildFrontDoor` logs one per LISTENER, and the loop `await`s
+   *     `startFrontDoorServer` between them, so those banners land in
+   *     DIFFERENT stdout chunks and therefore on different ticks. A
+   *     settle-based stop would silently drop every listener after the first.
+   *
+   * The other four print theirs once: `cloudfront` (one distribution per
+   * invocation), `agentcore-ws` (one listen line, either `ws://` or `http://`),
+   * and `ecs` / `ecs-task`, whose banners carry no capture group at all.
+   */
+  readyRepeats?: boolean;
 }
 
 /**
@@ -203,6 +222,8 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     portArgs: ['--port', '0', '--host', '127.0.0.1'],
     readyRe: /^Server listening on (\S+)/,
     capturesHttp: true,
+    // One banner per API group + one per WebSocket API.
+    readyRepeats: true,
   },
   alb: {
     // start-alb binds the deployed listener ports directly (no --port);
@@ -214,6 +235,8 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
     portArgs: [],
     readyRe: /^ALB front-door: (https?:\/\/\S+)/,
     capturesHttp: true,
+    // One banner per listener, and the loop awaits between them.
+    readyRepeats: true,
   },
   ecs: {
     // start-service runs the service replicas only — no host port, no
@@ -293,12 +316,41 @@ export function parsePublishedHostEndpoint(line: string): string | undefined {
   return m ? `http://${m[1]}` : undefined;
 }
 
+/**
+ * The one wording for "studio will not send requests to that destination"
+ * (issue #578), shared by every site that resolves a relay target: the ready
+ * line, the agentcore extra-endpoint line, the ecs replica publish banner, and
+ * the `--host-port` mapping. `endpoint` is untrusted text (child stdout, or a
+ * user-supplied flag value), so it is flattened + length-capped before being
+ * quoted back.
+ */
+function describeForeignEndpointRefusal(targetId: string, endpoint: string, what: string): string {
+  return (
+    `refused a non-loopback ${what} '${describeEndpointForMessage(endpoint)}' from ` +
+    `'${targetId}': a serve child always listens on this machine, so studio will ` +
+    'not send requests there. No endpoint was adopted and no capture proxy was started.'
+  );
+}
+
 /** ANSI SGR colour escapes, as the logger wraps a warn / error line with. */
 // eslint-disable-next-line no-control-regex -- ESC is exactly what is being stripped.
 const ANSI_SGR_RE = /\u001b\[[0-9;]*m/g;
 /** The verbose-mode preamble `<iso-timestamp> <LEVEL>  ` (`utils/logger`). */
 const VERBOSE_PREAMBLE_RE = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+(DEBUG|INFO|WARN|ERROR)\s+/;
-/** A child logger's `[module] ` tag (`utils/logger`'s `ChildLogger`). */
+/**
+ * A child logger's `[module] ` tag (`utils/logger`'s `ChildLogger`).
+ *
+ * Stripped ONLY after a verbose preamble, and ONLY for the ecs publish banner
+ * ({@link ClassifiedChildLine.untagged}) — never for the ready-banner match.
+ * `ChildLogger` emits the tag exclusively at `debug` level (`logger.ts`
+ * `info` / `warn` / `error` prefix only when `getLevel() === 'debug'`), which
+ * is also the level that renders the `<timestamp> <LEVEL>` preamble, so a BARE
+ * `[tag] ` at column 0 is never cdk-local's. It IS how relayed third-party
+ * container output arrives — `[<container>] ` (`ecs-task-runner`) and
+ * `[svc=... r=... c=...] ` (`ecs-service-runner`) — so stripping it
+ * unconditionally re-anchored an application's own log line to `^` and let it
+ * impersonate a ready banner (issue #578).
+ */
 const MODULE_TAG_RE = /^\[[^\]]*\]\s+/;
 /** The compact-mode level prefix `WARN: ` / `ERROR: ` (`utils/logger`). */
 const COMPACT_LEVEL_RE = /^(WARN|ERROR):\s/;
@@ -313,14 +365,26 @@ export interface ClassifiedChildLine {
    */
   diagnostic: boolean;
   /**
-   * The line with ANSI colour, the verbose `<timestamp> <LEVEL>` preamble, a
-   * `[module]` child-logger tag and the compact `WARN: ` / `ERROR: ` prefix
-   * removed — so a ready pattern can be anchored to `^` regardless of which
-   * of the logger's two rendering modes the child ran in. Leading whitespace
-   * is NOT trimmed: the banners start at column 0, and trimming would let an
+   * The line with ANSI colour, the verbose `<timestamp> <LEVEL>` preamble and
+   * the compact `WARN: ` / `ERROR: ` prefix removed — so a ready pattern can
+   * be anchored to `^` regardless of which of the logger's two rendering modes
+   * the child ran in. A `[module]` tag is deliberately NOT removed here: no
+   * ready banner is ever tag-prefixed (`start-api` / `start-cloudfront` use
+   * `process.stdout.write`; `start-alb` / `run-task` / `start-agentcore` use
+   * the ROOT logger), while relayed container output IS, so stripping it would
+   * hand a third-party log line the `^` anchor. Leading whitespace is NOT
+   * trimmed either: the banners start at column 0, and trimming would let an
    * indented line impersonate one.
    */
   text: string;
+  /**
+   * {@link text} with one leading `[module] ` tag additionally removed, and
+   * ONLY when a verbose preamble preceded it — the single shape a cdk-local
+   * child logger can emit. Used by exactly one caller: the ecs publish banner
+   * ({@link parsePublishedHostEndpoint}), the one banner written through
+   * `getLogger().child('ecs')`. The ready-banner match reads {@link text}.
+   */
+  untagged: string;
 }
 
 /**
@@ -345,24 +409,20 @@ export function classifyChildLine(line: string): ClassifiedChildLine {
     if (verbose[1] === 'WARN' || verbose[1] === 'ERROR') diagnostic = true;
     text = text.slice(verbose[0].length);
   }
-  // A `[module]` tag and a compact `WARN: ` prefix can both remain, in either
-  // order (the compact renderer emits `WARN: `; `studio-ui` also tolerates a
-  // leading tag before it), so strip up to two decorations.
-  for (let i = 0; i < 2; i += 1) {
-    const tag = MODULE_TAG_RE.exec(text);
-    if (tag) {
-      text = text.slice(tag[0].length);
-      continue;
-    }
-    const level = COMPACT_LEVEL_RE.exec(text);
-    if (level) {
-      diagnostic = true;
-      text = text.slice(level[0].length);
-      continue;
-    }
-    break;
+  const level = COMPACT_LEVEL_RE.exec(text);
+  if (level) {
+    diagnostic = true;
+    text = text.slice(level[0].length);
   }
-  return { diagnostic, text };
+  // The module tag is peeled into a SEPARATE field, and only behind a verbose
+  // preamble — see {@link MODULE_TAG_RE}. A bare `[tag] ` at column 0 is
+  // relayed container output, so `text` keeps it and no ready pattern anchors.
+  let untagged = text;
+  if (verbose) {
+    const tag = MODULE_TAG_RE.exec(text);
+    if (tag) untagged = text.slice(tag[0].length);
+  }
+  return { diagnostic, text, untagged };
 }
 
 interface ServeEntry extends StudioServeState {
@@ -602,7 +662,27 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         const first = hp.find(
           (r) => r && typeof r === 'object' && typeof r.right === 'string' && r.right.trim() !== ''
         );
-        if (first) entry.hostUrl = 'http://127.0.0.1:' + first.right.trim();
+        if (first) {
+          // Issue #578 review — the ONE relay destination that used to skip
+          // the loopback bound. The port half is interpolated verbatim, so
+          // `--host-port 80=1@evil.example` yields `http://127.0.0.1:1@evil.
+          // example`, whose HOST is `evil.example`. It is user-supplied rather
+          // than child-supplied, but it is the same destination the composer
+          // posts to directly, so it goes through the same resolution.
+          const candidate = 'http://127.0.0.1:' + first.right.trim();
+          const local = normalizeLocalUpstream(candidate);
+          if (local === undefined) {
+            const msg = describeForeignEndpointRefusal(
+              req.targetId,
+              candidate,
+              '--host-port mapping'
+            );
+            emitLog(config.bus, clock, req.targetId, `WARN: ${msg}`, 'stderr');
+            getLogger().warn(msg);
+          } else {
+            entry.hostUrl = local;
+          }
+        }
       }
     }
     entries.set(req.targetId, entry);
@@ -646,13 +726,45 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
        * is untrusted text, so it is flattened + length-capped before being
        * quoted back.
        */
-      const refuseForeignEndpoint = (endpoint: string, what: string): void => {
-        const msg =
-          `refused a non-loopback ${what} '${describeEndpointForMessage(endpoint)}' from ` +
-          `'${req.targetId}': a serve child always listens on this machine, so studio will ` +
-          'not send requests there. No endpoint was adopted and no capture proxy was started.';
+      const refuseForeignEndpoint = (endpoint: string, what: string): string => {
+        const msg = describeForeignEndpointRefusal(req.targetId, endpoint, what);
         emitLog(config.bus, clock, req.targetId, `WARN: ${msg}`, 'stderr');
         getLogger().warn(msg);
+        return msg;
+      };
+
+      /**
+       * Fail the serve NOW with `reason`, instead of leaving it `starting`
+       * until `readyTimeoutMs` expires (issue #578 review).
+       *
+       * A refused ready line is terminal: the child named the only endpoint it
+       * is going to name, and studio will not use it. Waiting out the default
+       * 120 s and then reporting `did not start within 120000ms` buries the
+       * real cause in the LOGS panel, and it is a live configuration rather
+       * than an attack that lands here — `cdkl start-alb --container-host
+       * <non-loopback>` makes the front-door banner the refused line. Mirrors
+       * the timeout path exactly (graceful SIGTERM so the child tears its own
+       * containers down, proxies closed, entry dropped) but carries the
+       * refusal text as the failure reason, so the UI error banner says why.
+       *
+       * The trade: a serve that would have recovered — a foreign-looking line
+       * arriving BEFORE the genuine banner — now dies instead of waiting. That
+       * line has to clear bound 1 (not a WARN / ERROR), bound 2 (column 0, and
+       * as of this change not tag-stripped) and still name a non-loopback,
+       * non-wildcard host, which is the misconfiguration case far more than
+       * the coincidence case; and the old outcome for it was a 120 s wait
+       * ending in the same failure with a worse message.
+       */
+      const failServe = (reason: string): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeoutFn(timer);
+        entry.status = 'error';
+        emitServe(entry, reason);
+        void stopChild(child, stopGraceMs, setTimeoutFn, clearTimeoutFn);
+        void closeProxies(entry);
+        entries.delete(req.targetId);
+        reject(new Error(reason));
       };
 
       // Handle a child ready line. `childUrl` (capture group 1) is the
@@ -679,7 +791,12 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         if (readyUrl !== undefined) {
           const local = normalizeLocalUpstream(readyUrl);
           if (local === undefined) {
-            refuseForeignEndpoint(readyUrl, 'ready line');
+            const msg = refuseForeignEndpoint(readyUrl, 'ready line');
+            // Terminal when the serve has no endpoint yet: settle NOW with the
+            // refusal as the reason rather than hanging until the ready
+            // timeout. Once running (an agentcore extra-endpoint line, a later
+            // alb listener) the serve keeps serving what it already has.
+            failServe(msg);
             return;
           }
           childUrl = local;
@@ -696,9 +813,22 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
             entry.proxies.push(proxy);
             endpoint = proxy.url;
           } catch {
-            // Proxy failed to bind — fall back to the direct child URL so
-            // the serve is still usable (just uncaptured).
-            endpoint = childUrl;
+            // Proxy failed to bind — fall back to the direct child URL so the
+            // serve is still usable (just uncaptured). Re-resolve it: the
+            // value published here is a destination the composer posts to with
+            // no proxy in front, and `startStudioProxy` enforces the same
+            // loopback bound by THROWING, so a caller that lost the guard
+            // above would otherwise have its refusal caught here and the
+            // foreign URL handed to the UI anyway (issue #578, defence in
+            // depth). Idempotent on the normal path — `childUrl` is already
+            // the resolved value.
+            const direct = normalizeLocalUpstream(childUrl);
+            if (direct === undefined) {
+              const msg = refuseForeignEndpoint(childUrl, 'ready line');
+              failServe(msg);
+              return;
+            }
+            endpoint = direct;
           }
         }
         // A stop() may have raced the async proxy startup; if so, drop the
@@ -720,7 +850,34 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         // of it at all; the line is still logged verbatim below.
         const parsed = classifyChildLine(line);
         if (!parsed.diagnostic) {
-          const m = spec.readyRe.exec(parsed.text);
+          // Issue #578 — stop reading `readyRe` once the serve has SETTLED,
+          // for the kinds whose banner is a single event. The banner marks a
+          // serve coming up, so a line arriving after that is not one, and
+          // letting it through is how an ordinary relayed handler log —
+          // `Server listening on http://127.0.0.1:9999`, at column 0 with no
+          // prefix, since Lambda container output is piped through raw
+          // (`docker-runner`'s `streamLogs`) — can add an endpoint and point a
+          // capture proxy, carrying the developer's headers and body, at a
+          // port it named. It stays on-box (the loopback bound holds), and it
+          // is additive rather than a re-point (the first endpoint, the one
+          // the UI shows, is never overwritten), but it is still a
+          // destination the child chose after boot.
+          //
+          // Where the line is drawn, and why it is not drawn wider: `api` and
+          // `alb` legitimately print the banner MORE THAN ONCE (see
+          // `ServeKindSpec.readyRepeats` — per API group / per WebSocket API,
+          // and per ALB listener with an `await` between them), so applying
+          // the stop there would silently drop real endpoints. Their residual
+          // is what bound 2 and bound 3 cover; closing it properly means
+          // prefixing relayed CONTAINER output the way ECS already does, which
+          // is `docker-runner`'s to fix, not this matcher's.
+          //
+          // The stop is scoped to `readyRe` alone. Two reads are legitimately
+          // post-settle and stay live: `extraEndpointRe` (agentcore's `http://`
+          // contract line, which by design follows the `ws://` listen line) and
+          // the `ecs` publish banner (one per replica, as containers come up).
+          // Both are narrower than `readyRe` and both keep the loopback bound.
+          const m = spec.readyRepeats || !settled ? spec.readyRe.exec(parsed.text) : null;
           // m[1] is the endpoint URL for api / alb; undefined for ecs (no
           // capture group) — a ready line with no host endpoint.
           if (m) void onReady(m[1]);
@@ -741,7 +898,10 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
           // (no proxy in front), so it carries the same loopback bound the
           // proxied endpoints do (issue #578).
           if (req.kind === 'ecs' && entry.hostUrl === undefined) {
-            const endpoint = parsePublishedHostEndpoint(parsed.text);
+            // The ONE banner a cdk-local child logger emits, so the one read
+            // that may look past a `[module]` tag — and only behind a verbose
+            // preamble (see `classifyChildLine`).
+            const endpoint = parsePublishedHostEndpoint(parsed.untagged);
             if (endpoint) {
               // Same resolution as the ready path: a wildcard `--container-host`
               // publish is rewritten to loopback (that IS where it is

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -741,7 +741,17 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       child.stderr.setEncoding('utf8');
 
       const timer = setTimeoutFn(() => {
-        if (settled) return;
+        // `entry.stopping` as well as `settled`, matching `failServe`. Without
+        // it a user `stop()` during boot produces `starting -> error -> stopped`
+        // -- an error banner for a serve they deliberately stopped, the exact
+        // symptom `failServe` guards against one screen below.
+        //
+        // The `entries.delete` below is the sharper reason: it is keyed by
+        // TARGET, not by this entry, so if the same target was restarted inside
+        // the window this stale timer evicts the NEW, running entry. Its child
+        // then has no record in `entries`, so it can never be stopped and its
+        // proxy is never closed, while this branch SIGTERMs the old child.
+        if (settled || entry.stopping) return;
         settled = true;
         entry.status = 'error';
         emitServe(entry, `Timed out after ${readyTimeoutMs}ms waiting for the serve to be ready.`);
@@ -750,7 +760,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         // on a half-booted child would orphan those containers.
         void stopChild(child, stopGraceMs, setTimeoutFn, clearTimeoutFn);
         void closeProxies(entry);
-        entries.delete(req.targetId);
+        if (entries.get(req.targetId) === entry) entries.delete(req.targetId);
         reject(new Error(`'${req.targetId}' did not start within ${readyTimeoutMs}ms.`));
       }, readyTimeoutMs);
       timer.unref?.();

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -325,11 +325,35 @@ export function parsePublishedHostEndpoint(line: string): string | undefined {
  * quoted back.
  */
 function describeForeignEndpointRefusal(targetId: string, endpoint: string, what: string): string {
+  const quoted = `'${describeEndpointForMessage(endpoint)}'`;
+  const outcome = 'No endpoint was adopted and no capture proxy was started.';
+  // Two different faults reach this one refusal, and calling both
+  // "non-loopback" misnames the commoner one: `--host-port 80=abc` builds
+  // `http://127.0.0.1:abc`, which `new URL` rejects for its port — a value
+  // that names loopback and is refused for not parsing at all. So does
+  // `http://:::8080` (an unbracketed IPv6 authority), which now also tears the
+  // whole serve down, making the wrong reason more expensive to misread.
+  if (!parsesAsUrl(endpoint)) {
+    return (
+      `refused an unparseable ${what} ${quoted} from '${targetId}': it is not a URL, ` +
+      `so studio cannot tell where a request to it would go. ${outcome}`
+    );
+  }
   return (
-    `refused a non-loopback ${what} '${describeEndpointForMessage(endpoint)}' from ` +
+    `refused a non-loopback ${what} ${quoted} from ` +
     `'${targetId}': a serve child always listens on this machine, so studio will ` +
-    'not send requests there. No endpoint was adopted and no capture proxy was started.'
+    `not send requests there. ${outcome}`
   );
+}
+
+/** True when `value` is a URL the WHATWG parser accepts. */
+function parsesAsUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** ANSI SGR colour escapes, as the logger wraps a warn / error line with. */
@@ -427,8 +451,27 @@ export function classifyChildLine(line: string): ClassifiedChildLine {
 
 interface ServeEntry extends StudioServeState {
   child: ChildProcessWithoutNullStreams;
-  /** Capture proxies fronting this serve's HTTP endpoints (slice C2). */
-  proxies: RunningStudioProxy[];
+  /**
+   * Capture proxies fronting this serve's HTTP endpoints (slice C2), keyed by
+   * the RESOLVED upstream each one forwards to.
+   *
+   * A map rather than a list, because `api` / `alb` are exempt from the
+   * post-settle `readyRe` stop (see {@link ServeKindSpec.readyRepeats}) and so
+   * can match the banner any number of times. Starting a fresh proxy per match
+   * bound the socket count to the child's OUTPUT: a handler behind `start-api`
+   * logging `Server listening on http://127.0.0.1:9999` once per invocation
+   * gave N listening sockets and N UI endpoints, released only at serve stop.
+   * The endpoint dedup downstream could never catch it — every proxy carries a
+   * fresh port, so `proxy.url` differs each time. Keying by upstream reuses the
+   * proxy already fronting that destination, while a genuinely NEW upstream
+   * (the multi-listener `alb` case) still gets its own.
+   *
+   * The value is the PENDING promise, not the settled proxy: two identical
+   * ready lines in one stdout chunk both reach this map before either
+   * `proxyFactory` call resolves, so caching the promise is what makes the
+   * second one a reuse instead of a race.
+   */
+  proxies: Map<string, Promise<RunningStudioProxy>>;
   /**
    * Temp dir holding the `--env-vars` SAM-shape file (issue #355), when the
    * serve was started with env-var overrides. Removed on teardown (the file
@@ -490,8 +533,12 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
    * leaks when a serve stops / errors / times out.
    */
   async function closeProxies(e: ServeEntry): Promise<void> {
-    const proxies = e.proxies.splice(0);
-    await Promise.all(proxies.map((p) => p.close().catch(() => undefined)));
+    const proxies = [...e.proxies.values()];
+    e.proxies.clear();
+    // Each entry is a PENDING proxy promise; await it before closing so a
+    // proxy still binding when the serve tears down is not orphaned, and
+    // swallow a rejected one (it never bound, so there is nothing to close).
+    await Promise.all(proxies.map((p) => p.then((x) => x.close()).catch(() => undefined)));
     if (e.envDir) {
       try {
         rmSync(e.envDir, { recursive: true, force: true });
@@ -647,7 +694,7 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
       endpoints: [],
       startedAt,
       child,
-      proxies: [],
+      proxies: new Map(),
     };
     if (child.pid !== undefined) entry.pid = child.pid;
     // Bind the env temp dir to the entry so closeProxies removes it on teardown.
@@ -756,7 +803,14 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
        * ending in the same failure with a worse message.
        */
       const failServe = (reason: string): void => {
-        if (settled) return;
+        // `entry.stopping` as well as `settled`, mirroring the `close` handler
+        // below: `stop()` marks the entry, drops it from the map and then
+        // awaits `stopChild` for up to `stopGraceMs` (45 s — an ALB teardown
+        // really takes that long). A refused ready line arriving inside that
+        // window used to emit an `error` serve event and reject `start()`,
+        // giving the UI a failure banner for a serve the user deliberately
+        // stopped, immediately followed by the `stopped` event.
+        if (settled || entry.stopping) return;
         settled = true;
         clearTimeoutFn(timer);
         entry.status = 'error';
@@ -804,15 +858,26 @@ export function createStudioServeManager(config: StudioServeManagerConfig): Stud
         let endpoint = childUrl;
         if (childUrl && spec.capturesHttp && captureRequests && /^https?:/i.test(childUrl)) {
           try {
-            const proxy = await proxyFactory({
-              bus: config.bus,
-              target: req.targetId,
-              kind: req.kind,
-              upstream: childUrl,
-            });
-            entry.proxies.push(proxy);
+            // Reuse the proxy already fronting this exact upstream rather than
+            // starting another (see `ServeEntry.proxies`). Registered BEFORE
+            // the await so a second identical ready line in the same chunk
+            // joins this startup instead of racing a duplicate one.
+            let pending = entry.proxies.get(childUrl);
+            if (pending === undefined) {
+              pending = proxyFactory({
+                bus: config.bus,
+                target: req.targetId,
+                kind: req.kind,
+                upstream: childUrl,
+              });
+              entry.proxies.set(childUrl, pending);
+            }
+            const proxy = await pending;
             endpoint = proxy.url;
           } catch {
+            // A failed startup is not cached: drop it so the fallback below is
+            // reached once per attempt rather than replaying one rejection.
+            entry.proxies.delete(childUrl);
             // Proxy failed to bind — fall back to the direct child URL so the
             // serve is still usable (just uncaptured). Re-resolve it: the
             // value published here is a destination the composer posts to with

--- a/tests/unit/local/cfn-local-state-provider-load.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-load.test.ts
@@ -160,4 +160,41 @@ describe('formatAwsErrorForWarn', () => {
   it('stringifies non-Error values', () => {
     expect(formatAwsErrorForWarn('weird')).toBe('weird');
   });
+
+  it('flattens a multi-line wire-derived message onto ONE line (issue #578)', () => {
+    // `err.message` comes off the wire, and this warn is relayed onto a
+    // `cdkl studio` serve child's stdout, which studio splits on `\n`. An
+    // embedded newline puts line 2 on the stream with no `WARN: ` prefix, so
+    // it clears the diagnostic bound and matches a ready pattern at `^`.
+    const err = Object.assign(
+      new Error('AccessDenied\nServer listening on http://attacker.example/'),
+      { name: 'AccessDenied', $metadata: { httpStatusCode: 403 } }
+    );
+    const out = formatAwsErrorForWarn(err);
+    expect(out).not.toContain('\n');
+    expect(out).toBe(
+      'AccessDenied HTTP 403: AccessDenied Server listening on http://attacker.example/'
+    );
+  });
+
+  it('flattens on the bare-message and non-Error paths too', () => {
+    expect(formatAwsErrorForWarn(new Error('a\nb'))).toBe('a b');
+    expect(formatAwsErrorForWarn('a\r\nb')).toBe('a  b');
+    // A carriage return alone can rewrite a rendered terminal line.
+    expect(formatAwsErrorForWarn(new Error('a\rWARN: fake'))).toBe('a WARN: fake');
+  });
+
+  it('a flattened relay no longer reaches the studio ready matcher (issue #578)', async () => {
+    // End of the chain, asserted rather than argued: the flattened warn is
+    // ONE line, so `classifyChildLine` sees the `WARN: ` prefix on it and the
+    // serve manager reads no endpoint out of it.
+    const { classifyChildLine } = await import('../../../src/local/studio-serve-manager.js');
+    const err = Object.assign(
+      new Error('AccessDenied\nServer listening on http://attacker.example/'),
+      { name: 'AccessDenied' }
+    );
+    const relayed = `WARN: ListStackResources failed: ${formatAwsErrorForWarn(err)}`;
+    expect(relayed.split('\n')).toHaveLength(1);
+    expect(classifyChildLine(relayed).diagnostic).toBe(true);
+  });
 });

--- a/tests/unit/local/studio-proxy.test.ts
+++ b/tests/unit/local/studio-proxy.test.ts
@@ -2,7 +2,14 @@ import { createServer, request as httpRequest, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { describe, it, expect, afterEach } from 'vite-plus/test';
 import { StudioEventBus, type StudioInvocationEvent } from '../../../src/local/studio-events.js';
-import { startStudioProxy, type RunningStudioProxy } from '../../../src/local/studio-proxy.js';
+import {
+  describeEndpointForMessage,
+  isLoopbackHostname,
+  isWildcardHostname,
+  normalizeLocalUpstream,
+  startStudioProxy,
+  type RunningStudioProxy,
+} from '../../../src/local/studio-proxy.js';
 
 const upstreams: Server[] = [];
 const proxies: RunningStudioProxy[] = [];
@@ -305,4 +312,187 @@ describe('startStudioProxy', () => {
   // is verified out-of-band (a standalone handshake + echo round-trip
   // passes) and mirrors the already-tested `front-door-server` WS bridge;
   // the gap is tracked as an accepted known cost in the PR body.
+});
+
+
+// ---------------------------------------------------------------------------
+// Issue #578 - the proxy forwards the developer's request (headers + body) to
+// whatever host its upstream names, so it enforces the loopback bound itself
+// rather than trusting the caller to have checked.
+// ---------------------------------------------------------------------------
+
+describe('isLoopbackHostname (issue #578)', () => {
+  it('accepts every spelling of this machine', () => {
+    for (const h of [
+      '127.0.0.1',
+      '127.0.0.53',
+      '127.5.5.5',
+      'localhost',
+      'LOCALHOST',
+      '::1',
+      '[::1]',
+      '0:0:0:0:0:0:0:1',
+      '::ffff:127.0.0.1',
+      '[::ffff:7f00:1]',
+    ]) {
+      expect(isLoopbackHostname(h), h).toBe(true);
+    }
+  });
+
+  it('refuses every other host, including the near-misses', () => {
+    for (const h of [
+      '0.0.0.0',
+      '192.168.0.5',
+      '169.254.169.254',
+      '10.0.0.1',
+      'attacker.example',
+      'localhost.attacker.example',
+      'my-localhost',
+      '127.0.0.1.attacker.example',
+      '2130706433.attacker.example',
+      '999.0.0.1',
+      '[2001:db8::1]',
+      '::ffff:169.254.169.254',
+      '',
+    ]) {
+      expect(isLoopbackHostname(h), h).toBe(false);
+    }
+  });
+});
+
+describe('normalizeLocalUpstream over a whole URL (issue #578)', () => {
+  it('accepts every loopback spelling a URL can normalise, including the compressed and integer forms', () => {
+    expect(normalizeLocalUpstream('http://127.0.0.1:51234')).toBe('http://127.0.0.1:51234');
+    expect(normalizeLocalUpstream('ws://localhost:49160/ws')).toBe('ws://localhost:49160/ws');
+    expect(normalizeLocalUpstream('http://[::1]:51234/x')).toBe('http://[::1]:51234/x');
+    // `URL` normalises both of these to the hostname `127.0.0.1`, so they are
+    // loopback despite not looking like it.
+    expect(normalizeLocalUpstream('http://127.1:8080')).toBe('http://127.1:8080');
+    expect(normalizeLocalUpstream('http://2130706433:8080')).toBe('http://2130706433:8080');
+  });
+
+  it('refuses a foreign host, and refuses what it cannot parse rather than guessing', () => {
+    expect(normalizeLocalUpstream('http://attacker.example/')).toBeUndefined();
+    expect(normalizeLocalUpstream('not-a-url')).toBeUndefined();
+    expect(normalizeLocalUpstream('')).toBeUndefined();
+  });
+});
+
+describe('describeEndpointForMessage (issue #578)', () => {
+  it('flattens control characters so a quoted endpoint cannot forge output', () => {
+    expect(describeEndpointForMessage('http://a.example/\u001b[31m\r\nWARN: fake')).toBe(
+      'http://a.example/?[31m??WARN: fake'
+    );
+  });
+
+  it('caps the length', () => {
+    const long = `http://${'a'.repeat(400)}.example/`;
+    const out = describeEndpointForMessage(long);
+    expect(out.length).toBe(123);
+    expect(out.endsWith('...')).toBe(true);
+  });
+});
+
+describe('startStudioProxy upstream bound (issue #578)', () => {
+  it('refuses a non-loopback upstream', () => {
+    for (const upstream of [
+      'http://attacker.example/',
+      'http://169.254.169.254:80',
+      'http://localhost.attacker.example:8080',
+    ]) {
+      // Thrown synchronously, like the `new URL(upstream)` parse failure right
+      // above it - both are refusals to even attempt a proxy, and every caller
+      // reaches this inside a try / catch.
+      expect(
+        () =>
+          startStudioProxy({
+            bus: new StudioEventBus(),
+            target: 'MyApi',
+            kind: 'api',
+            upstream,
+          }),
+        upstream
+      ).toThrow(/non-loopback upstream/);
+    }
+  });
+
+  it('still fronts a loopback upstream', async () => {
+    const bus = new StudioEventBus();
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('ok');
+    });
+    const proxy = await boot(bus, upstream);
+    const res = await httpReq(`${proxy.url}/`);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('ok');
+  });
+});
+
+
+describe('isWildcardHostname (issue #578)', () => {
+  it('recognises every spelling of the unspecified address', () => {
+    for (const h of ['0.0.0.0', '::', '[::]', '0:0:0:0:0:0:0:0', '::ffff:0.0.0.0', '[::ffff:0:0]']) {
+      expect(isWildcardHostname(h), h).toBe(true);
+    }
+  });
+
+  it('is not fooled by a host that merely starts with a zero', () => {
+    for (const h of ['0.0.0.1', '10.0.0.0', '0.0.0.0.attacker.example', '127.0.0.1', '']) {
+      expect(isWildcardHostname(h), h).toBe(false);
+    }
+  });
+});
+
+describe('normalizeLocalUpstream (issue #578)', () => {
+  it('rewrites a wildcard bind address to loopback, host token only', () => {
+    expect(normalizeLocalUpstream('http://0.0.0.0:51234')).toBe('http://127.0.0.1:51234');
+    expect(normalizeLocalUpstream('http://[::]:51234')).toBe('http://127.0.0.1:51234');
+    expect(normalizeLocalUpstream('http://[0:0:0:0:0:0:0:0]:51234')).toBe('http://127.0.0.1:51234');
+    expect(normalizeLocalUpstream('http://[::ffff:0.0.0.0]:51234')).toBe('http://127.0.0.1:51234');
+    // Scheme / port / path / query ride through unchanged.
+    expect(normalizeLocalUpstream('ws://[::]:49160/ws')).toBe('ws://127.0.0.1:49160/ws');
+    expect(normalizeLocalUpstream('https://0.0.0.0:8443/a/b?q=1#f')).toBe(
+      'https://127.0.0.1:8443/a/b?q=1#f'
+    );
+    expect(normalizeLocalUpstream('http://0.0.0.0')).toBe('http://127.0.0.1');
+  });
+
+  it('returns a loopback upstream byte-for-byte (no re-serialisation)', () => {
+    for (const u of ['http://127.0.0.1:51234', 'ws://localhost:49160/ws', 'http://[::1]:8080/x']) {
+      expect(normalizeLocalUpstream(u), u).toBe(u);
+    }
+  });
+
+  it('still refuses a foreign or unparseable upstream', () => {
+    for (const u of [
+      'http://attacker.example/',
+      'http://169.254.169.254:80',
+      'http://192.168.0.5:3000',
+      'http://localhost.attacker.example:8080',
+      'http://127.0.0.1.attacker.example:8080',
+      'not-a-url',
+      '',
+    ]) {
+      expect(normalizeLocalUpstream(u), u).toBeUndefined();
+    }
+  });
+});
+
+describe('startStudioProxy wildcard upstream (issue #578)', () => {
+  it('accepts a wildcard upstream and forwards it to loopback', async () => {
+    const bus = new StudioEventBus();
+    // The real upstream listens on 127.0.0.1 only; naming it `0.0.0.0` must
+    // still reach it, which it can only do if the proxy rewrote the
+    // DESTINATION rather than merely tolerating the string.
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('via-loopback');
+    });
+    const port = new URL(upstream).port;
+    const proxy = await boot(bus, `http://0.0.0.0:${port}`);
+    const res = await httpReq(`${proxy.url}/`);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('via-loopback');
+  });
 });

--- a/tests/unit/local/studio-proxy.test.ts
+++ b/tests/unit/local/studio-proxy.test.ts
@@ -616,7 +616,7 @@ describe('startStudioProxy wildcard upstream (issue #578)', () => {
 });
 
 describe('startStudioProxy IPv6 loopback upstream (issue #578 review)', () => {
-  it('forwards to a `[::1]` upstream instead of 502ing on the brackets', async () => {
+  it('forwards to a `[::1]` upstream instead of 502ing on the brackets', async (ctx) => {
     // `isLoopbackHostname` tolerates the brackets `URL.hostname` keeps on an
     // IPv6 literal, so `http://[::1]:<port>` is ACCEPTED - and `node:http`
     // then looks `[::1]` up as a NAME and fails `ENOTFOUND`, making every
@@ -630,8 +630,12 @@ describe('startStudioProxy IPv6 loopback upstream (issue #578 review)', () => {
         res.end('via-ipv6-loopback');
       }, '::1');
     } catch {
-      // No IPv6 loopback on this host: there is nothing to bind, so there is
-      // no claim to make either way.
+      // No IPv6 loopback on this host: there is nothing to bind, so there is no
+      // claim to make either way. Report it as SKIPPED rather than returning --
+      // a bare `return` passes with ZERO assertions, which is indistinguishable
+      // from a real pass, and that is precisely the "passed for the wrong
+      // reason" failure this file's `[::]` case exists to correct.
+      ctx.skip();
       return;
     }
     const bus = new StudioEventBus();

--- a/tests/unit/local/studio-proxy.test.ts
+++ b/tests/unit/local/studio-proxy.test.ts
@@ -29,14 +29,24 @@ afterEach(async () => {
   );
 });
 
-/** Boot a throwaway upstream HTTP server with the given handler. */
-function bootUpstream(handler: Parameters<typeof createServer>[1]): Promise<string> {
-  return new Promise((resolve) => {
+/**
+ * Boot a throwaway upstream HTTP server with the given handler, bound to
+ * `host` (default `127.0.0.1`). Resolves the URL it is REACHABLE at, which is
+ * not always the URL a test addresses it by - the wildcard / IPv6 cases below
+ * deliberately address it by a different spelling and assert it is still hit.
+ */
+function bootUpstream(
+  handler: Parameters<typeof createServer>[1],
+  host = '127.0.0.1'
+): Promise<string> {
+  return new Promise((resolve, reject) => {
     const server = createServer(handler);
     upstreams.push(server);
-    server.listen(0, '127.0.0.1', () => {
+    server.once('error', reject);
+    server.listen(0, host, () => {
       const port = (server.address() as AddressInfo).port;
-      resolve(`http://127.0.0.1:${port}`);
+      const authority = host.includes(':') ? `[${host}]` : host;
+      resolve(`http://${authority}:${port}`);
     });
   });
 }
@@ -314,7 +324,6 @@ describe('startStudioProxy', () => {
   // the gap is tracked as an accepted known cost in the PR body.
 });
 
-
 // ---------------------------------------------------------------------------
 // Issue #578 - the proxy forwards the developer's request (headers + body) to
 // whatever host its upstream names, so it enforces the loopback bound itself
@@ -569,11 +578,14 @@ describe('normalizeLocalUpstream (issue #578)', () => {
 });
 
 describe('startStudioProxy wildcard upstream (issue #578)', () => {
-  it('accepts a wildcard upstream and forwards it to loopback', async () => {
+  it('accepts the `0.0.0.0` wildcard and forwards it', async () => {
+    // `0.0.0.0` is the ordinary `--container-host` spelling, so ACCEPTING it
+    // is the property under test here - and only that. It does NOT prove the
+    // rewrite: `connect()` to `0.0.0.0` reaches a `127.0.0.1`-only listener on
+    // this platform anyway, so a proxy forwarding `config.upstream` RAW passes
+    // this case too. (It was written claiming otherwise; the `::` case below
+    // is the one that discriminates.)
     const bus = new StudioEventBus();
-    // The real upstream listens on 127.0.0.1 only; naming it `0.0.0.0` must
-    // still reach it, which it can only do if the proxy rewrote the
-    // DESTINATION rather than merely tolerating the string.
     const upstream = await bootUpstream((_req, res) => {
       res.writeHead(200, { 'content-type': 'text/plain' });
       res.end('via-loopback');
@@ -583,5 +595,49 @@ describe('startStudioProxy wildcard upstream (issue #578)', () => {
     const res = await httpReq(`${proxy.url}/`);
     expect(res.status).toBe(200);
     expect(res.body).toBe('via-loopback');
+  });
+
+  it('rewrites the `::` wildcard to loopback, which is the only way this lands', async () => {
+    // The discriminating spelling. `::` against a `127.0.0.1`-only listener is
+    // ECONNREFUSED, so a 200 here can ONLY come from the destination having
+    // been rewritten to `127.0.0.1` before the forward - a proxy that hands
+    // `config.upstream` through raw 502s instead.
+    const bus = new StudioEventBus();
+    const upstream = await bootUpstream((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('via-loopback');
+    });
+    const port = new URL(upstream).port;
+    const proxy = await boot(bus, `http://[::]:${port}`);
+    const res = await httpReq(`${proxy.url}/`);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('via-loopback');
+  });
+});
+
+describe('startStudioProxy IPv6 loopback upstream (issue #578 review)', () => {
+  it('forwards to a `[::1]` upstream instead of 502ing on the brackets', async () => {
+    // `isLoopbackHostname` tolerates the brackets `URL.hostname` keeps on an
+    // IPv6 literal, so `http://[::1]:<port>` is ACCEPTED - and `node:http`
+    // then looks `[::1]` up as a NAME and fails `ENOTFOUND`, making every
+    // request through such a proxy a 502. Accepted-then-broken is the worst of
+    // the three outcomes, and `--host ::1` reaches it through a serve's raw
+    // extra args. Asserts the BODY, so it can only pass on a real round trip.
+    let upstream: string;
+    try {
+      upstream = await bootUpstream((_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end('via-ipv6-loopback');
+      }, '::1');
+    } catch {
+      // No IPv6 loopback on this host: there is nothing to bind, so there is
+      // no claim to make either way.
+      return;
+    }
+    const bus = new StudioEventBus();
+    const proxy = await boot(bus, upstream);
+    const res = await httpReq(`${proxy.url}/`);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('via-ipv6-loopback');
   });
 });

--- a/tests/unit/local/studio-proxy.test.ts
+++ b/tests/unit/local/studio-proxy.test.ts
@@ -360,24 +360,6 @@ describe('isLoopbackHostname (issue #578)', () => {
   });
 });
 
-describe('normalizeLocalUpstream over a whole URL (issue #578)', () => {
-  it('accepts every loopback spelling a URL can normalise, including the compressed and integer forms', () => {
-    expect(normalizeLocalUpstream('http://127.0.0.1:51234')).toBe('http://127.0.0.1:51234');
-    expect(normalizeLocalUpstream('ws://localhost:49160/ws')).toBe('ws://localhost:49160/ws');
-    expect(normalizeLocalUpstream('http://[::1]:51234/x')).toBe('http://[::1]:51234/x');
-    // `URL` normalises both of these to the hostname `127.0.0.1`, so they are
-    // loopback despite not looking like it.
-    expect(normalizeLocalUpstream('http://127.1:8080')).toBe('http://127.1:8080');
-    expect(normalizeLocalUpstream('http://2130706433:8080')).toBe('http://2130706433:8080');
-  });
-
-  it('refuses a foreign host, and refuses what it cannot parse rather than guessing', () => {
-    expect(normalizeLocalUpstream('http://attacker.example/')).toBeUndefined();
-    expect(normalizeLocalUpstream('not-a-url')).toBeUndefined();
-    expect(normalizeLocalUpstream('')).toBeUndefined();
-  });
-});
-
 describe('describeEndpointForMessage (issue #578)', () => {
   it('flattens control characters so a quoted endpoint cannot forge output', () => {
     expect(describeEndpointForMessage('http://a.example/\u001b[31m\r\nWARN: fake')).toBe(
@@ -429,7 +411,6 @@ describe('startStudioProxy upstream bound (issue #578)', () => {
   });
 });
 
-
 describe('isWildcardHostname (issue #578)', () => {
   it('recognises every spelling of the unspecified address', () => {
     for (const h of ['0.0.0.0', '::', '[::]', '0:0:0:0:0:0:0:0', '::ffff:0.0.0.0', '[::ffff:0:0]']) {
@@ -445,6 +426,16 @@ describe('isWildcardHostname (issue #578)', () => {
 });
 
 describe('normalizeLocalUpstream (issue #578)', () => {
+  it('accepts every loopback spelling a URL can normalise, including the compressed and integer forms', () => {
+    expect(normalizeLocalUpstream('http://127.0.0.1:51234')).toBe('http://127.0.0.1:51234');
+    expect(normalizeLocalUpstream('ws://localhost:49160/ws')).toBe('ws://localhost:49160/ws');
+    expect(normalizeLocalUpstream('http://[::1]:51234/x')).toBe('http://[::1]:51234/x');
+    // `URL` normalises both of these to the hostname `127.0.0.1`, so they are
+    // loopback despite not looking like it.
+    expect(normalizeLocalUpstream('http://127.1:8080')).toBe('http://127.1:8080');
+    expect(normalizeLocalUpstream('http://2130706433:8080')).toBe('http://2130706433:8080');
+  });
+
   it('rewrites a wildcard bind address to loopback, host token only', () => {
     expect(normalizeLocalUpstream('http://0.0.0.0:51234')).toBe('http://127.0.0.1:51234');
     expect(normalizeLocalUpstream('http://[::]:51234')).toBe('http://127.0.0.1:51234');
@@ -475,6 +466,104 @@ describe('normalizeLocalUpstream (issue #578)', () => {
       '',
     ]) {
       expect(normalizeLocalUpstream(u), u).toBeUndefined();
+    }
+  });
+
+  it('carries userinfo through byte-for-byte on the wildcard rewrite', () => {
+    // The DECISION taken here: userinfo is preserved rather than dropped or
+    // refused. It is preservable safely because the post-condition re-parses
+    // the result and proves the host it actually names - so `tok@` riding
+    // along cannot move the destination without the check catching it.
+    // Dropping it instead would silently strip a credential the child put on
+    // the URL and turn a working upstream into a 401.
+    expect(normalizeLocalUpstream('http://tok@0.0.0.0:51234/')).toBe(
+      'http://tok@127.0.0.1:51234/'
+    );
+    expect(normalizeLocalUpstream('http://u:p@0.0.0.0:8080/x')).toBe(
+      'http://u:p@127.0.0.1:8080/x'
+    );
+    expect(normalizeLocalUpstream('http://u:p@[::]:8080/x?q=1#f')).toBe(
+      'http://u:p@127.0.0.1:8080/x?q=1#f'
+    );
+  });
+
+  it('refuses a rewrite whose RESULT is not loopback (the `\\` authority terminator)', () => {
+    // `\` ends the authority for the WHATWG parser but not for the `[/?#]`
+    // scan, so the host token the rewrite lands on is the wrong one and the
+    // result re-parses to host `0.0.0.0`. Caught by the post-condition rather
+    // than by adding `\` to the cut set - which would fix this one spelling
+    // and leave the next terminator open.
+    expect(normalizeLocalUpstream('http://0.0.0.0\\@attacker.example/')).toBeUndefined();
+    expect(normalizeLocalUpstream('http://0.0.0.0:8080\\@evil.example/')).toBeUndefined();
+    expect(normalizeLocalUpstream('ws://0.0.0.0\\@evil.example/ws')).toBeUndefined();
+  });
+
+  it('POST-CONDITION: every accepted result re-parses to a loopback host', () => {
+    // The property the function actually promises, asserted over the value it
+    // HANDS BACK rather than over the one it inspected on the way in - so a
+    // spelling nobody enumerated cannot slip a non-loopback destination out.
+    const INPUTS = [
+      // loopback, wildcard, and the odd spellings of each
+      'http://127.0.0.1:51234',
+      'http://127.1:8080',
+      'http://2130706433:8080',
+      'http://0177.0.0.1/',
+      'http://LOCALHOST:3000/',
+      'http://[::1]:51234/x',
+      'ws://localhost:49160/ws',
+      'http://0.0.0.0:51234',
+      'https://0.0.0.0:8443/a/b?q=1#f',
+      'http://[::]:51234',
+      'http://[0:0:0:0:0:0:0:0]:51234',
+      'http://[::ffff:0.0.0.0]:51234',
+      'http://tok@0.0.0.0:51234/',
+      'http://u:p@0.0.0.0:8080/x',
+      // things that must be refused rather than returned
+      'http://attacker.example/',
+      'http://0.0.0.0\\@attacker.example/',
+      'http://0.0.0.0:8080\\@evil.example/',
+      'http://127.0.0.1@attacker.example/',
+      'http://2852039166/',
+      'http://169.254.169.254:80',
+      'http://[2001:db8::1]:3000',
+      'http://:::8080',
+      'not-a-url',
+      '',
+    ];
+    let accepted = 0;
+    for (const input of INPUTS) {
+      const out = normalizeLocalUpstream(input);
+      if (out === undefined) continue;
+      accepted += 1;
+      // Must parse, and must name this machine.
+      const parsed = new URL(out);
+      expect(isLoopbackHostname(parsed.hostname), `${input} -> ${out}`).toBe(true);
+    }
+    // Guard the guard: a mutant that refuses everything would satisfy the
+    // loop vacuously.
+    expect(accepted).toBe(14);
+  });
+
+  it('delegates host judgement to `URL`, so its normalisations are the ones that count', () => {
+    const CASES: Array<[string, string | undefined]> = [
+      // userinfo `@` does NOT make the credential the host
+      ['http://127.0.0.1@attacker.example/', undefined],
+      // decimal integer form of 169.254.169.254
+      ['http://2852039166/', undefined],
+      // OCTAL 0177 == 127, which `URL` resolves to 127.0.0.1
+      ['http://0177.0.0.1/', 'http://0177.0.0.1/'],
+      // a rooted (trailing-dot) IPv4 still parses as the IPv4 literal
+      ['http://127.0.0.1./', 'http://127.0.0.1./'],
+      // ...but a rooted NAME is a name, and `localhost.` is not the literal
+      ['http://localhost./', undefined],
+      // hostnames are case-insensitive; `URL` lowercases them
+      ['http://LOCALHOST:3000/', 'http://LOCALHOST:3000/'],
+      ['HTTP://127.0.0.1:3000/', 'HTTP://127.0.0.1:3000/'],
+      // an UNBRACKETED IPv6 authority is not a URL at all
+      ['http://:::8080', undefined],
+    ];
+    for (const [input, expected] of CASES) {
+      expect(normalizeLocalUpstream(input), input).toBe(expected);
     }
   });
 });

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, it, expect, vi } from 'vite-plus/test';
+import { getLogger } from '../../../src/utils/logger.js';
 import {
   StudioEventBus,
   type StudioLogEvent,
@@ -1440,6 +1441,8 @@ function startPending(
   serves: StudioServeEvent[];
   logs: StudioLogEvent[];
   list: () => StudioServeState[];
+  /** The pending `start()` promise. Pre-attached `catch` so it never leaks. */
+  ready: Promise<StudioServeState>;
 } {
   const bus = new StudioEventBus();
   const { serves, logs } = collect(bus);
@@ -1454,7 +1457,7 @@ function startPending(
   });
   const ready = mgr.start({ targetId, kind });
   ready.catch(() => undefined);
-  return { child, fp, serves, logs, list: () => mgr.list() };
+  return { child, fp, serves, logs, list: () => mgr.list(), ready };
 }
 
 describe('classifyChildLine (issue #578)', () => {
@@ -1462,14 +1465,20 @@ describe('classifyChildLine (issue #578)', () => {
     expect(classifyChildLine('WARN: pinned image')).toEqual({
       diagnostic: true,
       text: 'pinned image',
+      untagged: 'pinned image',
     });
-    expect(classifyChildLine('ERROR: boom')).toEqual({ diagnostic: true, text: 'boom' });
+    expect(classifyChildLine('ERROR: boom')).toEqual({
+      diagnostic: true,
+      text: 'boom',
+      untagged: 'boom',
+    });
   });
 
   it('sees through the ANSI colour the logger wraps a warn line in', () => {
     expect(classifyChildLine('\u001b[33mWARN: pinned image\u001b[0m')).toEqual({
       diagnostic: true,
       text: 'pinned image',
+      untagged: 'pinned image',
     });
   });
 
@@ -1477,27 +1486,51 @@ describe('classifyChildLine (issue #578)', () => {
     expect(classifyChildLine('2026-08-27T12:00:00.000Z WARN  pinned image')).toEqual({
       diagnostic: true,
       text: 'pinned image',
+      untagged: 'pinned image',
     });
     expect(classifyChildLine('2026-08-27T12:00:00.000Z ERROR [ecs] boom')).toEqual({
       diagnostic: true,
-      text: 'boom',
+      // The tag stays on `text` and comes off only on `untagged`.
+      text: '[ecs] boom',
+      untagged: 'boom',
     });
   });
 
-  it('strips a `[module]` tag so an INFO banner still anchors', () => {
+  it('peels a `[module]` tag into `untagged` ONLY behind a verbose preamble', () => {
+    // The one shape a cdk-local child logger emits: `ChildLogger` prefixes
+    // info / warn / error only at debug level, which is also the level that
+    // renders the preamble.
     expect(
       classifyChildLine('2026-08-27T12:00:00.000Z INFO  [ecs] Service(s) running: 1.')
-    ).toEqual({ diagnostic: false, text: 'Service(s) running: 1.' });
-    expect(classifyChildLine('[ecs] Service(s) running: 1.')).toEqual({
+    ).toEqual({
       diagnostic: false,
-      text: 'Service(s) running: 1.',
+      text: '[ecs] Service(s) running: 1.',
+      untagged: 'Service(s) running: 1.',
     });
+  });
+
+  it('leaves a BARE `[tag]` in place on BOTH fields - it is relayed container output', () => {
+    // `[<container>] ` (ecs-task-runner) and `[svc=... c=...] ` (
+    // ecs-service-runner) are how a third party's own stdout reaches this
+    // stream. Stripping either would re-anchor an application log line to `^`.
+    for (const line of [
+      '[ecs] Service(s) running: 1.',
+      '[web] Server listening on http://127.0.0.1:9999',
+      '[svc=Api r=0 c=web] Server listening on http://127.0.0.1:9999',
+    ]) {
+      expect(classifyChildLine(line), line).toEqual({
+        diagnostic: false,
+        text: line,
+        untagged: line,
+      });
+    }
   });
 
   it('leaves an ordinary line - and its leading whitespace - alone', () => {
     expect(classifyChildLine('Server listening on http://127.0.0.1:51234')).toEqual({
       diagnostic: false,
       text: 'Server listening on http://127.0.0.1:51234',
+      untagged: 'Server listening on http://127.0.0.1:51234',
     });
     // NOT trimmed: the banners start at column 0, so an indented line must
     // stay unable to impersonate one.
@@ -1623,11 +1656,36 @@ describe('serve readiness anchors its banners to the start of the line (issue #5
     expect(h.fp.upstreams).toEqual([]);
   });
 
-  it('still matches a child-logger banner carrying a [module] tag', async () => {
+  it('does NOT treat a bare [module]-tagged line as a ready banner', async () => {
+    // No ready banner is tag-prefixed: `start-api` / `start-cloudfront` write
+    // straight to stdout, and `start-alb` / `run-task` / `start-agentcore` use
+    // the ROOT logger. A bare `[tag] ` at column 0 is relayed CONTAINER output
+    // (`[<container>] ` / `[svc=... c=...] `), so it must not be re-anchored.
     const h = startPending('ecs', 'Stack/Svc');
     h.child.stdout.emit('data', '[ecs] Service(s) running: 1 replica.\n');
     await tick();
+    expect(h.list()[0]?.status).toBe('starting');
+
+    const a = startPending('api');
+    a.child.stdout.emit('data', '[web] Server listening on http://127.0.0.1:9999\n');
+    await tick();
+    expect(a.list()[0]?.status).toBe('starting');
+    expect(a.fp.upstreams).toEqual([]);
+  });
+
+  it('still matches a child-logger banner behind the verbose preamble it really carries', async () => {
+    // The publish banner is the one banner written through
+    // `getLogger().child('ecs')`, and the tag only appears at debug level -
+    // i.e. always after the `<timestamp> <LEVEL>` preamble.
+    const h = startPending('ecs', 'Stack/Svc');
+    h.child.stdout.emit(
+      'data',
+      "2026-08-27T12:00:00.000Z INFO  [ecs] Container 'web' container port 80 published on 127.0.0.1:54321. Reach it at 127.0.0.1:54321.\n"
+    );
+    h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
+    await tick();
     expect(h.list()[0]?.status).toBe('running');
+    expect(h.list()[0]?.hostUrl).toBe('http://127.0.0.1:54321');
   });
 });
 
@@ -1646,19 +1704,35 @@ describe('serve readiness refuses a non-loopback endpoint (issue #578)', () => {
     'Server listening on not-a-url  (MyApi)',
   ];
 
-  it('adopts no endpoint, starts no proxy, and stays starting', async () => {
+  it('adopts no endpoint, starts no proxy, and fails the serve immediately', async () => {
     for (const line of FOREIGN) {
       const h = startPending('api');
       h.child.stdout.emit('data', `${line}\n`);
       await tick();
-      expect(h.list()[0]?.status, line).toBe('starting');
-      expect(h.list()[0]?.endpoints, line).toEqual([]);
+      // Settled NOW, not after the 120 s ready timeout: the child named the
+      // only endpoint it is going to name and studio will not use it, so the
+      // serve is dropped and the UI is told why (issue #578 review).
+      expect(h.list(), line).toEqual([]);
       expect(h.fp.upstreams, line).toEqual([]);
-      // The refusal is loud: a WARN line lands on the LOGS panel.
+      const last = h.serves.at(-1);
+      expect(last?.status, line).toBe('error');
+      // The failure REASON carries the refusal text - not a bare
+      // "did not start within 120000ms" with the cause buried in the logs.
+      expect(last?.message, line).toContain('non-loopback');
+      expect(last?.endpoints, line).toEqual([]);
+      // The refusal is also loud on the LOGS panel.
       const warn = h.logs.map((l) => l.line).find((l) => l.startsWith('WARN: refused'));
       expect(warn, line).toBeDefined();
       expect(warn, line).toContain('non-loopback');
+      // The child is torn down gracefully so it can stop its own containers.
+      expect(h.child.kill, line).toHaveBeenCalledWith('SIGTERM');
     }
+  });
+
+  it('rejects the pending start() with the refusal, not with a timeout message', async () => {
+    const h = startPending('api');
+    h.child.stdout.emit('data', 'Server listening on http://attacker.example/  (MyApi)\n');
+    await expect(h.ready).rejects.toThrow(/non-loopback/);
   });
 
   it('accepts every loopback spelling', async () => {
@@ -1692,8 +1766,9 @@ describe('serve readiness refuses a non-loopback endpoint (issue #578)', () => {
     const h = startPending('agentcore-ws', 'MyAgent');
     h.child.stdout.emit('data', 'Server listening on ws://attacker.example/ws  (MyAgent)\n');
     await tick();
-    expect(h.list()[0]?.status).toBe('starting');
-    expect(h.list()[0]?.endpoints).toEqual([]);
+    expect(h.list()).toEqual([]);
+    expect(h.serves.at(-1)?.status).toBe('error');
+    expect(h.serves.at(-1)?.message).toContain('non-loopback');
   });
 });
 
@@ -1802,7 +1877,8 @@ describe('a wildcard bind address is normalized to loopback, not refused (issue 
     const f = startPending('api', 'MyApi3');
     f.child.stdout.emit('data', 'Server listening on https://attacker.example/  (MyApi)\n');
     await tick();
-    expect(f.list()[0]?.status).toBe('starting');
+    expect(f.list()).toEqual([]);
+    expect(f.serves.at(-1)?.status).toBe('error');
     expect(f.fp.upstreams).toEqual([]);
   });
 
@@ -1839,5 +1915,310 @@ describe('a wildcard bind address is normalized to loopback, not refused (issue 
     expect(h.list()[0]?.status).toBe('running');
     expect(h.list()[0]?.hostUrl).toBe('http://127.0.0.1:54321');
     expect(h.logs.map((l) => l.line).some((l) => l.startsWith('WARN: refused'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #578 review round - the bounds the first pass left partly open.
+// ---------------------------------------------------------------------------
+
+describe('the agentcore-ws ready anchor is fenced too (issue #578)', () => {
+  // `agentcore-ws` carries its OWN `readyRe` literal, distinct from `api`'s.
+  // Without this case, reverting the `^` on that one literal alone left the
+  // whole suite green - so "all six anchors are fenced" was 5/6.
+  it('does not treat an embedded phrase as the agentcore ready banner', async () => {
+    for (const line of [
+      'agent boot: Server listening on ws://127.0.0.1:3000/ws',
+      'Reload complete. Server listening on ws://127.0.0.1:3000/ws',
+      '  Server listening on ws://127.0.0.1:3000/ws',
+      'agent boot: Server listening on http://127.0.0.1:3000',
+    ]) {
+      const h = startPending('agentcore-ws', 'MyAgent');
+      h.child.stdout.emit('data', `${line}\n`);
+      await tick();
+      expect(h.list()[0]?.status, line).toBe('starting');
+      expect(h.list()[0]?.endpoints, line).toEqual([]);
+      expect(h.fp.upstreams, line).toEqual([]);
+    }
+  });
+});
+
+describe('a relayed container log cannot impersonate a ready banner (issue #578)', () => {
+  // Bound 2's real target: `[<container>] ` (ecs-task-runner) and
+  // `[svc=... c=...] ` (ecs-service-runner) are how a third party's stdout
+  // reaches this stream, and stripping the tag re-anchored it to `^`.
+  it('leaves an ecs container-prefixed banner unmatched for every kind', async () => {
+    const CASES: Array<[StudioTargetKind, string]> = [
+      ['api', '[web] Server listening on http://127.0.0.1:9999'],
+      ['api', '[svc=Api r=0 c=web] Server listening on http://127.0.0.1:9999'],
+      ['cloudfront', '[web] CloudFront distribution serving on http://127.0.0.1:9999'],
+      ['alb', '[web] ALB front-door: http://127.0.0.1:9999'],
+      ['agentcore-ws', '[agent] Server listening on ws://127.0.0.1:9999/ws'],
+      ['ecs', '[web] Service(s) running: 1'],
+      ['ecs-task', '[web] Task running (family=evil)'],
+    ];
+    for (const [kind, line] of CASES) {
+      const h = startPending(kind, `T-${kind}-${line.length}`);
+      h.child.stdout.emit('data', `${line}\n`);
+      await tick();
+      expect(h.list()[0]?.status, line).toBe('starting');
+      expect(h.list()[0]?.endpoints, line).toEqual([]);
+      expect(h.fp.upstreams, line).toEqual([]);
+    }
+  });
+
+  it('stops reading readyRe once a single-banner serve is running', async () => {
+    // `cloudfront` prints its banner exactly once, so a later line carrying it
+    // is not a banner. (`api` / `alb` are exempt - they legitimately print
+    // several - see ServeKindSpec.readyRepeats.)
+    const h = startPending('cloudfront', 'MyDist');
+    h.child.stdout.emit('data', 'CloudFront distribution serving on http://127.0.0.1:51234\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+
+    // A handler's own log line, post-boot, at column 0 and unprefixed.
+    h.child.stdout.emit('data', 'CloudFront distribution serving on http://127.0.0.1:9999\n');
+    await tick();
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+    expect(h.list()[0]?.endpoints).toEqual([PROXIED]);
+  });
+
+  it('keeps reading the agentcore extra-endpoint line AFTER the serve is running', async () => {
+    // The stop is scoped to readyRe: agentcore's http:// contract line arrives
+    // by design after the ws:// listen line settled the serve.
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    h.child.stdout.emit('data', 'HTTP contract served on http://127.0.0.1:51234\n');
+    await tick();
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws', PROXIED]);
+  });
+
+  it('keeps reading the ecs publish banner AFTER the serve is running', async () => {
+    const h = startPending('ecs', 'Stack/Svc');
+    h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    h.child.stdout.emit(
+      'data',
+      "Container 'web' container port 80 published on 127.0.0.1:54321. Reach it at 127.0.0.1:54321.\n"
+    );
+    await tick();
+    expect(h.list()[0]?.hostUrl).toBe('http://127.0.0.1:54321');
+  });
+});
+
+describe('a refused ready line fails the serve immediately (issue #578)', () => {
+  it('does not leave an alb bound to a non-loopback --container-host hanging', async () => {
+    // `cdkl start-alb --container-host <non-loopback>` puts that host in the
+    // front-door banner, so this is a live configuration rather than an
+    // attack. It used to sit `starting` for the full 120 s ready timeout and
+    // then report a timeout, with the real cause only in the LOGS panel.
+    const h = startPending('alb', 'MyAlb');
+    h.child.stdout.emit('data', 'ALB front-door: http://10.1.2.3:8080 (listener port 80)\n');
+    await tick();
+    expect(h.list()).toEqual([]);
+    expect(h.serves.at(-1)?.status).toBe('error');
+    expect(h.serves.at(-1)?.message).toContain('non-loopback');
+    expect(h.child.kill).toHaveBeenCalledWith('SIGTERM');
+    await expect(h.ready).rejects.toThrow(/non-loopback/);
+  });
+
+  it('refuses an UNBRACKETED IPv6 bind address rather than guessing at it', async () => {
+    // `--container-host ::` makes the banner `http://:::8080`, which is not a
+    // URL: `new URL` rejects it, so the wildcard rewrite never runs. Repairing
+    // the spelling would mean re-deriving an authority the parser refused, so
+    // the answer is the honest one - refuse, fast, with the reason.
+    const h = startPending('alb', 'MyAlb');
+    h.child.stdout.emit('data', 'ALB front-door: http://:::8080 (listener port 80)\n');
+    await tick();
+    expect(h.list()).toEqual([]);
+    expect(h.serves.at(-1)?.status).toBe('error');
+    expect(h.serves.at(-1)?.message).toContain('non-loopback');
+  });
+
+  it('does NOT fail an already-running serve when a later endpoint line is refused', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    h.child.stdout.emit('data', 'HTTP contract served on http://attacker.example:80\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+  });
+
+  it('warns on the studio process logger, not only on the bus', async () => {
+    const warn = vi.spyOn(getLogger(), 'warn').mockImplementation(() => undefined);
+    try {
+      const h = startPending('api');
+      h.child.stdout.emit('data', 'Server listening on http://attacker.example/  (MyApi)\n');
+      await tick();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain('non-loopback');
+      expect(warn.mock.calls[0]?.[0]).toContain('MyApi');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe('the proxy-failure fallback keeps the loopback bound (issue #578)', () => {
+  /** A serve manager whose capture-proxy factory always fails to bind. */
+  function startWithFailingProxy(ready: string): {
+    child: ReturnType<typeof makeFakeChild>;
+    serves: StudioServeEvent[];
+    list: () => StudioServeState[];
+  } {
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      proxyFactory: () => Promise.reject(new Error('EADDRINUSE')),
+    });
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    p.catch(() => undefined);
+    child.stdout.emit('data', `${ready}\n`);
+    return { child, serves, list: () => mgr.list() };
+  }
+
+  it('publishes the NORMALIZED url, never the raw one the child printed', async () => {
+    // The fallback runs when the proxy cannot bind. It must hand the UI the
+    // resolved destination (127.0.0.1), not the wildcard bind address the
+    // child named - the composer posts to this string with no proxy in front.
+    const h = startWithFailingProxy('Server listening on http://0.0.0.0:51234  (MyApi)');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    expect(h.list()[0]?.endpoints).toEqual(['http://127.0.0.1:51234']);
+  });
+
+  it('adopts nothing when the REAL proxy refuses a foreign upstream', async () => {
+    // Defence in depth, with no injected factory at all: the serve manager
+    // falls back to the real `startStudioProxy`, which enforces the same
+    // loopback bound by throwing. Green while EITHER guard stands, red only
+    // when both are gone - which is the point of having two.
+    const bus = new StudioEventBus();
+    const { serves } = collect(bus);
+    const child = makeFakeChild();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+    });
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    p.catch(() => undefined);
+    child.stdout.emit('data', 'Server listening on http://attacker.example/  (MyApi)\n');
+    await tick();
+    expect(mgr.list().flatMap((e) => e.endpoints)).toEqual([]);
+    expect(serves.some((e) => e.endpoints.includes('http://attacker.example/'))).toBe(false);
+    expect(serves.at(-1)?.status).toBe('error');
+  });
+});
+
+describe('a stdout line split across chunks is reassembled first (issue #578)', () => {
+  it('classifies the REASSEMBLED line, not either half', async () => {
+    const h = startPending('api');
+    // The `WARN: ` prefix and the banner phrase land in different chunks, and
+    // the split is mid-token. Only reassembly makes the diagnostic bound see
+    // the prefix; the URL is LOOPBACK so nothing else would stop it.
+    h.child.stdout.emit('data', 'WARN: Serv');
+    h.child.stdout.emit('data', 'er listening on http://127.0.0.1:51234\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('starting');
+    expect(h.list()[0]?.endpoints).toEqual([]);
+    expect(h.fp.upstreams).toEqual([]);
+    // And the LOGS panel gets one whole line, not two fragments.
+    expect(h.logs.map((l) => l.line)).toEqual([
+      'WARN: Server listening on http://127.0.0.1:51234',
+    ]);
+  });
+});
+
+describe('the serve manager delegates host judgement to normalizeLocalUpstream (issue #578)', () => {
+  // Locks the delegation that was only implicit: these are `URL`'s
+  // normalisations, and the serve manager must inherit every one of them
+  // rather than re-deciding with a regex of its own.
+  const CASES: Array<[string, string | undefined]> = [
+    // userinfo `@` does not make the credential the host
+    ['http://127.0.0.1@attacker.example/', undefined],
+    // decimal integer form of 169.254.169.254
+    ['http://2852039166/', undefined],
+    // OCTAL 0177 == 127
+    ['http://0177.0.0.1/', 'http://0177.0.0.1/'],
+    // a rooted IPv4 literal is still the literal
+    ['http://127.0.0.1.:51234/', 'http://127.0.0.1.:51234/'],
+    // a rooted NAME is a name
+    ['http://localhost./', undefined],
+    // hostnames are case-insensitive
+    ['http://LOCALHOST:51234/', 'http://LOCALHOST:51234/'],
+  ];
+
+  it('adopts exactly what normalizeLocalUpstream accepts', async () => {
+    for (const [url, expected] of CASES) {
+      const h = startPending('api', `T-${url}`);
+      h.child.stdout.emit('data', `Server listening on ${url}  (MyApi)\n`);
+      await tick();
+      if (expected === undefined) {
+        expect(h.list(), url).toEqual([]);
+        expect(h.fp.upstreams, url).toEqual([]);
+      } else {
+        expect(h.list()[0]?.status, url).toBe('running');
+        expect(h.fp.upstreams, url).toEqual([expected]);
+      }
+    }
+  });
+});
+
+describe('the --host-port hostUrl carries the loopback bound too (issue #578)', () => {
+  function startEcsWithHostPort(right: string): {
+    child: ReturnType<typeof makeFakeChild>;
+    logs: StudioLogEvent[];
+    list: () => StudioServeState[];
+    ready: Promise<StudioServeState>;
+  } {
+    const bus = new StudioEventBus();
+    const { logs } = collect(bus);
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/p/cli.js',
+      bus,
+      spawnFn: (() => child) as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+    const ready = mgr.start({
+      targetId: 'Stack/Svc',
+      kind: 'ecs',
+      options: { '--host-port': [{ left: '80', right }] },
+    });
+    ready.catch(() => undefined);
+    return { child, logs, list: () => mgr.list(), ready };
+  }
+
+  it('refuses a --host-port value that smuggles a foreign host past the interpolation', async () => {
+    // The port half is interpolated verbatim into `http://127.0.0.1:<right>`,
+    // so `1@evil.example` makes `evil.example` the HOST. The composer posts to
+    // hostUrl DIRECTLY, with no proxy in front.
+    const h = startEcsWithHostPort('1@evil.example');
+    h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
+    await h.ready;
+    expect(h.list()[0]?.hostUrl).toBeUndefined();
+    const warn = h.logs.map((l) => l.line).find((l) => l.startsWith('WARN: refused'));
+    expect(warn).toBeDefined();
+    expect(warn).toContain('--host-port');
+  });
+
+  it('still adopts an ordinary --host-port value', async () => {
+    const h = startEcsWithHostPort('8080');
+    h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
+    await h.ready;
+    expect(h.list()[0]?.hostUrl).toBe('http://127.0.0.1:8080');
   });
 });

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -1090,7 +1090,11 @@ describe('createStudioServeManager', () => {
     expect(serves.at(-1)?.status).toBe('stopped');
     expect(serves.at(-1)?.message).toMatch(/exited/i);
     expect(mgr.list()).toEqual([]);
-    // The capture proxy must be torn down when the serve crashes.
+    // The capture proxy must be torn down when the serve crashes. One
+    // microtask, because the entry now holds the PENDING proxy promise (so a
+    // repeated ready line can join a startup already in flight instead of
+    // beginning a second one) and teardown awaits it before closing.
+    await new Promise((r) => setTimeout(r, 0));
     expect(fp.closes[0]).toHaveBeenCalled();
   });
 
@@ -1443,6 +1447,8 @@ function startPending(
   list: () => StudioServeState[];
   /** The pending `start()` promise. Pre-attached `catch` so it never leaks. */
   ready: Promise<StudioServeState>;
+  /** `stop()` for this target, so a teardown-window race is drivable. */
+  stop: () => Promise<void>;
 } {
   const bus = new StudioEventBus();
   const { serves, logs } = collect(bus);
@@ -1457,7 +1463,15 @@ function startPending(
   });
   const ready = mgr.start({ targetId, kind });
   ready.catch(() => undefined);
-  return { child, fp, serves, logs, list: () => mgr.list(), ready };
+  return {
+    child,
+    fp,
+    serves,
+    logs,
+    list: () => mgr.list(),
+    ready,
+    stop: () => mgr.stop({ targetId }),
+  };
 }
 
 describe('classifyChildLine (issue #578)', () => {
@@ -1694,18 +1708,21 @@ describe('serve readiness refuses a non-loopback endpoint (issue #578)', () => {
   // real banner by shape. The loopback bound is what stops them. (A `0.0.0.0`
   // bind is NOT here: a wildcard is a bind address, reachable on loopback, so
   // it is normalized rather than refused - see the wildcard describe below.)
-  const FOREIGN = [
-    'Server listening on http://attacker.example/  (MyApi)',
-    'Server listening on http://169.254.169.254:80  (MyApi)',
-    'Server listening on http://localhost.attacker.example:8080  (MyApi)',
-    'Server listening on http://127.0.0.1.attacker.example:8080  (MyApi)',
-    'Server listening on http://[2001:db8::1]:3000  (MyApi)',
-    'Server listening on http://192.168.0.5:3000  (MyApi)',
-    'Server listening on not-a-url  (MyApi)',
+  // Paired with the WORD the refusal must use, so the two faults that reach
+  // one refusal stay distinguishable: a value that parses and names another
+  // host, versus one that is not a URL at all (issue #578 review).
+  const FOREIGN: Array<[string, string]> = [
+    ['Server listening on http://attacker.example/  (MyApi)', 'non-loopback'],
+    ['Server listening on http://169.254.169.254:80  (MyApi)', 'non-loopback'],
+    ['Server listening on http://localhost.attacker.example:8080  (MyApi)', 'non-loopback'],
+    ['Server listening on http://127.0.0.1.attacker.example:8080  (MyApi)', 'non-loopback'],
+    ['Server listening on http://[2001:db8::1]:3000  (MyApi)', 'non-loopback'],
+    ['Server listening on http://192.168.0.5:3000  (MyApi)', 'non-loopback'],
+    ['Server listening on not-a-url  (MyApi)', 'unparseable'],
   ];
 
   it('adopts no endpoint, starts no proxy, and fails the serve immediately', async () => {
-    for (const line of FOREIGN) {
+    for (const [line, reason] of FOREIGN) {
       const h = startPending('api');
       h.child.stdout.emit('data', `${line}\n`);
       await tick();
@@ -1718,12 +1735,12 @@ describe('serve readiness refuses a non-loopback endpoint (issue #578)', () => {
       expect(last?.status, line).toBe('error');
       // The failure REASON carries the refusal text - not a bare
       // "did not start within 120000ms" with the cause buried in the logs.
-      expect(last?.message, line).toContain('non-loopback');
+      expect(last?.message, line).toContain(reason);
       expect(last?.endpoints, line).toEqual([]);
       // The refusal is also loud on the LOGS panel.
       const warn = h.logs.map((l) => l.line).find((l) => l.startsWith('WARN: refused'));
       expect(warn, line).toBeDefined();
-      expect(warn, line).toContain('non-loopback');
+      expect(warn, line).toContain(reason);
       // The child is torn down gracefully so it can stop its own containers.
       expect(h.child.kill, line).toHaveBeenCalledWith('SIGTERM');
     }
@@ -2036,7 +2053,11 @@ describe('a refused ready line fails the serve immediately (issue #578)', () => 
     await tick();
     expect(h.list()).toEqual([]);
     expect(h.serves.at(-1)?.status).toBe('error');
-    expect(h.serves.at(-1)?.message).toContain('non-loopback');
+    // And the reason is the one that actually applies. `:::8080` does not
+    // PARSE; calling it non-loopback would name a judgement never reached,
+    // which now costs more than a wrong word since this tears the serve down.
+    expect(h.serves.at(-1)?.message).toContain('unparseable');
+    expect(h.serves.at(-1)?.message).not.toContain('non-loopback');
   });
 
   it('does NOT fail an already-running serve when a later endpoint line is refused', async () => {
@@ -2220,5 +2241,217 @@ describe('the --host-port hostUrl carries the loopback bound too (issue #578)', 
     h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
     await h.ready;
     expect(h.list()[0]?.hostUrl).toBe('http://127.0.0.1:8080');
+  });
+
+  it('says UNPARSEABLE, not non-loopback, for a port half that is not a port', async () => {
+    // `80=abc` interpolates to `http://127.0.0.1:abc`, which `new URL` rejects
+    // for its port. The host it names IS loopback, so telling the user studio
+    // "refused a non-loopback --host-port mapping" describes a judgement that
+    // was never reached and points them at the wrong half of their flag.
+    const h = startEcsWithHostPort('abc');
+    h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
+    await h.ready;
+    expect(h.list()[0]?.hostUrl).toBeUndefined();
+    const warn = h.logs.map((l) => l.line).find((l) => l.startsWith('WARN: refused'));
+    expect(warn).toBeDefined();
+    expect(warn).toContain('unparseable');
+    expect(warn).toContain('--host-port');
+    expect(warn).not.toContain('non-loopback');
+  });
+
+  it('still says NON-LOOPBACK for a value that parses and names another host', async () => {
+    // The other branch: `1@evil.example` parses fine, and `evil.example` is
+    // the host. Both branches are pinned so the split cannot collapse back
+    // into one wording in either direction.
+    const h = startEcsWithHostPort('1@evil.example');
+    h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
+    await h.ready;
+    const warn = h.logs.map((l) => l.line).find((l) => l.startsWith('WARN: refused'));
+    expect(warn).toContain('non-loopback');
+    expect(warn).not.toContain('unparseable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #578 test-gap round - each block below kills a mutant the suite let
+// through. The comment on each names the mutation it fences.
+// ---------------------------------------------------------------------------
+
+describe('an alb adopts EVERY listener banner (issue #578)', () => {
+  // Mutant: delete `readyRepeats: true` from the `alb` spec. `buildFrontDoor`
+  // logs one banner per LISTENER and awaits `startFrontDoorServer` between
+  // them, so those land in different stdout chunks and therefore after the
+  // serve has settled. Without the exemption every listener but the first is
+  // silently dropped - and the whole suite stayed green, because only `api`'s
+  // exemption was covered.
+  it('reads a second ALB front-door banner arriving after the serve settled', async () => {
+    const h = startPending('alb', 'MyAlb');
+    h.child.stdout.emit('data', 'ALB front-door: http://127.0.0.1:51234 (listener port 80)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+
+    h.child.stdout.emit('data', 'ALB front-door: http://127.0.0.1:51235 (listener port 443)\n');
+    await tick();
+
+    // BOTH listeners are fronted, and both proxy URLs reach the UI.
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234', 'http://127.0.0.1:51235']);
+    expect(h.list()[0]?.endpoints).toEqual([PROXIED, 'http://127.0.0.1:61235']);
+  });
+});
+
+describe('a ready banner is matched on the TAG-BEARING text (issue #578)', () => {
+  // Mutants: `spec.readyRe.exec(parsed.text)` -> `parsed.untagged`, and the
+  // same on the `extraEndpointRe` line. `untagged` peels a `[module]` tag, and
+  // peeling it before matching is exactly what re-anchored relayed container
+  // output (`[web] `, `[svc=... c=...] `) to column 0. The existing module-tag
+  // cases could not see the difference: they use BARE `[tag]` lines, where no
+  // verbose preamble precedes the tag and so `text === untagged`. These lines
+  // carry a preamble AND a tag, which is the one shape that separates them.
+  it('does not read a banner sitting behind a [module] tag on a verbose line', async () => {
+    const h = startPending('api', 'MyApi');
+    h.child.stdout.emit(
+      'data',
+      '2026-08-27T12:00:00.000Z INFO  [web] Server listening on http://127.0.0.1:9999\n'
+    );
+    await tick();
+    expect(h.list()[0]?.status).toBe('starting');
+    expect(h.list()[0]?.endpoints).toEqual([]);
+    expect(h.fp.upstreams).toEqual([]);
+  });
+
+  it('applies the same to the agentcore extra-endpoint line', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+
+    h.child.stdout.emit(
+      'data',
+      '2026-08-27T12:00:00.000Z INFO  [web] HTTP contract served on http://127.0.0.1:9999\n'
+    );
+    await tick();
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+    expect(h.fp.upstreams).toEqual([]);
+  });
+});
+
+describe('every single-banner kind stops reading readyRe once settled (issue #578)', () => {
+  // Mutant: add `readyRepeats: true` to `agentcore-ws` / `ecs-task`. Only the
+  // `cloudfront` case covered the post-settle stop, so the exemption could be
+  // handed to a kind that does not need it with the suite still green.
+  it('does not attach a SECOND capture proxy for an agentcore-ws serve', async () => {
+    // This kind matters most of the three: it is `capturesHttp`, so a
+    // post-boot line naming an http:// endpoint would start a real proxy and
+    // publish it to the UI as this serve's endpoint.
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+
+    h.child.stdout.emit('data', 'Server listening on http://127.0.0.1:9999\n');
+    await tick();
+    expect(h.fp.upstreams).toEqual([]);
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+  });
+
+  it('does not re-announce an ecs-task run on a repeated Task running banner', async () => {
+    // `ecs-task`'s banner carries no capture group, so the damage is smaller:
+    // a duplicate `running` event rather than a duplicate destination. Pinned
+    // anyway, so the exemption stays a property of the two kinds that need it.
+    const h = startPending('ecs-task', 'Stack/TaskDef');
+    h.child.stdout.emit('data', 'Task running (family=Stack-TaskDef).\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+
+    h.child.stdout.emit('data', 'Task running (family=Stack-TaskDef).\n');
+    await tick();
+    expect(h.serves.filter((e) => e.status === 'running')).toHaveLength(1);
+  });
+});
+
+describe('the ready pipeline reads STDOUT only (issue #578)', () => {
+  // Mutant: run `child.stderr` through the same classify + readyRe pipeline.
+  // Nothing pinned the split, and it matters because a Lambda container's
+  // stderr is relayed raw and unprefixed (`docker-runner`'s `streamLogs`), so
+  // a handler writing to stderr would otherwise get the `^` anchor for free.
+  it('names no endpoint from a ready banner arriving on stderr', async () => {
+    const h = startPending('api', 'MyApi');
+    h.child.stderr.emit('data', LISTENING);
+    await tick();
+    expect(h.list()[0]?.status).toBe('starting');
+    expect(h.list()[0]?.endpoints).toEqual([]);
+    expect(h.fp.upstreams).toEqual([]);
+    // The line still reaches the LOGS panel - it is dropped as a SIGNAL, not
+    // hidden from the user.
+    expect(h.logs.map((l) => l.line)).toContain(LISTENING.trimEnd());
+  });
+});
+
+describe('a repeated ready line reuses its capture proxy (issue #578 review)', () => {
+  // Mutant: start a fresh proxy on every readyRe match. `api` / `alb` are
+  // exempt from the post-settle stop, so the socket count was bounded by the
+  // CHILD'S OUTPUT: a handler logging `Server listening on ...` once per
+  // invocation gave N listening sockets and N UI endpoints until serve stop.
+  // The endpoint dedup downstream cannot catch it - each proxy has a fresh
+  // port, so `proxy.url` differs every time.
+  it('starts ONE proxy for two identical api ready lines', async () => {
+    const h = startPending('api', 'MyApi');
+    h.child.stdout.emit('data', LISTENING);
+    await tick();
+    h.child.stdout.emit('data', LISTENING);
+    await tick();
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+    expect(h.list()[0]?.endpoints).toEqual([PROXIED]);
+  });
+
+  it('starts ONE proxy when both lines arrive in the SAME chunk', async () => {
+    // The racing shape: both matches reach the registry before either
+    // `proxyFactory` call resolves, so a map of SETTLED proxies would still
+    // start two. The pending promise is what makes the second one a reuse.
+    const h = startPending('api', 'MyApi');
+    h.child.stdout.emit('data', LISTENING + LISTENING);
+    await tick();
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+    expect(h.list()[0]?.endpoints).toEqual([PROXIED]);
+  });
+
+  // The other direction - two DISTINCT upstreams must still get a proxy each -
+  // is the multi-listener alb case above, which asserts exactly that.
+
+  it('closes the reused proxy exactly once on stop', async () => {
+    const h = startPending('api', 'MyApi');
+    h.child.stdout.emit('data', LISTENING);
+    await tick();
+    h.child.stdout.emit('data', LISTENING);
+    await tick();
+
+    const stopP = h.stop();
+    h.child.emit('close', 0);
+    await stopP;
+    expect(h.fp.closes).toHaveLength(1);
+    expect(h.fp.closes[0]).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('a refusal during teardown is not an error banner (issue #578 review)', () => {
+  // Mutant: guard `failServe` on `settled` alone. `stop()` marks the entry,
+  // drops it from the map and then awaits `stopChild` for up to `stopGraceMs`
+  // (45 s - a real ALB teardown takes that long). A refused ready line landing
+  // in that window emitted an `error` serve event and rejected `start()` with
+  // the refusal, so the UI showed a failure banner for a serve the user had
+  // deliberately stopped, immediately followed by `stopped`.
+  it('emits no error event for a serve the user already stopped', async () => {
+    const h = startPending('alb', 'MyAlb');
+    const stopP = h.stop();
+    h.child.stdout.emit('data', 'ALB front-door: http://10.1.2.3:8080 (listener port 80)\n');
+    await tick();
+
+    expect(h.serves.map((e) => e.status)).not.toContain('error');
+    h.child.emit('close', 0);
+    await stopP;
+
+    expect(h.serves.map((e) => e.status)).toEqual(['starting', 'stopped']);
+    // And `start()` still rejects for the reason it really failed for.
+    await expect(h.ready).rejects.toThrow(/stopped before it finished starting/i);
   });
 });

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -1091,7 +1091,7 @@ describe('createStudioServeManager', () => {
     expect(serves.at(-1)?.message).toMatch(/exited/i);
     expect(mgr.list()).toEqual([]);
     // The capture proxy must be torn down when the serve crashes. One
-    // microtask, because the entry now holds the PENDING proxy promise (so a
+    // macrotask turn, because the entry now holds the PENDING proxy promise (so a
     // repeated ready line can join a startup already in flight instead of
     // beginning a second one) and teardown awaits it before closing.
     await new Promise((r) => setTimeout(r, 0));
@@ -1438,7 +1438,9 @@ const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
  */
 function startPending(
   kind: StudioTargetKind,
-  targetId = 'MyApi'
+  targetId = 'MyApi',
+  /** Short-circuit the ready timeout so its callback is drivable. */
+  readyTimeoutMs?: number
 ): {
   child: ReturnType<typeof makeFakeChild>;
   fp: ReturnType<typeof fakeProxies>;
@@ -1460,6 +1462,7 @@ function startPending(
     spawnFn: (() => child) as never,
     clock: fixedClock(),
     proxyFactory: fp.factory,
+    ...(readyTimeoutMs === undefined ? {} : { readyTimeoutMs }),
   });
   const ready = mgr.start({ targetId, kind });
   ready.catch(() => undefined);
@@ -2453,5 +2456,43 @@ describe('a refusal during teardown is not an error banner (issue #578 review)',
     expect(h.serves.map((e) => e.status)).toEqual(['starting', 'stopped']);
     // And `start()` still rejects for the reason it really failed for.
     await expect(h.ready).rejects.toThrow(/stopped before it finished starting/i);
+  });
+
+  it('emits no error event when the READY TIMEOUT fires on an already-stopped serve', async () => {
+    // The sibling of the case above, one screen up in the source: the ready
+    // timeout had `if (settled)` where `failServe` has `if (settled ||
+    // entry.stopping)`, so a stop() during boot still produced
+    // `starting -> error -> stopped`.
+    const h = startPending('api', 'MyApi', 1);
+    const stopP = h.stop();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(h.serves.map((e) => e.status)).not.toContain('error');
+    h.child.emit('close', 0);
+    await stopP;
+    await expect(h.ready).rejects.toThrow();
+  });
+
+  it('keeps a RESTARTED serve listed while the previous boot timer is still pending', async () => {
+    // End-state property, and deliberately NOT a fence for the identity check
+    // on `entries.delete`. Probing showed that check has no reachable case:
+    // `entries.delete(req.targetId)` is keyed by TARGET rather than by entry,
+    // but every path that could reach it with a FOREIGN entry in the map goes
+    // through `stop()` first, which sets `stopping` -- so the guard above
+    // returns before the delete runs. The identity check stays as a local
+    // statement of the invariant; this case pins the behaviour it protects,
+    // which the guard is what actually delivers.
+    const first = startPending('api', 'MyApi', 1);
+    const stopFirst = first.stop();
+    first.child.emit('close', 0);
+    await stopFirst;
+
+    // Restart the same target, and let the FIRST boot's timer fire underneath.
+    const second = startPending('api', 'MyApi', 50_000);
+    second.child.stdout.emit('data', 'Server listening on http://127.0.0.1:51234\n');
+    await second.ready;
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(second.list().map((s) => s.targetId)).toEqual(['MyApi']);
   });
 });

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -5,10 +5,13 @@ import {
   StudioEventBus,
   type StudioLogEvent,
   type StudioServeEvent,
+  type StudioTargetKind,
 } from '../../../src/local/studio-events.js';
 import {
+  classifyChildLine,
   createStudioServeManager,
   parsePublishedHostEndpoint,
+  type StudioServeState,
 } from '../../../src/local/studio-serve-manager.js';
 
 /** A minimal stand-in for a long-running spawned serve child. */
@@ -1381,14 +1384,460 @@ describe('parsePublishedHostEndpoint (issue #392)', () => {
     ).toBe('http://127.0.0.1:54321');
   });
 
-  it('handles a non-loopback container-host IP', () => {
-    expect(parsePublishedHostEndpoint('published on 192.168.0.5:8080')).toBe(
-      'http://192.168.0.5:8080'
-    );
+  // Issue #578 — the phrase alone is no longer enough: `hostUrl` is a
+  // destination the request composer posts to DIRECTLY, so only the whole
+  // publish banner (which only `ecs-task-runner` emits) can name it. A relayed
+  // error message, or a replica's own application output, that happens to
+  // contain the words is not a publish line.
+  it('ignores the `published on` phrase outside the publish banner (issue #578)', () => {
+    expect(parsePublishedHostEndpoint('published on 192.168.0.5:8080')).toBeUndefined();
+    expect(
+      parsePublishedHostEndpoint('AccessDenied: token published on 10.1.2.3:9999 by the relay')
+    ).toBeUndefined();
+    expect(
+      parsePublishedHostEndpoint(
+        "  Container 'web' container port 80 published on 127.0.0.1:54321."
+      )
+    ).toBeUndefined();
+  });
+
+  // Non-loopback is still PARSED here — this stays a pure reader of the
+  // banner, and the loopback bound is the caller's (see the refusal tests).
+  it('parses a non-loopback container-host IP out of the banner (the caller refuses it)', () => {
+    expect(
+      parsePublishedHostEndpoint(
+        "Container 'web' container port 80 published on 192.168.0.5:8080. Reach it at 192.168.0.5:8080."
+      )
+    ).toBe('http://192.168.0.5:8080');
   });
 
   it('returns undefined for a line with no published endpoint', () => {
     expect(parsePublishedHostEndpoint('Service(s) running: 1 replica.')).toBeUndefined();
     expect(parsePublishedHostEndpoint('Starting container web')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #578 - an ordinary child log line must not be able to name the serve
+// endpoint studio proxies to (or the hostUrl the composer posts to directly).
+// ---------------------------------------------------------------------------
+
+/** Let a pending `onReady` (its proxy startup is async) settle. */
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * Start a serve WITHOUT awaiting readiness, so a line that must NOT be taken
+ * for a ready banner is observable: the entry stays `starting`, no proxy is
+ * created, and `start()`'s promise simply stays pending (it would reject only
+ * when the ready timeout fires, which these tests never trigger).
+ */
+function startPending(
+  kind: StudioTargetKind,
+  targetId = 'MyApi'
+): {
+  child: ReturnType<typeof makeFakeChild>;
+  fp: ReturnType<typeof fakeProxies>;
+  serves: StudioServeEvent[];
+  logs: StudioLogEvent[];
+  list: () => StudioServeState[];
+} {
+  const bus = new StudioEventBus();
+  const { serves, logs } = collect(bus);
+  const child = makeFakeChild();
+  const fp = fakeProxies();
+  const mgr = createStudioServeManager({
+    cliEntry: '/p/cli.js',
+    bus,
+    spawnFn: (() => child) as never,
+    clock: fixedClock(),
+    proxyFactory: fp.factory,
+  });
+  const ready = mgr.start({ targetId, kind });
+  ready.catch(() => undefined);
+  return { child, fp, serves, logs, list: () => mgr.list() };
+}
+
+describe('classifyChildLine (issue #578)', () => {
+  it('reads the compact WARN / ERROR prefix the logger emits', () => {
+    expect(classifyChildLine('WARN: pinned image')).toEqual({
+      diagnostic: true,
+      text: 'pinned image',
+    });
+    expect(classifyChildLine('ERROR: boom')).toEqual({ diagnostic: true, text: 'boom' });
+  });
+
+  it('sees through the ANSI colour the logger wraps a warn line in', () => {
+    expect(classifyChildLine('\u001b[33mWARN: pinned image\u001b[0m')).toEqual({
+      diagnostic: true,
+      text: 'pinned image',
+    });
+  });
+
+  it('reads the verbose `<timestamp> <LEVEL>` preamble (--verbose / CDKL_LOG_LEVEL=debug)', () => {
+    expect(classifyChildLine('2026-08-27T12:00:00.000Z WARN  pinned image')).toEqual({
+      diagnostic: true,
+      text: 'pinned image',
+    });
+    expect(classifyChildLine('2026-08-27T12:00:00.000Z ERROR [ecs] boom')).toEqual({
+      diagnostic: true,
+      text: 'boom',
+    });
+  });
+
+  it('strips a `[module]` tag so an INFO banner still anchors', () => {
+    expect(
+      classifyChildLine('2026-08-27T12:00:00.000Z INFO  [ecs] Service(s) running: 1.')
+    ).toEqual({ diagnostic: false, text: 'Service(s) running: 1.' });
+    expect(classifyChildLine('[ecs] Service(s) running: 1.')).toEqual({
+      diagnostic: false,
+      text: 'Service(s) running: 1.',
+    });
+  });
+
+  it('leaves an ordinary line - and its leading whitespace - alone', () => {
+    expect(classifyChildLine('Server listening on http://127.0.0.1:51234')).toEqual({
+      diagnostic: false,
+      text: 'Server listening on http://127.0.0.1:51234',
+    });
+    // NOT trimmed: the banners start at column 0, so an indented line must
+    // stay unable to impersonate one.
+    expect(classifyChildLine('  Server listening on http://10.0.0.5:3000').text).toBe(
+      '  Server listening on http://10.0.0.5:3000'
+    );
+  });
+});
+
+describe("serve readiness ignores cdk-local's own diagnostics (issue #578)", () => {
+  // Every spelling the logger can render a warn / error in. The URL is
+  // LOOPBACK on purpose: it would sail past the loopback bound, so these
+  // assertions isolate the diagnostic-skip rule.
+  const DIAGNOSTIC_SPELLINGS = [
+    'WARN: AccessDenied: Server listening on http://127.0.0.1:51234  (relayed)',
+    'ERROR: ExpiredTokenException: Server listening on http://127.0.0.1:51234  (relayed)',
+    '[ecs] WARN: Server listening on http://127.0.0.1:51234  (relayed)',
+    '\u001b[33mWARN: Server listening on http://127.0.0.1:51234  (relayed)\u001b[0m',
+    '2026-08-27T12:00:00.000Z WARN  Server listening on http://127.0.0.1:51234',
+    '2026-08-27T12:00:00.000Z ERROR [agentcore] Server listening on http://127.0.0.1:51234',
+  ];
+
+  it('does not flip to running and starts no proxy for any WARN / ERROR spelling', async () => {
+    for (const line of DIAGNOSTIC_SPELLINGS) {
+      const h = startPending('api');
+      h.child.stdout.emit('data', `${line}\n`);
+      await tick();
+      expect(h.list()[0]?.status, line).toBe('starting');
+      expect(h.list()[0]?.endpoints, line).toEqual([]);
+      expect(h.fp.upstreams, line).toEqual([]);
+      expect(
+        h.serves.map((e) => e.status),
+        line
+      ).toEqual(['starting']);
+      // The line is still surfaced to the LOGS panel verbatim.
+      expect(h.logs.at(-1)?.line, line).toBe(line);
+    }
+  });
+
+  it('still flips to running on the genuine banner that follows a diagnostic', async () => {
+    const h = startPending('api');
+    h.child.stdout.emit('data', 'WARN: Server listening on http://127.0.0.1:9999  (relayed)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('starting');
+    h.child.stdout.emit('data', LISTENING);
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    expect(h.list()[0]?.endpoints).toEqual([PROXIED]);
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+  });
+
+  it('ignores a diagnostic carrying the agentcore extra-endpoint phrase', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    h.child.stdout.emit(
+      'data',
+      'WARN: relay said: HTTP contract served on http://127.0.0.1:51234\n'
+    );
+    await tick();
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+    expect(h.fp.upstreams).toEqual([]);
+  });
+});
+
+describe('serve readiness anchors its banners to the start of the line (issue #578)', () => {
+  // Mid-line occurrences with a LOOPBACK URL: only the anchor stops these.
+  const EMBEDDED = [
+    'my-framework 1.2.3: Server listening on http://127.0.0.1:3000',
+    'Reload complete. Server listening on http://127.0.0.1:3000',
+    '  Server listening on http://127.0.0.1:3000',
+  ];
+
+  it('does not treat an embedded phrase as the api ready banner', async () => {
+    for (const line of EMBEDDED) {
+      const h = startPending('api');
+      h.child.stdout.emit('data', `${line}\n`);
+      await tick();
+      expect(h.list()[0]?.status, line).toBe('starting');
+      expect(h.fp.upstreams, line).toEqual([]);
+    }
+  });
+
+  it('does not treat an embedded phrase as the alb / cloudfront / ecs / ecs-task banner', async () => {
+    const cases: Array<[StudioTargetKind, string]> = [
+      ['alb', 'Failed to start ALB front-door: http://127.0.0.1:51234'],
+      ['cloudfront', 'note: CloudFront distribution serving on http://127.0.0.1:51234'],
+      ['ecs', 'Waiting until Service(s) running: MySvc'],
+      ['ecs-task', 'Not yet: Task running (family=fixture)'],
+    ];
+    for (const [kind, line] of cases) {
+      const h = startPending(kind, `T-${kind}`);
+      h.child.stdout.emit('data', `${line}\n`);
+      await tick();
+      expect(h.list()[0]?.status, line).toBe('starting');
+      expect(h.fp.upstreams, line).toEqual([]);
+    }
+  });
+
+  // The anchor must not cost a real serve its readiness under the verbose
+  // renderer, which every logger-emitted banner (alb / ecs / ecs-task /
+  // agentcore-ws) picks up from `--verbose` or an inherited
+  // CDKL_LOG_LEVEL=debug.
+  it('still matches a logger-rendered banner under --verbose', async () => {
+    const h = startPending('alb', 'MyAlb');
+    h.child.stdout.emit(
+      'data',
+      '2026-08-27T12:00:00.000Z INFO  ALB front-door: http://127.0.0.1:51234 (listener port 80)\n'
+    );
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+  });
+
+  it('does not treat an embedded phrase as the agentcore extra-endpoint line', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    // Loopback URL, no diagnostic prefix: only the anchor rejects it.
+    h.child.stdout.emit('data', 'agent boot: HTTP contract served on http://127.0.0.1:51234\n');
+    await tick();
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+    expect(h.fp.upstreams).toEqual([]);
+  });
+
+  it('still matches a child-logger banner carrying a [module] tag', async () => {
+    const h = startPending('ecs', 'Stack/Svc');
+    h.child.stdout.emit('data', '[ecs] Service(s) running: 1 replica.\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+  });
+});
+
+describe('serve readiness refuses a non-loopback endpoint (issue #578)', () => {
+  // Not diagnostics, and anchored at column 0 - indistinguishable from the
+  // real banner by shape. The loopback bound is what stops them. (A `0.0.0.0`
+  // bind is NOT here: a wildcard is a bind address, reachable on loopback, so
+  // it is normalized rather than refused - see the wildcard describe below.)
+  const FOREIGN = [
+    'Server listening on http://attacker.example/  (MyApi)',
+    'Server listening on http://169.254.169.254:80  (MyApi)',
+    'Server listening on http://localhost.attacker.example:8080  (MyApi)',
+    'Server listening on http://127.0.0.1.attacker.example:8080  (MyApi)',
+    'Server listening on http://[2001:db8::1]:3000  (MyApi)',
+    'Server listening on http://192.168.0.5:3000  (MyApi)',
+    'Server listening on not-a-url  (MyApi)',
+  ];
+
+  it('adopts no endpoint, starts no proxy, and stays starting', async () => {
+    for (const line of FOREIGN) {
+      const h = startPending('api');
+      h.child.stdout.emit('data', `${line}\n`);
+      await tick();
+      expect(h.list()[0]?.status, line).toBe('starting');
+      expect(h.list()[0]?.endpoints, line).toEqual([]);
+      expect(h.fp.upstreams, line).toEqual([]);
+      // The refusal is loud: a WARN line lands on the LOGS panel.
+      const warn = h.logs.map((l) => l.line).find((l) => l.startsWith('WARN: refused'));
+      expect(warn, line).toBeDefined();
+      expect(warn, line).toContain('non-loopback');
+    }
+  });
+
+  it('accepts every loopback spelling', async () => {
+    const LOCAL = [
+      'http://127.0.0.1:51234',
+      'http://127.5.5.5:51234',
+      'http://localhost:51234',
+      'http://[::1]:51234',
+    ];
+    for (const url of LOCAL) {
+      const h = startPending('api');
+      h.child.stdout.emit('data', `Server listening on ${url}  (MyApi)\n`);
+      await tick();
+      expect(h.list()[0]?.status, url).toBe('running');
+      expect(h.fp.upstreams, url).toEqual([url]);
+    }
+  });
+
+  it('refuses a non-loopback agentcore extra endpoint while keeping the ws:// one', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    h.child.stdout.emit('data', 'HTTP contract served on http://attacker.example:80\n');
+    await tick();
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+    expect(h.fp.upstreams).toEqual([]);
+    expect(h.logs.map((l) => l.line).some((l) => l.startsWith('WARN: refused'))).toBe(true);
+  });
+
+  it('refuses a non-loopback ws:// ready endpoint outright', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://attacker.example/ws  (MyAgent)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('starting');
+    expect(h.list()[0]?.endpoints).toEqual([]);
+  });
+});
+
+describe('ecs hostUrl carries the same bounds (issue #578)', () => {
+  const ECS_READY_LINE = 'Service(s) running: 1 replica.\n';
+  const banner = (endpoint: string): string =>
+    `Container 'web' container port 80 published on ${endpoint}. Reach it at ${endpoint}.\n`;
+
+  it('ignores a publish banner relayed inside a WARN / ERROR line', async () => {
+    for (const prefix of ['WARN: ', 'ERROR: ', '[ecs] WARN: ']) {
+      const h = startPending('ecs', 'Stack/Svc');
+      h.child.stdout.emit('data', prefix + banner('127.0.0.1:54321'));
+      h.child.stdout.emit('data', ECS_READY_LINE);
+      await tick();
+      expect(h.list()[0]?.status, prefix).toBe('running');
+      expect(h.list()[0]?.hostUrl, prefix).toBeUndefined();
+    }
+  });
+
+  it('ignores the `published on` phrase embedded mid-line', async () => {
+    const h = startPending('ecs', 'Stack/Svc');
+    h.child.stdout.emit('data', 'relay error: token published on 10.1.2.3:9999\n');
+    h.child.stdout.emit('data', ECS_READY_LINE);
+    await tick();
+    expect(h.list()[0]?.hostUrl).toBeUndefined();
+  });
+
+  it('refuses a non-loopback published endpoint, loudly', async () => {
+    for (const endpoint of ['192.168.0.5:8080', '169.254.169.254:80', '10.1.2.3:80']) {
+      const h = startPending('ecs', 'Stack/Svc');
+      h.child.stdout.emit('data', banner(endpoint));
+      h.child.stdout.emit('data', ECS_READY_LINE);
+      await tick();
+      expect(h.list()[0]?.hostUrl, endpoint).toBeUndefined();
+      expect(
+        h.logs.map((l) => l.line).some((l) => l.startsWith('WARN: refused')),
+        endpoint
+      ).toBe(true);
+    }
+  });
+
+  it('still adopts the genuine loopback publish banner', async () => {
+    const h = startPending('ecs', 'Stack/Svc');
+    h.child.stdout.emit('data', banner('127.0.0.1:54321'));
+    h.child.stdout.emit('data', ECS_READY_LINE);
+    await tick();
+    expect(h.list()[0]?.hostUrl).toBe('http://127.0.0.1:54321');
+  });
+});
+
+describe('a wildcard bind address is normalized to loopback, not refused (issue #578)', () => {
+  // `0.0.0.0` / `::` is a BIND address, not a destination: a server bound to
+  // it IS reachable on loopback, and `--container-host 0.0.0.0` is an ordinary
+  // value that `cdkl studio` auto-renders in "All options". Refusing it would
+  // silently break the request composer for that serve.
+  const WILDCARD_READY = [
+    'http://0.0.0.0:51234',
+    'http://[::]:51234',
+    'http://[0:0:0:0:0:0:0:0]:51234',
+    'http://[::ffff:0.0.0.0]:51234',
+  ];
+
+  it('flips to running and adopts the REWRITTEN loopback endpoint', async () => {
+    for (const url of WILDCARD_READY) {
+      const h = startPending('api');
+      h.child.stdout.emit('data', `Server listening on ${url}  (MyApi)\n`);
+      await tick();
+      expect(h.list()[0]?.status, url).toBe('running');
+      // Not merely "not refused": the endpoint handed to the UI is the proxy
+      // in front of the LOOPBACK-rewritten upstream.
+      expect(h.list()[0]?.endpoints, url).toEqual([PROXIED]);
+      expect(
+        h.logs.map((l) => l.line).some((l) => l.startsWith('WARN: refused')),
+        url
+      ).toBe(false);
+    }
+  });
+
+  it('hands the capture proxy 127.0.0.1, never the bind address', async () => {
+    for (const url of WILDCARD_READY) {
+      const h = startPending('api');
+      h.child.stdout.emit('data', `Server listening on ${url}  (MyApi)\n`);
+      await tick();
+      // The rewrite happens at the DESTINATION: the proxy forwards to
+      // 127.0.0.1:51234, not to the wildcard the child printed.
+      expect(h.fp.upstreams, url).toEqual(['http://127.0.0.1:51234']);
+    }
+  });
+
+  it('treats an https:// ready line (--tls) exactly like http://', async () => {
+    // `start-api` flips the banner's scheme to https under mTLS
+    // (local-start-api.ts:1149, `${server.scheme}://...`), and start-cloudfront
+    // does the same via `server.url` (cloudfront-server.ts:144). The guard
+    // reads the HOSTNAME, so the scheme changes nothing.
+    const h = startPending('api');
+    h.child.stdout.emit('data', 'Server listening on https://127.0.0.1:51234  (MyApi)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    expect(h.fp.upstreams).toEqual(['https://127.0.0.1:51234']);
+
+    const w = startPending('api', 'MyApi2');
+    w.child.stdout.emit('data', 'Server listening on https://0.0.0.0:51234  (MyApi)\n');
+    await tick();
+    expect(w.fp.upstreams).toEqual(['https://127.0.0.1:51234']);
+
+    const f = startPending('api', 'MyApi3');
+    f.child.stdout.emit('data', 'Server listening on https://attacker.example/  (MyApi)\n');
+    await tick();
+    expect(f.list()[0]?.status).toBe('starting');
+    expect(f.fp.upstreams).toEqual([]);
+  });
+
+  it('rewrites the host only - port and path survive (agentcore ws:// endpoint)', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://[::]:49160/ws  (MyAgent)\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    // ws:// passes through un-proxied, so this is the exact adopted string.
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws']);
+  });
+
+  it('normalizes the agentcore http:// contract endpoint too', async () => {
+    const h = startPending('agentcore-ws', 'MyAgent');
+    h.child.stdout.emit('data', 'Server listening on ws://127.0.0.1:49160/ws  (MyAgent)\n');
+    await tick();
+    h.child.stdout.emit('data', 'HTTP contract served on http://0.0.0.0:51234\n');
+    await tick();
+    expect(h.list()[0]?.endpoints).toEqual(['ws://127.0.0.1:49160/ws', PROXIED]);
+    expect(h.fp.upstreams).toEqual(['http://127.0.0.1:51234']);
+  });
+
+  it('normalizes a wildcard --container-host publish banner into hostUrl', async () => {
+    // Only the dotted IPv4 wildcard can reach this path: `--container-host`
+    // must be a numeric IP (Docker rejects hostnames), and the publish banner
+    // prints exactly what was bound.
+    const h = startPending('ecs', 'Stack/Svc');
+    h.child.stdout.emit(
+      'data',
+      "Container 'web' container port 80 published on 0.0.0.0:54321. Reach it at 0.0.0.0:54321.\n"
+    );
+    h.child.stdout.emit('data', 'Service(s) running: 1 replica.\n');
+    await tick();
+    expect(h.list()[0]?.status).toBe('running');
+    expect(h.list()[0]?.hostUrl).toBe('http://127.0.0.1:54321');
+    expect(h.logs.map((l) => l.line).some((l) => l.startsWith('WARN: refused'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`cdkl studio` learns BOTH that a spawned serve child is ready AND **where to
proxy to** by regex-matching every stdout line the child prints, and the
patterns were unanchored (`/Server listening on (\S+)/`). `onReady` handed the
captured URL to the capture proxy behind a scheme test alone, and
`startStudioProxy` derived host and port straight from `new URL(upstream)` with
no restriction -- so the studio UI's endpoint, and every request the composer
sends through it with its headers and body, went to whatever host that line
named.

Two ways a line that is not a ready line reached the matcher, and **the first
needs no attacker at all**: an application that logs
`Server listening on http://0.0.0.0:3000` -- an ordinary thing for a web
framework to print -- matched, as did a `WARN: ` line relaying a wire-derived
AWS SDK message.

## Three bounds, the third load-bearing

1. A line carrying cdk-local's own `WARN: ` / `ERROR: ` prefix is never
   pattern-matched at all. `classifyChildLine` strips ANSI SGR, the verbose
   `<ts> <LEVEL>` preamble and a `[module]` tag first -- **four of the six serve
   kinds log through `logger`**, so a naive anchor against the RAW line would
   have made alb / ecs / ecs-task / agentcore-ws never reach running under
   `--verbose`, which studio auto-renders in its "All options" section. That is
   why this is strip-then-anchor rather than just `^`.
2. All six `readyRe` and the `extraEndpointRe` are anchored to the line start.
3. The resolved upstream must be loopback, or the serve is refused with a warn
   -- no proxy, no adopted endpoint, and **no flip to running**, since flipping
   would publish a foreign URL to the UI as the serve's endpoint. Enforced again
   inside `startStudioProxy` itself, so no future call site can lose the bound.

A WILDCARD bind address (`0.0.0.0` / `::` and their equivalents) is REWRITTEN to
`127.0.0.1` rather than refused. It is a bind address, not a destination -- a
server bound to it IS reachable on loopback -- and `--container-host 0.0.0.0` is
an ordinary value for `start-service` / `run-task` that studio auto-renders. The
security property is untouched: no spelling of the wildcard reaches anywhere but
this machine, while a line naming a real foreign host still names a real foreign
host.

## Sibling site swept in the same lane, not filed

`parsePublishedHostEndpoint` derives the `ecs` serve's `hostUrl` from the
replica publish banner, and the request composer targets that host **directly,
with no proxy in between** -- the same root cause with a shorter path to the
user. It is now anchored to the whole banner and its result goes through the
same loopback resolution.

A grep of `src/local/studio-*.ts` for sites deriving a network destination from
child output returns exactly these three. `studio-request-relay` takes its
`baseUrl` from `state.endpoints` / `state.hostUrl`, so the chain closes here
without touching `local-studio.ts`.

## Behavior change

`startStudioProxy` is re-exported from `src/internal.ts`, and it now **throws
synchronously** on a non-loopback upstream (the same shape as the pre-existing
`new URL(...)` parse failure beside it). A host passing a loopback or wildcard
upstream needs no change; one passing a non-loopback upstream must stop, or
catch. Filed for the host CLI as
https://github.com/go-to-k/cdkd/issues/2317 (cat 4 required, plus cat 3 for the
new un-re-exported helpers).

**Corrected from the first draft of this body, which was wrong in BOTH the old
and the new code.** A non-loopback `--container-host` does not merely cost the
`ecs` composer its `hostUrl`: for `alb` the ready line IS the front-door URL and
it is bound to `--container-host`, so the whole serve is refused. It now fails
FAST with the refusal as its reason, rather than hanging out the 120-second ready
timeout and reporting `did not start within 120000ms`.

And the wildcard rewrite covers `0.0.0.0` and the BRACKETED `[::]`. The
UNBRACKETED `::` spelling that the ALB front-door actually prints
(`http://:::8080`) is not a URL at all, so it is refused rather than repaired --
reconstructing an authority the WHATWG parser already rejected means guessing,
and the loopback post-condition would then be validating the guess. The real
defect is the emitter: https://github.com/go-to-k/cdk-local/issues/599.

## Test plan

- `vp run verify`: 223 files / **3610** tests pass, 0 errors, 1 warning
  (pre-existing, `src/local/cloudfront-edge-event.ts:391`).
- **19 mutation probes, all RED** when the guarded line is reverted -- the
  diagnostic gate, each of the six anchors, the `extraEndpointRe` anchor, the
  `onReady` guard, the `ecs` guard, the publish-banner anchor, the three
  `classifyChildLine` strips, the proxy throw, and the four wildcard-rewrite
  probes. One probe initially reported NO discrimination (the `extraEndpointRe`
  anchor); the missing embedded-loopback case was added rather than the fence
  weakened.
- Defect spellings written and confirmed caught rather than just the one the
  issue named: `WARN: `, `ERROR: `, `[ecs] WARN: `, ANSI-wrapped, verbose
  `<ts> WARN`, verbose `<ts> ERROR [module]`; `attacker.example`,
  `169.254.169.254`, `localhost.attacker.example`, `127.0.0.1.attacker.example`,
  `192.168.0.5`, `10.1.2.3`, `2001:db8::1`, an unparseable URL; mid-line and
  indented embeddings. The diagnostic-spelling cases deliberately carry a
  LOOPBACK URL so they isolate bound 1 instead of passing via bound 3.
- An end-to-end proxy case: a real upstream bound to `127.0.0.1:PORT` only,
  addressed as `http://0.0.0.0:PORT`, returns its body through the proxy -- it
  could only reach it if the destination was actually rewritten.
- `/run-integ local-studio`: **PASSED** -- the full fixture, including the api /
  alb / ecs / agentcore serve endpoint assertions, the image-override rebuilds
  and the ALB backing-service serve. That is what proves anchoring broke none of
  the six serve kinds. 0 orphan containers / networks, and zero spurious
  `refused a non-loopback` lines in the run.

Closes #578


## Review round (2nd commit) -- three reviewers

The findings changed what the fix DOES, not only how it is tested.

**`normalizeLocalUpstream` now verifies its own output.** The wildcard rewrite
was string surgery, and `http://0.0.0.0\@attacker.example/` rewrote to something
that re-parsed to host `0.0.0.0`, because `\` terminates a WHATWG authority and
was not in the cut set. Rather than adding `\` -- the "write a better second
spelling" trap -- the function re-parses what it is about to return and requires
a loopback host. One post-condition, on every path, closing the SHAPE rather than
the instance. Userinfo is preserved byte-for-byte, which is safe *because* the
post-condition proves the host the result names.

(A reviewer also reported the userinfo branch corrupting `http://u:p@0.0.0.0/x`.
Re-verified against the pre-fix code: not reproducible. The backslash half did
reproduce. Reported here because a relayed finding that turns out to be wrong is
worth recording as such.)

**The `agentcore-ws` anchor was never fenced** -- a second `RegExp` literal, so
reverting its `^` alone left the suite green. The "all six anchors" claim in the
first draft was really 5/6. Now 6/6, probed individually.

**A bare `[tag]` is no longer stripped before matching**, because that is exactly
how container logs are relayed (`[web] `, `[svc=... c=...] `) -- the strip let
third-party output be re-anchored to column 0. The tag is now peeled only behind
a verbose preamble, and only for the one caller that needs it.

**`readyRe` no longer re-matches after the serve settles**, for four of the six
kinds. `api` and `alb` are exempt and documented, because both provably emit the
banner more than once (one per API group plus one per WebSocket API; one per ALB
listener, with an `await` between them). A blanket gate silently dropped every
listener after the first -- measured, not reasoned: the gated version failed the
existing multi-endpoint test.

Also: the proxy-failure fallback re-resolves instead of adopting the raw child
URL; `--host-port` was the one relay target never normalized and now is; and
`formatAwsErrorForWarn` flattens to one line, since `streamLines` splits on
newlines and line 2 of a multi-line WARN carried no prefix and matched at `^`.

## What this does NOT close

**The issue's path 1 is narrowed, not eliminated.** Container output is relayed
RAW on several paths, so a child printing a common phrase can still re-point a
serve at a wrong LOCAL port. The loopback bound holds throughout, so there is no
off-box forwarding -- but this PR should not be read as closing the attacker-free
case.

A first draft of this section scoped the residual to `api` and `alb`, on the
reasoning that those are the two kinds exempt from the post-settle `readyRe` gate.
The spec reviewer showed that is the wrong frame: the gate only blocks matching
AFTER a serve settles, so every kind that relays raw container output in its
PRE-settle window is exposed regardless. `agentcore-ws` relays the agent
container's stdout raw (`local-start-agentcore.ts:394`) starting BEFORE its own
banner, `api --warm` and `cloudfront` boot containers before theirs. The fix
changes `cdkl invoke`'s stdout and drags a fixture sweep, so it is
https://github.com/go-to-k/cdk-local/issues/598 rather than a line here -- and
that issue has been re-scoped accordingly.

**Multi-line diagnostics are flattened at one relay site, not all of them.**
`formatAwsErrorForWarn` now flattens, but `formatSsmError`
(`ssm-parameter-resolver.ts`) and a raw container-log tail in
`ecs-service-runner.ts` still do not, so line 2 of one of those still reaches the
matcher unprefixed. Folded as a checklist row onto
https://github.com/go-to-k/cdk-local/issues/579, which already owns that family of
relays.

## Test plan (2nd commit)

- `vp run verify`: 223 files / **3634** tests, 0 errors.
- **13 further mutation probes, all RED.** The defence-in-depth property was
  measured per-test rather than asserted: baseline green, guard 1 alone removed
  green, guard 2 alone removed green, BOTH removed red.
- `/run-integ local-studio` re-run after the round: **PASSED**, all six serve
  kinds, 0 orphan containers / networks, and zero spurious `refused a
  non-loopback` lines.


## Review round 3 -- four defects around the bound, five gaps in the fence

The code reviewer found NO blocker in the security bound: it drove
`normalizeLocalUpstream` over 28 adversarial spellings (backslash terminator,
`@`-in-userinfo, octal / decimal / compressed IPv4, `%30`, trailing dot,
tab-newline splice, non-special schemes) and every accepted result re-parses to
loopback -- and showed the two parses CANNOT disagree, since the proxy re-runs the
same `normalizeLocalUpstream` and `new URL` over the same bytes. That is what
makes the post-condition real rather than theatre.

Four defects AROUND it, all fixed:

- **Every ready-line match started a NEW capture proxy**, and the dedup could
  never fire because each carries a fresh port. With `api` / `alb` exempt from the
  settle gate, a handler logging the phrase once per invocation opened a socket
  per invocation. Proxies are now keyed by resolved upstream and reused -- storing
  the PENDING promise, because `start-api` writes its per-group and per-WebSocket
  banners in two consecutive `process.stdout.write` loops, so same-chunk is the
  NORMAL case and a settled-map would still start two.
- **`failServe` raced a user `stop()`**, emitting an error banner for a serve the
  user deliberately stopped (the teardown window is up to 45s for a real ALB).
- **A `[::1]` upstream was accepted and then 502'd on every request** -- the
  brackets reached `httpRequest`, where `{host:'[::1]'}` is `ENOTFOUND`.
  Pre-existing on main, but this PR's tests endorsed it, which makes it ours.
- **The refusal message said "non-loopback" about a loopback value**
  (`--host-port 80=abc` builds `http://127.0.0.1:abc`, which fails to parse).

Five fence gaps, each mutant verified green-before and red-after:

- **Deleting `readyRepeats: true` from `alb` left the WHOLE suite green** --
  every listener after the first silently dropped, which is exactly the bug the
  exemption exists to prevent. `api` was fenced; `alb` was not.
- Nothing pinned that `readyRe` reads the tag-BEARING field; switching either
  matcher to `untagged` was green, because the existing tag tests use bare
  `[tag]` lines where the two fields are equal.
- The post-settle stop was pinned for `cloudfront` only.
- **The wildcard proxy test passed for the wrong reason.** Its comment claimed
  the request could only land if the destination was rewritten; on this OS
  `connect()` to `0.0.0.0` reaches a `127.0.0.1` listener anyway, so forwarding
  the raw upstream was green. It now uses `[::]`, which genuinely refuses, and
  the false comment is corrected rather than left to mislead the next reader.
- A ready banner arriving on stderr was unfenced.

`/run-integ local-studio`: PASSED, all six serve kinds, 0 orphans. (One run
failed first at the post-studio `start-service` port-remap phase -- a direct
`start-service` that imports neither changed module, and green on re-run.)

`vp run verify`: 223 files / **3648** tests, 0 errors.


## Review round 4 (final)

No blocker. The reviewer drove the proxy map against five race shapes -- a ready
line arriving after `stop()` completes, `stop()` racing an in-flight creation, a
rejecting factory shared by two same-chunk lines -- and measured close-exactly-once,
no orphan, no unhandled rejection.

One real finding, and it is the same shape as everything else this session kept
producing: the neighbourhood was swept and the SIBLING one screen up was missed.
The ready-timeout callback had `if (settled)` where `failServe` had gained
`if (settled || entry.stopping)`, so a `stop()` during boot still produced
`starting -> error -> stopped`. Its `entries.delete(req.targetId)` is keyed by
TARGET rather than entry, so a stale timer could evict a RESTARTED serve's entry,
leaving that child unstoppable and its proxy unclosed.

Probing then produced a result worth recording rather than quietly keeping: the
identity check on that delete has NO reachable case, because every path reaching
it with a foreign entry goes through `stop()` first and the new guard returns
first. Reverting the identity check alone leaves the suite green. It stays as a
local statement of the invariant, and its test is labelled as pinning the
behaviour the GUARD delivers rather than as a fence for the check.

Also: the `[::1]` case returned early on a host without IPv6 loopback, passing
with ZERO assertions -- indistinguishable from a real pass, and exactly the
"passed for the wrong reason" failure the `[::]` case in the same file exists to
correct. It now reports as skipped.

One nit deliberately NOT taken: an identity-checked `entry.proxies.delete`.
`pending` is scoped inside the `try`, so it needs a hoist to compile, and the
reviewer had already measured that path unreachable. Adding code to satisfy an
unreachable nit is how the next round happens.

`/run-integ local-studio`: PASSED, all six serve kinds, 0 orphans.
`vp run verify`: 223 files / 3650 tests, 0 errors.
