### PR TITLE
chore(work-issues): the pr-review marker is the orchestrator's, a reviewer's worktree copy writes to the live tree, and the treadmill stops at round three

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -14,6 +14,17 @@ You find bugs the implementing agent might have missed. The caller provides a PR
 2. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 3. **Project conventions** — `.claude/CLAUDE.md` at the repo root for ESM `.js` imports, library + CLI dual entry, English-only committed artifacts, etc.
 
+**Never run a WRITING git verb — anywhere, including in a copy.** `checkout`,
+`add`, `commit`, `restore`, `stash`, `clean` and `reset` all mutate the tree you
+were asked to READ. A copy is not an escape: a linked worktree's `.git` is a
+FILE holding `gitdir: <repo>/.git/worktrees/<name>`, which `cp -R` carries, so a
+`git add -A` inside the copy stages into the REAL worktree's index — measured
+2026-08-29, three tracked deletions staged in a live lane worktree, noticed only
+because a later reviewer said the tree had gone dirty and it was not theirs.
+Report the target worktree's `git status --porcelain` at the START and at the
+END of your round; if it is non-empty at the start, say so rather than restoring
+anything (a peer may be mid-probe).
+
 ## Review focus
 
 Read every changed file end-to-end. For each, ask:

--- a/.claude/agents/pr-spec-reviewer.md
+++ b/.claude/agents/pr-spec-reviewer.md
@@ -16,6 +16,17 @@ You verify whether a PR's implementation matches a design doc. The caller provid
 2. **PR diff** — `gh pr diff <N>` for the full diff, `gh pr view <N> --json files -q '.files[].path'` for the file list.
 3. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch — leave the parent worktree on main. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 
+**Never run a WRITING git verb — anywhere, including in a copy.** `checkout`,
+`add`, `commit`, `restore`, `stash`, `clean` and `reset` all mutate the tree you
+were asked to READ. A copy is not an escape: a linked worktree's `.git` is a
+FILE holding `gitdir: <repo>/.git/worktrees/<name>`, which `cp -R` carries, so a
+`git add -A` inside the copy stages into the REAL worktree's index — measured
+2026-08-29, three tracked deletions staged in a live lane worktree, noticed only
+because a later reviewer said the tree had gone dirty and it was not theirs.
+Report the target worktree's `git status --porcelain` at the START and at the
+END of your round; if it is non-empty at the start, say so rather than restoring
+anything (a peer may be mid-probe).
+
 ## Review focus (the ENTIRE scope)
 
 For each D-decision and C-fix in the design doc, verify the implementation matches with a file:line citation. Nothing else. Do NOT comment on:

--- a/.claude/agents/pr-test-reviewer.md
+++ b/.claude/agents/pr-test-reviewer.md
@@ -14,6 +14,17 @@ You verify the test suite actually covers the new behavior. The caller provides 
 2. **Test contents** — `git fetch origin <branch>` then `git show origin/<branch>:tests/<path>`. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 3. **Implementation files** to identify untested branches.
 
+**Never run a WRITING git verb — anywhere, including in a copy.** `checkout`,
+`add`, `commit`, `restore`, `stash`, `clean` and `reset` all mutate the tree you
+were asked to READ. A copy is not an escape: a linked worktree's `.git` is a
+FILE holding `gitdir: <repo>/.git/worktrees/<name>`, which `cp -R` carries, so a
+`git add -A` inside the copy stages into the REAL worktree's index — measured
+2026-08-29, three tracked deletions staged in a live lane worktree, noticed only
+because a later reviewer said the tree had gone dirty and it was not theirs.
+Report the target worktree's `git status --porcelain` at the START and at the
+END of your round; if it is non-empty at the start, say so rather than restoring
+anything (a peer may be mid-probe).
+
 ## Review focus
 
 For each meaningful new behavior in the implementation, find a corresponding test or flag the gap. Specifically watch for:

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -307,15 +307,18 @@ the first two both went red against this repo's own
   the tree used `??` at four sites; widening it surfaced a real unfiled bug.
 
   **But when round three is still ADDING spellings, the instrument is wrong —
