### PR TITLE
chore(hooks): deliver the unmerged-lane warning to the model for your OWN lane, to the user for everyone else's

### DIFF
--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -59,8 +59,11 @@ cd "$REPO" 2>/dev/null || exit 0
 git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 
 # `lane_paths` carries the same rows as `lanes` in a machine-readable form --
-# worktree path, TAB, branch -- so the session's OWN lane can be picked out of
-# them below. These are taken verbatim: measured on macOS 2026-08-30, git
+# BRANCH, TAB, worktree path -- so the session's OWN lane can be picked out of
+# them below. The branch comes FIRST because it is the field that is safe to
+# bound a split by: git refnames may not contain a tab, a space or a backslash,
+# while a worktree PATH may contain all three. Splitting at the first tab
+# therefore yields the whole path, however it is spelled. These are taken verbatim: measured on macOS 2026-08-30, git
 # canonicalises what it hands back, so `git worktree list` reports
 # `/private/var/...` even for a worktree ADDED as `/var/...` or through a
 # symlink, and `rev-parse --show-toplevel` does the same. The uncanonical
@@ -78,7 +81,7 @@ while IFS= read -r wt; do
   [ "${ahead:-0}" -gt 0 ] || continue
   lanes="${lanes}  ${br}  (${ahead} commit(s) ahead, worktree ${wt##*/})
 "
-  lane_paths="${lane_paths}${wt}	${br}
+  lane_paths="${lane_paths}${br}	${wt}
 "
 done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10)}')
 
@@ -162,11 +165,23 @@ session_root=""
 # and never matches -- silently taking the not-mine branch for its OWN lane.
 session_root=$(cd "$session_root" 2>/dev/null && pwd -P) || session_root=$(pwd -P)
 
-# `ENVIRON`, not `-v root=...`: awk expands backslash escapes in a `-v` value,
-# so a worktree path containing a backslash would be compared in a different
-# spelling than the one git reported and never match.
-self_branch=$(printf '%s' "$lane_paths" |
-  root="$session_root" awk -F'\t' '$1 == ENVIRON["root"] { print $2; exit }')
+# Plain shell rather than awk. Every awk spelling of this comparison mangles
+# some path: `-v root=...` expands backslash escapes in the value, and `-F'\t'`
+# splits a path containing a tab into the wrong field. Both are the same class
+# as the space truncation fixed above, and parameter expansion has neither.
+TAB=$(printf '\t')
+self_branch=""
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  row_branch=${row%%"$TAB"*}
+  row_path=${row#*"$TAB"}
+  if [ "$row_path" = "$session_root" ]; then
+    self_branch="$row_branch"
+    break
+  fi
+done <<LANE_ROWS
+$lane_paths
+LANE_ROWS
 
 if [ -n "$self_branch" ]; then
   msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -25,6 +25,15 @@
 # alone separates "there is unmerged work here" from "there is not".
 set -u
 
+# The Stop event's JSON arrives on stdin, and is consumed here rather than
+# lazily: the payload has to be drained whether or not this hook goes on to use
+# it. Two fields are PARSED out of it further down, once a lane has actually
+# been found -- `stop_hook_active` (has the harness already continued this
+# turn?) and `cwd` (which worktree is the session in?). Same `cat` form every
+# other hook here uses -- Claude Code writes the payload and closes the pipe,
+# so this does not block.
+input=$(cat 2>/dev/null || true)
+
 # BASH_SOURCE resolves to whichever checkout this copy of the hook lives in --
 # in a linked worktree that is the LANE, not the main tree. That is fine as a
 # place to run `git` from (every worktree shares one object store and one
@@ -33,6 +42,11 @@ set -u
 # earlier revision skipped exactly that one. Measured from a lane 5 commits
 # ahead: the hook printed nothing. The main tree is excluded by BRANCH below
 # (`main`/`master`), which is the property that actually identifies it.
+#
+# BASH_SOURCE is not banned here, only that USE of it. The same value is the
+# fallback for `session_root` further down, where it answers the opposite
+# question -- which worktree IS the session's -- and being the lane is exactly
+# what makes it the right answer there.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO" 2>/dev/null || exit 0
 
@@ -44,7 +58,17 @@ cd "$REPO" 2>/dev/null || exit 0
 # parenthetical described over-reporting; the parenthetical was the true half.)
 git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 
+# `lane_paths` carries the same rows as `lanes` in a machine-readable form --
+# worktree path, TAB, branch -- so the session's OWN lane can be picked out of
+# them below. These are taken verbatim: measured on macOS 2026-08-30, git
+# canonicalises what it hands back, so `git worktree list` reports
+# `/private/var/...` even for a worktree ADDED as `/var/...` or through a
+# symlink, and `rev-parse --show-toplevel` does the same. The uncanonical
+# spelling in this hook comes from somewhere else entirely -- the `cd ... && pwd`
+# that builds `REPO` from BASH_SOURCE -- which is why `session_root` below is
+# canonicalised and these rows are not.
 lanes=""
+lane_paths=""
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
   br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
@@ -54,19 +78,124 @@ while IFS= read -r wt; do
   [ "${ahead:-0}" -gt 0 ] || continue
   lanes="${lanes}  ${br}  (${ahead} commit(s) ahead, worktree ${wt##*/})
 "
-done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+  lane_paths="${lane_paths}${wt}	${br}
+"
+done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10)}')
 
 [ -n "$lanes" ] || exit 0
 
