### PR TITLE
fix(local): extend the credential-error policy to the remaining SDK relays

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -572,21 +572,68 @@ compute-locally category for Lambda + API Gateway).
   websocket-server, ecs-task-runner, ecs-service-runner, ecs-network,
   cloud-map-registry, lambda-resolver, ecs-task-resolver,
   route-discovery, authorizer-resolver, lambda-authorizer, cognito-jwt,
-  sigv4-verify, credential-error (issues #564 / #570 — how an AWS SDK
-  failure is rendered into a DEFAULT-level log line: `describeAwsFailureForWarn`
-  keeps a modeled service exception's message, since that message is the
+  sigv4-verify, credential-error (issues #564 / #570 / #579 — how an AWS SDK
+  failure is rendered into a line a third party can read at DEFAULT level —
+  a log line, and since #579 a served HTTP response body too:
+  `describeAwsFailureForWarn` keeps a modeled service exception's message,
+  since that message is the
   diagnosis, flattened to one line and length-capped, and withholds every
   other error — credential-chain failures above all, which can carry a
   `credential_process` command line — to a clamped class name plus a
   character count, emitting the full text at `debug`;
   `describeCredentialLoadFailure` is the unconditional-withhold form for a
   `catch` around credential resolution alone, which is what `sigv4-verify`
-  uses. Both are re-exported from `src/internal.ts`. SCOPE: it governs
-  `sigv4-verify` plus the nine STS relays in `src/cli/commands/**`; the
-  remaining AWS SDK error relays elsewhere under `src/local/**` — notably
-  `formatAwsErrorForWarn` in `cfn-local-state-provider` and `formatSsmError`
-  in `ssm-parameter-resolver`, which still print an UNCLAMPED wire-derived
-  `err.name` — are enumerated in issue #579),
+  uses. Both are re-exported from `src/internal.ts`. Which one a site wants
+  is decided per occurrence on TWO axes — LEVEL (is the line default-level,
+  and does it reach somewhere a third party reads, such as the studio log
+  ring?) and RECONSTRUCTION (does the `catch` see only the credential chain,
+  or also a service RESPONSE whose message is the diagnosis?) — never
+  mechanically.
+  SCOPE: issue #570 covered `sigv4-verify` plus nine STS relays in
+  `src/cli/commands/**`; issue #579 extended the policy to the rest of the
+  codebase, so it now also governs `cfn-local-state-provider`
+  (`formatAwsErrorForWarn`, six callers, now a thin decoration over the
+  shared helper that appends a range-guarded HTTP status),
+  `ssm-parameter-resolver` (whose competing `formatSsmError` spelling was
+  DELETED rather than fixed), `state-resolver`, `cloudfront-kvs-client`,
+  `cloudfront-s3-origin`, `layer-arn-materializer`, `ecr-puller`,
+  `ecs-secrets-resolver`, `httpv2-service-integration` and
+  `local-studio`'s deployed-state image-context warn. #579 also closed two
+  NON-error leaks on those same lines: `cfn-local-state-provider` flattens the
+  wire-derived `PhysicalResourceId` it interpolates into three warns, and
+  `ecs-service-runner`'s exited-container log tail is emitted as ONE warn PER
+  LINE (so every line carries the `WARN: ` prefix `studio-serve-manager`'s
+  ready-line matcher skips) instead of one warn holding embedded newlines.
+  Note that `httpv2-service-integration` is the one governed site whose output
+  is an HTTP RESPONSE BODY rather than a log line — the widest reader of the
+  set — which is why the axes are stated in terms of readers, not logs.
+  DELIBERATELY OUTSIDE it, so the next sweep finds a decision rather than an
+  oversight — and note the test is what a `catch` CAN SEE, never where it
+  happens to sit: a `catch` around a purely LOCAL operation sees neither
+  population, which covers `agentcore-s3-bundle`'s unzip `catch` (it wraps
+  `unzipSync` and nothing else) and `layer-arn-materializer`'s presigned-URL
+  download and unzip (the URL carries its own authorization, so no credential
+  chain is resolved and no modeled service exception is parsed — though the
+  download's `HTTP <status> <statusText>` throw does relay a wire-derived
+  reason phrase, so it is FLATTENED even though it needs no withholding).
+  Applying that test by LOCATION instead is exactly how the sweep first got
+  `agentcore-s3-bundle`'s S3 GetObject wrong: it sits OUTSIDE the unzip `try`,
+  which made it uncovered rather than out of scope — it had no `catch` at all,
+  so the raw SDK error reached `formatError`'s
+  `${error.name}: ${error.message}` at default level. It now has one.
+  Genuinely outside, as a separate change: the role ARN has no LENGTH bound,
+  which wants a shape check at the three RESOLUTION points rather than a
+  log-line fix, since that also bounds the value SENT to
+  `AssumeRoleCommand.RoleArn` — tracked in
+  https://github.com/go-to-k/cdk-local/issues/607. Also still uncovered and
+  named here rather than left implicit: `cloudfront-server.ts:129`'s
+  catch-all `Request handling failed:` relay. Two calling
+  conventions the policy imposes, both learned the hard way in #579 — render
+  each failure ONCE (the helper EMITS the `debug` line, so a second call
+  prints it twice), and give cdk-local's OWN throws an identifiable class and
+  re-raise them ABOVE the relay (the policy is defined positively, so it
+  withholds anything that is not a parsed service response — including text
+  cdk-local wrote itself)),
   rie-client, intrinsic-image, runtime-image, target-lister
   (`cdkl list` target enumeration), target-picker (interactive arrow-key
   target selection via `@clack/prompts` when a target is omitted in a TTY),

--- a/src/cli/commands/ecs-service-emulator.ts
+++ b/src/cli/commands/ecs-service-emulator.ts
@@ -8,7 +8,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
-import { describeAwsFailureForWarn } from '../../local/credential-error.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, LocalStartServiceError } from '../../utils/error-handler.js';
 import { resolveMultiTarget } from '../../local/target-picker.js';
@@ -2380,10 +2380,36 @@ async function resolvePlaceholderAccount(
       );
     }
     return arn.split(TASK_ROLE_ACCOUNT_PLACEHOLDER).join(account);
+  } catch (err) {
+    // Issue #579 review round 4 — the sixth and last site of the derived
+    // population, and the exact twin of `local-run-task.ts`'s
+    // `resolvePlaceholderAccount` (both are `try { send } finally { destroy }`
+    // with no `catch`, and neither caller catches). It was deferred one round
+    // because PR #610 held this file; #610 merged, so it lands here rather than
+    // becoming a follow-up issue.
+    //
+    // `--assume-task-role` is not needed to reach it: the placeholder is what
+    // the resolver emits for an inline same-stack IAM role, so a plain
+    // `--from-cfn-stack` run on the default credential chain gets here.
+    if (err instanceof LocalStartServiceError) throw err;
+    const shownArn = flattenToOneLine(arn);
+    const detail = describeAwsFailureForWarn(err, 'STS GetCallerIdentity (task-role placeholder)');
+    throw new LocalStartServiceError(
+      `--assume-task-role: STS GetCallerIdentity failed while resolving placeholder ARN '${shownArn}': ${detail}. ` +
+        `Pass the ARN explicitly: --assume-task-role <arn>`
+    );
   } finally {
     sts.destroy();
   }
 }