-  change it rather than write a better pattern.** Measured 2026-08-29 across
-  go-to-k/cdk-local#630, go-to-k/cdkd#2381 and go-to-k/cdk-real-drift#1838, one
-  defect class in five escalating spellings: a fence over `.markgate.yml` read
-  block items only, so a FLOW list passed; then unquoted keys only, so
-  `"exclude":` passed; then a block scan terminating on `/^ {2}\S/`, which a
-  two-space COMMENT ended early while every case stayed GREEN and markgate
-  really did subtract; then a merge key (`<<: *anchor`) splicing an `exclude`
-  declared on a SIBLING gate. Each round added one more regex. **Three
-  spellings in three rounds is the signal to stop patterning.** Two shapes end
+  change it rather than write a better pattern.** Measured 2026-08-29 in three
+  repos at once, one defect class in a hand-rolled `.markgate.yml` reader.
+  go-to-k/cdkd#2383 tallies its own run as **four spellings across four rounds,
+  each patch moving the hole rather than closing it** — block items only, so a
+  FLOW list passed; then a quoted key; then a multi-line flow list; then a
+  merge key (`<<: *anchor`) splicing an `exclude` declared on a SIBLING gate,
+  which the raw-text tripwire added as that very backstop did not fire on. This
+  repo's own two were different again (go-to-k/cdk-local#631): single-quoted
+  and bare scalars, then a block sequence indented at the PARENT key's column,
+  which a reviewer used to hide three dead globs from a 9/9 green run. Same
+  shape, different spellings — which is the point. **Three spellings in three
+  rounds is the signal to stop patterning.** Two shapes end
   it and neither is a sixth pattern: parse the config with a REAL parser (a
   third-party, versioned library is not the fence checking its own work),
   ALLOW-LIST the tool's own keys, fail CLOSED outside them, and raw-scan the

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -305,6 +305,26 @@ the first two both went red against this repo's own
   `new (await import(…)).STSClient(…)`. go-to-k/cdkd#2111, same shape: a region
   scanner calibrated at 19 hits / zero false positives matched `||` only while
   the tree used `??` at four sites; widening it surfaced a real unfiled bug.
+
+  **But when round three is still ADDING spellings, the instrument is wrong —
+  change it rather than write a better pattern.** Measured 2026-08-29 across
+  go-to-k/cdk-local#630, go-to-k/cdkd#2381 and go-to-k/cdk-real-drift#1838, one
+  defect class in five escalating spellings: a fence over `.markgate.yml` read
+  block items only, so a FLOW list passed; then unquoted keys only, so
+  `"exclude":` passed; then a block scan terminating on `/^ {2}\S/`, which a
+  two-space COMMENT ended early while every case stayed GREEN and markgate
+  really did subtract; then a merge key (`<<: *anchor`) splicing an `exclude`
+  declared on a SIBLING gate. Each round added one more regex. **Three
+  spellings in three rounds is the signal to stop patterning.** Two shapes end
+  it and neither is a sixth pattern: parse the config with a REAL parser (a
+  third-party, versioned library is not the fence checking its own work),
+  ALLOW-LIST the tool's own keys, fail CLOSED outside them, and raw-scan the
+  whole map; or, as here — this repo declares no YAML dependency and adding one
+  so a single fence can read a single config is the worse trade — REFUSE every
+  shape the reader cannot model, which is the STRICTER option, not the weaker
+  one: an unmodelled shape stops the fence instead of passing through it.
+  `tests/unit/gates/markgate-include-globs.test.ts` is the worked example, and
+  it then held against every respelling its reviewers could construct.
 - **Delete the thing the fence REQUIRES, and watch it fail.** A predicate ORing
   whole-file substrings is satisfied by any one of them. A STATEFUL scanner
   fails the same way without any OR: the `#N` scan flipped one `inFence` boolean

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -109,12 +109,12 @@ SCOPED to the delta, whole round's findings at once, not trickled.
   probe. go-to-k/cdkd#2166 carries the worked example (a live arm written,
   passed, mutation-probed, reverted — none rebuilt).
 - **When two reviewers CONTRADICT each other, settle it in the code YOURSELF
