### PR TITLE
chore(work-issues): re-derive counts at the final sha; re-tier at that sha too

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -93,6 +93,19 @@ Run each check and report pass/fail:
      - **3-axis parallel** (large PR `>=` 1000 LOC OR security-sensitive paths) — dispatch all three of `pr-spec-reviewer` / `pr-code-reviewer` / `pr-test-reviewer` in parallel (single message, three Agent tool calls).
 
      The skill applies bias factors (security surfaces bump up; pure-infra / docs / tests-only bump down). Trust the recommendation; override only when you have a concrete reason (note the reason here).
+
+     **Recompute the tier at the sha you will bind the marker to, not at the
+     sha you first reviewed.** The tier is a function of the diff, and the diff
+     GROWS across fix-back rounds while the tier decision, made once, does not.
+     The `pr-review` marker is sha-bound so it correctly goes stale on a new
+     push — but staleness only forces a re-REVIEW at whatever tier you last
+     chose, so an under-tiered PR is re-reviewed just as thinly the second time.
+     Measured here on 2026-08-27: go-to-k/cdk-local#609 was tiered from its
+     first commit at 819 LOC / 5 files, which is `1-reviewer`, and one reviewer
+     was dispatched. Its fix round took it to 1342 LOC, which is `3-axis`. The
+     spec and test reviewers added only after re-computing then found a live
+     order-blind fail-open in the new code and two wrong counts in the PR body,
+     neither of which the single code reviewer's remit covered.
    - Synthesize the reviewer reports (or your inline read) into a pass / issues-found verdict. Any blocker → fix-back loop before continuing.
    - `git diff origin/main...HEAD` — confirm the diff is what you reviewed (no last-minute commits slipped through).
    - For each change: is it correct? complete? necessary?

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -486,6 +486,27 @@ run was the implementing agent deriving its next count with `awk` and catching
 its own correction mid-flight, and declining to relay a path from the
 orchestrator's message after grepping and finding no such file.
 
+**Re-derive at the FINAL sha, not at the round that produced the number.** The
+rule above says a relayed count must be re-run; the half it leaves out is WHEN,
+and that is where it actually fails. A count is correct when a round reports it
+and stale by the time it reaches the PR body, because the PR body is written once
+and the branch keeps moving. The durable artifact is the diff being merged, so
+that is the tree the number has to describe.
+
+Measured here on 2026-08-27 across one `/work-issues` run, which published FOUR
+counts, every one of them accurate for the round that reported it and wrong
+against the merged branch: "90 cases" (94 by the time it was checked), "52 -> 93
+cases" (the file was NEW, so against `main` it is 0 -> 118), "354 -> 368"
+(354 was a mid-PR peak; the real delta is 337 -> 358, and the feature that added
+the difference was later deleted), and "6 sites closed" (7 — the enumeration
+omitted one the totals included). Three of the four went into PR bodies and had
+to be patched after review caught them.
+
+The cheap discipline: derive every published count in the same pass that writes
+the body, from the branch you are about to merge, and paste the command. A number
+carried forward from a subagent's report three rounds ago is a number about a tree
+that no longer exists.
+
 **And whatever you do file, resolve it against the issues ALREADY OPEN first.**
 The sweep above looks for sibling sites in the CODE. This looks for a sibling
 ISSUE, and it is a different search with a different answer: the issue that
@@ -816,6 +837,31 @@ that, both run against the real tree rather than reasoned about, and on
 A fence is not evidence until you have watched it go red on something you had
 NOT already counted — the calibration hits do not count, and neither does the
 failure direction you drove with the same instances.