+
+/**
+ * Test-only seam (issue #579), mirroring `local-run-task.ts`'s. The function is
+ * module-private and otherwise reachable only through the full emulator boot,
+ * which needs Docker. NOT part of the library surface — not re-exported from
+ * `index.ts` / `internal.ts`.
+ */
+export { resolvePlaceholderAccount as resolvePlaceholderAccountForTest };
 
 async function assumeTaskRole(
   roleArn: string,

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -13,7 +13,7 @@ import {
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
-import { applyRoleArnIfSet } from '../../utils/role-arn.js';
+import { applyRoleArnIfSet, AssumeRoleFailure } from '../../utils/role-arn.js';
 import { getDockerCmd } from '../../utils/docker-cmd.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -888,9 +888,20 @@ export async function resolveHostCredentialsForSigV4(
       // see `describeAwsFailureForWarn` in `src/local/credential-error.ts`.
       // `assumeRoleArn` keeps printing for the reason recorded at the
       // `applyAgentCoreCredentialEnv` site below.
+      // Issue #579: `assumeAgentCoreExecutionRole` renders its own
+      // no-usable-credentials sentence, so re-rendering it here would WITHHOLD
+      // cdk-local's own text (a non-service error is the withheld branch by
+      // design). Inlined rather than factored into a helper: the source fence
+      // in `tests/unit/cli/sts-error-relay-source-fence.test.ts` requires a
+      // visible `describeAwsFailureForWarn` CALL in the window around the
+      // announcing line, and one level of indirection defeats that check.
+      const sigv4Detail =
+        err instanceof AssumeRoleFailure
+          ? err.detail
+          : describeAwsFailureForWarn(err, 'STS AssumeRole (--sigv4 signing)');
       logger.warn(
         `--assume-role: STS AssumeRole(${flattenToOneLine(assumeRoleArn)}) failed for --sigv4 signing: ` +
-          `${describeAwsFailureForWarn(err, 'STS AssumeRole (--sigv4 signing)')}. ` +
+          `${sigv4Detail}. ` +
           `Falling back to ${options.profile ? `--profile ${options.profile}` : 'shell credentials'}.`
       );
     }
@@ -1127,9 +1138,14 @@ export async function resolveAgentCoreCodeImageFromS3(
       // see `describeAwsFailureForWarn` in `src/local/credential-error.ts`.
       // `assumeRoleArn` keeps printing for the reason recorded at the
       // `applyAgentCoreCredentialEnv` site below.
+      // Same inline shape and the same reason as the `--sigv4` site above.
+      const bundleDetail =
+        err instanceof AssumeRoleFailure
+          ? err.detail
+          : describeAwsFailureForWarn(err, 'STS AssumeRole (fromS3 bundle download)');
       logger.warn(
         `--assume-role: STS AssumeRole(${flattenToOneLine(assumeRoleArn)}) failed for the fromS3 bundle download: ` +
-          `${describeAwsFailureForWarn(err, 'STS AssumeRole (fromS3 bundle download)')}. ` +
+          `${bundleDetail}. ` +
           `Falling back to ${options.profile ? `--profile ${options.profile}` : 'the default credentials'}.`
       );
     }
@@ -1453,8 +1469,13 @@ export async function applyAgentCoreCredentialEnv(
       // the ARN from a live `GetAgentRuntime` response, so it is wire-derived
       // text on the line the helper beside it just made forge-proof. On a real
       // ARN the call is a no-op, so the integ grep is unaffected.
+      // Same inline shape and the same reason as the two sites above.
+      const assumeDetail =
+        err instanceof AssumeRoleFailure
+          ? err.detail
+          : describeAwsFailureForWarn(err, 'STS AssumeRole');
       logger.warn(
-        `--assume-role: STS AssumeRole(${flattenToOneLine(args.assumeRoleArn)}) failed: ${describeAwsFailureForWarn(err, 'STS AssumeRole')}. ` +
+        `--assume-role: STS AssumeRole(${flattenToOneLine(args.assumeRoleArn)}) failed: ${assumeDetail}. ` +
           "Falling back to the developer's shell credentials."
       );
     }
@@ -1674,7 +1695,17 @@ async function assumeAgentCoreExecutionRole(
     );
     const creds = response.Credentials;
     if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-      throw new Error(`AssumeRole(${roleArn}) returned no usable credentials.`);
+      // Issue #579 review round 5 — identifiable, for the same reason the
+      // twin in `utils/role-arn.ts` is: all THREE call sites of this helper
+      // re-render what it throws through `describeAwsFailureForWarn`, and a
+      // bare `Error` has no `$fault`, so cdk-local's own sentence was withheld
+      // to `Error; N-character message withheld` at every one of them.
+      // `message` is byte-identical to what it threw before; only the class
+      // and the added `detail` are new.
+      throw new AssumeRoleFailure(
+        `AssumeRole(${flattenToOneLine(roleArn)}) returned no usable credentials.`,
+        'the response carried no usable credentials'
+      );
     }
     return {
       accessKeyId: creds.AccessKeyId,

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -14,7 +14,11 @@ import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/pro
 import { resolveContainerFallbackRegion } from './local-start-api.js';
 import { getLogger } from '../../utils/logger.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
-import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
+import {
+  applyRoleArnIfSet,
+  assumeRoleCredentials,
+  AssumeRoleFailure,
+} from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
 import { resolveSingleTarget } from '../../local/target-picker.js';
@@ -1069,7 +1073,20 @@ export async function resolveLambdaContainerEnv(
       // file's own hijacked-endpoint model it is wire-derived text sitting on
       // the very line the helper beside it just made forge-proof. On a real
       // ARN the call is a no-op, so the integ grep is unaffected.
-      const reason = describeAwsFailureForWarn(err, 'STS AssumeRole');
+      //
+      // Issue #579 review round 4: `assumeRoleCredentials` now renders the
+      // failure ITSELF, because three of its four call paths are unguarded all
+      // the way to `formatError`. Re-rendering its output here would hand
+      // `describeAwsFailureForWarn` a plain `Error` -- cdk-local's own, so no
+      // `$fault` -- and WITHHOLD text the policy had already sanitized, which
+      // is how `ExpiredTokenException: ...` briefly became
+      // `Error; 138-character message withheld`. Take the pre-rendered
+      // `detail` when it is there; the `debug` line was emitted at render
+      // time, so the withheld/at-debug pairing still holds exactly once.
+      const reason =
+        err instanceof AssumeRoleFailure
+          ? err.detail
+          : describeAwsFailureForWarn(err, 'STS AssumeRole');
       logger.warn(
         `--assume-role: STS AssumeRole(${flattenToOneLine(resolvedAssumeRoleArn)}) failed: ${reason}. ` +
           "Falling back to the developer's shell credentials."
@@ -1199,8 +1216,11 @@ export async function resolveAssumeRoleArnForLambda(
       //
       // Deliberately not LENGTH-capped here: unlike a service message, an ARN
       // has a shape, so the bound belongs at the `startsWith('arn:')`
-      // resolution point rather than at the log line. Recorded in issue #579
-      // (which carries the ARN-bound paragraph as well as the relay list).
+      // resolution point rather than at the log line. Tracked in
+      // https://github.com/go-to-k/cdk-local/issues/607 — it used to point at
+      // #579, which carried the ARN-bound paragraph alongside the relay list
+      // and closes with the relay work, so the pointer would have led to a
+      // closed issue.
       logger.info(
         `--assume-role: auto-resolved execution role from GetFunctionConfiguration: ${flattenToOneLine(liveArn)}`
       );

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -8,7 +8,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
-import { describeAwsFailureForWarn } from '../../local/credential-error.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
 import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -503,6 +503,19 @@ async function localRunTaskCommand(
 }
 
 /**
+ * cdk-local's own rejection from {@link resolvePlaceholderAccount}, so the
+ * relay below can tell it apart from a wire-derived SDK failure and re-raise it
+ * intact (issue #579).
+ */
+class PlaceholderAccountError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PlaceholderAccountError';
+    Object.setPrototypeOf(this, PlaceholderAccountError.prototype);
+  }
+}
+
+/**
  * If `arn` contains the `${AWS::AccountId}` placeholder emitted by the
  * resolver for inline same-stack IAM Roles, substitute the live caller
  * account via STS `GetCallerIdentity`. Otherwise pass through unchanged.
@@ -522,16 +535,50 @@ async function resolvePlaceholderAccount(
     const identity = await sts.send(new GetCallerIdentityCommand({}));
     const account = identity.Account;
     if (!account) {
-      throw new Error(
+      throw new PlaceholderAccountError(
         `--assume-task-role: GetCallerIdentity returned no Account; cannot resolve placeholder ARN '${arn}'. ` +
           `Pass the ARN explicitly: --assume-task-role <arn>`
       );
     }
     return arn.split(TASK_ROLE_ACCOUNT_PLACEHOLDER).join(account);
+  } catch (err) {
+    // Issue #579 review round 3 — the third instance of the `try { send }
+    // finally { destroy }` with no `catch`. Its caller does not catch either,
+    // so a `CredentialsProviderError` reached `formatError`'s
+    // `${error.name}: ${error.message}` at DEFAULT level, unflattened and
+    // unclamped. `--assume-task-role` is not required to reach it: the
+    // placeholder is emitted by the resolver for an inline same-stack IAM
+    // role, so a plain `--from-cfn-stack` run on the default credential chain
+    // gets here.
+    //
+    // cdk-local's own no-Account throw is identifiable so it is re-raised
+    // intact — it carries the remedy, and the policy would otherwise withhold
+    // text this file wrote itself.
+    if (err instanceof PlaceholderAccountError) throw err;
+    // Hoisted into a `const` rather than rendered inline, the same shape
+    // `local-invoke.ts`'s `--assume-role` site uses. That is not cosmetic:
+    // `sts-error-relay-source-fence.test.ts` reads a window of two lines before
+    // and one after the line announcing an STS failure, and an inline render
+    // wrapped across three lines put the helper call outside it — the fence
+    // reported this site as unguarded, correctly by its own rule.
+    const shownArn = flattenToOneLine(arn);
+    const detail = describeAwsFailureForWarn(err, 'STS GetCallerIdentity (task-role placeholder)');
+    throw new PlaceholderAccountError(
+      `--assume-task-role: STS GetCallerIdentity failed while resolving placeholder ARN '${shownArn}': ${detail}. ` +
+        `Pass the ARN explicitly: --assume-task-role <arn>`
+    );
   } finally {
     sts.destroy();
   }
 }
+
+/**
+ * Test-only seam (issue #579). `resolvePlaceholderAccount` is module-private
+ * and reached only through `runTask`'s full flow, which needs Docker; the unit
+ * suite drives it directly to fence the STS relay this round added. NOT part of
+ * the library surface — it is not re-exported from `index.ts` / `internal.ts`.
+ */
+export { resolvePlaceholderAccount as resolvePlaceholderAccountForTest };
 
 /**
  * Assume `roleArn` and return temp credentials.

--- a/src/cli/commands/local-studio.ts
+++ b/src/cli/commands/local-studio.ts
@@ -10,6 +10,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
+import { describeAwsFailureForWarn } from '../../local/credential-error.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
@@ -664,11 +665,19 @@ export async function prepareEcsImageContexts(args: {
       );
       contextByStack.set(stack.stackName, ctx);
     } catch (err) {
+      // Issue #579. LEVEL: a DEFAULT-level warn on studio's own stdout, the
+      // stream studio mirrors into the log ring it serves over HTTP.
+      // RECONSTRUCTION: `buildEcsImageResolutionContext` calls
+      // `stateProvider.load()` and `resolveTemplateSsmParameters()`, both AWS
+      // calls on the same credential chain, so a `CredentialsProviderError`
+      // reaches this `catch` alongside a modeled CloudFormation / SSM
+      // exception whose message is the diagnosis.
       logger.warn(
         `studio: could not build deployed-state image context for stack '${stack.stackName}'; ` +
-          `ECS services in it resolve against the synthed template only. ${
-            err instanceof Error ? err.message : String(err)
-          }`
+          `ECS services in it resolve against the synthed template only. ${describeAwsFailureForWarn(
+            err,
+            'deployed-state image context (CloudFormation + SSM)'
+          )}`
       );
       contextByStack.set(stack.stackName, undefined);
     } finally {

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -289,8 +289,8 @@ export {
 export { defaultCredentialsLoader, type CredentialsLoader } from './local/sigv4-verify.js';
 
 /**
- * Rendering an AWS SDK failure into a DEFAULT-level log line (issues #564,
- * #570).
+ * Rendering an AWS SDK failure into a DEFAULT-level line a third party can
+ * read (issues #564, #570, #579).
  *
  * Host-side use case: a host CLI that wraps these command factories prints
  * into the same stream cdk-local does, and a host that mirrors that stream
@@ -307,6 +307,26 @@ export { defaultCredentialsLoader, type CredentialsLoader } from './local/sigv4-
  * - `describeCredentialLoadFailure(err)` for a `catch` around credential
  *   RESOLUTION only, where nothing actionable is lost by withholding all of
  *   it; the caller emits its own `debug` line.
+ *
+ * Which one a site wants is decided on the two axes issue #570 named, and
+ * issue #579 applied to the rest of the codebase — LEVEL (is the line
+ * default-level, and does it reach somewhere a third party reads?) and
+ * RECONSTRUCTION (does the `catch` see only the credential chain, or also a
+ * service RESPONSE whose message is the diagnosis?). #579 also showed the
+ * axes are not log-specific: the widest reader in the sweep was an HTTP
+ * RESPONSE BODY (`httpv2-service-integration.ts`), not a log line at all. A
+ * `catch` around a purely LOCAL operation — an unzip, a file read, a docker
+ * invocation — has neither population and wants neither helper.
+ *
+ * TWO OBLIGATIONS on the caller, both learned from #579 rather than assumed:
+ *
+ * - Call it ONCE per failure. It EMITS the `debug` line carrying the withheld
+ *   text, so rendering the same error twice prints that line twice.
+ * - Re-raise the host's OWN throws before this sees them. The policy is
+ *   defined positively — anything that is not a parsed service response is
+ *   withheld — so a `catch` that also catches the caller's own
+ *   `throw new Error('...')` will withhold text the caller wrote itself. Give
+ *   those an identifiable class and re-raise it above the relay.
  *
  * The primitives underneath (the name clamp, the service-exception test, the
  * message sanitizer) are deliberately NOT exported: a host reusing the policy

--- a/src/local/agentcore-s3-bundle.ts
+++ b/src/local/agentcore-s3-bundle.ts
@@ -5,6 +5,7 @@ import { unzipSync } from 'fflate';
 import { CdkLocalError } from '../utils/error-handler.js';
 import { getLogger } from '../utils/logger.js';
 import { getEmbedConfig } from './embed-config.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
 
 /**
  * Download + extract a `fromS3` AgentCore CodeConfiguration bundle.
@@ -101,9 +102,18 @@ export async function downloadAndExtractS3Bundle(
   };
 }
 
+/**
+ * `s3://<bucket>/<key>[?versionId=...]` for a log or error line.
+ *
+ * FLATTENED (issue #579 review round 3). Under `--from-cfn-stack` the bucket
+ * and key are resolved from template intrinsics against DEPLOYED state — a
+ * `Ref` / `Fn::ImportValue` answered by `ListStackResources` / `ListExports` —
+ * so they are wire-derived on that path, and this string now lands on a
+ * default-level error line as well as the `info` progress line it always fed.
+ */
 function formatRef(location: S3BundleLocation): string {
-  const version = location.versionId ? `?versionId=${location.versionId}` : '';
-  return `s3://${location.bucket}/${location.key}${version}`;
+  const version = location.versionId ? `?versionId=${flattenToOneLine(location.versionId)}` : '';
+  return `s3://${flattenToOneLine(location.bucket)}/${flattenToOneLine(location.key)}${version}`;
 }
 
 /**
@@ -155,6 +165,35 @@ function defaultFetchObject(
         );
       }
       return await res.Body.transformToByteArray();
+    } catch (err) {
+      // Issue #579 review round 2 -- this `catch` did not exist, and its
+      // absence is why the site was first mis-triaged as out of scope. The
+      // module's OTHER `catch` wraps `unzipSync` only, which is a purely LOCAL
+      // operation and genuinely outside the credential-error policy. But
+      // "outside that catch" was read as "outside the sweep", when it meant the
+      // S3 read had NO catch at all: the raw SDK error propagated through
+      // `resolveAgentCoreCodeImageFromS3` to `withErrorHandling` ->
+      // `formatError`, which renders `${error.name}: ${error.message}`
+      // UNFLATTENED and UNCLAMPED at DEFAULT level.
+      //
+      // LEVEL: a top-level CLI error line -- printed on a plain
+      // `cdkl invoke-agentcore` run, no `--verbose` needed.
+      // RECONSTRUCTION: `client.send(...)` resolves the credential chain before
+      // the request goes out, and without `--assume-role` that is the DEFAULT
+      // chain, so a `CredentialsProviderError` carrying a `credential_process`
+      // command line reaches it -- alongside a modeled S3 exception
+      // (`NoSuchKey`, `AccessDenied`) whose message is the diagnosis.
+      //
+      // cdk-local's own empty-body throw above is re-raised INTACT: its text is
+      // this module's literal, not anything off the wire.
+      if (err instanceof CdkLocalError) throw err;
+      throw new CdkLocalError(
+        `S3 GetObject for ${formatRef(location)} failed: ${describeAwsFailureForWarn(
+          err,
+          'S3 GetObject (fromS3 bundle)'
+        )}`,
+        'LOCAL_INVOKE_AGENTCORE_S3_BUNDLE_FETCH_FAILED'
+      );
     } finally {
       client.destroy();
     }

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -75,7 +75,7 @@ import {
 } from '@aws-sdk/client-bedrock-agentcore-control';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { getLogger } from '../utils/logger.js';
-import { flattenToOneLine } from './credential-error.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
 import { collectSsmParameterRefs, resolveSsmParameters } from './ssm-parameter-resolver.js';
 import type { ResolvedSsmParameters } from './ssm-parameter-resolver.js';
 import type { CloudFormationTemplate } from '../types/resource.js';
@@ -283,7 +283,7 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       return resp.Environment?.Variables ?? {};
     } catch (err) {
       logger.warn(
-        `${this.label}: GetFunctionConfiguration(${functionPhysicalId}) failed: ${formatAwsErrorForWarn(err)}. ` +
+        `${this.label}: GetFunctionConfiguration(${flattenToOneLine(functionPhysicalId)}) failed: ${formatAwsErrorForWarn(err, 'Lambda GetFunctionConfiguration')}. ` +
           `Intrinsic-valued env vars that need the deployed value will warn-and-drop (grant lambda:GetFunctionConfiguration or override via --env-vars).`
       );
       return undefined;
@@ -318,7 +318,7 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       return undefined;
     } catch (err) {
       logger.warn(
-        `${this.label}: GetFunctionConfiguration(${functionPhysicalId}) for --assume-role auto-resolve failed: ${formatAwsErrorForWarn(err)}. ` +
+        `${this.label}: GetFunctionConfiguration(${flattenToOneLine(functionPhysicalId)}) for --assume-role auto-resolve failed: ${formatAwsErrorForWarn(err, 'Lambda GetFunctionConfiguration (--assume-role auto-resolve)')}. ` +
           `Pass the ARN explicitly: --assume-role <arn>.`
       );
       return undefined;
@@ -353,7 +353,7 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       return undefined;
     } catch (err) {
       logger.warn(
-        `${this.label}: GetAgentRuntime(${runtimePhysicalId}) for --assume-role auto-resolve failed: ${formatAwsErrorForWarn(err)}. ` +
+        `${this.label}: GetAgentRuntime(${flattenToOneLine(runtimePhysicalId)}) for --assume-role auto-resolve failed: ${formatAwsErrorForWarn(err, 'bedrock-agentcore-control GetAgentRuntime (--assume-role auto-resolve)')}. ` +
           `Pass the ARN explicitly: --assume-role <arn>.`
       );
       return undefined;
@@ -394,11 +394,13 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       // downstream can surface it verbatim in their error. The recorded
       // text excludes the `--from-cfn-stack:` label prefix; the
       // resolver wraps it in its own framing.
-      this.lastLoadError =
-        `ListStackResources(${this.cfnStackName}) failed: ${formatAwsErrorForWarn(err)} ` +
-        `(region='${this.region}')`;
+      // Rendered ONCE and reused. Issue #579 -- `formatAwsErrorForWarn` now
+      // EMITS the `debug` line carrying the withheld text, so calling it twice
+      // for one failure prints that line twice.
+      const detail = formatAwsErrorForWarn(err, 'CloudFormation ListStackResources');
+      this.lastLoadError = `ListStackResources(${this.cfnStackName}) failed: ${detail} (region='${this.region}')`;
       logger.warn(
-        `${this.label}: ListStackResources(${this.cfnStackName}) failed: ${formatAwsErrorForWarn(err)}. ` +
+        `${this.label}: ListStackResources(${this.cfnStackName}) failed: ${detail}. ` +
           `Was the stack deployed in region '${this.region}'? Falling back.`
       );
       return undefined;
@@ -418,7 +420,7 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       }
     } catch (err) {
       logger.warn(
-        `${this.label}: DescribeStacks(${this.cfnStackName}) failed: ${formatAwsErrorForWarn(err)}. ` +
+        `${this.label}: DescribeStacks(${this.cfnStackName}) failed: ${formatAwsErrorForWarn(err, 'CloudFormation DescribeStacks')}. ` +
           `Outputs will be empty (Fn::GetStackOutput cannot resolve).`
       );
       outputs = {};
@@ -493,7 +495,7 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       if (exportsPromise) return exportsPromise;
       exportsPromise = fetchAllExports(client).catch((err: unknown) => {
         logger.warn(
-          `${label}: ListExports (${region}) failed: ${formatAwsErrorForWarn(err)}. ` +
+          `${label}: ListExports (${region}) failed: ${formatAwsErrorForWarn(err, 'CloudFormation ListExports')}. ` +
             `Fn::ImportValue intrinsics will warn-and-drop.`
         );
         return undefined;
@@ -577,6 +579,16 @@ export function buildResourceStateMap(
     if (!r.LogicalResourceId || !r.PhysicalResourceId || !r.ResourceType) {
       continue;
     }
+    // Issue #579 — `PhysicalResourceId` is copied through with no validation,
+    // and it is WIRE-DERIVED: `ListStackResources` returns whatever the
+    // endpoint says. A physical id that reaches a `logger.warn` template is
+    // therefore the same forging surface as an error message, and one that
+    // fires on a path where the endpoint ALSO controls whether the follow-up
+    // call fails. The flatten is applied at each of those templates
+    // (`GetFunctionConfiguration` / `GetAgentRuntime`) rather than here,
+    // because the id's OTHER consumers (the substitution engine, an
+    // `AssumeRoleCommand.RoleArn`) want the value the endpoint actually sent,
+    // not a space-substituted one.
     out[r.LogicalResourceId] = {
       physicalId: r.PhysicalResourceId,
       resourceType: r.ResourceType,
@@ -717,22 +729,37 @@ export async function fetchAllExports(client: CloudFormationClient): Promise<Map
  * with bucket / region context), so the CFn provider extracts the
  * pieces directly here.
  *
- * Issue #578 — the result is FLATTENED TO ONE LINE via
- * {@link flattenToOneLine}, the same helper `credential-error` applies to
- * every other wire-derived value that lands on a log line, rather than a
- * second spelling of it. Both `err.name` and `err.message` come off the wire,
- * and this warn is relayed onto a `cdkl studio` serve child's stdout, where
- * `studio-serve-manager` splits on `\n`: an embedded newline puts line 2 on
- * the stream with no `WARN: ` prefix, so it clears the diagnostic bound and
- * matches a ready pattern at `^`. One line in, one line out.
+ * Issue #578 flattened the result to ONE LINE, because this warn is relayed
+ * onto a `cdkl studio` serve child's stdout where `studio-serve-manager`
+ * splits on `\n`: an embedded newline puts line 2 on the stream with no
+ * `WARN: ` prefix, so it clears the diagnostic bound and matches a ready
+ * pattern at `^`.
+ *
+ * Issue #579 finished the job. Flattening closed the forged-LINE half while
+ * leaving the OTHER two open: the wire-derived `err.name` was interpolated
+ * UNCLAMPED (`@aws-sdk/core` builds it from `x-amzn-errortype` with no length
+ * cap and no character class), and `err.message` printed verbatim whatever
+ * population it came from. LEVEL: every caller below is a DEFAULT-level warn.
+ * RECONSTRUCTION: each `catch` wraps a `client.send(...)` — CloudFormation,
+ * Lambda, or bedrock-agentcore-control — which resolves the credential chain
+ * before the request goes out, so the `catch` sees both a
+ * `CredentialsProviderError` (whose message can be a `credential_process`
+ * command line) and a modeled service exception whose message IS the
+ * diagnosis. That is exactly {@link describeAwsFailureForWarn}'s split, so
+ * this is now a thin decoration over it rather than a second spelling of the
+ * policy: `operation` names the call for the `debug` line the helper emits on
+ * the withheld branch.
+ *
+ * The HTTP status is KEPT and moved to a suffix. Unlike the name it is not
+ * body-derived — the SDK reads it off the HTTP response line — but it is
+ * still range-guarded to an integer status, since `$metadata` is a plain
+ * object a hostile shape could carry anything on.
  */
-export function formatAwsErrorForWarn(err: unknown): string {
-  if (!(err instanceof Error)) return flattenToOneLine(String(err));
-  const name = err.name && err.name !== 'Error' ? err.name : undefined;
-  const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
-  const prefixParts: string[] = [];
-  if (name !== undefined) prefixParts.push(name);
-  if (status !== undefined) prefixParts.push(`HTTP ${status}`);
-  if (prefixParts.length === 0) return flattenToOneLine(err.message);
-  return flattenToOneLine(`${prefixParts.join(' ')}: ${err.message}`);
+export function formatAwsErrorForWarn(err: unknown, operation: string): string {
+  const described = describeAwsFailureForWarn(err, operation);
+  const status = (err as { $metadata?: { httpStatusCode?: unknown } } | undefined)?.$metadata
+    ?.httpStatusCode;
+  return typeof status === 'number' && Number.isInteger(status) && status >= 100 && status < 600
+    ? `${described} (HTTP ${status})`
+    : described;
 }

--- a/src/local/cloudfront-kvs-client.ts
+++ b/src/local/cloudfront-kvs-client.ts
@@ -11,6 +11,11 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-cloudfront-keyvaluestore';
 import { getLogger } from '../utils/logger.js';
+import {
+  describeAwsFailureForWarn,
+  flattenToOneLine,
+  stringifyThrown,
+} from './credential-error.js';
 import type { KvsDataSource } from './cloudfront-kvs.js';
 
 /**
@@ -76,10 +81,24 @@ export function createDeployedKvsDataSource(
         return out.Value;
       } catch (err) {
         if (isKeyNotFound(err)) return undefined;
+        // Issue #579. LEVEL: this throw propagates out of the function sandbox
+        // to `cloudfront-server.ts`'s top-level handler, which relays its
+        // `message` into a DEFAULT-level `Request handling failed:` warn (and
+        // answers a fixed 500) -- so it IS a default-level line, one level up.
+        // RECONSTRUCTION: the `catch` wraps `client.send(GetKeyCommand)`, which
+        // resolves the credential chain before the request, so it sees both a
+        // `CredentialsProviderError` and a modeled
+        // `cloudfront-keyvaluestore` exception whose message is the diagnosis.
         throw new Error(
-          `cf.kvs().get('${key}') against ${options.kvsArn} failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`
+          // `kvsArn` is WIRE-DERIVED: `resolveDeployedKvsArnByName` copies
+          // `item.ARN` out of a `ListKeyValueStores` response with no
+          // validation, and this throw is relayed into a DEFAULT-level warn by
+          // `cloudfront-server.ts`. Same class as the `PhysicalResourceId`
+          // flatten (issue #579 review round 3).
+          `cf.kvs().get('${key}') against ${flattenToOneLine(options.kvsArn)} failed: ${describeAwsFailureForWarn(
+            err,
+            'CloudFront KeyValueStore GetKey'
+          )}`
         );
       }
     },
@@ -114,8 +133,15 @@ export async function resolveDeployedKvsArnByName(
       }
     }
   } catch (err) {
+    // Issue #579. LEVEL: `debug`, so only a reader who asked with `--verbose`
+    // sees it -- the message is KEPT rather than withheld, exactly as
+    // `sigv4-verify` keeps its own text at `debug`. It is still FLATTENED,
+    // because the `debug` stream is the same stdout `cdkl studio` mirrors into
+    // an HTTP-served ring, so a `\n` would forge a line there as surely as at
+    // `warn`. RECONSTRUCTION does not arise: nothing is withheld, so there is
+    // no population to split.
     getLogger().debug(
-      `ListKeyValueStores lookup for '${name}' failed: ${err instanceof Error ? err.message : String(err)}`
+      `ListKeyValueStores lookup for '${name}' failed: ${flattenToOneLine(stringifyThrown(err))}`
     );
   }
   return undefined;

--- a/src/local/cloudfront-s3-origin.ts
+++ b/src/local/cloudfront-s3-origin.ts
@@ -1,5 +1,6 @@
 import { getEmbedConfig } from './embed-config.js';
 import { getLogger } from '../utils/logger.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
 import {
   contentTypeForKey,
   resolveErrorResponseCandidates,
@@ -133,7 +134,15 @@ export function createS3OriginReader(
       if (direct.kind === 'denied' && !deniedWarned) {
         deniedWarned = true;
         getLogger().warn(
-          `S3 denied reading '${key}' from bucket '${bucketName}'. If this is an OAC-locked / private ` +
+          // Issue #579 review round 2 -- `key` is REQUEST-derived and is the
+          // most reachable forged-line vector in the whole sweep: `uriToKey`
+          // runs `decodeURIComponentSafe` over the request URI, so
+          // `GET /%0AWARN:%20anything` yields a key holding a REAL newline. No
+          // credentials, no hostile AWS endpoint, no `--verbose` -- any HTTP
+          // client that can reach the served port. Strictly more reachable than
+          // the `functionPhysicalId` flatten, which needs a hijacked
+          // CloudFormation endpoint.
+          `S3 denied reading '${flattenToOneLine(key)}' from bucket '${flattenToOneLine(bucketName)}'. If this is an OAC-locked / private ` +
             `bucket your credentials cannot read, point the origin at a local directory with ` +
             `--origin <originId>=<dir> (or use credentials with s3:GetObject on the bucket). ` +
             `${getEmbedConfig().cliName} start-cloudfront reads the origin from real S3.`
@@ -141,7 +150,8 @@ export function createS3OriginReader(
       }
       if (direct.kind === 'error') {
         getLogger().warn(
-          `S3 read of '${key}' from bucket '${bucketName}' failed: ${direct.message}`
+          // Request-derived `key`, flattened for the reason given above.
+          `S3 read of '${flattenToOneLine(key)}' from bucket '${flattenToOneLine(bucketName)}' failed: ${direct.message}`
         );
       }
     }
@@ -162,7 +172,11 @@ export function createS3OriginReader(
       // not silently swallowed on the way to the terminal 404.
       if (page.kind === 'denied' || page.kind === 'error') {
         getLogger().warn(
-          `S3 could not read custom-error page '${candidate.errorKey}' from bucket '${bucketName}' ` +
+          // `candidate.errorKey` comes from the distribution's
+          // `CustomErrorResponses[].ResponsePagePath`, i.e. the template --
+          // less reachable than `key`, but it lands on the same DEFAULT-level
+          // line and the flatten costs one call.
+          `S3 could not read custom-error page '${flattenToOneLine(candidate.errorKey)}' from bucket '${flattenToOneLine(bucketName)}' ` +
             `(${page.kind}); falling through.`
         );
       }
@@ -253,6 +267,18 @@ function defaultFetchObject(
  * Classify an S3 SDK error: a missing key (`NoSuchKey` / 404) is `not-found`
  * (try the SPA fallback), an `AccessDenied` / 403 is `denied` (a credential /
  * OAC config problem), anything else is `error`.
+ *
+ * Issue #579 — the `error` branch's `message` is the only one that reaches a
+ * log line (the reader prints it in a DEFAULT-level `S3 read of ... failed:`
+ * warn), so it is rendered by {@link describeAwsFailureForWarn}. LEVEL: a
+ * default-level warn, mirrored into the studio log ring. RECONSTRUCTION: the
+ * `catch` this classifies for wraps `client.send(GetObjectCommand)`, which
+ * resolves the credential chain before the request goes out — a
+ * `CredentialsProviderError` here is COMMON, since the whole point of this
+ * origin is reading a deployed bucket with the developer's own credentials —
+ * alongside a modeled S3 exception whose message is the diagnosis. The
+ * `not-found` / `denied` branches carry no message at all and are untouched:
+ * their names are structural discriminators, not text that gets printed.
  */
 export function classifyS3Error(err: unknown): S3FetchResult {
   const e = err as { name?: string; $metadata?: { httpStatusCode?: number } } | undefined;
@@ -260,5 +286,5 @@ export function classifyS3Error(err: unknown): S3FetchResult {
   const name = e?.name;
   if (status === 404 || name === 'NoSuchKey' || name === 'NotFound') return { kind: 'not-found' };
   if (status === 403 || name === 'AccessDenied' || name === 'Forbidden') return { kind: 'denied' };
-  return { kind: 'error', message: err instanceof Error ? err.message : String(err) };
+  return { kind: 'error', message: describeAwsFailureForWarn(err, 'S3 GetObject') };
 }

--- a/src/local/credential-error.ts
+++ b/src/local/credential-error.ts
@@ -13,15 +13,84 @@
  * SCOPE, stated so a later sweep finds a decision rather than an oversight:
  * this module governs those nine plus sigv4-verify's one, and its
  * {@link flattenToOneLine} additionally covers every other wire-derived value
- * printed on those lines (the role ARN, on the failure AND success paths). It
- * does NOT yet govern the AWS SDK error relays elsewhere under
- * `src/local/**` — notably
- * `formatAwsErrorForWarn` (`cfn-local-state-provider.ts`, six warn sites and
- * one non-warn caller)
- * and `formatSsmError` (`ssm-parameter-resolver.ts`), which still print an
- * UNCLAMPED wire-derived `err.name`. Those are enumerated and tracked in
- * issue #579; they were left out here so a cross-cutting refactor of eight
- * more files would not share a review with the policy that justifies it.
+ * printed on those lines (the role ARN, on the failure AND success paths).
+ *
+ * Issue #579 extended it to the AWS SDK error relays elsewhere under
+ * `src/local/**` (plus `local-studio.ts`'s image-context warn), so the policy
+ * is no longer scoped to `src/cli/commands/**`:
+ * `cfn-local-state-provider.ts` (`formatAwsErrorForWarn`, six callers),
+ * `ssm-parameter-resolver.ts` (whose `formatSsmError` was DELETED rather than
+ * fixed — it was a second spelling of the same forging vector),
+ * `state-resolver.ts`, `cloudfront-kvs-client.ts`, `cloudfront-s3-origin.ts`,
+ * `layer-arn-materializer.ts`, `ecr-puller.ts`, `ecs-secrets-resolver.ts` and
+ * `httpv2-service-integration.ts`. Each was decided on the SAME two axes below
+ * rather than rewritten mechanically, and a `catch` around a purely LOCAL
+ * operation was left alone: `agentcore-s3-bundle.ts`'s unzip and
+ * `layer-arn-materializer.ts`'s presigned-URL download / unzip see no
+ * credential chain and no service response, so there is nothing here for them.
+ *
+ * The test is what a `catch` CAN SEE, and applying it by LOCATION instead is
+ * how the sweep first got `agentcore-s3-bundle.ts` wrong. Its `try` does wrap
+ * `unzipSync` and nothing else — but that made the S3 `GetObject` above it
+ * UNCOVERED, not out of scope: it had no `catch` at all, so the raw SDK error
+ * propagated to `withErrorHandling` -> `formatError`, which prints
+ * `${error.name}: ${error.message}` unflattened and unclamped at DEFAULT
+ * level, and the default credential chain is what a run without
+ * `--assume-role` uses. "Outside that `catch`" is not "outside the sweep";
+ * ask which populations reach the site, and if the answer is "nothing catches
+ * it here", follow it to the frame that does.
+ *
+ * #579 also widened what LEVEL means, and the widening is the useful part:
+ * `httpv2-service-integration.ts`'s relay is not a log line at all, it is a
+ * served HTTP RESPONSE BODY — the widest reader in the sweep, since it needs
+ * neither `--verbose` nor access to the terminal, and the studio capture proxy
+ * records it onto the timeline besides. The axis is about READERS, not about
+ * logs.
+ *
+ * TWO CALLING CONVENTIONS this imposes, both found by #579 rather than
+ * anticipated here:
+ *
+ *   1. Render each failure ONCE. {@link describeAwsFailureForWarn} EMITS the
+ *      `debug` line, so calling it twice for one error prints that line twice
+ *      (`cfn-local-state-provider.ts`'s `load` did, having rendered the same
+ *      failure for its warn and for `lastLoadError`).
+ *   2. Re-raise cdk-local's OWN throws ABOVE the relay, with an identifiable
+ *      class. The discriminator is positive, so a `catch` that also catches
+ *      the caller's own `throw new Error('...')` withholds text cdk-local
+ *      wrote itself — which is the diagnostic loss this file's
+ *      {@link describeCredentialLoadFailure} note calls "a real diagnostic
+ *      loss, accepted". #579 stopped accepting it where it was cheap not to:
+ *      `layer-arn-materializer.ts`'s ARN-shape and missing-`Content.Location`
+ *      guards became `LayerMaterializationError`s and are re-raised, and
+ *      `httpv2-service-integration.ts`'s missing-RequestParameter 400 became a
+ *      `ServiceIntegrationRequestError` so an actionable 400 body did not
+ *      degrade into a class name and a character count.
+ *
+ * TWO CATCH-ALL relays remain outside it, and both are UNCOVERED. An earlier
+ * revision of this note gave them opposite verdicts in adjacent paragraphs —
+ * clearing one and rejecting the other on the same evidence — which was simply
+ * wrong about the first, so both now read the same way:
+ *
+ *   - `cloudfront-server.ts:129`'s `Request handling failed: ${err.message}`.
+ *     It is what makes `cloudfront-kvs-client.ts`'s throw a DEFAULT-level
+ *     line, and for THAT sub-path the text arrives pre-sanitized — but it is a
+ *     catch-all over the whole request pipeline, so an origin fetch, an
+ *     edge-function invoke or an SDK error raised anywhere below it still
+ *     reaches the line RAW.
+ *   - `ecs-service-emulator.ts`'s `logger.error` at three sites (`:909`,
+ *     `:1508`, `:1599`). One of them does carry
+ *     `ecs-secrets-resolver.ts`'s `EcsSecretsResolutionError`, which this
+ *     module sanitized on the way in — and reasoning from that to "the relay
+ *     is safe" is the SAME generalisation the bullet above rejects. All three
+ *     are catch-alls over a whole reload or replica roll, relaying
+ *     `err instanceof Error ? err.message : String(err)`, and what they
+ *     usually carry is docker CLI stderr, which is multi-line.
+ *
+ * So: one sub-path arriving pre-sanitized never clears a catch-all. Both need
+ * the same per-occurrence call as everything else in this list. Neither is
+ * done here — `cloudfront-server.ts` is out of this change's scope, and the
+ * emulator's three are a different population (docker output, not SDK errors)
+ * that wants the flattening half rather than the withholding half.
  *
  * # The two axes that decide it
  *
@@ -345,13 +414,27 @@ export function sanitizeServiceExceptionMessage(message: string): string {
  * echo, plus the clamped {@link clampErrorCode} when the throw carries one.
  *
  * Withholding is NOT free, and the cost lands on cdk-local's own text as well
- * as on the SDK's: `role-arn.ts`'s
- * `AssumeRole(<arn>) returned no usable credentials.` is a plain `Error` with
- * no `$fault`, so it is withheld like any other. That is a real diagnostic
- * loss, accepted because the alternative — an allow-list of messages that may
- * print — is the deny-list this design rejects, wearing the other sign. The
- * fix is to make cdk-local's own throws identifiable rather than to guess at
- * their text; it is not done here, and is noted in issue #579.
+ * as on the SDK's. The worked example used to be `role-arn.ts`'s
+ * `AssumeRole(<arn>) returned no usable credentials.`: a plain `Error` with no
+ * `$fault`, so it was withheld like any other, and the note recorded that as a
+ * real diagnostic loss accepted because the alternative — an allow-list of
+ * messages that may print — is the deny-list this design rejects, wearing the
+ * other sign. It also named the right fix: make cdk-local's own throws
+ * IDENTIFIABLE rather than guess at their text.
+ *
+ * Issue #579 did that, for exactly this example. `role-arn.ts` now throws
+ * `AssumeRoleFailure`, carrying a `detail` its relaying callers print verbatim
+ * — and the same pattern closed the identical loss in
+ * `layer-arn-materializer.ts`, `httpv2-service-integration.ts`,
+ * `ecr-puller.ts`, `local-run-task.ts` and `ecs-service-emulator.ts`. The
+ * general point stands and is what a new site should apply: the policy cannot
+ * tell cdk-local's own sentence from a hostile endpoint's, so a `catch` that
+ * can see both must make its own throws recognisable BEFORE the relay.
+ *
+ * The remaining ARN-length question — an ARN is structured, so the bound
+ * belongs at the three resolution points rather than at the log line — is
+ * tracked separately at
+ * https://github.com/go-to-k/cdk-local/issues/607.
  *
  * The LENGTH is reported, unlike in `ecs-secrets-resolver.ts`, and the
  * difference is deliberate: there the user already knows which secret it is

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -9,6 +9,7 @@ import { LocalInvokeBuildError } from '../utils/error-handler.js';
 import { getLogger } from '../utils/logger.js';
 import { buildStsClientConfig } from '../utils/profile-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
 
 /**
  * ECR pull fallback for `cdkl invoke` / `cdkl start-api` /
@@ -215,6 +216,26 @@ export async function pullEcrImage(imageUri: string, options: EcrPullOptions): P
       }
       callerAccount = identity.Account;
       CALLER_IDENTITY_CACHE.set(callerIdentityKey, callerAccount);
+    } catch (err) {
+      // Issue #579 review round 3 — the `try { send } finally { destroy }` with
+      // NO `catch`, the same shape whose mis-triage is documented at length in
+      // `agentcore-s3-bundle.ts`. `pullEcrImage` has six callers and none of
+      // them catches, so the raw SDK error reached `withErrorHandling` ->
+      // `formatError`, which prints `${error.name}: ${error.message}`
+      // unflattened and unclamped at DEFAULT level.
+      //
+      // This is the SAME `GetCallerIdentity` call issue #570 guarded at five
+      // sites under `src/cli/commands/**`, and it fires on the plain default
+      // credential chain — no `--assume-role` and no `--ecr-role-arn` needed,
+      // so it is the most reachable of the three sites this round adds.
+      // cdk-local's own no-Account throw is re-raised intact.
+      if (err instanceof LocalInvokeBuildError) throw err;
+      throw new LocalInvokeBuildError(
+        `STS GetCallerIdentity failed while preparing the ECR pull: ${describeAwsFailureForWarn(
+          err,
+          'STS GetCallerIdentity (ECR pull)'
+        )}. Verify your AWS credentials.`
+      );
     } finally {
       sts.destroy();
     }
@@ -327,9 +348,21 @@ async function assumeRoleForEcr(
     };
   } catch (err) {
     if (err instanceof LocalInvokeBuildError) throw err;
-    const reason = err instanceof Error ? err.message : String(err);
+    // Issue #579. LEVEL: thrown, so the top-level error handler prints it at
+    // default level. RECONSTRUCTION: the `catch` wraps
+    // `sts.send(AssumeRoleCommand)`, so it sees the credential chain (a
+    // `credential_process` command line is reachable here) as well as a modeled
+    // STS exception whose message is the diagnosis. cdk-local's own
+    // "returned no usable credentials" throw is re-raised on the line above, so
+    // withholding never eats it.
+    const reason = describeAwsFailureForWarn(err, 'STS AssumeRole (ECR pull)');
     throw new LocalInvokeBuildError(
-      `Failed to assume role ${roleArn} for ECR pull: ${reason}. ` +
+      // `roleArn` flattened for parity with the four #570 sites and
+      // `local-invoke-agentcore.ts`: it is usually the user's own
+      // `--ecr-role-arn` value, but the bare `--assume-role` form resolves an
+      // ARN from a live `GetFunctionConfiguration` / `GetAgentRuntime`
+      // response behind only a `startsWith('arn:')` check.
+      `Failed to assume role ${flattenToOneLine(roleArn)} for ECR pull: ${reason}. ` +
         "Verify the role exists and its trust policy permits the caller's identity to assume it."
     );
   } finally {
@@ -346,7 +379,22 @@ async function ecrLogin(client: ECRClient, accountId: string, region: string): P
   const logger = getLogger().child('ecr-puller');
   logger.debug(`ECR login (account=${accountId}, region=${region})`);
 
-  const response = await client.send(new GetAuthorizationTokenCommand({}));
+  // Issue #579 review round 3 — same shape one level down: this `send` sat in
+  // NO `try` at all, and its only caller wraps it in
+  // `try { ecrLogin(...) } finally { ecr.destroy() }`, so nothing between here
+  // and `formatError` could see it. `GetAuthorizationToken` runs on the
+  // assumed-role credentials when `--ecr-role-arn` is set and on the default
+  // chain otherwise, so both populations reach it.
+  const response = await client
+    .send(new GetAuthorizationTokenCommand({}))
+    .catch((err: unknown): never => {
+      throw new LocalInvokeBuildError(
+        `ECR GetAuthorizationToken failed (account=${accountId}, region=${region}): ${describeAwsFailureForWarn(
+          err,
+          'ECR GetAuthorizationToken'
+        )}. Verify the credentials can call ecr:GetAuthorizationToken.`
+      );
+    });
   const authData = response.authorizationData?.[0];
   if (!authData?.authorizationToken) {
     throw new LocalInvokeBuildError('Failed to get ECR authorization token');

--- a/src/local/ecs-secrets-resolver.ts
+++ b/src/local/ecs-secrets-resolver.ts
@@ -1,6 +1,7 @@
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { getLogger } from '../utils/logger.js';
+import { describeAwsFailureForWarn } from './credential-error.js';
 
 /**
  * Resolve `ContainerDefinitions[].Secrets[].ValueFrom` references to real
@@ -194,10 +195,21 @@ async function resolveSecretsManager(
     // throttling), which is exactly what makes a credential or IAM problem
     // diagnosable. It is the one throw in this function the sibling-branch
     // test block deliberately does not cover, and this is why.
+    //
+    // Issue #579 narrowed WHICH SDK errors that covers, without reversing the
+    // decision. LEVEL: this text reaches `ecs-service-emulator.ts`'s
+    // `logger.error` -- default level, and mirrored into the studio log ring.
+    // RECONSTRUCTION: `client.send(...)` resolves the credential chain before
+    // the request, so a `CredentialsProviderError` carrying a
+    // `credential_process` command line lands in the SAME `catch` as the
+    // modeled Secrets Manager exception this comment is about. The service
+    // exception's message still prints in full -- that is the half #554 kept;
+    // the chain failure is the half it never considered.
     throw new EcsSecretsResolutionError(
-      `Failed to resolve Secrets Manager secret for container '${entry.containerName}' / env '${entry.name}' (${shape.baseArn}): ${
-        err instanceof Error ? err.message : String(err)
-      }`
+      `Failed to resolve Secrets Manager secret for container '${entry.containerName}' / env '${entry.name}' (${shape.baseArn}): ${describeAwsFailureForWarn(
+        err,
+        'SecretsManager GetSecretValue'
+      )}`
     );
   }
   if (secretString === undefined) {
@@ -272,10 +284,14 @@ async function resolveSsm(entry: SecretEntry, shape: SsmShape, client: SSMClient
     return value;
   } catch (err) {
     if (err instanceof EcsSecretsResolutionError) throw err;
+    // Issue #579 -- the SSM twin of the Secrets Manager site above, decided on
+    // the same two axes. cdk-local's own "returned no Value" throw is re-raised
+    // on the line above, so withholding never eats it.
     throw new EcsSecretsResolutionError(
-      `Failed to resolve SSM parameter for container '${entry.containerName}' / env '${entry.name}' (${shape.name}): ${
-        err instanceof Error ? err.message : String(err)
-      }`
+      `Failed to resolve SSM parameter for container '${entry.containerName}' / env '${entry.name}' (${shape.name}): ${describeAwsFailureForWarn(
+        err,
+        'SSM GetParameter (ECS secret)'
+      )}`
     );
   }
 }

--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -14,6 +14,7 @@ import type { FrontDoorEndpointPool } from './front-door-pool.js';
 import { getContainerNetworkIp, getPublishedHostPort } from './docker-inspect.js';
 import { SHARED_SVC_SUBNET_OCTET, type TaskNetwork } from './ecs-network.js';
 import { getEmbedConfig } from './embed-config.js';
+import { flattenToOneLine } from './credential-error.js';
 import { attachContainerLogStreamer } from './container-log-streamer.js';
 
 /**
@@ -2332,6 +2333,22 @@ const defaultReadContainerLogsImpl = async (containerId: string): Promise<string
  * `read` is injectable so the unit test can assert the formatting without
  * a real container; production callers use the default `docker logs`
  * reader.
+ *
+ * Issue #579 — ONE `logger.warn` PER TAIL LINE, not one warn carrying an
+ * embedded `\n`. LEVEL: a default-level warn, and under `cdkl studio` the
+ * serve child's stdout is mirrored into a log ring served over HTTP. The
+ * studio serve manager reads that stdout with `streamLines`, which splits on
+ * `\n`, and it declines to pattern-match a line carrying cdk-local's own
+ * `WARN: ` prefix (issue #578). A multi-line warn defeats that bound from the
+ * inside: the logger prefixes the MESSAGE, so line 2 onward arrives
+ * prefix-less and is matched at `^` — and the content is the CONTAINER's own
+ * stdout, i.e. whatever the application printed. An app that logs
+ * `Server listening on http://10.0.0.9:3000` (which is exactly what a web
+ * framework prints, and this tail fires when such an app has just crashed)
+ * would re-point the capture proxy. RECONSTRUCTION does not arise: this is
+ * container output, not an AWS SDK failure, so nothing is withheld — the whole
+ * tail still prints, one prefixed line at a time. Each line is additionally
+ * flattened, so a `\r` or U+2028 inside one cannot re-split it downstream.
  */
 export async function printExitedContainerLogs(
   replicaIndex: number,
@@ -2350,9 +2367,24 @@ export async function printExitedContainerLogs(
   }
   const tail = raw.trimEnd();
   if (tail.length === 0) return;
+  // "last N lines", which is what it always said. Review round 2 changed this
+  // to "up to N each from stdout and stderr" on the theory that `--tail` binds
+  // per stream; round 3 checked `defaultReadContainerLogsImpl` and it does not.
+  // There is ONE `docker logs --tail <N>` invocation, `--tail` bounds the
+  // combined log, and the stdout/stderr split is just how the child process's
+  // two pipes are captured afterwards. The original wording was correct and is
+  // restored.
   logger.warn(
-    `Replica ${replicaIndex} essential container logs (last ${EXIT_LOG_TAIL_LINES} lines):\n${tail}`
+    `Replica ${replicaIndex} essential container logs (last ${EXIT_LOG_TAIL_LINES} lines):`
   );
+  for (const line of tail.split(/\r?\n/)) {
+    const flat = flattenToOneLine(line).trimEnd();
+    // A blank line inside the tail carries no diagnostic content, and emitting
+    // one would print a bare `Replica N | ` — the prefix is framing, not
+    // information, so there is nothing left to read on that line.
+    if (flat.trim().length === 0) continue;
+    logger.warn(`Replica ${replicaIndex} | ${flat}`);
+  }
 }
 
 const defaultSleepImpl = (ms: number): Promise<void> =>

--- a/src/local/httpv2-service-integration.ts
+++ b/src/local/httpv2-service-integration.ts
@@ -54,6 +54,13 @@ import type * as SqsNs from '@aws-sdk/client-sqs';
 import { stringifyValue } from '../utils/stringify.js';
 import { getLogger } from '../utils/logger.js';
 import { getEmbedConfig } from './embed-config.js';
+import {
+  clampErrorName,
+  describeAwsFailureForWarn,
+  isAwsServiceException,
+  sanitizeServiceExceptionMessage,
+  stringifyThrown,
+} from './credential-error.js';
 
 const logger = getLogger();
 
@@ -438,14 +445,39 @@ async function dispatchAppConfigGetConfiguration(
 // Helpers
 // ---------------------------------------------------------------------
 
+/**
+ * A REQUEST-shape rejection raised by cdk-local itself, before any AWS call.
+ *
+ * Issue #579 — it needs its own class so {@link translateSdkError} can tell it
+ * apart from a relayed SDK failure. Its message is cdk-local's own literal and
+ * names the missing parameter, so it is the diagnosis and must reach the
+ * client verbatim; the credential-error policy withholds every non-service
+ * exception, which would otherwise have turned this 400 into a class name and
+ * a character count. `credential-error.ts` names exactly this remedy: make
+ * cdk-local's own throws identifiable rather than guess at their text.
+ *
+ * The ONE remaining cdk-local-authored throw inside the guarded `try` is
+ * `getClient`'s `unknown service '<x>'`, and it is left withheld deliberately:
+ * its `switch` is exhaustive over the dispatched subtypes, so the arm is dead
+ * code guarding against a future subtype added without a client case. If it
+ * ever does fire, the developer who added that subtype reads the full text on
+ * the `debug` line the helper emits.
+ */
+class ServiceIntegrationRequestError extends Error {
+  readonly statusCode = 400;
+  constructor(message: string) {
+    super(message);
+    this.name = 'ServiceIntegrationRequestError';
+    Object.setPrototypeOf(this, ServiceIntegrationRequestError.prototype);
+  }
+}
+
 function requireParams(params: Record<string, string>, required: readonly string[]): void {
   const missing = required.filter((k) => !params[k] || params[k].trim() === '');
   if (missing.length > 0) {
-    const err: Error & { statusCode?: number } = new Error(
+    throw new ServiceIntegrationRequestError(
       `missing required RequestParameter(s): ${missing.join(', ')}`
     );
-    err.statusCode = 400;
-    throw err;
   }
 }
 
@@ -512,8 +544,39 @@ function errorResponse(statusCode: number, message: string): ServiceIntegrationR
  * Translate an AWS SDK error to an HTTP response. AWS SDK v3 surfaces
  * errors as instances carrying `$metadata.httpStatusCode` + `name`;
  * we honor the status code when present, default to 500.
+ *
+ * Issue #579 routed the two relayed fields through the credential-error
+ * policy. LEVEL: this one is NOT a log line — it is a RESPONSE BODY served on
+ * the local API port, which makes it the widest reader of the set: the studio
+ * capture proxy records a served response body onto the timeline, so the text
+ * reaches the same browser the log ring does, and any HTTP client reaches it
+ * without `--verbose`. RECONSTRUCTION: the `catch` wraps the per-subtype
+ * dispatch, i.e. one `client.send(...)`, so a `CredentialsProviderError`
+ * carrying a `credential_process` command line would have been JSON-encoded
+ * into that body verbatim. A modeled service exception's message is what a
+ * real API Gateway service integration surfaces and is the diagnosis, so it
+ * keeps printing; `code` is `err.name`, wire-derived, and is clamped.
  */
+/** A value usable as an HTTP status line without raising `ERR_HTTP_INVALID_STATUS_CODE`. */
+function isHttpStatus(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 100 && value < 600;
+}
+
 function translateSdkError(subtype: SupportedSubtype, err: unknown): ServiceIntegrationResult {
+  if (err instanceof ServiceIntegrationRequestError) {
+    // The RESPONSE SHAPE is preserved, not just the message. Before #579 this
+    // throw fell through the SDK branch below and produced `{ message, code }`,
+    // so returning the bare `{ message }` `errorResponse` builds would have
+    // dropped a field from a served body — a silent contract change riding
+    // along with a security fix. `code` carries the class name (it used to be
+    // the string `Error`, this throw having been an anonymous `Error`), which
+    // is cdk-local's own literal rather than anything off the wire.
+    return {
+      statusCode: err.statusCode,
+      body: JSON.stringify({ message: err.message, code: err.name }),
+      headers: { 'content-type': 'application/json' },
+    };
+  }
   if (err && typeof err === 'object') {
     const e = err as {
       name?: string;
@@ -521,13 +584,48 @@ function translateSdkError(subtype: SupportedSubtype, err: unknown): ServiceInte
       $metadata?: { httpStatusCode?: number };
       statusCode?: number;
     };
-    const status =
-      typeof e.statusCode === 'number' && e.statusCode >= 100 && e.statusCode < 600
-        ? e.statusCode
-        : (e.$metadata?.httpStatusCode ?? 500);
+    // Both candidates are RANGE-GUARDED. `e.statusCode` always was; issue #579
+    // review round 2 caught that `$metadata.httpStatusCode` was not, and this
+    // value becomes `res.statusCode` on a real `http.ServerResponse`, where a
+    // non-integer raises `ERR_HTTP_INVALID_STATUS_CODE` and takes the server's
+    // request handler down instead of answering. `$metadata` is a plain object
+    // that `decorateServiceException` copies parsed response-body keys onto, so
+    // "the SDK sets it" is not the same as "it is an integer".
+    const status = isHttpStatus(e.statusCode)
+      ? e.statusCode
+      : isHttpStatus(e.$metadata?.httpStatusCode)
+        ? e.$metadata.httpStatusCode
+        : 500;
     const body = {
-      message: e.message ?? 'AWS SDK call failed',
-      code: e.name ?? 'UnknownError',
+      // The KEPT branch uses `sanitizeServiceExceptionMessage` rather than the
+      // whole of `describeAwsFailureForWarn`, and the difference is this
+      // site's alone: a log line has one field, so the helper concatenates
+      // `<name>: <message>` into it, but this body already carries the name in
+      // `code`. Prefixing it into `message` as well would both duplicate it and
+      // change what a client parsing `message` reads (`Rate exceeded` becoming
+      // `ThrottlingException: Rate exceeded`). The WITHHELD branch still goes
+      // through the helper, so the `debug` line pairing is preserved.
+      // On the KEPT branch, read `e.message` when it is a string rather than
+      // going through `stringifyThrown`, which keys on `instanceof Error` and
+      // would render a service-exception-SHAPED plain object as the literal
+      // `[object Object]` — claiming to have kept the diagnosis while printing
+      // a placeholder. Safe on this branch specifically: the message is already
+      // judged printable here, and the sanitizer still flattens and caps it, so
+      // reading the field is exactly as bounded as reading `err.message` off an
+      // `Error`. (Every SDK-modeled exception DOES extend `Error`, so this is
+      // belt-and-braces for a hand-rolled or proxied throw rather than
+      // something `@aws-sdk/*` produces. Issue #579 review round 3.)
+      message: isAwsServiceException(err)
+        ? sanitizeServiceExceptionMessage(
+            typeof e.message === 'string' ? e.message : stringifyThrown(err)
+          )
+        : describeAwsFailureForWarn(err, `${subtype} service integration`),
+      // `code` is NOT widened the same way, and that asymmetry is deliberate:
+      // `clampErrorName` degrades a non-`Error` to `unknown` on purpose, "so
+      // the field never names a class the throw was not". A shape that is not
+      // an `Error` has no class, and `unknown` is the honest answer; the
+      // message half above carries the diagnosis regardless.
+      code: clampErrorName(err),
     };
     logger.debug(`[${subtype}] SDK error (${status}): ${stringifyValue(body)}`);
     return {
@@ -536,7 +634,16 @@ function translateSdkError(subtype: SupportedSubtype, err: unknown): ServiceInte
       headers: { 'content-type': 'application/json' },
     };
   }
-  return errorResponse(500, `Unexpected error invoking ${subtype}: ${String(err)}`);
+  // A non-object throw (`throw 'x'`) never carries a credential chain's message
+  // -- `CredentialsProviderError` is an `Error` -- but it is still relayed into
+  // a response body, so it goes through the same helper rather than `String()`.
+  return errorResponse(
+    500,
+    `Unexpected error invoking ${subtype}: ${describeAwsFailureForWarn(
+      err,
+      `${subtype} service integration`
+    )}`
+  );
 }
 
 // ---------------------------------------------------------------------

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -7,6 +7,7 @@ import { pipeline } from 'node:stream/promises';
 import { getLogger } from '../utils/logger.js';
 import type { ResolvedArnLambdaLayer } from './lambda-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
 
 /**
  * Materialize a literal-ARN Lambda Layer to a host tmpdir so it can be
@@ -106,6 +107,49 @@ export class LayerMaterializationError extends Error {
   }
 }
 
+/**
+ * cdk-local's OWN rejection raised INSIDE a guarded region, still needing the
+ * call site's framing (issue #579, review round 2).
+ *
+ * Two classes are needed, not one, because the guarded regions contain BOTH
+ * kinds of cdk-local throw and they want opposite handling:
+ *
+ *   - ALREADY FRAMED — the ARN-shape guard raises
+ *     `Layer <arn>: not a layer-version ARN ...`, which names the layer and the
+ *     problem and fires before any AWS call. Re-raising it INTACT is right;
+ *     wrapping it would double the `Layer <arn>:` prefix and, worse, prepend
+ *     `GetLayerVersion failed` to a failure where no call was ever made.
+ *   - UNFRAMED — `AssumeRole returned no Credentials` and
+ *     `GetLayerVersion response did not include Content.Location` are bare
+ *     sentences that mean nothing without the site's `Layer <arn>: <call>
+ *     failed: ... <remedy>` envelope.
+ *
+ * A first pass at #579 made both `LayerMaterializationError` and re-raised
+ * both, which silently DROPPED the envelope (and the `looksLikeAccessDenied`
+ * hint) from the second group. The existing tests only substring-match the
+ * inner sentence, so nothing went red. Hence a distinct type rather than a
+ * shared one: the catch keeps the message verbatim — it is cdk-local's own
+ * text, never anything off the wire, so the credential-error policy has
+ * nothing to decide about it — and still applies the framing.
+ */
+class UnframedLayerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnframedLayerError';
+    Object.setPrototypeOf(this, UnframedLayerError.prototype);
+  }
+}
+
+/**
+ * The detail half of a layer failure message: cdk-local's own text kept
+ * verbatim, anything else rendered by the shared credential-error policy.
+ */
+function layerFailureDetail(err: unknown, operation: string): string {
+  return err instanceof UnframedLayerError
+    ? err.message
+    : describeAwsFailureForWarn(err, operation);
+}
+
 export async function materializeLayerFromArn(
   layer: ResolvedArnLambdaLayer,
   options: MaterializeLayerOptions = {}
@@ -118,9 +162,21 @@ export async function materializeLayerFromArn(
       credentials = await assumeRoleForLayer(options.roleArn, layer.region, options);
       logger.debug(`Layer ${layer.arn}: assumed role ${options.roleArn} for GetLayerVersion`);
     } catch (err) {
+      // An ALREADY-FRAMED cdk-local throw passes through untouched; see
+      // {@link UnframedLayerError} for why the two cases are separate types.
+      if (err instanceof LayerMaterializationError) throw err;
+      // Issue #579. LEVEL: this THROWS rather than logging, but the text lands
+      // on the user through the top-level error handler, which is
+      // default-level output by construction. RECONSTRUCTION:
+      // `assumeRoleForLayer` wraps `sts.send(AssumeRoleCommand)` — the same
+      // two-population `catch` issue #570 split at nine sites in
+      // `src/cli/commands/**`; this one sits outside that scope, which is the
+      // only reason it was not covered there.
       throw new LayerMaterializationError(
-        `Layer ${layer.arn}: STS AssumeRole(${options.roleArn}) failed: ${errMsg(err)}. ` +
-          'Check the role trust policy permits your principal and sts:AssumeRole is allowed.'
+        `Layer ${layer.arn}: STS AssumeRole(${flattenToOneLine(options.roleArn)}) failed: ${layerFailureDetail(
+          err,
+          'STS AssumeRole (--layer-role-arn)'
+        )}. ` + 'Check the role trust policy permits your principal and sts:AssumeRole is allowed.'
       );
     }
   }
@@ -129,13 +185,24 @@ export async function materializeLayerFromArn(
   try {
     presignedUrl = await fetchLayerContentUrl(layer, credentials, options);
   } catch (err) {
+    // The ARN-shape guard frames itself (and fires before any call), so it
+    // passes through; the missing-`Content.Location` guard does not, and is
+    // kept verbatim inside this site's envelope by `layerFailureDetail`.
+    if (err instanceof LayerMaterializationError) throw err;
     const hint = looksLikeAccessDenied(err)
       ? ' GetLayerVersion access denied; check the credentials / role can read the layer ' +
         '(grant lambda:GetLayerVersion on the layer ARN, or pass --layer-role-arn <arn> ' +
         'to assume a role in the layer account).'
       : '';
+    // Issue #579 — same two-axis call as the AssumeRole site above;
+    // `fetchLayerContentUrl` is a `lambda:GetLayerVersion` call. `hint` is
+    // cdk-local's own literal and is derived from `looksLikeAccessDenied`,
+    // which reads the error rather than printing it, so it stays as is.
     throw new LayerMaterializationError(
-      `Layer ${layer.arn}: GetLayerVersion failed in region ${layer.region}: ${errMsg(err)}.${hint}`
+      `Layer ${layer.arn}: GetLayerVersion failed in region ${layer.region}: ${layerFailureDetail(
+        err,
+        'Lambda GetLayerVersion'
+      )}.${hint}`
     );
   }
 
@@ -222,7 +289,7 @@ async function fetchLayerContentUrl(
     const response = await client.send(command);
     const url = response?.Content?.Location;
     if (!url || typeof url !== 'string') {
-      throw new Error(
+      throw new UnframedLayerError(
         'GetLayerVersion response did not include Content.Location (presigned ZIP URL)'
       );
     }
@@ -244,7 +311,7 @@ async function assumeRoleForLayer(
     const response = await client.send(command);
     const creds = response?.Credentials;
     if (!creds?.AccessKeyId || !creds.SecretAccessKey) {
-      throw new Error('AssumeRole returned no Credentials');
+      throw new UnframedLayerError('AssumeRole returned no Credentials');
     }
     return {
       accessKeyId: creds.AccessKeyId,
@@ -309,7 +376,14 @@ async function downloadPresignedZip(
   const response = await fetch(presignedUrl);
   if (!response.ok) {
     throw new Error(
-      `HTTP ${response.status} ${response.statusText} from layer Content.Location URL`
+      // Issue #579 review round 2 — `statusText` is the HTTP REASON PHRASE, i.e.
+      // a string the presigned host chose, and it lands on a default-level
+      // line. The HTTP parser forbids CR/LF there, so the forged-LINE half was
+      // already closed by the protocol; `\x1b` (an ANSI escape) and U+2028 (a
+      // forced break in the studio UI's `<pre>`) are NOT forbidden, and
+      // `flattenToOneLine` covers all four categories rather than just the two
+      // the parser happens to stop.
+      `HTTP ${response.status} ${flattenToOneLine(response.statusText)} from layer Content.Location URL`
     );
   }
   const buf = await response.arrayBuffer();
@@ -431,6 +505,27 @@ async function inflateRaw(data: Uint8Array): Promise<Uint8Array> {
   });
 }
 
+/**
+ * Message of a thrown value, for the two throws that are NOT AWS SDK relays.
+ *
+ * Issue #579 deliberately left these two on `errMsg`: the presigned-URL
+ * download is a plain HTTPS fetch (the URL already carries its authorization,
+ * so no credential chain is resolved and no modeled service exception is
+ * parsed) and the unzip is a purely LOCAL operation. Neither `catch` can see a
+ * `credential_process` command line, so there is nothing for the
+ * credential-error policy to DECIDE about them. The two AWS calls in this
+ * module — STS `AssumeRole` and `lambda:GetLayerVersion` — go through
+ * `describeAwsFailureForWarn` instead.
+ *
+ * CORRECTED in review round 2: an earlier revision of this note claimed these
+ * catches see nothing wire-derived at all, which was stronger than the code.
+ * The download `catch` DOES see wire-derived text — `downloadPresignedZip`
+ * raises `HTTP <status> <statusText> ...`, and the reason phrase is whatever
+ * the presigned host sent. Nothing there needs WITHHOLDING (no credential
+ * chain, no secret), but it does need FLATTENING, which is applied at that
+ * throw rather than here, because `errMsg` is also used by the unzip `catch`
+ * whose input is a local `fflate` error.
+ */
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }

--- a/src/local/ssm-parameter-resolver.ts
+++ b/src/local/ssm-parameter-resolver.ts
@@ -35,6 +35,7 @@
 
 import { SSMClient, GetParametersCommand } from '@aws-sdk/client-ssm';
 import { getLogger } from '../utils/logger.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
 import type { CloudFormationTemplate } from '../types/resource.js';
 
 /** SSM-backed CFn parameter types CDK synthesizes for SSM lookups. */
@@ -175,8 +176,23 @@ export async function resolveSsmParameters(
         );
       }
     } catch (err) {
+      // Issue #579. LEVEL: a DEFAULT-level warn, mirrored into the studio log
+      // ring. RECONSTRUCTION: this `catch` wraps `client.send(...)`, which
+      // resolves the credential chain before the request goes out, so it sees
+      // BOTH a `CredentialsProviderError` (whose message can be a
+      // `credential_process` command line) and a modeled SSM exception
+      // (`AccessDeniedException`, `ParameterNotFound`) whose message IS the
+      // diagnosis -- the two-population split `describeAwsFailureForWarn`
+      // exists for. It replaces the local `formatSsmError`, which interpolated
+      // an UNCLAMPED wire-derived `err.name` and did not flatten.
       logger.warn(
-        `${label}: SSM GetParameters(${names.join(', ')}) failed: ${formatSsmError(err)}. ` +
+        // The parameter NAMES come from the template's `Default` values, so
+        // they land on this default-level warn the same way every other
+        // wire-adjacent value does; the flatten costs one call.
+        `${label}: SSM GetParameters(${flattenToOneLine(names.join(', '))}) failed: ${describeAwsFailureForWarn(
+          err,
+          'SSM GetParameters'
+        )}. ` +
           `Ref to the matching CloudFormation parameter(s) will warn-and-drop (grant ssm:GetParameters or override via --env-vars).`
       );
       continue;
@@ -203,16 +219,4 @@ export async function resolveSsmParameters(
   }
 
   return out;
-}
-
-/**
- * Format an SSM SDK error as `<name>: <message>` so the warn names the
- * error class (e.g. `AccessDeniedException`, `ThrottlingException`).
- * Mirrors `formatAwsErrorForWarn` in `cfn-local-state-provider.ts`.
- * Exported for unit testing.
- */
-export function formatSsmError(err: unknown): string {
-  if (!(err instanceof Error)) return String(err);
-  const name = err.name && err.name !== 'Error' ? err.name : undefined;
-  return name !== undefined ? `${name}: ${err.message}` : err.message;
 }

--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -102,6 +102,7 @@
  * one env var must not abort the whole `cdkl invoke` call.
  */
 
+import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
 import type { ResourceState } from '../types/state.js';
 
 /**
@@ -887,9 +888,48 @@ async function resolveImportValueAsync(
   try {
     resolved = await context.crossStackResolver.resolveImport(exportName);
   } catch (err) {
+    // Issue #579, corrected in review round 2. An earlier revision of this
+    // comment claimed `resolveImport` IS a CloudFormation `ListExports` call.
+    // It is not, and the distinction changes what this `catch` can see:
+    // `CrossStackResolver` is a HOST-IMPLEMENTED interface exported from
+    // `src/index.ts` (the STABLE surface), and cdk-local's own implementation
+    // in `cfn-local-state-provider.ts` catches its SDK failures INTERNALLY
+    // (`fetchAllExports(...).catch(...)` warns and resolves `undefined`). So
+    // nothing cdk-local throws reaches here at all: what does is a host
+    // resolver's throw, or a cdk-local bug.
+    //
+    // LEVEL: this `reason` is not logged here, but three DEFAULT-level warns
+    // print it verbatim (`local-invoke.ts`, `local-start-api.ts`,
+    // `local-invoke-agentcore.ts`), and studio mirrors those into its log ring.
+    //
+    // RECONSTRUCTION is therefore NOT established by inspection, and the
+    // withholding default is kept deliberately rather than by default: this
+    // interface's whole purpose is resolving DEPLOYED cross-stack state, so an
+    // AWS-backed host implementation is the expected case rather than the
+    // exotic one, and such a resolver resolves the same credential chain
+    // before its request goes out. The discriminator still does the right
+    // thing on both populations: a host that lets a modeled service exception
+    // escape keeps its message, because `$fault` / `$metadata` are set by the
+    // SDK from the response and not by anything the host chose.
+    //
+    // ACCEPTED COST, stated so it is not rediscovered as a bug: a host
+    // resolver's OWN `throw new Error('export index missing for X')` is
+    // withheld to a class name plus a length. It is recoverable at `debug`,
+    // and the remedy for a host that wants its text on the default line is the
+    // one this policy names everywhere else, and which cdk-local applies to
+    // its own throws in `layer-arn-materializer.ts` and
+    // `httpv2-service-integration.ts`: raise something identifiable and frame
+    // the message above the boundary.
     return {
       kind: 'unresolved',
-      reason: `Fn::ImportValue '${exportName}': lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+      // `exportName` is flattened for the same one-call reason every other
+      // wire-derived value on a default-level line is: it is resolved from the
+      // template (and may itself come through `Fn::Sub` against deployed
+      // state), and this `reason` is printed verbatim by three warns.
+      reason: `Fn::ImportValue '${flattenToOneLine(exportName)}': lookup failed: ${describeAwsFailureForWarn(
+        err,
+        'CrossStackResolver.resolveImport (Fn::ImportValue)'
+      )}`,
     };
   }
   if (resolved === undefined) {
@@ -999,9 +1039,20 @@ async function resolveGetStackOutputAsync(
       outputName
     );
   } catch (err) {
+    // Issue #579 — the same HOST-BOUNDARY catch as the `Fn::ImportValue` site
+    // above, decided the same way and for the same reasons; see the comment
+    // there. cdk-local's own `resolveGetStackOutput` warns and returns
+    // `undefined` rather than throwing, so this too only ever sees a host
+    // resolver's throw.
     return {
       kind: 'unresolved',
-      reason: `Fn::GetStackOutput '${stackName}.${outputName}' (${region}): lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+      // Same treatment for the three template-derived values here.
+      reason: `Fn::GetStackOutput '${flattenToOneLine(stackName)}.${flattenToOneLine(
+        outputName
+      )}' (${flattenToOneLine(region)}): lookup failed: ${describeAwsFailureForWarn(
+        err,
+        'CrossStackResolver.resolveGetStackOutput (Fn::GetStackOutput)'
+      )}`,
     };
   }
   if (resolved === undefined) {

--- a/src/utils/role-arn.ts
+++ b/src/utils/role-arn.ts
@@ -1,7 +1,59 @@
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
+import type { AssumeRoleCommandOutput } from '@aws-sdk/client-sts';
 import { getLogger } from './logger.js';
 import { getEmbedConfig } from '../local/embed-config.js';
 import { buildStsClientConfig } from './profile-resolver.js';
+import { describeAwsFailureForWarn, flattenToOneLine } from '../local/credential-error.js';
+
+/**
+ * {@link assumeRoleCredentials} failed, and the failure is cdk-local's OWN
+ * rendering of it rather than a raw SDK error.
+ *
+ * Exists because this helper has TWO kinds of caller and they need opposite
+ * things (issue #579 review round 4, found by #570's own harness going red):
+ *
+ *   - THREE paths are unguarded all the way to `formatError`
+ *     (`local-start-api`'s `assumeLambdaExecutionRole`, and `assumeTaskRole` in
+ *     both `local-run-task` and `ecs-service-emulator`). They need this helper
+ *     to render the failure, which is why it no longer propagates unwrapped.
+ *   - ONE path -- `local-invoke.ts`'s `resolveLambdaContainerEnv` -- ALREADY
+ *     renders it, guarded by the #570 lane. Wrapping for the first group broke
+ *     that one: the outer `describeAwsFailureForWarn` saw a plain `Error`
+ *     (no `$fault`, because it is cdk-local's own), withheld the
+ *     already-sanitized text, and turned `ExpiredTokenException: The security
+ *     token ... is expired` into `Error; 138-character message withheld`. The
+ *     policy withholding its OWN output is the worst of both branches.
+ *
+ * So `message` carries the framed sentence for the first group, and `detail`
+ * carries the bare half for a caller that supplies its own framing. A relay
+ * that re-renders `detail` would double-withhold it again; print it verbatim.
+ *
+ * BOTH of this helper's throws use it (issue #579 review round 5). The
+ * no-usable-credentials sibling was left a bare `Error` in round 4 and carried
+ * the identical defect one throw over: at `local-invoke.ts` it missed the
+ * `instanceof` test and rendered as `Error; 47-character message withheld`.
+ * That is the exact loss `credential-error.ts` documents as accepted and
+ * points here to fix, so it is fixed here rather than described again.
+ *
+ * NOT thrown when `makeError` is supplied -- that caller asked for its own
+ * class, and every `makeError` path today is in the unguarded group.
+ */
+export class AssumeRoleFailure extends Error {
+  /**
+   * The bare half, with no `AssumeRole(<arn>) ...` framing, safe to print
+   * VERBATIM on a line that adds its own. Already policy-rendered when the
+   * cause was an SDK error; cdk-local's own literal otherwise. Never re-render
+   * it -- that is what double-withholds.
+   */
+  readonly detail: string;
+
+  constructor(message: string, detail: string) {
+    super(message);
+    this.name = 'AssumeRoleFailure';
+    this.detail = detail;
+    Object.setPrototypeOf(this, AssumeRoleFailure.prototype);
+  }
+}
 
 /** Temporary credentials minted by {@link assumeRoleCredentials}. */
 export interface AssumedRoleCredentials {
@@ -24,9 +76,34 @@ export interface AssumedRoleCredentials {
  *
  * `sessionNameSuffix` distinguishes the callers in CloudTrail
  * (`<resourceNamePrefix>-<suffix>-<epochMs>`). `makeError` lets a
- * caller surface the no-usable-credentials failure as its own error
- * class (the ECS emulator throws `LocalStartServiceError`); STS
- * transport errors always propagate unwrapped.
+ * caller surface the failure as its own error class (the ECS emulator
+ * throws `LocalStartServiceError`).
+ *
+ * CHANGED by issue #579 review round 4: "STS transport errors always
+ * propagate unwrapped" is no longer true, and it was the last instance of the
+ * `try { send } finally { destroy }` with no `catch` that the derived
+ * population found. Propagating unwrapped meant the raw SDK error reached
+ * `withErrorHandling` -> `formatError`, which prints
+ * `${error.name}: ${error.message}` UNFLATTENED and UNCLAMPED at DEFAULT
+ * level — so a `CredentialsProviderError` carrying a `credential_process`
+ * command line landed there verbatim, from every `--assume-role` /
+ * `--assume-task-role` path in the CLI. This is the file `/review-pr`'s
+ * `UP_PATHS` names as credential-material surface, which is exactly why it is
+ * the wrong place to leave the relay open.
+ *
+ * The no-usable-credentials check sits OUTSIDE the `try` rather than being
+ * re-raised through an `instanceof` guard, because `makeError` mints the
+ * CALLER's class and there is no sentinel this function could test for.
+ * `sts.destroy()` still runs first — the `finally` fires on the way out of the
+ * `try`, and the response has already been read by then.
+ *
+ * What that buys is narrower than an earlier revision of this note claimed,
+ * and the overclaim is worth correcting rather than deleting: being outside the
+ * `try` means this function never routes its own text through the withholding
+ * policy, which is what the THREE `formatError` paths need — they print
+ * `message` directly. It does NOT help a caller that RE-RENDERS the error,
+ * because such a caller tests a class rather than a line number. That is what
+ * {@link AssumeRoleFailure} is for, and why BOTH throws below use it.
  */
 export async function assumeRoleCredentials(opts: {
   roleArn: string;
@@ -39,27 +116,42 @@ export async function assumeRoleCredentials(opts: {
   // profile's credentials (matching `aws sts assume-role --profile
   // <p>`), not the default env-shadowed chain (issue #245).
   const sts = new STSClient(buildStsClientConfig({ region: opts.region, profile: opts.profile }));
+  const shownArn = flattenToOneLine(opts.roleArn);
+  let response: AssumeRoleCommandOutput;
   try {
-    const response = await sts.send(
+    response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: opts.roleArn,
         RoleSessionName: `${getEmbedConfig().resourceNamePrefix}-${opts.sessionNameSuffix}-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );
-    const creds = response.Credentials;
-    if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
-      const message = `AssumeRole(${opts.roleArn}) returned no usable credentials.`;
-      throw opts.makeError ? opts.makeError(message) : new Error(message);
-    }
-    return {
-      accessKeyId: creds.AccessKeyId,
-      secretAccessKey: creds.SecretAccessKey,
-      sessionToken: creds.SessionToken,
-    };
+  } catch (err) {
+    const detail = describeAwsFailureForWarn(err, 'STS AssumeRole');
+    const message = `AssumeRole(${shownArn}) failed: ${detail}`;
+    throw opts.makeError ? opts.makeError(message) : new AssumeRoleFailure(message, detail);
   } finally {
     sts.destroy();
   }
+
+  // Outside the `try` on purpose; see the note above. cdk-local's own text is
+  // never routed through the withholding policy.
+  const creds = response.Credentials;
+  if (!creds?.AccessKeyId || !creds.SecretAccessKey || !creds.SessionToken) {
+    // `message` is BYTE-IDENTICAL to what this threw before issue #579 -- the
+    // three direct-print paths and `credential-error.ts`'s own worked example
+    // both quote it. What changed is the CLASS, so a re-rendering caller can
+    // recognise it, and `detail`, which drops the `AssumeRole(<arn>)` framing
+    // such a caller has already written.
+    const message = `AssumeRole(${shownArn}) returned no usable credentials.`;
+    const detail = 'the response carried no usable credentials';
+    throw opts.makeError ? opts.makeError(message) : new AssumeRoleFailure(message, detail);
+  }
+  return {
+    accessKeyId: creds.AccessKeyId,
+    secretAccessKey: creds.SecretAccessKey,
+    sessionToken: creds.SessionToken,
+  };
 }
 
 /**
@@ -96,31 +188,51 @@ export async function applyRoleArnIfSet(opts: {
   if (!roleArn) return;
 
   const logger = getLogger().child('role-arn');
-  logger.debug(`Assuming role ${roleArn}...`);
+  // FLATTENED at every interpolation (issue #579 review round 4). `roleArn` is
+  // usually the user's own flag value, but it also arrives from
+  // `<envPrefix>_ROLE_ARN` and, at the bare `--assume-role` call sites, from a
+  // live `GetFunctionConfiguration` / `GetAgentRuntime` response behind only a
+  // `startsWith('arn:')` check. The `info` line below is the more reachable of
+  // the two, because it fires on SUCCESS.
+  const shownArn = flattenToOneLine(roleArn);
+  logger.debug(`Assuming role ${shownArn}...`);
 
   const sts = new STSClient(buildStsClientConfig({ region: opts.region, profile: opts.profile }));
+  let response: AssumeRoleCommandOutput;
   try {
-    const response = await sts.send(
+    response = await sts.send(
       new AssumeRoleCommand({
         RoleArn: roleArn,
         RoleSessionName: `${getEmbedConfig().binaryName}-${Date.now()}`,
         DurationSeconds: 3600,
       })
     );
-    if (!response.Credentials) {
-      throw new Error(`AssumeRole returned no credentials for role ${roleArn}`);
-    }
-    const { AccessKeyId, SecretAccessKey, SessionToken, Expiration } = response.Credentials;
-    if (!AccessKeyId || !SecretAccessKey || !SessionToken) {
-      throw new Error(`AssumeRole response missing credentials fields for role ${roleArn}`);
-    }
-    process.env['AWS_ACCESS_KEY_ID'] = AccessKeyId;
-    process.env['AWS_SECRET_ACCESS_KEY'] = SecretAccessKey;
-    process.env['AWS_SESSION_TOKEN'] = SessionToken;
-    logger.info(
-      `Assumed role ${roleArn} (session expires ${Expiration?.toISOString() ?? 'unknown'})`
+  } catch (err) {
+    // The nine-caller site, and the most reachable relay the derived population
+    // turned up: NOTHING between here and `formatError` caught, so a
+    // `CredentialsProviderError` printed its `credential_process` command line
+    // at DEFAULT level from `cdkl studio`, the ECS emulator,
+    // `invoke-agentcore` and six other entry points.
+    throw new Error(
+      `AssumeRole(${shownArn}) failed: ${describeAwsFailureForWarn(err, 'STS AssumeRole')}`
     );
   } finally {
     sts.destroy();
   }
+
+  // cdk-local's own throws live OUTSIDE the guarded region, so the policy can
+  // never withhold text this file wrote itself.
+  if (!response.Credentials) {
+    throw new Error(`AssumeRole returned no credentials for role ${shownArn}`);
+  }
+  const { AccessKeyId, SecretAccessKey, SessionToken, Expiration } = response.Credentials;
+  if (!AccessKeyId || !SecretAccessKey || !SessionToken) {
+    throw new Error(`AssumeRole response missing credentials fields for role ${shownArn}`);
+  }
+  process.env['AWS_ACCESS_KEY_ID'] = AccessKeyId;
+  process.env['AWS_SECRET_ACCESS_KEY'] = SecretAccessKey;
+  process.env['AWS_SESSION_TOKEN'] = SessionToken;
+  logger.info(
+    `Assumed role ${shownArn} (session expires ${Expiration?.toISOString() ?? 'unknown'})`
+  );
 }

--- a/tests/unit/cli/local-studio-pin-classifier.test.ts
+++ b/tests/unit/cli/local-studio-pin-classifier.test.ts
@@ -61,6 +61,7 @@ const {
   classifyStudioTargets,
   reclassifyTargetsOnBindingChange,
 } = await import('../../../src/cli/commands/local-studio.js');
+const { getLogger } = await import('../../../src/utils/logger.js');
 
 function stack(name: string, region?: string): StackInfo {
   return {
@@ -232,7 +233,14 @@ describe('prepareEcsImageContexts', () => {
     const logger = fakeLogger();
     const dispose = vi.fn();
     hoisted.createLocalStateProvider.mockReturnValue({ dispose });
-    hoisted.buildEcsImageResolutionContext.mockRejectedValue(new Error('state load failed'));
+    // A MODELED service exception, so its message is the diagnosis and keeps
+    // printing (issue #579). A plain `Error` here would be withheld -- that is
+    // the shape a `CredentialsProviderError` arrives as.
+    const failure = new Error('state load failed');
+    Object.defineProperty(failure, 'name', { value: 'AccessDenied' });
+    hoisted.buildEcsImageResolutionContext.mockRejectedValue(
+      Object.assign(failure, { $fault: 'client', $metadata: { httpStatusCode: 403 } })
+    );
 
     const map = await prepareEcsImageContexts({
       serviceIds: ['dev/Svc'],
@@ -245,6 +253,83 @@ describe('prepareEcsImageContexts', () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('state load failed'));
     // Provider is still disposed on the failure path.
     expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Issue #579 — the RELAY half of that same warn.
+   *
+   * LEVEL: a DEFAULT-level warn on studio's own stdout, which studio mirrors
+   * into the log ring it serves over HTTP. RECONSTRUCTION:
+   * `buildEcsImageResolutionContext` calls `stateProvider.load()` and
+   * `resolveTemplateSsmParameters()`, both AWS calls on the same credential
+   * chain, so this `catch` sees a `CredentialsProviderError` (whose message
+   * can be a `credential_process` command line) alongside a modeled
+   * CloudFormation / SSM exception whose message is the diagnosis.
+   *
+   * This site's row lives here rather than in
+   * `tests/unit/local/aws-error-relay-sites.test.ts` (the rest of #579's
+   * table) because this file already owns `local-studio.ts`'s mock graph.
+   */
+  describe('#579 — the SDK failure it relays', () => {
+    const PASSPHRASE = 'hunter2-do-not-log';
+    const CHAIN_MESSAGE =
+      `Command failed: /opt/bin/get-creds --vault-passphrase ${PASSPHRASE}\n` +
+      `  vault: unlocked with passphrase ${PASSPHRASE}`;
+
+    async function driveWith(err: unknown): Promise<{ warn: string; debug: string[] }> {
+      const logger = fakeLogger();
+      const debugLines: string[] = [];
+      const spy = vi
+        .spyOn(getLogger(), 'debug')
+        .mockImplementation((m: string) => void debugLines.push(String(m)));
+      hoisted.createLocalStateProvider.mockReturnValue({ dispose: vi.fn() });
+      hoisted.buildEcsImageResolutionContext.mockRejectedValue(err);
+      try {
+        await prepareEcsImageContexts({
+          serviceIds: ['dev/Svc'],
+          stacks: [stack('dev', 'us-east-1')],
+          options: { fromCfnStack: true },
+          logger,
+        });
+      } finally {
+        spy.mockRestore();
+      }
+      const calls = (logger.warn as unknown as { mock: { calls: [string][] } }).mock.calls;
+      expect(calls).toHaveLength(1);
+      return { warn: calls[0]![0], debug: debugLines };
+    }
+
+    it('withholds a credential-chain message and prints it at debug', async () => {
+      const err = new Error(CHAIN_MESSAGE);
+      Object.defineProperty(err, 'name', { value: 'CredentialsProviderError' });
+      const { warn, debug } = await driveWith(err);
+
+      expect(warn).toContain(
+        'CredentialsProviderError; 125-character message withheld, logged at debug level under --verbose'
+      );
+      expect(warn).not.toContain(PASSPHRASE);
+      expect(warn).not.toContain('Command failed');
+      expect(warn).not.toContain('\n');
+
+      const withheld = debug.filter((l) => l.includes(PASSPHRASE));
+      expect(withheld).toHaveLength(1);
+      expect(withheld[0]!).toContain(
+        "deployed-state image context (CloudFormation + SSM): the AWS SDK's own failure message was:"
+      );
+      // The debug stream is the SAME stdout studio mirrors into its ring.
+      expect(withheld[0]!).not.toContain('\n');
+    });
+
+    it('clamps a forged wire-derived err.name and flattens a forged message', async () => {
+      const err = new Error('denied\nServer listening on http://attacker.example/');
+      Object.defineProperty(err, 'name', { value: 'Foo\nWARN: signature verified' });
+      const { warn } = await driveWith(
+        Object.assign(err, { $fault: 'client', $metadata: { httpStatusCode: 403 } })
+      );
+      expect(warn).toContain('unknown: denied Server listening on http://attacker.example/');
+      expect(warn).not.toContain('signature verified');
+      expect(warn).not.toContain('\n');
+    });
   });
 });
 

--- a/tests/unit/cli/sts-error-relay-sites.test.ts
+++ b/tests/unit/cli/sts-error-relay-sites.test.ts
@@ -550,3 +550,62 @@ describe('#570 — a forged newline in the role ARN cannot forge a line either',
     });
   });
 });
+
+/**
+ * Issue #579 review round 5 — the RENDER PATHS for cdk-local's own
+ * no-usable-credentials throw.
+ *
+ * `credential-error.ts` used to name this exact string as an accepted
+ * diagnostic loss: `AssumeRole(<arn>) returned no usable credentials.` is a
+ * plain `Error` with no `$fault`, so every relay below withheld it to
+ * `Error; 47-character message withheld` — cdk-local's own sentence hidden
+ * from the user by cdk-local's own policy, at all four sites at once. The
+ * remedy that note named (make the throw identifiable) is applied in
+ * `utils/role-arn.ts` and `local-invoke-agentcore.ts`; these cases are the
+ * other half of it, asserting what each site actually PRINTS.
+ *
+ * Driven by an STS response that RESOLVES with no `Credentials`, which is the
+ * only way to reach the throw — a rejection takes the transport branch instead.
+ */
+describe("#579 — cdk-local's own no-credentials sentence survives every relay", () => {
+  let warnLines: string[];
+
+  beforeEach(() => {
+    warnLines = [];
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    sendMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const quoting = sites.filter((s) => s.quotesRoleArn);
+
+  it('covers all four ARN-quoting sites', () => {
+    expect(quoting).toHaveLength(4);
+  });
+
+  describe.each(quoting)('$name', (site) => {
+    it('prints the rendered detail, not a withheld character count', async () => {
+      // Resolves with no `Credentials` -> cdk-local's own guard fires.
+      sendMock.mockResolvedValue({});
+      await site.drive();
+
+      const matches = warnLines.filter((l) => l.includes(site.reached));
+      expect(matches, `no warn line at ${site.name} contained its own literal`).toHaveLength(1);
+      const line = matches[0]!;
+      expect(line).toContain(`${site.reached}the response carried no usable credentials`);
+      // The regression this closes, asserted directly.
+      expect(line).not.toContain('message withheld');
+      expect(line).not.toContain('47-character');
+      // And no double framing from the inner sentence leaking through.
+      expect(line).not.toContain('returned no usable credentials.');
+    });
+  });
+});
+

--- a/tests/unit/cli/sts-error-relay-source-fence.test.ts
+++ b/tests/unit/cli/sts-error-relay-source-fence.test.ts
@@ -36,12 +36,27 @@ import { dirname, join } from 'node:path';
  *   - It is wording-bound. A tenth site spelled `STS ${op} failure` or with no
  *     `STS` token at all produces no finding — though a copy-paste-shaped one
  *     trips the exact-9 count loudly.
- *   - Its directory scope is `src/cli/commands/*.ts`, non-recursively. A
- *     relay of the same shape lives outside it today —
- *     `src/local/layer-arn-materializer.ts:122` renders
- *     `STS AssumeRole(${roleArn}) failed: ${errMsg(err)}` with an unflattening
- *     `errMsg`. It THROWS rather than logging, so it is a different surface,
- *     and it is pre-existing; it is enumerated in issue #579 with the rest.
+ *   - Its directory scope is `src/cli/commands/*.ts`, non-recursively. FOUR
+ *     relays of the same shape live outside it, and issue #579 added two of
+ *     them: `src/utils/role-arn.ts`'s `assumeRoleCredentials` and
+ *     `applyRoleArnIfSet`. The second is the NINE-caller site, the most
+ *     reachable AssumeRole relay in the repo, and neither is reachable by this
+ *     scan. Both are fenced behaviourally in
+ *     `tests/unit/utils/role-arn.test.ts` — but that is per-occurrence
+ *     coverage, NOT the tenth-site property: a NEW unguarded relay added
+ *     beside them still produces no finding here. Stated rather than left
+ *     implicit, because "it has tests" and "a new sibling cannot slip in" are
+ *     different guarantees and only the first holds there. The other two —
+ *     `src/local/layer-arn-materializer.ts`'s `STS AssumeRole(${roleArn})
+ *     failed:` and `src/local/ecr-puller.ts`'s `Failed to assume role ${arn}
+ *     for ECR pull:`. Issue #579 routed both through the shared policy and
+ *     fences them per-occurrence in
+ *     `tests/unit/local/aws-error-relay-sites.test.ts`, but this file's
+ *     TENTH-SITE property does not extend to them: a NEW unguarded STS relay
+ *     added under `src/local/**` still produces no finding here. Widening the
+ *     scan is not free — `src/local/**` carries far more prose naming STS than
+ *     the command layer does, and a fence that has to be suppressed is a fence
+ *     nobody keeps — so it is left undone deliberately rather than overlooked.
  *   - `stripComments` handles a leading and a trailing `//`, not a trailing
  *     BLOCK comment: one opening with a slash-star, naming the helper, and
  *     closing again on the same line, placed beside a destructured
@@ -184,7 +199,19 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
     // count AND the identity of the files carrying them are pinned, so a new
     // site in a file not previously carrying one fails here rather than
     // slipping past a hard-coded list.
-    expect(all).toHaveLength(9);
+    // ELEVEN since issue #579, which derived the population of catch-less SDK
+    // sends rather than working the enumerated list: round 3 added
+    // `local-run-task.ts`'s `resolvePlaceholderAccount` and round 4 its twin in
+    // `ecs-service-emulator.ts` (deferred one round only because PR #610 held
+    // that file). Both had no `catch` at all.
+    //
+    // This assertion FIRED on each of them as they were written — the
+    // tenth-site property the file exists for, triggering on real new sites
+    // rather than on hypothetical ones. It also caught a formatting detail on
+    // the first: an inline render wrapped across three lines put the helper
+    // call outside the guard window, and the fix was to hoist it into a `const`
+    // rather than to widen the window.
+    expect(all).toHaveLength(11);
     expect([...new Set(all.map((f) => f.file))].sort()).toEqual([
       'ecs-service-emulator.ts',
       'local-invoke-agentcore.ts',

--- a/tests/unit/local/aws-error-relay-sites.test.ts
+++ b/tests/unit/local/aws-error-relay-sites.test.ts
@@ -1,0 +1,1625 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { getLogger } from '../../../src/utils/logger.js';
+import type { CrossStackResolver } from '../../../src/local/state-resolver.js';
+
+/**
+ * Issue #579 — the CALL SITES outside `src/cli/commands/**`.
+ *
+ * Issue #570 settled the policy (`src/local/credential-error.ts`) and applied
+ * it to nine STS relays in the command layer, with a per-occurrence probe
+ * harness at `tests/unit/cli/sts-error-relay-sites.test.ts`. This file is that
+ * harness's sibling for the rest of the codebase: every remaining `catch` that
+ * relayed an AWS SDK error's `message` into a line a user sees at DEFAULT
+ * level.
+ *
+ * Every site is driven SEPARATELY, on purpose — the same reason the #570
+ * harness gives: a whole-symbol probe answers "is ANY of this fenced", not "is
+ * EACH". Each row below reaches exactly one `catch` and asserts against that
+ * site's own literal, so reverting one site turns exactly its rows red.
+ *
+ * TWO sites in issue #579's scope are NOT rows here, because their fixtures
+ * belong elsewhere and duplicating them would make this file the definition of
+ * a different module's mocks:
+ *
+ *   - `local-studio.ts` / `prepareEcsImageContexts` — covered by the `#579`
+ *     block in `tests/unit/cli/local-studio-pin-classifier.test.ts`, which
+ *     already owns that command's mock graph.
+ *   - `ecs-service-runner.ts` / `printExitedContainerLogs` — covered by
+ *     `tests/unit/local/ecs-service-runner-exit-logs.test.ts`. It is the one
+ *     site whose RECONSTRUCTION axis does not arise: the text is the
+ *     container's own stdout, not an SDK failure, so nothing is withheld and
+ *     the fix is the LEVEL half alone (one prefixed warn per line).
+ *
+ * A THIRD site is deliberately not a ROW but IS covered in this file, at the
+ * bottom: `cloudfront-kvs-client.ts`'s `ListKeyValueStores` relay. It cannot be
+ * a row because the table's five cases all assert WITHHOLDING, and that site
+ * withholds nothing — it is a `debug` line, so the message is KEPT and only
+ * flattened. Listing it as a row with four inapplicable cases would say less
+ * than a block that states what it actually guarantees.
+ *
+ * The helper's own behaviour is fenced in
+ * `tests/unit/local/credential-error.test.ts`; this file asserts only that
+ * each site routes through it.
+ *
+ * # READ THIS BEFORE ADDING A SITE
+ *
+ * Two rules, both paid for rather than reasoned out in advance. Issue #579 ran
+ * four review rounds and a mutation probe after each; the probe found
+ * unfenced changes in THREE of them, every time in the same two shapes.
+ *
+ * 1. A `flattenToOneLine` call is NEVER covered incidentally. Nothing
+ *    exercises it unless a case deliberately feeds it a character to flatten,
+ *    so a flatten added without its own case is invisible to the entire suite
+ *    and free for the next editor to delete. Rounds 1, 2 and 3 each shipped
+ *    flattens that a revert left fully green — the role ARN, the
+ *    `PhysicalResourceId`, the request-derived S3 key, the KVS ARN, four more.
+ *
+ * 2. A newly-added `catch` is invisible to every case that does not make the
+ *    call FAIL. The same applies to a re-raise guard: if no case throws
+ *    cdk-local's own error INSIDE the guarded region, dropping the guard stays
+ *    green while the policy silently withholds text this repo wrote itself.
+ *
+ * Neither shape reads as missing in a diff review, which is why the mutation
+ * probe is the check and the reading is not. After adding a site, REVERT it and
+ * confirm its rows go red. A probe that comes back green is a finding.
+ */
+
+// --------------------------------------------------------------------------
+// SDK mocks — one `send` per package so a row can never be satisfied by
+// another row's rejection.
+// --------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  ssmSend: vi.fn(),
+  cfnSend: vi.fn(),
+  lambdaSend: vi.fn(),
+  agentCoreSend: vi.fn(),
+  secretsSend: vi.fn(),
+  s3Send: vi.fn(),
+  kvsSend: vi.fn(),
+  stsSend: vi.fn(),
+  ecrSend: vi.fn(),
+  sqsSend: vi.fn(),
+  /** `resolveDeployedKvsArnByName` paginates rather than `send`s. */
+  kvsListPages: vi.fn(),
+}));
+
+function clientClass(send: ReturnType<typeof vi.fn>) {
+  return class {
+    send = send;
+    destroy(): void {}
+  };
+}
+class AnyCommand {
+  constructor(public input?: unknown) {}
+}
+
+vi.mock('@aws-sdk/client-ssm', () => ({
+  SSMClient: clientClass(mocks.ssmSend),
+  GetParametersCommand: AnyCommand,
+  GetParameterCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: clientClass(mocks.cfnSend),
+  ListStackResourcesCommand: AnyCommand,
+  DescribeStacksCommand: AnyCommand,
+  ListExportsCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: clientClass(mocks.lambdaSend),
+  GetFunctionConfigurationCommand: AnyCommand,
+  GetLayerVersionCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-bedrock-agentcore-control', () => ({
+  BedrockAgentCoreControlClient: clientClass(mocks.agentCoreSend),
+  GetAgentRuntimeCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: clientClass(mocks.secretsSend),
+  GetSecretValueCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: clientClass(mocks.s3Send),
+  GetObjectCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-cloudfront-keyvaluestore', () => ({
+  CloudFrontKeyValueStoreClient: clientClass(mocks.kvsSend),
+  GetKeyCommand: AnyCommand,
+  // The real class, so `err instanceof ResourceNotFoundException` in
+  // `isKeyNotFound` stays a meaningful test rather than always false.
+  ResourceNotFoundException: class extends Error {},
+}));
+vi.mock('@aws-sdk/client-cloudfront', () => ({
+  CloudFrontClient: clientClass(vi.fn()),
+  // The lookup iterates rather than `send`s, so the seam is the paginator: it
+  // defers to `kvsListPages`, which a test can make throw.
+  paginateListKeyValueStores: (): AsyncIterable<unknown> => ({
+    async *[Symbol.asyncIterator]() {
+      yield (await mocks.kvsListPages()) as unknown;
+    },
+  }),
+}));
+vi.mock('@aws-sdk/signature-v4a', () => ({}));
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: clientClass(mocks.stsSend),
+  AssumeRoleCommand: AnyCommand,
+  GetCallerIdentityCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-ecr', () => ({
+  ECRClient: clientClass(mocks.ecrSend),
+  GetAuthorizationTokenCommand: AnyCommand,
+}));
+vi.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: clientClass(mocks.sqsSend),
+  SendMessageCommand: AnyCommand,
+}));
+
+const { resolveSsmParameters } = await import('../../../src/local/ssm-parameter-resolver.js');
+const { SSMClient } = await import('@aws-sdk/client-ssm');
+const { CfnLocalStateProvider } = await import('../../../src/local/cfn-local-state-provider.js');
+const { substituteAgainstStateAsync } = await import('../../../src/local/state-resolver.js');
+const { createS3OriginReader } = await import('../../../src/local/cloudfront-s3-origin.js');
+const { createDeployedKvsDataSource, resolveDeployedKvsArnByName } = await import(
+  '../../../src/local/cloudfront-kvs-client.js'
+);
+const { materializeLayerFromArn } = await import('../../../src/local/layer-arn-materializer.js');
+const { pullEcrImage, __resetStsCachesForTesting } = await import(
+  '../../../src/local/ecr-puller.js'
+);
+const { resolvePlaceholderAccountForTest } = await import(
+  '../../../src/cli/commands/local-run-task.js'
+);
+const { resolvePlaceholderAccountForTest: emulatorResolvePlaceholderAccount } = await import(
+  '../../../src/cli/commands/ecs-service-emulator.js'
+);
+const { resolveEcsSecrets } = await import('../../../src/local/ecs-secrets-resolver.js');
+const { downloadAndExtractS3Bundle } = await import('../../../src/local/agentcore-s3-bundle.js');
+const { dispatchServiceIntegration, _resetClientCacheForTest } = await import(
+  '../../../src/local/httpv2-service-integration.js'
+);
+
+// --------------------------------------------------------------------------
+// Fixtures — the same two populations #570 fenced, restated so this file is
+// readable on its own.
+// --------------------------------------------------------------------------
+
+const PASSPHRASE = 'hunter2-do-not-log';
+const CHAIN_MESSAGE =
+  `Command failed: /opt/bin/get-creds --vault-passphrase ${PASSPHRASE}\n` +
+  `  vault: unlocked with passphrase ${PASSPHRASE}`;
+/** Measured in `credential-error.test.ts`, restated so the expected line is literal. */
+const CHAIN_MESSAGE_LENGTH = 125;
+const WITHHELD = `CredentialsProviderError; ${CHAIN_MESSAGE_LENGTH}-character message withheld, logged at debug level under --verbose`;
+
+class CredentialsProviderError extends Error {
+  override name = 'CredentialsProviderError';
+}
+function chainError(): Error {
+  return new CredentialsProviderError(CHAIN_MESSAGE);
+}
+
+/** The service message that must KEEP printing: it is the diagnosis. */
+const SERVICE_MESSAGE = 'The security token included in the request is expired';
+
+/**
+ * A MODELED service exception. `$fault` + `$metadata` are set by the SDK from
+ * the HTTP RESPONSE, never from anything the body names, which is why they are
+ * the discriminator: a hostile endpoint can change `err.name` but cannot move a
+ * `credential_process` command line onto this branch.
+ */
+function serviceError(message: string, name = 'ExpiredTokenException'): Error {
+  const e = new Error(message);
+  Object.defineProperty(e, 'name', { value: name });
+  // 400 rather than 403 on purpose: `cloudfront-s3-origin`'s `classifyS3Error`
+  // routes a 403 (and the name `AccessDenied`) into its `denied` branch, which
+  // carries NO message at all -- so a 403 fixture would make that row assert
+  // against a line the site never renders. The status is incidental to what
+  // these rows fence; the branch it lands in is not.
+  return Object.assign(e, { $fault: 'client', $metadata: { httpStatusCode: 400 } });
+}
+function expiredTokenError(): Error {
+  return serviceError(SERVICE_MESSAGE);
+}
+/**
+ * A service exception whose wire-derived message carries a forged log line.
+ *
+ * Named `ThrottlingException` rather than the `AccessDenied` the #570 harness
+ * uses, for the same reason the status is 400: `classifyS3Error` special-cases
+ * that NAME into its message-less `denied` branch. What this fixture fences is
+ * the MESSAGE's newline; the forged-NAME half has its own case below.
+ */
+function forgedServiceError(): Error {
+  return serviceError('denied\nWARN: signature verified', 'ThrottlingException');
+}
+
+let warnLines: string[] = [];
+let debugLines: string[] = [];
+
+/** The one warn line whose text contains `needle`. */
+function warnContaining(needle: string): string {
+  const matches = warnLines.filter((l) => l.includes(needle));
+  expect(matches, `no warn line contained '${needle}' — the fixture did not reach the site`)
+    .toHaveLength(1);
+  return matches[0]!;
+}
+
+/** Run `fn` and return the message of whatever it throws. */
+async function thrownMessage(fn: () => Promise<unknown>): Promise<string> {
+  try {
+    await fn();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error('expected the site to throw, but it resolved');
+}
+
+// --------------------------------------------------------------------------
+// Site drivers
+// --------------------------------------------------------------------------
+
+const LAYER = {
+  arn: 'arn:aws:lambda:us-east-1:111122223333:layer:MyLayer:3',
+  name: 'MyLayer',
+  version: '3',
+  region: 'us-east-1',
+} as unknown as Parameters<typeof materializeLayerFromArn>[0];
+
+/** `resolveSsmParameters(client, refs, label)` — the SSM client is the mock. */
+function ssmClient(): Parameters<typeof resolveSsmParameters>[0] {
+  return new SSMClient({}) as Parameters<typeof resolveSsmParameters>[0];
+}
+const SSM_REFS = [
+  { logicalId: 'DbHost', ssmName: '/app/db-host', isList: false },
+] as unknown as Parameters<typeof resolveSsmParameters>[1];
+
+function importValueResolver(reject: () => Error): CrossStackResolver {
+  return {
+    resolveImport: async () => {
+      throw reject();
+    },
+    resolveGetStackOutput: async () => {
+      throw reject();
+    },
+  } as unknown as CrossStackResolver;
+}
+
+/**
+ * What a site actually put in front of the reader.
+ *
+ * `text` is the rendered relay. `code` is set only where the site splits the
+ * class name into its own field instead of prefixing it into the text — which
+ * is the httpv2 body and nothing else, since a log line has one field and a
+ * JSON body has two.
+ */
+interface Relayed {
+  text: string;
+  code?: string;
+}
+
+interface Site {
+  /** `<file>` / `<enclosing function>` — the identity of the occurrence. */
+  name: string;
+  /**
+   * The `operation` literal the site passes to `describeAwsFailureForWarn`,
+   * which is what its `debug` line is prefixed with. Asserted because a
+   * copy-pasted wrong label is otherwise undetectable: the user-visible line
+   * reads correctly and only the `debug` line names the wrong call.
+   */
+  operation: string;
+  /** A literal unique to THIS site's text, proving the fixture reached it. */
+  reached: string;
+  /**
+   * Does the KEPT-branch rendering carry the class name as a `<name>: ` prefix?
+   *
+   * True at every log-line site, because `describeAwsFailureForWarn` has one
+   * field to put both halves in. False at the httpv2 site alone, whose JSON
+   * body carries the name in `code`, so its `message` is the bare sanitized
+   * text — the asymmetry is real and is asserted rather than smoothed over,
+   * since smoothing it over is how a row stops testing its own site.
+   */
+  namePrefix: boolean;
+  /** Run the site with `err` as the SDK rejection; return what it rendered. */
+  drive: (err: unknown) => Promise<Relayed>;
+}
+
+const sites: Site[] = [
+  {
+    name: 'ssm-parameter-resolver.ts / resolveSsmParameters',
+    operation: 'SSM GetParameters',
+    reached: 'SSM GetParameters(/app/db-host) failed: ',
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.ssmSend.mockRejectedValue(err);
+      await resolveSsmParameters(ssmClient(), SSM_REFS, '--from-cfn-stack');
+      return { text: warnContaining('SSM GetParameters(/app/db-host) failed: ') };
+    },
+  },
+  {
+    name: 'cfn-local-state-provider.ts / resolveDeployedFunctionEnv',
+    operation: 'Lambda GetFunctionConfiguration',
+    reached: 'GetFunctionConfiguration(fn-physical-id) failed: ',
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.lambdaSend.mockRejectedValue(err);
+      const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+      await p.resolveDeployedFunctionEnv('fn-physical-id');
+      p.dispose();
+      return { text: warnContaining('GetFunctionConfiguration(fn-physical-id) failed: ') };
+    },
+  },
+  {
+    name: 'cfn-local-state-provider.ts / resolveLambdaExecutionRoleArn',
+    operation: 'Lambda GetFunctionConfiguration (--assume-role auto-resolve)',
+    reached: 'GetFunctionConfiguration(fn-role-id) for --assume-role auto-resolve failed: ',
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.lambdaSend.mockRejectedValue(err);
+      const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+      await p.resolveLambdaExecutionRoleArn('fn-role-id');
+      p.dispose();
+      return { text: warnContaining('GetFunctionConfiguration(fn-role-id) for --assume-role') };
+    },
+  },
+  {
+    name: 'cfn-local-state-provider.ts / resolveAgentCoreRuntimeRoleArn',
+    operation: 'bedrock-agentcore-control GetAgentRuntime (--assume-role auto-resolve)',
+    reached: 'GetAgentRuntime(agent-id) for --assume-role auto-resolve failed: ',
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.agentCoreSend.mockRejectedValue(err);
+      const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+      await p.resolveAgentCoreRuntimeRoleArn('agent-id');
+      p.dispose();
+      return { text: warnContaining('GetAgentRuntime(agent-id) for --assume-role') };
+    },
+  },
+  {
+    name: 'cfn-local-state-provider.ts / load (ListStackResources)',
+    operation: 'CloudFormation ListStackResources',
+    reached: 'ListStackResources(S) failed: ',
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.cfnSend.mockRejectedValue(err);
+      const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+      await p.load('S', undefined);
+      p.dispose();
+      return { text: warnContaining('ListStackResources(S) failed: ') };
+    },
+  },
+  {
+    name: 'cfn-local-state-provider.ts / load (DescribeStacks)',
+    operation: 'CloudFormation DescribeStacks',
+    reached: 'DescribeStacks(S) failed: ',
+    namePrefix: true,
+    drive: async (err) => {
+      // ListStackResources must SUCCEED so the fixture reaches the second call.
+      mocks.cfnSend.mockResolvedValueOnce({ StackResourceSummaries: [] }).mockRejectedValue(err);
+      const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+      await p.load('S', undefined);
+      p.dispose();
+      return { text: warnContaining('DescribeStacks(S) failed: ') };
+    },
+  },
+  {
+    name: 'cfn-local-state-provider.ts / buildCrossStackResolver (ListExports)',
+    operation: 'CloudFormation ListExports',
+    reached: 'ListExports (us-east-1) failed: ',
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.cfnSend.mockRejectedValue(err);
+      const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+      const resolver = await p.buildCrossStackResolver();
+      await resolver?.resolveImport('SomeExport');
+      p.dispose();
+      return { text: warnContaining('ListExports (us-east-1) failed: ') };
+    },
+  },
+  {
+    name: 'state-resolver.ts / Fn::ImportValue',
+    operation: 'CrossStackResolver.resolveImport (Fn::ImportValue)',
+    reached: "Fn::ImportValue 'X': lookup failed: ",
+    namePrefix: true,
+    drive: async (err) => {
+      const r = await substituteAgainstStateAsync(
+        { 'Fn::ImportValue': 'X' },
+        { resources: {}, crossStackResolver: importValueResolver(() => err as Error) }
+      );
+      expect(r.kind).toBe('unresolved');
+      return { text: r.kind === 'unresolved' ? r.reason : '' };
+    },
+  },
+  {
+    name: 'state-resolver.ts / Fn::GetStackOutput',
+    operation: 'CrossStackResolver.resolveGetStackOutput (Fn::GetStackOutput)',
+    reached: "Fn::GetStackOutput 'Other.Out' (us-east-1): lookup failed: ",
+    namePrefix: true,
+    drive: async (err) => {
+      const r = await substituteAgainstStateAsync(
+        {
+          'Fn::GetStackOutput': {
+            StackName: 'Other',
+            OutputName: 'Out',
+            Region: 'us-east-1',
+          },
+        },
+        { resources: {}, crossStackResolver: importValueResolver(() => err as Error) }
+      );
+      expect(r.kind).toBe('unresolved');
+      return { text: r.kind === 'unresolved' ? r.reason : '' };
+    },
+  },
+  {
+    name: 'cloudfront-s3-origin.ts / classifyS3Error (via the reader warn)',
+    operation: 'S3 GetObject',
+    reached: "S3 read of 'index.html' from bucket 'cdn-bucket' failed: ",
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.s3Send.mockRejectedValue(err);
+      const reader = createS3OriginReader('cdn-bucket');
+      await reader({ uri: '/index.html' });
+      await reader.close();
+      return { text: warnContaining("S3 read of 'index.html' from bucket 'cdn-bucket' failed: ") };
+    },
+  },
+  {
+    name: 'cloudfront-kvs-client.ts / createDeployedKvsDataSource.getValue',
+    operation: 'CloudFront KeyValueStore GetKey',
+    reached: "cf.kvs().get('theme') against arn:aws:cloudfront::1:key-value-store/s failed: ",
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.kvsSend.mockRejectedValue(err);
+      const src = createDeployedKvsDataSource({
+        kvsArn: 'arn:aws:cloudfront::1:key-value-store/s',
+      });
+      return { text: await thrownMessage(() => src.getValue('theme')) };
+    },
+  },
+  {
+    name: 'layer-arn-materializer.ts / assumeRoleForLayer',
+    operation: 'STS AssumeRole (--layer-role-arn)',
+    reached: `Layer ${LAYER.arn}: STS AssumeRole(arn:aws:iam::1:role/L) failed: `,
+    namePrefix: true,
+    drive: async (err) => ({
+      text: await thrownMessage(() =>
+        materializeLayerFromArn(LAYER, {
+          roleArn: 'arn:aws:iam::1:role/L',
+          stsClientFactory: () => ({
+            send: async () => {
+              throw err;
+            },
+          }),
+        })
+      ),
+    }),
+  },
+  {
+    name: 'layer-arn-materializer.ts / fetchLayerContentUrl',
+    operation: 'Lambda GetLayerVersion',
+    reached: `Layer ${LAYER.arn}: GetLayerVersion failed in region us-east-1: `,
+    namePrefix: true,
+    drive: async (err) => ({
+      text: await thrownMessage(() =>
+        materializeLayerFromArn(LAYER, {
+          lambdaClientFactory: () => ({
+            send: async () => {
+              throw err;
+            },
+          }),
+        })
+      ),
+    }),
+  },
+  {
+    name: 'ecr-puller.ts / assumeRoleForEcr',
+    operation: 'STS AssumeRole (ECR pull)',
+    reached: 'Failed to assume role arn:aws:iam::1:role/E for ECR pull: ',
+    namePrefix: true,
+    drive: async (err) => {
+      __resetStsCachesForTesting();
+      // GetCallerIdentity must SUCCEED so the fixture reaches the AssumeRole.
+      mocks.stsSend.mockResolvedValueOnce({ Account: '999988887777' }).mockRejectedValue(err);
+      return {
+        text: await thrownMessage(() =>
+          pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+            region: 'us-east-1',
+            ecrRoleArn: 'arn:aws:iam::1:role/E',
+          })
+        ),
+      };
+    },
+  },
+  {
+    name: 'ecs-secrets-resolver.ts / resolveSecretsManager',
+    operation: 'SecretsManager GetSecretValue',
+    reached:
+      "Failed to resolve Secrets Manager secret for container 'api' / env 'DB_PASSWORD' (arn:aws:secretsmanager:us-east-1:1:secret:db): ",
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.secretsSend.mockRejectedValue(err);
+      const text = await thrownMessage(() =>
+        resolveEcsSecrets(
+          [
+            {
+              containerName: 'api',
+              name: 'DB_PASSWORD',
+              valueFrom: 'arn:aws:secretsmanager:us-east-1:1:secret:db',
+            },
+          ],
+          { region: 'us-east-1' }
+        )
+      );
+      return { text };
+    },
+  },
+  {
+    name: 'ecs-secrets-resolver.ts / resolveSsm',
+    operation: 'SSM GetParameter (ECS secret)',
+    reached:
+      "Failed to resolve SSM parameter for container 'api' / env 'API_KEY' (/app/api-key): ",
+    namePrefix: true,
+    drive: async (err) => {
+      mocks.ssmSend.mockRejectedValue(err);
+      const text = await thrownMessage(() =>
+        resolveEcsSecrets(
+          [
+            {
+              containerName: 'api',
+              name: 'API_KEY',
+              valueFrom: 'arn:aws:ssm:us-east-1:1:parameter/app/api-key',
+            },
+          ],
+          { region: 'us-east-1' }
+        )
+      );
+      return { text };
+    },
+  },
+  {
+    name: 'httpv2-service-integration.ts / translateSdkError',
+    operation: 'SQS-SendMessage service integration',
+    /**
+     * Empty, and that is the honest value rather than a gap.
+     *
+     * Every other row's relay is embedded in a sentence the site wrote, so a
+     * literal from that sentence proves the fixture reached the intended
+     * `catch`. This site's relay is a JSON body FIELD, so there is no framing
+     * around it — `message` IS the rendering. Reaching the site is proved
+     * instead by `JSON.parse` succeeding on the body plus the fact that only
+     * `sqsSend` was made to reject.
+     *
+     * `drive` returns the PARSED `message`, not the raw body. Asserting
+     * `not.toContain('\n')` against the raw body would be vacuous, since
+     * `JSON.stringify` escapes a newline to the two characters `\` `n` and the
+     * check would pass on text that renders as two lines wherever the body is
+     * displayed.
+     */
+    reached: '',
+    // The body carries the class name in `code`, so `message` is the bare
+    // sanitized text. This is the only `false` in the table.
+    namePrefix: false,
+    drive: async (err) => {
+      _resetClientCacheForTest();
+      mocks.sqsSend.mockRejectedValue(err);
+      const res = await dispatchServiceIntegration(
+        'SQS-SendMessage',
+        { QueueUrl: 'https://sqs.us-east-1.amazonaws.com/1/q', MessageBody: 'hi' },
+        'us-east-1'
+      );
+      const parsed = JSON.parse(res.body ?? '') as { message: string; code: string };
+      return { text: parsed.message, code: parsed.code };
+    },
+  },
+];
+
+describe('#579 — no AWS SDK error message reaches a default-level line unfiltered', () => {
+  beforeEach(() => {
+    warnLines = [];
+    debugLines = [];
+    for (const m of Object.values(mocks)) m.mockReset();
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'debug').mockImplementation((m: string) => {
+      debugLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('covers every relay site the sweep found, with no row silently dropped', () => {
+    // A table driven off the source could not notice a site being DELETED from
+    // it, so the count is asserted against a literal, and the `operation`
+    // labels are asserted UNIQUE: each names a distinct AWS call, so a
+    // copy-pasted label is a real defect rather than a stylistic one. (The
+    // #570 harness deliberately allows shared `reached` literals across rows;
+    // here no two sites share text, so both keys are unique.)
+    expect(sites).toHaveLength(17);
+    expect(new Set(sites.map((s) => s.name)).size).toBe(17);
+    expect(new Set(sites.map((s) => s.operation)).size).toBe(17);
+    expect(new Set(sites.map((s) => s.reached)).size).toBe(17);
+    // Exactly one site splits the class name into its own field. If a second
+    // one ever does, the shared cases below need to say which — a silent
+    // second `false` would mean a row stopped asserting the name at all.
+    expect(sites.filter((s) => !s.namePrefix).map((s) => s.name)).toEqual([
+      'httpv2-service-integration.ts / translateSdkError',
+    ]);
+  });
+
+  describe.each(sites)('$name', (site) => {
+    it('withholds a credential-chain message and prints it at debug', async () => {
+      const { text } = await site.drive(chainError());
+
+      expect(text).toContain(`${site.reached}${WITHHELD}`);
+      expect(text).not.toContain(PASSPHRASE);
+      expect(text).not.toContain('Command failed');
+      expect(text).not.toContain('\n');
+
+      // Withheld is only acceptable while the text is in full at `debug`, and
+      // that line must name THIS call — a copy-pasted `operation` label is
+      // invisible in the user-visible line.
+      const debug = debugLines.filter((l) => l.includes(PASSPHRASE));
+      expect(debug).toHaveLength(1);
+      expect(debug[0]!).toContain(`${site.operation}: the AWS SDK's own failure message was:`);
+      // Flattened: the debug stream is the same stdout studio mirrors into an
+      // HTTP-served ring, so the two-line chain message must arrive as one.
+      expect(debug[0]!).not.toContain('\n');
+    });
+
+    it('keeps a modeled service exception message, which is the diagnosis', async () => {
+      const { text, code } = await site.drive(expiredTokenError());
+      const named = site.namePrefix ? 'ExpiredTokenException: ' : '';
+      expect(text).toContain(`${site.reached}${named}${SERVICE_MESSAGE}`);
+      // Where the name lives in its own field, assert it there instead — the
+      // name must survive SOMEWHERE, or the reader cannot tell what failed.
+      if (!site.namePrefix) expect(code).toBe('ExpiredTokenException');
+    });
+
+    it('flattens a forged newline inside a kept service message', async () => {
+      const { text } = await site.drive(forgedServiceError());
+      const named = site.namePrefix ? 'ThrottlingException: ' : '';
+      expect(text).toContain(`${site.reached}${named}denied WARN: signature verified`);
+      expect(text).not.toContain('\n');
+    });
+
+    it('clamps a forged wire-derived err.name', async () => {
+      // `err.name` is built from `x-amzn-errortype` with no length cap and no
+      // newline stripping, so it is the OTHER half of the forging surface —
+      // and the half these sites interpolated raw before #579.
+      const { text, code } = await site.drive(
+        serviceError('denied', 'Foo\nWARN: signature verified')
+      );
+      expect(text).toContain(`${site.reached}${site.namePrefix ? 'unknown: ' : ''}denied`);
+      expect(text).not.toContain('signature verified');
+      if (!site.namePrefix) expect(code).toBe('unknown');
+    });
+
+    it('withholds an unstringifiable throw rather than crashing the site', async () => {
+      // Reaches `stringifyThrown`'s `[unstringifiable throw]` fallback through
+      // a real call site: `String()` on a null-prototype object raises
+      // TypeError, and that throw escaping the `catch` would turn a
+      // warn-and-continue (or a clean error) into an unhandled failure.
+      const { text } = await site.drive(Object.create(null));
+      expect(text).toContain(`${site.reached}unknown; 23-character message withheld`);
+    });
+  });
+});
+
+/**
+ * Issue #579 — the SECOND wire-derived value on those same lines, and it is
+ * not the error half.
+ *
+ * `cfn-local-state-provider.ts` interpolates a resource's PHYSICAL ID into
+ * three warn templates. That id is copied out of `ListStackResources`'
+ * `PhysicalResourceId` with no validation at all, so it is exactly as
+ * endpoint-controlled as an error message — and it fires on a path where the
+ * SAME endpoint decides whether the follow-up call fails. A hijacked
+ * CloudFormation endpoint answering
+ * `PhysicalResourceId: "fn\nWARN: forged"` and then failing the
+ * `GetFunctionConfiguration` it also serves puts an attacker-chosen entry in
+ * the studio ring by the same mechanism the `Hint:` line the #570 lane closed.
+ *
+ * This block exists because a mutation probe that reverted the flatten left
+ * every case in the table above GREEN — the same way #570's role-ARN flatten shipped
+ * unfenced.
+ */
+describe('#579 — a forged newline in a physical id cannot forge a line either', () => {
+  const FORGED_ID = 'fn-physical-id\nWARN: signature verified';
+
+  beforeEach(() => {
+    warnLines = [];
+    for (const m of Object.values(mocks)) m.mockReset();
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const idSites: { name: string; drive: () => Promise<void> }[] = [
+    {
+      name: 'resolveDeployedFunctionEnv',
+      drive: async () => {
+        mocks.lambdaSend.mockRejectedValue(new Error('boom'));
+        const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+        await p.resolveDeployedFunctionEnv(FORGED_ID);
+        p.dispose();
+      },
+    },
+    {
+      name: 'resolveLambdaExecutionRoleArn',
+      drive: async () => {
+        mocks.lambdaSend.mockRejectedValue(new Error('boom'));
+        const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+        await p.resolveLambdaExecutionRoleArn(FORGED_ID);
+        p.dispose();
+      },
+    },
+    {
+      name: 'resolveAgentCoreRuntimeRoleArn',
+      drive: async () => {
+        mocks.agentCoreSend.mockRejectedValue(new Error('boom'));
+        const p = new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+        await p.resolveAgentCoreRuntimeRoleArn(FORGED_ID);
+        p.dispose();
+      },
+    },
+  ];
+
+  it('covers all three physical-id-quoting sites', () => {
+    expect(idSites).toHaveLength(3);
+  });
+
+  describe.each(idSites)('$name', (site) => {
+    it('flattens the id, keeping every character on one line', async () => {
+      await site.drive();
+
+      const matches = warnLines.filter((l) => l.includes('WARN: signature verified'));
+      expect(matches, 'the forged id never reached a warn line at all').toHaveLength(1);
+      const line = matches[0]!;
+      // Every character survives -- only the break became a space, so the id is
+      // still recognisable to whoever has to debug it.
+      expect(line).toContain('fn-physical-id WARN: signature verified');
+      expect(line).not.toContain('\n');
+    });
+  });
+});
+
+/**
+ * Issue #579 — the httpv2 site is the only one whose output crosses a PROCESS
+ * boundary: it is a served HTTP response body, not a log line. So it carries a
+ * second obligation the log sites do not have, and this block is that
+ * obligation stated as cases rather than as prose: sanitizing the WIRE-derived
+ * half must not touch cdk-local's OWN text, and must not reshape the body.
+ *
+ * `requireParams`' 400 is the one that would have regressed. Before #579 it
+ * threw an anonymous `Error` carrying a `statusCode`, which fell through the
+ * SDK branch — so the credential-error policy, applied to that branch, would
+ * have withheld a message cdk-local wrote itself and turned an actionable 400
+ * into a class name and a character count.
+ */
+describe('#579 — the httpv2 body sanitizes wire text only, and keeps its shape', () => {
+  beforeEach(() => {
+    for (const m of Object.values(mocks)) m.mockReset();
+    vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("relays requireParams' 400 byte-identically, with the code field kept", async () => {
+    _resetClientCacheForTest();
+    const res = await dispatchServiceIntegration(
+      'SQS-SendMessage',
+      // `MessageBody` missing => the cdk-local-authored 400.
+      { QueueUrl: 'https://sqs.us-east-1.amazonaws.com/1/q' },
+      'us-east-1'
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body ?? '')).toEqual({
+      message: 'missing required RequestParameter(s): MessageBody',
+      code: 'ServiceIntegrationRequestError',
+    });
+    // It never reached the SDK, so nothing was withheld on the way.
+    expect(mocks.sqsSend).not.toHaveBeenCalled();
+  });
+
+  it('relays the no-region 400 byte-identically (raised before the guarded try)', async () => {
+    _resetClientCacheForTest();
+    const res = await dispatchServiceIntegration('SQS-SendMessage', { Region: '  ' }, '  ');
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body ?? '')).toEqual({
+      message:
+        "No AWS region configured. Set --region, AWS_REGION, or pass a 'Region' RequestParameter.",
+    });
+  });
+
+  it('keeps the SDK branch status code, which is what the integ fixture asserts', async () => {
+    // `tests/integration/local-start-api/verify.sh` accepts ANY status other
+    // than 501 on POST /sqs and only greps the body for the deferred-501
+    // marker. #579 changed `message` / `code` and NOTHING about `statusCode`,
+    // and this pins that so the fixture cannot be broken from here.
+    _resetClientCacheForTest();
+    mocks.sqsSend.mockRejectedValue(serviceError('The queue does not exist.', 'QueueDoesNotExist'));
+    const res = await dispatchServiceIntegration(
+      'SQS-SendMessage',
+      { QueueUrl: 'https://sqs.us-east-1.amazonaws.com/1/q', MessageBody: 'hi' },
+      'us-east-1'
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.body).not.toContain('Not Implemented');
+    // `message` is the BARE sanitized text: this body carries the class name
+    // in `code`, so prefixing it into `message` too would both duplicate it and
+    // change what a client parsing `message` reads (review round 2).
+    expect(JSON.parse(res.body ?? '')).toEqual({
+      message: 'The queue does not exist.',
+      code: 'QueueDoesNotExist',
+    });
+  });
+
+  it('defaults to 500 for a transport failure and withholds its message', async () => {
+    // The shape the integ fixture actually produces: it POSTs to
+    // `https://sqs.invalid.example/q`, so the SDK fails to RESOLVE the host.
+    // That is a plain `Error` with no `$fault`, i.e. the withheld branch — and
+    // the status is unchanged at 500, which is what keeps the fixture green.
+    _resetClientCacheForTest();
+    const dns = new Error('getaddrinfo ENOTFOUND sqs.invalid.example');
+    Object.assign(dns, { code: 'ENOTFOUND' });
+    mocks.sqsSend.mockRejectedValue(dns);
+    const res = await dispatchServiceIntegration(
+      'SQS-SendMessage',
+      { QueueUrl: 'https://sqs.invalid.example/q', MessageBody: 'hi' },
+      'us-east-1'
+    );
+    expect(res.statusCode).toBe(500);
+    expect(res.body).not.toContain('Not Implemented');
+    expect(res.body).not.toContain('sqs.invalid.example');
+    // `clampErrorCode` keeps a bare identifier, so the reader still learns it
+    // was a DNS failure rather than a misconfiguration.
+    expect(JSON.parse(res.body ?? '')).toEqual({
+      message:
+        'Error ENOTFOUND; 41-character message withheld, logged at debug level under --verbose',
+      code: 'Error',
+    });
+  });
+});
+
+/**
+ * Issue #579 review round 2 — three changes that had NO covering assertion.
+ *
+ * Each was found the same way the PhysicalResourceId flatten was: revert it,
+ * and the whole suite stays green. A change nothing asserts is a change the
+ * next editor may undo for free, which is the failure mode this file exists to
+ * prevent, so a probe that comes back all-green is a finding rather than a
+ * pass.
+ */
+describe('#579 — the three changes that shipped unfenced in round 1', () => {
+  beforeEach(() => {
+    debugLines = [];
+    for (const m of Object.values(mocks)) m.mockReset();
+    vi.spyOn(getLogger(), 'debug').mockImplementation((m: string) => {
+      debugLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('cloudfront-kvs-client.ts / resolveDeployedKvsArnByName (the debug relay)', () => {
+    /**
+     * NOT a `sites` row, and the header says why: this line is `debug`, so the
+     * message is KEPT rather than withheld and four of the table's five cases
+     * would not apply. What it must still do is FLATTEN — the `debug` stream is
+     * the same stdout `cdkl studio` mirrors into an HTTP-served ring — and
+     * survive an unstringifiable throw, because the whole point of the `catch`
+     * is that a lookup miss falls back to the unbound-KVS path.
+     */
+    async function driveLookup(err: unknown): Promise<{ arn: string } | undefined> {
+      mocks.kvsListPages.mockImplementation(() => {
+        throw err;
+      });
+      return resolveDeployedKvsArnByName('store-name');
+    }
+
+    it('keeps the message (it is debug) but flattens it onto one line', async () => {
+      await driveLookup(new Error('AccessDenied\nServer listening on http://attacker.example/'));
+      const line = debugLines.find((l) => l.includes("ListKeyValueStores lookup for 'store-name'"));
+      expect(line, 'the fixture did not reach the debug relay').toBeDefined();
+      // Kept in full — nothing is withheld at `debug`.
+      expect(line).toContain('Server listening on http://attacker.example/');
+      // But flattened: one emitted line, so it cannot forge a second one in
+      // the studio ring under `--verbose`.
+      expect(line).not.toContain('\n');
+      expect(line).toContain('AccessDenied Server listening on');
+    });
+
+    it('survives an unstringifiable throw instead of escaping the catch', async () => {
+      // The pre-#579 spelling was `String(err)`, which THROWS on a
+      // null-prototype object ("Cannot convert object to primitive value").
+      // That throw would escape this best-effort `catch` and turn a
+      // fall-back-to-unbound-KVS into a hard failure.
+      await expect(driveLookup(Object.create(null))).resolves.toBeUndefined();
+      const line = debugLines.find((l) => l.includes("ListKeyValueStores lookup for 'store-name'"));
+      expect(line).toContain('[unstringifiable throw]');
+    });
+
+    it('resolves undefined so the caller still falls back to the unbound path', async () => {
+      await expect(driveLookup(new Error('boom'))).resolves.toBeUndefined();
+    });
+  });
+
+  describe('httpv2-service-integration.ts / the NON-OBJECT throw branch', () => {
+    it('withholds a bare string throw from the served response body', async () => {
+      // `throw 'x'` skips the object branch entirely and lands on
+      // `errorResponse(500, ...)`, which used to interpolate `String(err)`.
+      // This is a RESPONSE BODY, so the text leaves the process.
+      _resetClientCacheForTest();
+      mocks.sqsSend.mockRejectedValue(`nope\nWARN: forged ${PASSPHRASE}`);
+      const res = await dispatchServiceIntegration(
+        'SQS-SendMessage',
+        { QueueUrl: 'https://sqs.us-east-1.amazonaws.com/1/q', MessageBody: 'hi' },
+        'us-east-1'
+      );
+      expect(res.statusCode).toBe(500);
+      const parsed = JSON.parse(res.body ?? '') as { message: string };
+      expect(parsed.message).toContain('Unexpected error invoking SQS-SendMessage: ');
+      expect(parsed.message).not.toContain(PASSPHRASE);
+      expect(parsed.message).not.toContain('WARN: forged');
+      // A bare string names no class, so the clamp reports `unknown` rather
+      // than inventing one.
+      expect(parsed.message).toContain('unknown; ');
+      expect(parsed.message).toContain('message withheld');
+    });
+  });
+
+  describe('layer-arn-materializer.ts / AssumeRole returned no Credentials', () => {
+    it("keeps cdk-local's own text AND the site's framing", async () => {
+      // Its twin (`GetLayerVersion response did not include Content.Location`)
+      // was fenced in round 1; this one was not. Both regressed the same way:
+      // round 1 re-raised them BARE, dropping the `Layer <arn>: <call> failed:
+      // ... <remedy>` envelope. The existing tests substring-match the inner
+      // sentence, so nothing went red.
+      const message = await thrownMessage(() =>
+        materializeLayerFromArn(LAYER, {
+          roleArn: 'arn:aws:iam::1:role/L',
+          // A response with no `Credentials` — cdk-local's own guard fires.
+          stsClientFactory: () => ({ send: async () => ({}) }),
+        })
+      );
+      expect(message).toBe(
+        `Layer ${LAYER.arn}: STS AssumeRole(arn:aws:iam::1:role/L) failed: ` +
+          'AssumeRole returned no Credentials. ' +
+          'Check the role trust policy permits your principal and sts:AssumeRole is allowed.'
+      );
+    });
+
+    it("keeps the Content.Location guard's framing too (its fenced twin)", async () => {
+      const message = await thrownMessage(() =>
+        materializeLayerFromArn(LAYER, {
+          lambdaClientFactory: () => ({ send: async () => ({ Content: {} }) }),
+        })
+      );
+      expect(message).toBe(
+        `Layer ${LAYER.arn}: GetLayerVersion failed in region us-east-1: ` +
+          'GetLayerVersion response did not include Content.Location (presigned ZIP URL).'
+      );
+    });
+
+    it('still passes an ALREADY-FRAMED throw through untouched', async () => {
+      // The ARN-shape guard frames itself and fires before any AWS call, so
+      // wrapping it would double the `Layer <arn>:` prefix and prepend
+      // `GetLayerVersion failed` to a failure where no call was made.
+      const message = await thrownMessage(() =>
+        materializeLayerFromArn(
+          { ...LAYER, arn: 'arn:aws:lambda:us-east-1:111122223333:layer:MyLayer' },
+          { lambdaClientFactory: () => ({ send: async () => ({}) }) }
+        )
+      );
+      // Pinned as an EXACT string, because this is an observable behaviour
+      // change and the PR body quotes it. On `main` the same input rendered
+      // DOUBLE-framed — `Layer <arn>: GetLayerVersion failed in region <r>:
+      // Layer <arn>: not a layer-version ARN ... .` with a doubled full stop —
+      // because the guard's own framed message was wrapped again by the site.
+      expect(message).toBe(
+        'Layer arn:aws:lambda:us-east-1:111122223333:layer:MyLayer: ' +
+          "not a layer-version ARN (no ':<version>' suffix to strip). " +
+          'Expected arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>.'
+      );
+      expect(message).not.toContain('GetLayerVersion failed in region');
+    });
+  });
+});
+
+/**
+ * Issue #579 review round 2 — the SECOND unfenced sweep.
+ *
+ * Round 2 fixed a blocker, two flatten sites and four nits, and a probe run
+ * over the whole round found SIX of them green when reverted: the same result
+ * the PhysicalResourceId flatten gave in round 1, from the same cause. A
+ * flatten is invisible to every assertion that does not deliberately feed it a
+ * character to flatten, and a new `catch` is invisible to every assertion that
+ * does not deliberately make the call fail. Neither shows up in a diff review
+ * as missing, which is why the probe is the check and not the reading.
+ */
+describe('#579 round 2 — the fixes that a probe found unfenced', () => {
+  beforeEach(() => {
+    warnLines = [];
+    debugLines = [];
+    for (const m of Object.values(mocks)) m.mockReset();
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'debug').mockImplementation((m: string) => {
+      debugLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('BLOCKER — agentcore-s3-bundle.ts / defaultFetchObject', () => {
+    /**
+     * The site the sweep first mis-triaged. Its `try` wrapped `client.send` in
+     * a `finally` with NO `catch`, so the raw SDK error propagated to
+     * `withErrorHandling` -> `formatError`, which prints
+     * `${error.name}: ${error.message}` unflattened and unclamped at DEFAULT
+     * level. Being outside the unzip `catch` made it UNCOVERED, not out of
+     * scope.
+     */
+    it('withholds a credential-chain failure instead of letting it reach formatError', async () => {
+      mocks.s3Send.mockRejectedValue(chainError());
+      const message = await thrownMessage(() =>
+        downloadAndExtractS3Bundle({ bucket: 'bkt', key: 'bundle.zip' })
+      );
+      expect(message).toContain('S3 GetObject for s3://bkt/bundle.zip failed: ');
+      expect(message).toContain(WITHHELD);
+      expect(message).not.toContain(PASSPHRASE);
+      expect(message).not.toContain('Command failed');
+      expect(message).not.toContain('\n');
+      // And the withheld text is recoverable, naming this call.
+      const debug = debugLines.filter((l) => l.includes(PASSPHRASE));
+      expect(debug).toHaveLength(1);
+      expect(debug[0]!).toContain(
+        "S3 GetObject (fromS3 bundle): the AWS SDK's own failure message was:"
+      );
+    });
+
+    it('keeps a modeled S3 exception message and clamps its forged name', async () => {
+      mocks.s3Send.mockRejectedValue(serviceError('The key does not exist.', 'NoSuchKey'));
+      expect(
+        await thrownMessage(() => downloadAndExtractS3Bundle({ bucket: 'bkt', key: 'k.zip' }))
+      ).toContain('failed: NoSuchKey: The key does not exist.');
+
+      mocks.s3Send.mockRejectedValue(serviceError('denied', 'Foo\nWARN: signature verified'));
+      const forged = await thrownMessage(() =>
+        downloadAndExtractS3Bundle({ bucket: 'bkt', key: 'k.zip' })
+      );
+      expect(forged).toContain('failed: unknown: denied');
+      expect(forged).not.toContain('signature verified');
+    });
+
+    it("re-raises cdk-local's own empty-body throw intact", async () => {
+      // It fires INSIDE the same `try`, so without the re-raise guard the
+      // policy would withhold a message cdk-local wrote itself.
+      mocks.s3Send.mockResolvedValue({});
+      expect(
+        await thrownMessage(() => downloadAndExtractS3Bundle({ bucket: 'bkt', key: 'k.zip' }))
+      ).toBe('S3 GetObject for s3://bkt/k.zip returned an empty body.');
+    });
+  });
+
+  describe('BLOCKER — cloudfront-s3-origin.ts / the REQUEST-derived key', () => {
+    // The most reachable forged-line vector in the sweep: `uriToKey` runs
+    // `decodeURIComponentSafe` over the request URI, so this needs no
+    // credentials, no hostile AWS endpoint and no `--verbose` — just an HTTP
+    // client that can reach the served port.
+    const FORGED_URI = '/%0AWARN:%20signature%20verified';
+
+    it('flattens the key on the read-failure warn', async () => {
+      mocks.s3Send.mockRejectedValue(serviceError('boom', 'InternalError'));
+      const reader = createS3OriginReader('cdn-bucket');
+      await reader({ uri: FORGED_URI });
+      await reader.close();
+      const line = warnContaining('signature verified');
+      expect(line).toContain("S3 read of ' WARN: signature verified'");
+      expect(line).not.toContain('\n');
+    });
+
+    it('flattens the key on the access-denied warn', async () => {
+      mocks.s3Send.mockRejectedValue(serviceError('nope', 'AccessDenied'));
+      const reader = createS3OriginReader('cdn-bucket');
+      await reader({ uri: FORGED_URI });
+      await reader.close();
+      const line = warnContaining('signature verified');
+      expect(line).toContain("S3 denied reading ' WARN: signature verified'");
+      expect(line).not.toContain('\n');
+    });
+
+    it('flattens the custom-error page key too', async () => {
+      // The primary key must MISS (404) so the reader falls through to the
+      // `CustomErrorResponses` candidate, and that read must then be DENIED so
+      // the warn under test fires (a plain miss on the error page is silent).
+      mocks.s3Send
+        .mockRejectedValueOnce(serviceError('gone', 'NoSuchKey'))
+        .mockRejectedValue(serviceError('nope', 'AccessDenied'));
+      const reader = createS3OriginReader('cdn-bucket');
+      await reader({
+        uri: '/ok.html',
+        customErrorResponses: [
+          {
+            errorCode: 404,
+            responseCode: 200,
+            responsePagePath: '/spa\nWARN: signature verified',
+          },
+        ] as unknown as Parameters<typeof reader>[0]['customErrorResponses'],
+      });
+      await reader.close();
+      const line = warnContaining("custom-error page 'spa WARN: signature verified'");
+      expect(line).not.toContain('\n');
+    });
+  });
+
+  describe('NIT — the wire-derived values on default-level lines', () => {
+    const FORGED_ARN = 'arn:aws:iam::1:role/x\nWARN: signature verified';
+
+    it('ecr-puller.ts flattens the role ARN', async () => {
+      __resetStsCachesForTesting();
+      mocks.stsSend
+        .mockResolvedValueOnce({ Account: '999988887777' })
+        .mockRejectedValue(new Error('boom'));
+      const message = await thrownMessage(() =>
+        pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+          region: 'us-east-1',
+          ecrRoleArn: FORGED_ARN,
+        })
+      );
+      expect(message).toContain('assume role arn:aws:iam::1:role/x WARN: signature verified');
+      expect(message).not.toContain('\n');
+    });
+
+    it('layer-arn-materializer.ts flattens the role ARN', async () => {
+      const message = await thrownMessage(() =>
+        materializeLayerFromArn(LAYER, {
+          roleArn: FORGED_ARN,
+          stsClientFactory: () => ({
+            send: async () => {
+              throw new Error('boom');
+            },
+          }),
+        })
+      );
+      expect(message).toContain('STS AssumeRole(arn:aws:iam::1:role/x WARN: signature verified)');
+      expect(message).not.toContain('\n');
+    });
+
+    it("layer-arn-materializer.ts flattens the presigned host's HTTP reason phrase", async () => {
+      // `statusText` is chosen by the presigned host. The HTTP parser forbids
+      // CR/LF there, so the fixture uses U+2028 and an ANSI escape — the two
+      // the protocol does NOT stop, and which still break a line in the studio
+      // UI's `<pre>` and in a terminal respectively.
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden\u2028WARN: signature verified\u001b[0m',
+      })) as unknown as typeof globalThis.fetch;
+      try {
+        const message = await thrownMessage(() =>
+          materializeLayerFromArn(LAYER, {
+            lambdaClientFactory: () => ({
+              send: async () => ({ Content: { Location: 'https://presigned.example/zip' } }),
+            }),
+          })
+        );
+        expect(message).toContain('HTTP 403 Forbidden WARN: signature verified');
+        expect(message).not.toContain('\u2028');
+        expect(message).not.toContain('\u001b');
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    });
+
+    it('httpv2 range-guards $metadata.httpStatusCode before it becomes res.statusCode', async () => {
+      // `decorateServiceException` copies parsed response-body keys onto the
+      // exception, so a non-integer here is reachable — and it would raise
+      // `ERR_HTTP_INVALID_STATUS_CODE` on a real `http.ServerResponse`, taking
+      // the request handler down instead of answering.
+      _resetClientCacheForTest();
+      const weird = new Error('boom');
+      Object.assign(weird, { $fault: 'client', $metadata: { httpStatusCode: '500\nWARN: x' } });
+      const res = await dispatchServiceIntegration(
+        'SQS-SendMessage',
+        { QueueUrl: 'https://sqs.us-east-1.amazonaws.com/1/q', MessageBody: 'hi' },
+        'us-east-1'
+      );
+      expect(typeof res.statusCode).toBe('number');
+      expect(Number.isInteger(res.statusCode)).toBe(true);
+      mocks.sqsSend.mockRejectedValue(weird);
+      const res2 = await dispatchServiceIntegration(
+        'SQS-SendMessage',
+        { QueueUrl: 'https://sqs.us-east-1.amazonaws.com/1/q', MessageBody: 'hi' },
+        'us-east-1'
+      );
+      expect(res2.statusCode).toBe(500);
+    });
+  });
+});
+
+/**
+ * Issue #579 review round 3 — the sites the DERIVED population found.
+ *
+ * Rounds 1 and 2 swept the list issue #579 enumerated. That list was an INPUT,
+ * not the population: the population is "every AWS SDK `.send(...)` whose
+ * failure can reach a default-level line", and deriving it (brace-matched
+ * `try` regions across `src/**`, then a caller check on every unguarded hit)
+ * turned up three more instances of the SAME `try { send } finally { destroy }`
+ * shape whose mis-triage `agentcore-s3-bundle.ts` documents at length —
+ * including the `GetCallerIdentity` call issue #570 had already guarded at five
+ * OTHER sites.
+ *
+ * The lesson is in the method, not the count: an enumerated list cannot tell
+ * you what it left out, and a shape this uniform is derivable.
+ */
+describe('#579 round 3 — the catch-less sends the derived population found', () => {
+  beforeEach(() => {
+    debugLines = [];
+    for (const m of Object.values(mocks)) m.mockReset();
+    vi.spyOn(getLogger(), 'debug').mockImplementation((m: string) => {
+      debugLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('ecr-puller.ts / pullEcrImage (STS GetCallerIdentity)', () => {
+    // The most reachable of the three: no `--assume-role`, no `--ecr-role-arn`,
+    // just a deployed-image pull on the default credential chain.
+    it('withholds a credential-chain failure and names the call at debug', async () => {
+      __resetStsCachesForTesting();
+      mocks.stsSend.mockRejectedValue(chainError());
+      const message = await thrownMessage(() =>
+        pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+          region: 'us-east-1',
+        })
+      );
+      expect(message).toContain('STS GetCallerIdentity failed while preparing the ECR pull: ');
+      expect(message).toContain(WITHHELD);
+      expect(message).not.toContain(PASSPHRASE);
+      expect(message).not.toContain('\n');
+      const debug = debugLines.filter((l) => l.includes(PASSPHRASE));
+      expect(debug).toHaveLength(1);
+      expect(debug[0]!).toContain(
+        "STS GetCallerIdentity (ECR pull): the AWS SDK's own failure message was:"
+      );
+    });
+
+    it('keeps a modeled STS exception and clamps a forged name', async () => {
+      __resetStsCachesForTesting();
+      mocks.stsSend.mockRejectedValue(expiredTokenError());
+      expect(
+        await thrownMessage(() =>
+          pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+            region: 'us-east-1',
+          })
+        )
+      ).toContain(`ExpiredTokenException: ${SERVICE_MESSAGE}`);
+
+      __resetStsCachesForTesting();
+      mocks.stsSend.mockRejectedValue(serviceError('denied', 'Foo\nWARN: signature verified'));
+      const forged = await thrownMessage(() =>
+        pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+          region: 'us-east-1',
+        })
+      );
+      expect(forged).toContain('unknown: denied');
+      expect(forged).not.toContain('signature verified');
+    });
+
+    it("re-raises cdk-local's own no-Account throw intact", async () => {
+      __resetStsCachesForTesting();
+      mocks.stsSend.mockResolvedValue({});
+      expect(
+        await thrownMessage(() =>
+          pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+            region: 'us-east-1',
+          })
+        )
+      ).toBe('STS GetCallerIdentity returned no Account. Verify your AWS credentials.');
+    });
+  });
+
+  describe('ecr-puller.ts / ecrLogin (ECR GetAuthorizationToken)', () => {
+    it('withholds a credential-chain failure from the login step', async () => {
+      __resetStsCachesForTesting();
+      // GetCallerIdentity succeeds so the fixture reaches the ECR client.
+      mocks.stsSend.mockResolvedValue({ Account: '111122223333' });
+      mocks.ecrSend.mockRejectedValue(chainError());
+      const message = await thrownMessage(() =>
+        pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+          region: 'us-east-1',
+        })
+      );
+      expect(message).toContain(
+        'ECR GetAuthorizationToken failed (account=111122223333, region=us-east-1): '
+      );
+      expect(message).toContain(WITHHELD);
+      expect(message).not.toContain(PASSPHRASE);
+      expect(message).not.toContain('\n');
+    });
+
+    it('keeps a modeled ECR exception message', async () => {
+      __resetStsCachesForTesting();
+      mocks.stsSend.mockResolvedValue({ Account: '111122223333' });
+      mocks.ecrSend.mockRejectedValue(serviceError('not authorized', 'AccessDeniedException'));
+      expect(
+        await thrownMessage(() =>
+          pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+            region: 'us-east-1',
+          })
+        )
+      ).toContain('AccessDeniedException: not authorized');
+    });
+  });
+
+  describe('ecs-service-emulator.ts / resolvePlaceholderAccount (STS GetCallerIdentity)', () => {
+    // The sixth and last site of the derived population, and the exact twin of
+    // `local-run-task.ts`'s below. Deferred ONE round only because PR #610 held
+    // this file; it lands in the same PR rather than as a follow-up.
+    const PLACEHOLDER_ARN = 'arn:aws:iam::${AWS::AccountId}:role/TaskRole';
+
+    it('withholds a credential-chain failure and names the call at debug', async () => {
+      mocks.stsSend.mockRejectedValue(chainError());
+      const message = await thrownMessage(() =>
+        emulatorResolvePlaceholderAccount(PLACEHOLDER_ARN, 'us-east-1', undefined)
+      );
+      expect(message).toContain('STS GetCallerIdentity failed while resolving placeholder ARN');
+      expect(message).toContain(WITHHELD);
+      expect(message).not.toContain(PASSPHRASE);
+      expect(message).not.toContain('\n');
+      const debug = debugLines.filter((l) => l.includes(PASSPHRASE));
+      expect(debug).toHaveLength(1);
+      expect(debug[0]!).toContain(
+        "STS GetCallerIdentity (task-role placeholder): the AWS SDK's own failure message was:"
+      );
+    });
+
+    it('keeps a modeled STS exception message', async () => {
+      mocks.stsSend.mockRejectedValue(expiredTokenError());
+      expect(
+        await thrownMessage(() =>
+          emulatorResolvePlaceholderAccount(PLACEHOLDER_ARN, 'us-east-1', undefined)
+        )
+      ).toContain(`ExpiredTokenException: ${SERVICE_MESSAGE}`);
+    });
+
+    it("re-raises cdk-local's own no-Account throw intact", async () => {
+      mocks.stsSend.mockResolvedValue({});
+      const message = await thrownMessage(() =>
+        emulatorResolvePlaceholderAccount(PLACEHOLDER_ARN, 'us-east-1', undefined)
+      );
+      expect(message).toContain('GetCallerIdentity returned no Account');
+      // The relay's framing must NOT be layered on top of it.
+      expect(message).not.toContain('STS GetCallerIdentity failed while resolving');
+    });
+
+    it('carries the same remedy its run-task twin does', async () => {
+      // Called "the exact twin" of `local-run-task.ts`'s site, and it dropped
+      // the remedy that BOTH the twin and this function's own in-`try` throw
+      // carry — so a user hitting the relay path got no way forward while the
+      // adjacent path told them exactly what to do.
+      mocks.stsSend.mockRejectedValue(new Error('boom'));
+      expect(
+        await thrownMessage(() =>
+          emulatorResolvePlaceholderAccount(PLACEHOLDER_ARN, 'us-east-1', undefined)
+        )
+      ).toContain('Pass the ARN explicitly: --assume-task-role <arn>');
+    });
+
+    it('flattens a forged newline in the placeholder ARN', async () => {
+      mocks.stsSend.mockRejectedValue(new Error('boom'));
+      const message = await thrownMessage(() =>
+        emulatorResolvePlaceholderAccount(
+          'arn:aws:iam::${AWS::AccountId}:role/x\nWARN: signature verified',
+          'us-east-1',
+          undefined
+        )
+      );
+      expect(message).toContain('role/x WARN: signature verified');
+      expect(message).not.toContain('\n');
+    });
+  });
+
+  describe('local-run-task.ts / resolvePlaceholderAccount (STS GetCallerIdentity)', () => {
+    const PLACEHOLDER_ARN = 'arn:aws:iam::${AWS::AccountId}:role/TaskRole';
+
+    it('withholds a credential-chain failure and names the call at debug', async () => {
+      mocks.stsSend.mockRejectedValue(chainError());
+      const message = await thrownMessage(() =>
+        resolvePlaceholderAccountForTest(PLACEHOLDER_ARN, 'us-east-1', undefined)
+      );
+      expect(message).toContain('STS GetCallerIdentity failed while resolving placeholder ARN');
+      expect(message).toContain(WITHHELD);
+      expect(message).not.toContain(PASSPHRASE);
+      expect(message).not.toContain('\n');
+      // The remedy still reaches the user — withholding the SDK's text must not
+      // take cdk-local's own guidance with it.
+      expect(message).toContain('Pass the ARN explicitly: --assume-task-role <arn>');
+      const debug = debugLines.filter((l) => l.includes(PASSPHRASE));
+      expect(debug).toHaveLength(1);
+      expect(debug[0]!).toContain(
+        "STS GetCallerIdentity (task-role placeholder): the AWS SDK's own failure message was:"
+      );
+    });
+
+    it('keeps a modeled STS exception message', async () => {
+      mocks.stsSend.mockRejectedValue(expiredTokenError());
+      expect(
+        await thrownMessage(() =>
+          resolvePlaceholderAccountForTest(PLACEHOLDER_ARN, 'us-east-1', undefined)
+        )
+      ).toContain(`ExpiredTokenException: ${SERVICE_MESSAGE}`);
+    });
+
+    it("re-raises cdk-local's own no-Account throw intact", async () => {
+      mocks.stsSend.mockResolvedValue({});
+      expect(
+        await thrownMessage(() =>
+          resolvePlaceholderAccountForTest(PLACEHOLDER_ARN, 'us-east-1', undefined)
+        )
+      ).toContain('GetCallerIdentity returned no Account');
+    });
+
+    it('passes a placeholder-free ARN through without any AWS call', async () => {
+      await expect(
+        resolvePlaceholderAccountForTest('arn:aws:iam::1:role/Plain', 'us-east-1', undefined)
+      ).resolves.toBe('arn:aws:iam::1:role/Plain');
+      expect(mocks.stsSend).not.toHaveBeenCalled();
+    });
+  });
+});
+
+/**
+ * Issue #579 review round 3 — the flatten/shape fixes, fenced.
+ *
+ * Third round, third all-green probe on the round's own flattens. The pattern
+ * is now established well enough to state as a rule: a `flattenToOneLine` call
+ * is invisible to every assertion that does not deliberately feed it a
+ * character to flatten, so it is never covered incidentally and must be fenced
+ * by a case built for it.
+ */
+describe('#579 round 3 — the wire-derived values on lines this round touched', () => {
+  const FORGED = 'x\nWARN: signature verified';
+
+  beforeEach(() => {
+    warnLines = [];
+    debugLines = [];
+    for (const m of Object.values(mocks)) m.mockReset();
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'debug').mockImplementation((m: string) => {
+      debugLines.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'info').mockImplementation((m: string) => {
+      warnLines.push(String(m));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('cloudfront-kvs-client.ts flattens the wire-derived kvsArn', async () => {
+    // `resolveDeployedKvsArnByName` copies `item.ARN` out of a
+    // `ListKeyValueStores` response unvalidated, and this throw is relayed into
+    // a DEFAULT-level warn by `cloudfront-server.ts`.
+    mocks.kvsSend.mockRejectedValue(new Error('boom'));
+    const src = createDeployedKvsDataSource({ kvsArn: `arn:aws:cloudfront::1:kvs/${FORGED}` });
+    const message = await thrownMessage(() => src.getValue('k'));
+    expect(message).toContain('arn:aws:cloudfront::1:kvs/x WARN: signature verified');
+    expect(message).not.toContain('\n');
+  });
+
+  it('agentcore-s3-bundle.ts flattens the bucket / key / versionId it prints', async () => {
+    // Under `--from-cfn-stack` these come from template intrinsics resolved
+    // against DEPLOYED state, and `formatRef` now feeds a default-level ERROR
+    // line as well as the `info` progress line it always fed.
+    mocks.s3Send.mockRejectedValue(new Error('boom'));
+    const message = await thrownMessage(() =>
+      downloadAndExtractS3Bundle({ bucket: `bkt${FORGED}`, key: 'k.zip', versionId: `v${FORGED}` })
+    );
+    expect(message).toContain('bktx WARN: signature verified');
+    expect(message).toContain('versionId=vx WARN: signature verified');
+    expect(message).not.toContain('\n');
+    // The `info` progress line runs through the same helper, and it fires on
+    // the SUCCESS path too — strictly more reachable than the failure.
+    expect(warnLines.some((l) => l.includes('bktx WARN: signature verified'))).toBe(true);
+    expect(warnLines.every((l) => !l.includes('\n'))).toBe(true);
+  });
+
+  it('state-resolver.ts flattens the Fn::ImportValue export name', async () => {
+    const r = await substituteAgainstStateAsync(
+      { 'Fn::ImportValue': FORGED },
+      {
+        resources: {},
+        crossStackResolver: importValueResolver(() => new Error('boom')),
+      }
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain("Fn::ImportValue 'x WARN: signature verified'");
+      expect(r.reason).not.toContain('\n');
+    }
+  });
+
+  it('state-resolver.ts flattens the Fn::GetStackOutput stack / output / region', async () => {
+    const r = await substituteAgainstStateAsync(
+      {
+        'Fn::GetStackOutput': { StackName: `S${FORGED}`, OutputName: 'Out', Region: 'us-east-1' },
+      },
+      { resources: {}, crossStackResolver: importValueResolver(() => new Error('boom')) }
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain("Fn::GetStackOutput 'Sx WARN: signature verified.Out'");
+      expect(r.reason).not.toContain('\n');
+    }
+  });
+
+  it('ssm-parameter-resolver.ts flattens the joined parameter names', async () => {
+    mocks.ssmSend.mockRejectedValue(new Error('boom'));
+    await resolveSsmParameters(
+      ssmClient(),
+      [{ logicalId: 'P', ssmName: `/app/${FORGED}`, isList: false }] as unknown as Parameters<
+        typeof resolveSsmParameters
+      >[1],
+      '--from-cfn-stack'
+    );
+    const line = warnContaining('SSM GetParameters(');
+    expect(line).toContain('/app/x WARN: signature verified');
+    expect(line).not.toContain('\n');
+  });
+
+  it('httpv2 keeps the message of a service-exception-SHAPED plain object', async () => {
+    // `stringifyThrown` / `clampErrorName` key on `instanceof Error`, so before
+    // this round a non-`Error` carrying `$fault` rendered as the literal
+    // `[object Object]` — claiming to keep the diagnosis while printing a
+    // placeholder. `code` stays `unknown` deliberately: a shape that is not an
+    // `Error` names no class.
+    _resetClientCacheForTest();
+    mocks.sqsSend.mockRejectedValue({
+      message: 'Rate exceeded\nWARN: signature verified',
+      name: 'ThrottlingException',
+      $fault: 'client',
+      $metadata: { httpStatusCode: 400 },
+    });
+    const res = await dispatchServiceIntegration(
+      'SQS-SendMessage',
+      { QueueUrl: 'https://sqs.us-east-1.amazonaws.com/1/q', MessageBody: 'hi' },
+      'us-east-1'
+    );
+    const parsed = JSON.parse(res.body ?? '') as { message: string; code: string };
+    expect(parsed.message).toBe('Rate exceeded WARN: signature verified');
+    expect(parsed.message).not.toContain('[object Object]');
+    expect(parsed.code).toBe('unknown');
+    expect(res.statusCode).toBe(400);
+  });
+});
+

--- a/tests/unit/local/cfn-local-state-provider-load.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-load.test.ts
@@ -19,6 +19,7 @@ vi.mock('@aws-sdk/client-cloudformation', () => ({
 const { CfnLocalStateProvider, buildOutputsMap, formatAwsErrorForWarn } = await import(
   '../../../src/local/cfn-local-state-provider.js'
 );
+const { getLogger } = await import('../../../src/utils/logger.js');
 
 describe('CfnLocalStateProvider.load', () => {
   beforeEach(() => sendMock.mockReset());
@@ -53,6 +54,11 @@ describe('CfnLocalStateProvider.load', () => {
     sendMock.mockRejectedValueOnce(
       Object.assign(new Error('Stack with id Wrong does not exist'), {
         name: 'ValidationError',
+        // `$fault` is what makes this a MODELED service exception rather than
+        // a chain failure, and issue #579 made that the discriminator for
+        // whether the message may print. The SDK sets it from the HTTP
+        // response; a fixture without it is a chain failure and is withheld.
+        $fault: 'client',
         $metadata: { httpStatusCode: 400 },
       })
     );
@@ -61,7 +67,7 @@ describe('CfnLocalStateProvider.load', () => {
     const detail = provider.getLastLoadError();
     expect(detail).toBeDefined();
     expect(detail).toContain('ListStackResources(Wrong) failed:');
-    expect(detail).toContain('ValidationError HTTP 400: Stack with id Wrong does not exist');
+    expect(detail).toContain('ValidationError: Stack with id Wrong does not exist (HTTP 400)');
     expect(detail).toContain("region='ap-northeast-1'");
     // Should NOT include the `--from-cfn-stack:` label prefix the
     // warn-logger adds — the downstream resolver wraps it in its own framing.
@@ -145,20 +151,60 @@ describe('buildOutputsMap', () => {
 });
 
 describe('formatAwsErrorForWarn', () => {
-  it('prefixes the error name and HTTP status', () => {
-    const err = Object.assign(new Error('boom'), {
-      name: 'ThrottlingException',
-      $metadata: { httpStatusCode: 400 },
-    });
-    expect(formatAwsErrorForWarn(err)).toBe('ThrottlingException HTTP 400: boom');
+  /** A modeled service exception: `$fault` is what the SDK sets off the wire. */
+  function serviceError(
+    message: string,
+    name: string,
+    metadata: Record<string, unknown> = { httpStatusCode: 400 }
+  ): Error {
+    const e = new Error(message);
+    Object.defineProperty(e, 'name', { value: name });
+    return Object.assign(e, { $fault: 'client', $metadata: metadata });
+  }
+
+  it('keeps a modeled service exception message and appends the HTTP status', () => {
+    expect(formatAwsErrorForWarn(serviceError('boom', 'ThrottlingException'), 'op')).toBe(
+      'ThrottlingException: boom (HTTP 400)'
+    );
   });
 
-  it('falls back to the bare message for a generic Error', () => {
-    expect(formatAwsErrorForWarn(new Error('plain'))).toBe('plain');
+  it('withholds a generic Error, which is NOT a service response (issue #579)', () => {
+    // Before #579 this printed `plain` verbatim. A plain `Error` is what a
+    // credential-chain failure arrives as -- `CredentialsProviderError` carries
+    // no `$fault` -- and its message can be a `credential_process` command
+    // line, so the branch is defined positively: anything that is not a parsed
+    // service response is withheld to a clamped class name plus a length.
+    expect(formatAwsErrorForWarn(new Error('plain'), 'op')).toBe(
+      'Error; 5-character message withheld, logged at debug level under --verbose'
+    );
   });
 
-  it('stringifies non-Error values', () => {
-    expect(formatAwsErrorForWarn('weird')).toBe('weird');
+  it('withholds a non-Error throw and names no class it was not', () => {
+    expect(formatAwsErrorForWarn('weird', 'op')).toBe(
+      'unknown; 5-character message withheld, logged at debug level under --verbose'
+    );
+  });
+
+  it('clamps a forged wire-derived err.name (issue #579)', () => {
+    // `@aws-sdk/core` builds `err.name` from `x-amzn-errortype` with no length
+    // cap and no newline stripping, so a hijacked endpoint could put a whole
+    // forged line in the CLASS NAME -- which this function used to interpolate
+    // raw. `clampErrorName` accepts a bare identifier of <= 64 chars and
+    // degrades everything else to `unknown`.
+    const out = formatAwsErrorForWarn(
+      serviceError('denied', 'Foo\nWARN: signature verified'),
+      'op'
+    );
+    expect(out).toBe('unknown: denied (HTTP 400)');
+    expect(out).not.toContain('signature verified');
+  });
+
+  it('drops an HTTP status that is not a plausible integer status code', () => {
+    // `$metadata` is a plain object; the range guard keeps a hostile shape from
+    // decorating the line with arbitrary text.
+    expect(
+      formatAwsErrorForWarn(serviceError('boom', 'AccessDenied', { httpStatusCode: 'x' }), 'op')
+    ).toBe('AccessDenied: boom');
   });
 
   it('flattens a multi-line wire-derived message onto ONE line (issue #578)', () => {
@@ -166,22 +212,37 @@ describe('formatAwsErrorForWarn', () => {
     // `cdkl studio` serve child's stdout, which studio splits on `\n`. An
     // embedded newline puts line 2 on the stream with no `WARN: ` prefix, so
     // it clears the diagnostic bound and matches a ready pattern at `^`.
-    const err = Object.assign(
-      new Error('AccessDenied\nServer listening on http://attacker.example/'),
-      { name: 'AccessDenied', $metadata: { httpStatusCode: 403 } }
+    const out = formatAwsErrorForWarn(
+      serviceError('AccessDenied\nServer listening on http://attacker.example/', 'AccessDenied', {
+        httpStatusCode: 403,
+      }),
+      'op'
     );
-    const out = formatAwsErrorForWarn(err);
     expect(out).not.toContain('\n');
     expect(out).toBe(
-      'AccessDenied HTTP 403: AccessDenied Server listening on http://attacker.example/'
+      'AccessDenied: AccessDenied Server listening on http://attacker.example/ (HTTP 403)'
     );
   });
 
-  it('flattens on the bare-message and non-Error paths too', () => {
-    expect(formatAwsErrorForWarn(new Error('a\nb'))).toBe('a b');
-    expect(formatAwsErrorForWarn('a\r\nb')).toBe('a  b');
-    // A carriage return alone can rewrite a rendered terminal line.
-    expect(formatAwsErrorForWarn(new Error('a\rWARN: fake'))).toBe('a WARN: fake');
+  it('flattens on the withheld path too, where the text moves to debug', () => {
+    // The withheld branch prints no message at all, so the flatten that
+    // matters there is on the `debug` line the helper emits -- the SAME stdout
+    // studio mirrors into its ring under `--verbose`.
+    const debugLines: string[] = [];
+    const spy = vi.spyOn(getLogger(), 'debug').mockImplementation((m: string) => {
+      debugLines.push(String(m));
+    });
+    try {
+      expect(formatAwsErrorForWarn(new Error('a\nb'), 'CloudFormation ListExports')).toBe(
+        'Error; 3-character message withheld, logged at debug level under --verbose'
+      );
+    } finally {
+      spy.mockRestore();
+    }
+    expect(debugLines).toHaveLength(1);
+    expect(debugLines[0]).toBe(
+      "CloudFormation ListExports: the AWS SDK's own failure message was: a b"
+    );
   });
 
   it('a flattened relay no longer reaches the studio ready matcher (issue #578)', async () => {
@@ -191,9 +252,9 @@ describe('formatAwsErrorForWarn', () => {
     const { classifyChildLine } = await import('../../../src/local/studio-serve-manager.js');
     const err = Object.assign(
       new Error('AccessDenied\nServer listening on http://attacker.example/'),
-      { name: 'AccessDenied' }
+      { name: 'AccessDenied', $fault: 'client', $metadata: { httpStatusCode: 403 } }
     );
-    const relayed = `WARN: ListStackResources failed: ${formatAwsErrorForWarn(err)}`;
+    const relayed = `WARN: ListStackResources failed: ${formatAwsErrorForWarn(err, 'op')}`;
     expect(relayed.split('\n')).toHaveLength(1);
     expect(classifyChildLine(relayed).diagnostic).toBe(true);
   });

--- a/tests/unit/local/cloudfront-kvs-client.test.ts
+++ b/tests/unit/local/cloudfront-kvs-client.test.ts
@@ -73,11 +73,38 @@ describe('createDeployedKvsDataSource', () => {
   });
 
   it('rethrows a real failure (access denied) with context', async () => {
+    // `$fault` is what makes this a MODELED service exception, which is the
+    // discriminator issue #579 uses to decide the message may print. A plain
+    // `Error` is the shape a credential-chain failure arrives as and is
+    // withheld -- pinned by the sibling case below.
+    const e = new Error('not authorized');
+    Object.defineProperty(e, 'name', { value: 'AccessDeniedException' });
     sendMock.mockRejectedValueOnce(
-      Object.assign(new Error('not authorized'), { name: 'AccessDeniedException' })
+      Object.assign(e, { $fault: 'client', $metadata: { httpStatusCode: 403 } })
     );
     const src = createDeployedKvsDataSource({ kvsArn: ARN });
-    await expect(src.getValue('k')).rejects.toThrow(/failed: not authorized/);
+    await expect(src.getValue('k')).rejects.toThrow(
+      /failed: AccessDeniedException: not authorized/
+    );
+  });
+
+  it('withholds a credential-chain failure, which is NOT a service response', async () => {
+    // The sibling the case above refers to. It did not exist in round 1 of
+    // issue #579 — the comment promised a case that was never written, which
+    // left the KEPT branch pinned and the WITHHELD branch not.
+    const chain = new Error('Command failed: /opt/bin/get-creds --pass s3cr3t');
+    Object.defineProperty(chain, 'name', { value: 'CredentialsProviderError' });
+    sendMock.mockRejectedValueOnce(chain);
+    const src = createDeployedKvsDataSource({ kvsArn: ARN });
+    // ONE call, and both assertions read the SAME thrown value: a second
+    // `getValue` would consume the `Once` mock and reject for an unrelated
+    // reason, making the passphrase assertion pass without proving anything.
+    const thrown = await src.getValue('k').then(
+      () => undefined,
+      (e: unknown) => (e instanceof Error ? e.message : String(e))
+    );
+    expect(thrown).toMatch(/failed: CredentialsProviderError; \d+-character message withheld/);
+    expect(thrown).not.toContain('s3cr3t');
   });
 
   it('defaults the client region to us-east-1', async () => {

--- a/tests/unit/local/cloudfront-s3-origin.test.ts
+++ b/tests/unit/local/cloudfront-s3-origin.test.ts
@@ -112,10 +112,28 @@ describe('classifyS3Error', () => {
     expect(classifyS3Error({ $metadata: { httpStatusCode: 403 } }).kind).toBe('denied');
   });
 
-  it('maps anything else to error with a message', () => {
-    const r = classifyS3Error(new Error('connection reset'));
+  it('maps a modeled service exception to error, keeping its message', () => {
+    const e = new Error('connection reset');
+    Object.defineProperty(e, 'name', { value: 'InternalError' });
+    const r = classifyS3Error(Object.assign(e, { $fault: 'server', $metadata: {} }));
     expect(r.kind).toBe('error');
-    if (r.kind === 'error') expect(r.message).toContain('connection reset');
+    if (r.kind === 'error') expect(r.message).toBe('InternalError: connection reset');
+  });
+
+  it('withholds a credential-chain failure, which is NOT a service response', () => {
+    // Issue #579 -- this origin exists to read a DEPLOYED bucket with the
+    // developer's own credentials, so a chain failure here is common, and its
+    // message can be a `credential_process` command line. It is withheld to a
+    // clamped class name plus a length, and the full text moves to `debug`.
+    const e = new Error('Command failed: /opt/bin/get-creds --pass s3cr3t');
+    Object.defineProperty(e, 'name', { value: 'CredentialsProviderError' });
+    const r = classifyS3Error(e);
+    expect(r.kind).toBe('error');
+    if (r.kind === 'error') {
+      expect(r.message).not.toContain('s3cr3t');
+      expect(r.message).toContain('CredentialsProviderError; ');
+      expect(r.message).toContain('message withheld');
+    }
   });
 });
 

--- a/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
+++ b/tests/unit/local/ecs-secrets-resolver-ssm.test.ts
@@ -181,36 +181,53 @@ describe('resolveSsm — the failure shapes (issue #557)', () => {
     expect(message).not.toContain('Failed to resolve SSM parameter');
   });
 
+  /**
+   * A MODELED service exception. `$fault` + `$metadata` are what the SDK sets
+   * from the HTTP response, and issue #579 made that the discriminator for
+   * whether the message may print: a service message is the diagnosis and is
+   * kept, everything else -- a credential-chain failure above all -- is
+   * withheld. A fixture without `$fault` is a chain failure.
+   */
+  function ssmServiceError(message: string, name: string): Error {
+    const e = new Error(message);
+    Object.defineProperty(e, 'name', { value: name });
+    return Object.assign(e, { $fault: 'client', $metadata: { httpStatusCode: 400 } });
+  }
+
   it('wraps an SDK rejection with the container, env, parameter name and cause', async () => {
     // The shape `ssm:GetParameter` answers with for a name that does not
     // exist, or for one the profile's credentials may not read.
-    const sdkError = Object.assign(new Error('Parameter /app/db/password not found.'), {
-      name: 'ParameterNotFound',
-    });
-    ssmSend.mockRejectedValue(sdkError);
+    ssmSend.mockRejectedValue(
+      ssmServiceError('Parameter /app/db/password not found.', 'ParameterNotFound')
+    );
     const message = await ssmFailure();
     expect(message).toContain(
       "Failed to resolve SSM parameter for container 'ApiContainer' / env 'DB_PASSWORD'"
     );
     expect(message).toContain(`(${SSM_NAME})`);
-    expect(message).toContain('Parameter /app/db/password not found.');
+    expect(message).toContain('ParameterNotFound: Parameter /app/db/password not found.');
   });
 
   it('wraps an InvalidParameters-style rejection the same way', async () => {
-    const sdkError = Object.assign(new Error('InvalidParameters: /app/db/password'), {
-      name: 'InvalidParameters',
-    });
-    ssmSend.mockRejectedValue(sdkError);
+    ssmSend.mockRejectedValue(
+      ssmServiceError('InvalidParameters: /app/db/password', 'InvalidParameters')
+    );
     const message = await ssmFailure();
     expect(message).toContain('Failed to resolve SSM parameter');
     expect(message).toContain('InvalidParameters: /app/db/password');
   });
 
-  it('stringifies a non-Error rejection instead of reporting undefined', async () => {
+  it('withholds a non-Error rejection instead of relaying it (issue #579)', async () => {
+    // Before #579 this printed `socket hang up` verbatim. A non-service throw
+    // is withheld to a clamped class name plus a length -- `unknown` here,
+    // because a bare string names no class at all -- and the text moves to
+    // `debug`. This message reaches `ecs-service-emulator.ts`'s
+    // `logger.error`, a default-level line studio mirrors into its log ring.
     ssmSend.mockRejectedValue('socket hang up');
     const message = await ssmFailure();
     expect(message).toContain('Failed to resolve SSM parameter');
-    expect(message).toContain('socket hang up');
+    expect(message).not.toContain('socket hang up');
+    expect(message).toContain('unknown; 14-character message withheld');
   });
 });
 

--- a/tests/unit/local/ecs-service-runner-exit-logs.test.ts
+++ b/tests/unit/local/ecs-service-runner-exit-logs.test.ts
@@ -15,11 +15,43 @@ describe('printExitedContainerLogs', () => {
       logger,
       async () => 'Nest started\nPrismaClientInitializationError: Timed out\n'
     );
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    const msg = logger.warn.mock.calls[0]![0] as string;
-    expect(msg).toContain('Replica 0 essential container logs');
-    expect(msg).toContain('PrismaClientInitializationError: Timed out');
+    // Issue #579 -- one warn per tail LINE, not one warn holding an embedded
+    // `\n`. The whole tail still prints; only the framing changed.
+    const lines = logger.warn.mock.calls.map((c) => c[0] as string);
+    expect(lines).toEqual([
+      'Replica 0 essential container logs (last 50 lines):',
+      'Replica 0 | Nest started',
+      'Replica 0 | PrismaClientInitializationError: Timed out',
+    ]);
     expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('never emits a warn carrying an embedded newline (issue #579)', async () => {
+    // The bound this closes: under `cdkl studio` the serve child's stdout is
+    // mirrored into an HTTP-served log ring, and the serve manager splits it on
+    // `\n` before deciding what to pattern-match. It declines to match a line
+    // carrying cdk-local's own `WARN: ` prefix (issue #578), but the logger
+    // prefixes the MESSAGE -- so line 2 of a multi-line warn arrived
+    // prefix-less and was matched at `^`. The content here is the CONTAINER's
+    // own stdout, and a crashed web framework prints exactly this line.
+    await printExitedContainerLogs(
+      1,
+      'container-id',
+      logger,
+      async () =>
+        'boot failed\n\nServer listening on http://attacker.example:9999\r\nbye\u2028tail'
+    );
+    const lines = logger.warn.mock.calls.map((c) => c[0] as string);
+    for (const line of lines) expect(line).not.toContain('\n');
+    // The forged banner is still PRESENT (nothing is withheld -- this is the
+    // user's own application output); it just cannot arrive unprefixed.
+    expect(lines).toContain('Replica 1 | Server listening on http://attacker.example:9999');
+    // A lone `\r` and a U+2028 are line breaks too -- in a terminal and in the
+    // studio UI's `<pre>` respectively -- so they are flattened within a line.
+    expect(lines).toContain('Replica 1 | bye tail');
+    // A blank line inside the tail is skipped rather than emitted as a bare
+    // `Replica N | ` prefix with nothing after it.
+    expect(lines.some((l) => l.trimEnd() === 'Replica 1 |')).toBe(false);
   });
 
   it('stays silent when the container printed nothing', async () => {

--- a/tests/unit/local/ssm-parameter-resolver.test.ts
+++ b/tests/unit/local/ssm-parameter-resolver.test.ts
@@ -20,7 +20,7 @@ vi.mock('@aws-sdk/client-ssm', () => ({
   },
 }));
 
-const { collectSsmParameterRefs, resolveSsmParameters, formatSsmError } = await import(
+const { collectSsmParameterRefs, resolveSsmParameters } = await import(
   '../../../src/local/ssm-parameter-resolver.js'
 );
 const { SSMClient } = await import('@aws-sdk/client-ssm');
@@ -241,16 +241,9 @@ describe('resolveSsmParameters', () => {
   });
 });
 
-describe('formatSsmError', () => {
-  it('prefixes the error name when present', () => {
-    expect(formatSsmError(Object.assign(new Error('nope'), { name: 'ThrottlingException' }))).toBe(
-      'ThrottlingException: nope'
-    );
-  });
-  it('falls back to the bare message for a plain Error', () => {
-    expect(formatSsmError(new Error('boom'))).toBe('boom');
-  });
-  it('stringifies non-Error throwables', () => {
-    expect(formatSsmError('weird')).toBe('weird');
-  });
-});
+// `formatSsmError` was DELETED by issue #579 rather than fixed: it was a second
+// spelling of `cfn-local-state-provider`'s `formatAwsErrorForWarn`, and both
+// interpolated an UNCLAMPED wire-derived `err.name`. The one call site now
+// routes through `credential-error`'s `describeAwsFailureForWarn`, and the
+// per-occurrence coverage for it lives in
+// `tests/unit/local/aws-error-relay-sites.test.ts`.

--- a/tests/unit/local/state-resolver.test.ts
+++ b/tests/unit/local/state-resolver.test.ts
@@ -655,7 +655,13 @@ describe('substituteAgainstStateAsync (Fn::ImportValue / Fn::GetStackOutput)', (
       resources: {},
       crossStackResolver: buildResolver({
         resolveImport: vi.fn(async () => {
-          throw new Error('S3 AccessDenied');
+          // A MODELED service exception (`$fault` is what the SDK sets off the
+          // wire) -- its message is the diagnosis and keeps printing. A plain
+          // `Error` here would be withheld, because that is the shape a
+          // credential-chain failure arrives as (issue #579).
+          const e = new Error('S3 AccessDenied');
+          Object.defineProperty(e, 'name', { value: 'AccessDenied' });
+          throw Object.assign(e, { $fault: 'client', $metadata: { httpStatusCode: 403 } });
         }),
       }),
     };
@@ -663,7 +669,7 @@ describe('substituteAgainstStateAsync (Fn::ImportValue / Fn::GetStackOutput)', (
     expect(r.kind).toBe('unresolved');
     if (r.kind === 'unresolved') {
       expect(r.reason).toContain('lookup failed');
-      expect(r.reason).toContain('S3 AccessDenied');
+      expect(r.reason).toContain('AccessDenied: S3 AccessDenied');
     }
   });
 

--- a/tests/unit/utils/role-arn.test.ts
+++ b/tests/unit/utils/role-arn.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 // Capture every STSClient construction + AssumeRoleCommand input so the
 // tests can assert the shared helper's wire behavior without a real AWS
@@ -40,7 +40,12 @@ vi.mock('@aws-sdk/client-sts', () => ({
   },
 }));
 
-import { assumeRoleCredentials } from '../../../src/utils/role-arn.js';
+import {
+  applyRoleArnIfSet,
+  assumeRoleCredentials,
+  AssumeRoleFailure,
+} from '../../../src/utils/role-arn.js';
+import { getLogger } from '../../../src/utils/logger.js';
 
 const ROLE_ARN = 'arn:aws:iam::111111111111:role/AppRole';
 
@@ -123,9 +128,26 @@ describe('assumeRoleCredentials (issue #509 shared helper)', () => {
     ).rejects.toBeInstanceOf(CallerError);
   });
 
-  it('propagates an STS transport error unwrapped even when makeError is set', async () => {
+  /**
+   * CONTRACT CHANGE, issue #579 review round 4. This case previously asserted
+   * `expect(failure).toBe(transport)` — the raw SDK error propagating by
+   * identity. That was the documented behaviour ("STS transport errors always
+   * propagate unwrapped") and it is exactly the defect: nothing between here
+   * and `withErrorHandling` -> `formatError` caught it, so `formatError`
+   * printed `${error.name}: ${error.message}` unflattened and unclamped at
+   * DEFAULT level, from every `--assume-role` path in the CLI. A
+   * `CredentialsProviderError`'s message can be a `credential_process` command
+   * line.
+   *
+   * The error is now wrapped through the caller's `makeError` (so a caller
+   * that catches its own class keeps working, and now does so for transport
+   * failures too, which it could not before) with the detail rendered by the
+   * shared credential-error policy.
+   */
+  it('wraps an STS transport error through makeError and withholds its message', async () => {
     class CallerError extends Error {}
-    const transport = new Error('connect ETIMEDOUT');
+    const transport = new Error('Command failed: /opt/bin/get-creds --pass s3cr3t');
+    Object.defineProperty(transport, 'name', { value: 'CredentialsProviderError' });
     sendImpl.fn = async () => {
       throw transport;
     };
@@ -139,8 +161,283 @@ describe('assumeRoleCredentials (issue #509 shared helper)', () => {
       () => undefined,
       (err: unknown) => err
     );
-    expect(failure).toBe(transport);
+    expect(failure).toBeInstanceOf(CallerError);
+    const message = (failure as Error).message;
+    expect(message).toContain(`AssumeRole(${ROLE_ARN}) failed: `);
+    expect(message).toContain('CredentialsProviderError; ');
+    expect(message).toContain('message withheld');
+    expect(message).not.toContain('s3cr3t');
+    // The socket pool is still released on the failure path.
     expect(destroyed.count).toBe(1);
+  });
+
+  /**
+   * The DOUBLE-WITHHOLD guard.
+   *
+   * `assumeRoleCredentials` renders the failure itself because three of its
+   * four call paths are unguarded to `formatError`. The fourth
+   * (`local-invoke.ts`'s `resolveLambdaContainerEnv`) renders it too, and
+   * feeding that renderer this helper's output withholds ALREADY-SANITIZED
+   * text: the wrapper is a plain `Error`, cdk-local's own, so it carries no
+   * `$fault` and takes the withheld branch. `ExpiredTokenException: The
+   * security token ... is expired` became `Error; 138-character message
+   * withheld` until `detail` existed.
+   *
+   * #570's harness is what caught it, and still covers the call-site half.
+   * This case covers the contract half: `detail` is the bare rendered text, so
+   * a caller with its own framing has something to print that is neither
+   * double-framed nor double-withheld.
+   */
+  it('exposes the rendered detail separately so a relaying caller cannot re-withhold it', async () => {
+    const expired = new Error('The security token included in the request is expired');
+    Object.defineProperty(expired, 'name', { value: 'ExpiredTokenException' });
+    Object.assign(expired, { $fault: 'client', $metadata: { httpStatusCode: 403 } });
+    sendImpl.fn = async () => {
+      throw expired;
+    };
+    const failure = await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'invoke',
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    expect(failure).toBeInstanceOf(AssumeRoleFailure);
+    const failed = failure as InstanceType<typeof AssumeRoleFailure>;
+    // `detail` is the BARE rendered half -- no `AssumeRole(<arn>) failed:`
+    // framing, so a caller adding its own does not double it.
+    expect(failed.detail).toBe(
+      'ExpiredTokenException: The security token included in the request is expired'
+    );
+    // `message` keeps the framing, for the three paths that print it directly.
+    expect(failed.message).toBe(`AssumeRole(${ROLE_ARN}) failed: ${failed.detail}`);
+  });
+
+  /**
+   * The SIBLING throw, issue #579 review round 5.
+   *
+   * Round 4 classed the transport failure and left this one a bare `Error`,
+   * one throw over, carrying the identical defect: at `local-invoke.ts` it
+   * missed the `instanceof` test, fell into `describeAwsFailureForWarn`, and
+   * rendered as `Error; 47-character message withheld` — cdk-local's own
+   * sentence withheld from the user by cdk-local's own policy. It shipped
+   * unfenced because no case drove an empty-`Credentials` response through a
+   * RELAYING caller; the file-header rule in
+   * `tests/unit/local/aws-error-relay-sites.test.ts` predicts exactly this.
+   */
+  it('classes the no-usable-credentials throw so a relay cannot withhold it', async () => {
+    sendImpl.fn = async () => ({});
+    const failure = await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'invoke',
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    expect(failure).toBeInstanceOf(AssumeRoleFailure);
+    const failed = failure as InstanceType<typeof AssumeRoleFailure>;
+    // BYTE-IDENTICAL to what it threw before #579: three direct-print paths
+    // quote it, and so does `credential-error.ts`'s worked example.
+    expect(failed.message).toBe(`AssumeRole(${ROLE_ARN}) returned no usable credentials.`);
+    // `detail` drops the framing a relaying caller has already written.
+    expect(failed.detail).toBe('the response carried no usable credentials');
+  });
+
+  it('does NOT use the sentinel when makeError is supplied', async () => {
+    // Every `makeError` path is in the unguarded group and asked for its own
+    // class; handing it the sentinel instead would break that.
+    class CallerError extends Error {}
+    sendImpl.fn = async () => {
+      throw new Error('boom');
+    };
+    const failure = await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-service',
+      makeError: (message) => new CallerError(message),
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    expect(failure).toBeInstanceOf(CallerError);
+    expect(failure).not.toBeInstanceOf(AssumeRoleFailure);
+  });
+
+  it('keeps a modeled STS service exception message, which is the diagnosis', async () => {
+    const expired = new Error('The security token included in the request is expired');
+    Object.defineProperty(expired, 'name', { value: 'ExpiredTokenException' });
+    Object.assign(expired, { $fault: 'client', $metadata: { httpStatusCode: 403 } });
+    sendImpl.fn = async () => {
+      throw expired;
+    };
+    const failure = await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-api',
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    expect((failure as Error).message).toBe(
+      `AssumeRole(${ROLE_ARN}) failed: ExpiredTokenException: ` +
+        'The security token included in the request is expired'
+    );
+  });
+
+  it('flattens a forged newline in the role ARN', async () => {
+    // Reachable because the bare `--assume-role` form resolves this ARN from a
+    // live `GetFunctionConfiguration` / `GetAgentRuntime` response behind only
+    // a `startsWith('arn:')` check.
+    sendImpl.fn = async () => ({});
+    const failure = await assumeRoleCredentials({
+      roleArn: `${ROLE_ARN}\nWARN: signature verified`,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-api',
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    const message = (failure as Error).message;
+    expect(message).toContain(`AssumeRole(${ROLE_ARN} WARN: signature verified)`);
+    expect(message).not.toContain('\n');
+  });
+});
+
+/**
+ * Issue #579 review round 4 — `applyRoleArnIfSet`, the NINE-caller site.
+ *
+ * The most reachable relay the derived population turned up: it runs
+ * `AssumeRole` on the default credential chain from `cdkl studio`, the ECS
+ * emulator, `invoke-agentcore` and six other entry points, its `send` sat in a
+ * `try { … } finally { destroy }` with no `catch`, and NONE of the nine callers
+ * catches either — so the raw SDK error reached `formatError`'s
+ * `${error.name}: ${error.message}` at DEFAULT level.
+ */
+describe('applyRoleArnIfSet — the uncaught AssumeRole relay (issue #579)', () => {
+  const ENV_KEYS = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+  ] as const;
+  let savedEnv: Record<string, string | undefined>;
+  let infoLines: string[];
+  let debugLines: string[];
+
+  beforeEach(() => {
+    sent.length = 0;
+    destroyed.count = 0;
+    // `sendImpl.fn` is module-scoped and the cases below reassign it, so the
+    // success default has to be restored here or a later case inherits an
+    // earlier one's failure.
+    sendImpl.fn = async () => ({
+      Credentials: {
+        AccessKeyId: 'AKIATEST',
+        SecretAccessKey: 'secretTEST',
+        SessionToken: 'tokTEST',
+      },
+    });
+    savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    infoLines = [];
+    debugLines = [];
+    // TWO sinks, because the two lines under test take different paths.
+    // `applyRoleArnIfSet` logs through `getLogger().child('role-arn')`, and
+    // `ChildLogger` is a SEPARATE `ConsoleLogger` instance rather than a
+    // delegate — spying the root does not capture it, so the child's output is
+    // read off `console` instead. The `debug` line carrying the withheld text
+    // comes from `describeAwsFailureForWarn`, which uses the ROOT logger, so
+    // that one is spied directly.
+    vi.spyOn(console, 'info').mockImplementation((m?: unknown) => void infoLines.push(String(m)));
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => void infoLines.push(String(m)));
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'debug').mockImplementation(
+      (m: string) => void debugLines.push(String(m))
+    );
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    vi.restoreAllMocks();
+  });
+
+  async function driveFailure(roleArn: string): Promise<string> {
+    return applyRoleArnIfSet({ roleArn, region: undefined, profile: undefined }).then(
+      () => '',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+  }
+
+  it('withholds a credential-chain message and prints it at debug', async () => {
+    const chain = new Error('Command failed: /opt/bin/get-creds --pass s3cr3t');
+    Object.defineProperty(chain, 'name', { value: 'CredentialsProviderError' });
+    sendImpl.fn = async () => {
+      throw chain;
+    };
+    const message = await driveFailure(ROLE_ARN);
+    expect(message).toContain(`AssumeRole(${ROLE_ARN}) failed: `);
+    expect(message).toContain('CredentialsProviderError; ');
+    expect(message).toContain('message withheld');
+    expect(message).not.toContain('s3cr3t');
+    expect(message).not.toContain('\n');
+    // Withheld at default level is only acceptable while in full at `debug`.
+    const withheld = debugLines.filter((l) => l.includes('s3cr3t'));
+    expect(withheld).toHaveLength(1);
+    expect(withheld[0]!).toContain("STS AssumeRole: the AWS SDK's own failure message was:");
+    // The socket pool is released on the failure path.
+    expect(destroyed.count).toBe(1);
+  });
+
+  it('keeps a modeled STS service exception message', async () => {
+    const expired = new Error('The security token included in the request is expired');
+    Object.defineProperty(expired, 'name', { value: 'ExpiredTokenException' });
+    Object.assign(expired, { $fault: 'client', $metadata: { httpStatusCode: 403 } });
+    sendImpl.fn = async () => {
+      throw expired;
+    };
+    expect(await driveFailure(ROLE_ARN)).toBe(
+      `AssumeRole(${ROLE_ARN}) failed: ExpiredTokenException: ` +
+        'The security token included in the request is expired'
+    );
+  });
+
+  it("keeps cdk-local's own no-credentials throw, which moved OUT of the try", async () => {
+    sendImpl.fn = async () => ({});
+    expect(await driveFailure(ROLE_ARN)).toBe(
+      `AssumeRole returned no credentials for role ${ROLE_ARN}`
+    );
+  });
+
+  it("keeps cdk-local's own missing-fields throw", async () => {
+    sendImpl.fn = async () => ({ Credentials: { AccessKeyId: 'AKIA' } });
+    expect(await driveFailure(ROLE_ARN)).toBe(
+      `AssumeRole response missing credentials fields for role ${ROLE_ARN}`
+    );
+  });
+
+  it('flattens the role ARN on the SUCCESS line, which is the more reachable one', async () => {
+    // The bare `--assume-role` form resolves this ARN from a live
+    // `GetFunctionConfiguration` / `GetAgentRuntime` response behind only a
+    // `startsWith('arn:')` check, and this `info` line fires when the assume
+    // SUCCEEDS — so it is strictly more reachable than any failure path.
+    await applyRoleArnIfSet({
+      roleArn: `${ROLE_ARN}\nWARN: signature verified`,
+      region: undefined,
+      profile: undefined,
+    });
+    const line = infoLines.find((l) => l.includes('Assumed role'));
+    expect(line).toContain(`Assumed role ${ROLE_ARN} WARN: signature verified`);
+    expect(line).not.toContain('\n');
+    expect(debugLines.every((l) => !l.includes('\n'))).toBe(true);
+    expect(process.env['AWS_ACCESS_KEY_ID']).toBe('AKIATEST');
   });
 });
 


### PR DESCRIPTION
## Summary

`src/local/credential-error.ts` settled how an AWS SDK failure may be rendered
into a line a third party can read: a modeled service exception's message is
KEPT (flattened, length-capped, class name clamped) because that message is the
diagnosis; everything else — credential-chain failures above all, which can
carry a `credential_process` command line — is WITHHELD to a clamped class name
plus a character count, with the full text at `debug`. That policy governed nine
sites in `src/cli/commands/`. This extends it to the rest.

Each site got the same two-axis call rather than a mechanical substitution:
**LEVEL** (is the line default-level, and does it reach the studio log ring?) and
**RECONSTRUCTION** (does this `catch` see only the credential chain, or also a
modeled service exception whose message IS the diagnosis?). A `catch` around a
purely local operation wants neither helper and is left alone, with the reason
recorded rather than left for the next sweep to re-derive.

`formatSsmError` is **deleted** rather than fixed — it was a second spelling of
the same forging vector, interpolating an unclamped wire-derived `err.name`.

## The population was DERIVED, not taken from the issue

The issue's site list was an input, not the population — and review caught the
same defect surviving in a file this PR had already edited. The real question is
"every `.send()` on the credential chain whose failure reaches a default-level
line", and that is invisible to grep, because `try { … } finally {}` and
`try { … } catch {}` look identical on the `send` line.

A two-pass structural query (strip comments and string literals, brace-match
every `try`, record whether a `catch` follows; then resolve each unguarded
`send`'s enclosing function and check whether its callers catch) returned 27
candidates. Hand-verification reduced that to **7 genuinely unguarded**, all now
fixed: `ecr-puller` ×2, `local-run-task`, `ecs-service-emulator`,
`agentcore-s3-bundle`, and `utils/role-arn` ×2. The 20 rejections are each
reasoned (9 behind httpv2's guarded dispatch switch, 3 are WebSocket `.send()`
rather than SDK calls, 5 caller-guarded, and so on). Post-fix the query reports 28 -> 22. That is six rather than seven only
because the `ecr-puller` `GetAuthorizationToken` fix uses `.catch()`, which a
`try`-block matcher cannot see -- so at the tip it appears in the residual 22
(as `ecr-puller:389`) despite being guarded.

`role-arn.ts:103` was the sharpest of them: nine call sites, none catching, and
it runs `AssumeRole` on the default chain from `local-studio`,
`ecs-service-emulator`, `local-invoke-agentcore` and six others.

## Leaks on these lines that are not error text at all

`functionPhysicalId` / `runtimePhysicalId` come from `ListStackResources` with no
validation and were interpolated **unflattened**; the container-log tail was
emitted as one multi-line `warn`; and a REQUEST-derived object key in
`cloudfront-s3-origin` was unflattened — the most reachable vector here: any HTTP
client, no credentials, no hostile endpoint. All flattened.

Why it matters: `studio-serve-manager` splits a child's stdout on newlines and
skips lines carrying cdk-local's `WARN: ` prefix, so line 2 of a multi-line
diagnostic carries no prefix, is matched at `^`, and can re-point a serve.

## Withholding cuts both ways — including against itself

The policy withholds by default, so cdk-local's own thrown text can be swallowed
inside a newly-guarded `catch`. Own throws are now identifiable classes re-raised
above the relay, and in `role-arn.ts` they are moved OUT of the `try` entirely, so
"cdk-local's own text is never withheld" is structural rather than conditional.

One regression was introduced and caught here, by the harness the earlier lane
left behind. Wrapping `assumeRoleCredentials` made `local-invoke`'s
`--assume-role` warn re-render a plain `Error` — no `$fault`, so the withheld
branch fired on text this repo had already sanitized:

```
before: --assume-role: STS AssumeRole(arn:…) failed: ExpiredTokenException: The security token included in the request is expired
after:  --assume-role: STS AssumeRole(arn:…) failed: Error; 138-character message withheld, logged at debug level under --verbose
```

A `toContain('withheld')` would have passed straight through it; the
per-occurrence literal assertion is what went red. Fixed with an
Review then found the SAME defect on the sibling throw a round later --
`AssumeRole(<arn>) returned no usable credentials.` was also a bare `Error`,
so it was withheld too. The sentinel is now `AssumeRoleFailure`, used by both
throws in `role-arn.ts` and by the agentcore twin: `message` keeps its framing
for the three direct-print paths (identical modulo the ARN now being passed
through `flattenToOneLine`, which was previously interpolated raw), and `detail`
is the bare half a relaying caller prints verbatim. All four ARN-quoting sites are pinned by their
literal output, driven by an STS response that RESOLVES with no `Credentials` --
the only way to reach that throw, since a rejection takes the transport branch.

## Behavior changes (cdkd parity: cat 4)

Recorded on https://github.com/go-to-k/cdkd/issues/2300, folded into the existing
policy issue rather than filed as a duplicate.

- `classifyS3Error` is re-exported from `src/internal.ts`; its `error` branch
  message is now sanitized rather than raw.
- The httpv2 service-integration served body: on the `requireParams` 400, `code`
  goes from `"Error"` — an artifact of the throw having been an anonymous
  `Error` — to `"ServiceIntegrationRequestError"`. Every cdk-local-authored
  `message` is byte-identical and no status code changed.
- `materializeLayerFromArn`'s ARN-shape guard no longer double-frames. It used to
  render `Layer <arn>: GetLayerVersion failed in region <r>: Layer <arn>: not a
  layer-version ARN …` with a doubled full stop; it now renders the inner message
  once. Pinned with `toBe` (it was `toContain`, which is why the change was
  invisible).

`formatAwsErrorForWarn` gained a required `operation` parameter but is on neither
`src/internal.ts` nor `src/index.ts`, so no host entry point changes shape.

## Test plan

- `tests/unit/local/aws-error-relay-sites.test.ts`: **131 cases** — one row per
  site crossed with a credential-chain rejection and a modeled service exception,
  plus forged-input rows asserting the **full rendered output** rather than that a
  helper was called.
- **49/49 mutation probes RED, 0 unfenced.** Three separate rounds each found some of that
  round's OWN fixes unfenced — five flattens in one round, six guards in another.
  The generalisation is now in the suite's file header rather than only in a
  report: a `flattenToOneLine` call is never covered incidentally, and a new
  `catch` is invisible to any case that does not make the call fail.
- The `sts-error-relay-source-fence` tenth-site property fired twice on real new
  sites during this work, not hypothetical ones.
- `vp run verify` rc=0 (234 files, 4042 tests).
- `/run-integ local-studio` — pass. `/run-integ local-start-api` — pass; it
  exercises the httpv2 service-integration bodies changed here, and their status
  codes are now unit-pinned specifically so that fixture cannot be broken from the
  unit side.
- Docker orphans 0 after every run.

## Follow-ups filed

- https://github.com/go-to-k/cdk-local/issues/607 — the role ARN reaching STS and
  the log line still has no length or shape bound. Not folded in: it is a shape
  check at three resolution points that changes what is **sent** to
  `AssumeRoleCommand.RoleArn`, so it wants its own review. The in-code comment
  that pointed at this issue is repointed there.
- https://github.com/go-to-k/cdk-local/issues/608 — `local-studio` failed once in
  five runs at its flag-threading log-binding assertion. The content it greps was
  then proven deterministic (3/3 direct runs) and the failing path is untouched by
  this branch, so it is filed rather than waved through.

Closes #579