-  before forwarding either.** In cdkd the spec reviewer CLEARED what the
-  security reviewer called a blocker on the same lines; the code's own comment
-  settled it. Forwarding both hands the implementer a contradiction with LESS
-  context; forwarding only the reassuring one is how a blocker ships. Routine
-  here (`/review-pr` dispatches 1 or 3 reviewers): read the disputed lines, then
-  say who was right and why.
+  before forwarding either** — forwarding both hands the implementer a
+  contradiction with LESS context than you have, forwarding only the reassuring
+  one is how a blocker ships. In cdkd a spec reviewer CLEARED what a security
+  reviewer called a blocker on the same lines, and the code's own comment
+  settled it. Routine here, since `/review-pr` dispatches 1 or 3 reviewers:
+  read the disputed lines, then say who was right and why.
 - **A diff with no `src/**` change** (docs, skills, rules, hooks, CI, config) is
   EXEMPT from the live-test, and from the integ unless it touches
   `tests/integration/**` — `integ-gate` short-circuits on `src/**` OR
@@ -198,6 +198,50 @@ glob, which missed three resource-owning fixtures — are in `.claude/CLAUDE.md`
 by `integ-gate` (any `src/**` / `tests/integration/**` touch; only `/run-integ`
 sets it), `pr-review-gate` (size / bias tier; only `/review-pr`), and, from a
 side worktree, `gh-pr-merge-worktree-gate` (only `/merge-pr`).
+
+**"Only `/review-pr`" is not the whole rule: `/review-pr` is run by the
+ORCHESTRATOR, and a LANE must never set `pr-review`.** The marker records who
+reviewed what at which sha, so a lane setting it is self-certification — the
+"sub-agent self-review is not independent review" failure, arriving through the
+marker rather than through the review. Measured 2026-08-29: this repo's own
+go-to-k/cdk-local#631 lane set it before any independent review existed, as did
+the sibling go-to-k/cdkd#2383 lane, both reading it as part of finishing rather
+than as merging. Say the marker out loud in the lane's brief, beside "stop at
+merge-ready". The gate is not what breaks: `pr-review-gate.sh` compares the
+recorded `.markgate-pr-review-sha` sentinel against the PR's current HEAD and
+refuses with a `(mismatch)` line, so a lane-set marker does not authorize an
+unreviewed merge; what it destroys is the record.
+
+**And the orchestrator's own review round is not optional because the lane
+already ran one.** A lane's reviewers are its children — same brief, same
+framing — so they clear what the lane already believes. Measured 2 for 2 in
+that run: on go-to-k/cdk-real-drift#1838 the lane's own 3-axis round reported
+clean and an independent 3-axis pass found a HIGH blocker (a flow-style
+`exclude:` a hand-rolled YAML scanner could not see, leaving its "no exclude
+declared" tripwire green while markgate really did subtract); on
+go-to-k/cdkd#2383 the same again one spelling deeper (a merge key splicing an
+`exclude` from a SIBLING gate, invisible to both the parser and a tripwire that
+grepped only the `check` block). Take the tier `/review-pr` gives for YOUR
+pass; a lane's clean round is not a measurement that lowers it.
+
+**A reviewer's scratch COPY of a worktree is not detached from git, so its
+`git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
+holding `gitdir: <repo>/.git/worktrees/<name>`, and `cp -R` carries the
+pointer: every git command inside the copy reads and WRITES the real worktree's
+index and HEAD. Measured 2026-08-29 in the sibling cdkd, where a read-only code
+reviewer copied a lane's worktree, ran `git add -A` there, and staged three
+tracked DELETIONS in the live tree that the lane's next commit would have
+shipped — nothing announced it, because the reviewer believed it was on a copy.
+Two lines therefore belong in every read-only reviewer's brief: **run no
+WRITING git verb** (`add` / `commit` / `restore` / `checkout` / `stash` /
+`clean`) anywhere, copy included, severing the pointer with `rm .git` if you
+must copy at all; and **report the TARGET worktree's `git status --porcelain`
+before AND after the round.** The pair is what makes damage attributable rather
+than a mystery a later agent finds: that incident surfaced only because the
+NEXT reviewer volunteered "the tree went dirty mid-review, not mine", after
+which the responsible one repaired the index with `git restore --staged` (index
+only, never the working tree). This repo runs its lanes in
+`.claude/worktrees/`, so the hazard is identical here.
 
 ### 8-z. When a mutation probe reports NO discrimination
 

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -207,22 +207,29 @@ marker rather than through the review. Measured 2026-08-29: this repo's own
 go-to-k/cdk-local#631 lane set it before any independent review existed, as did
 the sibling go-to-k/cdkd#2383 lane, both reading it as part of finishing rather
 than as merging. Say the marker out loud in the lane's brief, beside "stop at
-merge-ready". The gate is not what breaks: `pr-review-gate.sh` compares the
-recorded `.markgate-pr-review-sha` sentinel against the PR's current HEAD and
-refuses with a `(mismatch)` line, so a lane-set marker does not authorize an
-unreviewed merge; what it destroys is the record.
+merge-ready".
+
+**Do not read the sha binding as a backstop for this.**
+`pr-review-gate.sh` compares the recorded `.markgate-pr-review-sha` sentinel
+against the PR's current HEAD and refuses on a mismatch — which catches a
+marker a later PUSH left behind, not one set by the wrong AGENT. It cannot tell
+who set it; the sentinel is per-worktree, and `/merge-pr` merges from inside
+the feature worktree, so a lane that sets it after its final push produces a
+matching sha and merges unreviewed. go-to-k/cdk-local#631 was 1220 LOC over 13
+files — `3-axis` tier — and merged. The rule is the only thing standing there.
 
 **And the orchestrator's own review round is not optional because the lane
 already ran one.** A lane's reviewers are its children — same brief, same
-framing — so they clear what the lane already believes. Measured 2 for 2 in
-that run: on go-to-k/cdk-real-drift#1838 the lane's own 3-axis round reported
-clean and an independent 3-axis pass found a HIGH blocker (a flow-style
-`exclude:` a hand-rolled YAML scanner could not see, leaving its "no exclude
-declared" tripwire green while markgate really did subtract); on
-go-to-k/cdkd#2383 the same again one spelling deeper (a merge key splicing an
-`exclude` from a SIBLING gate, invisible to both the parser and a tripwire that
-grepped only the `check` block). Take the tier `/review-pr` gives for YOUR
-pass; a lane's clean round is not a measurement that lowers it.
+framing — so the thing they are least able to doubt is the premise the lane
+handed them. Measured on go-to-k/cdkd#2383 (2026-08-29): three rounds of the
+lane's own reviewers each found the next spelling of one defect, and it took an
+independent orchestrator-level round — round 4, A/B-ing the hand-rolled parser
+against the `yaml` library over 15 spellings and then against markgate 0.4.1
+itself — to find the YAML merge key, **the spelling the lane's own raw-text
+tripwire had been added specifically to backstop and did not fire on**. The
+sibling go-to-k/cdk-real-drift#1838 spent its own rounds on the same class.
+Take the tier `/review-pr` gives for YOUR pass: a lane's clean round is
+evidence about the lane's assumptions, not about the diff.
 
 **A reviewer's scratch COPY of a worktree is not detached from git, so its
 `git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