-msg="WARNING: unmerged lane(s) still open -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
-Each branch below is committed but not on origin/main. If any is YOURS, you are not done: rebase, run the
-gates, open the PR, merge. If one belongs to another session, say which and why, rather than leaving it
-unexplained. And if you are ending the turn with nothing that will re-invoke you, the honest label is
-STOPPED, not WAITING.
-One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
-becomes an ancestor of origin/main and keeps reading as ahead. If a lane below is already merged, the
-remaining work is to remove its worktree and delete the branch -- not to open another PR."
+# Everything past here builds a payload with `python3`. Without it the script
+# would end on a `command not found` and exit 127 -- on every turn, for a hook
+# whose entire job is advisory. Say nothing instead.
+command -v python3 >/dev/null 2>&1 || exit 0
 
-payload=$(printf '%s\n%s' "$msg" "$lanes" |
-  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
-printf '{"systemMessage": %s}' "$payload"
+# Everything below decides WHICH CHANNEL the warning leaves by, and the two are
+# not interchangeable -- on the Stop event they differ in whether the turn ends.
+#
+#   hookSpecificOutput.additionalContext -- delivered to the MODEL, and the turn
+#     CONTINUES so it can act. The installed Claude Code (2.1.251) states both
+#     halves as one sentence: "additionalContext is non-error feedback delivered
+#     to the model; the conversation continues so the model can act on it".
+#   systemMessage -- shown to the USER only ("Display a message to the user (all
+#     hooks)"), and the turn ends normally.
+#
+# There is no third option that reaches the model without continuing the turn,
+# which is the whole reason this hook has to choose. It used to emit
+# `systemMessage` unconditionally, so every word of a message written AT THE
+# AGENT ("you are not done", "the honest label is STOPPED") reached only the
+# party that cannot act on it (go-to-k/cdkd#2389).
+#
+# The split is by OWNERSHIP, because that is what decides whether a continuation
+# buys anything:
+#
+#   this session's own worktree is a lane -> additionalContext. This is the
+#     failure the hook exists for -- ending the turn with your own branch
+#     committed and no PR -- and a nudge the model may simply stop over is
+#     exactly what did not work.
+#   only OTHER worktrees are lanes -> systemMessage. The model cannot act on
+#     someone else's lane, so continuing the turn would buy a second reply that
+#     can only say "not mine". Measured while fixing this: four forced
+#     continuations in one session over ONE lane belonging to another session,
+#     each producing a reply whose entire content was that it was not this
+#     session's to touch. And because this repo SQUASH-merges, a merged branch
+#     reads as ahead forever, so one un-removed worktree would have made that
+#     permanent.
+parsed=$(HOOK_INPUT="$input" python3 -c '
+import json, os
+
+try:
+    data = json.loads(os.environ.get("HOOK_INPUT") or "{}")
+except ValueError:
+    data = {}
+if not isinstance(data, dict):
+    data = {}
+
+# The harness sends a JSON boolean. A STRING "false" is truthy in Python, and
+# reading it as "already continued" would silence the hook permanently, so the
+# textual spellings are folded down here rather than trusted.
+flag = data.get("stop_hook_active")
+if isinstance(flag, str):
+    flag = flag.strip().lower() not in ("", "false", "0", "no")
+print("1" if flag else "0")
+print(data.get("cwd") or "")
+')
+active=$(printf '%s\n' "$parsed" | sed -n 1p)
+hook_cwd=$(printf '%s\n' "$parsed" | sed -n 2p)
+
+# Already nudged once this turn and the model came back to Stop. Saying it again
+# would spin the turn instead of ending it, so stand down.
+[ "$active" = "1" ] && exit 0
+
+# Where is the SESSION? `cwd` from the event payload, resolved to its worktree
+# root. Falling back to this hook copy's own checkout is correct rather than
+# merely convenient: in a linked worktree BASH_SOURCE IS the lane. Note the
+# POLARITY -- an earlier revision used that same path to SKIP a worktree and so
+# went blind to the one case that matters (go-to-k/cdkd#2279); here it IDENTIFIES
+# the lane instead.
+session_root=""
+[ -n "$hook_cwd" ] && session_root=$(git -C "$hook_cwd" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$session_root" ] || session_root="$REPO"
+# `pwd -P` is the load-bearing half. The `git` answers above are already
+# canonical, but the BASH_SOURCE fallback is not: `REPO` is built with `cd ...
+# && pwd`, which keeps the spelling it was reached by, so a session launched
+# through a symlinked worktree path compares a symlink against git's real path
+# and never matches -- silently taking the not-mine branch for its OWN lane.
+session_root=$(cd "$session_root" 2>/dev/null && pwd -P) || session_root=$(pwd -P)
+
+# `ENVIRON`, not `-v root=...`: awk expands backslash escapes in a `-v` value,
+# so a worktree path containing a backslash would be compared in a different
+# spelling than the one git reported and never match.
+self_branch=$(printf '%s' "$lane_paths" |
+  root="$session_root" awk -F'\t' '$1 == ENVIRON["root"] { print $2; exit }')
+
+if [ -n "$self_branch" ]; then
+  msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
+This session's worktree is on '$self_branch', which is committed but not on origin/main, so you are not
+done: rebase, run the gates, open the PR, merge. If you are ending the turn with nothing that will
+re-invoke you, the honest label is STOPPED, not WAITING.
+One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
+becomes an ancestor of origin/main and keeps reading as ahead. If '$self_branch' is already merged, the
+remaining work is to remove its worktree and delete the branch -- not to open another PR.
+Every unmerged lane in this checkout:"
+  channel="ctx"
+else
+  msg="NOTE: unmerged lane(s) exist in this checkout, none of them this session's.
+This session's worktree is not among them, so there is likely nothing here for it to do; they belong to
+other sessions, or are already merged (this repo SQUASH-merges, so a merged branch never becomes an
+ancestor of origin/main and keeps reading as ahead -- clearing one means removing its worktree and
+deleting the branch, not opening another PR).
+Lanes:"
+  channel="sys"
+fi
+
+MSG="$msg
+$lanes" CHANNEL="$channel" python3 -c '
+import json, os
+
+msg = os.environ["MSG"]
+if os.environ["CHANNEL"] == "ctx":
+    payload = {"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": msg}}
+else:
+    payload = {"systemMessage": msg}
+print(json.dumps(payload))
+'

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -333,6 +333,33 @@ check "a spaced path can be the session's own lane" "ctx" "$(channel_of "$out")"
 git -C "$REPO" worktree remove --force "$REPO/wt with space"
 git -C "$REPO" branch -q -D feat/spaced
 
+# --- A worktree path containing a BACKSLASH or a TAB is still matched. Both
+# are legal in a path and neither is legal in a git refname, which is why the
+# row is `branch<TAB>path` and split at the FIRST tab -- the branch side cannot
+# contain one, so whatever follows is the whole path however it is spelled.
+# These fence the two awk spellings that were tried and rejected: `-v root=...`
+# expands backslash escapes in the value (the backslash case), and `-F'\t'`
+# puts a tabbed path in the wrong field (the tab case). Neither was visible to
+# any other case -- both mismatch quietly and fall through to the not-mine
+# branch, which is the safe direction and therefore the silent one. ---
+#
+# The payload is built with `json.dumps`, not `printf`: a literal backslash or
+# tab inside a JSON string is not valid JSON, so hand-formatting one makes the
+# hook fall back to BASH_SOURCE and the case then passes or fails for a reason
+# that has nothing to do with the path. Measured -- both cases failed that way
+# on their first attempt. A real harness escapes these; the fixture must too.
+odd_n=0
+for odd in 'bs\path' "$(printf 'tab\tpath')"; do
+  odd_n=$((odd_n + 1))
+  git -C "$REPO" worktree add -q "$REPO/$odd" -b "feat/odd-$odd_n" HEAD
+  git -C "$REPO/$odd" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+  payload=$(CWD="$REPO/$odd" python3 -c 'import json, os; print(json.dumps({"cwd": os.environ["CWD"]}))')
+  out=$(run_hook "$REPO" "$RUN" "$payload")
+  check "a path with a backslash or tab is the session's own lane [$odd_n]" "ctx" "$(channel_of "$out")"
+  git -C "$REPO" worktree remove --force "$REPO/$odd"
+  git -C "$REPO" branch -q -D "feat/odd-$odd_n"
+done
+
 # --- `stop_hook_active` as the STRING "false" must not silence the hook. Python
 # treats any non-empty string as truthy, so the naive read makes this the same
 # as `true` -- and since a hook that goes quiet still exits 0, the failure looks

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -30,15 +30,59 @@ check() {
   fi
 }
 
-# `lanes_in <output>` -> how many branch lines the payload named.
+# The hook now READS the Stop event's JSON from stdin, so every invocation has
+# to feed it one. Left unfed, `cat` inherits this script's stdin and a case can
+# hang instead of failing -- and a Stop hook that hangs never lets a turn end.
+run_hook() {
+  local dir="$1" hook="$2" stdin="${3-}"
+  [ "$#" -ge 3 ] || stdin='{}'
+  printf '%s' "$stdin" | (cd "$dir" && bash "$hook")
+  # The exit STATUS, parked in a file because every call site is a `$(...)`
+  # subshell. Silence is not the same as success here: on `Stop` a non-zero exit
+  # is a hook ERROR, and the five cases below that assert empty output would all
+  # pass against a hook that crashed before printing. Measured: turning the
+  # three silent `exit 0`s into `exit 1` left the suite green.
+  printf '%s' "$?" > "$RC_FILE"
+}
+
+# `rc_of` -> the status of the most recent run_hook call.
+rc_of() { cat "$RC_FILE"; }
+
+# `lanes_in <output>` -> how many branch lines the payload named, whichever
+# channel carried it. Deliberately channel-AGNOSTIC: the cases below split into
+# two groups, and only one of them is about the channel. Every count assertion
+# is about which BRANCHES got enumerated, and folding the channel into it would
+# make each of those fail for two unrelated reasons at once.
 lanes_in() {
   printf '%s' "$1" | python3 -c '
 import json, sys
 raw = sys.stdin.read()
 if not raw.strip():
     print(0); raise SystemExit
-msg = json.loads(raw)["systemMessage"]
+d = json.loads(raw)
+msg = d.get("hookSpecificOutput", {}).get("additionalContext") or d.get("systemMessage") or ""
 print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
+'
+}
+
+# `channel_of <output>` -> ctx | sys | none | BOTH.
+#
+# On the Stop event the channel IS the behaviour, not a formatting detail:
+# `additionalContext` is delivered to the model and CONTINUES the turn, while
+# `systemMessage` is shown to the user and lets it end. `BOTH` is reported
+# rather than silently preferring one, because a payload carrying both fields
+# would continue the turn AND print to the user -- neither of the two designs
+# below, and something a test that reads only its own key cannot see.
+channel_of() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+if not raw.strip():
+    print("none"); raise SystemExit
+d = json.loads(raw)
+ctx = bool(d.get("hookSpecificOutput", {}).get("additionalContext"))
+sysm = bool(d.get("systemMessage"))
+print("BOTH" if ctx and sysm else "ctx" if ctx else "sys" if sysm else "none")
 '
 }
 
@@ -55,6 +99,8 @@ print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
 SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
+RC_FILE="$SANDBOX/rc"
+
 REPO="$SANDBOX/repo"
 mkdir -p "$REPO/.claude/hooks"
 cp "$HOOK" "$REPO/.claude/hooks/"
@@ -66,28 +112,35 @@ git -C "$REPO" update-ref refs/remotes/origin/main HEAD
 
 # --- SILENT: nothing unmerged. The expensive half to get right, because a
 # false alarm every turn is indistinguishable from noise. ---
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "silent when no worktree exists" "" "$out"
+check "...and silent means exit 0, not a crash" "0" "$(rc_of)"
 
 # --- SILENT: a worktree that is level with origin/main is not a lane. ---
 git -C "$REPO" worktree add -q "$REPO/wt-level" -b feat/level HEAD
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "silent for a worktree with no commits of its own" "" "$out"
 
-# --- SILENT: a DETACHED worktree has no branch to report. ---
+# --- SILENT: a DETACHED worktree has no branch to report. It is committed
+# AHEAD on purpose: added at HEAD and left alone, the ahead-count check already
+# excludes it and the `[ -n "$br" ]` guard this case is named for is never what
+# makes it pass -- measured, deleting that guard left the suite green. Ahead and
+# branchless, the guard is the only thing standing between this and a lane line
+# with an empty branch name. Same trap the `main`/`master` case below documents.
 git -C "$REPO" worktree add -q "$REPO/wt-detached" --detach HEAD
-out=$(cd "$REPO" && bash "$RUN")
-check "silent for a detached worktree" "" "$out"
+git -C "$REPO/wt-detached" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'detached work'
+out=$(run_hook "$REPO" "$RUN")
+check "silent for a detached worktree that is ahead" "" "$out"
 
 # --- FIRES: one lane with a commit of its own. ---
 git -C "$REPO/wt-level" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "names the one lane that is ahead" "1" "$(lanes_in "$out")"
 
 # --- FIRES: counts each lane separately, and still ignores the detached one. ---
 git -C "$REPO" worktree add -q "$REPO/wt-two" -b feat/two HEAD
 git -C "$REPO/wt-two" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
 
 # --- FIRES: run from INSIDE a lane worktree, that lane must still be named. ---
@@ -99,12 +152,17 @@ check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
 # from the other side, by asserting the count is 2 rather than 3.
 mkdir -p "$REPO/wt-two/.claude/hooks"
 cp "$HOOK" "$REPO/wt-two/.claude/hooks/"
-out=$(cd "$REPO/wt-two" && bash "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
 check "names its OWN lane when run from inside it" "2" "$(lanes_in "$out")"
-if printf '%s' "$out" | grep -q 'feat/two'; then
-  pass=$((pass + 1)); printf 'OK   the self-lane is the one named\n'
+# Bind to the SELF line, not to the enumeration. The payload lists every lane,
+# so `grep feat/two` is satisfied by the listing no matter which branch the
+# message calls the session's own -- measured, forcing that line to name
+# `feat/level` instead left the suite green. `-F` plus the trailing comma so
+# `feat/two-x` cannot satisfy it either.
+if printf '%s' "$out" | grep -qF "This session's worktree is on 'feat/two',"; then
+  pass=$((pass + 1)); printf 'OK   the self-lane is the one the message names\n'
 else
-  fail=$((fail + 1)); fail_log+="FAIL the self-lane is not named\n"; printf 'FAIL the self-lane is named\n'
+  fail=$((fail + 1)); fail_log+="FAIL the message names the wrong self-lane\n"; printf 'FAIL the self-lane is the one the message names\n'
 fi
 
 # --- SILENT: the main tree ON `main`, ahead of origin/main, is NOT a lane.
@@ -115,7 +173,7 @@ fi
 # suite at 10/0. Direct commits on `main` are a different problem with its own
 # gate; this hook reports unmerged LANES.
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'on main'
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "the main tree on main is not a lane even when ahead" "2" "$(lanes_in "$out")"
 
 # --- The BRANCH filter, not the path, is what excludes the main tree. Put the
@@ -123,7 +181,7 @@ check "the main tree on main is not a lane even when ahead" "2" "$(lanes_in "$ou
 # other lane; otherwise the two filters mask each other and neither is fenced.
 git -C "$REPO" checkout -q -b feat/main-tree-lane
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "the main tree on a feature branch is a lane too" "3" "$(lanes_in "$out")"
 git -C "$REPO" checkout -q -
 git -C "$REPO" branch -q -D feat/main-tree-lane
@@ -135,6 +193,26 @@ else
   fail=$((fail + 1)); fail_log+="FAIL payload is not valid JSON\n"; printf 'FAIL payload is valid JSON\n'
 fi
 
+# --- SILENT, and exit 0, when `python3` is not installed. Everything past the
+# lane check is built by `python3`, so without the guard the script ends on a
+# `command not found` and returns 127 -- an ERROR reported on every single turn,
+# from a hook whose entire job is advisory. A PATH holding only the other
+# binaries it uses is what makes this measurable; with python3 present the guard
+# can be deleted and the suite stays green. ---
+# The list is every external the hook reaches for BEFORE the guard, `bash` and
+# `env` included -- `PATH=... bash` resolves `bash` through the replaced PATH
+# too, and the shebang is `env bash`. Each of them was added because its absence
+# produced a DIFFERENT failure than the one under test, which is the trap here:
+# a stub PATH that is too small makes the case pass for the wrong reason.
+STUBBIN="$SANDBOX/no-python"
+mkdir -p "$STUBBIN"
+for c in bash env dirname git awk sed cat; do
+  ln -sf "$(command -v "$c")" "$STUBBIN/$c"
+done
+out=$( (cd "$REPO" && printf '%s' '{}' | PATH="$STUBBIN" bash "$RUN"); printf '%s' "$?" > "$RC_FILE")
+check "silent when python3 is unavailable" "" "$out"
+check "...and exits 0 rather than 127" "0" "$(rc_of)"
+
 # --- SILENT: no `origin/main` at all (a fresh clone before the first fetch)
 # must not error or spam. ---
 BARE="$SANDBOX/norem"
@@ -142,8 +220,156 @@ mkdir -p "$BARE/.claude/hooks"
 cp "$HOOK" "$BARE/.claude/hooks/"
 git -C "$BARE" init -q .
 git -C "$BARE" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
-out=$(cd "$BARE" && bash "$BARE/.claude/hooks/$(basename "$HOOK")")
+out=$(run_hook "$BARE" "$BARE/.claude/hooks/$(basename "$HOOK")")
 check "silent when origin/main is unresolvable" "" "$out"
+check "...and that too is exit 0" "0" "$(rc_of)"
+
+# Re-run against the two-lane sandbox: the case above left `$out` empty (it ran
+# in the no-remote repo), and an assertion about the payload's SHAPE cannot be
+# made against no payload.
+out=$(run_hook "$REPO" "$RUN")
+check "still names both lanes on re-run" "2" "$(lanes_in "$out")"
+
+# --- CHANNEL: the session's OWN lane reaches the MODEL. `additionalContext` is
+# the only field that does, and it continues the turn so the model can act --
+# which is the failure this hook was written for, an agent ending the turn with
+# its own branch committed and no PR. For months this was `systemMessage`, which
+# the installed Claude Code describes as "Display a message to the user (all
+# hooks)": a message written at the AGENT reached only the party who cannot act
+# on it (go-to-k/cdkd#2389). ---
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
+check "own lane goes to the model" "ctx" "$(channel_of "$out")"
+check "own lane payload still enumerates every lane" "2" "$(lanes_in "$out")"
+if printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+sys.exit(0 if d["hookSpecificOutput"]["hookEventName"] == "Stop" else 1)
+'; then
+  pass=$((pass + 1)); printf 'OK   the hookEventName is Stop\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the hookEventName is not Stop\n"; printf 'FAIL the hookEventName is Stop\n'
+fi
+
+# --- CHANNEL: lanes that belong to SOMEONE ELSE go to the user instead. The
+# model cannot act on another session's worktree, so continuing the turn buys
+# one extra reply that can only say "not mine" -- measured four times in one
+# session while fixing #2389, over a single lane owned by another session. This repo
+# SQUASH-merges, so a merged branch reads as ahead forever and one un-removed
+# worktree would have made that permanent. ---
+out=$(run_hook "$REPO" "$RUN")
+check "other sessions' lanes go to the user" "sys" "$(channel_of "$out")"
+check "the user-facing payload still enumerates them" "2" "$(lanes_in "$out")"
+
+# --- The OWNERSHIP test reads `cwd` out of the event payload, not just the path
+# the hook was launched from. Run from the main tree while `cwd` names the lane:
+# without reading `cwd` this answers `sys`, so the two cases above cannot see
+# the difference on their own -- each of them has the launch path and `cwd`
+# agreeing, which is exactly the pair that makes either signal look sufficient.
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-two\"}")
+check "cwd naming a lane makes it the session's own" "ctx" "$(channel_of "$out")"
+
+# --- ...and the same field pointing at a NON-lane worktree must NOT. Otherwise
+# "cwd is set" rather than "cwd is a lane" would be what flips the channel, and
+# the case above would pass under a hook that simply believes any cwd. ---
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-detached\"}")
+check "cwd naming a non-lane worktree stays user-facing" "sys" "$(channel_of "$out")"
+
+# --- The session reached through a SYMLINKED spelling of its lane is still the
+# owner of that lane. No `cwd` in the payload, so the BASH_SOURCE fallback is
+# what has to answer -- and that path is built with `cd ... && pwd`, which keeps
+# the spelling it was reached BY, while git reports the real one. Without the
+# canonicalisation this compares a symlink to a real path, never matches, and
+# quietly hands the agent its own lane on the user-only channel.
+#
+# Every other case here is blind to that: git canonicalises both of ITS answers
+# (measured -- a worktree ADDED as `/var/...` is still listed as
+# `/private/var/...`), so the two sides agree no matter what, and dropping the
+# canonicalisation leaves the suite green. ---
+ln -s "$REPO/wt-two" "$SANDBOX/wt-two-link"
+out=$(run_hook "$SANDBOX/wt-two-link" "$SANDBOX/wt-two-link/.claude/hooks/$(basename "$HOOK")")
+check "a symlinked lane path is still the session's own lane" "ctx" "$(channel_of "$out")"
+
+# --- SILENT on the continuation pass. `additionalContext` CONTINUES the turn,
+# so a hook that keeps emitting it turns one nudge into a spin: the model is
+# pushed back to work, reaches Stop again with the same unmerged lane, and is
+# pushed again. The harness marks that second pass with `stop_hook_active`, and
+# standing down on it is what bounds this hook to a single forced continuation.
+# Without this case the loop is unfenced -- every case above passes `{}`, where
+# the flag is absent, so the branch could be deleted and the suite stay green. ---
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")" '{"stop_hook_active": true}')
+check "silent once the harness reports a continuation already happened" "" "$out"
+check "...standing down is exit 0, not a crash" "0" "$(rc_of)"
+
+# --- ...and NOT silent when the flag is present but false, which is the shape
+# every ordinary turn actually sends. A truthiness check that reads the KEY
+# rather than its VALUE would go permanently silent here, and the case above
+# cannot see that -- it only ever sends `true`. ---
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")" '{"stop_hook_active": false}')
+check "fires when the continuation flag is present but false" "2" "$(lanes_in "$out")"
+check "...and still reaches the model, not just the user" "ctx" "$(channel_of "$out")"
+
+# --- A worktree path containing a SPACE is still a lane. `git worktree list
+# --porcelain` prints `worktree <path>` with the path unquoted and unescaped, so
+# reading it with `$2` truncates at the first space; `git -C <truncated>` then
+# fails and the lane is dropped from BOTH the enumeration and the ownership
+# comparison -- the hook goes silent about a lane that exists, which is the one
+# failure direction it must never have. Documented as a fixed class in three
+# sibling hooks here; this one was never converted. ---
+git -C "$REPO" worktree add -q "$REPO/wt with space" -b feat/spaced HEAD
+git -C "$REPO/wt with space" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(run_hook "$REPO" "$RUN")
+check "a worktree path with a space is still enumerated" "3" "$(lanes_in "$out")"
+if printf '%s' "$out" | grep -q 'feat/spaced'; then
+  pass=$((pass + 1)); printf 'OK   the spaced lane is named\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the spaced lane is not named\n"; printf 'FAIL the spaced lane is named\n'
+fi
+
+# --- ...and it can be the session's OWN lane. Enumeration and ownership read
+# the same path through two different paths in the script, so a truncation that
+# still enumerates could break only the comparison. ---
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt with space\"}")
+check "a spaced path can be the session's own lane" "ctx" "$(channel_of "$out")"
+git -C "$REPO" worktree remove --force "$REPO/wt with space"
+git -C "$REPO" branch -q -D feat/spaced
+
+# --- `stop_hook_active` as the STRING "false" must not silence the hook. Python
+# treats any non-empty string as truthy, so the naive read makes this the same
+# as `true` -- and since a hook that goes quiet still exits 0, the failure looks
+# exactly like "no lanes" forever. The boolean cases above cannot see it. ---
+out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "false"}')
+check "the string \"false\" does not count as a continuation" "2" "$(lanes_in "$out")"
+out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "true"}')
+check "the string \"true\" does count as one" "" "$out"
+
+# --- Malformed / absent stdin must not take the warning down with it. The hook
+# reads stdin only to find one flag; a harness that sends nothing parseable is
+# not a reason to go quiet about an unmerged lane. ---
+# The channel is asserted alongside the count, not just the count: an
+# unparseable payload yields no `cwd`, and a hook that fell back to claiming the
+# FIRST lane as the session's own would still enumerate two and pass on the
+# count alone -- measured, that mutation left the suite green.
+out=$(run_hook "$REPO" "$RUN" 'not json at all')
+check "fires when the event JSON is unparseable" "2" "$(lanes_in "$out")"
+check "...and does not claim a lane it cannot attribute" "sys" "$(channel_of "$out")"
+out=$(run_hook "$REPO" "$RUN" '')
+check "fires when stdin is empty" "2" "$(lanes_in "$out")"
+check "...and likewise claims nothing" "sys" "$(channel_of "$out")"
+
+# --- The realistic `cwd`: a session sits SOMEWHERE INSIDE its worktree, rarely
+# at the root. Resolution is via `rev-parse --show-toplevel`, so a subdirectory
+# must attribute the same as the root; a naive string compare would not. ---
+mkdir -p "$REPO/wt-two/src/deep"
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-two/src/deep\"}")
+check "a subdirectory of a lane attributes to that lane" "ctx" "$(channel_of "$out")"
+
+# --- `cwd` in no git repository at all, and `cwd` in the MAIN tree: both are
+# "not a lane of mine", and neither may error out. ---
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$SANDBOX\"}")
+check "cwd outside any repo stays user-facing" "sys" "$(channel_of "$out")"
+check "...and still exits 0" "0" "$(rc_of)"
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO\"}")
+check "cwd in the main tree stays user-facing" "sys" "$(channel_of "$out")"
 
 printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Ports go-to-k/cdkd#2389, where this hook is carried verbatim.

