### PR TITLE
chore(skills): query for the precondition, not the remedy — plus two ordering traps

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -407,6 +407,42 @@ instance: one command factory mishandling a flag, one resolver arm missing a cas
 one caller of a shared helper assuming the old contract. Once the root cause is
 named, grep for the same shape across `src/` before writing the fix.
 
+**Query for the PRECONDITION minus the REMEDY, never for the remedy alone.** When the
+defect is a MISSING thing, the obvious grep searches for the thing that is missing —
+and it can only ever return the sites that already HAVE it. The absent sites are
+invisible to it by construction, so the sweep reports itself complete while covering
+only the half that was never broken. Ask instead: what makes a site ELIGIBLE for this
+defect, and which eligible sites lack the fix?
+
+Measured here on 2026-08-27, in go-to-k/cdk-local#587's lane. The root cause was "a
+fixture leaks the Docker image it builds". The enumeration used to bound the sweep was
+`grep -n "docker rmi\|docker image rm\|docker image prune" tests/integration/*/verify.sh`
+— a search for the REMEDY. It returned five sites, all of them fixtures that already had
+cleanup, and the lane closed all five and declared the class done. The correct query is
+eligibility minus remedy:
+
+```bash
+BUILDERS=$(grep -rl 'DockerImageFunction\|DockerImageCode\|ContainerImage.fromAsset\|fromImageAsset\|image-override\|fromDockerImageAsset' tests/integration/ \
+  | awk -F/ '{print $3}' | sort -u)
+for f in $BUILDERS; do
+  v="tests/integration/$f/verify.sh"; [ -f "$v" ] || continue
+  grep -q 'docker image rm\|docker rmi' "$v" || echo "NO CLEANUP: $f"
+done
+```
+
+It returns **six** further fixtures, and a seventh (`local-invoke-agentcore`) that
+neither query finds because its image comes from a Dockerfile rather than a
+`DockerImageFunction` — filed as the go-to-k/cdk-local#603 umbrella. So the remedy-shaped
+query saw 5 of 12 eligible sites and could not have seen the other 7.
+
+**The same run then repeated the mistake one level up, which is why this is a rule and
+not a footnote.** An agent that had just diagnosed the flaw in the orchestrator's query
+sized the residue from the ONE instance it had tripped over — "one fixture, ~30 min" —
+rather than asking which query would find the class. It was seven fixtures, three of them
+the heaviest in the suite. **A count derived from the instance you happened to hit is not
+a count**; sizing a deferral is exactly where that matters, because the `Effort` and
+`Estimate` lines are what a future session budgets from.
+
 **N sites of one root cause is ONE issue and ONE PR, never N issues.** This is the
 single largest source of unbounded backlog growth: split into N, each site pays the
 full fixed cost — triage, claim, worktree, review tier, integ run, merge — for a fix
@@ -899,8 +935,21 @@ Run `/verify-pr`. It walks the full checklist (typecheck / lint / build / tests,
 status, docs consistency, Docker + integ marker, code review, PR title/body
 freshness) and — critically — **live-tests the changed behavior**:
 
-**Run the integ LAST, and note that "last" does not hold still across review
-rounds — so DECLARE the tree final, in words, to whoever is still editing it.**
+**Run the integ LAST — and set the `check` / `docs` markers AFTER it, not before.**
+A fixture run writes `cdk.out/`, `node_modules/` and a `pnpm-lock.yaml` inside
+`tests/integration/<fixture>/`, and the `check` gate's include set is
+`src/**` + `tests/**` + the configs. markgate's `files` digest covers those
+artifacts even though git ignores them, so a green integ run STALES a `check`
+marker set minutes earlier — with the tracked tree completely unchanged and
+`git status` clean. The symptom is a `git commit` refused for "digest differs"
+that no source edit explains, and re-running `/check` before the integ cannot
+fix it. The working order is: edit -> integ -> `/check` -> `markgate set` ->
+commit. Measured here on 2026-08-27 across all three lanes of one run; the
+first occurrence cost a re-diagnosis plus a full re-run of the unit suite.
+
+**Then run the integ LAST in the other sense too: "last" does not hold still
+across review rounds — so DECLARE the tree final, in words, to whoever is still
+editing it.**
 The `integ` gate is `hash: diff` against `merge-base(origin/main, HEAD)`, so it
 digests this branch's DELTA over the include set rather than the working tree's
 behaviour. That has a consequence worth stating outright: a round of review
