### PR TITLE
fix(local): complete and unify the AWS partition tables, so a non-commercial layer ARN resolves

### DIFF
--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -168,19 +168,51 @@ export class EcsTaskResolutionError extends Error {
 }
 
 /**
+ * Region-prefix -> partition / URL-suffix table, most-specific prefix
+ * first. Covers all seven non-commercial partitions; the COMMERCIAL
+ * partition is deliberately NOT a row but the fallback below, so a
+ * brand-new commercial region resolves correctly before this table
+ * hears about it.
+ *
+ * Issue #575: the table used to carry four of the eight partitions, so
+ * an `eusc-` / `eu-isoe-` / `us-isof-` region fell through to the
+ * commercial row and produced `amazonaws.com` — a host that does not
+ * exist in those partitions.
+ */
+const PARTITION_TABLE: ReadonlyArray<{
+  regionPrefix: string;
+  partition: string;
+  urlSuffix: string;
+}> = [
+  { regionPrefix: 'cn-', partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' },
+  { regionPrefix: 'us-gov-', partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' },
+  { regionPrefix: 'us-isob-', partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' },
+  { regionPrefix: 'us-isof-', partition: 'aws-iso-f', urlSuffix: 'csp.hci.ic.gov' },
+  { regionPrefix: 'us-iso-', partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' },
+  { regionPrefix: 'eu-isoe-', partition: 'aws-iso-e', urlSuffix: 'cloud.adc-e.uk' },
+  { regionPrefix: 'eusc-', partition: 'aws-eusc', urlSuffix: 'amazonaws.eu' },
+];
+
+/**
  * Derive the AWS partition / URL suffix for an AWS region. Same mapping
  * CloudFormation applies to `${AWS::Partition}` / `${AWS::URLSuffix}`.
  * Exported so the CLI can keep the STS hop minimal — caller passes the
  * region in once, this returns the matching partition + suffix.
+ *
+ * The region is lower-cased before matching: `--region CN-NORTH-1` is a
+ * region the AWS CLI accepts, and an unnormalized compare used to send
+ * it to the commercial fallback (issue #575).
  */
 export function derivePartitionAndUrlSuffix(region: string): {
   partition: string;
   urlSuffix: string;
 } {
-  if (region.startsWith('cn-')) return { partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' };
-  if (region.startsWith('us-gov-')) return { partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' };
-  if (region.startsWith('us-iso-')) return { partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' };
-  if (region.startsWith('us-isob-')) return { partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' };
+  const normalized = region.toLowerCase();
+  for (const row of PARTITION_TABLE) {
+    if (normalized.startsWith(row.regionPrefix)) {
+      return { partition: row.partition, urlSuffix: row.urlSuffix };
+    }
+  }
   return { partition: 'aws', urlSuffix: 'amazonaws.com' };
 }
 

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -177,9 +177,13 @@ export class EcsTaskResolutionError extends Error {
  * this file already imports from it, so the reverse direction would be
  * an import cycle.
  *
- * Re-exported here so the existing importers (`local-invoke.ts`,
- * `ecs-service-emulator.ts`, `local-run-task.ts`, `local-start-api.ts`)
- * keep working unchanged.
+ * `derivePartitionAndUrlSuffix` is re-exported so the existing importers
+ * (`local-invoke.ts`, `ecs-service-emulator.ts`, `local-run-task.ts`,
+ * `local-start-api.ts`) keep working unchanged. `PARTITION_TABLE` is NOT
+ * inherited traffic -- it did not exist before this change -- and is
+ * carried along only so the pair stays reachable from one module; its
+ * sole consumer today is the test asserting the two names resolve to the
+ * SAME objects rather than to a second copy.
  */
 export { PARTITION_TABLE, derivePartitionAndUrlSuffix } from './intrinsic-image.js';
 

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -168,57 +168,20 @@ export class EcsTaskResolutionError extends Error {
 }
 
 /**
- * Region-prefix -> partition / URL-suffix table, most-specific prefix
- * first. Covers all seven non-commercial partitions; the COMMERCIAL
- * partition is deliberately NOT a row but the fallback below, so a
- * brand-new commercial region resolves correctly before this table
- * hears about it.
+ * The partition table + its lookup now live in `./intrinsic-image.js`,
+ * which is the ONE home for them in this package (issue #575,
+ * go-to-k/cdkd#1821: a second copy behind
+ * `derivePseudoParametersFromRegion` there had drifted three rows behind
+ * this one, so a `us-isof-` / `eu-isoe-` / `eusc-` region resolved
+ * commercial on that path). `intrinsic-image.ts` is a leaf module and
+ * this file already imports from it, so the reverse direction would be
+ * an import cycle.
  *
- * Exported so a test can iterate the REAL rows: a test that re-types
- * the prefixes locally cannot see a future row, which is the only thing
- * the ordering claim above needs fencing against.
- *
- * Issue #575: the table used to carry four of the eight partitions, so
- * an `eusc-` / `eu-isoe-` / `us-isof-` region fell through to the
- * commercial row and produced `amazonaws.com` — a host that does not
- * exist in those partitions.
+ * Re-exported here so the existing importers (`local-invoke.ts`,
+ * `ecs-service-emulator.ts`, `local-run-task.ts`, `local-start-api.ts`)
+ * keep working unchanged.
  */
-export const PARTITION_TABLE: ReadonlyArray<{
-  regionPrefix: string;
-  partition: string;
-  urlSuffix: string;
-}> = [
-  { regionPrefix: 'cn-', partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' },
-  { regionPrefix: 'us-gov-', partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' },
-  { regionPrefix: 'us-isob-', partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' },
-  { regionPrefix: 'us-isof-', partition: 'aws-iso-f', urlSuffix: 'csp.hci.ic.gov' },
-  { regionPrefix: 'us-iso-', partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' },
-  { regionPrefix: 'eu-isoe-', partition: 'aws-iso-e', urlSuffix: 'cloud.adc-e.uk' },
-  { regionPrefix: 'eusc-', partition: 'aws-eusc', urlSuffix: 'amazonaws.eu' },
-];
-
-/**
- * Derive the AWS partition / URL suffix for an AWS region. Same mapping
- * CloudFormation applies to `${AWS::Partition}` / `${AWS::URLSuffix}`.
- * Exported so the CLI can keep the STS hop minimal — caller passes the
- * region in once, this returns the matching partition + suffix.
- *
- * The region is lower-cased before matching: `--region CN-NORTH-1` is a
- * region the AWS CLI accepts, and an unnormalized compare used to send
- * it to the commercial fallback (issue #575).
- */
-export function derivePartitionAndUrlSuffix(region: string): {
-  partition: string;
-  urlSuffix: string;
-} {
-  const normalized = region.toLowerCase();
-  for (const row of PARTITION_TABLE) {
-    if (normalized.startsWith(row.regionPrefix)) {
-      return { partition: row.partition, urlSuffix: row.urlSuffix };
-    }
-  }
-  return { partition: 'aws', urlSuffix: 'amazonaws.com' };
-}
+export { PARTITION_TABLE, derivePartitionAndUrlSuffix } from './intrinsic-image.js';
 
 /**
  * Optional substitution data fed into `parseContainerImage`. Closes issue

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -174,12 +174,16 @@ export class EcsTaskResolutionError extends Error {
  * brand-new commercial region resolves correctly before this table
  * hears about it.
  *
+ * Exported so a test can iterate the REAL rows: a test that re-types
+ * the prefixes locally cannot see a future row, which is the only thing
+ * the ordering claim above needs fencing against.
+ *
  * Issue #575: the table used to carry four of the eight partitions, so
  * an `eusc-` / `eu-isoe-` / `us-isof-` region fell through to the
  * commercial row and produced `amazonaws.com` — a host that does not
  * exist in those partitions.
  */
-const PARTITION_TABLE: ReadonlyArray<{
+export const PARTITION_TABLE: ReadonlyArray<{
   regionPrefix: string;
   partition: string;
   urlSuffix: string;

--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -115,16 +115,87 @@ export function formatStateRemedy(context: ImageResolutionContext | undefined): 
 }
 
 /**
+ * Region-prefix -> partition / URL-suffix table, most-specific prefix
+ * first. Covers all seven non-commercial partitions; the COMMERCIAL
+ * partition is deliberately NOT a row but the fallback in
+ * `derivePartitionAndUrlSuffix` below, so a brand-new commercial region
+ * resolves correctly before this table hears about it.
+ *
+ * Exported so a test can iterate the REAL rows: a test that re-types
+ * the prefixes locally cannot see a future row, which is the only thing
+ * the ordering claim above needs fencing against.
+ *
+ * Issue #575: the table used to carry four of the eight partitions, so
+ * an `eusc-` / `eu-isoe-` / `us-isof-` region fell through to the
+ * commercial row and produced `amazonaws.com` — a host that does not
+ * exist in those partitions.
+ *
+ * This module is the ONE home for the table. It lived in
+ * `ecs-task-resolver.ts` until a SECOND, independently-drifting copy
+ * was found here behind `derivePseudoParametersFromRegion`
+ * (go-to-k/cdkd#1821 measured the divergence). `intrinsic-image.ts` is a
+ * leaf — every import it has is an `import type`, erased at compile
+ * time — and `ecs-task-resolver.ts` already imports from it, so this is
+ * the only direction that does not create an import cycle. That module
+ * re-exports both symbols so its own importers stay unchanged.
+ */
+export const PARTITION_TABLE: ReadonlyArray<{
+  regionPrefix: string;
+  partition: string;
+  urlSuffix: string;
+}> = [
+  { regionPrefix: 'cn-', partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' },
+  { regionPrefix: 'us-gov-', partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' },
+  { regionPrefix: 'us-isob-', partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' },
+  { regionPrefix: 'us-isof-', partition: 'aws-iso-f', urlSuffix: 'csp.hci.ic.gov' },
+  { regionPrefix: 'us-iso-', partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' },
+  { regionPrefix: 'eu-isoe-', partition: 'aws-iso-e', urlSuffix: 'cloud.adc-e.uk' },
+  { regionPrefix: 'eusc-', partition: 'aws-eusc', urlSuffix: 'amazonaws.eu' },
+];
+
+/**
+ * Derive the AWS partition / URL suffix for an AWS region. Same mapping
+ * CloudFormation applies to `${AWS::Partition}` / `${AWS::URLSuffix}`.
+ * Exported so the CLI can keep the STS hop minimal — caller passes the
+ * region in once, this returns the matching partition + suffix.
+ *
+ * The region is lower-cased before matching: `--region CN-NORTH-1` is a
+ * region the AWS CLI accepts, and an unnormalized compare used to send
+ * it to the commercial fallback (issue #575).
+ */
+export function derivePartitionAndUrlSuffix(region: string): {
+  partition: string;
+  urlSuffix: string;
+} {
+  const normalized = region.toLowerCase();
+  for (const row of PARTITION_TABLE) {
+    if (normalized.startsWith(row.regionPrefix)) {
+      return { partition: row.partition, urlSuffix: row.urlSuffix };
+    }
+  }
+  return { partition: 'aws', urlSuffix: 'amazonaws.com' };
+}
+
+/**
  * Derive the AWS pseudo parameters that are trivially knowable from the
  * deploy region alone, without any STS call or state load.
- * `urlSuffix` and `partition` follow the canonical AWS partition rules:
  *
- *   - region prefix `cn-*`        → partition `aws-cn`,     urlSuffix `amazonaws.com.cn`
- *   - region prefix `us-gov-*`    → partition `aws-us-gov`, urlSuffix `amazonaws.com`
- *   - region prefix `us-iso-*`    → partition `aws-iso`,    urlSuffix `c2s.ic.gov`
- *   - region prefix `us-isob-*`   → partition `aws-iso-b`,  urlSuffix `sc2s.sgov.gov`
- *   - everything else (`us-east-1` / `eu-west-2` / `ap-northeast-1` / etc.)
- *                                 → partition `aws`,        urlSuffix `amazonaws.com`
+ * `partition` / `urlSuffix` come from `derivePartitionAndUrlSuffix`
+ * above — the single partition authority in this package. This function
+ * used to carry its OWN if/else chain, which knew four of the eight
+ * partitions and compared case-sensitively, so a `us-isof-` / `eu-isoe-`
+ * / `eusc-` region (and any upper-cased region) resolved to the
+ * commercial partition: `${AWS::Partition}` substituted `aws` into every
+ * ARN built here, and the `Fn::Join` ECR `Code.ImageUri` reconstruction
+ * produced `<acct>.dkr.ecr.<region>.amazonaws.com`, a host that does not
+ * exist in those partitions. Quiet, because the value is structurally
+ * valid and nothing downstream rejects it (issue #575,
+ * go-to-k/cdkd#1821).
+ *
+ * `region` is returned VERBATIM, deliberately: the delegation lower-cases
+ * only for MATCHING. Lower-casing the RETURNED value would change what
+ * `${AWS::Region}` substitutes into templates, which is a separate
+ * behaviour change tracked in go-to-k/cdkd#1831.
  *
  * `accountId` is optional pass-through (caller decides whether to populate
  * it). The bootstrap-ECR URI shape that `lambda.DockerImageCode.fromImageAsset`
@@ -141,26 +212,10 @@ export function derivePseudoParametersFromRegion(
   accountId?: string
 ): { accountId?: string; region: string; partition: string; urlSuffix: string } | undefined {
   if (!region || typeof region !== 'string' || region.length === 0) return undefined;
-  let partition: string;
-  let urlSuffix: string;
-  if (region.startsWith('cn-')) {
-    partition = 'aws-cn';
-    urlSuffix = 'amazonaws.com.cn';
-  } else if (region.startsWith('us-gov-')) {
-    partition = 'aws-us-gov';
-    urlSuffix = 'amazonaws.com';
-  } else if (region.startsWith('us-isob-')) {
-    partition = 'aws-iso-b';
-    urlSuffix = 'sc2s.sgov.gov';
-  } else if (region.startsWith('us-iso-')) {
-    partition = 'aws-iso';
-    urlSuffix = 'c2s.ic.gov';
-  } else {
-    partition = 'aws';
-    urlSuffix = 'amazonaws.com';
-  }
+  const { partition, urlSuffix } = derivePartitionAndUrlSuffix(region);
   return {
     ...(accountId !== undefined && { accountId }),
+    // Verbatim, NOT the lower-cased form the match used — see above.
     region,
     partition,
     urlSuffix,

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -15,8 +15,11 @@ import type { StackInfo } from '../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../types/resource.js';
 import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cli/cdk-path.js';
 import { matchStacks } from '../cli/stack-matcher.js';
-import { derivePseudoParametersFromRegion, tryResolveImageFnJoin } from './intrinsic-image.js';
-import { derivePartitionAndUrlSuffix } from './ecs-task-resolver.js';
+import {
+  derivePartitionAndUrlSuffix,
+  derivePseudoParametersFromRegion,
+  tryResolveImageFnJoin,
+} from './intrinsic-image.js';
 import { stringifyValue } from '../utils/stringify.js';
 import { getEmbedConfig } from './embed-config.js';
 

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -146,7 +146,7 @@ export interface ResolvedArnLambdaLayer {
   logicalId: string;
   /**
    * Full literal ARN as it appeared in the template
-   * (`arn:aws:lambda:<region>:<account>:layer:<name>:<version>`). Kept
+   * (`arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>`). Kept
    * verbatim alongside `logicalId` because callers (the materializer)
    * need the canonical ARN string for SDK calls and the per-kind
    * branch is the only place where the difference matters.
@@ -971,7 +971,7 @@ function resolveSafeZipEntryPath(root: string, entry: string): string {
  *     from outside cdk.out and there's no local directory to bind-mount.
  *
  * **Literal-ARN handling** (issue #448): entries shaped like the string
- * `arn:aws:lambda:<region>:<account>:layer:<name>:<version>` are parsed
+ * `arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>` are parsed
  * into a `{kind: 'arn', ...}` resolved layer. The actual
  * `lambda:GetLayerVersion` + presigned-URL download + unzip happens
  * later in the CLI (`materializeLayerFromArn(...)`), which can optionally
@@ -1010,7 +1010,8 @@ export function resolveLambdaLayers(
           `Lambda '${logicalId}' has a Layers entry [${i}] ${getEmbedConfig().productName} cannot resolve locally: literal string '${entry}'. ` +
             'Expected a same-stack Ref / Fn::GetAtt to an AWS::Lambda::LayerVersion ' +
             'OR a literal layer-version ARN of the form ' +
-            'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.'
+            'arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>, ' +
+            'whose partition agrees with its region.'
         );
       }
       out.push({ kind: 'arn', logicalId: parsed.arn, ...parsed });
@@ -1023,7 +1024,8 @@ export function resolveLambdaLayers(
         `Lambda '${logicalId}' has a Layers entry [${i}] ${getEmbedConfig().productName} cannot resolve locally: ${describeLayerEntry(entry)}. ` +
           'Expected a same-stack Ref / Fn::GetAtt to an AWS::Lambda::LayerVersion ' +
           'OR a literal layer-version ARN of the form ' +
-          'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.'
+          'arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>, ' +
+          'whose partition agrees with its region.'
       );
     }
 
@@ -1051,7 +1053,7 @@ export function resolveLambdaLayers(
  * Parse a Lambda layer-version ARN string into its segments.
  *
  * Returns `undefined` for anything that does not match the strict
- * `arn:aws:lambda:<region>:<account>:layer:<name>:<version>` shape so
+ * `arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>` shape so
  * the caller can produce a clearer error than a silent
  * misinterpretation of hand-edited templates.
  *

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -16,6 +16,7 @@ import type { TemplateResource } from '../types/resource.js';
 import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cli/cdk-path.js';
 import { matchStacks } from '../cli/stack-matcher.js';
 import { derivePseudoParametersFromRegion, tryResolveImageFnJoin } from './intrinsic-image.js';
+import { derivePartitionAndUrlSuffix } from './ecs-task-resolver.js';
 import { stringifyValue } from '../utils/stringify.js';
 import { getEmbedConfig } from './embed-config.js';
 
@@ -1049,26 +1050,40 @@ export function resolveLambdaLayers(
  * Returns `undefined` for anything that does not match the strict
  * `arn:aws:lambda:<region>:<account>:layer:<name>:<version>` shape so
  * the caller can produce a clearer error than a silent
- * misinterpretation of hand-edited templates. The partition segment
- * accepts `aws` / `aws-cn` / `aws-us-gov` so GovCloud / China-region
- * ARNs work without code changes.
+ * misinterpretation of hand-edited templates.
+ *
+ * The partition segment is **derived from the region** rather than
+ * enumerated (issue #575). An alternation has to be re-edited every time
+ * AWS adds a partition — it listed three of the eight, so a layer ARN in
+ * `aws-iso` / `aws-iso-b` / `aws-iso-e` / `aws-iso-f` / `aws-eusc` did
+ * not parse and `resolveLambdaLayers` hard-threw — and it can never
+ * reject a self-inconsistent pair such as
+ * `arn:aws-cn:lambda:us-east-1:...`, which the derived compare does.
  *
  * Exported for unit testing.
  */
 export function parseLayerVersionArn(
   input: string
 ): { arn: string; region: string; accountId: string; name: string; version: string } | undefined {
-  // Region segment accepts up to two interior `<word>-` chunks before
-  // the numeric suffix so GovCloud (`us-gov-west-1`) / China
-  // (`cn-north-1`) / standard (`us-east-1`) regions all match.
+  // The region segment stays SHAPE-based (`<word>(-<word>)+-<digits>`,
+  // wide enough for the European Sovereign Cloud's four-letter
+  // `eusc-de-east-1` and for regions with more interior chunks than
+  // today's) rather than a loose charset, because
+  // `derivePartitionAndUrlSuffix` answers `aws` for any region it does
+  // not recognize — the commercial fallback that lets a brand-new region
+  // resolve before its table hears about it. With a charset,
+  // `arn:aws:lambda:garbage:...` would parse.
   const m =
-    /^arn:(aws|aws-cn|aws-us-gov):lambda:([a-z]{2}-(?:[a-z]+-){1,2}\d+):(\d{12}):layer:([A-Za-z0-9_-]+):(\d+)$/.exec(
+    /^arn:(aws(?:-[a-z]+)*):lambda:([a-z]{2,}(?:-[a-z]+)+-\d+):(\d{12}):layer:([A-Za-z0-9_-]+):(\d+)$/.exec(
       input
     );
   if (!m) return undefined;
+  const partition = m[1]!;
+  const region = m[2]!;
+  if (derivePartitionAndUrlSuffix(region).partition !== partition) return undefined;
   return {
     arn: input,
-    region: m[2]!,
+    region,
     accountId: m[3]!,
     name: m[4]!,
     version: m[5]!,

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -200,18 +200,24 @@ async function fetchLayerContentUrl(
     // `src/internal.ts`, so a host CLI can hand in a
     // `ResolvedArnLambdaLayer` it built itself, whose `arn` never went
     // through `parseLayerVersionArn`. The old re-interpolation was
-    // structurally immune to that; a bare `lastIndexOf` is not -- on a
-    // colon-free string it returns -1 and `slice(0, -1)` silently drops
-    // the last character, turning a caller's mistake into a confusing
-    // API error instead of a clear local one.
-    const lastColon = layer.arn.lastIndexOf(':');
-    if (lastColon <= 0) {
+    // structurally immune to that; stripping a tail is not.
+    //
+    // The guard asserts what is actually being stripped -- a NUMERIC
+    // version segment -- rather than merely that some colon exists. A
+    // bare `lastIndexOf` admits both failure shapes: a colon-free string
+    // returns -1 and `slice(0, -1)` drops the last character, AND a
+    // version-less `...:layer:MyLayer` strips the NAME instead, leaving
+    // `...:layer` paired with a `Number(undefined)` version. Both turn a
+    // caller's mistake into a confusing API error instead of a clear
+    // local one, which is the whole point of the check.
+    const versionSuffix = /^(.*):(\d+)$/.exec(layer.arn);
+    if (!versionSuffix) {
       throw new LayerMaterializationError(
         `Layer ${layer.arn}: not a layer-version ARN (no ':<version>' suffix to strip). ` +
           `Expected arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>.`
       );
     }
-    const versionLessArn = layer.arn.slice(0, lastColon);
+    const versionLessArn = versionSuffix[1]!;
     const command = await buildGetLayerVersionCommand(versionLessArn, Number(layer.version));
     const response = await client.send(command);
     const url = response?.Content?.Location;

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -195,7 +195,23 @@ async function fetchLayerContentUrl(
     // (issue #575). `parseLayerVersionArn` only accepts an ARN whose
     // partition agrees with its region, so the prefix here is already
     // the right one for `layer.region`.
-    const versionLessArn = layer.arn.slice(0, layer.arn.lastIndexOf(':'));
+    //
+    // Guarded because `materializeLayerFromArn` is re-exported from
+    // `src/internal.ts`, so a host CLI can hand in a
+    // `ResolvedArnLambdaLayer` it built itself, whose `arn` never went
+    // through `parseLayerVersionArn`. The old re-interpolation was
+    // structurally immune to that; a bare `lastIndexOf` is not -- on a
+    // colon-free string it returns -1 and `slice(0, -1)` silently drops
+    // the last character, turning a caller's mistake into a confusing
+    // API error instead of a clear local one.
+    const lastColon = layer.arn.lastIndexOf(':');
+    if (lastColon <= 0) {
+      throw new LayerMaterializationError(
+        `Layer ${layer.arn}: not a layer-version ARN (no ':<version>' suffix to strip). ` +
+          `Expected arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>.`
+      );
+    }
+    const versionLessArn = layer.arn.slice(0, lastColon);
     const command = await buildGetLayerVersionCommand(versionLessArn, Number(layer.version));
     const response = await client.send(command);
     const url = response?.Content?.Location;

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -187,7 +187,15 @@ async function fetchLayerContentUrl(
     // account references without a separate account-id flag. AWS docs:
     // "When provided the layer-version's ARN as LayerName, the
     // VersionNumber must still be set."
-    const versionLessArn = `arn:aws:lambda:${layer.region}:${layer.accountId}:layer:${layer.name}`;
+    //
+    // Derived from the ORIGINAL ARN by dropping its `:<version>` tail
+    // rather than re-interpolated from the parsed fields, because
+    // re-interpolation has to name a partition and hardcoding `aws`
+    // sends a partition-mismatched ARN to a non-commercial endpoint
+    // (issue #575). `parseLayerVersionArn` only accepts an ARN whose
+    // partition agrees with its region, so the prefix here is already
+    // the right one for `layer.region`.
+    const versionLessArn = layer.arn.slice(0, layer.arn.lastIndexOf(':'));
     const command = await buildGetLayerVersionCommand(versionLessArn, Number(layer.version));
     const response = await client.send(command);
     const url = response?.Content?.Location;

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -120,7 +120,8 @@ export type StateSubstitutionResult =
  * and `${AWS::*}` placeholders inside `Fn::Sub` / `Fn::Join` bodies are
  * substituted from this bag. The CLI layer typically derives every
  * field from the resolved region + an `sts:GetCallerIdentity` call
- * (see `derivePartitionAndUrlSuffix` in `ecs-task-resolver.ts`).
+ * (see `derivePartitionAndUrlSuffix` in `intrinsic-image.ts`, which
+ * `ecs-task-resolver.ts` re-exports).
  *
  * Every key is optional; a missing key reports unresolved per the
  * standard warn-and-drop policy.

--- a/tests/unit/local/layer-arn-materializer.test.ts
+++ b/tests/unit/local/layer-arn-materializer.test.ts
@@ -160,6 +160,7 @@ describe('materializeLayerFromArn', () => {
       // partition-mismatched ARN. Deriving it from the original ARN is
       // what makes the parse fix reach the wire.
       const layerNames: unknown[] = [];
+      const versionNumbers: unknown[] = [];
       const arn = `arn:${partition}:lambda:${region}:111122223333:layer:MyLayer:3`;
       const zip = await buildZip([{ name: 'nodejs/index.js', data: 'module.exports = 1;' }]);
 
@@ -167,6 +168,7 @@ describe('materializeLayerFromArn', () => {
         lambdaClientFactory: (): LambdaSendClient => ({
           send: async (command: { input?: { LayerName?: unknown } }) => {
             layerNames.push(command.input?.LayerName);
+            versionNumbers.push(command.input?.VersionNumber);
             return { Content: { Location: 'https://presigned.example/zip' } };
           },
         }),
@@ -177,19 +179,32 @@ describe('materializeLayerFromArn', () => {
       expect(layerNames).toEqual([
         `arn:${partition}:lambda:${region}:111122223333:layer:MyLayer`,
       ]);
+      // The version is stripped from the ARN and passed separately, so
+      // assert BOTH halves of the split -- a strip that took the wrong
+      // segment would show up here even if the prefix looked right.
+      expect(versionNumbers).toEqual([3]);
     }
   );
 
-  it('rejects a hand-built layer whose arn carries no version suffix, instead of silently truncating it', async () => {
+  it.each([
+    ['colon-free', 'not-an-arn'],
+    ['version-less layer ARN', 'arn:aws:lambda:us-east-1:111122223333:layer:MyLayer'],
+    ['non-numeric version', 'arn:aws:lambda:us-east-1:111122223333:layer:MyLayer:latest'],
+    ['version-less in another partition', 'arn:aws-cn:lambda:cn-north-1:111122223333:layer:MyLayer'],
+    ['empty version', 'arn:aws:lambda:us-east-1:111122223333:layer:MyLayer:'],
+  ])(
+    'rejects a hand-built layer whose arn has no numeric version suffix (%s)',
+    async (_label, arn) => {
     // `materializeLayerFromArn` is re-exported from `src/internal.ts`, so
     // a host CLI can pass a `ResolvedArnLambdaLayer` it built itself,
-    // whose `arn` never went through `parseLayerVersionArn`. Without the
-    // guard, `lastIndexOf(':')` returns -1 on a colon-free string and
-    // `slice(0, -1)` drops the last character, so the caller's mistake
-    // surfaces as a confusing AWS API error rather than a local one.
+    // whose `arn` never went through `parseLayerVersionArn`. Both failure
+    // shapes matter: a colon-free string used to strip the last
+    // CHARACTER, and a version-less `...:layer:MyLayer` used to strip the
+    // NAME -- leaving `...:layer` paired with `Number(undefined)`. The
+    // second is the one a plain colon check admits, so it is pinned here.
     let sent = 0;
     await expect(
-      materializeLayerFromArn(makeLayer({ arn: 'not-an-arn' }), {
+      materializeLayerFromArn(makeLayer({ arn }), {
         lambdaClientFactory: (): LambdaSendClient => ({
           send: async () => {
             sent += 1;
@@ -200,7 +215,8 @@ describe('materializeLayerFromArn', () => {
       })
     ).rejects.toThrow(/not a layer-version ARN/);
     expect(sent, 'must fail before any AWS call').toBe(0);
-  });
+    }
+  );
 
   it('routes through sts:AssumeRole when roleArn is set and forwards the temp creds to the Lambda client', async () => {
     const stsCalls: { region: string }[] = [];

--- a/tests/unit/local/layer-arn-materializer.test.ts
+++ b/tests/unit/local/layer-arn-materializer.test.ts
@@ -142,6 +142,44 @@ describe('materializeLayerFromArn', () => {
     expect(readFileSync(join(dir, 'nodejs', 'index.js'), 'utf-8')).toBe('module.exports = 42;');
   });
 
+  it.each([
+    ['aws', 'us-east-1'],
+    ['aws-cn', 'cn-north-1'],
+    ['aws-us-gov', 'us-gov-west-1'],
+    ['aws-iso', 'us-iso-east-1'],
+    ['aws-iso-b', 'us-isob-east-1'],
+    ['aws-iso-e', 'eu-isoe-west-1'],
+    ['aws-iso-f', 'us-isof-south-1'],
+    ['aws-eusc', 'eusc-de-east-1'],
+  ])(
+    'sends GetLayerVersion a LayerName in the layer OWN partition (%s), not a hardcoded commercial one',
+    async (partition, region) => {
+      // Issue #575. The version-less ARN used as LayerName used to be
+      // re-interpolated as `arn:aws:lambda:...`, so a layer in any
+      // non-commercial partition parsed and then hit the endpoint with a
+      // partition-mismatched ARN. Deriving it from the original ARN is
+      // what makes the parse fix reach the wire.
+      const layerNames: unknown[] = [];
+      const arn = `arn:${partition}:lambda:${region}:111122223333:layer:MyLayer:3`;
+      const zip = await buildZip([{ name: 'nodejs/index.js', data: 'module.exports = 1;' }]);
+
+      const dir = await materializeLayerFromArn(makeLayer({ arn, logicalId: arn, region }), {
+        lambdaClientFactory: (): LambdaSendClient => ({
+          send: async (command: { input?: { LayerName?: unknown } }) => {
+            layerNames.push(command.input?.LayerName);
+            return { Content: { Location: 'https://presigned.example/zip' } };
+          },
+        }),
+        fetchZip: async () => zip,
+      });
+      cleanupDirs.push(dir);
+
+      expect(layerNames).toEqual([
+        `arn:${partition}:lambda:${region}:111122223333:layer:MyLayer`,
+      ]);
+    }
+  );
+
   it('routes through sts:AssumeRole when roleArn is set and forwards the temp creds to the Lambda client', async () => {
     const stsCalls: { region: string }[] = [];
     const lambdaCalls: { credentials?: AwsCredentials }[] = [];

--- a/tests/unit/local/layer-arn-materializer.test.ts
+++ b/tests/unit/local/layer-arn-materializer.test.ts
@@ -180,6 +180,28 @@ describe('materializeLayerFromArn', () => {
     }
   );
 
+  it('rejects a hand-built layer whose arn carries no version suffix, instead of silently truncating it', async () => {
+    // `materializeLayerFromArn` is re-exported from `src/internal.ts`, so
+    // a host CLI can pass a `ResolvedArnLambdaLayer` it built itself,
+    // whose `arn` never went through `parseLayerVersionArn`. Without the
+    // guard, `lastIndexOf(':')` returns -1 on a colon-free string and
+    // `slice(0, -1)` drops the last character, so the caller's mistake
+    // surfaces as a confusing AWS API error rather than a local one.
+    let sent = 0;
+    await expect(
+      materializeLayerFromArn(makeLayer({ arn: 'not-an-arn' }), {
+        lambdaClientFactory: (): LambdaSendClient => ({
+          send: async () => {
+            sent += 1;
+            return { Content: { Location: 'https://presigned.example/zip' } };
+          },
+        }),
+        fetchZip: async () => Buffer.alloc(0),
+      })
+    ).rejects.toThrow(/not a layer-version ARN/);
+    expect(sent, 'must fail before any AWS call').toBe(0);
+  });
+
   it('routes through sts:AssumeRole when roleArn is set and forwards the temp creds to the Lambda client', async () => {
     const stsCalls: { region: string }[] = [];
     const lambdaCalls: { credentials?: AwsCredentials }[] = [];

--- a/tests/unit/local/layer-arn-partitions.test.ts
+++ b/tests/unit/local/layer-arn-partitions.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { parseLayerVersionArn, resolveLambdaLayers } from '../../../src/local/lambda-resolver.js';
+import { derivePartitionAndUrlSuffix } from '../../../src/local/ecs-task-resolver.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+
+/**
+ * Issue #575. `parseLayerVersionArn` is a CLASSIFIER (an ARN string in,
+ * accept / reject plus parsed fields out), so hand-picked positive cases
+ * cannot fence it — a pattern widened until it accepts everything
+ * satisfies every positive assertion. The fence here is DIFFERENTIAL:
+ * the pre-fix implementation and the current one are run over a
+ * generated input space, and every cell where they disagree must fall
+ * into an enumerated intended class, judged by the VALUE the current
+ * implementation returned rather than by which input produced it.
+ */
+
+interface ParsedLayerArn {
+  arn: string;
+  region: string;
+  accountId: string;
+  name: string;
+  version: string;
+}
+
+/**
+ * The PRE-FIX `parseLayerVersionArn`, transcribed verbatim from
+ * `git show origin/main:src/local/lambda-resolver.ts` (the regex is the
+ * one this branch replaces). Kept whole rather than reduced to its
+ * regex so the differential compares two functions of the same shape.
+ */
+function parseLayerVersionArnPreFix(input: string): ParsedLayerArn | undefined {
+  const m =
+    /^arn:(aws|aws-cn|aws-us-gov):lambda:([a-z]{2}-(?:[a-z]+-){1,2}\d+):(\d{12}):layer:([A-Za-z0-9_-]+):(\d+)$/.exec(
+      input
+    );
+  if (!m) return undefined;
+  return {
+    arn: input,
+    region: m[2]!,
+    accountId: m[3]!,
+    name: m[4]!,
+    version: m[5]!,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Independent oracle. Deliberately NOT the implementation's regex: it
+// segments the ARN by `:` and checks each field on its own terms, so an
+// implementation that widened its pattern is judged by what a layer ARN
+// actually is rather than by what it chose to match.
+// ---------------------------------------------------------------------------
+
+const REGION_SHAPE = /^[a-z]{2,}(?:-[a-z]+)+-\d+$/;
+
+/** Reasons the returned value is NOT a legitimate parse of `input`. */
+function violationsForAccepted(input: string, value: ParsedLayerArn): string[] {
+  const v: string[] = [];
+  const parts = input.split(':');
+  if (parts.length !== 8) {
+    return [`accepted an ARN with ${parts.length} segments (expected 8)`];
+  }
+  const [arnLiteral, partition, service, region, account, layerLiteral, name, version] = parts as [
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+  if (arnLiteral !== 'arn') v.push(`accepted a non-'arn' first segment '${arnLiteral}'`);
+  if (service !== 'lambda') v.push(`accepted a non-'lambda' service segment '${service}'`);
+  if (layerLiteral !== 'layer') v.push(`accepted a non-'layer' resource segment '${layerLiteral}'`);
+  if (!/^aws(?:-[a-z]+)*$/.test(partition)) v.push(`accepted a bogus partition '${partition}'`);
+  if (!REGION_SHAPE.test(region)) v.push(`accepted a non-region-shaped segment '${region}'`);
+  if (!/^\d{12}$/.test(account)) v.push(`accepted a non-12-digit account '${account}'`);
+  if (!/^[A-Za-z0-9_-]+$/.test(name)) v.push(`accepted an illegal layer name '${name}'`);
+  if (!/^\d+$/.test(version)) v.push(`accepted a non-numeric version '${version}'`);
+  if (derivePartitionAndUrlSuffix(region).partition !== partition) {
+    v.push(`accepted partition '${partition}' paired with region '${region}'`);
+  }
+  // Field mapping: the returned segments must be the ones in the input.
+  if (value.arn !== input) v.push(`arn field '${value.arn}' !== input`);
+  if (value.region !== region) v.push(`region field '${value.region}' !== '${region}'`);
+  if (value.accountId !== account) v.push(`accountId field '${value.accountId}' !== '${account}'`);
+  if (value.name !== name) v.push(`name field '${value.name}' !== '${name}'`);
+  if (value.version !== version) v.push(`version field '${value.version}' !== '${version}'`);
+  return v;
+}
+
+/**
+ * Reasons rejecting `input` is NOT legitimate. Only reached for inputs
+ * the PRE-FIX implementation accepted, so the shape is already known
+ * good; the one sanctioned reason to newly reject is that the partition
+ * segment disagrees with the region's partition.
+ */
+function violationsForNewlyRejected(input: string): string[] {
+  const parts = input.split(':');
+  const partition = parts[1] ?? '';
+  const region = parts[3] ?? '';
+  if (derivePartitionAndUrlSuffix(region).partition === partition) {
+    return [`rejected the self-consistent, well-formed ARN '${input}'`];
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Generated input space: 8 real partitions (plus bogus ones) x region
+// shapes (real, per-partition, and malformed) x account / name / version
+// variants, plus structural mutations of a canonical ARN.
+// ---------------------------------------------------------------------------
+
+const PARTITIONS = [
+  'aws',
+  'aws-cn',
+  'aws-us-gov',
+  'aws-iso',
+  'aws-iso-b',
+  'aws-iso-e',
+  'aws-iso-f',
+  'aws-eusc',
+  'aws-bogus',
+  'notaws',
+  '',
+];
+
+const REGIONS = [
+  // commercial
+  'us-east-1',
+  'eu-west-3',
+  'ap-southeast-4',
+  'ca-central-1',
+  // non-commercial, one or more per partition
+  'cn-north-1',
+  'cn-northwest-1',
+  'us-gov-west-1',
+  'us-gov-east-1',
+  'us-iso-east-1',
+  'us-iso-west-1',
+  'us-isob-east-1',
+  'us-isof-south-1',
+  'us-isof-east-1',
+  'eu-isoe-west-1',
+  'eusc-de-east-1',
+  // shape probes
+  'ap-southeast-new-extra-1',
+  'garbage',
+  'us-east',
+  'useast1',
+  'US-EAST-1',
+  'us--east-1',
+  'us-east-',
+  '-us-east-1',
+  'us-east-1a',
+  '',
+];
+
+const ACCOUNTS = ['123456789012', '000000000000', '12345678901', '1234567890123', 'abcdefghijkl', ''];
+const NAMES = ['my-layer', 'Powertools_Python', 'AWSLambdaPowertoolsPythonV2', 'bad name', 'has:colon', ''];
+const VERSIONS = ['1', '42', '007', 'x', '1a', ''];
+
+/** Structural mutations of a well-formed ARN — prefix / suffix / segment damage. */
+function structuralVariants(arn: string): string[] {
+  return [
+    arn.toUpperCase(),
+    ` ${arn}`,
+    `${arn} `,
+    arn.replace('arn:', 'ARN:'),
+    arn.replace(':lambda:', ':lamba:'),
+    arn.replace(':layer:', ':layers:'),
+    `${arn}:extra`,
+    arn.slice(0, -2),
+    arn.replace('arn:', ''),
+    `prefix${arn}`,
+    arn.replace(/:/g, '/'),
+  ];
+}
+
+function buildInputSpace(): string[] {
+  const out: string[] = [];
+  for (const partition of PARTITIONS) {
+    for (const region of REGIONS) {
+      for (const account of ACCOUNTS) {
+        for (const name of NAMES) {
+          for (const version of VERSIONS) {
+            out.push(`arn:${partition}:lambda:${region}:${account}:layer:${name}:${version}`);
+          }
+        }
+      }
+    }
+    out.push(
+      ...structuralVariants(`arn:${partition}:lambda:us-east-1:123456789012:layer:my-layer:1`)
+    );
+  }
+  return out;
+}
+
+/**
+ * The intended sub-reasons a cell may be NEWLY ACCEPTED — the three
+ * independent bounds the pre-fix regex carried. Used ONLY to tally
+ * floors, never to excuse a violation (that is judged by
+ * `violationsForAccepted` on the returned value alone). A cell may hit
+ * more than one: `arn:aws-eusc:...:eusc-de-east-1:...` is both a
+ * partition the alternation omitted AND a region shape it rejected, and
+ * today no input separates them since `eusc-` is that partition's only
+ * region prefix.
+ */
+function newlyAcceptedReasons(input: string): string[] {
+  const parts = input.split(':');
+  const partition = parts[1]!;
+  const region = parts[3]!;
+  const reasons: string[] = [];
+  if (partition !== 'aws' && partition !== 'aws-cn' && partition !== 'aws-us-gov') {
+    reasons.push(`partition:${partition}`);
+  }
+  if (!/^[a-z]{2}-/.test(region)) reasons.push('region-shape:first-token-longer-than-two');
+  // Interior `<word>-` chunks: everything between the first token and
+  // the numeric suffix. The pre-fix regex capped this at two.
+  const regionParts = region.split('-');
+  if (regionParts.length - 2 > 2) reasons.push('region-shape:extra-interior-chunks');
+  return reasons;
+}
+
+describe('parseLayerVersionArn — differential fence against the pre-fix regex (issue #575)', () => {
+  const inputs = buildInputSpace();
+
+  it('every disagreement with the pre-fix implementation falls in an intended class', () => {
+    const violations: string[] = [];
+    const newlyAccepted: string[] = [];
+    const newlyRejected: string[] = [];
+    let sameAccept = 0;
+    let sameReject = 0;
+    const acceptedReasonTally = new Map<string, number>();
+    const sameAcceptPartitions = new Set<string>();
+
+    for (const input of inputs) {
+      const before = parseLayerVersionArnPreFix(input);
+      const after = parseLayerVersionArn(input);
+
+      if (before && after) {
+        sameAccept++;
+        sameAcceptPartitions.add(input.split(':')[1]!);
+        if (JSON.stringify(before) !== JSON.stringify(after)) {
+          violations.push(
+            `divergent parse for '${input}': ${JSON.stringify(before)} vs ${JSON.stringify(after)}`
+          );
+        }
+        continue;
+      }
+      if (!before && !after) {
+        sameReject++;
+        continue;
+      }
+      if (after) {
+        // Class 1: newly accepted. Judged by the RETURNED VALUE.
+        const v = violationsForAccepted(input, after);
+        if (v.length > 0) {
+          violations.push(`${input}: ${v.join('; ')}`);
+        } else {
+          const reasons = newlyAcceptedReasons(input);
+          if (reasons.length === 0) {
+            violations.push(`${input}: newly accepted for no enumerated reason`);
+          } else {
+            newlyAccepted.push(input);
+            for (const reason of reasons) {
+              acceptedReasonTally.set(reason, (acceptedReasonTally.get(reason) ?? 0) + 1);
+            }
+          }
+        }
+        continue;
+      }
+      // Class 2: newly rejected. Judged by whether rejecting is legitimate.
+      const v = violationsForNewlyRejected(input);
+      if (v.length > 0) violations.push(`${input}: ${v.join('; ')}`);
+      else newlyRejected.push(input);
+    }
+
+    expect(violations.slice(0, 20)).toEqual([]);
+
+    // Floors — a pool that stops covering a class must not read as
+    // "no regressions". Each intended repair has to be REACHED.
+    for (const partition of ['aws-iso', 'aws-iso-b', 'aws-iso-e', 'aws-iso-f', 'aws-eusc']) {
+      expect(
+        acceptedReasonTally.get(`partition:${partition}`) ?? 0,
+        `no newly-accepted cell for partition '${partition}'`
+      ).toBeGreaterThan(0);
+    }
+    expect(
+      acceptedReasonTally.get('region-shape:first-token-longer-than-two') ?? 0,
+      "no newly-accepted cell for a region whose first token is longer than two letters (eusc-de-east-1)"
+    ).toBeGreaterThan(0);
+    expect(
+      acceptedReasonTally.get('region-shape:extra-interior-chunks') ?? 0,
+      'no newly-accepted cell for a region with more than two interior chunks'
+    ).toBeGreaterThan(0);
+    expect(newlyRejected.length, 'no newly-rejected cell (mismatched partition/region)').toBeGreaterThan(0);
+
+    // The commercial + two previously-known partitions must still parse
+    // exactly as before — the direction a total regression would break.
+    expect(sameAccept).toBeGreaterThan(0);
+    expect([...sameAcceptPartitions].sort()).toEqual(['aws', 'aws-cn', 'aws-us-gov']);
+    expect(sameReject).toBeGreaterThan(0);
+  });
+
+  it('rejects the self-inconsistent pair the pre-fix regex accepted', () => {
+    const mismatched = 'arn:aws-cn:lambda:us-east-1:123456789012:layer:my-layer:1';
+    expect(parseLayerVersionArnPreFix(mismatched)).toBeDefined();
+    expect(parseLayerVersionArn(mismatched)).toBeUndefined();
+  });
+
+  it('still rejects a non-region-shaped segment (the commercial fallback is not a hole)', () => {
+    expect(
+      parseLayerVersionArn('arn:aws:lambda:garbage:123456789012:layer:my-layer:1')
+    ).toBeUndefined();
+  });
+
+  it('accepts a region the partition table has never heard of, as commercial', () => {
+    const parsed = parseLayerVersionArn(
+      'arn:aws:lambda:xy-somewhere-9:123456789012:layer:my-layer:3'
+    );
+    expect(parsed?.region).toBe('xy-somewhere-9');
+    expect(parsed?.version).toBe('3');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The caller: `resolveLambdaLayers` hard-throws on a parse miss, so the
+// user-visible symptom of the pre-fix regex was `cdkl invoke` failing
+// outright in five of eight partitions.
+// ---------------------------------------------------------------------------
+
+function makeStackWithLayerArn(arn: string): { stack: StackInfo; props: Record<string, unknown> } {
+  const props = { Runtime: 'nodejs20.x', Handler: 'index.handler', Layers: [arn] };
+  const template: CloudFormationTemplate = {
+    Resources: { Fn: { Type: 'AWS::Lambda::Function', Properties: props } },
+  };
+  return {
+    stack: {
+      stackName: 'TestStack',
+      displayName: 'TestStack',
+      artifactId: 'TestStack',
+      template,
+      dependencyNames: [],
+    },
+    props,
+  };
+}
+
+describe('resolveLambdaLayers — literal layer ARNs resolve in every partition (issue #575)', () => {
+  const cases: Array<{ partition: string; region: string }> = [
+    { partition: 'aws', region: 'us-east-1' },
+    { partition: 'aws-cn', region: 'cn-north-1' },
+    { partition: 'aws-us-gov', region: 'us-gov-west-1' },
+    { partition: 'aws-iso', region: 'us-iso-east-1' },
+    { partition: 'aws-iso-b', region: 'us-isob-east-1' },
+    { partition: 'aws-iso-e', region: 'eu-isoe-west-1' },
+    { partition: 'aws-iso-f', region: 'us-isof-south-1' },
+    { partition: 'aws-eusc', region: 'eusc-de-east-1' },
+  ];
+
+  for (const { partition, region } of cases) {
+    it(`resolves a ${partition} layer ARN without throwing`, () => {
+      const arn = `arn:${partition}:lambda:${region}:123456789012:layer:AWSLambdaPowertoolsPythonV2:4`;
+      const { stack, props } = makeStackWithLayerArn(arn);
+      expect(resolveLambdaLayers(stack, 'Fn', props)).toEqual([
+        {
+          kind: 'arn',
+          logicalId: arn,
+          arn,
+          region,
+          accountId: '123456789012',
+          name: 'AWSLambdaPowertoolsPythonV2',
+          version: '4',
+        },
+      ]);
+    });
+  }
+
+  it('still throws for a partition/region pair that cannot be reconciled', () => {
+    const { stack, props } = makeStackWithLayerArn(
+      'arn:aws-cn:lambda:us-east-1:123456789012:layer:my-layer:1'
+    );
+    expect(() => resolveLambdaLayers(stack, 'Fn', props)).toThrow(/cannot resolve locally/);
+  });
+
+  it('still throws for a literal string that is not a layer ARN at all', () => {
+    const { stack, props } = makeStackWithLayerArn('not-an-arn');
+    expect(() => resolveLambdaLayers(stack, 'Fn', props)).toThrow(/cannot resolve locally/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The partition table itself.
+// ---------------------------------------------------------------------------
+
+describe('derivePartitionAndUrlSuffix — all eight partitions (issue #575)', () => {
+  const table: Array<{ region: string; partition: string; urlSuffix: string }> = [
+    { region: 'us-east-1', partition: 'aws', urlSuffix: 'amazonaws.com' },
+    { region: 'eu-west-3', partition: 'aws', urlSuffix: 'amazonaws.com' },
+    { region: 'cn-north-1', partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' },
+    { region: 'cn-northwest-1', partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' },
+    { region: 'us-gov-west-1', partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' },
+    { region: 'us-gov-east-1', partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' },
+    { region: 'us-iso-east-1', partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' },
+    { region: 'us-iso-west-1', partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' },
+    { region: 'us-isob-east-1', partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' },
+    { region: 'eu-isoe-west-1', partition: 'aws-iso-e', urlSuffix: 'cloud.adc-e.uk' },
+    { region: 'us-isof-south-1', partition: 'aws-iso-f', urlSuffix: 'csp.hci.ic.gov' },
+    { region: 'us-isof-east-1', partition: 'aws-iso-f', urlSuffix: 'csp.hci.ic.gov' },
+    { region: 'eusc-de-east-1', partition: 'aws-eusc', urlSuffix: 'amazonaws.eu' },
+  ];
+
+  for (const { region, partition, urlSuffix } of table) {
+    it(`maps ${region} to ${partition} / ${urlSuffix}`, () => {
+      expect(derivePartitionAndUrlSuffix(region)).toEqual({ partition, urlSuffix });
+    });
+  }
+
+  it('covers all eight partitions', () => {
+    expect(new Set(table.map((r) => r.partition)).size).toBe(8);
+  });
+
+  it('lower-cases the region before matching', () => {
+    expect(derivePartitionAndUrlSuffix('CN-NORTH-1')).toEqual({
+      partition: 'aws-cn',
+      urlSuffix: 'amazonaws.com.cn',
+    });
+    expect(derivePartitionAndUrlSuffix('US-Gov-West-1')).toEqual({
+      partition: 'aws-us-gov',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePartitionAndUrlSuffix('EUSC-DE-EAST-1')).toEqual({
+      partition: 'aws-eusc',
+      urlSuffix: 'amazonaws.eu',
+    });
+  });
+
+  it('falls back to the commercial partition for an unknown region', () => {
+    expect(derivePartitionAndUrlSuffix('xy-somewhere-9')).toEqual({
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePartitionAndUrlSuffix('')).toEqual({
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('does not confuse the three us-iso* prefixes with one another', () => {
+    expect(derivePartitionAndUrlSuffix('us-iso-east-1').partition).toBe('aws-iso');
+    expect(derivePartitionAndUrlSuffix('us-isob-east-1').partition).toBe('aws-iso-b');
+    expect(derivePartitionAndUrlSuffix('us-isof-east-1').partition).toBe('aws-iso-f');
+  });
+});

--- a/tests/unit/local/layer-arn-partitions.test.ts
+++ b/tests/unit/local/layer-arn-partitions.test.ts
@@ -448,9 +448,27 @@ describe('derivePartitionAndUrlSuffix — all eight partitions (issue #575)', ()
     });
   });
 
-  it('does not confuse the three us-iso* prefixes with one another', () => {
+  it('resolves each us-iso* prefix to its own partition', () => {
+    // NOT an ordering test, despite how it reads: no table prefix is a
+    // prefix of another (`'us-isob-east-1'.startsWith('us-iso-')` is
+    // false -- index 6 is `b`, not `-`), so these three pass under ANY
+    // table order. The "most-specific first" ordering in the table is
+    // defensive against a FUTURE row, and the assertion that actually
+    // fences it is the no-shadowing check below.
     expect(derivePartitionAndUrlSuffix('us-iso-east-1').partition).toBe('aws-iso');
     expect(derivePartitionAndUrlSuffix('us-isob-east-1').partition).toBe('aws-iso-b');
     expect(derivePartitionAndUrlSuffix('us-isof-east-1').partition).toBe('aws-iso-f');
+  });
+
+  it('has no table prefix that shadows another, so no row is order-dependent', () => {
+    // The real fence for the ordering claim. If a future row IS a
+    // prefix of an existing one, this goes red and the table's order
+    // stops being merely defensive -- at which point a case pinning
+    // that specific pair has to be written.
+    const prefixes = [...new Set(table.map((r) => r.regionPrefix))];
+    const shadowing = prefixes.flatMap((a) =>
+      prefixes.filter((b) => b !== a && b.startsWith(a)).map((b) => `${a} shadows ${b}`)
+    );
+    expect(shadowing).toEqual([]);
   });
 });

--- a/tests/unit/local/layer-arn-partitions.test.ts
+++ b/tests/unit/local/layer-arn-partitions.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { parseLayerVersionArn, resolveLambdaLayers } from '../../../src/local/lambda-resolver.js';
-import { derivePartitionAndUrlSuffix } from '../../../src/local/ecs-task-resolver.js';
+import {
+  derivePartitionAndUrlSuffix,
+  PARTITION_TABLE,
+} from '../../../src/local/ecs-task-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { CloudFormationTemplate } from '../../../src/types/resource.js';
 
@@ -461,11 +464,15 @@ describe('derivePartitionAndUrlSuffix — all eight partitions (issue #575)', ()
   });
 
   it('has no table prefix that shadows another, so no row is order-dependent', () => {
-    // The real fence for the ordering claim. If a future row IS a
-    // prefix of an existing one, this goes red and the table's order
-    // stops being merely defensive -- at which point a case pinning
-    // that specific pair has to be written.
-    const prefixes = [...new Set(table.map((r) => r.regionPrefix))];
+    // Iterates the REAL `PARTITION_TABLE`, not a list re-typed here: a
+    // local copy would not see a future row, which is the only thing
+    // the ordering claim needs fencing against. (The first draft of
+    // this test read `regionPrefix` off the region/partition/urlSuffix
+    // table above, a property that does not exist there, so it compared
+    // `[undefined]` against itself and passed under ANY table -- test
+    // files are excluded from `tsconfig.json`, so nothing typechecked
+    // the property away.)
+    const prefixes = [...new Set(PARTITION_TABLE.map((r) => r.regionPrefix))];
     const shadowing = prefixes.flatMap((a) =>
       prefixes.filter((b) => b !== a && b.startsWith(a)).map((b) => `${a} shadows ${b}`)
     );

--- a/tests/unit/local/layer-arn-partitions.test.ts
+++ b/tests/unit/local/layer-arn-partitions.test.ts
@@ -385,12 +385,23 @@ describe('resolveLambdaLayers — literal layer ARNs resolve in every partition 
     const { stack, props } = makeStackWithLayerArn(
       'arn:aws-cn:lambda:us-east-1:123456789012:layer:my-layer:1'
     );
-    expect(() => resolveLambdaLayers(stack, 'Fn', props)).toThrow(/cannot resolve locally/);
+    // The message must not send a China/GovCloud user back to the shape
+    // they already typed. Before the derived compare existed the only way
+    // to fail was a malformed ARN, so `arn:aws:lambda:...` was a fine
+    // thing to suggest; now a WELL-FORMED ARN can be rejected for the
+    // mismatch, and the remedy has to name the agreement requirement.
+    expect(() => resolveLambdaLayers(stack, 'Fn', props)).toThrow(
+      /arn:<partition>:lambda:.*partition agrees with its region/s
+    );
   });
 
   it('still throws for a literal string that is not a layer ARN at all', () => {
     const { stack, props } = makeStackWithLayerArn('not-an-arn');
     expect(() => resolveLambdaLayers(stack, 'Fn', props)).toThrow(/cannot resolve locally/);
+    // Distinguishable from the mismatch case above: this one quotes the
+    // offending literal back, which the reviewer flagged as untestable
+    // while both cases asserted only the shared prefix.
+    expect(() => resolveLambdaLayers(stack, 'Fn', props)).toThrow(/'not-an-arn'/);
   });
 });
 

--- a/tests/unit/local/partition-table-unification.test.ts
+++ b/tests/unit/local/partition-table-unification.test.ts
@@ -3,7 +3,9 @@ import {
   PARTITION_TABLE,
   derivePartitionAndUrlSuffix,
   derivePseudoParametersFromRegion,
+  tryResolveImageFnJoin,
 } from '../../../src/local/intrinsic-image.js';
+import type { TemplateResource } from '../../../src/types/resource.js';
 import * as ecsTaskResolver from '../../../src/local/ecs-task-resolver.js';
 
 /**
@@ -164,5 +166,104 @@ describe('derivePseudoParametersFromRegion — case asymmetry is deliberate', ()
       partition: 'aws-iso-f',
       urlSuffix: 'csp.hci.ic.gov',
     });
+  });
+});
+
+/**
+ * The end-to-end shape of the defect, composed rather than asserted a
+ * function at a time. go-to-k/cdkd#1821 describes the SYMPTOM as an ECR
+ * host that does not exist: with the short table, an `eusc-` /
+ * `eu-isoe-` / `us-isof-` region produced
+ * `<acct>.dkr.ecr.<region>.amazonaws.com`. Every other
+ * `tryResolveImageFnJoin` case in this repo hardcodes
+ * `urlSuffix: 'amazonaws.com'`, so none of them could ever have caught
+ * it -- the suffix never came from the table.
+ */
+/**
+ * Guard-the-guard for every assertion in this file that maps or filters
+ * `PARTITION_TABLE` and expects `[]`. All of them are satisfiable by an
+ * EMPTY table, so the table's own non-emptiness is what makes them mean
+ * anything. Asserting the exact row count rather than `> 0` so a
+ * silently-dropped row fails here and names itself, instead of leaving
+ * every downstream `toEqual([])` to pass on a shorter list.
+ */
+describe('PARTITION_TABLE is non-empty (the floor under every [] assertion here)', () => {
+  it('carries exactly the seven non-commercial partitions', () => {
+    expect(PARTITION_TABLE.length).toBe(7);
+    expect([...new Set(PARTITION_TABLE.map((r) => r.partition))].sort()).toEqual([
+      'aws-cn',
+      'aws-eusc',
+      'aws-iso',
+      'aws-iso-b',
+      'aws-iso-e',
+      'aws-iso-f',
+      'aws-us-gov',
+    ]);
+    // Commercial is the FALLBACK, deliberately not a row.
+    expect(PARTITION_TABLE.map((r) => r.partition)).not.toContain('aws');
+  });
+});
+
+describe('region -> pseudo parameters -> ECR image URI (issue #575, go-to-k/cdkd#1821)', () => {
+  const repoResources: Record<string, TemplateResource> = {
+    Repo1: { Type: 'AWS::ECR::Repository', Properties: {} },
+  };
+
+  function canonicalFromEcrJoin(repoLogicalId: string, tagOrDigest: string): unknown {
+    return {
+      'Fn::Join': [
+        '',
+        [
+          { 'Fn::Select': [4, { 'Fn::Split': [':', { 'Fn::GetAtt': [repoLogicalId, 'Arn'] }] }] },
+          '.dkr.ecr.',
+          { 'Fn::Select': [3, { 'Fn::Split': [':', { 'Fn::GetAtt': [repoLogicalId, 'Arn'] }] }] },
+          '.',
+          { Ref: 'AWS::URLSuffix' },
+          '/',
+          { Ref: repoLogicalId },
+          `:${tagOrDigest}`,
+        ],
+      ],
+    };
+  }
+
+  it.each([
+    ['us-isof-south-1', 'csp.hci.ic.gov'],
+    ['eu-isoe-west-1', 'cloud.adc-e.uk'],
+    ['eusc-de-east-1', 'amazonaws.eu'],
+    ['cn-north-1', 'amazonaws.com.cn'],
+    ['us-east-1', 'amazonaws.com'],
+  ])('builds the %s ECR host from the derived suffix (%s)', (region, expectedSuffix) => {
+    const pseudoParameters = derivePseudoParametersFromRegion(region);
+    expect(pseudoParameters, 'the region must resolve at all').toBeDefined();
+
+    const result = tryResolveImageFnJoin(canonicalFromEcrJoin('Repo1', 'latest'), repoResources, {
+      pseudoParameters,
+      stateResources: {
+        Repo1: {
+          physicalId: 'my-repo-name',
+          resourceType: 'AWS::ECR::Repository',
+          properties: {},
+          attributes: {
+            Arn: `arn:${pseudoParameters!.partition}:ecr:${region}:111111111111:repository/my-repo-name`,
+          },
+          dependencies: [],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      kind: 'resolved',
+      uri: `111111111111.dkr.ecr.${region}.${expectedSuffix}/my-repo-name:latest`,
+    });
+  });
+
+  it('would have produced a non-existent host before the table was completed', () => {
+    // Guard-the-guard on the cases above: assert the three new rows do
+    // NOT answer the commercial suffix, so a regression that reverted the
+    // table would fail here even if someone loosened the expectations.
+    for (const region of ['us-isof-south-1', 'eu-isoe-west-1', 'eusc-de-east-1']) {
+      expect(derivePseudoParametersFromRegion(region)!.urlSuffix).not.toBe('amazonaws.com');
+    }
   });
 });

--- a/tests/unit/local/partition-table-unification.test.ts
+++ b/tests/unit/local/partition-table-unification.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  PARTITION_TABLE,
+  derivePartitionAndUrlSuffix,
+  derivePseudoParametersFromRegion,
+} from '../../../src/local/intrinsic-image.js';
+import * as ecsTaskResolver from '../../../src/local/ecs-task-resolver.js';
+
+/**
+ * Issue #575 / go-to-k/cdkd#1821. cdk-local carried TWO independent
+ * region -> partition tables: the one behind `derivePartitionAndUrlSuffix`
+ * (completed to all eight partitions earlier on this branch) and a second
+ * if/else chain inside `derivePseudoParametersFromRegion`, which knew four
+ * and matched case-sensitively. The second one feeds `${AWS::Partition}` /
+ * `${AWS::URLSuffix}` substitution and the `Fn::Join` ECR `Code.ImageUri`
+ * reconstruction, so in `us-isof-` / `eu-isoe-` / `eusc-` regions it
+ * synthesized `<acct>.dkr.ecr.<region>.amazonaws.com` — a host that does
+ * not exist — and substituted `aws` into every ARN the resolver built.
+ * Quiet, because the value is structurally valid.
+ *
+ * The fix is ONE table. The fence that makes a future divergence
+ * IMPOSSIBLE rather than merely unlikely is the agreement suite below,
+ * and it is driven off the exported `PARTITION_TABLE` — a list re-typed
+ * here could not see a future row, which is exactly the vacuity that bit
+ * commit 73765f7 on this branch.
+ */
+
+/** Uppercase a region the way a user typing `--region CN-NORTH-1` would. */
+const shout = (region: string): string => region.toUpperCase();
+
+describe('one partition authority (issue #575, go-to-k/cdkd#1821)', () => {
+  it('ecs-task-resolver re-exports the SAME symbols, not a second copy', () => {
+    // Identity, not deep equality: a re-introduced private table would be
+    // deep-equal on the day it is written and drift later, which is the
+    // whole history of this bug. `toBe` fails the day the copy appears.
+    expect(ecsTaskResolver.PARTITION_TABLE).toBe(PARTITION_TABLE);
+    expect(ecsTaskResolver.derivePartitionAndUrlSuffix).toBe(derivePartitionAndUrlSuffix);
+  });
+
+  it('both entry points agree for every row of the REAL table', () => {
+    // Probe regions are GENERATED from the table, so a future row is
+    // covered the moment it is added -- no test edit required.
+    const probes = [
+      ...PARTITION_TABLE.flatMap((row) => [`${row.regionPrefix}east-1`, `${row.regionPrefix}west-2`]),
+      // Commercial fallback: not a table row, so it has to be listed.
+      'us-east-1',
+      'eu-west-2',
+      'ap-northeast-1',
+      'xy-somewhere-9',
+    ];
+    const disagreements = probes
+      .map((region) => ({
+        region,
+        viaTable: derivePartitionAndUrlSuffix(region),
+        viaPseudo: derivePseudoParametersFromRegion(region),
+      }))
+      .filter(
+        ({ viaTable, viaPseudo }) =>
+          viaPseudo?.partition !== viaTable.partition || viaPseudo?.urlSuffix !== viaTable.urlSuffix
+      );
+    expect(disagreements).toEqual([]);
+    // Guard the guard: a filter over an empty probe list is vacuously green.
+    expect(probes.length).toBe(PARTITION_TABLE.length * 2 + 4);
+  });
+
+  it('both entry points agree for every row when the region is UPPER-CASE', () => {
+    const disagreements = PARTITION_TABLE.map((row) => shout(`${row.regionPrefix}east-1`))
+      .map((region) => ({
+        region,
+        viaTable: derivePartitionAndUrlSuffix(region),
+        viaPseudo: derivePseudoParametersFromRegion(region),
+      }))
+      .filter(
+        ({ viaTable, viaPseudo }) =>
+          viaPseudo?.partition !== viaTable.partition || viaPseudo?.urlSuffix !== viaTable.urlSuffix
+      );
+    expect(disagreements).toEqual([]);
+  });
+});
+
+describe('derivePseudoParametersFromRegion — all eight partitions', () => {
+  const canonical: Array<{ region: string; partition: string; urlSuffix: string }> = [
+    { region: 'us-east-1', partition: 'aws', urlSuffix: 'amazonaws.com' },
+    { region: 'ap-northeast-1', partition: 'aws', urlSuffix: 'amazonaws.com' },
+    { region: 'cn-north-1', partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' },
+    { region: 'us-gov-west-1', partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' },
+    { region: 'us-iso-east-1', partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' },
+    { region: 'us-isob-east-1', partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' },
+    { region: 'us-isof-south-1', partition: 'aws-iso-f', urlSuffix: 'csp.hci.ic.gov' },
+    { region: 'eu-isoe-west-1', partition: 'aws-iso-e', urlSuffix: 'cloud.adc-e.uk' },
+    { region: 'eusc-de-east-1', partition: 'aws-eusc', urlSuffix: 'amazonaws.eu' },
+  ];
+
+  for (const { region, partition, urlSuffix } of canonical) {
+    it(`resolves ${region} to ${partition} / ${urlSuffix}`, () => {
+      expect(derivePseudoParametersFromRegion(region)).toEqual({ region, partition, urlSuffix });
+    });
+  }
+
+  it('covers all eight partitions', () => {
+    expect(new Set(canonical.map((r) => r.partition)).size).toBe(8);
+  });
+
+  it('exercises every row of the REAL table, so a future row forces a case here', () => {
+    // The canonical list above is hand-written on purpose (a generated
+    // region would assert the implementation against itself), so this
+    // pairs it with the real table: a row nothing here covers is named.
+    const uncovered = PARTITION_TABLE.filter(
+      (row) => !canonical.some((c) => c.region.startsWith(row.regionPrefix))
+    ).map((row) => row.regionPrefix);
+    expect(uncovered).toEqual([]);
+  });
+
+  it('falls back to the commercial partition for an unknown region', () => {
+    expect(derivePseudoParametersFromRegion('xy-somewhere-9')).toEqual({
+      region: 'xy-somewhere-9',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('returns undefined for undefined / empty region', () => {
+    expect(derivePseudoParametersFromRegion(undefined)).toBeUndefined();
+    expect(derivePseudoParametersFromRegion('')).toBeUndefined();
+  });
+
+  it('passes accountId through when supplied, and omits the field otherwise', () => {
+    expect(derivePseudoParametersFromRegion('eusc-de-east-1', '123456789012')).toEqual({
+      accountId: '123456789012',
+      region: 'eusc-de-east-1',
+      partition: 'aws-eusc',
+      urlSuffix: 'amazonaws.eu',
+    });
+    expect(derivePseudoParametersFromRegion('eusc-de-east-1')).not.toHaveProperty('accountId');
+  });
+});
+
+describe('derivePseudoParametersFromRegion — case asymmetry is deliberate', () => {
+  /**
+   * Matching is case-INSENSITIVE (delegation lower-cases), the returned
+   * `region` is VERBATIM. Both halves are pinned, because the tempting
+   * "tidy-up" is to lower-case the returned value too -- and that would
+   * change what `${AWS::Region}` substitutes into templates, a separate
+   * behaviour change tracked in go-to-k/cdkd#1831.
+   */
+  it('resolves the right partition from an upper-case region', () => {
+    expect(derivePseudoParametersFromRegion('CN-NORTH-1')).toEqual({
+      region: 'CN-NORTH-1',
+      partition: 'aws-cn',
+      urlSuffix: 'amazonaws.com.cn',
+    });
+  });
+
+  it('returns the region byte-identical to the input for every row of the REAL table', () => {
+    const mangled = PARTITION_TABLE.map((row) => shout(`${row.regionPrefix}east-1`))
+      .map((region) => ({ region, returned: derivePseudoParametersFromRegion(region)?.region }))
+      .filter(({ region, returned }) => returned !== region);
+    expect(mangled).toEqual([]);
+  });
+
+  it('a mixed-case region keeps its casing while still resolving non-commercially', () => {
+    expect(derivePseudoParametersFromRegion('Us-IsoF-South-1')).toEqual({
+      region: 'Us-IsoF-South-1',
+      partition: 'aws-iso-f',
+      urlSuffix: 'csp.hci.ic.gov',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl invoke` / `cdkl start-api` failed outright on a function whose
`Properties.Layers` carries a literal layer-version ARN, in five of the eight AWS
partitions. `parseLayerVersionArn` enumerated three (`aws` / `aws-cn` / `aws-us-gov`)
and `resolveLambdaLayers` hard-throws on a parse miss. A second, independent defect in
the same pattern: the region group `[a-z]{2}-(?:[a-z]+-){1,2}\d+` rejects the European
Sovereign Cloud's `eusc-de-east-1` on shape, so fixing the partition list alone would
not have been enough.

Fixing it surfaced three further defects on the same root cause, each found by a
different means and each folded in here rather than deferred:

| # | Defect | Found by |
|---|---|---|
| 1 | The fix stopped one function short of the wire — `fetchLayerContentUrl` rebuilt the version-less ARN with a hardcoded `arn:aws:`, so a now-parseable `aws-iso` ARN reached an `aws-iso` endpoint partition-mismatched | code review |
| 2 | A **second partition table** with the same four-of-eight gap, `derivePseudoParametersFromRegion` — wider blast radius than the layer path | resolving the fix against the sibling repo's backlog |
| 3 | The error message told a China / GovCloud user to use `arn:aws:lambda:...`, the exact shape now rejected for the mismatch | code review |

## What changed

**One table, not two.** `PARTITION_TABLE` + `derivePartitionAndUrlSuffix` now live in
`intrinsic-image.ts`, and `derivePseudoParametersFromRegion` delegates to them. The
import graph picked the home rather than taste: `intrinsic-image.ts`'s transitive
value-import closure is itself (both its imports are `import type`, erased), and
`ecs-task-resolver.ts` already imported from it, so the reverse direction would have
been a cycle. `ecs-task-resolver.ts` re-exports, leaving its four importers untouched;
`lambda-resolver.ts` now takes the symbol from the module it already imported
`derivePseudoParametersFromRegion` from, which also removes a `lambda -> ecs` edge.

That second table is the one that mattered most. Six call sites reach it
(`local-start-api.ts`, `local-invoke-agentcore.ts` x3, `lambda-resolver.ts`,
`agentcore-resolver.ts`) and it feeds `${AWS::Partition}` / `${AWS::URLSuffix}`
substitution plus the `Fn::Join` ECR `Code.ImageUri` reconstruction — so in three
partitions it synthesized `<acct>.dkr.ecr.<region>.amazonaws.com`, a host that does not
exist, and substituted `aws` into every ARN the resolver built. Quiet, because the
value is structurally valid and nothing downstream rejects it.

**Derive, do not enumerate.** `parseLayerVersionArn` keeps the region SHAPE-based
(`[a-z]{2,}(?:-[a-z]+)+-\d+`, not a charset, because the commercial fallback would
otherwise let `arn:aws:lambda:garbage:...` parse) and requires the derived partition to
equal the ARN's own. That also rejects the self-inconsistent
`arn:aws-cn:lambda:us-east-1:...`, which used to parse — something no alternation can do.

**Scope line.** `derivePseudoParametersFromRegion` still returns `region` VERBATIM.
Delegating gives lower-cased MATCHING for free, so `CN-NORTH-1` now resolves `aws-cn`,
but lower-casing the RETURNED field would change what `${AWS::Region}` substitutes —
a separate behavior change, tracked as https://github.com/go-to-k/cdkd/issues/1831. The asymmetry is pinned by
three cases so it cannot drift in either direction.

## Behavior change

`derivePseudoParametersFromRegion` and `derivePartitionAndUrlSuffix` now answer a
NON-COMMERCIAL partition for `us-isof-` / `eu-isoe-` / `eusc-` regions, and resolve
correctly for an upper-cased region, where both previously answered `aws` /
`amazonaws.com`. The former is re-exported from `src/internal.ts`, so this is visible on
the host surface: any host code that compensated for the old commercial answer should be
re-checked. Reported on the existing cdkd tracking issue rather than as a new one —
https://github.com/go-to-k/cdkd/issues/1821 already measured this exact divergence and names this remedy as its
preferred direction.

## Test plan

This is a CLASSIFIER, so hand-picked cases cannot fence it. The primary fence is
**differential**: 59,521 generated inputs through both the pre-fix implementation and
the current one, every disagreement required to fall in an enumerated intended class —
judged by an independent oracle over the RETURNED VALUE, never by which input produced
it, so a total-regression mutant cannot land in the intended-repair bucket — with a
floor per class so a shrinking pool cannot pass as "no regressions".

The fence that prevents a REPEAT is the **agreement** one: both entry points must answer
identically for every row of the exported `PARTITION_TABLE`, driven off the real table
rather than a list retyped in the test. A retyped list cannot see a future row, which is
precisely how this divergence survived in the first place.

Plus: one case per partition through the real `resolveLambdaLayers` caller; the
end-to-end composition region -> pseudo parameters -> ECR host, asserting
`...dkr.ecr.us-isof-south-1.csp.hci.ic.gov/...` (no prior test could have caught the
symptom — every existing `tryResolveImageFnJoin` case hardcodes `amazonaws.com`, so the
suffix never came from the table); and a non-emptiness floor under every `[]`-shaped
assertion over the table.

**Mutation probes** — every one with the edit confirmed landed by `grep -c` before the
result was read: dropping a table row, reverting either regex bound, dropping the
consistency check, always-`undefined`, accept-everything, dropping the lower-casing,
breaking the delegation, re-introducing a deep-equal second table, lower-casing the
returned region, neutering the version guard, and reverting the error message. Each reds
the assertion that exists for it.

**Live test** — a real `cdkl invoke` against a synthesized app whose function carries
`arn:aws-iso:lambda:us-iso-east-1:111122223333:layer:ProbeLayer:4`:

```
BEFORE (origin/main build):
  ERROR: LocalInvokeResolutionError: ... cannot resolve locally ...

AFTER (this branch):
  ERROR: LayerMaterializationError: ... GetLayerVersion failed in region us-iso-east-1:
  getaddrinfo ENOTFOUND lambda.us-iso-east-1.c2s.ic.gov.
```

The endpoint host is the point: `c2s.ic.gov` is the `aws-iso` suffix from the completed
table, so the fix reaches SDK endpoint resolution rather than merely the parse. ENOTFOUND
is expected — that partition is unreachable from a commercial network.

`vp run verify` green (226 files / 3648 tests); `/run-integ local-invoke-layers` and
`local-invoke-container` green with 0 orphan containers / networks. The repo-wide
`no-control-bytes` check a peer PR merged mid-lane was re-run over this diff: green.

## Remaining work

Reviewed 3-axis (906 LOC / 8 files, up-biased by `src/local/lambda-resolver.ts` on the
security surface). Spec review clean on all seven decisions. Every code- and test-review
finding above `nit` is fixed in this PR — the version-guard gap, the misleading error
message, the two indistinguishable throw cases, the missing end-to-end case, the
empty-table floor, and the unfenced `VersionNumber`.

**Won't-do** — moving the table to `src/utils/`. Why: it churns four existing importers
for no behaviour change. Recorded here.

Closes #575