`stop-unmerged-lane-warn.sh` emitted `systemMessage`, which on the `Stop` event
reaches the USER only. Every word of that message is addressed to the AGENT --
"you are not done", "the honest label is STOPPED, not WAITING" -- so the only
party that saw it was the one not being asked to act, while the user got the
same wall of text at the end of every turn.

On `Stop` the fields are not interchangeable, and the difference is behavioural
rather than cosmetic (measured against the installed Claude Code 2.1.251):

| field | who reads it | the turn |
| --- | --- | --- |
| `hookSpecificOutput.additionalContext` | the MODEL | CONTINUES -- it gets another turn to act |
| `systemMessage` | the USER only | ends normally |
| stdout / stderr at exit 0 | nobody (both discarded) | ends normally |

There is no fourth option that reaches the model WITHOUT continuing the turn, so
the hook now chooses by OWNERSHIP:

- **the session's own worktree is a lane** -> `additionalContext`. This is the
  failure the hook exists for.
- **only OTHER worktrees are lanes** -> `systemMessage`. The model cannot act on
  another session's lane, so continuing buys one extra reply that can only say
  "not mine".
- **`stop_hook_active` already set** -> silent, so one nudge never becomes a spin.

Ownership comes from `cwd` in the event payload resolved to its worktree root,
falling back to this hook copy's own checkout. Note the polarity against the
earlier inert-hook defect: the same BASH_SOURCE path that was wrong as a SKIP is
right as an IDENTIFIER.

