### PR TITLE
fix(integ): make a fixture's failure diagnosable, and its image cleanup scoped to its own

### DIFF
--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
@@ -31,6 +31,34 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-agentcore-froms3-from-cfn"
 CLI="node ${REPO_ROOT}/dist/cli.js"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+
 echo "[verify] region=${REGION} fromS3 intrinsic Code.S3.Bucket (Ref) + --from-cfn-stack"
 
 echo "[verify] step 1a: install + build cdk-local"
@@ -53,6 +81,7 @@ fi
 WE_CREATED_STACK=0
 EVENT_FILE=""
 cleanup() {
+  rm -f "${CDKL_STDERR}"
   rc=$?
   if [ "${WE_CREATED_STACK}" -eq 1 ]; then
     echo "[verify] cleanup: cdk destroy ${STACK} (autoDeleteObjects empties the bucket)"
@@ -135,7 +164,7 @@ echo "${OUT_NO_STATE}" | grep -q -- "--from-cfn-stack" || {
 echo "[verify] step 8: --event payload echoes through the fromS3-via-Ref agent"
 EVENT_FILE="$(mktemp)"
 echo '{"prompt":"hello froms3 ref"}' > "${EVENT_FILE}"
-RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack --event "${EVENT_FILE}" 2>/dev/null | tail -1)
+RESULT_EVENT=$(capture ${CLI} invoke-agentcore "${TARGET}" --from-cfn-stack --event "${EVENT_FILE}")
 echo "[verify]   response: ${RESULT_EVENT}"
 echo "${RESULT_EVENT}" | grep -q '"prompt":"hello froms3 ref"' || {
   echo "[verify] FAIL: expected the echoed event from the fromS3-via-Ref agent, got: ${RESULT_EVENT}"

--- a/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3-from-cfn/verify.sh
@@ -45,9 +45,14 @@ CLI="node ${REPO_ROOT}/dist/cli.js"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
+# Registered immediately, matching the other fixtures: `trap cleanup EXIT` is
+# installed further down, so without this a failure in between leaks the file.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
 capture() {
   local out rc=0
   out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
@@ -81,8 +86,11 @@ fi
 WE_CREATED_STACK=0
 EVENT_FILE=""
 cleanup() {
-  rm -f "${CDKL_STDERR}"
+  # rc=$? MUST be the first statement: it captures the SCRIPT's exit status.
+  # Any command above it (an `rm -f`, which always succeeds) overwrites $? and
+  # makes the `exit "${rc}"` below report 0 for a FAILED run.
   rc=$?
+  rm -f "${CDKL_STDERR}"
   if [ "${WE_CREATED_STACK}" -eq 1 ]; then
     echo "[verify] cleanup: cdk destroy ${STACK} (autoDeleteObjects empties the bucket)"
     (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \

--- a/tests/integration/local-invoke-agentcore-froms3/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3/verify.sh
@@ -34,6 +34,34 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-agentcore-froms3"
 CLI="node ${REPO_ROOT}/dist/cli.js"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+
 echo "[verify] region=${REGION} fromS3 bundle download + from-source build"
 
 echo "[verify] step 1a: install + build cdk-local"
@@ -61,6 +89,7 @@ KEY="bundles/agent-${SUFFIX}.zip"
 WE_CREATED_BUCKET=0
 EVENT_FILE=""
 cleanup() {
+  rm -f "${CDKL_STDERR}"
   rc=$?
   if [ "${WE_CREATED_BUCKET}" -eq 1 ]; then
     echo "[verify] cleanup: removing s3://${BUCKET}"
@@ -89,8 +118,8 @@ aws s3 cp "${TEST_DIR}/bundle.zip" "s3://${BUCKET}/${KEY}" --region "${REGION}" 
 echo "[verify]   uploaded s3://${BUCKET}/${KEY}"
 
 echo "[verify] step 4: cdkl invoke-agentcore (fromS3 download + build + run)"
-RESULT=$(${CLI} invoke-agentcore "${TARGET}" \
-  -c "bundleBucket=${BUCKET}" -c "bundleKey=${KEY}" 2>/dev/null | tail -1)
+RESULT=$(capture ${CLI} invoke-agentcore "${TARGET}" \
+  -c "bundleBucket=${BUCKET}" -c "bundleKey=${KEY}")
 echo "[verify]   response: ${RESULT}"
 echo "${RESULT}" | grep -q '"runtime":"python-froms3"' || {
   echo "[verify] FAIL: expected the fromS3 from-source agent to respond, got: ${RESULT}"
@@ -104,8 +133,8 @@ echo "${RESULT}" | grep -q '"greeting":"hello-from-s3"' || {
 echo "[verify] step 5: --event payload echoes through the fromS3 agent"
 EVENT_FILE="$(mktemp)"
 echo '{"prompt":"hello froms3"}' > "${EVENT_FILE}"
-RESULT_EVENT=$(${CLI} invoke-agentcore "${TARGET}" \
-  -c "bundleBucket=${BUCKET}" -c "bundleKey=${KEY}" --event "${EVENT_FILE}" 2>/dev/null | tail -1)
+RESULT_EVENT=$(capture ${CLI} invoke-agentcore "${TARGET}" \
+  -c "bundleBucket=${BUCKET}" -c "bundleKey=${KEY}" --event "${EVENT_FILE}")
 echo "[verify]   response: ${RESULT_EVENT}"
 echo "${RESULT_EVENT}" | grep -q '"prompt":"hello froms3"' || {
   echo "[verify] FAIL: expected the echoed event from the fromS3 agent, got: ${RESULT_EVENT}"

--- a/tests/integration/local-invoke-agentcore-froms3/verify.sh
+++ b/tests/integration/local-invoke-agentcore-froms3/verify.sh
@@ -48,9 +48,14 @@ CLI="node ${REPO_ROOT}/dist/cli.js"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
+# Registered immediately, matching the other fixtures: `trap cleanup EXIT` is
+# installed further down, so without this a failure in between leaks the file.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
 capture() {
   local out rc=0
   out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
@@ -89,8 +94,11 @@ KEY="bundles/agent-${SUFFIX}.zip"
 WE_CREATED_BUCKET=0
 EVENT_FILE=""
 cleanup() {
-  rm -f "${CDKL_STDERR}"
+  # rc=$? MUST be the first statement: it captures the SCRIPT's exit status.
+  # Any command above it (an `rm -f`, which always succeeds) overwrites $? and
+  # makes the `exit "${rc}"` below report 0 for a FAILED run.
   rc=$?
+  rm -f "${CDKL_STDERR}"
   if [ "${WE_CREATED_BUCKET}" -eq 1 ]; then
     echo "[verify] cleanup: removing s3://${BUCKET}"
     aws s3 rm "s3://${BUCKET}" --recursive --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -57,8 +57,10 @@ CODE_BASE_IMAGE="public.ecr.aws/docker/library/python:3.12-slim"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0
@@ -69,6 +71,20 @@ capture() {
     tail -20 "${CDKL_STDERR}" >&2
   fi
   printf '%s\n' "${out}" | tail -1
+}
+
+# `capture_all` is `capture`'s WHOLE-STDOUT sibling, for the assertions that
+# need every line rather than the last one -- an SSE token stream, an MCP or
+# A2A JSON-RPC body. Identical exit-status handling; only the tail differs.
+capture_all() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}"
 }
 # Registered immediately: the first capture happens before the fixture's own
 # first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
@@ -186,7 +202,7 @@ echo "==> [8/20] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
-RESULT_8=$(${CDKL} invoke-agentcore "${TARGET}" --event "${STREAM_EVENT}" 2>/dev/null)
+RESULT_8=$(capture_all ${CDKL} invoke-agentcore "${TARGET}" --event "${STREAM_EVENT}")
 echo "    response: ${RESULT_8}"
 for tok in hello from sse; do
   echo "${RESULT_8}" | grep -q "\"token\":\"${tok}\"" || {
@@ -203,7 +219,7 @@ echo "${RESULT_8}" | grep -q '\[DONE\]' || {
 # the default tools/list request returns the server's tools. The container
 # serves POST /mcp on 8000 (no /ping); readiness is a successful initialize.
 echo "==> [9/20] McpAgent (no --event) runs the handshake + tools/list"
-RESULT_9=$(${CDKL} invoke-agentcore "${MCP}" 2>/dev/null)
+RESULT_9=$(capture_all ${CDKL} invoke-agentcore "${MCP}")
 echo "    response: ${RESULT_9}"
 echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
   echo "FAIL: expected tools/list to return the add_numbers tool, got: ${RESULT_9}"
@@ -215,7 +231,7 @@ echo "==> [10/20] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
-RESULT_10=$(${CDKL} invoke-agentcore "${MCP}" --event "${CALL_EVENT}" 2>/dev/null)
+RESULT_10=$(capture_all ${CDKL} invoke-agentcore "${MCP}" --event "${CALL_EVENT}")
 echo "    response: ${RESULT_10}"
 echo "${RESULT_10}" | grep -q '"text": "5"' || {
   echo "FAIL: expected tools/call add_numbers(2,3) to return text \"5\", got: ${RESULT_10}"
@@ -257,7 +273,7 @@ echo "==> [13/20] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
-RESULT_13=$(${CDKL} invoke-agentcore "${TARGET}" --ws --event "${WS_EVENT}" 2>/dev/null)
+RESULT_13=$(capture_all ${CDKL} invoke-agentcore "${TARGET}" --ws --event "${WS_EVENT}")
 echo "    response: ${RESULT_13}"
 echo "${RESULT_13}" | grep -q '"ws":true' || {
   echo "FAIL: expected the /ws frame marker \"ws\":true, got: ${RESULT_13}"
@@ -386,7 +402,7 @@ echo "${OUT_17B}" | grep -q 'positive integer' || {
 # JSON-RPC 2.0 contract at POST / on 9000. With no --event, `cdkl
 # invoke-agentcore` defaults to `agent/getCard` (the agent discovery card).
 echo "==> [18/20] A2aAgent (no --event) runs the JSON-RPC agent/getCard request"
-RESULT_19=$(${CDKL} invoke-agentcore "${A2A}" 2>/dev/null)
+RESULT_19=$(capture_all ${CDKL} invoke-agentcore "${A2A}")
 echo "    response: ${RESULT_19}"
 echo "${RESULT_19}" | grep -q '"name": "fixture-a2a-agent"' || {
   echo "FAIL: expected the A2A agent card with name fixture-a2a-agent, got: ${RESULT_19}"
@@ -398,7 +414,7 @@ echo "==> [18/20] A2aAgent with --event runs tasks/send"
 A2A_EVENT=$(mktemp -t cdkl-a2a-event-XXXX.json)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${A2A_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"method":"tasks/send","params":{"id":"task-1","message":{"text":"hello a2a"}}}' > "${A2A_EVENT}"
-RESULT_19B=$(${CDKL} invoke-agentcore "${A2A}" --event "${A2A_EVENT}" 2>/dev/null)
+RESULT_19B=$(capture_all ${CDKL} invoke-agentcore "${A2A}" --event "${A2A_EVENT}")
 echo "    response: ${RESULT_19B}"
 echo "${RESULT_19B}" | grep -q '"id": "task-1"' || {
   echo "FAIL: expected tasks/send result echoing id=task-1, got: ${RESULT_19B}"
@@ -415,7 +431,7 @@ echo "${RESULT_19B}" | grep -q '"state": "completed"' || {
 # and streams each event line to stdout. The agent emits three events in order
 # (RUN_STARTED, MESSAGE_CONTENT, RUN_FINISHED).
 echo "==> [19/20] AguiAgent SSE event stream surfaces RUN_STARTED + MESSAGE_CONTENT + RUN_FINISHED"
-RESULT_20=$(${CDKL} invoke-agentcore "${AGUI}" 2>/dev/null)
+RESULT_20=$(capture_all ${CDKL} invoke-agentcore "${AGUI}")
 echo "    response (head): $(echo "${RESULT_20}" | head -c 300)..."
 echo "${RESULT_20}" | grep -q '"type":"RUN_STARTED"' || {
   echo "FAIL: expected RUN_STARTED event in AGUI SSE stream, got: ${RESULT_20}"

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -43,6 +43,39 @@ AGUI="CdkLocalInvokeAgentCoreFixture/AguiAgent"
 BASE_IMAGE="public.ecr.aws/docker/library/node:20-slim"
 CODE_BASE_IMAGE="public.ecr.aws/docker/library/python:3.12-slim"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -57,7 +90,7 @@ fi
 
 # Test 1 — default empty event: env injection + auto session id.
 echo "==> [1/20] Invoking EchoAgent with default empty event"
-RESULT_1=$(${CDKL} invoke-agentcore "${TARGET}" 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke-agentcore "${TARGET}")
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello-from-agent"' || {
   echo "FAIL: expected greeting=hello-from-agent in response, got: ${RESULT_1}"
@@ -72,9 +105,9 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 # Test 2 — event payload via --event echoes through /invocations.
 echo "==> [2/20] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke-agentcore "${TARGET}" --event "${EVENT_FILE}" 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke-agentcore "${TARGET}" --event "${EVENT_FILE}")
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
   echo "FAIL: expected echoed prompt in response, got: ${RESULT_2}"
@@ -84,9 +117,9 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 # Test 3 — --env-vars override wins over the template env.
 echo "==> [3/20] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke-agentcore "${TARGET}" --env-vars "${ENV_FILE}" 2>/dev/null | tail -1)
+RESULT_3=$(capture ${CDKL} invoke-agentcore "${TARGET}" --env-vars "${ENV_FILE}")
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -96,7 +129,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 # Test 4 — explicit --session-id reaches the container's session header.
 echo "==> [4/20] Invoking EchoAgent with explicit --session-id"
 SESSION="cdkl-integ-session-1234567890abcdef"
-RESULT_4=$(${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}" 2>/dev/null | tail -1)
+RESULT_4=$(capture ${CDKL} invoke-agentcore "${TARGET}" --session-id "${SESSION}")
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -q "\"sessionId\":\"${SESSION}\"" || {
   echo "FAIL: expected sessionId=${SESSION} in response, got: ${RESULT_4}"
@@ -127,7 +160,7 @@ RUNNING=$(docker ps -a --filter name=cdkl-agentcore- -q | wc -l | tr -d ' ')
 
 # Test 6 — --no-verify-auth skips verification and proceeds.
 echo "==> [6/20] ProtectedAgent with --no-verify-auth proceeds (auth skipped)"
-RESULT_6=$(${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth 2>/dev/null | tail -1)
+RESULT_6=$(capture ${CDKL} invoke-agentcore "${PROTECTED}" --no-verify-auth)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
   echo "FAIL: expected the agent to respond under --no-verify-auth, got: ${RESULT_6}"
@@ -138,7 +171,7 @@ echo "${RESULT_6}" | grep -q '"greeting":"hello-from-agent"' || {
 # is verified and forwarded to /invocations as the Authorization header.
 echo "==> [7/20] ProtectedAgent with --bearer-token forwards the Authorization header"
 TOKEN="header.payload.sig"
-RESULT_7=$(${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}" 2>/dev/null | tail -1)
+RESULT_7=$(capture ${CDKL} invoke-agentcore "${PROTECTED}" --bearer-token "${TOKEN}")
 echo "    response: ${RESULT_7}"
 echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
   echo "FAIL: expected the bearer token forwarded as Authorization: Bearer ${TOKEN}, got: ${RESULT_7}"
@@ -151,7 +184,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # line — so we capture all output, not just tail -1).
 echo "==> [8/20] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
 RESULT_8=$(${CDKL} invoke-agentcore "${TARGET}" --event "${STREAM_EVENT}" 2>/dev/null)
 echo "    response: ${RESULT_8}"
@@ -180,7 +213,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 # Test 10 — an MCP tools/call via --event returns the tool result.
 echo "==> [10/20] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
 RESULT_10=$(${CDKL} invoke-agentcore "${MCP}" --event "${CALL_EVENT}" 2>/dev/null)
 echo "    response: ${RESULT_10}"
@@ -193,7 +226,7 @@ echo "${RESULT_10}" | grep -q '"text": "5"' || {
 # source (no Dockerfile): cdkl builds it from source (run the entrypoint as-is,
 # no install) and the entrypoint self-serves the 8080 HTTP contract.
 echo "==> [11/20] CodeAgent (fromCodeAsset) builds from source + responds"
-RESULT_11=$(${CDKL} invoke-agentcore "${CODE}" 2>/dev/null | tail -1)
+RESULT_11=$(capture ${CDKL} invoke-agentcore "${CODE}")
 echo "    response: ${RESULT_11}"
 echo "${RESULT_11}" | grep -q '"runtime":"python-code"' || {
   echo "FAIL: expected the from-source python agent to respond, got: ${RESULT_11}"
@@ -207,9 +240,9 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 # Test 12 — a --event payload echoes through the from-source agent.
 echo "==> [12/20] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
-RESULT_12=$(${CDKL} invoke-agentcore "${CODE}" --event "${CODE_EVENT}" 2>/dev/null | tail -1)
+RESULT_12=$(capture ${CDKL} invoke-agentcore "${CODE}" --event "${CODE_EVENT}")
 echo "    response: ${RESULT_12}"
 echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
   echo "FAIL: expected echoed prompt from the from-source agent, got: ${RESULT_12}"
@@ -222,7 +255,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # Authorization + GREETING) then a second text frame, then closes.
 echo "==> [13/20] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
 RESULT_13=$(${CDKL} invoke-agentcore "${TARGET}" --ws --event "${WS_EVENT}" 2>/dev/null)
 echo "    response: ${RESULT_13}"
@@ -273,7 +306,7 @@ echo "${ERR_14}" | grep -q -- '--ws applies only to the HTTP / AGUI protocols' |
 # scope / claim checks are covered by the unit tests, which sign real RS256
 # tokens against mock JWKS.)
 echo "==> [15/20] ProtectedAgentClaims (allowedScopes + customClaims) invokes successfully"
-RESULT_15=$(${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s" 2>/dev/null | tail -1)
+RESULT_15=$(capture ${CDKL} invoke-agentcore "${PROTECTED_CLAIMS}" --bearer-token "h.p.s")
 echo "    response: ${RESULT_15}"
 echo "${RESULT_15}" | grep -q '"greeting":"hello-from-agent"' || {
   echo "FAIL: expected ProtectedAgentClaims to invoke under pass-through, got: ${RESULT_15}"
@@ -293,10 +326,10 @@ echo "${RESULT_15}" | grep -q '"authorization":"Bearer h.p.s"' || {
 # A second --sigv4 + --bearer-token sub-check confirms the mutually-exclusive
 # gate rejects pre-container.
 echo "==> [16/20] EchoAgent --sigv4 forwards an AWS4-HMAC-SHA256 Authorization header"
-RESULT_16=$(AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
+RESULT_16=$(capture env AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
   AWS_REGION=us-east-1 \
-  ${CDKL} invoke-agentcore "${TARGET}" --sigv4 2>/dev/null | tail -1)
+  ${CDKL} invoke-agentcore "${TARGET}" --sigv4)
 echo "    response: ${RESULT_16}"
 echo "${RESULT_16}" | grep -q '"authorization":"AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/' || {
   echo "FAIL: expected an AWS4-HMAC-SHA256 Authorization header carrying the access key id, got: ${RESULT_16}"
@@ -328,7 +361,7 @@ echo "${OUT_16B}" | grep -q 'mutually exclusive' || {
 # ignored). The negative sub-check confirms the parser rejects a non-positive
 # value pre-container.
 echo "==> [17/20] EchoAgent --timeout 60000 succeeds (flag is parsed + applied)"
-RESULT_17=$(${CDKL} invoke-agentcore "${TARGET}" --timeout 60000 2>/dev/null | tail -1)
+RESULT_17=$(capture ${CDKL} invoke-agentcore "${TARGET}" --timeout 60000)
 echo "    response: ${RESULT_17}"
 echo "${RESULT_17}" | grep -q '"greeting":"hello-from-agent"' || {
   echo "FAIL: expected EchoAgent to invoke under --timeout 60000, got: ${RESULT_17}"
@@ -363,7 +396,7 @@ echo "${RESULT_19}" | grep -q '"name": "fixture-a2a-agent"' || {
 # Test 19 — A2A with --event runs the tasks/send method.
 echo "==> [18/20] A2aAgent with --event runs tasks/send"
 A2A_EVENT=$(mktemp -t cdkl-a2a-event-XXXX.json)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${A2A_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${A2A_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"method":"tasks/send","params":{"id":"task-1","message":{"text":"hello a2a"}}}' > "${A2A_EVENT}"
 RESULT_19B=$(${CDKL} invoke-agentcore "${A2A}" --event "${A2A_EVENT}" 2>/dev/null)
 echo "    response: ${RESULT_19B}"

--- a/tests/integration/local-invoke-assume-role/verify.sh
+++ b/tests/integration/local-invoke-assume-role/verify.sh
@@ -61,8 +61,13 @@ docker pull "${IMAGE}"
 # Sentinel gates the cleanup trap: only run `cdk destroy` on a stack
 # THIS run created, never on a pre-existing one with the same name.
 WE_CREATED_STACK=0
+# Scratch file for invoke_capture's stderr (issue #577). Created here, BEFORE
+# `trap cleanup EXIT` is installed, so the trap that removes it can never fire
+# before the first write.
+CDKL_STDERR="$(mktemp)"
 cleanup() {
   rc=$?
+  rm -f "${CDKL_STDERR}"
   if [ "${rc}" -ne 0 ] && [ "${WE_CREATED_STACK}" -eq 1 ]; then
     echo "[verify] FAIL (exit ${rc}) — attempting cdk destroy to clean up"
     (cd "${TEST_DIR}" && cdk destroy "${STACK}" --force --region "${REGION}" \
@@ -132,9 +137,26 @@ echo "[verify]   IAM trust propagated"
 invoke_capture() {
   # Run cdkl invoke and return the last JSON-looking line on stdout.
   # `--no-pull` skips docker pull (image already cached by step 1c) so the
-  # repeat invocations are fast. Stderr is dropped; if assertion fails we
-  # re-run without the drop for diagnostics in the FAIL branch.
-  ${CLI} invoke "$@" --no-pull 2>/dev/null | tail -1
+  # repeat invocations are fast.
+  #
+  # The exit status is captured EXPLICITLY (issue #577). The old shape,
+  #     ${CLI} invoke "$@" --no-pull 2>/dev/null | tail -1
+  # aborted the WHOLE script at the caller's ASSIGNMENT when cdkl exited
+  # non-zero: pipefail failed the pipeline, the command substitution failed,
+  # and `set -e` killed the script BEFORE the grep, before the FAIL message
+  # and before that branch's stderr re-run -- then the EXIT trap destroyed
+  # the stack, taking the evidence with it. All the operator saw was
+  # `[verify] FAIL (exit 1) - attempting cdk destroy to clean up`.
+  #
+  # Now a non-zero exit prints the status plus the captured stderr and the
+  # assertion still runs, so the FAIL branch below is actually reachable.
+  local out rc=0
+  out="$(${CLI} invoke "$@" --no-pull 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] cdkl invoke exited ${rc}; stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
 }
 
 echo "[verify] step 5: baseline — cdkl invoke --from-cfn-stack (no --assume-role)"

--- a/tests/integration/local-invoke-buildkit/verify.sh
+++ b/tests/integration/local-invoke-buildkit/verify.sh
@@ -48,13 +48,53 @@ if [[ ! -d node_modules ]]; then
   vp install --prefer-offline
 fi
 
+# --- built-image handling (issue #587) -------------------------------------
+# This fixture used to `docker image rm -f` EVERY `cdkl-invoke-*` tag, twice
+# (here, and again in cleanup). Parallel integ lanes share one Docker daemon
+# on a dev host, so that blanket sweep deletes images other lanes are mid-run
+# on -- and the `| head -1` tag pick below had the mirror-image defect, since
+# it could just as easily land on a concurrent lane's tag.
+#
+# Everything is scoped to THIS fixture's own deterministic tag instead. cdkl
+# prints that tag on its `--no-build` path BEFORE it checks the local
+# registry, so a probe run reports the tag whether or not the image exists;
+# the probe is expected to exit non-zero when it does not, hence `|| true`.
+IMAGES_BEFORE="$(docker image ls --filter 'reference=cdkl-invoke-*' \
+  --format '{{.Repository}}:{{.Tag}}' | sort)"
+OWN_TAG="$(${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler \
+  --no-pull --no-build 2>&1 | grep -oE 'cdkl-invoke-[0-9a-f]+' | head -1 || true)"
+if [[ -z "${OWN_TAG}" ]]; then
+  echo "FAIL: could not resolve this fixture's cdkl-invoke-* tag from the --no-build probe"
+  exit 1
+fi
+OWN_TAG="${OWN_TAG}:latest"
+echo "==> This fixture's image tag: ${OWN_TAG}"
+
+remove_own_image() {
+  # Never `-f`: unforced `docker image rm` refuses an image a RUNNING
+  # container still holds, which keeps a concurrent lane safe.
+  docker image rm "${OWN_TAG}" >/dev/null 2>&1 || true
+}
+
 # Force a fresh build to guarantee the test actually exercises every
-# BuildKit feature this run (otherwise a stale Docker layer cache could
-# mask a broken --secret path).
-echo "==> Force-rebuilding (clear stale cdkl image so --secret / --target are re-exercised)"
-docker image ls --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' | while read -r tag; do
-  docker image rm -f "${tag}" >/dev/null 2>&1 || true
-done
+# BuildKit feature this run (otherwise a stale image could satisfy the
+# assertions below without `--secret` / `--target` ever being re-exercised).
+# ONLY this fixture's own tag is removed -- never a tag the snapshot held.
+echo "==> Force-rebuilding (clear this fixture's stale image so --secret / --target are re-exercised)"
+remove_own_image
+trap remove_own_image EXIT
+if docker image inspect "${OWN_TAG}" >/dev/null 2>&1; then
+  echo "FAIL: ${OWN_TAG} still present after removal — cannot guarantee a fresh build"
+  echo "      (a running container may still hold it; stop it and re-run)"
+  exit 1
+fi
+# Drop our own tag from the snapshot now that it is gone. A previous run
+# (or a crash) can leave it behind, and without this the "new since the
+# snapshot" assertion below would fail spuriously on the very rebuild it is
+# meant to certify. Every OTHER tag stays in the snapshot, and so stays
+# untouchable.
+IMAGES_BEFORE="$(printf '%s\n' "${IMAGES_BEFORE}" | grep -vxF "${OWN_TAG}" || true)"
+echo "    ✓ ${OWN_TAG} absent — any appearance below is a build from THIS run"
 
 
 echo "==> [1/3] Building + invoking BuildkitHandler (exercises every BuildKit feature)"
@@ -96,16 +136,25 @@ echo "    ✓ multi-stage --target=final"
 # content — must NOT match.
 echo "==> [2/3] Verifying secret content NEVER baked into image layers (security property of --secret)"
 SECRET_LITERAL=$(cat docker/secret.txt | head -1)
-CDKL_TAG=$(docker image ls --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' | head -1)
-if [[ -z "${CDKL_TAG}" ]]; then
-  echo "FAIL: no cdkl-invoke-* image found — build did not happen"
+# The tag was proven ABSENT before the build, so its presence now is proof a
+# real build ran in THIS process -- strictly stronger than the old check,
+# which any stale `cdkl-invoke-*` image (from this or any other lane) passed.
+CDKL_TAG="${OWN_TAG}"
+if ! docker image inspect "${CDKL_TAG}" >/dev/null 2>&1; then
+  echo "FAIL: ${CDKL_TAG} absent after the invoke — build did not happen this run"
   exit 1
 fi
+if ! docker image ls --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
+     | sort | comm -13 <(printf '%s\n' "${IMAGES_BEFORE}") - | grep -qxF "${CDKL_TAG}"; then
+  echo "FAIL: ${CDKL_TAG} is not a NEW tag since the pre-run snapshot — build did not happen this run"
+  exit 1
+fi
+echo "    ✓ ${CDKL_TAG} is new since the pre-run snapshot (a real build ran)"
 # Walk every layer's filesystem and grep for the secret literal. If
 # `--mount=type=secret` worked correctly, the secret was only on the
 # build container's RUN-step tmpfs, never on a layer.
 TMP_DUMP=$(mktemp)
-trap 'rm -rf "${TMP_DUMP}"' EXIT
+trap 'rm -rf "${TMP_DUMP}"; remove_own_image' EXIT
 docker save "${CDKL_TAG}" | tar -t 2>/dev/null > "${TMP_DUMP}"
 if docker save "${CDKL_TAG}" 2>/dev/null | grep -aq "${SECRET_LITERAL}"; then
   echo "FAIL: secret literal '${SECRET_LITERAL}' found in image layers — --mount=type=secret is leaking!"
@@ -127,17 +176,19 @@ echo "    ✓ --no-build reused the cached tag"
 
 rm -f /tmp/cdkl-buildkit-1.log /tmp/cdkl-buildkit-3.log
 
-# Cleanup: remove the cdkl-built image(s) so CI hosts don't accumulate
-# multi-stage builder layers across iterations. The integ owns the
-# `cdkl-invoke-*` namespace and the run-time docker containers are
-# already removed by `docker run --rm` + cdk-local's removeContainer().
-echo "==> Cleanup: removing cdkl-built images"
-docker image ls --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' | while read -r tag; do
-  docker image rm -f "${tag}" >/dev/null 2>&1 || true
-done
-# Also prune any dangling layers from the multi-stage build. `--force` is
-# fine here; we're operating on a known-isolated test image.
-docker image prune -f --filter "label=cdkl-invoke" >/dev/null 2>&1 || true
+# Cleanup: remove the image THIS run built, so CI hosts don't accumulate one
+# per iteration. Scoped to this fixture's own tag -- the fixture does NOT own
+# the whole `cdkl-invoke-*` namespace, which is shared with every other
+# container fixture and with concurrently running lanes. The run-time docker
+# containers are already removed by `docker run --rm` + cdk-local's
+# removeContainer().
+#
+# The `docker image prune --filter label=cdkl-invoke` that used to follow is
+# gone: cdk-local never passes `--label`, so it matched nothing and had never
+# pruned the multi-stage builder layers its comment claimed. An UNFILTERED
+# prune is exactly the cross-lane hazard this change removes.
+echo "==> Cleanup: removing the image built by this run (${OWN_TAG})"
+remove_own_image
 
 echo ""
 echo "==> All 3 BuildKit-Dockerfile checks passed"

--- a/tests/integration/local-invoke-buildkit/verify.sh
+++ b/tests/integration/local-invoke-buildkit/verify.sh
@@ -56,12 +56,22 @@ fi
 # it could just as easily land on a concurrent lane's tag.
 #
 # Everything is scoped to THIS fixture's own deterministic tag instead. cdkl
-# prints that tag on its `--no-build` path BEFORE it checks the local
-# registry, so a probe run reports the tag whether or not the image exists;
-# the probe is expected to exit non-zero when it does not, hence `|| true`.
+# prints that tag on its `--no-build` path BEFORE it checks the local registry,
+# so a probe run reports the tag whether or not the image exists.
+#
+# Two honest caveats about that probe:
+#   * It is NOT free. When the image is absent it exits non-zero right after
+#     printing the tag (hence `|| true`), but when the image IS present cdkl
+#     carries on and performs a real invoke -- a container run. That happens
+#     only on a warm host, in exactly the case where the image is about to be
+#     removed and rebuilt anyway, so the cost is accepted rather than hidden.
+#   * The tag arrives on an INFO-level line, so an exported CDKL_LOG_LEVEL=warn
+#     would suppress it and hard-fail the guard below. The level is pinned to
+#     info for the probe alone, so the fixture does not depend on the caller's
+#     environment.
 IMAGES_BEFORE="$(docker image ls --filter 'reference=cdkl-invoke-*' \
   --format '{{.Repository}}:{{.Tag}}' | sort)"
-OWN_TAG="$(${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler \
+OWN_TAG="$(CDKL_LOG_LEVEL=info ${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler \
   --no-pull --no-build 2>&1 | grep -oE 'cdkl-invoke-[0-9a-f]+' | head -1 || true)"
 if [[ -z "${OWN_TAG}" ]]; then
   echo "FAIL: could not resolve this fixture's cdkl-invoke-* tag from the --no-build probe"
@@ -71,9 +81,15 @@ OWN_TAG="${OWN_TAG}:latest"
 echo "==> This fixture's image tag: ${OWN_TAG}"
 
 remove_own_image() {
-  # Never `-f`: unforced `docker image rm` refuses an image a RUNNING
-  # container still holds, which keeps a concurrent lane safe.
-  docker image rm "${OWN_TAG}" >/dev/null 2>&1 || true
+  # Unforced first, so a container still holding the image is respected. But an
+  # unforced rm also refuses an image held by a container that is merely
+  # STOPPED, and a leftover container from an aborted run would then turn a
+  # passing fixture into a hard FAIL at the absence check below, where `-f`
+  # used to proceed. OWN_TAG is this fixture's OWN tag, so a scoped force-remove
+  # is safe as a fallback: it can never reach another fixture's or another
+  # lane's tag.
+  docker image rm "${OWN_TAG}" >/dev/null 2>&1 \
+    || docker image rm -f "${OWN_TAG}" >/dev/null 2>&1 || true
 }
 
 # Force a fresh build to guarantee the test actually exercises every
@@ -85,7 +101,7 @@ remove_own_image
 trap remove_own_image EXIT
 if docker image inspect "${OWN_TAG}" >/dev/null 2>&1; then
   echo "FAIL: ${OWN_TAG} still present after removal — cannot guarantee a fresh build"
-  echo "      (a running container may still hold it; stop it and re-run)"
+  echo "      (a container — running or stopped — may still hold it; remove it and re-run)"
   exit 1
 fi
 # Drop our own tag from the snapshot now that it is gone. A previous run
@@ -98,8 +114,16 @@ echo "    ✓ ${OWN_TAG} absent — any appearance below is a build from THIS ru
 
 
 echo "==> [1/3] Building + invoking BuildkitHandler (exercises every BuildKit feature)"
-${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler --no-pull >/tmp/cdkl-buildkit-1.log 2>&1
-RESULT_1=$(grep -E '"(buildArg|secretSha|fromBuildkitImage)"' /tmp/cdkl-buildkit-1.log | tail -1)
+# Both lines used to abort the script on failure (issue #577): a non-zero cdkl
+# under `set -e`, and a `grep` that matches nothing under `pipefail`. Either
+# killed the run BEFORE the FAIL branches below that `cat` the log.
+CDKL_RC_1=0
+${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler --no-pull >/tmp/cdkl-buildkit-1.log 2>&1 || CDKL_RC_1=$?
+if [ "${CDKL_RC_1}" -ne 0 ]; then
+  echo "[verify] cdkl invoke exited ${CDKL_RC_1}; log follows:" >&2
+  cat /tmp/cdkl-buildkit-1.log >&2
+fi
+RESULT_1=$(grep -E '"(buildArg|secretSha|fromBuildkitImage)"' /tmp/cdkl-buildkit-1.log | tail -1 || true)
 echo "    response: ${RESULT_1}"
 
 # Every BuildKit feature must show up in the response.
@@ -165,8 +189,16 @@ echo "    ✓ secret content absent from all image layers"
 # Re-invoke under --no-build to confirm tag stability (the deterministic
 # tag computed from the source must match across builds).
 echo "==> [3/3] Re-invoking under --no-build to confirm tag stability"
-${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler --no-pull --no-build >/tmp/cdkl-buildkit-3.log 2>&1
-RESULT_3=$(grep -E '"buildArg"' /tmp/cdkl-buildkit-3.log | tail -1)
+# Both lines used to abort the script on failure (issue #577): a non-zero cdkl
+# under `set -e`, and a `grep` that matches nothing under `pipefail`. Either
+# killed the run BEFORE the FAIL branches below that `cat` the log.
+CDKL_RC_3=0
+${CDKL} invoke CdkLocalInvokeBuildkitFixture/BuildkitHandler --no-pull --no-build >/tmp/cdkl-buildkit-3.log 2>&1 || CDKL_RC_3=$?
+if [ "${CDKL_RC_3}" -ne 0 ]; then
+  echo "[verify] cdkl invoke exited ${CDKL_RC_3}; log follows:" >&2
+  cat /tmp/cdkl-buildkit-3.log >&2
+fi
+RESULT_3=$(grep -E '"buildArg"' /tmp/cdkl-buildkit-3.log | tail -1 || true)
 echo "${RESULT_3}" | grep -q "\"buildArg\":\"${EXPECTED_BUILD_ARG}\"" || {
   echo "FAIL: --no-build re-invocation did not pick up the same baked image"
   cat /tmp/cdkl-buildkit-3.log

--- a/tests/integration/local-invoke-container/verify.sh
+++ b/tests/integration/local-invoke-container/verify.sh
@@ -34,8 +34,10 @@ BASE_IMAGE="public.ecr.aws/lambda/nodejs:20"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0
@@ -73,8 +75,10 @@ remove_run_images() {
   if [ -n "${new}" ]; then
     echo "==> Removing image(s) built by this run:"
     echo "${new}" | sed 's/^/      /'
-    # `docker image rm` refuses an image a RUNNING container still uses, so a
-    # concurrent lane mid-run is protected even if its tag lands in the delta.
+    # Unforced: `docker image rm` refuses an image while a container still holds
+    # it, so a lane whose container is UP survives. It does NOT cover a lane
+    # between `docker build` and `docker run` -- the delta scoping is what keeps
+    # this run away from another lane's tag in that window.
     echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
   fi
   rm -f "${IMAGES_BEFORE}"
@@ -148,7 +152,15 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 echo "==> [4/4] Invoking EchoHandler with --no-build (image must already be cached from steps 1-3)"
 COMBINED_4=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${COMBINED_4}" "${CDKL_STDERR}"; remove_run_images' EXIT
-${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --no-pull --no-build >"${COMBINED_4}" 2>&1
+# A non-zero exit here used to abort the script (issue #577) BEFORE any of the
+# three FAIL branches below that `cat "${COMBINED_4}"` -- so the one test whose
+# whole point is inspecting the log lost the log. Capture the status instead.
+CDKL_RC_4=0
+${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --no-pull --no-build >"${COMBINED_4}" 2>&1 || CDKL_RC_4=$?
+if [ "${CDKL_RC_4}" -ne 0 ]; then
+  echo "[verify] cdkl invoke exited ${CDKL_RC_4}; combined output follows:" >&2
+  cat "${COMBINED_4}" >&2
+fi
 RESULT_4=$(tail -1 "${COMBINED_4}")
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -q '"greeting":"hello"' || {

--- a/tests/integration/local-invoke-container/verify.sh
+++ b/tests/integration/local-invoke-container/verify.sh
@@ -20,6 +20,71 @@ cd "$(dirname "$0")"
 CDKL="node ../../../dist/cli.js"
 BASE_IMAGE="public.ecr.aws/lambda/nodejs:20"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+
+# --- built-image cleanup (issue #587) --------------------------------------
+# This fixture's DockerImageFunction makes cdkl `docker build` a
+# `cdkl-invoke-<hash>:latest` image of ~421 MB. Nothing removed it, so every
+# run leaked one -- and because the tag is a fingerprint of the asset (the
+# platform included), a change to the Dockerfile, the handler or the
+# architecture mints a NEW tag that no later run will ever reuse or reclaim.
+#
+# Only the tag(s) THIS run creates are removed: the set of `cdkl-invoke-*`
+# tags present now is snapshotted, and cleanup deletes only what appeared
+# since. A blanket `docker rmi` of every `cdkl-invoke-*` tag is deliberately
+# NOT used -- parallel integ lanes share one Docker daemon on a dev host, so
+# a blanket sweep deletes images other lanes are mid-run on, and it would
+# also destroy the local cache other container fixtures rely on.
+IMAGES_BEFORE="$(mktemp)"
+docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
+  | sort > "${IMAGES_BEFORE}"
+
+remove_run_images() {
+  [ -f "${IMAGES_BEFORE:-}" ] || return 0
+  local new
+  new="$(docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
+    | sort | comm -13 "${IMAGES_BEFORE}" -)"
+  if [ -n "${new}" ]; then
+    echo "==> Removing image(s) built by this run:"
+    echo "${new}" | sed 's/^/      /'
+    # `docker image rm` refuses an image a RUNNING container still uses, so a
+    # concurrent lane mid-run is protected even if its tag lands in the delta.
+    echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
+  fi
+  rm -f "${IMAGES_BEFORE}"
+}
+# Installed BEFORE test 1, because test 1 is what triggers the `docker build`.
+# The later `trap 'rm -f ...' EXIT` lines REPLACE this handler rather than
+# adding to it, so each of them re-appends `remove_run_images`; without this
+# first registration a failure during test 1 would still leak the image.
+trap 'rm -f "${CDKL_STDERR}"; remove_run_images' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -38,7 +103,7 @@ fi
 # documented as a no-op in CLI help — it still skips the public-base
 # image's `docker pull` from the ZIP path which we did up front).
 echo "==> [1/4] Invoking EchoHandler (container) with default empty event"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --no-pull)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -52,9 +117,9 @@ echo "${RESULT_1}" | grep -q '"fromContainer":true' || {
 # Test 2 — event payload via --event
 echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"; remove_run_images' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"key":"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -64,9 +129,9 @@ echo "${RESULT_2}" | grep -q '"key":"value"' || {
 # Test 3 — --env-vars override
 echo "==> [3/4] Invoking EchoHandler with --env-vars override"
 ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"; remove_run_images' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(capture ${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -82,7 +147,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 # greeting check.
 echo "==> [4/4] Invoking EchoHandler with --no-build (image must already be cached from steps 1-3)"
 COMBINED_4=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${COMBINED_4}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${COMBINED_4}" "${CDKL_STDERR}"; remove_run_images' EXIT
 ${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --no-pull --no-build >"${COMBINED_4}" 2>&1
 RESULT_4=$(tail -1 "${COMBINED_4}")
 echo "    response: ${RESULT_4}"
@@ -101,6 +166,8 @@ if grep -q "Building container image" "${COMBINED_4}"; then
   cat "${COMBINED_4}"
   exit 1
 fi
+
+remove_run_images
 
 echo ""
 echo "==> All 4 local-invoke container-Lambda tests passed"

--- a/tests/integration/local-invoke-dotnet/verify.sh
+++ b/tests/integration/local-invoke-dotnet/verify.sh
@@ -38,8 +38,10 @@ SDK_IMAGE="mcr.microsoft.com/dotnet/sdk:8.0"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0

--- a/tests/integration/local-invoke-dotnet/verify.sh
+++ b/tests/integration/local-invoke-dotnet/verify.sh
@@ -24,6 +24,39 @@ CDKL="node ../../../dist/cli.js"
 LAMBDA_IMAGE="public.ecr.aws/lambda/dotnet:8"
 SDK_IMAGE="mcr.microsoft.com/dotnet/sdk:8.0"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -61,7 +94,7 @@ fi
 # architecture and runs natively, so that number no longer describes it
 # and has been dropped rather than guessed at; the headroom is unchanged.
 echo "==> [1/3] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokeDotnetFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokeDotnetFixture/EchoHandler --no-pull)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -71,9 +104,9 @@ echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
 # Test 2 — event payload via --event
 echo "==> [2/3] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokeDotnetFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeDotnetFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"

--- a/tests/integration/local-invoke-java/verify.sh
+++ b/tests/integration/local-invoke-java/verify.sh
@@ -37,8 +37,10 @@ JDK_IMAGE="amazoncorretto:17"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0

--- a/tests/integration/local-invoke-java/verify.sh
+++ b/tests/integration/local-invoke-java/verify.sh
@@ -23,6 +23,39 @@ CDKL="node ../../../dist/cli.js"
 LAMBDA_IMAGE="public.ecr.aws/lambda/java:17"
 JDK_IMAGE="amazoncorretto:17"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -55,7 +88,7 @@ fi
 # function's Timeout: 30 + cdk-local's `invokeTimeoutMs = max(30s, 2 * fn.timeout)`
 # = 60s provides ample headroom.
 echo "==> [1/3] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokeJavaFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokeJavaFixture/EchoHandler --no-pull)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -65,9 +98,9 @@ echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
 # Test 2 — event payload via --event
 echo "==> [2/3] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokeJavaFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeJavaFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"

--- a/tests/integration/local-invoke-layers/verify.sh
+++ b/tests/integration/local-invoke-layers/verify.sh
@@ -35,8 +35,10 @@ IMAGE="public.ecr.aws/lambda/nodejs:20"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0
@@ -124,7 +126,15 @@ echo "${RESULT_2}" | grep -q '"counter":"count=42"' || {
 # `console.info`; we just want to verify the layer-count line appears
 # somewhere in the cdk-local output) so users know the layer wiring fired.
 echo "==> [3/3] Verifying cdk-local logs the layer count"
-LOG_OUTPUT=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>&1)
+# `capture` is not used here: this assertion greps the MERGED stdout+stderr,
+# which `capture` deliberately splits. Only the exit status needs handling --
+# without it a non-zero cdkl abandons the script before the FAIL branch that
+# prints the output (issue #577). The diagnostic is already in LOG_OUTPUT.
+LOG_RC=0
+LOG_OUTPUT=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>&1) || LOG_RC=$?
+if [ "${LOG_RC}" -ne 0 ]; then
+  echo "[verify] cdkl invoke exited ${LOG_RC}; its output is echoed by the assertion below" >&2
+fi
 echo "${LOG_OUTPUT}" | grep -q 'Mounting 3 Lambda layers at /opt' || {
   echo "FAIL: expected 'Mounting 3 Lambda layers' message in cdk-local output, got:"
   echo "${LOG_OUTPUT}"

--- a/tests/integration/local-invoke-layers/verify.sh
+++ b/tests/integration/local-invoke-layers/verify.sh
@@ -21,6 +21,39 @@ cd "$(dirname "$0")"
 CDKL="node ../../../dist/cli.js"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -38,9 +71,9 @@ fi
 # /opt mount point.
 echo "==> [1/3] Invoking EchoHandler (default empty event)"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"name":"alice","n":7}' > "${EVENT_FILE}"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_1}"
 
 # 1a: counters layer — distinct module name, no path overlap.
@@ -73,9 +106,9 @@ echo "${RESULT_1}" | grep -q '"greeting":"from-layer-B:hello-alice"' || {
 # end-to-end (sanity check that nothing was cached as constants).
 echo "==> [2/3] Invoking with a different event payload"
 EVENT2=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${EVENT2}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${EVENT2}" "${CDKL_STDERR}"' EXIT
 echo '{"name":"bob","n":42}' > "${EVENT2}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT2}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeLayersFixture/EchoHandler --event "${EVENT2}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"greeting":"from-layer-B:hello-bob"' || {
   echo "FAIL: expected greeting=from-layer-B:hello-bob, got: ${RESULT_2}"

--- a/tests/integration/local-invoke-provided/verify.sh
+++ b/tests/integration/local-invoke-provided/verify.sh
@@ -40,8 +40,10 @@ GO_IMAGE="golang:1.21-alpine"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0

--- a/tests/integration/local-invoke-provided/verify.sh
+++ b/tests/integration/local-invoke-provided/verify.sh
@@ -26,6 +26,39 @@ CDKL="node ../../../dist/cli.js"
 LAMBDA_IMAGE="public.ecr.aws/lambda/provided:al2023"
 GO_IMAGE="golang:1.21-alpine"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -85,7 +118,7 @@ fi
 # linux/amd64 emulation. The first invocation pays a one-time emulator
 # warm-up tax (~5s); the function's 30s timeout absorbs it comfortably.
 echo "==> [1/5] Invoking BootstrapHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapHandler --no-pull)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"Greeting": *"hello"|"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -95,9 +128,9 @@ echo "${RESULT_1}" | grep -Eq '"Greeting": *"hello"|"greeting": *"hello"' || {
 # Test 2 — asset-backed bootstrap with --event payload round-trip
 echo "==> [2/5] Invoking BootstrapHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -108,9 +141,9 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
 # bootstrap must keep its executable bit, else RIE -> Runtime.InvalidEntrypoint).
 echo "==> [3/5] Invoking BootstrapZipHandler (Code.fromAsset of a .zip with an executable bootstrap)"
 ZIP_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ZIP_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ZIP_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"from":"zip"}' > "${ZIP_EVENT}"
-RESULT_ZIP=$(${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapZipHandler --event "${ZIP_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_ZIP=$(capture ${CDKL} invoke CdkLocalInvokeProvidedFixture/BootstrapZipHandler --event "${ZIP_EVENT}" --no-pull)
 echo "    response: ${RESULT_ZIP}"
 echo "${RESULT_ZIP}" | grep -Eq '"Greeting": *"hello-from-zip"|"greeting": *"hello-from-zip"' || {
   echo "FAIL: expected greeting=hello-from-zip from the extracted zip bootstrap, got: ${RESULT_ZIP}"

--- a/tests/integration/local-invoke-python/verify.sh
+++ b/tests/integration/local-invoke-python/verify.sh
@@ -34,8 +34,10 @@ IMAGE="public.ecr.aws/lambda/python:3.12"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0

--- a/tests/integration/local-invoke-python/verify.sh
+++ b/tests/integration/local-invoke-python/verify.sh
@@ -20,6 +20,39 @@ cd "$(dirname "$0")"
 CDKL="node ../../../dist/cli.js"
 IMAGE="public.ecr.aws/lambda/python:3.12"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -34,7 +67,7 @@ fi
 
 # Test 1 — asset-backed Python Lambda echoes event + env var
 echo "==> [1/4] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --no-pull)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting": "hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -44,9 +77,9 @@ echo "${RESULT_1}" | grep -q '"greeting": "hello"' || {
 # Test 2 — event payload via --event
 echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"key": "value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -56,11 +89,11 @@ echo "${RESULT_2}" | grep -q '"key": "value"' || {
 # Test 3 — --env-vars override
 echo "==> [3/4] Invoking EchoHandler with --env-vars override"
 ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"' EXIT
 # Use a wildcard Parameters block so the test doesn't break if the L1
 # logical ID changes (mirrors the Node.js integ).
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(capture ${CDKL} invoke CdkLocalInvokePythonFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -q '"greeting": "overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -70,9 +103,9 @@ echo "${RESULT_3}" | grep -q '"greeting": "overridden"' || {
 # Test 4 — inline (Code.fromInline) Python Lambda
 echo "==> [4/4] Invoking InlineHandler (Code.ZipFile)"
 INLINE_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_4=$(${CDKL} invoke CdkLocalInvokePythonFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_4=$(capture ${CDKL} invoke CdkLocalInvokePythonFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull)
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -q '"hi": "there"' || {
   echo "FAIL: expected inlineEcho with hi=there, got: ${RESULT_4}"

--- a/tests/integration/local-invoke-ruby/verify.sh
+++ b/tests/integration/local-invoke-ruby/verify.sh
@@ -20,6 +20,39 @@ cd "$(dirname "$0")"
 CDKL="node ../../../dist/cli.js"
 IMAGE="public.ecr.aws/lambda/ruby:3.3"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -34,7 +67,7 @@ fi
 
 # Test 1 — asset-backed Ruby Lambda echoes event + env var
 echo "==> [1/4] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --no-pull)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -44,9 +77,9 @@ echo "${RESULT_1}" | grep -Eq '"greeting": *"hello"' || {
 # Test 2 — event payload via --event
 echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -56,11 +89,11 @@ echo "${RESULT_2}" | grep -Eq '"key": *"value"' || {
 # Test 3 — --env-vars override
 echo "==> [3/4] Invoking EchoHandler with --env-vars override"
 ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"' EXIT
 # Use a wildcard Parameters block so the test doesn't break if the L1
 # logical ID changes (mirrors the Python integ).
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(capture ${CDKL} invoke CdkLocalInvokeRubyFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -Eq '"greeting": *"overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -70,9 +103,9 @@ echo "${RESULT_3}" | grep -Eq '"greeting": *"overridden"' || {
 # Test 4 — inline (Code.fromInline) Ruby Lambda
 echo "==> [4/4] Invoking InlineHandler (Code.ZipFile)"
 INLINE_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_4=$(${CDKL} invoke CdkLocalInvokeRubyFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_4=$(capture ${CDKL} invoke CdkLocalInvokeRubyFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull)
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -Eq '"hi": *"there"' || {
   echo "FAIL: expected inlineEcho with hi=there, got: ${RESULT_4}"

--- a/tests/integration/local-invoke-ruby/verify.sh
+++ b/tests/integration/local-invoke-ruby/verify.sh
@@ -34,8 +34,10 @@ IMAGE="public.ecr.aws/lambda/ruby:3.3"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0

--- a/tests/integration/local-invoke/verify.sh
+++ b/tests/integration/local-invoke/verify.sh
@@ -34,8 +34,10 @@ IMAGE="public.ecr.aws/lambda/nodejs:20"
 # `set -e` never fires. On a non-zero exit it prints the status and the tail
 # of the captured stderr, then still emits the (possibly empty) last stdout
 # line, so the assertion runs, FAILS, and prints its own diagnostic -- with
-# the evidence in the log. On the happy path it is byte-identical to the old
-# shape: the last line of stdout, stderr suppressed.
+# the evidence in the log. On the happy path it emits the last NON-BLANK line of
+# stdout with stderr suppressed. That differs from the old shape only when stdout
+# ends in blank lines: the old shape yielded an empty string there, this yields
+# the last non-blank line.
 CDKL_STDERR="$(mktemp)"
 capture() {
   local out rc=0

--- a/tests/integration/local-invoke/verify.sh
+++ b/tests/integration/local-invoke/verify.sh
@@ -20,6 +20,39 @@ cd "$(dirname "$0")"
 CDKL="node ../../../dist/cli.js"
 IMAGE="public.ecr.aws/lambda/nodejs:20"
 
+# --- capture (issue #577) --------------------------------------------------
+# Under `set -euo pipefail` the shape
+#     VAR=$(${CLI} invoke ... 2>/dev/null | tail -1)
+# aborts the WHOLE script at the ASSIGNMENT when the CLI exits non-zero:
+# pipefail fails the pipeline, the command substitution fails, and `set -e`
+# kills the script BEFORE the grep, before the FAIL message, and before the
+# stderr re-run each FAIL branch does for diagnosis. The operator is left
+# with no response, no assertion and no stderr -- and for a *-from-cfn-stack
+# fixture the EXIT trap then destroys the stack, taking the evidence too.
+#
+# `capture` runs the command with its exit status captured EXPLICITLY, so
+# `set -e` never fires. On a non-zero exit it prints the status and the tail
+# of the captured stderr, then still emits the (possibly empty) last stdout
+# line, so the assertion runs, FAILS, and prints its own diagnostic -- with
+# the evidence in the log. On the happy path it is byte-identical to the old
+# shape: the last line of stdout, stderr suppressed.
+CDKL_STDERR="$(mktemp)"
+capture() {
+  local out rc=0
+  out="$("$@" 2>"${CDKL_STDERR}")" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "[verify] command exited ${rc}: $*" >&2
+    echo "[verify] captured stderr (last 20 lines):" >&2
+    tail -20 "${CDKL_STDERR}" >&2
+  fi
+  printf '%s\n' "${out}" | tail -1
+}
+# Registered immediately: the first capture happens before the fixture's own
+# first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
+# when a run fails on the very first step. Later traps replace this handler
+# and already list "${CDKL_STDERR}" themselves.
+trap 'rm -f "${CDKL_STDERR}"' EXIT
+
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
@@ -43,7 +76,7 @@ rm -f zip-lambda.zip
 
 # Test 1 — asset-backed Lambda echoes event + env var
 echo "==> [1/6] Invoking EchoHandler with default empty event"
-RESULT_1=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
+RESULT_1=$(capture ${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --no-pull)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
   echo "FAIL: expected greeting=hello in response, got: ${RESULT_1}"
@@ -53,9 +86,9 @@ echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
 # Test 2 — event payload via --event
 echo "==> [2/6] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
-RESULT_2=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
 echo "${RESULT_2}" | grep -q '"key":"value"' || {
   echo "FAIL: expected echoed key=value, got: ${RESULT_2}"
@@ -65,11 +98,11 @@ echo "${RESULT_2}" | grep -q '"key":"value"' || {
 # Test 3 — --env-vars override (Parameters)
 echo "==> [3/6] Invoking EchoHandler with --env-vars Parameters block"
 ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"' EXIT
 # Use a wildcard `Parameters` block so the test doesn't break if the
 # L1 logical ID changes.
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
-RESULT_3=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_3=$(capture ${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull)
 echo "    response: ${RESULT_3}"
 echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
   echo "FAIL: expected greeting=overridden, got: ${RESULT_3}"
@@ -79,11 +112,11 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 # Test 4 — --env-vars function-specific key by display path (issue #27)
 echo "==> [4/6] Invoking EchoHandler with --env-vars display-path key"
 DP_ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}" "${CDKL_STDERR}"' EXIT
 # The display-path key matches `Metadata['aws:cdk:path']` — i.e. the
 # same form `cdkl invoke <target>` already accepts.
 echo '{"CdkLocalInvokeFixture/EchoHandler":{"GREETING":"path-key-overridden"}}' > "${DP_ENV_FILE}"
-RESULT_4=$(${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${DP_ENV_FILE}" --no-pull 2>/dev/null | tail -1)
+RESULT_4=$(capture ${CDKL} invoke CdkLocalInvokeFixture/EchoHandler --env-vars "${DP_ENV_FILE}" --no-pull)
 echo "    response: ${RESULT_4}"
 echo "${RESULT_4}" | grep -q '"greeting":"path-key-overridden"' || {
   echo "FAIL: expected greeting=path-key-overridden, got: ${RESULT_4}"
@@ -93,9 +126,9 @@ echo "${RESULT_4}" | grep -q '"greeting":"path-key-overridden"' || {
 # Test 5 — inline (Code.ZipFile) Lambda
 echo "==> [5/6] Invoking InlineHandler (Code.ZipFile)"
 INLINE_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}" "${INLINE_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}" "${INLINE_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_5=$(${CDKL} invoke CdkLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_5=$(capture ${CDKL} invoke CdkLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull)
 echo "    response: ${RESULT_5}"
 echo "${RESULT_5}" | grep -q '"inlineEcho":{"hi":"there"}' || {
   echo "FAIL: expected inlineEcho={hi:there}, got: ${RESULT_5}"
@@ -107,9 +140,9 @@ echo "${RESULT_5}" | grep -q '"inlineEcho":{"hi":"there"}' || {
 # A successful echo with the zip-only env var proves the extracted code ran.
 echo "==> [6/6] Invoking ZipAssetHandler (Code.fromAsset of a .zip file)"
 ZIP_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}" "${INLINE_EVENT}" "${ZIP_EVENT}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}" "${INLINE_EVENT}" "${ZIP_EVENT}" "${CDKL_STDERR}"' EXIT
 echo '{"zip":"asset"}' > "${ZIP_EVENT}"
-RESULT_6=$(${CDKL} invoke CdkLocalInvokeFixture/ZipAssetHandler --event "${ZIP_EVENT}" --no-pull 2>/dev/null | tail -1)
+RESULT_6=$(capture ${CDKL} invoke CdkLocalInvokeFixture/ZipAssetHandler --event "${ZIP_EVENT}" --no-pull)
 echo "    response: ${RESULT_6}"
 echo "${RESULT_6}" | grep -q '"echoed":{"zip":"asset"}' || {
   echo "FAIL: expected echoed={zip:asset} from extracted zip asset, got: ${RESULT_6}"

--- a/tests/integration/local-run-task/verify.sh
+++ b/tests/integration/local-run-task/verify.sh
@@ -38,8 +38,10 @@ remove_run_override_images() {
   [ -n "${new}" ] || return 0
   echo "==> Removing override image(s) built by this run:"
   echo "${new}" | sed 's/^/      /'
-  # Never force-remove: an unforced `docker image rm` refuses an image a
-  # RUNNING container still holds, which keeps a concurrent lane safe.
+  # Unforced: `docker image rm` refuses an image while a container still holds
+  # it, so a lane whose container is UP survives. It does NOT cover a lane
+  # between `docker build` and `docker run` -- the delta scoping is what keeps
+  # this run away from another lane's tag in that window.
   echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
 }
 

--- a/tests/integration/local-run-task/verify.sh
+++ b/tests/integration/local-run-task/verify.sh
@@ -20,13 +20,36 @@ CDKL="node ../../../dist/cli.js"
 SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
 NGINX_IMAGE="public.ecr.aws/nginx/nginx:alpine"
 
+# --- built-image cleanup (issue #587) --------------------------------------
+# This used to force-remove EVERY `cdkl-override-*` tag. Parallel integ lanes
+# share one Docker daemon on a dev host, so that blanket sweep deletes override
+# images another lane is mid-run on. Only the tag(s) THIS run creates are
+# removed: the set present now is snapshotted, and cleanup deletes just what
+# appeared since. A run can produce SEVERAL override tags
+# (`cdkl-override-<svc>-<hash>:local`, one per covered target), so the delta is
+# a set rather than a single tag.
+IMAGES_BEFORE_OVERRIDE="$(docker images --filter 'reference=cdkl-override-*' \
+  --format '{{.Repository}}:{{.Tag}}' | sort)"
+
+remove_run_override_images() {
+  local new
+  new="$(docker images --filter 'reference=cdkl-override-*' --format '{{.Repository}}:{{.Tag}}' \
+    | sort | comm -13 <(printf '%s\n' "${IMAGES_BEFORE_OVERRIDE}") - | grep -v '^$' || true)"
+  [ -n "${new}" ] || return 0
+  echo "==> Removing override image(s) built by this run:"
+  echo "${new}" | sed 's/^/      /'
+  # Never force-remove: an unforced `docker image rm` refuses an image a
+  # RUNNING container still holds, which keeps a concurrent lane safe.
+  echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
+}
+
 cleanup() {
   echo "==> Cleanup: stopping any leftover containers"
   docker ps --filter "name=cdkl-" --format '{{.ID}}' | xargs -r docker rm -f >/dev/null 2>&1 || true
   docker network ls --filter "name=cdkl-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
   # Issue #388 — drop the local-only override image(s) the --image-override run
   # built (tag prefix is the embed binary name: `cdkl-override-*:local`).
-  docker images --filter 'reference=cdkl-override-*' -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
+  remove_run_override_images
 }
 trap cleanup EXIT
 

--- a/tests/integration/local-start-api-container/verify.sh
+++ b/tests/integration/local-start-api-container/verify.sh
@@ -40,6 +40,39 @@ if [[ ! -d node_modules ]]; then
 fi
 
 
+
+# --- built-image cleanup (issue #587) --------------------------------------
+# This fixture's DockerImageFunction makes cdkl `docker build` a
+# `cdkl-invoke-<hash>:latest` image of ~421 MB. Nothing removed it, so every
+# run leaked one -- and because the tag is a fingerprint of the asset (the
+# platform included), a change to the Dockerfile, the handler or the
+# architecture mints a NEW tag that no later run will ever reuse or reclaim.
+#
+# Only the tag(s) THIS run creates are removed: the set of `cdkl-invoke-*`
+# tags present now is snapshotted, and cleanup deletes only what appeared
+# since. A blanket `docker rmi` of every `cdkl-invoke-*` tag is deliberately
+# NOT used -- parallel integ lanes share one Docker daemon on a dev host, so
+# a blanket sweep deletes images other lanes are mid-run on, and it would
+# also destroy the local cache other container fixtures rely on.
+IMAGES_BEFORE="$(mktemp)"
+docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
+  | sort > "${IMAGES_BEFORE}"
+
+remove_run_images() {
+  [ -f "${IMAGES_BEFORE:-}" ] || return 0
+  local new
+  new="$(docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
+    | sort | comm -13 "${IMAGES_BEFORE}" -)"
+  if [ -n "${new}" ]; then
+    echo "==> Removing image(s) built by this run:"
+    echo "${new}" | sed 's/^/      /'
+    # `docker image rm` refuses an image a RUNNING container still uses, so a
+    # concurrent lane mid-run is protected even if its tag lands in the delta.
+    echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
+  fi
+  rm -f "${IMAGES_BEFORE}"
+}
+
 LOG_FILE="$(mktemp)"
 SERVER_PID=""
 
@@ -65,6 +98,7 @@ cleanup() {
     echo "${ORPHANS}" | xargs -r docker rm -f >/dev/null 2>&1 || true
   fi
   rm -f "${LOG_FILE}"
+  remove_run_images
 }
 trap cleanup EXIT INT TERM
 

--- a/tests/integration/local-start-api-container/verify.sh
+++ b/tests/integration/local-start-api-container/verify.sh
@@ -66,8 +66,10 @@ remove_run_images() {
   if [ -n "${new}" ]; then
     echo "==> Removing image(s) built by this run:"
     echo "${new}" | sed 's/^/      /'
-    # `docker image rm` refuses an image a RUNNING container still uses, so a
-    # concurrent lane mid-run is protected even if its tag lands in the delta.
+    # Unforced: `docker image rm` refuses an image while a container still holds
+    # it, so a lane whose container is UP survives. It does NOT cover a lane
+    # between `docker build` and `docker run` -- the delta scoping is what keeps
+    # this run away from another lane's tag in that window.
     echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
   fi
   rm -f "${IMAGES_BEFORE}"

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -58,6 +58,29 @@ RUN_FILE=$(mktemp)
 SSE_FILE=$(mktemp)
 STUDIO_PID=""
 SSE_PID=""
+
+# --- built-image cleanup (issue #587) --------------------------------------
+# This used to force-remove EVERY `cdkl-override-*` tag. Parallel integ lanes
+# share one Docker daemon on a dev host, so that blanket sweep deletes override
+# images another lane is mid-run on. Only the tag(s) THIS run creates are
+# removed: the set present now is snapshotted, and cleanup deletes just what
+# appeared since. A run can produce SEVERAL override tags
+# (`cdkl-override-<svc>-<hash>:local`, one per covered target), so the delta is
+# a set rather than a single tag.
+IMAGES_BEFORE_OVERRIDE="$(docker images --filter 'reference=cdkl-override-*' \
+  --format '{{.Repository}}:{{.Tag}}' | sort)"
+
+remove_run_override_images() {
+  local new
+  new="$(docker images --filter 'reference=cdkl-override-*' --format '{{.Repository}}:{{.Tag}}' \
+    | sort | comm -13 <(printf '%s\n' "${IMAGES_BEFORE_OVERRIDE}") - | grep -v '^$' || true)"
+  [ -n "${new}" ] || return 0
+  echo "==> Removing override image(s) built by this run:"
+  echo "${new}" | sed 's/^/      /'
+  # Never force-remove: an unforced `docker image rm` refuses an image a
+  # RUNNING container still holds, which keeps a concurrent lane safe.
+  echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
+}
 cleanup() {
   if [[ -n "${SSE_PID}" ]] && kill -0 "${SSE_PID}" 2>/dev/null; then
     kill "${SSE_PID}" 2>/dev/null || true
@@ -70,7 +93,7 @@ cleanup() {
   rm -f "$(pwd)/.studio-ws-client.mjs" "$(pwd)/.studio-agentcore-ws-client.mjs"
   # Drop the local-only image-override build(s) the ecs / alb / ecs-task picker
   # tests produced (tag prefix is the embed binary name: `cdkl-override-*:local`).
-  docker images --filter 'reference=cdkl-override-*' -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
+  remove_run_override_images
 }
 trap cleanup EXIT
 

--- a/tests/integration/local-studio/verify.sh
+++ b/tests/integration/local-studio/verify.sh
@@ -77,8 +77,10 @@ remove_run_override_images() {
   [ -n "${new}" ] || return 0
   echo "==> Removing override image(s) built by this run:"
   echo "${new}" | sed 's/^/      /'
-  # Never force-remove: an unforced `docker image rm` refuses an image a
-  # RUNNING container still holds, which keeps a concurrent lane safe.
+  # Unforced: `docker image rm` refuses an image while a container still holds
+  # it, so a lane whose container is UP survives. It does NOT cover a lane
+  # between `docker build` and `docker run` -- the delta scoping is what keeps
+  # this run away from another lane's tag in that window.
   echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
 }
 cleanup() {


### PR DESCRIPTION
## Summary

Two defects in the integration-test harness, one PR because the second one's fix lands
in a file the first one's sweep also touches.

### The unreachable diagnostic (closes 577)

Under `set -euo pipefail`, `RESULT=$(${CLI} invoke ... 2>/dev/null | tail -1)` aborts the
script at the ASSIGNMENT when the CLI exits non-zero — before the assertion, before the
FAIL message, and before the stderr re-run each FAIL branch performs precisely so the
failure can be read. The operator gets the EXIT trap line and nothing else, and for a
`*-from-cfn-stack` fixture the trap then destroys the stack, taking the evidence with it.

50 sites fixed across 14 files. Four are deliberately left alone —
`local-invoke-from-cfn-stack:216`, `-multi-stack:146`, `-large-stack:121`,
`local-invoke-agentcore-from-cfn:119` — because they sit inside an `if out=$(...) && ...`
retry loop, where `if` suppresses `set -e` and the shape is not broken.

The audit is three commands rather than one, because the obvious grep provably misses
shapes (multi-line spellings, helper bodies, log-then-grep pairs):

```
A: assignments direct from a CLI command substitution, not routed
   through capture/capture_all/|| rc/set +e            -> 0 remaining
B: bare CLI redirected to a log with no status capture -> 0 remaining
C: the original single grep, verbatim                  -> 4 (the if-guarded loops)
```

### The image sweeps (closes 587)

`local-invoke-container` never removed the image it built, leaking a ~421 MB tag per run.
**The issue's premise about the remedy was wrong, in both halves.** It told us to mirror
`local-invoke-buildkit` as the safe model — that fixture used `docker image rm -f`, not
`docker rmi`, and what it did was force-remove EVERY `cdkl-invoke-*` tag on the host,
twice per run. Copying it as instructed would have spread the most dangerous behaviour in
the repo to two more fixtures. `local-run-task` and `local-studio` carried the same
blanket sweep over the `cdkl-override-*` namespace. It also carried a
`docker image prune -f --filter label=cdkl-invoke` that had never matched anything,
because cdk-local never passes `--label` in the build path.

That is not hypothetical. Running the OLD code against a planted
`cdkl-override-sentinel-preexisting:local` deleted it; the new code leaves it standing.
Same experiment, opposite outcomes.

All five removal sites are now snapshot-then-delta and unforced: remove only tags that
appeared since this run started, never one the snapshot held, never `-f` (an unforced
`docker image rm` refuses an image a container still holds). `local-invoke-buildkit`
additionally needs its pre-run removal to keep FORCING a rebuild, so its "a build
happened" assertion is strengthened rather than dropped — the tag is proven absent, then
required present, which is stricter than the old "some `cdkl-invoke-*` tag exists" that
any stale image satisfied.

## The blocker this PR's own first round introduced

Worth stating plainly, because it is the most instructive part. Review caught that in two
`cleanup()` bodies the new `rm -f "${CDKL_STDERR}"` landed ABOVE `rc=$?`, so `rc` captured
`rm`'s status — always 0 — and `exit "${rc}"` reported success for a FAILED run. A red
fixture would have reported green and `/run-integ` would have set the `integ` marker on
it. That is strictly worse than the defect this PR was filed against: it loses the
FAILURE, not just the diagnostic. Proven by truncating each real fixture at its trap line
and forcing a failure — exit 0 before, exit 1 after — then audited across all 60 fixtures
(twelve capture `rc`; ten were already correct; both broken ones were this branch's).

## Test plan

Seven fixtures run green: `local-invoke`, `local-invoke-container`,
`local-start-api-container`, `local-invoke-buildkit`, `local-run-task`, `local-studio`,
`local-invoke-agentcore` (all 20), plus `local-invoke-layers` and `local-invoke-python`.
Image counts held at the host baseline (`cdkl-invoke` 5 -> 5, `cdkl-override` 0 -> 0) with
0 orphan containers or networks. Buildkit still exercises `--secret` / `--target` on a
freshly built image.

**Reachability, before and after**, against a real non-zero `cdkl invoke`: before, the
script dies silently at the assignment; after, it prints the exit code, the captured
stderr, and the FAIL branch naming the actual `CannotFindAsset` cause.

**Discrimination**: stubbing cdkl to answer without building reds the new build-happened
check and passes the old one.

**An unplanned live proof.** `local-invoke` hit a transient Docker port race mid-run and
printed exactly what 577 says is unreachable:

```
ERROR: DockerRunnerError: docker run failed: ... Bind for 127.0.0.1:55001 failed:
       port is already allocated
    response: Starting container (image=public.ecr.aws/lambda/nodejs:20, port=55001)...
FAIL: expected inlineEcho={hi:there}, got: Starting container (...)
```

Pre-fix that is a silent abort with no output — the "transient AND unattributable" pair
the issue was filed about, caught by the fix that closes it. It passed on re-run.

The three AWS-deploying fixtures (`local-invoke-assume-role`,
`local-invoke-agentcore-froms3`, `local-invoke-agentcore-froms3-from-cfn`) carry the same
mechanical edit but were NOT executed. The repo-wide `no-control-bytes` check a peer PR
merged mid-lane was re-run over this diff: green.

## Remaining work

- **TODO (issue 603)** — seven fixtures build a Docker image and never remove one, so
  every run leaks tags. Found by inverting the query: the enumeration behind this PR keyed
  on `docker rmi|docker image rm|docker image prune`, which by construction only finds
  fixtures that already HAVE cleanup, so a fixture with none was invisible to it.
  - Session-fit: next (not this session) — six more Docker fixture runs, three of them the
    heavy `*-watch` set and one needing real AWS, on top of a diff already at the edge of
    reviewable after three review rounds. This is the umbrella boundary, not convenience.
  - Severity: low — disk on a developer machine; no user-visible behaviour changes.
  - Effort: medium (M) — the helper is established here, but it must compose with
    `local-invoke-agentcore`'s seven existing traps and the `*-watch` fixtures' mid-run
    rebuilds.
  - Estimate: ~2-3 h — dominated by the fixture runs rather than the edits.
  - Notes: `local-invoke-agentcore`'s `verify.sh` IS in this diff (7 capture sites
    rewritten), so the file was touched WITHOUT its image leak being closed. The issue
    says so, to stop a future reader concluding the leak was reviewed and accepted here.

- **Won't-do** — reclaiming the 5 pre-existing `cdkl-invoke-*` images (2.9 GB) on the dev
  host.
  - Why: it needs exactly the blanket `cdkl-invoke-*` sweep this PR removes as unsafe
    under parallel lanes; they are removable by hand whenever the host is quiet.
  - Recorded: here, and in the in-code comments on the three `remove_*` helpers.

Closes #587
Closes #577