@@ -234,14 +241,17 @@ tracked DELETIONS in the live tree that the lane's next commit would have
 shipped — nothing announced it, because the reviewer believed it was on a copy.
 Two lines therefore belong in every read-only reviewer's brief: **run no
 WRITING git verb** (`add` / `commit` / `restore` / `checkout` / `stash` /
-`clean`) anywhere, copy included, severing the pointer with `rm .git` if you
-must copy at all; and **report the TARGET worktree's `git status --porcelain`
-before AND after the round.** The pair is what makes damage attributable rather
-than a mystery a later agent finds: that incident surfaced only because the
-NEXT reviewer volunteered "the tree went dirty mid-review, not mine", after
-which the responsible one repaired the index with `git restore --staged` (index
-only, never the working tree). This repo runs its lanes in
-`.claude/worktrees/`, so the hazard is identical here.
+`clean`) anywhere, copy included — and if you must copy, copy OUTSIDE every
+repository, since deleting the `.git` file does not detach the copy, it only
+makes discovery walk UPWARD into whatever encloses it; and **report the TARGET
+worktree's `git status --porcelain` before AND after the round.** The pair is
+what makes damage attributable rather than a mystery a later agent finds: that
+incident surfaced only because the NEXT reviewer volunteered "the tree went
+dirty mid-review, not mine", after which the responsible one repaired the index
+with `git restore --staged` (index only, never the working tree). This repo
+runs its lanes in `.claude/worktrees/`, so the hazard is identical — and both
+lines now live in `.claude/agents/pr-*-reviewer.md`, so a dispatch cannot omit
+them.
 
 ### 8-z. When a mutation probe reports NO discrimination
 

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -40,14 +40,21 @@ const skillsDir = join(repoRoot, '.claude', 'skills');
 
 const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 24,816 B (hunt-bugs)
 const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator measured ~7 KB at the split
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 25,748 B (implement.md, post-#627 compression)
+const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 27,474 B (implement.md, 2026-08-29)
 
 // The split skill's stage files must still exist and still carry the moved
 // content. 8 files / ~124 KB at the split; the floor sits far enough below
 // that narrative COMPRESSION stays legal while wholesale deletion fails.
 const SPLIT_SKILLS = ['work-issues'];
 const MIN_REFERENCE_FILES = 6;
-const MIN_REFERENCE_CORPUS_BYTES = 72_000; // re-measured 2026-08-28 after go-to-k/cdk-local#627's compression: corpus 96,422 B; 72,000 also catches hollowing the largest file (96,422 - 25,748 = 70,674 < floor)
+// The floor has a SECOND job beyond "the files still exist": it must sit above
+// `corpus - largest file`, so DELETING the biggest stage file cannot pass. That
+// property decays as the OTHER files grow (it is invariant when the largest one
+// is compressed, since both terms drop together), and it had already decayed:
+// at corpus 101,869 B with implement.md at 27,241 B, 72,000 no longer had it
+// (101,869 - 27,241 = 74,628 > 72,000). Re-measure both numbers whenever a
+// stage file changes size materially -- the property is silent when it lapses.
+const MIN_REFERENCE_CORPUS_BYTES = 78_000; // re-measured 2026-08-29: corpus 102,735 B, largest 27,474 B; 78,000 > 102,735 - 27,474 = 75,261, so hollowing the largest file still fails, with ~24 KB of compression headroom left below the floor
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })


