### PR TITLE
chore(work-issues): run lanes as per-issue subagents, with integ and merge serialized by the parent

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -28,23 +28,51 @@ optional** — each file carries hard rules and measured failure modes without
 which the stage summary below is not executable. A bare `§N` anywhere in this
 skill points into the file that holds that section (map in the table).
 
-**Delegate the read-heavy stages to subagents to keep this session's context for
-the lanes.** Two stages are shaped for it:
+**Delegate for context; keep the locks and the serialization in the parent.**
+The placements below are live-proven, not aspirational: on 2026-08-28 this
+repo's own skill-split PR (go-to-k/cdk-local#621) was built END-TO-END by a
+lane subagent — worktree, implementation, gates, reviewer dispatch, CI — with
+the parent doing only claims, serialized merges and cleanup, and every hook
+and markgate gate fired inside the lane's tool calls exactly as in the parent
+(the sibling go-to-k/cdk-real-drift#1831 shipped the same way the same day).
 
-- **Triage (stages 0–3)**: dispatch a read-only subagent (general-purpose or
-  Explore) whose prompt is: read `references/triage.md` in full, execute it
-  against this repo, and return ONLY the candidate table — per issue: number,
-  title, target files, rank + the rule that decided it, collision evidence
-  (worktrees / branches / claims found), and any premise-check findings. The raw
-  backlog listing and issue bodies stay out of the parent context. The PARENT
-  then claims (stage 4) — never the subagent, so the claim names the session
-  that will actually do the work.
-- **Retro (stage 10)**: after the last merge, dispatch a subagent with
+- **Triage (stages 0–3): a read-only subagent** (general-purpose or Explore)
+  whose prompt is: read `references/triage.md` in full, execute it against
+  this repo, and return ONLY the candidate table — per issue: number, title,
+  target files, rank + the rule that decided it, collision evidence
+  (worktrees / branches / claims found), and any premise-check findings. The
+  raw backlog listing and issue bodies stay out of the parent context.
+- **Claim (stage 4): the PARENT, never a subagent** — the claim is the lock,
+  so it names the session accountable for the lane; it also names the lane
+  branch/worktree the dispatched subagent will create (§4).
+- **Lanes (stages 5–8): one general-purpose subagent per claimed issue.**
+  Dispatch each with the issue number(s), the posted claim, and the stage
+  files to read at stage entry (`references/{implement,gates-and-pr,verify}.md`).
+  The lane creates its own worktree per §5, implements (unit + fixture
+  coverage in the SAME PR, per the never-defer-the-integ invariant), runs
+  `/check` + `/check-docs`, opens the PR, dispatches its review tier (a lane
+  may spawn reviewer subagents), addresses findings, and drives CI to green —
+  then STOPS at merge-ready and reports back: PR number, HEAD sha, markers
+  set, review verdicts, the integ fixture(s) its diff needs, anything
+  deferred. Its diffs, test logs and review round-trips never enter the
+  parent context. A lane must NOT start a Docker-side integ run
+  (`/run-integ`, or the `/create-integ` run a new-factory PR needs before
+  `gh pr create` — it asks the parent for that turn mid-lane) or a merge on
+  its own — that is the serialization invariant below, not a capability gap.
+- **Finishing (stage 9): the parent, one lane at a time.** Grant each
+  merge-ready lane its turn — resume the lane agent (SendMessage) to run its
+  named integ fixture(s) and `/merge-pr` while it holds the turn, or run
+  `/run-integ` and `/merge-pr` yourself FROM THAT LANE'S WORKTREE (markgate
+  markers are per-worktree, so the `integ` marker must land in the tree the
+  merge is judged from — §9). Post-merge (pull → worktree/branch audit)
+  follows §9.
+- **Retro (stage 10): a subagent**, dispatched after the last merge with
   `references/retro.md` plus this run's key evidence (what you re-read, what
   the text sent you into, corrections the user made) to measure the backlog
   effect, draft the skill edits, and ship them as the retro PR.
 
