### PR TITLE
fix(start-alb): bracket IPv6 literals when composing a URL authority

### DIFF
--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -111,6 +111,7 @@ import type { FrontDoorAuthGuard } from '../../local/elb-front-door-resolver.js'
 import { buildAuthCheck } from '../../local/front-door-auth.js';
 import { createJwksCache, type WarnedAt } from '../../local/cognito-jwt.js';
 import { isLocalCdkAssetImage, listPinnedTargets } from '../../local/image-pin-detector.js';
+import { formatAuthority } from '../../utils/url-authority.js';
 import {
   enforceImageOverrideOrphans,
   parseImageOverrideFlags,
@@ -2175,7 +2176,7 @@ export async function buildFrontDoor(
       servers.push(server);
 
       logger.info(
-        `ALB front-door: ${server.scheme}://${server.host}:${server.port} (listener port ${listener.listenerPort})`
+        `ALB front-door: ${server.scheme}://${formatAuthority(server.host, server.port)} (listener port ${listener.listenerPort})`
       );
       if (degradedHttps) {
         logger.warn(
@@ -2599,14 +2600,14 @@ export function logEndpointsBanner(
       const scheme = ep.protocol.toLowerCase() === 'udp' ? 'udp' : 'http';
       const override = ep.overridden ? '  (--host-port override)' : '';
       lines.push(
-        `    ${ep.containerName} container port ${ep.containerPort}/${ep.protocol} -> ${scheme}://${ep.host}:${ep.hostPort}${override}`
+        `    ${ep.containerName} container port ${ep.containerPort}/${ep.protocol} -> ${scheme}://${formatAuthority(ep.host, ep.hostPort)}${override}`
       );
     }
   }
   if (frontDoorServers.length > 0) {
     lines.push('  ALB front-door');
     for (const s of frontDoorServers) {
-      lines.push(`    ${s.scheme}://${s.host}:${s.port}`);
+      lines.push(`    ${s.scheme}://${formatAuthority(s.host, s.port)}`);
     }
   }
   if (lines.length === 0) return;

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -129,6 +129,7 @@ import {
 } from '../../local/cognito-jwt.js';
 import { defaultCredentialsLoader, type CredentialsLoader } from '../../local/sigv4-verify.js';
 import { singleFlight } from '../../utils/single-flight.js';
+import { formatAuthority } from '../../utils/url-authority.js';
 import {
   writeProfileCredentialsFile,
   type ProfileCredentialsFile,
@@ -317,6 +318,31 @@ export interface CreateLocalStartApiCommandOptions {
   extraStateProviders?: ExtraStateProviders;
   /** Embed-time branding overrides for a host wrapping this factory. */
   embedConfig?: CdkLocalEmbedConfig;
+}
+
+/**
+ * The `Server listening on <url>  (<label>)` ready banner, terminated with a
+ * newline.
+ *
+ * D8.4 — load-bearing, and the most machine-parsed line in the repo: several
+ * integ fixtures grep the prefix and extract the port from it, and
+ * `cdkl studio` matches it with `SERVE_SPECS.api.readyRe` and then resolves
+ * the captured URL with `new URL(...)` before it will front the serve with a
+ * capture proxy. An authority the WHATWG parser rejects therefore does not
+ * merely read badly — the studio serve is refused (issue #599).
+ *
+ * Exported so that contract has a unit test at the EMITTER. Both banner sites
+ * live inside the long-running boot function, which has no cheap test seam,
+ * so without this the only emitter-side coverage was the source fence.
+ */
+export function formatServerListeningBanner(
+  scheme: string,
+  host: string,
+  port: number,
+  pathSuffix: string,
+  label: string
+): string {
+  return `Server listening on ${scheme}://${formatAuthority(host, port)}${pathSuffix}  (${label})\n`;
 }
 
 async function localStartApiCommand(
@@ -1146,7 +1172,7 @@ async function localStartApiCommand(
   // verify.sh marker scan is unchanged.
   for (const { group, server } of servers) {
     process.stdout.write(
-      `Server listening on ${server.scheme}://${server.host}:${server.port}  (${group.displayName})\n`
+      formatServerListeningBanner(server.scheme, server.host, server.port, '', group.displayName)
     );
   }
   // #462: emit one banner per WebSocket server. The protocol prefix
@@ -1156,7 +1182,13 @@ async function localStartApiCommand(
   for (const ws of wsServers) {
     const scheme = ws.server.scheme === 'https' ? 'wss' : 'ws';
     process.stdout.write(
-      `Server listening on ${scheme}://${ws.server.host}:${ws.server.port}${ws.apiPath}  (${ws.api.apiLogicalId} (WebSocket API))\n`
+      formatServerListeningBanner(
+        scheme,
+        ws.server.host,
+        ws.server.port,
+        ws.apiPath,
+        `${ws.api.apiLogicalId} (WebSocket API)`
+      )
     );
   }
   process.stdout.write('^C to stop and clean up containers.\n');
@@ -3262,7 +3294,9 @@ function filterSpecsForGroup(
  */
 function printPerServerRouteTables(servers: readonly BootedApiServer[]): void {
   for (const { group, server } of servers) {
-    process.stdout.write(`\n${group.displayName}  (http://${server.host}:${server.port})\n`);
+    process.stdout.write(
+      `\n${group.displayName}  (http://${formatAuthority(server.host, server.port)})\n`
+    );
     printRouteTable(group.routes);
   }
 }

--- a/src/local/agentcore-a2a-client.ts
+++ b/src/local/agentcore-a2a-client.ts
@@ -1,4 +1,5 @@
 import { setTimeout as delay } from 'node:timers/promises';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * Client for the Bedrock AgentCore Runtime A2A protocol contract.
@@ -63,7 +64,7 @@ export async function a2aInvokeOnce(
   options: A2aInvokeOptions = {}
 ): Promise<A2aInvokeResult> {
   const fetchImpl = options.fetchImpl ?? fetch;
-  const url = `http://${host}:${port}${A2A_PATH}`;
+  const url = `http://${formatAuthority(host, port)}${A2A_PATH}`;
   const requestTimeoutMs = options.requestTimeoutMs ?? 120_000;
   const readyTimeoutMs = options.readyTimeoutMs ?? 30_000;
 

--- a/src/local/agentcore-client.ts
+++ b/src/local/agentcore-client.ts
@@ -1,4 +1,5 @@
 import { setTimeout as delay } from 'node:timers/promises';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * HTTP client for the Bedrock AgentCore Runtime container contract.
@@ -83,7 +84,7 @@ export async function waitForAgentCorePing(
 
   const tail = lastDetail ? `: ${lastDetail}` : '';
   throw new Error(
-    `AgentCore agent did not become ready on ${host}:${port} within ${timeoutMs}ms${tail}. ` +
+    `AgentCore agent did not become ready on ${formatAuthority(host, port)} within ${timeoutMs}ms${tail}. ` +
       `The container may have exited early or may not serve GET ${PING_PATH} — check 'docker logs' output.`
   );
 }
@@ -101,7 +102,7 @@ async function pingProbe(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(`http://${host}:${port}${PING_PATH}`, {
+    const response = await fetch(`http://${formatAuthority(host, port)}${PING_PATH}`, {
       method: 'GET',
       signal: controller.signal,
     });
@@ -144,7 +145,7 @@ export async function waitForAgentCoreHttpReady(
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 1000);
     try {
-      const response = await fetch(`http://${host}:${port}${path}`, {
+      const response = await fetch(`http://${formatAuthority(host, port)}${path}`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: '{}',
@@ -164,7 +165,7 @@ export async function waitForAgentCoreHttpReady(
 
   const tail = lastDetail ? `: ${lastDetail}` : '';
   throw new Error(
-    `AgentCore agent did not become ready on ${host}:${port} within ${timeoutMs}ms${tail}. ` +
+    `AgentCore agent did not become ready on ${formatAuthority(host, port)} within ${timeoutMs}ms${tail}. ` +
       `The container may have exited early or may not serve POST ${path} — check 'docker logs' output.`
   );
 }
@@ -231,7 +232,7 @@ export async function invokeAgentCore(
   event: unknown,
   options: InvokeAgentCoreOptions
 ): Promise<AgentCoreInvokeResult> {
-  const url = `http://${host}:${port}${INVOCATIONS_PATH}`;
+  const url = `http://${formatAuthority(host, port)}${INVOCATIONS_PATH}`;
   const body = JSON.stringify(event ?? {});
 
   const controller = new AbortController();

--- a/src/local/agentcore-http-server.ts
+++ b/src/local/agentcore-http-server.ts
@@ -12,6 +12,7 @@ import { attachAgentCoreWsBridge } from './agentcore-ws-bridge.js';
 import { AGENTCORE_SESSION_ID_HEADER } from './agentcore-client.js';
 import type { AgentCoreServeAuthCheck } from './agentcore-serve-auth.js';
 import { getLogger } from '../utils/logger.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * Host HTTP serve in front of a warm AgentCore runtime container, the serving
@@ -351,8 +352,8 @@ export function startAgentCoreHttpServer(
       );
       const port = (httpServer.address() as AddressInfo).port;
       resolve({
-        httpUrl: `http://${host}:${port}`,
-        ...(bridge && { wsUrl: `ws://${host}:${port}${bridge.path}` }),
+        httpUrl: `http://${formatAuthority(host, port)}`,
+        ...(bridge && { wsUrl: `ws://${formatAuthority(host, port)}${bridge.path}` }),
         port,
         // The proxy reads `config.containerPort` live per request, so mutating
         // it re-points subsequent requests (+ the bridge's getter) at the new

--- a/src/local/agentcore-mcp-client.ts
+++ b/src/local/agentcore-mcp-client.ts
@@ -1,4 +1,5 @@
 import { setTimeout as delay } from 'node:timers/promises';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * Client for the Bedrock AgentCore Runtime MCP protocol contract.
@@ -69,7 +70,7 @@ export async function mcpInvokeOnce(
   options: McpInvokeOptions = {}
 ): Promise<McpInvokeResult> {
   const fetchImpl = options.fetchImpl ?? fetch;
-  const url = `http://${host}:${port}${MCP_PATH}`;
+  const url = `http://${formatAuthority(host, port)}${MCP_PATH}`;
   const requestTimeoutMs = options.requestTimeoutMs ?? 120_000;
 
   const sessionId = await initializeWithRetry(fetchImpl, url, options.readyTimeoutMs ?? 30_000);

--- a/src/local/agentcore-sigv4-sign.ts
+++ b/src/local/agentcore-sigv4-sign.ts
@@ -1,6 +1,7 @@
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { SignatureV4 } from '@smithy/signature-v4';
 import { AGENTCORE_SESSION_ID_HEADER } from './agentcore-client.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * Client-side SigV4 signing for `cdkl invoke-agentcore --sigv4`.
@@ -92,7 +93,13 @@ export async function signAgentCoreInvocation(
     path: opts.path,
     headers: {
       'Content-Type': 'application/json',
-      Host: `${opts.host}:${opts.port}`,
+      // SIGNED, so this must be byte-identical to what Node puts on the
+      // wire: an IPv6 literal is bracketed there (`[::1]:8080`), and
+      // @smithy/signature-v4 signs this header verbatim rather than deriving
+      // it from `hostname` — both measured, see the unit cases. Concatenating
+      // host and port by hand signed `::1:8080` against a transmitted
+      // `[::1]:8080`, a signature that cannot verify (issue #599).
+      Host: formatAuthority(opts.host, opts.port),
       [AGENTCORE_SESSION_ID_HEADER]: opts.sessionId,
     },
     body: opts.body,

--- a/src/local/agentcore-ws-bridge.ts
+++ b/src/local/agentcore-ws-bridge.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from 'node:net';
 import { WebSocketServer, type WebSocket, type RawData } from 'ws';
 import { bridgeAgentCoreWs } from './agentcore-ws-client.js';
 import { getLogger } from '../utils/logger.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * Host-side WebSocket bridge in front of an AgentCore runtime's container
@@ -194,7 +195,7 @@ export function startAgentCoreWsBridge(
       );
       const port = (httpServer.address() as AddressInfo).port;
       resolve({
-        url: `ws://${host}:${port}${attached.path}`,
+        url: `ws://${formatAuthority(host, port)}${attached.path}`,
         port,
         close: () =>
           new Promise<void>((res) => {

--- a/src/local/agentcore-ws-client.ts
+++ b/src/local/agentcore-ws-client.ts
@@ -1,5 +1,6 @@
 import { WebSocket, type RawData } from 'ws';
 import { AGENTCORE_SESSION_ID_HEADER } from './agentcore-client.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * WebSocket client for the Bedrock AgentCore Runtime HTTP-protocol `/ws`
@@ -133,7 +134,7 @@ export function bridgeAgentCoreWs(
   options: BridgeAgentCoreWsOptions
 ): AgentCoreWsBridgeHandle {
   const Impl = options.webSocketImpl ?? WebSocket;
-  const url = `ws://${host}:${port}${WS_PATH}`;
+  const url = `ws://${formatAuthority(host, port)}${WS_PATH}`;
   const ws = new Impl(url, {
     headers: {
       [AGENTCORE_SESSION_ID_HEADER]: options.sessionId,
@@ -225,7 +226,7 @@ export async function invokeAgentCoreWs(
   options: InvokeAgentCoreWsOptions
 ): Promise<AgentCoreWsResult> {
   const Impl = options.webSocketImpl ?? WebSocket;
-  const url = `ws://${host}:${port}${WS_PATH}`;
+  const url = `ws://${formatAuthority(host, port)}${WS_PATH}`;
   const body = JSON.stringify(event ?? {});
 
   return new Promise<AgentCoreWsResult>((resolve, reject) => {

--- a/src/local/cloudfront-server.ts
+++ b/src/local/cloudfront-server.ts
@@ -34,6 +34,7 @@ import { serveFromStaticOrigin } from './cloudfront-static-origin.js';
 import type { S3OriginReader } from './cloudfront-s3-origin.js';
 import type { FrontDoorTlsMaterials } from './front-door-tls.js';
 import { applyCorsResponseHeadersFromConfig, matchPreflight } from './cors-handler.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * Invoke a warm Lambda RIE container with a Function URL event, keyed by the
@@ -141,7 +142,7 @@ export async function startCloudFrontServer(
     : createHttpServer(handler);
 
   const port = await listen(server, options.host, options.port);
-  const url = `${scheme}://${options.host}:${port}`;
+  const url = `${scheme}://${formatAuthority(options.host, port)}`;
   return {
     url,
     port,

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -36,6 +36,7 @@ import {
 } from './ecs-task-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
 import { applyEnvOverrideMap } from './env-resolver.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1299,7 +1300,8 @@ export function buildDockerRunArgs(opts: BuildDockerRunArgs): {
         .child('ecs')
         .info(
           `Container '${container.name}' container port ${pm.containerPort} published on ` +
-            `${containerHost}:${hostPort}${overrideNote}. Reach it at ${containerHost}:${hostPort}.`
+            `${formatAuthority(containerHost, hostPort)}${overrideNote}. ` +
+            `Reach it at ${formatAuthority(containerHost, hostPort)}.`
         );
       args.push('-p', `${containerHost}:${hostPort}:${pm.containerPort}/${pm.protocol}`);
       publishedEndpoints.push({

--- a/src/local/front-door-server.ts
+++ b/src/local/front-door-server.ts
@@ -9,6 +9,11 @@ import { createServer as createHttpsServer } from 'node:https';
 import { connect as netConnect, type Socket as NetSocket } from 'node:net';
 import type { Duplex } from 'node:stream';
 import { getLogger } from '../utils/logger.js';
+import {
+  formatAuthority,
+  formatHostForAuthority,
+  hostFromAuthority,
+} from '../utils/url-authority.js';
 import type { FrontDoorEndpointPool } from './front-door-pool.js';
 import {
   buildAlbLambdaEvent,
@@ -758,7 +763,9 @@ export function buildRedirectLocation(
   const reqQuery = qIndex === -1 ? '' : url.slice(qIndex + 1);
   const rawHost = req.headers['host'];
   const hostHeaderValue = Array.isArray(rawHost) ? rawHost[0] : rawHost;
-  const reqHostName = (hostHeaderValue ?? '').split(':')[0] ?? '';
+  // `split(':')[0]` reads `'['` out of a bracketed IPv6 Host header
+  // (`[::1]:8080`), which is what a conforming client sends — issue #599.
+  const reqHostName = hostFromAuthority(hostHeaderValue ?? '');
 
   const placeholders: Record<string, string> = {
     protocol: scheme,
@@ -788,7 +795,8 @@ export function buildRedirectLocation(
   // how an ALB-built Location reads.
   const isDefaultPort =
     (protocol === 'http' && port === '80') || (protocol === 'https' && port === '443');
-  const authority = isDefaultPort || port === '' ? host : `${host}:${port}`;
+  const authority =
+    isDefaultPort || port === '' ? formatHostForAuthority(host) : formatAuthority(host, port);
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
   const queryPart = query ? `?${query}` : '';
   return `${protocol}://${authority}${normalizedPath}${queryPart}`;

--- a/src/local/rie-client.ts
+++ b/src/local/rie-client.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'node:stream';
 import { setTimeout as delay } from 'node:timers/promises';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * HTTP client for the AWS Lambda Runtime Interface Emulator (RIE) baked
@@ -82,7 +83,7 @@ export async function waitForRieReady(host: string, port: number, timeoutMs = 50
 
   const tail = lastError instanceof Error ? `: ${lastError.message}` : '';
   throw new Error(
-    `RIE did not become ready on ${host}:${port} within ${timeoutMs}ms${tail}. ` +
+    `RIE did not become ready on ${formatAuthority(host, port)} within ${timeoutMs}ms${tail}. ` +
       `The container may have exited early — check 'docker logs' output.`
   );
 }
@@ -101,7 +102,7 @@ async function httpProbe(host: string, port: number, timeoutMs: number): Promise
     // invoke; some HTTP stacks have separate readiness for read-only vs
     // write methods. Body is a tiny empty JSON object so we don't pay
     // a content-length parse on the way through.
-    const response = await fetch(`http://${host}:${port}/`, {
+    const response = await fetch(`http://${formatAuthority(host, port)}/`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{}',
@@ -154,7 +155,7 @@ export async function invokeRie(
   event: unknown,
   timeoutMs: number
 ): Promise<InvokeResult> {
-  const url = `http://${host}:${port}${INVOKE_PATH}`;
+  const url = `http://${formatAuthority(host, port)}${INVOKE_PATH}`;
   const body = JSON.stringify(event ?? {});
 
   const controller = new AbortController();
@@ -340,7 +341,7 @@ export async function invokeRieStreaming(
   event: unknown,
   timeoutMs: number
 ): Promise<StreamingInvokeResult> {
-  const url = `http://${host}:${port}${INVOKE_PATH}`;
+  const url = `http://${formatAuthority(host, port)}${INVOKE_PATH}`;
   const body = JSON.stringify(event ?? {});
 
   const controller = new AbortController();

--- a/src/local/studio-proxy.ts
+++ b/src/local/studio-proxy.ts
@@ -2,6 +2,7 @@ import { createServer, request as httpRequest, type IncomingMessage } from 'node
 import { connect as netConnect, type Socket } from 'node:net';
 import type { AddressInfo } from 'node:net';
 import { StudioEventBus, type StudioTargetKind } from './studio-events.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /** Config for {@link startStudioProxy}. */
 export interface StudioProxyConfig {
@@ -374,7 +375,7 @@ export function startStudioProxy(config: StudioProxyConfig): Promise<RunningStud
       server.removeListener('error', reject);
       const port = (server.address() as AddressInfo).port;
       resolve({
-        url: `http://${host}:${port}`,
+        url: `http://${formatAuthority(host, port)}`,
         port,
         close: () =>
           new Promise<void>((resolveClose, rejectClose) => {

--- a/src/local/studio-serve-manager.ts
+++ b/src/local/studio-serve-manager.ts
@@ -289,6 +289,14 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
 };
 
 /**
+ * The `ecs-task-runner` replica publish banner, with its authority captured.
+ * The authority is a dotted-quad IPv4 or a bracketed IPv6 literal, each
+ * followed by `:<port>`.
+ */
+const PUBLISHED_ENDPOINT_RE =
+  /^Container '[^']*' container port \d+ published on ((?:\d{1,3}(?:\.\d{1,3}){3}|\[[0-9A-Fa-f:.]{2,45}\]):\d+)/;
+
+/**
  * Parse an auto-published replica host endpoint from an `ecs` serve child's
  * stdout (issue #392). `start-service` publishes each replica's declared
  * container port on the host — auto-remapping a privileged port (< 1024) to a
@@ -308,11 +316,17 @@ const SERVE_SPECS: Partial<Record<StudioTargetKind, ServeKindSpec>> = {
  * The loopback bound is applied by the CALLER (a parsed endpoint is still only
  * adopted when {@link normalizeLocalUpstream} accepts it), so this stays a pure
  * reader of the banner.
+ *
+ * The authority half accepts a BRACKETED IPv6 literal alongside the dotted
+ * quad (issue go-to-k/cdk-local#599). `ecs-task-runner` composes that banner
+ * through `formatAuthority`, so `--container-host ::1` prints
+ * `[::1]:54321` — an emitter that brackets and a reader that only knows IPv4
+ * is the same defect moved one file over. Brackets are REQUIRED here rather
+ * than optional: a bare `::1:54321` has no unambiguous split into host and
+ * port, and it is not what the emitter writes.
  */
 export function parsePublishedHostEndpoint(line: string): string | undefined {
-  const m = /^Container '[^']*' container port \d+ published on (\d{1,3}(?:\.\d{1,3}){3}:\d+)/.exec(
-    line
-  );
+  const m = PUBLISHED_ENDPOINT_RE.exec(line);
   return m ? `http://${m[1]}` : undefined;
 }
 

--- a/src/local/studio-server.ts
+++ b/src/local/studio-server.ts
@@ -10,6 +10,7 @@ import {
 import { renderStudioHtml } from './studio-ui.js';
 import type { StudioStore } from './studio-store.js';
 import type { TargetListing } from './target-lister.js';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /** One target as the studio UI consumes it (`GET /api/targets`). */
 export interface StudioTarget {
@@ -420,7 +421,7 @@ export async function startStudioServer(
   const boundPort = await listenWithBump(server, host, options.port, maxBump);
 
   return {
-    url: `http://${host}:${boundPort}`,
+    url: `http://${formatAuthority(host, boundPort)}`,
     port: boundPort,
     close: () =>
       new Promise<void>((resolveClose, reject) => {

--- a/src/local/websocket-mgmt-api.ts
+++ b/src/local/websocket-mgmt-api.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { WebSocket } from 'ws';
+import { formatAuthority } from '../utils/url-authority.js';
 
 /**
  * Local emulation of the AWS `apigatewaymanagementapi` data plane —
@@ -135,7 +136,7 @@ export function parseConnectionsPath(url: string): {
  * Issue #537 item 7.
  */
 export function buildMgmtEndpointEnvUrl(host: string, port: number, stage: string): string {
-  return `http://${host}:${port}/${stage}`;
+  return `http://${formatAuthority(host, port)}/${stage}`;
 }
 
 /**

--- a/src/utils/url-authority.ts
+++ b/src/utils/url-authority.ts
@@ -1,0 +1,132 @@
+/**
+ * Compose the authority component of a URL from a host and a port.
+ *
+ * Every local serve prints an endpoint banner, and several of those banners
+ * are MACHINE-PARSED — `cdkl studio` reads them to learn where to point its
+ * capture proxy (`local/studio-serve-manager`'s `readyRe` /
+ * `parsePublishedHostEndpoint`), then resolves the result with `new URL(...)`
+ * before it will forward anything there. So an authority that the WHATWG
+ * parser rejects is not a cosmetic log defect: the serve is refused.
+ *
+ * The one shape that used to be composed wrong is an IPv6 literal. RFC 3986
+ * 3.2.2 requires it to be bracketed inside an authority, so a bare
+ * `${host}:${port}` turns `--container-host ::` into `http://:::8080`, which
+ * is not a URL — while the IPv4 wildcard `0.0.0.0`, the same intention spelled
+ * differently, works. Issue go-to-k/cdk-local#599.
+ *
+ * The detection is mechanical rather than a list of known values: a colon is
+ * forbidden in both a registered name and an IPv4 address, so a host carrying
+ * one is an IPv6 literal — PROVIDED the rest of it could be one, which is a
+ * character-class test (hex digits, `:`, and `.` for the IPv4-mapped form)
+ * rather than an enumeration. The qualifier is load-bearing rather than
+ * pedantry: `buildRedirectLocation` fills its host from an ALB `#{host}`
+ * template or a configured literal, so a CRLF-injection attempt reaches this
+ * function AS-IS — `example.test\r\nx-injected: yes`, with the CR/LF still in
+ * it, because `front-door-server` sanitises the Location only AFTER building
+ * it. Either way it is a colon in something that is not an address and must
+ * pass through untouched rather than gain brackets it never had. (CR and LF
+ * are outside the character class by construction, so the raw and flattened
+ * spellings classify identically — but the raw one is what actually arrives.)
+ * Caught by `front-door-server.test.ts`'s raw-socket injection case.
+ */
+
+/**
+ * A host that could be an IPv6 literal: hex digits, `:` separators, and `.`
+ * for the IPv4-mapped form (`::ffff:127.0.0.1`). Deliberately NOT a full
+ * grammar — the job is to separate "an address" from "not an address", and
+ * validating an address that has already been bound to is not this function's
+ * business.
+ */
+const IPV6_LITERAL_CHARS = /^[0-9A-Fa-f:.]+$/;
+
+/**
+ * Render `host` as it must appear inside a URL authority.
+ *
+ * - An IPv6 literal is bracketed, in either case (`FE80::1` -> `[FE80::1]`).
+ * - An already-bracketed literal comes back bracketed exactly once, so the
+ *   function is idempotent: `[::1]` never becomes `[[::1]]`. That matters
+ *   because a caller often feeds back a `URL.hostname`, which is ALREADY
+ *   bracketed.
+ * - A zone id (`fe80::1%en0`) is DROPPED, keeping `[fe80::1]`. No URL parser
+ *   accepts one — Node's `new URL` throws on both the raw `%en0` and the
+ *   percent-encoded `%25en0` — and a zone id is a host-local interface
+ *   selector that carries no meaning for whoever reads the banner. Emitting
+ *   an authority nothing can parse is the exact failure this helper exists to
+ *   prevent, so the scope is dropped rather than propagated. The brackets are
+ *   removed BEFORE that decision, so `[fe80::1%en0]` is stripped too — an
+ *   early return on "already bracketed" would have waved the one input that
+ *   is both bracketed and unparseable straight through.
+ * - Everything else (IPv4 literal, registered name, the empty string, and a
+ *   colon-bearing string that is not an address) is returned untouched.
+ */
+export function formatHostForAuthority(host: string): string {
+  const wrapped = host.length > 1 && host.startsWith('[') && host.endsWith(']');
+  const inner = wrapped ? host.slice(1, -1) : host;
+  if (!inner.includes(':')) return host;
+  const zoneAt = inner.indexOf('%');
+  const literal = zoneAt === -1 ? inner : inner.slice(0, zoneAt);
+  if (!IPV6_LITERAL_CHARS.test(literal)) return host;
+  return `[${literal}]`;
+}
+
+/**
+ * Compose `<host>:<port>` for use inside a URL, bracketing an IPv6 literal.
+ *
+ * An empty `host` is passed through as-is rather than substituted: the helper
+ * composes an authority, it does not invent a host, and a caller that has no
+ * host has a bug of its own. The result (`:8080`) does not parse, which is the
+ * honest rendering of that state.
+ */
+export function formatAuthority(host: string, port: number | string): string {
+  return `${formatHostForAuthority(host)}:${port}`;
+}
+
+/**
+ * Read the HOST out of an authority (`<host>` or `<host>:<port>`), returning
+ * it BARE — an IPv6 literal comes back without its brackets, ready to be
+ * handed straight back to {@link formatAuthority}.
+ *
+ * The inverse of {@link formatAuthority}, and it exists for the same reason:
+ * `authority.split(':')[0]` is the obvious thing to write and it is wrong for
+ * exactly one input. A conforming client sends `Host: [::1]:8080` (measured —
+ * see `tests/unit/local/ipv6-host-header.test.ts`), and splitting that on the
+ * first colon yields `'['`, so an ALB `#{host}` substitution built from it
+ * produced `http://[:8080/...`. Issue go-to-k/cdk-local#599.
+ *
+ * # It refuses rather than guesses — on BOTH arms
+ *
+ * This is an attacker-reachable parser: the request `Host` header feeds an
+ * ALB `#{host}` substitution, and whatever comes back is composed into a
+ * redirect `Location`. So a malformed authority yields the empty string
+ * rather than the fragment that happens to be readable, on either branch.
+ *
+ * BRACKETED — read to the closing `]`, and only when the value is
+ * well-formed: there must BE a closing bracket, and what follows it must be
+ * empty or `:<digits>`. Guessing here is the worse of the two directions,
+ * because the guess PARSES: `[evil.example` (no closing bracket) would come
+ * back as `evil.example`, turning a half-named host into a valid `Location`
+ * the client would follow, where the malformed input should have produced
+ * nothing. `[a:b]junk` would silently drop its trailing junk, and `[x:y`
+ * would return a multi-colon value as a host — the very thing the other arm
+ * refuses.
+ *
+ * UNBRACKETED — the text before its single `:`. Two or more colons yields
+ * the empty string: it is not a shape any conforming client sends (Node
+ * brackets — measured in `tests/unit/local/ipv6-host-header.test.ts`), it has
+ * no unambiguous split, and returning the leading fragment would hand a
+ * caller a host that is not the one named. `split(':')[0]` did exactly that —
+ * `fe80::1:8080` came back as `'fe80'`.
+ */
+export function hostFromAuthority(authority: string): string {
+  if (authority.startsWith('[')) {
+    const close = authority.indexOf(']');
+    if (close === -1) return '';
+    const afterBracket = authority.slice(close + 1);
+    if (afterBracket !== '' && !/^:\d+$/.test(afterBracket)) return '';
+    return authority.slice(1, close);
+  }
+  const firstColon = authority.indexOf(':');
+  if (firstColon === -1) return authority;
+  if (authority.includes(':', firstColon + 1)) return '';
+  return authority.slice(0, firstColon);
+}

--- a/tests/unit/cli/ipv6-authority-banners.test.ts
+++ b/tests/unit/cli/ipv6-authority-banners.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { FrontDoorPlan } from '../../../src/cli/commands/ecs-service-emulator.js';
+import type { PublishedHostEndpoint } from '../../../src/local/ecs-task-runner.js';
+import type { StartedFrontDoorServer } from '../../../src/local/front-door-server.js';
+import { getLogger } from '../../../src/utils/logger.js';
+
+// Issue go-to-k/cdk-local#599 — the ALB front-door banner and the endpoints
+// banner are what `cdkl studio` reads to find the serve. Mock the ONE boundary
+// that would otherwise need a real socket (`startFrontDoorServer`) so the
+// bind-address spelling under test is free: the banner is composed from the
+// host the started server reports, not from anything the OS hands back.
+const { startFrontDoorServerMock } = vi.hoisted(() => ({ startFrontDoorServerMock: vi.fn() }));
+
+vi.mock('../../../src/local/front-door-server.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../src/local/front-door-server.js')>();
+  return { ...actual, startFrontDoorServer: startFrontDoorServerMock };
+});
+
+const { buildFrontDoor, logEndpointsBanner } = await import(
+  '../../../src/cli/commands/ecs-service-emulator.js'
+);
+
+/** A one-listener plan whose default action needs no backing target at all. */
+function fixedResponsePlan(): FrontDoorPlan {
+  return {
+    listeners: [
+      {
+        listenerPort: 80,
+        hostPort: 0,
+        protocol: 'HTTP',
+        defaultAction: { kind: 'fixed-response', statusCode: 404 },
+        rules: [],
+      },
+    ],
+  } as unknown as FrontDoorPlan;
+}
+
+function startedServer(host: string, port: number): StartedFrontDoorServer {
+  return {
+    scheme: 'http',
+    host,
+    port,
+    server: {} as never,
+    close: async () => undefined,
+  } as unknown as StartedFrontDoorServer;
+}
+
+function captureInfo(): string[] {
+  const lines: string[] = [];
+  vi.spyOn(getLogger(), 'info').mockImplementation((msg: string) => {
+    lines.push(msg);
+  });
+  return lines;
+}
+
+beforeEach(() => {
+  startFrontDoorServerMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * The banner under mutation probe. `--container-host ::` used to print
+ * `ALB front-door: http://:::8080`, which `new URL(...)` rejects — so studio
+ * refused the serve outright.
+ */
+describe('buildFrontDoor — ALB front-door banner (issue #599)', () => {
+  async function bannerFor(host: string, port: number): Promise<string> {
+    startFrontDoorServerMock.mockResolvedValue(startedServer(host, port));
+    const lines = captureInfo();
+    const logger = getLogger();
+    await buildFrontDoor(fixedResponsePlan(), { containerHost: host } as never, logger);
+    const banner = lines.find((l) => l.startsWith('ALB front-door: '));
+    expect(banner, `no ALB front-door banner in ${JSON.stringify(lines)}`).toBeDefined();
+    return banner as string;
+  }
+
+  function endpointOf(banner: string): string {
+    const m = /^ALB front-door: (\S+) /.exec(banner);
+    expect(m, `banner does not carry a whitespace-delimited endpoint: ${banner}`).not.toBeNull();
+    return (m as RegExpExecArray)[1] as string;
+  }
+
+  it('brackets an IPv6 bind address so the endpoint is a URL', async () => {
+    const banner = await bannerFor('::', 8080);
+    expect(banner).toBe('ALB front-door: http://[::]:8080 (listener port 80)');
+    const url = new URL(endpointOf(banner));
+    expect(url.hostname).toBe('[::]');
+    expect(url.port).toBe('8080');
+  });
+
+  it('brackets an IPv6 loopback bind address', async () => {
+    const url = new URL(endpointOf(await bannerFor('::1', 51234)));
+    expect(url.hostname).toBe('[::1]');
+  });
+
+  it('leaves an IPv4 wildcard byte-identical — the integ fixtures grep this line', async () => {
+    const banner = await bannerFor('0.0.0.0', 8080);
+    expect(banner).toBe('ALB front-door: http://0.0.0.0:8080 (listener port 80)');
+    expect(new URL(endpointOf(banner)).hostname).toBe('0.0.0.0');
+  });
+
+  it('leaves IPv4 loopback byte-identical', async () => {
+    const banner = await bannerFor('127.0.0.1', 8080);
+    expect(banner).toBe('ALB front-door: http://127.0.0.1:8080 (listener port 80)');
+  });
+
+  it('leaves a DNS host unbracketed', async () => {
+    const banner = await bannerFor('localhost', 8080);
+    expect(banner).toBe('ALB front-door: http://localhost:8080 (listener port 80)');
+    expect(new URL(endpointOf(banner)).hostname).toBe('localhost');
+  });
+});
+
+describe('logEndpointsBanner — published + front-door endpoints (issue #599)', () => {
+  function controller(host: string) {
+    return {
+      service: { serviceName: 'SvcA' },
+      runState: {
+        replicas: [
+          {
+            shuttingDown: false,
+            state: {
+              publishedEndpoints: [
+                {
+                  containerName: 'app',
+                  containerPort: 80,
+                  host,
+                  hostPort: 8080,
+                  protocol: 'tcp',
+                  overridden: false,
+                } as PublishedHostEndpoint,
+              ],
+            },
+          },
+        ],
+      },
+    } as never;
+  }
+
+  function run(host: string): string[] {
+    const lines = captureInfo();
+    logEndpointsBanner(
+      [{ controller: controller(host) }],
+      [startedServer(host, 9090)],
+      getLogger()
+    );
+    return lines;
+  }
+
+  it('brackets an IPv6 host in both the published line and the front-door line', () => {
+    const lines = run('::1');
+    expect(lines).toContain('    app container port 80/tcp -> http://[::1]:8080');
+    expect(lines).toContain('    http://[::1]:9090');
+    for (const l of lines.filter((x) => x.includes('://'))) {
+      expect(() => new URL(l.trim().split(' -> ').pop() as string)).not.toThrow();
+    }
+  });
+
+  it('leaves an IPv4 host byte-identical', () => {
+    const lines = run('127.0.0.1');
+    expect(lines).toContain('    app container port 80/tcp -> http://127.0.0.1:8080');
+    expect(lines).toContain('    http://127.0.0.1:9090');
+  });
+
+  it('leaves a DNS host unbracketed', () => {
+    const lines = run('localhost');
+    expect(lines).toContain('    app container port 80/tcp -> http://localhost:8080');
+    expect(lines).toContain('    http://localhost:9090');
+  });
+});

--- a/tests/unit/cli/start-api-listening-banner.test.ts
+++ b/tests/unit/cli/start-api-listening-banner.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { formatServerListeningBanner } from '../../../src/cli/commands/local-start-api.js';
+
+/**
+ * Issue go-to-k/cdk-local#599 — an EMITTER-side fence on the repo's most
+ * machine-parsed line. The reader side is covered (studio's `readyRe` is
+ * driven with a bracketed banner in `studio-serve-manager.test.ts`); this is
+ * the other half, so a change to what start-api PRINTS cannot pass on the
+ * strength of the reader still being able to parse a line nobody emits.
+ */
+
+/** studio's `SERVE_SPECS.api.readyRe`, byte-identical. */
+const STUDIO_READY_RE = /^Server listening on (\S+)/;
+
+/** `tests/integration/local-start-api/verify.sh`'s port extraction, transcribed. */
+function integPortOf(line: string): string {
+  const m = /^Server listening on http:\/\/[^\s]+\s+\(.*\)/.exec(line);
+  if (!m) return '';
+  return /.*:\/\/.*:([0-9]+).*/.exec(line)?.[1] ?? '';
+}
+
+describe('formatServerListeningBanner (issue #599)', () => {
+  it('brackets an IPv6 host into a banner studio can resolve', () => {
+    const line = formatServerListeningBanner('http', '::1', 51234, '', 'MyApi').trimEnd();
+    expect(line).toBe('Server listening on http://[::1]:51234  (MyApi)');
+
+    const captured = STUDIO_READY_RE.exec(line)?.[1];
+    expect(captured).toBe('http://[::1]:51234');
+    // The whole point: what studio captures must survive `new URL(...)`, which
+    // is what it does before it will front the serve with a capture proxy.
+    expect(new URL(captured as string).hostname).toBe('[::1]');
+  });
+
+  it('brackets an IPv6 host on the WebSocket banner, path suffix intact', () => {
+    const line = formatServerListeningBanner(
+      'ws',
+      '::',
+      49160,
+      '/ws',
+      'MyWsApi (WebSocket API)'
+    ).trimEnd();
+    expect(line).toBe('Server listening on ws://[::]:49160/ws  (MyWsApi (WebSocket API))');
+    const url = new URL(STUDIO_READY_RE.exec(line)?.[1] as string);
+    expect(url.hostname).toBe('[::]');
+    expect(url.pathname).toBe('/ws');
+  });
+
+  it('leaves an IPv4 host BYTE-IDENTICAL — the integ fixtures grep this line', () => {
+    const line = formatServerListeningBanner(
+      'http',
+      '127.0.0.1',
+      3000,
+      '',
+      'MyStack/HttpApi (HTTP API v2)'
+    );
+    expect(line).toBe('Server listening on http://127.0.0.1:3000  (MyStack/HttpApi (HTTP API v2))\n');
+    // Not just the string: the fixture's own extraction still finds the port.
+    expect(integPortOf(line.trimEnd())).toBe('3000');
+  });
+
+  it('leaves a DNS host unbracketed', () => {
+    expect(formatServerListeningBanner('https', 'localhost', 8443, '', 'X').trimEnd()).toBe(
+      'Server listening on https://localhost:8443  (X)'
+    );
+  });
+
+  it('always terminates with exactly one newline', () => {
+    for (const host of ['::1', '127.0.0.1', 'localhost'])
+      expect(formatServerListeningBanner('http', host, 1, '', 'L')).toMatch(/[^\n]\n$/);
+  });
+});

--- a/tests/unit/local/ipv6-authority-serve-urls.test.ts
+++ b/tests/unit/local/ipv6-authority-serve-urls.test.ts
@@ -1,0 +1,185 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { startAgentCoreHttpServer } from '../../../src/local/agentcore-http-server.js';
+import { startAgentCoreWsBridge } from '../../../src/local/agentcore-ws-bridge.js';
+import type { ResolvedDistribution } from '../../../src/local/cloudfront-resolver.js';
+import { startCloudFrontServer } from '../../../src/local/cloudfront-server.js';
+import { StudioEventBus } from '../../../src/local/studio-events.js';
+import { startStudioProxy } from '../../../src/local/studio-proxy.js';
+import { startStudioServer } from '../../../src/local/studio-server.js';
+
+/**
+ * Issue go-to-k/cdk-local#599 — the five serve components that BIND a socket
+ * and then hand back the URL they are reachable at. `cdkl studio` resolves
+ * those URLs with `new URL(...)` before it will forward anything, so an
+ * unbracketed IPv6 authority makes the serve unusable rather than ugly.
+ *
+ * The IPv6 half needs a real `::1` bind, so it is `ctx.skip()`ped on a host
+ * with no IPv6 loopback — the same treatment `studio-proxy.test.ts` gives its
+ * `[::1]` upstream case, and never a bare `return`, which would pass with zero
+ * assertions. The non-skippable guard for these sites is the source fence in
+ * `tests/unit/utils/url-authority-call-sites.test.ts`.
+ */
+
+const closers: Array<() => Promise<void>> = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(closers.splice(0).map((c) => c().catch(() => undefined)));
+  await Promise.all(
+    servers.splice(0).map(
+      (s) =>
+        new Promise<void>((r) => {
+          s.close(() => r());
+          s.closeAllConnections?.();
+        })
+    )
+  );
+});
+
+/** True when this host can bind IPv6 loopback at all. */
+async function hasIpv6Loopback(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once('error', () => resolve(false));
+    probe.listen(0, '::1', () => probe.close(() => resolve(true)));
+  });
+}
+
+/** A throwaway upstream on IPv4 loopback, for the components that need one. */
+function bootUpstream(): Promise<number> {
+  return new Promise((resolve) => {
+    const s = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"status":"Healthy"}');
+    });
+    servers.push(s);
+    s.listen(0, '127.0.0.1', () => resolve((s.address() as AddressInfo).port));
+  });
+}
+
+/** Assert the URL a serve reports parses and carries exactly `expectedHost`. */
+function expectServeUrl(url: string, expectedHost: string): URL {
+  const parsed = new URL(url);
+  expect(parsed.hostname).toBe(expectedHost);
+  expect(parsed.port).not.toBe('');
+  return parsed;
+}
+
+function emptyDistribution(): ResolvedDistribution {
+  return {
+    logicalId: 'Dist',
+    stackName: 'Stack',
+    behaviors: [{ targetOriginId: 'o1' }],
+    origins: new Map([['o1', { kind: 's3', originId: 'o1', localDirs: [] }]]),
+    customErrorResponses: [],
+  } as unknown as ResolvedDistribution;
+}
+
+/**
+ * One table row per bind-based serve: boot it on `host` and report the URL it
+ * hands back. Every row is run for IPv4, DNS and (when available) IPv6.
+ */
+const SERVES: ReadonlyArray<{ name: string; boot: (host: string) => Promise<string> }> = [
+  {
+    name: 'startCloudFrontServer',
+    boot: async (host) => {
+      const s = await startCloudFrontServer({ distribution: emptyDistribution(), host, port: 0 });
+      closers.push(() => s.close());
+      return s.url;
+    },
+  },
+  {
+    name: 'startAgentCoreHttpServer (httpUrl)',
+    boot: async (host) => {
+      const containerPort = await bootUpstream();
+      const s = await startAgentCoreHttpServer({ containerHost: '127.0.0.1', containerPort, host });
+      closers.push(() => s.close());
+      return s.httpUrl;
+    },
+  },
+  {
+    name: 'startAgentCoreHttpServer (wsUrl)',
+    boot: async (host) => {
+      const containerPort = await bootUpstream();
+      const s = await startAgentCoreHttpServer({
+        containerHost: '127.0.0.1',
+        containerPort,
+        host,
+        attachWs: true,
+      });
+      closers.push(() => s.close());
+      expect(s.wsUrl, 'attachWs did not produce a wsUrl').toBeDefined();
+      return s.wsUrl as string;
+    },
+  },
+  {
+    name: 'startAgentCoreWsBridge',
+    boot: async (host) => {
+      const containerPort = await bootUpstream();
+      const b = await startAgentCoreWsBridge({ containerHost: '127.0.0.1', containerPort, host });
+      closers.push(() => b.close());
+      return b.url;
+    },
+  },
+  {
+    name: 'startStudioServer',
+    boot: async (host) => {
+      const s = await startStudioServer({
+        port: 0,
+        host,
+        bus: new StudioEventBus(),
+        targetGroups: [],
+        appLabel: 'App',
+        cliName: 'cdkl',
+      } as unknown as Parameters<typeof startStudioServer>[0]);
+      closers.push(() => s.close());
+      return s.url;
+    },
+  },
+  {
+    name: 'startStudioProxy',
+    boot: async (host) => {
+      const upstreamPort = await bootUpstream();
+      const p = await startStudioProxy({
+        bus: new StudioEventBus(),
+        target: 'MyApi',
+        kind: 'api',
+        upstream: `http://127.0.0.1:${upstreamPort}`,
+        host,
+      } as unknown as Parameters<typeof startStudioProxy>[0]);
+      closers.push(() => p.close());
+      return p.url;
+    },
+  },
+];
+
+describe('serve URLs bracket an IPv6 bind address (issue #599)', () => {
+  for (const serve of SERVES) {
+    it(`${serve.name} reports a parseable URL on '::1'`, async (ctx) => {
+      if (!(await hasIpv6Loopback())) {
+        // Nothing to bind, so there is no claim to make either way. Reported
+        // as SKIPPED rather than silently passing with no assertions.
+        ctx.skip();
+        return;
+      }
+      const url = await serve.boot('::1');
+      const parsed = expectServeUrl(url, '[::1]');
+      expect(url).toContain('[::1]:');
+      expect(parsed.hostname).toBe('[::1]');
+    });
+
+    it(`${serve.name} leaves an IPv4 bind address unbracketed`, async () => {
+      const url = await serve.boot('127.0.0.1');
+      expectServeUrl(url, '127.0.0.1');
+      expect(url).not.toContain('[');
+    });
+
+    it(`${serve.name} leaves a DNS bind address unbracketed`, async () => {
+      const url = await serve.boot('localhost');
+      expectServeUrl(url, 'localhost');
+      expect(url).not.toContain('[');
+    });
+  }
+});

--- a/tests/unit/local/ipv6-authority-urls.test.ts
+++ b/tests/unit/local/ipv6-authority-urls.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { buildDockerRunArgs } from '../../../src/local/ecs-task-runner.js';
+import type { ResolvedEcsContainer, ResolvedEcsTask } from '../../../src/local/ecs-task-resolver.js';
+import { a2aInvokeOnce } from '../../../src/local/agentcore-a2a-client.js';
+import {
+  invokeAgentCore,
+  waitForAgentCoreHttpReady,
+  waitForAgentCorePing,
+} from '../../../src/local/agentcore-client.js';
+import { mcpInvokeOnce } from '../../../src/local/agentcore-mcp-client.js';
+import {
+  bridgeAgentCoreWs,
+  invokeAgentCoreWs,
+} from '../../../src/local/agentcore-ws-client.js';
+import { invokeRie, waitForRieReady } from '../../../src/local/rie-client.js';
+import { buildMgmtEndpointEnvUrl } from '../../../src/local/websocket-mgmt-api.js';
+
+/**
+ * Issue go-to-k/cdk-local#599 — the URLs these modules build from a host and a
+ * port are handed to `fetch` / the `ws` client / a Lambda's env, so an
+ * unbracketed IPv6 literal is not a cosmetic defect: `http://:::8080` is not a
+ * URL and the request never leaves.
+ *
+ * Each site is asserted three ways — an IPv6 host IS bracketed, an IPv4 and a
+ * DNS host are NOT touched, and the composed string PARSES with its hostname
+ * intact.
+ */
+
+/** The three host spellings every site below is crossed with. */
+const IPV6 = { host: '::1', expected: '[::1]' } as const;
+const IPV4 = { host: '127.0.0.1', expected: '127.0.0.1' } as const;
+const DNS = { host: 'localhost', expected: 'localhost' } as const;
+
+/** Assert `url` parses and carries exactly the expected authority. */
+function expectAuthority(url: string, expectedHost: string, port: number): URL {
+  const parsed = new URL(url);
+  expect(parsed.hostname).toBe(expectedHost);
+  expect(parsed.port).toBe(String(port));
+  return parsed;
+}
+
+/** Stub global fetch, recording every URL it is handed. */
+function captureFetch(body = '{"ok":true}'): string[] {
+  const urls: string[] = [];
+  vi.spyOn(globalThis, 'fetch').mockImplementation(((input: RequestInfo | URL) => {
+    urls.push(String(input));
+    return Promise.resolve(new Response(body, { headers: { 'content-type': 'application/json' } }));
+  }) as typeof fetch);
+  return urls;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('rie-client (issue #599)', () => {
+  for (const { host, expected } of [IPV6, IPV4, DNS]) {
+    it(`invokeRie posts to a parseable URL for host '${host}'`, async () => {
+      const urls = captureFetch();
+      await invokeRie(host, 9001, { k: 1 }, 1000);
+      expect(urls).toHaveLength(1);
+      expectAuthority(urls[0] as string, expected, 9001);
+    });
+  }
+
+  it('brackets an IPv6 host in the not-ready diagnostic', async () => {
+    await expect(waitForRieReady('::1', 9001, 0)).rejects.toThrow(
+      /RIE did not become ready on \[::1\]:9001/
+    );
+  });
+
+  it('leaves an IPv4 host bare in the not-ready diagnostic', async () => {
+    await expect(waitForRieReady('127.0.0.1', 9001, 0)).rejects.toThrow(
+      /RIE did not become ready on 127\.0\.0\.1:9001/
+    );
+  });
+});
+
+describe('agentcore-client (issue #599)', () => {
+  for (const { host, expected } of [IPV6, IPV4, DNS]) {
+    it(`invokeAgentCore posts to a parseable URL for host '${host}'`, async () => {
+      const urls = captureFetch();
+      await invokeAgentCore(host, 8080, { p: 1 }, { sessionId: 's'.repeat(33), timeoutMs: 1000 });
+      expect(urls).toHaveLength(1);
+      const parsed = expectAuthority(urls[0] as string, expected, 8080);
+      expect(parsed.pathname).toBe('/invocations');
+    });
+
+    it(`waitForAgentCoreHttpReady probes a parseable URL for host '${host}'`, async () => {
+      const urls = captureFetch();
+      await waitForAgentCoreHttpReady(host, 8000, '/mcp', 5000);
+      expect(urls.length).toBeGreaterThan(0);
+      const parsed = expectAuthority(urls[0] as string, expected, 8000);
+      expect(parsed.pathname).toBe('/mcp');
+    });
+  }
+
+  it('brackets an IPv6 host in the ping-timeout diagnostic', async () => {
+    await expect(waitForAgentCorePing('::1', 8080, 0)).rejects.toThrow(
+      /did not become ready on \[::1\]:8080/
+    );
+  });
+
+  it('leaves an IPv4 host bare in the ping-timeout diagnostic', async () => {
+    await expect(waitForAgentCorePing('127.0.0.1', 8080, 0)).rejects.toThrow(
+      /did not become ready on 127\.0\.0\.1:8080/
+    );
+  });
+});
+
+describe('agentcore MCP / A2A clients (issue #599)', () => {
+  /** A fetchImpl that answers every JSON-RPC POST and records the URL. */
+  function rpcFetch(urls: string[]): typeof fetch {
+    return ((input: RequestInfo | URL) => {
+      urls.push(String(input));
+      return Promise.resolve(
+        new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }), {
+          headers: { 'content-type': 'application/json', 'mcp-session-id': 'sess' },
+        })
+      );
+    }) as typeof fetch;
+  }
+
+  for (const { host, expected } of [IPV6, IPV4, DNS]) {
+    it(`mcpInvokeOnce posts to a parseable URL for host '${host}'`, async () => {
+      const urls: string[] = [];
+      await mcpInvokeOnce(host, 8000, { method: 'tools/list' }, { fetchImpl: rpcFetch(urls) });
+      expect(urls.length).toBeGreaterThan(0);
+      for (const u of urls) expect(expectAuthority(u, expected, 8000).pathname).toBe('/mcp');
+    });
+
+    it(`a2aInvokeOnce posts to a parseable URL for host '${host}'`, async () => {
+      const urls: string[] = [];
+      await a2aInvokeOnce(host, 9000, { method: 'message/send' }, { fetchImpl: rpcFetch(urls) });
+      expect(urls.length).toBeGreaterThan(0);
+      for (const u of urls) expect(expectAuthority(u, expected, 9000).pathname).toBe('/');
+    });
+  }
+});
+
+describe('buildMgmtEndpointEnvUrl (issue #599)', () => {
+  it('brackets an IPv6 host in the @connections endpoint a Lambda receives', () => {
+    const url = buildMgmtEndpointEnvUrl('::1', 3001, 'prod');
+    expect(url).toBe('http://[::1]:3001/prod');
+    expect(expectAuthority(url, '[::1]', 3001).pathname).toBe('/prod');
+  });
+
+  it('leaves an IPv4 host byte-identical', () => {
+    expect(buildMgmtEndpointEnvUrl('127.0.0.1', 3001, 'prod')).toBe('http://127.0.0.1:3001/prod');
+  });
+
+  it('leaves a DNS host unbracketed', () => {
+    expect(buildMgmtEndpointEnvUrl('localhost', 3001, 'prod')).toBe('http://localhost:3001/prod');
+  });
+});
+
+describe('ecs-task-runner replica publish banner (issue #599)', () => {
+  function container(): ResolvedEcsContainer {
+    return {
+      name: 'web',
+      image: { kind: 'public', uri: 'public.ecr.aws/docker/library/busybox:latest' },
+      environment: {},
+      sensitiveEnvKeys: [],
+      secrets: [],
+      portMappings: [{ containerPort: 8080, protocol: 'tcp' }],
+      mountPoints: [],
+      dependsOn: [],
+      links: [],
+      essential: true,
+      ulimits: [],
+      warnings: [],
+    } as unknown as ResolvedEcsContainer;
+  }
+
+  function bannerFor(containerHost: string): string {
+    const lines: string[] = [];
+    vi.spyOn(console, 'info').mockImplementation((msg?: unknown) => {
+      lines.push(String(msg));
+    });
+    buildDockerRunArgs({
+      task: { family: 'fam' } as unknown as ResolvedEcsTask,
+      container: container(),
+      image: 'public.ecr.aws/docker/library/busybox:latest',
+      network: 'net',
+      volumeByName: new Map(),
+      secrets: [],
+      envOverrides: undefined,
+      containerHost,
+      roleArn: undefined,
+      platformOverride: undefined,
+      region: undefined,
+    } as unknown as Parameters<typeof buildDockerRunArgs>[0]);
+    const banner = lines.find((l) => l.includes('published on'));
+    expect(banner, `no publish banner in ${JSON.stringify(lines)}`).toBeDefined();
+    return banner as string;
+  }
+
+  it('brackets an IPv6 container host, so the endpoint studio reads is a URL', () => {
+    const banner = bannerFor('::1');
+    expect(banner).toContain("Container 'web' container port 8080 published on [::1]:8080.");
+    expect(banner).toContain('Reach it at [::1]:8080.');
+    expectAuthority('http://[::1]:8080', '[::1]', 8080);
+  });
+
+  it('leaves an IPv4 container host byte-identical — studio greps this line', () => {
+    const banner = bannerFor('127.0.0.1');
+    expect(banner).toContain("Container 'web' container port 8080 published on 127.0.0.1:8080.");
+    expect(banner).toContain('Reach it at 127.0.0.1:8080.');
+  });
+
+  it('leaves a DNS container host unbracketed', () => {
+    expect(bannerFor('localhost')).toContain(
+      "Container 'web' container port 8080 published on localhost:8080."
+    );
+  });
+});
+
+describe('agentcore-ws-client (issue #599)', () => {
+  /**
+   * A stand-in `ws` implementation that records the URL it was constructed
+   * with and then behaves like a socket that opens and closes immediately, so
+   * neither entry point hangs.
+   */
+  function recordingWs(urls: string[]): never {
+    class FakeWs {
+      onceHandlers = new Map<string, Array<(...a: unknown[]) => void>>();
+      constructor(url: string) {
+        urls.push(url);
+        setTimeout(() => {
+          this.emit('open');
+          this.emit('close', 1000);
+        }, 0);
+      }
+      on(event: string, cb: (...a: unknown[]) => void): this {
+        const list = this.onceHandlers.get(event) ?? [];
+        list.push(cb);
+        this.onceHandlers.set(event, list);
+        return this;
+      }
+      once(event: string, cb: (...a: unknown[]) => void): this {
+        return this.on(event, cb);
+      }
+      off(): this {
+        return this;
+      }
+      removeListener(): this {
+        return this;
+      }
+      emit(event: string, ...args: unknown[]): void {
+        for (const cb of this.onceHandlers.get(event) ?? []) cb(...args);
+      }
+      send(): void {}
+      close(): void {
+        this.emit('close', 1000);
+      }
+      terminate(): void {}
+      readyState = 1;
+    }
+    return FakeWs as never;
+  }
+
+  for (const { host, expected } of [IPV6, IPV4, DNS]) {
+    it(`bridgeAgentCoreWs opens a parseable ws:// URL for host '${host}'`, () => {
+      const urls: string[] = [];
+      const handle = bridgeAgentCoreWs(host, 8080, {
+        sessionId: 's'.repeat(33),
+        onMessage: () => {},
+        webSocketImpl: recordingWs(urls),
+      });
+      handle.close();
+      expect(urls).toHaveLength(1);
+      const parsed = expectAuthority(urls[0] as string, expected, 8080);
+      expect(parsed.protocol).toBe('ws:');
+      expect(parsed.pathname).toBe('/ws');
+    });
+
+    it(`invokeAgentCoreWs opens a parseable ws:// URL for host '${host}'`, async () => {
+      const urls: string[] = [];
+      await invokeAgentCoreWs(host, 8080, { p: 1 }, {
+        sessionId: 's'.repeat(33),
+        onMessage: () => {},
+        timeoutMs: 2000,
+        webSocketImpl: recordingWs(urls),
+      });
+      expect(urls).toHaveLength(1);
+      const parsed = expectAuthority(urls[0] as string, expected, 8080);
+      expect(parsed.protocol).toBe('ws:');
+      expect(parsed.pathname).toBe('/ws');
+    });
+  }
+});

--- a/tests/unit/local/ipv6-host-header.test.ts
+++ b/tests/unit/local/ipv6-host-header.test.ts
@@ -1,0 +1,268 @@
+import { createServer, request, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { SignatureV4 } from '@smithy/signature-v4';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { signAgentCoreInvocation } from '../../../src/local/agentcore-sigv4-sign.js';
+import { buildRedirectLocation } from '../../../src/local/front-door-server.js';
+
+/**
+ * Issue go-to-k/cdk-local#599 — the `Host:` header cases.
+ *
+ * RFC 7230 §5.4 defines `Host = uri-host [ ":" port ]` with RFC 3986's
+ * `uri-host`, so an IP-literal is bracketed there exactly as it is in a URL.
+ * That is the reasoning; the two cases this file opens with are the
+ * MEASUREMENT, because the sigv4 site's correctness depends on the premise
+ * being true of the actual stack rather than of the RFC.
+ */
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (s) =>
+        new Promise<void>((r) => {
+          s.close(() => r());
+          s.closeAllConnections?.();
+        })
+    )
+  );
+});
+
+/** True when this host can bind IPv6 loopback at all. */
+function hasIpv6Loopback(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once('error', () => resolve(false));
+    probe.listen(0, '::1', () => probe.close(() => resolve(true)));
+  });
+}
+
+/** Boot an echo server on `host` that reports the `Host` header it received. */
+function bootHostEcho(host: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ host: req.headers.host }));
+    });
+    servers.push(s);
+    s.once('error', reject);
+    s.listen(0, host, () => resolve((s.address() as AddressInfo).port));
+  });
+}
+
+function receivedHost(body: string): string {
+  return (JSON.parse(body) as { host: string }).host;
+}
+
+function get(url: string): Promise<string> {
+  return fetch(url).then((r) => r.text());
+}
+
+describe('what Node actually transmits as the Host header (issue #599, measured)', () => {
+  it('brackets an IPv6 literal', async (ctx) => {
+    if (!(await hasIpv6Loopback())) {
+      // Nothing to bind, so there is no measurement to take. Reported as
+      // SKIPPED rather than passing with no assertion.
+      ctx.skip();
+      return;
+    }
+    const port = await bootHostEcho('::1');
+
+    // Measured 2026-08-27, Node 24 — every client shape agrees:
+    //   fetch('http://[::1]:P/')                     -> Host: [::1]:P
+    //   http.request({ hostname: '::1', family: 6 }) -> Host: [::1]:P
+    //   http.request({ host: '::1', family: 6 })     -> Host: [::1]:P
+    // (`hostname: '[::1]'` is the one spelling that FAILS — ENOTFOUND, since
+    // node:net resolves the bracketed form as a NAME. That asymmetry is why
+    // the URL layer brackets and the socket layer must not.)
+    expect(receivedHost(await get(`http://[::1]:${port}/`))).toBe(`[::1]:${port}`);
+
+    const viaRequest = await new Promise<string>((resolve, reject) => {
+      const r = request({ hostname: '::1', port, path: '/', family: 6 }, (res) => {
+        let d = '';
+        res.on('data', (c) => (d += c));
+        res.on('end', () => resolve(d));
+      });
+      r.on('error', reject);
+      r.end();
+    });
+    expect(receivedHost(viaRequest)).toBe(`[::1]:${port}`);
+  });
+
+  it('does NOT bracket an IPv4 literal', async () => {
+    const port = await bootHostEcho('127.0.0.1');
+    expect(receivedHost(await get(`http://127.0.0.1:${port}/`))).toBe(`127.0.0.1:${port}`);
+  });
+});
+
+describe('signAgentCoreInvocation — the SIGNED Host header (issue #599)', () => {
+  const credentials = { accessKeyId: 'AKIAEXAMPLE', secretAccessKey: 'secret' };
+  const base = {
+    credentials,
+    region: 'us-east-1',
+    path: '/invocations',
+    body: '{}',
+    sessionId: 's'.repeat(33),
+    now: () => Date.parse('2026-01-01T00:00:00Z'),
+  };
+
+  function signatureOf(authorization: string): string {
+    const m = /Signature=([0-9a-f]+)/.exec(authorization);
+    expect(m, `no Signature= in ${authorization}`).not.toBeNull();
+    return (m as RegExpExecArray)[1] as string;
+  }
+
+  /**
+   * An INDEPENDENT oracle: sign the identical request with the smithy signer
+   * directly, choosing the `Host` header spelling ourselves. Comparing the
+   * module's signature against each spelling says which authority it actually
+   * signed — rather than inferring it from two of the module's own outputs.
+   */
+  async function oracleSignature(hostname: string, hostHeader: string): Promise<string> {
+    const signer = new SignatureV4({
+      credentials,
+      region: 'us-east-1',
+      service: 'bedrock-agentcore',
+      sha256: Sha256,
+    });
+    const signed = await signer.sign(
+      {
+        method: 'POST',
+        protocol: 'http:',
+        hostname,
+        port: 8080,
+        path: '/invocations',
+        headers: {
+          'Content-Type': 'application/json',
+          Host: hostHeader,
+          'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': base.sessionId,
+        },
+        body: '{}',
+      } as never,
+      { signingDate: new Date(base.now()) }
+    );
+    const auth = Object.entries(signed.headers).find(
+      ([k]) => k.toLowerCase() === 'authorization'
+    )?.[1];
+    return signatureOf(String(auth));
+  }
+
+  /** What the module under test signs for `host`. */
+  async function moduleSignature(host: string): Promise<string> {
+    return signatureOf((await signAgentCoreInvocation({ ...base, host, port: 8080 })).authorization);
+  }
+
+  it('signs the BRACKETED authority for an IPv6 host — what Node puts on the wire', async () => {
+    // The whole point: @smithy/signature-v4 signs the `Host` header VERBATIM
+    // rather than deriving it from `hostname`, and Node transmits
+    // `[::1]:8080` (measured above). Signing the unbracketed form therefore
+    // signed a value that never goes on the wire, so the signature could not
+    // verify against what the server canonicalises.
+    const actual = await moduleSignature('::1');
+
+    const bracketed = await oracleSignature('::1', '[::1]:8080');
+    const unbracketed = await oracleSignature('::1', '::1:8080');
+
+    // Guard the guard: if the signer ignored the Host header (deriving it from
+    // `hostname` instead) both oracles would agree and the assertions below
+    // would pass vacuously.
+    expect(bracketed).not.toBe(unbracketed);
+
+    expect(actual).toBe(bracketed);
+    expect(actual).not.toBe(unbracketed);
+  });
+
+  it('is idempotent for a host that arrives already bracketed', async () => {
+    const bare = await signAgentCoreInvocation({ ...base, host: '::1', port: 8080 });
+    const pre = await signAgentCoreInvocation({ ...base, host: '[::1]', port: 8080 });
+    expect(signatureOf(pre.authorization)).toBe(signatureOf(bare.authorization));
+  });
+
+  // The IPv4 / DNS guard, against the SAME independent oracle. Comparing the
+  // module with itself proves nothing here: signing is deterministic, so two
+  // identical calls agree even if the module signed `[127.0.0.1]:8080`. This
+  // is the only fence on the signed Host for a non-IPv6 host, and it is the
+  // site where a wrong value yields a signature that will not verify.
+  for (const host of ['127.0.0.1', 'localhost', 'example.internal']) {
+    it(`signs the BARE authority for '${host}' — no brackets`, async () => {
+      const bare = await oracleSignature(host, `${host}:8080`);
+      const bracketed = await oracleSignature(host, `[${host}]:8080`);
+      // Guard the guard, again: the two spellings must be distinguishable.
+      expect(bare).not.toBe(bracketed);
+
+      const actual = await moduleSignature(host);
+      expect(actual).toBe(bare);
+      expect(actual).not.toBe(bracketed);
+    });
+  }
+});
+
+describe('buildRedirectLocation — ALB #{host} from the request Host header (issue #599)', () => {
+  const redirect = { kind: 'redirect', statusCode: 301 } as never;
+
+  function locationFor(hostHeader: string, action: object = {}): string {
+    return buildRedirectLocation(
+      { ...redirect, ...action } as never,
+      { url: '/a/b?x=1', headers: { host: hostHeader } },
+      8080
+    );
+  }
+
+  it('reads the host out of a BRACKETED IPv6 Host header and re-brackets it', () => {
+    // Before: `split(':')[0]` read `'['`, so the Location came out as
+    // `http://[:8080/a/b?x=1` — not a URL at all.
+    const loc = locationFor('[::1]:8080');
+    expect(loc).toBe('http://[::1]:8080/a/b?x=1');
+    expect(new URL(loc).hostname).toBe('[::1]');
+  });
+
+  it('brackets an IPv6 host in the default-port branch too', () => {
+    const loc = buildRedirectLocation(
+      { kind: 'redirect', statusCode: 301, port: '80' } as never,
+      { url: '/a', headers: { host: '[::1]:8080' } },
+      8080
+    );
+    expect(loc).toBe('http://[::1]/a');
+    expect(new URL(loc).hostname).toBe('[::1]');
+  });
+
+  it('leaves an IPv4 Host header byte-identical', () => {
+    expect(locationFor('127.0.0.1:8080')).toBe('http://127.0.0.1:8080/a/b?x=1');
+  });
+
+  it('leaves a DNS Host header byte-identical', () => {
+    expect(locationFor('example.com:8080')).toBe('http://example.com:8080/a/b?x=1');
+    expect(locationFor('example.com')).toBe('http://example.com:8080/a/b?x=1');
+  });
+
+  it('keeps an explicit literal host in the action untouched', () => {
+    expect(locationFor('127.0.0.1:8080', { host: 'elsewhere.example' })).toBe(
+      'http://elsewhere.example:8080/a/b?x=1'
+    );
+  });
+
+  /**
+   * The END STATE of `hostFromAuthority`'s refusal, pinned here rather than
+   * left for a reader to derive from the helper's return value. A malformed
+   * `Host` yields no host, so the `Location` names nowhere — an unfollowable
+   * URL, which is the correct outcome for input that named nothing readable.
+   */
+  it('emits a hostless Location for a malformed Host header rather than a guessed one', () => {
+    // An UNCLOSED bracket is the one that matters. `[evil.example` used to
+    // read back as `evil.example`, so this redirect emitted a VALID Location
+    // to a host the client only half-named — and a client follows a valid
+    // Location. Now nothing is named.
+    const guessed = 'http://evil.example:8080/a/b?x=1';
+    const loc = locationFor('[evil.example');
+    expect(loc).not.toBe(guessed);
+    expect(loc).toBe('http://:8080/a/b?x=1');
+    expect(() => new URL(loc)).toThrow();
+
+    // The unbracketed multi-colon arm reaches the same end state.
+    expect(locationFor('a:b:c')).toBe('http://:8080/a/b?x=1');
+    // ...and trailing junk after the brackets is not silently dropped.
+    expect(locationFor('[a:b]junk')).toBe('http://:8080/a/b?x=1');
+  });
+});

--- a/tests/unit/local/studio-serve-manager.test.ts
+++ b/tests/unit/local/studio-serve-manager.test.ts
@@ -2496,3 +2496,104 @@ describe('a refusal during teardown is not an error banner (issue #578 review)',
     expect(second.list().map((s) => s.targetId)).toEqual(['MyApi']);
   });
 });
+
+/**
+ * Issue go-to-k/cdk-local#599 — the emitters now BRACKET an IPv6 authority so
+ * their banners are URLs. A reader that only understands the IPv4 spelling
+ * would be the same defect moved one file over, so every banner studio parses
+ * is exercised in its bracketed form here.
+ */
+describe('IPv6 banners studio has to read back (issue #599)', () => {
+  function mgrWith(): {
+    child: ReturnType<typeof makeFakeChild>;
+    mgr: ReturnType<typeof createStudioServeManager>;
+    fp: ReturnType<typeof fakeProxies>;
+  } {
+    const child = makeFakeChild();
+    const fp = fakeProxies();
+    const mgr = createStudioServeManager({
+      cliEntry: '/path/to/cli.js',
+      bus: new StudioEventBus(),
+      nodeBin: '/usr/bin/node',
+      spawnFn: vi.fn(() => child as never) as never,
+      clock: fixedClock(),
+      proxyFactory: fp.factory,
+    });
+    return { child, mgr, fp };
+  }
+
+  it("reads a start-api `Server listening on http://[::1]:<port>` banner", async () => {
+    const { child, mgr, fp } = mgrWith();
+    const p = mgr.start({ targetId: 'MyApi', kind: 'api' });
+    child.stdout.emit('data', 'Server listening on http://[::1]:51234  (MyApi)\n');
+    const state = await p;
+    expect(state.status).toBe('running');
+    expect(fp.upstreams).toEqual(['http://[::1]:51234']);
+  });
+
+  it('reads a start-alb `ALB front-door: http://[::1]:<port>` banner', async () => {
+    const { child, mgr, fp } = mgrWith();
+    const p = mgr.start({ targetId: 'MyAlb', kind: 'alb' });
+    child.stdout.emit('data', 'ALB front-door: http://[::1]:51234 (listener port 80)\n');
+    const state = await p;
+    expect(state.status).toBe('running');
+    expect(fp.upstreams).toEqual(['http://[::1]:51234']);
+  });
+
+  it('reads a start-cloudfront `serving on http://[::1]:<port>` banner', async () => {
+    const { child, mgr, fp } = mgrWith();
+    const p = mgr.start({ targetId: 'MyDist', kind: 'cloudfront' });
+    child.stdout.emit('data', 'CloudFront distribution serving on http://[::1]:51234  (Dist)\n');
+    const state = await p;
+    expect(state.status).toBe('running');
+    expect(fp.upstreams).toEqual(['http://[::1]:51234']);
+  });
+
+  it("reads start-agentcore's bracketed ws:// listen line and http:// contract line", async () => {
+    const { child, mgr, fp } = mgrWith();
+    const p = mgr.start({ targetId: 'MyAgent', kind: 'agentcore-ws' });
+    child.stdout.emit(
+      'data',
+      'Server listening on ws://[::1]:49160/ws  (MyAgent (AgentCore WebSocket))\n' +
+        'HTTP contract served on http://[::1]:49160 — POST http://[::1]:49160/invocations\n'
+    );
+    const state = await p;
+    expect(state.status).toBe('running');
+    // The ws:// endpoint is handed through un-proxied; the http:// contract
+    // endpoint is fronted by the capture proxy.
+    expect(state.endpoints?.[0]).toBe('ws://[::1]:49160/ws');
+    expect(fp.upstreams).toEqual(['http://[::1]:49160']);
+  });
+
+  it('parses a bracketed IPv6 replica publish banner', () => {
+    expect(
+      parsePublishedHostEndpoint(
+        "Container 'web' container port 80 published on [::1]:54321. Reach it at [::1]:54321."
+      )
+    ).toBe('http://[::1]:54321');
+  });
+
+  it('still parses the IPv4 replica publish banner byte-identically', () => {
+    expect(
+      parsePublishedHostEndpoint(
+        "Container 'web' container port 80 published on 127.0.0.1:54321. Reach it at 127.0.0.1:54321."
+      )
+    ).toBe('http://127.0.0.1:54321');
+  });
+
+  it('refuses an UNBRACKETED IPv6 publish authority — not what the emitter writes', () => {
+    // `::1:54321` has no unambiguous split into host and port, so reading it
+    // would be guessing at what the emitter meant.
+    expect(
+      parsePublishedHostEndpoint("Container 'web' container port 80 published on ::1:54321.")
+    ).toBeUndefined();
+  });
+
+  it('keeps the publish banner anchored — a mid-message occurrence names nothing', () => {
+    expect(
+      parsePublishedHostEndpoint(
+        "relayed: Container 'web' container port 80 published on [::1]:54321."
+      )
+    ).toBeUndefined();
+  });
+});

--- a/tests/unit/utils/url-authority-call-sites.test.ts
+++ b/tests/unit/utils/url-authority-call-sites.test.ts
@@ -1,0 +1,287 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+
+/**
+ * Issue go-to-k/cdk-local#599 — the population fence.
+ *
+ * The defect was never one banner: it was that composing an authority as
+ * `${host}:${port}` is the obvious thing to write, and gets written again
+ * every time a new endpoint is printed. `cdkl studio` PARSES several of these
+ * banners with `new URL(...)` before it will forward anything, so an IPv6
+ * host that is not bracketed does not merely read badly — the serve is
+ * refused.
+ *
+ * So this file fences the POPULATION rather than the sites that happened to
+ * be found:
+ *
+ * - the NEGATIVE fence: no `${…host…}:${…}` adjacency may exist in `src/`
+ *   unless it is on {@link NON_AUTHORITY}, each entry saying why that colon
+ *   is not a URL authority;
+ * - the POSITIVE fence: every site that WAS converted must still route
+ *   through `formatAuthority`, so reverting one is red here even when its
+ *   behaviour is only reachable through a full serve boot.
+ */
+
+const SRC = join(import.meta.dirname, '../../../src');
+
+/** The helper itself defines the composition; scanning it would be circular. */
+const SELF = 'utils/url-authority.ts';
+
+/** Every `${expr}:${` adjacency, with the left-hand expression captured. */
+const ADJACENCY_RE = /\$\{([^{}]*)\}:\$\{/g;
+/** An expression that plausibly names a network host. */
+const HOSTISH_RE = /host|addr|ip|endpoint|origin|domain/i;
+
+interface Allowed {
+  /** Path relative to `src/`. */
+  readonly file: string;
+  /** A distinctive substring of the offending line. */
+  readonly contains: string;
+  /** Why this colon is not a URL authority — or why it is still unfixed. */
+  readonly why: string;
+}
+
+/**
+ * The colons that are NOT a URL authority. Two distinct reasons, and the list
+ * says which, because "exempt" is not one fact:
+ *
+ * - a DIFFERENT GRAMMAR — `docker run`'s `-p ip:hostPort:containerPort`,
+ *   `--add-host name:ip`, `-v hostPath:containerPath`. These are not RFC 3986
+ *   authorities and `formatAuthority` would be wrong in them. (Docker's `-p`
+ *   accepts an IPv6 host BOTH bare and bracketed — measured on Docker 29.3.1,
+ *   `-p :::18080:80` and `-p [::]:18083:80` both yield HostIp `::` — so there
+ *   is no latent defect hiding behind this exemption.)
+ * - HUMAN TEXT that merely mentions a host and a port, and is never fed to a
+ *   parser. Five are log lines; three are 502 / 504 RESPONSE BODIES, which
+ *   reach a wider reader than a log does and are labelled as such rather than
+ *   lumped in with the logs.
+ *
+ * Every host+port URL, banner and `Host:` header in `src/` routes through the
+ * helper; nothing in this list is an unconverted one.
+ *
+ * `docker run` argument grammars (`-p ip:hostPort:containerPort`,
+ * `--add-host name:ip`, `-v hostPath:containerPath`) are their own syntax,
+ * not RFC 3986 authorities, so `formatAuthority` would be wrong there. (Docker
+ * has its OWN bracket rule for an IPv6 `-p` address; that is a separate
+ * question from this one and is not settled here.) Diagnostic prose that
+ * merely mentions a host and port is left as prose.
+ */
+const NON_AUTHORITY: readonly Allowed[] = [
+  {
+    file: 'cli/commands/local-profile-credentials-file.ts',
+    contains: '${file.hostPath}:${file.containerPath}',
+    why: 'docker `-v` bind mount: two filesystem paths, no host',
+  },
+  {
+    file: 'local/docker-runner.ts',
+    contains: "'--add-host', `${entry.host}:${entry.ip}`",
+    why: 'docker `--add-host name:ip` grammar',
+  },
+  {
+    file: 'local/docker-runner.ts',
+    contains: "'-p', `${host}:${opts.hostPort}",
+    why: 'docker `-p` publish grammar',
+  },
+  {
+    file: 'local/docker-runner.ts',
+    contains: "'-p', `${host}:${opts.debugPort}",
+    why: 'docker `-p` publish grammar',
+  },
+  {
+    file: 'local/docker-runner.ts',
+    contains: '${mount.hostPath}:${mount.containerPath}',
+    why: 'docker `-v` bind mount: two filesystem paths, no host',
+  },
+  {
+    file: 'local/ecs-task-runner.ts',
+    contains: "'--add-host', `${h.host}:${h.ip}`",
+    why: 'docker `--add-host name:ip` grammar',
+  },
+  {
+    file: 'local/ecs-task-runner.ts',
+    contains: "'-p', `${containerHost}:${hostPort}",
+    why: 'docker `-p` publish grammar',
+  },
+  {
+    file: 'local/ecs-task-runner.ts',
+    contains: '${opts.profileCredentialsFile.hostPath}:${opts.profileCredentialsFile.containerPath}',
+    why: 'docker `-v` bind mount: two filesystem paths, no host',
+  },
+  {
+    file: 'local/ecs-task-runner.ts',
+    contains: '${v.hostPath}:${mp.containerPath}',
+    why: 'docker `-v` bind mount: two filesystem paths, no host',
+  },
+  {
+    file: 'local/container-pool.ts',
+    contains: 'on ${spec.containerHost}:${hostPort}',
+    why: 'logger.debug prose, never parsed',
+  },
+  {
+    file: 'local/ecs-service-runner.ts',
+    contains: 'registered at ${containerHost}:${hostPort}',
+    why: 'logger.info / warn prose, never parsed',
+  },
+  {
+    file: 'local/ecs-service-runner.ts',
+    contains: 'TCP probe ${ip}:${port} accepted',
+    why: 'logger.debug prose, never parsed',
+  },
+  {
+    file: 'local/ecs-service-runner.ts',
+    contains: 'TCP probe ${ip}:${port} did not accept',
+    why: 'logger.info / warn prose, never parsed',
+  },
+  {
+    file: 'local/front-door-server.ts',
+    contains: 'Replica ${endpoint.host}:${endpoint.port} behind',
+    why: 'the 504 RESPONSE BODY (writeError) — prose for a human, never parsed; the values are the replica pool\'s own endpoint, not request-derived',
+  },
+  {
+    file: 'local/front-door-server.ts',
+    contains: 'Failed to reach replica ${endpoint.host}:${endpoint.port}',
+    why: 'the 502 RESPONSE BODY, twice — writeError on the HTTP path and writeRawHttpError on the upgrade path. Body, not header: it lands after the CRLF that ends the head, so it cannot inject one, and the values are the replica pool\'s own endpoint',
+  },
+  {
+    file: 'local/front-door-server.ts',
+    contains: 'WS upstream error (${endpoint.host}:${endpoint.port})',
+    why: 'logger.debug prose, never parsed',
+  },
+];
+
+/**
+ * Every site issue #599 converted. Reverting any of them is red here — which
+ * is the only guard several of them have, since their banners are only
+ * reachable through a full serve boot.
+ *
+ * `count` is the number of sites that share the snippet, and it defaults to 1.
+ * Without it an `includes()` check is satisfied by ANY one of them, so the
+ * second and later copies were not pinned at all: reverting
+ * `invokeRieStreaming` alone stayed green because `invokeRie` still carried
+ * the byte-identical line.
+ */
+const CONVERTED: readonly { file: string; contains: string; count?: number }[] = [
+  { file: 'cli/commands/ecs-service-emulator.ts', contains: 'ALB front-door: ${server.scheme}://${formatAuthority(server.host, server.port)}' },
+  { file: 'cli/commands/ecs-service-emulator.ts', contains: '${scheme}://${formatAuthority(ep.host, ep.hostPort)}' },
+  { file: 'cli/commands/ecs-service-emulator.ts', contains: '${s.scheme}://${formatAuthority(s.host, s.port)}' },
+  // Both `Server listening on` sites now share one exported emitter
+  // (`formatServerListeningBanner`), which has its own behavioural test.
+  { file: 'cli/commands/local-start-api.ts', contains: 'Server listening on ${scheme}://${formatAuthority(host, port)}${pathSuffix}  (${label})' },
+  { file: 'cli/commands/local-start-api.ts', contains: '(http://${formatAuthority(server.host, server.port)})' },
+  { file: 'local/cloudfront-server.ts', contains: '`${scheme}://${formatAuthority(options.host, port)}`' },
+  { file: 'local/agentcore-http-server.ts', contains: 'httpUrl: `http://${formatAuthority(host, port)}`' },
+  { file: 'local/agentcore-http-server.ts', contains: 'wsUrl: `ws://${formatAuthority(host, port)}${bridge.path}`' },
+  { file: 'local/agentcore-ws-bridge.ts', contains: 'url: `ws://${formatAuthority(host, port)}${attached.path}`' },
+  { file: 'local/studio-server.ts', contains: 'url: `http://${formatAuthority(host, boundPort)}`' },
+  { file: 'local/studio-proxy.ts', contains: 'url: `http://${formatAuthority(host, port)}`' },
+  { file: 'local/ecs-task-runner.ts', contains: '`${formatAuthority(containerHost, hostPort)}${overrideNote}. `' },
+  { file: 'local/ecs-task-runner.ts', contains: 'Reach it at ${formatAuthority(containerHost, hostPort)}.' },
+  { file: 'local/websocket-mgmt-api.ts', contains: 'return `http://${formatAuthority(host, port)}/${stage}`' },
+  { file: 'local/rie-client.ts', contains: 'RIE did not become ready on ${formatAuthority(host, port)}' },
+  { file: 'local/rie-client.ts', contains: 'fetch(`http://${formatAuthority(host, port)}/`' },
+  // invokeRie + invokeRieStreaming
+  { file: 'local/rie-client.ts', contains: 'const url = `http://${formatAuthority(host, port)}${INVOKE_PATH}`', count: 2 },
+  // waitForAgentCorePing + waitForAgentCoreHttpReady
+  { file: 'local/agentcore-client.ts', contains: 'AgentCore agent did not become ready on ${formatAuthority(host, port)}', count: 2 },
+  { file: 'local/agentcore-client.ts', contains: 'fetch(`http://${formatAuthority(host, port)}${PING_PATH}`' },
+  { file: 'local/agentcore-client.ts', contains: 'fetch(`http://${formatAuthority(host, port)}${path}`' },
+  { file: 'local/agentcore-client.ts', contains: 'const url = `http://${formatAuthority(host, port)}${INVOCATIONS_PATH}`' },
+  { file: 'local/agentcore-mcp-client.ts', contains: 'const url = `http://${formatAuthority(host, port)}${MCP_PATH}`' },
+  { file: 'local/agentcore-a2a-client.ts', contains: 'const url = `http://${formatAuthority(host, port)}${A2A_PATH}`' },
+  // bridgeAgentCoreWs + invokeAgentCoreWs
+  { file: 'local/agentcore-ws-client.ts', contains: 'const url = `ws://${formatAuthority(host, port)}${WS_PATH}`', count: 2 },
+  { file: 'local/agentcore-sigv4-sign.ts', contains: 'Host: formatAuthority(opts.host, opts.port)' },
+  { file: 'local/front-door-server.ts', contains: 'isDefaultPort || port === \'\' ? formatHostForAuthority(host) : formatAuthority(host, port)' },
+  { file: 'local/front-door-server.ts', contains: 'hostFromAuthority(hostHeaderValue ?? \'\')' },
+];
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFiles(full));
+    else if (entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+interface Site {
+  readonly file: string;
+  readonly line: number;
+  readonly text: string;
+}
+
+function hostishAdjacencies(): Site[] {
+  const sites: Site[] = [];
+  for (const full of tsFiles(SRC)) {
+    const file = relative(SRC, full).split(/[\\/]/).join('/');
+    if (file === SELF) continue;
+    const lines = readFileSync(full, 'utf8').split('\n');
+    lines.forEach((text, i) => {
+      for (const m of text.matchAll(ADJACENCY_RE)) {
+        if (HOSTISH_RE.test(m[1] ?? '')) {
+          sites.push({ file, line: i + 1, text: text.trim() });
+          break;
+        }
+      }
+    });
+  }
+  return sites;
+}
+
+describe('URL-authority composition sites (issue #599)', () => {
+  const sites = hostishAdjacencies();
+
+  it('finds the population it is meant to fence (guard the guard)', () => {
+    // If the scan silently stopped matching, every assertion below would pass
+    // vacuously. The docker-argument sites alone keep this well above zero.
+    expect(sites.length).toBeGreaterThan(10);
+  });
+
+  it('composes no `${host}:${port}` authority outside the declared non-authority set', () => {
+    const unexplained = sites.filter(
+      (s) => !NON_AUTHORITY.some((a) => a.file === s.file && s.text.includes(a.contains))
+    );
+    expect(
+      unexplained.map((s) => `${s.file}:${s.line}  ${s.text}`),
+      'a new `${host}:${port}` was composed by hand — route it through `formatAuthority` ' +
+        '(src/utils/url-authority.ts), or add it to NON_AUTHORITY with the reason its colon is not a URL authority'
+    ).toEqual([]);
+  });
+
+  it('carries no stale non-authority exemption', () => {
+    const dead = NON_AUTHORITY.filter(
+      (a) => !sites.some((s) => s.file === a.file && s.text.includes(a.contains))
+    );
+    expect(
+      dead.map((a) => `${a.file}  ${a.contains}`),
+      'an exemption no longer matches any source line — delete it'
+    ).toEqual([]);
+  });
+
+  it('keeps every converted site routed through formatAuthority', () => {
+    const reverted = CONVERTED.map((c) => {
+      const want = c.count ?? 1;
+      const got = readFileSync(join(SRC, c.file), 'utf8').split(c.contains).length - 1;
+      return got === want ? undefined : `${c.file}  expected ${want}x, found ${got}x: ${c.contains}`;
+    }).filter((x): x is string => x !== undefined);
+    expect(
+      reverted,
+      'a site issue #599 converted no longer composes its authority through `formatAuthority` ' +
+        '(an EXACT count, so one of two byte-identical sites cannot hide behind the other)'
+    ).toEqual([]);
+  });
+
+  it('imports the helper in every file that uses it', () => {
+    const files = [...new Set(CONVERTED.map((c) => c.file))];
+    for (const file of files) {
+      // A file may pull in more than `formatAuthority` (front-door-server also
+      // needs `formatHostForAuthority` + the inverse `hostFromAuthority`), so
+      // match the named-import LIST rather than a single-symbol spelling.
+      expect(readFileSync(join(SRC, file), 'utf8'), file).toMatch(
+        /import \{[^}]*\bformatAuthority\b[^}]*\} from '\.\.?\/[^']*url-authority\.js';/
+      );
+    }
+  });
+});

--- a/tests/unit/utils/url-authority.test.ts
+++ b/tests/unit/utils/url-authority.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  formatAuthority,
+  formatHostForAuthority,
+  hostFromAuthority,
+} from '../../../src/utils/url-authority.js';
+
+/**
+ * Issue go-to-k/cdk-local#599 — the helper is fenced as a CLASSIFIER, not
+ * against a handful of remembered values.
+ *
+ * Every row below is crossed with a port and put through the SAME three
+ * assertions, and the parse / round-trip assertions are opt-OUT (`parses:
+ * false`) rather than opt-in. A spelling nobody imagined therefore fails by
+ * default: adding a row without deciding what it should do cannot pass.
+ */
+interface HostRow {
+  /** What a caller hands the helper (a `--container-host` value, a bind address). */
+  readonly host: string;
+  /** The host token the helper must render inside an authority. */
+  readonly expected: string;
+  /** Why this row exists — read out in the test name. */
+  readonly why: string;
+  /**
+   * Opt out of "the composed authority is a URL". The ONLY row that may is a
+   * host that is not a host: the helper composes an authority, it does not
+   * invent one, so an empty host stays empty and the result does not parse.
+   */
+  readonly parses?: false;
+  /**
+   * What `URL.hostname` reads back, when the parser NORMALISES the token the
+   * helper wrote. Defaults to {@link expected}; set only where the two
+   * legitimately differ. The helper is a composer, not a normaliser — it
+   * preserves the case it was handed, and the WHATWG parser lowercases an
+   * IPv6 literal. Making that explicit per row beats a case-insensitive
+   * compare, which would also hide a helper that started mangling case.
+   */
+  readonly parsedAs?: string;
+}
+
+const HOSTS: readonly HostRow[] = [
+  { host: '::', expected: '[::]', why: 'the IPv6 wildcard — the bug in the issue' },
+  { host: '::1', expected: '[::1]', why: 'IPv6 loopback' },
+  { host: 'fe80::1', expected: '[fe80::1]', why: 'a link-local literal' },
+  { host: '[::1]', expected: '[::1]', why: 'ALREADY bracketed — must not double-bracket' },
+  {
+    host: 'FE80::1',
+    expected: '[FE80::1]',
+    parsedAs: '[fe80::1]',
+    why: 'uppercase hex is a legal literal; the PARSER lowercases, the helper does not',
+  },
+  {
+    host: '2001:DB8::1',
+    expected: '[2001:DB8::1]',
+    parsedAs: '[2001:db8::1]',
+    why: 'mixed-case documentation prefix',
+  },
+  {
+    // The one input that is BOTH already bracketed and unparseable. An early
+    // return on "already bracketed" bypasses the zone-drop and emits
+    // `http://[fe80::1%en0]:8080`, which `new URL` rejects — precisely the
+    // failure this helper exists to prevent.
+    host: '[fe80::1%en0]',
+    expected: '[fe80::1]',
+    why: 'bracketed WITH a zone — the zone must still be dropped',
+  },
+  {
+    host: 'fe80::1%en0',
+    expected: '[fe80::1]',
+    why: 'a zone id — dropped, since no URL parser accepts one',
+  },
+  { host: '0.0.0.0', expected: '0.0.0.0', why: 'the IPv4 wildcard — the spelling that already worked' },
+  { host: '127.0.0.1', expected: '127.0.0.1', why: 'IPv4 loopback, the default everywhere' },
+  { host: 'localhost', expected: 'localhost', why: 'a registered name' },
+  { host: 'example.com', expected: 'example.com', why: 'a dotted registered name' },
+  { host: '', expected: '', why: 'no host at all — the caller has a bug, not the helper', parses: false },
+  {
+    // The ALB redirect writer fills its host from an `#{host}` template or a
+    // configured literal, and a CRLF-injection attempt arrives there
+    // FLATTENED (`front-door-server`'s raw-socket case), colon and all. It is
+    // not an address, so it must pass through rather than gain brackets it
+    // never had — which is why the classifier is a character-class test and
+    // not "contains a colon".
+    host: 'example.test  x-injected: yes',
+    expected: 'example.test  x-injected: yes',
+    why: 'a colon in something that CANNOT be an address',
+    parses: false,
+  },
+];
+
+const PORT = 8080;
+
+describe('formatHostForAuthority / formatAuthority (issue #599)', () => {
+  for (const row of HOSTS) {
+    describe(`host '${row.host}' (${row.why})`, () => {
+      it(`renders as '${row.expected}'`, () => {
+        expect(formatHostForAuthority(row.host)).toBe(row.expected);
+        expect(formatAuthority(row.host, PORT)).toBe(`${row.expected}:${PORT}`);
+      });
+
+      it('is idempotent', () => {
+        const once = formatHostForAuthority(row.host);
+        expect(formatHostForAuthority(once)).toBe(once);
+      });
+
+      if (row.parses === false) {
+        it('does NOT parse as a URL, and that is the documented answer', () => {
+          expect(() => new URL(`http://${formatAuthority(row.host, PORT)}`)).toThrow();
+        });
+      } else {
+        it('composes a URL the WHATWG parser accepts, whose hostname round-trips', () => {
+          const parsedAs = row.parsedAs ?? row.expected;
+          const authority = formatAuthority(row.host, PORT);
+          const url = new URL(`http://${authority}`);
+          expect(url.port).toBe(String(PORT));
+          expect(url.hostname).toBe(parsedAs);
+          // The round trip that matters in practice: a caller often feeds a
+          // parsed `URL.hostname` (already bracketed for IPv6) straight back
+          // into the helper. Re-composing from it must be a FIXED POINT — on
+          // the parsed spelling, since that is the value a caller actually
+          // holds once a URL has been through the parser.
+          expect(formatAuthority(url.hostname, url.port)).toBe(`${parsedAs}:${PORT}`);
+          expect(new URL(`http://${formatAuthority(url.hostname, url.port)}`).hostname).toBe(
+            parsedAs
+          );
+        });
+      }
+    });
+  }
+
+  it('accepts a string port as well as a number', () => {
+    expect(formatAuthority('::1', '8080')).toBe('[::1]:8080');
+    expect(formatAuthority('127.0.0.1', '8080')).toBe('127.0.0.1:8080');
+  });
+
+  it('survives a hostname the URL parser NORMALISES, without double-bracketing', () => {
+    // `::ffff:127.0.0.1` re-serialises as `[::ffff:7f00:1]`. The point is not
+    // the normalisation (that is the parser's business) but that feeding the
+    // parser's answer back in is safe.
+    const first = formatAuthority('::ffff:127.0.0.1', PORT);
+    const url = new URL(`http://${first}`);
+    expect(url.hostname).toBe('[::ffff:7f00:1]');
+    expect(formatAuthority(url.hostname, url.port)).toBe(`[::ffff:7f00:1]:${PORT}`);
+  });
+
+  it('leaves a `%` that is not a zone id alone, since it is not an IPv6 literal', () => {
+    // No `:`, so it is a registered name as far as an authority is concerned.
+    expect(formatHostForAuthority('weird%name')).toBe('weird%name');
+  });
+
+  it('brackets only what could BE an address, not merely what contains a colon', () => {
+    // Bracketed: every character is legal in an IPv6 literal.
+    for (const h of ['::', '::1', 'fe80::1', '::ffff:127.0.0.1', 'a:b:c'])
+      expect(formatHostForAuthority(h), h).toBe(`[${h}]`);
+    // Untouched: a colon inside something no address could be.
+    for (const h of ['host:name', 'example.test  x-injected: yes', 'http://x', 'a:b/c'])
+      expect(formatHostForAuthority(h), h).toBe(h);
+    // A degenerate all-legal-characters input still brackets. The classifier
+    // separates address-SHAPED from not-address-shaped; it does not validate
+    // an address, and a caller with `:` for a host has the same bug as one
+    // with `''` (see the table's `parses: false` rows).
+    expect(formatHostForAuthority(':')).toBe('[:]');
+  });
+});
+
+/**
+ * The inverse: read a host back OUT of an authority. Same table, so the two
+ * directions cannot drift — every host that composes must decompose to itself.
+ */
+describe('hostFromAuthority (issue #599)', () => {
+  // Scoped to the rows that compose a WELL-FORMED authority. The two
+  // `parses: false` rows are not hosts (the empty string; a flattened
+  // injection attempt), so their authority has no unambiguous split back and
+  // no round trip is claimed — see the explicit case at the end.
+  for (const row of HOSTS.filter((r) => r.parses !== false)) {
+    // Derived from the row's EXPECTED authority token rather than from its
+    // input: a zone id is dropped on the way in, so the round trip lands on
+    // the scope-free literal. Stated, not skipped.
+    const expectedBare = row.expected.startsWith('[')
+      ? row.expected.slice(1, -1)
+      : row.expected;
+
+    it(`recovers '${expectedBare}' from the authority built for '${row.host}'`, () => {
+      expect(hostFromAuthority(formatAuthority(row.host, PORT))).toBe(expectedBare);
+    });
+
+    it(`round-trips '${row.host}' back through formatAuthority unchanged`, () => {
+      const authority = formatAuthority(row.host, PORT);
+      expect(formatAuthority(hostFromAuthority(authority), PORT)).toBe(authority);
+    });
+  }
+
+  it('reads a bare host with no port', () => {
+    expect(hostFromAuthority('example.com')).toBe('example.com');
+    expect(hostFromAuthority('[::1]')).toBe('::1');
+    expect(hostFromAuthority('')).toBe('');
+  });
+
+  it('refuses to guess at a malformed authority, on BOTH arms', () => {
+    // One case list for both branches, because the defect was the same shape
+    // twice and fixing one arm is what left the other visible.
+    //
+    // UNBRACKETED: formerly `split(':')[0]`, which only LOOKED like a refusal
+    // for a value starting with a colon — the leading empty fragment. Every
+    // other spelling handed back a fragment that is not the host named:
+    // `fe80::1:8080` -> 'fe80', `2001:db8::1` -> '2001', `a:b:c:8080` -> 'a'.
+    //
+    // BRACKETED: the worse direction, because the guess PARSES. `[evil.example`
+    // came back as `evil.example`, so an ALB `#{host}` redirect emitted a
+    // VALID `Location` to a host the client only half-named — where the
+    // malformed input should have produced nothing at all. `[a:b]junk` dropped
+    // its trailing junk silently, and `[x:y` returned a multi-colon value as a
+    // host, which is exactly what the unbracketed arm refuses.
+    //
+    // This is an attacker-reachable parser (the request `Host` header feeds
+    // that substitution), so it refuses rather than guesses.
+    for (const a of [
+      // unbracketed
+      '::1:8080',
+      'fe80::1:8080',
+      '2001:db8::1',
+      'a:b:c:8080',
+      'example.test  x-injected: yes:8080',
+      '::',
+      // bracketed
+      '[evil.example',
+      '[a:b]junk',
+      '[x:y',
+      '[::1]:80x',
+      '[::1]junk:8080',
+    ]) {
+      expect(hostFromAuthority(a), a).toBe('');
+    }
+  });
+
+  it('still accepts a WELL-FORMED bracketed authority, with or without a port', () => {
+    // The other direction of the same rule — the refusal must not have eaten
+    // the shape it exists to read.
+    expect(hostFromAuthority('[::1]')).toBe('::1');
+    expect(hostFromAuthority('[::1]:8080')).toBe('::1');
+    expect(hostFromAuthority('[fe80::1]:1')).toBe('fe80::1');
+    expect(hostFromAuthority('[FE80::1]:65535')).toBe('FE80::1');
+  });
+
+  it('still reads the ordinary single-colon and no-colon spellings', () => {
+    expect(hostFromAuthority('127.0.0.1:8080')).toBe('127.0.0.1');
+    expect(hostFromAuthority('example.com:8080')).toBe('example.com');
+    expect(hostFromAuthority('example.com')).toBe('example.com');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkl start-alb --container-host ::` printed `ALB front-door: http://:::8080`.
That is not a URL — RFC 3986 3.2.2 requires an IPv6 literal in an authority to be
bracketed, and `new URL('http://:::8080')` throws. The banner is machine-parsed
(studio reads it to point its capture proxy), so the studio serve was refused as
well. `0.0.0.0` works, so two spellings of one intention behaved differently.

Adds `src/utils/url-authority.ts` (`formatHostForAuthority`, `formatAuthority`,
and the inverse `hostFromAuthority`) and routes **28 composition sites across 17
files** through it. The population was derived by enumerating every place a URL
or machine-parsed authority is built from a host and a port — not by grepping the
one spelling the issue suggested, which finds fewer.

A colon between a host and a port is not always an authority. Docker `-p` /
`--add-host` / `-v` arguments and human-readable log lines are exempted, each
with its reason recorded, and a source fence walks `src/` so a new hand-built
authority fails the suite.

## Two further defects, same root cause, fixed here rather than filed

- **The READ side was broken too.** `buildRedirectLocation` took the host as
  `split(':')[0]`, which yields `'['` for the `Host: [::1]:8080` a conforming
  client sends — measured as `Location: http://[:8080/a/b?x=1`.
- **`agentcore-sigv4-sign` signed a value that never goes on the wire.** It
  signed `Host: ::1:8080` while Node transmits `[::1]:8080`. Both halves were
  measured, not reasoned: a real `http.createServer` echoing `req.headers.host`
  shows Node brackets, and `@smithy/signature-v4` signs the header verbatim, so
  the two spellings produce **different signatures**. That is a signature that
  cannot verify, not a cosmetic difference.

Note the asymmetry that makes this subtle: the URL layer must bracket, the socket
layer must not (`http.request({hostname: '[::1]'})` gives ENOTFOUND). Socket-layer
call sites are deliberately untouched, and each was audited for which layer it
feeds.

## An existing security test caught the first classifier

The first cut was "a host containing `:` needs brackets", which also wrapped
flattened attacker text in the front-door CRLF-injection test. **The classifier
was narrowed, not the test relaxed** — to a hex/colon/dot character class, still
a class rather than an enumeration. `tests/unit/local/front-door-server.test.ts`
is byte-for-byte unmodified, and the narrowing is pinned in both directions so a
future re-widening goes red.

## Behavior change (cdkd parity: cat 4 + cat 3)

Every IPv6 banner cdk-local emits now brackets the literal, and the signed
`Host` header changes for IPv6 hosts. **IPv4 and DNS output is byte-identical**,
asserted per site rather than assumed, because ~30 integ fixtures grep these
lines verbatim. Filed as https://github.com/go-to-k/cdkd/issues/2338 with the
migration note (a host-side parser whose host group is an IPv4 dotted quad, or
which uses `split(':')[0]`, must be widened).

## Test plan

- **130 new cases** across 6 files plus 8 appended (re-derived independently, not
  taken from the implementer's count).
- The two Node/smithy measurements ship as executable tests against the real
  libraries, with a guard-the-guard that fails if smithy ever stopped signing the
  header verbatim — otherwise both oracles would agree and the test would pass
  vacuously.
- The classifier is fenced as a classifier: a table crossing the host space with
  opt-OUT parse assertions, so an unimagined shape fails by default.
- Mutation-probed, with the transcript taken from the shipped code.
- `vp run verify` rc=0 (233 files, 3890 tests).
- `/run-integ local-start-alb-routing-conditions` — pass.
- `/run-integ local-start-api` — pass (the `Server listening on` emitter changed).
- Docker orphans 0 after both.

Closes #599
