### PR TITLE
chore(work-issues): name the killed/refused-call trigger in the cwd gotcha

### DIFF
--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -30,7 +30,18 @@
   "no marker" because it ran in the main checkout while the marker sat in the
   lane's store, and a `.markgate-pr-review-sha` was written into the main
   checkout before the mistake was caught and redone from the lane. `pwd` costs
-  nothing; a marker in the wrong store costs a re-diagnosis.
+  nothing; a marker in the wrong store costs a re-diagnosis. **A KILLED or
+  REFUSED call is a named trigger for the cwd going wrong, and it lies about
+  the filesystem too**: a tool-call timeout that kills a call mid-run can bring
+  the persistent shell back at the session cwd, and a PreToolUse refusal aborts
+  the WHOLE call, so a directory it was going to `mkdir` never exists for a
+  later call's relative `cd` — and a failed `cd` stops an `&&` chain but NOT
+  the later lines of a multi-line call, which then write into whatever cwd was
+  current. Both measured in a cdkd `/work-issues` run on 2026-08-28 (retro
+  go-to-k/cdkd#2370); this repo has no main-tree EDIT gate to catch the stray
+  write, so the receipt matters more here. After any timeout or refusal, run
+  `pwd` and re-verify what the aborted call was supposed to create, before the
+  next relative-path command.
 - **A hook's `if` takes ONE pattern — ` or ` matches nothing and disables the
   gate outright.** On 2026-08-20 (go-to-k/cdk-real-drift#1801) all seventeen gates
   here were written as


### PR DESCRIPTION
Mirror of a `/work-issues` flow lesson found in cdkd on 2026-08-28 (retro go-to-k/cdkd#2370), landed here by the originating session per the three-repo mirror rule in `references/retro.md` section 10-c.

**The lesson**: the cwd gotcha prescribed the defenses (explicit `cd`, `pwd` receipts) without naming WHEN the cwd goes wrong. Two triggers were measured in one run: a tool-call timeout killing a call mid-run brings the persistent shell back at the session cwd, and a PreToolUse refusal aborts the WHOLE call, so a directory it was going to create never exists for a later call's relative `cd` — and a failed `cd` stops an `&&` chain but NOT the later lines of a multi-line call, which then write into whatever cwd was current.

**Adapted per this repo** (verified claim by claim against this repo's own files): cdk-local's marker stores are per-worktree (the bullet's existing text), and this repo has no main-tree EDIT gate (`ls .claude/hooks/` carries `main-tree-branch-gate.sh` but no `main-tree-edit-gate.sh`), so a stray write into the main tree is not blocked here and the `pwd` receipt is the only defense — stated in the amendment.

Landed in all three repos by this session: cdkd (go-to-k/cdkd#2370), this PR, and the cdk-real-drift twin. No mirror issues filed — the same-session landing covers the set.

**Verification** (prose-only diff): `vp run check` rc=0, `vp run build` rc=0, `vp run test` 4332/4332 rc=0 — including this repo's skill-file byte-cap suite and the bare-ref fence over the edited file.