-Stages 4–9 run in the parent: they hold the locks, the worktrees, and the gates.
+Running a lane in the parent instead stays legal (a single-lane run, or a lane
+the user wants to watch); the stage files apply unchanged either way.
 
 ## Stages
 
@@ -80,6 +108,13 @@ Stages 4–9 run in the parent: they hold the locks, the worktrees, and the gate
   the SAME PR — the `integ` gate enforces it at merge time. (§5, §8)
 - **Merge only via `/merge-pr`** — a hand-run `gh pr merge` from a side worktree
   is gate-blocked and trips the worktree fatal besides. (§9)
+- **Docker-side integ runs and merges are SERIALIZED across lanes** — the
+  parent grants the turn, one lane at a time; a lane subagent never starts
+  `/run-integ`, `/create-integ`, or `/merge-pr` on its own (the flow runs the
+  integ in §8 and the merge in §9). Everything else (edits, unit tests,
+  markers, PR create, reviews, CI) runs concurrently, because markgate
+  markers are per-worktree (`.claude/rules/hooks.md`) — while the Docker
+  daemon is shared host state. (§8, §9)
 - **English only in every published artifact** — issue bodies/comments, PR
   titles/bodies, commits, code. (`.claude/CLAUDE.md`)
 - **The run ends with the retro (stage 10) and the standard wrap report**

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -2,6 +2,13 @@
 
 ## 4. CLAIM the chosen issues BEFORE editing
 