### PR DESCRIPTION
## Summary

Stage-10 retrospective for the `/work-issues` run that landed go-to-k/cdk-local#631, go-to-k/cdkd#2383 and go-to-k/cdk-real-drift#1838 — one root cause fixed in all three repos ("every file the unit suite reads as INPUT must be inside the markgate `check` gate's include, else an edit leaves a recorded marker reporting FRESH while the suite is red").

One PR per repo; the sibling PRs carry the same lessons adapted to their own gates, and one lesson is deliberately absent from cdk-real-drift (it has no review-tier skill and nothing reads that marker).

## What changed, and where it fires

**`references/verify.md`** (section 8):

- **"Only `/review-pr`" was true and insufficient: `/review-pr` is run by the ORCHESTRATOR, and a LANE must never set `pr-review`.** This repo's own go-to-k/cdk-local#631 lane set it before any independent review existed, as did the sibling go-to-k/cdkd#2383 lane. Both read it as part of *finishing* rather than as *merging*, which is why "stop at merge-ready" did not prevent it — so the marker is now named for the lane's brief.

  **And the sha binding is not a backstop for it.** The first draft of this paragraph said it was, and review proved that false: `pr-review-gate.sh` compares `recorded_sha` to `head_sha` and cannot tell WHO set it. Markers and the sentinel are per-worktree, and `/merge-pr` merges from inside the feature worktree — the very worktree a lane sets it in — so a lane that sets it after its final push produces a matching sha and merges unreviewed. go-to-k/cdk-local#631 was 1220 LOC over 13 files, `3-axis` tier, and merged. What the binding catches is a marker a later PUSH left behind. The rule is the only thing standing there.

- **The orchestrator's own review round is not optional because the lane already ran one.** A lane's reviewers are its children — same brief, same framing — so the thing they are least able to doubt is the premise the lane handed them. The measurement is go-to-k/cdkd#2383's own record: three rounds of the lane's reviewers each found the next spelling of one defect, and it took an independent orchestrator-level round to find the YAML merge key — the spelling the lane's own raw-text tripwire had been added specifically to backstop and did not fire on.

