### PR TITLE
chore(hooks): register every hook via ${CLAUDE_PROJECT_DIR:-.} so a foreign cwd cannot swap or fail-open the gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,238 +16,238 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/branch-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/branch-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/branch-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/branch-gate.sh",
             "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/main-tree-branch-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/main-tree-branch-gate.sh",
             "if": "Bash(*git*switch*)",
             "timeout": 10,
             "statusMessage": "Checking main-tree branch-switch policy..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/main-tree-branch-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/main-tree-branch-gate.sh",
             "if": "Bash(*git*checkout*)",
             "timeout": 10,
             "statusMessage": "Checking main-tree branch-switch policy..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/commit-msg-heredoc-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit message form..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/control-char-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/control-char-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 15,
             "statusMessage": "Scanning staged files for NUL / control bytes..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/gh-pr-edit-deprecation-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/gh-pr-edit-deprecation-gate.sh",
             "if": "Bash(*gh*pr*edit*)",
             "timeout": 10,
             "statusMessage": "Checking gh pr edit deprecation..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/non-english-text-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/non-english-text-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/non-english-text-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/non-english-text-gate.sh",
             "if": "Bash(*gh*pr*edit*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/non-english-text-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/non-english-text-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/docs-inline-json-flag-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/docs-inline-json-flag-gate.sh",
             "if": "Bash(*gh*pr*edit*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/docs-inline-json-flag-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/docs-inline-json-flag-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Scanning PR diff for inline-JSON file-path flag misuse..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/post-merge-orphan-push-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/post-merge-orphan-push-gate.sh",
             "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking for orphan-push to merged branch..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/closes-paren-form-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/closes-paren-form-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Checking PR body for Closes (#N) parens-form trap..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-dup-check-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-dup-check-gate.sh",
             "if": "Bash(*gh*issue*create*)",
             "timeout": 10,
             "statusMessage": "Checking the issue body for a Dup-check line..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-classification-label-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-classification-label-gate.sh",
             "if": "Bash(*gh*issue*create*)",
             "timeout": 15,
             "statusMessage": "Checking the issue's Severity / Effort labels match its body..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-classification-label-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-classification-label-gate.sh",
             "if": "Bash(*gh*issue*edit*)",
             "timeout": 15,
             "statusMessage": "Checking the issue's Severity / Effort labels match its body..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-dup-check-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-dup-check-gate.sh",
             "if": "Bash(*gh*api*)",
             "timeout": 10,
             "statusMessage": "Checking the issue body for a Dup-check line..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pr-body-item-number-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pr-body-item-number-gate.sh",
             "if": "Bash(*gh*pr*edit*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pr-body-item-number-gate.sh",
             "if": "Bash(*gh*issue*create*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pr-body-item-number-gate.sh",
             "if": "Bash(*gh*issue*comment*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/pr-body-item-number-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pr-body-item-number-gate.sh",
             "if": "Bash(*gh*api*)",
             "timeout": 30,
             "statusMessage": "Scanning PR/issue body file for #N auto-link traps..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/markgate-pipe-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/markgate-pipe-gate.sh",
             "if": "Bash(*markgate*)",
             "timeout": 10,
             "statusMessage": "Checking markgate is not piped..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/check-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/check-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 15,
             "statusMessage": "Verifying check + docs markgate markers..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/pr-review-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pr-review-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Verifying pr-review marker (sha-bound)..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/verify-pr-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/verify-pr-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Verifying verify-pr markgate marker..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/verify-pr-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/verify-pr-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Verifying verify-pr markgate marker..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/integ-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/integ-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Verifying integ markgate marker..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/integ-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/integ-gate.sh",
             "if": "Bash(*git*merge*)",
             "timeout": 15,
             "statusMessage": "Verifying integ markgate marker..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/cdkd-parity-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/cdkd-parity-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Verifying cdkd-parity markgate marker..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/create-integ-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/create-integ-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Verifying create-integ markgate marker..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/gh-pr-merge-worktree-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/gh-pr-merge-worktree-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Checking worktree merge policy (/merge-pr)..."
@@ -260,7 +260,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/stop-unmerged-lane-warn.sh"
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stop-unmerged-lane-warn.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Closes #628. All 35 hook commands in `.claude/settings.json` were registered repo-relative (`.claude/hooks/<name>.sh`); a hook process resolves that against the session shell's CURRENT cwd, so from a sibling repo's tree (the documented cross-repo workflow) cdk-local's gate policy silently stopped being cdk-local's: same-named hooks executed the SIBLING's implementation, and cdk-local-only hooks (`gh-pr-merge-worktree-gate`, `markgate-pipe-gate`, `cdkd-parity-gate`, `create-integ-gate`, `integ-gate`, ...) failed to spawn and the call proceeded — fail-open. The mechanism was measured live in cdkd on 2026-08-28 (go-to-k/cdkd#2379); this repo carries the identical registration pattern.

The fix prefixes every command with `${CLAUDE_PROJECT_DIR:-.}/` — the documented hook env var pins resolution to the session's project root, and the `:-.` fallback degrades to today's exact behavior if the variable is ever unset, so the change cannot be WORSE than the status quo in any environment. Hook internals are untouched; only the spawn path moves. Mirrors the merged cdkd fix go-to-k/cdkd#2380.

## Test plan

- `python json.loads` on the rewritten file: valid; zero relative `"command": ".claude/hooks/"` forms remain; 35 rewritten.
- `tests/unit/hooks/gate-if-matchers.test.ts` (the settings-reading suite: gate selection is derived from `settings.json` hook commands): 26 tests pass — `includes('.claude/hooks/')` and the `basename` extraction both tolerate the new prefix.
- Full suite: 240 files / 4332 tests pass; `vp run check` and `vp run build` green.
- Live-fire caveat, stated rather than skipped: a running session keeps the hook commands it registered at start, so the end-to-end proof (a cdk-local gate blocking from a sibling cwd) is only observable in the NEXT session. The next session's verification command is in the issue (#628).