`additionalContext` unconditionally -- what the issue originally proposed -- was
implemented first and measured: four forced continuations in one session over
ONE lane belonging to another session, each producing a reply whose entire
content was that the lane was not that session's to touch. This repo
squash-merges, so a merged branch reads as ahead forever and one un-removed
worktree would have made that permanent.

## Defects fixed along the way

Each has its own case:

- **`awk '/^worktree /{print $2}'` truncated a worktree path at the first
  space**, dropping that lane from BOTH the enumeration and the ownership match
  -- the hook went silent about a lane that exists, which is the one failure
  direction it must never have.
- **No `python3` on PATH** ended the script on `command not found`, i.e. exit
  127 reported on every turn from an advisory hook.
- **`"stop_hook_active": "false"`** as a JSON string is truthy in Python and
  would have silenced the hook permanently.
- The ownership match is plain parameter expansion rather than `awk`: a `-v`
  value expands backslash escapes and `-F'\t'` mis-splits a path containing a
  tab -- both the space bug in different clothes. The row is `branch<TAB>path`
  because a git refname may not contain a tab, a space or a backslash while a
  path may contain all three.

## Test plan

Suite **17 -> 43 cases**, green under both `bash` 5.x and macOS `/bin/bash` 3.2,
alongside every other hook suite in this repo under both, plus this repo's own
`vp run check` / `build` / `test`.