@@ -1520,6 +1569,20 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   not just this one, since a sentence travels from any of them. Frontmatter,
   fenced code blocks, and backtick spans are exempt, so a paragraph can still
   show a bare `#N` as its own counter-example (this one does).
+
+  **But NOT in a PR or issue BODY — there the qualified form is refused, and a
+  full URL is the only spelling that passes.** The rule above governs the
+  agent-instruction FILES, which travel between repos. A PR body does not
+  travel, and `pr-body-item-number-gate.sh` refuses any `#N` its allow-list
+  does not cover -- `closes #N`, `(#N)`, fenced code and full GitHub URLs are
+  allowed; `go-to-k/cdkd#1821` is not. Measured here on 2026-08-27: a
+  `gh pr create` was blocked on two such refs, both of them correct
+  cross-repo citations written to satisfy the rule above. The two
+  requirements point opposite ways for the same string, so pick by
+  DESTINATION: `go-to-k/<repo>#N` in a file under `.claude/**`, and
+  `https://github.com/go-to-k/<repo>/issues/N` in a PR or issue body. Nothing
+  detects the mismatch until the gate fires at `gh pr create`, which is after
+  the body is written.
 
 ### 10-d. Ship it like any other change
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1603,6 +1603,18 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   detects the mismatch until the gate fires at `gh pr create`, which is after
   the body is written.
 
+  Two measurements from writing THIS paragraph, both worth having. The gate
+  refuses the SAME-repo qualified form too — `go-to-k/cdk-local#587` in a
+  cdk-local PR body is blocked exactly like the cross-repo one, so
+  "qualify it" is never the fix in a body; a full URL or a bare number in
+  prose is. And the refusal hit a `python3 <<PY ... PY` heredoc chained to
+  the `gh api` that would publish the body, so the WHOLE command was
+  aborted before the heredoc ran: the retry then re-read an unedited file
+  and reported the identical violation, which reads as "my fix did not
+  work" rather than "my fix never ran". That is the gotcha below about a
+  gated command needing its own Bash call, arriving through the one shape
+  that disguises itself as a failed edit.
+
 ### 10-d. Ship it like any other change
 
 `/merge-pr` removed every worktree THIS run added by §9 and you are back on

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -686,10 +686,29 @@ there). Per lane:
 
 ```bash
 git worktree add .claude/worktrees/<name> -b <branch> origin/main
-( cd .claude/worktrees/<name> \
-  && mise trust && mise install \    # a fresh worktree's .mise.toml is untrusted — vp / markgate won't resolve until this
-  && pnpm install )                  # worktrees have no node_modules
+cd .claude/worktrees/<name>
+# A fresh worktree's .mise.toml is untrusted, so vp / markgate do not resolve
+# until this. (A backslash continuation cannot carry a trailing comment, so
+# these are separate lines rather than one `&&` chain.)
+mise trust && mise install
+pnpm install    # worktrees have no node_modules
+vp run build    # ...and no dist/ — see below
 ```
+
+**Build BEFORE the first test run, and read a fresh worktree's failures with that
+in mind.** A worktree starts with no `dist/`, and any test that spawns the built
+CLI then fails on the missing binary rather than on its subject — with an
+assertion message about the SUBJECT, which is what makes it costly. This repo's
+integ fixtures resolve `node ../../../dist/cli.js`, so they are exposed directly,
+and `/run-integ` builds first for exactly this reason; the trap is that a UNIT
+suite can be exposed too. Measured in go-to-k/cdk-real-drift on 2026-08-27: a
+docs-only lane in a fresh worktree saw 13 failures in a CLI exit-code suite
+(`expected 1 to be 2`), reproduced them with its own edit stashed, and had begun
+writing them up as "a peer merge broke main" — the same file passed in the main
+checkout, which HAS a `dist/`, so every comparison pointed at main. One
+`vp run build` turned it green with no other change. **A fresh worktree failing
+where the main checkout passes is evidence about the WORKTREE first**, and a build
+costs seconds against a false broken-main report.
 
 Do the fix in the worktree (match the existing module/pattern exactly; ESM relative
 imports need the `.js` extension even in TS source). **Always add a test that fails


### PR DESCRIPTION
## Summary

Three lessons from one `/work-issues` run that closed four issues (575, 577, 585, 587)
across three lanes. No `src/**` change — this is agent tooling only.

