### PR TITLE
fix(hooks): control-char-gate decides its scan target from the command, not the index

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -515,7 +515,18 @@ GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
 # presents the gate with the PRE-add index and the offending file is invisible
 # (go-to-k/cdk-local#576). Built the same way every other verb here is, so
 # `git -C <path> add`, a launcher prefix and quoted spans all reach it.
-GATE_RE_GIT_ADD="^git${GATE_FLAGS}[[:space:]]+add([[:space:]]|$)"
+# `stage` is git's own built-in alias for `add` (not a user alias), so it has
+# to be here or the staging scan is one synonym away from being skipped.
+# The extra group is harmless: nothing reads a numbered BASH_REMATCH off
+# this regex -- `gate_target_dir` and `gate_verb_args` use [0] only.
+GATE_RE_GIT_ADD="^git${GATE_FLAGS}[[:space:]]+(add|stage)([[:space:]]|$)"
+# The removal verbs, for the same reason control-char-gate needs the staging
+# ones: `rm bad.ts && git add -A && git commit` is ONE Bash call, so at hook time
+# the file is still on disk with its control byte in it, while the commit that
+# call produces does not contain the file at all. The only place that deletion
+# is visible BEFORE the command runs is the command.
+GATE_RE_RM="^rm([[:space:]]|$)"
+GATE_RE_GIT_RM="^git${GATE_FLAGS}[[:space:]]+rm([[:space:]]|$)"
 GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
 # issue-classification-label-gate: the CLAIM site. `/work-issues` says most open
 # bodies are still in the old packed shape and are upgraded to the four-line
@@ -611,6 +622,28 @@ gate_unquote() {
   printf '%s' "$p"
 }
 
+# gate_verb_args <cmd> <verb-ere>
+#
+# Print, one line per matching segment, the text that FOLLOWS the matched verb
+# in that segment -- flags included, because the verb ERE has already consumed
+# the leading flag run. Nothing is printed for a command with no matching
+# segment.
+#
+# This is `gate_pr_selector`'s first two lines, factored out: that function
+# exists because four gates each rolled their own "strip the verb, then read the
+# arguments" and all four broke the moment GATE_GH_C widened. The strip must
+# come from the SAME constant that armed the gate -- `BASH_REMATCH[0]` of the
+# verb ERE -- so a gate cannot match one way and parse another. A caller that
+# wants something other than a PR number (control-char-gate wants `git add`'s
+# pathspecs) gets the same guarantee here instead of writing the strip again.
+gate_verb_args() {
+  local cmd="$1" re="$2" segment
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] || continue
+    printf '%s\n' "${segment#"${BASH_REMATCH[0]}"}"
+  done < <(gate_segments "$cmd")
+}
+
 # gate_pr_selector <command> <verb-ere>
 #
 # Print the PR number the guarded command targets, or NOTHING when it carries no
@@ -639,28 +672,6 @@ gate_unquote() {
 # the verb ERE is anchored at the segment start and already absorbs every flag
 # spelling, so `BASH_REMATCH[0]` is exactly the part to remove, whatever flags it
 # swallowed. A gate can no longer match one way and parse another.
-# gate_verb_args <cmd> <verb-ere>
-#
-# Print, one line per matching segment, the text that FOLLOWS the matched verb
-# in that segment -- flags included, because the verb ERE has already consumed
-# the leading flag run. Nothing is printed for a command with no matching
-# segment.
-#
-# This is `gate_pr_selector`'s first two lines, factored out: that function
-# exists because four gates each rolled their own "strip the verb, then read the
-# arguments" and all four broke the moment GATE_GH_C widened. The strip must
-# come from the SAME constant that armed the gate -- `BASH_REMATCH[0]` of the
-# verb ERE -- so a gate cannot match one way and parse another. A caller that
-# wants something other than a PR number (control-char-gate wants `git add`'s
-# pathspecs) gets the same guarantee here instead of writing the strip again.
-gate_verb_args() {
-  local cmd="$1" re="$2" segment
-  while IFS= read -r segment; do
-    [[ "$segment" =~ $re ]] || continue
-    printf '%s\n' "${segment#"${BASH_REMATCH[0]}"}"
-  done < <(gate_segments "$cmd")
-}
-
 gate_pr_selector() {
   local cmd="$1" re="$2" segment args tok
   while IFS= read -r segment; do

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -509,6 +509,13 @@ GATE_RE_GH_PR_MERGE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+merge([[:space:]]|
 GATE_RE_GIT_SWITCH="^git${GATE_FLAGS}[[:space:]]+switch([[:space:]]|$)"
 GATE_RE_GIT_CHECKOUT="^git${GATE_FLAGS}[[:space:]]+checkout([[:space:]]|$)"
 GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
+# control-char-gate: a `git add` in the SAME Bash call as the `git commit` is
+# what makes the commit's content differ from the index the gate can see. A
+# PreToolUse hook runs BEFORE its command, so `git add -A && git commit -F msg`
+# presents the gate with the PRE-add index and the offending file is invisible
+# (go-to-k/cdk-local#576). Built the same way every other verb here is, so
+# `git -C <path> add`, a launcher prefix and quoted spans all reach it.
+GATE_RE_GIT_ADD="^git${GATE_FLAGS}[[:space:]]+add([[:space:]]|$)"
 GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
 # issue-classification-label-gate: the CLAIM site. `/work-issues` says most open
 # bodies are still in the old packed shape and are upgraded to the four-line
@@ -632,6 +639,28 @@ gate_unquote() {
 # the verb ERE is anchored at the segment start and already absorbs every flag
 # spelling, so `BASH_REMATCH[0]` is exactly the part to remove, whatever flags it
 # swallowed. A gate can no longer match one way and parse another.
+# gate_verb_args <cmd> <verb-ere>
+#
+# Print, one line per matching segment, the text that FOLLOWS the matched verb
+# in that segment -- flags included, because the verb ERE has already consumed
+# the leading flag run. Nothing is printed for a command with no matching
+# segment.
+#
+# This is `gate_pr_selector`'s first two lines, factored out: that function
+# exists because four gates each rolled their own "strip the verb, then read the
+# arguments" and all four broke the moment GATE_GH_C widened. The strip must
+# come from the SAME constant that armed the gate -- `BASH_REMATCH[0]` of the
+# verb ERE -- so a gate cannot match one way and parse another. A caller that
+# wants something other than a PR number (control-char-gate wants `git add`'s
+# pathspecs) gets the same guarantee here instead of writing the strip again.
+gate_verb_args() {
+  local cmd="$1" re="$2" segment
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] || continue
+    printf '%s\n' "${segment#"${BASH_REMATCH[0]}"}"
+  done < <(gate_segments "$cmd")
+}
+
 gate_pr_selector() {
   local cmd="$1" re="$2" segment args tok
   while IFS= read -r segment; do

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -520,13 +520,6 @@ GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
 # The extra group is harmless: nothing reads a numbered BASH_REMATCH off
 # this regex -- `gate_target_dir` and `gate_verb_args` use [0] only.
 GATE_RE_GIT_ADD="^git${GATE_FLAGS}[[:space:]]+(add|stage)([[:space:]]|$)"
-# The removal verbs, for the same reason control-char-gate needs the staging
-# ones: `rm bad.ts && git add -A && git commit` is ONE Bash call, so at hook time
-# the file is still on disk with its control byte in it, while the commit that
-# call produces does not contain the file at all. The only place that deletion
-# is visible BEFORE the command runs is the command.
-GATE_RE_RM="^rm([[:space:]]|$)"
-GATE_RE_GIT_RM="^git${GATE_FLAGS}[[:space:]]+rm([[:space:]]|$)"
 GATE_RE_GH_ISSUE_CREATE="^gh${GATE_GH_C}[[:space:]]+issue[[:space:]]+create([[:space:]]|$)"
 # issue-classification-label-gate: the CLAIM site. `/work-issues` says most open
 # bodies are still in the old packed shape and are upgraded to the four-line

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -788,5 +788,49 @@ else
   pass=$((pass + 1)); printf 'OK   gate_segments is unchanged by the pipe mark\n'
 fi
 
+# --- GATE_RE_GIT_ADD + gate_verb_args (go-to-k/cdk-local#576) ------------------
+# control-char-gate has to know whether the SAME Bash call also stages, because
+# a PreToolUse hook runs before the command and the index it can read is the
+# PRE-add one. The verb regex is built like every other one here, so the flagged
+# and launcher spellings must reach it identically -- and `gate_verb_args` must
+# hand back the arguments with the flag run already consumed, so the gate cannot
+# match one way and parse another.
+A="$GATE_RE_GIT_ADD"
+
+want_match 0 "bare git add"                  'git add -A' "$A"
+want_match 0 "git add before a commit"       'git add -A && git commit -m x' "$A"
+want_match 0 "git -C <path> add"             'git -C /w/t add -A && git commit -m x' "$A"
+want_match 0 "git -C=<path> add (glued sep)" 'git -C=/w/t add -A' "$A"
+want_match 0 "launcher passthrough"          'mise exec -- git add -A' "$A"
+want_match 0 "inside bash -c"                'bash -c "git add -A && git commit -m x"' "$A"
+want_match 1 "add inside a string"           'echo "then git add -A"' "$A"
+want_match 1 "git add-something is not add"  'git add--interactive' "$A"
+want_match 1 "commit is not add"             'git commit -m x' "$A"
+want_match 1 "a pathspec named add"          'git rm add' "$A"
+
+# want_args <expected, newline-joined> <label> <command> <regex>
+want_args() {
+  local want="$1" label="$2" cmd="$3" re="$4" got
+  got=$(gate_verb_args "$cmd" "$re")
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s\n  want: [%s]\n  got:  [%s]\n' "$label" "$want" "$got"
+  fi
+}
+
+want_args "-A"          "args after a bare add"        'git add -A' "$A"
+# The `-C /w/t` is consumed by the verb ERE, so it must NOT come back as an
+# argument -- that is the whole reason the strip is BASH_REMATCH[0] of the same
+# regex that armed the gate rather than a locally written prefix chop.
+want_args "-A"          "leading -C is absorbed"       'git -C /w/t add -A' "$A"
+want_args "src/a.ts"    "a pathspec"                   'git add src/a.ts && git commit -m x' "$A"
+want_args '"d i r"'     "a quoted pathspec stays whole" 'git add "d i r"' "$A"
+# One line per matching segment, so two adds in one call are both readable.
+want_args "-u
+docs" "two add segments"                              'git add -u; git add docs' "$A"
+want_args ""            "no matching segment"          'git commit -m x' "$A"
+want_args "-am x"       "commit args, for the -a scan" 'git commit -am x' "$C"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -838,20 +838,6 @@ want_match 0 "git -C <path> stage"           'git -C /w/t stage src' "$A"
 want_match 1 "git stash is not git stage"    'git stash push -m x' "$A"
 want_args "-A"          "args after git stage"         'git stage -A' "$A"
 
-# The removal verbs: `rm bad.ts && git add -A && git commit` is one call, so the
-# deletion exists only in the command text when the hook runs.
-RM="$GATE_RE_RM"
-GRM="$GATE_RE_GIT_RM"
-want_match 0 "bare rm"                       'rm bad.ts && git add -A && git commit -m x' "$RM"
-want_match 0 "rm -rf"                        'rm -rf dir && git commit -am x' "$RM"
-want_match 1 "rmdir is not rm"               'rmdir dir && git commit -m x' "$RM"
-want_match 1 "rm inside a string"            'echo "rm bad.ts"' "$RM"
-want_match 1 "git rm is not bare rm"         'git rm bad.ts' "$RM"
-want_match 0 "git rm"                        'git rm -f bad.ts && git commit -m x' "$GRM"
-want_match 0 "git -C <path> rm"              'git -C /w/t rm bad.ts' "$GRM"
-want_match 1 "bare rm is not git rm"         'rm bad.ts' "$GRM"
-want_args "-f bad.ts"   "args after git rm"                'git rm -f bad.ts && git commit -m x' "$GRM"
-want_args "-rf dir"     "args after rm, cd absorbed"       'cd /w/t && rm -rf dir' "$RM"
 
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -832,5 +832,26 @@ docs" "two add segments"                              'git add -u; git add docs'
 want_args ""            "no matching segment"          'git commit -m x' "$A"
 want_args "-am x"       "commit args, for the -a scan" 'git commit -am x' "$C"
 
+# `stage` is git's own alias for `add`, so the staging scan must reach it.
+want_match 0 "git stage -A"                  'git stage -A && git commit -m x' "$A"
+want_match 0 "git -C <path> stage"           'git -C /w/t stage src' "$A"
+want_match 1 "git stash is not git stage"    'git stash push -m x' "$A"
+want_args "-A"          "args after git stage"         'git stage -A' "$A"
+
+# The removal verbs: `rm bad.ts && git add -A && git commit` is one call, so the
+# deletion exists only in the command text when the hook runs.
+RM="$GATE_RE_RM"
+GRM="$GATE_RE_GIT_RM"
+want_match 0 "bare rm"                       'rm bad.ts && git add -A && git commit -m x' "$RM"
+want_match 0 "rm -rf"                        'rm -rf dir && git commit -am x' "$RM"
+want_match 1 "rmdir is not rm"               'rmdir dir && git commit -m x' "$RM"
+want_match 1 "rm inside a string"            'echo "rm bad.ts"' "$RM"
+want_match 1 "git rm is not bare rm"         'git rm bad.ts' "$RM"
+want_match 0 "git rm"                        'git rm -f bad.ts && git commit -m x' "$GRM"
+want_match 0 "git -C <path> rm"              'git -C /w/t rm bad.ts' "$GRM"
+want_match 1 "bare rm is not git rm"         'rm bad.ts' "$GRM"
+want_args "-f bad.ts"   "args after git rm"                'git rm -f bad.ts && git commit -m x' "$GRM"
+want_args "-rf dir"     "args after rm, cd absorbed"       'cd /w/t && rm -rf dir' "$RM"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/control-char-gate.sh
+++ b/.claude/hooks/control-char-gate.sh
@@ -23,25 +23,46 @@
 # review-gate security surface, where `grep` had been silently answering nothing
 # for every audit since.
 #
-# So the scan target is now read off the command:
+# So each candidate file is collected with its PROVENANCE, and provenance
+# decides which bytes are read:
 #
-#   plain `git commit`          the INDEX (`git show :<file>` over
-#                               `diff --cached --diff-filter=ACM`). Unchanged.
-#   ... `git add <spec>` ...    the index AS WELL AS the WORKING TREE content
-#                               that the add would bring in.
-#   `git commit -a` / `--all`   the index as well as the working-tree content of
-#                               TRACKED MODIFIED files. `-a` does NOT pick up
-#                               untracked files, and this does not either.
+#   INDEX candidate      the staged blob, `git show :<file>`, over
+#                        `diff --cached --diff-filter=ACM`. Always collected.
+#   WORKING-TREE cand.   the file on disk. Collected only when the command
+#                        itself stages, and only for what that staging covers.
+#
+# An index candidate is NEVER read off disk and a working-tree candidate is
+# NEVER read out of the index. That separation is what keeps a plain
+# `git commit` an index-only verdict -- a dirty worktree it is not committing
+# must not block it -- while `git add -A && git commit` sees the disk.
+#
+# Which commands stage, and what:
+#
+#   plain `git commit`                nothing. Index only.
+#   `… git add|stage <spec> …`        what that add covers (untracked included).
+#   `git commit -a` / `--all`         TRACKED MODIFICATIONS ONLY. `-a` does not
+#                                     pick up untracked files, and neither does
+#                                     this.
+#   `git commit [-o|-i|--] <spec>`    a pathspec on `git commit` is an implicit
+#                                     `--only`: it commits the WORKING-TREE
+#                                     content of those paths and ignores the
+#                                     index for them. Missing this was a
+#                                     straight fail-open -- `git commit -m x
+#                                     f.ts` shipped a NUL with the index clean.
+#
+# The index scan is still done ALONGSIDE the working-tree one rather than being
+# replaced by it: a file staged EARLIER and unmodified since is in the commit
+# but is not "modified" relative to the index, so `git ls-files --modified`
+# never lists it. The one exception is a path the staging will DELETE -- either
+# the file is already gone from disk, or THIS CALL is what removes it
+# (`rm bad.ts && git add -A && git commit`, where the hook still sees the file).
+# Its staged blob is on its way out of the tree, so blocking on it would wedge
+# the very remediation this gate's own message asks for.
 #
 # The working-tree scan is deliberately a SUPERSET of what the commit will
 # contain in the ambiguous cases: a false block costs one message and a re-run,
 # a false pass is the bug above. Each branch that has to guess says which way it
 # errs, in a comment beside it.
-#
-# The index scan is still done on top of the working-tree one rather than being
-# replaced by it: a file staged EARLIER and unmodified since is in the commit
-# but is not "modified" relative to the index, so `git ls-files --modified`
-# never lists it.
 #
 # Files with binary/asset extensions (images, fonts, archives, etc.)
 # legitimately contain control bytes and are skipped, on both scans.
@@ -52,6 +73,14 @@
 # `git add` segment gets the same resolution against its OWN `-C` / `cd`, so
 # `cd /w/t && git add -A && git commit` and `git -C /w/t add -A && git -C /w/t
 # commit` both land on /w/t.
+#
+# UNRESTRICTED STAGING IS SCANNED FROM THE REPO ROOT, not from that directory.
+# `git ls-files` lists only what is under the CWD, while `git add -A` and
+# `git commit -a` have been WHOLE-TREE since git 2.0 -- so running the scan in a
+# subdirectory used to miss a control byte anywhere else in the repository, a
+# fail-open of exactly the same class as the one above. A pathspec-RESTRICTED
+# scan still runs in the command's own directory, because that is what its
+# pathspecs are relative to.
 #
 # Fails open (exit 0) when git / perl are unavailable, or when neither scan
 # finds any candidate file (a clean tree) -- a safety net must never wedge an
@@ -132,7 +161,21 @@ wt_all_paths=0
 wt_force=0
 wt_paths=""
 
-# --- `git add` in the same call ------------------------------------------
+# gate_cc_take_next -- drop the next token from the named argument string.
+# Used where a flag's value is a SEPARATE token, so the value is never mistaken
+# for a pathspec (`git commit -m x f.ts`: `x` is the message, `f.ts` is not).
+gate_cc_take_next() {
+  local _v="$1" _s
+  # `${!_v}` to READ and `printf -v` to WRITE: neither ever hands the argument
+  # text to `eval`, so a message body containing quotes, backticks or a `$(...)`
+  # is data here and stays data.
+  _s="${!_v}"
+  if [[ "$_s" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; then
+    printf -v "$_v" '%s' "${BASH_REMATCH[3]}"
+  fi
+}
+
+# --- `git add` / `git stage` in the same call ----------------------------
 while IFS= read -r add_args; do
   wt_scan=1
   seen_pathspec=0
@@ -157,13 +200,23 @@ while IFS= read -r add_args; do
         #   -p / -i   the human picks hunks / paths interactively
         #   --pathspec-from-file  the pathspecs are in a file, and reading it
         #                         here would be guessing at the shell's cwd
-        -p|--patch|-i|--interactive|--pathspec-from-file|--pathspec-from-file=*)
-          wt_all_paths=1; continue ;;
-        # Every other `-…`. ERRS BROAD in the one way it can be wrong: `git
-        # add`'s remaining flags are valueless, so treating an unknown one as
-        # valueless is right; if a future flag does take a value, that value is
-        # read as an extra pathspec, which only ever ADDS files to the scan.
-        -*) continue ;;
+        -p|--patch|-i|--interactive) wt_all_paths=1; continue ;;
+        --pathspec-from-file) wt_all_paths=1; gate_cc_take_next add_args; continue ;;
+        --pathspec-from-file=*) wt_all_paths=1; continue ;;
+        # The flags `git add` accepts that take NO value. Enumerated rather than
+        # inferred, so that the default below can be the safe one.
+        -n|--dry-run|--no-dry-run|-v|--verbose|--no-verbose|-e|--edit|-N \
+        |--intent-to-add|--sparse|--renormalize|--ignore-errors|--ignore-missing \
+        |--refresh|--ignore-removal|--no-all|--no-warn-embedded-repo|--chmod=*)
+          continue ;;
+        # Any `--flag=value` carries its value inside the token.
+        --*=*) continue ;;
+        # An UNKNOWN flag. ERRS BROAD: it may take a separate value, and the
+        # earlier "treat it as valueless" reading was a FAIL-OPEN, not a widen --
+        # the value became a pathspec, which also set `seen_pathspec` and so
+        # SUPPRESSED the whole-tree fallback. Measured: `git add --future-flag
+        # somevalue && git commit -m x` returned 0 with an untracked NUL present.
+        -*) wt_all_paths=1; continue ;;
       esac
     fi
     # A positional: a pathspec.