+
+**A suite enumerated along ONE dimension goes green over defects that live in the
+other one.** The probes above vary the SPELLING of the input. The second axis is
+the STATE the subject is in when the input arrives, and it is the one that gets
+enumerated by accident: every case reuses whatever fixture setup the first case
+needed, so the suite covers one row of a table it never drew.
+
+Measured here on 2026-08-27, twice in one PR (go-to-k/cdk-local#609). A commit
+gate shipped 52 green cases with two live fail-opens, was fixed, and shipped 93
+green cases with four more — and both times the misses were a file STATE the
+fixture never entered, not a command shape nobody imagined. Every case in the
+block that mattered used a file that was already staged, so the branches for an
+untracked file, a tracked-but-modified file, and a file deleted on disk were
+never executed. One of those branches let a NUL byte reach a commit.
+
+What ended it was drawing the table: six file states crossed with four command
+shapes, 24 cells, each an actual case. Two useful side effects. The cross-product
+makes the UNCOVERED cells nameable, so the PR could list what it deliberately does
+not handle (submodules, sparse-checkout, linked worktrees with a differing index,
+CRLF filters, merge-conflicted paths) instead of leaving that as an assumption.
+And three cells turned out to be false blocks nobody had noticed, which is a
+finding a one-dimensional suite cannot produce at all.
+
+So before trusting a green suite: name the dimensions the subject actually has,
+and check the cases are a grid rather than a line.
 
 **When the change alters a CLASSIFIER, hand-picked cases cannot fence it —
 measure the DELTA against the old implementation.** A classifier is any function


### PR DESCRIPTION
## Summary

Retrospective for the `/work-issues` run that landed
https://github.com/go-to-k/cdk-local/pull/609,
https://github.com/go-to-k/cdk-local/pull/610,
https://github.com/go-to-k/cdk-local/pull/611 and
https://github.com/go-to-k/cdk-local/pull/612. Three lessons, each amended into
the step where it fires rather than appended to a tail section.

**1. `/verify-pr` step 9 — recompute the review tier at the sha the marker binds
to.** The tier is a function of the diff, and the diff GROWS across fix-back
rounds while the tier decision, made once, does not. The `pr-review` marker is
sha-bound so it correctly goes stale on a new push — but staleness only forces a
re-REVIEW at whatever tier was last chosen, so an under-tiered PR gets re-reviewed
just as thinly. Measured: 609 was tiered from its first commit at 819 LOC / 5
files (`1-reviewer`) and one reviewer was dispatched; its fix round took it to
1342 LOC (`3-axis`). The spec and test reviewers added only after re-computing
found a live order-blind fail-open in the new code plus two wrong counts in the PR
body — neither inside the single code reviewer's remit.

**2. `/work-issues` §5 — re-derive counts at the FINAL sha.** The count rule
already said a relayed number must be re-run; the half it omitted is WHEN, and
that is where it actually failed. A count is correct when a round reports it and
stale by the time it reaches the PR body, because the body is written once and the
branch keeps moving. This run published four, every one accurate for its round and
wrong against the merged branch:

| published | actual | why it drifted |
|---|---|---|
| 90 cases | 94 | grew between report and merge |
| 52 → 93 | 0 → 118 | the file was NEW, so the `main` baseline is 0 |
| 354 → 368 | 337 → 358 | 354 was a mid-PR peak; the feature behind the delta was later deleted |
| 6 sites closed | 7 | the enumeration omitted one the totals included |

Three of the four reached PR bodies and were patched after review caught them.
Folded into the existing count paragraph rather than added beside it, so it stays
one rule.

**3. `/work-issues` §5 — a suite enumerated along ONE dimension goes green over
defects in the other.** The existing probes vary the SPELLING of the input. The
second axis is the STATE the subject is in when the input arrives, and that one
gets enumerated by accident, because every case reuses whatever fixture setup the
first case needed. 609 shipped 52 green cases with two live fail-opens, was fixed,
and shipped 93 green cases with four more — both times the misses were a file
state the fixture never entered (untracked, tracked-but-modified, deleted on
disk), not a command shape nobody imagined. One of those branches let a NUL byte
reach a commit. Drawing the grid (6 states × 4 command shapes, 24 cells) ended it,
made the deliberately-uncovered cells nameable, and surfaced three false blocks a
one-dimensional suite cannot produce at all.

## Cross-repo

These are flow lessons, not cdk-local-specific, so they are owed to the
`work-issues` skill in `cdkd` and `cdk-real-drift` as well. Filed as mirror issues
in the same turn rather than carried as three more gate cycles at the end of an
already long session — see the "Remaining work" note on this PR. Each mirror issue
names the other filing and records that the lesson landed here.

## Test plan

- `vp run verify` rc=0 (234 files, 4042 tests).
- `vp run test:hooks` rc=0 across all nine suites.
- `tests/unit/skills/work-issues-skill-refs.test.ts` green — it scans exactly
  these files for unqualified `#N` references, and every issue and PR reference
  added here is a full URL or fully qualified.
- Control-byte and non-English scans clean over both touched files.
- Prose-only diff: no `src/**`, so no live-test and no integ apply.
