### PR TITLE
chore(work-issues): a fact the orchestrator asserts becomes a code comment

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -712,7 +712,7 @@ cd .claude/worktrees/<name>
 # until this. (A backslash continuation cannot carry a trailing comment, so
 # these are separate lines rather than one `&&` chain.)
 mise trust && mise install
-pnpm install    # worktrees have no node_modules
+pnpm install    # worktrees have no node_modules -- and neither may the MAIN checkout
 vp run build    # ...and no dist/ — see below
 ```
 
@@ -914,6 +914,43 @@ if the fix needs a forbidden file" guardrail. Note: a subagent's Bash **bypasses
 the PreToolUse gate hooks**, so it can `gh pr create` past `verify-pr-gate` —
 enforce quality yourself; you (the orchestrator) still gate the MERGE via
 `/merge-pr`.
+
+**A FACT you assert to an implementing agent becomes a code comment.** This is
+the orchestrator's own version of the relayed-count rule above, and it is worse,
+because the agent cannot check you cheaply: it is inside one lane's files while
+you are the only one holding the repo-wide view. So it writes what you said into
+a JSDoc or an invariant comment, in good faith, and the claim outlives the
+session.
+
+Measured here on 2026-08-27 across one run, which produced THREE wrong
+orchestrator assertions, all from verification scoped narrower than the claim:
+
+- "there are two `RoleArn:` sends" — derived from a grep scoped to ONE file and
+  reported as a repo-wide count. There are five. The agent had already written
+  "one of the two places in the process where a role ARN is handed to STS" into
+  `src/utils/role-arn.ts` before review caught it.
+- "those two sends are safe, their values already passed `parseAssumeRoleToken`"
+  — the flags are declared as plain `new Option('<flag> <arn>', …)` with no
+  `argParser`, so they never reach that function. The real reason they were
+  low-risk is provenance (argv, never a wire source), which is a different
+  argument that survives a different set of changes.
+- "count the call sites and die when derived < found" — a rule specified without
+  running it against a correct fixture, where naming one base twice (deploy, then
+  destroy) makes `found > derived` on a fixture with nothing wrong.
+
+All three were caught by the agent verifying rather than obeying, and each cost a
+round. Two cheap habits fix it: **derive a repo-wide claim with a repo-wide
+query** (`grep -rn` over `src/`, not over the file you happen to be reading), and
+when you cannot, **say the claim is unverified** so the agent checks it before
+building on it rather than after.
+
+The converse is worth stating too, because it is what made those rounds
+recoverable: an agent that pushes back with a measurement is doing its job. When
+one does, correct the record where the false claim landed — in the code comment,
+not only in the chat — and keep the rejected version executable if you can. That
+run kept the orchestrator's wrong rule as a mutation probe, killed by a case
+named after the counterexample, so the decision is legible to whoever reads the
+file next.
 
 ## 6. Gates + PR (per lane)
 
@@ -1820,6 +1857,29 @@ the run evidence behind it — or "no skill change" plus what held.
   remote merge lands but local cleanup fails) and is gate-blocked besides.
 - **Never defer the integ** — a `src/**` fix ships its Docker/fixture coverage in
   the SAME PR (the `integ` gate enforces it at merge time).
+- **Do not restore an agent's uncommitted work with `git checkout -- <file>`.**
+  It resets to HEAD, and a fan-out agent's work is UNCOMMITTED by instruction, so
+  the file goes back to `origin/main` and the agent's edit is gone. On 2026-08-27
+  this destroyed a lane's fix while restoring after a mutation probe; it was
+  recoverable only because the probe had copied the file first. Copy before you
+  mutate, restore from the copy, and confirm by a property of the agent's work
+  (`grep -c <the symbol it added>`), not by `git status` being clean — clean is
+  exactly what the wrong restore produces.
+- **`git add -N` to get a diffstat leaves the index dirty and breaks the next
+  `rebase` / `stash`.** Both refuse with `Entry '<path>' not uptodate` or
+  `your index contains uncommitted changes`, which reads as a merge problem
+  rather than as your own earlier command. `git reset` clears it. Cheaper: get
+  the true size with `git status --porcelain | wc -l` plus
+  `git diff --shortstat`, or accept that untracked files are missing from the
+  stat and say so.
+- **A green suite in the MAIN checkout can be measuring nothing.** The
+  worktree rule in section 5 says a fresh worktree has no `node_modules` and no
+  `dist/`; the main checkout can be the one that is missing them, because the
+  lanes have been running `pnpm install` and it has not. On 2026-08-27 six runs
+  there returned `exit 1` and were read as a reproduction of a flake, when every
+  one was `Cannot find module .../vite-plus/dist/bin.js`. Read the failure text
+  before counting exit codes, and prefer measuring in a worktree that is set up
+  and whose diff cannot touch the subject.
 
 ## Important existing rules this skill leans on
 


### PR DESCRIPTION
## Summary

Retrospective for the `/work-issues` run that landed
https://github.com/go-to-k/cdk-local/pull/616,
https://github.com/go-to-k/cdk-local/pull/617 and
https://github.com/go-to-k/cdk-local/pull/618.

The headline lesson is about the **orchestrator**, not the lanes.

## A fact the orchestrator asserts becomes a code comment

An assertion handed to an implementing agent is not advice. The agent writes it
into a JSDoc or an invariant comment, in good faith, because it cannot check a
repo-wide claim cheaply from inside one lane's files — the orchestrator is the
only one holding that view. So a wrong claim outlives the session.

This run produced **three** wrong ones, all from verification scoped narrower
than the claim:

| asserted | actual | how it was scoped wrong |
|---|---|---|
| "there are two `RoleArn:` sends" | five | grepped ONE file, reported repo-wide |
| "those two already passed `parseAssumeRoleToken`" | the flags have **no `argParser`** and never reach it | inferred from the flag's name |
| "count call sites, die when derived < found" | fires on a *correct* fixture (one base named twice, deploy + destroy) | specified without running it against a correct fixture |

Each was caught by the agent **verifying rather than obeying**, and each cost a
round — the first only after `one of the two places in the process where a role
ARN is handed to STS` had already been written into `src/utils/role-arn.ts`.

Two habits fix it: derive a repo-wide claim with a repo-wide query (`grep -rn`
over `src/`, not over the file you happen to have open), and when you cannot, say
the claim is unverified so the agent checks it before building on it.

The converse is what made those rounds recoverable and is stated too: an agent
that pushes back with a measurement is doing its job; correct the record **where
the false claim landed** — in the code comment, not only in chat — and keep the
rejected version executable if you can. That run kept the orchestrator's wrong
rule as a mutation probe, killed by a case named after the counterexample, so the
decision is legible to whoever reads the file next.

## Three gotchas, each paid for in the same run

- **`git checkout -- <file>` destroys a fan-out agent's work.** That work is
  uncommitted by instruction, so the file resets to `origin/main`. It happened
  while restoring after a mutation probe and was recoverable only because the
  probe had copied the file first. Confirm a restore by a property of the agent's
  work (`grep -c <the symbol it added>`), never by `git status` being clean —
  clean is exactly what the wrong restore produces.
- **`git add -N` for a diffstat leaves the index dirty** and makes the next
  `rebase` / `stash` refuse with a message that reads as a merge problem rather
  than as your own earlier command. Hit twice in one run.
- **A suite in the MAIN checkout can be measuring nothing.** Six runs there
  returned `exit 1` and were read as reproducing a flake; every one was
  `Cannot find module .../vite-plus/dist/bin.js`, because the lanes had been
  running `pnpm install` and the main checkout had not. This amends the existing
  "worktrees have no `node_modules`" line, which states only the direction that
  happens to be less surprising.

## Test plan

- `vp run verify` rc=0; `vp run test:hooks` rc=0 across all seven suites.
- `tests/unit/skills/work-issues-skill-refs.test.ts` green — it scans exactly this
  file for unqualified `#N` references, and every issue/PR reference added here is
  a full URL.
- Prose-only diff, no `src/**`, so no live-test and no integ apply.
