### PR TITLE
chore(gates): put .markgate.yml itself inside the check gate's scope

### DIFF
--- a/.markgate.yml
+++ b/.markgate.yml
@@ -76,6 +76,14 @@ gates:
       - ".claude/rules/**"
       - ".claude/settings.json"
       - ".github/workflows/pr-inherit-issue-labels.yml"
+      # This file itself (issue #623): the gate's own definition decides
+      # what the marker MEANS, so editing it — including this include
+      # list — must stale a marker recorded under the old definition.
+      # Same argument as cdkd scoping `.mise.toml` into its check gate
+      # (the toolchain pin decides what green means). Measured during
+      # the #620 review: without this entry, appending include entries
+      # left `markgate verify check` at rc=0.
+      - ".markgate.yml"
       - "package.json"
       - "pnpm-lock.yaml"
       - "tsconfig*.json"


### PR DESCRIPTION
Closes #623

## What

Adds `.markgate.yml` itself to the `check` gate's `include`. The gate's own definition decides what the marker MEANS, so editing it — including the include list — must stale a marker recorded under the old definition. Same argument as cdkd scoping `.mise.toml` into its check gate (the toolchain pin decides what green means), arriving through the gate config instead of the toolchain.

Distinct root cause from (#620) / (#622), which put checker INPUTS inside the scope; this one is the gate's own definition. Found by that PR's review probe.

## Verification (bidirectional, in this worktree)

- CONTROL (pre-change): `markgate set check` → append a comment line to `.markgate.yml` → `markgate verify check` rc=0 — the measured defect.
- Post-change: same probe → rc=1.
- Out-of-scope control: README.md append keeps rc=0.
- `vp run check` / `build` / `test`: green (240 files / 4,332 tests).

## Won't-do (recorded here)

Only the `check` gate gets the entry, not every gate: `check` is the gate whose marker a definition edit most plausibly co-exists with (it guards every commit), and scoping `.markgate.yml` into gates with expensive setters (`integ`, with a Docker fixture run behind it) would force a real fixture run on a config comment edit. The issue also names the fuller upstream question (markgate self-detecting config edits, as it already does for hash-mode changes) — left with the issue's record; this entry is the repo-side stopgap.