- **A reviewer's scratch COPY of a worktree is not detached from git.** A linked worktree's `.git` is a FILE holding `gitdir: <repo>/.git/worktrees/<name>`, so `cp -R` carries the pointer and every git command inside the copy reads and WRITES the real worktree's index and HEAD. Measured in the sibling cdkd this run: a read-only reviewer copied a lane worktree, ran `git add -A` there, and staged three tracked DELETIONS in the live tree that the lane's next commit would have shipped. Nothing announced it; a LATER reviewer noticed the tree had gone dirty and said it was not theirs.

  Two lines therefore belong in every read-only reviewer's brief: no WRITING git verb anywhere (copying outside every repository if you must copy at all — deleting the `.git` file does not detach a copy, it only makes discovery walk UPWARD), and a before/after `git status --porcelain` of the target worktree. This repo runs its lanes in `.claude/worktrees/`, so the hazard is identical here.

**`.claude/agents/pr-{code,spec,test}-reviewer.md`** — because the rule above was REGISTERED in section 8 and executed nowhere. Each agent file now carries it, and the skill text points there rather than restating the mechanism twice.

**`references/implement.md`** (section 5):

- The spelling probe told you to write the defect in every spelling and said nothing about **when to stop**. go-to-k/cdkd#2383 tallies its own run as four spellings across four rounds, each patch moving the hole rather than closing it, ending on a `<<: *anchor` merge key splicing an `exclude` declared on a sibling gate. **This repo's own two were different again** (go-to-k/cdk-local#631): single-quoted and bare scalars, then a block sequence indented at the PARENT key's column, which a reviewer used to hide three dead globs from a 9/9 green run. Same shape, different spellings — which is the point. Three spellings in three rounds is the signal to change instrument.

  This repo's escape is the one worth recording, because it is the one a repo with no YAML dependency can take: `tests/unit/gates/markgate-include-globs.test.ts` REFUSES every shape its reader cannot model rather than adding another pattern, and adding a parser dependency so a single fence can read a single config was judged the worse trade. Refusal is the STRICTER option, not the weaker one — an unmodelled shape stops the fence instead of passing through it.

**`tests/unit/skills/skill-file-payload.test.ts`** — a fence this diff weakened, caught in review. `MIN_REFERENCE_CORPUS_BYTES` has a second job beyond "the files still exist": sitting above `corpus - largest file`, so deleting the biggest stage file cannot pass. This diff's growth silently ended that (corpus 101,869 B with `implement.md` at 27,241 B, so `101,869 - 27,241 = 74,628 > 72,000`). Floor raised to 78,000 against a re-measured corpus of 102,735 B / largest 27,474 B, with the decay condition written down: the property is invariant when the largest file is compressed and erodes when the others grow. Both stale measurements in the comments corrected.

## What was cut to pay for it

The "two reviewers CONTRADICT each other" bullet retold the cdkd incident at length; it now keeps the verdict and drops the retelling, because the new paragraph below it states the rule in full. Per the skill's own section 10-c, near-duplicate siblings blunt each other.

## Test plan

- `vp run check`: 0 errors. `vp run build`: pass.
- `vp run test`: 241 files / 4,345 tests pass, no type errors — including `tests/unit/skills/work-issues-skill-refs.test.ts` (every reference fully qualified as `go-to-k/<repo>#N`) and `tests/unit/skills/skill-file-payload.test.ts`.
- `vp run test:hooks`: rc 0, every suite `fail: 0` (255 `ok` lines).
- `check` and `docs` markers recorded from this worktree, after the review-fix round rather than before it.
- Live-test tier: prose-only diff with no `src/**` path, so the exemption applies in its PROSE arm — every gate, hook, sentinel, path, dependency and issue reference the new text names was resolved against **this** repo's own files by an independent read-only reviewer, claim by claim (the text was adapted from cdkd, where several of those claims differ). It returned one blocker, four minors and one nit; all are fixed in the second commit, and each incident cited was re-read from its own PR/issue body rather than from the number.

## Deliberately not done here

The `pr-review` marker is **not** set on this PR, and this agent is not merging it. That is the first lesson in the diff: the marker belongs to the orchestrator, after the reviewers it dispatched have reported.

## Backlog effect for the whole run

`closed 4 / filed 4 (new 4 / folded 0)` — zero left open, zero `Session-fit: next` deferrals. Closed: go-to-k/cdk-real-drift#1837, go-to-k/cdkd#2381, go-to-k/cdk-local#630, go-to-k/cdkd#2384. Filed = the same four; every one was filed and fixed inside the run, which is why `filed` equals `closed` rather than exceeding it.