@@ -182,72 +235,194 @@ while IFS= read -r add_args; do
   [ "$seen_pathspec" -eq 0 ] && wt_all_paths=1
 done < <(gate_verb_args "$cmd" "$GATE_RE_GIT_ADD")
 
-# --- `git commit -a` / `--all` -------------------------------------------
+# --- `git commit` itself: `-a`, and its PATHSPECS ------------------------
 # `-a` stages TRACKED MODIFICATIONS ONLY. It never picks up an untracked file,
-# so this branch leaves wt_untracked alone; getting that wrong in either
-# direction is a real defect, not a rounding error.
+# so that branch leaves wt_untracked alone; getting it wrong in either direction
+# is a real defect, not a rounding error.
+#
+# A POSITIONAL on `git commit` is an implicit `--only`: `git commit -m x f.ts`
+# commits the WORKING-TREE content of f.ts and ignores the index for it. So the
+# arguments have to be walked properly rather than skimmed for flags -- which
+# means knowing which flags take a SEPARATE value, or `-m`'s message text would
+# read as a pathspec and `f.ts` would never be seen.
 while IFS= read -r commit_args; do
   end_of_flags=0
+  seen_pathspec=0
+  takes_paths=0
   while [ -n "${commit_args// /}" ] && [[ "$commit_args" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
     tok="${BASH_REMATCH[1]}"
     commit_args="${BASH_REMATCH[3]}"
     [ -n "$tok" ] || break
-    [ "$end_of_flags" -eq 1 ] && continue
-    case "$tok" in
-      --) end_of_flags=1 ;;
-      # EXACT match only. `--amend`, `--allow-empty` and `--author` all start
-      # with `--a` and none of them stages anything.
-      --all) wt_scan=1; wt_all_paths=1 ;;
-      --*) ;;
-      -[A-Za-z]*)
-        # A short-flag CLUSTER: `-am "msg"` is `-a -m msg`. Walk it left to
-        # right and STOP at the first value-taking short flag, because what
-        # follows is that flag's value, not more flags -- `-Fa` is `-F a`, a
-        # message FILE named `a`, and reading its `a` as `--all` would be a
-        # false widen.
-        rest="${tok#-}"
-        while [ -n "$rest" ]; do
-          ch="${rest%"${rest#?}"}"
-          rest="${rest#?}"
-          case "$ch" in
-            a) wt_scan=1; wt_all_paths=1; break ;;
-            m|C|c|F|S|u|t) break ;;
-            *) ;;
-          esac
-        done
-        ;;
-      *) ;;
-    esac
+    if [ "$end_of_flags" -eq 0 ]; then
+      case "$tok" in
+        --) end_of_flags=1; continue ;;
+        # EXACT match only. `--amend`, `--allow-empty` and `--author` all start
+        # with `--a` and none of them stages anything.
+        --all) wt_scan=1; wt_all_paths=1; continue ;;
+        # These say "this commit takes pathspecs" without being one.
+        --only|--include) takes_paths=1; continue ;;
+        # ERRS BROAD, same reasoning as the add loop: the content is chosen
+        # interactively / listed in a file, so it cannot be computed here.
+        --patch|--interactive) wt_scan=1; wt_all_paths=1; continue ;;
+        --pathspec-from-file) wt_scan=1; wt_all_paths=1; gate_cc_take_next commit_args; continue ;;
+        --pathspec-from-file=*) wt_scan=1; wt_all_paths=1; continue ;;
+        # Long flags whose value is a SEPARATE token. Skipping the value is what
+        # stops `--author "A <a@b>"` from being read as a pathspec.
+        --message|--file|--reuse-message|--reedit-message|--fixup|--squash \
+        |--author|--date|--template|--cleanup|--trailer)
+          gate_cc_take_next commit_args; continue ;;
+        # `--flag=value` carries its value; every other long flag is valueless.
+        --*) continue ;;
+        -[A-Za-z]*)
+          # A short-flag CLUSTER: `-am "msg"` is `-a -m msg`. Walk it left to
+          # right, because a value-taking short flag ENDS the cluster -- what
+          # follows is its value. `-Fa` is `-F a`, a message FILE named `a`, and
+          # reading its `a` as `--all` would be a false widen.
+          rest="${tok#-}"
+          while [ -n "$rest" ]; do
+            ch="${rest%"${rest#?}"}"
+            rest="${rest#?}"
+            case "$ch" in
+              a) wt_scan=1; wt_all_paths=1 ;;
+              o|i) takes_paths=1 ;;
+              p) wt_scan=1; wt_all_paths=1 ;;
+              # Value is the rest of the cluster, or -- if the cluster ends
+              # here -- the NEXT TOKEN. Consuming it is what makes
+              # `git commit -m x f.ts` see `f.ts` and not `x`.
+              m|C|c|F|t)
+                [ -z "$rest" ] && gate_cc_take_next commit_args
+                rest="" ;;
+              # `-S` / `-u` take an OPTIONAL value that git only accepts GLUED
+              # (`-uall`, `-Skeyid`), never as a separate token. Ending the
+              # cluster here stops `-uall`'s `a` from reading as `--all`.
+              u|S) rest="" ;;
+              *) ;;
+            esac
+          done
+          continue ;;
+        -*) continue ;;
+      esac
+    fi
+    # A positional on `git commit`: an implicit `--only` pathspec, whose content
+    # comes from the WORKING TREE.
+    tok=$(gate_unquote "$tok")
+    case "$tok" in *'$'*|*'`'*) wt_scan=1; wt_all_paths=1; seen_pathspec=1; continue ;; esac
+    [ -n "$tok" ] || continue
+    wt_scan=1
+    seen_pathspec=1
+    wt_paths="$wt_paths$tok
+"
   done
+  # `-o` / `-i` with no pathspec of its own. ERRS BROAD rather than guessing at
+  # what it scopes to.
+  if [ "$takes_paths" -eq 1 ] && [ "$seen_pathspec" -eq 0 ]; then
+    wt_scan=1; wt_all_paths=1
+  fi
 done < <(gate_verb_args "$cmd" "$GATE_RE_GIT_COMMIT")
 
-# ---------------------------------------------------------------------------
-# Collect the files to scan.
-# ---------------------------------------------------------------------------
-# Two parallel arrays rather than one array of "dir:path" strings: a path may
-# contain a colon.
-scan_dir=()
-scan_path=()
+# A staging scan with nothing to scope it is a whole-tree scan; without this the
+# `--`-less `-o` shapes would reach `ls-files --` with an empty pathspec list.
+if [ "$wt_scan" -eq 1 ] && [ "$wt_all_paths" -eq 0 ] && [ -z "$wt_paths" ]; then
+  wt_all_paths=1
+fi
 
