### PR TITLE
fix(local): bound the role ARN's shape and length before it reaches STS

### DIFF
--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -13,7 +13,13 @@ import {
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
-import { applyRoleArnIfSet, AssumeRoleFailure } from '../../utils/role-arn.js';
+import {
+  applyRoleArnIfSet,
+  AssumeRoleFailure,
+  describeRejectedRoleArn,
+  isIamRoleArn,
+  refusedRoleArnMessage,
+} from '../../utils/role-arn.js';
 import { getDockerCmd } from '../../utils/docker-cmd.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -1508,10 +1514,37 @@ export async function resolveAssumeRoleArn(
   loaded: LocalStateRecord | undefined,
   stateProvider?: Pick<LocalStateProvider, 'resolveAgentCoreRuntimeRoleArn'>
 ): Promise<string | undefined> {
-  if (typeof options.assumeRole === 'string') return options.assumeRole;
+  if (typeof options.assumeRole === 'string') {
+    // Issue #607: `cdkl start-api` validates `--assume-role <arn>` at PARSE
+    // time (`parseAssumeRoleToken`, wired as that command's `argParser`), and
+    // this command has no argParser at all — so the identical spelling reached
+    // STS unchecked here. Rejecting at this resolution point restores the
+    // symmetry AND keeps an unbounded value off the callers' warn lines, which
+    // interpolate `flattenToOneLine(assumeRoleArn)` with no length cap of
+    // their own. A hard error, matching `parseAssumeRoleToken`: the user typed
+    // this, so silently ignoring it and falling back to shell credentials
+    // would be the wrong shape.
+    if (!isIamRoleArn(options.assumeRole)) {
+      throw new CdkLocalError(
+        `Invalid --assume-role value: expected an IAM role ARN like ` +
+          `arn:aws:iam::123456789012:role/MyRole, got ${describeRejectedRoleArn(options.assumeRole)}.`,
+        'LOCAL_INVOKE_AGENTCORE_ASSUME_ROLE_INVALID'
+      );
+    }
+    return options.assumeRole;
+  }
   if (options.assumeRole !== true) return undefined;
   // Bare --assume-role from here on.
-  if (resolved.roleArn) return resolved.roleArn;
+  // Issue #607: the template's literal `RoleArn`, the agentcore twin of
+  // `local-start-api`'s `Properties.Role`. Shape-checked, then FALL THROUGH to
+  // the state lookup on rejection — a runtime whose template RoleArn is not a
+  // usable ARN was always meant to be recoverable from deployed state.
+  if (resolved.roleArn !== undefined) {
+    if (isIamRoleArn(resolved.roleArn)) return resolved.roleArn;
+    getLogger().warn(
+      `--assume-role: the template RoleArn for '${resolved.logicalId}' is not a well-formed IAM role ARN: ${describeRejectedRoleArn(resolved.roleArn)}. Ignoring it.`
+    );
+  }
   if (loaded) {
     const fromState = resolveExecutionRoleArnFromState(loaded, resolved.logicalId, 'RoleArn');
     if (fromState) {
@@ -1527,7 +1560,14 @@ export async function resolveAssumeRoleArn(
     const runtimePhysicalId = loaded.resources[resolved.logicalId]?.physicalId;
     if (stateProvider?.resolveAgentCoreRuntimeRoleArn && runtimePhysicalId) {
       const liveArn = await stateProvider.resolveAgentCoreRuntimeRoleArn(runtimePhysicalId);
-      if (liveArn) {
+      // Issue #607: shape-checked here as well as inside cdk-local's own
+      // provider, because `stateProvider` is an INTERFACE a host CLI may
+      // implement. Same reasoning as the `local-invoke.ts` sibling.
+      if (liveArn !== undefined && !isIamRoleArn(liveArn)) {
+        getLogger().warn(
+          `--assume-role: GetAgentRuntime for '${resolved.logicalId}' produced a value that is not a well-formed IAM role ARN: ${describeRejectedRoleArn(liveArn)}. Ignoring it.`
+        );
+      } else if (liveArn) {
         // Issue #570: FLATTENED. `liveArn` is the deployed `roleArn` off a
         // `GetAgentRuntime` response with only a `startsWith('arn:')` check, and
         // `info` is a default level studio mirrors into an HTTP-served ring.
@@ -1681,6 +1721,33 @@ async function assumeAgentCoreExecutionRole(
   region: string | undefined,
   profile: string | undefined
 ): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }> {
+  // GUARDED SEND (issue #607). The THIRD of the five `new AssumeRoleCommand(`
+  // sites in `src/`, and the one that matters most after the two in
+  // `utils/role-arn.ts`: every one of this function's three callers passes
+  // `resolveAssumeRoleArn(...)`'s output, so the value can be the runtime's
+  // template `RoleArn`, a deployed-state read, a `GetAgentRuntime` response,
+  // or a host-supplied `LocalStateProvider`'s return. Those are all checked at
+  // their resolution points — but `--assume-role <arn>` returns EARLY from
+  // `resolveAssumeRoleArn` before any of them, and unlike `start-api` this
+  // command has no `parseAssumeRoleToken` argParser, so that spelling reached
+  // STS unchecked while its `start-api` equivalent was rejected at parse.
+  //
+  // Shares `refusedRoleArnMessage` with the two guarded sends in
+  // `utils/role-arn.ts` so all three word the refusal identically. Refuses
+  // BEFORE the SDK is even imported, so nothing is loaded, built or logged.
+  //
+  // Throws `AssumeRoleFailure`, NOT a bare error: all three callers re-render
+  // with `describeAwsFailureForWarn` unless the error is an
+  // `AssumeRoleFailure`, and a non-service error is that policy's WITHHELD
+  // branch — so a `CdkLocalError` here would come out as
+  // `CdkLocalError; 213-character message withheld`, the exact double-withhold
+  // `AssumeRoleFailure`'s own JSDoc exists to document.
+  if (!isIamRoleArn(roleArn)) {
+    throw new AssumeRoleFailure(
+      refusedRoleArnMessage(roleArn),
+      `the role ARN is not well-formed: ${describeRejectedRoleArn(roleArn)}`
+    );
+  }
   const { STSClient, AssumeRoleCommand } = await import('@aws-sdk/client-sts');
   // Thread `--profile` so AssumeRole is signed with the profile's
   // credentials, not the default env-shadowed chain (issue #245).

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -18,6 +18,8 @@ import {
   applyRoleArnIfSet,
   assumeRoleCredentials,
   AssumeRoleFailure,
+  describeRejectedRoleArn,
+  isIamRoleArn,
 } from '../../utils/role-arn.js';
 import { CdkLocalError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
@@ -1206,21 +1208,33 @@ export async function resolveAssumeRoleArnForLambda(
     // not its ARN. The function's deploy-time `Configuration.Role`
     // carries the full ARN.
     const liveArn = await stateProvider.resolveLambdaExecutionRoleArn(fnPhysicalId);
-    if (liveArn) {
+    // Issue #607: shape-checked HERE and not only inside cdk-local's own
+    // provider, because `LocalStateProvider` is an INTERFACE a host CLI may
+    // implement — `stateProvider` is whatever the caller passed, so the
+    // check inside `CfnLocalStateProvider` covers only cdk-local's own
+    // implementation. The send is bounded at the choke point regardless; this
+    // is what keeps a host provider's bad value off the `info` line below and
+    // names where it came from.
+    if (liveArn !== undefined && !isIamRoleArn(liveArn)) {
+      logger.warn(
+        `--assume-role: GetFunctionConfiguration for '${lambdaLogicalId}' produced a value that is not a well-formed IAM role ARN: ${describeRejectedRoleArn(liveArn)}. Ignoring it.`
+      );
+    } else if (liveArn) {
       // Issue #570: FLATTENED, and this site is the reason the failure warns
       // below are not enough on their own. `liveArn` is the deployed
-      // `Configuration.Role` straight off a `GetFunctionConfiguration` response,
-      // validated only by `startsWith('arn:')`, and `info` is a DEFAULT level
-      // that `cdkl studio` mirrors into an HTTP-served log ring. This fires on
-      // SUCCESS, so it is strictly more reachable than the failure path.
+      // `Configuration.Role` straight off a `GetFunctionConfiguration`
+      // response, and `info` is a DEFAULT level that `cdkl studio` mirrors
+      // into an HTTP-served log ring. This fires on SUCCESS, so it is strictly
+      // more reachable than the failure path.
       //
-      // Deliberately not LENGTH-capped here: unlike a service message, an ARN
-      // has a shape, so the bound belongs at the `startsWith('arn:')`
-      // resolution point rather than at the log line. Tracked in
-      // https://github.com/go-to-k/cdk-local/issues/607 — it used to point at
-      // #579, which carried the ARN-bound paragraph alongside the relay list
-      // and closes with the relay work, so the pointer would have led to a
-      // closed issue.
+      // Issue #607 CLOSED the other half. `liveArn` is no longer merely
+      // `startsWith('arn:')`: `resolveLambdaExecutionRoleArn` now shape- and
+      // length-checks it with `isIamRoleArn` at the resolution point, which is
+      // where the bound had to go — the same value is SENT as
+      // `AssumeRoleCommand.RoleArn`, so a cap at this log line would have
+      // bounded only what gets printed. The flatten here is now
+      // belt-and-braces rather than the only thing standing between a hostile
+      // endpoint and this line.
       logger.info(
         `--assume-role: auto-resolved execution role from GetFunctionConfiguration: ${flattenToOneLine(liveArn)}`
       );
@@ -1234,6 +1248,32 @@ export async function resolveAssumeRoleArnForLambda(
   return undefined;
 }
 
+/**
+ * Pull a resource's execution-role ARN out of deployed stack state.
+ *
+ * Both reads below are WIRE-derived — `properties` / `observedProperties` and
+ * the referenced role's cached `Arn` attribute all come from a
+ * CloudFormation-backed state record — and the value is handed to
+ * `AssumeRoleCommand.RoleArn`, so each is shape-checked with
+ * {@link isIamRoleArn} rather than the `startsWith('arn:')` it used to carry
+ * (issue #607).
+ *
+ * A value that is PRESENT and rejected warns, because a caller that gets
+ * `undefined` cannot distinguish "state names no role" from "state names
+ * something that is not a role ARN", and the second is a real misconfiguration
+ * a user needs to see. Rejection still returns `undefined`, so the existing
+ * fallback order (state -> live `GetFunctionConfiguration` -> shell
+ * credentials) is unchanged.
+ *
+ * The warns are worded WITHOUT a `--assume-role:` prefix on purpose. An
+ * earlier revision carried one, on the belief that every caller ends in that
+ * flag's "could not resolve the execution role ARN" line. It does not:
+ * {@link suggestAssumeRoleFromState} calls this function on a plain
+ * `cdkl invoke --from-cfn-stack` with NO role flag at all (its caller is
+ * guarded on `options.assumeRole === undefined`) and is silent on a miss — so
+ * the prefix named a flag the user had not passed, on the one path where the
+ * whole point is to SUGGEST it.
+ */
 export function resolveExecutionRoleArnFromState(
   state: Pick<StackState, 'resources'>,
   logicalId: string,
@@ -1242,17 +1282,36 @@ export function resolveExecutionRoleArnFromState(
   const lambda = state.resources[logicalId];
   if (!lambda) return undefined;
 
+  const logger = getLogger();
   const roleRef = lambda.properties?.[roleProperty] ?? lambda.observedProperties?.[roleProperty];
-  if (typeof roleRef === 'string' && roleRef.startsWith('arn:')) {
-    return roleRef;
+  if (typeof roleRef === 'string') {
+    if (isIamRoleArn(roleRef)) {
+      return roleRef;
+    }
+    logger.warn(
+      `Deployed state for '${logicalId}' carries a ${roleProperty} that is not a well-formed IAM role ARN: ${describeRejectedRoleArn(roleRef)}. Ignoring it.`
+    );
+    return undefined;
   }
   if (typeof roleRef === 'object' && roleRef !== null) {
     const refLogicalId = pickReferencedLogicalId(roleRef as Record<string, unknown>);
     if (refLogicalId) {
       const roleResource = state.resources[refLogicalId];
       const cached = roleResource?.attributes?.['Arn'];
-      if (typeof cached === 'string' && cached.startsWith('arn:')) {
+      if (isIamRoleArn(cached)) {
         return cached;
+      }
+      // An EMPTY `Arn` is not a misconfiguration — it is the documented
+      // sibling-stack shape (see issue #181 in this function's caller's
+      // JSDoc: `ListStackResources` returns the role's NAME, so the state map
+      // carries an empty `Arn` and the live `GetFunctionConfiguration`
+      // fallback is what resolves it). Warning on it would put a line on the
+      // normal success path. `cached !== undefined` did exactly that, because
+      // `''` passes it.
+      if (typeof cached === 'string' && cached.length > 0) {
+        logger.warn(
+          `The cached Arn attribute of '${refLogicalId}' is not a well-formed IAM role ARN: ${describeRejectedRoleArn(cached)}. Ignoring it.`
+        );
       }
     }
   }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -16,7 +16,12 @@ import {
 import { resolveProfileCredentials, buildStsClientConfig } from '../../utils/profile-resolver.js';
 import { getLogger } from '../../utils/logger.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from '../../local/credential-error.js';
-import { applyRoleArnIfSet, assumeRoleCredentials } from '../../utils/role-arn.js';
+import {
+  applyRoleArnIfSet,
+  assumeRoleCredentials,
+  describeRejectedRoleArn,
+  isIamRoleArn,
+} from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from '../../local/target-lister.js';
 import { isInteractive, pickManyTargets } from '../../local/target-picker.js';
@@ -2020,8 +2025,22 @@ export function resolveStartApiAssumeRoleArn(args: {
   // `Properties.Role` first (most CDK apps render this as an intrinsic,
   // but explicit-ARN refs DO surface here), then the deployed state.
   const roleProp = (lambdaResource.Properties ?? {})['Role'];
-  if (typeof roleProp === 'string' && roleProp.startsWith('arn:')) {
-    return roleProp;
+  if (typeof roleProp === 'string') {
+    // Issue #607: shape-checked, not `startsWith('arn:')`. This value is
+    // returned to a caller that hands it to `AssumeRoleCommand.RoleArn`. The
+    // send itself is bounded at the choke point in `utils/role-arn.ts`; the
+    // check HERE is what tells the user WHERE the bad value came from, which a
+    // refusal at the send cannot.
+    if (isIamRoleArn(roleProp)) {
+      return roleProp;
+    }
+    // Warn, then FALL THROUGH to the state lookup — the pre-#607 control flow
+    // for a string that failed the check, preserved deliberately: a template
+    // Role that is not a literal ARN was always meant to be recoverable from
+    // deployed state.
+    getLogger().warn(
+      `--assume-role: the template Role for '${logicalId}' is not a well-formed IAM role ARN: ${describeRejectedRoleArn(roleProp)}. Ignoring it.`
+    );
   }
   if (stateBundle) {
     const fromState = resolveExecutionRoleArnFromState(stateBundle.state, logicalId);

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,5 +1,6 @@
 import { Option } from 'commander';
 import { getEmbedConfig } from '../local/embed-config.js';
+import { isIamRoleArn } from '../utils/role-arn.js';
 
 /**
  * Parse context key=value pairs from CLI arguments into a Record.
@@ -141,8 +142,16 @@ export interface AssumeRoleOption {
   bareAutoResolve?: boolean;
 }
 
-const IAM_ROLE_ARN_REGEX = /^arn:[^:]+:iam::\d+:role\//;
-
+/**
+ * Shape-checks both forms against {@link isIamRoleArn}.
+ *
+ * This file used to own a private `IAM_ROLE_ARN_REGEX`, while three WIRE
+ * resolution points asked the same question with `startsWith('arn:')` (issue
+ * #607) — so "is this a role ARN?" had two answers depending on whether the
+ * value came from the flag or off a `GetFunctionConfiguration` response. The
+ * predicate now lives in `src/utils/role-arn.ts`, beside the AssumeRole call
+ * that consumes it, and this site calls it rather than keeping a copy.
+ */
 export function parseAssumeRoleToken(
   raw: string,
   previous: AssumeRoleOption | undefined
@@ -152,12 +161,21 @@ export function parseAssumeRoleToken(
 
   const eqIndex = raw.indexOf('=');
   if (eqIndex === -1) {
-    if (!IAM_ROLE_ARN_REGEX.test(raw)) {
+    // TRIMMED, like the pair form two lines below (issue #607). The pair form
+    // has always trimmed both sides and the bare form never did, which was an
+    // inconsistency between two spellings of one flag before this change and
+    // became user-visible with it: the old regex was unanchored, so a
+    // copy-pasted `--assume-role "arn:...:role/R "` with trailing whitespace
+    // was silently accepted, and an anchored pattern rejects it. Trimming is
+    // the fix that keeps the two forms agreeing, rather than making the bare
+    // form newly stricter than the pair form for the same text.
+    const bare = raw.trim();
+    if (!isIamRoleArn(bare)) {
       throw new Error(
         `Invalid --assume-role value "${raw}": expected an IAM role ARN like arn:aws:iam::123456789012:role/MyRole, or LogicalId=<arn>.`
       );
     }
-    acc.globalArn = raw;
+    acc.globalArn = bare;
     return acc;
   }
 
@@ -168,7 +186,7 @@ export function parseAssumeRoleToken(
       `Invalid --assume-role value "${raw}": left-hand side "${logicalId}" must be a CloudFormation logical ID (alphanumeric, leading letter).`
     );
   }
-  if (!IAM_ROLE_ARN_REGEX.test(arn)) {
+  if (!isIamRoleArn(arn)) {
     throw new Error(
       `Invalid --assume-role value "${raw}": right-hand side "${arn}" must be an IAM role ARN like arn:aws:iam::123456789012:role/MyRole.`
     );

--- a/src/local/cfn-local-state-provider.ts
+++ b/src/local/cfn-local-state-provider.ts
@@ -76,6 +76,7 @@ import {
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { getLogger } from '../utils/logger.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
+import { describeRejectedRoleArn, isIamRoleArn } from '../utils/role-arn.js';
 import { collectSsmParameterRefs, resolveSsmParameters } from './ssm-parameter-resolver.js';
 import type { ResolvedSsmParameters } from './ssm-parameter-resolver.js';
 import type { CloudFormationTemplate } from '../types/resource.js';
@@ -312,8 +313,26 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       const resp = await client.send(
         new GetFunctionConfigurationCommand({ FunctionName: functionPhysicalId })
       );
-      if (typeof resp.Role === 'string' && resp.Role.startsWith('arn:')) {
+      // Issue #607: a SHAPE check, not `startsWith('arn:')`. This value is
+      // not only printed — it is handed straight to
+      // `AssumeRoleCommand.RoleArn`, so a bound at the log line would cover
+      // only half of it.
+      if (isIamRoleArn(resp.Role)) {
         return resp.Role;
+      }
+      // A field that is ABSENT stays silent: there is nothing to report and
+      // the caller already warns that it could not resolve a role. A field
+      // that is PRESENT and rejected is different — it is either a real
+      // misconfiguration (a role name, an ARN of the wrong resource type) or
+      // an endpoint returning something it should not, and the caller's
+      // generic "could not resolve" says neither. So it warns HERE, where the
+      // rejected value is still in hand, and still returns `undefined` so the
+      // existing "pass the ARN explicitly" fallback is unchanged.
+      if (resp.Role !== undefined) {
+        logger.warn(
+          `${this.label}: GetFunctionConfiguration(${flattenToOneLine(functionPhysicalId)}) returned a Role that is not a well-formed IAM role ARN: ${describeRejectedRoleArn(resp.Role)}. ` +
+            `Ignoring it. Pass the ARN explicitly: --assume-role <arn>.`
+        );
       }
       return undefined;
     } catch (err) {
@@ -347,8 +366,17 @@ export class CfnLocalStateProvider implements LocalStateProvider {
       const resp = await client.send(
         new GetAgentRuntimeCommand({ agentRuntimeId: runtimePhysicalId })
       );
-      if (typeof resp.roleArn === 'string' && resp.roleArn.startsWith('arn:')) {
+      // Issue #607 — same shape check, same reason, as the Lambda sibling
+      // above: this value is SENT as `AssumeRoleCommand.RoleArn`.
+      if (isIamRoleArn(resp.roleArn)) {
         return resp.roleArn;
+      }
+      // Present-but-rejected warns; absent stays silent. See the sibling.
+      if (resp.roleArn !== undefined) {
+        logger.warn(
+          `${this.label}: GetAgentRuntime(${flattenToOneLine(runtimePhysicalId)}) returned a roleArn that is not a well-formed IAM role ARN: ${describeRejectedRoleArn(resp.roleArn)}. ` +
+            `Ignoring it. Pass the ARN explicitly: --assume-role <arn>.`
+        );
       }
       return undefined;
     } catch (err) {

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -10,6 +10,7 @@ import { getLogger } from '../utils/logger.js';
 import { buildStsClientConfig } from '../utils/profile-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
+import { isIamRoleArn, refusedRoleArnMessage } from '../utils/role-arn.js';
 
 /**
  * ECR pull fallback for `cdkl invoke` / `cdkl start-api` /
@@ -322,6 +323,34 @@ async function assumeRoleForEcr(
   profile: string | undefined,
   logger: ReturnType<ReturnType<typeof getLogger>['child']>
 ): Promise<TempCredentials> {
+  // GUARDED SEND (issue #607) — one of the two ARGV-SOURCED sends, the last of
+  // the five `new AssumeRoleCommand(` sites in `src/` to be guarded. This one
+  // is `--ecr-role-arn`; its twin is in the other file.
+  //
+  // The reason is CONSISTENCY and the LENGTH BOUND, explicitly NOT the threat
+  // model. #607 is about a role ARN arriving off the WIRE — a hostile
+  // `GetFunctionConfiguration` / `GetAgentRuntime` response or a compromised
+  // CloudFormation state read — and that path does not reach here: this
+  // function's ARN comes only from `--ecr-role-arn` on the user's own command
+  // line. A comment implying otherwise would be the next false invariant, and
+  // this lane already had to retract one ("one of the two places in the
+  // process where a role ARN is handed to STS" — there are five).
+  //
+  // What guarding buys is that all five sends answer "is this a role ARN?" the
+  // same way, and that an unbounded value cannot be sent or printed even when
+  // the user is the one who typed it. `--layer-role-arn` / `--ecr-role-arn`
+  // are declared as plain `new Option('<flag> <arn>', …)` with NO `argParser`
+  // — `local-start-api.ts` holds the repo's only `parseAssumeRoleToken`
+  // wiring — so nothing validated them before this.
+  //
+  // Thrown BEFORE the `debug` line and the client, and OUTSIDE the `try`, so a
+  // refused value is never printed, never opens a socket pool, and never meets
+  // the `catch`'s withholding policy — which would render cdk-local's own
+  // sentence as `LocalInvokeBuildError; NNN-character message withheld`.
+  if (!isIamRoleArn(roleArn)) {
+    throw new LocalInvokeBuildError(refusedRoleArnMessage(roleArn));
+  }
+
   logger.debug(`Assuming role ${roleArn} for ECR pull...`);
   // Thread `--profile` so the AssumeRole source identity is the profile's,
   // matching the rest of the pull path.

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -8,6 +8,7 @@ import { getLogger } from '../utils/logger.js';
 import type { ResolvedArnLambdaLayer } from './lambda-resolver.js';
 import { getEmbedConfig } from './embed-config.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from './credential-error.js';
+import { isIamRoleArn, refusedRoleArnMessage } from '../utils/role-arn.js';
 
 /**
  * Materialize a literal-ARN Lambda Layer to a host tmpdir so it can be
@@ -304,6 +305,36 @@ async function assumeRoleForLayer(
   region: string,
   options: MaterializeLayerOptions
 ): Promise<AwsCredentials> {
+  // GUARDED SEND (issue #607) — one of the two ARGV-SOURCED sends, the last of
+  // the five `new AssumeRoleCommand(` sites in `src/` to be guarded. This one
+  // is `--layer-role-arn`; its twin is in the other file.
+  //
+  // The reason is CONSISTENCY and the LENGTH BOUND, explicitly NOT the threat
+  // model. #607 is about a role ARN arriving off the WIRE — a hostile
+  // `GetFunctionConfiguration` / `GetAgentRuntime` response or a compromised
+  // CloudFormation state read — and that path does not reach here: this
+  // function's ARN comes only from `--layer-role-arn` on the user's own command
+  // line. A comment implying otherwise would be the next false invariant, and
+  // this lane already had to retract one ("one of the two places in the
+  // process where a role ARN is handed to STS" — there are five).
+  //
+  // What guarding buys is that all five sends answer "is this a role ARN?" the
+  // same way, and that an unbounded value cannot be sent or printed even when
+  // the user is the one who typed it. `--layer-role-arn` / `--ecr-role-arn`
+  // are declared as plain `new Option('<flag> <arn>', …)` with NO `argParser`
+  // — `local-start-api.ts` holds the repo's only `parseAssumeRoleToken`
+  // wiring — so nothing validated them before this.
+  //
+  // Throws the ALREADY-FRAMED `LayerMaterializationError`, not
+  // `UnframedLayerError`: the caller re-throws a framed error untouched, while
+  // an unframed one is wrapped in `STS AssumeRole(${flattenToOneLine(roleArn)})
+  // failed: …` — which interpolates the raw ARN with no cap, so framing the
+  // refusal there would put the very value being refused for its LENGTH onto
+  // the line. Self-framing keeps the whole message bounded.
+  if (!isIamRoleArn(roleArn)) {
+    throw new LayerMaterializationError(refusedRoleArnMessage(roleArn));
+  }
+
   const factory = options.stsClientFactory ?? (await defaultStsClientFactory());
   const client = factory(region);
   try {

--- a/src/utils/role-arn.ts
+++ b/src/utils/role-arn.ts
@@ -6,6 +6,161 @@ import { buildStsClientConfig } from './profile-resolver.js';
 import { describeAwsFailureForWarn, flattenToOneLine } from '../local/credential-error.js';
 
 /**
+ * Upper bound on a value this module is willing to treat as a role ARN.
+ *
+ * NOT invented here: it is the length constraint the receiving API itself
+ * documents for the field this value ends up in — STS `AssumeRole`'s
+ * `RoleArn` (AWS STS API Reference: "Length Constraints: Minimum length of
+ * 20. Maximum length of 2048."). Bounding at the receiver's own limit is the
+ * defensible number because anything above it is a value STS would reject
+ * anyway, so the cap can never turn a working configuration into a broken one.
+ *
+ * It is deliberately far above what a real role ARN needs — IAM's own entity
+ * limits put the ceiling near 600 characters (`arn:<partition>:iam::<12
+ * digits>:role/` plus a path of at most 512 and a name of at most 64) — because
+ * the job here is stopping an UNBOUNDED wire value from being sent and printed,
+ * not re-deriving IAM's schema. A tighter guess would be this module's own
+ * opinion; 2048 is the receiver's.
+ *
+ * The MINIMUM (20) is deliberately NOT enforced. The grammar below already
+ * implies a floor one character under it (`arn:a:iam::1:role/X` is 19), so
+ * enforcing it would reject a synthetic-but-well-shaped value for no security
+ * gain — length amplification is the half that matters here.
+ *
+ * The comparison is on UTF-16 units, which is exact for every value the
+ * grammar can ACCEPT (it admits printable ASCII only, where units, code points
+ * and bytes coincide) and a safe over-approximation for the rest.
+ */
+export const IAM_ROLE_ARN_MAX_LENGTH = 2048;
+
+/**
+ * The shape an IAM role ARN must have.
+ *
+ * Extracted from `src/cli/options.ts`, which validated `--assume-role` with
+ * `/^arn:[^:]+:iam::\d+:role\//` while three WIRE resolution points asked the
+ * same question with `startsWith('arn:')` (issue #607). Two spellings of one
+ * question regenerate: this is the single site that owns it, and every other
+ * site calls {@link isIamRoleArn} rather than paraphrasing it.
+ *
+ * Deliberate strictness decisions, in both directions:
+ *
+ *   - The PARTITION is `[A-Za-z0-9-]+`, so `aws`, `aws-cn`, `aws-us-gov` and
+ *     the iso partitions all pass. Tighter than the extracted `[^:]+` (which
+ *     admitted spaces and slashes), and still open-ended enough that a
+ *     partition AWS has not launched yet is not rejected by name.
+ *   - The ACCOUNT stays `[0-9]+` rather than `[0-9]{12}`. Real account ids are
+ *     12 digits, but this is a SHAPE bound, not a schema validator — AWS
+ *     rejects a wrong account id far better than cdk-local can — and this
+ *     repo's own fixtures use short ids (`arn:aws:iam::111:role/...`).
+ *   - The role tail is `[!-~]+`: at least one character, printable ASCII, no
+ *     spaces. That accepts every path-shaped role name
+ *     (`role/service-role/Foo`, `role/aws-service-role/x.amazonaws.com/Bar`)
+ *     because IAM's own path grammar is exactly printable-ASCII segments.
+ *   - The pattern is ANCHORED AT BOTH ENDS, which the extracted one was not.
+ *     That is the half that matters for a hostile endpoint: an unanchored
+ *     `role\/` accepts a value carrying a newline and a forged second line
+ *     after it, and it is the value's PRINTED half that the flatten at the log
+ *     sites was left holding on its own.
+ *
+ * LINEARITY: every quantified class is disjoint from the literal that follows
+ * it (`[A-Za-z0-9-]+` then `:`, `[0-9]+` then `:`), and the one class that is
+ * not (`[!-~]+`) is the last element before `$`. There is no alternation and
+ * no nested quantifier, so there is no input on which this backtracks
+ * super-linearly — which matters because it runs on values off the wire.
+ * {@link isIamRoleArn} also applies the length bound BEFORE the match, so the
+ * pattern never sees an unbounded string at all.
+ */
+const IAM_ROLE_ARN_PATTERN = /^arn:[A-Za-z0-9-]+:iam::[0-9]+:role\/[!-~]+$/;
+
+/**
+ * Is `value` a string shaped like an IAM role ARN, and short enough to send?
+ *
+ * The single authority for that question (issue #607). `src/cli/options.ts`
+ * asks it of a user-supplied `--assume-role`; `cfn-local-state-provider.ts`
+ * and `local-invoke.ts` ask it of a value that arrived off a live
+ * `GetFunctionConfiguration` / `GetAgentRuntime` response or out of deployed
+ * stack state, which is the population that motivated extracting it — such a
+ * value is not only PRINTED, it is SENT as `AssumeRoleCommand.RoleArn`, so a
+ * cap at the log line would bound only half of it.
+ *
+ * OVERLOADED on purpose. The wire callers pass `unknown` (a state
+ * `attributes.Arn`, an SDK response field) and want the `value is string`
+ * narrowing so they can drop a separate `typeof` test. `src/cli/options.ts`
+ * passes a value that is ALREADY `string`, and a predicate narrowing to
+ * `string` makes the NEGATIVE branch `never` — which turns that branch's own
+ * `Invalid --assume-role value "${raw}"` message into a
+ * `restrict-template-expressions` warning. The string overload returns a plain
+ * boolean so the error message the user actually reads still type-checks.
+ */
+export function isIamRoleArn(value: string): boolean;
+export function isIamRoleArn(value: unknown): value is string;
+export function isIamRoleArn(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  // Length FIRST: the pattern is linear, but there is no reason to hand it a
+  // megabyte from a hostile endpoint to find that out.
+  if (value.length > IAM_ROLE_ARN_MAX_LENGTH) return false;
+  return IAM_ROLE_ARN_PATTERN.test(value);
+}
+
+/**
+ * Longest prefix of a rejected value {@link describeRejectedRoleArn} will show.
+ *
+ * 128 rather than 64: `arn:aws:iam::123456789012:role/` is 31 characters on
+ * its own, so 64 left only 33 for the part that actually distinguishes one
+ * role from another — a CDK-generated name
+ * (`Stack-HandlerServiceRole1234ABCD-XXXXXXXXXXXX`) does not fit in that, and
+ * a preview that elides exactly the informative half is not a diagnosis. 128
+ * still leaves the rendered line well inside the 400-character bound its
+ * callers' tests assert.
+ */
+const REJECTED_ARN_PREVIEW_MAX = 128;
+
+/**
+ * Render a value {@link isIamRoleArn} REJECTED so it can go on a warn line.
+ *
+ * A rejection has two very different causes and the log line has to serve
+ * both: an ordinary misconfiguration (a role NAME where an ARN was expected,
+ * an ARN of the wrong resource type), where seeing the value is the whole
+ * diagnosis; and a hostile or broken endpoint returning something unbounded,
+ * where printing the value is the thing being prevented. So the value is
+ * shown, flattened and clamped, with its true length named — the same shape
+ * `sanitizeServiceExceptionMessage` uses, and for the same reason: a clamped
+ * preview must never be mistakable for the whole value.
+ *
+ * The cut is on CODE POINTS so it cannot emit half of a surrogate pair, and
+ * the reported count is the code-point count of the FLATTENED string, which is
+ * the string the preview is a prefix of.
+ */
+export function describeRejectedRoleArn(value: unknown): string {
+  if (typeof value !== 'string') return `a non-string ${typeof value} value`;
+  // Code points, not grapheme clusters: the property wanted is that the cut
+  // cannot split a surrogate PAIR. Same trade-off, and same reason, as
+  // `sanitizeServiceExceptionMessage`.
+  // oxlint-disable-next-line typescript/no-misused-spread
+  const points = [...flattenToOneLine(value)];
+  const preview =
+    points.length <= REJECTED_ARN_PREVIEW_MAX
+      ? points.join('')
+      : `${points.slice(0, REJECTED_ARN_PREVIEW_MAX).join('')}...`;
+  return `"${preview}" (${points.length} characters)`;
+}
+
+/**
+ * The sentence a guarded send throws when a value is refused before it leaves
+ * the process. One spelling, exported, so every guarded send words the refusal
+ * identically — including `local-invoke-agentcore.ts`'s own inline
+ * `AssumeRoleCommand`, which is not routed through this module.
+ */
+export function refusedRoleArnMessage(value: unknown): string {
+  return (
+    `AssumeRole refused: the role ARN is not a well-formed IAM role ARN ` +
+    `(expected arn:<partition>:iam::<account>:role/<name>, at most ` +
+    `${IAM_ROLE_ARN_MAX_LENGTH} characters): ${describeRejectedRoleArn(value)}. ` +
+    `Nothing was sent to STS.`
+  );
+}
+
+/**
  * {@link assumeRoleCredentials} failed, and the failure is cdk-local's OWN
  * rendering of it rather than a raw SDK error.
  *
@@ -112,6 +267,33 @@ export async function assumeRoleCredentials(opts: {
   sessionNameSuffix: string;
   makeError?: (message: string) => Error;
 }): Promise<AssumedRoleCredentials> {
+  // GUARDED SEND (issue #607). This is the site that owns "may this value be
+  // sent?" — as opposed to the resolution points, which own "where did this
+  // bad value come from?" and produce the sited warn a user can act on.
+  // Checking here bounds every caller of THIS helper, including the ones no
+  // resolution point covers: a `LocalStateProvider` supplied by a host CLI,
+  // whose return value cdk-local never sees resolved, and `<envPrefix>_ROLE_ARN`
+  // at the sibling below.
+  //
+  // It is NOT a process-wide choke point, and an earlier revision of this
+  // comment wrongly said it was ("one of the two places in the process where a
+  // role ARN is handed to STS ... bounds EVERY caller"). `grep -rn 'new
+  // AssumeRoleCommand(' src/` finds FIVE sends, not two. The other three are
+  // `local-invoke-agentcore.ts`'s `assumeAgentCoreExecutionRole` (guarded
+  // separately, against {@link refusedRoleArnMessage}, because it is on the
+  // wire path — its arg is `resolveAssumeRoleArn`'s output), and
+  // `layer-arn-materializer.ts` / `ecr-puller.ts`, whose ARNs come only from
+  // `--layer-role-arn` / `--ecr-role-arn` on the user's own command line. Any
+  // NEW send has to guard itself; nothing here does it for them.
+  //
+  // BEFORE the client is constructed and before anything is logged, so a
+  // refused value costs no network setup and never reaches a log line.
+  if (!isIamRoleArn(opts.roleArn)) {
+    const detail = `the role ARN is not well-formed: ${describeRejectedRoleArn(opts.roleArn)}`;
+    const message = refusedRoleArnMessage(opts.roleArn);
+    throw opts.makeError ? opts.makeError(message) : new AssumeRoleFailure(message, detail);
+  }
+
   // Thread `--profile` so the AssumeRole call is signed with the
   // profile's credentials (matching `aws sts assume-role --profile
   // <p>`), not the default env-shadowed chain (issue #245).
@@ -187,13 +369,27 @@ export async function applyRoleArnIfSet(opts: {
   const roleArn = opts.roleArn || process.env[`${getEmbedConfig().envPrefix}_ROLE_ARN`];
   if (!roleArn) return;
 
+  // GUARDED SEND (issue #607) — the eighteen-caller one. See the note in
+  // {@link assumeRoleCredentials}, including its correction about how many
+  // sends exist: the bound belongs where the value is handed to STS, not only
+  // where it was resolved. This send is the ONLY cover for
+  // `<envPrefix>_ROLE_ARN`, which reaches the process straight from the
+  // environment with no resolution point in front of it at all.
+  //
+  // Checked BEFORE the flatten and the `debug` line below, so a refused value
+  // is never printed anywhere, at any level.
+  if (!isIamRoleArn(roleArn)) {
+    throw new Error(refusedRoleArnMessage(roleArn));
+  }
+
   const logger = getLogger().child('role-arn');
-  // FLATTENED at every interpolation (issue #579 review round 4). `roleArn` is
-  // usually the user's own flag value, but it also arrives from
-  // `<envPrefix>_ROLE_ARN` and, at the bare `--assume-role` call sites, from a
-  // live `GetFunctionConfiguration` / `GetAgentRuntime` response behind only a
-  // `startsWith('arn:')` check. The `info` line below is the more reachable of
-  // the two, because it fires on SUCCESS.
+  // FLATTENED at every interpolation (issue #579 review round 4). Since #607
+  // this value has already passed {@link isIamRoleArn} directly above, which
+  // admits printable ASCII only — so the flatten is now provably a no-op here
+  // and is kept as belt-and-braces rather than as the thing standing between a
+  // hostile endpoint and this line. That inversion is the whole point of #607:
+  // a cap at the log line bounded only what gets PRINTED, while the same value
+  // was also SENT.
   const shownArn = flattenToOneLine(roleArn);
   logger.debug(`Assuming role ${shownArn}...`);
 

--- a/tests/unit/cli/assume-role-arn-log-flatten.test.ts
+++ b/tests/unit/cli/assume-role-arn-log-flatten.test.ts
@@ -44,12 +44,44 @@ import { resolveStartApiAssumeRoleArn } from '../../../src/cli/commands/local-st
  * stayed green. That was the third time in this lane a `flattenToOneLine` call
  * arrived without a test, so all SIX are driven here, each by the exported
  * function that owns it.
+ *
+ * UPDATED by issue #607, which closed the other half. `startsWith('arn:')` is
+ * no longer "the only validation anywhere on that path": the STATE resolution
+ * points (`resolveExecutionRoleArnFromState`, and cdk-local's own
+ * `CfnLocalStateProvider`) now shape- and length-check the value with
+ * `isIamRoleArn`, so a forged ARN is REJECTED before it can reach any of those
+ * lines — which also bounds what is SENT as `AssumeRoleCommand.RoleArn`, the
+ * half a flatten at the log line could never cover. The four state-derived
+ * cases below therefore assert the STRONGER property that superseded the
+ * flatten there: nothing forged is printed at all.
+ *
+ * ALL SIX now assert rejection, including the two that reach a log line
+ * through a `LocalStateProvider` the caller supplied. An earlier revision of
+ * this file left those two driving the flatten, on the grounds that a host
+ * CLI's own provider implementation is not covered by the check inside
+ * cdk-local's `CfnLocalStateProvider` — which was true, and was an argument
+ * for checking the provider RETURN, not for leaving it unchecked so that a
+ * test could keep asserting something. Both call sites now check what they are
+ * handed, and the send itself is bounded at the choke point in
+ * `src/utils/role-arn.ts` regardless of how the value got there.
+ *
+ * All SIX carry a WELL-FORMED-ARN guard-the-guard, because a test asserting
+ * that nothing was logged passes just as happily over a call site that stopped
+ * emitting for some entirely unrelated reason. Two of them did not, in an
+ * earlier revision that claimed here that all of them did: the agentcore- and
+ * start-api-from-state cases asserted only `forgedNeverResolved()`, which is
+ * vacuous over zero lines — strictly weaker than the `forgedLine()` they
+ * replaced, which failed loudly when its site went dead.
  */
 
 /** A forged ARN: `startsWith('arn:')` passes, and the tail forges a line. */
 const FORGED = 'arn:aws:iam::123456789012:role/x\nWARN: signature verified';
-/** What must appear instead — every character, on one line. */
-const FLAT = 'arn:aws:iam::123456789012:role/x WARN: signature verified';
+/**
+ * A well-formed role ARN (issue #607). Guards the guard: it proves a case that
+ * now asserts REJECTION is watching the shape check rather than a site that
+ * stopped emitting for some unrelated reason.
+ */
+const CLEAN = 'arn:aws:iam::123456789012:role/CleanRole';
 
 function stateWithRole(logicalId: string, roleArn: string, roleProperty = 'Role'): StackState {
   return {
@@ -85,93 +117,163 @@ describe('#570 — a forged newline in a role ARN cannot forge a line on the SUC
     vi.restoreAllMocks();
   });
 
-  /** The one emitted line that mentions the forged tail. */
-  function forgedLine(): string {
-    const matches = lines.filter((l) => l.includes('signature verified'));
-    expect(matches, 'no log line carried the ARN at all — the fixture missed the site').toHaveLength(
-      1
-    );
-    return matches[0]!;
+  /**
+   * The #607 property at a state site: the forged ARN is never RESOLVED.
+   *
+   * Not "the tail never appears" — the rejection warn deliberately shows the
+   * value it refused, so a real misconfiguration is diagnosable, and it shows
+   * it flattened and clamped. So the assertion is the two things that actually
+   * matter: no emitted line carries a raw newline (the forgery never lands),
+   * and any line mentioning the tail is the rejection warn rather than a line
+   * presenting it as the function's execution role.
+   */
+  function forgedNeverResolved(): void {
+    for (const line of lines) {
+      expect(line, 'a log line carried a raw newline').not.toContain('\n');
+    }
+    for (const line of lines.filter((l) => l.includes('signature verified'))) {
+      expect(
+        line,
+        'the forged tail appeared on a line that is not the #607 rejection warn'
+      ).toContain('not a well-formed IAM role ARN');
+    }
   }
 
-  it('premise: the fixture ARN passes the only validation on the path', () => {
-    // Non-vacuity for every case below. If `startsWith('arn:')` rejected this
-    // value, each site would return early and every assertion would pass over
-    // a line that was never emitted.
+  it('premise: the fixture ARN would pass the check #607 replaced', () => {
+    // Non-vacuity in both directions. `startsWith('arn:')` accepted this value
+    // — that is what made every line below reachable — and the shape check that
+    // replaced it does not, which is what the four state cases now assert.
     expect(FORGED.startsWith('arn:')).toBe(true);
     expect(FORGED).toContain('\n');
-    expect(FLAT).not.toContain('\n');
-    // And the state helper really does hand the raw value back.
-    expect(resolveExecutionRoleArnFromState(stateWithRole('Handler', FORGED), 'Handler')).toBe(
-      FORGED
+    // And the state helper now refuses to hand it back at all.
+    expect(
+      resolveExecutionRoleArnFromState(stateWithRole('Handler', FORGED), 'Handler')
+    ).toBeUndefined();
+    // Guard the guard: the same helper still resolves a WELL-FORMED ARN, so a
+    // rejection below is the shape check firing rather than the fixture being
+    // wrong in some other way.
+    expect(resolveExecutionRoleArnFromState(stateWithRole('Handler', CLEAN), 'Handler')).toBe(
+      CLEAN
     );
   });
 
-  it('local-invoke: from state', async () => {
-    await resolveAssumeRoleArnForLambda(true, stateWithRole('Handler', FORGED), undefined, 'Handler');
-    const line = forgedLine();
-    expect(line).toContain(`from state: ${FLAT}`);
-    expect(line).not.toContain('\n');
+  it('local-invoke: from state — #607 rejects it before any line is emitted', async () => {
+    const arn = await resolveAssumeRoleArnForLambda(
+      true,
+      stateWithRole('Handler', FORGED),
+      undefined,
+      'Handler'
+    );
+    expect(arn).toBeUndefined();
+    forgedNeverResolved();
   });
 
-  it('local-invoke: from GetFunctionConfiguration', async () => {
-    // State misses (no Role property), so the live fallback fires.
+  it('local-invoke: from GetFunctionConfiguration — #607 rejects the provider return', async () => {
+    // State misses (no Role property), so the live fallback fires. The
+    // provider here is a MOCK standing in for a host CLI's own
+    // `LocalStateProvider`: cdk-local's `CfnLocalStateProvider` checks at the
+    // source, a host's does not, so `resolveAssumeRoleArnForLambda` checks
+    // what it is handed rather than trusting the interface.
     const state = stateWithRole('Handler', FORGED, 'SomethingElse');
-    await resolveAssumeRoleArnForLambda(true, state, {
-      resolveLambdaExecutionRoleArn: vi.fn().mockResolvedValue(FORGED),
-    }, 'Handler');
-    const line = forgedLine();
-    expect(line).toContain(`from GetFunctionConfiguration: ${FLAT}`);
-    expect(line).not.toContain('\n');
+    const arn = await resolveAssumeRoleArnForLambda(
+      true,
+      state,
+      { resolveLambdaExecutionRoleArn: vi.fn().mockResolvedValue(FORGED) },
+      'Handler'
+    );
+    expect(arn).toBeUndefined();
+    forgedNeverResolved();
+    // Guard the guard: a well-formed provider return still resolves and still
+    // logs, so the rejection above is the check firing rather than the
+    // fallback having quietly stopped working.
+    const clean = await resolveAssumeRoleArnForLambda(
+      true,
+      stateWithRole('Handler', CLEAN, 'SomethingElse'),
+      { resolveLambdaExecutionRoleArn: vi.fn().mockResolvedValue(CLEAN) },
+      'Handler'
+    );
+    expect(clean).toBe(CLEAN);
+    expect(lines.some((l) => l.includes(`from GetFunctionConfiguration: ${CLEAN}`))).toBe(true);
   });
 
-  it('local-invoke-agentcore: from state', async () => {
+  it('local-invoke-agentcore: from state — #607 rejects it before any line is emitted', async () => {
     const loaded = stateWithRole('ChatAgent', FORGED, 'RoleArn') as unknown as LocalStateRecord;
-    await resolveAssumeRoleArn(
+    const arn = await resolveAssumeRoleArn(
       { assumeRole: true } as never,
       { logicalId: 'ChatAgent', resource: { Properties: {} } } as unknown as ResolvedAgentCoreRuntime,
       loaded,
       undefined
     );
-    const line = forgedLine();
-    expect(line).toContain(`resolved RoleArn from state: ${FLAT}`);
-    expect(line).not.toContain('\n');
+    expect(arn).toBeUndefined();
+    forgedNeverResolved();
+    // Guard the guard. Without it `forgedNeverResolved()` passes vacuously
+    // over zero emitted lines, which is what a DEAD lookup also produces — and
+    // the pre-#607 `forgedLine()` this replaced failed loudly in that case, so
+    // omitting it would make the rewrite strictly weaker than what it replaced.
+    const clean = await resolveAssumeRoleArn(
+      { assumeRole: true } as never,
+      { logicalId: 'ChatAgent', resource: { Properties: {} } } as unknown as ResolvedAgentCoreRuntime,
+      stateWithRole('ChatAgent', CLEAN, 'RoleArn') as unknown as LocalStateRecord,
+      undefined
+    );
+    expect(clean).toBe(CLEAN);
+    expect(lines.some((l) => l.includes(`resolved RoleArn from state: ${CLEAN}`))).toBe(true);
   });
 
-  it('local-invoke-agentcore: from GetAgentRuntime', async () => {
+  it('local-invoke-agentcore: from GetAgentRuntime — #607 rejects the provider return', async () => {
     const loaded = stateWithRole(
       'ChatAgent',
       FORGED,
       'SomethingElse'
     ) as unknown as LocalStateRecord;
-    await resolveAssumeRoleArn(
+    const arn = await resolveAssumeRoleArn(
       { assumeRole: true } as never,
       { logicalId: 'ChatAgent', resource: { Properties: {} } } as unknown as ResolvedAgentCoreRuntime,
       loaded,
       { resolveAgentCoreRuntimeRoleArn: vi.fn().mockResolvedValue(FORGED) }
     );
-    const line = forgedLine();
-    expect(line).toContain(`from GetAgentRuntime: ${FLAT}`);
-    expect(line).not.toContain('\n');
+    expect(arn).toBeUndefined();
+    forgedNeverResolved();
+    // Guard the guard, as above.
+    const clean = await resolveAssumeRoleArn(
+      { assumeRole: true } as never,
+      { logicalId: 'ChatAgent', resource: { Properties: {} } } as unknown as ResolvedAgentCoreRuntime,
+      stateWithRole('ChatAgent', CLEAN, 'SomethingElse') as unknown as LocalStateRecord,
+      { resolveAgentCoreRuntimeRoleArn: vi.fn().mockResolvedValue(CLEAN) }
+    );
+    expect(clean).toBe(CLEAN);
+    expect(lines.some((l) => l.includes(`from GetAgentRuntime: ${CLEAN}`))).toBe(true);
   });
 
-  it('local-invoke: the no-flag `Hint:` line, the most reachable of the six', () => {
-    // Fires with NO `--assume-role`, on a plain `cdkl invoke --from-cfn-stack`.
+  it('local-invoke: the no-flag `Hint:` line — #607 rejects it, so it never fires', () => {
+    // Was the most reachable of the six: it fires with NO `--assume-role`, on a
+    // plain `cdkl invoke --from-cfn-stack`. It reads the same state helper, so
+    // the shape check now stops it at the source.
     suggestAssumeRoleFromState(stateWithRole('Handler', FORGED), 'Handler');
-    const line = forgedLine();
-    expect(line).toContain(`uses execution role ${FLAT}`);
-    expect(line).not.toContain('\n');
+    forgedNeverResolved();
+    // Guard the guard: the line DOES fire, flattened, for a well-formed ARN, so
+    // the assertion above is the shape check rather than a dead call site.
+    suggestAssumeRoleFromState(stateWithRole('Handler', CLEAN), 'Handler');
+    expect(lines.some((l) => l.includes(`uses execution role ${CLEAN}`))).toBe(true);
   });
 
-  it('local-start-api: from state', () => {
-    resolveStartApiAssumeRoleArn({
+  it('local-start-api: from state — #607 rejects it before any line is emitted', () => {
+    const arn = resolveStartApiAssumeRoleArn({
       logicalId: 'Handler',
       assumeRole: { bareAutoResolve: true } as never,
       lambdaResource: { Type: 'AWS::Lambda::Function', Properties: {} } as never,
       stateBundle: { state: stateWithRole('Handler', FORGED) } as never,
     });
-    const line = forgedLine();
-    expect(line).toContain(`from state: ${FLAT}`);
-    expect(line).not.toContain('\n');
+    expect(arn).toBeUndefined();
+    forgedNeverResolved();
+    // Guard the guard, for the same reason as the agentcore sibling above.
+    const clean = resolveStartApiAssumeRoleArn({
+      logicalId: 'Handler',
+      assumeRole: { bareAutoResolve: true } as never,
+      lambdaResource: { Type: 'AWS::Lambda::Function', Properties: {} } as never,
+      stateBundle: { state: stateWithRole('Handler', CLEAN) } as never,
+    });
+    expect(clean).toBe(CLEAN);
+    expect(lines.some((l) => l.includes(`from state: ${CLEAN}`))).toBe(true);
   });
 });

--- a/tests/unit/cli/local-invoke-state-role-arn-shape.test.ts
+++ b/tests/unit/cli/local-invoke-state-role-arn-shape.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { getLogger } from '../../../src/utils/logger.js';
+import { resolveExecutionRoleArnFromState } from '../../../src/cli/commands/local-invoke.js';
+import type { StackState } from '../../../src/types/state.js';
+
+/**
+ * Issue #607 — the SHAPE check at the two `resolveExecutionRoleArnFromState`
+ * resolution points.
+ *
+ * The function has TWO independent reads and each used to be gated by
+ * `startsWith('arn:')`:
+ *
+ *   1. the STATE READ — `properties[roleProperty]` / `observedProperties[...]`
+ *      of the function or runtime resource, when it is a literal string;
+ *   2. its CACHE — when that property is an intrinsic (`Ref` / `Fn::GetAtt`),
+ *      the referenced role resource's cached `Arn` attribute.
+ *
+ * Both come out of a state record built from CloudFormation responses, and the
+ * value is handed to `AssumeRoleCommand.RoleArn`, so both are checked. They are
+ * fenced SEPARATELY here: they are two `if`s, and a single fixture exercising
+ * only the first would let the second regress silently.
+ */
+
+/** Passes `startsWith('arn:')`, which is exactly the point. */
+const OVERLONG = `arn:aws:iam::111:role/${'A'.repeat(100_000)}`;
+const FORGED = 'arn:aws:iam::111:role/R\nWARN: forged line';
+const GOOD = 'arn:aws:iam::111:role/RealRole';
+
+/** State whose Lambda names its role as a LITERAL string (the state read). */
+function literalRoleState(role: unknown, roleProperty = 'Role'): StackState {
+  return {
+    version: 1,
+    stackName: 'Stack',
+    resources: {
+      Handler: {
+        physicalId: 'handler-physical',
+        resourceType: 'AWS::Lambda::Function',
+        properties: { [roleProperty]: role },
+        attributes: {},
+        dependencies: [],
+      },
+    },
+    outputs: {},
+    lastModified: 0,
+  } as unknown as StackState;
+}
+
+/** State whose Lambda REFERENCES a role resource whose cached Arn is `arn`. */
+function referencedRoleState(arn: unknown): StackState {
+  return {
+    version: 1,
+    stackName: 'Stack',
+    resources: {
+      Handler: {
+        physicalId: 'handler-physical',
+        resourceType: 'AWS::Lambda::Function',
+        properties: { Role: { 'Fn::GetAtt': ['ExecRole', 'Arn'] } },
+        attributes: {},
+        dependencies: [],
+      },
+      ExecRole: {
+        physicalId: 'role-physical',
+        resourceType: 'AWS::IAM::Role',
+        properties: {},
+        attributes: arn === undefined ? {} : { Arn: arn },
+        dependencies: [],
+      },
+    },
+    outputs: {},
+    lastModified: 0,
+  } as unknown as StackState;
+}
+
+describe('#607 — resolveExecutionRoleArnFromState shape check', () => {
+  let warnings: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnings.push(String(m));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('premise: the rejected fixtures pass the check #607 replaced', () => {
+    // Non-vacuity for every rejection below.
+    expect(OVERLONG.startsWith('arn:')).toBe(true);
+    expect(FORGED.startsWith('arn:')).toBe(true);
+  });
+
+  describe('the state read (properties[roleProperty])', () => {
+    it('still resolves a well-formed ARN', () => {
+      expect(resolveExecutionRoleArnFromState(literalRoleState(GOOD), 'Handler')).toBe(GOOD);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('still honours a custom role property (the agentcore RoleArn spelling)', () => {
+      expect(
+        resolveExecutionRoleArnFromState(literalRoleState(GOOD, 'RoleArn'), 'Handler', 'RoleArn')
+      ).toBe(GOOD);
+    });
+
+    it('rejects an over-long value that merely starts with arn:', () => {
+      expect(resolveExecutionRoleArnFromState(literalRoleState(OVERLONG), 'Handler')).toBeUndefined();
+    });
+
+    it('rejects a value carrying a forged second line', () => {
+      expect(resolveExecutionRoleArnFromState(literalRoleState(FORGED), 'Handler')).toBeUndefined();
+    });
+
+    it('WARNS on a present-but-rejected value, naming the property', () => {
+      resolveExecutionRoleArnFromState(literalRoleState('MyRoleName'), 'Handler');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('not a well-formed IAM role ARN');
+      expect(warnings[0]).toContain("'Handler'");
+      expect(warnings[0]).toContain('Role');
+      expect(warnings[0]).toContain('"MyRoleName"');
+      // NOT prefixed `--assume-role:`. `suggestAssumeRoleFromState` calls this
+      // function on a plain `cdkl invoke --from-cfn-stack` with no role flag
+      // at all, so the prefix named a flag the user had not passed — on the
+      // one path whose whole purpose is to SUGGEST it.
+      expect(warnings[0]).not.toContain('--assume-role');
+    });
+
+    it('the warn is BOUNDED and single-line', () => {
+      resolveExecutionRoleArnFromState(literalRoleState(FORGED), 'Handler');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).not.toContain('\n');
+      resolveExecutionRoleArnFromState(literalRoleState(OVERLONG), 'Handler');
+      expect(warnings[1]!.length).toBeLessThan(400);
+      expect(warnings[1]).toContain(`(${OVERLONG.length} characters)`);
+    });
+
+    it('stays SILENT when the property is absent', () => {
+      expect(resolveExecutionRoleArnFromState(literalRoleState(undefined), 'Handler')).toBeUndefined();
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('stays SILENT when the property is an intrinsic (that is the cache path)', () => {
+      // An object roleRef is not a rejected string — it routes to read 2 — so
+      // the string branch must not warn about it.
+      resolveExecutionRoleArnFromState(referencedRoleState(GOOD), 'Handler');
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe('the cache (the referenced role resource attributes.Arn)', () => {
+    it('still resolves a well-formed cached ARN', () => {
+      expect(resolveExecutionRoleArnFromState(referencedRoleState(GOOD), 'Handler')).toBe(GOOD);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('rejects an over-long cached value that merely starts with arn:', () => {
+      expect(
+        resolveExecutionRoleArnFromState(referencedRoleState(OVERLONG), 'Handler')
+      ).toBeUndefined();
+    });
+
+    it('rejects a cached value carrying a forged second line', () => {
+      expect(
+        resolveExecutionRoleArnFromState(referencedRoleState(FORGED), 'Handler')
+      ).toBeUndefined();
+    });
+
+    it('WARNS on a present-but-rejected cached Arn, naming the referenced resource', () => {
+      resolveExecutionRoleArnFromState(referencedRoleState('role-name-only'), 'Handler');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('not a well-formed IAM role ARN');
+      expect(warnings[0]).toContain("'ExecRole'");
+      expect(warnings[0]).toContain('"role-name-only"');
+    });
+
+    it('the warn is BOUNDED and single-line', () => {
+      resolveExecutionRoleArnFromState(referencedRoleState(FORGED), 'Handler');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).not.toContain('\n');
+      resolveExecutionRoleArnFromState(referencedRoleState(OVERLONG), 'Handler');
+      expect(warnings[1]!.length).toBeLessThan(400);
+      expect(warnings[1]).toContain(`(${OVERLONG.length} characters)`);
+    });
+
+    it('stays SILENT when the cached Arn is absent', () => {
+      expect(
+        resolveExecutionRoleArnFromState(referencedRoleState(undefined), 'Handler')
+      ).toBeUndefined();
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('stays SILENT on an EMPTY cached Arn — the documented sibling-stack shape', () => {
+      // Issues #181 / #187, quoted in `resolveAssumeRoleArnForLambda`'s JSDoc:
+      // `ListStackResources` returns a sibling-stack role's NAME, so the state
+      // map carries an EMPTY `Arn` and the live `GetFunctionConfiguration`
+      // fallback is what resolves it. That is the normal SUCCESS path, so a
+      // warn here would fire on a working configuration. A `!== undefined`
+      // guard did exactly that, because `''` passes it.
+      expect(
+        resolveExecutionRoleArnFromState(referencedRoleState(''), 'Handler')
+      ).toBeUndefined();
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('still WARNS on a non-empty rejected cached Arn (the empty case is not a blanket mute)', () => {
+      resolveExecutionRoleArnFromState(referencedRoleState(' '), 'Handler');
+      expect(warnings).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/cli/options.test.ts
+++ b/tests/unit/cli/options.test.ts
@@ -75,6 +75,36 @@ describe('parseAssumeRoleToken', () => {
       ).toThrow(/Invalid --assume-role/);
     });
 
+    // Issue #607: the bare form now TRIMS, like the pair form always has. The
+    // old pattern was unanchored, so a copy-pasted value with trailing
+    // whitespace was silently accepted; an anchored one rejects it, and the
+    // two forms disagreeing about the same text would be a new bug rather than
+    // a fixed one. Both directions pinned.
+    it('trims surrounding whitespace on the bare form (issue #607)', () => {
+      const result = parseAssumeRoleToken(`  ${VALID_ARN}  `, undefined);
+      expect(result.globalArn).toBe(VALID_ARN);
+    });
+
+    it('trims a trailing newline on the bare form, the copy-paste shape', () => {
+      const result = parseAssumeRoleToken(`${VALID_ARN}\n`, undefined);
+      expect(result.globalArn).toBe(VALID_ARN);
+    });
+
+    it('agrees with the pair form on the same padded text', () => {
+      const bare = parseAssumeRoleToken(`  ${VALID_ARN}  `, undefined);
+      const pair = parseAssumeRoleToken(`  MyFn  =  ${VALID_ARN}  `, undefined);
+      expect(bare.globalArn).toBe(pair.perLambda['MyFn']);
+    });
+
+    it('still rejects INTERIOR whitespace, which trimming must not launder', () => {
+      expect(() =>
+        parseAssumeRoleToken('arn:aws:iam::123456789012:role/My Role', undefined)
+      ).toThrow(/Invalid --assume-role/);
+      expect(() =>
+        parseAssumeRoleToken('arn:aws:iam::123456789012:role/R\nERROR: forged', undefined)
+      ).toThrow(/Invalid --assume-role/);
+    });
+
     it('accepts gov-cloud / china partition (regex matches arn:<partition>)', () => {
       const arn = 'arn:aws-cn:iam::123456789012:role/CnRole';
       const result = parseAssumeRoleToken(arn, undefined);

--- a/tests/unit/cli/sts-error-relay-sites.test.ts
+++ b/tests/unit/cli/sts-error-relay-sites.test.ts
@@ -252,6 +252,20 @@ interface Site {
   reached: string;
   /** Whether the site interpolates the role ARN, which must keep printing. */
   quotesRoleArn: boolean;
+  /**
+   * What a FORGED role ARN does at this site, since issue #607 (only meaningful
+   * when `quotesRoleArn`).
+   *
+   *   - `'flattened'` — the value still reaches the warn, and the flatten is
+   *     what keeps it on one line. Sites whose ARN is handed in directly.
+   *   - `'refused-before-line'` — `--assume-role <arn>` is now rejected at its
+   *     resolution point, so the value never reaches a line at all. Stronger
+   *     than the flatten, and the reason these two rows changed.
+   *
+   * Declared PER SITE rather than accepted as a disjunction: "either outcome is
+   * fine" would pass over a site that silently switched from one to the other.
+   */
+  forgedArnOutcome?: 'flattened' | 'refused-before-line';
   drive: (arn?: string) => Promise<void>;
 }
 
@@ -271,6 +285,7 @@ const sites: Site[] = [
     operation: 'STS AssumeRole',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed: `,
     quotesRoleArn: true,
+    forgedArnOutcome: 'flattened',
     drive: async (arn = ROLE_ARN) => {
       await tolerate(() =>
         resolveLambdaContainerEnv(assumeRoleLambda(), { assumeRole: arn }, undefined)
@@ -319,6 +334,7 @@ const sites: Site[] = [
     operation: 'STS AssumeRole (--sigv4 signing)',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed for --sigv4 signing: `,
     quotesRoleArn: true,
+    forgedArnOutcome: 'refused-before-line',
     drive: async (arn = ROLE_ARN) => {
       await tolerate(() =>
         resolveHostCredentialsForSigV4(
@@ -336,6 +352,7 @@ const sites: Site[] = [
     operation: 'STS AssumeRole (fromS3 bundle download)',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed for the fromS3 bundle download: `,
     quotesRoleArn: true,
+    forgedArnOutcome: 'refused-before-line',
     drive: async (arn = ROLE_ARN) => {
       await tolerate(() =>
         resolveAgentCoreCodeImageFromS3(
@@ -366,6 +383,7 @@ const sites: Site[] = [
     operation: 'STS AssumeRole',
     reached: `--assume-role: STS AssumeRole(${ROLE_ARN}) failed: `,
     quotesRoleArn: true,
+    forgedArnOutcome: 'flattened',
     drive: async (arn = ROLE_ARN) => {
       await tolerate(() => applyAgentCoreCredentialEnv({}, { assumeRoleArn: arn }));
     },
@@ -536,17 +554,45 @@ describe('#570 — a forged newline in the role ARN cannot forge a line either',
     expect(quoting).toHaveLength(4);
   });
 
+  it('every quoting site declares its forged-ARN outcome', () => {
+    // Guards the guard: an undeclared row would silently skip both branches.
+    for (const site of quoting) {
+      expect(site.forgedArnOutcome, `${site.name} declares no forgedArnOutcome`).toBeDefined();
+    }
+    // Both outcomes are represented, so neither branch below is dead.
+    expect(quoting.filter((s) => s.forgedArnOutcome === 'flattened')).toHaveLength(2);
+    expect(quoting.filter((s) => s.forgedArnOutcome === 'refused-before-line')).toHaveLength(2);
+  });
+
   describe.each(quoting)('$name', (site) => {
-    it('flattens the ARN, keeping every character on one line', async () => {
+    it('a forged newline cannot forge a line', async () => {
       sendMock.mockRejectedValue(chainError());
       await site.drive(FORGED_ARN);
 
       const matches = warnLines.filter((l) => l.includes('WARN: signature verified'));
+      if (site.forgedArnOutcome === 'refused-before-line') {
+        // Issue #607. These two rows drive the EXPLICIT `--assume-role <arn>`
+        // spelling through `resolveAssumeRoleArn`, which now rejects a
+        // malformed value outright — matching `cdkl start-api`, which has
+        // rejected it at parse time all along via `parseAssumeRoleToken`. The
+        // forged value therefore never reaches a warn at all, which is
+        // strictly stronger than reaching one flattened.
+        expect(matches, 'the forged ARN still reached a warn line').toHaveLength(0);
+        return;
+      }
       expect(matches, 'the forged ARN never reached a warn line at all').toHaveLength(1);
       const line = matches[0]!;
       // Every character survives -- only the break became a space.
       expect(line).toContain('arn:aws:iam::123456789012:role/x WARN: signature verified');
       expect(line).not.toContain('\n');
+    });
+
+    it('guard-the-guard: a WELL-FORMED ARN still reaches this site', async () => {
+      // Without this the `refused-before-line` branch passes vacuously over a
+      // site that had stopped emitting for an unrelated reason.
+      sendMock.mockRejectedValue(chainError());
+      await site.drive();
+      expect(warnLines.some((l) => l.includes(site.reached))).toBe(true);
     });
   });
 });

--- a/tests/unit/cli/template-role-arn-shape.test.ts
+++ b/tests/unit/cli/template-role-arn-shape.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { getLogger } from '../../../src/utils/logger.js';
+import { resolveStartApiAssumeRoleArn } from '../../../src/cli/commands/local-start-api.js';
+import {
+  applyAgentCoreCredentialEnv,
+  resolveAssumeRoleArn,
+} from '../../../src/cli/commands/local-invoke-agentcore.js';
+import { refusedRoleArnMessage } from '../../../src/utils/role-arn.js';
+import { parseAssumeRoleToken } from '../../../src/cli/options.js';
+import type { LocalStateRecord } from '../../../src/local/local-state-provider.js';
+import type { ResolvedAgentCoreRuntime } from '../../../src/local/agentcore-resolver.js';
+
+/**
+ * Issue #607 — the two TEMPLATE-literal resolution points.
+ *
+ * Both read a role ARN out of the SYNTHESIZED template rather than off the
+ * wire, and both short-circuit the state lookup when they find one:
+ *
+ *   - `local-start-api.ts` — the Lambda's `Properties.Role`, when a CDK app
+ *     renders it as an explicit ARN string instead of an intrinsic;
+ *   - `local-invoke-agentcore.ts` — the runtime's `Properties.RoleArn`, the
+ *     same shape one construct over.
+ *
+ * They are lower-trust-risk than the wire points (the template is the user's
+ * own synth output), which is exactly why the check here is about the SITED
+ * DIAGNOSIS: the send is bounded at the choke point in `utils/role-arn.ts`
+ * either way, and a refusal there cannot say WHICH template property was
+ * wrong. Rejection warns and FALLS THROUGH to the state lookup — the
+ * pre-#607 control flow for a string that failed `startsWith('arn:')`.
+ */
+
+const GOOD = 'arn:aws:iam::123456789012:role/TemplateRole';
+const FROM_STATE = 'arn:aws:iam::123456789012:role/StateRole';
+/** Passes `startsWith('arn:')`, which is the check #607 replaced. */
+const BAD = `arn:aws:iam::123456789012:role/${'A'.repeat(100_000)}`;
+
+function stateWith(logicalId: string, roleArn: string, roleProperty: string): LocalStateRecord {
+  return {
+    version: 1,
+    stackName: 'Stack',
+    resources: {
+      [logicalId]: {
+        physicalId: `${logicalId}-physical`,
+        resourceType: 'AWS::Lambda::Function',
+        properties: { [roleProperty]: roleArn },
+        attributes: {},
+        dependencies: [],
+      },
+    },
+    outputs: {},
+    lastModified: 0,
+  } as unknown as LocalStateRecord;
+}
+
+describe('#607 — template-literal role-ARN resolution points', () => {
+  let warnings: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnings.push(String(m));
+    });
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('premise: the rejected fixture passes the check #607 replaced', () => {
+    expect(BAD.startsWith('arn:')).toBe(true);
+  });
+
+  describe("local-start-api: the Lambda's template Properties.Role", () => {
+    function drive(roleProp: unknown, withState = false): string | undefined {
+      return resolveStartApiAssumeRoleArn({
+        logicalId: 'Handler',
+        assumeRole: { bareAutoResolve: true } as never,
+        lambdaResource: {
+          Type: 'AWS::Lambda::Function',
+          Properties: roleProp === undefined ? {} : { Role: roleProp },
+        } as never,
+        ...(withState && {
+          stateBundle: { state: stateWith('Handler', FROM_STATE, 'Role') } as never,
+        }),
+      });
+    }
+
+    it('still returns a well-formed template Role', () => {
+      expect(drive(GOOD)).toBe(GOOD);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('rejects an over-long value that merely starts with arn:', () => {
+      expect(drive(BAD)).toBeUndefined();
+    });
+
+    it('WARNS on a present-but-rejected template Role, naming the Lambda', () => {
+      drive('MyRoleName');
+      expect(warnings[0]).toContain('template Role');
+      expect(warnings[0]).toContain("'Handler'");
+      expect(warnings[0]).toContain('not a well-formed IAM role ARN');
+      expect(warnings[0]).toContain('"MyRoleName"');
+    });
+
+    it('the warn is BOUNDED — the 100k value does not reach the line', () => {
+      drive(BAD);
+      expect(warnings[0]!.length).toBeLessThan(400);
+      expect(warnings[0]).toContain(`(${BAD.length} characters)`);
+    });
+
+    it('FALLS THROUGH to the state lookup rather than short-circuiting', () => {
+      // The pre-#607 control flow for a string that failed the check: the
+      // template value is ignored, and deployed state still gets its turn.
+      expect(drive(BAD, true)).toBe(FROM_STATE);
+    });
+
+    it('stays SILENT when the template Role is an intrinsic', () => {
+      expect(drive({ 'Fn::GetAtt': ['ExecRole', 'Arn'] })).toBeUndefined();
+      expect(warnings.filter((w) => w.includes('template Role'))).toHaveLength(0);
+    });
+  });
+
+  describe("local-invoke-agentcore: the runtime's template RoleArn", () => {
+    async function drive(roleArn: string | undefined, withState = false): Promise<string | undefined> {
+      return resolveAssumeRoleArn(
+        { assumeRole: true } as never,
+        {
+          logicalId: 'ChatAgent',
+          resource: { Properties: {} },
+          ...(roleArn !== undefined && { roleArn }),
+        } as unknown as ResolvedAgentCoreRuntime,
+        withState ? stateWith('ChatAgent', FROM_STATE, 'RoleArn') : undefined,
+        undefined
+      );
+    }
+
+    it('still returns a well-formed template RoleArn', async () => {
+      expect(await drive(GOOD)).toBe(GOOD);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('rejects an over-long value that merely starts with arn:', async () => {
+      expect(await drive(BAD)).toBeUndefined();
+    });
+
+    it('WARNS on a present-but-rejected template RoleArn, naming the runtime', async () => {
+      await drive('MyRoleName');
+      expect(warnings[0]).toContain('template RoleArn');
+      expect(warnings[0]).toContain("'ChatAgent'");
+      expect(warnings[0]).toContain('"MyRoleName"');
+    });
+
+    it('the warn is BOUNDED', async () => {
+      await drive(BAD);
+      expect(warnings[0]!.length).toBeLessThan(400);
+      expect(warnings[0]).toContain(`(${BAD.length} characters)`);
+    });
+
+    it('FALLS THROUGH to the state lookup rather than short-circuiting', async () => {
+      expect(await drive(BAD, true)).toBe(FROM_STATE);
+    });
+  });
+});
+
+/**
+ * Issue #607 review round 2 — the THIRD guarded send.
+ *
+ * `grep -rn 'new AssumeRoleCommand(' src/` finds FIVE sends, not the two in
+ * `src/utils/role-arn.ts` that an earlier revision of this lane's comments
+ * claimed. `local-invoke-agentcore.ts`'s `assumeAgentCoreExecutionRole` is the
+ * third, and it is the one on the WIRE path: all three of its callers pass
+ * `resolveAssumeRoleArn(...)`'s output.
+ *
+ * The hole it left was an ASYMMETRY. `cdkl start-api` wires
+ * `parseAssumeRoleToken` as its `--assume-role` argParser, so a malformed
+ * value is rejected at parse. `cdkl invoke-agentcore` declares no argParser at
+ * all, and `resolveAssumeRoleArn` returns an explicit
+ * `--assume-role <arn>` string EARLY, before every resolution point this lane
+ * added — so that one spelling reached STS unchecked.
+ */
+describe('#607 — cdkl invoke-agentcore --assume-role <arn> is checked like start-api', () => {
+  let warnings: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => void warnings.push(String(m)));
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const runtime = {
+    logicalId: 'ChatAgent',
+    resource: { Properties: {} },
+  } as unknown as ResolvedAgentCoreRuntime;
+
+  async function resolveExplicit(assumeRole: string): Promise<string | undefined> {
+    return resolveAssumeRoleArn({ assumeRole } as never, runtime, undefined, undefined);
+  }
+
+  it('still returns a well-formed explicit ARN', async () => {
+    await expect(resolveExplicit(GOOD)).resolves.toBe(GOOD);
+  });
+
+  it('REJECTS an over-long explicit ARN that merely starts with arn:', async () => {
+    await expect(resolveExplicit(BAD)).rejects.toThrow(/Invalid --assume-role value/);
+  });
+
+  it('REJECTS a forged newline in an explicit ARN', async () => {
+    await expect(resolveExplicit('arn:aws:iam::1:role/R\nWARN: forged')).rejects.toThrow(
+      /Invalid --assume-role value/
+    );
+  });
+
+  it('the refusal is BOUNDED and single-line — it cannot relay the value', async () => {
+    const message = await resolveExplicit(BAD).then(
+      () => '',
+      (err: unknown) => (err as Error).message
+    );
+    expect(message).toContain(`(${BAD.length} characters)`);
+    expect(message.length).toBeLessThan(500);
+    expect(message).not.toContain('\n');
+  });
+
+  it('matches what start-api rejects at parse time — the asymmetry is closed', async () => {
+    // The point of the fix: the same text, the same verdict, whichever command
+    // the user typed it into.
+    for (const bad of ['not-an-arn', 'arn:aws:iam::1:role/', BAD]) {
+      expect(() => parseAssumeRoleToken(bad, undefined)).toThrow(/Invalid --assume-role/);
+      await expect(resolveExplicit(bad)).rejects.toThrow(/Invalid --assume-role/);
+    }
+  });
+});
+
+
+/**
+ * The guarded SEND itself, driven through `applyAgentCoreCredentialEnv` — the
+ * one exported caller that takes an `assumeRoleArn` DIRECTLY rather than via
+ * `resolveAssumeRoleArn`, so it can still hand the send a value the resolution
+ * point never saw. That is exactly the population the send guard exists for.
+ */
+describe('#607 — assumeAgentCoreExecutionRole, the third guarded send', () => {
+  const ENV_KEYS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN'] as const;
+  let warnings: string[];
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    warnings = [];
+    savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => void warnings.push(String(m)));
+    vi.spyOn(getLogger(), 'info').mockImplementation(() => {});
+    vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    vi.restoreAllMocks();
+  });
+
+  /** The one warn this caller emits for a refused ARN. */
+  function refusalLine(): string {
+    const matches = warnings.filter((w) => w.includes('not well-formed'));
+    expect(matches, 'the send guard emitted no line at all').toHaveLength(1);
+    return matches[0]!;
+  }
+
+  it('REFUSES a malformed ARN and never mints credentials', async () => {
+    const dockerEnv: Record<string, string> = {};
+    await applyAgentCoreCredentialEnv(dockerEnv, { assumeRoleArn: 'not-an-arn' });
+    // The refusal is caught by the caller's existing warn-and-fall-back, so
+    // the command still runs on shell credentials — but nothing was assumed.
+    expect(dockerEnv['AWS_SESSION_TOKEN']).toBeUndefined();
+    expect(dockerEnv['AWS_ACCESS_KEY_ID']).toBeUndefined();
+    expect(refusalLine()).toContain('not well-formed');
+  });
+
+  it('guard-the-guard: a WELL-FORMED ARN is NOT refused by the send guard', async () => {
+    // Reaches the real STS import and fails on credentials instead, which is a
+    // DIFFERENT line. Without this, every refusal above would pass over a
+    // helper that had simply stopped assuming anything.
+    await applyAgentCoreCredentialEnv({}, { assumeRoleArn: GOOD });
+    expect(warnings.filter((w) => w.includes('not well-formed'))).toHaveLength(0);
+  });
+
+  it('the refusal renders VERBATIM — it is not double-withheld', async () => {
+    // The caller re-renders with `describeAwsFailureForWarn` unless the error
+    // is an `AssumeRoleFailure`, and a non-service error is that policy's
+    // WITHHELD branch. A `CdkLocalError` here would surface as
+    // `CdkLocalError; NNN-character message withheld` instead of the reason —
+    // the exact double-withhold `AssumeRoleFailure`'s JSDoc documents.
+    await applyAgentCoreCredentialEnv({}, { assumeRoleArn: 'not-an-arn' });
+    const line = refusalLine();
+    expect(line).not.toContain('message withheld');
+    expect(line).toContain('"not-an-arn" (10 characters)');
+  });
+
+  it("the guard's OWN half of the line is bounded, even for a 100k value", async () => {
+    await applyAgentCoreCredentialEnv({}, { assumeRoleArn: BAD });
+    const line = refusalLine();
+    // What the guard contributes is `describeRejectedRoleArn`'s output: a
+    // clamped preview plus the true length. The `AssumeRole(<arn>) failed:`
+    // FRAMING around it is the caller's, and it interpolates the raw ARN with
+    // no cap of its own — a pre-existing property of that line which this lane
+    // deliberately did not change, because an integ fixture greps the studio
+    // log ring for a real ARN and any re-rendering would break it. It is not
+    // reachable in production: every path that reaches this caller resolves
+    // through `resolveAssumeRoleArn`, which now rejects at its own points.
+    const guardHalf = line.slice(line.indexOf('the role ARN is not well-formed'));
+    expect(guardHalf).toContain(`(${BAD.length} characters)`);
+    expect(guardHalf.length).toBeLessThan(300);
+    expect(line).not.toContain('\n');
+  });
+
+  it('shares ONE refusal sentence with the two sends in utils/role-arn.ts', async () => {
+    // `refusedRoleArnMessage` is exported so all three guarded sends word the
+    // refusal identically. This caller prints the AssumeRoleFailure's `detail`
+    // (the bare half) under its own framing, so the shared sentence is
+    // asserted at its source rather than through this line.
+    expect(refusedRoleArnMessage('not-an-arn')).toContain('"not-an-arn" (10 characters)');
+    expect(refusedRoleArnMessage('not-an-arn')).toContain('Nothing was sent to STS');
+    await applyAgentCoreCredentialEnv({}, { assumeRoleArn: 'not-an-arn' });
+    expect(refusalLine()).toContain('"not-an-arn" (10 characters)');
+  });
+});

--- a/tests/unit/local/argv-role-arn-sends.test.ts
+++ b/tests/unit/local/argv-role-arn-sends.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+/**
+ * Issue #607 review round 3 — the FOURTH and FIFTH guarded sends.
+ *
+ * `grep -rn "new AssumeRoleCommand({" src/` finds five. Three were guarded in
+ * earlier rounds (`utils/role-arn.ts` x2, `local-invoke-agentcore.ts`). These
+ * two are the remainder: `ecr-puller.ts`'s `--ecr-role-arn` and
+ * `layer-arn-materializer.ts`'s `--layer-role-arn`.
+ *
+ * The reason they are guarded is CONSISTENCY and the LENGTH BOUND, NOT the
+ * #607 threat model — both take their ARN only from the user's own argv, never
+ * from a wire source, so a hostile endpoint cannot reach them. An earlier
+ * review round justified leaving them unguarded on the grounds that their
+ * values "already passed `parseAssumeRoleToken`"; they do not. Both flags are
+ * declared as plain `new Option('<flag> <arn>', ...)` with NO `argParser`, and
+ * `local-start-api.ts` holds the repo's only `parseAssumeRoleToken` wiring —
+ * so before this nothing validated them at all.
+ *
+ * What each test pins is that the refusal (a) happens, (b) happens BEFORE any
+ * STS client is built, and (c) renders its own bounded sentence rather than
+ * being swallowed by the module's withholding policy.
+ */
+
+const { stsCtorArgs, stsSend, ecrSend, runFg, runStream } = vi.hoisted(() => ({
+  stsCtorArgs: [] as Array<Record<string, unknown>>,
+  stsSend: vi.fn(),
+  ecrSend: vi.fn(),
+  runFg: vi.fn(),
+  runStream: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: class {
+    constructor(cfg: Record<string, unknown>) {
+      stsCtorArgs.push(cfg);
+    }
+    send = stsSend;
+    destroy(): void {}
+  },
+  GetCallerIdentityCommand: class {
+    kind = 'gci';
+  },
+  AssumeRoleCommand: class {
+    kind = 'assume';
+  },
+}));
+
+vi.mock('@aws-sdk/client-ecr', () => ({
+  ECRClient: class {
+    constructor() {}
+    send = ecrSend;
+    destroy(): void {}
+  },
+  GetAuthorizationTokenCommand: class {
+    kind = 'gat';
+  },
+}));
+
+vi.mock('../../../src/utils/docker-cmd.js', () => ({
+  runDockerForeground: runFg,
+  runDockerStreaming: runStream,
+  formatDockerLoginError: (s: string) => s,
+}));
+
+const { pullEcrImage, __resetStsCachesForTesting } = await import(
+  '../../../src/local/ecr-puller.js'
+);
+const { materializeLayerFromArn } = await import('../../../src/local/layer-arn-materializer.js');
+const { refusedRoleArnMessage } = await import('../../../src/utils/role-arn.js');
+
+/** Cross-account image, so the `--ecr-role-arn` branch is the one taken. */
+const IMAGE = '111122223333.dkr.ecr.ap-northeast-1.amazonaws.com/my-repo:latest';
+const GOOD = 'arn:aws:iam::999988887777:role/CrossAccountRead';
+/** Passes `startsWith('arn:')`, which is the check #607 replaced. */
+const OVERLONG = `arn:aws:iam::999988887777:role/${'A'.repeat(100_000)}`;
+const FORGED = 'arn:aws:iam::999988887777:role/R\nWARN: forged line';
+
+describe('#607 — ecr-puller: the --ecr-role-arn send', () => {
+  beforeEach(() => {
+    stsCtorArgs.length = 0;
+    stsSend.mockReset();
+    ecrSend.mockReset();
+    runFg.mockReset();
+    runStream.mockReset();
+    __resetStsCachesForTesting();
+    // Caller identity is a DIFFERENT account than the image, so the pull is
+    // cross-account and the role branch fires.
+    stsSend.mockImplementation((cmd: { kind?: string }) => {
+      if (cmd?.kind === 'assume') {
+        return Promise.resolve({
+          Credentials: { AccessKeyId: 'AKIA', SecretAccessKey: 's', SessionToken: 't' },
+        });
+      }
+      return Promise.resolve({ Account: '583942117338' });
+    });
+    ecrSend.mockResolvedValue({
+      authorizationData: [
+        {
+          authorizationToken: Buffer.from('AWS:pw').toString('base64'),
+          proxyEndpoint: 'https://111122223333.dkr.ecr.ap-northeast-1.amazonaws.com',
+        },
+      ],
+    });
+    runFg.mockResolvedValue(undefined);
+    runStream.mockResolvedValue(undefined);
+  });
+
+  async function drive(ecrRoleArn: string): Promise<string> {
+    return pullEcrImage(IMAGE, {
+      skipPull: false,
+      region: 'ap-northeast-1',
+      ecrRoleArn,
+    } as never).then(
+      () => '',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+  }
+
+  it('premise: the rejected fixtures pass the check #607 replaced', () => {
+    expect(OVERLONG.startsWith('arn:')).toBe(true);
+    expect(FORGED.startsWith('arn:')).toBe(true);
+  });
+
+  it('guard-the-guard: a WELL-FORMED --ecr-role-arn still assumes', async () => {
+    // Without this, every refusal below would pass over a branch that had
+    // simply stopped assuming anything.
+    expect(await drive(GOOD)).toBe('');
+    expect(stsSend.mock.calls.some((c) => (c[0] as { kind?: string })?.kind === 'assume')).toBe(
+      true
+    );
+  });
+
+  it('REFUSES an over-long value and never sends', async () => {
+    const message = await drive(OVERLONG);
+    expect(message).toContain('AssumeRole refused');
+    expect(message).toContain('Nothing was sent to STS');
+    expect(stsSend.mock.calls.some((c) => (c[0] as { kind?: string })?.kind === 'assume')).toBe(
+      false
+    );
+  });
+
+  it('REFUSES a forged newline, and the refusal is single-line', async () => {
+    const message = await drive(FORGED);
+    expect(message).toContain('AssumeRole refused');
+    expect(message).not.toContain('\n');
+  });
+
+  it('the refusal is BOUNDED and names the true length', async () => {
+    const message = await drive(OVERLONG);
+    expect(message).toContain(`(${OVERLONG.length} characters)`);
+    expect(message.length).toBeLessThan(500);
+  });
+
+  it('renders VERBATIM — the catch cannot withhold cdk-local’s own sentence', async () => {
+    // Thrown OUTSIDE the `try`, so it never meets `describeAwsFailureForWarn`,
+    // whose non-service branch would render it as
+    // `LocalInvokeBuildError; NNN-character message withheld`.
+    const message = await drive('not-an-arn');
+    expect(message).not.toContain('message withheld');
+    expect(message).toBe(refusedRoleArnMessage('not-an-arn'));
+  });
+});
+
+describe('#607 — layer-arn-materializer: the --layer-role-arn send', () => {
+  const layer = {
+    arn: 'arn:aws:lambda:us-west-2:999988887777:layer:Shared:3',
+    region: 'us-west-2',
+    versionNumber: 3,
+  } as never;
+
+  async function drive(roleArn: string, stsClientFactory?: unknown): Promise<string> {
+    return materializeLayerFromArn(layer, {
+      roleArn,
+      ...(stsClientFactory !== undefined && { stsClientFactory: stsClientFactory as never }),
+    }).then(
+      () => '',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+  }
+
+  it('guard-the-guard: a WELL-FORMED --layer-role-arn still reaches the STS factory', async () => {
+    let factoryCalled = false;
+    await drive(GOOD, () => {
+      factoryCalled = true;
+      return {
+        send: async () => ({ Credentials: { AccessKeyId: 'A', SecretAccessKey: 'S' } }),
+        destroy: () => {},
+      };
+    });
+    expect(factoryCalled).toBe(true);
+  });
+
+  it('REFUSES an over-long value before the STS factory is even built', async () => {
+    let factoryCalled = false;
+    const message = await drive(OVERLONG, () => {
+      factoryCalled = true;
+      return { send: async () => ({}), destroy: () => {} };
+    });
+    expect(message).toContain('AssumeRole refused');
+    expect(factoryCalled).toBe(false);
+  });
+
+  it('REFUSES a forged newline, and the refusal is single-line', async () => {
+    const message = await drive(FORGED);
+    expect(message).toContain('AssumeRole refused');
+    expect(message).not.toContain('\n');
+  });
+
+  it('the refusal is BOUNDED and names the true length', async () => {
+    const message = await drive(OVERLONG);
+    expect(message).toContain(`(${OVERLONG.length} characters)`);
+    expect(message.length).toBeLessThan(500);
+  });
+
+  it('is SELF-FRAMED, so the caller cannot re-interpolate the raw ARN', async () => {
+    // The caller wraps an UNframed error in
+    // `Layer <arn>: STS AssumeRole(${flattenToOneLine(roleArn)}) failed: ...`,
+    // which has no length cap — so framing the refusal there would put the
+    // very value being refused FOR ITS LENGTH onto the line. Throwing the
+    // already-framed `LayerMaterializationError` keeps the whole message
+    // bounded, and the assertion below is what pins that choice.
+    const message = await drive(OVERLONG);
+    expect(message).toBe(refusedRoleArnMessage(OVERLONG));
+    expect(message).not.toContain('STS AssumeRole(');
+    expect(message).not.toContain('message withheld');
+  });
+});

--- a/tests/unit/local/aws-error-relay-sites.test.ts
+++ b/tests/unit/local/aws-error-relay-sites.test.ts
@@ -1175,7 +1175,25 @@ describe('#579 round 2 — the fixes that a probe found unfenced', () => {
   describe('NIT — the wire-derived values on default-level lines', () => {
     const FORGED_ARN = 'arn:aws:iam::1:role/x\nWARN: signature verified';
 
-    it('ecr-puller.ts flattens the role ARN', async () => {
+    /** A well-formed ARN, for the guard-the-guards below. */
+    const CLEAN_ARN = 'arn:aws:iam::999988887777:role/CleanRole';
+
+    /**
+     * REWRITTEN by issue #607, like the sibling cases in
+     * `tests/unit/cli/sts-error-relay-sites.test.ts`.
+     *
+     * These two used to assert the FLATTEN: a forged newline reached the
+     * thrown message and the flatten was what kept it on one line. #607
+     * guards both sends — `--ecr-role-arn` and `--layer-role-arn` — so the
+     * forged value is now REFUSED before either line is built, which is
+     * strictly stronger. The flatten stays as belt-and-braces at the sites
+     * a well-formed ARN still reaches.
+     *
+     * NOTE the reason those two sends are guarded is CONSISTENCY and the
+     * LENGTH BOUND, not #607's threat model: both take their ARN only from
+     * the user's own argv, never from a wire response.
+     */
+    it('ecr-puller.ts REFUSES a forged role ARN before any line is built', async () => {
       __resetStsCachesForTesting();
       mocks.stsSend
         .mockResolvedValueOnce({ Account: '999988887777' })
@@ -1186,11 +1204,27 @@ describe('#579 round 2 — the fixes that a probe found unfenced', () => {
           ecrRoleArn: FORGED_ARN,
         })
       );
-      expect(message).toContain('assume role arn:aws:iam::1:role/x WARN: signature verified');
+      expect(message).toContain('AssumeRole refused');
+      expect(message).toContain('Nothing was sent to STS');
       expect(message).not.toContain('\n');
     });
 
-    it('layer-arn-materializer.ts flattens the role ARN', async () => {
+    it('ecr-puller.ts guard-the-guard: a WELL-FORMED ARN still reaches the flattened line', async () => {
+      __resetStsCachesForTesting();
+      mocks.stsSend
+        .mockResolvedValueOnce({ Account: '999988887777' })
+        .mockRejectedValue(new Error('boom'));
+      const message = await thrownMessage(() =>
+        pullEcrImage('111122223333.dkr.ecr.us-east-1.amazonaws.com/repo:tag', {
+          region: 'us-east-1',
+          ecrRoleArn: CLEAN_ARN,
+        })
+      );
+      expect(message).toContain(`assume role ${CLEAN_ARN}`);
+      expect(message).not.toContain('AssumeRole refused');
+    });
+
+    it('layer-arn-materializer.ts REFUSES a forged role ARN before any line is built', async () => {
       const message = await thrownMessage(() =>
         materializeLayerFromArn(LAYER, {
           roleArn: FORGED_ARN,
@@ -1201,8 +1235,26 @@ describe('#579 round 2 — the fixes that a probe found unfenced', () => {
           }),
         })
       );
-      expect(message).toContain('STS AssumeRole(arn:aws:iam::1:role/x WARN: signature verified)');
+      expect(message).toContain('AssumeRole refused');
       expect(message).not.toContain('\n');
+      // Self-framed: the caller's own wrapper interpolates the raw ARN with no
+      // length cap, so the refusal must not travel through it.
+      expect(message).not.toContain('STS AssumeRole(');
+    });
+
+    it('layer-arn-materializer.ts guard-the-guard: a WELL-FORMED ARN still reaches the flattened line', async () => {
+      const message = await thrownMessage(() =>
+        materializeLayerFromArn(LAYER, {
+          roleArn: CLEAN_ARN,
+          stsClientFactory: () => ({
+            send: async () => {
+              throw new Error('boom');
+            },
+          }),
+        })
+      );
+      expect(message).toContain(`STS AssumeRole(${CLEAN_ARN})`);
+      expect(message).not.toContain('AssumeRole refused');
     });
 
     it("layer-arn-materializer.ts flattens the presigned host's HTTP reason phrase", async () => {

--- a/tests/unit/local/cfn-local-state-provider-role-arn-shape.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-role-arn-shape.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { getLogger } from '../../../src/utils/logger.js';
+
+/**
+ * Issue #607 — the SHAPE check at the two `CfnLocalStateProvider` resolution
+ * points.
+ *
+ * Both read a role ARN straight off a live AWS response
+ * (`GetFunctionConfiguration`'s `Configuration.Role`,
+ * `GetAgentRuntime`'s `roleArn`) and hand it to a caller that passes it to
+ * `AssumeRoleCommand.RoleArn`. Until #607 the only validation was
+ * `startsWith('arn:')`, so an arbitrarily long value beginning `arn:` was
+ * accepted whole — printed AND sent.
+ *
+ * The sibling files `cfn-local-state-provider-exec-role.test.ts` /
+ * `-agentcore-role.test.ts` cover the happy path and the SDK-error path; this
+ * file covers what the check added, in both directions:
+ *
+ *   - an over-long / mis-shaped value is REJECTED, and
+ *   - the rejection WARNS rather than being silent, because a present-but-bad
+ *     field is a real misconfiguration the caller's generic "could not resolve"
+ *     line cannot describe — while an ABSENT field stays silent, since there is
+ *     nothing to report.
+ */
+
+const { lambdaSendMock, acSendMock } = vi.hoisted(() => ({
+  lambdaSendMock: vi.fn(),
+  acSendMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: class {
+    send = lambdaSendMock;
+    destroy(): void {}
+  },
+  GetFunctionConfigurationCommand: class {
+    constructor(public readonly input: unknown) {}
+  },
+}));
+
+vi.mock('@aws-sdk/client-bedrock-agentcore-control', () => ({
+  BedrockAgentCoreControlClient: class {
+    send = acSendMock;
+    destroy(): void {}
+  },
+  GetAgentRuntimeCommand: class {
+    constructor(public readonly input: unknown) {}
+  },
+}));
+
+vi.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: class {
+    send = vi.fn();
+    destroy(): void {}
+  },
+  ListStackResourcesCommand: class {},
+  DescribeStacksCommand: class {},
+  ListExportsCommand: class {},
+}));
+
+const { CfnLocalStateProvider } = await import('../../../src/local/cfn-local-state-provider.js');
+
+const GOOD = 'arn:aws:iam::111:role/Stack-ExecRole-AAA';
+/** Passes `startsWith('arn:')`, which is the whole point. */
+const OVERLONG = `arn:aws:iam::111:role/${'A'.repeat(100_000)}`;
+const FORGED = 'arn:aws:iam::111:role/R\nWARN: forged line';
+
+describe('#607 — CfnLocalStateProvider role-ARN shape check', () => {
+  let warnings: string[];
+
+  beforeEach(() => {
+    lambdaSendMock.mockReset();
+    acSendMock.mockReset();
+    warnings = [];
+    vi.spyOn(getLogger(), 'warn').mockImplementation((m: string) => {
+      warnings.push(String(m));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function provider(): InstanceType<typeof CfnLocalStateProvider> {
+    return new CfnLocalStateProvider({ cfnStackName: 'S', region: 'us-east-1' });
+  }
+
+  describe('resolveLambdaExecutionRoleArn (GetFunctionConfiguration Role)', () => {
+    it('premise: the rejected fixtures pass the check #607 replaced', () => {
+      // Non-vacuity. If these failed `startsWith('arn:')` the rejections below
+      // would prove nothing about the new check.
+      expect(OVERLONG.startsWith('arn:')).toBe(true);
+      expect(FORGED.startsWith('arn:')).toBe(true);
+    });
+
+    it('still returns a well-formed ARN', async () => {
+      lambdaSendMock.mockResolvedValueOnce({ Role: GOOD });
+      expect(await provider().resolveLambdaExecutionRoleArn('Scoring')).toBe(GOOD);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('rejects an over-long value that merely starts with arn:', async () => {
+      lambdaSendMock.mockResolvedValueOnce({ Role: OVERLONG });
+      expect(await provider().resolveLambdaExecutionRoleArn('Scoring')).toBeUndefined();
+    });
+
+    it('rejects a value carrying a forged second line', async () => {
+      lambdaSendMock.mockResolvedValueOnce({ Role: FORGED });
+      expect(await provider().resolveLambdaExecutionRoleArn('Scoring')).toBeUndefined();
+    });
+
+    it('WARNS on a present-but-rejected Role, so a misconfiguration is not silent', async () => {
+      lambdaSendMock.mockResolvedValueOnce({ Role: 'MyRoleName' });
+      await provider().resolveLambdaExecutionRoleArn('Scoring');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('not a well-formed IAM role ARN');
+      expect(warnings[0]).toContain('"MyRoleName"');
+      expect(warnings[0]).toContain('--assume-role <arn>');
+    });
+
+    it('the warn is BOUNDED — it cannot relay the whole rejected value', async () => {
+      lambdaSendMock.mockResolvedValueOnce({ Role: OVERLONG });
+      await provider().resolveLambdaExecutionRoleArn('Scoring');
+      expect(warnings).toHaveLength(1);
+      // The point of moving the bound to the resolution point: the value is
+      // 100k characters and the line stays short, while still naming the true
+      // length so a clamped preview is never mistaken for the whole value.
+      expect(warnings[0]!.length).toBeLessThan(400);
+      expect(warnings[0]).toContain(`(${OVERLONG.length} characters)`);
+    });
+
+    it('the warn cannot carry a forged newline', async () => {
+      lambdaSendMock.mockResolvedValueOnce({ Role: FORGED });
+      await provider().resolveLambdaExecutionRoleArn('Scoring');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).not.toContain('\n');
+    });
+
+    it('stays SILENT when the field is absent — nothing to report', async () => {
+      lambdaSendMock.mockResolvedValueOnce({});
+      expect(await provider().resolveLambdaExecutionRoleArn('Scoring')).toBeUndefined();
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe('resolveAgentCoreRuntimeRoleArn (GetAgentRuntime roleArn)', () => {
+    it('still returns a well-formed ARN', async () => {
+      acSendMock.mockResolvedValueOnce({ roleArn: GOOD });
+      expect(await provider().resolveAgentCoreRuntimeRoleArn('agent-abc')).toBe(GOOD);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('rejects an over-long value that merely starts with arn:', async () => {
+      acSendMock.mockResolvedValueOnce({ roleArn: OVERLONG });
+      expect(await provider().resolveAgentCoreRuntimeRoleArn('agent-abc')).toBeUndefined();
+    });
+
+    it('rejects a value carrying a forged second line', async () => {
+      acSendMock.mockResolvedValueOnce({ roleArn: FORGED });
+      expect(await provider().resolveAgentCoreRuntimeRoleArn('agent-abc')).toBeUndefined();
+    });
+
+    it('WARNS on a present-but-rejected roleArn', async () => {
+      acSendMock.mockResolvedValueOnce({ roleArn: 'arn:aws:iam::111:user/foo' });
+      await provider().resolveAgentCoreRuntimeRoleArn('agent-abc');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('not a well-formed IAM role ARN');
+      expect(warnings[0]).toContain('"arn:aws:iam::111:user/foo"');
+    });
+
+    it('the warn is BOUNDED and single-line', async () => {
+      acSendMock.mockResolvedValueOnce({ roleArn: OVERLONG });
+      await provider().resolveAgentCoreRuntimeRoleArn('agent-abc');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]!.length).toBeLessThan(400);
+      expect(warnings[0]).not.toContain('\n');
+    });
+
+    it('stays SILENT when the field is absent', async () => {
+      acSendMock.mockResolvedValueOnce({});
+      expect(await provider().resolveAgentCoreRuntimeRoleArn('agent-abc')).toBeUndefined();
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/utils/iam-role-arn-shape.test.ts
+++ b/tests/unit/utils/iam-role-arn-shape.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import {
+  IAM_ROLE_ARN_MAX_LENGTH,
+  describeRejectedRoleArn,
+  isIamRoleArn,
+} from '../../../src/utils/role-arn.js';
+
+/**
+ * Issue #607: `isIamRoleArn` is the single authority for "is this a role
+ * ARN?", asked of a user-supplied `--assume-role` AND of values that arrive
+ * off a live `GetFunctionConfiguration` / `GetAgentRuntime` response or out of
+ * deployed stack state — where the accepted value is not only printed but
+ * SENT, as `AssumeRoleCommand.RoleArn`.
+ *
+ * Fenced as a CLASSIFIER rather than with hand-picked values: the accepted
+ * population is a CROSS-PRODUCT of every partition against every account
+ * spelling against every role-tail shape, and the assertions are opt-OUT — a
+ * generated member is asserted ACCEPTED unless it is explicitly named in
+ * {@link GENERATED_REJECTIONS}. An unimagined shape added to any dimension
+ * therefore fails by default instead of quietly going untested.
+ *
+ * Control characters are spelled as escapes rather than as literal bytes, per
+ * this repo's `no-control-bytes` fence — a raw one makes `grep` treat the file
+ * as binary and silently suppress every match in it.
+ */
+
+/** Every partition an IAM role ARN can legitimately carry. */
+const PARTITIONS = ['aws', 'aws-cn', 'aws-us-gov', 'aws-iso', 'aws-iso-b', 'aws-iso-e', 'aws-eusc'];
+
+/**
+ * Account-id spellings. Real ids are 12 digits; the short forms are here
+ * because this repo's own fixtures use them (`arn:aws:iam::111:role/...`) and
+ * the predicate is deliberately a SHAPE bound, not a schema validator — AWS
+ * rejects a wrong account id far better than cdk-local can.
+ */
+const ACCOUNTS = ['123456789012', '111', '0'];
+
+/**
+ * Role-tail shapes, INCLUDING the path-shaped ones the issue calls out by
+ * name. IAM's path grammar is printable-ASCII segments, so all of these are
+ * legitimate and none may be rejected.
+ */
+const ROLE_TAILS = [
+  'MyRole',
+  'service-role/Foo',
+  'aws-service-role/x.amazonaws.com/Bar',
+  'cdk-hnb659fds-cfn-exec-role-123456789012-us-east-1',
+  'My_Role+Tag=1,name.ext@example-x',
+  'a',
+];
+
+/**
+ * Generated members that must be REJECTED despite being in the cross-product.
+ * Empty today — every partition x account x tail combination is legitimate —
+ * and kept as the opt-out hook so a future dimension can carry a known-bad
+ * member without loosening the default for everything else.
+ */
+const GENERATED_REJECTIONS = new Set<string>();
+
+function generated(): string[] {
+  const out: string[] = [];
+  for (const partition of PARTITIONS) {
+    for (const account of ACCOUNTS) {
+      for (const tail of ROLE_TAILS) {
+        out.push(`arn:${partition}:iam::${account}:role/${tail}`);
+      }
+    }
+  }
+  return out;
+}
+
+describe('isIamRoleArn — accepted population (cross-product, opt-out)', () => {
+  const members = generated();
+
+  it('generates the full cross-product (guards the guard)', () => {
+    // The LITERAL count, not `PARTITIONS.length * ACCOUNTS.length *
+    // ROLE_TAILS.length`. That product was the whole assertion in an earlier
+    // revision and it is a tautology: it is computed from the same three
+    // arrays the triple loop walks, so deleting a partition shrinks both sides
+    // together and the check stays green over a silently narrower population —
+    // which is exactly the failure an opt-out fence exists to prevent.
+    // 7 partitions x 3 accounts x 6 tails.
+    expect(members).toHaveLength(126);
+    expect(PARTITIONS).toHaveLength(7);
+    expect(ACCOUNTS).toHaveLength(3);
+    expect(ROLE_TAILS).toHaveLength(6);
+    expect(new Set(members).size).toBe(members.length);
+  });
+
+  it.each(members)('classifies %s', (value) => {
+    expect(isIamRoleArn(value)).toBe(!GENERATED_REJECTIONS.has(value));
+  });
+});
+
+/**
+ * Explicit rejections, each with the reason it is rejected — so a future
+ * loosening of the pattern has to delete a named case rather than silently
+ * flip a boolean.
+ */
+const REJECTED: Array<[reason: string, value: string]> = [
+  ['empty string', ''],
+  ['a bare role name', 'MyRole'],
+  ['no arn prefix at all', 'not-an-arn'],
+  ['merely starts with arn: — the check this replaces', 'arn:anything-at-all'],
+  ['merely starts with arn: and is long', `arn:${'x'.repeat(500)}`],
+  ['a non-IAM service', 'arn:aws:lambda:us-east-1:123456789012:function:Fn'],
+  ['an IAM ARN of the wrong resource type', 'arn:aws:iam::123456789012:user/foo'],
+  ['an IAM ARN of the wrong resource type (policy)', 'arn:aws:iam::123456789012:policy/foo'],
+  ['role prefix without a name', 'arn:aws:iam::123456789012:role/'],
+  ['a region in the iam slot (IAM ARNs are global)', 'arn:aws:iam:us-east-1:123456789012:role/R'],
+  ['a non-numeric account', 'arn:aws:iam::not-an-account:role/R'],
+  ['a missing account', 'arn:aws:iam:::role/R'],
+  ['leading whitespace', ' arn:aws:iam::123456789012:role/R'],
+  ['trailing whitespace', 'arn:aws:iam::123456789012:role/R '],
+  ['a space inside the role name', 'arn:aws:iam::123456789012:role/My Role'],
+  ['a space inside the partition', 'arn:aw s:iam::123456789012:role/R'],
+  // The forging vector the old unanchored pattern left open: a well-formed
+  // prefix, then a newline, then anything at all onto the log line.
+  ['an embedded newline and a forged second line', 'arn:aws:iam::1:role/R\nERROR: forged'],
+  ['an embedded carriage return', 'arn:aws:iam::1:role/R\rERROR: forged'],
+  ['a trailing NUL', 'arn:aws:iam::1:role/R\u0000'],
+  ['a bidi override in the role name', 'arn:aws:iam::1:role/R\u202Eevil'],
+  ['a non-ASCII role name', 'arn:aws:iam::1:role/R\u00F4le'],
+  // Length: the half a cap at the log line could never reach, because the
+  // same value is SENT to STS.
+  [
+    'one character over the ceiling',
+    `arn:aws:iam::123456789012:role/${'A'.repeat(IAM_ROLE_ARN_MAX_LENGTH - 31 + 1)}`,
+  ],
+  ['far over the ceiling', `arn:aws:iam::123456789012:role/${'A'.repeat(100_000)}`],
+];
+
+describe('isIamRoleArn — rejected population', () => {
+  it.each(REJECTED)('rejects %s', (_reason, value) => {
+    expect(isIamRoleArn(value)).toBe(false);
+  });
+
+  it('accepts a value exactly AT the ceiling', () => {
+    const prefix = 'arn:aws:iam::123456789012:role/';
+    const atLimit = `${prefix}${'A'.repeat(IAM_ROLE_ARN_MAX_LENGTH - prefix.length)}`;
+    expect(atLimit.length).toBe(IAM_ROLE_ARN_MAX_LENGTH);
+    expect(isIamRoleArn(atLimit)).toBe(true);
+  });
+
+  it('uses the ceiling the receiving API documents', () => {
+    // Not an invented number: STS `AssumeRole` documents `RoleArn` as
+    // "Maximum length of 2048", and that is the field this value is sent in.
+    expect(IAM_ROLE_ARN_MAX_LENGTH).toBe(2048);
+  });
+});
+
+/** Non-string inputs — the predicate is called on `unknown` at every wire site. */
+const NON_STRINGS: Array<[label: string, value: unknown]> = [
+  ['undefined', undefined],
+  ['null', null],
+  ['a number', 42],
+  ['a boolean', true],
+  ['an object', {}],
+  ['an array', ['arn:aws:iam::123456789012:role/R']],
+  // eslint-disable-next-line no-new-wrappers
+  ['a String object', new String('arn:aws:iam::123456789012:role/R')],
+  ['a symbol', Symbol('arn:aws:iam::123456789012:role/R')],
+  ['a function', () => 'arn:aws:iam::123456789012:role/R'],
+  ['an object with a matching toString', { toString: () => 'arn:aws:iam::1:role/R' }],
+  ['a null-prototype object', Object.create(null) as unknown],
+];
+
+describe('isIamRoleArn — non-string inputs', () => {
+  it.each(NON_STRINGS)('rejects %s', (_label, value) => {
+    expect(isIamRoleArn(value)).toBe(false);
+  });
+});
+
+describe('isIamRoleArn — linearity', () => {
+  // The pattern runs on values off the wire, so it must not backtrack
+  // super-linearly. Every quantified class is disjoint from the literal that
+  // follows it and the last one is anchored, so there is no such input — this
+  // pins that rather than trusting the reading. The adversarial cases sit AT
+  // the ceiling, since anything longer is rejected on length before the
+  // pattern sees it at all.
+  // Every fixture is <= IAM_ROLE_ARN_MAX_LENGTH, checked below. An earlier
+  // revision had two at 2052 characters — `arn:` plus 2048 — which the length
+  // bound rejects BEFORE the pattern runs, so those two measured the `if` and
+  // not the regex, contradicting the comment above them. The point of this
+  // case is the pattern, so the fixtures have to reach it.
+  const ADVERSARIAL = [
+    `arn:${'a'.repeat(IAM_ROLE_ARN_MAX_LENGTH - 4)}`,
+    `arn:${'a-'.repeat((IAM_ROLE_ARN_MAX_LENGTH - 4) / 2)}`,
+    `arn:aws:iam::${'1'.repeat(IAM_ROLE_ARN_MAX_LENGTH - 13)}`,
+    `arn:aws:iam::1:role/${'/'.repeat(IAM_ROLE_ARN_MAX_LENGTH - 20)}`,
+    'arn:aws:iam::1:role'.repeat(107),
+  ];
+
+  it('the adversarial fixtures actually REACH the pattern', () => {
+    // Guards the guard: a fixture over the ceiling is rejected by the length
+    // `if` and never exercises the regex at all.
+    for (const value of ADVERSARIAL) {
+      expect(value.length).toBeLessThanOrEqual(IAM_ROLE_ARN_MAX_LENGTH);
+    }
+  });
+
+  it('classifies adversarial near-misses in linear time', () => {
+    const started = Date.now();
+    for (let i = 0; i < 200; i++) {
+      for (const value of ADVERSARIAL) isIamRoleArn(value);
+    }
+    // A catastrophically-backtracking pattern does not finish this at all;
+    // the bound is deliberately loose so a slow CI box cannot flake it.
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+});
+
+describe('describeRejectedRoleArn', () => {
+  it('shows a short rejected value verbatim, with its length', () => {
+    expect(describeRejectedRoleArn('not-an-arn')).toBe('"not-an-arn" (10 characters)');
+  });
+
+  it('flattens control characters so a forged line cannot survive', () => {
+    const described = describeRejectedRoleArn('arn:aws:iam::1:role/R\nERROR: forged');
+    expect(described).not.toContain('\n');
+    expect(described).toContain('ERROR: forged');
+  });
+
+  it('clamps an over-long value and names its true length', () => {
+    const described = describeRejectedRoleArn('A'.repeat(5000));
+    expect(described).toContain('(5000 characters)');
+    expect(described.length).toBeLessThan(200);
+    expect(described).toContain('...');
+  });
+
+  it('does not split a surrogate pair when clamping', () => {
+    const described = describeRejectedRoleArn('\u{1F600}'.repeat(200));
+    // An emoji IS a surrogate pair, so the assertion is about LONE surrogates:
+    // a cut on UTF-16 units rather than code points would leave a high
+    // surrogate with no low one after it (or the reverse).
+    const LONE_SURROGATE =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(described).not.toMatch(LONE_SURROGATE);
+    expect(described).toContain('(200 characters)');
+  });
+
+  it('the preview keeps the DISTINGUISHING tail of a realistic rejected ARN', () => {
+    // The nit this pins: `arn:aws:iam::123456789012:role/` is 31 characters,
+    // so a 64-char preview left only 33 for the part that actually identifies
+    // the role. A CDK-generated name does not fit in 33, and a preview that
+    // elides exactly the informative half is not a diagnosis. Unpinned, the
+    // constant silently regresses — a mutation probe reverting 128 to 64 left
+    // this whole file green before this case existed.
+    const name = 'MyStack-HandlerServiceRole1234ABCD-a1b2c3d4e5f6';
+    // Rejected for its TRAILING SPACE, so the preview is what the user reads
+    // to see that there is one.
+    const rejected = `arn:aws:iam::123456789012:role/${name} `;
+    expect(isIamRoleArn(rejected)).toBe(false);
+    const described = describeRejectedRoleArn(rejected);
+    expect(described).toContain(name);
+    expect(described).not.toContain('...');
+    // Still comfortably inside the bound every caller's tests assert.
+    expect(described.length).toBeLessThan(400);
+  });
+
+  it('describes a non-string without interpolating it', () => {
+    expect(describeRejectedRoleArn(42)).toBe('a non-string number value');
+    expect(describeRejectedRoleArn(undefined)).toBe('a non-string undefined value');
+    expect(describeRejectedRoleArn(null)).toBe('a non-string object value');
+  });
+});
+
+
+/**
+ * DIFFERENTIAL against the predicate this one was extracted from.
+ *
+ * `src/cli/options.ts` on `origin/main` carried
+ * `const IAM_ROLE_ARN_REGEX = /^arn:[^:]+:iam::\d+:role\//` and validated
+ * `--assume-role` with it. Moving a predicate is only safe if it still answers
+ * the same way for the inputs its callers already had, so the old literal is
+ * reproduced here and the two are compared over every `--assume-role` spelling
+ * the existing suite exercises (`tests/unit/cli/options.test.ts`) plus the
+ * fixture ARNs the state-provider tests use.
+ *
+ * The `TIGHTENINGS` table below is a SAMPLE of the difference, not the whole
+ * of it — an earlier revision described it as the complete set, which it never
+ * was (a partition containing `.`, `/` or `_` is another whole class it does
+ * not name). Enumerating every class is the wrong shape of assertion anyway,
+ * because the enumeration can only ever be as complete as the imagination that
+ * wrote it.
+ *
+ * The property that DOES hold universally is stronger and is asserted
+ * directly: the new predicate is a strict SUBSET of the old one. No input
+ * exists that the new one accepts and the old one rejected, so migrating to it
+ * cannot LOOSEN `--assume-role` in any way, whatever the input. The sample
+ * then only has to show the subset is proper.
+ */
+const OLD_OPTIONS_REGEX = /^arn:[^:]+:iam::\d+:role\//;
+
+describe('isIamRoleArn - differential vs the extracted origin/main predicate', () => {
+  const COVERED_SPELLINGS = [
+    'arn:aws:iam::123456789012:role/MyRole',
+    'arn:aws:iam::123456789012:role/OtherRole',
+    'arn:aws-cn:iam::123456789012:role/CnRole',
+    'not-an-arn',
+    'arn:aws:iam::123456789012:user/foo',
+    'arn:aws:iam::111:role/Stack-AssumableExecRole-AAA',
+    'arn:aws:iam::111:role/Stack-AgentRuntimeExecRole-AAA',
+  ];
+
+  it.each(COVERED_SPELLINGS)('agrees with the old regex on %s', (value) => {
+    expect(isIamRoleArn(value)).toBe(OLD_OPTIONS_REGEX.test(value));
+  });
+
+  const TIGHTENINGS: Array<[what: string, value: string]> = [
+    ['a forged second line after a well-formed prefix', 'arn:aws:iam::1:role/R\nERROR: forged'],
+    ['a trailing NUL', 'arn:aws:iam::1:role/R\u0000'],
+    ['a role prefix with no name after it', 'arn:aws:iam::123456789012:role/'],
+    ['a space inside the partition', 'arn:a b:iam::1:role/R'],
+    ['an unbounded value', `arn:aws:iam::1:role/${'A'.repeat(100_000)}`],
+  ];
+
+  it.each(TIGHTENINGS)('deliberately tightens (sample): %s', (_what, value) => {
+    expect(OLD_OPTIONS_REGEX.test(value)).toBe(true);
+    expect(isIamRoleArn(value)).toBe(false);
+  });
+
+  it('is a strict SUBSET of the old predicate — no input is newly accepted', () => {
+    // The universal half, and the one that matters for a migration: whatever
+    // the input, `new => old`. If that holds, replacing the old predicate
+    // cannot admit anything it refused, so no `--assume-role` value becomes
+    // newly valid and no caller becomes newly reachable.
+    //
+    // Swept over every value this FILE names — both populations of the
+    // classifier, the differential's own tables, the non-strings — plus a
+    // generated sweep over each byte position, which is where an unimagined
+    // class would live.
+    const corpus: unknown[] = [
+      ...generated(),
+      ...REJECTED.map(([, v]) => v),
+      ...COVERED_SPELLINGS,
+      ...TIGHTENINGS.map(([, v]) => v),
+      ...NON_STRINGS.map(([, v]) => v),
+    ];
+    // One value per byte, injected at each of the five structural positions,
+    // so a character class that differs between the two patterns is found
+    // rather than guessed at.
+    for (let code = 0; code < 256; code++) {
+      const c = String.fromCharCode(code);
+      corpus.push(
+        `arn:aw${c}s:iam::123456789012:role/R`,
+        `arn:aws:iam::12${c}34:role/R`,
+        `arn:aws:iam::123456789012:role/R${c}`,
+        `arn:aws:iam::123456789012:role/${c}R`,
+        `${c}arn:aws:iam::123456789012:role/R`
+      );
+    }
+    expect(corpus.length).toBeGreaterThan(1400);
+    const newlyAccepted = corpus.filter(
+      (v) => isIamRoleArn(v) && !(typeof v === 'string' && OLD_OPTIONS_REGEX.test(v))
+    );
+    expect(newlyAccepted).toEqual([]);
+    // Guard the guard: the subset must be PROPER, or the assertion above would
+    // hold trivially for a predicate identical to the old one.
+    const newlyRejected = corpus.filter(
+      (v) => typeof v === 'string' && OLD_OPTIONS_REGEX.test(v) && !isIamRoleArn(v)
+    );
+    expect(newlyRejected.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/utils/role-arn.test.ts
+++ b/tests/unit/utils/role-arn.test.ts
@@ -290,11 +290,28 @@ describe('assumeRoleCredentials (issue #509 shared helper)', () => {
     );
   });
 
-  it('flattens a forged newline in the role ARN', async () => {
-    // Reachable because the bare `--assume-role` form resolves this ARN from a
-    // live `GetFunctionConfiguration` / `GetAgentRuntime` response behind only
-    // a `startsWith('arn:')` check.
-    sendImpl.fn = async () => ({});
+  /**
+   * REWRITTEN by issue #607. This case used to assert the FLATTEN: a forged
+   * newline reached the `AssumeRole(<arn>) failed:` framing, and the flatten
+   * was the only thing keeping it on one line — because the bare
+   * `--assume-role` form resolved the ARN from a live
+   * `GetFunctionConfiguration` / `GetAgentRuntime` response behind only a
+   * `startsWith('arn:')` check.
+   *
+   * #607 put a check at this send. So the forged value no longer gets as far
+   * as the framing, and the property worth asserting is the stronger one: it
+   * is REFUSED, and nothing was sent. The flatten stays as belt-and-braces; it
+   * is simply no longer what is being tested here.
+   *
+   * NOT a process-wide choke point, and an earlier revision of this note said
+   * it was ("one of the two places in the process where a role ARN is handed
+   * to STS"). `grep -rn 'new AssumeRoleCommand(' src/` finds FIVE sends. The
+   * third on the wire path — `local-invoke-agentcore.ts`'s
+   * `assumeAgentCoreExecutionRole` — is guarded separately against the same
+   * `refusedRoleArnMessage`; the remaining two take only `--layer-role-arn` /
+   * `--ecr-role-arn` from the user's own argv.
+   */
+  it('#607: REFUSES a forged newline before anything is sent to STS', async () => {
     const failure = await assumeRoleCredentials({
       roleArn: `${ROLE_ARN}\nWARN: signature verified`,
       region: undefined,
@@ -304,9 +321,66 @@ describe('assumeRoleCredentials (issue #509 shared helper)', () => {
       () => undefined,
       (err: unknown) => err
     );
+    expect(failure).toBeInstanceOf(AssumeRoleFailure);
     const message = (failure as Error).message;
-    expect(message).toContain(`AssumeRole(${ROLE_ARN} WARN: signature verified)`);
+    expect(message).toContain('AssumeRole refused');
+    expect(message).toContain('Nothing was sent to STS');
     expect(message).not.toContain('\n');
+    // The refusal happens BEFORE the client is built, so nothing was sent and
+    // no socket pool was opened.
+    expect(sent).toHaveLength(0);
+    expect(clientConfigs).toHaveLength(0);
+  });
+
+  it('#607: REFUSES an over-long value that merely starts with arn:', async () => {
+    const overlong = `arn:aws:iam::111111111111:role/${'A'.repeat(100_000)}`;
+    // Non-vacuity: it passes the check #607 replaced.
+    expect(overlong.startsWith('arn:')).toBe(true);
+    const failure = await assumeRoleCredentials({
+      roleArn: overlong,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-api',
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    const message = (failure as Error).message;
+    expect(message).toContain('AssumeRole refused');
+    // The refusal names the true length without relaying the value.
+    expect(message).toContain(`(${overlong.length} characters)`);
+    expect(message.length).toBeLessThan(500);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('#607: routes the refusal through makeError when a caller supplied one', async () => {
+    class OwnError extends Error {}
+    const failure = await assumeRoleCredentials({
+      roleArn: 'not-an-arn',
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-service',
+      makeError: (m) => new OwnError(m),
+    }).then(
+      () => undefined,
+      (err: unknown) => err
+    );
+    expect(failure).toBeInstanceOf(OwnError);
+    expect((failure as Error).message).toContain('AssumeRole refused');
+  });
+
+  it('#607 guard-the-guard: a WELL-FORMED ARN still reaches STS', async () => {
+    // Without this, every refusal above would pass over a helper that had
+    // simply stopped sending anything at all.
+    const creds = await assumeRoleCredentials({
+      roleArn: ROLE_ARN,
+      region: undefined,
+      profile: undefined,
+      sessionNameSuffix: 'start-api',
+    });
+    expect(creds.accessKeyId).toBe('AKIATEST');
+    expect(sent).toHaveLength(1);
+    expect((sent[0] as { input: { RoleArn: string } }).input.RoleArn).toBe(ROLE_ARN);
   });
 });
 
@@ -423,20 +497,96 @@ describe('applyRoleArnIfSet — the uncaught AssumeRole relay (issue #579)', () 
     );
   });
 
-  it('flattens the role ARN on the SUCCESS line, which is the more reachable one', async () => {
-    // The bare `--assume-role` form resolves this ARN from a live
-    // `GetFunctionConfiguration` / `GetAgentRuntime` response behind only a
-    // `startsWith('arn:')` check, and this `info` line fires when the assume
-    // SUCCEEDS — so it is strictly more reachable than any failure path.
-    await applyRoleArnIfSet({
-      roleArn: `${ROLE_ARN}\nWARN: signature verified`,
-      region: undefined,
-      profile: undefined,
-    });
+  /**
+   * REWRITTEN by issue #607, for the same reason as its
+   * `assumeRoleCredentials` sibling. This used to assert the flatten on the
+   * SUCCESS `info` line — the most reachable of the six #570 sites, because it
+   * fires when the assume WORKS. #607 checks the value at this send, ahead of
+   * the flatten AND ahead of the `debug` line, so a forged ARN is refused and
+   * no line is emitted for it at any level.
+   *
+   * This send is also the one that covers `<envPrefix>_ROLE_ARN`, which
+   * reaches the function straight from the environment with no resolution
+   * point in front of it at all.
+   */
+  it('#607: REFUSES a forged newline, emitting no line at any level', async () => {
+    const message = await driveFailure(`${ROLE_ARN}\nWARN: signature verified`);
+    expect(message).toContain('AssumeRole refused');
+    expect(message).toContain('Nothing was sent to STS');
+    expect(message).not.toContain('\n');
+    // Nothing sent, nothing logged, and the process env untouched — the
+    // refusal is ahead of all three.
+    expect(sent).toHaveLength(0);
+    expect(infoLines.filter((l) => l.includes('signature verified'))).toHaveLength(0);
+    expect(debugLines.filter((l) => l.includes('signature verified'))).toHaveLength(0);
+    expect(process.env['AWS_ACCESS_KEY_ID']).not.toBe('AKIATEST');
+  });
+
+  it('#607: REFUSES an over-long value passed as the option', async () => {
+    const overlong = `arn:aws:iam::111111111111:role/${'A'.repeat(100_000)}`;
+    expect(overlong.startsWith('arn:')).toBe(true);
+    const message = await driveFailure(overlong);
+    expect(message).toContain('AssumeRole refused');
+    expect(message).toContain(`(${overlong.length} characters)`);
+    expect(message.length).toBeLessThan(500);
+    expect(sent).toHaveLength(0);
+  });
+
+  /**
+   * The ENV branch, driven through `CDKL_ROLE_ARN` rather than the option.
+   *
+   * An earlier revision titled the case above "read out of the environment"
+   * while `driveFailure` passes `{ roleArn }` — so the env branch, which is
+   * this send's whole justification for existing (it is the ONLY check in
+   * front of `<envPrefix>_ROLE_ARN`, which has no resolution point at all),
+   * was never actually executed. `roleArn || process.env[...]` means an
+   * UNDEFINED option is what selects it.
+   */
+  it('#607: REFUSES a malformed CDKL_ROLE_ARN, the branch with no resolution point', async () => {
+    const saved = process.env['CDKL_ROLE_ARN'];
+    try {
+      process.env['CDKL_ROLE_ARN'] = `arn:aws:iam::111111111111:role/${'A'.repeat(100_000)}`;
+      const message = await applyRoleArnIfSet({
+        roleArn: undefined,
+        region: undefined,
+        profile: undefined,
+      }).then(
+        () => '',
+        (err: unknown) => (err instanceof Error ? err.message : String(err))
+      );
+      expect(message).toContain('AssumeRole refused');
+      expect(message).toContain('(100031 characters)');
+      expect(message.length).toBeLessThan(500);
+      expect(sent).toHaveLength(0);
+      expect(process.env['AWS_ACCESS_KEY_ID']).not.toBe('AKIATEST');
+    } finally {
+      if (saved === undefined) delete process.env['CDKL_ROLE_ARN'];
+      else process.env['CDKL_ROLE_ARN'] = saved;
+    }
+  });
+
+  it('#607 guard-the-guard: a WELL-FORMED CDKL_ROLE_ARN still assumes', async () => {
+    // Without this the env case above passes over a branch that had simply
+    // stopped reading the variable.
+    const saved = process.env['CDKL_ROLE_ARN'];
+    try {
+      process.env['CDKL_ROLE_ARN'] = ROLE_ARN;
+      await applyRoleArnIfSet({ roleArn: undefined, region: undefined, profile: undefined });
+      expect(sent).toHaveLength(1);
+      expect((sent[0] as { input: { RoleArn: string } }).input.RoleArn).toBe(ROLE_ARN);
+      expect(process.env['AWS_ACCESS_KEY_ID']).toBe('AKIATEST');
+    } finally {
+      if (saved === undefined) delete process.env['CDKL_ROLE_ARN'];
+      else process.env['CDKL_ROLE_ARN'] = saved;
+    }
+  });
+
+  it('#607 guard-the-guard: a WELL-FORMED ARN still assumes and still logs', async () => {
+    await applyRoleArnIfSet({ roleArn: ROLE_ARN, region: undefined, profile: undefined });
     const line = infoLines.find((l) => l.includes('Assumed role'));
-    expect(line).toContain(`Assumed role ${ROLE_ARN} WARN: signature verified`);
+    expect(line).toContain(`Assumed role ${ROLE_ARN}`);
     expect(line).not.toContain('\n');
-    expect(debugLines.every((l) => !l.includes('\n'))).toBe(true);
+    expect(sent).toHaveLength(1);
     expect(process.env['AWS_ACCESS_KEY_ID']).toBe('AKIATEST');
   });
 });


### PR DESCRIPTION
## Summary

A role ARN arriving off the wire was validated only by `startsWith('arn:')`, so a
hostile `GetFunctionConfiguration` / `GetAgentRuntime` / stack-state response
could return an arbitrarily long value beginning `arn:`. It is not only printed —
it is **SENT**, as `AssumeRoleCommand.RoleArn`.

**The repo already answered "is this a role ARN?"** — `IAM_ROLE_ARN_REGEX` in
`src/cli/options.ts` validated a user-supplied `--assume-role`. So it answered the
question two different ways depending on whether the value came from the flag or
off the wire. The predicate is extracted to `src/utils/role-arn.ts` as
`isIamRoleArn`; `options.ts` now uses it. There is no second spelling.

Two changes to the predicate itself:

- **Anchored at both ends.** The old one was not, which is the forging half: an
  unanchored `role\/` accepts a well-formed prefix followed by a newline and an
  attacker-chosen second line.
- **A 2048-character ceiling**, not invented — the STS `AssumeRole` API reference
  documents `RoleArn` as maximum length 2048, and that is the exact field the
  value is sent in. Bounding at the receiver's own limit cannot break a working
  config. The length check runs before the pattern, so the regex never sees an
  unbounded string.

## The bound is at the SENDS; the resolution points are the diagnosis

All **five** `AssumeRoleCommand` sites refuse before the STS client exists and
before any log line, so a refused value costs no socket and reaches no output.
**Nine** resolution points warn-and-fall-through with a sited message — including
two host `LocalStateProvider` returns and two template values that had **no check
at all**.

Each guarded send needed a different error class, and getting it wrong reproduced
a documented failure: throwing a plain error into a caller that renders via
`describeAwsFailureForWarn` lands in that policy's **withheld** branch, so
cdk-local's own sentence surfaced as `CdkLocalError; 213-character message
withheld`. `ecr-puller` throws outside its `try`; `layer-arn-materializer` throws
the already-framed class, because the unframed path interpolates the raw ARN with
no cap — framing the refusal there would print the very value being refused *for
its length*.

## Two corrections this PR makes to its own earlier reasoning

Both are recorded in-code, quoting what was wrong rather than silently rewriting:

1. **An earlier revision asserted a two-send process-wide choke point. There are
   five.** `grep -rn 'RoleArn:' src/` finds `role-arn.ts` ×2,
   `local-invoke-agentcore.ts`, `layer-arn-materializer.ts`, `ecr-puller.ts`. Each
   site now names its own flag rather than an ordinal, which drifts the moment a
   send is added.
2. **`--layer-role-arn` / `--ecr-role-arn` were assumed safe because their values
   "already passed `parseAssumeRoleToken`". They do not** — both are declared as
   plain `new Option('<flag> <arn>', …)` with no `argParser`, and
   `local-start-api.ts` holds the repo's only `parseAssumeRoleToken` wiring. The
   real reason they were low-risk is provenance (argv, never a wire source). They
   are guarded anyway for the length bound, and the comment says the reason is
   consistency and **not** the threat model — a comment implying otherwise would
   be the next false invariant.

## Behaviour changes (cdkd parity: cat 4) — https://github.com/go-to-k/cdkd/issues/2348

- `--assume-role` rejects spellings the old unanchored regex accepted (embedded
  newline/NUL after a well-formed prefix, empty role name, a partition containing
  a space, anything over 2048 chars). The new pattern is a strict SUBSET of the
  old, so nothing is newly accepted.
- `--assume-role` now trims the bare form. The pair form always did; the
  inconsistency was pre-existing and became user-visible only because the pattern
  is anchored, so a copy-pasted ARN with trailing whitespace would have started
  failing. Interior whitespace and embedded newlines are still rejected, so
  trimming cannot launder a forgery.
- `cdkl invoke-agentcore --assume-role <malformed>` is a hard error rather than a
  silent fallback, matching `start-api`'s parse-time rejection.
- The four `assumeRole*` helpers throw instead of sending.

## Test plan

Counts derived at the final sha: **184 / 28 / 14 / 11 / 17 / 22 / 7 / 52 / 133 /
43** across the new and modified suites. `vp run verify` rc=0 — 239 files, 4308
tests, 0 type errors.

- **19 mutation probes, all red**: nine resolution points, five sends, the
  predicate's length ceiling / end anchor / partition class, the bare-form trim,
  and the preview-length constant — which was **GREEN on the first sweep**, and is
  the reason it now has a pin. A constant nobody asserts is invisible to every
  test until someone writes the case.
- **The strict-subset property is asserted directly**, over a generated sweep
  injecting each of 256 byte values at five structural positions (>1400 inputs):
  `newlyAccepted` must be empty (no loosening is possible, whatever the input) and
  `newlyRejected` non-empty (so the assertion is not vacuous). That is stronger
  than the enumerated tightening list, which is labelled a sample.
- **Three security fences were rewritten, not weakened.** Where the new check made
  an old premise unreachable, each case asserts the stronger property with a
  well-formed-ARN guard-the-guard so a rejection assertion cannot pass vacuously
  over a dead site. `sts-error-relay-sites.test.ts` gained an explicit
  `forgedArnOutcome` per site with both branches asserted populated 2/2, rather
  than being relaxed to "either outcome is fine".
- `/run-integ local-invoke-from-cfn-stack` — pass (the state-read path, real AWS).
- `/run-integ local-studio` — pass (it greps the studio log ring for a real ARN).
- Docker orphans 0; post-run AWS sweep reports the fixture stack absent.

## Deliberately not changed

`applyAgentCoreCredentialEnv`'s warn interpolates the raw ARN uncapped. It is
unreachable now — every path resolving into it is checked at its own resolution
point — and `tests/integration/local-studio/verify.sh` greps the studio log ring
for a real ARN, so re-rendering that line would risk the fixture for no live gain.

Closes #607