+When lanes run as SUBAGENTS (the orchestrator's default for stages 5–8), the
+PARENT posts every claim in this section — the claim is the lock and must name
+the session accountable for the lane — and the claim's `<ref>` names the branch
+/ worktree the dispatched lane agent will create, not a branch the parent
+holds. Everything else in this section is unchanged, including the re-check for
+a competing claim/PR right before the lane starts.
+
 For EACH issue you will start:
 
 ```bash

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -2,6 +2,18 @@
 
 ## 5. One worktree per lane, then implement
 
+This stage (and stages 6–8) normally runs INSIDE a lane subagent the
+orchestrator dispatched — one general-purpose agent per claimed issue, so the
+lane's diffs, test output and review round-trips never land in the parent
+context. Every rule below applies unchanged inside the lane: hooks fire on the
+lane's tool calls, and markgate markers land in the lane's own worktree.
+Two actions are reserved to the parent's serialization turn and are NOT the
+lane's to start: a Docker-side integ run (`/run-integ` — and the
+`/create-integ` run a new-factory PR needs before `gh pr create`: ask the
+parent for that turn mid-lane) and the merge (`/merge-pr`) — the
+orchestrator's serialization invariant; §9. A lane stops at merge-ready and
+reports.
+
 **Before fixing, ask whether the defect has SIBLING SITES — and if it does, sweep
 them in THIS lane rather than filing them.** Most defects here are a CLASS, not an
 instance: one command factory mishandling a flag, one resolver arm missing a case,

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -2,6 +2,21 @@
 
 ## 9. Ship: merge → pull → cleanup (all via `/merge-pr`)
 
+With subagent lanes, this stage is the PARENT's serialization point: grant one
+merge-ready lane at a time its turn — resume that lane agent (SendMessage) to
+run its named integ fixture(s) and `/merge-pr` while it holds the turn, or run
+`/run-integ` and `/merge-pr` yourself FROM THAT LANE'S WORKTREE. The worktree
+matters mechanically, not stylistically: markgate markers are per-worktree
+(`.claude/rules/hooks.md` — `markgate set` runs in the worktree whose gated
+command it clears), so the `integ` marker a `/run-integ` sets is visible only
+to a merge judged from the same tree — cdkd measured the wrong-tree shape live
+on 2026-08-28 (go-to-k/cdkd#2363). Within the turn, run the fixture(s) first
+and refresh whatever markers the run staled (§8's ordering rule), then
+`/merge-pr`. The Docker daemon is shared host state (container / network
+names, host ports, image tags, the post-run orphan sweep), so never two lanes'
+integ runs — nor two merges — concurrently; everything after the merge in this
+section (pull → worktree/branch audit) stays with the parent.
+
 Merge every verified PR with the `/merge-pr` skill — NOT a hand-run
 `gh pr merge --squash --delete-branch`:
 


### PR DESCRIPTION
## Summary

Mirrors go-to-k/cdkd#2372 into this repo's `/work-issues` skill: the skill split (go-to-k/cdk-local#621) delegated triage and retro to subagents; this extends the model to the LANES themselves, which are the dominant parent-context cost (diffs, test output and review round-trips per lane).

- **Orchestrator (`SKILL.md`)**: the delegation section now places every stage — triage subagent (stages 0-3), PARENT-posted claims (stage 4), **one general-purpose lane subagent per claimed issue for stages 5-8** (worktree, implement, `/check` + `/check-docs`, PR create, review-tier dispatch, CI-green — then STOP at merge-ready and report PR number / HEAD sha / markers / verdicts / needed fixtures), parent-serialized finishing (stage 9), retro subagent (stage 10). Running a lane in the parent stays legal.
- **New hard invariant**: Docker-side integ runs and merges are SERIALIZED across lanes — the parent grants the turn, one lane at a time; a lane never starts `/run-integ`, `/create-integ`, or `/merge-pr` on its own (the flow runs the integ in section 8 / `references/verify.md` and the merge in section 9 / `references/ship.md`). Everything else runs concurrently because markgate markers are per-worktree (`.claude/rules/hooks.md`), while the Docker daemon is shared host state.
- **`references/claim.md`**: with subagent lanes the parent posts every claim; the claim's `<ref>` names the branch/worktree the dispatched lane agent will create. The competing-claim re-check is unchanged.
- **`references/implement.md`**: stages 5-8 normally run inside the lane subagent; every rule applies unchanged there (hooks fire on the lane's tool calls, markers land in the lane's worktree). Reserved to the parent's turn: `/run-integ`, the `/create-integ` run a new-factory PR needs before `gh pr create` (the lane asks for that turn mid-lane), and `/merge-pr`.
- **`references/ship.md`**: stage 9 is the parent's serialization point — resume the lane (SendMessage) to run its fixtures and `/merge-pr` while it holds the turn, or run both yourself FROM THAT LANE'S WORKTREE; markers are per-worktree, so the `integ` marker must land in the tree the merge is judged from (cdkd measured the wrong-tree shape live on 2026-08-28, go-to-k/cdkd#2363). Within the turn: fixtures first, refresh staled markers per section 8's ordering rule, then `/merge-pr`.

Adapted, not transplanted (the verbatim-transplant mistake was caught in review on go-to-k/cdk-real-drift#1831): this repo's stage numbering, its claim wording (competing-claim re-check, no compare-and-swap machinery), its `/merge-pr`-only merge rule, its Docker-based integ (`/run-integ` / `/create-integ` / `integ` gate), and its own per-worktree-marker documentation (`.claude/rules/hooks.md`) are what the new text cites.

Live evidence: go-to-k/cdk-local#621 itself was built end-to-end by a lane subagent on 2026-08-28 — worktree, implementation, gates, reviewer dispatch, CI — with every hook and markgate gate firing inside the lane's tool calls; this repo is the proof.

## Test plan

- `tests/unit/skills/skill-file-payload.test.ts` — orchestrator is 9,801 B, under the 12,000 B cap (30/30 with the refs test)
- `tests/unit/skills/work-issues-skill-refs.test.ts` — every cross-repo issue ref in the touched files is qualified (`go-to-k/<repo>#N`)
- `vp run check` / `vp run build` / `vp run test` — 4,332 tests pass
- Docs-only (`.claude/skills/**`): no `src/**` touch, so the `integ` / `cdkd-parity` gates are out of scope; no docs-visible surface touched

## Retrospective

No new surprises this session; the serialization invariant itself is the lesson being folded in (measured in cdkd on 2026-08-28, go-to-k/cdkd#2363 for the wrong-tree merge shape).
