### PR TITLE
chore(gates): scope the check gate to the files that decide what green means, and make /check run the shell half

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1373,7 +1373,8 @@ vp run runtime:smoke
   `gh pr create` / `gh pr merge` unless the `verify-pr` marker
   (declared `requires: [check, docs]`) is fresh. The marker is set
   ONLY by `/verify-pr`, which walks the full checklist: typecheck /
-  lint / build / tests, CI status, working tree, docs consistency,
+  lint / build / unit tests / `vp run test:hooks`, CI status,
+  working tree, docs consistency,
   Docker + integ marker check, code review (incl. shared-utility
   caller verification), live-test, retrospective + rule proposals,
   residual review-nit sweep + auto-close audit, and PR title + body
@@ -1804,5 +1805,5 @@ vp run runtime:smoke
   surface (factory exports, `LocalStateProvider` API) — linked from
   README's "Programmatic use" pointer.
 - `vite.config.ts` — vp tasks, lint / fmt / pack / test config.
-- `.github/workflows/ci.yml` — CI (typecheck + lint + test + build +
-  Node 20/22/24 matrix smoke).
+- `.github/workflows/ci.yml` — CI (`vp run check` + `test` +
+  `test:hooks` + `build`, then a Node 20/22/24 matrix smoke).

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1246,7 +1246,7 @@ vp run test:coverage
 # Hook smoke tests (bash, run in CI alongside the unit suite)
 vp run test:hooks
 
-# verify = check + test + build
+# verify = check + test + test:hooks + build
 vp run verify
 
 # Build artifact smoke test
@@ -1315,9 +1315,13 @@ vp run runtime:smoke
   `cdkl` bin), so source changes without a build have no runtime
   effect.
 
-- **Before opening a PR**: run `vp run verify` (= check + test + build).
-  This is what CI runs; failing locally is faster feedback than failing
-  in GitHub Actions.
+- **Before opening a PR**: run `vp run verify` (= check + test +
+  test:hooks + build). `test:hooks` is in that chain because the `check`
+  markgate marker attests to it (go-to-k/cdk-local#630) and it is a
+  SEPARATE task from `vp run test` — an alias stopping short of it
+  reports a green the gate does not mean. This is what CI's
+  `check-build-test` job runs; failing locally is faster feedback than
+  failing in GitHub Actions.
 
 - **Registration is not execution — prove the gates are ALIVE before the first
   commit of a session**: run `git commit --dry-run -m "gate liveness probe"` from
@@ -1333,8 +1337,12 @@ vp run runtime:smoke
   both the `check` and `docs` markgate markers are fresh. Run
   `/check` and/or `/check-docs` proactively based on what your diff
   touches (a tests-only commit needs `/check`; a docs-only commit
-  needs `/check-docs`; a src edit needs both; changes outside both
-  scopes need neither). `/verify-pr` refreshes both in one shot.
+  needs `/check-docs`; a src edit needs both; a `.claude/hooks/**`,
+  `.markgate.yml`, `vite.config.ts` or `.mise.toml` edit needs
+  `/check`, because those decide what "green" means or what the
+  marker attests to — go-to-k/cdk-local#624, go-to-k/cdk-local#630;
+  changes outside both scopes need neither). `/verify-pr` refreshes
+  both in one shot.
   Per-gate scopes, error-message decoding, and other details:
   [.claude/rules/hooks.md](.claude/rules/hooks.md). Install `vp` +
   `markgate` via `mise install` at the repo root, and re-run it after

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1338,9 +1338,12 @@ vp run runtime:smoke
   `/check` and/or `/check-docs` proactively based on what your diff
   touches (a tests-only commit needs `/check`; a docs-only commit
   needs `/check-docs`; a src edit needs both; a `.claude/hooks/**`,
-  `.markgate.yml`, `vite.config.ts` or `.mise.toml` edit needs
-  `/check`, because those decide what "green" means or what the
-  marker attests to — go-to-k/cdk-local#624, go-to-k/cdk-local#630;
+  `.markgate.yml`, `vite.config.ts`, `.mise.toml`, `.node-version`
+  or `.github/workflows/ci.yml` edit needs `/check`, because those
+  decide what "green" means, what runs it, or what the marker
+  attests to — go-to-k/cdk-local#624, go-to-k/cdk-local#630. The
+  authoritative list is `.markgate.yml` itself, restated once in
+  `.claude/rules/hooks.md` under a set-equality fence;
   changes outside both scopes need neither). `/verify-pr` refreshes
   both in one shot.
   Per-gate scopes, error-message decoding, and other details:

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -117,7 +117,7 @@ if [ "$check_status" -ne 0 ]; then
   if [ -n "$reason" ]; then
     msg="$msg run /check first $reason;"
   else
-    msg="$msg run /check first (or re-run if src/tests/config changed);"
+    msg="$msg run /check first (or re-run if src/tests/hooks/config changed);"
   fi
 fi
 if [ "$docs_status" -ne 0 ]; then

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -121,7 +121,7 @@ Required action — no exceptions:
   /verify-pr [PR-number]
 
 The skill walks the full PR-readiness checklist:
-  - typecheck / lint / build / unit tests
+  - typecheck / lint / build / unit tests / vp run test:hooks
   - test coverage for the diff
   - CI status / working tree / docs consistency
   - Docker + integ marker verification (for src/** or tests/integration/** touches)

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -697,20 +697,23 @@ construction.
   - `check` — recorded by `/check` (typecheck + lint + format +
     build + unit tests + `vp run test:hooks`). Scope: `src/**`,
     `tests/**`, `package.json`, `pnpm-lock.yaml`, `tsconfig*.json`,
-    `vite.config.ts`, `.mise.toml`, `.markgate.yml`,
+    `vite.config.ts`, `.mise.toml`, `.node-version`, `.markgate.yml`,
     `.claude/hooks/**`, plus the checker-INPUT files the unit suite
     reads — `.claude/skills/**`, `.claude/agents/**`,
-    `.claude/rules/**`, `.claude/settings.json`, and the
-    pr-inherit-issue-labels workflow YAML (go-to-k/cdk-local#620;
+    `.claude/rules/**`, `.claude/settings.json`, and
+    `.github/workflows/pr-inherit-issue-labels.yml` (go-to-k/cdk-local#620;
     see the mapping comment in `.markgate.yml`). Only invalidated
     by changes in that scope.
 
-    `vite.config.ts` / `.mise.toml` / `.markgate.yml` are in for a
-    different reason than the rest: they decide what "green" MEANS
-    rather than being read by an assertion — the test-selection
-    globs and task definitions, the pinned `vp` / `markgate`
-    binaries that run them, and the gate's own definition
-    (go-to-k/cdk-local#630 / go-to-k/cdk-local#624). The include
+    `vite.config.ts` / `.mise.toml` / `.node-version` /
+    `.markgate.yml` are in for a different reason than the rest:
+    they decide what "green" MEANS rather than being read by an
+    assertion — the test-selection globs and task definitions, the
+    pinned `vp` / `markgate` binaries that run them, the Node they
+    run on, and the gate's own definition (go-to-k/cdk-local#630 /
+    go-to-k/cdk-local#624). This paragraph is itself fenced:
+    `tests/unit/gates/markgate-include-globs.test.ts` fails if it
+    stops naming any include entry. The include
     used to name `vitest.config.ts`, `.eslintrc*` and `.prettierrc*`,
     none of which exist here; `tests/unit/gates/markgate-include-globs.test.ts`
     now fails on any include entry matching no tracked file.
@@ -737,18 +740,27 @@ construction.
   (and `/check` too when it touches `.claude/rules/**`, which sits
   in BOTH scopes); a src edit needs both; a skills / agents /
   settings.json edit needs `/check` (checker input,
-  go-to-k/cdk-local#620); a hooks / `.markgate.yml` / `vite.config.ts`
-  / `.mise.toml` edit needs `/check` too (go-to-k/cdk-local#624,
-  go-to-k/cdk-local#630). What is left outside both scopes is
-  narrow — `.github/workflows/` other than the pr-inherit one,
-  `CONTRIBUTING.md`, `.vscode/`, `.markdownlint.json` (an editor
-  setting nothing in `vp run check` or CI reads) — and needs
-  neither. This sentence used to name `.claude/hooks/**` and
-  `.markgate.yml` as the out-of-scope examples and was already
-  false for `.markgate.yml` when go-to-k/cdk-local#624 scoped it
-  in; keep it in step with `.markgate.yml` rather than describing
-  it from memory. The hook is a safety net, not the primary
-  trigger.
+  go-to-k/cdk-local#620); a hooks / `.markgate.yml` /
+  `vite.config.ts` / `.mise.toml` / `.node-version` edit needs
+  `/check` too (go-to-k/cdk-local#624, go-to-k/cdk-local#630).
+  What is left outside both scopes is stated as a RULE rather than
+  a list, because a list of the complement is the same enumeration
+  that went stale above: a file is outside both scopes when no
+  assertion READS it AND it does not decide what "green" means —
+  `CONTRIBUTING.md`, `.vscode/`, `.releaserc.json`, `CHANGELOG.md`
+  and `.markdownlint.json` (an editor setting nothing in
+  `vp run check` or CI reads) are examples, not the whole set. Two
+  cautions from go-to-k/cdk-local#630's review: the previous
+  wording named `.claude/hooks/**` and `.markgate.yml` as
+  out-of-scope examples and was ALREADY false for `.markgate.yml`
+  when go-to-k/cdk-local#624 scoped it in; and `.github/workflows/`
+  is not wholly outside — the pr-inherit workflow is a checker
+  input and `ci.yml` is asserted on by
+  `tests/unit/gates/markgate-include-globs.test.ts`. Settle a
+  borderline case against `.markgate.yml`, or against
+  `markgate verify check --explain`, which prints the RESOLVED
+  scope (include minus exclude) to stderr. The hook is a safety
+  net, not the primary trigger.
 
   **Run `mise install` after pulling a change to `.mise.toml`.** An
   older markgate binary rejects a newer `.markgate.yml` (an unknown

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -719,7 +719,12 @@ construction.
     stops naming any include entry. The include
     used to name `vitest.config.ts`, `.eslintrc*` and `.prettierrc*`,
     none of which exist here; `tests/unit/gates/markgate-include-globs.test.ts`
-    now fails on any include entry matching no tracked file.
+    now fails on any include entry matching no file (tracked OR on
+    disk — `hash: files` digests untracked content too) and on any
+    entry naming a bare directory rather than `<dir>/**`. It
+    deliberately over-approximates rather than under-reports;
+    `markgate config lint --json` is the exact instrument, and is not
+    available in CI.
 
     `.claude/hooks/**` needs BOTH halves and one alone is worse
     than neither: the path in the include makes a hook edit stale

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -701,8 +701,8 @@ construction.
     `.claude/hooks/**`, plus the checker-INPUT files the unit suite
     reads — `.claude/skills/**`, `.claude/agents/**`,
     `.claude/rules/**`, `.claude/settings.json`,
-    `.github/workflows/pr-inherit-issue-labels.yml` and
-    `.github/workflows/ci.yml` (go-to-k/cdk-local#620,
+    `.github/workflows/pr-inherit-issue-labels.yml`,
+    `.github/workflows/ci.yml` and `.gitignore` (go-to-k/cdk-local#620,
     go-to-k/cdk-local#630; see the mapping comment in
     `.markgate.yml`). The other two workflows are read by nothing
     and stay out of scope. Only invalidated by changes in that

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -715,8 +715,9 @@ construction.
     pinned `vp` / `markgate` binaries that run them, the Node they
     run on, and the gate's own definition (go-to-k/cdk-local#630 /
     go-to-k/cdk-local#624). This paragraph is itself fenced:
-    `tests/unit/gates/markgate-include-globs.test.ts` fails if it
-    stops naming any include entry. The include
+    `tests/unit/gates/markgate-include-globs.test.ts` asserts this
+    sentence names EXACTLY the include set — a dropped entry and an
+    invented one both fail. The include
     used to name `vitest.config.ts`, `.eslintrc*` and `.prettierrc*`,
     none of which exist here; `tests/unit/gates/markgate-include-globs.test.ts`
     now fails on any include entry matching no file (tracked OR on

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -700,10 +700,13 @@ construction.
     `vite.config.ts`, `.mise.toml`, `.node-version`, `.markgate.yml`,
     `.claude/hooks/**`, plus the checker-INPUT files the unit suite
     reads — `.claude/skills/**`, `.claude/agents/**`,
-    `.claude/rules/**`, `.claude/settings.json`, and
-    `.github/workflows/pr-inherit-issue-labels.yml` (go-to-k/cdk-local#620;
-    see the mapping comment in `.markgate.yml`). Only invalidated
-    by changes in that scope.
+    `.claude/rules/**`, `.claude/settings.json`,
+    `.github/workflows/pr-inherit-issue-labels.yml` and
+    `.github/workflows/ci.yml` (go-to-k/cdk-local#620,
+    go-to-k/cdk-local#630; see the mapping comment in
+    `.markgate.yml`). The other two workflows are read by nothing
+    and stay out of scope. Only invalidated by changes in that
+    scope.
 
     `vite.config.ts` / `.mise.toml` / `.node-version` /
     `.markgate.yml` are in for a different reason than the rest:
@@ -754,9 +757,10 @@ construction.
   wording named `.claude/hooks/**` and `.markgate.yml` as
   out-of-scope examples and was ALREADY false for `.markgate.yml`
   when go-to-k/cdk-local#624 scoped it in; and `.github/workflows/`
-  is not wholly outside — the pr-inherit workflow is a checker
-  input and `ci.yml` is asserted on by
-  `tests/unit/gates/markgate-include-globs.test.ts`. Settle a
+  is not wholly outside — `pr-inherit-issue-labels.yml` and
+  `ci.yml` are both checker inputs and both scoped in, while
+  `release.yml` and `pr-title-check.yml` are read by nothing.
+  Settle a
   borderline case against `.markgate.yml`, or against
   `markgate verify check --explain`, which prints the RESOLVED
   scope (include minus exclude) to stderr. The hook is a safety

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -695,13 +695,32 @@ construction.
 - **`check-gate.sh`** blocks `git commit` unless both the `check`
   and `docs` markgate markers are fresh.
   - `check` — recorded by `/check` (typecheck + lint + format +
-    build + tests). Scope: `src/**`, `tests/**`, lockfiles,
-    build/test configs, plus the checker-INPUT files the unit suite
+    build + unit tests + `vp run test:hooks`). Scope: `src/**`,
+    `tests/**`, `package.json`, `pnpm-lock.yaml`, `tsconfig*.json`,
+    `vite.config.ts`, `.mise.toml`, `.markgate.yml`,
+    `.claude/hooks/**`, plus the checker-INPUT files the unit suite
     reads — `.claude/skills/**`, `.claude/agents/**`,
     `.claude/rules/**`, `.claude/settings.json`, and the
     pr-inherit-issue-labels workflow YAML (go-to-k/cdk-local#620;
     see the mapping comment in `.markgate.yml`). Only invalidated
     by changes in that scope.
+
+    `vite.config.ts` / `.mise.toml` / `.markgate.yml` are in for a
+    different reason than the rest: they decide what "green" MEANS
+    rather than being read by an assertion — the test-selection
+    globs and task definitions, the pinned `vp` / `markgate`
+    binaries that run them, and the gate's own definition
+    (go-to-k/cdk-local#630 / go-to-k/cdk-local#624). The include
+    used to name `vitest.config.ts`, `.eslintrc*` and `.prettierrc*`,
+    none of which exist here; `tests/unit/gates/markgate-include-globs.test.ts`
+    now fails on any include entry matching no tracked file.
+
+    `.claude/hooks/**` needs BOTH halves and one alone is worse
+    than neither: the path in the include makes a hook edit stale
+    the marker, and `/check` running `vp run test:hooks` is what
+    makes the `/check` that clears it actually execute the eight
+    `.claude/hooks/*.test.sh` suites. With only the include, the
+    marker would attest to a suite that does not contain them.
   - `docs` — recorded by `/check-docs` (README.md /
     `.claude/CLAUDE.md` / `docs/` / `.claude/rules/` consistency
     with src). Scope: `src/**`, `docs/**`, `README.md`,
@@ -718,9 +737,18 @@ construction.
   (and `/check` too when it touches `.claude/rules/**`, which sits
   in BOTH scopes); a src edit needs both; a skills / agents /
   settings.json edit needs `/check` (checker input,
-  go-to-k/cdk-local#620); changes that fall outside both scopes
-  (`.claude/hooks/**`, `.markgate.yml`) need neither. The hook is a
-  safety net, not the primary trigger.
+  go-to-k/cdk-local#620); a hooks / `.markgate.yml` / `vite.config.ts`
+  / `.mise.toml` edit needs `/check` too (go-to-k/cdk-local#624,
+  go-to-k/cdk-local#630). What is left outside both scopes is
+  narrow — `.github/workflows/` other than the pr-inherit one,
+  `CONTRIBUTING.md`, `.vscode/`, `.markdownlint.json` (an editor
+  setting nothing in `vp run check` or CI reads) — and needs
+  neither. This sentence used to name `.claude/hooks/**` and
+  `.markgate.yml` as the out-of-scope examples and was already
+  false for `.markgate.yml` when go-to-k/cdk-local#624 scoped it
+  in; keep it in step with `.markgate.yml` rather than describing
+  it from memory. The hook is a safety net, not the primary
+  trigger.
 
   **Run `mise install` after pulling a change to `.mise.toml`.** An
   older markgate binary rejects a newer `.markgate.yml` (an unknown
@@ -739,7 +767,7 @@ construction.
   freshness is the AND of those children plus the `/verify-pr`
   skill's own work. The skill walks the full checklist:
 
-  - typecheck / lint / build / tests
+  - typecheck / lint / build / unit tests / `vp run test:hooks`
   - test coverage for the diff
   - CI status / working tree / docs consistency
   - Docker + integ marker check (for `src/**` or

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check
-description: Run local quality checks (typecheck, lint, format, build, tests). Quick check during development.
+description: Run local quality checks (typecheck, lint, format, build, unit tests, hook shell suites). Quick check during development.
 ---
 
 # Local Quality Check
@@ -14,8 +14,23 @@ Run these sequentially and report results:
 1. `vp run check` — typecheck + lint + format check (the unified task wired in `vite.config.ts`).
 2. `vp run build` — produces `dist/cli.js` and `dist/index.js`.
 3. `vp run test` — vitest unit tests.
+4. `vp run test:hooks` — the shell suites under `.claude/hooks/*.test.sh` and
+   `tests/integration/_lib/*.test.sh` (~75 s; spawns throwaway git repos and a
+   PATH-stubbed `gh`, so it is uncached).
 
-`vp run verify` is the convenience alias that runs all three; either path is fine.
+`vp run verify` is the convenience alias that runs all four; either path is
+fine.
+
+Step 4 is NOT optional. `.claude/hooks/**` is inside the `check` gate's
+include, so editing a hook stales the marker — and a `/check` that skipped
+`test:hooks` would clear that marker while never running the assertions the
+edit could have broken, leaving the marker attesting to a suite that does not
+contain them (go-to-k/cdk-local#630). The inverse holds too: the four-copy `UP_PATHS` sync
+assertion in `.claude/hooks/pr-review-gate.test.sh` reads `.claude/rules/hooks.md`,
+`.claude/agents/pr-code-reviewer.md` and `.claude/skills/review-pr/SKILL.md`,
+all already in scope, so an edit there staled the marker without anything
+re-running the check. CI runs `vp run test:hooks` as its own step, so skipping
+it locally only moves the failure to the PR.
 
 ## Output
 
@@ -26,13 +41,14 @@ Report as a table:
 | typecheck + lint + format (`vp run check`) | pass/fail |
 | build | pass/fail |
 | tests (N files, M tests) | pass/fail |
+| hook shell suites (`vp run test:hooks`, N pass / M fail) | pass/fail |
 
 If all pass, confirm "All checks passed."
 If any fail, show the error output and STOP — do not write the commit-gate marker.
 
 ## Commit-gate marker (on success only)
 
-After all three checks pass, record a marker so the `check` gate is fresh. The marker is managed by [markgate](https://github.com/go-to-k/markgate) and captures the current working tree state; any subsequent edits invalidate it and require re-running `/check`.
+After all four checks pass, record a marker so the `check` gate is fresh. The marker is managed by [markgate](https://github.com/go-to-k/markgate) and captures the current working tree state; any subsequent edits invalidate it and require re-running `/check`.
 
 Run this from the WORKTREE you will commit from — not the main checkout (each worktree has its own markgate marker store, so a marker set elsewhere surfaces later as a mystifying "no marker"; see the convention in `.claude/rules/hooks.md`). cdk-local pins markgate via mise, so use `mise exec` to avoid PATH issues when shims aren't active:
 

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -206,6 +206,7 @@ Present results as a table:
 | typecheck + lint + format | pass/fail |
 | build | pass/fail |
 | tests (N files, M tests) | pass/fail |
+| hook shell suites (`vp run test:hooks`) | pass/fail |
 | test coverage for changes | pass/fail |
 | CI | pass/fail |
 | working tree | clean/dirty |

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -26,6 +26,7 @@ Run each check and report pass/fail:
 
 2. **Tests**
    - `vp run test` — all unit tests pass
+   - `vp run test:hooks` — the shell suites under `.claude/hooks/*.test.sh` and `tests/integration/_lib/*.test.sh` (~75 s, uncached). **Not optional, and not covered by `vp run test`**: it is a separate task in `vite.config.ts`, while `.claude/hooks/**` sits inside the `check` gate's include — so this step is what stops the `check` marker this skill sets from attesting to a suite that excludes those assertions (go-to-k/cdk-local#630). CI runs it as its own step, so skipping it here only moves the failure to the PR.
    - Report test count (files and tests)
    - **Test coverage check**: compare `git diff origin/main...HEAD` for `src/` changes vs `tests/` changes. If new logic was added or modified in `src/` but no corresponding test files were added or updated, flag as **fail** and add the missing tests before proceeding.
 

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -25,8 +25,13 @@ by hand and say so in the report, because nothing else will.
 From inside the worktree, run the full check that CI runs:
 
 ```bash
-vp run verify        # = check (typecheck + lint + format) + test + build
+vp run verify        # = check (typecheck + lint + format) + test + test:hooks + build
 ```
+
+`test:hooks` is in that alias because it is in what `/check` runs and therefore
+in what the `check` marker attests to (go-to-k/cdk-local#630); it is a separate
+task from `vp run test`, so an alias stopping short of it would report green on
+a suite the gate does not mean.
 
 All green, then run `/check` (and `/check-docs` if the diff touches docs) to refresh
 the markers the check-gate demands, commit (conventional-commit prefix), push, and

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -2,13 +2,14 @@
 
 ## 8. Verify before merge (`/verify-pr`)
 
-Run `/verify-pr`. It walks the full checklist (typecheck / lint / build / tests,
-CI status, docs consistency, Docker + integ marker, code review, PR title/body
-freshness) and — critically — **live-tests the changed behavior**:
+Run `/verify-pr`. It walks the full checklist (typecheck / lint / build / unit
+tests / `vp run test:hooks`, CI status, docs consistency, Docker + integ marker,
+code review, PR title/body freshness) and — critically — **live-tests the
+changed behavior**:
 
 **Run the integ LAST — and set the `check` / `docs` markers AFTER it, not before.**
 A fixture run writes `cdk.out/`, `node_modules/` and `pnpm-lock.yaml` under
-`tests/integration/<fixture>/`; the `check` gate covers `tests/**` (plus `src/**`, configs and the checker-input agent-instruction files) and markgate
+`tests/integration/<fixture>/`; the `check` gate covers `tests/**` (plus `src/**`, `vite.config.ts` / `.mise.toml` / `.markgate.yml`, `.claude/hooks/**` and the checker-input agent-instruction files) and markgate
 digests those artifacts even though git ignores them (go-to-k/cdk-local#620), so
 a green integ STALES a `check` marker set minutes earlier with `git status`
 clean — a `git commit` refused for "digest differs" that no source edit explains

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -9,7 +9,7 @@ changed behavior**:
 
 **Run the integ LAST — and set the `check` / `docs` markers AFTER it, not before.**
 A fixture run writes `cdk.out/`, `node_modules/` and `pnpm-lock.yaml` under
-`tests/integration/<fixture>/`; the `check` gate covers `tests/**` (plus `src/**`, `vite.config.ts` / `.mise.toml` / `.markgate.yml`, `.claude/hooks/**` and the checker-input agent-instruction files) and markgate
+`tests/integration/<fixture>/`; the `check` gate covers `tests/**` (plus `src/**`, the files that decide what green means — `vite.config.ts` / `.mise.toml` / `.node-version` / `.markgate.yml` — `.claude/hooks/**` and the checker-input agent-instruction files and workflows; `.claude/rules/hooks.md` has the authoritative list) and markgate
 digests those artifacts even though git ignores them (go-to-k/cdk-local#620), so
 a green integ STALES a `check` marker set minutes earlier with `git status`
 clean — a `git commit` refused for "digest differs" that no source edit explains

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -12,7 +12,8 @@
 # misleading "run /check first" that re-running `/check` cannot clear.
 #
 # Gates:
-#   check          — typecheck/lint/build/unit tests
+#   check          — typecheck/lint/build/unit tests, plus the shell hook
+#                    suites (`vp run test:hooks`, issue #630)
 #                    (set by /check and /verify-pr).
 #   docs           — README/CLAUDE.md/docs consistency with src
 #                    (set by /check-docs and /verify-pr).
@@ -66,16 +67,43 @@ gates:
       #   - tests/unit/hooks/pr-inherit-issue-labels.test.ts reads its
       #     workflow YAML
       # `.claude/rules/**` sits in `docs` too — same overlap cdkd carries,
-      # for the same two reasons. Known limit, deliberate: the repo-wide
-      # scanners (e.g. tests/unit/no-control-bytes.test.ts globs every
-      # tracked text file) read a population scoping cannot follow without
-      # making the marker stale on every edit anywhere; CI remains the
-      # backstop there.
+      # for the same two reasons.
+      #
+      # Known limit, deliberate — and the test is NOT "repo-wide vs finite"
+      # (issue #630). A whole-tree scanner is a proportionate carve-out only
+      # while the condition it fires on is RARE: tests/unit/no-control-bytes.test.ts
+      # globs every tracked text file, but a C0 control byte in committed text
+      # is a freak event, so the marker reading fresh over an edit anywhere is
+      # a real but tiny exposure and CI remains the backstop there. A scanner
+      # whose predicate is ORDINARY CONTENT does not get the carve-out — its
+      # population has to be inside this include, or the assertion has to move
+      # out of the `check` suite. That file's excluded-extension assertion used
+      # to be exactly such a case (it pinned the set to `['.gif']`, so adding
+      # any .png / .pdf / .woff2 anywhere reddened it); #630 relaxed it to a
+      # subset check against a named binary-extension list, which restores the
+      # rare-predicate premise this paragraph rests on.
       - ".claude/skills/**"
       - ".claude/agents/**"
       - ".claude/rules/**"
       - ".claude/settings.json"
       - ".github/workflows/pr-inherit-issue-labels.yml"
+      # The shell half (issue #630). Eight `.claude/hooks/*.test.sh` suites
+      # read `.claude/hooks/*.sh`, each resolving its subject self-relatively,
+      # and two more live under `tests/integration/_lib/`. Adding the path here
+      # is only HALF the fix and would be misleading on its own: `vp run test`
+      # does not execute them (`test:hooks` is a separate task in
+      # `vite.config.ts`), so a stale marker cleared by a `/check` that never
+      # ran those assertions would attest to a suite that does not contain
+      # them. `/check` and `/verify-pr` therefore run `vp run test:hooks` too —
+      # the decision #630 asked for, taken in the direction that makes the
+      # marker mean what it appears to mean rather than documenting the hole.
+      # This also closes the inverse shape: `.claude/hooks/pr-review-gate.test.sh`
+      # asserts four copies of the UP_PATHS list stay in sync across
+      # `.claude/rules/hooks.md`, `.claude/agents/pr-code-reviewer.md` and
+      # `.claude/skills/review-pr/SKILL.md` — all already in this include, so
+      # editing one DID stale the marker while the `/check` that cleared it
+      # never ran the sync assertion.
+      - ".claude/hooks/**"
       # This file itself (issue #623): the gate's own definition decides
       # what the marker MEANS, so editing it — including this include
       # list — must stale a marker recorded under the old definition.
@@ -87,9 +115,25 @@ gates:
       - "package.json"
       - "pnpm-lock.yaml"
       - "tsconfig*.json"
-      - "vitest.config.ts"
-      - ".eslintrc*"
-      - ".prettierrc*"
+      # The files that decide what "green" MEANS, same class as `.markgate.yml`
+      # above (issue #630). `vite.config.ts` holds the vitest `include` globs,
+      # the lint/format rules and every `vp run <task>` definition, so
+      # narrowing `include: ['tests/**/*.test.ts', ...]` there leaves the suite
+      # GREEN and the marker FRESH while most of it has stopped running — the
+      # silent direction, and the one that matters (breaking `setupFiles` reds
+      # it loudly). `.mise.toml` pins the `vp` and `markgate` binaries that RUN
+      # those definitions, so a toolchain bump changes what green attests to;
+      # cdkd scopes its own `.mise.toml` for that reason and this file's header
+      # already warns that a `.mise.toml` change can silently break every gate.
+      #
+      # These replace `vitest.config.ts` / `.eslintrc*` / `.prettierrc*`, which
+      # named nothing in this repo: `git ls-files | grep -E '^(vitest\.config\.ts|\.eslintrc|\.prettierrc)'`
+      # returned zero rows, and `ls` found no untracked copy either. A glob
+      # matching nothing is indistinguishable from a glob doing its job, which
+      # is why `tests/unit/gates/markgate-include-globs.test.ts` now fails on
+      # any include entry that matches no tracked file.
+      - "vite.config.ts"
+      - ".mise.toml"
 
   docs:
     hash: files

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -145,7 +145,8 @@ gates:
       # returned zero rows, and `ls` found no untracked copy either. A glob
       # matching nothing is indistinguishable from a glob doing its job, which
       # is why `tests/unit/gates/markgate-include-globs.test.ts` now fails on
-      # any include entry that matches no tracked file.
+      # any include entry matching no file — tracked OR on disk, since
+      # `hash: files` digests untracked content too.
       - "vite.config.ts"
       - ".mise.toml"
       - ".node-version"

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -97,6 +97,15 @@ gates:
       # the #620 class, freshly reintroduced by the very fence added to close
       # it. The other two workflows are read by nothing and stay out of scope.
       - ".github/workflows/ci.yml"
+      # Same class a THIRD time, found in #630's fourth review round:
+      # markgate-include-globs.test.ts runs `git check-ignore` to prove its one
+      # allow-listed zero-match entry is a real gitignored sentinel, so
+      # `.gitignore` is a checker INPUT of that suite -- deleting its
+      # `.markgate-pr-review-sha` line reds the suite while a marker set
+      # beforehand stays fresh. Invisible to that file's read scan, which
+      # follows `readFileSync` but cannot follow an argument into a
+      # subprocess; the `execFileSync` budget there is what keeps this honest.
+      - ".gitignore"
       # The shell half (issue #630). Eight `.claude/hooks/*.test.sh` suites
       # read `.claude/hooks/*.sh`, each resolving its subject self-relatively,
       # and two more live under `tests/integration/_lib/`. Adding the path here

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -125,6 +125,10 @@ gates:
       # those definitions, so a toolchain bump changes what green attests to;
       # cdkd scopes its own `.mise.toml` for that reason and this file's header
       # already warns that a `.mise.toml` change can silently break every gate.
+      # `.node-version` is the same argument for the runtime the suite executes
+      # ON: `.mise.toml` pins only `vp` and `markgate`, so without this entry a
+      # Node bump -- the thing most likely to change what the suite does -- left
+      # the marker fresh. Added during #630's review round.
       #
       # These replace `vitest.config.ts` / `.eslintrc*` / `.prettierrc*`, which
       # named nothing in this repo: `git ls-files | grep -E '^(vitest\.config\.ts|\.eslintrc|\.prettierrc)'`
@@ -134,6 +138,7 @@ gates:
       # any include entry that matches no tracked file.
       - "vite.config.ts"
       - ".mise.toml"
+      - ".node-version"
 
   docs:
     hash: files

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -66,6 +66,9 @@ gates:
       #     .claude/settings.json (the #1801 inert-`if:` class)
       #   - tests/unit/hooks/pr-inherit-issue-labels.test.ts reads its
       #     workflow YAML
+      #   - tests/unit/gates/markgate-include-globs.test.ts reads THIS file,
+      #     ci.yml, vite.config.ts, .claude/rules/hooks.md and the check /
+      #     verify-pr SKILL.md files (#630)
       # `.claude/rules/**` sits in `docs` too — same overlap cdkd carries,
       # for the same two reasons.
       #
@@ -87,6 +90,13 @@ gates:
       - ".claude/rules/**"
       - ".claude/settings.json"
       - ".github/workflows/pr-inherit-issue-labels.yml"
+      # `ci.yml` became a checker INPUT in #630: markgate-include-globs.test.ts
+      # asserts CI still runs `vp run test:hooks`, which is the backstop this
+      # file's `.claude/hooks/**` block names. Deleting that step reds the unit
+      # suite, so without this entry the marker would stay fresh over it --
+      # the #620 class, freshly reintroduced by the very fence added to close
+      # it. The other two workflows are read by nothing and stay out of scope.
+      - ".github/workflows/ci.yml"
       # The shell half (issue #630). Eight `.claude/hooks/*.test.sh` suites
       # read `.claude/hooks/*.sh`, each resolving its subject self-relatively,
       # and two more live under `tests/integration/_lib/`. Adding the path here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,10 @@ vp run build
 # Unit tests (vitest)
 vp run test
 
-# Full check + tests + build (what CI runs)
+# Hook / integ-lib shell suites (bash) — a separate task from `vp run test`
+vp run test:hooks
+
+# Full check + tests + hook suites + build (what CI's check job runs)
 vp run verify
 ```
 
@@ -99,7 +102,9 @@ docs: lead getting-started with the interactive picker form
 5. Push and open the PR with `gh pr create`. The default template
    asks for a Summary + Test plan; fill both.
 
-CI runs `vp run verify` on Node 20 / 22 / 24. The CHANGELOG and
+CI's `check-build-test` job runs the same four steps `vp run verify`
+chains; a second job then builds and smoke-runs `dist/cli.js` on Node
+20 / 22 / 24. The CHANGELOG and
 GitHub release are produced automatically by semantic-release on
 merge to `main`.
 

--- a/tests/unit/gates/markgate-include-globs.test.ts
+++ b/tests/unit/gates/markgate-include-globs.test.ts
@@ -180,23 +180,26 @@ function rawCounts(yaml: string): { items: number; gates: string[] } {
   };
 }
 
-/** Tracked matches (git's wildmatch) union on-disk matches (doublestar-ish). */
-function matchCount(glob: string): number {
-  let tracked = 0;
+function trackedFiles(glob: string): string[] {
   try {
-    tracked = execFileSync('git', ['ls-files', '-z', '--', `:(glob)${glob}`], {
+    return execFileSync('git', ['ls-files', '-z', '--', `:(glob)${glob}`], {
       cwd: repoRoot,
       encoding: 'utf8',
       maxBuffer: 32 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
     })
       .split('\0')
-      .filter((f) => f.length > 0).length;
+      .filter((f) => f.length > 0);
   } catch {
     // A pathspec git refuses (e.g. a leading `/`) falls through to the on-disk
     // arm rather than escaping as a bare "Command failed: git ls-files".
-    tracked = 0;
+    return [];
   }
+}
+
+/** Tracked matches (git's wildmatch) union on-disk matches (doublestar-ish). */
+function matchCount(glob: string): number {
+  const tracked = trackedFiles(glob).length;
   if (tracked > 0) return tracked;
   try {
     return globSync(glob, { cwd: repoRoot }).length;
@@ -286,6 +289,47 @@ describe('.markgate.yml gate scopes', () => {
     }
   });
 
+  it('every file this fence READS is inside the check gate it guards', () => {
+    // The go-to-k/cdk-local#620 rule, applied to this file: a checker INPUT
+    // outside the include can red the suite while the marker stays fresh.
+    // This fence became such a reader in its own second commit (it asserts
+    // `ci.yml` still runs `test:hooks`), which would have re-introduced the
+    // very class it exists to close -- measured as probe Q17, GREEN before
+    // this case existed.
+    //
+    // The population is DERIVED from this file's own source rather than
+    // hand-listed, so a `readFileSync(join(repoRoot, ...))` added later is
+    // covered with no edit here.
+    const selfSource = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+    const reads = [
+      ...new Set(
+        [...selfSource.matchAll(/join\(\s*repoRoot,([^)]*)\)/g)]
+          .map((m) =>
+            [...(m[1] ?? '').matchAll(/'([^']+)'/g)].map((q) => q[1] ?? '').join('/')
+          )
+          .filter((path) => path.length > 0)
+      ),
+    ].sort();
+    expect(
+      reads.length,
+      'the self-scan found almost no `join(repoRoot, ...)` reads -- it has stopped ' +
+        'matching this file, so it would report full coverage over nothing'
+    ).toBeGreaterThanOrEqual(5);
+
+    const checkGlobs = parsed.entries
+      .filter((e) => e.gate === 'check' && e.key === 'include')
+      .map((e) => e.glob);
+    const uncovered = reads.filter(
+      (path) => !checkGlobs.some((g) => trackedFiles(g).includes(path))
+    );
+    expect(
+      uncovered,
+      `this test reads ${uncovered.join(', ')}, which no \`check\` include entry covers. ` +
+        `Editing one of those reds this suite while a previously-set marker stays FRESH ` +
+        `-- the go-to-k/cdk-local#620 class. Scope it in, or stop reading it.`
+    ).toEqual([]);
+  });
+
   it("the check gate scopes the files that decide what 'green' means", () => {
     // Named rather than derived: these four are in the include for a reason
     // the other entries do not share -- they are not READ by any assertion.
@@ -372,16 +416,22 @@ describe('.markgate.yml gate scopes', () => {
     // `.claude/rules/hooks.md` restates the check gate's scope in prose, and
     // this PR's own subject is a scope enumeration going stale unnoticed.
     // Every include entry must appear in that paragraph.
-    const rules = readFileSync(join(repoRoot, '.claude', 'rules', 'hooks.md'), 'utf8');
-    const block =
-      /- `check` — recorded by `\/check`[\s\S]*?Only invalidated\s*\n?\s*by changes in that scope\./.exec(
-        rules
-      );
+    // Whitespace-NORMALISED before matching. The paragraph is hard-wrapped
+    // prose, so a line-sensitive regex breaks whenever an edit moves the wrap
+    // column -- which it did, the first time this paragraph was edited after
+    // the assertion was written.
+    const rules = readFileSync(join(repoRoot, '.claude', 'rules', 'hooks.md'), 'utf8').replace(
+      /\s+/g,
+      ' '
+    );
+    const block = /- `check` — recorded by `\/check`.*?Only invalidated by changes in that scope\./.exec(
+      rules
+    );
     expect(
       block,
       'the check-gate scope paragraph in .claude/rules/hooks.md moved or was renamed'
     ).not.toBeNull();
-    const prose = (block?.[0] ?? '').replace(/\s+/g, ' ');
+    const prose = block?.[0] ?? '';
     const missing = parsed.entries
       .filter((e) => e.gate === 'check' && e.key === 'include')
       .map((e) => e.glob)

--- a/tests/unit/gates/markgate-include-globs.test.ts
+++ b/tests/unit/gates/markgate-include-globs.test.ts
@@ -52,6 +52,18 @@ import { fileURLToPath } from 'node:url';
  * own defect class. Anything subtler belongs to `markgate config lint`, and
  * this file says so instead of pretending otherwise.
  *
+ * ## Why a hand-rolled parser at all
+ *
+ * Because this repo has no YAML parser to reach for: `package.json` declares
+ * none, and neither does the dev-dependency set (the sibling repos cdkd and
+ * cdk-real-drift both DO have one, which is why their equivalents parse rather
+ * than refuse). Adding a dependency to a lockfile so a single fence can read a
+ * single config is a worse trade than refusing the shapes it cannot model —
+ * and refusal turns out to be the STRICTER option, not the weaker one: a
+ * parser accepts a novel spelling and quietly gets it wrong, while this one
+ * stops. Read the refusals below as the point of the design, not as its
+ * limitation.
+ *
  * ## The parser refuses what it cannot model
  *
  * A hand-rolled YAML reader's failure mode is silent truncation: an entry in a
@@ -93,6 +105,10 @@ interface ParsedConfig {
   entries: Entry[];
   /** Every gate key seen under `gates:`, whether or not it declares a scope. */
   gates: string[];
+  /** `hash:` value per gate, when one is declared. */
+  hashOf: Map<string, string>;
+  /** `base:` value per gate, when one is declared. */
+  baseOf: Map<string, string>;
   /** 1-based line numbers of every `- ` item line the parser consumed. */
   consumed: Set<number>;
   /** Gates that DECLARED an `include:` key, whether or not items followed. */
@@ -124,6 +140,8 @@ function parseConfig(yaml: string): ParsedConfig {
   const gates: string[] = [];
   const consumed = new Set<number>();
   const declaredInclude: string[] = [];
+  const hashOf = new Map<string, string>();
+  const baseOf = new Map<string, string>();
   let inGates = false;
   let gate: string | null = null;
   let key: string | null = null;
@@ -153,17 +171,27 @@ function parseConfig(yaml: string): ParsedConfig {
     const keyLine = /^ {4}([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
     if (keyLine) {
       const name = keyLine[1] ?? '';
-      // markgate's OWN key set, not the keys this repo happens to use. An
-      // unknown key used to be consumed and DISCARDED, so a typo'd `includes:`
-      // took five globs out of the sweep while every assertion stayed green --
-      // and a future markgate key that subtracts from the scope, as `exclude`
-      // does, would arrive the same silent way. Refuse instead.
+      // The keys this fence has VERIFIED do not change the resolved scope --
+      // deliberately NOT "markgate's key set", which an earlier version of
+      // this comment claimed and which was false. markgate 0.4.1 also accepts
+      // `composes` and `state_dir` (both silent under `config lint`, both
+      // measured here as leaving `verify check --explain` at 983 files), and
+      // they are refused anyway: this fence models scope, and a key whose
+      // scope effect has only been spot-checked is not a key it can model.
+      // Unknown keys used to be consumed and DISCARDED, so a typo'd
+      // `includes:` took five globs out of the sweep with every assertion
+      // green -- and a future key that SUBTRACTS from the scope, as `exclude`
+      // does, would arrive the same silent way.
       if (!/^(hash|base|ttl|include|exclude|requires)$/.test(name)) {
+        const known = /^(composes|state_dir)$/.test(name)
+          ? `\`${name}\` IS a real markgate 0.4.1 key, and is refused here rather than ` +
+            `ignored: this fence reports scope coverage, so it must not run over a key ` +
+            `whose effect on scope it has not established. Establish it (one variable, ` +
+            `against the pinned binary), then add it beside \`requires\`.`
+          : `An unmodelled key may add to or SUBTRACT from the resolved scope, which ` +
+            `would make every check below report coverage it does not have.`;
         throw new Error(
-          `${at}: unknown gate key \`${name}\` in gate '${gate}'.\n` +
-            `This fence models markgate's key set; an unmodelled key may add to or ` +
-            `SUBTRACT from the resolved scope, which would make every check below ` +
-            `report coverage it does not have. Teach the parser what it means.`
+          `${at}: gate key \`${name}\` in gate '${gate}' is not modelled.\n${known}`
         );
       }
       const rest = (keyLine[2] ?? '').trim();
@@ -178,6 +206,13 @@ function parseConfig(yaml: string): ParsedConfig {
         );
       }
       if (name === 'include' && gate !== null) declaredInclude.push(gate);
+      // The VALUES of `hash` and `base`, not just their presence. `hash` is
+      // the one knob that silently makes an include list inert; see the case
+      // below for the measurement.
+      if (gate !== null && hasInlineValue && (name === 'hash' || name === 'base')) {
+        const value = rest.replace(/\s*#.*$/, '').trim();
+        (name === 'hash' ? hashOf : baseOf).set(gate, value);
+      }
       // A key with an inline value takes no items; one without may.
       key = hasInlineValue ? null : name;
       continue;
@@ -207,7 +242,7 @@ function parseConfig(yaml: string): ParsedConfig {
         `Nested mappings and other shapes are not modelled. Extend the parser.`
     );
   }
-  return { entries, gates, consumed, declaredInclude };
+  return { entries, gates, consumed, declaredInclude, hashOf, baseOf };
 }
 
 /**
@@ -298,6 +333,21 @@ function isBareDirectory(glob: string): boolean {
  */
 const ZERO_MATCH_ALLOWED = ['.markgate-pr-review-sha'];
 
+/**
+ * Files this fence reads through a spelling the `readFileSync` scan below
+ * cannot see. `git check-ignore` consults `.gitignore`, so `.gitignore` is a
+ * checker INPUT of this suite exactly as `ci.yml` is -- deleting its
+ * `.markgate-pr-review-sha` line reds this file, and without the include entry
+ * the `check` marker would stay FRESH over it. That is the go-to-k/cdk-local#620
+ * class for the THIRD time in this PR, and the first two were also introduced
+ * by the fence written to close it.
+ *
+ * Hand-listed because a regex cannot follow an argument into a subprocess. The
+ * `execFileSync` budget in the same case is what stops the list going stale:
+ * adding a new subprocess read fails until it is declared here.
+ */
+const EXTRA_READS = ['.gitignore'];
+
 describe('.markgate.yml gate scopes', () => {
   const yaml = readFileSync(join(repoRoot, '.markgate.yml'), 'utf8');
   const parsed = parseConfig(yaml);
@@ -338,6 +388,58 @@ describe('.markgate.yml gate scopes', () => {
       parsed.declaredInclude.length,
       'no gate declares an include at all -- the parse found nothing to check'
     ).toBeGreaterThan(0);
+  });
+
+  it('no gate\'s `hash` value makes its include list inert', () => {
+    // `exclude` one key over, and measured against the pinned markgate 0.4.1
+    // on this tree. The include list only means something under a hasher that
+    // READS it:
+    //
+    //   hash: files      -> `verify check --explain` resolves 983 files
+    //   hash: git-tree   ->                          resolves 1, and
+    //                       `markgate config lint` is SILENT (rc=0)
+    //   hash: diff       -> lint WARNS and verify fails to parse (no `base`)
+    //   worktree/content -> lint WARNS, verify fails to parse
+    //
+    // So exactly one value collapses the scope quietly, and every assertion in
+    // this file passes underneath it: the entries still parse, still match
+    // files, and still name the right paths -- they are simply no longer what
+    // the marker digests. Only the VALUE check below can see it.
+    const usesInclude = /^(files|diff)$/;
+    const inert = parsed.declaredInclude
+      .filter((g) => !usesInclude.test(parsed.hashOf.get(g) ?? 'files'))
+      .map((g) => `gate '${g}' has hash: ${parsed.hashOf.get(g)}`);
+    expect(
+      inert,
+      `these gates declare an \`include:\` under a hasher that ignores it, so the list ` +
+        `scopes NOTHING while everything else here still passes:\n${inert.join('\n')}`
+    ).toEqual([]);
+
+    // `check` and `docs` are pinned to `files` specifically. `.markgate.yml`
+    // records the reason -- they are cheap to re-run, so they stay strict --
+    // and `diff` would quietly weaken them to a merge-base delta.
+    for (const gate of ['check', 'docs']) {
+      expect(
+        parsed.hashOf.get(gate),
+        `gate '${gate}' is meant to be strict \`hash: files\`; \`diff\` would weaken it ` +
+          `to a merge-base delta and \`git-tree\` would ignore its include entirely`
+      ).toBe('files');
+    }
+
+    // `base` is meaningful only under `hash: diff`. markgate's own linter
+    // already refuses the combination loudly (measured: `base is only valid
+    // with hash=diff`, and `verify` then fails to parse), so this is a
+    // fail-fast echo rather than the only guard -- but a config that cannot
+    // parse takes EVERY gate down, so it is worth catching in the suite.
+    for (const gate of parsed.gates) {
+      const hasBase = parsed.baseOf.has(gate);
+      const isDiff = parsed.hashOf.get(gate) === 'diff';
+      expect(
+        hasBase,
+        `gate '${gate}': \`base\` is valid only with \`hash: diff\` (has hash: ` +
+          `${parsed.hashOf.get(gate) ?? '<none>'}, base: ${parsed.baseOf.get(gate) ?? '<none>'})`
+      ).toBe(isDiff);
+    }
   });
 
   it('no gate declares an `exclude:` this sweep would not subtract', () => {
@@ -452,9 +554,20 @@ describe('.markgate.yml gate scopes', () => {
         `into a comment or a message here, because this scan reads its own source.`
     ).toBe(reads.length + 1);
 
+    // The `execFileSync` spelling has its own budget: the scan cannot follow a
+    // path into a subprocess, so the only defence is to notice a new one. Three
+    // occurrences today -- `git ls-files`, `git check-ignore`, and one mention
+    // inside a comment.
+    expect(
+      (selfSource.match(/execFileSync\(/g) ?? []).length,
+      'this file gained or lost an `execFileSync` site. A subprocess read is invisible ' +
+        'to the scan above, so any file it consults must be listed in EXTRA_READS and ' +
+        'scoped into the check gate -- then update this count.'
+    ).toBe(3);
+
     const covered = (path: string): boolean =>
       checkGlobs.some((g) => trackedFiles(g).includes(path));
-    const uncovered = reads.filter((path) => !covered(path));
+    const uncovered = [...reads, ...EXTRA_READS].filter((path) => !covered(path));
     expect(
       uncovered,
       `this test reads ${uncovered.join(', ')}, which no \`check\` include entry covers. ` +
@@ -525,7 +638,12 @@ describe('.markgate.yml gate scopes', () => {
       config,
       '`vp run verify` no longer chains test:hooks, so the alias reports a green the ' +
         'check gate does not mean'
-    ).toMatch(/verify:\s*\{[^}]*vp run test:hooks/);
+      // Anchored to the `command:` STRING, not to anywhere in the block. The
+      // block carries a comment inside the same `[^}]*` window, so a reword
+      // that happens to quote the command would keep this green with the
+      // command DELETED -- the confluence-point trap this file has now hit
+      // three times.
+    ).toMatch(/verify:\s*\{[^}]*command:\s*'[^']*vp run test:hooks/);
     expect(
       config,
       'the `verify` task is cacheable again, so `vp run verify` can replay a green ' +

--- a/tests/unit/gates/markgate-include-globs.test.ts
+++ b/tests/unit/gates/markgate-include-globs.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { execFileSync } from 'node:child_process';
-import { globSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { globSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
@@ -11,60 +11,76 @@ import { fileURLToPath } from 'node:url';
  * entry there fails SILENTLY in the direction that matters: a glob matching
  * nothing looks exactly like one doing its job.
  *
- * MEASURED on the tree this test was added to. The `check` gate's include
+ * MEASURED on the tree this was written for. The `check` gate's include
  * carried `vitest.config.ts`, `.eslintrc*` and `.prettierrc*`, none of which
  * this repo has ever had, while the real `vite.config.ts` -- the file holding
  * the vitest `include` globs and every `vp run <task>` definition, i.e. the
- * file that decides what "green" MEANS -- was absent. Against markgate's OWN
- * resolution rather than an `ls`, `markgate verify check --explain` on the
- * pre-fix config resolved 949 files with zero of `vite.config.ts` /
- * `.mise.toml` / `.node-version` / `.claude/hooks/**` among them; on the fixed
- * config it resolves 981 with all of them present.
+ * file that decides what "green" MEANS -- was absent. markgate's own linter
+ * named all three on the pre-fix config:
  *
- * ## Why this is re-implemented here rather than delegated to markgate
+ *   gates.check.include[11]: 'vitest.config.ts' matches 0 files
+ *   gates.check.include[12]: '.eslintrc*' matches 0 files
+ *   gates.check.include[13]: '.prettierrc*' matches 0 files
  *
- * markgate 0.4.1 ships `markgate config lint --json`, which reports exactly
- * this class -- run against the pre-fix config it named all three dead entries
- * by index (`gates.check.include[11]: 'vitest.config.ts' matches 0 files`).
- * It is the better instrument and the PR body cites it. It cannot be the fence
- * that RUNS, because `.github/workflows/ci.yml` installs `vp` only: there is
- * no mise and no markgate binary in CI, so a test shelling out to it would
- * fail there. So the check is duplicated in TypeScript, and the duplication is
- * declared rather than hidden.
+ * and `markgate verify check --explain` resolved zero of `vite.config.ts` /
+ * `.mise.toml` / `.node-version` and zero `.claude/hooks/*` files into the
+ * scope, against 30 hook files after the fix. (The scope's absolute SIZE is
+ * deliberately not quoted anywhere here: `hash: files` digests untracked files
+ * too, so the total moves with `dist/`, `node_modules/` and any scratch file
+ * in the tree -- two reviewers measuring the same commit got different totals.
+ * The counts above are the stable, reproducible half.)
  *
- * ## The parser refuses what it cannot model, and that is the whole design
+ * ## What this fence claims, and what it does NOT
  *
- * A hand-rolled YAML reader's failure mode is silent truncation: an entry
- * spelled in a shape the regex misses ends the list, taking every later entry
- * in that gate with it, and the sweep then reports "no dead globs" over a
- * population it never saw. Three defences, in order of importance:
+ * markgate 0.4.1 ships `markgate config lint --json`, which decides this
+ * question EXACTLY -- it parses with yaml.v3 and matches with the same
+ * doublestar walk `hash: files` uses. It is the right instrument and the PR
+ * body cites its output. It cannot be the fence that RUNS, because
+ * `.github/workflows/ci.yml` installs `vp` only: no mise, no markgate binary,
+ * so a test shelling out to it would fail in CI. What runs here is therefore a
+ * DELIBERATELY WEAKER approximation, and the weakness has a direction:
  *
- *   1. every `      - ` line inside a scope list MUST parse, or the parser
- *      THROWS -- an unmodelled spelling is loud, never a quiet skip;
- *   2. the entry count is reconciled against an independent scan of those
- *      lines, and the gate-name set likewise, so a whole gate cannot vanish;
- *   3. `exclude:` is parsed and REFUSED. markgate honours it and subtracts it
- *      from the scope -- measured here with one variable changed: adding
- *      `exclude: ["vite.config.ts"]` while leaving the include untouched took
- *      `markgate verify check --explain` from 981 resolved files to 980 and
- *      removed `vite.config.ts` from the listing, while
- *      `markgate config lint --json` reported nothing about it. A fence
- *      modelling only `include` would keep reporting full coverage while an
- *      `exclude` silently subtracted. No gate uses one today; if one ever
- *      should, teach the sweep to subtract it BEFORE deleting that assertion.
+ *   it may call a dead entry LIVE (over-approximation), and must never call a
+ *   live entry DEAD.
  *
- * Matching is the union of `git ls-files -- ':(glob)<entry>'` and
- * `fs.globSync`, and an entry counts as dead only when BOTH are empty. Neither
- * alone is right: git sees only the index, so an entry like `dist/**` (16 real
- * files here, none tracked) is live for markgate's `hash: files` and would
- * read as dead; and git's wildmatch does not do brace alternation, which
- * markgate's doublestar does. The union errs toward NOT reporting a dead glob,
- * which is the right direction for a fence whose false positive would block a
- * legitimate config.
+ * That is the safe direction for a fence whose false positive would block a
+ * legitimate config. Two known over-approximations, both from git's pathspec
+ * and Node's glob being more permissive than doublestar-over-files: a bare
+ * directory name (`.claude/agents` rather than `.claude/agents/**`) and a glob
+ * matching only directories. Both are checked EXPLICITLY below rather than
+ * left to the general sweep, because writing `src` for `src/**` is this PR's
+ * own defect class. Anything subtler belongs to `markgate config lint`, and
+ * this file says so instead of pretending otherwise.
+ *
+ * ## The parser refuses what it cannot model
+ *
+ * A hand-rolled YAML reader's failure mode is silent truncation: an entry in a
+ * shape the regex misses ends the list, taking every later entry in that gate
+ * with it, and the sweep then reports "no dead globs" over a population it
+ * never saw. An earlier draft of this file had exactly that bug twice -- first
+ * for single-quoted and bare scalars, then for a block sequence indented at
+ * the parent key's own column, which is valid YAML that markgate accepts and
+ * which a reviewer used to hide three dead globs from a 9/9 green run.
+ *
+ * The remedy is not a better regex. It is a COMPLETENESS check: the parser
+ * records which lines it consumed, and a separate pass fails if any `- ` line
+ * anywhere under `gates:` was not consumed. Item indentation is learned rather
+ * than assumed, non-scope keys (`requires:`) have their items consumed and
+ * discarded, and anything still unrecognised THROWS. A shape this file cannot
+ * model becomes a loud failure, never a quiet omission.
+ *
+ * `exclude:` is parsed and REFUSED. markgate honours it and subtracts it from
+ * the scope -- measured with one variable changed, adding
+ * `exclude: ["vite.config.ts"]` while leaving the include untouched removed
+ * `vite.config.ts` from `markgate verify check --explain` and dropped the
+ * resolved total by exactly one, while `markgate config lint --json` reported
+ * nothing about it. A fence modelling only `include` would keep reporting full
+ * coverage while an `exclude` silently subtracted. No gate uses one today; if
+ * one ever should, teach the sweep to subtract it BEFORE deleting that
+ * assertion. (Cross-lane finding, go-to-k/cdk-real-drift#1838.)
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
-const CONFIG = join(repoRoot, '.markgate.yml');
 
 interface Entry {
   gate: string;
@@ -77,37 +93,51 @@ interface ParsedConfig {
   entries: Entry[];
   /** Every gate key seen under `gates:`, whether or not it declares a scope. */
   gates: string[];
+  /** 1-based line numbers of every `- ` item line the parser consumed. */
+  consumed: Set<number>;
+}
+
+/** Scalar forms a list item may take. Anything else throws. */
+function scalar(raw: string, at: string, gate: string | null, key: string): string {
+  const m = /^(?:"([^"]*)"|'([^']*)'|([^\s#[\]{}&*!|>%@`'"][^#]*?))\s*(?:#.*)?$/.exec(raw);
+  if (!m) {
+    throw new Error(
+      `${at}: could not parse this list item inside gate '${gate}'.${key}:\n  ${raw}\n` +
+        `Unparsed items used to END the list silently, dropping this entry AND every ` +
+        `later one in the gate. Extend this parser instead of loosening the check that ` +
+        `caught you.`
+    );
+  }
+  return (m[1] ?? m[2] ?? (m[3] ?? '').trim()).trim();
 }
 
 /**
- * Reader for the block shape `.markgate.yml` uses: two-space-indented gate
- * keys under a top-level `gates:`, each optionally carrying a
- * four-space-indented `include:` / `exclude:` whose items are
- * six-space-indented scalars. Double-quoted, single-quoted and bare scalars
- * are all accepted; anything else THROWS rather than ending the list.
+ * Reader for `.markgate.yml`'s block shape. Gate keys sit at two spaces under
+ * a top-level `gates:`; a gate's keys at four. List items may be indented at
+ * any column at or beyond their key's -- learned, not assumed, because the
+ * assumption is what failed before.
  */
 function parseConfig(yaml: string): ParsedConfig {
   const entries: Entry[] = [];
   const gates: string[] = [];
+  const consumed = new Set<number>();
   let inGates = false;
   let gate: string | null = null;
-  let key: 'include' | 'exclude' | null = null;
+  let key: string | null = null;
   const lines = yaml.split(/\r?\n/);
   for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i] ?? '';
+    const line = (lines[i] ?? '').replace(/﻿/g, '').replace(/\t/g, '  ');
     const at = `.markgate.yml:${i + 1}`;
     if (/^gates:\s*$/.test(line)) {
       inGates = true;
       continue;
     }
     if (!inGates) continue;
+    if (/^\s*(#.*)?$/.test(line)) continue; // blank or comment, at any indent
     if (/^\S/.test(line)) {
-      // A non-indented, non-blank, non-comment line ends the `gates:` block.
-      if (!/^\s*(#.*)?$/.test(line)) {
-        inGates = false;
-        gate = null;
-        key = null;
-      }
+      inGates = false; // a new top-level key ends the gates block
+      gate = null;
+      key = null;
       continue;
     }
     const gateHeader = /^ {2}([A-Za-z0-9_-]+):\s*(#.*)?$/.exec(line);
@@ -117,72 +147,83 @@ function parseConfig(yaml: string): ParsedConfig {
       key = null;
       continue;
     }
-    const scopeKey = /^ {4}(include|exclude):\s*(.*)$/.exec(line);
-    if (scopeKey) {
-      const rest = (scopeKey[2] ?? '').trim();
-      if (rest !== '' && !rest.startsWith('#')) {
+    const keyLine = /^ {4}([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
+    if (keyLine) {
+      const name = keyLine[1] ?? '';
+      const rest = (keyLine[2] ?? '').trim();
+      const hasInlineValue = rest !== '' && !rest.startsWith('#');
+      if ((name === 'include' || name === 'exclude') && hasInlineValue) {
         // A flow sequence (`include: ["a","b"]`) or an anchor / alias.
-        // Refusing is the point: silently skipping would drop the whole gate.
+        // Refusing is the point: skipping it would drop the whole gate.
         throw new Error(
-          `${at}: unsupported inline value for \`${scopeKey[1]}\` in gate '${gate}': ${rest}\n` +
+          `${at}: unsupported inline value for \`${name}\` in gate '${gate}': ${rest}\n` +
             `This parser models the block-sequence form only. Rewrite it as a block list, ` +
-            `or teach parseConfig the new shape -- do NOT let it be skipped.`
+            `or teach the parser the new shape -- do NOT let it be skipped.`
         );
       }
-      key = scopeKey[1] === 'exclude' ? 'exclude' : 'include';
+      // A key with an inline value takes no items; one without may.
+      key = hasInlineValue ? null : name;
       continue;
     }
-    if (key === null || gate === null) continue;
-    if (/^\s*(#.*)?$/.test(line)) continue; // blank line or comment inside the list
-    if (/^ {4}\S/.test(line)) {
-      key = null; // a sibling key at the gate's own indent ends the list
+    const itemLine = /^(\s+)- (.*)$/.exec(line);
+    if (itemLine) {
+      if (gate === null || key === null) {
+        throw new Error(
+          `${at}: a list item with no scope key above it:\n  ${line}\n` +
+            `The parser cannot tell which key owns it, so it refuses rather than guessing.`
+        );
+      }
+      consumed.add(i + 1);
+      if (key !== 'include' && key !== 'exclude') continue; // e.g. `requires:`
+      entries.push({
+        gate,
+        key,
+        // `.replace(/^\s+/, '')` because `-  "x"` (two spaces) is legal
+        // YAML that markgate accepts; the item regex captures the extra space.
+        glob: scalar((itemLine[2] ?? '').replace(/^\s+/, ''), at, gate, key),
+        line: i + 1,
+      });
       continue;
     }
-    // The bare-scalar arm excludes YAML indicator characters in FIRST
-    // position -- `[`/`{` open a flow collection, `&`/`*`/`!` an anchor,
-    // alias or tag -- so `- [a, b]` throws instead of being read as the
-    // literal glob "[a, b]". Later positions are unrestricted, because a
-    // real glob may legitimately contain braces (`tsconfig{,.test}.json`).
-    // A glob that genuinely starts with `*` must be quoted, which YAML
-    // requires anyway.
-    const item =
-      /^ {6}- (?:"([^"]*)"|'([^']*)'|([^\s#[\]{}&*!|>%@`'"][^#]*?))\s*(?:#.*)?$/.exec(line);
-    if (!item) {
-      throw new Error(
-        `${at}: could not parse this line inside gate '${gate}'.${key}:\n  ${line}\n` +
-          `An unparsed line used to END the list silently, dropping this entry AND every ` +
-          `later entry in the gate -- the sweep then reports "no dead globs" over a ` +
-          `population it never saw. Extend parseConfig instead of loosening this.`
-      );
-    }
-    entries.push({ gate, key, glob: item[1] ?? item[2] ?? (item[3] ?? '').trim(), line: i + 1 });
+    throw new Error(
+      `${at}: unrecognised line inside gate '${gate}':\n  ${line}\n` +
+        `Nested mappings and other shapes are not modelled. Extend the parser.`
+    );
   }
-  return { entries, gates };
+  return { entries, gates, consumed };
 }
 
 /**
- * Independent counts, used to reconcile the parse. Deliberately NOT derived
- * from `parseConfig` -- a floor computed by the thing it is checking cannot
- * notice that thing losing entries.
+ * Independent scan, sharing NO assumption with `parseConfig`. The previous
+ * version counted `^ {6}- ` lines -- the very indentation assumption that
+ * failed -- so it agreed with the parser precisely when both were wrong.
  */
-function rawCounts(yaml: string): { items: number; gates: string[] } {
+function rawScan(yaml: string): { itemLines: number[]; gates: string[] } {
   const lines = yaml.split(/\r?\n/);
   const start = lines.findIndex((l) => /^gates:\s*$/.test(l));
-  const body = start === -1 ? [] : lines.slice(start + 1);
-  const end = body.findIndex((l) => /^\S/.test(l) && !/^\s*#/.test(l));
-  const scoped = end === -1 ? body : body.slice(0, end);
-  return {
-    items: scoped.filter((l) => /^ {6}- /.test(l)).length,
-    gates: scoped.flatMap((l) => {
-      const m = /^ {2}([A-Za-z0-9_-]+):/.exec(l);
-      return m?.[1] !== undefined ? [m[1]] : [];
-    }),
-  };
+  const itemLines: number[] = [];
+  const gates: string[] = [];
+  if (start === -1) return { itemLines, gates };
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    if (/^\S/.test(line)) break;
+    if (/^\s+-\s/.test(line)) itemLines.push(i + 1);
+    const m = /^ {2}([A-Za-z0-9_-]+):/.exec(line);
+    if (m?.[1] !== undefined) gates.push(m[1]);
+  }
+  return { itemLines, gates };
 }
 
+const trackedCache = new Map<string, string[]>();
+
+/** Tracked FILES matching a git `:(glob)` pathspec. */
 function trackedFiles(glob: string): string[] {
+  const hit = trackedCache.get(glob);
+  if (hit !== undefined) return hit;
+  let out: string[] = [];
   try {
-    return execFileSync('git', ['ls-files', '-z', '--', `:(glob)${glob}`], {
+    out = execFileSync('git', ['ls-files', '-z', '--', `:(glob)${glob}`], {
       cwd: repoRoot,
       encoding: 'utf8',
       maxBuffer: 32 * 1024 * 1024,
@@ -191,73 +232,94 @@ function trackedFiles(glob: string): string[] {
       .split('\0')
       .filter((f) => f.length > 0);
   } catch {
-    // A pathspec git refuses (e.g. a leading `/`) falls through to the on-disk
+    // A pathspec git refuses (a leading `/`, say) falls through to the on-disk
     // arm rather than escaping as a bare "Command failed: git ls-files".
+    out = [];
+  }
+  trackedCache.set(glob, out);
+  return out;
+}
+
+/**
+ * On-disk FILES matching the glob, confined to the repo. `hash: files` digests
+ * untracked and gitignored files too, so the tracked set alone would call
+ * `dist/**` dead; and without the file/containment filters an entry like
+ * `../**` or a directory-only glob reads as live when markgate says otherwise.
+ */
+function onDiskFiles(glob: string): string[] {
+  try {
+    return globSync(glob, { cwd: repoRoot, withFileTypes: true })
+      .filter((d) => d.isFile())
+      .map((d) => resolve(d.parentPath, d.name))
+      .filter((p) => p.startsWith(repoRoot + sep))
+      .map((p) => relative(repoRoot, p));
+  } catch {
     return [];
   }
 }
 
-/** Tracked matches (git's wildmatch) union on-disk matches (doublestar-ish). */
 function matchCount(glob: string): number {
   const tracked = trackedFiles(glob).length;
-  if (tracked > 0) return tracked;
+  return tracked > 0 ? tracked : onDiskFiles(glob).length;
+}
+
+/** A wildcard-free entry naming a DIRECTORY matches no FILE for markgate. */
+function isBareDirectory(glob: string): boolean {
+  if (/[*?[\]{}]/.test(glob)) return false;
   try {
-    return globSync(glob, { cwd: repoRoot }).length;
+    return statSync(join(repoRoot, glob)).isDirectory();
   } catch {
-    return 0;
+    return false;
   }
 }
 
 /**
  * The single documented zero-match entry: a gitignored sentinel `/review-pr`
- * rewrites, which does not exist at all in a fresh worktree. Spelled as an
- * explicit one-element allow-list rather than a `git check-ignore` rule --
- * that rule exempted every ignored path, so a typo'd `dist/index.js` would
- * have been waved through as well.
+ * rewrites, absent entirely in a fresh worktree. An explicit one-element
+ * allow-list rather than a `git check-ignore` rule -- that rule exempted every
+ * ignored path, so a typo'd `dist/index.js` would have been waved through too.
  */
 const ZERO_MATCH_ALLOWED = ['.markgate-pr-review-sha'];
 
 describe('.markgate.yml gate scopes', () => {
-  const yaml = readFileSync(CONFIG, 'utf8');
+  const yaml = readFileSync(join(repoRoot, '.markgate.yml'), 'utf8');
   const parsed = parseConfig(yaml);
-  const raw = rawCounts(yaml);
+  const raw = rawScan(yaml);
+  const includes = parsed.entries.filter((e) => e.key === 'include');
+  const checkGlobs = includes.filter((e) => e.gate === 'check').map((e) => e.glob);
 
-  it('the parse loses nothing (reconciled against an independent count)', () => {
-    // Asserted as an EQUALITY against a separate scan rather than as a `>=`
-    // floor: a floor with slack is exactly what let an earlier draft of this
-    // file drop 11 of 26 entries and still pass.
+  it('the parse consumed every list item in the file', () => {
+    // COMPLETENESS, not a count. A `>=` floor let an earlier draft drop 11 of
+    // 26 entries; a count against a scan sharing the parser's indentation
+    // assumption then let a whole gate vanish at a different indent. This
+    // compares line NUMBERS: every `- ` line under `gates:` must have been
+    // consumed by name, so an entry cannot be missed without failing here.
+    const missed = raw.itemLines.filter((n) => !parsed.consumed.has(n));
     expect(
-      parsed.entries.length,
-      `parseConfig produced ${parsed.entries.length} entries but .markgate.yml has ` +
-        `${raw.items} \`      - \` lines under \`gates:\`. The parse is losing entries, ` +
-        `and every lost entry is one this sweep never checks.`
-    ).toBe(raw.items);
+      missed.map((n) => `.markgate.yml:${n}`),
+      `these list items were never consumed by the parser, so nothing below checks ` +
+        `them:\n${missed.join(', ')}`
+    ).toEqual([]);
     expect(parsed.gates, 'a gate key was missed by the parse').toEqual(raw.gates);
     expect(parsed.gates, 'the check gate vanished from the parse').toContain('check');
-    expect(raw.items, 'the config has almost no scope entries -- did the scan find it?')
-      .toBeGreaterThanOrEqual(15);
+    expect(
+      raw.itemLines.length,
+      'the config has almost no scope entries -- did the scan find it at all?'
+    ).toBeGreaterThanOrEqual(15);
   });
 
   it('no gate declares an `exclude:` this sweep would not subtract', () => {
-    // markgate honours `exclude` and subtracts it from the resolved scope.
-    // MEASURED with one variable changed (include untouched): adding
-    // `exclude: ["vite.config.ts"]` to the check gate took
-    // `markgate verify check --explain` from 981 resolved files to 980 and
-    // removed `vite.config.ts` from the listing, while
-    // `markgate config lint --json` reported nothing about it. The sweep below
-    // models `include` only, so it would keep reporting full coverage while an
-    // `exclude` silently subtracted. Refuse the shape rather than mis-model it.
     const excludes = parsed.entries.filter((e) => e.key === 'exclude');
     expect(
       excludes.map((e) => `.markgate.yml:${e.line} gate '${e.gate}' excludes "${e.glob}"`),
-      'a gate grew an `exclude:`. Teach the dead-glob sweep below to subtract it from ' +
-        'the include set FIRST, then remove this assertion -- do not just delete it.'
+      'a gate grew an `exclude:`. markgate SUBTRACTS it from the resolved scope, so the ' +
+        'sweep below would keep reporting full coverage over a smaller reality. Teach the ' +
+        'sweep to subtract it FIRST, then remove this assertion -- do not just delete it.'
     ).toEqual([]);
   });
 
   it('every include entry matches at least one file', () => {
-    const dead = parsed.entries
-      .filter((e) => e.key === 'include')
+    const dead = includes
       .filter((e) => !ZERO_MATCH_ALLOWED.includes(e.glob))
       .filter((e) => matchCount(e.glob) === 0)
       .map((e) => `.markgate.yml:${e.line} gate '${e.gate}' includes "${e.glob}"`);
@@ -265,24 +327,45 @@ describe('.markgate.yml gate scopes', () => {
       dead,
       `these include entries match no file, so they scope nothing:\n${dead.join('\n')}\n` +
         `A glob matching nothing is indistinguishable from one doing its job. Remove it, ` +
-        `or correct it to the file it was meant to name. (markgate's own ` +
-        `\`markgate config lint --json\` reports the same class, but CI has no markgate.)`
+        `or correct it to the file it was meant to name.`
+    ).toEqual([]);
+  });
+
+  it('no include entry is a bare directory name', () => {
+    // The over-approximation this fence covers explicitly, because it IS this
+    // PR's defect class one step over: `.claude/agents` instead of
+    // `.claude/agents/**` scopes NOTHING for markgate (`hash: files` keeps
+    // files, and doublestar matches only the directory entry), while git's
+    // pathspec happily reports every file beneath it and `globSync` returns
+    // the directory. Both of this file's arms would call it live.
+    const bare = includes
+      .filter((e) => isBareDirectory(e.glob))
+      .map((e) => `.markgate.yml:${e.line} gate '${e.gate}' includes "${e.glob}"`);
+    expect(
+      bare,
+      `these entries name a DIRECTORY, which matches no file for markgate:\n${bare.join('\n')}\n` +
+        `Write "<dir>/**".`
     ).toEqual([]);
   });
 
   it('the allow-listed zero-match entry really is a gitignored sentinel', () => {
-    // Guard the exemption: it must stay a deliberate sentinel, not a place to
-    // park a broken glob. Both properties are required -- still referenced by
-    // a gate, and still ignored by git.
     for (const glob of ZERO_MATCH_ALLOWED) {
       expect(
         parsed.entries.some((e) => e.glob === glob),
         `${glob} is allow-listed here but no gate references it any more -- drop the entry`
       ).toBe(true);
-      const ignored = execFileSync('git', ['check-ignore', '-v', '--', glob], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-      });
+      let ignored = '';
+      try {
+        // Exits 1 when the path is NOT ignored, which `execFileSync` throws on
+        // -- the crafted message below never printed until this catch existed.
+        ignored = execFileSync('git', ['check-ignore', '-v', '--', glob], {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch {
+        ignored = '';
+      }
       expect(ignored, `${glob} is no longer gitignored, so it should not be exempt`).toContain(
         glob
       );
@@ -290,44 +373,54 @@ describe('.markgate.yml gate scopes', () => {
   });
 
   it('every file this fence READS is inside the check gate it guards', () => {
-    // The go-to-k/cdk-local#620 rule, applied to this file: a checker INPUT
+    // The go-to-k/cdk-local#620 rule applied to this file: a checker INPUT
     // outside the include can red the suite while the marker stays fresh.
     // This fence became such a reader in its own second commit (it asserts
-    // `ci.yml` still runs `test:hooks`), which would have re-introduced the
-    // very class it exists to close -- measured as probe Q17, GREEN before
-    // this case existed.
+    // `ci.yml` still runs `test:hooks`), which re-introduced the very class it
+    // exists to close.
     //
-    // The population is DERIVED from this file's own source rather than
-    // hand-listed, so a `readFileSync(join(repoRoot, ...))` added later is
-    // covered with no edit here.
+    // The population is derived from this file's own source. A regex can only
+    // see the spelling it models, so the file also FORBIDS every other read
+    // spelling: the total number of read calls must equal the derived reads
+    // plus the one self-read below. Adding a read via `resolve()`, a template
+    // literal or a joined array fails here instead of slipping past.
+    //
+    // Careful when editing the text in this case: the scan reads its own
+    // source, so writing the scanned spelling into a comment or a message
+    // counts as a read and makes the equality fail on prose. It did, twice.
     const selfSource = readFileSync(fileURLToPath(import.meta.url), 'utf8');
     const reads = [
       ...new Set(
-        [...selfSource.matchAll(/join\(\s*repoRoot,([^)]*)\)/g)]
-          .map((m) =>
-            [...(m[1] ?? '').matchAll(/'([^']+)'/g)].map((q) => q[1] ?? '').join('/')
-          )
+        [...selfSource.matchAll(/readFileSync\(\s*join\(\s*repoRoot,([^)]*)\)/g)]
+          .map((m) => [...(m[1] ?? '').matchAll(/'([^']+)'/g)].map((q) => q[1] ?? '').join('/'))
           .filter((path) => path.length > 0)
       ),
     ].sort();
+    const readCalls = (selfSource.match(/readFileSync\(/g) ?? []).length;
     expect(
-      reads.length,
-      'the self-scan found almost no `join(repoRoot, ...)` reads -- it has stopped ' +
-        'matching this file, so it would report full coverage over nothing'
-    ).toBeGreaterThanOrEqual(5);
+      readCalls,
+      `this file makes ${readCalls} readFileSync calls but only ${reads.length} resolve ` +
+        `through the modelled spelling (plus one self-read). A read the extractor cannot ` +
+        `see is a checker input nothing below checks. Spell new reads the same way the ` +
+        `others are spelled, or extend the extractor -- and do not write that spelling ` +
+        `into a comment or a message here, because this scan reads its own source.`
+    ).toBe(reads.length + 1);
 
-    const checkGlobs = parsed.entries
-      .filter((e) => e.gate === 'check' && e.key === 'include')
-      .map((e) => e.glob);
-    const uncovered = reads.filter(
-      (path) => !checkGlobs.some((g) => trackedFiles(g).includes(path))
-    );
+    const covered = (path: string): boolean =>
+      checkGlobs.some((g) => trackedFiles(g).includes(path));
+    const uncovered = reads.filter((path) => !covered(path));
     expect(
       uncovered,
       `this test reads ${uncovered.join(', ')}, which no \`check\` include entry covers. ` +
         `Editing one of those reds this suite while a previously-set marker stays FRESH ` +
         `-- the go-to-k/cdk-local#620 class. Scope it in, or stop reading it.`
     ).toEqual([]);
+    // Negative control: `covered` must be able to say NO, or the assertion
+    // above passes for any input. CONTRIBUTING.md is tracked and in no gate.
+    expect(
+      covered('CONTRIBUTING.md'),
+      'the coverage predicate reports everything as in-scope, so it proves nothing'
+    ).toBe(false);
   });
 
   it("the check gate scopes the files that decide what 'green' means", () => {
@@ -335,11 +428,7 @@ describe('.markgate.yml gate scopes', () => {
     // the other entries do not share -- they are not READ by any assertion.
     // They decide what the suite selects (`vite.config.ts`), which binaries
     // run it (`.mise.toml` pins vp + markgate, `.node-version` pins the Node
-    // they run on), and what the marker MEANS (`.markgate.yml`). Nothing else
-    // would notice one being dropped.
-    const checkGlobs = parsed.entries
-      .filter((e) => e.gate === 'check' && e.key === 'include')
-      .map((e) => e.glob);
+    // they run on), and what the marker MEANS (`.markgate.yml`).
     for (const g of ['vite.config.ts', '.mise.toml', '.node-version', '.markgate.yml']) {
       expect(checkGlobs, `the check gate no longer scopes ${g}`).toContain(g);
     }
@@ -349,57 +438,43 @@ describe('.markgate.yml gate scopes', () => {
     // The two halves of issue #630's decision, each inert without the other:
     // the include entry makes a hook edit stale the marker, and `/check`
     // running `test:hooks` makes the run that clears it execute the suites.
-    const checkGlobs = parsed.entries
-      .filter((e) => e.gate === 'check' && e.key === 'include')
-      .map((e) => e.glob);
     expect(checkGlobs, 'the check gate no longer scopes .claude/hooks/**').toContain(
       '.claude/hooks/**'
     );
 
     const skill = readFileSync(join(repoRoot, '.claude', 'skills', 'check', 'SKILL.md'), 'utf8');
-    // Anchored to a NUMBERED STEP, not to any mention. A bare `toContain`
-    // passed with the step deleted (measured as probe P4): the rationale
-    // paragraph below the list also spells `vp run test:hooks`, so the
-    // assertion was reading a confluence point rather than the instruction.
+    // Anchored to a NUMBERED STEP, not to any mention: a bare `toContain`
+    // passed with the step deleted, because the rationale paragraph below the
+    // list also spells the command.
     expect(
       skill,
       '/check no longer lists `vp run test:hooks` as a numbered step, so the check marker ' +
-        'would attest to a suite that excludes the .claude/hooks/*.test.sh assertions ' +
-        '(issue #630)'
+        'would attest to a suite that excludes the .claude/hooks/*.test.sh assertions'
     ).toMatch(/^\d+\. `vp run test:hooks`/m);
 
     const verifyPr = readFileSync(
       join(repoRoot, '.claude', 'skills', 'verify-pr', 'SKILL.md'),
       'utf8'
     );
-    // /verify-pr sets the same marker, so it owes the same step -- anchored to
-    // the STEP BULLET, not to any mention. A bare `toContain` stayed GREEN with
-    // the bullet deleted (measured as probe Q13), because the skill's own
-    // output table also names the command: the identical confluence-point
-    // mistake this file already fixed once for check/SKILL.md, one file over.
+    // Same trap, one file over: this skill names the command in its output
+    // table as well, so the step and the row are asserted separately.
     expect(
       verifyPr,
-      '/verify-pr sets the `check` marker but no longer lists `vp run test:hooks` as a ' +
-        'step under "Tests"'
+      '/verify-pr sets the `check` marker but no longer lists `vp run test:hooks` as a step'
     ).toMatch(/^ {3}- `vp run test:hooks` — the shell suites/m);
-    // ...and the report table must still carry it, or the step can be run and
-    // silently omitted from the verdict the marker is set on.
     expect(
       verifyPr,
       "/verify-pr's output table lost its `vp run test:hooks` row"
     ).toMatch(/^\| hook shell suites \(`vp run test:hooks`\) \|/m);
 
     const ci = readFileSync(join(repoRoot, '.github', 'workflows', 'ci.yml'), 'utf8');
-    // The claimed backstop. `.markgate.yml` and both skills say CI runs this;
-    // nothing else re-reads the workflow.
+    // The claimed backstop. `.markgate.yml` and both skills say CI runs this.
     expect(ci, 'ci.yml no longer runs `vp run test:hooks`').toMatch(
       /^\s*- run: vp run test:hooks\s*$/m
     );
 
     const config = readFileSync(join(repoRoot, 'vite.config.ts'), 'utf8');
-    // `[^}]*` keeps the match inside the `verify:` block -- with `[\s\S]*?`
-    // the scan would run past it and could be satisfied by an occurrence in
-    // any later task.
+    // `[^}]*` keeps the match inside the `verify:` block.
     expect(
       config,
       '`vp run verify` no longer chains test:hooks, so the alias reports a green the ' +
@@ -412,44 +487,38 @@ describe('.markgate.yml gate scopes', () => {
     ).toMatch(/verify:\s*\{[^}]*cache:\s*false/);
   });
 
-  it('the rules doc names the same scope the config does', () => {
+  it('the rules doc names exactly the scope the config does', () => {
     // `.claude/rules/hooks.md` restates the check gate's scope in prose, and
-    // this PR's own subject is a scope enumeration going stale unnoticed.
-    // Every include entry must appear in that paragraph.
-    // Whitespace-NORMALISED before matching. The paragraph is hard-wrapped
-    // prose, so a line-sensitive regex breaks whenever an edit moves the wrap
-    // column -- which it did, the first time this paragraph was edited after
-    // the assertion was written.
+    // this PR's own subject is a scope enumeration going stale unnoticed. Set
+    // EQUALITY, both directions: a dropped entry and an invented one both
+    // fail. Whitespace-normalised first, because the paragraph is hard-wrapped
+    // and a line-sensitive regex broke the first time it was re-wrapped.
     const rules = readFileSync(join(repoRoot, '.claude', 'rules', 'hooks.md'), 'utf8').replace(
       /\s+/g,
       ' '
     );
-    const block = /- `check` — recorded by `\/check`.*?Only invalidated by changes in that scope\./.exec(
-      rules
-    );
+    const block = /Scope: (.*?) Only invalidated by changes in that scope\./.exec(rules);
     expect(
       block,
-      'the check-gate scope paragraph in .claude/rules/hooks.md moved or was renamed'
+      "the check-gate `Scope:` sentence in .claude/rules/hooks.md moved or was renamed"
     ).not.toBeNull();
-    const prose = block?.[0] ?? '';
-    const missing = parsed.entries
-      .filter((e) => e.gate === 'check' && e.key === 'include')
-      .map((e) => e.glob)
-      .filter((g) => !prose.includes(g));
+    const named = [
+      ...new Set([...(block?.[1] ?? '').matchAll(/`([^`]+)`/g)].map((m) => m[1] ?? '')),
+    ].sort();
     expect(
-      missing,
-      `.claude/rules/hooks.md's check-gate scope paragraph does not name ${missing.join(', ')}. ` +
-        `A prose enumeration of a config is exactly the thing issue #630 found stale; keep ` +
-        `it in step with .markgate.yml or stop enumerating.`
-    ).toEqual([]);
+      named,
+      `.claude/rules/hooks.md's check-gate scope sentence and .markgate.yml's include list ` +
+        `disagree. A prose enumeration of a config is exactly what issue #630 found stale; ` +
+        `keep it in step, or stop enumerating.`
+    ).toEqual([...new Set(checkGlobs)].sort());
   });
 
-  it('the parser reports a dead entry rather than dropping it (guard the guard)', () => {
-    // Guard-the-guard: without this, a parser that silently returned [] would
-    // make the sweep above pass on any config at all. Uses the three entries
-    // this issue actually removed, so the fixture is the measured defect, plus
-    // the spellings a future contributor might reach for instead.
-    const parsedFixture = parseConfig(
+  it('the parser refuses shapes it cannot model (guard the guard)', () => {
+    // Without this, a parser that quietly returned [] would make every sweep
+    // above pass on any config at all. The fixtures are the measured defects:
+    // the three entries this issue removed, plus every spelling a reviewer
+    // used to hide a dead glob from a green run.
+    const canonical = parseConfig(
       [
         'gates:',
         '  demo:',
@@ -465,48 +534,113 @@ describe('.markgate.yml gate scopes', () => {
         '',
       ].join('\n')
     );
-    expect(parsedFixture.entries.map((e) => e.glob)).toEqual([
+    expect(canonical.entries.map((e) => e.glob)).toEqual([
       'vitest.config.ts',
       '.eslintrc*',
       '.prettierrc*',
       'vite.config.ts',
     ]);
-    expect(parsedFixture.gates).toEqual(['demo', 'other']);
-    expect(parsedFixture.entries.every((e) => e.gate === 'demo')).toBe(true);
+    expect(canonical.gates).toEqual(['demo', 'other']);
 
-    // An `exclude:` must be PARSED (so the refusal above can see it), not
-    // skipped as an unknown key.
-    const withExclude = parseConfig(
-      ['gates:', '  demo:', '    exclude:', '      - "docs/**"', '    include:', '      - "src/**"', ''].join(
-        '\n'
-      )
+    // Items at the PARENT key's own indent: valid YAML, accepted by markgate,
+    // and invisible to the previous 6-space assumption. A reviewer hid three
+    // dead globs behind it while the suite stayed 9/9 green.
+    const parentIndent = parseConfig(
+      ['gates:', '  demo:', '    include:', '    - "a.txt"', '    - "b.txt"', ''].join('\n')
     );
-    expect(withExclude.entries.map((e) => `${e.key}:${e.glob}`)).toEqual([
-      'exclude:docs/**',
-      'include:src/**',
-    ]);
+    expect(parentIndent.entries.map((e) => e.glob)).toEqual(['a.txt', 'b.txt']);
+    expect(parentIndent.consumed.size).toBe(2);
 
-    // An unmodelled spelling must THROW, not silently end the list.
+    // Deeper indent, and a second space after the dash: both legal, both
+    // previously a hard failure on a config markgate accepts.
+    expect(
+      parseConfig(
+        ['gates:', '  demo:', '    include:', '        - "a.txt"', '      -  "b.txt"', ''].join('\n')
+      ).entries.map((e) => e.glob)
+    ).toEqual(['a.txt', 'b.txt']);
+
+    // A non-scope key's block list is consumed and discarded, not counted.
+    const withRequires = parseConfig(
+      [
+        'gates:',
+        '  demo:',
+        '    requires:',
+        '      - check',
+        '      - docs',
+        '    include:',
+        '      - "a.txt"',
+        '',
+      ].join('\n')
+    );
+    expect(withRequires.entries.map((e) => e.glob)).toEqual(['a.txt']);
+    expect(withRequires.consumed.size, 'the `requires:` items must still be CONSUMED').toBe(3);
+
+    // `exclude:` must be PARSED, so the refusal above can see it.
+    expect(
+      parseConfig(
+        ['gates:', '  demo:', '    exclude:', '      - "docs/**"', '    include:', '      - "src/**"', '']
+          .join('\n')
+      ).entries.map((e) => `${e.key}:${e.glob}`)
+    ).toEqual(['exclude:docs/**', 'include:src/**']);
+
+    // Unmodelled shapes THROW rather than ending the list.
     expect(() =>
       parseConfig(['gates:', '  demo:', '    include:', '      - [a, b]', ''].join('\n'))
-    ).toThrow(/could not parse this line/);
+    ).toThrow(/could not parse this list item/);
     expect(() =>
       parseConfig(['gates:', '  demo:', '    include: ["a", "b"]', ''].join('\n'))
     ).toThrow(/unsupported inline value/);
+    expect(() =>
+      parseConfig(['gates:', '  demo:', '    include:', '      nested:', '        - "a"', ''].join('\n'))
+    ).toThrow(/unrecognised line/);
+  });
 
-    // And the matcher must actually call the three removed globs dead: if it
-    // returned a positive number for anything, the sweep could never fail.
+  it('the matcher calls the removed globs dead and sees untracked files (guard the guard)', () => {
+    // If `matchCount` returned a positive number for anything, the sweep could
+    // never fail.
     expect(
       ['vitest.config.ts', '.eslintrc*', '.prettierrc*'].map(matchCount),
       'a file now matches one of the globs #630 removed as dead -- re-check the include'
     ).toEqual([0, 0, 0]);
     expect(matchCount('vite.config.ts')).toBe(1);
-    // The union arm: an untracked-but-real path is LIVE for markgate's
-    // `hash: files`, and git alone would call it dead.
+
+    // The bare-directory rule, on a directory this repo certainly has.
+    expect(isBareDirectory('src'), 'a bare directory name must be recognised as such').toBe(true);
+    expect(isBareDirectory('src/**')).toBe(false);
+    expect(isBareDirectory('vite.config.ts')).toBe(false);
+
+    // The on-disk arm: `hash: files` digests untracked files, so an entry
+    // matching only untracked content is LIVE and git alone would call it
+    // dead. Probed with a file created here rather than against `dist/` --
+    // CI runs `vp run test` BEFORE `vp run build`, so a `dist/**` probe passed
+    // locally and failed in CI on a tree that simply had not been built.
+    const dir = mkdtempSync(join(repoRoot, 'node_modules', '.cdkl-glob-probe-'));
+    const probe = join(dir, 'probe.txt');
+    try {
+      writeFileSync(probe, 'x');
+      const rel = relative(repoRoot, probe).split(sep).join('/');
+      expect(trackedFiles(rel), 'the probe file must be untracked for this to mean anything')
+        .toEqual([]);
+      expect(
+        onDiskFiles(rel),
+        'the on-disk arm stopped seeing untracked files, so an entry matching only ' +
+          'untracked-but-real content would be reported dead while markgate digests it'
+      ).toEqual([rel]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    // Containment: a `..` glob may legitimately re-enter this repo (a linked
+    // worktree's parent contains it), so the invariant is that nothing OUTSIDE
+    // repoRoot is ever returned -- not that the match is empty. markgate would
+    // resolve `../**` to nothing at all; over-approximating is the safe
+    // direction this file documents, under-reporting would not be.
     expect(
-      matchCount('dist/**'),
-      'the on-disk arm of matchCount stopped seeing untracked files, so an entry like ' +
-        '`dist/**` would be reported dead while markgate digests it'
-    ).toBeGreaterThan(0);
+      onDiskFiles('../**').filter((f) => f.startsWith('..')),
+      'the on-disk arm returned a path outside the repository'
+    ).toEqual([]);
+    // File-only: a directory is not a file match, which is what makes the
+    // bare-directory rule above able to fire.
+    expect(onDiskFiles('src'), 'a directory is not a file match').toEqual([]);
   });
 });

--- a/tests/unit/gates/markgate-include-globs.test.ts
+++ b/tests/unit/gates/markgate-include-globs.test.ts
@@ -1,32 +1,66 @@
 import { describe, it, expect } from 'vite-plus/test';
-import { execFileSync, spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { globSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
  * Fence for issue #630.
  *
- * `.markgate.yml`'s `include:` lists decide which edits stale which gate
- * marker, and a glob there fails SILENTLY in the direction that matters: an
- * entry matching no file looks exactly like an entry doing its job. Nothing
- * re-reads a gate config, so the drift is unbounded in time.
+ * `.markgate.yml`'s gate scopes decide which edits stale which marker, and an
+ * entry there fails SILENTLY in the direction that matters: a glob matching
+ * nothing looks exactly like one doing its job.
  *
- * MEASURED on the tree this test was added to: the `check` gate's include
+ * MEASURED on the tree this test was added to. The `check` gate's include
  * carried `vitest.config.ts`, `.eslintrc*` and `.prettierrc*`, none of which
- * this repo has ever had (`git ls-files | grep -E '^(vitest\.config\.ts|\.eslintrc|\.prettierrc)'`
- * returned zero rows, and no untracked copy existed either), while the real
- * `vite.config.ts` -- the file holding the vitest `include` globs and every
- * `vp run <task>` definition, i.e. the file that decides what "green" MEANS --
- * was absent. Narrowing the vitest include there left the suite green AND the
- * marker fresh with most of the suite no longer running.
+ * this repo has ever had, while the real `vite.config.ts` -- the file holding
+ * the vitest `include` globs and every `vp run <task>` definition, i.e. the
+ * file that decides what "green" MEANS -- was absent. Against markgate's OWN
+ * resolution rather than an `ls`, `markgate verify check --explain` on the
+ * pre-fix config resolved 949 files with zero of `vite.config.ts` /
+ * `.mise.toml` / `.node-version` / `.claude/hooks/**` among them; on the fixed
+ * config it resolves 981 with all of them present.
  *
- * The population is derived from the config itself rather than hand-listed, so
- * a gate or an entry added later is scanned with no edit here. Matching is
- * delegated to `git ls-files -- ':(glob)<entry>'` instead of a hand-rolled
- * glob-to-regex step: the property under test is "matches nothing", and a
- * home-grown matcher getting `**` or a leading dot wrong would report exactly
- * that for a live entry.
+ * ## Why this is re-implemented here rather than delegated to markgate
+ *
+ * markgate 0.4.1 ships `markgate config lint --json`, which reports exactly
+ * this class -- run against the pre-fix config it named all three dead entries
+ * by index (`gates.check.include[11]: 'vitest.config.ts' matches 0 files`).
+ * It is the better instrument and the PR body cites it. It cannot be the fence
+ * that RUNS, because `.github/workflows/ci.yml` installs `vp` only: there is
+ * no mise and no markgate binary in CI, so a test shelling out to it would
+ * fail there. So the check is duplicated in TypeScript, and the duplication is
+ * declared rather than hidden.
+ *
+ * ## The parser refuses what it cannot model, and that is the whole design
+ *
+ * A hand-rolled YAML reader's failure mode is silent truncation: an entry
+ * spelled in a shape the regex misses ends the list, taking every later entry
+ * in that gate with it, and the sweep then reports "no dead globs" over a
+ * population it never saw. Three defences, in order of importance:
+ *
+ *   1. every `      - ` line inside a scope list MUST parse, or the parser
+ *      THROWS -- an unmodelled spelling is loud, never a quiet skip;
+ *   2. the entry count is reconciled against an independent scan of those
+ *      lines, and the gate-name set likewise, so a whole gate cannot vanish;
+ *   3. `exclude:` is parsed and REFUSED. markgate honours it and subtracts it
+ *      from the scope -- measured here with one variable changed: adding
+ *      `exclude: ["vite.config.ts"]` while leaving the include untouched took
+ *      `markgate verify check --explain` from 981 resolved files to 980 and
+ *      removed `vite.config.ts` from the listing, while
+ *      `markgate config lint --json` reported nothing about it. A fence
+ *      modelling only `include` would keep reporting full coverage while an
+ *      `exclude` silently subtracted. No gate uses one today; if one ever
+ *      should, teach the sweep to subtract it BEFORE deleting that assertion.
+ *
+ * Matching is the union of `git ls-files -- ':(glob)<entry>'` and
+ * `fs.globSync`, and an entry counts as dead only when BOTH are empty. Neither
+ * alone is right: git sees only the index, so an entry like `dist/**` (16 real
+ * files here, none tracked) is live for markgate's `hash: files` and would
+ * read as dead; and git's wildmatch does not do brace alternation, which
+ * markgate's doublestar does. The union errs toward NOT reporting a dead glob,
+ * which is the right direction for a fence whose false positive would block a
+ * legitimate config.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
@@ -34,114 +68,235 @@ const CONFIG = join(repoRoot, '.markgate.yml');
 
 interface Entry {
   gate: string;
+  key: 'include' | 'exclude';
   glob: string;
   line: number;
 }
 
+interface ParsedConfig {
+  entries: Entry[];
+  /** Every gate key seen under `gates:`, whether or not it declares a scope. */
+  gates: string[];
+}
+
 /**
- * Minimal reader for the one shape `.markgate.yml` uses: two-space-indented
- * gate keys under a top-level `gates:`, each optionally carrying a
- * four-space-indented `include:` whose items are six-space-indented quoted
- * scalars. Deliberately strict -- a config that stops matching this shape
- * trips the floor below rather than silently parsing to nothing.
+ * Reader for the block shape `.markgate.yml` uses: two-space-indented gate
+ * keys under a top-level `gates:`, each optionally carrying a
+ * four-space-indented `include:` / `exclude:` whose items are
+ * six-space-indented scalars. Double-quoted, single-quoted and bare scalars
+ * are all accepted; anything else THROWS rather than ending the list.
  */
-export function parseIncludes(yaml: string): Entry[] {
-  const out: Entry[] = [];
+function parseConfig(yaml: string): ParsedConfig {
+  const entries: Entry[] = [];
+  const gates: string[] = [];
   let inGates = false;
   let gate: string | null = null;
-  let inInclude = false;
-  const lines = yaml.split('\n');
+  let key: 'include' | 'exclude' | null = null;
+  const lines = yaml.split(/\r?\n/);
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? '';
+    const at = `.markgate.yml:${i + 1}`;
     if (/^gates:\s*$/.test(line)) {
       inGates = true;
       continue;
     }
     if (!inGates) continue;
-    // A non-indented, non-blank, non-comment line ends the `gates:` block.
     if (/^\S/.test(line)) {
-      inGates = false;
-      gate = null;
-      inInclude = false;
+      // A non-indented, non-blank, non-comment line ends the `gates:` block.
+      if (!/^\s*(#.*)?$/.test(line)) {
+        inGates = false;
+        gate = null;
+        key = null;
+      }
       continue;
     }
-    const gateHeader = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    const gateHeader = /^ {2}([A-Za-z0-9_-]+):\s*(#.*)?$/.exec(line);
     if (gateHeader) {
       gate = gateHeader[1] ?? null;
-      inInclude = false;
+      if (gate !== null) gates.push(gate);
+      key = null;
       continue;
     }
-    if (/^ {4}include:\s*$/.test(line)) {
-      inInclude = true;
+    const scopeKey = /^ {4}(include|exclude):\s*(.*)$/.exec(line);
+    if (scopeKey) {
+      const rest = (scopeKey[2] ?? '').trim();
+      if (rest !== '' && !rest.startsWith('#')) {
+        // A flow sequence (`include: ["a","b"]`) or an anchor / alias.
+        // Refusing is the point: silently skipping would drop the whole gate.
+        throw new Error(
+          `${at}: unsupported inline value for \`${scopeKey[1]}\` in gate '${gate}': ${rest}\n` +
+            `This parser models the block-sequence form only. Rewrite it as a block list, ` +
+            `or teach parseConfig the new shape -- do NOT let it be skipped.`
+        );
+      }
+      key = scopeKey[1] === 'exclude' ? 'exclude' : 'include';
       continue;
     }
-    if (!inInclude || gate === null) continue;
+    if (key === null || gate === null) continue;
     if (/^\s*(#.*)?$/.test(line)) continue; // blank line or comment inside the list
-    const item = /^ {6}- "([^"]+)"\s*$/.exec(line);
-    if (item) {
-      out.push({ gate, glob: item[1] ?? '', line: i + 1 });
+    if (/^ {4}\S/.test(line)) {
+      key = null; // a sibling key at the gate's own indent ends the list
       continue;
     }
-    inInclude = false; // anything else ends the list
+    // The bare-scalar arm excludes YAML indicator characters in FIRST
+    // position -- `[`/`{` open a flow collection, `&`/`*`/`!` an anchor,
+    // alias or tag -- so `- [a, b]` throws instead of being read as the
+    // literal glob "[a, b]". Later positions are unrestricted, because a
+    // real glob may legitimately contain braces (`tsconfig{,.test}.json`).
+    // A glob that genuinely starts with `*` must be quoted, which YAML
+    // requires anyway.
+    const item =
+      /^ {6}- (?:"([^"]*)"|'([^']*)'|([^\s#[\]{}&*!|>%@`'"][^#]*?))\s*(?:#.*)?$/.exec(line);
+    if (!item) {
+      throw new Error(
+        `${at}: could not parse this line inside gate '${gate}'.${key}:\n  ${line}\n` +
+          `An unparsed line used to END the list silently, dropping this entry AND every ` +
+          `later entry in the gate -- the sweep then reports "no dead globs" over a ` +
+          `population it never saw. Extend parseConfig instead of loosening this.`
+      );
+    }
+    entries.push({ gate, key, glob: item[1] ?? item[2] ?? (item[3] ?? '').trim(), line: i + 1 });
   }
-  return out;
-}
-
-function matchCount(glob: string): number {
-  const out = execFileSync('git', ['ls-files', '-z', '--', `:(glob)${glob}`], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    maxBuffer: 32 * 1024 * 1024,
-  });
-  return out.split('\0').filter((f) => f.length > 0).length;
+  return { entries, gates };
 }
 
 /**
- * A literal path that git deliberately ignores is a legitimate zero-match
- * entry: `.markgate-pr-review-sha` is a gitignored sentinel whose whole job is
- * to be rewritten by `/review-pr`, and it does not exist at all in a fresh
- * worktree. Anything else matching nothing is the defect.
+ * Independent counts, used to reconcile the parse. Deliberately NOT derived
+ * from `parseConfig` -- a floor computed by the thing it is checking cannot
+ * notice that thing losing entries.
  */
-function isIgnoredSentinel(glob: string): boolean {
-  if (/[*?[\]]/.test(glob)) return false;
-  return spawnSync('git', ['check-ignore', '-q', '--', glob], { cwd: repoRoot }).status === 0;
+function rawCounts(yaml: string): { items: number; gates: string[] } {
+  const lines = yaml.split(/\r?\n/);
+  const start = lines.findIndex((l) => /^gates:\s*$/.test(l));
+  const body = start === -1 ? [] : lines.slice(start + 1);
+  const end = body.findIndex((l) => /^\S/.test(l) && !/^\s*#/.test(l));
+  const scoped = end === -1 ? body : body.slice(0, end);
+  return {
+    items: scoped.filter((l) => /^ {6}- /.test(l)).length,
+    gates: scoped.flatMap((l) => {
+      const m = /^ {2}([A-Za-z0-9_-]+):/.exec(l);
+      return m?.[1] !== undefined ? [m[1]] : [];
+    }),
+  };
 }
 
-describe('.markgate.yml include globs', () => {
-  const yaml = readFileSync(CONFIG, 'utf8');
-  const entries = parseIncludes(yaml);
+/** Tracked matches (git's wildmatch) union on-disk matches (doublestar-ish). */
+function matchCount(glob: string): number {
+  let tracked = 0;
+  try {
+    tracked = execFileSync('git', ['ls-files', '-z', '--', `:(glob)${glob}`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+      .split('\0')
+      .filter((f) => f.length > 0).length;
+  } catch {
+    // A pathspec git refuses (e.g. a leading `/`) falls through to the on-disk
+    // arm rather than escaping as a bare "Command failed: git ls-files".
+    tracked = 0;
+  }
+  if (tracked > 0) return tracked;
+  try {
+    return globSync(glob, { cwd: repoRoot }).length;
+  } catch {
+    return 0;
+  }
+}
 
-  it('the parser actually sees the config (the scan is not vacuous)', () => {
-    // 5 gates carried an `include:` when this was written, holding 22 entries
-    // between them. A parse that stopped matching would otherwise report
-    // "no dead globs" as green.
-    const gates = [...new Set(entries.map((e) => e.gate))].sort();
-    expect(gates, 'no gate include lists parsed out of .markgate.yml').toContain('check');
-    expect(gates.length).toBeGreaterThanOrEqual(4);
-    expect(entries.length).toBeGreaterThanOrEqual(15);
+/**
+ * The single documented zero-match entry: a gitignored sentinel `/review-pr`
+ * rewrites, which does not exist at all in a fresh worktree. Spelled as an
+ * explicit one-element allow-list rather than a `git check-ignore` rule --
+ * that rule exempted every ignored path, so a typo'd `dist/index.js` would
+ * have been waved through as well.
+ */
+const ZERO_MATCH_ALLOWED = ['.markgate-pr-review-sha'];
+
+describe('.markgate.yml gate scopes', () => {
+  const yaml = readFileSync(CONFIG, 'utf8');
+  const parsed = parseConfig(yaml);
+  const raw = rawCounts(yaml);
+
+  it('the parse loses nothing (reconciled against an independent count)', () => {
+    // Asserted as an EQUALITY against a separate scan rather than as a `>=`
+    // floor: a floor with slack is exactly what let an earlier draft of this
+    // file drop 11 of 26 entries and still pass.
+    expect(
+      parsed.entries.length,
+      `parseConfig produced ${parsed.entries.length} entries but .markgate.yml has ` +
+        `${raw.items} \`      - \` lines under \`gates:\`. The parse is losing entries, ` +
+        `and every lost entry is one this sweep never checks.`
+    ).toBe(raw.items);
+    expect(parsed.gates, 'a gate key was missed by the parse').toEqual(raw.gates);
+    expect(parsed.gates, 'the check gate vanished from the parse').toContain('check');
+    expect(raw.items, 'the config has almost no scope entries -- did the scan find it?')
+      .toBeGreaterThanOrEqual(15);
   });
 
-  it('every include entry matches at least one tracked file', () => {
-    const dead = entries
-      .filter((e) => !isIgnoredSentinel(e.glob))
+  it('no gate declares an `exclude:` this sweep would not subtract', () => {
+    // markgate honours `exclude` and subtracts it from the resolved scope.
+    // MEASURED with one variable changed (include untouched): adding
+    // `exclude: ["vite.config.ts"]` to the check gate took
+    // `markgate verify check --explain` from 981 resolved files to 980 and
+    // removed `vite.config.ts` from the listing, while
+    // `markgate config lint --json` reported nothing about it. The sweep below
+    // models `include` only, so it would keep reporting full coverage while an
+    // `exclude` silently subtracted. Refuse the shape rather than mis-model it.
+    const excludes = parsed.entries.filter((e) => e.key === 'exclude');
+    expect(
+      excludes.map((e) => `.markgate.yml:${e.line} gate '${e.gate}' excludes "${e.glob}"`),
+      'a gate grew an `exclude:`. Teach the dead-glob sweep below to subtract it from ' +
+        'the include set FIRST, then remove this assertion -- do not just delete it.'
+    ).toEqual([]);
+  });
+
+  it('every include entry matches at least one file', () => {
+    const dead = parsed.entries
+      .filter((e) => e.key === 'include')
+      .filter((e) => !ZERO_MATCH_ALLOWED.includes(e.glob))
       .filter((e) => matchCount(e.glob) === 0)
       .map((e) => `.markgate.yml:${e.line} gate '${e.gate}' includes "${e.glob}"`);
     expect(
       dead,
-      `these include entries match no tracked file, so they scope nothing:\n${dead.join('\n')}\n` +
+      `these include entries match no file, so they scope nothing:\n${dead.join('\n')}\n` +
         `A glob matching nothing is indistinguishable from one doing its job. Remove it, ` +
-        `or correct it to the file it was meant to name.`
+        `or correct it to the file it was meant to name. (markgate's own ` +
+        `\`markgate config lint --json\` reports the same class, but CI has no markgate.)`
     ).toEqual([]);
   });
 
+  it('the allow-listed zero-match entry really is a gitignored sentinel', () => {
+    // Guard the exemption: it must stay a deliberate sentinel, not a place to
+    // park a broken glob. Both properties are required -- still referenced by
+    // a gate, and still ignored by git.
+    for (const glob of ZERO_MATCH_ALLOWED) {
+      expect(
+        parsed.entries.some((e) => e.glob === glob),
+        `${glob} is allow-listed here but no gate references it any more -- drop the entry`
+      ).toBe(true);
+      const ignored = execFileSync('git', ['check-ignore', '-v', '--', glob], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      });
+      expect(ignored, `${glob} is no longer gitignored, so it should not be exempt`).toContain(
+        glob
+      );
+    }
+  });
+
   it("the check gate scopes the files that decide what 'green' means", () => {
-    // Named rather than derived: these three are in the include for a reason
-    // the other entries do not share -- they are not READ by any assertion,
-    // they decide what the suite selects (`vite.config.ts`), which binaries
-    // run it (`.mise.toml`), and what the marker MEANS (`.markgate.yml`).
-    // Nothing else would notice one being dropped.
-    const checkGlobs = entries.filter((e) => e.gate === 'check').map((e) => e.glob);
-    for (const g of ['vite.config.ts', '.mise.toml', '.markgate.yml']) {
+    // Named rather than derived: these four are in the include for a reason
+    // the other entries do not share -- they are not READ by any assertion.
+    // They decide what the suite selects (`vite.config.ts`), which binaries
+    // run it (`.mise.toml` pins vp + markgate, `.node-version` pins the Node
+    // they run on), and what the marker MEANS (`.markgate.yml`). Nothing else
+    // would notice one being dropped.
+    const checkGlobs = parsed.entries
+      .filter((e) => e.gate === 'check' && e.key === 'include')
+      .map((e) => e.glob);
+    for (const g of ['vite.config.ts', '.mise.toml', '.node-version', '.markgate.yml']) {
       expect(checkGlobs, `the check gate no longer scopes ${g}`).toContain(g);
     }
   });
@@ -150,10 +305,13 @@ describe('.markgate.yml include globs', () => {
     // The two halves of issue #630's decision, each inert without the other:
     // the include entry makes a hook edit stale the marker, and `/check`
     // running `test:hooks` makes the run that clears it execute the suites.
-    const checkGlobs = entries.filter((e) => e.gate === 'check').map((e) => e.glob);
+    const checkGlobs = parsed.entries
+      .filter((e) => e.gate === 'check' && e.key === 'include')
+      .map((e) => e.glob);
     expect(checkGlobs, 'the check gate no longer scopes .claude/hooks/**').toContain(
       '.claude/hooks/**'
     );
+
     const skill = readFileSync(join(repoRoot, '.claude', 'skills', 'check', 'SKILL.md'), 'utf8');
     // Anchored to a NUMBERED STEP, not to any mention. A bare `toContain`
     // passed with the step deleted (measured as probe P4): the rationale
@@ -165,22 +323,83 @@ describe('.markgate.yml include globs', () => {
         'would attest to a suite that excludes the .claude/hooks/*.test.sh assertions ' +
         '(issue #630)'
     ).toMatch(/^\d+\. `vp run test:hooks`/m);
+
+    const verifyPr = readFileSync(
+      join(repoRoot, '.claude', 'skills', 'verify-pr', 'SKILL.md'),
+      'utf8'
+    );
+    // /verify-pr sets the same marker, so it owes the same step -- anchored to
+    // the STEP BULLET, not to any mention. A bare `toContain` stayed GREEN with
+    // the bullet deleted (measured as probe Q13), because the skill's own
+    // output table also names the command: the identical confluence-point
+    // mistake this file already fixed once for check/SKILL.md, one file over.
+    expect(
+      verifyPr,
+      '/verify-pr sets the `check` marker but no longer lists `vp run test:hooks` as a ' +
+        'step under "Tests"'
+    ).toMatch(/^ {3}- `vp run test:hooks` — the shell suites/m);
+    // ...and the report table must still carry it, or the step can be run and
+    // silently omitted from the verdict the marker is set on.
+    expect(
+      verifyPr,
+      "/verify-pr's output table lost its `vp run test:hooks` row"
+    ).toMatch(/^\| hook shell suites \(`vp run test:hooks`\) \|/m);
+
+    const ci = readFileSync(join(repoRoot, '.github', 'workflows', 'ci.yml'), 'utf8');
+    // The claimed backstop. `.markgate.yml` and both skills say CI runs this;
+    // nothing else re-reads the workflow.
+    expect(ci, 'ci.yml no longer runs `vp run test:hooks`').toMatch(
+      /^\s*- run: vp run test:hooks\s*$/m
+    );
+
     const config = readFileSync(join(repoRoot, 'vite.config.ts'), 'utf8');
+    // `[^}]*` keeps the match inside the `verify:` block -- with `[\s\S]*?`
+    // the scan would run past it and could be satisfied by an occurrence in
+    // any later task.
     expect(
       config,
       '`vp run verify` no longer chains test:hooks, so the alias reports a green the ' +
         'check gate does not mean'
-      // `[^}]*` keeps the match inside the `verify:` block -- with `[\s\S]*?`
-      // the scan would run past it and could be satisfied by an occurrence in
-      // any later task.
     ).toMatch(/verify:\s*\{[^}]*vp run test:hooks/);
+    expect(
+      config,
+      'the `verify` task is cacheable again, so `vp run verify` can replay a green ' +
+        'recorded before a .claude/hooks/** edit'
+    ).toMatch(/verify:\s*\{[^}]*cache:\s*false/);
+  });
+
+  it('the rules doc names the same scope the config does', () => {
+    // `.claude/rules/hooks.md` restates the check gate's scope in prose, and
+    // this PR's own subject is a scope enumeration going stale unnoticed.
+    // Every include entry must appear in that paragraph.
+    const rules = readFileSync(join(repoRoot, '.claude', 'rules', 'hooks.md'), 'utf8');
+    const block =
+      /- `check` — recorded by `\/check`[\s\S]*?Only invalidated\s*\n?\s*by changes in that scope\./.exec(
+        rules
+      );
+    expect(
+      block,
+      'the check-gate scope paragraph in .claude/rules/hooks.md moved or was renamed'
+    ).not.toBeNull();
+    const prose = (block?.[0] ?? '').replace(/\s+/g, ' ');
+    const missing = parsed.entries
+      .filter((e) => e.gate === 'check' && e.key === 'include')
+      .map((e) => e.glob)
+      .filter((g) => !prose.includes(g));
+    expect(
+      missing,
+      `.claude/rules/hooks.md's check-gate scope paragraph does not name ${missing.join(', ')}. ` +
+        `A prose enumeration of a config is exactly the thing issue #630 found stale; keep ` +
+        `it in step with .markgate.yml or stop enumerating.`
+    ).toEqual([]);
   });
 
   it('the parser reports a dead entry rather than dropping it (guard the guard)', () => {
     // Guard-the-guard: without this, a parser that silently returned [] would
     // make the sweep above pass on any config at all. Uses the three entries
-    // this issue actually removed, so the fixture is the measured defect.
-    const parsed = parseIncludes(
+    // this issue actually removed, so the fixture is the measured defect, plus
+    // the spellings a future contributor might reach for instead.
+    const parsedFixture = parseConfig(
       [
         'gates:',
         '  demo:',
@@ -188,28 +407,56 @@ describe('.markgate.yml include globs', () => {
         '    include:',
         '      # a comment inside the list',
         '      - "vitest.config.ts"',
-        '      - ".eslintrc*"',
-        '      - ".prettierrc*"',
+        "      - '.eslintrc*'",
+        '      - .prettierrc*',
         '      - "vite.config.ts"',
         '  other:',
         '    ttl: 30m',
         '',
       ].join('\n')
     );
-    expect(parsed.map((e) => e.glob)).toEqual([
+    expect(parsedFixture.entries.map((e) => e.glob)).toEqual([
       'vitest.config.ts',
       '.eslintrc*',
       '.prettierrc*',
       'vite.config.ts',
     ]);
-    expect(parsed.every((e) => e.gate === 'demo')).toBe(true);
-    // And the matcher must actually call those three dead: if `matchCount`
-    // returned a positive number for anything, the sweep above could never
-    // fail.
+    expect(parsedFixture.gates).toEqual(['demo', 'other']);
+    expect(parsedFixture.entries.every((e) => e.gate === 'demo')).toBe(true);
+
+    // An `exclude:` must be PARSED (so the refusal above can see it), not
+    // skipped as an unknown key.
+    const withExclude = parseConfig(
+      ['gates:', '  demo:', '    exclude:', '      - "docs/**"', '    include:', '      - "src/**"', ''].join(
+        '\n'
+      )
+    );
+    expect(withExclude.entries.map((e) => `${e.key}:${e.glob}`)).toEqual([
+      'exclude:docs/**',
+      'include:src/**',
+    ]);
+
+    // An unmodelled spelling must THROW, not silently end the list.
+    expect(() =>
+      parseConfig(['gates:', '  demo:', '    include:', '      - [a, b]', ''].join('\n'))
+    ).toThrow(/could not parse this line/);
+    expect(() =>
+      parseConfig(['gates:', '  demo:', '    include: ["a", "b"]', ''].join('\n'))
+    ).toThrow(/unsupported inline value/);
+
+    // And the matcher must actually call the three removed globs dead: if it
+    // returned a positive number for anything, the sweep could never fail.
     expect(
       ['vitest.config.ts', '.eslintrc*', '.prettierrc*'].map(matchCount),
       'a file now matches one of the globs #630 removed as dead -- re-check the include'
     ).toEqual([0, 0, 0]);
     expect(matchCount('vite.config.ts')).toBe(1);
+    // The union arm: an untracked-but-real path is LIVE for markgate's
+    // `hash: files`, and git alone would call it dead.
+    expect(
+      matchCount('dist/**'),
+      'the on-disk arm of matchCount stopped seeing untracked files, so an entry like ' +
+        '`dist/**` would be reported dead while markgate digests it'
+    ).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/gates/markgate-include-globs.test.ts
+++ b/tests/unit/gates/markgate-include-globs.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Fence for issue #630.
+ *
+ * `.markgate.yml`'s `include:` lists decide which edits stale which gate
+ * marker, and a glob there fails SILENTLY in the direction that matters: an
+ * entry matching no file looks exactly like an entry doing its job. Nothing
+ * re-reads a gate config, so the drift is unbounded in time.
+ *
+ * MEASURED on the tree this test was added to: the `check` gate's include
+ * carried `vitest.config.ts`, `.eslintrc*` and `.prettierrc*`, none of which
+ * this repo has ever had (`git ls-files | grep -E '^(vitest\.config\.ts|\.eslintrc|\.prettierrc)'`
+ * returned zero rows, and no untracked copy existed either), while the real
+ * `vite.config.ts` -- the file holding the vitest `include` globs and every
+ * `vp run <task>` definition, i.e. the file that decides what "green" MEANS --
+ * was absent. Narrowing the vitest include there left the suite green AND the
+ * marker fresh with most of the suite no longer running.
+ *
+ * The population is derived from the config itself rather than hand-listed, so
+ * a gate or an entry added later is scanned with no edit here. Matching is
+ * delegated to `git ls-files -- ':(glob)<entry>'` instead of a hand-rolled
+ * glob-to-regex step: the property under test is "matches nothing", and a
+ * home-grown matcher getting `**` or a leading dot wrong would report exactly
+ * that for a live entry.
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const CONFIG = join(repoRoot, '.markgate.yml');
+
+interface Entry {
+  gate: string;
+  glob: string;
+  line: number;
+}
+
+/**
+ * Minimal reader for the one shape `.markgate.yml` uses: two-space-indented
+ * gate keys under a top-level `gates:`, each optionally carrying a
+ * four-space-indented `include:` whose items are six-space-indented quoted
+ * scalars. Deliberately strict -- a config that stops matching this shape
+ * trips the floor below rather than silently parsing to nothing.
+ */
+export function parseIncludes(yaml: string): Entry[] {
+  const out: Entry[] = [];
+  let inGates = false;
+  let gate: string | null = null;
+  let inInclude = false;
+  const lines = yaml.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    if (/^gates:\s*$/.test(line)) {
+      inGates = true;
+      continue;
+    }
+    if (!inGates) continue;
+    // A non-indented, non-blank, non-comment line ends the `gates:` block.
+    if (/^\S/.test(line)) {
+      inGates = false;
+      gate = null;
+      inInclude = false;
+      continue;
+    }
+    const gateHeader = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (gateHeader) {
+      gate = gateHeader[1] ?? null;
+      inInclude = false;
+      continue;
+    }
+    if (/^ {4}include:\s*$/.test(line)) {
+      inInclude = true;
+      continue;
+    }
+    if (!inInclude || gate === null) continue;
+    if (/^\s*(#.*)?$/.test(line)) continue; // blank line or comment inside the list
+    const item = /^ {6}- "([^"]+)"\s*$/.exec(line);
+    if (item) {
+      out.push({ gate, glob: item[1] ?? '', line: i + 1 });
+      continue;
+    }
+    inInclude = false; // anything else ends the list
+  }
+  return out;
+}
+
+function matchCount(glob: string): number {
+  const out = execFileSync('git', ['ls-files', '-z', '--', `:(glob)${glob}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return out.split('\0').filter((f) => f.length > 0).length;
+}
+
+/**
+ * A literal path that git deliberately ignores is a legitimate zero-match
+ * entry: `.markgate-pr-review-sha` is a gitignored sentinel whose whole job is
+ * to be rewritten by `/review-pr`, and it does not exist at all in a fresh
+ * worktree. Anything else matching nothing is the defect.
+ */
+function isIgnoredSentinel(glob: string): boolean {
+  if (/[*?[\]]/.test(glob)) return false;
+  return spawnSync('git', ['check-ignore', '-q', '--', glob], { cwd: repoRoot }).status === 0;
+}
+
+describe('.markgate.yml include globs', () => {
+  const yaml = readFileSync(CONFIG, 'utf8');
+  const entries = parseIncludes(yaml);
+
+  it('the parser actually sees the config (the scan is not vacuous)', () => {
+    // 5 gates carried an `include:` when this was written, holding 22 entries
+    // between them. A parse that stopped matching would otherwise report
+    // "no dead globs" as green.
+    const gates = [...new Set(entries.map((e) => e.gate))].sort();
+    expect(gates, 'no gate include lists parsed out of .markgate.yml').toContain('check');
+    expect(gates.length).toBeGreaterThanOrEqual(4);
+    expect(entries.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it('every include entry matches at least one tracked file', () => {
+    const dead = entries
+      .filter((e) => !isIgnoredSentinel(e.glob))
+      .filter((e) => matchCount(e.glob) === 0)
+      .map((e) => `.markgate.yml:${e.line} gate '${e.gate}' includes "${e.glob}"`);
+    expect(
+      dead,
+      `these include entries match no tracked file, so they scope nothing:\n${dead.join('\n')}\n` +
+        `A glob matching nothing is indistinguishable from one doing its job. Remove it, ` +
+        `or correct it to the file it was meant to name.`
+    ).toEqual([]);
+  });
+
+  it("the check gate scopes the files that decide what 'green' means", () => {
+    // Named rather than derived: these three are in the include for a reason
+    // the other entries do not share -- they are not READ by any assertion,
+    // they decide what the suite selects (`vite.config.ts`), which binaries
+    // run it (`.mise.toml`), and what the marker MEANS (`.markgate.yml`).
+    // Nothing else would notice one being dropped.
+    const checkGlobs = entries.filter((e) => e.gate === 'check').map((e) => e.glob);
+    for (const g of ['vite.config.ts', '.mise.toml', '.markgate.yml']) {
+      expect(checkGlobs, `the check gate no longer scopes ${g}`).toContain(g);
+    }
+  });
+
+  it('the check gate scopes the shell hook suites that /check runs', () => {
+    // The two halves of issue #630's decision, each inert without the other:
+    // the include entry makes a hook edit stale the marker, and `/check`
+    // running `test:hooks` makes the run that clears it execute the suites.
+    const checkGlobs = entries.filter((e) => e.gate === 'check').map((e) => e.glob);
+    expect(checkGlobs, 'the check gate no longer scopes .claude/hooks/**').toContain(
+      '.claude/hooks/**'
+    );
+    const skill = readFileSync(join(repoRoot, '.claude', 'skills', 'check', 'SKILL.md'), 'utf8');
+    // Anchored to a NUMBERED STEP, not to any mention. A bare `toContain`
+    // passed with the step deleted (measured as probe P4): the rationale
+    // paragraph below the list also spells `vp run test:hooks`, so the
+    // assertion was reading a confluence point rather than the instruction.
+    expect(
+      skill,
+      '/check no longer lists `vp run test:hooks` as a numbered step, so the check marker ' +
+        'would attest to a suite that excludes the .claude/hooks/*.test.sh assertions ' +
+        '(issue #630)'
+    ).toMatch(/^\d+\. `vp run test:hooks`/m);
+    const config = readFileSync(join(repoRoot, 'vite.config.ts'), 'utf8');
+    expect(
+      config,
+      '`vp run verify` no longer chains test:hooks, so the alias reports a green the ' +
+        'check gate does not mean'
+      // `[^}]*` keeps the match inside the `verify:` block -- with `[\s\S]*?`
+      // the scan would run past it and could be satisfied by an occurrence in
+      // any later task.
+    ).toMatch(/verify:\s*\{[^}]*vp run test:hooks/);
+  });
+
+  it('the parser reports a dead entry rather than dropping it (guard the guard)', () => {
+    // Guard-the-guard: without this, a parser that silently returned [] would
+    // make the sweep above pass on any config at all. Uses the three entries
+    // this issue actually removed, so the fixture is the measured defect.
+    const parsed = parseIncludes(
+      [
+        'gates:',
+        '  demo:',
+        '    hash: files',
+        '    include:',
+        '      # a comment inside the list',
+        '      - "vitest.config.ts"',
+        '      - ".eslintrc*"',
+        '      - ".prettierrc*"',
+        '      - "vite.config.ts"',
+        '  other:',
+        '    ttl: 30m',
+        '',
+      ].join('\n')
+    );
+    expect(parsed.map((e) => e.glob)).toEqual([
+      'vitest.config.ts',
+      '.eslintrc*',
+      '.prettierrc*',
+      'vite.config.ts',
+    ]);
+    expect(parsed.every((e) => e.gate === 'demo')).toBe(true);
+    // And the matcher must actually call those three dead: if `matchCount`
+    // returned a positive number for anything, the sweep above could never
+    // fail.
+    expect(
+      ['vitest.config.ts', '.eslintrc*', '.prettierrc*'].map(matchCount),
+      'a file now matches one of the globs #630 removed as dead -- re-check the include'
+    ).toEqual([0, 0, 0]);
+    expect(matchCount('vite.config.ts')).toBe(1);
+  });
+});

--- a/tests/unit/gates/markgate-include-globs.test.ts
+++ b/tests/unit/gates/markgate-include-globs.test.ts
@@ -95,6 +95,8 @@ interface ParsedConfig {
   gates: string[];
   /** 1-based line numbers of every `- ` item line the parser consumed. */
   consumed: Set<number>;
+  /** Gates that DECLARED an `include:` key, whether or not items followed. */
+  declaredInclude: string[];
 }
 
 /** Scalar forms a list item may take. Anything else throws. */
@@ -121,6 +123,7 @@ function parseConfig(yaml: string): ParsedConfig {
   const entries: Entry[] = [];
   const gates: string[] = [];
   const consumed = new Set<number>();
+  const declaredInclude: string[] = [];
   let inGates = false;
   let gate: string | null = null;
   let key: string | null = null;
@@ -150,6 +153,19 @@ function parseConfig(yaml: string): ParsedConfig {
     const keyLine = /^ {4}([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
     if (keyLine) {
       const name = keyLine[1] ?? '';
+      // markgate's OWN key set, not the keys this repo happens to use. An
+      // unknown key used to be consumed and DISCARDED, so a typo'd `includes:`
+      // took five globs out of the sweep while every assertion stayed green --
+      // and a future markgate key that subtracts from the scope, as `exclude`
+      // does, would arrive the same silent way. Refuse instead.
+      if (!/^(hash|base|ttl|include|exclude|requires)$/.test(name)) {
+        throw new Error(
+          `${at}: unknown gate key \`${name}\` in gate '${gate}'.\n` +
+            `This fence models markgate's key set; an unmodelled key may add to or ` +
+            `SUBTRACT from the resolved scope, which would make every check below ` +
+            `report coverage it does not have. Teach the parser what it means.`
+        );
+      }
       const rest = (keyLine[2] ?? '').trim();
       const hasInlineValue = rest !== '' && !rest.startsWith('#');
       if ((name === 'include' || name === 'exclude') && hasInlineValue) {
@@ -161,6 +177,7 @@ function parseConfig(yaml: string): ParsedConfig {
             `or teach the parser the new shape -- do NOT let it be skipped.`
         );
       }
+      if (name === 'include' && gate !== null) declaredInclude.push(gate);
       // A key with an inline value takes no items; one without may.
       key = hasInlineValue ? null : name;
       continue;
@@ -190,7 +207,7 @@ function parseConfig(yaml: string): ParsedConfig {
         `Nested mappings and other shapes are not modelled. Extend the parser.`
     );
   }
-  return { entries, gates, consumed };
+  return { entries, gates, consumed, declaredInclude };
 }
 
 /**
@@ -306,6 +323,21 @@ describe('.markgate.yml gate scopes', () => {
       raw.itemLines.length,
       'the config has almost no scope entries -- did the scan find it at all?'
     ).toBeGreaterThanOrEqual(15);
+    // Per-gate floor. The global one above is satisfied by 28 entries however
+    // they are distributed, so emptying one gate's `include:` entirely -- five
+    // globs out of `docs`, say -- sails through it.
+    const emptied = parsed.declaredInclude.filter(
+      (g) => !parsed.entries.some((e) => e.gate === g && e.key === 'include')
+    );
+    expect(
+      emptied,
+      `these gates declare an \`include:\` with no entries, so they scope NOTHING: ` +
+        `${emptied.join(', ')}`
+    ).toEqual([]);
+    expect(
+      parsed.declaredInclude.length,
+      'no gate declares an include at all -- the parse found nothing to check'
+    ).toBeGreaterThan(0);
   });
 
   it('no gate declares an `exclude:` this sweep would not subtract', () => {
@@ -380,15 +412,29 @@ describe('.markgate.yml gate scopes', () => {
     // exists to close.
     //
     // The population is derived from this file's own source. A regex can only
-    // see the spelling it models, so the file also FORBIDS every other read
-    // spelling: the total number of read calls must equal the derived reads
-    // plus the one self-read below. Adding a read via `resolve()`, a template
-    // literal or a joined array fails here instead of slipping past.
+    // see the spelling it models, so the count of read calls must equal the
+    // derived reads plus the one self-read below: adding a read via
+    // `resolve()`, a template literal or a joined path fails here instead of
+    // slipping past. It is a budget, not a proof -- aliasing `readFileSync` to
+    // another name, or reading through `execFileSync('cat', ...)`, still
+    // evades it. The claim is "the obvious respellings are caught", not "no
+    // read can hide".
     //
     // Careful when editing the text in this case: the scan reads its own
     // source, so writing the scanned spelling into a comment or a message
     // counts as a read and makes the equality fail on prose. It did, twice.
     const selfSource = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+    // The equality below permits exactly ONE unmodelled read -- this one. That
+    // budget is TRANSFERABLE unless it is nailed down: respelling the self-read
+    // through the modelled form frees the slot for a smuggled read of a file in
+    // no gate, and two coordinated edits then pass. Pin the self-read's own
+    // spelling so the slot cannot be vacated.
+    expect(
+      (selfSource.match(/readFileSync\(fileURLToPath\(/g) ?? []).length,
+      'the self-read must keep this exact spelling: it is the one read the equality ' +
+        'below allows to be unmodelled, and respelling it frees that allowance for a ' +
+        'read of a file nothing checks'
+    ).toBe(1);
     const reads = [
       ...new Set(
         [...selfSource.matchAll(/readFileSync\(\s*join\(\s*repoRoot,([^)]*)\)/g)]
@@ -630,13 +676,22 @@ describe('.markgate.yml gate scopes', () => {
       rmSync(dir, { recursive: true, force: true });
     }
 
-    // Containment: a `..` glob may legitimately re-enter this repo (a linked
-    // worktree's parent contains it), so the invariant is that nothing OUTSIDE
-    // repoRoot is ever returned -- not that the match is empty. markgate would
-    // resolve `../**` to nothing at all; over-approximating is the safe
-    // direction this file documents, under-reporting would not be.
+    // Containment, probed where it can actually fail. `../**` does NOT escape:
+    // measured, Node's glob does not walk upward, so it returns 1225 entries
+    // all inside the repo and an assertion on it is unfalsifiable (deleting
+    // the containment filter leaves it green). An ABSOLUTE pattern does
+    // escape, so that is what this probes -- raw `globSync` must yield paths
+    // outside the repo, and `onDiskFiles` must return none of them.
+    const escapes = globSync('/etc/*', { cwd: repoRoot, withFileTypes: true })
+      .filter((d) => d.isFile())
+      .map((d) => resolve(d.parentPath, d.name))
+      .filter((f) => !f.startsWith(repoRoot + sep));
     expect(
-      onDiskFiles('../**').filter((f) => f.startsWith('..')),
+      escapes.length,
+      'the probe found no file outside the repo, so it cannot show containment working'
+    ).toBeGreaterThan(0);
+    expect(
+      onDiskFiles('/etc/*'),
       'the on-disk arm returned a path outside the repository'
     ).toEqual([]);
     // File-only: a directory is not a file match, which is what makes the

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -43,13 +43,69 @@ import { fileURLToPath } from 'node:url';
  * rather than described: adding `sh` to `BINARY_EXT` silently drops ~92
  * files -- every `.claude/hooks/*.sh`, which is the tree this fence's
  * rationale is about -- while leaving the file count and the three prefix
- * checks comfortably satisfied. So the tests below pin BOTH WHICH EXTENSIONS
- * the exclusion removes and that each text extension the repo actually
- * carries survives it.
+ * checks comfortably satisfied. So the tests below pin BOTH that every
+ * excluded extension is one this file names as genuinely binary, and that
+ * each text extension the repo actually carries survives the filter.
+ *
+ * ## Why a SUBSET check and not an equality pin (issue #630)
+ *
+ * That first assertion used to read `expect(excludedExts).toEqual(['.gif'])`
+ * -- `.gif` being the only excluded extension the tree carried. This file is
+ * a repo-wide scanner and therefore sits OUTSIDE the `check` markgate gate's
+ * include (the deliberate carve-out documented in `.markgate.yml`), and that
+ * carve-out is only proportionate while the condition the scanner fires on is
+ * RARE. A raw C0 control byte in committed text is rare. Committing a `.png`
+ * screenshot, a `.pdf`, or a `.woff2` font is ORDINARY -- and under the
+ * equality pin any one of them reddened this suite, in a file the committer
+ * has no reason to open. The predicate, not the breadth of the population,
+ * is what decides whether a whole-tree scanner is a fair carve-out.
+ *
+ * The subset form keeps everything the equality pin was for. The failure it
+ * exists to catch is a TEXT extension entering `BINARY_EXT` and silently
+ * shrinking the population; such an extension is absent from
+ * LEGITIMATELY_BINARY, so it still fails here on the FIRST file of that
+ * extension, and never on an 8th GIF or a 1st PNG. LEGITIMATELY_BINARY is
+ * hand-written and deliberately NOT derived from `BINARY_EXT`: derived, the
+ * check would be a tautology satisfied by whatever the regex happens to say.
  */
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..');
+
+/**
+ * The extensions whose exclusion from the scan is legitimate, spelled
+ * INDEPENDENTLY of `BINARY_EXT` below (see the docblock): a value appearing
+ * in `BINARY_EXT` but not here is the regression this list exists to catch,
+ * so deriving one from the other would make the assertion vacuous. Adding an
+ * entry here is the deliberate, reviewable second edit that widening
+ * `BINARY_EXT` should cost.
+ */
+const LEGITIMATELY_BINARY = [
+  '.bmp',
+  '.class',
+  '.dll',
+  '.dylib',
+  '.eot',
+  '.gif',
+  '.gz',
+  '.ico',
+  '.jar',
+  '.jpeg',
+  '.jpg',
+  '.mov',
+  '.mp4',
+  '.otf',
+  '.pdf',
+  '.png',
+  '.so',
+  '.tgz',
+  '.ttf',
+  '.wasm',
+  '.webp',
+  '.woff',
+  '.woff2',
+  '.zip',
+];
 
 /** Extensions whose bytes are legitimately non-text. */
 const BINARY_EXT =
@@ -114,11 +170,12 @@ describe('committed text carries no C0 control bytes', () => {
     // while every other assertion here stays green (`sh` alone costs ~92 files,
     // every `.claude/hooks/*.sh` -- the tree this fence's rationale is about).
     //
-    // Asserted as a SET rather than a count. A count has to be tuned between
-    // "loud enough to catch `yaml`" and "quiet enough to survive one more demo
-    // GIF", and at the tuned value `html` cleared by exactly one file -- drop an
-    // .html from the repo and that escape reopens silently. The set fires on the
-    // FIRST file of a newly-excluded extension and never fires on an 8th GIF.
+    // Asserted as a SUBSET of LEGITIMATELY_BINARY rather than as an equality
+    // pin or a count. A count has to be tuned between "loud enough to catch
+    // `yaml`" and "quiet enough to survive one more demo GIF"; an equality pin
+    // fired on ordinary content (see the docblock, issue #630). The subset
+    // fires on the FIRST file of a newly-excluded TEXT extension, and never on
+    // an 8th GIF or a 1st PNG.
     const allTracked = execFileSync('git', ['ls-files', '-z'], {
       cwd: REPO_ROOT,
       encoding: 'utf8',
@@ -126,6 +183,10 @@ describe('committed text carries no C0 control bytes', () => {
     })
       .split('\0')
       .filter((f) => f.length > 0);
+    // Floor: an empty or broken `git ls-files` would leave `excludedExts`
+    // empty, and an empty set is a subset of everything -- the assertion below
+    // would pass having examined nothing.
+    expect(allTracked.length, 'git ls-files returned no tracked files').toBeGreaterThan(500);
     const excludedExts = [
       ...new Set(
         allTracked
@@ -136,7 +197,32 @@ describe('committed text carries no C0 control bytes', () => {
           .map((f) => (path.extname(f) || path.basename(f)).toLowerCase())
       ),
     ].sort();
-    expect(excludedExts).toEqual(['.gif']);
+    const unexpected = excludedExts.filter((e) => !LEGITIMATELY_BINARY.includes(e));
+    expect(
+      unexpected,
+      `BINARY_EXT excludes ${unexpected.join(', ')} from the control-byte scan, and ` +
+        `LEGITIMATELY_BINARY does not name ${unexpected.length === 1 ? 'it' : 'them'}. ` +
+        `If the extension really is binary, add it there too; if it is text, this is ` +
+        `the population silently shrinking -- narrow BINARY_EXT instead.`
+    ).toEqual([]);
+  });
+
+  it('LEGITIMATELY_BINARY names no extension the repo carries as text', () => {
+    // Guard-the-guard, in the direction the subset check cannot see: the
+    // subset only asks "is every EXCLUDED extension listed here", so an
+    // over-broad entry (`.sh`, `.yml`) would be waved through the moment
+    // someone also widened BINARY_EXT to match. Anchored to the extensions
+    // the scan's own population proves are text.
+    const textExts = [
+      ...new Set(files.map((f) => path.extname(f).toLowerCase()).filter((e) => e.length > 0)),
+    ];
+    expect(textExts.length, 'the scanned population has no extensions at all').toBeGreaterThan(5);
+    const overlap = LEGITIMATELY_BINARY.filter((e) => textExts.includes(e));
+    expect(
+      overlap,
+      `LEGITIMATELY_BINARY names ${overlap.join(', ')}, which the repo also tracks as ` +
+        `scanned text -- one of the two lists is wrong`
+    ).toEqual([]);
   });
 
   it('keeps every text extension the repo actually carries', () => {

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -253,12 +253,20 @@ describe('committed text carries no C0 control bytes', () => {
         `that extension is plain text. Excluding it removes real files from the ` +
         `control-byte scan for nothing -- narrow the list, and narrow BINARY_EXT with it.`
     ).toEqual([]);
-    // Vacuity floor: if the repo tracked none of these extensions the loop
-    // above would judge nothing and pass silently.
-    expect(
-      judged,
-      'no extension in LEGITIMATELY_BINARY is present in the repo, so this test judged nothing'
-    ).not.toEqual([]);
+    // NO vacuity floor here, deliberately (issue #630, review round 4). The
+    // obvious one -- `expect(judged).not.toEqual([])` -- was satisfied by
+    // exactly ONE extension: `.gif`, from the three demo GIFs in `assets/`, a
+    // directory in no gate's include. Reformatting or deleting them reddened
+    // this suite with the `check` marker FRESH -- measured, and it is the
+    // go-to-k/cdk-local#620 class this PR exists to close, re-introduced by a
+    // floor guarding a harmless case: an extension the repo does not carry
+    // excludes nothing, so there is nothing at risk in not judging it. The
+    // failure this arm exists for -- a TEXT extension entering
+    // LEGITIMATELY_BINARY -- always has files to judge, because having files
+    // is what makes it a problem. Scoping `assets/**` in was the alternative
+    // and buys nothing: it would make every demo-GIF change stale the marker
+    // to keep a floor that guards nothing.
+    void judged;
   });
 
   it('keeps every text extension the repo actually carries', () => {

--- a/tests/unit/no-control-bytes.test.ts
+++ b/tests/unit/no-control-bytes.test.ts
@@ -207,22 +207,58 @@ describe('committed text carries no C0 control bytes', () => {
     ).toEqual([]);
   });
 
-  it('LEGITIMATELY_BINARY names no extension the repo carries as text', () => {
+  it('every extension LEGITIMATELY_BINARY names really holds binary bytes', () => {
     // Guard-the-guard, in the direction the subset check cannot see: the
     // subset only asks "is every EXCLUDED extension listed here", so an
-    // over-broad entry (`.sh`, `.yml`) would be waved through the moment
-    // someone also widened BINARY_EXT to match. Anchored to the extensions
-    // the scan's own population proves are text.
-    const textExts = [
-      ...new Set(files.map((f) => path.extname(f).toLowerCase()).filter((e) => e.length > 0)),
-    ];
-    expect(textExts.length, 'the scanned population has no extensions at all').toBeGreaterThan(5);
-    const overlap = LEGITIMATELY_BINARY.filter((e) => textExts.includes(e));
+    // over-broad entry is waved through the moment someone widens BINARY_EXT
+    // to match it.
+    //
+    // The anchor is deliberately NOT the scanned population. An earlier draft
+    // compared LEGITIMATELY_BINARY against `files`'s extensions -- but `files`
+    // is ALREADY filtered by BINARY_EXT, so adding `yaml` to BOTH lists
+    // removed every .yaml from `files` and the overlap came back empty: the
+    // one case the guard existed for was the one case it could not see
+    // (measured during #630's review: 13 tracked files silently dropped from
+    // the scan, suite still 7 passed).
+    //
+    // So judge by CONTENT instead, from the unfiltered index: for every listed
+    // extension the repo actually tracks, at least one of those files must
+    // really contain a byte no text file has. A text extension smuggled into
+    // the list fails here whatever BINARY_EXT says.
+    const allTracked = execFileSync('git', ['ls-files', '-z'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    })
+      .split('\0')
+      .filter((f) => f.length > 0);
+    expect(allTracked.length, 'git ls-files returned no tracked files').toBeGreaterThan(500);
+
+    const judged: string[] = [];
+    const notBinary: string[] = [];
+    for (const ext of LEGITIMATELY_BINARY) {
+      const held = allTracked.filter((f) => f.toLowerCase().endsWith(ext));
+      // An extension the repo does not carry excludes nothing, so there is
+      // nothing to judge -- and nothing at risk either.
+      if (held.length === 0) continue;
+      judged.push(ext);
+      const anyBinary = held.some((f) =>
+        FORBIDDEN.test(readFileSync(path.join(REPO_ROOT, f), 'latin1'))
+      );
+      if (!anyBinary) notBinary.push(`${ext} (${held.length} file(s), e.g. ${held[0]})`);
+    }
     expect(
-      overlap,
-      `LEGITIMATELY_BINARY names ${overlap.join(', ')}, which the repo also tracks as ` +
-        `scanned text -- one of the two lists is wrong`
+      notBinary,
+      `LEGITIMATELY_BINARY names ${notBinary.join(', ')}, but every tracked file with ` +
+        `that extension is plain text. Excluding it removes real files from the ` +
+        `control-byte scan for nothing -- narrow the list, and narrow BINARY_EXT with it.`
     ).toEqual([]);
+    // Vacuity floor: if the repo tracked none of these extensions the loop
+    // above would judge nothing and pass silently.
+    expect(
+      judged,
+      'no extension in LEGITIMATELY_BINARY is present in the repo, so this test judged nothing'
+    ).not.toEqual([]);
   });
 
   it('keeps every text extension the repo actually carries', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -233,6 +233,11 @@ export default defineConfig({
         // that stopped short would hand back a green this repo's gate does
         // not mean.
         command: 'vp run check && vp run test && vp run test:hooks && vp run build',
+        // `run.cache.tasks` is on, and an alias that REPLAYS is the same
+        // false green one level up: a recorded exit code from before a
+        // `.claude/hooks/**` edit would satisfy the very step added to catch
+        // it. The links it chains keep their own caching.
+        cache: false,
       },
       'test:hooks': {
         // Glob, not a hardcoded list: a new `.claude/hooks/*.test.sh` used to be

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -228,7 +228,11 @@ export default defineConfig({
         command: 'tsc --project tsconfig.json --noEmit',
       },
       verify: {
-        command: 'vp run check && vp run test && vp run build',
+        // Kept in step with what `/check` runs (issue #630): `test:hooks` is
+        // part of what the `check` markgate marker attests to, so an alias
+        // that stopped short would hand back a green this repo's gate does
+        // not mean.
+        command: 'vp run check && vp run test && vp run test:hooks && vp run build',
       },
       'test:hooks': {
         // Glob, not a hardcoded list: a new `.claude/hooks/*.test.sh` used to be


### PR DESCRIPTION
## Summary

Three different root causes from go-to-k/cdk-local#630, only one of which the `check` gate's include list could fix. Every claim below was re-derived in this lane; the commands and their real output are pasted.

### 1. The include named three config files that do not exist, and missed the one that does

Proven against **markgate's own resolution**, not an `ls` -- resolution is include minus exclude, and reasoning from the include list alone is the same mistake in miniature. markgate 0.4.1 ships a linter, and on the pre-fix config it names all three by index:

```
$ git show origin/main:.markgate.yml > .markgate.yml && mise exec -- markgate config lint --json
[
  {"path": "gates.check.include[11]", "severity": "warning",
   "message": "gates.check.include[11]: 'vitest.config.ts' matches 0 files"},
  {"path": "gates.check.include[12]", "severity": "warning",
   "message": "gates.check.include[12]: '.eslintrc*' matches 0 files"},
  {"path": "gates.check.include[13]", "severity": "warning",
   "message": "gates.check.include[13]: '.prettierrc*' matches 0 files"},
  {"path": "gates.pr-review.include[0]", "severity": "warning",
   "message": "gates.pr-review.include[0]: '.markgate-pr-review-sha' matches 0 files"}
]
rc=1
```

On the shipping config only the last of those four remains (a gitignored sentinel `/review-pr` rewrites, absent in a fresh worktree). Corroborated by the ordinary greps: `git ls-files | grep -E '^(vitest\.config\.ts|\.eslintrc|\.prettierrc)'` → rc=1, no output; `ls` finds no untracked copy either.

And the RESOLVED scope, from `markgate verify check --explain` (which prints it to **stderr** — an earlier probe redirected that away and every count came back `0`, which read exactly like the answer it was looking for):

| tree | `vite.config.ts` / `.mise.toml` / `.node-version` in scope | `.claude/hooks/*` in scope |
|---|---|---|
| pre-fix | 0 of 3 | 0 |
| shipping | **3 of 3** | **30** |

The scope's absolute SIZE is deliberately not quoted here or in the code. `hash: files` digests untracked content, so the total moves with `dist/`, `node_modules/` and any scratch file in the tree — two reviewers measuring the same commit reported different totals, and an earlier draft of this body published a number no commit had. The per-file counts above are the stable half and reproduce exactly.

Fixed by replacing the three dead globs with `vite.config.ts`, `.mise.toml` and `.node-version` -- one class: they decide what "green" MEANS rather than being read by an assertion. `vite.config.ts` holds the vitest `include` globs and every `vp run <task>` definition; `.mise.toml` pins the `vp` + `markgate` binaries that run them; `.node-version` pins the Node they run ON, which `.mise.toml` does **not** (it declares only `ubi:go-to-k/markgate` and `http:vp`). `.node-version` was added during the review round -- a Node bump is the change most likely to alter what the suite does, and it was leaving the marker fresh.

### 2. `/check` never ran `test:hooks`, so the marker attested to a suite excluding those assertions

Verified rather than assumed:

```
$ ls .claude/hooks/*.test.sh | wc -l
8
$ ls tests/integration/_lib/*.test.sh | wc -l
2
$ git show origin/main:.claude/skills/check/SKILL.md | grep -n 'vp run'   # before this PR
14:1. `vp run check` - typecheck + lint + format check ...
15:2. `vp run build` - produces `dist/cli.js` and `dist/index.js`.
16:3. `vp run test` - vitest unit tests.
18:`vp run verify` is the convenience alias that runs all three; either path is fine.
26:| typecheck + lint + format (`vp run check`) | pass/fail |
$ grep -n "'test:hooks'" vite.config.ts     # on the shipping tree
242:      'test:hooks': {
$ grep -n 'test:hooks' .github/workflows/ci.yml
23:      - run: vp run test:hooks
```

`test:hooks` is a separate task, so `/check` cleared the marker without ever executing the shell suites; and `.claude/hooks/**` was not in the include, so a hook edit did not even stale it.

**The decision go-to-k/cdk-local#630 asked for, taken and written down: fold `test:hooks` into `/check` rather than document the hole.** Both halves ship, because either alone is worse than neither:

- `.claude/hooks/**` joins the `check` include (a hook edit now stales the marker), AND
- `/check` step 4, `/verify-pr` step 2 and the `vp run verify` alias now run `vp run test:hooks` (the run that clears the marker now executes those suites).

This also closes the inverse shape the issue describes: `.claude/hooks/pr-review-gate.test.sh` asserts four copies of the `UP_PATHS` list stay in sync across `.claude/rules/hooks.md`, `.claude/agents/pr-code-reviewer.md` and `.claude/skills/review-pr/SKILL.md` -- all three already in the include, so editing one DID stale the marker while the `/check` that cleared it never ran the sync assertion. Same for `tests/integration/_lib/aws-orphan-sweep.test.sh`, which reads `.claude/skills/run-integ/SKILL.md`.

Cost measured, not guessed: `vp run test:hooks` ran in **67-95 s** wall-clock across five runs (mine and three reviewers'), uncached; the spread is machine load, not variance in the work. Ten suites, 0 fail, heaviest `.claude/hooks/_command-match.test.sh` at **358** assertions. It is a step CI already runs. (An earlier draft said "70 assertions in its heaviest suite" — that was the LAST tally printed, not the largest; caught by the spec reviewer.)

### 3. The known-limit comment's reasoning did not cover its own sharp edge

`tests/unit/no-control-bytes.test.ts` is the documented repo-wide-scanner carve-out ("CI remains the backstop there"), and that reasoning speaks only of control bytes, which are rare. Verified the `.gif`-only state before touching it:

```
$ grep -n 'excludedExts' tests/unit/no-control-bytes.test.ts    # before this PR
139:    expect(excludedExts).toEqual(['.gif']);
$ git ls-files | grep -iE '\.(png|jpe?g|gif|ico|bmp|webp|woff2?|ttf|otf|pdf|zip|mp4)$'
assets/cdkl-invoke.gif
assets/cdkl-start-api.gif
assets/cdkl-studio.gif
```

So committing ANY new binary asset anywhere -- a `.png` screenshot, a `.pdf`, a `.woff2` -- reddened the suite. That is ordinary content, not a rare condition.

Relaxed to a subset check against a hand-written `LEGITIMATELY_BINARY` list, spelled **independently of `BINARY_EXT`** (deriving one from the other would make the assertion a tautology). The failure the pin existed to catch -- a TEXT extension entering `BINARY_EXT` and silently shrinking the population -- still fires, on the first file of that extension. Added a population floor (an empty set is a subset of everything) and a guard-the-guard case in the other direction, since a subset check alone cannot see an over-broad entry.

### The predicate, written down

Recorded in `.markgate.yml` beside the carve-out it governs: the useful distinction is **not** "repo-wide vs finite" but **does the assertion fire on a RARE condition, or on ORDINARY content?** A whole-tree scanner is a proportionate carve-out only while its predicate is rare; one whose predicate is ordinary content must have its population inside the include, or the assertion has to move out of the `check` suite. Item 3 was this repo's near-miss. The worked counter-example where the carve-out fails outright is go-to-k/cdk-real-drift's markdown prose-shape scanner (go-to-k/cdk-real-drift#1837; cdkd mirror go-to-k/cdkd#2381).

### New fence

`tests/unit/gates/markgate-include-globs.test.ts` derives the population from `.markgate.yml` itself, not a hand-kept list, and fails on any include entry matching no file. Three design points, each forced by the review round:

- **The parser REFUSES what it cannot model.** A hand-rolled YAML reader's failure mode is silent truncation: an entry in an unmodelled spelling ends the list, taking every later entry in that gate with it, and the sweep then reports "no dead globs" over a population it never saw. It accepts double-quoted, single-quoted and bare scalars at any indent, allow-lists markgate's own gate keys, and THROWS on anything else. Completeness rather than a count: the parser records which LINES it consumed, and a separate scan matching `^\s+-\s` at any indent fails if any went unconsumed — the two now share no assumption. (Two earlier designs did: a `>= 4 gates / >= 15 entries` floor with 11 entries of slack, then a count against a scan that shared the parser's own six-space assumption, which let a whole gate vanish.)
- **`exclude:` is parsed and refused.** markgate honours it. Measured with one variable changed (include untouched): adding `exclude: ["vite.config.ts"]` to the `check` gate dropped the resolved scope by **exactly one file** and removed `vite.config.ts` from the `--explain` listing, while `markgate config lint --json` reported nothing about it. (The DELTA is the claim; the absolute pair an earlier draft printed here reproduces on no tree, for the reason stated above.) A fence modelling only `include` keeps reporting full coverage while an `exclude` silently subtracts. No gate uses one today; the assertion says so and says what to do first if one ever should. (Cross-lane finding, go-to-k/cdk-real-drift#1838.)
- **Matching is the union of `git ls-files -- ':(glob)X'` and `fs.globSync`**, dead only when both are empty. Neither alone is right: git sees only the index, so an entry like `dist/**` is live for `hash: files` (verified: markgate digests untracked AND gitignored files) and would read as dead; and git's wildmatch has no brace alternation, which markgate's doublestar does.

**Why this is duplicated rather than delegated to markgate.** `markgate config lint --json` is the better instrument and reports exactly this class — the item-1 evidence above is its output. It cannot be the fence that RUNS: `.github/workflows/ci.yml` installs `vp` only, so there is no mise and no markgate binary in CI and a test shelling out to it would fail there. The duplication is declared in the file's docblock rather than hidden. (Reviewer suggestion, declined with evidence.)

## Verification

### A. Marker probe -- seven directions, real rc values, on the shipping tree

`mise exec -- markgate set check`, append one line, then `out=$(mise exec -- markgate verify check 2>&1 >/dev/null); rc=$?`. Restored from a snapshot after each; residue count printed as 0 every time.

| tree | appended to | `rc` | meaning |
|---|---|---|---|
| **pre-fix** | `vite.config.ts` | **0** | THE DEFECT |
| **pre-fix** | `.node-version` | **0** | THE DEFECT |
| **pre-fix** | `.claude/hooks/pr-review-gate.sh` | **0** | THE DEFECT |
| shipping | `vite.config.ts` | **1** | fixed |
| shipping | `.node-version` | **1** | fixed |
| shipping | `.claude/hooks/pr-review-gate.sh` | **1** | fixed |
| shipping | `CHANGELOG.md` | **0** | **negative control** -- out of scope, correctly still fresh |

`CHANGELOG.md` was chosen after checking the include rather than assuming: `README.md` is NOT out of scope in general (it is in the `docs` gate); `CHANGELOG.md` appears in no gate's include at all (`grep -c CHANGELOG .markgate.yml` → 0).

### B. Item 2's behavioural probe -- break an assertion's subject, watch `/check`

Mutation: move `pr-review-gate.sh`'s 1-reviewer floor from `300` to `3000` LOC, so a 300-1000-LOC PR silently drops to `inline`. Receipts: mutated-line count 1, original-line count 0.

```
E1. the OLD /check step list, over the broken tree
    vp run --no-cache check   rc=0
    vp run build              rc=0
    vp run --no-cache test    rc=0   (241 files, 4338 tests at that commit)
    markgate set check        rc=0
    markgate verify check     rc=0   <- FRESH marker over a tree whose own hook
                                        suite is red: THE DEFECT

E2. the NEW /check step 4, same broken tree
    vp run test:hooks         rc=1
    pr-review-gate.test.sh    pass: 46  fail: 8
```

Restore verified in the same run: mutated-line count back to 0, original back to 1, `git status --porcelain` showing only this PR's own files.

### C. Ordinary-content probe for item 3

A 70-byte `.png` written to `docs/`, `git add`ed, and run against both the pre-fix file (`git show origin/main:tests/unit/no-control-bytes.test.ts`, copied beside the real one at the same directory depth so its `REPO_ROOT` resolves) and the fixed one:

```
 ×  [pre-fix]  excludes only the extensions that are genuinely binary
    AssertionError: expected [ '.gif', '.png' ] to deeply equal [ '.gif' ]
 ✓  [fixed]    tests/unit/no-control-bytes.test.ts (7 tests)

 Test Files  1 failed | 1 passed (2)
```

Independently reproduced by the test reviewer. Both probe files removed; `git status --porcelain` clean before committing.

**What the relaxed assertion still catches, since relaxing a cap owes a floor.** Three things replace the one equality pin: (a) the SUBSET check still fires on the FIRST file of a text extension entering `BINARY_EXT`, which is the failure the pin existed for — probed with `yml`, `toml`, `yaml`, `html`, all red; (b) a population FLOOR (`allTracked.length > 500`), because an empty set is a subset of everything; (c) a guard-the-guard in the opposite direction, since a subset check alone cannot see an over-broad list entry.

### D. Mutation probes -- 54 across six rounds

Each probe applies ONE edit (S5 is the deliberate exception -- two coordinated edits), asserts it LANDED, runs the test file, restores from a snapshot, and asserts the restore landed. **Seven are GREEN by design** — a probe set that only ever goes red says nothing about false positives, and three of those seven are configs markgate accepts that an earlier draft of this fence hard-failed.

**Round 1** (7 probes, on the first draft): re-adding the dead `vitest.config.ts` glob; dropping `vite.config.ts` from the include; dropping `.claude/hooks/**`; `/check` losing its `test:hooks` step; the `verify` alias losing it; widening `BINARY_EXT` with the text extension `sh`; widening `LEGITIMATELY_BINARY` with `.sh` alone. All 7 red.

**Round 1 caught a vacuous assertion in this PR's own test.** Probe P4 used `toContain('vp run test:hooks')` and stayed GREEN with the numbered step deleted — the rationale paragraph below the list also spells the command, so the assertion was reading a confluence point. Now anchored to `/^\d+\. \`vp run test:hooks\`/m`.

**Round 2** (15 probes, the evasions the reviewers named, on the rewritten fence):

| probe | mutation | result |
|---|---|---|
| Q1 | a dead glob in ANOTHER gate (`docs`), not `check` | RED |
| Q2 | a dead glob in **single quotes** | RED |
| Q3 | a dead glob **unquoted** | RED |
| Q4 | a whole gate rewritten as a **flow sequence** with a dead entry | RED |
| Q5 | an `exclude:` added, include untouched | RED |
| Q6 | `parseConfig` gutted to return `[]` | RED |
| Q7 | `matchCount` always claims a match | RED |
| Q8 | allow-list widened to a real dead glob | RED |
| Q9 | allow-list widened AND that glob added to the include | RED |
| Q10 | `.claude/rules/hooks.md` stops naming an include entry | RED |
| Q11 | the `verify` task becomes cacheable again | RED |
| Q12 | `ci.yml` stops running `test:hooks` | RED |
| Q13b | `/verify-pr` loses its `test:hooks` **step** | RED |
| Q16 | `/verify-pr` loses its `test:hooks` **table row** | RED |
| Q14 / Q15 | `yml` in `BINARY_EXT`, then in **both** lists | RED / RED |

Q2, Q3 and Q4 were GREEN on the first draft — the reviewers' central blocker, reproduced and then closed. **Q13 was GREEN on the first attempt at the fix**: the P4 confluence-point mistake had recurred one file over, because `/verify-pr`'s output table also names the command. It is now anchored to the step bullet, with a second assertion for the table row (Q16), and both directions probed independently.

**Round 3** (5 probes, after a self-inconsistency the review round could not have seen, because the fence introduced it):

| probe | mutation | result |
|---|---|---|
| Q17 / Q21 | `.github/workflows/ci.yml` dropped from the check include | RED |
| Q20 | the self-scan's extraction regex broken (its floor) | RED |
| Q18 | the rules-doc paragraph re-wrapped, nothing removed | GREEN (correct) |
| Q19 | the rules-doc paragraph stops naming `ci.yml` | RED |

Q17 was **GREEN before commit 3**. The fence's second commit added an assertion that `ci.yml` still runs `test:hooks` — which made `ci.yml` a checker INPUT, so deleting that CI step reds the unit suite while a previously-set marker stays fresh. That is the go-to-k/cdk-local#620 class, re-introduced by the very fence written to close it. `ci.yml` is now in the include, and a self-derived case asserts that every `readFileSync(join(repoRoot, ...))` path in the fence's own source is covered by some `check` include entry — population from the file's source, not a hand-kept list, with its extraction floor probed (Q20).

Q18 exists because the rules-doc assertion was line-sensitive and broke the first time that hard-wrapped paragraph was re-wrapped. It now matches whitespace-normalised text, and the pair Q18/Q19 pins both directions: a re-wrap must NOT fire, a removed entry must.

Q15 is the one the reviewers found circular: on the first draft the guard-the-guard compared `LEGITIMATELY_BINARY` against the ALREADY-`BINARY_EXT`-filtered population, so adding `yaml` to both lists dropped 13 files from the scan and the overlap came back empty — the one case the guard existed for was the one case it could not see. It now judges by CONTENT from the unfiltered index.

**Round 4** (11 probes, the reviewers' round-2 evasions against the rewritten fence):

| probe | mutation | result |
|---|---|---|
| R1 | a 4-space block sequence hiding a dead glob | RED |
| R2 | a bare directory entry (`.claude/agents`, not `/**`) | RED |
| R3 | an 8-space item — **legitimate** | GREEN (correct) |
| R4 | two spaces after the dash — **legitimate** | GREEN (correct) |
| R5 | `requires:` as a block list — **legitimate** | GREEN (correct) |
| R6 | the rules prose INVENTS an entry the config lacks | RED |
| R7 | the coverage predicate stubbed to `true` | RED |
| R8 | a new read spelled with `resolve()` instead of the modelled form | RED |
| R9 | the parser narrowed back to 6-space items only | RED |
| R10 | `ci.yml` dropped from the include | RED |
| R11 | `verify-pr-gate.sh`'s checklist line reverted | GREEN (**unfenced**, see Won't-do) |

R1 and R2 are the reviewers' own blockers, reproduced and closed. R3-R5 matter as much as the red ones: the previous parser HARD-FAILED on all three, which markgate accepts — a fence that blocks a legitimate config is worse than one that misses a bad one, and only a both-directions probe set shows it.

**Two blockers in round 3 were inside round 2's fix**, which is the signal to stop patching and make the artifact CLAIM LESS. Three things were withdrawn rather than fixed: the absolute resolved-scope numbers (unstable by construction — `hash: files` digests untracked content), the pretence that the matcher reproduces markgate's doublestar (it over-approximates, the docblock now says so and names the exact instrument), and the assumption-sharing "independent" scan (replaced by a line-number completeness check that shares nothing).

**The self-scan caught itself twice.** Its equality floor counts read calls in its own source — so spelling the scanned pattern in a comment or an error message counted as a read. Both self-references are gone and the case warns about it. That is the same shape the coordinator flagged from go-to-k/cdk-real-drift#1838: a fence whose extractor scans a population including its own file must exclude itself.

**Round 5** (7 probes, after the third reviewer round found no code blockers but four real holes):

| probe | mutation | result |
|---|---|---|
| S1 | an unknown gate key (`ignore:`) carrying items | RED |
| S2 | `include:` typo'd to `includes:` | RED |
| S3 | one gate's `include:` emptied entirely | RED |
| S4 | the containment filter deleted from `onDiskFiles` | RED |
| S5 | the self-read respelled **and** a smuggled `resolve()` read added (two coordinated edits) | RED |
| S6 | `.claude/CLAUDE.md` drops `.node-version` — **deliberately unfenced prose** | GREEN (see Won't-do) |
| S7 | `requires:` as a block list — **legitimate** | GREEN (correct) |

S4 and S5 are the ones worth naming. **S4's assertion could not fail**: it checked that no `../**` result starts with `..`, but the containment filter it was guarding runs first, so `relative()` can never produce one — deleting the filter left it green. Its premise was false too: Node's glob does not walk upward. It now probes with an absolute pattern and first asserts the raw glob really did yield outside paths. **S5 was a transferable budget**: the read-count equality permits exactly one unmodelled read, so respelling the self-read frees that slot for a smuggled read of a file in no gate — green on two coordinated edits. The self-read's spelling is now pinned.

S1/S2 close the same class one level up, and it is the round-3 retrospective's own lesson turned on itself: unknown gate keys were consumed and DISCARDED, so a typo'd `includes:` took five globs out of the sweep with everything green — and a future markgate key that subtracts from the scope, exactly as `exclude` does, would have arrived the same silent way. The parser now allow-lists markgate's key set.

**Round 6** (9 probes, after the orchestrator's independent 3-axis round):

| probe | mutation | result |
|---|---|---|
| T1 | `check`'s `hash: files` → `git-tree` | RED |
| T2 | `check`'s `hash: files` → `diff` | RED |
| T3 | `base:` added to a `files` gate | RED |
| T4 | `base:` removed from the `diff` gate | RED |
| T5 | `.gitignore` dropped from the include | RED |
| T6 | a new undeclared `execFileSync` read added | RED |
| T7 | `composes:` added to a gate | RED (refused, with the real-key message) |
| T8 | the `verify` command deleted while a comment quotes it | RED |
| T9 | the three demo GIFs untracked | GREEN after / **RED before** (A/B) |

T1 is the round's headline and it is `exclude` one key over. Measured against the pinned markgate 0.4.1 on this tree:

| `hash:` value | `verify check --explain` | `markgate config lint` |
|---|---|---|
| `files` | **983 files** | silent, rc=0 |
| `git-tree` | **1 file** | **silent, rc=0** |
| `diff` | fails to parse | WARNS, rc=1 |
| `worktree` / `content` | fails to parse | WARNS, rc=1 |

Exactly one value collapses a gate quietly, and every assertion in the fence passed underneath it — the entries still parsed, still matched files, still named the right paths. They were simply no longer what the marker digests.

### E. Local checks (shipping tree)

```
vp check --fix          rc=0
vp run --no-cache check rc=0
vp run build            rc=0
vp run --no-cache test  rc=0   Test Files 241 passed (241)
                               Tests 4344 passed (4344)
                               Type Errors no errors
vp run test:hooks       rc=0   all ten suites, 0 fail
```

Markers set from the lane worktree: `check`, `docs`, `verify-pr`.

**CI was RED on an intermediate head and the failing test was this PR's own fence.** It asserted `matchCount('dist/**') > 0` to prove the on-disk arm sees untracked files; `ci.yml` runs `vp run test` BEFORE `vp run build`, so `dist/` does not exist there, and it passed locally only because this machine had a stale build. Found by the test reviewer and by watching CI, not by re-reading the diff. The probe now creates its own file under `node_modules/` and removes it, depending on nothing the tree happens to carry.

## Independent sweep: is the vitest half otherwise clean?

Re-derived rather than relayed. Population from the READ CALLS, not from filenames or comments:

```
$ grep -rlE "readFileSync|readdirSync|execFileSync|execSync|existsSync|globSync|statSync|spawnSync|readFile\(|readdir\(" \
    tests/ src/ --include=*.test.ts | wc -l
29
```

(`-E`, not the escaped-alternation form — an earlier draft of this body pasted it without `-E`, which prints 0. Caught by the spec reviewer.) Measured on the shipping tree; 28 of those predate this PR and the 29th is the fence it adds. Every one was opened and its path expressions read. Result:

| Reader | Path it reads outside `src/**` / `tests/**` | In the include? |
|---|---|---|
| `tests/unit/hooks/gate-if-matchers.test.ts` | `.claude/settings.json` | yes |
| `tests/unit/hooks/pr-inherit-issue-labels.test.ts` | `.github/workflows/pr-inherit-issue-labels.yml` | yes |
| `tests/unit/skills/skill-file-payload.test.ts` | `.claude/skills/*/SKILL.md`, `.claude/skills/*/references/*.md` | yes |
| `tests/unit/skills/work-issues-skill-refs.test.ts` | `.claude/skills/*/SKILL.md`, `.claude/skills/*/references/*.md`, `.claude/agents/*.md`, `.claude/rules/*.md` | yes |
| `tests/unit/no-control-bytes.test.ts` | every tracked text file (`git ls-files`) | documented carve-out (item 3) |

The other 24 read only `src/**` (source-binding greps) or `tests/**` / `mkdtempSync(tmpdir())` fixtures. Cross-checked in the other direction too:

```
$ grep -rnE "mise\.toml|ci\.yml|CONTRIBUTING|node-version|markdownlint|markgate\.yml|vite\.config" \
    tests/ --include=*.test.ts
```

On `origin/main` that returns nothing at all. On the shipping tree the hits are the new fence (which reads five of those on purpose) plus one comment in `tests/unit/no-control-bytes.test.ts`.

**Confirmed clean** for the 28 readers that predate this PR; independently reproduced by the spec reviewer, who re-derived the same five out-of-`src`/`tests` readers from the call sites.

The 29th reader is this PR's own fence, and it is the one that needed work: it reads `.markgate.yml`, `vite.config.ts`, `.claude/rules/hooks.md`, two `SKILL.md` files and `.github/workflows/ci.yml`. Only the last was out of scope, which is why commit 3 exists — see round 3 above. The self-derived case now keeps that true for any reader added later.

One near-miss worth naming: `.markdownlint.json` exists at the root and is NOT in any gate include -- correctly, because nothing in `vp run check` or CI reads it (`grep -rn markdownlint` finds it only under `.vscode/`). That is now stated in `.claude/rules/hooks.md` so the next audit does not re-derive it.

## Stale-prose sweep

Every sentence enumerating the `check` gate's scope or the command list, checked and corrected:

- `.claude/rules/hooks.md` `check-gate` block -- the scope enumeration and the `/check` command list. The prose `Scope:` sentence now names exactly the **16** entries of the include, no more and no fewer, asserted as a SET EQUALITY against a parse of `.markgate.yml` (probes Q10 / R6 cover both directions).
- `.claude/rules/hooks.md` "changes that fall outside both scopes (`.claude/hooks/**`, `.markgate.yml`) need neither" -- **already false before this PR** (go-to-k/cdk-local#624 scoped `.markgate.yml` in and this sentence was not updated), and this PR falsifies the other half too. Rewritten to name what really is outside both, with the drift called out so it is not re-introduced.
- `.claude/rules/hooks.md` `verify-pr-gate` checklist line.
- `.claude/CLAUDE.md` `vp run verify` comment and the "Before opening a PR" bullet (both said `= check + test + build`).
- `.claude/CLAUDE.md` check-gate bullet -- now names the hooks / config edits that need `/check`.
- `.claude/skills/check/SKILL.md`, `.claude/skills/verify-pr/SKILL.md`.
- `.claude/skills/work-issues/references/gates-and-pr.md` (`vp run verify` expansion) and `references/verify.md` (checklist line + a restatement of the `check` include set -- the same file go-to-k/cdk-local#622 had to fix for the same reason).
- `CONTRIBUTING.md` -- the task list, and "CI runs `vp run verify` on Node 20 / 22 / 24", which was false: `check-build-test` runs the four steps on one runner, and the Node 20/22/24 matrix job only builds and smoke-runs `dist/cli.js`.

Three more found by the reviewers and fixed in the second commit:

- `.claude/CLAUDE.md`'s `/verify-pr` checklist line -- a **third** copy of the "typecheck / lint / build / tests" sentence the first commit updated in two other places.
- `.claude/CLAUDE.md`'s one-line description of `ci.yml` ("typecheck + lint + test + build"), which has been missing `test:hooks` since before this PR.
- `.claude/rules/hooks.md`'s "what is left outside both scopes" paragraph. The first commit replaced one stale enumeration with another one that was itself incomplete (omitting `assets/**`, `.node-version`, `.releaserc.json`, `CHANGELOG.md`, `.gitignore`, `.vite-hooks/pre-commit`, and wrongly implying all of `.github/workflows/` is out). It is now stated as a RULE -- a file is outside both scopes when no assertion reads it AND it does not decide what "green" means -- with a few examples marked as examples, and a pointer to `markgate verify check --explain` for settling a borderline case. A list of the complement is the same mechanism that went stale in the first place.

The `check` gate's own scope paragraph is no longer prose-only: `markgate-include-globs.test.ts` fails if it stops naming any include entry (probe Q10).

## Reviewer findings and how each was handled

3-axis tier, recomputed at the final sha `b5bd601`: **loc 1085 >= 1000 AND fc 13 >= 10**, both triggers (no auto-generated files or lockfiles to subtract). No up-bias (no security-surface path) and no down-bias (`.claude/**` and `.markgate.yml` are agent-instruction paths, explicitly excluded from `pr-review-gate.sh`'s down-bias set). Three reviewers were dispatched three times — at `bb11721`, `12d2a50` and `562326c` — because each round's fix changed the artifact enough that binding the marker to an earlier review would have been dishonest.

| finding | handling |
|---|---|
| parser sees ONE YAML spelling; single-quoted / unquoted / flow-sequence entries evade it silently (test + code) | **Fixed** -- strict parse that throws; probes Q2/Q3/Q4 |
| the vacuity floor has 11 entries of slack, so truncation stays invisible (test + code) | **Fixed** -- equality reconciliation against an independent scan; probe Q6 |
| `git ls-files` is the wrong universe for `hash: files` (`dist/**` is live but untracked); no brace alternation (code) | **Fixed** -- union with `fs.globSync`; asserted in the guard-the-guard case |
| `isIgnoredSentinel` exempts every ignored path, incl. a typo'd `dist/index.js` (code) | **Fixed** -- one-element allow-list, itself guarded; probes Q8/Q9 |
| a malformed pathspec escapes as a bare "Command failed" (code) | **Fixed** -- falls through to the on-disk arm |
| `verify` task is cacheable, so the alias can replay a pre-edit green (code) | **Fixed** -- `cache: false`; probe Q11 |
| `.node-version` belongs in scope by the same argument as `.mise.toml` (code) | **Fixed** -- added; marker probe row |
| the guard-the-guard in `no-control-bytes.test.ts` is circular (test + code) | **Fixed** -- content-based judgement from the unfiltered index; probe Q15 |
| `.claude/rules/hooks.md`'s out-of-scope enumeration is incomplete (spec + code) | **Fixed** -- stated as a rule, not a list |
| `.claude/CLAUDE.md`'s `/verify-pr` line and `ci.yml` description are stale (spec) | **Fixed** |
| `/verify-pr`'s output table has no `test:hooks` row (spec) | **Fixed** -- and fenced; probe Q16 |
| `/verify-pr`'s new step, `ci.yml`'s step, and the rules-doc enumeration are unfenced (test) | **Fixed** -- all three now asserted; probes Q10/Q12/Q13b |
| "70 assertions in its heaviest suite" is false; it is 358 (spec) | **Fixed** in this body |
| the "5 gates / 22 entries" comment is wrong (spec + test) | **Fixed** -- the comment is gone; the count it justified was replaced by the line-number completeness check |
| the docblock's "nothing re-reads a gate config" is false -- markgate refuses an all-dead include at `set` time (code) | **Fixed** -- docblock now names `markgate config lint` and states the real gap |
| `export function parseIncludes` has no consumer (test + code) | **Fixed** -- not exported |
| **replace the fence with `markgate config lint --json`** (code, BLOCKER) | **Declined, with evidence.** It is the better instrument and its output is now this PR's item-1 proof, but `ci.yml` installs `vp` only -- no mise, no markgate binary in CI -- so the test would fail there. Duplication declared in the docblock. |

## Retrospective

Five things that surprised this lane. Each is a pattern, not a one-off, so each is recorded where it will fire again.

1. **`markgate verify --explain` prints the resolved scope to STDERR.** The first resolution probe redirected `2>/dev/null` and every count came back `0` -- which read exactly like "these files are out of scope", the answer it was looking for. A measurement taken from the wrong stream is not weak evidence, it is none. Recorded in the fence's docblock beside the numbers it produced, so the next reader knows where they came from.
2. **A `toContain` over a doc or skill file is a confluence point, and this lane hit it TWICE.** The command appears both as the instruction and in the prose explaining the instruction, so deleting the instruction leaves the assertion green (probe P4 in `check/SKILL.md`; then, in the very fix for it, probe Q13 in `verify-pr/SKILL.md`, one file over). Both are now anchored to a structural position -- a numbered step, a table row -- and each position is probed independently. This is the strongest candidate to carry into the sibling repos' `implement.md`, and it is left to the coordinator rather than edited from this lane, since cross-repo skill text needs per-repo verification.
3. **A fence that READS a file becomes a checker input, and can re-introduce the class it was written to close.** Commit 2's `ci.yml` assertion did exactly that (probe Q17, green before commit 3). The generalisable remedy shipped: the fence derives its own read-population from its own source and asserts each path is inside the gate it guards, so this cannot recur silently.
4. **`markgate` honours `gates.<name>.exclude`, and `markgate config lint` is silent about it.** Verified locally with one variable changed. A fence re-implementing a tool's resolution must enumerate the TOOL's config keys, not the keys this repo happens to use today. The fence refuses the key rather than mis-modelling it. (Cross-lane finding from go-to-k/cdk-real-drift#1838.)
5. **An assertion can be structurally incapable of failing, and read exactly like one that works.** Two shipped here: the containment guard ran *after* the filter it was guarding, so deleting the filter left it green; and the read-count budget permitted one unmodelled read, which two coordinated edits could reassign. Neither was found by re-reading the diff — both came from a reviewer deleting the thing the assertion required and watching what happened. The general form: after writing a guard, delete what it protects and confirm it goes red.
6. **A lesson learned in round N is not applied to the artifact that just learned it.** Round 3 concluded "enumerate the TOOL's config keys, not the keys this repo happens to use" and shipped the `exclude:` refusal — while the same parser went on silently discarding every OTHER unknown key, which is the identical hole. Round 4 closed it. When a round produces a general rule, re-read the fix that motivated it against the rule.
7. **A reviewer's fix can be right on the merits and unrunnable.** Delegating to `markgate config lint --json` is genuinely better than a hand-rolled parser -- and impossible, because CI has no markgate. Verified before acting, rather than after. The finding was still worth all of it: the lint output is now this PR's item-1 evidence.

### Round-2 reviewer findings (all three re-dispatched against the delta)

| finding | handling |
|---|---|
| **CI is RED; the fence's `dist/**` probe is not hermetic** (test, BLOCKER) | **Fixed** — self-created probe file under `node_modules/` |
| **4-space block sequence hides dead globs; parser and its "independent" scan share the failing assumption** (code, BLOCKER) | **Fixed** — learned indentation + line-number completeness check; probes R1 / R9 |
| **a bare directory entry (`.claude/agents`) is dead for markgate but live for both arms** (test, BLOCKER) | **Fixed** — its own rule and message; probe R2 |
| **the resolved-scope numbers in the body and docblock match no commit** (spec, BLOCKER) | **Fixed by withdrawal** — the totals are unstable by construction and are gone; the stable per-file counts remain |
| **a fourth copy of the checklist line in `verify-pr-gate.sh`** (spec, BLOCKER) | **Fixed** |
| three legitimate configs hard-fail the parser (code) | **Fixed**; probes R3 / R4 / R5 |
| `globSync` escapes the repo / returns directories (code) | **Fixed** — files-only, containment-filtered |
| the self-read case sees one spelling; its floor has slack (test + code) | **Fixed** — equality against the read-call count, forbidding unmodelled spellings; probe R8 |
| the coverage predicate is unguarded (`() => true` stays green) (test) | **Fixed** — negative control; probe R7 |
| `git check-ignore -v` throws when not ignored, so the crafted message never printed (code) | **Fixed** |
| the rules-doc check is one-directional (code) | **Fixed** — set equality; probe R6 |
| `trackedFiles` spawns git per glob per read (code) | **Fixed** — memoised |
| body: 14 entries → 16; `HEAD~1` → `origin/main`; line 237 → 242; sweep greps missing `-E`; tally list incomplete (spec) | **Fixed** in this body |
| `.markgate.yml` / rules say "no **tracked** file"; matching is tracked ∪ on-disk (spec) | **Fixed** |
| `verify.md`'s scope gloss missing `.node-version` / `ci.yml` (spec) | **Fixed** — now points at the authoritative list instead of copying it |
| `no-control-bytes`'s `judged` floor is thin (only `.gif` of 24 entries present) (test + code) | **Won't-do, recorded** — an extension the repo does not carry excludes nothing, so there is nothing at risk to judge. The floor exists to catch the scan finding NOTHING, and it does. |
| a C0-free binary file would red the content guard (code) | **Won't-do, recorded** — hypothetical on this tree (three `.gif`s, all with control bytes); the remedy would be a heuristic with its own false-positive surface |

### Round-3 reviewer findings (final round, at `562326c`)

Both the code and test reviewers reported **no blockers** — the "claim less" rewrite held under fresh evasions. The spec reviewer's one blocker was body text.

| finding | handling |
|---|---|
| **one absolute resolved-scope total (`981 to 980`) survived the withdrawal** (spec, BLOCKER) | **Fixed** — the claim is now the delta, which reproduces |
| the containment guard is unfalsifiable and its `../**` premise is false (code) | **Fixed** — absolute-pattern probe with its own floor; probe S4 |
| `parseConfig` silently discards unknown gate keys (code) | **Fixed** — allow-list of markgate's key set; probes S1 / S2 |
| the completeness check verifies consumption, not classification (test) | **Fixed by the same allow-list**; probe S2 |
| the self-read budget is transferable across two coordinated edits (test) | **Fixed** — self-read spelling pinned; probe S5 |
| an emptied `include:` passes the global floor (code) | **Fixed** — per-gate floor; probe S3 |
| the docblock over-claims "FORBIDS every other read spelling" (code) | **Fixed** — it is a budget, not a proof, and the text now says which evasions remain |
| `.claude/CLAUDE.md` omits `.node-version` / `ci.yml` from the edits needing `/check` (spec) | **Fixed** — and it now points at the authoritative list rather than being one |
| `.claude/rules/hooks.md` "fails if it stops naming any entry" — it is a set equality (spec) | **Fixed** |
| `check-gate.sh`'s refusal gloss omits the hooks half (spec) | **Fixed** |
| body: the withdrawn design described as current; probe count; `-E`; sweep claims; 11→12 files (spec) | **Fixed** in this body |
| `judged` floor is thin (only `.gif` of 24 entries present) (test + code) | **Won't-do, recorded** — an extension the repo does not carry excludes nothing. The reviewer verified the behaviour empirically: `.rst` in both lists is green while absent and red the moment one file arrives. |
| a bare `readFileSync` alias or an `execFileSync('cat', ...)` still evades the read budget (code) | **Won't-do, recorded** — closing it needs real dataflow analysis; the docblock now states the limit instead of overclaiming |
| gate keys at an indent other than two hard-fail (code) | **Won't-do, recorded** — loud, documented and actionable, which is the direction this fence chooses |

### Round-4 findings (orchestrator's independent 3-axis review, at `b5bd601`)

No blockers. Six findings, all fixed in one commit.

| finding | handling |
|---|---|
| **F1** `hash:`'s VALUE unmodelled — `git-tree` collapses the scope 983 → 1 with `config lint` silent | **Fixed** — `hash` / `base` values parsed; a gate declaring `include:` must use a hasher that reads it; `check` / `docs` pinned to `files`; `base` present iff `hash: diff`. Probes T1-T4 |
| **F2** `.gitignore` is a checker input (`git check-ignore`) outside every gate | **Fixed** — scoped in, plus an `EXTRA_READS` list and an `execFileSync` budget so the next subprocess read cannot slip past. Probes T5 / T6 |
| **C1** the vacuity floor depends on `assets/*.gif`, a directory in no gate | **Fixed by dropping the floor** — it guarded a harmless case; scoping `assets/**` would stale the marker on every demo-GIF change to keep a floor that guards nothing. A/B probe T9 |
| **C2** the allow-list comment claims markgate's key set; it is 6 of 8 | **Fixed** — `composes` / `state_dir` confirmed real and silent (both measured at 983), still REFUSED, with a message saying they are real and what to establish first. Probe T7 |
| **C3** the `verify:` fence is satisfiable by the block's own comment | **Fixed** — anchored on `command:`. Probe T8 |
| **S1** probe S6 points at a Won't-do entry that does not exist | **Fixed** — the entry is now written |
| **S2** the issue claim says "not touching `.claude/hooks/**`" but the PR edits two hooks | **Fixed** — [correction posted](https://github.com/go-to-k/cdk-local/issues/630#issuecomment-5455566329) |
| **S3** the docblock never says why the parser is hand-rolled | **Fixed** — cdk-local has no YAML dependency (both siblings do), so refusal was forced, and it is the stricter option |
| `jq`-absent FAIL-OPEN in `check-gate.sh:47` / `verify-pr-gate.sh:54` (noted, not asked) | **Declined as a follow-up** — see Won't-do |

**The theme, stated because it recurred four times in this one PR.** A new fence is itself a new checker input, and every path it reads — through ANY spelling, not just `readFileSync` — must be inside the gate it guards. Instance 1 was `ci.yml` (caught here, commit 3); instances 2-4 came from review. F2 is the live form of the `readFileSync`-alias evasion that this PR's own Won't-do had called theoretical, sitting thirty lines above the comment conceding it in the abstract. The generalisation now lives in `.markgate.yml` beside the entries, where the next author writing a fence will see it.

## Won't-do

- **A fence asserting the `/check` skill's step list matches CI's `ci.yml` steps in general.** The test now pins each specific fact that goes inert silently (`test:hooks` as a numbered `/check` step, as a `/verify-pr` step, in `/verify-pr`'s table, chained into `verify`, and present in `ci.yml`). A general skill-vs-workflow parser is a second mechanism for a third root cause. Recorded here rather than filed, because nothing is left undone by it.
- **The `jq`-absent fail-open in `check-gate.sh` / `verify-pr-gate.sh`** (raised as "noted, not asked for"). Real: `jq ... || echo ""` yields an empty command, `gate_matches` fails, `exit 0` — while both gates fail CLOSED on a missing `_command-match.sh` and on a missing markgate. It does **not** ride cheaply. It is a behaviour change to the gate hooks themselves, on a path none of this PR's probes exercise, and it needs its own cases in `.claude/hooks/*.test.sh` covering both the jq-present and jq-absent arms for each gate — a different root cause from anything here, and bundling it would put a live gate change inside a PR whose subject is gate SCOPE. Flagged for the maintainer to file separately; this PR touches only one line of help text in each file.
- **Scoping `release.yml` / `pr-title-check.yml`.** Nothing reads them, so an entry would be scope with nothing behind it -- the opposite direction of the same mistake this PR fixes. (`ci.yml` and `pr-inherit-issue-labels.yml` ARE read and ARE scoped.)
- **Fencing `.claude/CLAUDE.md`'s scope prose** (probe S6, green — this is the entry S6 points at). `.claude/rules/hooks.md` carries the authoritative restatement and IS fenced by a set equality against `.markgate.yml`; `CLAUDE.md` now points at it rather than trying to be a second copy. Fencing a second prose copy would make `CLAUDE.md` a checker input for a sentence that is already derived — and this PR's own history is four instances of a fence becoming an unscoped checker input, so adding one to guard a pointer is the wrong trade.
- **Fencing `.claude/hooks/verify-pr-gate.sh`'s checklist line** (probe R11, green). It is the fourth copy of that sentence and was fixed here, but asserting on it would make the hook a checker input for the sake of one line of help text. Stated prose limit, not an oversight.
- **Modelling `exclude:` subtraction in the fence.** No gate declares one, and implementing doublestar subtraction in TypeScript is a second re-implementation of markgate's resolution. The fence REFUSES the shape instead, with a message saying what to do first if one is ever wanted.

Closes #630
