### PR TITLE
chore(hooks): see through both launcher spellings, so every gate stops being blind to them

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -228,6 +228,66 @@ gate_segments_raw() {
     SEP_SUBST="$GATE_SEP_SUBST" PIPE_MARK="${2:-}" <<< "$1"
 }
 
+# ---------------------------------------------------------------------------
+# Command STRINGS: which leading words RUN their quoted argument.
+#
+# `bash -c "<cmd>"` was the only shape recognised, so `mise exec -c "<cmd>"` --
+# which runs its argument exactly the same way -- stayed ONE opaque token and
+# EVERY gate here was blind to it (go-to-k/cdk-local#585):
+#
+#   mise exec -c "markgate verify integ | tail -5"   # not refused
+#   mise exec -c "gh pr merge 1 --squash"            # reached gh ungated
+#
+# `mise x -c` and `rtx exec -c` are the same shape. `mise exec -- <cmd>` is NOT
+# this shape -- there the command is ordinary argv rather than a string -- and
+# it needs no recursion for the one regex that cares, since
+# `GATE_RE_MARKGATE_VERDICT` absorbs the launcher itself via
+# `GATE_MARKGATE_LAUNCH`.
+#
+# The obvious `^(bash|zsh|ksh|sh|mise|rtx)` is WRONG: `mise -c` is not a thing,
+# only `mise exec -c` / `mise x -c` is, so the SUBCOMMAND is REQUIRED -- without
+# it the recursion would descend into text that never runs.
+#
+# Every token class below EXCLUDES quote characters, and `-c` / `--command` is
+# excluded from the flag run that may precede it. Both are about keeping the
+# parse UNIQUE rather than about what mise accepts: `=~` is POSIX
+# leftmost-longest, so an alternative able to start INSIDE a quoted span lets
+# the flag run reach a LATER `-c` and hand back the wrong body --
+# `mise exec -c "sh -c 'gh pr merge 1'"` would then recurse into
+# `gh pr merge 1'"`, which no verb regex matches, i.e. the very under-match this
+# fix exists to close.
+GATE_MISE_CMD_FLAG="(-c|--command)"
+GATE_MISE_VALUE_FLAG_NOCMD="(-C|--cd|-E|--env|-j|--jobs|--allow-env|--allow-net|--allow-read|--allow-write)"
+GATE_CMDSTRING_VALUE="(\"[^\"]*\"|'[^']*'|[^-[:space:]\"'][^[:space:]\"']*)"
+# One run of flags may sit before the subcommand and another between it and
+# `-c`: a value-taking flag with its value, a boolean flag, or a `tool@version`
+# pin (`mise exec node@20 -c "…"`).
+GATE_CMDSTRING_FLAGS="([[:space:]]+(${GATE_MISE_VALUE_FLAG_NOCMD}[[:space:]]+${GATE_CMDSTRING_VALUE}|--?[A-Za-z][^[:space:]\"']*|[^[:space:]\"']+@[^[:space:]\"']+))*"
+# Matches the PREFIX only -- the body is `${segment#"${BASH_REMATCH[0]}"}`, the
+# same technique `gate_pr_selector` uses, so nothing depends on a capture index
+# that the added alternative would renumber.
+GATE_RE_CMDSTRING="^((bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+|([^[:space:]]*/)?(mise|rtx)${GATE_CMDSTRING_FLAGS}[[:space:]]+(exec|x)${GATE_CMDSTRING_FLAGS}[[:space:]]+${GATE_MISE_CMD_FLAG}([[:space:]]+|=))"
+#
+# The PASSTHROUGH spelling of the same launcher, `mise exec -- <cmd>`, is NOT a
+# command string: the rest of the argv IS the command, so it belongs with the
+# LEADERS `gate_strip_prefix` already strips (`env`, `nohup`, `sudo`, `xargs`
+# …). `exec` is in that list, but the `mise` word, its flags, its subcommand and
+# the bare `--` are not -- and the list's `-[A-Za-z][^[:space:]]*` cannot absorb
+# `--`, which has no LETTER after the dash. So every gate here except the
+# markgate one was blind to it, in the same measurement as the `-c` hole above:
+#
+#   mise exec -- gh pr merge 1 --squash   # reached gh ungated
+#   mise exec -- git commit -m x          # reached git ungated
+#
+# `GATE_RE_MARKGATE_VERDICT` was the lone exception -- it absorbs the launcher
+# inside the verb regex itself, via `GATE_MARKGATE_LAUNCH` -- which is why the
+# defect was found through a markgate pipe and this half of it was not.
+#
+# The SUBCOMMAND is required for the same reason it is above: `mise install` and
+# `mise <verb>` are not passthroughs, and stripping one would hand every gate
+# text that never ran as a command.
+GATE_RE_LAUNCH_PASSTHRU="([^[:space:]]*/)?(mise|rtx)${GATE_CMDSTRING_FLAGS}[[:space:]]+(exec|x)${GATE_CMDSTRING_FLAGS}[[:space:]]+--"
+
 # Leading words that introduce a command without being one: env assignments,
 # wrappers, and the keywords that open a compound statement.
 gate_strip_prefix() {
@@ -247,8 +307,15 @@ gate_strip_prefix() {
     if [[ "$s" =~ ^[[:space:]]*[^\(\)\|\;\&[:space:]]+\)[[:space:]]*(.*)$ ]]; then
       s="${BASH_REMATCH[1]}"
     fi
-    if [[ "$s" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup|time|timeout[[:space:]]+[^[:space:]]+|exec|then|do|else|elif|if|while|until|!|sudo|xargs|-[A-Za-z][^[:space:]]*|\{|\()[[:space:]]+(.*)$ ]]; then
-      s="${BASH_REMATCH[2]}"
+    # `${s#"${BASH_REMATCH[0]}"}` rather than a trailing `(.*)$` capture: the
+    # launcher-passthrough alternative brings its own groups, and any capture
+    # added inside the alternation RENUMBERS a tail group. Reading the tail as
+    # "whatever the match did not consume" is immune to that -- the same reason
+    # `gate_pr_selector` scans from `BASH_REMATCH[0]`. Behaviour is unchanged:
+    # `[[:space:]]+` is greedy either way, so the removed prefix is exactly the
+    # leader plus its trailing run.
+    if [[ "$s" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup|time|timeout[[:space:]]+[^[:space:]]+|${GATE_RE_LAUNCH_PASSTHRU}|exec|then|do|else|elif|if|while|until|!|sudo|xargs|-[A-Za-z][^[:space:]]*|\{|\()[[:space:]]+ ]]; then
+      s="${s#"${BASH_REMATCH[0]}"}"
     fi
     s="${s#"${s%%[![:space:]]*}"}"
   done
@@ -280,7 +347,7 @@ gate_unquote_span() {
 # a pipe, and dropping the argument there would have made the recursion the one
 # blind spot of the piped-segment scan.
 gate_segments() {
-  local segment mark="${2:-}" piped inner
+  local segment mark="${2:-}" piped inner body
   while IFS= read -r segment; do
     # NOT `${segment//"$GATE_SEP_AMP"/&}`: since bash 5.2 an `&` in the
     # replacement means the MATCHED TEXT, so the placeholder survived and a
@@ -309,7 +376,9 @@ gate_segments() {
     # matching it as ONE segment missed `bash -c "cd /w && git commit"`
     # (go-to-k/cdkd#2130 test review). Recurse ONLY here — re-segmenting every
     # segment would split a quoted `--body` whose prose contains `&&`.
-    if [[ "$segment" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+(.*)$ ]]; then
+    # `GATE_RE_CMDSTRING` carries the launcher-hosted spelling of the same shape
+    # (`mise exec -c "<cmd>"`, go-to-k/cdk-local#585); see its definition above.
+    if [[ "$segment" =~ $GATE_RE_CMDSTRING ]]; then
       # `$piped` is re-attached to every segment the recursion yields, because
       # the pipe belongs to the OUTER command: in `bash -c 'markgate verify a'
       # | tail` it is the whole `bash -c` whose exit status the shell discards,
@@ -317,8 +386,9 @@ gate_segments() {
       # `gate_piped_segments` emitted NOTHING and the gate passed. Note it is
       # `$piped` and not `$GATE_PIPE_MARK`: marking unconditionally would mark
       # the inner segments of an UN-piped `bash -c` too.
+      body="${segment#"${BASH_REMATCH[0]}"}"
       while IFS= read -r inner; do printf '%s\n' "$inner$piped"; done \
-        < <(gate_segments "$(gate_unquote_span "${BASH_REMATCH[2]}")" "$mark")
+        < <(gate_segments "$(gate_unquote_span "$body")" "$mark")
       continue
     fi
     # An `if`, not `[ … ] && printf`: under a caller's `set -e` the trailing
@@ -494,7 +564,12 @@ GATE_RE_GH_API="^gh${GATE_GH_C}[[:space:]]+api([[:space:]]|$)"
 # `mise exec --help` rather than from memory: these are ALL of its value-taking
 # flags. The `--allow-*` sandbox four were missed on the first pass and were
 # false negatives (the gate simply did not fire).
-GATE_MARKGATE_VALUE_FLAG="(-C|--cd|-E|--env|-j|--jobs|-c|--command|--allow-env|--allow-net|--allow-read|--allow-write)"
+# Spelled as the union of the two halves defined above rather than as a second
+# enumeration: `GATE_RE_CMDSTRING` needs this list MINUS `-c` / `--command`
+# (which it matches itself), and a list written out twice is a list that drifts
+# -- exactly the failure `UP_PATHS` keeps re-learning. Same language as before,
+# only re-grouped; nothing indexes BASH_REMATCH on this regex.
+GATE_MARKGATE_VALUE_FLAG="(${GATE_MISE_VALUE_FLAG_NOCMD}|${GATE_MISE_CMD_FLAG})"
 GATE_MARKGATE_FLAG_VALUE="(\"[^\"]*\"|'[^']*'|[^-][^[:space:]]*)"
 #
 # The GLOBAL flag run before the subcommand (`mise -C /w exec -- markgate ...`)

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -546,6 +546,78 @@ want_match 0 "xargs behind a pipe" 'echo f | xargs git commit -m x' "$C"
 
 # --- go-to-k/cdkd#2130 test review: two real defects, and the unpinned rest ----
 want_match 0 "bash -c with an inner chain" 'bash -c "cd /w && git commit -m x"' "$C"
+
+# --- go-to-k/cdk-local#585: the LAUNCHER-hosted command string ----------------
+# `mise exec -c "<cmd>"` RUNS its argument exactly as `bash -c` does, but the
+# segment starts with `mise`, so the recursion never fired and every gate here
+# was blind to the spelling.
+want_match 0 "mise exec -c body"             'mise exec -c "git commit -m x"' "$C"
+want_match 0 "mise x -c body"                'mise x -c "gh pr merge 1 --squash"' "$M"
+want_match 0 "rtx exec -c body"              'rtx exec -c "gh pr merge 1 --squash"' "$M"
+want_match 0 "absolute launcher path"        '/opt/homebrew/bin/mise exec -c "git commit -m x"' "$C"
+want_match 0 "--command long spelling"       'mise exec --command "git commit -m x"' "$C"
+want_match 0 "--command= glued spelling"     'mise exec --command="git commit -m x"' "$C"
+want_match 0 "single-quoted body"            "mise exec -c 'git commit -m x'" "$C"
+want_match 0 "flag between exec and -c"      'mise exec --cd /w -c "git commit -m x"' "$C"
+want_match 0 "quoted flag value before -c"   'mise exec --cd "/w t" -c "git commit -m x"' "$C"
+want_match 0 "boolean flag before -c"        'mise exec --raw -c "git commit -m x"' "$C"
+want_match 0 "global flag before exec"       'mise -C /w exec -c "git commit -m x"' "$C"
+want_match 0 "tool pin before -c"            'mise exec node@20 -c "git commit -m x"' "$C"
+want_match 0 "inner chain inside the body"   'mise exec -c "cd /w && git commit -m x"' "$C"
+# A `-c` INSIDE the body must not be mistaken for the launcher's own. `=~` is
+# POSIX leftmost-longest, so a token class able to start inside a quoted span
+# lets the flag run reach the inner `-c` and hand back `git commit -m x'"'"'"`,
+# which no verb regex matches -- the under-match this fix exists to close.
+want_match 0 "nested sh -c inside the body"  "mise exec -c \"sh -c 'git commit -m x'\"" "$C"
+# The SUBCOMMAND is required: `mise -c` is not a thing, so recursing there would
+# descend into text that never runs.
+want_match 1 "bare mise -c does not recurse" 'mise -c "git commit -m x"' "$C"
+want_match 1 "bare rtx -c does not recurse"  'rtx -c "git commit -m x"' "$C"
+want_match 1 "mise run -c is not exec"       'mise run -c "git commit -m x"' "$C"
+# ...and a MENTION inside the body is still only a mention.
+want_match 1 "echo of the verb in the body"  'mise exec -c "echo git commit -m x"' "$C"
+want_match 1 "grep pattern in the body"      "mise exec -c \"rg 'git commit' .\"" "$C"
+want_match 1 "the launcher form as prose"    'echo "mise exec -c \"git commit\""' "$C"
+
+# ...and the PASSTHROUGH half of the same launcher. `mise exec -- <cmd>` hands
+# the rest of the argv to the command, so it is a LEADER rather than a command
+# string, and `gate_strip_prefix` knew nothing about it: every gate except the
+# markgate one (whose verb regex absorbs the launcher itself) saw `mise` and
+# stopped. Measured on the pre-fix tree: BOTH lines below were a MISS while
+# their unprefixed twins matched.
+want_match 0 "mise exec -- gh pr merge"       'mise exec -- gh pr merge 1 --squash' "$M"
+want_match 0 "mise exec -- git commit"        'mise exec -- git commit -m x' "$C"
+want_match 0 "mise exec -- git push"          'mise exec -- git push origin HEAD' "$P"
+want_match 0 "mise x -- passthrough"          'mise x -- gh pr merge 1' "$M"
+want_match 0 "rtx exec -- passthrough"        'rtx exec -- gh pr merge 1' "$M"
+want_match 0 "absolute launcher path, --"     '/opt/homebrew/bin/mise exec -- git commit -m x' "$C"
+want_match 0 "global flag before exec --"     'mise -C /w exec -- git commit -m x' "$C"
+want_match 0 "exec flag before --"            'mise exec --cd /w -- git commit -m x' "$C"
+want_match 0 "quoted exec flag value before --" 'mise exec --cd "/w t" -- git commit -m x' "$C"
+want_match 0 "boolean exec flag before --"    'mise exec --raw -- git commit -m x' "$C"
+want_match 0 "tool pin before --"             'mise exec node@20 -- git commit -m x' "$C"
+want_match 0 "cd && launcher passthrough"     'cd /w/t && mise exec -- git commit -m x' "$C"
+# The OVER-STRIP direction, which nothing else here looks for: a leader that
+# strips too eagerly turns a MENTION into a match, and that failure is a false
+# BLOCK on every gate at once. The subcommand requirement is what fences it --
+# `mise install` / `mise ls` / `mise settings set x` are not passthroughs.
+want_match 1 "passthrough of a grep is prose" 'mise exec -- rg "gh pr merge" .' "$M"
+want_match 1 "passthrough of an unrelated cmd" 'mise exec -- vp run test' "$C"
+want_match 1 "mise install is not exec"       'mise install -- git commit -m x' "$C"
+want_match 1 "bare mise -- is not exec"       'mise -- git commit -m x' "$C"
+want_match 1 "mise ls -- is not exec"         'mise ls -- git commit -m x' "$C"
+want_match 1 "two words before exec --"       'mise settings set x exec -- git commit -m x' "$C"
+want_match 1 "the passthrough as prose"       'echo "mise exec -- git commit -m x"' "$C"
+# The stripped leader must leave the SEGMENT parseable by the helpers that read
+# the verb's own flag run out of it. A surviving leader would hand the payload
+# cwd the verdict (`gate_target_dir`) or the wrong PR (`gate_pr_selector`).
+want_dir "/w/t"  "-C through the passthrough"  'mise exec -- git -C /w/t commit -m x' /base "$C"
+want_dir "/w/t"  "cd then the passthrough"     'cd /w/t && mise exec -- git commit -m x' /base "$C"
+want_dir "/w/t"  "gh -C through the passthrough" 'mise exec -- gh -C /w/t pr merge 1' /base "$M"
+want_dir "/base" "passthrough with no -C"      'mise exec -- git commit -m x' /base "$C"
+want_sel "552"   "selector through the passthrough" 'mise exec -- gh pr merge 552 --squash' "$M"
+want_sel "552"   "selector through passthrough + -R" \
+  'mise exec -- gh -R go-to-k/cdk-local pr merge 552 --squash' "$M"
 want_match 0 "process substitution"        'diff <(git commit -m x) b' "$C"
 # An escaped separator outside quotes is LITERAL — one `echo`, not two commands.
 want_match 1 "escaped semicolon is literal" 'echo a\; git commit -m x' "$C"
@@ -677,6 +749,14 @@ want_piped 1 "two non-flag words before exec"  'mise settings set x exec -- mark
 want_piped 0 "bash -c body, outer pipe"        "bash -c 'markgate verify a' | tail" "$MG"
 want_piped 0 "bash -c double-quoted body"      'bash -c "mise exec -- markgate verify a" | tail' "$MG"
 want_piped 1 "bash -c body, NOT piped"         "bash -c 'markgate verify a'" "$MG"
+# go-to-k/cdk-local#585: the launcher-hosted spelling of the same recursion.
+want_piped 0 "mise exec -c body, inner pipe"   'mise exec -c "markgate verify integ | tail"' "$MG"
+want_piped 0 "mise x -c body, inner pipe"      'mise x -c "markgate set integ | cat"' "$MG"
+want_piped 0 "rtx exec -c body, inner pipe"    'rtx exec -c "markgate verify integ | tail"' "$MG"
+want_piped 0 "mise exec -c body, OUTER pipe"   "mise exec -c 'markgate verify a' | tail" "$MG"
+want_piped 1 "mise exec -c body, NOT piped"    'mise exec -c "markgate verify integ"' "$MG"
+want_piped 1 "mise exec -c rg is not markgate" 'mise exec -c "rg markgate verify ."' "$MG"
+want_piped 1 "bare mise -c is not a launcher"  'mise -c "markgate verify integ | tail"' "$MG"
 want_piped 0 "mise exec with a tool pin"       'mise exec markgate@0.4 -- markgate verify integ | cat' "$MG"
 # Multi-line: the pipe is on a later line than the verb, and on the SAME line as
 # a different one. A segmenter that only ever saw line 1 passed both.

--- a/.claude/hooks/markgate-pipe-gate.test.sh
+++ b/.claude/hooks/markgate-pipe-gate.test.sh
@@ -82,6 +82,17 @@ run_case "inside bash -c"                             2 'bash -c "mise exec -- m
 # The pipe OUTSIDE `bash -c`: the recursion used to drop the outer mark, so
 # `gate_piped_segments` emitted nothing and the gate passed.
 run_case "bash -c body with the pipe OUTSIDE"         2 'bash -c "mise exec -- markgate verify integ" | tail -5'
+# go-to-k/cdk-local#585: `mise exec -c "<cmd>"` runs its argument the same way
+# `bash -c` does, but the segment starts with `mise`, so the recursion never
+# fired and this whole gate was blind to the spelling.
+run_case "mise exec -c hosting the pipe"              2 'mise exec -c "markgate verify integ | tail -5"'
+run_case "mise x -c hosting the pipe"                 2 'mise x -c "markgate set integ | tee /tmp/l"'
+run_case "rtx exec -c hosting the pipe"               2 'rtx exec -c "markgate verify integ | tail -5"'
+run_case "mise exec --command hosting the pipe"       2 'mise exec --command "markgate verify integ | tail -5"'
+run_case "mise exec -c body, pipe OUTSIDE"            2 'mise exec -c "markgate verify integ" | tail -5'
+run_case "launcher flag before the -c body"           2 'mise exec --cd /w/t -c "markgate verify integ | tail -5"'
+run_case "global flag before exec -c"                 2 'mise -C /w/t exec -c "markgate set integ | cat"'
+run_case "mise exec -c with 2>&1 before the pipe"     2 'mise exec -c "markgate verify integ 2>&1 | tail -5"'
 # Launcher flags that take a value must still reach the verb.
 run_case "mise exec -C <dir> -- markgate"             2 'mise exec -C /w/t -- markgate verify integ | tail -5'
 run_case "mise exec --cd <dir> -- markgate"           2 'mise exec --cd /w/t -- markgate set integ | tee /tmp/l'
@@ -155,6 +166,18 @@ run_case "grepping behind a boolean launcher flag"    0 'mise exec --raw rg mark
 run_case "grepping behind a short boolean flag"      0 'mise exec -q rg markgate verify . | head'
 run_case "grepping behind a global flag"              0 'mise -C /w/t exec -- rg markgate verify . | head'
 run_case "bash -c body, nothing piped"                0 'bash -c "mise exec -- markgate verify integ"'
+# ...and the go-to-k/cdk-local#585 recursion must not over-fire: the launcher
+# body is now segmented, so the same false blocks the `--` form fights apply to
+# it. Auditing THIS gate is the likeliest reason anyone types `markgate verify`
+# as grep input.
+run_case "mise exec -c grepping for the form"         0 'mise exec -c "rg markgate verify ."'
+run_case "mise exec -c body, nothing piped"           0 'mise exec -c "markgate verify integ"'
+run_case "mise exec -c body reads the status"         0 'mise exec -c "markgate verify integ || echo STALE"'
+run_case "mise exec -c status piped to awk"           0 'mise exec -c "markgate status integ | awk /state/"'
+# `mise -c` is not a thing -- only `mise exec -c` / `mise x -c` is -- so this
+# must NOT recurse into text that never runs.
+run_case "bare mise -c is not a launcher"             0 'mise -c "markgate verify integ | tail -5"'
+run_case "mise run -c is not exec"                    0 'mise run -c "markgate verify integ | tail -5"'
 # Multi-line ACCEPT, so the multi-line REFUSE cases above cannot be satisfied by
 # a mutation that simply refuses everything spanning a newline.
 run_case "multi-line, un-piped verdict"               0 'cd /w/t

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -300,6 +300,38 @@ The hooks split into three classes:
     inert — without that, ending the body would have started a fresh
     segment mid-prose and reintroduced the go-to-k/cdkd#2130
     body-text regression from the other end.
+  - **A LAUNCHER can host a command string too.** `gate_segments`
+    recursed into `bash -c "<cmd>"` and nothing else, so
+    `mise exec -c "<cmd>"` — which runs its argument exactly the same
+    way — stayed ONE opaque token and every gate in this file was blind
+    to it: `mise exec -c "markgate verify integ | tail -5"` was not
+    refused and `mise exec -c "gh pr merge 1 --squash"` reached `gh`
+    ungated (go-to-k/cdk-local#585). `GATE_RE_CMDSTRING` now carries both
+    shapes, `mise x -c` / `rtx exec -c` included. The SUBCOMMAND is
+    required: `mise -c` is not a thing, so the obvious
+    `^(bash|zsh|ksh|sh|mise|rtx)` would recurse into text that never
+    runs.
+  - **The launcher's PASSTHROUGH spelling was the other half of the same
+    hole.** `mise exec -- <cmd>` is not a command string — the rest of
+    the argv IS the command — so it belongs with the LEADERS
+    `gate_strip_prefix` strips (`env`, `nohup`, `sudo`, `xargs` …).
+    `exec` was already in that list, but the `mise` word, its flags, its
+    subcommand and the bare `--` were not, and the list's
+    `-[A-Za-z][^[:space:]]*` cannot absorb `--` (no LETTER after the
+    dash). So `mise exec -- gh pr merge 1 --squash` and
+    `mise exec -- git commit -m x` reached `gh` / `git` ungated while
+    their unprefixed twins were refused — and this is the spelling every
+    skill and hook in this repo actually writes.
+    `GATE_RE_MARKGATE_VERDICT` was the lone exception, absorbing the
+    launcher inside the verb regex itself via `GATE_MARKGATE_LAUNCH`,
+    which is why the defect surfaced through a markgate pipe and this
+    half of it did not. `GATE_RE_LAUNCH_PASSTHRU` now covers it, with
+    the same subcommand requirement (`mise install` / `mise ls` are not
+    passthroughs). The leader loop reads its tail as
+    `${s#"${BASH_REMATCH[0]}"}` rather than a trailing `(.*)$` capture,
+    since an alternative carrying its own groups renumbers a tail group.
+    Both halves are pinned in BOTH directions, over-strip included, in
+    `.claude/hooks/_command-match.test.sh`.
 
 ## 2. Branch / push safety
 


### PR DESCRIPTION
## Summary

`gate_segments` recursed into a command STRING for one shape only,
`^(bash|zsh|ksh|sh) -[a-z]*c`. `mise exec -c "<cmd>"` runs its argument exactly the
same way, but the segment starts with `mise`, so the whole quoted body stayed one
opaque token and every gate in `.claude/hooks/` was blind to it.

Auditing that turned up a **second launcher spelling the issue did not cover**, and it
is the one every skill in this repo actually writes: `mise exec -- <cmd>`.
`gate_strip_prefix` already strips `env` / `nohup` / `sudo` / `xargs` / `exec`, but not
the `mise` word, its flags, its subcommand, or the bare `--` — and the list's
`-[A-Za-z][^[:space:]]*` cannot absorb `--`, which has no letter after the dash.

Both were live bypasses, measured before the fix:

```
not refused : mise exec -c "markgate verify integ | tail -5"
ungated     : mise exec -c "gh pr merge 1 --squash"
MISS        : mise exec -- gh pr merge 1 --squash
MISS        : mise exec -- git commit -m x
```

`GATE_RE_MARKGATE_VERDICT` was the lone exception — it absorbs the launcher inside the
verb regex itself — which is why the defect surfaced through a markgate pipe and the
`--` half of it did not. So `verify-pr-gate`, `branch-gate`, `integ-gate` and the rest
were all bypassable by a prefix the flow itself tells you to type.

## What changed

The command-string shape goes to the recursion, the passthrough shape to the leader
list, and **both require the subcommand**: `mise -c` and `mise <verb>` are not
launchers, and the naive `^(bash|zsh|ksh|sh|mise|rtx)` the issue warns against would
descend into text that never runs. That over-match direction is fenced in both suites,
not merely described.

Two details the shape had to get right:

- **The tail read.** The added alternatives carry their own capture groups, which
  renumbers a trailing `(.*)$` — `BASH_REMATCH[2]` would silently have become a
  launcher path fragment. Both sites now read `${s#"${BASH_REMATCH[0]}"}`, the
  technique `gate_pr_selector` already uses, which no future alternative can renumber.
- **The flag enumeration stays single-sourced.** `GATE_MARKGATE_VALUE_FLAG` is now
  composed from the same two halves the new regexes use rather than spelled a second
  time. Its token classes also exclude quote characters: `=~` is leftmost-longest, so
  an alternative able to start INSIDE a quoted span lets the flag run reach a LATER
  `-c` and hand back the wrong body — the very under-match this fix closes. That was
  found by mutation-probing the issue's own literally-suggested constant reuse, not by
  guessing.

## Test plan

Fenced in both directions. `_command-match.test.sh` 285 -> 337 and
`markgate-pipe-gate.test.sh` 58 -> 72, with the five untouched suites holding exactly
(123 / 39 / 83 / 53 / 11) — that is the evidence the segmentation change is
behaviour-neutral for every pre-existing case, since `gate_strip_prefix` feeds
`gate_segments` for every gate. `gate_target_dir`, `gate_pr_selector` and
`gate_cmd_repo` are pinned THROUGH the passthrough too, because a surviving leader
would have handed the payload cwd the verdict. Green under macOS system bash 3.2.57 as
well as bash 5.x.

**Four mutation probes**, each with the edit confirmed landed before the result was
read: removing either alternative reds 18 and 16 cases respectively; relaxing the
subcommand to any word reds exactly the two over-strip cases; the issue's suggested
constant reuse reds the nested `sh -c` case.

**End-to-end live test** — the same payload through the real hook, old code vs new:

```
NEW (this branch):  mise exec -- gh pr merge 1 --squash  ->  rc=2  Blocked by verify-pr-gate
OLD (origin/main):  mise exec -- gh pr merge 1 --squash  ->  rc=0  (bypass)
```

and the negative direction, all `rc=0` as they must be: `mise exec -- vp run test`,
`mise install`, `mise exec -- rg "gh pr merge" .`, `echo "mise exec -- gh pr merge 1"`.
`branch-gate` through the launcher on `main` correctly returns rc=2.

`vp run verify` exit 0 (223 test files / 3568 tests); `vp run test:hooks` all green.

## Remaining work

Nothing remaining. No reviewer nits outstanding — this PR is `inline` tier by the
`/review-pr` heuristic (222 LOC / 4 files, no security-surface path, and `.claude/**`
is deliberately excluded from the docs down-bias), reviewed by reading the whole diff.

Closes #585