Three ORIGINAL cases were measured VACUOUS and repaired -- each could have its
guard deleted with the suite staying green: the detached-worktree case never
reached the `[ -n "$br" ]` guard it names (its subject was not ahead), the
self-lane case was satisfied by the lane ENUMERATION rather than by the message
naming the right branch, and the five silent cases asserted empty output with no
exit status, so a hook that crashed before printing passed all of them.

**Mutation probes: 18, all fenced** -- revert-to-`systemMessage`, always-`ctx`,
always-`sys`, ignore `cwd`, claim-the-first-lane, drop the `stop_hook_active`
stand-down, key-presence instead of value truthiness, emit both channels, drop
the `pwd -P` canonicalisation, drop the BASH_SOURCE fallback, revert the awk
`$2` truncation, delete the empty-branch guard, make the silent paths exit 1,
drop the python3 guard, and revert to each rejected awk spelling.

**Live-tested against this repo's real worktrees**, not only the sandbox: `cwd`
= this lane gives `additionalContext`, `cwd` = the main tree gives
`systemMessage`, and own-lane + `stop_hook_active` is silent.

## Won't-do

- `.claude/rules/hooks.md` here declares itself a reference for **PreToolUse**
  hooks and documents no Stop hook at all, so this PR adds no section to it. The
  rationale lives in the hook's own comment block, identical across the three
  repos that carry this hook.
- `input=$(cat ...)` blocks on a stdin that is never closed. It is the form the
  other hooks here already use and the harness always closes the pipe; changing
  it in this one file alone would be inconsistent without being safer.

## Follow-up

The own-lane continuation fires at the end of every turn for the whole life of
the lane, including while legitimately waiting on CI. A possible discriminator
and the argument against it are tracked in go-to-k/cdkd#2391; whatever is decided
there lands in all three repos.