-collect_index() {
-  local dir="$1" f
-  while IFS= read -r -d '' f; do
-    [ -n "$f" ] || continue
-    scan_dir[${#scan_dir[@]}]="$dir"
-    scan_path[${#scan_path[@]}]="$f"
-  done < <(
-    git -C "$dir" diff --cached --name-only --diff-filter=ACM -z 2>/dev/null || true
-  )
+# ---------------------------------------------------------------------------
+# Paths this same call REMOVES.
+# ---------------------------------------------------------------------------
+# `rm bad.ts && git add -A && git commit -m drop-it` is one Bash call, so at hook
+# time bad.ts is still on disk with its control byte, while the commit that call
+# produces does not contain the file at all. Blocking there wedges the exact
+# remediation this gate's own message asks for. The deletion is only visible in
+# the COMMAND before it runs -- the same place the staging had to be read from.
+#
+# Recorded as root-relative keys, and ONLY consulted for INDEX candidates: a
+# working-tree candidate that is being removed already reads as "no file on
+# disk" and is skipped on its own.
+removed_keys="
+"
+
+# gate_cc_collect_removals <verb-ere> <is-git-rm>
+# Resolve each removal segment's positional paths to root-relative names by
+# asking GIT to match them (`ls-files --cached -- <path>`), rather than doing
+# path arithmetic here: git owns pathspec semantics, handles a directory
+# argument, and normalises `/var` vs `/private/var` for free.
+gate_cc_collect_removals() {
+  local re="$1" is_git="$2" seg_args dir root tok cached f end_of_flags skip_seg
+  dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$re")
+  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)
+  [ -n "$root" ] || return 0
+  while IFS= read -r seg_args; do
+    end_of_flags=0
+    skip_seg=0
+    # `git rm --cached` un-tracks WITHOUT deleting, and a following `git add -A`
+    # would re-add the file. Not a removal; the whole segment is ignored.
+    if [ "$is_git" = "1" ]; then
+      case " $seg_args " in *" --cached "*) skip_seg=1 ;; esac
+    fi
+    [ "$skip_seg" -eq 1 ] && continue
+    while [ -n "${seg_args// /}" ] && [[ "$seg_args" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
+      tok="${BASH_REMATCH[1]}"
+      seg_args="${BASH_REMATCH[3]}"
+      [ -n "$tok" ] || break
+      if [ "$end_of_flags" -eq 0 ]; then
+        case "$tok" in
+          --) end_of_flags=1; continue ;;
+          -*) continue ;;
+        esac
+      fi
+      tok=$(gate_unquote "$tok")
+      [ -n "$tok" ] || continue
+      # ERRS TOWARD BLOCKING: an unrecognised removal is simply not recorded, so
+      # the index candidate keeps its scan. That is the safe direction here --
+      # unlike everywhere else in this file, a wrong entry in THIS list
+      # SUPPRESSES a scan.
+      #   $ / `   an unexpanded path is not a path.
+      #   * ? [   a GLOB, and git's pathspec language is BROADER than the
+      #           shell's: the shell expands `rm *.ts` against the CWD only,
+      #           while `ls-files -- '*.ts'` matches every .ts in the repository
+      #           and would suppress the scan of files the `rm` never touches.
+      case "$tok" in *'$'*|*'`'*|*'*'*|*'?'*|*'['*) continue ;; esac
+      while IFS= read -r -d '' f; do
+        [ -n "$f" ] || continue
+        removed_keys="$removed_keys$root/$f
+"
+      done < <(git -C "$dir" ls-files --full-name --cached -z -- "$tok" 2>/dev/null || true)
+    done
+  done < <(gate_verb_args "$cmd" "$re")
 }
 
+# `git rm` STAGES the removal itself, so it counts whatever else the call does.
+gate_cc_collect_removals "$GATE_RE_GIT_RM" 1
+# A plain `rm` only touches the disk; something else has to stage the deletion,
+# and only a WHOLE-TREE staging (`git add -A` / `-u` / `git commit -a`) is
+# certain to cover it. Under a pathspec-restricted staging the deletion may not
+# be staged at all, and a wrong skip here is a FAIL-OPEN, so that case
+# deliberately keeps the index scan.
+if [ "$wt_scan" -eq 1 ] && [ "$wt_all_paths" -eq 1 ]; then
+  gate_cc_collect_removals "$GATE_RE_RM" 0
+fi
+
+# ---------------------------------------------------------------------------
+# Collect the candidate files, each with its provenance.
+# ---------------------------------------------------------------------------
+# Three parallel arrays rather than one array of joined strings: a path may
+# contain any separator character one might pick.
+scan_kind=()   # I = staged blob, W = working-tree file
+scan_root=()   # repo root, so every path below is root-relative
+scan_path=()
+# The root-relative keys the WORKING-TREE scan covers, newline-delimited. Used
+# to spot a path the staging is DELETING.
+wt_keys="
+"
+
 collect_worktree() {
-  local dir="$1" root f
+  local dir="$1" root f run_in
   root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)
   # Not a repo (or git refused): nothing to add. The index scan handles the same
   # case the same way, and this is the pre-existing fail-open shape.
   [ -n "$root" ] || return 0
-  # `--full-name` so the paths are relative to the repo root and can be read
-  # back without depending on which subdirectory the add would have run in.
+  # `--full-name` so paths come back relative to the repo ROOT and can be read
+  # without depending on which subdirectory the command ran in.
   local args=(ls-files -z --full-name --modified)
   [ "$wt_untracked" -eq 1 ] && args=("${args[@]}" --others)
   # `--exclude-standard` keeps gitignored files out. It is dropped ONLY when a
@@ -258,7 +433,15 @@ collect_worktree() {
   if [ "$wt_force" -eq 0 ] || [ "$wt_all_paths" -eq 1 ]; then
     args=("${args[@]}" --exclude-standard)
   fi
+  # WHERE the listing runs is the difference between whole-tree and
+  # subtree-only, because `git ls-files` lists what is under its CWD:
+  #   unrestricted -> the repo ROOT, because `git add -A` / `git commit -a` are
+  #                   whole-tree regardless of where they were typed.
+  #   restricted   -> the command's OWN directory, because that is what its
+  #                   pathspecs are relative to.
+  run_in="$root"
   if [ "$wt_all_paths" -eq 0 ] && [ -n "$wt_paths" ]; then
+    run_in="$dir"
     args=("${args[@]}" --)
     while IFS= read -r f; do
       [ -n "$f" ] && args=("${args[@]}" "$f")
@@ -266,13 +449,33 @@ collect_worktree() {
   fi
   while IFS= read -r -d '' f; do
     [ -n "$f" ] || continue
-    scan_dir[${#scan_dir[@]}]="$root"
+    scan_kind[${#scan_kind[@]}]="W"
+    scan_root[${#scan_root[@]}]="$root"
     scan_path[${#scan_path[@]}]="$f"
-  done < <(git -C "$dir" "${args[@]}" 2>/dev/null || true)
+    wt_keys="$wt_keys$root/$f
+"
+  done < <(git -C "$run_in" "${args[@]}" 2>/dev/null || true)
 }
 
-collect_index "$commit_dir"
+collect_index() {
+  local dir="$1" root f
+  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)
+  [ -n "$root" ] || return 0
+  # Run from the ROOT so the names are root-relative and `git show :<path>` can
+  # be read back from the same place. `git diff --cached` is not CWD-scoped, so
+  # this changes the NAMES, never the SET.
+  while IFS= read -r -d '' f; do
+    [ -n "$f" ] || continue
+    scan_kind[${#scan_kind[@]}]="I"
+    scan_root[${#scan_root[@]}]="$root"
+    scan_path[${#scan_path[@]}]="$f"
+  done < <(
+    git -C "$root" diff --cached --name-only --diff-filter=ACM -z 2>/dev/null || true
+  )
+}
 
+# Worktree first, so `wt_keys` is complete before the index entries are filtered
+# against it.
 if [ "$wt_scan" -eq 1 ]; then
   # The `git add` may carry its OWN `-C` / follow its own `cd`, so it is
   # resolved against its own verb regex. Both directories are scanned when they
@@ -282,6 +485,7 @@ if [ "$wt_scan" -eq 1 ]; then
   collect_worktree "$commit_dir"
   [ -n "$add_dir" ] && [ "$add_dir" != "$commit_dir" ] && collect_worktree "$add_dir"
 fi
+collect_index "$commit_dir"
 
 [ ${#scan_path[@]} -eq 0 ] && exit 0
 
@@ -290,17 +494,17 @@ binary_ext_re='\.(png|jpe?g|gif|webp|bmp|ico|icns|pdf|woff2?|ttf|otf|eot|zip|gz|
 
 # The C0 scan itself. Line-oriented (not `-0777`) so the reported line numbers
 # are useful; a control byte never spans a line.
-c0_lines() {
-  LC_ALL=C perl -ne 'print "$.\n" if /[\x00-\x08\x0B\x0C\x0E-\x1F]/' 2>/dev/null \
-    | head -3 | paste -sd, -
-}
+C0_RE='print "$.\n" if /[\x00-\x08\x0B\x0C\x0E-\x1F]/'
 
 offenders=()
-seen="
+seen_scan="
+"
+seen_offender="
 "
 i=0
 while [ "$i" -lt ${#scan_path[@]} ]; do
-  d="${scan_dir[$i]}"
+  kind="${scan_kind[$i]}"
+  root="${scan_root[$i]}"
   f="${scan_path[$i]}"
   i=$((i + 1))
   [ -n "$f" ] || continue
@@ -310,29 +514,70 @@ while [ "$i" -lt ${#scan_path[@]} ]; do
     continue
   fi
   shopt -u nocasematch
-  # Both scans can name the same file (staged AND modified since); report once.
-  key="$d/$f"
-  case "$seen" in
+  key="$root/$f"
+  # Dedupe per (provenance, path), so a file that is BOTH a staged blob and a
+  # working copy is read on both sides rather than only the first.
+  #
+  # HONESTLY: with the working-tree pass collected first, a path-only key is
+  # behaviourally equivalent on every shape the suite could construct -- a
+  # mutation to a path-only key stays green, and that is recorded rather than
+  # papered over with an invented case. It is kept as (provenance, path) because
+  # the equivalence rests entirely on that collection ORDER, which nothing else
+  # here depends on; the pair key is free and does not.
+  case "$seen_scan" in
     *"
-$key
+$kind $key
 "*) continue ;;
   esac
-  seen="$seen$key
+  seen_scan="$seen_scan$kind $key
 "
   lines=""
-  if [ -f "$d/$f" ] && [ ! -L "$d/$f" ]; then
-    # The WORKING-TREE content: this is the half that plain `git show :<f>`
-    # could not see before a `git add` had run. Symlinks are skipped -- git
-    # stages the link TARGET PATH as the blob, not the pointee's bytes, so
-    # following the link would scan a file the commit does not contain.
-    lines=$(LC_ALL=C perl -ne 'print "$.\n" if /[\x00-\x08\x0B\x0C\x0E-\x1F]/' "$d/$f" 2>/dev/null | head -3 | paste -sd, -)
-  fi
-  if [ -z "$lines" ]; then
-    # The STAGED blob. Scanned even when the worktree copy was clean: the two
-    # can differ, and it is the staged side that gets committed.
-    lines=$(git -C "$d" show ":$f" 2>/dev/null | c0_lines)
+  if [ "$kind" = "W" ]; then
+    # WORKING-TREE content: the half a plain `git show :<f>` could not see
+    # before the `git add` had run. A path listed here but MISSING from disk is
+    # a DELETION being staged -- there is no content to scan, and nothing to
+    # report. Symlinks are skipped too: git stages the link TARGET PATH as the
+    # blob, not the pointee's bytes, so following the link would scan a file the
+    # commit does not contain.
+    if [ -f "$key" ] && [ ! -L "$key" ]; then
+      lines=$(LC_ALL=C perl -ne "$C0_RE" "$key" 2>/dev/null | head -3 | paste -sd, -)
+    fi
+  else
+    # STAGED blob. Read ONLY out of the index -- never off disk, so a dirty
+    # working copy cannot block a `git commit` that is not committing it.
+    #
+    # ...unless the staging in this same call is REMOVING the path: the file is
+    # gone from disk and the same path is a working-tree candidate, so the blob
+    # is on its way out of the tree. Blocking there would wedge the remediation
+    # this gate's own message asks for (`rm bad.ts && git add -A && git commit`
+    # would be refused, for a file that no longer exists).
+    skip_removed=0
+    # Already gone from disk, and the staging covers it: the blob is on its way
+    # out of the tree.
+    case "$wt_keys" in
+      *"
+$key
+"*) [ -e "$key" ] || skip_removed=1 ;;
+    esac
+    # ...or this same call is what removes it, before the commit runs.
+    case "$removed_keys" in
+      *"
+$key
+"*) skip_removed=1 ;;
+    esac
+    if [ "$skip_removed" -eq 0 ]; then
+      lines=$(git -C "$root" show ":$f" 2>/dev/null | LC_ALL=C perl -ne "$C0_RE" 2>/dev/null | head -3 | paste -sd, -)
+    fi
   fi
   if [ -n "$lines" ]; then
+    # One report line per FILE, even when both provenances flagged it.
+    case "$seen_offender" in
+      *"
+$key
+"*) continue ;;
+    esac
+    seen_offender="$seen_offender$key
+"
     offenders[${#offenders[@]}]="$f (line(s): $lines)"
   fi
 done

--- a/.claude/hooks/control-char-gate.sh
+++ b/.claude/hooks/control-char-gate.sh
@@ -1,35 +1,73 @@
 #!/usr/bin/env bash
 # control-char-gate.sh
 #
-# PreToolUse hook. Blocks `git commit` when a staged text file contains a
-# NUL (\x00) or any other C0 control byte other than tab (\x09), newline
+# PreToolUse hook. Blocks `git commit` when a text file the commit will contain
+# has a NUL (\x00) or any other C0 control byte other than tab (\x09), newline
 # (\x0A), or carriage return (\x0D).
 #
 # WHY: an editing artifact can land a raw control byte inside a source file
 # (e.g. a template-literal separator that was meant to be a space ending up
 # as a literal \x00). The formatter / linter does not flag it, but it breaks
 # `grep` (which then treats the file as binary and silently suppresses
-# matches), `diff`, and anything that assumes clean text — and it ships in
+# matches), `diff`, and anything that assumes clean text -- and it ships in
 # the committed source. This gate catches it at commit time.
 #
-# Scans the STAGED BLOB (`git show :<file>`) of every added/modified file,
-# not the diff: a NUL makes `git diff` report "Binary files differ" and hide
-# the added lines, so a diff-only scan would miss exactly the case we care
-# about. Files with binary/asset extensions (images, fonts, archives, etc.)
-# legitimately contain control bytes and are skipped.
+# WHAT IS SCANNED, and why it is decided from the COMMAND (go-to-k/cdk-local#576).
+#
+# The first version scanned the STAGED BLOB (`git show :<file>`) only. A
+# PreToolUse hook runs BEFORE the command it gates, so a single Bash call of the
+# shape `git add -A && git commit -F msg` presented the gate with the tree as it
+# was BEFORE `git add` ran: nothing was staged for the offending file, the gate
+# found nothing, and the control byte shipped. It happened -- two NUL bytes
+# reached `src/local/front-door-server.ts` on main that way, in a file on the
+# review-gate security surface, where `grep` had been silently answering nothing
+# for every audit since.
+#
+# So the scan target is now read off the command:
+#
+#   plain `git commit`          the INDEX (`git show :<file>` over
+#                               `diff --cached --diff-filter=ACM`). Unchanged.
+#   ... `git add <spec>` ...    the index AS WELL AS the WORKING TREE content
+#                               that the add would bring in.
+#   `git commit -a` / `--all`   the index as well as the working-tree content of
+#                               TRACKED MODIFIED files. `-a` does NOT pick up
+#                               untracked files, and this does not either.
+#
+# The working-tree scan is deliberately a SUPERSET of what the commit will
+# contain in the ambiguous cases: a false block costs one message and a re-run,
+# a false pass is the bug above. Each branch that has to guess says which way it
+# errs, in a comment beside it.
+#
+# The index scan is still done on top of the working-tree one rather than being
+# replaced by it: a file staged EARLIER and unmodified since is in the commit
+# but is not "modified" relative to the index, so `git ls-files --modified`
+# never lists it.
+#
+# Files with binary/asset extensions (images, fonts, archives, etc.)
+# legitimately contain control bytes and are skipped, on both scans.
 #
 # Cwd-aware via the shared `gate_target_dir`: resolves the working tree the
 # commit will actually act on from the matched segment's `git -C <path>` > the
-# last preceding `cd <path>` > the hook payload's `cwd` > its own $PWD.
+# last preceding `cd <path>` > the hook payload's `cwd` > its own $PWD. The
+# `git add` segment gets the same resolution against its OWN `-C` / `cd`, so
+# `cd /w/t && git add -A && git commit` and `git -C /w/t add -A && git -C /w/t
+# commit` both land on /w/t.
 #
-# Fails open (exit 0) when git / perl are unavailable or nothing is staged —
-# a safety net must never wedge an otherwise-valid commit.
+# Fails open (exit 0) when git / perl are unavailable, or when neither scan
+# finds any candidate file (a clean tree) -- a safety net must never wedge an
+# otherwise-valid commit. It does NOT fail open on a shape it cannot parse;
+# those widen the scan instead.
+#
+# Written to bash 3.2 (no `mapfile`, no `declare -A`): the shipped hook runs
+# under whatever bash the user has, and on macOS `/bin/bash` is still 3.2, where
+# `mapfile -d ''` was "command not found" and the gate exited 1 having scanned
+# nothing at all.
 
 set -u
 
 # Shared, segment-aware command matching (go-to-k/cdk-local#541). Sourcing it
-# gives this gate `gate_matches`, `gate_target_dir`, and the GATE_RE_* verb
-# regexes every gate now spells the same way.
+# gives this gate `gate_matches`, `gate_target_dir`, `gate_verb_args`, and the
+# GATE_RE_* verb regexes every gate now spells the same way.
 # Fail CLOSED if the shared matcher is missing or does not load: a gate that
 # cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
 # first shape here, and it silently disabled the gate whenever the library was
@@ -45,6 +83,14 @@ fi
 . "$_gate_lib"
 if ! declare -F gate_matches >/dev/null 2>&1; then
   echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
+# `gate_verb_args` is what reads `git add`'s pathspecs off the matched segment.
+# A library predating it would leave the staging scan silently absent -- exactly
+# the false pass go-to-k/cdk-local#576 is about -- so it is checked by name
+# rather than left to an unbound-command exit.
+if ! declare -F gate_verb_args >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_verb_args is undefined (older copy?)." >&2
   exit 2
 fi
 
@@ -68,51 +114,239 @@ command -v perl >/dev/null 2>&1 || exit 0
 # Where the gated command will actually run: a `-C <path>` inside the MATCHED
 # segment wins, else the last `cd <path>` segment before it, else the hook
 # payload's cwd (see gate_target_dir in _command-match.sh).
-target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_COMMIT")
+commit_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_COMMIT")
 
-# Staged added/modified files (NUL-delimited, so paths with spaces / newlines
-# are handled). Renames/copies/deletes are excluded — D has no content, and
-# the added side of R/C shows up as its own ACM entry when content changed.
-mapfile -d '' -t staged < <(
-  git -C "$target_dir" diff --cached --name-only --diff-filter=ACM -z 2>/dev/null || true
-)
-[[ ${#staged[@]} -eq 0 ]] && exit 0
+# ---------------------------------------------------------------------------
+# Decide, FROM THE COMMAND, whether this call also stages -- and what.
+# ---------------------------------------------------------------------------
+# wt_scan        1 when a working-tree scan is needed at all
+# wt_untracked   1 when it must include untracked files (`git add` does,
+#                `git commit -a` does NOT)
+# wt_all_paths   1 when the staging is not restricted to a pathspec
+# wt_force       1 when `git add -f` may reach gitignored files
+# wt_paths       the pathspecs, newline-separated (a pathspec containing a
+#                newline is not expressible on a command line anyway)
+wt_scan=0
+wt_untracked=0
+wt_all_paths=0
+wt_force=0
+wt_paths=""
+
+# --- `git add` in the same call ------------------------------------------
+while IFS= read -r add_args; do
+  wt_scan=1
+  seen_pathspec=0
+  this_untracked=1   # a bare `git add <spec>` stages untracked files under it
+  end_of_flags=0
+  while [ -n "${add_args// /}" ] && [[ "$add_args" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
+    tok="${BASH_REMATCH[1]}"
+    add_args="${BASH_REMATCH[3]}"
+    [ -n "$tok" ] || break
+    if [ "$end_of_flags" -eq 0 ]; then
+      case "$tok" in
+        --) end_of_flags=1; continue ;;
+        -A|--all|--no-ignore-removal) this_untracked=1; continue ;;
+        # `-u` stages tracked modifications only. Recorded as such rather than
+        # widened to untracked: `git add -u` genuinely cannot introduce an
+        # untracked file, and a sibling `git add -A` in the same call sets the
+        # flag for everyone anyway.
+        -u|--update) this_untracked=0; continue ;;
+        -f|--force) wt_force=1; continue ;;
+        # Shapes whose staged set this gate cannot compute. ERRS BROAD: the
+        # pathspec restriction is dropped and the whole tree is scanned.
+        #   -p / -i   the human picks hunks / paths interactively
+        #   --pathspec-from-file  the pathspecs are in a file, and reading it
+        #                         here would be guessing at the shell's cwd
+        -p|--patch|-i|--interactive|--pathspec-from-file|--pathspec-from-file=*)
+          wt_all_paths=1; continue ;;
+        # Every other `-…`. ERRS BROAD in the one way it can be wrong: `git
+        # add`'s remaining flags are valueless, so treating an unknown one as
+        # valueless is right; if a future flag does take a value, that value is
+        # read as an extra pathspec, which only ever ADDS files to the scan.
+        -*) continue ;;
+      esac
+    fi
+    # A positional: a pathspec.
+    tok=$(gate_unquote "$tok")
+    # An UNEXPANDED path is not a path (`git add "$FILE"`). ERRS BROAD: rather
+    # than scanning a literal `$FILE` that matches nothing, drop the restriction
+    # and scan the whole tree.
+    case "$tok" in *'$'*|*'`'*) wt_all_paths=1; seen_pathspec=1; continue ;; esac
+    [ -n "$tok" ] || continue
+    seen_pathspec=1
+    wt_paths="$wt_paths$tok
+"
+  done
+  [ "$this_untracked" -eq 1 ] && wt_untracked=1
+  # `git add -A` / `git add -u` with no pathspec is the whole tree.
+  [ "$seen_pathspec" -eq 0 ] && wt_all_paths=1
+done < <(gate_verb_args "$cmd" "$GATE_RE_GIT_ADD")
+
+# --- `git commit -a` / `--all` -------------------------------------------
+# `-a` stages TRACKED MODIFICATIONS ONLY. It never picks up an untracked file,
+# so this branch leaves wt_untracked alone; getting that wrong in either
+# direction is a real defect, not a rounding error.
+while IFS= read -r commit_args; do
+  end_of_flags=0
+  while [ -n "${commit_args// /}" ] && [[ "$commit_args" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
+    tok="${BASH_REMATCH[1]}"
+    commit_args="${BASH_REMATCH[3]}"
+    [ -n "$tok" ] || break
+    [ "$end_of_flags" -eq 1 ] && continue
+    case "$tok" in
+      --) end_of_flags=1 ;;
+      # EXACT match only. `--amend`, `--allow-empty` and `--author` all start
+      # with `--a` and none of them stages anything.
+      --all) wt_scan=1; wt_all_paths=1 ;;
+      --*) ;;
+      -[A-Za-z]*)
+        # A short-flag CLUSTER: `-am "msg"` is `-a -m msg`. Walk it left to
+        # right and STOP at the first value-taking short flag, because what
+        # follows is that flag's value, not more flags -- `-Fa` is `-F a`, a
+        # message FILE named `a`, and reading its `a` as `--all` would be a
+        # false widen.
+        rest="${tok#-}"
+        while [ -n "$rest" ]; do
+          ch="${rest%"${rest#?}"}"
+          rest="${rest#?}"
+          case "$ch" in
+            a) wt_scan=1; wt_all_paths=1; break ;;
+            m|C|c|F|S|u|t) break ;;
+            *) ;;
+          esac
+        done
+        ;;
+      *) ;;
+    esac
+  done
+done < <(gate_verb_args "$cmd" "$GATE_RE_GIT_COMMIT")
+
+# ---------------------------------------------------------------------------
+# Collect the files to scan.
+# ---------------------------------------------------------------------------
+# Two parallel arrays rather than one array of "dir:path" strings: a path may
+# contain a colon.
+scan_dir=()
+scan_path=()
+
+collect_index() {
+  local dir="$1" f
+  while IFS= read -r -d '' f; do
+    [ -n "$f" ] || continue
+    scan_dir[${#scan_dir[@]}]="$dir"
+    scan_path[${#scan_path[@]}]="$f"
+  done < <(
+    git -C "$dir" diff --cached --name-only --diff-filter=ACM -z 2>/dev/null || true
+  )
+}
+
+collect_worktree() {
+  local dir="$1" root f
+  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)
+  # Not a repo (or git refused): nothing to add. The index scan handles the same
+  # case the same way, and this is the pre-existing fail-open shape.
+  [ -n "$root" ] || return 0
+  # `--full-name` so the paths are relative to the repo root and can be read
+  # back without depending on which subdirectory the add would have run in.
+  local args=(ls-files -z --full-name --modified)
+  [ "$wt_untracked" -eq 1 ] && args=("${args[@]}" --others)
+  # `--exclude-standard` keeps gitignored files out. It is dropped ONLY when a
+  # `git add -f` is bounded by a pathspec: `-f` really can stage an ignored
+  # file, but an UNBOUNDED scan of every ignored path (node_modules, dist, the
+  # build cache) would make the gate itself the slowest thing in the commit.
+  # ERRS NARROW, knowingly, and only for `git add -f` with no pathspec.
+  if [ "$wt_force" -eq 0 ] || [ "$wt_all_paths" -eq 1 ]; then
+    args=("${args[@]}" --exclude-standard)
+  fi
+  if [ "$wt_all_paths" -eq 0 ] && [ -n "$wt_paths" ]; then
+    args=("${args[@]}" --)
+    while IFS= read -r f; do
+      [ -n "$f" ] && args=("${args[@]}" "$f")
+    done <<< "$wt_paths"
+  fi
+  while IFS= read -r -d '' f; do
+    [ -n "$f" ] || continue
+    scan_dir[${#scan_dir[@]}]="$root"
+    scan_path[${#scan_path[@]}]="$f"
+  done < <(git -C "$dir" "${args[@]}" 2>/dev/null || true)
+}
+
+collect_index "$commit_dir"
+
+if [ "$wt_scan" -eq 1 ]; then
+  # The `git add` may carry its OWN `-C` / follow its own `cd`, so it is
+  # resolved against its own verb regex. Both directories are scanned when they
+  # differ -- ERRS BROAD, and it is what covers `git -C /a add -A && git -C /b
+  # commit` as well as the ordinary same-directory call.
+  add_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_ADD")
+  collect_worktree "$commit_dir"
+  [ -n "$add_dir" ] && [ "$add_dir" != "$commit_dir" ] && collect_worktree "$add_dir"
+fi
+
+[ ${#scan_path[@]} -eq 0 ] && exit 0
 
 # Extensions whose blobs legitimately contain control bytes — never scanned.
 binary_ext_re='\.(png|jpe?g|gif|webp|bmp|ico|icns|pdf|woff2?|ttf|otf|eot|zip|gz|tgz|bz2|xz|tar|jar|war|7z|rar|wasm|mp4|m4v|mov|webm|avi|mkv|mp3|wav|flac|ogg|bin|exe|dll|so|dylib|node|class|keystore|jks|p12|pfx)$'
 
+# The C0 scan itself. Line-oriented (not `-0777`) so the reported line numbers
+# are useful; a control byte never spans a line.
+c0_lines() {
+  LC_ALL=C perl -ne 'print "$.\n" if /[\x00-\x08\x0B\x0C\x0E-\x1F]/' 2>/dev/null \
+    | head -3 | paste -sd, -
+}
+
 offenders=()
-for f in "${staged[@]}"; do
-  [[ -z "$f" ]] && continue
+seen="
+"
+i=0
+while [ "$i" -lt ${#scan_path[@]} ]; do
+  d="${scan_dir[$i]}"
+  f="${scan_path[$i]}"
+  i=$((i + 1))
+  [ -n "$f" ] || continue
   shopt -s nocasematch
   if [[ "$f" =~ $binary_ext_re ]]; then
     shopt -u nocasematch
     continue
   fi
   shopt -u nocasematch
-  # Print the line numbers of any blob line containing a C0 control byte
-  # other than tab / LF / CR. -0777 would slurp; we stay line-oriented so
-  # the reported line numbers are useful (a NUL does not span the regex).
-  lines=$(
-    git -C "$target_dir" show ":$f" 2>/dev/null \
-      | LC_ALL=C perl -ne 'print "$.\n" if /[\x00-\x08\x0B\x0C\x0E-\x1F]/' 2>/dev/null \
-      | head -3 | paste -sd, -
-  )
-  if [[ -n "$lines" ]]; then
-    offenders+=("$f (line(s): $lines)")
+  # Both scans can name the same file (staged AND modified since); report once.
+  key="$d/$f"
+  case "$seen" in
+    *"
+$key
+"*) continue ;;
+  esac
+  seen="$seen$key
+"
+  lines=""
+  if [ -f "$d/$f" ] && [ ! -L "$d/$f" ]; then
+    # The WORKING-TREE content: this is the half that plain `git show :<f>`
+    # could not see before a `git add` had run. Symlinks are skipped -- git
+    # stages the link TARGET PATH as the blob, not the pointee's bytes, so
+    # following the link would scan a file the commit does not contain.
+    lines=$(LC_ALL=C perl -ne 'print "$.\n" if /[\x00-\x08\x0B\x0C\x0E-\x1F]/' "$d/$f" 2>/dev/null | head -3 | paste -sd, -)
+  fi
+  if [ -z "$lines" ]; then
+    # The STAGED blob. Scanned even when the worktree copy was clean: the two
+    # can differ, and it is the staged side that gets committed.
+    lines=$(git -C "$d" show ":$f" 2>/dev/null | c0_lines)
+  fi
+  if [ -n "$lines" ]; then
+    offenders[${#offenders[@]}]="$f (line(s): $lines)"
   fi
 done
 
-if [[ ${#offenders[@]} -gt 0 ]]; then
-  echo "Blocked by control-char-gate: staged file(s) contain a NUL or other C0 control byte" >&2
+if [ ${#offenders[@]} -gt 0 ]; then
+  echo "Blocked by control-char-gate: file(s) this commit would contain have a NUL or other C0 control byte" >&2
   echo "(anything below 0x20 except tab / newline / carriage-return)." >&2
-  echo "  resolved target dir: $target_dir" >&2
+  echo "  resolved target dir: $commit_dir" >&2
   for o in "${offenders[@]}"; do
     echo "  - $o" >&2
   done
   echo "These are almost always an editing artifact (e.g. a separator that landed as a raw" >&2
   echo "NUL); they break grep / diff / tooling and must not ship in committed text. Open the" >&2
-  echo "file(s), remove the stray control character(s), re-stage, and commit again." >&2
+  echo "file(s) and remove the stray control character(s) before committing." >&2
   exit 2
 fi
 

--- a/.claude/hooks/control-char-gate.sh
+++ b/.claude/hooks/control-char-gate.sh
@@ -53,11 +53,10 @@
 # The index scan is still done ALONGSIDE the working-tree one rather than being
 # replaced by it: a file staged EARLIER and unmodified since is in the commit
 # but is not "modified" relative to the index, so `git ls-files --modified`
-# never lists it. The one exception is a path the staging will DELETE -- either
-# the file is already gone from disk, or THIS CALL is what removes it
-# (`rm bad.ts && git add -A && git commit`, where the hook still sees the file).
-# Its staged blob is on its way out of the tree, so blocking on it would wedge
-# the very remediation this gate's own message asks for.
+# never lists it. The one exception is a path that is ALREADY GONE from disk
+# while the staging covers it: `git add -A` will stage that deletion, so the
+# staged blob is on its way out of the tree. That is a fact about the TREE, not
+# a reading of the command -- see "what this gate does NOT try to know" below.
 #
 # The working-tree scan is deliberately a SUPERSET of what the commit will
 # contain in the ambiguous cases: a false block costs one message and a re-run,
@@ -81,6 +80,19 @@
 # fail-open of exactly the same class as the one above. A pathspec-RESTRICTED
 # scan still runs in the command's own directory, because that is what its
 # pathspecs are relative to.
+#
+# WHAT THIS GATE DOES NOT TRY TO KNOW: the ORDER of the segments, or that some
+# other command in the same call will delete the file before the commit runs.
+# A `rm bad.ts && git add -A && git commit` is therefore BLOCKED even though the
+# resulting commit would not contain bad.ts, and the message says how to proceed
+# (stage the deletion in its own call). An earlier revision parsed `rm` / `git
+# rm` to avoid that one false block. It cost a FAIL-OPEN (`git add -A && git
+# commit && rm x` passed, because order was not modelled), an abbreviation
+# bypass (`git rm --ca`), and a 90-second hang. The trade is not close: this
+# gate exists because a false PASS shipped a control byte to main, while a false
+# BLOCK costs one message and a second call -- the same asymmetry every "ERRS
+# BROAD" note below already argues for. So the parser is gone and the remedy
+# lives in the error message instead.
 #
 # Fails open (exit 0) when git / perl are unavailable, or when neither scan
 # finds any candidate file (a clean tree) -- a safety net must never wedge an
@@ -327,82 +339,6 @@ if [ "$wt_scan" -eq 1 ] && [ "$wt_all_paths" -eq 0 ] && [ -z "$wt_paths" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Paths this same call REMOVES.
-# ---------------------------------------------------------------------------
-# `rm bad.ts && git add -A && git commit -m drop-it` is one Bash call, so at hook
-# time bad.ts is still on disk with its control byte, while the commit that call
-# produces does not contain the file at all. Blocking there wedges the exact
-# remediation this gate's own message asks for. The deletion is only visible in
-# the COMMAND before it runs -- the same place the staging had to be read from.
-#
-# Recorded as root-relative keys, and ONLY consulted for INDEX candidates: a
-# working-tree candidate that is being removed already reads as "no file on
-# disk" and is skipped on its own.
-removed_keys="
-"
-
-# gate_cc_collect_removals <verb-ere> <is-git-rm>
-# Resolve each removal segment's positional paths to root-relative names by
-# asking GIT to match them (`ls-files --cached -- <path>`), rather than doing
-# path arithmetic here: git owns pathspec semantics, handles a directory
-# argument, and normalises `/var` vs `/private/var` for free.
-gate_cc_collect_removals() {
-  local re="$1" is_git="$2" seg_args dir root tok cached f end_of_flags skip_seg
-  dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$re")
-  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)
-  [ -n "$root" ] || return 0
-  while IFS= read -r seg_args; do
-    end_of_flags=0
-    skip_seg=0
-    # `git rm --cached` un-tracks WITHOUT deleting, and a following `git add -A`
-    # would re-add the file. Not a removal; the whole segment is ignored.
-    if [ "$is_git" = "1" ]; then
-      case " $seg_args " in *" --cached "*) skip_seg=1 ;; esac
-    fi
-    [ "$skip_seg" -eq 1 ] && continue
-    while [ -n "${seg_args// /}" ] && [[ "$seg_args" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
-      tok="${BASH_REMATCH[1]}"
-      seg_args="${BASH_REMATCH[3]}"
-      [ -n "$tok" ] || break
-      if [ "$end_of_flags" -eq 0 ]; then
-        case "$tok" in
-          --) end_of_flags=1; continue ;;
-          -*) continue ;;
-        esac
-      fi
-      tok=$(gate_unquote "$tok")
-      [ -n "$tok" ] || continue
-      # ERRS TOWARD BLOCKING: an unrecognised removal is simply not recorded, so
-      # the index candidate keeps its scan. That is the safe direction here --
-      # unlike everywhere else in this file, a wrong entry in THIS list
-      # SUPPRESSES a scan.
-      #   $ / `   an unexpanded path is not a path.
-      #   * ? [   a GLOB, and git's pathspec language is BROADER than the
-      #           shell's: the shell expands `rm *.ts` against the CWD only,
-      #           while `ls-files -- '*.ts'` matches every .ts in the repository
-      #           and would suppress the scan of files the `rm` never touches.
-      case "$tok" in *'$'*|*'`'*|*'*'*|*'?'*|*'['*) continue ;; esac
-      while IFS= read -r -d '' f; do
-        [ -n "$f" ] || continue
-        removed_keys="$removed_keys$root/$f
-"
-      done < <(git -C "$dir" ls-files --full-name --cached -z -- "$tok" 2>/dev/null || true)
-    done
-  done < <(gate_verb_args "$cmd" "$re")
-}
-
-# `git rm` STAGES the removal itself, so it counts whatever else the call does.
-gate_cc_collect_removals "$GATE_RE_GIT_RM" 1
-# A plain `rm` only touches the disk; something else has to stage the deletion,
-# and only a WHOLE-TREE staging (`git add -A` / `-u` / `git commit -a`) is
-# certain to cover it. Under a pathspec-restricted staging the deletion may not
-# be staged at all, and a wrong skip here is a FAIL-OPEN, so that case
-# deliberately keeps the index scan.
-if [ "$wt_scan" -eq 1 ] && [ "$wt_all_paths" -eq 1 ]; then
-  gate_cc_collect_removals "$GATE_RE_RM" 0
-fi
-
-# ---------------------------------------------------------------------------
 # Collect the candidate files, each with its provenance.
 # ---------------------------------------------------------------------------
 # Three parallel arrays rather than one array of joined strings: a path may
@@ -415,38 +351,64 @@ scan_path=()
 wt_keys="
 "
 
+# How many entries a `git add -f <pathspec>` listing may reach before the gate
+# gives up on scanning gitignored content. See the --exclude-standard comment.
+GATE_CC_FORCE_MAX=200
+
 collect_worktree() {
-  local dir="$1" root f run_in
+  local dir="$1" root f run_in n
   root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)
   # Not a repo (or git refused): nothing to add. The index scan handles the same
   # case the same way, and this is the pre-existing fail-open shape.
   [ -n "$root" ] || return 0
+
   # `--full-name` so paths come back relative to the repo ROOT and can be read
   # without depending on which subdirectory the command ran in.
-  local args=(ls-files -z --full-name --modified)
-  [ "$wt_untracked" -eq 1 ] && args=("${args[@]}" --others)
-  # `--exclude-standard` keeps gitignored files out. It is dropped ONLY when a
-  # `git add -f` is bounded by a pathspec: `-f` really can stage an ignored
-  # file, but an UNBOUNDED scan of every ignored path (node_modules, dist, the
-  # build cache) would make the gate itself the slowest thing in the commit.
-  # ERRS NARROW, knowingly, and only for `git add -f` with no pathspec.
-  if [ "$wt_force" -eq 0 ] || [ "$wt_all_paths" -eq 1 ]; then
-    args=("${args[@]}" --exclude-standard)
-  fi
+  local base=(ls-files -z --full-name --modified)
+  [ "$wt_untracked" -eq 1 ] && base=("${base[@]}" --others)
+
   # WHERE the listing runs is the difference between whole-tree and
   # subtree-only, because `git ls-files` lists what is under its CWD:
   #   unrestricted -> the repo ROOT, because `git add -A` / `git commit -a` are
   #                   whole-tree regardless of where they were typed.
   #   restricted   -> the command's OWN directory, because that is what its
   #                   pathspecs are relative to.
+  local paths=()
   run_in="$root"
   if [ "$wt_all_paths" -eq 0 ] && [ -n "$wt_paths" ]; then
     run_in="$dir"
-    args=("${args[@]}" --)
+    paths=(--)
     while IFS= read -r f; do
-      [ -n "$f" ] && args=("${args[@]}" "$f")
+      [ -n "$f" ] && paths=("${paths[@]}" "$f")
     done <<< "$wt_paths"
   fi
+
+  # `--exclude-standard` keeps gitignored files out of the listing, and it is
+  # kept unless dropping it is provably CHEAP.
+  #
+  # `git add -f` really can stage an ignored file, so the ignored content is in
+  # scope in principle. In practice a pathspec like `.` or a directory drags in
+  # the whole ignored tree: measured in this repo, `git add -f .` produced 4,001
+  # candidates and the gate took 25 s (44,563 and >90 s in the reviewer's
+  # worktree). A gate that wedges every commit is worse than the bug it
+  # prevents. So the listing is PROBED first -- cheap, since `ls-files` walks
+  # directories without reading file contents, and the probe stops as soon as it
+  # passes the cap -- and the exclusion is only dropped when the result is small.
+  #
+  # ERRS NARROW, knowingly and boundedly: a `git add -f` whose pathspec covers
+  # more than GATE_CC_FORCE_MAX entries has its IGNORED files unscanned. Its
+  # tracked and untracked-but-unignored files are still scanned, because those
+  # come from the listing that keeps --exclude-standard.
+  local excl=(--exclude-standard)
+  if [ "$wt_force" -eq 1 ] && [ "$wt_all_paths" -eq 0 ]; then
+    n=0
+    while IFS= read -r -d '' f; do
+      n=$((n + 1))
+      [ "$n" -gt "$GATE_CC_FORCE_MAX" ] && break
+    done < <(git -C "$run_in" "${base[@]}" ${paths[@]+"${paths[@]}"} 2>/dev/null || true)
+    [ "$n" -le "$GATE_CC_FORCE_MAX" ] && excl=()
+  fi
+
   while IFS= read -r -d '' f; do
     [ -n "$f" ] || continue
     scan_kind[${#scan_kind[@]}]="W"
@@ -454,7 +416,7 @@ collect_worktree() {
     scan_path[${#scan_path[@]}]="$f"
     wt_keys="$wt_keys$root/$f
 "
-  done < <(git -C "$run_in" "${args[@]}" 2>/dev/null || true)
+  done < <(git -C "$run_in" "${base[@]}" ${excl[@]+"${excl[@]}"} ${paths[@]+"${paths[@]}"} 2>/dev/null || true)
 }
 
 collect_index() {
@@ -492,14 +454,39 @@ collect_index "$commit_dir"
 # Extensions whose blobs legitimately contain control bytes — never scanned.
 binary_ext_re='\.(png|jpe?g|gif|webp|bmp|ico|icns|pdf|woff2?|ttf|otf|eot|zip|gz|tgz|bz2|xz|tar|jar|war|7z|rar|wasm|mp4|m4v|mov|webm|avi|mkv|mp3|wav|flac|ogg|bin|exe|dll|so|dylib|node|class|keystore|jks|p12|pfx)$'
 
-# The C0 scan itself. Line-oriented (not `-0777`) so the reported line numbers
-# are useful; a control byte never spans a line.
+# The C0 scan itself.
+#
+# ONE perl process for ALL working-tree candidates, not one per file. The
+# per-file fork was the other half of the `git add -f` slowness above: forks
+# dominate when the candidate list is long, and the list is only bounded by the
+# repository. Line-oriented (not `-0777`) so the reported line numbers stay
+# useful; a control byte never spans a line, and each file stops after 3 hits.
+#
+# Reads NUL-delimited names on stdin and runs with the repo root as its cwd, so
+# the names it prints back are the same root-relative ones used as keys here.
+# `$/` is localised for the name list: leaving it as NUL would make the inner
+# read see whole files as one "line" and every reported line number would be 1.
+C0_BATCH_PL='
+my @f;
+{ local $/ = "\0"; while (my $x = <STDIN>) { chomp $x; push @f, $x if length $x; } }
+for my $n (@f) {
+  open(my $fh, "<", $n) or next;
+  my $ln = 0; my @hit;
+  while (my $l = <$fh>) {
+    $ln++;
+    if ($l =~ /[\x00-\x08\x0B\x0C\x0E-\x1F]/) { push @hit, $ln; last if @hit >= 3; }
+  }
+  close $fh;
+  print $n, "\t", join(",", @hit), "\n" if @hit;
+}
+'
+# The single-file form, for staged blobs (which arrive on stdin as content).
 C0_RE='print "$.\n" if /[\x00-\x08\x0B\x0C\x0E-\x1F]/'
 
-offenders=()
+# Pass 1: filter and split the candidates by provenance. No file is read here.
+w_root=(); w_rel=()
+i_root=(); i_rel=()
 seen_scan="
-"
-seen_offender="
 "
 i=0
 while [ "$i" -lt ${#scan_path[@]} ]; do
@@ -531,7 +518,6 @@ $kind $key
   esac
   seen_scan="$seen_scan$kind $key
 "
-  lines=""
   if [ "$kind" = "W" ]; then
     # WORKING-TREE content: the half a plain `git show :<f>` could not see
     # before the `git add` had run. A path listed here but MISSING from disk is
@@ -540,46 +526,86 @@ $kind $key
     # blob, not the pointee's bytes, so following the link would scan a file the
     # commit does not contain.
     if [ -f "$key" ] && [ ! -L "$key" ]; then
-      lines=$(LC_ALL=C perl -ne "$C0_RE" "$key" 2>/dev/null | head -3 | paste -sd, -)
+      w_root[${#w_root[@]}]="$root"
+      w_rel[${#w_rel[@]}]="$f"
     fi
   else
-    # STAGED blob. Read ONLY out of the index -- never off disk, so a dirty
+    # STAGED blob, read ONLY out of the index -- never off disk, so a dirty
     # working copy cannot block a `git commit` that is not committing it.
     #
-    # ...unless the staging in this same call is REMOVING the path: the file is
-    # gone from disk and the same path is a working-tree candidate, so the blob
-    # is on its way out of the tree. Blocking there would wedge the remediation
-    # this gate's own message asks for (`rm bad.ts && git add -A && git commit`
-    # would be refused, for a file that no longer exists).
+    # ...unless the path is already GONE from disk while the staging covers it
+    # (it is a working-tree candidate): `git add -A` will stage that deletion,
+    # so the blob is on its way out of the tree and blocking on it would refuse
+    # a commit for a file that no longer exists. This is a fact about the tree,
+    # not a reading of the command -- the gate does not model `rm` (see header).
     skip_removed=0
-    # Already gone from disk, and the staging covers it: the blob is on its way
-    # out of the tree.
     case "$wt_keys" in
       *"
 $key
 "*) [ -e "$key" ] || skip_removed=1 ;;
     esac
-    # ...or this same call is what removes it, before the commit runs.
-    case "$removed_keys" in
-      *"
-$key
-"*) skip_removed=1 ;;
-    esac
     if [ "$skip_removed" -eq 0 ]; then
-      lines=$(git -C "$root" show ":$f" 2>/dev/null | LC_ALL=C perl -ne "$C0_RE" 2>/dev/null | head -3 | paste -sd, -)
+      i_root[${#i_root[@]}]="$root"
+      i_rel[${#i_rel[@]}]="$f"
     fi
   fi
-  if [ -n "$lines" ]; then
-    # One report line per FILE, even when both provenances flagged it.
-    case "$seen_offender" in
-      *"
-$key
-"*) continue ;;
-    esac
-    seen_offender="$seen_offender$key
+done
+
+# Pass 2: read the bytes. Offenders are keyed by "<root>/<rel>" so one file is
+# reported once however many provenances flagged it.
+offenders=()
+seen_offender="
 "
-    offenders[${#offenders[@]}]="$f (line(s): $lines)"
-  fi
+record() {
+  local root="$1" rel="$2" lines="$3" key="$1/$2"
+  [ -n "$lines" ] || return 0
+  case "$seen_offender" in
+    *"
+$key
+"*) return 0 ;;
+  esac
+  seen_offender="$seen_offender$key
+"
+  offenders[${#offenders[@]}]="$rel (line(s): $lines)"
+}
+
+# Working-tree candidates: one perl per distinct root (at most two -- the
+# commit's and the add's).
+j=0
+roots_done="
+"
+while [ "$j" -lt ${#w_rel[@]} ]; do
+  root="${w_root[$j]}"
+  j=$((j + 1))
+  case "$roots_done" in
+    *"
+$root
+"*) continue ;;
+  esac
+  roots_done="$roots_done$root
+"
+  while IFS=$'\t' read -r rel lines; do
+    [ -n "$rel" ] && record "$root" "$rel" "$lines"
+  done < <(
+    {
+      k=0
+      while [ "$k" -lt ${#w_rel[@]} ]; do
+        [ "${w_root[$k]}" = "$root" ] && printf '%s\0' "${w_rel[$k]}"
+        k=$((k + 1))
+      done
+    } | ( cd "$root" 2>/dev/null && LC_ALL=C perl -e "$C0_BATCH_PL" 2>/dev/null )
+  )
+done
+
+# Staged blobs: content comes from `git show`, so this stays one call per file.
+# Bounded by what the user actually staged, unlike the working-tree listing.
+j=0
+while [ "$j" -lt ${#i_rel[@]} ]; do
+  root="${i_root[$j]}"
+  f="${i_rel[$j]}"
+  j=$((j + 1))
+  lines=$(git -C "$root" show ":$f" 2>/dev/null | LC_ALL=C perl -ne "$C0_RE" 2>/dev/null | head -3 | paste -sd, -)
+  record "$root" "$f" "$lines"
 done
 
 if [ ${#offenders[@]} -gt 0 ]; then
@@ -592,6 +618,10 @@ if [ ${#offenders[@]} -gt 0 ]; then
   echo "These are almost always an editing artifact (e.g. a separator that landed as a raw" >&2
   echo "NUL); they break grep / diff / tooling and must not ship in committed text. Open the" >&2
   echo "file(s) and remove the stray control character(s) before committing." >&2
+  echo "If you are DELETING the file rather than fixing it, stage the deletion in its own" >&2
+  echo "call first ('git rm <path>', or 'rm <path>' then 'git add -A'), then commit: this" >&2
+  echo "gate reads the tree as it is BEFORE your command runs, so a deletion later in the" >&2
+  echo "same command line has not happened yet and the file still looks present to it." >&2
   exit 2
 fi
 

--- a/.claude/hooks/control-char-gate.test.sh
+++ b/.claude/hooks/control-char-gate.test.sh
@@ -29,6 +29,14 @@
 #   * an UNKNOWN `git add` flag's value was read as a pathspec, which also
 #     suppressed the whole-tree fallback.
 #
+# A third round found four more, including a FAIL-OPEN and a 90-second HANG, in
+# the `rm` parser that had been added to avoid ONE false block. That parser is
+# deleted rather than fixed again: a false PASS is what shipped a control byte
+# to main, a false BLOCK costs one message and a second call, and the remedy now
+# lives in the error text. What replaced the enumeration habit is the STATE x
+# SHAPE table near the end of this file -- both earlier rounds missed cases
+# because the tests reused whichever fixture state happened to work.
+#
 # And the ACCEPT block is as long, because widening a gate that every commit
 # passes through is how a fix turns into a wedge -- `git commit -a` in
 # particular must NOT pick up an untracked file, since `-a` does not, and
@@ -40,7 +48,7 @@
 #                its `setup` argument. No case reads this repository, so the
 #                suite cannot pass or fail on the state of the worktree it runs
 #                in -- measured by running it from the repo root with a dirty
-#                tree, from /tmp, and from $HOME (not a repo at all): 93/93
+#                tree, from /tmp, and from $HOME (not a repo at all): 115/115
 #                each time.
 #   cwd          pinned per case through the payload's `cwd` field: the case's
 #                own repo, or (for the `git -C` cases) a directory that is NOT a
@@ -171,6 +179,35 @@ run_count() {
   fi
 }
 
+# run_timed <name> <want_exit> <max_seconds> <setup> <cmd> [<want_fragment>]
+# Same as run_case plus a WALL-CLOCK bound. A correctness-only suite cannot see
+# a gate that answers correctly in four minutes, and that is a real failure mode
+# for a PreToolUse hook: it is in the path of every commit.
+run_timed() {
+  local name="$1" want="$2" budget="$3" setup="$4" cmd="$5" frag="${6:--}"
+  local repo got out payload started elapsed
+  repo="$(mk_repo "$setup")"
+  payload=$(jq -nc --arg c "$cmd" --arg d "$repo" \
+    '{tool_name:"Bash", cwd:$d, tool_input:{command:$c}}')
+  started=$(date +%s)
+  out=$(printf '%s' "$payload" | env -i PATH="$PINNED_PATH" HOME="$SANDBOX" \
+    bash "$GATE" 2>&1); got=$?
+  elapsed=$(( $(date +%s) - started ))
+  if [ "$got" != "$want" ]; then
+    fail=$((fail + 1)); printf 'FAIL %s (want exit %s, got %s)\n  out: %s\n' "$name" "$want" "$got" "$out"
+    return
+  fi
+  if [ "$frag" != "-" ] && ! printf '%s' "$out" | grep -qF "$frag"; then
+    fail=$((fail + 1)); printf 'FAIL %s (exit %s as wanted, but output does not name "%s")\n' "$name" "$got" "$frag"
+    return
+  fi
+  if [ "$elapsed" -gt "$budget" ]; then
+    fail=$((fail + 1)); printf 'FAIL %s took %ss, budget %ss\n' "$name" "$elapsed" "$budget"
+    return
+  fi
+  pass=$((pass + 1)); printf 'OK   %-62s %s\n' "$name" "(exit $got, ${elapsed}s <= ${budget}s)"
+}
+
 # The offending files, written from escapes. `probe.ts` carries a NUL on line 1;
 # `soh.ts` carries a 0x01, so the suite is not pinned to NUL alone.
 NUL_FILE='printf "const a = \"x\000y\";\n" > probe.ts'
@@ -182,6 +219,8 @@ TRACKED_NUL='echo clean > probe.ts; git add probe.ts; git commit -qm init; '"$NU
 # `root.ts` is COMMITTED CLEAN, so the index is clean and only the working copy
 # carries the NUL -- which is what makes an index-only scan answer "clean".
 ROOT_NUL='mkdir -p sub; echo hi > sub/a.ts; echo clean > root.ts; git add -A; git commit -qm init; printf "const a = \"x\000y\";\n" > root.ts'
+# NUL written and STAGED, worktree copy identical. Used by the deletion block.
+STAGED_NUL="$NUL_FILE; git add probe.ts"
 
 echo "== REFUSE: the command stages, so the WORKING TREE is in the commit ========"
 # THE case that fails on the pre-fix gate. Everything else in this block is a
@@ -194,6 +233,15 @@ run_case "issue repro: add -A && commit -F msg"    2 "$NUL_FILE; echo msg > m.tx
   'git add -A && git commit -F m.txt' 'probe.ts'
 run_case "a 0x01, not only NUL"                    2 "$SOH_FILE" \
   'git add -A && git commit -m x' 'soh.ts (line(s): 1)'
+# The reported LINE NUMBERS, which every case above happens to leave at 1. The
+# batch reader localises `$/` for the name list; without that the inner file
+# read also splits on NUL, each file comes back as a single "line", and every
+# report says line 1 -- correct-looking and useless. A mutation dropping the
+# `local` stayed 115/115 green until these two cases existed.
+run_case "line number beyond the first"            2 'printf "a\nb\nconst x = \"q\000r\";\nd\n" > deep.ts' \
+  'git add -A && git commit -m x' 'deep.ts (line(s): 3)'
+run_case "several lines, comma-joined and capped"  2 'printf "a\nx\000\ny\nz\000\nw\000\nv\000\n" > many.ts' \
+  'git add -A && git commit -m x' 'many.ts (line(s): 2,4,5)'
 run_case "git add --all (long form)"               2 "$NUL_FILE" \
   'git add --all && git commit -m x' 'probe.ts'
 run_case "git add . "                              2 "$NUL_FILE" \
@@ -416,46 +464,43 @@ run_case "from a subdir: scoped add stays scoped"  0 "$ROOT_NUL" \
   'git add a.ts && git commit -m x' - sub
 
 echo
-echo "== ACCEPT: removing the offending file is the REMEDIATION =================="
-# The gate's own message says to get rid of the control byte. Blocking the
-# removal wedges that. Two timings, and only the second is visible in the tree:
-# a `rm` in an EARLIER call leaves no file on disk, while a `rm` in the SAME
-# call has not run yet when the hook looks -- so that one is read off the
-# command, exactly like the staging is.
-STAGED_NUL="$NUL_FILE; git add probe.ts"
-run_case "rm in an earlier call, then add -A"      0 "$STAGED_NUL; rm probe.ts" \
+echo "== REFUSE: a deletion later in the SAME command line is NOT modelled ======="
+# These are DELIBERATE false blocks, and the message carries the remedy.
+#
+# An earlier revision parsed `rm` / `git rm` out of the command so that
+# `rm bad.ts && git add -A && git commit` would pass. It bought one avoided
+# false block and cost: a FAIL-OPEN (`git add -A && git commit && rm x` passed,
+# because segment ORDER was never modelled, and the commit really did contain
+# the byte), an abbreviation bypass (`git rm --ca`, which git accepts), a
+# directory-expansion miss, and a 90-second hang. The parser is gone. This gate
+# exists because a false PASS shipped a control byte to main; a false BLOCK
+# costs one message and a second call.
+run_case "rm in the same call is still blocked"    2 "$STAGED_NUL" \
+  'rm probe.ts && git add -A && git commit -m drop-it' 'probe.ts'
+run_case "git rm in the same call is still blocked" 2 "$STAGED_NUL" \
+  'git rm -f probe.ts && git commit -m drop-it' 'probe.ts'
+# ORDER. This is the shape the parser turned into a fail-open: the commit runs
+# BEFORE the cleanup, so the byte really is in it and refusing is correct.
+run_case "commit THEN rm (the byte IS committed)"  2 "$STAGED_NUL" \
+  'git add -A && git commit -m x && rm probe.ts' 'probe.ts'
+# ...and the reverse order, pinned so the direction is visible: a `git add`
+# anywhere in the call makes the working tree in scope, whether or not it runs
+# before the commit. ERRS TOWARD BLOCKING, by design.
+run_case "commit THEN add (order not modelled)"    2 "$NUL_FILE" \
+  'git commit -m x && git add -A' 'probe.ts'
+# The remedy has to be IN the message, since it is now the whole mitigation for
+# the cases above.
+run_case "the block names the deletion remedy"     2 "$STAGED_NUL" \
+  'rm probe.ts && git add -A && git commit -m drop-it' 'stage the deletion in its own'
+# And the remedy must actually WORK: once the deletion is staged, the path is a
+# `D` in the index, which `--diff-filter=ACM` excludes, so there is no candidate.
+run_case "remedy: deletion already staged"         0 "$STAGED_NUL; rm probe.ts; git add -A" \
+  'git commit -m drop-it'
+# The other half of the remedy: `rm` in an EARLIER call, deletion not yet
+# staged. Here the file's absence is a fact about the TREE rather than a reading
+# of the command, and the staging in this call covers it.
+run_case "remedy: rm earlier, staged in this call" 0 "$STAGED_NUL; rm probe.ts" \
   'git add -A && git commit -m drop-it'
-run_case "rm in the SAME call as the commit"       0 "$STAGED_NUL" \
-  'rm probe.ts && git add -A && git commit -m drop-it'
-run_case "git rm -f stages the removal itself"     0 "$STAGED_NUL" \
-  'git rm -f probe.ts && git commit -m drop-it'
-run_case "rm -rf <dir> covers the files under it"  0 'mkdir -p s; printf "x\000y\n" > s/probe.ts; git add s/probe.ts' \
-  'rm -rf s && git add -A && git commit -m drop-it'
-# ...and the removal must be READ, not assumed. Each of these still blocks.
-run_case "rm naming a DIFFERENT file still blocks" 2 "$STAGED_NUL" \
-  'rm other.ts && git add -A && git commit -m x' 'probe.ts'
-run_case "git rm --cached, then add -A re-adds it" 2 "$STAGED_NUL" \
-  'git rm --cached probe.ts && git add -A && git commit -m x' 'probe.ts'
-run_case "rm with an unexpanded path still blocks" 2 "$STAGED_NUL" \
-  'rm $F && git add -A && git commit -m x' 'probe.ts'
-run_case "a quoted mention of rm still blocks"     2 "$STAGED_NUL" \
-  'echo "rm probe.ts" && git add -A && git commit -m x' 'probe.ts'
-run_case "rmdir is not rm"                         2 "$STAGED_NUL" \
-  'rmdir probe.ts && git add -A && git commit -m x' 'probe.ts'
-# A GLOB in the removal is not recorded at all, because git's pathspec language
-# is broader than the shell's: the shell expands `rm *.ts` against the CWD, while
-# `ls-files -- '*.ts'` matches every .ts in the REPOSITORY -- so honouring it
-# would suppress the scan of a file the `rm` never touches. Here `sub/probe.ts`
-# is staged and would survive the shell's `rm *.ts`.
-run_case "a glob in rm suppresses nothing"         2 'mkdir -p sub; printf "x\000y\n" > sub/probe.ts; git add sub/probe.ts; echo hi > root.ts' \
-  'rm *.ts && git add -A && git commit -m x' 'sub/probe.ts'
-# A plain `rm` stages nothing, so without a whole-tree staging the blob still
-# commits. ERRS TOWARD BLOCKING, because a wrong entry in the removal list is
-# the one place in this gate where a mistake SUPPRESSES a scan.
-run_case "rm with NO staging in the call"          2 "$STAGED_NUL" \
-  'rm probe.ts && git commit -m x' 'probe.ts'
-run_case "rm under a pathspec-restricted staging"  2 "$STAGED_NUL" \
-  'rm probe.ts && git add probe.ts && git commit -m x' 'probe.ts'
 
 echo
 echo "== one report line per FILE, whatever its provenance ======================="
@@ -486,6 +531,108 @@ run_case "git add on its own (no commit)"          0 "$NUL_FILE" 'git add -A'
 run_case "a quoted mention of the command"         0 "$NUL_FILE; git add -A" 'echo "git commit -m x"'
 run_case "git commit-tree is not git commit"       0 "$NUL_FILE; git add -A" 'git commit-tree HEAD^{tree}'
 run_case "empty command"                           0 "$NUL_FILE; git add -A" ''
+
+echo
+echo "== STATE x SHAPE: every combination, spelled out =========================="
+# THE LESSON FROM TWO REVIEW ROUNDS. Round 1 shipped 52 green cases with two
+# live blockers; round 2 shipped 93 with four. Both times the missing cases were
+# shapes nobody had enumerated, and both times the tests reused whichever
+# FIXTURE STATE happened to work. Listing command shapes is only half the space:
+# what the gate answers depends just as much on where the bytes are.
+#
+# So the two axes are crossed exhaustively here. Six states of one NUL-bearing
+# file, times four command shapes, all 24 spelled out with the reasoning:
+#
+#            S1 commit   S2 add -A   S3 commit   S4 commit
+#            -m x        && commit   -am x       -m x f.ts
+#   A untracked      0        2           0           0
+#   B in HEAD        0        0           0           0
+#   C tracked-mod    0        2           2           2
+#   D staged         2        2           2           2
+#   E staged/clean   2        2*          2*          2*
+#   F deleted        2        0           0           0
+#
+# The cells marked * are KNOWN FALSE BLOCKS and the only ones in the table: the
+# index blob is dirty, the working copy is clean, and a whole-tree staging would
+# overwrite the index with that clean copy. Keeping the index scan is what
+# catches the file staged EARLIER and untouched since, which no `ls-files
+# --modified` will ever list; that is worth one false block in a state you reach
+# only by staging a control byte and then cleaning the file without re-staging.
+st_A='printf "const a = \"x\000y\";\n" > f.ts'
+st_B='printf "const a = \"x\000y\";\n" > f.ts; git add f.ts; git commit -qm init'
+st_C='echo clean > f.ts; git add f.ts; git commit -qm init; printf "const a = \"x\000y\";\n" > f.ts'
+st_D='printf "const a = \"x\000y\";\n" > f.ts; git add f.ts'
+st_E='printf "const a = \"x\000y\";\n" > f.ts; git add f.ts; echo clean > f.ts'
+st_F='printf "const a = \"x\000y\";\n" > f.ts; git add f.ts; rm f.ts'
+
+# A: untracked. Only a `git add` reaches it -- `-a` never stages an untracked
+# file, and a commit pathspec on one is an error in git.
+run_case "A untracked  x  commit -m"               0 "$st_A" 'git commit -m x'
+run_case "A untracked  x  add -A && commit"        2 "$st_A" 'git add -A && git commit -m x' 'f.ts'
+run_case "A untracked  x  commit -am"              0 "$st_A" 'git commit -am x'
+run_case "A untracked  x  commit -m x f.ts"        0 "$st_A" 'git commit -m x f.ts'
+# B: the byte is already in HEAD. Nothing here introduces it, so nothing blocks
+# -- the gate judges what THIS commit adds, not what the history holds.
+run_case "B in HEAD     x  commit -m"              0 "$st_B" 'git commit -m x'
+run_case "B in HEAD     x  add -A && commit"       0 "$st_B" 'git add -A && git commit -m x'
+run_case "B in HEAD     x  commit -am"             0 "$st_B" 'git commit -am x'
+run_case "B in HEAD     x  commit -m x f.ts"       0 "$st_B" 'git commit -m x f.ts'
+# C: committed clean, dirty on disk. The index is clean, so a plain commit is
+# genuinely clean; every staging shape picks the file up.
+run_case "C tracked-mod x  commit -m"              0 "$st_C" 'git commit -m x'
+run_case "C tracked-mod x  add -A && commit"       2 "$st_C" 'git add -A && git commit -m x' 'f.ts'
+run_case "C tracked-mod x  commit -am"             2 "$st_C" 'git commit -am x' 'f.ts'
+run_case "C tracked-mod x  commit -m x f.ts"       2 "$st_C" 'git commit -m x f.ts' 'f.ts'
+# D: staged, worktree identical. Every shape commits the byte.
+run_case "D staged       x  commit -m"             2 "$st_D" 'git commit -m x' 'f.ts'
+run_case "D staged       x  add -A && commit"      2 "$st_D" 'git add -A && git commit -m x' 'f.ts'
+run_case "D staged       x  commit -am"            2 "$st_D" 'git commit -am x' 'f.ts'
+run_case "D staged       x  commit -m x f.ts"      2 "$st_D" 'git commit -m x f.ts' 'f.ts'
+# E: staged dirty, then cleaned on disk. S1 is CORRECT (the index blob is what a
+# plain commit writes). S2-S4 are the table's only false blocks.
+run_case "E staged/clean x  commit -m"             2 "$st_E" 'git commit -m x' 'f.ts'
+run_case "E staged/clean x  add -A && commit  (*)" 2 "$st_E" 'git add -A && git commit -m x' 'f.ts'
+run_case "E staged/clean x  commit -am        (*)" 2 "$st_E" 'git commit -am x' 'f.ts'
+run_case "E staged/clean x  commit -m x f.ts  (*)" 2 "$st_E" 'git commit -m x f.ts' 'f.ts'
+# F: staged, then gone from disk, deletion not yet staged. S1 really does commit
+# the blob. The other three stage the deletion, so the blob leaves the tree --
+# and the file's ABSENCE is a fact about the tree, not a reading of the command.
+run_case "F deleted      x  commit -m"             2 "$st_F" 'git commit -m x' 'f.ts'
+run_case "F deleted      x  add -A && commit"      0 "$st_F" 'git add -A && git commit -m x'
+run_case "F deleted      x  commit -am"            0 "$st_F" 'git commit -am x'
+run_case "F deleted      x  commit -m x f.ts"      0 "$st_F" 'git commit -m x f.ts'
+
+echo
+echo "== BOUNDED TIME on a repo with a large ignored tree ========================"
+# `git add -f <pathspec>` is the one shape that may scan gitignored content, and
+# a pathspec of `.` drags in the entire ignored tree. Measured before the fix:
+# 4,001 candidates and 25 s here (44,563 and >90 s in the reviewer's worktree),
+# one `perl` fork each. A gate that wedges every commit is worse than the bug it
+# prevents, so the listing is probed and the exclusion only dropped when small,
+# and the working-tree scan is now ONE perl process rather than one per file.
+#
+# The budget is deliberately far below the pre-fix number and far above the
+# post-fix one (measured 0.11 s), so it discriminates without being flaky on a
+# loaded CI box.
+BIG_IGNORED='echo "ignored/" > .gitignore; mkdir -p ignored; i=0; while [ $i -lt 4000 ]; do printf "padding\n" > "ignored/f$i.txt"; i=$((i + 1)); done; printf "const a = \"x\000y\";\n" > probe.ts; git add .gitignore'
+run_timed "add -f . over 4000 ignored files"       2 20 "$BIG_IGNORED" \
+  'git add -f . && git commit -m x' 'probe.ts'
+run_timed "add -A over 4000 ignored files"         2 20 "$BIG_IGNORED" \
+  'git add -A && git commit -m x' 'probe.ts'
+# The cap's effect is BEHAVIOURAL, not only temporal -- which matters, because
+# batching alone already makes 4,000 files fast, so a wall-clock budget cannot
+# see the cap at all (measured: removing the cap kept the suite green until this
+# case existed). Here 300 ignored files each carry a NUL and the cap is 200, so
+# `--exclude-standard` is KEPT and exactly one file -- the unignored probe.ts --
+# is reported. That is the documented narrow trade, pinned: without the cap the
+# gate would report 301 files and print a 301-line error.
+BIG_IGNORED_NUL='echo "ignored/" > .gitignore; mkdir -p ignored; i=0; while [ $i -lt 300 ]; do printf "q\000r\n" > "ignored/f$i.ts"; i=$((i + 1)); done; printf "const a = \"x\000y\";\n" > probe.ts; git add .gitignore'
+run_count "add -f . past the cap reports only the unignored" 1 "$BIG_IGNORED_NUL" \
+  'git add -f . && git commit -m x'
+# ...and the narrow `-f` that CAN cheaply reach ignored content still does, so
+# the cap is a bound rather than a silent removal of the capability.
+run_case "add -f <one ignored file> still scans"   2 'printf "const a = \"x\000y\";\n" > ig.ts; echo ig.ts > .gitignore' \
+  'git add -f ig.ts && git commit -m x' 'ig.ts'
 
 echo
 echo "== the harness itself ======================================================"

--- a/.claude/hooks/control-char-gate.test.sh
+++ b/.claude/hooks/control-char-gate.test.sh
@@ -17,17 +17,30 @@
 # class an exit-code-only fence cannot see.
 #
 # So the REFUSE block below is organised by the shape of the staging, not by the
-# byte: what the gate reads has to follow from the command. And the ACCEPT block
-# is as long, because widening a gate that every commit passes through is how a
-# fix turns into a wedge -- `git commit -a` in particular must NOT pick up an
-# untracked file, since `-a` does not.
+# byte: what the gate reads has to follow from the command. Review of the first
+# fix found three more members of the SAME family, all of them measured, none of
+# them visible to the 52 cases that were green at the time:
+#
+#   * a PATHSPEC on `git commit` is an implicit `--only`, so
+#     `git commit -m x f.ts` commits the WORKING TREE and ignores the index;
+#   * `git ls-files` is CWD-scoped while `git add -A` is whole-tree, so from a
+#     SUBDIRECTORY the scan missed everything outside it -- no case had ever
+#     used a subdirectory cwd;
+#   * an UNKNOWN `git add` flag's value was read as a pathspec, which also
+#     suppressed the whole-tree fallback.
+#
+# And the ACCEPT block is as long, because widening a gate that every commit
+# passes through is how a fix turns into a wedge -- `git commit -a` in
+# particular must NOT pick up an untracked file, since `-a` does not, and
+# DELETING the offending file is the remediation this gate's own message asks
+# for, so it cannot be refused.
 #
 # HERMETICITY. Each axis is either pinned or measured-and-recorded:
 #   git repo     every case gets its OWN `mktemp -d` + `git init`, populated by
 #                its `setup` argument. No case reads this repository, so the
 #                suite cannot pass or fail on the state of the worktree it runs
 #                in -- measured by running it from the repo root with a dirty
-#                tree, from /tmp, and from $HOME (not a repo at all): 52/52
+#                tree, from /tmp, and from $HOME (not a repo at all): 93/93
 #                each time.
 #   cwd          pinned per case through the payload's `cwd` field: the case's
 #                own repo, or (for the `git -C` cases) a directory that is NOT a
@@ -87,7 +100,7 @@ mk_repo() {
   printf '%s' "$r"
 }
 
-# run_case <name> <want_exit> <setup> <cmd> [<want_fragment>] [repo|outside]
+# run_case <name> <want_exit> <setup> <cmd> [<want_fragment>] [repo|outside|<subdir>]
 #
 # 2 = blocked, 0 = allowed through. `{REPO}` in <cmd> is replaced with the
 # case's repository path. <want_fragment> ("-" or omitted to skip) must appear
@@ -95,6 +108,13 @@ mk_repo() {
 # file" from "blocked on something else", which is the same lesson
 # gate-command-recognition.test.sh learned by asserting what a gate ASKS its
 # verifier rather than only what it answers.
+#
+# The last argument is the payload's `cwd`: the repo root, a directory that is
+# NOT a repo, or a SUBDIRECTORY of the repo. That third mode is not decoration
+# -- `git ls-files` lists only what is under its CWD while `git add -A` and
+# `git commit -a` are whole-tree, so a scan run in a subdirectory silently
+# missed everything else in the repository. No case used a subdirectory cwd,
+# which is exactly why 52 green cases did not see it.
 run_case() {
   local name="$1" want="$2" setup="$3" cmd="$4" frag="${5:--}" where="${6:-repo}"
   local repo got out payload cwd
@@ -102,7 +122,8 @@ run_case() {
   cmd="${cmd//\{REPO\}/$repo}"
   case "$where" in
     outside) cwd="$SANDBOX" ;;
-    *)       cwd="$repo" ;;
+    repo)    cwd="$repo" ;;
+    *)       cwd="$repo/$where" ;;
   esac
   payload=$(jq -nc --arg c "$cmd" --arg d "$cwd" \
     '{tool_name:"Bash", cwd:$d, tool_input:{command:$c}}')
@@ -123,6 +144,33 @@ run_case() {
   pass=$((pass + 1)); printf 'OK   %-62s %s\n' "$name" "(exit $got)"
 }
 
+# run_count <name> <want_offender_lines> <setup> <cmd> [repo|outside|<subdir>]
+# Asserts the number of "  - <file>" lines. The gate collects a file once per
+# PROVENANCE (staged blob / working-tree copy) and both are scanned, so the
+# REPORT has to fold them back into one line -- otherwise the ordinary
+# `git add -A && git commit` over an already-staged file names it twice.
+run_count() {
+  local name="$1" want="$2" setup="$3" cmd="$4" where="${5:-repo}"
+  local repo out got cwd
+  repo="$(mk_repo "$setup")"
+  cmd="${cmd//\{REPO\}/$repo}"
+  case "$where" in
+    outside) cwd="$SANDBOX" ;;
+    repo)    cwd="$repo" ;;
+    *)       cwd="$repo/$where" ;;
+  esac
+  out=$(jq -nc --arg c "$cmd" --arg d "$cwd" \
+      '{tool_name:"Bash", cwd:$d, tool_input:{command:$c}}' \
+    | env -i PATH="$PINNED_PATH" HOME="$SANDBOX" bash "$GATE" 2>&1)
+  got=$(printf '%s\n' "$out" | grep -c '^  - ')
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-62s %s\n' "$name" "($got reported)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s reported line(s), got %s)\n  out: %s\n' \
+      "$name" "$want" "$got" "$out"
+  fi
+}
+
 # The offending files, written from escapes. `probe.ts` carries a NUL on line 1;
 # `soh.ts` carries a 0x01, so the suite is not pinned to NUL alone.
 NUL_FILE='printf "const a = \"x\000y\";\n" > probe.ts'
@@ -130,6 +178,10 @@ SOH_FILE='printf "const a = \"x\001y\";\n" > soh.ts'
 # A committed, then locally MODIFIED, NUL file -- the only shape `git commit -a`
 # actually stages.
 TRACKED_NUL='echo clean > probe.ts; git add probe.ts; git commit -qm init; '"$NUL_FILE"
+# The same shape at the repo ROOT, plus a subdirectory that a case can `cd` into.
+# `root.ts` is COMMITTED CLEAN, so the index is clean and only the working copy
+# carries the NUL -- which is what makes an index-only scan answer "clean".
+ROOT_NUL='mkdir -p sub; echo hi > sub/a.ts; echo clean > root.ts; git add -A; git commit -qm init; printf "const a = \"x\000y\";\n" > root.ts'
 
 echo "== REFUSE: the command stages, so the WORKING TREE is in the commit ========"
 # THE case that fails on the pre-fix gate. Everything else in this block is a
@@ -208,6 +260,76 @@ run_case "git add -f over a gitignored file"       2 "$NUL_FILE; echo probe.ts >
   'git add -f probe.ts && git commit -m x' 'probe.ts'
 
 echo
+echo "== REFUSE: a PATHSPEC on git commit is an implicit --only =================="
+# `git commit -m x f.ts` commits the WORKING-TREE content of f.ts and IGNORES
+# the index for it. The commit-argument walk used to read flags only and let
+# positionals fall through, so with the index clean this shipped a NUL. Reading
+# the positional means also knowing which flags take a SEPARATE value, or `-m`'s
+# own message text reads as a pathspec and the real one is never reached.
+run_case "commit -m x <pathspec>"                  2 "$TRACKED_NUL" \
+  'git commit -m x probe.ts' 'probe.ts (line(s): 1)'
+run_case "commit -o -m x <pathspec> (--only)"      2 "$TRACKED_NUL" \
+  'git commit -o -m x probe.ts' 'probe.ts'
+run_case "commit --only -m x <pathspec>"           2 "$TRACKED_NUL" \
+  'git commit --only -m x probe.ts' 'probe.ts'
+run_case "commit -i -m x <pathspec> (--include)"   2 "$TRACKED_NUL" \
+  'git commit -i -m x probe.ts' 'probe.ts'
+run_case "commit -m x -- <pathspec>"               2 "$TRACKED_NUL" \
+  'git commit -m x -- probe.ts' 'probe.ts'
+run_case "commit -F msg.txt <pathspec>"            2 "$TRACKED_NUL; echo m > m.txt" \
+  'git commit -F m.txt probe.ts' 'probe.ts'
+# `-o` / `-i` with no pathspec of their own: cannot be scoped, so widen. BOTH
+# spellings, because they are read by DIFFERENT code -- the long form by the
+# `--only|--include` case arm, the short one by the short-flag cluster walk.
+# Only pinning `-o` left the long arm unfenced: a mutation deleting it kept the
+# suite 89/89 green.
+run_case "commit -o with no pathspec widens"       2 "$TRACKED_NUL" \
+  'git commit -o -m x' 'probe.ts'
+run_case "commit --only with no pathspec widens"   2 "$TRACKED_NUL" \
+  'git commit --only -m x' 'probe.ts'
+run_case "commit --include with no pathspec widens" 2 "$TRACKED_NUL" \
+  'git commit --include -m x' 'probe.ts'
+run_case "commit -i with no pathspec widens"       2 "$TRACKED_NUL" \
+  'git commit -i -m x' 'probe.ts'
+run_case "commit -p (interactive hunks)"           2 "$TRACKED_NUL" \
+  'git commit -p -m x' 'probe.ts'
+run_case "commit --interactive"                    2 "$TRACKED_NUL" \
+  'git commit --interactive' 'probe.ts'
+
+echo
+echo "== REFUSE: unrestricted staging is WHOLE-TREE, not CWD-scoped =============="
+# `git ls-files` lists only what is under its CWD, while `git add -A` and
+# `git commit -a` have been whole-tree since git 2.0. Run from a subdirectory,
+# the scan used to miss a control byte anywhere else in the repository -- the
+# same fail-open class as the issue itself, and invisible to every case that
+# runs at the repo root.
+run_case "from a subdir: add -A, NUL at the root"  2 "$ROOT_NUL" \
+  'git add -A && git commit -m x' 'root.ts (line(s): 1)' sub
+run_case "from a subdir: commit -am, NUL at root"  2 "$ROOT_NUL" \
+  'git commit -am x' 'root.ts' sub
+run_case "from a subdir: add -u, NUL at the root"  2 "$ROOT_NUL" \
+  'git add -u && git commit -m x' 'root.ts' sub
+run_case "from a subdir: commit <pathspec> upward" 2 "$ROOT_NUL" \
+  'git commit -m x ../root.ts' 'root.ts' sub
+
+echo
+echo "== REFUSE: git stage is git add ==========================================="
+run_case "git stage -A"                            2 "$NUL_FILE" \
+  'git stage -A && git commit -m x' 'probe.ts'
+run_case "git stage <pathspec>"                    2 "$NUL_FILE" \
+  'git stage probe.ts && git commit -m x' 'probe.ts'
+
+echo
+echo "== REFUSE: an UNKNOWN git add flag must not suppress the fallback =========="
+# The unknown flag's value used to be read as a pathspec, which ALSO set
+# `seen_pathspec` and so suppressed the whole-tree fallback -- a fail-open, not
+# a widen. An unknown flag now drops the restriction instead.
+run_case "git add --future-flag <value>"           2 "$NUL_FILE" \
+  'git add --future-flag somevalue && git commit -m x' 'probe.ts'
+run_case "git add -Av (unrecognised cluster)"      2 "$NUL_FILE" \
+  'git add -Av && git commit -m x' 'probe.ts'
+
+echo
 echo "== REFUSE: the pre-existing INDEX scan is untouched ========================"
 run_case "already staged, plain git commit"        2 "$NUL_FILE; git add -A" \
   'git commit -m x' 'probe.ts (line(s): 1)'
@@ -221,8 +343,17 @@ run_case "staged NUL, worktree since cleaned"      2 "$NUL_FILE; git add probe.t
 echo
 echo "== ACCEPT: nothing the commit will contain has a control byte =============="
 # THE regression the fix must not break: no staging in the command, so the
-# working tree is none of the gate's business and the index is clean.
+# working tree is none of the gate's business.
 run_case "unstaged NUL, plain commit (no add)"     0 "$NUL_FILE" \
+  'git commit -m x'
+# The same claim over a TRACKED file, which is the sharper half: the index entry
+# EXISTS and is clean, and only the copy on disk is dirty. A gate that reads
+# disk-first for every candidate would block a commit that is genuinely clean.
+# Provenance is what keeps these two apart -- an index candidate is read out of
+# the index and never off disk, and vice versa. The mirror image of this case is
+# "staged NUL, worktree since cleaned" in the REFUSE block, which must still
+# block; together they pin that neither side is simply winning.
+run_case "clean staged blob, dirty working copy"   0 'echo clean > probe.ts; git add probe.ts; printf "x\000y\n" > probe.ts' \
   'git commit -m x'
 # The three cases below carry a TRACKED, LOCALLY MODIFIED NUL file, not an
 # untracked one, and that is the whole point of them: they exist to catch a
@@ -269,6 +400,76 @@ run_case "tab and CRLF only"                       0 'printf "a\tb\r\nc\n" > t.t
 # report a file that is not in the commit at all -- the false-block direction.
 run_case "symlink to a NUL file is not followed"   0 'printf "x\000y\n" > real.ts; ln -s real.ts link.ts; echo real.ts > .gitignore' \
   'git add -A && git commit -m x'
+# A flag VALUE is not a pathspec. Each of these would otherwise be read as an
+# implicit `--only` on a file that happens to share the name.
+run_case "commit -m <value that looks like a path>" 0 "$TRACKED_NUL" \
+  'git commit --amend -m probe.ts'
+run_case "commit --file <value>"                   0 "$TRACKED_NUL; echo m > m.txt" \
+  'git commit --file m.txt'
+run_case "commit --author <value>"                 0 "$TRACKED_NUL" \
+  'git commit --amend --author "A U Thor <a@example.com>"'
+run_case "commit -uall is -u all, not -a"          0 "$TRACKED_NUL" \
+  'git commit -uall --amend --no-edit'
+# A pathspec-RESTRICTED scan still runs where the command does, so a subdirectory
+# pathspec must NOT reach out to the rest of the repo.
+run_case "from a subdir: scoped add stays scoped"  0 "$ROOT_NUL" \
+  'git add a.ts && git commit -m x' - sub
+
+echo
+echo "== ACCEPT: removing the offending file is the REMEDIATION =================="
+# The gate's own message says to get rid of the control byte. Blocking the
+# removal wedges that. Two timings, and only the second is visible in the tree:
+# a `rm` in an EARLIER call leaves no file on disk, while a `rm` in the SAME
+# call has not run yet when the hook looks -- so that one is read off the
+# command, exactly like the staging is.
+STAGED_NUL="$NUL_FILE; git add probe.ts"
+run_case "rm in an earlier call, then add -A"      0 "$STAGED_NUL; rm probe.ts" \
+  'git add -A && git commit -m drop-it'
+run_case "rm in the SAME call as the commit"       0 "$STAGED_NUL" \
+  'rm probe.ts && git add -A && git commit -m drop-it'
+run_case "git rm -f stages the removal itself"     0 "$STAGED_NUL" \
+  'git rm -f probe.ts && git commit -m drop-it'
+run_case "rm -rf <dir> covers the files under it"  0 'mkdir -p s; printf "x\000y\n" > s/probe.ts; git add s/probe.ts' \
+  'rm -rf s && git add -A && git commit -m drop-it'
+# ...and the removal must be READ, not assumed. Each of these still blocks.
+run_case "rm naming a DIFFERENT file still blocks" 2 "$STAGED_NUL" \
+  'rm other.ts && git add -A && git commit -m x' 'probe.ts'
+run_case "git rm --cached, then add -A re-adds it" 2 "$STAGED_NUL" \
+  'git rm --cached probe.ts && git add -A && git commit -m x' 'probe.ts'
+run_case "rm with an unexpanded path still blocks" 2 "$STAGED_NUL" \
+  'rm $F && git add -A && git commit -m x' 'probe.ts'
+run_case "a quoted mention of rm still blocks"     2 "$STAGED_NUL" \
+  'echo "rm probe.ts" && git add -A && git commit -m x' 'probe.ts'
+run_case "rmdir is not rm"                         2 "$STAGED_NUL" \
+  'rmdir probe.ts && git add -A && git commit -m x' 'probe.ts'
+# A GLOB in the removal is not recorded at all, because git's pathspec language
+# is broader than the shell's: the shell expands `rm *.ts` against the CWD, while
+# `ls-files -- '*.ts'` matches every .ts in the REPOSITORY -- so honouring it
+# would suppress the scan of a file the `rm` never touches. Here `sub/probe.ts`
+# is staged and would survive the shell's `rm *.ts`.
+run_case "a glob in rm suppresses nothing"         2 'mkdir -p sub; printf "x\000y\n" > sub/probe.ts; git add sub/probe.ts; echo hi > root.ts' \
+  'rm *.ts && git add -A && git commit -m x' 'sub/probe.ts'
+# A plain `rm` stages nothing, so without a whole-tree staging the blob still
+# commits. ERRS TOWARD BLOCKING, because a wrong entry in the removal list is
+# the one place in this gate where a mistake SUPPRESSES a scan.
+run_case "rm with NO staging in the call"          2 "$STAGED_NUL" \
+  'rm probe.ts && git commit -m x' 'probe.ts'
+run_case "rm under a pathspec-restricted staging"  2 "$STAGED_NUL" \
+  'rm probe.ts && git add probe.ts && git commit -m x' 'probe.ts'
+
+echo
+echo "== one report line per FILE, whatever its provenance ======================="
+# The file is BOTH a staged blob and a dirty working copy here, and both are
+# scanned. Before the keys were made root-relative, an index entry keyed off the
+# command's directory and a working-tree entry keyed off the repo root, so from
+# a subdirectory the same file was named twice.
+run_count "staged AND dirty, at the repo root"     1 "$NUL_FILE; git add probe.ts; printf \"x\000z\n\" > probe.ts" \
+  'git add -A && git commit -m x'
+run_count "staged AND dirty, from a subdirectory"  1 'mkdir -p sub; printf "x\000y\n" > root.ts; git add root.ts; printf "x\000z\n" > root.ts' \
+  'git add -A && git commit -m x' sub
+run_count "a clean commit reports nothing"         0 'echo hi > a.txt' \
+  'git add -A && git commit -m x'
+
 echo
 echo "== ACCEPT: binary/asset extensions are skipped on BOTH scans ==============="
 run_case "NUL in a .png, staged by the command"    0 'printf "x\000y" > i.png' \

--- a/.claude/hooks/control-char-gate.test.sh
+++ b/.claude/hooks/control-char-gate.test.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# Behavioral test for control-char-gate.sh, driven through the REAL hook with
+# real PreToolUse payloads against real throwaway git repositories. Run from the
+# repo root:
+#   bash .claude/hooks/control-char-gate.test.sh
+#
+# WHAT THIS FILE EXISTS TO PIN (go-to-k/cdk-local#576). A PreToolUse hook runs
+# BEFORE the command it gates, and the gate used to scan the INDEX only. So
+#
+#   git add -A && git commit -F msg.txt
+#
+# in ONE Bash call handed the gate the tree as it was BEFORE the `git add`:
+# nothing was staged for the offending file, the gate found nothing, exit 0, and
+# the control byte shipped. That happened on main. The gate was registered, did
+# fire, and answered "clean" -- "registration is not execution" arriving through
+# COMMAND SHAPE rather than through a broken matcher, which is precisely the
+# class an exit-code-only fence cannot see.
+#
+# So the REFUSE block below is organised by the shape of the staging, not by the
+# byte: what the gate reads has to follow from the command. And the ACCEPT block
+# is as long, because widening a gate that every commit passes through is how a
+# fix turns into a wedge -- `git commit -a` in particular must NOT pick up an
+# untracked file, since `-a` does not.
+#
+# HERMETICITY. Each axis is either pinned or measured-and-recorded:
+#   git repo     every case gets its OWN `mktemp -d` + `git init`, populated by
+#                its `setup` argument. No case reads this repository, so the
+#                suite cannot pass or fail on the state of the worktree it runs
+#                in -- measured by running it from the repo root with a dirty
+#                tree, from /tmp, and from $HOME (not a repo at all): 52/52
+#                each time.
+#   cwd          pinned per case through the payload's `cwd` field: the case's
+#                own repo, or (for the `git -C` cases) a directory that is NOT a
+#                repo at all, so only the flag can resolve the tree.
+#   env          pinned with `env -i`; only PATH, HOME and the payload reach it.
+#   PATH         pinned to /usr/bin:/bin, so the gate runs against the SYSTEM
+#                git / perl / jq and the system `bash`. On macOS that is bash
+#                3.2, which is deliberate: the shipped hook has to work under
+#                whatever bash the user has, and the pre-fix gate used
+#                `mapfile -d ''` -- "command not found" there, after which it
+#                exited 1 having scanned nothing.
+#   $HOME        pinned to a throwaway dir, so no user dotfile and no
+#                ~/.gitconfig is read; user.name / user.email are set per repo.
+#   clock        not read -- no TTL, no marker store.
+#
+# NO LITERAL CONTROL BYTES LIVE IN THIS FILE. The offending bytes are written by
+# `printf` from `\000` / `\001` escapes at run time. Spelling one literally here
+# is the very defect under test, and `tests/unit/no-control-bytes.test.ts` would
+# fail CI over it.
+
+set -u
+
+HOOKS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$HOOKS/control-char-gate.sh"
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PINNED_PATH=/usr/bin:/bin
+
+# Every one of these is load-bearing, and their absence would make the suite
+# pass VACUOUSLY rather than fail: without `jq` the gate reads an EMPTY command
+# and every ACCEPT case is satisfied by a gate that never ran; without `git` or
+# `perl` the gate fails open by design and the same thing happens. So the
+# harness refuses to run rather than reporting green over nothing.
+for tool in jq git perl; do
+  if ! PATH="$PINNED_PATH" command -v "$tool" >/dev/null 2>&1; then
+    echo "FATAL: $tool is not on the pinned PATH ($PINNED_PATH), so cases would pass vacuously." >&2
+    exit 1
+  fi
+done
+
+pass=0; fail=0
+
+# mk_repo <setup>
+# A fresh repository with `setup` evaluated inside it. Prints its path.
+mk_repo() {
+  local r
+  r="$(mktemp -d "$SANDBOX/repo.XXXXXX")"
+  (
+    cd "$r" || exit 1
+    git init -q .
+    git config user.email t@example.com
+    git config user.name "Gate Test"
+    git config commit.gpgsign false
+    eval "$1"
+  ) >/dev/null 2>&1
+  printf '%s' "$r"
+}
+
+# run_case <name> <want_exit> <setup> <cmd> [<want_fragment>] [repo|outside]
+#
+# 2 = blocked, 0 = allowed through. `{REPO}` in <cmd> is replaced with the
+# case's repository path. <want_fragment> ("-" or omitted to skip) must appear
+# in the gate's output: an exit code alone cannot tell "blocked on the right
+# file" from "blocked on something else", which is the same lesson
+# gate-command-recognition.test.sh learned by asserting what a gate ASKS its
+# verifier rather than only what it answers.
+run_case() {
+  local name="$1" want="$2" setup="$3" cmd="$4" frag="${5:--}" where="${6:-repo}"
+  local repo got out payload cwd
+  repo="$(mk_repo "$setup")"
+  cmd="${cmd//\{REPO\}/$repo}"
+  case "$where" in
+    outside) cwd="$SANDBOX" ;;
+    *)       cwd="$repo" ;;
+  esac
+  payload=$(jq -nc --arg c "$cmd" --arg d "$cwd" \
+    '{tool_name:"Bash", cwd:$d, tool_input:{command:$c}}')
+  out=$(printf '%s' "$payload" | env -i PATH="$PINNED_PATH" HOME="$SANDBOX" \
+    bash "$GATE" 2>&1); got=$?
+  if [ "$got" != "$want" ]; then
+    fail=$((fail + 1))
+    printf 'FAIL %s (want exit %s, got %s)\n  cmd: %s\n  out: %s\n' \
+      "$name" "$want" "$got" "$cmd" "$out"
+    return
+  fi
+  if [ "$frag" != "-" ] && ! printf '%s' "$out" | grep -qF "$frag"; then
+    fail=$((fail + 1))
+    printf 'FAIL %s (exit %s as wanted, but output does not name "%s")\n  out: %s\n' \
+      "$name" "$got" "$frag" "$out"
+    return
+  fi
+  pass=$((pass + 1)); printf 'OK   %-62s %s\n' "$name" "(exit $got)"
+}
+
+# The offending files, written from escapes. `probe.ts` carries a NUL on line 1;
+# `soh.ts` carries a 0x01, so the suite is not pinned to NUL alone.
+NUL_FILE='printf "const a = \"x\000y\";\n" > probe.ts'
+SOH_FILE='printf "const a = \"x\001y\";\n" > soh.ts'
+# A committed, then locally MODIFIED, NUL file -- the only shape `git commit -a`
+# actually stages.
+TRACKED_NUL='echo clean > probe.ts; git add probe.ts; git commit -qm init; '"$NUL_FILE"
+
+echo "== REFUSE: the command stages, so the WORKING TREE is in the commit ========"
+# THE case that fails on the pre-fix gate. Everything else in this block is a
+# spelling of it.
+run_case "issue repro: add -A && commit -m"        2 "$NUL_FILE" \
+  'git add -A && git commit -m x' 'probe.ts (line(s): 1)'
+# The literal shape from the issue: `git commit -F <file>` is what this repo's
+# commit-msg-heredoc-gate MANDATES, so it is the spelling agents actually write.
+run_case "issue repro: add -A && commit -F msg"    2 "$NUL_FILE; echo msg > m.txt" \
+  'git add -A && git commit -F m.txt' 'probe.ts'
+run_case "a 0x01, not only NUL"                    2 "$SOH_FILE" \
+  'git add -A && git commit -m x' 'soh.ts (line(s): 1)'
+run_case "git add --all (long form)"               2 "$NUL_FILE" \
+  'git add --all && git commit -m x' 'probe.ts'
+run_case "git add . "                              2 "$NUL_FILE" \
+  'git add . && git commit -m x' 'probe.ts'
+run_case "git add <the file itself>"               2 "$NUL_FILE" \
+  'git add probe.ts && git commit -m x' 'probe.ts'
+run_case "git add <dir> containing it"             2 'mkdir -p s; printf "x\000y\n" > s/probe.ts' \
+  'git add s && git commit -m x' 's/probe.ts'
+run_case "quoted pathspec with a space"            2 'mkdir -p "d i r"; printf "x\000y\n" > "d i r/probe.ts"' \
+  'git add "d i r" && git commit -m x' 'd i r/probe.ts'
+run_case "git add -u over a TRACKED modification"  2 "$TRACKED_NUL" \
+  'git add -u && git commit -m x' 'probe.ts'
+run_case "separate segments: add; commit"          2 "$NUL_FILE" \
+  'git add -A; git commit -m x' 'probe.ts'
+run_case "multi-line add then commit"              2 "$NUL_FILE" \
+  'git add -A
+git commit -m x' 'probe.ts'
+run_case "cd <repo> && add -A && commit"           2 "$NUL_FILE" \
+  'cd {REPO} && git add -A && git commit -m x' 'probe.ts' outside
+run_case "git -C <repo> add / git -C <repo> commit" 2 "$NUL_FILE" \
+  'git -C {REPO} add -A && git -C {REPO} commit -m x' 'probe.ts' outside
+# The add and the commit naming DIFFERENT directories: both are scanned, which
+# is the deliberate broad branch.
+run_case "add -C <repo>, commit -C <repo> (split)" 2 "$NUL_FILE" \
+  'git -C {REPO} add -A && cd {REPO} && git commit -m x' 'probe.ts' outside
+# Launcher shapes. These must behave exactly like their plain spellings, which
+# is what sourcing gate_segments / gate_strip_prefix buys instead of a second
+# tokenizer written here (go-to-k/cdk-local#585).
+run_case "mise exec -- git add"                    2 "$NUL_FILE" \
+  'mise exec -- git add -A && git commit -m x' 'probe.ts'
+run_case "bash -c hosting both"                    2 "$NUL_FILE" \
+  'bash -c "git add -A && git commit -m x"' 'probe.ts'
+run_case "mise exec -c hosting both"               2 "$NUL_FILE" \
+  'mise exec -c "git add -A && git commit -m x"' 'probe.ts'
+run_case "leading env assignment"                  2 "$NUL_FILE" \
+  'FOO=1 git add -A && git commit -m x' 'probe.ts'
+run_case "inside a subshell"                       2 "$NUL_FILE" \
+  '(git add -A && git commit -m x)' 'probe.ts'
+
+echo
+echo "== REFUSE: git commit -a stages TRACKED MODIFICATIONS ======================"
+run_case "commit -am over a tracked modification"  2 "$TRACKED_NUL" \
+  'git commit -am x' 'probe.ts'
+run_case "commit -a -m over a tracked modification" 2 "$TRACKED_NUL" \
+  'git commit -a -m x' 'probe.ts'
+run_case "commit --all over a tracked modification" 2 "$TRACKED_NUL" \
+  'git commit --all -m x' 'probe.ts'
+
+echo
+echo "== REFUSE: shapes the gate cannot compute, so it scans MORE ================"
+# Each of these is a deliberate over-approximation: a false block costs one
+# message and a re-run, a false pass is the bug this gate exists for.
+run_case "git add -p (interactive: cannot compute)" 2 "$NUL_FILE" \
+  'git add -p && git commit -m x' 'probe.ts'
+run_case "git add -i (interactive: cannot compute)" 2 "$NUL_FILE" \
+  'git add -i && git commit -m x' 'probe.ts'
+run_case "--pathspec-from-file (spec is in a file)" 2 "$NUL_FILE; echo probe.ts > list" \
+  'git add --pathspec-from-file=list && git commit -m x' 'probe.ts'
+run_case "unexpanded pathspec (git add \$FILE)"     2 "$NUL_FILE" \
+  'git add $FILE && git commit -m x' 'probe.ts'
+# `git add -f` bounded by a pathspec really can stage a gitignored file, so
+# --exclude-standard is dropped for exactly that shape.
+run_case "git add -f over a gitignored file"       2 "$NUL_FILE; echo probe.ts > .gitignore" \
+  'git add -f probe.ts && git commit -m x' 'probe.ts'
+
+echo
+echo "== REFUSE: the pre-existing INDEX scan is untouched ========================"
+run_case "already staged, plain git commit"        2 "$NUL_FILE; git add -A" \
+  'git commit -m x' 'probe.ts (line(s): 1)'
+run_case "already staged, commit -F"               2 "$NUL_FILE; git add -A; echo m > m.txt" \
+  'git commit -F m.txt' 'probe.ts'
+# Staged dirty, then CLEANED in the worktree: the staged blob is what gets
+# committed, so the index scan has to survive a clean working copy.
+run_case "staged NUL, worktree since cleaned"      2 "$NUL_FILE; git add probe.ts; echo clean > probe.ts" \
+  'git commit -m x' 'probe.ts'
+
+echo
+echo "== ACCEPT: nothing the commit will contain has a control byte =============="
+# THE regression the fix must not break: no staging in the command, so the
+# working tree is none of the gate's business and the index is clean.
+run_case "unstaged NUL, plain commit (no add)"     0 "$NUL_FILE" \
+  'git commit -m x'
+# The three cases below carry a TRACKED, LOCALLY MODIFIED NUL file, not an
+# untracked one, and that is the whole point of them: they exist to catch a
+# false read of `--all` / `-a`, and `-a` stages tracked modifications ONLY. Over
+# an untracked file a wrongly-widened `-a` still finds nothing, so the case
+# would pass under the very mutation it is meant to fence -- measured, not
+# assumed: with `--all` relaxed to a `--a*` prefix (so `--amend` reads as
+# `--all`) and with the short-cluster walk no longer stopping at a value-taking
+# flag (so `-Fa` reads as `-a`), the untracked spelling of these cases stayed
+# 51/51 GREEN.
+# `--amend` / `--allow-empty` / `--author` all begin `--a` and none of them
+# stages anything, so the long-form match has to be exact.
+run_case "commit --amend is not --all"             0 "$TRACKED_NUL" \
+  'git commit --amend --no-edit'
+run_case "commit --allow-empty is not --all"       0 "$TRACKED_NUL" \
+  'git commit --allow-empty -m x'
+# `-F` takes a value, so the `a` in `-Fa` is a message FILENAME and not `--all`.
+# Reading it as `-a` would be a false widen; the cluster walk stops at `F`.
+run_case "commit -Fa is -F a, not -a"              0 "$TRACKED_NUL; printf x > a" \
+  'git commit -Fa'
+# ...and the same cluster must still FIND the `a` when it really is a flag, so
+# the stop rule cannot degrade into "never read a cluster at all". That is the
+# `commit -am` case in the REFUSE block above.
+# `-a` stages TRACKED modifications only. An UNTRACKED file is not one, and
+# getting this wrong in either direction is a defect rather than a rounding.
+run_case "commit -am over an UNTRACKED NUL file"   0 "$NUL_FILE" \
+  'git commit -am x'
+run_case "commit --all over an UNTRACKED NUL file" 0 "$NUL_FILE" \
+  'git commit --all -m x'
+# `git add -u` likewise cannot introduce an untracked file.
+run_case "git add -u with the NUL file UNTRACKED"  0 "$NUL_FILE" \
+  'git add -u && git commit -m x'
+run_case "clean tree, add -A && commit"            0 'echo hi > a.txt' \
+  'git add -A && git commit -m x'
+run_case "pathspec that does not cover the file"   0 "$NUL_FILE; echo hi > b.txt" \
+  'git add b.txt && git commit -m x'
+run_case "gitignored NUL file, add -A"             0 "$NUL_FILE; echo probe.ts > .gitignore" \
+  'git add -A && git commit -m x'
+# Tab / LF / CR are legal text and must never be reported.
+run_case "tab and CRLF only"                       0 'printf "a\tb\r\nc\n" > t.ts' \
+  'git add -A && git commit -m x'
+# A symlink's blob is the link TARGET PATH, not the pointee's bytes, so a link
+# to a control-byte-bearing file adds nothing to the commit. Following it would
+# report a file that is not in the commit at all -- the false-block direction.
+run_case "symlink to a NUL file is not followed"   0 'printf "x\000y\n" > real.ts; ln -s real.ts link.ts; echo real.ts > .gitignore' \
+  'git add -A && git commit -m x'
+echo
+echo "== ACCEPT: binary/asset extensions are skipped on BOTH scans ==============="
+run_case "NUL in a .png, staged by the command"    0 'printf "x\000y" > i.png' \
+  'git add -A && git commit -m x'
+run_case "NUL in a .woff2, already staged"         0 'printf "x\000y" > f.woff2; git add -A' \
+  'git commit -m x'
+run_case "uppercase .PNG (case-insensitive skip)"  0 'printf "x\000y" > I.PNG' \
+  'git add -A && git commit -m x'
+
+echo
+echo "== ACCEPT: not a gated command ============================================="
+run_case "git push"                                0 "$NUL_FILE; git add -A" 'git push origin HEAD'
+run_case "git add on its own (no commit)"          0 "$NUL_FILE" 'git add -A'
+run_case "a quoted mention of the command"         0 "$NUL_FILE; git add -A" 'echo "git commit -m x"'
+run_case "git commit-tree is not git commit"       0 "$NUL_FILE; git add -A" 'git commit-tree HEAD^{tree}'
+run_case "empty command"                           0 "$NUL_FILE; git add -A" ''
+
+echo
+echo "== the harness itself ======================================================"
+# The gate must FAIL CLOSED when the shared library is unusable, rather than
+# waving every commit through. Two shapes: absent, and present-but-older -- a
+# copy predating `gate_verb_args`, which is what READS `git add`'s pathspecs. On
+# an older copy the staging scan would be silently absent, i.e. exactly the
+# false pass go-to-k/cdk-local#576 is about, so it must not degrade to exit 0.
+#
+# The expected message fragment is load-bearing rather than decoration: deleting
+# the library trips BOTH the readability guard and the `declare -F` guard after
+# the failed source, so asserting only "exit 2 mentioning _command-match.sh"
+# would be satisfied twice over and neither guard would be fenced.
+fail_closed() {
+  local name="$1" want="$2" mutate="$3" tmp out rc repo
+  tmp="$SANDBOX/lib.$RANDOM"; mkdir -p "$tmp"
+  cp "$GATE" "$tmp/"
+  cp "$HOOKS/_command-match.sh" "$tmp/"
+  eval "$mutate"
+  repo="$(mk_repo "$NUL_FILE")"
+  out=$(jq -nc --arg d "$repo" \
+      '{tool_name:"Bash",cwd:$d,tool_input:{command:"git add -A && git commit -m x"}}' \
+    | env -i PATH="$PINNED_PATH" HOME="$SANDBOX" bash "$tmp/control-char-gate.sh" 2>&1); rc=$?
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "$want"; then
+    pass=$((pass + 1)); printf 'OK   %-62s %s\n' "$name" "(exit $rc)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s must exit 2 saying "%s" (got %s)\n  out: %s\n' \
+      "$name" "$want" "$rc" "$out"
+  fi
+}
+fail_closed "library absent" "is missing or unreadable" \
+  'rm -f "$tmp/_command-match.sh"'
+fail_closed "library predates gate_verb_args" "gate_verb_args is undefined" \
+  'perl -0pi -e "s/^gate_verb_args\(\) \{.*?^\}\n//ms" "$tmp/_command-match.sh"'
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -26,29 +26,99 @@ The hooks split into three classes:
 
 - **`control-char-gate.sh`** blocks `git commit` (incl. the
   `cd <path> && git commit` / `git -C <path> commit` worktree forms)
-  when a staged text file's blob contains a NUL (`\x00`) or any other
-  C0 control byte except tab / newline / carriage-return. Catches the
-  editing-artifact foot-gun where a separator lands as a raw control
+  when a text file the commit would contain has a NUL (`\x00`) or any
+  other C0 control byte except tab / newline / carriage-return. Catches
+  the editing-artifact foot-gun where a separator lands as a raw control
   byte inside source (the formatter / linter does NOT flag it, but it
   makes `grep` treat the file as binary and silently suppress matches,
-  and ships a control byte in committed text). Scans the STAGED BLOB
-  (`git show :<file>`) of each `--diff-filter=ACM` file, not the diff —
-  a NUL makes `git diff` report "Binary files differ" and hide the
-  added lines, so a diff-only scan would miss exactly this case.
+  and ships a control byte in committed text).
   Binary / asset extensions (images, fonts, archives, `.wasm`, etc.)
   are skipped (control bytes are legitimate there). Cwd-aware (same
   `git -C` > `cd` > payload `cwd` resolution as `branch-gate.sh`).
-  Fails open when `git` / `perl` are unavailable or nothing is staged.
-  No bypass marker — the fix is to remove the stray byte and re-stage.
+  Fails open when `git` / `perl` are unavailable or when neither scan
+  finds a candidate file. No bypass marker — the fix is to remove the
+  stray byte.
 
-  **The gate is not the only fence, because it is a PreToolUse hook and
-  therefore only ever sees the AGENT's tool calls.** Issue
-  go-to-k/cdk-local#576 records a command shape that walks past it —
-  `git add -A && git commit ...` in one call presents the gate with the
-  tree as it was BEFORE the `git add`, so nothing is staged yet for the
-  offending file. That is not hypothetical: on 2026-08-27
-  `src/local/front-door-server.ts` was found on `main` carrying two raw
-  NUL bytes (a regex character class and its comment in
+  **What it reads is decided by the COMMAND, not by the index**
+  (go-to-k/cdk-local#576). The first version scanned the STAGED BLOB
+  (`git show :<file>` over each `--diff-filter=ACM` entry) and nothing
+  else. That choice was right against the diff — a NUL makes `git diff`
+  report "Binary files differ" and hide the added lines, so a diff-only
+  scan would miss exactly this case — and wrong against the CLOCK: a
+  PreToolUse hook runs BEFORE the command it gates, so
+
+  ```bash
+  git add -A && git commit -F .commit-msg.txt
+  ```
+
+  in ONE Bash call handed the gate the tree as it was BEFORE the
+  `git add`. Nothing was staged for the offending file, the gate found
+  nothing, exit 0, and the control byte shipped. The gate was
+  registered, DID fire, and answered "clean" — "registration is not
+  execution" arriving through command shape rather than through a broken
+  matcher. And that shape is the common one, not an edge case: this
+  repo's own `check-gate.sh` short-circuits the whole Bash call, so
+  splitting staging and committing into two calls costs two gate round
+  trips.
+
+  So the scan target now follows from the command:
+
+  | command shape | what is scanned |
+  |---|---|
+  | plain `git commit` | the INDEX (`git show :<file>`), as before |
+  | `… git add <spec> …` | the index **and** the working-tree content that add would bring in |
+  | `git commit -a` / `--all` | the index **and** the working-tree content of TRACKED MODIFIED files |
+
+  `git commit -a` stages tracked modifications ONLY — it never picks up
+  an untracked file, and neither does this. The index scan is kept ON
+  TOP of the working-tree one rather than replaced by it: a file staged
+  EARLIER and unmodified since is in the commit but is not "modified"
+  relative to the index, so `git ls-files --modified` never lists it.
+
+  The shape is decided with the shared `_command-match.sh` machinery
+  (`GATE_RE_GIT_ADD`, and `gate_verb_args` for the arguments after the
+  matched verb), never a second tokenizer, so `mise exec -- git add -A`,
+  `bash -c "…"`, `git -C <path> add`, quoted spans and multi-line
+  commands all behave as their plain spellings do. The `git add`
+  segment gets its OWN `gate_target_dir` resolution, so an add and a
+  commit naming different trees scan both.
+
+  **Where it must guess, it scans MORE** — a false block costs one
+  message and a re-run, a false pass is the bug above. `git add -p` /
+  `-i` (the human picks interactively), `--pathspec-from-file` (the
+  pathspecs are in a file), and an UNEXPANDED pathspec (`git add
+  "$FILE"`) all drop the pathspec restriction and scan the whole tree;
+  an unknown `git add` flag is treated as valueless, so if a future one
+  does take a value that value is read as an extra pathspec, which only
+  ever ADDS files. Two branches err NARROW, knowingly: `git add -f` with
+  NO pathspec keeps `--exclude-standard` (an unbounded walk of every
+  gitignored path would make the gate the slowest thing in the commit;
+  `-f` WITH a pathspec does drop it), and a symlink is skipped, because
+  git stages the link TARGET PATH as the blob and following it would
+  scan bytes the commit does not contain.
+
+  The gate is written to bash 3.2 — no `mapfile`, no `declare -A`. It
+  had used `mapfile -d ''`, which bash 3.2 does not have. Measured on
+  2026-08-27 against `main`, with a NUL-bearing file staged: under the
+  `#!/usr/bin/env bash` shebang's resolution on a host whose `PATH`
+  carries Homebrew bash (5.3.9 here) the gate answered rc=2 and blocked
+  correctly, while the same hook run as `/bin/bash control-char-gate.sh`
+  (3.2.57) printed `mapfile: command not found`, then `staged: unbound
+  variable`, and exited **1** having scanned nothing. So this was a
+  portability hazard rather than a live failure on a developer machine
+  with bash 5 — but rc=1 is not rc=2, so where it did bite it FAILED
+  OPEN: the commit proceeds, and the only signal is an error on stderr
+  that reads like noise from the hook rather than a refusal.
+
+  `.claude/hooks/control-char-gate.test.sh` (52 cases, run by
+  `vp run test:hooks`) drives all of the above through the real hook
+  against throwaway repositories, in BOTH directions.
+
+  **The gate is still not the only fence, because it is a PreToolUse
+  hook and therefore only ever sees the AGENT's tool calls** — a human
+  typing the same line into a terminal never passes through it. On
+  2026-08-27 `src/local/front-door-server.ts` was found on `main`
+  carrying two raw NUL bytes (a regex character class and its comment in
   `sanitizeRawHeaderValue`) — functionally correct JavaScript, so no test
   or type-check noticed, while `grep -c host` on that 49 KB file answered
   `0` and `file` reported it as `data`. That file is on the `UP_PATHS`
@@ -452,6 +522,14 @@ reviewer at all. All four now call **`gate_pr_selector`** in
 armed the gate — whatever flags it absorbed — and scans only what follows. A
 gate can no longer match one way and parse another. Each of the four also
 fails CLOSED if the library predates the helper.
+
+**`gate_verb_args`** is that same strip with the PR-number reader removed: it
+prints the text following the matched verb, one line per matching segment, and
+nothing else. `control-char-gate.sh` uses it to read `git add`'s pathspecs and
+`git commit`'s `-a` (go-to-k/cdk-local#576). A gate wanting something other than
+a PR number gets the derived-from-the-same-constant guarantee instead of writing
+the strip a fifth time — which is the maintenance shape that produced all four
+bugs above. It too fails CLOSED if the library predates it.
 
 `gate_target_dir`'s `-C` recognition was widened alongside, for the same reason:
 the absorber now admits `gh -C=/w/t pr merge 1`, which previously resolved to the

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -61,19 +61,58 @@ The hooks split into three classes:
   splitting staging and committing into two calls costs two gate round
   trips.
 
-  So the scan target now follows from the command:
+  So every candidate file is collected with its PROVENANCE, and provenance
+  decides which bytes are read: an INDEX candidate is read out of the
+  index (`git show :<file>`) and NEVER off disk, a WORKING-TREE candidate
+  off disk and NEVER out of the index. That is what keeps a plain
+  `git commit` an index-only verdict — a dirty working copy it is not
+  committing must not block it — while `git add -A && git commit` sees
+  the disk. Which candidates exist follows from the command:
 
-  | command shape | what is scanned |
+  | command shape | what is collected |
   |---|---|
-  | plain `git commit` | the INDEX (`git show :<file>`), as before |
-  | `… git add <spec> …` | the index **and** the working-tree content that add would bring in |
+  | plain `git commit` | the INDEX only (`--diff-filter=ACM`), as before |
+  | `… git add\|stage <spec> …` | the index **and** the working-tree content that add would bring in |
   | `git commit -a` / `--all` | the index **and** the working-tree content of TRACKED MODIFIED files |
+  | `git commit [-o\|-i\|--] <spec>` | the index **and** the working-tree content of those paths |
+
+  The last row was a straight fail-open until go-to-k/cdk-local#576's
+  review: a pathspec on `git commit` is an implicit `--only`, which
+  commits the WORKING-TREE content of those paths and ignores the index
+  for them, so `git commit -m x f.ts` shipped a NUL with the index
+  clean. Reading a positional means also knowing which flags take a
+  SEPARATE value, or `-m`'s own message text reads as a pathspec and the
+  real one is never reached.
 
   `git commit -a` stages tracked modifications ONLY — it never picks up
   an untracked file, and neither does this. The index scan is kept ON
   TOP of the working-tree one rather than replaced by it: a file staged
   EARLIER and unmodified since is in the commit but is not "modified"
   relative to the index, so `git ls-files --modified` never lists it.
+
+  **Unrestricted staging is scanned from the repo ROOT.** `git ls-files`
+  lists only what is under its CWD, while `git add -A` and `git commit -a`
+  have been whole-tree since git 2.0 — so run from a subdirectory the
+  scan used to miss a control byte anywhere else in the repository, the
+  same fail-open class as the issue itself and invisible to every case
+  that runs at the repo root. A pathspec-RESTRICTED scan still runs in
+  the command's own directory, because that is what its pathspecs are
+  relative to.
+
+  **Removing the offending file is the remediation, so it is not
+  blocked.** A path the staging DELETES has its index scan skipped:
+  either the file is already gone from disk, or THIS CALL is what
+  removes it (`rm bad.ts && git add -A && git commit`, where the hook
+  still sees the file, so the deletion is read off the command exactly
+  as the staging is). `git rm` counts on its own because it stages;
+  a plain `rm` only counts under a whole-tree staging, and `git rm
+  --cached` never counts because a following `git add -A` re-adds the
+  file. This is the ONE list in the gate where a wrong entry SUPPRESSES
+  a scan, so it errs toward blocking: an unexpanded path, a quoted
+  mention, `rmdir`, or a GLOB records nothing — git's pathspec language
+  is broader than the shell's, so honouring `rm *.ts` would suppress the
+  scan of every `.ts` in the repository rather than the ones the shell
+  would actually have deleted.
 
   The shape is decided with the shared `_command-match.sh` machinery
   (`GATE_RE_GIT_ADD`, and `gate_verb_args` for the arguments after the
@@ -87,10 +126,14 @@ The hooks split into three classes:
   message and a re-run, a false pass is the bug above. `git add -p` /
   `-i` (the human picks interactively), `--pathspec-from-file` (the
   pathspecs are in a file), and an UNEXPANDED pathspec (`git add
-  "$FILE"`) all drop the pathspec restriction and scan the whole tree;
-  an unknown `git add` flag is treated as valueless, so if a future one
-  does take a value that value is read as an extra pathspec, which only
-  ever ADDS files. Two branches err NARROW, knowingly: `git add -f` with
+  "$FILE"`) all drop the pathspec restriction and scan the whole tree.
+  So does an UNKNOWN `git add` flag: the valueless reading it used to
+  get was a FAIL-OPEN rather than a widen, because the flag's value
+  became a pathspec, which also SUPPRESSED the whole-tree fallback —
+  measured, `git add --future-flag somevalue && git commit -m x`
+  returned 0 with an untracked NUL present. The flags `git add` really
+  does accept without a value are enumerated instead, so the default can
+  be the safe one. Two branches err NARROW, knowingly: `git add -f` with
   NO pathspec keeps `--exclude-standard` (an unbounded walk of every
   gitignored path would make the gate the slowest thing in the commit;
   `-f` WITH a pathspec does drop it), and a symlink is skipped, because
@@ -110,9 +153,11 @@ The hooks split into three classes:
   OPEN: the commit proceeds, and the only signal is an error on stderr
   that reads like noise from the hook rather than a refusal.
 
-  `.claude/hooks/control-char-gate.test.sh` (52 cases, run by
+  `.claude/hooks/control-char-gate.test.sh` (93 cases, run by
   `vp run test:hooks`) drives all of the above through the real hook
-  against throwaway repositories, in BOTH directions.
+  against throwaway repositories, in BOTH directions — including from a
+  SUBDIRECTORY cwd, whose absence is why 52 earlier green cases did not
+  see the whole-tree bug.
 
   **The gate is still not the only fence, because it is a PreToolUse
   hook and therefore only ever sees the AGENT's tool calls** — a human

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -99,20 +99,36 @@ The hooks split into three classes:
   the command's own directory, because that is what its pathspecs are
   relative to.
 
-  **Removing the offending file is the remediation, so it is not
-  blocked.** A path the staging DELETES has its index scan skipped:
-  either the file is already gone from disk, or THIS CALL is what
-  removes it (`rm bad.ts && git add -A && git commit`, where the hook
-  still sees the file, so the deletion is read off the command exactly
-  as the staging is). `git rm` counts on its own because it stages;
-  a plain `rm` only counts under a whole-tree staging, and `git rm
-  --cached` never counts because a following `git add -A` re-adds the
-  file. This is the ONE list in the gate where a wrong entry SUPPRESSES
-  a scan, so it errs toward blocking: an unexpanded path, a quoted
-  mention, `rmdir`, or a GLOB records nothing — git's pathspec language
-  is broader than the shell's, so honouring `rm *.ts` would suppress the
-  scan of every `.ts` in the repository rather than the ones the shell
-  would actually have deleted.
+  **What it does NOT try to know: segment ORDER, or that something else
+  in the call will delete the file.** `rm bad.ts && git add -A && git
+  commit` is BLOCKED, even though the resulting commit does not contain
+  bad.ts, and the error message says how to proceed — stage the deletion
+  in its own call. A revision of this gate did parse `rm` / `git rm` to
+  avoid that one false block. It bought nothing and cost four things: a
+  FAIL-OPEN (`git add -A && git commit && rm x` passed, because order
+  was never modelled and the commit really did contain the byte), an
+  abbreviation bypass (`git rm --ca`, which git accepts), a
+  directory-expansion miss, and a 90-second hang. Each round's fix was
+  more clever than the last, which is the tell that the artifact was
+  claiming more than it could deliver. The parser is gone and the remedy
+  lives in the message. One tree-level rule survives, and it is an
+  observation rather than a parse: a path ALREADY gone from disk that
+  the staging covers has its index scan skipped, because `git add -A`
+  will stage that deletion.
+
+  **It is bounded in time, which correctness cases cannot see.**
+  `git add -f <pathspec>` may legitimately reach gitignored content, but
+  a pathspec of `.` drags in the whole ignored tree: measured, 4,001
+  candidates and 25 s in this repo, 44,563 and over 90 s in a reviewer's
+  worktree, one `perl` fork each. A gate in the path of every commit
+  that wedges is worse than the bug it prevents. So the listing is
+  PROBED first (cheap — `ls-files` walks directories without reading
+  contents, and the probe stops at the cap) and `--exclude-standard` is
+  dropped only when the result is under `GATE_CC_FORCE_MAX`; and the
+  whole working-tree scan is ONE perl process for all candidates instead
+  of one per file. ERRS NARROW, boundedly: a `git add -f` covering more
+  than the cap leaves its IGNORED files unscanned, while its tracked and
+  unignored files are still scanned. Two cases pin a wall-clock budget.
 
   The shape is decided with the shared `_command-match.sh` machinery
   (`GATE_RE_GIT_ADD`, and `gate_verb_args` for the arguments after the
@@ -153,11 +169,17 @@ The hooks split into three classes:
   OPEN: the commit proceeds, and the only signal is an error on stderr
   that reads like noise from the hook rather than a refusal.
 
-  `.claude/hooks/control-char-gate.test.sh` (93 cases, run by
+  `.claude/hooks/control-char-gate.test.sh` (115 cases, run by
   `vp run test:hooks`) drives all of the above through the real hook
-  against throwaway repositories, in BOTH directions — including from a
-  SUBDIRECTORY cwd, whose absence is why 52 earlier green cases did not
-  see the whole-tree bug.
+  against throwaway repositories, in BOTH directions. Two review rounds
+  found live blockers behind 52 and then 93 green cases, both times in
+  shapes nobody had enumerated and both times because the cases reused
+  whichever fixture STATE happened to work. So the suite now crosses the
+  two axes explicitly: six states of a NUL-bearing file (untracked / in
+  HEAD / tracked-modified / staged / staged-then-cleaned / deleted on
+  disk) times four command shapes, all 24 cells spelled out with their
+  reasoning, plus a SUBDIRECTORY cwd, segment ORDER, and a wall-clock
+  budget.
 
   **The gate is still not the only fence, because it is a PreToolUse
   hook and therefore only ever sees the AGENT's tool calls** — a human


### PR DESCRIPTION
## Summary

`control-char-gate.sh` blocks a commit whose text files carry a NUL or other C0
control byte. It scanned the git INDEX only. A PreToolUse hook runs BEFORE the
command it gates, so `git add -A && git commit -F msg` in one Bash call showed it
the pre-`git add` tree: nothing staged for the offending file, gate found
nothing, exit 0, byte shipped. The gate was registered, DID fire, and answered
"clean".

The scan target is now read off the COMMAND.

| command shape | what is scanned |
|---|---|
| plain `git commit` | the index (unchanged) |
| `… git add <spec> …` | index + the working-tree content that add would bring in |
| `git commit -a` / `--all` | index + working-tree content of TRACKED MODIFIED files |
| `git commit -m x <pathspec>` | index + that pathspec's working-tree content |

## Three rounds, and the third one DELETED a feature

This took three review rounds. Worth recording what they found, because the
shape of the cascade is the interesting part.

**Round 1** shipped 52 green cases with two live fail-opens: `git commit -m x f.ts`
is an implicit `--only` that commits working-tree content and ignores the index
(measured rc=0, with the NUL then in `git show HEAD:f.ts`), and `git ls-files`
with no pathspec lists only the CWD subtree while `git add -A` has been
whole-tree since git 2.0 (rc=0 from a subdirectory, rc=2 from the root).

**Round 2** fixed those and, to stop the gate blocking its own remediation, added
a parser that read `rm` / `git rm` off the command. That parser produced FOUR
findings of its own, two of them fail-opens of the exact class this gate exists
to prevent:

- `git add -A && git commit -m x && rm x` returned **rc=0** while the commit did
  contain the byte — segment ORDER was never modelled.
- `git rm --ca` (git accepts the abbreviation) walked past a `--cached` guard
  written as a literal substring test.
- `git add -f <dir>` has a pathspec, so it missed the no-pathspec gate, dropped
  `--exclude-standard`, and forked one `perl` per ignored file. In this repo:
  44,563 candidates, **did not finish in 600 seconds**.

**Round 3 deleted the parser** rather than fixing it. It existed to avoid ONE
false block and bought that by inferring intent from command text, each round's
fix more elaborate than the last. Deleting it collapses three findings instead of
patching them: every `rm … && git add -A && git commit` shape now blocks
uniformly, whatever the file's state and however `git rm` is spelled. A false
block costs one message and a second call; a false pass shipped a control byte to
main. The error message carries the remedy instead.

One tree-level rule survives and is deliberately not a parse: an index candidate
whose file is already gone from disk while the staging covers it has its index
scan skipped. No verbs, no flags, no ordering — an observation of the tree, and
what makes the recommended remedy work.

The hang is independent and fixed on its own: `--exclude-standard` is dropped
only when the `-f` listing probes under a cap, and the working-tree scan is now
one `perl` process for all candidates instead of one per file. **Over 90 seconds
to 1** at 44,000 ignored files. It errs narrow and boundedly — past the cap a
`git add -f`'s IGNORED files go unscanned, while its tracked and unignored files
still are.

## Behaviour change worth knowing

The gate is now bash 3.2 clean. It had used `mapfile -d ''`, which 3.2 lacks.
Measured against main with a NUL staged: under the shebang's resolution on a host
carrying Homebrew bash (5.3.9) it blocked correctly at rc=2, but run as
`/bin/bash` (3.2.57) it printed `mapfile: command not found` and exited 1 having
scanned nothing. rc=1 is not rc=2, so where it bit, it FAILED OPEN. A portability
hazard rather than a live failure on a machine with bash 5.

## Test plan

Counts re-derived rather than asserted:

- `.claude/hooks/control-char-gate.test.sh` — **new file, 0 → 118 cases**.
- `.claude/hooks/_command-match.test.sh` — **337 → 358** (it peaked at 368 in
  round 2; the removal-verb cases went with the feature).
- `.claude/hooks/gate-command-recognition.test.sh` — 123, unchanged and green.
- `vp run test:hooks` rc=0 across all **nine** suites; `vp run verify` rc=0 (226
  files, 3730 tests).

Both earlier rounds shipped green suites whose gaps were shapes nobody had
enumerated, so the suite now covers the full **state × shape cross-product** —
untracked / already-in-HEAD / tracked-modified / staged / staged-then-cleaned /
deleted-on-disk, against four command shapes. What is deliberately NOT covered is
written down rather than assumed: submodules, sparse-checkout and
`--skip-worktree`, linked worktrees with a differing index, `core.fileMode` /
CRLF filters, and merge-conflicted paths.

17 mutation probes, every one discriminating, each with its anchor and marker
count verified before the result was read. Two landed green on the first attempt
and both turned out to be test gaps that were then closed — the cap (invisible to
a timing budget once batching existed) and `local $/` (every existing case had
its NUL on line 1, so "all line numbers become 1" was undetectable).

Live-tested end to end against real repositories under bash 3.2.57 and 5.3.9 with
identical verdicts, and from a subdirectory as well as the repo root.

No `src/**` or `tests/integration/**` change, so no integ applies.

Closes #576
