### PR TITLE
chore(gates): put the unit suite's checker-input files inside the check gate's scope

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -714,11 +714,13 @@ construction.
   in one shot.
 
   Match against the scope before running the skills — a tests-only
-  commit only needs `/check`; a docs-only commit only needs
-  `/check-docs`; a src edit needs both; changes that fall outside
-  both scopes (`.claude/hooks/**`, `.claude/skills/**`,
-  `.markgate.yml`) need neither. The hook is a safety net, not the
-  primary trigger.
+  commit only needs `/check`; a docs-only commit needs `/check-docs`
+  (and `/check` too when it touches `.claude/rules/**`, which sits
+  in BOTH scopes); a src edit needs both; a skills / agents /
+  settings.json edit needs `/check` (checker input,
+  go-to-k/cdk-local#620); changes that fall outside both scopes
+  (`.claude/hooks/**`, `.markgate.yml`) need neither. The hook is a
+  safety net, not the primary trigger.
 
   **Run `mise install` after pulling a change to `.mise.toml`.** An
   older markgate binary rejects a newer `.markgate.yml` (an unknown

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -696,8 +696,12 @@ construction.
   and `docs` markgate markers are fresh.
   - `check` — recorded by `/check` (typecheck + lint + format +
     build + tests). Scope: `src/**`, `tests/**`, lockfiles,
-    build/test configs (see `.markgate.yml`). Only invalidated by
-    changes in that scope.
+    build/test configs, plus the checker-INPUT files the unit suite
+    reads — `.claude/skills/**`, `.claude/agents/**`,
+    `.claude/rules/**`, `.claude/settings.json`, and the
+    pr-inherit-issue-labels workflow YAML (go-to-k/cdk-local#620;
+    see the mapping comment in `.markgate.yml`). Only invalidated
+    by changes in that scope.
   - `docs` — recorded by `/check-docs` (README.md /
     `.claude/CLAUDE.md` / `docs/` / `.claude/rules/` consistency
     with src). Scope: `src/**`, `docs/**`, `README.md`,

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -329,11 +329,14 @@ pnpm install                  # worktrees have no node_modules
   cdk-local change that never happened.
 - English only in every committed line (`non-english-text-gate` enforces it at PR
   time).
-- A `work-issues`-only edit is outside BOTH the `check` and `docs` gate scopes, but
-  `check-gate` verifies both markers on every commit without computing scope, and a
-  fresh worktree starts with NONE — and `gh pr create` is gated on `verify-pr` with
-  no diff-scope exemption. So run `/check`, `/check-docs`, `/verify-pr` there. No
-  `src/**` change means no integ and no live-test.
+- A `work-issues`-only edit sits INSIDE the `check` gate's scope
+  (go-to-k/cdk-local#620: `.claude/skills/**` / `.claude/agents/**` /
+  `.claude/rules/**` are the unit suite's INPUT — the byte-cap and bare-ref
+  scanners read them — so a skills edit stales the marker exactly as a
+  `tests/**` edit does), and `check-gate` verifies both markers on every commit
+  anyway, and a fresh worktree starts with NONE — and `gh pr create` is gated on
+  `verify-pr` with no diff-scope exemption. So run `/check`, `/check-docs`,
+  `/verify-pr` there. No `src/**` change means no integ and no live-test.
 - Merge it with `/merge-pr <n>` like every other lane — a hand-run `gh pr merge`
   from a side worktree is gate-blocked.
 - `/review-pr` no longer down-biases `.claude/**` (issue go-to-k/cdk-local#501), so a skill-only PR

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -8,8 +8,9 @@ freshness) and — critically — **live-tests the changed behavior**:
 
 **Run the integ LAST — and set the `check` / `docs` markers AFTER it, not before.**
 A fixture run writes `cdk.out/`, `node_modules/` and a `pnpm-lock.yaml` inside
-`tests/integration/<fixture>/`, and the `check` gate's include set is
-`src/**` + `tests/**` + the configs. markgate's `files` digest covers those
+`tests/integration/<fixture>/`, and the `check` gate's include set covers
+`src/**` + `tests/**` + the configs + the checker-input agent-instruction files
+(go-to-k/cdk-local#620). markgate's `files` digest covers those
 artifacts even though git ignores them, so a green integ run STALES a `check`
 marker set minutes earlier — with the tracked tree completely unchanged and
 `git status` clean. The symptom is a `git commit` refused for "digest differs"

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -53,6 +53,29 @@ gates:
     include:
       - "src/**"
       - "tests/**"
+      # Checker-INPUT files outside src/tests (issue #620): these are files
+      # the unit suite READS, so an edit to one can red the suite while a
+      # previously-set `check` marker stays FRESH — the marker then attests
+      # to a tree the checker's input no longer matches.
+      #   - tests/unit/skills/skill-file-payload.test.ts reads every
+      #     SKILL.md + references/*.md (byte caps, moved-not-dropped floors)
+      #   - tests/unit/skills/work-issues-skill-refs.test.ts reads skills +
+      #     agents + rules (bare-ref scan)
+      #   - tests/unit/hooks/gate-if-matchers.test.ts reads
+      #     .claude/settings.json (the #1801 inert-`if:` class)
+      #   - tests/unit/hooks/pr-inherit-issue-labels.test.ts reads its
+      #     workflow YAML
+      # `.claude/rules/**` sits in `docs` too — same overlap cdkd carries,
+      # for the same two reasons. Known limit, deliberate: the repo-wide
+      # scanners (e.g. tests/unit/no-control-bytes.test.ts globs every
+      # tracked text file) read a population scoping cannot follow without
+      # making the marker stale on every edit anywhere; CI remains the
+      # backstop there.
+      - ".claude/skills/**"
+      - ".claude/agents/**"
+      - ".claude/rules/**"
+      - ".claude/settings.json"
+      - ".github/workflows/pr-inherit-issue-labels.yml"
       - "package.json"
       - "pnpm-lock.yaml"
       - "tsconfig*.json"


### PR DESCRIPTION
Closes #620

## What

Adds the checker-INPUT files the unit suite reads to the `check` markgate gate's `include` in `.markgate.yml`, so an agent-instruction-only edit stales a previously-set `check` marker instead of leaving it fresh over a tree the suite would fail on. Mirrors the reasoning of https://github.com/go-to-k/cdkd/issues/2041 (a checker's input sitting outside the gate that guards it).

New globs, each mapped to the test that reads it (comment in `.markgate.yml` carries the same mapping):

- `.claude/skills/**` — `tests/unit/skills/skill-file-payload.test.ts` (byte caps, moved-not-dropped floors)
- `.claude/agents/**`, `.claude/rules/**` — `tests/unit/skills/work-issues-skill-refs.test.ts` (bare-ref scan reads skills + agents + rules); `.claude/rules/**` now sits in both `check` and `docs`, the same overlap cdkd carries
- `.claude/settings.json` — `tests/unit/hooks/gate-if-matchers.test.ts` (the inert-`if:` class, https://github.com/go-to-k/cdk-real-drift/issues/1801)
- `.github/workflows/pr-inherit-issue-labels.yml` — `tests/unit/hooks/pr-inherit-issue-labels.test.ts`

The last two were found by the issue's own sweep run one level wider (eligibility-minus-remedy over every `readFileSync` target in `tests/`): same root cause, so they ride this lane rather than a new issue.

Also updates the now-false sentence in `.claude/skills/work-issues/references/retro.md` §10-d ("A `work-issues`-only edit is outside BOTH the `check` and `docs` gate scopes" → it now sits INSIDE `check` as checker input), and the `check` scope enumeration in `.claude/rules/hooks.md`'s check-gate entry.

## Verification (the issue's own bidirectional probe, plus per-glob)

- CONTROL (pre-change): `markgate set check` → 1-byte append to `references/gotchas.md` → `markgate verify check` rc=0 — the defect (marker fresh over changed checker input).
- Post-change, same probe per glob: skills edit rc=1, agents edit rc=1, rules edit rc=1, `.claude/settings.json` rc=1, workflow YAML rc=1.
- Out-of-scope control: README.md append keeps rc=0 (no over-widening).
- Red-test half: `mise exec -- vp test run tests/unit/skills/` — 30/30 green on the clean tree.

## Won't-do (recorded here)

Repo-wide scanner inputs are NOT scoped: `tests/unit/no-control-bytes.test.ts` reads every tracked text file (`git ls-files`), a population the gate cannot follow without making the marker stale on every edit anywhere — which would make the scope meaningless. CI remains the backstop for that class; noted in the `.markgate.yml` comment.

## Review round (1 pr-code-reviewer)

Blocker (fixed in the second commit): the check-gate entry's "Match against the scope" paragraph still listed `.claude/skills/**` as outside both gate scopes, 15 lines below the enumeration this PR updated — a same-file self-contradiction. Minor (fixed): the work-issues `references/verify.md` restated the old include set. The reviewer also verified all five globs stale the marker by probe, confirmed the negative control, swept `tests/` for further out-of-scope reads (none precise remain), and confirmed the cdkd `.claude/rules/**` dual-scope precedent claim.

TODO (issue #623): the reviewer's probe found that editing `.markgate.yml` ITSELF does not stale the `check` marker (the gate's own definition sits outside its scope — a distinct root cause from this PR's checker-input one). Filed and claimed for a follow-up lane in the same session.
