### PR TITLE
fix(test): stop unit tests running a real command action, which exited the worker

### DIFF
--- a/tests/helpers/without-action.ts
+++ b/tests/helpers/without-action.ts
@@ -1,0 +1,49 @@
+import type { Command } from 'commander';
+
+/**
+ * Strip a real CLI command's action handler so a test can drive
+ * `cmd.parse(...)` for its OPTION PARSING ONLY.
+ *
+ * Why this exists (issue go-to-k/cdk-local#402): Commander runs the
+ * registered action as part of `parse()`. A site-level binding test that
+ * builds a REAL factory (`createLocalStartAlbCommand()`,
+ * `createLocalStartServiceCommand()`, ...) and parses an argv to assert on
+ * `cmd.opts()` therefore also STARTS the command — synth, docker
+ * pre-flight, servers, watchers — even though it only ever asserts the
+ * parsed options.
+ *
+ * That is not a slow test; it is a test that outlives itself. Measured on
+ * `tests/unit/cli/local-start-no-logs.test.ts` with an `async_hooks` probe,
+ * four `parse()` calls left four live `PROCESSWRAP` handles at worker exit:
+ *
+ *     at ensureDockerAvailable        (src/local/docker-runner.ts:379)
+ *     at runEcsServiceEmulator        (src/cli/commands/ecs-service-emulator.ts:626)
+ *     at .../local-start-service.ts:98
+ *
+ * i.e. a unit test shelling out to real `docker`. The file's assertions all
+ * pass and the file completes, but the orphaned action chain keeps running
+ * in the forked worker and eventually rejects. `tests/setup.ts` makes
+ * `process.exit` a no-op, so that rejection surfaces as an unhandled
+ * rejection, which Node 24 turns into a non-zero worker exit. Vitest defers
+ * worker termination to the end of the run, so whether the parent has
+ * already removed its `emitUnexpectedExit` listener is a race: lose it and
+ * the whole run reports
+ *
+ *     Error: [vitest-pool]: Worker forks emitted error.
+ *     Caused by: Error: Worker exited unexpectedly
+ *
+ * and exits 1 with every test passing. Measured 5 failures in 10 local
+ * `vp test run` invocations before this fix.
+ *
+ * Replacing the action keeps the parse — and therefore every assertion
+ * these tests make about `cmd.opts()` — completely unchanged. It only drops
+ * the side effect the test never wanted. Reach for it whenever a test
+ * builds a real `createLocal*Command()` and parses argv without mocking the
+ * modules that command's action reaches.
+ */
+export function withoutAction(cmd: Command): Command {
+  // Commander stores a single action handler per command, so registering a
+  // no-op replaces the factory's real one.
+  cmd.action(() => {});
+  return cmd;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { afterAll, vi } from 'vite-plus/test';
+import { afterAll, expect, vi } from 'vite-plus/test';
 import {
   installTerminateGuard,
   pruneForeignSignalListeners,
@@ -161,14 +161,7 @@ interface UndiciDispatcher {
   constructor: new () => UndiciDispatcher;
 }
 
-afterAll(async () => {
-  // Prune any SIGTERM / SIGINT handlers a CLI command action registered while
-  // driving its parse during this file (issue #402). They accumulate across
-  // files in the reused worker (MaxListeners noise) and retain server / socket
-  // references that feed the "Worker exited unexpectedly" native-handle crash;
-  // our prepended fast-terminate guard is preserved.
-  pruneForeignSignalListeners(process, fastTerminate);
-
+async function destroyUndiciPool(): Promise<void> {
   const slot = globalThis as Record<symbol, unknown>;
   const dispatcher = slot[UNDICI_GLOBAL_DISPATCHER] as UndiciDispatcher | undefined;
   // Undefined until the worker issues its first `fetch`; nothing to clear.
@@ -182,4 +175,62 @@ afterAll(async () => {
   } catch {
     // Best-effort teardown — never fail a green suite over pool cleanup.
   }
+}
+
+/**
+ * Fail a test file that finishes while a child process it spawned is still
+ * running (issue go-to-k/cdk-local#402).
+ *
+ * This is the fence for the root cause of the "Worker exited unexpectedly"
+ * exit-1 flake: a unit test that builds a REAL `createLocal*Command()` and
+ * calls `cmd.parse(...)` also RUNS the command's action, which reaches
+ * `ensureDockerAvailable` and shells out to `docker`. The file's assertions
+ * pass and the file ends, but the orphaned action chain keeps running in the
+ * forked worker and eventually rejects; `process.exit` is a no-op here, so
+ * Node 24 turns that into a non-zero worker exit. Vitest defers worker
+ * termination to the end of the run, so whether the parent has already
+ * dropped its `emitUnexpectedExit` listener is a race — losing it fails the
+ * whole run with every test passing. Measured 5 failures in 10 local runs
+ * before the fix, 0 in 27 after.
+ *
+ * The leak is deterministic even though the crash is not, which is what makes
+ * it worth asserting: the flake needs a race, this check does not.
+ *
+ * `tests/helpers/without-action.ts` is the fix a tripped assertion wants.
+ */
+async function assertNoLeakedChildProcesses(): Promise<void> {
+  // Yield one macrotask first: a child the file legitimately spawned AND
+  // awaited (front-door-tls shells out to `openssl`) can still be listed for
+  // a tick after it exits, and flagging that would make this check itself
+  // flaky.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const leaked = process.getActiveResourcesInfo().filter((r) => r === 'ProcessWrap').length;
+  if (leaked === 0) {
+    return;
+  }
+
+  const testPath = expect.getState().testPath ?? 'this test file';
+  throw new Error(
+    `${testPath} finished with ${leaked} child process(es) still running.\n` +
+      'A unit test spawned a real subprocess and never waited for it. The usual ' +
+      "cause is calling `parse()` on a real `createLocal*Command()`: Commander runs " +
+      'the action, which shells out to `docker`. Wrap the command in ' +
+      '`withoutAction()` from `tests/helpers/without-action.ts` to parse options ' +
+      'without running the action, or await / kill the process the test starts. ' +
+      'See issue go-to-k/cdk-local#402.'
+  );
+}
+
+afterAll(async () => {
+  // Prune any SIGTERM / SIGINT handlers a CLI command action registered while
+  // driving its parse during this file (issue #402). They accumulate across
+  // files in the reused worker (MaxListeners noise) and retain server / socket
+  // references; our prepended fast-terminate guard is preserved.
+  pruneForeignSignalListeners(process, fastTerminate);
+
+  await destroyUndiciPool();
+
+  // Last, so the cleanup above always runs even when this throws.
+  await assertNoLeakedChildProcesses();
 });

--- a/tests/unit/cli/local-start-alb-watch.test.ts
+++ b/tests/unit/cli/local-start-alb-watch.test.ts
@@ -6,6 +6,7 @@ import {
   createLocalStartAlbCommand,
 } from '../../../src/cli/commands/local-start-alb.js';
 import { type EcsServiceEmulatorOptions } from '../../../src/cli/commands/ecs-service-emulator.js';
+import { withoutAction } from '../../helpers/without-action.js';
 
 /**
  * Phase 3 of issue #214 — locks the `cdkl start-alb --watch` wiring
@@ -63,7 +64,10 @@ describe('start-alb --watch (Phase 3 of #214)', () => {
     // argument would leave the gate's `=== true` check falsy and
     // silently disable `--watch` for start-alb. Drive the parse
     // end-to-end so any drift trips this test.
-    const cmd = createLocalStartAlbCommand();
+    // Options only: `parse()` would otherwise run the real start-alb
+    // action, which shells out to `docker` and leaves live child processes
+    // behind after this file finishes (issue #402).
+    const cmd = withoutAction(createLocalStartAlbCommand());
     // Disable Commander's default exit + output so a parse misstep
     // throws into the test rather than calling process.exit(1).
     cmd.exitOverride();
@@ -74,7 +78,7 @@ describe('start-alb --watch (Phase 3 of #214)', () => {
     // Default value: a parse WITHOUT `--watch` must leave `opts().watch`
     // falsy so the gate's `=== true` check rejects it (and the watcher
     // is never installed).
-    const cmd2 = createLocalStartAlbCommand();
+    const cmd2 = withoutAction(createLocalStartAlbCommand());
     cmd2.exitOverride();
     cmd2.configureOutput({ writeOut: () => {}, writeErr: () => {} });
     cmd2.parse(['node', 'cdkl', 'start-alb', 'MyStack:WebLB'], { from: 'user' });

--- a/tests/unit/cli/local-start-api-assume-role-bare-binding.test.ts
+++ b/tests/unit/cli/local-start-api-assume-role-bare-binding.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vite-plus/test';
 import { Command } from 'commander';
 import { createLocalStartApiCommand } from '../../../src/cli/commands/local-start-api.js';
 import type { AssumeRoleOption } from '../../../src/cli/options.js';
+import { withoutAction } from '../../helpers/without-action.js';
 
 const ARN = 'arn:aws:iam::123456789012:role/MyRole';
 const ARN_2 = 'arn:aws:iam::123456789012:role/OtherRole';
@@ -25,9 +26,10 @@ function parseStartApiArgs(args: string[]): {
   assumeRole: AssumeRoleOption | undefined;
   assumeRoleAuto: boolean;
 } {
-  const cmd = createLocalStartApiCommand();
-  // Stub the action so parseAsync doesn't try to boot the server.
-  cmd.action(() => {});
+  // Options only: `parse()` would otherwise run the real start-api action
+  // and boot the server. Single-sourced with the other parse-only sites so
+  // one documented helper carries the reason (issue #402).
+  const cmd = withoutAction(createLocalStartApiCommand());
   cmd.exitOverride();
   cmd.parse(['node', 'cdkl', ...args]);
   return cmd.opts() as {

--- a/tests/unit/cli/local-start-cloudfront.test.ts
+++ b/tests/unit/cli/local-start-cloudfront.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../src/cli/commands/local-start-cloudfront.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+import { withoutAction } from '../../helpers/without-action.js';
 
 function stack(name: string, template: CloudFormationTemplate): StackInfo {
   return {
@@ -197,8 +198,9 @@ describe('createLocalStartCloudFrontCommand — option surface', () => {
   });
 
   it('resolves --no-pull to pull=false (Commander negation)', () => {
-    const fresh = createLocalStartCloudFrontCommand();
-    fresh.action(() => {});
+    // Options only: `parse()` would otherwise run the real start-cloudfront
+    // action (issue #402).
+    const fresh = withoutAction(createLocalStartCloudFrontCommand());
     const parsed = fresh.parse(['node', 'cdkl', 'My/Dist', '--no-pull'], { from: 'user' });
     expect(parsed.opts().pull).toBe(false);
   });

--- a/tests/unit/cli/local-start-no-logs.test.ts
+++ b/tests/unit/cli/local-start-no-logs.test.ts
@@ -7,6 +7,7 @@ import {
   createLocalStartAlbCommand,
 } from '../../../src/cli/commands/local-start-alb.js';
 import { addCommonEcsServiceOptions } from '../../../src/cli/commands/ecs-service-emulator.js';
+import { withoutAction } from '../../helpers/without-action.js';
 
 /**
  * Issue #227 review fix (Test G1) — site-level binding test for the
@@ -37,7 +38,10 @@ import { addCommonEcsServiceOptions } from '../../../src/cli/commands/ecs-servic
  */
 
 function parseWith(create: () => Command, argv: string[]): { logs: unknown } {
-  const cmd = create();
+  // Options only: `parse()` would otherwise run the real start-service /
+  // start-alb action, which shells out to `docker` and leaves live child
+  // processes behind after this file finishes (issue #402).
+  const cmd = withoutAction(create());
   cmd.exitOverride();
   cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} });
   cmd.parse(argv, { from: 'user' });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,20 +72,23 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     setupFiles: ['./tests/setup.ts'],
-    // Diagnostics for issue #402's "Worker exited unexpectedly" crash variant:
-    // a reused forks worker occasionally dies on a native handle AFTER all
-    // assertions pass. It is intermittent and not locally reproducible, so we
-    // arm Node's diagnostic report on the forks workers — a fatal C++ error or
-    // an uncaught exception writes a `report.*.json` (native + JS stack, open
-    // libuv handles) to cwd, which CI dumps to the log on failure (see
-    // `.github/workflows/ci.yml`). No overhead on a clean run — a report is
-    // written ONLY when a worker actually crashes.
+    // Diagnostics for issue #402's "Worker exited unexpectedly" exit-1
+    // variant: a forks worker exits non-zero AFTER all assertions pass, and
+    // whether that races vitest's `emitUnexpectedExit` teardown decides
+    // whether a green suite reports exit 1. Node's diagnostic report writes a
+    // `report.*.json` (native + JS stack, open libuv handles) to cwd on a
+    // fatal error or an uncaught exception, which CI dumps to the log on
+    // failure (see `.github/workflows/ci.yml`). No overhead on a clean run.
+    //
+    // These MUST stay top-level: vitest 4 REMOVED `test.poolOptions` (it
+    // warns `DEPRECATED \`test.poolOptions\` was removed in Vitest 4` and
+    // ignores the block), so the `poolOptions.forks.execArgv` these lived in
+    // until #402's root-cause pass never reached a worker at all — which is
+    // why the CI dump step had been reporting "No Node diagnostic report
+    // written" for every occurrence and the crash looked native when it was
+    // an ordinary non-zero exit.
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        execArgv: ['--report-on-fatalerror', '--report-uncaught-exception'],
-      },
-    },
+    execArgv: ['--report-on-fatalerror', '--report-uncaught-exception'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

CI's `check-build-test` intermittently exited 1 with **every test passing**. The
issue had it as a native crash in an undici keep-alive socket, and as not
locally reproducible. Both halves were wrong.

**It reproduces locally at 5 failures in 10 runs.** `vp run test` is CACHED and
replays a recorded exit code; `vp test run` is not, and the flake is plain once
you stop replaying a cached green. Independently re-measured by the orchestrator:
1 failure in 6 on the unfixed tree with the exact signature, 0 in 8 on the fixed
one.

## Root cause

Not undici. `tests/unit/cli/local-start-no-logs.test.ts` and
`local-start-alb-watch.test.ts` build **real** `createLocal*Command()` factories
with **zero mocks** and call `cmd.parse(...)` to read `cmd.opts()`. Commander
runs the action as part of `parse()`, so each parse started the real command — a
unit test shelling out to `docker`. An `async_hooks` probe on the leaked
`PROCESSWRAP`:

```
at ensureDockerAvailable   (src/local/docker-runner.ts:379)
at runEcsServiceEmulator   (src/cli/commands/ecs-service-emulator.ts:626)
at .../local-start-service.ts:98
```

Assertions pass, the file ends, and the orphaned action chain keeps running in
the fork and eventually rejects. `tests/setup.ts` makes `process.exit` a no-op,
so Node 24 turns that into a non-zero worker exit. Vitest defers worker
termination to the end of the run, so whether the parent has already dropped
`emitUnexpectedExit` is a **race** — losing it fails the whole run green. Live
`ProcessWrap` counts matched parse-site counts exactly (4 and 2).

This also explains the **hang** variant reported on the same issue: same file,
same cause.

## The diagnostics that were supposed to explain this had never armed

Vitest 4 **removed** `test.poolOptions` — it prints `DEPRECATED … was removed in
Vitest 4` and ignores the block. So the `poolOptions.forks.execArgv` added for
this issue never reached a worker, and every CI failure's *"No Node diagnostic
report written (worker did not hit a fatal/uncaught crash)"* was **vacuous** —
which is exactly what made an ordinary non-zero exit look like a native crash.
`execArgv` is top-level in Vitest 4; moved.

## The fence

`assertNoLeakedChildProcesses()` in `tests/setup.ts` fails any file finishing
with a live `ProcessWrap`. **The leak is deterministic even though the crash is
not**, which is what makes it assertable: the flake needs a race, the check does
not. It runs last in the existing `afterAll` so cleanup always completes, and
yields one macrotask first — load-bearing, because a legitimately awaited child
(`front-door-tls` shells out to `openssl`) is still listed for a tick and
flagging it would make the check itself flaky.

Known limitation, stated rather than discovered: the count is process-wide, so in
a reused forks worker a leak could in principle be attributed to a later file
than the one that caused it. It fails in the safe direction — someone
investigates — and the message names the usual cause.

## Scope note: two of the six file changes are a refactor, not a fix

`local-start-api-assume-role-bare-binding.test.ts` and
`local-start-cloudfront.test.ts` are converted from a hand-rolled inline
`cmd.action(() => {})` to the same helper. **They were never exposed** — they
already stubbed the action, so they never leaked. This is single-sourcing: three
spellings of one idiom, none naming the issue, is how the next person
reintroduces it. Calling it "swept two more leak sites" would overstate it.

## Test plan

- **5/10 failures before → 0 in 27 runs after** (implementer), and **1/6 before →
  0/8 after** (orchestrator, measured independently on separate trees).
- **Mutation probe**: removing the helper from one file gives
  `Test Files 1 failed | Tests 5 passed`, naming the 4 leaked processes — the
  pathology in one line, and precisely what used to escape as a random worker
  crash. Re-run independently by the orchestrator with the same result.
- **No assertion changed or weakened.** These tests only ever asserted
  `cmd.opts()`; the action's execution was never asserted. Test count is
  unchanged at 4042.
- `vp run verify` rc=0 (234 files, 4042 tests, 0 type errors), with `test`
  genuinely re-run rather than cache-replayed.
- No `src/**` or `tests/integration/**` change, so no integ applies.

## What remains unproven

Causal identity with CI is **inferred, not observed**: a signature-identical
local failure was reproduced and eliminated, but no CI failure was ever captured
with the fix absent and diagnostics armed. It is possible CI has an additional
trigger. No CI run has exercised this fix yet.

## Follow-up filed

https://github.com/go-to-k/cdk-local/issues/615 — a *different* flake found
while measuring this one: `cfn-local-state-provider-load.test.ts` times out at 5s
roughly 1 run in 27. Distinct signature (`Tests 1 failed | 4041 passed`, no
`Worker exited unexpectedly`), and the new fence would not catch it — nothing
leaks, the test simply does not finish.

Closes #402
