### PR TITLE
chore(work-issues): when the skill is launched inside a worktree, take the tree it is standing in instead of nesting another

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1295,7 +1295,16 @@ vp run runtime:smoke
   `.claude/worktrees/<branch>/`; use
   `git worktree add .claude/worktrees/<branch> -b <branch> origin/main`
   rather than branching in the main worktree (shared state across
-  parallel agents).
+  parallel agents). **That recipe is the MAIN-CHECKOUT case and is wrong
+  from anywhere else** (go-to-k/cdk-local#635): when the session is ALREADY
+  inside a linked worktree -- an Orca/ADE workspace, or a stray `cd` into an
+  existing lane -- `git worktree add` NESTS one worktree inside another, and
+  deleting the outer workspace takes the inner directory, its uncommitted
+  work and its git registration with it. There, create nothing and remove
+  nothing: work on the branch already checked out, stop `/merge-pr` after
+  step 4, and leave the tree for whoever made it. `/work-issues` computes
+  which case applies before its first stage and `/hunt-bugs` points at that
+  probe; do not re-implement it here.
 
 - **Squash merge only, via `/merge-pr`**: merge every PR with the
   `/merge-pr <N>` skill — it squash-merges (flat history) from inside the

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -130,7 +130,8 @@ none and work on the branch already checked out there** — `git worktree add` r
 from inside a worktree nests one, and deleting the outer workspace takes the
 inner directory, its uncommitted work and its git registration with it
 (go-to-k/cdk-local#635). Compute the mode with the one-line probe in
-`/work-issues` `references/triage.md` section 3, which also carries the
+`.claude/skills/work-issues/references/launch-mode.md`, the file that holds the
+ONLY copy of it; `/work-issues` `references/triage.md` section 3 carries the
 ownership check to run before adopting a tree you did not create. A hunt takes
 one fix at a time, so nothing else about this flow changes — except step 8's
 cleanup. The `mise trust` / `pnpm install` / `vp run build` lines still apply:

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -125,6 +125,17 @@ it, `mise trust && mise install` (a fresh worktree's `.mise.toml` is untrusted, 
 `node_modules`) → `vp run build` (the CLI runs from `dist/` — `node dist/cli.js`,
 or the `cdkl` bin).
 
+**Unless this hunt was LAUNCHED from a linked worktree, in which case create
+none and work on the branch already checked out there** — `git worktree add` run
+from inside a worktree nests one, and deleting the outer workspace takes the
+inner directory, its uncommitted work and its git registration with it
+(go-to-k/cdk-local#635). Compute the mode with the one-line probe in
+`/work-issues` `references/triage.md` section 3, which also carries the
+ownership check to run before adopting a tree you did not create. A hunt takes
+one fix at a time, so nothing else about this flow changes — except step 8's
+cleanup. The `mise trust` / `pnpm install` / `vp run build` lines still apply:
+an adopted workspace may be missing any of them.
+
 ### 2. Scaffold the fixture
 
 Add a fixture under `tests/integration/<name>/` — mirror an existing one
@@ -271,7 +282,7 @@ Sweep every container / network (and any `--from-cfn-stack` stack) — see below
 then set the `/check` + `/check-docs` markers, commit, push, `/run-integ` (the
 `integ` marker), `/verify-pr`, `gh pr create`.
 
-### 8. Merge (via /merge-pr) + remove the worktree
+### 8. Merge (via /merge-pr) + remove the worktree YOU added
 
 Take it all the way to merged — do not leave a green PR hanging:
 
@@ -280,6 +291,11 @@ Take it all the way to merged — do not leave a green PR hanging:
    fatal) and cleans the worktree + local + remote branch in one pass. Do NOT
    hand-run `gh pr merge --squash --delete-branch` from a side worktree — it's
    gate-blocked (`gh-pr-merge-worktree-gate.sh`).
+   **Launched IN-PLACE (step 1): stop `/merge-pr` after its step 4** (confirm
+   `state=MERGED`) and skip its step 5 — `git worktree remove "$WT" --force`
+   would delete the cwd this hunt is running in, and `git branch -D "$BR"` the
+   branch it is standing on. Cleanup of a workspace this run did not create
+   belongs to whoever did; say so in the report instead of doing it.
 2. **Confirm the worktree YOU added is gone** — `/merge-pr` removes it; a
    left-behind worktree is the silent residue of this flow. Check `git worktree
    list` for yours specifically, NOT for a list with only the main checkout in it:
@@ -288,7 +304,9 @@ Take it all the way to merged — do not leave a green PR hanging:
    live peer lane. Confirm it is finished (`git log --oneline -1 <branch>`, then
    `gh pr list --state all --head <branch>` for an OPEN PR) before removing it, and
    leave it alone when in doubt. `git worktree prune` drops entries whose directory
-   is already gone.
+   is already gone. An IN-PLACE hunt added no worktree, so it removes none: its
+   closing check is that the launch tree and its branch are exactly as it found
+   them.
 
 ### 9. Record what you learned
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -19,21 +19,24 @@ and colliding on the same file. The run does not end at the last merge: the retr
 stage folds what this run taught you back into this skill's files, while the
 evidence still exists.
 
-## Launch mode: compute it before stage 0
+## Launch mode: main checkout, or already inside a worktree
 
 Every worktree instruction below assumes the launch location is the MAIN
 checkout. Launched from a linked worktree instead (an Orca/ADE workspace, or a
 session that `cd`-ed into `.claude/worktrees/<x>`), `git worktree add` NESTS a
 worktree inside one, and deleting the outer workspace takes the inner directory,
 its uncommitted work and its git registration with it (go-to-k/cdk-local#635).
-Run the one-line probe at the top of §3, state the answer in the opening report,
-and pass it into every lane dispatch. `IN-PLACE` changes four things and nothing
-else: ONE issue rather than a batch (§3); create no worktree, work on the branch
-already checked out here (§5); remove no worktree and delete no branch, so
-`/merge-pr` stops after its step 4 (§9, §10-d); and pull the main checkout
-through `git -C`, because `main` is checked out THERE (§9). Adopting a tree you
-did not create needs the ownership probes in §3 first — a peer's live lane is a
-lane, not a workspace.
+COMPUTE which one you are in AT THE TOP OF STAGE 3: the one-line probe sits
+there (`references/triage.md` holds the ONLY copy of it), and §3 is the first
+place the answer is used. State the answer in the opening report — the first
+message you write after running the probe, before any lane starts — and pass it
+into every lane dispatch. `IN-PLACE` changes four things and nothing else: ONE
+issue rather than a batch (§3); create no worktree, work on the branch already
+checked out here (§5); remove no worktree and delete no branch, so `/merge-pr`
+stops after its step 4 (§9, §10-d); and pull the main checkout through
+`git -C`, because `main` is checked out THERE (§9). Adopting a tree you did not
+create needs the ownership probes in §3 first — a peer's live lane is a lane,
+not a workspace.
 
 ## How this skill is packaged (read this before stage 0)
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -19,6 +19,22 @@ and colliding on the same file. The run does not end at the last merge: the retr
 stage folds what this run taught you back into this skill's files, while the
 evidence still exists.
 
+## Launch mode: compute it before stage 0
+
+Every worktree instruction below assumes the launch location is the MAIN
+checkout. Launched from a linked worktree instead (an Orca/ADE workspace, or a
+session that `cd`-ed into `.claude/worktrees/<x>`), `git worktree add` NESTS a
+worktree inside one, and deleting the outer workspace takes the inner directory,
+its uncommitted work and its git registration with it (go-to-k/cdk-local#635).
+Run the one-line probe at the top of §3, state the answer in the opening report,
+and pass it into every lane dispatch. `IN-PLACE` changes four things and nothing
+else: ONE issue rather than a batch (§3); create no worktree, work on the branch
+already checked out here (§5); remove no worktree and delete no branch, so
+`/merge-pr` stops after its step 4 (§9, §10-d); and pull the main checkout
+through `git -C`, because `main` is checked out THERE (§9). Adopting a tree you
+did not create needs the ownership probes in §3 first — a peer's live lane is a
+lane, not a workspace.
+
 ## How this skill is packaged (read this before stage 0)
 
 This file is a thin orchestrator. The full procedure lives in per-stage files
@@ -44,11 +60,13 @@ and markgate gate fired inside the lane's tool calls exactly as in the parent
   raw backlog listing and issue bodies stay out of the parent context.
 - **Claim (stage 4): the PARENT, never a subagent** — the claim is the lock,
   so it names the session accountable for the lane; it also names the lane
-  branch/worktree the dispatched subagent will create (§4).
+  branch/worktree the dispatched subagent will create (§4) — or, IN-PLACE, the
+  branch already checked out here.
 - **Lanes (stages 5–8): one general-purpose subagent per claimed issue.**
   Dispatch each with the issue number(s), the posted claim, and the stage
   files to read at stage entry (`references/{implement,gates-and-pr,verify}.md`).
-  The lane creates its own worktree per §5, implements (unit + fixture
+  The lane creates its own worktree per §5 — or works in place, so pass the
+  launch mode in the dispatch — implements (unit + fixture
   coverage in the SAME PR, per the never-defer-the-integ invariant), runs
   `/check` + `/check-docs`, opens the PR, dispatches its review tier (a lane
   may spawn reviewer subagents), addresses findings, and drives CI to green —
@@ -81,9 +99,9 @@ the user wants to watch); the stage files apply unchanged either way.
 | 0. Safety screen | `references/triage.md` | Untrusted issues/comments: `author_association` via REST, never download/run third-party content, defer engage/minimize/block to the maintainer |
 | 1. List backlog | `references/triage.md` | REST listing (PR filter, `per_page=100`, `created_at`), volume assessment |
 | 2. Collision landscape | `references/triage.md` | Worktree/branch/PR/ref-recency probes, their pre-first-write blind spot (before a lane's first write, only its §4 claim comment can see it), the shared cross-cutting runtime modules at most one lane may own |
-| 3. Pick file-disjoint issues | `references/triage.md` | Disjointness gate, ranking rules, premise checks against `origin/main`, and §3-a: a FRESH issue belongs to the lane that FILED it (60-minute window) |
+| 3. Pick file-disjoint issues | `references/triage.md` | Launch-mode probe (how many lanes you may take), disjointness gate, ranking rules, premise checks against `origin/main`, and §3-a: a FRESH issue belongs to the lane that FILED it (60-minute window) |
 | 4. Claim | `references/claim.md` | Claim comment BEFORE first edit (English only, like every issue this run files), claim what you FILE too, re-check for a competing claim right before you start |
-| 5. Implement | `references/implement.md` | One worktree per lane, build before first test, sibling-site sweeps, unit + integ in the SAME PR |
+| 5. Implement | `references/implement.md` | One tree per lane, build before first test, sibling-site sweeps, unit + integ in the SAME PR |
 | 6. Gates + PR | `references/gates-and-pr.md` | Gate liveness probe before the session's first commit, `vp run verify`, `/check` + `/check-docs` markers, PR create with `Closes #<n>` |
 | 7. Main advanced | `references/gates-and-pr.md` | Rebase over parallel merges, re-grep what LANDED, run a peer's new repo-wide check over your diff |
 | 8. Verify before merge | `references/verify.md` | `/verify-pr`, `/run-integ`, review tier + reviewer dispatch, live test, §8-z: what a no-discrimination mutation probe actually means |
@@ -102,8 +120,9 @@ the user wants to watch); the stage files apply unchanged either way.
   artifact that proves the lane exists. (§2, §4)
 - **Two lanes never edit the same file**; at most one lane per shared
   cross-cutting runtime module (list in §2). (§3)
-- **Never work in the main checkout** — one worktree per lane under
-  `.claude/worktrees/<branch>/`. (§5)
+- **Never work in the main checkout** — one tree per lane: a new worktree under
+  `.claude/worktrees/<branch>/`, or the launch worktree itself when the mode is
+  IN-PLACE. (§3, §5)
 - **Never defer the integ**: a `src/**` fix ships its Docker/fixture coverage in
   the SAME PR — the `integ` gate enforces it at merge time. (§5, §8)
 - **Merge only via `/merge-pr`** — a hand-run `gh pr merge` from a side worktree

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -8,16 +8,16 @@ argument-hint: "[optional focus, e.g. 'start-alb issues' | '#231 #234' | 'cloudf
 
 Take OPEN issues (usually filed by `/hunt-bugs` — wrong routing, missing env
 injection, container-boot gaps, reload misbehavior) and drive a few of them to
-merged fixes. The differentiator of this skill over just "fix issue #N" is
-**safe, collision-free PARALLELISM**: when there is a backlog and other
-agents/sessions are running, pick issues that cannot step on each other,
-announce which ones you took, and only then start.
+merged fixes. The differentiator over just "fix issue #N" is **safe,
+collision-free PARALLELISM**: with a backlog and other agents running, pick
+issues that cannot step on each other, announce which ones you took, and only
+then start.
 
 The golden rule: **decide the set FIRST, claim it on the issues, THEN edit.** The
-issue comment is the lock — it is what stops two agents from fixing the same thing
-and colliding on the same file. The run does not end at the last merge: the retro
-stage folds what this run taught you back into this skill's files, while the
-evidence still exists.
+issue comment is the lock — what stops two agents fixing the same thing and
+colliding on the same file. The run does not end at the last merge: the retro
+folds what it taught you back into this skill's files, while the evidence still
+exists.
 
 ## Launch mode: main checkout, or already inside a worktree
 
@@ -26,88 +26,99 @@ checkout. Launched from a linked worktree instead (an Orca/ADE workspace, or a
 session that `cd`-ed into `.claude/worktrees/<x>`), `git worktree add` NESTS a
 worktree inside one, and deleting the outer workspace takes the inner directory,
 its uncommitted work and its git registration with it (go-to-k/cdk-local#635).
-COMPUTE which one you are in AT THE TOP OF STAGE 3: the one-line probe sits
-there (`references/triage.md` holds the ONLY copy of it), and §3 is the first
-place the answer is used. State the answer in the opening report — the first
-message you write after running the probe, before any lane starts — and pass it
-into every lane dispatch. `IN-PLACE` changes four things and nothing else: ONE
-issue rather than a batch (§3); create no worktree, work on the branch already
-checked out here (§5); remove no worktree and delete no branch, so `/merge-pr`
-stops after its step 4 (§9, §10-d); and pull the main checkout through
-`git -C`, because `main` is checked out THERE (§9). Adopting a tree you did not
-create needs the ownership probes in §3 first — a peer's live lane is a lane,
-not a workspace.
+
+**The PARENT computes which case applies BEFORE stage 0**: read
+`references/launch-mode.md` and run the probe it holds (the ONLY copy). Before
+stage 0 because §2's collision scan already consumes the answer — IN-PLACE its
+relative `.claude/worktrees/<w>` paths resolve to nothing and it reports an
+empty board, which reads as "no competing agents". In the PARENT because
+stages 0–3 are delegated to a subagent whose return payload carries no git
+state. State all three printed values — `MODE`, which is
+`MAIN-CHECKOUT` or `IN-PLACE`, plus `LANE_TREE` and `MAIN_CHECKOUT` — in the
+opening report, the first message you write after running the probe and before
+any lane starts, and pass them into the triage dispatch and into every lane
+dispatch. That report is their only recorded copy, and §3's ownership anchor
+("STOP unless this is the tree you meant to adopt") needs a comparand — which
+matters more here than in cdkd, the one sibling with a `session-owner`
+sentinel, because this repo has none.
+
+`IN-PLACE` changes a great deal more than the lane count: the collision scan's
+paths, the claim, the branch recipe, the cleanup step, how `main` is reached,
+and where the retro branch is created. `references/launch-mode.md` carries the
+COMPLETE list as a table mapping each consequence to the stage that fires it —
+read it there, and do NOT re-summarise it here. The previous revision of this
+paragraph said "changes four things and nothing else" and named four; an
+undercount in the always-loaded orchestrator wins over the reference file it
+points at, which is the one direction this file must never be wrong in.
 
 ## How this skill is packaged (read this before stage 0)
 
 This file is a thin orchestrator. The full procedure lives in per-stage files
-under `references/`, split so a run loads only the stage it is in instead of the
-whole corpus. **Reading the stage file at stage entry is MANDATORY, not
-optional** — each file carries hard rules and measured failure modes without
-which the stage summary below is not executable. A bare `§N` anywhere in this
-skill points into the file that holds that section (map in the table).
+under `references/`, so a run loads only the stage it is in. **Reading the stage
+file at stage entry is MANDATORY** — each carries hard rules and measured
+failure modes without which the summary below is not executable. A bare `§N`
+points into the file holding that section (map in the table).
 
 **Delegate for context; keep the locks and the serialization in the parent.**
-The placements below are live-proven, not aspirational: on 2026-08-28 this
-repo's own skill-split PR (go-to-k/cdk-local#621) was built END-TO-END by a
-lane subagent — worktree, implementation, gates, reviewer dispatch, CI — with
-the parent doing only claims, serialized merges and cleanup, and every hook
-and markgate gate fired inside the lane's tool calls exactly as in the parent
-(the sibling go-to-k/cdk-real-drift#1831 shipped the same way the same day).
+The placements below are live-proven, not aspirational — §5 carries the run
+that proved them.
 
 - **Triage (stages 0–3): a read-only subagent** (general-purpose or Explore)
   whose prompt is: read `references/triage.md` in full, execute it against
   this repo, and return ONLY the candidate table — per issue: number, title,
   target files, rank + the rule that decided it, collision evidence
-  (worktrees / branches / claims found), and any premise-check findings. The
-  raw backlog listing and issue bodies stay out of the parent context.
+  (worktrees / branches / claims found), and any premise-check findings. Hand
+  it `MODE` / `LANE_TREE` / `MAIN_CHECKOUT` from the probe: §2's worktree scan
+  needs the absolute main checkout, and a read-only subagent cannot return git
+  state the parent does not already hold. The raw backlog listing and issue
+  bodies stay out of the parent context.
 - **Claim (stage 4): the PARENT, never a subagent** — the claim is the lock,
   so it names the session accountable for the lane; it also names the lane
   branch/worktree the dispatched subagent will create (§4) — or, IN-PLACE, the
   branch already checked out here.
 - **Lanes (stages 5–8): one general-purpose subagent per claimed issue.**
   Dispatch each with the issue number(s), the posted claim, and the stage
-  files to read at stage entry (`references/{implement,gates-and-pr,verify}.md`).
-  The lane creates its own worktree per §5 — or works in place, so pass the
-  launch mode in the dispatch — implements (unit + fixture
+  files to read at stage entry (`references/{implement,gates-and-pr,verify}.md`),
+  and the probe's `MODE` / `LANE_TREE` / `MAIN_CHECKOUT`. The lane creates its
+  own worktree per §5 — or works in place — implements (unit + fixture
   coverage in the SAME PR, per the never-defer-the-integ invariant), runs
   `/check` + `/check-docs`, opens the PR, dispatches its review tier (a lane
   may spawn reviewer subagents), addresses findings, and drives CI to green —
   then STOPS at merge-ready and reports back: PR number, HEAD sha, markers
   set, review verdicts, the integ fixture(s) its diff needs, anything
   deferred. Its diffs, test logs and review round-trips never enter the
-  parent context. A lane must NOT start a Docker-side integ run
-  (`/run-integ`, or the `/create-integ` run a new-factory PR needs before
-  `gh pr create` — it asks the parent for that turn mid-lane) or a merge on
-  its own — that is the serialization invariant below, not a capability gap.
+  parent context. A lane must NOT start a Docker-side integ run (`/run-integ`,
+  or the `/create-integ` a new-factory PR needs before `gh pr create`) or a
+  merge on its own — it asks the parent for that turn mid-lane. That is the
+  serialization invariant below, not a capability gap.
 - **Finishing (stage 9): the parent, one lane at a time.** Grant each
   merge-ready lane its turn — resume the lane agent (SendMessage) to run its
-  named integ fixture(s) and `/merge-pr` while it holds the turn, or run
-  `/run-integ` and `/merge-pr` yourself FROM THAT LANE'S WORKTREE (markgate
-  markers are per-worktree, so the `integ` marker must land in the tree the
-  merge is judged from — §9). Post-merge (pull → worktree/branch audit)
-  follows §9.
+  named integ fixture(s) and `/merge-pr` while it holds the turn, or run both
+  yourself FROM THAT LANE'S WORKTREE (markers are per-worktree, so the `integ`
+  one must land in the tree the merge is judged from — §9). Post-merge (pull →
+  worktree/branch audit) follows §9.
 - **Retro (stage 10): a subagent**, dispatched after the last merge with
   `references/retro.md` plus this run's key evidence (what you re-read, what
   the text sent you into, corrections the user made) to measure the backlog
   effect, draft the skill edits, and ship them as the retro PR.
 
-Running a lane in the parent instead stays legal (a single-lane run, or a lane
-the user wants to watch); the stage files apply unchanged either way.
+Running a lane in the parent stays legal (a single-lane run, or one the user
+wants to watch); the stage files apply unchanged either way.
 
 ## Stages
 
 | Stage | File (read at entry) | What it covers |
 |---|---|---|
+| Before 0. Launch mode | `references/launch-mode.md` | The probe (the ONLY copy), reading its three values, why the parent runs it before stage 0, and the table mapping every IN-PLACE consequence to its stage |
 | 0. Safety screen | `references/triage.md` | Untrusted issues/comments: `author_association` via REST, never download/run third-party content, defer engage/minimize/block to the maintainer |
 | 1. List backlog | `references/triage.md` | REST listing (PR filter, `per_page=100`, `created_at`), volume assessment |
-| 2. Collision landscape | `references/triage.md` | Worktree/branch/PR/ref-recency probes, their pre-first-write blind spot (before a lane's first write, only its §4 claim comment can see it), the shared cross-cutting runtime modules at most one lane may own |
-| 3. Pick file-disjoint issues | `references/triage.md` | Launch-mode probe (how many lanes you may take), disjointness gate, ranking rules, premise checks against `origin/main`, and §3-a: a FRESH issue belongs to the lane that FILED it (60-minute window) |
+| 2. Collision landscape | `references/triage.md` | Worktree/branch/PR/ref-recency probes (absolute, via `<MAIN_CHECKOUT>`), their pre-first-write blind spot, the shared cross-cutting runtime modules at most one lane may own |
+| 3. Pick file-disjoint issues | `references/triage.md` | Lane count from the launch mode, ownership probes before adopting a tree, disjointness gate, ranking rules, premise checks against `origin/main`, and §3-a: a FRESH issue belongs to the lane that FILED it (60-minute window) |
 | 4. Claim | `references/claim.md` | Claim comment BEFORE first edit (English only, like every issue this run files), claim what you FILE too, re-check for a competing claim right before you start |
 | 5. Implement | `references/implement.md` | One tree per lane, build before first test, sibling-site sweeps, unit + integ in the SAME PR |
-| 6. Gates + PR | `references/gates-and-pr.md` | Gate liveness probe before the session's first commit, `vp run verify`, `/check` + `/check-docs` markers, PR create with `Closes #<n>` |
+| 6. Gates + PR | `references/gates-and-pr.md` | Gate liveness probe before the first commit, `vp run verify`, `/check` + `/check-docs` markers, PR create with `Closes #<n>` |
 | 7. Main advanced | `references/gates-and-pr.md` | Rebase over parallel merges, re-grep what LANDED, run a peer's new repo-wide check over your diff |
-| 8. Verify before merge | `references/verify.md` | `/verify-pr`, `/run-integ`, review tier + reviewer dispatch, live test, §8-z: what a no-discrimination mutation probe actually means |
+| 8. Verify before merge | `references/verify.md` | `/verify-pr`, `/run-integ`, review tier + reviewer dispatch, live test, §8-z (a no-discrimination mutation probe) |
 | 9. Ship | `references/ship.md` | `/merge-pr` (never a hand-run merge) → pull → worktree cleanup, owner probes before removing a worktree |
 | 10. Retro | `references/retro.md` | Net backlog effect (§10-0), promotion check on this run's `next` filings, where a lesson lands (§10-b/c), ship the retro PR (§10-d) |
 | Appendix | `references/gotchas.md` | Gotchas learned the hard way + the existing rules this skill leans on |
@@ -118,9 +129,9 @@ the user wants to watch); the stage files apply unchanged either way.
   non-maintainer attached or linked — any vector (zip / patch / package /
   `curl | sh`) is the same play. Read bodies via `gh api` only. (§0)
 - **Claim before the first edit, on every issue you take** — and claim what you
-  FILE when this run means to pick it up; re-check for a competing claim right
-  before you start. Before a lane's first write, the claim comment is the ONLY
-  artifact that proves the lane exists. (§2, §4)
+  FILE when this run means to pick it up; re-check right before you start.
+  Before a lane's first write the claim is the ONLY artifact proving it exists.
+  (§2, §4)
 - **Two lanes never edit the same file**; at most one lane per shared
   cross-cutting runtime module (list in §2). (§3)
 - **Never work in the main checkout** — one tree per lane: a new worktree under
@@ -132,11 +143,9 @@ the user wants to watch); the stage files apply unchanged either way.
   is gate-blocked and trips the worktree fatal besides. (§9)
 - **Docker-side integ runs and merges are SERIALIZED across lanes** — the
   parent grants the turn, one lane at a time; a lane subagent never starts
-  `/run-integ`, `/create-integ`, or `/merge-pr` on its own (the flow runs the
-  integ in §8 and the merge in §9). Everything else (edits, unit tests,
-  markers, PR create, reviews, CI) runs concurrently, because markgate
-  markers are per-worktree (`.claude/rules/hooks.md`) — while the Docker
-  daemon is shared host state. (§8, §9)
+  `/run-integ`, `/create-integ`, or `/merge-pr` on its own. Everything else
+  runs concurrently: markgate markers are per-worktree, the Docker daemon is
+  shared host state. (§8, §9)
 - **English only in every published artifact** — issue bodies/comments, PR
   titles/bodies, commits, code. (`.claude/CLAUDE.md`)
 - **The run ends with the retro (stage 10) and the standard wrap report**
@@ -146,11 +155,8 @@ the user wants to watch); the stage files apply unchanged either way.
 
 The retro amends the STAGE FILE the lesson belongs to — `references/<stage>.md`
 — never this orchestrator, unless the stage list itself changed. This file's
-byte size is capped by `tests/unit/skills/skill-file-payload.test.ts`; the cap
-is the mechanical stop on the growth loop that produced the 120 KB predecessor
-of this layout. §10-b/§10-c (in `references/retro.md`) govern how to edit:
-amend in place, escalate a twice-violated sentence to a test or hook, qualify
-every cross-repo issue reference (`go-to-k/cdk-local#N`, never bare `#N` — this
-directory is mirrored into the sibling repos and
-`tests/unit/skills/work-issues-skill-refs.test.ts` enforces it over every
-mirrored `.md` file, the ones here included).
+byte size is capped by `tests/unit/skills/skill-file-payload.test.ts`, the
+mechanical stop on the growth loop that produced the 120 KB predecessor of this
+layout; §10-b/§10-c (in `references/retro.md`) govern how to edit, including the
+qualified-reference rule `tests/unit/skills/work-issues-skill-refs.test.ts`
+enforces over every mirrored `.md` file, the ones here included.

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -9,6 +9,19 @@ the session accountable for the lane — and the claim's `<ref>` names the branc
 holds. Everything else in this section is unchanged, including the re-check for
 a competing claim/PR right before the lane starts.
 
+**An IN-PLACE run names the tree it is STANDING IN** (§3's launch-mode probe):
+the `<ref>` is the branch and worktree already checked out, so read them out of
+git rather than composing a name —
+
+```bash
+git branch --show-current      # the branch the claim must name
+git rev-parse --show-toplevel  # the worktree the claim must name
+```
+
+— because nothing new will be created, and a claim pointing at a worktree that
+never appears is exactly what §9's owner probes misread. Such a run claims ONE
+issue (§3), not a set.
+
 For EACH issue you will start:
 
 ```bash

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -9,18 +9,25 @@ the session accountable for the lane — and the claim's `<ref>` names the branc
 holds. Everything else in this section is unchanged, including the re-check for
 a competing claim/PR right before the lane starts.
 
-**An IN-PLACE run names the tree it is STANDING IN** (§3's launch-mode probe):
-the `<ref>` is the branch and worktree already checked out, so read them out of
-git rather than composing a name —
+**An IN-PLACE run names the tree it is STANDING IN**
+(`references/launch-mode.md`): the `<ref>` is the branch already checked out
+here plus the `LANE_TREE` the probe recorded. Read the BRANCH out of git rather
+than composing a name; take the TREE from the opening report rather than
+re-deriving it with `git rev-parse --show-toplevel`, whose answer follows a cwd
+that may have silently reset to the main checkout —
 
 ```bash
-git branch --show-current      # the branch the claim must name
-git rev-parse --show-toplevel  # the worktree the claim must name
+git -C "<LANE_TREE>" branch --show-current   # the branch the claim must name
 ```
 
 — because nothing new will be created, and a claim pointing at a worktree that
-never appears is exactly what §9's owner probes misread. Such a run claims ONE
-issue (§3), not a set.
+never appears is exactly what §9's owner probes misread.
+
+**An empty branch name means the tree is DETACHED, not that the claim is
+blocked.** The branch is created in §5, after this stage — so write "the branch
+§5 will create in `<LANE_TREE>`" and post the claim on time. A claim delayed
+until a branch exists is a claim posted after the first edit, which is the one
+thing this stage forbids. Such a run claims ONE issue (§3), not a set.
 
 For EACH issue you will start:
 

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -47,7 +47,7 @@ Confirm the TRUE diff and rebase:
 
 ```bash
 git diff --stat $(git merge-base origin/main <branch>)..<branch>   # the real change
-git -C .claude/worktrees/<name> rebase origin/main                 # only SHARED LINES conflict
+git -C <lane tree> rebase origin/main   # .claude/worktrees/<name>, or, IN-PLACE, this tree
 ```
 
 Re-run gates, `git push --force-with-lease`.

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -47,7 +47,7 @@ Confirm the TRUE diff and rebase:
 
 ```bash
 git diff --stat $(git merge-base origin/main <branch>)..<branch>   # the real change
-git -C <lane tree> rebase origin/main   # .claude/worktrees/<name>, or, IN-PLACE, this tree
+git -C "<LANE_TREE>" rebase origin/main   # the path the launch-mode probe recorded
 ```
 
 Re-run gates, `git push --force-with-lease`.

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -22,7 +22,7 @@
   cannot tell a finished lane from a session working right now, already-merged
   branch tip included. The closing check is "mine are gone", not "only main
   remains".
-- **Start every marker / gate command with an explicit `cd <worktree> &&`** — the
+- **Start every marker / gate command with an explicit `cd <lane tree> &&`** — the
   shell cwd does not reliably persist across tool calls, and a `markgate set` /
   sha-sentinel write that lands in the WRONG worktree surfaces later as a
   mystifying `no marker` (each worktree has its own markgate store; fired twice
@@ -52,6 +52,19 @@
   pins all three properties. **The general shape: a gate you have never watched
   go RED is not a gate** — the failure stays invisible until someone types a
   command that should have been blocked and notices it was not.
+- **An IN-PLACE run ends with the Stop hook still calling its lane unmerged, and
+  the remedy it names is one this mode forbids.**
+  `.claude/hooks/stop-unmerged-lane-warn.sh` enumerates every worktree whose
+  branch is ahead of `origin/main`, and this repo SQUASH-merges, so a merged
+  branch reads as ahead forever; because the launch worktree IS the session's,
+  the warning arrives as `additionalContext` — "remove its worktree and delete
+  the branch" — which §3's launch-mode rule forbids here. Expected, not a
+  defect: confirm the PR is MERGED (`gh pr view <n> --json state`) and say so in
+  the wrap. The tree is only clearable from inside by LEAVING the branch —
+  `git switch --detach origin/main`, since the hook skips a detached worktree
+  (`git branch --show-current` is empty) and `main` itself is checked out in the
+  main checkout — and whether to do that belongs to the tool that owns the
+  workspace, not to this run.
 - **A gated command must be the ONLY thing in its Bash call.** A PreToolUse hook
   denial aborts the WHOLE command string BEFORE any line runs — including
   preamble side effects you assumed happened: a blocked
@@ -102,7 +115,9 @@
   messages, issue comments on this repo).
 - **Always add unit tests** for a fix — do not wait to be asked.
 - **All changes via PR; never commit to `main`.** Develop in a git worktree under
-  `.claude/worktrees/<branch>/` with DISJOINT files; merge via `/merge-pr`.
+  `.claude/worktrees/<branch>/` — or, when the run was launched inside a worktree
+  already, in that one (§3's launch-mode probe) — with DISJOINT files; merge via
+  `/merge-pr`.
   (`.claude/CLAUDE.md` → Workflow rules.)
 - **Never defer integration tests to a later PR** — every slice ships its own integ
   coverage green before merge. (`.claude/CLAUDE.md` → Workflow rules.)

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -142,9 +142,14 @@ lines stay exactly as written, and the same two values ride the command as
 
 ```bash
 # A LITERAL path, and no shell variable anywhere in this command. Substitute
-# `<issue-slug>` with something lane-specific (the root cause plus your branch)
-# -- parallel lanes share /tmp, and that uniqueness is the only thing `mktemp`
-# was buying here.
+# `<issue-slug>` per FINDING, not per lane -- the root cause plus your branch.
+# Two reasons, and the second is the one that bites: parallel lanes share /tmp,
+# AND the gate prefers a READABLE file at that path over the heredoc below it.
+# Measured: with a file already there carrying `Dup-check:`, a command whose
+# heredoc omits that line exits 0 and then overwrites it, filing the
+# marker-less body. Reusing one slug for a second finding is exactly how that
+# happens. (The reverse cannot: a blocked call runs nothing, so a marker-less
+# file can only exist if a marked command wrote it.)
 cat > /tmp/wi-issue-body-<issue-slug>.md <<'BODY'
 <one paragraph: the root cause, and where the evidence for it is>
 
@@ -300,7 +305,7 @@ the one the gate missed. This session's hooks lane makes the gate match in
 COMMAND POSITION and judge the matched SEGMENT; driven against that copy the
 chained form is refused (rc=2) and the allowance for `git fetch origin &&
 git switch main` still passes (rc=0). The protection is that FIXED gate. Until
-the hooks lane merges to `main`, re-run `git rev-parse --show-toplevel`
+`fix/body-file-gate-fallback` (go-to-k/cdk-local#637) merges to `main` -- check with `git log origin/main --oneline -1 -- .claude/hooks/main-tree-branch-gate.sh` --, re-run `git rev-parse --show-toplevel`
 immediately before the switch and confirm it is this lane's tree.
 
 **Build BEFORE the first test run, and read a fresh worktree's failures with that

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -141,12 +141,27 @@ lines stay exactly as written, and the same two values ride the command as
 `--label severity:<high|medium|low> --label effort:<small|medium|large>`:
 
 ```bash
-B=$(mktemp)   # assign it HERE and write the body into it -- a separate fenced
-              # block is a separate shell, so a `B` set in an earlier one is
-              # already empty by the time this block runs
+B=$(mktemp)   # assign it HERE and WRITE it before `gh` reads it -- a separate
+              # fenced block is a separate shell, so a `B` set in an earlier one
+              # is already empty by the time this block runs
+cat > "$B" <<'BODY'
+<one paragraph: the root cause, and where the evidence for it is>
+
+Dup-check: searched open issues for <terms> -- none covers this root cause
+Session-fit: next (not this session) -- <reason>
+Severity: high -- <what stays broken while it is undone>
+Effort: large (L) -- <which verification cycle it drags>
+Estimate: ~3 h+ -- <what eats the time>
+BODY
 gh issue create -t 'fix(local): ...' --body-file "$B" \
   --label severity:high --label effort:large
 ```
+
+The `cat` is load-bearing, not filler: `mktemp` creates the file EMPTY, so
+`B=$(mktemp)` followed straight by `--body-file "$B"` files an issue with NO
+body — no `Dup-check:` line, no classification. `heredoc -> file -> --body-file`
+in one call is the mandated shape here, with the delimiter QUOTED so backticks
+and `$` in the body stay literal instead of running.
 
 Prose is invisible to `gh issue list`, so ranking by `Severity` costs one
 `gh issue view` per candidate without labels. Only these two get labels:

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -1,6 +1,6 @@
 <!-- Part of the /work-issues skill. Stage files: triage.md (§0–§3), claim.md (§4), implement.md (§5), gates-and-pr.md (§6–§7), verify.md (§8), ship.md (§9), retro.md (§10), gotchas.md (appendix). A bare §N points into the file that holds that section. READ THIS FILE IN FULL when your run enters this stage. -->
 
-## 5. One worktree per lane, then implement
+## 5. One tree per lane, then implement
 
 This stage (and stages 6–8) normally runs INSIDE a lane subagent the
 orchestrator dispatched — one general-purpose agent per claimed issue, so the
@@ -220,6 +220,13 @@ Never edit in the main checkout (`main-tree-branch-gate.sh` blocks branch creati
 there). Per lane:
 
 ```bash
+# MAIN-CHECKOUT mode only (§3's launch-mode probe). An IN-PLACE run skips these
+# two lines, keeps the tree and branch it was launched in, and creates nothing:
+# a nested worktree dies with the outer workspace, taking its uncommitted work
+# (go-to-k/cdk-local#635). If that branch is detached or its PR already merged,
+# `git switch -c <branch> origin/main` IN THIS TREE instead --
+# `main-tree-branch-gate.sh` fires only when the target dir IS the main tree.
+# The setup lines below still apply: an adopted workspace may be missing them.
 git worktree add .claude/worktrees/<name> -b <branch> origin/main
 cd .claude/worktrees/<name>
 # A fresh worktree's .mise.toml is untrusted, so vp / markgate do not resolve
@@ -240,7 +247,7 @@ reproduced them with its edit stashed, and had begun writing up "a peer merge
 broke main" — one `vp run build` turned them green. **A fresh worktree failing
 where the main checkout passes is evidence about the WORKTREE first.**
 
-Do the fix in the worktree (match the existing module/pattern exactly; ESM
+Do the fix in the lane's tree (match the existing module/pattern exactly; ESM
 relative imports need the `.js` extension even in TS source). **Always add a test
 that fails without the fix and passes with it** — usually a unit test:
 `tests/unit/**` mirrors `src/**`, external boundaries (toolkit-lib, docker CLI,

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -148,8 +148,13 @@ lines stay exactly as written, and the same two values ride the command as
 # Measured: with a file already there carrying `Dup-check:`, a command whose
 # heredoc omits that line exits 0 and then overwrites it, filing the
 # marker-less body. Reusing one slug for a second finding is exactly how that
-# happens. (The reverse cannot: a blocked call runs nothing, so a marker-less
-# file can only exist if a marked command wrote it.)
+# happens. The REVERSE is reachable too, and it costs a FALSE BLOCK: run that
+# same slug a THIRD time with a properly marked heredoc and the gate returns
+# rc=2, because it reads the STALE marker-less file on disk in preference to
+# the heredoc about to replace it -- the refusal is about a stale READABLE
+# file, not a missing marker (measured 2026-09-01, here and in cdkd). Nor does
+# a marker-less file need a gated writer: a plain
+# `cat > /tmp/wi-issue-body-x.md` carries no `gh` verb, so no gate sees it.
 cat > /tmp/wi-issue-body-<issue-slug>.md <<'BODY'
 <one paragraph: the root cause, and where the evidence for it is>
 
@@ -305,8 +310,22 @@ the one the gate missed. This session's hooks lane makes the gate match in
 COMMAND POSITION and judge the matched SEGMENT; driven against that copy the
 chained form is refused (rc=2) and the allowance for `git fetch origin &&
 git switch main` still passes (rc=0). The protection is that FIXED gate. Until
-`fix/body-file-gate-fallback` (go-to-k/cdk-local#637) merges to `main` -- check with `git log origin/main --oneline -1 -- .claude/hooks/main-tree-branch-gate.sh` --, re-run `git rev-parse --show-toplevel`
-immediately before the switch and confirm it is this lane's tree.
+`fix/body-file-gate-fallback` (go-to-k/cdk-local#639) merges to `main`, re-run
+`git rev-parse --show-toplevel` immediately before the switch and confirm it is
+this lane's tree. Ask whether the fix has LANDED by CONTENT, never by the last
+commit subject on the file. That subject today opens
+`fix(hooks): see a gated verb behind if/while/sudo/xargs/case ...`, which reads
+like exactly this command-position fix while that same `main` copy still passes
+the chained form -- believe it and you retire the anchor early:
+
+```bash
+git show origin/main:.claude/hooks/main-tree-branch-gate.sh | grep -c gate_verb_args
+```
+
+`0` means the fix is NOT on `main` and the anchor still stands (measured
+2026-09-01); non-zero means it landed and the anchor can be retired.
+`gate_verb_args` strips the verb off the MATCHED segment, so it exists only in
+the fixed copy -- the same grep against go-to-k/cdk-local#639's head prints 2.
 
 **Build BEFORE the first test run, and read a fresh worktree's failures with that
 in mind.** A worktree starts with no `dist/`; any test spawning the built CLI

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -141,6 +141,9 @@ lines stay exactly as written, and the same two values ride the command as
 `--label severity:<high|medium|low> --label effort:<small|medium|large>`:
 
 ```bash
+B=$(mktemp)   # assign it HERE and write the body into it -- a separate fenced
+              # block is a separate shell, so a `B` set in an earlier one is
+              # already empty by the time this block runs
 gh issue create -t 'fix(local): ...' --body-file "$B" \
   --label severity:high --label effort:large
 ```

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -14,6 +14,14 @@ parent for that turn mid-lane) and the merge (`/merge-pr`) — the
 orchestrator's serialization invariant; §9. A lane stops at merge-ready and
 reports.
 
+That placement is live-proven, not aspirational, and SKILL.md points here for
+the evidence: on 2026-08-28 this repo's own skill-split PR
+(go-to-k/cdk-local#621) was built END-TO-END by a lane subagent — worktree,
+implementation, gates, reviewer dispatch, CI — with the parent doing only
+claims, serialized merges and cleanup, and every hook and markgate gate fired
+inside the lane's tool calls exactly as in the parent (the sibling
+go-to-k/cdk-real-drift#1831 shipped the same way the same day).
+
 **Before fixing, ask whether the defect has SIBLING SITES — and if it does, sweep
 them in THIS lane rather than filing them.** Most defects here are a CLASS, not an
 instance: once the root cause is named, grep for the same shape across `src/`.

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -141,10 +141,11 @@ lines stay exactly as written, and the same two values ride the command as
 `--label severity:<high|medium|low> --label effort:<small|medium|large>`:
 
 ```bash
-B=$(mktemp)   # assign it HERE and WRITE it before `gh` reads it -- a separate
-              # fenced block is a separate shell, so a `B` set in an earlier one
-              # is already empty by the time this block runs
-cat > "$B" <<'BODY'
+# A LITERAL path, and no shell variable anywhere in this command. Substitute
+# `<issue-slug>` with something lane-specific (the root cause plus your branch)
+# -- parallel lanes share /tmp, and that uniqueness is the only thing `mktemp`
+# was buying here.
+cat > /tmp/wi-issue-body-<issue-slug>.md <<'BODY'
 <one paragraph: the root cause, and where the evidence for it is>
 
 Dup-check: searched open issues for <terms> -- none covers this root cause
@@ -153,15 +154,38 @@ Severity: high -- <what stays broken while it is undone>
 Effort: large (L) -- <which verification cycle it drags>
 Estimate: ~3 h+ -- <what eats the time>
 BODY
-gh issue create -t 'fix(local): ...' --body-file "$B" \
+gh issue create -t 'fix(local): ...' \
+  --body-file /tmp/wi-issue-body-<issue-slug>.md \
   --label severity:high --label effort:large
 ```
 
-The `cat` is load-bearing, not filler: `mktemp` creates the file EMPTY, so
-`B=$(mktemp)` followed straight by `--body-file "$B"` files an issue with NO
-body — no `Dup-check:` line, no classification. `heredoc -> file -> --body-file`
-in one call is the mandated shape here, with the delimiter QUOTED so backticks
-and `$` in the body stay literal instead of running.
+**The path is LITERAL because a `$VAR` one cannot be filed at all.**
+`issue-dup-check-gate.sh` reads the command TEXT at PreToolUse time, before any
+of it has run, and refuses a `--body-file` path containing `$` or a backtick
+outright: it cannot open such a file to look for the `Dup-check:` line, and it
+fails closed rather than guessing. Measured 2026-08-31 by driving the hook with
+each payload: the `B=$(mktemp)` + `--body-file "$B"` spelling this section used
+to print returns **rc=2 in all three repos** (cdk-local, cdkd, cdk-real-drift),
+so the body it so carefully writes is never filed; the literal-path form above
+returns **rc=0** from both gates that see it here (`issue-dup-check-gate.sh` and
+`issue-classification-label-gate.sh`). Deleting just the `Dup-check:` line from
+the literal form returns rc=2 again, so that rc=0 is the gate passing a good
+command, not the gate failing to look.
+
+**The FOLD recipe above keeps `mktemp`, and that asymmetry is the gate set, not
+taste.** Folding runs `gh issue edit`, which `issue-dup-check-gate.sh` does not
+match at all, and the classification gate falls back to reading the command text
+when a path is unresolvable — measured rc=0 from both, same day, same driver.
+Folding also NEEDS a unique file it reads back; minting only needs a name no
+concurrent lane will reuse, which the substituted slug gives.
+
+The `cat` is load-bearing, not filler: an empty file pointed at by
+`--body-file` files an issue with NO body — no `Dup-check:` line, no
+classification — and that spelling is refused for the reason you would expect
+("carries no `Dup-check:` line") rather than for the path. Write the body; do
+not treat the gate as the thing that will notice. `heredoc -> file ->
+--body-file` in one call is the mandated shape here, with the delimiter QUOTED
+so backticks and `$` in the body stay literal instead of running.
 
 Prose is invisible to `gh issue list`, so ranking by `Severity` costs one
 `gh issue view` per candidate without labels. Only these two get labels:
@@ -235,15 +259,15 @@ query), the deferral is sound — put the line in the issue body beside
 `Session-fit`.
 
 Never edit in the main checkout (`main-tree-branch-gate.sh` blocks branch creation
-there). Per lane:
+there — with the coverage limit measured below). Per lane:
 
 ```bash
 # MAIN-CHECKOUT mode only (§3's launch-mode probe). An IN-PLACE run skips these
 # two lines, keeps the tree and branch it was launched in, and creates nothing:
 # a nested worktree dies with the outer workspace, taking its uncommitted work
 # (go-to-k/cdk-local#635). If that branch is detached or its PR already merged,
-# `git switch -c <branch> origin/main` IN THIS TREE instead --
-# `main-tree-branch-gate.sh` fires only when the target dir IS the main tree.
+# take a fresh one IN THIS TREE instead -- the recipe and what does and does not
+# protect it are below this block.
 # The setup lines below still apply: an adopted workspace may be missing them.
 git worktree add .claude/worktrees/<name> -b <branch> origin/main
 cd .claude/worktrees/<name>
@@ -254,6 +278,30 @@ mise trust && mise install
 pnpm install    # worktrees have no node_modules -- and neither may the MAIN checkout
 vp run build    # ...and no dist/ — see below
 ```
+
+**IN-PLACE: if the branch here is detached, or its PR has already merged, take a
+fresh one WITHOUT leaving the tree** — and know what is and is not protecting you
+while you do:
+
+```bash
+git fetch origin && git switch -c <branch> origin/main
+```
+
+The `&&` is deliberate: unchained, a failed `fetch` still branches, off a stale
+`origin/main`. **`main-tree-branch-gate.sh` is the backstop for running that line
+after a cwd reset — but it did NOT cover this spelling until this session's
+hooks change, so do not read the claim as one that always held.** Measured on
+both copies of the hook, 2026-08-31: the version then on `main` skipped to the
+FIRST `git` token, read `git fetch origin && git switch -c ...` as `sub=fetch`,
+fell to a fail-open arm and exited 0 — a BARE `git switch -c <b> origin/main`
+was refused (rc=2) while the chained form THIS FILE PRINTS was not (rc=0), in
+this repo and in cdkd alike, so the spelling the skill prescribes was exactly
+the one the gate missed. This session's hooks lane makes the gate match in
+COMMAND POSITION and judge the matched SEGMENT; driven against that copy the
+chained form is refused (rc=2) and the allowance for `git fetch origin &&
+git switch main` still passes (rc=0). The protection is that FIXED gate. Until
+the hooks lane merges to `main`, re-run `git rev-parse --show-toplevel`
+immediately before the switch and confirm it is this lane's tree.
 
 **Build BEFORE the first test run, and read a fresh worktree's failures with that
 in mind.** A worktree starts with no `dist/`; any test spawning the built CLI

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -1,0 +1,130 @@
+<!-- Part of the /work-issues skill. Stage files: launch-mode.md (before stage 0), triage.md (§0–§3), claim.md (§4), implement.md (§5), gates-and-pr.md (§6–§7), verify.md (§8), ship.md (§9), retro.md (§10), gotchas.md (appendix). A bare §N points into the file that holds that section. READ THIS FILE IN FULL before stage 0. -->
+
+## Launch mode — the PARENT runs this BEFORE stage 0
+
+This is the ONLY copy of the probe. SKILL.md "Launch mode" points here rather
+than restating it, because a second verbatim copy of a command is the drift
+shape §10-b fences elsewhere.
+
+```bash
+[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = true ] \
+  || { echo 'PROBE FAILED: not inside a git work tree -- do not guess the mode'; exit 1; }
+COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
+GITDIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)
+LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
+MAIN_CHECKOUT=$(dirname "$COMMON")
+[ "$GITDIR" = "$COMMON" ] && MODE=MAIN-CHECKOUT || MODE=IN-PLACE
+printf 'MODE=%s\nLANE_TREE=%s\nMAIN_CHECKOUT=%s\n' "$MODE" "$LANE_TREE" "$MAIN_CHECKOUT"
+```
+
+### Why here and not at the top of stage 3
+
+The probe used to sit at the top of §3, on the reasoning that §3 is the first
+place the answer is used. Both halves of that were wrong, and each one alone
+would be enough to move it:
+
+- **Stages 1 and 2 already consume the mode.** §2's collision map runs
+  `git -C .claude/worktrees/<w> log|show|status` — a RELATIVE path, correct
+  only from the main checkout. Run IN-PLACE, the cwd is a lane tree, that path
+  does not exist, git errors, and the scan returns NOTHING. An empty collision
+  map reads as "no competing agents", which is the exact failure §2 exists to
+  prevent, and it fails QUIETLY. `MAIN_CHECKOUT` is what makes that scan
+  absolute, so it has to exist before §2 runs, not after.
+- **Stages 0–3 are DELEGATED to a read-only triage subagent** (SKILL.md), whose
+  return payload is a candidate table — no git state, no paths. An answer
+  computed inside it never reaches the parent, and the parent is the party that
+  later runs `git worktree add` or does not. Computing it in the parent before
+  dispatching anything removes the problem instead of documenting it.
+
+So: run it in the parent, pass `MODE` / `LANE_TREE` / `MAIN_CHECKOUT` into the
+triage dispatch and into every lane dispatch, and state all three in the
+opening report.
+
+### Reading the three values
+
+`GITDIR` equals `COMMON` only in the main checkout — a linked worktree's
+`--git-dir` is `<common-dir>/worktrees/<name>`. `pwd -P` is load-bearing in
+BOTH directions: the main checkout answers `.git` RELATIVELY for both, so an
+unnormalised compare is only accidentally right, and macOS spells `/tmp` as
+`/private/tmp`. Chosen over comparing against the first row of
+`git worktree list --porcelain` because it needs no listing order, no path
+parsing and no awareness of other worktrees.
+
+`MAIN_CHECKOUT` is `dirname "$COMMON"` — the parent of the ONE shared git dir —
+never `pwd` and never `--show-toplevel`, both of which answer "the tree I am
+standing in" and so are exactly wrong in the mode that needs the value.
+
+`LANE_TREE` is "the tree this run stands in", NOT "the lane worktree":
+MAIN-CHECKOUT records the main checkout under it, and the two are equal there.
+IN-PLACE they differ, and that difference is the whole point.
+
+**The guard on the first line is not decoration.** Outside a work tree every
+`git rev-parse` fails and each substitution collapses to the empty string, so
+an unguarded compare tests `""` against `""` and prints MAIN-CHECKOUT — a wrong
+verdict, with a wrong `LANE_TREE` beside it. Measured 2026-08-31, the shells
+even disagreed about the wreckage: bash REFUSES `cd ""` (rc=1) while zsh
+accepts it (rc=0) and prints the cwd twice. `--is-inside-work-tree` is compared
+to the literal `true` rather than trusted for its exit status, because inside a
+`.git` directory it prints `false` and exits 0 — measured 2026-09-01; the
+exit-status form passed there and produced an empty `LANE_TREE` under a
+`MAIN-CHECKOUT` verdict. With the value compare, both non-repo positions fail
+loudly in both shells, and the shell divergence stops mattering.
+
+**An empty value is worse than a failed command, which is why the probe stops
+rather than warning.** `git -C "" rev-parse --show-toplevel` exits 0 and prints
+the CWD's repo, so a `git -C "<LANE_TREE>"` recipe handed a blank silently
+retargets whatever tree the shell is standing in — the main checkout, in
+exactly the scenario the `-C` was added for. The guard would degrade into the
+bug it guards, with no failure to read.
+
+### The values are RECORDED, never re-derived
+
+The opening report is their ONLY recorded copy. Every later stage runs in a
+fresh shell whose cwd may have silently reset to the main checkout (appendix,
+the `cd <lane tree> &&` rule), so a stage that re-derives `LANE_TREE` from
+`$(git rev-parse --show-toplevel)` or from `pwd` answers "the main checkout" in
+precisely the case the value exists to guard.
+
+**`<LANE_TREE>` and `<MAIN_CHECKOUT>` in a later stage are SUBSTITUTION
+PLACEHOLDERS, not shell variables.** Paste the absolute path from the opening
+report into the command text. Do NOT write `git -C "$LANE_TREE"`: the
+assignments live in THIS fenced block, and every later block is its own Bash
+call and its own shell (§9 spells the same trap out for `MAIN`), so the variable
+is already empty there — and per the paragraph above, an empty `-C`
+does not fail, it re-targets. A placeholder that was never substituted is
+visible in the command you are about to run; an empty variable is not visible
+anywhere.
+
+**This repo keeps no worktree-owner sentinel** — cdkd's `session-owner` file
+has no counterpart here, and cdk-real-drift has none either — so the recorded
+`LANE_TREE`, the ownership probes in §5 and the §4 claim comments are the WHOLE
+ownership record. That is why the recorded value matters more here than in the
+one sibling that does have the sentinel, not less.
+
+### What IN-PLACE changes, and where each consequence fires
+
+SKILL.md carries the same list in short form; this is the one with the file
+pointers. IN-PLACE means this run was launched inside a worktree someone else
+created (an Orca/ADE workspace, a stray `cd`), so it has exactly ONE working
+tree:
+
+| # | Consequence | Where |
+|---|---|---|
+| 1 | Take ONE issue and finish it — a second lane would need a worktree NESTED inside this one, which dies with the outer workspace and takes its uncommitted work, plus the same-branch double-checkout collision (go-to-k/cdk-local#635) | §3 |
+| 2 | §2's worktree probes take `<MAIN_CHECKOUT>/.claude/worktrees/<w>`, not a relative path | §2 |
+| 3 | The claim names the branch and tree already checked out here, read out of git rather than composed | §4 |
+| 4 | Create no worktree; work on the branch already here, after confirming the tree is YOURS | §5 |
+| 5 | A tree that is DETACHED or whose PR already merged does create a branch — in place, without leaving the tree | §5 |
+| 6 | `/merge-pr` stops once the merge is CONFIRMED: its local-cleanup step (the `git worktree remove` + `git branch -D` one) must not run at all, because a lane that removes the tree it runs in deletes its own cwd | §9 |
+| 7 | `main` is checked out in the main checkout, so `git checkout main && git pull` cannot run here — pull through `git -C "<MAIN_CHECKOUT>"` | §9 |
+| 8 | The retro branch is created in THIS tree, so the run legitimately ends on a branch that is not the one it started on | §10-d |
+
+There is deliberately no rebuild row: this repo's ship stage ends at the pull,
+and users invoke `node dist/cli.js` from their own checkout rather than a
+globally linked binary built in the main tree. The sibling cdkd has that step
+and has to relocate it; do not import it here.
+
+"Four things and nothing else" was the previous count, and it was wrong in the
+direction that matters: this file is not always loaded, SKILL.md is, so an
+undercount in the orchestrator wins over the reference files it points at.
+Count the rows before writing a number beside them.

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -241,9 +241,15 @@ worktree to add, and `git worktree add` from inside this tree NESTS the very
 worktree this mode exists to prevent. There is also no `main` to be back on;
 the lane's own tree is still here with its deps installed, so take the retro
 branch IN IT. `B` is re-assigned because a separate fenced block is a separate
-shell (§9's `$MAIN` trap). `main-tree-branch-gate` fires only when the target
-dir IS the main tree, and the merged lane branch cannot be reused (re-pushing
-it is refused by post-merge-orphan-push-gate).
+shell (§9's `$MAIN` trap), and the merged lane branch cannot be reused
+(re-pushing it is refused by post-merge-orphan-push-gate).
+`main-tree-branch-gate` does back this switch up against a cwd reset, but only
+since this session's hooks change — §5 measured both copies, and the version
+then on `main` passed the chained `git fetch origin && git switch -c ...`
+form below (rc=0) while refusing a bare `git switch -c` (rc=2). Do not read
+the backstop as one that always held, and until the hooks lane merges to
+`main`, confirm `git rev-parse --show-toplevel` is this lane's tree immediately
+before running the block.
 
 ```bash
 B=chore/work-issues-retro-<lesson-slug>

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -247,9 +247,14 @@ shell (§9's `$MAIN` trap), and the merged lane branch cannot be reused
 since this session's hooks change — §5 measured both copies, and the version
 then on `main` passed the chained `git fetch origin && git switch -c ...`
 form below (rc=0) while refusing a bare `git switch -c` (rc=2). Do not read
-the backstop as one that always held, and until `fix/body-file-gate-fallback` (go-to-k/cdk-local#637) merges to
-`main`, confirm `git rev-parse --show-toplevel` is this lane's tree immediately
-before running the block.
+the backstop as one that always held, and until `fix/body-file-gate-fallback`
+(go-to-k/cdk-local#639) merges to `main`, confirm `git rev-parse
+--show-toplevel` is this lane's tree immediately before running the branch
+block below. Ask whether the fix has landed by CONTENT, not by the file's last
+commit subject (which names an earlier hooks change and reads like this one):
+`git show origin/main:.claude/hooks/main-tree-branch-gate.sh` piped to
+`grep -c gate_verb_args` prints `0` while the fix is absent and non-zero once
+it lands.
 
 ```bash
 B=chore/work-issues-retro-<lesson-slug>

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -232,6 +232,13 @@ git worktree add ".claude/worktrees/${B##*/}" -b "$B" origin/main
 cd ".claude/worktrees/${B##*/}"
 mise trust && mise install    # untrusted .mise.toml: vp / markgate will not resolve
 pnpm install                  # worktrees have no node_modules
+
+# IN-PLACE (§3's launch-mode probe): there is no `main` to be back on and no
+# worktree to add -- the lane's own tree is still here, deps installed. Take the
+# retro branch IN IT. `main-tree-branch-gate` fires only when the target dir IS
+# the main tree, and the merged lane branch cannot be reused (re-pushing it is
+# refused by post-merge-orphan-push-gate).
+git fetch origin && git switch -c "$B" origin/main
 ```
 
 - `chore:` prefix — agent tooling, not `src/**`; a `fix:` / `feat:` prefix
@@ -250,7 +257,10 @@ pnpm install                  # worktrees have no node_modules
   tier; a wrong rule here propagates into every future session.
 - **Merge it (via `/merge-pr`) before the wrap report**, which also removes
   the worktree — §9's closing check is "every worktree THIS run added is
-  gone". `Session-fit: now`: deferring leaves main self-inconsistent (the
+  gone". An IN-PLACE run added none: it stops `/merge-pr` after step 4 (§9)
+  and leaves the tree standing on the retro branch for whoever owns the
+  workspace (the appendix has what the Stop hook will say about that).
+  `Session-fit: now`: deferring leaves main self-inconsistent (the
   skill keeps prescribing what this run proved wrong), the evidence dies with
   the session, and the open PR is NOT CLOSEABLE.
 

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -247,7 +247,7 @@ shell (§9's `$MAIN` trap), and the merged lane branch cannot be reused
 since this session's hooks change — §5 measured both copies, and the version
 then on `main` passed the chained `git fetch origin && git switch -c ...`
 form below (rc=0) while refusing a bare `git switch -c` (rc=2). Do not read
-the backstop as one that always held, and until the hooks lane merges to
+the backstop as one that always held, and until `fix/body-file-gate-fallback` (go-to-k/cdk-local#637) merges to
 `main`, confirm `git rev-parse --show-toplevel` is this lane's tree immediately
 before running the block.
 

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -221,6 +221,8 @@ After `/merge-pr` you are back on `main` (`branch-gate` blocks commits;
 `main-tree-branch-gate` blocks branching there), so the retro gets its own
 worktree:
 
+MAIN-CHECKOUT (§3's launch-mode probe) — run THIS block, and not the next one:
+
 ```bash
 # Suffix the branch with the LESSON, not just the date: a merged branch is
 # deleted (re-pushing that name is refused by post-merge-orphan-push-gate), and
@@ -232,12 +234,19 @@ git worktree add ".claude/worktrees/${B##*/}" -b "$B" origin/main
 cd ".claude/worktrees/${B##*/}"
 mise trust && mise install    # untrusted .mise.toml: vp / markgate will not resolve
 pnpm install                  # worktrees have no node_modules
+```
 
-# IN-PLACE (§3's launch-mode probe): there is no `main` to be back on and no
-# worktree to add -- the lane's own tree is still here, deps installed. Take the
-# retro branch IN IT. `main-tree-branch-gate` fires only when the target dir IS
-# the main tree, and the merged lane branch cannot be reused (re-pushing it is
-# refused by post-merge-orphan-push-gate).
+IN-PLACE — run THIS block INSTEAD of the one above, never both: there is no
+worktree to add, and `git worktree add` from inside this tree NESTS the very
+worktree this mode exists to prevent. There is also no `main` to be back on;
+the lane's own tree is still here with its deps installed, so take the retro
+branch IN IT. `B` is re-assigned because a separate fenced block is a separate
+shell (§9's `$MAIN` trap). `main-tree-branch-gate` fires only when the target
+dir IS the main tree, and the merged lane branch cannot be reused (re-pushing
+it is refused by post-merge-orphan-push-gate).
+
+```bash
+B=chore/work-issues-retro-<lesson-slug>
 git fetch origin && git switch -c "$B" origin/main
 ```
 

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -2,8 +2,10 @@
 
 ## 10. Fold what the run taught you back into this skill
 
-Trigger: after §9's last lane is merged and its worktree removed, BEFORE the wrap
-report — the evidence exists only while this session's context is alive.
+Trigger: after §9's last lane is merged and every worktree THIS run added is
+removed — an IN-PLACE run added none, so for it the trigger is the last merge —
+BEFORE the wrap report; the evidence exists only while this session's context is
+alive.
 
 `/verify-pr` step 11's retrospective was per LANE; this one covers **the flow
 itself** (this skill's docs + the skills it drives) across the WHOLE run —

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -85,15 +85,17 @@ git checkout main && git pull origin main    # bring the merges local
 
 IN-PLACE — run THIS block INSTEAD, never both: `main` is checked out in the main
 tree, so a `checkout main` HERE dies with `'main' is already used by worktree at
-...`. Never leave your own tree; pull the main checkout through `-C`. `MAIN` is
-derived HERE rather than borrowed from a neighbouring block — each fenced block
-is its own Bash call and its own shell, so a variable assigned in another one is
-empty here:
+...`. Never leave your own tree; pull the main checkout through `-C`, using the
+path the launch-mode probe already recorded rather than re-deriving it from a
+`git worktree list` row (the old spelling depended on the main checkout being
+row 1, which is true today and is not a documented guarantee):
 
 ```bash
-# The main checkout is always the FIRST row of `git worktree list`.
-MAIN=$(git worktree list --porcelain | awk 'NR==1{print substr($0,10)}')
-git -C "$MAIN" pull origin main
+# <MAIN_CHECKOUT> is the ABSOLUTE path the launch-mode probe printed
+# (references/launch-mode.md) -- substituted here, never carried as a shell
+# variable, because each fenced block is its own Bash call and an empty `-C`
+# does not fail, it re-targets the cwd.
+git -C "<MAIN_CHECKOUT>" pull origin main
 ```
 
 (There is no post-release rebuild step to relocate: this repo's flow ends at the
@@ -140,8 +142,14 @@ squash-merges: a merged tip is never an ancestor of `main`, so `-d` refuses it a
 unmerged work — but only after confirming the PR is MERGED. The closing check is
 that **every worktree AND every local branch THIS run added is gone** — never that
 only the main checkout remains. **An IN-PLACE run ADDED none, so it removes
-none**: its closing check is that it left the launch tree and its branch exactly
-as it found them, and the wrap SAYS whose cleanup that is instead of doing it.
+none**: its closing check is "added no worktree, so removed none; deleted no
+branch", and the wrap SAYS whose cleanup that is instead of doing it. It is NOT
+"left the launch tree and its branch exactly as it found them" — §10-d has the
+run end standing on a RETRO branch this tree created, so that check could never
+pass and would read as a failure at the end of every correct IN-PLACE run.
+(The same sentence in `hunt-bugs/SKILL.md` is CORRECT there: that skill never
+branches in place.)
+
 `git worktree remove` on its own never deletes a branch, so a crashed or
 interrupted `/merge-pr` leaves the local ref behind
 (cdkd's section 9 claimed otherwise and accumulated a dozen stale merged

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -24,16 +24,35 @@ Merge every verified PR with the `/merge-pr` skill — NOT a hand-run
 /merge-pr <n>
 ```
 
-**An IN-PLACE run (§3's launch-mode probe) stops `/merge-pr` after its step 4.**
-Steps 1-4 (resolve paths, set the `merge-pr` marker, `gh pr merge --squash`,
-confirm `state=MERGED`) run unchanged; step 5 must NOT — `git worktree remove
-"$WT" --force` on the tree this run is standing in deletes its own cwd, and
-`git branch -D "$BR"` targets the branch it is standing on. Skip step 5
-entirely, do step 6 (confirm the remote branch is gone) from this tree, and say
-in the report that the local tree and branch are still there ON PURPOSE.
-Cleanup of a workspace this run did not create belongs to whoever did — the
-outer tool, or the operator. `/merge-pr`'s own step 1 already has the sibling
-case (`WT` == `MAIN`, skip the remove); this is the second one it does not name.
+**An IN-PLACE run (§3's launch-mode probe) stops `/merge-pr` once the merge is
+CONFIRMED** — its step 4, the `state=MERGED` read. Everything up to there
+(resolve paths, set the `merge-pr` marker, `gh pr merge --squash`, confirm the
+merge) runs unchanged. **The LOCAL-CLEANUP step must not run at all**: that is
+the one doing `git worktree remove "$WT" --force` plus `git branch -D "$BR"`,
+numbered 5 today — name it by what it DOES, because `/merge-pr`'s own step 1
+still calls the removal "step 4" and the number is the one part of this that
+drifts. Skip it entirely, do the remote-branch confirmation (step 6) from this
+tree, and say in the report that the local tree and branch are still there ON
+PURPOSE. Cleanup of a workspace this run did not create belongs to whoever did
+— the outer tool, or the operator.
+
+`/merge-pr`'s step 1 names one adjacent case (`WT` == `MAIN` — main worktree,
+nothing to detach). There are TWO it does not, and they are different from each
+other:
+
+- **A linked worktree under `.claude/worktrees/`** — the ordinary IN-PLACE case
+  above. The gate fires, `/merge-pr` is mandatory, and only the cleanup step is
+  dropped.
+- **A linked worktree that is NOT under `.claude/worktrees/`** — an Orca/ADE
+  workspace, which is neither the main checkout nor a path the gate recognises.
+  `gh-pr-merge-worktree-gate.sh` matches `*/.claude/worktrees/*` only, so from
+  there it FAILS OPEN: a hand-run `gh pr merge` is not blocked, and nothing
+  forces the merge through `/merge-pr` at all. Step 1's sanity check ("`WT`
+  should be under `.claude/worktrees/`") has no arm for it either. Use
+  `/merge-pr` anyway — its marker is harmless when the gate never consults it —
+  and drop the local-cleanup step exactly as above. Treat a gate that stays
+  silent here as a gate that did not run, never as a verdict that the merge was
+  checked.
 
 `/merge-pr` squash-merges from inside the feature worktree WITHOUT
 `--delete-branch` (so gh runs no local cleanup and never trips the `'main' is
@@ -58,13 +77,22 @@ content your local green never saw — the fix is fetch + rebase + re-run, not
 distrusting the check (go-to-k/cdk-local#524 failed on a line
 go-to-k/cdk-local#520 merged in parallel).
 
+MAIN-CHECKOUT — run THIS block, and not the next one:
+
+```bash
+git checkout main && git pull origin main    # bring the merges local
+```
+
+IN-PLACE — run THIS block INSTEAD, never both: `main` is checked out in the main
+tree, so a `checkout main` HERE dies with `'main' is already used by worktree at
+...`. Never leave your own tree; pull the main checkout through `-C`. `MAIN` is
+derived HERE rather than borrowed from a neighbouring block — each fenced block
+is its own Bash call and its own shell, so a variable assigned in another one is
+empty here:
+
 ```bash
 # The main checkout is always the FIRST row of `git worktree list`.
 MAIN=$(git worktree list --porcelain | awk 'NR==1{print substr($0,10)}')
-git checkout main && git pull origin main    # bring the merges local
-# IN-PLACE: `main` is checked out in $MAIN, so a `checkout main` HERE dies with
-# `'main' is already used by worktree at ...` -- never leave your own tree, pull
-# the main checkout through -C instead:
 git -C "$MAIN" pull origin main
 ```
 

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -24,6 +24,17 @@ Merge every verified PR with the `/merge-pr` skill — NOT a hand-run
 /merge-pr <n>
 ```
 
+**An IN-PLACE run (§3's launch-mode probe) stops `/merge-pr` after its step 4.**
+Steps 1-4 (resolve paths, set the `merge-pr` marker, `gh pr merge --squash`,
+confirm `state=MERGED`) run unchanged; step 5 must NOT — `git worktree remove
+"$WT" --force` on the tree this run is standing in deletes its own cwd, and
+`git branch -D "$BR"` targets the branch it is standing on. Skip step 5
+entirely, do step 6 (confirm the remote branch is gone) from this tree, and say
+in the report that the local tree and branch are still there ON PURPOSE.
+Cleanup of a workspace this run did not create belongs to whoever did — the
+outer tool, or the operator. `/merge-pr`'s own step 1 already has the sibling
+case (`WT` == `MAIN`, skip the remove); this is the second one it does not name.
+
 `/merge-pr` squash-merges from inside the feature worktree WITHOUT
 `--delete-branch` (so gh runs no local cleanup and never trips the `'main' is
 already used by worktree` fatal a hand-run merge hits from a side worktree), then
@@ -48,8 +59,19 @@ distrusting the check (go-to-k/cdk-local#524 failed on a line
 go-to-k/cdk-local#520 merged in parallel).
 
 ```bash
+# The main checkout is always the FIRST row of `git worktree list`.
+MAIN=$(git worktree list --porcelain | awk 'NR==1{print substr($0,10)}')
 git checkout main && git pull origin main    # bring the merges local
+# IN-PLACE: `main` is checked out in $MAIN, so a `checkout main` HERE dies with
+# `'main' is already used by worktree at ...` -- never leave your own tree, pull
+# the main checkout through -C instead:
+git -C "$MAIN" pull origin main
 ```
+
+(There is no post-release rebuild step to relocate: this repo's flow ends at the
+pull, and users invoke `node dist/cli.js` from their own checkout rather than a
+globally linked binary built in the main tree. The sibling cdkd has that step
+and has to run it in `$MAIN`; do not import it here.)
 
 When your PR landed into a file another PR touched in the same window, grep the
 merged `main` for a marker string from EACH side before believing both survived —
@@ -89,8 +111,11 @@ squash-merges: a merged tip is never an ancestor of `main`, so `-d` refuses it a
 "not fully merged". Read that refusal as the expected squash artifact, not as
 unmerged work — but only after confirming the PR is MERGED. The closing check is
 that **every worktree AND every local branch THIS run added is gone** — never that
-only the main checkout remains. `git worktree remove` on its own never deletes a
-branch, so a crashed or interrupted `/merge-pr` leaves the local ref behind
+only the main checkout remains. **An IN-PLACE run ADDED none, so it removes
+none**: its closing check is that it left the launch tree and its branch exactly
+as it found them, and the wrap SAYS whose cleanup that is instead of doing it.
+`git worktree remove` on its own never deletes a branch, so a crashed or
+interrupted `/merge-pr` leaves the local ref behind
 (cdkd's section 9 claimed otherwise and accumulated a dozen stale merged
 branches before go-to-k/cdkd#2015 corrected it):
 

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -147,6 +147,52 @@ rest; a fix living entirely in one is naturally disjoint.
 
 ## 3. Pick a FEW FILE-DISJOINT issues
 
+**How many lanes you may pick is decided by the LAUNCH MODE, so compute that
+first — it is one command and it is not guessable from the prompt:**
+
+```bash
+[ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
+ = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] && echo MAIN-CHECKOUT || echo IN-PLACE
+```
+
+Equal only in the main checkout: a linked worktree's `--git-dir` is
+`<common-dir>/worktrees/<name>`, while the main checkout's is the common dir
+itself. `pwd -P` is load-bearing in BOTH directions — the main checkout answers
+`.git` RELATIVELY for both, so an unnormalised compare is only accidentally
+right, and macOS spells `/tmp` as `/private/tmp`. Chosen over comparing against
+the first row of `git worktree list --porcelain` because it needs no listing
+order, no path parsing and no awareness of other worktrees.
+
+`IN-PLACE` means this run was launched inside a worktree someone else created
+(an Orca/ADE workspace, a stray `cd` into `.claude/worktrees/<x>`), so it has
+exactly ONE working tree: **take ONE issue and finish it.** A second lane would
+need a worktree nested inside this one, and deleting the outer workspace then
+takes the inner directory with it — uncommitted work gone, the git registration
+orphaned until a `prune`, plus the same-branch double-checkout collision
+(go-to-k/cdk-local#635). Rank as usual, claim the top candidate, and leave the
+rest for the next run. The other consequences live where they fire: the claim
+names the tree you are STANDING IN (§4), no worktree is created (§5), none is
+removed and no branch deleted (§9, §10-d), and `main` is pulled through
+`git -C` because it is checked out in the main checkout (§9).
+
+**Adopting a tree you did not create needs an ownership check FIRST**, because a
+stray `cd` into a peer's live lane looks exactly like an empty workspace:
+
+```bash
+git status --porcelain          # non-empty = someone's uncommitted work; STOP
+git branch --show-current       # the branch you would be committing to
+git log --oneline -3            # whose commits are these
+gh pr list --state all --head "$(git branch --show-current)"
+```
+
+This repo keeps no worktree-owner sentinel (the sibling cdkd's
+`session-owner` file has no counterpart here), so those probes plus the §4 claim
+comments on the issue thread are the whole ownership record — and §9's rule
+applies unchanged: read every probe as evidence of LIFE only, never of absence.
+If the tree is not yours, stop and report; do not nest a worktree inside it.
+
+Everything below is the MAIN-CHECKOUT case.
+
 The parallel-integration constraint (same as the worktree rule): **two lanes
 must edit DISJOINT files** — two issues landing in the same file (e.g.
 `ecs-service-emulator.ts`) bundle into ONE lane (one worktree, one PR) or one

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -202,9 +202,10 @@ gh pr list --state all --head "$(git branch --show-current)"
 ```
 
 This repo keeps no worktree-owner sentinel (the sibling cdkd's
-`session-owner` file has no counterpart here), so those probes plus the §4 claim
-comments on the issue thread are the whole ownership record — which makes the
-anchor line matter more here than in either sibling, not less. §9's rule applies
+`session-owner` file has no counterpart here, and cdk-real-drift has none
+either), so those probes plus the §4 claim comments on the issue thread are the
+whole ownership record — which makes the anchor line matter more here than in
+cdkd, the one sibling that does have the sentinel. §9's rule applies
 unchanged: read every probe as evidence of LIFE only, never of absence. If the
 tree is not yours, stop and report; do not nest a worktree inside it.
 

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -161,7 +161,10 @@ itself. `pwd -P` is load-bearing in BOTH directions — the main checkout answer
 `.git` RELATIVELY for both, so an unnormalised compare is only accidentally
 right, and macOS spells `/tmp` as `/private/tmp`. Chosen over comparing against
 the first row of `git worktree list --porcelain` because it needs no listing
-order, no path parsing and no awareness of other worktrees.
+order, no path parsing and no awareness of other worktrees. Run it INSIDE the
+repo: outside one both substitutions are empty and `cd ""` returns 0, so it
+prints MAIN-CHECKOUT — a wrong verdict, saved only by the next git command
+failing loudly.
 
 `IN-PLACE` means this run was launched inside a worktree someone else created
 (an Orca/ADE workspace, a stray `cd` into `.claude/worktrees/<x>`), so it has

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -105,9 +105,16 @@ gh pr list --state open --json number,title,headRefName   # their PRs
 For each active worktree, find what it ACTUALLY edits (not the stale-base noise):
 
 ```bash
-git -C .claude/worktrees/<w> log --oneline -1     # its tip — `origin/main`'s until it commits
-git -C .claude/worktrees/<w> show --stat HEAD     # the files that commit HAS FINISHED
-git -C .claude/worktrees/<w> status --porcelain   # what it is editing RIGHT NOW
+# <MAIN_CHECKOUT> is the ABSOLUTE path the launch-mode probe printed
+# (references/launch-mode.md). A relative `.claude/worktrees/<w>` is correct
+# only from the main checkout: run IN-PLACE the cwd is a lane tree, the path
+# does not exist, git errors, and this scan reports NOTHING -- which reads as
+# "no competing agents", the exact failure this stage exists to prevent, and it
+# fails QUIETLY. Substitute the recorded path; never `$MAIN_CHECKOUT`, which is
+# empty in this shell and makes `-C` re-target the cwd instead of failing.
+git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" log --oneline -1     # its tip — `origin/main`'s until it commits
+git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" show --stat HEAD     # the files that commit HAS FINISHED
+git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" status --porcelain   # what it is editing RIGHT NOW
 ```
 
 **A file another agent is editing is OFF-LIMITS** — and the third probe is the
@@ -147,29 +154,13 @@ rest; a fix living entirely in one is naturally disjoint.
 
 ## 3. Pick a FEW FILE-DISJOINT issues
 
-**How many lanes you may pick is decided by the LAUNCH MODE, so compute that
-first — it is one command and it is not guessable from the prompt:**
-
-```bash
-[ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
- = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] && echo MAIN-CHECKOUT || echo IN-PLACE
-```
-
-Equal only in the main checkout: a linked worktree's `--git-dir` is
-`<common-dir>/worktrees/<name>`, while the main checkout's is the common dir
-itself. `pwd -P` is load-bearing in BOTH directions — the main checkout answers
-`.git` RELATIVELY for both, so an unnormalised compare is only accidentally
-right, and macOS spells `/tmp` as `/private/tmp`. Chosen over comparing against
-the first row of `git worktree list --porcelain` because it needs no listing
-order, no path parsing and no awareness of other worktrees. Run it INSIDE the
-repo. Outside one, `git rev-parse` fails and both substitutions collapse to the
-empty string, so the test compares `""` with `""`
-and prints MAIN-CHECKOUT — a wrong verdict. Measured 2026-08-31, and the
-mechanism differs by shell without changing the answer: bash REFUSES `cd ""`
-(rc=1, `cd: null directory`) so the `&& pwd -P` never runs, while zsh accepts it
-(rc=0) and `pwd -P` then prints the same cwd twice. Nothing downstream reliably
-catches it, either: the next git command runs in whatever tree the shell is
-actually in, and that tree may well be a real repo.
+**How many lanes you may pick is decided by the LAUNCH MODE, and the parent
+already settled it before stage 0** — `references/launch-mode.md` holds the
+probe (the ONLY copy) and the reading of its edge cases, and the dispatch that
+started this stage carries its `MODE` / `LANE_TREE` / `MAIN_CHECKOUT`. If the
+dispatch did not, STOP and ask for them rather than re-running the probe here:
+a triage subagent's answer is not the parent's, and the parent is the party
+that later runs `git worktree add` or does not.
 
 `IN-PLACE` means this run was launched inside a worktree someone else created
 (an Orca/ADE workspace, a stray `cd` into `.claude/worktrees/<x>`), so it has
@@ -178,10 +169,7 @@ need a worktree nested inside this one, and deleting the outer workspace then
 takes the inner directory with it — uncommitted work gone, the git registration
 orphaned until a `prune`, plus the same-branch double-checkout collision
 (go-to-k/cdk-local#635). Rank as usual, claim the top candidate, and leave the
-rest for the next run. The other consequences live where they fire: the claim
-names the tree you are STANDING IN (§4), no worktree is created (§5), none is
-removed and no branch deleted (§9, §10-d), and `main` is pulled through
-`git -C` because it is checked out in the main checkout (§9).
+rest for the next run.
 
 **Adopting a tree you did not create needs an ownership check FIRST**, because a
 stray `cd` into a peer's live lane looks exactly like an empty workspace:
@@ -189,7 +177,7 @@ stray `cd` into a peer's live lane looks exactly like an empty workspace:
 ```bash
 # The FIRST line is the anchor, and it is why none of the rest needs a `-C`:
 # every probe under it describes THIS shell's tree, so a cwd that has silently
-# reset to the main checkout (appendix, "Bash cwd silent reset") shows up IN THE
+# reset to the main checkout (appendix, the `cd <lane tree> &&` rule) shows up IN THE
 # OUTPUT instead of being invisible. Without it the block answers "clean, no
 # claim, no PR" about a tree nobody asked about, and READS as a description of
 # this lane. Anchoring a READ this way is enough -- noticing afterwards costs
@@ -209,7 +197,13 @@ cdkd, the one sibling that does have the sentinel. §9's rule applies
 unchanged: read every probe as evidence of LIFE only, never of absence. If the
 tree is not yours, stop and report; do not nest a worktree inside it.
 
-Everything below is the MAIN-CHECKOUT case.
+**The MAIN-CHECKOUT case is the DISJOINTNESS PARAGRAPH below and nothing
+wider.** An earlier revision said "everything below is the MAIN-CHECKOUT case",
+which told an IN-PLACE run to skip the security-first ranking, the `Severity`
+ranking, the premise-check-against-`origin/main` rule and §3-a's 60-minute
+freshness gate — all mode-independent, and the last a HARD gate. The rest of
+what IN-PLACE changes lives in `references/launch-mode.md`'s table, mapped to
+§2, §4, §5, §9 and §10-d.
 
 The parallel-integration constraint (same as the worktree rule): **two lanes
 must edit DISJOINT files** — two issues landing in the same file (e.g.

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -162,9 +162,14 @@ itself. `pwd -P` is load-bearing in BOTH directions — the main checkout answer
 right, and macOS spells `/tmp` as `/private/tmp`. Chosen over comparing against
 the first row of `git worktree list --porcelain` because it needs no listing
 order, no path parsing and no awareness of other worktrees. Run it INSIDE the
-repo: outside one both substitutions are empty and `cd ""` returns 0, so it
-prints MAIN-CHECKOUT — a wrong verdict, saved only by the next git command
-failing loudly.
+repo. Outside one, `git rev-parse` fails and both substitutions collapse to the
+empty string, so the test compares `""` with `""`
+and prints MAIN-CHECKOUT — a wrong verdict. Measured 2026-08-31, and the
+mechanism differs by shell without changing the answer: bash REFUSES `cd ""`
+(rc=1, `cd: null directory`) so the `&& pwd -P` never runs, while zsh accepts it
+(rc=0) and `pwd -P` then prints the same cwd twice. Nothing downstream reliably
+catches it, either: the next git command runs in whatever tree the shell is
+actually in, and that tree may well be a real repo.
 
 `IN-PLACE` means this run was launched inside a worktree someone else created
 (an Orca/ADE workspace, a stray `cd` into `.claude/worktrees/<x>`), so it has
@@ -182,6 +187,14 @@ removed and no branch deleted (§9, §10-d), and `main` is pulled through
 stray `cd` into a peer's live lane looks exactly like an empty workspace:
 
 ```bash
+# The FIRST line is the anchor, and it is why none of the rest needs a `-C`:
+# every probe under it describes THIS shell's tree, so a cwd that has silently
+# reset to the main checkout (appendix, "Bash cwd silent reset") shows up IN THE
+# OUTPUT instead of being invisible. Without it the block answers "clean, no
+# claim, no PR" about a tree nobody asked about, and READS as a description of
+# this lane. Anchoring a READ this way is enough -- noticing afterwards costs
+# nothing; a WRITE is a different problem (§5's branch recipe).
+git rev-parse --show-toplevel   # STOP unless this is the tree you meant to adopt
 git status --porcelain          # non-empty = someone's uncommitted work; STOP
 git branch --show-current       # the branch you would be committing to
 git log --oneline -3            # whose commits are these
@@ -190,9 +203,10 @@ gh pr list --state all --head "$(git branch --show-current)"
 
 This repo keeps no worktree-owner sentinel (the sibling cdkd's
 `session-owner` file has no counterpart here), so those probes plus the §4 claim
-comments on the issue thread are the whole ownership record — and §9's rule
-applies unchanged: read every probe as evidence of LIFE only, never of absence.
-If the tree is not yours, stop and report; do not nest a worktree inside it.
+comments on the issue thread are the whole ownership record — which makes the
+anchor line matter more here than in either sibling, not less. §9's rule applies
+unchanged: read every probe as evidence of LIFE only, never of absence. If the
+tree is not yours, stop and report; do not nest a worktree inside it.
 
 Everything below is the MAIN-CHECKOUT case.
 

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -54,7 +54,7 @@ const MIN_REFERENCE_FILES = 6;
 // at corpus 101,869 B with implement.md at 27,241 B, 72,000 no longer had it
 // (101,869 - 27,241 = 74,628 > 72,000). Re-measure both numbers whenever a
 // stage file changes size materially -- the property is silent when it lapses.
-const MIN_REFERENCE_CORPUS_BYTES = 86_000; // re-measured 2026-08-31: corpus 111,313 B, largest 28,013 B; 86,000 > 111,313 - 28,013 = 83,300, so hollowing the largest file still fails, with ~25 KB of compression headroom left below the floor. The previous 78,000 had lapsed silently as the other stage files grew -- exactly the decay the paragraph above warns about
+const MIN_REFERENCE_CORPUS_BYTES = 88_000; // re-measured 2026-08-31 (second pass, after the ship.md merge-pr / launch-mode text): corpus 113,468 B, largest implement.md 28,227 B; 88,000 > 113,468 - 28,227 = 85,241, so hollowing the largest file still fails, with ~25 KB of compression headroom left below the floor. 78,000 had lapsed silently as the other stage files grew, and the 86,000 set earlier the same day was already down to 759 B of margin -- exactly the decay the paragraph above warns about, which is why the raise takes real margin rather than the minimum that passes
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -39,13 +39,13 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
 const skillsDir = join(repoRoot, '.claude', 'skills');
 
 const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 26,092 B (hunt-bugs, 2026-08-31)
-const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator was ~7 KB at the 2026-08-28 split; re-measured 11,066 B on 2026-09-01 (934 B of margin)
+const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator was ~7 KB at the 2026-08-28 split; re-measured 11,306 B on 2026-09-01, review round 4 (694 B of margin)
 // The re-measurement is the point, not trivia: the orchestrator grew to within
 // 934 B of its cap while this comment still quoted the at-split figure, so nobody
 // adding a paragraph could see how little room was left. Re-measure it whenever
 // the orchestrator is edited -- a cap with an unmeasured margin is one nobody can
 // plan against.
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file re-measured 32,000 B (implement.md, 2026-09-01, review round 3)
+const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file re-measured 33,572 B (implement.md, 2026-09-01, review round 4)
 
 // The split skill's stage files must still exist and still carry the moved
 // content. 8 files / ~124 KB at the split; the floor sits far enough below
@@ -59,7 +59,7 @@ const MIN_REFERENCE_FILES = 6;
 // at corpus 101,869 B with implement.md at 27,241 B, 72,000 no longer had it
 // (101,869 - 27,241 = 74,628 > 72,000). Re-measure both numbers whenever a
 // stage file changes size materially -- the property is silent when it lapses.
-const MIN_REFERENCE_CORPUS_BYTES = 90_000; // re-derived 2026-09-01 (review round 3) at the final tree: corpus 118,751 B, largest implement.md 32,000 B, so the property needs a floor above 118,751 - 32,000 = 86,751. The 88,000 held here still cleared it, but by only 1,249 B -- the same thin margin that let 78,000 and then 86,000 lapse silently on 2026-08-31 -- so it is raised to 90,000: 3,249 B of margin, with ~28 KB (118,751 - 90,000 = 28,751 B) of narrative compression headroom left below the floor. Re-measure BOTH numbers whenever a stage file changes size materially; a lapsed floor is not a weaker guard but a SILENT one
+const MIN_REFERENCE_CORPUS_BYTES = 90_000; // re-derived 2026-09-01 (review round 4) at the final tree: corpus 120,739 B, largest implement.md 33,572 B, so the property needs a floor above 120,739 - 33,572 = 87,167. 90,000 clears that by 2,833 B and is left UNCHANGED -- it was raised from 88,000 one round earlier, when 78,000 and then 86,000 had lapsed silently on 2026-08-31, and it still holds. ~31 KB (120,739 - 90,000 = 30,739 B) of narrative compression headroom remains below the floor. Re-measure BOTH numbers whenever a stage file changes size materially; a lapsed floor is not a weaker guard but a SILENT one
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -39,13 +39,16 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
 const skillsDir = join(repoRoot, '.claude', 'skills');
 
 const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 26,092 B (hunt-bugs, 2026-08-31)
-const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator was ~7 KB at the 2026-08-28 split; re-measured 11,306 B on 2026-09-01, review round 4 (694 B of margin)
-// The re-measurement is the point, not trivia: the orchestrator grew to within
-// 934 B of its cap while this comment still quoted the at-split figure, so nobody
-// adding a paragraph could see how little room was left. Re-measure it whenever
-// the orchestrator is edited -- a cap with an unmeasured margin is one nobody can
-// plan against.
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file re-measured 33,572 B (implement.md, 2026-09-01, review round 4)
+const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator was ~7 KB at the 2026-08-28 split; re-measured 11,575 B on 2026-09-01, review round 6 (425 B of margin)
+// The re-measurement is the point, not trivia: the orchestrator has repeatedly
+// grown to within a few hundred bytes of its cap while this comment still quoted
+// the at-split figure, so nobody adding a paragraph could see how little room was
+// left. Round 6 added the parent-runs-the-probe design and paid for most of it by
+// moving the probe and its edge-case reading into references/launch-mode.md
+// (8,141 B, read once before stage 0) and leaving a pointer here -- the direction
+// this cap exists to force. Re-measure it whenever the orchestrator is edited --
+// a cap with an unmeasured margin is one nobody can plan against.
+const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file re-measured 34,073 B (implement.md, 2026-09-01, review round 6)
 
 // The split skill's stage files must still exist and still carry the moved
 // content. 8 files / ~124 KB at the split; the floor sits far enough below
@@ -55,11 +58,19 @@ const MIN_REFERENCE_FILES = 6;
 // The floor has a SECOND job beyond "the files still exist": it must sit above
 // `corpus - largest file`, so DELETING the biggest stage file cannot pass. That
 // property decays as the OTHER files grow (it is invariant when the largest one
-// is compressed, since both terms drop together), and it had already decayed:
-// at corpus 101,869 B with implement.md at 27,241 B, 72,000 no longer had it
-// (101,869 - 27,241 = 74,628 > 72,000). Re-measure both numbers whenever a
-// stage file changes size materially -- the property is silent when it lapses.
-const MIN_REFERENCE_CORPUS_BYTES = 90_000; // re-derived 2026-09-01 (review round 4) at the final tree: corpus 120,739 B, largest implement.md 33,572 B, so the property needs a floor above 120,739 - 33,572 = 87,167. 90,000 clears that by 2,833 B and is left UNCHANGED -- it was raised from 88,000 one round earlier, when 78,000 and then 86,000 had lapsed silently on 2026-08-31, and it still holds. ~31 KB (120,739 - 90,000 = 30,739 B) of narrative compression headroom remains below the floor. Re-measure BOTH numbers whenever a stage file changes size materially; a lapsed floor is not a weaker guard but a SILENT one
+// is compressed, since both terms drop together), and it had already decayed
+// twice inside one week (78,000 then 86,000 on 2026-08-31). It is now ASSERTED
+// at the bottom of this file rather than only described here, so the next lapse
+// is a red test at the commit that causes it instead of a silent hole.
+//
+// What this floor does NOT catch, stated plainly: gutting a NON-largest stage
+// file. A byte floor cannot see that, and raising it until it could would forbid
+// legitimate compression. The per-file guards are elsewhere and are about
+// CONTENT rather than size -- work-issues-skill-refs.test.ts pins the document
+// count, and work-issues-launch-mode.test.ts pins that each arm-bearing stage
+// file still names the mode it branches on and that the probe exists exactly
+// once.
+const MIN_REFERENCE_CORPUS_BYTES = 100_000; // re-derived 2026-09-01 (review round 6) at the final tree: 9 stage files, corpus 130,349 B, largest implement.md 34,073 B, so the property needs a floor above 130,349 - 34,073 = 96,276, which the 90,000 held here no longer provided. 100,000 restores it with 3,724 B of margin and is strictly TIGHTER (no upper bound touched). Sized against `corpus - largest` rather than the either-largest case, because the top two are 13,694 B apart (implement.md 34,073, triage.md 20,379) -- a flip is not near; cdkd sizes against the flip because its top two are 3,242 B apart. ~30 KB (130,349 - 100,000 = 30,349 B) of narrative compression headroom remains below the floor
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })
@@ -157,6 +168,25 @@ describe('skill file payload budget', () => {
           `wholesale deletion as an improvement; this floor is what notices content ` +
           `being DROPPED rather than moved or compressed.`
       ).toBeGreaterThanOrEqual(MIN_REFERENCE_CORPUS_BYTES);
+
+      // The floor's OWN invariant, asserted rather than described. Everything
+      // above only says "the corpus is big enough"; what the floor is FOR is
+      // that deleting the single largest stage file cannot pass, which holds
+      // only while the floor sits above `corpus - largest`. That property
+      // decays silently as the other files grow -- the comment beside the
+      // constant records it lapsing twice (78,000 then 86,000) inside one week,
+      // each time found by a human re-deriving it by hand. Asserting it makes
+      // the next lapse a red test at the commit that causes it, and the failure
+      // message carries the number to raise the floor to.
+      const largest = Math.max(...refs.map((f) => statSync(f).size));
+      expect(
+        MIN_REFERENCE_CORPUS_BYTES,
+        `MIN_REFERENCE_CORPUS_BYTES (${MIN_REFERENCE_CORPUS_BYTES}) has lapsed: the ` +
+          `${name} corpus is ${total} B and its largest stage file is ${largest} B, so ` +
+          `deleting that one file would leave ${total - largest} B and still pass. Raise ` +
+          `the floor above ${total - largest} (and re-derive the comment beside it), or ` +
+          `re-derive it DOWNWARD in the same commit as a genuine compression pass.`
+      ).toBeGreaterThan(total - largest);
     });
   }
 });

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -38,9 +38,9 @@ import { dirname, join } from 'node:path';
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const skillsDir = join(repoRoot, '.claude', 'skills');
 
-const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 24,816 B (hunt-bugs)
+const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 26,092 B (hunt-bugs, 2026-08-31)
 const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator measured ~7 KB at the split
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 27,474 B (implement.md, 2026-08-29)
+const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 28,013 B (implement.md, 2026-08-31)
 
 // The split skill's stage files must still exist and still carry the moved
 // content. 8 files / ~124 KB at the split; the floor sits far enough below
@@ -54,7 +54,7 @@ const MIN_REFERENCE_FILES = 6;
 // at corpus 101,869 B with implement.md at 27,241 B, 72,000 no longer had it
 // (101,869 - 27,241 = 74,628 > 72,000). Re-measure both numbers whenever a
 // stage file changes size materially -- the property is silent when it lapses.
-const MIN_REFERENCE_CORPUS_BYTES = 78_000; // re-measured 2026-08-29: corpus 102,735 B, largest 27,474 B; 78,000 > 102,735 - 27,474 = 75,261, so hollowing the largest file still fails, with ~24 KB of compression headroom left below the floor
+const MIN_REFERENCE_CORPUS_BYTES = 86_000; // re-measured 2026-08-31: corpus 111,313 B, largest 28,013 B; 86,000 > 111,313 - 28,013 = 83,300, so hollowing the largest file still fails, with ~25 KB of compression headroom left below the floor. The previous 78,000 had lapsed silently as the other stage files grew -- exactly the decay the paragraph above warns about
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -40,7 +40,7 @@ const skillsDir = join(repoRoot, '.claude', 'skills');
 
 const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 26,092 B (hunt-bugs, 2026-08-31)
 const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator measured ~7 KB at the split
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 28,013 B (implement.md, 2026-08-31)
+const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file re-measured 28,972 B (implement.md, 2026-08-31, review round 2)
 
 // The split skill's stage files must still exist and still carry the moved
 // content. 8 files / ~124 KB at the split; the floor sits far enough below
@@ -54,7 +54,7 @@ const MIN_REFERENCE_FILES = 6;
 // at corpus 101,869 B with implement.md at 27,241 B, 72,000 no longer had it
 // (101,869 - 27,241 = 74,628 > 72,000). Re-measure both numbers whenever a
 // stage file changes size materially -- the property is silent when it lapses.
-const MIN_REFERENCE_CORPUS_BYTES = 88_000; // re-measured 2026-08-31 (second pass, after the ship.md merge-pr / launch-mode text): corpus 113,468 B, largest implement.md 28,227 B; 88,000 > 113,468 - 28,227 = 85,241, so hollowing the largest file still fails, with ~25 KB of compression headroom left below the floor. 78,000 had lapsed silently as the other stage files grew, and the 86,000 set earlier the same day was already down to 759 B of margin -- exactly the decay the paragraph above warns about, which is why the raise takes real margin rather than the minimum that passes
+const MIN_REFERENCE_CORPUS_BYTES = 88_000; // re-measured 2026-08-31 (second pass, after the ship.md merge-pr / launch-mode text): corpus 114,213 B, largest implement.md 28,972 B; 88,000 > 114,213 - 28,972 = 85,241 (re-measured 2026-08-31, review round 2: the round's edit grew the largest file and the corpus by the same 745 B, so the difference is unchanged -- the invariance the paragraph above names), so hollowing the largest file still fails, with ~25 KB of compression headroom left below the floor. 78,000 had lapsed silently as the other stage files grew, and the 86,000 set earlier the same day was already down to 759 B of margin -- exactly the decay the paragraph above warns about, which is why the raise takes real margin rather than the minimum that passes
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -39,8 +39,13 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
 const skillsDir = join(repoRoot, '.claude', 'skills');
 
 const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 26,092 B (hunt-bugs, 2026-08-31)
-const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator measured ~7 KB at the split
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file re-measured 28,972 B (implement.md, 2026-08-31, review round 2)
+const MAX_ORCHESTRATOR_BYTES = 12_000; // work-issues orchestrator was ~7 KB at the 2026-08-28 split; re-measured 11,066 B on 2026-09-01 (934 B of margin)
+// The re-measurement is the point, not trivia: the orchestrator grew to within
+// 934 B of its cap while this comment still quoted the at-split figure, so nobody
+// adding a paragraph could see how little room was left. Re-measure it whenever
+// the orchestrator is edited -- a cap with an unmeasured margin is one nobody can
+// plan against.
+const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file re-measured 32,000 B (implement.md, 2026-09-01, review round 3)
 
 // The split skill's stage files must still exist and still carry the moved
 // content. 8 files / ~124 KB at the split; the floor sits far enough below
@@ -54,7 +59,7 @@ const MIN_REFERENCE_FILES = 6;
 // at corpus 101,869 B with implement.md at 27,241 B, 72,000 no longer had it
 // (101,869 - 27,241 = 74,628 > 72,000). Re-measure both numbers whenever a
 // stage file changes size materially -- the property is silent when it lapses.
-const MIN_REFERENCE_CORPUS_BYTES = 88_000; // re-measured 2026-08-31 (second pass, after the ship.md merge-pr / launch-mode text): corpus 114,213 B, largest implement.md 28,972 B; 88,000 > 114,213 - 28,972 = 85,241 (re-measured 2026-08-31, review round 2: the round's edit grew the largest file and the corpus by the same 745 B, so the difference is unchanged -- the invariance the paragraph above names), so hollowing the largest file still fails, with ~25 KB of compression headroom left below the floor. 78,000 had lapsed silently as the other stage files grew, and the 86,000 set earlier the same day was already down to 759 B of margin -- exactly the decay the paragraph above warns about, which is why the raise takes real margin rather than the minimum that passes
+const MIN_REFERENCE_CORPUS_BYTES = 90_000; // re-derived 2026-09-01 (review round 3) at the final tree: corpus 118,751 B, largest implement.md 32,000 B, so the property needs a floor above 118,751 - 32,000 = 86,751. The 88,000 held here still cleared it, but by only 1,249 B -- the same thin margin that let 78,000 and then 86,000 lapse silently on 2026-08-31 -- so it is raised to 90,000: 3,249 B of margin, with ~28 KB (118,751 - 90,000 = 28,751 B) of narrative compression headroom left below the floor. Re-measure BOTH numbers whenever a stage file changes size materially; a lapsed floor is not a weaker guard but a SILENT one
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })

--- a/tests/unit/skills/work-issues-launch-mode.test.ts
+++ b/tests/unit/skills/work-issues-launch-mode.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * The `/work-issues` LAUNCH-MODE machinery, which decides whether a run creates
+ * a worktree per lane or works in the tree it was launched in.
+ *
+ * WHY THIS FILE EXISTS. `skill-file-payload.test.ts` and
+ * `work-issues-skill-refs.test.ts` measure BYTES and CITATIONS. Neither looks at
+ * what the prose says, so every mode-specific arm in this skill was untested --
+ * and the orchestrator cap made that worse than merely untested: `SKILL.md` sits
+ * a few hundred bytes under a 12,000 B cap, so DELETING the launch-mode section
+ * was the cheapest way to buy headroom and the suite would have called it an
+ * improvement. Measured 2026-09-01: deleting the probe block, deleting the whole
+ * `## Launch mode` section, and deleting every line containing `IN-PLACE` or
+ * `MAIN-CHECKOUT` were all GREEN before this file existed.
+ *
+ * Three properties, in increasing order of what they actually prove:
+ *
+ *   1. the probe exists EXACTLY ONCE in the skill directory -- pinning both its
+ *      presence and the single-copy claim the text makes about it (a second
+ *      verbatim copy is the drift shape section 10-b fences elsewhere);
+ *   2. every file carrying a mode-specific ARM still names the mode(s) it
+ *      branches on, so gutting one file's arms fails even though the corpus
+ *      byte floor (which only notices the LARGEST file disappearing) would not;
+ *   3. the probe is EXECUTED, in a real git repo and in a real linked worktree
+ *      of it, and must answer with the two literal verdicts. This is the one
+ *      arm of the whole change that is executable rather than prose, and the
+ *      shell-edge-case reading beside it in the doc is otherwise re-checked by
+ *      nothing.
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const skillDir = join(repoRoot, '.claude', 'skills', 'work-issues');
+const LAUNCH_MODE_DOC = join('references', 'launch-mode.md');
+
+/** Every markdown file of the skill, orchestrator first. */
+function skillDocs(): string[] {
+  return [
+    'SKILL.md',
+    ...readdirSync(join(skillDir, 'references'))
+      .filter((f) => f.endsWith('.md'))
+      .sort()
+      .map((f) => join('references', f)),
+  ];
+}
+
+function read(rel: string): string {
+  return readFileSync(join(skillDir, rel), 'utf8');
+}
+
+/**
+ * The probe's distinguishing token. `--git-common-dir` is what makes the mode
+ * decidable at all (a linked worktree's `--git-dir` differs from it, the main
+ * checkout's does not), so counting it counts copies of the probe.
+ */
+const PROBE_TOKEN = '--git-common-dir';
+
+/**
+ * Files that carry a mode-specific ARM and the marker(s) each must still name.
+ * Not every file needs both: `claim.md` and `gotchas.md` only qualify the
+ * IN-PLACE side, and `gates-and-pr.md` deliberately carries NO arm (its
+ * `git -C "<LANE_TREE>"` spelling is correct in both modes, which is why the
+ * mode words were removed from it rather than duplicated).
+ */
+const ARM_BEARING: Record<string, string[]> = {
+  'SKILL.md': ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [LAUNCH_MODE_DOC]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'triage.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'implement.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'ship.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'retro.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'claim.md')]: ['IN-PLACE'],
+  [join('references', 'gotchas.md')]: ['IN-PLACE'],
+};
+
+/** The first fenced ```bash block of a markdown file. */
+export function firstBashBlock(markdown: string): string | null {
+  const lines = markdown.split('\n');
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (start === -1) {
+      if (/^```bash\s*$/.test(lines[i]!)) start = i + 1;
+    } else if (/^```\s*$/.test(lines[i]!)) {
+      return lines.slice(start, i).join('\n');
+    }
+  }
+  return null;
+}
+
+describe('work-issues launch-mode probe', () => {
+  it('the probe exists exactly once across the skill directory, in launch-mode.md', () => {
+    const hits = skillDocs().filter((doc) => read(doc).includes(PROBE_TOKEN));
+    expect(
+      hits,
+      `Expected exactly one file to carry the launch-mode probe (\`${PROBE_TOKEN}\`), found ` +
+        `${hits.length}: ${hits.join(', ') || '(none)'}. The skill's own text calls ` +
+        `${LAUNCH_MODE_DOC} the ONLY copy: zero hits means the probe was deleted and every ` +
+        `IN-PLACE arm downstream is unreachable; two means a second verbatim copy that will ` +
+        `drift out of step with the first.`
+    ).toEqual([LAUNCH_MODE_DOC]);
+    const occurrences = read(LAUNCH_MODE_DOC).split(PROBE_TOKEN).length - 1;
+    expect(occurrences, `${LAUNCH_MODE_DOC} repeats the probe token ${occurrences} times`).toBe(1);
+  });
+
+  it('the orchestrator points at the launch-mode stage file', () => {
+    // The parent reads SKILL.md and nothing else before stage 0; if the pointer
+    // goes, the probe is unreachable however intact the file it lives in is.
+    expect(read('SKILL.md')).toContain(`references/launch-mode.md`);
+  });
+
+  for (const [doc, markers] of Object.entries(ARM_BEARING)) {
+    it(`${doc} still names the mode(s) it branches on: ${markers.join(', ')}`, () => {
+      const text = read(doc);
+      const missing = markers.filter((m) => !text.includes(m));
+      expect(
+        missing,
+        `${doc} no longer mentions ${missing.join(' / ')}. Either its mode-specific arm was ` +
+          `deleted (the byte floors do not notice: they only catch the LARGEST stage file ` +
+          `disappearing), or the arm moved -- in which case update ARM_BEARING in this file ` +
+          `so the assertion keeps tracking where the behaviour actually lives.`
+      ).toEqual([]);
+    });
+  }
+
+  describe('the probe, executed', () => {
+    /**
+     * Runs the doc's OWN fenced probe -- extracted, not re-typed -- against a
+     * throwaway repo and a linked worktree of it. A copy re-typed here would
+     * pass while the shipped one was broken, which is the whole failure this
+     * test is for.
+     */
+    const block = firstBashBlock(read(LAUNCH_MODE_DOC));
+
+    it('extracts a non-vacuous probe block from the doc', () => {
+      expect(block, `no fenced bash block found in ${LAUNCH_MODE_DOC}`).not.toBeNull();
+      expect(block!).toContain(PROBE_TOKEN);
+      expect(block!).toContain('MAIN-CHECKOUT');
+      expect(block!).toContain('IN-PLACE');
+    });
+
+    it('answers MAIN-CHECKOUT in a main checkout and IN-PLACE in a linked worktree', () => {
+      const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'wi-launch-mode-')));
+      try {
+        const main = join(tmp, 'main');
+        const lane = join(tmp, 'lane');
+        const script = join(tmp, 'probe.sh');
+        writeFileSync(script, `${block}\n`);
+        // Hermetic: a user's global config (hooksPath, templates, signing) must
+        // not decide whether this test passes.
+        const env = { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+        const git = (args: string[], cwd = tmp) =>
+          execFileSync('git', args, { cwd, env, encoding: 'utf8' });
+        git(['init', '-q', main]);
+        git(['-C', main, '-c', 'user.email=t@example.com', '-c', 'user.name=t', 'commit', '-q', '--allow-empty', '-m', 'init']);
+        git(['-C', main, 'worktree', 'add', '-q', lane, '-b', 'lane-branch']);
+
+        const run = (cwd: string) =>
+          Object.fromEntries(
+            execFileSync('bash', [script], { cwd, env, encoding: 'utf8' })
+              .trim()
+              .split('\n')
+              .map((l) => {
+                const at = l.indexOf('=');
+                return [l.slice(0, at), l.slice(at + 1)] as const;
+              })
+          );
+
+        const fromMain = run(main);
+        expect(fromMain.MODE).toBe('MAIN-CHECKOUT');
+        expect(fromMain.LANE_TREE).toBe(main);
+        expect(fromMain.MAIN_CHECKOUT).toBe(main);
+
+        const fromLane = run(lane);
+        expect(fromLane.MODE).toBe('IN-PLACE');
+        // The two values differing IS the mode, and MAIN_CHECKOUT must point at
+        // the OTHER tree -- that is the value section 2's collision scan needs
+        // and the one a `pwd`- or `--show-toplevel`-derived probe gets wrong.
+        expect(fromLane.LANE_TREE).toBe(lane);
+        expect(fromLane.MAIN_CHECKOUT).toBe(main);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses to answer outside a work tree instead of printing a wrong verdict', () => {
+      // The dangerous failure is not an error, it is a CONFIDENT MAIN-CHECKOUT:
+      // with every `git rev-parse` failing, an unguarded compare tests "" against
+      // "" and says "main checkout" while standing nowhere. Inside `.git` the
+      // trap is subtler still -- `--is-inside-work-tree` prints `false` and exits
+      // ZERO there, so an exit-status guard passes and yields an empty LANE_TREE.
+      const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'wi-launch-mode-neg-')));
+      try {
+        const main = join(tmp, 'main');
+        const script = join(tmp, 'probe.sh');
+        writeFileSync(script, `${block}\n`);
+        const env = { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+        execFileSync('git', ['init', '-q', main], { cwd: tmp, env, encoding: 'utf8' });
+
+        for (const cwd of [tmp, join(main, '.git')]) {
+          let failed = false;
+          let output = '';
+          try {
+            output = execFileSync('bash', [script], { cwd, env, encoding: 'utf8', stdio: 'pipe' });
+          } catch (e) {
+            failed = true;
+            output = String((e as { stdout?: string }).stdout ?? '');
+          }
+          expect(failed, `the probe answered "${output.trim()}" from ${cwd} instead of failing`).toBe(true);
+          expect(output).not.toContain('MODE=');
+        }
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #635

Closes go-to-k/cdk-local#635.

`/work-issues` creates its lane worktree with a CWD-RELATIVE path, which is
right from the main checkout and wrong from anywhere else. Launched inside a
linked worktree -- an Orca/ADE workspace, or a session that just `cd`-ed into
`.claude/worktrees/<x>` -- `git worktree add` NESTS one worktree inside another.
Deleting the outer workspace then takes the inner directory, its uncommitted
work and its git registration with it, plus the same-branch double-checkout
collision.

This is the cdk-local half of a three-repo change (go-to-k/cdkd#2399,
go-to-k/cdk-real-drift#1847); the three lanes stay convergent, and every
remaining divergence is stated in the text rather than left to a reader to
guess.

## The probe runs in the PARENT, before stage 0

Earlier revisions of this branch put the probe "at the top of stage 3", on the
reasoning that nothing before stage 3 consumes the launch mode. That reasoning
was false in two independent ways, and either one alone moves the probe:

- **Stage 2 already consumes it.** The collision scan runs
  `git -C .claude/worktrees/<w> log|show|status` -- a RELATIVE path, correct
  only from the main checkout. Run IN-PLACE the cwd is a lane tree, the path
  does not exist, git errors, and the scan returns NOTHING. An empty collision
  map reads as "no competing agents", which is precisely the failure that stage
  exists to prevent, and it fails QUIETLY.
- **Stages 0-3 are DELEGATED to a read-only triage subagent**, whose return
  payload is a candidate table: no git state, no paths. An answer computed
  inside it never reaches the parent -- and the parent is the party that later
  runs `git worktree add` or does not.

So the probe now lives in a new stage file, `references/launch-mode.md`
(8,141 B), read by the PARENT before stage 0. It captures three values at one
instant, and the parent passes all three into the triage dispatch and every lane
dispatch:

    [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = true ] \
      || { echo 'PROBE FAILED: not inside a git work tree -- do not guess the mode'; exit 1; }
    COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
    GITDIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)
    LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
    MAIN_CHECKOUT=$(dirname "$COMMON")
    [ "$GITDIR" = "$COMMON" ] && MODE=MAIN-CHECKOUT || MODE=IN-PLACE
    printf 'MODE=%s\nLANE_TREE=%s\nMAIN_CHECKOUT=%s\n' "$MODE" "$LANE_TREE" "$MAIN_CHECKOUT"

The previous body claimed "the probe now captures the path". It did not -- the
shipped probe echoed a mode string only. It does now, and `MAIN_CHECKOUT` is
the parent of the ONE shared git dir: never `pwd`, never `--show-toplevel`,
both of which answer "the tree I am standing in" and so are exactly wrong in
the mode that needs the value. Stage 2's scan takes
`git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>"` in BOTH modes, and section 9's
post-merge pull takes `git -C "<MAIN_CHECKOUT>"` instead of parsing
`git worktree list --porcelain`'s first row (true today, not a documented
guarantee).

**The first-line guard is new and it closes a measured hole.** The previous
probe documented that outside a repo every substitution collapses to `""`, so
the compare tests `""` against `""` and prints a confident MAIN-CHECKOUT, and
recorded that bash and zsh differ in how they fail. Nothing re-checked either
claim. Worse, `git rev-parse --is-inside-work-tree` prints `false` and exits
**zero** inside a `.git` directory (measured 2026-09-01), so an exit-status
guard passes there and yields an empty `LANE_TREE` under a `MAIN-CHECKOUT`
verdict. Comparing the VALUE to the literal `true` makes both non-repo
positions fail loudly in both shells.

## Converged with cdkd where the divergence had no reason

The opening report asked for "the answer" here while cdkd's asked for BOTH the
mode and the tree path, CITING the STOP anchor that needs something to compare
against. cdk-local's anchor therefore had nothing to compare against -- in the
repo whose own text says the record matters MORE here, because there is no
`session-owner` sentinel. Both now report `MODE` / `LANE_TREE` /
`MAIN_CHECKOUT`, and `launch-mode.md` says why the record carries more weight
here.

`SKILL.md` said "IN-PLACE changes four things and nothing else". It changes at
least eight. Because `SKILL.md` is the always-loaded orchestrator, a short list
there wins over the reference files it points at -- so rather than restate the
list twice and let it drift again, it now names the areas and points at the
COMPLETE table in `references/launch-mode.md`, with no count for a later edit to
falsify.

`references/triage.md`'s "Everything below is the MAIN-CHECKOUT case" was FALSE
and told an IN-PLACE run to skip a HARD gate: below it sit the security-first
ranking, the `Severity` ranking, the premise-check-against-`origin/main` rule
and the freshness quarantine, all mode-independent. It is now scoped to the
disjointness paragraph it actually describes.

`ship.md`'s IN-PLACE closing check -- "it left the launch tree and its branch
exactly as it found them" -- contradicted `retro.md`, where section 10-d has the
run end standing on a RETRO branch it created in that tree. Every correct
IN-PLACE run would have failed that check. It now reads "added no worktree, so
removed none; deleted no branch", and says so explicitly, including that the
same sentence in `hunt-bugs/SKILL.md` is CORRECT there (that skill never
branches in place).

## Tests: the change's own behaviour, not its byte count

Every assertion the previous rounds added was a byte count or a file-existence
check, so the diff's own behaviour was untested -- and the 12,000 B orchestrator
cap made it worse than untested. `SKILL.md` sits a few hundred bytes under that
cap, so DELETING the launch-mode section was the cheapest way to buy headroom
and the suite would have applauded it. Measured before this round: deleting the
`## Launch mode` block and deleting the IN-PLACE arm from `references/triage.md`
were both GREEN.

`tests/unit/skills/work-issues-launch-mode.test.ts` (13 cases) asserts three
properties, each mutation-proven against a scratch copy:

| assertion | mutation | result |
| --- | --- | --- |
| probe occurs exactly once in the skill dir | delete the probe block | 3 failed |
| ...and only once | add a second copy to `triage.md` | 1 failed |
| orchestrator points at the stage file | repoint it at `triage.md` | 1 failed |
| each arm-bearing file names its mode(s) | delete the `## Launch mode` section | 1 failed |
| " | delete every `IN-PLACE`/`MAIN-CHECKOUT` line in `SKILL.md` | 1 failed |
| " | delete them across all 10 docs | 10 failed |
| " | gut `triage.md`'s arms | 1 failed |
| the probe, EXECUTED in a repo and a worktree of it | swap the two verdicts | 1 failed |
| " | derive `MAIN_CHECKOUT` from `--show-toplevel` | 1 failed |
| refuses to answer outside a work tree | revert to the exit-status guard | 1 failed |

The executable case extracts the doc's OWN fenced block rather than re-typing
it, builds a throwaway repo plus a real `git worktree add` child, and asserts
`MODE` / `LANE_TREE` / `MAIN_CHECKOUT` in both. It also drives the two non-repo
positions (outside any repo, and inside `.git`) and requires a non-zero exit.

## The corpus floor now asserts its own invariant

`skill-file-payload.test.ts` derived its floor from "it must sit above
`corpus - largest`" and then never checked it. The comment beside the constant
records it lapsing twice inside one week (78,000, then 86,000), each time found
by a human re-deriving it by hand. It is now one assertion whose failure message
carries the number to raise to:

    expect(MIN_REFERENCE_CORPUS_BYTES).toBeGreaterThan(total - largest)

Re-derived at the FINAL tree: 9 stage files, corpus 130,349 B, largest
`implement.md` 34,073 B, so the floor must exceed 96,276. The previous body said
this branch sets it to 86,000; the branch actually set 90,000, and 86,000 would
already have LAPSED against 87,167. It is now **100,000**, clearing the binding
number by 3,724 B and leaving 30,349 B of compression room. Sized against
`corpus - largest` rather than the either-largest case because the top two are
13,694 B apart -- cdkd sizes against the flip because its top two are 3,242 B
apart, and that difference is stated in both files.

What the floor does NOT catch is now stated instead of implied: gutting a
NON-largest stage file. A byte floor cannot see that, and raising it until it
could would forbid legitimate compression -- so the per-file guards are the
CONTENT ones above.

## Also in this diff

- **Pointers that did not resolve.** `hunt-bugs/SKILL.md` cited `/work-issues`
  `references/triage.md` section 3 as carrying the probe; it now cites
  `references/launch-mode.md`. `triage.md` cited an appendix entry called "Bash
  cwd silent reset" -- that string exists nowhere in this repo; the entry is
  `gotchas.md`'s `cd <lane tree> &&` rule, which is what it now names.
- **Half-applied IN-PLACE qualifiers.** `retro.md`'s trigger "after section 9's
  last lane is merged and its worktree removed" was unsatisfiable in a mode that
  removes none; it now says "every worktree THIS run added", and names the last
  merge as the IN-PLACE trigger.
- **The claim names a branch that may not exist yet.** On a DETACHED IN-PLACE
  tree `git branch --show-current` is empty and the branch is only created in
  stage 5. `claim.md` now says to write "the branch section 5 will create in
  `<LANE_TREE>`" and post the claim ON TIME -- a claim delayed until a branch
  exists is a claim posted after the first edit.
- **One spelling for the lane tree.** `gates-and-pr.md`'s unquoted
  `git -C <lane tree>` was a third spelling of the same placeholder; all three
  repos now write `git -C "<LANE_TREE>"`, quoted, matching the probe's output
  name.
- **`.claude/CLAUDE.md` is unchanged in this round.** It already carries the
  launch-mode paragraph and already said `/work-issues` "computes which case
  applies before its first stage" -- aspirational when written, literally true
  now, so the SKILL.md side was fixed rather than the rule.

## Byte accounting (re-measured at the final tree)

| file | bytes | note |
| --- | --- | --- |
| `work-issues/SKILL.md` | 11,575 | 425 B under the 12,000 B cap (the previous body's 11,066 was stale even then: it was 11,306) |
| `references/launch-mode.md` | 8,141 | new; read once, before stage 0 |
| `references/implement.md` | 34,073 | largest stage file, well under the 64,000 B cap |
| `references/triage.md` | 20,379 | lost the probe and its edge-case reading |

No cap was raised. Most of the orchestrator's new material went into the stage
file with a pointer left behind -- the direction the cap exists to force.

## Suite

`vp run verify`: 242 test files, 4,359 passed, no type errors, build clean,
format clean.