### 1. A sweep that greps for the REMEDY can only find sites that already have it

The lane for issue 587 bounded its sweep with
`grep 'docker rmi|docker image rm|docker image prune' tests/integration/*/verify.sh`.
That returned five fixtures — all of them ones that already HAD cleanup. The defect was
"a fixture leaks the Docker image it builds", so the sites that mattered were precisely
the ones that could not appear in that output.

Querying eligibility minus remedy — builds an image, does not remove one — returns six
more, plus a seventh (`local-invoke-agentcore`) that neither query finds because its
image comes from a Dockerfile rather than a `DockerImageFunction`. So the remedy-shaped
query saw 5 of 12 eligible sites and reported the class closed. The residue is filed as
https://github.com/go-to-k/cdk-local/issues/603.

**The same run then repeated the mistake one level up**, which is what makes it a rule
rather than a footnote: an agent that had just diagnosed the flaw in the orchestrator's
query sized the residue from the ONE instance it had tripped over — "one fixture,
~30 min" — instead of asking which query would find the class. It was seven fixtures,
three of them the heaviest in the suite. That second occurrence lands directly on the
`Effort` and `Estimate` lines a future session budgets from, so it is not a cosmetic
miss.

### 2. Set the `check` / `docs` markers AFTER the integ, not before

A fixture run writes `cdk.out/`, `node_modules/` and a `pnpm-lock.yaml` inside
`tests/integration/<fixture>/`. The `check` gate's include set is `src/**` + `tests/**`
+ configs, and markgate's `files` digest covers those artifacts even though git ignores
them. So a green integ run STALES a `check` marker set minutes earlier, with the tracked
tree completely unchanged and `git status` clean.

The symptom is a `git commit` refused for "digest differs" that no source edit explains,
and re-running `/check` BEFORE the integ cannot clear it. Working order is
edit -> integ -> `/check` -> `markgate set` -> commit. Hit on the first of three lanes;
cost a re-diagnosis plus a full re-run of the unit suite.

### 3. The "fully qualify every ref" rule stops at the file boundary

`/work-issues` section 10-c requires every issue / PR reference in a mirrored
agent-instruction file to be written `go-to-k/<repo>#N`, and a repo test enforces it.
`pr-body-item-number-gate.sh` refuses exactly that form in a PR body — its allow-list is
`closes #N`, `(#N)`, fenced code, and full GitHub URLs.

The two requirements point opposite ways for the same string. This run hit the block on
`gh pr create` for two refs written specifically to satisfy the file rule. The split is
by DESTINATION: qualified form in `.claude/**`, full URL in a PR or issue body. Nothing
detects the mismatch until the gate fires, which is after the body is written.

## Test plan

No `src/**` change, so no integ and no live-test — the diff is one skill file.
`vp run verify` green (226 files / 3648 tests, 0 type errors). The repo's own reference
fence, `tests/unit/skills/work-issues-skill-refs.test.ts`, was run over the edited text
and passes — relevant here because lesson 3 is about that exact rule and the new prose
cites cross-repo issues.

Each lesson is amended into the step where it fires (section 5, section 8, section 10-c)
rather than appended as a tail section, and each carries its date, the run that produced
it, and the measurement behind it.

## Remaining work

- **TODO (issue 603)** — the seven leaking fixtures that lesson 1 uncovered.
  - Session-fit: next (not this session) — six Docker fixture runs, three of them the
    heavy `*-watch` set and one needing real AWS.
  - Severity: low — disk on a developer machine; no user-visible behaviour changes.
  - Effort: medium (M) — the helper is established; composing it with
    `local-invoke-agentcore`'s seven existing traps and the `*-watch` fixtures' mid-run
    rebuilds is the work.
  - Estimate: ~2-3 h — dominated by the fixture runs.
  - Notes: filed during this run, with the corrected count derived from the query rather
    than from the one instance that surfaced it.

- **Won't-do** — mirroring lesson 1 into the sibling repos' `work-issues` skills in this
  session.
  - Why: lessons 2 and 3 are cdk-local-specific (this repo's markgate scopes and its own
    hook), so only lesson 1 is a genuine flow lesson, and landing it properly means two
    more worktrees, gate cycles and PRs after a run that has already merged four. Called
    out rather than done silently so the next reader sees the choice was made.
  - Recorded: here.
